### PR TITLE
explicitely specified proto version

### DIFF
--- a/lightning.proto
+++ b/lightning.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // The outer layer handles encryption, authentication and message
 // boundaries.
 


### PR DESCRIPTION
With upcoming proto3, I think it is better to specify the syntax in the proto file (protoc complains otherwise).

Btw, any reason why you didn't use the fixed64 hack for, say, bitcoin_pubkey/key field ? Why not define a "oneof" [fixed size 65-bytes key] or [fixed size 33-bytes key], for the sake of consistency ?

I am not saying I would do that, I would actually have just used bytes everywhere.