### PR TITLE
fix compile issue: missing braces around initializer

### DIFF
--- a/daemon/bitcoind.c
+++ b/daemon/bitcoind.c
@@ -192,7 +192,7 @@ static void process_transactions(struct bitcoin_cli *bcli)
 
 	end = json_next(tokens);
 	for (t = tokens + 1; t < end; t = json_next(t)) {
-		struct sha256_double txid, blkhash = { 0 };
+		struct sha256_double txid, blkhash;
 		const jsmntok_t *txidtok, *conftok, *blkindxtok, *blktok;
 		unsigned int conf;
 		bool is_coinbase;


### PR DESCRIPTION
If you compile with gcc(version 4.8.2), it'll cause failure. Error is "missing braces around initializer".