### PR TITLE
setup_first_commit: initialize their remote commit with their commit fee rate

### DIFF
--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -2137,8 +2137,14 @@ bool setup_first_commit(struct peer *peer)
 	if (!peer->local.commit->cstate)
 		return false;
 
-	peer->remote.commit->cstate = copy_funding(peer,
-						   peer->local.commit->cstate);
+    peer->remote.commit->cstate = initial_funding(peer,
+                             peer->anchor.satoshis,
+                             peer->remote.commit_fee_rate,
+                             peer->local.offer_anchor
+                             == CMD_OPEN_WITH_ANCHOR ?
+                             OURS : THEIRS);
+    if (!peer->remote.commit->cstate)
+        return false;
 
 	peer->local.commit->tx = create_commit_tx(peer->local.commit,
 						  &peer->local.finalkey,


### PR DESCRIPTION
Hi,
I believe that there's a small bug in the current code which copies the local channel state, including the local fee rate, into the remote commit data. It should use the fee rate received in their open message instead. 
Thanks.