### PR TITLE
routing: Fix for single hop routes segfaulting.

### DIFF
--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -278,7 +278,7 @@ struct peer *find_route(struct lightningd_state *dstate,
 	assert(n == src);
 
 	/* We should only add routes if we have a peer. */
-	first = find_peer(dstate, &(*route)[0]->src->id);
+	first = find_peer(dstate, &dst->id);
 	if (!first) {
 		log_broken_struct(dstate->base_log, "No peer %s?",
 				  struct pubkey, &(*route)[0]->src->id);


### PR DESCRIPTION
The first hop is being stripped from computed routes, however the
first channel of the route is being used to get our peer address. This
results in segfaults if the route is just one hop, i.e., has no first
channel to get the peer's address from. Fixed by simply using an
existing pointer to our peer.