### PR TITLE
jsonrpc: Added 'getchannels' RPC method.

### DIFF
--- a/daemon/jsonrpc.c
+++ b/daemon/jsonrpc.c
@@ -292,6 +292,7 @@ static const struct json_command *cmdlist[] = {
 	&listinvoice_command,
 	&delinvoice_command,
 	&waitinvoice_command,
+	&getchannels_command,
 	&getroute_command,
 	&sendpay_command,
 	&getinfo_command,

--- a/daemon/jsonrpc.h
+++ b/daemon/jsonrpc.h
@@ -60,6 +60,7 @@ void setup_jsonrpc(struct lightningd_state *dstate, const char *rpc_filename);
 extern const struct json_command newaddr_command;
 extern const struct json_command connect_command;
 extern const struct json_command close_command;
+extern const struct json_command getchannels_command;
 extern const struct json_command getpeers_command;
 
 /* Invoice management. */


### PR DESCRIPTION
'getchannels' returns a 'channels' array containing an object for each
known channel. Each channel object represents one direction of a
bidirectional channel, with a from and a to node ID along with the fees
for that direction. This matched the internal storage of channels and
allows unbalanced fees for each direction.