### PR TITLE
Added IRC node announcements to learn about nodes in the network

### DIFF
--- a/daemon/jsonrpc.c
+++ b/daemon/jsonrpc.c
@@ -285,6 +285,7 @@ static const struct json_command *cmdlist[] = {
 	&getlog_command,
 	&connect_command,
 	&getpeers_command,
+	&getnodes_command,
 	&gethtlcs_command,
 	&close_command,
 	&newaddr_command,

--- a/daemon/jsonrpc.h
+++ b/daemon/jsonrpc.h
@@ -61,6 +61,7 @@ extern const struct json_command newaddr_command;
 extern const struct json_command connect_command;
 extern const struct json_command close_command;
 extern const struct json_command getpeers_command;
+extern const struct json_command getnodes_command;
 
 /* Invoice management. */
 extern const struct json_command invoice_command;

--- a/daemon/lightningd.h
+++ b/daemon/lightningd.h
@@ -130,5 +130,8 @@ struct lightningd_state {
 
 	/* Re-exec hack for testing. */
 	char **reexec;
+
+	/* IP/hostname to be announced for incoming connections */
+	char *external_ip;
 };
 #endif /* LIGHTNING_DAEMON_LIGHTNING_H */

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -20,6 +20,11 @@ struct node_connection {
 
 struct node {
 	struct pubkey id;
+
+	/* IP/Hostname and port of this node */
+	char *hostname;
+	int port;
+
 	/* Routes connecting to us, from us. */
 	struct node_connection **in, **out;
 
@@ -45,6 +50,12 @@ struct node *get_node(struct lightningd_state *dstate,
 /* msatoshi must be possible (< 21 million BTC), ie < 2^60.
  * If it returns more than msatoshi, it overflowed. */
 s64 connection_fee(const struct node_connection *c, u64 msatoshi);
+
+/* Updates existing node, or creates a new one as required. */
+struct node *add_node(struct lightningd_state *dstate,
+		      const struct pubkey *pk,
+		      char *hostname,
+		      int port);
 
 /* Updates existing connection, or creates new one as required. */
 struct node_connection *add_connection(struct lightningd_state *dstate,

--- a/irc.c
+++ b/irc.c
@@ -3,6 +3,8 @@
 #include "daemon/log.h"
 
 void (*irc_privmsg_cb)(struct ircstate *, const struct privmsg *) = NULL;
+void (*irc_command_cb)(struct ircstate *, const struct irccommand *) = NULL;
+void (*irc_connect_cb)(struct ircstate *) = NULL;
 void (*irc_disconnect_cb)(struct ircstate *) = NULL;
 
 static struct io_plan *irc_connected(struct io_conn *conn, struct lightningd_state *dstate, struct ircstate *state);
@@ -63,7 +65,7 @@ static struct io_plan *irc_write_loop(struct io_conn *conn, struct ircstate *sta
 		       );
 }
 
-/* 
+/*
  * Called by the read loop to handle individual lines. This splits the
  * line into a struct irccommand and passes it on to the specific
  * handlers for the irccommand type. It silently drops any irccommand
@@ -94,10 +96,14 @@ static void handle_irc_command(struct ircstate *state, const char *line)
 		pm->msg = tal_strjoin(m, splits + 2, " ", STR_NO_TRAIL);
 		irc_privmsg_cb(state, pm);
 	}
+
+	if (irc_command_cb != NULL)
+		irc_command_cb(state, m);
+
 	tal_free(m);
 }
 
-/* 
+/*
  * Read incoming data and split it along the newline boundaries. Takes
  * care of buffering incomplete lines and passes the lines to the
  * handle_irc_command handler.
@@ -168,7 +174,9 @@ static struct io_plan *irc_connected(struct io_conn *conn, struct lightningd_sta
 	state->connected = true;
 	irc_send(state, "USER", "%s 0 * :A lightning node", state->nick);
 	irc_send(state, "NICK", "%s", state->nick);
-	irc_send(state, "JOIN", "#lightning-nodes");
+
+	if (irc_connect_cb != NULL)
+		irc_connect_cb(state);
 
 	return io_duplex(conn,
 			 io_read_partial(conn,

--- a/irc.h
+++ b/irc.h
@@ -53,8 +53,10 @@ struct ircstate {
 	struct timerel reconnect_timeout;
 };
 
-/* Callback to register for incoming messages */
+/* Callbacks to register for incoming messages, events and raw commands */
 extern void (*irc_privmsg_cb)(struct ircstate *, const struct privmsg *);
+extern void (*irc_command_cb)(struct ircstate *, const struct irccommand *);
+extern void (*irc_connect_cb)(struct ircstate *);
 extern void (*irc_disconnect_cb)(struct ircstate *);
 
 /* Send messages to IRC */


### PR DESCRIPTION
Added IRC node annoucement. Each node now announces its existence on the IRC channel, with its ID, hostname and port. The announcements are signed by the node's ID and the external address/hostname is discovered by issuing a WHOIS to the IRC server. We'll need to figure out a better way of identifying our external IP if we drop IRC.

The `getnodes` JSON-RPC method was also added to see what nodes we know about.

Notice that there currently is no timeout for known nodes, nor is there permanent storage of any kind, so restarting the node is currently the only way to forget about nodes.