### PR TITLE
jsonrpc: Fail connect if TX broadcast fails

### DIFF
--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -2921,6 +2921,17 @@ const struct json_command connect_command = {
 	"Returns the {id} on success (once channel established)"
 };
 
+void broadcast_tx_complete(struct lightningd_state *dstate,
+			   const char *msg, struct outgoing_tx *otx)
+{
+	if (strstr(msg, "bad-txns-inputs-spent") && otx->peer &&
+	    otx->peer->open_jsoncmd) {
+		command_fail(otx->peer->open_jsoncmd,
+			     "Inputs already spent: %s", msg);
+		otx->peer->open_jsoncmd = NULL;
+	}
+}
+
 /* Have any of our HTLCs passed their deadline? */
 static bool any_deadline_past(struct peer *peer)
 {

--- a/daemon/peer.h
+++ b/daemon/peer.h
@@ -81,6 +81,8 @@ struct outgoing_tx {
 	struct list_node list;
 	const struct bitcoin_tx *tx;
 	struct sha256_double txid;
+	struct peer *peer;
+	u8 *rawtx;
 };
 
 struct peer {
@@ -290,4 +292,6 @@ void debug_dump_peers(struct lightningd_state *dstate);
 
 void reconnect_peers(struct lightningd_state *dstate);
 void cleanup_peers(struct lightningd_state *dstate);
+
+void broadcast_tx_complete(struct lightningd_state *dstate, const char *msg, struct outgoing_tx *otx);
 #endif /* LIGHTNING_DAEMON_PEER_H */


### PR DESCRIPTION
Rewired the broadcast_tx call to call the `broadcast_tx_complete`
callback once `bitcoin-cli` returns from `sendrawtransaction` so that we
can potentially report a failure if the broadcast failed. This also
added some more context to the `struct outgoing_tx` and `rawtx` which we
can potentially free after the broadcast completes.

Fixes #51
