### PR TITLE
Test speedups

### DIFF
--- a/daemon/test/Makefile
+++ b/daemon/test/Makefile
@@ -1,40 +1,53 @@
 check: daemon-tests
 
-daemon-test.sh-%:
-	NO_VALGRIND=$(NO_VALGRIND) daemon/test/test.sh --$*
+# We run three different bitcoinds, for different types of tests.
+# Provides limited paralellism.
+daemon-test.sh-0-%:
+	NO_VALGRIND=$(NO_VALGRIND) VARIANT=0 daemon/test/test.sh --$*
+daemon-test.sh-1-%:
+	NO_VALGRIND=$(NO_VALGRIND) VARIANT=1 daemon/test/test.sh --$*
+daemon-test.sh-2-%:
+	NO_VALGRIND=$(NO_VALGRIND) VARIANT=2 daemon/test/test.sh --$*
 
 # These don't work in parallel, so chain the deps
-daemon-test.sh-steal: daemon-test.sh-dump-onchain
-daemon-test.sh-dump-onchain: daemon-test.sh-timeout-anchor
-daemon-test.sh-timeout-anchor: daemon-test.sh-different-fee-rates
-daemon-test.sh-different-fee-rates: daemon-test.sh-normal
-daemon-test.sh-normal: daemon-test.sh-manual-commit
-daemon-test.sh-manual-commit: daemon-test.sh-mutual-close-with-htlcs
-daemon-test.sh-mutual-close-with-htlcs: daemon-test.sh-steal\ --reconnect
-daemon-test.sh-steal\ --reconnect: daemon-test.sh-dump-onchain\ --reconnect
-daemon-test.sh-dump-onchain\ --reconnect: daemon-test.sh-timeout-anchor\ --reconnect
-daemon-test.sh-timeout-anchor\ --reconnect: daemon-test.sh-different-fee-rates\ --reconnect
-daemon-test.sh-different-fee-rates\ --reconnect: daemon-test.sh-normal\ --reconnect
-daemon-test.sh-normal\ --reconnect: daemon-test.sh-manual-commit\ --reconnect
-daemon-test.sh-manual-commit\ --reconnect: daemon-test.sh-mutual-close-with-htlcs\ --reconnect
-daemon-test.sh-mutual-close-with-htlcs\ --reconnect: daemon-test.sh-steal\ --restart
-daemon-test.sh-steal\ --restart: daemon-test.sh-dump-onchain\ --restart
-daemon-test.sh-dump-onchain\ --restart: daemon-test.sh-timeout-anchor\ --restart
-daemon-test.sh-timeout-anchor\ --restart: daemon-test.sh-different-fee-rates\ --restart
-daemon-test.sh-different-fee-rates\ --restart: daemon-test.sh-normal\ --restart
-daemon-test.sh-normal\ --restart: daemon-test.sh-mutual-close-with-htlcs\ --restart
-daemon-test.sh-mutual-close-with-htlcs\ --restart: daemon-test-setup
+daemon-test.sh-0-steal: daemon-test.sh-0-dump-onchain
+daemon-test.sh-0-dump-onchain: daemon-test.sh-0-timeout-anchor
+daemon-test.sh-0-timeout-anchor: daemon-test.sh-0-different-fee-rates
+daemon-test.sh-0-different-fee-rates: daemon-test.sh-0-normal
+daemon-test.sh-0-normal: daemon-test.sh-0-manual-commit
+daemon-test.sh-0-manual-commit: daemon-test.sh-0-mutual-close-with-htlcs
+daemon-test.sh-0-mutual-close-with-htlcs: daemon-test-setup-0
+
+daemon-test.sh-1-steal\ --restart: daemon-test.sh-1-dump-onchain\ --restart
+daemon-test.sh-1-dump-onchain\ --restart: daemon-test.sh-1-timeout-anchor\ --restart
+daemon-test.sh-1-timeout-anchor\ --restart: daemon-test.sh-1-different-fee-rates\ --restart
+daemon-test.sh-1-different-fee-rates\ --restart: daemon-test.sh-1-normal\ --restart
+daemon-test.sh-1-normal\ --restart: daemon-test.sh-1-manual-commit\ --restart
+daemon-test.sh-1-manual-commit\ --restart: daemon-test.sh-1-mutual-close-with-htlcs\ --restart
+daemon-test.sh-1-mutual-close-with-htlcs\ --restart: daemon-test-setup-1
+
+daemon-test.sh-2-steal\ --reconnect: daemon-test.sh-2-dump-onchain\ --reconnect
+daemon-test.sh-2-dump-onchain\ --reconnect: daemon-test.sh-2-timeout-anchor\ --reconnect
+daemon-test.sh-2-timeout-anchor\ --reconnect: daemon-test.sh-2-different-fee-rates\ --reconnect
+daemon-test.sh-2-different-fee-rates\ --reconnect: daemon-test.sh-2-normal\ --reconnect
+daemon-test.sh-2-normal\ --reconnect: daemon-test.sh-2-manual-commit\ --reconnect
+daemon-test.sh-2-manual-commit\ --reconnect: daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect
+daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect: daemon-test-setup-2
 
 # We shutdown first in case something is left over.
-daemon-test-setup: daemon-all
-	daemon/test/scripts/shutdown.sh 2>/dev/null || true
-	daemon/test/scripts/setup.sh
+daemon-test-setup-%: daemon-all
+	VARIANT=$* daemon/test/scripts/shutdown.sh 2>/dev/null || true
+	VARIANT=$* daemon/test/scripts/setup.sh
 
-daemon-test-shutdown: daemon-test.sh-steal
-	daemon/test/scripts/shutdown.sh
+daemon-test-shutdown-0: daemon-test.sh-0-steal
+	VARIANT=0 daemon/test/scripts/shutdown.sh
+daemon-test-shutdown-1: daemon-test.sh-1-steal\ --restart
+	VARIANT=1 daemon/test/scripts/shutdown.sh
+daemon-test-shutdown-2: daemon-test.sh-2-steal\ --reconnect
+	VARIANT=2 daemon/test/scripts/shutdown.sh
 
-# Forms a long dependency chain.
-daemon-all-test.sh: daemon-test-shutdown
+# Forms long dependency chains.
+daemon-all-test.sh: daemon-test-shutdown-0 daemon-test-shutdown-1 daemon-test-shutdown-2
 
 # Note that these actually #include everything they need, except ccan/ and bitcoin/.
 # That allows for unit testing of statics, and special effects.

--- a/daemon/test/Makefile
+++ b/daemon/test/Makefile
@@ -1,7 +1,6 @@
 check: daemon-tests
 
 daemon-test.sh-%:
-	daemon/test/scripts/shutdown.sh 2>/dev/null || true
 	NO_VALGRIND=$(NO_VALGRIND) daemon/test/test.sh --$*
 
 # These don't work in parallel, so chain the deps
@@ -24,8 +23,18 @@ daemon-test.sh-dump-onchain\ --restart: daemon-test.sh-timeout-anchor\ --restart
 daemon-test.sh-timeout-anchor\ --restart: daemon-test.sh-different-fee-rates\ --restart
 daemon-test.sh-different-fee-rates\ --restart: daemon-test.sh-normal\ --restart
 daemon-test.sh-normal\ --restart: daemon-test.sh-mutual-close-with-htlcs\ --restart
-daemon-test.sh-mutual-close-with-htlcs\ --restart: daemon-all
-daemon-all-test.sh: daemon-test.sh-steal
+daemon-test.sh-mutual-close-with-htlcs\ --restart: daemon-test-setup
+
+# We shutdown first in case something is left over.
+daemon-test-setup: daemon-all
+	daemon/test/scripts/shutdown.sh 2>/dev/null || true
+	daemon/test/scripts/setup.sh
+
+daemon-test-shutdown: daemon-test.sh-steal
+	daemon/test/scripts/shutdown.sh
+
+# Forms a long dependency chain.
+daemon-all-test.sh: daemon-test-shutdown
 
 # Note that these actually #include everything they need, except ccan/ and bitcoin/.
 # That allows for unit testing of statics, and special effects.

--- a/daemon/test/Makefile
+++ b/daemon/test/Makefile
@@ -13,26 +13,26 @@ daemon-test.sh-2-%:
 daemon-test.sh-0-steal: daemon-test.sh-0-dump-onchain
 daemon-test.sh-0-dump-onchain: daemon-test.sh-0-timeout-anchor
 daemon-test.sh-0-timeout-anchor: daemon-test.sh-0-different-fee-rates
-daemon-test.sh-0-different-fee-rates: daemon-test.sh-0-normal
-daemon-test.sh-0-normal: daemon-test.sh-0-manual-commit
-daemon-test.sh-0-manual-commit: daemon-test.sh-0-mutual-close-with-htlcs
-daemon-test.sh-0-mutual-close-with-htlcs: daemon-test-setup-0
+daemon-test.sh-0-different-fee-rates: daemon-test.sh-0-mutual-close-with-htlcs
+daemon-test.sh-0-mutual-close-with-htlcs: daemon-test.sh-0-manual-commit
+daemon-test.sh-0-manual-commit: daemon-test.sh-0-normal
+daemon-test.sh-0-normal: daemon-test-setup-0
 
 daemon-test.sh-1-steal\ --restart: daemon-test.sh-1-dump-onchain\ --restart
 daemon-test.sh-1-dump-onchain\ --restart: daemon-test.sh-1-timeout-anchor\ --restart
 daemon-test.sh-1-timeout-anchor\ --restart: daemon-test.sh-1-different-fee-rates\ --restart
-daemon-test.sh-1-different-fee-rates\ --restart: daemon-test.sh-1-normal\ --restart
-daemon-test.sh-1-normal\ --restart: daemon-test.sh-1-manual-commit\ --restart
-daemon-test.sh-1-manual-commit\ --restart: daemon-test.sh-1-mutual-close-with-htlcs\ --restart
-daemon-test.sh-1-mutual-close-with-htlcs\ --restart: daemon-test-setup-1
+daemon-test.sh-1-different-fee-rates\ --restart: daemon-test.sh-1-mutual-close-with-htlcs\ --restart
+daemon-test.sh-1-mutual-close-with-htlcs\ --restart: daemon-test.sh-1-manual-commit\ --restart
+daemon-test.sh-1-manual-commit\ --restart: daemon-test.sh-1-normal\ --restart
+daemon-test.sh-1-normal\ --restart: daemon-test-setup-1
 
 daemon-test.sh-2-steal\ --reconnect: daemon-test.sh-2-dump-onchain\ --reconnect
 daemon-test.sh-2-dump-onchain\ --reconnect: daemon-test.sh-2-timeout-anchor\ --reconnect
 daemon-test.sh-2-timeout-anchor\ --reconnect: daemon-test.sh-2-different-fee-rates\ --reconnect
-daemon-test.sh-2-different-fee-rates\ --reconnect: daemon-test.sh-2-normal\ --reconnect
-daemon-test.sh-2-normal\ --reconnect: daemon-test.sh-2-manual-commit\ --reconnect
-daemon-test.sh-2-manual-commit\ --reconnect: daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect
-daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect: daemon-test-setup-2
+daemon-test.sh-2-different-fee-rates\ --reconnect: daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect
+daemon-test.sh-2-mutual-close-with-htlcs\ --reconnect: daemon-test.sh-2-manual-commit\ --reconnect
+daemon-test.sh-2-manual-commit\ --reconnect: daemon-test.sh-2-normal\ --reconnect
+daemon-test.sh-2-normal\ --reconnect: daemon-test-setup-2
 
 # We shutdown first in case something is left over.
 daemon-test-setup-%: daemon-all

--- a/daemon/test/scripts/setup.sh
+++ b/daemon/test/scripts/setup.sh
@@ -45,8 +45,8 @@ else
     exit 1
 fi
 
-scripts/generate-block.sh init
+`dirname $0`/generate-block.sh init
 
-A1=`scripts/get-new-address.sh`
+A1=$(`dirname $0`/get-new-address.sh)
 TX=`$CLI sendmany "" "{ \"$A1\":0.01 }"`
-scripts/generate-block.sh
+`dirname $0`/generate-block.sh

--- a/daemon/test/scripts/setup.sh
+++ b/daemon/test/scripts/setup.sh
@@ -15,7 +15,7 @@ rm -rf $DATADIR
 mkdir $DATADIR
 
 # Find a free port (racy, but hey)
-PORT=`findport 18332`
+PORT=`findport 18332 $VARIANT`
 RPCPORT=`findport $(($PORT + 1))`
 
 # Create appropriate config file so cmdline matches.
@@ -29,7 +29,7 @@ EOF
 $DAEMON &
 i=0
 while ! $CLI getinfo >/dev/null 2>&1; do
-    if [ $i -gt 30 ]; then
+    if [ $i -gt 60 ]; then
 	echo $DAEMON start failed? >&1
 	exit 1
     fi

--- a/daemon/test/scripts/setup.sh
+++ b/daemon/test/scripts/setup.sh
@@ -2,6 +2,9 @@
 
 . `dirname $0`/vars.sh
 
+VERSION=$(`dirname $0`/../../lightning-cli --version | head -n1)
+[ $VERSION = `git describe --always --dirty` ] || (echo Wrong version $VERSION >&2; exit 1)
+
 if $CLI getinfo 2>/dev/null; then
     echo $DAEMON already running >&2
     exit 1

--- a/daemon/test/scripts/shutdown.sh
+++ b/daemon/test/scripts/shutdown.sh
@@ -2,5 +2,10 @@
 
 . `dirname $0`/vars.sh
 
+[ ! -f $DATADIR/regtest/bitcoind.pid ] || BITCOIN_PID=`cat $DATADIR/regtest/bitcoind.pid`
+
 $CLI stop
 sleep 1 # Make sure socket is closed.
+
+# Now make sure it's dead.
+if [ -n "$BITCOIN_PID" ]; then kill -9 $BITCOIN_PID 2>/dev/null || true; fi

--- a/daemon/test/scripts/vars.sh
+++ b/daemon/test/scripts/vars.sh
@@ -4,7 +4,7 @@
 if which eatmydata >/dev/null; then EATMYDATA=eatmydata; fi
 
 STYLE=bitcoin
-DATADIR=/tmp/bitcoin-lightning
+DATADIR=/tmp/bitcoin-lightning$VARIANT
 CLI="bitcoin-cli -datadir=$DATADIR"
 REGTESTDIR=regtest
 DAEMON="$EATMYDATA bitcoind -datadir=$DATADIR"
@@ -12,6 +12,8 @@ DAEMON="$EATMYDATA bitcoind -datadir=$DATADIR"
 findport()
 {
     PORT=$1
+    # Give two ports per variant.
+    if [ x"$2" != x ]; then PORT=$(($PORT + $2 * 2)); fi
     while netstat -ntl | grep -q ":$PORT "; do PORT=$(($PORT + 1)); done
     echo $PORT
 }

--- a/daemon/test/scripts/vars.sh
+++ b/daemon/test/scripts/vars.sh
@@ -5,11 +5,6 @@ DATADIR=/tmp/bitcoin-lightning
 CLI="bitcoin-cli -datadir=$DATADIR"
 REGTESTDIR=regtest
 DAEMON="bitcoind -datadir=$DATADIR"
-if grep ^FEATURES ../Makefile | cut -d'#' -f1 | grep -q BIP68; then
-	SEQ_ENFORCEMENT=true
-else
-	SEQ_ENFORCEMENT=false
-fi
 
 findport()
 {

--- a/daemon/test/scripts/vars.sh
+++ b/daemon/test/scripts/vars.sh
@@ -1,10 +1,13 @@
 # Sourced by other scripts
 
+# Suppress sync if we can, for speedup.
+if which eatmydata >/dev/null; then EATMYDATA=eatmydata; fi
+
 STYLE=bitcoin
 DATADIR=/tmp/bitcoin-lightning
 CLI="bitcoin-cli -datadir=$DATADIR"
 REGTESTDIR=regtest
-DAEMON="bitcoind -datadir=$DATADIR"
+DAEMON="$EATMYDATA bitcoind -datadir=$DATADIR"
 
 findport()
 {

--- a/daemon/test/test.sh
+++ b/daemon/test/test.sh
@@ -40,12 +40,13 @@ ONE_HTLCS_FEE=$(( (338 + 32) * $FEE_RATE / 2000 * 2000))
 EXTRA_FEE=$(($ONE_HTLCS_FEE - $NO_HTLCS_FEE))
 
 # Always use valgrind if available.
-[ -n "$NO_VALGRIND" ] || PREFIX="valgrind -q --error-exitcode=7"
+PREFIX=$EATMYDATA
+[ -n "$NO_VALGRIND" ] || PREFIX="$EATMYDATA valgrind -q --error-exitcode=7"
 
 while [ $# != 0 ]; do
     case x"$1" in
 	x"--valgrind-vgdb")
-	    [ -n "$NO_VALGRIND" ] || PREFIX="valgrind --vgdb-error=1"
+	    [ -n "$NO_VALGRIND" ] || PREFIX="$EATMYDATA valgrind --vgdb-error=1"
 	    REDIR1="/dev/tty"
 	    REDIRERR1="/dev/tty"
 	    REDIR2="/dev/tty"

--- a/daemon/test/test.sh
+++ b/daemon/test/test.sh
@@ -441,9 +441,14 @@ if ! check "$LCLI3 getlog 2>/dev/null | $FGREP Hello"; then
     exit 1
 fi
 
-# Version should be correct
-VERSION=`$LCLI1 getinfo | sed -n 's/.*"version" : "\([^"]*\)".*/\1/p'`
-[ $VERSION = `git describe --always --dirty` ] || (echo Wrong version $VERSION >&2; exit 1)
+# Version should match binary version
+GETINFO_VERSION=`$LCLI1 getinfo | sed -n 's/.*"version" : "\([^"]*\)".*/\1/p'`
+LCLI_VERSION=$($LCLI1 --version | head -n1)
+LDAEMON_VERSION=$($LIGHTNINGD1 --version | head -n1)
+if [ $GETINFO_VERSION != $LCLI_VERSION -o $GETINFO_VERSION != $LDAEMON_VERSION ]; then
+   echo Wrong versions: getinfo gave $GETINFO_VERSION, cli gave $LCLI_VERSION, daemon gave $LDAEMON_VERSION >&2
+   exit 1
+fi
 
 ID1=`$LCLI1 getlog | sed -n 's/.*"ID: \([0-9a-f]*\)".*/\1/p'`
 [ `$LCLI1 getinfo | sed -n 's/.*"id" : "\([0-9a-f]*\)".*/\1/p'` = $ID1 ]

--- a/daemon/test/test.sh
+++ b/daemon/test/test.sh
@@ -5,7 +5,13 @@ cd `git rev-parse --show-toplevel`/daemon/test
 
 . scripts/vars.sh
 
-scripts/setup.sh
+# If bitcoind not already running, start it.
+if ! $CLI getinfo >/dev/null 2>&1; then
+    scripts/setup.sh
+    SHUTDOWN_BITCOIN=scripts/shutdown.sh
+else
+    SHUTDOWN_BITCOIN=/bin/true
+fi
 
 # Bash variables for in-depth debugging.
 #set -vx
@@ -343,7 +349,7 @@ all_ok()
     if grep ^== $DIR1/errors; then exit 1; fi
     if grep ^== $DIR2/errors; then exit 1; fi
     if grep ^== $DIR3/errors; then exit 1; fi
-    scripts/shutdown.sh
+    $SHUTDOWN_BITCOIN
 
     trap "rm -rf $DIR1 $DIR2 $DIR3" EXIT
     exit 0

--- a/daemon/test/test.sh
+++ b/daemon/test/test.sh
@@ -724,7 +724,9 @@ if [ -n "$MANUALCOMMIT" ]; then
 fi
 [ ! -n "$MANUALCOMMIT" ] || lcli1 dev-commit $ID2
 
-check lcli1 "getlog debug | $FGREP 'Both committed to FULFILL of our HTLC'"
+# If we're very slow, manually committed above, and we're restarting,
+# we may restart *after* this and thus not see it in the log.
+[ "$RECONNECT$MANUALCOMMIT" = restart1 ] || check lcli1 "getlog debug | $FGREP 'Both committed to FULFILL of our HTLC'"
 check lcli2 "getlog debug | $FGREP 'Both committed to FULFILL of their HTLC'"
 
 # We've transferred the HTLC amount to 2, who now has to pay fees,

--- a/daemon/test/test.sh
+++ b/daemon/test/test.sh
@@ -234,7 +234,7 @@ check()
 	fi
 	sleep 1
 	i=$(($i + 1))
-	if [ $i = 30 ]; then
+	if [ $i = 60 ]; then
 	    return 1
 	fi
     done
@@ -399,8 +399,8 @@ cp $DIR2/config $DIR3/config
 if [ x"$RECONNECT" = xrestart ]; then
     # Make sure node2 & 3 restart on same port, by setting in config.
     # Find a free TCP port.
-    echo port=`findport 4000` >> $DIR2/config
-    echo port=`findport 4010` >> $DIR3/config
+    echo port=`findport 4000 $VARIANT` >> $DIR2/config
+    echo port=`findport 4010 $VARIANT` >> $DIR3/config
 fi
 
 if [ -n "$DIFFERENT_FEES" ]; then


### PR DESCRIPTION
This reduces runtime (particularly if eatmydata is installed), and allows some parallelism in running test.sh.  No changes to the tests themselves, though they can definitely be reduced.