### PR TITLE
peer_disconnect: simply free if in STATE_INIT.

### DIFF
--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -2603,9 +2603,7 @@ static void peer_disconnect(struct io_conn *conn, struct peer *peer)
 
 	/* Not even set up yet?  Simply free.*/
 	if (peer->state == STATE_INIT) {
-		/* FIXME: Make reconnect work for STATE_INIT, but
-		 * cleanup if we don't reconnect after some duration. */
-		db_forget_peer(peer);
+		/* This means we didn't get past crypto handshake or hit db */
 		tal_free(peer);
 		return;
 	}


### PR DESCRIPTION
db_forget_peer() was harmless, but we haven't been entered into the
database yet anyway, and it asserted that we should have been STATE_CLOSED.

Closes: #67
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>