### PR TITLE
lightningd: don't listen at all if no port number set.

### DIFF
--- a/daemon/lightningd.c
+++ b/daemon/lightningd.c
@@ -487,7 +487,7 @@ int main(int argc, char *argv[])
 			   "A bitcoin lightning daemon.",
 			   "Print this message.");
 	opt_register_arg("--port", opt_set_uintval, NULL, &portnum,
-			 "Port to bind to (otherwise, dynamic port is used)");
+			 "Port to bind to (otherwise, we don't listen)");
 	opt_register_arg("--bitcoin-datadir", opt_set_charp, NULL,
 			 &bitcoin_datadir,
 			 "-datadir arg for bitcoin-cli");
@@ -543,7 +543,8 @@ int main(int argc, char *argv[])
 	setup_jsonrpc(dstate, dstate->rpc_filename);
 
 	/* Set up connections from peers. */
-	setup_listeners(dstate, portnum);
+	if (portnum != 0)
+		setup_listeners(dstate, portnum);
 
 	/* set up IRC peer discovery */
 	if (dstate->config.use_irc)

--- a/daemon/test/scripts/helpers.sh
+++ b/daemon/test/scripts/helpers.sh
@@ -117,12 +117,9 @@ EOF
     cp $DIR1/config $DIR2/config
     [ $NUM_LIGHTNINGD = 2 ] || cp $DIR1/config $DIR3/config
 
-    if [ x"$RECONNECT" = xrestart ]; then
-	# Make sure node2 & 3 restart on same port, by setting in config.
-	# Find a free TCP port.
-	echo port=`findport 4000 $VARIANT` >> $DIR2/config
-	[ $NUM_LIGHTNINGD = 2 ] || echo port=`findport 4010 $VARIANT` >> $DIR3/config
-    fi
+    # Find a free TCP port.
+    echo port=`findport 4000 $VARIANT` >> $DIR2/config
+    [ $NUM_LIGHTNINGD = 2 ] || echo port=`findport 4010 $VARIANT` >> $DIR3/config
 }
 
 # Use DIR REDIR REDIRERR GDBFLAG


### PR DESCRIPTION
When we support the Milan protocol, we'll use a default port.  But
for now, don't listen at all unless a port is specified.

Fixes: #54
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>