### PR TITLE
Fix warnings for clang build (-Werror)

### DIFF
--- a/daemon/cryptopkt.c
+++ b/daemon/cryptopkt.c
@@ -112,14 +112,14 @@ struct io_data {
 	/* Stuff we need to keep around to talk to peer. */
 	struct dir_state in, out;
 
-	/* Length we're currently reading. */
-	struct crypto_pkt hdr_in;
-
 	/* Callback once packet decrypted. */
 	struct io_plan *(*cb)(struct io_conn *, struct peer *);
 
 	/* Once peer is assigned, this is set. */
 	struct peer *peer;
+
+	/* Length we're currently reading. */
+	struct crypto_pkt hdr_in;
 };
 
 static void *proto_tal_alloc(void *allocator_data, size_t size)

--- a/daemon/db.c
+++ b/daemon/db.c
@@ -1575,7 +1575,7 @@ void db_update_htlc_state(struct peer *peer, const struct htlc *htlc,
 
 void db_update_feechange_state(struct peer *peer,
 			       const struct feechange *f,
-			       enum htlc_state oldstate)
+			       enum feechange_state oldstate)
 {
 	const char *ctx = tal_tmpctx(peer);
 	const char *peerid = pubkey_to_hexstr(ctx, peer->id);
@@ -1593,7 +1593,7 @@ void db_update_feechange_state(struct peer *peer,
 }
 
 void db_remove_feechange(struct peer *peer, const struct feechange *feechange,
-			 enum htlc_state oldstate)
+			 enum feechange_state oldstate)
 {
 	const char *ctx = tal(peer, char);
 	const char *peerid = pubkey_to_hexstr(ctx, peer->id);

--- a/daemon/db.h
+++ b/daemon/db.h
@@ -55,9 +55,9 @@ void db_resolve_invoice(struct lightningd_state *dstate,
 			const char *label, u64 paid_num);
 void db_update_feechange_state(struct peer *peer,
 			       const struct feechange *f,
-			       enum htlc_state oldstate);
+			       enum feechange_state oldstate);
 void db_remove_feechange(struct peer *peer, const struct feechange *feechange,
-			 enum htlc_state oldstate);
+			 enum feechange_state oldstate);
 void db_new_commit_info(struct peer *peer, enum side side,
 			const struct sha256 *prev_rhash);
 void db_remove_their_prev_revocation_hash(struct peer *peer);

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -382,7 +382,7 @@ void log_struct_(struct log *log, int level,
 	tal_free(ctx);
 }
 
-void log_blob_(struct log *log, enum log_level level, const char *fmt,
+void log_blob_(struct log *log, int level, const char *fmt,
 	       size_t len, ...)
 {
 	va_list ap;

--- a/daemon/log.h
+++ b/daemon/log.h
@@ -42,7 +42,7 @@ void log_(struct log *log, enum log_level level, const char *fmt, ...)
 void log_add(struct log *log, const char *fmt, ...) PRINTF_FMT(2,3);
 void logv(struct log *log, enum log_level level, const char *fmt, va_list ap);
 
-void log_blob_(struct log *log, enum log_level level, const char *fmt,
+void log_blob_(struct log *log, int level, const char *fmt,
 	       size_t len, ...)
 	PRINTF_FMT(3,5);
 

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -467,7 +467,7 @@ static bool peer_received_unexpected_pkt(struct peer *peer, const Pkt *pkt,
 					 const char *where)
 {
 	const char *p;
-	Pkt *err;
+	Pkt *err = NULL;
 
 	log_unusual(peer->log, "%s: received unexpected pkt %u (%s) in %s",
 		    where, pkt->pkt_case, pkt_name(pkt->pkt_case),
@@ -4120,7 +4120,7 @@ static enum watch_result anchor_spent(struct peer *peer,
 	enum state newstate;
 	struct htlc_map_iter it;
 	struct htlc *h;
-	u64 commit_num;
+	u64 commit_num = 0;
 
 	assert(input_num < tx->input_count);
 


### PR DESCRIPTION
So it builds on
```
$ clang --version
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin16.1.0
```

Thanks Christian for the insights on Lightning yesterday.