### PR TITLE
Implementation of the gossip protocol

### DIFF
--- a/bitcoin/pubkey.c
+++ b/bitcoin/pubkey.c
@@ -65,3 +65,11 @@ bool pubkey_eq(const struct pubkey *a, const struct pubkey *b)
 {
 	return structeq(&a->pubkey, &b->pubkey);
 }
+
+int pubkey_cmp(const struct pubkey *a, const struct pubkey *b)
+{
+	u8 keya[33], keyb[33];
+	pubkey_to_der(keya, a);
+	pubkey_to_der(keyb, b);
+	return memcmp(keya, keyb, sizeof(keya));
+}

--- a/bitcoin/pubkey.h
+++ b/bitcoin/pubkey.h
@@ -32,4 +32,7 @@ void pubkey_to_der(u8 der[PUBKEY_DER_LEN], const struct pubkey *key);
 
 /* Are these keys equal? */
 bool pubkey_eq(const struct pubkey *a, const struct pubkey *b);
+
+/* Compare the keys `a` and `b`. Return <0 if `a`<`b`, 0 if equal and >0 otherwise */
+int pubkey_cmp(const struct pubkey *a, const struct pubkey *b);
 #endif /* LIGHTNING_PUBKEY_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -31,6 +31,7 @@ DAEMON_SRC :=					\
 	daemon/netaddr.c			\
 	daemon/opt_time.c			\
 	daemon/output_to_htlc.c			\
+	daemon/p2p_announce.c			\
 	daemon/packets.c			\
 	daemon/pay.c				\
 	daemon/peer.c				\
@@ -81,6 +82,7 @@ DAEMON_HEADERS :=				\
 	daemon/netaddr.h			\
 	daemon/opt_time.h			\
 	daemon/output_to_htlc.h			\
+	daemon/p2p_announce.h			\
 	daemon/packets.h			\
 	daemon/pay.h				\
 	daemon/peer.h				\

--- a/daemon/lightningd.c
+++ b/daemon/lightningd.c
@@ -7,6 +7,7 @@
 #include "lightningd.h"
 #include "log.h"
 #include "opt_time.h"
+#include "p2p_announce.h"
 #include "peer.h"
 #include "routing.h"
 #include "secrets.h"
@@ -551,6 +552,9 @@ int main(int argc, char *argv[])
 	/* set up IRC peer discovery */
 	if (dstate->config.use_irc)
 		setup_irc_connection(dstate);
+
+	/* set up P2P gossip protocol */
+	setup_p2p_announce(dstate);
 
 	log_info(dstate->base_log, "Hello world!");
 

--- a/daemon/lightningd.c
+++ b/daemon/lightningd.c
@@ -371,6 +371,7 @@ static struct lightningd_state *lightningd_state(void)
 	dstate->reexec = NULL;
 	dstate->external_ip = NULL;
 	dstate->announce = NULL;
+	list_head_init(&dstate->broadcast_queue);
 	return dstate;
 }
 

--- a/daemon/lightningd.h
+++ b/daemon/lightningd.h
@@ -147,5 +147,8 @@ struct lightningd_state {
 
 	/* Announce timer. */
 	struct oneshot *announce;
+
+	/* Outgoing messages queued for the staggered broadcast */
+	struct list_head broadcast_queue;
 };
 #endif /* LIGHTNING_DAEMON_LIGHTNING_H */

--- a/daemon/p2p_announce.c
+++ b/daemon/p2p_announce.c
@@ -384,7 +384,7 @@ static void announce(struct lightningd_state *dstate)
 	struct peer *p;
 	int nchan = 0;
 
-	new_reltimer(dstate, dstate, time_from_sec(6), announce, dstate);
+	new_reltimer(dstate, dstate, time_from_sec(5*60*60), announce, dstate);
 
 	list_for_each(&dstate->peers, p, list) {
 		if (state_is_normal(p->state)) {
@@ -419,6 +419,6 @@ static void process_broadcast_queue(struct lightningd_state *dstate)
 
 void setup_p2p_announce(struct lightningd_state *dstate)
 {
-	new_reltimer(dstate, dstate, time_from_sec(30), announce, dstate);
+	new_reltimer(dstate, dstate, time_from_sec(5*60*60), announce, dstate);
 	new_reltimer(dstate, dstate, time_from_sec(30), process_broadcast_queue, dstate);
 }

--- a/daemon/p2p_announce.c
+++ b/daemon/p2p_announce.c
@@ -12,6 +12,24 @@
 #include <ccan/tal/tal.h>
 #include <secp256k1.h>
 
+struct queued_message {
+	int type;
+
+	/* Unique tag specifying the msg origin */
+	void *tag;
+
+	/* Timestamp for `channel_update`s and `node_announcement`s, 0
+	 * for `channel_announcement`s */
+	u32 timestamp;
+
+	/* Serialized payload */
+	u8 *payload;
+
+	struct list_node list;
+
+	/* who told us about this message? */
+	struct peer *origin;
+};
 
 u8 ipv4prefix[] = {
 	0x00, 0x00, 0x00, 0x00,
@@ -57,6 +75,38 @@ static void broadcast(struct lightningd_state *dstate,
 		if (state_is_normal(p->state) && origin != p)
 			queue_pkt_nested(p, type, pkt);
 	}
+}
+
+static void queue_broadcast(struct lightningd_state *dstate,
+			    const int type,
+			    const u32 timestamp,
+			    const u8 *tag,
+			    const u8 *payload,
+			    struct peer *origin)
+{
+	struct queued_message *el, *msg;
+	list_for_each(&dstate->broadcast_queue, el, list) {
+		if (el->type == type &&
+		    tal_count(tag) == tal_count(el->tag) &&
+		    memcmp(el->tag, tag, tal_count(tag)) == 0 &&
+		    el->timestamp < timestamp){
+			/* Found a replacement */
+			el->payload = tal_free(el->payload);
+			el->payload = tal_dup_arr(el, u8, payload, tal_count(payload), 0);
+			el->timestamp = timestamp;
+			el->origin = origin;
+			return;
+		}
+	}
+
+	/* No match found, add a new message to the queue */
+	msg = tal(dstate, struct queued_message);
+	msg->type = type;
+	msg->timestamp = timestamp;
+	msg->tag = tal_dup_arr(msg, u8, tag, tal_count(tag), 0);
+	msg->payload = tal_dup_arr(msg, u8, payload, tal_count(payload), 0);
+	msg->origin = origin;
+	list_add_tail(&dstate->broadcast_queue, &msg->list);
 }
 
 static bool add_channel_direction(struct lightningd_state *dstate,
@@ -110,7 +160,14 @@ void handle_channel_announcement(
 	}
 
 	serialized = towire_channel_announcement(msg, msg);
-	broadcast(peer->dstate, WIRE_CHANNEL_ANNOUNCEMENT, serialized, peer);
+
+	u8 *tag = tal_arr(msg, u8, 0);
+	towire_channel_id(&tag, &msg->channel_id);
+	queue_broadcast(peer->dstate,
+			WIRE_CHANNEL_ANNOUNCEMENT,
+			0, /* `channel_announcement`s do not have a timestamp */
+			tag,
+			serialized, peer);
 	tal_free(msg);
 }
 
@@ -159,7 +216,13 @@ void handle_channel_update(struct peer *peer, const struct msg_channel_update *m
 		  msg->flags
 		);
 
-	broadcast(peer->dstate, WIRE_CHANNEL_UPDATE, serialized, peer);
+	u8 *tag = tal_arr(msg, u8, 0);
+	towire_channel_id(&tag, &msg->channel_id);
+	queue_broadcast(peer->dstate,
+			WIRE_CHANNEL_UPDATE,
+			msg->timestamp,
+			tag,
+			serialized, peer);
 	tal_free(msg);
 }
 
@@ -203,7 +266,13 @@ void handle_node_announcement(
 	node->port = msg->port;
 	memcpy(node->rgb_color, msg->rgb_color, 3);
 
-	broadcast(peer->dstate, WIRE_NODE_ANNOUNCEMENT, serialized, peer);
+	u8 *tag = tal_arr(msg, u8, 0);
+	towire_pubkey(&tag, &msg->node_id);
+	queue_broadcast(peer->dstate,
+			WIRE_NODE_ANNOUNCEMENT,
+			msg->timestamp,
+			tag,
+			serialized, peer);
 	tal_free(msg);
 }
 
@@ -335,9 +404,21 @@ void announce_channel(struct lightningd_state *dstate, struct peer *peer)
 	broadcast_channel_announcement(dstate, peer);
 	broadcast_channel_update(dstate, peer);
 	broadcast_node_announcement(dstate);
+
+}
+
+static void process_broadcast_queue(struct lightningd_state *dstate)
+{
+	new_reltimer(dstate, dstate, time_from_sec(30), process_broadcast_queue, dstate);
+	struct queued_message *el;
+	while ((el = list_pop(&dstate->broadcast_queue, struct queued_message, list)) != NULL) {
+		broadcast(dstate, el->type, el->payload, NULL);
+		tal_free(el);
+	}
 }
 
 void setup_p2p_announce(struct lightningd_state *dstate)
 {
 	new_reltimer(dstate, dstate, time_from_sec(30), announce, dstate);
+	new_reltimer(dstate, dstate, time_from_sec(30), process_broadcast_queue, dstate);
 }

--- a/daemon/p2p_announce.c
+++ b/daemon/p2p_announce.c
@@ -263,8 +263,7 @@ void handle_node_announcement(
 	}
 
 	node->last_timestamp = msg->timestamp;
-	if (node->hostname)
-		node->hostname = tal_free(node->hostname);
+	node->hostname = tal_free(node->hostname);
 	node->hostname = read_ip(node, &msg->ipv6);
 	node->port = msg->port;
 	memcpy(node->rgb_color, msg->rgb_color, 3);
@@ -296,6 +295,7 @@ static void broadcast_channel_update(struct lightningd_state *dstate, struct pee
 	msg->channel_id.outnum = peer->anchor.index;
 	msg->flags = pubkey_cmp(&dstate->id, peer->id) > 0;
 	msg->expiry = dstate->config.min_htlc_expiry;
+	//FIXME(cdecker) Make the minimum HTLC configurable
 	msg->htlc_minimum_msat = 1;
 	msg->fee_base_msat = dstate->config.fee_base;
 	msg->fee_proportional_millionths = dstate->config.fee_per_satoshi;

--- a/daemon/p2p_announce.c
+++ b/daemon/p2p_announce.c
@@ -1,0 +1,322 @@
+#include "daemon/chaintopology.h"
+#include "daemon/log.h"
+#include "daemon/p2p_announce.h"
+#include "daemon/packets.h"
+#include "daemon/peer.h"
+#include "daemon/routing.h"
+#include "daemon/secrets.h"
+#include "daemon/timeout.h"
+
+#include <arpa/inet.h>
+#include <ccan/tal/str/str.h>
+#include <ccan/tal/tal.h>
+#include <secp256k1.h>
+
+
+u8 ipv4prefix[] = {
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0xFF, 0xFF
+};
+
+/* Read an IP from `srcip` and convert it into the dotted
+ * notation. Handles both IPv4 and IPv6 addresses and converts
+ * accordingly. We differentiate the two by using the RFC 4291
+ * IPv4-mapped IPv6 format */
+static char* read_ip(const tal_t *ctx, const struct ipv6 *srcip)
+{
+	char tempaddr[INET6_ADDRSTRLEN];
+
+	if (memcmp(srcip, ipv4prefix, sizeof(ipv4prefix)) == 0) {
+		inet_ntop(AF_INET, srcip + 12, tempaddr, sizeof(tempaddr));
+	}else{
+		inet_ntop(AF_INET6, srcip, tempaddr, sizeof(tempaddr));
+	}
+	return tal_strdup(ctx, tempaddr);
+}
+
+/* Serialize the IP address in `srcip` into a 16 byte
+ * representation. It handles both IPv6 and IPv4 addresses, prefixing
+ * IPv4 addresses with the prefix described in RFC 4291. */
+static void write_ip(struct ipv6 *dstip, char *srcip)
+{
+	if (!strchr(srcip, ':')) {
+		memcpy(dstip, ipv4prefix, sizeof(ipv4prefix));
+		inet_pton(AF_INET, srcip, dstip);
+	} else {
+		inet_pton(AF_INET6, srcip, dstip);
+	}
+}
+
+static void broadcast(struct lightningd_state *dstate,
+		      int type, u8 *pkt,
+		      struct peer *origin)
+{
+	struct peer *p;
+	list_for_each(&dstate->peers, p, list) {
+		if (state_is_normal(p->state) && origin != p)
+			queue_pkt_nested(p, type, pkt);
+	}
+}
+
+static bool add_channel_direction(struct lightningd_state *dstate,
+				  const struct pubkey *from,
+				  const struct pubkey *to,
+				  const int direction,
+				  const struct channel_id *channel_id
+	)
+{
+	struct node_connection *c = get_connection(dstate, from, to);
+	if (c){
+		/* Do not clobber connections added otherwise */
+		memcpy(&c->channel_id, channel_id, sizeof(c->channel_id));
+		c->flags = direction;
+		printf("Found node_connection via get_connection");
+		return false;
+	}else if(get_connection_by_cid(dstate, channel_id, direction)) {
+		return false;
+	}
+	half_add_connection(dstate,
+			    from,
+			    to,
+			    channel_id, direction);
+	return true;
+}
+
+void handle_channel_announcement(
+	struct peer *peer,
+	const struct msg_channel_announcement *msg)
+{
+	u8 *serialized;
+	bool forward = false;
+	if (!msg)
+		return;
+
+	//FIXME(cdecker) Check signatures, when the spec is settled
+	//FIXME(cdecker) Check chain topology for the anchor TX
+
+	log_debug(peer->log, "Received channel_announcement for channel %d:%d:%d",
+			  msg->channel_id.blocknum,
+			  msg->channel_id.txnum,
+			  msg->channel_id.outnum
+		);
+	forward |= add_channel_direction(peer->dstate, &msg->node_id_1,
+					 &msg->node_id_2, 0, &msg->channel_id);
+	forward |= add_channel_direction(peer->dstate, &msg->node_id_2,
+					 &msg->node_id_1, 1, &msg->channel_id);
+	if (!forward){
+		log_debug(peer->log, "Not forwarding channel_announcement");
+		return;
+	}
+
+	serialized = towire_channel_announcement(msg, msg);
+	broadcast(peer->dstate, WIRE_CHANNEL_ANNOUNCEMENT, serialized, peer);
+	tal_free(msg);
+}
+
+void handle_channel_update(struct peer *peer, const struct msg_channel_update *msg)
+{
+	if (!msg)
+		return;
+
+	u8 *serialized;
+	struct node_connection *c;
+
+	log_debug(peer->log, "Received channel_update for channel %d:%d:%d(%d)",
+		  msg->channel_id.blocknum,
+		  msg->channel_id.txnum,
+		  msg->channel_id.outnum,
+		  msg->flags & 0x01
+		);
+
+	c = get_connection_by_cid(peer->dstate, &msg->channel_id, msg->flags & 0x1);
+
+	if (!c) {
+		log_debug(peer->log, "Ignoring update for unknown channel %d:%d:%d",
+			  msg->channel_id.blocknum,
+			  msg->channel_id.txnum,
+			  msg->channel_id.outnum
+			);
+		return;
+	} else if (c->last_timestamp >= msg->timestamp) {
+		log_debug(peer->log, "Ignoring outdated update.");
+		return;
+	}
+
+	//FIXME(cdecker) Check signatures
+	serialized = towire_channel_update(msg, msg);
+
+	c->last_timestamp = msg->timestamp;
+	c->delay = msg->expiry;
+	c->htlc_minimum_msat = msg->htlc_minimum_msat;
+	c->base_fee = msg->fee_base_msat;
+	c->proportional_fee = msg->fee_proportional_millionths;
+	c->active = true;
+	log_debug(peer->log, "Channel %d:%d:%d(%d) was updated.",
+		  msg->channel_id.blocknum,
+		  msg->channel_id.txnum,
+		  msg->channel_id.outnum,
+		  msg->flags
+		);
+
+	broadcast(peer->dstate, WIRE_CHANNEL_UPDATE, serialized, peer);
+	tal_free(msg);
+}
+
+void handle_node_announcement(
+	struct peer *peer, const struct msg_node_announcement *msg)
+{
+	u8 *serialized;
+	struct sha256_double hash;
+	struct node *node;
+
+	if (!msg)
+		return;
+
+	log_debug_struct(peer->log,
+			 "Received node_announcement for node %s",
+			 struct pubkey, &msg->node_id);
+
+	serialized = towire_node_announcement(msg, msg);
+	sha256_double(&hash, serialized + 64, tal_count(serialized) - 64);
+	if (!check_signed_hash(&hash, &msg->signature, &msg->node_id)) {
+		log_debug(peer->dstate->base_log,
+			  "Ignoring node announcement, signature verification failed.");
+		return;
+	}
+	node = get_node(peer->dstate, &msg->node_id);
+
+	if (!node) {
+		log_debug(peer->dstate->base_log,
+			  "Node not found, was the node_announcement preceeded by at least channel_announcement?");
+		return;
+	} else if (node->last_timestamp >= msg->timestamp) {
+		log_debug(peer->dstate->base_log,
+			  "Ignoring node announcement, it's outdated.");
+		return;
+	}
+
+	node->last_timestamp = msg->timestamp;
+	if (node->hostname)
+		node->hostname = tal_free(node->hostname);
+	node->hostname = read_ip(node, &msg->ipv6);
+	node->port = msg->port;
+	memcpy(node->rgb_color, msg->rgb_color, 3);
+
+	broadcast(peer->dstate, WIRE_NODE_ANNOUNCEMENT, serialized, peer);
+	tal_free(msg);
+}
+
+static void broadcast_channel_update(struct lightningd_state *dstate, struct peer *peer)
+{
+	struct msg_channel_update *msg;
+	struct txlocator *loc;
+	u8 *serialized;
+
+	msg = tal(peer, struct msg_channel_update);
+	loc = locate_tx(msg, dstate, &peer->anchor.txid);
+
+	msg->timestamp = timeabs_to_timeval(time_now()).tv_sec;
+	msg->channel_id.blocknum = loc->blkheight;
+	msg->channel_id.txnum = loc->index;
+	msg->channel_id.outnum = peer->anchor.index;
+	msg->flags = pubkey_cmp(&dstate->id, peer->id) > 0;
+	msg->expiry = dstate->config.min_htlc_expiry;
+	msg->htlc_minimum_msat = 1;
+	msg->fee_base_msat = dstate->config.fee_base;
+	msg->fee_proportional_millionths = dstate->config.fee_per_satoshi;
+
+	/* Avoid triggering memcheck */
+	memset(&msg->signature, 0, sizeof(msg->signature));
+	serialized = towire_channel_update(msg, msg);
+	privkey_sign(dstate, serialized + 64, tal_count(serialized) - 64, &msg->signature);
+	serialized = towire_channel_update(msg, msg);
+
+	broadcast(dstate, WIRE_CHANNEL_UPDATE, serialized, NULL);
+	tal_free(msg);
+}
+
+static void broadcast_node_announcement(struct lightningd_state *dstate)
+{
+	u8 *serialized;
+
+	/* Are we listeing for incoming connections at all? */
+	if (!dstate->external_ip || !dstate->portnum)
+		return;
+
+	struct msg_node_announcement *msg = tal(dstate, struct msg_node_announcement);
+	msg->timestamp = timeabs_to_timeval(time_now()).tv_sec;
+	msg->node_id = dstate->id;
+	write_ip(&msg->ipv6, dstate->external_ip);
+	msg->port = dstate->portnum;
+	memset(&msg->rgb_color, 0x00, 3);
+
+	serialized = towire_node_announcement(msg, msg);
+	privkey_sign(dstate, serialized + 64, tal_count(serialized) - 64, &msg->signature);
+	serialized = towire_node_announcement(msg, msg);
+	broadcast(dstate, WIRE_NODE_ANNOUNCEMENT, serialized, NULL);
+	tal_free(msg);
+
+}
+
+static void broadcast_channel_announcement(struct lightningd_state *dstate, struct peer *peer)
+{
+	struct msg_channel_announcement *msg = tal(peer, struct msg_channel_announcement);
+	struct txlocator *loc;
+	u8 *ser;
+
+	loc = locate_tx(msg, dstate, &peer->anchor.txid);
+
+	msg->channel_id.blocknum = loc->blkheight;
+	msg->channel_id.txnum = loc->index;
+	msg->channel_id.outnum = peer->anchor.index;
+
+	if (pubkey_cmp(&dstate->id, peer->id) > 0) {
+		msg->node_id_1 = *peer->id;
+		msg->node_id_2 = dstate->id;
+		msg->bitcoin_key_1 = *peer->id;
+		msg->bitcoin_key_2 = dstate->id;
+	} else {
+		msg->node_id_2 = *peer->id;
+		msg->node_id_1 = dstate->id;
+		msg->bitcoin_key_2 = *peer->id;
+		msg->bitcoin_key_1 = dstate->id;
+	}
+
+	//FIXME(cdecker) actually sign this packet, currently not pinned down in spec
+	ser = towire_channel_announcement(msg, msg);
+	broadcast(dstate, WIRE_CHANNEL_ANNOUNCEMENT, ser, NULL);
+	tal_free(msg);
+}
+
+static void announce(struct lightningd_state *dstate)
+{
+	struct peer *p;
+	int nchan = 0;
+
+	new_reltimer(dstate, dstate, time_from_sec(6), announce, dstate);
+
+	list_for_each(&dstate->peers, p, list) {
+		if (state_is_normal(p->state)) {
+			broadcast_channel_announcement(dstate, p);
+			broadcast_channel_update(dstate, p);
+			nchan += 1;
+		}
+	}
+
+	/* No point in broadcasting our node if we don't have a channel */
+	if (nchan > 0)
+		broadcast_node_announcement(dstate);
+}
+
+void announce_channel(struct lightningd_state *dstate, struct peer *peer)
+{
+	broadcast_channel_announcement(dstate, peer);
+	broadcast_channel_update(dstate, peer);
+	broadcast_node_announcement(dstate);
+}
+
+void setup_p2p_announce(struct lightningd_state *dstate)
+{
+	new_reltimer(dstate, dstate, time_from_sec(30), announce, dstate);
+}

--- a/daemon/p2p_announce.h
+++ b/daemon/p2p_announce.h
@@ -1,0 +1,17 @@
+#ifndef LIGHTNING_DAEMON_P2P_ANNOUNCE_H
+#define LIGHTNING_DAEMON_P2P_ANNOUNCE_H
+#include "config.h"
+#include "lightningd.h"
+#include "wire/gen_wire.h"
+
+void setup_p2p_announce(struct lightningd_state *dstate);
+
+/* Handlers for incoming messages */
+void handle_channel_announcement(struct peer *peer, const struct msg_channel_announcement *announce);
+void handle_channel_update(struct peer *peer, const struct msg_channel_update *update);
+void handle_node_announcement(struct peer *peer, const struct msg_node_announcement *node);
+
+/* Used to announce the existence of a channel and the endpoints */
+void announce_channel(struct lightningd_state *dstate, struct peer *peer);
+
+#endif /* LIGHTNING_DAEMON_P2P_ANNOUNCE_H */

--- a/daemon/packets.c
+++ b/daemon/packets.c
@@ -213,6 +213,19 @@ void queue_pkt_revocation(struct peer *peer,
 	queue_pkt(peer, PKT__PKT_UPDATE_REVOCATION, u);
 }
 
+/* Send a serialized nested packet. */
+void queue_pkt_nested(struct peer *peer,
+		      int type,
+		      const u8 *nested_pkt)
+{
+		NestedPkt *pb = tal(peer, NestedPkt);
+		nested_pkt__init(pb);
+		pb->type = type;
+		pb->inner_pkt.len = tal_count(nested_pkt);
+		pb->inner_pkt.data = tal_dup_arr(pb, u8, nested_pkt, pb->inner_pkt.len, 0);
+		queue_pkt(peer, PKT__PKT_NESTED, pb);
+}
+
 Pkt *pkt_err(struct peer *peer, const char *msg, ...)
 {
 	Error *e = tal(peer, Error);

--- a/daemon/packets.h
+++ b/daemon/packets.h
@@ -24,6 +24,7 @@ void queue_pkt_revocation(struct peer *peer,
 			  const struct sha256 *next_hash);
 void queue_pkt_close_shutdown(struct peer *peer);
 void queue_pkt_close_signature(struct peer *peer);
+void queue_pkt_nested(struct peer *peer, int type, const u8 *nested_pkt);
 
 Pkt *pkt_err(struct peer *peer, const char *msg, ...);
 Pkt *pkt_init(struct peer *peer, u64 ack);

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -747,6 +747,7 @@ static bool open_wait_pkt_in(struct peer *peer, const Pkt *pkt)
 			peer_open_complete(peer, NULL);
 			set_peer_state(peer, STATE_NORMAL, __func__, true);
 			announce_channel(peer->dstate, peer);
+			sync_routing_table(peer->dstate, peer);
 		} else {
 			set_peer_state(peer, STATE_OPEN_WAIT_ANCHORDEPTH,
 				       __func__, true);
@@ -2529,8 +2530,10 @@ static struct io_plan *init_pkt_in(struct io_conn *conn, struct peer *peer)
 
 	peer_has_connected(peer);
 
-	if (state_is_normal(peer->state))
+	if (state_is_normal(peer->state)){
 		announce_channel(peer->dstate, peer);
+		sync_routing_table(peer->dstate, peer);
+	}
 
 	return io_duplex(conn,
 			 peer_read_packet(conn, peer, pkt_in),
@@ -3317,6 +3320,7 @@ static void peer_depth_ok(struct peer *peer)
 		peer_open_complete(peer, NULL);
 		set_peer_state(peer, STATE_NORMAL, __func__, true);
 		announce_channel(peer->dstate, peer);
+		sync_routing_table(peer->dstate, peer);
 		break;
 	default:
 		log_broken(peer->log, "%s: state %s",

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -746,6 +746,7 @@ static bool open_wait_pkt_in(struct peer *peer, const Pkt *pkt)
 		if (peer->state == STATE_OPEN_WAIT_THEIRCOMPLETE) {
 			peer_open_complete(peer, NULL);
 			set_peer_state(peer, STATE_NORMAL, __func__, true);
+			announce_channel(peer->dstate, peer);
 		} else {
 			set_peer_state(peer, STATE_OPEN_WAIT_ANCHORDEPTH,
 				       __func__, true);
@@ -2527,6 +2528,10 @@ static struct io_plan *init_pkt_in(struct io_conn *conn, struct peer *peer)
 	peer->inpkt = tal_free(peer->inpkt);
 
 	peer_has_connected(peer);
+
+	if (state_is_normal(peer->state))
+		announce_channel(peer->dstate, peer);
+
 	return io_duplex(conn,
 			 peer_read_packet(conn, peer, pkt_in),
 			 pkt_out(conn, peer));
@@ -3311,6 +3316,7 @@ static void peer_depth_ok(struct peer *peer)
 	case STATE_OPEN_WAIT_ANCHORDEPTH:
 		peer_open_complete(peer, NULL);
 		set_peer_state(peer, STATE_NORMAL, __func__, true);
+		announce_channel(peer->dstate, peer);
 		break;
 	default:
 		log_broken(peer->log, "%s: state %s",

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -13,6 +13,7 @@
 #include "names.h"
 #include "netaddr.h"
 #include "output_to_htlc.h"
+#include "p2p_announce.h"
 #include "packets.h"
 #include "pay.h"
 #include "peer.h"

--- a/daemon/peer.h
+++ b/daemon/peer.h
@@ -14,6 +14,7 @@
 #include "netaddr.h"
 #include "protobuf_convert.h"
 #include "state.h"
+#include "wire/gen_wire.h"
 #include <ccan/crypto/sha256/sha256.h>
 #include <ccan/crypto/shachain/shachain.h>
 #include <ccan/list/list.h>

--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -388,6 +388,8 @@ struct peer *find_route(const tal_t *ctx,
 		     n = node_map_next(dstate->nodes, &it)) {
 			size_t num_edges = tal_count(n->in);
 			for (i = 0; i < num_edges; i++) {
+				if (!n->in[i]->active)
+					continue;
 				bfg_one_edge(n, i, riskfactor);
 				log_debug(dstate->base_log, "We seek %p->%p, this is %p -> %p",
 					  dst, src, n->in[i]->src, n->in[i]->dst);

--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -153,7 +153,7 @@ struct node_connection *get_connection_by_cid(const struct lightningd_state *dst
 	        num_conn = tal_count(n->out);
 		for (i = 0; i < num_conn; i++){
 			c = n->out[i];
-			if (memcmp(&c->channel_id, chanid, sizeof(*chanid)) == 0 &&
+			if (structeq(&c->channel_id, chanid) &&
 			    (c->flags&0x1) == direction)
 			    return c;
 		}
@@ -196,7 +196,6 @@ get_or_make_connection(struct lightningd_state *dstate,
 	nc = tal(dstate, struct node_connection);
 	nc->src = from;
 	nc->dst = to;
-	memset(&nc->channel_id, 0, sizeof(nc->channel_id));
 	nc->channel_announcement = NULL;
 	nc->channel_update = NULL;
 	log_add(dstate->base_log, " = %p (%p->%p)", nc, from, to);
@@ -570,7 +569,7 @@ void sync_routing_table(struct lightningd_state *dstate, struct peer *peer)
 			if (nc->channel_update)
 				queue_pkt_nested(peer, WIRE_CHANNEL_UPDATE, nc->channel_update);
 		}
-		if (n->node_announcement)
+		if (n->node_announcement && num_edges > 0)
 			queue_pkt_nested(peer, WIRE_NODE_ANNOUNCEMENT, n->node_announcement);
 	}
 }

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -32,6 +32,10 @@ struct node_connection {
 	/* Flags as specified by the `channel_update`s, among other
 	 * things indicated direction wrt the `channel_id` */
 	u16 flags;
+
+	/* Cached `channel_announcement` and `channel_update` we might forward to new peers*/
+	u8 *channel_announcement;
+	u8 *channel_update;
 };
 
 struct node {
@@ -61,6 +65,9 @@ struct node {
 
 	/* Color to be used when displaying the name */
 	u8 rgb_color[3];
+
+	/* Cached `node_announcement` we might forward to new peers. */
+	u8 *node_announcement;
 };
 
 struct lightningd_state;
@@ -124,5 +131,8 @@ struct peer *find_route(const tal_t *ctx,
 struct node_map *empty_node_map(struct lightningd_state *dstate);
 
 char *opt_add_route(const char *arg, struct lightningd_state *dstate);
+
+/* Dump all known channels and nodes to the peer. Used when a new connection was established. */
+void sync_routing_table(struct lightningd_state *dstate, struct peer *peer);
 
 #endif /* LIGHTNING_DAEMON_ROUTING_H */

--- a/daemon/secrets.h
+++ b/daemon/secrets.h
@@ -3,6 +3,7 @@
 /* Routines to handle private keys. */
 #include "config.h"
 #include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
 
 struct peer;
 struct lightningd_state;

--- a/lightning.pb-c.c
+++ b/lightning.pb-c.c
@@ -1125,6 +1125,49 @@ void   error__free_unpacked
   assert(message->base.descriptor == &error__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
+void   nested_pkt__init
+                     (NestedPkt         *message)
+{
+  static NestedPkt init_value = NESTED_PKT__INIT;
+  *message = init_value;
+}
+size_t nested_pkt__get_packed_size
+                     (const NestedPkt *message)
+{
+  assert(message->base.descriptor == &nested_pkt__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t nested_pkt__pack
+                     (const NestedPkt *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &nested_pkt__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t nested_pkt__pack_to_buffer
+                     (const NestedPkt *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &nested_pkt__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+NestedPkt *
+       nested_pkt__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (NestedPkt *)
+     protobuf_c_message_unpack (&nested_pkt__descriptor,
+                                allocator, len, data);
+}
+void   nested_pkt__free_unpacked
+                     (NestedPkt *message,
+                      ProtobufCAllocator *allocator)
+{
+  assert(message->base.descriptor == &nested_pkt__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
 void   pkt__init
                      (Pkt         *message)
 {
@@ -2682,7 +2725,58 @@ const ProtobufCMessageDescriptor error__descriptor =
   (ProtobufCMessageInit) error__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor pkt__field_descriptors[15] =
+static const ProtobufCFieldDescriptor nested_pkt__field_descriptors[2] =
+{
+  {
+    "type",
+    1,
+    PROTOBUF_C_LABEL_REQUIRED,
+    PROTOBUF_C_TYPE_UINT32,
+    0,   /* quantifier_offset */
+    offsetof(NestedPkt, type),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "inner_pkt",
+    2,
+    PROTOBUF_C_LABEL_REQUIRED,
+    PROTOBUF_C_TYPE_BYTES,
+    0,   /* quantifier_offset */
+    offsetof(NestedPkt, inner_pkt),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned nested_pkt__field_indices_by_name[] = {
+  1,   /* field[1] = inner_pkt */
+  0,   /* field[0] = type */
+};
+static const ProtobufCIntRange nested_pkt__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor nested_pkt__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "nested_pkt",
+  "NestedPkt",
+  "NestedPkt",
+  "",
+  sizeof(NestedPkt),
+  2,
+  nested_pkt__field_descriptors,
+  nested_pkt__field_indices_by_name,
+  1,  nested_pkt__number_ranges,
+  (ProtobufCMessageInit) nested_pkt__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor pkt__field_descriptors[16] =
 {
   {
     "update_add_htlc",
@@ -2864,6 +2958,18 @@ static const ProtobufCFieldDescriptor pkt__field_descriptors[15] =
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "nested",
+    128,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Pkt, pkt_case),
+    offsetof(Pkt, nested),
+    &nested_pkt__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned pkt__field_indices_by_name[] = {
   13,   /* field[13] = auth */
@@ -2871,6 +2977,7 @@ static const unsigned pkt__field_indices_by_name[] = {
   11,   /* field[11] = close_signature */
   12,   /* field[12] = error */
   14,   /* field[14] = init */
+  15,   /* field[15] = nested */
   6,   /* field[6] = open */
   7,   /* field[7] = open_anchor */
   8,   /* field[8] = open_commit_sig */
@@ -2882,14 +2989,15 @@ static const unsigned pkt__field_indices_by_name[] = {
   1,   /* field[1] = update_fulfill_htlc */
   5,   /* field[5] = update_revocation */
 };
-static const ProtobufCIntRange pkt__number_ranges[5 + 1] =
+static const ProtobufCIntRange pkt__number_ranges[6 + 1] =
 {
   { 2, 0 },
   { 20, 6 },
   { 30, 10 },
   { 40, 12 },
   { 50, 13 },
-  { 0, 15 }
+  { 128, 15 },
+  { 0, 16 }
 };
 const ProtobufCMessageDescriptor pkt__descriptor =
 {
@@ -2899,10 +3007,10 @@ const ProtobufCMessageDescriptor pkt__descriptor =
   "Pkt",
   "",
   sizeof(Pkt),
-  15,
+  16,
   pkt__field_descriptors,
   pkt__field_indices_by_name,
-  5,  pkt__number_ranges,
+  6,  pkt__number_ranges,
   (ProtobufCMessageInit) pkt__init,
   NULL,NULL,NULL    /* reserved[123] */
 };

--- a/lightning.pb-c.h
+++ b/lightning.pb-c.h
@@ -41,6 +41,7 @@ typedef struct _UpdateRevocation UpdateRevocation;
 typedef struct _CloseShutdown CloseShutdown;
 typedef struct _CloseSignature CloseSignature;
 typedef struct _Error Error;
+typedef struct _NestedPkt NestedPkt;
 typedef struct _Pkt Pkt;
 
 
@@ -546,6 +547,20 @@ struct  _Error
     , NULL }
 
 
+/*
+ * Nested message to transport standard protocol messages through the legacy transport
+ */
+struct  _NestedPkt
+{
+  ProtobufCMessage base;
+  uint32_t type;
+  ProtobufCBinaryData inner_pkt;
+};
+#define NESTED_PKT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&nested_pkt__descriptor) \
+    , 0, {0,NULL} }
+
+
 typedef enum {
   PKT__PKT__NOT_SET = 0,
   PKT__PKT_AUTH = 50,
@@ -563,6 +578,7 @@ typedef enum {
   PKT__PKT_CLOSE_SHUTDOWN = 30,
   PKT__PKT_CLOSE_SIGNATURE = 31,
   PKT__PKT_ERROR = 40,
+  PKT__PKT_NESTED = 128,
 } Pkt__PktCase;
 
 /*
@@ -603,6 +619,10 @@ struct  _Pkt
      * Unexpected issue.
      */
     Error *error;
+    /*
+     * Shim to upgrade to new packet format
+     */
+    NestedPkt *nested;
   };
 };
 #define PKT__INIT \
@@ -1104,6 +1124,25 @@ Error *
 void   error__free_unpacked
                      (Error *message,
                       ProtobufCAllocator *allocator);
+/* NestedPkt methods */
+void   nested_pkt__init
+                     (NestedPkt         *message);
+size_t nested_pkt__get_packed_size
+                     (const NestedPkt   *message);
+size_t nested_pkt__pack
+                     (const NestedPkt   *message,
+                      uint8_t             *out);
+size_t nested_pkt__pack_to_buffer
+                     (const NestedPkt   *message,
+                      ProtobufCBuffer     *buffer);
+NestedPkt *
+       nested_pkt__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   nested_pkt__free_unpacked
+                     (NestedPkt *message,
+                      ProtobufCAllocator *allocator);
 /* Pkt methods */
 void   pkt__init
                      (Pkt         *message);
@@ -1203,6 +1242,9 @@ typedef void (*CloseSignature_Closure)
 typedef void (*Error_Closure)
                  (const Error *message,
                   void *closure_data);
+typedef void (*NestedPkt_Closure)
+                 (const NestedPkt *message,
+                  void *closure_data);
 typedef void (*Pkt_Closure)
                  (const Pkt *message,
                   void *closure_data);
@@ -1239,6 +1281,7 @@ extern const ProtobufCMessageDescriptor update_revocation__descriptor;
 extern const ProtobufCMessageDescriptor close_shutdown__descriptor;
 extern const ProtobufCMessageDescriptor close_signature__descriptor;
 extern const ProtobufCMessageDescriptor error__descriptor;
+extern const ProtobufCMessageDescriptor nested_pkt__descriptor;
 extern const ProtobufCMessageDescriptor pkt__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/lightning.proto
+++ b/lightning.proto
@@ -223,6 +223,12 @@ message error {
   optional string problem = 1;
 }
 
+// Nested message to transport standard protocol messages through the legacy transport
+message nested_pkt {
+  required uint32 type = 1;
+  required bytes inner_pkt = 2;
+}
+
 // This is the union which defines all of them
 message pkt {
   oneof pkt {
@@ -249,5 +255,8 @@ message pkt {
 
     // Unexpected issue.
     error error = 40;
+
+    // Shim to upgrade to new packet format
+    nested_pkt nested = 128;
   }
 }

--- a/wire/gen_wire_csv
+++ b/wire/gen_wire_csv
@@ -51,9 +51,6 @@ funding_locked,8,channel-id,8
 funding_locked,16,announcement-node-signature,64
 funding_locked,80,announcement-bitcoin-signature,64
 funding_locked,144,next-per-commitment-point,33
-update_fee,37
-update_fee,0,channel-id,8
-update_fee,8,feerate-per-kw,4
 shutdown,38
 shutdown,0,channel-id,8
 shutdown,8,len,2
@@ -89,6 +86,9 @@ revoke_and_ack,40,next-per-commitment-point,33
 revoke_and_ack,73,padding,1
 revoke_and_ack,74,num-htlc-timeouts,2
 revoke_and_ack,76,htlc-timeout-signature,num-htlc-timeouts*64
+update_fee,134
+update_fee,0,channel-id,8
+update_fee,8,feerate-per-kw,4
 channel_announcement,256
 channel_announcement,0,node-signature-1,64
 channel_announcement,64,node-signature-2,64


### PR DESCRIPTION
Implementation of the gossip protocol as per spec (lightningnetwork/lightning-rfc@8c8664452b079e66bd3356cac9c73b8e878ccbb7). The following changes are included:

 - A small shim that allows the new message format to be transported over the legacy transport layer
 - Tracking transaction indexes so that we can check anchor transactions
 - Creation and handling of `channel_announcement`, `channel_update` and `node_announcement`
 - Regular broadcasts as heartbeat
 - Triggering announcements on channel establishment
 - Synchronization of routing tables upon connection

Signatures are partially populated, but aren't checked yet since we need to have the channel establishment implemented first, which provides us with the remote signatures as well.

Fixes #88 