### PR TITLE
trivial: Add `addresses` field to generate-wire.py

### DIFF
--- a/wire/tools/generate-wire.py
+++ b/wire/tools/generate-wire.py
@@ -61,6 +61,9 @@ class Field(object):
 
         if fieldname.endswith('features'):
             return ('u8',1)
+
+        if fieldname == 'addresses':
+            return ('u8', 1)
     
         # We translate signatures and pubkeys.
         if 'signature' in fieldname:


### PR DESCRIPTION
It was failing the compile if we had a recent enough spec.