### PR TITLE
Add coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ libsecp256k1.la
 gen_*
 daemon/lightning-cli
 check-bolt
+coverage

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,13 @@ check-source: check-makefile check-source-bolt check-whitespace	\
 
 full-check: check $(TEST_PROGRAMS) check-source
 
+coverage/coverage.info: check $(TEST_PROGRAMS)
+	mkdir coverage || true
+	lcov --capture --directory . --output-file coverage/coverage.info
+
+coverage: coverage/coverage.info
+	genhtml coverage/coverage.info --output-directory coverage
+
 # Ignore test/ directories.
 TAGS: FORCE
 	$(RM) TAGS; find * -name test -type d -prune -o -name '*.[ch]' -print | xargs etags --append
@@ -360,6 +367,8 @@ clean: daemon-clean wire-clean
 	$(RM) ccan/config.h gen_*.h
 	$(RM) ccan/ccan/cdump/tools/cdump-enumstr.o
 	$(RM) doc/deployable-lightning.{aux,bbl,blg,dvi,log,out,tex}
+	find . -name '*gcda' -delete
+	find . -name '*gcno' -delete
 
 include daemon/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ VALGRIND=valgrind -q --error-exitcode=7
 VALGRIND_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes
 endif
 
+ifeq ($(COVERAGE),1)
+COVFLAGS = --coverage
+endif
+
 # This is where we add new features as bitcoin adds them.
 FEATURES :=
 
@@ -194,9 +198,9 @@ PROGRAMS := $(TEST_PROGRAMS)
 
 CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition
 CDEBUGFLAGS := -g -fstack-protector
-CFLAGS := $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) -I secp256k1/include/ -I . $(FEATURES)
+CFLAGS := $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) -I secp256k1/include/ -I . $(FEATURES) $(COVFLAGS)
 
-LDLIBS := -lprotobuf-c -lgmp -lsodium -lsqlite3
+LDLIBS := -lprotobuf-c -lgmp -lsodium -lsqlite3 $(COVFLAGS)
 $(PROGRAMS): CFLAGS+=-I.
 
 default: $(PROGRAMS) $(MANPAGES) daemon-all


### PR DESCRIPTION
Setting the environment variable `COVERAGE=1` allows us to turn coverage measurements on. This produces a number of auxiliary gcno and gcda files which can then be converted into coverage reports. `make coverage` then allows us to generate HTML reports.

I know line coverage and branch coverage is not a perfect metric, but it might get us some more visibility into where more tests might be needed.