### PR TITLE
[depends] Commit to HTLC in onion packet

### DIFF
--- a/daemon/pay.c
+++ b/daemon/pay.c
@@ -442,9 +442,7 @@ static void json_sendpay(struct command *cmd,
 	randombytes_buf(&sessionkey, sizeof(sessionkey));
 
 	/* Onion will carry us from first peer onwards. */
-	packet = create_onionpacket(
-		cmd, ids, hoppayloads,
-		sessionkey, (u8*)"", 0);
+	packet = create_onionpacket(cmd, ids, hoppayloads, sessionkey);
 	onion = serialize_onionpacket(cmd, packet);
 
 	if (pc)

--- a/daemon/pay.c
+++ b/daemon/pay.c
@@ -442,7 +442,8 @@ static void json_sendpay(struct command *cmd,
 	randombytes_buf(&sessionkey, sizeof(sessionkey));
 
 	/* Onion will carry us from first peer onwards. */
-	packet = create_onionpacket(cmd, ids, hoppayloads, sessionkey);
+	packet = create_onionpacket(cmd, ids, hoppayloads, sessionkey,
+				    pc->rhash.u.u8, sizeof(struct sha256));
 	onion = serialize_onionpacket(cmd, packet);
 
 	if (pc)

--- a/daemon/pay.c
+++ b/daemon/pay.c
@@ -443,7 +443,7 @@ static void json_sendpay(struct command *cmd,
 
 	/* Onion will carry us from first peer onwards. */
 	packet = create_onionpacket(cmd, ids, hoppayloads, sessionkey,
-				    pc->rhash.u.u8, sizeof(struct sha256));
+				    rhash.u.u8, sizeof(struct sha256));
 	onion = serialize_onionpacket(cmd, packet);
 
 	if (pc)

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -4730,10 +4730,7 @@ static void json_newhtlc(struct command *cmd,
 	hoppayloads = tal_arrz(cmd, struct hoppayload, 1);
 	memcpy(&path[0], peer->id, sizeof(struct pubkey));
 	randombytes_buf(&sessionkey, sizeof(sessionkey));
-	packet = create_onionpacket(
-		cmd,
-		path,
-		hoppayloads, sessionkey, (u8*)"", 0);
+	packet = create_onionpacket(cmd, path, hoppayloads, sessionkey);
 	onion = serialize_onionpacket(cmd, packet);
 
 	log_debug(peer->log, "JSON command to add new HTLC");

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -887,7 +887,8 @@ static void their_htlc_added(struct peer *peer, struct htlc *htlc,
 	packet = parse_onionpacket(peer,
 				   htlc->routing, tal_count(htlc->routing));
 	if (packet)
-		step = process_onionpacket(packet, packet, &pk);
+		step = process_onionpacket(packet, packet, &pk, htlc->rhash.u.u8,
+					   sizeof(htlc->rhash));
 
 	if (!step) {
 		log_unusual(peer->log, "Bad onion, failing HTLC %"PRIu64,
@@ -4730,7 +4731,8 @@ static void json_newhtlc(struct command *cmd,
 	hoppayloads = tal_arrz(cmd, struct hoppayload, 1);
 	memcpy(&path[0], peer->id, sizeof(struct pubkey));
 	randombytes_buf(&sessionkey, sizeof(sessionkey));
-	packet = create_onionpacket(cmd, path, hoppayloads, sessionkey);
+	packet = create_onionpacket(cmd, path, hoppayloads, sessionkey,
+				    rhash.u.u8, sizeof(rhash));
 	onion = serialize_onionpacket(cmd, packet);
 
 	log_debug(peer->log, "JSON command to add new HTLC");

--- a/daemon/sphinx.c
+++ b/daemon/sphinx.c
@@ -272,7 +272,7 @@ static bool create_shared_secret(
 	secp256k1_ec_pubkey_serialize(secp256k1_ctx, ecres, &outputlen,
 				      &pkcopy, SECP256K1_EC_COMPRESSED);
 	struct sha256 h;
-	sha256(&h, ecres + 1, sizeof(ecres) - 1);
+	sha256(&h, ecres, sizeof(ecres));
 	memcpy(secret, &h, sizeof(h));
 	return true;
 }
@@ -361,7 +361,7 @@ static struct hop_params *generate_hop_params(
 			secp256k1_ctx, der, &outputlen, &temp,
 			SECP256K1_EC_COMPRESSED);
 		struct sha256 h;
-		sha256(&h, der + 1, sizeof(der) - 1);
+		sha256(&h, der, sizeof(der));
 		memcpy(&params[i].secret, &h, sizeof(h));
 
 		compute_blinding_factor(

--- a/daemon/sphinx.h
+++ b/daemon/sphinx.h
@@ -14,10 +14,9 @@
 #define NUM_MAX_HOPS 20
 #define HOP_PAYLOAD_SIZE 20
 #define TOTAL_HOP_PAYLOAD_SIZE (NUM_MAX_HOPS * HOP_PAYLOAD_SIZE)
-#define MESSAGE_SIZE 0
 #define ROUTING_INFO_SIZE (2 * NUM_MAX_HOPS * SECURITY_PARAMETER)
 #define TOTAL_PACKET_SIZE (1 + 33 + SECURITY_PARAMETER + ROUTING_INFO_SIZE + \
-			   TOTAL_HOP_PAYLOAD_SIZE + MESSAGE_SIZE)
+			   TOTAL_HOP_PAYLOAD_SIZE)
 
 struct onionpacket {
 	/* Cleartext information */
@@ -29,7 +28,6 @@ struct onionpacket {
 	/* Encrypted information */
 	u8 routinginfo[ROUTING_INFO_SIZE];
 	u8 hoppayloads[TOTAL_HOP_PAYLOAD_SIZE];
-	u8 payload[MESSAGE_SIZE];
 };
 
 enum route_next_case {
@@ -46,7 +44,6 @@ struct hoppayload {
 struct route_step {
 	enum route_next_case nextcase;
 	struct onionpacket *next;
-	u8 *payload;
 	struct hoppayload *hoppayload;
 };
 
@@ -60,16 +57,12 @@ struct route_step {
  *    HOP_PAYLOAD_SIZE bytes)
  * @num_hops: path length in nodes
  * @sessionkey: 20 byte random session key to derive secrets from
- * @message: end-to-end payload destined for the final recipient
- * @messagelen: length of @message
  */
 struct onionpacket *create_onionpacket(
 	const tal_t * ctx,
 	struct pubkey path[],
 	struct hoppayload hoppayloads[],
-	const u8 * sessionkey,
-	const u8 * message,
-	const size_t messagelen
+	const u8 * sessionkey
 	);
 
 /**

--- a/daemon/sphinx.h
+++ b/daemon/sphinx.h
@@ -57,12 +57,16 @@ struct route_step {
  *    HOP_PAYLOAD_SIZE bytes)
  * @num_hops: path length in nodes
  * @sessionkey: 20 byte random session key to derive secrets from
+ * @assocdata: associated data to commit to in HMACs
+ * @assocdatalen: length of the assocdata
  */
 struct onionpacket *create_onionpacket(
 	const tal_t * ctx,
 	struct pubkey path[],
 	struct hoppayload hoppayloads[],
-	const u8 * sessionkey
+	const u8 * sessionkey,
+	const u8 *assocdata,
+	const size_t assocdatalen
 	);
 
 /**
@@ -73,11 +77,15 @@ struct onionpacket *create_onionpacket(
  * @packet: incoming packet being processed
  * @hop_privkey: the processing node's private key to decrypt the packet
  * @hoppayload: the per-hop payload destined for the processing node.
+ * @assocdata: associated data to commit to in HMACs
+ * @assocdatalen: length of the assocdata
  */
 struct route_step *process_onionpacket(
 	const tal_t * ctx,
 	const struct onionpacket *packet,
-	struct privkey *hop_privkey
+	struct privkey *hop_privkey,
+	const u8 *assocdata,
+	const size_t assocdatalen
 	);
 
 /**

--- a/test/test_sphinx.c
+++ b/test/test_sphinx.c
@@ -16,6 +16,8 @@ int main(int argc, char **argv)
 {
 	bool generate = false, decode = false;
 	const tal_t *ctx = talz(NULL, tal_t);
+	u8 assocdata[32];
+	memset(assocdata, 'B', sizeof(assocdata));
 
 	secp256k1_ctx = secp256k1_context_create(
 		SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
@@ -56,7 +58,9 @@ int main(int argc, char **argv)
 		struct onionpacket *res = create_onionpacket(ctx,
 							     path,
 							     hoppayloads,
-							     sessionkey);
+							     sessionkey,
+							     assocdata,
+							     sizeof(assocdata));
 
 		u8 *serialized = serialize_onionpacket(ctx, res);
 		if (!serialized)
@@ -87,7 +91,8 @@ int main(int argc, char **argv)
 		if (!msg)
 			errx(1, "Error parsing message.");
 
-		step = process_onionpacket(ctx, msg, &seckey);
+		step = process_onionpacket(ctx, msg, &seckey, assocdata,
+					   sizeof(assocdata));
 
 		if (!step->next)
 			errx(1, "Error processing message.");

--- a/test/test_sphinx.c
+++ b/test/test_sphinx.c
@@ -54,11 +54,9 @@ int main(int argc, char **argv)
 			memset(&hoppayloads[i], 'A', sizeof(hoppayloads[i]));
 
 		struct onionpacket *res = create_onionpacket(ctx,
-				   path,
-				   hoppayloads,
-				   sessionkey,
-				   (u8*)"testing",
-				   7);
+							     path,
+							     hoppayloads,
+							     sessionkey);
 
 		u8 *serialized = serialize_onionpacket(ctx, res);
 		if (!serialized)


### PR DESCRIPTION
We want to commit to the HTLC payment-hash in the onion packet HMAC so that it is not possible to replay a previous onion without also transferring the matching funds. Also removes the last remains of the end-to-end payload which is not needed anymore.

This depends on #110, which includes the first two commits.