### PR TITLE
jsonrpc: Added `awaitpayment` method

### DIFF
--- a/daemon/invoice.c
+++ b/daemon/invoice.c
@@ -301,7 +301,7 @@ static const struct json_command delinvoice_command = {
 };
 AUTODATA(json_command, &delinvoice_command);
 
-static void json_waitinvoice(struct command *cmd,
+static void json_waitanyinvoice(struct command *cmd,
 			    const char *buffer, const jsmntok_t *params)
 {
 	struct invoice *i;
@@ -343,13 +343,13 @@ static void json_waitinvoice(struct command *cmd,
 	list_add_tail(&invs->invoice_waiters, &w->list);
 }
 
-static const struct json_command waitinvoice_command = {
-	"waitinvoice",
-	json_waitinvoice,
+static const struct json_command waitanyinvoice_command = {
+	"waitanyinvoice",
+	json_waitanyinvoice,
 	"Wait for the next invoice to be paid, after {label} (if supplied)))",
 	"Returns {label}, {rhash} and {msatoshi} on success. "
 };
-AUTODATA(json_command, &waitinvoice_command);
+AUTODATA(json_command, &waitanyinvoice_command);
 
 
 /* Wait for an incoming payment matching the `label` in the JSON
@@ -357,7 +357,7 @@ AUTODATA(json_command, &waitinvoice_command);
  * already been received or it may add the `cmd` to the list of
  * waiters, if the payment is still pending.
  */
-static void json_awaitpayment(struct command *cmd,
+static void json_waitinvoice(struct command *cmd,
 			      const char *buffer, const jsmntok_t *params)
 {
 	struct invoice *i;
@@ -392,10 +392,10 @@ static void json_awaitpayment(struct command *cmd,
 	list_add_tail(&invs->invoice_waiters, &w->list);
 }
 
-static const struct json_command awaitpayment_command = {
-	"awaitpayment",
-	json_awaitpayment,
+static const struct json_command waitinvoice_command = {
+	"waitinvoice",
+	json_waitinvoice,
 	"Wait for an incoming payment matching the invoice with {label}",
 	"Returns {label}, {rhash} and {msatoshi} on success"
 };
-AUTODATA(json_command, &awaitpayment_command);
+AUTODATA(json_command, &waitinvoice_command);

--- a/daemon/test/test-routing
+++ b/daemon/test/test-routing
@@ -91,7 +91,7 @@ fi
 
 [ "`lcli3 listinvoice RHASH | tr -s '\012\011\" ' ' '`" = "[ { label : RHASH , rhash : $RHASH , msatoshi : $HTLC_AMOUNT, complete : true } ] " ]
 
-[ "`lcli3 waitinvoice | tr -s '\012\011\" ' ' '`" = "{ label : RHASH , rhash : $RHASH , msatoshi : $HTLC_AMOUNT } " ]
+[ "`lcli3 waitanyinvoice | tr -s '\012\011\" ' ' '`" = "{ label : RHASH , rhash : $RHASH , msatoshi : $HTLC_AMOUNT } " ]
 
 # Can't pay twice (try from node2)
 ROUTE2=`lcli2 getroute $ID3 $HTLC_AMOUNT 1`


### PR DESCRIPTION
`awaitinvoice` can be used to wait on a specific invoice to be
completed. If the invoice was previously paid, then the command
returns immediately, otherwise it'll block until the invoice is
paid. This complements `waitinvoice` which uses a highwatermark and
waits for the next invoice. I found waitinvoice a bit hard to use
since it doesn't allow waiting for a specific invoice to be completed,
just the next in the insertion order.