### PR TITLE
Python integration testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,9 @@ protocol-diagrams: $(patsubst %.script, doc/protocol-%.svg, $(notdir $(wildcard 
 
 check: test-protocol
 
+pytest: daemon/lightningd
+	PYTHONPATH=contrib/pylightning python3 tests/test_lightningd.py
+
 # Keep includes in alpha order.
 check-src-include-order/%: %
 	@if [ "$$(grep '^#include' < $<)" != "$$(grep '^#include' < $< | LC_ALL=C sort)" ]; then echo "$<:1: includes out of order"; grep '^#include' < $<; echo VERSUS; grep '^#include' < $< | LC_ALL=C sort; exit 1; fi
@@ -286,9 +289,9 @@ check-source: check-makefile check-source-bolt check-whitespace	\
 	$(CORE_TX_HEADERS:%=check-hdr-include-order/%)		\
 	$(BITCOIN_HEADERS:%=check-hdr-include-order/%)
 
-full-check: check $(TEST_PROGRAMS) check-source
+full-check: check pytest $(TEST_PROGRAMS) check-source
 
-coverage/coverage.info: check $(TEST_PROGRAMS)
+coverage/coverage.info: check $(TEST_PROGRAMS) pytest
 	mkdir coverage || true
 	lcov --capture --directory . --output-file coverage/coverage.info
 

--- a/contrib/pylightning/lightning/__init__.py
+++ b/contrib/pylightning/lightning/__init__.py
@@ -1,0 +1,1 @@
+from .lightning import LightningRpc

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -1,0 +1,178 @@
+from concurrent import futures
+
+import io
+import json
+import logging
+import socket
+import sys
+import threading
+
+class LightningRpc(object):
+    """RPC client for the `lightningd` daemon.
+
+    This RPC client connects to the `lightningd` daemon through a unix
+    domain socket and passes calls through. Since some of the calls
+    are blocking, the corresponding python methods include an `async`
+    keyword argument. If `async` is set to true then the method
+    returns a future immediately, instead of blocking indefinitely.
+
+    This implementation is thread safe in that it locks the socket
+    between calls, but it does not (yet) support concurrent calls.
+    """
+    def __init__(self, socket_path, executor=None):
+        self.socket_path = socket_path
+        self.socket = None
+        self.buff = b''
+        self.decoder = json.JSONDecoder()
+        self.executor = executor
+
+    def connect_rpc(self):
+        pass
+
+    def _writeobj(self, sock, obj):
+        s = json.dumps(obj)
+        sock.sendall(bytearray(s, 'UTF-8'))
+
+    def _readobj(self, sock):
+        buff = b''
+        while True:
+            try:
+                buff += sock.recv(1024)
+                # Convert late to UTF-8 so glyphs split across recvs do not
+                # impact us
+                objs, _ = self.decoder.raw_decode(buff.decode("UTF-8"))
+                return objs
+            except ValueError:
+                # Probably didn't read enough 
+                pass
+
+    def _call(self, method, args):
+        logging.debug("Calling %s with arguments %r", method, args)
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.socket_path)
+        self._writeobj(sock, {
+            "method": method,
+            "params": args,
+            "id": 0
+        })
+        resp = self._readobj(sock)
+        sock.close()
+
+        logging.debug("Received response for %s call: %r", method, resp)
+        if 'error' in resp:
+            raise ValueError("RPC call failed: {}".format(resp['error']))
+        elif 'result' not in resp:
+            raise ValueError("Malformed response, 'result' missing.")
+        return resp['result']
+
+    def getchannels(self):
+        """List all known channels.
+        """
+        return self._call("getchannels", [])['channels']
+
+    def getnodes(self):
+        """List all known nodes in the network.
+        """
+        return self._call("getnodes", [])
+
+    def getlog(self, level=None):
+        """Get logs, with optional level: [io|debug|info|unusual]
+        """
+        return self._call("getlog", [level])
+
+    def getpeers(self):
+        """Return a list of peers.
+        """
+        return self._call("getpeers", [])
+
+    def getroute(self, destination, amount, riskfactor=1):
+        """Return route to `destination` for `amount` milli satoshis, using `riskfactor`
+        """
+        return self._call("getroute", [destination, amount, riskfactor])['route']
+
+    def getinfo(self):
+        """Get general information about this node"""
+        return self._call("getinfo", [])
+
+    def invoice(self, amount, label, paymentKey=None):
+        """Create a new invoice.
+
+        Create invoice for `amount` millisatoshi with
+        `label`. Optionally you can specify the `paymentKey`,
+        otherwise a random one will be generated. The `label` has to
+        be unique.
+        """
+        args = [amount, label]
+        if paymentKey is not None:
+            args.append(paymentKey)
+        return self._call("invoice", args)
+
+    def waitinvoice(self, label=None, async=False):
+        """Wait for the next invoice to be paid, after `label` (if supplied)
+        """
+        args = []
+        if label is not None:
+            args.append(label)
+        def call():
+            return self._call("waitinvoice", args)
+        if async:
+            return self.executor.submit(call)
+        else:
+            return call()
+
+    def sendpay(self, route, paymenthash):
+        """Send along `route` in return for preimage of `paymenthash`
+        """
+        return self._call("sendpay", [route, paymenthash])
+
+    def pay(self, destination, amount, paymenthash):
+        """Shorthand for `getroute` and `sendpay`
+
+        Sends `amount` millisatoshi to `destination` for invoice matching `paymenthash`
+        """
+        route = self.getroute(destination, amount, 1)
+        return self.sendpay(route, paymenthash)
+
+    def dev_rhash(self, secret):
+        res = self._call("dev-rhash", [secret])
+        print(res)
+        return self._call("dev-rhash", [secret])['rhash']
+
+    def dev_newhtlc(self, peerid, amount, expiry, rhash):
+        return self._call("dev-newhtlc", [peerid, amount, expiry, rhash])
+
+    def dev_add_route(self, src, dst, base_fee, fee_rate, delay, minblocks):
+        return self._call("dev-add-route", [src, dst, base_fee, fee_rate, delay, minblocks])
+
+    def connect(self, hostname, port, fundingtxhex, async=False):
+        """Connect to a `host` at `port` using `fundingtxhex` to fund
+        """
+        def call_connect():
+            return self._call("connect", [hostname, port, fundingtxhex])
+
+        if not async:
+            return call_connect()
+        else:
+            return self.executor.submit(call_connect)
+
+    def newaddr(self):
+        """Get a new address to fund a channel
+        """
+        return self._call("newaddr", [])
+
+if __name__ == "__main__":
+    l1 = LightningRpc("/tmp/lightning1/lightning-rpc")
+    l1.connect_rpc()
+    l5 = LightningRpc("/tmp/lightning5/lightning-rpc")
+    l5.connect_rpc()
+
+    import random
+
+    info5 = l5.getinfo()
+    print(info5)
+    invoice = l5.invoice(100, "lbl{}".format(random.random()))
+    print(invoice)
+    route = l1.getroute(info5['id'], 100, 1)
+    print(route)
+    print(l1.sendpay(route, invoice['rhash']))

--- a/contrib/pylightning/setup.py
+++ b/contrib/pylightning/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='pylightning',
+      version='0.0.1',
+      description='Client library for lightningd',
+      url='http://github.com/ElementsProject/lightning',
+      author='Christian Decker',
+      author_email='decker.christian@gmail.com',
+      license='MIT',
+      packages=['lightning'],
+      zip_safe=True)

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -55,6 +55,7 @@ static void log_default_print(const char *prefix,
 	} else {
 		printf("%s \t%s\n", prefix, str);
 	}
+	fflush(stdout);
 }
 
 static size_t log_bufsize(const struct log_entry *e)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+python-bitcoinrpc==1.0

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1,0 +1,198 @@
+from binascii import hexlify, unhexlify
+from concurrent import futures
+from hashlib import sha256
+from utils import BitcoinD, LightningD, LightningRpc, LightningNode
+
+import logging
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+bitcoind = None
+TEST_DIR = tempfile.mkdtemp(prefix='lightning-')
+VALGRIND = os.getenv("NOVALGRIND", None) == None
+
+if os.getenv("TEST_DEBUG", None) != None:
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+logging.info("Tests running in '%s'", TEST_DIR)
+
+
+def setupBitcoind():
+    global bitcoind
+    bitcoind = BitcoinD(rpcport=28332)
+    bitcoind.start()
+    info = bitcoind.rpc.getinfo()
+    # Make sure we have segwit and some funds
+    if info['blocks'] < 432:
+        logging.debug("SegWit not active, generating some more blocks")
+        bitcoind.rpc.generate(432 - info['blocks'])
+    elif info['balance'] < 1:
+        logging.debug("Insufficient balance, generating 1 block")
+        bitcoind.rpc.generate(1)
+
+
+def tearDownBitcoind():
+    global bitcoind
+    try:
+        bitcoind.rpc.stop()
+    except:
+        bitcoind.proc.kill()
+    bitcoind.proc.wait()
+
+
+def setUpModule():
+    setupBitcoind()
+
+
+def tearDownModule():
+    tearDownBitcoind()
+
+
+class NodeFactory(object):
+    """A factory to setup and start `lightningd` daemons.
+    """
+    def __init__(self, func, executor):
+        self.func = func
+        self.next_id = 1
+        self.nodes = []
+        self.executor = executor
+
+    def get_node(self):
+        node_id = self.next_id
+        self.next_id += 1
+
+        lightning_dir = os.path.join(
+            TEST_DIR, self.func._testMethodName, "lightning-{}/".format(node_id))
+
+        socket_path = os.path.join(lightning_dir, "lightning-rpc").format(node_id)
+        daemon = LightningD(lightning_dir, bitcoind.bitcoin_dir, port=16330+node_id)
+        rpc = LightningRpc(socket_path, self.executor)
+        node = LightningNode(daemon, rpc, bitcoind, self.executor)
+        self.nodes.append(node)
+        if VALGRIND:
+            node.daemon.cmd_line = [
+                '/usr/bin/valgrind',
+                '-q',
+                '--error-exitcode=7',
+                '--log-file={}/valgrind-errors'.format(node.daemon.lightning_dir)
+            ] + node.daemon.cmd_line
+
+        node.daemon.start()
+        node.rpc.connect_rpc()
+        # Cache `getinfo`, we'll be using it a lot
+        node.info = node.rpc.getinfo()
+        return node
+
+    def killall(self):
+        for n in self.nodes:
+            n.daemon.stop()
+
+
+class LightningDTests(unittest.TestCase):
+
+    def setUp(self):
+        # Most of the executor threads will be waiting for IO, so
+        # let's have a few of them
+        self.executor = futures.ThreadPoolExecutor(max_workers=20)
+        self.node_factory = NodeFactory(self, self.executor)
+
+    def tearDown(self):
+        self.node_factory.killall()
+        self.executor.shutdown(wait=False)
+        # TODO(cdecker) Check that valgrind didn't find any errors
+
+    def test_connect(self):
+        l1 = self.node_factory.get_node()
+        l2 = self.node_factory.get_node()
+        l1.connect(l2, 0.01, async=False)
+
+    def test_successful_payment(self):
+        l1 = self.node_factory.get_node()
+        l2 = self.node_factory.get_node()
+        bitcoind = l1.bitcoin
+
+        capacity = 0.01 * 10**8 * 10**3
+        htlc_amount = 10000
+        l1.connect(l2, 0.01)
+
+        invoice = l2.rpc.invoice(htlc_amount, "successful_payment")
+
+        # TODO(cdecker) Assert that we have an invoice
+        rhash = invoice['rhash']
+        assert len(rhash) == 64
+
+        route = l1.rpc.getroute(l2.info['id'], htlc_amount, 1)
+        assert len(route) == 1
+        assert route[0] == {'msatoshi': htlc_amount, 'id': l2.info['id'], 'delay': 6}
+
+        receipt = l1.rpc.sendpay(route, invoice['rhash'])
+        assert sha256(unhexlify(receipt['preimage'])).hexdigest() == rhash
+
+        # Now go for the combined RPC call
+        invoice = l2.rpc.invoice(100, "one_shot_payment")
+        l1.rpc.pay(l2.info['id'], 100, invoice['rhash'])
+
+    def test_multihop_payment(self):
+        nodes = [self.node_factory.get_node() for _ in range(5)]
+        conn_futures = [nodes[i].connect(nodes[i+1], 0.01, async=True) for i in range(len(nodes)-1)]
+        
+        htlc_amount = 10000
+
+        # Now wait for all of them
+        [f.result() for f in conn_futures]
+
+        time.sleep(1)
+        
+        # Manually add channel l2 -> l3 to l1 so that it can compute the route
+        for i in range(len(nodes)-1):
+            nodes[0].rpc.dev_add_route(nodes[i].info['id'], nodes[i+1].info['id'], 1, 1, 6, 6)
+        #l1.rpc.dev_add_route(l2.info['id'], l3.info['id'], 1, 1, 6, 6)
+
+        invoice = nodes[-1].rpc.invoice(htlc_amount, "multihop_payment")
+        route = nodes[0].rpc.getroute(nodes[-1].info['id'], htlc_amount, 1)
+        receipt = nodes[0].rpc.sendpay(route, invoice['rhash'])
+
+        nodes[-1].daemon.wait_for_log("STATE_NORMAL_COMMITTING => STATE_NORMAL")
+        nodes[0].daemon.wait_for_log("STATE_NORMAL_COMMITTING => STATE_NORMAL")
+
+    @unittest.skip('Too damn long')
+    def test_routing_gossip(self):
+        nodes = [self.node_factory.get_node() for _ in range(20)]
+        l1 = nodes[0]
+        l5 = nodes[4]
+
+        for i in range(len(nodes)-1):
+            nodes[i].connect(nodes[i+1], 0.01)
+        start_time = time.time()
+
+        while time.time() - start_time < len(nodes) * 30:
+            if sum([c['active'] for c in l1.rpc.getchannels()]) == 2*(len(nodes)-1):
+                break
+            time.sleep(1)
+            l1.bitcoin.rpc.getinfo()
+
+        while time.time() - start_time < len(nodes) * 30:
+            if sum([c['active'] for c in l5.rpc.getchannels()]) == 2*(len(nodes)-1):
+                break
+            time.sleep(1)
+            l1.bitcoin.rpc.getinfo()
+
+        # Quick check that things are reasonable
+        assert sum([len(l.rpc.getchannels()) for l in nodes]) == 5*2*(len(nodes) - 1)
+
+        # Deep check that all channels are in there
+        comb = []
+        for i in range(len(nodes) - 1):
+            comb.append((nodes[i].info['id'], nodes[i+1].info['id']))
+            comb.append((nodes[i+1].info['id'], nodes[i].info['id']))
+
+        for n in nodes:
+            seen = []
+            for c in n.rpc.getchannels():
+                seen.append((c['from'],c['to']))
+            assert set(seen) == set(comb)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,221 @@
+from bitcoinrpc.authproxy import AuthServiceProxy
+from lightning import LightningRpc
+
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+
+
+BITCOIND_CONFIG = {
+    "rpcuser": "rpcuser",
+    "rpcpassword": "rpcpass",
+    "rpcport": 18332,
+}
+
+
+LIGHTNINGD_CONFIG = {
+    "bitcoind-poll": "1s",
+    "log-level": "debug",
+    "deadline-blocks": 5,
+    "min-htlc-expiry": 6,
+    "locktime-blocks": 6,
+}
+
+
+def write_config(filename, opts):
+    with open(filename, 'w') as f:
+        for k, v in opts.items():
+            f.write("{}={}\n".format(k, v))
+
+
+class TailableProc(object):
+    """A monitorable process that we can start, stop and tail.
+
+    This is the base class for the daemons. It allows us to directly
+    tail the processes and react to their output.
+    """
+
+    def __init__(self):
+        self.logs = []
+        self.logs_cond = threading.Condition(threading.RLock())
+        self.thread = threading.Thread(target=self.tail)
+        self.thread.daemon = True
+        self.cmd_line = None
+        self.running = False
+        self.proc = None
+        
+    def start(self):
+        """Start the underlying process and start monitoring it.
+        """
+        logging.debug("Starting '%s'", " ".join(self.cmd_line))
+        self.proc = subprocess.Popen(self.cmd_line, stdout=subprocess.PIPE)
+        self.thread.start()
+        self.running = True
+
+    def stop(self):
+        self.proc.terminate()
+        self.proc.kill()
+
+    def tail(self):
+        """Tail the stdout of the process and remember it.
+
+        Stores the lines of output produced by the process in
+        self.logs and signals that a new line was read so that it can
+        be picked up by consumers.
+        """
+        for line in iter(self.proc.stdout.readline, ''):
+            if len(line) == 0:
+                break
+            with self.logs_cond:
+                self.logs.append(str(line.rstrip()))
+                logging.debug("%s: %s", self.prefix, line.decode().rstrip())
+                self.logs_cond.notifyAll()
+        self.running = False
+    
+    def wait_for_log(self, regex, offset=1000, timeout=60):
+        """Look for `regex` in the logs.
+
+        We tail the stdout of the process and look for `regex`,
+        starting from `offset` lines in the past. We fail if the
+        timeout is exceeded or if the underlying process exits before
+        the `regex` was found. The reason we start `offset` lines in
+        the past is so that we can issue a command and not miss its
+        effects.
+
+        """
+        logging.debug("Waiting for '%s' in the logs", regex)
+        ex = re.compile(regex)
+        start_time = time.time()
+        pos = max(len(self.logs) - offset, 0)
+        while True:
+            
+            if time.time() > start_time + timeout:
+                raise TimeoutError('Unable to find "{}" in logs.'.format(regex))
+            elif not self.running:
+                raise ValueError('Process died while waiting for logs')
+
+            with self.logs_cond:
+                if pos >= len(self.logs):
+                    self.logs_cond.wait(1)
+                    continue
+
+                if ex.search(self.logs[pos]):
+                    logging.debug("Found '%s' in logs", regex)
+                    return self.logs[pos]
+                pos += 1
+
+
+class ThreadSafeAuthServiceProxy(AuthServiceProxy):
+    """Thread-safe variant of the AuthServiceProxy.
+    """
+
+    lock = threading.RLock()
+    
+    def __call__(self, *args):
+        with ThreadSafeAuthServiceProxy.lock:
+            AuthServiceProxy.__call__(self, *args)
+
+
+class BitcoinD(TailableProc):
+
+    def __init__(self, bitcoin_dir="/tmp/bitcoind-test", rpcport=18332):
+        TailableProc.__init__(self)
+        
+        self.bitcoin_dir = bitcoin_dir
+        self.rpcport = rpcport
+        self.prefix = 'bitcoind'
+
+        regtestdir = os.path.join(bitcoin_dir, 'regtest')
+        if not os.path.exists(regtestdir):
+            os.makedirs(regtestdir)
+
+        self.cmd_line = [
+            '/usr/bin/bitcoind',
+            '-datadir={}'.format(bitcoin_dir),
+            '-printtoconsole',
+            '-server',
+            '-regtest',
+            '-debug',
+            '-logtimestamps',
+            '-nolisten',
+        ]
+        BITCOIND_CONFIG['rpcport'] = rpcport
+        write_config(os.path.join(bitcoin_dir, 'bitcoin.conf'), BITCOIND_CONFIG)
+        write_config(os.path.join(regtestdir, 'bitcoin.conf'), BITCOIND_CONFIG)
+        self.rpc = ThreadSafeAuthServiceProxy(
+            "http://rpcuser:rpcpass@127.0.0.1:{}".format(self.rpcport))
+
+    def start(self):
+        TailableProc.start(self)
+        self.wait_for_log("dnsseed thread exit", timeout=10)
+        logging.info("BitcoinD started")
+
+
+class LightningD(TailableProc):
+    def __init__(self, lightning_dir, bitcoin_dir, port=9735):
+        TailableProc.__init__(self)
+        self.lightning_dir = lightning_dir
+        self.port = port
+        self.cmd_line = [
+            'daemon/lightningd',
+            '--bitcoin-datadir={}'.format(bitcoin_dir),
+            '--lightning-dir={}'.format(lightning_dir),
+            '--port={}'.format(port),
+            '--disable-irc',
+            '--bitcoind-regtest',
+        ]
+
+        self.cmd_line += ["--{}={}".format(k, v) for k, v in LIGHTNINGD_CONFIG.items()]
+        self.prefix = 'lightningd'
+
+        if not os.path.exists(lightning_dir):
+            os.makedirs(lightning_dir)
+
+    def start(self):
+        TailableProc.start(self)
+        self.wait_for_log("Hello world!")
+        logging.info("LightningD started")
+
+    def stop(self):
+        TailableProc.stop(self)
+        logging.info("LightningD stopped")
+
+class LightningNode(object):
+    def __init__(self, daemon, rpc, btc, executor):
+        self.rpc = rpc
+        self.daemon = daemon
+        self.bitcoin = btc
+        self.executor = executor
+
+    def connect(self, remote_node, capacity, async=False):
+        # Collect necessary information
+        addr = self.rpc.newaddr()['address']
+        txid = self.bitcoin.rpc.sendtoaddress(addr, capacity)
+        tx = self.bitcoin.rpc.gettransaction(txid)
+
+        def call_connect():
+            self.rpc.connect('127.0.0.1', remote_node.daemon.port, tx['hex'], async=False)
+        t = threading.Thread(target=call_connect)
+        t.daemon = True
+        t.start()
+        
+        def wait_connected():
+            # TODO(cdecker) Monitor the mempool to see if its time to generate yet.
+            time.sleep(5)
+        
+            # The sleep should have given bitcoind time to add the tx to its mempool
+            self.bitcoin.rpc.generate(1)
+
+            #fut.result(timeout=5)
+
+            # Now wait for confirmation
+            self.daemon.wait_for_log("STATE_NORMAL")
+            remote_node.daemon.wait_for_log("STATE_NORMAL")
+
+        if async:
+            return self.executor.submit(wait_connected)
+        else:
+            return wait_connected()


### PR DESCRIPTION
This implements the python RPC framework in contrib, and uses it to build end-to-end integration tests that can spin up `lightningd` instances on the fly and run several scenarios. The scenarios are isolated so hopefully we get more relevant feedback of what is broken. We do collect valgrind information but we don't yet fail a test if valgrind reports an error.

This also includes flushing stdout on logs since we tail the subprocess to check actions instead of polling `getlog` all the time. It relies on `python-bitcoinrpc` for the communication with `bitcoind` so a `pip3 install -r tests/requirements.txt` is needed.