### PR TITLE
Refactoring timers and adding them to gossip

### DIFF
--- a/daemon/chaintopology.c
+++ b/daemon/chaintopology.c
@@ -80,7 +80,7 @@ static void next_topology_timer(struct lightningd_state *dstate)
 		dstate->topology->startup = false;
 		io_break(dstate);
 	}
-	new_reltimer(dstate, dstate, dstate->config.poll_time,
+	new_reltimer(&dstate->timers, dstate, dstate->config.poll_time,
 		     start_poll_chaintip, dstate);
 }
 

--- a/daemon/irc_announce.c
+++ b/daemon/irc_announce.c
@@ -95,7 +95,7 @@ static void announce(struct ircstate *state)
 
 	/* By default we announce every 6 hours, otherwise when someone joins */
 	log_debug(state->log, "Setting long announce time: 6 hours");
-	state->dstate->announce = new_reltimer(state->dstate, state,
+	state->dstate->announce = new_reltimer(&state->dstate->timers, state,
 					       time_from_sec(3600 * 6),
 					       announce, state);
 }
@@ -105,7 +105,8 @@ static void handle_irc_disconnect(struct ircstate *state)
 {
 	/* Stop announcing. */
 	state->dstate->announce = tal_free(state->dstate->announce);
-	new_reltimer(state->dstate, state, state->reconnect_timeout, irc_connect, state);
+	new_reltimer(&state->dstate->timers, state, state->reconnect_timeout,
+		     irc_connect, state);
 }
 
 /* Verify a signed privmsg */
@@ -243,7 +244,7 @@ static void handle_irc_command(struct ircstate *istate, const struct irccommand 
 		delay = pseudorand(60000000);
 		log_debug(istate->log, "Setting new announce time %u sec",
 			  delay / 1000000);
-		dstate->announce = new_reltimer(dstate, istate,
+		dstate->announce = new_reltimer(&dstate->timers, istate,
 						time_from_usec(delay),
 						announce, istate);
 	}

--- a/daemon/p2p_announce.c
+++ b/daemon/p2p_announce.c
@@ -176,7 +176,7 @@ static void announce(struct lightningd_state *dstate)
 	struct peer *p;
 	int nchan = 0;
 
-	new_reltimer(dstate, dstate, time_from_sec(5*60*60), announce, dstate);
+	new_reltimer(&dstate->timers, dstate, time_from_sec(5*60*60), announce, dstate);
 
 	list_for_each(&dstate->peers, p, list) {
 		if (state_is_normal(p->state)) {
@@ -203,7 +203,7 @@ static void process_broadcast_queue(struct lightningd_state *dstate)
 {
 	struct peer *p;
 	struct queued_message *msg;
-	new_reltimer(dstate, dstate, time_from_sec(30), process_broadcast_queue, dstate);
+	new_reltimer(&dstate->timers, dstate, time_from_sec(30), process_broadcast_queue, dstate);
 	list_for_each(&dstate->peers, p, list) {
 		if (!state_is_normal(p->state))
 			continue;
@@ -219,6 +219,6 @@ static void process_broadcast_queue(struct lightningd_state *dstate)
 
 void setup_p2p_announce(struct lightningd_state *dstate)
 {
-	new_reltimer(dstate, dstate, time_from_sec(5*60*60), announce, dstate);
-	new_reltimer(dstate, dstate, time_from_sec(30), process_broadcast_queue, dstate);
+	new_reltimer(&dstate->timers, dstate, time_from_sec(5*60*60), announce, dstate);
+	new_reltimer(&dstate->timers, dstate, time_from_sec(30), process_broadcast_queue, dstate);
 }

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -259,7 +259,7 @@ static void remote_changes_pending(struct peer *peer)
 {
 	if (!peer->commit_timer) {
 		log_debug(peer->log, "remote_changes_pending: adding timer");
-		peer->commit_timer = new_reltimer(peer->dstate, peer,
+		peer->commit_timer = new_reltimer(&peer->dstate->timers, peer,
 						  peer->dstate->config.commit_time,
 						  try_commit, peer);
 	} else
@@ -4415,7 +4415,7 @@ static void reconnect_failed(struct io_conn *conn, struct peer *peer)
 	}
 
 	log_debug(peer->log, "Setting timer to re-connect");
-	new_reltimer(peer->dstate, peer, time_from_sec(15), try_reconnect, peer);
+	new_reltimer(&peer->dstate->timers, peer, time_from_sec(15), try_reconnect, peer);
 }
 
 static struct io_plan *init_conn(struct io_conn *conn, struct peer *peer)

--- a/daemon/timeout.h
+++ b/daemon/timeout.h
@@ -8,15 +8,15 @@
 #include <ccan/typesafe_cb/typesafe_cb.h>
 
 /* tal_free this to disable timer. */
-struct oneshot *new_reltimer_(struct lightningd_state *dstate,
+struct oneshot *new_reltimer_(struct timers *timers,
 			      const tal_t *ctx,
 			      struct timerel expire,
 			      void (*cb)(void *), void *arg);
 
-#define new_reltimer(dstate, ctx, relexpire, func, arg)		\
-	new_reltimer_((dstate), (ctx), (relexpire),			\
+#define new_reltimer(timers, ctx, relexpire, func, arg)		\
+	new_reltimer_((timers), (ctx), (relexpire),			\
 		      typesafe_cb(void, void *, (func), (arg)), (arg))
 
-void timer_expired(struct lightningd_state *dstate, struct timer *timer);
+void timer_expired(tal_t *ctx, struct timer *timer);
 
 #endif /* LIGHTNING_DAEMON_TIMEOUT_H */

--- a/lightningd/gossip/Makefile
+++ b/lightningd/gossip/Makefile
@@ -16,7 +16,7 @@ LIGHTNINGD_GOSSIP_CONTROL_OBJS := $(LIGHTNINGD_GOSSIP_CONTROL_SRC:.c=.o)
 # These should eventually be migrated to the lightningd directory, after
 # deprecating the legacy daemons
 LIGHTNINGD_GOSSIP_LEGACY_HEADERS := daemon/routing.h daemon/broadcast.h \
-	daemon/log.h daemon/pseudorand.h
+	daemon/log.h daemon/pseudorand.h daemon/timeout.h
 
 # lightningd/gossip needs these:
 LIGHTNINGD_GOSSIP_HEADERS := lightningd/gossip/gen_gossip_control_wire.h \


### PR DESCRIPTION
Added timer support to the gossip daemon, after refactoring the timers to use `struct timers` instead of the indirection through the `lightningd_state`.