### PR TITLE
bugfix: Assert was killing daemon

### DIFF
--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -1856,10 +1856,9 @@ static bool peer_start_shutdown(struct peer *peer)
 
 	queue_pkt_close_shutdown(peer);
 
-	if (peer->state == STATE_NORMAL_COMMITTING)
+	if (peer->state == STATE_NORMAL_COMMITTING) {
 		newstate = STATE_SHUTDOWN_COMMITTING;
-	else {
-		assert(peer->state == STATE_NORMAL);
+	} else {
 		newstate = STATE_SHUTDOWN;
 	}
 	set_peer_state(peer, newstate, __func__, true);


### PR DESCRIPTION
This seems rather easy to fix, the only case we do not want to set
`STATE_SHUTDOWN` us when we have updates which we have not committed
yet, which is handled separately in the other IF-branch.

Close #82 