### PR TITLE
doc: Fixed two small mistakes in the `getroute` documentation

### DIFF
--- a/daemon/pay.c
+++ b/daemon/pay.c
@@ -217,7 +217,7 @@ static void json_getroute(struct command *cmd,
 			     "msatoshi", &msatoshitok,
 			     "riskfactor", &riskfactortok,
 			     NULL)) {
-		command_fail(cmd, "Need id and msatoshi");
+		command_fail(cmd, "Need id, msatoshi and riskfactor");
 		return;
 	}
 

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -9,7 +9,7 @@ lightning-getroute - Protocol for routing a payment.
 
 SYNOPSIS
 --------
-*getroute* 'msatoshi' 'id' 'riskfactor'
+*getroute* 'id' 'msatoshi' 'riskfactor'
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
Two arguments were flipped and riskfactor was missing in the error
message returned from the JSON.