### PR TITLE
Added handling of gossip messages either directly or through a separate owning daemon

### DIFF
--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -39,6 +39,7 @@ LIGHTNINGD_LIB_SRC :=				\
 	lightningd/channel.c			\
 	lightningd/channel_config.c		\
 	lightningd/commit_tx.c			\
+	lightningd/connection.c			\
 	lightningd/cryptomsg.c			\
 	lightningd/crypto_sync.c		\
 	lightningd/debug.c			\

--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -51,6 +51,8 @@ struct peer {
 
 	u8 *req_in;
 	const u8 **peer_out;
+
+	int gossip_client_fd;
 };
 
 static void msg_enqueue(const u8 ***q, const u8 *add)
@@ -199,6 +201,11 @@ int main(int argc, char *argv[])
 		status_failed(WIRE_CHANNEL_BAD_COMMAND, "%s",
 			      tal_hex(msg, msg));
 	tal_free(msg);
+	peer->gossip_client_fd = fdpass_recv(REQ_FD);
+	if (peer->gossip_client_fd == -1)
+		status_failed(
+		    WIRE_CHANNEL_BAD_COMMAND,
+		    "Did not receive a valid client socket to gossipd");
 
 	/* We derive everything from the one secret seed. */
 	derive_basepoints(&seed, &funding_pubkey[LOCAL], &points[LOCAL],

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -16,7 +16,8 @@ channel_normal_operation,1001
 #include <lightningd/cryptomsg.h>
 #include <lightningd/channel_config.h>
 
-# Begin!  You're still waiting for the tx to be buried though.
+# Begin!  You're still waiting for the tx to be buried though (passes
+# gossipd-client fd)
 channel_init,1
 channel_init,0,funding_txid,32,struct sha256_double
 channel_init,32,funding_txout,2

--- a/lightningd/connection.c
+++ b/lightningd/connection.c
@@ -2,26 +2,6 @@
 #include <ccan/take/take.h>
 #include <wire/wire_io.h>
 
-static void daemon_conn_enqueue(struct daemon_conn *dc, u8 *msg)
-{
-	size_t n = tal_count(dc->msg_out);
-	tal_resize(&dc->msg_out, n + 1);
-	dc->msg_out[n] = tal_dup_arr(dc->ctx, u8, msg, tal_count(msg), 0);
-}
-
-static const u8 *daemon_conn_dequeue(struct daemon_conn *dc)
-{
-	const u8 *msg;
-	size_t n = tal_count(dc->msg_out);
-
-	if (n == 0)
-		return NULL;
-	msg = dc->msg_out[0];
-	memmove(dc->msg_out, dc->msg_out + 1, sizeof(dc->msg_in[0]) * (n - 1));
-	tal_resize(&dc->msg_out, n - 1);
-	return msg;
-}
-
 struct io_plan *daemon_conn_read_next(struct io_conn *conn,
 				      struct daemon_conn *dc)
 {
@@ -33,7 +13,7 @@ struct io_plan *daemon_conn_read_next(struct io_conn *conn,
 struct io_plan *daemon_conn_write_next(struct io_conn *conn,
 				       struct daemon_conn *dc)
 {
-	const u8 *msg = daemon_conn_dequeue(dc);
+	const u8 *msg = msg_dequeue(&dc->out);
 	if (msg) {
 		return io_write_wire(conn, take(msg), daemon_conn_write_next,
 				     dc);
@@ -60,7 +40,7 @@ void daemon_conn_init(tal_t *ctx, struct daemon_conn *dc, int fd,
 
 	dc->ctx = ctx;
 	dc->msg_in = NULL;
-	dc->msg_out = tal_arr(ctx, u8 *, 0);
+	msg_queue_init(&dc->out, dc->ctx);
 	dc->conn_fd = fd;
 	dc->msg_queue_cleared_cb = NULL;
 	io_new_conn(ctx, fd, daemon_conn_start, dc);
@@ -68,6 +48,6 @@ void daemon_conn_init(tal_t *ctx, struct daemon_conn *dc, int fd,
 
 void daemon_conn_send(struct daemon_conn *dc, u8 *msg)
 {
-	daemon_conn_enqueue(dc, msg);
+	msg_enqueue(&dc->out, msg);
 	io_wake(dc);
 }

--- a/lightningd/connection.c
+++ b/lightningd/connection.c
@@ -1,0 +1,69 @@
+#include "connection.h"
+#include <ccan/take/take.h>
+#include <wire/wire_io.h>
+
+static void daemon_conn_enqueue(struct daemon_conn *dc, u8 *msg)
+{
+	size_t n = tal_count(dc->msg_out);
+	tal_resize(&dc->msg_out, n + 1);
+	dc->msg_out[n] = tal_dup_arr(dc->ctx, u8, msg, tal_count(msg), 0);
+}
+
+static const u8 *daemon_conn_dequeue(struct daemon_conn *dc)
+{
+	const u8 *msg;
+	size_t n = tal_count(dc->msg_out);
+
+	if (n == 0)
+		return NULL;
+	msg = dc->msg_out[0];
+	memmove(dc->msg_out, dc->msg_out + 1, sizeof(dc->msg_in[0]) * (n-1));
+	tal_resize(&dc->msg_out, n-1);
+	return msg;
+}
+
+struct io_plan *daemon_conn_read_next(struct io_conn *conn,
+				      struct daemon_conn *dc)
+{
+	dc->msg_in = tal_free(dc->msg_in);
+	return io_read_wire(conn, dc->ctx, &dc->msg_in, dc->daemon_conn_recv,
+			    dc);
+}
+
+static struct io_plan *daemon_conn_write_next(struct io_conn *conn,
+				       struct daemon_conn *dc)
+{
+	const u8 *msg = daemon_conn_dequeue(dc);
+	if (msg) {
+		return io_write_wire(conn, take(msg), daemon_conn_write_next, dc);
+	} else {
+		return io_out_wait(conn, dc, daemon_conn_write_next, dc);
+	}
+}
+
+static struct io_plan *daemon_conn_start(struct io_conn *conn,
+					 struct daemon_conn *dc)
+{
+	dc->conn = conn;
+	return io_duplex(conn, daemon_conn_read_next(conn, dc),
+			 daemon_conn_write_next(conn, dc));
+}
+
+void daemon_conn_init(tal_t *ctx, struct daemon_conn *dc, int fd,
+		      struct io_plan *(*daemon_conn_recv)(struct io_conn *,
+							  struct daemon_conn *))
+{
+	dc->daemon_conn_recv = daemon_conn_recv;
+
+	dc->ctx = ctx;
+	dc->msg_in = NULL;
+	dc->msg_out = tal_arr(ctx, u8 *, 0);
+	dc->conn_fd = fd;
+	io_new_conn(ctx, fd, daemon_conn_start, dc);
+}
+
+void daemon_conn_send(struct daemon_conn *dc, u8 *msg)
+{
+	daemon_conn_enqueue(dc, msg);
+	io_wake(dc);
+}

--- a/lightningd/connection.c
+++ b/lightningd/connection.c
@@ -17,8 +17,8 @@ static const u8 *daemon_conn_dequeue(struct daemon_conn *dc)
 	if (n == 0)
 		return NULL;
 	msg = dc->msg_out[0];
-	memmove(dc->msg_out, dc->msg_out + 1, sizeof(dc->msg_in[0]) * (n-1));
-	tal_resize(&dc->msg_out, n-1);
+	memmove(dc->msg_out, dc->msg_out + 1, sizeof(dc->msg_in[0]) * (n - 1));
+	tal_resize(&dc->msg_out, n - 1);
 	return msg;
 }
 
@@ -30,12 +30,15 @@ struct io_plan *daemon_conn_read_next(struct io_conn *conn,
 			    dc);
 }
 
-static struct io_plan *daemon_conn_write_next(struct io_conn *conn,
+struct io_plan *daemon_conn_write_next(struct io_conn *conn,
 				       struct daemon_conn *dc)
 {
 	const u8 *msg = daemon_conn_dequeue(dc);
 	if (msg) {
-		return io_write_wire(conn, take(msg), daemon_conn_write_next, dc);
+		return io_write_wire(conn, take(msg), daemon_conn_write_next,
+				     dc);
+	} else if (dc->msg_queue_cleared_cb) {
+		return dc->msg_queue_cleared_cb(conn, dc);
 	} else {
 		return io_out_wait(conn, dc, daemon_conn_write_next, dc);
 	}
@@ -59,6 +62,7 @@ void daemon_conn_init(tal_t *ctx, struct daemon_conn *dc, int fd,
 	dc->msg_in = NULL;
 	dc->msg_out = tal_arr(ctx, u8 *, 0);
 	dc->conn_fd = fd;
+	dc->msg_queue_cleared_cb = NULL;
 	io_new_conn(ctx, fd, daemon_conn_start, dc);
 }
 

--- a/lightningd/connection.h
+++ b/lightningd/connection.h
@@ -1,0 +1,48 @@
+#ifndef LIGHTNING_LIGHTNINGD_CONNECTION_H
+#define LIGHTNING_LIGHTNINGD_CONNECTION_H
+
+#include "config.h"
+#include <ccan/io/io.h>
+#include <ccan/short_types/short_types.h>
+
+struct daemon_conn {
+	/* Context to tallocate all things from, possibly the
+	 * container of this connection. */
+	tal_t *ctx;
+
+	/* Last message we received */
+	u8 *msg_in;
+
+	/* Array of queued outgoing messages */
+	u8 **msg_out;
+
+	int conn_fd;
+	struct io_conn *conn;
+
+	/* Callback for incoming messages */
+	struct io_plan *(*daemon_conn_recv)(struct io_conn *conn, struct daemon_conn *);
+};
+
+/**
+ * daemon_conn_init - Initialize a new daemon connection
+ *
+ * @ctx: context to allocate from
+ * @dc: daemon_conn to initialize
+ * @fd: socket file descriptor to wrap
+ * @daemon_conn_recv: callback function to be called upon receiving a message
+ */
+void daemon_conn_init(tal_t *ctx, struct daemon_conn *dc, int fd,
+		      struct io_plan *(*daemon_conn_recv)(struct io_conn *,
+							  struct daemon_conn *));
+/**
+ * daemon_conn_send - Enqueue an outgoing message to be sent
+ */
+void daemon_conn_send(struct daemon_conn *dc, u8 *msg);
+
+/**
+ * daemon_conn_read_next - Read the next message
+ */
+struct io_plan *daemon_conn_read_next(struct io_conn *conn,
+				      struct daemon_conn *dc);
+
+#endif /* LIGHTNING_LIGHTNINGD_CONNECTION_H */

--- a/lightningd/connection.h
+++ b/lightningd/connection.h
@@ -4,6 +4,7 @@
 #include "config.h"
 #include <ccan/io/io.h>
 #include <ccan/short_types/short_types.h>
+#include <lightningd/msg_queue.h>
 
 struct daemon_conn {
 	/* Context to tallocate all things from, possibly the
@@ -13,8 +14,8 @@ struct daemon_conn {
 	/* Last message we received */
 	u8 *msg_in;
 
-	/* Array of queued outgoing messages */
-	u8 **msg_out;
+	/* Queue of outgoing messages */
+	struct msg_queue out;
 
 	int conn_fd;
 	struct io_conn *conn;

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -297,10 +297,7 @@ static struct io_plan *new_peer_got_fd(struct io_conn *conn, struct peer *peer)
 	if (!peer->conn) {
 		peer->error = "Could not create connection";
 		tal_free(peer);
-	} else
-		/* Free peer if conn closed. */
-		tal_steal(peer->conn, peer);
-
+	}
 	return next_req_in(conn, peer->daemon);
 }
 
@@ -316,11 +313,7 @@ static struct io_plan *new_peer(struct io_conn *conn, struct daemon *daemon,
 
 static struct io_plan *release_peer_fd(struct io_conn *conn, struct peer *peer)
 {
-	int fd = peer->fd;
-	struct daemon *daemon = peer->daemon;
-
-	tal_free(peer);
-	return io_send_fd(conn, fd, next_req_in, daemon);
+	return io_send_fd(conn, peer->fd, next_req_in, peer->daemon);
 }
 
 static struct io_plan *release_peer(struct io_conn *conn, struct daemon *daemon,

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -10,6 +10,7 @@
 #include <ccan/take/take.h>
 #include <ccan/tal/str/str.h>
 #include <daemon/broadcast.h>
+#include <daemon/log.h>
 #include <daemon/routing.h>
 #include <daemon/timeout.h>
 #include <errno.h>
@@ -425,6 +426,8 @@ static struct io_plan *next_req_in(struct io_conn *conn, struct daemon *daemon)
 int main(int argc, char *argv[])
 {
 	struct daemon *daemon;
+	struct log_book *log_book;
+	struct log *base_log;
 
 	subdaemon_debug(argc, argv);
 
@@ -434,7 +437,10 @@ int main(int argc, char *argv[])
 	}
 
 	daemon = tal(NULL, struct daemon);
-	daemon->rstate = new_routing_state(daemon, NULL);
+	log_book = new_log_book(daemon, 2 * 1024 * 1024, LOG_INFORM);
+	base_log =
+	    new_log(daemon, log_book, "lightningd_gossip(%u):", (int)getpid());
+	daemon->rstate = new_routing_state(daemon, base_log);
 	list_head_init(&daemon->peers);
 	timers_init(&daemon->timers, time_mono());
 	daemon->msg_in = NULL;

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -74,6 +74,8 @@ struct peer {
 	bool local;
 };
 
+static void wake_pkt_out(struct peer *peer);
+
 static void destroy_peer(struct peer *peer)
 {
 	list_del_from(&peer->daemon->peers, &peer->list);
@@ -98,7 +100,26 @@ static struct peer *setup_new_peer(struct daemon *daemon, const u8 *msg)
 	peer->proxy_msg_out = tal_arr(peer, u8*, 0);
 	list_add_tail(&daemon->peers, &peer->list);
 	tal_add_destructor(peer, destroy_peer);
+	wake_pkt_out(peer);
 	return peer;
+}
+
+static void handle_gossip_msg(struct routing_state *rstate, u8 *msg)
+{
+	int t = fromwire_peektype(msg);
+	switch(t) {
+	case WIRE_CHANNEL_ANNOUNCEMENT:
+		handle_channel_announcement(rstate, msg, tal_count(msg));
+		break;
+
+	case WIRE_NODE_ANNOUNCEMENT:
+		handle_node_announcement(rstate, msg, tal_count(msg));
+		break;
+
+	case WIRE_CHANNEL_UPDATE:
+		handle_channel_update(rstate, msg, tal_count(msg));
+		break;
+	}
 }
 
 static struct io_plan *peer_msgin(struct io_conn *conn,
@@ -114,15 +135,9 @@ static struct io_plan *peer_msgin(struct io_conn *conn,
 		return io_close(conn);
 
 	case WIRE_CHANNEL_ANNOUNCEMENT:
-		handle_channel_announcement(peer->daemon->rstate, msg, tal_count(msg));
-		return peer_read_message(conn, &peer->pcs, peer_msgin);
-
 	case WIRE_NODE_ANNOUNCEMENT:
-		handle_node_announcement(peer->daemon->rstate, msg, tal_count(msg));
-		return peer_read_message(conn, &peer->pcs, peer_msgin);
-
 	case WIRE_CHANNEL_UPDATE:
-		handle_channel_update(peer->daemon->rstate, msg, tal_count(msg));
+		handle_gossip_msg(peer->daemon->rstate, msg);
 		return peer_read_message(conn, &peer->pcs, peer_msgin);
 
 	case WIRE_INIT:
@@ -180,6 +195,8 @@ static struct io_plan *pkt_out(struct io_conn *conn, struct peer *peer);
 static void wake_pkt_out(struct peer *peer)
 {
 	peer->gossip_sync = true;
+	new_reltimer(&peer->daemon->timers, peer, time_from_sec(30),
+		     wake_pkt_out, peer);
 	io_wake(peer);
 }
 
@@ -193,8 +210,6 @@ static struct io_plan *peer_dump_gossip(struct io_conn *conn, struct peer *peer)
 				      &peer->broadcast_index);
 
 	if (!next) {
-		new_reltimer(&peer->daemon->timers, peer, time_from_sec(30),
-			     wake_pkt_out, peer);
 		/* Going to wake up in pkt_out since we mix time based and
 		 * message based wakeups */
 		return io_out_wait(conn, peer, pkt_out, peer);
@@ -262,8 +277,6 @@ static struct io_plan *client_dump_gossip(struct io_conn *conn, struct peer *pee
 				      &peer->broadcast_index);
 
 	if (!next) {
-		new_reltimer(&peer->daemon->timers, peer, time_from_sec(30),
-			     wake_pkt_out, peer);
 		return io_out_wait(conn, peer, client_pkt_out, peer);
 	} else {
 		return io_write_wire(conn, next->payload, client_dump_gossip, peer);
@@ -283,8 +296,6 @@ static struct io_plan *client_pkt_out(struct io_conn *conn, struct peer *peer)
 
 	if (peer->local) {
 		/* Not our turn, the local loop is taking care of broadcasts */
-		new_reltimer(&peer->daemon->timers, peer, time_from_sec(30),
-			     wake_pkt_out, peer);
 		/* Going to wake up in pkt_out since we mix time based and
 		 * message based wakeups */
 		return io_out_wait(conn, peer, client_pkt_out, peer);

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -436,6 +436,9 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
+	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY |
+						 SECP256K1_CONTEXT_SIGN);
+
 	daemon = tal(NULL, struct daemon);
 	log_book = new_log_book(daemon, 2 * 1024 * 1024, LOG_INFORM);
 	base_log =

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -71,7 +71,7 @@ static void peer_nongossip(struct subd *gossip, const u8 *msg, int fd)
 	peer_accept_open(peer, &cs, inner);
 }
 
-static void peer_ready(struct subd *gossip, const u8 *msg)
+static void peer_ready(struct subd *gossip, const u8 *msg, int fd)
 {
 	u64 unique_id;
 	struct peer *peer;
@@ -97,6 +97,8 @@ static void peer_ready(struct subd *gossip, const u8 *msg)
 		command_success(peer->connect_cmd, response);
 		peer->connect_cmd = NULL;
 	}
+
+	peer->gossip_client_fd = fd;
 
 	peer_set_condition(peer, "Exchanging gossip");
 }
@@ -128,7 +130,10 @@ static enum subd_msg_ret gossip_msg(struct subd *gossip,
 		peer_nongossip(gossip, msg, fd);
 		break;
 	case WIRE_GOSSIPSTATUS_PEER_READY:
-		peer_ready(gossip, msg);
+		if (fd == -1) {
+			return SUBD_NEED_FD;
+		}
+		peer_ready(gossip, msg, fd);
 		break;
 	}
 	return SUBD_COMPLETE;

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -42,6 +42,16 @@ struct peer *find_peer(struct lightningd_state *dstate, const struct pubkey *id)
 	FIXME_IMPLEMENT();
 }
 
+struct peer *find_peer_by_unique_id(struct lightningd *ld, u64 unique_id)
+{
+	struct peer *peer;
+	list_for_each(&ld->peers, peer, list) {
+		if (peer->unique_id == unique_id)
+			return peer;
+	}
+	return NULL;
+}
+
 void peer_debug(struct peer *peer, const char *fmt, ...);
 void peer_debug(struct peer *peer, const char *fmt, ...)
 {

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -55,7 +55,7 @@ struct lightningd {
 
 void derive_peer_seed(struct lightningd *ld, struct privkey *peer_seed,
 		      const struct pubkey *peer_id);
-
+struct peer *find_peer_by_unique_id(struct lightningd *ld, u64 unique_id);
 /* FIXME */
 static inline struct lightningd *
 ld_from_dstate(const struct lightningd_state *dstate)

--- a/lightningd/msg_queue.c
+++ b/lightningd/msg_queue.c
@@ -3,13 +3,14 @@
 void msg_queue_init(struct msg_queue *q, const tal_t *ctx)
 {
 	q->q = tal_arr(ctx, const u8 *, 0);
+	q->ctx = ctx;
 }
 
 void msg_enqueue(struct msg_queue *q, const u8 *add)
 {
 	size_t n = tal_count(q->q);
 	tal_resize(&q->q, n+1);
-	q->q[n] = add;
+	q->q[n] = tal_dup_arr(q->ctx, u8, add, tal_len(add), 0);
 
 	/* In case someone is waiting */
 	io_wake(q);

--- a/lightningd/msg_queue.h
+++ b/lightningd/msg_queue.h
@@ -7,6 +7,7 @@
 
 struct msg_queue {
 	const u8 **q;
+	const tal_t *ctx;
 };
 
 void msg_queue_init(struct msg_queue *q, const tal_t *ctx);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -669,6 +669,7 @@ static void peer_start_channeld(struct peer *peer, bool am_funder,
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(peer->owner, take(msg));
+	subd_send_fd(peer->owner, peer->gossip_client_fd);
 }
 
 static bool opening_release_tx(struct subd *opening, const u8 *resp,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -52,6 +52,9 @@ struct peer {
 
 	/* Secret seed (FIXME: Move to hsm!) */
 	struct privkey *seed;
+
+	/* Gossip client fd, forwarded to the respective owner */
+	int gossip_client_fd;
 };
 
 struct peer *peer_by_unique_id(struct lightningd *ld, u64 unique_id);

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -373,7 +373,7 @@ void subd_send_msg(struct subd *sd, const u8 *msg_out)
 	assert(fromwire_peektype(msg_out) != STATUS_TRACE);
 	if (!taken(msg_out))
 		msg_out = tal_dup_arr(sd, u8, msg_out, tal_len(msg_out), 0);
-	msg_enqueue(&sd->outq, msg_out);
+	msg_enqueue(&sd->outq, take(msg_out));
 }
 
 void subd_send_fd(struct subd *sd, int fd)
@@ -382,7 +382,7 @@ void subd_send_fd(struct subd *sd, int fd)
 	u8 *fdmsg = tal_arr(sd, u8, 0);
 	towire_u16(&fdmsg, STATUS_TRACE);
 	towire_u32(&fdmsg, fd);
-	msg_enqueue(&sd->outq, fdmsg);
+	msg_enqueue(&sd->outq, take(fdmsg));
 }
 
 void subd_req_(struct subd *sd,


### PR DESCRIPTION
This is a complete rewrite of #124. We no longer bounce messages through `lightningd` instead passing over one socket endpoint to the owner, which can then communicate directly with `gossipd`.

The socket endpoint is passed back to `lightningd` immediately after `gossipd` finishes its initialization, and should `gossipd` not be the owner of the peer, it'll simply send the serialized gossip messages through its endpoint to the current owner.

The forwarding is currently implemented only in `channeld` since that is the daemon the peer is spending most time in, and since the other daemons are unlikely to actually do any forwarding.

~~There are two open improvements that I'd like to tackle outside of this PR:~~

 - ~~`gossipd` does not yet use the `daemon_conn` abstraction~~
 - ~~There is some code duplication in `gossipd` regarding the dumping for the broadcast, once for the direct peer communication and once for the communication through an owning daemon. For this I don't yet have a clean solution.~~

~~Given the conflict with the `subd` refactor, I'd like to postpone these until later, so that we can keep the clashes to a minimum.~~