### PR TITLE
Added request number based multiplexing to `subd`

### DIFF
--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -48,6 +48,7 @@ LIGHTNINGD_LIB_SRC :=				\
 	lightningd/key_derive.c			\
 	lightningd/msg_queue.c			\
 	lightningd/peer_failed.c		\
+	lightningd/gen_subd_wire.c		\
 	lightningd/utxo.c
 
 LIGHTNINGD_LIB_OBJS := $(LIGHTNINGD_LIB_SRC:.c=.o)
@@ -65,6 +66,13 @@ LIGHTNINGD_OBJS := $(LIGHTNINGD_SRC:.c=.o)
 
 LIGHTNINGD_JSMN_OBJS := daemon/jsmn.o
 LIGHTNINGD_JSMN_HEADERS := daemon/jsmn/jsmn.h
+
+lightningd/gen_subd_wire.h: $(WIRE_GEN) lightningd/subd_wire.csv
+	$(WIRE_GEN) --header $@ subd_wire_type < lightningd/subd_wire.csv > $@
+
+lightningd/gen_subd_wire.c: $(WIRE_GEN) lightningd/subd_wire.csv
+	$(WIRE_GEN) ${@:.c=.h} subd_wire_type < lightningd/subd_wire.csv > $@
+LIGHTNINGD_HEADERS_GEN += lightningd/gen_subd_wire.h
 
 # We accumulate all lightningd/ headers in these three:
 LIGHTNINGD_HEADERS_NOGEN =			\
@@ -85,7 +93,8 @@ LIGHTNINGD_HEADERS_NOGEN =			\
 # Generated headers
 LIGHTNINGD_HEADERS_GEN =			\
 	$(WIRE_GEN_HEADERS)			\
-	$(GEN_HEADERS)
+	$(GEN_HEADERS)				\
+	lightningd/gen_subd_wire.h
 
 # Headers we don't directly own (ie. don't check them)
 LIGHTNINGD_EXTERNAL_HEADERS =			\

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -374,6 +374,8 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon *daemon)
 	case WIRE_GOSSIPSTATUS_PEER_BAD_MSG:
 	case WIRE_GOSSIPSTATUS_PEER_READY:
 	case WIRE_GOSSIPSTATUS_PEER_NONGOSSIP:
+	case WIRE_GOSSIP_GETNODES_REQ:
+	case WIRE_GOSSIP_GETNODES_REPLY:
 		break;
 	}
 

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -17,7 +17,9 @@
 #include <inttypes.h>
 #include <lightningd/cryptomsg.h>
 #include <lightningd/debug.h>
+#include <lightningd/gen_subd_wire.h>
 #include <lightningd/gossip/gen_gossip_wire.h>
+#include <lightningd/subd.h>
 #include <secp256k1_ecdh.h>
 #include <sodium/randombytes.h>
 #include <status.h>
@@ -324,7 +326,7 @@ static struct io_plan *release_peer_fd(struct io_conn *conn, struct peer *peer)
 }
 
 static struct io_plan *release_peer(struct io_conn *conn, struct daemon *daemon,
-				    const u8 *msg)
+				    const u8 *msg, u32 request_id)
 {
 	u64 unique_id;
 	struct peer *peer;
@@ -342,9 +344,10 @@ static struct io_plan *release_peer(struct io_conn *conn, struct daemon *daemon,
 			tal_steal(daemon, peer);
 			io_close_taken_fd(peer->conn);
 
-			out = towire_gossipctl_release_peer_reply(msg,
-								  unique_id,
-								  &peer->pcs.cs);
+			out = towire_subd_reply(
+			    msg, request_id, SUBD_FINAL_REPLY,
+			    towire_gossipctl_release_peer_reply(msg, unique_id,
+								&peer->pcs.cs));
 			return io_write_wire(conn, out, release_peer_fd, peer);
 		}
 	}
@@ -354,16 +357,29 @@ static struct io_plan *release_peer(struct io_conn *conn, struct daemon *daemon,
 
 static struct io_plan *recv_req(struct io_conn *conn, struct daemon *daemon)
 {
-	enum gossip_wire_type t = fromwire_peektype(daemon->msg_in);
+	enum gossip_wire_type t;
+	u8 *msg = daemon->msg_in;
+	u32 request_id;
+	u8 *req;
+	/* Outer type is either a subd type or a gossip type */
+	int outer_type = fromwire_peektype(msg);
 
+	if (outer_type == WIRE_SUBD_REQUEST) {
+		/* Unwrap the message from its request frame */
+		fromwire_subd_request(msg, msg, NULL, &request_id, &req);
+		t = fromwire_peektype(req);
+		status_trace("Received request %d (%s) from main daemon.", request_id, gossip_wire_type_name(t));
+	} else {
+		t = fromwire_peektype(daemon->msg_in);
+	}
 	status_trace("req: type %s len %zu",
 		     gossip_wire_type_name(t), tal_count(daemon->msg_in));
 
 	switch (t) {
 	case WIRE_GOSSIPCTL_NEW_PEER:
-		return new_peer(conn, daemon, daemon->msg_in);
+		return new_peer(conn, daemon, msg);
 	case WIRE_GOSSIPCTL_RELEASE_PEER:
-		return release_peer(conn, daemon, daemon->msg_in);
+		return release_peer(conn, daemon, req, request_id);
 
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIPSTATUS_INIT_FAILED:

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -46,3 +46,10 @@ gossipstatus_peer_nongossip,0,unique_id,8
 gossipstatus_peer_nongossip,10,crypto_state,144,struct crypto_state
 gossipstatus_peer_nongossip,154,len,2
 gossipstatus_peer_nongossip,156,msg,len,u8
+
+# JSON-RPC `getnodes` request
+gossip_getnodes_req,5
+gossip_getnodes_reply,105
+gossip_getnodes_reply,0,msglen,2,u16
+gossip_getnodes_reply,2,msg,msglen,u8
+

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -116,8 +116,10 @@ static enum subd_msg_ret gossip_msg(struct subd *gossip,
 	/* These are messages we send, not them. */
 	case WIRE_GOSSIPCTL_NEW_PEER:
 	case WIRE_GOSSIPCTL_RELEASE_PEER:
+	case WIRE_GOSSIP_GETNODES_REQ:
 	/* This is a reply, so never gets through to here. */
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
+	case WIRE_GOSSIP_GETNODES_REPLY:
 		break;
 	case WIRE_GOSSIPSTATUS_PEER_BAD_MSG:
 		peer_bad_message(gossip, msg);

--- a/lightningd/handshake/handshake.c
+++ b/lightningd/handshake/handshake.c
@@ -11,8 +11,10 @@
 #include <ccan/short_types/short_types.h>
 #include <errno.h>
 #include <lightningd/debug.h>
+#include <lightningd/gen_subd_wire.h>
 #include <lightningd/handshake/gen_handshake_wire.h>
 #include <lightningd/hsm/client.h>
+#include <lightningd/subd.h>
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
 #include <sodium/crypto_aead_chacha20poly1305.h>
@@ -970,6 +972,8 @@ int main(int argc, char *argv[])
 	int hsmfd = 3, clientfd = 4;
 	struct secret ck, rk, sk;
 	struct crypto_state cs;
+	u8 *req;
+	u32 request_id;
 
 	if (argc == 2 && streq(argv[1], "--version")) {
 		printf("%s\n", version());
@@ -987,28 +991,31 @@ int main(int argc, char *argv[])
 	if (!msg)
 		status_failed(WIRE_HANDSHAKE_BAD_COMMAND, "%s", strerror(errno));
 
-	if (fromwire_handshake_responder(msg, NULL, &my_id)) {
+	/* Unwrap the subd request */
+	fromwire_subd_request(msg, msg, NULL, &request_id, &req);
+	if (fromwire_handshake_responder(req, NULL, &my_id)) {
 		responder(clientfd, &my_id, &their_id, &ck, &sk, &rk);
 		cs.rn = cs.sn = 0;
 		cs.sk = sk.s;
 		cs.rk = rk.s;
 		cs.r_ck = cs.s_ck = ck.s;
-		wire_sync_write(REQ_FD,
-				towire_handshake_responder_reply(msg,
-								 &their_id,
-								 &cs));
-	} else if (fromwire_handshake_initiator(msg, NULL, &my_id,
-						&their_id)) {
+		wire_sync_write(
+		    REQ_FD, towire_subd_reply(req, request_id, SUBD_FINAL_REPLY,
+					      towire_handshake_responder_reply(
+						  req, &their_id, &cs)));
+	} else if (fromwire_handshake_initiator(req, NULL, &my_id, &their_id)) {
 		initiator(clientfd, &my_id, &their_id, &ck, &sk, &rk);
 		cs.rn = cs.sn = 0;
 		cs.sk = sk.s;
 		cs.rk = rk.s;
 		cs.r_ck = cs.s_ck = ck.s;
-		wire_sync_write(REQ_FD,
-				towire_handshake_initiator_reply(msg, &cs));
+		wire_sync_write(
+		    REQ_FD, towire_subd_reply(
+				req, request_id, SUBD_FINAL_REPLY,
+				towire_handshake_initiator_reply(req, &cs)));
 	} else
 		status_failed(WIRE_HANDSHAKE_BAD_COMMAND, "%i",
-			      fromwire_peektype(msg));
+			      fromwire_peektype(req));
 
 	/* Hand back the fd. */
 	fdpass_send(REQ_FD, clientfd);

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -11,11 +11,15 @@ struct io_conn;
 
 enum subd_msg_ret {
 	SUBD_NEED_FD,
-	SUBD_COMPLETE
+	SUBD_COMPLETE,
+	SUBD_CONTINUED
 };
 
 /* By convention, replies are requests + 100 */
 #define SUBD_REPLY_OFFSET 100
+
+/* Is this the last reply in the stream of replies? */
+#define SUBD_FINAL_REPLY 1
 
 /* One of our subds. */
 struct subd {

--- a/lightningd/subd_wire.csv
+++ b/lightningd/subd_wire.csv
@@ -1,0 +1,10 @@
+subd_request,0x4000
+subd_request,0,request_id,4,u32
+subd_request,4,reqlen,2,u16
+subd_request,6,req,reqlen,u8
+
+subd_reply,0x4001
+subd_reply,0,request_id,4,u32
+subd_reply,4,flags,1,u8
+subd_reply,5,replen,2,u16
+subd_reply,7,rep,replen,u8


### PR DESCRIPTION
So far we were always using the issue order and type to match replies
to requests. This has two problems: two concurrent requests with the
same type may get mixed up, and there is no way of streaming a
multipart response to the requestor, since the request object was
being freed after receiving the first reply.

This is an attempt at fixing both, by introducing explicit request
numbering and flags to signal the end of a reply.