### PR TITLE
Announce newly created channel upon `funding_locked`

### DIFF
--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -40,3 +40,4 @@ channel_init,562,remote_node_id,33,struct pubkey
 
 # Tx is deep enough, go!
 channel_funding_locked,2
+channel_funding_locked,0,short_channel_id,8,struct short_channel_id

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -35,6 +35,8 @@ channel_init,476,feerate,4
 channel_init,480,funding_satoshi,8
 channel_init,488,push_msat,8
 channel_init,496,seed,32,struct privkey
+channel_init,529,local_node_id,33,struct pubkey
+channel_init,562,remote_node_id,33,struct pubkey
 
 # Tx is deep enough, go!
 channel_funding_locked,2

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -665,7 +665,9 @@ static void peer_start_channeld(struct peer *peer, bool am_funder,
 				  15000,
 				  peer->funding_satoshi,
 				  peer->push_msat,
-				  peer->seed);
+				  peer->seed,
+				  &peer->ld->dstate.id,
+				  peer->id);
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(peer->owner, take(msg));


### PR DESCRIPTION
If we complete the setup of a new channel announce it to `gossipd` and the peer we are connected to. Also create the first `channel_update` so that the channel becomes usable.

It still uses zeroed signatures and some dummy default data in the channel update, I'll fix those as soon as we have the `getroute` call out of the way.