### PR TITLE
Implement `getnodes` in the multi-daemon architecture

### DIFF
--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -45,6 +45,7 @@ LIGHTNINGD_LIB_SRC :=				\
 	lightningd/debug.c			\
 	lightningd/derive_basepoints.c		\
 	lightningd/funding_tx.c			\
+	lightningd/gossip_msg.c			\
 	lightningd/htlc_tx.c			\
 	lightningd/key_derive.c			\
 	lightningd/msg_queue.c			\

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -46,3 +46,10 @@ gossipstatus_peer_nongossip,0,unique_id,8
 gossipstatus_peer_nongossip,10,crypto_state,144,struct crypto_state
 gossipstatus_peer_nongossip,154,len,2
 gossipstatus_peer_nongossip,156,msg,len,u8
+
+# Pass JSON-RPC getnodes call through
+gossip_getnodes_request,5
+
+gossip_getnodes_reply,105
+gossip_getnodes_reply,0,replen,2,u16
+gossip_getnodes_reply,2,reply,replen,u8

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -1,0 +1,27 @@
+#include <lightningd/gossip_msg.h>
+#include <wire/wire.h>
+
+void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry)
+{
+	u8 hostnamelen;
+	fromwire_pubkey(pptr, max, &entry->nodeid);
+	hostnamelen = fromwire_u8(pptr, max);
+	entry->hostname = tal_arr(entry, char, hostnamelen);
+	fromwire_u8_array(pptr, max, (u8*)entry->hostname, hostnamelen);
+	entry->port = fromwire_u16(pptr, max);
+}
+void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry)
+{
+	u8 hostnamelen;
+	towire_pubkey(pptr, &entry->nodeid);
+	if (entry->hostname) {
+		hostnamelen = strlen(entry->hostname);
+		towire_u8(pptr, hostnamelen);
+		towire_u8_array(pptr, (u8*)entry->hostname, hostnamelen);
+	}else {
+		/* If we don't have a hostname just write an empty string */
+		hostnamelen = 0;
+		towire_u8(pptr, hostnamelen);
+	}
+	towire_u16(pptr, entry->port);
+}

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -1,0 +1,15 @@
+#ifndef LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H
+#define LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H
+#include "config.h"
+#include <bitcoin/pubkey.h>
+
+struct gossip_getnodes_entry {
+	struct pubkey nodeid;
+	char *hostname;
+	u16 port;
+};
+
+void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
+void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry);
+
+#endif /* LIGHTNING_LIGHTGNINGD_GOSSIP_MSG_H */


### PR DESCRIPTION
This is the first of the `gossipd` JSON-RPC calls. The PR adds a new `gossip_getnodes_entry` struct which can be serialized and deserialized from a byte stream. The reply itself is just a variable length byte stream containing the serialized structs. 