### PR TITLE
Implemented `getroute` JSON-RPC call in new daemon

### DIFF
--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -750,7 +750,7 @@ void handle_channel_update(struct routing_state *rstate, const u8 *update, size_
 	c->htlc_minimum_msat = htlc_minimum_msat;
 	c->base_fee = fee_base_msat;
 	c->proportional_fee = fee_proportional_millionths;
-	c->active = true;
+	c->active = (flags & ROUTING_FLAGS_DISABLED) == 0;
 	log_debug(rstate->base_log, "Channel %d:%d:%d(%d) was updated.",
 		  short_channel_id.blocknum,
 		  short_channel_id.txnum,

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -88,6 +88,12 @@ struct routing_state {
 	struct broadcast_state *broadcasts;
 };
 
+struct route_hop {
+	struct pubkey nodeid;
+	u32 amount;
+	u32 delay;
+};
+
 //FIXME(cdecker) The log will have to be replaced for the new subdaemon, keeping for now to keep changes small.
 struct routing_state *new_routing_state(const tal_t *ctx, struct log *base_log);
 
@@ -139,14 +145,10 @@ struct node_connection *get_connection_by_scid(const struct routing_state *rstat
 void remove_connection(struct routing_state *rstate,
 		       const struct pubkey *src, const struct pubkey *dst);
 
-struct pubkey *find_route(const tal_t *ctx,
-			struct routing_state *rstate,
-			const struct pubkey *from,
-			const struct pubkey *to,
-			u64 msatoshi,
-			double riskfactor,
-			s64 *fee,
-			struct node_connection ***route);
+struct node_connection *
+find_route(const tal_t *ctx, struct routing_state *rstate,
+	   const struct pubkey *from, const struct pubkey *to, u64 msatoshi,
+	   double riskfactor, s64 *fee, struct node_connection ***route);
 
 struct node_map *empty_node_map(const tal_t *ctx);
 
@@ -166,5 +168,11 @@ u8 *write_ip(const tal_t *ctx, const char *srcip, int port);
 void handle_channel_announcement(struct routing_state *rstate, const u8 *announce, size_t len);
 void handle_channel_update(struct routing_state *rstate, const u8 *update, size_t len);
 void handle_node_announcement(struct routing_state *rstate, const u8 *node, size_t len);
+
+/* Compute a route to a destination, for a given amount and riskfactor. */
+struct route_hop *get_route(tal_t *ctx, struct routing_state *rstate,
+			    const struct pubkey *source,
+			    const struct pubkey *destination,
+			    const u32 msatoshi, double riskfactor);
 
 #endif /* LIGHTNING_DAEMON_ROUTING_H */

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -7,6 +7,7 @@
 #include <ccan/htable/htable_type.h>
 
 #define ROUTING_MAX_HOPS 20
+#define ROUTING_FLAGS_DISABLED 2
 
 struct node_connection {
 	struct node *src, *dst;

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -529,7 +529,9 @@ int main(int argc, char *argv[])
 						 SECP256K1_CONTEXT_SIGN);
 
 	daemon = tal(NULL, struct daemon);
-	log_book = new_log_book(daemon, 2 * 1024 * 1024, LOG_INFORM);
+	/* Do not log absolutely anything, stdout is now a socket
+	 * connected to some other daemon. */
+	log_book = new_log_book(daemon, 2 * 1024 * 1024, LOG_BROKEN + 1);
 	base_log =
 	    new_log(daemon, log_book, "lightningd_gossip(%u):", (int)getpid());
 	daemon->rstate = new_routing_state(daemon, base_log);

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -451,6 +451,12 @@ static struct io_plan *release_peer(struct io_conn *conn, struct daemon *daemon,
 		      "Unknown peer %"PRIu64, unique_id);
 }
 
+static struct io_plan *getroute(struct io_conn *conn, struct daemon *daemon, u8 *msg)
+{
+	return next_req_in(conn, daemon);
+}
+
+
 static struct io_plan *getnodes(struct io_conn *conn, struct daemon *daemon)
 {
 	tal_t *tmpctx = tal_tmpctx(daemon);
@@ -493,8 +499,12 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master
 	case WIRE_GOSSIP_GETNODES_REQUEST:
 		return getnodes(conn, daemon);
 
+	case WIRE_GOSSIP_GETROUTE_REQUEST:
+		return getroute(conn, daemon, daemon->msg_in);
+
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIP_GETNODES_REPLY:
+	case WIRE_GOSSIP_GETROUTE_REPLY:
 	case WIRE_GOSSIPSTATUS_INIT_FAILED:
 	case WIRE_GOSSIPSTATUS_BAD_NEW_PEER_REQUEST:
 	case WIRE_GOSSIPSTATUS_BAD_RELEASE_REQUEST:

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -60,3 +60,14 @@ gossip_getnodes_request,5
 gossip_getnodes_reply,105
 gossip_getnodes_reply,0,num_nodes,u16
 gossip_getnodes_reply,2,nodes,num_nodes*struct gossip_getnodes_entry
+
+# Pass JSON-RPC getroute call through
+gossip_getroute_request,6
+gossip_getroute_request,0,source,struct pubkey
+gossip_getroute_request,33,destination,struct pubkey
+gossip_getroute_request,66,msatoshi,u32
+gossip_getroute_request,70,riskfactor,u16
+
+gossip_getroute_reply,106
+gossip_getroute_reply,0,num_hops,u16
+gossip_getroute_reply,2,hops,num_hops*struct route_hop

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -142,9 +142,11 @@ static size_t gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIPCTL_NEW_PEER:
 	case WIRE_GOSSIPCTL_RELEASE_PEER:
 	case WIRE_GOSSIP_GETNODES_REQUEST:
+	case WIRE_GOSSIP_GETROUTE_REQUEST:
 	/* This is a reply, so never gets through to here. */
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIP_GETNODES_REPLY:
+	case WIRE_GOSSIP_GETROUTE_REPLY:
 		break;
 	case WIRE_GOSSIPSTATUS_PEER_BAD_MSG:
 		peer_bad_message(gossip, msg);
@@ -218,3 +220,14 @@ static const struct json_command getnodes_command = {
     "getnodes", json_getnodes, "Retrieve all nodes in our local network view",
     "Returns a list of all nodes that we know about"};
 AUTODATA(json_command, &getnodes_command);
+
+static void json_getroute(struct command *cmd, const char *buffer, const jsmntok_t *params)
+{
+}
+
+static const struct json_command getroute_command = {
+	"getroute", json_getroute,
+	"Return route to {id} for {msatoshi}, using {riskfactor}",
+	"Returns a {route} array of {id} {msatoshi} {delay}: msatoshi and delay (in blocks) is cumulative."
+};
+AUTODATA(json_command, &getroute_command);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -25,3 +25,17 @@ void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry 
 	}
 	towire_u16(pptr, entry->port);
 }
+
+void fromwire_route_hop(const u8 **pptr, size_t *max, struct route_hop *entry)
+{
+	fromwire_pubkey(pptr, max, &entry->nodeid);
+	entry->amount = fromwire_u32(pptr, max);
+	entry->delay = fromwire_u32(pptr, max);
+}
+void towire_route_hop(u8 **pptr, const struct route_hop *entry)
+{
+	towire_pubkey(pptr, &entry->nodeid);
+	towire_u32(pptr, entry->amount);
+	towire_u32(pptr, entry->delay);
+}
+

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H
 #include "config.h"
 #include <bitcoin/pubkey.h>
+#include <daemon/routing.h>
 
 struct gossip_getnodes_entry {
 	struct pubkey nodeid;
@@ -11,5 +12,8 @@ struct gossip_getnodes_entry {
 
 void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
 void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry);
+
+void fromwire_route_hop(const u8 **pprt, size_t *max, struct route_hop *entry);
+void towire_route_hop(u8 **pprt, const struct route_hop *entry);
 
 #endif /* LIGHTNING_LIGHTGNINGD_GOSSIP_MSG_H */


### PR DESCRIPTION
This PR implements the `getroute` JSON-RPC call in the multi-daemon architecture. It refactors part of the routing algorithm to split the route generation from the JSON-handling in `pay.c` and it uses the `route_hop` struct to communicate the route across the wire.

This is a work-in-progress PR, and it depends on #130 (which covers the first few commits). There is a bug that causes the connection to the peer being killed, possibly when `getroute` is called before the announcements settle:
```
lightningd_channel(27778): FAILURE WIRE_CHANNEL_PEER_READ_FAILED: peer connection broken: Connection reset by peer
```
I think we have some wires crossed, possibly freeing the peer somewhere, but I didn't find it yet.