### PR TITLE
PR #130 refinements

### DIFF
--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -45,6 +45,7 @@ LIGHTNINGD_LIB_SRC :=				\
 	lightningd/debug.c			\
 	lightningd/derive_basepoints.c		\
 	lightningd/funding_tx.c			\
+	lightningd/gossip_msg.c			\
 	lightningd/htlc_tx.c			\
 	lightningd/key_derive.c			\
 	lightningd/msg_queue.c			\

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -19,25 +19,25 @@ channel_normal_operation,1001
 # Begin!  You're still waiting for the tx to be buried though (passes
 # gossipd-client fd)
 channel_init,1
-channel_init,0,funding_txid,32,struct sha256_double
+channel_init,0,funding_txid,struct sha256_double
 channel_init,32,funding_txout,2
-channel_init,34,our_config,36,struct channel_config
-channel_init,70,their_config,36,struct channel_config
-channel_init,106,first_commit_sig,64,secp256k1_ecdsa_signature
-channel_init,166,crypto_state,144,struct crypto_state
+channel_init,34,our_config,struct channel_config
+channel_init,70,their_config,struct channel_config
+channel_init,106,first_commit_sig,secp256k1_ecdsa_signature
+channel_init,166,crypto_state,struct crypto_state
 channel_init,310,remote_fundingkey,33
 channel_init,343,revocation_basepoint,33
 channel_init,376,payment_basepoint,33
 channel_init,409,delayed_payment_basepoint,33
 channel_init,442,their_per_commit_point,33
-channel_init,475,am_funder,1,bool
+channel_init,475,am_funder,bool
 channel_init,476,feerate,4
 channel_init,480,funding_satoshi,8
 channel_init,488,push_msat,8
-channel_init,496,seed,32,struct privkey
-channel_init,529,local_node_id,33,struct pubkey
-channel_init,562,remote_node_id,33,struct pubkey
+channel_init,496,seed,struct privkey
+channel_init,529,local_node_id,struct pubkey
+channel_init,562,remote_node_id,struct pubkey
 
 # Tx is deep enough, go!
 channel_funding_locked,2
-channel_funding_locked,0,short_channel_id,8,struct short_channel_id
+channel_funding_locked,0,short_channel_id,struct short_channel_id

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -9,7 +9,7 @@ gossipstatus_fdpass_failed,0x8004
 gossipstatus_peer_bad_msg,1000
 gossipstatus_peer_bad_msg,0,unique_id,8
 gossipstatus_peer_bad_msg,8,len,2
-gossipstatus_peer_bad_msg,10,err,len,u8
+gossipstatus_peer_bad_msg,10,err,len*u8
 
 #include <lightningd/cryptomsg.h>
 
@@ -17,7 +17,7 @@ gossipstatus_peer_bad_msg,10,err,len,u8
 # (if it is to move onto a channel, we get a status msg).
 gossipctl_new_peer,1
 gossipctl_new_peer,0,unique_id,8
-gossipctl_new_peer,8,crypto_state,144,struct crypto_state
+gossipctl_new_peer,8,crypto_state,struct crypto_state
 
 # Tell it to release a peer which has initialized.
 gossipctl_release_peer,2
@@ -26,7 +26,7 @@ gossipctl_release_peer,0,unique_id,8
 # This releases the peer and returns the cryptostate (followed by fd)
 gossipctl_release_peer_reply,102
 gossipctl_release_peer_reply,0,unique_id,8
-gossipctl_release_peer_reply,8,crypto_state,144,struct crypto_state
+gossipctl_release_peer_reply,8,crypto_state,struct crypto_state
 
 # This is where we save a peer's features.
 #gossipstatus_peer_features,1
@@ -43,13 +43,13 @@ gossipstatus_peer_ready,0,unique_id,8
 # Peer can send non-gossip packet (usually an open_channel) (followed by fd)
 gossipstatus_peer_nongossip,4
 gossipstatus_peer_nongossip,0,unique_id,8
-gossipstatus_peer_nongossip,10,crypto_state,144,struct crypto_state
+gossipstatus_peer_nongossip,10,crypto_state,struct crypto_state
 gossipstatus_peer_nongossip,154,len,2
-gossipstatus_peer_nongossip,156,msg,len,u8
+gossipstatus_peer_nongossip,156,msg,len*u8
 
 # Pass JSON-RPC getnodes call through
 gossip_getnodes_request,5
 
 gossip_getnodes_reply,105
-gossip_getnodes_reply,0,replen,2,u16
-gossip_getnodes_reply,2,reply,replen,u8
+gossip_getnodes_reply,0,replen,u16
+gossip_getnodes_reply,2,reply,replen*u8

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -50,6 +50,7 @@ gossipstatus_peer_nongossip,156,msg,len*u8
 # Pass JSON-RPC getnodes call through
 gossip_getnodes_request,5
 
+#include <lightningd/gossip_msg.h>
 gossip_getnodes_reply,105
-gossip_getnodes_reply,0,replen,u16
-gossip_getnodes_reply,2,reply,replen*u8
+gossip_getnodes_reply,0,num_nodes,u16
+gossip_getnodes_reply,2,nodes,num_nodes*struct gossip_getnodes_entry

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -46,3 +46,10 @@ gossipstatus_peer_nongossip,0,unique_id,8
 gossipstatus_peer_nongossip,10,crypto_state,144,struct crypto_state
 gossipstatus_peer_nongossip,154,len,2
 gossipstatus_peer_nongossip,156,msg,len,u8
+
+# Pass JSON-RPC getnodes call through
+gossip_getnodes_request,5
+
+gossip_getnodes_reply,105
+gossip_getnodes_reply,0,replen,2,u16
+gossip_getnodes_reply,2,reply,replen,u8

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -1,0 +1,27 @@
+#include <lightningd/gossip_msg.h>
+#include <wire/wire.h>
+
+void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry)
+{
+	u8 hostnamelen;
+	fromwire_pubkey(pptr, max, &entry->nodeid);
+	hostnamelen = fromwire_u8(pptr, max);
+	entry->hostname = tal_arr(entry, char, hostnamelen);
+	fromwire_u8_array(pptr, max, (u8*)entry->hostname, hostnamelen);
+	entry->port = fromwire_u16(pptr, max);
+}
+void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry)
+{
+	u8 hostnamelen;
+	towire_pubkey(pptr, &entry->nodeid);
+	if (entry->hostname) {
+		hostnamelen = strlen(entry->hostname);
+		towire_u8(pptr, hostnamelen);
+		towire_u8_array(pptr, (u8*)entry->hostname, hostnamelen);
+	}else {
+		/* If we don't have a hostname just write an empty string */
+		hostnamelen = 0;
+		towire_u8(pptr, hostnamelen);
+	}
+	towire_u16(pptr, entry->port);
+}

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -1,0 +1,15 @@
+#ifndef LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H
+#define LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H
+#include "config.h"
+#include <bitcoin/pubkey.h>
+
+struct gossip_getnodes_entry {
+	struct pubkey nodeid;
+	char *hostname;
+	u16 port;
+};
+
+void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
+void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry);
+
+#endif /* LIGHTNING_LIGHTGNINGD_GOSSIP_MSG_H */

--- a/lightningd/handshake/handshake_wire.csv
+++ b/lightningd/handshake/handshake_wire.csv
@@ -36,12 +36,12 @@ handshake_responder,1
 handshake_responder,1,my_id,33
 handshake_responder_reply,101
 handshake_responder_reply,0,initiator_id,33
-handshake_responder_reply,33,cs,144,struct crypto_state
+handshake_responder_reply,33,cs,struct crypto_state
 
 handshake_initiator,2
 handshake_initiator,0,my_id,33
 handshake_initiator,33,responder_id,33
 
 handshake_initiator_reply,102
-handshake_initiator_reply,0,cs,144,struct crypto_state
+handshake_initiator_reply,0,cs,struct crypto_state
 

--- a/lightningd/hsm/hsm_wire.csv
+++ b/lightningd/hsm/hsm_wire.csv
@@ -9,17 +9,17 @@ hsmstatus_key_failed,0x8004
 hsmstatus_client_bad_request,1000
 hsmstatus_client_bad_request,0,unique-id,8
 hsmstatus_client_bad_request,8,len,2
-hsmstatus_client_bad_request,10,msg,len,u8
+hsmstatus_client_bad_request,10,msg,len*u8
 
 # Start the HSM.
 hsmctl_init,1
-hsmctl_init,0,new,1,bool
+hsmctl_init,0,new,bool
 
 hsmctl_init_reply,101
 hsmctl_init_reply,0,node_id,33
-hsmctl_init_reply,33,peer_seed,32,struct privkey
+hsmctl_init_reply,33,peer_seed,struct privkey
 hsmctl_init_reply,65,bip32_len,2
-hsmctl_init_reply,67,bip32_seed,bip32_len*1,u8
+hsmctl_init_reply,67,bip32_seed,bip32_len*u8
 
 # ECDH returns an fd.
 hsmctl_hsmfd_ecdh,3
@@ -38,10 +38,10 @@ hsmctl_sign_funding,16,change_keyindex,4
 hsmctl_sign_funding,20,our_pubkey,33
 hsmctl_sign_funding,52,their_pubkey,33
 hsmctl_sign_funding,85,num_inputs,2
-hsmctl_sign_funding,87,inputs,num_inputs*49,struct utxo
+hsmctl_sign_funding,87,inputs,num_inputs*struct utxo
 
 hsmctl_sign_funding_reply,104
 hsmctl_sign_funding_reply,0,num_sigs,2
-hsmctl_sign_funding_reply,0,sig,num_sigs*64,secp256k1_ecdsa_signature
+hsmctl_sign_funding_reply,0,sig,num_sigs*secp256k1_ecdsa_signature
 
 

--- a/lightningd/opening/opening_wire.csv
+++ b/lightningd/opening/opening_wire.csv
@@ -15,13 +15,13 @@ opening_peer_bad_initial_message,0x8014
 #include <lightningd/channel_config.h>
 opening_init,0
 # Base configuration we'll offer (channel reserve will vary with amount)
-opening_init,0,our_config,36,struct channel_config
+opening_init,0,our_config,struct channel_config
 # Minimum/maximum configuration values we'll accept
 opening_init,36,max_to_self_delay,4
 opening_init,40,min_effective_htlc_capacity_msat,8
-opening_init,48,crypto_state,144,struct crypto_state
+opening_init,48,crypto_state,struct crypto_state
 # Seed to generate all the keys from
-opening_init,196,seed,32,struct privkey
+opening_init,196,seed,struct privkey
 
 # This means we offer the open.
 opening_open,1
@@ -37,14 +37,14 @@ opening_open_reply,0,remote_fundingkey,33
 
 # Now we give the funding txid and outnum.
 opening_open_funding,2
-opening_open_funding,0,txid,32,struct sha256_double
-opening_open_funding,32,txout,2,u16
+opening_open_funding,0,txid,struct sha256_double
+opening_open_funding,32,txout,u16
 
 # This gives their sig, means we can broadcast tx: we're done.
 opening_open_funding_reply,102
-opening_open_funding_reply,0,their_config,36,struct channel_config
-opening_open_funding_reply,36,first_commit_sig,64,secp256k1_ecdsa_signature
-opening_open_funding_reply,100,crypto_state,144,struct crypto_state
+opening_open_funding_reply,0,their_config,struct channel_config
+opening_open_funding_reply,36,first_commit_sig,secp256k1_ecdsa_signature
+opening_open_funding_reply,100,crypto_state,struct crypto_state
 opening_open_funding_reply,244,revocation_basepoint,33
 opening_open_funding_reply,277,payment_basepoint,33
 opening_open_funding_reply,310,delayed_payment_basepoint,33
@@ -55,20 +55,20 @@ opening_accept,3
 opening_accept,0,min_feerate,4
 opening_accept,4,max_feerate,4
 opening_accept,8,len,2
-opening_accept,10,msg,len,u8
+opening_accept,10,msg,len*u8
 
 # This gives the txid of their funding tx to watch.
 opening_accept_reply,103
-opening_accept_reply,0,funding_txid,32,struct sha256_double
+opening_accept_reply,0,funding_txid,struct sha256_double
 
 # Acknowledge watch is in place, now can send sig.
 opening_accept_finish,4
 
 opening_accept_finish_reply,104
-opening_accept_finish_reply,32,funding_txout,2,u16
-opening_accept_finish_reply,0,their_config,36,struct channel_config
-opening_accept_finish_reply,36,first_commit_sig,64,secp256k1_ecdsa_signature
-opening_accept_finish_reply,100,crypto_state,144,struct crypto_state
+opening_accept_finish_reply,32,funding_txout,u16
+opening_accept_finish_reply,0,their_config,struct channel_config
+opening_accept_finish_reply,36,first_commit_sig,secp256k1_ecdsa_signature
+opening_accept_finish_reply,100,crypto_state,struct crypto_state
 opening_accept_finish_reply,244,remote_fundingkey,33
 opening_accept_finish_reply,277,revocation_basepoint,33
 opening_accept_finish_reply,310,payment_basepoint,33

--- a/lightningd/utxo.c
+++ b/lightningd/utxo.c
@@ -18,20 +18,3 @@ void fromwire_utxo(const u8 **ptr, size_t *max, struct utxo *utxo)
 	utxo->keyindex = fromwire_u32(ptr, max);
 	utxo->is_p2sh = fromwire_bool(ptr, max);
 }
-
-void fromwire_utxo_array(const u8 **ptr, size_t *max,
-			 struct utxo *utxo, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		fromwire_utxo(ptr, max, &utxo[i]);
-}
-
-void towire_utxo_array(u8 **pptr, const struct utxo *utxo, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_utxo(pptr, &utxo[i]);
-}

--- a/lightningd/utxo.h
+++ b/lightningd/utxo.h
@@ -16,9 +16,4 @@ struct utxo {
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo);
 void fromwire_utxo(const u8 **ptr, size_t *max, struct utxo *utxo);
-
-void fromwire_utxo_array(const u8 **ptr, size_t *max,
-			 struct utxo *utxo, size_t num);
-
-void towire_utxo_array(u8 **pptr, const struct utxo *utxo, size_t num);
 #endif /* LIGHTNING_LIGHTNINGD_UTXO_H */

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -160,51 +160,9 @@ void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num)
 	fromwire(cursor, max, arr, num);
 }
 
-void fromwire_u32_array(const u8 **cursor, size_t *max, u32 *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		arr[i] = fromwire_u32(cursor, max);
-}
-
-void fromwire_u64_array(const u8 **cursor, size_t *max, u64 *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		arr[i] = fromwire_u64(cursor, max);
-}
-
-void fromwire_bool_array(const u8 **cursor, size_t *max, bool *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		arr[i] = fromwire_bool(cursor, max);
-}
-
 void fromwire_pad(const u8 **cursor, size_t *max, size_t num)
 {
 	fromwire(cursor, max, NULL, num);
-}
-
-void fromwire_secp256k1_ecdsa_signature_array(const u8 **cursor, size_t *max,
-			      secp256k1_ecdsa_signature *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		fromwire_secp256k1_ecdsa_signature(cursor, max, arr + i);
-}
-
-void fromwire_sha256_double_array(const u8 **cursor, size_t *max,
-				  struct sha256_double *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		fromwire_sha256_double(cursor, max, arr + i);
 }
 
 static char *fmt_short_channel_id(const tal_t *ctx,

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -104,30 +104,6 @@ void towire_u8_array(u8 **pptr, const u8 *arr, size_t num)
 	towire(pptr, arr, num);
 }
 
-void towire_u32_array(u8 **pptr, const u32 *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_u32(pptr, arr[i]);
-}
-
-void towire_u64_array(u8 **pptr, const u64 *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_u64(pptr, arr[i]);
-}
-
-void towire_bool_array(u8 **pptr, const bool *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_bool(pptr, arr[i]);
-}
-
 void towire_pad(u8 **pptr, size_t num)
 {
 	/* Simply insert zeros. */
@@ -135,22 +111,4 @@ void towire_pad(u8 **pptr, size_t num)
 
 	tal_resize(pptr, oldsize + num);
 	memset(*pptr + oldsize, 0, num);
-}
-
-void towire_secp256k1_ecdsa_signature_array(u8 **pptr,
-			    const secp256k1_ecdsa_signature *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_secp256k1_ecdsa_signature(pptr, arr+i);
-}
-
-void towire_sha256_double_array(u8 **pptr,
-				const struct sha256_double *arr, size_t num)
-{
-	size_t i;
-
-	for (i = 0; i < num; i++)
-		towire_sha256_double(pptr, arr+i);
 }

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -43,14 +43,6 @@ void towire_pad(u8 **pptr, size_t num);
 void towire_bool(u8 **pptr, bool v);
 
 void towire_u8_array(u8 **pptr, const u8 *arr, size_t num);
-void towire_u32_array(u8 **pptr, const u32 *arr, size_t num);
-void towire_u64_array(u8 **pptr, const u64 *arr, size_t num);
-void towire_bool_array(u8 **pptr, const bool *arr, size_t num);
-void towire_secp256k1_ecdsa_signature_array(u8 **pptr,
-			const secp256k1_ecdsa_signature *arr, size_t num);
-void towire_sha256_double_array(u8 **pptr,
-				const struct sha256_double *arr, size_t num);
-
 
 const u8 *fromwire(const u8 **cursor, size_t *max, void *copy, size_t n);
 u8 fromwire_u8(const u8 **cursor, size_t *max);
@@ -73,12 +65,4 @@ void fromwire_ipv6(const u8 **cursor, size_t *max, struct ipv6 *ipv6);
 void fromwire_pad(const u8 **cursor, size_t *max, size_t num);
 
 void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num);
-void fromwire_u32_array(const u8 **cursor, size_t *max, u32 *arr, size_t num);
-void fromwire_u64_array(const u8 **cursor, size_t *max, u64 *arr, size_t num);
-void fromwire_bool_array(const u8 **cursor, size_t *max, bool *arr, size_t num);
-
-void fromwire_secp256k1_ecdsa_signature_array(const u8 **cursor, size_t *max,
-			      secp256k1_ecdsa_signature *arr, size_t num);
-void fromwire_sha256_double_array(const u8 **cursor, size_t *max,
-				  struct sha256_double *arr, size_t num);
 #endif /* LIGHTNING_WIRE_WIRE_H */


### PR DESCRIPTION
Some much-needed rework of generate-wire.py make it easier to have generate-wire do all the marshaling for getnodes.

To be fair, we could have applied the last patch with the following csv, but it's a hack:

  gossip_getnodes_reply,0,num_nodes,2,u16
  gossip_getnodes_reply,2,nodes,num_nodes*100,struct gossip_getnodes_entry

Now we just do this:

  gossip_getnodes_reply,0,num_nodes,u16
  gossip_getnodes_reply,2,nodes,num_nodes*struct gossip_getnodes_entry
