### PR TITLE
wiregen: Passing ctx to array helpers that require it

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -101,6 +101,16 @@ class LightningRpc(UnixDomainSocketRpc):
     def getnodes(self):
         return self._call("getnodes", [])
 
+    def newaddr(self):
+        return self._call("newaddr", [])['address']
+
+    def addfunds(self, tx):
+        return self._call("addfunds", [tx])
+
+    def fundchannel(self, node_id, capacity):
+        return self._call("fundchannel", [node_id, capacity])
+
+
 class LegacyLightningRpc(UnixDomainSocketRpc):
     def getchannels(self):
         """List all known channels.

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -21,7 +21,10 @@ class UnixDomainSocketRpc(object):
         buff = b''
         while True:
             try:
-                buff += sock.recv(1024)
+                b = sock.recv(1024)
+                buff += b
+                if len(b) == 0:
+                    return {'error': 'Connection to RPC server lost.'}
                 # Convert late to UTF-8 so glyphs split across recvs do not
                 # impact us
                 objs, _ = self.decoder.raw_decode(buff.decode("UTF-8"))

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -1,12 +1,12 @@
 #include <lightningd/gossip_msg.h>
 #include <wire/wire.h>
 
-void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry)
+void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry)
 {
 	u8 hostnamelen;
 	fromwire_pubkey(pptr, max, &entry->nodeid);
 	hostnamelen = fromwire_u8(pptr, max);
-	entry->hostname = tal_arr(entry, char, hostnamelen);
+	entry->hostname = tal_arr(ctx, char, hostnamelen);
 	fromwire_u8_array(pptr, max, (u8*)entry->hostname, hostnamelen);
 	entry->port = fromwire_u16(pptr, max);
 }

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -9,7 +9,7 @@ struct gossip_getnodes_entry {
 	u16 port;
 };
 
-void fromwire_gossip_getnodes_entry(const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
+void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
 void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry);
 
 #endif /* LIGHTNING_LIGHTGNINGD_GOSSIP_MSG_H */

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -198,7 +198,10 @@ class LightningNode(object):
         tx = self.bitcoin.rpc.gettransaction(txid)
 
         def call_connect():
-            self.rpc.connect('127.0.0.1', remote_node.daemon.port, tx['hex'], async=False)
+            try:
+                self.rpc.connect('127.0.0.1', remote_node.daemon.port, tx['hex'], async=False)
+            except:
+                pass
         t = threading.Thread(target=call_connect)
         t.daemon = True
         t.start()

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -23,6 +23,11 @@ type2size = {
     'bool': 1
 }
 
+# These struct array helpers require a context to allocate from.
+varlen_structs = [
+    'gossip_getnodes_entry',
+]
+
 class FieldType(object):
     def __init__(self,name):
         self.name = name
@@ -235,8 +240,9 @@ class Message(object):
                 subcalls.append('\t\t{}[i] = fromwire_{}(&cursor, plen);'
                                 .format(name, basetype))
             else:
-                subcalls.append('\t\tfromwire_{}(&cursor, plen, {} + i);'
-                                .format(basetype, name))
+                ctx = "ctx, " if basetype in varlen_structs else ""
+                subcalls.append('\t\tfromwire_{}({}&cursor, plen, {} + i);'
+                                .format(basetype, ctx, name))
 
     def print_fromwire(self,is_header):
         ctx_arg = 'const tal_t *ctx, ' if self.has_variable_fields else ''


### PR DESCRIPTION
Some of the struct array helpers need to allocate data when
deserializing their fields. The `getnodes` reply is one such example
that allocates the hostname. Since the change to calling array helpers
the getnodes call was broken because it was attempting to allocate off
of the entry, which did not have a tal header, thus failing.