### PR TITLE
jsonrpc: Implemented `getchannels` JSON-RPC call

### DIFF
--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -71,3 +71,9 @@ gossip_getroute_request,70,riskfactor,u16
 gossip_getroute_reply,106
 gossip_getroute_reply,0,num_hops,u16
 gossip_getroute_reply,2,hops,num_hops*struct route_hop
+
+gossip_getchannels_request,7
+
+gossip_getchannels_reply,107
+gossip_getchannels_reply,0,num_channels,u16
+gossip_getchannels_reply,2,nodes,num_channels*struct gossip_getchannels_entry

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -39,3 +39,28 @@ void towire_route_hop(u8 **pptr, const struct route_hop *entry)
 	towire_u32(pptr, entry->delay);
 }
 
+void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
+				      struct gossip_getchannels_entry *entry)
+{
+	fromwire_short_channel_id(pptr, max, &entry->short_channel_id);
+	fromwire_pubkey(pptr, max, &entry->source);
+	fromwire_pubkey(pptr, max, &entry->destination);
+	entry->active = fromwire_bool(pptr, max);
+	entry->fee_per_kw = fromwire_u32(pptr, max);
+	entry->delay = fromwire_u32(pptr, max);
+	entry->last_update_timestamp = fromwire_u32(pptr, max);
+	entry->flags = fromwire_u16(pptr, max);
+}
+
+void towire_gossip_getchannels_entry(
+    u8 **pptr, const struct gossip_getchannels_entry *entry)
+{
+	towire_short_channel_id(pptr, &entry->short_channel_id);
+	towire_pubkey(pptr, &entry->source);
+	towire_pubkey(pptr, &entry->destination);
+	towire_bool(pptr, entry->active);
+	towire_u32(pptr, entry->fee_per_kw);
+	towire_u32(pptr, entry->delay);
+	towire_u32(pptr, entry->last_update_timestamp);
+	towire_u16(pptr, entry->flags);
+}

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -10,10 +10,28 @@ struct gossip_getnodes_entry {
 	u16 port;
 };
 
-void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry);
-void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry);
+struct gossip_getchannels_entry {
+	struct pubkey source, destination;
+	u32 fee_per_kw;
+	bool active;
+	struct short_channel_id short_channel_id;
+	u32 last_update_timestamp;
+	u32 delay;
+	u16 flags;
+};
+
+void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr,
+				    size_t *max,
+				    struct gossip_getnodes_entry *entry);
+void towire_gossip_getnodes_entry(u8 **pptr,
+				  const struct gossip_getnodes_entry *entry);
 
 void fromwire_route_hop(const u8 **pprt, size_t *max, struct route_hop *entry);
 void towire_route_hop(u8 **pprt, const struct route_hop *entry);
+
+void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
+				       struct gossip_getchannels_entry *entry);
+void towire_gossip_getchannels_entry(
+    u8 **pptr, const struct gossip_getchannels_entry *entry);
 
 #endif /* LIGHTNING_LIGHTGNINGD_GOSSIP_MSG_H */


### PR DESCRIPTION
Same structure as the previous JSON-RPC requests. Since the request is empty for now, we don't even bother to parse it, but we might change that in the future, once we implement the paging of large results.