### PR TITLE
Use HSM to compute signatures for channel_announcement and channel_update messages

### DIFF
--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -80,6 +80,7 @@ LIGHTNINGD_HEADERS_NOGEN =			\
 	lightningd/hsm_control.h		\
 	lightningd/htlc_end.h			\
 	lightningd/lightningd.h			\
+	lightningd/pay.h			\
 	lightningd/peer_control.h		\
 	lightningd/subd.h			\
 	$(LIGHTNINGD_OLD_LIB_HEADERS)		\

--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -236,6 +236,7 @@ static struct io_plan *peer_out(struct io_conn *conn, struct peer *peer)
 	if (!out)
 		return msg_queue_wait(conn, &peer->peer_out, peer_out, peer);
 
+	status_trace("peer_out %s", wire_type_name(fromwire_peektype(out)));
 	return peer_write_message(conn, &peer->pcs, out, peer_out);
 }
 
@@ -821,6 +822,7 @@ static void handle_peer_fail_htlc(struct peer *peer, const u8 *msg)
 static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
 {
 	enum wire_type type = fromwire_peektype(msg);
+	status_trace("peer_in %s", wire_type_name(type));
 
 	/* Must get funding_locked before almost anything. */
 	if (!peer->funding_locked[REMOTE]) {

--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -145,9 +145,11 @@ static void send_announcement_signatures(struct peer *peer)
 			      "HSM returned an invalid signature");
 	}
 
-	/* FIXME: Calculate bitcoin sig. */
-	memset(&peer->announcement_bitcoin_sigs[LOCAL], 0,
-	       sizeof(peer->announcement_bitcoin_sigs[LOCAL]));
+	/* TODO(cdecker) Move this to the HSM once we store the
+	 * funding_privkey there */
+	sign_hash(&peer->our_secrets.funding_privkey, &hash,
+		  &peer->announcement_bitcoin_sigs[LOCAL]);
+
 	msg = towire_announcement_signatures(
 	    tmpctx, &peer->channel_id, &peer->short_channel_ids[LOCAL],
 	    &peer->announcement_node_sigs[LOCAL],

--- a/lightningd/hsm/hsm_client_wire_csv
+++ b/lightningd/hsm/hsm_client_wire_csv
@@ -3,3 +3,11 @@ hsm_ecdh_req,1
 hsm_ecdh_req,0,point,33
 hsm_ecdh_resp,100
 hsm_ecdh_resp,0,ss,32
+
+hsm_cannouncement_sig_req,2
+hsm_cannouncement_sig_req,0,bitcoin_id,struct pubkey
+hsm_cannouncement_sig_req,33,calen,u16
+hsm_cannouncement_sig_req,35,ca,calen
+
+hsm_cannouncement_sig_reply,102
+hsm_cannouncement_sig_reply,0,node_signature,64

--- a/lightningd/hsm/hsm_client_wire_csv
+++ b/lightningd/hsm/hsm_client_wire_csv
@@ -11,3 +11,11 @@ hsm_cannouncement_sig_req,35,ca,calen
 
 hsm_cannouncement_sig_reply,102
 hsm_cannouncement_sig_reply,0,node_signature,64
+
+hsm_cupdate_sig_req,3
+hsm_cupdate_sig_req,0,culen,u16
+hsm_cupdate_sig_req,2,cu,culen
+
+hsm_cupdate_sig_reply,103
+hsm_cupdate_sig_reply,0,culen,u16
+hsm_cupdate_sig_reply,2,cu,culen

--- a/lightningd/hsm/hsm_wire.csv
+++ b/lightningd/hsm/hsm_wire.csv
@@ -44,4 +44,9 @@ hsmctl_sign_funding_reply,104
 hsmctl_sign_funding_reply,0,num_sigs,2
 hsmctl_sign_funding_reply,0,sig,num_sigs*secp256k1_ecdsa_signature
 
+# Request a client socket for a `channeld`, allows signing announcements 
+hsmctl_hsmfd_channeld,5
+hsmctl_hsmfd_channeld,0,unique_id,8
 
+# Empty reply, just an fd
+hsmctl_hsmfd_channeld_reply,105

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -71,10 +71,12 @@ static int hsm_msg(struct subd *hsm, const u8 *msg, const int *fds)
 	/* HSM doesn't send these */
 	case WIRE_HSMCTL_INIT:
 	case WIRE_HSMCTL_HSMFD_ECDH:
+	case WIRE_HSMCTL_HSMFD_CHANNELD:
 	case WIRE_HSMCTL_SIGN_FUNDING:
 
 	/* Replies should be paired to individual requests. */
 	case WIRE_HSMCTL_INIT_REPLY:
+	case WIRE_HSMCTL_HSMFD_CHANNELD_REPLY:
 	case WIRE_HSMCTL_HSMFD_ECDH_FD_REPLY:
 	case WIRE_HSMCTL_SIGN_FUNDING_REPLY:
 		errx(1, "HSM gave invalid message %s", hsm_wire_type_name(t));

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -953,8 +953,8 @@ static void peer_start_channeld(struct peer *peer, enum side funder,
 
 	/* Get fd from hsm. */
 	subd_req(peer, peer->ld->hsm,
-		 take(towire_hsmctl_hsmfd_ecdh(peer, peer->unique_id)), -1, 1,
-		 peer_start_channeld_hsmfd, cds);
+		 take(towire_hsmctl_hsmfd_channeld(peer, peer->unique_id)),
+		 -1, 1, peer_start_channeld_hsmfd, cds);
 }
 
 static bool opening_release_tx(struct subd *opening, const u8 *resp,

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -149,10 +149,18 @@ class LightningDTests(BaseLightningDTests):
         l1.daemon.wait_for_log('Normal operation')
         l2.daemon.wait_for_log('Normal operation')
 
-        time.sleep(1)
+        l1.daemon.wait_for_log('peer_out WIRE_ANNOUNCEMENT_SIGNATURES')
+        l1.daemon.wait_for_log('peer_in WIRE_ANNOUNCEMENT_SIGNATURES')
+
+        l1.daemon.wait_for_log('peer_out WIRE_CHANNEL_ANNOUNCEMENT')
+        l1.daemon.wait_for_log('peer_in WIRE_CHANNEL_ANNOUNCEMENT')
 
         nodes = l1.rpc.getnodes()['nodes']
         assert set([n['nodeid'] for n in nodes]) == set([l1.info['id'], l2.info['id']])
+
+        channels = l1.rpc.getchannels()['channels']
+        assert len(channels) == 2
+        assert [c['active'] for c in channels] == [True, True]
 
 class LegacyLightningDTests(BaseLightningDTests):
 


### PR DESCRIPTION
We first pass a client socket to `channeld` so we they can communicate, and `channeld` can ask for signatures. Then we rewire the sending logic for `channel_announcement`s and `channel_update`s in order to handle the new async behavior needed to get the signatures. Finally we validate the signatures in `gossipd` and ignore them if validation fails.