### PR TITLE
Fix a double-free bug in the negotiation phase

### DIFF
--- a/daemon/cryptopkt.c
+++ b/daemon/cryptopkt.c
@@ -443,6 +443,9 @@ static struct io_plan *recv_body_negotiate(struct io_conn *conn,
 	if (!check_proof(neg, neg->log, pkt, neg->expected_id, &id))
 		return io_close(conn);
 
+	/* Steal so that the callback may not accidentally free it for us */
+	tal_steal(NULL, neg);
+
 	plan = neg->cb(conn, neg->dstate, neg->iod, neg->log, &id, neg->arg);
 	tal_free(neg);
 	return plan;


### PR DESCRIPTION
The callback on `key_negotiate` was closing the connection under
certain circumstances and would also `free` the key_negotiate, which
would then be freed again once it returns. We steal it off of the
connection during the callback and doing the free manually afterwards
to make sure this can't happen.

Thanks to @jgriffiths for tracking this one down.

Fixes #142

Reported-By: @bjd and @bgorlick