### PR TITLE
Sphinx reply encryption and decryption functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ libwally-core/src/libwallycore.% libwally-core/src/secp256k1/libsecp256k1.%: $(L
 lightning.pb-c.c lightning.pb-c.h: lightning.proto
 	@if $(CHANGED_FROM_GIT); then echo $(PROTOCC) lightning.proto --c_out=.; $(PROTOCC) lightning.proto --c_out=.; else touch $@; fi
 
-$(TEST_PROGRAMS): % : %.o $(BITCOIN_OBJS) $(LIBBASE58_OBJS) $(WIRE_OBJS) $(CCAN_OBJS) utils.o version.o libwallycore.a libsecp256k1.a libsodium.a
+$(TEST_PROGRAMS): % : %.o $(BITCOIN_OBJS) $(LIBBASE58_OBJS) $(WIRE_OBJS) $(CCAN_OBJS) lightningd/sphinx.o utils.o version.o libwallycore.a libsecp256k1.a libsodium.a
 
 ccan/config.h: ccan/tools/configurator/configurator
 	if $< > $@.new; then mv $@.new $@; else rm $@.new; exit 1; fi
@@ -392,6 +392,8 @@ update-mocks/%: %
           fi; \
 	  tail -n +$$END $< >> $$BASE.new; mv $$BASE.new $<; \
 	fi
+
+test/test_sphinx: libsodium.a
 
 unittest/%: %
 	$(VALGRIND) $(VALGRIND_TEST_ARGS) $*

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -30,7 +30,6 @@ LIGHTNINGD_OLD_HEADERS := $(LIGHTNINGD_OLD_SRC:.c=.h)
 LIGHTNINGD_OLD_LIB_SRC :=			\
 	daemon/htlc_state.c			\
 	daemon/pseudorand.c			\
-	daemon/sphinx.c				\
 	daemon/timeout.c
 LIGHTNINGD_OLD_LIB_OBJS := $(LIGHTNINGD_OLD_LIB_SRC:.c=.o)
 LIGHTNINGD_OLD_LIB_HEADERS := $(LIGHTNINGD_OLD_LIB_SRC:.c=.h)
@@ -52,6 +51,7 @@ LIGHTNINGD_LIB_SRC :=				\
 	lightningd/msg_queue.c			\
 	lightningd/peer_failed.c		\
 	lightningd/ping.c			\
+	lightningd/sphinx.c			\
 	lightningd/status.c			\
 	lightningd/utxo.c
 

--- a/lightningd/sphinx.c
+++ b/lightningd/sphinx.c
@@ -1,0 +1,496 @@
+#include "sphinx.h"
+#include "utils.h"
+#include <assert.h>
+
+#include <ccan/crypto/ripemd160/ripemd160.h>
+#include <ccan/crypto/sha256/sha256.h>
+#include <ccan/mem/mem.h>
+
+#include <err.h>
+
+#include <secp256k1_ecdh.h>
+
+#include <sodium/crypto_auth_hmacsha256.h>
+#include <sodium/crypto_stream_chacha20.h>
+
+#define BLINDING_FACTOR_SIZE 32
+#define SHARED_SECRET_SIZE 32
+#define NUM_STREAM_BYTES ((2 * NUM_MAX_HOPS + 2) * SECURITY_PARAMETER)
+#define KEY_LEN 32
+
+struct hop_params {
+	u8 secret[SHARED_SECRET_SIZE];
+	u8 blind[BLINDING_FACTOR_SIZE];
+	secp256k1_pubkey ephemeralkey;
+};
+
+struct keyset {
+	u8 pi[KEY_LEN];
+	u8 mu[KEY_LEN];
+	u8 rho[KEY_LEN];
+	u8 gamma[KEY_LEN];
+};
+
+/* Small helper to append data to a buffer and update the position
+ * into the buffer
+ */
+static void write_buffer(u8 *dst, const void *src, const size_t len, int *pos)
+{
+	memcpy(dst + *pos, src, len);
+	*pos += len;
+}
+
+/* Read len bytes from the source at position pos into dst and update
+ * the position pos accordingly.
+ */
+static void read_buffer(void *dst, const u8 *src, const size_t len, int *pos)
+{
+	memcpy(dst, src + *pos, len);
+	*pos += len;
+}
+
+u8 *serialize_onionpacket(
+	const tal_t *ctx,
+	const struct onionpacket *m)
+{
+	u8 *dst = tal_arr(ctx, u8, TOTAL_PACKET_SIZE);
+
+	u8 der[33];
+	size_t outputlen = 33;
+	int p = 0;
+
+	secp256k1_ec_pubkey_serialize(secp256k1_ctx,
+				      der,
+				      &outputlen,
+				      &m->ephemeralkey,
+				      SECP256K1_EC_COMPRESSED);
+
+	write_buffer(dst, &m->version, 1, &p);
+	write_buffer(dst, der, outputlen, &p);
+	write_buffer(dst, m->mac, sizeof(m->mac), &p);
+	write_buffer(dst, m->routinginfo, ROUTING_INFO_SIZE, &p);
+	write_buffer(dst, m->hoppayloads, TOTAL_HOP_PAYLOAD_SIZE, &p);
+	return dst;
+}
+
+struct onionpacket *parse_onionpacket(
+	const tal_t *ctx,
+	const void *src,
+	const size_t srclen
+	)
+{
+	struct onionpacket *m;
+	int p = 0;
+	u8 rawEphemeralkey[33];
+
+	if (srclen != TOTAL_PACKET_SIZE)
+		return NULL;
+
+	m = talz(ctx, struct onionpacket);
+
+	read_buffer(&m->version, src, 1, &p);
+	if (m->version != 0x01) {
+		// FIXME add logging
+		return tal_free(m);
+	}
+	read_buffer(rawEphemeralkey, src, 33, &p);
+
+	if (secp256k1_ec_pubkey_parse(secp256k1_ctx, &m->ephemeralkey, rawEphemeralkey, 33) != 1)
+		return tal_free(m);
+
+	read_buffer(&m->mac, src, 20, &p);
+	read_buffer(&m->routinginfo, src, ROUTING_INFO_SIZE, &p);
+	read_buffer(&m->hoppayloads, src, TOTAL_HOP_PAYLOAD_SIZE, &p);
+	return m;
+}
+
+static struct hoppayload *parse_hoppayload(const tal_t *ctx, u8 *src)
+{
+	int p = 0;
+	struct hoppayload *result = talz(ctx, struct hoppayload);
+
+	read_buffer(&result->realm, src, sizeof(result->realm), &p);
+	read_buffer(&result->amt_to_forward,
+		    src, sizeof(result->amt_to_forward), &p);
+	read_buffer(&result->outgoing_cltv_value,
+		    src, sizeof(result->outgoing_cltv_value), &p);
+	read_buffer(&result->unused_with_v0_version_on_header,
+		    src, sizeof(result->unused_with_v0_version_on_header), &p);
+	return result;
+}
+
+static void serialize_hoppayload(u8 *dst, struct hoppayload *hp)
+{
+	int p = 0;
+
+	write_buffer(dst, &hp->realm, sizeof(hp->realm), &p);
+	write_buffer(dst, &hp->amt_to_forward, sizeof(hp->amt_to_forward), &p);
+	write_buffer(dst, &hp->outgoing_cltv_value,
+		     sizeof(hp->outgoing_cltv_value), &p);
+	write_buffer(dst, &hp->unused_with_v0_version_on_header,
+		     sizeof(hp->unused_with_v0_version_on_header), &p);
+}
+
+
+static void xorbytes(uint8_t *d, const uint8_t *a, const uint8_t *b, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		d[i] = a[i] ^ b[i];
+}
+
+/*
+ * Generate a pseudo-random byte stream of length `dstlen` from key `k` and
+ * store it in `dst`. `dst must be at least `dstlen` bytes long.
+ */
+static void generate_cipher_stream(void *dst, const u8 *k, size_t dstlen)
+{
+	u8 nonce[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+	crypto_stream_chacha20(dst, dstlen, nonce, k);
+}
+
+static bool compute_hmac(
+	void *dst,
+	const void *src,
+	size_t len,
+	const void *key,
+	size_t keylen)
+{
+	crypto_auth_hmacsha256_state state;
+
+	crypto_auth_hmacsha256_init(&state, key, keylen);
+	crypto_auth_hmacsha256_update(&state, memcheck(src, len), len);
+	crypto_auth_hmacsha256_final(&state, dst);
+	return true;
+}
+
+static void compute_packet_hmac(const struct onionpacket *packet,
+				const u8 *assocdata, const size_t assocdatalen,
+				u8 *mukey, u8 *hmac)
+{
+	u8 mactemp[ROUTING_INFO_SIZE + TOTAL_HOP_PAYLOAD_SIZE + assocdatalen];
+	u8 mac[32];
+	int pos = 0;
+
+	write_buffer(mactemp, packet->routinginfo, ROUTING_INFO_SIZE, &pos);
+	write_buffer(mactemp, packet->hoppayloads, TOTAL_HOP_PAYLOAD_SIZE, &pos);
+	write_buffer(mactemp, assocdata, assocdatalen, &pos);
+
+	compute_hmac(mac, mactemp, sizeof(mactemp), mukey, KEY_LEN);
+	memcpy(hmac, mac, 20);
+}
+
+static bool generate_key(void *k, const char *t, u8 tlen, const u8 *s)
+{
+	return compute_hmac(k, s, KEY_LEN, t, tlen);
+}
+
+static bool generate_header_padding(
+	void *dst, size_t dstlen,
+	const size_t hopsize,
+	const char *keytype,
+	size_t keytypelen,
+	const u8 numhops,
+	struct hop_params *params
+	)
+{
+	int i;
+	u8 cipher_stream[(NUM_MAX_HOPS + 1) * hopsize];
+	u8 key[KEY_LEN];
+
+	memset(dst, 0, dstlen);
+	for (i = 1; i < numhops; i++) {
+		if (!generate_key(&key, keytype, keytypelen, params[i - 1].secret))
+			return false;
+
+		generate_cipher_stream(cipher_stream, key, sizeof(cipher_stream));
+		int pos = ((NUM_MAX_HOPS - i) + 1) * hopsize;
+		xorbytes(dst, dst, cipher_stream + pos, sizeof(cipher_stream) - pos);
+	}
+	return true;
+}
+
+static void compute_blinding_factor(const secp256k1_pubkey *key,
+				    const u8 sharedsecret[SHARED_SECRET_SIZE],
+				    u8 res[BLINDING_FACTOR_SIZE])
+{
+	struct sha256_ctx ctx;
+	u8 der[33];
+	size_t outputlen = 33;
+	struct sha256 temp;
+
+	secp256k1_ec_pubkey_serialize(secp256k1_ctx, der, &outputlen, key,
+				      SECP256K1_EC_COMPRESSED);
+	sha256_init(&ctx);
+	sha256_update(&ctx, der, sizeof(der));
+	sha256_update(&ctx, sharedsecret, SHARED_SECRET_SIZE);
+	sha256_done(&ctx, &temp);
+	memcpy(res, &temp, 32);
+}
+
+static bool blind_group_element(
+	secp256k1_pubkey *blindedelement,
+	const secp256k1_pubkey *pubkey,
+	const u8 blind[BLINDING_FACTOR_SIZE])
+{
+	/* tweak_mul is inplace so copy first. */
+	if (pubkey != blindedelement)
+		*blindedelement = *pubkey;
+	if (secp256k1_ec_pubkey_tweak_mul(secp256k1_ctx, blindedelement, blind) != 1)
+		return false;
+	return true;
+}
+
+static bool create_shared_secret(
+	u8 *secret,
+	const secp256k1_pubkey *pubkey,
+	const u8 *sessionkey)
+{
+
+	if (secp256k1_ecdh(secp256k1_ctx, secret, pubkey, sessionkey) != 1)
+		return false;
+	return true;
+}
+
+bool onion_shared_secret(
+	u8 *secret,
+	const struct onionpacket *packet,
+	const struct privkey *privkey)
+{
+	return create_shared_secret(secret, &packet->ephemeralkey,
+				    privkey->secret);
+}
+
+void pubkey_hash160(
+	u8 *dst,
+	const struct pubkey *pubkey)
+{
+	struct ripemd160 r;
+	struct sha256 h;
+	u8 der[33];
+	size_t outputlen = 33;
+
+	secp256k1_ec_pubkey_serialize(secp256k1_ctx,
+				      der,
+				      &outputlen,
+				      &pubkey->pubkey,
+				      SECP256K1_EC_COMPRESSED);
+	sha256(&h, der, sizeof(der));
+	ripemd160(&r, h.u.u8, sizeof(h));
+
+	memcpy(dst, r.u.u8, sizeof(r));
+}
+
+static void generate_key_set(const u8 secret[SHARED_SECRET_SIZE],
+			     struct keyset *keys)
+{
+	generate_key(keys->rho, "rho", 3, secret);
+	generate_key(keys->pi, "pi", 2, secret);
+	generate_key(keys->mu, "mu", 2, secret);
+	generate_key(keys->gamma, "gamma", 5, secret);
+}
+
+static struct hop_params *generate_hop_params(
+	const tal_t *ctx,
+	const u8 *sessionkey,
+	struct pubkey path[])
+{
+	int i, j, num_hops = tal_count(path);
+	secp256k1_pubkey temp;
+	u8 blind[BLINDING_FACTOR_SIZE];
+	struct hop_params *params = tal_arr(ctx, struct hop_params, num_hops);
+
+	/* Initialize the first hop with the raw information */
+	if (secp256k1_ec_pubkey_create(
+		    secp256k1_ctx, &params[0].ephemeralkey, sessionkey) != 1)
+		return NULL;
+
+	if (!create_shared_secret(
+		    params[0].secret, &path[0].pubkey, sessionkey))
+		return NULL;
+
+	compute_blinding_factor(
+		&params[0].ephemeralkey, params[0].secret,
+		params[0].blind);
+
+	/* Recursively compute all following ephemeral public keys,
+	 * secrets and blinding factors
+	 */
+	for (i = 1; i < num_hops; i++) {
+		if (!blind_group_element(
+			    &params[i].ephemeralkey,
+			    &params[i - 1].ephemeralkey,
+			    params[i - 1].blind))
+			return NULL;
+
+		/* Blind this hop's point with all previous blinding factors
+		 * Order is indifferent, multiplication is commutative.
+		 */
+		memcpy(&blind, sessionkey, 32);
+		temp = path[i].pubkey;
+		if (!blind_group_element(&temp, &temp, blind))
+			return NULL;
+		for (j = 0; j < i; j++)
+			if (!blind_group_element(
+				    &temp,
+				    &temp,
+				    params[j].blind))
+				return NULL;
+
+		/* Now hash temp and store it. This requires us to
+		 * DER-serialize first and then skip the sign byte.
+		 */
+		u8 der[33];
+		size_t outputlen = 33;
+		secp256k1_ec_pubkey_serialize(
+			secp256k1_ctx, der, &outputlen, &temp,
+			SECP256K1_EC_COMPRESSED);
+		struct sha256 h;
+		sha256(&h, der, sizeof(der));
+		memcpy(&params[i].secret, &h, sizeof(h));
+
+		compute_blinding_factor(
+			&params[i].ephemeralkey,
+			params[i].secret, params[i].blind);
+	}
+	return params;
+}
+
+struct onionpacket *create_onionpacket(
+	const tal_t *ctx,
+	struct pubkey *path,
+	struct hoppayload hoppayloads[],
+	const u8 *sessionkey,
+	const u8 *assocdata,
+	const size_t assocdatalen
+	)
+{
+	struct onionpacket *packet = talz(ctx, struct onionpacket);
+	int i, num_hops = tal_count(path);
+	u8 filler[2 * (num_hops - 1) * SECURITY_PARAMETER];
+	u8 hopfiller[(num_hops - 1) * HOP_PAYLOAD_SIZE];
+	struct keyset keys;
+	u8 nextaddr[20], nexthmac[SECURITY_PARAMETER];
+	u8 stream[ROUTING_INFO_SIZE], hopstream[TOTAL_HOP_PAYLOAD_SIZE];
+	struct hop_params *params = generate_hop_params(ctx, sessionkey, path);
+	u8 binhoppayloads[tal_count(path)][HOP_PAYLOAD_SIZE];
+
+	for (i = 0; i < num_hops; i++)
+		serialize_hoppayload(binhoppayloads[i], &hoppayloads[i]);
+
+	if (!params)
+		return NULL;
+	packet->version = 1;
+	memset(nextaddr, 0, 20);
+	memset(nexthmac, 0, 20);
+	memset(packet->routinginfo, 0, ROUTING_INFO_SIZE);
+
+	generate_header_padding(filler, sizeof(filler), 2 * SECURITY_PARAMETER,
+				"rho", 3, num_hops, params);
+	generate_header_padding(hopfiller, sizeof(hopfiller), HOP_PAYLOAD_SIZE,
+				"gamma", 5, num_hops, params);
+
+	for (i = num_hops - 1; i >= 0; i--) {
+		generate_key_set(params[i].secret, &keys);
+		generate_cipher_stream(stream, keys.rho, ROUTING_INFO_SIZE);
+
+		/* Rightshift mix-header by 2*SECURITY_PARAMETER */
+		memmove(packet->routinginfo + 2 * SECURITY_PARAMETER, packet->routinginfo,
+			ROUTING_INFO_SIZE - 2 * SECURITY_PARAMETER);
+		memcpy(packet->routinginfo, nextaddr, SECURITY_PARAMETER);
+		memcpy(packet->routinginfo + SECURITY_PARAMETER, nexthmac, SECURITY_PARAMETER);
+		xorbytes(packet->routinginfo, packet->routinginfo, stream, ROUTING_INFO_SIZE);
+
+		/* Rightshift hop-payloads and obfuscate */
+		memmove(packet->hoppayloads + HOP_PAYLOAD_SIZE, packet->hoppayloads,
+			TOTAL_HOP_PAYLOAD_SIZE - HOP_PAYLOAD_SIZE);
+		memcpy(packet->hoppayloads, binhoppayloads[i], HOP_PAYLOAD_SIZE);
+		generate_cipher_stream(hopstream, keys.gamma, TOTAL_HOP_PAYLOAD_SIZE);
+		xorbytes(packet->hoppayloads, packet->hoppayloads, hopstream,
+			 TOTAL_HOP_PAYLOAD_SIZE);
+
+		if (i == num_hops - 1) {
+			size_t len = (NUM_MAX_HOPS - num_hops + 1) * 2 * SECURITY_PARAMETER;
+			memcpy(packet->routinginfo + len, filler, sizeof(filler));
+			len = (NUM_MAX_HOPS - num_hops + 1) * HOP_PAYLOAD_SIZE;
+			memcpy(packet->hoppayloads + len, hopfiller, sizeof(hopfiller));
+		}
+
+		compute_packet_hmac(packet, assocdata, assocdatalen, keys.mu,
+				    nexthmac);
+		pubkey_hash160(nextaddr, &path[i]);
+	}
+	memcpy(packet->mac, nexthmac, sizeof(nexthmac));
+	memcpy(&packet->ephemeralkey, &params[0].ephemeralkey, sizeof(secp256k1_pubkey));
+	return packet;
+}
+
+/*
+ * Given a onionpacket msg extract the information for the current
+ * node and unwrap the remainder so that the node can forward it.
+ */
+struct route_step *process_onionpacket(
+	const tal_t *ctx,
+	const struct onionpacket *msg,
+	const u8 *shared_secret,
+	const u8 *assocdata,
+	const size_t assocdatalen
+	)
+{
+	struct route_step *step = talz(ctx, struct route_step);
+	u8 hmac[20];
+	struct keyset keys;
+	u8 paddedhoppayloads[TOTAL_HOP_PAYLOAD_SIZE + HOP_PAYLOAD_SIZE];
+	u8 hopstream[TOTAL_HOP_PAYLOAD_SIZE + HOP_PAYLOAD_SIZE];
+	u8 blind[BLINDING_FACTOR_SIZE];
+	u8 stream[NUM_STREAM_BYTES];
+	u8 paddedheader[ROUTING_INFO_SIZE + 2 * SECURITY_PARAMETER];
+
+	step->next = talz(step, struct onionpacket);
+	step->next->version = msg->version;
+	generate_key_set(shared_secret, &keys);
+
+	compute_packet_hmac(msg, assocdata, assocdatalen, keys.mu, hmac);
+
+	if (memcmp(msg->mac, hmac, sizeof(hmac)) != 0) {
+		warnx("Computed MAC does not match expected MAC, the message was modified.");
+		return tal_free(step);
+	}
+
+	//FIXME:store seen secrets to avoid replay attacks
+	generate_cipher_stream(stream, keys.rho, sizeof(stream));
+
+	memset(paddedheader, 0, sizeof(paddedheader));
+	memcpy(paddedheader, msg->routinginfo, ROUTING_INFO_SIZE);
+	xorbytes(paddedheader, paddedheader, stream, sizeof(stream));
+
+	/* Extract the per-hop payload */
+	generate_cipher_stream(hopstream, keys.gamma, sizeof(hopstream));
+
+	memset(paddedhoppayloads, 0, sizeof(paddedhoppayloads));
+	memcpy(paddedhoppayloads, msg->hoppayloads, TOTAL_HOP_PAYLOAD_SIZE);
+	xorbytes(paddedhoppayloads, paddedhoppayloads, hopstream, sizeof(hopstream));
+	step->hoppayload = parse_hoppayload(step, paddedhoppayloads);
+	memcpy(&step->next->hoppayloads, paddedhoppayloads + HOP_PAYLOAD_SIZE,
+	       TOTAL_HOP_PAYLOAD_SIZE);
+
+	compute_blinding_factor(&msg->ephemeralkey, shared_secret, blind);
+	if (!blind_group_element(&step->next->ephemeralkey, &msg->ephemeralkey, blind))
+		return tal_free(step);
+	memcpy(&step->next->nexthop, paddedheader, SECURITY_PARAMETER);
+	memcpy(&step->next->mac,
+	       paddedheader + SECURITY_PARAMETER,
+	       SECURITY_PARAMETER);
+
+	memcpy(&step->next->routinginfo, paddedheader + 2 * SECURITY_PARAMETER, ROUTING_INFO_SIZE);
+
+	if (memeqzero(step->next->mac, sizeof(step->next->mac))) {
+		step->nextcase = ONION_END;
+	} else {
+		step->nextcase = ONION_FORWARD;
+	}
+
+	return step;
+}

--- a/lightningd/sphinx.h
+++ b/lightningd/sphinx.h
@@ -1,0 +1,140 @@
+#ifndef LIGHTNING_DAEMON_SPHINX_H
+#define LIGHTNING_DAEMON_SPHINX_H
+
+#include "config.h"
+#include "bitcoin/privkey.h"
+#include "bitcoin/pubkey.h"
+
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+#include <secp256k1.h>
+#include <sodium/randombytes.h>
+
+#define SECURITY_PARAMETER 20
+#define NUM_MAX_HOPS 20
+#define HOP_PAYLOAD_SIZE 20
+#define TOTAL_HOP_PAYLOAD_SIZE (NUM_MAX_HOPS * HOP_PAYLOAD_SIZE)
+#define ROUTING_INFO_SIZE (2 * NUM_MAX_HOPS * SECURITY_PARAMETER)
+#define TOTAL_PACKET_SIZE (1 + 33 + SECURITY_PARAMETER + ROUTING_INFO_SIZE + \
+			   TOTAL_HOP_PAYLOAD_SIZE)
+
+struct onionpacket {
+	/* Cleartext information */
+	u8 version;
+	u8 nexthop[20];
+	u8 mac[20];
+	secp256k1_pubkey ephemeralkey;
+
+	/* Encrypted information */
+	u8 routinginfo[ROUTING_INFO_SIZE];
+	u8 hoppayloads[TOTAL_HOP_PAYLOAD_SIZE];
+};
+
+enum route_next_case {
+	ONION_END = 0,
+	ONION_FORWARD = 1,
+};
+
+/* BOLT #4:
+ *
+ * The format of the per-hop-payload for a version 0 packet is as follows:
+```
++----------------+--------------------------+-------------------------------+--------------------------------------------+
+| realm (1 byte) | amt_to_forward (8 bytes) | outgoing_cltv_value (4 bytes) | unused_with_v0_version_on_header (7 bytes) |
++----------------+--------------------------+-------------------------------+--------------------------------------------+
+```
+*/
+struct hoppayload {
+	u8 realm;
+	u64 amt_to_forward;
+	u32 outgoing_cltv_value;
+	u8 unused_with_v0_version_on_header[7];
+};
+
+struct route_step {
+	enum route_next_case nextcase;
+	struct onionpacket *next;
+	struct hoppayload *hoppayload;
+};
+
+/**
+ * create_onionpacket - Create a new onionpacket that can be routed
+ * over a path of intermediate nodes.
+ *
+ * @ctx: tal context to allocate from
+ * @path: public keys of nodes along the path.
+ * @hoppayloads: payloads destined for individual hosts (limited to
+ *    HOP_PAYLOAD_SIZE bytes)
+ * @num_hops: path length in nodes
+ * @sessionkey: 20 byte random session key to derive secrets from
+ * @assocdata: associated data to commit to in HMACs
+ * @assocdatalen: length of the assocdata
+ */
+struct onionpacket *create_onionpacket(
+	const tal_t * ctx,
+	struct pubkey path[],
+	struct hoppayload hoppayloads[],
+	const u8 * sessionkey,
+	const u8 *assocdata,
+	const size_t assocdatalen
+	);
+
+/**
+ * onion_shared_secret - calculate ECDH shared secret between nodes.
+ *
+ * @secret: the shared secret (32 bytes long)
+ * @pubkey: the public key of the other node
+ * @privkey: the private key of this node (32 bytes long)
+ */
+bool onion_shared_secret(
+	u8 *secret,
+	const struct onionpacket *packet,
+	const struct privkey *privkey);
+
+/**
+ * process_onionpacket - process an incoming packet by stripping one
+ * onion layer and return the packet for the next hop.
+ *
+ * @ctx: tal context to allocate from
+ * @packet: incoming packet being processed
+ * @shared_secret: the result of onion_shared_secret.
+ * @hoppayload: the per-hop payload destined for the processing node.
+ * @assocdata: associated data to commit to in HMACs
+ * @assocdatalen: length of the assocdata
+ */
+struct route_step *process_onionpacket(
+	const tal_t * ctx,
+	const struct onionpacket *packet,
+	const u8 *shared_secret,
+	const u8 *assocdata,
+	const size_t assocdatalen
+	);
+
+/**
+ * serialize_onionpacket - Serialize an onionpacket to a buffer.
+ *
+ * @ctx: tal context to allocate from
+ * @packet: the packet to serialize
+ */
+u8 *serialize_onionpacket(
+	const tal_t *ctx,
+	const struct onionpacket *packet);
+
+/**
+ * parese_onionpacket - Parse an onionpacket from a buffer.
+ *
+ * @ctx: tal context to allocate from
+ * @src: buffer to read the packet from
+ * @srclen: length of the @src
+ */
+struct onionpacket *parse_onionpacket(
+	const tal_t *ctx,
+	const void *src,
+	const size_t srclen
+	);
+
+void pubkey_hash160(
+	u8 *dst,
+	const struct pubkey *pubkey);
+
+#endif /* LIGHTNING_DAEMON_SPHINX_H */

--- a/lightningd/sphinx.h
+++ b/lightningd/sphinx.h
@@ -121,7 +121,7 @@ u8 *serialize_onionpacket(
 	const struct onionpacket *packet);
 
 /**
- * parese_onionpacket - Parse an onionpacket from a buffer.
+ * parse_onionpacket - Parse an onionpacket from a buffer.
  *
  * @ctx: tal context to allocate from
  * @src: buffer to read the packet from
@@ -136,5 +136,42 @@ struct onionpacket *parse_onionpacket(
 void pubkey_hash160(
 	u8 *dst,
 	const struct pubkey *pubkey);
+
+struct onionreply {
+	/* Node index in the path that is replying */
+	int origin_index;
+	u8 *msg;
+};
+
+/**
+ * create_onionreply - Format a failure message so we can return it
+ *
+ * @ctx: tal context to allocate from
+ * @shared_secret: The shared secret used in the forward direction, used for the
+ *     HMAC
+ * @failure_msg: message (must support tal_len)
+ */
+u8 *create_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *failure_msg);
+
+/**
+ * wrap_onionreply - Add another encryption layer to the reply.
+ *
+ * @ctx: tal context to allocate from
+ * @shared_secret: the shared secret associated with the HTLC, used for the
+ *     encryption.
+ * @reply: the reply to wrap
+ */
+u8 *wrap_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *reply);
+
+/**
+ * unwrap_onionreply - Remove layers, check integrity and parse reply
+ *
+ * @ctx: tal context to allocate from
+ * @shared_secrets: shared secrets from the forward path
+ * @numhops: path length and number of shared_secrets provided
+ * @reply: the incoming reply
+ */
+struct onionreply *unwrap_onionreply(tal_t *ctx, u8 **shared_secrets,
+				     const int numhops, const u8 *reply);
 
 #endif /* LIGHTNING_DAEMON_SPHINX_H */

--- a/test/test_sphinx.c
+++ b/test/test_sphinx.c
@@ -9,8 +9,9 @@
 #include <assert.h>
 #include <unistd.h>
 
-#include "daemon/sphinx.h"
-#include "daemon/sphinx.c"
+#include "lightningd/sphinx.h"
+
+secp256k1_context *secp256k1_ctx;
 
 int main(int argc, char **argv)
 {

--- a/test/test_sphinx.c
+++ b/test/test_sphinx.c
@@ -10,12 +10,96 @@
 #include <unistd.h>
 
 #include "lightningd/sphinx.h"
+#include "utils.h"
 
 secp256k1_context *secp256k1_ctx;
 
+/* Create an onionreply with the test vector parameters and check that
+ * we match the test vectors and that we can also unwrap it. */
+static void run_unit_tests(void)
+{
+	tal_t *tmpctx = tal_tmpctx(NULL);
+	struct onionreply *oreply;
+	u8 *reply;
+	u8 *raw = tal_hexdata(tmpctx, "2002", 4);
+
+	/* Shared secrets we already have from the forward path */
+	char *secrets[] = {
+	    "53eb63ea8a3fec3b3cd433b85cd62a4b145e1dda09391b348c4e1cd36a03ea66",
+	    "a6519e98832a0b179f62123b3567c106db99ee37bef036e783263602f3488fae",
+	    "3a6b412548762f0dbccce5c7ae7bb8147d1caf9b5471c34120b30bc9c04891cc",
+	    "21e13c2d7cfe7e18836df50872466117a295783ab8aab0e7ecc8c725503ad02d",
+	    "b5756b9b542727dbafc6765a49488b023a725d631af688fc031217e90770c328",
+	};
+	u8 *ss[] = {
+	    tal_hexdata(tmpctx, secrets[0], 64),
+	    tal_hexdata(tmpctx, secrets[1], 64),
+	    tal_hexdata(tmpctx, secrets[2], 64),
+	    tal_hexdata(tmpctx, secrets[3], 64),
+	    tal_hexdata(tmpctx, secrets[4], 64),
+	};
+
+	u8 *intermediates[] = {
+	    tal_hexdata(tmpctx, "500d8596f76d3045bfdbf99914b98519fe76ea139a47d1"
+				"ab34da8730a01515e63a04819d896f45610741c83ad40b"
+				"7712aefaddec8c6baf7325d92ea4ca4d1df8bce517f7e5"
+				"4554608bf2bd8071a4f52a7a2f7ffbb1413edad81eeea5"
+				"785aa9d990f2865dc23b4bc3c301a94eec4eabebca66be"
+				"5cf638f693ec256aec514620cc28ee4a94bd9565bc4d49"
+				"62b9d3641d4278fb319ed2b84de5",
+			304),
+	    tal_hexdata(tmpctx, "669478a3ddf9ba4049df8fa51f73ac712b9c20389b5fb1"
+				"85663f16115045868ab7dd8db956128dae8857add94e67"
+				"02fb4c3a4de22e2e669e1ed926b04447fc73034bb730f4"
+				"932acd62727b75348a648a1128744657ca6a4e713b9b64"
+				"6c3ca66cac02cdab44dd3439890ef3aaf61708714f7375"
+				"349b8da541b2548d452d84de7084bb95b3ac2345201d62"
+				"4d31f4d52078aa0fa05a88b4e202",
+			304),
+	    tal_hexdata(tmpctx, "6984b0ccd86f37995857363df13670acd064bfd132c517"
+				"b23a7dfb4470e7d16aff98e25d41d3dfb7466e74f81b3e"
+				"545563cdd8f5524dae873de61d7bdfccd496af2584930d"
+				"2b566b4f8d3881f8c043df92224f38cf094cfc09d92655"
+				"989531524593ec6d6caec1863bdfaa79229b5020acc034"
+				"cd6deeea1021c50586947b9b8e6faa83b81fbfa6133c0a"
+				"f5d6b07c017f7158fa94f0d206ba",
+			304),
+	    tal_hexdata(tmpctx, "08cd44478211b8a4370ab1368b5ffe8c9c92fb8398715f"
+				"fdcba31d358e842c21a0839ab361940011585323930fa5"
+				"b9fae0c85770a2279ff59ec427ad1bbff9001c0cd14970"
+				"04bd2a0f68b50704cf6d6a4bf3c8b6a0833399a24b3456"
+				"961ba00736785112594f65b6b2d44d9f5ea4e49b5e1ec2"
+				"af978cbe31c67114440ac51a62081df0ed46d4a3df295d"
+				"a0b0fe25c0115019f03f15ec86fa",
+			304),
+	    tal_hexdata(tmpctx, "69b1e5a3e05a7b5478e6529cd1749fdd8c66da6ffa31d2"
+				"eb0f2dbbf4394713c6a8c9b16ab5f12fd45edd73c1b0c8"
+				"b33002df376801ff58aaa94000bf8a86f92620f343baef"
+				"38a580102395ae3abf9128d1047a0736ff9b83d456740e"
+				"bbb4aeb3aa9737f18fb4afb4aa074fb26c4d702f429688"
+				"88550a3bded8c05247e045b866baef0499f079fdaeef65"
+				"38f31d44deafffdfd3afa2fb4ca9",
+			304),
+	};
+
+	reply = create_onionreply(tmpctx, ss[4], raw);
+	for (int i = 4; i >= 0; i--) {
+		printf("input_packet %s\n", tal_hex(tmpctx, reply));
+		reply = wrap_onionreply(tmpctx, ss[i], reply);
+		printf("obfuscated_packet %s\n", tal_hex(tmpctx, reply));
+		assert(memcmp(reply, intermediates[i], tal_len(reply)) == 0);
+	}
+
+	oreply = unwrap_onionreply(tmpctx, ss, 5, reply);
+	printf("unwrapped %s\n", tal_hex(tmpctx, oreply->msg));
+	assert(memcmp(raw, oreply->msg, tal_len(raw)) == 0);
+
+	tal_free(tmpctx);
+}
+
 int main(int argc, char **argv)
 {
-	bool generate = false, decode = false;
+	bool generate = false, decode = false, unit = false;
 	const tal_t *ctx = talz(NULL, tal_t);
 	u8 assocdata[32];
 	memset(assocdata, 'B', sizeof(assocdata));
@@ -34,10 +118,15 @@ int main(int argc, char **argv)
 	opt_register_noarg("--decode",
 			   opt_set_bool, &decode,
 			   "Decode onion from stdin given the private key");
+	opt_register_noarg("--unit",
+			   opt_set_bool, &unit,
+			   "Run unit tests against test vectors");
 
 	opt_parse(&argc, argv, opt_log_stderr_exit);
 
-	if (generate) {
+	if (unit) {
+		run_unit_tests();
+	} else if (generate) {
 		int num_hops = argc - 1;
 		struct pubkey *path = tal_arr(ctx, struct pubkey, num_hops);
 		u8 privkeys[argc - 1][32];


### PR DESCRIPTION
This is the implementation of the encryption and decryption functionality for onion routed replies. It conforms with BOLT 04 at version lightningnetwork/lightning-rfc@4a2146b1edf6e5bbbd499c689b9df21d55a0c4ec. It does not yet include the integration with the new daemon since that is likely to clash with Rusty's HTLC forwarding patch.

It also creates a copy of the sphinx implementation in order to avoid having to maintain backward compatibility with the old daemon.