### PR TITLE
Make gossip broadcast interval configurable and fix two bugs

### DIFF
--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -44,6 +44,8 @@ struct daemon {
 	struct routing_state *rstate;
 
 	struct timers timers;
+
+	u32 broadcast_interval;
 };
 
 struct peer {
@@ -285,7 +287,8 @@ static struct io_plan *peer_msgin(struct io_conn *conn,
 static void wake_pkt_out(struct peer *peer)
 {
 	peer->gossip_sync = true;
-	new_reltimer(&peer->daemon->timers, peer, time_from_sec(30),
+	new_reltimer(&peer->daemon->timers, peer,
+		     time_from_msec(peer->daemon->broadcast_interval),
 		     wake_pkt_out, peer);
 	/* Notify the peer-write loop */
 	msg_wake(&peer->peer_out);
@@ -617,6 +620,19 @@ static struct io_plan *ping_req(struct io_conn *conn, struct daemon *daemon,
 	return daemon_conn_read_next(conn, &daemon->master);
 }
 
+/* Parse an incoming gossip init message and assign config variables
+ * to the daemon.
+ */
+static struct io_plan *gossip_init(struct daemon_conn *master,
+				   struct daemon *daemon, u8 *msg)
+{
+	if (!fromwire_gossipctl_init(msg, NULL, &daemon->broadcast_interval)) {
+		status_failed(WIRE_GOSSIPSTATUS_INIT_FAILED,
+			      "Unable to parse init message");
+	}
+	return daemon_conn_read_next(master->conn, master);
+}
+
 static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master)
 {
 	struct daemon *daemon = container_of(master, struct daemon, master);
@@ -626,6 +642,9 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master
 		     gossip_wire_type_name(t), tal_count(master->msg_in));
 
 	switch (t) {
+	case WIRE_GOSSIPCTL_INIT:
+		return gossip_init(master, daemon, master->msg_in);
+
 	case WIRE_GOSSIPCTL_NEW_PEER:
 		return new_peer(conn, daemon, master->msg_in);
 	case WIRE_GOSSIPCTL_RELEASE_PEER:
@@ -690,6 +709,7 @@ int main(int argc, char *argv[])
 	daemon->rstate = new_routing_state(daemon, base_log);
 	list_head_init(&daemon->peers);
 	timers_init(&daemon->timers, time_mono());
+	daemon->broadcast_interval = 30000;
 
 	/* stdin == control */
 	daemon_conn_init(daemon, &daemon->master, STDIN_FILENO, recv_req);

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -19,6 +19,10 @@ gossipstatus_peer_failed,10,err,len*u8
 
 #include <lightningd/cryptomsg.h>
 
+# Initialize the gossip daemon
+gossipctl_init,0
+gossipctl_init,0,broadcast_interval,4
+
 # These take an fd, but have no response
 # (if it is to move onto a channel, we get a status msg).
 gossipctl_new_peer,1

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -228,6 +228,14 @@ int main(int argc, char *argv[])
 	opt_register_arg("--dev-debugger=<subdaemon>", opt_subd_debug, NULL,
 			 ld, "Wait for gdb attach at start of <subdaemon>");
 
+	opt_register_arg("--dev-broadcast-interval=<ms>", opt_set_uintval,
+			 opt_show_uintval, &ld->broadcast_interval,
+			 "Time between gossip broadcasts in milliseconds (default: 30000)");
+
+	/* FIXME: move to option initialization once we drop the
+	 * legacy daemon */
+	ld->broadcast_interval = 30000;
+
 	/* Handle options and config; move to .lightningd */
 	newdir = handle_opts(&ld->dstate, argc, argv);
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -55,6 +55,8 @@ struct lightningd {
 
 	/* HTLCs in flight. */
 	struct htlc_end_map htlc_ends;
+
+	u32 broadcast_interval;
 };
 
 void derive_peer_seed(struct lightningd *ld, struct privkey *peer_seed,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -260,3 +260,15 @@ class LightningNode(object):
             return self.executor.submit(wait_connected)
         else:
             return wait_connected()
+
+    def openchannel(self, remote_node, capacity):
+        addr = self.rpc.newaddr()['address']
+        txid = self.bitcoin.rpc.sendtoaddress(addr, capacity / 10**6)
+        tx = self.bitcoin.rpc.getrawtransaction(txid)
+        self.rpc.addfunds(tx)
+        self.rpc.fundchannel(remote_node.info['id'], capacity)
+        self.daemon.wait_for_log('sendrawtx exit 0, gave')
+        time.sleep(1)
+        self.bitcoin.rpc.generate(6)
+        self.daemon.wait_for_log('Normal operation')
+


### PR DESCRIPTION
Adds the `--dev-broadcast-interval` flag so we can finally add tests for this as well, and not have to manually add channels. This is don with a new `gossip_init` message that is just sent after the daemon is spun up, but before we actually pass any peers in.

This also fixes two annoying bugs where we were waiting on the wrong object for wakeups for peers that are no longer directly attached to `gossipd` and the `broadcast_index` on the peer being uninitialized, both of which would result in the broadcast being stopped.

It throws in a new integration test for good measure.