### PR TITLE
Fixing Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ sudo: true
 script:
   - docker pull cdecker/lightning-ci > /dev/null
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make -j3
-  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check
+  - docker run --rm=true -e NOVALGRIND=${NOVALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -e NO_VALGRIND=${NOVALGRIND:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 
 # Trusty (aka 14.04) is way way too old, so run in docker...
 script:
+  - docker pull cdecker/lightning-ci > /dev/null
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make -j3
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check-source

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -15,9 +15,12 @@ import utils
 
 bitcoind = None
 TEST_DIR = tempfile.mkdtemp(prefix='lightning-')
-VALGRIND = os.getenv("NOVALGRIND", None) == None
+VALGRIND = os.getenv("NOVALGRIND", "0") == "0"
+TEST_DEBUG = os.getenv("TEST_DEBUG", "0") == "1"
 
-if os.getenv("TEST_DEBUG", None) != None:
+print("Testing results are in {}".format(TEST_DIR))
+
+if TEST_DEBUG:
     logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 logging.info("Tests running in '%s'", TEST_DIR)
 


### PR DESCRIPTION
We had two flaky tests, mainly due to triggering due to things in the log that were either not seen in the logs or triggering too early. I also removed the legacy gossip test that was being skipped anyway, and improved the environment variable handling, including adding passthrough from the travis env when testing in docker. This last change shoudl allow us to turn `valgrind` on/off without having to create a new commit and turn log spewing on/off on demand on the config page (`https://travis-ci.org/<username>/lightning/settings`).