### PR TITLE
Sphinx reply integration

### DIFF
--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -651,7 +651,8 @@ static void their_htlc_locked(const struct htlc *htlc, struct peer *peer)
 					   rs->nextcase == ONION_FORWARD,
 					   rs->hop_data.amt_forward,
 					   rs->hop_data.outgoing_cltv,
-					   &rs->hop_data.channel_id);
+					   &rs->hop_data.channel_id,
+					   &ss);
 	daemon_conn_send(&peer->master, take(msg));
 	tal_free(tmpctx);
 	return;

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -88,6 +88,7 @@ channel_accepted_htlc,0,forward,bool
 channel_accepted_htlc,0,amt_to_forward,u64
 channel_accepted_htlc,0,outgoing_cltv_value,u32
 channel_accepted_htlc,0,next_channel,struct short_channel_id
+channel_accepted_htlc,0,shared_secret,32
 
 # FIXME: Add code to commit current channel state!
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -31,7 +31,7 @@ struct htlc_end {
 
 	/* If we are forwarding, remember the shared secret for an
 	 * eventual reply */
-	struct sha256 shared_secret;
+	struct sha256 *shared_secret;
 
 	/* If we are the origin, remember all shared secrets, so we
 	 * can unwrap an eventual reply */

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -28,6 +28,7 @@ struct htlc_end {
 	u32 outgoing_cltv_value;
 	u32 cltv_expiry;
 	struct sha256 payment_hash;
+	struct sha256 shared_secret;
 };
 
 static inline const struct htlc_end *keyof_htlc_end(const struct htlc_end *e)

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -28,7 +28,14 @@ struct htlc_end {
 	u32 outgoing_cltv_value;
 	u32 cltv_expiry;
 	struct sha256 payment_hash;
+
+	/* If we are forwarding, remember the shared secret for an
+	 * eventual reply */
 	struct sha256 shared_secret;
+
+	/* If we are the origin, remember all shared secrets, so we
+	 * can unwrap an eventual reply */
+	struct sha256 *path_secrets;
 };
 
 static inline const struct htlc_end *keyof_htlc_end(const struct htlc_end *e)

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -163,6 +163,7 @@ static void json_sendpay(struct command *cmd,
 	u64 amount, lastamount;
 	struct onionpacket *packet;
 	u8 *msg;
+	struct sha256 *path_secrets;
 
 	if (!json_get_params(buffer, params,
 			     "route", &routetok,
@@ -321,8 +322,8 @@ static void json_sendpay(struct command *cmd,
 	randombytes_buf(&sessionkey, sizeof(sessionkey));
 
 	/* Onion will carry us from first peer onwards. */
-	packet = create_onionpacket(cmd, ids, hop_data, sessionkey,
-				    rhash.u.u8, sizeof(struct sha256));
+	packet = create_onionpacket(cmd, ids, hop_data, sessionkey, rhash.u.u8,
+				    sizeof(struct sha256), &path_secrets);
 	onion = serialize_onionpacket(cmd, packet);
 
 	if (pc)
@@ -344,6 +345,7 @@ static void json_sendpay(struct command *cmd,
 	pc->out->msatoshis = amount;
 	pc->out->other_end = NULL;
 	pc->out->pay_command = pc;
+	pc->out->path_secrets = tal_steal(pc->out, path_secrets);
 
 	log_info(ld->log, "Sending %"PRIu64" over %zu hops to deliver %"PRIu64,
 		 amount, n_hops, lastamount);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1088,7 +1088,8 @@ static int peer_accepted_htlc(struct peer *peer, const u8 *msg)
 					    hend->next_onion, &forward,
 					    &hend->amt_to_forward,
 					    &hend->outgoing_cltv_value,
-					    &hend->next_channel)) {
+					    &hend->next_channel,
+					    &hend->shared_secret)) {
 		log_broken(peer->log, "bad fromwire_channel_accepted_htlc %s",
 			   tal_hex(peer, msg));
 		return -1;

--- a/lightningd/sphinx.c
+++ b/lightningd/sphinx.c
@@ -361,7 +361,8 @@ struct onionpacket *create_onionpacket(
 	struct hop_data hops_data[],
 	const u8 *sessionkey,
 	const u8 *assocdata,
-	const size_t assocdatalen
+	const size_t assocdatalen,
+	struct sha256 **path_secrets
 	)
 {
 	struct onionpacket *packet = talz(ctx, struct onionpacket);
@@ -402,6 +403,11 @@ struct onionpacket *create_onionpacket(
 	}
 	memcpy(packet->mac, nexthmac, sizeof(nexthmac));
 	memcpy(&packet->ephemeralkey, &params[0].ephemeralkey, sizeof(secp256k1_pubkey));
+
+	*path_secrets = tal_arr(ctx, struct sha256, num_hops);
+	for (i=0; i<num_hops; i++) {
+		create_shared_secret((*path_secrets)[i].u.u8, &path[i].pubkey, sessionkey);
+	}
 	return packet;
 }
 
@@ -461,7 +467,7 @@ struct route_step *process_onionpacket(
 	return step;
 }
 
-u8 *create_onionreply(tal_t *ctx, const u8 *shared_secret,
+u8 *create_onionreply(const tal_t *ctx, const u8 *shared_secret,
 		      const u8 *failure_msg)
 {
 	size_t msglen = tal_len(failure_msg);
@@ -486,7 +492,7 @@ u8 *create_onionreply(tal_t *ctx, const u8 *shared_secret,
 	return reply;
 }
 
-u8 *wrap_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *reply)
+u8 *wrap_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *reply)
 {
 	u8 key[KEY_LEN];
 	size_t streamlen = tal_len(reply);
@@ -498,7 +504,7 @@ u8 *wrap_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *reply)
 	return result;
 }
 
-struct onionreply *unwrap_onionreply(tal_t *ctx, u8 **shared_secrets,
+struct onionreply *unwrap_onionreply(const tal_t *ctx, u8 **shared_secrets,
 				     const int numhops, const u8 *reply)
 {
 	tal_t *tmpctx = tal_tmpctx(ctx);

--- a/lightningd/sphinx.c
+++ b/lightningd/sphinx.c
@@ -372,6 +372,7 @@ struct onionpacket *create_onionpacket(
 	u8 nexthmac[SECURITY_PARAMETER];
 	u8 stream[ROUTING_INFO_SIZE];
 	struct hop_params *params = generate_hop_params(ctx, sessionkey, path);
+	struct sha256 *secrets = tal_arr(ctx, struct sha256, num_hops);
 
 	if (!params)
 		return NULL;
@@ -404,10 +405,11 @@ struct onionpacket *create_onionpacket(
 	memcpy(packet->mac, nexthmac, sizeof(nexthmac));
 	memcpy(&packet->ephemeralkey, &params[0].ephemeralkey, sizeof(secp256k1_pubkey));
 
-	*path_secrets = tal_arr(ctx, struct sha256, num_hops);
 	for (i=0; i<num_hops; i++) {
-		create_shared_secret((*path_secrets)[i].u.u8, &path[i].pubkey, sessionkey);
+		memcpy(&secrets[i], params[i].secret, SHARED_SECRET_SIZE);
 	}
+
+	*path_secrets = secrets;
 	return packet;
 }
 
@@ -514,6 +516,10 @@ struct onionreply *unwrap_onionreply(const tal_t *ctx, u8 **shared_secrets,
 	const u8 *cursor;
 	size_t max;
 	u16 msglen;
+
+	if (tal_len(reply) != ONION_REPLY_SIZE + sizeof(hmac) + 4) {
+		goto fail;
+	}
 
 	memcpy(msg, reply, tal_len(reply));
 	oreply->origin_index = -1;

--- a/lightningd/sphinx.h
+++ b/lightningd/sphinx.h
@@ -78,6 +78,7 @@ struct route_step {
  * @sessionkey: 32 byte random session key to derive secrets from
  * @assocdata: associated data to commit to in HMACs
  * @assocdatalen: length of the assocdata
+ * @path_secrets: (out) shared secrets generated for the entire path
  */
 struct onionpacket *create_onionpacket(
 	const tal_t * ctx,
@@ -85,7 +86,8 @@ struct onionpacket *create_onionpacket(
 	struct hop_data hops_data[],
 	const u8 * sessionkey,
 	const u8 *assocdata,
-	const size_t assocdatalen
+	const size_t assocdatalen,
+	struct sha256 **path_secrets
 	);
 
 /**
@@ -160,7 +162,7 @@ struct onionreply {
  *     HMAC
  * @failure_msg: message (must support tal_len)
  */
-u8 *create_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *failure_msg);
+u8 *create_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *failure_msg);
 
 /**
  * wrap_onionreply - Add another encryption layer to the reply.
@@ -170,7 +172,7 @@ u8 *create_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *failure_msg
  *     encryption.
  * @reply: the reply to wrap
  */
-u8 *wrap_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *reply);
+u8 *wrap_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *reply);
 
 /**
  * unwrap_onionreply - Remove layers, check integrity and parse reply
@@ -180,7 +182,7 @@ u8 *wrap_onionreply(tal_t *ctx, const u8 *shared_secret, const u8 *reply);
  * @numhops: path length and number of shared_secrets provided
  * @reply: the incoming reply
  */
-struct onionreply *unwrap_onionreply(tal_t *ctx, u8 **shared_secrets,
+struct onionreply *unwrap_onionreply(const tal_t *ctx, u8 **shared_secrets,
 				     const int numhops, const u8 *reply);
 
 #endif /* LIGHTNING_DAEMON_SPHINX_H */

--- a/test/test_sphinx.c
+++ b/test/test_sphinx.c
@@ -132,7 +132,8 @@ int main(int argc, char **argv)
 		u8 privkeys[argc - 1][32];
 		u8 sessionkey[32];
 		struct hop_data hops_data[num_hops];
-
+		struct sha256 *shared_secrets;
+		
 		memset(&sessionkey, 'A', sizeof(sessionkey));
 
 		int i;
@@ -155,7 +156,8 @@ int main(int argc, char **argv)
 							     hops_data,
 							     sessionkey,
 							     assocdata,
-							     sizeof(assocdata));
+							     sizeof(assocdata),
+							     &shared_secrets);
 
 		u8 *serialized = serialize_onionpacket(ctx, res);
 		if (!serialized)


### PR DESCRIPTION
This wires in the onion reply, by creating the message on failure origin, incrementally wrapping it in more encryption layers at each hops, and then unwrapping it at the recipient, i.e., the HTLC origin. Wrapping and unwrapping happens on the master daemon, and we store shared secrets in the `htlc_end` struct for easier access.

We could recompute the secrets on the final recipient since it has the pubkeys and the sessionkey, but we'd still need to keep track of those, so we just keep the secrets around. This also still uses the 20 byte HMACs matching the test vectors (see lightningnetwork/lightning-rfc#158 for details), not the corrected ones from lightningnetwork/lightning-rfc#158, but it'll be a 2 line fix once that has been merged.

Depends on #156, only the last 3 commits are actually part of this PR, everything else should be discussed on #156 