### PR TITLE
struct secret: use everywhere.

### DIFF
--- a/bitcoin/base58.c
+++ b/bitcoin/base58.c
@@ -114,7 +114,7 @@ char *key_to_base58(const tal_t *ctx, bool test_net, const struct privkey *key)
 	u8 version = test_net ? 239 : 128;
 	size_t outlen = sizeof(out);
 
-	memcpy(buf, key->secret, sizeof(key->secret));
+	memcpy(buf, key->secret.data, sizeof(key->secret.data));
 	/* Mark this as a compressed key. */
 	buf[32] = 1;
 
@@ -148,9 +148,9 @@ bool key_from_base58(const char *base58, size_t base58_len,
 		return false;
 
 	/* Copy out secret. */
-	memcpy(priv->secret, keybuf + 1, sizeof(priv->secret));
+	memcpy(priv->secret.data, keybuf + 1, sizeof(priv->secret.data));
 
-	if (!secp256k1_ec_seckey_verify(secp256k1_ctx, priv->secret))
+	if (!secp256k1_ec_seckey_verify(secp256k1_ctx, priv->secret.data))
 		return false;
 
 	/* Get public key, too. */

--- a/bitcoin/privkey.h
+++ b/bitcoin/privkey.h
@@ -3,8 +3,13 @@
 #include "config.h"
 #include <ccan/short_types/short_types.h>
 
+/* General 256-bit secret, which must be private.  Used in various places. */
+struct secret {
+	u8 data[32];
+};
+
 /* This is a private key.  Keep it secret. */
 struct privkey {
-	u8 secret[32];
+	struct secret secret;
 };
 #endif /* LIGHTNING_BITCOIN_PRIVKEY_H */

--- a/bitcoin/pubkey.c
+++ b/bitcoin/pubkey.c
@@ -34,7 +34,7 @@ bool pubkey_from_privkey(const struct privkey *privkey,
 			 struct pubkey *key)
 {
 	if (!secp256k1_ec_pubkey_create(secp256k1_ctx,
-					&key->pubkey, privkey->secret))
+					&key->pubkey, privkey->secret.data))
 		return false;
 	return true;
 }
@@ -98,3 +98,4 @@ static char *privkey_to_hexstr(const tal_t *ctx, const struct privkey *secret)
 	return str;
 }
 REGISTER_TYPE_TO_STRING(privkey, privkey_to_hexstr);
+REGISTER_TYPE_TO_HEXSTR(secret);

--- a/bitcoin/signature.c
+++ b/bitcoin/signature.c
@@ -83,7 +83,7 @@ void sign_hash(const struct privkey *privkey,
 	ok = secp256k1_ecdsa_sign(secp256k1_ctx,
 				  s,
 				  h->sha.u.u8,
-				  privkey->secret, NULL, NULL);
+				  privkey->secret.data, NULL, NULL);
 	assert(ok);
 }
 

--- a/daemon/lightningd.h
+++ b/daemon/lightningd.h
@@ -99,7 +99,7 @@ struct lightningd_state {
 	struct list_head pay_commands;
 
 	/* Our private key */
-	struct secret *secret;
+	struct privkey *privkey;
 
 	/* This is us. */
 	struct pubkey id;

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -878,7 +878,6 @@ static void their_htlc_added(struct peer *peer, struct htlc *htlc,
 			     struct peer *only_dest)
 {
 	struct invoice *invoice;
-	struct privkey pk;
 	struct onionpacket *packet;
 	struct route_step *step = NULL;
 
@@ -909,15 +908,13 @@ static void their_htlc_added(struct peer *peer, struct htlc *htlc,
 		return;
 	}
 
-	//FIXME: dirty trick to retrieve unexported state
-	memcpy(&pk, peer->dstate->secret, sizeof(pk));
-
 	packet = parse_onionpacket(peer,
 				   htlc->routing, tal_count(htlc->routing));
 	if (packet) {
 		u8 shared_secret[32];
 
-		if (onion_shared_secret(shared_secret, packet, &pk))
+		if (onion_shared_secret(shared_secret, packet,
+					peer->dstate->privkey))
 			step = process_onionpacket(packet, packet,
 						   shared_secret,
 						   htlc->rhash.u.u8,

--- a/daemon/sphinx.c
+++ b/daemon/sphinx.c
@@ -260,7 +260,7 @@ bool onion_shared_secret(
 	const struct privkey *privkey)
 {
 	return create_shared_secret(secret, &packet->ephemeralkey,
-				    privkey->secret);
+				    privkey->secret.data);
 }
 
 void pubkey_hash160(

--- a/daemon/wallet.c
+++ b/daemon/wallet.c
@@ -45,7 +45,8 @@ bool restore_wallet_address(struct lightningd_state *dstate,
 static void new_keypair(struct privkey *privkey, struct pubkey *pubkey)
 {
 	do {
-		randombytes_buf(privkey->secret, sizeof(privkey->secret));
+		randombytes_buf(privkey->secret.data,
+				sizeof(privkey->secret.data));
 	} while (!pubkey_from_privkey(privkey, pubkey));
 }
 

--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -595,7 +595,8 @@ static void their_htlc_locked(const struct htlc *htlc, struct peer *peer)
 	u8 *msg;
 	struct onionpacket *op;
 	struct route_step *rs;
-	struct sha256 ss, bad_onion_sha;
+	struct sha256 bad_onion_sha;
+	struct secret ss;
 	enum onion_type failcode;
 	enum channel_remove_err rerr;
 	struct pubkey ephemeral;
@@ -625,7 +626,7 @@ static void their_htlc_locked(const struct htlc *htlc, struct peer *peer)
 		goto bad_onion;
 	}
 
-	rs = process_onionpacket(tmpctx, op, ss.u.u8, htlc->rhash.u.u8,
+	rs = process_onionpacket(tmpctx, op, ss.data, htlc->rhash.u.u8,
 				 sizeof(htlc->rhash));
 	if (!rs) {
 		failcode = WIRE_INVALID_ONION_HMAC;

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -88,7 +88,7 @@ channel_accepted_htlc,0,forward,bool
 channel_accepted_htlc,0,amt_to_forward,u64
 channel_accepted_htlc,0,outgoing_cltv_value,u32
 channel_accepted_htlc,0,next_channel,struct short_channel_id
-channel_accepted_htlc,0,shared_secret,32
+channel_accepted_htlc,0,shared_secret,struct secret
 
 # FIXME: Add code to commit current channel state!
 

--- a/lightningd/cryptomsg.h
+++ b/lightningd/cryptomsg.h
@@ -1,7 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_CRYPTOMSG_H
 #define LIGHTNING_LIGHTNINGD_CRYPTOMSG_H
 #include "config.h"
-#include <ccan/crypto/sha256/sha256.h>
+#include <bitcoin/privkey.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 
@@ -12,9 +12,9 @@ struct crypto_state {
 	/* Received and sent nonces. */
 	u64 rn, sn;
 	/* Sending and receiving keys. */
-	struct sha256 sk, rk;
+	struct secret sk, rk;
 	/* Chaining key for re-keying */
-	struct sha256 s_ck, r_ck;
+	struct secret s_ck, r_ck;
 };
 
 struct peer_crypto_state {

--- a/lightningd/derive_basepoints.c
+++ b/lightningd/derive_basepoints.c
@@ -23,9 +23,9 @@ bool derive_basepoints(const struct privkey *seed,
 		    "c-lightning", strlen("c-lightning"));
 
 	secrets->funding_privkey = keys.f;
-	secrets->revocation_basepoint_secret = keys.r;
-	secrets->payment_basepoint_secret = keys.p;
-	secrets->delayed_payment_basepoint_secret = keys.d;
+	secrets->revocation_basepoint_secret = keys.r.secret;
+	secrets->payment_basepoint_secret = keys.p.secret;
+	secrets->delayed_payment_basepoint_secret = keys.d.secret;
 
 	if (!pubkey_from_privkey(&keys.f, funding_pubkey)
 	    || !pubkey_from_privkey(&keys.r, &basepoints->revocation)

--- a/lightningd/derive_basepoints.h
+++ b/lightningd/derive_basepoints.h
@@ -14,9 +14,9 @@ struct basepoints {
 
 struct secrets {
 	struct privkey funding_privkey;
-	struct privkey revocation_basepoint_secret;
-	struct privkey payment_basepoint_secret;
-	struct privkey delayed_payment_basepoint_secret;
+	struct secret revocation_basepoint_secret;
+	struct secret payment_basepoint_secret;
+	struct secret delayed_payment_basepoint_secret;
 };
 
 bool derive_basepoints(const struct privkey *seed,

--- a/lightningd/dev_newhtlc.c
+++ b/lightningd/dev_newhtlc.c
@@ -62,7 +62,7 @@ static void json_dev_newhtlc(struct command *cmd,
 	u8 *onion;
 	struct htlc_end *hend;
 	struct pubkey *path = tal_arrz(cmd, struct pubkey, 1);
-	struct sha256 *shared_secrets;
+	struct secret *shared_secrets;
 
 	if (!json_get_params(buffer, params,
 			     "peerid", &peeridtok,

--- a/lightningd/handshake/test/run-handshake.c
+++ b/lightningd/handshake/test/run-handshake.c
@@ -61,10 +61,10 @@ void hsm_setup(int fd)
 {
 }
 
-bool hsm_do_ecdh(struct sha256 *ss, const struct pubkey *point)
+bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point)
 {
-	return secp256k1_ecdh(secp256k1_ctx, ss->u.u8, &point->pubkey,
-			      privkey.secret) == 1;
+	return secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
+			      privkey.secret.data) == 1;
 }
 
 int main(void)
@@ -80,11 +80,11 @@ int main(void)
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
 						 | SECP256K1_CONTEXT_SIGN);
 
-	memset(responder_privkey.secret, 0x21,
-	       sizeof(responder_privkey.secret));
+	memset(responder_privkey.secret.data, 0x21,
+	       sizeof(responder_privkey.secret.data));
 	if (!secp256k1_ec_pubkey_create(secp256k1_ctx,
 					&responder_id.pubkey,
-					responder_privkey.secret))
+					responder_privkey.secret.data))
 		errx(1, "Keygen failed");
 
 	if (pipe(fds1) != 0 || pipe(fds2) != 0)
@@ -104,7 +104,7 @@ int main(void)
 		privkey = responder_privkey;
 		status_prefix = "RESPR";
 		status_trace("ls.priv: 0x%s",
-			     tal_hexstr(trc, responder_privkey.secret,
+			     tal_hexstr(trc, &responder_privkey,
 					sizeof(responder_privkey)));
 		status_trace("ls.pub: 0x%s",
 			     type_to_string(trc, struct pubkey, &responder_id));
@@ -125,19 +125,19 @@ int main(void)
 		close(fds2[1]);
 		close(fds1[0]);
 
-		memset(initiator_privkey.secret, 0x11,
-		       sizeof(initiator_privkey.secret));
+		memset(initiator_privkey.secret.data, 0x11,
+		       sizeof(initiator_privkey.secret.data));
 		memset(e_priv, 0x12, sizeof(e_priv));
 		if (!secp256k1_ec_pubkey_create(secp256k1_ctx,
 						&initiator_id.pubkey,
-						initiator_privkey.secret))
+						initiator_privkey.secret.data))
 			errx(1, "Initiator keygen failed");
 		privkey = initiator_privkey;
 		status_prefix = "INITR";
 		status_trace("rs.pub: 0x%s",
 			     type_to_string(trc, struct pubkey, &responder_id));
 		status_trace("ls.priv: 0x%s",
-			     tal_hexstr(trc, initiator_privkey.secret,
+			     tal_hexstr(trc, &initiator_privkey,
 					sizeof(initiator_privkey)));
 		status_trace("ls.pub: 0x%s",
 			     type_to_string(trc, struct pubkey, &initiator_id));

--- a/lightningd/hsm/client.c
+++ b/lightningd/hsm/client.c
@@ -9,7 +9,7 @@ void hsm_setup(int fd)
 	hsm_fd = fd;
 }
 
-bool hsm_do_ecdh(struct sha256 *ss, const struct pubkey *point)
+bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point)
 {
 	u8 *req = towire_hsm_ecdh_req(NULL, point), *resp;
 	size_t len;

--- a/lightningd/hsm/client.h
+++ b/lightningd/hsm/client.h
@@ -7,11 +7,11 @@
 #include <stdbool.h>
 
 struct pubkey;
-struct sha256;
+struct secret;
 
 /* Setup communication to the HSM */
 void hsm_setup(int fd);
 
 /* Do ECDH using this node id secret. */
-bool hsm_do_ecdh(struct sha256 *ss, const struct pubkey *point);
+bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point);
 #endif /* LIGHTNING_LIGHTNINGD_HSM_H */

--- a/lightningd/hsm/hsm_client_wire_csv
+++ b/lightningd/hsm/hsm_client_wire_csv
@@ -1,8 +1,8 @@
 # Give me ECDH(node-id-secret,point)
 hsm_ecdh_req,1
-hsm_ecdh_req,0,point,33
+hsm_ecdh_req,0,point,struct pubkey
 hsm_ecdh_resp,100
-hsm_ecdh_resp,0,ss,32
+hsm_ecdh_resp,0,ss,struct secret
 
 hsm_cannouncement_sig_req,2
 hsm_cannouncement_sig_req,0,bitcoin_id,struct pubkey

--- a/lightningd/hsm/hsm_wire.csv
+++ b/lightningd/hsm/hsm_wire.csv
@@ -17,7 +17,7 @@ hsmctl_init,0,new,bool
 
 hsmctl_init_reply,101
 hsmctl_init_reply,0,node_id,33
-hsmctl_init_reply,33,peer_seed,struct privkey
+hsmctl_init_reply,33,peer_seed,struct secret
 hsmctl_init_reply,65,bip32_len,2
 hsmctl_init_reply,67,bip32_seed,bip32_len*u8
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -31,11 +31,11 @@ struct htlc_end {
 
 	/* If we are forwarding, remember the shared secret for an
 	 * eventual reply */
-	struct sha256 *shared_secret;
+	struct secret *shared_secret;
 
 	/* If we are the origin, remember all shared secrets, so we
 	 * can unwrap an eventual reply */
-	struct sha256 *path_secrets;
+	struct secret *path_secrets;
 };
 
 static inline const struct htlc_end *keyof_htlc_end(const struct htlc_end *e)

--- a/lightningd/key_derive.h
+++ b/lightningd/key_derive.h
@@ -3,13 +3,14 @@
 #include "config.h"
 
 struct pubkey;
+struct secret;
 
 /* For `localkey`, `remotekey`, `local-delayedkey` and `remote-delayedkey` */
 bool derive_simple_key(const struct pubkey *basepoint,
 		       const struct pubkey *per_commitment_point,
 		       struct pubkey *key);
 
-bool derive_simple_privkey(const struct privkey *base_secret,
+bool derive_simple_privkey(const struct secret *base_secret,
 			   const struct pubkey *basepoint,
 			   const struct pubkey *per_commitment_point,
 			   struct privkey *key);
@@ -19,8 +20,8 @@ bool derive_revocation_key(const struct pubkey *basepoint,
 			   const struct pubkey *per_commitment_point,
 			   struct pubkey *key);
 
-bool derive_revocation_privkey(const struct privkey *base_secret,
-			       const struct privkey *per_commitment_secret,
+bool derive_revocation_privkey(const struct secret *base_secret,
+			       const struct secret *per_commitment_secret,
 			       const struct pubkey *basepoint,
 			       const struct pubkey *per_commitment_point,
 			       struct privkey *key);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -33,7 +33,7 @@ struct lightningd {
 	/* All peers we're tracking. */
 	struct list_head peers;
 	/* FIXME: This should stay in HSM */
-	struct privkey peer_seed;
+	struct secret peer_seed;
 	/* Used to give a unique seed to every peer. */
 	u64 peer_counter;
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -163,7 +163,7 @@ static void json_sendpay(struct command *cmd,
 	u64 amount, lastamount;
 	struct onionpacket *packet;
 	u8 *msg;
-	struct sha256 *path_secrets;
+	struct secret *path_secrets;
 
 	if (!json_get_params(buffer, params,
 			     "route", &routetok,

--- a/lightningd/sphinx.h
+++ b/lightningd/sphinx.h
@@ -87,7 +87,7 @@ struct onionpacket *create_onionpacket(
 	const u8 * sessionkey,
 	const u8 *assocdata,
 	const size_t assocdatalen,
-	struct sha256 **path_secrets
+	struct secret **path_secrets
 	);
 
 /**
@@ -162,7 +162,8 @@ struct onionreply {
  *     HMAC
  * @failure_msg: message (must support tal_len)
  */
-u8 *create_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *failure_msg);
+u8 *create_onionreply(const tal_t *ctx, const struct secret *shared_secret,
+		      const u8 *failure_msg);
 
 /**
  * wrap_onionreply - Add another encryption layer to the reply.
@@ -172,7 +173,8 @@ u8 *create_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *failu
  *     encryption.
  * @reply: the reply to wrap
  */
-u8 *wrap_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *reply);
+u8 *wrap_onionreply(const tal_t *ctx, const struct secret *shared_secret,
+		    const u8 *reply);
 
 /**
  * unwrap_onionreply - Remove layers, check integrity and parse reply
@@ -182,7 +184,8 @@ u8 *wrap_onionreply(const tal_t *ctx, const u8 *shared_secret, const u8 *reply);
  * @numhops: path length and number of shared_secrets provided
  * @reply: the incoming reply
  */
-struct onionreply *unwrap_onionreply(const tal_t *ctx, u8 **shared_secrets,
+struct onionreply *unwrap_onionreply(const tal_t *ctx,
+				     const struct secret *shared_secrets,
 				     const int numhops, const u8 *reply);
 
 #endif /* LIGHTNING_DAEMON_SPHINX_H */

--- a/lightningd/test/run-cryptomsg.c
+++ b/lightningd/test/run-cryptomsg.c
@@ -59,20 +59,20 @@ static struct io_plan *check_msg_read(struct io_conn *conn, struct peer *peer,
 	return NULL;
 }
 
-static struct sha256 sha256_from_hex(const char *hex)
+static struct secret secret_from_hex(const char *hex)
 {
-	struct sha256 sha256;
+	struct secret secret;
 	hex += 2;
-	if (!hex_decode(hex, strlen(hex), &sha256, sizeof(sha256)))
+	if (!hex_decode(hex, strlen(hex), &secret, sizeof(secret)))
 		abort();
-	return sha256;
+	return secret;
 }
 
 int main(void)
 {
 	tal_t *tmpctx = tal_tmpctx(NULL);
 	struct peer_crypto_state cs_out, cs_in;
-	struct sha256 sk, rk, ck;
+	struct secret sk, rk, ck;
 	const void *msg = tal_dup_arr(tmpctx, char, "hello", 5, 0);
 	size_t i;
 
@@ -89,9 +89,9 @@ int main(void)
 	 * # HKDF(0x919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01,zero)
 	 * output: sk,rk=0x969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9,0xbb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442
 	 */
-	ck = sha256_from_hex("0x919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01");
-	sk = sha256_from_hex("0x969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9");
-	rk = sha256_from_hex("0xbb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442");
+	ck = secret_from_hex("0x919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01");
+	sk = secret_from_hex("0x969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9");
+	rk = secret_from_hex("0xbb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442");
 
 	cs_out.cs.sn = cs_out.cs.rn = cs_in.cs.sn = cs_in.cs.rn = 0;
 	cs_out.cs.sk = cs_in.cs.rk = sk;

--- a/type_to_string.h
+++ b/type_to_string.h
@@ -21,6 +21,7 @@ union printable_types {
 	const secp256k1_pubkey *secp256k1_pubkey;
 	const struct channel_id *channel_id;
 	const struct short_channel_id *short_channel_id;
+	const struct secret *secret;
 	const struct privkey *privkey;
 	const secp256k1_ecdsa_signature *secp256k1_ecdsa_signature;
 	const struct channel *channel;

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -106,9 +106,14 @@ void fromwire_pubkey(const u8 **cursor, size_t *max, struct pubkey *pubkey)
 		fail_pull(cursor, max);
 }
 
+void fromwire_secret(const u8 **cursor, size_t *max, struct secret *secret)
+{
+	fromwire(cursor, max, secret->data, sizeof(secret->data));
+}
+
 void fromwire_privkey(const u8 **cursor, size_t *max, struct privkey *privkey)
 {
-	fromwire(cursor, max, privkey->secret, sizeof(privkey->secret));
+	fromwire_secret(cursor, max, &privkey->secret);
 }
 
 void fromwire_secp256k1_ecdsa_signature(const u8 **cursor,

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -58,9 +58,14 @@ void towire_pubkey(u8 **pptr, const struct pubkey *pubkey)
 	towire(pptr, output, outputlen);
 }
 
+void towire_secret(u8 **pptr, const struct secret *secret)
+{
+	towire(pptr, secret->data, sizeof(secret->data));
+}
+
 void towire_privkey(u8 **pptr, const struct privkey *privkey)
 {
-	towire(pptr, privkey->secret, sizeof(privkey->secret));
+	towire_secret(pptr, &privkey->secret);
 }
 
 void towire_secp256k1_ecdsa_signature(u8 **pptr,

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -31,6 +31,7 @@ int fromwire_peektype(const u8 *cursor);
 void towire(u8 **pptr, const void *data, size_t len);
 void towire_pubkey(u8 **pptr, const struct pubkey *pubkey);
 void towire_privkey(u8 **pptr, const struct privkey *privkey);
+void towire_secret(u8 **pptr, const struct secret *secret);
 void towire_secp256k1_ecdsa_signature(u8 **pptr,
 			      const secp256k1_ecdsa_signature *signature);
 void towire_channel_id(u8 **pptr, const struct channel_id *channel_id);
@@ -55,6 +56,7 @@ u16 fromwire_u16(const u8 **cursor, size_t *max);
 u32 fromwire_u32(const u8 **cursor, size_t *max);
 u64 fromwire_u64(const u8 **cursor, size_t *max);
 bool fromwire_bool(const u8 **cursor, size_t *max);
+void fromwire_secret(const u8 **cursor, size_t *max, struct secret *secret);
 void fromwire_privkey(const u8 **cursor, size_t *max, struct privkey *privkey);
 void fromwire_pubkey(const u8 **cursor, size_t *max, struct pubkey *pubkey);
 void fromwire_secp256k1_ecdsa_signature(const u8 **cursor, size_t *max,


### PR DESCRIPTION
We alternated between using a sha256 and using a privkey, but there are
numerous places where we have a random 32 bytes which are neither.

This fixes many of them (plus, struct privkey is now defined in terms of
struct secret).

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>