### PR TITLE
Routing node announcements

### DIFF
--- a/daemon/irc_announce.c
+++ b/daemon/irc_announce.c
@@ -177,9 +177,7 @@ static void handle_irc_node_announcement(
 	char **splits)
 {
 	struct pubkey *pk = talz(msg, struct pubkey);
-	char *hostname = tal_strdup(msg, splits[2]);
-	int port = atoi(splits[3]);
-	if (!pubkey_from_hexstr(splits[1], strlen(splits[1]), pk) || port < 1)
+	if (!pubkey_from_hexstr(splits[1], strlen(splits[1]), pk))
 		return;
 
 	if (!verify_signed_privmsg(istate, pk, msg)) {
@@ -191,7 +189,7 @@ static void handle_irc_node_announcement(
 			splits[1]);
 	}
 
-	struct node *node = add_node(istate->dstate->rstate, pk, hostname, port);
+	struct node *node = add_node(istate->dstate->rstate, pk);
 	if (splits[4] != NULL){
 		tal_free(node->alias);
 		node->alias = tal_hexdata(node, splits[4], strlen(splits[4]));
@@ -233,8 +231,7 @@ static void handle_irc_command(struct ircstate *istate, const struct irccommand 
 		log_debug(dstate->base_log, "Detected my own IP as %s", dstate->external_ip);
 
 		// Add our node to the node_map for completeness
-		add_node(istate->dstate->rstate, &dstate->id,
-			 dstate->external_ip, dstate->portnum);
+		add_node(istate->dstate->rstate, &dstate->id);
 	} else if (streq(cmd->command, "JOIN")) {
 		unsigned int delay;
 

--- a/daemon/json.c
+++ b/daemon/json.c
@@ -1,5 +1,6 @@
 /* JSON core and helpers */
 #include "json.h"
+#include <arpa/inet.h>
 #include <assert.h>
 #include <ccan/build_assert/build_assert.h>
 #include <ccan/str/hex/hex.h>
@@ -451,6 +452,25 @@ void json_add_short_channel_id(struct json_result *response,
 {
 	char *str = tal_fmt(response, "%d:%d:%d", id->blocknum, id->txnum, id->outnum);
 	json_add_string(response, fieldname, str);
+}
+
+void json_add_address(struct json_result *response, const char *fieldname,
+		      const struct ipaddr *addr)
+{
+	json_object_start(response, fieldname);
+	char *addrstr = tal_arr(response, char, INET6_ADDRSTRLEN);
+	if (addr->type == ADDR_TYPE_IPV4) {
+		inet_ntop(AF_INET, addr->addr, addrstr, INET_ADDRSTRLEN);
+		json_add_string(response, "type", "ipv4");
+		json_add_string(response, "address", addrstr);
+		json_add_num(response, "port", addr->port);
+	} else if (addr->type == ADDR_TYPE_IPV6) {
+		inet_ntop(AF_INET6, addr->addr, addrstr, INET6_ADDRSTRLEN);
+		json_add_string(response, "type", "ipv6");
+		json_add_string(response, "address", addrstr);
+		json_add_num(response, "port", addr->port);
+	}
+	json_object_end(response);
 }
 
 void json_add_object(struct json_result *result, ...)

--- a/daemon/json.h
+++ b/daemon/json.h
@@ -112,6 +112,10 @@ void json_add_short_channel_id(struct json_result *response,
 			       const char *fieldname,
 			       const struct short_channel_id *id);
 
+/* JSON serialize a network address for a node */
+void json_add_address(struct json_result *response, const char *fieldname,
+		      const struct ipaddr *addr);
+
 void json_add_object(struct json_result *result, ...);
 
 const char *json_result_string(const struct json_result *result);

--- a/daemon/lightningd.h
+++ b/daemon/lightningd.h
@@ -7,6 +7,7 @@
 #include <ccan/short_types/short_types.h>
 #include <ccan/timer/timer.h>
 #include <stdio.h>
+#include <wire/wire.h>
 
 /* Various adjustable things. */
 struct config {
@@ -58,6 +59,9 @@ struct config {
 
 	/* Whether to ignore database version. */
 	bool db_version_ignore;
+
+	/* IPv4 or IPv6 address to announce to the network */
+	struct ipaddr ipaddr;
 };
 
 /* Here's where the global variables hide! */

--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -78,6 +78,7 @@ struct node *new_node(struct routing_state *rstate,
 	n->alias = NULL;
 	n->hostname = NULL;
 	n->node_announcement = NULL;
+	n->last_timestamp = 0;
 	node_map_add(rstate->nodes, n);
 	tal_add_destructor(n, destroy_node);
 

--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -74,9 +74,7 @@ struct node *new_node(struct routing_state *rstate,
 	n->id = *id;
 	n->in = tal_arr(n, struct node_connection *, 0);
 	n->out = tal_arr(n, struct node_connection *, 0);
-	n->port = 0;
 	n->alias = NULL;
-	n->hostname = NULL;
 	n->node_announcement = NULL;
 	n->last_timestamp = 0;
 	n->addresses = tal_arr(n, struct ipaddr, 0);
@@ -88,9 +86,7 @@ struct node *new_node(struct routing_state *rstate,
 
 struct node *add_node(
 	struct routing_state *rstate,
-	const struct pubkey *pk,
-	char *hostname,
-	int port)
+	const struct pubkey *pk)
 {
 	struct node *n = get_node(rstate, pk);
 	if (!n) {
@@ -101,8 +97,6 @@ struct node *add_node(
 		log_debug_struct(rstate->base_log, "Update existing node %s",
 				 struct pubkey, pk);
 	}
-	n->hostname = tal_steal(n, hostname);
-	n->port = port;
 	return n;
 }
 
@@ -916,13 +910,6 @@ void handle_node_announcement(
 	node->addresses = tal_steal(node, ipaddrs);
 
 	node->last_timestamp = timestamp;
-	node->hostname = tal_free(node->hostname);
-
-	if (!read_ip(node, addresses, &node->hostname, &node->port)) {
-		/* FIXME: SHOULD fail connection here. */
-		tal_free(serialized);
-		return;
-	}
 
 	memcpy(node->rgb_color, rgb_color, 3);
 

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -45,6 +45,7 @@ struct node {
 	struct pubkey id;
 
 	/* IP/Hostname and port of this node (may be NULL) */
+	struct ipaddr *addresses;
 	char *hostname;
 	int port;
 

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -46,8 +46,6 @@ struct node {
 
 	/* IP/Hostname and port of this node (may be NULL) */
 	struct ipaddr *addresses;
-	char *hostname;
-	int port;
 
 	u32 last_timestamp;
 
@@ -112,9 +110,7 @@ s64 connection_fee(const struct node_connection *c, u64 msatoshi);
 
 /* Updates existing node, or creates a new one as required. */
 struct node *add_node(struct routing_state *rstate,
-		      const struct pubkey *pk,
-		      char *hostname,
-		      int port);
+		      const struct pubkey *pk);
 
 /* Updates existing connection, or creates new one as required. */
 struct node_connection *add_connection(struct routing_state *rstate,

--- a/daemon/routingrpc.c
+++ b/daemon/routingrpc.c
@@ -136,6 +136,7 @@ static void json_getnodes(struct command *cmd,
 	struct json_result *response = new_json_result(cmd);
 	struct node *n;
 	struct node_map_iter i;
+	size_t j;
 
 	n = node_map_first(cmd->dstate->rstate->nodes, &i);
 
@@ -145,12 +146,11 @@ static void json_getnodes(struct command *cmd,
 	while (n != NULL) {
 		json_object_start(response, NULL);
 		json_add_pubkey(response, "nodeid", &n->id);
-		json_add_num(response, "port", n->port);
-		if (!n->port)
-			json_add_null(response, "hostname");
-		else
-			json_add_string(response, "hostname", n->hostname);
-
+		json_array_start(response, "addresses");
+		for (j=0; j<tal_count(n->addresses); j++) {
+			json_add_address(response, NULL, &n->addresses[j]);
+		}
+		json_array_end(response);
 		json_object_end(response);
 		n = node_map_next(cmd->dstate->rstate->nodes, &i);
 	}

--- a/lightningd/channel/channel_wire.csv
+++ b/lightningd/channel/channel_wire.csv
@@ -117,3 +117,5 @@ channel_ping,0,len,u16
 channel_ping_reply,111
 channel_ping_reply,0,totlen,u16
 
+# Channeld tells the master that the channel has been announced
+channel_announced,12

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -572,6 +572,7 @@ static struct io_plan *getnodes(struct io_conn *conn, struct daemon *daemon)
 		nodes[node_count].nodeid = n->id;
 		nodes[node_count].hostname = n->hostname;
 		nodes[node_count].port = n->port;
+		nodes[node_count].addresses = n->addresses;
 		node_count++;
 		n = node_map_next(daemon->rstate->nodes, &i);
 	}

--- a/lightningd/gossip/gossip.c
+++ b/lightningd/gossip/gossip.c
@@ -570,8 +570,6 @@ static struct io_plan *getnodes(struct io_conn *conn, struct daemon *daemon)
 	while (n != NULL) {
 		tal_resize(&nodes, node_count + 1);
 		nodes[node_count].nodeid = n->id;
-		nodes[node_count].hostname = n->hostname;
-		nodes[node_count].port = n->port;
 		nodes[node_count].addresses = n->addresses;
 		node_count++;
 		n = node_map_next(daemon->rstate->nodes, &i);

--- a/lightningd/gossip/gossip_wire.csv
+++ b/lightningd/gossip/gossip_wire.csv
@@ -98,3 +98,9 @@ gossip_resolve_channel_request,0,channel_id,struct short_channel_id
 gossip_resolve_channel_reply,109
 gossip_resolve_channel_reply,0,num_keys,u16
 gossip_resolve_channel_reply,0,keys,num_keys*struct pubkey
+
+# The main daemon forward some gossip message to gossipd, allows injecting
+# arbitrary gossip messages.
+gossip_forwarded_msg,10
+gossip_forwarded_msg,0,msglen,2
+gossip_forwarded_msg,2,msg,msglen

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -198,7 +198,7 @@ static bool json_getnodes_reply(struct subd *gossip, const u8 *reply,
 {
 	struct gossip_getnodes_entry *nodes;
 	struct json_result *response = new_json_result(cmd);
-	size_t i;
+	size_t i, j;
 
 	if (!fromwire_gossip_getnodes_reply(reply, reply, NULL, &nodes)) {
 		command_fail(cmd, "Malformed gossip_getnodes response");
@@ -211,12 +211,11 @@ static bool json_getnodes_reply(struct subd *gossip, const u8 *reply,
 	for (i = 0; i < tal_count(nodes); i++) {
 		json_object_start(response, NULL);
 		json_add_pubkey(response, "nodeid", &nodes[i].nodeid);
-		if (tal_len(nodes[i].hostname) > 0) {
-			json_add_string(response, "hostname", nodes[i].hostname);
-		} else {
-			json_add_null(response, "hostname");
+		json_array_start(response, "addresses");
+		for (j=0; j<tal_count(nodes[i].addresses); j++) {
+			json_add_address(response, NULL, &nodes[i].addresses[j]);
 		}
-		json_add_num(response, "port", nodes[i].port);
+		json_array_end(response);
 		json_object_end(response);
 	}
 	json_array_end(response);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -148,6 +148,7 @@ static int gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIP_GETCHANNELS_REQUEST:
 	case WIRE_GOSSIP_PING:
 	case WIRE_GOSSIP_RESOLVE_CHANNEL_REQUEST:
+	case WIRE_GOSSIP_FORWARDED_MSG:
 	/* This is a reply, so never gets through to here. */
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIP_GETNODES_REPLY:

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -3,7 +3,6 @@
 
 void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max, struct gossip_getnodes_entry *entry)
 {
-	u8 hostnamelen;
 	u8 numaddresses, i;
 	fromwire_pubkey(pptr, max, &entry->nodeid);
 	numaddresses = fromwire_u8(pptr, max);
@@ -12,15 +11,9 @@ void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *m
 	for (i=0; i<numaddresses; i++) {
 		fromwire_ipaddr(pptr, max, entry->addresses);
 	}
-
-	hostnamelen = fromwire_u8(pptr, max);
-	entry->hostname = tal_arr(ctx, char, hostnamelen);
-	fromwire_u8_array(pptr, max, (u8*)entry->hostname, hostnamelen);
-	entry->port = fromwire_u16(pptr, max);
 }
 void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry)
 {
-	u8 hostnamelen;
 	u8 i, numaddresses = tal_count(entry->addresses);
 	towire_pubkey(pptr, &entry->nodeid);
 	towire_u8(pptr, numaddresses);
@@ -28,17 +21,6 @@ void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry 
 	for (i=0; i<numaddresses; i++) {
 		towire_ipaddr(pptr, &entry->addresses[i]);
 	}
-
-	if (entry->hostname) {
-		hostnamelen = strlen(entry->hostname);
-		towire_u8(pptr, hostnamelen);
-		towire_u8_array(pptr, (u8*)entry->hostname, hostnamelen);
-	}else {
-		/* If we don't have a hostname just write an empty string */
-		hostnamelen = 0;
-		towire_u8(pptr, hostnamelen);
-	}
-	towire_u16(pptr, entry->port);
 }
 
 void fromwire_route_hop(const u8 **pptr, size_t *max, struct route_hop *entry)

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -7,8 +7,6 @@
 struct gossip_getnodes_entry {
 	struct pubkey nodeid;
 	struct ipaddr *addresses;
-	char *hostname;
-	u16 port;
 };
 
 struct gossip_getchannels_entry {

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -6,6 +6,7 @@
 
 struct gossip_getnodes_entry {
 	struct pubkey nodeid;
+	struct ipaddr *addresses;
 	char *hostname;
 	u16 port;
 };

--- a/lightningd/hsm/hsm_wire.csv
+++ b/lightningd/hsm/hsm_wire.csv
@@ -50,3 +50,11 @@ hsmctl_hsmfd_channeld,0,unique_id,8
 
 # Empty reply, just an fd
 hsmctl_hsmfd_channeld_reply,105
+
+# Master asks the HSM to sign a node_announcement
+hsmctl_node_announcement_sig_req,6
+hsmctl_node_announcement_sig_req,0,annlen,2
+hsmctl_node_announcement_sig_req,2,announcement,annlen*u8
+
+hsmctl_node_announcement_sig_reply,106
+hsmctl_node_announcement_sig_reply,0,signature,secp256k1_ecdsa_signature

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -73,12 +73,14 @@ static int hsm_msg(struct subd *hsm, const u8 *msg, const int *fds)
 	case WIRE_HSMCTL_HSMFD_ECDH:
 	case WIRE_HSMCTL_HSMFD_CHANNELD:
 	case WIRE_HSMCTL_SIGN_FUNDING:
+	case WIRE_HSMCTL_NODE_ANNOUNCEMENT_SIG_REQ:
 
 	/* Replies should be paired to individual requests. */
 	case WIRE_HSMCTL_INIT_REPLY:
 	case WIRE_HSMCTL_HSMFD_CHANNELD_REPLY:
 	case WIRE_HSMCTL_HSMFD_ECDH_FD_REPLY:
 	case WIRE_HSMCTL_SIGN_FUNDING_REPLY:
+	case WIRE_HSMCTL_NODE_ANNOUNCEMENT_SIG_REPLY:
 		errx(1, "HSM gave invalid message %s", hsm_wire_type_name(t));
 	}
 	return 0;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1259,11 +1259,14 @@ static u8 *create_node_announcement(const tal_t *ctx, struct lightningd *ld,
 	u8 rgb[3] = {0x77, 0x88, 0x99};
 	u8 alias[32];
 	u8 *features = NULL;
-	u8 *addresses = NULL;
+	u8 *addresses = tal_arr(ctx, u8, 0);
 	u8 *announcement;
 	if (!sig) {
 		sig = tal(ctx, secp256k1_ecdsa_signature);
 		memset(sig, 0, sizeof(*sig));
+	}
+	if (ld->dstate.config.ipaddr.type != ADDR_TYPE_PADDING) {
+		towire_ipaddr(&addresses, &ld->dstate.config.ipaddr);
 	}
 	memset(alias, 0, sizeof(alias));
 	announcement =

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -165,9 +165,27 @@ void fromwire_preimage(const u8 **cursor, size_t *max, struct preimage *preimage
 	fromwire(cursor, max, preimage, sizeof(*preimage));
 }
 
-void fromwire_ipv6(const u8 **cursor, size_t *max, struct ipv6 *ipv6)
+void fromwire_ipaddr(const u8 **cursor, size_t *max, struct ipaddr *addr)
 {
-	fromwire(cursor, max, ipv6, sizeof(*ipv6));
+	/* Skip any eventual padding */
+	while (**cursor == 0) {
+		*cursor += 1;
+	}
+
+	addr->type = **cursor;
+	switch (addr->type) {
+	case 1:
+		addr->addrlen = 4;
+		break;
+	case 2:
+		addr->addrlen = 16;
+		break;
+	default:
+		fail_pull(cursor, max);
+		return;
+	}
+	fromwire(cursor, max, addr->addr, addr->addrlen);
+	addr->port = fromwire_u16(cursor, max);
 }
 
 void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num)

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -173,6 +173,7 @@ void fromwire_ipaddr(const u8 **cursor, size_t *max, struct ipaddr *addr)
 	}
 
 	addr->type = **cursor;
+	*cursor += 1;
 	switch (addr->type) {
 	case 1:
 		addr->addrlen = 4;

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -109,9 +109,11 @@ void towire_preimage(u8 **pptr, const struct preimage *preimage)
 	towire(pptr, preimage, sizeof(*preimage));
 }
 
-void towire_ipv6(u8 **pptr, const struct ipv6 *ipv6)
+void towire_ipaddr(u8 **pptr, const struct ipaddr *addr)
 {
-	towire(pptr, ipv6, sizeof(*ipv6));
+	towire_u8(pptr, addr->type);
+	towire(pptr, addr->addr, addr->addrlen);
+	towire_u16(pptr, addr->port);
 }
 
 void towire_u8_array(u8 **pptr, const u8 *arr, size_t num)

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -17,9 +17,26 @@ struct short_channel_id {
 struct channel_id {
 	u8 id[32];
 };
-struct ipv6 {
-	u8 addr[16];
+
+/* Address types as defined in the lightning specification. Does not
+ * match AF_INET and AF_INET6 so we just define our
+ * own. ADDR_TYPE_PADDING is also used to signal in the config whether
+ * an address is defined at all. */
+enum wire_addr_type {
+	ADDR_TYPE_PADDING = 0,
+	ADDR_TYPE_IPV4 = 1,
+	ADDR_TYPE_IPV6 = 2,
 };
+
+/* FIXME(cdecker) Extend this once we have defined how TOR addresses
+ * should look like */
+struct ipaddr {
+	enum wire_addr_type type;
+	u8 addrlen;
+	u8 addr[16];
+	u16 port;
+};
+
 struct preimage;
 
 void derive_channel_id(struct channel_id *channel_id,
@@ -40,7 +57,7 @@ void towire_short_channel_id(u8 **pptr,
 void towire_sha256(u8 **pptr, const struct sha256 *sha256);
 void towire_sha256_double(u8 **pptr, const struct sha256_double *sha256d);
 void towire_preimage(u8 **pptr, const struct preimage *preimage);
-void towire_ipv6(u8 **pptr, const struct ipv6 *ipv6);
+void towire_ipaddr(u8 **pptr, const struct ipaddr *addr);
 void towire_u8(u8 **pptr, u8 v);
 void towire_u16(u8 **pptr, u16 v);
 void towire_u32(u8 **pptr, u32 v);
@@ -69,7 +86,7 @@ void fromwire_sha256(const u8 **cursor, size_t *max, struct sha256 *sha256);
 void fromwire_sha256_double(const u8 **cursor, size_t *max,
 			    struct sha256_double *sha256d);
 void fromwire_preimage(const u8 **cursor, size_t *max, struct preimage *preimage);
-void fromwire_ipv6(const u8 **cursor, size_t *max, struct ipv6 *ipv6);
+void fromwire_ipaddr(const u8 **cursor, size_t *max, struct ipaddr *addr);
 void fromwire_pad(const u8 **cursor, size_t *max, size_t num);
 
 void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num);


### PR DESCRIPTION
Implement node announcements in the gossip protocol. `channeld` notifies the master daemon that it has announced its channel. The master daemon can then proceed to announce the node. This is necessary since peers will not accept node announcements if they do not know a channel for that node.

Placing this in the master daemon in order not to have to pass down all the information to a subdaemon. We could move it down to `gossipd`, however that would also require adding a new connection to the HSM from gossip to get the signatures.

We currently don't have a good way to detect our external IP. We used to use the IRC connection to retrieve it, but I'd like to retire IRC soonish. Speaking of which, I didn't bother to parse `struct ipaddr`s for announcements on IRC, since I think it'll go down soon with the removal of the legacy daemon.

Besides the raw routing implementation, this PR also adds the multiple addresses return for `getnodes` and cleans up the single hostname + port handling we had before. Makes the JSON-RPC a bit less easy to use since we now need to look for `ipv4` or `ipv6` in a list of addresses, but it reflects the routing protocol better.