### PR TITLE
Minor fixes

### DIFF
--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -170,16 +170,6 @@ static u8 *stack_number(const tal_t *ctx, unsigned int num)
 	return tal_dup_arr(ctx, u8, &val, 1, 0);
 }
 
-/* Is a < b? (If equal we don't care) */
-static bool key_less(const struct pubkey *a, const struct pubkey *b)
-{
-	u8 a_der[PUBKEY_DER_LEN], b_der[PUBKEY_DER_LEN];
-	pubkey_to_der(a_der, a);
-	pubkey_to_der(b_der, b);
-
-	return memcmp(a_der, b_der, sizeof(a_der)) < 0;
-}
-
 /* tal_count() gives the length of the script. */
 u8 *bitcoin_redeem_2of2(const tal_t *ctx,
 			const struct pubkey *key1,
@@ -187,7 +177,7 @@ u8 *bitcoin_redeem_2of2(const tal_t *ctx,
 {
 	u8 *script = tal_arr(ctx, u8, 0);
 	add_number(&script, 2);
-	if (key_less(key1, key2)) {
+	if (pubkey_cmp(key1, key2) < 0) {
 		add_push_key(&script, key1);
 		add_push_key(&script, key2);
 	} else {
@@ -354,7 +344,7 @@ u8 **bitcoin_witness_2of2(const tal_t *ctx,
 	witness[0] = stack_number(witness, 0);
 
 	/* sig order should match key order. */
-	if (key_less(key1, key2)) {
+	if (pubkey_cmp(key1, key2) < 0) {
 		witness[1] = stack_sig(witness, sig1);
 		witness[2] = stack_sig(witness, sig2);
 	} else {

--- a/daemon/bitcoind.c
+++ b/daemon/bitcoind.c
@@ -131,7 +131,6 @@ static void bcli_finished(struct io_conn *conn, struct bitcoin_cli *bcli)
 	} else
 		*bcli->exitstatus = WEXITSTATUS(status);
 
-	log_debug(bitcoind->log, "reaped %u: %s", ret, bcli_args(bcli));
 	bitcoind->req_running = false;
 	bcli->process(bcli);
 
@@ -149,8 +148,6 @@ static void next_bcli(struct bitcoind *bitcoind)
 	bcli = list_pop(&bitcoind->pending, struct bitcoin_cli, list);
 	if (!bcli)
 		return;
-
-	log_debug(bcli->bitcoind->log, "starting: %s", bcli_args(bcli));
 
 	bcli->pid = pipecmdarr(&bcli->fd, NULL, &bcli->fd, bcli->args);
 	if (bcli->pid < 0)
@@ -296,6 +293,7 @@ void bitcoind_sendrawtx_(struct peer *peer,
 				    int exitstatus, const char *msg, void *),
 			 void *arg)
 {
+	log_debug(bitcoind->log, "sendrawtransaction: %s", hextx);
 	start_bitcoin_cli(bitcoind, NULL, process_sendrawtx, true, cb, arg,
 			  "sendrawtransaction", hextx, NULL);
 }
@@ -309,8 +307,6 @@ static void process_chaintips(struct bitcoin_cli *bcli)
 	void (*cb)(struct bitcoind *bitcoind,
 		   struct sha256_double *tipid,
 		   void *arg) = bcli->cb;
-
-	log_debug(bcli->bitcoind->log, "Got getchaintips result");
 
 	tokens = json_parse_input(bcli->output, bcli->output_bytes, &valid);
 	if (!tokens)

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -130,6 +130,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dstate.announce = NULL;
 	ld->topology = ld->dstate.topology = new_topology(ld, ld->log);
 	ld->bitcoind = ld->dstate.bitcoind = new_bitcoind(ld, ld->log);
+	ld->bitcoind->testmode = ld->dstate.testnet?BITCOIND_TESTNET:BITCOIND_MAINNET;
 
 	/* FIXME: Move into invoice daemon. */
 	ld->dstate.invoices = invoices_init(&ld->dstate);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -128,8 +128,6 @@ class BaseLightningDTests(unittest.TestCase):
         self.node_factory = NodeFactory(self, self.executor)
 
     def getValgrindErrors(self, node):
-        if not VALGRIND:
-            return None, None
         error_file = '{}valgrind-errors'.format(node.daemon.lightning_dir)
         with open(error_file, 'r') as f:
             errors = f.read().strip()
@@ -147,12 +145,15 @@ class BaseLightningDTests(unittest.TestCase):
     def tearDown(self):
         self.node_factory.killall()
         self.executor.shutdown(wait=False)
-        err_count = 0
-        for node in self.node_factory.nodes:
-            err_count += self.printValgrindErrors(node)
-        if err_count:
-            raise ValueError(
-                "{} nodes reported valgrind errors".format(err_count))
+
+        # Do not check for valgrind error files if it is disabled
+        if VALGRIND:
+            err_count = 0
+            for node in self.node_factory.nodes:
+                err_count += self.printValgrindErrors(node)
+            if err_count:
+                raise ValueError(
+                    "{} nodes reported valgrind errors".format(err_count))
 
 class LightningDTests(BaseLightningDTests):
     def connect(self):


### PR DESCRIPTION
Some minor fixes I had laying around:

 - Don't even check for `valgrind` logs if we didn't start it
 - Respect the `testnet` flag set in the config
 - Deduplicate pubkey comparison
 - Remove logs for spawning and reaping subdaemons (they are quite noisy)