### PR TITLE
fix: Correctly serialize/deserialize short_channel_ids

### DIFF
--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -158,7 +158,7 @@ struct node_connection *get_connection_by_scid(const struct routing_state *rstat
 	        num_conn = tal_count(n->out);
 		for (i = 0; i < num_conn; i++){
 			c = n->out[i];
-			if (structeq(&c->short_channel_id, schanid) &&
+			if (short_channel_id_eq(&c->short_channel_id, schanid) &&
 			    (c->flags&0x1) == direction)
 			    return c;
 		}

--- a/daemon/routing.h
+++ b/daemon/routing.h
@@ -180,4 +180,7 @@ struct route_hop *get_route(tal_t *ctx, struct routing_state *rstate,
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst);
 
+bool short_channel_id_eq(const struct short_channel_id *a,
+			 const struct short_channel_id *b);
+
 #endif /* LIGHTNING_DAEMON_ROUTING_H */

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -138,15 +138,15 @@ void fromwire_channel_id(const u8 **cursor, size_t *max,
 void fromwire_short_channel_id(const u8 **cursor, size_t *max,
 			       struct short_channel_id *short_channel_id)
 {
-	be32 txnum = 0;
-	u8 outnum;
+	be32 txnum = 0, blocknum = 0;
 
-	short_channel_id->blocknum = fromwire_u32(cursor, max);
 	/* Pulling 3 bytes off wire is tricky; they're big-endian. */
+	fromwire(cursor, max, (char *)&blocknum + 1, 3);
+	short_channel_id->blocknum = be32_to_cpu(blocknum);
 	fromwire(cursor, max, (char *)&txnum + 1, 3);
 	short_channel_id->txnum = be32_to_cpu(txnum);
-	fromwire(cursor, max, &outnum, 1);
-	short_channel_id->outnum = outnum;
+
+	short_channel_id->outnum = fromwire_u16 (cursor, max);
 }
 
 void fromwire_sha256(const u8 **cursor, size_t *max, struct sha256 *sha256)

--- a/wire/peer_wire.c
+++ b/wire/peer_wire.c
@@ -72,3 +72,10 @@ bool unknown_msg_discardable(const u8 *cursor)
 	enum wire_type t = fromwire_peektype(cursor);
 	return unknown_type(t) && (t & 1);
 }
+
+bool short_channel_id_eq(const struct short_channel_id *a,
+			 const struct short_channel_id *b)
+{
+	return a->blocknum == b->blocknum && a->txnum == b->txnum &&
+	       a->outnum == b->outnum;
+}

--- a/wire/peer_wire.h
+++ b/wire/peer_wire.h
@@ -19,4 +19,7 @@ bool unknown_msg_discardable(const u8 *cursor);
 /* Return true if it's a gossip message. */
 bool gossip_msg(u8 *cursor);
 
+/* Compare two short_channel_ids and return true if they are the equal */
+bool short_channel_id_eq(const struct short_channel_id *a,
+			 const struct short_channel_id *b);
 #endif /* LIGHTNING_WIRE_PEER_WIRE_H */

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -87,11 +87,11 @@ void towire_short_channel_id(u8 **pptr,
 			     const struct short_channel_id *short_channel_id)
 {
 	be32 txnum = cpu_to_be32(short_channel_id->txnum);
-	u8 outnum = short_channel_id->outnum;
+	be32 blocknum = cpu_to_be32(short_channel_id->blocknum);
 
-	towire_u32(pptr, short_channel_id->blocknum);
+	towire(pptr, (char *)&blocknum + 1, 3);
 	towire(pptr, (char *)&txnum + 1, 3);
-	towire(pptr, &outnum, 1);
+	towire_u16(pptr, short_channel_id->outnum);
 }
 
 void towire_sha256(u8 **pptr, const struct sha256 *sha256)

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -9,10 +9,15 @@
 #include <ccan/short_types/short_types.h>
 #include <stdlib.h>
 
+/* Short Channel ID is composed of 3 bytes for the block height, 3
+ * bytes of tx index in block and 2 bytes of output index. The
+ * bitfield is mainly for unit tests where it is nice to be able to
+ * just memset them and not have to take care about the extra byte for
+ * u32 */
 struct short_channel_id {
-	u32 blocknum;
+	u32 blocknum : 24;
 	u32 txnum : 24;
-	u8 outnum : 8;
+	u16 outnum;
 };
 struct channel_id {
 	u8 id[32];


### PR DESCRIPTION
Fixes the `short_channel_id` being serialized as 4 bytes block height,
3 bytes transaction index and 1 byte output number, to use 3+3+2 as
the spec says.

The reordering in the unit test structs is mainly to be able to still
use `eq_upto` for tests.

Fixes #169 