### PR TITLE
[WIP] Get new daemon to compile on debian jessie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ WIRE_GEN := tools/generate-wire.py
 PROGRAMS := $(TEST_PROGRAMS)
 
 CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition
-CDEBUGFLAGS := -g -fstack-protector
+CDEBUGFLAGS := -std=gnu11 -g -fstack-protector
 CFLAGS := $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) -I libwally-core/src/secp256k1/include/ -I libwally-core/include/ -I libsodium/src/libsodium/include/ -I . $(FEATURES) $(COVFLAGS) -DSHACHAIN_BITS=48
 
 LDLIBS := -lprotobuf-c -lgmp -lsqlite3 $(COVFLAGS)


### PR DESCRIPTION
@cornwarecjp pointed this one out. Debian jessy cannot currently compile using `make` due to a number of issues. The first one is that it ships with a 4.x gcc version which doesn't default to the `gnu11` standard, fixed by adding `-std=gnu11` to the `CFLAGS`. The other one is that it ships with an older protobuf-c, and we apparently rely on some of the internal enumerations. I don't think we'll fix that since protobufs are only used in the legacy version. I was able to build the new daemon (and dependencies) with the following:

    make daemon/lightning-cli lightningd/lightningd lightningd/lightningd_channel lightningd/lightningd_gossip lightningd/lightningd_handshake lightningd/lightningd_hsm lightningd/lightningd_opening

Notice that `daemon/lightningd` (the legacy daemon) is missing. Also the integration tests will fail since they rely on the legacy daemon being present. We can partially run the tests using 

    PYTHONPATH=contrib/pylightning python3 tests/test_lightningd.py

and ignoring the failed tests for the legacy dameon.

This is work in progress until @cornwarecjp confirms that this is working, so please do not merge :wink: 