### PR TITLE
script: Consolidate scripts to use pubkey_to_hash160

### DIFF
--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -47,13 +47,6 @@ static void hash160(struct ripemd160 *redeemhash, const void *mem, size_t len)
 	ripemd160(redeemhash, h.u.u8, sizeof(h));
 }
 
-static void hash160_key(struct ripemd160 *khash, const struct pubkey *key)
-{
-	u8 der[PUBKEY_DER_LEN];
-	pubkey_to_der(der, key);
-	hash160(khash, der, sizeof(der));
-}
-
 static void add(u8 **scriptp, const void *mem, size_t len)
 {
 	size_t oldlen = tal_count(*scriptp);
@@ -245,7 +238,7 @@ u8 *bitcoin_redeem_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key)
 	/* BIP141: BIP16 redeemScript pushed in the scriptSig is exactly a
 	 * push of a version byte plus a push of a witness program. */
 	add_number(&script, 0);
-	hash160_key(&keyhash, key);
+	pubkey_to_hash160(key, &keyhash);
 	add_push_bytes(&script, &keyhash, sizeof(keyhash));
 	return script;
 }
@@ -313,7 +306,7 @@ u8 *scriptpubkey_p2wpkh(const tal_t *ctx, const struct pubkey *key)
 	u8 *script = tal_arr(ctx, u8, 0);
 
 	add_op(&script, OP_0);
-	hash160_key(&h, key);
+	pubkey_to_hash160(key, &h);
 	add_push_bytes(&script, &h, sizeof(h));
 	return script;
 }
@@ -470,8 +463,8 @@ u8 *p2wpkh_scriptcode(const tal_t *ctx, const struct pubkey *key)
 {
 	struct ripemd160 pkhash;
 	u8 *script = tal_arr(ctx, u8, 0);
+	pubkey_to_hash160(key, &pkhash);
 
-	hash160_key(&pkhash, key);
 	/* BIP143:
 	 *
 	 * For P2WPKH witness program, the scriptCode is
@@ -726,7 +719,7 @@ u8 *bitcoin_wscript_htlc_offer(const tal_t *ctx,
 
 	add_op(&script, OP_DUP);
 	add_op(&script, OP_HASH160);
-	hash160_key(&ripemd, revocationkey);
+	pubkey_to_hash160(revocationkey, &ripemd);
 	add_push_bytes(&script, &ripemd, sizeof(ripemd));
 	add_op(&script, OP_EQUAL);
 	add_op(&script, OP_IF);
@@ -794,7 +787,7 @@ u8 *bitcoin_wscript_htlc_receive(const tal_t *ctx,
 
 	add_op(&script, OP_DUP);
 	add_op(&script, OP_HASH160);
-	hash160_key(&ripemd, revocationkey);
+	pubkey_to_hash160(revocationkey, &ripemd);
 	add_push_bytes(&script, &ripemd, sizeof(ripemd));
 	add_op(&script, OP_EQUAL);
 	add_op(&script, OP_IF);

--- a/daemon/peer.c
+++ b/daemon/peer.c
@@ -203,11 +203,11 @@ struct peer *find_peer(struct lightningd_state *dstate, const struct pubkey *id)
 struct peer *find_peer_by_pkhash(struct lightningd_state *dstate, const u8 *pkhash)
 {
 	struct peer *peer;
-	u8 addr[20];
+	struct ripemd160 addr;
 
 	list_for_each(&dstate->peers, peer, list) {
-		pubkey_hash160(addr, peer->id);
-		if (memcmp(addr, pkhash, sizeof(addr)) == 0)
+		pubkey_to_hash160(peer->id, &addr);
+		if (memcmp(&addr, pkhash, sizeof(addr)) == 0)
 			return peer;
 	}
 	return NULL;

--- a/daemon/sphinx.h
+++ b/daemon/sphinx.h
@@ -133,8 +133,4 @@ struct onionpacket *parse_onionpacket(
 	const size_t srclen
 	);
 
-void pubkey_hash160(
-	u8 *dst,
-	const struct pubkey *pubkey);
-
 #endif /* LIGHTNING_DAEMON_SPHINX_H */

--- a/lightningd/sphinx.c
+++ b/lightningd/sphinx.c
@@ -236,26 +236,6 @@ bool onion_shared_secret(
 				    privkey->secret.data);
 }
 
-void pubkey_hash160(
-	u8 *dst,
-	const struct pubkey *pubkey)
-{
-	struct ripemd160 r;
-	struct sha256 h;
-	u8 der[33];
-	size_t outputlen = 33;
-
-	secp256k1_ec_pubkey_serialize(secp256k1_ctx,
-				      der,
-				      &outputlen,
-				      &pubkey->pubkey,
-				      SECP256K1_EC_COMPRESSED);
-	sha256(&h, der, sizeof(der));
-	ripemd160(&r, h.u.u8, sizeof(h));
-
-	memcpy(dst, r.u.u8, sizeof(r));
-}
-
 static void generate_key_set(const u8 secret[SHARED_SECRET_SIZE],
 			     struct keyset *keys)
 {

--- a/lightningd/sphinx.h
+++ b/lightningd/sphinx.h
@@ -156,10 +156,6 @@ struct onionpacket *parse_onionpacket(
 	const size_t srclen
 	);
 
-void pubkey_hash160(
-	u8 *dst,
-	const struct pubkey *pubkey);
-
 struct onionreply {
 	/* Node index in the path that is replying */
 	int origin_index;


### PR DESCRIPTION
Had this cleanup laying around for a while. It removes some duplicate functionality from sphinx, script and peer.