### PR TITLE
peer: Check localfeatures and globalfeatures against what we support

### DIFF
--- a/lightningd/new_connection.c
+++ b/lightningd/new_connection.c
@@ -1,5 +1,5 @@
-#include <ccan/fdpass/fdpass.h>
 #include <ccan/array_size/array_size.h>
+#include <ccan/fdpass/fdpass.h>
 #include <ccan/tal/str/str.h>
 #include <daemon/jsonrpc.h>
 #include <daemon/log.h>

--- a/lightningd/new_connection.c
+++ b/lightningd/new_connection.c
@@ -111,7 +111,7 @@ static bool requires_unsupported_features(const u8 *bitmap,
 		}
 
 		/* Cancel out supported bits, check for even bits */
-		if ((~support & bitmap[i]) & 0xAA)
+		if ((~support & bitmap[i]) & 0x55)
 			return true;
 	}
 	return false;


### PR DESCRIPTION
We support a number of features already, so failing connections
whenever we see an even bit set is not a good idea. This turned out to
kill our connections to eclair.