### PR TITLE
fix: Allow pings while waiting for the channel to lock

### DIFF
--- a/lightningd/channel/channel.c
+++ b/lightningd/channel/channel.c
@@ -1281,7 +1281,8 @@ static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
 		if (type != WIRE_FUNDING_LOCKED
 		    && type != WIRE_CHANNEL_ANNOUNCEMENT
 		    && type != WIRE_CHANNEL_UPDATE
-		    && type != WIRE_NODE_ANNOUNCEMENT) {
+		    && type != WIRE_NODE_ANNOUNCEMENT
+		    && type != WIRE_PING) {
 			peer_failed(io_conn_fd(peer->peer_conn),
 				    &peer->pcs.cs,
 				    &peer->channel_id,


### PR DESCRIPTION
This was causing failures on testnet where confirmations are not
immediate.

Reported-by: Fabrice Drouin @sstone
Signed-off-by: Christian Decker <decker.christian@gmail.com>