### PR TITLE
gossip: Fix crash of getroute if we don't know any channels

### DIFF
--- a/daemon/routing.c
+++ b/daemon/routing.c
@@ -371,6 +371,10 @@ find_route(const tal_t *ctx, struct routing_state *rstate,
 		log_info_struct(rstate->base_log, "find_route: cannot find %s",
 				struct pubkey, to);
 		return NULL;
+	} else if (!dst) {
+		log_info_struct(rstate->base_log, "find_route: cannot find myself (%s)",
+				struct pubkey, to);
+		return NULL;
 	} else if (dst == src) {
 		log_info_struct(rstate->base_log, "find_route: this is %s, refusing to create empty route",
 				struct pubkey, to);


### PR DESCRIPTION
This happens when we either have no channel open, or didn't announce
the channel. This patch just fails the getroute request. I'll later
add the non-broadcast announcement for local channels that should fix
this for unannounced channels.