### PR TITLE
gossip: Use bit 3 (mask 0x08) to signal initial routing sync

### DIFF
--- a/lightningd/handshake/handshake.c
+++ b/lightningd/handshake/handshake.c
@@ -970,7 +970,10 @@ static void exchange_init(int fd, struct crypto_state *cs,
 	 * #9](09-features.md), and MUST set to zero any feature bits that are
 	 * not defined.
 	 */
-	u8 *msg = towire_init(NULL, NULL, NULL);
+	u8 *localfeatures = tal_arrz(NULL, u8, 1);
+	localfeatures[0] = LOCALFEATURES_INITIAL_ROUTING_SYNC;
+	u8 *msg = towire_init(NULL, NULL, localfeatures);
+	localfeatures = tal_free(localfeatures);
 
 	if (!sync_crypto_write(cs, fd, msg))
 		status_failed(WIRE_INITMSG_WRITE_FAILED, "%s", strerror(errno));

--- a/lightningd/new_connection.c
+++ b/lightningd/new_connection.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <wire/wire_sync.h>
 
-const u8 supported_local_features[] = {0x03};
+const u8 supported_local_features[] = {LOCALFEATURES_INITIAL_ROUTING_SYNC};
 const u8 supported_global_features[] = {0x00};
 
 /* Before we have identified the peer, we just have a connection object. */

--- a/wire/peer_wire.h
+++ b/wire/peer_wire.h
@@ -26,7 +26,20 @@ bool is_gossip_msg(const u8 *cursor);
  * of the funding flow wishes to advertise this channel publicly to
  * the network as detailed within [BOLT #7]
  */
-#define CHANNEL_FLAGS_ANNOUNCE_CHANNEL	1
+#define CHANNEL_FLAGS_ANNOUNCE_CHANNEL 1
+
+/* BOLT #7:
+ *
+ * Upon establishing a connection, the two endpoints negotiate whether
+ * to perform an initial sync by setting the `initial_routing_sync`
+ * flags in the `init` message. The endpoint SHOULD set the
+ * `initial_routing_sync` flag if it requires a full copy of the other
+ * endpoint's routing state. Upon receiving an init message with the
+ * `initial_routing_sync` flag set the node sends `channel_announcement`s,
+ * `channel_update`s and `node_announcement`s for all known channels and
+ * nodes as if they were just received.
+ */
+#define LOCALFEATURES_INITIAL_ROUTING_SYNC 0x08
 
 /* Compare two short_channel_ids and return true if they are the equal */
 bool short_channel_id_eq(const struct short_channel_id *a,


### PR DESCRIPTION
After quite some back and forth we seem to finally agree on the bit
3 (mask 0x08) to signal optional `initial_routing_sync`.

I extracted the constant into `peer_wire.h` to make it globally accessible.