### PR TITLE
fix: Only add cli_args if we have some defined

### DIFF
--- a/bitcoin/chainparams.c
+++ b/bitcoin/chainparams.c
@@ -13,7 +13,7 @@ const struct chainparams networks[] = {
 				     0x0a, 0x8c, 0xe2, 0x6f}}},
      .rpc_port = 8332,
      .cli = "bitcoin-cli",
-     .cli_args = "",
+     .cli_args = NULL,
      .dust_limit = 546,
      .testnet = false},
     {.index = 1,

--- a/daemon/bitcoind.c
+++ b/daemon/bitcoind.c
@@ -28,10 +28,13 @@ static char **gather_args(struct bitcoind *bitcoind,
 			  const tal_t *ctx, const char *cmd, va_list ap)
 {
 	size_t n = 0;
-	char **args = tal_arr(ctx, char *, 3);
+	char **args = tal_arr(ctx, char *, 2);
 
 	args[n++] = cast_const(char *, bitcoind->chainparams->cli);
-	args[n++] = cast_const(char *, bitcoind->chainparams->cli_args);
+	if (bitcoind->chainparams->cli_args) {
+		args[n++] = cast_const(char *, bitcoind->chainparams->cli_args);
+		tal_resize(&args, n + 1);
+	}
 
 	if (bitcoind->datadir) {
 		args[n++] = tal_fmt(args, "-datadir=%s", bitcoind->datadir);


### PR DESCRIPTION
This was causing calls to `bitcoin-cli` to fail on mainnet since it
was interpreting the empty string as the RPC method to call.

Fixes #208 