### PR TITLE
Channel persistence strikes back

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -21,6 +21,7 @@
 #include <daemon/options.h>
 #include <daemon/routing.h>
 #include <daemon/timeout.h>
+#include <lightningd/onchain/onchain_wire.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <utils.h>
@@ -265,11 +266,14 @@ int main(int argc, char *argv[])
 
 	/* Load peers from database */
 	wallet_channels_load_active(ld->wallet, &ld->peers);
+
+	/* TODO(cdecker) Move this into common location for initialization */
 	struct peer *peer;
 	list_for_each(&ld->peers, peer, list) {
 		populate_peer(ld, peer);
 		peer->seed = tal(peer, struct privkey);
 		derive_peer_seed(ld, peer->seed, &peer->id, peer->channel->id);
+		peer->htlcs = tal_arr(peer, struct htlc_stub, 0);
 	}
 
 	/* Create RPC socket (if any) */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -267,6 +267,15 @@ int main(int argc, char *argv[])
 		       /* FIXME: Load from peers. */
 		       0);
 
+	/* Load peers from database */
+	wallet_channels_load_active(ld->wallet, &ld->peers);
+	struct peer *peer;
+	list_for_each(&ld->peers, peer, list) {
+		populate_peer(ld, peer);
+		peer->seed = tal(peer, struct privkey);
+		derive_peer_seed(ld, peer->seed, &peer->id);
+	}
+
 	/* Create RPC socket (if any) */
 	setup_jsonrpc(&ld->dstate, ld->dstate.rpc_filename);
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -65,8 +65,23 @@ struct lightningd {
 	const struct chainparams *chainparams;
 };
 
+/**
+ * derive_peer_seed - Generate a unique secret for this peer's channel
+ *
+ * @ld: the lightning daemon to get global secret from
+ * @peer_seed: where to store the generated secret
+ * @peer_id: the id node_id of the remote peer
+ * @chan_id: channel ID
+ *
+ * This method generates a unique secret from the given parameters. It
+ * is important that this secret be unique for each channel, but it
+ * must be reproducible for the same channel in case of
+ * reconnection. We use the DB channel ID to guarantee unique secrets
+ * per channel.
+ */
 void derive_peer_seed(struct lightningd *ld, struct privkey *peer_seed,
-		      const struct pubkey *peer_id);
+		      const struct pubkey *peer_id, const u64 channel_id);
+
 struct peer *find_peer_by_unique_id(struct lightningd *ld, u64 unique_id);
 /* FIXME */
 static inline struct lightningd *

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -433,6 +433,11 @@ static bool peer_reconnected(struct lightningd *ld,
 	log_info(peer->log, "Peer has reconnected, state %s",
 		 peer_state_name(peer->state));
 
+	/* FIXME: Don't assume protocol here! */
+	if (!netaddr_from_fd(fd, SOCK_STREAM, IPPROTO_TCP, &peer->netaddr)) {
+		log_unusual(ld->log, "Failed to get netaddr for peer: %s",
+			    strerror(errno));
+	}
 	/* BOLT #2:
 	 *
 	 * On reconnection, if a channel is in an error state, the node SHOULD

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -541,7 +541,6 @@ static struct wallet_channel *peer_channel_new(struct wallet *w,
 	wc->peer = peer;
 
 	/* TODO(cdecker) See if we already stored this peer in the DB and load if yes */
-	wc->peer_id = 0;
 	wc->id = 0;
 
 	if (!wallet_channel_save(w, wc)) {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -540,7 +540,7 @@ static struct wallet_channel *peer_channel_new(struct wallet *w,
 	struct wallet_channel *wc = tal(peer, struct wallet_channel);
 	wc->peer = peer;
 
-	/* TODO(cdecker) See if we already stored this peer in the DB and load if yes */
+	wallet_peer_by_nodeid(w, &peer->id, peer);
 	wc->id = 0;
 
 	if (!wallet_channel_save(w, wc)) {
@@ -589,6 +589,11 @@ void add_peer(struct lightningd *ld, u64 unique_id,
 	peer->next_htlc_id = 0;
 	peer->htlcs = tal_arr(peer, struct htlc_stub, 0);
 	wallet_shachain_init(ld->wallet, &peer->their_shachain);
+
+	/* If we have the peer in the DB, this'll populate the fields,
+	 * failure just indicates that the peer wasn't found in the
+	 * DB */
+	wallet_peer_by_nodeid(ld->wallet, id, peer);
 
 	/* peer->channel gets populated as soon as we start opening a channel */
 	peer->channel = NULL;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -862,6 +862,7 @@ static void json_getpeers(struct command *cmd,
 		json_add_string(response, "netaddr",
 				netaddr_name(response, &p->netaddr));
 		json_add_pubkey(response, "peerid", &p->id);
+		json_add_bool(response, "connected", p->owner != NULL);
 		if (p->owner)
 			json_add_string(response, "owner", p->owner->name);
 		if (p->scid)

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -20,6 +20,9 @@ struct crypto_state;
 struct peer {
 	struct lightningd *ld;
 
+	/* Database ID of the peer */
+	u64 dbid;
+
 	/* Unique ID of connection (works even if we have multiple to same id) */
 	u64 unique_id;
 

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -158,6 +158,18 @@ void add_peer(struct lightningd *ld, u64 unique_id,
 	      int fd, const struct pubkey *id,
 	      const struct crypto_state *cs);
 
+/**
+ * populate_peer -- Populate daemon fields in a peer
+ *
+ * @ld: the daemon to wire the peer into
+ * @peer: the peer to populate
+ *
+ * Creating a new peer, or loading a peer from the database we need to
+ * populate a number of fields, e.g., the logging handler and the
+ * pointer to the daemon. populate_peer does exactly that.
+ */
+void populate_peer(struct lightningd *ld, struct peer *peer);
+
 /* Could be configurable. */
 #define OUR_CHANNEL_FLAGS CHANNEL_FLAGS_ANNOUNCE_CHANNEL
 

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -98,6 +98,8 @@ struct peer {
 
 	/* FIXME: Just leave this in the db. */
 	struct htlc_stub *htlcs;
+
+	struct wallet_channel *channel;
 };
 
 static inline bool peer_can_add_htlc(const struct peer *peer)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -858,6 +858,35 @@ class LightningDTests(BaseLightningDTests):
         c.execute('SELECT COUNT(*) FROM outputs WHERE status=2')
         assert(c.fetchone()[0] == 2)
 
+    def test_channel_persistence(self):
+        # Start two nodes and open a channel (to remember)
+        l1, l2 = self.connect()
+
+        # Neither node should have a channel open, they are just connected
+        for n in (l1, l2):
+            assert(n.db_query('SELECT COUNT(id) as count FROM channels;')[0]['count'] == 0)
+
+        self.fund_channel(l1, l2, 100000)
+
+        peers = l1.rpc.getpeers()['peers']
+        assert(len(peers) == 1 and peers[0]['state'] == 'CHANNELD_NORMAL')
+
+        # Both nodes should now have exactly one channel in the database
+        for n in (l1, l2):
+            assert(n.db_query('SELECT COUNT(id) as count FROM channels;')[0]['count'] == 1)
+
+        l1.daemon.stop()
+
+        # Let the other side notice, then stop it
+        wait_for(lambda: not l2.rpc.getpeers()['peers'][0]['connected'])
+        l2.daemon.stop()
+
+        # Now restart l1 and it should reload peers/channels from the DB
+        l1.daemon.start()
+
+        #wait_for(lambda: len(l1.rpc.getpeers()['peers']) == 1)
+
+
 class LegacyLightningDTests(BaseLightningDTests):
 
     def test_connect(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -186,7 +186,6 @@ class BitcoinD(TailableProc):
             '-printtoconsole',
             '-server',
             '-regtest',
-            '-debug',
             '-logtimestamps',
             '-nolisten',
         ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,8 +42,6 @@ class TailableProc(object):
     def __init__(self, outputDir=None):
         self.logs = []
         self.logs_cond = threading.Condition(threading.RLock())
-        self.thread = threading.Thread(target=self.tail)
-        self.thread.daemon = True
         self.cmd_line = None
         self.running = False
         self.proc = None
@@ -55,6 +53,8 @@ class TailableProc(object):
         """
         logging.debug("Starting '%s'", " ".join(self.cmd_line))
         self.proc = subprocess.Popen(self.cmd_line, stdout=subprocess.PIPE)
+        self.thread = threading.Thread(target=self.tail)
+        self.thread.daemon = True
         self.thread.start()
         self.running = True
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from lightning import LightningRpc
 import logging
 import os
 import re
+import sqlite3
 import subprocess
 import threading
 import time
@@ -301,3 +302,17 @@ class LightningNode(object):
         self.bitcoin.rpc.generate(6)
         self.daemon.wait_for_log('-> CHANNELD_NORMAL|STATE_NORMAL')
 
+    def db_query(self, query):
+        db = sqlite3.connect(os.path.join(self.daemon.lightning_dir, "lightningd.sqlite3"))
+        db.row_factory = sqlite3.Row
+        c = db.cursor()
+        c.execute(query)
+        rows = c.fetchall()
+
+        result = []
+        for row in rows:
+            result.append(dict(zip(row.keys(), row)))
+
+        c.close()
+        db.close()
+        return result

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -79,7 +79,7 @@ char *dbmigrations[] = {
     ");",
     "CREATE TABLE peers ("
     "  id INTEGER,"
-    "  node_id BLOB," /* pubkey */
+    "  node_id BLOB UNIQUE," /* pubkey */
     "  address TEXT,"
     "  PRIMARY KEY (id)"
     ");",

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -38,7 +38,8 @@ char *dbmigrations[] = {
        hash BLOB,							\
        PRIMARY KEY (shachain_id, pos));",
     "CREATE TABLE channels ("
-    "  id INTEGER," /* unique_id */
+    "  id INTEGER," /* chan->id */
+    "  unique_id INTEGER,"
     "  peer_id INTEGER REFERENCES peers(id) ON DELETE CASCADE,"
     "  short_channel_id BLOB,"
     "  channel_config_local INTEGER,"

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -499,7 +499,7 @@ static bool wallet_stmt2channel(struct wallet *w, sqlite3_stmt *stmt,
 		chan->peer->local_shutdown_idx = sqlite3_column_int64(stmt, col++);
 	} else {
 		chan->peer->remote_shutdown_scriptpubkey = tal_free(chan->peer->remote_shutdown_scriptpubkey);
-		chan->peer->local_shutdown_idx = 0;
+		chan->peer->local_shutdown_idx = -1;
 		col += 2;
 	}
 
@@ -691,7 +691,7 @@ bool wallet_channel_save(struct wallet *w, struct wallet_channel *chan){
 		      "  push_msatoshi=%"PRIu64","
 		      "  msatoshi_local=%s,"
 		      "  shutdown_scriptpubkey_remote='%s',"
-		      "  shutdown_keyidx_local=%"PRIu64","
+		      "  shutdown_keyidx_local=%"PRId64","
 		      "  channel_config_local=%"PRIu64","
 		      "  last_tx=%s, last_sig=%s"
 		      " WHERE id=%"PRIu64,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -550,6 +550,8 @@ static bool wallet_stmt2channel(struct wallet *w, sqlite3_stmt *stmt,
 
 	assert(col == 34);
 
+	chan->peer->channel = chan;
+
 	return ok;
 }
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -243,8 +243,10 @@ bool wallet_shachain_init(struct wallet *wallet, struct wallet_shachain *chain)
 {
 	/* Create shachain */
 	shachain_init(&chain->chain);
-	if (!db_exec(__func__, wallet->db,
-		     "INSERT INTO shachains (min_index, num_valid) VALUES (0,0);")) {
+	if (!db_exec(
+		__func__, wallet->db,
+		"INSERT INTO shachains (min_index, num_valid) VALUES (%"PRIu64",0);",
+		chain->chain.min_index)) {
 		return false;
 	}
 	chain->id = sqlite3_last_insert_rowid(wallet->db->sql);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -184,4 +184,17 @@ bool wallet_channel_config_save(struct wallet *w, struct channel_config *cc);
  */
 bool wallet_channel_config_load(struct wallet *w, const u64 id,
 				struct channel_config *cc);
+
+/**
+ * wallet_peer_by_nodeid -- Given a node_id/pubkey, load the peer from DB
+ *
+ * @w: the wallet to load from
+ * @nodeid: the node_id to search for
+ * @peer(out): the destination where to store the peer
+ *
+ * Returns true on success, or false if we were unable to find a peer
+ * with the given node_id.
+ */
+bool wallet_peer_by_nodeid(struct wallet *w, const struct pubkey *nodeid,
+			   struct peer *peer);
 #endif /* WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -52,7 +52,6 @@ struct wallet_shachain {
 /* TODO(cdecker) Separate peer from channel */
 struct wallet_channel {
 	u64 id;
-	u64 peer_id;
 	struct peer *peer;
 };
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -4,6 +4,7 @@
 #include "config.h"
 #include "db.h"
 #include <ccan/crypto/shachain/shachain.h>
+#include <ccan/list/list.h>
 #include <ccan/tal/tal.h>
 #include <lightningd/channel_config.h>
 #include <lightningd/utxo.h>
@@ -197,4 +198,16 @@ bool wallet_channel_config_load(struct wallet *w, const u64 id,
  */
 bool wallet_peer_by_nodeid(struct wallet *w, const struct pubkey *nodeid,
 			   struct peer *peer);
+
+/**
+ * wlalet_channels_load_active -- Load persisted active channels into the peers
+ *
+ * @w: wallet to load from
+ * @peers: list_head to load channels/peers into
+ *
+ * Be sure to call this only once on startup since it'll append peers
+ * loaded from the database to the list without checking.
+ */
+bool wallet_channels_load_active(struct wallet *w, struct list_head *peers);
+
 #endif /* WALLET_WALLET_H */

--- a/wallet/wallet_tests.c
+++ b/wallet/wallet_tests.c
@@ -132,7 +132,7 @@ static bool channelseq(struct wallet_channel *c1, struct wallet_channel *c2)
 	struct channel_info *ci1 = p1->channel_info, *ci2 = p2->channel_info;
 	struct changed_htlc *lc1 = p1->last_sent_commit, *lc2 = p2->last_sent_commit;
 	CHECK(c1->id == c2->id);
-	CHECK(c1->peer_id == c2->peer_id);
+	CHECK(c1->peer->dbid == c2->peer->dbid);
 	CHECK(p1->their_shachain.id == p2->their_shachain.id);
 	CHECK_MSG(pubkey_eq(&p1->id, &p2->id), "NodeIDs do not match");
 	CHECK((p1->scid == NULL && p2->scid == NULL) || short_channel_id_eq(p1->scid, p2->scid));
@@ -221,7 +221,7 @@ static bool test_channel_crud(const tal_t *ctx)
 
 	/* We just inserted them into an empty DB so this must be 1 */
 	CHECK(c1.id == 1);
-	CHECK(c1.peer_id == 1);
+	CHECK(c1.peer->dbid == 1);
 	CHECK(c1.peer->their_shachain.id == 1);
 
 	/* Variant 2: update with scid set */
@@ -232,7 +232,7 @@ static bool test_channel_crud(const tal_t *ctx)
 
 	/* Updates should not result in new ids */
 	CHECK(c1.id == 1);
-	CHECK(c1.peer_id == 1);
+	CHECK(c1.peer->dbid == 1);
 	CHECK(c1.peer->their_shachain.id == 1);
 
 	/* Variant 3: update with our_satoshi set */


### PR DESCRIPTION
Ok, this is finally the second half of the channel persistence. It integrates the persistence primitives with the lightningd and re-populates peers/channels.

I also stumbled over a number of small bugs, that got fixed along the way. This is still a bit of a sledhe hammer approach since it simply dumps everything on every update, and loads everything on startup, but it is a start.