### PR TITLE
Fix build: Correct SHA_POST() macro in pbkdf2.c

### DIFF
--- a/libwally-core/src/pbkdf2.c
+++ b/libwally-core/src/pbkdf2.c
@@ -10,7 +10,7 @@
 #define SHA_T sha256
 #define SHA_ALIGN_T uint32_t
 #define SHA_MEM u32
-#define SHA_POST(name) name ## sha256
+#define SHA_POST(name) name ## sha256_internal
 #define PBKDF2_HMAC_SHA_LEN PBKDF2_HMAC_SHA256_LEN
 #include "pbkdf2.inl"
 


### PR DESCRIPTION
The hmac_sha256() function got renamed to hmac_sha256_internal() in
9624a1a10eeec459ea0eaf57593c8bd8b9a16f31, but one obscure occasion
where it was used was missed and therefore it was still used with its
old name.