### PR TITLE
Remember change outputs

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1995,6 +1995,8 @@ static void init_channel(struct peer *peer)
 
 	assert(!(fcntl(MASTER_FD, F_GETFL) & O_NONBLOCK));
 
+	status_setup_sync(MASTER_FD);
+
 	msg = wire_sync_read(peer, MASTER_FD);
 	if (!fromwire_channel_init(peer, msg, NULL,
 				   &peer->chain_hash,
@@ -2041,8 +2043,6 @@ static void init_channel(struct peer *peer)
 				   &funding_signed))
 		status_failed(WIRE_CHANNEL_BAD_COMMAND, "Init: %s",
 			      tal_hex(msg, msg));
-
-	status_setup_sync(MASTER_FD);
 
 	status_trace("init %s: remote_per_commit = %s, old_remote_per_commit = %s"
 		     " next_idx_local = %"PRIu64

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1378,6 +1378,7 @@ static void opening_got_hsm_funding_sig(struct funding_channel *fc,
 {
 	secp256k1_ecdsa_signature *sigs;
 	struct bitcoin_tx *tx = fc->funding_tx;
+	u64 change_satoshi;
 	size_t i;
 
 	if (!fromwire_hsmctl_sign_funding_reply(fc, resp, NULL, &sigs))
@@ -1406,6 +1407,9 @@ static void opening_got_hsm_funding_sig(struct funding_channel *fc,
 	broadcast_tx(fc->peer->ld->topology, fc->peer, tx, funding_broadcast_failed);
 	watch_tx(fc->peer, fc->peer->ld->topology, fc->peer, tx,
 		 funding_lockin_cb, NULL);
+
+	/* Extract the change output and add it to the DB */
+	wallet_extract_owned_outputs(fc->peer->ld->wallet, tx, &change_satoshi);
 
 	/* FIXME: Remove arg from cb? */
 	watch_txo(fc->peer, fc->peer->ld->topology, fc->peer,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "db.h"
+#include <bitcoin/tx.h>
 #include <ccan/crypto/shachain/shachain.h>
 #include <ccan/list/list.h>
 #include <ccan/tal/tal.h>
@@ -210,5 +211,11 @@ bool wallet_peer_by_nodeid(struct wallet *w, const struct pubkey *nodeid,
  * loaded from the database to the list without checking.
  */
 bool wallet_channels_load_active(struct wallet *w, struct list_head *peers);
+
+/**
+ * wallet_extract_owned_outputs - given a tx, extract all of our outputs
+ */
+int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
+				 u64 *total_satoshi);
 
 #endif /* WALLET_WALLET_H */

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -28,39 +28,6 @@ struct withdrawal {
 };
 
 /**
- * wallet_extract_owned_outputs - given a tx, extract all of our outputs
- */
-static int wallet_extract_owned_outputs(struct wallet *w,
-					const struct bitcoin_tx *tx,
-					u64 *total_satoshi)
-{
-	int num_utxos = 0;
-	for (size_t output = 0; output < tal_count(tx->output); output++) {
-		struct utxo *utxo;
-		u32 index;
-		bool is_p2sh;
-
-		if (!wallet_can_spend(w, tx->output[output].script, &index, &is_p2sh))
-			continue;
-
-		utxo = tal(w, struct utxo);
-		utxo->keyindex = index;
-		utxo->is_p2sh = is_p2sh;
-		utxo->amount = tx->output[output].amount;
-		utxo->status = output_state_available;
-		bitcoin_txid(tx, &utxo->txid);
-		utxo->outnum = output;
-		if (!wallet_add_utxo(w, utxo, p2sh_wpkh)) {
-			tal_free(utxo);
-			return -1;
-		}
-		*total_satoshi += utxo->amount;
-		num_utxos++;
-	}
-	return num_utxos;
-}
-
-/**
  * wallet_withdrawal_broadcast - The tx has been broadcast (or it failed)
  *
  * This is the final step in the withdrawal. We either successfully


### PR DESCRIPTION
We are currently forgetting any change we get from a funding transaction. This PR changes that. It hooks into `hsm_funding_sig`, i.e., the place we use to broadcast the funding transaction, to grab our change outputs. While the outputs are not yet confirmed, they can already be used for further funding transactions or withdrawals, and it makes the marking of spent outputs and adding the change at the same time.