### PR TITLE
Added 32bit configuration for travis and fix a minor size_t == u64 assumption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ dist: trusty
 sudo: true
 
 env:
-  - NO_VALGRIND=1
-  - NO_VALGRIND=0
+  - NO_VALGRIND=1 ARCH=32
+  - NO_VALGRIND=1 ARCH=64
+  - NO_VALGRIND=0 ARCH=64
 
 # Trusty (aka 14.04) is way way too old, so run in docker...
 script:
-  - docker pull cdecker/lightning-ci > /dev/null
-  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make -j3
-  - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check
-  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci make check-source
+  - docker pull cdecker/lightning-ci:${ARCH}bit > /dev/null
+  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3
+  - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check
+  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check-source

--- a/lightningd/test/run-commit_tx.c
+++ b/lightningd/test/run-commit_tx.c
@@ -269,7 +269,7 @@ static void report_htlcs(const struct bitcoin_tx *tx,
 			      wscript[i],
 			      x_remote_secretkey, remotekey,
 			      &remotesig[i]);
-		printf("# signature for output %zi (htlc %zu)\n", i, htlc->id);
+		printf("# signature for output %zi (htlc %"PRIu64")\n", i, htlc->id);
 		printf("remote_htlc_signature = %s\n",
 		       type_to_string(tmpctx, secp256k1_ecdsa_signature,
 				      &remotesig[i]));


### PR DESCRIPTION
This came up a few times, so I decided to use travis to build `lightningd` in a 32bit docker image, just like we already do for the other builds. I decided against adding a valgrind version since it's extremely slow and potentially delays the CI results.