### PR TITLE
lightningd: fix node_announce message when timestamps change.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -400,6 +400,25 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_log('sendrawtx exit 0')
         assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 1
 
+    def test_gossip_badsig(self):
+        l1 = self.node_factory.get_node()
+        l2 = self.node_factory.get_node()
+        l3 = self.node_factory.get_node()
+
+        # l2 connects to both, so l1 can't reconnect and thus l2 drops to chain
+        l2.rpc.connect('localhost', l1.info['port'], l1.info['id'])
+        l2.rpc.connect('localhost', l3.info['port'], l3.info['id'])
+        self.fund_channel(l2, l1, 10**6)
+        self.fund_channel(l2, l3, 10**6)
+
+        # Wait for route propagation.
+        l1.bitcoin.rpc.generate(5)
+        l1.daemon.wait_for_log('Received node_announcement for node {}'
+                               .format(l3.info['id']))
+        assert not l1.daemon.is_in_log('signature verification failed')
+        assert not l2.daemon.is_in_log('signature verification failed')
+        assert not l3.daemon.is_in_log('signature verification failed')
+
     def test_permfail(self):
         l1,l2 = self.connect()
 


### PR DESCRIPTION
Discovered we were intermittantly sending out bogus announcements, due
passing a second time boundary while waiting for HSM.

This method is more robust: not only if timestamp changes, but if other
information (eg. port and IP) were to change in future.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>