### PR TITLE
pytest: Cleanly shut down lightningd after tests

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -333,6 +333,11 @@ static void json_sendpay(struct command *cmd,
 	/* Wait until we get response. */
 	tal_add_destructor2(cmd, remove_cmd_from_pc, pc);
 
+	/* They're both children of ld, but on shutdown make sure we
+	 * destroy the command before the pc, otherwise the
+	 * remove_cmd_from_pc destructor causes a use-after-free */
+	tal_steal(pc, cmd);
+
 	failcode = send_htlc_out(peer, amount, first_hop_data.outgoing_cltv,
 				 &rhash, onion, NULL, pc, &pc->out);
 	if (failcode) {

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -125,8 +125,16 @@ class NodeFactory(object):
         return node
 
     def killall(self):
+        rcs = []
+        failed = False
         for n in self.nodes:
-            n.stop()
+            try:
+                n.stop()
+            except:
+                failed = True
+            rcs.append(n.daemon.proc.returncode)
+        if failed:
+            raise Exception("At least one lightning exited with non-zero return code: {}".format(rcs))
 
 
 class BaseLightningDTests(unittest.TestCase):

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -538,18 +538,7 @@ class LightningDTests(BaseLightningDTests):
             'channel': '1:1:1'
         }
 
-        q = queue.Queue()
-
-        def try_pay():
-            try:
-                l1.rpc.sendpay(to_json([routestep]), rhash, async=False)
-                q.put(None)
-            except Exception as err:
-                q.put(err)
-
-        t = threading.Thread(target=try_pay)
-        t.daemon = True
-        t.start()
+        payfuture = self.executor.submit(l1.rpc.sendpay, to_json([routestep]), rhash)
 
         # l1 will drop to chain.
         l1.daemon.wait_for_log('permfail')
@@ -562,10 +551,7 @@ class LightningDTests(BaseLightningDTests):
         bitcoind.rpc.generate(3)
 
         # It should fail.
-        err = q.get(timeout = 5)
-        assert type(err) is ValueError
-        t.join(timeout=1)
-        assert not t.isAlive()
+        self.assertRaises(ValueError, payfuture.result, 5)
 
         l1.daemon.wait_for_log('WIRE_PERMANENT_CHANNEL_FAILURE: missing in commitment tx')
 
@@ -604,18 +590,7 @@ class LightningDTests(BaseLightningDTests):
             'channel': '1:1:1'
         }
 
-        q = queue.Queue()
-
-        def try_pay():
-            try:
-                l1.rpc.sendpay(to_json([routestep]), rhash, async=False)
-                q.put(None)
-            except Exception as err:
-                q.put(err)
-
-        t = threading.Thread(target=try_pay)
-        t.daemon = True
-        t.start()
+        payfuture = self.executor.submit(l1.rpc.sendpay, to_json([routestep]), rhash)
 
         # l1 will drop to chain.
         l1.daemon.wait_for_log('permfail')
@@ -636,10 +611,7 @@ class LightningDTests(BaseLightningDTests):
         bitcoind.rpc.generate(3)
 
         # It should fail.
-        err = q.get(timeout = 5)
-        assert type(err) is ValueError
-        t.join(timeout=1)
-        assert not t.isAlive()
+        self.assertRaises(ValueError, payfuture.result, 5)
 
         l1.daemon.wait_for_log('WIRE_PERMANENT_CHANNEL_FAILURE: timed out')
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -126,7 +126,7 @@ class NodeFactory(object):
 
     def killall(self):
         for n in self.nodes:
-            n.daemon.stop()
+            n.stop()
 
 
 class BaseLightningDTests(unittest.TestCase):
@@ -1541,9 +1541,8 @@ class LightningDTests(BaseLightningDTests):
         time.sleep(1)
         assert l1.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 99990000
         assert l2.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 10000
-
         # Stop l2, l1 will reattempt to connect
-        l2.daemon.stop()
+        l2.stop()
 
         # Wait for l1 to notice
         wait_for(lambda: not l1.rpc.getpeers()['peers'][0]['connected'])
@@ -1562,7 +1561,7 @@ class LightningDTests(BaseLightningDTests):
         assert l2.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 20000
 
         # Finally restart l1, and make sure it remembers
-        l1.daemon.stop()
+        l1.stop()
         l1.daemon.start()
         assert l1.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 99980000
 


### PR DESCRIPTION
This amends the pytest framework with clean shutdowns of `lightningd` during the teardown after tests. It uses a three step approach: issue a JSON-RPC stop, wait for it to terminate for 10 seconds, if still running, issue a signal, wait for it to terminate for 10 seconds and if it is still alive, then be more persuasive a.k.a. kill it. This allows us to get rid of the wait loop for crashes since crashes can write their log during the timeouts. And we also get an indication whether we exited cleanly or not (non-zero return codes raise exceptions).

It took a bit longer to implement because it exposed a number of use-after-free bugs during the shutdown (and there may be more that may pop up later). These are all due to the coarse-grained lifetimes we give some of the allocations, i.e., allocating off of `ld`, and due to lifetimes of related objects that are however not allocated off of each other. See commits for details.