### PR TITLE
Add --no-reconnect flag

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -240,15 +240,6 @@ int main(int argc, char *argv[])
 	ld->daemon_dir = find_my_path(ld, argv[0]);
 
 	register_opts(ld);
-	opt_register_arg("--dev-debugger=<subdaemon>", opt_subd_debug, NULL,
-			 ld, "Wait for gdb attach at start of <subdaemon>");
-
-	opt_register_arg("--dev-broadcast-interval=<ms>", opt_set_uintval,
-			 opt_show_uintval, &ld->broadcast_interval,
-			 "Time between gossip broadcasts in milliseconds (default: 30000)");
-
-	opt_register_arg("--dev-disconnect=<filename>", opt_subd_dev_disconnect,
-			 NULL, ld, "File containing disconnection points");
 
 	/* FIXME: move to option initialization once we drop the
 	 * legacy daemon */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -64,6 +64,9 @@ struct config {
 
 	/* IPv4 or IPv6 address to announce to the network */
 	struct ipaddr ipaddr;
+
+	/* Disable automatic reconnects */
+	bool no_reconnect;
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -224,6 +224,8 @@ static void config_register_opts(struct lightningd *ld)
 	opt_register_arg("--fee-per-satoshi", opt_set_s32, opt_show_s32,
 			 &ld->config.fee_per_satoshi,
 			 "Microsatoshi fee for every satoshi in HTLC");
+	opt_register_noarg("--no-reconnect", opt_set_bool,
+			   &ld->config.no_reconnect, "Disable automatic reconnect attempts");
 
 	opt_register_arg("--ipaddr", opt_set_ipaddr, NULL,
 			   &ld->config.ipaddr,
@@ -298,6 +300,9 @@ static const struct config testnet_config = {
 
 	/* Do not advertise any IP */
 	.ipaddr.type = 0,
+
+	/* Automatically reconnect */
+	.no_reconnect = false,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -356,6 +361,9 @@ static const struct config mainnet_config = {
 
 	/* Do not advertise any IP */
 	.ipaddr.type = 0,
+
+	/* Automatically reconnect */
+	.no_reconnect = false,
 };
 
 static void check_config(struct lightningd *ld)

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -15,6 +15,7 @@
 #include <lightningd/log.h>
 #include <lightningd/opt_time.h>
 #include <lightningd/options.h>
+#include <lightningd/subd.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -243,6 +244,13 @@ static void dev_register_opts(struct lightningd *ld)
 			   &ld->topology->dev_no_broadcast, opt_hidden);
 	opt_register_noarg("--dev-fail-on-subdaemon-fail", opt_set_bool,
 			   &ld->dev_subdaemon_fail, opt_hidden);
+	opt_register_arg("--dev-debugger=<subdaemon>", opt_subd_debug, NULL,
+			 ld, "Wait for gdb attach at start of <subdaemon>");
+	opt_register_arg("--dev-broadcast-interval=<ms>", opt_set_uintval,
+			 opt_show_uintval, &ld->broadcast_interval,
+			 "Time between gossip broadcasts in milliseconds (default: 30000)");
+	opt_register_arg("--dev-disconnect=<filename>", opt_subd_dev_disconnect,
+			 NULL, ld, "File containing disconnection points");
 }
 
 static const struct config testnet_config = {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -89,6 +89,11 @@ static void try_reconnect(struct peer *peer)
 
 static void peer_reconnect(struct peer *peer)
 {
+	/* Don't schedule an attempt if we disabled reconnections with
+	 * the `--no-reconnect` flag */
+	if (peer->ld->config.no_reconnect)
+		return;
+
 	new_reltimer(&peer->ld->timers,
 		     peer, peer->ld->config.poll_time,
 		     try_reconnect, peer);


### PR DESCRIPTION
Especially when testing we might want to disable the automatic
reconnection logic in order not to masquerade bugs that disappear when
reconnecting.