### PR TITLE
wallet: Wrap HTLC and channel updates in DB transactions

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1885,7 +1885,47 @@ static void peer_start_closingd_after_shutdown(struct peer *peer, const u8 *msg,
 	peer_set_condition(peer, CHANNELD_SHUTTING_DOWN, CLOSINGD_SIGEXCHANGE);
 }
 
-static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
+/**
+ * transactional_msg_handler - Wrap a msg handler in a DB transaction
+ *
+ * Initiates a DB transaction, executes the @handler with the given
+ * arguments and terminates the transaction after the handler
+ * returns. If the handler's return value is negative the transaction
+ * is aborted. If the handler returns a positive value we attempt to
+ * commit the transaction. Returns the return value from the handler
+ * or -1 on commit failure.
+ */
+static int transactional_msg_handler(int (*handler)(struct peer *, const u8 *),
+				     struct peer *peer, const u8 *msg)
+{
+	struct db *db = peer->ld->wallet->db;
+	int ret;
+        /* Make sure we are the outermost transaction */
+	assert(!db->in_transaction);
+	db_begin_transaction(db);
+
+	ret = handler(peer, msg);
+	if (ret >= 0 && !db_commit_transaction(db)) {
+		peer_internal_error(
+			peer, "Could not commit db transaction: %s",
+			db->err);
+		ret = -1;
+	}
+
+	/* If the commit fails or the handler aborts we will attempt a
+	 * rollback */
+	if (ret < 0) {
+		db_rollback_transaction(db);
+	}
+
+	/* Make sure we don't leak transactions */
+	assert(!db->in_transaction);
+	return ret;
+
+
+}
+
+static unsigned int channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 {
 	enum channel_wire_type t = fromwire_peektype(msg);
 
@@ -1895,13 +1935,13 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 				   CHANNELD_AWAITING_LOCKIN, CHANNELD_NORMAL);
 		break;
 	case WIRE_CHANNEL_SENDING_COMMITSIG:
-		peer_sending_commitsig(sd->peer, msg);
+		transactional_msg_handler(peer_sending_commitsig, sd->peer, msg);
 		break;
 	case WIRE_CHANNEL_GOT_COMMITSIG:
-		peer_got_commitsig(sd->peer, msg);
+		transactional_msg_handler(peer_got_commitsig, sd->peer, msg);
 		break;
 	case WIRE_CHANNEL_GOT_REVOKE:
-		peer_got_revoke(sd->peer, msg);
+		transactional_msg_handler(peer_got_revoke,sd->peer, msg);
 		break;
 	case WIRE_CHANNEL_ANNOUNCE:
 		peer_channel_announce(sd->peer, msg);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1129,8 +1129,6 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 		  commitnum, tal_count(added), tal_count(fulfilled),
 		  tal_count(failed), tal_count(changed));
 
-	/* FIXME: store commit & htlc signature information. */
-
 	/* New HTLCs */
 	for (i = 0; i < tal_count(added); i++)
 		added_their_htlc(peer, &added[i], &shared_secrets[i]);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -975,7 +975,7 @@ static bool peer_save_commitsig_sent(struct peer *peer, u64 commitnum)
 	return true;
 }
 
-void peer_sending_commitsig(struct peer *peer, const u8 *msg)
+bool peer_sending_commitsig(struct peer *peer, const u8 *msg)
 {
 	u64 commitnum;
 	struct changed_htlc *changed_htlcs;
@@ -989,14 +989,14 @@ void peer_sending_commitsig(struct peer *peer, const u8 *msg)
 						&commit_sig, &htlc_sigs)) {
 		peer_internal_error(peer, "bad channel_sending_commitsig %s",
 				    tal_hex(peer, msg));
-		return;
+		return false;
 	}
 
 	for (i = 0; i < tal_count(changed_htlcs); i++) {
 		if (!changed_htlc(peer, changed_htlcs + i)) {
 			peer_internal_error(peer,
 				   "channel_sending_commitsig: update failed");
-			return;
+			return false;
 		}
 
 		/* While we're here, sanity check added ones are in
@@ -1015,14 +1015,14 @@ void peer_sending_commitsig(struct peer *peer, const u8 *msg)
 				   " Added %"PRIu64", maxid now %"PRIu64
 				   " from %"PRIu64,
 				   num_local_added, maxid, peer->next_htlc_id);
-			return;
+			return false;
 		}
 		/* FIXME: Save to db */
 		peer->next_htlc_id += num_local_added;
 	}
 
 	if (!peer_save_commitsig_sent(peer, commitnum))
-		return;
+		return false;
 
 	/* Last was commit. */
 	peer->last_was_revoke = false;
@@ -1032,6 +1032,7 @@ void peer_sending_commitsig(struct peer *peer, const u8 *msg)
 	/* Tell it we've got it, and to go ahead with commitment_signed. */
 	subd_send_msg(peer->owner,
 		      take(towire_channel_sending_commitsig_reply(msg)));
+	return true;
 }
 
 static void added_their_htlc(struct peer *peer,
@@ -1094,7 +1095,7 @@ static bool peer_sending_revocation(struct peer *peer,
 }
 
 /* This also implies we're sending revocation */
-void peer_got_commitsig(struct peer *peer, const u8 *msg)
+bool peer_got_commitsig(struct peer *peer, const u8 *msg)
 {
 	u64 commitnum;
 	secp256k1_ecdsa_signature commit_sig;
@@ -1120,7 +1121,7 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 		peer_internal_error(peer,
 				    "bad fromwire_channel_got_commitsig %s",
 				    tal_hex(peer, msg));
-		return;
+		return false;
 	}
 
 	log_debug(peer->log,
@@ -1136,28 +1137,28 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 	/* Save information now for fulfilled & failed HTLCs */
 	for (i = 0; i < tal_count(fulfilled); i++) {
 		if (!peer_fulfilled_our_htlc(peer, &fulfilled[i]))
-			return;
+			return false ;
 	}
 
 	for (i = 0; i < tal_count(failed); i++) {
 		if (!peer_failed_our_htlc(peer, &failed[i]))
-			return;
+			return false;
 	}
 
 	for (i = 0; i < tal_count(changed); i++) {
 		if (!changed_htlc(peer, &changed[i])) {
 			peer_internal_error(peer,
 					    "got_commitsig: update failed");
-			return;
+			return false;
 		}
 	}
 
 	/* Since we're about to send revoke, bump state again. */
 	if (!peer_sending_revocation(peer, added, fulfilled, failed, changed))
-		return;
+		return false;
 
 	if (!peer_save_commitsig_received(peer, commitnum))
-		return;
+		return false;
 
 	peer_last_tx(peer, tx, &commit_sig);
 	/* FIXME: Put these straight in the db! */
@@ -1167,6 +1168,7 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 	/* Tell it we've committed, and to go ahead with revoke. */
 	msg = towire_channel_got_commitsig_reply(msg);
 	subd_send_msg(peer->owner, take(msg));
+	return true;
 }
 
 /* Shuffle them over, forgetting the ancient one. */
@@ -1178,7 +1180,7 @@ void update_per_commit_point(struct peer *peer,
 	ci->remote_per_commit = *per_commitment_point;
 }
 
-void peer_got_revoke(struct peer *peer, const u8 *msg)
+bool peer_got_revoke(struct peer *peer, const u8 *msg)
 {
 	u64 revokenum;
 	struct sha256 per_commitment_secret;
@@ -1193,7 +1195,7 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 					 &changed)) {
 		peer_internal_error(peer, "bad fromwire_channel_got_revoke %s",
 				    tal_hex(peer, msg));
-		return;
+		return false;
 	}
 
 	log_debug(peer->log,
@@ -1207,12 +1209,12 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 		if (changed[i].newstate == RCVD_ADD_ACK_REVOCATION) {
 			if (!peer_accepted_htlc(peer, changed[i].id,
 						&failcodes[i]))
-				return;
+				return false;
 		} else {
 			if (!changed_htlc(peer, &changed[i])) {
 				peer_internal_error(peer,
 						    "got_revoke: update failed");
-				return;
+				return false;
 			}
 		}
 	}
@@ -1220,14 +1222,14 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 	if (revokenum >= (1ULL << 48)) {
 		peer_internal_error(peer, "got_revoke: too many txs %"PRIu64,
 				    revokenum);
-		return;
+		return false;
 	}
 
 	if (revokenum != revocations_received(&peer->their_shachain.chain)) {
 		peer_internal_error(peer, "got_revoke: expected %"PRIu64
 				    " got %"PRIu64,
 				    revocations_received(&peer->their_shachain.chain), revokenum);
-		return;
+		return false;
 	}
 
 	/* BOLT #2:
@@ -1244,7 +1246,7 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 						   &per_commitment_secret),
 				    revokenum);
 		peer_fail_permanent(peer, take((u8 *)err));
-		return;
+		return false;
 	}
 
 	/* FIXME: Check per_commitment_secret -> per_commit_point */
@@ -1270,6 +1272,7 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 		fatal("Could not save channel to database: %s",
 		      peer->ld->wallet->db->err);
 	}
+	return true;
 }
 
 static void *tal_arr_append_(void **p, size_t size)

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -27,9 +27,9 @@ void peer_htlcs(const tal_t *ctx,
 		struct failed_htlc **failed_htlcs,
 		enum side **failed_sides);
 
-void peer_sending_commitsig(struct peer *peer, const u8 *msg);
-void peer_got_commitsig(struct peer *peer, const u8 *msg);
-void peer_got_revoke(struct peer *peer, const u8 *msg);
+bool peer_sending_commitsig(struct peer *peer, const u8 *msg);
+bool peer_got_commitsig(struct peer *peer, const u8 *msg);
+bool peer_got_revoke(struct peer *peer, const u8 *msg);
 
 void update_per_commit_point(struct peer *peer,
 			     const struct pubkey *per_commitment_point);

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -222,12 +222,15 @@ static void close_db(struct db *db) { sqlite3_close(db->sql); }
 
 bool db_begin_transaction(struct db *db)
 {
-	assert(!db->in_transaction);
-	/* Clear any errors from previous transactions and
-	 * non-transactional queries */
-	db_clear_error(db);
-	db->in_transaction = db_exec(__func__, db, "BEGIN TRANSACTION;");
-	return db->in_transaction;
+	if (!db->in_transaction) {
+		/* Clear any errors from previous transactions and
+		 * non-transactional queries */
+		db_clear_error(db);
+		db->in_transaction = db_exec(__func__, db, "BEGIN TRANSACTION;");
+		assert(db->in_transaction);
+		return db->in_transaction;
+	}
+	return false;
 }
 
 bool db_commit_transaction(struct db *db)

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -39,9 +39,11 @@ bool PRINTF_FMT(3, 4)
 /**
  * db_begin_transaction - Begin a transaction
  *
- * We do not support nesting multiple transactions, so make sure that
- * we are not in a transaction when calling this. Returns true if we
- * succeeded in starting a transaction.
+ * Begin a new DB transaction if we aren't already in one. Returns
+ * true if the call started a transaction, i.e., the caller MUST take
+ * care to either commit or rollback. If false, this is a nested
+ * transaction and the caller MUST not commit/rollback, since the
+ * transaction is handled at a higher level in the callstack.
  */
 bool db_begin_transaction(struct db *db);
 


### PR DESCRIPTION
Since we always work with a batch of HTLCs (the batch that the
signature covers) it'd wasteful to commit state transitions
individually. So here we wrap them in a DB transaction, deferring the
sync disk write until we commit. This single change increases
throughput from 2.8tx/s to ~150tx/s (then again I was the one that
slowed it down in the first place.