### PR TITLE
peer: Do not keep the htlc_stubs in memory

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -290,7 +290,6 @@ int main(int argc, char *argv[])
 		populate_peer(ld, peer);
 		peer->seed = tal(peer, struct privkey);
 		derive_peer_seed(ld, peer->seed, &peer->id, peer->channel->id);
-		peer->htlcs = tal_arr(peer, struct htlc_stub, 0);
 		peer->owner = NULL;
 		if (!wallet_htlcs_load_for_channel(ld->wallet, peer->channel,
 						   &ld->htlcs_in, &ld->htlcs_out)) {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1358,7 +1358,7 @@ static u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx
 }
 
 /* If we want to know if this HTLC is missing, return depth. */
-static bool tell_if_missing(const struct peer *peer, size_t n,
+static bool tell_if_missing(const struct peer *peer, struct htlc_stub *stub,
 			    bool *tell_immediate)
 {
 	struct htlc_out *hout;
@@ -1367,7 +1367,7 @@ static bool tell_if_missing(const struct peer *peer, size_t n,
 	*tell_immediate = false;
 
 	/* Is it a current HTLC? */
-	hout = find_htlc_out_by_ripemd(peer, &peer->htlcs[n].ripemd);
+	hout = find_htlc_out_by_ripemd(peer, &stub->ripemd);
 	if (!hout)
 		return false;
 
@@ -1482,7 +1482,7 @@ static enum watch_result funding_spent(struct peer *peer,
 	/* FIXME: Don't queue all at once, use an empty cb... */
 	for (size_t i = 0; i < tal_count(stubs); i++) {
 		bool tell_immediate;
-		bool tell = tell_if_missing(peer, i, &tell_immediate);
+		bool tell = tell_if_missing(peer, &stubs[i], &tell_immediate);
 		msg = towire_onchain_htlc(peer, &stubs[i],
 					  tell, tell_immediate);
 		subd_send_msg(peer->owner, take(msg));

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -635,7 +635,6 @@ void add_peer(struct lightningd *ld, u64 unique_id,
 	peer->next_index[LOCAL]
 		= peer->next_index[REMOTE] = 0;
 	peer->next_htlc_id = 0;
-	peer->htlcs = tal_arr(peer, struct htlc_stub, 0);
 	wallet_shachain_init(ld->wallet, &peer->their_shachain);
 
 	/* If we have the peer in the DB, this'll populate the fields,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -98,9 +98,6 @@ struct peer {
 	bool last_was_revoke;
 	struct changed_htlc *last_sent_commit;
 
-	/* FIXME: Just leave this in the db. */
-	struct htlc_stub *htlcs;
-
 	struct wallet_channel *channel;
 };
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -716,7 +716,6 @@ static void fulfill_our_htlc_out(struct peer *peer, struct htlc_out *hout,
 	hout->preimage = tal_dup(hout, struct preimage, preimage);
 	htlc_out_check(hout, __func__);
 
-	/* FIXME: Save to db */
 	wallet_htlc_update(peer->ld->wallet, hout->dbid, hout->hstate, preimage);
 
 	if (hout->in)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1199,3 +1199,37 @@ bool wallet_invoice_remove(struct wallet *wallet, struct invoice *inv)
 	sqlite3_bind_int64(stmt, 1, inv->id);
 	return db_exec_prepared(wallet->db, stmt) && sqlite3_changes(wallet->db->sql) == 1;
 }
+
+struct htlc_stub *wallet_htlc_stubs(tal_t *ctx, struct wallet *wallet,
+				    struct wallet_channel *chan)
+{
+	struct htlc_stub *stubs;
+	struct sha256 payment_hash;
+	sqlite3_stmt *stmt = db_prepare(wallet->db,
+		"SELECT channel_id, direction, cltv_expiry, payment_hash "
+		"FROM channel_htlcs WHERE channel_id = ?;");
+
+	if (!stmt) {
+		log_broken(wallet->log, "Error preparing select: %s", wallet->db->err);
+		return NULL;
+	}
+	sqlite3_bind_int64(stmt, 1, chan->id);
+
+	stubs = tal_arr(ctx, struct htlc_stub, 0);
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		int n = tal_count(stubs);
+		tal_resize(&stubs, n+1);
+
+		assert(sqlite3_column_int64(stmt, 0) == chan->id);
+
+		/* FIXME: merge these two enums */
+		stubs[n].owner = sqlite3_column_int(stmt, 1)==DIRECTION_INCOMING?REMOTE:LOCAL;
+		stubs[n].cltv_expiry = sqlite3_column_int(stmt, 2);
+
+		sqlite3_column_hexval(stmt, 3, &payment_hash, sizeof(payment_hash));
+		ripemd160(&stubs[n].ripemd, payment_hash.u.u8, sizeof(payment_hash.u));
+	}
+	sqlite3_finalize(stmt);
+	return stubs;
+}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -11,6 +11,7 @@
 #include <common/utxo.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/invoice.h>
+#include <onchaind/onchain_wire.h>
 #include <wally_bip32.h>
 
 struct lightningd;
@@ -335,5 +336,19 @@ bool wallet_invoices_load(struct wallet *wallet, struct invoices *invs);
  * @inv: Invoice to remove.
  */
 bool wallet_invoice_remove(struct wallet *wallet, struct invoice *inv);
+
+/**
+ * wallet_htlc_stubs - Retrieve HTLC stubs for the given channel
+ *
+ * Load minimal necessary information about HTLCs for the on-chain
+ * settlement. This returns a `tal_arr` allocated off of @ctx with the
+ * necessary size to hold all HTLCs.
+ *
+ * @ctx: Allocation context for the return value
+ * @wallet: Wallet to load from
+ * @chan: Channel to fetch stubs for
+ */
+struct htlc_stub *wallet_htlc_stubs(tal_t *ctx, struct wallet *wallet,
+				    struct wallet_channel *chan);
 
 #endif /* WALLET_WALLET_H */


### PR DESCRIPTION
We'd like to not keep them in memory and retrieve them on-demand when
`onchaind` is launched. This uses the `channel_htlcs` table as backing
but only fetches the minimal necessary information.
