### PR TITLE
Update docker images for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 # Trusty (aka 14.04) is way way too old, so run in docker...
 script:
-  - docker pull cdecker/lightning-ci:${ARCH}bit > /dev/null
+  - docker pull cdecker/lightning-ci:${ARCH}bit | tee
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3 DEVELOPER=${DEVELOPER}
   - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check DEVELOPER=${DEVELOPER}
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
 # Trusty (aka 14.04) is way way too old, so run in docker...
 script:
   - docker pull cdecker/lightning-ci:${ARCH}bit | tee
+  - echo "Building..."
+  - echo "travis_fold:start:SCRIPT folding starts"
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3 DEVELOPER=${DEVELOPER}
+  - echo "travis_fold:end:SCRIPT folding ends"
   - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check DEVELOPER=${DEVELOPER}
   - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check-source

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -1,12 +1,14 @@
 FROM ubuntu:16.04
+MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /build
 
-RUN echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/bitcoin.list
 RUN apt-get -qq update && \
-    apt-get -qq install --allow-unauthenticated -yy \
-        eatmydata \
+    apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+	autoconf \
+	automake \
+	eatmydata \
 	software-properties-common \
 	build-essential \
 	autoconf \
@@ -20,8 +22,14 @@ RUN apt-get -qq update && \
 	python3 \
 	valgrind \
 	net-tools \
-	bitcoind \
 	python3-pip \
-	&& rm -rf /var/lib/apt/lists/*
+	wget && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp/ && \
+    wget https://bitcoin.org/bin/bitcoin-core-0.15.0.1/bitcoin-0.15.0.1-x86_64-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    tar -xvzf bitcoin.tar.gz && \
+    mv /tmp/bitcoin-0.15.0/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.0
 
 RUN pip3 install python-bitcoinlib==0.7.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -1,34 +1,35 @@
 FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
-RUN echo deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main > /etc/apt/sources.list.d/bitcoin-bitcoin-xenial.list
-RUN apt-get update -qq
-RUN apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
-    asciidoc \
-    curl \
-    git \
-    make \
-    automake \
-    autoconf \
-    libtool \
-    bitcoind \
-    build-essential \
-    libprotobuf-c-dev \
-    libsodium-dev \
-    libbase58-dev \
-    libsqlite3-dev \
-    libgmp-dev \
-    libsqlite3-dev \
-    git \
-    net-tools \
-    valgrind \
-    ca-certificates \
-    python \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install python-bitcoinlib==0.7.
-RUN mkdir /build
+ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /build
+
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+	autoconf \
+	automake \
+	eatmydata \
+	software-properties-common \
+	build-essential \
+	autoconf \
+	libtool \
+	libprotobuf-c-dev \
+	libsqlite3-dev \
+	libgmp-dev \
+	libsqlite3-dev \
+	git \
+	python \
+	python3 \
+	valgrind \
+	net-tools \
+	python3-pip \
+        wget && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp/ && \
+    wget https://bitcoin.org/bin/bitcoin-core-0.15.0.1/bitcoin-0.15.0.1-i686-pc-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    tar -xvzf bitcoin.tar.gz && \
+    mv /tmp/bitcoin-0.15.0/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.0
+
+RUN pip3 install python-bitcoinlib==0.7.0


### PR DESCRIPTION
Updates the docker CI builder images to use `bitcoind` v0.15.1 in order to fix #332. In addition it pipes `docker pull` through `tee` so we can see which images where used for the build, and collapses the build information in the Travis UI if building succeeds.

Closes #332