### PR TITLE
Use native sqlite3 binding for queries and don't hex encode binary fields

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1,6 +1,5 @@
 #include "db.h"
 
-#include <ccan/str/hex/hex.h>
 #include <ccan/tal/str/str.h>
 #include <ccan/tal/tal.h>
 #include <inttypes.h>
@@ -409,15 +408,6 @@ bool db_set_intvar(struct db *db, char *varname, s64 val)
 		    "INSERT INTO vars (name, val) VALUES ('%s', '%" PRId64
 		    "');",
 		    varname, val);
-}
-
-bool sqlite3_column_hexval(sqlite3_stmt *s, int col, void *dest, size_t destlen)
-{
-	const char *source = sqlite3_column_blob(s, col);
-	size_t sourcelen = sqlite3_column_bytes(s, col);
-	if (sourcelen / 2 != destlen)
-		return false;
-	return hex_decode(source, sourcelen, dest, destlen);
 }
 
 bool sqlite3_bind_short_channel_id(sqlite3_stmt *stmt, int col,

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -80,12 +80,6 @@ bool db_set_intvar(struct db *db, char *varname, s64 val);
 s64 db_get_intvar(struct db *db, char *varname, s64 defval);
 
 /**
- * sqlite3_column_hexval - Helper to populate a binary field from a hex value
- */
-bool sqlite3_column_hexval(sqlite3_stmt *s, int col, void *dest,
-			   size_t destlen);
-
-/**
  * db_prepare -- Prepare a DB query/command
  *
  * Tiny wrapper around `sqlite3_prepare_v2` that checks and sets

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -102,7 +102,8 @@ sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query);
  * all non-null variables using the `sqlite3_bind_*` functions, it can
  * be executed with this function. It is a small, transaction-aware,
  * wrapper around `sqlite3_step`, that also sets `db->err` if the
- * execution fails.
+ * execution fails. This will take ownership of `stmt` and will free
+ * it before returning.
  *
  * @db: The database to execute on
  * @stmt: The prepared statement to execute

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -2,9 +2,14 @@
 #define WALLET_DB_H
 
 #include "config.h"
+#include <bitcoin/pubkey.h>
+#include <bitcoin/preimage.h>
+#include <bitcoin/short_channel_id.h>
+#include <bitcoin/tx.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 
+#include <secp256k1_ecdh.h>
 #include <sqlite3.h>
 #include <stdbool.h>
 
@@ -110,5 +115,24 @@ sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query);
  */
 #define db_exec_prepared(db,stmt) db_exec_prepared_(__func__,db,stmt)
 bool db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt);
+
+bool sqlite3_bind_short_channel_id(sqlite3_stmt *stmt, int col,
+				   const struct short_channel_id *id);
+bool sqlite3_column_short_channel_id(sqlite3_stmt *stmt, int col,
+				     struct short_channel_id *dest);
+bool sqlite3_bind_tx(sqlite3_stmt *stmt, int col, const struct bitcoin_tx *tx);
+struct bitcoin_tx *sqlite3_column_tx(const tal_t *ctx, sqlite3_stmt *stmt,
+				     int col);
+bool sqlite3_bind_signature(sqlite3_stmt *stmt, int col, const secp256k1_ecdsa_signature *sig);
+bool sqlite3_column_signature(sqlite3_stmt *stmt, int col, secp256k1_ecdsa_signature *sig);
+
+bool sqlite3_column_pubkey(sqlite3_stmt *stmt, int col,  struct pubkey *dest);
+bool sqlite3_bind_pubkey(sqlite3_stmt *stmt, int col, const struct pubkey *pk);
+
+bool sqlite3_column_preimage(sqlite3_stmt *stmt, int col,  struct preimage *dest);
+bool sqlite3_bind_preimage(sqlite3_stmt *stmt, int col, const struct preimage *p);
+
+bool sqlite3_column_sha256(sqlite3_stmt *stmt, int col,  struct sha256 *dest);
+bool sqlite3_bind_sha256(sqlite3_stmt *stmt, int col, const struct sha256 *p);
 
 #endif /* WALLET_DB_H */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -351,14 +351,6 @@ bool wallet_shachain_load(struct wallet *wallet, u64 id,
 	return true;
 }
 
-static bool sqlite3_column_short_channel_id(sqlite3_stmt *stmt, int col,
-					    struct short_channel_id *dest)
-{
-	const char *source = sqlite3_column_blob(stmt, col);
-	size_t sourcelen = sqlite3_column_bytes(stmt, col);
-	return short_channel_id_from_str(source, sourcelen, dest);
-}
-
 static bool sqlite3_column_sig(sqlite3_stmt *stmt, int col, secp256k1_ecdsa_signature *sig)
 {
 	u8 buf[64];
@@ -367,27 +359,11 @@ static bool sqlite3_column_sig(sqlite3_stmt *stmt, int col, secp256k1_ecdsa_sign
 	return secp256k1_ecdsa_signature_parse_compact(secp256k1_ctx, sig, buf) == 1;
 }
 
-static bool sqlite3_column_pubkey(sqlite3_stmt *stmt, int col,  struct pubkey *dest)
-{
-	u8 buf[PUBKEY_DER_LEN];
-	if (!sqlite3_column_hexval(stmt, col, buf, sizeof(buf)))
-		return false;
-	return pubkey_from_der(buf, sizeof(buf), dest);
-}
-
 static u8 *sqlite3_column_varhexblob(tal_t *ctx, sqlite3_stmt *stmt, int col)
 {
 	const u8 *source = sqlite3_column_blob(stmt, col);
 	size_t sourcelen = sqlite3_column_bytes(stmt, col);
 	return tal_hexdata(ctx, source, sourcelen);
-}
-
-static struct bitcoin_tx *sqlite3_column_tx(const tal_t *ctx,
-					    sqlite3_stmt *stmt, int col)
-{
-	return bitcoin_tx_from_hex(ctx,
-				   sqlite3_column_blob(stmt, col),
-				   sqlite3_column_bytes(stmt, col));
 }
 
 static bool wallet_peer_load(struct wallet *w, const u64 id, struct peer *peer)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1,7 +1,6 @@
 #include "wallet.h"
 
 #include <bitcoin/script.h>
-#include <ccan/str/hex/hex.h>
 #include <ccan/tal/str/str.h>
 #include <inttypes.h>
 #include <lightningd/lightningd.h>

--- a/wallet/wallet_tests.c
+++ b/wallet/wallet_tests.c
@@ -11,6 +11,20 @@
 void invoice_add(struct invoices *invs,
 		 struct invoice *inv){}
 
+/**
+ * mempat -- Set the memory to a pattern
+ *
+ * Used mainly to check that we don't mix fields while
+ * serializing/unserializing.
+ */
+static void mempat(void *dst, size_t len)
+{
+	static int n = 0;
+	u8 *p = (u8*)dst;
+	for(int i=0 ; i < len; ++i)
+		p[i] = n % 251; /* Prime */
+}
+
 static struct wallet *create_test_wallet(const tal_t *ctx)
 {
 	char filename[] = "/tmp/ldb-XXXXXX";
@@ -204,12 +218,12 @@ static bool test_channel_crud(const tal_t *ctx)
 	memset(c2, 0, sizeof(*c2));
 	memset(&p, 0, sizeof(p));
 	memset(&ci, 3, sizeof(ci));
-	memset(hash, 'B', sizeof(*hash));
-	memset(sig, 0, sizeof(*sig));
-	memset(&last_commit, 0, sizeof(last_commit));
+	mempat(hash, sizeof(*hash));
+	mempat(sig, sizeof(*sig));
+	mempat(&last_commit, sizeof(last_commit));
 	pubkey_from_der(tal_hexdata(w, "02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66), 33, &pk);
 	ci.feerate_per_kw = 31337;
-	memset(&p.id, 'A', sizeof(p.id));
+	mempat(&p.id, sizeof(p.id));
 	c1.peer = &p;
 	p.id = pk;
 	p.our_msatoshi = NULL;


### PR DESCRIPTION
Thou shalt not build SQL queries as string, nor shalt you hex encode all binary fields because that's the only way to add them to string based queries...

This took way longer than expected because rebases kept introducing crashes and the slow Travis didn't help either.