### PR TITLE
Radical database simplification: everything in transactions

### DIFF
--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -29,6 +29,9 @@ struct bitcoind {
 	/* Where to do logging. */
 	struct log *log;
 
+	/* Main lightningd structure */
+	struct lightningd *ld;
+
 	/* Are we currently running a bitcoind request (it's ratelimited) */
 	bool req_running;
 
@@ -46,7 +49,9 @@ struct bitcoind {
 	bool shutdown;
 };
 
-struct bitcoind *new_bitcoind(const tal_t *ctx, struct log *log);
+struct bitcoind *new_bitcoind(const tal_t *ctx,
+			      struct lightningd *ld,
+			      struct log *log);
 
 void wait_for_bitcoind(struct bitcoind *bitcoind);
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -551,9 +551,9 @@ static void destroy_outgoing_txs(struct chain_topology *topo)
 		tal_free(otx);
 }
 
-struct chain_topology *new_topology(const tal_t *ctx, struct log *log)
+struct chain_topology *new_topology(struct lightningd *ld, struct log *log)
 {
-	struct chain_topology *topo = tal(ctx, struct chain_topology);
+	struct chain_topology *topo = tal(ld, struct chain_topology);
 
 	block_map_init(&topo->block_map);
 	list_head_init(&topo->outgoing_txs);
@@ -562,7 +562,7 @@ struct chain_topology *new_topology(const tal_t *ctx, struct log *log)
 	topo->log = log;
 	topo->default_fee_rate = 40000;
 	topo->override_fee_rate = 0;
-	topo->bitcoind = new_bitcoind(topo, log);
+	topo->bitcoind = new_bitcoind(topo, ld, log);
 #if DEVELOPER
 	topo->dev_no_broadcast = false;
 #endif

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -149,7 +149,7 @@ void broadcast_tx(struct chain_topology *topo,
 				 int exitstatus,
 				 const char *err));
 
-struct chain_topology *new_topology(const tal_t *ctx, struct log *log);
+struct chain_topology *new_topology(struct lightningd *ld, struct log *log);
 void setup_topology(struct chain_topology *topology,
 		    struct timers *timers,
 		    struct timerel poll_time, u32 first_peer_block);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -168,12 +168,7 @@ static void json_invoice(struct command *cmd,
 		return;
 	}
 
-	if (!wallet_invoice_save(cmd->ld->wallet, invoice)) {
-		printf("Could not save the invoice to the database: %s",
-			  cmd->ld->wallet->db->err);
-		command_fail(cmd, "database error");
-		return;
-	}
+	wallet_invoice_save(cmd->ld->wallet, invoice);
 
 	/* Construct bolt11 string. */
 	b11 = new_bolt11(cmd, &invoice->msatoshi);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -287,8 +287,8 @@ static void json_delinvoice(struct command *cmd,
 	}
 
 	if (!wallet_invoice_remove(cmd->ld->wallet, i)) {
-		log_broken(cmd->ld->log, "Error attempting to remove invoice %"PRIu64": %s",
-			   i->id, cmd->ld->wallet->db->err);
+		log_broken(cmd->ld->log, "Error attempting to remove invoice %"PRIu64,
+			   i->id);
 		command_fail(cmd, "Database error");
 		return;
 	}

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -506,7 +506,9 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 		return;
 	}
 
+	db_begin_transaction(jcon->ld->wallet->db);
 	cmd->dispatch(jcon->current, jcon->buffer, params);
+	db_commit_transaction(jcon->ld->wallet->db);
 }
 
 static struct io_plan *write_json(struct io_conn *conn,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -315,8 +315,11 @@ int main(int argc, char *argv[])
 		if (v == ld)
 			break;
 
-		if (expired)
+		if (expired) {
+			db_begin_transaction(ld->wallet->db);
 			timer_expired(ld, expired);
+			db_commit_transaction(ld->wallet->db);
+		}
 	}
 
 	shutdown_subdaemons(ld);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -261,16 +261,19 @@ int main(int argc, char *argv[])
 	/* Now we know our ID, we can set our color/alias if not already. */
 	setup_color_and_alias(ld);
 
-	/* Initialize block topology. */
+	/* Initialize block topology (does its own transaction) */
 	setup_topology(ld->topology,
 		       &ld->timers,
 		       ld->config.poll_time,
 		       /* FIXME: Load from peers. */
 		       0);
 
+	/* Everything is within a transaction. */
+	db_begin_transaction(ld->wallet->db);
+
 	/* Load invoices from the database */
 	if (!wallet_invoices_load(ld->wallet, ld->invoices)) {
-		err(1, "Could not load invoices from the database");
+		fatal("Could not load invoices from the database");
 	}
 
 	/* Set up gossip daemon. */
@@ -288,12 +291,14 @@ int main(int argc, char *argv[])
 		peer->owner = NULL;
 		if (!wallet_htlcs_load_for_channel(ld->wallet, peer->channel,
 						   &ld->htlcs_in, &ld->htlcs_out)) {
-			err(1, "could not load htlcs for channel: %s", ld->wallet->db->err);
+			fatal("could not load htlcs for channel");
 		}
 	}
-	if (!wallet_htlcs_reconnect(ld->wallet, &ld->htlcs_in, &ld->htlcs_out)) {
-		errx(1, "could not reconnect htlcs loaded from wallet, wallet may be inconsistent.");
-	}
+	if (!wallet_htlcs_reconnect(ld->wallet, &ld->htlcs_in, &ld->htlcs_out))
+		fatal("could not reconnect htlcs loaded from wallet, wallet may be inconsistent.");
+
+	db_commit_transaction(ld->wallet->db);
+
 	/* Create RPC socket (if any) */
 	setup_jsonrpc(ld, ld->rpc_filename);
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -252,10 +252,7 @@ void peer_set_condition(struct peer *peer, enum peer_state old_state,
 	if (peer_persists(peer)) {
 		assert(peer->channel != NULL);
 		/* TODO(cdecker) Selectively save updated fields to DB */
-		if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-			fatal("Could not save channel to database: %s",
-			      peer->ld->wallet->db->err);
-		}
+		wallet_channel_save(peer->ld->wallet, peer->channel);
 	}
 }
 
@@ -447,9 +444,7 @@ static struct wallet_channel *peer_channel_new(struct wallet *w,
 	wallet_peer_by_nodeid(w, &peer->id, peer);
 	wc->id = 0;
 
-	if (!wallet_channel_save(w, wc)) {
-		fatal("Unable to save channel to database: %s", w->db->err);
-	}
+	wallet_channel_save(w, wc);
 
 	return wc;
 }
@@ -1668,10 +1663,7 @@ static void peer_got_shutdown(struct peer *peer, const u8 *msg)
 	}
 
 	/* TODO(cdecker) Selectively save updated fields to DB */
-	if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      peer->ld->wallet->db->err);
-	}
+	wallet_channel_save(peer->ld->wallet, peer->channel);
 }
 
 void peer_last_tx(struct peer *peer, struct bitcoin_tx *tx,
@@ -1733,11 +1725,7 @@ static void peer_received_closing_signature(struct peer *peer, const u8 *msg)
 	/* FIXME: Make sure signature is correct! */
 	if (better_closing_fee(peer, tx)) {
 		/* TODO(cdecker) Selectively save updated fields to DB */
-		if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-			fatal("Could not save channel to database: %s",
-			      peer->ld->wallet->db->err);
-		}
-
+		wallet_channel_save(peer->ld->wallet, peer->channel);
 		peer_last_tx(peer, tx, &sig);
 	}
 
@@ -2313,10 +2301,7 @@ static void peer_accept_channel(struct lightningd *ld,
 	/* Store the channel in the database in order to get a channel
 	 * ID that is unique and which we can base the peer_seed on */
 	peer->channel = peer_channel_new(ld->wallet, peer);
-	if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      peer->ld->wallet->db->err);
-	}
+	wallet_channel_save(peer->ld->wallet, peer->channel);
 	peer->seed = tal(peer, struct privkey);
 	derive_peer_seed(ld, peer->seed, &peer->id, peer->channel->id);
 
@@ -2377,10 +2362,7 @@ static void peer_offer_channel(struct lightningd *ld,
 	/* Store the channel in the database in order to get a channel
 	 * ID that is unique and which we can base the peer_seed on */
 	fc->peer->channel = peer_channel_new(ld->wallet, fc->peer);
-	if (!wallet_channel_save(fc->peer->ld->wallet, fc->peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      fc->peer->ld->wallet->db->err);
-	}
+	wallet_channel_save(fc->peer->ld->wallet, fc->peer->channel);
 	fc->peer->seed = tal(fc->peer, struct privkey);
 	derive_peer_seed(ld, fc->peer->seed, &fc->peer->id,
 			 fc->peer->channel->id);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -56,8 +56,7 @@ static bool htlc_in_update_state(struct peer *peer,
 	if (!state_update_ok(peer, hin->hstate, newstate, hin->key.id, "in"))
 		return false;
 
-	if (!wallet_htlc_update(peer->ld->wallet, hin->dbid, newstate, hin->preimage))
-		return false;
+	wallet_htlc_update(peer->ld->wallet, hin->dbid, newstate, hin->preimage);
 
 	hin->hstate = newstate;
 	htlc_in_check(hin, __func__);
@@ -71,8 +70,7 @@ static bool htlc_out_update_state(struct peer *peer,
 	if (!state_update_ok(peer, hout->hstate, newstate, hout->key.id, "out"))
 		return false;
 
-	if (!wallet_htlc_update(peer->ld->wallet, hout->dbid, newstate, NULL))
-		return false;
+	wallet_htlc_update(peer->ld->wallet, hout->dbid, newstate, NULL);
 
 	hout->hstate = newstate;
 	htlc_out_check(hout, __func__);
@@ -919,12 +917,8 @@ static bool update_out_htlc(struct peer *peer, u64 id, enum htlc_state newstate)
 		return false;
 	}
 
-	if (!hout->dbid && !wallet_htlc_save_out(peer->ld->wallet, peer->channel, hout)) {
-		peer_internal_error(
-		    peer, "Unable to save the htlc_out to the database: %s",
-		    peer->ld->wallet->db->err);
-		return false;
-	}
+	if (!hout->dbid)
+		wallet_htlc_save_out(peer->ld->wallet, peer->channel, hout);
 
 	if (!htlc_out_update_state(peer, hout, newstate))
 		return false;
@@ -962,10 +956,7 @@ static bool peer_save_commitsig_received(struct peer *peer, u64 commitnum)
 	peer->next_index[LOCAL]++;
 
 	/* FIXME: Save to database, with sig and HTLCs. */
-	if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      peer->ld->wallet->db->err);
-	}
+	wallet_channel_save(peer->ld->wallet, peer->channel);
 	return true;
 }
 
@@ -982,11 +973,7 @@ static bool peer_save_commitsig_sent(struct peer *peer, u64 commitnum)
 	peer->next_index[REMOTE]++;
 
 	/* FIXME: Save to database, with sig and HTLCs. */
-	if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      peer->ld->wallet->db->err);
-	}
-
+	wallet_channel_save(peer->ld->wallet, peer->channel);
 	return true;
 }
 
@@ -1283,10 +1270,7 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 		hin = find_htlc_in(&peer->ld->htlcs_in, peer, changed[i].id);
 		local_fail_htlc(hin, failcodes[i]);
 	}
-	if (!wallet_channel_save(peer->ld->wallet, peer->channel)) {
-		fatal("Could not save channel to database: %s",
-		      peer->ld->wallet->db->err);
-	}
+	wallet_channel_save(peer->ld->wallet, peer->channel);
 }
 
 static void *tal_arr_append_(void **p, size_t size)

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -31,7 +31,7 @@ struct subd {
 	/* For logging */
 	struct log *log;
 
-	/* Callback when non-reply message comes in. */
+	/* Callback when non-reply message comes in (inside db transaction) */
 	unsigned (*msgcb)(struct subd *, const u8 *, const int *);
 	const char *(*msgname)(int msgtype);
 
@@ -57,7 +57,7 @@ struct subd {
  * @ld: global state
  * @name: basename of daemon
  * @msgname: function to get name from messages
- * @msgcb: function to call when non-fatal message received (or NULL)
+ * @msgcb: function to call (inside db transaction) when non-fatal message received (or NULL)
  * @...: NULL-terminated list of pointers to  fds to hand as fd 3, 4...
  *	(can be take, if so, set to -1)
  *
@@ -78,7 +78,7 @@ struct subd *new_global_subd(struct lightningd *ld,
  * @name: basename of daemon
  * @peer: peer to associate.
  * @msgname: function to get name from messages
- * @msgcb: function to call when non-fatal message received (or NULL)
+ * @msgcb: function to call (inside db transaction) when non-fatal message received (or NULL)
  * @...: NULL-terminated list of pointers to  fds to hand as fd 3, 4...
  *	(can be take, if so, set to -1)
  *
@@ -122,7 +122,7 @@ void subd_send_fd(struct subd *sd, int fd);
  * @msg_out: request message (can be take)
  * @fd_out: if >=0 fd to pass at the end of the message (closed after)
  * @num_fds_in: how many fds to read in to hand to @replycb if it's a reply.
- * @replycb: callback when reply comes in (can free subd)
+ * @replycb: callback (inside db transaction) when reply comes in (can free subd)
  * @replycb_data: final arg to hand to @replycb
  *
  * @replycb cannot free @sd, so it returns false to remove it.

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -7,11 +7,11 @@ int unused_main(int argc, char *argv[]);
 /* Generated stub for crashlog_activate */
 void crashlog_activate(const char *argv0 UNNEEDED, struct log *log UNNEEDED)
 { fprintf(stderr, "crashlog_activate called!\n"); abort(); }
-/* Generated stub for db_begin_transaction */
-bool db_begin_transaction(struct db *db UNNEEDED)
-{ fprintf(stderr, "db_begin_transaction called!\n"); abort(); }
+/* Generated stub for db_begin_transaction_ */
+void db_begin_transaction_(struct db *db UNNEEDED, const char *location UNNEEDED)
+{ fprintf(stderr, "db_begin_transaction_ called!\n"); abort(); }
 /* Generated stub for db_commit_transaction */
-bool db_commit_transaction(struct db *db UNNEEDED)
+void db_commit_transaction(struct db *db UNNEEDED)
 { fprintf(stderr, "db_commit_transaction called!\n"); abort(); }
 /* Generated stub for debug_poll */
 int debug_poll(struct pollfd *fds UNNEEDED, nfds_t nfds UNNEEDED, int timeout UNNEEDED)

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -7,9 +7,18 @@ int unused_main(int argc, char *argv[]);
 /* Generated stub for crashlog_activate */
 void crashlog_activate(const char *argv0 UNNEEDED, struct log *log UNNEEDED)
 { fprintf(stderr, "crashlog_activate called!\n"); abort(); }
+/* Generated stub for db_begin_transaction */
+bool db_begin_transaction(struct db *db UNNEEDED)
+{ fprintf(stderr, "db_begin_transaction called!\n"); abort(); }
+/* Generated stub for db_commit_transaction */
+bool db_commit_transaction(struct db *db UNNEEDED)
+{ fprintf(stderr, "db_commit_transaction called!\n"); abort(); }
 /* Generated stub for debug_poll */
 int debug_poll(struct pollfd *fds UNNEEDED, nfds_t nfds UNNEEDED, int timeout UNNEEDED)
 { fprintf(stderr, "debug_poll called!\n"); abort(); }
+/* Generated stub for fatal */
+void   fatal(const char *fmt UNNEEDED, ...)
+{ fprintf(stderr, "fatal called!\n"); abort(); }
 /* Generated stub for gossip_init */
 void gossip_init(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "gossip_init called!\n"); abort(); }

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -47,7 +47,7 @@ struct log_book *new_log_book(const tal_t *ctx UNNEEDED,
 			      enum log_level printlevel UNNEEDED)
 { fprintf(stderr, "new_log_book called!\n"); abort(); }
 /* Generated stub for new_topology */
-struct chain_topology *new_topology(const tal_t *ctx UNNEEDED, struct log *log UNNEEDED)
+struct chain_topology *new_topology(struct lightningd *ld UNNEEDED, struct log *log UNNEEDED)
 { fprintf(stderr, "new_topology called!\n"); abort(); }
 /* Generated stub for populate_peer */
 void populate_peer(struct lightningd *ld UNNEEDED, struct peer *peer UNNEEDED)

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -161,7 +161,7 @@ static void db_do_exec(const char *caller, struct db *db, const char *cmd)
 	}
 }
 
-void PRINTF_FMT(3, 4)
+static void PRINTF_FMT(3, 4)
     db_exec(const char *caller, struct db *db, const char *fmt, ...)
 {
 	va_list ap;

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -366,13 +366,15 @@ static int db_migration_count(void)
 static bool db_migrate(struct db *db)
 {
 	/* Attempt to read the version from the database */
-	int current = db_get_version(db);
-	int available = db_migration_count();
+	int current, available;
 
 	if (!db_begin_transaction(db)) {
 		/* No need to rollback, we didn't even start... */
 		return false;
 	}
+
+	current = db_get_version(db);
+	available = db_migration_count();
 
 	while (++current <= available) {
 		if (!db_exec(__func__, db, "%s", dbmigrations[current]))

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -227,12 +227,15 @@ static void close_db(struct db *db) { sqlite3_close(db->sql); }
 
 bool db_begin_transaction(struct db *db)
 {
-	assert(!db->in_transaction);
-	/* Clear any errors from previous transactions and
-	 * non-transactional queries */
-	db_clear_error(db);
-	db->in_transaction = db_exec(__func__, db, "BEGIN TRANSACTION;");
-	return db->in_transaction;
+	if (!db->in_transaction) {
+		/* Clear any errors from previous transactions and
+		 * non-transactional queries */
+		db_clear_error(db);
+		db->in_transaction = db_exec(__func__, db, "BEGIN TRANSACTION;");
+		assert(db->in_transaction);
+		return db->in_transaction;
+	}
+	return false;
 }
 
 bool db_commit_transaction(struct db *db)

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -235,6 +235,7 @@ bool db_begin_transaction(struct db *db)
 		assert(db->in_transaction);
 		return db->in_transaction;
 	}
+	db->in_transaction++;
 	return false;
 }
 
@@ -242,7 +243,7 @@ bool db_commit_transaction(struct db *db)
 {
 	assert(db->in_transaction);
 	bool ret = db_exec(__func__, db, "COMMIT;");
-	db->in_transaction = false;
+	db->in_transaction--;
 	return ret;
 }
 
@@ -250,7 +251,7 @@ bool db_rollback_transaction(struct db *db)
 {
 	assert(db->in_transaction);
 	bool ret = db_exec(__func__, db, "ROLLBACK;");
-	db->in_transaction = false;
+	db->in_transaction--;
 	return ret;
 }
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -122,86 +122,64 @@ char *dbmigrations[] = {
     NULL,
 };
 
-/**
- * db_clear_error - Clear any errors from previous queries
- */
-static void db_clear_error(struct db *db)
-{
-	db->err = tal_free(db->err);
-}
-
 sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query)
 {
 	int err;
 	sqlite3_stmt *stmt;
-	if (db->in_transaction && db->err)
-		return NULL;
 
-	db_clear_error(db);
+	assert(db->in_transaction);
+
 	err = sqlite3_prepare_v2(db->sql, query, -1, &stmt, NULL);
 
-	if (err != SQLITE_OK) {
-		db->err = tal_fmt(db, "%s: %s: %s", caller, query,
-				  sqlite3_errmsg(db->sql));
-	}
+	if (err != SQLITE_OK)
+		fatal("%s: %s: %s", caller, query, sqlite3_errmsg(db->sql));
+
 	return stmt;
 }
 
-bool db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt)
+void db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt)
 {
-	if (db->in_transaction && db->err) {
-		goto fail;
-	}
+	assert(db->in_transaction);
 
-	db_clear_error(db);
-
-	if (sqlite3_step(stmt) !=  SQLITE_DONE) {
-		db->err =
-		    tal_fmt(db, "%s: %s", caller, sqlite3_errmsg(db->sql));
-		goto fail;
-	}
+	if (sqlite3_step(stmt) !=  SQLITE_DONE)
+		fatal("%s: %s", caller, sqlite3_errmsg(db->sql));
 
 	sqlite3_finalize(stmt);
-	return true;
-fail:
-	sqlite3_finalize(stmt);
-	return false;
 }
 
-bool PRINTF_FMT(3, 4)
+/* This one doesn't check if we're in a transaction. */
+static void db_do_exec(const char *caller, struct db *db, const char *cmd)
+{
+	char *errmsg;
+	int err;
+
+	err = sqlite3_exec(db->sql, cmd, NULL, NULL, &errmsg);
+	if (err != SQLITE_OK) {
+		fatal("%s:%s:%s:%s", caller, sqlite3_errstr(err), cmd, errmsg);
+		/* Only reached in testing */
+		sqlite3_free(errmsg);
+	}
+}
+
+void PRINTF_FMT(3, 4)
     db_exec(const char *caller, struct db *db, const char *fmt, ...)
 {
 	va_list ap;
-	char *cmd, *errmsg;
-	int err;
+	char *cmd;
 
-	if (db->in_transaction && db->err)
-		return false;
-
-	db_clear_error(db);
+	assert(db->in_transaction);
 
 	va_start(ap, fmt);
 	cmd = tal_vfmt(db, fmt, ap);
 	va_end(ap);
 
-	err = sqlite3_exec(db->sql, cmd, NULL, NULL, &errmsg);
-	if (err != SQLITE_OK) {
-		tal_free(db->err);
-		db->err = tal_fmt(db, "%s:%s:%s:%s", caller,
-				  sqlite3_errstr(err), cmd, errmsg);
-		sqlite3_free(errmsg);
-		tal_free(cmd);
-		return false;
-	}
+	db_do_exec(caller, db, cmd);
 	tal_free(cmd);
-	return true;
 }
 
 bool db_exec_prepared_mayfail_(const char *caller, struct db *db, sqlite3_stmt *stmt)
 {
-	if (db->in_transaction && db->err) {
-		goto fail;
-	}
+	assert(db->in_transaction);
 
 	if (sqlite3_step(stmt) != SQLITE_DONE) {
 		goto fail;
@@ -221,10 +199,7 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 	char *query;
 	sqlite3_stmt *stmt;
 
-	if (db->in_transaction && db->err)
-		return NULL;
-
-	db_clear_error(db);
+	assert(db->in_transaction);
 
 	va_start(ap, fmt);
 	query = tal_vfmt(db, fmt, ap);
@@ -237,50 +212,20 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 
 static void close_db(struct db *db) { sqlite3_close(db->sql); }
 
-bool db_begin_transaction(struct db *db)
+void db_begin_transaction_(struct db *db, const char *location)
 {
-	if (!db->in_transaction) {
-		/* Clear any errors from previous transactions and
-		 * non-transactional queries */
-		db_clear_error(db);
-		db->in_transaction = db_exec(__func__, db, "BEGIN TRANSACTION;");
-		assert(db->in_transaction);
-		return db->in_transaction;
-	}
-	db->in_transaction++;
-	return false;
+	if (db->in_transaction)
+		fatal("Already in transaction from %s", db->in_transaction);
+
+	db_do_exec(location, db, "BEGIN TRANSACTION;");
+	db->in_transaction = location;
 }
 
-bool db_commit_transaction(struct db *db)
-{
-	bool ret;
-
-	assert(db->in_transaction);
-	if (db->err) {
-		char *errmsg;
-		int err;
-
-		/* Do this manually: db_exec is a NOOP with db->err */
-		err = sqlite3_exec(db->sql, "ROLLBACK;", NULL, NULL, &errmsg);
-		if (err != SQLITE_OK) {
-			db->err = tal_fmt(db, "%s then ROLLBACK failed:%s:%s",
-					  db->err, sqlite3_errstr(err), errmsg);
-			sqlite3_free(errmsg);
-		}
-		ret = false;
-	} else {
-		ret = db_exec(__func__, db, "COMMIT;");
-	}
-	db->in_transaction--;
-	return ret;
-}
-
-bool db_rollback_transaction(struct db *db)
+void db_commit_transaction(struct db *db)
 {
 	assert(db->in_transaction);
-	bool ret = db_exec(__func__, db, "ROLLBACK;");
-	db->in_transaction--;
-	return ret;
+	db_exec(__func__, db, "COMMIT;");
+	db->in_transaction = NULL;
 }
 
 /**
@@ -308,11 +253,8 @@ static struct db *db_open(const tal_t *ctx, char *filename)
 	db->filename = tal_dup_arr(db, char, filename, strlen(filename), 0);
 	db->sql = sql;
 	tal_add_destructor(db, close_db);
-	db->in_transaction = false;
-	db->err = NULL;
-	if (!db_exec(__func__, db, "PRAGMA foreign_keys = ON;")) {
-		fatal("Could not enable foreignkeys on database: %s", db->err);
-	}
+	db->in_transaction = NULL;
+	db_do_exec(__func__, db, "PRAGMA foreign_keys = ON;");
 
 	return db;
 }
@@ -411,16 +353,14 @@ s64 db_get_intvar(struct db *db, char *varname, s64 defval)
 	return res;
 }
 
-bool db_set_intvar(struct db *db, char *varname, s64 val)
+void db_set_intvar(struct db *db, char *varname, s64 val)
 {
 	/* Attempt to update */
 	db_exec(__func__, db,
 		"UPDATE vars SET val='%" PRId64 "' WHERE name='%s';", val,
 		varname);
-	if (sqlite3_changes(db->sql) > 0)
-		return true;
-	else
-		return db_exec(
+	if (sqlite3_changes(db->sql) == 0)
+		db_exec(
 		    __func__, db,
 		    "INSERT INTO vars (name, val) VALUES ('%s', '%" PRId64
 		    "');",

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -203,7 +203,6 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 	va_list ap;
 	char *query;
 	sqlite3_stmt *stmt;
-	int err;
 
 	if (db->in_transaction && db->err)
 		return NULL;
@@ -214,12 +213,8 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 	query = tal_vfmt(db, fmt, ap);
 	va_end(ap);
 
-	err = sqlite3_prepare_v2(db->sql, query, -1, &stmt, NULL);
-	if (err != SQLITE_OK) {
-		db->in_transaction = false;
-		db->err = tal_fmt(db, "%s:%s:%s:%s", caller,
-				  sqlite3_errstr(err), query, sqlite3_errmsg(db->sql));
-	}
+	/* Sets stmt to NULL if not SQLITE_OK */
+	sqlite3_prepare_v2(db->sql, query, -1, &stmt, NULL);
 	return stmt;
 }
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -197,6 +197,23 @@ bool PRINTF_FMT(3, 4)
 	return true;
 }
 
+bool db_exec_prepared_mayfail_(const char *caller, struct db *db, sqlite3_stmt *stmt)
+{
+	if (db->in_transaction && db->err) {
+		goto fail;
+	}
+
+	if (sqlite3_step(stmt) != SQLITE_DONE) {
+		goto fail;
+	}
+
+	sqlite3_finalize(stmt);
+	return true;
+fail:
+	sqlite3_finalize(stmt);
+	return false;
+}
+
 sqlite3_stmt *PRINTF_FMT(3, 4)
     db_query(const char *caller, struct db *db, const char *fmt, ...)
 {

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -44,9 +44,11 @@ bool PRINTF_FMT(3, 4)
 /**
  * db_begin_transaction - Begin a transaction
  *
- * We do not support nesting multiple transactions, so make sure that
- * we are not in a transaction when calling this. Returns true if we
- * succeeded in starting a transaction.
+ * Begin a new DB transaction if we aren't already in one. Returns
+ * true if the call started a transaction, i.e., the caller MUST take
+ * care to either commit or rollback. If false, this is a nested
+ * transaction and the caller MUST not commit/rollback, since the
+ * transaction is handled at a higher level in the callstack.
  */
 bool db_begin_transaction(struct db *db);
 

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -112,6 +112,15 @@ sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query);
 #define db_exec_prepared(db,stmt) db_exec_prepared_(__func__,db,stmt)
 bool db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt);
 
+/**
+ * db_exec_prepared_mayfail - db_exec_prepared, but don't set db->err if it fails.
+ */
+#define db_exec_prepared_mayfail(db,stmt) \
+	db_exec_prepared_mayfail_(__func__,db,stmt)
+bool db_exec_prepared_mayfail_(const char *caller,
+			       struct db *db,
+			       sqlite3_stmt *stmt);
+
 bool sqlite3_bind_short_channel_id(sqlite3_stmt *stmt, int col,
 				   const struct short_channel_id *id);
 bool sqlite3_column_short_channel_id(sqlite3_stmt *stmt, int col,

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -39,12 +39,6 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 	db_query(const char *caller, struct db *db, const char *fmt, ...);
 
 /**
- * db_exec - execute a statement, call fatal() if it fails.
- */
-void PRINTF_FMT(3, 4)
-	db_exec(const char *caller, struct db *db, const char *fmt, ...);
-
-/**
  * db_begin_transaction - Begin a transaction
  *
  * Begin a new DB transaction.  fatal() on database error.

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -15,7 +15,7 @@
 
 struct db {
 	char *filename;
-	bool in_transaction;
+	unsigned int in_transaction;
 	const char *err;
 	sqlite3 *sql;
 };

--- a/wallet/db_tests.c
+++ b/wallet/db_tests.c
@@ -24,7 +24,7 @@ static bool test_empty_db_migrate(void)
 	struct db *db = create_test_db(__func__);
 	CHECK(db);
 	CHECK(db_get_version(db) == -1);
-	CHECK(db_migrate(db));
+	db_migrate(db);
 	CHECK(db_get_version(db) == db_migration_count());
 
 	tal_free(db);
@@ -55,7 +55,7 @@ static bool test_vars(void)
 	struct db *db = create_test_db(__func__);
 	char *varname = "testvar";
 	CHECK(db);
-	CHECK(db_migrate(db));
+	db_migrate(db);
 
 	/* Check default behavior */
 	CHECK(db_get_intvar(db, varname, 42) == 42);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -18,9 +18,6 @@ struct wallet *wallet_new(const tal_t *ctx, struct log *log)
 	wallet->db = db_setup(wallet);
 	wallet->log = log;
 	wallet->bip32_base = NULL;
-	if (!wallet->db) {
-		fatal("Unable to setup the wallet database");
-	}
 	return wallet;
 }
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -24,6 +24,7 @@ struct wallet *wallet_new(const tal_t *ctx, struct log *log)
 	return wallet;
 }
 
+/* We actually use the db constraints to uniquify, so OK if this fails. */
 bool wallet_add_utxo(struct wallet *w, struct utxo *utxo,
 		     enum wallet_output_type type)
 {
@@ -36,7 +37,7 @@ bool wallet_add_utxo(struct wallet *w, struct utxo *utxo,
 	sqlite3_bind_int(stmt, 4, type);
 	sqlite3_bind_int(stmt, 5, output_state_available);
 	sqlite3_bind_int(stmt, 6, utxo->keyindex);
-	return db_exec_prepared(w->db, stmt);
+	return db_exec_prepared_mayfail(w->db, stmt);
 }
 
 /**

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -141,7 +141,7 @@ s64 wallet_get_newindex(struct lightningd *ld);
 /**
  * wallet_shachain_init -- wallet wrapper around shachain_init
  */
-bool wallet_shachain_init(struct wallet *wallet, struct wallet_shachain *chain);
+void wallet_shachain_init(struct wallet *wallet, struct wallet_shachain *chain);
 
 /**
  * wallet_shachain_add_hash -- wallet wrapper around shachain_add_hash

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -179,12 +179,12 @@ bool wallet_channel_load(struct wallet *w, const u64 id,
  * @chan: the instance to store (not const so we can update the unique_id upon
  *   insert)
  */
-bool wallet_channel_save(struct wallet *w, struct wallet_channel *chan);
+void wallet_channel_save(struct wallet *w, struct wallet_channel *chan);
 
 /**
  * wallet_channel_config_save -- Upsert a channel_config into the database
  */
-bool wallet_channel_config_save(struct wallet *w, struct channel_config *cc);
+void wallet_channel_config_save(struct wallet *w, struct channel_config *cc);
 
 /**
  * wallet_channel_config_load -- Load channel_config from database into cc
@@ -237,7 +237,7 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
  * for state transitions or to set the `payment_key` for completed
  * HTLCs.
  */
-bool wallet_htlc_save_in(struct wallet *wallet,
+void wallet_htlc_save_in(struct wallet *wallet,
 			 const struct wallet_channel *chan, struct htlc_in *in);
 
 /**
@@ -245,7 +245,7 @@ bool wallet_htlc_save_in(struct wallet *wallet,
  *
  * See comment for wallet_htlc_save_in.
  */
-bool wallet_htlc_save_out(struct wallet *wallet,
+void wallet_htlc_save_out(struct wallet *wallet,
 			  const struct wallet_channel *chan,
 			  struct htlc_out *out);
 
@@ -262,7 +262,7 @@ bool wallet_htlc_save_out(struct wallet *wallet,
  * `struct htlc_out` and optionally set the `payment_key` should the
  * HTLC have been settled.
  */
-bool wallet_htlc_update(struct wallet *wallet, const u64 htlc_dbid,
+void wallet_htlc_update(struct wallet *wallet, const u64 htlc_dbid,
 			const enum htlc_state new_state,
 			const struct preimage *payment_key);
 
@@ -312,7 +312,7 @@ bool wallet_htlcs_reconnect(struct wallet *wallet,
  * @wallet: Wallet to store in
  * @inv: Invoice to save
  */
-bool wallet_invoice_save(struct wallet *wallet, struct invoice *inv);
+void wallet_invoice_save(struct wallet *wallet, struct invoice *inv);
 
 /**
  * wallet_invoices_load -- Load all invoices into memory

--- a/wallet/wallet_tests.c
+++ b/wallet/wallet_tests.c
@@ -1,12 +1,31 @@
+  #include <lightningd/log.h>
+
+static void wallet_fatal(const char *fmt, ...);
+#define fatal wallet_fatal
+
 #include "wallet.c"
 
 #include "db.c"
 
 #include <ccan/mem/mem.h>
-#include <lightningd/log.h>
+#include <ccan/tal/str/str.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <wallet/test_utils.h>
+
+static char *wallet_err;
+static void wallet_fatal(const char *fmt, ...)
+{
+	va_list ap;
+
+	/* Fail hard if we're complaining about not being in transaction */
+	assert(!strstarts(fmt, "No longer in transaction"));
+
+	va_start(ap, fmt);
+	wallet_err = tal_vfmt(NULL, fmt, ap);
+	va_end(ap);
+}
 
 void invoice_add(struct invoices *invs,
 		 struct invoice *inv){}
@@ -37,7 +56,8 @@ static struct wallet *create_test_wallet(const tal_t *ctx)
 	w->db = db_open(w, filename);
 
 	CHECK_MSG(w->db, "Failed opening the db");
-	CHECK_MSG(db_migrate(w->db), "DB migration failed");
+	db_migrate(w->db);
+	CHECK_MSG(!wallet_err, "DB migration failed");
 
 	ltmp = tal_tmpctx(ctx);
 	log_book = new_log_book(w, 20*1024*1024, LOG_DBG);
@@ -57,7 +77,8 @@ static bool test_wallet_outputs(void)
 
 	w->db = db_open(w, filename);
 	CHECK_MSG(w->db, "Failed opening the db");
-	CHECK_MSG(db_migrate(w->db), "DB migration failed");
+	db_migrate(w->db);
+	CHECK_MSG(!wallet_err, "DB migration failed");
 
 	memset(&u, 0, sizeof(u));
 
@@ -108,7 +129,8 @@ static bool test_shachain_crud(void)
 
 	w->db = db_open(w, filename);
 	CHECK_MSG(w->db, "Failed opening the db");
-	CHECK_MSG(db_migrate(w->db), "DB migration failed");
+	db_migrate(w->db);
+	CHECK_MSG(!wallet_err, "DB migration failed");
 
 	CHECK_MSG(fd != -1, "Unable to generate temp filename");
 	close(fd);

--- a/wallet/wallet_tests.c
+++ b/wallet/wallet_tests.c
@@ -22,13 +22,16 @@ static void wallet_fatal(const char *fmt, ...)
 	/* Fail hard if we're complaining about not being in transaction */
 	assert(!strstarts(fmt, "No longer in transaction"));
 
+	/* Fail hard if we're complaining about not being in transaction */
+	assert(!strstarts(fmt, "No longer in transaction"));
+
 	va_start(ap, fmt);
 	wallet_err = tal_vfmt(NULL, fmt, ap);
 	va_end(ap);
 }
 
 #define transaction_wrap(db, ...)					\
-	(db_begin_transaction(db), __VA_ARGS__, db_commit_transaction(db))
+	(db_begin_transaction(db), __VA_ARGS__, db_commit_transaction(db), wallet_err == NULL)
 
 void invoice_add(struct invoices *invs,
 		 struct invoice *inv){}
@@ -85,6 +88,8 @@ static bool test_wallet_outputs(void)
 
 	memset(&u, 0, sizeof(u));
 
+	db_begin_transaction(w->db);
+
 	/* Should work, it's the first time we add it */
 	CHECK_MSG(wallet_add_utxo(w, &u, p2sh_wpkh),
 		  "wallet_add_utxo failed on first add");
@@ -117,6 +122,7 @@ static bool test_wallet_outputs(void)
 					      output_state_spent),
 		  "could not change output state ignoring oldstate");
 
+	db_commit_transaction(w->db);
 	tal_free(w);
 	return true;
 }
@@ -143,7 +149,10 @@ static bool test_shachain_crud(void)
 	memset(&b, 0, sizeof(b));
 
 	w->db = db_open(w, filename);
-	CHECK(wallet_shachain_init(w, &a));
+	db_begin_transaction(w->db);
+	CHECK_MSG(!wallet_err, "db_begin_transaction failed");
+	wallet_shachain_init(w, &a);
+	CHECK(!wallet_err);
 
 	CHECK(a.id == 1);
 
@@ -158,6 +167,9 @@ static bool test_shachain_crud(void)
 
 	CHECK(wallet_shachain_load(w, a.id, &b));
 	CHECK_MSG(memcmp(&a, &b, sizeof(a)) == 0, "Loading from database doesn't match");
+
+	db_commit_transaction(w->db);
+	CHECK(!wallet_err);
 	tal_free(w);
 	return true;
 }
@@ -261,11 +273,16 @@ static bool test_channel_crud(const tal_t *ctx)
 	ci.remote_per_commit = pk;
 	ci.old_remote_per_commit = pk;
 
+	db_begin_transaction(w->db);
+	CHECK(!wallet_err);
+
 	/* Variant 1: insert with null for scid, funding_tx_id, channel_info, last_tx */
 	wallet_channel_save(w, &c1);
 	CHECK_MSG(!wallet_err,
-		  tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Load from DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v1)");
 
 	/* We just inserted them into an empty DB so this must be 1 */
@@ -277,8 +294,10 @@ static bool test_channel_crud(const tal_t *ctx)
 	c1.peer->scid = talz(w, struct short_channel_id);
 	wallet_channel_save(w, &c1);
 	CHECK_MSG(!wallet_err,
-		  tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v2)");
 
 	/* Updates should not result in new ids */
@@ -290,39 +309,51 @@ static bool test_channel_crud(const tal_t *ctx)
 	c1.peer->our_msatoshi = &msat;
 
 	wallet_channel_save(w, &c1);
-	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v3)");
 
 	/* Variant 4: update with funding_tx_id */
 	c1.peer->funding_txid = hash;
 	wallet_channel_save(w, &c1);
-	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v4)");
 
 	/* Variant 5: update with channel_info */
 	p.channel_info = &ci;
 	wallet_channel_save(w, &c1);
-	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v5)");
 
 	/* Variant 6: update with last_commit_sent */
 	p.last_sent_commit = &last_commit;
 	wallet_channel_save(w, &c1);
-	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v6)");
 
 	/* Variant 7: update with last_tx (taken from BOLT #3) */
 	p.last_tx = bitcoin_tx_from_hex(w, "02000000000101bef67e4e2fb9ddeeb3461973cd4c62abb35050b1add772995b820b584a488489000000000038b02b8003a00f0000000000002200208c48d15160397c9731df9bc3b236656efb6665fbfe92b4a6878e88a499f741c4c0c62d0000000000160014ccf1af2f2aabee14bb40fa3851ab2301de843110ae8f6a00000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e040047304402206a2679efa3c7aaffd2a447fd0df7aba8792858b589750f6a1203f9259173198a022008d52a0e77a99ab533c36206cb15ad7aeb2aa72b93d4b571e728cb5ec2f6fe260147304402206d6cb93969d39177a09d5d45b583f34966195b77c7e585cf47ac5cce0c90cefb022031d71ae4e33a4e80df7f981d696fbdee517337806a3c7138b7491e2cbb077a0e01475221023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb21030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c152ae3e195220", strlen("02000000000101bef67e4e2fb9ddeeb3461973cd4c62abb35050b1add772995b820b584a488489000000000038b02b8003a00f0000000000002200208c48d15160397c9731df9bc3b236656efb6665fbfe92b4a6878e88a499f741c4c0c62d0000000000160014ccf1af2f2aabee14bb40fa3851ab2301de843110ae8f6a00000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e040047304402206a2679efa3c7aaffd2a447fd0df7aba8792858b589750f6a1203f9259173198a022008d52a0e77a99ab533c36206cb15ad7aeb2aa72b93d4b571e728cb5ec2f6fe260147304402206d6cb93969d39177a09d5d45b583f34966195b77c7e585cf47ac5cce0c90cefb022031d71ae4e33a4e80df7f981d696fbdee517337806a3c7138b7491e2cbb077a0e01475221023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb21030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c152ae3e195220"));
 	p.last_sig = sig;
 	wallet_channel_save(w, &c1);
-	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
-	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
+	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB"));
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v7)");
 
+	db_commit_transaction(w->db);
+	CHECK(!wallet_err);
 	tal_free(w);
 	return true;
 }
@@ -346,7 +377,7 @@ static bool test_channel_config_crud(const tal_t *ctx)
 	    cc1->id == 1,
 	    tal_fmt(ctx, "channel_config->id != 1; got %" PRIu64, cc1->id));
 
-	CHECK(wallet_channel_config_load(w, cc1->id, cc2));
+	CHECK(transaction_wrap(w->db, wallet_channel_config_load(w, cc1->id, cc2)));
 	CHECK(memeq(cc1, sizeof(*cc1), cc2, sizeof(*cc2)));
        	return true;
 }
@@ -363,7 +394,8 @@ static bool test_htlc_crud(const tal_t *ctx)
 	struct htlc_out_map *htlcs_out = tal(ctx, struct htlc_out_map);
 
 	/* Make sure we have our references correct */
-	db_exec(__func__, w->db, "INSERT INTO channels (id) VALUES (1);");
+	CHECK(transaction_wrap(w->db,
+			       db_exec(__func__, w->db, "INSERT INTO channels (id) VALUES (1);")));
 	chan->id = 1;
 	chan->peer = peer;
 
@@ -383,11 +415,13 @@ static bool test_htlc_crud(const tal_t *ctx)
 
 	/* Store the htlc_in */
 	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_save_in(w, chan, &in)),
-		  tal_fmt(ctx, "Save htlc_in failed: %s", w->db->err));
+		  tal_fmt(ctx, "Save htlc_in failed: %s", wallet_err));
 	CHECK_MSG(in.dbid != 0, "HTLC DB ID was not set.");
 	/* Saving again should get us a collision */
 	CHECK_MSG(!transaction_wrap(w->db, wallet_htlc_save_in(w, chan, &in)),
 		  "Saving two HTLCs with the same data must not succeed.");
+	CHECK(wallet_err);
+	wallet_err = tal_free(wallet_err);
 
 	/* Update */
 	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, RCVD_ADD_HTLC, NULL)),
@@ -397,21 +431,28 @@ static bool test_htlc_crud(const tal_t *ctx)
 	    "Update HTLC with payment_key failed");
 
 	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_save_out(w, chan, &out)),
-		  tal_fmt(ctx, "Save htlc_out failed: %s", w->db->err));
+		  tal_fmt(ctx, "Save htlc_out failed: %s", wallet_err));
 	CHECK_MSG(out.dbid != 0, "HTLC DB ID was not set.");
 
 	CHECK_MSG(!transaction_wrap(w->db, wallet_htlc_save_out(w, chan, &out)),
 		  "Saving two HTLCs with the same data must not succeed.");
+	CHECK(wallet_err);
+	wallet_err = tal_free(wallet_err);
 
 	/* Attempt to load them from the DB again */
 	htlc_in_map_init(htlcs_in);
 	htlc_out_map_init(htlcs_out);
+
+	db_begin_transaction(w->db);
+	CHECK(!wallet_err);
 
 	CHECK_MSG(wallet_htlcs_load_for_channel(w, chan, htlcs_in, htlcs_out),
 		  "Failed loading HTLCs");
 
 	CHECK_MSG(wallet_htlcs_reconnect(w, htlcs_in, htlcs_out),
 		  "Unable to reconnect htlcs.");
+	db_commit_transaction(w->db);
+	CHECK(!wallet_err);
 
 	hin = htlc_in_map_get(htlcs_in, &in.key);
 	hout = htlc_out_map_get(htlcs_out, &out.key);

--- a/wallet/wallet_tests.c
+++ b/wallet/wallet_tests.c
@@ -27,6 +27,9 @@ static void wallet_fatal(const char *fmt, ...)
 	va_end(ap);
 }
 
+#define transaction_wrap(db, ...)					\
+	(db_begin_transaction(db), __VA_ARGS__, db_commit_transaction(db))
+
 void invoice_add(struct invoices *invs,
 		 struct invoice *inv){}
 
@@ -259,7 +262,9 @@ static bool test_channel_crud(const tal_t *ctx)
 	ci.old_remote_per_commit = pk;
 
 	/* Variant 1: insert with null for scid, funding_tx_id, channel_info, last_tx */
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v1)");
 
@@ -270,7 +275,9 @@ static bool test_channel_crud(const tal_t *ctx)
 
 	/* Variant 2: update with scid set */
 	c1.peer->scid = talz(w, struct short_channel_id);
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err,
+		  tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v2)");
 
@@ -281,32 +288,38 @@ static bool test_channel_crud(const tal_t *ctx)
 
 	/* Variant 3: update with our_satoshi set */
 	c1.peer->our_msatoshi = &msat;
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v3)");
 
 	/* Variant 4: update with funding_tx_id */
 	c1.peer->funding_txid = hash;
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v4)");
 
 	/* Variant 5: update with channel_info */
 	p.channel_info = &ci;
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v5)");
 
 	/* Variant 6: update with last_commit_sent */
 	p.last_sent_commit = &last_commit;
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v6)");
 
 	/* Variant 7: update with last_tx (taken from BOLT #3) */
 	p.last_tx = bitcoin_tx_from_hex(w, "02000000000101bef67e4e2fb9ddeeb3461973cd4c62abb35050b1add772995b820b584a488489000000000038b02b8003a00f0000000000002200208c48d15160397c9731df9bc3b236656efb6665fbfe92b4a6878e88a499f741c4c0c62d0000000000160014ccf1af2f2aabee14bb40fa3851ab2301de843110ae8f6a00000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e040047304402206a2679efa3c7aaffd2a447fd0df7aba8792858b589750f6a1203f9259173198a022008d52a0e77a99ab533c36206cb15ad7aeb2aa72b93d4b571e728cb5ec2f6fe260147304402206d6cb93969d39177a09d5d45b583f34966195b77c7e585cf47ac5cce0c90cefb022031d71ae4e33a4e80df7f981d696fbdee517337806a3c7138b7491e2cbb077a0e01475221023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb21030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c152ae3e195220", strlen("02000000000101bef67e4e2fb9ddeeb3461973cd4c62abb35050b1add772995b820b584a488489000000000038b02b8003a00f0000000000002200208c48d15160397c9731df9bc3b236656efb6665fbfe92b4a6878e88a499f741c4c0c62d0000000000160014ccf1af2f2aabee14bb40fa3851ab2301de843110ae8f6a00000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e040047304402206a2679efa3c7aaffd2a447fd0df7aba8792858b589750f6a1203f9259173198a022008d52a0e77a99ab533c36206cb15ad7aeb2aa72b93d4b571e728cb5ec2f6fe260147304402206d6cb93969d39177a09d5d45b583f34966195b77c7e585cf47ac5cce0c90cefb022031d71ae4e33a4e80df7f981d696fbdee517337806a3c7138b7491e2cbb077a0e01475221023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb21030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c152ae3e195220"));
 	p.last_sig = sig;
-	CHECK_MSG(wallet_channel_save(w, &c1), tal_fmt(w, "Insert into DB: %s", w->db->err));
+	wallet_channel_save(w, &c1);
+	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", w->db->err));
 	CHECK_MSG(wallet_channel_load(w, c1.id, c2), tal_fmt(w, "Load from DB: %s", w->db->err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v7)");
 
@@ -328,7 +341,7 @@ static bool test_channel_config_crud(const tal_t *ctx)
 	cc1->to_self_delay = 5;
 	cc1->max_accepted_htlcs = 6;
 
-	CHECK(wallet_channel_config_save(w, cc1));
+	CHECK(transaction_wrap(w->db, wallet_channel_config_save(w, cc1)));
 	CHECK_MSG(
 	    cc1->id == 1,
 	    tal_fmt(ctx, "channel_config->id != 1; got %" PRIu64, cc1->id));
@@ -369,23 +382,25 @@ static bool test_htlc_crud(const tal_t *ctx)
 	out.msatoshi = 41;
 
 	/* Store the htlc_in */
-	CHECK_MSG(wallet_htlc_save_in(w, chan, &in),
+	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_save_in(w, chan, &in)),
 		  tal_fmt(ctx, "Save htlc_in failed: %s", w->db->err));
 	CHECK_MSG(in.dbid != 0, "HTLC DB ID was not set.");
 	/* Saving again should get us a collision */
-	CHECK_MSG(!wallet_htlc_save_in(w, chan, &in),
+	CHECK_MSG(!transaction_wrap(w->db, wallet_htlc_save_in(w, chan, &in)),
 		  "Saving two HTLCs with the same data must not succeed.");
+
 	/* Update */
-	CHECK_MSG(wallet_htlc_update(w, in.dbid, RCVD_ADD_HTLC, NULL),
+	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, RCVD_ADD_HTLC, NULL)),
 		  "Update HTLC with null payment_key failed");
 	CHECK_MSG(
-	    wallet_htlc_update(w, in.dbid, SENT_REMOVE_HTLC, &payment_key),
+		transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, SENT_REMOVE_HTLC, &payment_key)),
 	    "Update HTLC with payment_key failed");
 
-	CHECK_MSG(wallet_htlc_save_out(w, chan, &out),
+	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_save_out(w, chan, &out)),
 		  tal_fmt(ctx, "Save htlc_out failed: %s", w->db->err));
 	CHECK_MSG(out.dbid != 0, "HTLC DB ID was not set.");
-	CHECK_MSG(!wallet_htlc_save_out(w, chan, &out),
+
+	CHECK_MSG(!transaction_wrap(w->db, wallet_htlc_save_out(w, chan, &out)),
 		  "Saving two HTLCs with the same data must not succeed.");
 
 	/* Attempt to load them from the DB again */


### PR DESCRIPTION
This starts with the first patch on #307 then goes a different direction.  By the end:

1. All database failures are fatal().
2. Every database operation is inside a transaction.
3. No transactions are nested.

There are only five entry points, so we place transactions there:

1.  Setup.
2.  subd message receipt.
3.  json commands.
4.  timers.
5.  bitcoind results.
