### PR TITLE
Switch to use the py.test test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ ifeq ($(COVERAGE),1)
 COVFLAGS = --coverage
 endif
 
+PYTEST := $(shell command -v pytest 2> /dev/null)
+
 # This is where we add new features as bitcoin adds them.
 FEATURES :=
 
@@ -170,7 +172,11 @@ check:
 	$(MAKE) pytest
 
 pytest: $(ALL_PROGRAMS)
+ifndef PYTEST
 	PYTHONPATH=contrib/pylightning DEVELOPER=$(DEVELOPER) python3 tests/test_lightningd.py -f
+else
+	PYTHONPATH=contrib/pylightning TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) -vx tests/test_lightningd.py
+endif
 
 # Keep includes in alpha order.
 check-src-include-order/%: %

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -23,6 +23,7 @@ RUN apt-get -qq update && \
 	valgrind \
 	net-tools \
 	python3-pip \
+	python-pkg-resources \
 	wget && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -32,4 +33,4 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.0/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.0
 
-RUN pip3 install python-bitcoinlib==0.7.0
+RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -23,7 +23,8 @@ RUN apt-get -qq update && \
 	valgrind \
 	net-tools \
 	python3-pip \
-        wget && \
+	python-pkg-resources \
+	wget && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
@@ -32,4 +33,4 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.0/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.0
 
-RUN pip3 install python-bitcoinlib==0.7.0
+RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0


### PR DESCRIPTION
The py.test unit test runner offers a number of more advanced features
than simply running using unittest.main. In particular it allows us to
capture a tests output and print it if it fails. This change checks
whether we have pytest available and if yes, enables verbose tests and
runs using pytest. This'll give the usual experience (with colors!)
and show us the stdout if a test fails making travis a lot easier to
handle.

![selection_003](https://user-images.githubusercontent.com/120117/32609286-7f4ba1da-c55f-11e7-8c97-5ff80a412279.png)
