### PR TITLE
Store pending and completed payments in DB

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -104,6 +104,9 @@ void resolve_invoice(struct lightningd *ld, struct invoice *invoice)
 		tell_waiter(w->cmd, invoice);
 
 	wallet_invoice_save(ld->wallet, invoice);
+
+	/* Also mark the payment in the history table as complete */
+	wallet_payment_set_status(ld->wallet, &invoice->rhash, PAYMENT_COMPLETE);
 }
 
 static void json_invoice(struct command *cmd,
@@ -115,6 +118,7 @@ static void json_invoice(struct command *cmd,
 	struct invoices *invs = cmd->ld->invoices;
 	struct bolt11 *b11;
 	char *b11enc;
+	struct wallet_payment payment;
 
 	if (!json_get_params(buffer, params,
 			     "amount", &msatoshi,
@@ -192,6 +196,20 @@ static void json_invoice(struct command *cmd,
 	/* OK, connect it to main state, respond with hash */
 	tal_steal(invs, invoice);
 	list_add_tail(&invs->invlist, &invoice->list);
+
+	/* Store the payment so we can later show it in the history */
+	payment.id = 0;
+	payment.incoming = true;
+	payment.payment_hash = invoice->rhash;
+	payment.destination = NULL;
+	payment.status = PAYMENT_PENDING;
+	payment.msatoshi = invoice->msatoshi;
+	payment.timestamp = b11->timestamp;
+
+	if (!wallet_payment_add(cmd->ld->wallet, &payment)) {
+		command_fail(cmd, "Unable to record payment in the database.");
+		return;
+	}
 
 	json_object_start(response, NULL);
 	json_add_hex(response, "rhash",

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -194,6 +194,7 @@ static void shutdown_subdaemons(struct lightningd *ld)
 {
 	struct peer *p;
 
+	db_begin_transaction(ld->wallet->db);
 	/* Let everyone shutdown cleanly. */
 	close(ld->hsm_fd);
 	subd_shutdown(ld->gossip, 10);
@@ -202,6 +203,7 @@ static void shutdown_subdaemons(struct lightningd *ld)
 
 	while ((p = list_top(&ld->peers, struct peer, list)) != NULL)
 		tal_free(p);
+	db_commit_transaction(ld->wallet->db);
 }
 
 struct chainparams *get_chainparams(const struct lightningd *ld)

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -68,6 +68,7 @@ void payment_succeeded(struct lightningd *ld, struct htlc_out *hout,
 		       const struct preimage *rval)
 {
 	assert(!hout->pay_command->rval);
+	wallet_payment_set_status(ld->wallet, &hout->payment_hash, PAYMENT_COMPLETE);
 	hout->pay_command->rval = tal_dup(hout->pay_command,
 					  struct preimage, rval);
 	json_pay_success(hout->pay_command->cmd, rval);
@@ -80,6 +81,8 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 	struct pay_command *pc = hout->pay_command;
 	enum onion_type failcode;
 	struct onionreply *reply;
+
+	wallet_payment_set_status(ld->wallet, &hout->payment_hash, PAYMENT_FAILED);
 
 	/* This gives more details than a generic failure message,
 	 * and also the failuremsg here is unencrypted */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -120,6 +120,17 @@ char *dbmigrations[] = {
     "  UNIQUE (label),"
     "  UNIQUE (payment_hash)"
     ");",
+    "CREATE TABLE payments ("
+    "  id INTEGER,"
+    "  timestamp INTEGER,"
+    "  status INTEGER,"
+    "  payment_hash BLOB,"
+    "  direction INTEGER,"
+    "  destination BLOB,"
+    "  msatoshi INTEGER,"
+    "  PRIMARY KEY (id),"
+    "  UNIQUE (payment_hash)"
+    ");",
     NULL,
 };
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -62,6 +62,35 @@ struct wallet_channel {
 	struct peer *peer;
 };
 
+/* Possible states for a wallet_payment. Payments start in
+ * `PENDING`. Outgoing payments are set to `PAYMENT_COMPLETE` once we
+ * get the preimage matching the rhash, or to
+ * `PAYMENT_FAILED`. Incoming payments are set to `PAYMENT_COMPLETE`
+ * once the matching invoice is marked as complete, or `FAILED`
+ * otherwise.  */
+/* /!\ This is a DB ENUM, please do not change the numbering of any
+ * already defined elements (adding is ok) /!\ */
+enum wallet_payment_status {
+	PAYMENT_PENDING = 0,
+	PAYMENT_COMPLETE = 1,
+	PAYMENT_FAILED = 2
+};
+
+/* Incoming and outgoing payments. A simple persisted representation
+ * of a payment we either initiated or received. This can be used by
+ * a UI to display the balance history. We explicitly exclude
+ * forwarded payments.
+ */
+struct wallet_payment {
+	u64 id;
+	u32 timestamp;
+	bool incoming;
+	struct sha256 payment_hash;
+	enum wallet_transfer_status status;
+	struct pubkey *destination;
+	u64 msatoshi;
+};
+
 /**
  * wallet_new - Constructor for a new sqlite3 based wallet
  *

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -86,7 +86,7 @@ struct wallet_payment {
 	u32 timestamp;
 	bool incoming;
 	struct sha256 payment_hash;
-	enum wallet_transfer_status status;
+	enum wallet_payment_status status;
 	struct pubkey *destination;
 	u64 msatoshi;
 };
@@ -379,5 +379,32 @@ bool wallet_invoice_remove(struct wallet *wallet, struct invoice *inv);
  */
 struct htlc_stub *wallet_htlc_stubs(tal_t *ctx, struct wallet *wallet,
 				    struct wallet_channel *chan);
+
+/**
+ * wallet_payment_add - Record a new incoming/outgoing payment
+ *
+ * Stores the payment in the database.
+ */
+bool wallet_payment_add(struct wallet *wallet,
+			 struct wallet_payment *payment);
+
+/**
+ * wallet_payment_by_hash - Retrieve a specific payment
+ *
+ * Given the `payment_hash` retrieve the matching payment.
+ */
+struct wallet_payment *
+wallet_payment_by_hash(const tal_t *ctx, struct wallet *wallet,
+				const struct sha256 *payment_hash);
+
+/**
+ * wallet_payment_set_status - Update the status of the payment
+ *
+ * Search for the payment with the given `payment_hash` and update
+ * its state.
+ */
+void wallet_payment_set_status(struct wallet *wallet,
+				const struct sha256 *payment_hash,
+				const enum wallet_payment_status newstatus);
 
 #endif /* WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -407,4 +407,10 @@ void wallet_payment_set_status(struct wallet *wallet,
 				const struct sha256 *payment_hash,
 				const enum wallet_payment_status newstatus);
 
+/**
+ * wallet_payment_list - Retrieve a list of payments
+ */
+const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
+						    struct wallet *wallet);
+
 #endif /* WALLET_WALLET_H */


### PR DESCRIPTION
This implements the persistence of payments to the database as per #302. It serves the dual purpose of having some indication whether a payment failed or succeeded when restarting while sending, and it serves as backing for an eventual wallet listing the payment history.

Both incoming and outgoing payments are stored in the same table for ease of use. I had the `payment_key` duplicated in there as well, but thought keeping it in the HTLCs would suffice for now, therefore I removed it again.

When restarting the destructor of the HTLC will mark the payment as failed for now, which I think should be ok for now, but it may flip the payment from `failed` -> `completed` on reconnect and success, which may seem strange for now.

In addition this introduces a performance regression somewhere,  pretty sure it's ff2fd1cecb4afdc22ee71d863dce3d45993b4ca9, but will test it separately and attempt to merge it into an existing db transaction to get rid of the halving of throughput :-)

Fixes #302