### PR TITLE
htlc: Defer saving the outgoing payment until we store the HTLC

### DIFF
--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -138,7 +138,8 @@ struct htlc_out *new_htlc_out(const tal_t *ctx,
 			      const struct sha256 *payment_hash,
 			      const u8 *onion_routing_packet,
 			      struct htlc_in *in,
-			      struct pay_command *pc)
+			      struct pay_command *pc,
+			      struct wallet_payment *payment)
 {
 	struct htlc_out *hout = tal(ctx, struct htlc_out);
 
@@ -149,6 +150,7 @@ struct htlc_out *new_htlc_out(const tal_t *ctx,
 	hout->msatoshi = msatoshi;
 	hout->cltv_expiry = cltv_expiry;
 	hout->payment_hash = *payment_hash;
+	hout->payment = payment;
 	memcpy(hout->onion_routing_packet, onion_routing_packet,
 	       sizeof(hout->onion_routing_packet));
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -72,6 +72,9 @@ struct htlc_out {
 
 	/* Otherwise, payment command which created it. */
 	struct pay_command *pay_command;
+
+	/* Temporary payment store, so we can save everything in one go */
+	struct wallet_payment *payment;
 };
 
 static inline const struct htlc_key *keyof_htlc_in(const struct htlc_in *in)
@@ -127,7 +130,8 @@ struct htlc_out *new_htlc_out(const tal_t *ctx,
 			      const struct sha256 *payment_hash,
 			      const u8 *onion_routing_packet,
 			      struct htlc_in *in,
-			      struct pay_command *pc);
+			      struct pay_command *pc,
+			      struct wallet_payment *payment);
 
 void connect_htlc_in(struct htlc_in_map *map, struct htlc_in *hin);
 void connect_htlc_out(struct htlc_out_map *map, struct htlc_out *hout);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -447,6 +447,7 @@ enum onion_type send_htlc_out(struct peer *out, u64 amount, u32 cltv,
 			      const struct sha256 *payment_hash,
 			      const u8 *onion_routing_packet,
 			      struct htlc_in *in,
+			      struct wallet_payment *payment,
 			      struct pay_command *pc,
 			      struct htlc_out **houtp)
 {
@@ -467,7 +468,8 @@ enum onion_type send_htlc_out(struct peer *out, u64 amount, u32 cltv,
 
 	/* Make peer's daemon own it, catch if it dies. */
 	hout = new_htlc_out(out->owner, out, amount, cltv,
-			    payment_hash, onion_routing_packet, in, pc);
+			    payment_hash, onion_routing_packet, in,
+			    pc, payment);
 	tal_add_destructor(hout, hout_subd_died);
 
 	msg = towire_channel_offer_htlc(out, amount, cltv, payment_hash,
@@ -558,7 +560,7 @@ static void forward_htlc(struct htlc_in *hin,
 
 	failcode = send_htlc_out(next, amt_to_forward,
 				 outgoing_cltv_value, &hin->payment_hash,
-				 next_onion, hin, NULL, NULL);
+				 next_onion, hin, NULL, NULL, NULL);
 	if (!failcode)
 		return;
 
@@ -927,8 +929,21 @@ static bool update_out_htlc(struct peer *peer, u64 id, enum htlc_state newstate)
 		return false;
 	}
 
-	if (!hout->dbid)
+	if (!hout->dbid) {
 		wallet_htlc_save_out(peer->ld->wallet, peer->channel, hout);
+	}
+
+	/* We only have a payment if we initiated the payment. */
+	if (hout->payment) {
+		/* Now that we are committed, and inside the
+		 * transaction context of the update, add the payment
+		 * to the history. */
+		wallet_payment_add(peer->ld->wallet, hout->payment);
+
+		/* No need to carry the payment info around anymore,
+		 * we'll update in the database directly */
+		hout->payment = tal_free(hout->payment);
+	}
 
 	if (!htlc_out_update_state(peer, hout, newstate))
 		return false;

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -39,6 +39,7 @@ enum onion_type send_htlc_out(struct peer *out, u64 amount, u32 cltv,
 			      const struct sha256 *payment_hash,
 			      const u8 *onion_routing_packet,
 			      struct htlc_in *in,
+			      struct wallet_payment *payment,
 			      struct pay_command *pc,
 			      struct htlc_out **houtp);
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,0 +1,87 @@
+from concurrent.futures import ThreadPoolExecutor
+from lightning import LightningRpc
+from test_lightningd import NodeFactory
+import logging
+import pytest
+import random
+import utils
+
+from concurrent import futures
+from time import time
+from tqdm import tqdm
+
+
+num_workers = 480
+num_payments = 10000
+
+
+@pytest.fixture
+def executor():
+    ex = futures.ThreadPoolExecutor(max_workers=num_workers)
+    yield ex
+    ex.shutdown(wait=False)
+
+@pytest.fixture(scope="module")
+def bitcoind():
+    bitcoind = utils.BitcoinD(rpcport=28332)
+    bitcoind.start()
+    info = bitcoind.rpc.getinfo()
+    # Make sure we have segwit and some funds
+    if info['blocks'] < 432:
+        logging.debug("SegWit not active, generating some more blocks")
+        bitcoind.rpc.generate(432 - info['blocks'])
+    elif info['balance'] < 1:
+        logging.debug("Insufficient balance, generating 1 block")
+        bitcoind.rpc.generate(1)
+
+    yield bitcoind
+
+    try:
+        bitcoind.rpc.stop()
+    except:
+        bitcoind.proc.kill()
+    bitcoind.proc.wait()
+
+@pytest.fixture
+def node_factory(request, bitcoind, executor):
+    nf = NodeFactory(request.node.name, bitcoind, executor)
+    yield nf
+    nf.killall()
+
+def test_single_hop(node_factory, executor):
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node()
+
+    l1.rpc.connect(l2.rpc.getinfo()['id'], 'localhost:%d' % l2.rpc.getinfo()['port'])
+    l1.openchannel(l2, 4000000)
+
+    print("Collecting invoices")
+    fs = []
+    invoices = []
+    for i in tqdm(range(num_payments)):
+        invoices.append(l2.rpc.invoice(1000, 'invoice-%d' % (i), 'desc')['rhash'])
+
+    route = l1.rpc.getroute(l2.rpc.getinfo()['id'], 1000, 1)['route']
+    print("Sending payments")
+    start_time = time()
+
+    for i in invoices:
+        fs.append(executor.submit(l1.rpc.sendpay, route, i))
+
+    for f in tqdm(fs):
+        f.result()
+
+    diff = time() - start_time
+    print("Done. %d payments performed in %f seconds (%f payments per second)" % (num_payments, diff, num_payments / diff))
+
+def test_single_payment(node_factory, benchmark):
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node()
+    l1.rpc.connect(l2.rpc.getinfo()['id'], 'localhost:%d' % l2.rpc.getinfo()['port'])
+    l1.openchannel(l2, 4000000)
+
+    def do_pay(l1, l2):
+        invoice = l2.rpc.invoice(1000, 'invoice-{}'.format(random.random()), 'desc')['bolt11']
+        l1.rpc.pay(invoice)
+
+    benchmark(do_pay, l1, l2)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1285,7 +1285,7 @@ class LightningDTests(BaseLightningDTests):
 
         channels = l1.rpc.getchannels()['channels']
         assert len(channels) == 2
-        assert [c['active'] for c in channels] == [True, True]
+        wait_for(lambda: [c['active'] for c in channels] == [True, True])
 
     def ping_tests(self, l1, l2):
         # 0-byte pong gives just type + length field.
@@ -2314,6 +2314,6 @@ class LightningDTests(BaseLightningDTests):
         bitcoind.rpc.generate(99)
         l1.daemon.wait_for_log('onchaind complete, forgetting peer')
         l2.daemon.wait_for_log('onchaind complete, forgetting peer')
-        
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This addresses a performance regression introduced by
6ceb375650af30682027cdc22e6d029b4382f423. We were storing it in an
otherwise empty DB transaction, which means that DB transaction was no
longer a no-op. Now we defer storing until we need to store the
corresponding HTLC anyway, so we can just piggyback on top of that
transaction.

This is also more consistent since we'd be forgetting the payment
anyway if we restart between adding the HTLC and committing to it.

The first commit also adds the benchmarks I've been using to find the regression.