### PR TITLE
Makefile: clean needs to do more, distclean should remove everything.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ clean: wire-clean
 	$(RM) $(CCAN_OBJS) $(CDUMP_OBJS) $(ALL_OBJS)
 	$(RM) $(ALL_PROGRAMS) $(ALL_PROGRAMS:=.o)
 	$(RM) $(ALL_TEST_PROGRAMS) $(ALL_TEST_PROGRAMS:=.o)
-	$(RM) ccan/config.h gen_*.h
+	$(RM) ccan/config.h gen_*.h ccan/tools/configurator/configurator
 	$(RM) ccan/ccan/cdump/tools/cdump-enumstr.o
 	$(RM) check-bolt tools/check-bolt tools/*.o
 	find . -name '*gcda' -delete

--- a/bitcoin/Makefile
+++ b/bitcoin/Makefile
@@ -62,3 +62,7 @@ check-whitespace: $(BITCOIN_SRC:%=check-whitespace/%) $(BITCOIN_HEADERS:%=check-
 
 bitcoin-tests: $(BITCOIN_TEST_PROGRAMS:%=unittest/%)
 
+clean: bitcoin-clean
+
+bitcoin-clean:
+	$(RM) $(BITCOIN_OBJS) $(BITCOIN_TEST_PROGRAMS) $(BITCOIN_TEST_OBJS)

--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -93,6 +93,6 @@ check-whitespace: $(LIGHTNINGD_CHANNEL_SRC_NOGEN:%=check-whitespace/%) $(LIGHTNI
 clean: lightningd/channel-clean
 
 lightningd/channel-clean:
-	$(RM) $(LIGHTNINGD_CHANNEL_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_CHANNEL_OBJS) channeld/gen_*
 
 -include channeld/test/Makefile 

--- a/closingd/Makefile
+++ b/closingd/Makefile
@@ -77,6 +77,6 @@ check-whitespace: $(LIGHTNINGD_CLOSING_SRC_NOGEN:%=check-whitespace/%) $(LIGHTNI
 clean: closingd-clean
 
 closingd-clean:
-	$(RM) $(LIGHTNINGD_CLOSING_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_CLOSING_OBJS) closingd/gen_*
 
 -include closingd/test/Makefile 

--- a/common/Makefile
+++ b/common/Makefile
@@ -63,4 +63,9 @@ check-whitespace: $(COMMON_SRC:%=check-whitespace/%) $(COMMON_HEADERS:%=check-wh
 check-source: $(COMMON_SRC:%=check-src-include-order/%)			\
 	$(COMMON_HEADERS_NOGEN:%=check-hdr-include-order/%)
 
+clean: common-clean
+
+common-clean:
+	$(RM) common/gen*
+
 include common/test/Makefile

--- a/external/Makefile
+++ b/external/Makefile
@@ -84,11 +84,11 @@ distclean: external-distclean
 clean: external-clean
 
 external-clean:
-	$(RM) $(EXTERNAL_LIBS)
+	$(RM) $(EXTERNAL_LIBS) external/*.la external/*.o
 
 external-distclean:
 	make -C external/libsodium distclean || true
 	$(RM) -rf external/libbacktrace-build
-	$(RM) external/libsodium.la external/libsodium/src/libsodium/libsodium.la
+	$(RM) external/libsodium/src/libsodium/libsodium.la
 	$(RM) external/libwally-core/src/secp256k1/libsecp256k1.la external/libwally-core/src/libwallycore.la
-	cd external/libwally-core && tools/cleanup.sh
+	$(RM) -r `git status --ignored --porcelain external/libwally-core | grep '^!! ' | cut -c3-`

--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -76,6 +76,6 @@ check-whitespace: $(LIGHTNINGD_GOSSIP_ALLSRC_NOGEN:%=check-whitespace/%) $(LIGHT
 clean: gossipd-clean
 
 gossipd-clean:
-	$(RM) $(LIGHTNINGD_GOSSIP_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_GOSSIP_OBJS) gossipd/gen_*
 
 -include gossipd/test/Makefile 

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -81,6 +81,6 @@ check-whitespace: $(LIGHTNINGD_HSM_ALLSRC_NOGEN:%=check-whitespace/%) $(LIGHTNIN
 clean: lightningd/hsm-clean
 
 lightningd/hsm-clean:
-	$(RM) $(LIGHTNINGD_HSM_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_HSM_OBJS) hsmd/gen_*
 
 -include hsmd/test/Makefile 

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -105,6 +105,6 @@ lightningd/lightningd: $(LIGHTNINGD_OBJS) $(LIGHTNINGD_COMMON_OBJS) $(BITCOIN_OB
 clean: lightningd-clean
 
 lightningd-clean:
-	$(RM) $(LIGHTNINGD_OBJS) $(LIGHTNINGD_JSMN_OBJS) $(LIGHTNINGD_PROGRAM)
+	$(RM) $(LIGHTNINGD_OBJS) $(LIGHTNINGD_JSMN_OBJS) $(LIGHTNINGD_PROGRAM) lightningd/gen*
 
 include lightningd/test/Makefile

--- a/onchaind/Makefile
+++ b/onchaind/Makefile
@@ -86,6 +86,6 @@ check-whitespace: $(LIGHTNINGD_ONCHAIN_SRC_NOGEN:%=check-whitespace/%) $(LIGHTNI
 clean: onchaind-clean
 
 onchaind-clean:
-	$(RM) $(LIGHTNINGD_ONCHAIN_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_ONCHAIN_OBJS) onchaind/gen_*
 
 -include onchaind/test/Makefile 

--- a/openingd/Makefile
+++ b/openingd/Makefile
@@ -86,6 +86,6 @@ check-whitespace: $(LIGHTNINGD_OPENING_SRC_NOGEN:%=check-whitespace/%) $(LIGHTNI
 clean: opening-clean
 
 opening-clean:
-	$(RM) $(LIGHTNINGD_OPENING_OBJS) gen_*
+	$(RM) $(LIGHTNINGD_OPENING_OBJS) openingd/gen_*
 
 -include openingd/test/Makefile 


### PR DESCRIPTION
I checked this with git status --ignored after a full build and 'make distclean'.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>