### PR TITLE
Scan incoming blocks for our transactions

### DIFF
--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -222,6 +222,9 @@ static struct io_plan *handle_channeld(struct io_conn *conn,
 	struct client *c = container_of(dc, struct client, dc);
 	enum hsm_client_wire_type t = fromwire_peektype(dc->msg_in);
 
+	status_trace("Client: type %s len %zu",
+		     hsm_client_wire_type_name(t), tal_count(dc->msg_in));
+
 	switch (t) {
 	case WIRE_HSM_ECDH_REQ:
 		return handle_ecdh(conn, dc);

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -60,6 +60,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/peer_control.c		\
 	lightningd/peer_htlcs.c			\
 	lightningd/subd.c			\
+	lightningd/txfilter.c			\
 	lightningd/watch.c
 
 # Source files without corresponding headers
@@ -85,7 +86,7 @@ ALL_GEN_HEADERS += $(LIGHTNINGD_HEADERS_GEN)
 # All together in one convenient var
 LIGHTNINGD_HEADERS = $(LIGHTNINGD_HEADERS_NOGEN) $(LIGHTNINGD_HEADERS_GEN) $(EXTERNAL_HEADERS) $(WIRE_HEADERS) $(BITCOIN_HEADERS) $(COMMON_HEADERS) $(WALLET_LIB_HEADERS)
 
-$(LIGHTNINGD_OBJS): $(LIGHTNINGD_HEADERS) 
+$(LIGHTNINGD_OBJS): $(LIGHTNINGD_HEADERS)
 
 lightningd/gen_peer_state_names.h: lightningd/peer_state.h ccan/ccan/cdump/tools/cdump-enumstr
 	ccan/ccan/cdump/tools/cdump-enumstr lightningd/peer_state.h > $@

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -388,12 +388,7 @@ static void process_chaintips(struct bitcoin_cli *bcli)
 		}
 
 		if (!json_tok_streq(bcli->output, status, "active")) {
-			log_debug(bcli->bitcoind->log,
-				  "Ignoring chaintip %.*s status %.*s",
-				  hash->end - hash->start,
-				  bcli->output + hash->start,
-				  status->end - status->start,
-				  bcli->output + status->start);
+			/* Ignoring this chaintip since it's not active */
 			continue;
 		}
 		if (valid) {

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -58,6 +58,7 @@ static void connect_block(struct chain_topology *topo,
 			  struct block *b)
 {
 	size_t i;
+	u64 satoshi_owned;
 
 	assert(b->height == -1);
 	assert(b->prev == NULL);
@@ -86,9 +87,14 @@ static void connect_block(struct chain_topology *topo,
 				txowatch_fire(topo, txo, tx, j, b);
 		}
 
+		satoshi_owned = 0;
+		wallet_extract_owned_outputs(topo->bitcoind->ld->wallet, tx,
+					     &satoshi_owned);
+
 		/* We did spends first, in case that tells us to watch tx. */
 		bitcoin_txid(tx, &txid);
-		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid))
+		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid) ||
+		    satoshi_owned != 0)
 			add_tx_to_block(b, tx, i);
 	}
 	b->full_txs = tal_free(b->full_txs);

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -88,8 +88,10 @@ static void connect_block(struct chain_topology *topo,
 		}
 
 		satoshi_owned = 0;
-		wallet_extract_owned_outputs(topo->bitcoind->ld->wallet, tx,
-					     &satoshi_owned);
+		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
+			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
+						     tx, &satoshi_owned);
+		}
 
 		/* We did spends first, in case that tells us to watch tx. */
 		bitcoin_txid(tx, &txid);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -7,6 +7,7 @@
 #include <ccan/time/time.h>
 #include <ccan/timer/timer.h>
 #include <lightningd/htlc_end.h>
+#include <lightningd/txfilter.h>
 #include <stdio.h>
 #include <wallet/wallet.h>
 
@@ -130,6 +131,9 @@ struct lightningd {
 
 	/* Any outstanding "pay" commands. */
 	struct list_head pay_commands;
+
+	/* Transaction filter matching what we're interested in */
+	struct txfilter *owned_txfilter;
 
 #if DEVELOPER
 	/* If we want to debug a subdaemon. */

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -13,6 +13,9 @@ void db_begin_transaction_(struct db *db UNNEEDED, const char *location UNNEEDED
 /* Generated stub for db_commit_transaction */
 void db_commit_transaction(struct db *db UNNEEDED)
 { fprintf(stderr, "db_commit_transaction called!\n"); abort(); }
+/* Generated stub for db_get_intvar */
+s64 db_get_intvar(struct db *db UNNEEDED, char *varname UNNEEDED, s64 defval UNNEEDED)
+{ fprintf(stderr, "db_get_intvar called!\n"); abort(); }
 /* Generated stub for debug_poll */
 int debug_poll(struct pollfd *fds UNNEEDED, nfds_t nfds UNNEEDED, int timeout UNNEEDED)
 { fprintf(stderr, "debug_poll called!\n"); abort(); }
@@ -75,6 +78,12 @@ void subd_shutdown(struct subd *subd UNNEEDED, unsigned int seconds UNNEEDED)
 /* Generated stub for timer_expired */
 void timer_expired(tal_t *ctx UNNEEDED, struct timer *timer UNNEEDED)
 { fprintf(stderr, "timer_expired called!\n"); abort(); }
+/* Generated stub for txfilter_add_derkey */
+void txfilter_add_derkey(struct txfilter *filter UNNEEDED, u8 derkey[33])
+{ fprintf(stderr, "txfilter_add_derkey called!\n"); abort(); }
+/* Generated stub for txfilter_new */
+struct txfilter *txfilter_new(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "txfilter_new called!\n"); abort(); }
 /* Generated stub for version */
 const char *version(void)
 { fprintf(stderr, "version called!\n"); abort(); }

--- a/lightningd/txfilter.c
+++ b/lightningd/txfilter.c
@@ -24,7 +24,7 @@ static void txfilter_add_scriptpubkey(struct txfilter *filter, u8 *script)
 	filter->scriptpubkeys[count] = tal_dup_arr(filter, u8, script, tal_len(script), 0);
 }
 
-void txfilter_add_derkey(struct txfilter *filter, u8 derkey[33])
+void txfilter_add_derkey(struct txfilter *filter, u8 derkey[PUBKEY_DER_LEN])
 {
 	tal_t *tmpctx = tal_tmpctx(filter);
 	u8 *skp, *p2sh;

--- a/lightningd/txfilter.c
+++ b/lightningd/txfilter.c
@@ -1,0 +1,54 @@
+#include "txfilter.h"
+
+#include <bitcoin/script.h>
+#include <ccan/crypto/ripemd160/ripemd160.h>
+#include <common/utils.h>
+
+struct txfilter {
+	u8 **scriptpubkeys;
+};
+
+
+
+struct txfilter *txfilter_new(const tal_t *ctx)
+{
+	struct txfilter *filter = tal(ctx, struct txfilter);
+	filter->scriptpubkeys = tal_arr(filter, u8*, 0);
+	return filter;
+}
+
+static void txfilter_add_scriptpubkey(struct txfilter *filter, u8 *script)
+{
+	size_t count = tal_count(filter->scriptpubkeys);
+	tal_resize(&filter->scriptpubkeys, count + 1);
+	filter->scriptpubkeys[count] = tal_dup_arr(filter, u8, script, tal_len(script), 0);
+}
+
+void txfilter_add_derkey(struct txfilter *filter, u8 derkey[33])
+{
+	tal_t *tmpctx = tal_tmpctx(filter);
+	u8 *skp, *p2sh;
+
+	skp = scriptpubkey_p2wpkh_derkey(tmpctx, derkey);
+	p2sh = scriptpubkey_p2sh(tmpctx, skp);
+
+	txfilter_add_scriptpubkey(filter, take(skp));
+	txfilter_add_scriptpubkey(filter, take(p2sh));
+
+	tal_free(tmpctx);
+}
+
+
+bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx)
+{
+	u8 *oscript;
+	for (size_t i = 0; i < tal_count(tx->output); i++) {
+		oscript = tx->output[i].script;
+
+		for (size_t j = 0; j < tal_count(filter->scriptpubkeys); j++) {
+			if (scripteq(oscript, filter->scriptpubkeys[j]))
+				return true;
+		}
+	}
+	return false;
+}

--- a/lightningd/txfilter.h
+++ b/lightningd/txfilter.h
@@ -1,0 +1,30 @@
+#ifndef LIGHTNING_LIGHTNINGD_TXFILTER_H
+#define LIGHTNING_LIGHTNINGD_TXFILTER_H
+#include "config.h"
+#include <bitcoin/tx.h>
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+struct txfilter;
+
+/**
+ * txfilter_new -- Construct and initialize a new txfilter
+ */
+struct txfilter *txfilter_new(const tal_t *ctx);
+
+/**
+ * txfilter_add_derkey -- Add a scriptpubkeys matching the der key to the filter
+ *
+ * This ensures that we recognize the scriptpubkeys to our keys when
+ * filtering transactions. If any of the outputs matches the
+ * scriptpubkey then the transaction is marked as a match. Adds
+ * scriptpubkey for both raw p2wpkh and p2wpkh wrapped in p2sh.
+ */
+void txfilter_add_derkey(struct txfilter *filter, u8 derkey[33]);
+
+/**
+ * txfilter_match -- Check whether the tx matches the filter
+ */
+bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx);
+
+#endif /* LIGHTNING_LIGHTNINGD_TXFILTER_H */

--- a/lightningd/txfilter.h
+++ b/lightningd/txfilter.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_TXFILTER_H
 #define LIGHTNING_LIGHTNINGD_TXFILTER_H
 #include "config.h"
+#include <bitcoin/pubkey.h>
 #include <bitcoin/tx.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
@@ -20,7 +21,7 @@ struct txfilter *txfilter_new(const tal_t *ctx);
  * scriptpubkey then the transaction is marked as a match. Adds
  * scriptpubkey for both raw p2wpkh and p2wpkh wrapped in p2sh.
  */
-void txfilter_add_derkey(struct txfilter *filter, u8 derkey[33]);
+void txfilter_add_derkey(struct txfilter *filter, u8 derkey[PUBKEY_DER_LEN]);
 
 /**
  * txfilter_match -- Check whether the tx matches the filter

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -256,7 +256,7 @@ class LightningD(TailableProc):
 
     def start(self):
         TailableProc.start(self)
-        self.wait_for_log("Creating IPv6 listener on port")
+        self.wait_for_log("Hello world from")
         logging.info("LightningD started")
 
     def wait(self, timeout=10):

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -182,9 +182,9 @@ bool wallet_shachain_add_hash(struct wallet *wallet,
 
 /* Simply passes through to shachain_get_hash since it doesn't touch
  * the DB */
-static inline bool wallet_shachain_get_hash(struct wallet *w,
-					    struct wallet_shachain *chain,
-					    u64 index, struct sha256 *hash)
+inline bool wallet_shachain_get_hash(struct wallet *w,
+				     struct wallet_shachain *chain,
+				     u64 index, struct sha256 *hash)
 {
 	return shachain_get_hash(&chain->chain, index, hash);
 }

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -222,6 +222,8 @@ static void json_newaddr(struct command *cmd,
 		return;
 	}
 
+	txfilter_add_derkey(cmd->ld->owned_txfilter, ext.pub_key);
+
 	redeemscript = bitcoin_redeem_p2sh_p2wpkh(cmd, &pubkey);
 	sha256(&h, redeemscript, tal_count(redeemscript));
 	ripemd160(&p2sh, h.u.u8, sizeof(h));


### PR DESCRIPTION
This fixes #219 by passing the transactions in incoming blocks to the wallet which then extracts its funds and records them in the database. It also records the transaction as being interesting so we keep them around to maybe check their confirmations later.