### PR TITLE
channeld: channel_update must use peer's htlc_minimum_msat.

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -252,11 +252,11 @@ static u8 *create_channel_update(const tal_t *ctx,
 	    talz(tmpctx, secp256k1_ecdsa_signature);
 
 	flags = peer->channel_direction | (disabled << 1);
-	/* FIXME: Add configuration option to specify `htlc_minimum_msat` */
 	cupdate = towire_channel_update(
 	    tmpctx, sig, &peer->chain_hash,
 	    &peer->short_channel_ids[LOCAL], timestamp, flags,
-	    peer->cltv_delta, 1, peer->fee_base, peer->fee_per_satoshi);
+	    peer->cltv_delta, peer->conf[REMOTE].htlc_minimum_msat,
+	    peer->fee_base, peer->fee_per_satoshi);
 
 	msg = towire_hsm_cupdate_sig_req(tmpctx, cupdate);
 


### PR DESCRIPTION
As per the spec fix: lightningnetwork/lightning-rfc#287

Reported-by: Pierre-Marie Padiou
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>