### PR TITLE
Updates with messages

### DIFF
--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -58,7 +58,12 @@ CHANNELD_COMMON_OBJS :=				\
 	common/timeout.o			\
 	common/type_to_string.o			\
 	common/utils.o				\
-	common/version.o
+	common/version.o			\
+	common/wireaddr.o			\
+	gossipd/gen_gossip_wire.o		\
+	lightningd/gossip_msg.o			\
+	wire/fromwire.o				\
+	wire/towire.o
 
 # Control daemon uses this:
 LIGHTNINGD_CHANNEL_CONTROL_HEADERS := $(LIGHTNINGD_CHANNEL_HEADERS_GEN)

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1,3 +1,15 @@
+/* Main channel operation daemon: runs from funding_locked to shutdown_complete.
+ *
+ * We're fairly synchronous: our main loop looks for gossip, master or
+ * peer requests and services them synchronously.
+ *
+ * The exceptions are:
+ * 1. When we've asked the master something: in that case, we queue
+ *    non-response packets for later processing while we await the reply.
+ * 2. We queue and send non-blocking responses to peers: if both peers were
+ *    reading and writing synchronously we could deadlock if we hit buffer
+ *    limits, unlikely as that is.
+ */
 #include <bitcoin/privkey.h>
 #include <bitcoin/script.h>
 #include <ccan/cast/cast.h>
@@ -6,7 +18,6 @@
 #include <ccan/crypto/shachain/shachain.h>
 #include <ccan/err/err.h>
 #include <ccan/fdpass/fdpass.h>
-#include <ccan/io/io.h>
 #include <ccan/mem/mem.h>
 #include <ccan/structeq/structeq.h>
 #include <ccan/take/take.h>
@@ -16,8 +27,6 @@
 #include <channeld/full_channel.h>
 #include <channeld/gen_channel_wire.h>
 #include <common/crypto_sync.h>
-#include <common/cryptomsg.h>
-#include <common/daemon_conn.h>
 #include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/dev_disconnect.h>
@@ -59,7 +68,7 @@ struct commit_sigs {
 };
 
 struct peer {
-	struct peer_crypto_state pcs;
+	struct crypto_state cs;
 	struct channel_config conf[NUM_SIDES];
 	bool funding_locked[NUM_SIDES];
 	u64 next_index[NUM_SIDES];
@@ -94,10 +103,17 @@ struct peer {
 	struct channel_id channel_id;
 	struct channel *channel;
 
+	/* Pending msgs to send (not encrypted) */
 	struct msg_queue peer_out;
-	struct io_conn *peer_conn;
 
-	struct daemon_conn gossip_client;
+	/* Current msg to send, and offset (encrypted) */
+	const u8 *peer_outmsg;
+	size_t peer_outoff;
+
+#if DEVELOPER
+	/* Sabotage fd after sending next msg. */
+	bool post_sabotage;
+#endif
 
 	/* Messages from master: we queue them since we might be waiting for
 	 * a specific reply. */
@@ -157,11 +173,8 @@ static void *tal_arr_append_(void **p, size_t size)
 }
 #define tal_arr_append(p) tal_arr_append_((void **)(p), sizeof(**(p)))
 
-static struct io_plan *gossip_client_recv(struct io_conn *conn,
-					  struct daemon_conn *dc)
+static void gossip_in(struct peer *peer, const u8 *msg)
 {
-	u8 *msg = dc->msg_in;
-	struct peer *peer = container_of(dc, struct peer, gossip_client);
 	u16 type = fromwire_peektype(msg);
 
 	if (type == WIRE_CHANNEL_ANNOUNCEMENT || type == WIRE_CHANNEL_UPDATE ||
@@ -171,8 +184,6 @@ static struct io_plan *gossip_client_recv(struct io_conn *conn,
 		status_failed(STATUS_FAIL_GOSSIP_IO,
 			      "Got bad message from gossipd: %s",
 			      tal_hex(msg, msg));
-
-	return daemon_conn_read_next(conn, dc);
 }
 
 static void send_announcement_signatures(struct peer *peer)
@@ -304,21 +315,7 @@ static u8 *create_channel_announcement(const tal_t *ctx, struct peer *peer)
 	return cannounce;
 }
 
-static struct io_plan *peer_out(struct io_conn *conn, struct peer *peer)
-{
-	const u8 *out = msg_dequeue(&peer->peer_out);
-	if (!out)
-		return msg_queue_wait(conn, &peer->peer_out, peer_out, peer);
-
-	status_trace("peer_out %s", wire_type_name(fromwire_peektype(out)));
-	return peer_write_message(conn, &peer->pcs, out, peer_out);
-}
-
-static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg);
-
-static struct io_plan *handle_peer_funding_locked(struct io_conn *conn,
-						  struct peer *peer,
-						  const u8 *msg)
+static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
 {
 	struct channel_id chanid;
 
@@ -328,16 +325,16 @@ static struct io_plan *handle_peer_funding_locked(struct io_conn *conn,
 	 * it receives one.
 	 */
 	if (peer->funding_locked[REMOTE])
-		return peer_read_message(conn, &peer->pcs, peer_in);
+		return;
 
 	peer->old_remote_per_commit = peer->remote_per_commit;
 	if (!fromwire_funding_locked(msg, NULL, &chanid,
 				     &peer->remote_per_commit))
-		peer_failed(PEER_FD, &peer->pcs.cs, &peer->channel_id,
+		peer_failed(PEER_FD, &peer->cs, &peer->channel_id,
 			    "Bad funding_locked %s", tal_hex(msg, msg));
 
 	if (!structeq(&chanid, &peer->channel_id))
-		peer_failed(PEER_FD, &peer->pcs.cs, &peer->channel_id,
+		peer_failed(PEER_FD, &peer->cs, &peer->channel_id,
 			    "Wrong channel id in %s (expected %s)",
 			    tal_hex(trc, msg),
 			    type_to_string(msg, struct channel_id,
@@ -354,8 +351,6 @@ static struct io_plan *handle_peer_funding_locked(struct io_conn *conn,
 	}
 
 	send_announcement_signatures(peer);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
 static void announce_channel(struct peer *peer)
@@ -372,9 +367,7 @@ static void announce_channel(struct peer *peer)
 	tal_free(cannounce);
 }
 
-static struct io_plan *handle_peer_announcement_signatures(struct io_conn *conn,
-							   struct peer *peer,
-							   const u8 *msg)
+static void handle_peer_announcement_signatures(struct peer *peer, const u8 *msg)
 {
 	struct channel_id chanid;
 
@@ -383,14 +376,14 @@ static struct io_plan *handle_peer_announcement_signatures(struct io_conn *conn,
 					      &peer->short_channel_ids[REMOTE],
 					      &peer->announcement_node_sigs[REMOTE],
 					      &peer->announcement_bitcoin_sigs[REMOTE]))
-		peer_failed(PEER_FD, &peer->pcs.cs, &peer->channel_id,
+		peer_failed(PEER_FD, &peer->cs, &peer->channel_id,
 			    "Bad announcement_signatures %s",
 			    tal_hex(msg, msg));
 
 	/* Make sure we agree on the channel ids */
 	/* FIXME: Check short_channel_id */
 	if (!structeq(&chanid, &peer->channel_id)) {
-		peer_failed(PEER_FD, &peer->pcs.cs, &peer->channel_id,
+		peer_failed(PEER_FD, &peer->cs, &peer->channel_id,
 			    "Wrong channel_id or short_channel_id in %s or %s",
 			    tal_hexstr(trc, &chanid, sizeof(struct channel_id)),
 			    tal_hexstr(trc, &peer->short_channel_ids[REMOTE],
@@ -402,8 +395,6 @@ static struct io_plan *handle_peer_announcement_signatures(struct io_conn *conn,
 	/* We have the remote sigs, do we have the local ones as well? */
 	if (peer->funding_locked[LOCAL] && peer->have_sigs[LOCAL])
 		announce_channel(peer);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
 static void get_shared_secret(const struct htlc *htlc,
@@ -435,8 +426,7 @@ static void get_shared_secret(const struct htlc *htlc,
 	tal_free(tmpctx);
 }
 
-static struct io_plan *handle_peer_add_htlc(struct io_conn *conn,
-					    struct peer *peer, const u8 *msg)
+static void handle_peer_add_htlc(struct peer *peer, const u8 *msg)
 {
 	struct channel_id channel_id;
 	u64 id;
@@ -451,7 +441,7 @@ static struct io_plan *handle_peer_add_htlc(struct io_conn *conn,
 				      &payment_hash, &cltv_expiry,
 				      onion_routing_packet))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad peer_add_htlc %s", tal_hex(msg, msg));
 
@@ -460,7 +450,7 @@ static struct io_plan *handle_peer_add_htlc(struct io_conn *conn,
 				   onion_routing_packet, &htlc);
 	if (add_err != CHANNEL_ERR_ADD_OK)
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad peer_add_htlc: %u", add_err);
 
@@ -468,19 +458,16 @@ static struct io_plan *handle_peer_add_htlc(struct io_conn *conn,
 	 * send it to the master which handles all HTLC failures. */
 	htlc->shared_secret = tal(htlc, struct secret);
 	get_shared_secret(htlc, htlc->shared_secret);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
-static struct io_plan *handle_peer_feechange(struct io_conn *conn,
-					     struct peer *peer, const u8 *msg)
+static void handle_peer_feechange(struct peer *peer, const u8 *msg)
 {
 	struct channel_id channel_id;
 	u32 feerate;
 
 	if (!fromwire_update_fee(msg, NULL, &channel_id, &feerate)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fee %s", tal_hex(msg, msg));
 	}
@@ -492,7 +479,7 @@ static struct io_plan *handle_peer_feechange(struct io_conn *conn,
 	 */
 	if (peer->channel->funder != REMOTE)
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "update_fee from non-funder?");
 
@@ -503,7 +490,7 @@ static struct io_plan *handle_peer_feechange(struct io_conn *conn,
 	 */
 	if (feerate < peer->feerate_min || feerate > peer->feerate_max)
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "update_fee %u outside range %u-%u",
 			    feerate, peer->feerate_min, peer->feerate_max);
@@ -517,13 +504,12 @@ static struct io_plan *handle_peer_feechange(struct io_conn *conn,
 	 */
 	if (!channel_update_feerate(peer->channel, feerate))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "update_fee %u unaffordable",
 			    feerate);
 
 	status_trace("peer updated fee to %u", feerate);
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
 static struct changed_htlc *changed_htlc_arr(const tal_t *ctx,
@@ -772,9 +758,6 @@ static void send_commit(struct peer *peer)
 		/* Covers the case where we've just been told to shutdown. */
 		maybe_send_shutdown(peer);
 
-		if (shutdown_complete(peer))
-			io_break(peer);
-
 		peer->commit_timer = NULL;
 		tal_free(tmpctx);
 		return;
@@ -810,10 +793,6 @@ static void send_commit(struct peer *peer)
 	/* Timer now considered expired, you can add a new one. */
 	peer->commit_timer = NULL;
 	start_commit_timer(peer);
-
-	if (shutdown_complete(peer))
-		io_break(peer);
-
 	tal_free(tmpctx);
 }
 
@@ -864,8 +843,7 @@ static u8 *make_revocation_msg(const struct peer *peer, u64 revoke_index)
 				     &point);
 }
 
-/* We come back here once master has acked the commit_sig we received */
-static struct io_plan *send_revocation(struct io_conn *conn, struct peer *peer)
+static void send_revocation(struct peer *peer)
 {
 	/* Revoke previous commit. */
 	u8 *msg = make_revocation_msg(peer, peer->next_index[LOCAL]-1);
@@ -880,12 +858,6 @@ static struct io_plan *send_revocation(struct io_conn *conn, struct peer *peer)
 	}
 
 	msg_enqueue(&peer->peer_out, take(msg));
-
-	/* This might have been the final revoke_and_ack... */
-	if (shutdown_complete(peer))
-		io_break(peer);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
 static u8 *got_commitsig_msg(const tal_t *ctx,
@@ -962,8 +934,7 @@ static u8 *got_commitsig_msg(const tal_t *ctx,
 	return msg;
 }
 
-static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
-					      struct peer *peer, const u8 *msg)
+static void handle_peer_commit_sig(struct peer *peer, const u8 *msg)
 {
 	const tal_t *tmpctx = tal_tmpctx(peer);
 	struct channel_id channel_id;
@@ -982,7 +953,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 		 * does not include any updates.
 		 */
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "commit_sig with no changes");
 	}
@@ -996,7 +967,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 	if (!fromwire_commitment_signed(tmpctx, msg, NULL,
 					&channel_id, &commit_sig, &htlc_sigs))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad commit_sig %s", tal_hex(msg, msg));
 
@@ -1028,7 +999,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 			  &peer->channel->funding_pubkey[REMOTE], &commit_sig)) {
 		dump_htlcs(peer->channel, "receiving commit_sig");
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad commit_sig signature %"PRIu64" %s for tx %s wscript %s key %s",
 			    peer->next_index[LOCAL],
@@ -1049,7 +1020,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 	 */
 	if (tal_count(htlc_sigs) != tal_count(txs) - 1)
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Expected %zu htlc sigs, not %zu",
 			    tal_count(txs) - 1, tal_count(htlc_sigs));
@@ -1064,7 +1035,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 		if (!check_tx_sig(txs[1+i], 0, NULL, wscripts[1+i],
 				  &remote_htlckey, &htlc_sigs[i]))
 			peer_failed(PEER_FD,
-				    &peer->pcs.cs,
+				    &peer->cs,
 				    &peer->channel_id,
 				    "Bad commit_sig signature %s for htlc %s wscript %s key %s",
 				    type_to_string(msg, secp256k1_ecdsa_signature, &htlc_sigs[i]),
@@ -1085,7 +1056,7 @@ static struct io_plan *handle_peer_commit_sig(struct io_conn *conn,
 	master_wait_sync_reply(tmpctx, peer, take(msg),
 			       WIRE_CHANNEL_GOT_COMMITSIG_REPLY);
 	tal_free(tmpctx);
-	return send_revocation(conn, peer);
+	return send_revocation(peer);
 }
 
 static u8 *got_revoke_msg(const tal_t *ctx, u64 revoke_num,
@@ -1115,22 +1086,7 @@ static u8 *got_revoke_msg(const tal_t *ctx, u64 revoke_num,
 	return msg;
 }
 
-/* We come back here once master has acked the revoke_and_ack we received */
-static struct io_plan *accepted_revocation(struct io_conn *conn,
-					   struct peer *peer)
-{
-	start_commit_timer(peer);
-
-	/* We might now have an empty HTLC. */
-	if (shutdown_complete(peer))
-		io_break(peer);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
-}
-
-static struct io_plan *handle_peer_revoke_and_ack(struct io_conn *conn,
-						  struct peer *peer,
-						  const u8 *msg)
+static void handle_peer_revoke_and_ack(struct peer *peer, const u8 *msg)
 {
 	struct sha256 old_commit_secret;
 	struct privkey privkey;
@@ -1142,7 +1098,7 @@ static struct io_plan *handle_peer_revoke_and_ack(struct io_conn *conn,
 	if (!fromwire_revoke_and_ack(msg, NULL, &channel_id, &old_commit_secret,
 				     &next_per_commit)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad revoke_and_ack %s", tal_hex(msg, msg));
 	}
@@ -1160,14 +1116,14 @@ static struct io_plan *handle_peer_revoke_and_ack(struct io_conn *conn,
 	memcpy(&privkey, &old_commit_secret, sizeof(privkey));
 	if (!pubkey_from_privkey(&privkey, &per_commit_point)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad privkey %s",
 			    type_to_string(msg, struct privkey, &privkey));
 	}
 	if (!pubkey_eq(&per_commit_point, &peer->old_remote_per_commit)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Wrong privkey %s for %"PRIu64" %s",
 			    type_to_string(msg, struct privkey, &privkey),
@@ -1199,12 +1155,12 @@ static struct io_plan *handle_peer_revoke_and_ack(struct io_conn *conn,
 		     type_to_string(trc, struct pubkey,
 				    &peer->old_remote_per_commit));
 
+	start_commit_timer(peer);
+
 	tal_free(tmpctx);
-	return accepted_revocation(conn, peer);
 }
 
-static struct io_plan *handle_peer_fulfill_htlc(struct io_conn *conn,
-						struct peer *peer, const u8 *msg)
+static void handle_peer_fulfill_htlc(struct peer *peer, const u8 *msg)
 {
 	struct channel_id channel_id;
 	u64 id;
@@ -1214,7 +1170,7 @@ static struct io_plan *handle_peer_fulfill_htlc(struct io_conn *conn,
 	if (!fromwire_update_fulfill_htlc(msg, NULL, &channel_id,
 					  &id, &preimage)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fulfill_htlc %s", tal_hex(msg, msg));
 	}
@@ -1224,7 +1180,7 @@ static struct io_plan *handle_peer_fulfill_htlc(struct io_conn *conn,
 	case CHANNEL_ERR_REMOVE_OK:
 		/* FIXME: We could send preimages to master immediately. */
 		start_commit_timer(peer);
-		return peer_read_message(conn, &peer->pcs, peer_in);
+		return;
 	/* These shouldn't happen, because any offered HTLC (which would give
 	 * us the preimage) should have timed out long before.  If we
 	 * were to get preimages from other sources, this could happen. */
@@ -1234,7 +1190,7 @@ static struct io_plan *handle_peer_fulfill_htlc(struct io_conn *conn,
 	case CHANNEL_ERR_HTLC_NOT_IRREVOCABLE:
 	case CHANNEL_ERR_BAD_PREIMAGE:
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fulfill_htlc: failed to fulfill %"
 			    PRIu64 " error %u", id, e);
@@ -1242,8 +1198,7 @@ static struct io_plan *handle_peer_fulfill_htlc(struct io_conn *conn,
 	abort();
 }
 
-static struct io_plan *handle_peer_fail_htlc(struct io_conn *conn,
-					     struct peer *peer, const u8 *msg)
+static void handle_peer_fail_htlc(struct peer *peer, const u8 *msg)
 {
 	struct channel_id channel_id;
 	u64 id;
@@ -1254,7 +1209,7 @@ static struct io_plan *handle_peer_fail_htlc(struct io_conn *conn,
 	if (!fromwire_update_fail_htlc(msg, msg, NULL,
 				       &channel_id, &id, &reason)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fulfill_htlc %s", tal_hex(msg, msg));
 	}
@@ -1266,14 +1221,14 @@ static struct io_plan *handle_peer_fail_htlc(struct io_conn *conn,
 		htlc = channel_get_htlc(peer->channel, LOCAL, id);
 		htlc->fail = tal_steal(htlc, reason);
 		start_commit_timer(peer);
-		return peer_read_message(conn, &peer->pcs, peer_in);
+		return;
 	case CHANNEL_ERR_NO_SUCH_ID:
 	case CHANNEL_ERR_ALREADY_FULFILLED:
 	case CHANNEL_ERR_HTLC_UNCOMMITTED:
 	case CHANNEL_ERR_HTLC_NOT_IRREVOCABLE:
 	case CHANNEL_ERR_BAD_PREIMAGE:
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fail_htlc: failed to remove %"
 			    PRIu64 " error %u", id, e);
@@ -1281,9 +1236,7 @@ static struct io_plan *handle_peer_fail_htlc(struct io_conn *conn,
 	abort();
 }
 
-static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
-						       struct peer *peer,
-						       const u8 *msg)
+static void handle_peer_fail_malformed_htlc(struct peer *peer, const u8 *msg)
 {
 	struct channel_id channel_id;
 	u64 id;
@@ -1297,7 +1250,7 @@ static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
 						 &sha256_of_onion,
 						 &failure_code)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fail_malformed_htlc %s",
 			    tal_hex(msg, msg));
@@ -1310,7 +1263,7 @@ static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
 	 */
 	if (!(failure_code & BADONION)) {
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fail_malformed_htlc failure code %u",
 			    failure_code);
@@ -1342,14 +1295,14 @@ static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
 		/* FIXME: Make htlc->fail a u8 *! */
 		htlc->fail = fail;
 		start_commit_timer(peer);
-		return peer_read_message(conn, &peer->pcs, peer_in);
+		return;
 	case CHANNEL_ERR_NO_SUCH_ID:
 	case CHANNEL_ERR_ALREADY_FULFILLED:
 	case CHANNEL_ERR_HTLC_UNCOMMITTED:
 	case CHANNEL_ERR_HTLC_NOT_IRREVOCABLE:
 	case CHANNEL_ERR_BAD_PREIMAGE:
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad update_fail_malformed_htlc: failed to remove %"
 			    PRIu64 " error %u", id, e);
@@ -1357,14 +1310,13 @@ static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
 	abort();
 }
 
-static struct io_plan *handle_ping(struct io_conn *conn,
-				   struct peer *peer, const u8 *msg)
+static void handle_ping(struct peer *peer, const u8 *msg)
 {
 	u8 *pong;
 
 	if (!check_ping_make_pong(peer, msg, &pong))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad ping");
 
@@ -1374,43 +1326,38 @@ static struct io_plan *handle_ping(struct io_conn *conn,
 
 	if (pong)
 		msg_enqueue(&peer->peer_out, take(pong));
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
-static struct io_plan *handle_pong(struct io_conn *conn,
-				   struct peer *peer, const u8 *pong)
+static void handle_pong(struct peer *peer, const u8 *pong)
 {
 	u8 *ignored;
 
 	status_trace("Got pong!");
 	if (!fromwire_pong(pong, pong, NULL, &ignored))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad pong %s", tal_hex(pong, pong));
 
 	if (!peer->num_pings_outstanding)
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Unexpected pong");
 
 	peer->num_pings_outstanding--;
 	wire_sync_write(MASTER_FD,
 			take(towire_channel_ping_reply(pong, tal_len(pong))));
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
-static struct io_plan *handle_peer_shutdown(struct io_conn *conn,
-					    struct peer *peer,
-					    const u8 *shutdown)
+static void handle_peer_shutdown(struct peer *peer, const u8 *shutdown)
 {
 	struct channel_id channel_id;
 	u8 *scriptpubkey;
 
 	if (!fromwire_shutdown(peer, shutdown, NULL, &channel_id, &scriptpubkey))
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "Bad shutdown %s", tal_hex(peer, shutdown));
 
@@ -1419,13 +1366,9 @@ static struct io_plan *handle_peer_shutdown(struct io_conn *conn,
 			take(towire_channel_got_shutdown(peer, scriptpubkey)));
 
 	peer->shutdown_sent[REMOTE] = true;
-	if (shutdown_complete(peer))
-		io_break(peer);
-
-	return peer_read_message(conn, &peer->pcs, peer_in);
 }
 
-static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
+static void peer_in(struct peer *peer, const u8 *msg)
 {
 	enum wire_type type = fromwire_peektype(msg);
 	status_trace("peer_in %s", wire_type_name(type));
@@ -1439,7 +1382,7 @@ static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
 		    && type != WIRE_NODE_ANNOUNCEMENT
 		    && type != WIRE_PING) {
 			peer_failed(PEER_FD,
-				    &peer->pcs.cs,
+				    &peer->cs,
 				    &peer->channel_id,
 				    "%s (%u) before funding locked",
 				    wire_type_name(type), type);
@@ -1448,35 +1391,50 @@ static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
 
 	switch (type) {
 	case WIRE_FUNDING_LOCKED:
-		return handle_peer_funding_locked(conn, peer, msg);
+		handle_peer_funding_locked(peer, msg);
+		return;
 	case WIRE_ANNOUNCEMENT_SIGNATURES:
-		return handle_peer_announcement_signatures(conn, peer, msg);
+		handle_peer_announcement_signatures(peer, msg);
+		return;
 	case WIRE_CHANNEL_ANNOUNCEMENT:
 	case WIRE_CHANNEL_UPDATE:
 	case WIRE_NODE_ANNOUNCEMENT:
 		/* Forward to gossip daemon */
-		daemon_conn_send(&peer->gossip_client, msg);
-		return peer_read_message(conn, &peer->pcs, peer_in);
+		if (!wire_sync_write(GOSSIP_FD, msg))
+			status_failed(STATUS_FAIL_GOSSIP_IO,
+				      "Forwarding to gossipd: %s",
+				      strerror(errno));
+		return;
 	case WIRE_UPDATE_ADD_HTLC:
-		return handle_peer_add_htlc(conn, peer, msg);
+		handle_peer_add_htlc(peer, msg);
+		return;
 	case WIRE_COMMITMENT_SIGNED:
-		return handle_peer_commit_sig(conn, peer, msg);
+		handle_peer_commit_sig(peer, msg);
+		return;
 	case WIRE_UPDATE_FEE:
-		return handle_peer_feechange(conn, peer, msg);
+		handle_peer_feechange(peer, msg);
+		return;
 	case WIRE_REVOKE_AND_ACK:
-		return handle_peer_revoke_and_ack(conn, peer, msg);
+		handle_peer_revoke_and_ack(peer, msg);
+		return;
 	case WIRE_UPDATE_FULFILL_HTLC:
-		return handle_peer_fulfill_htlc(conn, peer, msg);
+		handle_peer_fulfill_htlc(peer, msg);
+		return;
 	case WIRE_UPDATE_FAIL_HTLC:
-		return handle_peer_fail_htlc(conn, peer, msg);
+		handle_peer_fail_htlc(peer, msg);
+		return;
 	case WIRE_UPDATE_FAIL_MALFORMED_HTLC:
-		return handle_peer_fail_malformed_htlc(conn, peer, msg);
+		handle_peer_fail_malformed_htlc(peer, msg);
+		return;
 	case WIRE_PING:
-		return handle_ping(conn, peer, msg);
+		handle_ping(peer, msg);
+		return;
 	case WIRE_PONG:
-		return handle_pong(conn, peer, msg);
+		handle_pong(peer, msg);
+		return;
 	case WIRE_SHUTDOWN:
-		return handle_peer_shutdown(conn, peer, msg);
+		handle_peer_shutdown(peer, msg);
+		return;
 
 	case WIRE_INIT:
 	case WIRE_ERROR:
@@ -1486,37 +1444,27 @@ static struct io_plan *peer_in(struct io_conn *conn, struct peer *peer, u8 *msg)
 	case WIRE_FUNDING_SIGNED:
 	case WIRE_CHANNEL_REESTABLISH:
 	case WIRE_CLOSING_SIGNED:
-		goto badmessage;
+		break;
 	}
 
-badmessage:
 	peer_failed(PEER_FD,
-		    &peer->pcs.cs,
+		    &peer->cs,
 		    &peer->channel_id,
 		    "Peer sent unknown message %u (%s)",
 		    type, wire_type_name(type));
 }
 
-static struct io_plan *setup_peer_conn(struct io_conn *conn, struct peer *peer)
+static void peer_conn_broken(struct peer *peer)
 {
-	return io_duplex(conn, peer_read_message(conn, &peer->pcs, peer_in),
-			 peer_out(conn, peer));
-}
+	const char *e = strerror(errno);
 
-static void peer_conn_broken(struct io_conn *conn, struct peer *peer)
-{
 	/* If we have signatures, send an update to say we're disabled. */
 	if (peer->have_sigs[LOCAL] && peer->have_sigs[REMOTE]) {
-		u8 *cupdate = create_channel_update(conn, peer, true);
+		u8 *cupdate = create_channel_update(peer, peer, true);
 
-		daemon_conn_send(&peer->gossip_client, cupdate);
-		msg_enqueue(&peer->peer_out, take(cupdate));
-
-		/* Make sure gossipd actually gets this message before dying */
-		daemon_conn_sync_flush(&peer->gossip_client);
+		wire_sync_write(GOSSIP_FD, take(cupdate));
 	}
-	status_failed(STATUS_FAIL_PEER_IO,
-		      "peer connection broken: %s", strerror(errno));
+	status_failed(STATUS_FAIL_PEER_IO, "peer read failed: %s", e);
 }
 
 static void resend_revoke(struct peer *peer)
@@ -1544,7 +1492,7 @@ static void send_fail_or_fulfill(struct peer *peer, const struct htlc *h)
 						 h->r);
 	} else
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "HTLC %"PRIu64" state %s not failed/fulfilled",
 			    h->id, htlc_state_name(h->state));
@@ -1577,7 +1525,7 @@ static void resend_commitment(struct peer *peer, const struct changed_htlc *last
 		 * then they asked for a retransmit */
 		if (!h)
 			peer_failed(PEER_FD,
-				    &peer->pcs.cs,
+				    &peer->cs,
 				    &peer->channel_id,
 				    "Can't find HTLC %"PRIu64" to resend",
 				    last[i].id);
@@ -1637,19 +1585,19 @@ static void peer_reconnect(struct peer *peer)
 	msg = towire_channel_reestablish(peer, &peer->channel_id,
 					 peer->next_index[LOCAL],
 					 peer->revocations_received);
-	if (!sync_crypto_write(&peer->pcs.cs, PEER_FD, take(msg)))
+	if (!sync_crypto_write(&peer->cs, PEER_FD, take(msg)))
 		status_failed(STATUS_FAIL_PEER_IO,
 			      "Failed writing reestablish: %s", strerror(errno));
 
 again:
-	msg = sync_crypto_read(peer, &peer->pcs.cs, PEER_FD);
+	msg = sync_crypto_read(peer, &peer->cs, PEER_FD);
 	if (!msg)
 		status_failed(STATUS_FAIL_PEER_IO,
 			      "Failed reading reestablish: %s", strerror(errno));
 
 	if (is_gossip_msg(msg)) {
 		/* Forward to gossip daemon */
-		daemon_conn_send(&peer->gossip_client, msg);
+		wire_sync_write(GOSSIP_FD, take(msg));
 		goto again;
 	}
 
@@ -1748,7 +1696,7 @@ again:
 	 */
 	} else if (next_local_commitment_number != peer->next_index[REMOTE])
 		peer_failed(PEER_FD,
-			    &peer->pcs.cs,
+			    &peer->cs,
 			    &peer->channel_id,
 			    "bad reestablish commitment_number: %"PRIu64
 			    " vs %"PRIu64,
@@ -1786,7 +1734,7 @@ again:
 	/* Reenable channel by sending a channel_update without the
 	 * disable flag */
 	cupdate = create_channel_update(peer, peer, false);
-	daemon_conn_send(&peer->gossip_client, cupdate);
+	wire_sync_write(GOSSIP_FD, cupdate);
 	msg_enqueue(&peer->peer_out, take(cupdate));
 
 	/* Corner case: we will get upset with them if they send
@@ -2191,32 +2139,32 @@ static void req_in(struct peer *peer, const u8 *msg)
 	switch (t) {
 	case WIRE_CHANNEL_FUNDING_LOCKED:
 		handle_funding_locked(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_FUNDING_ANNOUNCE_DEPTH:
 		handle_funding_announce_depth(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_OFFER_HTLC:
 		handle_offer_htlc(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_FEERATES:
 		handle_feerates(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_FULFILL_HTLC:
 		handle_preimage(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_FAIL_HTLC:
 		handle_fail(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_PING:
 		handle_ping_cmd(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_SEND_SHUTDOWN:
 		handle_shutdown_cmd(peer, msg);
-		goto out;
+		return;
 	case WIRE_CHANNEL_DEV_REENABLE_COMMIT:
 #if DEVELOPER
 		handle_dev_reenable_commit(peer);
-		goto out;
+		return;
 #endif /* DEVELOPER */
 	case WIRE_CHANNEL_NORMAL_OPERATION:
 	case WIRE_CHANNEL_INIT:
@@ -2236,9 +2184,6 @@ static void req_in(struct peer *peer, const u8 *msg)
 		break;
 	}
 	master_badmsg(-1, msg);
-
-out:
-	tal_free(msg);
 }
 
 /* We do this synchronously. */
@@ -2276,7 +2221,7 @@ static void init_channel(struct peer *peer)
 				   feerate_per_kw,
 				   &peer->feerate_min, &peer->feerate_max,
 				   &peer->their_commit_sig,
-				   &peer->pcs.cs,
+				   &peer->cs,
 				   &funding_pubkey[REMOTE],
 				   &points[REMOTE].revocation,
 				   &points[REMOTE].payment,
@@ -2369,9 +2314,6 @@ static void init_channel(struct peer *peer)
 	if (reconnected)
 		peer_reconnect(peer);
 
-	peer->peer_conn = io_new_conn(peer, PEER_FD, setup_peer_conn, peer);
-	io_set_finish(peer->peer_conn, peer_conn_broken, peer);
-
 	/* If we have a funding_signed message, send that immediately */
 	if (funding_signed)
 		msg_enqueue(&peer->peer_out, take(funding_signed));
@@ -2380,101 +2322,89 @@ static void init_channel(struct peer *peer)
 }
 
 #ifndef TESTING
-static void gossip_gone(struct io_conn *unused, struct daemon_conn *dc)
+static void do_peer_write(struct peer *peer)
 {
-	status_failed(STATUS_FAIL_GOSSIP_IO,
-		      "Gossip connection closed");
+	int r;
+	size_t len = tal_len(peer->peer_outmsg);
+
+	r = write(PEER_FD, peer->peer_outmsg + peer->peer_outoff,
+		  len - peer->peer_outoff);
+	if (r < 0)
+		status_failed(STATUS_FAIL_PEER_IO,
+			      "Peer write failed: %s", strerror(errno));
+
+	peer->peer_outoff += r;
+	if (peer->peer_outoff == len) {
+		peer->peer_outmsg = tal_free(peer->peer_outmsg);
+#if DEVELOPER
+		if (peer->post_sabotage)
+			dev_sabotage_fd(PEER_FD);
+#endif
+	}
 }
 
-/* FIXME: This doesn't cover partly read packets!  We could be halfway
- * through receiving a gossip msg, for example.  We'll simply reconnect
- * in this case, but the real fix is to wean off ccan/io here, as it doesn't
- * buy us anything: a poll for read on gossipfd, masterfd and peerfd then acting
- * synchronous would be a simpler model. */
-static void send_shutdown_complete(struct peer *peer)
+static bool peer_write_pending(struct peer *peer)
 {
 	const u8 *msg;
 
-	/* Push out any outstanding messages to peer. */
-	if (!io_flush_sync(peer->peer_conn))
-		status_failed(STATUS_FAIL_PEER_IO, "Syncing conn");
+	if (peer->peer_outmsg)
+		return true;
 
-	/* Set FD blocking to flush it */
-	io_fd_block(PEER_FD, true);
+	msg = msg_dequeue(&peer->peer_out);
+	if (!msg)
+		return false;
 
-	while ((msg = msg_dequeue(&peer->peer_out)) != NULL) {
-		if (!sync_crypto_write(&peer->pcs.cs, PEER_FD, take(msg)))
-			status_failed(STATUS_FAIL_PEER_IO,
-				      "Flushing msgs");
+#if DEVELOPER
+	peer->post_sabotage = false;
+
+	switch (dev_disconnect(fromwire_peektype(msg))) {
+	case DEV_DISCONNECT_BEFORE:
+		dev_sabotage_fd(PEER_FD);
+		break;
+	case DEV_DISCONNECT_DROPPKT:
+		msg = tal_free(msg);
+		peer->post_sabotage = true;
+		peer->peer_outmsg = NULL;
+		peer->peer_outoff = 0;
+		return true;
+	case DEV_DISCONNECT_AFTER:
+		peer->post_sabotage = true;
+		break;
+	case DEV_DISCONNECT_BLACKHOLE:
+		dev_blackhole_fd(PEER_FD);
+		break;
+	case DEV_DISCONNECT_NORMAL:
+		break;
 	}
+#endif
+
+	status_trace("peer_out %s", wire_type_name(fromwire_peektype(msg)));
+	peer->peer_outmsg = cryptomsg_encrypt_msg(peer, &peer->cs, take(msg));
+	peer->peer_outoff = 0;
+	return true;
+}
+
+static void send_shutdown_complete(struct peer *peer)
+{
+	/* Push out any incomplete messages to peer. */
+	while (peer_write_pending(peer))
+		do_peer_write(peer);
 
 	/* Now we can tell master shutdown is complete. */
 	wire_sync_write(MASTER_FD,
 			take(towire_channel_shutdown_complete(peer,
-							      &peer->pcs.cs)));
+							      &peer->cs)));
 	fdpass_send(MASTER_FD, PEER_FD);
 	fdpass_send(MASTER_FD, GOSSIP_FD);
 	close(MASTER_FD);
 }
 
-static bool process_reqs(struct peer *peer)
-{
-	const u8 *msg;
-	bool changed = false;
-
-	/* In case we've deferred, process packet backlog. */
-	while ((msg = msg_dequeue(&peer->from_master)) != NULL) {
-		status_trace("Now dealing with deferred %s",
-			     channel_wire_type_name(fromwire_peektype(msg)));
-		req_in(peer, msg);
-		changed = true;
-	}
-
-	return changed;
-}
-
-static struct peer *peer;
-
-/* If this becomes a common pattern, we could make it a helper in common/ */
-static int poll_with_masterfd(struct pollfd *fds, nfds_t nfds, int timeout)
-{
-	struct pollfd *fds_plus;
-	int r;
-
-	/* This can change things, so return as if poll found nothing. */
-	if (process_reqs(peer))
-		return 0;
-
-	/* Add master fd to fds. */
-	fds_plus = tal_dup_arr(peer, struct pollfd, fds, nfds, 1);
-	fds_plus[nfds].fd = MASTER_FD;
-	fds_plus[nfds].events = POLLIN;
-	fds_plus[nfds].revents = 0;
-
-	r = debug_poll(fds_plus, nfds+1, timeout);
-	if (r > 0) {
-		if (fds_plus[nfds].revents & POLLIN) {
-			u8 *msg = wire_sync_read(peer, MASTER_FD);
-
-			if (!msg)
-				status_failed(STATUS_FAIL_MASTER_IO,
-					      "Can't read command: %s",
-					      strerror(errno));
-			msg_enqueue(&peer->from_master, take(msg));
-			r--;
-		} else if (fds_plus[nfds].revents & (POLLHUP|POLLNVAL|POLLERR))
-			/* Can't report error, master gone. */
-			errx(2, "Error polling master fd");
-	}
-	/* Copy back revents values */
-	memcpy(fds, fds_plus, nfds * sizeof(*fds));
-	tal_free(fds_plus);
-	return r;
-}
-
 int main(int argc, char *argv[])
 {
-	int i;
+	int i, nfds;
+	fd_set fds_in, fds_out;
+	struct peer *peer;
+
 	if (argc == 2 && streq(argv[1], "--version")) {
 		printf("%s\n", version());
 		exit(0);
@@ -2495,6 +2425,11 @@ int main(int argc, char *argv[])
 	peer->announce_depth_reached = false;
 	msg_queue_init(&peer->from_master, peer);
 	msg_queue_init(&peer->peer_out, peer);
+	peer->peer_outmsg = NULL;
+	peer->peer_outoff = 0;
+#if DEVELOPER
+	peer->post_sabotage = false;
+#endif
 	peer->next_commit_sigs = NULL;
 	peer->shutdown_sent[LOCAL] = false;
 
@@ -2507,24 +2442,99 @@ int main(int argc, char *argv[])
 		       sizeof(peer->announcement_bitcoin_sigs[i]));
 	}
 
-	daemon_conn_init(peer, &peer->gossip_client, GOSSIP_FD,
-			 gossip_client_recv, gossip_gone);
-
-	init_peer_crypto_state(peer, &peer->pcs);
-
 	/* Read init_channel message sync. */
 	init_channel(peer);
 
-	/* Make sure we process and listen for master msgs. */
-	io_poll_override(poll_with_masterfd);
+	FD_ZERO(&fds_in);
+	FD_SET(MASTER_FD, &fds_in);
+	FD_SET(PEER_FD, &fds_in);
+	FD_SET(GOSSIP_FD, &fds_in);
 
-	for (;;) {
-		struct timer *expired = NULL;
-		io_loop(&peer->timers, &expired);
+	FD_ZERO(&fds_out);
+	FD_SET(PEER_FD, &fds_out);
+	nfds = GOSSIP_FD+1;
 
-		if (!expired)
-			break;
-		timer_expired(peer, expired);
+	while (!shutdown_complete(peer)) {
+		struct timemono first;
+		fd_set rfds = fds_in, wfds, *wptr;
+		struct timeval timeout, *tptr;
+		struct timer *expired;
+		const u8 *msg;
+		struct timemono now = time_mono();
+
+		/* For simplicity, we process one event at a time. */
+		msg = msg_dequeue(&peer->from_master);
+		if (msg) {
+			status_trace("Now dealing with deferred %s",
+				     channel_wire_type_name(
+					     fromwire_peektype(msg)));
+			req_in(peer, msg);
+			continue;
+		}
+
+		expired = timers_expire(&peer->timers, now);
+		if (expired) {
+			timer_expired(peer, expired);
+			continue;
+		}
+
+		if (timer_earliest(&peer->timers, &first)) {
+			timeout = timespec_to_timeval(
+				timemono_between(first, now).ts);
+			tptr = &timeout;
+		} else
+			tptr = NULL;
+
+		if (peer_write_pending(peer)) {
+			wfds = fds_out;
+			wptr = &wfds;
+		} else
+			wptr = NULL;
+
+		if (select(nfds, &rfds, wptr, NULL, tptr) < 0)
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "select failed: %s", strerror(errno));
+
+		/* Try writing out encrypted packet if any (don't block!) */
+		if (wptr && FD_ISSET(PEER_FD, wptr)) {
+			if (!io_fd_block(PEER_FD, false))
+				status_failed(STATUS_FAIL_INTERNAL_ERROR,
+					      "NONBLOCK failed: %s",
+					      strerror(errno));
+			do_peer_write(peer);
+			if (!io_fd_block(PEER_FD, true))
+				status_failed(STATUS_FAIL_INTERNAL_ERROR,
+					      "NONBLOCK unset failed: %s",
+					      strerror(errno));
+			continue;
+		}
+
+		if (FD_ISSET(MASTER_FD, &rfds)) {
+			msg = wire_sync_read(peer, MASTER_FD);
+
+			if (!msg)
+				status_failed(STATUS_FAIL_MASTER_IO,
+					      "Can't read command: %s",
+					      strerror(errno));
+			req_in(peer, msg);
+		} else if (FD_ISSET(GOSSIP_FD, &rfds)) {
+			msg = wire_sync_read(peer, GOSSIP_FD);
+
+			if (!msg)
+				status_failed(STATUS_FAIL_GOSSIP_IO,
+					      "Can't read command: %s",
+					      strerror(errno));
+			gossip_in(peer, msg);
+		} else if (FD_ISSET(PEER_FD, &rfds)) {
+			/* This could take forever, but who cares? */
+			msg = sync_crypto_read(peer, &peer->cs, PEER_FD);
+
+			if (!msg)
+				peer_conn_broken(peer);
+			peer_in(peer, msg);
+		} else
+			msg = NULL;
+		tal_free(msg);
 	}
 
 	/* We only exit when shutdown is complete. */

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1977,20 +1977,118 @@ static void handle_preimage(struct peer *peer, const u8 *inmsg)
 	abort();
 }
 
+static u8 *foreign_channel_update(const tal_t *ctx,
+				  struct peer *peer,
+				  const struct short_channel_id *scid)
+{
+	/* FIXME! */
+	return NULL;
+}
+
+static u8 *make_failmsg(const tal_t *ctx,
+			struct peer *peer,
+			const struct htlc *htlc,
+			enum onion_type failcode,
+			const struct short_channel_id *scid)
+{
+	u8 *msg, *channel_update = NULL;
+	u32 cltv_expiry = abs_locktime_to_blocks(&htlc->expiry);
+
+	switch (failcode) {
+	case WIRE_INVALID_REALM:
+		msg = towire_invalid_realm(ctx);
+		goto done;
+	case WIRE_TEMPORARY_NODE_FAILURE:
+		msg = towire_temporary_node_failure(ctx);
+		goto done;
+	case WIRE_PERMANENT_NODE_FAILURE:
+		msg = towire_permanent_node_failure(ctx);
+		goto done;
+	case WIRE_REQUIRED_NODE_FEATURE_MISSING:
+		msg = towire_required_node_feature_missing(ctx);
+		goto done;
+	case WIRE_TEMPORARY_CHANNEL_FAILURE:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_temporary_channel_failure(ctx, channel_update);
+		goto done;
+	case WIRE_CHANNEL_DISABLED:
+		msg = towire_channel_disabled(ctx);
+		goto done;
+	case WIRE_PERMANENT_CHANNEL_FAILURE:
+		msg = towire_permanent_channel_failure(ctx);
+		goto done;
+	case WIRE_REQUIRED_CHANNEL_FEATURE_MISSING:
+		msg = towire_required_channel_feature_missing(ctx);
+		goto done;
+	case WIRE_UNKNOWN_NEXT_PEER:
+		msg = towire_unknown_next_peer(ctx);
+		goto done;
+	case WIRE_AMOUNT_BELOW_MINIMUM:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_amount_below_minimum(ctx, htlc->msatoshi,
+						  channel_update);
+		goto done;
+	case WIRE_FEE_INSUFFICIENT:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_fee_insufficient(ctx, htlc->msatoshi,
+					      channel_update);
+		goto done;
+	case WIRE_INCORRECT_CLTV_EXPIRY:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_incorrect_cltv_expiry(ctx, cltv_expiry,
+						   channel_update);
+		goto done;
+	case WIRE_EXPIRY_TOO_SOON:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_expiry_too_soon(ctx, channel_update);
+		goto done;
+	case WIRE_EXPIRY_TOO_FAR:
+		msg = towire_expiry_too_far(ctx);
+		goto done;
+	case WIRE_UNKNOWN_PAYMENT_HASH:
+		msg = towire_unknown_payment_hash(ctx);
+		goto done;
+	case WIRE_INCORRECT_PAYMENT_AMOUNT:
+		msg = towire_incorrect_payment_amount(ctx);
+		goto done;
+	case WIRE_FINAL_EXPIRY_TOO_SOON:
+		msg = towire_final_expiry_too_soon(ctx);
+		goto done;
+	case WIRE_FINAL_INCORRECT_CLTV_EXPIRY:
+		msg = towire_final_incorrect_cltv_expiry(ctx, cltv_expiry);
+		goto done;
+	case WIRE_FINAL_INCORRECT_HTLC_AMOUNT:
+		msg = towire_final_incorrect_htlc_amount(ctx, htlc->msatoshi);
+		goto done;
+	case WIRE_INVALID_ONION_VERSION:
+	case WIRE_INVALID_ONION_HMAC:
+	case WIRE_INVALID_ONION_KEY:
+		break;
+	}
+	status_failed(STATUS_FAIL_INTERNAL_ERROR,
+		      "Asked to create failmsg %u (%s)",
+		      failcode, onion_type_name(failcode));
+
+done:
+	tal_free(channel_update);
+	return msg;
+}
+
 static void handle_fail(struct peer *peer, const u8 *inmsg)
 {
 	u8 *msg;
 	u64 id;
 	u8 *errpkt;
 	u16 failcode;
+	struct short_channel_id scid;
 	enum channel_remove_err e;
 	struct htlc *h;
 
 	if (!fromwire_channel_fail_htlc(inmsg, inmsg, NULL, &id, &errpkt,
-					&failcode))
+					&failcode, &scid))
 		master_badmsg(WIRE_CHANNEL_FAIL_HTLC, inmsg);
 
-	if ((failcode & BADONION) && tal_len(errpkt))
+	if (failcode && tal_len(errpkt))
 		status_failed(STATUS_FAIL_MASTER_IO,
 			      "Invalid channel_fail_htlc: %s with errpkt?",
 			      onion_type_name(failcode));
@@ -2009,8 +2107,13 @@ static void handle_fail(struct peer *peer, const u8 *inmsg)
 							id, &sha256_of_onion,
 							failcode);
 		} else {
-			u8 *reply = wrap_onionreply(inmsg, h->shared_secret,
-						    errpkt);
+			u8 *reply;
+
+			if (failcode)
+				errpkt = make_failmsg(inmsg, peer, h,
+						      failcode, &scid);
+			reply = wrap_onionreply(inmsg, h->shared_secret,
+						errpkt);
 			msg = towire_update_fail_htlc(peer, &peer->channel_id,
 						      id, reply);
 		}

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -427,7 +427,7 @@ static struct io_plan *handle_peer_add_htlc(struct io_conn *conn,
 
 	add_err = channel_add_htlc(peer->channel, REMOTE, id, amount_msat,
 				   cltv_expiry, &payment_hash,
-				   onion_routing_packet);
+				   onion_routing_packet, NULL);
 	if (add_err != CHANNEL_ERR_ADD_OK)
 		peer_failed(io_conn_fd(peer->peer_conn),
 			    &peer->pcs.cs,
@@ -1253,7 +1253,7 @@ static struct io_plan *handle_peer_fail_htlc(struct io_conn *conn,
 			    "Bad update_fulfill_htlc %s", tal_hex(msg, msg));
 	}
 
-	e = channel_fail_htlc(peer->channel, LOCAL, id);
+	e = channel_fail_htlc(peer->channel, LOCAL, id, NULL);
 	switch (e) {
 	case CHANNEL_ERR_REMOVE_OK:
 		/* Save reason for when we tell master. */
@@ -1310,10 +1310,9 @@ static struct io_plan *handle_peer_fail_malformed_htlc(struct io_conn *conn,
 			    failure_code);
 	}
 
-	e = channel_fail_htlc(peer->channel, LOCAL, id);
+	e = channel_fail_htlc(peer->channel, LOCAL, id, &htlc);
 	switch (e) {
 	case CHANNEL_ERR_REMOVE_OK:
-		htlc = channel_get_htlc(peer->channel, LOCAL, id);
 		/* FIXME: Do this! */
 		/* BOLT #2:
 		 *
@@ -1855,7 +1854,7 @@ static void handle_offer_htlc(struct peer *peer, const u8 *inmsg)
 
 	e = channel_add_htlc(peer->channel, LOCAL, peer->htlc_id,
 			     amount_msat, cltv_expiry, &payment_hash,
-			     onion_routing_packet);
+			     onion_routing_packet, NULL);
 	status_trace("Adding HTLC %"PRIu64" msat=%"PRIu64" cltv=%u gave %i",
 		     peer->htlc_id, amount_msat, cltv_expiry, e);
 
@@ -1979,6 +1978,7 @@ static void handle_fail(struct peer *peer, const u8 *inmsg)
 	u8 *errpkt;
 	u16 malformed;
 	enum channel_remove_err e;
+	struct htlc *h;
 
 	if (!fromwire_channel_fail_htlc(inmsg, inmsg, NULL, &id, &malformed,
 					&errpkt))
@@ -1989,15 +1989,13 @@ static void handle_fail(struct peer *peer, const u8 *inmsg)
 			      "Invalid channel_fail_htlc: bad malformed 0x%x",
 			      malformed);
 
-	e = channel_fail_htlc(peer->channel, REMOTE, id);
+	e = channel_fail_htlc(peer->channel, REMOTE, id, &h);
 	switch (e) {
 	case CHANNEL_ERR_REMOVE_OK:
 		if (malformed) {
-			struct htlc *h;
 			struct sha256 sha256_of_onion;
 			status_trace("Failing %"PRIu64" with code %u",
 				     id, malformed);
-			h = channel_get_htlc(peer->channel, REMOTE, id);
 			sha256(&sha256_of_onion, h->routing,
 			       tal_len(h->routing));
 			msg = towire_update_fail_malformed_htlc(peer,

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -92,11 +92,11 @@ channel_fulfill_htlc,,payment_preimage,struct preimage
 # Main daemon says HTLC failed
 channel_fail_htlc,1006
 channel_fail_htlc,,id,u64
-# If malformed is non-zero, it's a BADONION code
-channel_fail_htlc,,malformed,u16
-# Otherwise, error_pkt contains failreason.
+# If this is non-zero length, you need to wrap this and pass it on.
 channel_fail_htlc,,len,u16
 channel_fail_htlc,,error_pkt,len*u8
+# If it errcode is != 0, it's a local error, otherwise we're passing thru.
+channel_fail_htlc,,errcode,u16
 
 # Ping/pong test.
 channel_ping,1011

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -97,6 +97,8 @@ channel_fail_htlc,,len,u16
 channel_fail_htlc,,error_pkt,len*u8
 # If it errcode is != 0, it's a local error, otherwise we're passing thru.
 channel_fail_htlc,,errcode,u16
+# If errcode & UPDATE, this says which outgoing channel failed.
+channel_fail_htlc,,which_channel,struct short_channel_id
 
 # Ping/pong test.
 channel_ping,1011

--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -21,6 +21,9 @@ struct htlc {
 	/* The preimage which hashes to rhash (if known) */
 	struct preimage *r;
 
+	/* The routing shared secret (only for incoming) */
+	struct secret *shared_secret;
+
 	/* FIXME: We could union these together: */
 	/* Routing information sent with this HTLC. */
 	const u8 *routing;

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -305,6 +305,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	htlc->id = id;
 	htlc->msatoshi = msatoshi;
 	htlc->state = state;
+	htlc->shared_secret = NULL;
 
 	/* FIXME: Change expiry to simple u32 */
 

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -471,7 +471,8 @@ enum channel_add_err channel_add_htlc(struct channel *channel,
 				      u64 msatoshi,
 				      u32 cltv_expiry,
 				      const struct sha256 *payment_hash,
-				      const u8 routing[TOTAL_PACKET_SIZE])
+				      const u8 routing[TOTAL_PACKET_SIZE],
+				      struct htlc **htlcp)
 {
 	enum htlc_state state;
 
@@ -482,7 +483,7 @@ enum channel_add_err channel_add_htlc(struct channel *channel,
 
 	/* FIXME: check expiry etc. against config. */
 	return add_htlc(channel, state, id, msatoshi, cltv_expiry,
-			payment_hash, routing, NULL, true);
+			payment_hash, routing, htlcp, true);
 }
 
 struct htlc *channel_get_htlc(struct channel *channel, enum side sender, u64 id)
@@ -555,7 +556,8 @@ enum channel_remove_err channel_fulfill_htlc(struct channel *channel,
 }
 
 enum channel_remove_err channel_fail_htlc(struct channel *channel,
-					  enum side owner, u64 id)
+					  enum side owner, u64 id,
+					  struct htlc **htlcp)
 {
 	struct htlc *htlc;
 
@@ -590,7 +592,8 @@ enum channel_remove_err channel_fail_htlc(struct channel *channel,
 	channel->changes_pending[owner] = true;
 
 	dump_htlc(htlc, "FAIL:");
-
+	if (htlcp)
+		*htlcp = htlc;
 	return CHANNEL_ERR_REMOVE_OK;
 }
 

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -105,6 +105,7 @@ enum channel_add_err {
  * @cltv_expiry: block number when HTLC can no longer be redeemed.
  * @payment_hash: hash whose preimage can redeem HTLC.
  * @routing: routing information (copied)
+ * @htlcp: optional pointer for resulting htlc: filled in iff CHANNEL_ERR_NONE.
  *
  * If this returns CHANNEL_ERR_NONE, the fee htlc was added and
  * the output amounts adjusted accordingly.  Otherwise nothing
@@ -116,7 +117,8 @@ enum channel_add_err channel_add_htlc(struct channel *channel,
 				      u64 msatoshi,
 				      u32 cltv_expiry,
 				      const struct sha256 *payment_hash,
-				      const u8 routing[TOTAL_PACKET_SIZE]);
+				      const u8 routing[TOTAL_PACKET_SIZE],
+				      struct htlc **htlcp);
 
 /**
  * channel_get_htlc: find an HTLC
@@ -146,12 +148,14 @@ enum channel_remove_err {
  * @channel: The channel state
  * @owner: the side who offered the HTLC (opposite to that failing it)
  * @id: unique HTLC id.
+ * @htlcp: optional pointer for failed htlc: filled in iff CHANNEL_ERR_REMOVE_OK.
  *
  * This will remove the htlc and credit the value of the HTLC (back)
  * to its offerer.
  */
 enum channel_remove_err channel_fail_htlc(struct channel *channel,
-					  enum side owner, u64 id);
+					  enum side owner, u64 id,
+					  struct htlc **htlcp);
 
 /**
  * channel_fulfill_htlc: remove an HTLC, funds to side which accepted it.

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -150,7 +150,7 @@ static const struct htlc **include_htlcs(struct channel *channel, enum side side
 		memset(&preimage, i, sizeof(preimage));
 		sha256(&hash, &preimage, sizeof(preimage));
 		e = channel_add_htlc(channel, sender, i, msatoshi, 500+i, &hash,
-				     dummy_routing);
+				     dummy_routing, NULL);
 		assert(e == CHANNEL_ERR_ADD_OK);
 		htlcs[i] = channel_get_htlc(channel, sender, i);
 	}
@@ -248,7 +248,7 @@ static void send_and_fulfill_htlc(struct channel *channel,
 	sha256(&rhash, &r, sizeof(r));
 
 	assert(channel_add_htlc(channel, sender, 1337, msatoshi, 900, &rhash,
-				dummy_routing) == CHANNEL_ERR_ADD_OK);
+				dummy_routing, NULL) == CHANNEL_ERR_ADD_OK);
 
 	changed_htlcs = tal_arr(channel, const struct htlc *, 0);
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -641,7 +641,7 @@ static void handle_get_update(struct peer *peer, const u8 *msg)
 
 reply:
 	msg = towire_gossip_get_update_reply(msg, update);
-	msg_enqueue(&peer->peer_out, take(msg));
+	daemon_conn_send(&peer->owner_conn, take(msg));
 }
 
 /**

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -131,3 +131,14 @@ gossip_getpeers_reply,3111
 gossip_getpeers_reply,,num,u16
 gossip_getpeers_reply,,id,num*struct pubkey
 gossip_getpeers_reply,,addr,num*struct wireaddr
+
+# Channel daemon can ask for updates for a specific channel, for sending
+# errors.  Must be distinct from WIRE_CHANNEL_ANNOUNCEMENT etc. gossip msgs!
+gossip_get_update,3012
+gossip_get_update,,short_channel_id,struct short_channel_id
+
+# If channel isn't known, update will be empty.
+gossip_get_update_reply,3112
+gossip_get_update_reply,,len,u16
+gossip_get_update_reply,,update,len*u8
+

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -68,7 +68,9 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIPCTL_HANDLE_PEER:
 	case WIRE_GOSSIPCTL_RELEASE_PEER:
 	case WIRE_GOSSIPCTL_PEER_ADDRHINT:
+	case WIRE_GOSSIP_GET_UPDATE:
 	/* This is a reply, so never gets through to here. */
+	case WIRE_GOSSIP_GET_UPDATE_REPLY:
 	case WIRE_GOSSIP_GETNODES_REPLY:
 	case WIRE_GOSSIP_GETROUTE_REPLY:
 	case WIRE_GOSSIP_GETCHANNELS_REPLY:

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -32,11 +32,11 @@ struct htlc_in {
 	/* Shared secret for us to send any failure message. */
 	struct secret shared_secret;
 
-	/* If we failed HTLC, here's the message. */
-	const u8 *failuremsg;
+	/* If a local error, this is non-zero. */
+	enum onion_type failcode;
 
-	/* If it was malformed, here's the error. */
-	enum onion_type malformed;
+	/* Either a remote error, or local error if !(failure & BADONION). */
+	const u8 *failuremsg;
 
 	/* If they fulfilled, here's the preimage. */
 	struct preimage *preimage;
@@ -58,11 +58,11 @@ struct htlc_out {
 	/* Onion information */
 	u8 onion_routing_packet[TOTAL_PACKET_SIZE];
 
-	/* If we failed HTLC, here's the message. */
-	const u8 *failuremsg;
+	/* If a local error, this is non-zero. */
+	enum onion_type failcode;
 
-	/* If it was malformed, here's the error. */
-	enum onion_type malformed;
+	/* Either a remote error, or local error if !(failure & BADONION). */
+	const u8 *failuremsg;
 
 	/* If we fulfilled, here's the preimage. */
 	struct preimage *preimage;

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -35,11 +35,15 @@ struct htlc_in {
 	/* If a local error, this is non-zero. */
 	enum onion_type failcode;
 
-	/* Either a remote error, or local error if !(failure & BADONION). */
+	/* For a remote error. */
 	const u8 *failuremsg;
+
+	/* If failcode & UPDATE, this is the channel which failed. */
+	struct short_channel_id failoutchannel;
 
 	/* If they fulfilled, here's the preimage. */
 	struct preimage *preimage;
+
 };
 
 struct htlc_out {
@@ -61,7 +65,7 @@ struct htlc_out {
 	/* If a local error, this is non-zero. */
 	enum onion_type failcode;
 
-	/* Either a remote error, or local error if !(failure & BADONION). */
+	/* For a remote error. */
 	const u8 *failuremsg;
 
 	/* If we fulfilled, here's the preimage. */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -99,18 +99,13 @@ static void fail_in_htlc(struct htlc_in *hin,
 		subd_send_msg(hin->key.peer->owner,
 			      take(towire_channel_fail_htlc(hin,
 							    hin->key.id,
-							    hin->failcode,
-							    NULL)));
+							    NULL,
+							    hin->failcode)));
 	} else {
-		u8 *reply;
-
-		/* This obfuscates the message, whether local or forwarded. */
-		reply = wrap_onionreply(hin, &hin->shared_secret,
-					hin->failuremsg);
 		subd_send_msg(hin->key.peer->owner,
 			      take(towire_channel_fail_htlc(hin, hin->key.id,
-							    0, reply)));
-		tal_free(reply);
+							    hin->failuremsg,
+							    0)));
 	}
 }
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -29,10 +29,10 @@ def bitcoind():
     # Make sure we have segwit and some funds
     if info['blocks'] < 432:
         logging.debug("SegWit not active, generating some more blocks")
-        bitcoind.rpc.generate(432 - info['blocks'])
+        bitcoind.generate_block(432 - info['blocks'])
     elif info['balance'] < 1:
         logging.debug("Insufficient balance, generating 1 block")
-        bitcoind.rpc.generate(1)
+        bitcoind.generate_block(1)
 
     yield bitcoind
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -220,6 +220,10 @@ class BitcoinD(TailableProc):
 
         logging.info("BitcoinD started")
 
+    def generate_block(self, numblocks=1):
+        # As of 0.16, generate() is removed; use generatetoaddress.
+        self.rpc.generatetoaddress(numblocks, self.rpc.getnewaddress())
+
 # lightning-1 => 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 aka JUNIORBEAM #0266e4
 # lightning-2 => 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 aka SILENTARTIST #022d22
 # lightning-3 => 035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d aka HOPPINGFIRE #035d2b
@@ -297,7 +301,7 @@ class LightningNode(object):
                     raise TimeoutError('No new transactions in mempool')
                 time.sleep(0.1)
 
-            self.bitcoin.rpc.generate(1)
+            self.bitcoin.generate_block(1)
 
             #fut.result(timeout=5)
 
@@ -318,7 +322,7 @@ class LightningNode(object):
         self.rpc.fundchannel(remote_node.info['id'], capacity)
         self.daemon.wait_for_log('sendrawtx exit 0, gave')
         time.sleep(1)
-        self.bitcoin.rpc.generate(6)
+        self.bitcoin.generate_block(6)
         self.daemon.wait_for_log('-> CHANNELD_NORMAL|STATE_NORMAL')
 
     def db_query(self, query):

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -901,8 +901,9 @@ static bool wallet_stmt2htlc_in(const struct wallet_channel *channel,
 	memcpy(&in->onion_routing_packet, sqlite3_column_blob(stmt, 8),
 	       sizeof(in->onion_routing_packet));
 
+	/* FIXME: These need to be saved in db! */
 	in->failuremsg = NULL;
-	in->malformed = 0;
+	in->failcode = 0;
 
 	return ok;
 }
@@ -936,7 +937,7 @@ static bool wallet_stmt2htlc_out(const struct wallet_channel *channel,
 	       sizeof(out->onion_routing_packet));
 
 	out->failuremsg = NULL;
-	out->malformed = 0;
+	out->failcode = 0;
 
 	/* Need to defer wiring until we can look up all incoming
 	 * htlcs, will wire using origin_htlc_id */

--- a/wire/gen_peer_wire_csv
+++ b/wire/gen_peer_wire_csv
@@ -33,6 +33,7 @@ open_channel,219,delayed_payment_basepoint,33
 open_channel,252,htlc_basepoint,33
 open_channel,285,first_per_commitment_point,33
 open_channel,318,channel_flags,1
+open_channel,319,shutdown_len,2,option_upfront_shutdown_script
 accept_channel,33
 accept_channel,0,temporary_channel_id,32
 accept_channel,32,dust_limit_satoshis,8
@@ -48,6 +49,7 @@ accept_channel,138,payment_basepoint,33
 accept_channel,171,delayed_payment_basepoint,33
 accept_channel,204,htlc_basepoint,33
 accept_channel,237,first_per_commitment_point,33
+accept_channel,270,shutdown_len,2,option_upfront_shutdown_script
 funding_created,34
 funding_created,0,temporary_channel_id,32
 funding_created,32,funding_txid,32


### PR DESCRIPTION
Kind of went the long way around: channeld needs to ask gossipd for update_channel, and that's our first request-response.  The best way to treat this is to make channeld do gossipd comms sync (like it does for master comms); cleanest way to do that is to remove ccan/io, which also fixes another potential bug.