### PR TITLE
Use pytest3 (which uses python3) instead of pytest (which might use python2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq ($(COVERAGE),1)
 COVFLAGS = --coverage
 endif
 
-PYTEST := $(shell command -v pytest 2> /dev/null)
+PYTEST := $(shell command -v pytest3 2> /dev/null)
 
 # This is where we add new features as bitcoin adds them.
 FEATURES :=


### PR DESCRIPTION
Use `pytest3` (which uses `python3`) instead of `pytest` (which might use `python2`).

`make check` currently fails if `pytest` is referencing `python2`. This patch fixes that by explicitly using `pytest3`.

As I understand it the tests assume Python 3 (please correct me if I'm wrong!).

On a Ubuntu 16.04.3 LTS system:

```
$ diff -u $(which pytest) $(which pytest3)
--- /usr/bin/pytest	2016-01-18 06:10:32.000000000 +0100
+++ /usr/bin/pytest3	2016-01-18 06:10:32.000000000 +0100
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3

 import warnings
 warnings.simplefilter('default', DeprecationWarning)
```