### PR TITLE
WIP: Announce channels to the involved peers directly after funding locked

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -210,6 +210,9 @@ static void send_temporary_announcement(struct peer *peer)
 	cannounce = create_channel_announcement(tmpctx, peer);
 	cupdate = create_channel_update(tmpctx, peer, false, false);
 
+	msg_enqueue(&peer->peer_out, cannounce);
+	msg_enqueue(&peer->peer_out, cupdate);
+
 	wire_sync_write(GOSSIP_FD, take(cannounce));
 	wire_sync_write(GOSSIP_FD, take(cupdate));
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1114,7 +1114,7 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 				     &daemon->localfeatures)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}
-	daemon->rstate = new_routing_state(daemon, &chain_hash);
+	daemon->rstate = new_routing_state(daemon, &chain_hash, &daemon->id);
 
 	setup_listeners(daemon, port);
 	return daemon_conn_read_next(master->conn, master);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -31,6 +31,7 @@
 #include <gossipd/handshake.h>
 #include <gossipd/routing.h>
 #include <hsmd/client.h>
+#include <hsmd/gen_hsm_client_wire.h>
 #include <inttypes.h>
 #include <lightningd/gossip_msg.h>
 #include <netdb.h>
@@ -43,6 +44,7 @@
 #include <unistd.h>
 #include <wire/gen_peer_wire.h>
 #include <wire/wire_io.h>
+#include <wire/wire_sync.h>
 
 #define HSM_FD 3
 
@@ -371,12 +373,69 @@ static struct io_plan *owner_msg_in(struct io_conn *conn,
 static struct io_plan *nonlocal_dump_gossip(struct io_conn *conn,
 					    struct daemon_conn *dc);
 
-static void handle_gossip_msg(struct routing_state *rstate, u8 *msg)
+/* Create a node_announcement with the given signature. It may be NULL
+ * in the case we need to create a provisional announcement for the
+ * HSM to sign. This is typically called twice: once with the dummy
+ * signature to get it signed and a second time to build the full
+ * packet with the signature. The timestamp is handed in since that is
+ * the only thing that may change between the dummy creation and the
+ * call with a signature.*/
+static u8 *create_node_announcement(const tal_t *ctx, struct daemon *daemon,
+				    secp256k1_ecdsa_signature *sig,
+				    u32 timestamp)
 {
+	u8 *features = NULL;
+	u8 *addresses = tal_arr(ctx, u8, 0);
+	u8 *announcement;
+	size_t i;
+	if (!sig) {
+		sig = tal(ctx, secp256k1_ecdsa_signature);
+		memset(sig, 0, sizeof(*sig));
+	}
+	for (i = 0; i < tal_count(daemon->wireaddrs); i++)
+		towire_wireaddr(&addresses, daemon->wireaddrs+i);
+
+	announcement =
+	    towire_node_announcement(ctx, sig, features, timestamp,
+				     &daemon->id, daemon->rgb, daemon->alias,
+				     addresses);
+	return announcement;
+}
+
+static void send_node_announcement(struct daemon *daemon)
+{
+	tal_t *tmpctx = tal_tmpctx(daemon);
+	u32 timestamp = time_now().ts.tv_sec;
+	secp256k1_ecdsa_signature sig;
+	u8 *msg, *nannounce = create_node_announcement(tmpctx, daemon, NULL, timestamp);
+
+	if (!wire_sync_write(HSM_FD, take(towire_hsm_node_announcement_sig_req(tmpctx, nannounce))))
+		status_failed(STATUS_FAIL_MASTER_IO, "Could not write to HSM: %s", strerror(errno));
+
+	msg = wire_sync_read(tmpctx, HSM_FD);
+	if (!fromwire_hsm_node_announcement_sig_reply(msg, NULL, &sig))
+		status_failed(STATUS_FAIL_MASTER_IO, "HSM returned an invalid node_announcement sig");
+
+	/* We got the signature for out provisional node_announcement back
+	 * from the HSM, create the real announcement and forward it to
+	 * gossipd so it can take care of forwarding it. */
+	nannounce = create_node_announcement(tmpctx, daemon, &sig, timestamp);
+	handle_node_announcement(daemon->rstate, take(nannounce), tal_len(nannounce));
+	tal_free(tmpctx);
+}
+
+static void handle_gossip_msg(struct daemon *daemon, u8 *msg)
+{
+	struct routing_state *rstate = daemon->rstate;
 	int t = fromwire_peektype(msg);
 	switch(t) {
 	case WIRE_CHANNEL_ANNOUNCEMENT:
-		handle_channel_announcement(rstate, msg, tal_count(msg));
+		/* Add the channel_announcement to the routing state,
+		 * it'll tell us whether this is local and signed, so
+		 * we can hand in a node_announcement as well. */
+		if(handle_channel_announcement(rstate, msg, tal_count(msg))) {
+			send_node_announcement(daemon);
+		}
 		break;
 
 	case WIRE_NODE_ANNOUNCEMENT:
@@ -489,7 +548,7 @@ static struct io_plan *peer_msgin(struct io_conn *conn,
 	case WIRE_CHANNEL_ANNOUNCEMENT:
 	case WIRE_NODE_ANNOUNCEMENT:
 	case WIRE_CHANNEL_UPDATE:
-		handle_gossip_msg(peer->daemon->rstate, msg);
+		handle_gossip_msg(peer->daemon, msg);
 		return peer_next_in(conn, peer);
 
 	case WIRE_PING:
@@ -661,7 +720,7 @@ static struct io_plan *owner_msg_in(struct io_conn *conn,
 	int type = fromwire_peektype(msg);
 	if (type == WIRE_CHANNEL_ANNOUNCEMENT || type == WIRE_CHANNEL_UPDATE ||
 	    type == WIRE_NODE_ANNOUNCEMENT) {
-		handle_gossip_msg(peer->daemon->rstate, dc->msg_in);
+		handle_gossip_msg(peer->daemon, dc->msg_in);
 	} else if (type == WIRE_GOSSIP_GET_UPDATE) {
 		handle_get_update(peer, dc->msg_in);
 	}
@@ -1161,7 +1220,7 @@ static void handle_forwarded_msg(struct io_conn *conn, struct daemon *daemon, co
 	if (!fromwire_gossip_forwarded_msg(msg, msg, NULL, &payload))
 		master_badmsg(WIRE_GOSSIP_FORWARDED_MSG, msg);
 
-	handle_gossip_msg(daemon->rstate, payload);
+	handle_gossip_msg(daemon, payload);
 }
 
 static struct io_plan *handshake_out_success(struct io_conn *conn,

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -71,6 +71,10 @@ struct daemon {
 
 	/* Local and global features to offer to peers. */
 	u8 *localfeatures, *globalfeatures;
+
+	u8 alias[33];
+	u8 rgb[3];
+	struct wireaddr *wireaddrs;
 };
 
 /* Peers we're trying to reach. */
@@ -1111,7 +1115,9 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 				     &daemon->broadcast_interval,
 				     &chain_hash, &daemon->id, &port,
 				     &daemon->globalfeatures,
-				     &daemon->localfeatures)) {
+				     &daemon->localfeatures,
+				     &daemon->wireaddrs,
+				     daemon->rgb, daemon->alias)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}
 	daemon->rstate = new_routing_state(daemon, &chain_hash, &daemon->id);

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -12,6 +12,10 @@ gossipctl_init,,gflen,u16
 gossipctl_init,,gfeatures,gflen*u8
 gossipctl_init,,lflen,u16
 gossipctl_init,,lfeatures,lflen*u8
+gossipctl_init,,num_wireaddrs,u16
+gossipctl_init,,wireaddrs,num_wireaddrs*struct wireaddr
+gossipctl_init,,rgb,3*u8
+gossipctl_init,,alias,32*u8
 
 # Master -> gossipd: Optional hint for where to find peer.
 gossipctl_peer_addrhint,3014

--- a/gossipd/handshake.c
+++ b/gossipd/handshake.c
@@ -22,8 +22,6 @@
 #include <unistd.h>
 #include <wire/wire.h>
 
-#define HSM_FD 3
-
 #ifndef SUPERVERBOSE
 #define SUPERVERBOSE(...)
 #endif

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -513,9 +513,6 @@ bool handle_channel_announcement(
 	// FIXME: Check features!
 	//FIXME(cdecker) Check chain topology for the anchor TX
 
-	status_trace("Received channel_announcement for channel %s",
-		     type_to_string(trc, struct short_channel_id,
-				    &short_channel_id));
 
 	local = pubkey_eq(&node_id_1, &rstate->local_id) ||
 		pubkey_eq(&node_id_2, &rstate->local_id);
@@ -523,6 +520,11 @@ bool handle_channel_announcement(
 	    &node_id_1, &node_id_2, &bitcoin_key_1, &bitcoin_key_2,
 	    &node_signature_1, &node_signature_2, &bitcoin_signature_1,
 	    &bitcoin_signature_2, serialized);
+
+	status_trace("Received channel_announcement for channel %s, local=%d, sigfail=%d",
+		     type_to_string(trc, struct short_channel_id,
+				    &short_channel_id), local, sigfail);
+
 
 	if (sigfail && !local) {
 		status_trace(

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -424,9 +424,11 @@ static bool add_channel_direction(struct routing_state *rstate,
 	c = half_add_connection(rstate, from, to, short_channel_id, direction);
 
 	/* Remember the announcement so we can forward it to new peers */
-	tal_free(c->channel_announcement);
-	c->channel_announcement = tal_dup_arr(c, u8, announcement,
-					      tal_count(announcement), 0);
+	if (announcement) {
+		tal_free(c->channel_announcement);
+		c->channel_announcement = tal_dup_arr(c, u8, announcement,
+						      tal_count(announcement), 0);
+	}
 	return true;
 }
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -26,12 +26,14 @@ static struct node_map *empty_node_map(const tal_t *ctx)
 }
 
 struct routing_state *new_routing_state(const tal_t *ctx,
-					const struct sha256_double *chain_hash)
+					const struct sha256_double *chain_hash,
+					const struct pubkey *local_id)
 {
 	struct routing_state *rstate = tal(ctx, struct routing_state);
 	rstate->nodes = empty_node_map(rstate);
 	rstate->broadcasts = new_broadcast_state(rstate);
 	rstate->chain_hash = *chain_hash;
+	rstate->local_id = *local_id;
 	return rstate;
 }
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -193,6 +193,7 @@ get_or_make_connection(struct routing_state *rstate,
 	nc->dst = to;
 	nc->channel_announcement = NULL;
 	nc->channel_update = NULL;
+	nc->announced = false;
 
 	/* Hook it into in/out arrays. */
 	i = tal_count(to->in);
@@ -540,7 +541,7 @@ bool handle_channel_announcement(
 	/* Is this a new connection? */
 	c0 = get_connection_by_scid(rstate, &short_channel_id, 0);
 	c1 = get_connection_by_scid(rstate, &short_channel_id, 1);
-	forward = !c0 || !c1 || !c0->channel_announcement || !c1->channel_announcement;
+	forward = !c0 || !c1 || !c0->announced || !c1->announced;
 
 	add_channel_direction(rstate, &node_id_1, &node_id_2, &short_channel_id,
 			      sigfail ? NULL : serialized);
@@ -561,6 +562,9 @@ bool handle_channel_announcement(
 			tag, serialized);
 
 	tal_free(tmpctx);
+	c0 = get_connection_by_scid(rstate, &short_channel_id, 0);
+	c1 = get_connection_by_scid(rstate, &short_channel_id, 1);
+	c0->announced = c1->announced = true;
 	return local;
 }
 

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -83,6 +83,9 @@ struct routing_state {
 	struct broadcast_state *broadcasts;
 
 	struct sha256_double chain_hash;
+
+	/* Our own ID so we can identify local channels */
+	struct pubkey local_id;
 };
 
 struct route_hop {
@@ -117,7 +120,15 @@ struct node_connection *get_connection_by_scid(const struct routing_state *rstat
 					      const u8 direction);
 
 /* Handlers for incoming messages */
-void handle_channel_announcement(struct routing_state *rstate, const u8 *announce, size_t len);
+
+/**
+ * handle_channel_announcement -- Add channel announcement to state
+ *
+ * Returns true if the channel was fully signed and is local. This
+ * means that if we haven't sent a node_announcement just yet, now
+ * would be a good time.
+ */
+bool handle_channel_announcement(struct routing_state *rstate, const u8 *announce, size_t len);
 void handle_channel_update(struct routing_state *rstate, const u8 *update, size_t len);
 void handle_node_announcement(struct routing_state *rstate, const u8 *node, size_t len);
 

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -22,6 +22,9 @@ struct node_connection {
 	/* Is this connection active? */
 	bool active;
 
+	/* Was this channel already announced through a channel_announcement? */
+	bool announced;
+
 	s64 last_timestamp;
 
 	/* Minimum number of msatoshi in an HTLC */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -93,7 +93,8 @@ struct route_hop {
 };
 
 struct routing_state *new_routing_state(const tal_t *ctx,
-					const struct sha256_double *chain_hash);
+					const struct sha256_double *chain_hash,
+					const struct pubkey *local_id);
 
 /* msatoshi must be possible (< 21 million BTC), ie < 2^60.
  * If it returns more than msatoshi, it overflowed. */

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -67,8 +67,6 @@ int main(void)
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
 						 | SECP256K1_CONTEXT_SIGN);
 
-	rstate = new_routing_state(ctx, &zerohash);
-
 	pubkey_from_hexstr("03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf",
 			   strlen("03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf"),
 			   &a);
@@ -79,6 +77,7 @@ int main(void)
 			   strlen("02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06"),
 			   &c);
 
+	rstate = new_routing_state(ctx, &zerohash, &a);
 
 	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 	nc = get_or_make_connection(rstate, &c, &b);

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -78,9 +78,9 @@ int main(void)
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
 						 | SECP256K1_CONTEXT_SIGN);
 
-	rstate = new_routing_state(ctx, &zerohash);
-
 	memset(&tmp, 'a', sizeof(tmp));
+	rstate = new_routing_state(ctx, &zerohash, &a);
+
 	pubkey_from_privkey(&tmp, &a);
 	new_node(rstate, &a);
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -126,7 +126,8 @@ void gossip_init(struct lightningd *ld)
 				    &get_chainparams(ld)->genesis_blockhash,
 				    &ld->id, ld->portnum,
 				    get_supported_global_features(tmpctx),
-				    get_supported_local_features(tmpctx));
+				    get_supported_local_features(tmpctx),
+				    ld->wireaddrs, ld->rgb, ld->alias);
 	subd_send_msg(ld->gossip, msg);
 	tal_free(tmpctx);
 }

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -89,7 +89,7 @@ struct lightningd {
 	struct pubkey id;
 
 	/* My name is... my favorite color is... */
-	char *alias; /* At least 32 bytes (zero-filled) */
+	u8 *alias; /* At least 32 bytes (zero-filled) */
 	u8 *rgb; /* tal_len() == 3. */
 
 	/* Any pending timers. */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -168,8 +168,8 @@ static char *opt_set_alias(const char *arg, struct lightningd *ld)
 	 */
 	if (strlen(arg) > 32)
 		return tal_fmt(NULL, "Alias '%s' is over 32 characters", arg);
-	ld->alias = tal_arrz(ld, char, 33);
-	strncpy(ld->alias, arg, 32);
+	ld->alias = tal_arrz(ld, u8, 33);
+	strncpy((char*)ld->alias, arg, 32);
 	return NULL;
 }
 
@@ -572,11 +572,11 @@ void setup_color_and_alias(struct lightningd *ld)
 		memcpy(&noun, der+3+sizeof(adjective), sizeof(noun));
 		noun %= ARRAY_SIZE(codename_noun);
 		adjective %= ARRAY_SIZE(codename_adjective);
-		ld->alias = tal_arrz(ld, char, 33);
+		ld->alias = tal_arrz(ld, u8, 33);
 		assert(strlen(codename_adjective[adjective])
 		       + strlen(codename_noun[noun]) < 33);
-		strcpy(ld->alias, codename_adjective[adjective]);
-		strcat(ld->alias, codename_noun[noun]);
+		strcpy((char*)ld->alias, codename_adjective[adjective]);
+		strcat((char*)ld->alias, codename_noun[noun]);
 	}
 }
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1336,7 +1336,7 @@ class LightningDTests(BaseLightningDTests):
     def test_routing_gossip_reconnect(self):
         # Connect two peers, reconnect and then see if we resume the
         # gossip.
-        disconnects = ['-WIRE_CHANNEL_ANNOUNCEMENT']
+        disconnects = ['-WIRE_NODE_ANNOUNCEMENT']
         l1 = self.node_factory.get_node(disconnect=disconnects)
         l2 = self.node_factory.get_node()
         l3 = self.node_factory.get_node()

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -323,9 +323,9 @@ class LightningDTests(BaseLightningDTests):
 
         # Wait for route propagation.
         bitcoind.generate_block(5)
-        l1.daemon.wait_for_logs(['Received channel_update for channel {}\(0\)'
+        l1.daemon.wait_for_logs(['Received public channel_update for channel {}\(0\)'
                                  .format(chanid),
-                                'Received channel_update for channel {}\(1\)'
+                                'Received public channel_update for channel {}\(1\)'
                                  .format(chanid)])
 
         inv = l2.rpc.invoice(123000, 'test_pay', 'description', 1)['bolt11']
@@ -689,9 +689,9 @@ class LightningDTests(BaseLightningDTests):
 
         # Wait for route propagation.
         bitcoind.generate_block(5)
-        l1.daemon.wait_for_logs(['Received channel_update for channel {}\(0\)'
+        l1.daemon.wait_for_logs(['Received public channel_update for channel {}\(0\)'
                                  .format(chanid),
-                                'Received channel_update for channel {}\(1\)'
+                                'Received public channel_update for channel {}\(1\)'
                                  .format(chanid)])
 
         inv = l2.rpc.invoice(123000, 'test_pay', 'description')['bolt11']
@@ -1511,10 +1511,10 @@ class LightningDTests(BaseLightningDTests):
 
         # Make sure l1 has seen announce for all channels.
         l1.daemon.wait_for_logs([
-            'Received channel_update for channel {}\\(0\\)'.format(c1),
-            'Received channel_update for channel {}\\(1\\)'.format(c1),
-            'Received channel_update for channel {}\\(0\\)'.format(c2),
-            'Received channel_update for channel {}\\(1\\)'.format(c2)])
+            'Received public channel_update for channel {}\\(0\\)'.format(c1),
+            'Received public channel_update for channel {}\\(1\\)'.format(c1),
+            'Received public channel_update for channel {}\\(0\\)'.format(c2),
+            'Received public channel_update for channel {}\\(1\\)'.format(c2)])
 
         # BOLT #7:
         #
@@ -1610,10 +1610,10 @@ class LightningDTests(BaseLightningDTests):
 
         # Make sure l1 has seen announce for all channels.
         l1.daemon.wait_for_logs([
-            'Received channel_update for channel {}\\(0\\)'.format(c1),
-            'Received channel_update for channel {}\\(1\\)'.format(c1),
-            'Received channel_update for channel {}\\(0\\)'.format(c2),
-            'Received channel_update for channel {}\\(1\\)'.format(c2)])
+            'Received public channel_update for channel {}\\(0\\)'.format(c1),
+            'Received public channel_update for channel {}\\(1\\)'.format(c1),
+            'Received public channel_update for channel {}\\(0\\)'.format(c2),
+            'Received public channel_update for channel {}\\(1\\)'.format(c2)])
 
         route = l1.rpc.getroute(l3.info['id'], 4999999, 1)["route"]
         assert len(route) == 2
@@ -1649,9 +1649,9 @@ class LightningDTests(BaseLightningDTests):
 
         # Wait for route propagation.
         bitcoind.generate_block(5)
-        l1.daemon.wait_for_logs(['Received channel_update for channel {}\(0\)'
+        l1.daemon.wait_for_logs(['Received public channel_update for channel {}\(0\)'
                                  .format(chanid),
-                                'Received channel_update for channel {}\(1\)'
+                                'Received public channel_update for channel {}\(1\)'
                                  .format(chanid)])
 
         amt = 200000000
@@ -1689,9 +1689,9 @@ class LightningDTests(BaseLightningDTests):
 
         # Wait for route propagation.
         bitcoind.generate_block(5)
-        l1.daemon.wait_for_logs(['Received channel_update for channel {}\(0\)'
+        l1.daemon.wait_for_logs(['Received public channel_update for channel {}\(0\)'
                                  .format(chanid),
-                                'Received channel_update for channel {}\(1\)'
+                                'Received public channel_update for channel {}\(1\)'
                                  .format(chanid)])
 
         amt = 200000000
@@ -2270,9 +2270,9 @@ class LightningDTests(BaseLightningDTests):
         # Now make sure an HTLC works.
         # (First wait for route propagation.)
         bitcoind.generate_block(6)
-        l1.daemon.wait_for_logs(['Received channel_update for channel {}\(0\)'
+        l1.daemon.wait_for_logs(['Received public channel_update for channel {}\(0\)'
                                  .format(chanid),
-                                'Received channel_update for channel {}\(1\)'
+                                'Received public channel_update for channel {}\(1\)'
                                  .format(chanid)])
 
         # Make payments.


### PR DESCRIPTION
This should fix #284 and depends on #413 (the first 8 commits are from there). It creates unsigned `channel_announcement`s and `channel_update`s for a channel that has just locked in. They are then sent to the other endpoint of the channel and to `gossipd` (other nodes would ignore them due to missing/invalid signatures, but better not send them anyway). `gossipd` will process them adding the channel to the local view of the network, making them usable for routes, however it won't queue them for broadcast.

The reason this is still WIP is that we have a flaky test `test_reconnect_sender_add1` which occasionally fails because the `sendpay` command doesn't fail when running under `valgrind`. It appears that for some reason we appear to automatically re-attempt the payment after reconnect when this PR is merged, and the payment succeeds. For comparison see the [log before](https://gist.github.com/cdecker/d0416f5cc07164d257a37ab6a546f21c#file-test_reconnect_sender_add1-before) (especially the lines surrounding the [first `dev_disconnect`](https://gist.github.com/cdecker/d0416f5cc07164d257a37ab6a546f21c#file-test_reconnect_sender_add1-before-L548)) and the [log after](https://gist.github.com/cdecker/d0416f5cc07164d257a37ab6a546f21c#file-test_reconnect_sender_add1-after) (also around the [`first dev_disconnect`](https://gist.github.com/cdecker/d0416f5cc07164d257a37ab6a546f21c#file-test_reconnect_sender_add1-after-L627)). I'm wondering how this can happen even though the test has nothing to do with `gossipd`, since we construct the route manually.

@rustyrussell any idea why this happens?