### PR TITLE
Make json_withdraw check testnet flag.

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -114,6 +114,18 @@ static void json_withdraw(struct command *cmd,
 		return;
 	}
 
+	/* Check address given is compatible with the chain we are on. */
+	if (testnet != get_chainparams(cmd->ld)->testnet) {
+		if (testnet) {
+			command_fail(cmd,
+				    "Use of testnet address on mainnet");
+		} else {
+			command_fail(cmd,
+				    "Use of mainnet address on testnet");
+		}
+		return;
+	}
+
 	/* Select the coins */
 	withdraw->utxos = wallet_select_coins(cmd, cmd->ld->wallet,
 					      withdraw->amount,


### PR DESCRIPTION
  `bitcoin_from_base58` returns a `testnet` flag, but `json_withdraw`
did not actually check it. Add a basic check that the given
withdraw address belongs to the same net `lightningd` is using.