### PR TITLE
Remove static inline to fix the clang build and added clang travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,16 @@ notifications:
   email: false
 
 env:
-  - NO_VALGRIND=1 ARCH=32 DEVELOPER=1
-  - NO_VALGRIND=1 ARCH=64 DEVELOPER=1
-  - NO_VALGRIND=0 ARCH=64 DEVELOPER=1
-  - NO_VALGRIND=0 ARCH=64 DEVELOPER=0
+  - NO_VALGRIND=1 ARCH=32 DEVELOPER=1 COMPILER=gcc
+  - NO_VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc
+  - NO_VALGRIND=0 ARCH=64 DEVELOPER=1 COMPILER=gcc
+  - NO_VALGRIND=0 ARCH=64 DEVELOPER=0 COMPILER=gcc
+  - NO_VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=clang
 
 # Trusty (aka 14.04) is way way too old, so run in docker...
 script:
   - docker pull cdecker/lightning-ci:${ARCH}bit | tee
-  - echo "Building..."
-  - echo "travis_fold:start:SCRIPT folding starts"
-  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3 DEVELOPER=${DEVELOPER}
-  - echo "travis_fold:end:SCRIPT folding ends"
-  - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check DEVELOPER=${DEVELOPER}
+  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3 CC=${COMPILER} DEVELOPER=${DEVELOPER}
+  - docker run --rm=true -e NO_VALGRIND=${NO_VALGRIND:-0} -e TEST_DEBUG=${TEST_DEBUG:-0} -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make CC=${COMPILER} check DEVELOPER=${DEVELOPER}
 #  - git clone https://github.com/lightningnetwork/lightning-rfc.git
 #  - docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check-source BOLTDIR=lightning-rfc

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -8,6 +8,7 @@ RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
 	autoconf \
 	automake \
+	clang \
 	eatmydata \
 	software-properties-common \
 	build-essential \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -8,6 +8,7 @@ RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
 	autoconf \
 	automake \
+	clang \
 	eatmydata \
 	software-properties-common \
 	build-essential \

--- a/gossipd/handshake.c
+++ b/gossipd/handshake.c
@@ -687,6 +687,7 @@ static struct io_plan *act_one_initiator(struct io_conn *conn,
 				      SECP256K1_EC_COMPRESSED);
 	SUPERVERBOSE("output: 0x%s", tal_hexstr(trc, &h->act1, ACT_ONE_SIZE));
 
+	check_act_one(&h->act1);
 	return io_write(conn, &h->act1, ACT_ONE_SIZE, act_two_initiator, h);
 }
 
@@ -764,6 +765,7 @@ static struct io_plan *act_three_responder2(struct io_conn *conn,
 		     h->act3.tag, sizeof(h->act3.tag), NULL, 0))
 		return handshake_failed(conn, h);
 
+	check_act_three(&h->act3);
 	return handshake_succeeded(conn, h);
 }
 
@@ -859,6 +861,7 @@ static struct io_plan *act_two_responder(struct io_conn *conn,
 				      SECP256K1_EC_COMPRESSED);
 	SUPERVERBOSE("output: 0x%s", tal_hexstr(trc, &h->act2, ACT_TWO_SIZE));
 
+	check_act_two(&h->act2);
 	return io_write(conn, &h->act2, ACT_TWO_SIZE, act_three_responder, h);
 }
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -180,14 +180,6 @@ bool wallet_shachain_add_hash(struct wallet *wallet,
 			      uint64_t index,
 			      const struct sha256 *hash);
 
-/* Simply passes through to shachain_get_hash since it doesn't touch
- * the DB */
-inline bool wallet_shachain_get_hash(struct wallet *w,
-				     struct wallet_shachain *chain,
-				     u64 index, struct sha256 *hash)
-{
-	return shachain_get_hash(&chain->chain, index, hash);
-}
 /**
  * wallet_shachain_load -- Load an existing shachain from the wallet.
  *

--- a/wire/test/run-peer-wire.c
+++ b/wire/test/run-peer-wire.c
@@ -70,16 +70,6 @@ static void set_pubkey(struct pubkey *key)
 #define eq_var(p1, p2, field)			\
 	(tal_count((p1)->field) == tal_count((p2)->field) && memcmp((p1)->field, (p2)->field, tal_count((p1)->field) * sizeof(*(p1)->field)) == 0)
 
-static inline bool eq_skip_(const void *p1, const void *p2,
-			    size_t off, size_t skip, size_t total)
-{
-	if (memcmp(p1, p2, off) != 0)
-		return false;
-	p1 = (char *)p1 + off + skip;
-	p2 = (char *)p2 + off + skip;
-	return memcmp(p1, p2, total - (off + skip)) == 0;
-}
-
 /* Convenience structs for everyone! */
 struct msg_error {
 	struct channel_id channel_id;


### PR DESCRIPTION
Clang doesn't like static inlines that are unused, so removing these fixes the clang build.