### PR TITLE
peer: add peer_has_error

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -189,7 +189,7 @@ void peer_fail_permanent(struct peer *peer, const u8 *msg TAKES)
 		    (int)tal_len(msg), (char *)msg);
 
 	/* We can have multiple errors, eg. onchaind failures. */
-	if (!peer->error)
+	if (!peer_has_error(peer))
 		peer->error = towire_error(peer, &all_channels, msg);
 
 	peer_set_owner(peer, NULL);
@@ -561,7 +561,7 @@ void peer_connected(struct lightningd *ld, const u8 *msg,
 			  peer_state_name(peer->state));
 
 		/* FIXME: We can have errors for multiple channels. */
-		if (peer->error) {
+		if (peer_has_error(peer)) {
 			error = peer->error;
 			goto send_error;
 		}

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -133,6 +133,11 @@ static inline bool peer_on_chain(const struct peer *peer)
 	return peer_state_on_chain(peer->state);
 }
 
+static inline bool peer_has_error(const struct peer *peer)
+{
+  return !(peer->error == NULL || peer->error[0] == '\0');
+}
+
 static inline bool peer_wants_reconnect(const struct peer *peer)
 {
 	return peer->state >= CHANNELD_AWAITING_LOCKIN

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1419,7 +1419,7 @@ void notify_new_block(struct lightningd *ld, u32 height)
 				continue;
 
 			/* Peer already failed, or we hit it? */
-			if (hout->key.peer->error)
+			if (peer_has_error(hout->key.peer))
 				continue;
 
 			peer_fail_permanent_str(hout->key.peer,
@@ -1464,7 +1464,7 @@ void notify_new_block(struct lightningd *ld, u32 height)
 				continue;
 
 			/* Peer already failed, or we hit it? */
-			if (hin->key.peer->error)
+			if (peer_has_error(hin->key.peer))
 				continue;
 
 			peer_fail_permanent_str(hin->key.peer,


### PR DESCRIPTION
This handles the case where peer->error is sometimes an empty string