### PR TITLE
README.md: Add link to waitanyinvoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ JSON-RPC interface is documented in the following manual pages:
 * [invoice](doc/lightning-invoice.7.txt)
 * [listinvoice](doc/lightning-listinvoice.7.txt)
 * [waitinvoice](doc/lightning-waitinvoice.7.txt)
+* [waitanyinvoice](doc/lightning-waitanyinvoice.7.txt)
 * [delinvoice](doc/lightning-delinvoice.7.txt)
 * [getroute](doc/lightning-getroute.7.txt)
 * [sendpay](doc/lightning-sendpay.7.txt)


### PR DESCRIPTION
Fixes: #439 

("fixes" in the sense that the issue requests a feature we already seem to have, and the likely reason, why the feature is requested is because the feature doc, while already documented in the meager documentation we have, is not linked to from the README.md file)