### PR TITLE
Implement correct ordering of waitanyinvoice

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -334,6 +334,10 @@ class LightningDTests(BaseLightningDTests):
         assert b11['expiry'] == 3600
         assert b11['payee'] == l1.info['id']
 
+        # Check pay_index is null
+        outputs = l1.db_query('SELECT pay_index IS NULL AS q FROM invoices WHERE label="label";')
+        assert len(outputs) == 1 and outputs[0]['q'] != 0
+
     def test_invoice_expiry(self):
         l1,l2 = self.connect()
 
@@ -718,6 +722,10 @@ class LightningDTests(BaseLightningDTests):
         inv = l2.rpc.invoice(123000, 'test_pay', 'description')['bolt11']
         l1.rpc.pay(inv);
         assert l2.rpc.listinvoice('test_pay')[0]['complete'] == True
+
+        # Check pay_index is not null
+        outputs = l2.db_query('SELECT pay_index IS NOT NULL AS q FROM invoices WHERE label="label";')
+        assert len(outputs) == 1 and outputs[0]['q'] != 0
 
     def test_bad_opening(self):
         # l1 asks for a too-long locktime

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -135,6 +135,16 @@ char *dbmigrations[] = {
     /* Add expiry field to invoices (effectively infinite). */
     "ALTER TABLE invoices ADD expiry_time INTEGER;",
     "UPDATE invoices SET expiry_time=9223372036854775807;",
+    /* Add pay_index field to paid invoices (initially, same order as id). */
+    "ALTER TABLE invoices ADD pay_index INTEGER;",
+    "CREATE UNIQUE INDEX invoices_pay_index"
+    "  ON invoices(pay_index);",
+    "UPDATE invoices SET pay_index=id WHERE state=1;", /* only paid invoice */
+    /* Create next_pay_index variable (highest pay_index). */
+    "INSERT OR REPLACE INTO vars(name, val)"
+    "  VALUES('next_pay_index', "
+    "    COALESCE((SELECT MAX(pay_index) FROM invoices WHERE state=1), 0) + 1"
+    "  );",
     NULL,
 };
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1125,6 +1125,65 @@ bool wallet_htlcs_reconnect(struct wallet *wallet,
 	return true;
 }
 
+int wallet_invoice_nextpaid(const tal_t *cxt,
+			    const struct wallet *wallet,
+			    const char *labelz,
+			    char **outlabel,
+			    struct sha256 *outrhash,
+			    u64 *outmsatoshi)
+{
+	sqlite3_stmt *stmt;
+	int res;
+	u64 pay_index;
+
+	/* Generate query. */
+	if (labelz) {
+		/* Find label. */
+		stmt = db_prepare(wallet->db,
+				"SELECT pay_index FROM invoices WHERE label=?;");
+		sqlite3_bind_text(stmt, 1, labelz, strlen(labelz), SQLITE_TRANSIENT);
+		res = sqlite3_step(stmt);
+		if (res != SQLITE_ROW) {
+			sqlite3_finalize(stmt);
+			return -1;
+		}
+		pay_index = sqlite3_column_int64(stmt, 0);
+		sqlite3_finalize(stmt);
+
+		stmt = db_prepare(wallet->db,
+				"SELECT label, payment_hash, msatoshi FROM invoices"
+				" WHERE pay_index NOT NULL"
+				"   AND pay_index > ?"
+				" ORDER BY pay_index ASC LIMIT 1;");
+		sqlite3_bind_int64(stmt, 1, pay_index);
+	} else {
+		stmt = db_prepare(wallet->db,
+				"SELECT label, payment_hash, msatoshi FROM invoices"
+				" WHERE pay_index NOT NULL"
+				" ORDER BY pay_index ASC LIMIT 1;");
+	}
+
+	res = sqlite3_step(stmt);
+	if (res != SQLITE_ROW) {
+		/* No paid invoice found. */
+		sqlite3_finalize(stmt);
+		return 0;
+	} else {
+		/* Paid invoice found, return data. */
+		*outlabel = tal_strndup(cxt, sqlite3_column_blob(stmt, 0), sqlite3_column_bytes(stmt, 0));
+
+		assert(sqlite3_column_bytes(stmt, 1) == sizeof(struct sha256));
+		memcpy(outrhash, sqlite3_column_blob(stmt, 1), sqlite3_column_bytes(stmt, 1));
+
+		*outmsatoshi = sqlite3_column_int64(stmt, 2);
+
+		sqlite3_finalize(stmt);
+		return 1;
+	}
+
+	return -1;
+}
+
 /* Acquire the next pay_index. */
 static s64 wallet_invoice_next_pay_index(struct db *db)
 {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -331,6 +331,32 @@ bool wallet_htlcs_reconnect(struct wallet *wallet,
 			    struct htlc_out_map *htlcs_out);
 
 /**
+ * wallet_invoice_nextpaid -- Find a paid invoice.
+ *
+ * Get the details (label, rhash, msatoshi) of the next paid
+ * invoice after the invoice with the given label. If label is
+ * `NULL`, get the details of the first paid invoice. Return -1
+ * if label is non-`NULL` and is not found, 0 if no more paid
+ * invoices after specified invoice (or no paid invoices if label
+ * is `NULL`), 1 if the next paid invoice was found.
+ *
+ * @ctx: Context to create the returned label.
+ * @wallet: Wallet to query
+ * @labelz: The label to be queried (zero-terminated), or
+ * `NULL` if first invoice is to be queried.
+ * @outlabel: Pointer to label of found paid invoice. Caller
+ * must free if this function returns 1.
+ * @outrhash: Pointer to struct rhash to be filled.
+ * @outmsatoshi: Pointer to number of millisatoshis value to pay.
+ */
+int wallet_invoice_nextpaid(const tal_t *cxt,
+			    const struct wallet *wallet,
+			    const char *labelz,
+			    char **outlabel,
+			    struct sha256 *outrhash,
+			    u64 *outmsatoshi);
+
+/**
  * wallet_invoice_save -- Save/update an invoice to the wallet
  *
  * Save or update the invoice in the wallet. If `inv->id` is 0 this


### PR DESCRIPTION
Fixes: #442 

Eventually, anyway.  At this point, only a (failing) test is in this pull request.

The issue is the below:

1.  Make invoices A and B, in that order (make invoice A first, before making invoice B)
2.  Pay invoice B.
3.  Wait any invoice (no argument) -> return B (correct)
4.  Pay invoice A.
4.  Wait any invoice (argument: B) -> expect return A immediately, but blocks instead

Note that the documentation of `waitanyinvoice` indicates that it traverses in order of payment.  However currently the actual implementation traverses in order of invoice creation.  This is not reliable as it is external actors who will pay, and they may take random amounts of time to actually perform the payment.