### PR TITLE
Correctly implement waitinvoice

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -86,6 +86,10 @@ static void tell_waiter(struct command *cmd, const struct invoice *paid)
 	json_object_end(response);
 	command_success(cmd, response);
 }
+static void tell_waiter_deleted(struct command *cmd, const struct invoice *paid)
+{
+	command_fail(cmd, "invoice deleted during wait");
+}
 
 void resolve_invoice(struct lightningd *ld, struct invoice *invoice)
 {
@@ -94,8 +98,13 @@ void resolve_invoice(struct lightningd *ld, struct invoice *invoice)
 
 	invoice->state = PAID;
 
-	/* Tell all the waiters about the new paid invoice */
+	/* Tell all the waitanyinvoice waiters about the new paid invoice */
 	while ((w = list_pop(&invs->invoice_waiters,
+			     struct invoice_waiter,
+			     list)) != NULL)
+		tell_waiter(w->cmd, invoice);
+	/* Tell any waitinvoice waiters about the invoice getting paid. */
+	while ((w = list_pop(&invoice->invoice_waiters,
 			     struct invoice_waiter,
 			     list)) != NULL)
 		tell_waiter(w->cmd, invoice);
@@ -131,10 +140,20 @@ static char *delete_invoice(const tal_t *cxt,
 			    struct invoices *invs,
 			    struct invoice *i)
 {
+	struct invoice_waiter *w;
 	if (!wallet_invoice_remove(wallet, i)) {
 		return tal_strdup(cxt, "Database error");
 	}
 	list_del_from(&invs->invlist, &i->list);
+
+	/* Tell all the waiters about the fact that it was deleted. */
+	while ((w = list_pop(&i->invoice_waiters,
+			     struct invoice_waiter,
+			     list)) != NULL) {
+		tell_waiter_deleted(w->cmd, i);
+		/* No need to free w: w is a sub-object of cmd,
+		 * and tell_waiter_deleted also deletes the cmd. */
+	}
 
 	tal_free(i);
 	return NULL;
@@ -165,6 +184,7 @@ static void json_invoice(struct command *cmd,
 	invoice = tal(cmd, struct invoice);
 	invoice->id = 0;
 	invoice->state = UNPAID;
+	list_head_init(&invoice->invoice_waiters);
 	randombytes_buf(invoice->r.r, sizeof(invoice->r.r));
 
 	sha256(&invoice->rhash, invoice->r.r, sizeof(invoice->r.r));
@@ -459,7 +479,7 @@ static void json_waitinvoice(struct command *cmd,
 		/* There is an unpaid one matching, let's wait... */
 		w = tal(cmd, struct invoice_waiter);
 		w->cmd = cmd;
-		list_add_tail(&invs->invoice_waiters, &w->list);
+		list_add_tail(&i->invoice_waiters, &w->list);
 		command_still_pending(cmd);
 	}
 }

--- a/lightningd/invoice.h
+++ b/lightningd/invoice.h
@@ -25,6 +25,7 @@ struct invoice {
 	struct preimage r;
 	u64 expiry_time;
 	struct sha256 rhash;
+	struct list_head invoice_waiters;
 };
 
 #define INVOICE_MAX_LABEL_LEN 128

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2339,6 +2339,35 @@ class LightningDTests(BaseLightningDTests):
         assert not l2.daemon.is_in_log('signature verification failed')
         assert not l3.daemon.is_in_log('signature verification failed')
 
+    def test_waitinvoice(self):
+        """Test waiting for one invoice will not return if another invoice
+        is paid.
+        """
+        # Setup
+        l1, l2 = self.connect()
+        self.fund_channel(l1, l2, 10**6)
+        l1.bitcoin.generate_block(6)
+        l1.daemon.wait_for_log('Received node_announcement for node {}'.format(l2.info['id']))
+
+        # Create invoices
+        inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1')
+        inv2 = l2.rpc.invoice(1000, 'inv2', 'inv2')
+
+        # Start waiting on invoice 1, should block
+        f = self.executor.submit(l2.rpc.waitinvoice, 'inv1')
+        time.sleep(1)
+        assert not f.done()
+        # Pay invoice 2
+        l1.rpc.pay(inv2['bolt11'])
+        # Waiter should stil be blocked
+        time.sleep(1)
+        assert not f.done()
+        # Pay invoice 1
+        l1.rpc.pay(inv1['bolt11'])
+        # Waiter should now finish
+        r = f.result(timeout=5)
+        assert r['label'] == 'inv1'
+
     def test_waitanyinvoice(self):
         """Test various variants of waiting for the next invoice to complete.
         """

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1168,6 +1168,8 @@ static bool wallet_stmt2invoice(sqlite3_stmt *stmt, struct invoice *inv)
 	inv->label = tal_strndup(inv, sqlite3_column_blob(stmt, 4), sqlite3_column_bytes(stmt, 4));
 	inv->msatoshi = sqlite3_column_int64(stmt, 5);
 	inv->expiry_time = sqlite3_column_int64(stmt, 6);
+
+	list_head_init(&inv->invoice_waiters);
 	return true;
 }
 


### PR DESCRIPTION
Fixes: #444 

Eventually, anyway.  As of this time, this pull request only includes a failing test.  When completed it will include the solution also.

The issue is the below:

1.  Make invoice A and B.
2.  Wait invoice A, should block
3. Pay B -> the "Wait invoice A" returns at this point (it should not)
4.  Pay A -> the "Wait invoice A" should return at this point (not earlier)

