### PR TITLE
Let channeld add the outgoing channel as soon as funding locked on both sides

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1539,6 +1539,7 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master
 	case WIRE_GOSSIP_GETPEERS_REQUEST:
 		return get_peers(conn, daemon, master->msg_in);
 
+	/* We send these, we don't receive them */
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLYFAIL:
 	case WIRE_GOSSIP_GETNODES_REPLY:
@@ -1552,7 +1553,8 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master
 	case WIRE_GOSSIP_GET_UPDATE:
 	case WIRE_GOSSIP_GET_UPDATE_REPLY:
 	case WIRE_GOSSIP_SEND_GOSSIP:
-	break;
+	case WIRE_GOSSIP_LOCAL_ADD_CHANNEL:
+		break;
 	}
 
 	/* Master shouldn't give bad requests. */

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -144,3 +144,16 @@ gossip_send_gossip,3016
 gossip_send_gossip,,gossip_index,u64
 gossip_send_gossip,,len,u16
 gossip_send_gossip,,gossip,len*u8
+
+# Both sides have seen the funding tx being locked, but we have not
+# yet reached the announcement depth. So we add the channel locally so
+# we can use it already.
+gossip_local_add_channel,3017
+gossip_local_add_channel,,short_channel_id,struct short_channel_id
+gossip_local_add_channel,,chain_hash,struct sha256_double
+gossip_local_add_channel,,remote_node_id,struct pubkey
+gossip_local_add_channel,,flags,u16
+gossip_local_add_channel,,cltv_expiry_delta,u16
+gossip_local_add_channel,,htlc_minimum_msat,u64
+gossip_local_add_channel,,fee_base_msat,u32
+gossip_local_add_channel,,fee_proportional_millionths,u32

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -83,6 +83,10 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLY:
 	case WIRE_GOSSIPCTL_RELEASE_PEER_REPLYFAIL:
 		break;
+	/* These are inter-daemon messages, not received by us */
+	case WIRE_GOSSIP_LOCAL_ADD_CHANNEL:
+		break;
+
 	case WIRE_GOSSIP_PEER_CONNECTED:
 		if (tal_count(fds) != 2)
 			return 2;


### PR DESCRIPTION
This is an alternative to #414. The main difference is that instead of having unsigned `channel_announcement` and `channel_update` messages that are allowed through if they are local, we add a new message that `channeld` can send to `gossipd` when both sides lock. This message now contains only the necessary information for the outgoing direction, and will immediately activate the channel so we can use it.

Fixes #284 
Depends on #413 (only the last 4 commits are for this PR, all others are from #413)