### PR TITLE
Don't think payment in progress if it fails locally.

### DIFF
--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -61,6 +61,7 @@ CHANNELD_COMMON_OBJS :=				\
 	common/utils.o				\
 	common/utxo.o				\
 	common/version.o			\
+	common/wire_error.o			\
 	common/wireaddr.o			\
 	gossipd/gen_gossip_wire.o		\
 	lightningd/gossip_msg.o			\

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -41,6 +41,7 @@
 #include <common/timeout.h>
 #include <common/type_to_string.h>
 #include <common/version.h>
+#include <common/wire_error.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <gossipd/gen_gossip_wire.h>
@@ -1469,8 +1470,14 @@ static void peer_in(struct peer *peer, const u8 *msg)
 		handle_peer_shutdown(peer, msg);
 		return;
 
-	case WIRE_INIT:
 	case WIRE_ERROR:
+		peer_failed(PEER_FD,
+			    &peer->cs,
+			    &peer->channel_id,
+			    "Peer sent error %s",
+			    sanitize_error(peer, msg, NULL));
+
+	case WIRE_INIT:
 	case WIRE_OPEN_CHANNEL:
 	case WIRE_ACCEPT_CHANNEL:
 	case WIRE_FUNDING_CREATED:

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -252,6 +252,7 @@ static void send_payment(struct command *cmd,
 	pc->ids = tal_steal(pc, ids);
 	pc->msatoshi = route[n_hops-1].amount;
 	pc->path_secrets = tal_steal(pc, path_secrets);
+	pc->out = NULL;
 
 	log_info(cmd->ld->log, "Sending %u over %zu hops to deliver %"PRIu64,
 		 route[0].amount, n_hops, pc->msatoshi);

--- a/wire/gen_onion_wire_csv
+++ b/wire/gen_onion_wire_csv
@@ -30,8 +30,6 @@ incorrect_cltv_expiry,6,channel_update,len
 expiry_too_soon,UPDATE|14
 expiry_too_soon,0,len,2
 expiry_too_soon,2,channel_update,len
-expiry_too_far,21
-channel_disabled,UPDATE|20
 unknown_payment_hash,PERM|15
 incorrect_payment_amount,PERM|16
 final_expiry_too_soon,17
@@ -39,3 +37,5 @@ final_incorrect_cltv_expiry,18
 final_incorrect_cltv_expiry,0,cltv_expiry,4
 final_incorrect_htlc_amount,19
 final_incorrect_htlc_amount,0,incoming_htlc_amt,4
+channel_disabled,UPDATE|20
+expiry_too_far,21


### PR DESCRIPTION
Also make logs more effective by printing error when we get one in channeld.