### PR TITLE
Fix three causes of test fails.

### DIFF
--- a/gossipd/broadcast.c
+++ b/gossipd/broadcast.c
@@ -1,3 +1,4 @@
+#include <ccan/mem/mem.h>
 #include <gossipd/broadcast.h>
 
 struct broadcast_state *new_broadcast_state(tal_t *ctx)
@@ -21,28 +22,48 @@ static struct queued_message *new_queued_message(tal_t *ctx,
 	return msg;
 }
 
+/* Returns 0 for not-found */
+static u64 find_broadcast(const struct broadcast_state *bstate,
+			  const int type, const u8 *tag)
+{
+	struct queued_message *msg;
+	u64 index;
+
+	/* FIXME: Use a hash */
+	for (msg = uintmap_first(&bstate->broadcasts, &index);
+	     msg;
+	     msg = uintmap_after(&bstate->broadcasts, &index)) {
+		if (msg->type == type
+		    && memeq(msg->tag, tal_len(msg->tag), tag, tal_len(tag)))
+			return index;
+	}
+	return 0;
+}
+
 void queue_broadcast(struct broadcast_state *bstate,
 		     const int type,
 		     const u8 *tag,
-		     const u8 *payload)
+		     const u8 *payload,
+		     bool replace_inplace)
 {
 	struct queued_message *msg;
 	u64 index;
 
 	/* Remove any tag&type collisions */
-	for (msg = uintmap_first(&bstate->broadcasts, &index);
-	     msg;
-	     msg = uintmap_after(&bstate->broadcasts, &index)) {
-		if (msg->type == type && memcmp(msg->tag, tag, tal_count(tag)) == 0) {
-			uintmap_del(&bstate->broadcasts, index);
-			tal_free(msg);
-		}
-	}
+	index = find_broadcast(bstate, type, tag);
+	if (index == 0)
+		replace_inplace = false;
+	else
+		tal_free(uintmap_del(&bstate->broadcasts, index));
 
 	/* Now add the message to the queue */
 	msg = new_queued_message(bstate, type, tag, payload);
-	uintmap_add(&bstate->broadcasts, bstate->next_index, msg);
-	bstate->next_index += 1;
+	if (replace_inplace) {
+		uintmap_add(&bstate->broadcasts, index, msg);
+	} else {
+		uintmap_add(&bstate->broadcasts, bstate->next_index, msg);
+		bstate->next_index += 1;
+	}
 }
 
 struct queued_message *next_broadcast_message(struct broadcast_state *bstate, u64 last_index)

--- a/gossipd/broadcast.h
+++ b/gossipd/broadcast.h
@@ -29,11 +29,13 @@ struct broadcast_state *new_broadcast_state(tal_t *ctx);
 /* Queue a new message to be broadcast and replace any outdated
  * broadcast. Replacement is done by comparing the `type` and the
  * `tag`, if both match the old message is dropped from the queue. The
- * new message is added to the top of the broadcast queue. */
+ * new message is added to the top of the broadcast queue, unless
+ * replace_inplace is set, in which case it replaces the old (if any) */
 void queue_broadcast(struct broadcast_state *bstate,
 			     const int type,
 			     const u8 *tag,
-			     const u8 *payload);
+			     const u8 *payload,
+			     bool replace_inplace);
 
 struct queued_message *next_broadcast_message(struct broadcast_state *bstate, u64 last_index);
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -565,6 +565,9 @@ bool handle_channel_announcement(
 	c1 = get_connection_by_scid(rstate, &short_channel_id, 1);
 	forward = !c0 || !c1 || !c0->channel_announcement || !c1->channel_announcement;
 
+	/* FIXME: What should we do if this channel_announce is completely
+	 * different from previous?  eg. different nodes?  We would have to
+	 * clear out the old announce and all updates... */
 	add_channel_direction(rstate, &node_id_1, &node_id_2, &short_channel_id,
 			      sigfail ? NULL : serialized);
 	add_channel_direction(rstate, &node_id_2, &node_id_1, &short_channel_id,
@@ -581,7 +584,7 @@ bool handle_channel_announcement(
 	u8 *tag = tal_arr(tmpctx, u8, 0);
 	towire_short_channel_id(&tag, &short_channel_id);
 	queue_broadcast(rstate->broadcasts, WIRE_CHANNEL_ANNOUNCEMENT,
-			tag, serialized);
+			tag, serialized, true);
 
 	tal_free(tmpctx);
 	return local;
@@ -677,7 +680,7 @@ void handle_channel_update(struct routing_state *rstate, const u8 *update)
 	queue_broadcast(rstate->broadcasts,
 			WIRE_CHANNEL_UPDATE,
 			tag,
-			serialized);
+			serialized, false);
 
 	tal_free(c->channel_update);
 	c->channel_update = tal_steal(c, serialized);
@@ -783,7 +786,8 @@ void handle_node_announcement(
 	queue_broadcast(rstate->broadcasts,
 			WIRE_NODE_ANNOUNCEMENT,
 			tag,
-			serialized);
+			serialized,
+			false);
 	tal_free(node->node_announcement);
 	node->node_announcement = tal_steal(node, serialized);
 	tal_free(tmpctx);

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -67,7 +67,8 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED)
+			     const u8 *payload UNNEEDED,
+			     bool replace_inplace UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -38,7 +38,8 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED)
+			     const u8 *payload UNNEEDED,
+			     bool replace_inplace UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -31,7 +31,8 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED)
+			     const u8 *payload UNNEEDED,
+			     bool replace_inplace UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -149,6 +149,7 @@ struct htlc_out *new_htlc_out(const tal_t *ctx,
 	hout->dbid = 0;
 
 	hout->key.peer = peer;
+	hout->key.id = HTLC_INVALID_ID;
 	hout->msatoshi = msatoshi;
 	hout->cltv_expiry = cltv_expiry;
 	hout->payment_hash = *payment_hash;

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -13,6 +13,8 @@ struct htlc_key {
 	u64 id;
 };
 
+#define HTLC_INVALID_ID (-1ULL)
+
 /* Incoming HTLC */
 struct htlc_in {
 	/* The database primary key for this htlc. Must be 0 until it

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -351,7 +351,8 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds,
 		return;
 	}
 
-	if (find_htlc_out(&subd->ld->htlcs_out, hout->key.peer, hout->key.id)) {
+	if (find_htlc_out(&subd->ld->htlcs_out, hout->key.peer, hout->key.id)
+	    || hout->key.id == HTLC_INVALID_ID) {
 		peer_internal_error(subd->peer,
 				    "Bad offer_htlc_reply HTLC id %"PRIu64
 				    " is a duplicate",


### PR DESCRIPTION
I noted a spurious failure on test_reconnect_sender_add1: we
actually sent an update_commit, which should have been suppressed.

Additionally, we have a gossip reorder issue, which I've fixed in the simplest way I can.

Finally, a destructor was printing out an uninitialized field in some cases.