### PR TITLE
Fix the channel announcement and update order error

### DIFF
--- a/common/status.h
+++ b/common/status.h
@@ -54,7 +54,7 @@ void status_trace(const char *fmt, ...) PRINTF_FMT(1,2);
 /* vprintf-style */
 void status_tracev(const char *fmt, va_list ap);
 /* Send a failure status code with printf-style msg, and exit. */
-void status_failed(enum status_fail, const char *fmt, ...) PRINTF_FMT(2,3) NORETURN;
+void status_failed(enum status_fail code, const char *fmt, ...) PRINTF_FMT(2,3) NORETURN;
 
 /* Helper for master failures: sends STATUS_FAIL_MASTER_IO.
  * msg NULL == read failure. */

--- a/gossipd/broadcast.h
+++ b/gossipd/broadcast.h
@@ -29,13 +29,11 @@ struct broadcast_state *new_broadcast_state(tal_t *ctx);
 /* Queue a new message to be broadcast and replace any outdated
  * broadcast. Replacement is done by comparing the `type` and the
  * `tag`, if both match the old message is dropped from the queue. The
- * new message is added to the top of the broadcast queue, unless
- * replace_inplace is set, in which case it replaces the old (if any) */
+ * new message is added to the top of the broadcast queue. */
 void queue_broadcast(struct broadcast_state *bstate,
 			     const int type,
 			     const u8 *tag,
-			     const u8 *payload,
-			     bool replace_inplace);
+			     const u8 *payload);
 
 struct queued_message *next_broadcast_message(struct broadcast_state *bstate, u64 last_index);
 

--- a/gossipd/broadcast.h
+++ b/gossipd/broadcast.h
@@ -29,8 +29,9 @@ struct broadcast_state *new_broadcast_state(tal_t *ctx);
 /* Queue a new message to be broadcast and replace any outdated
  * broadcast. Replacement is done by comparing the `type` and the
  * `tag`, if both match the old message is dropped from the queue. The
- * new message is added to the top of the broadcast queue. */
-void queue_broadcast(struct broadcast_state *bstate,
+ * new message is added to the top of the broadcast queue. Returns
+ * true if a previous entry with the same tag has been evicted. */
+bool queue_broadcast(struct broadcast_state *bstate,
 			     const int type,
 			     const u8 *tag,
 			     const u8 *payload);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -583,8 +583,12 @@ bool handle_channel_announcement(
 			      serialized);
 
 	if (forward) {
-		assert(!queue_broadcast(rstate->broadcasts, WIRE_CHANNEL_ANNOUNCEMENT,
-					(u8*)tag, serialized));
+		if (queue_broadcast(rstate->broadcasts,
+				    WIRE_CHANNEL_ANNOUNCEMENT,
+				    (u8*)tag, serialized))
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "Announcemnet %s was replaced?",
+				      tal_hex(trc, serialized));
 	}
 
 	tal_free(tmpctx);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -580,8 +580,8 @@ bool handle_channel_announcement(
 
 	u8 *tag = tal_arr(tmpctx, u8, 0);
 	towire_short_channel_id(&tag, &short_channel_id);
-	queue_broadcast(rstate->broadcasts, WIRE_CHANNEL_ANNOUNCEMENT,
-			tag, serialized);
+	assert(!queue_broadcast(rstate->broadcasts, WIRE_CHANNEL_ANNOUNCEMENT,
+				tag, serialized));
 
 	tal_free(tmpctx);
 	return local;

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -565,9 +565,6 @@ bool handle_channel_announcement(
 	c1 = get_connection_by_scid(rstate, &short_channel_id, 1);
 	forward = !c0 || !c1 || !c0->channel_announcement || !c1->channel_announcement;
 
-	/* FIXME: What should we do if this channel_announce is completely
-	 * different from previous?  eg. different nodes?  We would have to
-	 * clear out the old announce and all updates... */
 	add_channel_direction(rstate, &node_id_1, &node_id_2, &short_channel_id,
 			      sigfail ? NULL : serialized);
 	add_channel_direction(rstate, &node_id_2, &node_id_1, &short_channel_id,
@@ -584,7 +581,7 @@ bool handle_channel_announcement(
 	u8 *tag = tal_arr(tmpctx, u8, 0);
 	towire_short_channel_id(&tag, &short_channel_id);
 	queue_broadcast(rstate->broadcasts, WIRE_CHANNEL_ANNOUNCEMENT,
-			tag, serialized, true);
+			tag, serialized);
 
 	tal_free(tmpctx);
 	return local;
@@ -680,7 +677,7 @@ void handle_channel_update(struct routing_state *rstate, const u8 *update)
 	queue_broadcast(rstate->broadcasts,
 			WIRE_CHANNEL_UPDATE,
 			tag,
-			serialized, false);
+			serialized);
 
 	tal_free(c->channel_update);
 	c->channel_update = tal_steal(c, serialized);
@@ -786,8 +783,7 @@ void handle_node_announcement(
 	queue_broadcast(rstate->broadcasts,
 			WIRE_NODE_ANNOUNCEMENT,
 			tag,
-			serialized,
-			false);
+			serialized);
 	tal_free(node->node_announcement);
 	node->node_announcement = tal_steal(node, serialized);
 	tal_free(tmpctx);

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -67,8 +67,7 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED,
-			     bool replace_inplace UNNEEDED)
+			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -69,6 +69,9 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for status_failed */
+void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
+{ fprintf(stderr, "status_failed called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)
 { fprintf(stderr, "towire_pubkey called!\n"); abort(); }

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -64,7 +64,7 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
-void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
+bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -38,8 +38,7 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED,
-			     bool replace_inplace UNNEEDED)
+			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -35,7 +35,7 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
-void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
+bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -40,6 +40,9 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for status_failed */
+void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
+{ fprintf(stderr, "status_failed called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)
 { fprintf(stderr, "towire_pubkey called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -33,6 +33,9 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for status_failed */
+void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
+{ fprintf(stderr, "status_failed called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)
 { fprintf(stderr, "towire_pubkey called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -31,8 +31,7 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
-			     const u8 *payload UNNEEDED,
-			     bool replace_inplace UNNEEDED)
+			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
 /* Generated stub for towire_pubkey */
 void towire_pubkey(u8 **pptr UNNEEDED, const struct pubkey *pubkey UNNEEDED)

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -28,7 +28,7 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
-void queue_broadcast(struct broadcast_state *bstate UNNEEDED,
+bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)


### PR DESCRIPTION
The error is caused by us incorrectly tracking the announcement state of a channel, and concluding that all channel_announcement were new announcements if the channel had already been added via side-loading, e.g., adding a local channel. It was flaky because only `valgrind` would give us enough time to actually observe this incorrect ordering.

I decided against the belt-and-suspenders solution of keeping in-place replacements and doing the check here, because the in-place replacement added more complexity and wasn't used at all anymore, hence the revert in the first commit. The eviction check when adding a new channel_announcement will make sure we don't accidentally replace an existing announcement so we'll catch this earlier in future.