### PR TITLE
Use the bitcoind config file to discover auth params in pytest

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1876,7 +1876,7 @@ class LightningDTests(BaseLightningDTests):
         # Just to be sure, second openingd hand over to channeld.
         l2.daemon.wait_for_log('lightning_openingd.*REPLY WIRE_OPENING_FUNDEE_REPLY with 2 fds')
 
-    @unittest.skipIf(os.getenv("ARCH", "64") == "32" , "temporarily disabled due to flaky behavior, issue #468")
+    @unittest.skip("temporarily disabled due to flaky behavior, issue #468")
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_reconnect_normal(self):
         # Should reconnect fine even if locked message gets lost.

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1876,6 +1876,7 @@ class LightningDTests(BaseLightningDTests):
         # Just to be sure, second openingd hand over to channeld.
         l2.daemon.wait_for_log('lightning_openingd.*REPLY WIRE_OPENING_FUNDEE_REPLY with 2 fds')
 
+    @unittest.skipIf(os.getenv("ARCH", "64") == "32" , "temporarily disabled due to flaky behavior, issue #468")
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_reconnect_normal(self):
         # Should reconnect fine even if locked message gets lost.


### PR DESCRIPTION
With the upgrade to python-bitcoinlib==0.9.0 we seemingly lost the ability to specify the auth params in the service URL, so this just rips the service URL out and passes in the bitcoind config file. The RPC lib then goes and parses it. Rather annoying that it won't merge the two or allow specifying the RPC auth params in the constructor though.

Also temporarily disables test_reconnect_normal, which has been flaky lately. That status is tracked in #468 

Fixes #469 