### PR TITLE
Avoid writing uninitialized value data->realm in serialize_hop_data(...) (via create_onionpacket(...))

### DIFF
--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -369,6 +369,7 @@ struct onionpacket *create_onionpacket(
 
 	for (i = num_hops - 1; i >= 0; i--) {
 		memcpy(hops_data[i].hmac, nexthmac, SECURITY_PARAMETER);
+		hops_data[i].realm = 0;
 		generate_key_set(params[i].secret, &keys);
 		generate_cipher_stream(stream, keys.rho, ROUTING_INFO_SIZE);
 


### PR DESCRIPTION
Avoid writing uninitialized value `data->realm` in `serialize_hop_data(...)` (via `create_onionpacket(...)`).