### PR TITLE
peer_control: make hardcoded feerates consistent between json_fund_channel and peer_offer_channel

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2535,7 +2535,7 @@ static void peer_offer_channel(struct lightningd *ld,
 
 	msg = towire_opening_funder(fc, fc->peer->funding_satoshi,
 				    fc->peer->push_msat,
-				    get_feerate(ld->topology, FEERATE_IMMEDIATE),
+				    get_feerate(ld->topology, FEERATE_NORMAL),
 				    max_minimum_depth,
 				    fc->change, fc->change_keyindex,
 				    fc->peer->channel_flags,

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -686,7 +686,7 @@ class LightningDTests(BaseLightningDTests):
         self.assertRaises(ValueError, self.pay, l1, l2, 10**9 + 1)
 
         # This is the fee, which needs to be taken into account for l1.
-        available = 10**9 - 13440
+        available = 10**9 - 6720
         # Reserve is 1%.
         reserve = 10**7
 


### PR DESCRIPTION
Stops some transactions from failing on the other side due to insufficient funds.