### PR TITLE
gossip: Fix a typo in the add_channel_direction logic

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -441,7 +441,7 @@ add_channel_direction(struct routing_state *rstate, const struct pubkey *from,
 		/* We already know the channel by its scid, just
 		 * update the announcement below */
 		c = c2;
-	} else if (c2) {
+	} else if (c1) {
 		/* We found the channel by its endpoints, not by scid,
 		 * so update its scid */
 		memcpy(&c1->short_channel_id, short_channel_id,


### PR DESCRIPTION
As reported here: https://github.com/ElementsProject/lightning/commit/0db821e2cf3b61690cdf898093a7daa139a43607#diff-74b07f2f7fca9b628a3528312b240dd3R444