### PR TITLE
Add missing call to va_end()

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -264,8 +264,10 @@ bool json_get_params(const char *buffer, const jsmntok_t param[], ...)
 		    && buffer[(*tokptr)->start] == 'n') {
 			*tokptr = NULL;
 		}
-		if (compulsory && !*tokptr)
+		if (compulsory && !*tokptr) {
+			va_end(ap);
 			return false;
+		}
 	}
 
 	va_end(ap);


### PR DESCRIPTION
Add missing call to `va_end()`.

Each invocation of `va_start()` must be matched by a corresponding invocation of `va_end()` in the same function.