### PR TITLE
Avoid passing uninitialized value dummy with uninitialized field addrlen to {initiator,responder}_handshake_

### DIFF
--- a/gossipd/test/run-initiator-success.c
+++ b/gossipd/test/run-initiator-success.c
@@ -223,6 +223,7 @@ int main(void)
 	e_priv = privkey("1212121212121212121212121212121212121212121212121212121212121212");
 	e_pub = pubkey("036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7");
 
+	dummy.addrlen = 0;
 	initiator_handshake(ctx, &ls_pub, &rs_pub, &dummy, success, ctx);
 	/* Should not exit! */
 	abort();

--- a/gossipd/test/run-responder-success.c
+++ b/gossipd/test/run-responder-success.c
@@ -219,6 +219,7 @@ int main(void)
 	e_priv = privkey("2222222222222222222222222222222222222222222222222222222222222222");
 	e_pub = pubkey("02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27");
 
+	dummy.addrlen = 0;
 	responder_handshake(ctx, &ls_pub, &dummy, success, ctx);
 	/* Should not exit! */
 	abort();


### PR DESCRIPTION
Avoid passing uninitialized value `dummy` with uninitialized field `addrlen` to `{initiator,responder}_handshake_`.