### PR TITLE
Issue 476

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -639,7 +639,6 @@ static struct io_plan *peer_pkt_out(struct io_conn *conn, struct peer *peer);
 static struct io_plan *local_gossip_broadcast_done(struct io_conn *conn,
 						   struct peer *peer)
 {
-	status_trace("%s", __func__);
 	peer->broadcast_index++;
 	return peer_pkt_out(conn, peer);
 }

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -573,8 +573,8 @@ bool handle_channel_announcement(
 	/* Is this a new connection? It is if we don't know the
 	 * channel yet, or do not have a matching announcement in the
 	 * case of side-loaded channels*/
-	c0 = get_connection_by_scid(rstate, &short_channel_id, 0);
-	c1 = get_connection_by_scid(rstate, &short_channel_id, 1);
+	c0 = get_connection(rstate, &node_id_2, &node_id_1);
+	c1 = get_connection(rstate, &node_id_1, &node_id_2);
 	forward = !c0 || !c1 || !c0->channel_announcement || !c1->channel_announcement;
 
 	add_channel_direction(rstate, &node_id_1, &node_id_2, &short_channel_id,


### PR DESCRIPTION
Looking up by `short_channel_id` could under some circumstances result in the channel not being found and later being marked as replaced. Looking up by the endpoints is much more reliable.

This is just a quick-fix for #476, I'll rework and consolidate the channel-creation paths later, they changed quite a log since they were first introduced and can be simplified (e.g., no more JSON-RPC command to add a channel and similar).