### PR TITLE
assert(tal_count(log) > 0) (previously implicitly assumed) in log_to_json(...)

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -130,6 +130,7 @@ static void log_to_json(unsigned int skipped,
 	json_add_time(info->response, "time", diff.ts);
 	json_add_string(info->response, "source", prefix);
 	if (level == LOG_IO) {
+		assert(tal_count(log) > 0);
 		if (log[0])
 			json_add_string(info->response, "direction", "IN");
 		else


### PR DESCRIPTION
~Avoid potential unsigned integer overflow in `log_to_json(...)`.~
  
`assert(tal_count(log) > 0)` (now implicitly assumed) in `log_to_json(...)`.