### PR TITLE
lightningd: simplify permenant failure.

### DIFF
--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -208,9 +208,7 @@ u8 *get_supported_local_features(const tal_t *ctx);
 /* Peer has failed, but try reconnected. */
 PRINTF_FMT(2,3) void peer_fail_transient(struct peer *peer, const char *fmt,...);
 /* Peer has failed, give up on it. */
-void peer_fail_permanent(struct peer *peer, const u8 *msg TAKES);
-/* Version where we supply the reason string. */
-void peer_fail_permanent_str(struct peer *peer, const char *str TAKES);
+void peer_fail_permanent(struct peer *peer, const char *fmt, ...);
 /* Permanent error, but due to internal problems, not peer. */
 void peer_internal_error(struct peer *peer, const char *fmt, ...);
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1213,12 +1213,11 @@ void peer_got_revoke(struct peer *peer, const u8 *msg)
 	if (!wallet_shachain_add_hash(peer->ld->wallet, &peer->their_shachain,
 				      shachain_index(revokenum),
 				      &per_commitment_secret)) {
-		char *err = tal_fmt(peer,
+		peer_fail_permanent(peer,
 				    "Bad per_commitment_secret %s for %"PRIu64,
 				    type_to_string(msg, struct sha256,
 						   &per_commitment_secret),
 				    revokenum);
-		peer_fail_permanent(peer, take((u8 *)err));
 		return;
 	}
 
@@ -1429,13 +1428,12 @@ void notify_new_block(struct lightningd *ld, u32 height)
 			if (hout->key.peer->error)
 				continue;
 
-			peer_fail_permanent_str(hout->key.peer,
-						take(tal_fmt(hout,
-						     "Offered HTLC %"PRIu64
-						     " %s cltv %u hit deadline",
-						     hout->key.id,
-						     htlc_state_name(hout->hstate),
-						     hout->cltv_expiry)));
+			peer_fail_permanent(hout->key.peer,
+					    "Offered HTLC %"PRIu64
+					    " %s cltv %u hit deadline",
+					    hout->key.id,
+					    htlc_state_name(hout->hstate),
+					    hout->cltv_expiry);
 			removed = true;
 		}
 	/* Iteration while removing is safe, but can skip entries! */
@@ -1474,13 +1472,12 @@ void notify_new_block(struct lightningd *ld, u32 height)
 			if (hin->key.peer->error)
 				continue;
 
-			peer_fail_permanent_str(hin->key.peer,
-						take(tal_fmt(hin,
-						     "Fulfilled HTLC %"PRIu64
-						     " %s cltv %u hit deadline",
-						     hin->key.id,
-						     htlc_state_name(hin->hstate),
-						     hin->cltv_expiry)));
+			peer_fail_permanent(hin->key.peer,
+					    "Fulfilled HTLC %"PRIu64
+					    " %s cltv %u hit deadline",
+					    hin->key.id,
+					    htlc_state_name(hin->hstate),
+					    hin->cltv_expiry);
 			removed = true;
 		}
 	/* Iteration while removing is safe, but can skip entries! */

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -459,10 +459,7 @@ static struct io_plan *sd_msg_read(struct io_conn *conn, struct subd *sd)
 			struct peer *peer = sd->peer;
 			sd->peer = NULL;
 
-			peer_fail_permanent(peer,
-					    take(tal_dup_arr(peer, u8,
-							     (u8 *)str, str_len,
-							     0)));
+			peer_fail_permanent(peer, "%s: %.*s", sd->name, str_len, str);
 		}
 		goto close;
 	}


### PR DESCRIPTION
Turns out everyone wanted a formatted string anyway.

Inspired-by: @practicalswift 