### PR TITLE
Remember and spend unilateral close outputs

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -383,10 +383,9 @@ static void pull_witness(struct bitcoin_tx_input *inputs, size_t i,
 	}
 }
 
-struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx,
-				   const u8 **cursor, size_t *max)
+struct bitcoin_tx *pull_bitcoin_tx_onto(const tal_t *ctx, const u8 **cursor,
+					size_t *max, struct bitcoin_tx *tx)
 {
-	struct bitcoin_tx *tx = tal(ctx, struct bitcoin_tx);
 	size_t i;
 	u64 count;
 	u8 flag = 0;
@@ -423,6 +422,13 @@ struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx,
 	if (!*cursor)
 		tx = tal_free(tx);
 	return tx;
+}
+
+struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx,
+				   const u8 **cursor, size_t *max)
+{
+	struct bitcoin_tx *tx = tal(ctx, struct bitcoin_tx);
+	return pull_bitcoin_tx_onto(ctx, cursor, max, tx);
 }
 
 struct bitcoin_tx *bitcoin_tx_from_hex(const tal_t *ctx, const char *hex,

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -71,4 +71,18 @@ bool bitcoin_txid_to_hex(const struct bitcoin_txid *txid,
 struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx,
 				   const u8 **cursor, size_t *max);
 
+/**
+ * pull_bitcoin_tx_onto - De-serialize a bitcoin tx into tx
+ *
+ * Like pull_bitcoin_tx, but skips the allocation of tx. Used by the
+ * wire implementation where the caller allocates, and the callee only
+ * fills in values.
+ *
+ * @ctx: Allocation context
+ * @cursor: buffer to read from
+ * @max: Buffer size left to read
+ * @tx (out): Destination transaction
+ */
+struct bitcoin_tx *pull_bitcoin_tx_onto(const tal_t *ctx, const u8 **cursor,
+					size_t *max, struct bitcoin_tx *tx);
 #endif /* LIGHTNING_BITCOIN_TX_H */

--- a/common/htlc_wire.c
+++ b/common/htlc_wire.c
@@ -60,14 +60,6 @@ void towire_shachain(u8 **pptr, const struct shachain *shachain)
 	}
 }
 
-void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx)
-{
-	u8 *txlin = linearize_tx(NULL, tx);
-
-	towire(pptr, txlin, tal_len(txlin));
-	tal_free(txlin);
-}
-
 void fromwire_added_htlc(const u8 **cursor, size_t *max,
 			 struct added_htlc *added)
 {
@@ -139,18 +131,5 @@ void fromwire_shachain(const u8 **cursor, size_t *max,
 	for (i = 0; i < shachain->num_valid; i++) {
 		shachain->known[i].index = fromwire_u64(cursor, max);
 		fromwire_sha256(cursor, max, &shachain->known[i].hash);
-	}
-}
-
-void fromwire_bitcoin_tx(const u8 **cursor, size_t *max, struct bitcoin_tx *tx)
-{
-	/* FIXME: We'd really expect to allocate tx ourselves, but
-	 * for the sake of simple structures, we don't write the
-	 * generator that way. */
-	struct bitcoin_tx *tx2 = pull_bitcoin_tx(tx, cursor, max);
-	if (tx2) {
-		*tx = *tx2;
-		/* This hangs around with tx until freed */
-		notleak(tx2);
 	}
 }

--- a/common/htlc_wire.h
+++ b/common/htlc_wire.h
@@ -42,7 +42,6 @@ void towire_changed_htlc(u8 **pptr, const struct changed_htlc *changed);
 void towire_htlc_state(u8 **pptr, const enum htlc_state hstate);
 void towire_side(u8 **pptr, const enum side side);
 void towire_shachain(u8 **pptr, const struct shachain *shachain);
-void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
 
 void fromwire_added_htlc(const u8 **cursor, size_t *max,
 			 struct added_htlc *added);
@@ -56,5 +55,4 @@ enum htlc_state fromwire_htlc_state(const u8 **cursor, size_t *max);
 enum side fromwire_side(const u8 **cursor, size_t *max);
 void fromwire_shachain(const u8 **cursor, size_t *max,
 		       struct shachain *shachain);
-void fromwire_bitcoin_tx(const u8 **cursor, size_t *max, struct bitcoin_tx *tx);
 #endif /* LIGHTNING_COMMON_HTLC_WIRE_H */

--- a/common/permute_tx.c
+++ b/common/permute_tx.c
@@ -40,6 +40,9 @@ static void swap_inputs(struct bitcoin_tx_input *inputs,
 	struct bitcoin_tx_input tmpinput;
 	const void *tmp;
 
+	if (i1 == i2)
+		return;
+
 	tmpinput = inputs[i1];
 	inputs[i1] = inputs[i2];
 	inputs[i2] = tmpinput;
@@ -57,7 +60,7 @@ void permute_inputs(struct bitcoin_tx_input *inputs, size_t num_inputs,
 	size_t i;
 
 	/* Now do a dumb sort (num_inputs is small). */
-	for (i = 0; i < num_inputs; i++) {
+	for (i = 0; i < num_inputs-1; i++) {
 		/* Swap best into first place. */
 		swap_inputs(inputs, map,
 			    i, i + find_best_in(inputs + i, num_inputs - i));
@@ -70,6 +73,9 @@ static void swap_outputs(struct bitcoin_tx_output *outputs,
 {
 	struct bitcoin_tx_output tmpoutput;
 	const void *tmp;
+
+	if (i1 == i2)
+		return;
 
 	tmpoutput = outputs[i1];
 	outputs[i1] = outputs[i2];
@@ -121,7 +127,7 @@ void permute_outputs(struct bitcoin_tx_output *outputs, size_t num_outputs,
 	size_t i;
 
 	/* Now do a dumb sort (num_outputs is small). */
-	for (i = 0; i < num_outputs; i++) {
+	for (i = 0; i < num_outputs-1; i++) {
 		/* Swap best into first place. */
 		swap_outputs(outputs, map,
 			     i, i + find_best_out(outputs + i, num_outputs - i));

--- a/common/utxo.c
+++ b/common/utxo.c
@@ -3,20 +3,38 @@
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo)
 {
+	/* Is this a unilateral close output and needs the
+	 * close_info? */
+	bool is_unilateral_close = utxo->close_info != NULL;
 	towire_bitcoin_txid(pptr, &utxo->txid);
 	towire_u32(pptr, utxo->outnum);
 	towire_u64(pptr, utxo->amount);
 	towire_u32(pptr, utxo->keyindex);
 	towire_bool(pptr, utxo->is_p2sh);
+
+	towire_bool(pptr, is_unilateral_close);
+	if (is_unilateral_close) {
+		towire_u64(pptr, utxo->close_info->channel_id);
+		towire_pubkey(pptr, &utxo->close_info->peer_id);
+		towire_pubkey(pptr, &utxo->close_info->commitment_point);
+	}
 }
 
-void fromwire_utxo(const u8 **ptr, size_t *max, struct utxo *utxo)
+void fromwire_utxo(const tal_t *ctx, const u8 **ptr, size_t *max, struct utxo *utxo)
 {
 	fromwire_bitcoin_txid(ptr, max, &utxo->txid);
 	utxo->outnum = fromwire_u32(ptr, max);
 	utxo->amount = fromwire_u64(ptr, max);
 	utxo->keyindex = fromwire_u32(ptr, max);
 	utxo->is_p2sh = fromwire_bool(ptr, max);
+	if (fromwire_bool(ptr, max)) {
+		utxo->close_info = tal(ctx, struct unilateral_close_info);
+		utxo->close_info->channel_id = fromwire_u64(ptr, max);
+		fromwire_pubkey(ptr, max, &utxo->close_info->peer_id);
+		fromwire_pubkey(ptr, max, &utxo->close_info->commitment_point);
+	} else {
+		utxo->close_info = NULL;
+	}
 }
 
 

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -1,10 +1,19 @@
 #ifndef LIGHTNING_COMMON_UTXO_H
 #define LIGHTNING_COMMON_UTXO_H
 #include "config.h"
+#include <bitcoin/pubkey.h>
+#include <bitcoin/shadouble.h>
 #include <bitcoin/tx.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 #include <stdbool.h>
+
+/* Information needed for their_unilateral/to-us outputs */
+struct unilateral_close_info {
+	u64 channel_id;
+	struct pubkey peer_id;
+	struct pubkey commitment_point;
+};
 
 struct utxo {
 	struct bitcoin_txid txid;
@@ -13,6 +22,10 @@ struct utxo {
 	u32 keyindex;
 	bool is_p2sh;
 	u8 status;
+
+	/* Optional unilateral close information, NULL if this is just
+	 * a HD key */
+	struct unilateral_close_info *close_info;
 };
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo);

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -29,7 +29,7 @@ struct utxo {
 };
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo);
-void fromwire_utxo(const u8 **ptr, size_t *max, struct utxo *utxo);
+void fromwire_utxo(const tal_t *ctx, const u8 **ptr, size_t *max, struct utxo *utxo);
 
 /* build_utxos/funding_tx use array of pointers, but marshall code
  * wants arr of structs */

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -23,6 +23,7 @@ HSMD_COMMON_OBJS :=				\
 	common/bip32.o				\
 	common/daemon_conn.o			\
 	common/debug.o				\
+	common/derive_basepoints.o		\
 	common/funding_tx.o			\
 	common/hash_u5.o			\
 	common/io_debug.o			\

--- a/hsmd/hsm_client_wire_csv
+++ b/hsmd/hsm_client_wire_csv
@@ -57,8 +57,7 @@ hsm_sign_withdrawal,,num_inputs,u16
 hsm_sign_withdrawal,,inputs,num_inputs*struct utxo
 
 hsm_sign_withdrawal_reply,107
-hsm_sign_withdrawal_reply,,num_sigs,u16
-hsm_sign_withdrawal_reply,,sig,num_sigs*secp256k1_ecdsa_signature
+hsm_sign_withdrawal_reply,,tx,struct bitcoin_tx
 
 # Sign an invoice
 hsm_sign_invoice,8

--- a/hsmd/hsm_client_wire_csv
+++ b/hsmd/hsm_client_wire_csv
@@ -35,8 +35,7 @@ hsm_sign_funding,,num_inputs,u16
 hsm_sign_funding,,inputs,num_inputs*struct utxo
 
 hsm_sign_funding_reply,104
-hsm_sign_funding_reply,,num_sigs,u16
-hsm_sign_funding_reply,,sig,num_sigs*secp256k1_ecdsa_signature
+hsm_sign_funding_reply,,tx,struct bitcoin_tx
 
 # Master asks the HSM to sign a node_announcement
 hsm_node_announcement_sig_req,6

--- a/lightningd/build_utxos.c
+++ b/lightningd/build_utxos.c
@@ -15,7 +15,6 @@ const struct utxo **build_utxos(const tal_t *ctx,
 				u64 *change_satoshis, u32 *change_keyindex)
 {
 	u64 fee_estimate = 0;
-	u64 bip32_max_index = db_get_intvar(ld->wallet->db, "bip32_max_index", 0);
 	const struct utxo **utxos =
 	    wallet_select_coins(ctx, ld->wallet, satoshi_out, feerate_per_kw,
 				outputscriptlen,
@@ -30,8 +29,7 @@ const struct utxo **build_utxos(const tal_t *ctx,
 		*change_satoshis = 0;
 		*change_keyindex = 0;
 	} else {
-		*change_keyindex = bip32_max_index + 1;
-		db_set_intvar(ld->wallet->db, "bip32_max_index", *change_keyindex);
+		*change_keyindex = wallet_get_newindex(ld);
 	}
 	return utxos;
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1276,6 +1276,14 @@ static void handle_irrevocably_resolved(struct peer *peer, const u8 *msg)
 	free_peer(peer, "onchaind complete, forgetting peer");
 }
 
+/**
+ * onchain_add_utxo -- onchaind is telling us about a UTXO we own
+ */
+static void onchain_add_utxo(struct peer *peer, const u8 *msg)
+{
+	/* FIXME(cdecker) Implement */
+}
+
 static unsigned int onchain_msg(struct subd *sd, const u8 *msg, const int *fds)
 {
 	enum onchain_wire_type t = fromwire_peektype(msg);
@@ -1307,6 +1315,10 @@ static unsigned int onchain_msg(struct subd *sd, const u8 *msg, const int *fds)
 
 	case WIRE_ONCHAIN_ALL_IRREVOCABLY_RESOLVED:
 		handle_irrevocably_resolved(sd->peer, msg);
+		break;
+
+	case WIRE_ONCHAIN_ADD_UTXO:
+		onchain_add_utxo(sd->peer, msg);
 		break;
 
 	/* We send these, not receive them */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1699,6 +1699,8 @@ static void peer_got_shutdown(struct peer *peer, const u8 *msg)
 			return;
 		}
 
+		txfilter_add_scriptpubkey(peer->ld->owned_txfilter, scriptpubkey);
+
 		/* BOLT #2:
 		 *
 		 * A receiving node MUST reply to a `shutdown` message with a
@@ -2687,6 +2689,8 @@ static void json_close(struct command *cmd,
 		}
 
 		peer_set_condition(peer, CHANNELD_NORMAL, CHANNELD_SHUTTING_DOWN);
+
+		txfilter_add_scriptpubkey(peer->ld->owned_txfilter, shutdown_scriptpubkey);
 
 		if (peer->owner)
 			subd_send_msg(peer->owner,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1434,6 +1434,7 @@ static enum watch_result funding_spent(struct peer *peer,
 		tal_free(tmpctx);
 		return DELETE_WATCH;
 	}
+	txfilter_add_scriptpubkey(peer->ld->owned_txfilter, scriptpubkey);
 
 	if (!bip32_pubkey(peer->ld->wallet->bip32_base, &ourkey, keyindex)) {
 		peer_internal_error(peer,

--- a/lightningd/test/run-funding_tx.c
+++ b/lightningd/test/run-funding_tx.c
@@ -99,6 +99,7 @@ int main(void)
 	utxo.outnum = 0;
 	utxo.amount = 5000000000;
 	utxo.is_p2sh = false;
+	utxo.close_info = NULL;
 	funding_satoshis = 10000000;
 	fee = 13920;
 

--- a/lightningd/txfilter.c
+++ b/lightningd/txfilter.c
@@ -17,7 +17,7 @@ struct txfilter *txfilter_new(const tal_t *ctx)
 	return filter;
 }
 
-static void txfilter_add_scriptpubkey(struct txfilter *filter, u8 *script)
+void txfilter_add_scriptpubkey(struct txfilter *filter, u8 *script)
 {
 	size_t count = tal_count(filter->scriptpubkeys);
 	tal_resize(&filter->scriptpubkeys, count + 1);

--- a/lightningd/txfilter.h
+++ b/lightningd/txfilter.h
@@ -28,4 +28,9 @@ void txfilter_add_derkey(struct txfilter *filter, u8 derkey[PUBKEY_DER_LEN]);
  */
 bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx);
 
+/**
+ * txfilter_add_scriptpubkey -- Add a serialized scriptpubkey to the filter
+ */
+void txfilter_add_scriptpubkey(struct txfilter *filter, u8 *script);
+
 #endif /* LIGHTNING_LIGHTNINGD_TXFILTER_H */

--- a/onchaind/onchain.c
+++ b/onchaind/onchain.c
@@ -1887,6 +1887,13 @@ static void handle_their_unilateral(const struct bitcoin_tx *tx,
 						 OUTPUT_TO_US, NULL, NULL, NULL);
 			ignore_output(out);
 			script[LOCAL] = NULL;
+
+			/* Tell the master that it will want to add
+			 * this UTXO to its outputs */
+			wire_sync_write(REQ_FD, towire_onchain_add_utxo(
+						    tmpctx, txid, i,
+						    remote_per_commitment_point,
+						    tx->output[i].amount));
 			continue;
 		}
 		if (script[REMOTE]

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -82,3 +82,10 @@ onchain_htlc_timeout,,htlc,struct htlc_stub
 
 # onchaind->master: this peer can be forgotten
 onchain_all_irrevocably_resolved,5011
+
+# onchaind->master: hey, I identified a UTXO you'll want to track
+onchain_add_utxo,5012
+onchain_add_utxo,,prev_out_tx,struct bitcoin_txid
+onchain_add_utxo,,prev_out_index,u32
+onchain_add_utxo,,per_commit_point,struct pubkey
+onchain_add_utxo,,value,u64

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -31,6 +31,7 @@ type2size = {
 varlen_structs = [
     'gossip_getnodes_entry',
     'failed_htlc',
+    'utxo',
 ]
 
 class FieldType(object):
@@ -297,7 +298,7 @@ class Message(object):
                 self.print_fromwire_array(subcalls, basetype, f, f.name,
                                           f.num_elems)
             elif f.is_variable_size():
-                subcalls.append("\t//2th case {name}".format(name=f.name))
+                subcalls.append("\t//2nd case {name}".format(name=f.name))
                 subcalls.append('\t*{} = {} ? tal_arr(ctx, {}, {}) : NULL;'
                                 .format(f.name, f.lenvar, f.fieldtype.name, f.lenvar))
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -150,6 +150,9 @@ char *dbmigrations[] = {
      * pre-release software, so it's forgivable. */
     "ALTER TABLE channels ADD first_blocknum INTEGER;",
     "UPDATE channels SET first_blocknum=CAST(short_channel_id AS INTEGER) WHERE short_channel_id IS NOT NULL;",
+    "ALTER TABLE outputs ADD COLUMN channel_id INTEGER;",
+    "ALTER TABLE outputs ADD COLUMN peer_id BLOB;",
+    "ALTER TABLE outputs ADD COLUMN commitment_point BLOB;",
     NULL,
 };
 
@@ -491,5 +494,17 @@ bool sqlite3_column_sha256(sqlite3_stmt *stmt, int col,  struct sha256 *dest)
 bool sqlite3_bind_sha256(sqlite3_stmt *stmt, int col, const struct sha256 *p)
 {
 	sqlite3_bind_blob(stmt, col, p, sizeof(struct sha256), SQLITE_TRANSIENT);
+	return true;
+}
+
+bool sqlite3_column_sha256_double(sqlite3_stmt *stmt, int col,  struct sha256_double *dest)
+{
+	assert(sqlite3_column_bytes(stmt, col) == sizeof(struct sha256_double));
+	return memcpy(dest, sqlite3_column_blob(stmt, col), sizeof(struct sha256_double));
+}
+
+bool sqlite3_bind_sha256_double(sqlite3_stmt *stmt, int col, const struct sha256_double *p)
+{
+	sqlite3_bind_blob(stmt, col, p, sizeof(struct sha256_double), SQLITE_TRANSIENT);
 	return true;
 }

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -132,4 +132,7 @@ bool sqlite3_bind_preimage(sqlite3_stmt *stmt, int col, const struct preimage *p
 bool sqlite3_column_sha256(sqlite3_stmt *stmt, int col,  struct sha256 *dest);
 bool sqlite3_bind_sha256(sqlite3_stmt *stmt, int col, const struct sha256 *p);
 
+bool sqlite3_column_sha256_double(sqlite3_stmt *stmt, int col,  struct sha256_double *dest);
+bool sqlite3_bind_sha256_double(sqlite3_stmt *stmt, int col, const struct sha256_double *p);
+
 #endif /* WALLET_DB_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -44,7 +44,8 @@ enum wallet_output_type {
 	to_local = 1,
 	htlc_offer = 3,
 	htlc_recv = 4,
-	our_change = 5
+	our_change = 5,
+	p2wpkh = 6
 };
 
 /* A database backed shachain struct. The datastructure is

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -228,3 +228,7 @@ void derive_channel_id(struct channel_id *channel_id,
 	channel_id->id[sizeof(*channel_id)-1] ^= txout;
 }
 
+void fromwire_bitcoin_tx(const u8 **cursor, size_t *max, struct bitcoin_tx *tx)
+{
+	pull_bitcoin_tx_onto(tx, cursor, max, tx);
+}

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -153,3 +153,11 @@ void towire_pad(u8 **pptr, size_t num)
 	tal_resize(pptr, oldsize + num);
 	memset(*pptr + oldsize, 0, num);
 }
+
+void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx)
+{
+	tal_t *tmpctx = tal_tmpctx(NULL);
+	u8 *lin = linearize_tx(tmpctx, tx);
+	towire_u8_array(pptr, lin, tal_len(lin));
+	tal_free(tmpctx);
+}

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -54,6 +54,8 @@ void towire_bool(u8 **pptr, bool v);
 
 void towire_u8_array(u8 **pptr, const u8 *arr, size_t num);
 
+void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
+
 const u8 *fromwire(const u8 **cursor, size_t *max, void *copy, size_t n);
 u8 fromwire_u8(const u8 **cursor, size_t *max);
 u16 fromwire_u16(const u8 **cursor, size_t *max);
@@ -84,4 +86,6 @@ void fromwire_ripemd160(const u8 **cursor, size_t *max, struct ripemd160 *ripemd
 void fromwire_pad(const u8 **cursor, size_t *max, size_t num);
 
 void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num);
+
+void fromwire_bitcoin_tx(const u8 **cursor, size_t *max, struct bitcoin_tx *tx);
 #endif /* LIGHTNING_WIRE_WIRE_H */


### PR DESCRIPTION
This should get us all the funds that we own back, on unilateral close, cheat and collaborative close. First we make sure to remember all outputs that we are interested in and store them in the DB. Special care needs to be taken for the unilateral_close:to_us output, since it's the only p2wpkh output which we don't use keyindex for. For this case we need to extend the output data to include the peer_id, channel_id and commitment_point.

This also refactors the funding and withdrawal transaction generation to let `hsmd` generate the full TX instead of just the signatures. This de-duplicates and simplifies the creation of these transaction since we no longer need to generate them in two separate parts and ensure that they are identical.

Fixes #385 