### PR TITLE
Make README.md install instructions consistent with doc/INSTALL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please refer to the [installation documentation](doc/INSTALL.md) for detailed in
 For the impatient here's the gist of it for Ubuntu and Debian:
 
 ```
-sudo apt-get install -y autoconf git build-essential libtool libgmp-dev libsqlite3-dev python python3
+sudo apt-get install -y autoconf build-essential git libtool libgmp-dev libsqlite3-dev python3 net-tools
 git clone https://github.com/ElementsProject/lightning.git
 cd lightning
 make


### PR DESCRIPTION
Make `README.md` install instructions consistent with `doc/INSTALL.md`:
* Remove python2 dependency.
* Add net-tools dependency.