### PR TITLE
Use deterministic command-line ordering when executing lightningd from tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -253,7 +253,7 @@ class LightningD(TailableProc):
             self.cmd_line += ['--dev-broadcast-interval=1000']
             if not random_hsm:
                 self.cmd_line += ['--dev-hsm-seed={}'.format(seed.hex())]
-        self.cmd_line += ["--{}={}".format(k, v) for k, v in LIGHTNINGD_CONFIG.items()]
+        self.cmd_line += ["--{}={}".format(k, v) for k, v in sorted(LIGHTNINGD_CONFIG.items())]
         self.prefix = 'lightningd(%d)' % (port)
 
         if not os.path.exists(lightning_dir):


### PR DESCRIPTION
Use deterministic command-line ordering when executing `lightningd` from tests.

Iteration order of `dict`:s is non-deterministic in Python3. This results in randomized ordering of command-line options passed to `lightningd` between test runs which makes the options list harder to read :-)

Before this patch:

```
# Test run 1
valgrind -q --trace-children=yes --trace-children-skip=*bitcoin-cli* --error-exitcode=7 --log-file=/tmp/lightning-…/test_channel_persistence/lightning-2//valgrind-errors.%p lightningd/lightningd --bitcoin-datadir=/tmp/bitcoind-test --lightning-dir=/tmp/lightning-…/test_channel_persistence/lightning-2/ --port=16332 --override-fee-rates=15000/7500/1000 --network=regtest --dev-broadcast-interval=1000 --dev-hsm-seed=… 
  --cltv-final=5 --locktime-blocks=5 --log-level=debug --bitcoind-poll=1s --cltv-delta=6 --dev-fail-on-subdaemon-fail --dev-debugger=channeld

# Test run 2
valgrind -q --trace-children=yes --trace-children-skip=*bitcoin-cli* --error-exitcode=7 --log-file=/tmp/lightning-…/test_channel_persistence/lightning-2//valgrind-errors.%p lightningd/lightningd --bitcoin-datadir=/tmp/bitcoind-test --lightning-dir=/tmp/lightning-…/test_channel_persistence/lightning-2/ --port=16332 --override-fee-rates=15000/7500/1000 --network=regtest --dev-broadcast-interval=1000 --dev-hsm-seed=…
  --bitcoind-poll=1s --log-level=debug --cltv-delta=6 --cltv-final=5 --locktime-blocks=5 --dev-fail-on-subdaemon-fail --dev-debugger=channeld
```
  
After this patch:

```
# Test run 1
valgrind -q --trace-children=yes --trace-children-skip=*bitcoin-cli* --error-exitcode=7 --log-file=/tmp/lightning-…/test_channel_persistence/lightning-2//valgrind-errors.%p lightningd/lightningd --bitcoin-datadir=/tmp/bitcoind-test --lightning-dir=/tmp/lightning-…/test_channel_persistence/lightning-2/ --port=16332 --override-fee-rates=15000/7500/1000 --network=regtest --dev-broadcast-interval=1000 --dev-hsm-seed=… 
  --bitcoind-poll=1s --cltv-delta=6 --cltv-final=5 --locktime-blocks=5 --log-level=debug --dev-fail-on-subdaemon-fail --dev-debugger=channeld

# Test run 2
valgrind -q --trace-children=yes --trace-children-skip=*bitcoin-cli* --error-exitcode=7 --log-file=/tmp/lightning-…/test_channel_persistence/lightning-2//valgrind-errors.%p lightningd/lightningd --bitcoin-datadir=/tmp/bitcoind-test --lightning-dir=/tmp/lightning-…/test_channel_persistence/lightning-2/ --port=16332 --override-fee-rates=15000/7500/1000 --network=regtest --dev-broadcast-interval=1000 --dev-hsm-seed=… 
  --bitcoind-poll=1s --cltv-delta=6 --cltv-final=5 --locktime-blocks=5 --log-level=debug --dev-fail-on-subdaemon-fail --dev-debugger=channeld

```