### PR TITLE
Silence test suite warnings: "ResourceWarning: unclosed file <_io.BufferedReader name=N>"

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from bitcoin.rpc import RawProxy as BitcoinProxy
 from lightning import LightningRpc
 
+import atexit
 import logging
 import os
 import re
@@ -55,6 +56,7 @@ class TailableProc(object):
         """
         logging.debug("Starting '%s'", " ".join(self.cmd_line))
         self.proc = subprocess.Popen(self.cmd_line, stdout=subprocess.PIPE, env=self.env)
+        atexit.register(self.proc.stdout.close)
         self.thread = threading.Thread(target=self.tail)
         self.thread.daemon = True
         self.thread.start()


### PR DESCRIPTION
Silence test suite warnings: `ResourceWarning: unclosed file <_io.BufferedReader name=N>`

Before this patch:

```
$ PYTHONPATH=contrib/pylightning:$PYTHONPATH DEVELOPER=1 python3 tests/test_lightningd.py -f
Testing results are in /tmp/lightning-c174u2jv
test_addfunds_from_block (__main__.LightningDTests)
Send funds to the daemon without telling it explicitly ... ok
/usr/lib/python3.5/unittest/suite.py:107: ResourceWarning: unclosed file <_io.BufferedReader name=5>
  for index, test in enumerate(self):
test_bad_opening (__main__.LightningDTests) ... ok
/usr/lib/python3.5/unittest/suite.py:107: ResourceWarning: unclosed file <_io.BufferedReader name=6>
  for index, test in enumerate(self):
/usr/lib/python3.5/unittest/suite.py:107: ResourceWarning: unclosed file <_io.BufferedReader name=5>
  for index, test in enumerate(self):
test_balance (__main__.LightningDTests) ... ok
/usr/lib/python3.5/unittest/suite.py:107: ResourceWarning: unclosed file <_io.BufferedReader name=6>
  for index, test in enumerate(self):
/usr/lib/python3.5/unittest/suite.py:107: ResourceWarning: unclosed file <_io.BufferedReader name=5>
  for index, test in enumerate(self):
```

After this patch:

```
PYTHONPATH=contrib/pylightning:$PYTHONPATH DEVELOPER=1 python3 tests/test_lightningd.py -f
Testing results are in /tmp/lightning-evi_odb_
test_addfunds_from_block (__main__.LightningDTests)
Send funds to the daemon without telling it explicitly ... ok
test_bad_opening (__main__.LightningDTests) ... ok
test_balance (__main__.LightningDTests) ... ok
```
  