### PR TITLE
pytest: Avoid leaking stdout fds

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,6 +100,7 @@ class TailableProc(object):
                 logging.debug("%s: %s", self.prefix, line.decode().rstrip())
                 self.logs_cond.notifyAll()
         self.running = False
+        self.proc.stdout.close()
 
     def is_in_log(self, regex):
         """Look for `regex` in the logs."""


### PR DESCRIPTION
Alternative take on #521, this time without registering an `atexit` callback, closing the fd where it is used. Still not perfect since we are opening in one thread and closing in the other, but should work fine. Reproduced the leak before and verified it's gone afterwards.