### PR TITLE
gossip: Do not return empty address-objects for getnodes

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -385,6 +385,10 @@ void json_add_short_channel_id(struct json_result *response,
 void json_add_address(struct json_result *response, const char *fieldname,
 		      const struct wireaddr *addr)
 {
+	/* No need to print padding */
+	if (addr->type == ADDR_TYPE_PADDING)
+		return;
+
 	json_object_start(response, fieldname);
 	char *addrstr = tal_arr(response, char, INET6_ADDRSTRLEN);
 	if (addr->type == ADDR_TYPE_IPV4) {


### PR DESCRIPTION
Some nodes are adding padding entries that we faithfully returned as well in our JSON-RPC reply. They're pretty useless, so let's not print them.