### PR TITLE
subdaemon.c: subdaemon_setup() routine for all daemons.

### DIFF
--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -38,7 +38,6 @@ CHANNELD_COMMON_OBJS :=				\
 	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/derive_basepoints.o		\
 	common/dev_disconnect.o			\
 	common/htlc_state.o			\
@@ -57,6 +56,7 @@ CHANNELD_COMMON_OBJS :=				\
 	common/pseudorand.o			\
 	common/sphinx.o				\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/timeout.o			\
 	common/type_to_string.o			\
 	common/utils.o				\

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -27,7 +27,6 @@
 #include <channeld/full_channel.h>
 #include <channeld/gen_channel_wire.h>
 #include <common/crypto_sync.h>
-#include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/dev_disconnect.h>
 #include <common/htlc_tx.h>
@@ -38,6 +37,7 @@
 #include <common/ping.h>
 #include <common/sphinx.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/timeout.h>
 #include <common/type_to_string.h>
 #include <common/version.h>
@@ -49,7 +49,6 @@
 #include <hsmd/gen_hsm_client_wire.h>
 #include <inttypes.h>
 #include <secp256k1.h>
-#include <signal.h>
 #include <stdio.h>
 #include <wire/gen_onion_wire.h>
 #include <wire/peer_wire.h>
@@ -2499,17 +2498,7 @@ int main(int argc, char *argv[])
 	fd_set fds_in, fds_out;
 	struct peer *peer;
 
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
-
-	subdaemon_debug(argc, argv);
-
-	/* We handle write returning errors! */
-	signal(SIGCHLD, SIG_IGN);
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
-						 | SECP256K1_CONTEXT_SIGN);
+	subdaemon_setup(argc, argv);
 
 	peer = tal(NULL, struct peer);
 	peer->num_pings_outstanding = 0;

--- a/closingd/Makefile
+++ b/closingd/Makefile
@@ -47,7 +47,6 @@ CLOSINGD_COMMON_OBJS :=				\
 	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/dev_disconnect.o			\
 	common/derive_basepoints.o		\
 	common/htlc_wire.o			\
@@ -56,6 +55,7 @@ CLOSINGD_COMMON_OBJS :=				\
 	common/peer_failed.o			\
 	common/permute_tx.o			\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/type_to_string.o			\
 	common/utils.o				\
 	common/version.o

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -2,17 +2,16 @@
 #include <closingd/gen_closing_wire.h>
 #include <common/close_tx.h>
 #include <common/crypto_sync.h>
-#include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/htlc.h>
 #include <common/peer_failed.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/version.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <wire/peer_wire.h>
@@ -170,17 +169,8 @@ int main(int argc, char *argv[])
 	u64 next_index[NUM_SIDES], revocations_received;
 	u64 gossip_index;
 
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
+	subdaemon_setup(argc, argv);
 
-	subdaemon_debug(argc, argv);
-
-	/* We handle write returning errors! */
-	signal(SIGCHLD, SIG_IGN);
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
-						 | SECP256K1_CONTEXT_SIGN);
 	status_setup_sync(REQ_FD);
 
 	msg = wire_sync_read(ctx, REQ_FD);

--- a/common/Makefile
+++ b/common/Makefile
@@ -9,7 +9,6 @@ COMMON_SRC :=					\
 	common/crypto_sync.c			\
 	common/cryptomsg.c			\
 	common/daemon_conn.c			\
-	common/debug.c				\
 	common/derive_basepoints.c		\
 	common/dev_disconnect.c			\
 	common/funding_tx.c			\
@@ -31,6 +30,7 @@ COMMON_SRC :=					\
 	common/pseudorand.c			\
 	common/sphinx.c				\
 	common/status.c				\
+	common/subdaemon.c			\
 	common/timeout.c			\
 	common/type_to_string.c			\
 	common/utils.c				\

--- a/common/debug.h
+++ b/common/debug.h
@@ -1,7 +1,0 @@
-#ifndef LIGHTNING_COMMON_DEBUG_H
-#define LIGHTNING_COMMON_DEBUG_H
-#include "config.h"
-
-void subdaemon_debug(int argc, char *argv[]);
-
-#endif /* LIGHTNING_COMMON_DEBUG_H */

--- a/common/subdaemon.h
+++ b/common/subdaemon.h
@@ -1,0 +1,7 @@
+#ifndef LIGHTNING_COMMON_SUBDAEMON_H
+#define LIGHTNING_COMMON_SUBDAEMON_H
+#include "config.h"
+
+void subdaemon_setup(int argc, char *argv[]);
+
+#endif /* LIGHTNING_COMMON_SUBDAEMON_H */

--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -39,13 +39,13 @@ GOSSIPD_COMMON_OBJS :=				\
 	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/dev_disconnect.o			\
 	common/io_debug.o			\
 	common/msg_queue.o			\
 	common/ping.o				\
 	common/pseudorand.o			\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/timeout.o			\
 	common/type_to_string.o			\
 	common/utils.o				\

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -15,10 +15,10 @@
 #include <ccan/timer/timer.h>
 #include <common/cryptomsg.h>
 #include <common/daemon_conn.h>
-#include <common/debug.h>
 #include <common/io_debug.h>
 #include <common/ping.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/timeout.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
@@ -1624,16 +1624,8 @@ int main(int argc, char *argv[])
 {
 	struct daemon *daemon;
 
-	subdaemon_debug(argc, argv);
+	subdaemon_setup(argc, argv);
 	io_poll_override(debug_poll);
-
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
-
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY |
-						 SECP256K1_CONTEXT_SIGN);
 
 	daemon = tal(NULL, struct daemon);
 	list_head_init(&daemon->peers);

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -22,7 +22,6 @@ LIGHTNINGD_HSM_OBJS := $(LIGHTNINGD_HSM_SRC:.c=.o)
 HSMD_COMMON_OBJS :=				\
 	common/bip32.o				\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/derive_basepoints.o		\
 	common/funding_tx.o			\
 	common/hash_u5.o			\
@@ -31,6 +30,7 @@ HSMD_COMMON_OBJS :=				\
 	common/msg_queue.o			\
 	common/permute_tx.o			\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/type_to_string.o			\
 	common/utils.o				\
 	common/utxo.o				\

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -14,13 +14,13 @@
 #include <ccan/read_write_all/read_write_all.h>
 #include <ccan/take/take.h>
 #include <common/daemon_conn.h>
-#include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/funding_tx.h>
 #include <common/hash_u5.h>
 #include <common/io_debug.h>
 #include <common/key_derive.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/version.h>
@@ -833,16 +833,8 @@ int main(int argc, char *argv[])
 {
 	struct client *client;
 
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
-
-	subdaemon_debug(argc, argv);
+	subdaemon_setup(argc, argv);
 	io_poll_override(debug_poll);
-
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
-						 | SECP256K1_CONTEXT_SIGN);
 
 	client = new_client(NULL, NULL, HSM_CAP_MASTER | HSM_CAP_SIGN_GOSSIP, handle_client, STDIN_FILENO);
 

--- a/onchaind/Makefile
+++ b/onchaind/Makefile
@@ -48,7 +48,6 @@ $(LIGHTNINGD_ONCHAIN_OBJS): $(LIGHTNINGD_HEADERS)
 # Common source we use.
 ONCHAIND_COMMON_OBJS :=				\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/derive_basepoints.o		\
 	common/dev_disconnect.o			\
 	common/htlc_tx.o			\
@@ -60,6 +59,7 @@ ONCHAIND_COMMON_OBJS :=				\
 	common/msg_queue.o			\
 	common/permute_tx.o			\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/type_to_string.o			\
 	common/utils.o				\
 	common/version.o

--- a/onchaind/onchain.c
+++ b/onchaind/onchain.c
@@ -3,13 +3,13 @@
 #include <ccan/mem/mem.h>
 #include <ccan/structeq/structeq.h>
 #include <ccan/tal/str/str.h>
-#include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/htlc_tx.h>
 #include <common/initial_commit_tx.h>
 #include <common/key_derive.h>
 #include <common/keyset.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/version.h>
@@ -18,7 +18,6 @@
 #include <lightningd/peer_state.h>
 #include <onchaind/gen_onchain_wire.h>
 #include <onchaind/onchain_types.h>
-#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <wire/wire_sync.h>
@@ -1976,17 +1975,8 @@ int main(int argc, char *argv[])
 	bool *tell_if_missing, *tell_immediately;
 	u32 tx_blockheight;
 
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
+	subdaemon_setup(argc, argv);
 
-	subdaemon_debug(argc, argv);
-
-	/* We handle write returning errors! */
-	signal(SIGCHLD, SIG_IGN);
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
-						 | SECP256K1_CONTEXT_SIGN);
 	status_setup_sync(REQ_FD);
 
 	missing_htlc_msgs = tal_arr(ctx, u8 *, 0);

--- a/openingd/Makefile
+++ b/openingd/Makefile
@@ -41,7 +41,6 @@ OPENINGD_COMMON_OBJS :=				\
 	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon_conn.o			\
-	common/debug.o				\
 	common/derive_basepoints.o		\
 	common/dev_disconnect.o			\
 	common/funding_tx.o			\
@@ -57,6 +56,7 @@ OPENINGD_COMMON_OBJS :=				\
 	common/permute_tx.o			\
 	common/pseudorand.o			\
 	common/status.o				\
+	common/subdaemon.o			\
 	common/type_to_string.o			\
 	common/utils.o				\
 	common/utxo.o				\

--- a/openingd/opening.c
+++ b/openingd/opening.c
@@ -7,7 +7,6 @@
 #include <ccan/structeq/structeq.h>
 #include <ccan/tal/str/str.h>
 #include <common/crypto_sync.h>
-#include <common/debug.h>
 #include <common/derive_basepoints.h>
 #include <common/funding_tx.h>
 #include <common/initial_channel.h>
@@ -16,6 +15,7 @@
 #include <common/ping.h>
 #include <common/pseudorand.h>
 #include <common/status.h>
+#include <common/subdaemon.h>
 #include <common/type_to_string.h>
 #include <common/version.h>
 #include <common/wire_error.h>
@@ -23,7 +23,6 @@
 #include <inttypes.h>
 #include <openingd/gen_opening_wire.h>
 #include <secp256k1.h>
-#include <signal.h>
 #include <stdio.h>
 #include <wally_bip32.h>
 #include <wire/gen_peer_wire.h>
@@ -761,17 +760,8 @@ int main(int argc, char *argv[])
 	struct ext_key bip32_base;
 	u32 network_index;
 
-	if (argc == 2 && streq(argv[1], "--version")) {
-		printf("%s\n", version());
-		exit(0);
-	}
+	subdaemon_setup(argc, argv);
 
-	subdaemon_debug(argc, argv);
-
-	/* We handle write returning errors! */
-	signal(SIGCHLD, SIG_IGN);
-	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
-						 | SECP256K1_CONTEXT_SIGN);
 	status_setup_sync(REQ_FD);
 
 	msg = wire_sync_read(state, REQ_FD);


### PR DESCRIPTION
Our handling of SIGPIPE was incoherent and inconsistent, and we had much
cut & paste between the daemons.  They should *ALL* ignore SIGPIPE, and
much of the rest of the boilerplate can be shared, so should be.

Reported-by: @ZmnSCPxj
Fixes: #528
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>