### PR TITLE
Make sure fsync, connect and close are never accidentally passed negative arguments

### DIFF
--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -489,6 +489,10 @@ static void create_new_hsm(struct daemon_conn *master)
 			      "closing: %s", strerror(errno));
 	}
 	fd = open(".", O_RDONLY);
+	if (fd < 0) {
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "opening: %s", strerror(errno));
+	}
 	if (fsync(fd) != 0) {
 		unlink_noerr("hsm_secret");
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -673,6 +673,9 @@ void setup_jsonrpc(struct lightningd *ld, const char *rpc_filename)
 	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		errx(1, "domain socket creation failed");
+	}
 	if (strlen(rpc_filename) + 1 > sizeof(addr.sun_path))
 		errx(1, "rpc filename '%s' too long", rpc_filename);
 	strcpy(addr.sun_path, rpc_filename);

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -121,7 +121,7 @@ static void close_taken_fds(va_list *ap)
 	int *fd;
 
 	while ((fd = va_arg(*ap, int *)) != NULL) {
-		if (taken(fd)) {
+		if (taken(fd) && *fd >= 0) {
 			close(*fd);
 			*fd = -1;
 		}


### PR DESCRIPTION
Make sure `fsync`, `connect` and `close` are never accidentally passed negative arguments.