### PR TITLE
chaintopology: fix use-after-free which sometimes causes fatal() in clear_otx_peer

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -227,13 +227,15 @@ static void broadcast_done(struct bitcoind *bitcoind,
 		return;
 	}
 
+	/* No longer needs to be disconnected if peer dies. */
+	tal_del_destructor2(otx->peer, clear_otx_peer, otx);
+
 	if (otx->failed && exitstatus != 0) {
 		otx->failed(otx->peer, exitstatus, msg);
 		tal_free(otx);
 	} else {
 		/* For continual rebroadcasting, until peer freed. */
 		tal_steal(otx->peer, otx);
-		tal_del_destructor2(otx->peer, clear_otx_peer, otx);
 		list_add_tail(&otx->topo->outgoing_txs, &otx->list);
 		tal_add_destructor(otx, destroy_outgoing_tx);
 	}


### PR DESCRIPTION
I've only seen this under travis, so I can't verify that this fixes it, but it's certainly a bug which could cause that issue.
