### PR TITLE
pytest: Minor cleanups and bumping pylightning to 0.0.2

### DIFF
--- a/contrib/pylightning/setup.py
+++ b/contrib/pylightning/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pylightning',
-      version='0.0.1',
+      version='0.0.2',
       description='Client library for lightningd',
       url='http://github.com/ElementsProject/lightning',
       author='Christian Decker',

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -70,9 +70,6 @@ def tearDownBitcoind():
         bitcoind.proc.kill()
     bitcoind.proc.wait()
 
-def breakpoint():
-    import pdb; pdb.set_trace()
-
 class NodeFactory(object):
     """A factory to setup and start `lightningd` daemons.
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,7 +121,6 @@ class TailableProc(object):
         starting from last of the previous waited-for log entries (if any).  We
         fail if the timeout is exceeded or if the underlying process
         exits before all the `regexs` were found.
-
         """
         logging.debug("Waiting for {} in the logs".format(regexs))
         exs = [re.compile(r) for r in regexs]
@@ -131,9 +130,6 @@ class TailableProc(object):
         while True:
             if time.time() > start_time + timeout:
                 print("Can't find {} in logs".format(exs))
-                with self.logs_cond:
-                    for i in range(initial_pos, len(self.logs)):
-                        print("  " + self.logs[i])
                 for r in exs:
                     if self.is_in_log(r):
                         print("({} was previously in logs!)".format(r))


### PR DESCRIPTION
These are some small improvements. I bumped pylightning 0.0.2 to get rid of the legacy support in the pypi package.

The only major change is that we no longer use a global `bitcoind` instance shared by all tests, instead we spawn a new one for each test in their respective test-directory. This enhances isolation between tests, and should make hacks like generating 100 blocks between tests obsolete. It's also now possible to inspect the final blockchain state in isolation as it is left by the test.

This change comes at a price however, since we need to spawn `bitcoind` and generate 432 blocks to enable segwit. My measurements show that the overhead is about 1-3 seconds per test, so not that massive compared to the rest of the tests:

|                    | No_valgrind   | Valgrind |
|--------------------|---------------|----------|
| bitcoind per suite | 10 min 24 sec | 46:15.31 |
| bitcoind per test  | 11 min 38 sec | 49:21.64 |