### PR TITLE
Add assertion for the assumed tal_count(msg) >= sizeof(be16) in subdaemon_malformed_msg(...)

### DIFF
--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -347,9 +347,7 @@ static void subdaemon_malformed_msg(struct subd *sd, const u8 *msg)
 {
 	log_broken(sd->log, "%i: malformed string '%.s'",
 		   fromwire_peektype(msg),
-		   tal_hexstr(msg,
-			      msg + sizeof(be16),
-			      tal_count(msg) - sizeof(be16)));
+		   tal_hex(msg, msg));
 
 #if DEVELOPER
 	if (sd->ld->dev_subdaemon_fail)


### PR DESCRIPTION
Add assertion for the assumed `tal_count(msg) >= sizeof(be16)` in `subdaemon_malformed_msg(...)`.

An unsigned integer overflow will occur if `tal_count(msg) >= sizeof(be16)` does not hold true.

Explicit is better than implicit :-)