### PR TITLE
emacs: add .dir-locals.el for linux style C

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+((c-mode . ((c-file-style . "linux")
+            (indent-tabs-mode . t)
+            (show-trailing-whitespace . t)
+            (c-basic-offset . 8)
+            (tab-width . 8)
+            ))
+)


### PR DESCRIPTION
This will automatically configure proper indent settings for new contributors using emacs.