### PR TITLE
Check return value of read_all(...) call in do_cmd(...)

### DIFF
--- a/test/test_protocol.c
+++ b/test/test_protocol.c
@@ -981,7 +981,9 @@ static void do_cmd(struct peer *peer)
 	} else if (streq(cmd, "restore")) {
 		write_all(peer->cmddonefd, "", 1);
 		/* Ack, then read in blob */
-		read_all(peer->cmdfd, &peer->db, sizeof(peer->db));
+		if (!read_all(peer->cmdfd, &peer->db, sizeof(peer->db))) {
+			errx(1, "Read failed for command \"restore\"");
+		}
 		restore_state(peer);
 	} else if (streq(cmd, "checksync")) {
 		struct commit_tx ours, theirs;


### PR DESCRIPTION
Check return value of `read_all(...)` call in `do_cmd(...)`.

All other users of `read_all(...)` check the return value:

```
hsmd/hsm.c:    if (!read_all(fd, &secretstuff.hsm_secret, sizeof(secretstuff.hsm_secret)))
test/test_protocol.c:    if (!read_all(fd, p, len))
wire/wire_sync.c:    if (!read_all(fd, &len, sizeof(len)))
wire/wire_sync.c:    if (!read_all(fd, msg, wirelen_to_cpu(len)))
```