### PR TITLE
Check return value of derive_simple_privkey(...) call in hsm_unilateral_close_privkey(...)

### DIFF
--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -575,9 +575,12 @@ static void hsm_unilateral_close_privkey(struct privkey *dst,
 	derive_peer_seed(&peer_seed, &peer_seed_base, &info->peer_id, info->channel_id);
 	derive_basepoints(&peer_seed, NULL, &basepoints, &secrets, NULL);
 
-	derive_simple_privkey(&secrets.payment_basepoint_secret,
-			      &basepoints.payment, &info->commitment_point,
-			      dst);
+	if (!derive_simple_privkey(&secrets.payment_basepoint_secret,
+				   &basepoints.payment, &info->commitment_point,
+				   dst)) {
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "Deriving unilateral_close_privkey");
+	}
 }
 
 /**


### PR DESCRIPTION
Check return value of `derive_simple_privkey(...)` call in `hsm_unilateral_close_privkey(...)`.

All other users of `derive_simple_privkey(...)` check the return value:

```
channeld/channel.c:     if (!derive_simple_privkey(&peer->our_secrets.htlc_basepoint_secret,
lightningd/test/run-commit_tx.c:        if (!derive_simple_privkey(&x_remote_htlc_basepoint_secret,
lightningd/test/run-commit_tx.c:        if (!derive_simple_privkey(&x_local_delayed_payment_basepoint_secret,
lightningd/test/run-commit_tx.c:        if (!derive_simple_privkey(&x_local_htlc_basepoint_secret,
lightningd/test/run-key_derive.c:       if (!derive_simple_privkey(&base_secret, &base_point,
onchaind/onchain.c:     if (!derive_simple_privkey(&secrets->delayed_payment_basepoint_secret,
onchaind/onchain.c:     if (!derive_simple_privkey(&secrets->payment_basepoint_secret,
onchaind/onchain.c:     if (!derive_simple_privkey(&secrets->htlc_basepoint_secret,
onchaind/onchain.c:     if (!derive_simple_privkey(&secrets->payment_basepoint_secret,
onchaind/onchain.c:     if (!derive_simple_privkey(&secrets->htlc_basepoint_secret,
```