### PR TITLE
Check return value of json_get_params(...) call in json_getlog(...) and json_getpeers(...)

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -150,7 +150,10 @@ static void json_getlog(struct command *cmd,
 	struct log_book *lr = cmd->ld->log_book;
 	jsmntok_t *level;
 
-	json_get_params(buffer, params, "?level", &level, NULL);
+	if (!json_get_params(buffer, params, "?level", &level, NULL)) {
+		command_fail(cmd, "Invalid arguments");
+		return;
+	}
 
 	info.num_skipped = 0;
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -945,7 +945,10 @@ static void json_getpeers(struct command *cmd,
 	struct getpeers_args *gpa = tal(cmd, struct getpeers_args);
 
 	gpa->cmd = cmd;
-	json_get_params(buffer, params, "?level", &leveltok, NULL);
+	if (!json_get_params(buffer, params, "?level", &leveltok, NULL)) {
+		command_fail(cmd, "Invalid arguments");
+		return;
+	}
 
 	if (leveltok) {
 		gpa->ll = tal(gpa, enum log_level);


### PR DESCRIPTION
Check return value of `json_get_params(...)` call in `json_getlog(...)` and `json_getpeers(...)`.

All other users of `json_get_params(...)` check the return value:

```
lightningd/chaintopology.c:     if (!json_get_params(buffer, params,
lightningd/chaintopology.c:     if (!json_get_params(buffer, params,
lightningd/dev_ping.c:  if (!json_get_params(buffer, params,
lightningd/gossip_control.c:    if (!json_get_params(buffer, params,
lightningd/invoice.c:   if (!json_get_params(buffer, params,
lightningd/invoice.c:   if (!json_get_params(buffer, params,
lightningd/invoice.c:   if (!json_get_params(buffer, params,
lightningd/invoice.c:   if (!json_get_params(buffer, params,
lightningd/invoice.c:   if (!json_get_params(buffer, params, "label", &labeltok, NULL)) {
lightningd/invoice.c:   if (!json_get_params(buffer, params,
lightningd/jsonrpc.c:   if (!json_get_params(buffer, params,
lightningd/pay.c:       if (!json_get_params(buffer, params,
lightningd/pay.c:       if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
lightningd/peer_control.c:      if (!json_get_params(buffer, params,
wallet/walletrpc.c:     if (!json_get_params(buffer, params,
wallet/walletrpc.c:     if (!json_get_params(buffer, params, "tx", &txtok, NULL)) {
```