### PR TITLE
test_lightning: don't fire prematurely on test_gossip_jsonrpc.

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -563,6 +563,9 @@ static struct io_plan *peer_msgin(struct io_conn *conn,
 	case WIRE_CHANNEL_ANNOUNCEMENT:
 	case WIRE_NODE_ANNOUNCEMENT:
 	case WIRE_CHANNEL_UPDATE:
+		status_trace("%s direct from peer %s",
+			     wire_type_name(t),
+			     type_to_string(trc, struct pubkey, &peer->id));
 		handle_gossip_msg(peer->daemon, msg);
 		return peer_next_in(conn, peer);
 
@@ -793,6 +796,9 @@ static struct io_plan *owner_msg_in(struct io_conn *conn,
 	int type = fromwire_peektype(msg);
 	if (type == WIRE_CHANNEL_ANNOUNCEMENT || type == WIRE_CHANNEL_UPDATE ||
 	    type == WIRE_NODE_ANNOUNCEMENT) {
+		status_trace("%s via other daemon from peer %s",
+			     wire_type_name(type),
+			     type_to_string(trc, struct pubkey, &peer->id));
 		handle_gossip_msg(peer->daemon, dc->msg_in);
 	} else if (type == WIRE_GOSSIP_GET_UPDATE) {
 		handle_get_update(peer, dc->msg_in);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1353,8 +1353,9 @@ class LightningDTests(BaseLightningDTests):
         nodes = l1.rpc.getnodes()['nodes']
         assert set([n['nodeid'] for n in nodes]) == set([l1.info['id'], l2.info['id']])
 
-        l1.daemon.wait_for_log('peer_in WIRE_CHANNEL_UPDATE')
-        l2.daemon.wait_for_log('peer_in WIRE_CHANNEL_UPDATE')
+        # channeld should pass update to gossipd (both directions)
+        l1.daemon.wait_for_logs(['WIRE_CHANNEL_UPDATE via other daemon']*2)
+        l2.daemon.wait_for_logs(['WIRE_CHANNEL_UPDATE via other daemon']*2)
 
         # Now should be active and public.
         channels = l1.rpc.getchannels()['channels']


### PR DESCRIPTION
We wait the the receipt of the CHANNEL_UPDATE message by channeld,
but that doesn't mean it reached gossipd yet.  Add log in gossipd,
and check that.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>