### PR TITLE
peer_control: send addrhints in activate_peer

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2734,7 +2734,13 @@ const char *peer_state_name(enum peer_state state)
 
 static void activate_peer(struct peer *peer)
 {
+	u8 *msg;
+
 	assert(!peer->owner);
+
+	/* Pass gossipd any addrhints we currently have */
+	msg = towire_gossipctl_peer_addrhint(peer, &peer->id, &peer->addr);
+	subd_send_msg(peer->ld->gossip, take(msg));
 
 	/* FIXME: We should never have these in the database! */
 	if (!peer->funding_txid) {
@@ -2751,7 +2757,7 @@ static void activate_peer(struct peer *peer)
 		  funding_spent, NULL);
 
 	if (peer_wants_reconnect(peer)) {
-		u8 *msg = towire_gossipctl_reach_peer(peer, &peer->id);
+		msg = towire_gossipctl_reach_peer(peer, &peer->id);
 		subd_send_msg(peer->ld->gossip, take(msg));
 	}
 }


### PR DESCRIPTION
Since we now have addresses in the database, we can resend them as hints to gossipd on startup.

Fixes #527 