### PR TITLE
Remove incoming payments

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -85,7 +85,6 @@ static void json_invoice(struct command *cmd,
 	struct wallet *wallet = cmd->ld->wallet;
 	struct bolt11 *b11;
 	char *b11enc;
-	struct wallet_payment payment;
 	u64 expiry = 3600;
 
 	if (!json_get_params(buffer, params,
@@ -159,23 +158,6 @@ static void json_invoice(struct command *cmd,
 
 	/* FIXME: add private routes if necessary! */
 	b11enc = bolt11_encode(cmd, b11, false, hsm_sign_b11, cmd->ld);
-
-	/* Store the payment so we can later show it in the history */
-	payment.id = 0;
-	payment.incoming = true;
-	payment.payment_hash = invoice->rhash;
-	payment.destination = NULL;
-	payment.status = PAYMENT_PENDING;
-	if (invoice->msatoshi)
-		payment.msatoshi = tal_dup(cmd, u64, invoice->msatoshi);
-	else
-		payment.msatoshi = NULL;
-	payment.timestamp = b11->timestamp;
-
-	if (!wallet_payment_add(cmd->ld->wallet, &payment)) {
-		command_fail(cmd, "Unable to record payment in the database.");
-		return;
-	}
 
 	json_object_start(response, NULL);
 	json_add_hex(response, "payment_hash",

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -243,12 +243,10 @@ static bool send_payment(struct command *cmd,
 
 		payment = tal(tmpctx, struct wallet_payment);
 		payment->id = 0;
-		payment->incoming = false;
 		payment->payment_hash = *rhash;
-		payment->destination = &ids[n_hops - 1];
+		payment->destination = ids[n_hops - 1];
 		payment->status = PAYMENT_PENDING;
-		payment->msatoshi = tal(payment, u64);
-		*payment->msatoshi = route[n_hops-1].amount;
+		payment->msatoshi = route[n_hops-1].amount;
 		payment->timestamp = time_now().ts.tv_sec;
 	}
 	pc->cmd = cmd;
@@ -500,12 +498,9 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 		const struct wallet_payment *t = payments[i];
 		json_object_start(response, NULL);
 		json_add_u64(response, "id", t->id);
-		json_add_bool(response, "incoming", t->incoming);
 		json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
-		if (!t->incoming)
-			json_add_pubkey(response, "destination", t->destination);
-		if (t->msatoshi)
-			json_add_u64(response, "msatoshi", *t->msatoshi);
+		json_add_pubkey(response, "destination", &t->destination);
+		json_add_u64(response, "msatoshi", t->msatoshi);
 		json_add_u64(response, "timestamp", t->timestamp);
 
 		switch (t->status) {
@@ -530,6 +525,6 @@ static const struct json_command listpayments_command = {
 	"listpayments",
 	json_listpayments,
 	"Get a list of incoming and outgoing payments",
-	"Returns a list of payments with {direction}, {payment_hash}, {destination} if outgoing and {msatoshi}"
+	"Returns a list of payments with {payment_hash}, {destination}, {msatoshi}, {timestamp} and {status}"
 };
 AUTODATA(json_command, &listpayments_command);

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -126,6 +126,7 @@ char *dbmigrations[] = {
     "  timestamp INTEGER,"
     "  status INTEGER,"
     "  payment_hash BLOB,"
+    /* FIXME: Direction is now always 1 (OUTGOING), can be removed */
     "  direction INTEGER,"
     "  destination BLOB,"
     "  msatoshi INTEGER,"

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -68,9 +68,7 @@ struct wallet_channel {
 /* Possible states for a wallet_payment. Payments start in
  * `PENDING`. Outgoing payments are set to `PAYMENT_COMPLETE` once we
  * get the preimage matching the rhash, or to
- * `PAYMENT_FAILED`. Incoming payments are set to `PAYMENT_COMPLETE`
- * once the matching invoice is marked as complete, or `FAILED`
- * otherwise.  */
+ * `PAYMENT_FAILED`. */
 /* /!\ This is a DB ENUM, please do not change the numbering of any
  * already defined elements (adding is ok) /!\ */
 enum wallet_payment_status {
@@ -79,19 +77,17 @@ enum wallet_payment_status {
 	PAYMENT_FAILED = 2
 };
 
-/* Incoming and outgoing payments. A simple persisted representation
- * of a payment we either initiated or received. This can be used by
- * a UI to display the balance history. We explicitly exclude
- * forwarded payments.
+/* Outgoing payments. A simple persisted representation
+ * of a payment we initiated. This can be used by
+ * a UI (alongside invoices) to display the balance history.
  */
 struct wallet_payment {
 	u64 id;
 	u32 timestamp;
-	bool incoming;
 	struct sha256 payment_hash;
 	enum wallet_payment_status status;
-	struct pubkey *destination;
-	u64 *msatoshi;
+	struct pubkey destination;
+	u64 msatoshi;
 };
 
 /**


### PR DESCRIPTION
(On top of #572 )

As noted when reviewing #545 we have redundant information between invoices and payments.  Yet the two uses are very different: a large server will issue many invoices which never get paid, but still won't make many payments.  A wallet may be the other way around.

(Incoming payments were also *inaccurate*, reflecting invoice amounts and not the actual payment).

@ZmnSCPxj also found that the dual-use was strained when "any" valued invoices were added.

These patches removes incoming invoices, for consideration of @cdecker 

Closes: #570 
