### PR TITLE
Change some RPC fields from `amount` to `msatoshi`

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -179,12 +179,12 @@ static void json_invoice(struct command *cmd,
 	u64 expiry = 3600;
 
 	if (!json_get_params(buffer, params,
-			     "amount", &msatoshi,
+			     "msatoshi", &msatoshi,
 			     "label", &label,
 			     "description", &desc,
 			     "?expiry", &exp,
 			     NULL)) {
-		command_fail(cmd, "Need {amount}, {label} and {description}");
+		command_fail(cmd, "Need {msatoshi}, {label} and {description}");
 		return;
 	}
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -530,6 +530,6 @@ static const struct json_command listpayments_command = {
 	"listpayments",
 	json_listpayments,
 	"Get a list of incoming and outgoing payments",
-	"Returns a list of payments with {direction}, {payment_hash}, {destination} if outgoing and {amount}"
+	"Returns a list of payments with {direction}, {payment_hash}, {destination} if outgoing and {msatoshi}"
 };
 AUTODATA(json_command, &listpayments_command);


### PR DESCRIPTION
For `invoice` RPC, use `msatoshi`, since our response uses `msatoshi` anyway, as well as our manfile and online help.  All invoice-related responses use `msatoshi` as field name, not amount.

For `listpayments` RPC, change the online help to use `msatoshi` instead of `amount`, in line with the actual response of `listpayments`.