### PR TITLE
Implement channel pruning specification

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -81,6 +81,8 @@ struct daemon {
 
 	/* To make sure our node_announcement timestamps increase */
 	u32 last_announce_timestamp;
+
+	u32 update_channel_interval;
 };
 
 /* Peers we're trying to reach. */
@@ -1307,13 +1309,11 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 	struct bitcoin_blkid chain_hash;
 	u16 port;
 
-	if (!fromwire_gossipctl_init(daemon, msg, NULL,
-				     &daemon->broadcast_interval,
-				     &chain_hash, &daemon->id, &port,
-				     &daemon->globalfeatures,
-				     &daemon->localfeatures,
-				     &daemon->wireaddrs,
-				     daemon->rgb, daemon->alias)) {
+	if (!fromwire_gossipctl_init(
+		daemon, msg, NULL, &daemon->broadcast_interval, &chain_hash,
+		&daemon->id, &port, &daemon->globalfeatures,
+		&daemon->localfeatures, &daemon->wireaddrs, daemon->rgb,
+		daemon->alias, &daemon->update_channel_interval)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}
 	daemon->rstate = new_routing_state(daemon, &chain_hash, &daemon->id);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1197,6 +1197,14 @@ fail:
 	return -1;
 }
 
+static void gossip_prune_network(struct daemon *daemon)
+{
+	/* Schedule next run now */
+	new_reltimer(&daemon->timers, daemon,
+		     time_from_sec(daemon->update_channel_interval/2),
+		     gossip_prune_network, daemon);
+
+}
 static struct io_plan *connection_in(struct io_conn *conn, struct daemon *daemon)
 {
 	struct wireaddr addr;
@@ -1319,6 +1327,11 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 	daemon->rstate = new_routing_state(daemon, &chain_hash, &daemon->id);
 
 	setup_listeners(daemon, port);
+
+	new_reltimer(&daemon->timers, daemon,
+		     time_from_sec(daemon->update_channel_interval/2),
+		     gossip_prune_network, daemon);
+
 	return daemon_conn_read_next(master->conn, master);
 }
 

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -16,6 +16,7 @@ gossipctl_init,,num_wireaddrs,u16
 gossipctl_init,,wireaddrs,num_wireaddrs*struct wireaddr
 gossipctl_init,,rgb,3*u8
 gossipctl_init,,alias,32*u8
+gossipctl_init,,update_channel_interval,u32
 
 # Master -> gossipd: Optional hint for where to find peer.
 gossipctl_peer_addrhint,3014

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -553,6 +553,7 @@ const struct short_channel_id *handle_channel_announcement(
 
 	tag = type_to_string(pending, struct short_channel_id,
 			     &pending->short_channel_id);
+	tal_resize(&tag, strlen(tag));
 
 	/* BOLT #7:
 	 *
@@ -622,6 +623,7 @@ bool handle_pending_cannouncement(struct routing_state *rstate,
 	list_del_from(&rstate->pending_cannouncement, &pending->list);
 
 	tag = type_to_string(pending, struct short_channel_id, scid);
+	tal_resize(&tag, strlen(tag));
 
 	/* BOLT #7:
 	 *

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -162,12 +162,12 @@ void gossip_init(struct lightningd *ld)
 	if (!ld->gossip)
 		err(1, "Could not subdaemon gossip");
 
-	msg = towire_gossipctl_init(tmpctx, ld->config.broadcast_interval,
-				    &get_chainparams(ld)->genesis_blockhash,
-				    &ld->id, ld->portnum,
-				    get_supported_global_features(tmpctx),
-				    get_supported_local_features(tmpctx),
-				    ld->wireaddrs, ld->rgb, ld->alias);
+	msg = towire_gossipctl_init(
+	    tmpctx, ld->config.broadcast_interval,
+	    &get_chainparams(ld)->genesis_blockhash, &ld->id, ld->portnum,
+	    get_supported_global_features(tmpctx),
+	    get_supported_local_features(tmpctx), ld->wireaddrs, ld->rgb,
+	    ld->alias, ld->config.channel_update_interval);
 	subd_send_msg(ld->gossip, msg);
 	tal_free(tmpctx);
 }

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -68,6 +68,9 @@ struct config {
 
 	/* Disable automatic reconnects */
 	bool no_reconnect;
+
+	/* Channel update interval */
+	u32 channel_update_interval;
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -343,6 +343,9 @@ static const struct config testnet_config = {
 
 	/* Automatically reconnect */
 	.no_reconnect = false,
+
+	/* Send a keepalive update at least every week, prune every twice that */
+	.channel_update_interval = 1209600/2,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -401,6 +404,9 @@ static const struct config mainnet_config = {
 
 	/* Automatically reconnect */
 	.no_reconnect = false,
+
+	/* Send a keepalive update at least every week, prune every twice that */
+	.channel_update_interval = 1209600/2,
 };
 
 static void check_config(struct lightningd *ld)
@@ -521,6 +527,12 @@ void register_opts(struct lightningd *ld)
 			 "RRGGBB hex color for node");
 	opt_register_arg("--alias", opt_set_alias, NULL, ld,
 			 "Up to 32-byte alias for node");
+
+	opt_register_arg(
+	    "--channel-update-interval=<s>", opt_set_u32, opt_show_u32,
+	    &ld->config.channel_update_interval,
+	    "Time in seconds between channel updates for our own channels.");
+
 	opt_register_logging(ld->log);
 	opt_register_version();
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1450,6 +1450,8 @@ class LightningDTests(BaseLightningDTests):
 
         assert scid2 not in [c['short_channel_id'] for c in l1.rpc.getchannels()['channels']]
         assert scid2 not in [c['short_channel_id'] for c in l2.rpc.getchannels()['channels']]
+        assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.getnodes()['nodes']]
+        assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.getnodes()['nodes']]
 
     def ping_tests(self, l1, l2):
         # 0-byte pong gives just type + length field.


### PR DESCRIPTION
Implements the channel pruning recommendation as per BOLT 07. In order to keep the command line options to a minimum it derives a total of 3 intervals out of the `--channel-update-interval` flag:

 - `channel_update_interval`: minimum time between sending `channel_update`s
 - 2x `channel_update_interval`: maximum age that we keep channels around before pruning them from the local view
 - `channel_update_interval`/2: time between pruning runs

By default `channel_update_interval` is set to 1 week, so the maximum age matches the spec.