### PR TITLE
Issue 552

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -918,7 +918,6 @@ static bool peer_save_commitsig_received(struct peer *peer, u64 commitnum,
 	/* Update peer->last_sig and peer->last_tx before saving to db */
 	peer_last_tx(peer, tx, commit_sig);
 
-	wallet_channel_save(peer->ld->wallet, peer->channel, 0);
 	return true;
 }
 
@@ -992,10 +991,11 @@ void peer_sending_commitsig(struct peer *peer, const u8 *msg)
 	if (!peer_save_commitsig_sent(peer, commitnum))
 		return;
 
-	/* Last was commit.  FIXME: Save to db. */
+	/* Last was commit. */
 	peer->last_was_revoke = false;
 	tal_free(peer->last_sent_commit);
 	peer->last_sent_commit = tal_steal(peer, changed_htlcs);
+	wallet_channel_save(peer->ld->wallet, peer->channel, 0);
 
 	/* Tell it we've got it, and to go ahead with commitment_signed. */
 	subd_send_msg(peer->owner,
@@ -1134,6 +1134,8 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 
 	if (!peer_save_commitsig_received(peer, commitnum, tx, &commit_sig))
 		return;
+
+	wallet_channel_save(peer->ld->wallet, peer->channel, 0);
 
 	/* FIXME: Put these straight in the db! */
 	tal_free(peer->last_htlc_sigs);

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -156,6 +156,7 @@ char *dbmigrations[] = {
     "ALTER TABLE invoices ADD COLUMN msatoshi_received INTEGER;",
     /* Normally impossible, so at least we'll know if databases are ancient. */
     "UPDATE invoices SET msatoshi_received=0 WHERE state=1;",
+    "ALTER TABLE channels ADD COLUMN last_was_revoke INTEGER;",
     NULL,
 };
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -281,6 +281,8 @@ static bool channelseq(struct wallet_channel *c1, struct wallet_channel *c2)
 		CHECK(p1->local_shutdown_idx == p2->local_shutdown_idx);
 	}
 
+	CHECK(p1->last_was_revoke == p2->last_was_revoke);
+
 	return true;
 }
 
@@ -373,6 +375,7 @@ static bool test_channel_crud(const tal_t *ctx)
 
 	/* Variant 3: update with our_satoshi set */
 	c1.peer->our_msatoshi = &msat;
+	c1.peer->last_was_revoke = !c1.peer->last_was_revoke;
 
 	wallet_channel_save(w, &c1, 0);
 	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));


### PR DESCRIPTION
Adds a single new `wallet_channel_save` call when sending a commitsig, and hoists another call up into the caller. Persists `peer->last_was_revoke` to DB.

Fixes #552 
