### PR TITLE
Fix unitialized fields in htlc_out constructed from wallet database entry

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1049,6 +1049,9 @@ static bool wallet_stmt2htlc_out(const struct wallet_channel *channel,
 	 * htlcs, will wire using origin_htlc_id */
 	out->in = NULL;
 
+	out->pay_command = NULL;
+	out->payment = NULL;
+
 	return ok;
 }
 


### PR DESCRIPTION
I ran into a segfault on de-reference of an uninitialized `pay_command` pointer and I found that htlc_out structures constructed from database did not initialize all fields.

I this PR I have added NULL inits for the missing fields assuming there is nothing else sensible that should be put there. An other option could be to memset the new htlc_out to zero before filling it in so that when the htlc_out structure is modified nothing has to be changed again here.

```
valgrind --tool=memcheck --leak-check=full --error-limit=no --num-callers=50 --malloc-fill=aa --free-fill=55 --log-file="vg_lightningd.log.%p"  lightningd/lightningd --network=testnet --log-level=debug --bitcoin-datadir /storage/testnet 

==12520== Memcheck, a memory error detector
==12520== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==12520== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==12520== Command: lightningd/lightningd --network=testnet --log-level=debug --bitcoin-datadir /storage/testnet
==12520== Parent PID: 28607
==12520== 
==12520== Use of uninitialised value of size 8
==12520==    at 0x414178: json_pay_failed (pay.c:57)
==12520==    by 0x41431D: payment_failed (pay.c:89)
==12520==    by 0x41FC20: onchain_failed_our_htlc (peer_htlcs.c:783)
==12520==    by 0x418D70: handle_missing_htlc_output (peer_control.c:1197)
==12520==    by 0x41918A: onchain_msg (peer_control.c:1311)
==12520==    by 0x423037: sd_msg_read (subd.c:474)
==12520==    by 0x4564F0: next_plan (io.c:59)
==12520==    by 0x456FC7: do_plan (io.c:387)
==12520==    by 0x457005: io_ready (io.c:397)
==12520==    by 0x4588C3: io_loop (poll.c:305)
==12520==    by 0x40F234: main (lightningd.c:350)
==12520== 
==12520== Invalid read of size 8
==12520==    at 0x414178: json_pay_failed (pay.c:57)
==12520==    by 0x41431D: payment_failed (pay.c:89)
==12520==    by 0x41FC20: onchain_failed_our_htlc (peer_htlcs.c:783)
==12520==    by 0x418D70: handle_missing_htlc_output (peer_control.c:1197)
==12520==    by 0x41918A: onchain_msg (peer_control.c:1311)
==12520==    by 0x423037: sd_msg_read (subd.c:474)
==12520==    by 0x4564F0: next_plan (io.c:59)
==12520==    by 0x456FC7: do_plan (io.c:387)
==12520==    by 0x457005: io_ready (io.c:397)
==12520==    by 0x4588C3: io_loop (poll.c:305)
==12520==    by 0x40F234: main (lightningd.c:350)
==12520==  Address 0xaaaaaaaaaaaaaafa is not stack'd, malloc'd or (recently) free'd
==12520== 
==12520== Jump to the invalid address stated on the next line
==12520==    at 0x0: ???
==12520==    by 0x4813A6: backtrace_full (backtrace.c:127)
==12520==    by 0x4107EF: log_crash (log.c:436)
==12520==    by 0x535A4AF: ??? (in /lib/x86_64-linux-gnu/libc-2.23.so)
==12520==    by 0x414177: json_pay_failed (pay.c:57)
==12520==    by 0x41431D: payment_failed (pay.c:89)
==12520==    by 0x41FC20: onchain_failed_our_htlc (peer_htlcs.c:783)
==12520==    by 0x418D70: handle_missing_htlc_output (peer_control.c:1197)
==12520==    by 0x41918A: onchain_msg (peer_control.c:1311)
==12520==    by 0x423037: sd_msg_read (subd.c:474)
==12520==    by 0x4564F0: next_plan (io.c:59)
==12520==    by 0x456FC7: do_plan (io.c:387)
==12520==    by 0x457005: io_ready (io.c:397)
==12520==    by 0x4588C3: io_loop (poll.c:305)
==12520==    by 0x40F234: main (lightningd.c:350)
==12520==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==12520== 
==12520== 
==12520== Process terminating with default action of signal 11 (SIGSEGV)
==12520==  Bad permissions for mapped region at address 0x0
==12520==    at 0x0: ???
==12520==    by 0x4813A6: backtrace_full (backtrace.c:127)
==12520==    by 0x4107EF: log_crash (log.c:436)
==12520==    by 0x535A4AF: ??? (in /lib/x86_64-linux-gnu/libc-2.23.so)
==12520==    by 0x414177: json_pay_failed (pay.c:57)
==12520==    by 0x41431D: payment_failed (pay.c:89)
==12520==    by 0x41FC20: onchain_failed_our_htlc (peer_htlcs.c:783)
==12520==    by 0x418D70: handle_missing_htlc_output (peer_control.c:1197)
==12520==    by 0x41918A: onchain_msg (peer_control.c:1311)
==12520==    by 0x423037: sd_msg_read (subd.c:474)
==12520==    by 0x4564F0: next_plan (io.c:59)
==12520==    by 0x456FC7: do_plan (io.c:387)
==12520==    by 0x457005: io_ready (io.c:397)
==12520==    by 0x4588C3: io_loop (poll.c:305)
==12520==    by 0x40F234: main (lightningd.c:350)
==12520== 
```