### PR TITLE
bitcoind: properly handle spent outputs in gettxout

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -432,7 +432,9 @@ static void process_gettxout(struct bitcoin_cli *bcli)
 	struct bitcoin_tx_output out;
 	bool valid;
 
-	if (*bcli->exitstatus != 0) {
+	/* As of at least v0.15.1.0, bitcoind returns "success" but an empty
+	   string on a spent gettxout */
+	if (*bcli->exitstatus != 0 || bcli->output_bytes == 0) {
 		log_debug(bcli->bitcoind->log, "%s: not unspent output?",
 			  bcli_args(bcli));
 		tal_free(go);


### PR DESCRIPTION
exit status is not enough to detect spent outputs. gettxout will return a
success exit code and 0 bytes.

Almost Fixies #589, but there is still one more place it crashes after this patch