### PR TITLE
Avoid segfault on CLI command "dev-memleak" when $LIGHTNINGD_DEV_MEMLEAK is not set

### DIFF
--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -144,9 +144,11 @@ static void json_memleak(struct command *cmd,
 {
 	struct json_result *response = new_json_result(cmd);
 
-	if (!getenv("LIGHTNINGD_DEV_MEMLEAK"))
+	if (!getenv("LIGHTNINGD_DEV_MEMLEAK")) {
 		command_fail(cmd,
 			     "Leak detection needs $LIGHTNINGD_DEV_MEMLEAK");
+		return;
+	}
 
 	json_object_start(response, NULL);
 	scan_mem(cmd, response, cmd->ld);


### PR DESCRIPTION
Avoid segfault on CLI command `dev-memleak` when `$LIGHTNINGD_DEV_MEMLEAK` is not set.

Before this patch:

```
$ cli/lightning-cli dev-memleak
lightning-cli: Non-object response ''
$ cli/lightning-cli dev-memleak
lightning-cli: Connecting to 'lightning-rpc': Connection refused
```

After this patch:

```
$ cli/lightning-cli dev-memleak
"Leak detection needs $LIGHTNINGD_DEV_MEMLEAK"
$ cli/lightning-cli dev-memleak
"Leak detection needs $LIGHTNINGD_DEV_MEMLEAK"
```
