### PR TITLE
Use correct description for the "help" CLI command. 

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -241,7 +241,7 @@ static void json_crash(struct command *cmd,
 static const struct json_command dev_crash_command = {
 	"dev-crash",
 	json_crash,
-	"Call fatal().",
+	"Call fatal()",
 	"Simple crash test for developers"
 };
 AUTODATA(json_command, &dev_crash_command);

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -51,8 +51,8 @@ static void json_help(struct command *cmd,
 static const struct json_command help_command = {
 	"help",
 	json_help,
-	"describe commands",
-	"[<command>] if specified gives details about a single command."
+	"List available commands",
+	"Returns an array of available commands",
 };
 AUTODATA(json_command, &help_command);
 


### PR DESCRIPTION
* Use correct description for the `help` CLI command
* Use consistent formatting for CLI command descriptions