### PR TITLE
Fix double free of message buffer.

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -208,11 +208,11 @@ void peer_fail_permanent(struct peer *peer, const char *fmt, ...)
 	}
 
 	peer_set_owner(peer, NULL);
-	if (peer_persists(peer))
+	if (peer_persists(peer)) {
 		drop_to_chain(peer);
-	else
+		tal_free(why);
+	} else
 		free_peer(peer, why);
-	tal_free(why);
 }
 
 void peer_internal_error(struct peer *peer, const char *fmt, ...)


### PR DESCRIPTION
Fixes #600 

Message buffer `why` is allocated in the `peer` context and also freed when peer is freed.
Only explicitly free the buffer when peer itself is not freed yet.