### PR TITLE
pay: remove gratuitous check for msatoshitok being 'null'.

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -444,7 +444,7 @@ static void json_pay(struct command *cmd,
 
 	if (b11->msatoshi) {
 		msatoshi = *b11->msatoshi;
-		if (msatoshitok && !json_tok_is_null(buffer, msatoshitok)) {
+		if (msatoshitok) {
 			command_fail(cmd, "msatoshi parameter unnecessary");
 			return;
 		}


### PR DESCRIPTION
json_get_params does this for us.

Fixes: 78adf0b (pay: allow 'null' msatoshi field.)
Reported-by: ZmnSCPxj
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>