### PR TITLE
Avoid segfault on CLI command "decodepay 1111111" (invalid short bech32 string)

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -474,6 +474,9 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
 
         b11->routes = tal_arr(b11, struct route_info *, 0);
 
+        if (strlen(str) < 8)
+                return decode_fail(b11, fail, "Bad bech32 string");
+
         hrp = tal_arr(tmpctx, char, strlen(str) - 6);
         data = tal_arr(tmpctx, u5, strlen(str) - 8);
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -627,6 +627,8 @@ class LightningDTests(BaseLightningDTests):
         assert b11['fallback']['type'] == 'P2WSH'
         assert b11['fallback']['addr'] == 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3'
 
+        self.assertRaises(ValueError, l1.rpc.decodepay, '1111111')
+
     def test_sendpay(self):
         l1,l2 = self.connect()
 


### PR DESCRIPTION
Avoid segfault on CLI command `decodepay 1111111` (invalid short bech32 string).

Before this patch:

```
$ cli/lightning-cli decodepay 1111111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 111111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 11111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 1111111
lightning-cli: Non-object response ''
$ cli/lightning-cli decodepay 1111111
lightning-cli: Connecting to 'lightning-rpc': Connection refused
```

After this patch:

```
$ cli/lightning-cli decodepay 1111111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 111111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 11111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 1111111
"Invalid bolt11: Bad bech32 string"
$ cli/lightning-cli decodepay 1111111
"Invalid bolt11: Bad bech32 string"
```