### PR TITLE
channeld: --ignore-fee-limits as a hack for fee disparities.

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -624,6 +624,9 @@ static void handle_peer_feechange(struct peer *peer, const u8 *msg)
 			    &peer->channel_id,
 			    "update_fee from non-funder?");
 
+	status_trace("update_fee %u, range %u-%u",
+		     feerate, peer->feerate_min, peer->feerate_max);
+
 	/* BOLT #2:
 	 *
 	 * A receiving node SHOULD fail the channel if the `update_fee` is too

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -71,6 +71,9 @@ struct config {
 
 	/* Channel update interval */
 	u32 channel_update_interval;
+
+	/* Do we let the funder set any fee rate they want */
+	bool ignore_fee_limits;
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -204,6 +204,9 @@ static char *opt_set_fee_rates(const char *arg, struct chain_topology *topo)
 
 static void config_register_opts(struct lightningd *ld)
 {
+	opt_register_arg("--ignore-fee-limits", opt_set_bool_arg, opt_show_bool,
+			 &ld->config.ignore_fee_limits,
+			 "(DANGEROUS) allow peer to set any feerate");
 	opt_register_arg("--locktime-blocks", opt_set_u32, opt_show_u32,
 			 &ld->config.locktime_blocks,
 			 "Blocks before peer can unilaterally spend funds");
@@ -346,6 +349,9 @@ static const struct config testnet_config = {
 
 	/* Send a keepalive update at least every week, prune every twice that */
 	.channel_update_interval = 1209600/2,
+
+	/* Testnet sucks */
+	.ignore_fee_limits = true,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -407,6 +413,9 @@ static const struct config mainnet_config = {
 
 	/* Send a keepalive update at least every week, prune every twice that */
 	.channel_update_interval = 1209600/2,
+
+	/* Mainnet should have more stable fees */
+	.ignore_fee_limits = false,
 };
 
 static void check_config(struct lightningd *ld)

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -220,4 +220,9 @@ void setup_listeners(struct lightningd *ld);
 void activate_peers(struct lightningd *ld);
 
 void free_htlcs(struct lightningd *ld, const struct peer *peer);
+
+/* Get range of feerates to insist other side abide by for normal channels. */
+u32 feerate_min(struct lightningd *ld);
+u32 feerate_max(struct lightningd *ld);
+
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1501,15 +1501,11 @@ void notify_feerate_change(struct lightningd *ld)
 		if (!peer->owner)
 			continue;
 
-		/* FIXME: low bound is probably too low. */
 		msg = towire_channel_feerates(peer,
 					      get_feerate(ld->topology,
 							  FEERATE_IMMEDIATE),
-					      get_feerate(ld->topology,
-							  FEERATE_NORMAL) / 2,
-					      get_feerate(ld->topology,
-							  FEERATE_IMMEDIATE)
-					      * 5);
+					      feerate_min(ld),
+					      feerate_max(ld));
 		subd_send_msg(peer->owner, take(msg));
 	}
 }

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2709,6 +2709,7 @@ class LightningDTests(BaseLightningDTests):
         l1.daemon.wait_for_log('onchaind complete, forgetting peer')
         l2.daemon.wait_for_log('onchaind complete, forgetting peer')
 
+    @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_fee_limits(self):
         # FIXME: Test case where opening denied.
         l1, l2 = self.connect()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -244,7 +244,8 @@ class LightningD(TailableProc):
             '--lightning-dir={}'.format(lightning_dir),
             '--port={}'.format(port),
             '--override-fee-rates=15000/7500/1000',
-            '--network=regtest'
+            '--network=regtest',
+            '--ignore-fee-limits=false'
         ]
         if DEVELOPER:
             self.cmd_line += ['--dev-broadcast-interval=1000']


### PR DESCRIPTION
This, of course, should never be used.  But it helps maintain connections
for the moment while we dig deeper into feerates.
