### PR TITLE
withdraw: Swap 'satoshi' and 'destination' params to match online help.

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -306,7 +306,7 @@ static void json_withdraw(struct command *cmd,
 static const struct json_command withdraw_command = {
 	"withdraw",
 	json_withdraw,
-	"Send {satoshi} (or 'all') to the {destination} address via Bitcoin transaction",
+	"Send to {destination} address {satoshi} (or 'all') amount via Bitcoin transaction",
 	"Returns the withdrawal transaction ID"
 };
 AUTODATA(json_command, &withdraw_command);


### PR DESCRIPTION
Fixes #620 

Note that this reverses the 'satoshi' and 'destination' params in the 'withdraw' rpc method to match the online help.

I think this order makes more sense, but it's an API change. Hopefully we're at a stage where that is still OK.