### PR TITLE
Json api cleanup

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -79,9 +79,9 @@ class LightningRpc(UnixDomainSocketRpc):
         """Get info about a specific peer, optionally with its log.
         """
         if log_level:
-            peers = self.getpeers(log_level)['peers']
+            peers = self.listpeers(log_level)['peers']
         else:
-            peers = self.getpeers()['peers']
+            peers = self.listpeers()['peers']
         for p in peers:
             if p['peerid'] == peer_id:
                 return p

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -79,13 +79,12 @@ class LightningRpc(UnixDomainSocketRpc):
         """Get info about a specific peer, optionally with its log.
         """
         if log_level:
-            peers = self.listpeers(log_level)['peers']
+            peers = self.listpeers(peer_id, log_level)['peers']
         else:
-            peers = self.listpeers()['peers']
-        for p in peers:
-            if p['peerid'] == peer_id:
-                return p
-        return None
+            peers = self.listpeers(peer_id)['peers']
+        if len(peers) == 0:
+            return None
+        return peers[0]
 
     def getlog(self, level=None):
         args = []

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-delinvoice.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
-	doc/lightning-listinvoice.7 \
+	doc/lightning-listinvoices.7 \
 	doc/lightning-listpayments.7 \
 	doc/lightning-pay.7 \
 	doc/lightning-sendpay.7 \

--- a/doc/lightning-delinvoice.7
+++ b/doc/lightning-delinvoice.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-delinvoice
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/13/2018
+.\"      Date: 01/18/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-DELINVOIC" "7" "01/13/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-DELINVOIC" "7" "01/18/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,13 +28,15 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-lightning-delinvoice \- Protocol for removing an unpaid invoice\&.
+lightning-delinvoice \- Protocol for removing an invoice\&.
 .SH "SYNOPSIS"
 .sp
-\fBdelinvoice\fR \fIlabel\fR
+\fBdelinvoice\fR \fIlabel\fR \fIstatus\fR
 .SH "DESCRIPTION"
 .sp
-The \fBdelinvoice\fR RPC command removes an unpaid invoice\&. The caller should be particularly aware of the error case caused by a payment just before this command is invoked!
+The \fBdelinvoice\fR RPC command removes an invoice with \fIstatus\fR as given in \fBlistinvoices\fR\&.
+.sp
+The caller should be particularly aware of the error case caused by the \fIstatus\fR chaning just before this command is invoked!
 .SH "RETURN VALUE"
 .sp
 On success, an invoice description will be returned as per lightning\-listinvoice(7)\&.

--- a/doc/lightning-delinvoice.7.txt
+++ b/doc/lightning-delinvoice.7.txt
@@ -4,17 +4,19 @@ LIGHTNING-DELINVOICE(7)
 
 NAME
 ----
-lightning-delinvoice - Protocol for removing an unpaid invoice.
+lightning-delinvoice - Protocol for removing an invoice.
 
 SYNOPSIS
 --------
-*delinvoice* 'label'
+*delinvoice* 'label' 'status'
 
 DESCRIPTION
 -----------
-The *delinvoice* RPC command removes an unpaid invoice.  The caller
-should be particularly aware of the error case caused by a payment
-just before this command is invoked!
+The *delinvoice* RPC command removes an invoice with 'status' as
+given in *listinvoices*.
+
+The caller should be particularly aware of the error case caused by 
+the 'status' chaning just before this command is invoked!
 
 RETURN VALUE
 ------------

--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-getroute
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/13/2018
+.\"      Date: 01/16/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-GETROUTE" "7" "01/13/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-GETROUTE" "7" "01/16/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,10 +31,10 @@
 lightning-getroute \- Protocol for routing a payment (low\-level)\&.
 .SH "SYNOPSIS"
 .sp
-\fBgetroute\fR \fIid\fR \fImsatoshi\fR \fIriskfactor\fR
+\fBgetroute\fR \fIid\fR \fImsatoshi\fR \fIriskfactor\fR [\fIcltv\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBgetroute\fR RPC command attempts to find the best route for the payment of \fImsatoshi\fR to lightning node \fIid\fR\&.
+The \fBgetroute\fR RPC command attempts to find the best route for the payment of \fImsatoshi\fR to lightning node \fIid\fR, such that the payment will arrive at \fIid\fR with \fIcltv\fR\-blocks to spare (default 9)\&.
 .sp
 There are two considerations for how good a route is: how low the fees are, and how long your payment will get stuck if a node goes down during the process\&. The \fIriskfactor\fR floating\-point field controls this tradeoff; it is the annual cost of your funds being stuck (as a percentage), multiplied by the percentage chance of each node failing\&.
 .sp

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -9,12 +9,13 @@ lightning-getroute - Protocol for routing a payment (low-level).
 
 SYNOPSIS
 --------
-*getroute* 'id' 'msatoshi' 'riskfactor'
+*getroute* 'id' 'msatoshi' 'riskfactor' ['cltv']
 
 DESCRIPTION
 -----------
 The *getroute* RPC command attempts to find the best route for the payment
-of 'msatoshi' to lightning node 'id'.
+of 'msatoshi' to lightning node 'id', such that the payment will arrive
+at 'id' with 'cltv'-blocks to spare (default 9).
 
 There are two considerations for how good a route is: how low the
 fees are, and how long your payment will get stuck if a node goes down

--- a/doc/lightning-listinvoices.7
+++ b/doc/lightning-listinvoices.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listinvoices
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/16/2018
+.\"      Date: 01/18/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTINVOI" "7" "01/16/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTINVOI" "7" "01/18/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ lightning-listinvoices \- Protocol for querying invoice status
 The \fBlistinvoices\fR RPC command gets the status of a specific invoice, if it exists, or the status of all invoices if given no argument\&.
 .SH "RETURN VALUE"
 .sp
-On success, an array \fIinvoices\fR of objects is returned\&. Each object contains \fIlabel\fR, \fIpayment_hash, \*(Aqcomplete\fR (a boolean), and \fIexpiry_time\fR (a UNIX timestamp)\&. If the \fImsatoshi\fR argument to lightning\-invoice(7) was not "any", there will be an \fImsatoshi\fR field\&. If the invoice has been paid, there will be a \fIpay_index\fR field and an \fImsatoshi_received\fR field (which may be slightly greater than \fImsatoshi\fR as some overpaying is permitted to allow clients to obscure payment paths)\&.
+On success, an array \fIinvoices\fR of objects is returned\&. Each object contains \fIlabel\fR, \fIpayment_hash\fR, \fIstatus\fR (one of \fIunpaid\fR, \fIpaid\fR or \fIexpired\fR), and \fIexpiry_time\fR (a UNIX timestamp)\&. If the \fImsatoshi\fR argument to lightning\-invoice(7) was not "any", there will be an \fImsatoshi\fR field\&. If the invoice \fIstatus\fR is \fIpaid\fR, there will be a \fIpay_index\fR field and an \fImsatoshi_received\fR field (which may be slightly greater than \fImsatoshi\fR as some overpaying is permitted to allow clients to obscure payment paths)\&.
 .SH "AUTHOR"
 .sp
 Rusty Russell <rusty@rustcorp\&.com\&.au> is mainly responsible\&.

--- a/doc/lightning-listinvoices.7
+++ b/doc/lightning-listinvoices.7
@@ -1,13 +1,13 @@
 '\" t
-.\"     Title: lightning-listinvoice
+.\"     Title: lightning-listinvoices
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/13/2018
+.\"      Date: 01/16/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTINVOI" "7" "01/13/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTINVOI" "7" "01/16/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,13 +28,13 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-lightning-listinvoice \- Protocol for querying invoice status
+lightning-listinvoices \- Protocol for querying invoice status
 .SH "SYNOPSIS"
 .sp
-\fBlistinvoice\fR [\fIlabel\fR]
+\fBlistinvoices\fR [\fIlabel\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBlistinvoice\fR RPC command gets the status of a specific invoice, if it exists, or the status of all invoices if given no argument\&.
+The \fBlistinvoices\fR RPC command gets the status of a specific invoice, if it exists, or the status of all invoices if given no argument\&.
 .SH "RETURN VALUE"
 .sp
 On success, an array \fIinvoices\fR of objects is returned\&. Each object contains \fIlabel\fR, \fIpayment_hash, \*(Aqcomplete\fR (a boolean), and \fIexpiry_time\fR (a UNIX timestamp)\&. If the \fImsatoshi\fR argument to lightning\-invoice(7) was not "any", there will be an \fImsatoshi\fR field\&. If the invoice has been paid, there will be a \fIpay_index\fR field and an \fImsatoshi_received\fR field (which may be slightly greater than \fImsatoshi\fR as some overpaying is permitted to allow clients to obscure payment paths)\&.

--- a/doc/lightning-listinvoices.7.txt
+++ b/doc/lightning-listinvoices.7.txt
@@ -17,7 +17,7 @@ it exists, or the status of all invoices if given no argument.
 
 RETURN VALUE
 ------------
-On success, an array 'invoices' of objects is returned.  Each object contains 'label', 'payment_hash, 'complete' (a boolean), and 'expiry_time' (a UNIX timestamp).  If the 'msatoshi' argument to lightning-invoice(7) was not "any", there will be an 'msatoshi' field. If the invoice has been paid, there will be a 'pay_index' field and an 'msatoshi_received' field (which may be slightly greater than 'msatoshi' as some overpaying is permitted to allow clients to obscure payment paths).
+On success, an array 'invoices' of objects is returned.  Each object contains 'label', 'payment_hash', 'status' (one of 'unpaid', 'paid' or 'expired'), and 'expiry_time' (a UNIX timestamp).  If the 'msatoshi' argument to lightning-invoice(7) was not "any", there will be an 'msatoshi' field. If the invoice 'status' is 'paid', there will be a 'pay_index' field and an 'msatoshi_received' field (which may be slightly greater than 'msatoshi' as some overpaying is permitted to allow clients to obscure payment paths).
 
 //FIXME:Enumerate errors
 

--- a/doc/lightning-listinvoices.7.txt
+++ b/doc/lightning-listinvoices.7.txt
@@ -1,18 +1,18 @@
-LIGHTNING-LISTINVOICE(7)
-========================
+LIGHTNING-LISTINVOICES(7)
+=========================
 :doctype: manpage
 
 NAME
 ----
-lightning-listinvoice - Protocol for querying invoice status
+lightning-listinvoices - Protocol for querying invoice status
 
 SYNOPSIS
 --------
-*listinvoice* ['label']
+*listinvoices* ['label']
 
 DESCRIPTION
 -----------
-The *listinvoice* RPC command gets the status of a specific invoice, if
+The *listinvoices* RPC command gets the status of a specific invoice, if
 it exists, or the status of all invoices if given no argument.
 
 RETURN VALUE

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1066,11 +1066,19 @@ static struct io_plan *getchannels_req(struct io_conn *conn, struct daemon *daem
 	struct gossip_getchannels_entry *entries;
 	struct node *n;
 	struct node_map_iter i;
+	struct short_channel_id *scid;
+
+	fromwire_gossip_getchannels_request(msg, msg, NULL, &scid);
 
 	entries = tal_arr(tmpctx, struct gossip_getchannels_entry, num_chans);
 	n = node_map_first(daemon->rstate->nodes, &i);
 	while (n != NULL) {
 		for (j=0; j<tal_count(n->out); j++){
+			if (scid &&
+			    !short_channel_id_eq(scid,
+						 &n->out[j]->short_channel_id)) {
+				continue;
+			}
 			tal_resize(&entries, num_chans + 1);
 			entries[num_chans].source = n->out[j]->src->id;
 			entries[num_chans].destination = n->out[j]->dst->id;

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1733,11 +1733,14 @@ static struct io_plan *get_peers(struct io_conn *conn,
 	size_t n = 0;
 	struct pubkey *id = tal_arr(conn, struct pubkey, n);
 	struct wireaddr *wireaddr = tal_arr(conn, struct wireaddr, n);
+	struct pubkey *specific_id = NULL;
 
-	if (!fromwire_gossip_getpeers_request(msg, NULL))
+	if (!fromwire_gossip_getpeers_request(msg, msg, NULL, &specific_id))
 		master_badmsg(WIRE_GOSSIPCTL_PEER_ADDRHINT, msg);
 
 	list_for_each(&daemon->peers, peer, list) {
+		if (specific_id && !pubkey_eq(specific_id, &peer->id))
+			continue;
 		tal_resize(&id, n+1);
 		tal_resize(&wireaddr, n+1);
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1101,7 +1101,15 @@ static void append_node(struct gossip_getnodes_entry **nodes,
 	size_t num_nodes = tal_count(*nodes);
 	tal_resize(nodes, num_nodes + 1);
 	(*nodes)[num_nodes].nodeid = n->id;
+	(*nodes)[num_nodes].last_timestamp = n->last_timestamp;
+	if (n->last_timestamp < 0) {
+		(*nodes)[num_nodes].addresses = NULL;
+		return;
+	}
+
 	(*nodes)[num_nodes].addresses = n->addresses;
+	(*nodes)[num_nodes].alias = n->alias;
+	memcpy((*nodes)[num_nodes].color, n->rgb_color, 3);
 }
 
 static struct io_plan *getnodes(struct io_conn *conn, struct daemon *daemon,

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -105,6 +105,9 @@ gossip_getroute_reply,,num_hops,u16
 gossip_getroute_reply,,hops,num_hops*struct route_hop
 
 gossip_getchannels_request,3007
+# In practice, 0 or 1.
+gossip_getchannels_request,,num,u16
+gossip_getchannels_request,,short_channel_id,num*struct short_channel_id
 
 gossip_getchannels_reply,3107
 gossip_getchannels_reply,,num_channels,u16

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -83,6 +83,9 @@ gossipctl_hand_back_peer,,msg,len*u8
 
 # Pass JSON-RPC getnodes call through
 gossip_getnodes_request,3005
+# Can be 0 or 1 currently
+gossip_getnodes_request,,num,u16
+gossip_getnodes_request,,id,num*struct pubkey
 
 #include <lightningd/gossip_msg.h>
 gossip_getnodes_reply,3105

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -135,6 +135,9 @@ gossip_resolve_channel_reply,,keys,num_keys*struct pubkey
 
 # The main daemon asks for peers
 gossip_getpeers_request,3011
+# 0 or 1
+gossip_getpeers_request,,num,u16
+gossip_getpeers_request,,id,num*struct pubkey
 
 gossip_getpeers_reply,3111
 gossip_getpeers_reply,,num,u16

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -934,6 +934,8 @@ void handle_node_announcement(
 	node->last_timestamp = timestamp;
 
 	memcpy(node->rgb_color, rgb_color, 3);
+	tal_free(node->alias);
+	node->alias = tal_dup_arr(node, u8, alias, 32, 0);
 
 	u8 *tag = tal_arr(tmpctx, u8, 0);
 	towire_pubkey(&tag, &node_id);

--- a/lightningd/dev_ping.c
+++ b/lightningd/dev_ping.c
@@ -40,17 +40,17 @@ static void json_dev_ping(struct command *cmd,
 {
 	struct peer *peer;
 	u8 *msg;
-	jsmntok_t *peeridtok, *lentok, *pongbytestok;
+	jsmntok_t *idtok, *lentok, *pongbytestok;
 	unsigned int len, pongbytes;
 	struct pubkey id;
 	struct subd *owner;
 
 	if (!json_get_params(buffer, params,
-			     "peerid", &peeridtok,
+			     "id", &idtok,
 			     "len", &lentok,
 			     "pongbytes", &pongbytestok,
 			     NULL)) {
-		command_fail(cmd, "Need peerid, len and pongbytes");
+		command_fail(cmd, "Need id, len and pongbytes");
 		return;
 	}
 
@@ -70,10 +70,10 @@ static void json_dev_ping(struct command *cmd,
 		return;
 	}
 
-	if (!json_tok_pubkey(buffer, peeridtok, &id)) {
+	if (!json_tok_pubkey(buffer, idtok, &id)) {
 		command_fail(cmd, "'%.*s' is not a valid pubkey",
-			     (int)(peeridtok->end - peeridtok->start),
-			     buffer + peeridtok->start);
+			     (int)(idtok->end - idtok->start),
+			     buffer + idtok->start);
 		return;
 	}
 
@@ -102,7 +102,7 @@ static void json_dev_ping(struct command *cmd,
 static const struct json_command dev_ping_command = {
 	"dev-ping",
 	json_dev_ping,
-	"Offer {peerid} a ping of length {len} asking for {pongbytes}",
+	"Offer {id} a ping of length {len} asking for {pongbytes}",
 	"Returns { totlen: u32 } on success"
 };
 AUTODATA(json_command, &dev_ping_command);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -4,6 +4,7 @@
 #include "lightningd.h"
 #include "peer_control.h"
 #include "subd.h"
+#include <ccan/array_size/array_size.h>
 #include <ccan/err/err.h>
 #include <ccan/fdpass/fdpass.h>
 #include <ccan/take/take.h>
@@ -199,6 +200,17 @@ static void json_getnodes_reply(struct subd *gossip, const u8 *reply,
 	for (i = 0; i < tal_count(nodes); i++) {
 		json_object_start(response, NULL);
 		json_add_pubkey(response, "nodeid", &nodes[i].nodeid);
+		if (nodes[i].last_timestamp < 0) {
+			json_object_end(response);
+			continue;
+		}
+		json_add_string(response, "alias",
+				tal_strndup(response, (char *)nodes[i].alias,
+					    tal_len(nodes[i].alias)));
+		json_add_hex(response, "color",
+			     nodes[i].color, ARRAY_SIZE(nodes[i].color));
+		json_add_u64(response, "last_timestamp",
+			     nodes[i].last_timestamp);
 		json_array_start(response, "addresses");
 		for (j=0; j<tal_count(nodes[i].addresses); j++) {
 			json_add_address(response, NULL, &nodes[i].addresses[j]);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -342,7 +342,7 @@ static const struct json_command getroute_command = {
 AUTODATA(json_command, &getroute_command);
 
 /* Called upon receiving a getchannels_reply from `gossipd` */
-static void json_getchannels_reply(struct subd *gossip, const u8 *reply,
+static void json_listchannels_reply(struct subd *gossip, const u8 *reply,
 				   const int *fds, struct command *cmd)
 {
 	size_t i;
@@ -383,16 +383,16 @@ static void json_getchannels_reply(struct subd *gossip, const u8 *reply,
 	command_success(cmd, response);
 }
 
-static void json_getchannels(struct command *cmd, const char *buffer,
+static void json_listchannels(struct command *cmd, const char *buffer,
 			     const jsmntok_t *params)
 {
 	u8 *req = towire_gossip_getchannels_request(cmd);
 	subd_req(cmd->ld->gossip, cmd->ld->gossip,
-		 req, -1, 0, json_getchannels_reply, cmd);
+		 req, -1, 0, json_listchannels_reply, cmd);
 	command_still_pending(cmd);
 }
 
-static const struct json_command getchannels_command = {
-    "getchannels", json_getchannels, "List all known channels.",
+static const struct json_command listchannels_command = {
+    "listchannels", json_listchannels, "List all known channels.",
     "Returns a 'channels' array with all known channels including their fees."};
-AUTODATA(json_command, &getchannels_command);
+AUTODATA(json_command, &listchannels_command);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -6,6 +6,13 @@ void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *m
 {
 	u8 numaddresses, i;
 	fromwire_pubkey(pptr, max, &entry->nodeid);
+	entry->last_timestamp = fromwire_u64(pptr, max);
+
+	if (entry->last_timestamp < 0) {
+		entry->addresses = NULL;
+		entry->alias = NULL;
+		return;
+	}
 	numaddresses = fromwire_u8(pptr, max);
 
 	entry->addresses = tal_arr(ctx, struct wireaddr, numaddresses);
@@ -16,16 +23,26 @@ void fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *m
 			return;
 		}
 	}
+	entry->alias = tal_arr(ctx, u8, fromwire_u8(pptr, max));
+	fromwire(pptr, max, entry->alias, tal_len(entry->alias));
+	fromwire(pptr, max, entry->color, sizeof(entry->color));
 }
 void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry)
 {
 	u8 i, numaddresses = tal_count(entry->addresses);
 	towire_pubkey(pptr, &entry->nodeid);
-	towire_u8(pptr, numaddresses);
+	towire_u64(pptr, entry->last_timestamp);
 
+	if (entry->last_timestamp < 0)
+		return;
+
+	towire_u8(pptr, numaddresses);
 	for (i=0; i<numaddresses; i++) {
 		towire_wireaddr(pptr, &entry->addresses[i]);
 	}
+	towire_u8(pptr, tal_len(entry->alias));
+	towire(pptr, entry->alias, tal_len(entry->alias));
+	towire(pptr, entry->color, sizeof(entry->color));
 }
 
 void fromwire_route_hop(const u8 **pptr, size_t *max, struct route_hop *entry)

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -6,7 +6,10 @@
 
 struct gossip_getnodes_entry {
 	struct pubkey nodeid;
+	s64 last_timestamp; /* -1 means never: following fields ignored */
 	struct wireaddr *addresses;
+	u8 *alias;
+	u8 color[3];
 };
 
 struct gossip_getchannels_entry {

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -411,6 +411,8 @@ static void json_decodepay(struct command *cmd,
                 json_add_hex(response, "description_hash",
                              b11->description_hash,
                              sizeof(*b11->description_hash));
+	json_add_num(response, "min_final_cltv_expiry",
+		     b11->min_final_cltv_expiry);
         if (tal_len(b11->fallback)) {
                 struct bitcoin_address pkh;
                 struct ripemd160 sh;

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -45,10 +45,15 @@ static void json_add_invoice(struct json_result *response,
 		json_add_u64(response, "pay_index", inv->pay_index);
 		json_add_u64(response, "msatoshi_received",
 			     inv->msatoshi_received);
-		json_add_u64(response, "paid_timestamp",
-			     inv->paid_timestamp);
+		if (deprecated_apis)
+			json_add_u64(response, "paid_timestamp",
+				     inv->paid_timestamp);
+		json_add_u64(response, "paid_at", inv->paid_timestamp);
 	}
-	json_add_u64(response, "expiry_time", inv->expiry_time);
+	if (deprecated_apis)
+		json_add_u64(response, "expiry_time", inv->expiry_time);
+	json_add_u64(response, "expires_at", inv->expiry_time);
+
 	json_object_end(response);
 }
 
@@ -178,7 +183,9 @@ static void json_invoice(struct command *cmd,
 	json_object_start(response, NULL);
 	json_add_hex(response, "payment_hash",
 		     &invoice->rhash, sizeof(invoice->rhash));
-	json_add_u64(response, "expiry_time", invoice->expiry_time);
+	if (deprecated_apis)
+		json_add_u64(response, "expiry_time", invoice->expiry_time);
+	json_add_u64(response, "expires_at", invoice->expiry_time);
 	json_add_string(response, "bolt11", b11enc);
 	if (b11->description_hash)
 		json_add_string(response, "description", b11->description);
@@ -191,7 +198,7 @@ static const struct json_command invoice_command = {
 	"invoice",
 	json_invoice,
 	"Create invoice for {msatoshi} with {label} and {description} with optional {expiry} seconds (default 1 hour)",
-	"Returns the {payment_hash}, {expiry_time} and {bolt11} on success, and {description} if too large for {bolt11}. "
+	"Returns the {payment_hash}, {expires_at} and {bolt11} on success, and {description} if too large for {bolt11}. "
 };
 AUTODATA(json_command, &invoice_command);
 
@@ -252,7 +259,7 @@ static const struct json_command listinvoice_command = {
 	"listinvoice",
 	json_listinvoice,
 	"(DEPRECATED) Show invoice {label} (or all, if no {label}))",
-	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. ",
+	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expires_time} on success. ",
 	.deprecated = true
 };
 AUTODATA(json_command, &listinvoice_command);
@@ -267,7 +274,7 @@ static const struct json_command listinvoices_command = {
 	"listinvoices",
 	json_listinvoices,
 	"Show invoice {label} (or all, if no {label}))",
-	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. ",
+	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {status}, {pay_index} (if paid) and {expires_at} on success. ",
 };
 AUTODATA(json_command, &listinvoices_command);
 
@@ -326,7 +333,7 @@ static const struct json_command delinvoice_command = {
 	"delinvoice",
 	json_delinvoice,
 	"Delete unpaid invoice {label} with {status}",
-	"Returns {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. "
+	"Returns {label}, {payment_hash}, {msatoshi} (if set), {status}, {pay_index} (if paid) and {expires_at} on success. "
 };
 AUTODATA(json_command, &delinvoice_command);
 
@@ -369,7 +376,7 @@ static const struct json_command waitanyinvoice_command = {
 	"waitanyinvoice",
 	json_waitanyinvoice,
 	"Wait for the next invoice to be paid, after {lastpay_index} (if supplied)))",
-	"Returns {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} and {expiry_time} on success. "
+	"Returns {label}, {payment_hash}, {msatoshi} (if set), {status}, {pay_index} and {expires_at} on success. "
 };
 AUTODATA(json_command, &waitanyinvoice_command);
 
@@ -414,7 +421,7 @@ static const struct json_command waitinvoice_command = {
 	"waitinvoice",
 	json_waitinvoice,
 	"Wait for an incoming payment matching the invoice with {label}",
-	"Returns {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} and {expiry_time} on success"
+	"Returns {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} and {expires_at} on success"
 };
 AUTODATA(json_command, &waitinvoice_command);
 
@@ -454,7 +461,9 @@ static void json_decodepay(struct command *cmd,
 	json_object_start(response, NULL);
 
 	json_add_string(response, "currency", b11->chain->bip173_name);
-	json_add_u64(response, "timestamp", b11->timestamp);
+	if (deprecated_apis)
+		json_add_u64(response, "timestamp", b11->timestamp);
+	json_add_u64(response, "created_at", b11->timestamp);
 	json_add_u64(response, "expiry", b11->expiry);
 	json_add_pubkey(response, "payee", &b11->receiver_id);
         if (b11->msatoshi)

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -222,10 +222,19 @@ static void json_listinvoice(struct command *cmd,
 static const struct json_command listinvoice_command = {
 	"listinvoice",
 	json_listinvoice,
-	"Show invoice {label} (or all, if no {label}))",
-	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. "
+	"(DEPRECATED) Show invoice {label} (or all, if no {label}))",
+	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. ",
+	.deprecated = true
 };
 AUTODATA(json_command, &listinvoice_command);
+
+static const struct json_command listinvoice_command = {
+	"listinvoices",
+	json_listinvoices,
+	"Show invoice {label} (or all, if no {label}))",
+	"Returns an array of {label}, {payment_hash}, {msatoshi} (if set), {complete}, {pay_index} (if paid) and {expiry_time} on success. ",
+};
+AUTODATA(json_command, &listinvoices_command);
 
 static void json_delinvoice(struct command *cmd,
 			    const char *buffer, const jsmntok_t *params)

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -279,7 +279,6 @@ static void json_delinvoice(struct command *cmd,
 	struct json_result *response = new_json_result(cmd);
 	const char *label;
 	struct wallet *wallet = cmd->ld->wallet;
-	bool error;
 
 	if (!json_get_params(buffer, params,
 			     "label", &labeltok,
@@ -300,10 +299,9 @@ static void json_delinvoice(struct command *cmd,
 	 * otherwise the invoice will be freed. */
 	json_add_invoice(response, i, true);
 
-	error = wallet_invoice_delete(wallet, i);
-
-	if (error) {
-		log_broken(cmd->ld->log, "Error attempting to remove invoice %"PRIu64,
+	if (!wallet_invoice_delete(wallet, i)) {
+		log_broken(cmd->ld->log,
+			   "Error attempting to remove invoice %"PRIu64,
 			   i->id);
 		command_fail(cmd, "Database error");
 		return;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -175,7 +175,9 @@ static void json_getlog(struct command *cmd,
 
 	info.response = new_json_result(cmd);
 	json_object_start(info.response, NULL);
-	json_add_time(info.response, "creation_time", log_init_time(lr)->ts);
+	if (deprecated_apis)
+		json_add_time(info.response, "creation_time", log_init_time(lr)->ts);
+	json_add_time(info.response, "created_at", log_init_time(lr)->ts);
 	json_add_num(info.response, "bytes_used", (unsigned int)log_used(lr));
 	json_add_num(info.response, "bytes_max", (unsigned int)log_max_mem(lr));
 	json_array_start(info.response, "log");

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -53,7 +53,7 @@ static const struct json_command help_command = {
 	"help",
 	json_help,
 	"List available commands",
-	"Returns an array of available commands",
+	"Returns an array {help} of available commands",
 };
 AUTODATA(json_command, &help_command);
 
@@ -294,7 +294,8 @@ static void json_help(struct command *cmd,
 	struct json_result *response = new_json_result(cmd);
 	struct json_command **cmdlist = get_cmdlist();
 
-	json_array_start(response, NULL);
+	json_object_start(response, NULL);
+	json_array_start(response, "help");
 	for (i = 0; i < num_cmdlist; i++) {
 		json_add_object(response,
 				"command", JSMN_STRING,
@@ -304,6 +305,7 @@ static void json_help(struct command *cmd,
 				NULL);
 	}
 	json_array_end(response);
+	json_object_end(response);
 	command_success(cmd, response);
 }
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -16,6 +16,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/options.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -521,6 +522,13 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	if (!cmd) {
 		command_fail(jcon->current,
 			     "Unknown command '%.*s'",
+			     (int)(method->end - method->start),
+			     jcon->buffer + method->start);
+		return;
+	}
+	if (cmd->deprecated && !deprecated_apis) {
+		command_fail(jcon->current,
+			     "command '%.*s' is deprecated",
 			     (int)(method->end - method->start),
 			     jcon->buffer + method->start);
 		return;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -387,6 +387,14 @@ void json_add_short_channel_id(struct json_result *response,
 			type_to_string(response, struct short_channel_id, id));
 }
 
+bool json_tok_short_channel_id(const char *buffer, const jsmntok_t *tok,
+			       struct short_channel_id *scid)
+{
+	return short_channel_id_from_str(buffer + tok->start,
+					 tok->end - tok->start,
+					 scid);
+}
+
 void json_add_address(struct json_result *response, const char *fieldname,
 		      const struct wireaddr *addr)
 {

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -76,6 +76,10 @@ void json_add_txid(struct json_result *result, const char *fieldname,
 bool json_tok_pubkey(const char *buffer, const jsmntok_t *tok,
 		     struct pubkey *pubkey);
 
+/* Extract a short_channel_id from this */
+bool json_tok_short_channel_id(const char *buffer, const jsmntok_t *tok,
+			       struct short_channel_id *scid);
+
 /* '"fieldname" : "1234:5:6"' */
 void json_add_short_channel_id(struct json_result *response,
 			       const char *fieldname,

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -53,6 +53,7 @@ struct json_command {
 			 const char *buffer, const jsmntok_t *params);
 	const char *description;
 	const char *help;
+	bool deprecated;
 };
 
 struct json_result *null_response(const tal_t *ctx);

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -29,6 +29,8 @@
 #include <unistd.h>
 #include <wire/wire.h>
 
+bool deprecated_apis = true;
+
 /* Tal wrappers for opt. */
 static void *opt_allocfn(size_t size)
 {
@@ -269,6 +271,9 @@ static void config_register_opts(struct lightningd *ld)
 			       ld,
 			       "Select the network parameters (bitcoin, testnet,"
 			       " regtest, or litecoin)");
+	opt_register_arg("--deprecated-apis", opt_set_bool_arg, opt_show_bool,
+			 &deprecated_apis,
+			 "Enable deprecated options, JSONRPC commands, fields, etc.");
 }
 
 #if DEVELOPER

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -271,7 +271,8 @@ static void config_register_opts(struct lightningd *ld)
 			       ld,
 			       "Select the network parameters (bitcoin, testnet,"
 			       " regtest, or litecoin)");
-	opt_register_arg("--deprecated-apis", opt_set_bool_arg, opt_show_bool,
+	opt_register_arg("--allow-deprecated-apis",
+			 opt_set_bool_arg, opt_show_bool,
 			 &deprecated_apis,
 			 "Enable deprecated options, JSONRPC commands, fields, etc.");
 }

--- a/lightningd/options.h
+++ b/lightningd/options.h
@@ -15,4 +15,7 @@ bool handle_opts(struct lightningd *ld, int argc, char *argv[]);
 
 /* Derive default color and alias from the pubkey. */
 void setup_color_and_alias(struct lightningd *ld);
+
+/* Global to allow deprecated options. */
+extern bool deprecated_apis;
 #endif /* LIGHTNING_LIGHTNINGD_OPTIONS_H */

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -12,6 +12,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/options.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/peer_htlcs.h>
 #include <lightningd/subd.h>
@@ -494,7 +495,9 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 		json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
 		json_add_pubkey(response, "destination", &t->destination);
 		json_add_u64(response, "msatoshi", t->msatoshi);
-		json_add_u64(response, "timestamp", t->timestamp);
+		if (deprecated_apis)
+			json_add_u64(response, "timestamp", t->timestamp);
+		json_add_u64(response, "created_at", t->timestamp);
 
 		switch (t->status) {
 		case PAYMENT_PENDING:
@@ -523,6 +526,6 @@ static const struct json_command listpayments_command = {
 	"listpayments",
 	json_listpayments,
 	"Get a list of outgoing payments",
-	"Returns a list of payments with {payment_hash}, {destination}, {msatoshi}, {timestamp} and {status} (and {payment_preimage} if {status} is 'complete')"
+	"Returns a list of payments with {payment_hash}, {destination}, {msatoshi}, {created_at} and {status} (and {payment_preimage} if {status} is 'complete')"
 };
 AUTODATA(json_command, &listpayments_command);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -485,7 +485,8 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 
 	payments = wallet_payment_list(cmd, cmd->ld->wallet, rhash);
 
-	json_array_start(response, NULL);
+	json_object_start(response, NULL);
+	json_array_start(response, "payments");
 	for (int i=0; i<tal_count(payments); i++) {
 		const struct wallet_payment *t = payments[i];
 		json_object_start(response, NULL);
@@ -514,6 +515,7 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 		json_object_end(response);
 	}
 	json_array_end(response);
+	json_object_end(response);
 	command_success(cmd, response);
 }
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -299,8 +299,7 @@ static void json_sendpay(struct command *cmd,
 			return;
 		}
 
-		if (!short_channel_id_from_str(buffer + chantok->start,
-					       chantok->end - chantok->start,
+		if (!json_tok_short_channel_id(buffer, chantok,
 					       &route[n_hops].channel_id)) {
 			command_fail(cmd, "route %zu invalid channel_id", n_hops);
 			return;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -824,7 +824,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 					type_to_string(response, struct wireaddr,
 						       &p->addr));
 		json_array_end(response);
-		json_add_pubkey(response, "peerid", &p->id);
+		json_add_pubkey(response, "id", &p->id);
 		json_add_bool(response, "connected", p->owner != NULL);
 		if (p->owner)
 			json_add_string(response, "owner", p->owner->name);
@@ -857,7 +857,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 		json_object_start(response, NULL);
 		/* Fake state. */
 		json_add_string(response, "state", "GOSSIPING");
-		json_add_pubkey(response, "peerid", ids+i);
+		json_add_pubkey(response, "id", ids+i);
 		json_array_start(response, "netaddr");
 		if (addrs[i].type != ADDR_TYPE_PADDING)
 			json_add_string(response, NULL,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -869,7 +869,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 	command_success(gpa->cmd, response);
 }
 
-static void json_getpeers(struct command *cmd,
+static void json_listpeers(struct command *cmd,
 			  const char *buffer, const jsmntok_t *params)
 {
 	jsmntok_t *leveltok;
@@ -905,13 +905,13 @@ static void json_getpeers(struct command *cmd,
 	command_still_pending(cmd);
 }
 
-static const struct json_command getpeers_command = {
-	"getpeers",
-	json_getpeers,
+static const struct json_command listpeers_command = {
+	"listpeers",
+	json_listpeers,
 	"List the current peers, if {level} is set, include {log}s",
 	"Returns a 'peers' array"
 };
-AUTODATA(json_command, &getpeers_command);
+AUTODATA(json_command, &listpeers_command);
 
 struct peer *peer_from_json(struct lightningd *ld,
 			    const char *buffer,

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1461,14 +1461,16 @@ class LightningDTests(BaseLightningDTests):
         assert n2['nodeid'] == l2.info['id']
 
         # Might not have seen other node-announce yet.
-        assert n1['alias'] == 'JUNIORBEAM'
-        assert n1['color'] == '0266e4'
-        if not 'alias' in n2:
-            assert not 'color' in n2
-            assert not 'addresses' in n2
-        else:
-            assert n2['alias'] == 'SILENTARTIST'
-            assert n2['color'] == '022d22'
+        # TODO(cdecker) Can't check these without DEVELOPER=1, re-enable after we get alias and color into getinfo
+        if DEVELOPER:
+            assert n1['alias'] == 'JUNIORBEAM'
+            assert n1['color'] == '0266e4'
+            if not 'alias' in n2:
+                assert not 'color' in n2
+                assert not 'addresses' in n2
+            else:
+                assert n2['alias'] == 'SILENTARTIST'
+                assert n2['color'] == '022d22'
 
         assert [c['active'] for c in l1.rpc.listchannels()['channels']] == [True, True]
         assert [c['public'] for c in l1.rpc.listchannels()['channels']] == [True, True]

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -733,14 +733,14 @@ class LightningDTests(BaseLightningDTests):
         invoice2 = l2.rpc.listinvoices('testpayment2')['invoices'][0]
         payments = l1.rpc.listpayments(None, invoice2['payment_hash'])['payments']
         assert len(payments) == 1
-        print(payments)
+
         assert payments[0]['status'] == 'complete'
         assert payments[0]['payment_preimage'] == preimage2['preimage']
 
         invoice3 = l2.rpc.listinvoices('testpayment3')['invoices'][0]
         payments = l1.rpc.listpayments(None, invoice3['payment_hash'])['payments']
         assert len(payments) == 1
-        print(payments)
+
         assert payments[0]['status'] == 'complete'
         assert payments[0]['payment_preimage'] == preimage3['preimage']
 
@@ -784,7 +784,7 @@ class LightningDTests(BaseLightningDTests):
         preimage = l1.rpc.pay(inv)
         after = int(time.time())
         invoice = l2.rpc.listinvoices('test_pay')['invoices'][0]
-        print(invoice)
+
         assert invoice['status'] == 'paid'
         assert invoice['paid_timestamp'] >= before
         assert invoice['paid_timestamp'] <= after
@@ -918,10 +918,7 @@ class LightningDTests(BaseLightningDTests):
         # Only l1 has a direct output since all of l2's outputs are respent (it failed)
         assert closetxid in set([o['txid'] for o in l1.rpc.listfunds()['outputs']])
 
-        #import pdb; pdb.set_trace()
-
         addr = l1.bitcoin.rpc.getnewaddress()
-        print(addr)
         l1.rpc.withdraw(addr, "all")
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -675,10 +675,10 @@ class LightningDTests(BaseLightningDTests):
         # FIXME: test paying via another node, should fail to pay twice.
         p1 = l1.rpc.getpeer(l2.info['id'], 'info')
         p2 = l2.rpc.getpeer(l1.info['id'], 'info')
-        assert p1['msatoshi_to_us'] == 10**6 * 1000
-        assert p1['msatoshi_total'] == 10**6 * 1000
-        assert p2['msatoshi_to_us'] == 0
-        assert p2['msatoshi_total'] == 10**6 * 1000
+        assert p1['channels'][0]['msatoshi_to_us'] == 10**6 * 1000
+        assert p1['channels'][0]['msatoshi_total'] == 10**6 * 1000
+        assert p2['channels'][0]['msatoshi_to_us'] == 0
+        assert p2['channels'][0]['msatoshi_total'] == 10**6 * 1000
 
         # This works.
         preimage2 = l1.rpc.sendpay(to_json([routestep]), rhash)
@@ -690,10 +690,10 @@ class LightningDTests(BaseLightningDTests):
         time.sleep(1)
         p1 = l1.rpc.getpeer(l2.info['id'], 'info')
         p2 = l2.rpc.getpeer(l1.info['id'], 'info')
-        assert p1['msatoshi_to_us'] == 10**6 * 1000 - amt
-        assert p1['msatoshi_total'] == 10**6 * 1000
-        assert p2['msatoshi_to_us'] == amt
-        assert p2['msatoshi_total'] == 10**6 * 1000
+        assert p1['channels'][0]['msatoshi_to_us'] == 10**6 * 1000 - amt
+        assert p1['channels'][0]['msatoshi_total'] == 10**6 * 1000
+        assert p2['channels'][0]['msatoshi_to_us'] == amt
+        assert p2['channels'][0]['msatoshi_total'] == 10**6 * 1000
 
         # Repeat will "succeed", but won't actually send anything (duplicate)
         assert not l1.daemon.is_in_log('... succeeded')

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -332,8 +332,8 @@ class LightningDTests(BaseLightningDTests):
         after = int(time.time())
         b11 = l1.rpc.decodepay(inv['bolt11'])
         assert b11['currency'] == 'tb'
-        assert b11['timestamp'] >= before
-        assert b11['timestamp'] <= after
+        assert b11['created_at'] >= before
+        assert b11['created_at'] <= after
         assert b11['payment_hash'] == inv['payment_hash']
         assert b11['description'] == 'description'
         assert b11['expiry'] == 3600
@@ -367,7 +367,7 @@ class LightningDTests(BaseLightningDTests):
         time.sleep(2)
         self.assertRaises(ValueError, l1.rpc.pay, inv)
         assert l2.rpc.listinvoices('test_pay')['invoices'][0]['status'] == 'expired'
-        assert l2.rpc.listinvoices('test_pay')['invoices'][0]['expiry_time'] < time.time()
+        assert l2.rpc.listinvoices('test_pay')['invoices'][0]['expires_at'] < time.time()
 
         # Try deleting it.
         self.assertRaisesRegex(ValueError,
@@ -440,7 +440,7 @@ class LightningDTests(BaseLightningDTests):
         # * `0lkg3c`: Bech32 checksum
         b11 = l1.rpc.decodepay('lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w')
         assert b11['currency'] == 'bc'
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['description'] == 'Please consider supporting this project'
         assert b11['expiry'] == 3600
@@ -468,7 +468,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 2500 * 10**11 // 1000000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['description'] == '1 cup coffee'
         assert b11['expiry'] == 60
@@ -493,7 +493,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqscc6gd6ql3jrc5yzme8v4ntcewwz5cnw92tz0pc8qcuufvq7khhr8wpald05e92xw006sq94mg8v2ndf4sefvf9sygkshp5zfem29trqq2yxxz7', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -517,7 +517,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lntb20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un98kmzzhznpurw9sgl2v0nklu2g4d0keph5t7tj9tcqd8rexnd07ux4uv2cjvcqwaxgj7v4uwn5wmypjd5n69z2xm3xgksg28nwht7f6zspwp3f9t', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'tb'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -547,7 +547,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzqj9n4evl6mr5aj9f58zp6fyjzup6ywn3x6sk8akg5v4tgn2q8g4fhx05wf6juaxu9760yp46454gpg5mtzgerlzezqcqvjnhjh8z3g2qqdhhwkj', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -588,7 +588,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppj3a24vwu6r8ejrss3axul8rxldph2q7z9kmrgvr7xlaqm47apw3d48zm203kzcq357a4ls9al2ea73r8jcceyjtya6fu5wzzpe50zrge6ulk4nvjcpxlekvmxl6qcs9j3tz0469gq5g658y', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -613,7 +613,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppqw508d6qejxtdg4y5r3zarvary0c5xw7kepvrhrm9s57hejg0p662ur5j5cr03890fa7k2pypgttmh4897d3raaq85a293e9jpuqwl0rnfuwzam7yr8e690nd2ypcq9hlkdwdvycqa0qza8', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -638,7 +638,7 @@ class LightningDTests(BaseLightningDTests):
         b11 = l1.rpc.decodepay('lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q28j0v3rwgy9pvjnd48ee2pl8xrpxysd5g44td63g6xcjcu003j3qe8878hluqlvl3km8rm92f5stamd3jw763n3hck0ct7p8wwj463cql26ava', 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon')
         assert b11['currency'] == 'bc'
         assert b11['msatoshi'] == 20 * 10**11 // 1000
-        assert b11['timestamp'] == 1496314658
+        assert b11['created_at'] == 1496314658
         assert b11['payment_hash'] == '0001020304050607080900010203040506070809000102030405060708090102'
         assert b11['expiry'] == 3600
         assert b11['payee'] == '03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad'
@@ -786,8 +786,8 @@ class LightningDTests(BaseLightningDTests):
         invoice = l2.rpc.listinvoices('test_pay')['invoices'][0]
 
         assert invoice['status'] == 'paid'
-        assert invoice['paid_timestamp'] >= before
-        assert invoice['paid_timestamp'] <= after
+        assert invoice['paid_at'] >= before
+        assert invoice['paid_at'] <= after
 
         # Repeat payments are NOPs (if valid): we can hand null.
         l1.rpc.pay(inv, None)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1775,6 +1775,17 @@ class LightningDTests(BaseLightningDTests):
                                .format(bitcoind.rpc.getblockcount() + 9 + shadow_route))
         assert l3.rpc.listinvoice('test_forward_different_fees_and_cltv')[0]['complete'] == True
 
+        # Check that we see all the channels
+        shortids = set(c['short_channel_id'] for c in l2.rpc.listchannels()['channels'])
+        for scid in shortids:
+            c = l1.rpc.listchannels(scid)['channels']
+            # We get one entry for each direction.
+            assert len(c) == 2
+            assert c[0]['short_channel_id'] == scid
+            assert c[1]['short_channel_id'] == scid
+            assert c[0]['source'] == c[1]['destination']
+            assert c[1]['source'] == c[0]['destination']
+        
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-broadcast-interval")
     def test_forward_pad_fees_and_cltv(self):
         """Test that we are allowed extra locktime delta, and fees"""

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2056,7 +2056,7 @@ class LightningDTests(BaseLightningDTests):
 
         # Fundee remembers, funder doesn't.
         assert l1.rpc.getpeer(l2.info['id']) == None
-        assert l2.rpc.getpeer(l1.info['id'])['peerid'] == l1.info['id']
+        assert l2.rpc.getpeer(l1.info['id'])['id'] == l1.info['id']
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_reconnect_signed(self):
@@ -2074,8 +2074,8 @@ class LightningDTests(BaseLightningDTests):
         l1.rpc.fundchannel(l2.info['id'], 20000)
 
         # They haven't forgotten each other.
-        assert l1.rpc.getpeer(l2.info['id'])['peerid'] == l2.info['id']
-        assert l2.rpc.getpeer(l1.info['id'])['peerid'] == l1.info['id']
+        assert l1.rpc.getpeer(l2.info['id'])['id'] == l2.info['id']
+        assert l2.rpc.getpeer(l1.info['id'])['id'] == l1.info['id']
 
         # Technically, this is async to fundchannel (and could reconnect first)
         l1.daemon.wait_for_logs(['sendrawtx exit 0',

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1374,18 +1374,18 @@ class LightningDTests(BaseLightningDTests):
         assert not l1.daemon.is_in_log('peer_out WIRE_ANNOUNCEMENT_SIGNATURES')
 
         # Channels should be activated locally
-        wait_for(lambda: [c['active'] for c in l1.rpc.getchannels()['channels']] == [True])
+        wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True])
 
         # Make sure we can route through the channel, will raise on failure
         l1.rpc.getroute(l2.info['id'], 100, 1)
 
         # Outgoing should be active, but not public.
-        channels = l1.rpc.getchannels()['channels']
+        channels = l1.rpc.listchannels()['channels']
         assert len(channels) == 1
         assert channels[0]['active'] == True
         assert channels[0]['public'] == False
 
-        channels = l2.rpc.getchannels()['channels']
+        channels = l2.rpc.listchannels()['channels']
         assert len(channels) == 1
         assert channels[0]['active'] == True
         assert channels[0]['public'] == False
@@ -1431,10 +1431,10 @@ class LightningDTests(BaseLightningDTests):
             assert n2['alias'] == 'SILENTARTIST'
             assert n2['color'] == '022d22'
 
-        assert [c['active'] for c in l1.rpc.getchannels()['channels']] == [True, True]
-        assert [c['public'] for c in l1.rpc.getchannels()['channels']] == [True, True]
-        assert [c['active'] for c in l2.rpc.getchannels()['channels']] == [True, True]
-        assert [c['public'] for c in l2.rpc.getchannels()['channels']] == [True, True]
+        assert [c['active'] for c in l1.rpc.listchannels()['channels']] == [True, True]
+        assert [c['public'] for c in l1.rpc.listchannels()['channels']] == [True, True]
+        assert [c['active'] for c in l2.rpc.listchannels()['channels']] == [True, True]
+        assert [c['public'] for c in l2.rpc.listchannels()['channels']] == [True, True]
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-broadcast-interval")
     def test_gossip_pruning(self):
@@ -1454,9 +1454,9 @@ class LightningDTests(BaseLightningDTests):
         l1.bitcoin.rpc.generate(6)
 
         # Channels should be activated locally
-        wait_for(lambda: [c['active'] for c in l1.rpc.getchannels()['channels']] == [True]*4)
-        wait_for(lambda: [c['active'] for c in l2.rpc.getchannels()['channels']] == [True]*4)
-        wait_for(lambda: [c['active'] for c in l3.rpc.getchannels()['channels']] == [True]*4)
+        wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True]*4)
+        wait_for(lambda: [c['active'] for c in l2.rpc.listchannels()['channels']] == [True]*4)
+        wait_for(lambda: [c['active'] for c in l3.rpc.listchannels()['channels']] == [True]*4)
 
         # All of them should send a keepalive message
         l1.daemon.wait_for_logs([
@@ -1484,8 +1484,8 @@ class LightningDTests(BaseLightningDTests):
             "Pruning channel {}/{} from network view".format(scid2, 1),
         ])
 
-        assert scid2 not in [c['short_channel_id'] for c in l1.rpc.getchannels()['channels']]
-        assert scid2 not in [c['short_channel_id'] for c in l2.rpc.getchannels()['channels']]
+        assert scid2 not in [c['short_channel_id'] for c in l1.rpc.listchannels()['channels']]
+        assert scid2 not in [c['short_channel_id'] for c in l2.rpc.listchannels()['channels']]
         assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.listnodes()['nodes']]
         assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.listnodes()['nodes']]
 
@@ -1540,7 +1540,7 @@ class LightningDTests(BaseLightningDTests):
 
         # Settle the gossip
         for n in [l1, l2, l3]:
-            wait_for(lambda: len(n.rpc.getchannels()['channels']) == 4)
+            wait_for(lambda: len(n.rpc.listchannels()['channels']) == 4)
 
     def test_second_channel(self):
         l1 = self.node_factory.get_node()
@@ -1573,7 +1573,7 @@ class LightningDTests(BaseLightningDTests):
             start_time = time.time()
             # Wait at most 10 seconds, broadcast interval is 1 second
             while time.time() - start_time < 10:
-                channels = n.rpc.getchannels()['channels']
+                channels = n.rpc.listchannels()['channels']
                 if len(channels) == expected_connections:
                     break
                 else:
@@ -1590,7 +1590,7 @@ class LightningDTests(BaseLightningDTests):
 
         for n in nodes:
             seen = []
-            channels = n.rpc.getchannels()['channels']
+            channels = n.rpc.listchannels()['channels']
             for c in channels:
                 seen.append((c['source'],c['destination']))
             assert set(seen) == set(comb)
@@ -2795,7 +2795,7 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_log('Received node_announcement for node {}'.format(l1.info['id']))
 
         # Both directions should be active before the restart
-        wait_for(lambda: [c['active'] for c in l1.rpc.getchannels()['channels']] == [True, True])
+        wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True, True])
 
         # Restart l2, will cause l1 to reconnect
         l2.stop()
@@ -2804,7 +2804,7 @@ class LightningDTests(BaseLightningDTests):
         # Now they should sync and re-establish again
         l1.daemon.wait_for_log('Received node_announcement for node {}'.format(l2.info['id']))
         l2.daemon.wait_for_log('Received node_announcement for node {}'.format(l1.info['id']))
-        wait_for(lambda: [c['active'] for c in l1.rpc.getchannels()['channels']] == [True, True])
+        wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True, True])
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_update_fee(self):

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1412,8 +1412,14 @@ class LightningDTests(BaseLightningDTests):
                                  'Channel {}\\(1\\) was updated.'
                                  .format(channel_id)])
 
-        nodes = l1.rpc.getnodes()['nodes']
+        nodes = l1.rpc.listnodes()['nodes']
         assert set([n['nodeid'] for n in nodes]) == set([l1.info['id'], l2.info['id']])
+
+        # Test listnodes with an arg, while we're here.
+        n1 = l1.rpc.listnodes(l1.info['id'])['nodes'][0]
+        n2 = l1.rpc.listnodes(l2.info['id'])['nodes'][0]
+        assert n1['nodeid'] == l1.info['id']
+        assert n2['nodeid'] == l2.info['id']
 
         assert [c['active'] for c in l1.rpc.getchannels()['channels']] == [True, True]
         assert [c['public'] for c in l1.rpc.getchannels()['channels']] == [True, True]
@@ -1470,8 +1476,8 @@ class LightningDTests(BaseLightningDTests):
 
         assert scid2 not in [c['short_channel_id'] for c in l1.rpc.getchannels()['channels']]
         assert scid2 not in [c['short_channel_id'] for c in l2.rpc.getchannels()['channels']]
-        assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.getnodes()['nodes']]
-        assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.getnodes()['nodes']]
+        assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.listnodes()['nodes']]
+        assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.listnodes()['nodes']]
 
     def ping_tests(self, l1, l2):
         # 0-byte pong gives just type + length field.

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -369,6 +369,21 @@ class LightningDTests(BaseLightningDTests):
         assert l2.rpc.listinvoices('test_pay')['invoices'][0]['status'] == 'expired'
         assert l2.rpc.listinvoices('test_pay')['invoices'][0]['expiry_time'] < time.time()
 
+        # Try deleting it.
+        self.assertRaisesRegex(ValueError,
+                               'Invoice status is expired not unpaid',
+                               l2.rpc.delinvoice,
+                               'test_pay', 'unpaid')
+        self.assertRaisesRegex(ValueError,
+                               'Invoice status is expired not paid',
+                               l2.rpc.delinvoice,
+                               'test_pay', 'paid')
+        l2.rpc.delinvoice('test_pay', 'expired')
+
+        self.assertRaisesRegex(ValueError,
+                               'Unknown invoice',
+                               l2.rpc.delinvoice,
+                               'test_pay', 'expired')
     def test_connect(self):
         l1,l2 = self.connect()
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1421,6 +1421,16 @@ class LightningDTests(BaseLightningDTests):
         assert n1['nodeid'] == l1.info['id']
         assert n2['nodeid'] == l2.info['id']
 
+        # Might not have seen other node-announce yet.
+        assert n1['alias'] == 'JUNIORBEAM'
+        assert n1['color'] == '0266e4'
+        if not 'alias' in n2:
+            assert not 'color' in n2
+            assert not 'addresses' in n2
+        else:
+            assert n2['alias'] == 'SILENTARTIST'
+            assert n2['color'] == '022d22'
+
         assert [c['active'] for c in l1.rpc.getchannels()['channels']] == [True, True]
         assert [c['public'] for c in l1.rpc.getchannels()['channels']] == [True, True]
         assert [c['active'] for c in l2.rpc.getchannels()['channels']] == [True, True]

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -385,8 +385,8 @@ class LightningDTests(BaseLightningDTests):
         assert ret['id'] == l1.info['id']
 
         # Should still only have one peer!
-        assert len(l1.rpc.getpeers()) == 1
-        assert len(l2.rpc.getpeers()) == 1
+        assert len(l1.rpc.listpeers()) == 1
+        assert len(l2.rpc.listpeers()) == 1
 
     def test_balance(self):
         l1,l2 = self.connect()
@@ -1979,8 +1979,8 @@ class LightningDTests(BaseLightningDTests):
                                    .format(l2.info['id']))
 
         # Should still only have one peer!
-        assert len(l1.rpc.getpeers()) == 1
-        assert len(l2.rpc.getpeers()) == 1
+        assert len(l1.rpc.listpeers()) == 1
+        assert len(l2.rpc.listpeers()) == 1
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_disconnect_funder(self):
@@ -2008,8 +2008,8 @@ class LightningDTests(BaseLightningDTests):
         l1.rpc.fundchannel(l2.info['id'], 20000)
 
         # Should still only have one peer!
-        assert len(l1.rpc.getpeers()) == 1
-        assert len(l2.rpc.getpeers()) == 1
+        assert len(l1.rpc.listpeers()) == 1
+        assert len(l2.rpc.listpeers()) == 1
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_disconnect_fundee(self):
@@ -2035,8 +2035,8 @@ class LightningDTests(BaseLightningDTests):
         l1.rpc.fundchannel(l2.info['id'], 20000)
 
         # Should still only have one peer!
-        assert len(l1.rpc.getpeers()) == 1
-        assert len(l2.rpc.getpeers()) == 1
+        assert len(l1.rpc.listpeers()) == 1
+        assert len(l2.rpc.listpeers()) == 1
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_disconnect_half_signed(self):
@@ -2460,8 +2460,8 @@ class LightningDTests(BaseLightningDTests):
         # Fail because l1 dislikes l2's huge locktime.
         self.assertRaisesRegex(ValueError, r'to_self_delay \d+ larger than \d+',
                                l1.rpc.fundchannel, l2.info['id'], int(funds/10))
-        assert l1.rpc.getpeers()['peers'][0]['connected']
-        assert l2.rpc.getpeers()['peers'][0]['connected']
+        assert l1.rpc.listpeers()['peers'][0]['connected']
+        assert l2.rpc.listpeers()['peers'][0]['connected']
 
         # Restart l2 without ridiculous locktime.
         l2.daemon.cmd_line.remove('--locktime-blocks={}'.format(max_locktime + 1))
@@ -2473,8 +2473,8 @@ class LightningDTests(BaseLightningDTests):
                                l1.rpc.fundchannel, l2.info['id'], funds)
 
         # Should still be connected.
-        assert l1.rpc.getpeers()['peers'][0]['connected']
-        assert l2.rpc.getpeers()['peers'][0]['connected']
+        assert l1.rpc.listpeers()['peers'][0]['connected']
+        assert l2.rpc.listpeers()['peers'][0]['connected']
 
         # This works.
         l1.rpc.fundchannel(l2.info['id'], int(funds/10))
@@ -2541,7 +2541,7 @@ class LightningDTests(BaseLightningDTests):
 
         self.fund_channel(l1, l2, 100000)
 
-        peers = l1.rpc.getpeers()['peers']
+        peers = l1.rpc.listpeers()['peers']
         assert(len(peers) == 1 and peers[0]['state'] == 'CHANNELD_NORMAL')
 
         # Both nodes should now have exactly one channel in the database
@@ -2562,28 +2562,28 @@ class LightningDTests(BaseLightningDTests):
         print(" ".join(l2.daemon.cmd_line + ['--dev-debugger=channeld']))
 
         # Wait for l1 to notice
-        wait_for(lambda: not l1.rpc.getpeers()['peers'][0]['connected'])
+        wait_for(lambda: not l1.rpc.listpeers()['peers'][0]['connected'])
 
         # Now restart l1 and it should reload peers/channels from the DB
         l2.daemon.start()
-        wait_for(lambda: len(l2.rpc.getpeers()['peers']) == 1)
+        wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 1)
 
         # Wait for the restored HTLC to finish
-        wait_for(lambda: l1.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 99990000, interval=1)
+        wait_for(lambda: l1.rpc.listpeers()['peers'][0]['msatoshi_to_us'] == 99990000, interval=1)
 
-        wait_for(lambda: len([p for p in l1.rpc.getpeers()['peers'] if p['connected']]), interval=1)
-        wait_for(lambda: len([p for p in l2.rpc.getpeers()['peers'] if p['connected']]), interval=1)
+        wait_for(lambda: len([p for p in l1.rpc.listpeers()['peers'] if p['connected']]), interval=1)
+        wait_for(lambda: len([p for p in l2.rpc.listpeers()['peers'] if p['connected']]), interval=1)
 
         # Now make sure this is really functional by sending a payment
         self.pay(l1, l2, 10000)
         time.sleep(1)
-        assert l1.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 99980000
-        assert l2.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 20000
+        assert l1.rpc.listpeers()['peers'][0]['msatoshi_to_us'] == 99980000
+        assert l2.rpc.listpeers()['peers'][0]['msatoshi_to_us'] == 20000
 
         # Finally restart l1, and make sure it remembers
         l1.stop()
         l1.daemon.start()
-        assert l1.rpc.getpeers()['peers'][0]['msatoshi_to_us'] == 99980000
+        assert l1.rpc.listpeers()['peers'][0]['msatoshi_to_us'] == 99980000
 
         # Now make sure l1 is watching for unilateral closes
         l2.rpc.dev_fail(l1.info['id']);

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -249,6 +249,7 @@ class LightningD(TailableProc):
             '--bitcoin-datadir={}'.format(bitcoin_dir),
             '--lightning-dir={}'.format(lightning_dir),
             '--port={}'.format(port),
+            '--deprecated-apis=false',
             '--override-fee-rates=15000/7500/1000',
             '--network=regtest',
             '--ignore-fee-limits=false'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -326,11 +326,10 @@ class LightningNode(object):
     def openchannel(self, remote_node, capacity):
         addr = self.rpc.newaddr()['address']
         txid = self.bitcoin.rpc.sendtoaddress(addr, capacity / 10**6)
-        tx = self.bitcoin.rpc.getrawtransaction(txid)
-        self.rpc.addfunds(tx)
+        self.bitcoin.generate_block(1)
+        self.daemon.wait_for_log('Owning output .* txid {}'.format(txid))
         self.rpc.fundchannel(remote_node.info['id'], capacity)
         self.daemon.wait_for_log('sendrawtx exit 0, gave')
-        time.sleep(1)
         self.bitcoin.generate_block(6)
         self.daemon.wait_for_log('-> CHANNELD_NORMAL|STATE_NORMAL')
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -249,7 +249,7 @@ class LightningD(TailableProc):
             '--bitcoin-datadir={}'.format(bitcoin_dir),
             '--lightning-dir={}'.format(lightning_dir),
             '--port={}'.format(port),
-            '--deprecated-apis=false',
+            '--allow-deprecated-apis=false',
             '--override-fee-rates=15000/7500/1000',
             '--network=regtest',
             '--ignore-fee-limits=false'

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -230,8 +230,10 @@ bool invoices_delete(struct invoices *invoices,
 	sqlite3_bind_int64(stmt, 1, invoice->id);
 	db_exec_prepared(invoices->db, stmt);
 
-	if (sqlite3_changes(invoices->db->sql) != 1)
+	if (sqlite3_changes(invoices->db->sql) != 1) {
+		tal_free(tmpctx);
 		return false;
+	}
 
 	/* Delete from invoices object. */
 	list_del_from(&invoices->invlist, &invoice->list);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1427,8 +1427,10 @@ void wallet_payment_set_status(struct wallet *wallet,
 	}
 }
 
-const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
-						  struct wallet *wallet)
+const struct wallet_payment **
+wallet_payment_list(const tal_t *ctx,
+		    struct wallet *wallet,
+		    const struct sha256 *payment_hash)
 {
 	const struct wallet_payment **payments;
 	sqlite3_stmt *stmt;
@@ -1436,12 +1438,23 @@ const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
 	size_t i;
 
 	payments = tal_arr(ctx, const struct wallet_payment *, 0);
-	stmt = db_prepare(
-		wallet->db,
-		"SELECT id, status, destination, "
-		"msatoshi, payment_hash, timestamp, payment_preimage, "
-		"path_secrets "
-		"FROM payments;");
+	if (payment_hash) {
+		stmt = db_prepare(
+			wallet->db,
+			"SELECT id, status, destination, "
+			"msatoshi, payment_hash, timestamp, payment_preimage, "
+			"path_secrets "
+			"FROM payments "
+			"WHERE payment_hash = ?;");
+		sqlite3_bind_sha256(stmt, 1, payment_hash);
+	} else {
+		stmt = db_prepare(
+			wallet->db,
+			"SELECT id, status, destination, "
+			"msatoshi, payment_hash, timestamp, payment_preimage, "
+			"path_secrets "
+			"FROM payments;");
+	}
 
 	for (i = 0; sqlite3_step(stmt) == SQLITE_ROW; i++) {
 		tal_resize(&payments, i+1);
@@ -1452,6 +1465,8 @@ const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
 
 	/* Now attach payments not yet in db. */
 	list_for_each(&wallet->unstored_payments, p, list) {
+		if (payment_hash && !structeq(&p->payment_hash, payment_hash))
+			continue;
 		tal_resize(&payments, i+1);
 		payments[i++] = p;
 	}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -592,8 +592,11 @@ struct secret *wallet_payment_get_secrets(const tal_t *ctx,
 
 /**
  * wallet_payment_list - Retrieve a list of payments
+ *
+ * payment_hash: optional filter for only this payment hash.
  */
 const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
-						    struct wallet *wallet);
+						  struct wallet *wallet,
+						  const struct sha256 *payment_hash);
 
 #endif /* WALLET_WALLET_H */


### PR DESCRIPTION
(On top of previous payments rework patch, but you can ignore that for review).

If we don't fix up API warts now, we're stuck with them! We can always add new optional fields, but if anyone wants to review the current APIs for consistency, now would be a good time!

1. Make everything listy of form "list<plural>". getpeers->listpeers, getnotes->listnodes, getchannels->listchannels, getinvoice->getinvoices, listinvoice->listinvoices. 
2. Never return an undecorated JSON array.  It's redundant now, but if we want to add new toplevel fields, this will suck.
3. Use "id" instead of "peerid" consistently.
4. Keep listinvoice untouched for now, but deprecated (avoid breaking Lightning Charge).
5. Add --deprecated-apis=false option (defaults true) so you can test futureproofness of your stack.
6. Most list commands enhanced to take an optional selector, for getting a single (listchannels is the
   exception, as it returns two entries per channel, one for each dir).
7. listinvoices has 'status: unpaid|paid|expired' now, 'complete: true|false' is deprecated.

