### PR TITLE
Tidy README Fix, add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The recipient creates an invoice with the expected `<amount>` in millisatoshi (o
 cli/lightning-cli invoice <amount> <label> <description>
 ```
 
-This returns some internal details, and a standard invoice string called `bolt11` (named after the [BOLT #11 lightning spec](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md).
+This returns some internal details, and a standard invoice string called `bolt11` (named after the [BOLT #11 lightning spec](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md)).
 
 The sender can feed this `bolt11` string to the `decodepay` command to see what it is, and pay it simply using the `pay` command:
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -17,7 +17,7 @@ To Build on Ubuntu 15.10 or above
 
 Get dependencies:
 ```
-sudo apt-get install -y autoconf build-essential git libtool libgmp-dev libsqlite3-dev python3 net-tools
+sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python3 net-tools
 ```
 
 If you don't have Bitcoin installed locally you'll need to install that as well:


### PR DESCRIPTION
Tiny patch to documentation, adding missing `autoconf` dependency and fixing a dangling paren.