### PR TITLE
pay hands back failures to gossipd

### DIFF
--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -56,7 +56,8 @@ GOSSIPD_COMMON_OBJS :=				\
 	common/wire_error.o			\
 	hsmd/client.o				\
 	hsmd/gen_hsm_client_wire.o		\
-	lightningd/gossip_msg.o
+	lightningd/gossip_msg.o			\
+	wire/gen_onion_wire.o
 
 $(LIGHTNINGD_GOSSIP_OBJS) $(LIGHTNINGD_GOSSIP_CLIENT_OBJS): $(LIGHTNINGD_HEADERS) $(LIGHTNINGD_GOSSIP_HEADERS)
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1890,17 +1890,21 @@ static struct io_plan *handle_routing_failure(struct io_conn *conn,
 	struct pubkey erring_node;
 	struct short_channel_id erring_channel;
 	u16 failcode;
+	u8 *channel_update;
 
-	if (!fromwire_gossip_routing_failure(msg, NULL,
+	if (!fromwire_gossip_routing_failure(msg,
+					     msg, NULL,
 					     &erring_node,
 					     &erring_channel,
-					     &failcode))
+					     &failcode,
+					     &channel_update))
 		master_badmsg(WIRE_GOSSIP_ROUTING_FAILURE, msg);
 
 	routing_failure(daemon->rstate,
 			&erring_node,
 			&erring_channel,
-			(enum onion_type) failcode);
+			(enum onion_type) failcode,
+			channel_update);
 
 	return daemon_conn_read_next(conn, &daemon->master);
 }

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -202,3 +202,5 @@ gossip_routing_failure,3021
 gossip_routing_failure,,erring_node,struct pubkey
 gossip_routing_failure,,erring_channel,struct short_channel_id
 gossip_routing_failure,,failcode,u16
+gossip_routing_failure,,len,u16
+gossip_routing_failure,,channel_update,len*u8

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -1,5 +1,6 @@
 #include <common/cryptomsg.h>
 #include <common/wireaddr.h>
+#include <wire/gen_onion_wire.h>
 
 # Initialize the gossip daemon.
 gossipctl_init,3000
@@ -195,3 +196,9 @@ gossip_disable_channel,3019
 gossip_disable_channel,,short_channel_id,struct short_channel_id
 gossip_disable_channel,,direction,u8
 gossip_disable_channel,,active,bool
+
+# master->gossipd a routing failure occurred
+gossip_routing_failure,3021
+gossip_routing_failure,,erring_node,struct pubkey
+gossip_routing_failure,,erring_channel,struct short_channel_id
+gossip_routing_failure,,failcode,u16

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -13,6 +13,7 @@
 #include <common/type_to_string.h>
 #include <common/wireaddr.h>
 #include <inttypes.h>
+#include <wire/gen_onion_wire.h>
 #include <wire/gen_peer_wire.h>
 
 #ifndef SUPERVERBOSE
@@ -236,6 +237,12 @@ get_or_make_connection(struct routing_state *rstate,
 
 	tal_add_destructor(nc, destroy_connection);
 	return nc;
+}
+
+static void delete_connection(struct routing_state *rstate,
+			      const struct node_connection *connection)
+{
+	tal_free(connection);
 }
 
 struct node_connection *half_add_connection(
@@ -993,4 +1000,100 @@ struct route_hop *get_route(tal_t *ctx, struct routing_state *rstate,
 
 	/* FIXME: Shadow route! */
 	return hops;
+}
+
+/* Get the struct node_connection matching the short_channel_id,
+ * which must be an out connection of the given node. */
+static struct node_connection *
+get_out_node_connection_of(struct routing_state *rstate,
+			   const struct node *node,
+			   const struct short_channel_id *short_channel_id)
+{
+	int i;
+
+	for (i = 0; i < tal_count(node->out); ++i) {
+		if (short_channel_id_eq(&node->out[i]->short_channel_id, short_channel_id))
+			return node->out[i];
+	}
+
+	return NULL;
+}
+
+/**
+ * routing_failure_on_nc - Handle routing failure on a specific
+ * node_connection.
+ */
+static void routing_failure_on_nc(struct routing_state *rstate,
+				  enum onion_type failcode,
+				  struct node_connection *nc)
+{
+	/* BOLT #4:
+	 *
+	 * - if the PERM bit is NOT set:
+	 *   - SHOULD restore the channels as it receives new `channel_update`s.
+	 */
+	if (failcode & PERM)
+		nc->active = false;
+	else
+		delete_connection(rstate, nc);
+}
+
+void routing_failure(struct routing_state *rstate,
+		     const struct pubkey *erring_node_pubkey,
+		     const struct short_channel_id *scid,
+		     enum onion_type failcode)
+{
+	const tal_t *tmpctx = tal_tmpctx(rstate);
+	struct node *node;
+	struct node_connection *nc;
+	int i;
+
+	status_trace("Received routing failure 0x%04x (%s), "
+		     "erring node %s, "
+		     "channel %s",
+		     (int) failcode, onion_type_name(failcode),
+		     type_to_string(tmpctx, struct pubkey, erring_node_pubkey),
+		     type_to_string(tmpctx, struct short_channel_id, scid));
+
+	node = get_node(rstate, erring_node_pubkey);
+	if (!node) {
+		status_trace("UNUSUAL routing_failure: "
+			     "Erring node %s not in map",
+			     type_to_string(tmpctx, struct pubkey,
+					    erring_node_pubkey));
+		/* No node, so no channel, so any channel_update
+		 * can also be ignored. */
+		goto out;
+	}
+
+	/* BOLT #4:
+	 *
+	 * - if the NODE bit is set:
+	 *   - SHOULD remove all channels connected with the erring node from
+	 *   consideration.
+	 *
+	 */
+	if (failcode & NODE) {
+		for (i = 0; i < tal_count(node->in); ++i)
+			routing_failure_on_nc(rstate, failcode, node->in[i]);
+		for (i = 0; i < tal_count(node->out); ++i)
+			routing_failure_on_nc(rstate, failcode, node->out[i]);
+	} else {
+		nc = get_out_node_connection_of(rstate, node, scid);
+		if (nc)
+			routing_failure_on_nc(rstate, failcode, nc);
+		else
+			status_trace("UNUSUAL routing_failure: "
+				     "Channel %s not an out channel "
+				     "of node %s",
+				     type_to_string(tmpctx,
+						    struct short_channel_id,
+						    scid),
+				     type_to_string(tmpctx, struct pubkey,
+						    erring_node_pubkey));
+	}
+
+	/* FIXME: if UPDATE is set, apply the channel update. */
+out:
+	tal_free(tmpctx);
 }

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -153,7 +153,8 @@ struct route_hop *get_route(tal_t *ctx, struct routing_state *rstate,
 void routing_failure(struct routing_state *rstate,
 		     const struct pubkey *erring_node,
 		     const struct short_channel_id *erring_channel,
-		     enum onion_type failcode);
+		     enum onion_type failcode,
+		     const u8 *channel_update);
 
 /* Utility function that, given a source and a destination, gives us
  * the direction bit the matching channel should get */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -4,6 +4,7 @@
 #include <bitcoin/pubkey.h>
 #include <ccan/htable/htable_type.h>
 #include <gossipd/broadcast.h>
+#include <wire/gen_onion_wire.h>
 #include <wire/wire.h>
 
 #define ROUTING_MAX_HOPS 20
@@ -148,6 +149,11 @@ struct route_hop *get_route(tal_t *ctx, struct routing_state *rstate,
 			    const struct pubkey *destination,
 			    const u32 msatoshi, double riskfactor,
 			    u32 final_cltv);
+/* Disable channel(s) based on the given routing failure. */
+void routing_failure(struct routing_state *rstate,
+		     const struct pubkey *erring_node,
+		     const struct short_channel_id *erring_channel,
+		     enum onion_type failcode);
 
 /* Utility function that, given a source and a destination, gives us
  * the direction bit the matching channel should get */

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -63,6 +63,9 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
+/* Generated stub for onion_type_name */
+const char *onion_type_name(int e UNNEEDED)
+{ fprintf(stderr, "onion_type_name called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
 bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -57,6 +57,9 @@ bool fromwire_channel_update(const void *p UNNEEDED, size_t *plen UNNEEDED, secp
 /* Generated stub for fromwire_node_announcement */
 bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, size_t *plen UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, u8 **features UNNEEDED, u32 *timestamp UNNEEDED, struct pubkey *node_id UNNEEDED, u8 rgb_color[3] UNNEEDED, u8 alias[32] UNNEEDED, u8 **addresses UNNEEDED)
 { fprintf(stderr, "fromwire_node_announcement called!\n"); abort(); }
+/* Generated stub for fromwire_peektype */
+int fromwire_peektype(const u8 *cursor UNNEEDED)
+{ fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
 /* Generated stub for fromwire_u8 */
 u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u8 called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -34,6 +34,9 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
+/* Generated stub for onion_type_name */
+const char *onion_type_name(int e UNNEEDED)
+{ fprintf(stderr, "onion_type_name called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
 bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -28,6 +28,9 @@ bool fromwire_channel_update(const void *p UNNEEDED, size_t *plen UNNEEDED, secp
 /* Generated stub for fromwire_node_announcement */
 bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, size_t *plen UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, u8 **features UNNEEDED, u32 *timestamp UNNEEDED, struct pubkey *node_id UNNEEDED, u8 rgb_color[3] UNNEEDED, u8 alias[32] UNNEEDED, u8 **addresses UNNEEDED)
 { fprintf(stderr, "fromwire_node_announcement called!\n"); abort(); }
+/* Generated stub for fromwire_peektype */
+int fromwire_peektype(const u8 *cursor UNNEEDED)
+{ fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
 /* Generated stub for fromwire_u8 */
 u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u8 called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -21,6 +21,9 @@ bool fromwire_channel_update(const void *p UNNEEDED, size_t *plen UNNEEDED, secp
 /* Generated stub for fromwire_node_announcement */
 bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, size_t *plen UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, u8 **features UNNEEDED, u32 *timestamp UNNEEDED, struct pubkey *node_id UNNEEDED, u8 rgb_color[3] UNNEEDED, u8 alias[32] UNNEEDED, u8 **addresses UNNEEDED)
 { fprintf(stderr, "fromwire_node_announcement called!\n"); abort(); }
+/* Generated stub for fromwire_peektype */
+int fromwire_peektype(const u8 *cursor UNNEEDED)
+{ fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
 /* Generated stub for fromwire_u8 */
 u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u8 called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -27,6 +27,9 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
+/* Generated stub for onion_type_name */
+const char *onion_type_name(int e UNNEEDED)
+{ fprintf(stderr, "onion_type_name called!\n"); abort(); }
 /* Generated stub for queue_broadcast */
 bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const int type UNNEEDED,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -110,6 +110,7 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIP_SEND_GOSSIP:
 	case WIRE_GOSSIP_GET_TXOUT_REPLY:
 	case WIRE_GOSSIP_DISABLE_CHANNEL:
+	case WIRE_GOSSIP_ROUTING_FAILURE:
 	/* This is a reply, so never gets through to here. */
 	case WIRE_GOSSIP_GET_UPDATE_REPLY:
 	case WIRE_GOSSIP_GETNODES_REPLY:

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -65,11 +65,10 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 	struct secret *path_secrets;
 	const tal_t *tmpctx = tal_tmpctx(ld);
 
-	wallet_payment_set_status(ld->wallet, &hout->payment_hash,
-				  PAYMENT_FAILED, NULL);
-
 	/* This gives more details than a generic failure message */
 	if (localfail) {
+		wallet_payment_set_status(ld->wallet, &hout->payment_hash,
+					  PAYMENT_FAILED, NULL);
 		json_pay_failed(hout->cmd, NULL, hout->failcode, localfail);
 		tal_free(tmpctx);
 		return;
@@ -95,6 +94,12 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 			 reply->origin_index,
 			 failcode, onion_type_name(failcode));
 	}
+
+	/* This may invalidated the payment structure returned, so
+	 * access to payment object should not be done after the
+	 * below call.  */
+	wallet_payment_set_status(ld->wallet, &hout->payment_hash,
+				  PAYMENT_FAILED, NULL);
 
 	/* FIXME: save ids we can turn reply->origin_index into sender. */
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -349,6 +349,8 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds,
 		} else
 			local_fail_htlc(hout->in, failure_code,
 					hout->key.peer->scid);
+		/* Prevent hout from being failed twice. */
+		tal_del_destructor(hout, hout_subd_died);
 		tal_free(hout);
 		return;
 	}

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -339,6 +339,7 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds,
 	}
 
 	if (failure_code) {
+		hout->failcode = (enum onion_type) failure_code;
 		if (!hout->in) {
 			char *localfail = tal_fmt(msg, "%s: %.*s",
 						  onion_type_name(failure_code),

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -776,6 +776,21 @@ class LightningDTests(BaseLightningDTests):
         # But this should work.
         self.pay(l2, l1, available - reserve*2)
 
+    def test_pay0(self):
+        """Test paying 0 amount
+        """
+        l1,l2 = self.connect()
+        # Set up channel.
+        chanid = self.fund_channel(l1, l2, 10**6)
+        self.wait_for_routes(l1, [chanid])
+
+        # Get any-amount invoice
+        inv = l2.rpc.invoice("any", "any", 'description')['bolt11']
+
+        # Amount must be nonzero!
+        self.assertRaisesRegex(ValueError, 'WIRE_AMOUNT_BELOW_MINIMUM',
+                               l1.rpc.pay, inv, 0)
+
     def test_pay(self):
         l1,l2 = self.connect()
 
@@ -811,9 +826,6 @@ class LightningDTests(BaseLightningDTests):
             # Must provide an amount!
             self.assertRaises(ValueError, l1.rpc.pay, inv2)
             self.assertRaises(ValueError, l1.rpc.pay, inv2, None)
-            # Amount must be nonzero!
-            self.assertRaisesRegex(ValueError, 'WIRE_AMOUNT_BELOW_MINIMUM',
-                                   l1.rpc.pay, inv2, 0)
             l1.rpc.pay(inv2, random.randint(1000, 999999))
 
         # Should see 6 completed payments

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -117,6 +117,11 @@ bool sqlite3_bind_short_channel_id(sqlite3_stmt *stmt, int col,
 				   const struct short_channel_id *id);
 bool sqlite3_column_short_channel_id(sqlite3_stmt *stmt, int col,
 				     struct short_channel_id *dest);
+bool sqlite3_bind_short_channel_id_array(sqlite3_stmt *stmt, int col,
+					 const struct short_channel_id *id);
+struct short_channel_id *
+sqlite3_column_short_channel_id_array(const tal_t *ctx,
+				      sqlite3_stmt *stmt, int col);
 bool sqlite3_bind_tx(sqlite3_stmt *stmt, int col, const struct bitcoin_tx *tx);
 struct bitcoin_tx *sqlite3_column_tx(const tal_t *ctx, sqlite3_stmt *stmt,
 				     int col);
@@ -125,6 +130,11 @@ bool sqlite3_column_signature(sqlite3_stmt *stmt, int col, secp256k1_ecdsa_signa
 
 bool sqlite3_column_pubkey(sqlite3_stmt *stmt, int col,  struct pubkey *dest);
 bool sqlite3_bind_pubkey(sqlite3_stmt *stmt, int col, const struct pubkey *pk);
+
+bool sqlite3_bind_pubkey_array(sqlite3_stmt *stmt, int col,
+			       const struct pubkey *pks);
+struct pubkey *sqlite3_column_pubkey_array(const tal_t *ctx,
+					   sqlite3_stmt *stmt, int col);
 
 bool sqlite3_column_preimage(sqlite3_stmt *stmt, int col,  struct preimage *dest);
 bool sqlite3_bind_preimage(sqlite3_stmt *stmt, int col, const struct preimage *p);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -93,7 +93,10 @@ struct wallet_payment {
 	u64 msatoshi;
 	/* If and only if PAYMENT_COMPLETE */
 	struct preimage *payment_preimage;
+	/* Needed for recovering from routing failures. */
 	struct secret *path_secrets;
+	struct pubkey *route_nodes;
+	struct short_channel_id *route_channels;
 };
 
 /**


### PR DESCRIPTION
Fixes: #550 

Eventually.  Remaining:

- [x] Save the route somewhere somehow on lightningd's side.  Maybe as a blob on the db? Or just in-memory (with an intervening shutdown/restart losing the route information -> an intervening shutdown/restart will restart gossipd's mapping information too anyway, so why retain (possibly obsolete) routing information?).
- [x] Have the route failure reported on routing failure.
- [x] Hash out exactly how `sendpay` should differ from `pay`.  Presumably `sendpay` only tries the specific route specified and should probably return the result of the attempt immediately without retrying, while `pay` does a best-effort and keeps retrying until a permanent failure at the payee or no-route-found from gossipd.
- [x] Report failures of local channels also.
- [x] ~~Implement `data` error return on `sendpay` if a routing error occurred.~~ Do this in a later PR instead, it is big enough already!
- [x] Create test for routing reporting.