### PR TITLE
Sync dependencies between README.md and doc/INSTALL.md. Add dependency consistency check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,10 @@ check-whitespace/%: %
 
 check-whitespace: check-whitespace/Makefile check-whitespace/tools/check-bolt.c $(ALL_TEST_PROGRAMS:%=check-whitespace/%.c)
 
-check-source: check-makefile check-source-bolt check-whitespace
+check-markdown:
+	@tools/check-markdown.sh
+
+check-source: check-makefile check-source-bolt check-whitespace check-markdown
 
 full-check: check check-source
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please refer to the [installation documentation](doc/INSTALL.md) for detailed in
 For the impatient here's the gist of it for Ubuntu and Debian:
 
 ```
-sudo apt-get install -y autoconf build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
+sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
 git clone https://github.com/ElementsProject/lightning.git
 cd lightning
 make

--- a/tools/check-markdown.sh
+++ b/tools/check-markdown.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+diff -u <(egrep 'sudo apt-get install .*git' README.md) \
+     <(egrep 'sudo apt-get install .*git' doc/INSTALL.md)
+if [[ $? != 0 ]]; then
+    echo "Dependencies listed in README.md are not identical to those listed in doc/INSTALL.md (see above). Please fix."
+    exit 1
+fi


### PR DESCRIPTION
Sync dependencies between `README.md` and `doc/INSTALL.md` and add a Travis/`check-source` check to make sure these do not get out of sync again :-)

Before this patch:

```
$ diff -u <(egrep 'sudo apt-get install .*git' README.md) <(egrep 'sudo apt-get install .*git' doc/INSTALL.md)
--- /dev/fd/63    2018-01-18 17:26:34.330464546 +0100
+++ /dev/fd/62    2018-01-18 17:26:34.330464546 +0100
@@ -1 +1 @@
-sudo apt-get install -y autoconf build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
+sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
$
```

After this patch:

```
$ diff -u <(egrep 'sudo apt-get install .*git' README.md) <(egrep 'sudo apt-get install .*git' doc/INSTALL.md)
$
```