### PR TITLE
channeld: don't consider shutdown complete if feechange pending.

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -697,7 +697,10 @@ static bool shutdown_complete(const struct peer *peer)
 {
 	return peer->shutdown_sent[LOCAL]
 		&& peer->shutdown_sent[REMOTE]
-		&& !channel_has_htlcs(peer->channel);
+		&& !channel_has_htlcs(peer->channel)
+		/* We could be awaiting revoke-and-ack for a feechange */
+		&& peer->revocations_received == peer->next_index[REMOTE] - 1;
+
 }
 
 /* BOLT #2:


### PR DESCRIPTION
Travis gave an error:

```
DEBUG:root:lightningd(16333): lightning_closingd(8004): STATUS_FAIL_PEER_BAD: Expected closing_signed:
0085b679bd79b836b05c649cad9af31156cb1d50de448a59c6359ab7c85f4b63913d2e3bc8ad4a80ab698558e5b4949b78dc36acc90dde4f5ac006fd6ca1d109feea03aef9c718e9ce09bbb52dc8308ba8f46b43808ea1a551d41aee72af7af77628d1
```

Which is caused by us not waiting for the revoke-and-ack from a feechange
when we're shutting down.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>