### PR TITLE
quickfixing issue #662 to make CLI more userfriendly for inexperienced users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ You can start `lightningd` with the following command:
 lightningd/lightningd --network=testnet --log-level=debug
 ```
 
+### Listing all commands:
+`cli/lighting-cli help` will print a table of the API and lists the following commands
+
 ### Opening a channel on the Bitcoin testnet
 
 First you need to transfer some funds to `lightningd` so that it can open a channel:

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -58,10 +58,9 @@ static bool wallet_stmt2invoice(sqlite3_stmt *stmt, struct invoice *inv)
 	}
 
 	inv->expiry_time = sqlite3_column_int64(stmt, 6);
-	/* Correctly 0 if pay_index is NULL. */
-	inv->pay_index = sqlite3_column_int64(stmt, 7);
 
 	if (inv->state == PAID) {
+		inv->pay_index = sqlite3_column_int64(stmt, 7);
 		inv->msatoshi_received = sqlite3_column_int64(stmt, 8);
 		inv->paid_timestamp = sqlite3_column_int64(stmt, 9);
 	}
@@ -181,7 +180,6 @@ const struct invoice *invoices_create(struct invoices *invoices,
 	memcpy(&invoice->r, &r, sizeof(invoice->r));
 	memcpy(&invoice->rhash, &rhash, sizeof(invoice->rhash));
 	invoice->expiry_time = expiry_time;
-	invoice->pay_index = 0;
 	list_head_init(&invoice->waitone_waiters);
 
 	/* Add to invoices object. */


### PR DESCRIPTION
I basically changed one line of code extending the help message from `./lighting-cli --help` to point out that `./lighting-cli help` lists all the available commands

c.f.: https://github.com/ElementsProject/lightning/issues/662