### PR TITLE
[0.6] wallet: Properly save `wallet_payment::path_secrets`.

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1287,14 +1287,18 @@ void wallet_payment_store(struct wallet *wallet,
 		"  payment_hash,"
 		"  destination,"
 		"  msatoshi,"
-		"  timestamp"
-		") VALUES (?, ?, ?, ?, ?);");
+		"  timestamp,"
+		"  path_secrets"
+		") VALUES (?, ?, ?, ?, ?, ?);");
 
 	sqlite3_bind_int(stmt, 1, payment->status);
 	sqlite3_bind_sha256(stmt, 2, &payment->payment_hash);
 	sqlite3_bind_pubkey(stmt, 3, &payment->destination);
 	sqlite3_bind_int64(stmt, 4, payment->msatoshi);
 	sqlite3_bind_int(stmt, 5, payment->timestamp);
+	sqlite3_bind_blob(stmt, 6, payment->path_secrets,
+				   tal_len(payment->path_secrets),
+				   SQLITE_TRANSIENT);
 
 	db_exec_prepared(wallet->db, stmt);
 


### PR DESCRIPTION
Fixes: #657

Decided not to add the route information here --- instead save in DB separately.

Needed for #638 to progress, we cannot find the routing failure if `path_secrets` is not accessible inside `payment_failed`.