### PR TITLE
Don't greet new users with an error message

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -606,9 +606,8 @@ bool handle_opts(struct lightningd *ld, int argc, char *argv[])
 
 	/* Move to config dir, to save ourselves the hassle of path manip. */
 	if (chdir(ld->config_dir) != 0) {
-		log_unusual(ld->log, "Creating lightningd dir %s"
-			    " (because chdir gave %s)",
-			    ld->config_dir, strerror(errno));
+		log_unusual(ld->log, "Creating lightningd dir %s",
+			    ld->config_dir);
 		if (mkdir(ld->config_dir, 0700) != 0)
 			fatal("Could not make directory %s: %s",
 			      ld->config_dir, strerror(errno));


### PR DESCRIPTION
Don't greet new users with an error message (`No such file or directory`) for an expected non-failure condition. The important failure case is handled a few lines down after the `chdir(…)` call has been is repeated post-`mkdir(…)`.

Before this patch:

```
$ lightningd/lightningd
lightningd(PID): Creating lightningd dir /root/.lightning (because chdir gave No such file or directory)
lightningd(PID): Creating database
```

After this patch:

```
$ lightningd/lightningd
lightningd(PID): Creating lightningd dir /root/.lightning
lightningd(PID): Creating database
```