### PR TITLE
Added that peer id should be given to dev-sign-last-tx

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2813,7 +2813,7 @@ static void json_sign_last_tx(struct command *cmd,
 static const struct json_command dev_sign_last_tx = {
 	"dev-sign-last-tx",
 	json_sign_last_tx,
-	"Sign and return the last commitment transaction",
+	"Sign and return the last commitment transaction with peer {id}",
 	"Sign last transaction with peer @id, return as @tx."
 	"  This should never be called outside testing!"
 };


### PR DESCRIPTION
Similar format as line 2719 in peer_control.c      
Changing this changes the description in `help`, right? 
