### PR TITLE
lightning-cli: Add support for null argument.

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -103,6 +103,7 @@ int main(int argc, char *argv[])
 		if (strspn(argv[i], "0123456789") == strlen(argv[i])
 		    || streq(argv[i], "true")
 		    || streq(argv[i], "false")
+		    || streq(argv[i], "null")
 		    || argv[i][0] == '{'
 		    || argv[i][0] == '['
 		    || argv[i][0] == '"')

--- a/doc/lightning-cli.1
+++ b/doc/lightning-cli.1
@@ -2,12 +2,12 @@
 .\"     Title: lightning-cli
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 09/06/2016
+.\"      Date: 01/22/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-CLI" "1" "09/06/2016" "\ \&" "\ \&"
+.TH "LIGHTNING\-CLI" "1" "01/22/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -62,6 +62,11 @@ Print version number to standard output and exit\&.
 .SH "COMMANDS"
 .sp
 \fIlightning\-cli\fR simply uses the JSON RPC interface to talk to \fIlightningd\fR, and prints the results\&. Thus the commands available depend entirely on the lightning daemon itself\&.
+.SH "ARGUMENTS"
+.sp
+Arguments are provided positionally after the command name\&. Arguments may be integer numbers (composed entirely of digits), floating\-point numbers (has a radix point but otherwise composed of digits), \fItrue\fR, \fIfalse\fR, or \fInull\fR\&. Other arguments are treated as strings\&.
+.sp
+Some commands have optional arguments\&. You may use \fInull\fR to skip optional arguments to provide later arguments\&.
 .SH "EXAMPLES"
 .PP
 \fBExample\ \&1.\ \&List commands\fR

--- a/doc/lightning-cli.1.txt
+++ b/doc/lightning-cli.1.txt
@@ -34,6 +34,18 @@ COMMANDS
 and prints the results.  Thus the commands available depend entirely on the
 lightning daemon itself.
 
+ARGUMENTS
+---------
+Arguments are provided positionally after the command name.
+Arguments may be integer numbers (composed entirely of digits),
+floating-point numbers (has a radix point but otherwise composed
+of digits), 'true', 'false', or 'null'.
+Other arguments are treated as strings.
+
+Some commands have optional arguments.
+You may use 'null' to skip optional arguments to provide
+later arguments.
+
 EXAMPLES
 --------
 .List commands


### PR DESCRIPTION
Fixes: #685 

Should now allow `lightning-cli pay $BOLT11 null null $RISKFACTOR` to skip over optional `msatoshi` and `description` arguments.