### PR TITLE
Build fixes and increased cross-platform compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ CCAN_OBJS :=					\
 	ccan-opt-usage.o			\
 	ccan-opt.o				\
 	ccan-pipecmd.o				\
+	ccan-ptr_valid.o			\
 	ccan-read_write_all.o			\
 	ccan-str-hex.o				\
 	ccan-str.o				\
@@ -430,6 +431,8 @@ ccan-list.o: $(CCANDIR)/ccan/list/list.c
 ccan-asort.o: $(CCANDIR)/ccan/asort/asort.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 ccan-autodata.o: $(CCANDIR)/ccan/autodata/autodata.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+ccan-ptr_valid.o: $(CCANDIR)/ccan/ptr_valid/ptr_valid.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 ccan-read_write_all.o: $(CCANDIR)/ccan/read_write_all/read_write_all.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,10 @@ ALL_PROGRAMS =
 CPPFLAGS = -DBINTOPKGLIBEXECDIR='"'$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))'"'
 CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition
 CDEBUGFLAGS := -std=gnu11 -g -fstack-protector
-CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS
+CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS
 
-LDLIBS = -lgmp -lsqlite3 $(COVFLAGS)
+LDFLAGS = -L/usr/local/lib
+LDLIBS = -lm -lgmp -lsqlite3 $(COVFLAGS)
 
 default: all-programs all-test-programs
 

--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -4,6 +4,8 @@
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/wireaddr.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <wire/wire.h>
 
 /* Returns false if we didn't parse it, and *cursor == NULL if malformed. */

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -53,3 +53,36 @@ bitcoind &
 ```
 **Note**: You may need to include `testnet=1` in `bitcoin.conf`
 
+To Build on FreeBSD 11.1-RELEASE
+---------------------
+
+Get dependencies:
+```
+# pkg install -y autoconf automake git gmake libtool python python3 sqlite3
+```
+
+If you don't have Bitcoin installed locally you'll need to install that as well:
+```
+# pkg install -y bitcoin-daemon bitcoin-utils
+```
+
+Clone lightning:
+```
+$ git clone https://github.com/ElementsProject/lightning.git
+$ cd lightning
+```
+
+Build lightning:
+```
+$ gmake
+```
+
+Running lightning:
+
+**Note**: Edit your `/usr/local/etc/bitcoin.conf` to include `rpcuser=<foo>` and `rpcpassword=<bar>` first, you may also need to include `testnet=1`
+
+```
+# service bitcoind start
+$ ./lightningd/lightningd &
+$ ./cli/lightning-cli help
+```

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -29,6 +29,7 @@
 #include <lightningd/log.h>
 #include <lightningd/options.h>
 #include <onchaind/onchain_wire.h>
+#include <signal.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -14,6 +14,7 @@
 #include <lightningd/log.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <sys/socket.h>
 #include <sys/stat.h>


### PR DESCRIPTION
- Now builds on FreeBSD 11.1-RELEASE with clang 4.0.0
- Still builds on Ubuntu
- New `#include`s make the codebase more UNIX compatible.
- Now correctly builds and links `ptr_valid`