### PR TITLE
pylightning: Add and move example to README

### DIFF
--- a/contrib/pylightning/README.md
+++ b/contrib/pylightning/README.md
@@ -1,0 +1,34 @@
+# pylightning: A python client library for lightningd
+
+### Installation
+
+You need to have the futures python library installed to be able to use pylightning:
+
+```
+pip install futures
+```
+
+### Example
+
+```py
+from pylightning import LightningRpc
+import random
+
+# Create two instances of the LightningRpc object using two different c-lightning daemons on your computer
+l1 = LightningRpc("/tmp/lightning1/lightning-rpc")
+l5 = LightningRpc("/tmp/lightning5/lightning-rpc")
+
+info5 = l5.getinfo()
+print(info5)
+
+# Create invoice for test payment
+invoice = l5.invoice(100, "lbl{}".format(random.random()), "testpayment")
+print(invoice)
+
+# Get route to l1
+route = l1.getroute(info5['id'], 100, 1)
+print(route)
+
+# Pay invoice
+print(l1.sendpay(route['route'], invoice['payment_hash']))
+```

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -99,19 +99,3 @@ class LightningRpc(UnixDomainSocketRpc):
         msatoshi, {delay} blocks delay and {minblocks} minimum timeout
         """
         return self._call("dev-add-route", [src, dst, base, var, delay, minblocks])
-
-
-
-if __name__ == "__main__":
-    l1 = LightningRpc("/tmp/lightning1/lightning-rpc")
-    l5 = LightningRpc("/tmp/lightning5/lightning-rpc")
-
-    import random
-
-    info5 = l5.getinfo()
-    print(info5)
-    invoice = l5.invoice(100, "lbl{}".format(random.random()), "testpayment")
-    print(invoice)
-    route = l1.getroute(info5['id'], 100, 1)
-    print(route)
-    print(l1.sendpay(route['route'], invoice['payment_hash']))


### PR DESCRIPTION
Removed the example from the lighting python library code and started a README. I think this is better in terms of organization and allows the README to be extended in future with more elaborate examples.