### PR TITLE
Minor doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cli/lightning-cli fundchannel <node_id> <amount>
 
 This opens a connection and, on top of that connection, then opens a channel.
 The funding transaction needs 1 confirmations in order for the channel to be usable, and 6 to be broadcast for others to use.
-You can check the status of the channel using `cli/lightning-cli listpeers`, which after 1 confirmation should say that `state` is `CHANNELD_NORMAL`; after 6 confirmations you can use `cli/lightning-cli listchannels` to verify that the `public` field is now `true`.
+You can check the status of the channel using `cli/lightning-cli getpeers`, which after 1 confirmation should say that `state` is `CHANNELD_NORMAL`; after 6 confirmations you can use `cli/lightning-cli getchannels` to verify that the `public` field is now `true`.
 
 ### Sending and receiving payments
 


### PR DESCRIPTION
The CLI commands getpeers and getchannels were incorrectly referred to as listpeers and listchannels in readme.md. This caused me a few moments of confusion when getting lightning up and running.