### PR TITLE
Purge channels from the DB after they have been irrevocably committed

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1244,8 +1244,8 @@ static void handle_irrevocably_resolved(struct peer *peer, const u8 *msg)
 	/* FIXME: Implement check_htlcs to ensure no dangling hout->in ptrs! */
 	free_htlcs(peer->ld, peer);
 
-	/* FIXME: Remove peer from db. */
 	log_info(peer->log, "onchaind complete, forgetting peer");
+	wallet_channel_delete(peer->ld->wallet, peer->channel->id);
 
 	/* This will also free onchaind. */
 	free_peer(peer, "onchaind complete, forgetting peer");

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -836,6 +836,14 @@ void wallet_channel_save(struct wallet *w, struct wallet_channel *chan,
 	tal_free(tmpctx);
 }
 
+void wallet_channel_delete(struct wallet *w, u64 wallet_id)
+{
+	sqlite3_stmt *stmt;
+	stmt = db_prepare(w->db, "DELETE FROM channels WHERE id=?");
+	sqlite3_bind_int64(stmt, 1, wallet_id);
+	db_exec_prepared(w->db, stmt);
+}
+
 int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 				 u64 *total_satoshi)
 {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -216,6 +216,11 @@ void wallet_channel_save(struct wallet *w, struct wallet_channel *chan,
 			 u32 current_block_height);
 
 /**
+ * wallet_channel_delete -- After resolving a channel, forget about it
+ */
+void wallet_channel_delete(struct wallet *w, u64 wallet_id);
+
+/**
  * wallet_channel_config_save -- Upsert a channel_config into the database
  */
 void wallet_channel_config_save(struct wallet *w, struct channel_config *cc);


### PR DESCRIPTION
This may cause the lingering `onchaind_mutual` channels in #721. Channels didn't get removed from the DB even though they were removed in memory. Alternatively we could mark the channels as resolved by setting their status to something that we ignore when loading.

Dropping the channels cascades to remove all dependent tables, so this suffices to clear everything.