### PR TITLE
Onboarding: Make "lightning-cli" (without arguments) output the equivalent of "lightning-cli --help; lightning-cli help"

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -67,16 +67,20 @@ int main(int argc, char *argv[])
 	configdir_register_opts(ctx, &lightning_dir, &rpc_filename);
 
 	opt_register_noarg("--help|-h", opt_usage_and_exit,
-			   "<command> [<params>...]", "Show this message\t use the command help (without hyphen) to get a list of all commands");
+			   "<command> [<params>...]", "Show this message. Use the command help (without hyphens -- \"lightning-cli help\") to get a list of all RPC commands");
 	opt_register_version();
 
 	opt_early_parse(argc, argv, opt_log_stderr_exit);
 	opt_parse(&argc, argv, opt_log_stderr_exit);
 
 	method = argv[1];
-	if (!method)
-		errx(ERROR_USAGE, "Need at least one argument\n%s",
-		     opt_usage(argv[0], NULL));
+	if (!method) {
+		char *usage = opt_usage(argv[0], NULL);
+		printf("%s\n", usage);
+		tal_free(usage);
+		printf("Querying lightningd for available RPC commands (\"lightning-cli help\"):\n\n");
+		method = "help";
+	}
 
 	if (chdir(lightning_dir) != 0)
 		err(ERROR_TALKING_TO_LIGHTNINGD, "Moving into '%s'",

--- a/common/configdir.c
+++ b/common/configdir.c
@@ -30,7 +30,7 @@ void configdir_register_opts(const tal_t *ctx,
 
 	opt_register_early_arg("--lightning-dir", opt_set_talstr, opt_show_charp,
 			       configdir,
-			       "working directory: all other files are relative to this");
+			       "Set working directory. All other files are relative to this");
 
 	opt_register_arg("--rpc-file", opt_set_talstr, opt_show_charp,
 			 rpc_filename,


### PR DESCRIPTION
Make `lightning-cli` (without arguments) output the equivalent of `lightning-cli --help; lightning-cli help`

New users invoking `lightning-cli` are likely interested in what RPC commands they can invoke via the command.