### PR TITLE
Onboarding: tweak grammar conventions for RPC responses

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -563,7 +563,7 @@ void json_dev_broadcast(struct command *cmd,
 	}
 
 	if (!json_tok_bool(buffer, enabletok, &enable)) {
-		command_fail(cmd, "enable must be true or false");
+		command_fail(cmd, "Enable must be true or false");
 		return;
 	}
 
@@ -625,7 +625,7 @@ static void json_dev_setfees(struct command *cmd,
 			continue;
 		if (!json_tok_number(buffer, ratetok[i],
 				     &topo->override_fee_rate[i])) {
-			command_fail(cmd, "invalid feerate %.*s",
+			command_fail(cmd, "Invalid feerate %.*s",
 				     (int)(ratetok[i]->end - ratetok[i]->start),
 				     buffer + ratetok[i]->start);
 			return;

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -66,7 +66,7 @@ static void tell_waiter(struct command *cmd, const struct invoice *paid)
 }
 static void tell_waiter_deleted(struct command *cmd)
 {
-	command_fail(cmd, "invoice deleted during wait");
+	command_fail(cmd, "Invoice deleted during wait");
 }
 static void wait_on_invoice(const struct invoice *invoice, void *cmd)
 {
@@ -140,12 +140,12 @@ static void json_invoice(struct command *cmd,
 		return;
 	}
 	if (strlen(label_val) > INVOICE_MAX_LABEL_LEN) {
-		command_fail(cmd, "label '%s' over %u bytes", label_val,
+		command_fail(cmd, "Label '%s' over %u bytes", label_val,
 			     INVOICE_MAX_LABEL_LEN);
 		return;
 	}
 	if (exp && !json_tok_u64(buffer, exp, &expiry)) {
-		command_fail(cmd, "expiry '%.*s' invalid seconds",
+		command_fail(cmd, "Expiry '%.*s' invalid seconds",
 			     exp->end - exp->start,
 			     buffer + exp->start);
 		return;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -617,7 +617,7 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	if (cmd->deprecated && !deprecated_apis) {
 		command_fail_detailed(jcon->current,
 				      JSONRPC2_METHOD_NOT_FOUND, NULL,
-				      "command '%.*s' is deprecated",
+				      "Command '%.*s' is deprecated",
 				      (int)(method->end - method->start),
 				      jcon->buffer + method->start);
 		return;

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -39,7 +39,7 @@ static void json_pay_failed(struct command *cmd,
 {
 	/* Can be NULL if JSON RPC goes away. */
 	if (cmd) {
-		command_fail(cmd, "failed: %s (%s)",
+		command_fail(cmd, "Failed: %s (%s)",
 			     onion_type_name(failure_code), details);
 	}
 }
@@ -342,8 +342,8 @@ static bool send_payment(struct command *cmd,
 		/* FIXME: We should really do something smarter here! */
 		log_debug(cmd->ld->log, "json_sendpay: found previous");
 		if (payment->status == PAYMENT_PENDING) {
-			log_add(cmd->ld->log, "... still in progress");
-			command_fail(cmd, "still in progress");
+			log_add(cmd->ld->log, "Payment is still in progress");
+			command_fail(cmd, "Payment is still in progress");
 			return false;
 		}
 		if (payment->status == PAYMENT_COMPLETE) {
@@ -351,13 +351,13 @@ static bool send_payment(struct command *cmd,
 			/* Must match successful payment parameters. */
 			if (payment->msatoshi != hop_data[n_hops-1].amt_forward) {
 				command_fail(cmd,
-					     "already succeeded with amount %"
+					     "Already succeeded with amount %"
 					     PRIu64, payment->msatoshi);
 				return false;
 			}
 			if (!structeq(&payment->destination, &ids[n_hops-1])) {
 				command_fail(cmd,
-					     "already succeeded to %s",
+					     "Already succeeded to %s",
 					     type_to_string(cmd, struct pubkey,
 							    &payment->destination));
 				return false;
@@ -371,7 +371,7 @@ static bool send_payment(struct command *cmd,
 
 	peer = peer_by_id(cmd->ld, &ids[0]);
 	if (!peer) {
-		command_fail(cmd, "no connection to first peer found");
+		command_fail(cmd, "No connection to first peer found");
 		return false;
 	}
 
@@ -390,7 +390,7 @@ static bool send_payment(struct command *cmd,
 				 rhash, onion, NULL, cmd,
 				 &hout);
 	if (failcode) {
-		command_fail(cmd, "first peer not ready: %s",
+		command_fail(cmd, "First peer not ready: %s",
 			     onion_type_name(failcode));
 		return false;
 	}
@@ -463,7 +463,7 @@ static void json_sendpay(struct command *cmd,
 		const jsmntok_t *amttok, *idtok, *delaytok, *chantok;
 
 		if (t->type != JSMN_OBJECT) {
-			command_fail(cmd, "route %zu '%.*s' is not an object",
+			command_fail(cmd, "Route %zu '%.*s' is not an object",
 				     n_hops,
 				     (int)(t->end - t->start),
 				     buffer + t->start);
@@ -474,7 +474,7 @@ static void json_sendpay(struct command *cmd,
 		delaytok = json_get_member(buffer, t, "delay");
 		chantok = json_get_member(buffer, t, "channel");
 		if (!amttok || !idtok || !delaytok || !chantok) {
-			command_fail(cmd, "route %zu needs msatoshi/id/channel/delay",
+			command_fail(cmd, "Route %zu needs msatoshi/id/channel/delay",
 				     n_hops);
 			return;
 		}
@@ -483,22 +483,22 @@ static void json_sendpay(struct command *cmd,
 
 		/* What that hop will forward */
 		if (!json_tok_number(buffer, amttok, &route[n_hops].amount)) {
-			command_fail(cmd, "route %zu invalid msatoshi",
+			command_fail(cmd, "Route %zu invalid msatoshi",
 				     n_hops);
 			return;
 		}
 
 		if (!json_tok_short_channel_id(buffer, chantok,
 					       &route[n_hops].channel_id)) {
-			command_fail(cmd, "route %zu invalid channel_id", n_hops);
+			command_fail(cmd, "Route %zu invalid channel_id", n_hops);
 			return;
 		}
 		if (!json_tok_pubkey(buffer, idtok, &route[n_hops].nodeid)) {
-			command_fail(cmd, "route %zu invalid id", n_hops);
+			command_fail(cmd, "Route %zu invalid id", n_hops);
 			return;
 		}
 		if (!json_tok_number(buffer, delaytok, &route[n_hops].delay)) {
-			command_fail(cmd, "route %zu invalid delay", n_hops);
+			command_fail(cmd, "Route %zu invalid delay", n_hops);
 			return;
 		}
 		n_hops++;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -768,7 +768,7 @@ static void json_connect(struct command *cmd,
 		if (porttok) {
 			u32 port;
 			if (!json_tok_number(buffer, porttok, &port)) {
-				command_fail(cmd, "port %.*s not valid",
+				command_fail(cmd, "Port %.*s not valid",
 					     porttok->end - porttok->start,
 					     buffer + porttok->start);
 				return;
@@ -778,7 +778,7 @@ static void json_connect(struct command *cmd,
 			addr.port = DEFAULT_PORT;
 		}
 		if (!parse_wireaddr(name, &addr, addr.port) || !addr.port) {
-			command_fail(cmd, "host %s:%u not valid",
+			command_fail(cmd, "Host %s:%u not valid",
 				     name, addr.port);
 			return;
 		}

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3151,12 +3151,12 @@ class LightningDTests(BaseLightningDTests):
 
         # Can't pay while its offline.
         self.assertRaises(ValueError, l1.rpc.sendpay, to_json(route), rhash)
-        l1.daemon.wait_for_log('Failing: first peer not ready: WIRE_TEMPORARY_CHANNEL_FAILURE')
+        l1.daemon.wait_for_log('Failing: First peer not ready: WIRE_TEMPORARY_CHANNEL_FAILURE')
 
         # Should fail due to temporary channel fail
         self.assertRaises(ValueError, l1.rpc.sendpay, to_json(route), rhash)
-        l1.daemon.wait_for_log('Failing: first peer not ready: WIRE_TEMPORARY_CHANNEL_FAILURE')
-        assert not l1.daemon.is_in_log('... still in progress')
+        l1.daemon.wait_for_log('Failing: First peer not ready: WIRE_TEMPORARY_CHANNEL_FAILURE')
+        assert not l1.daemon.is_in_log('Payment is still in progress')
 
         # After it sees block, someone should close channel.
         bitcoind.generate_block(1)


### PR DESCRIPTION
Capitalized all CLI (JSON) error responses in-line with the rest of the error responses. Some minor textual tweaks for some error responses.