### PR TITLE
Usability: Prefix logging to stdout with ISO 8601 formatted date and time in UTC

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -68,11 +68,11 @@ static void log_to_file(const char *prefix,
 	fflush(logf);
 }
 
-static void log_default_print(const char *prefix,
-			      enum log_level level,
-			      bool continued,
-			      const struct timeabs *time,
-			      const char *str, void *arg)
+static void log_to_stdout(const char *prefix,
+			  enum log_level level,
+			  bool continued,
+			  const struct timeabs *time,
+			  const char *str, void *arg)
 {
 	log_to_file(prefix, level, continued, time, str, stdout);
 }
@@ -122,7 +122,7 @@ struct log_book *new_log_book(const tal_t *ctx,
 	assert(max_mem > sizeof(struct log) * 2);
 	lr->mem_used = 0;
 	lr->max_mem = max_mem;
-	lr->print = log_default_print;
+	lr->print = log_to_stdout;
 	lr->print_level = printlevel;
 	lr->init_time = time_now();
 	list_head_init(&lr->log);
@@ -467,7 +467,7 @@ static void log_crash(int sig)
 				       crashlog);
 	}
 
-	if (crashlog->lr->print == log_default_print) {
+	if (crashlog->lr->print == log_to_stdout) {
 		int fd;
 
 		/* We expect to be in config dir. */

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -53,10 +53,17 @@ static void log_default_print(const char *prefix,
 			      bool continued,
 			      const char *str, void *arg)
 {
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	char iso8601_msec_fmt[sizeof("YYYY-mm-ddTHH:MM:SS.%03dZ")];
+	strftime(iso8601_msec_fmt, sizeof(iso8601_msec_fmt), "%FT%T.%%03dZ", gmtime(&tv.tv_sec));
+	char iso8601_s[sizeof("YYYY-mm-ddTHH:MM:SS.nnnZ")];
+	snprintf(iso8601_s, sizeof(iso8601_s), iso8601_msec_fmt, (int) tv.tv_usec / 1000);
+
 	if (!continued) {
-		printf("%s %s\n", prefix, str);
+		printf("%s %s %s\n", iso8601_s, prefix, str);
 	} else {
-		printf("%s \t%s\n", prefix, str);
+		printf("%s %s \t%s\n", iso8601_s, prefix, str);
 	}
 	fflush(stdout);
 }

--- a/lightningd/log.h
+++ b/lightningd/log.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_LIGHTNINGD_LOG_H
 #include "config.h"
 #include <ccan/tal/tal.h>
+#include <ccan/time/time.h>
 #include <ccan/typesafe_cb/typesafe_cb.h>
 #include <common/type_to_string.h>
 #include <stdarg.h>
@@ -54,12 +55,14 @@ const char *log_prefix(const struct log *log);
 					   const char *,		\
 					   enum log_level,		\
 					   bool,			\
+					   const struct timeabs *,	\
 					   const char *), (arg))
 
 void set_log_outfn_(struct log_book *lr,
 		    void (*print)(const char *prefix,
 				  enum log_level level,
 				  bool continued,
+				  const struct timeabs *time,
 				  const char *str, void *arg),
 		    void *arg);
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -697,6 +697,7 @@ send_error:
 static void copy_to_parent_log(const char *prefix,
 			       enum log_level level,
 			       bool continued,
+			       const struct timeabs *time,
 			       const char *str,
 			       struct peer *peer)
 {


### PR DESCRIPTION
Prefix logging to standard output with [ISO 8601](https://sv.wikipedia.org/wiki/ISO_8601) formatted date and time in UTC.

Before this patch:

```
$ lightningd/lightningd
lightningd(PID): Server started with public key …
```

After this patch:

```
$ lightningd/lightningd
2018-01-26T14:38:22.210Z lightningd(PID): Server started with public key …
```