### PR TITLE
Explain table vars

### DIFF
--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -137,11 +137,11 @@ Table `vars` contains global variables used by lightning node.
     bip32_max_index|4
     ...
 
-Note:
+Variables:
 * `next_pay_index` last resolved invoice counter.
 * `bip32_max_index` last wallet derivation counter. 
 
-Every times `newaddr` command is called, a new wallet is generated with Bip32 derivation and `bip32_max_index` counter is increased to the last derivation index.
+Note: Every times `newaddr` command is called, a new wallet is generated with Bip32 derivation and `bip32_max_index` counter is increased to the last derivation index.
 Each address generated after `bip32_max_index` is not included as lightning funds.
 
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -124,6 +124,27 @@ Some data is stored as raw bytes, use `HEX(column)` to pretty print these.
 Make sure that clightning is not running when you query the database, as some
 queries may lock the database and cause crashes.
 
+#### Common variables
+Table `vars` contains global variables used by lightning node.
+
+    $ sqlite3 ~/.lightning/lightningd.sqlite3
+    SQLite version 3.21.0 2017-10-24 18:55:49
+    Enter ".help" for usage hints.
+    sqlite> .headers on
+    sqlite> select * from vars;
+    name|val
+    next_pay_index|2
+    bip32_max_index|4
+    ...
+
+Note:
+* `next_pay_index` last resolved invoice counter.
+* `bip32_max_index` last wallet derivation counter. 
+
+Every times `newaddr` command is called, a new wallet is generated with Bip32 derivation and `bip32_max_index` counter is increased to the last derivation index.
+Each address generated after `bip32_max_index` is not included as lightning funds.
+
+
 Testing
 -------
 


### PR DESCRIPTION
Explain table `vars` and `bip32_max_index` variable used to check bip32 wallet derivation.