### PR TITLE
Properly comply with Error Objects of JSON-RPC 2.0

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -457,6 +457,11 @@ void json_add_num(struct json_result *result, const char *fieldname, unsigned in
 	json_start_member(result, fieldname);
 	result_append_fmt(result, "%u", value);
 }
+void json_add_snum(struct json_result *result, const char *fieldname, int value)
+{
+	json_start_member(result, fieldname);
+	result_append_fmt(result, "%d", value);
+}
 
 void json_add_u64(struct json_result *result, const char *fieldname,
 		  uint64_t value)

--- a/common/json.h
+++ b/common/json.h
@@ -89,6 +89,9 @@ void json_add_string(struct json_result *result, const char *fieldname, const ch
 void json_add_literal(struct json_result *result, const char *fieldname,
 		      const char *literal, int len);
 /* '"fieldname" : value' or 'value' if fieldname is NULL */
+void json_add_snum(struct json_result *result, const char *fieldname,
+		   int value);
+/* '"fieldname" : value' or 'value' if fieldname is NULL */
 void json_add_num(struct json_result *result, const char *fieldname,
 		  unsigned int value);
 /* '"fieldname" : value' or 'value' if fieldname is NULL */

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -324,24 +324,38 @@ static void connection_result(struct json_connection *jcon,
 			      const char *id,
 			      const char *res,
 			      const char *err,
-			      int code)
+			      int code,
+			      const struct json_result *data)
 {
 	struct json_output *out = tal(jcon, struct json_output);
+	const tal_t *tmpctx;
+	const char* data_str;
+
 	if (err == NULL)
 		out->json = tal_fmt(out,
 				    "{ \"jsonrpc\": \"2.0\", "
 				    "\"result\" : %s,"
 				    " \"id\" : %s }\n",
 				    res, id);
-	else
+	else {
+		tmpctx = tal_tmpctx(out);
+		if (data)
+			data_str = tal_fmt(tmpctx,
+					   ", \"data\" : %s",
+					   json_result_string(data));
+		else
+			data_str = "";
+
 		out->json = tal_fmt(out,
 				    "{ \"jsonrpc\": \"2.0\", "
 				    " \"error\" : "
 				      "{ \"code\" : %d,"
-				      " \"message\" : %s},"
+				      " \"message\" : %s%s },"
 				    " \"id\" : %s }\n",
-				    code,
-				    err, id);
+				    code, err, data_str,
+				    id);
+		tal_free(tmpctx);
+	}
 
 	/* Queue for writing, and wake writer (and maybe reader). */
 	list_add_tail(&jcon->output, &out->list);
@@ -436,16 +450,19 @@ void command_success(struct command *cmd, struct json_result *result)
 		return;
 	}
 	assert(jcon->current == cmd);
-	connection_result(jcon, cmd->id, json_result_string(result), NULL, 0);
+	connection_result(jcon, cmd->id, json_result_string(result),
+			  NULL, 0, NULL);
 	log_debug(jcon->log, "Success");
 	jcon->current = tal_free(cmd);
 }
 
-void command_fail(struct command *cmd, const char *fmt, ...)
+static void command_fail_v(struct command *cmd,
+			   int code,
+			   const struct json_result *data,
+			   const char *fmt, va_list ap)
 {
 	char *quote, *error;
 	struct json_connection *jcon = cmd->jcon;
-	va_list ap;
 
 	if (!jcon) {
 		log_unusual(cmd->ld->log,
@@ -454,9 +471,7 @@ void command_fail(struct command *cmd, const char *fmt, ...)
 		return;
 	}
 
-	va_start(ap, fmt);
 	error = tal_vfmt(cmd, fmt, ap);
-	va_end(ap);
 
 	log_debug(jcon->log, "Failing: %s", error);
 
@@ -468,8 +483,24 @@ void command_fail(struct command *cmd, const char *fmt, ...)
 	quote = tal_fmt(cmd, "\"%s\"", error);
 
 	assert(jcon->current == cmd);
-	connection_result(jcon, cmd->id, NULL, quote, -1);
+	connection_result(jcon, cmd->id, NULL, quote, -1, data);
 	jcon->current = tal_free(cmd);
+}
+void command_fail(struct command *cmd, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	command_fail_v(cmd, -1, NULL, fmt, ap);
+	va_end(ap);
+}
+void command_fail_detailed(struct command *cmd,
+			   int code, const struct json_result *data,
+			   const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	command_fail_v(cmd, code, data, fmt, ap);
+	va_end(ap);
 }
 
 void command_still_pending(struct command *cmd)
@@ -484,7 +515,8 @@ static void json_command_malformed(struct json_connection *jcon,
 				   const char *error)
 {
 	return connection_result(jcon, id, NULL, error,
-				 JSONRPC2_INVALID_REQUEST);
+				 JSONRPC2_INVALID_REQUEST,
+				 NULL);
 }
 
 static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -333,7 +333,7 @@ static void json_result(struct json_connection *jcon,
 	else
 		out->json = tal_fmt(out,
 				    "{ \"jsonrpc\": \"2.0\", "
-				    " \"error\" : %s,"
+				    " \"error\" : { \"code\" : -1, \"message\" : %s},"
 				    " \"id\" : %s }\n",
 				    err, id);
 

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -58,6 +58,10 @@ struct json_command {
 struct json_result *null_response(const tal_t *ctx);
 void command_success(struct command *cmd, struct json_result *response);
 void PRINTF_FMT(2, 3) command_fail(struct command *cmd, const char *fmt, ...);
+void PRINTF_FMT(4, 5) command_fail_detailed(struct command *cmd,
+					     int code,
+					     const struct json_result *data,
+					     const char *fmt, ...);
 
 /* Mainly for documentation, that we plan to close this later. */
 void command_still_pending(struct command *cmd);


### PR DESCRIPTION
http://www.jsonrpc.org/specification#error_object

Partly in preparation for #638, where we will modify `sendpay` to report routing failures via the `data` field of error objects. Since we currently do NOT actually use error objects, this PR is required first.