### PR TITLE
Allow pong when in CHANNELD_AWAITING_LOCKIN

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1579,7 +1579,8 @@ static void peer_in(struct peer *peer, const u8 *msg)
 		    && type != WIRE_CHANNEL_ANNOUNCEMENT
 		    && type != WIRE_CHANNEL_UPDATE
 		    && type != WIRE_NODE_ANNOUNCEMENT
-		    && type != WIRE_PING) {
+		    && type != WIRE_PING
+		    && type != WIRE_PONG) {
 			peer_failed(PEER_FD,
 				    &peer->cs,
 				    &peer->channel_id,


### PR DESCRIPTION
Right now it allows ping but not pong. 
If A sends a ping expecting a pong to B during CHANNELD_AWAITING_LOCKIN,
It would result in 
`STATUS_FAIL_PEER_BAD: WIRE_PONG (19) before funding locked`    
resulting in an unilateral channel close by A.