### PR TITLE
Unwatch for onchaind

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1195,7 +1195,20 @@ static void handle_onchain_broadcast_tx(struct peer *peer, const u8 *msg)
 
 static void handle_onchain_unwatch_tx(struct peer *peer, const u8 *msg)
 {
-	/* FIXME: unwatch tx and children here. */
+	struct bitcoin_txid txid;
+	struct txwatch *txw;
+
+	if (!fromwire_onchain_unwatch_tx(msg, NULL, &txid)) {
+		peer_internal_error(peer, "Invalid onchain_unwatch_tx");
+		return;
+	}
+
+	/* Frees the txo watches, too: see watch_tx_and_outputs() */
+	txw = find_txwatch(peer->ld->topology, &txid, peer);
+	if (!txw)
+		log_unusual(peer->log, "Can't unwatch txid %s",
+			    type_to_string(ltmp, struct bitcoin_txid, &txid));
+	tal_free(txw);
 }
 
 static void handle_extracted_preimage(struct peer *peer, const u8 *msg)

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -112,6 +112,24 @@ struct txwatch *watch_txid_(const tal_t *ctx,
 	return w;
 }
 
+struct txwatch *find_txwatch(struct chain_topology *topo,
+			     const struct bitcoin_txid *txid,
+			     const struct peer *peer)
+{
+	struct txwatch_hash_iter i;
+	struct txwatch *w;
+
+	/* We could have more than one peer watching same txid, though we
+	 * don't for onchaind. */
+	for (w = txwatch_hash_getfirst(&topo->txwatches, txid, &i);
+	     w;
+	     w = txwatch_hash_getnext(&topo->txwatches, txid, &i)) {
+		if (w->peer == peer)
+			break;
+	}
+	return w;
+}
+
 bool watching_txid(const struct chain_topology *topo,
 		   const struct bitcoin_txid *txid)
 {

--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -134,6 +134,10 @@ struct txowatch *watch_txo_(const tal_t *ctx,
 				       const struct block *block),	\
 		  (cbdata))
 
+struct txwatch *find_txwatch(struct chain_topology *topo,
+			     const struct bitcoin_txid *txid,
+			     const struct peer *peer);
+
 void txwatch_fire(struct chain_topology *topo,
 		  const struct bitcoin_tx *tx,
 		  unsigned int depth);

--- a/onchaind/onchain.c
+++ b/onchaind/onchain.c
@@ -508,7 +508,7 @@ static void unwatch_tx(const struct bitcoin_tx *tx)
 
 	bitcoin_txid(tx, &txid);
 
-	msg = towire_onchain_unwatch_tx(tx, &txid, tal_count(tx->output));
+	msg = towire_onchain_unwatch_tx(tx, &txid);
 	wire_sync_write(REQ_FD, take(msg));
 }
 

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -62,7 +62,6 @@ onchain_depth,,depth,u32
 # onchaind->master: We don't want to watch this tx, or its outputs
 onchain_unwatch_tx,5006
 onchain_unwatch_tx,,txid,struct bitcoin_txid
-onchain_unwatch_tx,,num_outputs,u32
 
 # master->onchaind: We know HTLC preimage
 onchain_known_preimage,5007

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2427,6 +2427,13 @@ class LightningDTests(BaseLightningDTests):
         c.execute('SELECT COUNT(*) FROM outputs WHERE status=0')
         assert(c.fetchone()[0] == 6)
 
+        # Test withdrawal to self.
+        out = l1.rpc.withdraw(l1.rpc.newaddr()['address'], 'all')
+        bitcoind.rpc.generate(1)
+        c = db.cursor()
+        c.execute('SELECT COUNT(*) FROM outputs WHERE status=0')
+        assert(c.fetchone()[0] == 1)
+        
         out = l1.rpc.withdraw(waddr, 'all')
         c = db.cursor()
         c.execute('SELECT COUNT(*) FROM outputs WHERE status=0')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,11 +108,11 @@ class TailableProc(object):
         self.running = False
         self.proc.stdout.close()
 
-    def is_in_log(self, regex):
+    def is_in_log(self, regex, start = 0):
         """Look for `regex` in the logs."""
 
         ex = re.compile(regex)
-        for l in self.logs:
+        for l in self.logs[start:]:
             if ex.search(l):
                 logging.debug("Found '%s' in logs", regex)
                 return True

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -58,7 +58,9 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind,
 		tx = bitcoin_tx_from_hex(withdraw, withdraw->hextx, strlen(withdraw->hextx));
 		assert(tx != NULL);
 		wallet_extract_owned_outputs(ld->wallet, tx, &change_satoshi);
-		assert(change_satoshi == withdraw->changesatoshi);
+
+		/* Note normally, change_satoshi == withdraw->changesatoshi, but
+		 * not if we're actually making a payment to ourselves! */
 
 		struct json_result *response = new_json_result(cmd);
 		json_object_start(response, NULL);


### PR DESCRIPTION
@cdecker reported we were using a heap of mem and falling behind in blocks which onchaind was spamming the logs with "Notified about tx %s output %u spend, but we don't care" messages.

Currently, we follow all txs from the funding tx onwards, in case onchaind is interested in them.  We have a FIXME to do something when onchaind says it's not interested, so this actually fixes that.