### PR TITLE
bitcoind: mark request no longer running, even if it fails.

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -140,7 +140,7 @@ static void bcli_finished(struct io_conn *conn, struct bitcoin_cli *bcli)
 				      (int)bcli->output_bytes,
 				      bcli->output);
 			bitcoind->error_count++;
-
+			bitcoind->req_running = false;
 			goto done;
 		}
 	} else


### PR DESCRIPTION
We added code to allow a few spurious failures, but it didn't unmark
the request running.

IRC user 'mlz' provided logs from his stuck-at-old-block lightningd:

lightningd(31981): Adding block 1261159: 00000000da3890ccd0f313a74fccfd4789654b496836da5c28a8d2ad28852264

lightningd(31981): Adding block 1261160: 00000000f70938a33aecbdd7b047cb5cf5b095ea4770c1335acf1859bad1e767

lightningd(31981): bitcoin-cli -testnet estimatesmartfee 2 CONSERVATIVE exited with status 1

Fixes: #749
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

I wonder if this is also implicated in #803 ...