### PR TITLE
Cache txouts and avoid duplicate lookups

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -618,6 +618,11 @@ const struct short_channel_id *handle_channel_announcement(
 	tal_free(tag);
 
 	/* FIXME: Handle duplicates as per BOLT #7 */
+
+	if (find_pending_cannouncement(rstate, &pending->short_channel_id) != NULL) {
+		/* Drop it like it's hot */
+		return tal_free(pending);
+	}
 	list_add_tail(&rstate->pending_cannouncement, &pending->list);
 	return &pending->short_channel_id;
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -614,8 +614,8 @@ void peer_connection_failed(struct lightningd *ld, const u8 *msg)
 	bool addr_unknown;
 	char *error;
 
-	if (!fromwire_gossip_peer_connection_failed(msg, NULL, &id, &attempts,
-						    &timediff, &addr_unknown))
+	if (!fromwire_gossip_peer_connection_failed(msg, NULL, &id, &timediff,
+						    &attempts, &addr_unknown))
 		fatal(
 		    "Gossip gave bad GOSSIP_PEER_CONNECTION_FAILED message %s",
 		    tal_hex(msg, msg));


### PR DESCRIPTION
This is just a quick fix to reduce the number of lookups, more elaborate optimizations coming soon.

This avoids duplicating lookups while we are already looking up txouts, and it avoids doing a lookup, only to discard it later because we already know about the channel.