### PR TITLE
wallet: Add a simple txo rescan command to sync with bitcoind UTXO

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -570,14 +570,6 @@ static void process_getblock(struct bitcoin_cli *bcli)
 	go->cb = cb;
 	/* Now get the raw tx output. */
 	bitcoind_gettxout(bcli->bitcoind, &txid, go->outnum, process_get_output, go);
-/*
-	start_bitcoin_cli(bcli->bitcoind, NULL,
-			  process_gettxout, true, process_get_output, go,
-			  "gettxout",
-			  take(type_to_string(go, struct bitcoin_txid, &txid)),
-			  take(tal_fmt(go, "%u", go->outnum)),
-			  NULL);
-*/
 }
 
 static void process_getblockhash_for_txout(struct bitcoin_cli *bcli)
@@ -670,16 +662,12 @@ void bitcoind_gettxout(struct bitcoind *bitcoind,
 				  void *arg),
 		       void *arg)
 {
-	tal_t *tmpctx = tal_tmpctx(bitcoind);
-
-
 	start_bitcoin_cli(bitcoind, NULL,
 			  process_gettxout, true, cb, arg,
 			  "gettxout",
-			  take(type_to_string(tmpctx, struct bitcoin_txid, txid)),
-			  take(tal_fmt(tmpctx, "%u", outnum)),
+			  take(type_to_string(NULL, struct bitcoin_txid, txid)),
+			  take(tal_fmt(NULL, "%u", outnum)),
 			  NULL);
-	tal_free(tmpctx);
 }
 
 static void destroy_bitcoind(struct bitcoind *bitcoind)

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_LIGHTNINGD_BITCOIND_H
 #include "config.h"
 #include <bitcoin/chainparams.h>
+#include <bitcoin/tx.h>
 #include <ccan/list/list.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
@@ -147,5 +148,12 @@ void bitcoind_getoutput_(struct bitcoind *bitcoind,
 						struct bitcoind *,	\
 						const struct bitcoin_tx_output*), \
 			    (arg))
+
+void bitcoind_gettxout(struct bitcoind *bitcoind,
+		       const struct bitcoin_txid *txid, const u32 outnum,
+		       void (*cb)(struct bitcoind *bitcoind,
+				  const struct bitcoin_tx_output *txout,
+				  void *arg),
+		       void *arg);
 
 #endif /* LIGHTNING_LIGHTNINGD_BITCOIND_H */


### PR DESCRIPTION
So many channels stuck in channeld_awaiting_lockin, and I don't like
suggesting manually editing the DB, so this adds a very simple way to
sync with bitcoind's UTXO view. `dev` since it is dangerous, then
again if bitcoind says those funds aren't available there's little we
can do anyway.