### PR TITLE
check-spelling: don't paginate, and give file and line.

### DIFF
--- a/tools/check-spelling.sh
+++ b/tools/check-spelling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git grep -iE 'l[ightn]{6}g|l[ightn]{8}g|ilghtning|lgihtning|lihgtning|ligthning|lighnting|lightinng|lightnnig|lightnign' -- . ':!tools/check-spelling.sh'
+git --no-pager grep -nHiE 'l[ightn]{6}g|l[ightn]{8}g|ilghtning|lgihtning|lihgtning|ligthning|lighnting|lightinng|lightnnig|lightnign' -- . ':!tools/check-spelling.sh'
 if [[ $? == 0 ]]; then
     echo "Identified a likely misspelling of the word \"lightning\" (see above). Please fix."
     echo "Is this warning incorrect? Please teach tools/check-spelling.sh about the exciting new word."


### PR DESCRIPTION
The pagination causes it to wait for a keypress even with no output
under emacs (complaining about the terminal); we don't want it anyway.

Example output:

Makefile:228:#lighnting!
Identified a likely misspelling of the word "lightning" (see above). Please fix.
Is this warning incorrect? Please teach tools/check-spelling.sh about the exciting new word.
Makefile:230: recipe for target 'check-spelling' failed

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>