### PR TITLE
Mark last parameter of log_to_stdout(...) as intentionally unused

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -72,7 +72,7 @@ static void log_to_stdout(const char *prefix,
 			  enum log_level level,
 			  bool continued,
 			  const struct timeabs *time,
-			  const char *str, void *arg)
+			  const char *str, void *unused UNUSED)
 {
 	log_to_file(prefix, level, continued, time, str, stdout);
 }


### PR DESCRIPTION
Mark last parameter of `log_to_stdout(...)` as intentionally unused.