### PR TITLE
Make gossipd more forgiving of temporary routing failures

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -341,6 +341,12 @@ static void bfg_one_edge(struct node *node, size_t edgenum, double riskfactor)
 	}
 }
 
+/* Determine if the given node_connection is routable */
+static bool nc_is_routable(const struct node_connection *nc)
+{
+	return nc->active;
+}
+
 /* riskfactor is already scaled to per-block amount */
 static struct node_connection *
 find_route(const tal_t *ctx, struct routing_state *rstate,
@@ -397,8 +403,8 @@ find_route(const tal_t *ctx, struct routing_state *rstate,
 					     type_to_string(trc, struct pubkey,
 							    &n->id),
 					     i, num_edges);
-				if (!n->in[i]->active) {
-					SUPERVERBOSE("...inactive");
+				if (!nc_is_routable(n->in[i])) {
+					SUPERVERBOSE("...unroutable");
 					continue;
 				}
 				bfg_one_edge(n, i, riskfactor);

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -38,6 +38,10 @@ struct node_connection {
 	/* Cached `channel_announcement` and `channel_update` we might forward to new peers*/
 	u8 *channel_announcement;
 	u8 *channel_update;
+
+	/* If greater than current time, this connection should not
+	 * be used for routing. */
+	time_t unroutable_until;
 };
 
 struct node {


### PR DESCRIPTION
Fixes: #867 

Policy: disable failing channels for 20 seconds, or the next `channel_update`.

Implementation: Use a `u64 unroutable_until`, a UNIX-time variable, which prevents a channel from being used for routing if less than the current time in UNIX epoch.  Set this to 20+current time if routing failure reported.  Set to 0 on construction or `channel_update`.