### PR TITLE
jsonrpc: Let failing of `cmd` free `names`

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -685,7 +685,6 @@ bool json_get_params(struct command *cmd,
 			command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS, NULL,
 					      "Missing '%s' parameter",
 					      names[num_names]);
-			tal_free(names);
 			return false;
 		}
 		num_names++;

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3239,5 +3239,18 @@ class LightningDTests(BaseLightningDTests):
         j, _ = json.JSONDecoder().raw_decode(out)
         assert 'help [command]' in j['verbose'] 
 
+        # Test missing parameters.
+        try:
+            # This will error due to missing parameters.
+            # We want to check if lightningd will crash.
+            out = subprocess.check_output(['cli/lightning-cli',
+                                           '--lightning-dir={}'
+                                           .format(l1.daemon.lightning_dir),
+                                           '-J', '-o',
+                                           'sendpay']).decode('utf-8')
+        except:
+            pass
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes: #885
