### PR TITLE
gossipd performance improvements

### DIFF
--- a/bitcoin/short_channel_id.c
+++ b/bitcoin/short_channel_id.c
@@ -32,3 +32,9 @@ bool short_channel_id_eq(const struct short_channel_id *a,
 	return a->blocknum == b->blocknum && a->txnum == b->txnum &&
 	       a->outnum == b->outnum;
 }
+
+u64 short_channel_id_to_uint(const struct short_channel_id *scid)
+{
+	return ((u64)scid->blocknum & 0xFFFFFF) << 40 |
+	       ((u64)scid->txnum & 0xFFFFFF) << 16 | (scid->outnum & 0xFFFF);
+}

--- a/bitcoin/short_channel_id.h
+++ b/bitcoin/short_channel_id.h
@@ -25,4 +25,7 @@ bool short_channel_id_eq(const struct short_channel_id *a,
 
 char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid);
 
+/* Fast, platform dependent, way to convert from a short_channel_id to u64 */
+u64 short_channel_id_to_uint(const struct short_channel_id *scid);
+
 #endif /* LIGHTNING_BITCOIN_SHORT_CHANNEL_ID_H */

--- a/gossipd/broadcast.c
+++ b/gossipd/broadcast.c
@@ -22,6 +22,28 @@ static struct queued_message *new_queued_message(tal_t *ctx,
 	return msg;
 }
 
+bool replace_broadcast(struct broadcast_state *bstate, u64 *index,
+		       const int type, const u8 *tag, const u8 *payload)
+{
+	struct queued_message *msg;
+	bool evicted = false;
+
+	msg = uintmap_get(&bstate->broadcasts, *index);
+	if (msg && msg->type == type &&
+	    memeq(msg->tag, tal_len(msg->tag), tag, tal_len(tag))) {
+		uintmap_del(&bstate->broadcasts, *index);
+		tal_free(msg);
+		evicted = true;
+	}
+
+	*index = bstate->next_index;
+	/* Now add the message to the queue */
+	msg = new_queued_message(bstate, type, tag, payload);
+	uintmap_add(&bstate->broadcasts, *index, msg);
+	bstate->next_index++;
+	return evicted;
+}
+
 bool queue_broadcast(struct broadcast_state *bstate,
 		     const int type,
 		     const u8 *tag,
@@ -37,7 +59,8 @@ bool queue_broadcast(struct broadcast_state *bstate,
 	for (msg = uintmap_first(&bstate->broadcasts, &index);
 	     msg;
 	     msg = uintmap_after(&bstate->broadcasts, &index)) {
-		if (msg->type == type && memcmp(msg->tag, tag, tal_len(tag)) == 0) {
+		if (msg->type == type &&
+		    memeq(msg->tag, tal_len(msg->tag), tag, tal_len(tag))) {
 			uintmap_del(&bstate->broadcasts, index);
 			tal_free(msg);
 			evicted = true;

--- a/gossipd/broadcast.h
+++ b/gossipd/broadcast.h
@@ -20,8 +20,8 @@ struct queued_message {
 };
 
 struct broadcast_state {
-u32 next_index;
-UINTMAP(struct queued_message *) broadcasts;
+	u32 next_index;
+	UINTMAP(struct queued_message *) broadcasts;
 };
 
 struct broadcast_state *new_broadcast_state(tal_t *ctx);
@@ -35,6 +35,17 @@ bool queue_broadcast(struct broadcast_state *bstate,
 			     const int type,
 			     const u8 *tag,
 			     const u8 *payload);
+
+/* Replace a queued message with @index, if it matches the type and
+ * tag for the new message. The new message will be queued with the
+ * next highest index. @index is updated to hold the index of the
+ * newly queued message*/
+bool replace_broadcast(struct broadcast_state *bstate,
+		       u64 *index,
+		       const int type,
+		       const u8 *tag,
+		       const u8 *payload);
+
 
 struct queued_message *next_broadcast_message(struct broadcast_state *bstate, u64 last_index);
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -797,6 +797,7 @@ static void handle_local_add_channel(struct peer *peer, u8 *msg)
 	chan->public = false;
 	uintmap_add(&rstate->channels, short_channel_id_to_uint(&scid), chan);
 
+	chan->pending = NULL;
 	direction = get_channel_direction(&rstate->local_id, &remote_node_id);
 	c = half_add_connection(rstate, &rstate->local_id, &remote_node_id, &scid, direction);
 	channel_add_connection(rstate, chan, c);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -771,6 +771,7 @@ static void handle_local_add_channel(struct peer *peer, u8 *msg)
 	u32 fee_base_msat, fee_proportional_millionths;
 	u64 htlc_minimum_msat;
 	struct node_connection *c;
+	struct routing_channel *chan;
 
 	if (!fromwire_gossip_local_add_channel(
 		msg, NULL, &scid, &chain_hash, &remote_node_id, &flags,
@@ -792,8 +793,13 @@ static void handle_local_add_channel(struct peer *peer, u8 *msg)
 		return;
 	}
 
+	chan = routing_channel_new(rstate, &scid);
+	chan->public = false;
+	uintmap_add(&rstate->channels, short_channel_id_to_uint(&scid), chan);
+
 	direction = get_channel_direction(&rstate->local_id, &remote_node_id);
 	c = half_add_connection(rstate, &rstate->local_id, &remote_node_id, &scid, direction);
+	channel_add_connection(rstate, chan, c);
 
 	c->active = true;
 	c->last_timestamp = 0;

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -183,23 +183,13 @@ struct node_connection *get_connection_by_scid(const struct routing_state *rstat
 					      const struct short_channel_id *schanid,
 					      const u8 direction)
 {
-	struct node *n;
-	int i, num_conn;
-	struct node_map *nodes = rstate->nodes;
-	struct node_connection *c;
-	struct node_map_iter it;
+	u64 scid = short_channel_id_to_uint(schanid);
+	struct routing_channel *chan = uintmap_get(&rstate->channels, scid);
 
-	//FIXME(cdecker) We probably want to speed this up by indexing by chanid.
-	for (n = node_map_first(nodes, &it); n; n = node_map_next(nodes, &it)) {
-	        num_conn = tal_count(n->out);
-		for (i = 0; i < num_conn; i++){
-			c = n->out[i];
-			if (short_channel_id_eq(&c->short_channel_id, schanid) &&
-			    (c->flags&0x1) == direction)
-			    return c;
-		}
-	}
-	return NULL;
+	if (chan == NULL)
+		return NULL;
+	else
+		return chan->connections[direction];
 }
 
 static struct node_connection *

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -130,6 +130,7 @@ static struct node *new_node(struct routing_state *rstate,
 	n->out = tal_arr(n, struct node_connection *, 0);
 	n->alias = NULL;
 	n->node_announcement = NULL;
+	n->announcement_idx = 0;
 	n->last_timestamp = -1;
 	n->addresses = tal_arr(n, struct wireaddr, 0);
 	node_map_add(rstate->nodes, n);
@@ -1038,10 +1039,11 @@ void handle_node_announcement(
 
 	u8 *tag = tal_arr(tmpctx, u8, 0);
 	towire_pubkey(&tag, &node_id);
-	queue_broadcast(rstate->broadcasts,
-			WIRE_NODE_ANNOUNCEMENT,
-			tag,
-			serialized);
+	replace_broadcast(rstate->broadcasts,
+			  &node->announcement_idx,
+			  WIRE_NODE_ANNOUNCEMENT,
+			  tag,
+			  serialized);
 	tal_free(node->node_announcement);
 	node->node_announcement = tal_steal(node, serialized);
 	tal_free(tmpctx);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -68,6 +68,8 @@ struct routing_state *new_routing_state(const tal_t *ctx,
 	rstate->chain_hash = *chain_hash;
 	rstate->local_id = *local_id;
 	list_head_init(&rstate->pending_cannouncement);
+	uintmap_init(&rstate->channels);
+
 	return rstate;
 }
 

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -94,6 +94,8 @@ struct routing_channel {
 
 	struct node_connection *connections[2];
 	struct node *nodes[2];
+
+	u64 msg_indexes[3];
 };
 
 struct routing_state {

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -74,6 +74,9 @@ struct node {
 
 	/* Cached `node_announcement` we might forward to new peers. */
 	u8 *node_announcement;
+
+	/* What index does the announcement broadcast have? */
+	u64 announcement_idx;
 };
 
 const secp256k1_pubkey *node_map_keyof_node(const struct node *n);

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -96,6 +96,9 @@ struct routing_channel {
 	struct node *nodes[2];
 
 	u64 msg_indexes[3];
+
+	/* Is this a public channel, or was it only added locally? */
+	bool public;
 };
 
 struct routing_state {
@@ -179,6 +182,15 @@ void routing_failure(struct routing_state *rstate,
 		     const struct short_channel_id *erring_channel,
 		     enum onion_type failcode,
 		     const u8 *channel_update);
+
+/* routing_channel constructor */
+struct routing_channel *routing_channel_new(const tal_t *ctx,
+					    struct short_channel_id *scid);
+
+/* Add the connection to the channel */
+void channel_add_connection(struct routing_state *rstate,
+			    struct routing_channel *chan,
+			    struct node_connection *nc);
 
 /* Utility function that, given a source and a destination, gives us
  * the direction bit the matching channel should get */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -84,6 +84,8 @@ size_t node_map_hash_key(const secp256k1_pubkey *key);
 bool node_map_node_eq(const struct node *n, const secp256k1_pubkey *key);
 HTABLE_DEFINE_TYPE(struct node, node_map_keyof_node, node_map_hash_key, node_map_node_eq, node_map);
 
+struct pending_node_map;
+
 enum txout_state {
 	TXOUT_FETCHING,
 	TXOUT_PRESENT,
@@ -107,6 +109,8 @@ struct routing_channel {
 struct routing_state {
 	/* All known nodes. */
 	struct node_map *nodes;
+
+	struct pending_node_map *pending_node_map;
 
 	/* channel_announcement which are pending short_channel_id lookup */
 	struct list_head pending_cannouncement;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -81,6 +81,21 @@ size_t node_map_hash_key(const secp256k1_pubkey *key);
 bool node_map_node_eq(const struct node *n, const secp256k1_pubkey *key);
 HTABLE_DEFINE_TYPE(struct node, node_map_keyof_node, node_map_hash_key, node_map_node_eq, node_map);
 
+enum txout_state {
+	TXOUT_FETCHING,
+	TXOUT_PRESENT,
+	TXOUT_MISSING
+};
+
+struct routing_channel {
+	struct short_channel_id scid;
+	enum txout_state state;
+	u8 *txout_script;
+
+	struct node_connection *connections[2];
+	struct node *nodes[2];
+};
+
 struct routing_state {
 	/* All known nodes. */
 	struct node_map *nodes;
@@ -94,6 +109,9 @@ struct routing_state {
 
 	/* Our own ID so we can identify local channels */
 	struct pubkey local_id;
+
+        /* A map of channels indexed by short_channel_ids */
+	UINTMAP(struct routing_channel*) channels;
 };
 
 struct route_hop {

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -85,6 +85,7 @@ bool node_map_node_eq(const struct node *n, const secp256k1_pubkey *key);
 HTABLE_DEFINE_TYPE(struct node, node_map_keyof_node, node_map_hash_key, node_map_node_eq, node_map);
 
 struct pending_node_map;
+struct pending_cannouncement;
 
 enum txout_state {
 	TXOUT_FETCHING,
@@ -104,6 +105,8 @@ struct routing_channel {
 
 	/* Is this a public channel, or was it only added locally? */
 	bool public;
+
+	struct pending_cannouncement *pending;
 };
 
 struct routing_state {

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -75,6 +75,13 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for replace_broadcast */
+bool replace_broadcast(struct broadcast_state *bstate UNNEEDED,
+		       u64 *index UNNEEDED,
+		       const int type UNNEEDED,
+		       const u8 *tag UNNEEDED,
+		       const u8 *payload UNNEEDED)
+{ fprintf(stderr, "replace_broadcast called!\n"); abort(); }
 /* Generated stub for status_failed */
 void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "status_failed called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -46,6 +46,13 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for replace_broadcast */
+bool replace_broadcast(struct broadcast_state *bstate UNNEEDED,
+		       u64 *index UNNEEDED,
+		       const int type UNNEEDED,
+		       const u8 *tag UNNEEDED,
+		       const u8 *payload UNNEEDED)
+{ fprintf(stderr, "replace_broadcast called!\n"); abort(); }
 /* Generated stub for status_failed */
 void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "status_failed called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -39,6 +39,13 @@ bool queue_broadcast(struct broadcast_state *bstate UNNEEDED,
 			     const u8 *tag UNNEEDED,
 			     const u8 *payload UNNEEDED)
 { fprintf(stderr, "queue_broadcast called!\n"); abort(); }
+/* Generated stub for replace_broadcast */
+bool replace_broadcast(struct broadcast_state *bstate UNNEEDED,
+		       u64 *index UNNEEDED,
+		       const int type UNNEEDED,
+		       const u8 *tag UNNEEDED,
+		       const u8 *payload UNNEEDED)
+{ fprintf(stderr, "replace_broadcast called!\n"); abort(); }
 /* Generated stub for status_failed */
 void status_failed(enum status_fail code UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "status_failed called!\n"); abort(); }

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1677,7 +1677,8 @@ class LightningDTests(BaseLightningDTests):
         needle = "Received channel_update for channel"
         l1.daemon.wait_for_log(needle)
         l2.daemon.wait_for_log(needle)
-        wait_for(lambda: len(l1.getactivechannels()) == 2)
+        # Need to increase timeout, intervals cannot be shortened with DEVELOPER=0
+        wait_for(lambda: len(l1.getactivechannels()) == 2, timeout=60)
 
         nodes = l1.rpc.listnodes()['nodes']
         assert set([n['nodeid'] for n in nodes]) == set([l1.info['id'], l2.info['id']])


### PR DESCRIPTION
Replaces the list-based lookup of `node_connection`s with a channels `uintmap` that is indexed by the channel's `short_channel_id`. Node announcements are now also stored in a separate `pending_node_announcement_map` until the `txout` verification completes. Tracking `node_connection` and `node` state independently makes the logic easier.

We also reduce verbosity of `gossipd`, only replace updates with newer ones if the `txout` verification is pending, and remember pending `node_announcement`s that arrive while we are still verifying the `txout` (these were dropped before).