### PR TITLE
[doc] install: add libsodium-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please refer to the [installation documentation](doc/INSTALL.md) for detailed in
 For the impatient here's the gist of it for Ubuntu and Debian:
 
 ```
-sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
+sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools libsodium-dev
 git clone https://github.com/ElementsProject/lightning.git
 cd lightning
 make

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -17,7 +17,7 @@ To Build on Ubuntu 15.10 or above
 
 Get dependencies:
 ```
-sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools
+sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools libsodium-dev
 ```
 
 If you don't have Bitcoin installed locally you'll need to install that as well:


### PR DESCRIPTION
As of recently I started to see:
```
/usr/bin/ld: cannot find -lsodium
collect2: error: ld returned 1 exit status
Makefile:271: recipe for target 'ccan/ccan/cdump/tools/cdump-enumstr' failed
make: *** [ccan/ccan/cdump/tools/cdump-enumstr] Error 1
```