### PR TITLE
Update jsmn: fix case where lightning-cli would hang

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -87,6 +87,8 @@ static size_t human_readable(const char *buffer, const jsmntok_t *t, char term)
 			n += human_readable(buffer, t + n, '\n');
 		}
 		return n;
+	case JSMN_UNDEFINED:
+		break;
 	}
 	abort();
 }
@@ -162,7 +164,7 @@ int main(int argc, char *argv[])
 	char *lightning_dir;
 	const tal_t *ctx = tal(NULL, char);
 	jsmn_parser parser;
-	jsmnerr_t parserr;
+	int parserr;
 	enum format format = DEFAULT_FORMAT;
 	enum input input = DEFAULT_INPUT;
 

--- a/common/json.c
+++ b/common/json.c
@@ -239,7 +239,7 @@ jsmntok_t *json_parse_input(const char *input, int len, bool *valid)
 {
 	jsmn_parser parser;
 	jsmntok_t *toks;
-	jsmnerr_t ret;
+	int ret;
 	size_t i;
 
 	toks = tal_arr(input, jsmntok_t, 10);


### PR DESCRIPTION
jsmn_parse was returning 0 (it's supposed to return the number of tokens used), which made lightning-cli hang.  After some debugging, turns out this was fixed upstream:

edd751896de5de1fcee95cb65949e6784c726751
Author: Serge A. Zaitsev <zaitsev.serge@gmail.com>
Date:   Sat Oct 17 14:58:47 2015 +0200

    fixed return value on incremental parting