### PR TITLE
gossipd: Move include of time.h to routing.h

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -7,7 +7,6 @@
 #include <ccan/endian/endian.h>
 #include <ccan/structeq/structeq.h>
 #include <ccan/tal/str/str.h>
-#include <ccan/time/time.h>
 #include <common/features.h>
 #include <common/pseudorand.h>
 #include <common/status.h>

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <bitcoin/pubkey.h>
 #include <ccan/htable/htable_type.h>
+#include <ccan/time/time.h>
 #include <gossipd/broadcast.h>
 #include <wire/gen_onion_wire.h>
 #include <wire/wire.h>


### PR DESCRIPTION
Commit a57a2dcb860ee315cb7ce04be9e37e16e5a6ae1e introduced a time_t in routing.h. So also move the time.h include to the header. This fixes the build on FreeBSD.