### PR TITLE
lightningd: Don't crash when libunwind backtrace not available

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -453,6 +453,13 @@ static int log_backtrace(void *log, uintptr_t pc,
 	return 0;
 }
 
+static void log_backtrace_error(void *log, const char *msg,
+				int errnum)
+{
+	log_broken(log, "error getting backtrace: %s (%d)",
+		   msg, errnum);
+}
+
 static struct log *crashlog;
 
 /* FIXME: Dump peer logs! */
@@ -463,7 +470,7 @@ static void log_crash(int sig)
 	if (sig) {
 		log_broken(crashlog, "FATAL SIGNAL %i RECEIVED", sig);
 		if (backtrace_state)
-			backtrace_full(backtrace_state, 0, log_backtrace, NULL,
+			backtrace_full(backtrace_state, 0, log_backtrace, log_backtrace_error,
 				       crashlog);
 	}
 


### PR DESCRIPTION
libunwind does not accept a NULL parameter for the error callback. It will simply call into the NULL pointer. So add an error callback.

This makes the crash output somewhat more sensible on FreeBSD, where there is no libunwind stack trace available:

    2018-02-05T20:24:50.598Z lightningd(75556): error getting backtrace: no stack trace because unwind library not available (0)
