### PR TITLE
test_lightningd: Increase times in expiration waiting test.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -404,25 +404,25 @@ class LightningDTests(BaseLightningDTests):
 
         # Test expiration waiting.
         # The second invoice created expires first.
-        l2.rpc.invoice('any', 'inv1', 'description', 5)
-        l2.rpc.invoice('any', 'inv2', 'description', 2)
-        l2.rpc.invoice('any', 'inv3', 'description', 8)
+        l2.rpc.invoice('any', 'inv1', 'description', 10)
+        l2.rpc.invoice('any', 'inv2', 'description', 4)
+        l2.rpc.invoice('any', 'inv3', 'description', 16)
         # Check waitinvoice correctly waits
         w1 = self.executor.submit(l2.rpc.waitinvoice, 'inv1')
         w2 = self.executor.submit(l2.rpc.waitinvoice, 'inv2')
         w3 = self.executor.submit(l2.rpc.waitinvoice, 'inv3')
-        time.sleep(1) # total 1
+        time.sleep(2) # total 2
         assert not w1.done()
         assert not w2.done()
         assert not w3.done()
-        time.sleep(2) # total 3
+        time.sleep(4) # total 6
         assert not w1.done()
         self.assertRaises(ValueError, w2.result)
         assert not w3.done()
-        time.sleep(3) # total 6
+        time.sleep(6) # total 12
         self.assertRaises(ValueError, w1.result)
         assert not w3.done()
-        time.sleep(4) # total 10
+        time.sleep(8) # total 20
         self.assertRaises(ValueError, w3.result)
 
     def test_connect(self):

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3127,7 +3127,11 @@ class LightningDTests(BaseLightningDTests):
         # L1 asks for stupid low fees
         l1.rpc.dev_setfees(15)
 
-        l1.daemon.wait_for_log('STATUS_FAIL_PEER_BAD')
+        l1.daemon.wait_for_log('STATUS_FAIL_PEER_BAD:.*update_fee 15 outside range 4250-75000')
+        # Make sure the resolution of this one doesn't interfere with the next!
+        # Note: may succeed, may fail with insufficient fee, depending on how
+        # bitcoind feels!
+        l1.daemon.wait_for_log('sendrawtx exit')
 
         # Restore to normal.
         l1.rpc.dev_setfees(15000)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1015,7 +1015,7 @@ class LightningDTests(BaseLightningDTests):
         num_peers = len(feerates) * len(amounts)
         self.give_funds(l1, (10**6) * num_peers + 10000 * num_peers)
 
-        # Create them in a batch, but only valgrind one in three, for speed!
+        # Create them in a batch, for speed!
         peers = []
         for feerate in feerates:
             for amount in amounts:
@@ -1029,7 +1029,9 @@ class LightningDTests(BaseLightningDTests):
                 peers.append(p)
 
         for p in peers:
-                l1.rpc.fundchannel(p.info['id'], 10**6)
+            l1.rpc.fundchannel(p.info['id'], 10**6)
+            # Technically, this is async to fundchannel returning.
+            l1.daemon.wait_for_log('sendrawtx exit 0')
 
         bitcoind.generate_block(6)
 


### PR DESCRIPTION
Fixes: #916

Makes it less flaky, as, the increased times reduce the
relative delay in processing by slower machines.