### PR TITLE
test_lightning: fix race on testing, esp. test_closing_different_fees.

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -808,7 +808,8 @@ static void handle_local_add_channel(struct peer *peer, u8 *msg)
 	c->htlc_minimum_msat = htlc_minimum_msat;
 	c->base_fee = fee_base_msat;
 	c->proportional_fee = fee_proportional_millionths;
-	status_trace("Channel %s(%d) was updated (LOCAL)",
+	/* Designed to match msg in handle_channel_update, for easy testing */
+	status_trace("Received local update for channel %s(%d) now ACTIVE",
 		     type_to_string(msg, struct short_channel_id, &scid),
 		     direction);
 }

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -931,10 +931,11 @@ void handle_channel_update(struct routing_state *rstate, const u8 *update)
 		return;
 	}
 
-	status_trace("Received channel_update for channel %s(%d)",
+	status_trace("Received channel_update for channel %s(%d) now %s",
 		     type_to_string(trc, struct short_channel_id,
 				    &short_channel_id),
-		     flags & 0x01);
+		     flags & 0x01,
+		     flags & ROUTING_FLAGS_DISABLED ? "DISABLED" : "ACTIVE");
 
 	c->last_timestamp = timestamp;
 	c->delay = expiry;


### PR DESCRIPTION
We get intermittant failed: WIRE_UNKNOWN_NEXT_PEER (First peer not ready)
because CHANNELD_NORMAL and actually telling gossipd that the channel
is available are distinct things.

But we may also directly send the announcement sigs if the height is
sufficient, so the simplest is to unify the messages.
