### PR TITLE
Fix dev-rescan-outputs crash on 0 outputs

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -474,10 +474,16 @@ static void json_dev_rescan_outputs(struct command *cmd, const char *buffer,
 	json_object_start(rescan->response, NULL);
 	json_array_start(rescan->response, "outputs");
 	rescan->utxos =
-	    wallet_get_utxos(rescan, cmd->ld->wallet, output_state_any);
+			wallet_get_utxos(rescan, cmd->ld->wallet, output_state_any);
+	if (tal_count(rescan->utxos) == 0) {
+		json_array_end(rescan->response);
+		json_object_end(rescan->response);
+		command_success(cmd, rescan->response);
+		return;
+	}
 	bitcoind_gettxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
-			  rescan->utxos[0]->outnum, process_utxo_result,
-			  rescan);
+		rescan->utxos[0]->outnum, process_utxo_result,
+		rescan);
 	command_still_pending(cmd);
 }
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -473,8 +473,7 @@ static void json_dev_rescan_outputs(struct command *cmd, const char *buffer,
 	/* Open the result structure so we can incrementally add results */
 	json_object_start(rescan->response, NULL);
 	json_array_start(rescan->response, "outputs");
-	rescan->utxos =
-			wallet_get_utxos(rescan, cmd->ld->wallet, output_state_any);
+	rescan->utxos = wallet_get_utxos(rescan, cmd->ld->wallet, output_state_any);
 	if (tal_count(rescan->utxos) == 0) {
 		json_array_end(rescan->response);
 		json_object_end(rescan->response);
@@ -482,8 +481,8 @@ static void json_dev_rescan_outputs(struct command *cmd, const char *buffer,
 		return;
 	}
 	bitcoind_gettxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
-		rescan->utxos[0]->outnum, process_utxo_result,
-		rescan);
+			rescan->utxos[0]->outnum, process_utxo_result,
+			rescan);
 	command_still_pending(cmd);
 }
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -481,8 +481,8 @@ static void json_dev_rescan_outputs(struct command *cmd, const char *buffer,
 		return;
 	}
 	bitcoind_gettxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
-			rescan->utxos[0]->outnum, process_utxo_result,
-			rescan);
+			 rescan->utxos[0]->outnum, process_utxo_result,
+			 rescan);
 	command_still_pending(cmd);
 }
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -481,8 +481,8 @@ static void json_dev_rescan_outputs(struct command *cmd, const char *buffer,
 		return;
 	}
 	bitcoind_gettxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
-			 rescan->utxos[0]->outnum, process_utxo_result,
-			 rescan);
+			  rescan->utxos[0]->outnum, process_utxo_result,
+			  rescan);
 	command_still_pending(cmd);
 }
 


### PR DESCRIPTION
Fix crash lightning when run dev-rescan-outputs with 0 outputs.
```shell
$ lightning-cli dev-rescan-outputs
lightning-cli: reading response: Success
```
log
```
2018-02-07T13:02:14.395Z lightningd(7759): Adding block 508096: 0000000000000000001530becd6a20abbb016c082d2ee33d692e38086344498c
2018-02-07T13:02:46.193Z lightningd(7759): Connected json input
2018-02-07T13:02:46.194Z lightningd(7759): FATAL SIGNAL 11 RECEIVED
2018-02-07T13:02:46.202Z lightningd(7759): backtrace: lightningd/log.c:473 (log_crash) 0x563834a27da1
2018-02-07T13:02:46.202Z lightningd(7759): backtrace: (null):0 ((null)) 0x7fb58378713f
2018-02-07T13:02:46.202Z lightningd(7759): backtrace: wallet/walletrpc.c:557 (json_dev_rescan_outputs) 0x563834a6c297
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: lightningd/jsonrpc.c:627 (parse_request) 0x563834a246af
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: lightningd/jsonrpc.c:794 (read_json) 0x563834a24f75
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x563834a73708
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: ccan/ccan/io/io.c:387 (do_plan) 0x563834a74205
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: ccan/ccan/io/io.c:397 (io_ready) 0x563834a74243
2018-02-07T13:02:46.203Z lightningd(7759): backtrace: ccan/ccan/io/poll.c:305 (io_loop) 0x563834a75b7c
2018-02-07T13:02:46.204Z lightningd(7759): backtrace: lightningd/lightningd.c:351 (main) 0x563834a2655f
2018-02-07T13:02:46.204Z lightningd(7759): backtrace: (null):0 ((null)) 0x7fb5837711c0
2018-02-07T13:02:46.204Z lightningd(7759): backtrace: (null):0 ((null)) 0x563834a19b89
2018-02-07T13:02:46.204Z lightningd(7759): backtrace: (null):0 ((null)) 0xffffffffffffffff
Fatal signal 11. 0x563834a27e93 log_crash
	lightningd/log.c:499
0x7fb58378713f ???
	???:0
0x563834a6c297 json_dev_rescan_outputs
	wallet/walletrpc.c:557
0x563834a246af parse_request
	lightningd/jsonrpc.c:627
0x563834a24f75 read_json
	lightningd/jsonrpc.c:794
0x563834a73708 next_plan
	ccan/ccan/io/io.c:59
0x563834a74205 do_plan
	ccan/ccan/io/io.c:387
0x563834a74243 io_ready
	ccan/ccan/io/io.c:397
0x563834a75b7c io_loop
	ccan/ccan/io/poll.c:305
0x563834a2655f main
	lightningd/lightningd.c:351
0x7fb5837711c0 ???
	???:0
0x563834a19b89 ???
	???:0
0xffffffffffffffff ???
	???:0
Log dumped in crash.log
```