### PR TITLE
test_lightningd: race fix for activation of channels in test_gossip_jsonprc

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1681,6 +1681,7 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_log(needle)
         # Need to increase timeout, intervals cannot be shortened with DEVELOPER=0
         wait_for(lambda: len(l1.getactivechannels()) == 2, timeout=60)
+        wait_for(lambda: len(l2.getactivechannels()) == 2, timeout=60)
 
         nodes = l1.rpc.listnodes()['nodes']
         assert set([n['nodeid'] for n in nodes]) == set([l1.info['id'], l2.info['id']])


### PR DESCRIPTION

```
>       assert [c['active'] for c in l2.rpc.listchannels()['channels']] == [True, True]
E       AssertionError: assert [True, False] == [True, True]
E         At index 1 diff: False != True
E         Full diff:
E         - [True, False]
E         + [True, True]
```

We don't actually wait that l2's gossipd has also processed the message.
