### PR TITLE
gossipd: fix race where we can handoff peer with bad cryptostate.

### DIFF
--- a/common/cryptomsg.c
+++ b/common/cryptomsg.c
@@ -382,13 +382,6 @@ struct io_plan *peer_write_message(struct io_conn *conn,
 	return io_write(conn, pcs->out, tal_count(pcs->out), post, pcs);
 }
 
-/* We write in one op, so it's all or nothing. */
-bool peer_out_started(const struct io_conn *conn,
-		      const struct peer_crypto_state *cs)
-{
-	return io_plan_out_started(conn);
-}
-
 /* We read in two parts, so we might have started body. */
 bool peer_in_started(const struct io_conn *conn,
 		     const struct peer_crypto_state *cs)

--- a/common/cryptomsg.h
+++ b/common/cryptomsg.h
@@ -33,9 +33,7 @@ struct io_plan *peer_read_message(struct io_conn *conn,
 							  struct peer *,
 							  u8 *msg));
 
-/* Have we already started writing/reading a message? */
-bool peer_out_started(const struct io_conn *conn,
-		      const struct peer_crypto_state *cs);
+/* Have we already started reading a message? */
 bool peer_in_started(const struct io_conn *conn,
 		     const struct peer_crypto_state *cs);
 


### PR DESCRIPTION
EBUG:root:lightningd(16333): 2018-02-08T02:12:21.158Z lightningd(8262): lightning_openingd(0382ce59ebf18be7d84677c2e35f23294b9992ceca95491fcf8a56c6cb2d9de199): Failed hdr decrypt with rn=2

We only hand off the peer if we've not started writing, but that was
insufficient: we increment the sn twice on encrypting packet, so there's
a window before we've actually started writing where this is now
wrong.

The simplest fix is only to hand off from master when we've just written,
and have the read-packet path simply wake the write-packet path.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>