### PR TITLE
Fix log injection attack and return on JSON parse failure

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -660,7 +660,10 @@ again:
 			log_unusual(jcon->ld->log,
 				    "Invalid token in json input: '%.*s'",
 				    (int)jcon->used, jcon->buffer);
-			return io_close(conn);
+			json_command_malformed(
+			    jcon, NULL,
+			    "Invalid token in json input");
+			return io_halfclose(conn);
 		}
 		/* We need more. */
 		goto read_more;

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -256,6 +256,12 @@ void logv(struct log *log, enum log_level level, const char *fmt, va_list ap)
 	struct log_entry *l = new_log_entry(log, level);
 
 	l->log = tal_vfmt(l, fmt, ap);
+
+	/* Sanitize any non-printable characters, and replace with '?' */
+	for (size_t i=0; i<strlen(l->log); i++)
+		if (l->log[i] < ' ' || l->log[i] >= 0x7f)
+			l->log[i] = '?';
+
 	maybe_print(log, l, 0);
 
 	add_entry(log, l);
@@ -289,6 +295,12 @@ void logv_add(struct log *log, const char *fmt, va_list ap)
 	list_del_from(&log->lr->log, &l->list);
 
 	tal_append_vfmt(&l->log, fmt, ap);
+
+	/* Sanitize any non-printable characters, and replace with '?' */
+	for (size_t i=oldlen; i<strlen(l->log); i++)
+		if (l->log[i] < ' ' || l->log[i] >= 0x7f)
+			l->log[i] = '?';
+
 	add_entry(log, l);
 
 	maybe_print(log, l, oldlen);


### PR DESCRIPTION
As reported by @practicalswift in #945 it is possible to inject
non-printable, or shell escape, characters in a json command, that
will fail to parse and then clear the shell.

The second commit also adds an error response when we're unable
to parse the request, just to be extra nice :wink: 

Fixes #945 
Fixes #908 