### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Don't hesitate to reach out to us on IRC at [#lightning-dev @ freenode.net](http
 
 ## Getting Started
 
-c-lightning currently only works on Linux (and possibly Mac OS with some tweaking), and requires a locally running `bitcoind` (version 0.15 or above) that is fully caught up with the network you're testing on.
+c-lightning currently only works on Linux (and possibly Mac OS with some tweaking), and requires a locally running `bitcoind` (version 0.15 or above) that is fully caught up with the network you're testing on. Pruning (prune=n option in bitcoin.conf) is not currently supported.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cli/lightning-cli fundchannel <node_id> <amount>
 
 This opens a connection and, on top of that connection, then opens a channel.
 The funding transaction needs 1 confirmations in order for the channel to be usable, and 6 to be broadcast for others to use.
-You can check the status of the channel using `cli/lightning-cli listpeers`, which after 1 confirmation should say that `state` is `CHANNELD_NORMAL`; after 6 confirmations you can use `cli/lightning-cli listchannels` to verify that the `public` field is now `true`.
+You can check the status of the channel using `cli/lightning-cli listpeers`, which after 3 confirmations (1 on testnet) should say that `state` is `CHANNELD_NORMAL`; after 6 confirmations you can use `cli/lightning-cli listchannels` to verify that the `public` field is now `true`.
  
 ### Different states 
 


### PR DESCRIPTION
A couple of readme fixes for issues I ran into:

* bitcoind node with pruning enabled doesn't work properly

* Number of confirmations needed for a channel to enter NORMAL state is now 3 but readme still says 1.