### PR TITLE
Store HTLC signatures in the database

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1147,9 +1147,10 @@ void peer_got_commitsig(struct peer *peer, const u8 *msg)
 
 	wallet_channel_save(peer->ld->wallet, peer->channel);
 
-	/* FIXME: Put these straight in the db! */
 	tal_free(peer->last_htlc_sigs);
 	peer->last_htlc_sigs = tal_steal(peer, htlc_sigs);
+	wallet_htlc_sigs_save(peer->ld->wallet, peer->channel->id,
+			      peer->last_htlc_sigs);
 
 	/* Tell it we've committed, and to go ahead with revoke. */
 	msg = towire_channel_got_commitsig_reply(msg);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2112,7 +2112,7 @@ class LightningDTests(BaseLightningDTests):
         """Interrupt a payment between two peers, then fail and recover funds using the HTLC sig.
         """
         l1 = self.node_factory.get_node(options=['--dev-no-reconnect'])
-        l2 = self.node_factory.get_node()
+        l2 = self.node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'])
 
         l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
         self.fund_channel(l1, l2, 10**6)

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -189,6 +189,8 @@ char *dbmigrations[] = {
      * concerns. */
     "ALTER TABLE payments ADD COLUMN route_nodes BLOB;",
     "ALTER TABLE payments ADD COLUMN route_channels TEXT;",
+    "CREATE TABLE htlc_sigs (channelid INTEGER REFERENCES channels(id) ON DELETE CASCADE, signature BLOB);",
+    "CREATE INDEX channel_idx ON htlc_sigs (channelid)",
     NULL,
 };
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -619,4 +619,9 @@ const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
 						  struct wallet *wallet,
 						  const struct sha256 *payment_hash);
 
+/**
+ * wallet_htlc_sigs_save - Store the latest HTLC sigs for the channel
+ */
+void wallet_htlc_sigs_save(struct wallet *w, u64 channel_id,
+			   secp256k1_ecdsa_signature *htlc_sigs);
 #endif /* WALLET_WALLET_H */


### PR DESCRIPTION
As proposed by @rustyrussell we just clear any HTLC signatures for the channel in question and write them all, without associating them with the HTLCs they are bound to. The test runs through the failure case of a misbehaving peer that allows us to recover the funds in the HTLC.

Fixes #553 