### PR TITLE
Improve log message when receiving packet with unknown message type

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -630,10 +630,10 @@ static struct io_plan *peer_msgin(struct io_conn *conn,
 	 * odd-numbered types without ascertaining that the recipient
 	 * understands it. */
 	if (t & 1) {
-		status_trace("Peer %s sent unknown packet %u, ignoring",
+		status_trace("Peer %s sent packet with unknown message type %u, ignoring",
 			     type_to_string(trc, struct pubkey, &peer->id), t);
 	} else
-		peer_error(peer, "Unknown packet %u", t);
+		peer_error(peer, "Packet with unknown message type %u", t);
 
 	return peer_next_in(conn, peer);
 }


### PR DESCRIPTION
Improve log message when receiving unknown message type.

Now mirroring the terminology used in BOLTs (i.e. "unknown message types" in BOLT 1).