### PR TITLE
doc: Include apt-get update as first step

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -17,6 +17,7 @@ To Build on Ubuntu 15.10 or above
 
 Get dependencies:
 ```
+sudo apt-get update
 sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools libsodium-dev
 ```
 


### PR DESCRIPTION
First time users following these steps may get an error like "Unable to locate package libsodium-dev" if apt-get update is not run first.

This will help noobs avoid frustration.