### PR TITLE
doc: Include apt-get update as first step

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Please refer to the [installation documentation](doc/INSTALL.md) for detailed in
 For the impatient here's the gist of it for Ubuntu and Debian:
 
 ```
+sudo apt-get update
 sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools libsodium-dev
 git clone https://github.com/ElementsProject/lightning.git
 cd lightning


### PR DESCRIPTION
For the impatient! First time users following these steps may get an error like "Unable to locate package libsodium-dev" if apt-get update is not run first.