### PR TITLE
Preventing lightningd closing when the session ends.

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -83,7 +83,7 @@ Running lightning:
 
 ```
 # service bitcoind start
-$ ./lightningd/lightningd &
+$ nohup ./lightningd/lightningd &
 $ ./cli/lightning-cli help
 ```
 


### PR DESCRIPTION
At the moment lightningd doesn't go in background simply adding the "&".
If the server is remote or if, for any other reason the session ends, the program stops without the
user even knowing it. 

Nohup is just a suggestion which works for me. I'm fine with any other procedure. 

It could be useful to useful to mention that the output is appended into nohup.out 
even if there's a message telling that.