### PR TITLE
Add option --from-blockheight

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -325,6 +325,11 @@ int main(int argc, char *argv[])
 
 	peer_first_blocknum = wallet_channels_first_blocknum(ld->wallet);
 
+	if (ld->config.from_blockheight > -1){
+		// Get_init_blockhash() go back of 100 blocks
+		peer_first_blocknum = ld->config.from_blockheight + 100;
+	}
+
 	db_commit_transaction(ld->wallet->db);
 
 	/* Initialize block topology (does its own transaction) */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -26,6 +26,9 @@ struct config {
 	/* How long do we let them lock up our funds? (blocks) */
 	u32 locktime_max;
 
+	/* Add block from blockheight (-1 to use default chaintopology strategy). */
+	s32 from_blockheight;
+
 	/* How many blocks before we expect to see anchor?. */
 	u32 anchor_onchain_wait;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -220,6 +220,9 @@ static void config_register_opts(struct lightningd *ld)
 	opt_register_arg("--max-locktime-blocks", opt_set_u32, opt_show_u32,
 			 &ld->config.locktime_max,
 			 "Maximum blocks a peer can lock up our funds");
+	opt_register_arg("--from-blockheight", opt_set_s32, opt_show_s32,
+			 &ld->config.from_blockheight,
+			 "Add blocks from blockchain height");
 	opt_register_arg("--anchor-onchain", opt_set_u32, opt_show_u32,
 			 &ld->config.anchor_onchain_wait,
 			 "Blocks before we give up on pending anchor transaction");
@@ -320,6 +323,9 @@ static const struct config testnet_config = {
 	/* They can have up to 3 days. */
 	.locktime_max = 3 * 6 * 24,
 
+    /* Default -1 to use default chaintopology strategy. */
+    .from_blockheight = -1,
+
 	/* Testnet can have long runs of empty blocks. */
 	.anchor_onchain_wait = 100,
 
@@ -372,6 +378,9 @@ static const struct config mainnet_config = {
 
 	/* They can have up to 3 days. */
 	.locktime_max = 3 * 6 * 24,
+
+    /* Default -1 to use default chaintopology strategy. */
+    .from_blockheight = -1,
 
 	/* You should get in within 10 blocks. */
 	.anchor_onchain_wait = 10,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -323,8 +323,8 @@ static const struct config testnet_config = {
 	/* They can have up to 3 days. */
 	.locktime_max = 3 * 6 * 24,
 
-    /* Default -1 to use default chaintopology strategy. */
-    .from_blockheight = -1,
+	/* Default -1 to use default chaintopology strategy. */
+	.from_blockheight = -1,
 
 	/* Testnet can have long runs of empty blocks. */
 	.anchor_onchain_wait = 100,
@@ -379,8 +379,8 @@ static const struct config mainnet_config = {
 	/* They can have up to 3 days. */
 	.locktime_max = 3 * 6 * 24,
 
-    /* Default -1 to use default chaintopology strategy. */
-    .from_blockheight = -1,
+	/* Default -1 to use default chaintopology strategy. */
+	.from_blockheight = -1,
 
 	/* You should get in within 10 blocks. */
 	.anchor_onchain_wait = 10,


### PR DESCRIPTION
Add option `--from-blockheight` for lightningd to define the first block to add at startup time.
If not specify, or set to default value -1, lightningd uses the current strategy.
In according to `setup_topology()`, block download starts one before the block selected in `--from-blockheight`.

Help:
```bash
$ lightingd --help
...
--max-locktime-blocks <arg>    Maximum blocks a peer can lock up our funds (default: 432)
--from-blockheight <arg>       Add blocks from blockchain height (default: -1)
--anchor-onchain <arg>         Blocks before we give up on pending anchor transaction (default: 100)
...
```
Example:
```bash
$ lightingd --from-blockheight 500000
...
2018-02-13T16:02:05.745Z lightningd(28362): Adding block 499999: 0000000000000000007962066dcd6675830883516bcf40047d42740a85eb2919
...
2018-02-13T16:02:05.944Z lightningd(28362): Adding block 500000: 00000000000000000024fb37364cbf81fd49cc2d51c09c75c35433c3a1945d04
2018-02-13T16:02:40.595Z lightningd(28442): Adding block 500001: 0000000000000000005c9959b3216f8640f94ec96edea69fe12ad7dee8b74e92
```

Resolve the following issue:
1. send satoshi in a lightning wallet created by `lightning-cli newaddr` (for example at height 500000)
2. check incoming transaction: `lightning-cli listfunds` show outputs available to spent
3. wait 102 blocks
4. restart lightningd (in log: first block added is 100-1 blocks before the current blockchain height = 500001)
5. `lightning-cli listfunds` shows no outputs

Start lightningd with the option `--from-blockheight 500000` resolves this issue and `listfunds` shows outputs available to spent.