### PR TITLE
jsonrpc: don't crash on multiple commands at once.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3421,17 +3421,14 @@ class LightningDTests(BaseLightningDTests):
             b'{"id":4,"jsonrpc":"2.0","method":"listpeers","params":[]}',
             b'{"id":5,"jsonrpc":"2.0","method":"listpeers","params":[]}',
             b'{"id":6,"jsonrpc":"2.0","method":"listpeers","params":[]}',
-            b'{"method": "invoice", "params": [100, "foo", "foo"], "jsonrpc": "2.0", "id": 7 }',
+            b'{"method": "invoice", "params": [100, "foo", "foo", 1], "jsonrpc": "2.0", "id": 7 }',
             b'{"method": "waitinvoice", "params": ["foo"], "jsonrpc" : "2.0", "id": 8 }',
             b'{"method": "delinvoice", "params": ["foo", "unpaid"], "jsonrpc" : "2.0", "id": 9 }',
         ]
 
         sock.sendall(b'\n'.join(commands))
 
-        # We only care to get back enough results, not their content
-        for _ in commands:
-            l1.rpc._readobj(sock)
-        #time.sleep(1)
+        l1.rpc._readobj(sock)
         sock.close()
 
     def test_cli(self):


### PR DESCRIPTION
Once we read a command, we are supposed to io_wait until it finishes.
However, we are actually woken in two places: when it's complete
(which is correct), and when it's written out (which is wrong).

~~~This was because the reader and writer were waiting on the same location: make the writer wait/wake on the output queue, instead.~~~
Indeed, when a command is finished, it's time to wake both the output and the input: 
by making the low-level `json_done` routine free the old cmd as well as queue the output,
we reduce code duplication and also make it clear what it's doing.

Fixes: #934
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>