### PR TITLE
onchain: handle case where multiple HTLCs exist for same payment_hash.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -698,6 +698,11 @@ void onchain_fulfilled_htlc(struct peer *peer, const struct preimage *preimage)
 		if (hout->key.peer != peer)
 			continue;
 
+		/* It's possible that we failed some and succeeded one,
+		 * if we got multiple errors. */
+		if (hout->failcode != 0 || hout->failuremsg)
+			continue;
+
 		if (!structeq(&hout->payment_hash, &payment_hash))
 			continue;
 


### PR DESCRIPTION
We will have probably failed the others, but either way, don't try to
fulfill an HTLC we've already failed.

Fixes: #394
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>