### PR TITLE
Add dev-listaddrs option

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -413,7 +413,6 @@ static void json_listaddrs(struct command *cmd,
 	if (!json_get_params(cmd, buffer, params,
 			     "?bip32_max_index", &bip32tok,
 			     NULL)) {
-		tal_free(tmpctx);
 		return;
 	}
 
@@ -432,14 +431,12 @@ static void json_listaddrs(struct command *cmd,
 		if (bip32_key_from_parent(cmd->ld->wallet->bip32_base, keyidx,
 					  BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
 			command_fail(cmd, "Keys generation failure");
-			tal_free(tmpctx);
 			return;
 		}
 
 		if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey.pubkey,
 					       ext.pub_key, sizeof(ext.pub_key))) {
 			command_fail(cmd, "Key parsing failure");
-			tal_free(tmpctx);
 			return;
 		}
 
@@ -458,7 +455,6 @@ static void json_listaddrs(struct command *cmd,
 		ok = segwit_addr_encode(out_p2wpkh, hrp, 0, h160.u.u8, sizeof(h160.u.u8));
 		if (!ok) {
 			command_fail(cmd, "p2wpkh address encoding failure.");
-			tal_free(tmpctx);
 			return;
 		}
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -426,9 +426,7 @@ static void json_listaddrs(struct command *cmd,
 	for (s64 keyidx = 0; keyidx < bip32_max_index; keyidx++) {
 
 		if(keyidx == BIP32_INITIAL_HARDENED_CHILD){
-			command_fail(cmd, "Keys exhausted ");
-			tal_free(tmpctx);
-			return;
+			break;
 		}
 
 		if (bip32_key_from_parent(cmd->ld->wallet->bip32_base, keyidx,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -393,6 +393,102 @@ static const struct json_command newaddr_command = {
 };
 AUTODATA(json_command, &newaddr_command);
 
+static void json_listaddrs(struct command *cmd,
+						   const char *buffer, const jsmntok_t *params)
+{
+	struct json_result *response = new_json_result(cmd);
+	struct ext_key ext;
+	struct sha256 h;
+	struct ripemd160 h160;
+	struct pubkey pubkey;
+	jsmntok_t *bip32tok;
+	u8 *redeemscript;
+	bool ok;
+	char *out_p2sh;
+	char *out_p2wpkh;
+	const char *hrp;
+	u64 bip32_max_index;
+	const tal_t *tmpctx = tal_tmpctx(NULL);
+
+	if (!json_get_params(cmd, buffer, params,
+						 "?bip32_max_index", &bip32tok, NULL)) {
+		tal_free(tmpctx);
+		return;
+	}
+
+	if (!bip32tok || !json_tok_u64(buffer, bip32tok, &bip32_max_index)) {
+		bip32_max_index = db_get_intvar(cmd->ld->wallet->db, "bip32_max_index", 0);
+	}
+	json_object_start(response, NULL);
+	json_array_start(response, "addresses");
+
+	for (s64 keyidx = 0; keyidx < bip32_max_index; keyidx++) {
+
+
+		if(keyidx == BIP32_INITIAL_HARDENED_CHILD){
+			command_fail(cmd, "Keys exhausted ");
+			tal_free(tmpctx);
+			return;
+		}
+
+		if (bip32_key_from_parent(cmd->ld->wallet->bip32_base, keyidx,
+								  BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
+			command_fail(cmd, "Keys generation failure");
+			tal_free(tmpctx);
+			return;
+		}
+
+		if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey.pubkey,
+									   ext.pub_key, sizeof(ext.pub_key))) {
+			command_fail(cmd, "Key parsing failure");
+			tal_free(tmpctx);
+			return;
+		}
+
+		// p2sh
+		redeemscript = bitcoin_redeem_p2sh_p2wpkh(cmd, &pubkey);
+		sha256(&h, redeemscript, tal_count(redeemscript));
+		ripemd160(&h160, h.u.u8, sizeof(h));
+		out_p2sh = p2sh_to_base58(cmd,
+								  get_chainparams(cmd->ld)->testnet, &h160);
+
+		// bech32 : p2wpkh
+		hrp = get_chainparams(cmd->ld)->bip173_name;
+		/* out buffer is 73 + strlen(human readable part). see bech32.h */
+		out_p2wpkh = tal_arr(cmd, char, 73 + strlen(hrp));
+		pubkey_to_hash160(&pubkey, &h160);
+		ok = segwit_addr_encode(out_p2wpkh, hrp, 0, h160.u.u8, sizeof(h160.u.u8));
+		if (!ok) {
+			command_fail(cmd, "p2wpkh address encoding failure.");
+			tal_free(tmpctx);
+			return;
+		}
+
+		// outputs
+		json_object_start(response, NULL);
+		json_add_u64(response, "keyidx", keyidx);
+		json_add_pubkey(response, "pubkey", &pubkey);
+		json_add_string(response, "p2sh", out_p2sh);
+		json_add_hex(response, "p2sh_redeemscript", redeemscript, sizeof(struct ripemd160) + 1);
+		json_add_string(response, "bech32", out_p2wpkh);
+		json_add_hex(response, "bech32_redeemscript", &h160.u.u8, sizeof(struct ripemd160));
+
+		json_object_end(response);
+	}
+	json_array_end(response);
+	json_object_end(response);
+	command_success(cmd, response);
+	tal_free(tmpctx);
+}
+
+static const struct json_command listaddrs_command = {
+	"dev-listaddrs",
+	json_listaddrs,
+	"Show addresses list up to derivation {index} (default is the last bip32 index)", false,
+	"Show addresses of your internal wallet. Use `newaddr` to generate a new address."
+};
+AUTODATA(json_command, &listaddrs_command);
+
 static void json_listfunds(struct command *cmd, const char *buffer UNUSED,
 			   const jsmntok_t *params UNUSED)
 {

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -408,7 +408,6 @@ static void json_listaddrs(struct command *cmd,
 	char *out_p2wpkh;
 	const char *hrp;
 	u64 bip32_max_index;
-	const tal_t *tmpctx = tal_tmpctx(cmd);
 
 	if (!json_get_params(cmd, buffer, params,
 			     "?bip32_max_index", &bip32tok,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -408,7 +408,7 @@ static void json_listaddrs(struct command *cmd,
 	char *out_p2wpkh;
 	const char *hrp;
 	u64 bip32_max_index;
-	const tal_t *tmpctx = tal_tmpctx(NULL);
+	const tal_t *tmpctx = tal_tmpctx(cmd);
 
 	if (!json_get_params(cmd, buffer, params,
 			     "?bip32_max_index", &bip32tok,
@@ -474,8 +474,8 @@ static void json_listaddrs(struct command *cmd,
 	}
 	json_array_end(response);
 	json_object_end(response);
-	command_success(cmd, response);
 	tal_free(tmpctx);
+	command_success(cmd, response);
 }
 
 static const struct json_command listaddrs_command = {

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -411,7 +411,8 @@ static void json_listaddrs(struct command *cmd,
 	const tal_t *tmpctx = tal_tmpctx(NULL);
 
 	if (!json_get_params(cmd, buffer, params,
-						 "?bip32_max_index", &bip32tok, NULL)) {
+			     "?bip32_max_index", &bip32tok,
+			     NULL)) {
 		tal_free(tmpctx);
 		return;
 	}
@@ -424,7 +425,6 @@ static void json_listaddrs(struct command *cmd,
 
 	for (s64 keyidx = 0; keyidx < bip32_max_index; keyidx++) {
 
-
 		if(keyidx == BIP32_INITIAL_HARDENED_CHILD){
 			command_fail(cmd, "Keys exhausted ");
 			tal_free(tmpctx);
@@ -432,14 +432,14 @@ static void json_listaddrs(struct command *cmd,
 		}
 
 		if (bip32_key_from_parent(cmd->ld->wallet->bip32_base, keyidx,
-								  BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
+					  BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
 			command_fail(cmd, "Keys generation failure");
 			tal_free(tmpctx);
 			return;
 		}
 
 		if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey.pubkey,
-									   ext.pub_key, sizeof(ext.pub_key))) {
+					       ext.pub_key, sizeof(ext.pub_key))) {
 			command_fail(cmd, "Key parsing failure");
 			tal_free(tmpctx);
 			return;
@@ -469,10 +469,9 @@ static void json_listaddrs(struct command *cmd,
 		json_add_u64(response, "keyidx", keyidx);
 		json_add_pubkey(response, "pubkey", &pubkey);
 		json_add_string(response, "p2sh", out_p2sh);
-		json_add_hex(response, "p2sh_redeemscript", redeemscript, sizeof(struct ripemd160) + 1);
+		json_add_hex(response, "p2sh_redeemscript", redeemscript, tal_count(redeemscript));
 		json_add_string(response, "bech32", out_p2wpkh);
 		json_add_hex(response, "bech32_redeemscript", &h160.u.u8, sizeof(struct ripemd160));
-
 		json_object_end(response);
 	}
 	json_array_end(response);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -474,7 +474,6 @@ static void json_listaddrs(struct command *cmd,
 	}
 	json_array_end(response);
 	json_object_end(response);
-	tal_free(tmpctx);
 	command_success(cmd, response);
 }
 


### PR DESCRIPTION
Add dev-listaddrs command to show bip32 addresses list (up to bip32_max_index). From pr #940
#### help

``` shell
$ lightning-cli help
...
command=dev-listaddrs
description=Show addresses list up to derivation {index} (default is the last bip32 index)
...
```
#### output
``` shell
$ lightning-cli dev-listaddrs
{ "addresses" : 
        [ 
                { 
                         "keyidx" : 0,
                         "pubkey" : "...",     
                         "p2sh": "...",   
                         "p2sh_redeemscript": "...",
                         "bech32": "...",
                         "bech32_redeemscript": "..." 
                }, 
                .... 
        ]
}
```
Set optional value {index} to show also future derivations up to {index}. This could be useful for testing and recovery. Default {index} value is `bip32_max_index` in `vars` table of sqlite file.

#### suggestion
If you prefer, I can add an `address_type` option (bech32 or p2sh, like `get_newaddr`) to show only one kind of derivation address. 
In this case, it shows only 2 fields (`address`,`redeemscript`) instead 4 fields (`p2sh`,`p2sh_redeemscript`,`bech32`,`bech32_redeemscript`) as described at [discussion](https://github.com/ElementsProject/lightning/pull/940#discussion_r167813902).