### PR TITLE
Pylightning

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -105,7 +105,7 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("dev-blockheight")
 
-    def dev_setfees(self, immediate, normal=None, slow=None):
+    def dev_setfees(self, immediate=None, normal=None, slow=None):
         """
         Set feerate in satoshi-per-kw for {immediate}, {normal} and {slow}
         (each is optional, when set, separate by spaces) and show the value of those three feerates

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -882,8 +882,8 @@ class LightningDTests(BaseLightningDTests):
         # Wait for route propagation.
         self.wait_for_routes(l1, [chanid])
 
-        inv1 = l2.rpc.invoice(123000, 'test_pay', 'description')['bolt11']
-        l1.rpc.pay(inv1, description='00000')
+        inv1 = l2.rpc.invoice(123000, 'test_pay', '1000')['bolt11']
+        l1.rpc.pay(inv1, description='1000')
         payment1 = l1.rpc.listpayments(inv1)['payments']
         assert len(payment1) == 1 and payment1[0]['msatoshi'] == 123000
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -776,14 +776,14 @@ class LightningDTests(BaseLightningDTests):
         assert len(payments) == 2
 
         invoice2 = l2.rpc.listinvoices('testpayment2')['invoices'][0]
-        payments = l1.rpc.listpayments(None, invoice2['payment_hash'])['payments']
+        payments = l1.rpc.listpayments(payment_hash=invoice2['payment_hash'])['payments']
         assert len(payments) == 1
 
         assert payments[0]['status'] == 'complete'
         assert payments[0]['payment_preimage'] == preimage2['preimage']
 
         invoice3 = l2.rpc.listinvoices('testpayment3')['invoices'][0]
-        payments = l1.rpc.listpayments(None, invoice3['payment_hash'])['payments']
+        payments = l1.rpc.listpayments(payment_hash=invoice3['payment_hash'])['payments']
         assert len(payments) == 1
 
         assert payments[0]['status'] == 'complete'

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -850,7 +850,7 @@ class LightningDTests(BaseLightningDTests):
         assert invoice['paid_at'] <= after
 
         # Repeat payments are NOPs (if valid): we can hand null.
-        l1.rpc.pay(inv, None)
+        l1.rpc.pay(inv)
         # This won't work: can't provide an amount (even if correct!)
         self.assertRaises(ValueError, l1.rpc.pay, inv, 123000)
         self.assertRaises(ValueError, l1.rpc.pay, inv, 122000)
@@ -865,7 +865,6 @@ class LightningDTests(BaseLightningDTests):
             inv2 = l2.rpc.invoice("any", label, 'description')['bolt11']
             # Must provide an amount!
             self.assertRaises(ValueError, l1.rpc.pay, inv2)
-            self.assertRaises(ValueError, l1.rpc.pay, inv2, None)
             l1.rpc.pay(inv2, random.randint(1000, 999999))
 
         # Should see 6 completed payments

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -875,6 +875,33 @@ class LightningDTests(BaseLightningDTests):
         assert len(l1.rpc.listpayments(inv)['payments']) == 1
         assert l1.rpc.listpayments(inv)['payments'][0]['payment_preimage'] == preimage['preimage']
 
+    def test_pay_optional_args(self):
+        l1,l2 = self.connect()
+
+        chanid = self.fund_channel(l1, l2, 10**6)
+ 
+        # Wait for route propagation.
+        self.wait_for_routes(l1, [chanid])
+
+        inv1 = l2.rpc.invoice(123000, 'test_pay', 'description')['bolt11']
+        l1.rpc.pay(inv1, description='00000')
+        payment1 = l1.rpc.listpayments(inv1)['payments']
+        assert len(payment1) == 1 and payment1[0]['msatoshi'] == 123000
+
+        inv2 = l2.rpc.invoice(321000, 'test_pay2', 'description')['bolt11']
+        l1.rpc.pay(inv2, riskfactor=5.0)
+        payment2 = l1.rpc.listpayments(inv2)['payments']
+        assert len(payment2) == 1 and payment2[0]['msatoshi'] == 321000
+
+        anyinv = l2.rpc.invoice('any', 'any_pay', 'description')['bolt11']
+        l1.rpc.pay(anyinv, description='1000', msatoshi='500')
+        payment3 = l1.rpc.listpayments(anyinv)['payments']
+        assert len(payment3) == 1 and payment3[0]['msatoshi'] == 500
+
+        transactions = l1.rpc.listpayments()
+        # Should see 3 completed transactions
+        assert len(l1.rpc.listpayments()['payments']) == 3
+
     # Long test involving 4 lightningd instances.
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_report_routing_failure(self):


### PR DESCRIPTION
Optional named args in pylightning were handled incorrectly:
 dev_setfees(100, slow=100) -> {'immediate': 100, 'normal': 100}
 pay(invoice, description='1000') -> {'invoice': invoice, 'msatoshi': 1000}
This branch changes behavior to always put args in correct places in RPC request and adds some tests to avoid regression.