### PR TITLE
Add cross-compilation terms to external submodule configurators

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -31,7 +31,7 @@ external/libsodium.a: external/libsodium/src/libsodium/libsodium.la
 external/libsodium/src/libsodium/include/sodium.h: submodcheck-libsodium
 
 external/libsodium/src/libsodium/libsodium.la: external/libsodium/src/libsodium/include/sodium.h
-	cd external/libsodium && ./autogen.sh && ./configure CC="$(CC)" --enable-static=yes --enable-shared=no --enable-tests=no --libdir=`pwd`/.. && $(MAKE)
+	cd external/libsodium && ./autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --enable-tests=no --libdir=`pwd`/.. && $(MAKE)
 
 $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS): submodcheck-libwally-core
 
@@ -41,7 +41,7 @@ external/libsecp256k1.% external/libwallycore.%: external/libwally-core/src/secp
 	$(MAKE) -C external/libwally-core install-exec
 
 external/libwally-core/src/libwallycore.% external/libwally-core/src/secp256k1/libsecp256k1.%: $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS)
-	cd external/libwally-core && ./tools/autogen.sh && ./configure CC="$(CC)" --enable-static=yes --enable-module-recovery --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
+	cd external/libwally-core && ./tools/autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-module-recovery --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
 
 external/jsmn/jsmn.h: submodcheck-jsmn
 
@@ -74,7 +74,7 @@ external/libbacktrace/backtrace.h: submodcheck-libbacktrace
 # Need separate build dir: changes inside submodule make git think it's dirty.
 external/libbacktrace.a: external/libbacktrace/backtrace.h
 	@mkdir external/libbacktrace-build 2>/dev/null || true
-	cd external/libbacktrace-build && ../libbacktrace/configure CC="$(CC)" --enable-static=yes --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
+	cd external/libbacktrace-build && ../libbacktrace/configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
 	$(MAKE) -C external/libbacktrace-build install-exec
 
 distclean: external-distclean


### PR DESCRIPTION
This way one can pass BUILD and HOST vars in order to cross-compile. Such as:
`BUILD=x86_64 HOST=arm-linux-androideabi make`