### PR TITLE
wallet: Add check that wallet matches the network on startup

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -304,6 +304,9 @@ int main(int argc, char *argv[])
 	/* Everything is within a transaction. */
 	db_begin_transaction(ld->wallet->db);
 
+	if (!wallet_network_check(ld->wallet, get_chainparams(ld)))
+		errx(1, "Wallet network check failed.");
+
 	/* Initialize the transaction filter with our pubkeys. */
 	init_txfilter(ld->wallet, ld->owned_txfilter);
 

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -107,6 +107,10 @@ bool wallet_htlcs_reconnect(struct wallet *wallet UNNEEDED,
 /* Generated stub for wallet_invoice_load */
 bool wallet_invoice_load(struct wallet *wallet UNNEEDED)
 { fprintf(stderr, "wallet_invoice_load called!\n"); abort(); }
+/* Generated stub for wallet_network_check */
+bool wallet_network_check(struct wallet *w UNNEEDED,
+			  const struct chainparams *chainparams UNNEEDED)
+{ fprintf(stderr, "wallet_network_check called!\n"); abort(); }
 /* Generated stub for wallet_new */
 struct wallet *wallet_new(struct lightningd *ld UNNEEDED,
 			  struct log *log UNNEEDED, struct timers *timers UNNEEDED)

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "db.h"
+#include <bitcoin/chainparams.h>
 #include <bitcoin/tx.h>
 #include <ccan/crypto/shachain/shachain.h>
 #include <ccan/list/list.h>
@@ -618,4 +619,15 @@ const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
  */
 void wallet_htlc_sigs_save(struct wallet *w, u64 channel_id,
 			   secp256k1_ecdsa_signature *htlc_sigs);
+
+/**
+ * wallet_network_check - Check that the wallet is setup for this chain
+ *
+ * Ensure that the genesis_hash from the chainparams matches the
+ * genesis_hash with which the DB was initialized. Returns false if
+ * the check failed, i.e., if the genesis hashes do not match.
+ */
+bool wallet_network_check(struct wallet *w,
+			  const struct chainparams *chainparams);
+
 #endif /* WALLET_WALLET_H */


### PR DESCRIPTION
Adds a simple check that compares genesis-blockhashes from the
chainparams against the blockhash that the wallet was created
with. The wallet is network specific, so mixing is always a bad idea.
