### PR TITLE
Fix route payment failure when upgraded from old db

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -365,6 +365,16 @@ class LightningNode(object):
         db.close()
         return result
 
+    # Assumes node is stopped!
+    def db_manip(self, query):
+        db = sqlite3.connect(os.path.join(self.daemon.lightning_dir, "lightningd.sqlite3"))
+        db.row_factory = sqlite3.Row
+        c = db.cursor()
+        c.execute(query)
+        db.commit()
+        c.close()
+        db.close()
+
     def stop(self, timeout=10):
         """ Attempt to do a clean shutdown, but kill if it hangs
         """

--- a/wallet/test/Makefile
+++ b/wallet/test/Makefile
@@ -10,6 +10,7 @@ WALLET_TEST_COMMON_OBJS :=			\
 	common/timeout.o			\
 	common/utils.o				\
 	common/wireaddr.o			\
+	common/version.o			\
 	wire/towire.o				\
 	wire/fromwire.o
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1560,7 +1560,7 @@ wallet_payment_list(const tal_t *ctx,
 			wallet->db,
 			"SELECT id, status, destination, "
 			"msatoshi, payment_hash, timestamp, payment_preimage, "
-			"path_secrets "
+			"path_secrets, route_nodes, route_channels "
 			"FROM payments "
 			"WHERE payment_hash = ?;");
 		sqlite3_bind_sha256(stmt, 1, payment_hash);


### PR DESCRIPTION
There are several bug reports with similar backtraces; while searching I spotted one missing case, but also decided we should record the upgrades.

I've asked great user who entrusted me with their db file to test this...