### PR TITLE
Add assertions to clarify our assumptions about msg != NULL

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -636,8 +636,8 @@ static void json_sendpay_on_resolve(const struct sendpay_result *r,
 {
 	struct command *cmd = (struct command*) vcmd;
 
-	struct json_result *data;
-	const char *msg;
+	struct json_result *data = NULL;
+	const char *msg = NULL;
 	struct routing_failure *fail;
 
 	if (r->succeeded)
@@ -693,6 +693,7 @@ static void json_sendpay_on_resolve(const struct sendpay_result *r,
 			break;
 		}
 
+		assert(msg);
 		command_fail_detailed(cmd, r->errorcode, data, "%s", msg);
 	}
 }

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -51,8 +51,8 @@ json_pay_success(struct command *cmd,
 static void json_pay_failure(struct command *cmd,
 			     const struct sendpay_result *r)
 {
-	struct json_result *data;
-	const char *msg;
+	struct json_result *data = NULL;
+	const char *msg = NULL;
 	struct routing_failure *fail;
 
 	assert(!r->succeeded);
@@ -109,6 +109,7 @@ static void json_pay_failure(struct command *cmd,
 		break;
 	}
 
+	assert(msg);
 	command_fail_detailed(cmd, r->errorcode, data, "%s", msg);
 }
 


### PR DESCRIPTION
Avoid using uninitialized values when calling `command_fail_detailed(...)`.

