### PR TITLE
Pass the $(CC) variable to the configurator executable when building config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ ALL_PROGRAMS += ccan/ccan/cdump/tools/cdump-enumstr
 ccan/ccan/cdump/tools/cdump-enumstr.o: $(CCAN_HEADERS) Makefile
 
 ccan/config.h: ccan/tools/configurator/configurator
-	if $< > $@.new; then mv $@.new $@; else rm $@.new; exit 1; fi
+	if $< $(CC) -static > $@.new; then mv $@.new $@; else rm $@.new; exit 1; fi
 
 gen_version.h: FORCE
 	@(echo "#define VERSION \"`git describe --always --dirty`\"" && echo "#define VERSION_NAME \"$(NAME)\"" && echo "#define BUILD_FEATURES \"$(FEATURES)\"") > $@.new


### PR DESCRIPTION
When cross compiling it's important that the resulting config.h reflects the platform we are building for and not the one we are building on. Otherwise we end up with a config.h that defines headers that are not there on the target platform, wrong endianness and so on.

The -static flag is there to be able to easily run the configurator test executables on the build machine with qemu-*.

E.g. Without the -static flag the resulting dynamically linked ARM executables complain about the lack of linker (/lib/ld-linux-armhf.so or /system/bin/linker for Android), since these files are not usually available on the build machine building statically avoids this problem and results in a proper config.h for cross compiling.

Related to #653 