### PR TITLE
Add PIE option to Makefile to build position independent executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ ifeq ($(COVERAGE),1)
 COVFLAGS = --coverage
 endif
 
+ifeq ($(PIE),1)
+PIE_CFLAGS=-fPIE -fPIC
+PIE_LDFLAGS=-pie
+endif
+
 PYTEST := $(shell command -v pytest 2> /dev/null)
 
 # This is where we add new features as bitcoin adds them.
@@ -152,9 +157,9 @@ ALL_PROGRAMS =
 CPPFLAGS = -DBINTOPKGLIBEXECDIR='"'$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))'"'
 CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition
 CDEBUGFLAGS := -std=gnu11 -g -fstack-protector
-CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS
+CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS)
 
-LDFLAGS = -L/usr/local/lib
+LDFLAGS = -L/usr/local/lib $(PIE_LDFLAGS)
 LDLIBS = -lm -lgmp -lsqlite3 $(COVFLAGS)
 
 default: all-programs all-test-programs


### PR DESCRIPTION
As of version 5.0 Android requires all dynamically linked executables to support PIE. This allows programs to be loaded at a different addresses, making it harder for attackers to target.

Enable with `PIE=1`
Somewhat related to #653 