### PR TITLE
A more detailed description of the "amount" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ First you need to transfer some funds to `lightningd` so that it can open a chan
 cli/lightning-cli newaddr
 
 # Returns a transaction id <txid>
-bitcoin-cli -testnet sendtoaddress <address> <amount>
+bitcoin-cli -testnet sendtoaddress <address> <amount_in_bitcoins>
 ```
 
 `lightningd` will register the funds once the transaction is
@@ -102,7 +102,7 @@ Let's assume the **remote** node is accepting connections at
 
 ```
 cli/lightning-cli connect <node_id> <ip> [<port>]
-cli/lightning-cli fundchannel <node_id> <amount>
+cli/lightning-cli fundchannel <node_id> <amount_in_satoshis>
 ```
 
 This opens a connection and, on top of that connection, then opens a channel.


### PR DESCRIPTION
The more frequent question I ask to myself when initiating channels regards the amount field.

In this document we have three different denominations and the modification proposed aims to address the possible doubts or errors.
The names <amount_in_bitcoins>, <amount_in_satoshis> or <amount_in_millisatoshis> (this last is omitted because the denomination is in the description) are not so elegant but they could serve the purpose.