### PR TITLE
lightningd: fix crash when htlc failed and source is onchain.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -105,6 +105,10 @@ static void fail_in_htlc(struct htlc_in *hin,
 	if (!hin->key.channel->owner)
 		return;
 
+	/* onchaind doesn't care, it can't do anything but wait */
+	if (channel_on_chain(hin->key.channel))
+		return;
+
 	subd_send_msg(hin->key.channel->owner,
 		      take(towire_channel_fail_htlc(hin,
 						    hin->key.id,


### PR DESCRIPTION
If the source channel is onchain, we try to send a message to onchaind
which (1) doesn't care, (2) doesn't take a channel_fail_htlc msg, and
(3) causes us to crash in subd.c:

	assert(!strstarts(sd->msgname(fromwire_peektype(msg_out)), "INVALID"));

Fixes: #821
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>