### PR TITLE
Expose version via default name and ping responses (if DEVELOPER=1)

### DIFF
--- a/common/ping.h
+++ b/common/ping.h
@@ -10,4 +10,7 @@ bool check_ping_make_pong(const tal_t *ctx, const u8 *ping, u8 **pong);
 /* Make a ping packet requesting num_pong_bytes */
 u8 *make_ping(const tal_t *ctx, u16 num_pong_bytes, u16 padlen);
 
+/* Returns error string if something wrong. */
+const char *got_pong(const u8 *pong, size_t *num_pings_outstanding);
+
 #endif /* LIGHTNING_COMMON_PING_H */

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -502,20 +502,13 @@ static void handle_ping(struct peer *peer, u8 *ping)
 
 static void handle_pong(struct peer *peer, const u8 *pong)
 {
-	u8 *ignored;
+	const char *err = got_pong(pong, &peer->local->num_pings_outstanding);
 
-	status_trace("Got pong!");
-	if (!fromwire_pong(pong, pong, &ignored)) {
-		peer_error(peer, "Bad pong");
+	if (err) {
+		peer_error(peer, "%s", err);
 		return;
 	}
 
-	if (!peer->local->num_pings_outstanding) {
-		peer_error(peer, "Unexpected pong");
-		return;
-	}
-
-	peer->local->num_pings_outstanding--;
 	daemon_conn_send(&peer->daemon->master,
 			 take(towire_gossip_ping_reply(pong, true,
 						       tal_len(pong))));

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1862,11 +1862,17 @@ class LightningDTests(BaseLightningDTests):
 
         # Test gossip pinging.
         self.ping_tests(l1, l2)
+        if DEVELOPER:
+            l1.daemon.wait_for_log('Got pong 1000 bytes \({}\.\.\.\)'
+                                   .format(l2.info['version']), timeout=1)
 
         self.fund_channel(l1, l2, 10**5)
 
         # channeld pinging
         self.ping_tests(l1, l2)
+        if DEVELOPER:
+            l1.daemon.wait_for_log('Got pong 1000 bytes \({}\.\.\.\)'
+                                   .format(l2.info['version']))
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_routing_gossip_reconnect(self):

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1762,13 +1762,13 @@ class LightningDTests(BaseLightningDTests):
         # Might not have seen other node-announce yet.
         # TODO(cdecker) Can't check these without DEVELOPER=1, re-enable after we get alias and color into getinfo
         if DEVELOPER:
-            assert n1['alias'] == 'JUNIORBEAM'
+            assert n1['alias'].startswith('JUNIORBEAM')
             assert n1['color'] == '0266e4'
             if not 'alias' in n2:
                 assert not 'color' in n2
                 assert not 'addresses' in n2
             else:
-                assert n2['alias'] == 'SILENTARTIST'
+                assert n2['alias'].startswith('SILENTARTIST')
                 assert n2['color'] == '022d22'
 
         assert [c['active'] for c in l1.rpc.listchannels()['channels']] == [True, True]


### PR DESCRIPTION
This is helpful for debugging, as many bug reports could be caused by the remote end being old.