### PR TITLE
move library path to LDLIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations 
 CDEBUGFLAGS := -std=gnu11 -g -fstack-protector
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS)
 
-LDFLAGS = -L/usr/local/lib $(PIE_LDFLAGS)
-LDLIBS = -lm -lgmp -lsqlite3 $(COVFLAGS)
+LDFLAGS = $(PIE_LDFLAGS)
+LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 $(COVFLAGS)
 
 default: all-programs all-test-programs
 


### PR DESCRIPTION
Fixes #1060 

Tested on Ubuntu 16.04.3 LTS