### PR TITLE
Remove persistent in-memory invoice structures

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -245,15 +245,15 @@ static void json_add_invoices(struct json_result *response,
 			      const char *buffer, const jsmntok_t *label,
 			      bool modern)
 {
-	const struct invoice *i;
+	struct invoice_iterator it;
 	struct invoice_details details;
 	char *lbl = NULL;
 	if (label)
 		lbl = tal_strndup(response, &buffer[label->start], label->end - label->start);
 
-	i = NULL;
-	while ((i = wallet_invoice_iterate(wallet, i)) != NULL) {
-		wallet_invoice_details(response, wallet, i, &details);
+	memset(&it, 0, sizeof(it));
+	while (wallet_invoice_iterate(wallet, &it)) {
+		wallet_invoice_iterator_deref(response, wallet, &it, &details);
 		if (lbl && !streq(details.label, lbl))
 			continue;
 		json_add_invoice(response, &details, modern);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -229,7 +229,7 @@ static void handle_localpay(struct htlc_in *hin,
 			    u32 outgoing_cltv_value)
 {
 	enum onion_type failcode;
-	const struct invoice *invoice;
+	struct invoice invoice;
 	struct invoice_details details;
 	struct lightningd *ld = hin->key.channel->peer->ld;
 	const tal_t *tmpctx = tal_tmpctx(ld);
@@ -262,8 +262,7 @@ static void handle_localpay(struct htlc_in *hin,
 		goto fail;
 	}
 
-	invoice = wallet_invoice_find_unpaid(ld->wallet, payment_hash);
-	if (!invoice) {
+	if (!wallet_invoice_find_unpaid(ld->wallet, &invoice, payment_hash)) {
 		failcode = WIRE_UNKNOWN_PAYMENT_HASH;
 		goto fail;
 	}

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3213,7 +3213,7 @@ class LightningDTests(BaseLightningDTests):
         # Create invoices
         inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1')
         inv2 = l2.rpc.invoice(1000, 'inv2', 'inv2')
-        inv3 = l2.rpc.invoice(1000, 'inv3', 'inv3')
+        l2.rpc.invoice(1000, 'inv3', 'inv3')
 
         # Start waiting on invoice 3
         f3 = self.executor.submit(l2.rpc.waitinvoice, 'inv3')

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -446,13 +446,21 @@ bool invoices_delete(struct invoices *invoices,
 	return true;
 }
 
-const struct invoice *invoices_iterate(struct invoices *invoices,
-				       const struct invoice *invoice)
+bool invoices_iterate(struct invoices *invoices,
+		      struct invoice_iterator *it)
 {
-	if (invoice)
-		return list_next(&invoices->invlist, invoice, list);
+	if (it->curr)
+		it->curr = list_next(&invoices->invlist, it->curr, list);
 	else
-		return list_top(&invoices->invlist, struct invoice, list);
+		it->curr = list_top(&invoices->invlist, struct invoice, list);
+	return it->curr != NULL;
+}
+void invoices_iterator_deref(const tal_t *ctx,
+			     struct invoices *invoices,
+			     const struct invoice_iterator *it,
+			     struct invoice_details *details)
+{
+	invoices_get_details(ctx, invoices, it->curr, details);
 }
 
 static s64 get_next_pay_index(struct db *db)

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -96,11 +96,9 @@ static void wallet_stmt2invoice_details(const tal_t *ctx,
 {
 	dtl->state = sqlite3_column_int(stmt, 0);
 
-	assert(sqlite3_column_bytes(stmt, 1) == sizeof(struct preimage));
-	memcpy(&dtl->r, sqlite3_column_blob(stmt, 1), sqlite3_column_bytes(stmt, 1));
+	sqlite3_column_preimage(stmt, 1, &dtl->r);
 
-	assert(sqlite3_column_bytes(stmt, 2) == sizeof(struct sha256));
-	memcpy(&dtl->rhash, sqlite3_column_blob(stmt, 2), sqlite3_column_bytes(stmt, 2));
+	sqlite3_column_sha256(stmt, 2, &dtl->rhash);
 
 	dtl->label = tal_strndup(ctx, sqlite3_column_blob(stmt, 3), sqlite3_column_bytes(stmt, 3));
 

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -8,6 +8,7 @@
 struct db;
 struct invoice;
 struct invoice_details;
+struct invoice_iterator;
 struct invoices;
 struct log;
 struct sha256;
@@ -91,18 +92,34 @@ bool invoices_delete(struct invoices *invoices,
  * invoices_iterate - Iterate over all existing invoices
  *
  * @invoices - the invoice handler.
- * @invoice - the previous invoice you iterated over.
+ * @iterator - the iterator object to use.
  *
- * Return NULL at end-of-sequence. Usage:
+ * Return false at end-of-sequence, true if still iterating.
+ * Usage:
  *
- *   const struct invoice *i;
- *   i = NULL;
- *   while ((i = invoices_iterate(invoices, i))) {
+ *   struct invoice_iterator it;
+ *   memset(&it, 0, sizeof(it))
+ *   while (invoices_iterate(wallet, &it)) {
  *       ...
  *   }
  */
-const struct invoice *invoices_iterate(struct invoices *invoices,
-				       const struct invoice *invoice);
+bool invoices_iterate(struct invoices *invoices,
+		      struct invoice_iterator *it);
+
+/**
+ * wallet_invoice_iterator_deref - Read the details of the
+ * invoice currently pointed to by the given iterator.
+ *
+ * @ctx - the owner of the label and msatoshi fields returned.
+ * @wallet - the wallet whose invoices are to be iterated over.
+ * @iterator - the iterator object to use.
+ * @details - pointer to details object to load.
+ *
+ */
+void invoices_iterator_deref(const tal_t *ctx,
+			     struct invoices *invoices,
+			     const struct invoice_iterator *it,
+			     struct invoice_details *details);
 
 /**
  * invoices_resolve - Mark an invoice as paid

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -39,6 +39,7 @@ bool invoices_load(struct invoices *invoices);
  * invoices_create - Create a new invoice.
  *
  * @invoices - the invoice handler.
+ * @pinvoice - pointer to location to load new invoice in.
  * @msatoshi - the amount the invoice should have, or
  * NULL for any-amount invoices.
  * @label - the unique label for this invoice. Must be
@@ -46,36 +47,44 @@ bool invoices_load(struct invoices *invoices);
  * @expiry - the number of seconds before the invoice
  * expires
  *
- * Returns NULL if label already exists or expiry is 0.
+ * Returns false if label already exists or expiry is 0.
+ * Returns true if created invoice.
  * FIXME: Fallback addresses
  */
-const struct invoice *invoices_create(struct invoices *invoices,
-				      u64 *msatoshi TAKES,
-				      const char *label TAKES,
-				      u64 expiry);
+bool invoices_create(struct invoices *invoices,
+		     struct invoice *pinvoice,
+		     u64 *msatoshi TAKES,
+		     const char *label TAKES,
+		     u64 expiry);
 
 /**
  * invoices_find_by_label - Search for an invoice by label
  *
  * @invoices - the invoice handler.
+ * @pinvoice - pointer to location to load found invoice in.
  * @label - the label to search for. Must be null-terminated.
  *
- * Returns NULL if no invoice with that label exists.
+ * Returns false if no invoice with that label exists.
+ * Returns true if found.
  */
-const struct invoice *invoices_find_by_label(struct invoices *invoices,
-					     const char *label);
+bool invoices_find_by_label(struct invoices *invoices,
+			    struct invoice *pinvoice,
+			    const char *label);
 
 /**
  * invoices_find_unpaid - Search for an unpaid, unexpired invoice by
  * payment_hash
  *
  * @invoices - the invoice handler.
+ * @pinvoice - pointer to location to load found invoice in.
  * @rhash - the payment_hash to search for.
  *
- * Returns NULL if no invoice with that payment hash exists.
+ * Returns false if no unpaid invoice with that rhash exists.
+ * Returns true if found.
  */
-const struct invoice *invoices_find_unpaid(struct invoices *invoices,
-					   const struct sha256 *rhash);
+bool invoices_find_unpaid(struct invoices *invoices,
+			  struct invoice *pinvoice,
+			  const struct sha256 *rhash);
 
 /**
  * invoices_delete - Delete an invoice
@@ -86,7 +95,7 @@ const struct invoice *invoices_find_unpaid(struct invoices *invoices,
  * Return false on failure.
  */
 bool invoices_delete(struct invoices *invoices,
-		     const struct invoice *invoice);
+		     struct invoice invoice);
 
 /**
  * invoices_iterate - Iterate over all existing invoices
@@ -132,7 +141,7 @@ void invoices_iterator_deref(const tal_t *ctx,
  * does not check).
  */
 void invoices_resolve(struct invoices *invoices,
-		      const struct invoice *invoice,
+		      struct invoice invoice,
 		      u64 msatoshi_received);
 
 /**
@@ -173,7 +182,7 @@ void invoices_waitany(const tal_t *ctx,
  */
 void invoices_waitone(const tal_t *ctx,
 		      struct invoices *invoices,
-		      struct invoice const *invoice,
+		      struct invoice invoice,
 		      void (*cb)(const struct invoice *, void*),
 		      void *cbarg);
 
@@ -187,7 +196,7 @@ void invoices_waitone(const tal_t *ctx,
  */
 void invoices_get_details(const tal_t *ctx,
 			  struct invoices *invoices,
-			  const struct invoice *invoice,
+			  struct invoice invoice,
 			  struct invoice_details *details);
 
 #endif /* LIGHTNING_WALLET_INVOICES_H */

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -7,6 +7,7 @@
 
 struct db;
 struct invoice;
+struct invoice_details;
 struct invoices;
 struct log;
 struct sha256;
@@ -158,5 +159,18 @@ void invoices_waitone(const tal_t *ctx,
 		      struct invoice const *invoice,
 		      void (*cb)(const struct invoice *, void*),
 		      void *cbarg);
+
+/**
+ * invoices_get_details - Get the invoice_details of an invoice.
+ *
+ * @ctx - the owner of the label and msatoshi fields returned.
+ * @invoices - the invoice handler,
+ * @invoice - the invoice to get details on.
+ * @details - pointer to details object to load.
+ */
+void invoices_get_details(const tal_t *ctx,
+			  struct invoices *invoices,
+			  const struct invoice *invoice,
+			  struct invoice_details *details);
 
 #endif /* LIGHTNING_WALLET_INVOICES_H */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -112,6 +112,12 @@ const struct invoice *invoices_find_by_label(struct invoices *invoices UNNEEDED,
 const struct invoice *invoices_find_unpaid(struct invoices *invoices UNNEEDED,
 					   const struct sha256 *rhash UNNEEDED)
 { fprintf(stderr, "invoices_find_unpaid called!\n"); abort(); }
+/* Generated stub for invoices_get_details */
+void invoices_get_details(const tal_t *ctx UNNEEDED,
+			  struct invoices *invoices UNNEEDED,
+			  const struct invoice *invoice UNNEEDED,
+			  struct invoice_details *details UNNEEDED)
+{ fprintf(stderr, "invoices_get_details called!\n"); abort(); }
 /* Generated stub for invoices_iterate */
 const struct invoice *invoices_iterate(struct invoices *invoices UNNEEDED,
 				       const struct invoice *invoice UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -119,9 +119,15 @@ void invoices_get_details(const tal_t *ctx UNNEEDED,
 			  struct invoice_details *details UNNEEDED)
 { fprintf(stderr, "invoices_get_details called!\n"); abort(); }
 /* Generated stub for invoices_iterate */
-const struct invoice *invoices_iterate(struct invoices *invoices UNNEEDED,
-				       const struct invoice *invoice UNNEEDED)
+bool invoices_iterate(struct invoices *invoices UNNEEDED,
+		      struct invoice_iterator *it UNNEEDED)
 { fprintf(stderr, "invoices_iterate called!\n"); abort(); }
+/* Generated stub for invoices_iterator_deref */
+void invoices_iterator_deref(const tal_t *ctx UNNEEDED,
+			     struct invoices *invoices UNNEEDED,
+			     const struct invoice_iterator *it UNNEEDED,
+			     struct invoice_details *details UNNEEDED)
+{ fprintf(stderr, "invoices_iterator_deref called!\n"); abort(); }
 /* Generated stub for invoices_load */
 bool invoices_load(struct invoices *invoices UNNEEDED)
 { fprintf(stderr, "invoices_load called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -95,27 +95,30 @@ u8 *get_supported_global_features(const tal_t *ctx UNNEEDED)
 u8 *get_supported_local_features(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "get_supported_local_features called!\n"); abort(); }
 /* Generated stub for invoices_create */
-const struct invoice *invoices_create(struct invoices *invoices UNNEEDED,
-				      u64 *msatoshi TAKES UNNEEDED,
-				      const char *label TAKES UNNEEDED,
-				      u64 expiry UNNEEDED)
+bool invoices_create(struct invoices *invoices UNNEEDED,
+		     struct invoice *pinvoice UNNEEDED,
+		     u64 *msatoshi TAKES UNNEEDED,
+		     const char *label TAKES UNNEEDED,
+		     u64 expiry UNNEEDED)
 { fprintf(stderr, "invoices_create called!\n"); abort(); }
 /* Generated stub for invoices_delete */
 bool invoices_delete(struct invoices *invoices UNNEEDED,
-		     const struct invoice *invoice UNNEEDED)
+		     struct invoice invoice UNNEEDED)
 { fprintf(stderr, "invoices_delete called!\n"); abort(); }
 /* Generated stub for invoices_find_by_label */
-const struct invoice *invoices_find_by_label(struct invoices *invoices UNNEEDED,
-					     const char *label UNNEEDED)
+bool invoices_find_by_label(struct invoices *invoices UNNEEDED,
+			    struct invoice *pinvoice UNNEEDED,
+			    const char *label UNNEEDED)
 { fprintf(stderr, "invoices_find_by_label called!\n"); abort(); }
 /* Generated stub for invoices_find_unpaid */
-const struct invoice *invoices_find_unpaid(struct invoices *invoices UNNEEDED,
-					   const struct sha256 *rhash UNNEEDED)
+bool invoices_find_unpaid(struct invoices *invoices UNNEEDED,
+			  struct invoice *pinvoice UNNEEDED,
+			  const struct sha256 *rhash UNNEEDED)
 { fprintf(stderr, "invoices_find_unpaid called!\n"); abort(); }
 /* Generated stub for invoices_get_details */
 void invoices_get_details(const tal_t *ctx UNNEEDED,
 			  struct invoices *invoices UNNEEDED,
-			  const struct invoice *invoice UNNEEDED,
+			  struct invoice invoice UNNEEDED,
 			  struct invoice_details *details UNNEEDED)
 { fprintf(stderr, "invoices_get_details called!\n"); abort(); }
 /* Generated stub for invoices_iterate */
@@ -139,7 +142,7 @@ struct invoices *invoices_new(const tal_t *ctx UNNEEDED,
 { fprintf(stderr, "invoices_new called!\n"); abort(); }
 /* Generated stub for invoices_resolve */
 void invoices_resolve(struct invoices *invoices UNNEEDED,
-		      const struct invoice *invoice UNNEEDED,
+		      struct invoice invoice UNNEEDED,
 		      u64 msatoshi_received UNNEEDED)
 { fprintf(stderr, "invoices_resolve called!\n"); abort(); }
 /* Generated stub for invoices_waitany */
@@ -152,7 +155,7 @@ void invoices_waitany(const tal_t *ctx UNNEEDED,
 /* Generated stub for invoices_waitone */
 void invoices_waitone(const tal_t *ctx UNNEEDED,
 		      struct invoices *invoices UNNEEDED,
-		      struct invoice const *invoice UNNEEDED,
+		      struct invoice invoice UNNEEDED,
 		      void (*cb)(const struct invoice * UNNEEDED, void*) UNNEEDED,
 		      void *cbarg UNNEEDED)
 { fprintf(stderr, "invoices_waitone called!\n"); abort(); }

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1287,10 +1287,17 @@ bool wallet_invoice_delete(struct wallet *wallet,
 {
 	return invoices_delete(wallet->invoices, invoice);
 }
-const struct invoice *wallet_invoice_iterate(struct wallet *wallet,
-					     const struct invoice *invoice)
+bool wallet_invoice_iterate(struct wallet *wallet,
+			    struct invoice_iterator *it)
 {
-	return invoices_iterate(wallet->invoices, invoice);
+	return invoices_iterate(wallet->invoices, it);
+}
+void wallet_invoice_iterator_deref(const tal_t *ctx,
+				   struct wallet *wallet,
+				   const struct invoice_iterator *it,
+				   struct invoice_details *details)
+{
+	return invoices_iterator_deref(ctx, wallet->invoices, it, details);
 }
 void wallet_invoice_resolve(struct wallet *wallet,
 			    const struct invoice *invoice,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1314,7 +1314,13 @@ void wallet_invoice_waitone(const tal_t *ctx,
 {
 	invoices_waitone(ctx, wallet->invoices, invoice, cb, cbarg);
 }
-
+void wallet_invoice_details(const tal_t *ctx,
+			    struct wallet *wallet,
+			    const struct invoice *invoice,
+			    struct invoice_details *details)
+{
+	invoices_get_details(ctx, wallet->invoices, invoice, details);
+}
 
 
 struct htlc_stub *wallet_htlc_stubs(const tal_t *ctx, struct wallet *wallet,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1266,24 +1266,27 @@ bool wallet_invoice_load(struct wallet *wallet)
 {
 	return invoices_load(wallet->invoices);
 }
-const struct invoice *wallet_invoice_create(struct wallet *wallet,
-					    u64 *msatoshi TAKES,
-					    const char *label TAKES,
-					    u64 expiry) {
-	return invoices_create(wallet->invoices, msatoshi, label, expiry);
+bool wallet_invoice_create(struct wallet *wallet,
+			   struct invoice *pinvoice,
+			   u64 *msatoshi TAKES,
+			   const char *label TAKES,
+			   u64 expiry) {
+	return invoices_create(wallet->invoices, pinvoice, msatoshi, label, expiry);
 }
-const struct invoice *wallet_invoice_find_by_label(struct wallet *wallet,
-						   const char *label)
+bool wallet_invoice_find_by_label(struct wallet *wallet,
+				  struct invoice *pinvoice,
+				  const char *label)
 {
-	return invoices_find_by_label(wallet->invoices, label);
+	return invoices_find_by_label(wallet->invoices, pinvoice, label);
 }
-const struct invoice *wallet_invoice_find_unpaid(struct wallet *wallet,
-						 const struct sha256 *rhash)
+bool wallet_invoice_find_unpaid(struct wallet *wallet,
+				struct invoice *pinvoice,
+				const struct sha256 *rhash)
 {
-	return invoices_find_unpaid(wallet->invoices, rhash);
+	return invoices_find_unpaid(wallet->invoices, pinvoice, rhash);
 }
 bool wallet_invoice_delete(struct wallet *wallet,
-			   const struct invoice *invoice)
+			   struct invoice invoice)
 {
 	return invoices_delete(wallet->invoices, invoice);
 }
@@ -1300,7 +1303,7 @@ void wallet_invoice_iterator_deref(const tal_t *ctx,
 	return invoices_iterator_deref(ctx, wallet->invoices, it, details);
 }
 void wallet_invoice_resolve(struct wallet *wallet,
-			    const struct invoice *invoice,
+			    struct invoice invoice,
 			    u64 msatoshi_received)
 {
 	invoices_resolve(wallet->invoices, invoice, msatoshi_received);
@@ -1315,7 +1318,7 @@ void wallet_invoice_waitany(const tal_t *ctx,
 }
 void wallet_invoice_waitone(const tal_t *ctx,
 			    struct wallet *wallet,
-			    struct invoice const *invoice,
+			    struct invoice invoice,
 			    void (*cb)(const struct invoice *, void*),
 			    void *cbarg)
 {
@@ -1323,7 +1326,7 @@ void wallet_invoice_waitone(const tal_t *ctx,
 }
 void wallet_invoice_details(const tal_t *ctx,
 			    struct wallet *wallet,
-			    const struct invoice *invoice,
+			    struct invoice invoice,
 			    struct invoice_details *details)
 {
 	invoices_get_details(ctx, wallet->invoices, invoice, details);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -397,8 +397,6 @@ struct invoice {
 	struct list_node list;
 	/* Database ID */
 	u64 id;
-	/* Any JSON waitinvoice calls waiting for this to be paid */
-	struct list_head waitone_waiters;
 	/* Any expiration timer in effect */
 	struct oneshot *expiration_timer;
 	/* The owning invoices object. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -397,8 +397,6 @@ struct invoice {
 	struct list_node list;
 	/* Database ID */
 	u64 id;
-	/* Any expiration timer in effect */
-	struct oneshot *expiration_timer;
 	/* The owning invoices object. */
 	struct invoices *owner;
 	/* Loaded details. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -390,6 +390,13 @@ struct invoice_details {
 	u64 paid_timestamp;
 };
 
+/* An object that handles iteration over the set of invoices */
+struct invoice_iterator {
+	/* The contents of this object is subject to change
+	 * and should not be depended upon */
+	const struct invoice *curr;
+};
+
 struct invoice {
 	/* Internal, rest of lightningd should not use */
 	/* List off ld->wallet->invoices. Must be first or else
@@ -476,18 +483,34 @@ bool wallet_invoice_delete(struct wallet *wallet,
  * wallet_invoice_iterate - Iterate over all existing invoices
  *
  * @wallet - the wallet whose invoices are to be iterated over.
- * @invoice - the previous invoice you iterated over.
+ * @iterator - the iterator object to use.
  *
- * Return NULL at end-of-sequence. Usage:
+ * Return false at end-of-sequence, true if still iterating.
+ * Usage:
  *
- *   const struct invoice *i;
- *   i = NULL;
- *   while ((i = wallet_invoice_iterate(wallet, i))) {
+ *   struct invoice_iterator it;
+ *   memset(&it, 0, sizeof(it))
+ *   while (wallet_invoice_iterate(wallet, &it)) {
  *       ...
  *   }
  */
-const struct invoice *wallet_invoice_iterate(struct wallet *wallet,
-					     const struct invoice *invoice);
+bool wallet_invoice_iterate(struct wallet *wallet,
+			    struct invoice_iterator *it);
+
+/**
+ * wallet_invoice_iterator_deref - Read the details of the
+ * invoice currently pointed to by the given iterator.
+ *
+ * @ctx - the owner of the label and msatoshi fields returned.
+ * @wallet - the wallet whose invoices are to be iterated over.
+ * @iterator - the iterator object to use.
+ * @details - pointer to details object to load.
+ *
+ */
+void wallet_invoice_iterator_deref(const tal_t *ctx,
+				   struct wallet *wallet,
+				   const struct invoice_iterator *it,
+				   struct invoice_details *details);
 
 /**
  * wallet_invoice_resolve - Mark an invoice as paid


### PR DESCRIPTION
Use the db directly as much as we can.

Lowers our memory footprint slightly (depending on how many invoices we have and how long the application keeps invoices alive after paying).