### PR TITLE
contrib: Add flake8 and pytest-rerunfailures to builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ PIE_LDFLAGS=-pie
 endif
 
 PYTEST := $(shell command -v pytest 2> /dev/null)
+PYTEST_OPTS := -v -x
+ifeq ($(TRAVIS),true)
+PYTEST_OPTS += --reruns=3
+endif
 
 # This is where we add new features as bitcoin adds them.
 FEATURES :=
@@ -197,7 +201,7 @@ pytest: $(ALL_PROGRAMS)
 ifndef PYTEST
 	PYTHONPATH=contrib/pylightning:$$PYTHONPATH DEVELOPER=$(DEVELOPER) python3 tests/test_lightningd.py -f
 else
-	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) -vx tests/test_lightningd.py --test-group=$(TEST_GROUP) --test-group-count=$(TEST_GROUP_COUNT)
+	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) -vx tests/test_lightningd.py --test-group=$(TEST_GROUP) --test-group-count=$(TEST_GROUP_COUNT) $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -35,4 +35,5 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
 
-RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0
+RUN pip3 install --upgrade pip && \
+    pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -35,4 +35,4 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
 
-RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3
+RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -35,4 +35,5 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
 
-RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0
+RUN pip3 install --upgrade pip && \
+    pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -35,4 +35,4 @@ RUN cd /tmp/ && \
     mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
 
-RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3
+RUN pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -8,6 +8,7 @@ import queue
 import os
 import random
 import re
+import shutil
 import socket
 import sqlite3
 import string
@@ -105,6 +106,9 @@ class NodeFactory(object):
 
         lightning_dir = os.path.join(
             TEST_DIR, self.testname, "lightning-{}/".format(node_id))
+
+        if os.path.exists(lightning_dir):
+            shutil.rmtree(lightning_dir)
 
         socket_path = os.path.join(lightning_dir, "lightning-rpc").format(node_id)
         port = 16330 + node_id


### PR DESCRIPTION
This adds two new python dependencies to the CI builder:

 - flake8: to check the coding style for python scripts
 - pytest-rerunfailures: allows to rerun failed tests for a fixed number of times

The latter may hide some flaky tests, but it greatly reduces the need to manually kick travis, so I consider it a net plus. The goal should definitely be to reduce the number of flaky tests, but some tend to slip through anyway. I have an idea to collect flakyness records for tests to re-add the visibility we lose here, but it's not quite done yet.

Fixes #1078 