### PR TITLE
Better handling bitcoin cli fail

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -22,10 +22,6 @@
 #include <inttypes.h>
 #include <lightningd/chaintopology.h>
 
-#define BITCOIN_CLI "bitcoin-cli"
-
-char *bitcoin_datadir;
-
 /* Add the n'th arg to *args, incrementing n and keeping args of size n+1 */
 static void add_arg(const char ***args, const char *arg)
 {
@@ -40,7 +36,7 @@ static const char **gather_args(const struct bitcoind *bitcoind,
 	const char **args = tal_arr(ctx, const char *, 1);
 	const char *arg;
 
-	args[0] = bitcoind->chainparams->cli;
+	args[0] = bitcoind->cli ? bitcoind->cli : bitcoind->chainparams->cli;
 	if (bitcoind->chainparams->cli_args)
 		add_arg(&args, bitcoind->chainparams->cli_args);
 
@@ -773,6 +769,7 @@ struct bitcoind *new_bitcoind(const tal_t *ctx,
 
 	/* Use testnet by default, change later if we want another network */
 	bitcoind->chainparams = chainparams_for_network("testnet");
+	bitcoind->cli = NULL;
 	bitcoind->datadir = NULL;
 	bitcoind->ld = ld;
 	bitcoind->log = log;

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -25,6 +25,9 @@ enum bitcoind_mode {
 };
 
 struct bitcoind {
+	/* eg. "bitcoin-cli" */
+	char *cli;
+
 	/* -datadir arg for bitcoin-cli. */
 	char *datadir;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -562,6 +562,9 @@ void register_opts(struct lightningd *ld)
 	opt_register_arg("--alias", opt_set_alias, NULL, ld,
 			 "Up to 32-byte alias for node");
 
+	opt_register_arg("--bitcoin-cli", opt_set_talstr, NULL,
+			 &ld->topology->bitcoind->cli,
+			 "bitcoin-cli pathname");
 	opt_register_arg("--bitcoin-rpcuser", opt_set_talstr, NULL,
 			 &ld->topology->bitcoind->rpcuser,
 			 "bitcoind RPC username");


### PR DESCRIPTION
On IRC BearShark reported that his node always stopped updating blocks; then I noticed that my own node was mysteriously still running after I stopped bitcoind.

Indeed, it was the spurious failure handling which was biting us again.  This fixes and adds tests.