### PR TITLE
lightning-cli: Be more discerning about literals.

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -131,13 +131,14 @@ static char *opt_set_ordered(enum input *input)
 
 static bool is_literal(const char *arg)
 {
-	return strspn(arg, "0123456789") == strlen(arg)
+	size_t arglen = strlen(arg);
+	return strspn(arg, "0123456789") == arglen
 		|| streq(arg, "true")
 		|| streq(arg, "false")
 		|| streq(arg, "null")
-		|| arg[0] == '{'
-		|| arg[0] == '['
-		|| arg[0] == '"';
+		|| (arg[0] == '{' && arg[arglen - 1] == '}')
+		|| (arg[0] == '[' && arg[arglen - 1] == ']')
+		|| (arg[0] == '"' && arg[arglen - 1] == '"');
 }
 
 static void add_input(char **cmd, const char *input,


### PR DESCRIPTION
Fixes: #574

The issue states that we should follow the standard when
parsing the port for IPv6 [addr]:port syntax, but this is
actually already supported by the daemon. The issue arises
due to the `lightning-cli` misinterpreting [addr]:port as
an array. This modification makes [addr]:port interpreted
as a string.