### PR TITLE
test_lightningd.py: lightningd currently calls getblock, not getblockhash.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1122,11 +1122,11 @@ class LightningDTests(BaseLightningDTests):
 
         # This should cause both estimatefee and getblockhash fail
         l1.daemon.wait_for_logs(['estimatesmartfee .* exited with status 1',
-                                 'getblockhash .* exited with status 1'])
+                                 'getblock .* exited with status 1'])
 
         # And they should retry!
         l1.daemon.wait_for_logs(['estimatesmartfee .* exited with status 1',
-                                 'getblockhash .* exited with status 1'])
+                                 'getblock .* exited with status 1'])
 
         # Restore, then it should recover and get blockheight.
         self.fake_bitcoind_unfail(l1)


### PR DESCRIPTION
Without this change, the test fails for me. To be honest, I don't know how this could ever have worked, or what change made it fail.

For me, this test (without the patch) already failed in the commit that added it (737a7148b51e006d6bf62d00e47cf71e3be6d711), so it doesn't seem to be a later regression.