### PR TITLE
json-rpc: translate NULL into "null" instead of "(null)".

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -263,6 +263,8 @@ static void connection_complete_ok(struct json_connection *jcon,
 				   const char *id,
 				   const struct json_result *result)
 {
+    assert(id != NULL);
+
 	/* This JSON is simple enough that we build manually */
 	json_done(jcon, cmd, take(tal_fmt(jcon,
 					  "{ \"jsonrpc\": \"2.0\", "
@@ -290,11 +292,7 @@ static void connection_complete_error(struct json_connection *jcon,
 	else
 		data_str = "";
 
-    /*
-    tal_fmt translates NULL into "(null)", which is not valid JSON.
-    Prevent this by pre-emptively translating NULL into "null".
-    */
-    if(id == NULL) id = "null";
+    assert(id != NULL);
 
 	json_done(jcon, cmd, take(tal_fmt(tmpctx,
 					  "{ \"jsonrpc\": \"2.0\", "
@@ -691,7 +689,7 @@ again:
 				    "Invalid token in json input: '%.*s'",
 				    (int)jcon->used, jcon->buffer);
 			json_command_malformed(
-			    jcon, NULL,
+			    jcon, "null",
 			    "Invalid token in json input");
 			return io_halfclose(conn);
 		}

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -263,7 +263,7 @@ static void connection_complete_ok(struct json_connection *jcon,
 				   const char *id,
 				   const struct json_result *result)
 {
-    assert(id != NULL);
+	assert(id != NULL);
 
 	/* This JSON is simple enough that we build manually */
 	json_done(jcon, cmd, take(tal_fmt(jcon,
@@ -292,7 +292,7 @@ static void connection_complete_error(struct json_connection *jcon,
 	else
 		data_str = "";
 
-    assert(id != NULL);
+	assert(id != NULL);
 
 	json_done(jcon, cmd, take(tal_fmt(tmpctx,
 					  "{ \"jsonrpc\": \"2.0\", "

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -290,6 +290,12 @@ static void connection_complete_error(struct json_connection *jcon,
 	else
 		data_str = "";
 
+    /*
+    tal_fmt translates NULL into "(null)", which is not valid JSON.
+    Prevent this by pre-emptively translating NULL into "null".
+    */
+    if(id == NULL) id = "null";
+
 	json_done(jcon, cmd, take(tal_fmt(tmpctx,
 					  "{ \"jsonrpc\": \"2.0\", "
 					  " \"error\" : "


### PR DESCRIPTION
It turns out that #957 is insufficient to solve #908 . This fix is needed to really say "id": null instead of "id": (null).

This is probably an incomplete fix: it would be better to make sure that **all** cases of NULL are translated into "null". However, I didn't want to touch the tal_fmt implementation. What would be a good approach? make a json_fmt wrapper around tal_fmt to do this? I didn't do this yet: since I'm not too familiar with the code base yet, I didn't want to make too large changes without any guidance.
