### PR TITLE
Store invoice bolt11 in case an RPC client needs it later

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -200,6 +200,8 @@ char *dbmigrations[] = {
     "DELETE FROM peers WHERE id NOT IN (SELECT peer_id FROM channels);",
     /* The ONCHAIND_CHEATED/THEIR_UNILATERAL/OUR_UNILATERAL/MUTUAL are now one */
     "UPDATE channels SET STATE = 8 WHERE state > 8;",
+    /* Add bolt11 to invoices table*/
+    "ALTER TABLE invoices ADD bolt11 TEXT;",
     NULL,
 };
 

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -4,6 +4,7 @@
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 #include <ccan/take/take.h>
+#include <bitcoin/preimage.h>
 
 struct db;
 struct invoice;
@@ -55,7 +56,10 @@ bool invoices_create(struct invoices *invoices,
 		     struct invoice *pinvoice,
 		     u64 *msatoshi TAKES,
 		     const char *label TAKES,
-		     u64 expiry);
+		     u64 expiry,
+		     const char *b11enc,
+		     const struct preimage *r,
+		     const struct sha256 *rhash);
 
 /**
  * invoices_find_by_label - Search for an invoice by label

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -99,7 +99,10 @@ bool invoices_create(struct invoices *invoices UNNEEDED,
 		     struct invoice *pinvoice UNNEEDED,
 		     u64 *msatoshi TAKES UNNEEDED,
 		     const char *label TAKES UNNEEDED,
-		     u64 expiry UNNEEDED)
+		     u64 expiry UNNEEDED,
+		     const char *b11enc UNNEEDED,
+		     const struct preimage *r UNNEEDED,
+		     const struct sha256 *rhash UNNEEDED)
 { fprintf(stderr, "invoices_create called!\n"); abort(); }
 /* Generated stub for invoices_delete */
 bool invoices_delete(struct invoices *invoices UNNEEDED,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1270,8 +1270,12 @@ bool wallet_invoice_create(struct wallet *wallet,
 			   struct invoice *pinvoice,
 			   u64 *msatoshi TAKES,
 			   const char *label TAKES,
-			   u64 expiry) {
-	return invoices_create(wallet->invoices, pinvoice, msatoshi, label, expiry);
+			   u64 expiry,
+			   const char *b11enc,
+			   const struct preimage *r,
+			   const struct sha256 *rhash)
+{
+	return invoices_create(wallet->invoices, pinvoice, msatoshi, label, expiry, b11enc, r, rhash);
 }
 bool wallet_invoice_find_by_label(struct wallet *wallet,
 				  struct invoice *pinvoice,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -441,7 +441,10 @@ bool wallet_invoice_create(struct wallet *wallet,
 			   struct invoice *pinvoice,
 			   u64 *msatoshi TAKES,
 			   const char *label TAKES,
-			   u64 expiry);
+			   u64 expiry,
+			   const char *b11enc,
+			   const struct preimage *r,
+			   const struct sha256 *rhash);
 
 /**
  * wallet_invoice_find_by_label - Search for an invoice by label

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -388,6 +388,8 @@ struct invoice_details {
 	u64 msatoshi_received;
 	/* Set if state == PAID; time paid */
 	u64 paid_timestamp;
+	/* BOLT11 encoding for this invoice */
+	const char *bolt11;
 };
 
 /* An object that handles iteration over the set of invoices */


### PR DESCRIPTION
Rationale: sometimes debtors forget their debts and we have to remind them to pay. Most polite way would be to resend the bolt11 string. 

Say a dumb RPC client connects to the deamon and `listinvoices`. In case we have outstanding (non-paid, non-expired) invoices we should also have the bolt11 available to "share".

Here's a real world scenario on my side:
![screenshot_20180227_163500](https://user-images.githubusercontent.com/762502/36740378-8c59a244-1be2-11e8-8d7d-4e5cd2ce638a.png)

Let me know what you think!