### PR TITLE
Add specific external libs to the makefile clean recipe

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -82,6 +82,9 @@ clean: external-clean
 
 external-clean:
 	$(RM) $(EXTERNAL_LIBS) external/*.la external/*.o
+	make -C external/libsodium clean
+	make -C external/libwally-core clean
+	make -C external/libwally-core/src clean
 
 external-distclean:
 	make -C external/libsodium distclean || true


### PR DESCRIPTION
To avoid failed linking of cross compiled binaries left out after an incomplete `make clean`