### PR TITLE
Fix libtool error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,9 +427,9 @@ uninstall:
 
 installcheck:
 	@rm -rf testinstall || true
-	$(MAKE) DESTDIR=testinstall install
+	$(MAKE) DESTDIR=$$(pwd)/testinstall install
 	testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
-	$(MAKE) DESTDIR=testinstall uninstall
+	$(MAKE) DESTDIR=$$(pwd)/testinstall uninstall
 	@if test `find testinstall '!' -type d | wc -l` -ne 0; then \
 		echo 'make uninstall left some files in testinstall directory!'; \
 		exit 1; \

--- a/external/Makefile
+++ b/external/Makefile
@@ -26,22 +26,22 @@ submodcheck-%: FORCE
 
 # We build libsodium, since Ubuntu xenial has one too old.
 external/libsodium.a: external/libsodium/src/libsodium/libsodium.la
-	$(MAKE) -C external/libsodium install-exec
+	$(MAKE) -C external/libsodium DESTDIR=$$(pwd)/external install-exec
 
 external/libsodium/src/libsodium/include/sodium.h: submodcheck-libsodium
 
 external/libsodium/src/libsodium/libsodium.la: external/libsodium/src/libsodium/include/sodium.h
-	cd external/libsodium && ./autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --enable-tests=no --libdir=`pwd`/.. && $(MAKE)
+	cd external/libsodium && ./autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --enable-tests=no --prefix=/ --libdir=/ && $(MAKE)
 
 $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS): submodcheck-libwally-core
 
 # libsecp included in libwally.
 # Wildcards here are magic.  See http://stackoverflow.com/questions/2973445/gnu-makefile-rule-generating-a-few-targets-from-a-single-source-file
 external/libsecp256k1.% external/libwallycore.%: external/libwally-core/src/secp256k1/libsecp256k1.la external/libwally-core/src/libwallycore.la
-	$(MAKE) -C external/libwally-core install-exec
+	$(MAKE) -C external/libwally-core DESTDIR=$$(pwd)/external install-exec
 
 external/libwally-core/src/libwallycore.% external/libwally-core/src/secp256k1/libsecp256k1.%: $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS)
-	cd external/libwally-core && ./tools/autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-module-recovery --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
+	cd external/libwally-core && ./tools/autogen.sh && ./configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-module-recovery --enable-shared=no --prefix=/ --libdir=/ && $(MAKE)
 
 external/jsmn/jsmn.h: submodcheck-jsmn
 
@@ -74,8 +74,8 @@ external/libbacktrace/backtrace.h: submodcheck-libbacktrace
 # Need separate build dir: changes inside submodule make git think it's dirty.
 external/libbacktrace.a: external/libbacktrace/backtrace.h
 	@mkdir external/libbacktrace-build 2>/dev/null || true
-	cd external/libbacktrace-build && ../libbacktrace/configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --libdir=`pwd`/.. && $(MAKE)
-	$(MAKE) -C external/libbacktrace-build install-exec
+	cd external/libbacktrace-build && ../libbacktrace/configure CC="$(CC)" --enable-static=yes --host="$(HOST)" --build="$(BUILD)" --enable-shared=no --prefix=/ --libdir=/ && $(MAKE)
+	$(MAKE) -C external/libbacktrace-build DESTDIR=$$(pwd)/external install-exec
 
 distclean: external-distclean
 clean: external-clean


### PR DESCRIPTION
This is how the error before the fix looked like on Arch Linux with
GNU libtool 2.4.6.40-6ca5-dirty:

    $ make installcheck
    ...
    make[4]: Entering directory '/home/jasan/lightning/external/libwally-core/src/secp256k1'
     /usr/bin/mkdir -p 'testinstall/home/jasan/lightning/external/libwally-core/..'
     /bin/sh ./libtool   --mode=install /usr/bin/install -c   libsecp256k1.la 'testinstall/home/jasan/lightning/external/libwally-core/..'
    Usage: /home/jasan/lightning/external/libwally-core/src/secp256k1/libtool [OPTION]... [MODE-ARG]...
    Try 'libtool --help' for more information.
    libtool:   error: 'testinstall/home/jasan/lightning/external/libwally-core/..' must be an absolute directory name
    make[4]: *** [Makefile:910: install-libLTLIBRARIES] Error 1
    make[4]: Leaving directory '/home/jasan/lightning/external/libwally-core/src/secp256k1'
    make[3]: *** [Makefile:1253: install-exec-recursive] Error 1
    make[3]: Leaving directory '/home/jasan/lightning/external/libwally-core/src'
    make[2]: *** [Makefile:429: install-exec-recursive] Error 1
    make[2]: Leaving directory '/home/jasan/lightning/external/libwally-core'
    make[1]: *** [external/Makefile:41: external/libwallycore.a] Error 2
    rm external/libwally-core/src/secp256k1/libsecp256k1.la
    make[1]: Leaving directory '/home/jasan/lightning'
    make: *** [Makefile:430: installcheck] Error 2

Then there was linking error which needed to be fixed by correcting
the idea of installing external libraries to a particular directory.