### PR TITLE
test_lightningd.py: Enable bech32 test for DEVELOPER

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -2,6 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV BITCOIN_VERSION 0.16.0
 WORKDIR /build
 
 RUN apt-get -qq update && \
@@ -30,10 +31,11 @@ RUN apt-get -qq update && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
-    wget https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-x86_64-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    VER=$BITCOIN_VERSION && \
+    wget https://bitcoin.org/bin/bitcoin-core-$VER/bitcoin-$VER-x86_64-linux-gnu.tar.gz -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
-    mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
-    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
+    mv /tmp/bitcoin-$VER/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-$VER
 
 RUN pip3 install --upgrade pip && \
     pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -2,6 +2,7 @@ FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV BITCOIN_VERSION 0.16.0
 WORKDIR /build
 
 RUN apt-get -qq update && \
@@ -30,10 +31,11 @@ RUN apt-get -qq update && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
-    wget https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-i686-pc-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    VER=$BITCOIN_VERSION && \
+    wget https://bitcoin.org/bin/bitcoin-core-$VER/bitcoin-$VER-i686-pc-linux-gnu.tar.gz -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
-    mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
-    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
+    mv /tmp/bitcoin-$VER/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-$VER
 
 RUN pip3 install --upgrade pip && \
     pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2715,7 +2715,7 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_logs(['sendrawtx exit 0', ' to CLOSINGD_COMPLETE'])
         assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 1
 
-    @unittest.skip("FIXME: needs bitcoind 0.16")
+    @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_bech32_funding(self):
         # Don't get any funds from previous runs.
         l1 = self.node_factory.get_node(random_hsm=True)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -52,9 +52,9 @@ def setupBitcoind(directory):
 
     info = bitcoind.rpc.getblockchaininfo()
     # Make sure we have segwit and some funds
-    if info['blocks'] < 432:
+    if info['blocks'] < 100:
         logging.debug("SegWit not active, generating some more blocks")
-        bitcoind.generate_block(432 - info['blocks'])
+        bitcoind.generate_block(100 - info['blocks'])
     elif bitcoind.rpc.getwalletinfo()['balance'] < 1:
         logging.debug("Insufficient balance, generating 1 block")
         bitcoind.generate_block(1)


### PR DESCRIPTION
Since bitcoind 0.16 is already released it is safe to enable
this test already.