### PR TITLE
Adjust log level for logging disconnected RPC users ("Command failed after jcon close")

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -413,8 +413,8 @@ static void command_fail_v(struct command *cmd,
 	struct json_connection *jcon = cmd->jcon;
 
 	if (!jcon) {
-		log_unusual(cmd->ld->log,
-			    "Command failed after jcon close");
+		log_debug(cmd->ld->log,
+			  "Command failed after jcon close");
 		tal_free(cmd);
 		return;
 	}


### PR DESCRIPTION
Adjust log level for logging disconnected RPC users (`Command failed after jcon close`).

This is a follow-up to #1121.