### PR TITLE
Update CI builder image to use bitcoind 0.16.0 and reduce number of required blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ bitcoind -daemon -testnet
 ```
 
 Wait until `bitcoind` has synchronized with the testnet network.
-In case you use regtest, make sure you generate at least 432 blocks to
-activate SegWit.
 
 Make sure that you do not have `walletbroadcast=0` in your
 `~/.bitcoin/bitcoin.conf`, or you may run into trouble.

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -2,6 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV BITCOIN_VERSION 0.16.0
 WORKDIR /build
 
 RUN apt-get -qq update && \
@@ -30,10 +31,10 @@ RUN apt-get -qq update && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
-    wget https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-x86_64-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
-    mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
-    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
+    mv /tmp/bitcoin-$BITCOIN_VERSION/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
     pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -2,6 +2,7 @@ FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV BITCOIN_VERSION 0.16.0
 WORKDIR /build
 
 RUN apt-get -qq update && \
@@ -30,10 +31,10 @@ RUN apt-get -qq update && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
-    wget https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-i686-pc-linux-gnu.tar.gz -O bitcoin.tar.gz && \
+    wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-i686-pc-linux-gnu.tar.gz -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
-    mv /tmp/bitcoin-0.15.1/bin/bitcoin* /usr/local/bin/ && \
-    rm -rf bitcoin.tar.gz /tmp/bitcoin-0.15.1
+    mv /tmp/bitcoin-$BITCOIN_VERSION/bin/bitcoin* /usr/local/bin/ && \
+    rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
     pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2722,7 +2722,7 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_logs(['sendrawtx exit 0', ' to CLOSINGD_COMPLETE'])
         assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 1
 
-    @unittest.skip("FIXME: needs bitcoind 0.16")
+    @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_bech32_funding(self):
         # Don't get any funds from previous runs.
         l1 = self.node_factory.get_node(random_hsm=True)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -58,10 +58,9 @@ def setupBitcoind(directory):
                          " is needed, current version is {}".format(info['version']))
 
     info = bitcoind.rpc.getblockchaininfo()
-    # Make sure we have segwit and some funds
-    if info['blocks'] < 121:
-        logging.debug("SegWit not active, generating some more blocks")
-        bitcoind.generate_block(121 - info['blocks'])
+    # Make sure we have some spendable funds
+    if info['blocks'] < 101:
+        bitcoind.generate_block(101 - info['blocks'])
     elif bitcoind.rpc.getwalletinfo()['balance'] < 1:
         logging.debug("Insufficient balance, generating 1 block")
         bitcoind.generate_block(1)


### PR DESCRIPTION
Now seems to slightly overlap with #1127. Updates bitcoind to version 0.16.0 and reduces number of blocks pre-generated to 121, instead of 432. 121 are required at least so we have some mature funds.