### PR TITLE
Refuse to forget a channel with HTLCs

### DIFF
--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -199,4 +199,8 @@ void derive_channel_seed(struct lightningd *ld, struct privkey *seed,
 
 void channel_set_billboard(struct channel *channel, bool perm,
 			   const char *str TAKES);
+
+struct htlc_in *channel_has_htlc_in(struct channel *channel);
+struct htlc_out *channel_has_htlc_out(struct channel *channel);
+
 #endif /* LIGHTNING_LIGHTNINGD_CHANNEL_H */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1086,6 +1086,15 @@ static void json_dev_forget_channel(struct command *cmd, const char *buffer,
 		return;
 	}
 
+	if (channel_has_htlc_out(forget->channel) ||
+	    channel_has_htlc_in(forget->channel)) {
+		command_fail(cmd, "This channel has HTLCs attached and it is "
+				  "not safe to forget it. Please use `close` "
+				  "or `dev-fail` instead.");
+		return;
+
+	}
+
 	bitcoind_gettxout(cmd->ld->topology->bitcoind,
 			  &forget->channel->funding_txid,
 			  forget->channel->funding_outnum,


### PR DESCRIPTION
Second take of #987, this time we don't just drop the HTLCs on the floor, we outright refuse to forget the channel. `dev-forget-channel` was not intended as a long term solution and will be abandoned soon, but we should make sure we fail gracefully and don't crash.

Fixes #946 