### PR TITLE
Short channel id cleanup

### DIFF
--- a/bitcoin/short_channel_id.c
+++ b/bitcoin/short_channel_id.c
@@ -3,6 +3,14 @@
 #include <stdio.h>
 #include <string.h>
 
+void mk_short_channel_id(struct short_channel_id *scid,
+			 u32 blocknum, u32 txnum, u16 outnum)
+{
+	scid->u64 = (((u64)blocknum & 0xFFFFFF) << 40 |
+		     ((u64)txnum & 0xFFFFFF) << 16 |
+		     (outnum & 0xFFFF));
+}
+
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst)
 {
@@ -15,26 +23,14 @@ bool short_channel_id_from_str(const char *str, size_t strlen,
 	buf[strlen] = 0;
 
 	matches = sscanf(buf, "%u:%u:%hu", &blocknum, &txnum, &outnum);
-	dst->blocknum = blocknum;
-	dst->txnum = txnum;
-	dst->outnum = outnum;
+	mk_short_channel_id(dst, blocknum, txnum, outnum);
 	return matches == 3;
 }
 
 char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid)
 {
-	return tal_fmt(ctx, "%d:%d:%d", scid->blocknum, scid->txnum, scid->outnum);
-}
-
-bool short_channel_id_eq(const struct short_channel_id *a,
-			 const struct short_channel_id *b)
-{
-	return a->blocknum == b->blocknum && a->txnum == b->txnum &&
-	       a->outnum == b->outnum;
-}
-
-u64 short_channel_id_to_uint(const struct short_channel_id *scid)
-{
-	return ((u64)scid->blocknum & 0xFFFFFF) << 40 |
-	       ((u64)scid->txnum & 0xFFFFFF) << 16 | (scid->outnum & 0xFFFF);
+	return tal_fmt(ctx, "%d:%d:%d",
+		       short_channel_id_blocknum(scid),
+		       short_channel_id_txnum(scid),
+		       short_channel_id_outnum(scid));
 }

--- a/bitcoin/short_channel_id.h
+++ b/bitcoin/short_channel_id.h
@@ -36,12 +36,6 @@ void mk_short_channel_id(struct short_channel_id *scid,
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst);
 
-static inline bool short_channel_id_eq(const struct short_channel_id *a,
-				       const struct short_channel_id *b)
-{
-	return a->u64 == b->u64;
-}
-
 /* Fast, platform dependent, way to convert from a short_channel_id to u64 */
 static inline u64 short_channel_id_to_uint(const struct short_channel_id *scid)
 {

--- a/bitcoin/short_channel_id.h
+++ b/bitcoin/short_channel_id.h
@@ -36,12 +36,6 @@ void mk_short_channel_id(struct short_channel_id *scid,
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst);
 
-/* Fast, platform dependent, way to convert from a short_channel_id to u64 */
-static inline u64 short_channel_id_to_uint(const struct short_channel_id *scid)
-{
-	return scid->u64;
-}
-
 char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid);
 
 #endif /* LIGHTNING_BITCOIN_SHORT_CHANNEL_ID_H */

--- a/bitcoin/short_channel_id.h
+++ b/bitcoin/short_channel_id.h
@@ -12,20 +12,42 @@
  * just memset them and not have to take care about the extra byte for
  * u32 */
 struct short_channel_id {
-	u32 blocknum : 24;
-	u32 txnum : 24;
-	u16 outnum;
+	u64 u64;
 };
+
+static inline u32 short_channel_id_blocknum(const struct short_channel_id *scid)
+{
+	return scid->u64 >> 40;
+}
+
+static inline u32 short_channel_id_txnum(const struct short_channel_id *scid)
+{
+	return (scid->u64 >> 16) & 0x00FFFFFF;
+}
+
+static inline u16 short_channel_id_outnum(const struct short_channel_id *scid)
+{
+	return scid->u64 & 0xFFFF;
+}
+
+void mk_short_channel_id(struct short_channel_id *scid,
+			 u32 blocknum, u32 txnum, u16 outnum);
 
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst);
 
-bool short_channel_id_eq(const struct short_channel_id *a,
-			 const struct short_channel_id *b);
-
-char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid);
+static inline bool short_channel_id_eq(const struct short_channel_id *a,
+				       const struct short_channel_id *b)
+{
+	return a->u64 == b->u64;
+}
 
 /* Fast, platform dependent, way to convert from a short_channel_id to u64 */
-u64 short_channel_id_to_uint(const struct short_channel_id *scid);
+static inline u64 short_channel_id_to_uint(const struct short_channel_id *scid)
+{
+	return scid->u64;
+}
+
+char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid);
 
 #endif /* LIGHTNING_BITCOIN_SHORT_CHANNEL_ID_H */

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -533,8 +533,8 @@ static void check_short_ids_match(struct peer *peer)
 	assert(peer->have_sigs[LOCAL]);
 	assert(peer->have_sigs[REMOTE]);
 
-	if (!short_channel_id_eq(&peer->short_channel_ids[LOCAL],
-				 &peer->short_channel_ids[REMOTE]))
+	if (!structeq(&peer->short_channel_ids[LOCAL],
+		      &peer->short_channel_ids[REMOTE]))
 		peer_failed(&peer->cs, peer->gossip_index,
 			    &peer->channel_id,
 			    "We disagree on short_channel_ids:"

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -733,8 +733,7 @@ static void handle_get_update(struct peer *peer, const u8 *msg)
 	}
 
 	for (i = 0; i < tal_count(us->out); i++) {
-		if (!short_channel_id_eq(&us->out[i]->short_channel_id,
-					 &schanid))
+		if (!structeq(&us->out[i]->short_channel_id, &schanid))
 			continue;
 
 		update = us->out[i]->channel_update;
@@ -1093,8 +1092,7 @@ static struct io_plan *getchannels_req(struct io_conn *conn, struct daemon *daem
 	while (n != NULL) {
 		for (j=0; j<tal_count(n->out); j++){
 			if (scid &&
-			    !short_channel_id_eq(scid,
-						 &n->out[j]->short_channel_id)) {
+			    !structeq(scid, &n->out[j]->short_channel_id)) {
 				continue;
 			}
 			tal_resize(&entries, num_chans + 1);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -785,7 +785,7 @@ static void handle_local_add_channel(struct peer *peer, u8 *msg)
 
 	chan = routing_channel_new(rstate, &scid);
 	chan->public = false;
-	uintmap_add(&rstate->channels, short_channel_id_to_uint(&scid), chan);
+	uintmap_add(&rstate->channels, scid.u64, chan);
 
 	chan->pending = NULL;
 	direction = get_channel_direction(&rstate->local_id, &remote_node_id);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -338,8 +338,9 @@ static void bfg_one_edge(struct node *node, size_t edgenum, double riskfactor,
 	double fee_scale = 1.0;
 
 	if (fuzz != 0.0) {
-		u64 scid = short_channel_id_to_uint(&c->short_channel_id);
-		u64 h =	siphash24(base_seed, &scid, sizeof(scid));
+		u64 h =	siphash24(base_seed,
+				  &c->short_channel_id,
+				  sizeof(c->short_channel_id));
 
 		/* Scale fees for this channel */
 		/* rand = (h / UINT64_MAX)  random number between 0.0 -> 1.0
@@ -651,7 +652,6 @@ const struct short_channel_id *handle_channel_announcement(
 	u8 *features;
 	secp256k1_ecdsa_signature node_signature_1, node_signature_2;
 	secp256k1_ecdsa_signature bitcoin_signature_1, bitcoin_signature_2;
-	u64 scid;
 	struct routing_channel *chan;
 
 	pending = tal(rstate, struct pending_cannouncement);
@@ -676,8 +676,6 @@ const struct short_channel_id *handle_channel_announcement(
 		tal_free(pending);
 		return NULL;
 	}
-
-	scid = short_channel_id_to_uint(&pending->short_channel_id);
 
 	/* Check if we know the channel already (no matter in what
 	 * state, we stop here if yes). */
@@ -743,7 +741,7 @@ const struct short_channel_id *handle_channel_announcement(
 
 	/* The channel will be public if we complete the verification */
 	chan->public = true;
-	uintmap_add(&rstate->channels, scid, chan);
+	uintmap_add(&rstate->channels, pending->short_channel_id.u64, chan);
 
 	/* Add both endpoints to the pending_node_map so we can stash
 	 * node_announcements while we wait for the txout check */

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1194,7 +1194,7 @@ get_out_node_connection_of(const struct node *node,
 	int i;
 
 	for (i = 0; i < tal_count(node->out); ++i) {
-		if (short_channel_id_eq(&node->out[i]->short_channel_id, short_channel_id))
+		if (structeq(&node->out[i]->short_channel_id, short_channel_id))
 			return node->out[i];
 	}
 

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -124,6 +124,13 @@ struct routing_state {
 	UINTMAP(struct routing_channel*) channels;
 };
 
+static inline struct routing_channel *
+get_channel(const struct routing_state *rstate,
+	    const struct short_channel_id *scid)
+{
+	return uintmap_get(&rstate->channels, short_channel_id_to_uint(scid));
+}
+
 struct route_hop {
 	struct short_channel_id channel_id;
 	struct pubkey nodeid;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -128,7 +128,7 @@ static inline struct routing_channel *
 get_channel(const struct routing_state *rstate,
 	    const struct short_channel_id *scid)
 {
-	return uintmap_get(&rstate->channels, short_channel_id_to_uint(scid));
+	return uintmap_get(&rstate->channels, scid->u64);
 }
 
 struct route_hop {

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -89,7 +89,9 @@ static void get_txout(struct subd *gossip, const u8 *msg)
 	/* FIXME: Block less than 6 deep? */
 
 	bitcoind_getoutput(gossip->ld->topology->bitcoind,
-			   scid->blocknum, scid->txnum, scid->outnum,
+			   short_channel_id_blocknum(scid),
+			   short_channel_id_txnum(scid),
+			   short_channel_id_outnum(scid),
 			   got_txout, scid);
 }
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -256,7 +256,7 @@ remote_routing_failure(const tal_t *ctx,
 	const struct pubkey *erring_node;
 	const struct short_channel_id *route_channels;
 	const struct short_channel_id *erring_channel;
-	static const struct short_channel_id dummy_channel = { 0, 0, 0 };
+	static const struct short_channel_id dummy_channel = { 0 };
 	int origin_index;
 	bool retry_plausible;
 	bool report_to_gossipd;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1069,7 +1069,7 @@ static void json_dev_forget_channel(struct command *cmd, const char *buffer,
 		if (scidtok) {
 			if (!channel->scid)
 				continue;
-			if (!short_channel_id_eq(channel->scid, &scid))
+			if (!structeq(channel->scid, &scid))
 				continue;
 		}
 		if (forget->channel) {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -521,9 +521,9 @@ static enum watch_result funding_lockin_cb(struct channel *channel,
 	/* If we restart, we could already have peer->scid from database */
 	if (!channel->scid) {
 		channel->scid = tal(channel, struct short_channel_id);
-		channel->scid->blocknum = loc->blkheight;
-		channel->scid->txnum = loc->index;
-		channel->scid->outnum = channel->funding_outnum;
+		mk_short_channel_id(channel->scid,
+				    loc->blkheight, loc->index,
+				    channel->funding_outnum);
 	}
 	tal_free(loc);
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -607,7 +607,7 @@ static bool channelseq(struct channel *c1, struct channel *c2)
 	CHECK(c1->peer == c2->peer);
 	CHECK(c1->their_shachain.id == c2->their_shachain.id);
 	CHECK_MSG(pubkey_eq(&p1->id, &p2->id), "NodeIDs do not match");
-	CHECK((c1->scid == NULL && c2->scid == NULL) || short_channel_id_eq(c1->scid, c2->scid));
+	CHECK((c1->scid == NULL && c2->scid == NULL) || structeq(c1->scid, c2->scid));
 	CHECK(c1->our_msatoshi == c2->our_msatoshi);
 	CHECK((c1->remote_shutdown_scriptpubkey == NULL && c2->remote_shutdown_scriptpubkey == NULL) || memeq(
 		      c1->remote_shutdown_scriptpubkey,

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -158,15 +158,7 @@ void fromwire_channel_id(const u8 **cursor, size_t *max,
 void fromwire_short_channel_id(const u8 **cursor, size_t *max,
 			       struct short_channel_id *short_channel_id)
 {
-	be32 txnum = 0, blocknum = 0;
-
-	/* Pulling 3 bytes off wire is tricky; they're big-endian. */
-	fromwire(cursor, max, (char *)&blocknum + 1, 3);
-	short_channel_id->blocknum = be32_to_cpu(blocknum);
-	fromwire(cursor, max, (char *)&txnum + 1, 3);
-	short_channel_id->txnum = be32_to_cpu(txnum);
-
-	short_channel_id->outnum = fromwire_u16 (cursor, max);
+	short_channel_id->u64 = fromwire_u64(cursor, max);
 }
 
 void fromwire_sha256(const u8 **cursor, size_t *max, struct sha256 *sha256)

--- a/wire/test/run-peer-wire.c
+++ b/wire/test/run-peer-wire.c
@@ -704,7 +704,7 @@ static bool channel_announcement_eq(const struct msg_channel_announcement *a,
 	return eq_upto(a, b, features)
 		&& eq_var(a, b, features)
 		&& eq_field(a, b, chain_hash)
-		&& short_channel_id_eq(&a->short_channel_id, &b->short_channel_id)
+		&& structeq(&a->short_channel_id, &b->short_channel_id)
 		&& eq_between(a, b, node_id_1, bitcoin_key_2);
 }
 
@@ -718,7 +718,7 @@ static bool announcement_signatures_eq(const struct msg_announcement_signatures 
 			      const struct msg_announcement_signatures *b)
 {
 	return eq_upto(a, b, short_channel_id) &&
-		short_channel_id_eq(&a->short_channel_id, &b->short_channel_id);
+		structeq(&a->short_channel_id, &b->short_channel_id);
 }
 
 static bool update_fail_htlc_eq(const struct msg_update_fail_htlc *a,
@@ -804,7 +804,7 @@ static bool channel_update_eq(const struct msg_channel_update *a,
 			      const struct msg_channel_update *b)
 {
 	return eq_upto(a, b, short_channel_id) &&
-		short_channel_id_eq(&a->short_channel_id, &b->short_channel_id);
+		structeq(&a->short_channel_id, &b->short_channel_id);
 }
 
 static bool accept_channel_eq(const struct msg_accept_channel *a,

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -105,12 +105,7 @@ void towire_channel_id(u8 **pptr, const struct channel_id *channel_id)
 void towire_short_channel_id(u8 **pptr,
 			     const struct short_channel_id *short_channel_id)
 {
-	be32 txnum = cpu_to_be32(short_channel_id->txnum);
-	be32 blocknum = cpu_to_be32(short_channel_id->blocknum);
-
-	towire(pptr, (char *)&blocknum + 1, 3);
-	towire(pptr, (char *)&txnum + 1, 3);
-	towire_u16(pptr, short_channel_id->outnum);
+	towire_u64(pptr, short_channel_id->u64);
 }
 
 void towire_sha256(u8 **pptr, const struct sha256 *sha256)


### PR DESCRIPTION
Turns out bitfields were a mistake.  I knew this, but I've learned it again.