### PR TITLE
Add assertions in various places to ensure tal_fmt doesn't receive NULL as argument for strings.

### DIFF
--- a/common/type_to_string.c
+++ b/common/type_to_string.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <bitcoin/preimage.h>
 #include <ccan/crypto/ripemd160/ripemd160.h>
 #include <ccan/crypto/sha256/sha256.h>
@@ -5,7 +6,6 @@
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <inttypes.h>
-#include <assert.h>
 
 /* We need at least one, and these are in CCAN so register it here. */
 REGISTER_TYPE_TO_HEXSTR(sha256);

--- a/common/type_to_string.c
+++ b/common/type_to_string.c
@@ -5,6 +5,7 @@
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <inttypes.h>
+#include <assert.h>
 
 /* We need at least one, and these are in CCAN so register it here. */
 REGISTER_TYPE_TO_HEXSTR(sha256);
@@ -19,6 +20,8 @@ char *type_to_string_(const tal_t *ctx,  const char *typename,
 	size_t i;
 	static size_t num_p;
 	static struct type_to_string **t = NULL;
+
+	assert(typename != NULL);
 
 	if (!t)
 		t = autodata_get(type_to_string, &num_p);

--- a/common/utils.c
+++ b/common/utils.c
@@ -53,6 +53,9 @@ const char *tmpctx_any(void)
 	struct tmpctx *t = list_top(&tmpctxs, struct tmpctx, list);
 
 	if (t)
+	{
+		assert(t->file != NULL);
 		return tal_fmt(t, "%s:%u", t->file, t->line);
+	}
 	return NULL;
 }

--- a/common/utils.c
+++ b/common/utils.c
@@ -52,8 +52,7 @@ const char *tmpctx_any(void)
 {
 	struct tmpctx *t = list_top(&tmpctxs, struct tmpctx, list);
 
-	if (t)
-	{
+	if (t) {
 		assert(t->file != NULL);
 		return tal_fmt(t, "%s:%u", t->file, t->line);
 	}

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -264,6 +264,7 @@ static void connection_complete_ok(struct json_connection *jcon,
 				   const struct json_result *result)
 {
 	assert(id != NULL);
+	assert(result != NULL);
 
 	/* This JSON is simple enough that we build manually */
 	json_done(jcon, cmd, take(tal_fmt(jcon,

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -73,6 +73,8 @@ static int json_add_syminfo(void *data, uintptr_t pc UNUSED,
 	struct json_result *response = data;
 	char *str;
 
+	assert(filename != NULL);
+	assert(function != NULL);
 	str = tal_fmt(response, "%s:%u (%s)", filename, lineno, function);
 	json_add_string(response, NULL, str);
 	tal_free(str);

--- a/lightningd/opt_time.c
+++ b/lightningd/opt_time.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <assert.h>
 
 static bool match(const char *str, const char *abbrev, const char *full)
 {
@@ -25,6 +26,8 @@ char *opt_set_time(const char *arg, struct timerel *t)
 {
 	char *endp;
 	unsigned long int l;
+
+	assert(arg != NULL);
 
 	/* This is how the manpage says to do it.  Yech. */
 	errno = 0;
@@ -81,6 +84,8 @@ void opt_show_time(char buf[OPT_SHOW_LEN], const struct timerel *t)
 char *opt_set_timeabs(const char *arg, struct timeabs *t)
 {
 	long double d;
+
+	assert(arg != NULL);
 
 	if (sscanf(arg, "%Lf", &d) != 1)
 		return tal_fmt(NULL, "'%s' is not a time", arg);

--- a/lightningd/opt_time.c
+++ b/lightningd/opt_time.c
@@ -1,10 +1,10 @@
 #include "opt_time.h"
+#include <assert.h>
 #include <ccan/str/str.h>
 #include <ccan/tal/str/str.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include <assert.h>
 
 static bool match(const char *str, const char *abbrev, const char *full)
 {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -71,6 +71,8 @@ static char *opt_set_u32(const char *arg, u32 *u)
 	char *endp;
 	unsigned long l;
 
+	assert(arg != NULL);
+
 	/* This is how the manpage says to do it.  Yech. */
 	errno = 0;
 	l = strtoul(arg, &endp, 0);
@@ -86,6 +88,8 @@ static char *opt_set_u16(const char *arg, u16 *u)
 {
 	char *endp;
 	unsigned long l;
+
+	assert(arg != NULL);
 
 	/* This is how the manpage says to do it.  Yech. */
 	errno = 0;
@@ -103,6 +107,8 @@ static char *opt_set_s32(const char *arg, s32 *u)
 	char *endp;
 	long l;
 
+	assert(arg != NULL);
+
 	/* This is how the manpage says to do it.  Yech. */
 	errno = 0;
 	l = strtol(arg, &endp, 0);
@@ -118,6 +124,8 @@ static char *opt_add_ipaddr(const char *arg, struct lightningd *ld)
 {
 	size_t n = tal_count(ld->wireaddrs);
 	char const *err_msg;
+
+	assert(arg != NULL);
 
 	tal_resize(&ld->wireaddrs, n+1);
 
@@ -146,6 +154,8 @@ static void opt_show_u16(char buf[OPT_SHOW_LEN], const u16 *u)
 
 static char *opt_set_network(const char *arg, struct lightningd *ld)
 {
+	assert(arg != NULL);
+
 	ld->topology->bitcoind->chainparams = chainparams_for_network(arg);
 	if (!ld->topology->bitcoind->chainparams)
 		return tal_fmt(NULL, "Unknown network name '%s'", arg);
@@ -160,6 +170,8 @@ static void opt_show_network(char buf[OPT_SHOW_LEN],
 
 static char *opt_set_rgb(const char *arg, struct lightningd *ld)
 {
+	assert(arg != NULL);
+
 	ld->rgb = tal_free(ld->rgb);
 	/* BOLT #7:
 	 *
@@ -173,6 +185,8 @@ static char *opt_set_rgb(const char *arg, struct lightningd *ld)
 
 static char *opt_set_alias(const char *arg, struct lightningd *ld)
 {
+	assert(arg != NULL);
+
 	ld->alias = tal_free(ld->alias);
 	/* BOLT #7:
 	 *
@@ -298,6 +312,8 @@ static void config_register_opts(struct lightningd *ld)
 #if DEVELOPER
 static char *opt_set_hsm_seed(const char *arg, struct lightningd *ld)
 {
+	assert(arg != NULL);
+
 	ld->dev_hsm_seed = tal_hexdata(ld, arg, strlen(arg));
 	if (ld->dev_hsm_seed)
 		return NULL;
@@ -479,6 +495,7 @@ static void config_log_stderr_exit(const char *fmt, ...)
 		const char *arg = va_arg(ap, const char *);
 		const char *problem = va_arg(ap, const char *);
 
+		assert(arg != NULL);
 		msg = tal_fmt(NULL, "%s line %s: %.*s: %s",
 			      argv0, arg+strlen(arg)+1, len-2, arg+2, problem);
 	} else {

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -672,6 +672,7 @@ static void json_sendpay_on_resolve(const struct sendpay_result *r,
 				     r->onionreply, tal_len(r->onionreply));
 			json_object_end(data);
 
+			assert(r->details != NULL);
 			msg = tal_fmt(cmd,
 				      "failed: WIRE_PERMANENT_NODE_FAILURE "
 				      "(%s)",
@@ -700,6 +701,7 @@ static void json_sendpay_on_resolve(const struct sendpay_result *r,
 					     tal_len(fail->channel_update));
 			json_object_end(data);
 
+			assert(r->details != NULL);
 			msg = tal_fmt(cmd,
 				      "failed: %s (%s)",
 				      onion_type_name(fail->failcode),

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -105,6 +105,7 @@ static void json_pay_failure(struct pay *pay,
 				     tal_len(fail->channel_update));
 		json_object_end(data);
 
+		assert(r->details != NULL);
 		msg = tal_fmt(pay,
 			      "failed: %s (%s)",
 			      onion_type_name(fail->failcode),

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -805,6 +805,7 @@ void onchain_failed_our_htlc(const struct channel *channel,
 	hout->failcode = WIRE_PERMANENT_CHANNEL_FAILURE;
 
 	if (!hout->in) {
+		assert(why != NULL);
 		char *localfail = tal_fmt(channel, "%s: %s",
 					  onion_type_name(WIRE_PERMANENT_CHANNEL_FAILURE),
 					  why);

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -659,6 +659,8 @@ static struct subd *new_subd(struct lightningd *ld,
 	const char *debug_subd = NULL;
 	int disconnect_fd = -1;
 
+	assert(name != NULL);
+
 #if DEVELOPER
 	debug_subd = ld->dev_debug_subdaemon;
 	disconnect_fd = ld->dev_disconnect_fd;

--- a/test/test_state_coverage.c
+++ b/test/test_state_coverage.c
@@ -489,6 +489,7 @@ static unsigned int htlc_id_from_pkt(const Pkt *pkt)
 static Pkt *htlc_pkt(const tal_t *ctx, const char *prefix, unsigned int id)
 {
 	assert(id != -1);
+	assert(prefix != NULL);
 	return (Pkt *)tal_fmt(ctx, "%s: HTLC #%u", prefix, id);
 }
 
@@ -501,6 +502,7 @@ static unsigned int htlc_id_from_tx(const struct bitcoin_tx *tx)
 static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 				  const char *prefix, unsigned int id)
 {
+	assert(prefix != NULL);
 	return (struct bitcoin_tx *)tal_fmt(ctx, "%s HTLC #%u", prefix, id);
 }
 


### PR DESCRIPTION
Also: since I didn't understand the tal_fmt occurrence in config_log_stderr_exit at first, I felt the need to rework the code quite a bit to make it easier to understand. It's still a bit of a hack - the only way to make it really clean is to either extend the opt library, or use something else.

I don't guarantee that this correctly covers all occurrences of tal_fmt. Such a guarantee wouldn't be very valuable anyway, since the code still changes a lot.
