### PR TITLE
bitcoin.bib: Add Satoshi paper URL and date to bib file

### DIFF
--- a/doc/bitcoin.bib
+++ b/doc/bitcoin.bib
@@ -16,7 +16,9 @@
 @misc{nakamoto2008bitcoin,
 	title={{Bitcoin: A peer-to-peer electronic cash system}},
 	author={Nakamoto, Satoshi},
-	year={2008}
+	note = {\url{https://bitcoin.org/bitcoin.pdf}},
+	year={2008},
+	urldate ={2008-10-31}
 }
 @misc{BitcoinChannels,
 	title =	{{Instant TX for established business relationships (need replacements/nLockTime)}},


### PR DESCRIPTION
Date according to Wikipedia which cites other source.