### PR TITLE
revert 0e40c8 and re-enable test_withdraw

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2753,7 +2753,6 @@ class LightningDTests(BaseLightningDTests):
         # Don't get any funds from previous runs.
         l1 = self.node_factory.get_node(random_hsm=True)
         l2 = self.node_factory.get_node(random_hsm=True)
-        l3 = self.node_factory.get_node(random_hsm=True)
         addr = l1.rpc.newaddr()['address']
 
         # Add some funds to withdraw later
@@ -2770,24 +2769,20 @@ class LightningDTests(BaseLightningDTests):
         c.execute('SELECT COUNT(*) FROM outputs WHERE status=0')
         assert(c.fetchone()[0] == 10)
 
-        # Renable when the bitcoin wallet can generate a "bcrt1" address
-        # waddr = l1.bitcoin.rpc.getnewaddress()
-        # Instead for now, Use an address from l3
-        waddr = l3.rpc.newaddr('bech32')['address']
+        waddr = l1.bitcoin.rpc.getnewaddress()
         # Now attempt to withdraw some (making sure we collect multiple inputs)
         self.assertRaises(ValueError, l1.rpc.withdraw, 'not an address', amount)
         self.assertRaises(ValueError, l1.rpc.withdraw, waddr, 'not an amount')
         self.assertRaises(ValueError, l1.rpc.withdraw, waddr, -amount)
 
-        l1.rpc.withdraw(waddr, 2 * amount)
+        out = l1.rpc.withdraw(waddr, 2 * amount)
 
         # Make sure bitcoind received the withdrawal
-        # Skip these checks because the withdrawal was made to a lightning wallet
-        # Renable when the bitcoin wallet can generate a "bcrt1" address
-        # unspent = l1.bitcoin.rpc.listunspent(0)
-        # withdrawal = [u for u in unspent if u['txid'] == out['txid']]
-        # assert(len(withdrawal) == 1)
-        # assert(withdrawal[0]['amount'] == Decimal('0.02'))
+        unspent = l1.bitcoin.rpc.listunspent(0)
+        withdrawal = [u for u in unspent if u['txid'] == out['txid']]
+        assert(len(withdrawal) == 1)
+
+        assert(withdrawal[0]['amount'] == Decimal('0.02'))
 
         # Now make sure two of them were marked as spent
         c = db.cursor()


### PR DESCRIPTION
I initially disabled this until 0.16 because the withdraw command
was modified to require 'brct1' addresses for regtest.
But commit bd07a9 allows a regular testnet address to work
just as well. So renable this check.