### PR TITLE
pylightning: label is required for waitinvoice()

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -193,7 +193,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("waitanyinvoice", payload)
 
-    def waitinvoice(self, label=None):
+    def waitinvoice(self, label):
         """
         Wait for an incoming payment matching the invoice with {label}
         """


### PR DESCRIPTION
This patch make sure label don't have default value.

Signed-off-by: Douglas Schilling Landgraf <dougsland@gmail.com>