### PR TITLE
pay/sendpay: Use spec names for rhash and r.

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -254,13 +254,13 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("getinfo")
 
-    def sendpay(self, route, rhash):
+    def sendpay(self, route, payment_hash):
         """
-        Send along {route} in return for preimage of {rhash}
+        Send along {route} in return for preimage of {payment_hash}
         """
         payload = {
             "route": route,
-            "rhash": rhash
+            "payment_hash": payment_hash
         }
         return self.call("sendpay", payload)
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -640,7 +640,7 @@ json_sendpay_success(struct command *cmd,
 
 	response = new_json_result(cmd);
 	json_object_start(response, NULL);
-	json_add_hex(response, "preimage",
+	json_add_hex(response, "payment_preimage",
 		     payment_preimage, sizeof(*payment_preimage));
 	json_object_end(response);
 	command_success(cmd, response);
@@ -724,7 +724,7 @@ static void json_sendpay(struct command *cmd,
 
 	if (!json_get_params(cmd, buffer, params,
 			     "route", &routetok,
-			     "rhash", &rhashtok,
+			     "payment_hash", &rhashtok,
 			     NULL)) {
 		return;
 	}
@@ -807,7 +807,7 @@ static void json_sendpay(struct command *cmd,
 static const struct json_command sendpay_command = {
 	"sendpay",
 	json_sendpay,
-	"Send along {route} in return for preimage of {rhash}"
+	"Send along {route} in return for preimage of {payment_hash}"
 };
 AUTODATA(json_command, &sendpay_command);
 

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -52,7 +52,7 @@ json_pay_success(struct command *cmd,
 
 	response = new_json_result(cmd);
 	json_object_start(response, NULL);
-	json_add_hex(response, "preimage",
+	json_add_hex(response, "payment_preimage",
 		     payment_preimage, sizeof(*payment_preimage));
 	json_add_num(response, "getroute_tries", getroute_tries);
 	json_add_num(response, "sendpay_tries", sendpay_tries);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -838,14 +838,14 @@ class LightningDTests(BaseLightningDTests):
         assert len(payments) == 1
 
         assert payments[0]['status'] == 'complete'
-        assert payments[0]['payment_preimage'] == preimage2['preimage']
+        assert payments[0]['payment_preimage'] == preimage2['payment_preimage']
 
         invoice3 = l2.rpc.listinvoices('testpayment3')['invoices'][0]
         payments = l1.rpc.listpayments(payment_hash=invoice3['payment_hash'])['payments']
         assert len(payments) == 1
 
         assert payments[0]['status'] == 'complete'
-        assert payments[0]['payment_preimage'] == preimage3['preimage']
+        assert payments[0]['payment_preimage'] == preimage3['payment_preimage']
 
     def test_sendpay_cant_afford(self):
         l1, l2 = self.connect()
@@ -938,7 +938,7 @@ class LightningDTests(BaseLightningDTests):
 
         # Test listpayments indexed by bolt11.
         assert len(l1.rpc.listpayments(inv)['payments']) == 1
-        assert l1.rpc.listpayments(inv)['payments'][0]['payment_preimage'] == preimage['preimage']
+        assert l1.rpc.listpayments(inv)['payments'][0]['payment_preimage'] == preimage['payment_preimage']
 
     def test_pay_optional_args(self):
         l1, l2 = self.connect()
@@ -3111,7 +3111,7 @@ class LightningDTests(BaseLightningDTests):
         self.wait_for_routes(l1, [chanid])
 
         # A duplicate should succeed immediately (nop) and return correct preimage.
-        preimage = l1.rpc.pay(inv1['bolt11'])['preimage']
+        preimage = l1.rpc.pay(inv1['bolt11'])['payment_preimage']
         assert l1.rpc.dev_rhash(preimage)['rhash'] == inv1['payment_hash']
 
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")


### PR DESCRIPTION
Part of #1088 