### PR TITLE
Routing cleanup finished

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -211,7 +211,6 @@ static void init_node_connection(struct routing_state *rstate,
 
 	c->src = from;
 	c->dst = to;
-	c->short_channel_id = chan->scid;
 	c->channel_update = NULL;
 	c->unroutable_until = 0;
 	c->active = false;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -31,10 +31,6 @@ struct node_connection {
 	/* Minimum number of msatoshi in an HTLC */
 	u32 htlc_minimum_msat;
 
-	/* The channel ID, as determined by the anchor transaction */
-	/* FIXME: Remove */
-	struct short_channel_id short_channel_id;
-
 	/* Flags as specified by the `channel_update`s, among other
 	 * things indicated direction wrt the `channel_id` */
 	u16 flags;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -66,7 +66,7 @@ struct node {
 		/* Total risk premium of this route. */
 		u64 risk;
 		/* Where that came from. */
-		struct node_connection *prev;
+		struct routing_channel *prev;
 	} bfg[ROUTING_MAX_HOPS+1];
 
 	/* UTF-8 encoded alias as tal_arr, not zero terminated */
@@ -118,6 +118,14 @@ static inline int pubkey_idx(const struct pubkey *id1, const struct pubkey *id2)
 	return pubkey_cmp(id1, id2) > 0;
 }
 
+static inline struct node *other_node(const struct node *n,
+				      struct routing_channel *chan)
+{
+	int idx = (chan->nodes[1] == n);
+
+	return chan->nodes[!idx];
+}
+
 /* FIXME: We could avoid these by having two channels arrays */
 static inline struct node_connection *connection_from(const struct node *n,
 						      struct routing_channel *chan)
@@ -129,14 +137,14 @@ static inline struct node_connection *connection_from(const struct node *n,
 	return &chan->connections[idx];
 }
 
-static inline struct node_connection *connection_to(const struct node *n,
-						    struct routing_channel *chan)
+static inline int connection_to(const struct node *n,
+				struct routing_channel *chan)
 {
 	int idx = (chan->nodes[1] == n);
 
 	assert(chan->connections[idx].src == n);
 	assert(chan->connections[!idx].dst == n);
-	return &chan->connections[!idx];
+	return !idx;
 }
 
 struct routing_state {

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -218,14 +218,14 @@ int main(int argc, char *argv[])
 		struct pubkey from = nodeid(pseudorand(num_nodes));
 		struct pubkey to = nodeid(pseudorand(num_nodes));
 		u64 fee;
-		struct routing_channel **route = NULL, *chan;
+		struct routing_channel **route;
 
-		chan = find_route(ctx, rstate, &from, &to,
+		route = find_route(ctx, rstate, &from, &to,
 				  pseudorand(100000),
 				  riskfactor,
 				  0.75, &base_seed,
-				  &fee, &route);
-		num_success += (chan != NULL);
+				  &fee);
+		num_success += (route != NULL);
 		tal_free(route);
 	}
 	end = time_mono();

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -102,22 +102,22 @@ void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 const void *trc;
 
 /* Updates existing route if required. */
-static struct node_connection *add_connection(struct routing_state *rstate,
-					      const struct pubkey *from,
-					      const struct pubkey *to,
-					      u32 base_fee, s32 proportional_fee,
-					      u32 delay)
+static struct half_chan *add_connection(struct routing_state *rstate,
+					const struct pubkey *from,
+					const struct pubkey *to,
+					u32 base_fee, s32 proportional_fee,
+					u32 delay)
 {
 	struct short_channel_id scid;
-	struct node_connection *c;
-	struct routing_channel *chan;
+	struct half_chan *c;
+	struct chan *chan;
 
 	memset(&scid, 0, sizeof(scid));
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_routing_channel(rstate, &scid, from, to);
+		chan = new_chan(rstate, &scid, from, to);
 
-	c = &chan->connections[pubkey_idx(from, to)];
+	c = &chan->half[pubkey_idx(from, to)];
 	c->base_fee = base_fee;
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
 		struct pubkey from = nodeid(pseudorand(num_nodes));
 		struct pubkey to = nodeid(pseudorand(num_nodes));
 		u64 fee;
-		struct routing_channel **route;
+		struct chan **route;
 
 		route = find_route(ctx, rstate, &from, &to,
 				  pseudorand(100000),

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -122,7 +122,6 @@ static struct node_connection *add_connection(struct routing_state *rstate,
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
 	c->active = true;
-	c->short_channel_id = scid;
 	c->flags = get_channel_direction(from, to);
 	return c;
 }

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -218,14 +218,14 @@ int main(int argc, char *argv[])
 		struct pubkey from = nodeid(pseudorand(num_nodes));
 		struct pubkey to = nodeid(pseudorand(num_nodes));
 		u64 fee;
-		struct node_connection **route = NULL, *nc;
+		struct routing_channel **route = NULL, *chan;
 
-		nc = find_route(ctx, rstate, &from, &to,
-				pseudorand(100000),
-				riskfactor,
-				0.75, &base_seed,
-				&fee, &route);
-		num_success += (nc != NULL);
+		chan = find_route(ctx, rstate, &from, &to,
+				  pseudorand(100000),
+				  riskfactor,
+				  0.75, &base_seed,
+				  &fee, &route);
+		num_success += (chan != NULL);
 		tal_free(route);
 	}
 	end = time_mono();

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -94,7 +94,8 @@ int main(void)
 	struct routing_state *rstate;
 	struct pubkey a, b, c;
 	u64 fee;
-	struct node_connection **route;
+	struct routing_channel **route;
+	struct routing_channel *first;
 	const double riskfactor = 1.0 / BLOCKS_PER_YEAR / 10000;
 
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
@@ -148,11 +149,17 @@ int main(void)
 	nc->flags = 1;
 	nc->last_timestamp = 1504064344;
 
-	nc = find_route(ctx, rstate, &a, &c, 100000, riskfactor, 0.0, NULL, &fee, &route);
-	assert(nc);
+	first = find_route(ctx, rstate, &a, &c, 100000, riskfactor, 0.0, NULL, &fee, &route);
+	assert(first);
 	assert(tal_count(route) == 1);
-	assert(pubkey_eq(&route[0]->src->id, &b));
-	assert(pubkey_eq(&route[0]->dst->id, &c));
+	assert(pubkey_eq(&first->nodes[0]->id, &a)
+	       || pubkey_eq(&first->nodes[1]->id, &a));
+	assert(pubkey_eq(&first->nodes[0]->id, &b)
+	       || pubkey_eq(&first->nodes[1]->id, &b));
+	assert(pubkey_eq(&route[0]->nodes[0]->id, &b)
+	       || pubkey_eq(&route[0]->nodes[1]->id, &b));
+	assert(pubkey_eq(&route[0]->nodes[0]->id, &c)
+	       || pubkey_eq(&route[0]->nodes[1]->id, &c));
 
 	tal_free(ctx);
 	secp256k1_context_destroy(secp256k1_ctx);

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -68,25 +68,25 @@ const void *trc;
 bool short_channel_id_from_str(const char *str, size_t strlen,
 			       struct short_channel_id *dst);
 
-static struct node_connection *
+static struct half_chan *
 get_or_make_connection(struct routing_state *rstate,
 		       const struct pubkey *from_id,
 		       const struct pubkey *to_id,
 		       const char *shortid)
 {
 	struct short_channel_id scid;
-	struct routing_channel *chan;
+	struct chan *chan;
 
 	if (!short_channel_id_from_str(shortid, strlen(shortid), &scid))
 		abort();
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_routing_channel(rstate, &scid, from_id, to_id);
+		chan = new_chan(rstate, &scid, from_id, to_id);
 
-	return &chan->connections[pubkey_idx(from_id, to_id)];
+	return &chan->half[pubkey_idx(from_id, to_id)];
 }
 
-static bool channel_is_between(const struct routing_channel *chan,
+static bool channel_is_between(const struct chan *chan,
 			       const struct pubkey *a, const struct pubkey *b)
 {
 	if (pubkey_eq(&chan->nodes[0]->id, a)
@@ -104,11 +104,11 @@ int main(void)
 {
 	static const struct bitcoin_blkid zerohash;
 	const tal_t *ctx = trc = tal_tmpctx(NULL);
-	struct node_connection *nc;
+	struct half_chan *nc;
 	struct routing_state *rstate;
 	struct pubkey a, b, c;
 	u64 fee;
-	struct routing_channel **route;
+	struct chan **route;
 	const double riskfactor = 1.0 / BLOCKS_PER_YEAR / 10000;
 
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -87,7 +87,6 @@ static struct node_connection *add_connection(struct routing_state *rstate,
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
 	c->active = true;
-	c->short_channel_id = scid;
 	c->flags = get_channel_direction(from, to);
 	return c;
 }


### PR DESCRIPTION
This removes the redundant fields and finally renames everything into more uniform terms: 'node' 'chan' and 'half_chan'.