### PR TITLE
clear onchaind subd in channel on error

### DIFF
--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -330,6 +330,8 @@ static void onchain_error(struct channel *channel,
 {
 	/* FIXME: re-launch? */
 	log_broken(channel->log, "%s", desc);
+	channel_set_billboard(channel, true, desc);
+	channel_set_owner(channel, NULL);
 }
 
 /* With a reorg, this can get called multiple times; each time we'll kill


### PR DESCRIPTION
When the subdaemon closes unexpectedly, clear the reference and
update the channel billboard with the description.

Fixes https://github.com/ElementsProject/lightning/issues/1114