### PR TITLE
gossip: Use the internal utxoset to verify channels and store capacity in routing table

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1818,7 +1818,7 @@ static struct io_plan *handle_txout_reply(struct io_conn *conn,
 	if (!fromwire_gossip_get_txout_reply(msg, msg, &scid, &satoshis, &outscript))
 		master_badmsg(WIRE_GOSSIP_GET_TXOUT_REPLY, msg);
 
-	if (handle_pending_cannouncement(daemon->rstate, &scid, outscript))
+	if (handle_pending_cannouncement(daemon->rstate, &scid, satoshis, outscript))
 		send_node_announcement(daemon);
 
 	return daemon_conn_read_next(conn, &daemon->master);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1813,8 +1813,9 @@ static struct io_plan *handle_txout_reply(struct io_conn *conn,
 {
 	struct short_channel_id scid;
 	u8 *outscript;
+	u64 satoshis;
 
-	if (!fromwire_gossip_get_txout_reply(msg, msg, &scid, &outscript))
+	if (!fromwire_gossip_get_txout_reply(msg, msg, &scid, &satoshis, &outscript))
 		master_badmsg(WIRE_GOSSIP_GET_TXOUT_REPLY, msg);
 
 	if (handle_pending_cannouncement(daemon->rstate, &scid, outscript))

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1116,6 +1116,7 @@ static void append_half_channel(struct gossip_getchannels_entry **entries,
 
 	e->source = chan->nodes[idx]->id;
 	e->destination = chan->nodes[!idx]->id;
+	e->satoshis = chan->satoshis;
 	e->active = c->active;
 	e->flags = c->flags;
 	e->public = (c->channel_update != NULL);

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -191,6 +191,7 @@ gossip_get_txout,,short_channel_id,struct short_channel_id
 # master->gossipd here is the output, or empty if none.
 gossip_get_txout_reply,3118
 gossip_get_txout_reply,,short_channel_id,struct short_channel_id
+gossip_get_txout_reply,,satoshis,u64
 gossip_get_txout_reply,,len,u16
 gossip_get_txout_reply,,outscript,len*u8
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -225,6 +225,7 @@ struct chan *new_chan(struct routing_state *rstate,
 	chan->channel_announcement = NULL;
 	chan->channel_announce_msgidx = 0;
 	chan->public = false;
+	chan->satoshis = 0;
 
 	n = tal_count(n2->chans);
 	tal_resize(&n2->chans, n+1);
@@ -646,6 +647,7 @@ const struct short_channel_id *handle_channel_announcement(
 
 bool handle_pending_cannouncement(struct routing_state *rstate,
 				  const struct short_channel_id *scid,
+				  const u64 satoshis,
 				  const u8 *outscript)
 {
 	bool local;
@@ -706,6 +708,7 @@ bool handle_pending_cannouncement(struct routing_state *rstate,
 
 	/* Channel is now public. */
 	chan->public = true;
+	chan->satoshis = satoshis;
 
 	/* Save channel_announcement. */
 	tal_free(chan->channel_announcement);

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -61,6 +61,8 @@ struct chan {
 
 	/* Is this a public channel, or was it only added locally? */
 	bool public;
+
+	u64 satoshis;
 };
 
 struct node {
@@ -210,6 +212,7 @@ handle_channel_announcement(struct routing_state *rstate,
  */
 bool handle_pending_cannouncement(struct routing_state *rstate,
 				  const struct short_channel_id *scid,
+				  const u64 satoshis,
 				  const u8 *txscript);
 void handle_channel_update(struct routing_state *rstate, const u8 *update);
 void handle_node_announcement(struct routing_state *rstate, const u8 *node);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -81,6 +81,7 @@ static void got_txout(struct bitcoind *bitcoind,
 static void get_txout(struct subd *gossip, const u8 *msg)
 {
 	struct short_channel_id *scid = tal(gossip, struct short_channel_id);
+	struct outpoint *op;
 
 	if (!fromwire_gossip_get_txout(msg, scid))
 		fatal("Gossip gave bad GOSSIP_GET_TXOUT message %s",
@@ -88,11 +89,19 @@ static void get_txout(struct subd *gossip, const u8 *msg)
 
 	/* FIXME: Block less than 6 deep? */
 
-	bitcoind_getoutput(gossip->ld->topology->bitcoind,
-			   short_channel_id_blocknum(scid),
-			   short_channel_id_txnum(scid),
-			   short_channel_id_outnum(scid),
-			   got_txout, scid);
+	op = wallet_outpoint_for_scid(gossip->ld->wallet, scid, scid);
+
+	if (op) {
+		subd_send_msg(gossip, towire_gossip_get_txout_reply(
+					  scid, scid, op->scriptpubkey));
+		tal_free(scid);
+	} else {
+		bitcoind_getoutput(gossip->ld->topology->bitcoind,
+				   short_channel_id_blocknum(scid),
+				   short_channel_id_txnum(scid),
+				   short_channel_id_outnum(scid),
+				   got_txout, scid);
+	}
 }
 
 static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -66,7 +66,7 @@ static void got_txout(struct bitcoind *bitcoind,
 		      struct short_channel_id *scid)
 {
 	const u8 *script;
-	u64 satoshis = 0;
+	u64 satoshis;
 
 	/* output will be NULL if it wasn't found */
 	if (output) {
@@ -74,6 +74,7 @@ static void got_txout(struct bitcoind *bitcoind,
 		satoshis = output->amount;
 	} else {
 		script = NULL;
+		satoshis = 0;
 	}
 
 	subd_send_msg(

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -444,6 +444,7 @@ static void json_listchannels_reply(struct subd *gossip UNUSED, const u8 *reply,
 		json_add_num(response, "flags", entries[i].flags);
 		json_add_bool(response, "active", entries[i].active);
 		json_add_bool(response, "public", entries[i].public);
+		json_add_u64(response, "satoshis", entries[i].satoshis);
 		if (entries[i].last_update_timestamp >= 0) {
 			json_add_num(response, "last_update",
 				     entries[i].last_update_timestamp);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -71,6 +71,7 @@ void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
 	fromwire_short_channel_id(pptr, max, &entry->short_channel_id);
 	fromwire_pubkey(pptr, max, &entry->source);
 	fromwire_pubkey(pptr, max, &entry->destination);
+	entry->satoshis = fromwire_u64(pptr, max);
 	entry->active = fromwire_bool(pptr, max);
 	entry->flags = fromwire_u16(pptr, max);
 	entry->public = fromwire_bool(pptr, max);
@@ -88,6 +89,7 @@ void towire_gossip_getchannels_entry(
 	towire_short_channel_id(pptr, &entry->short_channel_id);
 	towire_pubkey(pptr, &entry->source);
 	towire_pubkey(pptr, &entry->destination);
+	towire_u64(pptr, entry->satoshis);
 	towire_bool(pptr, entry->active);
 	towire_u16(pptr, entry->flags);
 	towire_bool(pptr, entry->public);

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -14,6 +14,7 @@ struct gossip_getnodes_entry {
 
 struct gossip_getchannels_entry {
 	struct pubkey source, destination;
+	u64 satoshis;
 	bool active;
 	struct short_channel_id short_channel_id;
 	u16 flags;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -108,6 +108,16 @@ struct wallet_payment {
 	struct short_channel_id *route_channels;
 };
 
+struct outpoint {
+	struct bitcoin_txid txid;
+	u32 blockheight;
+	u32 txindex;
+	u32 outnum;
+	u64 satoshis;
+	u8 *scriptpubkey;
+	u32 spendheight;
+};
+
 /**
  * wallet_new - Constructor for a new sqlite3 based wallet
  *
@@ -710,6 +720,9 @@ void wallet_blocks_rollback(struct wallet *w, u32 height);
 
 void wallet_outpoint_spend(struct wallet *w, const u32 blockheight,
 			   const struct bitcoin_txid *txid, const u32 outnum);
+
+struct outpoint *wallet_outpoint_for_scid(struct wallet *w, tal_t *ctx,
+					  const struct short_channel_id *scid);
 
 void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 			const u32 outnum, const u32 blockheight,


### PR DESCRIPTION
This PR shortcircuits the txout check to use the internal utxoset if present, saving us from having to call out and parse a block. In addition we now annotate the channels in our routing view to have the total capacity of the channel, hopefully allowing us to make more informed routing decisions in the future.