### PR TITLE
Add gitattribute to enforce lf on sh and py files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf
+*.py text eol=lf
+Makefile text eol=lf


### PR DESCRIPTION
Not having this change make in a nightmare to code on windows while running on docker.