### PR TITLE
pytest: Re-enable formerly flaky test_reconnect_normal

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2544,7 +2544,6 @@ class LightningDTests(BaseLightningDTests):
         # Just to be sure, second openingd hand over to channeld.
         l2.daemon.wait_for_log('lightning_openingd.*REPLY WIRE_OPENING_FUNDEE_REPLY with 2 fds')
 
-    @unittest.skip("temporarily disabled due to flaky behavior, issue #468")
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_reconnect_normal(self):
         # Should reconnect fine even if locked message gets lost.


### PR DESCRIPTION
Fixes #468 