### PR TITLE
Change `sendpay` result to be nearer to `listpayments`

### DIFF
--- a/doc/lightning-sendpay.7
+++ b/doc/lightning-sendpay.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-sendpay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 03/08/2018
+.\"      Date: 03/14/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-SENDPAY" "7" "03/08/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-SENDPAY" "7" "03/14/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -43,7 +43,7 @@ The response will occur when the payment is on its way to the destination\&. The
 Once a payment has succeeded, calls to \fBsendpay\fR with the same \fIhash\fR but a different amount or destination will fail; this prevents accidental multiple payments\&. Calls to \fBsendpay\fR with the same \fIhash\fR, amount, and destination as a previous successful payment (even if a different route) will return immediately with success\&.
 .SH "RETURN VALUE"
 .sp
-On success, an object with field \fIcompleted\fR is returned\&. Typically this field is \fIfalse\fR, but if the payment has already succeeded before to the same destination and amount, the field shall be set to \fItrue\fR and the \fIpreimage\fR will be returned also\&.
+On success, an object similar to the output of \fBlistpayments\fR will be returned\&. This object will have a \fIstatus\fR field that is typically the string \fI"pending"\fR, but may be \fI"complete"\fR if the payment was already performed successfully\&.
 .sp
 On error, if the error occurred from a node other than the final destination, the route table will be updated so that getroute(7) should return an alternate route (if any)\&. An error from the final destination implies the payment should not be retried\&.
 .sp
@@ -58,21 +58,6 @@ The following error codes may occur:
 .IP \(bu 2.3
 .\}
 \-1\&. Catchall nonspecific error\&.
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.sp -1
-.IP \(bu 2.3
-.\}
-200\&. A previous
-\fBsendpay\fR
-or
-\fBpay\fR
-is in progress\&.
 .RE
 .sp
 .RS 4

--- a/doc/lightning-sendpay.7.txt
+++ b/doc/lightning-sendpay.7.txt
@@ -37,10 +37,11 @@ immediately with success.
 RETURN VALUE
 ------------
 
-On success, an object with field 'completed' is returned.
-Typically this field is 'false', but if the payment has already
-succeeded before to the same destination and amount, the field
-shall be set to 'true' and the 'preimage' will be returned also.
+On success, an object similar to the output of *listpayments* will
+be returned.
+This object will have a 'status' field that is typically the
+string '"pending"', but may be '"complete"' if the payment was
+already performed successfully.
 
 On error, if the error occurred from a node other than the final
 destination, the route table will be updated so that getroute(7)
@@ -50,7 +51,6 @@ destination implies the payment should not be retried.
 The following error codes may occur:
 
 * -1. Catchall nonspecific error.
-* 200. A previous *sendpay* or *pay* is in progress.
 * 201. Already paid with this 'hash' using different amount or
   destination.
 * 202. Unparseable onion reply. The 'data' field of the error

--- a/doc/lightning-waitsendpay.7
+++ b/doc/lightning-waitsendpay.7
@@ -1,0 +1,209 @@
+'\" t
+.\"     Title: lightning-waitsendpay
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 03/14/2018
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-WAITSENDP" "7" "03/14/2018" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-waitsendpay \- Protocol for sending a payment via a route\&.
+.SH "SYNOPSIS"
+.sp
+\fBwaitsendpay\fR \fIpayment_hash\fR [\fItimeout\fR]
+.SH "DESCRIPTION"
+.sp
+The \fBwaitsendpay\fR RPC command polls or waits for the status of an outgoing payment that was initiated by a previous \fBsendpay\fR invocation\&.
+.sp
+Optionally the client may provide a \fItimeout\fR, an integer in seconds, for this RPC command to return\&. If the \fItimeout\fR is provided and the given amount of time passes without the payment definitely succeeding or definitely failing, this command returns with a 200 error code (payment still in progress)\&. If \fItimeout\fR is not provided this call will wait indefinitely\&.
+.sp
+Indicating a \fItimeout\fR of 0 effectively makes this call a pollable query of the status of the payment\&.
+.sp
+If the payment completed with success, this command returns with success\&. Otherwise, if the payment completed with failure, this command returns an error\&.
+.SH "RETURN VALUE"
+.sp
+On success, an object similar to the output of \fBlistpayments\fR will be returned\&. This object will have a \fIstatus\fR field that is the string \fI"complete"\fR\&.
+.sp
+On error, if the error occurred from a node other than the final destination, the route table will be updated so that getroute(7) should return an alternate route (if any)\&. An error from the final destination implies the payment should not be retried\&.
+.sp
+The following error codes may occur:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\-1\&. Catchall nonspecific error\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+200\&. Timed out before the payment could complete\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+202\&. Unparseable onion reply\&. The
+\fIdata\fR
+field of the error will have an
+\fIonionreply\fR
+field, a hex string representation of the raw onion reply\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+203\&. Permanent failure at destination\&. The
+\fIdata\fR
+field of the error will be routing failure object\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+204\&. Failure along route; retry a different route\&. The
+\fIdata\fR
+field of the error will be routing failure object\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+208\&. A payment for
+\fIpayment_hash\fR
+was never made and there is nothing to wait for\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+209\&. The payment already failed, but the reason for failure was not stored\&. This should only occur when querying failed payments on very old databases\&.
+.RE
+.sp
+A routing failure object has the fields below:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIerring_index\fR\&. The index of the node along the route that reported the error\&. 0 for the local node, 1 for the first hop, and so on\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIerring_node\fR\&. The hex string of the pubkey id of the node that reported the error\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIerring_channel\fR\&. The short channel ID of the channel that has the error, or
+\fI0:0:0\fR
+if the destination node raised the error\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIfailcode\fR\&. The failure code, as per BOLT #4\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIchannel_update\fR\&. The hex string of the
+\fIchannel_update\fR
+message received from the remote node\&. Only present if error is from the remote node and the
+\fIfailcode\fR
+has the UPDATE bit set, as per BOLT #4\&.
+.RE
+.SH "AUTHOR"
+.sp
+ZmnSCPxj <ZmnSCPxj@protonmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-sendpay(7), lightning\-pay(7)\&.
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-waitsendpay.7.txt
+++ b/doc/lightning-waitsendpay.7.txt
@@ -8,7 +8,7 @@ lightning-waitsendpay - Protocol for sending a payment via a route.
 
 SYNOPSIS
 --------
-*waitsendpay* 'hash' ['timeout']
+*waitsendpay* 'payment_hash' ['timeout']
 
 DESCRIPTION
 -----------
@@ -36,9 +36,10 @@ returns an error.
 RETURN VALUE
 ------------
 
-On success, an object with field 'completed' is returned.
-This field will be 'true' and another field 'preimage' of the
-object will be set to the preimage.
+On success, an object similar to the output of *listpayments* will
+be returned.
+This object will have a 'status' field that is the
+string '"complete"'.
 
 On error, if the error occurred from a node other than the final
 destination, the route table will be updated so that getroute(7)
@@ -56,8 +57,8 @@ The following error codes may occur:
   the error will be routing failure object.
 * 204. Failure along route; retry a different route. The 'data'
   field of the error will be routing failure object.
-* 208. A payment for 'hash' was never made and there is nothing
-  to wait for.
+* 208. A payment for 'payment_hash' was never made and there is
+  nothing to wait for.
 * 209. The payment already failed, but the reason for failure
   was not stored. This should only occur when querying failed
   payments on very old databases.

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -804,20 +804,55 @@ send_payment(const tal_t *ctx,
 }
 
 /*-----------------------------------------------------------------------------
+Utility
+-----------------------------------------------------------------------------*/
+
+/* Outputs fields, not a separate object*/
+static void
+json_add_payment_fields(struct json_result *response,
+			const struct wallet_payment *t)
+{
+	json_add_u64(response, "id", t->id);
+	json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
+	json_add_pubkey(response, "destination", &t->destination);
+	json_add_u64(response, "msatoshi", t->msatoshi);
+	if (deprecated_apis)
+		json_add_u64(response, "timestamp", t->timestamp);
+	json_add_u64(response, "created_at", t->timestamp);
+
+	switch (t->status) {
+	case PAYMENT_PENDING:
+		json_add_string(response, "status", "pending");
+		break;
+	case PAYMENT_COMPLETE:
+		json_add_string(response, "status", "complete");
+		break;
+	case PAYMENT_FAILED:
+		json_add_string(response, "status", "failed");
+		break;
+	}
+	if (t->payment_preimage)
+		json_add_hex(response, "payment_preimage",
+			     t->payment_preimage,
+			     sizeof(*t->payment_preimage));
+
+}
+
+/*-----------------------------------------------------------------------------
 JSON-RPC sendpay interface
 -----------------------------------------------------------------------------*/
 
 static void
 json_sendpay_success(struct command *cmd,
-		     const struct preimage *payment_preimage)
+		     const struct sendpay_result *r)
 {
 	struct json_result *response;
 
+	assert(r->payment->status == PAYMENT_COMPLETE);
+
 	response = new_json_result(cmd);
 	json_object_start(response, NULL);
-	json_add_bool(response, "completed", true);
-	json_add_hex(response, "payment_preimage",
-		     payment_preimage, sizeof(*payment_preimage));
+	json_add_payment_fields(response, r->payment);
 	json_object_end(response);
 	command_success(cmd, response);
 }
@@ -832,10 +867,13 @@ static void json_waitsendpay_on_resolve(const struct sendpay_result *r,
 	struct routing_failure *fail;
 
 	if (r->succeeded)
-		json_sendpay_success(cmd, &r->preimage);
+		json_sendpay_success(cmd, r);
 	else {
 		switch (r->errorcode) {
+			/* We will never handle this case */
 		case PAY_IN_PROGRESS:
+			abort();
+
 		case PAY_RHASH_ALREADY_USED:
 		case PAY_UNSPECIFIED_ERROR:
 		case PAY_NO_SUCH_PAYMENT:
@@ -905,7 +943,7 @@ static void json_sendpay_on_resolve(const struct sendpay_result* r,
 		json_object_start(response, NULL);
 		json_add_string(response, "message",
 				"Monitor status with listpayments or waitsendpay");
-		json_add_bool(response, "completed", false);
+		json_add_payment_fields(response, r->payment);
 		json_object_end(response);
 		command_success(cmd, response);
 	} else
@@ -1115,32 +1153,8 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 	json_object_start(response, NULL);
 	json_array_start(response, "payments");
 	for (int i=0; i<tal_count(payments); i++) {
-		const struct wallet_payment *t = payments[i];
 		json_object_start(response, NULL);
-		json_add_u64(response, "id", t->id);
-		json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
-		json_add_pubkey(response, "destination", &t->destination);
-		json_add_u64(response, "msatoshi", t->msatoshi);
-		if (deprecated_apis)
-			json_add_u64(response, "timestamp", t->timestamp);
-		json_add_u64(response, "created_at", t->timestamp);
-
-		switch (t->status) {
-		case PAYMENT_PENDING:
-			json_add_string(response, "status", "pending");
-			break;
-		case PAYMENT_COMPLETE:
-			json_add_string(response, "status", "complete");
-			break;
-		case PAYMENT_FAILED:
-			json_add_string(response, "status", "failed");
-			break;
-		}
-		if (t->payment_preimage)
-			json_add_hex(response, "payment_preimage",
-				     t->payment_preimage,
-				     sizeof(*t->payment_preimage));
-
+		json_add_payment_fields(response, payments[i]);
 		json_object_end(response);
 	}
 	json_array_end(response);

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -10,6 +10,7 @@ struct htlc_out;
 struct lightningd;
 struct route_hop;
 struct sha256;
+struct wallet_payment;
 
 /* Routing failure object */
 struct routing_failure {
@@ -29,6 +30,9 @@ struct sendpay_result {
 	/* Error code, one of the PAY_* macro in jsonrpc_errors.h.
 	 * Only loaded if payment failed. */
 	int errorcode;
+	/* Pointer to the payment. Only loaded if payment
+	 * succeeded or if error is PAY_IN_PROGRESS */
+	const struct wallet_payment *payment;
 	/* Unparseable onion reply. Only loaded if payment failed,
 	 * and errorcode == PAY_UNPARSEABLE_ONION. */
 	const u8* onionreply;


### PR DESCRIPTION
Part of fix for #1088.

A note on `json_add_payment_fields`: I intend to reuse this function for the modification for `pay` output.  My intent is that `pay` displays the fields for the payment, but also adds some fields --- `getroute_tries`, `sendpay_tries`, `route`, `failures` --- indicating detailed information about the payment. Thus, the reason why `json_add_payment_fields` provides the payment details but does not open and close an object.