### PR TITLE
tools/rel.sh: Make POSIXLY compatible `sed` script.

### DIFF
--- a/tools/rel.sh
+++ b/tools/rel.sh
@@ -2,6 +2,6 @@
 
 from=${1}
 to=${2}
-common=`printf '%s\0%s' "${from}" "${to}" | sed 's/\(.*\).*\x0\1.*/\1/' | sed 's@/[^/]*$@/@'`
+common=`printf '%s\n%s' "${from}" "${to}" | sed 'N;s/\(.*\).*\n\1.*$/\1/' | sed 's@/[^/]*$@/@'`
 prefix=`printf '%s\n' ${from#$common} | sed 's@[^/][^/]*@..@g'`
 printf '%s\n' "$prefix/${to#$common}"


### PR DESCRIPTION
Fixes: #1221

We were using `\x0` to match NUL chars in the input (on the
assumption that NUL chars are "impossible" for decent LFS-compliant
systems).
However `\x0` is a GNUism.
Use the `\n` and the newline character, which is supported by (most)
POSIX sed.