### PR TITLE
chaintopology: Add missing `block_map_del`.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -440,6 +440,7 @@ static void remove_tip(struct chain_topology *topo)
 		txwatch_fire(topo, b->txs[i], 0);
 
 	wallet_block_remove(topo->wallet, b);
+	block_map_del(&topo->block_map, b);
 	tal_free(b);
 }
 


### PR DESCRIPTION
We would `block_map_add` inside `add_tip`, but we never
`block_map_del` inside `remove_tip`, which is dangerous as
we actually `tal_free` the block inside `remove_tip`.

Our CI did not reliably trap this problem since block
hashes are random and rerunning the `test_blockchaintrack`
often passed spuriously.