### PR TITLE
Fix for crash when onchaind hits a deleted payment.

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -431,6 +431,17 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 					 &hout->payment_hash);
 
 #ifdef COMPAT_V052
+	/* Prior to "pay: delete HTLC when we delete payment." we would
+	 * delete a payment on retry, but leave the HTLC. */
+	if (!payment) {
+		log_unusual(hout->key.channel->log,
+			    "No payment for %s:"
+			    " was this an old database?",
+			    type_to_string(tmpctx, struct sha256,
+					   &hout->payment_hash));
+		return;
+	}
+
 	/* FIXME: Prior to 299b280f7, we didn't put route_nodes and
 	 * route_channels in db.  If this happens, it's an old payment,
 	 * so we can simply mark it failed in db and return. */

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1366,7 +1366,6 @@ class LightningDTests(BaseLightningDTests):
         # Note: for this test we leave onchaind running, so we can detect
         # any leaks!
 
-    @unittest.skip("Expected failure")
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_onchain_dust_out(self):
         """Onchain handling of outgoing dust htlcs (they should fail)"""

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1468,6 +1468,24 @@ struct htlc_stub *wallet_htlc_stubs(const tal_t *ctx, struct wallet *wallet,
 	return stubs;
 }
 
+void wallet_local_htlc_out_delete(struct wallet *wallet,
+				  struct channel *chan,
+				  const struct sha256 *payment_hash)
+{
+	sqlite3_stmt *stmt;
+
+	stmt = db_prepare(wallet->db,
+			  "DELETE FROM channel_htlcs"
+			  " WHERE direction = ?"
+			  " AND origin_htlc = ?"
+			  " AND payment_hash = ?");
+	sqlite3_bind_int(stmt, 1, DIRECTION_OUTGOING);
+	sqlite3_bind_int(stmt, 2, 0);
+	sqlite3_bind_sha256(stmt, 3, payment_hash);
+
+	db_exec_prepared(wallet->db, stmt);
+}
+
 static struct wallet_payment *
 find_unstored_payment(struct wallet *wallet, const struct sha256 *payment_hash)
 {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -651,6 +651,17 @@ void wallet_payment_delete(struct wallet *wallet,
 			   const struct sha256 *payment_hash);
 
 /**
+ * wallet_local_htlc_out_delete - Remove a local outgoing failed HTLC
+ *
+ * This is not a generic HTLC cleanup!  This is specifically for the
+ * narrow (and simple!) case of removing the HTLC associated with a
+ * local outgoing payment.
+ */
+void wallet_local_htlc_out_delete(struct wallet *wallet,
+				  struct channel *chan,
+				  const struct sha256 *payment_hash);
+
+/**
  * wallet_payment_by_hash - Retrieve a specific payment
  *
  * Given the `payment_hash` retrieve the matching payment.


### PR DESCRIPTION
I also note that we *never* delete HTLCs, though we can (and should!) once they're in the final revoked state.