### PR TITLE
channel_fail_permanent: Use a channel-level error, not an all-channels error.

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -20,6 +20,7 @@
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
 #include <openingd/gen_opening_wire.h>
+#include <wire/wire.h>
 #include <wire/wire_sync.h>
 
 /* Channel we're still opening. */
@@ -245,6 +246,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	struct channel *channel;
 	struct json_result *response;
 	struct lightningd *ld = openingd->ld;
+	struct channel_id cid;
 
 	assert(tal_count(fds) == 2);
 
@@ -384,6 +386,9 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	linear = linearize_tx(response, fundingtx);
 	json_add_hex(response, "tx", linear, tal_len(linear));
 	json_add_txid(response, "txid", &channel->funding_txid);
+	derive_channel_id(&cid, &channel->funding_txid, funding_outnum);
+	json_add_string(response, "channel_id",
+			type_to_string(tmpctx, struct channel_id, &cid));
 	json_object_end(response);
 	command_success(fc->cmd, response);
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -635,6 +635,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 		json_add_uncommitted_channel(response, p->uncommitted_channel);
 
 		list_for_each(&p->channels, channel, list) {
+			struct channel_id cid;
 			json_object_start(response, NULL);
 			json_add_string(response, "state",
 					channel_state_name(channel));
@@ -645,6 +646,13 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 				json_add_short_channel_id(response,
 							  "short_channel_id",
 							  channel->scid);
+			derive_channel_id(&cid,
+					  &channel->funding_txid,
+					  channel->funding_outnum);
+			json_add_string(response, "channel_id",
+					type_to_string(tmpctx,
+						       struct channel_id,
+						       &cid));
 			json_add_txid(response,
 				      "funding_txid",
 				      &channel->funding_txid);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1246,8 +1246,9 @@ class LightningDTests(BaseLightningDTests):
         l2.daemon.wait_for_log(' to ONCHAIN')
         l2.daemon.wait_for_log('Propose handling OUR_UNILATERAL/DELAYED_OUTPUT_TO_US by OUR_DELAYED_RETURN_TO_WALLET (.*) after 5 blocks')
 
+        cid = l1.rpc.listpeers(l2.info['id'])['peers'][0]['channels'][0]['channel_id']
         wait_for(lambda: l1.rpc.listpeers(l2.info['id'])['peers'][0]['channels'][0]['status'] ==
-                 ['CHANNELD_NORMAL:Received error from peer: channel ALL: Internal error: Failing due to dev-fail command',
+                 ['CHANNELD_NORMAL:Received error from peer: channel {}: Internal error: Failing due to dev-fail command'.format(cid),
                   'ONCHAIN:Tracking their unilateral close',
                   'ONCHAIN:All outputs resolved: waiting 99 more blocks before forgetting channel'])
 


### PR DESCRIPTION
Fixes: #1229

The principle is that `error` should really be as specific as possible.  We also have vague plans to maybe, might be, have multiple channels per peer, in some possibility that may or may not be 0.