### PR TITLE
wallet: Remove onion-decoding information from db on payment success/fail

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -245,6 +245,12 @@ char *dbmigrations[] = {
     "ALTER TABLE payments ADD failchannel BLOB;", /* erring_channel */
     "ALTER TABLE payments ADD failupdate BLOB;", /* channel_update - can be NULL*/
     /* -- Payment routing failure information ends -- */
+    /* Delete route data for already succeeded or failed payments */
+    "UPDATE payments"
+    "   SET path_secrets = NULL"
+    "     , route_nodes = NULL"
+    "     , route_channels = NULL"
+    " WHERE status <> 0;", /* PAYMENT_PENDING */
     NULL,
 };
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1706,6 +1706,16 @@ void wallet_payment_set_status(struct wallet *wallet,
 		sqlite3_bind_sha256(stmt, 2, payment_hash);
 		db_exec_prepared(wallet->db, stmt);
 	}
+	if (newstatus != PAYMENT_PENDING) {
+		stmt = db_prepare(wallet->db,
+				  "UPDATE payments"
+				  "   SET path_secrets = NULL"
+				  "     , route_nodes = NULL"
+				  "     , route_channels = NULL"
+				  " WHERE payment_hash = ?;");
+		sqlite3_bind_sha256(stmt, 1, payment_hash);
+		db_exec_prepared(wallet->db, stmt);
+	}
 }
 
 void wallet_payment_get_failinfo(const tal_t *ctx,


### PR DESCRIPTION
Fixes: #1177