### PR TITLE
Disable backtrace on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.pb
 *.gcda
 *.gcno
+*.dSYM
 TAGS
 ccan/tools/configurator/configurator
 ccan/ccan/cdump/tools/cdump-enumstr

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "external/libwally-core"]
 	path = external/libwally-core
 	url = https://github.com/ElementsProject/libwally-core.git
+	ignore = dirty

--- a/common/subdaemon.c
+++ b/common/subdaemon.c
@@ -1,4 +1,5 @@
 #include <backtrace.h>
+#include <backtrace-supported.h>
 #include <ccan/err/err.h>
 #include <ccan/str/str.h>
 #include <common/dev_disconnect.h>
@@ -12,6 +13,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if BACKTRACE_SUPPORTED
 static struct backtrace_state *backtrace_state;
 
 static int backtrace_status(void *unused UNUSED, uintptr_t pc,
@@ -51,6 +53,7 @@ static void crashlog_activate(void)
 	sigaction(SIGSEGV, &sa, NULL);
 	sigaction(SIGBUS, &sa, NULL);
 }
+#endif
 
 #if DEVELOPER
 extern volatile bool debugger_connected;
@@ -65,8 +68,10 @@ void subdaemon_setup(int argc, char *argv[])
 	}
 
 	err_set_progname(argv[0]);
+#if BACKTRACE_SUPPORTED
 	backtrace_state = backtrace_create_state(argv[0], 0, NULL, NULL);
 	crashlog_activate();
+#endif
 
 	/* We handle write returning errors! */
 	signal(SIGPIPE, SIG_IGN);

--- a/common/subdaemon.c
+++ b/common/subdaemon.c
@@ -1,5 +1,5 @@
-#include <backtrace.h>
 #include <backtrace-supported.h>
+#include <backtrace.h>
 #include <ccan/err/err.h>
 #include <ccan/str/str.h>
 #include <common/dev_disconnect.h>

--- a/external/Makefile
+++ b/external/Makefile
@@ -16,7 +16,8 @@ EXTERNAL_INCLUDE_FLAGS :=					\
 	-I external/libwally-core/src/secp256k1/include/	\
 	-I external/jsmn/					\
 	-I external/libbase58/					\
-	-I external/libbacktrace
+	-I external/libbacktrace/				\
+	-I external/libbacktrace-build
 
 EXTERNAL_LDLIBS := -Lexternal $(patsubst lib%.a,-l%,$(notdir $(EXTERNAL_LIBS)))
 

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -1,6 +1,6 @@
 #include "log.h"
-#include <backtrace.h>
 #include <backtrace-supported.h>
+#include <backtrace.h>
 #include <ccan/array_size/array_size.h>
 #include <ccan/list/list.h>
 #include <ccan/opt/opt.h>

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -1,5 +1,6 @@
 #include "log.h"
 #include <backtrace.h>
+#include <backtrace-supported.h>
 #include <ccan/array_size/array_size.h>
 #include <ccan/list/list.h>
 #include <ccan/opt/opt.h>
@@ -464,6 +465,7 @@ void opt_register_logging(struct lightningd *ld)
 			 "log to file instead of stdout");
 }
 
+#if BACKTRACE_SUPPORTED
 static int log_backtrace(void *log, uintptr_t pc,
 			 const char *filename, int lineno,
 			 const char *function)
@@ -522,9 +524,11 @@ static void log_crash(int sig)
 		fprintf(stderr, "Log dumped in %s", logfile);
 	fprintf(stderr, "\n");
 }
+#endif
 
 void crashlog_activate(const char *argv0 UNUSED, struct log *log)
 {
+#if BACKTRACE_SUPPORTED
 	struct sigaction sa;
 	crashlog = log;
 
@@ -537,6 +541,7 @@ void crashlog_activate(const char *argv0 UNUSED, struct log *log)
 	sigaction(SIGFPE, &sa, NULL);
 	sigaction(SIGSEGV, &sa, NULL);
 	sigaction(SIGBUS, &sa, NULL);
+#endif
 }
 
 void log_dump_to_file(int fd, const struct log_book *lr)
@@ -576,6 +581,7 @@ void fatal(const char *fmt, ...)
 	fprintf(stderr, "\n");
 	va_end(ap);
 
+#if BACKTRACE_SUPPORTED
 	/* Early on, we just dump errors to stderr. */
 	if (crashlog) {
 		va_start(ap, fmt);
@@ -583,6 +589,7 @@ void fatal(const char *fmt, ...)
 		va_end(ap);
 		log_crash(0);
 	}
+#endif
 	abort();
 }
 


### PR DESCRIPTION
fix https://github.com/ElementsProject/lightning/issues/840

backtrace module does not support mac. So, disable crash log if BACKTRACE_SUPPORTED is 0.

The reason why this patch fix https://github.com/ElementsProject/lightning/issues/840 is not fully identified. On mac, SIGSEGV and SIGBUS signal happens after jsonrpc only when signal handlers are registered with ``sigaction()``.