### PR TITLE
Track confirmations for change and their_unilateral/to_us outputs

### DIFF
--- a/common/utxo.h
+++ b/common/utxo.h
@@ -28,10 +28,10 @@ struct utxo {
 	struct unilateral_close_info *close_info;
 
 	/* NULL if we haven't seen it in a block, otherwise the block it's in */
-	const int *blockheight;
+	const u32 *blockheight;
 
 	/* NULL if not spent yet, otherwise, the block the spending transaction is in */
-	const int *spendheight;
+	const u32 *spendheight;
 };
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo);

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -78,7 +78,8 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		satoshi_owned = 0;
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
-						     tx, b, &satoshi_owned);
+						     tx, &b->height,
+						     &satoshi_owned);
 		}
 
 		/* We did spends first, in case that tells us to watch tx. */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -35,7 +35,7 @@ struct outgoing_tx {
 };
 
 struct block {
-	int height;
+	u32 height;
 
 	/* Actual header. */
 	struct bitcoin_block_hdr hdr;

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -220,6 +220,7 @@ static void handle_irrevocably_resolved(struct channel *channel, const u8 *msg)
 static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 {
 	struct utxo *u = tal(msg, struct utxo);
+	u32 blockheight;
 	u->close_info = tal(u, struct unilateral_close_info);
 
 	u->is_p2sh = true;
@@ -227,14 +228,14 @@ static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 	u->status = output_state_available;
 	u->close_info->channel_id = channel->dbid;
 	u->close_info->peer_id = channel->peer->id;
-	u->blockheight = NULL;
 	u->spendheight = NULL;
 
 	if (!fromwire_onchain_add_utxo(msg, &u->txid, &u->outnum,
 				       &u->close_info->commitment_point,
-				       &u->amount)) {
+				       &u->amount, &blockheight)) {
 		fatal("onchaind gave invalid add_utxo message: %s", tal_hex(msg, msg));
 	}
+	u->blockheight = blockheight>0?&blockheight:NULL;
 
 	outpointfilter_add(channel->peer->ld->wallet->owned_outpoints, &u->txid, u->outnum);
 	wallet_add_utxo(channel->peer->ld->wallet, u, p2wpkh);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -236,7 +236,7 @@ static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 		fatal("onchaind gave invalid add_utxo message: %s", tal_hex(msg, msg));
 	}
 
-
+	outpointfilter_add(channel->peer->ld->wallet->owned_outpoints, &u->txid, u->outnum);
 	wallet_add_utxo(channel->peer->ld->wallet, u, p2wpkh);
 }
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -371,6 +371,12 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	/* Extract the change output and add it to the DB */
 	wallet_extract_owned_outputs(ld->wallet, fundingtx, NULL, &change_satoshi);
 
+	/* Make sure we recognize our change output by its scriptpubkey in
+	 * future. This assumes that we have only two outputs, may not be true
+	 * if we add support for multifundchannel */
+	if (tal_count(fundingtx->output) == 2)
+		txfilter_add_scriptpubkey(ld->owned_txfilter, fundingtx->output[!funding_outnum].script);
+
 	/* Send it out and watch for confirms. */
 	broadcast_tx(ld->topology, channel, fundingtx, funding_broadcast_failed);
 

--- a/onchaind/onchain.c
+++ b/onchaind/onchain.c
@@ -2039,7 +2039,8 @@ static void handle_their_unilateral(const struct bitcoin_tx *tx,
 			wire_sync_write(REQ_FD, towire_onchain_add_utxo(
 						    tmpctx, txid, i,
 						    remote_per_commitment_point,
-						    tx->output[i].amount));
+						    tx->output[i].amount,
+						    tx_blockheight));
 			continue;
 		}
 		if (script[REMOTE]

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -87,3 +87,4 @@ onchain_add_utxo,,prev_out_tx,struct bitcoin_txid
 onchain_add_utxo,,prev_out_index,u32
 onchain_add_utxo,,per_commit_point,struct pubkey
 onchain_add_utxo,,value,u64
+onchain_add_utxo,,blockheight,u32

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1271,6 +1271,9 @@ class LightningDTests(BaseLightningDTests):
         l1, l2 = self.connect()
 
         self.fund_channel(l1, l2, 10**6)
+
+        # The funding change should be confirmed and our only output
+        assert [o['status'] for o in l1.rpc.listfunds()['outputs']] == ['confirmed']
         self.pay(l1, l2, 200000000)
 
         # Make sure l2 has received sig with 0 htlcs!
@@ -1329,8 +1332,10 @@ class LightningDTests(BaseLightningDTests):
         bitcoind.generate_block(5)
         wait_forget_channels(l2)
 
-        # Only l1 has a direct output since all of l2's outputs are respent (it failed)
-        assert closetxid in set([o['txid'] for o in l1.rpc.listfunds()['outputs']])
+        # Only l1 has a direct output since all of l2's outputs are respent (it
+        # failed). Also the output should now be listed as confirmed since we
+        # generated some more blocks.
+        assert (closetxid, "confirmed") in set([(o['txid'], o['status']) for o in l1.rpc.listfunds()['outputs']])
 
         addr = l1.bitcoin.rpc.getnewaddress()
         l1.rpc.withdraw(addr, "all")

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -118,7 +118,7 @@ bool wallet_add_utxo(struct wallet *w, struct utxo *utxo,
  */
 static bool wallet_stmt2output(sqlite3_stmt *stmt, struct utxo *utxo)
 {
-	int *blockheight, *spendheight;
+	u32 *blockheight, *spendheight;
 	sqlite3_column_sha256_double(stmt, 0, &utxo->txid.shad);
 	utxo->outnum = sqlite3_column_int(stmt, 1);
 	utxo->amount = sqlite3_column_int64(stmt, 2);
@@ -138,13 +138,13 @@ static bool wallet_stmt2output(sqlite3_stmt *stmt, struct utxo *utxo)
 	utxo->spendheight = NULL;
 
 	if (sqlite3_column_type(stmt, 9) != SQLITE_NULL) {
-		blockheight = tal(utxo, int);
+		blockheight = tal(utxo, u32);
 		*blockheight = sqlite3_column_int(stmt, 9);
 		utxo->blockheight = blockheight;
 	}
 
 	if (sqlite3_column_type(stmt, 10) != SQLITE_NULL) {
-		spendheight = tal(utxo, int);
+		spendheight = tal(utxo, u32);
 		*spendheight = sqlite3_column_int(stmt, 10);
 		utxo->spendheight = spendheight;
 	}
@@ -1034,7 +1034,7 @@ static void wallet_output_confirm(struct wallet *w,
 }
 
 int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
-				 const struct block *block, u64 *total_satoshi)
+				 const u32 *blockheight, u64 *total_satoshi)
 {
 	int num_utxos = 0;
 	for (size_t output = 0; output < tal_count(tx->output); output++) {
@@ -1055,7 +1055,7 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 		utxo->outnum = output;
 		utxo->close_info = NULL;
 
-		utxo->blockheight = block?&block->height:NULL;
+		utxo->blockheight = blockheight?blockheight:NULL;
 		utxo->spendheight = NULL;
 
 		log_debug(w->log, "Owning output %zu %"PRIu64" (%s) txid %s",
@@ -1070,8 +1070,8 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 			 * blockheight. This can happen when we grab
 			 * the output from a transaction we created
 			 * ourselves. */
-			if (block)
-				wallet_output_confirm(w, &utxo->txid, utxo->outnum, block->height);
+			if (blockheight)
+				wallet_output_confirm(w, &utxo->txid, utxo->outnum, *blockheight);
 			tal_free(utxo);
 			continue;
 		}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -298,7 +298,7 @@ u32 wallet_first_blocknum(struct wallet *w, u32 first_possible);
  * wallet_extract_owned_outputs - given a tx, extract all of our outputs
  */
 int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
-				 const struct block *block, u64 *total_satoshi);
+				 const u32 *blockheight, u64 *total_satoshi);
 
 /**
  * wallet_htlc_save_in - store an htlc_in in the database


### PR DESCRIPTION
We were not tracking confirmations for change outputs and their_unilateral/to_us outputs:

 - Scripts of change outputs were not being added to the txfilter, hence we didn't get a notification
 - their_unilateral/to_us were not added to the txfilter and since we learnt about them only _after_ they were confirmed through `onchaind` we were missing its confirmation.

This PR fixes both, and includes a small fix.

Fixes #1209 