### PR TITLE
pay: Also record how much we actually ended up sending.

### DIFF
--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -46,6 +46,7 @@ json_add_payment_fields(struct json_result *response,
 	json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
 	json_add_pubkey(response, "destination", &t->destination);
 	json_add_u64(response, "msatoshi", t->msatoshi);
+	json_add_u64(response, "msatoshi_sent", t->msatoshi_sent);
 	if (deprecated_apis)
 		json_add_u64(response, "timestamp", t->timestamp);
 	json_add_u64(response, "created_at", t->timestamp);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -784,6 +784,7 @@ send_payment(const tal_t *ctx,
 	payment->destination = ids[n_hops - 1];
 	payment->status = PAYMENT_PENDING;
 	payment->msatoshi = route[n_hops-1].amount;
+	payment->msatoshi_sent = route[0].amount;
 	payment->timestamp = time_now().ts.tv_sec;
 	payment->payment_preimage = NULL;
 	payment->path_secrets = tal_steal(payment, path_secrets);

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -267,6 +267,9 @@ char *dbmigrations[] = {
     "     , out_msatoshi_offered = 0, out_msatoshi_fulfilled = 0"
     "     ;",
     /* -- Routing statistics ends --*/
+    /* Record the msatoshi actually sent in a payment. */
+    "ALTER TABLE payments ADD msatoshi_sent INTEGER;",
+    "UPDATE payments SET msatoshi_sent = msatoshi;",
     NULL,
 };
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -943,6 +943,7 @@ static bool test_payment_crud(struct lightningd *ld, const tal_t *ctx)
 
 	t->id = 0;
 	t->msatoshi = 100;
+	t->msatoshi_sent = 101;
 	t->status = PAYMENT_PENDING;
 	t->payment_preimage = NULL;
 	memset(&t->payment_hash, 1, sizeof(t->payment_hash));
@@ -955,6 +956,7 @@ static bool test_payment_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK(t2->status == t->status);
 	CHECK(pubkey_cmp(&t2->destination, &t->destination) == 0);
 	CHECK(t2->msatoshi == t->msatoshi);
+	CHECK(t2->msatoshi_sent == t->msatoshi_sent);
 	CHECK(!t2->payment_preimage);
 
 	t->status = PAYMENT_COMPLETE;
@@ -967,6 +969,7 @@ static bool test_payment_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK(t2->status == t->status);
 	CHECK(pubkey_cmp(&t2->destination, &t->destination) == 0);
 	CHECK(t2->msatoshi == t->msatoshi);
+	CHECK(t2->msatoshi_sent == t->msatoshi_sent);
 	CHECK(structeq(t->payment_preimage, t2->payment_preimage));
 
 	db_commit_transaction(w->db);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1618,8 +1618,9 @@ void wallet_payment_store(struct wallet *wallet,
 		"  timestamp,"
 		"  path_secrets,"
 		"  route_nodes,"
-		"  route_channels"
-		") VALUES (?, ?, ?, ?, ?, ?, ?, ?);");
+		"  route_channels,"
+		"  msatoshi_sent"
+		") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);");
 
 	sqlite3_bind_int(stmt, 1, payment->status);
 	sqlite3_bind_sha256(stmt, 2, &payment->payment_hash);
@@ -1632,6 +1633,7 @@ void wallet_payment_store(struct wallet *wallet,
 	sqlite3_bind_pubkey_array(stmt, 7, payment->route_nodes);
 	sqlite3_bind_short_channel_id_array(stmt, 8,
 					    payment->route_channels);
+	sqlite3_bind_int64(stmt, 9, payment->msatoshi_sent);
 
 	db_exec_prepared(wallet->db, stmt);
 
@@ -1684,6 +1686,8 @@ static struct wallet_payment *wallet_stmt2payment(const tal_t *ctx,
 	payment->route_channels
 		= sqlite3_column_short_channel_id_array(payment, stmt, 9);
 
+	payment->msatoshi_sent = sqlite3_column_int64(stmt, 10);
+
 	return payment;
 }
 
@@ -1702,7 +1706,8 @@ wallet_payment_by_hash(const tal_t *ctx, struct wallet *wallet,
 	stmt = db_prepare(wallet->db,
 			  "SELECT id, status, destination,"
 			  "msatoshi, payment_hash, timestamp, payment_preimage, "
-			  "path_secrets, route_nodes, route_channels "
+			  "path_secrets, route_nodes, route_channels, "
+			  "msatoshi_sent "
 			  "FROM payments "
 			  "WHERE payment_hash = ?");
 
@@ -1922,7 +1927,8 @@ wallet_payment_list(const tal_t *ctx,
 			wallet->db,
 			"SELECT id, status, destination, "
 			"msatoshi, payment_hash, timestamp, payment_preimage, "
-			"path_secrets, route_nodes, route_channels "
+			"path_secrets, route_nodes, route_channels, "
+			"msatoshi_sent "
 			"FROM payments;");
 	}
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -101,6 +101,7 @@ struct wallet_payment {
 	enum wallet_payment_status status;
 	struct pubkey destination;
 	u64 msatoshi;
+	u64 msatoshi_sent;
 	/* If and only if PAYMENT_COMPLETE */
 	struct preimage *payment_preimage;
 	/* Needed for recovering from routing failures. */


### PR DESCRIPTION
Add `msatoshi_sent` field to payments, symmetrical to the `msatoshi_received` field of invoices.