### PR TITLE
tests: Use correct privkey when calculating pubkey used in new_routing_state(...) call

### DIFF
--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -151,9 +151,9 @@ int main(void)
 	setup_tmpctx();
 
 	memset(&tmp, 'a', sizeof(tmp));
+	pubkey_from_privkey(&tmp, &a);
 	rstate = new_routing_state(tmpctx, &zerohash, &a, 0);
 
-	pubkey_from_privkey(&tmp, &a);
 	new_node(rstate, &a);
 
 	memset(&tmp, 'b', sizeof(tmp));


### PR DESCRIPTION
Use correct privkey when calculating pubkey used in `new_routing_state(...)` call.

Prior to this commit `a` was uninitialized when calling `new_routing_state(...)`.

Context: https://github.com/ElementsProject/lightning/pull/1262#issuecomment-375627602