### PR TITLE
lightningd/subd.h: Add missing wire/wire.h.

### DIFF
--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -25,7 +25,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wallet/db.h>
-#include <wire/wire.h>
 #include <wire/wire_io.h>
 
 static bool move_fd(int from, int to)

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -7,6 +7,7 @@
 #include <ccan/tal/tal.h>
 #include <ccan/typesafe_cb/typesafe_cb.h>
 #include <common/msg_queue.h>
+#include <wire/wire.h>
 
 struct crypto_state;
 struct io_conn;


### PR DESCRIPTION
If not included, a source file containing only `#include<lightningd/subd.h>` will fail compilation.