### PR TITLE
Add --bitcoin-rpcport option

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -48,6 +48,10 @@ static const char **gather_args(const struct bitcoind *bitcoind,
 		add_arg(&args,
 			tal_fmt(args, "-rpcconnect=%s", bitcoind->rpcconnect));
 
+	if (bitcoind->rpcport)
+		add_arg(&args,
+			tal_fmt(args, "-rpcport=%s", bitcoind->rpcport));
+
 	if (bitcoind->rpcuser)
 		add_arg(&args, tal_fmt(args, "-rpcuser=%s", bitcoind->rpcuser));
 
@@ -804,6 +808,7 @@ struct bitcoind *new_bitcoind(const tal_t *ctx,
 	bitcoind->rpcuser = NULL;
 	bitcoind->rpcpass = NULL;
 	bitcoind->rpcconnect = NULL;
+	bitcoind->rpcport = NULL;
 	list_head_init(&bitcoind->pending);
 	tal_add_destructor(bitcoind, destroy_bitcoind);
 

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -54,7 +54,7 @@ struct bitcoind {
 	bool shutdown;
 
 	/* Passthrough parameters for bitcoin-cli */
-	char *rpcuser, *rpcpass, *rpcconnect;
+	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
 };
 
 struct bitcoind *new_bitcoind(const tal_t *ctx,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -648,6 +648,9 @@ void register_opts(struct lightningd *ld)
 	opt_register_arg("--bitcoin-rpcconnect", opt_set_talstr, NULL,
 			 &ld->topology->bitcoind->rpcconnect,
 			 "bitcoind RPC host to connect to");
+	opt_register_arg("--bitcoin-rpcport", opt_set_talstr, NULL,
+			 &ld->topology->bitcoind->rpcport,
+			 "bitcoind RPC port");
 	opt_register_arg("--pid-file=<file>", opt_set_talstr, opt_show_charp,
 			 &ld->pidfile,
 			 "Specify pid file");


### PR DESCRIPTION
It's useful when we are connecting to a bitcoind set to a port other than default 8332