### PR TITLE
wallet: Remove pruned outpoints from utxoset outpoint_filter

### DIFF
--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -291,6 +291,10 @@ bool outpointfilter_matches(struct outpointfilter *of UNNEEDED,
 /* Generated stub for outpointfilter_new */
 struct outpointfilter *outpointfilter_new(tal_t *ctx UNNEEDED)
 { fprintf(stderr, "outpointfilter_new called!\n"); abort(); }
+/* Generated stub for outpointfilter_remove */
+void outpointfilter_remove(struct outpointfilter *of UNNEEDED,
+			   const struct bitcoin_txid *txid UNNEEDED, const u32 outnum UNNEEDED)
+{ fprintf(stderr, "outpointfilter_remove called!\n"); abort(); }
 /* Generated stub for peer_accept_channel */
 u8 *peer_accept_channel(const tal_t *ctx UNNEEDED,
 			struct lightningd *ld UNNEEDED,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2003,6 +2003,17 @@ bool wallet_network_check(struct wallet *w,
 static void wallet_utxoset_prune(struct wallet *w, const u32 blockheight)
 {
 	sqlite3_stmt *stmt;
+	struct bitcoin_txid txid;
+
+	stmt = db_prepare(w->db, "SELECT txid, outnum FROM utxoset WHERE spendheight < ?");
+	sqlite3_bind_int(stmt, 1, blockheight - UTXO_PRUNE_DEPTH);
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		sqlite3_column_sha256_double(stmt, 0, &txid.shad);
+		outpointfilter_remove(w->utxoset_outpoints, &txid, sqlite3_column_int(stmt, 1));
+	}
+	sqlite3_finalize(stmt);
+
 	stmt = db_prepare(w->db, "DELETE FROM utxoset WHERE spendheight < ?");
 	sqlite3_bind_int(stmt, 1, blockheight - UTXO_PRUNE_DEPTH);
 	db_exec_prepared(w->db, stmt);


### PR DESCRIPTION
As noted by @rustyrussell [here](https://github.com/ElementsProject/lightning/pull/1275#discussion_r176962952) I never got around to clear pruned outpoints from the filter, so this fixes that.