### PR TITLE
Fix: Overflow check mul_overflows_s64(int64_t, int64_t) overflows and triggers UB

### DIFF
--- a/common/overflows.h
+++ b/common/overflows.h
@@ -12,16 +12,6 @@ static inline bool add_overflows_u64(uint64_t a, uint64_t b)
 	return (a + b) < a;
 }
 
-static inline bool mul_overflows_s64(int64_t a, int64_t b)
-{
-	int64_t ret;
-
-	if (a == 0)
-		return false;
-	ret = a * b;
-	return (ret / a != b);
-}
-
 static inline bool mul_overflows_u64(uint64_t a, uint64_t b)
 {
 	uint64_t ret;


### PR DESCRIPTION
The overflow check `mul_overflows_s64(int64_t, int64_t)` overflows:

When doing say `mul_overflows_s64(9223372036854775807, 2)` a signed integer overflow occurs `mul_overflows_s64` when calculating `a * b`.

Since this is an signed integer overflow this triggers UB, which in turn means that we cannot trust the check.

Luckily `mul_overflows_s64(int64_t, int64_t)` is unused. Removing it.