### PR TITLE
travis: Updated docker builder images to include cppcheck

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -10,6 +10,7 @@ RUN apt-get -qq update && \
 	autoconf \
 	automake \
 	clang \
+	cppcheck \
 	eatmydata \
 	software-properties-common \
 	build-essential \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -10,6 +10,7 @@ RUN apt-get -qq update && \
 	autoconf \
 	automake \
 	clang \
+	cppcheck \
 	eatmydata \
 	software-properties-common \
 	build-essential \


### PR DESCRIPTION
It's a check dependency from PR #1262.
