### PR TITLE
.gitignore: Ignore `gossip_store` file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ gossipd/test/run-responder-success
 test/test_protocol
 test/test_sphinx
 tests/.pytest.restart
+gossip_store


### PR DESCRIPTION
This, is generated, by `make check`.
Probably better to put it in some location elsewhere, though?