### PR TITLE
Node statistics

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -150,6 +150,15 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("listchannels", payload)
 
+    def listnodestats(self, id=None):
+        """
+        Show statistics for all known nodes, accept optional node pubkey {id}
+        """
+        payload = {
+            "id": id
+        }
+        return self.call("listnodestats", payload)
+
     def invoice(self, msatoshi, label, description, expiry=None, fallback=None):
         """
         Create an invoice for {msatoshi} with {label} and {description} with

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,6 +12,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-listinvoices.7 \
+	doc/lightning-listnodestats.7 \
 	doc/lightning-listpayments.7 \
 	doc/lightning-pay.7 \
 	doc/lightning-sendpay.7 \

--- a/doc/lightning-listnodestats.7.txt
+++ b/doc/lightning-listnodestats.7.txt
@@ -1,0 +1,65 @@
+LIGHTNING-LISTNODESTATS(7)
+==========================
+:doctype: manpage
+
+NAME
+----
+lightning-listnodestats - Protocol for querying node-level statistics
+
+SYNOPSIS
+--------
+*listnodestats* ['id']
+
+DESCRIPTION
+-----------
+
+The *listnodestats* RPC command returns some node statistics and
+counters for nodes known by this node.
+
+If the 'id' is specified, information about the specific node is
+returned; the returned array is an array with a single element.
+If the specified 'id' is not found in the node statistics database,
+an error is returned.
+
+The command is intended, to provide information to automated
+programmable channel managers ("pilots") to help their
+heuristics judge good nodes to fund channels to and judge
+bad nodes to close channels with.
+
+RETURN VALUE
+------------
+
+On success, an object with a field 'nodestats' is returned.
+This field is an array of objects.
+Each object contains:
+
+* 'index' - an arbitrary numeric index unique for each node.
+* 'nodeid' - the public key (id) of the node, as a string.
+* 'time_first_seen' - the earliest time, as a Unix Epoch number,
+  that we saw this node alive.
+  Can be usd 
+* 'time_last_seen' - the latest time, as a Unix Epoch number,
+  that we saw this node alive.
+* 'forwarding_failures' - the number of times, that a payment
+  we made failed to reach the destination because this node
+  caused a failure.
+* 'connect_failures' - the number of times, that we gave up
+  on trying to connect to this node.
+* 'channel_failures' - the number of times, that a channel with
+  this node was closed due to an error on either side.
+
+If an 'id' is specified but is not found in the node statistics
+table, an error is returned.
+
+AUTHOR
+------
+
+ZmnSCPxj <ZmnSCPxj@protonmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-listinvoices(7), lightning-listpayments(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -229,6 +229,11 @@ gossipctl_peer_disconnect_replyfail,,isconnected,bool
 gossip_outpoint_spent,3024
 gossip_outpoint_spent,,short_channel_id,struct short_channel_id
 
+# Gossipd -> master:  we just received gossip about a node, so probably
+# it is still alive, so update node statistics DB last-time-node-was-seen
+gossip_nodestats_mark_seen,3025
+gossip_nodestats_mark_seen,,id,struct pubkey
+
 # gossip_store messages: messages persisted in the gossip_store
 gossip_store_channel_announcement,4096
 gossip_store_channel_announcement,,len,u16

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -164,6 +164,10 @@ struct routing_state {
 
         /* A map of channels indexed by short_channel_ids */
 	UINTMAP(struct chan *) chanmap;
+
+	/* Nodes waiting to be informed to the lightningd as being
+	 * recently seen alive. */
+	struct pubkey *nodestats_to_mark_seen;
 };
 
 static inline struct chan *
@@ -288,5 +292,15 @@ void routing_add_channel_update(struct routing_state *rstate,
  */
 bool routing_add_node_announcement(struct routing_state *rstate,
                                   const u8 *msg TAKES);
+
+/**
+ * Get public keys that will be informed to the lightningd as
+ * having been seen recently, and hence should be updated as
+ * alive.
+ * Return a tal_arr of public keys owned by the given ctx.
+ * Return NULL if nothing to inform.
+ */
+struct pubkey *routing_get_nodestats_to_mark_seen(struct routing_state *rstate,
+						  const tal_t *ctx);
 
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -80,7 +80,8 @@ LIGHTNINGD_SRC :=				\
 # Source files without corresponding headers
 LIGHTNINGD_SRC_NOHDR :=				\
 	lightningd/dev_ping.c			\
-	lightningd/memdump.c
+	lightningd/memdump.c			\
+	lightningd/nodestatsrpc.c
 
 LIGHTNINGD_OBJS := $(LIGHTNINGD_SRC:.c=.o) $(LIGHTNINGD_SRC_NOHDR:.c=.o)
 

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -312,6 +312,10 @@ void channel_fail_permanent(struct channel *channel, const char *fmt, ...)
 		channel->error = towire_errorfmt(channel, &cid, "%s", why);
 	}
 
+	/* Update channel failures for that node. */
+	wallet_nodestats_incr_channel_failures(channel->peer->ld->wallet,
+					       &channel->peer->id);
+
 	channel_set_owner(channel, NULL);
 	drop_to_chain(ld, channel);
 	tal_free(why);

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -57,6 +57,9 @@ void connect_failed(struct lightningd *ld, const struct pubkey *id,
 {
 	struct connect *i, *next;
 
+	/* Report failure to wallet node statistics. */
+	wallet_nodestats_incr_connect_failures(ld->wallet, id);
+
 	/* Careful!  Completing command frees connect. */
 	list_for_each_safe(&ld->connects, i, next, list) {
 		if (pubkey_eq(&i->id, id))

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -112,6 +112,21 @@ static void get_txout(struct subd *gossip, const u8 *msg)
 	}
 }
 
+static void
+gossip_nodestats_mark_seen(struct subd *gossip, const u8 *msg)
+{
+	struct pubkey node;
+	if (!fromwire_gossip_nodestats_mark_seen(msg, &node))
+		fatal("Gossip gave bad GOSSIP_NODESTATS_MARK_SEEN message %s",
+		      tal_hex(msg, msg));
+
+	log_debug(gossip->log,
+		  "Processing GOSSIP_NODESTATS_MARK_SEEN %s",
+		  type_to_string(tmpctx, struct pubkey, &node));
+
+	wallet_nodestats_mark_seen(gossip->ld->wallet, &node);
+}
+
 static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 {
 	enum gossip_wire_type t = fromwire_peektype(msg);
@@ -177,6 +192,9 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 		break;
 	case WIRE_GOSSIP_GET_TXOUT:
 		get_txout(gossip, msg);
+		break;
+	case WIRE_GOSSIP_NODESTATS_MARK_SEEN:
+		gossip_nodestats_mark_seen(gossip, msg);
 		break;
 	}
 	return 0;

--- a/lightningd/nodestatsrpc.c
+++ b/lightningd/nodestatsrpc.c
@@ -1,0 +1,77 @@
+#include <ccan/autodata/autodata.h>
+#include <common/json.h>
+#include <lightningd/json.h>
+#include <lightningd/jsonrpc.h>
+#include <lightningd/lightningd.h>
+#include <wallet/wallet.h>
+
+static void
+json_add_nodestats(struct json_result *result, char const *field,
+		   const struct nodestats_detail *detail)
+{
+	json_object_start(result, field);
+	json_add_u64(result, "index", detail->index);
+	json_add_pubkey(result, "nodeid", &detail->nodeid);
+	json_add_u64(result, "time_first_seen", detail->time_first_seen);
+	json_add_u64(result, "time_last_seen", detail->time_last_seen);
+	json_add_num(result, "forwarding_failures", detail->forwarding_failures);
+	json_add_num(result, "connect_failures", detail->connect_failures);
+	json_add_num(result, "channel_failures", detail->channel_failures);
+	json_object_end(result);
+}
+
+static void
+json_listnodestats(struct command *cmd,
+		   const char *buffer,
+		   const jsmntok_t *params)
+{
+	struct wallet *wallet = cmd->ld->wallet;
+	jsmntok_t *idtok;
+	struct pubkey id;
+	struct json_result *result;
+	struct nodestats_detail detail;
+	u64 it;
+
+	if (!json_get_params(cmd, buffer, params,
+			     "?id", &idtok,
+			     NULL)) {
+		return;
+	}
+
+	if (idtok && !json_tok_pubkey(buffer, idtok, &id)) {
+		command_fail(cmd, "id is not a public key: '%.*s'",
+			     idtok->end - idtok->start,
+			     buffer + idtok->start);
+		return;
+	}
+
+	result = new_json_result(cmd);
+
+	json_object_start(result, NULL);
+	json_array_start(result, "nodestats");
+	if (idtok) {
+		if (wallet_nodestats_get_by_pubkey(wallet, &detail, &id))
+			json_add_nodestats(result, NULL, &detail);
+		else {
+			command_fail(cmd, "No statistics for node");
+			return;
+		}
+	} else {
+		for (it = wallet_nodestats_iterate(wallet, 0);
+		     it != 0;
+		     it = wallet_nodestats_iterate(wallet, it)) {
+			wallet_nodestats_get_by_index(wallet, &detail, it);
+			json_add_nodestats(result, NULL, &detail);
+		}
+	}
+	json_array_end(result);
+	json_object_end(result);
+
+	command_success(cmd, result);
+}
+static const struct json_command listnodestats_command = {
+	"listnodestats",
+	&json_listnodestats,
+	"List node statistics; show single item if given node pubkey {id}"
+};
+AUTODATA(json_command, &listnodestats_command);

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -19,6 +19,7 @@ struct routing_failure {
 	enum onion_type failcode;
 	struct pubkey erring_node;
 	struct short_channel_id erring_channel;
+	struct pubkey *failing_node;
 	u8 *channel_update;
 };
 

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -7,6 +7,7 @@ wallet-wrongdir:
 WALLET_LIB_SRC :=		\
 	wallet/db.c		\
 	wallet/invoices.c	\
+	wallet/nodestats.c	\
 	wallet/txfilter.c	\
 	wallet/wallet.c		\
 	wallet/walletrpc.c

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -276,6 +276,17 @@ char *dbmigrations[] = {
     "  FROM utxoset LEFT OUTER JOIN blocks on (blockheight == blocks.height) "
     "  WHERE blocks.hash IS NULL"
     ");",
+    /* -- Node statistics -- */
+    "CREATE TABLE node_statistics"
+    "     ( id INTEGER PRIMARY KEY AUTOINCREMENT"
+    "     , nodeid BLOB UNIQUE"
+    "     , time_first_seen INTEGER"
+    "     , time_last_seen INTEGER"
+    "     , forwarding_failures INTEGER DEFAULT 0"
+    "     , connect_failures INTEGER DEFAULT 0"
+    "     , channel_failures INTEGER DEFAULT 0"
+    "     );",
+    /* -- Node statistics ends -- */
     NULL,
 };
 

--- a/wallet/nodestats.c
+++ b/wallet/nodestats.c
@@ -1,0 +1,192 @@
+#include "nodestats.h"
+#include <bitcoin/pubkey.h>
+#include <ccan/tal/str/str.h>
+#include <ccan/time/time.h>
+#include <common/utils.h>
+#include <lightningd/log.h>
+#include <wallet/db.h>
+#include <wallet/wallet.h>
+
+struct nodestats {
+	struct db *db;
+	struct log *log;
+};
+
+struct nodestats *
+nodestats_new(const tal_t *ctx,
+	      struct db *db,
+	      struct log *log)
+{
+	struct nodestats *nodestats = tal(ctx, struct nodestats);
+
+	nodestats->db = db;
+	nodestats->log = log;
+
+	return nodestats;
+}
+/* FIXME: pruning of very old nodes */
+
+/* Create an entry for the node if needed. */
+static void
+nodestats_create(struct nodestats *nodestats,
+		 const struct pubkey *pubkey)
+{
+	sqlite3_stmt *stmt;
+	u64 now = time_now().ts.tv_sec;
+
+	stmt = db_prepare(nodestats->db,
+			  "INSERT OR IGNORE INTO node_statistics"
+			  "          ( nodeid"
+			  "          , time_first_seen, time_last_seen"
+			  "          )"
+			  "   VALUES ( ?"
+			  "          , ?, ?"
+			  "          );");
+	sqlite3_bind_pubkey(stmt, 1, pubkey);
+	sqlite3_bind_int64(stmt, 2, now);
+	sqlite3_bind_int64(stmt, 3, now);
+	db_exec_prepared(nodestats->db, stmt);
+}
+
+/* Inform node statistics that we have seen this node. */
+void
+nodestats_mark_seen(struct nodestats *nodestats,
+		    const struct pubkey *pubkey)
+{
+	sqlite3_stmt *stmt;
+	u64 now;
+
+	nodestats_create(nodestats, pubkey);
+
+	now = time_now().ts.tv_sec;
+
+	stmt = db_prepare(nodestats->db,
+			  "UPDATE node_statistics"
+			  "   SET time_last_seen = ?"
+			  " WHERE nodeid = ?;");
+	sqlite3_bind_int64(stmt, 1, now);
+	sqlite3_bind_pubkey(stmt, 2, pubkey);
+	db_exec_prepared(nodestats->db, stmt);
+}
+
+/* Increment counters. */
+static void
+nodestats_incr(struct nodestats *nodestats,
+	       const struct pubkey *pubkey,
+	       const char *counter)
+{
+	sqlite3_stmt *stmt;
+
+	nodestats_create(nodestats, pubkey);
+
+	stmt = db_prepare(nodestats->db,
+			  tal_fmt(tmpctx,
+				  "UPDATE node_statistics"
+				  "   SET %s = %s + 1"
+				  " WHERE nodeid = ?;",
+				  counter, counter));
+	sqlite3_bind_pubkey(stmt, 1, pubkey);
+	db_exec_prepared(nodestats->db, stmt);
+}
+void
+nodestats_incr_forwarding_failures(struct nodestats *ns, const struct pubkey *n)
+{
+	nodestats_incr(ns, n, "forwarding_failures");
+}
+void
+nodestats_incr_connect_failures(struct nodestats *ns, const struct pubkey *n)
+{
+	nodestats_incr(ns, n, "connect_failures");
+}
+void
+nodestats_incr_channel_failures(struct nodestats *ns, const struct pubkey *n)
+{
+	nodestats_incr(ns, n, "channel_failures");
+}
+
+u64
+nodestats_iterate(struct nodestats *nodestats, u64 previndex)
+{
+	sqlite3_stmt *stmt;
+	u64 index;
+
+	stmt = db_prepare(nodestats->db,
+			  "SELECT id"
+			  "  FROM node_statistics"
+			  " WHERE id > ?"
+			  " ORDER BY id ASC LIMIT 1;");
+	sqlite3_bind_int64(stmt, 1, previndex);
+
+	if (sqlite3_step(stmt) == SQLITE_ROW)
+		index = sqlite3_column_int64(stmt, 0);
+	else
+		index = 0;
+
+	sqlite3_finalize(stmt);
+
+	return index;
+}
+
+/* Get node statistics details */
+#define nodestats_columns \
+	"id, nodeid, time_first_seen, time_last_seen, " \
+	"forwarding_failures, connect_failures, channel_failures"
+
+static void
+nodestats_stmt2detail(sqlite3_stmt *stmt, struct nodestats_detail *detail)
+{
+	detail->index = sqlite3_column_int64(stmt, 0);
+	sqlite3_column_pubkey(stmt, 1, &detail->nodeid);
+	detail->time_first_seen = sqlite3_column_int64(stmt, 2);
+	detail->time_last_seen = sqlite3_column_int64(stmt, 3);
+	detail->forwarding_failures = sqlite3_column_int(stmt, 4);
+	detail->connect_failures = sqlite3_column_int(stmt, 5);
+	detail->channel_failures = sqlite3_column_int(stmt, 6);
+}
+
+bool
+nodestats_get_by_index(struct nodestats *nodestats,
+		       struct nodestats_detail *detail,
+		       u64 index)
+{
+	sqlite3_stmt *stmt;
+	bool res;
+
+	stmt = db_prepare(nodestats->db,
+			  "SELECT " nodestats_columns
+			  "  FROM node_statistics"
+			  " WHERE id = ?;");
+	sqlite3_bind_int64(stmt, 1, index);
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		nodestats_stmt2detail(stmt, detail);
+		res = true;
+	} else
+		res = false;
+
+	sqlite3_finalize(stmt);
+
+	return res;
+}
+bool
+nodestats_get_by_pubkey(struct nodestats *nodestats,
+		       struct nodestats_detail *detail,
+		       const struct pubkey *pubkey)
+{
+	sqlite3_stmt *stmt;
+	bool res;
+
+	stmt = db_prepare(nodestats->db,
+			  "SELECT " nodestats_columns
+			  "  FROM node_statistics"
+			  " WHERE nodeid = ?;");
+	sqlite3_bind_pubkey(stmt, 1, pubkey);
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		nodestats_stmt2detail(stmt, detail);
+		res = true;
+	} else
+		res = false;
+
+	sqlite3_finalize(stmt);
+
+	return res;
+}

--- a/wallet/nodestats.h
+++ b/wallet/nodestats.h
@@ -1,0 +1,78 @@
+#ifndef LIGHTNING_WALLET_NODESTATS_H
+#define LIGHTNING_WALLET_NODESTATS_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+struct db;
+struct log;
+struct nodestats;
+struct nodestats_detail;
+struct pubkey;
+
+/**
+ * nodestats_new - Constructor for a new node statistics handler
+ *
+ * @ctx - the owner of the node statistics handler.
+ * @db - the database connection to use for tracking node statistics.
+ * @log - the log to report to.
+ */
+struct nodestats *nodestats_new(const tal_t *ctx,
+				struct db *db,
+				struct log *log);
+
+/**
+ * nodestats_mark_seen - Inform the node statistics handler that
+ * we have seen a node.
+ *
+ * @nodestats - the node statistics handler
+ * @node - the node
+ */
+void nodestats_mark_seen(struct nodestats *nodestats,
+			 const struct pubkey *node);
+
+/**
+ * nodestats_incr_* - Inform the node statistics handler to
+ * increment a counter.
+ *
+ * @nodestats - the node statistics handler
+ * @node - the node
+ */
+void nodestats_incr_forwarding_failures(struct nodestats *nodestats,
+					const struct pubkey *node);
+void nodestats_incr_connect_failures(struct nodestats *nodestats,
+				     const struct pubkey *node);
+void nodestats_incr_channel_failures(struct nodestats *nodestats,
+				     const struct pubkey *node);
+
+/**
+ * nodestats_iterate - Iterate over indices of the nodestats
+ * table.
+ *
+ * Start iteration with 0, which returns an index that can
+ * be used with nodestats_get_by_index.
+ * If this returns a 0, no more node statistics.
+ *
+ * @nodestats - the node statistics handler
+ * @previndex - Previous index.
+ */
+u64 nodestats_iterate(struct nodestats *nodestats,
+		      u64 previndex);
+
+/**
+ * nodestats_get_by_index/pubkey - Get detailed node statistics.
+ *
+ * @nodestats - the node statistics handler.
+ * @detail - the statistics to load.
+ * @index/@pubkey - key to find node.
+ *
+ * Return false if not found
+ */
+bool nodestats_get_by_index(struct nodestats *nodestats,
+			    struct nodestats_detail *detail,
+			    u64 index);
+bool nodestats_get_by_pubkey(struct nodestats *nodestats,
+			     struct nodestats_detail *detail,
+			     const struct pubkey *pubkey);
+
+#endif /* LIGHTNING_WALLET_NODESTATS_H */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -278,6 +278,41 @@ void log_io(struct log *log UNNEEDED, enum log_level dir UNNEEDED, const char *c
 /* Generated stub for new_json_result */
 struct json_result *new_json_result(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "new_json_result called!\n"); abort(); }
+/* Generated stub for nodestats_get_by_index */
+bool nodestats_get_by_index(struct nodestats *nodestats UNNEEDED,
+			    struct nodestats_detail *detail UNNEEDED,
+			    u64 index UNNEEDED)
+{ fprintf(stderr, "nodestats_get_by_index called!\n"); abort(); }
+/* Generated stub for nodestats_get_by_pubkey */
+bool nodestats_get_by_pubkey(struct nodestats *nodestats UNNEEDED,
+			     struct nodestats_detail *detail UNNEEDED,
+			     const struct pubkey *pubkey UNNEEDED)
+{ fprintf(stderr, "nodestats_get_by_pubkey called!\n"); abort(); }
+/* Generated stub for nodestats_incr_channel_failures */
+void nodestats_incr_channel_failures(struct nodestats *nodestats UNNEEDED,
+				     const struct pubkey *node UNNEEDED)
+{ fprintf(stderr, "nodestats_incr_channel_failures called!\n"); abort(); }
+/* Generated stub for nodestats_incr_connect_failures */
+void nodestats_incr_connect_failures(struct nodestats *nodestats UNNEEDED,
+				     const struct pubkey *node UNNEEDED)
+{ fprintf(stderr, "nodestats_incr_connect_failures called!\n"); abort(); }
+/* Generated stub for nodestats_incr_forwarding_failures */
+void nodestats_incr_forwarding_failures(struct nodestats *nodestats UNNEEDED,
+					const struct pubkey *node UNNEEDED)
+{ fprintf(stderr, "nodestats_incr_forwarding_failures called!\n"); abort(); }
+/* Generated stub for nodestats_iterate */
+u64 nodestats_iterate(struct nodestats *nodestats UNNEEDED,
+		      u64 previndex UNNEEDED)
+{ fprintf(stderr, "nodestats_iterate called!\n"); abort(); }
+/* Generated stub for nodestats_mark_seen */
+void nodestats_mark_seen(struct nodestats *nodestats UNNEEDED,
+			 const struct pubkey *node UNNEEDED)
+{ fprintf(stderr, "nodestats_mark_seen called!\n"); abort(); }
+/* Generated stub for nodestats_new */
+struct nodestats *nodestats_new(const tal_t *ctx UNNEEDED,
+				struct db *db UNNEEDED,
+				struct log *log UNNEEDED)
+{ fprintf(stderr, "nodestats_new called!\n"); abort(); }
 /* Generated stub for null_response */
 struct json_result *null_response(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "null_response called!\n"); abort(); }


### PR DESCRIPTION
Add node-level statistics for tracking various events:

1.  Time a node was first seen.
2.  Time a node was last seen (including successful payment attempts and successful forwards, and `node_announcement`)
3.  Number of times a node was unable to receive a payment for forwarding or final payment (`forwarding_failures`).
4.  Number of times we were unable to reach a node for connecting (`connect_failures`).
5.  Number of times a channel with a node was `error`ed by either side (`channel_failures`).

Intent is usage with automated programmable systems for managing channels ("pilot").  Hopefully node statistics can be used to judge appropriateness of a node for channeling with.

----

I am somewhat unsatisfied with how I send information that a `node_announcement` was accepted from gossipd to masterd.  What I did, was, enqueue public keys to an array in `routing_state`, and every 1 second grab the current array and send them all to masterd.  Asking also, for suggestion of alternative for this system.