### PR TITLE
Adjust loglevel for error message "Failed to get peername for incoming conn"

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1427,8 +1427,8 @@ static struct io_plan *connection_in(struct io_conn *conn, struct daemon *daemon
 	socklen_t len = sizeof(s);
 
 	if (getpeername(io_conn_fd(conn), (struct sockaddr *)&s, &len) != 0) {
-		status_unusual("Failed to get peername for incoming conn: %s",
-			       strerror(errno));
+		status_trace("Failed to get peername for incoming conn: %s",
+			     strerror(errno));
 		return io_close(conn);
 	}
 


### PR DESCRIPTION
Adjust loglevel for error message "Failed to get peername for incoming conn".

I've seen this triggered on testnet. Likely not of interest for an end-user running with the default loglevel.