### PR TITLE
Simplify version output (lightningd --version)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 #! /usr/bin/make
-NAME=Bitcoin Savings & Trust Daily Interest II
 
-# TODO: Decide: c-lightning, lightningd, lightning?
 PKGNAME = c-lightning
 
 # We use our own internal ccan copy.
@@ -291,7 +289,7 @@ ccan/config.h: ccan/tools/configurator/configurator Makefile
 	if $< --configurator-cc="$(CONFIGURATOR_CC)" $(CC) $(CFLAGS) > $@.new; then mv $@.new $@; else rm $@.new; exit 1; fi
 
 gen_version.h: FORCE
-	@(echo "#define VERSION \"`git describe --always --dirty`\"" && echo "#define VERSION_NAME \"$(NAME)\"" && echo "#define BUILD_FEATURES \"$(FEATURES)\"") > $@.new
+	@(echo "#define VERSION \"`git describe --always --dirty=-with-local-modifications`\"" && echo "#define BUILD_FEATURES \"$(FEATURES)\"") > $@.new
 	@if cmp $@.new $@ >/dev/null 2>&2; then rm -f $@.new; else mv $@.new $@; echo Version updated; fi
 
 # All binaries require the external libs, ccan

--- a/common/version.c
+++ b/common/version.c
@@ -9,8 +9,9 @@ const char *version(void)
 
 char *version_and_exit(const void *unused UNUSED)
 {
-	printf("%s\n"
-	       "aka. %s\n"
-	       "Built with: %s\n", VERSION, VERSION_NAME, BUILD_FEATURES);
+	printf("%s\n", VERSION);
+	if (BUILD_FEATURES[0]) {
+		printf("Built with features: %s\n", BUILD_FEATURES);
+	}
 	exit(0);
 }


### PR DESCRIPTION
Before this commit:

```
$ lightningd/lightningd --version
v0.5.2-2016-11-21-2451-gcd1eb52-dirty
aka. Bitcoin Savings & Trust Daily Interest II
Built with:
```
After this commit:

```
$ lightningd/lightningd --version
v0.5.2-2016-11-21-2451-gcd1eb52-with-local-modifications
```
