### PR TITLE
Add support for local socket connections

### DIFF
--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -33,7 +33,7 @@ enum wire_addr_type {
 struct wireaddr {
 	enum wire_addr_type type;
 	u8 addrlen;
-	u8 addr[16];
+	u8 addr[108];
 	u16 port;
 };
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -46,6 +46,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/un.h>
 #include <unistd.h>
 #include <wire/gen_peer_wire.h>
 #include <wire/wire_io.h>
@@ -1552,12 +1553,13 @@ static struct io_plan *connection_in(struct io_conn *conn, struct daemon *daemon
 				   init_new_peer, daemon);
 }
 
-static void setup_listeners(struct daemon *daemon, u16 portnum)
+static void setup_listeners(struct daemon *daemon, u16 portnum, const char *localsocket)
 {
 	struct sockaddr_in addr;
 	struct sockaddr_in6 addr6;
+	struct sockaddr_un sun;
 	socklen_t len;
-	int fd1, fd2;
+	int fd1, fd2, fd3;
 
 	if (!portnum) {
 		status_info("Zero portnum, not listening for incoming");
@@ -1615,6 +1617,27 @@ static void setup_listeners(struct daemon *daemon, u16 portnum)
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Could not bind to a network address on port %u",
 			      portnum);
+
+	/* Optional UNIX socket */
+	if (localsocket) {
+		memset(&sun, 0, sizeof(sun));
+		sun.sun_family = AF_UNIX;
+		strcpy(sun.sun_path, (char*)localsocket);
+
+		fd3 = make_listen_fd(AF_UNIX, &sun, sizeof(sun), false);
+		if (fd3 >= 0) {
+			len = sizeof(sun);
+			if (getsockname(fd3, (void *)&sun, &len) != 0) {
+				status_broken("Failed get UNIX sockname: %s",
+					      strerror(errno));
+				close_noerr(fd3);
+				fd3 = -1;
+			} else {
+				status_trace("Creating UNIX socket listener");
+				io_new_listener(daemon, fd3, connection_in, daemon);
+			}
+		}
+	}
 }
 
 /* Parse an incoming gossip init message and assign config variables
@@ -1653,11 +1676,12 @@ static struct io_plan *gossip_activate(struct daemon_conn *master,
 				       const u8 *msg)
 {
 	u16 port;
+	u8* localsocket;
 
-	if (!fromwire_gossipctl_activate(msg, &port))
+	if (!fromwire_gossipctl_activate(msg, msg, &port, &localsocket))
 		master_badmsg(WIRE_GOSSIPCTL_ACTIVATE, msg);
 
-	setup_listeners(daemon, port);
+	setup_listeners(daemon, port, (const char*)localsocket);
 
 	/* OK, we're ready! */
 	daemon_conn_send(&daemon->master,

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1542,6 +1542,12 @@ static struct io_plan *connection_in(struct io_conn *conn, struct daemon *daemon
 		BUILD_ASSERT(sizeof(s4->sin_addr) <= sizeof(addr.addr));
 		memcpy(addr.addr, &s4->sin_addr, addr.addrlen);
 		addr.port = ntohs(s4->sin_port);
+	} else if (s.ss_family == AF_UNIX) {
+		struct sockaddr_un *sun = (void *)&s;
+		addr.type = ADDR_TYPE_PADDING;
+		addr.addrlen = sizeof(sun->sun_path);
+		memcpy(addr.addr, &sun->sun_path, addr.addrlen);
+		addr.port = 0;
 	} else {
 		status_broken("Unknown socket type %i for incoming conn",
 			      s.ss_family);

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -23,6 +23,8 @@ gossipctl_init,,no_reconnect,bool
 gossipctl_activate,3025
 # If non-zero, port to listen on.
 gossipctl_activate,,port,u16
+gossipctl_activate,,lslen,u16
+gossipctl_activate,,localsocket,lslen*u8
 
 # Gossipd->master, I am ready.
 gossipctl_activate_reply,3125

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -227,7 +227,7 @@ static void gossip_activate_done(struct subd *gossip UNUSED,
 
 void gossip_activate(struct lightningd *ld)
 {
-	const u8 *msg = towire_gossipctl_activate(NULL, ld->portnum);
+	const u8 *msg = towire_gossipctl_activate(NULL, ld->portnum, ld->localsocket_filename);
 	subd_req(ld->gossip, ld->gossip, take(msg), -1, 0,
 		 gossip_activate_done, NULL);
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -303,6 +303,9 @@ int main(int argc, char *argv[])
 	if (!ld->daemon_dir)
 		errx(1, "Could not find daemons");
 
+	/* Don't accept local connections by default */
+	ld->localsocket_filename = NULL;
+
 	register_opts(ld);
 
 	/* Handle options and config; move to .lightningd */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -89,6 +89,9 @@ struct lightningd {
 	char *config_dir;
 	char *rpc_filename;
 
+	/* Local socket for incoming connections */
+	u8 *localsocket_filename;
+
 	/* Configuration settings. */
 	struct config config;
 


### PR DESCRIPTION
This is a flexible way to connect two instances of c-lightning via means other than the official ones. Run one side with `--localsocket=lightning-listener` and the other simply connects to the full socket path.

In practice two c-lightning instances are run on separate machines with glue code connecting to sockets and forwarding data between them.

I use this to make a lightning connection (on an otherwise disconnected device) via NFC, but can be made to support bluetooth, infrared, sound or even smoke signals, anything really. Use case would be communicating with always-connected payment terminals with a mobile device that might not be.

This is way out of lightning spec but _it doesn't seem to hurt anything_. Let me know know what you think!
 