### PR TITLE
bt_print and bt_exit is enclosed in the conditional

### DIFF
--- a/common/daemon.c
+++ b/common/daemon.c
@@ -84,10 +84,9 @@ void daemon_setup(const char *argv0,
 {
 	err_set_progname(argv0);
 
+#if BACKTRACE_SUPPORTED
 	bt_print = backtrace_print;
 	bt_exit = backtrace_exit;
-
-#if BACKTRACE_SUPPORTED
 #if DEVELOPER
 	/* Suppresses backtrace (breaks valgrind) */
 	if (!getenv("LIGHTNINGD_DEV_NO_BACKTRACE"))


### PR DESCRIPTION
Fixes: #1328

In commit https://github.com/ElementsProject/lightning/commit/feb6b52f0f83ac1f6f2a35537e6e541f9d3a3110 some conditionals were put around the declaration of `bt_print` and `bt_exit`'s declaration.  When I pull the repo down and `make` it on my system, I get the following errors:

```
common/daemon.c:87:2: error: use of undeclared identifier 'bt_print'
        bt_print = backtrace_print;
        ^
common/daemon.c:88:2: error: use of undeclared identifier 'bt_exit'
        bt_exit = backtrace_exit;
        ^
2 errors generated.
make: *** [common/daemon.o] Error 1
```

Which make sense since those declarations are not actually present.

This commit encloses the calls to `bt_print` and `bt_exit` in the `BACKTRACE_SUPPORTED` conditional.