### PR TITLE
shellcheck: restore the check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ check-cppcheck: .cppcheck-suppress
 	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs cppcheck -q --language=c --std=c11 --error-exitcode=1 --suppressions-list=.cppcheck-suppress
 
 check-shellcheck:
-	true||git ls-files -- "*.sh" | xargs shellcheck
+	git ls-files -- "*.sh" | xargs shellcheck
 
 check-source: check-makefile check-source-bolt check-whitespace check-markdown check-spelling check-python check-includes check-cppcheck check-shellcheck
 


### PR DESCRIPTION
Accidentally disabled in 9c3691340fa430ed1daf08dc40f76bd7369f66cc.
