### PR TITLE
master: Move pid-file creation after the daemonization

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -290,9 +290,6 @@ int main(int argc, char *argv[])
 	/* Handle options and config; move to .lightningd */
 	newdir = handle_opts(ld, argc, argv);
 
-	/* Create PID file */
-	pidfile_create(ld);
-
 	/* Ignore SIGPIPE: we look at our write return values*/
 	signal(SIGPIPE, SIG_IGN);
 
@@ -372,6 +369,9 @@ int main(int argc, char *argv[])
 	/* Now we're about to start, become daemon if desired. */
 	if (ld->daemon)
 		daemonize_but_keep_dir(ld);
+
+	/* Create PID file */
+	pidfile_create(ld);
 
 	/* Mark ourselves live. */
 	log_info(ld->log, "Server started with public key %s, alias %s (color #%s) and lightningd %s",


### PR DESCRIPTION
Creating the pid-file before daemonizing results in the pid-file containing the
pid of the process that started the daemon, but is now dead.

Fixes #1338