### PR TITLE
jsonrpc: Pretty-print the json results

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -269,17 +269,23 @@ static void check_fieldname(const struct json_result *result,
 		assert(fieldname);
 }
 
-static void json_start_member(struct json_result *result, const char *fieldname)
+static void result_add_indent(struct json_result *result);
+
+	static void json_start_member(struct json_result *result, const char *fieldname)
 {
 	/* Prepend comma if required. */
 	if (result->s[0]
-	    && !result_ends_with(result, "{ ")
-	    && !result_ends_with(result, "[ "))
-		result_append(result, ", ");
+	    && !result_ends_with(result, "{")
+	    && !result_ends_with(result, "["))
+		result_append(result, ", \n");
+	else
+		result_append(result, "\n");
+
+	result_add_indent(result);
 
 	check_fieldname(result, fieldname);
 	if (fieldname)
-		result_append_fmt(result, "\"%s\" : ", fieldname);
+		result_append_fmt(result, "\"%s\": ", fieldname);
 }
 
 static void result_add_indent(struct json_result *result)
@@ -289,9 +295,8 @@ static void result_add_indent(struct json_result *result)
 	if (!indent)
 		return;
 
-	result_append(result, "\n");
 	for (i = 0; i < indent; i++)
-		result_append(result, "\t");
+		result_append(result, "  ");
 }
 
 static void result_add_wrap(struct json_result *result, jsmntype_t type)
@@ -314,29 +319,31 @@ static void result_pop_wrap(struct json_result *result, jsmntype_t type)
 void json_array_start(struct json_result *result, const char *fieldname)
 {
 	json_start_member(result, fieldname);
-	result_add_indent(result);
-	result_append(result, "[ ");
+	result_append(result, "[");
 	result_add_wrap(result, JSMN_ARRAY);
 }
 
 void json_array_end(struct json_result *result)
 {
-	result_append(result, " ]");
+	result_append(result, "\n");
 	result_pop_wrap(result, JSMN_ARRAY);
+	result_add_indent(result);
+	result_append(result, "]");
 }
 
 void json_object_start(struct json_result *result, const char *fieldname)
 {
 	json_start_member(result, fieldname);
-	result_add_indent(result);
-	result_append(result, "{ ");
+	result_append(result, "{");
 	result_add_wrap(result, JSMN_OBJECT);
 }
 
 void json_object_end(struct json_result *result)
 {
-	result_append(result, " }");
+	result_append(result, "\n");
 	result_pop_wrap(result, JSMN_OBJECT);
+	result_add_indent(result);
+	result_append(result, "}");
 }
 
 void json_add_num(struct json_result *result, const char *fieldname, unsigned int value)

--- a/common/test/run-json.c
+++ b/common/test/run-json.c
@@ -100,12 +100,12 @@ static void test_json_escape(void)
 		if (i == '\\' || i == '"'
 		    || i == '\n' || i == '\r' || i == '\b'
 		    || i == '\t' || i == '\f')
-			assert(strstarts(str, "{ \"x\" : \"\\"));
-		else if (i < 32 || i == 127)
-			assert(strstarts(str, "{ \"x\" : \"\\u00"));
-		else {
-			char expect[] = "{ \"x\" : \"?\" }";
-			expect[9] = i;
+			assert(strstarts(str, "\n{\n  \"x\": \"\\"));
+		else if (i < 32 || i == 127) {
+			assert(strstarts(str, "\n{\n  \"x\": \"\\u00"));
+		} else {
+			char expect[] = "\n{\n  \"x\": \"?\"\n}";
+			expect[11] = i;
 			assert(streq(str, expect));
 		}
 		tal_free(result);


### PR DESCRIPTION
Just a small cleanup of the indentation code, so we don't have to reformat all
the issue reports to become readable. This is much closer to what `jq` or
`json_pp` spit out and doesn't have those infinitely long lines.