### PR TITLE
Some drive-by fixes

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -29,6 +29,7 @@ RUN apt-get -qq update && \
 	python3-pip \
 	python3-setuptools \
 	python-pkg-resources \
+	shellcheck \
 	wget && \
 	rm -rf /var/lib/apt/lists/*
 

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -29,6 +29,7 @@ RUN apt-get -qq update && \
 	python3-pip \
 	python3-setuptools \
 	python-pkg-resources \
+	shellcheck \
 	wget && \
 	rm -rf /var/lib/apt/lists/*
 

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1035,6 +1035,9 @@ static struct io_plan *hand_back_peer(struct io_conn *conn,
 					       &rpeer->inner_msg))
 		master_badmsg(WIRE_GOSSIPCTL_HAND_BACK_PEER, msg);
 
+	status_debug("Handing back peer %s to master",
+		     type_to_string(msg, struct pubkey, &rpeer->id));
+
 	return io_recv_fd(conn, &rpeer->peer_fd,
 			  read_returning_gossipfd, rpeer);
 }

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -2020,9 +2020,6 @@ static struct io_plan *recv_req(struct io_conn *conn, struct daemon_conn *master
 	struct daemon *daemon = container_of(master, struct daemon, master);
 	enum gossip_wire_type t = fromwire_peektype(master->msg_in);
 
-	status_trace("req: type %s len %zu",
-		     gossip_wire_type_name(t), tal_count(master->msg_in));
-
 	switch (t) {
 	case WIRE_GOSSIPCTL_INIT:
 		return gossip_init(master, daemon, master->msg_in);

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -604,6 +604,7 @@ static bool process_getblockhash_for_txout(struct bitcoin_cli *bcli)
 		   const struct bitcoin_tx_output *output,
 		   void *arg) = bcli->cb;
 	struct get_output *go = bcli->cb_arg;
+	char *blockhash;
 
 	if (*bcli->exitstatus != 0) {
 		void *cbarg = go->cbarg;
@@ -614,10 +615,11 @@ static bool process_getblockhash_for_txout(struct bitcoin_cli *bcli)
 		return true;
 	}
 
+	/* Strip the newline at the end of the previous output */
+	blockhash = tal_strndup(NULL, bcli->output, bcli->output_bytes-1);
+
 	start_bitcoin_cli(bcli->bitcoind, NULL, process_getblock, false, cb, go,
-			  "getblock",
-			  take(tal_strndup(NULL, bcli->output,bcli->output_bytes)),
-			  NULL);
+			  "getblock", take(blockhash), NULL);
 	return true;
 }
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -271,8 +271,8 @@ class LightningDTests(BaseLightningDTests):
 
         assert ret['id'] == l2.info['id']
 
-        l1.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l1.daemon.wait_for_log('Handing back peer .* to master')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
         return l1, l2
 
     # Waits until l1 notices funds
@@ -1148,8 +1148,8 @@ class LightningDTests(BaseLightningDTests):
 
         assert ret['id'] == l2.info['id']
 
-        l1.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l1.daemon.wait_for_log('Handing back peer .* to master')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
 
         self.give_funds(l1, 10**6 + 1000000)
         self.assertRaises(ValueError, l1.rpc.fundchannel, l2.info['id'], 10**6)
@@ -2434,7 +2434,7 @@ class LightningDTests(BaseLightningDTests):
 
         assert ret['id'] == l3.info['id']
 
-        l3.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l3.daemon.wait_for_log('Handing back peer .* to master')
         self.fund_channel(l1, l2, 10**6)
         self.fund_channel(l2, l3, 10**6)
 
@@ -2529,14 +2529,14 @@ class LightningDTests(BaseLightningDTests):
         ret = l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
         assert ret['id'] == l2.info['id']
 
-        l1.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l1.daemon.wait_for_log('Handing back peer .* to master')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
 
         ret = l2.rpc.connect(l3.info['id'], 'localhost', l3.info['port'])
         assert ret['id'] == l3.info['id']
 
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l3.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
+        l3.daemon.wait_for_log('Handing back peer .* to master')
 
         c1 = self.fund_channel(l1, l2, 10**6)
         c2 = self.fund_channel(l2, l3, 10**6)
@@ -2633,14 +2633,14 @@ class LightningDTests(BaseLightningDTests):
         ret = l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
         assert ret['id'] == l2.info['id']
 
-        l1.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l1.daemon.wait_for_log('Handing back peer .* to master')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
 
         ret = l2.rpc.connect(l3.info['id'], 'localhost', l3.info['port'])
         assert ret['id'] == l3.info['id']
 
-        l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-        l3.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+        l2.daemon.wait_for_log('Handing back peer .* to master')
+        l3.daemon.wait_for_log('Handing back peer .* to master')
 
         c1 = self.fund_channel(l1, l2, 10**6)
         c2 = self.fund_channel(l2, l3, 10**6)
@@ -4056,8 +4056,8 @@ class LightningDTests(BaseLightningDTests):
             ret = l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
             assert ret['id'] == l2.info['id']
 
-            l1.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
-            l2.daemon.wait_for_log('WIRE_GOSSIPCTL_HAND_BACK_PEER')
+            l1.daemon.wait_for_log('Handing back peer .* to master')
+            l2.daemon.wait_for_log('Handing back peer .* to master')
             self.fund_channel(l1, l2, 10**6)
 
             l1.rpc.close(l2.info['id'])

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4227,7 +4227,7 @@ class LightningDTests(BaseLightningDTests):
         # and we try to add a block twice when rescanning:
         l1.restart()
 
-        # At height 442 we receive an incoming payment
+        # At height 111 we receive an incoming payment
         hashes = btc.rpc.generate(9)
         btc.rpc.sendtoaddress(addr, 1)
         time.sleep(1)  # mempool is still unpredictable
@@ -4240,15 +4240,17 @@ class LightningDTests(BaseLightningDTests):
         ######################################################################
         # Second failure scenario: perform a 20 block reorg
         btc.rpc.generate(10)
-        blockheight = btc.rpc.getblockcount()
-        wait_for(lambda: l1.rpc.dev_blockheight()['blockheight'] == blockheight)
+        btc.rpc.getblockcount()
+        l1.daemon.wait_for_log(r'Adding block 121: [a-f0-9]{32}')
 
         # Now reorg out with a longer fork of 21 blocks
         btc.rpc.invalidateblock(hashes[0])
-        hashes = btc.rpc.generate(21)
+        btc.wait_for_log(r'InvalidChainFound: invalid block=.*  height=102')
+        hashes = btc.rpc.generate(30)
+        time.sleep(1)
 
-        blockheight = btc.rpc.getblockcount()
-        wait_for(lambda: l1.rpc.dev_blockheight()['blockheight'] == blockheight)
+        btc.rpc.getblockcount()
+        l1.daemon.wait_for_log(r'Adding block 131: [a-f0-9]{32}')
 
         # Our funds got reorged out, we should not have any funds that are confirmed
         assert [o for o in l1.rpc.listfunds()['outputs'] if o['status'] != "unconfirmed"] == []

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -746,7 +746,7 @@ struct pubkey *sqlite3_column_pubkey_array(const tal_t *ctx,
 		return NULL;
 
 	n = sqlite3_column_bytes(stmt, col) / PUBKEY_DER_LEN;
-	assert(n * PUBKEY_DER_LEN == sqlite3_column_bytes(stmt, col));
+	assert(n * PUBKEY_DER_LEN == (size_t)sqlite3_column_bytes(stmt, col));
 	ret = tal_arr(ctx, struct pubkey, n);
 	ders = sqlite3_column_blob(stmt, col);
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -826,6 +826,10 @@ u32 wallet_first_blocknum(struct wallet *w, u32 first_possible)
 	first_utxo = db_get_intvar(w->db, "last_processed_block", UINT32_MAX);
 #endif
 
+	/* Never go below the start of the Lightning Network */
+	if (first_utxo < first_possible)
+		first_utxo = first_possible;
+
 	if (first_utxo < first_channel)
 		return first_utxo;
 	else


### PR DESCRIPTION
A number of fixes that are not really big enough to warrant their own PRs.

 - Update the builder images to include `shellcheck`
 - Some warnings
 - An attempt to fix the flaky `test_blockchaintrack` test by ensuring rollback is complete before proceeding
 - A less noisy `gossipd` to be less annoying during block rescan
 - Lowerbound rescan to the start of LN, otherwise repeated restarts will back off indefinitely
 - Don't copy newline when looking up a block for a `txout`