### PR TITLE
wallet, payalgo: Save detail of payment failures for later reporting.

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -290,6 +290,12 @@ char *dbmigrations[] = {
     "     , msatoshi_to_us_max = msatoshi_local"
     "     ;",
     /* -- Min and max msatoshi_to_us ends -- */
+    /* -- Detailed payment failure -- */
+    "ALTER TABLE payments ADD faildetail TEXT;",
+    "UPDATE payments"
+    "   SET faildetail = 'unspecified payment failure reason'"
+    " WHERE status = 2;", /* PAYMENT_FAILED */
+    /* -- Detailed payment faiure ends -- */
     NULL,
 };
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -11,6 +11,7 @@
 #include <lightningd/log.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/peer_htlcs.h>
+#include <string.h>
 
 #define SQLITE_MAX_UINT 0x7FFFFFFFFFFFFFFF
 #define DIRECTION_INCOMING 0
@@ -1766,7 +1767,8 @@ void wallet_payment_get_failinfo(const tal_t *ctx,
 				 enum onion_type *failcode,
 				 struct pubkey **failnode,
 				 struct short_channel_id **failchannel,
-				 u8 **failupdate)
+				 u8 **failupdate,
+				 char **faildetail)
 {
 	sqlite3_stmt *stmt;
 	int res;
@@ -1777,7 +1779,7 @@ void wallet_payment_get_failinfo(const tal_t *ctx,
 			  "SELECT failonionreply, faildestperm"
 			  "     , failindex, failcode"
 			  "     , failnode, failchannel"
-			  "     , failupdate"
+			  "     , failupdate, faildetail"
 			  "  FROM payments"
 			  " WHERE payment_hash=?;");
 	sqlite3_bind_sha256(stmt, 1, payment_hash);
@@ -1814,6 +1816,8 @@ void wallet_payment_get_failinfo(const tal_t *ctx,
 		*failupdate = tal_arr(ctx, u8, len);
 		memcpy(*failupdate, sqlite3_column_blob(stmt, 6), len);
 	}
+	*faildetail = tal_strndup(ctx, sqlite3_column_blob(stmt, 7),
+				  sqlite3_column_bytes(stmt, 7));
 
 	sqlite3_finalize(stmt);
 }
@@ -1826,7 +1830,8 @@ void wallet_payment_set_failinfo(struct wallet *wallet,
 				 enum onion_type failcode,
 				 const struct pubkey *failnode,
 				 const struct short_channel_id *failchannel,
-				 const u8 *failupdate /*tal_arr*/)
+				 const u8 *failupdate /*tal_arr*/,
+				 const char *faildetail)
 {
 	sqlite3_stmt *stmt;
 
@@ -1839,6 +1844,7 @@ void wallet_payment_set_failinfo(struct wallet *wallet,
 			  "     , failnode=?"
 			  "     , failchannel=?"
 			  "     , failupdate=?"
+			  "     , faildetail=?"
 			  " WHERE payment_hash=?;");
 	if (failonionreply)
 		sqlite3_bind_blob(stmt, 1,
@@ -1867,8 +1873,11 @@ void wallet_payment_set_failinfo(struct wallet *wallet,
 				  SQLITE_TRANSIENT);
 	else
 		sqlite3_bind_null(stmt, 7);
+	sqlite3_bind_blob(stmt, 8,
+			  faildetail, strlen(faildetail),
+			  SQLITE_TRANSIENT);
 
-	sqlite3_bind_sha256(stmt, 8, payment_hash);
+	sqlite3_bind_sha256(stmt, 9, payment_hash);
 
 	db_exec_prepared(wallet->db, stmt);
 }

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -735,7 +735,8 @@ void wallet_payment_get_failinfo(const tal_t *ctx,
 				 enum onion_type *failcode,
 				 struct pubkey **failnode,
 				 struct short_channel_id **failchannel,
-				 u8 **failupdate);
+				 u8 **failupdate,
+				 char **faildetail);
 /**
  * wallet_payment_set_failinfo - Set failure information for a given
  * `payment_hash`.
@@ -748,7 +749,8 @@ void wallet_payment_set_failinfo(struct wallet *wallet,
 				 enum onion_type failcode,
 				 const struct pubkey *failnode,
 				 const struct short_channel_id *failchannel,
-				 const u8 *failupdate);
+				 const u8 *failupdate,
+				 const char *faildetail);
 
 /**
  * wallet_payment_list - Retrieve a list of payments


### PR DESCRIPTION
Pointless for remote failures as those are never sent by
the erring node, but for local failures we can give more
detail.