### PR TITLE
Demote 'Announcement X was replaced' to status_unusual

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -621,9 +621,8 @@ void routing_add_channel_announcement(struct routing_state *rstate,
 
 	if (replace_broadcast(chan, rstate->broadcasts,
 			      &chan->channel_announce_msgidx, take(msg)))
-		status_failed(STATUS_FAIL_INTERNAL_ERROR,
-			      "Announcement %s was replaced?",
-			      tal_hex(tmpctx, msg));
+    status_unusual("Announcement %s was replaced?",
+                   tal_hex(tmpctx, msg));
 }
 
 u8 *handle_channel_announcement(struct routing_state *rstate,


### PR DESCRIPTION
Workaround for #1334.

Although my node has been running fine with it for days, apparently this isn't without risk, as @cdecker wrote:

>  Not making the error fatal results in null-pointers later in the execution, which is really strange

Removing `gossip_store` in `~/.lightning` as suggested by @ZmnSCPxj is probably safer.