### PR TITLE
routing: Use 64-bit msatoshi for messages to and from routing.

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1097,7 +1097,8 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 				    u8 *msg)
 {
 	struct pubkey source, destination;
-	u32 msatoshi, final_cltv;
+	u64 msatoshi;
+	u32 final_cltv;
 	u16 riskfactor;
 	u8 *out;
 	struct route_hop *hops;
@@ -1108,7 +1109,7 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 					 &source, &destination,
 					 &msatoshi, &riskfactor, &final_cltv,
 					 &fuzz, &seed);
-	status_trace("Trying to find a route from %s to %s for %d msatoshi",
+	status_trace("Trying to find a route from %s to %s for %"PRIu64" msatoshi",
 		     pubkey_to_hexstr(tmpctx, &source),
 		     pubkey_to_hexstr(tmpctx, &destination), msatoshi);
 

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -104,7 +104,7 @@ gossip_getnodes_reply,,nodes,num_nodes*struct gossip_getnodes_entry
 gossip_getroute_request,3006
 gossip_getroute_request,,source,struct pubkey
 gossip_getroute_request,,destination,struct pubkey
-gossip_getroute_request,,msatoshi,u32
+gossip_getroute_request,,msatoshi,u64
 gossip_getroute_request,,riskfactor,u16
 gossip_getroute_request,,final_cltv,u32
 gossip_getroute_request,,fuzz,double

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1233,7 +1233,7 @@ u8 *handle_node_announcement(struct routing_state *rstate, const u8 *node_ann)
 struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    const struct pubkey *source,
 			    const struct pubkey *destination,
-			    const u32 msatoshi, double riskfactor,
+			    const u64 msatoshi, double riskfactor,
 			    u32 final_cltv,
 			    double fuzz, const struct siphash_seed *base_seed)
 {

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -176,7 +176,7 @@ get_channel(const struct routing_state *rstate,
 struct route_hop {
 	struct short_channel_id channel_id;
 	struct pubkey nodeid;
-	u32 amount;
+	u64 amount;
 	u32 delay;
 };
 
@@ -238,7 +238,7 @@ struct node *get_node(struct routing_state *rstate, const struct pubkey *id);
 struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    const struct pubkey *source,
 			    const struct pubkey *destination,
-			    const u32 msatoshi, double riskfactor,
+			    const u64 msatoshi, double riskfactor,
 			    u32 final_cltv,
 			    double fuzz,
 			    const struct siphash_seed *base_seed);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -54,14 +54,14 @@ void fromwire_route_hop(const u8 **pptr, size_t *max, struct route_hop *entry)
 {
 	fromwire_pubkey(pptr, max, &entry->nodeid);
 	fromwire_short_channel_id(pptr, max, &entry->channel_id);
-	entry->amount = fromwire_u32(pptr, max);
+	entry->amount = fromwire_u64(pptr, max);
 	entry->delay = fromwire_u32(pptr, max);
 }
 void towire_route_hop(u8 **pptr, const struct route_hop *entry)
 {
 	towire_pubkey(pptr, &entry->nodeid);
 	towire_short_channel_id(pptr, &entry->channel_id);
-	towire_u32(pptr, entry->amount);
+	towire_u64(pptr, entry->amount);
 	towire_u32(pptr, entry->delay);
 }
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -741,7 +741,7 @@ send_payment(const tal_t *ctx,
 				    sizeof(struct sha256), &path_secrets);
 	onion = serialize_onionpacket(tmpctx, packet);
 
-	log_info(ld->log, "Sending %u over %zu hops to deliver %"PRIu64"",
+	log_info(ld->log, "Sending %"PRIu64" over %zu hops to deliver %"PRIu64"",
 		 route[0].amount, n_hops, msatoshi);
 
 	failcode = send_htlc_out(channel, route[0].amount,
@@ -969,7 +969,7 @@ static void json_sendpay(struct command *cmd,
 		tal_resize(&route, n_hops + 1);
 
 		/* What that hop will forward */
-		if (!json_tok_number(buffer, amttok, &route[n_hops].amount)) {
+		if (!json_tok_u64(buffer, amttok, &route[n_hops].amount)) {
 			command_fail(cmd, "Route %zu invalid msatoshi",
 				     n_hops);
 			return;

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -362,7 +362,7 @@ static char const *stringify_route(const tal_t *ctx, struct route_hop *route)
 	size_t i;
 	char *rv = tal_strdup(ctx, "us");
 	for (i = 0; i < tal_count(route); ++i)
-		tal_append_fmt(&rv, " -> %s (%"PRIu32"msat, %"PRIu32"blk) -> %s",
+		tal_append_fmt(&rv, " -> %s (%"PRIu64"msat, %"PRIu32"blk) -> %s",
 			       type_to_string(ctx, struct short_channel_id, &route[i].channel_id),
 			       route[i].amount, route[i].delay,
 			       type_to_string(ctx, struct pubkey, &route[i].nodeid));


### PR DESCRIPTION
Fixes: #1344

Internally both payment and routing use 64-bit, but the interface
between them used 32-bit.
Since both components already support 64-bit we should use that.