### PR TITLE
peer_control: Make close wait for complete closure, with timeout.

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -333,12 +333,16 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel", payload)
 
-    def close(self, peer_id):
+    def close(self, peer_id, force=None, timeout=None):
         """
-        Close the channel with peer {id}
+        Close the channel with peer {id}, forcing a unilateral
+        close if {force} is True, and timing out with {timeout}
+        seconds.
         """
         payload = {
-            "id": peer_id
+            "id": peer_id,
+            "force": force,
+            "timeout": timeout
         }
         return self.call("close", payload)
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,6 +6,7 @@ doc-wrongdir:
 
 MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-autocleaninvoice.7 \
+	doc/lightning-close.7 \
 	doc/lightning-decodepay.7 \
 	doc/lightning-delexpiredinvoice.7 \
 	doc/lightning-delinvoice.7 \

--- a/doc/lightning-close.7
+++ b/doc/lightning-close.7
@@ -1,0 +1,59 @@
+'\" t
+.\"     Title: lightning-close
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/15/2018
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-CLOSE" "7" "04/15/2018" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-close \- Protocol for closing channels with direct peers
+.SH "SYNOPSIS"
+.sp
+\fBclose\fR \fIid\fR [\fIforce\fR] [\fItimeout\fR]
+.SH "DESCRIPTION"
+.sp
+The \fBclose\fR RPC command attempts to close the channel cooperatively with the peer\&. It applies to the active channel of the direct peer corresponding to the given peer \fIid\fR\&.
+.sp
+The \fBclose\fR command will time out and return with an error when the number of seconds specified in \fItimeout\fR is reached\&. If unspecified, it times out in 30 seconds\&.
+.sp
+The \fIforce\fR argument, if the JSON value \fItrue\fR, will cause the channel to be unilaterally closed when the timeout is reached\&. If so, timeout will not cause an error, but instead cause the channel to be failed and put onchain unilaterally\&. Unilateral closes will lead to your funds getting locked according to the \fIto_self_delay\fR parameter of the peer\&.
+.sp
+Normally the peer needs to be live and connected in order to negotiate a mutual close\&. Forcing a unilateral close can be used if you suspect you can no longer contact the peer\&.
+.SH "RETURN VALUE"
+.sp
+On success, an object with fields \fItx\fR and \fItxid\fR containing the closing transaction are returned\&. It will also have a field \fItype\fR which is either the JSON string \fImutual\fR or the JSON string \fIunilateral\fR\&. A \fImutual\fR close means that we could negotiate a close with the peer, while a \fIunilateral\fR close means that the \fIforce\fR flag was set and we had to close the channel without waiting for the counterparty\&.
+.sp
+A unilateral close may still occur with \fIforce\fR set to \fIfalse\fR if the peer did not behave correctly during the close negotiation\&.
+.sp
+Unilateral closes will return your funds after a delay\&. The delay will vary based on the peer \fIto_self_delay\fR setting, not your own setting\&.
+.sp
+On failure, if \fBclose\fR failed due to timing out with \fIforce\fR argument \fIfalse\fR, the channel will still eventually close once we have contacted the peer\&.
+.SH "AUTHOR"
+.sp
+ZmnSCPxj <ZmnSCPxj@protonmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-close.7.txt
+++ b/doc/lightning-close.7.txt
@@ -1,0 +1,70 @@
+LIGHTNING-CLOSE(7)
+==================
+:doctype: manpage
+
+NAME
+----
+lightning-close - Protocol for closing channels with direct peers
+
+SYNOPSIS
+--------
+*close* 'id' ['force'] ['timeout']
+
+DESCRIPTION
+-----------
+
+The *close* RPC command attempts to close the channel cooperatively
+with the peer.
+It applies to the active channel of the direct peer corresponding to
+the given peer 'id'.
+
+The *close* command will time out and return with an error when the
+number of seconds specified in 'timeout' is reached.
+If unspecified, it times out in 30 seconds.
+
+The 'force' argument, if the JSON value 'true', will cause the
+channel to be unilaterally closed when the timeout is reached.
+If so, timeout will not cause an error, but instead cause the
+channel to be failed and put onchain unilaterally.
+Unilateral closes will lead to your funds getting locked according
+to the 'to_self_delay' parameter of the peer.
+
+Normally the peer needs to be live and connected in order to negotiate
+a mutual close.
+Forcing a unilateral close can be used if you suspect you can no longer
+contact the peer.
+
+RETURN VALUE
+------------
+
+On success, an object with fields 'tx' and 'txid' containing the
+closing transaction are returned.
+It will also have a field 'type' which is either the JSON string
+'mutual' or the JSON string 'unilateral'.
+A 'mutual' close means that we could negotiate a close with the
+peer, while a 'unilateral' close means that the 'force' flag was
+set and we had to close the channel without waiting for the
+counterparty.
+
+A unilateral close may still occur with 'force' set to 'false' if
+the peer did not behave correctly during the close negotiation.
+
+Unilateral closes will return your funds after a delay.
+The delay will vary based on the peer 'to_self_delay' setting, not
+your own setting.
+
+On failure, if *close* failed due to timing out with 'force'
+argument 'false', the channel will still eventually close once
+we have contacted the peer.
+
+AUTHOR
+------
+ZmnSCPxj <ZmnSCPxj@protonmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -321,7 +321,8 @@ void channel_fail_permanent(struct channel *channel, const char *fmt, ...)
 	}
 
 	channel_set_owner(channel, NULL);
-	drop_to_chain(ld, channel);
+	/* Drop non-cooperatively (unilateral) to chain. */
+	drop_to_chain(ld, channel, false);
 	tal_free(why);
 }
 

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -93,7 +93,8 @@ static void peer_closing_complete(struct channel *channel, const u8 *msg)
 	if (channel->state == CLOSINGD_COMPLETE)
 		return;
 
-	drop_to_chain(channel->peer->ld, channel);
+	/* Channel gets dropped to chain cooperatively. */
+	drop_to_chain(channel->peer->ld, channel, true);
 	channel_set_state(channel, CLOSINGD_SIGEXCHANGE, CLOSINGD_COMPLETE);
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -68,6 +68,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	list_head_init(&ld->connects);
 	list_head_init(&ld->waitsendpay_commands);
 	list_head_init(&ld->sendpay_commands);
+	list_head_init(&ld->close_commands);
 	ld->wireaddrs = tal_arr(ld, struct wireaddr, 0);
 	ld->portnum = DEFAULT_PORT;
 	timers_init(&ld->timers, time_mono());

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -138,6 +138,8 @@ struct lightningd {
 	struct list_head waitsendpay_commands;
 	/* Outstanding sendpay commands. */
 	struct list_head sendpay_commands;
+	/* Outstanding close commands. */
+	struct list_head close_commands;
 
 	/* Maintained by invoices.c */
 	struct invoices *invoices;

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -102,7 +102,7 @@ u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx);
 /* We've loaded peers from database, set them going. */
 void activate_peers(struct lightningd *ld);
 
-void drop_to_chain(struct lightningd *ld, struct channel *channel);
+void drop_to_chain(struct lightningd *ld, struct channel *channel, bool cooperative);
 
 /* Get range of feerates to insist other side abide by for normal channels. */
 u32 feerate_min(struct lightningd *ld);

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1333,10 +1333,16 @@ class LightningDTests(BaseLightningDTests):
                 self.pay(l1, p, 100000000)
 
         # Now close
-        closes = [self.executor.submit(l1.rpc.close, p.info['id']) for p in peers]
+        # All closes occur in parallel, and on Travis,
+        # ALL those lightningd are running on a single core,
+        # so increase the timeout so that this test will pass
+        # when valgrind is enabled.
+        # (close timeout defaults to 30 as of this writing, more
+        # than double the default)
+        closes = [self.executor.submit(l1.rpc.close, p.info['id'], False, 72) for p in peers]
 
         for c in closes:
-            c.result(30)
+            c.result(72)
 
         bitcoind.generate_block(1)
         for p in peers:

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1180,8 +1180,10 @@ class LightningDTests(BaseLightningDTests):
             billboard = l1.rpc.listpeers(l2.info['id'])['peers'][0]['channels'][0]['status']
             assert billboard == ['CHANNELD_NORMAL:Funding transaction locked. Channel announced.']
 
-        # This should return, then close.
-        l1.rpc.close(l2.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
         l2.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
 
@@ -1306,7 +1308,9 @@ class LightningDTests(BaseLightningDTests):
 
         # Now close
         for p in peers:
-            l1.rpc.close(p.info['id'])
+            self.assertRaisesRegex(ValueError,
+                                   "Channel close negotiation not finished",
+                                   l1.rpc.close, p.info['id'], False, 0)
 
         for p in peers:
             p.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
@@ -3088,8 +3092,10 @@ class LightningDTests(BaseLightningDTests):
 
         assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 0
 
-        # This should return, then close.
-        l1.rpc.close(l2.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
         l2.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
 
@@ -3114,7 +3120,10 @@ class LightningDTests(BaseLightningDTests):
         l1.daemon.wait_for_log('sendrawtx exit 0')
         bitcoind.generate_block(1)
 
-        l1.rpc.close(l2.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log('CHANNELD_AWAITING_LOCKIN to CHANNELD_SHUTTING_DOWN')
         l2.daemon.wait_for_log('CHANNELD_AWAITING_LOCKIN to CHANNELD_SHUTTING_DOWN')
 
@@ -3149,8 +3158,10 @@ class LightningDTests(BaseLightningDTests):
 
         assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 0
 
-        # This should return, then close.
-        l1.rpc.close(l2.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
         l2.daemon.wait_for_log(' to CHANNELD_SHUTTING_DOWN')
 
@@ -3808,7 +3819,9 @@ class LightningDTests(BaseLightningDTests):
         self.pay(l2, l1, 100000000)
 
         # Now shutdown cleanly.
-        l1.rpc.close(l2.info['id'])
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
         l2.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
 
@@ -3852,8 +3865,10 @@ class LightningDTests(BaseLightningDTests):
         l1.rpc.dev_setfees()
         l1.daemon.wait_for_log('dev-setfees: fees now 21098/7654/321')
 
-        # Now shutdown cleanly.
-        l1.rpc.close(l2.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
         l2.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
 
@@ -3892,8 +3907,10 @@ class LightningDTests(BaseLightningDTests):
         # 15sat/byte fee
         l1.daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
 
-        # Now shutdown cleanly.
-        l1.rpc.close(l3.info['id'])
+        # This should return with an error, then close.
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l3.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
         l3.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
 
@@ -3924,7 +3941,9 @@ class LightningDTests(BaseLightningDTests):
         assert l2.daemon.is_in_log('got commitsig [0-9]*: feerate 14000')
 
         # Now shutdown cleanly.
-        l1.rpc.close(l2.info['id'])
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
         l2.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
 
@@ -4060,7 +4079,9 @@ class LightningDTests(BaseLightningDTests):
             l2.daemon.wait_for_log('Handing back peer .* to master')
             self.fund_channel(l1, l2, 10**6)
 
-            l1.rpc.close(l2.info['id'])
+            self.assertRaisesRegex(ValueError,
+                                   "Channel close negotiation not finished",
+                                   l1.rpc.close, l2.info['id'], False, 0)
             l1.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
             l2.daemon.wait_for_log(' to CLOSINGD_COMPLETE')
 
@@ -4205,7 +4226,9 @@ class LightningDTests(BaseLightningDTests):
         assert l1.rpc.getpeer(l2.info['id'])['color'] == l1.rpc.listnodes(l2.info['id'])['nodes'][0]['color']
 
         # Close the channel to forget the peer
-        l1.rpc.close(l2.info['id'])
+        self.assertRaisesRegex(ValueError,
+                               "Channel close negotiation not finished",
+                               l1.rpc.close, l2.info['id'], False, 0)
         l1.daemon.wait_for_log('Forgetting remote peer')
         bitcoind.generate_block(100)
         l1.daemon.wait_for_log('WIRE_ONCHAIN_ALL_IRREVOCABLY_RESOLVED')

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -253,6 +253,10 @@ bool json_tok_bool(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, b
 bool json_tok_loglevel(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 		       enum log_level *level UNNEEDED)
 { fprintf(stderr, "json_tok_loglevel called!\n"); abort(); }
+/* Generated stub for json_tok_number */
+bool json_tok_number(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		     unsigned int *num UNNEEDED)
+{ fprintf(stderr, "json_tok_number called!\n"); abort(); }
 /* Generated stub for json_tok_pubkey */
 bool json_tok_pubkey(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 		     struct pubkey *pubkey UNNEEDED)


### PR DESCRIPTION
Also report tx and txid, and whether we closed unilaterally or
bilaterally, if we could close the channel.

Also make a manpage.

Fixes: #1207
Fixes: #714
Fixes: #622