### PR TITLE
closingd: Correct whose turn it is when moving from initial negotiation to continuous negotiation.

### DIFF
--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -338,7 +338,8 @@ struct feerange {
 
 static void init_feerange(struct feerange *feerange,
 			  u64 commitment_fee,
-			  const u64 offer[NUM_SIDES])
+			  const u64 offer[NUM_SIDES],
+			  bool allow_mistakes)
 {
 	feerange->min = 0;
 
@@ -349,6 +350,7 @@ static void init_feerange(struct feerange *feerange,
          *    in [BOLT #3](03-transactions.md#fee-calculation).
 	 */
 	feerange->max = commitment_fee;
+	feerange->allow_mistakes = allow_mistakes;
 
 	if (offer[LOCAL] > offer[REMOTE])
 		feerange->higher_side = LOCAL;
@@ -526,7 +528,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Now we have first two points, we can init fee range. */
-	init_feerange(&feerange, commitment_fee, offer);
+	init_feerange(&feerange, commitment_fee, offer, deprecated_api);
 
 	/* Now apply the one constraint from above (other is inside loop). */
 	adjust_feerange(&cs, gossip_index, &channel_id, &feerange,

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -530,18 +530,12 @@ int main(int argc, char *argv[])
 	/* Now we have first two points, we can init fee range. */
 	init_feerange(&feerange, commitment_fee, offer, deprecated_api);
 
-	/* Now apply the one constraint from above (other is inside loop). */
-	adjust_feerange(&cs, gossip_index, &channel_id, &feerange,
-			offer[!whose_turn], !whose_turn);
-
 	/* Now any extra rounds required. */
 	while (offer[LOCAL] != offer[REMOTE]) {
-		/* If they differ, adjust feerate. */
-		adjust_feerange(&cs, gossip_index, &channel_id, &feerange,
-				offer[whose_turn], whose_turn);
-
-		/* Now its the other side's turn. */
-		whose_turn = !whose_turn;
+		/* Still don't agree: adjust feerange based on previous offer */
+		adjust_feerange(&cs, gossip_index, &channel_id,
+				&feerange,
+				offer[!whose_turn], !whose_turn);
 
 		if (whose_turn == LOCAL) {
 			offer[LOCAL] = adjust_offer(&cs, gossip_index,
@@ -570,6 +564,8 @@ int main(int argc, char *argv[])
 						our_dust_limit,
 						min_fee_to_accept);
 		}
+
+		whose_turn = !whose_turn;
 	}
 
 	peer_billboard(true, "We agreed on a closing fee of %"PRIu64" satoshi",

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -338,8 +338,7 @@ struct feerange {
 
 static void init_feerange(struct feerange *feerange,
 			  u64 commitment_fee,
-			  const u64 offer[NUM_SIDES],
-			  bool allow_mistakes)
+			  const u64 offer[NUM_SIDES])
 {
 	feerange->min = 0;
 
@@ -350,7 +349,7 @@ static void init_feerange(struct feerange *feerange,
          *    in [BOLT #3](03-transactions.md#fee-calculation).
 	 */
 	feerange->max = commitment_fee;
-	feerange->allow_mistakes = allow_mistakes;
+	feerange->allow_mistakes = false;
 
 	if (offer[LOCAL] > offer[REMOTE])
 		feerange->higher_side = LOCAL;
@@ -528,11 +527,14 @@ int main(int argc, char *argv[])
 	}
 
 	/* Now we have first two points, we can init fee range. */
-	init_feerange(&feerange, commitment_fee, offer, deprecated_api);
+	init_feerange(&feerange, commitment_fee, offer);
 
 	/* Apply (and check) funder offer now. */
 	adjust_feerange(&cs, gossip_index, &channel_id,
 			&feerange, offer[funder], funder);
+
+	/* Older spec clients would make offers independently, so allow */
+	feerange.allow_mistakes = deprecated_api;
 
 	/* Now any extra rounds required. */
 	while (offer[LOCAL] != offer[REMOTE]) {

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -530,6 +530,10 @@ int main(int argc, char *argv[])
 	/* Now we have first two points, we can init fee range. */
 	init_feerange(&feerange, commitment_fee, offer, deprecated_api);
 
+	/* Apply (and check) funder offer now. */
+	adjust_feerange(&cs, gossip_index, &channel_id,
+			&feerange, offer[funder], funder);
+
 	/* Now any extra rounds required. */
 	while (offer[LOCAL] != offer[REMOTE]) {
 		/* Still don't agree: adjust feerange based on previous offer */

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -21,8 +21,7 @@ static bool better_closing_fee(struct lightningd *ld,
 			       struct channel *channel,
 			       const struct bitcoin_tx *tx)
 {
-	u64 weight, fee, last_fee, ideal_fee, min_fee;
-	s64 old_diff, new_diff;
+	u64 weight, fee, last_fee, min_fee;
 	size_t i;
 
 	/* Calculate actual fee (adds in eliminated outputs) */
@@ -49,23 +48,9 @@ static bool better_closing_fee(struct lightningd *ld,
 		return false;
 	}
 
-	ideal_fee = get_feerate(ld->topology, FEERATE_NORMAL) * weight / 1000;
-
-	/* We prefer fee which is closest to our ideal. */
-	old_diff = imaxabs((s64)ideal_fee - (s64)last_fee);
-	new_diff = imaxabs((s64)ideal_fee - (s64)fee);
-
-	/* In case of a tie, prefer new over old: this covers the preference
-	 * for a mutual close over a unilateral one. */
-	log_debug(channel->log, "... That's %s our ideal %"PRIu64,
-		 new_diff < old_diff
-		 ? "closer to"
-		 : new_diff > old_diff
-		 ? "further from"
-		 : "same distance to",
-		 ideal_fee);
-
-	return new_diff <= old_diff;
+	/* Prefer lower fee: in case of a tie, prefer new over old: this
+	 * covers the preference for a mutual close over a unilateral one. */
+	return fee <= last_fee;
 }
 
 static void peer_received_closing_signature(struct channel *channel,


### PR DESCRIPTION
Fixes: #1361 

Reported-by: @nayuta-ueno 