### PR TITLE
Persistence transaction tracking in the database

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -85,8 +85,10 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		/* We did spends first, in case that tells us to watch tx. */
 		bitcoin_txid(tx, &txid);
 		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid) ||
-		    satoshi_owned != 0)
+		    satoshi_owned != 0) {
 			add_tx_to_block(b, tx, i);
+			wallet_transaction_add(topo->wallet, tx, b->height, i);
+		}
 	}
 	b->full_txs = tal_free(b->full_txs);
 }
@@ -257,6 +259,7 @@ void broadcast_tx(struct chain_topology *topo,
 	log_add(topo->log, " (tx %s)",
 		type_to_string(tmpctx, struct bitcoin_txid, &otx->txid));
 
+	wallet_transaction_add(topo->wallet, tx, 0, 0);
 	bitcoind_sendrawtx(topo->bitcoind, otx->hextx, broadcast_done, otx);
 }
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -127,15 +127,13 @@ static struct block *block_for_tx(const struct chain_topology *topo,
 }
 
 size_t get_tx_depth(const struct chain_topology *topo,
-		    const struct bitcoin_txid *txid,
-		    const struct bitcoin_tx **tx)
+		    const struct bitcoin_txid *txid)
 {
-	const struct block *b;
+	u32 blockheight = wallet_transaction_height(topo->wallet, txid);
 
-	b = block_for_tx(topo, txid, tx);
-	if (!b)
+	if (blockheight == 0)
 		return 0;
-	return topo->tip->height - b->height + 1;
+	return topo->tip->height - blockheight + 1;
 }
 
 struct txs_to_broadcast {

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -49,9 +49,6 @@ struct block {
 	/* Key for hash table */
 	struct bitcoin_blkid blkid;
 
-	/* Transactions in this block we care about */
-	const struct bitcoin_tx **txs;
-
 	/* And their associated index in the block */
 	u32 *txnums;
 

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -129,10 +129,9 @@ struct txlocator {
 };
 
 /* This is the number of blocks which would have to be mined to invalidate
- * the tx (optional tx is filled in if return is non-zero). */
+ * the tx */
 size_t get_tx_depth(const struct chain_topology *topo,
-		    const struct bitcoin_txid *txid,
-		    const struct bitcoin_tx **tx);
+		    const struct bitcoin_txid *txid);
 
 /* Get highest block number. */
 u32 get_block_height(const struct chain_topology *topo);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -57,11 +57,10 @@ static void handle_onchain_init_reply(struct channel *channel, const u8 *msg)
 }
 
 static enum watch_result onchain_tx_watched(struct channel *channel,
-					    const struct bitcoin_tx *tx,
+					    const struct bitcoin_txid *txid,
 					    unsigned int depth)
 {
 	u8 *msg;
-	struct bitcoin_txid txid;
 
 	if (depth == 0) {
 		log_unusual(channel->log, "Chain reorganization!");
@@ -75,8 +74,7 @@ static enum watch_result onchain_tx_watched(struct channel *channel,
 		return KEEP_WATCHING;
 	}
 
-	bitcoin_txid(tx, &txid);
-	msg = towire_onchain_depth(channel, &txid, depth);
+	msg = towire_onchain_depth(channel, txid, depth);
 	subd_send_msg(channel->owner, take(msg));
 	return KEEP_WATCHING;
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -516,7 +516,7 @@ static enum watch_result funding_lockin_cb(struct channel *channel,
 	if (depth < channel->minimum_depth)
 		return KEEP_WATCHING;
 
-	loc = locate_tx(channel, ld->topology, txid);
+	loc = wallet_transaction_locate(channel, ld->wallet, txid);
 
 	/* If we restart, we could already have peer->scid from database */
 	if (!channel->scid) {

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -229,17 +229,15 @@ static bool txw_fire(struct txwatch *txw,
 }
 
 void txwatch_fire(struct chain_topology *topo,
-		  const struct bitcoin_tx *tx,
+		  const struct bitcoin_txid *txid,
 		  unsigned int depth)
 {
-	struct bitcoin_txid txid;
 	struct txwatch *txw;
 
-	bitcoin_txid(tx, &txid);
-	txw = txwatch_hash_get(&topo->txwatches, &txid);
+	txw = txwatch_hash_get(&topo->txwatches, txid);
 
 	if (txw)
-		txw_fire(txw, &txid, depth);
+		txw_fire(txw, txid, depth);
 }
 
 void txowatch_fire(const struct txowatch *txow,

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -281,9 +281,8 @@ again:
 	     w;
 	     w = txwatch_hash_next(&topo->txwatches, &i)) {
 		u32 depth;
-		const struct bitcoin_tx *tx;
 
-		depth = get_tx_depth(topo, &w->txid, &tx);
+		depth = get_tx_depth(topo, &w->txid);
 		if (depth)
 			needs_rerun |= txw_fire(w, &w->txid, depth);
 	}

--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -70,7 +70,7 @@ struct txwatch *find_txwatch(struct chain_topology *topo,
 			     const struct channel *channel);
 
 void txwatch_fire(struct chain_topology *topo,
-		  const struct bitcoin_tx *tx,
+		  const struct bitcoin_txid *txid,
 		  unsigned int depth);
 
 void txowatch_fire(const struct txowatch *txow,

--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -44,7 +44,7 @@ struct txwatch *watch_txid(const tal_t *ctx,
 			   struct channel *channel,
 			   const struct bitcoin_txid *txid,
 			   enum watch_result (*cb)(struct channel *channel,
-						    const struct bitcoin_tx *,
+						    const struct bitcoin_txid *,
 						   unsigned int depth));
 
 struct txwatch *watch_tx(const tal_t *ctx,
@@ -52,7 +52,7 @@ struct txwatch *watch_tx(const tal_t *ctx,
 			 struct channel *channel,
 			 const struct bitcoin_tx *tx,
 			 enum watch_result (*cb)(struct channel *channel,
-						  const struct bitcoin_tx *,
+						  const struct bitcoin_txid *,
 						  unsigned int depth));
 
 struct txowatch *watch_txo(const tal_t *ctx,

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -290,6 +290,16 @@ char *dbmigrations[] = {
     "     , msatoshi_to_us_max = msatoshi_local"
     "     ;",
     /* -- Min and max msatoshi_to_us ends -- */
+    /* Transactions we are interested in. Either we sent them ourselves or we
+     * are watching them. We don't cascade block height deletes so we don't
+     * forget any of them by accident.*/
+    "CREATE TABLE transactions ("
+    "  id BLOB"
+    ", blockheight INTEGER REFERENCES blocks(height) ON DELETE SET NULL"
+    ", txindex INTEGER"
+    ", rawtx BLOB"
+    ", PRIMARY KEY (id)"
+    ");",
     NULL,
 };
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -385,7 +385,7 @@ struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   struct channel *channel UNNEEDED,
 			   const struct bitcoin_txid *txid UNNEEDED,
 			   enum watch_result (*cb)(struct channel *channel UNNEEDED,
-						    const struct bitcoin_tx * UNNEEDED,
+						    const struct bitcoin_txid * UNNEEDED,
 						   unsigned int depth))
 { fprintf(stderr, "watch_txid called!\n"); abort(); }
 /* Generated stub for watch_txo */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2201,3 +2201,20 @@ void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
 		db_exec_prepared(w->db, stmt);
 	}
 }
+
+u32 wallet_transaction_height(struct wallet *w, const struct bitcoin_txid *txid)
+{
+	u32 blockheight;
+	sqlite3_stmt *stmt = db_prepare(
+		w->db, "SELECT blockheight, txindex, rawtx FROM transactions WHERE id=?");
+	sqlite3_bind_sha256(stmt, 1, &txid->shad.sha);
+
+	if (sqlite3_step(stmt) != SQLITE_ROW) {
+		sqlite3_finalize(stmt);
+		return 0;
+	}
+
+	blockheight = sqlite3_column_int(stmt, 0);
+	sqlite3_finalize(stmt);
+	return blockheight;
+}

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2246,3 +2246,25 @@ fail:
 	sqlite3_finalize(stmt);
 	return NULL;
 }
+
+struct bitcoin_txid *wallet_transactions_by_height(const tal_t *ctx,
+						   struct wallet *w,
+						   const u32 blockheight)
+{
+	sqlite3_stmt *stmt;
+	struct bitcoin_txid *txids = tal_arr(ctx, struct bitcoin_txid, 0);
+	int count = 0;
+	stmt = db_prepare(
+	    w->db, "SELECT id FROM transactions WHERE blockheight=?");
+	sqlite3_bind_int(stmt, 1, blockheight);
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		count++;
+		tal_resize(&txids, count);
+		sqlite3_column_sha256(stmt, 0, &txids[count-1].shad.sha);
+	}
+	sqlite3_finalize(stmt);
+
+	return txids;
+}
+

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -827,4 +827,11 @@ u32 wallet_transaction_height(struct wallet *w, const struct bitcoin_txid *txid)
 struct txlocator *wallet_transaction_locate(const tal_t *ctx, struct wallet *w,
 					    const struct bitcoin_txid *txid);
 
+/**
+ * Get transaction IDs for transactions that we are tracking.
+ */
+struct bitcoin_txid *wallet_transactions_by_height(const tal_t *ctx,
+						   struct wallet *w,
+						   const u32 blockheight);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -820,4 +820,11 @@ void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
  */
 u32 wallet_transaction_height(struct wallet *w, const struct bitcoin_txid *txid);
 
+/**
+ * Locate a transaction in the blockchain, returns NULL if the transaction is
+ * not tracked or is not yet confirmed.
+ */
+struct txlocator *wallet_transaction_locate(const tal_t *ctx, struct wallet *w,
+					    const struct bitcoin_txid *txid);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -814,4 +814,10 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
 			    const u32 blockheight, const u32 txindex);
 
+/**
+ * Get the confirmation height of a transaction we are watching by its
+ * txid. Returns 0 if the transaction was not part of any block.
+ */
+u32 wallet_transaction_height(struct wallet *w, const struct bitcoin_txid *txid);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -810,4 +810,8 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 			const u32 outnum, const u32 blockheight,
 			const u32 txindex, const u8 *scriptpubkey,
 			const u64 satoshis);
+
+void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
+			    const u32 blockheight, const u32 txindex);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
This is some preparatory work to get to no-rescan startups. We store transactions we own, watch or broadcast in a DB table. This allows us to track their depth and recover the transactions for debugging purposes. The transactions will also be used by the `onchaind` replay (next PR) to feed transactions in and restore its state.