### PR TITLE
Make deprecated out-of-range fee handling deterministic

### DIFF
--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -341,6 +341,7 @@ static void init_feerange(struct feerange *feerange,
 			  const u64 offer[NUM_SIDES])
 {
 	feerange->min = 0;
+	feerange->allow_mistakes = true;
 
 	/* BOLT #2:
 	 *


### PR DESCRIPTION
Make deprecated out-of-range fee handling deterministic.

Prior to this commit `feerange->allow_mistakes ` had an indeterminate value (an unspecified value or a trap representation).