### PR TITLE
lightning-autocleaninvoice.7: Properly generate instead of using an empty file.

### DIFF
--- a/doc/lightning-autocleaninvoice.7
+++ b/doc/lightning-autocleaninvoice.7
@@ -1,0 +1,55 @@
+'\" t
+.\"     Title: lightning-autocleaninvoice
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/16/2018
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-AUTOCLEAN" "7" "04/16/2018" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-autocleaninvoice \- Set up auto\-delete of expired invoice
+.SH "SYNOPSIS"
+.sp
+\fBautocleaninvoice\fR [\fIcycle_seconds\fR] [\fIexpired_by\fR]
+.SH "DESCRIPTION"
+.sp
+The \fBautocleaninvoice\fR RPC command sets up automatic cleaning of expired invoices\&.
+.sp
+Autoclean will be done every \fIcycle_seconds\fR seconds\&. Setting \fIcycle_seconds\fR to 0 disables autoclean\&. If not specified, this defaults to 3600 (one hour)\&.
+.sp
+Every autoclean cycle, expired invoices, which have already been expired for at least \fIexpired_by\fR seconds, will be deleted\&. If \fIexpired_by\fR is not specified, this defaults to 86400 (one day)\&.
+.sp
+On startup of the daemon, no autoclean is set up\&.
+.SH "RETURN VALUE"
+.sp
+On success, an empty object is returned\&.
+.SH "AUTHOR"
+.sp
+ZmnSCPxj <ZmnSCPxj@protonmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-delexpiredinvoice(7), lightning\-delinvoice(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning


### PR DESCRIPTION


Strange behavior where `a2x` sometimes does not work at all.