### PR TITLE
Adapt relative weights of channel traversal costs

### DIFF
--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-getroute
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/19/2018
+.\"      Date: 04/17/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-GETROUTE" "7" "02/19/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-GETROUTE" "7" "04/17/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 lightning-getroute \- Protocol for routing a payment (low\-level)\&.
 .SH "SYNOPSIS"
 .sp
-\fBgetroute\fR \fIid\fR \fImsatoshi\fR \fIriskfactor\fR [\fIcltv\fR] [\fIfuzzpercent\fR] [\fIseed\fR]
+\fBgetroute\fR \fIid\fR \fImsatoshi\fR \fIriskfactor\fR [\fIcltv\fR] [\fIfuzzpercent\fR] [\fIseed\fR] [\fIfeecostbias\fR]
 .SH "DESCRIPTION"
 .sp
 The \fBgetroute\fR RPC command attempts to find the best route for the payment of \fImsatoshi\fR to lightning node \fIid\fR, such that the payment will arrive at \fIid\fR with \fIcltv\fR\-blocks to spare (default 9)\&.
@@ -45,6 +45,8 @@ If you didn\(cqt care about risk, \fIriskfactor\fR would be zero\&.
 The \fIfuzzpercent\fR is a floating\-point number, between 0\&.0 to 100\&.0, unit of percent\&. The \fIfuzzpercent\fR is used to distort computed fees along each channel, to provide some randomization to the route generated\&. 0\&.0 means the exact fee of that channel is used, while 100\&.0 means the fee used might be from 0 to twice the actual fee\&. The default is 5\&.0, or up to 5% fee distortion\&.
 .sp
 The \fIseed\fR is a string whose bytes are used to seed the RNG for the route randomization\&. If not specified, a random string is used\&.
+.sp
+The \fIfeecostbias\fR is a floating\-point number, higher than 0\&.0 and less than 2\&.0, that indicates whether to bias against high fees or high delays when computing the risk of the route\&. Default is 1\&.0, meaning no bias\&. Higher than 1\&.0 biases against high fee routes, while less than 1\&.0 biases against low fee routes\&.
 .SH "RISKFACTOR EFFECT ON ROUTING"
 .sp
 The risk factor is treated as if it were an additional fee on the route, for the purposes of comparing routes\&.

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -9,7 +9,7 @@ lightning-getroute - Protocol for routing a payment (low-level).
 
 SYNOPSIS
 --------
-*getroute* 'id' 'msatoshi' 'riskfactor' ['cltv'] ['fuzzpercent'] ['seed']
+*getroute* 'id' 'msatoshi' 'riskfactor' ['cltv'] ['fuzzpercent'] ['seed'] ['feecostbias']
 
 DESCRIPTION
 -----------
@@ -41,6 +41,12 @@ The 'seed' is a string whose bytes are used to seed the RNG for
 the route randomization.
 If not specified, a random string is used.
 
+The 'feecostbias' is a floating-point number, higher than 0.0 and
+less than 2.0, that indicates whether to bias against high fees or
+high delays when computing the risk of the route.
+Default is 1.0, meaning no bias.
+Higher than 1.0 biases against high fee routes, while less than 1.0
+biases against low fee routes.
 
 RISKFACTOR EFFECT ON ROUTING
 ----------------------------

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1107,18 +1107,21 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 	struct route_hop *hops;
 	double fuzz;
 	struct siphash_seed seed;
+	double feecostbias;
 
 	fromwire_gossip_getroute_request(msg,
 					 &source, &destination,
 					 &msatoshi, &riskfactor, &final_cltv,
-					 &fuzz, &seed);
+					 &fuzz, &seed,
+					 &feecostbias);
 	status_trace("Trying to find a route from %s to %s for %"PRIu64" msatoshi",
 		     pubkey_to_hexstr(tmpctx, &source),
 		     pubkey_to_hexstr(tmpctx, &destination), msatoshi);
 
 	hops = get_route(tmpctx, daemon->rstate, &source, &destination,
 			 msatoshi, 1, final_cltv,
-			 fuzz, &seed);
+			 fuzz, &seed,
+			 feecostbias);
 
 	out = towire_gossip_getroute_reply(msg, hops);
 	daemon_conn_send(&daemon->master, out);

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -109,6 +109,7 @@ gossip_getroute_request,,riskfactor,u16
 gossip_getroute_request,,final_cltv,u32
 gossip_getroute_request,,fuzz,double
 gossip_getroute_request,,seed,struct siphash_seed
+gossip_getroute_request,,feecostbias,double
 
 gossip_getroute_reply,3106
 gossip_getroute_reply,,num_hops,u16

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -241,7 +241,8 @@ struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    const u64 msatoshi, double riskfactor,
 			    u32 final_cltv,
 			    double fuzz,
-			    const struct siphash_seed *base_seed);
+			    const struct siphash_seed *base_seed,
+			    double feecostbias);
 /* Disable channel(s) based on the given routing failure. */
 void routing_failure(struct routing_state *rstate,
 		     const struct pubkey *erring_node,

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
 				  pseudorand(100000),
 				  riskfactor,
 				  0.75, &base_seed,
-				  &fee);
+				  &fee, 1.0, 1.0);
 		num_success += (route != NULL);
 		tal_free(route);
 	}

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -179,7 +179,7 @@ int main(void)
 	nc->flags = 1;
 	nc->last_timestamp = 1504064344;
 
-	route = find_route(tmpctx, rstate, &a, &c, 100000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &c, 100000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &b));

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -188,7 +188,7 @@ int main(void)
 	/* A<->B */
 	add_connection(rstate, &a, &b, 1, 1, 1);
 
-	route = find_route(tmpctx, rstate, &a, &b, 1000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &b, 1000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(tal_count(route) == 1);
 	assert(fee == 0);
 
@@ -202,7 +202,7 @@ int main(void)
 	status_trace("C = %s", type_to_string(tmpctx, struct pubkey, &c));
 	add_connection(rstate, &b, &c, 1, 1, 1);
 
-	route = find_route(tmpctx, rstate, &a, &c, 1000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &c, 1000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(tal_count(route) == 2);
 	assert(fee == 1);
 
@@ -216,14 +216,14 @@ int main(void)
 	add_connection(rstate, &d, &c, 0, 2, 1);
 
 	/* Will go via D for small amounts. */
-	route = find_route(tmpctx, rstate, &a, &c, 1000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &c, 1000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &d));
 	assert(channel_is_between(route[1], &d, &c));
 	assert(fee == 0);
 
 	/* Will go via B for large amounts. */
-	route = find_route(tmpctx, rstate, &a, &c, 3000000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &c, 3000000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &b));
 	assert(channel_is_between(route[1], &b, &c));
@@ -231,7 +231,7 @@ int main(void)
 
 	/* Make B->C inactive, force it back via D */
 	get_connection(rstate, &b, &c)->active = false;
-	route = find_route(tmpctx, rstate, &a, &c, 3000000, riskfactor, 0.0, NULL, &fee);
+	route = find_route(tmpctx, rstate, &a, &c, 3000000, riskfactor, 0.0, NULL, &fee, 1.0, 1.0);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &d));
 	assert(channel_is_between(route[1], &d, &c));

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -507,6 +507,7 @@ static bool json_pay_try(struct pay *pay)
 	struct siphash_seed seed;
 	u64 maxoverpayment;
 	u64 overpayment;
+	double feecostbias = 1.0;
 
 	/* If too late anyway, fail now. */
 	if (time_after(now, pay->expiry)) {
@@ -558,7 +559,8 @@ static bool json_pay_try(struct pay *pay)
 					     pay->riskfactor,
 					     pay->min_final_cltv_expiry,
 					     &pay->fuzz,
-					     &seed);
+					     &seed,
+					     &feecostbias);
 	subd_req(pay->try_parent, cmd->ld->gossip, req, -1, 0, json_pay_getroute_reply, pay);
 
 	return true;


### PR DESCRIPTION
Dynamically adapt relative weights of channel traversal costs, to more likely succeed to pay given the `pay` acceptable cost settings.