### PR TITLE
Clean up codes by adjusting wrong indents

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -474,12 +474,12 @@ static u8 *check_channel_update(const tal_t *ctx,
 }
 
 static u8 *check_channel_announcement(const tal_t *ctx,
-    const struct pubkey *node1_key, const struct pubkey *node2_key,
-    const struct pubkey *bitcoin1_key, const struct pubkey *bitcoin2_key,
-    const secp256k1_ecdsa_signature *node1_sig,
-    const secp256k1_ecdsa_signature *node2_sig,
-    const secp256k1_ecdsa_signature *bitcoin1_sig,
-    const secp256k1_ecdsa_signature *bitcoin2_sig, const u8 *announcement)
+	const struct pubkey *node1_key, const struct pubkey *node2_key,
+	const struct pubkey *bitcoin1_key, const struct pubkey *bitcoin2_key,
+	const secp256k1_ecdsa_signature *node1_sig,
+	const secp256k1_ecdsa_signature *node2_sig,
+	const secp256k1_ecdsa_signature *bitcoin1_sig,
+	const secp256k1_ecdsa_signature *bitcoin2_sig, const u8 *announcement)
 {
 	/* 2 byte msg type + 256 byte signatures */
 	int offset = 258;
@@ -1086,39 +1086,39 @@ static struct wireaddr *read_addresses(const tal_t *ctx, const u8 *ser)
 
 bool routing_add_node_announcement(struct routing_state *rstate, const u8 *msg TAKES)
 {
-       struct node *node;
-       secp256k1_ecdsa_signature signature;
-       u32 timestamp;
-       struct pubkey node_id;
-       u8 rgb_color[3];
-       u8 alias[32];
-       u8 *features, *addresses;
-       struct wireaddr *wireaddrs;
-       fromwire_node_announcement(tmpctx, msg,
-                                  &signature, &features, &timestamp,
-                                  &node_id, rgb_color, alias,
-                                  &addresses);
+	struct node *node;
+	secp256k1_ecdsa_signature signature;
+	u32 timestamp;
+	struct pubkey node_id;
+	u8 rgb_color[3];
+	u8 alias[32];
+	u8 *features, *addresses;
+	struct wireaddr *wireaddrs;
+	fromwire_node_announcement(tmpctx, msg,
+	                           &signature, &features, &timestamp,
+	                           &node_id, rgb_color, alias,
+	                           &addresses);
 
-       node = get_node(rstate, &node_id);
+	node = get_node(rstate, &node_id);
 
-       /* May happen if we accepted the node_announcement due to a local
+	/* May happen if we accepted the node_announcement due to a local
 	* channel, for which we didn't have the announcement hust yet. */
-       if (node == NULL)
-	       return false;
+	if (node == NULL)
+		return false;
 
-       wireaddrs = read_addresses(tmpctx, addresses);
-       tal_free(node->addresses);
-       node->addresses = tal_steal(node, wireaddrs);
+	wireaddrs = read_addresses(tmpctx, addresses);
+	tal_free(node->addresses);
+	node->addresses = tal_steal(node, wireaddrs);
 
-       node->last_timestamp = timestamp;
-       memcpy(node->rgb_color, rgb_color, 3);
-       tal_free(node->alias);
-       node->alias = tal_dup_arr(node, u8, alias, 32, 0);
+	node->last_timestamp = timestamp;
+	memcpy(node->rgb_color, rgb_color, 3);
+	tal_free(node->alias);
+	node->alias = tal_dup_arr(node, u8, alias, 32, 0);
 
-       replace_broadcast(node, rstate->broadcasts,
-                         &node->node_announce_msgidx,
-                         msg);
-       return true;
+	replace_broadcast(node, rstate->broadcasts,
+	                  &node->node_announce_msgidx,
+	                  msg);
+	return true;
 }
 
 static bool node_has_public_channels(struct node *node)

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1095,9 +1095,9 @@ bool routing_add_node_announcement(struct routing_state *rstate, const u8 *msg T
 	u8 *features, *addresses;
 	struct wireaddr *wireaddrs;
 	fromwire_node_announcement(tmpctx, msg,
-	                           &signature, &features, &timestamp,
-	                           &node_id, rgb_color, alias,
-	                           &addresses);
+				   &signature, &features, &timestamp,
+				   &node_id, rgb_color, alias,
+				   &addresses);
 
 	node = get_node(rstate, &node_id);
 
@@ -1116,8 +1116,8 @@ bool routing_add_node_announcement(struct routing_state *rstate, const u8 *msg T
 	node->alias = tal_dup_arr(node, u8, alias, 32, 0);
 
 	replace_broadcast(node, rstate->broadcasts,
-	                  &node->node_announce_msgidx,
-	                  msg);
+			  &node->node_announce_msgidx,
+			  msg);
 	return true;
 }
 

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -252,8 +252,7 @@ static bool check_client_capabilities(struct client *client,
 	case WIRE_HSM_SIGN_INVOICE:
 		return (client->capabilities & HSM_CAP_MASTER) != 0;
 
-      /* These are messages sent by the HSM so we should never receive
-       * them */
+	/* These are messages sent by the HSM so we should never receive them */
 	case WIRE_HSM_ECDH_RESP:
 	case WIRE_HSM_CANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSM_CUPDATE_SIG_REPLY:

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -2,7 +2,8 @@
 #include <lightningd/gossip_msg.h>
 #include <wire/wire.h>
 
-struct gossip_getnodes_entry *fromwire_gossip_getnodes_entry(const tal_t *ctx, const u8 **pptr, size_t *max)
+struct gossip_getnodes_entry *fromwire_gossip_getnodes_entry(const tal_t *ctx,
+	const u8 **pptr, size_t *max)
 {
 	u8 numaddresses, i;
 	struct gossip_getnodes_entry *entry;
@@ -32,7 +33,8 @@ struct gossip_getnodes_entry *fromwire_gossip_getnodes_entry(const tal_t *ctx, c
 	return entry;
 }
 
-void towire_gossip_getnodes_entry(u8 **pptr, const struct gossip_getnodes_entry *entry)
+void towire_gossip_getnodes_entry(u8 **pptr,
+				  const struct gossip_getnodes_entry *entry)
 {
 	u8 i, numaddresses = tal_count(entry->addresses);
 	towire_pubkey(pptr, &entry->nodeid);
@@ -83,8 +85,8 @@ void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
 	}
 }
 
-void towire_gossip_getchannels_entry(
-    u8 **pptr, const struct gossip_getchannels_entry *entry)
+void towire_gossip_getchannels_entry(u8 **pptr,
+	const struct gossip_getchannels_entry *entry)
 {
 	towire_short_channel_id(pptr, &entry->short_channel_id);
 	towire_pubkey(pptr, &entry->source);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -68,7 +68,7 @@ void towire_route_hop(u8 **pptr, const struct route_hop *entry)
 }
 
 void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
-				      struct gossip_getchannels_entry *entry)
+				       struct gossip_getchannels_entry *entry)
 {
 	fromwire_short_channel_id(pptr, max, &entry->short_channel_id);
 	fromwire_pubkey(pptr, max, &entry->source);
@@ -86,7 +86,7 @@ void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
 }
 
 void towire_gossip_getchannels_entry(u8 **pptr,
-	const struct gossip_getchannels_entry *entry)
+				     const struct gossip_getchannels_entry *entry)
 {
 	towire_short_channel_id(pptr, &entry->short_channel_id);
 	towire_pubkey(pptr, &entry->source);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -839,7 +839,7 @@ static void json_fund_channel(struct command *cmd,
 	bool all_funds = false;
 	struct funding_channel * fc;
 	u32 feerate_per_kw = get_feerate(cmd->ld->topology, FEERATE_NORMAL);
-    u64 fee_estimate;
+	u64 fee_estimate;
 	u8 *msg;
 
 	if (!json_get_params(cmd, buffer, params,
@@ -856,7 +856,6 @@ static void json_fund_channel(struct command *cmd,
 
 	if (json_tok_streq(buffer, sattok, "all")) {
 		all_funds = true;
-
 	} else if (!json_tok_u64(buffer, sattok, &fc->funding_satoshi)) {
 		command_fail(cmd, "Invalid satoshis");
 		return;
@@ -873,7 +872,7 @@ static void json_fund_channel(struct command *cmd,
 
 	/* Try to do this now, so we know if insufficient funds. */
 	/* FIXME: dustlimit */
-    if (all_funds) {
+	if (all_funds) {
 		fc->utxomap = wallet_select_all(cmd, cmd->ld->wallet,
 			feerate_per_kw,
 			BITCOIN_SCRIPTPUBKEY_P2WSH_LEN,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -83,7 +83,7 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
  * the HSM to generate the signatures.
  */
 static void json_withdraw(struct command *cmd,
-			      const char *buffer, const jsmntok_t *params)
+			  const char *buffer, const jsmntok_t *params)
 {
 	jsmntok_t *desttok, *sattok;
 	struct withdrawal *withdraw;
@@ -281,7 +281,7 @@ static const struct json_command newaddr_command = {
 AUTODATA(json_command, &newaddr_command);
 
 static void json_listaddrs(struct command *cmd,
-						   const char *buffer, const jsmntok_t *params)
+			   const char *buffer, const jsmntok_t *params)
 {
 	struct json_result *response = new_json_result(cmd);
 	struct ext_key ext;
@@ -326,7 +326,7 @@ static void json_listaddrs(struct command *cmd,
 		sha256(&h, redeemscript, tal_count(redeemscript));
 		ripemd160(&h160, h.u.u8, sizeof(h));
 		char *out_p2sh = p2sh_to_base58(cmd,
-								  get_chainparams(cmd->ld)->testnet, &h160);
+						get_chainparams(cmd->ld)->testnet, &h160);
 
 		// bech32 : p2wpkh
 		const char *hrp = get_chainparams(cmd->ld)->bip173_name;
@@ -357,7 +357,8 @@ static void json_listaddrs(struct command *cmd,
 static const struct json_command listaddrs_command = {
 	"dev-listaddrs",
 	json_listaddrs,
-	"Show addresses list up to derivation {index} (default is the last bip32 index)", false,
+	"Show addresses list up to derivation {index} (default is the last bip32 index)",
+	false,
 	"Show addresses of your internal wallet. Use `newaddr` to generate a new address."
 };
 AUTODATA(json_command, &listaddrs_command);
@@ -386,8 +387,9 @@ static void json_listfunds(struct command *cmd, const char *buffer UNUSED,
 				     utxos[i]->keyindex);
 			pubkey_to_hash160(&funding_pubkey, &h160);
 			if (utxos[i]->is_p2sh) {
-					out = p2sh_to_base58(cmd,
-					get_chainparams(cmd->ld)->testnet, &h160);
+				out = p2sh_to_base58(cmd,
+						     get_chainparams(cmd->ld)->testnet,
+						     &h160);
 			} else {
 				const char *hrp = get_chainparams(cmd->ld)->bip173_name;
 				/* out buffer is 73 + strlen(human readable part). see bech32.h */
@@ -442,7 +444,8 @@ static void json_listfunds(struct command *cmd, const char *buffer UNUSED,
 static const struct json_command listfunds_command = {
 	"listfunds",
 	json_listfunds,
-	"Show available funds from the internal wallet", false,
+	"Show available funds from the internal wallet",
+	false,
 	"Returns a list of funds (outputs) that can be used by the internal wallet to open new channels or can be withdrawn, using the `withdraw` command, to another wallet."
 };
 AUTODATA(json_command, &listfunds_command);
@@ -513,8 +516,10 @@ static void json_dev_rescan_outputs(struct command *cmd,
 }
 
 static const struct json_command dev_rescan_output_command = {
-    "dev-rescan-outputs", json_dev_rescan_outputs,
-    "Synchronize the state of our funds with bitcoind", false,
-    "For each output stored in the internal wallet ask `bitcoind` whether we are in sync with its state (spent vs. unspent)"
+	"dev-rescan-outputs",
+	json_dev_rescan_outputs,
+	"Synchronize the state of our funds with bitcoind",
+	false,
+	"For each output stored in the internal wallet ask `bitcoind` whether we are in sync with its state (spent vs. unspent)"
 };
 AUTODATA(json_command, &dev_rescan_output_command);


### PR DESCRIPTION
There were 7 spaces in routing.c and 4 spaces in other files. Replaced them with tabs.
I searched them with this script and edited manually.
```
grep -r --exclude bech32.c --exclude signature.c --exclude chainparams.c --exclude options.c --exclude netaddress.c --exclude db.c --exclude wallet.c --exclude *wire.c '^    ' */*.c | grep -v '        '
```