### PR TITLE
Store locally added channels to the gossip_store

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -786,55 +786,6 @@ static void handle_get_update(struct peer *peer, const u8 *msg)
 	daemon_conn_send(peer->remote, take(msg));
 }
 
-static void handle_local_add_channel(struct routing_state *rstate, u8 *msg)
-{
-	struct short_channel_id scid;
-	struct bitcoin_blkid chain_hash;
-	struct pubkey remote_node_id;
-	u16 cltv_expiry_delta;
-	u32 fee_base_msat, fee_proportional_millionths;
-	u64 htlc_minimum_msat;
-	int idx;
-	struct chan *chan;
-
-	if (!fromwire_gossip_local_add_channel(
-		msg, &scid, &chain_hash, &remote_node_id,
-		&cltv_expiry_delta, &htlc_minimum_msat, &fee_base_msat,
-		&fee_proportional_millionths)) {
-		status_broken("Unable to parse local_add_channel message: %s", tal_hex(msg, msg));
-		return;
-	}
-
-	if (!structeq(&chain_hash, &rstate->chain_hash)) {
-		status_broken("Received local_add_channel for unknown chain %s",
-			     type_to_string(msg, struct bitcoin_blkid,
-					    &chain_hash));
-		return;
-	}
-
-	if (get_channel(rstate, &scid)) {
-		status_broken("Attempted to local_add_channel a known channel");
-		return;
-	}
-
-	/* Create new channel */
-	chan = new_chan(rstate, &scid, &rstate->local_id, &remote_node_id);
-
-	idx = pubkey_idx(&rstate->local_id, &remote_node_id),
-	/* Activate the half_chan from us to them. */
-	set_connection_values(chan, idx,
-			      fee_base_msat,
-			      fee_proportional_millionths,
-			      cltv_expiry_delta,
-			      true,
-			      0,
-			      htlc_minimum_msat);
-	/* Designed to match msg in handle_channel_update, for easy testing */
-	status_trace("Received local update for channel %s(%d) now ACTIVE",
-		     type_to_string(msg, struct short_channel_id, &scid),
-		     idx);
-}
-
 /**
  * owner_msg_in - Called by the `peer->remote` upon receiving a
  * message

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -806,6 +806,8 @@ static struct io_plan *owner_msg_in(struct io_conn *conn,
 	} else if (type == WIRE_GOSSIP_GET_UPDATE) {
 		handle_get_update(peer, dc->msg_in);
 	} else if (type == WIRE_GOSSIP_LOCAL_ADD_CHANNEL) {
+		gossip_store_local_add_channel(peer->daemon->rstate->store,
+					       dc->msg_in);
 		handle_local_add_channel(peer->daemon->rstate, dc->msg_in);
 	} else {
 		status_broken("peer %s: send us unknown msg of type %s",

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -786,9 +786,8 @@ static void handle_get_update(struct peer *peer, const u8 *msg)
 	daemon_conn_send(peer->remote, take(msg));
 }
 
-static void handle_local_add_channel(struct peer *peer, u8 *msg)
+static void handle_local_add_channel(struct routing_state *rstate, u8 *msg)
 {
-	struct routing_state *rstate = peer->daemon->rstate;
 	struct short_channel_id scid;
 	struct bitcoin_blkid chain_hash;
 	struct pubkey remote_node_id;
@@ -856,7 +855,7 @@ static struct io_plan *owner_msg_in(struct io_conn *conn,
 	} else if (type == WIRE_GOSSIP_GET_UPDATE) {
 		handle_get_update(peer, dc->msg_in);
 	} else if (type == WIRE_GOSSIP_LOCAL_ADD_CHANNEL) {
-		handle_local_add_channel(peer, dc->msg_in);
+		handle_local_add_channel(peer->daemon->rstate, dc->msg_in);
 	} else {
 		status_broken("peer %s: send us unknown msg of type %s",
 			      type_to_string(tmpctx, struct pubkey, &peer->id),

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -109,6 +109,15 @@ void gossip_store_add_channel_delete(struct gossip_store *gs,
 	tal_free(msg);
 }
 
+void gossip_store_local_add_channel(struct gossip_store *gs,
+				    const u8 *add_msg)
+{
+	u8 *msg = towire_gossip_store_local_add_channel(NULL, add_msg);
+	gossip_store_append(gs, msg);
+	tal_free(msg);
+}
+
+
 void gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 {
 	beint32_t belen;
@@ -163,6 +172,9 @@ void gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 			}
 			tal_free(c);
 			stats[3]++;
+		} else if (fromwire_gossip_store_local_add_channel(
+			       msg, msg, &gossip_msg)) {
+			handle_local_add_channel(rstate, gossip_msg);
 		} else {
 			bad = "Unknown message";
 			goto truncate;

--- a/gossipd/gossip_store.csv
+++ b/gossipd/gossip_store.csv
@@ -14,3 +14,7 @@ gossip_store_node_announcement,,announcement,len*u8
 
 gossip_store_channel_delete,4099
 gossip_store_channel_delete,,short_channel_id,struct short_channel_id
+
+gossip_store_local_add_channel,4100
+gossip_store_local_add_channel,,len,u16
+gossip_store_local_add_channel,,local_add,len*u8

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -31,6 +31,12 @@ void gossip_store_add_channel_announcement(struct gossip_store *gs,
 					   const u8 *gossip_msg, u64 satoshis);
 
 /**
+ * Store a local_add_channel so we remember it when restarting
+ */
+void gossip_store_local_add_channel(struct gossip_store *gs,
+				    const u8 *add_msg);
+
+/**
  * Store a channel_update with its associated data in the gossip_store
  */
 void gossip_store_add_channel_update(struct gossip_store *gs,

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -289,4 +289,14 @@ bool routing_add_channel_update(struct routing_state *rstate,
 bool routing_add_node_announcement(struct routing_state *rstate,
                                   const u8 *msg TAKES);
 
+
+/**
+ * Add a local channel.
+ *
+ * Entrypoint to add a local channel that was not learned through gossip. This
+ * is the case for private channels or channels that have not yet reached
+ * `announce_depth`.
+ */
+void handle_local_add_channel(struct routing_state *rstate, u8 *msg);
+
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -74,6 +74,9 @@ bool fromwire_gossip_store_channel_delete(const void *p UNNEEDED, struct short_c
 /* Generated stub for fromwire_gossip_store_channel_update */
 bool fromwire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **update UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_store_local_add_channel */
+bool fromwire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **local_add UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_node_announcement */
 bool fromwire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_node_announcement called!\n"); abort(); }
@@ -117,6 +120,9 @@ u8 *towire_gossip_store_channel_delete(const tal_t *ctx UNNEEDED, const struct s
 /* Generated stub for towire_gossip_store_channel_update */
 u8 *towire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const u8 *update UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for towire_gossip_store_local_add_channel */
+u8 *towire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const u8 *local_add UNNEEDED)
+{ fprintf(stderr, "towire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_node_announcement */
 u8 *towire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_node_announcement called!\n"); abort(); }

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -62,6 +62,9 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 /* Generated stub for fromwire_channel_update */
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_local_add_channel */
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -38,6 +38,9 @@ bool fromwire_gossip_store_channel_delete(const void *p UNNEEDED, struct short_c
 /* Generated stub for fromwire_gossip_store_channel_update */
 bool fromwire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **update UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_store_local_add_channel */
+bool fromwire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **local_add UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_node_announcement */
 bool fromwire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_node_announcement called!\n"); abort(); }
@@ -81,6 +84,9 @@ u8 *towire_gossip_store_channel_delete(const tal_t *ctx UNNEEDED, const struct s
 /* Generated stub for towire_gossip_store_channel_update */
 u8 *towire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const u8 *update UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for towire_gossip_store_local_add_channel */
+u8 *towire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const u8 *local_add UNNEEDED)
+{ fprintf(stderr, "towire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_node_announcement */
 u8 *towire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_node_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -26,6 +26,9 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 /* Generated stub for fromwire_channel_update */
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_local_add_channel */
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -24,6 +24,9 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 /* Generated stub for fromwire_channel_update */
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_local_add_channel */
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -36,6 +36,9 @@ bool fromwire_gossip_store_channel_delete(const void *p UNNEEDED, struct short_c
 /* Generated stub for fromwire_gossip_store_channel_update */
 bool fromwire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **update UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_store_local_add_channel */
+bool fromwire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **local_add UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_node_announcement */
 bool fromwire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_store_node_announcement called!\n"); abort(); }
@@ -79,6 +82,9 @@ u8 *towire_gossip_store_channel_delete(const tal_t *ctx UNNEEDED, const struct s
 /* Generated stub for towire_gossip_store_channel_update */
 u8 *towire_gossip_store_channel_update(const tal_t *ctx UNNEEDED, const u8 *update UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_update called!\n"); abort(); }
+/* Generated stub for towire_gossip_store_local_add_channel */
+u8 *towire_gossip_store_local_add_channel(const tal_t *ctx UNNEEDED, const u8 *local_add UNNEEDED)
+{ fprintf(stderr, "towire_gossip_store_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_node_announcement */
 u8 *towire_gossip_store_node_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_node_announcement called!\n"); abort(); }


### PR DESCRIPTION
The following would lead to an unusable channel until `announce_depth` was reached:

 - Fund a channel
 - Wait for funding locked
 - Restart

This PR simply stores locally added channels (not yet at `funding_depth` or not public) and replays the `local_add_channel` on `gossip_store` read.

Fixes #1367
