### PR TITLE
test_lightningd.py: Make test_penalty_inhtlc not fail due to reconnect.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1816,8 +1816,8 @@ class LightningDTests(BaseLightningDTests):
     def test_penalty_inhtlc(self):
         """Test penalty transaction with an incoming HTLC"""
         # We suppress each one after first commit; HTLC gets added not fulfilled.
-        l1 = self.node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True)
-        l2 = self.node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'])
+        l1 = self.node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True, may_reconnect=True)
+        l2 = self.node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_reconnect=True)
 
         l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
         self.fund_channel(l1, l2, 10**6)


### PR DESCRIPTION
The test disconnects at `=WIRE_COMMITMENT_SIGNED-nocommit`,
then reconnects to continue `REVOKE_AND_ACK`, so I think it
should indeed reconnect.

This was introduced in #1408.
I am uncertain why, the last commit in that PR passed, but an
intermediate commit failed on `test_penalty_inhtlc`:

https://travis-ci.org/ElementsProject/lightning/jobs/370024920