### PR TITLE
Track db statements

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -278,6 +278,15 @@ static void pidfile_create(const struct lightningd *ld)
 	write_all(pid_fd, pid, strlen(pid));
 }
 
+/* Yuck, we need globals here. */
+static int (*io_poll_debug)(struct pollfd *, nfds_t, int);
+static int io_poll_lightningd(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	db_assert_no_outstanding_statements();
+
+	return io_poll_debug(fds, nfds, timeout);
+}
+
 int main(int argc, char *argv[])
 {
 	struct lightningd *ld;
@@ -307,6 +316,9 @@ int main(int argc, char *argv[])
 	ld->wallet = wallet_new(ld, ld->log, &ld->timers);
 	ld->owned_txfilter = txfilter_new(ld);
 	ld->topology->wallet = ld->wallet;
+
+	/* We do extra checks in io_loop. */
+	io_poll_debug = io_poll_override(io_poll_lightningd);
 
 	/* Set up HSM. */
 	hsm_init(ld, newdir);

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -18,6 +18,9 @@ void daemon_setup(const char *argv0 UNNEEDED,
 /* Generated stub for daemon_shutdown */
 void daemon_shutdown(void)
 { fprintf(stderr, "daemon_shutdown called!\n"); abort(); }
+/* Generated stub for db_assert_no_outstanding_statements */
+void db_assert_no_outstanding_statements(void)
+{ fprintf(stderr, "db_assert_no_outstanding_statements called!\n"); abort(); }
 /* Generated stub for db_begin_transaction_ */
 void db_begin_transaction_(struct db *db UNNEEDED, const char *location UNNEEDED)
 { fprintf(stderr, "db_begin_transaction_ called!\n"); abort(); }

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -331,6 +331,71 @@ char *dbmigrations[] = {
     NULL,
 };
 
+/* Leak tracking. */
+#if DEVELOPER
+/* We need a global here, since caller has no context.  Yuck! */
+static struct list_head db_statements = LIST_HEAD_INIT(db_statements);
+
+struct db_statement {
+	struct list_node list;
+	sqlite3_stmt *stmt;
+	const char *origin;
+};
+
+static struct db_statement *find_statement(sqlite3_stmt *stmt)
+{
+	struct db_statement *i;
+
+	list_for_each(&db_statements, i, list) {
+		if (i->stmt == stmt)
+			return i;
+	}
+	return NULL;
+}
+
+void db_assert_no_outstanding_statements(void)
+{
+	struct db_statement *dbstat;
+
+	dbstat = list_top(&db_statements, struct db_statement, list);
+	if (dbstat)
+		fatal("Unfinalized statement %s", dbstat->origin);
+}
+
+static void dev_statement_start(sqlite3_stmt *stmt, const char *origin)
+{
+	struct db_statement *dbstat = tal(NULL, struct db_statement);
+	dbstat->stmt = stmt;
+	dbstat->origin = origin;
+	list_add(&db_statements, &dbstat->list);
+}
+
+static void dev_statement_end(sqlite3_stmt *stmt)
+{
+	struct db_statement *dbstat = find_statement(stmt);
+	list_del_from(&db_statements, &dbstat->list);
+	tal_free(dbstat);
+}
+#else
+static void dev_statement_start(sqlite3_stmt *stmt, const char *origin)
+{
+}
+
+static void dev_statement_end(sqlite3_stmt *stmt)
+{
+}
+
+void db_assert_no_outstanding_statements(void)
+{
+}
+#endif
+
+void db_stmt_done(sqlite3_stmt *stmt)
+{
+	dev_statement_end(stmt);
+	sqlite3_finalize(stmt);
+}
+
 sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query)
 {
 	int err;
@@ -343,6 +408,7 @@ sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query)
 	if (err != SQLITE_OK)
 		fatal("%s: %s: %s", caller, query, sqlite3_errmsg(db->sql));
 
+	dev_statement_start(stmt, caller);
 	return stmt;
 }
 
@@ -353,7 +419,7 @@ void db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt)
 	if (sqlite3_step(stmt) !=  SQLITE_DONE)
 		fatal("%s: %s", caller, sqlite3_errmsg(db->sql));
 
-	sqlite3_finalize(stmt);
+	db_stmt_done(stmt);
 }
 
 /* This one doesn't check if we're in a transaction. */
@@ -394,15 +460,15 @@ bool db_exec_prepared_mayfail_(const char *caller UNUSED, struct db *db, sqlite3
 		goto fail;
 	}
 
-	sqlite3_finalize(stmt);
+	db_stmt_done(stmt);
 	return true;
 fail:
-	sqlite3_finalize(stmt);
+	db_stmt_done(stmt);
 	return false;
 }
 
 sqlite3_stmt *PRINTF_FMT(3, 4)
-    db_query(const char *caller UNUSED, struct db *db, const char *fmt, ...)
+    db_query(const char *caller, struct db *db, const char *fmt, ...)
 {
 	va_list ap;
 	char *query;
@@ -417,11 +483,14 @@ sqlite3_stmt *PRINTF_FMT(3, 4)
 	/* Sets stmt to NULL if not SQLITE_OK */
 	sqlite3_prepare_v2(db->sql, query, -1, &stmt, NULL);
 	tal_free(query);
+	if (stmt)
+		dev_statement_start(stmt, caller);
 	return stmt;
 }
 
 static void destroy_db(struct db *db)
 {
+	db_assert_no_outstanding_statements();
 	sqlite3_close(db->sql);
 }
 
@@ -437,6 +506,7 @@ void db_begin_transaction_(struct db *db, const char *location)
 void db_commit_transaction(struct db *db)
 {
 	assert(db->in_transaction);
+	db_assert_no_outstanding_statements();
 	db_exec(__func__, db, "COMMIT;");
 	db->in_transaction = NULL;
 }
@@ -492,11 +562,11 @@ static int db_get_version(struct db *db)
 
 	err = sqlite3_step(stmt);
 	if (err != SQLITE_ROW) {
-		sqlite3_finalize(stmt);
+		db_stmt_done(stmt);
 		return -1;
 	} else {
 		res = sqlite3_column_int64(stmt, 0);
-		sqlite3_finalize(stmt);
+		db_stmt_done(stmt);
 		return res;
 	}
 }
@@ -599,7 +669,7 @@ s64 db_get_intvar(struct db *db, char *varname, s64 defval)
 		const unsigned char *stringvar = sqlite3_column_text(stmt, 0);
 		res = atol((const char *)stringvar);
 	}
-	sqlite3_finalize(stmt);
+	db_stmt_done(stmt);
 	return res;
 }
 

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -37,7 +37,9 @@ struct db *db_setup(const tal_t *ctx, struct log *log);
  * db_query - Prepare and execute a query, and return the result (or NULL)
  */
 sqlite3_stmt *PRINTF_FMT(3, 4)
-	db_query(const char *caller, struct db *db, const char *fmt, ...);
+	db_query_(const char *location, struct db *db, const char *fmt, ...);
+#define db_query(db, ...) \
+	db_query_(__FILE__ ":" stringify(__LINE__), db, __VA_ARGS__)
 
 /**
  * db_begin_transaction - Begin a transaction
@@ -84,8 +86,9 @@ s64 db_get_intvar(struct db *db, char *varname, s64 defval);
  * @db: Database to query/exec
  * @query: The SQL statement to compile
  */
-#define db_prepare(db,query) db_prepare_(__func__,db,query)
-sqlite3_stmt *db_prepare_(const char *caller, struct db *db, const char *query);
+#define db_prepare(db,query) \
+	db_prepare_(__FILE__ ":" stringify(__LINE__), db, query)
+sqlite3_stmt *db_prepare_(const char *location, struct db *db, const char *query);
 
 /**
  * db_exec_prepared -- Execute a prepared statement

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -112,6 +112,12 @@ bool db_exec_prepared_mayfail_(const char *caller,
 			       struct db *db,
 			       sqlite3_stmt *stmt);
 
+/* Wrapper around sqlite3_finalize(), for tracking statements. */
+void db_stmt_done(sqlite3_stmt *stmt);
+
+/* Call when you know there should be no outstanding db statements. */
+void db_assert_no_outstanding_statements(void);
+
 /* Do not keep db open across a fork: needed for --daemon */
 void db_close_for_fork(struct db *db);
 void db_reopen_after_fork(struct db *db);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -496,7 +496,7 @@ static struct peer *wallet_peer_load(struct wallet *w, const u64 dbid)
 	struct wireaddr *addrp, addr;
 
 	sqlite3_stmt *stmt =
-		db_query(__func__, w->db,
+		db_query(w->db,
 			 "SELECT id, node_id, address FROM peers WHERE id=%"PRIu64";", dbid);
 
 	if (!stmt || sqlite3_step(stmt) != SQLITE_ROW) {
@@ -685,9 +685,8 @@ bool wallet_channels_load_active(const tal_t *ctx, struct wallet *w)
 	sqlite3_stmt *stmt;
 
 	/* We load all channels */
-	stmt = db_query(
-	    __func__, w->db, "SELECT %s FROM channels;",
-	    channel_fields);
+	stmt = db_query(w->db, "SELECT %s FROM channels;",
+			channel_fields);
 
 	w->max_channel_dbid = 0;
 
@@ -828,7 +827,7 @@ bool wallet_channel_config_load(struct wallet *w, const u64 id,
 	    "SELECT id, dust_limit_satoshis, max_htlc_value_in_flight_msat, "
 	    "channel_reserve_satoshis, htlc_minimum_msat, to_self_delay, "
 	    "max_accepted_htlcs FROM channel_configs WHERE id=%" PRIu64 ";";
-	sqlite3_stmt *stmt = db_query(__func__, w->db, query, id);
+	sqlite3_stmt *stmt = db_query(w->db, query, id);
 	if (!stmt || sqlite3_step(stmt) != SQLITE_ROW) {
 		db_stmt_done(stmt);
 		return false;
@@ -1008,7 +1007,7 @@ void wallet_peer_delete(struct wallet *w, u64 peer_dbid)
 	sqlite3_stmt *stmt;
 
 	/* Must not have any channels still using this peer */
-	stmt = db_query(__func__, w->db,
+	stmt = db_query(w->db,
 			"SELECT * FROM channels WHERE peer_id = %"PRIu64,
 			peer_dbid);
 	assert(sqlite3_step(stmt) == SQLITE_DONE);
@@ -1280,7 +1279,7 @@ bool wallet_htlcs_load_for_channel(struct wallet *wallet,
 
 	log_debug(wallet->log, "Loading HTLCs for channel %"PRIu64, chan->dbid);
 	sqlite3_stmt *stmt = db_query(
-	    __func__, wallet->db,
+	    wallet->db,
 	    "SELECT id, channel_htlc_id, msatoshi, cltv_expiry, hstate, "
 	    "payment_hash, shared_secret, payment_key, routing_onion FROM channel_htlcs WHERE "
 	    "direction=%d AND channel_id=%" PRIu64 " AND hstate != %d",
@@ -1301,7 +1300,7 @@ bool wallet_htlcs_load_for_channel(struct wallet *wallet,
 	db_stmt_done(stmt);
 
 	stmt = db_query(
-	    __func__, wallet->db,
+	    wallet->db,
 	    "SELECT id, channel_htlc_id, msatoshi, cltv_expiry, hstate, "
 	    "payment_hash, origin_htlc, payment_key, routing_onion FROM channel_htlcs WHERE "
 	    "direction=%d AND channel_id=%" PRIu64 " AND hstate != %d",
@@ -1907,7 +1906,7 @@ void wallet_htlc_sigs_save(struct wallet *w, u64 channel_id,
 bool wallet_network_check(struct wallet *w,
 			  const struct chainparams *chainparams)
 {
-	sqlite3_stmt *stmt = db_query(__func__, w->db,
+	sqlite3_stmt *stmt = db_query(w->db,
 				      "SELECT val FROM vars WHERE name='genesis_hash'");
 	struct bitcoin_blkid chainhash;
 


### PR DESCRIPTION
This adds minimal tracking to our sqlite3_stmts, to avoid problems like the one we saw causing --daemon to fail in #1420 

Turns out there are more leaks, so this fixes them.