### PR TITLE
lightningd: loosen feerate minimum.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -253,7 +253,7 @@ static void next_updatefee_timer(struct chain_topology *topo);
  * This formula is satisfied by a feerate of 4030 (hand-search).
  */
 #define FEERATE_FLOOR 253
-static u32 feerate_floor(void)
+u32 feerate_floor(void)
 {
 	/* Assert that bitcoind will see this as above minRelayTxFee */
 	BUILD_ASSERT(FEERATE_BITCOIND_SEES(FEERATE_FLOOR, MINIMUM_TX_WEIGHT)

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -136,6 +136,9 @@ u32 get_block_height(const struct chain_topology *topo);
 /* Get fee rate in satoshi per kiloweight. */
 u32 get_feerate(const struct chain_topology *topo, enum feerate feerate);
 
+/* Get the minimum possible fee to allow relaying by bitcoind */
+u32 feerate_floor(void);
+
 /* Broadcast a single tx, and rebroadcast as reqd (copies tx).
  * If failed is non-NULL, call that and don't rebroadcast. */
 void broadcast_tx(struct chain_topology *topo,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -744,15 +744,8 @@ u8 *peer_accept_channel(const tal_t *ctx,
 
 	subd_send_msg(uc->openingd, take(msg));
 
-	/* BOLT #2:
-	 *
-	 * Given the variance in fees, and the fact that the transaction may
-	 * be spent in the future, it's a good idea for the fee payer to keep
-	 * a good margin, say 5x the expected fee requirement */
 	msg = towire_opening_fundee(uc, uc->minimum_depth,
-				    get_feerate(ld->topology, FEERATE_SLOW),
-				    get_feerate(ld->topology, FEERATE_IMMEDIATE)
-				    * 5,
+				    feerate_min(ld), feerate_max(ld),
 				    open_msg);
 
 	subd_req(uc, uc->openingd, take(msg), -1, 2,

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4135,7 +4135,7 @@ class LightningDTests(BaseLightningDTests):
         # L1 asks for stupid low fees
         l1.rpc.dev_setfees(15)
 
-        l1.daemon.wait_for_log('Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 15 outside range 4250-75000')
+        l1.daemon.wait_for_log('Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 15 outside range 500-75000')
         # Make sure the resolution of this one doesn't interfere with the next!
         # Note: may succeed, may fail with insufficient fee, depending on how
         # bitcoind feels!
@@ -4277,7 +4277,7 @@ class LightningDTests(BaseLightningDTests):
         # Make l2 upset by asking for crazy fee.
         l1.rpc.dev_setfees('150000')
         # Wait for l1 notice
-        l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 150000 outside range 4250-75000')
+        l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 150000 outside range 500-75000')
 
         # Can't pay while its offline.
         self.assertRaises(ValueError, l1.rpc.sendpay, to_json(route), rhash)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -71,6 +71,9 @@ bool extract_channel_id(const u8 *in_pkt UNNEEDED, struct channel_id *channel_id
 /* Generated stub for features_supported */
 bool features_supported(const u8 *gfeatures UNNEEDED, const u8 *lfeatures UNNEEDED)
 { fprintf(stderr, "features_supported called!\n"); abort(); }
+/* Generated stub for feerate_floor */
+u32 feerate_floor(void)
+{ fprintf(stderr, "feerate_floor called!\n"); abort(); }
 /* Generated stub for fromwire_gossipctl_peer_disconnect_reply */
 bool fromwire_gossipctl_peer_disconnect_reply(const void *p UNNEEDED)
 { fprintf(stderr, "fromwire_gossipctl_peer_disconnect_reply called!\n"); abort(); }


### PR DESCRIPTION
We're getting spurious closures, even on mainnet.  Using --ignore-fee-limits
is dangerous; it's slightly less so to lower the minimum (which is the
usual cause of problems).

So let's halve it.

This is a workaround, until we get independent feerates in the spec.

(Note: I've labeled this as fixes #613 but that should have been fixed by previous update_fee fixes; this addresses more the other comments on that issue which refer to spontaneous closures without --override-fee-rates).