### PR TITLE
master: Move the gossipd initialization after the other inits

### DIFF
--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -7,8 +7,6 @@ gossipctl_init,3000
 gossipctl_init,,broadcast_interval,u32
 gossipctl_init,,chain_hash,struct bitcoin_blkid
 gossipctl_init,,id,struct pubkey
-# If non-zero, port to listen on.
-gossipctl_init,,port,u16
 gossipctl_init,,gflen,u16
 gossipctl_init,,gfeatures,gflen*u8
 gossipctl_init,,lflen,u16
@@ -21,8 +19,13 @@ gossipctl_init,,update_channel_interval,u32
 # DEVELOPER only
 gossipctl_init,,no_reconnect,bool
 
+# Activate the gossip daemon, so others can connect.
+gossipctl_activate,3025
+# If non-zero, port to listen on.
+gossipctl_activate,,port,u16
+
 # Gossipd->master, I am ready.
-gossipctl_init_reply,3100
+gossipctl_activate_reply,3125
 
 # Master -> gossipd: Optional hint for where to find peer.
 gossipctl_peer_addrhint,3014

--- a/lightningd/gossip_control.h
+++ b/lightningd/gossip_control.h
@@ -8,6 +8,7 @@
 struct lightningd;
 
 void gossip_init(struct lightningd *ld);
+void gossip_activate(struct lightningd *ld);
 
 void gossipd_notify_spend(struct lightningd *ld,
 			  const struct short_channel_id *scid);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -328,9 +328,6 @@ int main(int argc, char *argv[])
 	/* Now we know our ID, we can set our color/alias if not already. */
 	setup_color_and_alias(ld);
 
-	/* Set up gossip daemon. */
-	gossip_init(ld);
-
 	/* Everything is within a transaction. */
 	db_begin_transaction(ld->wallet->db);
 
@@ -393,6 +390,10 @@ int main(int argc, char *argv[])
 		       &ld->timers,
 		       ld->config.poll_time,
 		       blockheight);
+
+	/* Set up gossip daemon. Needs to be after the initialization of
+	 * chaintopology, otherwise we may be asking for uninitialized data. */
+	gossip_init(ld);
 
 	/* Replay transactions for all running onchainds */
 	onchaind_replay_channels(ld);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -328,6 +328,9 @@ int main(int argc, char *argv[])
 	/* Now we know our ID, we can set our color/alias if not already. */
 	setup_color_and_alias(ld);
 
+	/* Set up gossip daemon. */
+	gossip_init(ld);
+
 	/* Everything is within a transaction. */
 	db_begin_transaction(ld->wallet->db);
 
@@ -391,9 +394,9 @@ int main(int argc, char *argv[])
 		       ld->config.poll_time,
 		       blockheight);
 
-	/* Set up gossip daemon. Needs to be after the initialization of
+	/* Activate gossip daemon. Needs to be after the initialization of
 	 * chaintopology, otherwise we may be asking for uninitialized data. */
-	gossip_init(ld);
+	gossip_activate(ld);
 
 	/* Replay transactions for all running onchainds */
 	onchaind_replay_channels(ld);

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -42,6 +42,9 @@ void   fatal(const char *fmt UNNEEDED, ...)
 /* Generated stub for free_htlcs */
 void free_htlcs(struct lightningd *ld UNNEEDED, const struct channel *channel UNNEEDED)
 { fprintf(stderr, "free_htlcs called!\n"); abort(); }
+/* Generated stub for gossip_activate */
+void gossip_activate(struct lightningd *ld UNNEEDED)
+{ fprintf(stderr, "gossip_activate called!\n"); abort(); }
 /* Generated stub for gossip_init */
 void gossip_init(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "gossip_init called!\n"); abort(); }


### PR DESCRIPTION
If we start accepting peer connections before we initialized some of the other
parts (mainly the chaintopology) we could end up asking for stuff that isn't
ready yet (blockchain head for example).

Fixes #1437
