### PR TITLE
make: Disable DEVELOPER by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ VALGRIND=valgrind -q --error-exitcode=7
 VALGRIND_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes --errors-for-leak-kinds=all
 endif
 
-# By default, we are in DEVELOPER mode, use DEVELOPER= on cmdline to override.
+# By default, we are not in DEVELOPER mode, use DEVELOPER=1 on cmdline to override.
 DEVELOPER := 0
 
 ifeq ($(DEVELOPER),1)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VALGRIND_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes 
 endif
 
 # By default, we are in DEVELOPER mode, use DEVELOPER= on cmdline to override.
-DEVELOPER := 1
+DEVELOPER := 0
 
 ifeq ($(DEVELOPER),1)
 DEV_CFLAGS=-DDEVELOPER=1 -DCCAN_TAL_DEBUG=1 -DCCAN_TAKE_DEBUG=1


### PR DESCRIPTION
We had quite a few users running into issues because the `--dev-xyz` options and
`dev-xyz` RPC calls were available. Before a release we should make sure that
the default compilation flags are safe.