### PR TITLE
lightningd: Move onchaind replay and gossipd activation after daemonization

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -394,13 +394,6 @@ int main(int argc, char *argv[])
 		       ld->config.poll_time,
 		       blockheight);
 
-	/* Activate gossip daemon. Needs to be after the initialization of
-	 * chaintopology, otherwise we may be asking for uninitialized data. */
-	gossip_activate(ld);
-
-	/* Replay transactions for all running onchainds */
-	onchaind_replay_channels(ld);
-
 	/* Create RPC socket (if any) */
 	setup_jsonrpc(ld, ld->rpc_filename);
 
@@ -410,6 +403,13 @@ int main(int argc, char *argv[])
 
 	/* Create PID file */
 	pidfile_create(ld);
+
+	/* Activate gossip daemon. Needs to be after the initialization of
+	 * chaintopology, otherwise we may be asking for uninitialized data. */
+	gossip_activate(ld);
+
+	/* Replay transactions for all running onchainds */
+	onchaind_replay_channels(ld);
 
 	/* Mark ourselves live. */
 	log_info(ld->log, "Server started with public key %s, alias %s (color #%s) and lightningd %s",


### PR DESCRIPTION
Fixes: #1445

Hacky fix, possibly.  First cut at avoiding starting up onchaind and gossipd (which might make queries of chaintopology, which might start up a bitcoin-cli) before we can daemonize.

Please ignore the unnecessary merge commit for now, I will fix that later, the other commit is the one I want to merge in.  @Sjors, could you try this branch?