### PR TITLE
pytest: Enable parallel test execution and start migration to modern fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,10 @@ check:
 
 pytest: $(ALL_PROGRAMS)
 ifndef PYTEST
-	PYTHONPATH=contrib/pylightning:$$PYTHONPATH DEVELOPER=$(DEVELOPER) python3 tests/test_lightningd.py -f
+	@echo "py.test is required to run the integration tests, please install using 'pip3 install -r tests/requirements.txt'"
+	exit 1
 else
-	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) -vx tests/test_lightningd.py --test-group=$(TEST_GROUP) --test-group-count=$(TEST_GROUP_COUNT) $(PYTEST_OPTS)
+	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) -vx tests/ --test-group=$(TEST_GROUP) --test-group-count=$(TEST_GROUP_COUNT) $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -47,4 +47,4 @@ RUN cd /tmp/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2
+    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2 flaky==3.4.0

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -47,4 +47,4 @@ RUN cd /tmp/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1
+    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -25,5 +25,5 @@ RUN wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_
     mv bitcoin-$BITCOIN_VERSION/bin/bitcoin* /usr/local/bin/ && \
     rm -rf bitcoin.tar.gz bitcoin-$BITCOIN_VERSION
 
-RUN pip3 install --upgrade pip && \
-    pip3 install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -47,4 +47,4 @@ RUN cd /tmp/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2
+    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2 flaky==3.4.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -47,4 +47,4 @@ RUN cd /tmp/ && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
 
 RUN pip3 install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1
+    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 pytest-xdist==1.22.2

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,12 +15,22 @@ DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
 TEST_DEBUG = os.getenv("TEST_DEBUG", "0") == "1"
 
 
+# A dict in which we count how often a particular test has run so far. Used to
+# give each attempt its own numbered directory, and avoid clashes.
+__attempts = {}
+
+
 @pytest.fixture
 def directory(test_name):
-    """Return a per-test specific directory
+    """Return a per-test specific directory.
+
+    This makes a unique test-directory even if a test is rerun multiple times.
+
     """
-    global TEST_DIR
-    yield os.path.join(TEST_DIR, test_name)
+    global TEST_DIR, __attempts
+    # Auto set value if it isn't in the dict yet
+    __attempts[test_name] = __attempts.get(test_name, 0) + 1
+    yield os.path.join(TEST_DIR, "{}_{}".format(test_name, __attempts[test_name]))
 
 
 @pytest.fixture

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,144 @@
+from concurrent import futures
+from test_lightningd import NodeFactory
+
+import logging
+import os
+import pytest
+import re
+import tempfile
+import utils
+
+
+TEST_DIR = tempfile.mkdtemp(prefix='ltests-')
+VALGRIND = os.getenv("NO_VALGRIND", "0") == "0"
+DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+TEST_DEBUG = os.getenv("TEST_DEBUG", "0") == "1"
+
+
+@pytest.fixture
+def directory(test_name):
+    """Return a per-test specific directory
+    """
+    global TEST_DIR
+    yield os.path.join(TEST_DIR, test_name)
+
+
+@pytest.fixture
+def test_name(request):
+    yield request.function.__name__
+
+
+@pytest.fixture
+def bitcoind(directory):
+    bitcoind = utils.BitcoinD(bitcoin_dir=directory, rpcport=28332)
+    try:
+        bitcoind.start()
+    except Exception:
+        bitcoind.stop()
+        raise
+
+    info = bitcoind.rpc.getnetworkinfo()
+
+    if info['version'] < 160000:
+        bitcoind.rpc.stop()
+        raise ValueError("bitcoind is too old. At least version 16000 (v0.16.0)"
+                         " is needed, current version is {}".format(info['version']))
+
+    info = bitcoind.rpc.getblockchaininfo()
+    # Make sure we have some spendable funds
+    if info['blocks'] < 101:
+        bitcoind.generate_block(101 - info['blocks'])
+    elif bitcoind.rpc.getwalletinfo()['balance'] < 1:
+        logging.debug("Insufficient balance, generating 1 block")
+        bitcoind.generate_block(1)
+
+    yield bitcoind
+
+    try:
+        bitcoind.rpc.stop()
+    except Exception:
+        bitcoind.proc.kill()
+    bitcoind.proc.wait()
+
+
+@pytest.fixture
+def node_factory(directory, test_name, bitcoind, executor):
+    nf = NodeFactory(test_name, bitcoind, executor, directory=directory)
+    yield nf
+    err_count = 0
+    ok = nf.killall([not n.may_fail for n in nf.nodes])
+    if VALGRIND:
+        for node in nf.nodes:
+            err_count += printValgrindErrors(node)
+        if err_count:
+            raise ValueError("{} nodes reported valgrind errors".format(err_count))
+
+    for node in nf.nodes:
+        err_count += printCrashLog(node)
+    if err_count:
+        raise ValueError("{} nodes had crash.log files".format(err_count))
+    for node in nf.nodes:
+        err_count += checkReconnect(node)
+    if err_count:
+        raise ValueError("{} nodes had unexpected reconnections".format(err_count))
+
+    if not ok:
+        raise Exception("At least one lightning exited with unexpected non-zero return code")
+
+
+def getValgrindErrors(node):
+    for error_file in os.listdir(node.daemon.lightning_dir):
+        if not re.fullmatch("valgrind-errors.\d+", error_file):
+            continue
+        with open(os.path.join(node.daemon.lightning_dir, error_file), 'r') as f:
+            errors = f.read().strip()
+            if errors:
+                return errors, error_file
+    return None, None
+
+
+def printValgrindErrors(node):
+    errors, fname = getValgrindErrors(node)
+    if errors:
+        print("-" * 31, "Valgrind errors", "-" * 32)
+        print("Valgrind error file:", fname)
+        print(errors)
+        print("-" * 80)
+    return 1 if errors else 0
+
+
+def getCrashLog(node):
+    if node.may_fail:
+        return None, None
+    try:
+        crashlog = os.path.join(node.daemon.lightning_dir, 'crash.log')
+        with open(crashlog, 'r') as f:
+            return f.readlines(), crashlog
+    except Exception:
+        return None, None
+
+
+def printCrashLog(node):
+    errors, fname = getCrashLog(node)
+    if errors:
+        print("-" * 10, "{} (last 50 lines)".format(fname), "-" * 10)
+        for l in errors[-50:]:
+            print(l, end='')
+        print("-" * 80)
+    return 1 if errors else 0
+
+
+def checkReconnect(node):
+    # Without DEVELOPER, we can't suppress reconnection.
+    if node.may_reconnect or not DEVELOPER:
+        return 0
+    if node.daemon.is_in_log('Peer has reconnected'):
+        return 1
+    return 0
+
+
+@pytest.fixture
+def executor():
+    ex = futures.ThreadPoolExecutor(max_workers=20)
+    yield ex
+    ex.shutdown(wait=False)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -30,7 +30,7 @@ def test_name(request):
 
 @pytest.fixture
 def bitcoind(directory):
-    bitcoind = utils.BitcoinD(bitcoin_dir=directory, rpcport=28332)
+    bitcoind = utils.BitcoinD(bitcoin_dir=directory, rpcport=None)
     try:
         bitcoind.start()
     except Exception:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,4 @@
 python-bitcoinlib==0.7.0
+ephemeral-port-reserve==1.1.0
+pytest-forked==0.2
+flaky==3.4.0

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1,0 +1,60 @@
+from fixtures import *  # noqa: F401,F403
+from test_lightningd import wait_for
+
+import os
+import time
+import unittest
+
+
+DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+
+
+@unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-broadcast-interval")
+def test_gossip_pruning(node_factory, bitcoind):
+    """ Create channel and see it being updated in time before pruning
+    """
+    opts = {'channel-update-interval': 5}
+    l1, l2, l3 = node_factory.get_nodes(3, opts)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
+    l2.rpc.connect(l3.info['id'], 'localhost', l3.info['port'])
+
+    scid1 = l1.fund_channel(l2, 10**6)
+    scid2 = l2.fund_channel(l3, 10**6)
+
+    bitcoind.rpc.generate(6)
+
+    # Channels should be activated locally
+    wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True] * 4)
+    wait_for(lambda: [c['active'] for c in l2.rpc.listchannels()['channels']] == [True] * 4)
+    wait_for(lambda: [c['active'] for c in l3.rpc.listchannels()['channels']] == [True] * 4)
+
+    # All of them should send a keepalive message
+    l1.daemon.wait_for_logs([
+        'Sending keepalive channel_update for {}'.format(scid1),
+    ])
+    l2.daemon.wait_for_logs([
+        'Sending keepalive channel_update for {}'.format(scid1),
+        'Sending keepalive channel_update for {}'.format(scid2),
+    ])
+    l3.daemon.wait_for_logs([
+        'Sending keepalive channel_update for {}'.format(scid2),
+    ])
+
+    # Now kill l3, so that l2 and l1 can prune it from their view after 10 seconds
+
+    # FIXME: This sleep() masks a real bug: that channeld sends a
+    # channel_update message (to disable the channel) with same
+    # timestamp as the last keepalive, and thus is ignored.  The minimal
+    # fix is to backdate the keepalives 1 second, but maybe we should
+    # simply have gossipd generate all updates?
+    time.sleep(1)
+    l3.stop()
+
+    l1.daemon.wait_for_log("Pruning channel {} from network view".format(scid2))
+    l2.daemon.wait_for_log("Pruning channel {} from network view".format(scid2))
+
+    assert scid2 not in [c['short_channel_id'] for c in l1.rpc.listchannels()['channels']]
+    assert scid2 not in [c['short_channel_id'] for c in l2.rpc.listchannels()['channels']]
+    assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.listnodes()['nodes']]
+    assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.listnodes()['nodes']]

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -316,8 +316,7 @@ class BaseLightningDTests(unittest.TestCase):
 
 class LightningDTests(BaseLightningDTests):
     def connect(self, may_reconnect=False):
-        l1 = self.node_factory.get_node(may_reconnect=may_reconnect)
-        l2 = self.node_factory.get_node(may_reconnect=may_reconnect)
+        l1, l2 = self.node_factory.get_nodes(2, opts={'may_reconnect': may_reconnect})
         ret = l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
 
         assert ret['id'] == l2.info['id']

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 from decimal import Decimal
 from ephemeral_port_reserve import reserve as reserve_port
+from flaky import flaky
 from utils import wait_for
 
 import copy
@@ -1437,6 +1438,7 @@ class LightningDTests(BaseLightningDTests):
         bitcoind.generate_block(5)
         sync_blockheight([l1])
 
+    @flaky
     def test_closing_different_fees(self):
         l1 = self.node_factory.get_node()
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -95,12 +95,17 @@ def teardown_bitcoind():
 class NodeFactory(object):
     """A factory to setup and start `lightningd` daemons.
     """
-    def __init__(self, testname, bitcoind, executor):
+    def __init__(self, testname, bitcoind, executor, directory=None):
         self.testname = testname
         self.next_id = 1
         self.nodes = []
         self.executor = executor
         self.bitcoind = bitcoind
+        if directory is not None:
+            self.directory = directory
+        else:
+            self.directory = os.path.join(TEST_DIR, testname)
+        self.lock = threading.Lock()
 
     def split_options(self, opts):
         """Split node options from cli options
@@ -148,7 +153,7 @@ class NodeFactory(object):
         self.next_id += 1
 
         lightning_dir = os.path.join(
-            TEST_DIR, self.testname, "lightning-{}/".format(node_id))
+            self.directory, "lightning-{}/".format(node_id))
 
         if os.path.exists(lightning_dir):
             shutil.rmtree(lightning_dir)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -163,7 +163,10 @@ class NodeFactory(object):
             shutil.rmtree(lightning_dir)
 
         socket_path = os.path.join(lightning_dir, "lightning-rpc").format(node_id)
-        daemon = utils.LightningD(lightning_dir, self.bitcoind.bitcoin_dir, port=port, random_hsm=random_hsm)
+        daemon = utils.LightningD(
+            lightning_dir, self.bitcoind.bitcoin_dir,
+            port=port, random_hsm=random_hsm, node_id=node_id
+        )
         # If we have a disconnect string, dump it to a file for daemon.
         if disconnect:
             with open(os.path.join(lightning_dir, "dev_disconnect"), "w") as f:

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -2440,58 +2440,6 @@ class LightningDTests(BaseLightningDTests):
         node = l2.rpc.listnodes(l1.info['id'])['nodes'][0]
         assert node['alias'] == weird_name
 
-    @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-broadcast-interval")
-    def test_gossip_pruning(self):
-        """ Create channel and see it being updated in time before pruning
-        """
-        opts = {'channel-update-interval': 5}
-        l1 = self.node_factory.get_node(options=opts)
-        l2 = self.node_factory.get_node(options=opts)
-        l3 = self.node_factory.get_node(options=opts)
-
-        l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
-        l2.rpc.connect(l3.info['id'], 'localhost', l3.info['port'])
-
-        scid1 = self.fund_channel(l1, l2, 10**6)
-        scid2 = self.fund_channel(l2, l3, 10**6)
-
-        l1.bitcoin.rpc.generate(6)
-
-        # Channels should be activated locally
-        wait_for(lambda: [c['active'] for c in l1.rpc.listchannels()['channels']] == [True] * 4)
-        wait_for(lambda: [c['active'] for c in l2.rpc.listchannels()['channels']] == [True] * 4)
-        wait_for(lambda: [c['active'] for c in l3.rpc.listchannels()['channels']] == [True] * 4)
-
-        # All of them should send a keepalive message
-        l1.daemon.wait_for_logs([
-            'Sending keepalive channel_update for {}'.format(scid1),
-        ])
-        l2.daemon.wait_for_logs([
-            'Sending keepalive channel_update for {}'.format(scid1),
-            'Sending keepalive channel_update for {}'.format(scid2),
-        ])
-        l3.daemon.wait_for_logs([
-            'Sending keepalive channel_update for {}'.format(scid2),
-        ])
-
-        # Now kill l3, so that l2 and l1 can prune it from their view after 10 seconds
-
-        # FIXME: This sleep() masks a real bug: that channeld sends a
-        # channel_update message (to disable the channel) with same
-        # timestamp as the last keepalive, and thus is ignored.  The minimal
-        # fix is to backdate the keepalives 1 second, but maybe we should
-        # simply have gossipd generate all updates?
-        time.sleep(1)
-        l3.stop()
-
-        l1.daemon.wait_for_log("Pruning channel {} from network view".format(scid2))
-        l2.daemon.wait_for_log("Pruning channel {} from network view".format(scid2))
-
-        assert scid2 not in [c['short_channel_id'] for c in l1.rpc.listchannels()['channels']]
-        assert scid2 not in [c['short_channel_id'] for c in l2.rpc.listchannels()['channels']]
-        assert l3.info['id'] not in [n['nodeid'] for n in l1.rpc.listnodes()['nodes']]
-        assert l3.info['id'] not in [n['nodeid'] for n in l2.rpc.listnodes()['nodes']]
-
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-no-reconnect")
     def test_gossip_persistence(self):
         """Gossip for a while, restart and it should remember.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ import time
 
 from bitcoin.rpc import RawProxy as BitcoinProxy
 from decimal import Decimal
+from ephemeral_port_reserve import reserve
 
 
 BITCOIND_CONFIG = {
@@ -209,8 +210,11 @@ class SimpleBitcoinProxy:
 
 class BitcoinD(TailableProc):
 
-    def __init__(self, bitcoin_dir="/tmp/bitcoind-test", rpcport=18332):
+    def __init__(self, bitcoin_dir="/tmp/bitcoind-test", rpcport=None):
         TailableProc.__init__(self, bitcoin_dir, verbose=False)
+
+        if rpcport is None:
+            rpcport = reserve()
 
         self.bitcoin_dir = bitcoin_dir
         self.rpcport = rpcport

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -251,7 +251,7 @@ class BitcoinD(TailableProc):
 
 
 class LightningD(TailableProc):
-    def __init__(self, lightning_dir, bitcoin_dir, port=9735, random_hsm=False):
+    def __init__(self, lightning_dir, bitcoin_dir, port=9735, random_hsm=False, node_id=0):
         TailableProc.__init__(self, lightning_dir)
         self.lightning_dir = lightning_dir
         self.port = port
@@ -281,7 +281,7 @@ class LightningD(TailableProc):
                 f.write(seed)
         if DEVELOPER:
             self.opts['dev-broadcast-interval'] = 1000
-        self.prefix = 'lightningd(%d)' % (port)
+        self.prefix = 'lightningd-%d' % (node_id)
 
     @property
     def cmd_line(self):


### PR DESCRIPTION
I got a bit sidetracked while implementing the `local_channel_updates` patch (that's going to be my next PR). This PR modernizes the integration test environment using the pytest style fixtures, flattening the test structure (functions instead of class methods) and begins the migrating the tests into smaller, better structured test files. The goal is to split the huge `test_lightningd` into smaller, topic based test files that can be selectively executed for changes, e.g., executing `test_gossip.py` if we changed gossip and don't expect failures in other parts of the suite (CI will still catch those).

One major change is that we now have the tests isolated into their own directory and selecting random ports for all daemons, which means that we can run the tests in parallel with `pytest-xdist`:

```
$ NO_VALGRIND=1 DEVELOPER=1 TEST_DEBUG=0 py.test -v tests/ -p no:logging -n 25
...
=== 99 passed, 1 skipped in 137.54 seconds ===
```

Which should speed up the change-test-fix cycle alot. One downside is that we add a few required dependencies: `pytest` and `ephemeral-port-reserve`, and since we're at it we also add `flaky`. These can be easily installed via `pip3 install -r tests/requirements.txt` and I strongly suggest using virtualenvs for these anyway.

`flaky` now also works as a decorator, it'll just rerun the test once (and really produce an independent result thanks to the directory isolation). This is more of a stop-gap solution to be able to work with the CI, and should not free us from actually stabilizing the test though :wink: 