### PR TITLE
doc: Added fundchannel man page.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,6 +11,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-decodepay.7 \
 	doc/lightning-delexpiredinvoice.7 \
 	doc/lightning-delinvoice.7 \
+	doc/lightning-fundchannel.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-listfunds.7 \

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -1,0 +1,114 @@
+'\" t
+.\"     Title: lightning-fundchannel
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 05/07/2018
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-FUNDCHANN" "7" "05/07/2018" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-fundchannel \- Command for establishing a lightning channel\&.
+.SH "SYNOPSIS"
+.sp
+\fBfundchannel\fR \fIid\fR \fIsatoshi\fR
+.SH "DESCRIPTION"
+.sp
+The \fBfundchannel\fR RPC command opens a payment channel with a peer by commiting a funding transaction to the blockchain as defined in BOLT #2\&. \fBfundchannel\fR by itself does not attempt to open a connection\&. A connection must first be established using \fBconnect\fR\&. Once the transaction is confirmed, normal channel operations may begin\&. Readiness is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL for the channel\&.
+.sp
+\fIid\fR is the peer id obtained from \fBconnect\fR\&.
+.sp
+\fIsatoshi\fR is the amount in satoshis taken from the internal wallet to fund the channel\&. The string \fIall\fR can be used to specify all available funds\&. This value must be greater than the dust limit, currently set to 546\&. And it must be less than 1<<24 (approximately 0\&.16778 BTC)\&.
+.SH "RETURN VALUE"
+.sp
+On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well as the \fIchannel_id\fR of the newly created channel\&. On failure, an error is reported and the channel is not funded\&.
+.sp
+The following error codes may occur:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\-1\&. Catchall nonspecific arror\&.
+.RE
+.sp
+The above error may include a descriptive message indicating:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The
+\fIid\fR
+is invalid\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+There are not enough funds in the internal wallet to create the transaction\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The maximum allowed funding amount is exceeded\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIsatoshi\fR
+is less than the dust limit\&.
+.RE
+.sp
+Failure may also occur if \fBlightningd\fR and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc\&.)\&.
+.SH "SEE ALSO"
+.sp
+lightning\-connect(7), lightning\-listfunds(), lightning\-listpeers(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -1,0 +1,56 @@
+LIGHTNING-FUNDCHANNEL(7)
+========================
+:doctype: manpage
+
+NAME
+----
+lightning-fundchannel - Command for establishing a lightning channel.
+
+SYNOPSIS
+--------
+*fundchannel* 'id' 'satoshi'
+
+DESCRIPTION
+-----------
+The *fundchannel* RPC command opens a payment channel with a peer by commiting
+a funding transaction to the blockchain as defined in BOLT #2.
+*fundchannel* by itself does not attempt to open a connection.
+A connection must first be established using *connect*.
+Once the transaction is confirmed, normal channel operations may begin.
+Readiness is indicated by *listpeers* reporting a 'state' of CHANNELD_NORMAL
+for the channel.
+
+'id' is the peer id obtained from *connect*.
+
+'satoshi' is the amount in satoshis taken from the internal wallet to fund the channel.
+The string 'all' can be used to specify all available funds.
+This value must be greater than the dust limit, currently set to 546.
+And it must be less than 1<<24 (approximately 0.16778 BTC).
+
+RETURN VALUE
+------------
+On success, the 'tx' and 'txid' of the transaction is returned, as well as the
+'channel_id' of the newly created channel.
+On failure, an error is reported and the channel is not funded.
+
+The following error codes may occur:
+
+* -1. Catchall nonspecific arror.
+
+The above error may include a descriptive message indicating:
+
+* The 'id' is invalid.
+* There are not enough funds in the internal wallet to create the transaction.
+* The maximum allowed funding amount is exceeded.
+* 'satoshi' is less than the dust limit.
+
+Failure may also occur if *lightningd* and the peer cannot agree on channel
+parameters (funding limits, channel reserves, fees, etc.).
+
+SEE ALSO
+--------
+lightning-connect(7), lightning-listfunds(), lightning-listpeers(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning


### PR DESCRIPTION
This describes `fundchannel` as it works today (as I understand it). #1360

It definitely could use better error codes instead of -1 for everything.

Is there a better way to tell if the channel is ready than the one I described?