### PR TITLE
Forget channel if we are fundee and it has not confirmed yet for a long time

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -16,6 +16,7 @@
 #include <common/timeout.h>
 #include <common/utils.h>
 #include <inttypes.h>
+#include <lightningd/channel_control.h>
 #include <lightningd/gossip_control.h>
 
 /* Mutual recursion via timer. */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -158,7 +158,6 @@ void begin_topology(struct chain_topology *topo);
 
 struct txlocator *locate_tx(const void *ctx, const struct chain_topology *topo, const struct bitcoin_txid *txid);
 
-void notify_new_block(struct lightningd *ld, unsigned int height);
 void notify_feerate_change(struct lightningd *ld);
 
 #if DEVELOPER

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -92,7 +92,7 @@ struct channel {
 
 	/* Blockheight at creation, scans for funding confirmations
 	 * will start here */
-	u64 first_blocknum;
+	u32 first_blocknum;
 
 	/* Feerate range */
 	u32 min_possible_feerate, max_possible_feerate;

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -341,12 +341,7 @@ is_fundee_should_forget(struct lightningd *ld,
 			struct channel *channel,
 			u32 block_height)
 {
-	u32 max_no_funding_tx = 2016;
-
-	/* FIXME: we should be getting max_no_funding_tx
-	 * from an lightningd option, which is why we get
-	 * it as an argument. */
-	(void) ld;
+	u32 max_funding_unconfirmed = ld->max_funding_unconfirmed;
 
 	/* BOLT #2:
 	 *
@@ -369,7 +364,7 @@ is_fundee_should_forget(struct lightningd *ld,
 		return false;
 
 	/* Timeout in blocks not yet reached. */
-	if (block_height - channel->first_blocknum < max_no_funding_tx)
+	if (block_height - channel->first_blocknum < max_funding_unconfirmed)
 		return false;
 
 	/* Ah forget it! */

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -19,5 +19,8 @@ bool channel_tell_funding_locked(struct lightningd *ld,
 				 struct channel *channel,
 				 const struct bitcoin_txid *txid,
 				 u32 depth);
+/* Notify channels of new blocks. */
+void channel_notify_new_block(struct lightningd *ld,
+			      u32 block_height);
 
 #endif /* LIGHTNING_LIGHTNINGD_CHANNEL_CONTROL_H */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -87,6 +87,8 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->use_proxy_always = false;
 	ld->pure_tor_setup = false;
 	ld->tor_service_password = NULL;
+	ld->max_funding_unconfirmed = 2016;
+
 	return ld;
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <lightningd/bitcoind.h>
 #include <lightningd/chaintopology.h>
+#include <lightningd/channel_control.h>
 #include <lightningd/invoice.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/log.h>
@@ -290,6 +291,14 @@ static int io_poll_lightningd(struct pollfd *fds, nfds_t nfds, int timeout)
 	db_assert_no_outstanding_statements();
 
 	return io_poll_debug(fds, nfds, timeout);
+}
+
+void notify_new_block(struct lightningd *ld,
+		      u32 block_height)
+{
+	/* Inform our subcomponents individually. */
+	htlcs_notify_new_block(ld, block_height);
+	channel_notify_new_block(ld, block_height);
 }
 
 int main(int argc, char *argv[])

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -160,6 +160,10 @@ struct lightningd {
 	u64 ini_autocleaninvoice_cycle;
 	u64 ini_autocleaninvoice_expiredby;
 
+	/* Number of blocks we wait for a channel to get funded
+	 * if we are the fundee. */
+	u32 max_funding_unconfirmed;
+
 #if DEVELOPER
 	/* If we want to debug a subdaemon. */
 	const char *dev_debug_subdaemon;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -192,4 +192,7 @@ struct backtrace_state *backtrace_state;
 /* Check we can run subdaemons, and check their versions */
 void test_daemons(const struct lightningd *ld);
 
+/* Notify lightningd about new blocks. */
+void notify_new_block(struct lightningd *ld, u32 block_height);
+
 #endif /* LIGHTNING_LIGHTNINGD_LIGHTNINGD_H */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -49,7 +49,7 @@ struct uncommitted_channel {
 
 	/* Blockheight at creation, scans for funding confirmations
 	 * will start here */
-	u64 first_blocknum;
+	u32 first_blocknum;
 
 	/* These are *not* filled in by new_uncommitted_channel: */
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -406,6 +406,15 @@ static void config_register_opts(struct lightningd *ld)
 	opt_register_early_arg("--always-use-proxy",
 			       opt_set_bool_arg, opt_show_bool,
 			       &ld->use_proxy_always, "Use the proxy always");
+
+#if DEVELOPER
+	opt_register_arg("--dev-max-funding-unconfirmed-blocks",
+			 opt_set_u32, opt_show_u32,
+			 &ld->max_funding_unconfirmed,
+			 "Maximum number of blocks we wait for a channel "
+			 "funding transaction to confirm, if we are the "
+			 "fundee.");
+#endif
 }
 
 #if DEVELOPER

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1514,7 +1514,7 @@ static u32 htlc_in_deadline(const struct lightningd *ld,
 	return hin->cltv_expiry - (ld->config.cltv_expiry_delta + 1)/2;
 }
 
-void notify_new_block(struct lightningd *ld, u32 height)
+void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 {
 	bool removed;
 

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -57,4 +57,6 @@ void onchain_failed_our_htlc(const struct channel *channel,
 			     const char *why);
 void onchain_fulfilled_htlc(struct channel *channel,
 			    const struct preimage *preimage);
+
+void htlcs_notify_new_block(struct lightningd *ld, u32 height);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -11,6 +11,10 @@ void activate_peers(struct lightningd *ld UNNEEDED)
 /* Generated stub for begin_topology */
 void begin_topology(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "begin_topology called!\n"); abort(); }
+/* Generated stub for channel_notify_new_block */
+void channel_notify_new_block(struct lightningd *ld UNNEEDED,
+			      u32 block_height UNNEEDED)
+{ fprintf(stderr, "channel_notify_new_block called!\n"); abort(); }
 /* Generated stub for daemon_setup */
 void daemon_setup(const char *argv0 UNNEEDED,
 		  void (*backtrace_print)(const char *fmt UNNEEDED, ...) UNNEEDED,
@@ -58,6 +62,9 @@ size_t hash_htlc_key(const struct htlc_key *htlc_key UNNEEDED)
 /* Generated stub for hsm_init */
 void hsm_init(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "hsm_init called!\n"); abort(); }
+/* Generated stub for htlcs_notify_new_block */
+void htlcs_notify_new_block(struct lightningd *ld UNNEEDED, u32 height UNNEEDED)
+{ fprintf(stderr, "htlcs_notify_new_block called!\n"); abort(); }
 /* Generated stub for json_escape */
 struct json_escaped *json_escape(const tal_t *ctx UNNEEDED, const char *str TAKES UNNEEDED)
 { fprintf(stderr, "json_escape called!\n"); abort(); }

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4633,6 +4633,43 @@ class LightningDTests(BaseLightningDTests):
         l1.daemon.wait_for_log(r'Adding block 105')
         assert not l1.daemon.is_in_log(r'Adding block 102')
 
+    @unittest.skipIf(not DEVELOPER, "needs --dev-max-funding-unconfirmed-blocks")
+    def test_fundee_forget_funding_tx_unconfirmed(self):
+        """Test that fundee will forget the channel if
+        the funding tx has been unconfirmed for too long.
+        """
+        # Keep this low (default is 2016), since everything
+        # is much slower in VALGRIND mode and wait_for_log
+        # could time out before lightningd processes all the
+        # blocks.
+        blocks = 200
+        # funder
+        l1 = self.node_factory.get_node(fake_bitcoin_cli=True)
+        # fundee
+        l2 = self.node_factory.get_node(options={"dev-max-funding-unconfirmed-blocks": blocks})
+        l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+        # Give funder some funds.
+        self.give_funds(l1, 10**7)
+        # Let blocks settle.
+        time.sleep(1)
+
+        # Prevent funder from broadcasting funding tx.
+        self.fake_bitcoind_fail(l1, 1)
+        # Fund the channel.
+        # The process will complete, but funder will be unable
+        # to broadcast and confirm funding tx.
+        l1.rpc.fundchannel(l2.info['id'], 10**6)
+        # Prevent l1 from timing out bitcoin-cli.
+        self.fake_bitcoind_unfail(l1)
+        # Generate blocks until unconfirmed.
+        bitcoind.generate_block(blocks)
+
+        # fundee will forget channel!
+        l2.daemon.wait_for_log('Forgetting channel: It has been {} blocks'.format(blocks))
+        # fundee will also forget and disconnect from peer.
+        assert len(l2.rpc.listpeers(l1.info['id'])['peers']) == 0
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
As per BOLT spec:

> A non-funding node (fundee):
>   - SHOULD forget the channel if it does not see the
> funding transaction after a reasonable timeout.

We use blocks as unit of timeout.  We forget the channel, if we are the fundee, if it has been 2016 blocks (`--max-funding-unconfirmed-blocks`, two weeks) since the channel was opened, and we have not seen it locked in yet.