### PR TITLE
pytest: Fix flaky `test_closing_id` test

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1,0 +1,29 @@
+from fixtures import *  # noqa: F401,F403
+
+import os
+
+
+DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+
+
+def test_closing_id(node_factory):
+    """Test closing using peer ID and full channel ID
+    """
+    l1, l2 = node_factory.get_nodes(2)
+
+    # Close by full channel ID.
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.info['port'])
+    l1.fund_channel(l2, 10**6)
+    cid = l2.rpc.listpeers()['peers'][0]['channels'][0]['channel_id']
+    l2.rpc.close(cid)
+    l1.daemon.wait_for_log("Forgetting remote peer .*")
+    l2.daemon.wait_for_log("Forgetting remote peer .*")
+
+    # Close by peer ID.
+    l2.rpc.connect(l1.info['id'], 'localhost', l1.info['port'])
+    l1.daemon.wait_for_log("hand_back_peer .*: now local again")
+    l2.fund_channel(l1, 10**6)
+    pid = l1.info['id']
+    l2.rpc.close(pid)
+    l1.daemon.wait_for_log("Forgetting remote peer .*")
+    l2.daemon.wait_for_log("Forgetting remote peer .*")

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1288,21 +1288,6 @@ class LightningDTests(BaseLightningDTests):
 
         l2.daemon.wait_for_log('to_self_delay 100 larger than 99')
 
-    def test_closing_id(self):
-        """Test closing using peer ID and full channel ID"""
-        l1, l2 = self.connect()
-
-        # Close by full channel ID.
-        self.fund_channel(l1, l2, 10**6)
-        cid = l2.rpc.listpeers()['peers'][0]['channels'][0]['channel_id']
-        l2.rpc.close(cid)
-
-        # Close by peer ID.
-        l1.rpc.connect(l2.info['id'])
-        self.fund_channel(l2, l1, 10**6)
-        pid = l1.info['id']
-        l2.rpc.close(pid)
-
     def test_closing(self):
         l1, l2 = self.connect()
 


### PR DESCRIPTION
It simply wasn't waiting for us to register the peer before attempting to open a
connection. Moved into a separate test to be able rerun multiple times.
