### PR TITLE
Fix BUILD_ASSERT failure in wireaddr_to_sockname

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -8,9 +8,7 @@
 #include <common/wireaddr.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/un.h>
 #include <wire/wire.h>
 
 /* Returns false if we didn't parse it, and *cursor == NULL if malformed. */

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -5,6 +5,8 @@
 #include <ccan/tal/tal.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 struct in6_addr;
 struct in_addr;
@@ -87,12 +89,12 @@ enum wireaddr_internal_type {
 struct wireaddr_internal {
 	enum wireaddr_internal_type itype;
 	union {
-		/* ADDR_INTERNAL_SOCKNAME */
+		/* ADDR_INTERNAL_WIREADDR */
 		struct wireaddr wireaddr;
 		/* ADDR_INTERNAL_ALLPROTO */
 		u16 port;
-		/* ADDR_INTERNAL_WIREADDR */
-		char sockname[108];
+		/* ADDR_INTERNAL_SOCKNAME */
+		char sockname[sizeof(((struct sockaddr_un *)0)->sun_path)];
 	} u;
 };
 bool parse_wireaddr_internal(const char *arg, struct wireaddr_internal *addr, u16 port, bool wildcard_ok, const char **err_msg);


### PR DESCRIPTION
Fix BUILD_ASSERT failure on macOS, introduced in https://github.com/ElementsProject/lightning/commit/6b2282fc1dd9f09cf238340d9e1daa9de424b098

Fixes: #1478