### PR TITLE
lightning-cli: clean up -H a little more, don't suppress `help listpeeers` etc

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4358,7 +4358,7 @@ class LightningDTests(BaseLightningDTests):
                                        .format(l1.daemon.lightning_dir),
                                        'help']).decode('utf-8')
         # Test some known output.
-        assert 'help\n    List available commands, or give verbose help on one command' in out
+        assert 'command=help\ndescription=List available commands, or give verbose help on one command.\n' in out
 
         # Test JSON output.
         out = subprocess.check_output(['cli/lightning-cli',


### PR DESCRIPTION
No wonder nobody was filling these in!

    $ cli/lightning-cli help listpeers
    HELP! Please contribute a description for this command!

And:

    $ cli/lightning-cli help help
    help [command]
    Without [command]:
      Outputs an array of objects with 'command' and 'description'
    With [command]:
      Give a single object containing 'verbose', which completely describes
      the command inputs and outputs.

This is a subtle attempt to encourage @isghe as in #1476 :)