### PR TITLE
gossipd: when reconnecting, make sure we free old connection.

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -463,8 +463,9 @@ static struct io_plan *peer_connected(struct io_conn *conn, struct peer *peer)
 			add_reconnecting_peer(peer->daemon, peer);
 			return io_wait(conn, peer, retry_peer_connected, peer);
 		}
-		/* Local peers can just be discarded when they reconnect */
-		tal_free(old_peer);
+		/* Local peers can just be discarded when they reconnect:
+		 * closing conn will free peer. */
+		io_close(old_peer->local->conn);
 	}
 
 	reached_peer(peer, conn);


### PR DESCRIPTION
Looks like old connection got a callback, and we blew up since
the old peer was freed:

2018-05-06T10:57:11.865Z lightning_gossipd(14387): ...will try again in 300 seconds
2018-05-06T10:57:16.397Z lightning_gossipd(14387): peer_out WIRE_INIT
2018-05-06T10:57:16.405Z lightning_gossipd(14387): peer_in WIRE_INIT
2018-05-06T10:57:16.406Z lightning_gossipd(14387): peer 03b30e131241fe28fc923d74a060a8c7abfcc91323c485f8a9cf964575cb4fd3f4: reconnect for local peer
2018-05-06T10:57:16.406Z lightning_gossipd(14387): peer 03b30e131241fe28fc923d74a060a8c7abfcc91323c485f8a9cf964575cb4fd3f4 now remote
2018-05-06T10:57:16.406Z lightning_gossipd(14387): UPDATE WIRE_GOSSIP_PEER_CONNECTED
2018-05-06T10:57:16.406Z lightning_gossipd(14387): UPDATE WIRE_GOSSIP_PEER_CONNECTED
2018-05-06T10:57:16.406Z lightning_gossipd(14387): Handing back peer 03b30e131241fe28fc923d74a060a8c7abfcc91323c485f8a9cf964575cb4fd3f4 to master
2018-05-06T10:57:16.420Z lightning_gossipd(14387): hand_back_peer 03b30e131241fe28fc923d74a060a8c7abfcc91323c485f8a9cf964575cb4fd3f4: now local again
2018-05-06T10:57:16.420Z lightning_gossipd(14387): FATAL SIGNAL 11
2018-05-06T10:57:16.420Z lightning_gossipd(14387): backtrace: common/daemon.c:42 (crashdump) 0x416991
2018-05-06T10:57:16.420Z lightning_gossipd(14387): backtrace: (null):0 ((null)) 0x7f70cf57a4af
2018-05-06T10:57:16.420Z lightning_gossipd(14387): backtrace: common/msg_queue.c:38 (msg_dequeue) 0x418232
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: gossipd/gossip.c:816 (peer_pkt_out) 0x404ac4
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x4316db
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: ccan/ccan/io/io.c:427 (io_do_always) 0x4322ce
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: ccan/ccan/io/poll.c:228 (handle_always) 0x433abd
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: ccan/ccan/io/poll.c:249 (io_loop) 0x433b48
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: gossipd/gossip.c:2407 (main) 0x4093aa
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: (null):0 ((null)) 0x7f70cf56582f
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: (null):0 ((null)) 0x402ad8
2018-05-06T10:57:16.421Z lightning_gossipd(14387): backtrace: (null):0 ((null)) 0xffffffffffffffff
2018-05-06T10:57:16.421Z lightning_gossipd(14387): STATUS_FAIL_INTERNAL_ERROR: FATAL SIGNAL

Fixes: #1469
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>