### PR TITLE
Fix build on linux-musl

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2419-g9bdb4be8
+CCAN version: init-2423-g696c9b68

--- a/ccan/ccan/endian/endian.h
+++ b/ccan/ccan/endian/endian.h
@@ -113,9 +113,17 @@ static inline uint64_t bswap_64(uint64_t val)
 #elif HAVE_LITTLE_ENDIAN && HAVE_BIG_ENDIAN
 #error "Can't compile for both big and little endian."
 #elif HAVE_LITTLE_ENDIAN
+#ifndef __BYTE_ORDER
 #define __BYTE_ORDER	__LITTLE_ENDIAN
+#elif __BYTE_ORDER != __LITTLE_ENDIAN
+#error "__BYTE_ORDER already defined, but not equal to __LITTLE_ENDIAN"
+#endif
 #elif HAVE_BIG_ENDIAN
+#ifndef __BYTE_ORDER
 #define __BYTE_ORDER	__BIG_ENDIAN
+#elif __BYTE_ORDER != __BIG_ENDIAN
+#error "__BYTE_ORDER already defined, but not equal to __BIG_ENDIAN"
+#endif
 #endif
 
 

--- a/ccan/ccan/opt/usage.c
+++ b/ccan/ccan/opt/usage.c
@@ -110,7 +110,7 @@ static char *add_desc(char *base, size_t *len, size_t *max,
 
 	base = add_str(base, len, max, opt->names);
 	off = strlen(opt->names);
-	if (opt->type == OPT_HASARG
+	if ((opt->type & OPT_HASARG)
 	    && !strchr(opt->names, ' ')
 	    && !strchr(opt->names, '=')) {
 		base = add_str(base, len, max, " <arg>");

--- a/ccan/tools/configurator/configurator.c
+++ b/ccan/tools/configurator/configurator.c
@@ -102,7 +102,8 @@ static struct test tests[] = {
 	  "#include <stdio.h>\n"
 	  "static char *func(int x) {"
 	  "	char *p;\n"
-	  "	if (asprintf(&p, \"%u\", x) == -1) p = NULL;"
+	  "	if (asprintf(&p, \"%u\", x) == -1) \n"
+	  "		p = NULL;\n"
 	  "	return p;\n"
 	  "}" },
 	{ "HAVE_ATTRIBUTE_COLD", DEFINES_FUNC, NULL, NULL,


### PR DESCRIPTION
Will allow me to build on alpine, fix this error I get on https://github.com/ElementsProject/lightning/pull/1318

```
In file included from ./bitcoin/block.h:5:0,
                 from ./wire/wire.h:4,
                 from ./common/sphinx.h:12,
                 from devtools/onion.c:5:
ccan/ccan/endian/endian.h:116:0: error: "__BYTE_ORDER" redefined [-Werror]
 #define __BYTE_ORDER __LITTLE_ENDIAN

In file included from /usr/include/sys/types.h:70:0,
                 from external/libsodium/src/libsodium/include/sodium/randombytes.h:5,
                 from ./common/sphinx.h:11,
                 from devtools/onion.c:5:
/usr/include/endian.h:11:0: note: this is the location of the previous definition
 #define __BYTE_ORDER __BYTE_ORDER__

cc1: all warnings being treated as errors
make: *** [<builtin>: devtools/onion.o] Error 1
make: *** Waiting for unfinished jobs....
```

Should be fixed upstream https://github.com/rustyrussell/ccan/issues/68 @rustyrussell 