### PR TITLE
Avoid static analyzer warning about integer wraparound

### DIFF
--- a/gossipd/tor_autoservice.c
+++ b/gossipd/tor_autoservice.c
@@ -161,6 +161,7 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 				cookiefileerrno = errno;
 				continue;
 			}
+			assert(tal_len(contents) != 0);
 			discard_remaining_response(rbuf);
 			tor_send_cmd(rbuf,
 				     tal_fmt(tmpctx, "AUTHENTICATE %s",


### PR DESCRIPTION
Avoid static analyzer warning about integer wraparound.