### PR TITLE
Separate counter variable declaration from for loop statements.

### DIFF
--- a/bitcoin/chainparams.c
+++ b/bitcoin/chainparams.c
@@ -58,7 +58,9 @@ const struct chainparams networks[] = {
 
 const struct chainparams *chainparams_for_network(const char *network_name)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(networks); i++) {
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(networks); i++) {
 		if (streq(network_name, networks[i].network_name)) {
 			return &networks[i];
 		}
@@ -77,7 +79,9 @@ const struct chainparams *chainparams_by_index(const int index)
 
 const struct chainparams *chainparams_by_bip173(const char *bip173_name)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(networks); i++) {
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(networks); i++) {
 		if (streq(bip173_name, networks[i].bip173_name)) {
 			return &networks[i];
 		}

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1075,6 +1075,7 @@ static u8 *got_commitsig_msg(const tal_t *ctx,
 	struct added_htlc *added;
 	struct secret *shared_secret;
 	u8 *msg;
+	size_t i;
 
 	changed = tal_arr(tmpctx, struct changed_htlc, 0);
 	added = tal_arr(tmpctx, struct added_htlc, 0);
@@ -1082,7 +1083,7 @@ static u8 *got_commitsig_msg(const tal_t *ctx,
 	failed = tal_arr(tmpctx, const struct failed_htlc *, 0);
 	fulfilled = tal_arr(tmpctx, struct fulfilled_htlc, 0);
 
-	for (size_t i = 0; i < tal_count(changed_htlcs); i++) {
+	for (i = 0; i < tal_count(changed_htlcs); i++) {
 		const struct htlc *htlc = changed_htlcs[i];
 		if (htlc->state == RCVD_ADD_COMMIT) {
 			struct added_htlc *a = tal_arr_append(&added);
@@ -1258,9 +1259,10 @@ static u8 *got_revoke_msg(const tal_t *ctx, u64 revoke_num,
 			  const struct htlc **changed_htlcs)
 {
 	u8 *msg;
+	size_t i;
 	struct changed_htlc *changed = tal_arr(tmpctx, struct changed_htlc, 0);
 
-	for (size_t i = 0; i < tal_count(changed_htlcs); i++) {
+	for (i = 0; i < tal_count(changed_htlcs); i++) {
 		struct changed_htlc *c = tal_arr_append(&changed);
 		const struct htlc *htlc = changed_htlcs[i];
 
@@ -2390,7 +2392,8 @@ static void init_shared_secrets(struct channel *channel,
 				const struct added_htlc *htlcs,
 				const enum htlc_state *hstates)
 {
-	for (size_t i = 0; i < tal_count(htlcs); i++) {
+	size_t i;
+	for (i = 0; i < tal_count(htlcs); i++) {
 		struct htlc *htlc;
 
 		/* We only derive this for HTLCs *they* added. */

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -1044,8 +1044,9 @@ bool channel_force_htlcs(struct channel *channel,
 const char *channel_add_err_name(enum channel_add_err e)
 {
 	static char invalidbuf[sizeof("INVALID ") + STR_MAX_CHARS(e)];
+	size_t i;
 
-	for (size_t i = 0; enum_channel_add_err_names[i].name; i++) {
+	for (i = 0; enum_channel_add_err_names[i].name; i++) {
 		if (enum_channel_add_err_names[i].v == e)
 			return enum_channel_add_err_names[i].name;
 	}
@@ -1056,8 +1057,9 @@ const char *channel_add_err_name(enum channel_add_err e)
 const char *channel_remove_err_name(enum channel_remove_err e)
 {
 	static char invalidbuf[sizeof("INVALID ") + STR_MAX_CHARS(e)];
+	size_t i;
 
-	for (size_t i = 0; enum_channel_remove_err_names[i].name; i++) {
+	for (i = 0; enum_channel_remove_err_names[i].name; i++) {
 		if (enum_channel_remove_err_names[i].v == e)
 			return enum_channel_remove_err_names[i].name;
 	}

--- a/cli/test/run-large-input.c
+++ b/cli/test/run-large-input.c
@@ -86,6 +86,7 @@ int main(int argc UNUSED, char *argv[])
 	setup_locale();
 
 	char *fake_argv[] = { argv[0], "--lightning-dir=/tmp/", "test", NULL };
+	size_t i;
 
 	/* sizeof() is an overestimate, but we don't care. */
 	response = tal_arr(NULL, char,
@@ -97,7 +98,7 @@ int main(int argc UNUSED, char *argv[])
 	response_off = strlen(HEADER);
 
 	/* Append a huge log */
-	for (size_t i = 0; i < NUM_ENTRIES; i++) {
+	for (i = 0; i < NUM_ENTRIES; i++) {
 		memcpy(response + response_off, LOG_ENTRY, sizeof(LOG_ENTRY)-1);
 		response_off += sizeof(LOG_ENTRY)-1;
 	}

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -446,6 +446,7 @@ int main(int argc, char *argv[])
 	enum side whose_turn;
 	bool deprecated_api;
 	u8 *channel_reestablish;
+	size_t i;
 
 	subdaemon_setup(argc, argv);
 
@@ -502,7 +503,7 @@ int main(int argc, char *argv[])
 	 *    - SHOULD send a `closing_signed` message.
 	 */
 	whose_turn = funder;
-	for (size_t i = 0; i < 2; i++, whose_turn = !whose_turn) {
+	for (i = 0; i < 2; i++, whose_turn = !whose_turn) {
 		if (whose_turn == LOCAL) {
 			send_offer(&cs,
 				   &channel_id, funding_pubkey,

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -521,10 +521,11 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
                 u64 m10 = 10;
                 u64 amount;
                 char *end;
+				size_t i;
 
                 /* Gather and trim multiplier */
                 end = amountstr + strlen(amountstr)-1;
-                for (size_t i = 0; i < ARRAY_SIZE(multipliers); i++) {
+                for (i = 0; i < ARRAY_SIZE(multipliers); i++) {
                         if (*end == multipliers[i].letter) {
                                 m10 = multipliers[i].m10;
                                 *end = '\0';
@@ -730,10 +731,12 @@ static void push_field(u5 **data, char type, const void *src, size_t nbits)
  */
 static void push_varlen_field(u5 **data, char type, u64 val)
 {
+		size_t nbits;
+
         assert(bech32_charset_rev[(unsigned char)type] >= 0);
         push_varlen_uint(data, bech32_charset_rev[(unsigned char)type], 5);
 
-        for (size_t nbits = 5; nbits < 65; nbits += 5) {
+        for (nbits = 5; nbits < 65; nbits += 5) {
                 if ((val >> nbits) == 0) {
                         push_varlen_uint(data, nbits / 5, 10);
                         push_varlen_uint(data, val,  nbits);
@@ -830,8 +833,9 @@ static void encode_f(u5 **data, const u8 *fallback)
 static void encode_r(u5 **data, const struct route_info *r)
 {
         u8 *rinfo = tal_arr(NULL, u8, 0);
+		size_t i;
 
-        for (size_t i = 0; i < tal_count(r); i++)
+        for (i = 0; i < tal_count(r); i++)
                 towire_route_info(&rinfo, r);
 
         push_field(data, 'r', rinfo, tal_len(rinfo) * CHAR_BIT);
@@ -868,6 +872,7 @@ char *bolt11_encode_(const tal_t *ctx,
         u8 sig_and_recid[65];
         u8 *hrpu8;
         int recid;
+		size_t i;
 
         /* BOLT #11:
          *
@@ -926,10 +931,10 @@ char *bolt11_encode_(const tal_t *ctx,
         if (b11->min_final_cltv_expiry != DEFAULT_C)
                 encode_c(&data, b11->min_final_cltv_expiry);
 
-        for (size_t i = 0; i < tal_count(b11->fallbacks); i++)
+        for (i = 0; i < tal_count(b11->fallbacks); i++)
                 encode_f(&data, b11->fallbacks[i]);
 
-        for (size_t i = 0; i < tal_count(b11->routes); i++)
+        for (i = 0; i < tal_count(b11->routes); i++)
                 encode_r(&data, b11->routes[i]);
 
         list_for_each(&b11->extra_fields, extra, list)

--- a/common/features.c
+++ b/common/features.c
@@ -21,8 +21,9 @@ static void set_bit(u8 **ptr, u32 bit)
 static u8 *mkfeatures(const tal_t *ctx, const u32 *arr, size_t n)
 {
 	u8 *f = tal_arr(ctx, u8, 0);
+	size_t i;
 
-	for (size_t i = 0; i < n; i++)
+	for (i = 0; i < n; i++)
 		set_bit(&f, OPTIONAL_FEATURE(arr[i]));
 	return f;
 }
@@ -64,7 +65,8 @@ static bool feature_supported(int feature_bit,
 			      const u32 *supported,
 			      size_t num_supported)
 {
-	for (size_t i = 0; i < num_supported; i++) {
+	size_t i;
+	for (i = 0; i < num_supported; i++) {
 		if (supported[i] == feature_bit)
 			return true;
 	}
@@ -87,9 +89,10 @@ static bool all_supported_features(const u8 *bitmap,
 				   size_t num_supported)
 {
 	size_t len = tal_count(bitmap);
+	size_t bitnum;
 
 	/* It's OK to be odd: only check even bits. */
-	for (size_t bitnum = 0; bitnum < len; bitnum += 2) {
+	for (bitnum = 0; bitnum < len; bitnum += 2) {
 		if (!test_bit(bitmap, bitnum/8, bitnum%8))
 			continue;
 

--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -534,6 +534,7 @@ struct onionreply *unwrap_onionreply(const tal_t *ctx,
 	u8 key[KEY_LEN], hmac[HMAC_SIZE];
 	const u8 *cursor;
 	size_t max;
+	size_t i;
 	u16 msglen;
 
 	if (tal_len(reply) != ONION_REPLY_SIZE + sizeof(hmac) + 4) {
@@ -543,7 +544,7 @@ struct onionreply *unwrap_onionreply(const tal_t *ctx,
 	memcpy(msg, reply, tal_len(reply));
 	oreply->origin_index = -1;
 
-	for (int i = 0; i < numhops; i++) {
+	for (i = 0; i < numhops; i++) {
 		/* Since the encryption is just XORing with the cipher
 		 * stream encryption is identical to decryption */
 		msg = wrap_onionreply(tmpctx, &shared_secrets[i], msg);

--- a/common/subdaemon.c
+++ b/common/subdaemon.c
@@ -31,19 +31,21 @@ volatile bool debugger_connected;
 
 void subdaemon_setup(int argc, char *argv[])
 {
+	int i;
+
 	if (argc == 2 && streq(argv[1], "--version")) {
 		printf("%s\n", version());
 		exit(0);
 	}
 
-	for (int i = 1; i < argc; i++) {
+	for (i = 1; i < argc; i++) {
 		if (streq(argv[i], "--log-io"))
 			logging_io = true;
 	}
 
 #if DEVELOPER
 	/* From debugger, set debugger_spin to 0. */
-	for (int i = 1; i < argc; i++) {
+	for (i = 1; i < argc; i++) {
 		if (streq(argv[i], "--debugger")) {
 			fprintf(stderr, "gdb -ex 'attach %u' -ex 'p debugger_connected=1' %s\n",
 				getpid(), argv[0]);

--- a/common/test/run-bolt11.c
+++ b/common/test/run-bolt11.c
@@ -72,6 +72,7 @@ static void test_b11(const char *b11str,
 	struct bolt11 *b11;
 	char *fail;
 	char *reproduce;
+	size_t i;
 
 	b11 = bolt11_decode(tmpctx, b11str, hashed_desc, &fail);
 	if (!b11)
@@ -93,7 +94,7 @@ static void test_b11(const char *b11str,
 	assert(b11->min_final_cltv_expiry == expect_b11->min_final_cltv_expiry);
 
 	assert(tal_count(b11->fallbacks) == tal_count(expect_b11->fallbacks));
-	for (size_t i = 0; i < tal_count(b11->fallbacks); i++)
+	for (i = 0; i < tal_count(b11->fallbacks); i++)
 		assert(memeq(b11->fallbacks[i], tal_len(b11->fallbacks[i]),
 			     expect_b11->fallbacks[i],
 			     tal_len(expect_b11->fallbacks[i])));
@@ -106,7 +107,7 @@ static void test_b11(const char *b11str,
 
 	/* Re-encode to check */
 	reproduce = bolt11_encode(tmpctx, b11, false, test_sign, NULL);
-	for (size_t i = 0; i < strlen(reproduce); i++) {
+	for (i = 0; i < strlen(reproduce); i++) {
 		if (reproduce[i] != b11str[i])
 			abort();
 	}

--- a/common/test/run-sphinx.c
+++ b/common/test/run-sphinx.c
@@ -93,6 +93,7 @@ static void run_unit_tests(void)
 	};
 
 	int replylen = 164 * 2;
+	int i;
 
 	u8 *intermediates[] = {
 	    tal_hexdata(tmpctx, "500d8596f76d3045bfdbf99914b98519fe76ea130dc223"
@@ -144,7 +145,7 @@ static void run_unit_tests(void)
 	};
 
 	reply = create_onionreply(tmpctx, &ss[4], raw);
-	for (int i = 4; i >= 0; i--) {
+	for (i = 4; i >= 0; i--) {
 		printf("input_packet %s\n", tal_hex(tmpctx, reply));
 		reply = wrap_onionreply(tmpctx, &ss[i], reply);
 		printf("obfuscated_packet %s\n", tal_hex(tmpctx, reply));

--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -551,7 +551,9 @@ struct addrinfo *wireaddr_to_addrinfo(const tal_t *ctx,
 
 bool all_tor_addresses(const struct wireaddr_internal *wireaddr)
 {
-	for (int i = 0; i < tal_count(wireaddr); i++) {
+	int i;
+
+	for (i = 0; i < tal_count(wireaddr); i++) {
 		switch (wireaddr[i].itype) {
 		case ADDR_INTERNAL_SOCKNAME:
 			return false;

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -18,7 +18,9 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 {
 	struct bitcoin_tx *tx =
 	    bitcoin_tx(ctx, tal_count(utxos), changesat ? 2 : 1);
-	for (size_t i = 0; i < tal_count(utxos); i++) {
+	size_t i;
+
+	for (i = 0; i < tal_count(utxos); i++) {
 		tx->input[i].txid = utxos[i]->txid;
 		tx->input[i].index = utxos[i]->outnum;
 		tx->input[i].amount = tal_dup(tx, u64, &utxos[i]->amount);

--- a/devtools/bolt11-cli.c
+++ b/devtools/bolt11-cli.c
@@ -142,8 +142,9 @@ int main(int argc, char *argv[])
         }
 
 	for (i = 0; i < tal_count(b11->routes); i++) {
+		size_t n;
 		printf("route: (node/chanid/fee/expirydelta) ");
-		for (size_t n = 0; n < tal_count(b11->routes[i]); n++) {
+		for (n = 0; n < tal_count(b11->routes[i]); n++) {
 			printf(" %s/%s/%u/%u/%u",
 			       type_to_string(ctx, struct pubkey,
 					      &b11->routes[i][n].pubkey),

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -19,11 +19,12 @@ static void do_generate(int argc, char **argv)
 	struct hop_data hops_data[num_hops];
 	struct secret *shared_secrets;
 	u8 assocdata[32];
+	int i;
 
 	memset(&sessionkey, 'A', sizeof(sessionkey));
 	memset(&assocdata, 'B', sizeof(assocdata));
 
-	for (int i = 0; i < num_hops; i++) {
+	for (i = 0; i < num_hops; i++) {
 		if (!hex_decode(argv[1 + i], 66, privkeys[i], 33)) {
 			errx(1, "Invalid private key hex '%s'", argv[1 + i]);
 		}
@@ -33,7 +34,7 @@ static void do_generate(int argc, char **argv)
 		fprintf(stderr, "Node %d pubkey %s\n", i, secp256k1_pubkey_to_hexstr(ctx, &path[i].pubkey));
 	}
 
-	for (int i = 0; i < num_hops; i++) {
+	for (i = 0; i < num_hops; i++) {
 		memset(&hops_data[i], 0, sizeof(hops_data[i]));
 		hops_data[i].realm = i;
 		memset(&hops_data[i].channel_id, i,

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1644,11 +1644,12 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 	struct sockaddr_un addrun;
 	int fd;
 	struct wireaddr_internal *binding;
+	size_t i;
 
 	binding = tal_arr(ctx, struct wireaddr_internal, 0);
 	daemon->announcable = tal_arr(daemon, struct wireaddr, 0);
 
-	for (size_t i = 0; i < tal_count(daemon->proposed_wireaddr); i++) {
+	for (i = 0; i < tal_count(daemon->proposed_wireaddr); i++) {
 		struct wireaddr_internal wa = daemon->proposed_wireaddr[i];
 
 		if (!(daemon->proposed_listen_announce[i] & ADDR_LISTEN)) {
@@ -1723,7 +1724,7 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 	}
 
 	/* Now we have bindings, set up any Tor auto addresses */
-	for (size_t i = 0; i < tal_count(daemon->proposed_wireaddr); i++) {
+	for (i = 0; i < tal_count(daemon->proposed_wireaddr); i++) {
 		if (!(daemon->proposed_listen_announce[i] & ADDR_LISTEN))
 			continue;
 
@@ -2002,6 +2003,7 @@ gossip_resolve_addr(const tal_t *ctx,
 		    const struct pubkey *id)
 {
 	struct node *node;
+	size_t i;
 
 	/* Get from routing state. */
 	node = get_node(rstate, id);
@@ -2012,7 +2014,7 @@ gossip_resolve_addr(const tal_t *ctx,
 
 	/* FIXME: When struct addrhint can contain more than one address,
 	 * we should copy all routable addresses. */
-	for (size_t i = 0; i < tal_count(node->addresses); i++) {
+	for (i = 0; i < tal_count(node->addresses); i++) {
 		struct wireaddr_internal *a;
 
 		if (!address_routable(&node->addresses[i],

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1329,12 +1329,13 @@ static struct io_plan *getnodes(struct io_conn *conn, struct daemon *daemon,
 	struct node *n;
 	const struct gossip_getnodes_entry **nodes;
 	struct pubkey *ids;
+	size_t i;
 
 	fromwire_gossip_getnodes_request(tmpctx, msg, &ids);
 
 	nodes = tal_arr(tmpctx, const struct gossip_getnodes_entry *, 0);
 	if (ids) {
-		for (size_t i = 0; i < tal_count(ids); i++) {
+		for (i = 0; i < tal_count(ids); i++) {
 			n = get_node(daemon->rstate, &ids[i]);
 			if (n)
 				append_node(&nodes, n);
@@ -1495,6 +1496,7 @@ static void gossip_refresh_network(struct daemon *daemon)
 	/* Anything below this highwater mark could be pruned if not refreshed */
 	s64 highwater = now - daemon->rstate->prune_timeout / 2;
 	struct node *n;
+	size_t i;
 
 	/* Schedule next run now */
 	new_reltimer(&daemon->timers, daemon,
@@ -1506,7 +1508,7 @@ static void gossip_refresh_network(struct daemon *daemon)
 	if (n) {
 		/* Iterate through all outgoing connection and check whether
 		 * it's time to re-announce */
-		for (size_t i = 0; i < tal_count(n->chans); i++) {
+		for (i = 0; i < tal_count(n->chans); i++) {
 			struct half_chan *hc = half_chan_from(n, n->chans[i]);
 
 			if (!is_halfchan_defined(hc)) {

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1135,7 +1135,8 @@ bool routing_add_node_announcement(struct routing_state *rstate, const u8 *msg T
 
 static bool node_has_public_channels(struct node *node)
 {
-	for (size_t i = 0; i < tal_count(node->chans); i++)
+	size_t i;
+	for (i = 0; i < tal_count(node->chans); i++)
 		if (is_chan_public(node->chans[i]))
 			return true;
 	return false;
@@ -1357,6 +1358,7 @@ void routing_failure(struct routing_state *rstate,
 {
 	struct node *node;
 	time_t now = time_now().ts.tv_sec;
+	size_t i;
 
 	status_trace("Received routing failure 0x%04x (%s), "
 		     "erring node %s, "
@@ -1383,7 +1385,7 @@ void routing_failure(struct routing_state *rstate,
 	 *
 	 */
 	if (failcode & NODE) {
-		for (int i = 0; i < tal_count(node->chans); ++i) {
+		for (i = 0; i < tal_count(node->chans); ++i) {
 			routing_failure_channel_out(tmpctx, node, failcode,
 						    node->chans[i],
 						    now);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -608,6 +608,7 @@ bool routing_add_channel_announcement(struct routing_state *rstate,
 	struct pubkey node_id_2;
 	struct pubkey bitcoin_key_1;
 	struct pubkey bitcoin_key_2;
+	size_t i;
 
 	fromwire_channel_announcement(
 	    tmpctx, msg, &node_signature_1, &node_signature_2,
@@ -628,7 +629,7 @@ bool routing_add_channel_announcement(struct routing_state *rstate,
 	insert_broadcast(rstate->broadcasts, chan->channel_announce);
 
 	/* If we had private updates for channels, we can broadcast them too. */
-	for (size_t i = 0; i < ARRAY_SIZE(chan->half); i++) {
+	for (i = 0; i < ARRAY_SIZE(chan->half); i++) {
 		if (!is_halfchan_defined(&chan->half[i]))
 			continue;
 		insert_broadcast(rstate->broadcasts,

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -161,12 +161,13 @@ static struct pubkey nodeid(size_t n)
 static void populate_random_node(struct routing_state *rstate, u64 n)
 {
 	struct pubkey id = nodeid(n);
+	size_t i;
 
 	/* Create 2 random channels. */
 	if (n < 1)
 		return;
 
-	for (size_t i = 0; i < 2; i++) {
+	for (i = 0; i < 2; i++) {
 		struct pubkey randnode = nodeid(pseudorand(n));
 
 		add_connection(rstate, &id, &randnode,
@@ -210,6 +211,7 @@ int main(int argc, char *argv[])
 	bool perfme = false;
 	const double riskfactor = 0.01 / BLOCKS_PER_YEAR / 10000;
 	struct siphash_seed base_seed;
+	size_t i;
 
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
 						 | SECP256K1_CONTEXT_SIGN);
@@ -229,7 +231,7 @@ int main(int argc, char *argv[])
 		opt_usage_and_exit("[num_nodes [num_runs]]");
 
 	memset(&base_seed, 0, sizeof(base_seed));
-	for (size_t i = 0; i < num_nodes; i++)
+	for (i = 0; i < num_nodes; i++)
 		populate_random_node(rstate, i);
 
 	in_bench = true;
@@ -238,7 +240,7 @@ int main(int argc, char *argv[])
 
 	start = time_mono();
 	num_success = 0;
-	for (size_t i = 0; i < num_runs; i++) {
+	for (i = 0; i < num_runs; i++) {
 		struct pubkey from = nodeid(pseudorand(num_nodes));
 		struct pubkey to = nodeid(pseudorand(num_nodes));
 		u64 fee;

--- a/gossipd/tor_autoservice.c
+++ b/gossipd/tor_autoservice.c
@@ -186,7 +186,9 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 static const struct wireaddr *
 find_local_address(const struct wireaddr_internal *bindings)
 {
-	for (size_t i = 0; i < tal_count(bindings); i++) {
+	size_t i;
+
+	for (i = 0; i < tal_count(bindings); i++) {
 		if (bindings[i].itype != ADDR_INTERNAL_WIREADDR)
 			continue;
 		if (bindings[i].u.wireaddr.type != ADDR_TYPE_IPV4

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -657,7 +657,7 @@ static void sign_funding_tx(struct daemon_conn *master, const u8 *msg)
 	}
 
 	/* Now complete the transaction by attaching the scriptSigs where necessary */
-	for (size_t i=0; i<tal_count(utxomap); i++)
+	for (i=0; i<tal_count(utxomap); i++)
 		tx->input[i].script = scriptSigs[i];
 
 	daemon_conn_send(master,
@@ -677,6 +677,8 @@ static void sign_withdrawal_tx(struct daemon_conn *master, const u8 *msg)
 	struct ext_key ext;
 	struct pubkey changekey;
 	u8 *scriptpubkey;
+	size_t i;
+
 
 	if (!fromwire_hsm_sign_withdrawal(tmpctx, msg, &satoshi_out,
 					  &change_out, &change_keyindex,
@@ -700,7 +702,7 @@ static void sign_withdrawal_tx(struct daemon_conn *master, const u8 *msg)
 		&changekey, change_out, NULL);
 
 	scriptSigs = tal_arr(tmpctx, u8*, tal_count(utxos));
-	for (size_t i = 0; i < tal_count(utxos); i++) {
+	for (i = 0; i < tal_count(utxos); i++) {
 		struct pubkey inkey;
 		struct privkey inprivkey;
 		const struct utxo *in = utxos[i];
@@ -727,7 +729,7 @@ static void sign_withdrawal_tx(struct daemon_conn *master, const u8 *msg)
 	}
 
 	/* Now complete the transaction by attaching the scriptSigs where necessary */
-	for (size_t i=0; i<tal_count(utxos); i++)
+	for (i=0; i<tal_count(utxos); i++)
 		tx->input[i].script = scriptSigs[i];
 
 	daemon_conn_send(master,

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -275,8 +275,9 @@ static void update_feerates(struct bitcoind *bitcoind,
 {
 	u32 old_feerates[NUM_FEERATES];
 	bool changed = false;
+	size_t i, j;
 
-	for (size_t i = 0; i < NUM_FEERATES; i++) {
+	for (i = 0; i < NUM_FEERATES; i++) {
 		u32 feerate = satoshi_per_kw[i];
 
 		if (feerate < feerate_floor())
@@ -295,8 +296,8 @@ static void update_feerates(struct bitcoind *bitcoind,
 		topo->feerate[i] = feerate;
 	}
 
-	for (size_t i = 0; i < NUM_FEERATES; i++) {
-		for (size_t j = 0; j < i; j++) {
+	for (i = 0; i < NUM_FEERATES; i++) {
+		for (j = 0; j < i; j++) {
 			if (topo->feerate[j] < topo->feerate[i]) {
 				log_debug(topo->log,
 					  "Feerate %s (%u) above %s (%u)",
@@ -365,9 +366,10 @@ static void updates_complete(struct chain_topology *topo)
 static void topo_update_spends(struct chain_topology *topo, struct block *b)
 {
 	const struct short_channel_id *scid;
-	for (size_t i = 0; i < tal_count(b->full_txs); i++) {
+	size_t i, j;
+	for (i = 0; i < tal_count(b->full_txs); i++) {
 		const struct bitcoin_tx *tx = b->full_txs[i];
-		for (size_t j = 0; j < tal_count(tx->input); j++) {
+		for (j = 0; j < tal_count(tx->input); j++) {
 			const struct bitcoin_tx_input *input = &tx->input[j];
 			scid = wallet_outpoint_spend(topo->wallet, tmpctx,
 						     b->height, &input->txid,
@@ -382,9 +384,10 @@ static void topo_update_spends(struct chain_topology *topo, struct block *b)
 
 static void topo_add_utxos(struct chain_topology *topo, struct block *b)
 {
-	for (size_t i = 0; i < tal_count(b->full_txs); i++) {
+	size_t i, j;
+	for (i = 0; i < tal_count(b->full_txs); i++) {
 		const struct bitcoin_tx *tx = b->full_txs[i];
-		for (size_t j = 0; j < tal_count(tx->output); j++) {
+		for (j = 0; j < tal_count(tx->output); j++) {
 			const struct bitcoin_tx_output *output = &tx->output[j];
 			if (is_p2wsh(output->script, NULL)) {
 				wallet_utxoset_add(topo->wallet, tx, j,
@@ -622,6 +625,7 @@ static void json_dev_setfees(struct command *cmd,
 	jsmntok_t *ratetok[NUM_FEERATES];
 	struct chain_topology *topo = cmd->ld->topology;
 	struct json_result *response;
+	size_t i;
 
 	if (!json_get_params(cmd, buffer, params,
 			     "?immediate", &ratetok[FEERATE_IMMEDIATE],
@@ -633,12 +637,12 @@ static void json_dev_setfees(struct command *cmd,
 
 	if (!topo->override_fee_rate) {
 		u32 fees[NUM_FEERATES];
-		for (size_t i = 0; i < ARRAY_SIZE(fees); i++)
+		for (i = 0; i < ARRAY_SIZE(fees); i++)
 			fees[i] = get_feerate(topo, i);
 		topo->override_fee_rate = tal_dup_arr(topo, u32, fees,
 						      ARRAY_SIZE(fees), 0);
 	}
-	for (size_t i = 0; i < NUM_FEERATES; i++) {
+	for (i = 0; i < NUM_FEERATES; i++) {
 		if (!ratetok[i])
 			continue;
 		if (!json_tok_number(buffer, ratetok[i],

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -247,7 +247,8 @@ const char *channel_state_name(const struct channel *channel)
 
 const char *channel_state_str(enum channel_state state)
 {
-	for (size_t i = 0; enum_channel_state_names[i].name; i++)
+	size_t i;
+	for (i = 0; enum_channel_state_names[i].name; i++)
 		if (enum_channel_state_names[i].v == state)
 			return enum_channel_state_names[i].name;
 	return "unknown";

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -111,6 +111,7 @@ static struct json_escaped *json_tok_label(const tal_t *ctx,
 					   const jsmntok_t *tok)
 {
 	struct json_escaped *label;
+	size_t i;
 
 	label = json_tok_escaped_string(ctx, buffer, tok);
 	if (label)
@@ -120,7 +121,7 @@ static struct json_escaped *json_tok_label(const tal_t *ctx,
 	if (tok->type != JSMN_PRIMITIVE)
 		return NULL;
 
-	for (int i = tok->start; i < tok->end; i++)
+	for (i = tok->start; i < tok->end; i++)
 		if (!cisdigit(buffer[i]))
 			return NULL;
 
@@ -778,16 +779,17 @@ static void json_decodepay(struct command *cmd,
                              sizeof(*b11->description_hash));
 	json_add_num(response, "min_final_cltv_expiry",
 		     b11->min_final_cltv_expiry);
-        if (tal_count(b11->fallbacks)) {
+	if (tal_count(b11->fallbacks)) {
+		size_t i;
 		if (deprecated_apis)
 			json_add_fallback(response, "fallback",
-					  b11->fallbacks[0], b11->chain);
+					b11->fallbacks[0], b11->chain);
 		json_array_start(response, "fallbacks");
-		for (size_t i = 0; i < tal_count(b11->fallbacks); i++)
+		for (i = 0; i < tal_count(b11->fallbacks); i++)
 			json_add_fallback(response, NULL,
-					  b11->fallbacks[i], b11->chain);
+					b11->fallbacks[i], b11->chain);
 		json_array_end(response);
-        }
+	}
 
         if (tal_count(b11->routes)) {
                 size_t i, n;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -146,6 +146,7 @@ static void json_getinfo(struct command *cmd,
 			 const char *buffer UNUSED, const jsmntok_t *params UNUSED)
 {
 	struct json_result *response = new_json_result(cmd);
+	size_t i;
 
 	json_object_start(response, NULL);
 	json_add_pubkey(response, "id", &cmd->ld->id);
@@ -155,13 +156,13 @@ static void json_getinfo(struct command *cmd,
 
 		/* These are the addresses we're announcing */
 		json_array_start(response, "address");
-		for (size_t i = 0; i < tal_count(cmd->ld->announcable); i++)
+		for (i = 0; i < tal_count(cmd->ld->announcable); i++)
 			json_add_address(response, NULL, cmd->ld->announcable+i);
 		json_array_end(response);
 
 		/* This is what we're actually bound to. */
 		json_array_start(response, "binding");
-		for (size_t i = 0; i < tal_count(cmd->ld->binding); i++)
+		for (i = 0; i < tal_count(cmd->ld->binding); i++)
 			json_add_address_internal(response, NULL,
 						  cmd->ld->binding+i);
 		json_array_end(response);
@@ -570,7 +571,8 @@ bool json_get_params(struct command *cmd,
 		/* Find each parameter among the valid names */
 		for (t = param + 1; t < end; t = json_next(t+1)) {
 			bool found = false;
-			for (size_t i = 0; i < num_names; i++) {
+			size_t i;
+			for (i = 0; i < num_names; i++) {
 				if (json_tok_streq(buffer, t, names[i]))
 					found = true;
 			}
@@ -775,7 +777,8 @@ static const char* segwit_addr_net_decode(int *witness_version,
 				   const char *addrz)
 {
 	const char *network[] = { "bc", "tb", "bcrt" };
-	for (int i = 0; i < sizeof(network) / sizeof(*network); ++i) {
+	size_t i;
+	for (i = 0; i < sizeof(network) / sizeof(*network); ++i) {
 		if (segwit_addr_decode(witness_version,
 				       witness_program, witness_program_len,
 				       network[i], addrz))

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -235,9 +235,10 @@ static void init_txfilter(struct wallet *w, struct txfilter *filter)
 {
 	struct ext_key ext;
 	u64 bip32_max_index;
+	u64 i;
 
 	bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
-	for (u64 i = 0; i <= bip32_max_index; i++) {
+	for (i = 0; i <= bip32_max_index; i++) {
 		if (bip32_key_from_parent(w->bip32_base, i, BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
 			abort();
 		}

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -252,11 +252,12 @@ void logv(struct log *log, enum log_level level, const char *fmt, va_list ap)
 {
 	int save_errno = errno;
 	struct log_entry *l = new_log_entry(log, level);
+	size_t i;
 
 	l->log = tal_vfmt(l, fmt, ap);
 
 	/* Sanitize any non-printable characters, and replace with '?' */
-	for (size_t i=0; i<strlen(l->log); i++)
+	for (i=0; i<strlen(l->log); i++)
 		if (l->log[i] < ' ' || l->log[i] >= 0x7f)
 			l->log[i] = '?';
 
@@ -287,6 +288,7 @@ void logv_add(struct log *log, const char *fmt, va_list ap)
 {
 	struct log_entry *l = list_tail(&log->lr->log, struct log_entry, list);
 	size_t oldlen = strlen(l->log);
+	size_t i;
 
 	/* Remove from list, so it doesn't get pruned. */
 	log->lr->mem_used -= mem_used(l);
@@ -295,7 +297,7 @@ void logv_add(struct log *log, const char *fmt, va_list ap)
 	tal_append_vfmt(&l->log, fmt, ap);
 
 	/* Sanitize any non-printable characters, and replace with '?' */
-	for (size_t i=oldlen; i<strlen(l->log); i++)
+	for (i=oldlen; i<strlen(l->log); i++)
 		if (l->log[i] < ' ' || l->log[i] >= 0x7f)
 			l->log[i] = '?';
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -282,6 +282,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	struct json_result *response;
 	struct lightningd *ld = openingd->ld;
 	struct channel_id cid;
+	size_t i;
 
 	assert(tal_count(fds) == 2);
 
@@ -332,7 +333,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 		  tal_count(fundingtx->input),
 		  tal_count(fundingtx->output));
 
-	for (size_t i = 0; i < tal_count(fundingtx->input); i++) {
+	for (i = 0; i < tal_count(fundingtx->input); i++) {
 		log_debug(fc->uc->log, "%zi: %"PRIu64" satoshi (%s) %s\n",
 			  i, fc->wtx.utxos[i]->amount,
 			  fc->wtx.utxos[i]->is_p2sh ? "P2SH" : "SEGWIT",

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -879,7 +879,9 @@ static void json_add_opt_addrs(struct json_result *response,
 			       const enum addr_listen_announce *listen_announce,
 			       enum addr_listen_announce ala)
 {
-	for (size_t i = 0; i < tal_count(wireaddrs); i++) {
+	size_t i;
+
+	for (i = 0; i < tal_count(wireaddrs); i++) {
 		if (listen_announce[i] != ala)
 			continue;
 		json_add_string(response,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -268,10 +268,12 @@ static char *opt_set_alias(const char *arg, struct lightningd *ld)
 
 static char *opt_set_fee_rates(const char *arg, struct chain_topology *topo)
 {
+	size_t i;
+
 	tal_free(topo->override_fee_rate);
 	topo->override_fee_rate = tal_arr(topo, u32, 3);
 
-	for (size_t i = 0; i < tal_count(topo->override_fee_rate); i++) {
+	for (i = 0; i < tal_count(topo->override_fee_rate); i++) {
 		char *endp;
 		char term;
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1094,6 +1094,7 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 	struct json_result *response = new_json_result(cmd);
 	jsmntok_t *bolt11tok, *rhashtok;
 	struct sha256 *rhash = NULL;
+	size_t i;
 
 	if (!json_get_params(cmd, buffer, params,
 			     "?bolt11", &bolt11tok,
@@ -1137,7 +1138,7 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 
 	json_object_start(response, NULL);
 	json_array_start(response, "payments");
-	for (int i=0; i<tal_count(payments); i++) {
+	for (i=0; i<tal_count(payments); i++) {
 		json_object_start(response, NULL);
 		json_add_payment_fields(response, payments[i]);
 		json_object_end(response);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -722,7 +722,8 @@ static void json_add_node_decoration(struct json_result *response,
 				     struct gossip_getnodes_entry **nodes,
 				     const struct pubkey *id)
 {
-	for (size_t i = 0; i < tal_count(nodes); i++) {
+	size_t i;
+	for (i = 0; i < tal_count(nodes); i++) {
 		struct json_escaped *esc;
 
 		/* If no addresses, then this node announcement hasn't been
@@ -752,6 +753,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 	struct gossip_getnodes_entry **nodes;
 	struct json_result *response = new_json_result(gpa->cmd);
 	struct peer *p;
+	size_t i;
 
 	if (!fromwire_gossip_getpeers_reply(msg, msg, &ids, &addrs, &nodes)) {
 		command_fail(gpa->cmd, "Bad response from gossipd");
@@ -870,7 +872,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 				     channel->our_config.max_accepted_htlcs);
 
 			json_array_start(response, "status");
-			for (size_t i = 0;
+			for (i = 0;
 			     i < ARRAY_SIZE(channel->billboard.permanent);
 			     i++) {
 				if (!channel->billboard.permanent[i])
@@ -913,7 +915,7 @@ static void gossipd_getpeers_complete(struct subd *gossip, const u8 *msg,
 		json_object_end(response);
 	}
 
-	for (size_t i = 0; i < tal_count(ids); i++) {
+	for (i = 0; i < tal_count(ids); i++) {
 		/* Don't report peers in both, which can happen if they're
 		 * reconnecting */
 		if (peer_by_id(gpa->cmd->ld, ids + i))

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -278,7 +278,8 @@ class Message(object):
             subcalls.append('\tfromwire_{}_array(&cursor, &plen, {}, {});'
                             .format(basetype, name, num_elems))
         else:
-            subcalls.append('\tfor (size_t i = 0; i < {}; i++)'
+            subcalls.append('\t{\n\tsize_t i;\n')
+            subcalls.append('\tfor (i = 0; i < {}; i++)'
                             .format(num_elems))
             if f.fieldtype.is_assignable():
                 subcalls.append('\t\t({})[i] = fromwire_{}(&cursor, &plen);'
@@ -289,6 +290,7 @@ class Message(object):
             else:
                 subcalls.append('\t\tfromwire_{}(&cursor, &plen, {} + i);'
                                 .format(basetype, name))
+            subcalls.append('\n\t}')
 
     def print_fromwire(self, is_header):
         ctx_arg = 'const tal_t *ctx, ' if self.has_variable_fields else ''
@@ -367,7 +369,8 @@ class Message(object):
             subcalls.append('\ttowire_{}_array(&p, {}, {});'
                             .format(basetype, f.name, num_elems))
         else:
-            subcalls.append('\tfor (size_t i = 0; i < {}; i++)\n'
+            subcalls.append('\t{\n\tsize_t i;\n')
+            subcalls.append('\tfor (i = 0; i < {}; i++)\n'
                             .format(num_elems))
             if f.fieldtype.is_assignable() or basetype in varlen_structs:
                 subcalls.append('\t\ttowire_{}(&p, {}[i]);'
@@ -375,6 +378,7 @@ class Message(object):
             else:
                 subcalls.append('\t\ttowire_{}(&p, {} + i);'
                                 .format(basetype, f.name))
+            subcalls.append('\n\t}')
 
     def print_towire(self, is_header):
         template = towire_header_templ if is_header else towire_impl_templ
@@ -441,7 +445,8 @@ class Message(object):
                             .format(basetype, num_elems))
         else:
             subcalls.append('\tprintf("[");')
-            subcalls.append('\tfor (size_t i = 0; i < {}; i++) {{'
+            subcalls.append('\t{\n\tsize_t i;\n')
+            subcalls.append('\tfor (i = 0; i < {}; i++) {{'
                             .format(num_elems))
             subcalls.append('\t\t{} v;'.format(f.fieldtype.name))
             if f.fieldtype.is_assignable():
@@ -457,7 +462,7 @@ class Message(object):
             self.add_truncate_check(subcalls, indent='\t\t')
 
             subcalls.append('\t\tprintwire_{}(&v);'.format(basetype))
-            subcalls.append('\t}')
+            subcalls.append('\t}}')
             subcalls.append('\tprintf("]");')
 
     def print_printwire(self, is_header):

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -489,8 +489,9 @@ void txfilter_add_scriptpubkey(struct txfilter *filter UNNEEDED, const u8 *scrip
 static void mempat(void *dst, size_t len)
 {
 	static int n = 0;
+	int i;
 	u8 *p = (u8*)dst;
-	for(int i=0 ; i < len; ++i)
+	for(i=0 ; i < len; ++i)
 		p[i] = n % 251; /* Prime */
 }
 
@@ -613,6 +614,7 @@ static bool test_shachain_crud(void)
 	struct wallet *w = tal(NULL, struct wallet);
 	struct sha256 seed, hash;
 	uint64_t index = UINT64_MAX >> (64 - SHACHAIN_BITS);
+	int i;
 
 	w->db = db_open(w, filename);
 	CHECK_MSG(w->db, "Failed opening the db");
@@ -637,7 +639,7 @@ static bool test_shachain_crud(void)
 	CHECK(a.chain.num_valid == 0);
 	CHECK(shachain_next_index(&a.chain) == index);
 
-	for (int i=0; i<100; i++) {
+	for (i=0; i<100; i++) {
 		shachain_from_seed(&seed, index, &hash);
 		CHECK(wallet_shachain_add_hash(w, &a, index, &hash));
 		index--;

--- a/wallet/txfilter.c
+++ b/wallet/txfilter.c
@@ -75,10 +75,11 @@ void txfilter_add_derkey(struct txfilter *filter,
 
 bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx)
 {
-	for (size_t i = 0; i < tal_count(tx->output); i++) {
+	size_t i, j;
+	for (i = 0; i < tal_count(tx->output); i++) {
 		u8 *oscript = tx->output[i].script;
 
-		for (size_t j = 0; j < tal_count(filter->scriptpubkeys); j++) {
+		for (j = 0; j < tal_count(filter->scriptpubkeys); j++) {
 			if (scripteq(oscript, filter->scriptpubkeys[j]))
 				return true;
 		}

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -217,7 +217,7 @@ static void json_newaddr(struct command *cmd, const char *buffer UNUSED,
 	struct pubkey pubkey;
 	jsmntok_t *addrtype;
 	bool is_p2wpkh;
-	s64 keyidx;
+	u64 keyidx;
 	char *out;
 
 	if (!json_get_params(cmd, buffer, params,
@@ -286,6 +286,7 @@ static void json_listaddrs(struct command *cmd,
 	struct pubkey pubkey;
 	jsmntok_t *bip32tok;
 	u64 bip32_max_index;
+	u64 keyidx;
 
 	if (!json_get_params(cmd, buffer, params,
 			     "?bip32_max_index", &bip32tok,
@@ -299,7 +300,7 @@ static void json_listaddrs(struct command *cmd,
 	json_object_start(response, NULL);
 	json_array_start(response, "addresses");
 
-	for (s64 keyidx = 0; keyidx <= bip32_max_index; keyidx++) {
+	for (keyidx = 0; keyidx <= bip32_max_index; keyidx++) {
 
 		if(keyidx == BIP32_INITIAL_HARDENED_CHILD){
 			break;
@@ -370,9 +371,11 @@ static void json_listfunds(struct command *cmd, const char *buffer UNUSED,
 	    wallet_get_utxos(cmd, cmd->ld->wallet, output_state_available);
 	char* out;
 	struct pubkey funding_pubkey;
+	size_t i;
+
 	json_object_start(response, NULL);
 	json_array_start(response, "outputs");
-	for (size_t i = 0; i < tal_count(utxos); i++) {
+	for (i = 0; i < tal_count(utxos); i++) {
 		json_object_start(response, NULL);
 		json_add_txid(response, "txid", &utxos[i]->txid);
 		json_add_num(response, "output", utxos[i]->outnum);


### PR DESCRIPTION
This makes the code conform to (an older version of?) the C standard.
The reason I propose this change is because I wanted to analyze the (rather large) code base with ncc, but it failed to recognize constructions like for(int i=0; ...).