### PR TITLE
wireaddr: Avoid buffer overflow in fmt_wireaddr_without_port()

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -207,7 +207,7 @@ REGISTER_TYPE_TO_STRING(wireaddr_internal, fmt_wireaddr_internal);
 char *fmt_wireaddr_without_port(const tal_t * ctx, const struct wireaddr *a)
 {
 	char *ret, *hex;
-	char addrstr[LARGEST_ADDRLEN];
+	char addrstr[INET6_ADDRSTRLEN];
 
 	switch (a->type) {
 	case ADDR_TYPE_IPV4:


### PR DESCRIPTION
`addrstr` is an array of 35 bytes (`char addrstr[LARGEST_ADDRLEN] `).

In the case of an IPv6 address we execute:

```
 	case ADDR_TYPE_IPV6:
 		if (!inet_ntop(AF_INET6, a->addr, addrstr, INET6_ADDRSTRLEN))
 			return "Unprintable-ipv6-address";
 		return tal_fmt(ctx, "[%s]", addrstr);
```

Since `INET6_ADDRSTRLEN > LARGEST_ADDRLEN` we trigger a buffer overflow when calling `inet_ntop(…)`.

```
$ git grep -E '#define.*(LARGEST_ADDRLEN|TOR_V3_ADDRLEN)'
common/wireaddr.h:#define       TOR_V3_ADDRLEN 35
common/wireaddr.h:#define       LARGEST_ADDRLEN TOR_V3_ADDRLEN
$ grep INET6_ADDRSTRLEN /usr/src/linux-headers-4.4.0-116/include/linux/inet.h
#define INET6_ADDRSTRLEN	(48)
$ grep INET6_ADDRSTRLEN /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/netinet6/in6.h
#define	INET6_ADDRSTRLEN	46
```