### PR TITLE
wire: remove --check-alignment arg from spec parsing tool.

### DIFF
--- a/wire/Makefile
+++ b/wire/Makefile
@@ -26,12 +26,11 @@ ALL_GEN_HEADERS += $(WIRE_GEN_HEADERS)
 
 # They may not have the bolts.
 BOLT_EXTRACT=$(BOLTDIR)/tools/extract-formats.py
-# FIXME: Re-enable --check-alignment!
 wire/gen_peer_wire_csv: FORCE
 	@set -e; if [ -f $(BOLT_EXTRACT) ]; then for f in $(BOLTDIR)/0[127]*.md $(BOLT_EXTRACT); do if [ $$f -nt $@ -o ! -f $@ ]; then $(BOLT_EXTRACT) --message-fields --message-types $(BOLTDIR)/0[127]*.md > $@; break; fi; done; fi
 
 wire/gen_onion_wire_csv: FORCE
-	@set -e; if [ -f $(BOLT_EXTRACT) ]; then for f in $(BOLTDIR)/04*.md $(BOLT_EXTRACT); do if [ $$f -nt $@ -o ! -f $@ ]; then echo '#include <wire/onion_defs.h>' > $@ && $(BOLT_EXTRACT) --message-fields --message-types --check-alignment $(BOLTDIR)/04*.md >> $@; break; fi; done; fi
+	@set -e; if [ -f $(BOLT_EXTRACT) ]; then for f in $(BOLTDIR)/04*.md $(BOLT_EXTRACT); do if [ $$f -nt $@ -o ! -f $@ ]; then echo '#include <wire/onion_defs.h>' > $@ && $(BOLT_EXTRACT) --message-fields --message-types $(BOLTDIR)/04*.md >> $@; break; fi; done; fi
 
 wire/gen_peer_wire.h: $(WIRE_GEN) wire/gen_peer_wire_csv
 	$(WIRE_GEN) --bolt --header $@ wire_type < wire/gen_peer_wire_csv > $@


### PR DESCRIPTION
It's no longer functional, and is being removed upstream.