### PR TITLE
Makefile: Propagate `NO_VALGRIND` to `py.test` invocation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ ifndef PYTEST
 	@echo "py.test is required to run the integration tests, please install using 'pip3 install -r tests/requirements.txt'"
 	exit 1
 else
-	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) $(PYTEST) tests/ $(PYTEST_OPTS)
+	PYTHONPATH=contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) NO_VALGRIND=$(NO_VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.


### PR DESCRIPTION
Previously, by uncommenting NO_VALGRIND in Makefile, the variable
was not propagated and the children processes would still try to
use Valgrind.
    
Tested on Alpine Linux:

    make NO_VALGRIND=1 check

Also works after uncommenting both related lines in Makefile.