### PR TITLE
Fix channel_update timestamp races

### DIFF
--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -198,6 +198,14 @@ gossip_local_add_channel,3017
 gossip_local_add_channel,,short_channel_id,struct short_channel_id
 gossip_local_add_channel,,remote_node_id,struct pubkey
 
+gossip_local_channel_update,3026
+gossip_local_channel_update,,short_channel_id,struct short_channel_id
+gossip_local_channel_update,,disable,bool
+gossip_local_channel_update,,cltv_expiry_delta,u16
+gossip_local_channel_update,,htlc_minimum_msat,u64
+gossip_local_channel_update,,fee_base_msat,u32
+gossip_local_channel_update,,fee_proportional_millionths,u32
+
 # Gossipd->master get this tx output please.
 gossip_get_txout,3018
 gossip_get_txout,,short_channel_id,struct short_channel_id

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -154,6 +154,7 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIPCTL_PEER_DISCONNECT_REPLYFAIL:
 	/* These are inter-daemon messages, not received by us */
 	case WIRE_GOSSIP_LOCAL_ADD_CHANNEL:
+	case WIRE_GOSSIP_LOCAL_CHANNEL_UPDATE:
 		break;
 
 	case WIRE_GOSSIP_PEER_CONNECTED:


### PR DESCRIPTION
Rather than having gossipd and channeld both generate signed updates, have gossipd always do it.