### PR TITLE
Do not call strlen for every character in the log entry

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -255,8 +255,10 @@ void logv(struct log *log, enum log_level level, const char *fmt, va_list ap)
 
 	l->log = tal_vfmt(l, fmt, ap);
 
+	size_t log_len = strlen(l->log);
+
 	/* Sanitize any non-printable characters, and replace with '?' */
-	for (size_t i=0; i<strlen(l->log); i++)
+	for (size_t i=0; i<log_len; i++)
 		if (l->log[i] < ' ' || l->log[i] >= 0x7f)
 			l->log[i] = '?';
 


### PR DESCRIPTION
Low hanging fruit taking quite of CPU.

![image](https://user-images.githubusercontent.com/3020646/40318537-e9ac0752-5d5f-11e8-8845-94f836183fe5.png)

(was log level debug)