### PR TITLE
doc/HACKING.md: remove note about DEVELOPER mode being default

### DIFF
--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -162,7 +162,7 @@ Testing
 -------
 
 There are three kinds of tests.  For best results, you should have
-valgrind installed, and build with DEVELOPER=1 (currently the default).
+valgrind installed, and build with DEVELOPER=1.
 
 * source tests - run by `make check-source`, looks for whitespace,
   header order, and checks formatted quotes from BOLTs if BOLTDIR


### PR DESCRIPTION
The DEVELOPER mode is not the default since 00e75fee,
change the documentation accordingly.