### PR TITLE
Added error code parameter to command_fail

### DIFF
--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -22,7 +22,8 @@ bool wtx_select_utxos(struct wallet_tx * tx, u32 fee_rate_per_kw,
 					      &tx->amount,
 					      &fee_estimate);
 		if (!tx->utxos || tx->amount < 546) {
-			command_fail(tx->cmd, "Cannot afford fee %"PRIu64,
+			command_fail(tx->cmd, LIGHTNINGD,
+				     "Cannot afford fee %"PRIu64,
 				     fee_estimate);
 			return false;
 		}
@@ -33,8 +34,8 @@ bool wtx_select_utxos(struct wallet_tx * tx, u32 fee_rate_per_kw,
 						fee_rate_per_kw, out_len,
 						&fee_estimate, &tx->change);
 		if (!tx->utxos || tx->amount < 546) {
-			command_fail(tx->cmd,
-			"Cannot afford funding transaction");
+			command_fail(tx->cmd, LIGHTNINGD,
+				     "Cannot afford funding transaction");
 			return false;
 		}
 		if (tx->change < 546) {

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -4,6 +4,7 @@
 #include "bitcoind.h"
 #include "chaintopology.h"
 #include "jsonrpc.h"
+#include "jsonrpc_errors.h"
 #include "lightningd.h"
 #include "log.h"
 #include "watch.h"
@@ -656,7 +657,8 @@ static void json_dev_setfees(struct command *cmd,
 			continue;
 		if (!json_tok_number(buffer, ratetok[i],
 				     &topo->dev_override_fee_rate[i])) {
-			command_fail(cmd, "Invalid feerate %.*s",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Invalid feerate %.*s",
 				     ratetok[i]->end - ratetok[i]->start,
 				     buffer + ratetok[i]->start);
 			return;

--- a/lightningd/dev_ping.c
+++ b/lightningd/dev_ping.c
@@ -5,6 +5,7 @@
 #include <lightningd/htlc_end.h>
 #include <lightningd/json.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <lightningd/peer_control.h>
@@ -23,9 +24,9 @@ static void ping_reply(struct subd *subd, const u8 *msg, const int *fds UNUSED,
 		ok = fromwire_gossip_ping_reply(msg, &sent, &totlen);
 
 	if (!ok)
-		command_fail(cmd, "Bad reply message");
+		command_fail(cmd, LIGHTNINGD, "Bad reply message");
 	else if (!sent)
-		command_fail(cmd, "Unknown peer");
+		command_fail(cmd, LIGHTNINGD, "Unknown peer");
 	else {
 		struct json_result *response = new_json_result(cmd);
 
@@ -57,7 +58,8 @@ static void json_dev_ping(struct command *cmd,
 	/* FIXME: These checks are horrible, use a peer flag to say it's
 	 * ready to forward! */
 	if (!json_tok_number(buffer, lentok, &len)) {
-		command_fail(cmd, "'%.*s' is not a valid number",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid number",
 			     lentok->end - lentok->start,
 			     buffer + lentok->start);
 		return;
@@ -79,12 +81,14 @@ static void json_dev_ping(struct command *cmd,
 	 *    * [`byteslen`:`ignored`]
 	 */
 	if (len > 65535 - 2 - 2 - 2) {
-		command_fail(cmd, "%u would result in oversize ping", len);
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "%u would result in oversize ping", len);
 		return;
 	}
 
 	if (!json_tok_number(buffer, pongbytestok, &pongbytes)) {
-		command_fail(cmd, "'%.*s' is not a valid number",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid number",
 			     pongbytestok->end - pongbytestok->start,
 			     buffer + pongbytestok->start);
 		return;
@@ -92,12 +96,14 @@ static void json_dev_ping(struct command *cmd,
 
 	/* Note that > 65531 is valid: it means "no pong reply" */
 	if (pongbytes > 65535) {
-		command_fail(cmd, "pongbytes %u > 65535", pongbytes);
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "pongbytes %u > 65535", pongbytes);
 		return;
 	}
 
 	if (!json_tok_pubkey(buffer, idtok, &id)) {
-		command_fail(cmd, "'%.*s' is not a valid pubkey",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid pubkey",
 			     idtok->end - idtok->start,
 			     buffer + idtok->start);
 		return;
@@ -111,7 +117,7 @@ static void json_dev_ping(struct command *cmd,
 		if (!channel
 		    || !channel->owner
 		    || !streq(channel->owner->name, "lightning_channeld")) {
-			command_fail(cmd, "Peer in %s",
+			command_fail(cmd, LIGHTNINGD, "Peer in %s",
 				     channel && channel->owner
 				     ? channel->owner->name
 				     : "unattached");

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -72,7 +72,8 @@ bool json_get_params(struct command *cmd,
 
 struct json_result *null_response(const tal_t *ctx);
 void command_success(struct command *cmd, struct json_result *response);
-void PRINTF_FMT(2, 3) command_fail(struct command *cmd, const char *fmt, ...);
+void PRINTF_FMT(3, 4) command_fail(struct command *cmd, int code,
+				   const char *fmt, ...);
 void PRINTF_FMT(4, 5) command_fail_detailed(struct command *cmd,
 					     int code,
 					     const struct json_result *data,

--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -10,6 +10,12 @@
 #define JSONRPC2_METHOD_NOT_FOUND	-32601
 #define JSONRPC2_INVALID_PARAMS		-32602
 
+/* Uncategorized error.
+ * FIXME: This should be replaced in all places
+ * with a specific error code, and then removed.
+ */
+#define LIGHTNINGD                      -1
+
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 #define PAY_IN_PROGRESS			200
 #define PAY_RHASH_ALREADY_USED		201

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/options.h>
 #include <signal.h>
@@ -664,7 +665,7 @@ static void json_getlog(struct command *cmd,
 	if (!level)
 		minlevel = LOG_INFORM;
 	else if (!json_tok_loglevel(buffer, level, &minlevel)) {
-		command_fail(cmd, "Invalid level param");
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Invalid level param");
 		return;
 	}
 

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -5,6 +5,7 @@
 #include <common/memleak.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <stdio.h>
@@ -148,7 +149,7 @@ static void json_memleak(struct command *cmd,
 	struct json_result *response = new_json_result(cmd);
 
 	if (!getenv("LIGHTNINGD_DEV_MEMLEAK")) {
-		command_fail(cmd,
+		command_fail(cmd, LIGHTNINGD,
 			     "Leak detection needs $LIGHTNINGD_DEV_MEMLEAK");
 		return;
 	}

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -20,6 +20,7 @@
 #include <lightningd/bitcoind.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <lightningd/options.h>
@@ -1031,7 +1032,8 @@ static void json_listconfigs(struct command *cmd,
 	json_object_end(response);
 
 	if (configtok && !found) {
-		command_fail(cmd, "Unknown config option '%.*s'",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "Unknown config option '%.*s'",
 			     configtok->end - configtok->start,
 			     buffer + configtok->start);
 		return;

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -932,14 +932,16 @@ static void json_sendpay(struct command *cmd,
 	if (!hex_decode(buffer + rhashtok->start,
 			rhashtok->end - rhashtok->start,
 			&rhash, sizeof(rhash))) {
-		command_fail(cmd, "'%.*s' is not a valid sha256 hash",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid sha256 hash",
 			     rhashtok->end - rhashtok->start,
 			     buffer + rhashtok->start);
 		return;
 	}
 
 	if (routetok->type != JSMN_ARRAY) {
-		command_fail(cmd, "'%.*s' is not an array",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not an array",
 			     routetok->end - routetok->start,
 			     buffer + routetok->start);
 		return;
@@ -953,7 +955,8 @@ static void json_sendpay(struct command *cmd,
 		const jsmntok_t *amttok, *idtok, *delaytok, *chantok;
 
 		if (t->type != JSMN_OBJECT) {
-			command_fail(cmd, "Route %zu '%.*s' is not an object",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu '%.*s' is not an object",
 				     n_hops,
 				     t->end - t->start,
 				     buffer + t->start);
@@ -964,7 +967,8 @@ static void json_sendpay(struct command *cmd,
 		delaytok = json_get_member(buffer, t, "delay");
 		chantok = json_get_member(buffer, t, "channel");
 		if (!amttok || !idtok || !delaytok || !chantok) {
-			command_fail(cmd, "Route %zu needs msatoshi/id/channel/delay",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu needs msatoshi/id/channel/delay",
 				     n_hops);
 			return;
 		}
@@ -973,35 +977,40 @@ static void json_sendpay(struct command *cmd,
 
 		/* What that hop will forward */
 		if (!json_tok_u64(buffer, amttok, &route[n_hops].amount)) {
-			command_fail(cmd, "Route %zu invalid msatoshi",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu invalid msatoshi",
 				     n_hops);
 			return;
 		}
 
 		if (!json_tok_short_channel_id(buffer, chantok,
 					       &route[n_hops].channel_id)) {
-			command_fail(cmd, "Route %zu invalid channel_id", n_hops);
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu invalid channel_id", n_hops);
 			return;
 		}
 		if (!json_tok_pubkey(buffer, idtok, &route[n_hops].nodeid)) {
-			command_fail(cmd, "Route %zu invalid id", n_hops);
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu invalid id", n_hops);
 			return;
 		}
 		if (!json_tok_number(buffer, delaytok, &route[n_hops].delay)) {
-			command_fail(cmd, "Route %zu invalid delay", n_hops);
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Route %zu invalid delay", n_hops);
 			return;
 		}
 		n_hops++;
 	}
 
 	if (n_hops == 0) {
-		command_fail(cmd, "Empty route");
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Empty route");
 		return;
 	}
 
 	if (msatoshitok) {
 		if (!json_tok_u64(buffer, msatoshitok, &msatoshi)) {
-			command_fail(cmd, "'%.*s' is not a number",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "'%.*s' is not a number",
 				     msatoshitok->end - msatoshitok->start,
 				     buffer + msatoshitok->start);
 			return;
@@ -1014,7 +1023,8 @@ static void json_sendpay(struct command *cmd,
 		 * fail. */
 		if (!(msatoshi <= route[n_hops-1].amount &&
 		      route[n_hops-1].amount <= 2 * msatoshi)) {
-			command_fail(cmd, "msatoshi %"PRIu64" out of range",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "msatoshi %"PRIu64" out of range",
 				     msatoshi);
 			return;
 		}
@@ -1035,8 +1045,7 @@ AUTODATA(json_command, &sendpay_command);
 
 static void waitsendpay_timeout(struct command *cmd)
 {
-	command_fail_detailed(cmd, PAY_IN_PROGRESS, NULL,
-			      "Timed out while waiting");
+	command_fail(cmd, PAY_IN_PROGRESS, "Timed out while waiting");
 }
 
 static void json_waitsendpay(struct command *cmd, const char *buffer,
@@ -1056,14 +1065,16 @@ static void json_waitsendpay(struct command *cmd, const char *buffer,
 	if (!hex_decode(buffer + rhashtok->start,
 			rhashtok->end - rhashtok->start,
 			&rhash, sizeof(rhash))) {
-		command_fail(cmd, "'%.*s' is not a valid sha256 hash",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid sha256 hash",
 			     rhashtok->end - rhashtok->start,
 			     buffer + rhashtok->start);
 		return;
 	}
 
 	if (timeouttok && !json_tok_number(buffer, timeouttok, &timeout)) {
-		command_fail(cmd, "'%.*s' is not a valid number",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid number",
 			     timeouttok->end - timeouttok->start,
 			     buffer + timeouttok->start);
 		return;
@@ -1107,7 +1118,8 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 		char *b11str, *fail;
 
 		if (rhashtok) {
-			command_fail(cmd, "Can only specify one of"
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Can only specify one of"
 				     " {bolt11} or {payment_hash}");
 			return;
 		}
@@ -1117,7 +1129,8 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 
 		b11 = bolt11_decode(cmd, b11str, NULL, &fail);
 		if (!b11) {
-			command_fail(cmd, "Invalid bolt11: %s", fail);
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "Invalid bolt11: %s", fail);
 			return;
 		}
 		rhash = &b11->payment_hash;
@@ -1126,7 +1139,8 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 		if (!hex_decode(buffer + rhashtok->start,
 				rhashtok->end - rhashtok->start,
 				rhash, sizeof(*rhash))) {
-			command_fail(cmd, "'%.*s' is not a valid sha256 hash",
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "'%.*s' is not a valid sha256 hash",
 				     rhashtok->end - rhashtok->start,
 				     buffer + rhashtok->start);
 			return;

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -629,7 +629,8 @@ static void json_pay(struct command *cmd,
 
 	b11 = bolt11_decode(pay, b11str, desc, &fail);
 	if (!b11) {
-		command_fail(cmd, "Invalid bolt11: %s", fail);
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "Invalid bolt11: %s", fail);
 		return;
 	}
 
@@ -641,7 +642,8 @@ static void json_pay(struct command *cmd,
 	pay->min_final_cltv_expiry = b11->min_final_cltv_expiry;
 
 	if (retryfortok && !json_tok_number(buffer, retryfortok, &retryfor)) {
-		command_fail(cmd, "'%.*s' is not an integer",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not an integer",
 			     retryfortok->end - retryfortok->start,
 			     buffer + retryfortok->start);
 		return;
@@ -650,16 +652,18 @@ static void json_pay(struct command *cmd,
 	if (b11->msatoshi) {
 		msatoshi = *b11->msatoshi;
 		if (msatoshitok) {
-			command_fail(cmd, "msatoshi parameter unnecessary");
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "msatoshi parameter unnecessary");
 			return;
 		}
 	} else {
 		if (!msatoshitok) {
-			command_fail(cmd, "msatoshi parameter required");
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				     "msatoshi parameter required");
 			return;
 		}
 		if (!json_tok_u64(buffer, msatoshitok, &msatoshi)) {
-			command_fail(cmd,
+			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				     "msatoshi '%.*s' is not a valid number",
 				     msatoshitok->end-msatoshitok->start,
 				     buffer + msatoshitok->start);
@@ -670,7 +674,8 @@ static void json_pay(struct command *cmd,
 
 	if (riskfactortok
 	    && !json_tok_double(buffer, riskfactortok, &riskfactor)) {
-		command_fail(cmd, "'%.*s' is not a valid double",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid double",
 			     riskfactortok->end - riskfactortok->start,
 			     buffer + riskfactortok->start);
 		return;
@@ -679,19 +684,22 @@ static void json_pay(struct command *cmd,
 
 	if (maxfeetok
 	    && !json_tok_double(buffer, maxfeetok, &maxfeepercent)) {
-		command_fail(cmd, "'%.*s' is not a valid double",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid double",
 			     maxfeetok->end - maxfeetok->start,
 			     buffer + maxfeetok->start);
 		return;
 	}
 	/* Ensure it is in range 0.0 <= maxfeepercent <= 100.0 */
 	if (!(0.0 <= maxfeepercent)) {
-		command_fail(cmd, "%f maxfeepercent must be non-negative",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "%f maxfeepercent must be non-negative",
 			     maxfeepercent);
 		return;
 	}
 	if (!(maxfeepercent <= 100.0)) {
-		command_fail(cmd, "%f maxfeepercent must be <= 100.0",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "%f maxfeepercent must be <= 100.0",
 			     maxfeepercent);
 		return;
 	}
@@ -699,13 +707,14 @@ static void json_pay(struct command *cmd,
 
 	if (maxdelaytok
 	    && !json_tok_number(buffer, maxdelaytok, &maxdelay)) {
-		command_fail(cmd, "'%.*s' is not a valid double",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "'%.*s' is not a valid integer",
 			     maxdelaytok->end - maxdelaytok->start,
 			     buffer + maxdelaytok->start);
 		return;
 	}
 	if (maxdelay < pay->min_final_cltv_expiry) {
-		command_fail(cmd,
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 			     "maxdelay (%u) must be greater than "
 			     "min_final_cltv_expiry (%"PRIu32") of "
 			     "invoice",

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -11,6 +11,7 @@
 #include <lightningd/chaintopology.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <lightningd/pay.h>
@@ -1647,12 +1648,14 @@ static void json_dev_ignore_htlcs(struct command *cmd, const char *buffer,
 
 	peer = peer_from_json(cmd->ld, buffer, nodeidtok);
 	if (!peer) {
-		command_fail(cmd, "Could not find channel with that peer");
+		command_fail(cmd, LIGHTNINGD,
+			     "Could not find channel with that peer");
 		return;
 	}
 
 	if (!json_tok_bool(buffer, ignoretok, &peer->ignore_htlcs)) {
-		command_fail(cmd, "Invalid boolean '%.*s'",
+		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			     "Invalid boolean '%.*s'",
 			     ignoretok->end - ignoretok->start,
 			     buffer + ignoretok->start);
 		return;

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -51,7 +51,8 @@ bool channel_tell_funding_locked(struct lightningd *ld UNNEEDED,
 				 u32 depth UNNEEDED)
 { fprintf(stderr, "channel_tell_funding_locked called!\n"); abort(); }
 /* Generated stub for command_fail */
-void  command_fail(struct command *cmd UNNEEDED, const char *fmt UNNEEDED, ...)
+void  command_fail(struct command *cmd UNNEEDED, int code UNNEEDED,
+		   const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "command_fail called!\n"); abort(); }
 /* Generated stub for command_still_pending */
 void command_still_pending(struct command *cmd UNNEEDED)


### PR DESCRIPTION
Until now, `command_fail()` reported an error code of -1 for all uses.
This PR adds an `int code` parameter to `command_fail()`, requiring the
caller to explicitly include the error code.

This is part of #1464.

The majority of the calls are used during parameter validation and
their error code is now JSONRPC2_INVALID_PARAMS.

The rest of the calls report an error code of LIGHTNINGD, which I defined to
-1 in `jsonrpc_errors.h`.  The intention here is that as we improve our error
reporting all occurenaces of LIGHTNINGD will go away and we can eventually
remove it.

I also converted calls to `command_fail_detailed()` that took a `NULL` `data`
parameter to use the new `command_fail()`.

The only difference from an end user perspecive is that bad input errors that
used to be -1 will now be -32602 (JSONRPC2_INVALID_PARAMS).