### PR TITLE
Make dump_htlcs SUPERVERBOSE

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -113,6 +113,7 @@ static void dump_htlc(const struct htlc *htlc, const char *prefix)
 
 void dump_htlcs(const struct channel *channel, const char *prefix)
 {
+#ifdef SUPERVERBOSE
 	struct htlc_map_iter it;
 	const struct htlc *htlc;
 
@@ -121,6 +122,7 @@ void dump_htlcs(const struct channel *channel, const char *prefix)
 	     htlc = htlc_map_next(channel->htlcs, &it)) {
 		dump_htlc(htlc, prefix);
 	}
+#endif
 }
 
 /* Returns up to three arrays:


### PR DESCRIPTION
This is the cause of linear slow down in payment in https://github.com/ElementsProject/lightning/issues/1506

Thanks to @Saibato  and @ZmnSCPxj 

Before

![40040663-18230b4e-5856-11e8-9432-9759e11bd8bb 1](https://user-images.githubusercontent.com/3020646/40700647-69463a76-6415-11e8-9482-ce4e6da2f6e3.png)

After

![40700510-c5edddf2-6414-11e8-8640-3a505812733d 1](https://user-images.githubusercontent.com/3020646/40700641-5b310448-6415-11e8-8d0f-28fa4dcc1689.png)
