### PR TITLE
In Debian at least, the Python 3 version of pytest is called pytest-3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifneq ($(NO_COMPAT),1)
 COMPAT_CFLAGS=-DCOMPAT_V052=1
 endif
 
-PYTEST := $(shell command -v pytest 2> /dev/null)
+PYTEST := $(shell command -v pytest-3 2> /dev/null)
 PYTEST_OPTS := -v -x
 
 # This is where we add new features as bitcoin adds them.


### PR DESCRIPTION
Use this executable name to make sure we don't try to use the Python 2 version.