### PR TITLE
Do not ask bitcoind for outpoints we should know

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -745,14 +745,14 @@ struct chain_topology *new_topology(struct lightningd *ld, struct log *log)
 
 void setup_topology(struct chain_topology *topo,
 		    struct timers *timers,
-		    u32 first_blocknum)
+		    u32 min_blockheight, u32 max_blockheight)
 {
 	memset(&topo->feerate, 0, sizeof(topo->feerate));
 	topo->timers = timers;
 
 	/* FIXME(cdecker) Actually load this from DB */
-	topo->min_blockheight = first_blocknum;
-	topo->max_blockheight = first_blocknum;
+	topo->min_blockheight = min_blockheight;
+	topo->max_blockheight = max_blockheight;
 
 	/* Make sure bitcoind is started, and ready */
 	wait_for_bitcoind(topo->bitcoind);

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -422,6 +422,7 @@ static void add_tip(struct chain_topology *topo, struct block *b)
 	filter_block_txs(topo, b);
 
 	block_map_add(&topo->block_map, b);
+	topo->max_blockheight = b->height;
 }
 
 static struct block *new_block(struct chain_topology *topo,
@@ -509,7 +510,7 @@ static void init_topo(struct bitcoind *bitcoind UNUSED,
 		      struct bitcoin_block *blk,
 		      struct chain_topology *topo)
 {
-	topo->root = new_block(topo, blk, topo->first_blocknum);
+	topo->root = new_block(topo, blk, topo->max_blockheight);
 	block_map_add(&topo->block_map, topo->root);
 	topo->tip = topo->prev_tip = topo->root;
 
@@ -533,32 +534,32 @@ static void get_init_blockhash(struct bitcoind *bitcoind, u32 blockcount,
 	/* If bitcoind's current blockheight is below the requested height, just
 	 * go back to that height. This might be a new node catching up, or
 	 * bitcoind is processing a reorg. */
-	if (blockcount < topo->first_blocknum) {
+	if (blockcount < topo->max_blockheight) {
 		if (bitcoind->ld->config.rescan < 0) {
 			/* Absolute blockheight, but bitcoind's blockheight isn't there yet */
 			/* Protect against underflow in subtraction.
 			 * Possible in regtest mode. */
 			if (blockcount < 1)
-				topo->first_blocknum = 0;
+				topo->max_blockheight = 0;
 			else
-				topo->first_blocknum = blockcount - 1;
-		} else if (topo->first_blocknum == UINT32_MAX) {
+				topo->max_blockheight = blockcount - 1;
+		} else if (topo->max_blockheight == UINT32_MAX) {
 			/* Relative rescan, but we didn't know the blockheight */
 			/* Protect against underflow in subtraction.
 			 * Possible in regtest mode. */
 			if (blockcount < bitcoind->ld->config.rescan)
-				topo->first_blocknum = 0;
+				topo->max_blockheight = 0;
 			else
-				topo->first_blocknum = blockcount - bitcoind->ld->config.rescan;
+				topo->max_blockheight = blockcount - bitcoind->ld->config.rescan;
 		}
 	}
 
 	/* Rollback to the given blockheight, so we start track
 	 * correctly again */
-	wallet_blocks_rollback(topo->wallet, topo->first_blocknum);
+	wallet_blocks_rollback(topo->wallet, topo->max_blockheight);
 
 	/* Get up to speed with topology. */
-	bitcoind_getblockhash(bitcoind, topo->first_blocknum,
+	bitcoind_getblockhash(bitcoind, topo->max_blockheight,
 			      get_init_block, topo);
 }
 
@@ -749,7 +750,9 @@ void setup_topology(struct chain_topology *topo,
 	memset(&topo->feerate, 0, sizeof(topo->feerate));
 	topo->timers = timers;
 
-	topo->first_blocknum = first_blocknum;
+	/* FIXME(cdecker) Actually load this from DB */
+	topo->min_blockheight = first_blocknum;
+	topo->max_blockheight = first_blocknum;
 
 	/* Make sure bitcoind is started, and ready */
 	wait_for_bitcoind(topo->bitcoind);

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -89,8 +89,8 @@ struct chain_topology {
 	/* Where to log things. */
 	struct log *log;
 
-	/* How far back (in blocks) to go. */
-	unsigned int first_blocknum;
+	/* What range of blocks do we have in our database? */
+	u32 min_blockheight, max_blockheight;
 
 	/* How often to poll. */
 	u32 poll_seconds;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -150,9 +150,8 @@ void broadcast_tx(struct chain_topology *topo,
 				 const char *err));
 
 struct chain_topology *new_topology(struct lightningd *ld, struct log *log);
-void setup_topology(struct chain_topology *topology,
-		    struct timers *timers,
-		    u32 first_channel_block);
+void setup_topology(struct chain_topology *topology, struct timers *timers,
+		    u32 min_blockheight, u32 max_blockheight);
 
 void begin_topology(struct chain_topology *topo);
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -306,7 +306,7 @@ void notify_new_block(struct lightningd *ld,
 int main(int argc, char *argv[])
 {
 	struct lightningd *ld;
-	u32 blockheight;
+	u32 blockheight, first_block;
 
 	setup_locale();
 	daemon_setup(argv[0], log_backtrace_print, log_backtrace_exit);
@@ -388,7 +388,7 @@ int main(int argc, char *argv[])
 	/* Get the blockheight we are currently at, UINT32_MAX is used to signal
 	 * an unitialized wallet and that we should start off of bitcoind's
 	 * current height */
-	blockheight = wallet_blocks_height(ld->wallet, UINT32_MAX);
+	wallet_blocks_heights(ld->wallet, UINT32_MAX, &first_block, &blockheight);
 
 	/* If we were asked to rescan from an absolute height (--rescan < 0)
 	 * then just go there. Otherwise take compute the diff to our current

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -306,7 +306,7 @@ void notify_new_block(struct lightningd *ld,
 int main(int argc, char *argv[])
 {
 	struct lightningd *ld;
-	u32 blockheight, first_block;
+	u32 min_blockheight, max_blockheight;
 
 	setup_locale();
 	daemon_setup(argv[0], log_backtrace_print, log_backtrace_exit);
@@ -388,24 +388,22 @@ int main(int argc, char *argv[])
 	/* Get the blockheight we are currently at, UINT32_MAX is used to signal
 	 * an unitialized wallet and that we should start off of bitcoind's
 	 * current height */
-	wallet_blocks_heights(ld->wallet, UINT32_MAX, &first_block, &blockheight);
+	wallet_blocks_heights(ld->wallet, UINT32_MAX, &min_blockheight, &max_blockheight);
 
 	/* If we were asked to rescan from an absolute height (--rescan < 0)
-	 * then just go there. Otherwise take compute the diff to our current
-	 * height, lowerbounded by 0. */
+	 * then just go there. Otherwise compute the diff to our current height,
+	 * lowerbounded by 0. */
 	if (ld->config.rescan < 0)
-		blockheight = -ld->config.rescan;
-	else if (blockheight < (u32)ld->config.rescan)
-		blockheight = 0;
-	else if (blockheight != UINT32_MAX)
-		blockheight -= ld->config.rescan;
+		max_blockheight = -ld->config.rescan;
+	else if (max_blockheight < (u32)ld->config.rescan)
+		max_blockheight = 0;
+	else if (max_blockheight != UINT32_MAX)
+		max_blockheight -= ld->config.rescan;
 
 	db_commit_transaction(ld->wallet->db);
 
 	/* Initialize block topology (does its own transaction) */
-	setup_topology(ld->topology,
-		       &ld->timers,
-		       blockheight);
+	setup_topology(ld->topology, &ld->timers, min_blockheight, max_blockheight);
 
 	/* Create RPC socket (if any) */
 	setup_jsonrpc(ld, ld->rpc_filename);

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -101,9 +101,8 @@ void setup_color_and_alias(struct lightningd *ld UNNEEDED)
 void setup_jsonrpc(struct lightningd *ld UNNEEDED, const char *rpc_filename UNNEEDED)
 { fprintf(stderr, "setup_jsonrpc called!\n"); abort(); }
 /* Generated stub for setup_topology */
-void setup_topology(struct chain_topology *topology UNNEEDED,
-		    struct timers *timers UNNEEDED,
-		    u32 first_channel_block UNNEEDED)
+void setup_topology(struct chain_topology *topology UNNEEDED, struct timers *timers UNNEEDED,
+		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)
 { fprintf(stderr, "setup_topology called!\n"); abort(); }
 /* Generated stub for subd_shutdown */
 void subd_shutdown(struct subd *subd UNNEEDED, unsigned int seconds UNNEEDED)

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -121,9 +121,9 @@ struct txfilter *txfilter_new(const tal_t *ctx UNNEEDED)
 /* Generated stub for version */
 const char *version(void)
 { fprintf(stderr, "version called!\n"); abort(); }
-/* Generated stub for wallet_blocks_height */
-u32 wallet_blocks_height(struct wallet *w UNNEEDED, u32 def UNNEEDED)
-{ fprintf(stderr, "wallet_blocks_height called!\n"); abort(); }
+/* Generated stub for wallet_blocks_heights */
+void wallet_blocks_heights(struct wallet *w UNNEEDED, u32 def UNNEEDED, u32 *min UNNEEDED, u32 *max UNNEEDED)
+{ fprintf(stderr, "wallet_blocks_heights called!\n"); abort(); }
 /* Generated stub for wallet_channels_load_active */
 bool wallet_channels_load_active(const tal_t *ctx UNNEEDED, struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_channels_load_active called!\n"); abort(); }

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -769,20 +769,20 @@ void wallet_channel_stats_load(struct wallet *w,
 	db_stmt_done(stmt);
 }
 
-u32 wallet_blocks_height(struct wallet *w, u32 def)
+void wallet_blocks_heights(struct wallet *w, u32 def, u32 *min, u32 *max)
 {
-	u32 blockheight;
-	sqlite3_stmt *stmt = db_prepare(w->db, "SELECT MAX(height) FROM blocks;");
+	assert(min != NULL && max != NULL);
+	sqlite3_stmt *stmt = db_prepare(w->db, "SELECT MIN(height), MAX(height) FROM blocks;");
 
 	/* If we ever processed a block we'll get the latest block in the chain */
 	if (sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_type(stmt, 0) != SQLITE_NULL) {
-		blockheight = sqlite3_column_int(stmt, 0);
-		db_stmt_done(stmt);
-		return blockheight;
+		*min = sqlite3_column_int(stmt, 0);
+		*max = sqlite3_column_int(stmt, 1);
 	} else {
-		db_stmt_done(stmt);
-		return def;
+		*min = def;
+		*max = def;
 	}
+	db_stmt_done(stmt);
 }
 
 static void wallet_channel_config_insert(struct wallet *w,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -316,13 +316,15 @@ void wallet_channel_stats_load(struct wallet *w, u64 cdbid, struct channel_stats
 /**
  * Retrieve the blockheight of the last block processed by lightningd.
  *
- * Will return either the maximal blockheight or the default value if the wallet
- * was never used before.
+ * Will set min/max either the minimal/maximal blockheight or the default value
+ * if the wallet was never used before.
  *
  * @w: wallet to load from.
  * @def: the default value to return if we've never used the wallet before
+ * @min(out): height of the first block we track
+ * @max(out): height of the last block we added
  */
-u32 wallet_blocks_height(struct wallet *w, u32 def);
+void wallet_blocks_heights(struct wallet *w, u32 def, u32 *min, u32 *max);
 
 /**
  * wallet_extract_owned_outputs - given a tx, extract all of our outputs


### PR DESCRIPTION
We now remember the block range that we have stored in the DB and don't go ask for outpoints that we would know if they'd exist.

This was a common problem before: we'd receive a `channel_announcement` for a spent outpoint (the remote node didn't prune) and we'd always call out to `bitcoind` even though we removed the outpoint earlier and it not existing should have been the signal to ignore the announcement.