### PR TITLE
Add 'make ncc' target, for source code analysis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,11 @@ coverage/coverage.info: check pytest
 coverage: coverage/coverage.info
 	genhtml coverage/coverage.info --output-directory coverage
 
+# We make libwallycore.la a dependency, so that it gets built normally, without ncc.
+# Ncc can't handle the libwally source code (yet).
+ncc: external/libwally-core/src/libwallycore.la
+	CC="ncc -ncgcc -ncld -ncfabs" AR=nccar LD=nccld make
+
 # Ignore test/ directories.
 TAGS: FORCE
 	$(RM) TAGS; find * -name test -type d -prune -o -name '*.[ch]' -print | xargs etags --append
@@ -362,6 +367,7 @@ clean: wire-clean
 	$(RM) check-bolt tools/check-bolt tools/*.o
 	find . -name '*gcda' -delete
 	find . -name '*gcno' -delete
+	find . -name '*.nccout' -delete
 
 update-mocks/%: %
 	@tools/update-mocks.sh "$*"
@@ -470,7 +476,7 @@ installcheck:
 	@rm -rf testinstall || true
 
 .PHONY: installdirs install-program install-data install uninstall \
-	installcheck
+	installcheck ncc
 
 ccan-breakpoint.o: $(CCANDIR)/ccan/breakpoint/breakpoint.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -186,6 +186,17 @@ valgrind installed, and build with DEVELOPER=1.
 Our Travis CI instance (see `.travis.yml`) runs all these for each
 pull request.
 
+Source code analysis
+--------------------
+An updated version of the NCC source code analysis tool is available at
+
+https://github.com/bitonic-cjp/ncc
+
+It can be used to analyze the lightningd source code by running
+`make clean && make ncc`. The output (which is built in parallel with the
+binaries) is stored in .nccout files. You can browse it, for instance, with
+a command like `nccnav lightningd/lightningd.nccout`.
+
 Subtleties
 ----------
 


### PR DESCRIPTION
Personally, I find it difficult to grok the Lightningd source code. I hope this helps.