### PR TITLE
Increase cltv_final

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -492,7 +492,7 @@ static const struct config testnet_config = {
 
 	/* Be aggressive on testnet. */
 	.cltv_expiry_delta = 6,
-	.cltv_final = 6,
+	.cltv_final = 10,
 
 	/* Send commit 10msec after receiving; almost immediately. */
 	.commit_time_ms = 10,
@@ -544,7 +544,7 @@ static const struct config mainnet_config = {
 	 *
 	 * The minimum `cltv_expiry` we will accept for terminal payments: the
 	 * worst case for the terminal node C lower at `2R+G+S` blocks */
-	.cltv_final = 8,
+	.cltv_final = 10,
 
 	/* Send commit 10msec after receiving; almost immediately. */
 	.commit_time_ms = 10,


### PR DESCRIPTION
I think it's better if the default value works with other implementations. If you want to be more aggressive, you'd start lightningd with `--cltv-final=6` for instance.

As explained in https://github.com/ACINQ/eclair/issues/526, Eclair won't accept payment requests with `cltv_final` too low. Error message from Eclair for any value below 10:
```
1 attempts:
- (remote) payment expiry is too close to the current block height for safe handling by the final node
```