### PR TITLE
README: Add ./configure to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For the impatient here's the gist of it for Ubuntu and Debian:
       libsqlite3-dev python python3 net-tools zlib1g-dev
     git clone https://github.com/ElementsProject/lightning.git
     cd lightning
+    ./configure
     make
 
 Or if you like to throw `docker` into the mix:


### PR DESCRIPTION
Now required, after the changes in https://github.com/ElementsProject/lightning/commit/c49765553ffc352e678684703c513351d418969e.