### PR TITLE
gossip: Duplicate removes can result in null pointers in broadcast

### DIFF
--- a/gossipd/broadcast.c
+++ b/gossipd/broadcast.c
@@ -33,8 +33,10 @@ struct broadcast_state *new_broadcast_state(tal_t *ctx)
 void broadcast_del(struct broadcast_state *bstate, u64 index, const u8 *payload)
 {
 	const struct queued_message *q = uintmap_del(&bstate->broadcasts, index);
-	assert(q->payload == payload);
-	broadcast_state_check(bstate, "broadcast_del");
+	if (q != NULL) {
+		assert(q->payload == payload);
+		broadcast_state_check(bstate, "broadcast_del");
+	}
 }
 
 static void destroy_queued_message(struct queued_message *msg,


### PR DESCRIPTION
The destructor not being the only place where we delete from the `uintmap` means that sometimes the delete in the destructor will end up not finding the item. Specifically this will happen here:

https://github.com/ElementsProject/lightning/blob/4429c6e7cd78c1eca39742ad57d5ff02ce5e6852/gossipd/routing.c#L230-L233

We delete from the map, don't reinsert, and then eventually we `tal_free` the message.