### PR TITLE
Armbian build instructions

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -7,7 +7,8 @@
 6. [macOS](#to-build-on-macos)
 7. [Android](#to-cross-compile-for-android)
 8. [Raspberry Pi](#to-cross-compile-for-raspberry-pi)
-9. [Additional steps](#additional-steps)
+9. [Armbian](#to-compile-for-armbian)
+10. [Additional steps](#additional-steps)
 
 Library Requirements
 --------------------
@@ -271,6 +272,15 @@ The compilation will eventually fail due to a compile error in the `cdump` CCAN 
     make clean -C ccan/ccan/cdump/tools
     make CC=gcc -C ccan/ccan/cdump/tools
     BUILD=x86_64 MAKE_HOST=arm-linux-gnueabihf make PIE=1 DEVELOPER=0 CONFIGURATOR_CC="arm-linux-gnueabihf-gcc -static" LDFLAGS="-L/path/to/gmp-and-sqlite/lib" CFLAGS="-std=gnu11 -I /path/to/gmp-and-sqlite/include -I . -I ccan -I external/libwally-core/src/secp256k1/include -I external/libsodium/src/libsodium/include -I external/jsmn -I external/libwally-core/include -I external/libbacktrace -I external/libbase58"
+
+To compile for Armbian
+--------------------
+For all the other Pi devices out there, consider using [Armbian](https://www.armbian.com).
+
+You can compile in `customize-image.sh` using the instructions for Ubuntu.
+
+A working example that compiles both bitcoind and c-lightning for Armbian can
+be found [here](https://github.com/Sjors/armbian-bitcoin-core).
 
 Additional steps
 --------------------


### PR DESCRIPTION
There's more pies than the Raspberry.

Armbian uses Ubuntu 16.04 / 18.04 to build images that you can then put on an SD card. You can pass extra commands to that process which I've used to compile c-lightning. This works fine using just the regular Ubuntu instructions, but it's pretty slow. I'm not entirely sure how Armbian tricks the build process into creating the correct binary for the device architecture, but it does.

Based on experience cross-compiling Bitcoin Core, I suspect cross-compiling c-lightning will be much faster if done on the Ubuntu VM, rather than during the Armbian build process. However I wasn't able to figure out how to tweak the Raspberry Pi instructions to do this.

Perhaps these instructions are useful as-is, but otherwise we can leave this open until someone figures it out.