### PR TITLE
opts: Be more lenient about locktime_max and fee range by default

### DIFF
--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -60,6 +60,10 @@ struct config {
 
 	/* ipv6 bind disable */
 	bool no_ipv6_bind;
+
+	/* Accept fee changes only if they are in the range our_fee -
+	 * our_fee*multiplier */
+	u32 max_fee_multiplier;
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -524,7 +524,7 @@ static const struct config testnet_config = {
 	.rescan = 30,
 
 	/* Fees may be in the range our_fee - 10*our_fee */
-	.max_fee_multiplier = 5,
+	.max_fee_multiplier = 10,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -580,7 +580,7 @@ static const struct config mainnet_config = {
 	.rescan = 15,
 
 	/* Fees may be in the range our_fee - 10*our_fee */
-	.max_fee_multiplier = 5,
+	.max_fee_multiplier = 10,
 };
 
 static void check_config(struct lightningd *ld)

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -477,8 +477,9 @@ static const struct config testnet_config = {
 	/* 6 blocks to catch cheating attempts. */
 	.locktime_blocks = 6,
 
-	/* They can have up to 5 days. */
-	.locktime_max = 5 * 6 * 24,
+	/* They can have up to 14 days, maximumu value that lnd will ask for by default. */
+	/* FIXME Convince lnd to use more reasonable defaults... */
+	.locktime_max = 14 * 6 * 24,
 
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 1,
@@ -521,8 +522,9 @@ static const struct config mainnet_config = {
 	/* ~one day to catch cheating attempts. */
 	.locktime_blocks = 6 * 24,
 
-	/* They can have up to 5 days. */
-	.locktime_max = 5 * 6 * 24,
+	/* They can have up to 14 days, maximumu value that lnd will ask for by default. */
+	/* FIXME Convince lnd to use more reasonable defaults... */
+	.locktime_max = 14 * 6 * 24,
 
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 3,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -462,6 +462,13 @@ static void dev_register_opts(struct lightningd *ld)
 	opt_register_arg("--dev-bitcoind-poll", opt_set_u32, opt_show_u32,
 			 &ld->topology->poll_seconds,
 			 "Time between polling for new transactions");
+	opt_register_arg("--dev-max-fee-multiplier", opt_set_u32, opt_show_u32,
+			 &ld->config.max_fee_multiplier,
+			 "Allow the fee proposed by the remote end to be up to "
+			 "multiplier times higher than our own. Small values "
+			 "will cause channels to be closed more often due to "
+			 "fee fluctuations, large values may result in large "
+			 "fees.");
 	opt_register_arg("--dev-override-fee-rates", opt_set_fee_rates, NULL,
 			 ld->topology,
 			 "Force a specific rates (immediate/normal/slow) in satoshis per kw regardless of estimated fees");
@@ -515,6 +522,9 @@ static const struct config testnet_config = {
 
 	/* Rescan 5 hours of blocks on testnet, it's reorg happy */
 	.rescan = 30,
+
+	/* Fees may be in the range our_fee - 10*our_fee */
+	.max_fee_multiplier = 5,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -568,6 +578,9 @@ static const struct config mainnet_config = {
 
 	/* Rescan 2.5 hours of blocks on startup, it's not so reorg happy */
 	.rescan = 15,
+
+	/* Fees may be in the range our_fee - 10*our_fee */
+	.max_fee_multiplier = 5,
 };
 
 static void check_config(struct lightningd *ld)

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -182,13 +182,14 @@ u32 feerate_min(struct lightningd *ld)
  *
  * Given the variance in fees, and the fact that the transaction may
  * be spent in the future, it's a good idea for the fee payer to keep
- * a good margin, say 5x the expected fee requirement */
+ * a good margin, say 10x the expected fee requirement */
 u32 feerate_max(struct lightningd *ld)
 {
 	if (ld->config.ignore_fee_limits)
 		return UINT_MAX;
 
-	return get_feerate(ld->topology, FEERATE_IMMEDIATE) * 5;
+	return get_feerate(ld->topology, FEERATE_IMMEDIATE) *
+	       ld->config.max_fee_multiplier;
 }
 
 static void sign_last_tx(struct channel *channel)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3953,8 +3953,8 @@ class LightningDTests(BaseLightningDTests):
     def test_funding_fail(self):
         """Add some funds, fund a channel without enough funds"""
         # Previous runs with same bitcoind can leave funds!
-        l1 = self.node_factory.get_node(random_hsm=True)
         max_locktime = 5 * 6 * 24
+        l1 = self.node_factory.get_node(random_hsm=True, options={'max-locktime-blocks': max_locktime})
         l2 = self.node_factory.get_node(options={'watchtime-blocks': max_locktime + 1})
         l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4487,8 +4487,9 @@ class LightningDTests(BaseLightningDTests):
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_fee_limits(self):
         # FIXME: Test case where opening denied.
-        l1, l2 = self.connect()
-        self.fund_channel(l1, l2, 10**6)
+        l1, l2 = self.node_factory.get_nodes(2, opts={'dev-max-fee-multiplier': 5})
+        l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+        l1.fund_channel(l2, 10**6)
 
         # L1 asks for stupid low fees
         l1.rpc.dev_setfees(15)
@@ -4618,9 +4619,9 @@ class LightningDTests(BaseLightningDTests):
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_pay_disconnect(self):
         """If the remote node has disconnected, we fail payment, but can try again when it reconnects"""
-        l1, l2 = self.connect()
-
-        chanid = self.fund_channel(l1, l2, 10**6)
+        l1, l2 = self.node_factory.get_nodes(2, opts={'dev-max-fee-multiplier': 5})
+        l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+        chanid = l1.fund_channel(l2, 10**6)
 
         # Wait for route propagation.
         self.wait_for_routes(l1, [chanid])


### PR DESCRIPTION
This has been brought up a few times, and I think we should at least ensure that the default parameters of the three implementations match. Together with #1551 this obviates all the workarounds I had in the integration testing suite. I still think our old defaults were better, but maybe we can go back to saner defaults over time.

I added the `max_fee_multiplier` as an option since it was the only non-configurable parameter that needed to be changed for this.

Closes #1110 
Closes #1560