### PR TITLE
tests: reenable developer tests.

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -2,8 +2,10 @@ from fixtures import *  # noqa: F401,F403
 
 import os
 
+with open('config.vars') as configfile:
+    config = dict([(line.rstrip().split('=', 1)) for line in configfile])
 
-DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+DEVELOPER = os.getenv("DEVELOPER", config['DEVELOPER']) == "1"
 
 
 def test_closing_id(node_factory):

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -6,7 +6,10 @@ import time
 import unittest
 
 
-DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+with open('config.vars') as configfile:
+    config = dict([(line.rstrip().split('=', 1)) for line in configfile])
+
+DEVELOPER = os.getenv("DEVELOPER", config['DEVELOPER']) == "1"
 
 
 @unittest.skipIf(not DEVELOPER, "needs --dev-broadcast-interval, --dev-channelupdate-interval")

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -1730,7 +1730,7 @@ class LightningDTests(BaseLightningDTests):
             'channel': '1:1:1'
         }
         l1.rpc.sendpay(to_json([routestep]), rhash)
-        l1.daemon.wait_for_log(r'Disabling channel')
+        l1.daemon.wait_for_log('sendrawtx exit 0')
         bitcoind.rpc.generate(1)
 
         # Wait for nodes to notice the failure, this seach needle is after the


### PR DESCRIPTION
72d103d6bb8ddc3b06fb980946ab75e055f7a8a1 deprecated DEVELOPER env var
in favor of config.vars, but didn't update test_closing.py or test_gossip.py.

5d0a54b7f0880c22afc2e9082bd9e89f2cf61fbe then removed the explicit
DEVELOPER= setting from Travis.
