### PR TITLE
Fix valgrind warning with IPv6 sockets

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -151,6 +151,7 @@ bool wireaddr_to_ipv4(const struct wireaddr *addr, struct sockaddr_in *s4)
 {
 	if (addr->type != ADDR_TYPE_IPV4)
 		return false;
+	memset(s4, 0, sizeof(*s4));
 	s4->sin_family = AF_INET;
 	s4->sin_port = htons(addr->port);
 	assert(addr->addrlen == sizeof(s4->sin_addr));
@@ -162,6 +163,7 @@ bool wireaddr_to_ipv6(const struct wireaddr *addr, struct sockaddr_in6 *s6)
 {
 	if (addr->type != ADDR_TYPE_IPV6)
 		return false;
+	memset(s6, 0, sizeof(*s6));
 	s6->sin6_family = AF_INET6;
 	s6->sin6_port = htons(addr->port);
 	assert(addr->addrlen == sizeof(s6->sin6_addr));


### PR DESCRIPTION
2018-06-14T01:09:03.495Z lightningd(23766): HSM: created new hsm_secret file
==23785== Syscall param socketcall.bind(my_addr.sin6_flowinfo) points to uninitialised byte(s)
==23785==    at 0x5731877: bind (syscall-template.S:78)
==23785==    by 0x11767C: make_listen_fd (gossip.c:2405)
==23785==    by 0x117DA2: handle_wireaddr_listen (gossip.c:2558)
==23785==    by 0x1183B7: setup_listeners (gossip.c:2653)
==23785==    by 0x118E86: gossip_activate (gossip.c:2871)
==23785==    by 0x11AC42: recv_req (gossip.c:3543)
==23785==    by 0x143FF1: next_plan (io.c:59)
==23785==    by 0x144AEE: do_plan (io.c:387)
==23785==    by 0x144B2C: io_ready (io.c:397)
==23785==    by 0x146719: io_loop (poll.c:310)
==23785==    by 0x11B0B0: main (gossip.c:3687)
==23785==  Address 0x1ffeffffa4 is on thread 1's stack
==23785==  in frame #2, created by handle_wireaddr_listen (gossip.c:2539)

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>