### PR TITLE
Gossip leak plugging/neatening and channeld crash fix.

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1703,7 +1703,13 @@ static void resend_commitment(struct peer *peer, const struct changed_htlc *last
 	enqueue_peer_msg(peer, take(msg));
 	tal_free(commit_sigs);
 
-	assert(peer->revocations_received == peer->next_index[REMOTE] - 2);
+	/* If we have already received the revocation for the previous, the
+	 * other side shouldn't be asking for a retransmit! */
+	if (peer->revocations_received != peer->next_index[REMOTE] - 2)
+		status_unusual("Retransmitted commitment_signed %"PRIu64
+			       " but they already send revocation %"PRIu64"?",
+			       peer->next_index[REMOTE]-1,
+			       peer->revocations_received);
 }
 
 /* Our local wrapper around read_peer_msg */

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -650,16 +650,16 @@ static struct io_plan *peer_connected(struct io_conn *conn, struct peer *peer)
 				= peer->daemon->rstate->broadcasts->next_index;
 	}
 
-	/* This is a full peer now; we keep it around until master says
-	 * it's dead. */
-	peer_finalized(peer);
-
 	/* We will not have anything queued, since we're not duplex. */
 	msg = towire_gossip_peer_connected(peer, &peer->id, &peer->addr,
 					   &peer->local->pcs.cs,
 					   peer->gfeatures, peer->lfeatures);
 	if (!send_peer_with_fds(peer, msg))
 		return io_close(conn);
+
+	/* This is a full peer now; we keep it around until master says
+	 * it's dead. */
+	peer_finalized(peer);
 
 	/* Start the gossip flowing. */
 	wake_gossip_out(peer);

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -353,7 +353,7 @@ new_local_peer_state(struct peer *peer, const struct crypto_state *cs)
 	lps->pcs.cs = *cs;
 	lps->return_to_master = false;
 	lps->num_pings_outstanding = 0;
-	msg_queue_init(&lps->peer_out, peer);
+	msg_queue_init(&lps->peer_out, lps);
 
 	return lps;
 }

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1561,7 +1561,10 @@ static struct io_plan *peer_pkt_out(struct io_conn *conn, struct peer *peer)
 	/* First priority is queued packets, if any */
 	const u8 *out;
 
+	assert(peer->local);
 again:
+	/* Second assert may trigger if something happens due to loop */
+	assert(peer->local);
 	out = msg_dequeue(&peer->local->peer_out);
 	if (out) {
 		if (is_all_channel_error(out))

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1865,6 +1865,8 @@ static bool nonlocal_dump_gossip(struct io_conn *conn, struct daemon_conn *dc)
 
 static struct io_plan *new_peer_got_fd(struct io_conn *conn, struct peer *peer)
 {
+	struct daemon *daemon = peer->daemon;
+
 	peer->local->conn = io_new_conn(conn, peer->local->fd,
 					peer_start_gossip, peer);
 	if (!peer->local->conn) {
@@ -1875,7 +1877,7 @@ static struct io_plan *new_peer_got_fd(struct io_conn *conn, struct peer *peer)
 		/* If conn dies, we forget peer. */
 		tal_steal(peer->local->conn, peer);
 	}
-	return daemon_conn_read_next(conn, &peer->daemon->master);
+	return daemon_conn_read_next(conn, &daemon->master);
 }
 
 /* This lets us read the fds in before handling anything. */

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -506,6 +506,9 @@ static void queue_peer_msg(struct peer *peer, const u8 *msg TAKES)
 		if (taken(msg))
 			tal_free(msg);
 		daemon_conn_send(peer->remote, take(send));
+	} else { /* Waiting to die. */
+		if (taken(msg))
+			tal_free(msg);
 	}
 }
 

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -38,7 +38,7 @@ struct bitcoind {
 	struct lightningd *ld;
 
 	/* Are we currently running a bitcoind request (it's ratelimited) */
-	bool req_running;
+	struct bitcoin_cli *current;
 
 	/* Pending requests. */
 	struct list_head pending;


### PR DESCRIPTION
We've had some weird crashes on sleepyark, so I audited gossipd.  Found some lifetime issues, and user-after-free in corner cases, but no smoking gun.

I also fixed an overzealous assert in lightning_channeld.