### PR TITLE
gossip: Fix "already reaching" issue

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -3136,7 +3136,7 @@ static void try_reach_peer(struct daemon *daemon, const struct pubkey *id,
 			status_failed(STATUS_FAIL_MASTER_IO,
 				      "Already reaching %s",
 				      type_to_string(tmpctx, struct pubkey, id));
-		reach->master_needs_response = true;
+		reach->master_needs_response = master_needs_response;
 		return;
 	}
 


### PR DESCRIPTION
I think this is what is causing #1536: getting disconnected causes gossipd to
attempt to reach the peer again, unconditionally setting the flag to tell the
master. At the same time the master also issues a reaching command (which is
allowed since it is its first), but then it clashes on the already set
flag. Setting this flag only when the master actually needs to be told should
fix this.

Haven't touched this code in a while so @rustyrussell will have to pitch in about its correctness :wink: 

Fixes #1536 