### PR TITLE
pay: Use `locktime_max` as maximum cumulative CLTV delta

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -321,7 +321,7 @@ static void config_register_opts(struct lightningd *ld)
 			 &ld->config.locktime_blocks, opt_hidden);
 	opt_register_arg("--max-locktime-blocks", opt_set_u32, opt_show_u32,
 			 &ld->config.locktime_max,
-			 "Maximum blocks a peer can lock up our funds");
+			 "Maximum blocks funds may be locked for");
 	opt_register_arg("--funding-confirms", opt_set_u32, opt_show_u32,
 			 &ld->config.anchor_confirms,
 			 "Confirmations required for funding transaction");
@@ -486,7 +486,7 @@ static const struct config testnet_config = {
 
 	/* They can have up to 14 days, maximumu value that lnd will ask for by default. */
 	/* FIXME Convince lnd to use more reasonable defaults... */
-	.locktime_max = 14 * 6 * 24,
+	.locktime_max = 14 * 24 * 6,
 
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 1,
@@ -534,7 +534,7 @@ static const struct config mainnet_config = {
 
 	/* They can have up to 14 days, maximumu value that lnd will ask for by default. */
 	/* FIXME Convince lnd to use more reasonable defaults... */
-	.locktime_max = 14 * 6 * 24,
+	.locktime_max = 14 * 24 * 6,
 
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 3,

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -602,7 +602,7 @@ static void json_pay(struct command *cmd,
 	struct bolt11 *b11;
 	char *fail, *b11str, *desc;
 	unsigned int retryfor = 60;
-	unsigned int maxdelay = 500;
+	unsigned int maxdelay = cmd->ld->config.locktime_max;
 
 	if (!json_get_params(cmd, buffer, params,
 			     "bolt11", &bolt11tok,


### PR DESCRIPTION
Proposed by @rustyrussell.
Fixes #1586