### PR TITLE
Added wallet related error codes

### DIFF
--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -20,8 +20,9 @@ static bool check_amount(const struct wallet_tx *tx)
 		return false;
 	}
 	if (tx->amount < 546) {
-		command_fail(tx->cmd, FUND_DUST_LIMIT_UNMET,
-			     "Dust limit unmet");
+		command_fail(tx->cmd, FUND_OUTPUT_IS_DUST,
+			     "Output %"PRIu64" satoshis would be dust",
+			     tx->amount);
 		return false;
 	}
 	return true;

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 06/15/2018
+.\"      Date: 06/17/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "06/15/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/17/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -86,7 +86,7 @@ The following error codes may occur:
 .sp -1
 .IP \(bu 2.3
 .\}
-302\&. The dust limit is not met\&.
+302\&. The output amount is too small, and would be considered dust\&.
 .RE
 .sp
 Failure may also occur if \fBlightningd\fR and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc\&.)\&.

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/07/2018
+.\"      Date: 06/15/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "05/07/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/15/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ The \fBfundchannel\fR RPC command opens a payment channel with a peer by commiti
 .sp
 \fIid\fR is the peer id obtained from \fBconnect\fR\&.
 .sp
-\fIsatoshi\fR is the amount in satoshis taken from the internal wallet to fund the channel\&. The string \fIall\fR can be used to specify all available funds\&. This value must be greater than the dust limit, currently set to 546\&. And it must be less than 1<<24 (approximately 0\&.16778 BTC)\&.
+\fIsatoshi\fR is the amount in satoshis taken from the internal wallet to fund the channel\&. The string \fIall\fR can be used to specify all available funds\&. This value cannot be less than the dust limit, currently set to 546\&. And it must be less than 1<<24 (approximately 0\&.16778 BTC)\&.
 .SH "RETURN VALUE"
 .sp
 On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well as the \fIchannel_id\fR of the newly created channel\&. On failure, an error is reported and the channel is not funded\&.
@@ -53,22 +53,7 @@ The following error codes may occur:
 .sp -1
 .IP \(bu 2.3
 .\}
-\-1\&. Catchall nonspecific arror\&.
-.RE
-.sp
-The above error may include a descriptive message indicating:
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.sp -1
-.IP \(bu 2.3
-.\}
-The
-\fIid\fR
-is invalid\&.
+\-1\&. Catchall nonspecific error\&.
 .RE
 .sp
 .RS 4
@@ -79,7 +64,7 @@ is invalid\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-There are not enough funds in the internal wallet to create the transaction\&.
+300\&. The maximum allowed funding amount is exceeded\&.
 .RE
 .sp
 .RS 4
@@ -90,7 +75,7 @@ There are not enough funds in the internal wallet to create the transaction\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-The maximum allowed funding amount is exceeded\&.
+301\&. There are not enough funds in the internal wallet (including fees) to create the transaction\&.
 .RE
 .sp
 .RS 4
@@ -101,8 +86,7 @@ The maximum allowed funding amount is exceeded\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIsatoshi\fR
-is less than the dust limit\&.
+302\&. The dust limit is not met\&.
 .RE
 .sp
 Failure may also occur if \fBlightningd\fR and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc\&.)\&.

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -39,7 +39,7 @@ The following error codes may occur:
 * 300. The maximum allowed funding amount is exceeded.
 * 301. There are not enough funds in the internal wallet (including fees) to
        create the transaction.
-* 302. The dust limit is not met.
+* 302. The output amount is too small, and would be considered dust.
 
 Failure may also occur if *lightningd* and the peer cannot agree on channel
 parameters (funding limits, channel reserves, fees, etc.).

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -24,7 +24,7 @@ for the channel.
 
 'satoshi' is the amount in satoshis taken from the internal wallet to fund the channel.
 The string 'all' can be used to specify all available funds.
-This value must be greater than the dust limit, currently set to 546.
+This value cannot be less than the dust limit, currently set to 546.
 And it must be less than 1<<24 (approximately 0.16778 BTC).
 
 RETURN VALUE
@@ -35,14 +35,11 @@ On failure, an error is reported and the channel is not funded.
 
 The following error codes may occur:
 
-* -1. Catchall nonspecific arror.
-
-The above error may include a descriptive message indicating:
-
-* The 'id' is invalid.
-* There are not enough funds in the internal wallet to create the transaction.
-* The maximum allowed funding amount is exceeded.
-* 'satoshi' is less than the dust limit.
+* -1. Catchall nonspecific error.
+* 300. The maximum allowed funding amount is exceeded.
+* 301. There are not enough funds in the internal wallet (including fees) to
+       create the transaction.
+* 302. The dust limit is not met.
 
 Failure may also occur if *lightningd* and the peer cannot agree on channel
 parameters (funding limits, channel reserves, fees, etc.).

--- a/doc/lightning-withdraw.7
+++ b/doc/lightning-withdraw.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-withdraw
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 06/15/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-WITHDRAW" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-WITHDRAW" "7" "06/15/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -44,9 +44,43 @@ The address can be of any Bitcoin accepted type, including bech32\&.
 On success, an object with attributes \fItx\fR and \fItxid\fR will be returned\&.
 .sp
 \fItx\fR represents the raw bitcoin, fully signed, transaction and \fItxid\fR represent the bitcoin transaction id\&.
-.SH "ERRORS"
 .sp
-If an incorrect address is supplied or the \fIsatoshi\fR parameter exceeds the amount in the internal wallet an error message will be returned\&.
+On failure, an error is reported and the channel is not funded\&.
+.sp
+The following error codes may occur:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\-1\&. Catchall nonspecific error\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+301\&. There are not enough funds in the internal wallet (including fees) to create the transaction\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+302\&. The dust limit is not met\&.
+.RE
 .SH "AUTHOR"
 .sp
 Felix <fixone@gmail\&.com> is mainly responsible\&.

--- a/doc/lightning-withdraw.7.txt
+++ b/doc/lightning-withdraw.7.txt
@@ -33,11 +33,14 @@ be returned.
 'tx' represents the raw bitcoin, fully signed, transaction
 and 'txid' represent the bitcoin transaction id.
 
-ERRORS
-------
-If an incorrect address is supplied or the 'satoshi' 
-parameter exceeds the amount in the internal wallet 
-an error message will be returned. 
+On failure, an error is reported and the channel is not funded.
+
+The following error codes may occur:
+
+* -1. Catchall nonspecific error.
+* 301. There are not enough funds in the internal wallet (including fees) to
+       create the transaction.
+* 302. The dust limit is not met.
 
 AUTHOR
 ------

--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -32,7 +32,7 @@
 /* `fundchannel` or `withdraw` errors */
 #define FUND_MAX_EXCEEDED               300
 #define FUND_CANNOT_AFFORD              301
-#define FUND_DUST_LIMIT_UNMET           302
+#define FUND_OUTPUT_IS_DUST             302
 
 /* Errors from `invoice` command */
 #define INVOICE_LABEL_ALREADY_EXISTS	900

--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -29,6 +29,11 @@
 #define PAY_UNSPECIFIED_ERROR		209
 #define PAY_STOPPED_RETRYING		210
 
+/* `fundchannel` or `withdraw` errors */
+#define FUND_MAX_EXCEEDED               300
+#define FUND_CANNOT_AFFORD              301
+#define FUND_DUST_LIMIT_UNMET           302
+
 /* Errors from `invoice` command */
 #define INVOICE_LABEL_ALREADY_EXISTS	900
 #define INVOICE_PREIMAGE_ALREADY_EXISTS	901

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -919,7 +919,7 @@ static void json_fund_channel(struct command *cmd,
 		return;
 
 	if (fc->wtx.amount > MAX_FUNDING_SATOSHI) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		command_fail(cmd, FUND_MAX_EXCEEDED,
 			     "Funding satoshi must be <= %d",
 			     MAX_FUNDING_SATOSHI);
 		return;

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -3915,7 +3915,7 @@ class LightningDTests(BaseLightningDTests):
 
         # This should fail, can't even afford fee.
         self.assertRaises(ValueError, l1.rpc.withdraw, waddr, 'all')
-        l1.daemon.wait_for_log('Cannot afford fee')
+        l1.daemon.wait_for_log('Cannot afford funding transaction')
 
     def test_funding_change(self):
         """Add some funds, fund a channel, and make sure we remember the change


### PR DESCRIPTION
New codes: FUND_MAX_EXCEEDED, FUND_CANNOT_AFFORD, FUND_DUST_LIMIT_UNMET.

The error message "Cannot afford fee" was not exactly correct because
it would also occur if the amount requested could not be afforded.  So
I changed it to the more generic "Cannot afford transaction".

Other things:

* Fixed off-by-one satoshi in fundchannel manpage.
* Changed 'arror' to 'error' because we are not pirates.