### PR TITLE
pytest: make test_connect use an unknown id.

### DIFF
--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -669,17 +669,17 @@ class LightningDTests(BaseLightningDTests):
         # Should get reasonable error if unknown addr for peer.
         self.assertRaisesRegex(ValueError,
                                "No address known",
-                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304e')
+                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304d')
 
         # Should get reasonable error if connection refuse.
         self.assertRaisesRegex(ValueError,
                                "Connection establishment: Connection refused",
-                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304e', 'localhost', 1)
+                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304d', 'localhost', 1)
 
         # Should get reasonable error if wrong key for peer.
         self.assertRaisesRegex(ValueError,
                                "Cryptographic handshake: ",
-                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304e', 'localhost', l2.port)
+                               l1.rpc.connect, '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304d', 'localhost', l2.port)
 
     @unittest.skipIf(not DEVELOPER, "needs --dev-allow-localhost")
     def test_connect_by_gossip(self):


### PR DESCRIPTION
This test failed:

       AssertionError: "No address known" does not match "RPC call failed: {'code': -1, 'message': 'Connection establishment: Connection timed out'}, method: connect, payload: {'id': '032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304e'}"

Because someone seems to have actually used this ID on testnet!

	DEBUG:root:lightningd-1: 2018-06-19T07:14:39.413Z lightning_gossipd(3467): Resolved ln1qvk0zhg6m8z2prfxa2cerrmn9k803lwx4wukgzlnmvt5xukyjycyugwvuk8.lseed.bitcoinstats.com to 91.194.91.220:9735

Change the last digit, creating an unknowable ID so this can't happen again.

Reported-by: @sturles
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>