### PR TITLE
Add cli option to disable DNS node ID lookup

### DIFF
--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -89,6 +89,7 @@ char *fmt_wireaddr_without_port(const tal_t *ctx, const struct wireaddr *a);
  * we wanted to do a DNS lookup. */
 bool wireaddr_from_hostname(struct wireaddr *addr, const char *hostname,
 			    const u16 port, bool *no_dns,
+			    struct sockaddr *broken_reply,
 			    const char **err_msg);
 
 void wireaddr_from_ipv4(struct wireaddr *addr,

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/10/2018
+.\"      Date: 06/20/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "05/10/2018" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "06/20/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -203,14 +203,16 @@ How long to wait before sending commitment messages to the peer: in theory incre
 .sp
 Lightning channel and HTLC options:
 .PP
-\fBlocktime\-blocks\fR=\fIBLOCKS\fR
+\fBwatchtime\-blocks\fR=\fIBLOCKS\fR
 .RS 4
-How long we need to spot an outdated close attempt, which is also how long the peer would need to wait if they perform a unilateral close\&.
+How long we need to spot an outdated close attempt: on opening a channel we tell our peer that this is how long they\(cqll have to wait if they perform a unilateral close\&.
 .RE
 .PP
 \fBmax\-locktime\-blocks\fR=\fIBLOCKS\fR
 .RS 4
-The longest we\(cqll ever allow a peer to hold up payments, in the worst case\&. If they ask for longer, we\(cqll refuse to create a channel, and if an HTLC asks for longer, we\(cqll refuse it\&.
+The longest our funds can be delayed (ie\&. the longest
+\fBwatchtime\-blocks\fR
+our peer can ask for, and also the longest HTLC timeout we will accept)\&. If our peer asks for longer, we\(cqll refuse to create a channel, and if an HTLC asks for longer, we\(cqll refuse it\&.
 .RE
 .PP
 \fBfunding\-confirms\fR=\fIBLOCKS\fR
@@ -406,6 +408,11 @@ is set)\&.
 .RS 4
 Always use the
 \fBproxy\fR, even to connect to normal IP addresses (you can still connect to Unix domain sockets manually)\&. This also disables all DNS lookups, to avoid leaking information\&.
+.RE
+.PP
+\fBdisable\-dns\fR
+.RS 4
+Disable the DNS bootstrapping mechanism to find a node by its node ID\&.
 .RE
 .PP
 \fBtor\-service\-password\fR=\fIPASSWORD\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -100,7 +100,7 @@ Lightning daemon options:
 
 *pid-file*='PATH'::
     Specify pid file to write to.
-  
+
 *log-level*='LEVEL'::
     What log level to print out: options are io, debug, info, unusual, broken.
 
@@ -278,10 +278,13 @@ or precisely control where to bind and what to announce with the
     can still connect to Unix domain sockets manually).  This also disables
     all DNS lookups, to avoid leaking information.
 
+*disable-dns*::
+    Disable the DNS bootstrapping mechanism to find a node by its node ID.
+
 *tor-service-password*='PASSWORD'::
     Set a Tor control password, which may be needed for 'autotor:' to
     authenticate to the Tor control port.
-    
+
 BUGS
 ----
 You should report bugs on our github issues page, and maybe submit a

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -170,6 +170,8 @@ struct daemon {
 	bool use_proxy_always;
 	char *tor_password;
 
+	/* @see lightningd.config.use_dns */
+	bool use_dns;
 };
 
 /* Peers we're trying to reach. */
@@ -2836,7 +2838,7 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 		&daemon->proposed_listen_announce, daemon->rgb,
 		daemon->alias, &update_channel_interval, &daemon->reconnect,
 		&proxyaddr, &daemon->use_proxy_always,
-		&dev_allow_localhost,
+		&dev_allow_localhost, &daemon->use_dns,
 		&daemon->tor_password)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -3169,7 +3169,7 @@ static void try_reach_peer(struct daemon *daemon, const struct pubkey *id,
 			a = tal(tmpctx, struct wireaddr_internal);
 			wireaddr_from_unresolved(a, seedname(tmpctx, id),
 						 DEFAULT_PORT);
-		} else {
+		} else if (daemon->use_dns) {
 			a = seed_resolve_addr(tmpctx, id);
 		}
 	}

--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -172,6 +172,10 @@ struct daemon {
 
 	/* @see lightningd.config.use_dns */
 	bool use_dns;
+
+	/* The address that the broken response returns instead of
+	 * NXDOMAIN. NULL if we have not detected a broken resolver. */
+	struct sockaddr *broken_resolver_response;
 };
 
 /* Peers we're trying to reach. */
@@ -358,6 +362,37 @@ new_local_peer_state(struct peer *peer, const struct crypto_state *cs)
 	msg_queue_init(&lps->peer_out, lps);
 
 	return lps;
+}
+
+/**
+ * Some ISP resolvers will reply with a dummy IP to queries that would otherwise
+ * result in an NXDOMAIN reply. This just checks whether we have one such
+ * resolver upstream and remembers its reply so we can try to filter future
+ * dummies out.
+ */
+static bool broken_resolver(struct daemon *daemon)
+{
+	struct addrinfo *addrinfo;
+	struct addrinfo hints;
+	char *hostname = "nxdomain-test.doesntexist";
+	int err;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = 0;
+	hints.ai_flags = AI_ADDRCONFIG;
+	err = getaddrinfo(hostname, tal_fmt(tmpctx, "%d", 42),
+			      &hints, &addrinfo);
+
+	daemon->broken_resolver_response =
+	    tal_free(daemon->broken_resolver_response);
+
+	if (err == 0) {
+		daemon->broken_resolver_response = tal_dup(daemon, struct sockaddr, addrinfo->ai_addr);
+		freeaddrinfo(addrinfo);
+	}
+
+	return 	daemon->broken_resolver_response != NULL;
 }
 
 static struct peer *new_peer(const tal_t *ctx,
@@ -2855,6 +2890,11 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 	} else
 		daemon->proxyaddr = NULL;
 
+	if (broken_resolver(daemon)) {
+		status_trace("Broken DNS resolver detected, will check for "
+			     "dummy replies");
+	}
+
 	/* Load stored gossip messages */
 	gossip_store_load(daemon->rstate, daemon->rstate->store);
 
@@ -3061,7 +3101,8 @@ static const char *seedname(const tal_t *ctx, const struct pubkey *id)
 }
 
 static struct wireaddr_internal *
-seed_resolve_addr(const tal_t *ctx, const struct pubkey *id)
+seed_resolve_addr(const tal_t *ctx, const struct pubkey *id,
+		  struct sockaddr *broken_reply)
 {
 	struct wireaddr_internal *a;
 	const char *addr;
@@ -3072,7 +3113,7 @@ seed_resolve_addr(const tal_t *ctx, const struct pubkey *id)
 	a = tal(ctx, struct wireaddr_internal);
 	a->itype = ADDR_INTERNAL_WIREADDR;
 	if (!wireaddr_from_hostname(&a->u.wireaddr, addr, DEFAULT_PORT, NULL,
-				    NULL)) {
+				    broken_reply, NULL)) {
 		status_trace("Could not resolve %s", addr);
 		return tal_free(a);
 	} else {
@@ -3170,7 +3211,8 @@ static void try_reach_peer(struct daemon *daemon, const struct pubkey *id,
 			wireaddr_from_unresolved(a, seedname(tmpctx, id),
 						 DEFAULT_PORT);
 		} else if (daemon->use_dns) {
-			a = seed_resolve_addr(tmpctx, id);
+			a = seed_resolve_addr(tmpctx, id,
+					      daemon->broken_resolver_response);
 		}
 	}
 
@@ -3685,6 +3727,7 @@ int main(int argc, char *argv[])
 	timers_init(&daemon->timers, time_mono());
 	daemon->broadcast_interval = 30000;
 	daemon->last_announce_timestamp = 0;
+	daemon->broken_resolver_response = NULL;
 	/* stdin == control */
 	daemon_conn_init(daemon, &daemon->master, STDIN_FILENO, recv_req,
 			 master_gone);

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -23,6 +23,7 @@ gossipctl_init,,num_tor_proxyaddrs,u16
 gossipctl_init,,tor_proxyaddr,num_tor_proxyaddrs*struct wireaddr
 gossipctl_init,,use_tor_proxy_always,bool
 gossipctl_init,,dev_allow_localhost,bool
+gossipctl_init,,use_dns,bool
 gossipctl_init,,tor_password,wirestring
 
 # Activate the gossip daemon, so others can connect.

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -246,7 +246,7 @@ void gossip_init(struct lightningd *ld)
 	    listen_announce, ld->rgb,
 	    ld->alias, ld->config.channel_update_interval, ld->reconnect,
 	    ld->proxyaddr, ld->use_proxy_always || ld->pure_tor_setup,
-	    allow_localhost,
+	    allow_localhost, ld->config.use_dns,
 	    ld->tor_service_password ? ld->tor_service_password : "");
 	subd_send_msg(ld->gossip, msg);
 }

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -64,6 +64,9 @@ struct config {
 	/* Accept fee changes only if they are in the range our_fee -
 	 * our_fee*multiplier */
 	u32 max_fee_multiplier;
+
+	/* Are we allowed to use DNS lookup for peers. */
+	bool use_dns;
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -409,6 +409,9 @@ static void config_register_opts(struct lightningd *ld)
 			       opt_set_bool_arg, opt_show_bool,
 			       &ld->use_proxy_always, "Use the proxy always");
 
+	opt_register_noarg("--disable-dns", opt_set_invbool, &ld->config.use_dns,
+			   "Disable DNS lookups of peers");
+
 #if DEVELOPER
 	opt_register_arg("--dev-max-funding-unconfirmed-blocks",
 			 opt_set_u32, opt_show_u32,
@@ -529,6 +532,8 @@ static const struct config testnet_config = {
 
 	/* Fees may be in the range our_fee - 10*our_fee */
 	.max_fee_multiplier = 10,
+
+	.use_dns = true,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -590,6 +595,8 @@ static const struct config mainnet_config = {
 
 	/* Fees may be in the range our_fee - 10*our_fee */
 	.max_fee_multiplier = 10,
+
+	.use_dns = true,
 };
 
 static void check_config(struct lightningd *ld)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,6 +24,7 @@ LIGHTNINGD_CONFIG = {
     "cltv-final": 5,
     "watchtime-blocks": 5,
     "rescan": 1,
+    'disable-dns': None,
 }
 
 DEVELOPER = os.getenv("DEVELOPER", "0") == "1"


### PR DESCRIPTION
This is a more durable fix of #1600 I think. It adds the option to disable DNS lookups of node IDs, uses that option while testing, and also tries to identify a misbehaving DNS ISP resolver that hijacks NXDOMAIN replies, like @gwillen pointed out might happen. It's best effort, but even if it fails, it'll just perform a failing connect attempt.

What do you think @rustyrussell, shall we keep that last commit in there?