### PR TITLE
gossipd: fix compile error, uninitialized variable

### DIFF
--- a/gossipd/tor_autoservice.c
+++ b/gossipd/tor_autoservice.c
@@ -120,7 +120,7 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 {
 	char *line;
 	char *cookiefile = NULL;
-	int cookiefileerrno;
+	int cookiefileerrno = 0;
 
 	tor_send_cmd(rbuf, "PROTOCOLINFO 1");
 


### PR DESCRIPTION
Seems to be a problem with gcc 6.4+?

Fixes #1527

Signed-off-by: William Casarin <jb55@jb55.com>