### PR TITLE
Two small changes for the release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #! /usr/bin/make
 VERSION_NAME=I Accidentally The Smart Contract
-VERSION=$(shell git describe --always --dirty=-modded)
+VERSION=$(shell git describe --always --dirty=-modded --abbrev=7)
 DISTRO=$(shell lsb_release -is 2>/dev/null || echo unknown)-$(shell lsb_release -rs 2>/dev/null || echo unknown)
 PKGNAME = c-lightning
 

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -15,9 +15,11 @@ RUN dnf update -y && \
 		python3-devel \
 		python3-pip \
 		python3-setuptools \
+		redhat-lsb \
 		net-tools \
 		valgrind \
 		wget \
+		xz \
 		zlib-devel && \
 	dnf clean all
 


### PR DESCRIPTION
 - Sets the commit ID length to 7 on all platforms
 - Adds two more dependencies to the fedora build so it can build the tarball