### PR TITLE
Add configure and .gitmodules to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.sh text eol=lf
 *.py text eol=lf
 Makefile text eol=lf
+configure text eol=lf
+.gitmodules text eol=lf


### PR DESCRIPTION
Without this, building the `dockerfile` on windows will likely fail.