### PR TITLE
[Docker] Fix: Bind socat to the right port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN apk add --update curl && \
   rm -rf glibc.apk glibc-bin.apk /var/cache/apk/*
 
 ENV LIGHTNINGD_DATA=/root/.lightning
-ENV LIGHTNINGD_PORT=9735
+ENV LIGHTNINGD_RPC_PORT=9835
 
 VOLUME [ "/root/.lightning" ]
 
@@ -99,5 +99,5 @@ COPY --from=builder /opt/bitcoin/bin /usr/bin
 COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh
 
-EXPOSE 9735
+EXPOSE 9735 9835
 ENTRYPOINT  [ "./entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you build the image yourself, you can use the build arg `DEVELOPER=1` to buil
 
 It has the following environment variable:
 
-* `EXPOSE_TCP` default to false, if true, use expose c-lightning on port 9735. (Use this only for testing)
+* `EXPOSE_TCP` default to false, if true, use expose c-lightning RPC on port 9835. (Use this only for testing)
 
 Here is an example of a docker-compose file with bitcoind and c-lightning on `testnet` which expose litecoin's rpc interface on default ports `18332` and c-lightning API on port `9735`:
 

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -10,8 +10,9 @@ if [ "$EXPOSE_TCP" == "true" ]; then
     while read -r i; do if [ "$i" = "lightning-rpc" ]; then break; fi; done \
     < <(inotifywait  -e create,open --format '%f' --quiet "$LIGHTNINGD_DATA" --monitor)
     echo "C-Lightning started"
+    echo "C-Lightning started, RPC available on port $LIGHTNINGD_RPC_PORT"
 
-    socat "TCP4-listen:$LIGHTNINGD_PORT,fork,reuseaddr" "UNIX-CONNECT:$LIGHTNINGD_DATA/lightning-rpc" &
+    socat "TCP4-listen:$LIGHTNINGD_RPC_PORT,fork,reuseaddr" "UNIX-CONNECT:$LIGHTNINGD_DATA/lightning-rpc" &
     fg %-
 else
     lightningd "$@"


### PR DESCRIPTION
A bug in the dockerfile has been introduced because of unclear `LIGHTNINGD_PORT` environment variable.

`socat` was trying to bind on the same port as lightning, while it should have been on a different one exposing the API by TCP. 

As such I renamed `LIGHTNINGD_PORT` to `LIGHTNINGD_RPC_PORT`, and made sure it is properly used.

