### PR TITLE
lightningd: don't send uninialized malformed fields to channeld.

### DIFF
--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -801,6 +801,110 @@ static u8 *gossipd_wait_sync_reply(const tal_t *ctx,
 			       GOSSIP_FD, &peer->from_gossipd, "gossipd");
 }
 
+static u8 *foreign_channel_update(const tal_t *ctx,
+				  struct peer *peer,
+				  const struct short_channel_id *scid)
+{
+	u8 *msg, *update;
+
+	msg = towire_gossip_get_update(NULL, scid);
+	msg = gossipd_wait_sync_reply(tmpctx, peer, take(msg),
+				      WIRE_GOSSIP_GET_UPDATE_REPLY);
+	if (!fromwire_gossip_get_update_reply(ctx, msg, &update))
+		status_failed(STATUS_FAIL_GOSSIP_IO,
+			      "Invalid update reply");
+	return update;
+}
+
+static u8 *make_failmsg(const tal_t *ctx,
+			struct peer *peer,
+			const struct htlc *htlc,
+			enum onion_type failcode,
+			const struct short_channel_id *scid)
+{
+	u8 *msg, *channel_update = NULL;
+	u32 cltv_expiry = abs_locktime_to_blocks(&htlc->expiry);
+
+	switch (failcode) {
+	case WIRE_INVALID_REALM:
+		msg = towire_invalid_realm(ctx);
+		goto done;
+	case WIRE_TEMPORARY_NODE_FAILURE:
+		msg = towire_temporary_node_failure(ctx);
+		goto done;
+	case WIRE_PERMANENT_NODE_FAILURE:
+		msg = towire_permanent_node_failure(ctx);
+		goto done;
+	case WIRE_REQUIRED_NODE_FEATURE_MISSING:
+		msg = towire_required_node_feature_missing(ctx);
+		goto done;
+	case WIRE_TEMPORARY_CHANNEL_FAILURE:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_temporary_channel_failure(ctx, channel_update);
+		goto done;
+	case WIRE_CHANNEL_DISABLED:
+		msg = towire_channel_disabled(ctx);
+		goto done;
+	case WIRE_PERMANENT_CHANNEL_FAILURE:
+		msg = towire_permanent_channel_failure(ctx);
+		goto done;
+	case WIRE_REQUIRED_CHANNEL_FEATURE_MISSING:
+		msg = towire_required_channel_feature_missing(ctx);
+		goto done;
+	case WIRE_UNKNOWN_NEXT_PEER:
+		msg = towire_unknown_next_peer(ctx);
+		goto done;
+	case WIRE_AMOUNT_BELOW_MINIMUM:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_amount_below_minimum(ctx, htlc->msatoshi,
+						  channel_update);
+		goto done;
+	case WIRE_FEE_INSUFFICIENT:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_fee_insufficient(ctx, htlc->msatoshi,
+					      channel_update);
+		goto done;
+	case WIRE_INCORRECT_CLTV_EXPIRY:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_incorrect_cltv_expiry(ctx, cltv_expiry,
+						   channel_update);
+		goto done;
+	case WIRE_EXPIRY_TOO_SOON:
+		channel_update = foreign_channel_update(ctx, peer, scid);
+		msg = towire_expiry_too_soon(ctx, channel_update);
+		goto done;
+	case WIRE_EXPIRY_TOO_FAR:
+		msg = towire_expiry_too_far(ctx);
+		goto done;
+	case WIRE_UNKNOWN_PAYMENT_HASH:
+		msg = towire_unknown_payment_hash(ctx);
+		goto done;
+	case WIRE_INCORRECT_PAYMENT_AMOUNT:
+		msg = towire_incorrect_payment_amount(ctx);
+		goto done;
+	case WIRE_FINAL_EXPIRY_TOO_SOON:
+		msg = towire_final_expiry_too_soon(ctx);
+		goto done;
+	case WIRE_FINAL_INCORRECT_CLTV_EXPIRY:
+		msg = towire_final_incorrect_cltv_expiry(ctx, cltv_expiry);
+		goto done;
+	case WIRE_FINAL_INCORRECT_HTLC_AMOUNT:
+		msg = towire_final_incorrect_htlc_amount(ctx, htlc->msatoshi);
+		goto done;
+	case WIRE_INVALID_ONION_VERSION:
+	case WIRE_INVALID_ONION_HMAC:
+	case WIRE_INVALID_ONION_KEY:
+		break;
+	}
+	status_failed(STATUS_FAIL_INTERNAL_ERROR,
+		      "Asked to create failmsg %u (%s)",
+		      failcode, onion_type_name(failcode));
+
+done:
+	tal_free(channel_update);
+	return msg;
+}
+
 static struct commit_sigs *calc_commitsigs(const tal_t *ctx,
 					   const struct peer *peer,
 					   u64 commit_index)
@@ -2132,110 +2236,6 @@ static void handle_preimage(struct peer *peer, const u8 *inmsg)
 			      "HTLC %"PRIu64" preimage failed", id);
 	}
 	abort();
-}
-
-static u8 *foreign_channel_update(const tal_t *ctx,
-				  struct peer *peer,
-				  const struct short_channel_id *scid)
-{
-	u8 *msg, *update;
-
-	msg = towire_gossip_get_update(NULL, scid);
-	msg = gossipd_wait_sync_reply(tmpctx, peer, take(msg),
-				      WIRE_GOSSIP_GET_UPDATE_REPLY);
-	if (!fromwire_gossip_get_update_reply(ctx, msg, &update))
-		status_failed(STATUS_FAIL_GOSSIP_IO,
-			      "Invalid update reply");
-	return update;
-}
-
-static u8 *make_failmsg(const tal_t *ctx,
-			struct peer *peer,
-			const struct htlc *htlc,
-			enum onion_type failcode,
-			const struct short_channel_id *scid)
-{
-	u8 *msg, *channel_update = NULL;
-	u32 cltv_expiry = abs_locktime_to_blocks(&htlc->expiry);
-
-	switch (failcode) {
-	case WIRE_INVALID_REALM:
-		msg = towire_invalid_realm(ctx);
-		goto done;
-	case WIRE_TEMPORARY_NODE_FAILURE:
-		msg = towire_temporary_node_failure(ctx);
-		goto done;
-	case WIRE_PERMANENT_NODE_FAILURE:
-		msg = towire_permanent_node_failure(ctx);
-		goto done;
-	case WIRE_REQUIRED_NODE_FEATURE_MISSING:
-		msg = towire_required_node_feature_missing(ctx);
-		goto done;
-	case WIRE_TEMPORARY_CHANNEL_FAILURE:
-		channel_update = foreign_channel_update(ctx, peer, scid);
-		msg = towire_temporary_channel_failure(ctx, channel_update);
-		goto done;
-	case WIRE_CHANNEL_DISABLED:
-		msg = towire_channel_disabled(ctx);
-		goto done;
-	case WIRE_PERMANENT_CHANNEL_FAILURE:
-		msg = towire_permanent_channel_failure(ctx);
-		goto done;
-	case WIRE_REQUIRED_CHANNEL_FEATURE_MISSING:
-		msg = towire_required_channel_feature_missing(ctx);
-		goto done;
-	case WIRE_UNKNOWN_NEXT_PEER:
-		msg = towire_unknown_next_peer(ctx);
-		goto done;
-	case WIRE_AMOUNT_BELOW_MINIMUM:
-		channel_update = foreign_channel_update(ctx, peer, scid);
-		msg = towire_amount_below_minimum(ctx, htlc->msatoshi,
-						  channel_update);
-		goto done;
-	case WIRE_FEE_INSUFFICIENT:
-		channel_update = foreign_channel_update(ctx, peer, scid);
-		msg = towire_fee_insufficient(ctx, htlc->msatoshi,
-					      channel_update);
-		goto done;
-	case WIRE_INCORRECT_CLTV_EXPIRY:
-		channel_update = foreign_channel_update(ctx, peer, scid);
-		msg = towire_incorrect_cltv_expiry(ctx, cltv_expiry,
-						   channel_update);
-		goto done;
-	case WIRE_EXPIRY_TOO_SOON:
-		channel_update = foreign_channel_update(ctx, peer, scid);
-		msg = towire_expiry_too_soon(ctx, channel_update);
-		goto done;
-	case WIRE_EXPIRY_TOO_FAR:
-		msg = towire_expiry_too_far(ctx);
-		goto done;
-	case WIRE_UNKNOWN_PAYMENT_HASH:
-		msg = towire_unknown_payment_hash(ctx);
-		goto done;
-	case WIRE_INCORRECT_PAYMENT_AMOUNT:
-		msg = towire_incorrect_payment_amount(ctx);
-		goto done;
-	case WIRE_FINAL_EXPIRY_TOO_SOON:
-		msg = towire_final_expiry_too_soon(ctx);
-		goto done;
-	case WIRE_FINAL_INCORRECT_CLTV_EXPIRY:
-		msg = towire_final_incorrect_cltv_expiry(ctx, cltv_expiry);
-		goto done;
-	case WIRE_FINAL_INCORRECT_HTLC_AMOUNT:
-		msg = towire_final_incorrect_htlc_amount(ctx, htlc->msatoshi);
-		goto done;
-	case WIRE_INVALID_ONION_VERSION:
-	case WIRE_INVALID_ONION_HMAC:
-	case WIRE_INVALID_ONION_KEY:
-		break;
-	}
-	status_failed(STATUS_FAIL_INTERNAL_ERROR,
-		      "Asked to create failmsg %u (%s)",
-		      failcode, onion_type_name(failcode));
-
-done:
-	tal_free(channel_update);
-	return msg;
 }
 
 static void handle_fail(struct peer *peer, const u8 *inmsg)

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1473,7 +1473,7 @@ static void handle_peer_fulfill_htlc(struct peer *peer, const u8 *msg)
 			    "Bad update_fulfill_htlc %s", tal_hex(msg, msg));
 	}
 
-	e = channel_fulfill_htlc(peer->channel, LOCAL, id, &preimage);
+	e = channel_fulfill_htlc(peer->channel, LOCAL, id, &preimage, NULL);
 	switch (e) {
 	case CHANNEL_ERR_REMOVE_OK:
 		/* FIXME: We could send preimages to master immediately. */
@@ -1510,11 +1510,10 @@ static void handle_peer_fail_htlc(struct peer *peer, const u8 *msg)
 			    "Bad update_fulfill_htlc %s", tal_hex(msg, msg));
 	}
 
-	e = channel_fail_htlc(peer->channel, LOCAL, id, NULL);
+	e = channel_fail_htlc(peer->channel, LOCAL, id, &htlc);
 	switch (e) {
 	case CHANNEL_ERR_REMOVE_OK:
 		/* Save reason for when we tell master. */
-		htlc = channel_get_htlc(peer->channel, LOCAL, id);
 		htlc->fail = tal_steal(htlc, reason);
 		start_commit_timer(peer);
 		return;
@@ -2217,7 +2216,7 @@ static void handle_preimage(struct peer *peer, const u8 *inmsg)
 	if (!fromwire_channel_fulfill_htlc(inmsg, &id, &preimage))
 		master_badmsg(WIRE_CHANNEL_FULFILL_HTLC, inmsg);
 
-	switch (channel_fulfill_htlc(peer->channel, REMOTE, id, &preimage)) {
+	switch (channel_fulfill_htlc(peer->channel, REMOTE, id, &preimage, NULL)) {
 	case CHANNEL_ERR_REMOVE_OK:
 		msg = towire_update_fulfill_htlc(NULL, &peer->channel_id,
 						 id, &preimage);

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -1215,7 +1215,7 @@ static u8 *got_commitsig_msg(const tal_t *ctx,
 				f = tal_arr_append(&failed);
 				*f = tal(failed, struct failed_htlc);
 				(*f)->id = htlc->id;
-				(*f)->malformed = htlc->failcode;
+				(*f)->failcode = htlc->failcode;
 				(*f)->failreason = cast_const(u8 *, htlc->fail);
 			}
 		} else {

--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -27,8 +27,12 @@ struct htlc {
 	/* FIXME: We could union these together: */
 	/* Routing information sent with this HTLC. */
 	const u8 *routing;
+
+	/* Failure message we received or generated. */
 	const u8 *fail;
-	enum onion_type malformed;
+	/* For a local failure, we might have to generate fail ourselves
+	 * (or, if BADONION we send a update_fail_malformed_htlc). */
+	enum onion_type failcode;
 };
 
 static inline bool htlc_has(const struct htlc *h, int flag)

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -108,7 +108,8 @@ static void dump_htlc(const struct htlc *htlc, const char *prefix)
 		     htlc_state_name(htlc->state),
 		     htlc_state_name(remote_state),
 		     htlc->r ? "FULFILLED" : htlc->fail ? "FAILED" :
-		     htlc->malformed ? "MALFORMED" : "");
+		     htlc->failcode
+		     ? tal_fmt(tmpctx, "FAILCODE:%u", htlc->failcode) : "");
 }
 
 void dump_htlcs(const struct channel *channel, const char *prefix)
@@ -325,7 +326,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 
 	htlc->rhash = *payment_hash;
 	htlc->fail = NULL;
-	htlc->malformed = 0;
+	htlc->failcode = 0;
 	htlc->r = NULL;
 	htlc->routing = tal_dup_arr(htlc, u8, routing, TOTAL_PACKET_SIZE, 0);
 
@@ -904,7 +905,7 @@ static bool adjust_balance(struct channel *channel, struct htlc *htlc)
 		if (htlc_has(htlc, HTLC_FLAG(side, HTLC_F_COMMITTED)))
 			continue;
 
-		if (!htlc->fail && !htlc->malformed && !htlc->r) {
+		if (!htlc->fail && !htlc->failcode && !htlc->r) {
 			status_trace("%s HTLC %"PRIu64
 				     " %s neither fail nor fulfill?",
 				     htlc_state_owner(htlc->state) == LOCAL
@@ -1029,10 +1030,10 @@ bool channel_force_htlcs(struct channel *channel,
 				     failed[i]->id);
 			return false;
 		}
-		if (htlc->malformed) {
-			status_trace("Fail %s HTLC %"PRIu64" already malformed",
+		if (htlc->failcode) {
+			status_trace("Fail %s HTLC %"PRIu64" already fail %u",
 				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id);
+				     failed[i]->id, htlc->failcode);
 			return false;
 		}
 		if (!htlc_has(htlc, HTLC_REMOVING)) {
@@ -1043,7 +1044,7 @@ bool channel_force_htlcs(struct channel *channel,
 			return false;
 		}
 		if (failed[i]->malformed)
-			htlc->malformed = failed[i]->malformed;
+			htlc->failcode = failed[i]->malformed;
 		else
 			htlc->fail = tal_dup_arr(htlc, u8,
 						 failed[i]->failreason,

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -1049,13 +1049,14 @@ bool channel_force_htlcs(struct channel *channel,
 				     htlc_state_name(htlc->state));
 			return false;
 		}
-		if (failed[i]->malformed)
-			htlc->failcode = failed[i]->malformed;
-		else
+		htlc->failcode = failed[i]->failcode;
+		if (failed[i]->failreason)
 			htlc->fail = tal_dup_arr(htlc, u8,
 						 failed[i]->failreason,
 						 tal_len(failed[i]->failreason),
 						 0);
+		else
+			htlc->fail = NULL;
 	}
 
 	for (i = 0; i < tal_count(htlcs); i++) {

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -494,9 +494,10 @@ struct htlc *channel_get_htlc(struct channel *channel, enum side sender, u64 id)
 }
 
 enum channel_remove_err channel_fulfill_htlc(struct channel *channel,
-					      enum side owner,
-					      u64 id,
-					      const struct preimage *preimage)
+					     enum side owner,
+					     u64 id,
+					     const struct preimage *preimage,
+					     struct htlc **htlcp)
 {
 	struct sha256 hash;
 	struct htlc *htlc;
@@ -556,6 +557,9 @@ enum channel_remove_err channel_fulfill_htlc(struct channel *channel,
 	channel->changes_pending[owner] = true;
 
 	dump_htlc(htlc, "FULFILL:");
+
+	if (htlcp)
+		*htlcp = htlc;
 
 	return CHANNEL_ERR_REMOVE_OK;
 }

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -997,6 +997,12 @@ bool channel_force_htlcs(struct channel *channel,
 				     fulfilled[i].id);
 			return false;
 		}
+		if (htlc->failcode) {
+			status_trace("Fulfill %s HTLC %"PRIu64" already fail %u",
+				     fulfilled_sides[i] == LOCAL ? "out" : "in",
+				     fulfilled[i].id, htlc->failcode);
+			return false;
+		}
 		if (!htlc_has(htlc, HTLC_REMOVING)) {
 			status_trace("Fulfill %s HTLC %"PRIu64" state %s",
 				     fulfilled_sides[i] == LOCAL ? "out" : "in",

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -129,6 +129,7 @@ enum channel_remove_err channel_fail_htlc(struct channel *channel,
  * @channel: The channel state
  * @owner: the side who offered the HTLC (opposite to that fulfilling it)
  * @id: unique HTLC id.
+ * @htlcp: optional pointer for resulting htlc: filled in if and only if CHANNEL_ERR_FULFILL_OK.
  *
  * If the htlc exists, is not already fulfilled, the preimage is correct and
  * HTLC committed at the recipient, this will add a pending change to
@@ -138,7 +139,8 @@ enum channel_remove_err channel_fail_htlc(struct channel *channel,
 enum channel_remove_err channel_fulfill_htlc(struct channel *channel,
 					     enum side owner,
 					     u64 id,
-					     const struct preimage *preimage);
+					     const struct preimage *preimage,
+					     struct htlc **htlcp);
 
 /**
  * approx_max_feerate: what's the max funder could raise fee rate to?

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -250,7 +250,7 @@ static void send_and_fulfill_htlc(struct channel *channel,
 		assert(ret);
 		ret = channel_sending_revoke_and_ack(channel);
 		assert(!ret);
-		assert(channel_fulfill_htlc(channel, LOCAL, 1337, &r)
+		assert(channel_fulfill_htlc(channel, LOCAL, 1337, &r, NULL)
 		       == CHANNEL_ERR_REMOVE_OK);
 		ret = channel_rcvd_commit(channel, &changed_htlcs);
 		assert(ret);
@@ -271,7 +271,7 @@ static void send_and_fulfill_htlc(struct channel *channel,
 		assert(ret);
 		ret = channel_rcvd_revoke_and_ack(channel, &changed_htlcs);
 		assert(!ret);
-		assert(channel_fulfill_htlc(channel, REMOTE, 1337, &r)
+		assert(channel_fulfill_htlc(channel, REMOTE, 1337, &r, NULL)
 		       == CHANNEL_ERR_REMOVE_OK);
 		ret = channel_sending_commit(channel, &changed_htlcs);
 		assert(ret);

--- a/common/htlc_wire.h
+++ b/common/htlc_wire.h
@@ -26,7 +26,8 @@ struct fulfilled_htlc {
 
 struct failed_htlc {
 	u64 id;
-	enum onion_type malformed;
+	/* Either this is 0 and failreason non-NULL, or vice versa. */
+	enum onion_type failcode;
 	u8 *failreason;
 };
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -771,8 +771,8 @@ static bool peer_failed_our_htlc(struct channel *channel,
 	if (!htlc_out_update_state(channel, hout, RCVD_REMOVE_COMMIT))
 		return false;
 
-	hout->failcode = failed->malformed;
-	if (!failed->malformed)
+	hout->failcode = failed->failcode;
+	if (!failed->failcode)
 		hout->failuremsg = tal_dup_arr(hout, u8, failed->failreason,
 					       tal_len(failed->failreason), 0);
 
@@ -1384,7 +1384,7 @@ static void add_fulfill(u64 id, enum side side,
 }
 
 static void add_fail(u64 id, enum side side,
-		     enum onion_type malformed,
+		     enum onion_type failcode,
 		     const u8 *failuremsg,
 		     const struct failed_htlc ***failed_htlcs,
 		     enum side **failed_sides)
@@ -1397,7 +1397,7 @@ static void add_fail(u64 id, enum side side,
 
 	*f = tal(*failed_htlcs, struct failed_htlc);
 	(*f)->id = id;
-	(*f)->malformed = malformed;
+	(*f)->failcode = failcode;
 	if (failuremsg)
 		(*f)->failreason
 			= tal_dup_arr(*f, u8, failuremsg, tal_len(failuremsg), 0);


### PR DESCRIPTION
==1224== Uninitialised byte(s) found during client check request
==1224==    at 0x152CAD: memcheck_ (mem.h:247)
==1224==    by 0x152D18: towire (towire.c:17)
==1224==    by 0x152DA1: towire_u16 (towire.c:28)
==1224==    by 0x142189: towire_failed_htlc (htlc_wire.c:29)
==1224==    by 0x16343F: towire_channel_init (gen_channel_wire.c:596)
==1224==    by 0x115C2C: peer_start_channeld (channel_control.c:249)
==1224==    by 0x131701: peer_connected (peer_control.c:503)
==1224==    by 0x117820: gossip_msg (gossip_control.c:182)
==1224==    by 0x139D97: sd_msg_read (subd.c:500)
==1224==    by 0x139676: read_fds (subd.c:327)
==1224==    by 0x179D52: next_plan (io.c:59)
==1224==    by 0x17A84F: do_plan (io.c:387)
==1224==  Address 0x1ffefffabe is on thread 1's stack
==1224==  in frame #2, created by towire_u16 (towire.c:26)

Followed by:

2018-06-18T21:53:04.129Z lightningd(1224): 03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134 chan #1: Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel d0101486543e1a8b6871556a4fe1fba4ad4d83ce7f6f92919fd17bd1545d2fd5: UpdateFailMalformedHtlc message doesn't have BADONION bit set

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>