### PR TITLE
add alias and color to getinfo

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -150,6 +150,8 @@ static void json_getinfo(struct command *cmd,
 
 	json_object_start(response, NULL);
 	json_add_pubkey(response, "id", &cmd->ld->id);
+	json_add_string(response, "alias", (const char *)cmd->ld->alias);
+	json_add_hex(response, "color", (const void *)cmd->ld->rgb, tal_len(cmd->ld->rgb));
 	if (cmd->ld->listen) {
 		if (deprecated_apis)
 			json_add_num(response, "port", cmd->ld->portnum);


### PR DESCRIPTION
Fixes #1627 

```sh
$./lightning-cli getinfo     
{
  "id": "03cd0d4e43e3c36507cb42479a0c3c7cc843f26146a4c81c274c796017a2205919", 
  "alias": "LOUDSCAN-v0.6-2-g50efe34-modded", 
  "color": "03cd0d", 
  "port": 9735, 
  "address": [
  ], 
  "binding": [
    {
      "type": "ipv6", 
      "address": "::", 
      "port": 9735
    }
  ], 
  "version": "v0.6-2-g50efe34-modded", 
  "blockheight": 494785, 
  "network": "testnet"
}

```