### PR TITLE
travis: Add asciidoc, excluding latex, to the builder images

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -8,6 +8,7 @@ WORKDIR /build
 
 RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+	asciidoc \
 	autoconf \
 	automake \
 	clang \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -8,6 +8,7 @@ WORKDIR /build
 
 RUN apt-get -qq update && \
     apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+	asciidoc \
 	autoconf \
 	automake \
 	clang \


### PR DESCRIPTION
Fixes #1641