### PR TITLE
tools/check-includes.sh: shellcheck recommended fixes

### DIFF
--- a/tools/check-includes.sh
+++ b/tools/check-includes.sh
@@ -11,7 +11,7 @@ for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_W
 do
     HEADER_ID_BASE=$(tr / _ <<< "${HEADER_FILE/%.h/}" | tr "[:lower:]" "[:upper:]")
     HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
-    if [[ $(grep -cE "^#((ifndef|define) ${HEADER_ID}|endif /\* ${HEADER_ID} \*/)$" "${HEADER_FILE}") != 3 ]]; then
+    if [[ $(grep -cE "^#((ifndef|define) ${HEADER_ID}|endif /\\* ${HEADER_ID} \\*/)$" "${HEADER_FILE}") != 3 ]]; then
         echo "${HEADER_FILE} seems to be missing the expected include guard:"
         echo "  #ifndef ${HEADER_ID}"
         echo "  #define ${HEADER_ID}"
@@ -25,7 +25,7 @@ done
 # Check redundant includes
 
 filter_suffix() {
-    git ls-files | grep -v 'ccan/' | grep -E "\.${1}"'$'
+    git ls-files | grep -v 'ccan/' | grep -E "\\.${1}"'$'
 }
 
 for HEADER_FILE in $(filter_suffix h); do


### PR DESCRIPTION
```
$ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.5.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

In tools/check-includes.sh line 14:
    if [[ $(grep -cE "^#((ifndef|define) ${HEADER_ID}|endif /\* ${HEADER_ID} \*/)$" "${HEADER_FILE}") != 3 ]]; then
                                                             ^-- SC1117: Backslash is literal in "\*". Prefer explicit escaping: "\\*".

In tools/check-includes.sh line 28:
    git ls-files | grep -v 'ccan/' | grep -E "\.${1}"'$'
                                              ^-- SC1117: Backslash is literal in "\.". Prefer explicit escaping: "\\.".
```