### PR TITLE
cli: launch a manpage when help is passed an argument

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -104,7 +104,7 @@ static void human_help(const char *buffer, const jsmntok_t *result) {
 		curr++;
 	}
 
-	printf("---\nrun `man lightning-{command}` for more information on each command\n");
+	printf("---\nrun `lightning-cli help <command>` for more information on a specific command\n");
 }
 
 enum format {
@@ -168,6 +168,12 @@ static void add_input(char **cmd, const char *input,
 		tal_append_fmt(cmd, ", ");
 }
 
+static void
+exec_man (const char *page) {
+	execlp("man", "man", page, (char *)NULL);
+	err(1, "Running man command");
+}
+
 int main(int argc, char *argv[])
 {
 	setup_locale();
@@ -221,6 +227,14 @@ int main(int argc, char *argv[])
 			format = HUMAN;
 		else
 			format = JSON;
+	}
+
+	/* Launch a manpage if we have a help command with an argument. We do
+	 * not need to have lightningd running in this case. */
+	if (streq(method, "help") && format == HUMAN && argc >= 3) {
+		char command[strlen(argv[2]) + sizeof("lightning-")];
+		sprintf(command, "lightning-%s", argv[2]);
+		exec_man(command);
 	}
 
 	if (chdir(lightning_dir) != 0)


### PR DESCRIPTION
Lift it to the start of main, so that it can short-circuit the lightningd
connection. It does not need to be running for this to work.

example:

  lightning-cli help pay
  lightning-cli help cli

Signed-off-by: William Casarin <jb55@jb55.com>