### PR TITLE
jsonrpc: Remove `dev-blockheight` in favor of `getinfo`

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -105,12 +105,6 @@ class LightningRpc(UnixDomainSocketRpc):
         res = self.call("listpeers", payload)
         return res.get("peers") and res["peers"][0] or None
 
-    def dev_blockheight(self):
-        """
-        Show current block height
-        """
-        return self.call("dev-blockheight")
-
     def dev_setfees(self, immediate=None, normal=None, slow=None):
         """
         Set feerate in satoshi-per-kw for {immediate}, {normal} and {slow}

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -570,26 +570,6 @@ u32 get_feerate(const struct chain_topology *topo, enum feerate feerate)
 }
 
 #if DEVELOPER
-static void json_dev_blockheight(struct command *cmd,
-				 const char *buffer UNUSED, const jsmntok_t *params UNUSED)
-{
-	struct chain_topology *topo = cmd->ld->topology;
-	struct json_result *response;
-
-	response = new_json_result(cmd);
-	json_object_start(response, NULL);
-	json_add_num(response, "blockheight", get_block_height(topo));
-	json_object_end(response);
-	command_success(cmd, response);
-}
-
-static const struct json_command dev_blockheight = {
-	"dev-blockheight",
-	json_dev_blockheight,
-	"Show current block height"
-};
-AUTODATA(json_command, &dev_blockheight);
-
 static void json_dev_setfees(struct command *cmd,
 			     const char *buffer, const jsmntok_t *params)
 {


### PR DESCRIPTION
`getinfo` has been providing the blockheight for a good while and doesn't
require the `DEVELOPER=1` flag during compilation, so it should be the preferred
method to retrieve the blockchain height.

I also think we don't need to go through the deprecation since this was a dev-only RPC call.