### PR TITLE
travis: Add xmllint to the builder image

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -32,6 +32,7 @@ RUN apt-get -qq update && \
 	python3-setuptools \
 	python-pkg-resources \
 	shellcheck \
+	libxml2-utils \
 	wget \
 	zlib1g-dev && \
 	rm -rf /var/lib/apt/lists/*

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -32,6 +32,7 @@ RUN apt-get -qq update && \
 	python3-setuptools \
 	python-pkg-resources \
 	shellcheck \
+	libxml2-utils \
 	wget \
 	zlib1g-dev && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Seems that it is required for the manpage conversion.