### PR TITLE
README.md: 18332 is default bitcoind rpc port for testnet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ It has the following environment variable:
 
 * `EXPOSE_TCP` default to false, if true, use expose c-lightning RPC on port 9835. (Use this only for testing)
 
-Here is an example of a docker-compose file with bitcoind and c-lightning on `testnet` which expose litecoin's rpc interface on default ports `18332` and c-lightning API on port `9735`:
+Here is an example of a docker-compose file with bitcoind and c-lightning on `testnet` which expose bitcoind's rpc interface on default ports `18332` and c-lightning API on port `9735`:
 
 ```
 version: "3"


### PR DESCRIPTION
The README currently says the docker-compose file will "expose litecoin's rpc interface on default ports 18332". This is confusing because I don't see litecoin being used anywhere.

It looks like 18332 is the default RPC port for bitcoind on testnet.