### PR TITLE
gossip: Fix concurrent PR merge issue with structeq

### DIFF
--- a/gossipd/gossip.c
+++ b/gossipd/gossip.c
@@ -1699,7 +1699,7 @@ static struct local_update *find_local_update(struct daemon *daemon,
 	struct local_update *i;
 
 	list_for_each(&daemon->local_updates, i, list) {
-		if (structeq(scid, &i->scid))
+		if (short_channel_id_eq(scid, &i->scid))
 			return i;
 	}
 	return NULL;


### PR DESCRIPTION
PR #1618 in parallel with the migration to macro `structeq` created this.

Fixes #1674