### PR TITLE
params: Fix arg size

### DIFF
--- a/lightningd/params.h
+++ b/lightningd/params.h
@@ -64,7 +64,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 		  (arg) + 0*sizeof((cb)((const char *)NULL,		\
 					(const jsmntok_t *)NULL,	\
 					(arg)) == true),		\
-		  0
+		  (size_t)0
 /*
  * Similar to above but for optional parameters.
  * @arg must be the address of a pointer. If found during parsing, it will be


### PR DESCRIPTION
Fixes #1668

Making the explicit cast to `size_t` fixes the issue. I'm not sure exactly what the architectural difference is. The type sizes seem to all be the same as my desktop.  However he is using gcc 7.3 and I'm using 7.2.

Signed-off-by: Mark Beckwith <wythe@intrig.com>