### PR TITLE
params: shortened names

### DIFF
--- a/lightningd/params.c
+++ b/lightningd/params.c
@@ -269,10 +269,9 @@ static void check_params(struct param *params)
 }
 #endif
 
-static bool param_parse_arr(struct command *cmd,
-			    const char *buffer,
-			    const jsmntok_t tokens[],
-			    struct param *params)
+static bool param_arr(struct command *cmd, const char *buffer,
+		      const jsmntok_t tokens[],
+		      struct param *params)
 {
 #if DEVELOPER
 	check_params(params);
@@ -287,8 +286,8 @@ static bool param_parse_arr(struct command *cmd,
 	return false;
 }
 
-bool param_parse(struct command *cmd, const char *buffer,
-		 const jsmntok_t tokens[], ...)
+bool param(struct command *cmd, const char *buffer,
+	   const jsmntok_t tokens[], ...)
 {
 	struct param *params = tal_arr(cmd, struct param, 0);
 	const char *name;
@@ -304,5 +303,5 @@ bool param_parse(struct command *cmd, const char *buffer,
 	}
 	va_end(ap);
 
-	return param_parse_arr(cmd, buffer, tokens, params);
+	return param_arr(cmd, buffer, tokens, params);
 }

--- a/lightningd/params.h
+++ b/lightningd/params.h
@@ -2,36 +2,37 @@
 #define LIGHTNING_LIGHTNINGD_PARAMS_H
 #include "config.h"
 
-struct param;
-
 /*
   Typesafe callback system for unmarshalling and validating json parameters.
 
   Typical usage:
 	unsigned cltv;
-	const jsmntok_t *note;
 	u64 *msatoshi;
+	const jsmntok_t *note;
+	u64 expiry;
 
-	if (!param_parse(cmd, buffer, tokens,
-			 param_req("cltv", json_tok_number, &cltv),
-			 param_opt("note", json_tok_tok, &note),
-			 param_opt("msatoshi", json_tok_u64, &msatoshi),
-			 NULL))
+	if (!param(cmd, buffer, params,
+		   p_req("cltv", json_tok_number, &cltv),
+		   p_opt("msatoshi", json_tok_u64, &msatoshi),
+		   p_opt_tok("note", &note),
+		   p_opt_def("expiry", json_tok_u64, &expiry, 3600),
+		   NULL))
 		return;
 
   At this point in the code you can be assured the json tokens were successfully
-  parsed.  If not, param_parse() returns false, having already called
-  command_fail() with a descriptive error message. The data section of the json
-  result contains the offending parameter and its value.
+  parsed.  If not, param() returned false, having already called command_fail()
+  with a descriptive error message. The data section of the json result contains
+  the offending parameter and its value.
 
-  cltv is a required parameter, and is set correctly.
+  cltv is a required parameter. It must be present in the json input and will
+  be set appropriately.
 
-  note and msatoshi are optional parameters.  Their argument will be set to NULL
-  if they are not provided.
+  msatoshi is optional.  If not present it will be set to NULL.
 
-  The note parameter uses a special callback, param_opt_tok: it
-  simply sets note to the appropriate value (or NULL) and lets the
-  handler do the validating.
+  note is also optional. It uses a special callback that simply sets note to the
+  appropriate value (or NULL) and lets the handler do the validating.
+
+  expiry is also optional and will be set to a default value if not present.
 
   There are canned failure messages for common callbacks. An example:
 
@@ -39,11 +40,16 @@ struct param;
 
   Otherwise a generic message is provided.
  */
-bool param_parse(struct command *cmd, const char *buffer,
-		 const jsmntok_t params[], ...);
 
 /*
- * This callback provided must follow this signature; e.g.,
+ * parse the json tokens.  @params can be an array of values, or an object
+ * of named values.
+ */
+bool param(struct command *cmd, const char *buffer,
+	   const jsmntok_t params[], ...);
+
+/*
+ * The callback provided must follow this signature; e.g.,
  * bool json_tok_double(const char *buffer, const jsmntok_t *tok, double *arg)
  */
 typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
@@ -55,36 +61,35 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
  *
  * This operation is typesafe; i.e., a compilation error will occur if the types
  * of @arg and the last parameter of @cb do not match (see the weird 0*sizeof).
- *
- * Returns an opaque pointer that can be later used in param_is_set().
  */
-#define param_req(name, cb, arg)					\
-		  name"",						\
-		  true,							\
-		  (cb),							\
-		  (arg) + 0*sizeof((cb)((const char *)NULL,		\
-					(const jsmntok_t *)NULL,	\
-					(arg)) == true),		\
-		  (size_t)0
+#define p_req(name, cb, arg)					\
+	      name"",						\
+	      true,						\
+	      (cb),				 		\
+	      (arg) + 0*sizeof((cb)((const char *)NULL,		\
+				    (const jsmntok_t *)NULL,	\
+				    (arg)) == true),		\
+	      (size_t)0
+
 /*
  * Similar to above but for optional parameters.
  * @arg must be the address of a pointer. If found during parsing, it will be
  * allocated, otherwise it will be set to NULL.
  */
-#define param_opt(name, cb, arg)				\
-		  name"",					\
-		  false,					\
-		  (cb),						\
-		  (arg) + 0*sizeof((cb)((const char *)NULL,	\
-					(const jsmntok_t *)NULL,\
-					*(arg)) == true),	\
-		  sizeof(**(arg))
+#define p_opt(name, cb, arg)					\
+	      name"",						\
+	      false,						\
+	      (cb),				 		\
+	      (arg) + 0*sizeof((cb)((const char *)NULL,		\
+				    (const jsmntok_t *)NULL,	\
+				    *(arg)) == true),		\
+	      sizeof(**(arg))
 
 /*
- * Similar to param_req but for optional parameters with defaults.
+ * Similar to p_req but for optional parameters with defaults.
  * @arg will be set to @def if it isn't found during parsing.
  */
-#define param_opt_default(name, cb, arg, def)				\
+#define p_opt_def(name, cb, arg, def)					\
 		  name"",						\
 		  false,						\
 		  (cb),							\
@@ -98,11 +103,11 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
  *
  * Note: weird sizeof() does type check that arg really is a (const) jsmntok_t **.
  */
-#define param_opt_tok(name, arg)					\
-		      name"",						\
-		      false,						\
-		      json_tok_tok,					\
-		      (arg) + 0*sizeof(*(arg) == (jsmntok_t *)NULL),	\
-		      sizeof(const jsmntok_t *)
+#define p_opt_tok(name, arg)						\
+		  name"",						\
+		  false,						\
+		  json_tok_tok,						\
+		  (arg) + 0*sizeof(*(arg) == (jsmntok_t *)NULL),	\
+		  sizeof(const jsmntok_t *)
 
 #endif /* LIGHTNING_LIGHTNINGD_PARAMS_H */

--- a/lightningd/test/run-params.c
+++ b/lightningd/test/run-params.c
@@ -89,10 +89,10 @@ static struct json *json_parse(const tal_t * ctx, const char *str)
 static void zero_params(void)
 {
 	struct json *j = json_parse(cmd, "{}");
-	assert(param_parse(cmd, j->buffer, j->toks, NULL));
+	assert(param(cmd, j->buffer, j->toks, NULL));
 
 	j = json_parse(cmd, "[]");
-	assert(param_parse(cmd, j->buffer, j->toks, NULL));
+	assert(param(cmd, j->buffer, j->toks, NULL));
 }
 
 struct sanity {
@@ -127,9 +127,9 @@ static void stest(const struct json *j, struct sanity *b)
 {
 	u64 ival;
 	double dval;
-	if (!param_parse(cmd, j->buffer, j->toks,
-			 param_req("u64", json_tok_u64, &ival),
-			 param_req("double", json_tok_double, &dval), NULL)) {
+	if (!param(cmd, j->buffer, j->toks,
+		   p_req("u64", json_tok_u64, &ival),
+		   p_req("double", json_tok_double, &dval), NULL)) {
 		assert(failed == true);
 		assert(b->failed == true);
 		assert(strstr(fail_msg, b->fail_str));
@@ -161,9 +161,8 @@ static void tok_tok(void)
 		const jsmntok_t *tok = NULL;
 		struct json *j = json_parse(cmd, "{ 'satoshi', '546' }");
 
-		assert(param_parse(cmd, j->buffer, j->toks,
-				   param_req("satoshi", json_tok_tok,
-					     &tok), NULL));
+		assert(param(cmd, j->buffer, j->toks,
+			     p_req("satoshi", json_tok_tok, &tok), NULL));
 		assert(tok);
 		assert(json_tok_number(j->buffer, tok, &n));
 		assert(n == 546);
@@ -174,8 +173,8 @@ static void tok_tok(void)
 		const jsmntok_t *tok = (const jsmntok_t *) 65535;
 
 		struct json *j = json_parse(cmd, "{}");
-		assert(param_parse(cmd, j->buffer, j->toks,
-				   param_opt_tok("satoshi", &tok), NULL));
+		assert(param(cmd, j->buffer, j->toks,
+			     p_opt_tok("satoshi", &tok), NULL));
 
 		/* make sure it *is* NULL */
 		assert(tok == NULL);
@@ -186,14 +185,14 @@ static void tok_tok(void)
 static void dup_names(void)
 {
 	struct json *j =
-	    json_parse(cmd,
-		       "{ 'u64' : '42', 'u64' : '43', 'double' : '3.15' }");
+		json_parse(cmd,
+			   "{ 'u64' : '42', 'u64' : '43', 'double' : '3.15' }");
 
 	u64 i;
 	double d;
-	assert(!param_parse(cmd, j->buffer, j->toks,
-			    param_req("u64", json_tok_u64, &i),
-			    param_req("double", json_tok_double, &d), NULL));
+	assert(!param(cmd, j->buffer, j->toks,
+		      p_req("u64", json_tok_u64, &i),
+		      p_req("double", json_tok_double, &d), NULL));
 }
 
 static void null_params(void)
@@ -206,15 +205,15 @@ static void null_params(void)
 	for (int i = 0; i < tal_count(ints) - 1; ++i)
 		ints[i] = i;
 
-	assert(param_parse(cmd, j->buffer, j->toks,
-			   param_req("0", json_tok_u64, &ints[0]),
-			   param_req("1", json_tok_u64, &ints[1]),
-			   param_req("2", json_tok_u64, &ints[2]),
-			   param_req("3", json_tok_u64, &ints[3]),
-			   param_opt_default("4", json_tok_u64, &ints[4], 999),
-			   param_opt("5", json_tok_u64, &intptrs[0]),
-			   param_opt("6", json_tok_u64, &intptrs[1]),
-			   NULL));
+	assert(param(cmd, j->buffer, j->toks,
+		     p_req("0", json_tok_u64, &ints[0]),
+		     p_req("1", json_tok_u64, &ints[1]),
+		     p_req("2", json_tok_u64, &ints[2]),
+		     p_req("3", json_tok_u64, &ints[3]),
+		     p_opt_def("4", json_tok_u64, &ints[4], 999),
+		     p_opt("5", json_tok_u64, &intptrs[0]),
+		     p_opt("6", json_tok_u64, &intptrs[1]),
+		     NULL));
 	for (int i = 0; i < tal_count(ints); ++i)
 		assert(ints[i] == i + 10);
 	for (int i = 0; i < tal_count(intptrs); ++i)
@@ -227,15 +226,15 @@ static void null_params(void)
 		intptrs[i] = (void *)42;
 
 	j = json_parse(cmd, "[ '10', '11', '12', '13', '14']");
-	assert(param_parse(cmd, j->buffer, j->toks,
-			   param_req("0", json_tok_u64, &ints[0]),
-			   param_req("1", json_tok_u64, &ints[1]),
-			   param_req("2", json_tok_u64, &ints[2]),
-			   param_req("3", json_tok_u64, &ints[3]),
-			   param_opt("4", json_tok_u64, &intptrs[0]),
-			   param_opt("5", json_tok_u64, &intptrs[1]),
-			   param_opt_default("6", json_tok_u64, &ints[4], 888),
-			   NULL));
+	assert(param(cmd, j->buffer, j->toks,
+		     p_req("0", json_tok_u64, &ints[0]),
+		     p_req("1", json_tok_u64, &ints[1]),
+		     p_req("2", json_tok_u64, &ints[2]),
+		     p_req("3", json_tok_u64, &ints[3]),
+		     p_opt("4", json_tok_u64, &intptrs[0]),
+		     p_opt("5", json_tok_u64, &intptrs[1]),
+		     p_opt_def("6", json_tok_u64, &ints[4], 888),
+		     NULL));
 	assert(*intptrs[0] == 14);
 	assert(intptrs[1] == NULL);
 	assert(ints[4] == 888);
@@ -289,46 +288,45 @@ static void bad_programmer(void)
 
 	/* check for repeated names */
 	if (setjmp(jump) == 0) {
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("repeat", json_tok_u64, &ival),
-			    param_req("double", json_tok_double, &dval),
-			    param_req("repeat", json_tok_u64, &ival2), NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("repeat", json_tok_u64, &ival),
+		      p_req("double", json_tok_double, &dval),
+		      p_req("repeat", json_tok_u64, &ival2), NULL);
 		/* shouldn't get here */
 		restore_assert(old_stderr);
 		assert(false);
 	}
 
 	if (setjmp(jump) == 0) {
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("repeat", json_tok_u64, &ival),
-			    param_req("double", json_tok_double, &dval),
-			    param_req("repeat", json_tok_u64, &ival), NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("repeat", json_tok_u64, &ival),
+		      p_req("double", json_tok_double, &dval),
+		      p_req("repeat", json_tok_u64, &ival), NULL);
 		restore_assert(old_stderr);
 		assert(false);
 	}
 
 	if (setjmp(jump) == 0) {
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("u64", json_tok_u64, &ival),
-			    param_req("repeat", json_tok_double, &dval),
-			    param_req("repeat", json_tok_double, &dval), NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("u64", json_tok_u64, &ival),
+		      p_req("repeat", json_tok_double, &dval),
+		      p_req("repeat", json_tok_double, &dval), NULL);
 		restore_assert(old_stderr);
 		assert(false);
 	}
 
 	/* check for repeated arguments */
 	if (setjmp(jump) == 0) {
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("u64", json_tok_u64, &ival),
-			    param_req("repeated-arg", json_tok_u64, &ival),
-			    NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("u64", json_tok_u64, &ival),
+		      p_req("repeated-arg", json_tok_u64, &ival), NULL);
 		restore_assert(old_stderr);
 		assert(false);
 	}
 
 	if (setjmp(jump) == 0) {
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("u64", (param_cb)NULL, &ival), NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("u64", (param_cb) NULL, &ival), NULL);
 		restore_assert(old_stderr);
 		assert(false);
 	}
@@ -339,13 +337,11 @@ static void bad_programmer(void)
 		    json_parse(cmd, "[ '25', '546', '26', '1.1' ]");
 		unsigned int msatoshi;
 		double riskfactor;
-		param_parse(cmd, j->buffer, j->toks,
-			    param_req("u64", json_tok_u64, &ival),
-			    param_req("double", json_tok_double, &dval),
-			    param_opt_default("msatoshi",
-					      json_tok_number, &msatoshi, 100),
-			    param_req("riskfactor", json_tok_double,
-				      &riskfactor), NULL);
+		param(cmd, j->buffer, j->toks,
+		      p_req("u64", json_tok_u64, &ival),
+		      p_req("double", json_tok_double, &dval),
+		      p_opt_def("msatoshi", json_tok_number, &msatoshi, 100),
+		      p_req("riskfactor", json_tok_double, &riskfactor), NULL);
 		restore_assert(old_stderr);
 		assert(false);
 	}
@@ -390,7 +386,7 @@ static void five_hundred_params(void)
 
 	/* first test object version */
 	struct json *j = json_parse(params, obj->s);
-	assert(param_parse_arr(cmd, j->buffer, j->toks, params));
+	assert(param_arr(cmd, j->buffer, j->toks, params));
 	for (int i = 0; i < tal_count(ints); ++i) {
 		assert(ints[i] == i);
 		ints[i] = 65535;
@@ -398,7 +394,7 @@ static void five_hundred_params(void)
 
 	/* now test array */
 	j = json_parse(params, arr->s);
-	assert(param_parse_arr(cmd, j->buffer, j->toks, params));
+	assert(param_arr(cmd, j->buffer, j->toks, params));
 	for (int i = 0; i < tal_count(ints); ++i) {
 		assert(ints[i] == i);
 	}
@@ -414,16 +410,17 @@ static void sendpay(void)
 	u64 *msatoshi;
 	unsigned cltv;
 
-	if (!param_parse(cmd, j->buffer, j->toks,
-			 param_req("route", json_tok_tok, &routetok),
-			 param_req("cltv", json_tok_number, &cltv),
-			 param_opt_tok("note", &note),
-			 param_opt("msatoshi", json_tok_u64, &msatoshi),
-			 NULL))
+	if (!param(cmd, j->buffer, j->toks,
+		   p_req("route", json_tok_tok, &routetok),
+		   p_req("cltv", json_tok_number, &cltv),
+		   p_opt_tok("note", &note),
+		   p_opt("msatoshi", json_tok_u64, &msatoshi),
+		   NULL))
 		assert(false);
 
 	assert(note);
-	assert(!strncmp("hello there", j->buffer + note->start, note->end - note->start));
+	assert(!strncmp("hello there", j->buffer + note->start,
+			note->end - note->start));
 	assert(msatoshi);
 	assert(*msatoshi == 547);
 }
@@ -436,12 +433,12 @@ static void sendpay_nulltok(void)
 	u64 *msatoshi;
 	unsigned cltv;
 
-	if (!param_parse(cmd, j->buffer, j->toks,
-			 param_req("route", json_tok_tok, &routetok),
-			 param_req("cltv", json_tok_number, &cltv),
-			 param_opt_tok("note", &note),
-			 param_opt("msatoshi", json_tok_u64, &msatoshi),
-			 NULL))
+	if (!param(cmd, j->buffer, j->toks,
+		   p_req("route", json_tok_tok, &routetok),
+		   p_req("cltv", json_tok_number, &cltv),
+		   p_opt_tok("note", &note),
+		   p_opt("msatoshi", json_tok_u64, &msatoshi),
+		   NULL))
 		assert(false);
 
 	assert(note == NULL);


### PR DESCRIPTION
This is a cosmetic change only. No functional changes.

I shortened the names of macros and changed param_parse() to param().

Also went through params.h with a fine-toothed comb and updated the comments
to reflect the current API.

I wanted to change the files:

	params.c -> param.c
	params.h -> param.h
	run-params.c -> run->param.c

but that confused `git diff` for params.h so its best left for another PR.

I'm keeping #1682 updated locally with all these changes.

Signed-off-by: Mark Beckwith <wythe@intrig.com>