### PR TITLE
improves exponential smoothing of feerate estimates

### DIFF
--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -10,6 +10,7 @@
 #include <jsmn.h>
 #include <lightningd/watch.h>
 #include <stddef.h>
+#include <math.h>
 
 struct bitcoin_tx;
 struct bitcoind;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -9,8 +9,8 @@
 #include <ccan/time/time.h>
 #include <jsmn.h>
 #include <lightningd/watch.h>
-#include <stddef.h>
 #include <math.h>
+#include <stddef.h>
 
 struct bitcoin_tx;
 struct bitcoind;


### PR DESCRIPTION
- fixes problem with polling interval > 150 * 0.9
- fixes log message `feerate hit floor` at every feerate change
- smoothed fee now reaches 90% of (exp weighted) fee estimates polled in last
120s, independent of polling interval
- only apply smoothing when effect > 10 percent so it doesn't correct forever
- fix indentation

NOTE: Currently when starting a node, the first fee estimate always is `default_fee_rate = 40000`. So it takes about 4min for smoothed fee to reach _normal_ values, see #1698. Not sure if that is a problem.