### PR TITLE
pytest: make utils.py read config.vars.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,10 @@ LIGHTNINGD_CONFIG = {
     'disable-dns': None,
 }
 
-DEVELOPER = os.getenv("DEVELOPER", "0") == "1"
+with open('config.vars') as configfile:
+    config = dict([(line.rstrip().split('=', 1)) for line in configfile])
+
+DEVELOPER = os.getenv("DEVELOPER", config['DEVELOPER']) == "1"
 TIMEOUT = int(os.getenv("TIMEOUT", "60"))
 
 


### PR DESCRIPTION
I could not figure out why test_announce_address suddenly stopped working:
I had previously been using DEVELOPER=1 on the cmdline for historical
reasons when testing locally.
