### PR TITLE
fix: compile error with clang

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -257,7 +257,7 @@ static void update_feerates(struct bitcoind *bitcoind,
         u32 feerate_smooth = feerate * alpha + old_feerates[i] * (1 - alpha);
         /* But to avoid updating forever, only apply smoothing when its
          * effect is more then 10 percent */
-        if (abs(feerate - feerate_smooth) > (0.1 * feerate)) {
+        if (abs((int)feerate - (int)feerate_smooth) > (0.1 * feerate)) {
             feerate = feerate_smooth;
             log_debug(topo->log,
 					  "...feerate %u smoothed to %u (alpha=%.2f)",


### PR DESCRIPTION
I am trying to build the master branch with clang 3.8.0 on Ubuntu 16.04 and I am having a compile error.
This error does not occur with gcc 5.4.0.

> make CC=clang
> clang -DBINTOPKGLIBEXECDIR='"'../libexec/c-lightning'"' -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -std=gnu11 -g -fstack-protector -I ccan -I external/libsodium/src/libsodium/include -I external/libwally-core/include/ -I external/libwally-core/src/secp256k1/include/ -I external/jsmn/ -I external/libbase58/ -I external/libbacktrace/ -I external/libbacktrace-build -I . -I/usr/local/include    -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS  -DCOMPAT_V052=1 -DBINTOPKGLIBEXECDIR='"'../libexec/c-lightning'"'  -c -o lightningd/chaintopology.o lightningd/chaintopology.c
> lightningd/chaintopology.c:260:13: error: taking the absolute value of unsigned type 'unsigned int' has no effect
>       [-Werror,-Wabsolute-value]
>         if (abs(feerate - feerate_smooth) > (0.1 * feerate)) {
>             ^
> lightningd/chaintopology.c:260:13: note: remove the call to 'abs' since unsigned values cannot be negative
>         if (abs(feerate - feerate_smooth) > (0.1 * feerate)) {
>             ^~~
> 1 error generated.
> <builtin>: recipe for target 'lightningd/chaintopology.o' failed
> make: *** [lightningd/chaintopology.o] Error 1