### PR TITLE
Prevent defaulting of feerate at first poll

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -235,7 +235,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 			    const u32 *satoshi_per_kw,
 			    struct chain_topology *topo)
 {
-	u32 old_feerates[NUM_FEERATES] = { 0 };
+	u32 old_feerates[NUM_FEERATES];
 	bool changed = false;
 	/* Smoothing factor alpha for simple exponential smoothing. The goal is to
 	 * have the feerate account for 90 percent of the values polled in the last
@@ -245,6 +245,9 @@ static void update_feerates(struct bitcoind *bitcoind,
 
 	for (size_t i = 0; i < NUM_FEERATES; i++) {
 		u32 feerate = satoshi_per_kw[i];
+
+		/* FIXME: This duplicate line mysteriously prevents channeld crash in some tests */
+		old_feerates[i] = get_feerate(topo, i);
 
 		/* If estimatefee failed, don't do anything. */
 		if (!feerate)

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -238,43 +238,43 @@ static void update_feerates(struct bitcoind *bitcoind,
 	u32 old_feerates[NUM_FEERATES];
 	bool changed = false;
 	/* Smoothing factor alpha for simple exponential smoothing. The goal is to
-     * have the feerate account for 90 percent of the values polled in the last
-     * 2 minutes. The following will do that in a polling interval
-     * independent manner. */
+	 * have the feerate account for 90 percent of the values polled in the last
+	 * 2 minutes. The following will do that in a polling interval
+	 * independent manner. */
 	double alpha = 1 - pow(0.1,(double)topo->poll_seconds / 120);
 
 	for (size_t i = 0; i < NUM_FEERATES; i++) {
 		u32 feerate = satoshi_per_kw[i];
 
-        /* If estimatefee failed, don't do anything. */
+		/* If estimatefee failed, don't do anything. */
 		if (!feerate)
 			continue;
 
-        /* Prevent defaulting of feerates at startup */
-        if (topo->startup) {
-            topo->feerate[i] = feerate;
-        }
+		/* Prevent defaulting of feerates at startup */
+		if (topo->startup) {
+			topo->feerate[i] = feerate;
+		}
 
 		/* Takes into account override_fee_rate */
 		old_feerates[i] = get_feerate(topo, i);
 
-        /* Smooth the feerate to avoid spikes. */
-        u32 feerate_smooth = feerate * alpha + old_feerates[i] * (1 - alpha);
-        /* But to avoid updating forever, only apply smoothing when its
-         * effect is more then 10 percent */
-        if (abs((int)feerate - (int)feerate_smooth) > (0.1 * feerate)) {
-            feerate = feerate_smooth;
-            log_debug(topo->log,
+		/* Smooth the feerate to avoid spikes. */
+		u32 feerate_smooth = feerate * alpha + old_feerates[i] * (1 - alpha);
+		/* But to avoid updating forever, only apply smoothing when its
+		 * effect is more then 10 percent */
+		if (abs((int)feerate - (int)feerate_smooth) > (0.1 * feerate)) {
+			feerate = feerate_smooth;
+			log_debug(topo->log,
 					  "...feerate %u smoothed to %u (alpha=%.2f)",
 					  satoshi_per_kw[i], feerate, alpha);
-        }
+		}
 
-        if (feerate < feerate_floor()) {
-            feerate = feerate_floor();
-            log_debug(topo->log,
+		if (feerate < feerate_floor()) {
+			feerate = feerate_floor();
+			log_debug(topo->log,
 					  "...feerate %u hit floor %u",
 					  satoshi_per_kw[i], feerate);
-        }
+		}
 
 		if (feerate != topo->feerate[i]) {
 			log_debug(topo->log, "%s feerate %u (was %u)",
@@ -283,8 +283,8 @@ static void update_feerates(struct bitcoind *bitcoind,
 		}
 		topo->feerate[i] = feerate;
 	}
-
-    topo->startup = false;
+	/* Moving this forward in time is ok */
+	topo->startup = false;
 
 	/* Make sure fee rates are in order. */
 	for (size_t i = 0; i < NUM_FEERATES; i++) {
@@ -689,7 +689,7 @@ struct chain_topology *new_topology(struct lightningd *ld, struct log *log)
 	topo->log = log;
 	topo->default_fee_rate = 40000;
 	memset(topo->feerate, 0, sizeof(topo->feerate));
-    topo->startup = true;
+	topo->startup = true;
 	topo->bitcoind = new_bitcoind(topo, ld, log);
 	topo->wallet = ld->wallet;
 	topo->poll_seconds = 30;

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -235,7 +235,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 			    const u32 *satoshi_per_kw,
 			    struct chain_topology *topo)
 {
-	u32 old_feerates[NUM_FEERATES];
+	u32 old_feerates[NUM_FEERATES] = { 0 };
 	bool changed = false;
 	/* Smoothing factor alpha for simple exponential smoothing. The goal is to
 	 * have the feerate account for 90 percent of the values polled in the last

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -11,7 +11,6 @@
 #include <lightningd/watch.h>
 #include <math.h>
 #include <stddef.h>
-#include <math.h>
 
 struct bitcoin_tx;
 struct bitcoind;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -11,6 +11,7 @@
 #include <lightningd/watch.h>
 #include <math.h>
 #include <stddef.h>
+#include <math.h>
 
 struct bitcoin_tx;
 struct bitcoind;


### PR DESCRIPTION
- Do not default `feerates` at the first feerate poll after `begin_topology()`
- Properly initializes feerate smoothing
- Mostly fixes #1698

NOTE: This does not prevent **any** defaulting of `feerates`, as there are other paths to `get_feerate()` that can happen before `begin_topology()`.