### PR TITLE
lightningd: fix crash by rpc.invoice with clang

### DIFF
--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -96,7 +96,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 		  (arg) + 0*sizeof((cb)((const char *)NULL,		\
 					(const jsmntok_t *)NULL,	\
 					(arg)) == true),		\
-		  ((void)((*arg) = (def)), 0)
+		  ((void)((*arg) = (def)), (size_t)0)
 
 /*
  * For when you want an optional raw token.


### PR DESCRIPTION
I am trying to build the master branch with clang 3.8.0(not gcc) on Ubuntu 16.04.
lightningd crashs on rpc.invoice.
There is type mismatch of variable argument.

```
./configure 
make NO_VALGRIND=1 CC=clang
PYTHONPATH=contrib/pylightning:$PYTHONPATH DEVELOPER=0 VALGRIND=0 pytest tests/test_lightningd.py::LightningDTests::test_invoice
```

and lightningd is crashed.

> +0.144888971 lightningd(22121):DEBUG: Connected json input
> +0.144913591 lightningd(22121):jcon fd 16:IO_IN: 7b226964223a20302c20226d6574686f64223a2022696e766f696365222c2022706172616d73223a207b226465736372697074696f6e223a2022646573637269
> +0.144920203 lightningd(22121):jcon fd 16:IO_IN: 7074696f6e222c20226c6162656c223a20226c6162656c222c2022657870697279223a202233373030222c20226d7361746f736869223a203132333030302c20
> +0.144928022 lightningd(22121):jcon fd 16:IO_IN: 2266616c6c6261636b73223a205b226263727431717975736e756773686b6e366b6835766d646a70653868796c76786c786a79336e7330686d7273222c2022324d78717a4e414e4a4e41644d6a485171385a4c6b777a6f6f78414669527a5876457a225d7d7d
> +0.149532611 lightningd(22121):BROKEN: FATAL SIGNAL 6 (version v0.6-98-gd84d358)
> +0.150030499 lightningd(22121):BROKEN: backtrace: common/daemon.c:42 (crashdump) 0x438ff5
> +0.150064523 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0x7fbf91f6e4af
> +0.150082213 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0x7fbf91f6e428
> +0.150097251 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0x7fbf91f70029
> +0.150111946 lightningd(22121):BROKEN: backtrace: ccan/ccan/tal/tal.c:98 (call_error) 0x489f30
> +0.150130483 lightningd(22121):BROKEN: backtrace: ccan/ccan/tal/tal.c:252 (allocate) 0x488892
> +0.150146405 lightningd(22121):BROKEN: backtrace: ccan/ccan/tal/tal.c:448 (tal_alloc_) 0x48868d
> +0.150161788 lightningd(22121):BROKEN: backtrace: lightningd/param.c:83 (make_callback) 0x422f0a
> +0.150177015 lightningd(22121):BROKEN: backtrace: lightningd/param.c:191 (parse_by_name) 0x422e40
> +0.150192185 lightningd(22121):BROKEN: backtrace: lightningd/param.c:285 (param_arr) 0x422b45
> +0.150206831 lightningd(22121):BROKEN: backtrace: lightningd/param.c:309 (param) 0x4229c6
> +0.150221889 lightningd(22121):BROKEN: backtrace: lightningd/invoice.c:175 (json_invoice) 0x4106d6
> +0.150237435 lightningd(22121):BROKEN: backtrace: lightningd/jsonrpc.c:489 (parse_request) 0x415ecd
> +0.150252548 lightningd(22121):BROKEN: backtrace: lightningd/jsonrpc.c:559 (read_json) 0x415862
> +0.150267708 lightningd(22121):BROKEN: backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x4798e5
> +0.150282634 lightningd(22121):BROKEN: backtrace: ccan/ccan/io/io.c:387 (do_plan) 0x47a588
> +0.150297204 lightningd(22121):BROKEN: backtrace: ccan/ccan/io/io.c:397 (io_ready) 0x47a3f3
> +0.150314249 lightningd(22121):BROKEN: backtrace: ccan/ccan/io/poll.c:310 (io_loop) 0x47c0fd
> +0.150329454 lightningd(22121):BROKEN: backtrace: lightningd/lightningd.c:444 (main) 0x416980
> +0.150344245 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0x7fbf91f5982f
> +0.150358372 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0x4035f8
> +0.150371837 lightningd(22121):BROKEN: backtrace: (null):0 ((null)) 0xffffffffffffffff