### PR TITLE
Change withdrawal documentation failure outcome - referred to channel not transaction.

### DIFF
--- a/doc/lightning-withdraw.7
+++ b/doc/lightning-withdraw.7
@@ -45,7 +45,7 @@ On success, an object with attributes \fItx\fR and \fItxid\fR will be returned\&
 .sp
 \fItx\fR represents the raw bitcoin, fully signed, transaction and \fItxid\fR represent the bitcoin transaction id\&.
 .sp
-On failure, an error is reported and the channel is not funded\&.
+On failure, an error is reported and the withdrawal transaction is not created.\&.
 .sp
 The following error codes may occur:
 .sp

--- a/doc/lightning-withdraw.7.txt
+++ b/doc/lightning-withdraw.7.txt
@@ -33,7 +33,7 @@ be returned.
 'tx' represents the raw bitcoin, fully signed, transaction
 and 'txid' represent the bitcoin transaction id.
 
-On failure, an error is reported and the channel is not funded.
+On failure, an error is reported and the withdrawal transaction is not created.
 
 The following error codes may occur:
 


### PR DESCRIPTION
The failure outcome of withdraw method mentioned channel not being funded - but it should refer to withdrawal transaction not being created.