### PR TITLE
Updated docs to reflect bech32 default

### DIFF
--- a/doc/lightning-newaddr.7
+++ b/doc/lightning-newaddr.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-newaddr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 07/23/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-NEWADDR" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-NEWADDR" "7" "07/23/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,22 +31,22 @@
 lightning-newaddr \- Command for generating a new address to be used by c\-lightning\&.
 .SH "SYNOPSIS"
 .sp
-\fBnewaddr\fR [ \fIp2sh\-segwit\fR | \fIbech32\fR ]
+\fBnewaddr\fR [ \fIaddresstype\fR ]
 .SH "DESCRIPTION"
 .sp
 The \fBnewaddr\fR RPC command generates a new address which can subsequently be used to fund channels managed by the c\-lightning node\&.
 .sp
 The funding transaction needs to be confirmed before funds can be used\&.
 .sp
-The optional parameter specifies the type of address wanted i\&.e\&. p2sh\-segwit (e\&.g\&. 2MxaozoqWwiUcuD9KKgUSrLFDafLqimT9Ta on bitcoin testnet or 3MZxzq3jBSKNQ2e7dzneo9hy4FvNzmMmt3 on bitcoin mainnet) or bech32 (e\&.g\&. tb1qu9j4lg5f9rgjyfhvfd905vw46eg39czmktxqgg on bitcoin testnet or bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej on bitcoin mainnet)\&.
+\fIaddresstype\fR specifies the type of address wanted; i\&.e\&. p2sh\-segwit (e\&.g\&. 2MxaozoqWwiUcuD9KKgUSrLFDafLqimT9Ta on bitcoin testnet or 3MZxzq3jBSKNQ2e7dzneo9hy4FvNzmMmt3 on bitcoin mainnet) or bech32 (e\&.g\&. tb1qu9j4lg5f9rgjyfhvfd905vw46eg39czmktxqgg on bitcoin testnet or bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej on bitcoin mainnet)\&.
 .sp
-If not specified the address generated is p2sh\-segwit\&.
+If not specified the address generated is bech32\&.
 .SH "RETURN VALUE"
 .sp
 On success, a new address will be returned\&.
 .SH "ERRORS"
 .sp
-If a non recognized address type is requested an error message will be returned
+If an unrecognized address type is requested an error message will be returned\&.
 .SH "AUTHOR"
 .sp
 Felix <fixone@gmail\&.com> is mainly responsible\&.

--- a/doc/lightning-newaddr.7.txt
+++ b/doc/lightning-newaddr.7.txt
@@ -9,7 +9,7 @@ be used by c-lightning.
 
 SYNOPSIS
 --------
-*newaddr* [ 'p2sh-segwit' | 'bech32' ]
+*newaddr* [ 'addresstype' ]
 
 DESCRIPTION
 -----------
@@ -18,13 +18,13 @@ subsequently be used to fund channels managed by the c-lightning node.
 
 The funding transaction needs to be confirmed before funds can be used. 
 
-The optional parameter specifies the type of address wanted i.e. 
+'addresstype' specifies the type of address wanted; i.e.
 p2sh-segwit (e.g. 2MxaozoqWwiUcuD9KKgUSrLFDafLqimT9Ta on bitcoin testnet 
 or 3MZxzq3jBSKNQ2e7dzneo9hy4FvNzmMmt3 on bitcoin mainnet) or bech32 
 (e.g. tb1qu9j4lg5f9rgjyfhvfd905vw46eg39czmktxqgg on bitcoin testnet or 
 bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej on bitcoin mainnet).
 
-If not specified the address generated is p2sh-segwit.
+If not specified the address generated is bech32.
 
 RETURN VALUE
 ------------
@@ -32,7 +32,7 @@ On success, a new address will be returned.
 
 ERRORS
 ------
-If a non recognized address type is requested an error message will be returned
+If an unrecognized address type is requested an error message will be returned.
 
 AUTHOR
 ------

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -268,7 +268,7 @@ static void json_newaddr(struct command *cmd, const char *buffer UNUSED,
 static const struct json_command newaddr_command = {
 	"newaddr",
 	json_newaddr,
-	"Get a new {bech32, p2sh-segwit} address to fund a channel", false,
+	"Get a new {bech32, p2sh-segwit} address to fund a channel (default is bech32)", false,
 	"Generates a new address that belongs to the internal wallet. Funds sent to these addresses will be managed by lightningd. Use `withdraw` to withdraw funds to an external wallet."
 };
 AUTODATA(json_command, &newaddr_command);


### PR DESCRIPTION
#1729

Also:

The manpage did not specify the name of the named parameter (addresstype).
It does now.

Fixed manpage grammar errors.
