### PR TITLE
pay: Exempt a fee from the maxfeepercent rule it is still tiny

### DIFF
--- a/doc/lightning-pay.7
+++ b/doc/lightning-pay.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-pay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 07/28/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-PAY" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-PAY" "7" "07/28/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -34,7 +34,7 @@ lightning-pay \- Command for sending a payment to a BOLT11 invoice
 \fBpay\fR \fIbolt11\fR [\fImsatoshi\fR] [\fIdescription\fR] [\fIriskfactor\fR] [\fImaxfeepercent\fR] [\fIretry_for\fR] [\fImaxdelay\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBpay\fR RPC command attempts to find a route to the given destination, and send the funds it asks for\&. If the \fIbolt11\fR does not contain an amount, \fImsatoshi\fR is required, otherwise if it is specified it must be \fInull\fR\&. If \fIbolt11\fR contains a description hash (\fIh\fR field) \fIdescription\fR is required, otherwise it is unused\&. The \fIriskfactor\fR is described in detail in lightning\-getroute(7), and defaults to 1\&.0\&. The \fImaxfeepercent\fR limits the money paid in fees, and defaults to 0\&.5\&. The \(oqmaxfeepercent\(cq is a percentage of the amount that is to be paid\&.
+The \fBpay\fR RPC command attempts to find a route to the given destination, and send the funds it asks for\&. If the \fIbolt11\fR does not contain an amount, \fImsatoshi\fR is required, otherwise if it is specified it must be \fInull\fR\&. If \fIbolt11\fR contains a description hash (\fIh\fR field) \fIdescription\fR is required, otherwise it is unused\&. The \fIriskfactor\fR is described in detail in lightning\-getroute(7), and defaults to 1\&.0\&. The \fImaxfeepercent\fR limits the money paid in fees, and defaults to 0\&.5\&. The maxfeepercent\*(Aq is a percentage of the amount that is to be paid\&. The `exemptfee option can be used for tiny payments which would be dominated by the fee leveraged by forwarding nodes\&. Setting exemptfee allows the maxfeepercent check to be skipped on fees that are smaller than exemptfee (default: 5000 millsatoshi)\&.
 .sp
 The \fBpay\fR RPC command will randomize routes slightly, as long as the route achieves the targeted \fImaxfeepercent\fR and \fImaxdelay\fR\&.
 .sp

--- a/doc/lightning-pay.7.txt
+++ b/doc/lightning-pay.7.txt
@@ -22,6 +22,10 @@ in lightning-getroute(7), and defaults to 1.0.
 The 'maxfeepercent' limits the money paid in fees, and defaults to 0.5.
 The `maxfeepercent' is a percentage of the amount that is to be
 paid.
+The `exemptfee` option can be used for tiny payments which would be dominated by
+the fee leveraged by forwarding nodes. Setting `exemptfee` allows the
+`maxfeepercent` check to be skipped on fees that are smaller than `exemptfee`
+(default: 5000 millsatoshi).
 
 The *pay* RPC command will randomize routes slightly, as long as the
 route achieves the targeted 'maxfeepercent' and 'maxdelay'.

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -711,6 +711,7 @@ static const struct json_command pay_command = {
 	"{description} (required if {bolt11} uses description hash), "
 	"{riskfactor} (default 1.0), "
 	"{maxfeepercent} (default 0.5) the maximum acceptable fee as a percentage (e.g. 0.5 => 0.5%), "
+	"{exemptfee} (default 5000 msat) disables the maxfeepercent check for fees below the threshold, "
 	"{retry_for} (default 60) the integer number of seconds before we stop retrying, and "
 	"{maxdelay} (default 500) the maximum number of blocks we allow the funds to possibly get locked"
 };

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -65,9 +65,9 @@ bool invoices_create(struct invoices *invoices,
 /**
  * invoices_find_by_label - Search for an invoice by label
  *
- * @invoices - the invoice handler.
- * @pinvoice - pointer to location to load found invoice in.
- * @label - the label to search for.
+ * @param invoices - the invoice handler.
+ * @param pinvoice - pointer to location to load found invoice in.
+ * @param label - the label to search for.
  *
  * Returns false if no invoice with that label exists.
  * Returns true if found.


### PR DESCRIPTION
Several users have noticed that they cannot pay satoshis.place or similar places
that have tiny payment amounts if they are not directly connected. This is due
to the forwarding fee dominating the transferred amount.

This commit adds a new option, exempting tiny fees (up to 5 satoshis by default)
from having to pass the maxfeepercent flag. While we could have told users to
tweak maxfeepercent I think it is usefull to have a default exemption.

Not sure about the name of the option just yet, the current naming is based on
exempting it from the check, which feels clunky. Maybe someone else has a
good idea?

Fixes #1746 

Ping @SerafinTech, @renepickhardt, @jonathancross