### PR TITLE
Remove sigaction from run-param test

### DIFF
--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -15,6 +15,7 @@
  * with a specific error code, and then removed.
  */
 #define LIGHTNINGD                      -1
+#define LIGHTNINGD_INTERNAL             -2
 
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 #define PAY_IN_PROGRESS			200

--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -15,7 +15,9 @@
  * with a specific error code, and then removed.
  */
 #define LIGHTNINGD                      -1
-#define LIGHTNINGD_INTERNAL             -2
+
+/* Developer error in the parameters to param() call */
+#define PARAM_DEV_ERROR                 -2
 
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 #define PAY_IN_PROGRESS			200

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -284,7 +284,7 @@ static bool param_arr(struct command *cmd, const char *buffer,
 {
 #if DEVELOPER
 	if (!check_params(params)) {
-		command_fail(cmd, LIGHTNINGD_INTERNAL, "programmer error");
+		command_fail(cmd, PARAM_DEV_ERROR, "programmer error");
 		return false;
 	}
 #endif
@@ -312,8 +312,8 @@ bool param(struct command *cmd, const char *buffer,
 		void *arg = va_arg(ap, void *);
 		size_t argsize = va_arg(ap, size_t);
 		if  (!param_add(&params, name, required, cb, arg, argsize)) {
-			command_fail(cmd, LIGHTNINGD_INTERNAL,
-				     "programmer error");
+			command_fail(cmd, PARAM_DEV_ERROR, "programmer error");
+			va_end(ap);
 			return false;
 		}
 	}

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -284,7 +284,7 @@ static bool param_arr(struct command *cmd, const char *buffer,
 {
 #if DEVELOPER
 	if (!check_params(params)) {
-		command_fail(cmd, PARAM_DEV_ERROR, "programmer error");
+		command_fail(cmd, PARAM_DEV_ERROR, "developer error");
 		return false;
 	}
 #endif
@@ -312,7 +312,7 @@ bool param(struct command *cmd, const char *buffer,
 		void *arg = va_arg(ap, void *);
 		size_t argsize = va_arg(ap, size_t);
 		if  (!param_add(&params, name, required, cb, arg, argsize)) {
-			command_fail(cmd, PARAM_DEV_ERROR, "programmer error");
+			command_fail(cmd, PARAM_DEV_ERROR, "developer error");
 			va_end(ap);
 			return false;
 		}

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -10,8 +10,15 @@
 #include <ccan/err/err.h>
 #include <unistd.h>
 
-bool failed;
 char *fail_msg;
+bool failed = false;
+
+static bool check_fail(void) {
+	if (!failed)
+		return false;
+	failed = false;
+	return true;
+}
 
 struct command *cmd;
 
@@ -82,7 +89,6 @@ static struct json *json_parse(const tal_t * ctx, const char *str)
 	if (ret <= 0) {
 		assert(0);
 	}
-	failed = false;
 	return j;
 }
 
@@ -130,10 +136,11 @@ static void stest(const struct json *j, struct sanity *b)
 	if (!param(cmd, j->buffer, j->toks,
 		   p_req("u64", json_tok_u64, &ival),
 		   p_req("double", json_tok_double, &dval), NULL)) {
-		assert(failed == true);
+		assert(check_fail());
 		assert(b->failed == true);
 		assert(strstr(fail_msg, b->fail_str));
 	} else {
+		assert(!check_fail());
 		assert(b->failed == false);
 		assert(ival == 42);
 		assert(dval > 3.1499 && b->dval < 3.1501);

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -241,6 +241,7 @@ static void null_params(void)
 }
 
 #if DEVELOPER
+#if 0
 jmp_buf jump;
 static void handle_abort(int sig)
 {
@@ -274,12 +275,14 @@ static void restore_assert(int old_stderr)
 		err(1, "restore_assert");
 
 }
+#endif
 
 /*
  * Check to make sure there are no programming mistakes.
  */
 static void bad_programmer(void)
 {
+#if 0
 	u64 ival;
 	u64 ival2;
 	double dval;
@@ -346,6 +349,7 @@ static void bad_programmer(void)
 		assert(false);
 	}
 	restore_assert(old_stderr);
+#endif
 }
 #endif
 

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -268,33 +268,33 @@ static void bad_programmer(void)
 		      p_req("double", json_tok_double, &dval),
 		      p_req("repeat", json_tok_u64, &ival2), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 
 	assert(!param(cmd, j->buffer, j->toks,
 		      p_req("repeat", json_tok_u64, &ival),
 		      p_req("double", json_tok_double, &dval),
 		      p_req("repeat", json_tok_u64, &ival), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 
 	assert(!param(cmd, j->buffer, j->toks,
 		      p_req("u64", json_tok_u64, &ival),
 		      p_req("repeat", json_tok_double, &dval),
 		      p_req("repeat", json_tok_double, &dval), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 
 	/* check for repeated arguments */
 	assert(!param(cmd, j->buffer, j->toks,
 		      p_req("u64", json_tok_u64, &ival),
 		      p_req("repeated-arg", json_tok_u64, &ival), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 
 	assert(!param(cmd, j->buffer, j->toks,
 		      p_req("u64", (param_cb) NULL, &ival), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 
 	/* Add required param after optional */
 	j = json_parse(cmd, "[ '25', '546', '26', '1.1' ]");
@@ -306,7 +306,7 @@ static void bad_programmer(void)
 		      p_opt_def("msatoshi", json_tok_number, &msatoshi, 100),
 		      p_req("riskfactor", json_tok_double, &riskfactor), NULL));
 	assert(check_fail());
-	assert(strstr(fail_msg, "programmer error"));
+	assert(strstr(fail_msg, "developer error"));
 }
 #endif
 


### PR DESCRIPTION
This should fix #1693. The `sigaction` code was not working for musl devices for some reason. So I just removed all the DEVELOPER mode `asserts` from `param.c` and instead just returned an error.

Then I removed all the `sigaction/setjump/longjmp` shenanigans from `run-param.c`.

It's less code and easier to read.  @jsarenik can test when he gets a chance. But I think it is a worthwhile
patch regardless.