### PR TITLE
Consider channel parameters before selecting for a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to/from peers, instead of `gossipd` doing that itself.
 - Test: `python-xdist` is now a dependency for tests.
 - Logging: JSON connections no longer spam debug logs.
-
+- Routing: We no longer consider channels that are not usable either because of
+  their capacity or their `htlc_minimum_msat` parameter (#1777)
 ### Deprecated
 
 Note: You should always set `allow-deprecated-apis=false` to test for
@@ -84,7 +85,7 @@ changes.
 - JSON API: `getlog` result field `creation_time`.  Use `created_at`.
 - JSON API: `getpeers` result field `channel_reserve_satoshis`.  Use `their_channel_reserve_satoshis`.
 - JSON API: `getpeers` result field `to_self_delay`.  Use `their_to_self_delay`.
-  
+
 
 [Unreleased]: https://github.com/ElementsProject/lightning/compare/v0.6...HEAD
 [0.6]: https://github.com/ElementsProject/lightning/releases/tag/v0.6

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -360,7 +360,8 @@ static void make_channel_local_active(struct peer *peer)
 	/* Tell gossipd about local channel. */
 	msg = towire_gossip_local_add_channel(NULL,
 					      &peer->short_channel_ids[LOCAL],
-					      &peer->node_ids[REMOTE]);
+					      &peer->node_ids[REMOTE],
+					      peer->channel->funding_msat / 1000);
  	wire_sync_write(GOSSIP_FD, take(msg));
 
 	/* Tell gossipd and the other side what parameters we expect should

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -121,6 +121,7 @@ gossip_send_gossip,,gossip,len*u8
 gossip_local_add_channel,3017
 gossip_local_add_channel,,short_channel_id,struct short_channel_id
 gossip_local_add_channel,,remote_node_id,struct pubkey
+gossip_local_add_channel,,satoshis,u64
 
 gossip_local_channel_update,3026
 gossip_local_channel_update,,short_channel_id,struct short_channel_id

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -282,7 +282,8 @@ static void bad_gossip_order(const u8 *msg, const char *source,
 struct chan *new_chan(struct routing_state *rstate,
 		      const struct short_channel_id *scid,
 		      const struct pubkey *id1,
-		      const struct pubkey *id2)
+		      const struct pubkey *id2,
+		      u64 satoshis)
 {
 	struct chan *chan = tal(rstate, struct chan);
 	int n1idx = pubkey_idx(id1, id2);
@@ -306,7 +307,7 @@ struct chan *new_chan(struct routing_state *rstate,
 	chan->txout_script = NULL;
 	chan->channel_announce = NULL;
 	chan->channel_announcement_index = 0;
-	chan->satoshis = 0;
+	chan->satoshis = satoshis;
 	chan->local_disabled = false;
 
 	n = tal_count(n2->chans);
@@ -740,9 +741,8 @@ bool routing_add_channel_announcement(struct routing_state *rstate,
 	 * channel_announcements.  See handle_channel_announcement. */
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_chan(rstate, &scid, &node_id_1, &node_id_2);
+		chan = new_chan(rstate, &scid, &node_id_1, &node_id_2, satoshis);
 
-	chan->satoshis = satoshis;
 	/* Channel is now public. */
 	chan->channel_announce = tal_dup_arr(chan, u8, msg, tal_count(msg), 0);
 
@@ -1679,7 +1679,6 @@ void handle_local_add_channel(struct routing_state *rstate, const u8 *msg)
 {
 	struct short_channel_id scid;
 	struct pubkey remote_node_id;
-	struct chan *chan;
 	u64 satoshis;
 
 	if (!fromwire_gossip_local_add_channel(msg, &scid, &remote_node_id,
@@ -1699,6 +1698,5 @@ void handle_local_add_channel(struct routing_state *rstate, const u8 *msg)
 		     type_to_string(tmpctx, struct short_channel_id, &scid));
 
 	/* Create new (unannounced) channel */
-	chan = new_chan(rstate, &scid, &rstate->local_id, &remote_node_id);
-	chan->satoshis = satoshis;
+	new_chan(rstate, &scid, &rstate->local_id, &remote_node_id, satoshis);
 }

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -408,7 +408,7 @@ static void bfg_one_edge(struct node *node,
 			/* Skip a channels if it indicated that it won't route
 			 * the requeuested amount. */
 			continue;
-		} else if (requiredcap + risk >= MAX_MSATOSHI) {
+		} else if (requiredcap >= MAX_MSATOSHI) {
 			SUPERVERBOSE("...extreme %"PRIu64
 				     " + fee %"PRIu64
 				     " + risk %"PRIu64" ignored",

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -403,6 +403,10 @@ static void bfg_one_edge(struct node *node,
 			/* Skip this edge if the channel has insufficient
 			 * capacity to route the required amount */
 			continue;
+		} else if (requiredcap < c->htlc_minimum_msat) {
+			/* Skip a channels if it indicated that it won't route
+			 * the requeuested amount. */
+			continue;
 		} else if (requiredcap + risk >= MAX_MSATOSHI) {
 			SUPERVERBOSE("...extreme %"PRIu64
 				     " + fee %"PRIu64

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1669,9 +1669,13 @@ void handle_local_add_channel(struct routing_state *rstate, const u8 *msg)
 {
 	struct short_channel_id scid;
 	struct pubkey remote_node_id;
+	struct chan *chan;
+	u64 satoshis;
 
-	if (!fromwire_gossip_local_add_channel(msg, &scid, &remote_node_id)) {
-		status_broken("Unable to parse local_add_channel message: %s", tal_hex(msg, msg));
+	if (!fromwire_gossip_local_add_channel(msg, &scid, &remote_node_id,
+					       &satoshis)) {
+		status_broken("Unable to parse local_add_channel message: %s",
+			      tal_hex(msg, msg));
 		return;
 	}
 
@@ -1685,5 +1689,6 @@ void handle_local_add_channel(struct routing_state *rstate, const u8 *msg)
 		     type_to_string(tmpctx, struct short_channel_id, &scid));
 
 	/* Create new (unannounced) channel */
-	new_chan(rstate, &scid, &rstate->local_id, &remote_node_id);
+	chan = new_chan(rstate, &scid, &rstate->local_id, &remote_node_id);
+	chan->satoshis = satoshis;
 }

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -206,10 +206,17 @@ struct routing_state *new_routing_state(const tal_t *ctx,
 					const struct pubkey *local_id,
 					u32 prune_timeout);
 
+/**
+ * Add a new bidirectional channel from id1 to id2 with the given
+ * short_channel_id and capacity to the local network view. The channel may not
+ * already exist, and might create the node entries for the two endpoints, if
+ * they do not exist yet.
+ */
 struct chan *new_chan(struct routing_state *rstate,
 		      const struct short_channel_id *scid,
 		      const struct pubkey *id1,
-		      const struct pubkey *id2);
+		      const struct pubkey *id2,
+		      u64 satoshis);
 
 /* Handlers for incoming messages */
 

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -66,7 +66,7 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
-bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED)
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -154,7 +154,7 @@ static void add_connection(struct routing_state *rstate,
 	memset(&scid, 0, sizeof(scid));
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_chan(rstate, &scid, from, to);
+		chan = new_chan(rstate, &scid, from, to, 1000000);
 
 	c = &chan->half[pubkey_idx(from, to)];
 	c->base_fee = base_fee;

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -30,7 +30,7 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
-bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED)
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -121,13 +121,11 @@ get_or_make_connection(struct routing_state *rstate,
 		abort();
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_chan(rstate, &scid, from_id, to_id);
+		chan = new_chan(rstate, &scid, from_id, to_id, satoshis);
 
 	/* Make sure it's seen as initialized (update non-NULL). */
 	chan->half[idx].channel_update = (void *)chan;
 	chan->half[idx].htlc_minimum_msat = 0;
-
-	chan->satoshis = satoshis;
 
 	return &chan->half[pubkey_idx(from_id, to_id)];
 }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -28,7 +28,7 @@ bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNE
 bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
-bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED)
+bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_local_add_channel called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_store_channel_announcement */
 bool fromwire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **announcement UNNEEDED, u64 *satoshis UNNEEDED)

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -119,9 +119,7 @@ static void add_connection(struct routing_state *rstate,
 
 	chan = get_channel(rstate, &scid);
 	if (!chan)
-		chan = new_chan(rstate, &scid, from, to);
-
-	chan->satoshis = 100000;
+		chan = new_chan(rstate, &scid, from, to, 100000);
 
 	c = &chan->half[pubkey_idx(from, to)];
 	/* Make sure it's seen as initialized (update non-NULL). */

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -121,6 +121,8 @@ static void add_connection(struct routing_state *rstate,
 	if (!chan)
 		chan = new_chan(rstate, &scid, from, to);
 
+	chan->satoshis = 100000;
+
 	c = &chan->half[pubkey_idx(from, to)];
 	/* Make sure it's seen as initialized (update non-NULL). */
 	c->channel_update = (void *)c;

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -130,6 +130,7 @@ static void add_connection(struct routing_state *rstate,
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
 	c->flags = get_channel_direction(from, to);
+	c->htlc_minimum_msat = 0;
 }
 
 /* Returns chan connecting from and to: *idx set to refer


### PR DESCRIPTION
So far we were ignoring the channel capacity and the self-declared `htlc_minimum_msat`. This PR changes that, returning fewer results when looking for a route, and reducing the number of failed attempts.