### PR TITLE
lightningd: add status field, show when we're syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Documentation: Added CHANGELOG.md
-- JSON API: `getinfo` has new fields `alias` and `color`.
+- JSON API: `getinfo` has new fields `alias`, `status` and `color`.
 - JSON API: `listpeers` has new fields `global_features` and `local_features`.
 - JSON API:`listnodes` has new field `global_features`.
 - Protocol: gossipd now deliberately delays spamming with `channel_update`.

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -92,6 +92,7 @@ ALL_OBJS += $(LIGHTNINGD_OBJS)
 LIGHTNINGD_HEADERS_NOGEN =			\
 	$(LIGHTNINGD_SRC:.c=.h)			\
 	lightningd/channel_state.h			\
+	lightningd/status.h			\
 	lightningd/jsonrpc_errors.h
 
 # Generated headers

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -67,6 +67,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/lightningd.c			\
 	lightningd/log.c			\
 	lightningd/log_status.c			\
+	lightningd/status.c			\
 	lightningd/onchain_control.c		\
 	lightningd/opening_control.c		\
 	lightningd/options.c			\

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -353,6 +353,9 @@ static void updates_complete(struct chain_topology *topo)
 		topo->prev_tip = topo->tip;
 	}
 
+	/* Let lightningd know that we're done syncing */
+	*topo->lightningd_status = LIGHTNINGD_STATUS_READY;
+
 	/* Try again soon. */
 	next_topology_timer(topo);
 }
@@ -422,6 +425,10 @@ static struct block *new_block(struct chain_topology *topo,
 	log_debug(topo->log, "Adding block %u: %s",
 		  height,
 		  type_to_string(tmpctx, struct bitcoin_blkid, &b->blkid));
+
+	/* Update lightningd status to let them know we're still adding blocks */
+	*topo->lightningd_status = LIGHTNINGD_STATUS_SYNCING;
+
 	assert(!block_map_get(&topo->block_map, &b->blkid));
 	b->next = NULL;
 	b->prev = NULL;

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -706,10 +706,12 @@ struct chain_topology *new_topology(struct lightningd *ld, struct log *log)
 
 void setup_topology(struct chain_topology *topo,
 		    struct timers *timers,
-		    u32 min_blockheight, u32 max_blockheight)
+		    u32 min_blockheight, u32 max_blockheight,
+		    enum lightningd_status *lightningd_status)
 {
 	memset(&topo->feerate, 0, sizeof(topo->feerate));
 	topo->timers = timers;
+	topo->lightningd_status = lightningd_status;
 
 	topo->min_blockheight = min_blockheight;
 	topo->max_blockheight = max_blockheight;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -8,6 +8,7 @@
 #include <ccan/structeq/structeq.h>
 #include <ccan/time/time.h>
 #include <jsmn.h>
+#include <lightningd/status.h>
 #include <lightningd/watch.h>
 #include <math.h>
 #include <stddef.h>
@@ -116,6 +117,9 @@ struct chain_topology {
 	/* Force a particular fee rate regardless of estimatefee (satoshis/kw) */
 	u32 *dev_override_fee_rate;
 #endif
+
+	/* lightningd's status so we can update it when we're done syncing */
+	int *lightningd_status;
 };
 
 /* Information relevant to locating a TX in a blockchain. */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -119,7 +119,7 @@ struct chain_topology {
 #endif
 
 	/* lightningd's status so we can update it when we're done syncing */
-	int *lightningd_status;
+	enum lightningd_status *lightningd_status;
 };
 
 /* Information relevant to locating a TX in a blockchain. */
@@ -153,7 +153,8 @@ void broadcast_tx(struct chain_topology *topo,
 
 struct chain_topology *new_topology(struct lightningd *ld, struct log *log);
 void setup_topology(struct chain_topology *topology, struct timers *timers,
-		    u32 min_blockheight, u32 max_blockheight);
+		    u32 min_blockheight, u32 max_blockheight,
+		    enum lightningd_status *lightningd_status);
 
 void begin_topology(struct chain_topology *topo);
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -25,6 +25,7 @@
 #include <lightningd/log.h>
 #include <lightningd/options.h>
 #include <lightningd/param.h>
+#include <lightningd/status.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -158,6 +159,7 @@ static void json_getinfo(struct command *cmd,
 	json_add_string(response, "version", version());
 	json_add_num(response, "blockheight", get_block_height(cmd->ld->topology));
 	json_add_string(response, "network", get_chainparams(cmd->ld)->network_name);
+	json_add_string(response, "status", lightningd_status_to_str(cmd->ld->status));
 	json_object_end(response);
 	command_success(cmd, response);
 }

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -90,6 +90,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->pure_tor_setup = false;
 	ld->tor_service_password = NULL;
 	ld->max_funding_unconfirmed = 2016;
+	ld->status = LIGHTNINGD_STATUS_READY;
 
 	return ld;
 }

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -413,7 +413,8 @@ int main(int argc, char *argv[])
 	db_commit_transaction(ld->wallet->db);
 
 	/* Initialize block topology (does its own transaction) */
-	setup_topology(ld->topology, &ld->timers, min_blockheight, max_blockheight);
+	setup_topology(ld->topology, &ld->timers, min_blockheight,
+		       max_blockheight, &ld->status);
 
 	/* Create RPC socket (if any) */
 	setup_jsonrpc(ld, ld->rpc_filename);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -8,6 +8,7 @@
 #include <ccan/timer/timer.h>
 #include <common/json_escaped.h>
 #include <lightningd/htlc_end.h>
+#include <lightningd/status.h>
 #include <stdio.h>
 #include <wallet/txfilter.h>
 #include <wallet/wallet.h>
@@ -203,6 +204,8 @@ struct lightningd {
 	bool use_proxy_always;
 	char *tor_service_password;
 	bool pure_tor_setup;
+
+	enum lightningd_status status;
 };
 
 const struct chainparams *get_chainparams(const struct lightningd *ld);

--- a/lightningd/status.c
+++ b/lightningd/status.c
@@ -1,0 +1,16 @@
+
+#include <assert.h>
+#include <lightningd/status.h>
+
+
+const char *lightningd_status_to_str(enum lightningd_status status) {
+	switch (status) {
+	case LIGHTNINGD_STATUS_READY:
+		return "ready";
+	case LIGHTNINGD_STATUS_SYNCING:
+		return "syncing";
+	}
+
+	assert(!"lightningd_status_to_str called with an unknown status");
+	return "unknown";
+}

--- a/lightningd/status.h
+++ b/lightningd/status.h
@@ -1,0 +1,14 @@
+
+
+#ifndef LIGHTNING_LIGHTNINGD_STATUS_H
+#define LIGHTNING_LIGHTNINGD_STATUS_H
+
+#include "config.h"
+
+enum lightningd_status {
+	LIGHTNINGD_STATUS_READY,
+	LIGHTNINGD_STATUS_SYNCING
+};
+
+#endif /* LIGHTNING_LIGHTNINGD_STATUS_H */
+

--- a/lightningd/status.h
+++ b/lightningd/status.h
@@ -10,5 +10,7 @@ enum lightningd_status {
 	LIGHTNINGD_STATUS_SYNCING
 };
 
+const char *lightningd_status_to_str(enum lightningd_status status);
+
 #endif /* LIGHTNING_LIGHTNINGD_STATUS_H */
 

--- a/lightningd/test/run-find_my_path.c
+++ b/lightningd/test/run-find_my_path.c
@@ -105,7 +105,8 @@ void setup_jsonrpc(struct lightningd *ld UNNEEDED, const char *rpc_filename UNNE
 { fprintf(stderr, "setup_jsonrpc called!\n"); abort(); }
 /* Generated stub for setup_topology */
 void setup_topology(struct chain_topology *topology UNNEEDED, struct timers *timers UNNEEDED,
-		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)
+		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED,
+		    enum lightningd_status *lightningd_status UNNEEDED)
 { fprintf(stderr, "setup_topology called!\n"); abort(); }
 /* Generated stub for subd_shutdown */
 void subd_shutdown(struct subd *subd UNNEEDED, unsigned int seconds UNNEEDED)

--- a/tests/test_lightningd.py
+++ b/tests/test_lightningd.py
@@ -4939,6 +4939,19 @@ class LightningDTests(BaseLightningDTests):
         assert l1.rpc.listnodes()['nodes'] == []
         assert l2.rpc.listnodes()['nodes'] == []
 
+    def test_sync_status(self):
+        "Make sure the status says syncing when we're adding blocks"
+        l1 = self.node_factory.get_node(random_hsm=True)
+
+        height = bitcoind.rpc.getblockcount()
+
+        assert "syncing" == l1.rpc.getinfo()['status']
+
+        l1.daemon.wait_for_log('Adding block {}'.format(height))
+
+        time.sleep(1)
+        assert "ready" == l1.rpc.getinfo()['status']
+
     @flaky
     @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
     def test_blockchaintrack(self):


### PR DESCRIPTION
This patchset adds a status field to lightningd, which is available in `getinfo`.

See #1652 for motivation.

Fixes #1652

This is a rework of #1789 to use enums instead of bit flags for the status as recommended by @rustyrussell 
