### PR TITLE
Use snprintf(...) instead of sprintf(...)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,10 @@ check-setup_locale:
 check-tmpctx:
 	@if git grep -n 'tal_free[(]tmpctx)' | grep -Ev '^ccan/|/test/|^common/daemon.c:|^common/utils.c:'; then echo "Don't free tmpctx!">&2; exit 1; fi
 
-check-source: check-makefile check-source-bolt check-whitespace check-markdown check-spelling check-python check-includes check-cppcheck check-shellcheck check-setup_locale check-tmpctx
+check-discouraged-functions:
+	@if git grep -E "[^a-z_/](fgets|fputs|gets|scanf|sprintf)\(" -- "*.c" "*.h" ":(exclude)ccan/"; then exit 1; fi
+
+check-source: check-makefile check-source-bolt check-whitespace check-markdown check-spelling check-python check-includes check-cppcheck check-shellcheck check-setup_locale check-tmpctx check-discouraged-functions
 
 full-check: check check-source
 

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -1082,7 +1082,7 @@ const char *channel_add_err_name(enum channel_add_err e)
 		if (enum_channel_add_err_names[i].v == e)
 			return enum_channel_add_err_names[i].name;
 	}
-	sprintf(invalidbuf, "INVALID %i", e);
+	snprintf(invalidbuf, sizeof(invalidbuf), "INVALID %i", e);
 	return invalidbuf;
 }
 
@@ -1094,6 +1094,6 @@ const char *channel_remove_err_name(enum channel_remove_err e)
 		if (enum_channel_remove_err_names[i].v == e)
 			return enum_channel_remove_err_names[i].name;
 	}
-	sprintf(invalidbuf, "INVALID %i", e);
+	snprintf(invalidbuf, sizeof(invalidbuf), "INVALID %i", e);
 	return invalidbuf;
 }

--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 	 * not need to have lightningd running in this case. */
 	if (streq(method, "help") && format == HUMAN && argc >= 3) {
 		char command[strlen(argv[2]) + sizeof("lightning-")];
-		sprintf(command, "lightning-%s", argv[2]);
+		snprintf(command, sizeof(command), "lightning-%s", argv[2]);
 		exec_man(command);
 	}
 

--- a/common/json_escaped.c
+++ b/common/json_escaped.c
@@ -89,7 +89,7 @@ static struct json_escaped *escape(const tal_t *ctx,
 			break;
 		default:
 			if ((unsigned)str[i] < ' ' || str[i] == 127) {
-				sprintf(esc->s + n, "\\u%04X", str[i]);
+				snprintf(esc->s + n, 7, "\\u%04X", str[i]);
 				n += 5;
 				continue;
 			}

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -350,7 +350,7 @@ static void do_one_estimatefee(struct bitcoind *bitcoind,
 {
 	char blockstr[STR_MAX_CHARS(u32)];
 
-	sprintf(blockstr, "%u", efee->blocks[efee->i]);
+	snprintf(blockstr, sizeof(blockstr), "%u", efee->blocks[efee->i]);
 	start_bitcoin_cli(bitcoind, NULL, process_estimatefee, false, NULL, efee,
 			  "estimatesmartfee", blockstr, efee->estmode[efee->i],
 			  NULL);
@@ -682,7 +682,7 @@ void bitcoind_getblockhash_(struct bitcoind *bitcoind,
 			    void *arg)
 {
 	char str[STR_MAX_CHARS(height)];
-	sprintf(str, "%u", height);
+	snprintf(str, sizeof(str), "%u", height);
 
 	start_bitcoin_cli(bitcoind, NULL, process_getblockhash, true, cb, arg,
 			  "getblockhash", str, NULL);

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -360,12 +360,12 @@ static void log_one_line(unsigned int skipped,
 	char buf[101];
 
 	if (skipped) {
-		sprintf(buf, "%s... %u skipped...", data->prefix, skipped);
+		snprintf(buf, sizeof(buf), "%s... %u skipped...", data->prefix, skipped);
 		write_all(data->fd, buf, strlen(buf));
 		data->prefix = "\n";
 	}
 
-	sprintf(buf, "%s+%lu.%09u %s%s: ",
+	snprintf(buf, sizeof(buf), "%s+%lu.%09u %s%s: ",
 		data->prefix,
 		(unsigned long)diff.ts.tv_sec,
 		(unsigned)diff.ts.tv_nsec,
@@ -501,7 +501,7 @@ static void log_dump_to_file(int fd, const struct log_book *lr)
 	}
 
 	start = lr->init_time.ts.tv_sec;
-	len = sprintf(buf, "%zu bytes, %s", lr->mem_used, ctime(&start));
+	len = snprintf(buf, sizeof(buf), "%zu bytes, %s", lr->mem_used, ctime(&start));
 	write_all(fd, buf, len);
 
 	/* ctime includes \n... WTF? */
@@ -579,7 +579,7 @@ static void json_add_time(struct json_result *result, const char *fieldname,
 {
 	char timebuf[100];
 
-	sprintf(timebuf, "%lu.%09u",
+	snprintf(timebuf, sizeof(timebuf), "%lu.%09u",
 		(unsigned long)ts.tv_sec,
 		(unsigned)ts.tv_nsec);
 	json_add_string(result, fieldname, timebuf);

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -15,7 +15,7 @@ static void json_add_ptr(struct json_result *response, const char *name,
 			 const void *ptr)
 {
 	char ptrstr[STR_MAX_CHARS(void *)];
-	sprintf(ptrstr, "%p", ptr);
+	snprintf(ptrstr, sizeof(ptrstr), "%p", ptr);
 	json_add_string(response, name, ptrstr);
 }
 

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -703,7 +703,7 @@ const char *{enumname}_name(int e)
 \t{cases}
 \t}}
 
-\tsprintf(invalidbuf, "INVALID %i", e);
+\tsnprintf(invalidbuf, sizeof(invalidbuf), "INVALID %i", e);
 \treturn invalidbuf;
 }}
 


### PR DESCRIPTION
Use `snprintf(...)` instead of `sprintf(...)`.

Better safe than sorry.

Before:

```
$ git grep [^a-z/]sprintf -- "*.h" "*.c" | grep -v ccan/ | wc -l
11
$ git grep [^a-z/]snprintf -- "*.h" "*.c" | grep -v ccan/ | wc -l
5
```

After:

```
$ git grep [^a-z/]sprintf -- "*.h" "*.c" | grep -v ccan/ | wc -l
0
$ git grep [^a-z/]snprintf -- "*.h" "*.c" | grep -v ccan/ | wc -l
16
```

**Note to reviewers**: The `snprintf` call in `common/json_escaped.c` is the only not using `sizeof(…)`.