### PR TITLE
Fix example docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ services:
   clightning_bitcoin:
     image: elementsproject/lightningd
     command:
-      - lightningd
       - --bitcoin-rpcconnect=bitcoind
       - --bitcoin-rpcuser=rpcuser
       - --bitcoin-rpcpassword=rpcpass


### PR DESCRIPTION
docker-compose treats `command` field as args to `ENTRYPOINT` if `ENTRYPOINT` exists in Dockerfile.
And, [c-lightning's Dockerfile](https://github.com/ElementsProject/lightning/blob/master/Dockerfile#L103) contains `ENTRYPOINT`.
So, removed line causes `lightningd lightningd --bitcoin-rpcconnect=bitcoind ...` to be executed and lightningd returns an error

> lightningd: no arguments accepted