### PR TITLE
Pre openingd enhance cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VG_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes --erro
 endif
 
 ifeq ($(DEVELOPER),1)
-DEV_CFLAGS=-DCCAN_TAKE_DEBUG=1
+DEV_CFLAGS=-DCCAN_TAKE_DEBUG=1 -DCCAN_TAL_DEBUG=1
 else
 DEV_CFLAGS=
 endif

--- a/channeld/channel.c
+++ b/channeld/channel.c
@@ -2488,9 +2488,7 @@ int main(int argc, char *argv[])
 		if (msg) {
 			status_trace("Now dealing with deferred gossip %u",
 				     fromwire_peektype(msg));
-			handle_gossip_msg(take(msg), &peer->cs,
-					  sync_crypto_write_arg,
-					  NULL);
+			handle_gossip_msg(PEER_FD, &peer->cs, take(msg));
 			continue;
 		}
 
@@ -2523,9 +2521,7 @@ int main(int argc, char *argv[])
 			 * connection comes in. */
 			if (!msg)
 				peer_failed_connection_lost();
-			handle_gossip_msg(msg, &peer->cs,
-					  sync_crypto_write_arg,
-					  peer);
+			handle_gossip_msg(PEER_FD, &peer->cs, take(msg));
 		} else if (FD_ISSET(PEER_FD, &rfds)) {
 			/* This could take forever, but who cares? */
 			msg = sync_crypto_read(tmpctx, &peer->cs, PEER_FD);

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -107,8 +107,7 @@ static void do_reconnect(struct crypto_state *cs,
 	msg = towire_channel_reestablish(NULL, channel_id,
 					 next_index[LOCAL],
 					 revocations_received);
-	if (!sync_crypto_write(cs, PEER_FD, take(msg)))
-		peer_failed_connection_lost();
+	sync_crypto_write(cs, PEER_FD, take(msg));
 
 	/* They might have already send reestablish, which triggered us */
 	while (!channel_reestablish) {
@@ -189,8 +188,7 @@ static void send_offer(struct crypto_state *cs,
 	status_trace("sending fee offer %"PRIu64, fee_to_offer);
 
 	msg = towire_closing_signed(NULL, channel_id, fee_to_offer, &our_sig);
-	if (!sync_crypto_write(cs, PEER_FD, take(msg)))
-		peer_failed_connection_lost();
+	sync_crypto_write(cs, PEER_FD, take(msg));
 }
 
 static void tell_master_their_offer(const secp256k1_ecdsa_signature *their_sig,

--- a/closingd/closing.c
+++ b/closingd/closing.c
@@ -90,8 +90,7 @@ static u8 *closing_read_peer_msg(const tal_t *ctx,
 		msg = peer_or_gossip_sync_read(ctx, PEER_FD, GOSSIP_FD,
 					       cs, &from_gossipd);
 		if (from_gossipd) {
-			handle_gossip_msg(msg, cs, sync_crypto_write_arg,
-					  NULL);
+			handle_gossip_msg(PEER_FD, cs, take(msg));
 			continue;
 		}
 		if (!handle_peer_gossip_or_error(PEER_FD, GOSSIP_FD, cs,

--- a/common/crypto_sync.c
+++ b/common/crypto_sync.c
@@ -2,6 +2,7 @@
 #include <common/crypto_sync.h>
 #include <common/cryptomsg.h>
 #include <common/dev_disconnect.h>
+#include <common/peer_failed.h>
 #include <common/status.h>
 #include <common/utils.h>
 #include <errno.h>
@@ -9,14 +10,13 @@
 #include <wire/wire.h>
 #include <wire/wire_sync.h>
 
-bool sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES)
+void sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES)
 {
 #if DEVELOPER
 	bool post_sabotage = false;
 	int type = fromwire_peektype(msg);
 #endif
 	u8 *enc;
-	bool ret;
 
 	status_peer_io(LOG_IO_OUT, msg);
 	enc = cryptomsg_encrypt_msg(NULL, cs, msg);
@@ -25,7 +25,7 @@ bool sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES)
 	switch (dev_disconnect(type)) {
 	case DEV_DISCONNECT_BEFORE:
 		dev_sabotage_fd(fd);
-		return false;
+		peer_failed_connection_lost();
 	case DEV_DISCONNECT_DROPPKT:
 		enc = tal_free(enc); /* FALL THRU */
 	case DEV_DISCONNECT_AFTER:
@@ -38,14 +38,14 @@ bool sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES)
 		break;
 	}
 #endif
-	ret = write_all(fd, enc, tal_count(enc));
+	if (!write_all(fd, enc, tal_count(enc)))
+		peer_failed_connection_lost();
 	tal_free(enc);
 
 #if DEVELOPER
 	if (post_sabotage)
 		dev_sabotage_fd(fd);
 #endif
-	return ret;
 }
 
 u8 *sync_crypto_read(const tal_t *ctx, struct crypto_state *cs, int fd)
@@ -55,24 +55,24 @@ u8 *sync_crypto_read(const tal_t *ctx, struct crypto_state *cs, int fd)
 
 	if (!read_all(fd, hdr, sizeof(hdr))) {
 		status_trace("Failed reading header: %s", strerror(errno));
-		return NULL;
+		peer_failed_connection_lost();
 	}
 
 	if (!cryptomsg_decrypt_header(cs, hdr, &len)) {
 		status_trace("Failed hdr decrypt with rn=%"PRIu64, cs->rn-1);
-		return NULL;
+		peer_failed_connection_lost();
 	}
 
 	enc = tal_arr(ctx, u8, len + 16);
 	if (!read_all(fd, enc, tal_count(enc))) {
 		status_trace("Failed reading body: %s", strerror(errno));
-		return tal_free(enc);
+		peer_failed_connection_lost();
 	}
 
 	dec = cryptomsg_decrypt_body(ctx, cs, enc);
 	tal_free(enc);
 	if (!dec)
-		status_trace("Failed body decrypt with rn=%"PRIu64, cs->rn-2);
+		peer_failed_connection_lost();
 	else
 		status_peer_io(LOG_IO_IN, dec);
 

--- a/common/crypto_sync.h
+++ b/common/crypto_sync.h
@@ -6,7 +6,10 @@
 
 struct crypto_state;
 
-bool sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES);
+/* Exits with peer_failed_connection_lost() if write fails. */
+void sync_crypto_write(struct crypto_state *cs, int fd, const void *msg TAKES);
+
+/* Exits with peer_failed_connection_lost() if can't read packet. */
 u8 *sync_crypto_read(const tal_t *ctx, struct crypto_state *cs, int fd);
 
 #endif /* LIGHTNING_COMMON_CRYPTO_SYNC_H */

--- a/common/memleak.c
+++ b/common/memleak.c
@@ -91,7 +91,7 @@ static void children_into_htable(const void *exclude1, const void *exclude2,
 				continue;
 
 			/* ccan/io allocates pollfd array. */
-			if (streq(name, "struct pollfd[]") && !tal_parent(i))
+			if (strends(name, "struct pollfd[]") && !tal_parent(i))
 				continue;
 
 			/* Don't add tmpctx. */

--- a/common/peer_failed.c
+++ b/common/peer_failed.c
@@ -36,8 +36,12 @@ void peer_failed_received_errmsg(int peer_fd, int gossip_fd,
 				 const char *desc,
 				 const struct channel_id *channel_id)
 {
-	u8 *msg = towire_status_peer_error(NULL, channel_id,
-					   desc, cs, NULL);
+	static const struct channel_id all_channels;
+	u8 *msg;
+
+	if (!channel_id)
+		channel_id = &all_channels;
+	msg = towire_status_peer_error(NULL, channel_id, desc, cs, NULL);
 	peer_billboard(true, "Received error from peer: %s", desc);
 	status_send_fatal(take(msg), peer_fd, gossip_fd);
 }

--- a/common/peer_failed.h
+++ b/common/peer_failed.h
@@ -21,7 +21,8 @@ void peer_failed_(int peer_fd, int gossip_fd,
 		  const char *fmt, ...)
 	PRINTF_FMT(5,6) NORETURN;
 
-/* We're failing because peer sent us an error message */
+/* We're failing because peer sent us an error message: NULL
+ * channel_id means all channels. */
 void peer_failed_received_errmsg(int peer_fd, int gossip_fd,
 				 struct crypto_state *cs,
 				 const char *desc,

--- a/common/read_peer_msg.h
+++ b/common/read_peer_msg.h
@@ -84,7 +84,7 @@ bool handle_peer_gossip_or_error(int peer_fd, int gossip_fd,
 #define read_peer_msg(ctx, cs, chanid, send_reply, arg)			\
 	read_peer_msg_((ctx), PEER_FD, GOSSIP_FD, (cs),			\
 		       (chanid),					\
-		       typesafe_cb_preargs(bool, void *, (send_reply), (arg), \
+		       typesafe_cb_preargs(void, void *, (send_reply), (arg), \
 					   struct crypto_state *, int,	\
 					   const u8 *),			\
 		       arg)
@@ -93,13 +93,13 @@ bool handle_peer_gossip_or_error(int peer_fd, int gossip_fd,
 #define read_peer_msg_nogossip(ctx, cs, chanid, send_reply, arg)	\
 	read_peer_msg_((ctx), PEER_FD, -1, (cs),			\
 		       (chanid),					\
-		       typesafe_cb_preargs(bool, void *, (send_reply), (arg), \
+		       typesafe_cb_preargs(void, void *, (send_reply), (arg), \
 					   struct crypto_state *, int,	\
 					   const u8 *),			\
 		       arg)
 
 /* Helper: sync_crypto_write, with extra args it ignores */
-bool sync_crypto_write_arg(struct crypto_state *cs, int fd, const u8 *TAKES,
+void sync_crypto_write_arg(struct crypto_state *cs, int fd, const u8 *TAKES,
 			   void *unused);
 
 /* Handler for a gossip msg; used by channeld since it queues them. */
@@ -114,7 +114,7 @@ bool sync_crypto_write_arg(struct crypto_state *cs, int fd, const u8 *TAKES,
 void handle_gossip_msg_(const u8 *msg TAKES,
 			int peer_fd,
 			struct crypto_state *cs,
-			bool (*send_msg)(struct crypto_state *cs, int fd,
+			void (*send_msg)(struct crypto_state *cs, int fd,
 					 const u8 *TAKES, void *arg),
 			void *arg);
 
@@ -122,7 +122,7 @@ u8 *read_peer_msg_(const tal_t *ctx,
 		   int peer_fd, int gossip_fd,
 		   struct crypto_state *cs,
 		   const struct channel_id *channel,
-		   bool (*send_reply)(struct crypto_state *cs, int fd,
+		   void (*send_reply)(struct crypto_state *cs, int fd,
 				      const u8 *TAKES,  void *arg),
 		   void *arg);
 

--- a/common/read_peer_msg.h
+++ b/common/read_peer_msg.h
@@ -9,6 +9,69 @@ struct crypto_state;
 struct channel_id;
 
 /**
+ * peer_or_gossip_sync_read - read a peer message, or maybe a gossip msg.
+ * @ctx: context to allocate return packet from.
+ * @peer_fd, @gossip_fd: peer and gossip fd.
+ * @cs: the cryptostate (updated)
+ * @from_gossipd: true if the msg was from gossipd, otherwise false.
+ *
+ * Will call peer_failed_connection_lost() or
+ * status_failed(STATUS_FAIL_GOSSIP_IO) or return a message.
+ *
+ * Usually, you should call handle_gossip_msg if *@from_gossipd is
+ * true, otherwise if is_peer_error() handle the error, otherwise if
+ * is_msg_for_gossipd() then send to gossipd, otherwise if is
+ * is_wrong_channel() send that as a reply.  Otherwise it should be
+ * a valid message.
+ */
+u8 *peer_or_gossip_sync_read(const tal_t *ctx,
+			     int peer_fd, int gossip_fd,
+			     struct crypto_state *cs,
+			     bool *from_gossipd);
+
+/**
+ * is_peer_error - if it's an error, describe if it applies to this channel.
+ * @ctx: context to allocate return from.
+ * @msg: the peer message.
+ * @channel_id: the channel id of the current channel.
+ * @desc: set to non-NULL if this describes a channel we care about.
+ * @all_channels: set to true if this applies to all channels.
+ *
+ * If @desc is NULL, ignore this message.  Otherwise, that's usually passed
+ * to peer_failed_received_errmsg().
+ */
+bool is_peer_error(const tal_t *ctx, const u8 *msg,
+		   const struct channel_id *channel_id,
+		   char **desc, bool *all_channels);
+
+/**
+ * is_wrong_channel - if it's a message about a different channel, return true
+ * @msg: the peer message.
+ * @channel_id: the channel id of the current channel.
+ * @actual: set to the actual channel id if this returns false.
+ *
+ * Note that this only handles some message types, returning false for others.
+ */
+bool is_wrong_channel(const u8 *msg, const struct channel_id *expected,
+		      struct channel_id *actual);
+
+
+/**
+ * handle_peer_gossip_or_error - simple handler for all the above cases.
+ * @peer_fd, @gossip_fd: peer and gossip fd.
+ * @cs: the cryptostate (updated)
+ * @msg: the peer message (only taken if returns true).
+ *
+ * This returns true if it handled the packet: a gossip packet (forwarded
+ * to gossipd), an error packet (causes peer_failed_received_errmsg or
+ * ignored), or a message about the wrong channel (sends sync error reply).
+ */
+bool handle_peer_gossip_or_error(int peer_fd, int gossip_fd,
+				 struct crypto_state *cs,
+				 const struct channel_id *channel_id,
+				 const u8 *msg TAKES);
+
+/**
  * read_peer_msg - read & decode in a peer message, handling common ones.
  * @ctx: context to allocate return packet from.
  * @cs: the cryptostate (updated)

--- a/common/read_peer_msg.h
+++ b/common/read_peer_msg.h
@@ -3,7 +3,6 @@
 #include "config.h"
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
-#include <ccan/typesafe_cb/typesafe_cb.h>
 
 struct crypto_state;
 struct channel_id;
@@ -71,59 +70,8 @@ bool handle_peer_gossip_or_error(int peer_fd, int gossip_fd,
 				 const struct channel_id *channel_id,
 				 const u8 *msg TAKES);
 
-/**
- * read_peer_msg - read & decode in a peer message, handling common ones.
- * @ctx: context to allocate return packet from.
- * @cs: the cryptostate (updated)
- * @chanid: the channel id (for identifying errors)
- * @send_reply: the way to send a reply packet (eg. sync_crypto_write_arg)
- *
- * This returns NULL if it handled the message, so it's normally called in
- * a loop.
- */
-#define read_peer_msg(ctx, cs, chanid, send_reply, arg)			\
-	read_peer_msg_((ctx), PEER_FD, GOSSIP_FD, (cs),			\
-		       (chanid),					\
-		       typesafe_cb_preargs(void, void *, (send_reply), (arg), \
-					   struct crypto_state *, int,	\
-					   const u8 *),			\
-		       arg)
-
-/* Like the above, but don't read from GOSSIP_FD */
-#define read_peer_msg_nogossip(ctx, cs, chanid, send_reply, arg)	\
-	read_peer_msg_((ctx), PEER_FD, -1, (cs),			\
-		       (chanid),					\
-		       typesafe_cb_preargs(void, void *, (send_reply), (arg), \
-					   struct crypto_state *, int,	\
-					   const u8 *),			\
-		       arg)
-
-/* Helper: sync_crypto_write, with extra args it ignores */
-void sync_crypto_write_arg(struct crypto_state *cs, int fd, const u8 *TAKES,
-			   void *unused);
-
-/* Handler for a gossip msg; used by channeld since it queues them. */
-#define handle_gossip_msg(msg, cs, send_reply, arg)			\
-	handle_gossip_msg_((msg), PEER_FD, (cs),			\
-			   typesafe_cb_preargs(bool, void *,		\
-					       (send_reply), (arg),	\
-					       struct crypto_state *, int, \
-					       const u8 *),		\
-			   arg)
-
-void handle_gossip_msg_(const u8 *msg TAKES,
-			int peer_fd,
-			struct crypto_state *cs,
-			void (*send_msg)(struct crypto_state *cs, int fd,
-					 const u8 *TAKES, void *arg),
-			void *arg);
-
-u8 *read_peer_msg_(const tal_t *ctx,
-		   int peer_fd, int gossip_fd,
-		   struct crypto_state *cs,
-		   const struct channel_id *channel,
-		   void (*send_reply)(struct crypto_state *cs, int fd,
-				      const u8 *TAKES,  void *arg),
-		   void *arg);
+/* We got this message from gossipd: forward/quit as it asks. */
+void handle_gossip_msg(int peer_fd, struct crypto_state *cs,
+		       const u8 *msg TAKES);
 
 #endif /* LIGHTNING_COMMON_READ_PEER_MSG_H */

--- a/common/utils.c
+++ b/common/utils.c
@@ -34,8 +34,6 @@ void setup_locale(void)
 	putenv("LC_ALL=C"); /* For exec{l,lp,v,vp}(...) */
 }
 
-/* Global temporary convenience context: freed in io loop core. */
-
 /* Initial creation of tmpctx. */
 void setup_tmpctx(void)
 {
@@ -45,9 +43,9 @@ void setup_tmpctx(void)
 /* Free any children of tmpctx. */
 void clean_tmpctx(void)
 {
-	/* Minor optimization: don't do anything if tmpctx unused. */
-	if (tal_first(tmpctx)) {
-		tal_free(tmpctx);
-		tmpctx = tal_arr_label(NULL, char, 0, "tmpctx");
-	}
+	const tal_t *p;
+
+	/* Don't actually free tmpctx: we hand pointers to it around. */
+	while ((p = tal_first(tmpctx)) != NULL)
+		tal_free(p);
 }

--- a/common/utils.h
+++ b/common/utils.h
@@ -22,7 +22,7 @@ u8 *tal_hexdata(const tal_t *ctx, const void *str, size_t len);
 /* Use the POSIX C locale. */
 void setup_locale(void);
 
-/* Global temporary convenience context: freed in io loop core. */
+/* Global temporary convenience context: children freed in io loop core. */
 extern const tal_t *tmpctx;
 
 /* Initial creation of tmpctx. */

--- a/connectd/Makefile
+++ b/connectd/Makefile
@@ -41,7 +41,6 @@ CONNECTD_COMMON_OBJS :=				\
 	common/bech32_util.o			\
 	common/bip32.o				\
 	common/crypto_state.o			\
-	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon.o				\
 	common/daemon_conn.o			\

--- a/connectd/connect.c
+++ b/connectd/connect.c
@@ -1186,7 +1186,7 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 					    false);
 			status_trace("Created socket listener on file %s",
 				     addrun.sun_path);
-			io_new_listener(daemon, fd, connection_in, daemon);
+			add_listen_fd(daemon, fd);
 			/* We don't announce socket names */
 			assert(!announce);
 			add_binding(&binding, &wa);

--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -40,7 +40,6 @@ GOSSIPD_COMMON_OBJS :=				\
 	common/bech32_util.o			\
 	common/bip32.o				\
 	common/crypto_state.o			\
-	common/crypto_sync.o			\
 	common/cryptomsg.o			\
 	common/daemon.o				\
 	common/daemon_conn.o			\

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -98,9 +98,7 @@ void delete_channel(struct channel *channel)
 	wallet_channel_delete(channel->peer->ld->wallet, channel->dbid);
 	tal_free(channel);
 
-	/* Last one out frees the peer */
-	if (list_empty(&peer->channels) && !peer->uncommitted_channel)
-		delete_peer(peer);
+	maybe_delete_peer(peer);
 }
 
 void get_channel_basepoints(struct lightningd *ld,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -400,6 +400,7 @@ void channel_notify_new_block(struct lightningd *ld,
 			    block_height - channel->first_blocknum,
 			    type_to_string(tmpctx, struct bitcoin_txid,
 					   &channel->funding_txid));
+		/* FIXME: Send an error packet for this case! */
 		/* And forget it. */
 		delete_channel(channel);
 	}

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -224,11 +224,16 @@ static void shutdown_subdaemons(struct lightningd *ld)
 		}
 
 		/* Freeing uncommitted channel will free peer. */
-		if (p->uncommitted_channel)
-			tal_free(p->uncommitted_channel);
-		else
-			/* Removes itself from list as we free it */
-			tal_free(p);
+		if (p->uncommitted_channel) {
+			struct uncommitted_channel *uc = p->uncommitted_channel;
+
+			/* Setting to NULL stops destroy_uncommitted_channel
+			 * from trying to remove peer from db! */
+			p->uncommitted_channel = NULL;
+			tal_free(uc);
+		}
+		/* Removes itself from list as we free it */
+		tal_free(p);
 	}
 	db_commit_transaction(ld->wallet->db);
 }

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -52,10 +52,6 @@ struct uncommitted_channel {
 	/* Public key for funding tx. */
 	struct pubkey local_funding_pubkey;
 
-	/* Blockheight at creation, scans for funding confirmations
-	 * will start here */
-	u32 first_blocknum;
-
 	/* These are *not* filled in by new_uncommitted_channel: */
 
 	/* Minimum funding depth (if funder == REMOTE). */
@@ -247,7 +243,9 @@ wallet_commit_channel(struct lightningd *ld,
 			      NULL, /* No remote_shutdown_scriptpubkey yet */
 			      final_key_idx, false,
 			      NULL, /* No commit sent yet */
-			      uc->first_blocknum,
+			      /* If we're fundee, could be a little before this
+			       * in theory, but it's only used for timing out. */
+			      get_block_height(ld->topology),
 			      feerate, feerate,
 			      /* We are connected */
 			      true,
@@ -624,7 +622,6 @@ new_uncommitted_channel(struct lightningd *ld,
 	tal_free(idname);
 
 	uc->fc = fc;
-	uc->first_blocknum = get_block_height(ld->topology);
 	uc->our_config.id = 0;
 
 	get_channel_basepoints(ld, &uc->peer->id, uc->dbid,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -584,6 +584,10 @@ static void destroy_uncommitted_channel(struct uncommitted_channel *uc)
 		subd_release_channel(openingd, uc);
 	}
 
+	/* This is how shutdown_subdaemons tells us not to delete from db! */
+	if (!uc->peer->uncommitted_channel)
+		return;
+
 	uc->peer->uncommitted_channel = NULL;
 
 	maybe_delete_peer(uc->peer);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -586,9 +586,7 @@ static void destroy_uncommitted_channel(struct uncommitted_channel *uc)
 
 	uc->peer->uncommitted_channel = NULL;
 
-	/* Last one out frees */
-	if (list_empty(&uc->peer->channels))
-		delete_peer(uc->peer);
+	maybe_delete_peer(uc->peer);
 }
 
 /* Returns NULL if there's already an opening or active channel for this peer */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -445,8 +445,6 @@ void peer_connected(struct lightningd *ld, const u8 *msg,
 	struct crypto_state cs;
 	u8 *gfeatures, *lfeatures;
 	u8 *error;
-	u8 *global_features;
-	u8 *local_features;
 	struct channel *channel;
 	struct wireaddr_internal addr;
 	struct uncommitted_channel *uc;
@@ -456,25 +454,6 @@ void peer_connected(struct lightningd *ld, const u8 *msg,
 					    &gfeatures, &lfeatures))
 		fatal("Connectd gave bad CONNECT_PEER_CONNECTED message %s",
 		      tal_hex(msg, msg));
-
-	if (!features_supported(gfeatures, lfeatures)) {
-		log_unusual(ld->log, "peer %s offers unsupported features %s/%s",
-			    type_to_string(msg, struct pubkey, &id),
-			    tal_hex(msg, gfeatures),
-			    tal_hex(msg, lfeatures));
-		global_features = get_offered_global_features(msg);
-		local_features = get_offered_local_features(msg);
-		error = towire_errorfmt(msg, NULL,
-					"We only offer globalfeatures %s"
-					" and localfeatures %s",
-					tal_hexstr(msg,
-						   global_features,
-						   tal_count(global_features)),
-					tal_hexstr(msg,
-						   local_features,
-						   tal_count(local_features)));
-		goto send_error;
-	}
 
 	/* Were we trying to open a channel, and we've raced? */
 	if (handle_opening_channel(ld, &id, &addr, &cs,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -60,8 +60,8 @@ struct peer *new_peer(struct lightningd *ld, u64 dbid,
 		      const struct wireaddr_internal *addr,
 		      const u8 *gfeatures TAKES, const u8 *lfeatures TAKES);
 
-/* Also removes from db. */
-void delete_peer(struct peer *peer);
+/* Last one out deletes peer.  Also removes from db. */
+void maybe_delete_peer(struct peer *peer);
 
 struct peer *peer_by_id(struct lightningd *ld, const struct pubkey *id);
 struct peer *peer_from_json(struct lightningd *ld,

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -321,7 +321,7 @@ static void subdaemon_malformed_msg(struct subd *sd, const u8 *msg)
 
 #if DEVELOPER
 	if (sd->ld->dev_subdaemon_fail)
-		fatal("Subdaemon %s sent malformed message", sd->name);
+		exit(1);
 #endif
 }
 
@@ -356,7 +356,7 @@ static bool log_status_fail(struct subd *sd, const u8 *msg)
 
 #if DEVELOPER
 	if (sd->ld->dev_subdaemon_fail)
-		fatal("Subdaemon %s hit error", sd->name);
+		exit(1);
 #endif
 	return true;
 }
@@ -533,9 +533,11 @@ static void destroy_subd(struct subd *sd)
 		break;
 	}
 
-	if (fail_if_subd_fails && WIFSIGNALED(status))
-		fatal("Subdaemon %s killed with signal %i",
-		      sd->name, WTERMSIG(status));
+	if (fail_if_subd_fails && WIFSIGNALED(status)) {
+		log_broken(sd->log, "Subdaemon %s killed with signal %i",
+			   sd->name, WTERMSIG(status));
+		exit(1);
+	}
 
 	/* In case we're freed manually, such as channel_fail_permanent */
 	if (sd->conn)

--- a/openingd/opening.c
+++ b/openingd/opening.c
@@ -297,8 +297,7 @@ static u8 *funder_channel(struct state *state,
 				  &ours->htlc,
 				  &state->next_per_commit[LOCAL],
 				  channel_flags);
-	if (!sync_crypto_write(&state->cs, PEER_FD, msg))
-		peer_failed_connection_lost();
+	sync_crypto_write(&state->cs, PEER_FD, msg);
 
 	state->remoteconf = tal(state, struct channel_config);
 
@@ -458,8 +457,7 @@ static u8 *funder_channel(struct state *state,
 				     &state->funding_txid,
 				     state->funding_txout,
 				     &sig);
-	if (!sync_crypto_write(&state->cs, PEER_FD, msg))
-		peer_failed_connection_lost();
+	sync_crypto_write(&state->cs, PEER_FD, msg);
 
 	/* BOLT #2:
 	 *
@@ -690,8 +688,7 @@ static u8 *fundee_channel(struct state *state,
 				    &ours->htlc,
 				    &state->next_per_commit[LOCAL]);
 
-	if (!sync_crypto_write(&state->cs, PEER_FD, take(msg)))
-		peer_failed_connection_lost();
+	sync_crypto_write(&state->cs, PEER_FD, take(msg));
 
 	peer_billboard(false,
 		       "Incoming channel: accepted, now waiting for them to create funding tx");

--- a/openingd/opening.c
+++ b/openingd/opening.c
@@ -236,8 +236,7 @@ static u8 *opening_read_peer_msg(const tal_t *ctx, struct state *state)
 		msg = peer_or_gossip_sync_read(ctx, PEER_FD, GOSSIP_FD,
 					       &state->cs, &from_gossipd);
 		if (from_gossipd) {
-			handle_gossip_msg(msg, &state->cs, sync_crypto_write_arg,
-					  NULL);
+			handle_gossip_msg(PEER_FD, &state->cs, take(msg));
 			continue;
 		}
 		if (!handle_peer_gossip_or_error(PEER_FD, GOSSIP_FD, &state->cs,


### PR DESCRIPTION
These are accumulated cleanups I did on the way to changing openingd to take care of a peer before either side opens a channel.

The main change is to tear apart read_peer_msg() which was trying to handle too much (and it gets even worse after openingd changes to not fail the peer on non-catastrophic error).