### PR TITLE
doc: document p2sh-segwit address gen for faucet coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ If you don't have any testcoins you can get a few from a faucet such as
 [TPs' testnet faucet][tps] or [Kiwi's testnet faucet][kiw].
 You can send it directly to the `lightningd` address.
 
+You may need to generate a p2sh-segwit address if the faucet does not support
+bech32:
+
+    # Return a p2sh-segwit address
+    cli/lightning-cli newaddr p2sh-segwit
+
 [tps]: http://tpfaucet.appspot.com/
 [kiw]: https://testnet.manu.backend.hamburg/faucet
 


### PR DESCRIPTION
Now that the default newaddr type is bech32, this step seems to be tripping
people up.

Reported-by: #c-lightning users
Signed-off-by: William Casarin <jb55@jb55.com>