### PR TITLE
lightning-cli: consider empty inputs to be strings

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -145,6 +145,9 @@ static char *opt_set_ordered(enum input *input)
 static bool is_literal(const char *arg)
 {
 	size_t arglen = strlen(arg);
+	if (arglen == 0) {
+		return false;
+	}
 	return strspn(arg, "0123456789") == arglen
 		|| streq(arg, "true")
 		|| streq(arg, "false")


### PR DESCRIPTION
I got a user report with a strange error like this:

    lightning-cli invoice msatoshi="any" label="" description=""
    { "code" : -32602, "message" : "Missing 'description' parameter" }

It turns out that

* The shell translates foo="" into an argv element "foo="
* lightning-cli correctly sees a parameter with name "foo" and value ""
* lightning-cli then incorrectly considers "" to be a literal value, because it consists entirely of decimal characters
* lightning-cli then does *not* put quotes around the empty string, which messes up the JSON-formatted command

This patch fixes this behavior by always considering empty values to be strings (which are then quoted in the JSON command).
