### PR TITLE
Enhanced param parsing

### DIFF
--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -112,13 +112,7 @@ static bool make_callback(struct command *cmd,
 			return false;
 		}
 	} else {
-		char *msg = def->cbx(cmd, def->name, buffer, tok, def->arg);
-		if (msg) {
-			command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS,
-					      make_result(cmd, def->name, buffer, tok),
-					      "%s: %s", def->name, msg);
-			return false;
-		}
+		return def->cbx(cmd, def->name, buffer, tok, def->arg);
 	}
 	return true;
 }

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -12,16 +12,18 @@ struct param {
 	bool is_set;
 	bool required;
 	param_cb cb;
+	param_cbx cbx;
 	void *arg;
 	size_t argsize;
 };
 
 static bool param_add(struct param **params,
-		      const char *name, bool required, param_cb cb, void *arg,
+		      const char *name, bool required, param_cb cb,
+		      param_cbx cbx, void *arg,
 		      size_t argsize)
 {
 #if DEVELOPER
-	if (!(name && cb && arg))
+	if (!(name && (cb || cbx) && arg))
 		return false;
 #endif
 	struct param *last;
@@ -33,6 +35,7 @@ static bool param_add(struct param **params,
 	last->name = name;
 	last->required = required;
 	last->cb = cb;
+	last->cbx = cbx;
 	last->arg = arg;
 	last->argsize = argsize;
 	/* Non-0 means we are supposed to allocate iff found */
@@ -72,30 +75,50 @@ static const char *find_fail_format(param_cb cb)
 	return fmt->format;
 }
 
+/* Create a json_result out of a jsmntok_t. */
+static struct json_result *make_result(tal_t *ctx, const char *name, const char *buffer,
+				       const jsmntok_t *tok)
+{
+	struct json_result *data = new_json_result(ctx);
+	const char *val = tal_fmt(ctx, "%.*s", tok->end - tok->start,
+				  buffer + tok->start);
+	json_object_start(data, NULL);
+	json_add_string(data, name, val);
+	json_object_end(data);
+	return data;
+}
+
 static bool make_callback(struct command *cmd,
 			  struct param *def,
-			  const char *buffer, const jsmntok_t * tok)
+			  const char *buffer, const jsmntok_t *tok)
 {
 	void *arg;
 	def->is_set = true;
-	if (def->argsize && def->cb != (param_cb)json_tok_tok) {
-		*(void **)def->arg
-			= arg
-			= tal_arr_label(cmd, char, def->argsize, "param");
-	} else
-		arg = def->arg;
-	if (!def->cb(buffer, tok, arg)) {
-		struct json_result *data = new_json_result(cmd);
-		const char *val = tal_fmt(cmd, "%.*s", tok->end - tok->start,
-					  buffer + tok->start);
-		json_object_start(data, NULL);
-		json_add_string(data, def->name, val);
-		json_object_end(data);
-		command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS, data,
-				      find_fail_format(def->cb), def->name,
-				      tok->end - tok->start,
-				      buffer + tok->start);
-		return false;
+
+	if (def->cb) {
+		if (def->argsize && def->cb != (param_cb)json_tok_tok) {
+			*(void **)def->arg
+				= arg
+				= tal_arr_label(cmd, char, def->argsize, "param");
+		} else
+			arg = def->arg;
+
+		if (!def->cb(buffer, tok, arg)) {
+			command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS,
+					      make_result(cmd, def->name, buffer, tok),
+					      find_fail_format(def->cb), def->name,
+					      tok->end - tok->start,
+					      buffer + tok->start);
+			return false;
+		}
+	} else {
+		char *msg = def->cbx(cmd, buffer, tok, def->arg);
+		if (msg) {
+			command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS,
+					      make_result(cmd, def->name, buffer, tok),
+					      "%s: %s", def->name, msg);
+			return false;
+		}
 	}
 	return true;
 }
@@ -308,10 +331,12 @@ bool param(struct command *cmd, const char *buffer,
 	va_start(ap, tokens);
 	while ((name = va_arg(ap, const char *)) != NULL) {
 		bool required = va_arg(ap, int);
-		param_cb cb = va_arg(ap, param_cb);
+		bool advanced = va_arg(ap, int);
+		param_cb cb = advanced ? NULL : va_arg(ap, param_cb);
+		param_cbx cbx = advanced ? va_arg(ap, param_cbx) : NULL;
 		void *arg = va_arg(ap, void *);
 		size_t argsize = va_arg(ap, size_t);
-		if  (!param_add(&params, name, required, cb, arg, argsize)) {
+		if  (!param_add(&params, name, required, cb, cbx, arg, argsize)) {
 			command_fail(cmd, PARAM_DEV_ERROR, "developer error");
 			va_end(ap);
 			return false;

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -112,7 +112,7 @@ static bool make_callback(struct command *cmd,
 			return false;
 		}
 	} else {
-		char *msg = def->cbx(cmd, buffer, tok, def->arg);
+		char *msg = def->cbx(cmd, def->name, buffer, tok, def->arg);
 		if (msg) {
 			command_fail_detailed(cmd, JSONRPC2_INVALID_PARAMS,
 					      make_result(cmd, def->name, buffer, tok),

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -55,6 +55,14 @@ bool param(struct command *cmd, const char *buffer,
 typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 
 /*
+ * Advanced callback. Returns NULL on success, error message on failure.
+ */
+typedef char *(*param_cbx)(struct command *cmd,
+			   const char *buffer,
+			   const jsmntok_t *tok,
+			   void **arg);
+
+/*
  * Add a handler to unmarshal a required json token into @arg. The handler must
  * return true on success and false on failure.  Upon failure, command_fail will be
  * called with a descriptive error message.
@@ -65,11 +73,23 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 #define p_req(name, cb, arg)					\
 	      name"",						\
 	      true,						\
+	      false,						\
 	      (cb),				 		\
 	      (arg) + 0*sizeof((cb)((const char *)NULL,		\
 				    (const jsmntok_t *)NULL,	\
 				    (arg)) == true),		\
 	      (size_t)0
+
+#define p_req_tal(name, cbx, arg)				\
+		  name"",					\
+		  true,						\
+		  true,						\
+		  (cbx),				 	\
+		  (arg) + 0*sizeof((cbx)((const tal_t *)NULL,   \
+				   (const char *)NULL,		\
+				   (const jsmntok_t *)NULL,	\
+				   (arg)) == NULL),		\
+		  (size_t)0
 
 /*
  * Similar to above but for optional parameters.
@@ -79,11 +99,23 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 #define p_opt(name, cb, arg)					\
 	      name"",						\
 	      false,						\
+	      false,						\
 	      (cb),				 		\
 	      (arg) + 0*sizeof((cb)((const char *)NULL,		\
 				    (const jsmntok_t *)NULL,	\
 				    *(arg)) == true),		\
 	      sizeof(**(arg))
+
+#define p_opt_tal(name, cbx, arg)				\
+		  name"",					\
+		  false,					\
+		  true,						\
+		  (cbx),				 	\
+		  (arg) + 0*sizeof((cbx)((const tal_t *)NULL,   \
+				   (const char *)NULL,		\
+				   (const jsmntok_t *)NULL,	\
+				   (arg)) == NULL),		\
+		  sizeof(**(arg))
 
 /*
  * Similar to p_req but for optional parameters with defaults.
@@ -91,6 +123,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
  */
 #define p_opt_def(name, cb, arg, def)					\
 		  name"",						\
+		  false,						\
 		  false,						\
 		  (cb),							\
 		  (arg) + 0*sizeof((cb)((const char *)NULL,		\
@@ -105,6 +138,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
  */
 #define p_opt_tok(name, arg)						\
 		  name"",						\
+		  false,						\
 		  false,						\
 		  json_tok_tok,						\
 		  (arg) + 0*sizeof(*(arg) == (jsmntok_t *)NULL),	\

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -140,7 +140,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\
-		  ({ *arg = tal(cmd, typeof(**arg)); **arg = def; (size_t)0;})
+		  ({ (*arg) = tal((cmd), typeof(**arg)); (**arg) = (def); (size_t)0;})
 
 /*
  * For when you want an optional raw token.

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -85,7 +85,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 		  true,						\
 		  true,						\
 		  (cbx),				 	\
-		  (arg) + 0*sizeof((cbx)((const tal_t *)NULL,   \
+		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\
@@ -111,7 +111,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 		  false,					\
 		  true,						\
 		  (cbx),				 	\
-		  (arg) + 0*sizeof((cbx)((const tal_t *)NULL,   \
+		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -131,6 +131,17 @@ typedef char *(*param_cbx)(struct command *cmd,
 					(arg)) == true),		\
 		  ((void)((*arg) = (def)), (size_t)0)
 
+#define p_opt_def_tal(name, cbx, arg, def)				\
+		  name"",					\
+		  false,					\
+		  true,						\
+		  (cbx),				 	\
+		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
+				   (const char *)NULL,		\
+				   (const jsmntok_t *)NULL,	\
+				   (arg)) == NULL),		\
+		  ({ *arg = tal(cmd, typeof(**arg)); **arg = def; (size_t)0;})
+
 /*
  * For when you want an optional raw token.
  *

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -57,7 +57,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
 /*
  * Advanced callback. Returns NULL on success, error message on failure.
  */
-typedef char *(*param_cbx)(struct command *cmd,
+typedef bool(*param_cbx)(struct command *cmd,
 			   const char *name,
 			   const char *buffer,
 			   const jsmntok_t *tok,
@@ -90,7 +90,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 				   (const char *)NULL,		\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
-				   (arg)) == NULL),		\
+				   (arg)) == true),		\
 		  (size_t)0
 
 /*
@@ -117,7 +117,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 				   (const char *)NULL,		\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
-				   (arg)) == NULL),		\
+				   (arg)) == true),		\
 		  sizeof(**(arg))
 
 /*
@@ -143,7 +143,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 				   (const char *)NULL,		\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
-				   (arg)) == NULL),		\
+				   (arg)) == true),		\
 		  ({ (*arg) = tal((cmd), typeof(**arg)); (**arg) = (def); (size_t)0;})
 
 /*

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -58,6 +58,7 @@ typedef bool(*param_cb)(const char *buffer, const jsmntok_t *tok, void *arg);
  * Advanced callback. Returns NULL on success, error message on failure.
  */
 typedef char *(*param_cbx)(struct command *cmd,
+			   const char *name,
 			   const char *buffer,
 			   const jsmntok_t *tok,
 			   void **arg);
@@ -87,6 +88,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 		  (cbx),				 	\
 		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
 				   (const char *)NULL,		\
+				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\
 		  (size_t)0
@@ -113,6 +115,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 		  (cbx),				 	\
 		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
 				   (const char *)NULL,		\
+				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\
 		  sizeof(**(arg))
@@ -137,6 +140,7 @@ typedef char *(*param_cbx)(struct command *cmd,
 		  true,						\
 		  (cbx),				 	\
 		  (arg) + 0*sizeof((cbx)((struct command *)NULL,\
+				   (const char *)NULL,		\
 				   (const char *)NULL,		\
 				   (const jsmntok_t *)NULL,	\
 				   (arg)) == NULL),		\

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -403,7 +403,7 @@ static void sendpay_nulltok(void)
 	assert(msatoshi == NULL);
 }
 
-static char *json_tok_msat(const tal_t *ctx,
+static char *json_tok_msat(struct command *cmd,
 			   const char *buffer,
 			   const jsmntok_t * msatoshi,
 			   u64 **msatoshi_val)
@@ -425,7 +425,7 @@ static char *json_tok_msat(const tal_t *ctx,
 
 /* This can eventually replace json_tok_tok and we can remove the special p_opt_tok()
  * macro. */
-static char *json_tok_tok_x(const tal_t *ctx,
+static char *json_tok_tok_x(struct command *cmd,
 			    const char *buffer,
 			    const jsmntok_t *tok,
 			    const jsmntok_t **arg)
@@ -438,12 +438,12 @@ static char *json_tok_tok_x(const tal_t *ctx,
  * New version of json_tok_label conforming to advanced style. This can eventually
  * replace the existing json_tok_label.
  */
-static char *json_tok_label_x(const tal_t *ctx,
+static char *json_tok_label_x(struct command *cmd,
 			      const char *buffer,
 			      const jsmntok_t *tok,
 			      struct json_escaped **label)
 {
-	if ((*label = json_tok_escaped_string(ctx, buffer, tok)))
+	if ((*label = json_tok_escaped_string(cmd, buffer, tok)))
 		return NULL;
 
 	/* Allow literal numbers */
@@ -454,12 +454,12 @@ static char *json_tok_label_x(const tal_t *ctx,
 		if (!cisdigit(buffer[i]))
 			goto fail;
 
-	if ((*label = json_escaped_string_(ctx, buffer + tok->start,
+	if ((*label = json_escaped_string_(cmd, buffer + tok->start,
 				    tok->end - tok->start)))
 		return NULL;
 
 fail:
-	return tal_fmt(ctx, "expected a string or number, not '%.*s'",
+	return tal_fmt(cmd, "expected a string or number, not '%.*s'",
 		       tok->end - tok->start,
 		       buffer + tok->start);
 }

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -499,6 +499,18 @@ static void advanced(void)
 		assert(!strcmp(label->s, "3"));
 		assert(!strcmp(foo->s, "foo"));
 	}
+	{
+		u64 *msat;
+		u64 *msat2;
+		struct json *j = json_parse(cmd, "[ 3 ]");
+		assert(param(cmd, j->buffer, j->toks,
+			      p_opt_def_tal("msat", json_tok_msat, &msat, 23),
+			      p_opt_def_tal("msat2", json_tok_msat, &msat2, 53),
+			      NULL));
+		assert(*msat == 3);
+		assert(msat2);
+		assert(*msat2 == 53);
+	}
 }
 
 static void advanced_fail(void)

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -404,6 +404,7 @@ static void sendpay_nulltok(void)
 }
 
 static char *json_tok_msat(struct command *cmd,
+			   const char *name,
 			   const char *buffer,
 			   const jsmntok_t * msatoshi,
 			   u64 **msatoshi_val)
@@ -426,6 +427,7 @@ static char *json_tok_msat(struct command *cmd,
 /* This can eventually replace json_tok_tok and we can remove the special p_opt_tok()
  * macro. */
 static char *json_tok_tok_x(struct command *cmd,
+			   const char *name,
 			    const char *buffer,
 			    const jsmntok_t *tok,
 			    const jsmntok_t **arg)
@@ -439,6 +441,7 @@ static char *json_tok_tok_x(struct command *cmd,
  * replace the existing json_tok_label.
  */
 static char *json_tok_label_x(struct command *cmd,
+			      const char *name,
 			      const char *buffer,
 			      const jsmntok_t *tok,
 			      struct json_escaped **label)


### PR DESCRIPTION
This adds and tests two new macros; `p_req_tal()` and `p_opt_tal()`. They support
callbacks that take a ~~`tal_t *`~~ `struct command *`  context.  Example:

	static char *json_tok_label_x(struct command *cmd,
				      const char *buffer,
				      const jsmntok_t *tok,
				      struct json_escaped **label)

The above is taken from the run-param unit test (near the bottom of the diff).
On success, `*label` is allocated and initialized, and NULL is returned. On failure, an error string
is returned.

`param()` will take care of calling `command_fail` with the error message.

We can pretty much remove all remaining usage of `json_tok_tok` in the codebase
with this type of callback.

The question remains: Should we convert all existing `json_tok_X()` functions to
this new form or leave them alone?