### PR TITLE
pytest: hand 'True' to decoderawtransaction so it doesn't get confused.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -495,15 +495,12 @@ class LightningNode(object):
         l2.daemon.wait_for_logs(['update for channel .* now ACTIVE', 'to CHANNELD_NORMAL'])
 
         # Hacky way to find our output.
-        decoded = self.bitcoin.rpc.decoderawtransaction(tx)
+        decoded = self.bitcoin.rpc.decoderawtransaction(tx, True)
         for out in decoded['vout']:
-            # Sometimes a float?  Sometimes a decimal?  WTF Python?!
             if out['scriptPubKey']['type'] == 'witness_v0_scripthash':
-                if out['value'] == Decimal(amount) / 10**8 or out['value'] * 10**8 == amount:
+                if out['value'] == Decimal(amount) / 10**8:
                     return "{}:1:{}".format(self.bitcoin.rpc.getblockcount(), out['n'])
-        # Intermittent decoding failure.  See if it decodes badly twice?
-        decoded2 = self.bitcoin.rpc.decoderawtransaction(tx)
-        raise ValueError("Can't find {} payment in {} (1={} 2={})".format(amount, tx, decoded, decoded2))
+        raise ValueError("Can't find {} payment in {} (1={} 2={})".format(amount, tx, decoded))
 
     def subd_pid(self, subd):
         """Get the process id of the given subdaemon, eg channeld or gossipd"""


### PR DESCRIPTION
This explains the very-very occasional issue we had parsing (hence the
random-looking fixes!).  The decoderawtransaction heuristic sometimes
thinks it's a zero-input tx, not a segwit tx.  Setting 'iswitness' to
true makes it reliable.

Here's the example I finally caught:

```
rusty$ bitcoin-cli decoderawtransaction  0200000000010180f80017ceb208d84cd5be0d4e21c1acb91798c55ada6541f7633a2739453b4e0100000000ffffffff0269300f0000000000160014774b1c651a1b409213057783547e2bd37a71731240420f00000000002200205f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e02483045022100ba65a905cf4ebbb9728dc682fcf17cb73ade0ca224729a1878f689a8afa9a49e02206f323f224c5171d170aafb8ff57e2761411a27dea304ac8f9a3663c456d21f3e012102225ce166e84b3833d9f620863b4e713099de616f559e8768f44ff674054bb07d00000000
{
  "txid": "3b8b78c18d30036f93b10a67eb8731325927fb046be969d24075e5b2e1e66e07",
  "hash": "3b8b78c18d30036f93b10a67eb8731325927fb046be969d24075e5b2e1e66e07",
  "version": 2,
  "size": 235,
  "vsize": 235,
  "locktime": 0,
  "vin": [
  ],
  "vout": [
    {
      "value": 6267898963.53775617,
      "n": 0,
      "scriptPubKey": {
        "asm": "be0d4e21c1acb91798c55ada6541f7633a2739453b4e0100000000ffffffff0269300f0000000000160014774b1c651a1b409213057783547e2bd37a71731240420f00000000002200205f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e02483045022100ba65a905cf4ebbb9728dc682fcf17cb73ade0ca224729a1878f689a8afa9a49e02206f323f224c5171d170aafb8ff57e2761411a27dea304ac8f9a3663c456d21f3e012102225ce166e84b3833d9f620863b4e713099de616f559e8768f44ff674054bb0 OP_TUCK",
        "hex": "4cd5be0d4e21c1acb91798c55ada6541f7633a2739453b4e0100000000ffffffff0269300f0000000000160014774b1c651a1b409213057783547e2bd37a71731240420f00000000002200205f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e02483045022100ba65a905cf4ebbb9728dc682fcf17cb73ade0ca224729a1878f689a8afa9a49e02206f323f224c5171d170aafb8ff57e2761411a27dea304ac8f9a3663c456d21f3e012102225ce166e84b3833d9f620863b4e713099de616f559e8768f44ff674054bb07d",
        "type": "nonstandard"
      }
    }
  ]
}
rusty$ bitcoin-cli decoderawtransaction  0200000000010180f80017ceb208d84cd5be0d4e21c1acb91798c55ada6541f7633a2739453b4e0100000000ffffffff0269300f0000000000160014774b1c651a1b409213057783547e2bd37a71731240420f00000000002200205f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e02483045022100ba65a905cf4ebbb9728dc682fcf17cb73ade0ca224729a1878f689a8afa9a49e02206f323f224c5171d170aafb8ff57e2761411a27dea304ac8f9a3663c456d21f3e012102225ce166e84b3833d9f620863b4e713099de616f559e8768f44ff674054bb07d00000000 true
{
  "txid": "d1f0e478ada951d4ee2d952a526a90cda181da6226980d69b345f644ed57a05d",
  "hash": "3b8b78c18d30036f93b10a67eb8731325927fb046be969d24075e5b2e1e66e07",
  "version": 2,
  "size": 235,
  "vsize": 153,
  "locktime": 0,
  "vin": [
    {
      "txid": "4e3b4539273a63f74165da5ac59817b9acc1214e0dbed54cd808b2ce1700f880",
      "vout": 1,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "3045022100ba65a905cf4ebbb9728dc682fcf17cb73ade0ca224729a1878f689a8afa9a49e02206f323f224c5171d170aafb8ff57e2761411a27dea304ac8f9a3663c456d21f3e01",
        "02225ce166e84b3833d9f620863b4e713099de616f559e8768f44ff674054bb07d"
      ],
      "sequence": 4294967295
    }
  ],
  "vout": [
    {
      "value": 0.00995433,
      "n": 0,
      "scriptPubKey": {
        "asm": "0 774b1c651a1b409213057783547e2bd37a717312",
        "hex": "0014774b1c651a1b409213057783547e2bd37a717312",
        "reqSigs": 1,
        "type": "witness_v0_keyhash",
        "addresses": [
          "bc1qwa93ceg6rdqfyyc9w7p4gl3t6da8zucjnugke0"
        ]
      }
    },
    {
      "value": 0.01000000,
      "n": 1,
      "scriptPubKey": {
        "asm": "0 5f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e",
        "hex": "00205f743123f9584a76058bac1142ec2bc6c60b4b2af1d3145e74418d41ae51009e",
        "reqSigs": 1,
        "type": "witness_v0_scripthash",
        "addresses": [
          "bc1qta6rzgletp98vpvt4sg59mptcmrqkje278f3ghn5gxx5rtj3qz0qgkydgs"
        ]
      }
    }
  ]
}

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>