### PR TITLE
contrib: add init file for systemd

### DIFF
--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -1,0 +1,48 @@
+# It is not recommended to modify this file in-place, because it will
+# be overwritten during package upgrades. If you want to add further
+# options or overwrite existing ones then use
+# $ systemctl edit lightningd.service
+# See "man systemd.service" for details.
+
+# Note that almost all daemon options could be specified in
+# /etc/lightningd/bitcoin.conf
+
+[Unit]
+Description=C-Lightning daemon
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=/usr/bin/lightningd --daemon --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid
+
+# Creates /run/lightningd owned by bitcoin
+RuntimeDirectory=lightningd
+
+User=bitcoin
+Group=bitcoin
+Type=forking
+PIDFile=/run/lightningd/lightningd.pid
+Restart=on-failure
+
+# Hardening measures
+####################
+
+# Provide a private /tmp and /var/tmp.
+PrivateTmp=true
+
+# Mount /usr, /boot/ and /etc read-only for the process.
+ProtectSystem=full
+
+# Disallow the process and all of its children to gain
+# new privileges through execve().
+NoNewPrivileges=true
+
+# Use a new /dev namespace only populated with API pseudo devices
+# such as /dev/null, /dev/zero and /dev/random.
+PrivateDevices=true
+
+# Deny the creation of writable and executable memory mappings.
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -5,7 +5,7 @@
 # See "man systemd.service" for details.
 
 # Note that almost all daemon options could be specified in
-# /etc/lightningd/bitcoin.conf
+# /etc/lightningd/lightningd.conf
 
 [Unit]
 Description=C-Lightning daemon


### PR DESCRIPTION
Similar to init/bitcoind.service, this patch
includes an initial lightningd.service.