### PR TITLE
do not start fee estimation with option: --dev-override-fee-rates

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -727,8 +727,17 @@ void setup_topology(struct chain_topology *topo,
 
 void begin_topology(struct chain_topology *topo)
 {
-	/* Begin fee estimation. */
+#if DEVELOPER
+    if (topo->dev_override_fee_rate) {
+        log_info(topo->log, "Fee estimation disabled because: "
+                 "--dev-override-fee-rates");
+    } else {
+        /* Begin fee estimation. */
+        start_fee_estimate(topo);
+    }
+#else
 	start_fee_estimate(topo);
+#endif
 
 	try_extend_tip(topo);
 }


### PR DESCRIPTION
To remove  _fee estimation_ log messages in certain cases:
- Disable fee estimation (loop) completely when `--dev-override-fee-rates` is used
- Because fee estimates is not needed when overridden
- Fixes #1806