### PR TITLE
in ./lightningd --help, tell for which network the default values are shown

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -713,11 +713,16 @@ static char *test_daemons_and_exit(struct lightningd *ld)
 	return NULL;
 }
 
-static char *opt_lightningd_usage(struct lightningd *ld) {
+static char *opt_lightningd_usage(struct lightningd *ld)
+{
 	/* Reload config so that --help has the correct network defaults
 	 * to display before it exits */
 	setup_default_config(ld);
-	opt_usage_and_exit("\nA bitcoin lightning daemon.");
+	char *extra = tal_fmt(NULL, "\nA bitcoin lightning daemon (default "
+			"values shown for network: %s).",
+	                get_chainparams(ld)->network_name);
+	opt_usage_and_exit(extra);
+	tal_free(extra);
 	return NULL;
 }
 


### PR DESCRIPTION
When `./lightningd --help` is called, show for which network the default values are shown. 

Before this PR, user had to scroll down to find out that `testnet` is the default network for which default value are shown.