### PR TITLE
Export hsm secret to mnemonic seed

### DIFF
--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -1022,7 +1022,7 @@ static void bitcoin_keypair(struct privkey *privkey,
 }
 
 static void display_mnemonic_word_list(void){
-	char **mnemonic_secret=NULL;
+	char *mnemonic_secret[24];
 	int ret = bip39_mnemonic_from_bytes(NULL,secretstuff.hsm_secret.data,32,mnemonic_secret);
     if (ret!=WALLY_OK){
     	status_info("HSM: convert hsm_secret to mnemonic seed failed. error code: %d",ret);

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -39,6 +39,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <wally_bip32.h>
+#include <wally_bip39.h>
 #include <wire/gen_peer_wire.h>
 #include <wire/wire_io.h>
 
@@ -1020,6 +1021,20 @@ static void bitcoin_keypair(struct privkey *privkey,
 			      "BIP32 pubkey %u create failed", index);
 }
 
+static void display_mnemonic_word_list(void){
+	char **mnemonic_secret=NULL;
+	int ret = bip39_mnemonic_from_bytes(NULL,secretstuff.hsm_secret.data,32,mnemonic_secret);
+    if (ret!=WALLY_OK){
+    	status_info("HSM: convert hsm_secret to mnemonic seed failed. error code: %d",ret);
+    }
+	status_info("HSM: your should remember / write down the following words to recover your funds!");
+	if (mnemonic_secret){
+		int i = 0;
+		while ( *mnemonic_secret )
+			status_info( "%d. %s", ++i, *mnemonic_secret++ );
+	}
+}
+
 static void maybe_create_new_hsm(void)
 {
 	int fd = open("hsm_secret", O_CREAT|O_EXCL|O_WRONLY, 0400);
@@ -1057,6 +1072,8 @@ static void maybe_create_new_hsm(void)
 			      "fsyncdir: %s", strerror(errno));
 	}
 	close(fd);
+	display_mnemonic_word_list();
+
 	status_unusual("HSM: created new hsm_secret file");
 }
 

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -1027,7 +1027,7 @@ static void display_mnemonic_word_list(void){
     if (ret!=WALLY_OK){
     	status_info("HSM: convert hsm_secret to mnemonic seed failed. error code: %d",ret);
     }
-	status_info("HSM: your should remember / write down the following words to recover your funds: %s",
+	status_info("HSM: you should remember / write down the following words to recover your funds: %s",
 			mnemonic_secret);
 }
 

--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -1022,17 +1022,13 @@ static void bitcoin_keypair(struct privkey *privkey,
 }
 
 static void display_mnemonic_word_list(void){
-	char *mnemonic_secret[24];
-	int ret = bip39_mnemonic_from_bytes(NULL,secretstuff.hsm_secret.data,32,mnemonic_secret);
+	char *mnemonic_secret;
+	int ret = bip39_mnemonic_from_bytes(NULL,secretstuff.hsm_secret.data,32,&mnemonic_secret);
     if (ret!=WALLY_OK){
     	status_info("HSM: convert hsm_secret to mnemonic seed failed. error code: %d",ret);
     }
-	status_info("HSM: your should remember / write down the following words to recover your funds!");
-	if (mnemonic_secret){
-		int i = 0;
-		while ( *mnemonic_secret )
-			status_info( "%d. %s", ++i, *mnemonic_secret++ );
-	}
+	status_info("HSM: your should remember / write down the following words to recover your funds: %s",
+			mnemonic_secret);
 }
 
 static void maybe_create_new_hsm(void)


### PR DESCRIPTION
This is a suggestion to fix #1762
I am not sure if that patch is desirable since it basically writes the private key to the logfile. On the other hand the logfile will be stored in `./lightning` next to `hsm_secret` so from a security perspective it does not change anything. 
Also I am not to happy with the message in status. knowing `hsm_secret` does not mean that one can recover channel states...

edit: of course the function `display_mnemonic_word_list` does not have to be called in `maybe_create_new_hsm `. It could rather be wrapped to some API call for `lightning-cli`