### PR TITLE
replace use of non standard mv -n flag

### DIFF
--- a/tools/refresh-submodules.sh
+++ b/tools/refresh-submodules.sh
@@ -6,12 +6,11 @@ if [ $# = 0 ]; then
 fi
 
 # git submodule can't run in parallel.  Really.
-echo $$ > .refresh-submodules.$$
-if ! mv -n .refresh-submodules.$$ .refresh-submodules; then
-    rm -f .refresh-submodules.$$
+if ! mkdir .refresh-submodules 2>/dev/null ; then
     exit 0
 fi
-trap "rm -f .refresh-submodules" EXIT
+
+trap "rmdir .refresh-submodules" EXIT
 
 # Be a little careful here, since we do rm -rf!
 for m in "$@"; do


### PR DESCRIPTION
Hi,

i built c-lighning on OpenBSD-current today and run into a problem with the use of the non-standard `mv -n` flag in `refresh-submodules.sh`.

The FreeBSD man page says that this flag should be avoided in scripts if possible.
See https://man.openbsd.org/FreeBSD-11.1/mv#COMPATIBILITY.

This PR replaces the use of `mv -n`. Now we first test if the file is there. If it is, we exit. If it is not we write the current PID to it.

Cheers,
Fabian