### PR TITLE
Fix confirmation of to-us outputs on reorganization or restart.

### DIFF
--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -75,11 +75,12 @@ static void onchain_tx_depth(struct channel *channel,
 /**
  * Entrypoint for the txwatch callback, calls onchain_tx_depth.
  */
-static enum watch_result onchain_tx_watched(struct channel *channel,
+static enum watch_result onchain_tx_watched(struct lightningd *ld,
+					    struct channel *channel,
 					    const struct bitcoin_txid *txid,
 					    unsigned int depth)
 {
-	u32 blockheight = channel->peer->ld->topology->tip->height;
+	u32 blockheight = get_block_height(ld->topology);
 	if (depth == 0) {
 		log_unusual(channel->log, "Chain reorganization!");
 		channel_set_owner(channel, NULL, false);
@@ -93,7 +94,7 @@ static enum watch_result onchain_tx_watched(struct channel *channel,
 	}
 
 	/* Store the channeltx so we can replay later */
-	wallet_channeltxs_add(channel->peer->ld->wallet, channel,
+	wallet_channeltxs_add(ld->wallet, channel,
 			      WIRE_ONCHAIN_DEPTH, txid, 0, blockheight);
 
 	onchain_tx_depth(channel, txid, depth);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -508,12 +508,12 @@ send_error:
 	peer_start_openingd(peer, &cs, peer_fd, gossip_fd, error);
 }
 
-static enum watch_result funding_lockin_cb(struct channel *channel,
+static enum watch_result funding_lockin_cb(struct lightningd *ld,
+					   struct channel *channel,
 					   const struct bitcoin_txid *txid,
 					   unsigned int depth)
 {
 	const char *txidstr;
-	struct lightningd *ld = channel->peer->ld;
 
 	txidstr = type_to_string(channel, struct bitcoin_txid, txid);
 	log_debug(channel->log, "Funding tx %s depth %u of %u",

--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -12,6 +12,7 @@ struct bitcoin_tx;
 struct block;
 struct channel;
 struct chain_topology;
+struct lightningd;
 struct txowatch;
 struct txwatch;
 
@@ -43,17 +44,19 @@ struct txwatch *watch_txid(const tal_t *ctx,
 			   struct chain_topology *topo,
 			   struct channel *channel,
 			   const struct bitcoin_txid *txid,
-			   enum watch_result (*cb)(struct channel *channel,
-						    const struct bitcoin_txid *,
+			   enum watch_result (*cb)(struct lightningd *ld,
+						   struct channel *channel,
+						   const struct bitcoin_txid *,
 						   unsigned int depth));
 
 struct txwatch *watch_tx(const tal_t *ctx,
 			 struct chain_topology *topo,
 			 struct channel *channel,
 			 const struct bitcoin_tx *tx,
-			 enum watch_result (*cb)(struct channel *channel,
-						  const struct bitcoin_txid *,
-						  unsigned int depth));
+			 enum watch_result (*cb)(struct lightningd *ld,
+						 struct channel *channel,
+						 const struct bitcoin_txid *,
+						 unsigned int depth));
 
 struct txowatch *watch_txo(const tal_t *ctx,
 			   struct chain_topology *topo,

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -244,7 +244,8 @@ def test_closing_different_fees(node_factory, bitcoind, executor):
     bitcoind.generate_block(1)
     for p in peers:
         p.daemon.wait_for_log(' to ONCHAIN')
-        wait_for(lambda: only_one(p.rpc.listpeers(l1.info['id'])['peers'][0]['channels'])['status'][1] == 'ONCHAIN:Tracking mutual close transaction')
+        wait_for(lambda: 'ONCHAIN:Tracking mutual close transaction' in only_one(p.rpc.listpeers(l1.info['id'])['peers'][0]['channels'])['status'])
+
     l1.daemon.wait_for_logs([' to ONCHAIN'] * num_peers)
 
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1112,7 +1112,6 @@ def test_permfail_htlc_out(node_factory, bitcoind, executor):
     wait_for(lambda: l2.rpc.listpeers()['peers'] == [])
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_permfail(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -347,8 +347,9 @@ struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   struct chain_topology *topo UNNEEDED,
 			   struct channel *channel UNNEEDED,
 			   const struct bitcoin_txid *txid UNNEEDED,
-			   enum watch_result (*cb)(struct channel *channel UNNEEDED,
-						    const struct bitcoin_txid * UNNEEDED,
+			   enum watch_result (*cb)(struct lightningd *ld UNNEEDED,
+						   struct channel *channel UNNEEDED,
+						   const struct bitcoin_txid * UNNEEDED,
 						   unsigned int depth))
 { fprintf(stderr, "watch_txid called!\n"); abort(); }
 /* Generated stub for watch_txo */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1055,20 +1055,18 @@ void wallet_peer_delete(struct wallet *w, u64 peer_dbid)
 	db_exec_prepared(w->db, stmt);
 }
 
-static void wallet_output_confirm(struct wallet *w,
-				  const struct bitcoin_txid *txid,
-				  const u32 outnum,
-				  const u32 confirmation_height)
+void wallet_confirm_tx(struct wallet *w,
+		       const struct bitcoin_txid *txid,
+		       const u32 confirmation_height)
 {
 	sqlite3_stmt *stmt;
 	assert(confirmation_height > 0);
 	stmt = db_prepare(w->db,
 			  "UPDATE outputs "
 			  "SET confirmation_height = ? "
-			  "WHERE prev_out_tx = ? AND prev_out_index = ?");
+			  "WHERE prev_out_tx = ?");
 	sqlite3_bind_int(stmt, 1, confirmation_height);
 	sqlite3_bind_sha256_double(stmt, 2, &txid->shad);
-	sqlite3_bind_int(stmt, 3, outnum);
 
 	db_exec_prepared(w->db, stmt);
 }
@@ -1111,7 +1109,7 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 			 * the output from a transaction we created
 			 * ourselves. */
 			if (blockheight)
-				wallet_output_confirm(w, &utxo->txid, utxo->outnum, *blockheight);
+				wallet_confirm_tx(w, &utxo->txid, *blockheight);
 			tal_free(utxo);
 			continue;
 		}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -249,6 +249,16 @@ bool wallet_update_output_status(struct wallet *w,
 struct utxo **wallet_get_utxos(const tal_t *ctx, struct wallet *w,
 			      const enum output_status state);
 
+
+/**
+ * wallet_get_unconfirmed_closeinfo_utxos - Retrieve any unconfirmed utxos w/ closeinfo
+ *
+ * Returns a `tal_arr` of `utxo` structs. Double indirection in order
+ * to be able to steal individual elements onto something else.
+ */
+struct utxo **wallet_get_unconfirmed_closeinfo_utxos(const tal_t *ctx,
+						     struct wallet *w);
+
 const struct utxo **wallet_select_coins(const tal_t *ctx, struct wallet *w,
 					const u64 value,
 					const u32 feerate_per_kw,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -226,6 +226,13 @@ bool wallet_add_utxo(struct wallet *w, struct utxo *utxo,
 		     enum wallet_output_type type);
 
 /**
+ * wallet_confirm_tx - Confirm a tx which contains a UTXO.
+ */
+void wallet_confirm_tx(struct wallet *w,
+		       const struct bitcoin_txid *txid,
+		       const u32 confirmation_height);
+
+/**
  * wallet_update_output_status - Perform an output state transition
  *
  * Change the current status of an output we are tracking in the


### PR DESCRIPTION
Came across this bug while completing the implementation of option_dataloss_protect.

I think this shows fairly nicely that we should be using BIP32 for the to-remote outputs in a future version of the spec.  We'd still need a different base for the output, but it'd be far simpler.