### PR TITLE
hsmd: log master extended private key when built in developer mode and logging at debug log level

### DIFF
--- a/hsmd/hsm.c
+++ b/hsmd/hsm.c
@@ -976,6 +976,20 @@ static void populate_secretstuff(void)
 				  &secretstuff.bip32) != WALLY_OK)
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Can't derive private bip32 key");
+
+#if DEVELOPER
+	unsigned char master_ext_prv_key_serialized[BIP32_SERIALIZED_LEN];
+	bip32_key_serialize(&master_extkey, BIP32_FLAG_KEY_PRIVATE, master_ext_prv_key_serialized, sizeof(master_ext_prv_key_serialized));
+
+	char *base58_check_encoded_master_ext_prv_key = NULL;
+	wally_base58_from_bytes(master_ext_prv_key_serialized, sizeof(master_ext_prv_key_serialized), BASE58_FLAG_CHECKSUM, &base58_check_encoded_master_ext_prv_key);
+	/* given this master extended private key, the first keypair used is found at BIP32 derivation path m/0/0/0 */
+	/* the second is at m/0/0/1, etc... note that non-hardened derivation is used. */
+	status_debug("HSM: master key %s", base58_check_encoded_master_ext_prv_key);
+	wally_free_string(base58_check_encoded_master_ext_prv_key);
+
+	wally_bzero(master_ext_prv_key_serialized, sizeof(master_ext_prv_key_serialized));
+#endif /* DEVELOPER */
 }
 
 static void bitcoin_pubkey(struct pubkey *pubkey, u32 index)


### PR DESCRIPTION
when built for developers and while logging at debug log level, output the base58 check encoded master private key when it is loaded by the hsm at startup.

this makes tinkering easier because otherwise developers have to use/make another utility to get the master key (the hsm_secret is stretched into the bip32 seed by the hkdf and then the master key is derived from the bip32 seed).

build time:
`./configure --enable-developer`

run time:
`--log-level debug`

here's an example log message (with most of the key redacted):
`2018-08-14T14:06:48.155Z lightning_hsmd(12345): HSM: master key tprv...`