### PR TITLE
Support log rotation, don't append crash.log files but use per-peer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   their capacity or their `htlc_minimum_msat` parameter (#1777)
 - We now try to connect to all known addresses for a peer, not just
   the one given or the first one announced.
+- Crash logs are now placed one-per file like `crash.log.20180822233752`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Config: `--conf` option to set config file.
 - JSON API: Added description to invoices and payments (#1740).
 - pylightning: RpcError now has `method` and `payload` fields.
+- Sending lightningd a SIGHUP will make it reopen its `log-file`, if any.
 
 ### Changed
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -156,7 +156,7 @@ Prefix for log lines: this can be customized if you want to merge logs with mult
 .PP
 \fBlog\-file\fR=\fIPATH\fR
 .RS 4
-Log to this file instead of stdout\&.
+Log to this file instead of stdout\&. Sending lightningd(1) SIGHUP will cause it to reopen this file (useful for log rotation)\&.
 .RE
 .PP
 \fBrpc\-file\fR=\fIPATH\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -109,7 +109,8 @@ Lightning daemon options:
     multiple daemons.
 
 *log-file*='PATH'::
-    Log to this file instead of stdout.
+    Log to this file instead of stdout.  Sending lightningd(1) SIGHUP will cause
+    it to reopen this file (useful for log rotation).
 
 *rpc-file*='PATH'::
     Set JSON-RPC socket (or /dev/tty), such as for lightning-cli(1).

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -569,18 +569,22 @@ static void log_dump_to_file(int fd, const struct log_book *lr)
 void log_backtrace_exit(void)
 {
 	int fd;
-	char logfile[sizeof("/tmp/lightning-crash.log.%u") + STR_MAX_CHARS(int)];
+	char timebuf[sizeof("YYYYmmddHHMMSS")];
+	char logfile[sizeof("/tmp/lightning-crash.log.") + sizeof(timebuf)];
+	struct timeabs time = time_now();
+
+	strftime(timebuf, sizeof(timebuf), "%Y%m%d%H%M%S", gmtime(&time.ts.tv_sec));
 
 	if (!crashlog)
 		return;
 
 	/* We expect to be in config dir. */
-	snprintf(logfile, sizeof(logfile), "crash.log.%u", getpid());
+	snprintf(logfile, sizeof(logfile), "crash.log.%s", timebuf);
 
 	fd = open(logfile, O_WRONLY|O_CREAT|O_TRUNC, 0600);
 	if (fd < 0) {
 		snprintf(logfile, sizeof(logfile),
-			 "/tmp/lightning-crash.log.%u", getpid());
+			 "/tmp/lightning-crash.log.%s", timebuf);
 		fd = open(logfile, O_WRONLY|O_CREAT|O_TRUNC, 0600);
 	}
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -875,8 +875,11 @@ def test_logging(node_factory):
 def test_crashlog(node_factory):
     l1 = node_factory.get_node(may_fail=True)
 
-    crashpath = os.path.join(l1.daemon.lightning_dir,
-                             'crash.log.{}'.format(l1.daemon.proc.pid))
-    assert not os.path.exists(crashpath)
+    def has_crash_log(n):
+        files = os.listdir(n.daemon.lightning_dir)
+        crashfiles = [f for f in files if 'crash.log' in f]
+        return len(crashfiles) > 0
+
+    assert not has_crash_log(l1)
     l1.daemon.proc.send_signal(signal.SIGSEGV)
-    wait_for(lambda: os.path.exists(crashpath))
+    wait_for(lambda: has_crash_log(l1))


### PR DESCRIPTION
This is based on ~~~#1846~~~ #1863 because I needed the start flag to get_node(), but it's basically the last two commits.