### PR TITLE
Never guess feerates

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -108,19 +108,6 @@ class LightningRpc(UnixDomainSocketRpc):
         res = self.call("listpeers", payload)
         return res.get("peers") and res["peers"][0] or None
 
-    def dev_setfees(self, immediate=None, normal=None, slow=None):
-        """
-        Set feerate in satoshi-per-kw for {immediate}, {normal} and {slow}
-        (each is optional, when set, separate by spaces) and show the value
-        of those three feerates
-        """
-        payload = {
-            "immediate": immediate,
-            "normal": normal,
-            "slow": slow
-        }
-        return self.call("dev-setfees", payload)
-
     def listnodes(self, node_id=None):
         """
         Show all nodes in our local network view, filter on node {id}

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -280,7 +280,7 @@ start_bitcoin_cli(struct bitcoind *bitcoind,
 
 static bool extract_feerate(struct bitcoin_cli *bcli,
 			    const char *output, size_t output_bytes,
-			    double *feerate)
+			    u64 *feerate)
 {
 	const jsmntok_t *tokens, *feeratetok;
 	bool valid;
@@ -303,7 +303,7 @@ static bool extract_feerate(struct bitcoin_cli *bcli,
 	if (!feeratetok)
 		return false;
 
-	return json_to_double(output, feeratetok, feerate);
+	return json_tok_bitcoin_amount(output, feeratetok, feerate);
 }
 
 struct estimatefee {
@@ -322,7 +322,7 @@ static void do_one_estimatefee(struct bitcoind *bitcoind,
 
 static bool process_estimatefee(struct bitcoin_cli *bcli)
 {
-	double feerate;
+	u64 feerate;
 	struct estimatefee *efee = bcli->cb_arg;
 
 	/* FIXME: We could trawl recent blocks for median fee... */
@@ -332,7 +332,7 @@ static bool process_estimatefee(struct bitcoin_cli *bcli)
 		efee->satoshi_per_kw[efee->i] = 0;
 	} else
 		/* Rate in satoshi per kw. */
-		efee->satoshi_per_kw[efee->i] = feerate * 100000000 / 4;
+		efee->satoshi_per_kw[efee->i] = feerate / 4;
 
 	efee->i++;
 	if (efee->i == tal_count(efee->satoshi_per_kw)) {

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -309,7 +309,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 			continue;
 
 		/* Initial smoothed feerate is the polled feerate */
-		if (topo->feerate_uninitialized) {
+		if (!topo->feerate[i]) {
 			old_feerates[i] = feerate;
 			log_debug(topo->log,
 					  "Smoothed feerate estimate for %s initialized to polled estimate %u",

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -131,8 +131,8 @@ size_t get_tx_depth(const struct chain_topology *topo,
 /* Get highest block number. */
 u32 get_block_height(const struct chain_topology *topo);
 
-/* Get fee rate in satoshi per kiloweight. */
-u32 get_feerate(const struct chain_topology *topo, enum feerate feerate);
+/* Get fee rate in satoshi per kiloweight, or 0 if unavailable! */
+u32 try_get_feerate(const struct chain_topology *topo, enum feerate feerate);
 
 /* Broadcast a single tx, and rebroadcast as reqd (copies tx).
  * If failed is non-NULL, call that and don't rebroadcast. */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -82,7 +82,7 @@ struct chain_topology {
 	struct block *prev_tip, *tip;
 	struct block_map block_map;
 	u32 feerate[NUM_FEERATES];
-	bool startup;
+	bool feerate_uninitialized;
 
 	/* Where to store blockchain info. */
 	struct wallet *wallet;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -155,6 +155,7 @@ void begin_topology(struct chain_topology *topo);
 
 struct txlocator *locate_tx(const void *ctx, const struct chain_topology *topo, const struct bitcoin_txid *txid);
 
+/* In channel_control.c */
 void notify_feerate_change(struct lightningd *ld);
 
 #if DEVELOPER

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -111,11 +111,6 @@ struct chain_topology {
 	/* Transactions/txos we are watching. */
 	struct txwatch_hash txwatches;
 	struct txowatch_hash txowatches;
-
-#if DEVELOPER
-	/* Force a particular fee rate regardless of estimatefee (satoshis/kw) */
-	u32 *dev_override_fee_rate;
-#endif
 };
 
 /* Information relevant to locating a TX in a blockchain. */

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -17,6 +17,47 @@
 #include <lightningd/subd.h>
 #include <wire/wire_sync.h>
 
+static void update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	u8 *msg = towire_channel_feerates(NULL,
+					  get_feerate(ld->topology,
+						      FEERATE_IMMEDIATE),
+					  feerate_min(ld),
+					  feerate_max(ld));
+	subd_send_msg(channel->owner, take(msg));
+}
+
+static void try_update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	/* No point until funding locked in */
+	if (!channel_fees_can_change(channel))
+		return;
+
+	/* Can't if no daemon listening. */
+	if (!channel->owner)
+		return;
+
+	update_feerates(ld, channel);
+}
+
+void notify_feerate_change(struct lightningd *ld)
+{
+	struct peer *peer;
+
+	/* FIXME: We should notify onchaind about NORMAL fee change in case
+	 * it's going to generate more txs. */
+	list_for_each(&ld->peers, peer, list) {
+		struct channel *channel = peer_active_channel(peer);
+
+		if (!channel)
+			continue;
+
+		/* FIXME: We choose not to drop to chain if we can't contact
+		 * peer.  We *could* do so, however. */
+		try_update_feerates(ld, channel);
+	}
+}
+
 static void lockin_complete(struct channel *channel)
 {
 	/* We set this once we're locked in. */

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -24,6 +24,10 @@ static void lockin_complete(struct channel *channel)
 	/* We set this once they're locked in. */
 	assert(channel->remote_funding_locked);
 	channel_set_state(channel, CHANNELD_AWAITING_LOCKIN, CHANNELD_NORMAL);
+
+	/* Fees might have changed (and we use IMMEDIATE once we're funded),
+	 * so update now. */
+	try_update_feerates(channel->peer->ld, channel);
 }
 
 /* We were informed by channeld that it announced the channel and sent

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -288,6 +288,10 @@ void peer_start_channeld(struct channel *channel,
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(channel->owner, take(initmsg));
+
+	/* On restart, feerate might not be what we expect: adjust now. */
+	if (channel->funder == LOCAL)
+		try_update_feerates(ld, channel);
 }
 
 bool channel_tell_funding_locked(struct lightningd *ld,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -19,11 +19,16 @@
 
 static void update_feerates(struct lightningd *ld, struct channel *channel)
 {
-	u8 *msg = towire_channel_feerates(NULL,
-					  get_feerate(ld->topology,
-						      FEERATE_IMMEDIATE),
-					  feerate_min(ld),
-					  feerate_max(ld));
+	u8 *msg;
+	u32 feerate = try_get_feerate(ld->topology, FEERATE_IMMEDIATE);
+
+	/* Nothing to do if we don't know feerate. */
+	if (!feerate)
+		return;
+
+	msg = towire_channel_feerates(NULL, feerate,
+				      feerate_min(ld, NULL),
+				      feerate_max(ld, NULL));
 	subd_send_msg(channel->owner, take(msg));
 }
 
@@ -292,8 +297,8 @@ void peer_start_channeld(struct channel *channel,
 				      &channel->our_config,
 				      &channel->channel_info.their_config,
 				      channel->channel_info.feerate_per_kw,
-				      feerate_min(ld),
-				      feerate_max(ld),
+				      feerate_min(ld, NULL),
+				      feerate_max(ld, NULL),
 				      &channel->last_sig,
 				      cs,
 				      &channel->channel_info.remote_fundingkey,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -736,7 +736,8 @@ void peer_start_openingd(struct peer *peer,
 				  cs, &uc->local_basepoints,
 				  &uc->local_funding_pubkey,
 				  uc->minimum_depth,
-				  feerate_min(peer->ld), feerate_max(peer->ld),
+				  feerate_min(peer->ld, NULL),
+				  feerate_max(peer->ld, NULL),
 				  !peer_active_channel(peer),
 				  send_msg);
 	subd_send_msg(uc->openingd, take(msg));
@@ -762,7 +763,7 @@ static void json_fund_channel(struct command *cmd,
 	struct pubkey *id;
 	struct peer *peer;
 	struct channel *channel;
-	u32 feerate_per_kw = get_feerate(cmd->ld->topology, FEERATE_NORMAL);
+	u32 feerate_per_kw = try_get_feerate(cmd->ld->topology, FEERATE_NORMAL);
 	u8 *msg;
 
 	fc->cmd = cmd;
@@ -776,6 +777,11 @@ static void json_fund_channel(struct command *cmd,
 
 	if (!json_tok_wtx(&fc->wtx, buffer, sattok, MAX_FUNDING_SATOSHI))
 		return;
+
+	if (!feerate_per_kw) {
+		command_fail(cmd, LIGHTNINGD, "Cannot estimate fees");
+		return;
+	}
 
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
@@ -816,8 +822,7 @@ static void json_fund_channel(struct command *cmd,
 	msg = towire_opening_funder(NULL,
 				    fc->wtx.amount,
 				    fc->push_msat,
-				    get_feerate(cmd->ld->topology,
-						FEERATE_NORMAL),
+				    feerate_per_kw,
 				    fc->wtx.change,
 				    fc->wtx.change_key_index,
 				    fc->channel_flags,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -401,29 +401,6 @@ static void config_register_opts(struct lightningd *ld)
 }
 
 #if DEVELOPER
-static char *opt_set_fee_rates(const char *arg, struct chain_topology *topo)
-{
-	tal_free(topo->dev_override_fee_rate);
-	topo->dev_override_fee_rate = tal_arr(topo, u32, 3);
-
-	for (size_t i = 0; i < tal_count(topo->dev_override_fee_rate); i++) {
-		char *endp;
-		char term;
-
-		if (i == tal_count(topo->dev_override_fee_rate)-1)
-			term = '\0';
-		else
-			term = '/';
-		topo->dev_override_fee_rate[i] = strtol(arg, &endp, 10);
-		if (endp == arg || *endp != term)
-			return tal_fmt(NULL,
-				       "Feerates must be <num>/<num>/<num>");
-
-		arg = endp + 1;
-	}
-	return NULL;
-}
-
 static void dev_register_opts(struct lightningd *ld)
 {
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
@@ -451,9 +428,6 @@ static void dev_register_opts(struct lightningd *ld)
 			 "will cause channels to be closed more often due to "
 			 "fee fluctuations, large values may result in large "
 			 "fees.");
-	opt_register_arg("--dev-override-fee-rates", opt_set_fee_rates, NULL,
-			 ld->topology,
-			 "Force a specific rates (immediate/normal/slow) in satoshis per kw regardless of estimated fees");
 
 	opt_register_arg(
 	    "--dev-channel-update-interval=<s>", opt_set_u32, opt_show_u32,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -179,16 +179,25 @@ u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx)
 	return scriptpubkey_p2wpkh(ctx, &shutdownkey);
 }
 
-u32 feerate_min(struct lightningd *ld)
+u32 feerate_min(struct lightningd *ld, bool *unknown)
 {
 	u32 min;
+
+	if (unknown)
+		*unknown = false;
 
 	/* We can't allow less than feerate_floor, since that won't relay */
 	if (ld->config.ignore_fee_limits)
 		min = 1;
-	else
-		/* Set this to half of slow rate.*/
-		min = get_feerate(ld->topology, FEERATE_SLOW) / 2;
+	else {
+		u32 feerate = try_get_feerate(ld->topology, FEERATE_SLOW);
+		if (!feerate) {
+			if (unknown)
+				*unknown = true;
+		}
+		/* Set this to half of slow rate (if unknown, will be floor) */
+		min = feerate / 2;
+	}
 
 	if (min < feerate_floor())
 		return feerate_floor();
@@ -201,13 +210,25 @@ u32 feerate_min(struct lightningd *ld)
  * spent in the future, it's a good idea for the fee payer to keep a good
  * margin (say 5x the expected fee requirement)
  */
-u32 feerate_max(struct lightningd *ld)
+u32 feerate_max(struct lightningd *ld, bool *unknown)
 {
+	u32 feerate;
+
+	if (unknown)
+		*unknown = false;
+
 	if (ld->config.ignore_fee_limits)
 		return UINT_MAX;
 
-	return get_feerate(ld->topology, FEERATE_IMMEDIATE) *
-	       ld->config.max_fee_multiplier;
+	/* If we don't know feerate, don't limit other side. */
+	feerate = try_get_feerate(ld->topology, FEERATE_IMMEDIATE);
+	if (!feerate) {
+		if (unknown)
+			*unknown = true;
+		return UINT_MAX;
+	}
+
+	return feerate * ld->config.max_fee_multiplier;
 }
 
 static void sign_last_tx(struct channel *channel)

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -88,9 +88,10 @@ void activate_peers(struct lightningd *ld);
 
 void drop_to_chain(struct lightningd *ld, struct channel *channel, bool cooperative);
 
-/* Get range of feerates to insist other side abide by for normal channels. */
-u32 feerate_min(struct lightningd *ld);
-u32 feerate_max(struct lightningd *ld);
+/* Get range of feerates to insist other side abide by for normal channels.
+ * If we have to guess, sets *unknown to true, otherwise false. */
+u32 feerate_min(struct lightningd *ld, bool *unknown);
+u32 feerate_max(struct lightningd *ld, bool *unknown);
 
 void channel_watch_funding(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1662,6 +1662,29 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 	} while (removed);
 }
 
+static void update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	u8 *msg = towire_channel_feerates(NULL,
+					  get_feerate(ld->topology,
+						      FEERATE_IMMEDIATE),
+					  feerate_min(ld),
+					  feerate_max(ld));
+	subd_send_msg(channel->owner, take(msg));
+}
+
+void try_update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	/* No point until funding locked in */
+	if (!channel_fees_can_change(channel))
+		return;
+
+	/* Can't if no daemon listening. */
+	if (!channel->owner)
+		return;
+
+	update_feerates(ld, channel);
+}
+
 void notify_feerate_change(struct lightningd *ld)
 {
 	struct peer *peer;
@@ -1670,22 +1693,13 @@ void notify_feerate_change(struct lightningd *ld)
 	 * it's going to generate more txs. */
 	list_for_each(&ld->peers, peer, list) {
 		struct channel *channel = peer_active_channel(peer);
-		u8 *msg;
 
-		if (!channel || !channel_fees_can_change(channel))
+		if (!channel)
 			continue;
 
 		/* FIXME: We choose not to drop to chain if we can't contact
 		 * peer.  We *could* do so, however. */
-		if (!channel->owner)
-			continue;
-
-		msg = towire_channel_feerates(channel,
-					      get_feerate(ld->topology,
-							  FEERATE_IMMEDIATE),
-					      feerate_min(ld),
-					      feerate_max(ld));
-		subd_send_msg(channel->owner, take(msg));
+		try_update_feerates(ld, channel);
 	}
 }
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1662,47 +1662,6 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 	} while (removed);
 }
 
-static void update_feerates(struct lightningd *ld, struct channel *channel)
-{
-	u8 *msg = towire_channel_feerates(NULL,
-					  get_feerate(ld->topology,
-						      FEERATE_IMMEDIATE),
-					  feerate_min(ld),
-					  feerate_max(ld));
-	subd_send_msg(channel->owner, take(msg));
-}
-
-void try_update_feerates(struct lightningd *ld, struct channel *channel)
-{
-	/* No point until funding locked in */
-	if (!channel_fees_can_change(channel))
-		return;
-
-	/* Can't if no daemon listening. */
-	if (!channel->owner)
-		return;
-
-	update_feerates(ld, channel);
-}
-
-void notify_feerate_change(struct lightningd *ld)
-{
-	struct peer *peer;
-
-	/* FIXME: We should notify onchaind about NORMAL fee change in case
-	 * it's going to generate more txs. */
-	list_for_each(&ld->peers, peer, list) {
-		struct channel *channel = peer_active_channel(peer);
-
-		if (!channel)
-			continue;
-
-		/* FIXME: We choose not to drop to chain if we can't contact
-		 * peer.  We *could* do so, however. */
-		try_update_feerates(ld, channel);
-	}
-}
-
 #if DEVELOPER
 static void json_dev_ignore_htlcs(struct command *cmd, const char *buffer,
 				  const jsmntok_t *params)

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -60,5 +60,4 @@ void onchain_fulfilled_htlc(struct channel *channel,
 
 void htlcs_notify_new_block(struct lightningd *ld, u32 height);
 
-void try_update_feerates(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -59,4 +59,6 @@ void onchain_fulfilled_htlc(struct channel *channel,
 			    const struct preimage *preimage);
 
 void htlcs_notify_new_block(struct lightningd *ld, u32 height);
+
+void try_update_feerates(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -200,11 +200,7 @@ def test_closing_different_fees(node_factory, bitcoind, executor):
     peers = []
     for feerate in feerates:
         for amount in amounts:
-            p = node_factory.get_node(options={
-                'dev-override-fee-rates': '{}/{}/{}'.format(feerate[0],
-                                                            feerate[1],
-                                                            feerate[2])
-            })
+            p = node_factory.get_node(feerates=feerate)
             p.feerate = feerate
             p.amount = amount
             l1.rpc.connect(p.info['id'], 'localhost', p.port)
@@ -896,8 +892,9 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l2.daemon.wait_for_log('permfail')
     l2.daemon.wait_for_log('sendrawtx exit 0')
 
-    # Make l1's fees really high.
-    l1.rpc.dev_setfees('100000', '100000', '100000')
+    # Make l1's fees really high (and wait for it to exceed 50000)
+    l1.set_feerates((100000, 100000, 100000))
+    l1.daemon.wait_for_log('Feerate estimate for Normal set to [56789][0-9]{4}')
 
     bitcoind.generate_block(1)
     l1.daemon.wait_for_log(' to ONCHAIN')

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -917,7 +917,6 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l1.daemon.wait_for_log('onchaind complete, forgetting peer')
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_fail")
 def test_onchain_different_fees(node_factory, bitcoind, executor):
     """Onchain handling when we've had a range of fees"""

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -284,7 +284,8 @@ def test_closing_negotiation_reconnect(node_factory, bitcoind):
 def test_penalty_inhtlc(node_factory, bitcoind, executor):
     """Test penalty transaction with an incoming HTLC"""
     # We suppress each one after first commit; HTLC gets added not fulfilled.
-    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -355,7 +356,8 @@ def test_penalty_inhtlc(node_factory, bitcoind, executor):
 def test_penalty_outhtlc(node_factory, bitcoind, executor):
     """Test penalty transaction with an outgoing HTLC"""
     # First we need to get funds to l2, so suppress after second.
-    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'], may_fail=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'], may_fail=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -522,7 +524,8 @@ def test_onchain_unwatch(node_factory, bitcoind):
 def test_onchaind_replay(node_factory, bitcoind):
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
     options = {'watchtime-blocks': 201, 'cltv-delta': 101}
-    l1 = node_factory.get_node(options=options, disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options=options, disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(options=options)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -574,7 +577,8 @@ def test_onchain_dust_out(node_factory, bitcoind, executor):
     """Onchain handling of outgoing dust htlcs (they should fail)"""
     # HTLC 1->2, 1 fails after it's irrevocably committed
     disconnects = ['@WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -638,7 +642,8 @@ def test_onchain_timeout(node_factory, bitcoind, executor):
     """Onchain handling of outgoing failed htlcs"""
     # HTLC 1->2, 1 fails just after it's irrevocably committed
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
     l2 = node_factory.get_node()
 
@@ -869,7 +874,8 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     # We need 2 to drop to chain, because then 1's HTLC timeout tx
     # is generated on-the-fly, and is thus feerate sensitive.
     disconnects = ['-WIRE_UPDATE_FAIL_HTLC', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -988,7 +994,8 @@ def test_onchain_different_fees(node_factory, bitcoind, executor):
 def test_permfail_new_commit(node_factory, bitcoind, executor):
     # Test case where we have two possible commits: it will use new one.
     disconnects = ['-WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1025,7 +1032,8 @@ def test_permfail_new_commit(node_factory, bitcoind, executor):
 def test_permfail_htlc_in(node_factory, bitcoind, executor):
     # Test case where we fail with unsettled incoming HTLC.
     disconnects = ['-WIRE_UPDATE_FULFILL_HTLC', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1069,7 +1077,8 @@ def test_permfail_htlc_out(node_factory, bitcoind, executor):
     # Test case where we fail with unsettled outgoing HTLC.
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
     l1 = node_factory.get_node(options={'dev-no-reconnect': None})
-    l2 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l2 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.daemon.wait_for_log('openingd-{} chan #1: Handed peer, entering loop'.format(l1.info['id']))

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -917,20 +917,29 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l1.daemon.wait_for_log('onchaind complete, forgetting peer')
 
 
+@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_fail")
 def test_onchain_different_fees(node_factory, bitcoind, executor):
     """Onchain handling when we've had a range of fees"""
-    l1, l2 = node_factory.line_graph(2, fundchannel=True, fundamount=10**7)
+    l1 = node_factory.get_node(may_reconnect=True)
+    l2 = node_factory.get_node(may_reconnect=True)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.fund_channel(l2, 10**7)
 
     l2.rpc.dev_ignore_htlcs(id=l1.info['id'], ignore=True)
     p1 = executor.submit(l1.pay, l2, 1000000000)
     l1.daemon.wait_for_log('htlc 0: RCVD_ADD_ACK_COMMIT->SENT_ADD_ACK_REVOCATION')
 
-    l1.rpc.dev_setfees('14000')
+    l1.set_feerates((16000, 7500, 3750))
     p2 = executor.submit(l1.pay, l2, 900000000)
     l1.daemon.wait_for_log('htlc 1: RCVD_ADD_ACK_COMMIT->SENT_ADD_ACK_REVOCATION')
 
-    l1.rpc.dev_setfees('5000')
+    # Restart with different feerate for second HTLC.
+    l1.set_feerates((5000, 5000, 3750))
+    l1.restart()
+    l1.daemon.wait_for_log('peer_out WIRE_UPDATE_FEE')
+
     p3 = executor.submit(l1.pay, l2, 800000000)
     l1.daemon.wait_for_log('htlc 2: RCVD_ADD_ACK_COMMIT->SENT_ADD_ACK_REVOCATION')
 
@@ -945,11 +954,11 @@ def test_onchain_different_fees(node_factory, bitcoind, executor):
     # Both sides should have correct feerate
     assert l1.db_query('SELECT min_possible_feerate, max_possible_feerate FROM channels;') == [{
         'min_possible_feerate': 5000,
-        'max_possible_feerate': 14000
+        'max_possible_feerate': 16000
     }]
     assert l2.db_query('SELECT min_possible_feerate, max_possible_feerate FROM channels;') == [{
         'min_possible_feerate': 5000,
-        'max_possible_feerate': 14000
+        'max_possible_feerate': 16000
     }]
 
     bitcoind.generate_block(5)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1094,7 +1094,7 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     time.sleep(1)
 
     # Prevent funder from broadcasting funding tx.
-    l1.fake_bitcoind_fail(1)
+    l1.fake_bitcoind_fail('exit 1')
     # Fund the channel.
     # The process will complete, but funder will be unable
     # to broadcast and confirm funding tx.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -375,8 +375,10 @@ def test_reconnect_sender_add1(node_factory):
                    '+WIRE_UPDATE_ADD_HTLC-nocommit',
                    '@WIRE_UPDATE_ADD_HTLC-nocommit']
 
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -408,8 +410,10 @@ def test_reconnect_sender_add(node_factory):
                    '-WIRE_REVOKE_AND_ACK',
                    '@WIRE_REVOKE_AND_ACK',
                    '+WIRE_REVOKE_AND_ACK']
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -436,7 +440,8 @@ def test_reconnect_receiver_add(node_factory):
                    '-WIRE_REVOKE_AND_ACK',
                    '@WIRE_REVOKE_AND_ACK',
                    '+WIRE_REVOKE_AND_ACK']
-    l1 = node_factory.get_node(may_reconnect=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(may_reconnect=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects,
                                may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -719,7 +724,8 @@ def test_channel_persistence(node_factory, bitcoind, executor):
     # Start two nodes and open a channel (to remember). l2 will
     # mysteriously die while committing the first HTLC so we can
     # check that HTLCs reloaded from the DB work.
-    l1 = node_factory.get_node(may_reconnect=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(may_reconnect=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'],
                                may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -915,7 +921,9 @@ def test_fee_limits(node_factory):
 def test_update_fee_reconnect(node_factory, bitcoind):
     # Disconnect after first commitsig.
     disconnects = ['+WIRE_COMMITMENT_SIGNED']
-    l1 = node_factory.get_node(disconnect=disconnects, may_reconnect=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=disconnects, may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     chan = l1.fund_channel(l2, 10**6)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1083,7 +1083,7 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     # blocks.
     blocks = 200
     # funder
-    l1 = node_factory.get_node(fake_bitcoin_cli=True)
+    l1 = node_factory.get_node()
     # fundee
     l2 = node_factory.get_node(options={"dev-max-funding-unconfirmed-blocks": blocks})
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1094,13 +1094,13 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     time.sleep(1)
 
     # Prevent funder from broadcasting funding tx.
-    l1.fake_bitcoind_fail('exit 1')
+    l1.bitcoind_cmd_override('exit 1')
     # Fund the channel.
     # The process will complete, but funder will be unable
     # to broadcast and confirm funding tx.
     l1.rpc.fundchannel(l2.info['id'], 10**6)
     # Prevent l1 from timing out bitcoin-cli.
-    l1.fake_bitcoind_unfail()
+    l1.bitcoind_cmd_remove_override()
     # Generate blocks until unconfirmed.
     bitcoind.generate_block(blocks)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1093,3 +1093,54 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     l2.daemon.wait_for_log('Forgetting channel: It has been {} blocks'.format(blocks))
     # fundee will also forget and disconnect from peer.
     assert len(l2.rpc.listpeers(l1.info['id'])['peers']) == 0
+
+
+@unittest.skipIf(not DEVELOPER, "needs dev_fail")
+def test_no_fee_estimate(node_factory, bitcoind, executor):
+    l1 = node_factory.get_node(start=False)
+    l1.bitcoind_cmd_override(cmd='estimatesmartfee',
+                             failscript="""echo '{ "errors": [ "Insufficient data or no feerate found" ], "blocks": 0 }'; exit 0""")
+    l1.start()
+
+    l2 = node_factory.get_node()
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    # Can't fund a channel.
+    l1.fundwallet(10**7)
+    with pytest.raises(RpcError, match=r'Cannot estimate fees'):
+        l1.rpc.fundchannel(l2.info['id'], 10**6)
+
+    # Can't withdraw either.
+    with pytest.raises(RpcError, match=r'Cannot estimate fees'):
+        l1.rpc.withdraw(l2.rpc.newaddr()['address'], 'all')
+
+    # But can accept incoming connections.
+    l2.fund_channel(l1, 10**6)
+
+    # Can do HTLCs.
+    l2.pay(l1, 10**5)
+
+    # Can do mutual close.
+    l1.rpc.close(l2.info['id'])
+    bitcoind.generate_block(100)
+
+    # Can do unilateral close.
+    l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
+    l2.fund_channel(l1, 10**6)
+    l2.pay(l1, 10**9 // 2)
+    l1.rpc.dev_fail(l2.info['id'])
+    l1.daemon.wait_for_log('sendrawtx exit 0')
+    bitcoind.generate_block(5)
+    l1.daemon.wait_for_log('sendrawtx exit 0')
+    bitcoind.generate_block(100)
+
+    # Restart estimatesmartfee, wait for it to pass 5000
+    l1.set_feerates((15000, 7500, 3750), True)
+    l1.daemon.wait_for_log('Feerate estimate for Normal set to [567][0-9]{3}')
+
+    # Can now fund a channel.
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.fundchannel(l2.info['id'], 10**6)
+
+    # Can withdraw.
+    l1.rpc.withdraw(l2.rpc.newaddr()['address'], 'all')

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -88,7 +88,7 @@ def test_bitcoin_failure(node_factory, bitcoind):
     # Make sure we're not failing it between getblockhash and getblock.
     sync_blockheight(bitcoind, [l1])
 
-    l1.fake_bitcoind_fail(1)
+    l1.fake_bitcoind_fail('exit 1')
 
     # This should cause both estimatefee and getblockhash fail
     l1.daemon.wait_for_logs(['estimatesmartfee .* exited with status 1',

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -153,7 +153,9 @@ def test_ping(node_factory):
 def test_htlc_sig_persistence(node_factory, executor):
     """Interrupt a payment between two peers, then fail and recover funds using the HTLC sig.
     """
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -201,8 +203,10 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
 
     # HTLC 1->2, 1 fails after it's irrevocably committed, can't reconnect
     disconnects = ['@WIRE_REVOKE_AND_ACK']
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               options={'dev-no-reconnect': None})
+                               options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -258,8 +262,10 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
 
     # HTLC 1->2, 1 fails after 2 has sent committed the fulfill
     disconnects = ['-WIRE_REVOKE_AND_ACK*2']
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               options={'dev-no-reconnect': None})
+                               options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -780,7 +786,9 @@ def test_reserve_enforcement(node_factory, executor):
 @unittest.skipIf(not DEVELOPER, "needs dev_disconnect")
 def test_htlc_send_timeout(node_factory, bitcoind):
     """Test that we don't commit an HTLC to an unreachable node."""
-    l1 = node_factory.get_node(options={'log-level': 'io'})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'log-level': 'io'},
+                               feerates=(7500, 7500, 7500))
     # Blackhole it after it sends HTLC_ADD to l3.
     l2 = node_factory.get_node(disconnect=['0WIRE_UPDATE_ADD_HTLC'],
                                options={'log-level': 'io'})

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -83,12 +83,12 @@ def test_db_upgrade(node_factory):
 
 
 def test_bitcoin_failure(node_factory, bitcoind):
-    l1 = node_factory.get_node(fake_bitcoin_cli=True)
+    l1 = node_factory.get_node()
 
     # Make sure we're not failing it between getblockhash and getblock.
     sync_blockheight(bitcoind, [l1])
 
-    l1.fake_bitcoind_fail('exit 1')
+    l1.bitcoind_cmd_override('exit 1')
 
     # This should cause both estimatefee and getblockhash fail
     l1.daemon.wait_for_logs(['estimatesmartfee .* exited with status 1',
@@ -99,7 +99,7 @@ def test_bitcoin_failure(node_factory, bitcoind):
                              'getblockhash .* exited with status 1'])
 
     # Restore, then it should recover and get blockheight.
-    l1.fake_bitcoind_unfail()
+    l1.bitcoind_cmd_remove_override()
     bitcoind.generate_block(5)
     sync_blockheight(bitcoind, [l1])
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -182,9 +182,11 @@ def test_pay_optional_args(node_factory):
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_payment_success_persistence(node_factory, executor):
     # Start two nodes and open a channel.. die during payment.
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -226,9 +228,11 @@ def test_payment_success_persistence(node_factory, executor):
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_payment_failed_persistence(node_factory, executor):
     # Start two nodes and open a channel.. die during payment.
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -443,7 +447,7 @@ def test_sendpay_cant_afford(node_factory):
         pay(l1, l2, 10**9 + 1)
 
     # This is the fee, which needs to be taken into account for l1.
-    available = 10**9 - 6720
+    available = 10**9 - 13440
     # Reserve is 1%.
     reserve = 10**7
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -94,9 +94,9 @@ def test_pay_disconnect(node_factory, bitcoind):
     route = l1.rpc.getroute(l2.info['id'], 123000, 1)["route"]
 
     # Make l2 upset by asking for crazy fee.
-    l1.rpc.dev_setfees('150000')
-    # Wait for l1 notice
-    l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 150000 outside range 1875-75000')
+    l1.set_feerates((250000, 7500, 3750))
+    # Wait for l2 to notice
+    l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee [0-9]* outside range 1875-75000')
 
     # Can't pay while its offline.
     with pytest.raises(RpcError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -601,18 +601,19 @@ class LightningNode(object):
         # wait for sendpay to comply
         self.rpc.waitsendpay(rhash)
 
-    def fake_bitcoind_fail(self, failscript='exit 1', cmd=None):
+    def bitcoind_cmd_override(self, failscript='exit 1', cmd=None):
         # Create and rename, for atomicity.
         f = os.path.join(self.daemon.lightning_dir, "bitcoin-cli-fail.tmp")
         with open(f, "w") as text_file:
             text_file.write(failscript)
+        os.chmod(f, os.stat(f).st_mode | stat.S_IEXEC)
         if cmd:
             failfile = "bitcoin-cli-fail-{}".format(cmd)
         else:
             failfile = "bitcoin-cli-fail"
         os.rename(f, os.path.join(self.daemon.lightning_dir, failfile))
 
-    def fake_bitcoind_unfail(self, cmd=None):
+    def bitcoind_cmd_remove_override(self, cmd=None):
         if cmd:
             failfile = "bitcoin-cli-fail-{}".format(cmd)
         else:
@@ -644,7 +645,6 @@ class NodeFactory(object):
             'may_fail',
             'may_reconnect',
             'random_hsm',
-            'fake_bitcoin_cli'
         ]
         node_opts = {k: v for k, v in opts.items() if k in node_opt_keys}
         cli_opts = {k: v for k, v in opts.items() if k not in node_opt_keys}
@@ -673,8 +673,7 @@ class NodeFactory(object):
 
         return [j.result() for j in jobs]
 
-    def get_node(self, disconnect=None, options=None, may_fail=False, may_reconnect=False, random_hsm=False,
-                 fake_bitcoin_cli=False):
+    def get_node(self, disconnect=None, options=None, may_fail=False, may_reconnect=False, random_hsm=False):
         with self.lock:
             node_id = self.next_id
             self.next_id += 1
@@ -705,18 +704,16 @@ class NodeFactory(object):
             if not may_reconnect:
                 daemon.opts["dev-no-reconnect"] = None
 
-        if fake_bitcoin_cli:
-            cli = os.path.join(lightning_dir, "fake-bitcoin-cli")
-            with open(cli, "w") as text_file:
-                text_file.write('#! /bin/sh\n'
-                                '! [ -f bitcoin-cli-fail ] || . {ldir}/bitcoin-cli-fail\n'
-                                'for a in "$@"; do\n'
-                                '\t! [ -f bitcoin-cli-fail-"$a" ] || . {ldir}/bitcoin-cli-fail-"$a"\n'
-                                'done\n'
-                                'exec bitcoin-cli "$@"\n'
-                                .format(ldir=lightning_dir))
-            os.chmod(cli, os.stat(cli).st_mode | stat.S_IEXEC)
-            daemon.opts['bitcoin-cli'] = cli
+        cli = os.path.join(lightning_dir, "fake-bitcoin-cli")
+        with open(cli, "w") as text_file:
+            text_file.write('#! /bin/sh\n'
+                            '! [ -x bitcoin-cli-fail ] || exec ./bitcoin-cli-fail "$@"\n'
+                            'for a in "$@"; do\n'
+                            '\t! [ -x bitcoin-cli-fail-"$a" ] || exec ./bitcoin-cli-fail-"$a" "$@"\n'
+                            'done\n'
+                            'exec bitcoin-cli "$@"\n')
+        os.chmod(cli, os.stat(cli).st_mode | stat.S_IEXEC)
+        daemon.opts['bitcoin-cli'] = cli
 
         if options is not None:
             daemon.opts.update(options)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -75,9 +75,6 @@ bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UN
 /* Generated stub for fromwire_hsm_sign_commitment_tx_reply */
 bool fromwire_hsm_sign_commitment_tx_reply(const void *p UNNEEDED, secp256k1_ecdsa_signature *sig UNNEEDED)
 { fprintf(stderr, "fromwire_hsm_sign_commitment_tx_reply called!\n"); abort(); }
-/* Generated stub for get_feerate */
-u32 get_feerate(const struct chain_topology *topo UNNEEDED, enum feerate feerate UNNEEDED)
-{ fprintf(stderr, "get_feerate called!\n"); abort(); }
 /* Generated stub for invoices_autoclean_set */
 void invoices_autoclean_set(struct invoices *invoices UNNEEDED,
 			    u64 cycle_seconds UNNEEDED,
@@ -357,6 +354,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 /* Generated stub for towire_hsm_sign_commitment_tx */
 u8 *towire_hsm_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct pubkey *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 funding_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_commitment_tx called!\n"); abort(); }
+/* Generated stub for try_get_feerate */
+u32 try_get_feerate(const struct chain_topology *topo UNNEEDED, enum feerate feerate UNNEEDED)
+{ fprintf(stderr, "try_get_feerate called!\n"); abort(); }
 /* Generated stub for watch_txid */
 struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   struct chain_topology *topo UNNEEDED,


### PR DESCRIPTION
This is part 1 of splitting #1846.  No changes from that, however.

Six patches are test infrastructure: I know @cdecker wants to change that, but I'd prefer that happen afterwards rather than blocking these fixes.

Things this fixes:
1. There was a window on startup where we'd use default feerate.   Instead, we wait.
2. We did not correctly update fees when restarting, or if they changed before funding tx locked in.
3. If we couldn't get a fee estimate on startup, we put zeroes into the averager, which meant when bitcoind started giving estimates, we'd be low for quite a while.
4. Since we hid the default feerate in the estimator, callers couldn't know when it was being used.
    In practice, they either have other sources to estimate feerate (existing tx), or should refuse
    (opening channels, withdrawing funds).
