### PR TITLE
Never guess feerate

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -108,19 +108,6 @@ class LightningRpc(UnixDomainSocketRpc):
         res = self.call("listpeers", payload)
         return res.get("peers") and res["peers"][0] or None
 
-    def dev_setfees(self, immediate=None, normal=None, slow=None):
-        """
-        Set feerate in satoshi-per-kw for {immediate}, {normal} and {slow}
-        (each is optional, when set, separate by spaces) and show the value
-        of those three feerates
-        """
-        payload = {
-            "immediate": immediate,
-            "normal": normal,
-            "slow": slow
-        }
-        return self.call("dev-setfees", payload)
-
     def listnodes(self, node_id=None):
         """
         Show all nodes in our local network view, filter on node {id}

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -344,8 +344,8 @@ static void update_feerates(struct bitcoind *bitcoind,
 	}
 
 	if (topo->feerate_uninitialized) {
-		/* Moving this forward in time is ok, but feerate smoothing is effectively
-		 * disabled until topo->startup is set to false */
+		/* This doesn't mean we *have* a fee estimate, but it does
+		 * mean we tried. */
 		topo->feerate_uninitialized = false;
 		maybe_completed_init(topo);
 	}

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -309,7 +309,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 			continue;
 
 		/* Initial smoothed feerate is the polled feerate */
-		if (topo->feerate_uninitialized) {
+		if (!topo->feerate[i]) {
 			old_feerates[i] = feerate;
 			log_debug(topo->log,
 					  "Smoothed feerate estimate for %s initialized to polled estimate %u",

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -131,8 +131,8 @@ size_t get_tx_depth(const struct chain_topology *topo,
 /* Get highest block number. */
 u32 get_block_height(const struct chain_topology *topo);
 
-/* Get fee rate in satoshi per kiloweight. */
-u32 get_feerate(const struct chain_topology *topo, enum feerate feerate);
+/* Get fee rate in satoshi per kiloweight, or 0 if unavailable! */
+u32 try_get_feerate(const struct chain_topology *topo, enum feerate feerate);
 
 /* Broadcast a single tx, and rebroadcast as reqd (copies tx).
  * If failed is non-NULL, call that and don't rebroadcast. */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -82,7 +82,7 @@ struct chain_topology {
 	struct block *prev_tip, *tip;
 	struct block_map block_map;
 	u32 feerate[NUM_FEERATES];
-	bool startup;
+	bool feerate_uninitialized;
 
 	/* Where to store blockchain info. */
 	struct wallet *wallet;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -155,6 +155,7 @@ void begin_topology(struct chain_topology *topo);
 
 struct txlocator *locate_tx(const void *ctx, const struct chain_topology *topo, const struct bitcoin_txid *txid);
 
+/* In channel_control.c */
 void notify_feerate_change(struct lightningd *ld);
 
 #if DEVELOPER

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -111,11 +111,6 @@ struct chain_topology {
 	/* Transactions/txos we are watching. */
 	struct txwatch_hash txwatches;
 	struct txowatch_hash txowatches;
-
-#if DEVELOPER
-	/* Force a particular fee rate regardless of estimatefee (satoshis/kw) */
-	u32 *dev_override_fee_rate;
-#endif
 };
 
 /* Information relevant to locating a TX in a blockchain. */

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -25,6 +25,10 @@ static void lockin_complete(struct channel *channel)
 	/* We set this once they're locked in. */
 	assert(channel->remote_funding_locked);
 	channel_set_state(channel, CHANNELD_AWAITING_LOCKIN, CHANNELD_NORMAL);
+
+	/* Fees might have changed (and we use IMMEDIATE once we're funded),
+	 * so update now. */
+	try_update_feerates(channel->peer->ld, channel);
 }
 
 /* We were informed by channeld that it announced the channel and sent

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -333,6 +333,10 @@ void peer_start_channeld(struct channel *channel,
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(channel->owner, take(initmsg));
+
+	/* On restart, feerate might not be what we expect: adjust now. */
+	if (channel->funder == LOCAL)
+		try_update_feerates(ld, channel);
 }
 
 bool channel_tell_funding_locked(struct lightningd *ld,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -401,29 +401,6 @@ static void config_register_opts(struct lightningd *ld)
 }
 
 #if DEVELOPER
-static char *opt_set_fee_rates(const char *arg, struct chain_topology *topo)
-{
-	tal_free(topo->dev_override_fee_rate);
-	topo->dev_override_fee_rate = tal_arr(topo, u32, 3);
-
-	for (size_t i = 0; i < tal_count(topo->dev_override_fee_rate); i++) {
-		char *endp;
-		char term;
-
-		if (i == tal_count(topo->dev_override_fee_rate)-1)
-			term = '\0';
-		else
-			term = '/';
-		topo->dev_override_fee_rate[i] = strtol(arg, &endp, 10);
-		if (endp == arg || *endp != term)
-			return tal_fmt(NULL,
-				       "Feerates must be <num>/<num>/<num>");
-
-		arg = endp + 1;
-	}
-	return NULL;
-}
-
 static void dev_register_opts(struct lightningd *ld)
 {
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
@@ -451,9 +428,6 @@ static void dev_register_opts(struct lightningd *ld)
 			 "will cause channels to be closed more often due to "
 			 "fee fluctuations, large values may result in large "
 			 "fees.");
-	opt_register_arg("--dev-override-fee-rates", opt_set_fee_rates, NULL,
-			 ld->topology,
-			 "Force a specific rates (immediate/normal/slow) in satoshis per kw regardless of estimated fees");
 
 	opt_register_arg(
 	    "--dev-channel-update-interval=<s>", opt_set_u32, opt_show_u32,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -88,9 +88,10 @@ void activate_peers(struct lightningd *ld);
 
 void drop_to_chain(struct lightningd *ld, struct channel *channel, bool cooperative);
 
-/* Get range of feerates to insist other side abide by for normal channels. */
-u32 feerate_min(struct lightningd *ld);
-u32 feerate_max(struct lightningd *ld);
+/* Get range of feerates to insist other side abide by for normal channels.
+ * If we have to guess, sets *unknown to true, otherwise false. */
+u32 feerate_min(struct lightningd *ld, bool *unknown);
+u32 feerate_max(struct lightningd *ld, bool *unknown);
 
 void channel_watch_funding(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1671,47 +1671,6 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 	} while (removed);
 }
 
-static void update_feerates(struct lightningd *ld, struct channel *channel)
-{
-	u8 *msg = towire_channel_feerates(NULL,
-					  get_feerate(ld->topology,
-						      FEERATE_IMMEDIATE),
-					  feerate_min(ld),
-					  feerate_max(ld));
-	subd_send_msg(channel->owner, take(msg));
-}
-
-void try_update_feerates(struct lightningd *ld, struct channel *channel)
-{
-	/* No point until funding locked in */
-	if (!channel_fees_can_change(channel))
-		return;
-
-	/* Can't if no daemon listening. */
-	if (!channel->owner)
-		return;
-
-	update_feerates(ld, channel);
-}
-
-void notify_feerate_change(struct lightningd *ld)
-{
-	struct peer *peer;
-
-	/* FIXME: We should notify onchaind about NORMAL fee change in case
-	 * it's going to generate more txs. */
-	list_for_each(&ld->peers, peer, list) {
-		struct channel *channel = peer_active_channel(peer);
-
-		if (!channel)
-			continue;
-
-		/* FIXME: We choose not to drop to chain if we can't contact
-		 * peer.  We *could* do so, however. */
-		try_update_feerates(ld, channel);
-	}
-}
-
 #if DEVELOPER
 static void json_dev_ignore_htlcs(struct command *cmd, const char *buffer,
 				  const jsmntok_t *params)

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1671,6 +1671,29 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 	} while (removed);
 }
 
+static void update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	u8 *msg = towire_channel_feerates(NULL,
+					  get_feerate(ld->topology,
+						      FEERATE_IMMEDIATE),
+					  feerate_min(ld),
+					  feerate_max(ld));
+	subd_send_msg(channel->owner, take(msg));
+}
+
+void try_update_feerates(struct lightningd *ld, struct channel *channel)
+{
+	/* No point until funding locked in */
+	if (!channel_fees_can_change(channel))
+		return;
+
+	/* Can't if no daemon listening. */
+	if (!channel->owner)
+		return;
+
+	update_feerates(ld, channel);
+}
+
 void notify_feerate_change(struct lightningd *ld)
 {
 	struct peer *peer;
@@ -1679,22 +1702,13 @@ void notify_feerate_change(struct lightningd *ld)
 	 * it's going to generate more txs. */
 	list_for_each(&ld->peers, peer, list) {
 		struct channel *channel = peer_active_channel(peer);
-		u8 *msg;
 
-		if (!channel || !channel_fees_can_change(channel))
+		if (!channel)
 			continue;
 
 		/* FIXME: We choose not to drop to chain if we can't contact
 		 * peer.  We *could* do so, however. */
-		if (!channel->owner)
-			continue;
-
-		msg = towire_channel_feerates(channel,
-					      get_feerate(ld->topology,
-							  FEERATE_IMMEDIATE),
-					      feerate_min(ld),
-					      feerate_max(ld));
-		subd_send_msg(channel->owner, take(msg));
+		try_update_feerates(ld, channel);
 	}
 }
 

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -60,5 +60,4 @@ void onchain_fulfilled_htlc(struct channel *channel,
 
 void htlcs_notify_new_block(struct lightningd *ld, u32 height);
 
-void try_update_feerates(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -59,4 +59,6 @@ void onchain_fulfilled_htlc(struct channel *channel,
 			    const struct preimage *preimage);
 
 void htlcs_notify_new_block(struct lightningd *ld, u32 height);
+
+void try_update_feerates(struct lightningd *ld, struct channel *channel);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -200,11 +200,7 @@ def test_closing_different_fees(node_factory, bitcoind, executor):
     peers = []
     for feerate in feerates:
         for amount in amounts:
-            p = node_factory.get_node(options={
-                'dev-override-fee-rates': '{}/{}/{}'.format(feerate[0],
-                                                            feerate[1],
-                                                            feerate[2])
-            })
+            p = node_factory.get_node(feerates=feerate)
             p.feerate = feerate
             p.amount = amount
             l1.rpc.connect(p.info['id'], 'localhost', p.port)
@@ -896,8 +892,9 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l2.daemon.wait_for_log('permfail')
     l2.daemon.wait_for_log('sendrawtx exit 0')
 
-    # Make l1's fees really high.
-    l1.rpc.dev_setfees('100000', '100000', '100000')
+    # Make l1's fees really high (and wait for it to exceed 50000)
+    l1.set_feerates((100000, 100000, 100000))
+    l1.daemon.wait_for_log('Feerate estimate for Normal set to [56789][0-9]{4}')
 
     bitcoind.generate_block(1)
     l1.daemon.wait_for_log(' to ONCHAIN')

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -917,7 +917,6 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l1.daemon.wait_for_log('onchaind complete, forgetting peer')
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_fail")
 def test_onchain_different_fees(node_factory, bitcoind, executor):
     """Onchain handling when we've had a range of fees"""

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -284,7 +284,8 @@ def test_closing_negotiation_reconnect(node_factory, bitcoind):
 def test_penalty_inhtlc(node_factory, bitcoind, executor):
     """Test penalty transaction with an incoming HTLC"""
     # We suppress each one after first commit; HTLC gets added not fulfilled.
-    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'], may_fail=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED-nocommit'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -355,7 +356,8 @@ def test_penalty_inhtlc(node_factory, bitcoind, executor):
 def test_penalty_outhtlc(node_factory, bitcoind, executor):
     """Test penalty transaction with an outgoing HTLC"""
     # First we need to get funds to l2, so suppress after second.
-    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'], may_fail=True)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'], may_fail=True, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['=WIRE_COMMITMENT_SIGNED*3-nocommit'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -522,7 +524,8 @@ def test_onchain_unwatch(node_factory, bitcoind):
 def test_onchaind_replay(node_factory, bitcoind):
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
     options = {'watchtime-blocks': 201, 'cltv-delta': 101}
-    l1 = node_factory.get_node(options=options, disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options=options, disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(options=options)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -574,7 +577,8 @@ def test_onchain_dust_out(node_factory, bitcoind, executor):
     """Onchain handling of outgoing dust htlcs (they should fail)"""
     # HTLC 1->2, 1 fails after it's irrevocably committed
     disconnects = ['@WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -638,7 +642,8 @@ def test_onchain_timeout(node_factory, bitcoind, executor):
     """Onchain handling of outgoing failed htlcs"""
     # HTLC 1->2, 1 fails just after it's irrevocably committed
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
     l2 = node_factory.get_node()
 
@@ -869,7 +874,8 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     # We need 2 to drop to chain, because then 1's HTLC timeout tx
     # is generated on-the-fly, and is thus feerate sensitive.
     disconnects = ['-WIRE_UPDATE_FAIL_HTLC', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -985,7 +991,8 @@ def test_onchain_different_fees(node_factory, bitcoind, executor):
 def test_permfail_new_commit(node_factory, bitcoind, executor):
     # Test case where we have two possible commits: it will use new one.
     disconnects = ['-WIRE_REVOKE_AND_ACK', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1022,7 +1029,8 @@ def test_permfail_new_commit(node_factory, bitcoind, executor):
 def test_permfail_htlc_in(node_factory, bitcoind, executor):
     # Test case where we fail with unsettled incoming HTLC.
     disconnects = ['-WIRE_UPDATE_FULFILL_HTLC', 'permfail']
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None}, feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1066,7 +1074,8 @@ def test_permfail_htlc_out(node_factory, bitcoind, executor):
     # Test case where we fail with unsettled outgoing HTLC.
     disconnects = ['+WIRE_REVOKE_AND_ACK', 'permfail']
     l1 = node_factory.get_node(options={'dev-no-reconnect': None})
-    l2 = node_factory.get_node(disconnect=disconnects)
+    # Feerates identical so we don't get gratuitous commit to update them
+    l2 = node_factory.get_node(disconnect=disconnects, feerates=(7500, 7500, 7500))
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.daemon.wait_for_log('openingd-{} chan #1: Handed peer, entering loop'.format(l1.info['id']))
@@ -1127,9 +1136,11 @@ def test_permfail(node_factory, bitcoind):
     l1.pay(l2, 200000000)
 
     # Make sure l2 has received sig with 0 htlcs!
+    l2.daemon.wait_for_log('Received commit_sig with 1 htlc sigs')
     l2.daemon.wait_for_log('Received commit_sig with 0 htlc sigs')
 
     # Make sure l1 has final revocation.
+    l1.daemon.wait_for_log('Sending commit_sig with 1 htlc sigs')
     l1.daemon.wait_for_log('Sending commit_sig with 0 htlc sigs')
     l1.daemon.wait_for_log('peer_in WIRE_REVOKE_AND_ACK')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1160,13 +1160,14 @@ def test_no_fee_estimate(node_factory, bitcoind, executor):
 def test_funder_feerate_reconnect(node_factory, bitcoind):
     # l1 updates fees, then reconnect so l2 retransmits commitment_signed.
     disconnects = ['-WIRE_COMMITMENT_SIGNED']
-    l1 = node_factory.get_node(may_reconnect=True)
+    l1 = node_factory.get_node(may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects, may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.fund_channel(l2, 10**6)
 
-    # lockin will cause fee update, causing disconnect.
-    bitcoind.generate_block(5)
+    # create fee update, causing disconnect.
+    l1.set_feerates((15000, 7500, 3750))
     l2.daemon.wait_for_log('dev_disconnect: \-WIRE_COMMITMENT_SIGNED')
 
     # Wait until they reconnect.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1168,11 +1168,13 @@ def test_dataloss_protection(node_factory, bitcoind):
                            # channel_id
                            "[0-9a-f]{64}"
                            # next_local_commitment_number
-                           "0000000000000001"
+                           "000000000000000[1-9]"
                            # next_remote_revocation_number
-                           "0000000000000000"
-                           # your_last_per_commitment_secret (unknown == zeroes)
-                           "0{64}"
+                           "000000000000000[0-9]"
+                           # your_last_per_commitment_secret (funding_depth may
+                           # trigger a fee-update and commit, hence this may not
+                           # be zero)
+                           "[0-9a-f]{64}"
                            # my_current_per_commitment_point
                            "0[23][0-9a-f]{64}")
     # After an htlc, we should get different results (two more commits)
@@ -1190,9 +1192,9 @@ def test_dataloss_protection(node_factory, bitcoind):
                            # channel_id
                            "[0-9a-f]{64}"
                            # next_local_commitment_number
-                           "0000000000000003"
+                           "000000000000000[1-9]"
                            # next_remote_revocation_number
-                           "0000000000000002"
+                           "000000000000000[1-9]"
                            # your_last_per_commitment_secret
                            "[0-9a-f]{64}"
                            # my_current_per_commitment_point
@@ -1219,12 +1221,12 @@ def test_dataloss_protection(node_factory, bitcoind):
     # l2 should still recover something!
     bitcoind.generate_block(1)
 
-    l2.daemon.wait_for_log("ERROR: Unknown commitment #2, recovering our funds!")
+    l2.daemon.wait_for_log("ERROR: Unknown commitment #[0-9], recovering our funds!")
 
     # Restarting l2, and it should remember from db.
     l2.restart()
 
-    l2.daemon.wait_for_log("ERROR: Unknown commitment #2, recovering our funds!")
+    l2.daemon.wait_for_log("ERROR: Unknown commitment #[0-9], recovering our funds!")
     bitcoind.generate_block(100)
     l2.daemon.wait_for_log('WIRE_ONCHAIN_ALL_IRREVOCABLY_RESOLVED')
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -792,7 +792,8 @@ def test_htlc_send_timeout(node_factory, bitcoind):
                                feerates=(7500, 7500, 7500))
     # Blackhole it after it sends HTLC_ADD to l3.
     l2 = node_factory.get_node(disconnect=['0WIRE_UPDATE_ADD_HTLC'],
-                               options={'log-level': 'io'})
+                               options={'log-level': 'io'},
+                               feerates=(7500, 7500, 7500))
     l3 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -154,7 +154,9 @@ def test_ping(node_factory):
 def test_htlc_sig_persistence(node_factory, executor):
     """Interrupt a payment between two peers, then fail and recover funds using the HTLC sig.
     """
-    l1 = node_factory.get_node(options={'dev-no-reconnect': None})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -202,8 +204,10 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
 
     # HTLC 1->2, 1 fails after it's irrevocably committed, can't reconnect
     disconnects = ['@WIRE_REVOKE_AND_ACK']
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               options={'dev-no-reconnect': None})
+                               options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -259,8 +263,10 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
 
     # HTLC 1->2, 1 fails after 2 has sent committed the fulfill
     disconnects = ['-WIRE_REVOKE_AND_ACK*2']
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               options={'dev-no-reconnect': None})
+                               options={'dev-no-reconnect': None},
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -781,7 +787,9 @@ def test_reserve_enforcement(node_factory, executor):
 @unittest.skipIf(not DEVELOPER, "needs dev_disconnect")
 def test_htlc_send_timeout(node_factory, bitcoind):
     """Test that we don't commit an HTLC to an unreachable node."""
-    l1 = node_factory.get_node(options={'log-level': 'io'})
+    # Feerates identical so we don't get gratuitous commit to update them
+    l1 = node_factory.get_node(options={'log-level': 'io'},
+                               feerates=(7500, 7500, 7500))
     # Blackhole it after it sends HTLC_ADD to l3.
     l2 = node_factory.get_node(disconnect=['0WIRE_UPDATE_ADD_HTLC'],
                                options={'log-level': 'io'})

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -189,9 +189,11 @@ def test_pay_optional_args(node_factory):
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_payment_success_persistence(node_factory, executor):
     # Start two nodes and open a channel.. die during payment.
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -233,9 +235,11 @@ def test_payment_success_persistence(node_factory, executor):
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_payment_failed_persistence(node_factory, executor):
     # Start two nodes and open a channel.. die during payment.
+    # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
-                               may_reconnect=True)
+                               may_reconnect=True,
+                               feerates=(7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -450,7 +454,7 @@ def test_sendpay_cant_afford(node_factory):
         pay(l1, l2, 10**9 + 1)
 
     # This is the fee, which needs to be taken into account for l1.
-    available = 10**9 - 6720
+    available = 10**9 - 13440
     # Reserve is 1%.
     reserve = 10**7
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -106,9 +106,10 @@ def test_pay_disconnect(node_factory, bitcoind):
     l1.daemon.wait_for_log('peer_out WIRE_CHANNEL_REESTABLISH')
 
     # Make l2 upset by asking for crazy fee.
-    l1.rpc.dev_setfees('150000')
+    l1.set_feerates((10**6, 1000**6, 1000**6), False)
+
     # Wait for l1 notice
-    l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee 150000 outside range 1875-75000')
+    l1.daemon.wait_for_log(r'Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: received ERROR channel .*: update_fee \d+ outside range 1875-75000')
 
     # Should fail due to permenant channel fail
     with pytest.raises(RpcError):

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -75,9 +75,6 @@ bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UN
 /* Generated stub for fromwire_hsm_sign_commitment_tx_reply */
 bool fromwire_hsm_sign_commitment_tx_reply(const void *p UNNEEDED, secp256k1_ecdsa_signature *sig UNNEEDED)
 { fprintf(stderr, "fromwire_hsm_sign_commitment_tx_reply called!\n"); abort(); }
-/* Generated stub for get_feerate */
-u32 get_feerate(const struct chain_topology *topo UNNEEDED, enum feerate feerate UNNEEDED)
-{ fprintf(stderr, "get_feerate called!\n"); abort(); }
 /* Generated stub for invoices_autoclean_set */
 void invoices_autoclean_set(struct invoices *invoices UNNEEDED,
 			    u64 cycle_seconds UNNEEDED,
@@ -357,6 +354,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 /* Generated stub for towire_hsm_sign_commitment_tx */
 u8 *towire_hsm_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct pubkey *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 funding_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_commitment_tx called!\n"); abort(); }
+/* Generated stub for try_get_feerate */
+u32 try_get_feerate(const struct chain_topology *topo UNNEEDED, enum feerate feerate UNNEEDED)
+{ fprintf(stderr, "try_get_feerate called!\n"); abort(); }
 /* Generated stub for watch_txid */
 struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   struct chain_topology *topo UNNEEDED,


### PR DESCRIPTION
This is based on #1863 and #1861 (merged)

It's the basically the middle part of #1846 .

Things this fixes:

1.  There was a window on startup where we'd use default feerate. Instead, we wait.
2.  We did not correctly update fees when restarting, or if they changed before funding tx locked in.
3.  If we couldn't get a fee estimate on startup, we put zeroes into the averager, which meant when bitcoind started giving estimates, we'd be low for quite a while.
4.  Since we hid the default feerate in the estimator, callers couldn't know when it was being used.
     In practice, they either have other sources to estimate feerate (existing tx), or should refuse
     (opening channels, withdrawing funds).
