### PR TITLE
lightningd: fix double-free on multiple HTLC timeouts.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -408,6 +408,9 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds UNU
 
 static void htlc_offer_timeout(struct channel *channel)
 {
+	/* Unset this in case we reconnect and start again. */
+	channel->htlc_timeout = NULL;
+
 	/* If owner died, we should already be taken care of. */
 	if (!channel->owner || channel->state != CHANNELD_NORMAL)
 		return;


### PR DESCRIPTION
We can close a connection with a peer to timeout an HTLC, but
we need to clear the pointer otherwise next time we try, we'll
free an expired pointer:

```
lightningd: Fatal signal 6 (version v0.6-336-gfcd1eb5-modded)
0x13ce86 crashdump
	common/daemon.c:37
0x5739f1f ???
	???:0
0x5739e97 ???
	???:0
0x573b800 ???
	???:0
0x1850c3 call_error
	ccan/ccan/tal/tal.c:93
0x18528b check_bounds
	ccan/ccan/tal/tal.c:165
0x1852ca to_tal_hdr
	ccan/ccan/tal/tal.c:174
0x185bfb tal_free
	ccan/ccan/tal/tal.c:472
0x1343a8 peer_sending_commitsig
	lightningd/peer_htlcs.c:1035
0x114f25 channel_msg
	lightningd/channel_control.c:159
0x13756b sd_msg_read
	lightningd/subd.c:474
0x177c1f next_plan
	ccan/ccan/io/io.c:59
0x178717 do_plan
	ccan/ccan/io/io.c:387
0x178755 io_ready
	ccan/ccan/io/io.c:397
0x17a336 io_loop
	ccan/ccan/io/poll.c:310
0x120589 main
	lightningd/lightningd.c:455
0x571cb96 ???
	???:0
0x10e6d9 ???
	???:0
0xffffffffffffffff ???
	???:0
2018-08-16T06:41:21.249Z lightningd(869): FATAL SIGNAL 6 (version v0.6-336-gfcd1eb5-modded)
2018-08-16T06:41:21.250Z lightningd(869): backtrace: common/daemon.c:42 (crashdump) 0x13ceda
2018-08-16T06:41:21.250Z lightningd(869): backtrace: (null):0 ((null)) 0x5739f1f
2018-08-16T06:41:21.250Z lightningd(869): backtrace: (null):0 ((null)) 0x5739e97
2018-08-16T06:41:21.251Z lightningd(869): backtrace: (null):0 ((null)) 0x573b800
2018-08-16T06:41:21.251Z lightningd(869): backtrace: ccan/ccan/tal/tal.c:93 (call_error) 0x1850c3
2018-08-16T06:41:21.251Z lightningd(869): backtrace: ccan/ccan/tal/tal.c:165 (check_bounds) 0x18528b
2018-08-16T06:41:21.252Z lightningd(869): backtrace: ccan/ccan/tal/tal.c:174 (to_tal_hdr) 0x1852ca
2018-08-16T06:41:21.252Z lightningd(869): backtrace: ccan/ccan/tal/tal.c:472 (tal_free) 0x185bfb
2018-08-16T06:41:21.252Z lightningd(869): backtrace: lightningd/peer_htlcs.c:1035 (peer_sending_commitsig) 0x1343a8
2018-08-16T06:41:21.252Z lightningd(869): backtrace: lightningd/channel_control.c:159 (channel_msg) 0x114f25
2018-08-16T06:41:21.253Z lightningd(869): backtrace: lightningd/subd.c:474 (sd_msg_read) 0x13756b
2018-08-16T06:41:21.253Z lightningd(869): backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x177c1f
2018-08-16T06:41:21.253Z lightningd(869): backtrace: ccan/ccan/io/io.c:387 (do_plan) 0x178717
2018-08-16T06:41:21.253Z lightningd(869): backtrace: ccan/ccan/io/io.c:397 (io_ready) 0x178755
2018-08-16T06:41:21.253Z lightningd(869): backtrace: ccan/ccan/io/poll.c:310 (io_loop) 0x17a336
2018-08-16T06:41:21.253Z lightningd(869): backtrace: lightningd/lightningd.c:455 (main) 0x120589
2018-08-16T06:41:21.254Z lightningd(869): backtrace: (null):0 ((null)) 0x571cb96
2018-08-16T06:41:21.254Z lightningd(869): backtrace: (null):0 ((null)) 0x10e6d9
2018-08-16T06:41:21.254Z lightningd(869): backtrace: (null):0 ((null)) 0xffffffffffffffff
Log dumped in crash.log
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>