### PR TITLE
WIP: Have feerates command disable/enable fee estimate polling

### DIFF
--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -100,6 +100,10 @@ struct chain_topology {
 	/* How often to poll. */
 	u32 poll_seconds;
 
+	/* FIXME can we use this instead of poll_seconds=0 as flag indicating polling
+	 * in that case we don't have to touch poll_seconds */
+	struct oneshot *fee_timer;
+
 	/* The bitcoind. */
 	struct bitcoind *bitcoind;
 


### PR DESCRIPTION
This is a proof of concept of:
- `feerate` command used to add/injects fee rates now first _disables_ the  polling loop and smoothing
- add `feerate` command option `restart-polling` to restart the polling loop
- fixes a bug in #1870  where add/inject `feerates` starts new polling loop, resulting in irregular fee updates
- don't need to rely on `fake-bitcoin-cli` (scripts) to override fee rates

Still has many bugs and needs improvements. Perhaps I am missing something essential why this is NOT a good idea? Would love to get some feedback.