### PR TITLE
channel_id unknown at funding time. Needs to be node_id

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -331,12 +331,12 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("listpeers", payload)
 
-    def fundchannel(self, channel_id, satoshi):
+    def fundchannel(self, node_id, satoshi):
         """
         Fund channel with {id} using {satoshi} satoshis"
         """
         payload = {
-            "id": channel_id,
+            "id": node_id,
             "satoshi": satoshi
         }
         return self.call("fundchannel", payload)


### PR DESCRIPTION
No semantical change but when using the python lib for the rpc-api it is confusing that my developing environment suggests that I should fund a channel and pass a channel_id when in fact I want to pass a node_id