### PR TITLE
lightningd: clean up tmpctx on exit before freeing ld.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -475,6 +475,9 @@ int main(int argc, char *argv[])
 	close(pid_fd);
 	remove(ld->pidfile);
 
+	/* FIXME: pay can have children off tmpctx which unlink from
+	 * ld->payments, so clean that up. */
+	clean_tmpctx();
 	tal_free(ld);
 	opt_free_table();
 


### PR DESCRIPTION
Fixes: #1866
