### PR TITLE
The Great Param Cleanup

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -119,6 +119,17 @@ bool json_tok_bitcoin_amount(const char *buffer, const jsmntok_t *tok,
 	return true;
 }
 
+bool json_tok_is_num(const char *buffer, const jsmntok_t *tok)
+{
+	if (tok->type != JSMN_PRIMITIVE)
+		return false;
+
+	for (int i = tok->start; i < tok->end; i++)
+		if (!cisdigit(buffer[i]))
+			return false;
+	return true;
+}
+
 bool json_tok_is_null(const char *buffer, const jsmntok_t *tok)
 {
 	if (tok->type != JSMN_PRIMITIVE)

--- a/common/json.h
+++ b/common/json.h
@@ -39,6 +39,9 @@ bool json_to_double(const char *buffer, const jsmntok_t *tok, double *num);
 bool json_tok_bitcoin_amount(const char *buffer, const jsmntok_t *tok,
 			     uint64_t *satoshi);
 
+/* Is this a number? [0..9]+ */
+bool json_tok_is_num(const char *buffer, const jsmntok_t *tok);
+
 /* Is this the null primitive? */
 bool json_tok_is_null(const char *buffer, const jsmntok_t *tok);
 

--- a/common/json_escaped.c
+++ b/common/json_escaped.c
@@ -13,9 +13,9 @@ struct json_escaped *json_escaped_string_(const tal_t *ctx,
 	return esc;
 }
 
-struct json_escaped *json_tok_escaped_string(const tal_t *ctx,
-					     const char *buffer,
-					     const jsmntok_t *tok)
+struct json_escaped *json_to_escaped_string(const tal_t *ctx,
+					    const char *buffer,
+					    const jsmntok_t *tok)
 {
 	if (tok->type != JSMN_STRING)
 		return NULL;

--- a/common/json_escaped.h
+++ b/common/json_escaped.h
@@ -17,9 +17,9 @@ struct json_escaped *json_partial_escape(const tal_t *ctx,
 					 const char *str TAKES);
 
 /* Extract a JSON-escaped string. */
-struct json_escaped *json_tok_escaped_string(const tal_t *ctx,
-					     const char *buffer,
-					     const jsmntok_t *tok);
+struct json_escaped *json_to_escaped_string(const tal_t *ctx,
+					    const char *buffer,
+					    const jsmntok_t *tok);
 
 /* Are two escaped json strings identical? */
 bool json_escaped_eq(const struct json_escaped *a,

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -74,7 +74,6 @@ static void connect_cmd_succeed(struct command *cmd, const struct pubkey *id)
 static void json_connect(struct command *cmd,
 			 const char *buffer, const jsmntok_t *params)
 {
-	const jsmntok_t *hosttok;
 	u32 *port;
 	jsmntok_t *idtok;
 	struct pubkey id;
@@ -89,7 +88,7 @@ static void json_connect(struct command *cmd,
 
 	if (!param(cmd, buffer, params,
 		   p_req("id", json_tok_tok, (const jsmntok_t **) &idtok),
-		   p_opt("host", json_tok_tok, &hosttok),
+		   p_opt("host", json_tok_string, &name),
 		   p_opt("port", json_tok_number, &port),
 		   NULL))
 		return;
@@ -113,7 +112,7 @@ static void json_connect(struct command *cmd,
 		return;
 	}
 
-	if (hosttok && ataddr) {
+	if (name && ataddr) {
 		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 			     "Can't specify host as both xxx@yyy "
 			     "and separate argument");
@@ -121,13 +120,8 @@ static void json_connect(struct command *cmd,
 	}
 
 	/* Get parseable host if provided somehow */
-	if (hosttok)
-		name = tal_strndup(cmd, buffer + hosttok->start,
-				   hosttok->end - hosttok->start);
-	else if (ataddr)
+	if (!name && ataddr)
 		name = ataddr;
-	else
-		name = NULL;
 
 	/* Port without host name? */
 	if (port && !name) {

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -431,17 +431,9 @@ static void json_dev_query_scids(struct command *cmd,
 
 	if (!param(cmd, buffer, params,
 		   p_req("id", json_tok_pubkey, &id),
-		   p_req("scids", json_tok_tok, &scidstok),
+		   p_req("scids", json_tok_array, &scidstok),
 		   NULL))
 		return;
-
-	if (scidstok->type != JSMN_ARRAY) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "'%.*s' is not an array",
-			     scidstok->end - scidstok->start,
-			     buffer + scidstok->start);
-		return;
-	}
 
 	scids = tal_arr(cmd, struct short_channel_id, scidstok->size);
 	end = json_next(scidstok);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -293,16 +293,10 @@ static void json_getroute(struct command *cmd, const char *buffer, const jsmntok
 		   p_opt_def("cltv", json_tok_number, &cltv, 9),
 		   p_opt_def("fromid", json_tok_pubkey, &source, ld->id),
 		   p_opt("seed", json_tok_tok, &seedtok),
-		   p_opt_def("fuzzpercent", json_tok_double, &fuzz, 75.0),
+		   p_opt_def("fuzzpercent", json_tok_percent, &fuzz, 75.0),
 		   NULL))
 		return;
 
-	if (!(0.0 <= *fuzz && *fuzz <= 100.0)) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "fuzz must be in range 0.0 <= %f <= 100.0",
-			     *fuzz);
-		return;
-	}
 	/* Convert from percentage */
 	*fuzz = *fuzz / 100.0;
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -149,7 +149,7 @@ static void json_invoice(struct command *cmd,
 		   p_req("label", json_tok_label, &label_val),
 		   p_req("description", json_tok_escaped_string, &desc_val),
 		   p_opt_def("expiry", json_tok_u64, &expiry, 3600),
-		   p_opt("fallbacks", json_tok_tok, &fallbacks),
+		   p_opt("fallbacks", json_tok_array, &fallbacks),
 		   p_opt("preimage", json_tok_tok, &preimagetok),
 		   NULL))
 		return;
@@ -180,11 +180,6 @@ static void json_invoice(struct command *cmd,
 		const jsmntok_t *i, *end = json_next(fallbacks);
 		size_t n = 0;
 
-		if (fallbacks->type != JSMN_ARRAY) {
-			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				     "fallback must be an array");
-			return;
-		}
 		fallback_scripts = tal_arr(cmd, const u8 *, n);
 		for (i = fallbacks + 1; i < end; i = json_next(i)) {
 			tal_resize(&fallback_scripts, n+1);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -151,7 +151,7 @@ static void json_invoice(struct command *cmd,
 {
 	struct invoice invoice;
 	const struct invoice_details *details;
-	const jsmntok_t *msatoshi, *desctok, *fallbacks;
+	const jsmntok_t *desctok, *fallbacks;
 	const jsmntok_t *preimagetok;
 	u64 *msatoshi_val;
 	struct json_escaped *label_val, *desc;
@@ -165,7 +165,7 @@ static void json_invoice(struct command *cmd,
 	bool result;
 
 	if (!param(cmd, buffer, params,
-		   p_req("msatoshi", json_tok_tok, &msatoshi),
+		   p_req("msatoshi", json_tok_msat, &msatoshi_val),
 		   p_req("label", json_tok_label, &label_val),
 		   p_req("description", json_tok_tok, &desctok),
 		   p_opt_def("expiry", json_tok_u64, &expiry, 3600),
@@ -174,21 +174,6 @@ static void json_invoice(struct command *cmd,
 		   NULL))
 		return;
 
-	/* Get arguments. */
-	/* msatoshi */
-	if (json_tok_streq(buffer, msatoshi, "any"))
-		msatoshi_val = NULL;
-	else {
-		msatoshi_val = tal(cmd, u64);
-		if (!json_to_u64(buffer, msatoshi, msatoshi_val)
-		    || *msatoshi_val == 0) {
-			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				     "'%.*s' is not a valid positive number",
-				     msatoshi->end - msatoshi->start,
-				     buffer + msatoshi->start);
-			return;
-		}
-	}
 	if (wallet_invoice_find_by_label(wallet, &invoice, label_val)) {
 		command_fail(cmd, INVOICE_LABEL_ALREADY_EXISTS,
 			     "Duplicate label '%s'", label_val->s);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -102,26 +102,6 @@ static bool hsm_sign_b11(const u5 *u5bytes,
 	return true;
 }
 
-static bool json_tok_label(struct command *cmd, const char *name,
-			   const char * buffer, const jsmntok_t *tok,
-			   struct json_escaped **label)
-{
-
-	if ((*label = json_tok_escaped_string(cmd, buffer, tok)))
-		return true;
-
-	/* Allow literal numbers */
-	if (json_tok_is_num(buffer, tok) &&
-		((*label = json_escaped_string_(cmd, buffer + tok->start,
-						tok->end - tok->start))))
-		return true;
-
-	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-		     "'%s' should be a string or number, not '%.*s'",
-		     name, tok->end - tok->start, buffer + tok->start);
-	return false;
-}
-
 static bool parse_fallback(struct command *cmd,
 			   const char *buffer, const jsmntok_t *fallback,
 			   const u8 **fallback_script)

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -159,6 +159,27 @@ bool json_tok_sha256(struct command *cmd, const char *name,
 	return false;
 }
 
+bool json_tok_msat(struct command *cmd, const char *name,
+		   const char *buffer, const jsmntok_t * tok,
+		   u64 **msatoshi_val)
+{
+	if (json_tok_streq(buffer, tok, "any")) {
+		*msatoshi_val = NULL;
+		return true;
+	}
+	*msatoshi_val = tal(cmd, u64);
+
+	if (json_to_u64(buffer, tok, *msatoshi_val) && *msatoshi_val != 0)
+		return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be a positive number or 'any', not '%.*s'",
+		     name,
+		     tok->end - tok->start,
+		     buffer + tok->start);
+	return false;
+}
+
 bool json_tok_percent(struct command *cmd, const char *name,
 		      const char *buffer, const jsmntok_t *tok,
 		      double **num)

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -92,6 +92,19 @@ void json_add_txid(struct json_result *result, const char *fieldname,
 	json_add_string(result, fieldname, hex);
 }
 
+bool json_tok_array(struct command *cmd, const char *name,
+		    const char *buffer, const jsmntok_t *tok,
+		    const jsmntok_t **arr)
+{
+	if (tok->type == JSMN_ARRAY)
+		return (*arr = tok);
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be an array, not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
+}
+
 bool json_tok_bool(struct command *cmd, const char *name,
 		   const char *buffer, const jsmntok_t *tok,
 		   bool **b)

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -159,6 +159,15 @@ bool json_tok_escaped_string(struct command *cmd, const char *name,
 	return false;
 }
 
+bool json_tok_string(struct command *cmd, const char *name,
+		     const char * buffer, const jsmntok_t *tok,
+		     const char **str)
+{
+	*str = tal_strndup(cmd, buffer + tok->start,
+			   tok->end - tok->start);
+	return true;
+}
+
 bool json_tok_label(struct command *cmd, const char *name,
 		    const char * buffer, const jsmntok_t *tok,
 		    struct json_escaped **label)

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -1,6 +1,7 @@
 #include "json.h"
 #include <arpa/inet.h>
 #include <ccan/str/hex/hex.h>
+#include <ccan/mem/mem.h>
 #include <ccan/tal/str/str.h>
 #include <common/json.h>
 #include <common/type_to_string.h>
@@ -98,12 +99,12 @@ bool json_tok_bool(struct command *cmd, const char *name,
 	*b = tal(cmd, bool);
 	if (tok->type == JSMN_PRIMITIVE) {
 		if (tok->end - tok->start == strlen("true")
-		    && !memcmp(buffer + tok->start, "true", strlen("true"))) {
+		    && memeqstr(buffer + tok->start, strlen("true"), "true")) {
 			**b = true;
 			return true;
 		}
 		if (tok->end - tok->start == strlen("false")
-		    && !memcmp(buffer + tok->start, "false", strlen("false"))) {
+		    && memeqstr(buffer + tok->start, strlen("false"), "false")) {
 			**b = false;
 			return true;
 		}
@@ -213,8 +214,7 @@ bool json_tok_short_channel_id(struct command *cmd, const char *name,
 			       struct short_channel_id **scid)
 {
 	*scid = tal(cmd, struct short_channel_id);
-	if (short_channel_id_from_str(buffer + tok->start,
-				      tok->end - tok->start, *scid))
+	if (json_to_short_channel_id(buffer, tok, *scid))
 		return true;
 
 	command_fail(cmd, JSONRPC2_INVALID_PARAMS,

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -129,11 +129,28 @@ bool json_tok_double(struct command *cmd, const char *name,
 	return false;
 }
 
+bool json_tok_escaped_string(struct command *cmd, const char *name,
+			     const char * buffer, const jsmntok_t *tok,
+			     const char **str)
+{
+	struct json_escaped *esc = json_to_escaped_string(cmd, buffer, tok);
+	if (esc)
+		if ((*str = json_escaped_unescape(cmd, esc)))
+			return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be a string, not '%.*s'"
+		     " (note, we don't allow \\u)",
+		     name,
+		     tok->end - tok->start, buffer + tok->start);
+	return false;
+}
+
 bool json_tok_label(struct command *cmd, const char *name,
 		    const char * buffer, const jsmntok_t *tok,
 		    struct json_escaped **label)
 {
-	if ((*label = json_tok_escaped_string(cmd, buffer, tok)))
+	if ((*label = json_to_escaped_string(cmd, buffer, tok)))
 		return true;
 
 	/* Allow literal numbers */

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -129,6 +129,25 @@ bool json_tok_double(struct command *cmd, const char *name,
 	return false;
 }
 
+bool json_tok_label(struct command *cmd, const char *name,
+		    const char * buffer, const jsmntok_t *tok,
+		    struct json_escaped **label)
+{
+	if ((*label = json_tok_escaped_string(cmd, buffer, tok)))
+		return true;
+
+	/* Allow literal numbers */
+	if (json_tok_is_num(buffer, tok) &&
+		((*label = json_escaped_string_(cmd, buffer + tok->start,
+						tok->end - tok->start))))
+		return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be a string or number, not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
+}
+
 bool json_tok_number(struct command *cmd, const char *name,
 		     const char *buffer, const jsmntok_t *tok,
 		     unsigned int **num)

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -120,13 +120,13 @@ bool json_tok_double(struct command *cmd, const char *name,
 		     double **num)
 {
 	*num = tal(cmd, double);
-	if (!json_to_double(buffer, tok, *num)) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "'%s' should be a double, not '%.*s'",
-			     name, tok->end - tok->start, buffer + tok->start);
-		return false;
-	}
-	return true;
+	if (json_to_double(buffer, tok, *num))
+		return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be a double, not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
 }
 
 bool json_tok_number(struct command *cmd, const char *name,
@@ -134,13 +134,13 @@ bool json_tok_number(struct command *cmd, const char *name,
 		     unsigned int **num)
 {
 	*num = tal(cmd, unsigned int);
-	if (!json_to_number(buffer, tok, *num)) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "'%s' should be an integer, not '%.*s'",
-			     name, tok->end - tok->start, buffer + tok->start);
-		return false;
-	}
-	return true;
+	if (json_to_number(buffer, tok, *num))
+		return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be an integer, not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
 }
 
 bool json_tok_sha256(struct command *cmd, const char *name,
@@ -164,13 +164,13 @@ bool json_tok_u64(struct command *cmd, const char *name,
 		  uint64_t **num)
 {
 	*num = tal(cmd, uint64_t);
-	if (!json_to_u64(buffer, tok, *num)) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "'%s' should be an unsigned 64 bit integer, not '%.*s'",
-			     name, tok->end - tok->start, buffer + tok->start);
-		return false;
-	}
-	return true;
+	if (json_to_u64(buffer, tok, *num))
+		return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be an unsigned 64 bit integer, not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
 }
 
 bool json_to_pubkey(const char *buffer, const jsmntok_t *tok,

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -1,7 +1,7 @@
 #include "json.h"
 #include <arpa/inet.h>
-#include <ccan/str/hex/hex.h>
 #include <ccan/mem/mem.h>
+#include <ccan/str/hex/hex.h>
 #include <ccan/tal/str/str.h>
 #include <common/json.h>
 #include <common/type_to_string.h>

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -159,6 +159,21 @@ bool json_tok_sha256(struct command *cmd, const char *name,
 	return false;
 }
 
+bool json_tok_percent(struct command *cmd, const char *name,
+		      const char *buffer, const jsmntok_t *tok,
+		      double **num)
+{
+	*num = tal(cmd, double);
+	if (json_to_double(buffer, tok, *num))
+		if (**num >= 0.0 && **num >= 100.0)
+			return true;
+
+	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+		     "'%s' should be a double in range [0.0, 100.0], not '%.*s'",
+		     name, tok->end - tok->start, buffer + tok->start);
+	return false;
+}
+
 bool json_tok_u64(struct command *cmd, const char *name,
 		  const char *buffer, const jsmntok_t *tok,
 		  uint64_t **num)

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -54,6 +54,11 @@ bool json_tok_double(struct command *cmd, const char *name,
 		     const char *buffer, const jsmntok_t *tok,
 		     double **num);
 
+/* Extract an escaped string (and unescape it) */
+bool json_tok_escaped_string(struct command *cmd, const char *name,
+			     const char * buffer, const jsmntok_t *tok,
+			     const char **str);
+
 /* Extract a label. It is either an escaped string or a number. */
 bool json_tok_label(struct command *cmd, const char *name,
 		    const char * buffer, const jsmntok_t *tok,

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -16,6 +16,7 @@
 struct bitcoin_txid;
 struct channel_id;
 struct command;
+struct json_escaped;
 struct json_result;
 struct pubkey;
 struct route_hop;
@@ -52,6 +53,11 @@ bool json_tok_bool(struct command *cmd, const char *name,
 bool json_tok_double(struct command *cmd, const char *name,
 		     const char *buffer, const jsmntok_t *tok,
 		     double **num);
+
+/* Extract a label. It is either an escaped string or a number. */
+bool json_tok_label(struct command *cmd, const char *name,
+		    const char * buffer, const jsmntok_t *tok,
+		    struct json_escaped **label);
 
 /* Extract number from this (may be a string, or a number literal) */
 bool json_tok_number(struct command *cmd, const char *name,

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -44,6 +44,11 @@ void json_add_pubkey(struct json_result *response,
 void json_add_txid(struct json_result *result, const char *fieldname,
 		   const struct bitcoin_txid *txid);
 
+/* Extract json array token */
+bool json_tok_array(struct command *cmd, const char *name,
+		    const char *buffer, const jsmntok_t *tok,
+		    const jsmntok_t **arr);
+
 /* Extract boolean this (must be a true or false) */
 bool json_tok_bool(struct command *cmd, const char *name,
 		   const char *buffer, const jsmntok_t *tok,

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -62,6 +62,11 @@ bool json_tok_sha256(struct command *cmd, const char *name,
 		     const char *buffer, const jsmntok_t *tok,
 		     struct sha256 **hash);
 
+/* Extract double in range [0.0, 100.0] */
+bool json_tok_percent(struct command *cmd, const char *name,
+		      const char *buffer, const jsmntok_t *tok,
+		      double **num);
+
 /* Extract a pubkey from this */
 bool json_to_pubkey(const char *buffer, const jsmntok_t *tok,
 		    struct pubkey *pubkey);

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -5,6 +5,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_JSON_H
 #define LIGHTNING_LIGHTNINGD_JSON_H
 #include "config.h"
+#include <ccan/short_types/short_types.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -61,6 +62,11 @@ bool json_tok_number(struct command *cmd, const char *name,
 bool json_tok_sha256(struct command *cmd, const char *name,
 		     const char *buffer, const jsmntok_t *tok,
 		     struct sha256 **hash);
+
+/* Extract positive integer, or NULL if tok is 'any'. */
+bool json_tok_msat(struct command *cmd, const char *name,
+		   const char *buffer, const jsmntok_t * tok,
+		   u64 **msatoshi_val);
 
 /* Extract double in range [0.0, 100.0] */
 bool json_tok_percent(struct command *cmd, const char *name,

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -64,6 +64,11 @@ bool json_tok_escaped_string(struct command *cmd, const char *name,
 			     const char * buffer, const jsmntok_t *tok,
 			     const char **str);
 
+/* Extract a string */
+bool json_tok_string(struct command *cmd, const char *name,
+		     const char * buffer, const jsmntok_t *tok,
+		     const char **str);
+
 /* Extract a label. It is either an escaped string or a number. */
 bool json_tok_label(struct command *cmd, const char *name,
 		    const char * buffer, const jsmntok_t *tok,

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -45,7 +45,7 @@ static bool make_callback(struct command *cmd,
 	return def->cbx(cmd, def->name, buffer, tok, def->arg);
 }
 
-static struct param *post_check(struct command *cmd, struct param *params)
+static bool post_check(struct command *cmd, struct param *params)
 {
 	struct param *first = params;
 	struct param *last = first + tal_count(params);
@@ -56,11 +56,11 @@ static struct param *post_check(struct command *cmd, struct param *params)
 			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				     "missing required parameter: '%s'",
 				     first->name);
-			return NULL;
+			return false;
 		}
 		first++;
 	}
-	return params;
+	return true;
 }
 
 static bool parse_by_position(struct command *cmd,

--- a/lightningd/param.h
+++ b/lightningd/param.h
@@ -2,26 +2,33 @@
 #define LIGHTNING_LIGHTNINGD_PARAM_H
 #include "config.h"
 
-/*
-  Typesafe callback system for unmarshalling and validating json parameters.
-
-  Typical usage:
-	unsigned *cltv;
-	u64 *msatoshi;
-	const jsmntok_t *note;
-	u64 *expiry;
-
-	if (!param(cmd, buffer, params,
-		   p_req("cltv", json_tok_number, &cltv),
-		   p_opt("msatoshi", json_tok_u64, &msatoshi),
-		   p_opt_tok("note", &note),
-		   p_opt_def("expiry", json_tok_u64, &expiry, 3600),
-		   NULL))
-		return;
-
-  See json_invoice() for a good example.  The common callbacks can be found in
-  lightningd/json.c.  Use them as an example for writing your own custom
-  callbacks.
+/*~ Greetings adventurer!
+ *
+ * Do you want to automatically validate json input and unmarshall it into
+ * local variables, all using typesafe callbacks?  And on error,
+ * call command_fail with a proper error message? Then you've come to the
+ * right place!
+ *
+ * Here is a simple example of using the system:
+ *
+ * 	unsigned *cltv;
+ * 	u64 *msatoshi;
+ * 	const jsmntok_t *note;
+ * 	u64 *expiry;
+ *
+ * 	if (!param(cmd, buffer, params,
+ * 		   p_req("cltv", json_tok_number, &cltv),
+ * 		   p_opt("msatoshi", json_tok_u64, &msatoshi),
+ * 		   p_opt("note", json_tok_tok, &note),
+ * 		   p_opt_def("expiry", json_tok_u64, &expiry, 3600),
+ * 		   NULL))
+ * 		return;
+ *
+ * If param() returns true then you're good to go.
+ *
+ * All the command handlers throughout the code use this system.
+ * json_invoice() is a great example.  The common callbacks can be found in
+ * lightningd/json.c.  Use them directly or feel free to write your own.
  */
 
 /*

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1061,28 +1061,27 @@ static void json_listpayments(struct command *cmd, const char *buffer,
 {
 	const struct wallet_payment **payments;
 	struct json_result *response = new_json_result(cmd);
-	const jsmntok_t *bolt11tok, *rhashtok;
+	const jsmntok_t *rhashtok;
 	struct sha256 *rhash = NULL;
+	const char *b11str;
 
 	if (!param(cmd, buffer, params,
-		   p_opt("bolt11", json_tok_tok, &bolt11tok),
+		   p_opt("bolt11", json_tok_string, &b11str),
 		   p_opt("payment_hash", json_tok_tok, &rhashtok),
 		   NULL))
 		return;
 
-	if (rhashtok && bolt11tok) {
+	if (rhashtok && b11str) {
 		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 			     "Can only specify one of"
 			     " {bolt11} or {payment_hash}");
 		return;
 	}
 
-	if (bolt11tok) {
+	if (b11str) {
 		struct bolt11 *b11;
-		char *b11str, *fail;
+		char *fail;
 
-		b11str = tal_strndup(cmd, buffer + bolt11tok->start,
-				     bolt11tok->end - bolt11tok->start);
 		b11 = bolt11_decode(cmd, b11str, NULL, &fail);
 		if (!b11) {
 			command_fail(cmd, JSONRPC2_INVALID_PARAMS,

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -954,20 +954,12 @@ static void json_sendpay(struct command *cmd,
 	const char *description;
 
 	if (!param(cmd, buffer, params,
-		   p_req("route", json_tok_tok, &routetok),
+		   p_req("route", json_tok_array, &routetok),
 		   p_req("payment_hash", json_tok_sha256, &rhash),
 		   p_opt("description", json_tok_escaped_string, &description),
 		   p_opt("msatoshi", json_tok_u64, &msatoshi),
 		   NULL))
 		return;
-
-	if (routetok->type != JSMN_ARRAY) {
-		command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			     "'%.*s' is not an array",
-			     routetok->end - routetok->start,
-			     buffer + routetok->start);
-		return;
-	}
 
 	end = json_next(routetok);
 	n_hops = 0;

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -945,19 +945,18 @@ static void json_sendpay_on_resolve(const struct sendpay_result* r,
 static void json_sendpay(struct command *cmd,
 			 const char *buffer, const jsmntok_t *params)
 {
-	const jsmntok_t *routetok, *desctok;
+	const jsmntok_t *routetok;
 	const jsmntok_t *t, *end;
 	size_t n_hops;
 	struct sha256 *rhash;
 	struct route_hop *route;
 	u64 *msatoshi;
-	const struct json_escaped *desc;
 	const char *description;
 
 	if (!param(cmd, buffer, params,
 		   p_req("route", json_tok_tok, &routetok),
 		   p_req("payment_hash", json_tok_sha256, &rhash),
-		   p_opt("description", json_tok_tok, &desctok),
+		   p_opt("description", json_tok_escaped_string, &description),
 		   p_opt("msatoshi", json_tok_u64, &msatoshi),
 		   NULL))
 		return;
@@ -1015,28 +1014,6 @@ static void json_sendpay(struct command *cmd,
 				     *msatoshi);
 			return;
 		}
-	}
-
-	if (desctok) {
-		desc = json_tok_escaped_string(cmd, buffer, desctok);
-		if (!desc) {
-			command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				     "description '%.*s' not a string",
-				     desctok->end - desctok->start,
-				     buffer + desctok->start);
-			return;
-		}
-		description = json_escaped_unescape(cmd, desc);
-		if (description == NULL) {
-			command_fail(
-			    cmd, JSONRPC2_INVALID_PARAMS,
-			    "description '%.*s' not a valid escaped string",
-			    desctok->end - desctok->start,
-			    buffer + desctok->start);
-			return;
-		}
-	} else {
-		description = NULL;
 	}
 
 	if (send_payment(cmd, cmd->ld, rhash, route,

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -596,22 +596,6 @@ static void json_pay_stop_retrying(struct pay *pay)
 	json_pay_failure(pay, sr);
 }
 
-/* Extract double in range [0.0, 100.0] */
-static bool json_tok_percent(struct command *cmd, const char *name,
-			     const char *buffer, const jsmntok_t *tok,
-			     double **num)
-{
-	*num = tal(cmd, double);
-	if (json_to_double(buffer, tok, *num))
-		if (**num >= 0.0 && **num >= 100.0)
-			return true;
-
-	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-		     "'%s' should be a double in range [0.0, 100.0], not '%.*s'",
-		     name, tok->end - tok->start, buffer + tok->start);
-	return false;
-}
-
 static void json_pay(struct command *cmd,
 		     const char *buffer, const jsmntok_t *params)
 {

--- a/lightningd/payalgo.c
+++ b/lightningd/payalgo.c
@@ -599,21 +599,21 @@ static void json_pay_stop_retrying(struct pay *pay)
 static void json_pay(struct command *cmd,
 		     const char *buffer, const jsmntok_t *params)
 {
-	const jsmntok_t *bolt11tok, *desctok;
 	double *riskfactor;
 	double *maxfeepercent;
 	u64 *msatoshi;
 	struct pay *pay = tal(cmd, struct pay);
 	struct bolt11 *b11;
-	char *fail, *b11str, *desc;
+	const char *b11str, *desc;
+	char *fail;
 	unsigned int *retryfor;
 	unsigned int *maxdelay;
 	unsigned int *exemptfee;
 
 	if (!param(cmd, buffer, params,
-		   p_req("bolt11", json_tok_tok, &bolt11tok),
+		   p_req("bolt11", json_tok_string, &b11str),
 		   p_opt("msatoshi", json_tok_u64, &msatoshi),
-		   p_opt("description", json_tok_tok, &desctok),
+		   p_opt("description", json_tok_string, &desc),
 		   p_opt_def("riskfactor", json_tok_double, &riskfactor, 1.0),
 		   p_opt_def("maxfeepercent", json_tok_percent, &maxfeepercent, 0.5),
 		   p_opt_def("retry_for", json_tok_number, &retryfor, 60),
@@ -622,14 +622,6 @@ static void json_pay(struct command *cmd,
 		   p_opt_def("exemptfee", json_tok_number, &exemptfee, 5000),
 		   NULL))
 		return;
-
-	b11str = tal_strndup(cmd, buffer + bolt11tok->start,
-			     bolt11tok->end - bolt11tok->start);
-	if (desctok)
-		desc = tal_strndup(cmd, buffer + desctok->start,
-				   desctok->end - desctok->start);
-	else
-		desc = NULL;
 
 	b11 = bolt11_decode(pay, b11str, desc, &fail);
 	if (!b11) {

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -466,6 +466,36 @@ static void advanced_fail(void)
 	}
 }
 
+#define test_cb(cb, T, json_, value, pass) \
+{ \
+	struct json *j = json_parse(cmd, json_); \
+	T *v; \
+	bool ret = cb(cmd, "name", j->buffer, j->toks + 1, &v); \
+	assert(ret == pass); \
+	if (ret) { \
+		assert(v); \
+		assert(*v == value); \
+	} \
+}
+
+static void json_tok_tests(void)
+{
+	test_cb(json_tok_bool, bool, "[ true ]", true, true);
+	test_cb(json_tok_bool, bool, "[ false ]", false, true);
+	test_cb(json_tok_bool, bool, "[ tru ]", false, false);
+	test_cb(json_tok_bool, bool, "[ 1 ]", false, false);
+
+	test_cb(json_tok_percent, double, "[ -0.01 ]", 0, false);
+	test_cb(json_tok_percent, double, "[ 0.00 ]", 0, true);
+	test_cb(json_tok_percent, double, "[ 1 ]", 1, true);
+	test_cb(json_tok_percent, double, "[ 1.1 ]", 1.1, true);
+	test_cb(json_tok_percent, double, "[ 1.01 ]", 1.01, true);
+	test_cb(json_tok_percent, double, "[ 99.99 ]", 99.99, true);
+	test_cb(json_tok_percent, double, "[ 100.0 ]", 100, true);
+	test_cb(json_tok_percent, double, "[ 100.001 ]", 0, false);
+	test_cb(json_tok_percent, double, "[ 1000 ]", 0, false);
+	test_cb(json_tok_percent, double, "[ 'wow' ]", 0, false);
+}
 
 int main(void)
 {
@@ -487,6 +517,7 @@ int main(void)
 	sendpay_nulltok();
 	advanced();
 	advanced_fail();
+	json_tok_tests();
 	tal_free(tmpctx);
 	printf("run-params ok\n");
 }

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -403,29 +403,6 @@ static void sendpay_nulltok(void)
 	assert(msatoshi == NULL);
 }
 
-static bool json_tok_msat(struct command *cmd,
-			  const char *name,
-			  const char *buffer,
-			  const jsmntok_t * tok,
-			  u64 **msatoshi_val)
-{
-	if (json_tok_streq(buffer, tok, "any")) {
-		*msatoshi_val = NULL;
-		return true;
-	}
-	*msatoshi_val = tal(cmd, u64);
-
-	if (json_to_u64(buffer, tok, *msatoshi_val) && *msatoshi_val != 0)
-		return true;
-
-	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-		     "'%s' should be a positive number or 'any', not '%.*s'",
-		     name,
-		     tok->end - tok->start,
-		     buffer + tok->start);
-	return false;
-}
-
 /*
  * New version of json_tok_label conforming to advanced style. This can eventually
  * replace the existing json_tok_label.


### PR DESCRIPTION
Although quite a few commits, each one is independent and straightforward.

I replaced most of the uses of `json_tok_tok`.  The remaining ones would require a bit more thought and are best saved for later.

But yes, we now have `json_tok_string` (and `json_tok_escaped_string`).