### PR TITLE
chaintopology: don't "fix" unknown feerate against known one.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -384,11 +384,15 @@ static void update_feerates(struct bitcoind *bitcoind,
 		maybe_completed_init(topo);
 	}
 
-	/* Make sure fee rates are in order. */
+	/* Make sure (known) fee rates are in order. */
 	for (size_t i = 0; i < NUM_FEERATES; i++) {
+		if (!topo->feerate[i])
+			continue;
 		for (size_t j = 0; j < i; j++) {
+			if (!topo->feerate[j])
+				continue;
 			if (topo->feerate[j] < topo->feerate[i]) {
-				log_debug(topo->log,
+				log_unusual(topo->log,
 					  "Feerate estimate for %s (%u) above %s (%u)",
 					  feerate_name(i), topo->feerate[i],
 					  feerate_name(j), topo->feerate[j]);


### PR DESCRIPTION
This was found because it means we have a non-zero feerate without
filling in the history of that feerate:

==15895== Conditional jump or move depends on uninitialised value(s)
==15895==    at 0x408699: feerate_max (chaintopology.c:828)
==15895==    by 0x41BE49: peer_start_openingd (opening_control.c:733)
==15895==    by 0x425FE9: peer_connected (peer_control.c:515)
==15895==    by 0x40CB8F: connectd_msg (connect_control.c:304)
==15895==    by 0x42DB4E: sd_msg_read (subd.c:475)
==15895==    by 0x42D499: read_fds (subd.c:302)
==15895==    by 0x46EB18: next_plan (io.c:59)
==15895==    by 0x46F5E9: do_plan (io.c:387)
==15895==    by 0x46F627: io_ready (io.c:397)
==15895==    by 0x471187: io_loop (poll.c:310)
==15895==    by 0x41683D: main (lightningd.c:732)
