### PR TITLE
pytest: Fix configure to find pytest when installed using pip3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ check:
 
 pytest: $(ALL_PROGRAMS)
 ifndef PYTEST
-	@echo "py.test is required to run the integration tests, please install using 'pip3 install -r tests/requirements.txt'"
+	@echo "py.test is required to run the integration tests, please install using 'pip3 install -r tests/requirements.txt', and rerun 'configure'."
 	exit 1
 else
 # Explicitly hand DEVELOPER and VALGRIND so you can override on make cmd line.

--- a/configure
+++ b/configure
@@ -72,10 +72,16 @@ find_pytest()
 	fi
     done
 
-    if python3 -c "import pytest" ; then
-        echo "python3 -m pytest"
-        return
-    fi
+    PYTHON_BINS="python python3"
+    for p in $PYTHON_BINS; do
+        if [ "$(which $p)" != "" ] ; then
+            $p --version 2>&1 | grep -q "Python 3." || continue
+            if $p -c "import pytest" ; then
+                echo "$p -m pytest"
+                return
+            fi
+        fi
+    done
 }
 
 PYTEST=${PYTEST:-`find_pytest`}

--- a/configure
+++ b/configure
@@ -71,6 +71,11 @@ find_pytest()
 	    return
 	fi
     done
+
+    if python3 -c "import pytest" ; then
+        echo "python3 -m pytest"
+        return
+    fi
 }
 
 PYTEST=${PYTEST:-`find_pytest`}


### PR DESCRIPTION
Running `make pytest` when pytest is not installed, results in a message instructing the user to install it using `pip3`.
However, after installing it using `pip3`, `configure` still can't find it.

This PR addresses this issue by letting `configure` find if the module is accessible to `python3` and setting the command as `python3 -m pytest`.