### PR TITLE
Doc spelling corrections

### DIFF
--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 08/29/2018
+.\"      Date: 09/07/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "08/29/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "09/07/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -34,7 +34,7 @@ lightning-fundchannel \- Command for establishing a lightning channel\&.
 \fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBfundchannel\fR RPC command opens a payment channel with a peer by commiting a funding transaction to the blockchain as defined in BOLT #2\&. \fBfundchannel\fR by itself does not attempt to open a connection\&. A connection must first be established using \fBconnect\fR\&. Once the transaction is confirmed, normal channel operations may begin\&. Readiness is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL for the channel\&.
+The \fBfundchannel\fR RPC command opens a payment channel with a peer by committing a funding transaction to the blockchain as defined in BOLT #2\&. \fBfundchannel\fR by itself does not attempt to open a connection\&. A connection must first be established using \fBconnect\fR\&. Once the transaction is confirmed, normal channel operations may begin\&. Readiness is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL for the channel\&.
 .sp
 \fIid\fR is the peer id obtained from \fBconnect\fR\&.
 .sp

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-The *fundchannel* RPC command opens a payment channel with a peer by commiting
+The *fundchannel* RPC command opens a payment channel with a peer by committing
 a funding transaction to the blockchain as defined in BOLT #2.
 *fundchannel* by itself does not attempt to open a connection.
 A connection must first be established using *connect*.

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listfunds
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 09/07/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTFUNDS" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTFUNDS" "7" "09/07/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -131,7 +131,7 @@ Each entry in \fIchannels\fR will include:
 .IP \(bu 2.3
 .\}
 \fIchannel_sat\fR
-\- available satoshis on our node\(cqs end of the channel (values rounded to the nearest satoshi as internal storage is in milisatoshi)\&.
+\- available satoshis on our node\(cqs end of the channel (values rounded to the nearest satoshi as internal storage is in millisatoshi)\&.
 .RE
 .sp
 .RS 4
@@ -143,7 +143,7 @@ Each entry in \fIchannels\fR will include:
 .IP \(bu 2.3
 .\}
 \fIchannel_total_sat\fR
-\- total channel value in satoshi (values rounded to the nearest satoshi as internal storage is in milisatoshi)\&.
+\- total channel value in satoshi (values rounded to the nearest satoshi as internal storage is in millisatoshi)\&.
 .RE
 .sp
 .RS 4

--- a/doc/lightning-listfunds.7.txt
+++ b/doc/lightning-listfunds.7.txt
@@ -43,10 +43,10 @@ Each entry in 'channels' will include:
 number and output index of the channel funding transaction).
 
 - 'channel_sat' - available satoshis on our node's end of the channel 
-(values rounded to the nearest satoshi as internal storage is in milisatoshi).
+(values rounded to the nearest satoshi as internal storage is in millisatoshi).
 
 - 'channel_total_sat' - total channel value in satoshi 
-(values rounded to the nearest satoshi as internal storage is in milisatoshi). 
+(values rounded to the nearest satoshi as internal storage is in millisatoshi). 
 
 - 'funding_txid' - funding transaction id.
 

--- a/doc/lightning-pay.7
+++ b/doc/lightning-pay.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-pay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/28/2018
+.\"      Date: 09/07/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-PAY" "7" "07/28/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-PAY" "7" "09/07/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -34,7 +34,7 @@ lightning-pay \- Command for sending a payment to a BOLT11 invoice
 \fBpay\fR \fIbolt11\fR [\fImsatoshi\fR] [\fIdescription\fR] [\fIriskfactor\fR] [\fImaxfeepercent\fR] [\fIretry_for\fR] [\fImaxdelay\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBpay\fR RPC command attempts to find a route to the given destination, and send the funds it asks for\&. If the \fIbolt11\fR does not contain an amount, \fImsatoshi\fR is required, otherwise if it is specified it must be \fInull\fR\&. If \fIbolt11\fR contains a description hash (\fIh\fR field) \fIdescription\fR is required, otherwise it is unused\&. The \fIriskfactor\fR is described in detail in lightning\-getroute(7), and defaults to 1\&.0\&. The \fImaxfeepercent\fR limits the money paid in fees, and defaults to 0\&.5\&. The maxfeepercent\*(Aq is a percentage of the amount that is to be paid\&. The `exemptfee option can be used for tiny payments which would be dominated by the fee leveraged by forwarding nodes\&. Setting exemptfee allows the maxfeepercent check to be skipped on fees that are smaller than exemptfee (default: 5000 millsatoshi)\&.
+The \fBpay\fR RPC command attempts to find a route to the given destination, and send the funds it asks for\&. If the \fIbolt11\fR does not contain an amount, \fImsatoshi\fR is required, otherwise if it is specified it must be \fInull\fR\&. If \fIbolt11\fR contains a description hash (\fIh\fR field) \fIdescription\fR is required, otherwise it is unused\&. The \fIriskfactor\fR is described in detail in lightning\-getroute(7), and defaults to 1\&.0\&. The \fImaxfeepercent\fR limits the money paid in fees, and defaults to 0\&.5\&. The maxfeepercent\*(Aq is a percentage of the amount that is to be paid\&. The `exemptfee option can be used for tiny payments which would be dominated by the fee leveraged by forwarding nodes\&. Setting exemptfee allows the maxfeepercent check to be skipped on fees that are smaller than exemptfee (default: 5000 millisatoshi)\&.
 .sp
 The \fBpay\fR RPC command will randomize routes slightly, as long as the route achieves the targeted \fImaxfeepercent\fR and \fImaxdelay\fR\&.
 .sp

--- a/doc/lightning-pay.7.txt
+++ b/doc/lightning-pay.7.txt
@@ -25,7 +25,7 @@ paid.
 The `exemptfee` option can be used for tiny payments which would be dominated by
 the fee leveraged by forwarding nodes. Setting `exemptfee` allows the
 `maxfeepercent` check to be skipped on fees that are smaller than `exemptfee`
-(default: 5000 millsatoshi).
+(default: 5000 millisatoshi).
 
 The *pay* RPC command will randomize routes slightly, as long as the
 route achieves the targeted 'maxfeepercent' and 'maxdelay'.

--- a/doc/lightning-waitinvoice.7
+++ b/doc/lightning-waitinvoice.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-waitinvoice
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 09/07/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-WAITINVOI" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-WAITINVOI" "7" "09/07/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -41,7 +41,7 @@ On success, an invoice description will be returned as per lightning\-listinvoic
 .sp
 If the invoice is deleted while unpaid, or the invoice does not exist, this command will return with an error with code \-1\&.
 .sp
-If the invoice expires before being pad, or is already expired, this command will return with an error with code \-2, with the data being the invoice data as per \fBlistinvoice\fR\&.
+If the invoice expires before being paid, or is already expired, this command will return with an error with code \-2, with the data being the invoice data as per \fBlistinvoice\fR\&.
 .SH "AUTHOR"
 .sp
 Christian Decker <decker\&.christian@gmail\&.com> is mainly responsible\&.

--- a/doc/lightning-waitinvoice.7.txt
+++ b/doc/lightning-waitinvoice.7.txt
@@ -23,7 +23,7 @@ The 'status' field will be 'paid'.
 If the invoice is deleted while unpaid, or the invoice does not exist,
 this command will return with an error with code -1.
 
-If the invoice expires before being pad, or is already expired, this
+If the invoice expires before being paid, or is already expired, this
 command will return with an error with code -2, with the data being
 the invoice data as per *listinvoice*.
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 08/15/2018
+.\"      Date: 09/07/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "08/15/2018" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "09/07/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,7 +36,7 @@ lightningd-config \- Lightning daemon configuration file
 .sp
 lightningd(8) reads a configuration file called \fIconfig\fR, if it exists, when it starts up\&. The location of this file defaults to \fB\&.lightning\fR in the home directory, but can be overridden by the \fI\-\-lightning\-dir\fR option on the lightningd(8) command line\&.
 .sp
-Configuration file options are processsed first, then command line options: later options override earlier ones except \fIaddr\fR options which accumulate\&.
+Configuration file options are processed first, then command line options: later options override earlier ones except \fIaddr\fR options which accumulate\&.
 .sp
 All these options are mirrored as commandline arguments to lightningd(8), so \fI\-\-foo\fR becomes simply \fIfoo\fR in the configuration file, and \fI\-\-foo=bar\fR becomes \fIfoo=bar\fR in the configuration file\&.
 .sp
@@ -316,7 +316,7 @@ or \*(AqTORIPADDRESS\*(Aq\&.
 .PP
 \fBbind\-addr\fR=\fI[IPADDRESS[:PORT]]|SOCKETPATH\fR
 .RS 4
-Set an IP address or UNIX domain socket to listen to, but do not announce\&. A UNIX domain socket is distingished from an IP address by beginning with a
+Set an IP address or UNIX domain socket to listen to, but do not announce\&. A UNIX domain socket is distinguished from an IP address by beginning with a
 \fI/\fR\&.
 .sp
 .if n \{\
@@ -436,7 +436,7 @@ to authenticate to the Tor control port\&.
 .RE
 .SH "BUGS"
 .sp
-You should report bugs on our github issues page, and maybe submit a fix to gain our eternal gratutide!
+You should report bugs on our github issues page, and maybe submit a fix to gain our eternal gratitude!
 .SH "AUTHOR"
 .sp
 Rusty Russell <rusty@rustcorp\&.com\&.au> wrote this man page, and much of the configuration language, but many others did the hard work of actually implementing these options\&.

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -18,7 +18,7 @@ exists, when it starts up.  The location of this file defaults to
 *.lightning* in the home directory, but can be overridden by the
 '--lightning-dir' option on the lightningd(8) command line.
 
-Configuration file options are processsed first, then command line
+Configuration file options are processed first, then command line
 options: later options override earlier ones except 'addr' options
 which accumulate.
 
@@ -235,7 +235,7 @@ or precisely control where to bind and what to announce with the
 *bind-addr*='[IPADDRESS[:PORT]]|SOCKETPATH'::
 
     Set an IP address or UNIX domain socket to listen to, but do not
-    announce.  A UNIX domain socket is distingished from an IP address
+    announce.  A UNIX domain socket is distinguished from an IP address
     by beginning with a '/'.
 
     An empty 'IPADDRESS' is a special value meaning bind to IPv4 and/or
@@ -294,7 +294,7 @@ or precisely control where to bind and what to announce with the
 BUGS
 ----
 You should report bugs on our github issues page, and maybe submit a
-fix to gain our eternal gratutide!
+fix to gain our eternal gratitude!
 
 AUTHOR
 ------


### PR DESCRIPTION
While working on the rust bindings I noticed some English spelling errors in the doc, so I've done an `aspell` run.

Second commit regenerates the man-pages from the source files.