### PR TITLE
ping: First parameter is called 'id' not 'peerid', fix help

### DIFF
--- a/lightningd/ping.c
+++ b/lightningd/ping.c
@@ -86,6 +86,6 @@ static void json_ping(struct command *cmd,
 static const struct json_command ping_command = {
 	"ping",
 	json_ping,
-	"Send {peerid} a ping of length {len} (default 128) asking for {pongbytes} (default 128)"
+	"Send peer {id} a ping of length {len} (default 128) asking for {pongbytes} (default 128)"
 };
 AUTODATA(json_command, &ping_command);


### PR DESCRIPTION
The first argument of 'ping' was documented as 'peerid', however internally it is expected to be just 'id'.

To avoid breaking the API, opt to fix the documentation.