### PR TITLE
Openingd: prioritize incoming peer traffic over sending out gossip

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1157,10 +1157,11 @@ int main(int argc, char *argv[])
 		 * don't try to service more than one fd per loop. */
 		if (pollfd[0].revents & POLLIN)
 			msg = handle_master_in(state);
-		else if (pollfd[1].revents & POLLIN)
-			handle_gossip_in(state);
 		else if (pollfd[2].revents & POLLIN)
 			msg = handle_peer_in(state);
+		else if (pollfd[1].revents & POLLIN)
+			handle_gossip_in(state);
+
 		clean_tmpctx();
 	}
 


### PR DESCRIPTION
 openingd: prioritize incoming peer traffic over handling (and sendind out) gossip

- reduces probability for a deadlock where we block on sending data because
  the other peer cannot receive because it blocks on sending data etc.
- when either side sends so much data that it fills up the kernel/network buffer
- however sending out gossip can still block when (malicious) peer never receives

Fixes #1943 
thanks to the advice of @rustyrussell