### PR TITLE
Remove 100% upper limit for percentage arguments

### DIFF
--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-getroute
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/26/2018
+.\"      Date: 09/17/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-GETROUTE" "7" "04/26/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-GETROUTE" "7" "09/17/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -42,7 +42,7 @@ For example, if you thought there was a 1% chance that a node would fail, and it
 .sp
 If you didn\(cqt care about risk, \fIriskfactor\fR would be zero\&.
 .sp
-The \fIfuzzpercent\fR is a floating\-point number, between 0\&.0 to 100\&.0, unit of percent\&. The \fIfuzzpercent\fR is used to distort computed fees along each channel, to provide some randomization to the route generated\&. 0\&.0 means the exact fee of that channel is used, while 100\&.0 means the fee used might be from 0 to twice the actual fee\&. The default is 5\&.0, or up to 5% fee distortion\&.
+The \fIfuzzpercent\fR is a positive floating\-point number, representing a percentage of the actual fee\&. The \fIfuzzpercent\fR is used to distort computed fees along each channel, to provide some randomization to the route generated\&. 0\&.0 means the exact fee of that channel is used, while 100\&.0 means the fee used might be from 0 to twice the actual fee\&. The default is 5\&.0, or up to 5% fee distortion\&.
 .sp
 The \fIseed\fR is a string whose bytes are used to seed the RNG for the route randomization\&. If not specified, a random string is used\&.
 .SH "RISKFACTOR EFFECT ON ROUTING"

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -29,8 +29,7 @@ fail, and it would cost you 20% per annum if that happened,
 
 If you didn't care about risk, 'riskfactor' would be zero.
 
-The 'fuzzpercent' is a floating-point number, between 0.0 to 100.0,
-unit of percent.
+The 'fuzzpercent' is a positive floating-point number, representing a percentage of the actual fee.
 The 'fuzzpercent' is used to distort computed fees along each channel,
 to provide some randomization to the route generated.
 0.0 means the exact fee of that channel is used,

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listfunds
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 09/07/2018
+.\"      Date: 09/18/2018
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTFUNDS" "7" "09/07/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTFUNDS" "7" "09/18/2018" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -327,7 +327,7 @@ static const struct json_command getroute_command = {
 	json_getroute,
 	"Show route to {id} for {msatoshi}, using {riskfactor} and optional {cltv} (default 9). "
 	"If specified search from {fromid} otherwise use this node as source. "
-	"Randomize the route with up to {fuzzpercent} (0.0 -> 100.0, default 5.0) "
+	"Randomize the route with up to {fuzzpercent} (default 5.0) "
 	"using {seed} as an arbitrary-size string seed."
 };
 AUTODATA(json_command, &getroute_command);

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -238,12 +238,11 @@ bool json_tok_percent(struct command *cmd, const char *name,
 		      double **num)
 {
 	*num = tal(cmd, double);
-	if (json_to_double(buffer, tok, *num))
-		if (**num >= 0.0 && **num <= 100.0)
-			return true;
+	if (json_to_double(buffer, tok, *num) && **num >= 0.0)
+		return true;
 
 	command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-		     "'%s' should be a double in range [0.0, 100.0], not '%.*s'",
+		     "'%s' should be a positive double, not '%.*s'",
 		     name, tok->end - tok->start, buffer + tok->start);
 	return false;
 }

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -502,8 +502,8 @@ static void json_tok_tests(void)
 	test_cb(json_tok_percent, double, "[ 1.01 ]", 1.01, true);
 	test_cb(json_tok_percent, double, "[ 99.99 ]", 99.99, true);
 	test_cb(json_tok_percent, double, "[ 100.0 ]", 100, true);
-	test_cb(json_tok_percent, double, "[ 100.001 ]", 0, false);
-	test_cb(json_tok_percent, double, "[ 1000 ]", 0, false);
+	test_cb(json_tok_percent, double, "[ 100.001 ]", 100.001, true);
+	test_cb(json_tok_percent, double, "[ 1000 ]", 1000, true);
 	test_cb(json_tok_percent, double, "[ 'wow' ]", 0, false);
 }
 


### PR DESCRIPTION
The `json_tok_percentage` parser is used for the `fuzzpercent` in `getroute` and
`maxfeepercent` in `pay`. In both cases it seems reasonable to allow values
larger than 100%. This has bitten users in the past when they transferred single
satoshis to things like satoshis.place over a route longer than 2 hops.

Fixes #1914 