### PR TITLE
BOLT updates, up to and incl split flags in `channel_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - JSON API: `listpeers` has new field `scratch_txid`: the latest tx in channel.
+- JSON API: `listchannels` has two new fields: `message_flags` and `channel_flags`. This replaces `flags`.
 - Bitcoind: more parallelism in requests, for very slow nodes.
 - Testing: fixed logging, cleaner interception of bitcoind, minor fixes.
 
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Note: You should always set `allow-deprecated-apis=false` to test for
 changes.
+
+- JSON RPC: `listchannels`' `flags` field. This has been split into two fields, see Added.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CCANDIR := ccan
 
 # Where we keep the BOLT RFCs
 BOLTDIR := ../lightning-rfc/
-BOLTVERSION := a9195a84d07b9350f0eb1262ed0c1a82bc42e4ef
+BOLTVERSION := 0891374d47ddffa64c5a2e6ad151247e3d6b7a59
 
 -include config.vars
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CCANDIR := ccan
 
 # Where we keep the BOLT RFCs
 BOLTDIR := ../lightning-rfc/
-BOLTVERSION := 21e3688e843f82267b3970cda69fa93158dc9517
+BOLTVERSION := 4b62d26af93a07166d6a9de2cb5eff80849d9c19
 
 -include config.vars
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CCANDIR := ccan
 
 # Where we keep the BOLT RFCs
 BOLTDIR := ../lightning-rfc/
-BOLTVERSION := 4b62d26af93a07166d6a9de2cb5eff80849d9c19
+BOLTVERSION := a9195a84d07b9350f0eb1262ed0c1a82bc42e4ef
 
 -include config.vars
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CCANDIR := ccan
 
 # Where we keep the BOLT RFCs
 BOLTDIR := ../lightning-rfc/
-BOLTVERSION := fd9da9b95eb5d585252d7e749212151502e0cc17
+BOLTVERSION := 21e3688e843f82267b3970cda69fa93158dc9517
 
 -include config.vars
 

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -200,7 +200,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	 *
 	 * 5. If the `to_local` amount is greater or equal to
 	 *    `dust_limit_satoshis`, add a [`to_local`
-	 *    output](#to-local-output).
+	 *    output](#to_local-output).
 	 */
 	if (self_pay_msat / 1000 >= dust_limit_satoshis) {
 		u8 *wscript = to_self_wscript(tmpctx, to_self_delay,keyset);
@@ -218,7 +218,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	 *
 	 * 6. If the `to_remote` amount is greater or equal to
 	 *    `dust_limit_satoshis`, add a [`to_remote`
-	 *    output](#to-remote-output).
+	 *    output](#to_remote-output).
 	 */
 	if (other_pay_msat / 1000 >= dust_limit_satoshis) {
 		/* BOLT #3:

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -157,7 +157,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	 *
 	 * 5. If the `to_local` amount is greater or equal to
 	 *    `dust_limit_satoshis`, add a [`to_local`
-	 *    output](#to-local-output).
+	 *    output](#to_local-output).
 	 */
 	if (self_pay_msat / 1000 >= dust_limit_satoshis) {
 		u8 *wscript = to_self_wscript(tmpctx, to_self_delay,keyset);
@@ -170,7 +170,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	 *
 	 * 6. If the `to_remote` amount is greater or equal to
 	 *    `dust_limit_satoshis`, add a [`to_remote`
-	 *    output](#to-remote-output).
+	 *    output](#to_remote-output).
 	 */
 	if (other_pay_msat / 1000 >= dust_limit_satoshis) {
 		/* BOLT #3:

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -31,7 +31,11 @@ struct half_chan {
 
 	/* Flags as specified by the `channel_update`s, among other
 	 * things indicated direction wrt the `channel_id` */
-	u16 flags;
+	u8 channel_flags;
+
+	/* Flags as specified by the `channel_update`s, indicates
+	 * optional fields.  */
+	u8 message_flags;
 
 	/* If greater than current time, this connection should not
 	 * be used for routing. */
@@ -81,7 +85,7 @@ static inline bool is_halfchan_defined(const struct half_chan *hc)
 
 static inline bool is_halfchan_enabled(const struct half_chan *hc)
 {
-	return is_halfchan_defined(hc) && !(hc->flags & ROUTING_FLAGS_DISABLED);
+	return is_halfchan_defined(hc) && !(hc->channel_flags & ROUTING_FLAGS_DISABLED);
 }
 
 struct node {

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -63,7 +63,7 @@ void broadcast_del(struct broadcast_state *bstate UNNEEDED, u64 index UNNEEDED, 
 bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, secp256k1_ecdsa_signature *node_signature_1 UNNEEDED, secp256k1_ecdsa_signature *node_signature_2 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_1 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_2 UNNEEDED, u8 **features UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *node_id_1 UNNEEDED, struct pubkey *node_id_2 UNNEEDED, struct pubkey *bitcoin_key_1 UNNEEDED, struct pubkey *bitcoin_key_2 UNNEEDED)
 { fprintf(stderr, "fromwire_channel_announcement called!\n"); abort(); }
 /* Generated stub for fromwire_channel_update */
-bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u8 *message_flags UNNEEDED, u8 *channel_flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
 bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
@@ -160,7 +160,7 @@ static void add_connection(struct routing_state *rstate,
 	c->base_fee = base_fee;
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
-	c->flags = get_channel_direction(from, to);
+	c->channel_flags = get_channel_direction(from, to);
 }
 
 static struct pubkey nodeid(size_t n)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -3,7 +3,7 @@
  * Expect route 03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf -> 0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae -> 02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06
  *
  * getchannels:
- * {'channels': [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]}
+ * {'channels': [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]}
  */
 #include <common/status.h>
 
@@ -27,7 +27,7 @@ void broadcast_del(struct broadcast_state *bstate UNNEEDED, u64 index UNNEEDED, 
 bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, secp256k1_ecdsa_signature *node_signature_1 UNNEEDED, secp256k1_ecdsa_signature *node_signature_2 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_1 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_2 UNNEEDED, u8 **features UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *node_id_1 UNNEEDED, struct pubkey *node_id_2 UNNEEDED, struct pubkey *bitcoin_key_1 UNNEEDED, struct pubkey *bitcoin_key_2 UNNEEDED)
 { fprintf(stderr, "fromwire_channel_announcement called!\n"); abort(); }
 /* Generated stub for fromwire_channel_update */
-bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u8 *message_flags UNNEEDED, u8 *channel_flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
 bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
@@ -172,38 +172,42 @@ int main(void)
 
 	rstate = new_routing_state(tmpctx, &zerohash, &a, 0);
 
-	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
+	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 
 	nc = get_or_make_connection(rstate, &c, &b, "6990:2:1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
-	nc->flags = 1;
+	nc->channel_flags = 1;
+	nc->message_flags = 0;
 	nc->last_timestamp = 1504064344;
 
-	/* {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
+	/* {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
 	nc = get_or_make_connection(rstate, &b, &a, "6989:2:1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
-	nc->flags = 0;
+	nc->channel_flags = 0;
+	nc->message_flags = 0;
 	nc->last_timestamp = 1504064344;
 
-	/* {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
+	/* {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
 	nc = get_or_make_connection(rstate, &b, &c, "6990:2:1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
-	nc->flags = 0;
+	nc->channel_flags = 0;
+	nc->message_flags = 0;
 	nc->last_timestamp = 1504064344;
 	nc->htlc_minimum_msat = 100;
 
-	/* {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]} */
+	/* {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]} */
 	nc = get_or_make_connection(rstate, &a, &b, "6989:2:1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
-	nc->flags = 1;
+	nc->channel_flags = 1;
+	nc->message_flags = 0;
 	nc->last_timestamp = 1504064344;
 
 	route = find_route(tmpctx, rstate, &a, &c, 100000, riskfactor, 0.0, NULL, &fee);

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -25,7 +25,7 @@ void broadcast_del(struct broadcast_state *bstate UNNEEDED, u64 index UNNEEDED, 
 bool fromwire_channel_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, secp256k1_ecdsa_signature *node_signature_1 UNNEEDED, secp256k1_ecdsa_signature *node_signature_2 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_1 UNNEEDED, secp256k1_ecdsa_signature *bitcoin_signature_2 UNNEEDED, u8 **features UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *node_id_1 UNNEEDED, struct pubkey *node_id_2 UNNEEDED, struct pubkey *bitcoin_key_1 UNNEEDED, struct pubkey *bitcoin_key_2 UNNEEDED)
 { fprintf(stderr, "fromwire_channel_announcement called!\n"); abort(); }
 /* Generated stub for fromwire_channel_update */
-bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u16 *flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
+bool fromwire_channel_update(const void *p UNNEEDED, secp256k1_ecdsa_signature *signature UNNEEDED, struct bitcoin_blkid *chain_hash UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, u32 *timestamp UNNEEDED, u8 *message_flags UNNEEDED, u8 *channel_flags UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, u64 *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED)
 { fprintf(stderr, "fromwire_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_local_add_channel */
 bool fromwire_gossip_local_add_channel(const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct pubkey *remote_node_id UNNEEDED, u64 *satoshis UNNEEDED)
@@ -127,7 +127,7 @@ static void add_connection(struct routing_state *rstate,
 	c->base_fee = base_fee;
 	c->proportional_fee = proportional_fee;
 	c->delay = delay;
-	c->flags = get_channel_direction(from, to);
+	c->channel_flags = get_channel_direction(from, to);
 	c->htlc_minimum_msat = 0;
 }
 
@@ -258,7 +258,7 @@ int main(void)
 	assert(fee == 1 + 3);
 
 	/* Make B->C inactive, force it back via D */
-	get_connection(rstate, &b, &c)->flags |= ROUTING_FLAGS_DISABLED;
+	get_connection(rstate, &b, &c)->channel_flags |= ROUTING_FLAGS_DISABLED;
 	route = find_route(tmpctx, rstate, &a, &c, 3000000, riskfactor, 0.0, NULL, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -653,7 +653,8 @@ static struct io_plan *handle_channel_update_sig(struct io_conn *conn,
 	struct short_channel_id scid;
 	u32 timestamp, fee_base_msat, fee_proportional_mill;
 	u64 htlc_minimum_msat;
-	u16 flags, cltv_expiry_delta;
+	u8 message_flags, channel_flags;
+	u16 cltv_expiry_delta;
 	struct bitcoin_blkid chain_hash;
 	u8 *cu;
 
@@ -661,7 +662,7 @@ static struct io_plan *handle_channel_update_sig(struct io_conn *conn,
 		return bad_req(conn, c, msg_in);
 
 	if (!fromwire_channel_update(cu, &sig, &chain_hash,
-				     &scid, &timestamp, &flags,
+				     &scid, &timestamp, &message_flags, &channel_flags,
 				     &cltv_expiry_delta, &htlc_minimum_msat,
 				     &fee_base_msat, &fee_proportional_mill)) {
 		return bad_req_fmt(conn, c, msg_in, "Bad inner channel_update");
@@ -676,7 +677,7 @@ static struct io_plan *handle_channel_update_sig(struct io_conn *conn,
 	sign_hash(&node_pkey, &hash, &sig);
 
 	cu = towire_channel_update(tmpctx, &sig, &chain_hash,
-				   &scid, timestamp, flags,
+				   &scid, timestamp, message_flags, channel_flags,
 				   cltv_expiry_delta, htlc_minimum_msat,
 				   fee_base_msat, fee_proportional_mill);
 	return req_reply(conn, c, take(towire_hsm_cupdate_sig_reply(NULL, cu)));

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -26,6 +26,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/jsonrpc_errors.h>
 #include <lightningd/log.h>
+#include <lightningd/options.h>
 #include <lightningd/param.h>
 #include <lightningd/ping.h>
 #include <sodium/randombytes.h>
@@ -346,9 +347,13 @@ static void json_listchannels_reply(struct subd *gossip UNUSED, const u8 *reply,
 					       &entries[i].short_channel_id));
 		json_add_bool(response, "public", entries[i].public);
 		json_add_u64(response, "satoshis", entries[i].satoshis);
-		json_add_num(response, "flags", entries[i].flags);
+		json_add_num(response, "message_flags", entries[i].message_flags);
+		json_add_num(response, "channel_flags", entries[i].channel_flags);
+		/* Prior to spec v0891374d47ddffa64c5a2e6ad151247e3d6b7a59, these two were a single u16 field */
+		if (deprecated_apis)
+			json_add_num(response, "flags", ((u16)entries[i].message_flags << 8) | entries[i].channel_flags);
 		json_add_bool(response, "active",
-			      !(entries[i].flags & ROUTING_FLAGS_DISABLED)
+			      !(entries[i].channel_flags & ROUTING_FLAGS_DISABLED)
 			      && !entries[i].local_disabled);
 		json_add_num(response, "last_update",
 			     entries[i].last_update_timestamp);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -84,7 +84,8 @@ void fromwire_gossip_getchannels_entry(const u8 **pptr, size_t *max,
 	fromwire_pubkey(pptr, max, &entry->source);
 	fromwire_pubkey(pptr, max, &entry->destination);
 	entry->satoshis = fromwire_u64(pptr, max);
-	entry->flags = fromwire_u16(pptr, max);
+	entry->message_flags = fromwire_u8(pptr, max);
+	entry->channel_flags = fromwire_u8(pptr, max);
 	entry->public = fromwire_bool(pptr, max);
 	entry->local_disabled = fromwire_bool(pptr, max);
 	entry->last_update_timestamp = fromwire_u32(pptr, max);
@@ -100,7 +101,8 @@ void towire_gossip_getchannels_entry(u8 **pptr,
 	towire_pubkey(pptr, &entry->source);
 	towire_pubkey(pptr, &entry->destination);
 	towire_u64(pptr, entry->satoshis);
-	towire_u16(pptr, entry->flags);
+	towire_u8(pptr, entry->message_flags);
+	towire_u8(pptr, entry->channel_flags);
 	towire_bool(pptr, entry->public);
 	towire_bool(pptr, entry->local_disabled);
 	towire_u32(pptr, entry->last_update_timestamp);

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -22,7 +22,8 @@ struct gossip_getchannels_entry {
 	struct pubkey source, destination;
 	u64 satoshis;
 	struct short_channel_id short_channel_id;
-	u16 flags;
+	u8 message_flags;
+	u8 channel_flags;
 	bool public;
 	bool local_disabled;
 	u32 last_update_timestamp;

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -440,7 +440,6 @@ static u8 *funder_channel(struct state *state,
 	/* BOLT #2:
 	 *
 	 * The receiver:
-	 *...
 	 *  - if `minimum_depth` is unreasonably large:
 	 *    - MAY reject the channel.
 	 */
@@ -704,10 +703,9 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 
 	/* BOLT #2:
 	 *
-	 * The receiver:
-	 *  - if the `chain_hash` value, within the `open_channel`, message is
-	 *    set to a hash of a chain that is unknown to the receiver:
-	 *     - MUST reject the channel.
+	 * The receiving node MUST fail the channel if:
+	 *  - the `chain_hash` value is set to a hash of a chain
+	 *  that is unknown to the receiver.
 	 */
 	if (!bitcoin_blkid_eq(&chain_hash,
 			      &state->chainparams->genesis_blockhash)) {
@@ -733,6 +731,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	/* BOLT #2:
 	 *
 	 * The receiving node MUST fail the channel if:
+	 * ...
 	 *   - `push_msat` is greater than `funding_satoshis` * 1000.
 	 */
 	if (state->push_msat > state->funding_satoshis * 1000) {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -557,7 +557,7 @@ class LightningNode(object):
 
     def is_channel_active(self, chanid):
         channels = self.rpc.listchannels()['channels']
-        active = [(c['short_channel_id'], c['flags']) for c in channels if c['active']]
+        active = [(c['short_channel_id'], c['channel_flags']) for c in channels if c['active']]
         return (chanid, 0) in active and (chanid, 1) in active
 
     def wait_for_channel_onchain(self, peerid):

--- a/wire/gen_peer_wire_csv
+++ b/wire/gen_peer_wire_csv
@@ -143,7 +143,8 @@ channel_update,0,signature,64
 channel_update,64,chain_hash,32
 channel_update,96,short_channel_id,8
 channel_update,104,timestamp,4
-channel_update,108,flags,2
+channel_update,108,message_flags,1
+channel_update,109,channel_flags,1
 channel_update,110,cltv_expiry_delta,2
 channel_update,112,htlc_minimum_msat,8
 channel_update,120,fee_base_msat,4

--- a/wire/test/run-peer-wire.c
+++ b/wire/test/run-peer-wire.c
@@ -123,7 +123,8 @@ struct msg_revoke_and_ack {
 struct msg_channel_update {
 	secp256k1_ecdsa_signature signature;
 	u32 timestamp;
-	u16 flags;
+	u8 message_flags;
+	u8 channel_flags;
 	u16 expiry;
 	u64 htlc_minimum_msat;
 	u32 fee_base_msat;
@@ -376,7 +377,8 @@ static void *towire_struct_channel_update(const tal_t *ctx,
 				     &s->chain_hash,
 				     &s->short_channel_id,
 				     s->timestamp,
-				     s->flags,
+				     s->message_flags,
+				     s->channel_flags,
 				     s->expiry,
 				     s->htlc_minimum_msat,
 				     s->fee_base_msat,
@@ -392,7 +394,8 @@ static struct msg_channel_update *fromwire_struct_channel_update(const tal_t *ct
 				    &s->chain_hash,
 				    &s->short_channel_id,
 				    &s->timestamp,
-				    &s->flags,
+				    &s->message_flags,
+				    &s->channel_flags,
 				    &s->expiry,
 				    &s->htlc_minimum_msat,
 				    &s->fee_base_msat,


### PR DESCRIPTION
Updates to BOLTs. Mostly copy changes, except for flag breakout in BOLT7.

BOLT 7's been [updated](https://github.com/lightningnetwork/lightning-rfc/commit/0891374d47ddffa64c5a2e6ad151247e3d6b7a59) to split the flags field in `channel_update`
into two: `channel_flags` and `message_flags`. This changeset does the
minimal necessary to get to building with the new flags.

