### PR TITLE
pytest: wait until mock is called for set_feerates.

### DIFF
--- a/tests/btcproxy.py
+++ b/tests/btcproxy.py
@@ -29,6 +29,7 @@ class BitcoinRpcProxy(object):
         self.app.add_url_rule("/", "API entrypoint", self.proxy, methods=['POST'])
         self.rpcport = rpcport
         self.mocks = {}
+        self.mock_counts = {}
         self.bitcoind = bitcoind
         self.request_count = 0
 
@@ -40,8 +41,10 @@ class BitcoinRpcProxy(object):
         # If we have set a mock for this method reply with that instead of
         # forwarding the request.
         if method in self.mocks and type(method) == dict:
+            self.mock_counts[method] += 1
             return self.mocks[method]
         elif method in self.mocks and callable(self.mocks[method]):
+            self.mock_counts[method] += 1
             return self.mocks[method](r)
 
         try:
@@ -100,5 +103,6 @@ class BitcoinRpcProxy(object):
         """
         if response is not None:
             self.mocks[method] = response
+            self.mock_counts[method] = 0
         elif method in self.mocks:
             del self.mocks[method]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -627,8 +627,10 @@ class LightningNode(object):
             }
         self.daemon.rpcproxy.mock_rpc('estimatesmartfee', mock_estimatesmartfee)
 
+        # Technically, this waits until it's called, not until it's processed.
+        # We wait until all three levels have been called.
         if wait_for_effect:
-            self.daemon.wait_for_log('Feerate estimate for .* set to')
+            wait_for(lambda: self.daemon.rpcproxy.mock_counts['estimatesmartfee'] >= 3)
 
 
 class NodeFactory(object):


### PR DESCRIPTION
Got a spurious failure in test_no_fee_estimate; we fired too soon from the logs (presumably
we raced in on the first response, but estimatesmartfee gets called 3 times).
