### PR TITLE
Help usage

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -78,6 +78,9 @@ static void json_stop(struct command *cmd,
 {
 	struct json_result *response = new_json_result(cmd);
 
+	if (!param(cmd, buffer, params, NULL))
+		return;
+
 	/* This can't have closed yet! */
 	cmd->jcon->stop = true;
 	json_add_string(response, NULL, "Shutting down");
@@ -121,6 +124,9 @@ AUTODATA(json_command, &dev_rhash_command);
 static void json_crash(struct command *cmd UNUSED,
 		       const char *buffer UNUSED, const jsmntok_t *params UNUSED)
 {
+	if (!param(cmd, buffer, params, NULL))
+		return;
+
 	fatal("Crash at user request");
 }
 
@@ -136,6 +142,9 @@ static void json_getinfo(struct command *cmd,
 			 const char *buffer UNUSED, const jsmntok_t *params UNUSED)
 {
 	struct json_result *response = new_json_result(cmd);
+
+	if (!param(cmd, buffer, params, NULL))
+		return;
 
 	json_object_start(response, NULL);
 	json_add_pubkey(response, "id", &cmd->ld->id);

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -282,6 +282,8 @@ static void connection_complete_ok(struct json_connection *jcon,
 {
 	assert(id != NULL);
 	assert(result != NULL);
+	if (cmd->ok)
+		*(cmd->ok) = true;
 
 	/* This JSON is simple enough that we build manually */
 	json_done(jcon, cmd, take(tal_fmt(jcon,
@@ -309,6 +311,9 @@ static void connection_complete_error(struct json_connection *jcon,
 		data_str = "";
 
 	assert(id != NULL);
+
+	if (cmd->ok)
+		*(cmd->ok) = false;
 
 	json_done(jcon, cmd, take(tal_fmt(tmpctx,
 					  "{ \"jsonrpc\": \"2.0\", "
@@ -452,6 +457,7 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 			    json_tok_contents(jcon->buffer, id),
 			    json_tok_len(id));
 	c->mode = CMD_NORMAL;
+	c->ok = NULL;
 	list_add(&jcon->commands, &c->list);
 	tal_add_destructor(c, destroy_cmd);
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -442,6 +442,7 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	c->id = tal_strndup(c,
 			    json_tok_contents(jcon->buffer, id),
 			    json_tok_len(id));
+	c->mode = CMD_NORMAL;
 	list_add(&jcon->commands, &c->list);
 	tal_add_destructor(c, destroy_cmd);
 

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -10,6 +10,14 @@ struct bitcoin_txid;
 struct wireaddr;
 struct wallet_tx;
 
+/* The command mode tells param() how to process. */
+enum command_mode {
+	/* Normal command processing */
+	CMD_NORMAL,
+	/* Create command usage string, nothing else. */
+	CMD_USAGE
+};
+
 /* Context for a command (from JSON, but might outlive the connection!)
  * You can allocate off this for temporary objects. */
 struct command {
@@ -25,6 +33,10 @@ struct command {
 	struct json_connection *jcon;
 	/* Have we been marked by command_still_pending?  For debugging... */
 	bool pending;
+	/* Tell param() how to process the command */
+	enum command_mode mode;
+	/* This is created if mode is CMD_USAGE */
+	const char *usage;
 };
 
 struct json_connection {

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -37,6 +37,7 @@ struct command {
 	enum command_mode mode;
 	/* This is created if mode is CMD_USAGE */
 	const char *usage;
+	bool *ok;
 };
 
 struct json_connection {

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -10,6 +10,7 @@
 #include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/param.h>
 #include <stdio.h>
 
 static void json_add_ptr(struct json_result *response, const char *name,
@@ -56,6 +57,9 @@ static void json_memdump(struct command *cmd,
 			 const jsmntok_t *params UNNEEDED)
 {
 	struct json_result *response = new_json_result(cmd);
+
+	if (!param(cmd, buffer, params, NULL))
+		return;
 
 	add_memdump(response, NULL, NULL, cmd);
 
@@ -150,6 +154,9 @@ static void json_memleak(struct command *cmd,
 			 const jsmntok_t *params UNNEEDED)
 {
 	struct json_result *response = new_json_result(cmd);
+
+	if (!param(cmd, buffer, params, NULL))
+		return;
 
 	if (!getenv("LIGHTNINGD_DEV_MEMLEAK")) {
 		command_fail(cmd, LIGHTNINGD,

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -223,6 +223,21 @@ static bool check_params(struct param *params)
 }
 #endif
 
+static char *param_usage(const tal_t *ctx,
+			 const struct param *params)
+{
+	char *usage = tal_strdup(ctx, "");
+	for (size_t i = 0; i < tal_count(params); i++) {
+		if (i != 0)
+			tal_append_fmt(&usage, " ");
+		if (params[i].required)
+			tal_append_fmt(&usage, "%s", params[i].name);
+		else
+			tal_append_fmt(&usage, "[%s]", params[i].name);
+	}
+	return usage;
+}
+
 static bool param_arr(struct command *cmd, const char *buffer,
 		      const jsmntok_t tokens[],
 		      struct param *params)
@@ -262,6 +277,11 @@ bool param(struct command *cmd, const char *buffer,
 		}
 	}
 	va_end(ap);
+
+	if (cmd->mode == CMD_USAGE) {
+		cmd->usage = param_usage(cmd, params);
+		return false;
+	}
 
 	return param_arr(cmd, buffer, tokens, params);
 }

--- a/lightningd/param.c
+++ b/lightningd/param.c
@@ -244,7 +244,7 @@ static bool param_arr(struct command *cmd, const char *buffer,
 {
 #if DEVELOPER
 	if (!check_params(params)) {
-		command_fail(cmd, PARAM_DEV_ERROR, "developer error");
+		command_fail(cmd, PARAM_DEV_ERROR, "developer error: check_params");
 		return false;
 	}
 #endif
@@ -271,7 +271,8 @@ bool param(struct command *cmd, const char *buffer,
 		param_cbx cbx = va_arg(ap, param_cbx);
 		void *arg = va_arg(ap, void *);
 		if  (!param_add(&params, name, required, cbx, arg)) {
-			command_fail(cmd, PARAM_DEV_ERROR, "developer error");
+			command_fail(cmd, PARAM_DEV_ERROR,
+				     "developer error: param_add %s", name);
 			va_end(ap);
 			return false;
 		}

--- a/lightningd/test/run-param.c
+++ b/lightningd/test/run-param.c
@@ -253,6 +253,16 @@ static void null_params(void)
 	assert(*intptrs[6] == 888);
 }
 
+static void no_params(void)
+{
+	struct json *j = json_parse(cmd, "[]");
+	assert(param(cmd, j->buffer, j->toks, NULL));
+
+	j = json_parse(cmd, "[ 'unexpected' ]");
+	assert(!param(cmd, j->buffer, j->toks, NULL));
+}
+
+
 #if DEVELOPER
 /*
  * Check to make sure there are no programming mistakes.
@@ -560,12 +570,14 @@ int main(void)
 	setup_locale();
 	setup_tmpctx();
 	cmd = tal(tmpctx, struct command);
+	cmd->mode = CMD_NORMAL;
 	fail_msg = tal_arr(cmd, char, 10000);
 
 	zero_params();
 	sanity();
 	tok_tok();
 	null_params();
+	no_params();
 #if DEVELOPER
 	bad_programmer();
 #endif

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -622,7 +622,7 @@ def test_cli(node_factory):
                                    .format(l1.daemon.lightning_dir),
                                    'help']).decode('utf-8')
     # Test some known output.
-    assert 'help\n    List available commands, or give verbose help on one command' in out
+    assert 'help [command]\n    List available commands, or give verbose help on one {command}' in out
 
     # Test JSON output.
     out = subprocess.check_output(['cli/lightning-cli',

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -388,6 +388,10 @@ static void json_listfunds(struct command *cmd, const char *buffer UNUSED,
 	    wallet_get_utxos(cmd, cmd->ld->wallet, output_state_available);
 	char* out;
 	struct pubkey funding_pubkey;
+
+	if (!param(cmd, buffer, params, NULL))
+		return;
+
 	json_object_start(response, NULL);
 	json_array_start(response, "outputs");
 	for (size_t i = 0; i < tal_count(utxos); i++) {
@@ -505,6 +509,10 @@ static void json_dev_rescan_outputs(struct command *cmd,
 				    const jsmntok_t *params UNUSED)
 {
 	struct txo_rescan *rescan = tal(cmd, struct txo_rescan);
+
+	if (!param(cmd, buffer, params, NULL))
+		return;
+
 	rescan->response = new_json_result(cmd);
 	rescan->cmd = cmd;
 


### PR DESCRIPTION
The help command now adds command usage to its output.

Instead of seeing, for example:

    decodepay
        Decode {bolt11}, using {description} if necessary

we see:

    decodepay bolt11 [description]
        Decode {bolt11}, using {description} if necessary

Note: Removed discussion of `check` command.  It was removed and saved for later patch.

This patch is a big step toward allowing us to write tests that:
1. Verify the manpage SYNOPSIS is correct.
2. Exhaustively test the API.

The first three commits adds the infrastructure.  The approach I took
is to introduce different command modes.  And the behavior of `param()` changes based on the mode.

Inspired-By: discussions with @rustyrussell 

