### PR TITLE
tools/gen-wire: 3th -> 3rd

### DIFF
--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -401,7 +401,7 @@ class Message(object):
                                     .format(f.name, f.name, f.fieldtype.name,
                                             basetype, f.name))
                 elif f.is_assignable():
-                    subcalls.append("//3th case {name}".format(name=f.name))
+                    subcalls.append("//3rd case {name}".format(name=f.name))
                     if f.is_len_var:
                         subcalls.append('{} = fromwire_{}(&cursor, &plen);'
                                         .format(f.name, basetype))


### PR DESCRIPTION
This looked like a mistake. Small grammar fix in wire gen tool.