### PR TITLE
json: Support streaming JSON messages

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -148,16 +148,6 @@ const jsmntok_t *json_next(const jsmntok_t *tok)
 	return t;
 }
 
-const jsmntok_t *json_last_toks(const jsmntok_t *tok)
-{
-	const jsmntok_t *t = tok;
-	for (size_t i=0; i<tok->size; i++) {
-		t++;
-		t = json_last_toks(t);
-	}
-	return t;
-}
-
 const jsmntok_t *json_get_member(const char *buffer, const jsmntok_t tok[],
 				 const char *label)
 {
@@ -224,7 +214,7 @@ again:
 	 * ret=JSMN_ERROR_PART, but due to the previous check we know we read at
 	 * least one full element, so count tokens that are part of this root
 	 * element. */
-	ret = json_last_toks(toks) - toks + 1;
+	ret = json_next(toks) - toks;
 
 	/* Cut to length and return. */
 	*valid = true;

--- a/common/json.h
+++ b/common/json.h
@@ -106,5 +106,9 @@ void json_add_hex_talarr(struct json_result *result,
 			 const tal_t *data);
 void json_add_object(struct json_result *result, ...);
 
+/* Get a pointer to the last child element of this object */
+const jsmntok_t *json_last_toks(const jsmntok_t *tok);
+
+
 const char *json_result_string(const struct json_result *result);
 #endif /* LIGHTNING_COMMON_JSON_H */

--- a/common/json.h
+++ b/common/json.h
@@ -106,9 +106,5 @@ void json_add_hex_talarr(struct json_result *result,
 			 const tal_t *data);
 void json_add_object(struct json_result *result, ...);
 
-/* Get a pointer to the last child element of this object */
-const jsmntok_t *json_last_toks(const jsmntok_t *tok);
-
-
 const char *json_result_string(const struct json_result *result);
 #endif /* LIGHTNING_COMMON_JSON_H */


### PR DESCRIPTION
It turns out we were heavily relying on the fact that after each message from
the client there'd be a flush, and that there would not be anything after the
JSON object we read. This will no longer be the case once we start streaming
things or we are very quick in issuing the JSON-RPC requests.

This just takes one of the error paths (incomplete read) and makes it into a
successful path if we have indeed read a full root element.