### PR TITLE
git: ignore all current and future unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,32 +21,11 @@ __pycache__
 config.vars
 
 # Ignore some generated binaries
-lightningd/test/run-channel
-lightningd/test/run-cryptomsg
-lightningd/test/run-commit_tx
-lightningd/test/run-find_my_path
-lightningd/test/run-funding_tx
-lightningd/test/run-param
-lightningd/test/run-key_derive
-common/test/run-ip_port_parsing
-wire/test/run-peer-wire
-bitcoin/test/run-tx-encode
-channeld/test/run-full_channel
-common/test/run-bolt11
-common/test/run-derive_basepoints
-common/test/run-features
-common/test/run-json
-common/test/run-sphinx
-connectd/test/run-initiator-success
-connectd/test/run-responder-success
-daemon/test/run-maxfee
+*/test/run-*
+!*/test/run-*.c
 external/libbacktrace-build/
 external/libbacktrace.a
 external/libbacktrace.la
-gossipd/test/run-find_route-specific
-gossipd/test/run-initiator-success
-gossipd/test/run-responder-success
-onchaind/test/run-grind_feerate
 test/test_protocol
 test/test_sphinx
 tests/.pytest.restart


### PR DESCRIPTION
I wanted to add a couple recently created unit tests to the
.gitignore file, but instead I replaced all the names of tests with a simple
regex.

This works because git doesn't ignore files that are already in git. So
source and header file are safe.
