### PR TITLE
git: ignore vim's c-tags 'tags' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.rej
 .cppcheck-suppress
 TAGS
+tags
 ccan/tools/configurator/configurator
 ccan/ccan/cdump/tools/cdump-enumstr
 gen_*


### PR DESCRIPTION
Vim's c-tags file is all lowercase, unlike some other text editor's, which appears to be all caps.