### PR TITLE
pytest: Fix benchmarks after the fixture migration

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -4,10 +4,8 @@ from time import time
 from tqdm import tqdm
 
 
-import logging
 import pytest
 import random
-import utils
 
 
 num_workers = 480

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,5 @@ pytest-xdist==1.22.2
 flaky==3.4.0
 CherryPy==17.3.0
 Flask==1.0.2
+pytest-benchmark==3.1.1
+tqdm==4.26.0


### PR DESCRIPTION
Back when we migrated to pure `py.test` based tests we broke some of the benchmarks.