### PR TITLE
Make it more obvious that you need to install cppcheck + fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ check-cppcheck: .cppcheck-suppress
 	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs cppcheck -q --language=c --std=c11 --error-exitcode=1 --suppressions-list=.cppcheck-suppress
 
 check-shellcheck:
-	git ls-files -- "*.sh" | xargs shellcheck
+	@git ls-files -- "*.sh" | xargs shellcheck
 
 check-setup_locale:
 	@tools/check-setup_locale.sh

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -158,7 +158,7 @@ Testing
 Install `valgrind` and the python dependencies for best results:
 
 ```
-sudo apt install valgrind
+sudo apt install valgrind cppcheck shellcheck
 pip3 install -r tests/requirements.txt
 ```
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -319,6 +319,7 @@ static void connection_complete_error(struct json_connection *jcon,
 
 	assert(id != NULL);
 
+	assert(cmd);
 	if (cmd->ok)
 		*(cmd->ok) = false;
 


### PR DESCRIPTION
I finally figured out why `cppcheck` and `shellcheck` weren't working for me -- I didn't have them installed. :man_facepalming: 

This updates the notes in HACKING.md to include them as a part of the setup instructions for the test infrastructure.

Once they were running, `cppcheck` was failing because of a warning. This also adds a null pointer check to quiet down the warning so that the check will pass.