### PR TITLE
make: fix broken error message in bolt-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ check-makefile:
 
 # Any mention of BOLT# must be followed by an exact quote, modulo whitespace.
 bolt-check/%: % bolt-precheck tools/check-bolt
-	@if [ -d .tmp.lightningrfc ]; then tools/check-bolt .tmp.lightningrfc $<; else Not checking BOLTs: BOLTDIR $(BOLTDIR) does not exist >&2; fi
+	@if [ -d .tmp.lightningrfc ]; then tools/check-bolt .tmp.lightningrfc $<; else echo "Not checking BOLTs: BOLTDIR $(BOLTDIR) does not exist" >&2; fi
 
 LOCAL_BOLTDIR=.tmp.lightningrfc
 


### PR DESCRIPTION
It looks like a printf was missing for the bolt-check error message

Signed-off-by: William Casarin <jb55@jb55.com>