### PR TITLE
Reduce logging spam, especially when testing.

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -764,10 +764,10 @@ def test_channel_persistence(node_factory, bitcoind, executor):
     wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 1)
 
     # Wait for the restored HTLC to finish
-    wait_for(lambda: only_one(l1.rpc.listpeers()['peers'][0]['channels'])['msatoshi_to_us'] == 99990000, interval=1)
+    wait_for(lambda: only_one(l1.rpc.listpeers()['peers'][0]['channels'])['msatoshi_to_us'] == 99990000)
 
-    wait_for(lambda: len([p for p in l1.rpc.listpeers()['peers'] if p['connected']]), interval=1)
-    wait_for(lambda: len([p for p in l2.rpc.listpeers()['peers'] if p['connected']]), interval=1)
+    wait_for(lambda: len([p for p in l1.rpc.listpeers()['peers'] if p['connected']]))
+    wait_for(lambda: len([p for p in l2.rpc.listpeers()['peers'] if p['connected']]))
 
     # Now make sure this is really functional by sending a payment
     l1.pay(l2, 10000)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -543,7 +543,7 @@ def test_routing_gossip(node_factory, bitcoind):
         return len(missing) == 0
 
     for n in nodes:
-        wait_for(lambda: check_gossip(n), interval=1)
+        wait_for(lambda: check_gossip(n))
 
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -943,7 +943,7 @@ def test_logging(node_factory):
 
     def check_new_log():
         log2 = open(logpath).readlines()
-        return len(log2) > 1 and log2[0].endswith("Started log due to SIGHUP\n")
+        return len(log2) > 0 and log2[0].endswith("Started log due to SIGHUP\n")
     wait_for(check_new_log)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,10 +39,14 @@ TIMEOUT = int(os.getenv("TIMEOUT", "60"))
 VALGRIND = os.getenv("VALGRIND", config['VALGRIND']) == "1"
 
 
-def wait_for(success, timeout=TIMEOUT, interval=0.1):
+def wait_for(success, timeout=TIMEOUT):
     start_time = time.time()
+    interval = 0.25
     while not success() and time.time() < start_time + timeout:
         time.sleep(interval)
+        interval *= 2
+        if interval > 5:
+            interval = 5
     if time.time() > start_time + timeout:
         raise ValueError("Error waiting for {}", success)
 
@@ -570,7 +574,7 @@ class LightningNode(object):
         wait_for(lambda: txid in self.bitcoin.rpc.getrawmempool())
 
     def wait_channel_active(self, chanid):
-        wait_for(lambda: self.is_channel_active(chanid), interval=1)
+        wait_for(lambda: self.is_channel_active(chanid))
 
     # This waits until gossipd sees channel_update in both directions
     # (or for local channels, at least a local announcement)


### PR DESCRIPTION
We seem to be getting some spurious Travis failures, but the logs are too long and Travis kills it.   Half the logs are bitcoin-cli messages, so let's only log those if a request takes a ridiculous period of time (10 seconds).  The other cause of log spam is the 600 times we try a command in wait_for(), so make that do exponential backoff; here that made basically no difference to the test time with -n10.