### PR TITLE
Avoid applying the unary minus operator to an unsigned operand

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -72,7 +72,7 @@ static void htlc_arr_append(const struct htlc ***arr, const struct htlc *htlc)
 static s64 balance_adding_htlc(const struct htlc *htlc, enum side side)
 {
 	if (htlc_owner(htlc) == side)
-		return -htlc->msatoshi;
+		return -(s64)htlc->msatoshi;
 	return 0;
 }
 


### PR DESCRIPTION
Avoid applying the unary minus operator to an unsigned operand.

Rationale:

```
[cling]$ #include <stdint.h>
[cling]$ typedef uint64_t u64;
[cling]$ typedef int64_t s64;
[cling]$ u64 msatoshi = 5
(unsigned long) 5
[cling]$ -msatoshi
(unsigned long) 18446744073709551611
[cling]$ -(s64)msatoshi
(long) -5
```

Explicit is better than implicit – also when it comes to conversions :-)