### PR TITLE
lightningd: fail fundchannel command when feerate is below feerate_floor

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1,3 +1,4 @@
+#include "bitcoin/feerate.h"
 #include <bitcoin/privkey.h>
 #include <bitcoin/script.h>
 #include <ccan/tal/str/str.h>
@@ -789,6 +790,11 @@ static void json_fund_channel(struct command *cmd,
 			command_fail(cmd, LIGHTNINGD, "Cannot estimate fees");
 			return;
 		}
+	}
+
+	if (*feerate_per_kw < feerate_floor()) {
+		command_fail(cmd, LIGHTNINGD, "Feerate below feerate floor");
+			return;
 	}
 
 	peer = peer_by_id(cmd->ld, id);


### PR DESCRIPTION
With `fundchannel` command, check that the user-supplied feerate is not below `feerate_floor`. Otherwise we solely rely on the _receiver_ to do that check.
Fixes #1990

Note: if the _receiver_ allows feerates below `feerate_floor,` it is not [BOLT](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-open_channel-message) compliant.

> The receiving node MUST fail the channel if:
> ..
>    it considers feerate_per_kw too small for timely processing or unreasonably large.

and

> The sending node SHOULD:
> ...
>    set feerate_per_kw to at least the rate it estimates would cause the transaction to be immediately included in a block.