### PR TITLE
jsonrpc: fix crash on bad JSON input.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -279,6 +279,7 @@ static void json_done(struct json_connection *jcon,
 	struct json_output *out = tal(jcon, struct json_output);
 	out->json = tal_strdup(out, json);
 
+	/* Can be NULL if we failed to parse! */
 	tal_free(cmd);
 
 	/* Queue for writing, and wake writer. */
@@ -323,8 +324,8 @@ static void connection_complete_error(struct json_connection *jcon,
 
 	assert(id != NULL);
 
-	assert(cmd);
-	if (cmd->ok)
+	/* cmd *can be* NULL if we failed to parse! */
+	if (cmd && cmd->ok)
 		*(cmd->ok) = false;
 
 	json_done(jcon, cmd, take(tal_fmt(tmpctx,


### PR DESCRIPTION
It went something like:

   @niftynei: Hey, cppcheck complains this might be NULL, so I put in a check.
   @rustyrussell : cppcheck is dumb.  Make it an assert("Rusty always right!").
   @niftynei: You seem certain of this so I shall do that.
             https://github.com/ElementsProject/lightning/pull/1994
   ...
   @renepickhardt: I asked fiatjaf to run `lightning-cli sendpay "[{'id':'02db8f487fcc0a'}]" 4efe0ba89b`  and his node crashed!
   @rustyrussell: grep Assertion logs/*
         `lightningd/jsonrpc.c:326: connection_complete_error: Assertion 'Rusty is always right!' failed.`

It turns out that in the 'can't parse' error case, we hand NULL cmd to connection_compete_error.

Next time, less asserting, more grepping!

(As see in #2010)