### PR TITLE
channeld: allow WIRE_ANNOUNCEMENT_SIGNATURES before funding_locked.

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1630,7 +1630,9 @@ static void peer_in(struct peer *peer, const u8 *msg)
 	if (!peer->funding_locked[REMOTE]) {
 		if (type != WIRE_FUNDING_LOCKED
 		    && type != WIRE_PONG
-		    && type != WIRE_SHUTDOWN) {
+		    && type != WIRE_SHUTDOWN
+		    /* lnd sends this early; it's harmless. */
+		    && type != WIRE_ANNOUNCEMENT_SIGNATURES) {
 			peer_failed(&peer->cs,
 				    &peer->channel_id,
 				    "%s (%u) before funding locked",


### PR DESCRIPTION
LND does this, and we get upset with it.  I had assumed we would only
do this after funding_locked (since we don't consider the channel
shortid stable until that point), but TBH 6 confirms is probably
enough.

Fixes: #1985

Note that this is talked about in spec commit https://github.com/lightningnetwork/lightning-rfc/pull/474