### PR TITLE
Fix channel stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ changes.
 - JSON RPC: `ping` now works even after one peer fails to respond.
 - JSON RPC: `getroute` `fuzzpercent` and `pay` `maxfeepercent` can now be > 100.
 - JSON RPC: `riskfactor` in `pay` and `getroute` no longer always treated as 1.
+- JSON-RPC: `listpeers` was always reporting 0 for all stats.
 - Protocol: fix occasional deadlock when both peers flood with gossip.
 - Protocol: fix occasional long delay on sending `reply_short_channel_ids_end`.
 - Protocol: re-send `node_announcement` when address/alias/color etc change.

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -61,6 +61,26 @@ def test_single_payment(node_factory, benchmark):
     benchmark(do_pay, l1, l2)
 
 
+def test_forward_payment(node_factory, benchmark):
+    l1, l2, l3 = node_factory.line_graph(3, announce=True)
+
+    def do_pay(src, dest):
+        invoice = dest.rpc.invoice(1000, 'invoice-{}'.format(random.random()), 'desc')['bolt11']
+        src.rpc.pay(invoice)
+
+    benchmark(do_pay, l1, l3)
+
+
+def test_long_forward_payment(node_factory, benchmark):
+    nodes = node_factory.line_graph(21, announce=True)
+
+    def do_pay(src, dest):
+        invoice = dest.rpc.invoice(1000, 'invoice-{}'.format(random.random()), 'desc')['bolt11']
+        src.rpc.pay(invoice)
+
+    benchmark(do_pay, nodes[0], nodes[-1])
+
+
 def test_invoice(node_factory, benchmark):
     l1 = node_factory.get_node()
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -976,7 +976,6 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     assert only_one(l3.rpc.listinvoices('test_forward_pad_fees_and_cltv')['invoices'])['status'] == 'paid'
 
 
-@pytest.mark.xfail(strict=True)
 def test_forward_stats(node_factory):
     l1, l2, l3 = node_factory.line_graph(3, announce=True)
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -974,3 +974,33 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     l1.rpc.sendpay(route, rhash)
     l1.rpc.waitsendpay(rhash)
     assert only_one(l3.rpc.listinvoices('test_forward_pad_fees_and_cltv')['invoices'])['status'] == 'paid'
+
+
+@pytest.mark.xfail(strict=True)
+def test_forward_stats(node_factory):
+    l1, l2, l3 = node_factory.line_graph(3, announce=True)
+
+    inv = l3.rpc.invoice(100000, "first", "desc")['bolt11']
+    l1.rpc.pay(inv)
+
+    inchan = l2.rpc.listpeers(l1.info['id'])['peers'][0]['channels'][0]
+    outchan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+
+    def extract_stats(c):
+        return {k: v for k, v in c.items() if 'in_' in k or 'out_' in k}
+
+    instats = extract_stats(inchan)
+    outstats = extract_stats(outchan)
+
+    # Check that we correctly account channel changes
+    assert instats['in_payments_offered'] == 1
+    assert instats['in_payments_fulfilled'] == 1
+    assert instats['in_msatoshi_offered'] >= 100000
+    assert instats['in_msatoshi_offered'] == instats['in_msatoshi_fulfilled']
+
+    assert outstats['out_payments_offered'] == 1
+    assert outstats['out_payments_fulfilled'] == 1
+    assert outstats['out_msatoshi_offered'] >= 100000
+    assert outstats['out_msatoshi_offered'] == outstats['out_msatoshi_fulfilled']
+
+    assert outstats['out_msatoshi_fulfilled'] < instats['in_msatoshi_fulfilled']

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -798,6 +798,7 @@ void wallet_channel_stats_load(struct wallet *w,
 			       struct channel_stats *stats)
 {
 	sqlite3_stmt *stmt;
+	int res;
 	stmt = db_prepare(w->db,
 			  "SELECT  in_payments_offered,  in_payments_fulfilled"
 			  "     ,  in_msatoshi_offered,  in_msatoshi_fulfilled"
@@ -806,6 +807,12 @@ void wallet_channel_stats_load(struct wallet *w,
 			  "  FROM channels"
 			  " WHERE id = ?");
 	sqlite3_bind_int64(stmt, 1, id);
+
+	res = sqlite3_step(stmt);
+
+	/* This must succeed, since we know the channel exists */
+	assert(res == SQLITE_ROW);
+
 	stats->in_payments_offered = sqlite3_column_int64(stmt, 0);
 	stats->in_payments_fulfilled = sqlite3_column_int64(stmt, 1);
 	stats->in_msatoshi_offered = sqlite3_column_int64(stmt, 2);


### PR DESCRIPTION
Turns out we weren't really loading channel stats, instead returning only 0 for all stats. Probably this is why people assumed their nodes were not forwarding anything and were surprised when the balances changed without any apparent forwarding.