### PR TITLE
Track fees earned by forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ changes.
 - JSON RPC: `ping` now works even after one peer fails to respond.
 - JSON RPC: `getroute` `fuzzpercent` and `pay` `maxfeepercent` can now be > 100.
 - JSON RPC: `riskfactor` in `pay` and `getroute` no longer always treated as 1.
+- JSON-RPC: `listpeers` was always reporting 0 for all stats.
 - Protocol: fix occasional deadlock when both peers flood with gossip.
 - Protocol: fix occasional long delay on sending `reply_short_channel_ids_end`.
 - Protocol: re-send `node_announcement` when address/alias/color etc change.

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -647,6 +647,56 @@ static void json_add_htlcs(struct lightningd *ld,
 	json_array_end(response);
 }
 
+static void json_channel_add_stats(struct lightningd *ld,
+				struct json_result *response, u64 channel_id)
+{
+	struct channel_stats channel_stats;
+	/* Provide channel statistics */
+	wallet_channel_stats_load(ld->wallet, channel_id, &channel_stats);
+
+	if (deprecated_apis) {
+		json_add_u64(response, "in_payments_offered",
+			     channel_stats.in_payments_offered);
+		json_add_u64(response, "in_msatoshi_offered",
+			     channel_stats.in_msatoshi_offered);
+		json_add_u64(response, "in_payments_fulfilled",
+			     channel_stats.in_payments_fulfilled);
+		json_add_u64(response, "in_msatoshi_fulfilled",
+			     channel_stats.in_msatoshi_fulfilled);
+		json_add_u64(response, "out_payments_offered",
+			     channel_stats.out_payments_offered);
+		json_add_u64(response, "out_msatoshi_offered",
+			     channel_stats.out_msatoshi_offered);
+		json_add_u64(response, "out_payments_fulfilled",
+			     channel_stats.out_payments_fulfilled);
+		json_add_u64(response, "out_msatoshi_fulfilled",
+			     channel_stats.out_msatoshi_fulfilled);
+	}
+
+	json_object_start(response, "stats");
+	json_add_u64(response, "in_payments_offered",
+		     channel_stats.in_payments_offered);
+	json_add_u64(response, "in_msatoshi_offered",
+		     channel_stats.in_msatoshi_offered);
+	json_add_u64(response, "in_payments_fulfilled",
+		     channel_stats.in_payments_fulfilled);
+	json_add_u64(response, "in_msatoshi_fulfilled",
+		     channel_stats.in_msatoshi_fulfilled);
+	json_add_u64(response, "in_msatoshi_fee",
+		     channel_stats.in_msatoshi_fee);
+	json_add_u64(response, "out_payments_offered",
+		     channel_stats.out_payments_offered);
+	json_add_u64(response, "out_msatoshi_offered",
+		     channel_stats.out_msatoshi_offered);
+	json_add_u64(response, "out_payments_fulfilled",
+		     channel_stats.out_payments_fulfilled);
+	json_add_u64(response, "out_msatoshi_fulfilled",
+		     channel_stats.out_msatoshi_fulfilled);
+	json_add_u64(response, "out_msatoshi_fee",
+		     channel_stats.out_msatoshi_fee);
+	json_object_end(response);
+}
+
 static void json_add_peer(struct lightningd *ld,
 			  struct json_result *response,
 			  struct peer *p,
@@ -696,7 +746,6 @@ static void json_add_peer(struct lightningd *ld,
 
 	list_for_each(&p->channels, channel, list) {
 		struct channel_id cid;
-		struct channel_stats channel_stats;
 		u64 our_reserve_msat = channel->channel_info.their_config.channel_reserve_satoshis * 1000;
 		json_object_start(response, NULL);
 		json_add_string(response, "state",
@@ -782,26 +831,7 @@ static void json_add_peer(struct lightningd *ld,
 					channel->billboard.transient);
 		json_array_end(response);
 
-		/* Provide channel statistics */
-		wallet_channel_stats_load(ld->wallet,
-					  channel->dbid,
-					  &channel_stats);
-		json_add_u64(response, "in_payments_offered",
-			     channel_stats.in_payments_offered);
-		json_add_u64(response, "in_msatoshi_offered",
-			     channel_stats.in_msatoshi_offered);
-		json_add_u64(response, "in_payments_fulfilled",
-			     channel_stats.in_payments_fulfilled);
-		json_add_u64(response, "in_msatoshi_fulfilled",
-			     channel_stats.in_msatoshi_fulfilled);
-		json_add_u64(response, "out_payments_offered",
-			     channel_stats.out_payments_offered);
-		json_add_u64(response, "out_msatoshi_offered",
-			     channel_stats.out_msatoshi_offered);
-		json_add_u64(response, "out_payments_fulfilled",
-			     channel_stats.out_payments_fulfilled);
-		json_add_u64(response, "out_msatoshi_fulfilled",
-			     channel_stats.out_msatoshi_fulfilled);
+		json_channel_add_stats(ld, response, channel->dbid);
 
 		json_add_htlcs(ld, response, channel);
 		json_object_end(response);

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -61,6 +61,26 @@ def test_single_payment(node_factory, benchmark):
     benchmark(do_pay, l1, l2)
 
 
+def test_forward_payment(node_factory, benchmark):
+    l1, l2, l3 = node_factory.line_graph(3, announce=True)
+
+    def do_pay(src, dest):
+        invoice = dest.rpc.invoice(1000, 'invoice-{}'.format(random.random()), 'desc')['bolt11']
+        src.rpc.pay(invoice)
+
+    benchmark(do_pay, l1, l3)
+
+
+def test_long_forward_payment(node_factory, benchmark):
+    nodes = node_factory.line_graph(21, announce=True)
+
+    def do_pay(src, dest):
+        invoice = dest.rpc.invoice(1000, 'invoice-{}'.format(random.random()), 'desc')['bolt11']
+        src.rpc.pay(invoice)
+
+    benchmark(do_pay, nodes[0], nodes[-1])
+
+
 def test_invoice(node_factory, benchmark):
     l1 = node_factory.get_node()
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -976,7 +976,6 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     assert only_one(l3.rpc.listinvoices('test_forward_pad_fees_and_cltv')['invoices'])['status'] == 'paid'
 
 
-@pytest.mark.xfail(strict=True)
 def test_forward_stats(node_factory):
     l1, l2, l3 = node_factory.line_graph(3, announce=True)
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -982,14 +982,8 @@ def test_forward_stats(node_factory):
     inv = l3.rpc.invoice(100000, "first", "desc")['bolt11']
     l1.rpc.pay(inv)
 
-    inchan = l2.rpc.listpeers(l1.info['id'])['peers'][0]['channels'][0]
-    outchan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
-
-    def extract_stats(c):
-        return {k: v for k, v in c.items() if 'in_' in k or 'out_' in k}
-
-    instats = extract_stats(inchan)
-    outstats = extract_stats(outchan)
+    instats = l2.rpc.listpeers(l1.info['id'])['peers'][0]['channels'][0]['stats']
+    outstats = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]['stats']
 
     # Check that we correctly account channel changes
     assert instats['in_payments_offered'] == 1

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -974,3 +974,33 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     l1.rpc.sendpay(route, rhash)
     l1.rpc.waitsendpay(rhash)
     assert only_one(l3.rpc.listinvoices('test_forward_pad_fees_and_cltv')['invoices'])['status'] == 'paid'
+
+
+@pytest.mark.xfail(strict=True)
+def test_forward_stats(node_factory):
+    l1, l2, l3 = node_factory.line_graph(3, announce=True)
+
+    inv = l3.rpc.invoice(100000, "first", "desc")['bolt11']
+    l1.rpc.pay(inv)
+
+    inchan = l2.rpc.listpeers(l1.info['id'])['peers'][0]['channels'][0]
+    outchan = l2.rpc.listpeers(l3.info['id'])['peers'][0]['channels'][0]
+
+    def extract_stats(c):
+        return {k: v for k, v in c.items() if 'in_' in k or 'out_' in k}
+
+    instats = extract_stats(inchan)
+    outstats = extract_stats(outchan)
+
+    # Check that we correctly account channel changes
+    assert instats['in_payments_offered'] == 1
+    assert instats['in_payments_fulfilled'] == 1
+    assert instats['in_msatoshi_offered'] >= 100000
+    assert instats['in_msatoshi_offered'] == instats['in_msatoshi_fulfilled']
+
+    assert outstats['out_payments_offered'] == 1
+    assert outstats['out_payments_fulfilled'] == 1
+    assert outstats['out_msatoshi_offered'] >= 100000
+    assert outstats['out_msatoshi_offered'] == outstats['out_msatoshi_fulfilled']
+
+    assert outstats['out_msatoshi_fulfilled'] < instats['in_msatoshi_fulfilled']

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -339,6 +339,8 @@ char *dbmigrations[] = {
     "ALTER TABLE channels ADD future_per_commitment_point BLOB;",
     /* last_sent_commit array fix */
     "ALTER TABLE channels ADD last_sent_commit BLOB;",
+    "ALTER TABLE channels ADD in_msatoshi_fee INTEGER NOT NULL DEFAULT 0;",
+    "ALTER TABLE channels ADD out_msatoshi_fee INTEGER NOT NULL DEFAULT 0;",
     NULL,
 };
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -798,6 +798,7 @@ void wallet_channel_stats_load(struct wallet *w,
 			       struct channel_stats *stats)
 {
 	sqlite3_stmt *stmt;
+	int res;
 	stmt = db_prepare(w->db,
 			  "SELECT  in_payments_offered,  in_payments_fulfilled"
 			  "     ,  in_msatoshi_offered,  in_msatoshi_fulfilled"
@@ -806,6 +807,12 @@ void wallet_channel_stats_load(struct wallet *w,
 			  "  FROM channels"
 			  " WHERE id = ?");
 	sqlite3_bind_int64(stmt, 1, id);
+
+	res = sqlite3_step(stmt);
+
+	/* This must succeed, since we know the channel exists */
+	assert(res == SQLITE_ROW);
+
 	stats->in_payments_offered = sqlite3_column_int64(stmt, 0);
 	stats->in_payments_fulfilled = sqlite3_column_int64(stmt, 1);
 	stats->in_msatoshi_offered = sqlite3_column_int64(stmt, 2);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -788,6 +788,16 @@ void wallet_channel_stats_incr_out_fulfilled(struct wallet *w, u64 id, u64 m)
 	wallet_channel_counter_incr(w, id, "out_msatoshi_fulfilled", m);
 }
 
+void wallet_channel_stats_incr_in_fee(struct wallet *w, u64 id, u64 m)
+{
+	wallet_channel_counter_incr(w, id, "in_msatoshi_fee", 1);
+}
+
+void wallet_channel_stats_incr_out_fee(struct wallet *w, u64 id, u64 m)
+{
+	wallet_channel_counter_incr(w, id, "out_msatoshi_fee", 1);
+}
+
 void wallet_channel_stats_load(struct wallet *w,
 			       u64 id,
 			       struct channel_stats *stats)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -809,6 +809,7 @@ void wallet_channel_stats_load(struct wallet *w,
 			  "     ,  in_msatoshi_offered,  in_msatoshi_fulfilled"
 			  "     , out_payments_offered, out_payments_fulfilled"
 			  "     , out_msatoshi_offered, out_msatoshi_fulfilled"
+			  "     , in_msatoshi_fee, out_msatoshi_fee"
 			  "  FROM channels"
 			  " WHERE id = ?");
 	sqlite3_bind_int64(stmt, 1, id);
@@ -826,6 +827,8 @@ void wallet_channel_stats_load(struct wallet *w,
 	stats->out_payments_fulfilled = sqlite3_column_int64(stmt, 5);
 	stats->out_msatoshi_offered = sqlite3_column_int64(stmt, 6);
 	stats->out_msatoshi_fulfilled = sqlite3_column_int64(stmt, 7);
+	stats->in_msatoshi_fee = sqlite3_column_int64(stmt, 8);
+	stats->out_msatoshi_fee = sqlite3_column_int64(stmt, 9);
 	db_stmt_done(stmt);
 }
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -193,9 +193,9 @@ struct outpoint {
 /* Statistics for a channel */
 struct channel_stats {
 	u64  in_payments_offered,  in_payments_fulfilled;
-	u64  in_msatoshi_offered,  in_msatoshi_fulfilled;
+	u64  in_msatoshi_offered,  in_msatoshi_fulfilled,  in_msatoshi_fee;
 	u64 out_payments_offered, out_payments_fulfilled;
-	u64 out_msatoshi_offered, out_msatoshi_fulfilled;
+	u64 out_msatoshi_offered, out_msatoshi_fulfilled, out_msatoshi_fee;
 };
 
 struct channeltx {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -388,8 +388,10 @@ bool wallet_channels_load_active(const tal_t *ctx, struct wallet *w);
  */
 void wallet_channel_stats_incr_in_offered(struct wallet *w, u64 cdbid, u64 msatoshi);
 void wallet_channel_stats_incr_in_fulfilled(struct wallet *w, u64 cdbid, u64 msatoshi);
+void wallet_channel_stats_incr_in_fee(struct wallet *w, u64 id, u64 m);
 void wallet_channel_stats_incr_out_offered(struct wallet *w, u64 cdbid, u64 msatoshi);
 void wallet_channel_stats_incr_out_fulfilled(struct wallet *w, u64 cdbid, u64 msatoshi);
+void wallet_channel_stats_incr_out_fee(struct wallet *w, u64 id, u64 m);
 
 /**
  * wallet_channel_stats_load - Load channel statistics


### PR DESCRIPTION
This adds simple tracking of fees when forwarding payments. The fee is counted both on the upstream as well as the downstream channel, so to get the total fee earned we need to sum up `in_msatoshi_fee` OR `out_satoshi_fee` not both, since that'd double the amount, but that's a minor quirk. If desired I can add the total fee earned into some other RPC call (`getinfo`?) that computes it correctly.

The first three commits are from #2017.

Fixes #1786 