### PR TITLE
docker: Update docker images and docs to non-CVE-2018-17144 bitcoind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BITCOIN_VERSION=0.16.0
+ARG BITCOIN_VERSION=0.17.0
 ENV BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Here is an example of a docker-compose file with bitcoind and c-lightning on `te
 version: "3"
 services:
   bitcoind:
-    image: nicolasdorier/docker-bitcoin:0.16.0
+    image: nicolasdorier/docker-bitcoin:0.16.3
     container_name: bitcoind
     environment:
       BITCOIN_EXTRA_ARGS: |

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.17.0
 
 WORKDIR /build
 

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -1,6 +1,6 @@
 FROM fedora:28
 
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.17.0
 WORKDIR /tmp
 
 RUN dnf update -y && \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -2,7 +2,7 @@ FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.17.0
 
 WORKDIR /build
 


### PR DESCRIPTION
While not strictly necessary it's certainly a good idea to test
against the latest one and not encourage users to use old versions.

Doesn't seem big enough of a change to note in the changelog.

Fixes #2020 