### PR TITLE
gossipd: minor fixes.

### DIFF
--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -93,13 +93,12 @@ gossip_query_channel_range_reply,,scids,num*struct short_channel_id
 gossip_dev_set_max_scids_encode_size,3030
 gossip_dev_set_max_scids_encode_size,,max,u32
 
-# Given a short_channel_id, return the endpoints
-gossip_resolve_channel_request,3009
-gossip_resolve_channel_request,,channel_id,struct short_channel_id
+# Given a short_channel_id, return the other endpoint (or none if DNE)
+gossip_get_channel_peer,3009
+gossip_get_channel_peer,,channel_id,struct short_channel_id
 
-gossip_resolve_channel_reply,3109
-gossip_resolve_channel_reply,,num_keys,u16
-gossip_resolve_channel_reply,,keys,num_keys*struct pubkey
+gossip_get_channel_peer_reply,3109
+gossip_get_channel_peer_reply,,peer_id,?struct pubkey
 
 # Channel daemon can ask for updates for a specific channel, for sending
 # errors.  Must be distinct from WIRE_CHANNEL_ANNOUNCEMENT etc. gossip msgs!

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -4,7 +4,7 @@
 
 # Initialize the gossip daemon.
 gossipctl_init,3000
-gossipctl_init,,broadcast_interval,u32
+gossipctl_init,,broadcast_interval_msec,u32
 gossipctl_init,,chain_hash,struct bitcoin_blkid
 gossipctl_init,,id,struct pubkey
 gossipctl_init,,gflen,u16

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -80,7 +80,7 @@ struct daemon {
 
 	struct timers timers;
 
-	u32 broadcast_interval;
+	u32 broadcast_interval_msec;
 
 	/* Global features to list in node_announcement. */
 	u8 *globalfeatures;
@@ -929,7 +929,7 @@ static bool maybe_queue_gossip(struct peer *peer)
 	/* Gossip is drained.  Wait for next timer. */
 	peer->gossip_timer
 		= new_reltimer(&peer->daemon->timers, peer,
-			       time_from_msec(peer->daemon->broadcast_interval),
+			       time_from_msec(peer->daemon->broadcast_interval_msec),
 			       wake_gossip_out, peer);
 	return false;
 }
@@ -1818,7 +1818,7 @@ static struct io_plan *gossip_init(struct daemon_conn *master,
 	u32 update_channel_interval;
 
 	if (!fromwire_gossipctl_init(
-		daemon, msg, &daemon->broadcast_interval, &chain_hash,
+		daemon, msg, &daemon->broadcast_interval_msec, &chain_hash,
 		&daemon->id, &daemon->globalfeatures,
 		daemon->rgb,
 		daemon->alias, &update_channel_interval,
@@ -2140,7 +2140,6 @@ int main(int argc, char *argv[])
 	daemon = tal(NULL, struct daemon);
 	list_head_init(&daemon->peers);
 	timers_init(&daemon->timers, time_mono());
-	daemon->broadcast_interval = 30000;
 	daemon->last_announce_timestamp = 0;
 
 	/* stdin == control */

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1538,6 +1538,10 @@ static struct io_plan *get_incoming_channels(struct io_conn *conn,
 			const struct half_chan *hc;
 			struct route_info *ri;
 
+			/* Don't leak private channels. */
+			if (!is_chan_public(c))
+				continue;
+
 			hc = &c->half[half_chan_to(node, c)];
 
 			if (!is_halfchan_enabled(hc))

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -161,7 +161,7 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 		err(1, "Could not subdaemon gossip");
 
 	msg = towire_gossipctl_init(
-	    tmpctx, ld->config.broadcast_interval,
+	    tmpctx, ld->config.broadcast_interval_msec,
 	    &get_chainparams(ld)->genesis_blockhash, &ld->id,
 	    get_offered_globalfeatures(tmpctx),
 	    ld->rgb,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -106,7 +106,7 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIP_GETROUTE_REQUEST:
 	case WIRE_GOSSIP_GETCHANNELS_REQUEST:
 	case WIRE_GOSSIP_PING:
-	case WIRE_GOSSIP_RESOLVE_CHANNEL_REQUEST:
+	case WIRE_GOSSIP_GET_CHANNEL_PEER:
 	case WIRE_GOSSIP_GET_UPDATE:
 	case WIRE_GOSSIP_SEND_GOSSIP:
 	case WIRE_GOSSIP_GET_TXOUT_REPLY:
@@ -126,7 +126,7 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIP_GETCHANNELS_REPLY:
 	case WIRE_GOSSIP_SCIDS_REPLY:
 	case WIRE_GOSSIP_QUERY_CHANNEL_RANGE_REPLY:
-	case WIRE_GOSSIP_RESOLVE_CHANNEL_REPLY:
+	case WIRE_GOSSIP_GET_CHANNEL_PEER_REPLY:
 	case WIRE_GOSSIP_GET_INCOMING_CHANNELS_REPLY:
 	/* These are inter-daemon messages, not received by us */
 	case WIRE_GOSSIP_LOCAL_ADD_CHANNEL:

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -46,7 +46,7 @@ struct config {
 	u32 commit_time_ms;
 
 	/* How often to broadcast gossip (msec) */
-	u32 broadcast_interval;
+	u32 broadcast_interval_msec;
 
 	/* Channel update interval */
 	u32 channel_update_interval;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -405,7 +405,7 @@ static void dev_register_opts(struct lightningd *ld)
 	opt_register_arg("--dev-debugger=<subdaemon>", opt_subd_debug, NULL,
 			 ld, "Invoke gdb at start of <subdaemon>");
 	opt_register_arg("--dev-broadcast-interval=<ms>", opt_set_uintval,
-			 opt_show_uintval, &ld->config.broadcast_interval,
+			 opt_show_uintval, &ld->config.broadcast_interval_msec,
 			 "Time between gossip broadcasts in milliseconds");
 	opt_register_arg("--dev-disconnect=<filename>", opt_subd_dev_disconnect,
 			 NULL, ld, "File containing disconnection points");
@@ -465,7 +465,7 @@ static const struct config testnet_config = {
 	 *   - SHOULD flush outgoing gossip messages once every 60
 	 *     seconds, independently of the arrival times of the messages.
 	 */
-	.broadcast_interval = 60000,
+	.broadcast_interval_msec = 60000,
 
 	/* Send a keepalive update at least every week, prune every twice that */
 	.channel_update_interval = 1209600/2,
@@ -528,7 +528,7 @@ static const struct config mainnet_config = {
 	 *   - SHOULD flush outgoing gossip messages once every 60
 	 *     seconds, independently of the arrival times of the messages.
 	 */
-	.broadcast_interval = 60000,
+	.broadcast_interval_msec = 60000,
 
 	/* Send a keepalive update at least every week, prune every twice that */
 	.channel_update_interval = 1209600/2,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -85,9 +85,9 @@ bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p
 /* Generated stub for fromwire_connect_peer_connected */
 bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct pubkey *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct crypto_state *crypto_state UNNEEDED, u8 **globalfeatures UNNEEDED, u8 **localfeatures UNNEEDED)
 { fprintf(stderr, "fromwire_connect_peer_connected called!\n"); abort(); }
-/* Generated stub for fromwire_gossip_resolve_channel_reply */
-bool fromwire_gossip_resolve_channel_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct pubkey **keys UNNEEDED)
-{ fprintf(stderr, "fromwire_gossip_resolve_channel_reply called!\n"); abort(); }
+/* Generated stub for fromwire_gossip_get_channel_peer_reply */
+bool fromwire_gossip_get_channel_peer_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct pubkey **peer_id UNNEEDED)
+{ fprintf(stderr, "fromwire_gossip_get_channel_peer_reply called!\n"); abort(); }
 /* Generated stub for fromwire_hsm_sign_commitment_tx_reply */
 bool fromwire_hsm_sign_commitment_tx_reply(const void *p UNNEEDED, secp256k1_ecdsa_signature *sig UNNEEDED)
 { fprintf(stderr, "fromwire_hsm_sign_commitment_tx_reply called!\n"); abort(); }
@@ -424,9 +424,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
-/* Generated stub for towire_gossip_resolve_channel_request */
-u8 *towire_gossip_resolve_channel_request(const tal_t *ctx UNNEEDED, const struct short_channel_id *channel_id UNNEEDED)
-{ fprintf(stderr, "towire_gossip_resolve_channel_request called!\n"); abort(); }
+/* Generated stub for towire_gossip_get_channel_peer */
+u8 *towire_gossip_get_channel_peer(const tal_t *ctx UNNEEDED, const struct short_channel_id *channel_id UNNEEDED)
+{ fprintf(stderr, "towire_gossip_get_channel_peer called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_commitment_tx */
 u8 *towire_hsm_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct pubkey *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 funding_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_commitment_tx called!\n"); abort(); }


### PR DESCRIPTION
More side-effects of writing documentation and re-reading the code:

1. Don't leak private channels in routeboost.
2. Don't accept non-local short-channel-ids when forwarding.
3. Clarify the gossip timer expiry setting.
