### PR TITLE
Update Bitcoin and Litecoin binaries to fix CVE-2018-17144

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BITCOIN_VERSION=0.16.0
+ARG BITCOIN_VERSION=0.16.3
 ENV BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc
@@ -38,10 +38,10 @@ RUN mkdir /opt/bitcoin && cd /opt/bitcoin \
     && tar -xzvf $BITCOIN_TARBALL $BD/bitcoin-cli --strip-components=1 \
     && rm $BITCOIN_TARBALL
 
-ENV LITECOIN_VERSION 0.14.2
-ENV LITECOIN_URL https://download.litecoin.org/litecoin-0.14.2/linux/litecoin-0.14.2-x86_64-linux-gnu.tar.gz
-ENV LITECOIN_SHA256 05f409ee57ce83124f2463a3277dc8d46fca18637052d1021130e4deaca07b3c
-ENV LITECOIN_ASC_URL https://download.litecoin.org/litecoin-0.14.2/linux/litecoin-0.14.2-linux-signatures.asc
+ENV LITECOIN_VERSION 0.16.3
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz
+ENV LITECOIN_SHA256 686d99d1746528648c2c54a1363d046436fd172beadaceea80bdc93043805994
+ENV LITECOIN_ASC_URL https://download.litecoin.org/litecoin-0.16.3/linux/litecoin-0.16.3-x86_64-linux-gnu.tar.gz.asc
 ENV LITECOIN_PGP_KEY FE3348877809386C
 
 # install litecoin binaries

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Here is an example of a docker-compose file with bitcoind and c-lightning on `te
 version: "3"
 services:
   bitcoind:
-    image: nicolasdorier/docker-bitcoin:0.16.0
+    image: nicolasdorier/docker-bitcoin:0.16.3
     container_name: bitcoind
     environment:
       BITCOIN_EXTRA_ARGS: |

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.16.3
 
 WORKDIR /build
 

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -1,6 +1,6 @@
 FROM fedora:28
 
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.16.3
 WORKDIR /tmp
 
 RUN dnf update -y && \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -2,7 +2,7 @@ FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_VERSION 0.16.3
 
 WORKDIR /build
 


### PR DESCRIPTION
https://bitcoincore.org/en/2018/09/20/notice/

Might be worth to don't use the versions that are vulnerable. 