### PR TITLE
bolt11: better message when you try to 'lightning-cli pay' an onchain addr

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -467,11 +467,11 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
 
         b11->routes = tal_arr(b11, struct route_info *, 0);
 
-        if (strlen(str) < 8)
-                return decode_fail(b11, fail, "Bad bech32 string");
+        if (!strstarts(str, "ln"))
+                return decode_fail(b11, fail, "Invoices must start with ln");
 
-        hrp = tal_arr(tmpctx, char, strlen(str) - 6);
-        data = tal_arr(tmpctx, u5, strlen(str) - 8);
+        hrp = tal_arr(tmpctx, char, strlen(str));
+        data = tal_arr(tmpctx, u5, strlen(str));
 
         if (!bech32_decode(hrp, data, &data_len, str, (size_t)-1))
                 return decode_fail(b11, fail, "Bad bech32 string");


### PR DESCRIPTION
Give a clear error at the beginning if it's not bolt11 payment,
rather than falling foul of other checks.

This will work at least until some altcoin adapts the 'ln' prefix :)