### PR TITLE
Fee tracking2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - JSON API: `listpeers` has new array `htlcs`: the current live payments.
 - JSON API: `listchannels` has two new fields: `message_flags` and `channel_flags`. This replaces `flags`.
 - JSON API: `invoice` now adds route hint to invoices for incoming capacity (RouteBoost), and warns if insufficient capacity.
+- JSON API: `listforwards` lists all forwarded payments, their associated channels, and fees.
+- JSON API: `getinfo` shows forwarding fees earnt as `msatoshi_fees_collected`.
 - Bitcoind: more parallelism in requests, for very slow nodes.
 - Testing: fixed logging, cleaner interception of bitcoind, minor fixes.
 - Protocol: we set and handle the new `htlc_maximum_msat` channel_update field.
-- JSON API: `invoice` now adds route hint to invoices for incoming capacity (RouteBoost), and warns if insufficient capacity.
-- JSON API: `listforwards` lists all forwarded payments, their associated channels, and fees.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bitcoind: more parallelism in requests, for very slow nodes.
 - Testing: fixed logging, cleaner interception of bitcoind, minor fixes.
 - Protocol: we set and handle the new `htlc_maximum_msat` channel_update field.
+- JSON API: `invoice` now adds route hint to invoices for incoming capacity (RouteBoost), and warns if insufficient capacity.
+- JSON API: `listforwards` lists all forwarded payments, their associated channels, and fees.
 
 ### Changed
 
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Config: config file can override `lightning-dir` (makes sense with `--conf`).
 - Config: `--conf` option is now relative to current directory, not `lightning-dir`.
 - lightning-cli: `help <cmd>` prints basic information even if no man page found.
+- JSON API: `getinfo` now reports global statistics about forwarded payments, including total fees earned and amounts routed.
 
 ### Deprecated
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -428,6 +428,15 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("listfunds")
 
+    def getroutestats(self, details=True):
+        """Get statistics about routed payments.
+
+        If @details is True, this'll include the individual forwarded
+        payments.
+
+        """
+        return self.call("getroutestats", payload={'details': details})
+
     def dev_rescan_outputs(self):
         """
         Synchronize the state of our funds with bitcoind

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -428,14 +428,10 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("listfunds")
 
-    def getroutestats(self, details=True):
-        """Get statistics about routed payments.
-
-        If @details is True, this'll include the individual forwarded
-        payments.
-
+    def listforwards(self):
+        """List all forwarded payments and their information
         """
-        return self.call("getroutestats", payload={'details': details})
+        return self.call("listforwards")
 
     def dev_rescan_outputs(self):
         """

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -138,35 +138,6 @@ static const struct json_command dev_crash_command = {
 AUTODATA(json_command, &dev_crash_command);
 #endif /* DEVELOPER */
 
-static void getinfo_add_routestats(struct json_result *response,
-				   struct wallet *wallet)
-{
-	const struct forwarding_stats *stats;
-	stats = wallet_forwarded_payments_stats(wallet, tmpctx);
-
-	json_object_start(response, "routestats");
-	json_object_start(response, "settled");
-	json_add_num(response, "fee_msatoshis", stats->fee[FORWARD_SETTLED]);
-	json_add_num(response, "count", stats->count[FORWARD_SETTLED]);
-	json_add_num(response, "msatoshi", stats->msatoshi[FORWARD_SETTLED]);
-	json_object_end(response);
-
-	json_object_start(response, "failed");
-	json_add_num(response, "fee_msatoshis", stats->fee[FORWARD_FAILED]);
-	json_add_num(response, "count", stats->count[FORWARD_FAILED]);
-	json_add_num(response, "msatoshi", stats->msatoshi[FORWARD_FAILED]);
-	json_object_end(response);
-
-	json_object_start(response, "pending");
-	json_add_num(response, "fee_msatoshis", stats->fee[FORWARD_OFFERED]);
-	json_add_num(response, "count", stats->count[FORWARD_FAILED]);
-	json_add_num(response, "msatoshi", stats->msatoshi[FORWARD_FAILED]);
-	json_object_end(response);
-	json_object_end(response);
-
-	tal_free(stats);
-}
-
 static void json_getinfo(struct command *cmd,
 			 const char *buffer UNUSED, const jsmntok_t *params UNUSED)
 {
@@ -196,7 +167,8 @@ static void json_getinfo(struct command *cmd,
 	json_add_string(response, "version", version());
 	json_add_num(response, "blockheight", get_block_height(cmd->ld->topology));
 	json_add_string(response, "network", get_chainparams(cmd->ld)->network_name);
-	getinfo_add_routestats(response, cmd->ld->wallet);
+	json_add_u64(response, "msatoshi_fees_collected",
+		     wallet_total_forward_fees(cmd->ld->wallet));
 	json_object_end(response);
 	command_success(cmd, response);
 }

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1880,6 +1880,7 @@ static void listforwardings_add_forwardings(struct json_result *response, struct
 	for (size_t i=0; i<tal_count(forwardings); i++) {
 		const struct forwarding *cur = &forwardings[i];
 		json_object_start(response, NULL);
+
 		json_add_short_channel_id(response, "in_channel", &cur->channel_in);
 		json_add_short_channel_id(response, "out_channel", &cur->channel_out);
 		json_add_num(response, "in_msatoshi", cur->msatoshi_in);

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1047,6 +1047,6 @@ def test_forward_stats(node_factory, bitcoind):
 
     assert outchan['out_msatoshi_fulfilled'] < inchan['in_msatoshi_fulfilled']
 
-    stats = l2.rpc.getroutestats()
+    stats = l2.rpc.listforwards()
 
     assert [f['status'] for f in stats['forwards']] == ['settled', 'failed', 'offered']

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1050,3 +1050,6 @@ def test_forward_stats(node_factory, bitcoind):
     stats = l2.rpc.listforwards()
 
     assert [f['status'] for f in stats['forwards']] == ['settled', 'failed', 'offered']
+    assert l2.rpc.getinfo()['msatoshi_fees_collected'] == 1 + amount // 100000
+    assert l1.rpc.getinfo()['msatoshi_fees_collected'] == 0
+    assert l3.rpc.getinfo()['msatoshi_fees_collected'] == 0

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -985,7 +985,7 @@ def test_forward_stats(node_factory, bitcoind):
     hash) and l5 will keep the HTLC dangling by disconnecting.
 
     """
-    amount = 10**4
+    amount = 10**5
     l1, l2, l3 = node_factory.line_graph(3, announce=False)
     l4 = node_factory.get_node()
     l5 = node_factory.get_node(may_fail=True)
@@ -1046,3 +1046,7 @@ def test_forward_stats(node_factory, bitcoind):
     assert outchan['out_msatoshi_offered'] == outchan['out_msatoshi_fulfilled']
 
     assert outchan['out_msatoshi_fulfilled'] < inchan['in_msatoshi_fulfilled']
+
+    stats = l2.rpc.getroutestats()
+
+    assert [f['status'] for f in stats['forwards']] == ['settled', 'failed', 'offered']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -380,8 +380,12 @@ class LightningNode(object):
         self.may_fail = may_fail
         self.may_reconnect = may_reconnect
 
-    def openchannel(self, remote_node, capacity, addrtype="p2sh-segwit", confirm=True, announce=True):
+    def openchannel(self, remote_node, capacity, addrtype="p2sh-segwit", confirm=True, announce=True, connect=True):
         addr, wallettxid = self.fundwallet(10 * capacity, addrtype)
+
+        if connect and remote_node.info['id'] not in [p['id'] for p in self.rpc.listpeers()['peers']]:
+            self.rpc.connect(remote_node.info['id'], '127.0.0.1', remote_node.daemon.port)
+
         fundingtx = self.rpc.fundchannel(remote_node.info['id'], capacity)
 
         # Wait for the funding transaction to be in bitcoind's mempool

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -339,6 +339,21 @@ char *dbmigrations[] = {
     "ALTER TABLE channels ADD future_per_commitment_point BLOB;",
     /* last_sent_commit array fix */
     "ALTER TABLE channels ADD last_sent_commit BLOB;",
+
+    /* Stats table to track forwarded HTLCs. The values in the HTLCs
+     * and their states are replicated here and the entries are not
+     * deleted when the HTLC entries or the channel entries are
+     * deleted to avoid unexpected drops in statistics. */
+    "CREATE TABLE forwarded_payments ("
+    "  in_htlc_id INTEGER REFERENCES channel_htlcs(id) ON DELETE SET NULL"
+    ", out_htlc_id INTEGER REFERENCES channel_htlcs(id) ON DELETE SET NULL"
+    ", in_channel_scid INTEGER"
+    ", out_channel_scid INTEGER"
+    ", in_msatoshi INTEGER"
+    ", out_msatoshi INTEGER"
+    ", state INTEGER"
+    ", UNIQUE(in_htlc_id, out_htlc_id)"
+    ");",
     NULL,
 };
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2427,34 +2427,31 @@ void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
 	sqlite3_bind_int64(stmt, 4, out->key.channel->scid->u64);
 	sqlite3_bind_int64(stmt, 5, in->msatoshi);
 	sqlite3_bind_int64(stmt, 6, out->msatoshi);
-	sqlite3_bind_int(stmt, 7, state);
+	sqlite3_bind_int(stmt, 7, wallet_forward_status_in_db(state));
 	db_exec_prepared(w->db, stmt);
 }
 
-const struct forwarding_stats *wallet_forwarded_payments_stats(struct wallet *w,
-							      const tal_t *ctx)
+u64 wallet_total_forward_fees(struct wallet *w)
 {
-	struct forwarding_stats *stats = talz(ctx, struct forwarding_stats);
 	sqlite3_stmt *stmt;
+	u64 total;
+	int res;
+
 	stmt = db_prepare(w->db,
 			  "SELECT"
-			  "  state"
-			  ", COUNT(*)"
-			  ", SUM(out_msatoshi) as total"
-			  ", SUM(in_msatoshi - out_msatoshi) as fee "
+			  " SUM(in_msatoshi - out_msatoshi) "
 			  "FROM forwarded_payments "
-			  "GROUP BY state;");
+			  "WHERE state = ?;");
 
-	while (sqlite3_step(stmt) == SQLITE_ROW) {
-		enum forward_status state = sqlite3_column_int(stmt, 0);
-		stats->count[state] = sqlite3_column_int64(stmt, 1);
-		stats->msatoshi[state] = sqlite3_column_int64(stmt, 2);
-		stats->fee[state] = sqlite3_column_int64(stmt, 3);
-	}
+	sqlite3_bind_int(stmt, 1, wallet_forward_status_in_db(FORWARD_SETTLED));
 
+	res = sqlite3_step(stmt);
+	assert(res == SQLITE_ROW);
+
+	total = sqlite3_column_int64(stmt, 0);
 	db_stmt_done(stmt);
 
-	return stats;
+	return total;
 }
 
 const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2481,9 +2481,16 @@ const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
 		cur->msatoshi_in = sqlite3_column_int64(stmt, 1);
 		cur->msatoshi_out = sqlite3_column_int64(stmt, 2);
 		cur->fee = cur->msatoshi_in - cur->msatoshi_out;
-		sqlite3_column_sha256_double(stmt, 3, &cur->payment_hash);
-		sqlite3_column_short_channel_id(stmt, 4, &cur->channel_in);
-		sqlite3_column_short_channel_id(stmt, 5, &cur->channel_out);
+
+		if (sqlite3_column_type(stmt, 3) != SQLITE_NULL) {
+			cur->payment_hash = tal(ctx, struct sha256_double);
+			sqlite3_column_sha256_double(stmt, 3, cur->payment_hash);
+		} else {
+			cur->payment_hash = NULL;
+		}
+
+		cur->channel_in.u64 = sqlite3_column_int64(stmt, 4);
+		cur->channel_out.u64 = sqlite3_column_int64(stmt, 5);
 	}
 
 	db_stmt_done(stmt);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -118,6 +118,34 @@ static inline enum wallet_output_type wallet_output_type_in_db(enum wallet_outpu
 	fatal("%s: %u is invalid", __func__, w);
 }
 
+/**
+ * Possible states for forwards
+ *
+ */
+/* /!\ This is a DB ENUM, please do not change the numbering of any
+ * already defined elements (adding is ok) /!\ */
+enum forward_status {
+	FORWARD_OFFERED = 0,
+	FORWARD_SETTLED = 1,
+	FORWARD_FAILED = 2
+};
+
+static inline enum forward_status wallet_forward_status_in_db(enum forward_status s)
+{
+	switch (s) {
+	case FORWARD_OFFERED:
+		BUILD_ASSERT(FORWARD_OFFERED == 0);
+		return s;
+	case FORWARD_SETTLED:
+		BUILD_ASSERT(FORWARD_SETTLED == 1);
+		return s;
+	case FORWARD_FAILED:
+		BUILD_ASSERT(FORWARD_FAILED == 2);
+		return s;
+	}
+	fatal("%s: %u is invalid", __func__, s);
+}
+
 /* A database backed shachain struct. The datastructure is
  * writethrough, reads are performed from an in-memory version, all
  * writes are passed through to the DB. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -162,7 +162,7 @@ static inline const char* forward_status_name(enum forward_status status)
 struct forwarding {
 	struct short_channel_id channel_in, channel_out;
 	u64 msatoshi_in, msatoshi_out, fee;
-	struct sha256_double payment_hash;
+	struct sha256_double *payment_hash;
 	enum forward_status status;
 };
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -166,11 +166,6 @@ struct forwarding {
 	enum forward_status status;
 };
 
-struct forwarding_stats {
-	/* One entry for each of the forward_statuses */
-	u64 count[3], msatoshi[3], fee[3];
-};
-
 /* A database backed shachain struct. The datastructure is
  * writethrough, reads are performed from an in-memory version, all
  * writes are passed through to the DB. */
@@ -1028,10 +1023,9 @@ void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
 				  enum forward_status state);
 
 /**
- * Retrieve global stats about all forwarded_payments
+ * Retrieve summary of successful forwarded payments' fees
  */
-const struct forwarding_stats *wallet_forwarded_payments_stats(struct wallet *w,
-							       const tal_t *ctx);
+u64 wallet_total_forward_fees(struct wallet *w);
 
 /**
  * Retrieve a list of all forwarded_payments

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -995,4 +995,8 @@ u32 *wallet_onchaind_channels(struct wallet *w,
 struct channeltx *wallet_channeltxs_get(struct wallet *w, const tal_t *ctx,
 					u32 channel_id);
 
+void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
+				  const struct htlc_out *out,
+				  enum forward_status state);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -146,6 +146,31 @@ static inline enum forward_status wallet_forward_status_in_db(enum forward_statu
 	fatal("%s: %u is invalid", __func__, s);
 }
 
+static inline const char* forward_status_name(enum forward_status status)
+{
+	switch(status) {
+	case FORWARD_OFFERED:
+		return "offered";
+	case FORWARD_SETTLED:
+		return "settled";
+	case FORWARD_FAILED:
+		return "failed";
+	}
+	abort();
+}
+
+struct forwarding {
+	struct short_channel_id channel_in, channel_out;
+	u64 msatoshi_in, msatoshi_out, fee;
+	struct sha256_double payment_hash;
+	enum forward_status status;
+};
+
+struct forwarding_stats {
+	/* One entry for each of the forward_statuses */
+	u64 count[3], msatoshi[3], fee[3];
+};
+
 /* A database backed shachain struct. The datastructure is
  * writethrough, reads are performed from an in-memory version, all
  * writes are passed through to the DB. */
@@ -995,8 +1020,22 @@ u32 *wallet_onchaind_channels(struct wallet *w,
 struct channeltx *wallet_channeltxs_get(struct wallet *w, const tal_t *ctx,
 					u32 channel_id);
 
+/**
+ * Add of update a forwarded_payment
+ */
 void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
 				  const struct htlc_out *out,
 				  enum forward_status state);
 
+/**
+ * Retrieve global stats about all forwarded_payments
+ */
+const struct forwarding_stats *wallet_forwarded_payments_stats(struct wallet *w,
+							       const tal_t *ctx);
+
+/**
+ * Retrieve a list of all forwarded_payments
+ */
+const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
+						       const tal_t *ctx);
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
New attempt at tracking fees. This supersedes #2018, and tries to things a bit differently: we use a separate table to track forwarded payments individually and add a new `listforwardings` JSON-RPC command that lists them, as well as spitting out some overall statistics.

Not so sure about the name `forwardings`, maybe @rustyrussell or @niftynei have a better idea? Alternatives include `forwards`, `routedpayments`, `forwardedpayments`, ... but I'd like to stick with a single word, instead of tacking `payments` at the end.

The table persists its entries even after the HTLC or the channel has been deleted, in order to avoid bumpy stats.

Closes #2018 