### PR TITLE
Fix handling of CLTVs: in three ways!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ changes.
 - Protocol: fix occasional deadlock when both peers flood with gossip.
 - Protocol: fix occasional long delay on sending `reply_short_channel_ids_end`.
 - Protocol: re-send `node_announcement` when address/alias/color etc change.
+- Protocol: multiple HTLCs with the same payment_hash are handled correctly.
 - Options: 'autotor' defaults to port 9051 if not specified.
 
 ### Security

--- a/channeld/commit_tx.h
+++ b/channeld/commit_tx.h
@@ -33,7 +33,7 @@ size_t commit_tx_num_untrimmed(const struct htlc **htlcs,
  * @self_pay_msat: amount to pay directly to self
  * @other_pay_msat: amount to pay directly to the other side
  * @htlcs: tal_arr of htlcs committed by transaction (some may be trimmed)
- * @htlc_map: outputed map of outnum->HTLC (NULL for direct outputs), or NULL.
+ * @htlc_map: outputed map of outnum->HTLC (NULL for direct outputs).
  * @obscured_commitment_number: number to encode in commitment transaction
  * @side: side to generate commitment transaction for.
  *

--- a/common/close_tx.c
+++ b/common/close_tx.c
@@ -58,6 +58,6 @@ struct bitcoin_tx *create_close_tx(const tal_t *ctx,
 		return tal_free(tx);
 	tal_resize(&tx->output, num_outputs);
 
-	permute_outputs(tx->output, num_outputs, NULL);
+	permute_outputs(tx->output, NULL, NULL);
 	return tx;
 }

--- a/common/funding_tx.c
+++ b/common/funding_tx.c
@@ -52,12 +52,12 @@ struct bitcoin_tx *funding_tx(const tal_t *ctx,
 		map[1] = int2ptr(1);
 		tx->output[1].script = scriptpubkey_p2wpkh(tx, changekey);
 		tx->output[1].amount = change_satoshis;
-		permute_outputs(tx->output, tal_count(tx->output), map);
+		permute_outputs(tx->output, NULL, map);
 		*outnum = (map[0] == int2ptr(0) ? 0 : 1);
 	} else {
 		*outnum = 0;
 	}
 
-	permute_inputs(tx->input, tal_count(tx->input), (const void **)utxomap);
+	permute_inputs(tx->input, (const void **)utxomap);
 	return tx;
 }

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -194,7 +194,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	 * 7. Sort the outputs into [BIP 69
 	 *    order](#transaction-input-and-output-ordering)
 	 */
-	permute_outputs(tx->output, tal_count(tx->output), NULL);
+	permute_outputs(tx->output, NULL, NULL);
 
 	/* BOLT #3:
 	 *

--- a/common/permute_tx.h
+++ b/common/permute_tx.h
@@ -5,15 +5,23 @@
 
 struct htlc;
 
-/* Permute the transaction into BIP69 order. */
-void permute_inputs(struct bitcoin_tx_input *inputs, size_t num_inputs,
-		    const void **map);
+/**
+ * permute_inputs: permute the transaction inputs into BIP69 order.
+ * @inputs: usually bitcoin_tx->inputs, must be tal_arr.
+ * @map: if non-NULL, pointers to be permuted the same as the inputs.
+ */
+void permute_inputs(struct bitcoin_tx_input *inputs, const void **map);
 
-/* If @map is non-NULL, it will be permuted the same as the outputs.
+/**
+ * permute_outputs: permute the transaction outputs into BIP69 + cltv order.
+ * @outputs: usually bitcoin_tx->outputs, must be tal_arr.
+ * @cltvs: CLTV delays to use as a tie-breaker, or NULL.
+ * @map: if non-NULL, pointers to be permuted the same as the outputs.
  *
  * So the caller initiates the map with which htlcs are used, it
  * can easily see which htlc (if any) is in output #0 with map[0].
  */
-void permute_outputs(struct bitcoin_tx_output *outputs, size_t num_outputs,
+void permute_outputs(struct bitcoin_tx_output *outputs,
+		     u32 *cltvs,
 		     const void **map);
 #endif /* LIGHTNING_COMMON_PERMUTE_TX_H */

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -38,9 +38,9 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 		map[1] = int2ptr(1);
 		tx->output[1].script = scriptpubkey_p2wpkh(tx, changekey);
 		tx->output[1].amount = changesat;
-		permute_outputs(tx->output, tal_count(tx->output), map);
+		permute_outputs(tx->output, NULL, map);
 	}
-	permute_inputs(tx->input, tal_count(tx->input), (const void **)utxos);
+	permute_inputs(tx->input, (const void **)utxos);
 	return tx;
 }
 

--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -152,7 +152,7 @@ struct htlc_out *htlc_out_check(const struct htlc_out *hout,
 				       " less than %"PRIu64,
 				       hout->in->msatoshi, hout->msatoshi);
 		if (hout->in->cltv_expiry <= hout->cltv_expiry)
-			return corrupt(abortstr, "Input ctlv_expiry %u"
+			return corrupt(abortstr, "Input cltv_expiry %u"
 				       " less than %u",
 				       hout->in->cltv_expiry, hout->cltv_expiry);
 		if (!sha256_eq(&hout->in->payment_hash, &hout->payment_hash))

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -343,8 +343,12 @@ static bool tell_if_missing(const struct channel *channel,
 	/* Keep valgrind happy. */
 	*tell_immediate = false;
 
-	/* Is it a current HTLC? */
-	hout = find_htlc_out_by_ripemd(channel, &stub->ripemd);
+	/* Don't care about incoming HTLCs, just ones we offered. */
+	if (stub->owner == REMOTE)
+		return false;
+
+	/* Might not be a current HTLC. */
+	hout = find_htlc_out(&channel->peer->ld->htlcs_out, channel, stub->id);
 	if (!hout)
 		return false;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -316,10 +316,10 @@ static void config_register_opts(struct lightningd *ld)
 			 "Percentage of fee to request for their commitment");
 	opt_register_arg("--cltv-delta", opt_set_u32, opt_show_u32,
 			 &ld->config.cltv_expiry_delta,
-			 "Number of blocks for ctlv_expiry_delta");
+			 "Number of blocks for cltv_expiry_delta");
 	opt_register_arg("--cltv-final", opt_set_u32, opt_show_u32,
 			 &ld->config.cltv_final,
-			 "Number of blocks for final ctlv_expiry");
+			 "Number of blocks for final cltv_expiry");
 	opt_register_arg("--commit-time=<millseconds>",
 			 opt_set_u32, opt_show_u32,
 			 &ld->config.commit_time_ms,

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -50,8 +50,6 @@ enum onion_type send_htlc_out(struct channel *out, u64 amount, u32 cltv,
 			      struct htlc_in *in,
 			      struct htlc_out **houtp);
 
-struct htlc_out *find_htlc_out_by_ripemd(const struct channel *channel,
-					 const struct ripemd160 *ripemd160);
 void onchain_failed_our_htlc(const struct channel *channel,
 			     const struct htlc_stub *htlc,
 			     const char *why);

--- a/onchaind/onchain_wire.c
+++ b/onchaind/onchain_wire.c
@@ -6,6 +6,7 @@ void towire_htlc_stub(u8 **pptr, const struct htlc_stub *htlc_stub)
 {
 	towire_side(pptr, htlc_stub->owner);
 	towire_u32(pptr, htlc_stub->cltv_expiry);
+	towire_u64(pptr, htlc_stub->id);
 	towire_ripemd160(pptr, &htlc_stub->ripemd);
 }
 
@@ -14,5 +15,6 @@ void fromwire_htlc_stub(const u8 **cursor, size_t *max,
 {
 	htlc_stub->owner = fromwire_side(cursor, max);
 	htlc_stub->cltv_expiry = fromwire_u32(cursor, max);
+	htlc_stub->id = fromwire_u64(cursor, max);
 	fromwire_ripemd160(cursor, max, &htlc_stub->ripemd);
 }

--- a/onchaind/onchain_wire.h
+++ b/onchaind/onchain_wire.h
@@ -9,6 +9,7 @@
 struct htlc_stub {
 	enum side owner;
 	u32 cltv_expiry;
+	u64 id;
 	struct ripemd160 ripemd;
 };
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -630,7 +630,6 @@ def test_onchain_dust_out(node_factory, bitcoind, executor):
     assert only_one(l2.rpc.listinvoices('onchain_dust_out')['invoices'])['status'] == 'unpaid'
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_onchain_timeout(node_factory, bitcoind, executor):
     """Onchain handling of outgoing failed htlcs"""
@@ -1094,7 +1093,6 @@ def setup_multihtlc_test(node_factory, bitcoind):
     return h, nodes
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_ignore_htlcs")
 def test_onchain_multihtlc_our_unilateral(node_factory, bitcoind):
     """Node pushes a channel onchain with multiple HTLCs with same payment_hash """
@@ -1182,7 +1180,6 @@ def test_onchain_multihtlc_our_unilateral(node_factory, bitcoind):
             assert only_one(nodes[i].rpc.listpeers(nodes[i + 1].info['id'])['peers'])['connected']
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_ignore_htlcs")
 def test_onchain_multihtlc_their_unilateral(node_factory, bitcoind):
     """Node pushes a channel onchain with multiple HTLCs with same payment_hash """

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1025,6 +1025,259 @@ def test_permfail_new_commit(node_factory, bitcoind, executor):
     wait_for(lambda: l2.rpc.listpeers()['peers'] == [])
 
 
+def setup_multihtlc_test(node_factory, bitcoind):
+    # l1 -> l2 -> l3 -> l4 -> l5 -> l6 -> l7
+    # l1 and l7 ignore and HTLCs they're sent.
+    # For each direction, we create these HTLCs with same payment_hash:
+    #   1 failed (CLTV1)
+    #   1 failed (CLTV2)
+    #   2 live (CLTV2)
+    #   1 live (CLTV3)
+    nodes = node_factory.line_graph(7, announce=True,
+                                    opts={'dev-no-reconnect': None,
+                                          'may_reconnect': True})
+
+    # Balance by pushing half the funds.
+    b11 = nodes[-1].rpc.invoice(10**9 // 2, '1', 'balancer')['bolt11']
+    nodes[0].rpc.pay(b11)
+
+    nodes[0].rpc.dev_ignore_htlcs(id=nodes[1].info['id'], ignore=True)
+    nodes[-1].rpc.dev_ignore_htlcs(id=nodes[-2].info['id'], ignore=True)
+
+    preimage = "0" * 64
+    h = nodes[0].rpc.invoice(msatoshi=10**8, label='x', description='desc',
+                             preimage=preimage)['payment_hash']
+    nodes[-1].rpc.invoice(msatoshi=10**8, label='x', description='desc',
+                          preimage=preimage)['payment_hash']
+
+    # First, the failed attempts (paying wrong node).  CLTV1
+    r = nodes[0].rpc.getroute(nodes[-2].info['id'], 10**8, 1)["route"]
+    nodes[0].rpc.sendpay(r, h)
+    with pytest.raises(RpcError, match=r'UNKNOWN_PAYMENT_HASH'):
+        nodes[0].rpc.waitsendpay(h)
+
+    r = nodes[-1].rpc.getroute(nodes[1].info['id'], 10**8, 1)["route"]
+    nodes[-1].rpc.sendpay(r, h)
+    with pytest.raises(RpcError, match=r'UNKNOWN_PAYMENT_HASH'):
+        nodes[-1].rpc.waitsendpay(h)
+
+    # Now increment CLTV -> CLTV2
+    bitcoind.generate_block(1)
+    sync_blockheight(bitcoind, nodes)
+
+    # Now, the live attempts with CLTV2 (blackholed by end nodes)
+    r = nodes[0].rpc.getroute(nodes[-1].info['id'], 10**8, 1)["route"]
+    nodes[0].rpc.sendpay(r, h)
+    r = nodes[-1].rpc.getroute(nodes[0].info['id'], 10**8, 1)["route"]
+    nodes[-1].rpc.sendpay(r, h)
+
+    # We send second HTLC from different node, since they refuse to send
+    # multiple with same hash.
+    r = nodes[1].rpc.getroute(nodes[-1].info['id'], 10**8, 1)["route"]
+    nodes[1].rpc.sendpay(r, h)
+    r = nodes[-2].rpc.getroute(nodes[0].info['id'], 10**8, 1)["route"]
+    nodes[-2].rpc.sendpay(r, h)
+
+    # Now increment CLTV -> CLTV3.
+    bitcoind.generate_block(1)
+    sync_blockheight(bitcoind, nodes)
+
+    r = nodes[2].rpc.getroute(nodes[-1].info['id'], 10**8, 1)["route"]
+    nodes[2].rpc.sendpay(r, h)
+    r = nodes[-3].rpc.getroute(nodes[0].info['id'], 10**8, 1)["route"]
+    nodes[-3].rpc.sendpay(r, h)
+
+    # Make sure HTLCs have reached the end.
+    nodes[0].daemon.wait_for_logs(['peer_in WIRE_UPDATE_ADD_HTLC'] * 3)
+    nodes[-1].daemon.wait_for_logs(['peer_in WIRE_UPDATE_ADD_HTLC'] * 3)
+
+    return h, nodes
+
+
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_ignore_htlcs")
+def test_onchain_multihtlc_our_unilateral(node_factory, bitcoind):
+    """Node pushes a channel onchain with multiple HTLCs with same payment_hash """
+    h, nodes = setup_multihtlc_test(node_factory, bitcoind)
+
+    mid = len(nodes) // 2
+
+    for i in range(len(nodes) - 1):
+        assert only_one(nodes[i].rpc.listpeers(nodes[i + 1].info['id'])['peers'])['connected']
+
+    # Now midnode goes onchain with n+1 channel.
+    nodes[mid].rpc.dev_fail(nodes[mid + 1].info['id'])
+    nodes[mid].wait_for_channel_onchain(nodes[mid + 1].info['id'])
+
+    bitcoind.generate_block(1)
+    nodes[mid].daemon.wait_for_log(' to ONCHAIN')
+    nodes[mid + 1].daemon.wait_for_log(' to ONCHAIN')
+
+    # Now, restart and manually reconnect end nodes (so they don't ignore HTLCs)
+    # In fact, they'll fail them with WIRE_TEMPORARY_NODE_FAILURE.
+    nodes[0].restart()
+    nodes[-1].restart()
+
+    # We disabled auto-reconnect so we'd detect breakage, so manually reconnect.
+    nodes[0].rpc.connect(nodes[1].info['id'], 'localhost', nodes[1].port)
+    nodes[-1].rpc.connect(nodes[-2].info['id'], 'localhost', nodes[-2].port)
+
+    # Wait for HTLCs to stabilize.
+    nodes[0].daemon.wait_for_logs(['peer_out WIRE_UPDATE_FAIL_HTLC'] * 3)
+    nodes[0].daemon.wait_for_log('peer_out WIRE_COMMITMENT_SIGNED')
+    nodes[0].daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
+    nodes[-1].daemon.wait_for_logs(['peer_out WIRE_UPDATE_FAIL_HTLC'] * 3)
+    nodes[-1].daemon.wait_for_log('peer_out WIRE_COMMITMENT_SIGNED')
+    nodes[-1].daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
+
+    # After at depth 5, midnode will spend its own to-self output.
+    bitcoind.generate_block(4)
+    nodes[mid].wait_for_onchaind_broadcast('OUR_DELAYED_RETURN_TO_WALLET',
+                                           'OUR_UNILATERAL/DELAYED_OUTPUT_TO_US')
+
+    # The three outgoing HTLCs time out at 21, 21 and 22 blocks.
+    bitcoind.generate_block(16)
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TX',
+                                           'OUR_UNILATERAL/OUR_HTLC')
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TX',
+                                           'OUR_UNILATERAL/OUR_HTLC')
+    bitcoind.generate_block(1)
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TX',
+                                           'OUR_UNILATERAL/OUR_HTLC')
+
+    # And three more for us to consider them all settled.
+    bitcoind.generate_block(3)
+
+    # Now, those nodes should have correctly failed the HTLCs
+    for n in nodes[:mid - 1]:
+        with pytest.raises(RpcError, match=r'WIRE_PERMANENT_CHANNEL_FAILURE'):
+            n.rpc.waitsendpay(h, TIMEOUT)
+
+    # Other timeouts are 27,27,28 blocks.
+    bitcoind.generate_block(2)
+    nodes[mid].daemon.wait_for_logs(['Ignoring output.*: OUR_UNILATERAL/THEIR_HTLC'] * 2)
+    for _ in range(2):
+        nodes[mid + 1].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
+                                                   'THEIR_UNILATERAL/OUR_HTLC')
+    bitcoind.generate_block(1)
+    nodes[mid].daemon.wait_for_log('Ignoring output.*: OUR_UNILATERAL/THEIR_HTLC')
+    nodes[mid + 1].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
+                                               'THEIR_UNILATERAL/OUR_HTLC')
+
+    # Depth 3 to consider it settled.
+    bitcoind.generate_block(3)
+
+    for n in nodes[mid + 1:]:
+        with pytest.raises(RpcError, match=r'WIRE_PERMANENT_CHANNEL_FAILURE'):
+            n.rpc.waitsendpay(h, TIMEOUT)
+
+    # At depth 100 it's all done (we didn't bother waiting for mid+1's
+    # spends, so that might still be going)
+    bitcoind.generate_block(96)
+    nodes[mid].daemon.wait_for_logs(['onchaind complete, forgetting peer'])
+
+    # No other channels should have failed.
+    for i in range(len(nodes) - 1):
+        if i != mid:
+            assert only_one(nodes[i].rpc.listpeers(nodes[i + 1].info['id'])['peers'])['connected']
+
+
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_ignore_htlcs")
+def test_onchain_multihtlc_their_unilateral(node_factory, bitcoind):
+    """Node pushes a channel onchain with multiple HTLCs with same payment_hash """
+    h, nodes = setup_multihtlc_test(node_factory, bitcoind)
+
+    mid = len(nodes) // 2
+
+    for i in range(len(nodes) - 1):
+        assert only_one(nodes[i].rpc.listpeers(nodes[i + 1].info['id'])['peers'])['connected']
+
+    # Now midnode+1 goes onchain with midnode channel.
+    nodes[mid + 1].rpc.dev_fail(nodes[mid].info['id'])
+    nodes[mid + 1].wait_for_channel_onchain(nodes[mid].info['id'])
+
+    bitcoind.generate_block(1)
+    nodes[mid].daemon.wait_for_log(' to ONCHAIN')
+    nodes[mid + 1].daemon.wait_for_log(' to ONCHAIN')
+
+    # Now, restart and manually reconnect end nodes (so they don't ignore HTLCs)
+    # In fact, they'll fail them with WIRE_TEMPORARY_NODE_FAILURE.
+    nodes[0].restart()
+    nodes[-1].restart()
+
+    # We disabled auto-reconnect so we'd detect breakage, so manually reconnect.
+    nodes[0].rpc.connect(nodes[1].info['id'], 'localhost', nodes[1].port)
+    nodes[-1].rpc.connect(nodes[-2].info['id'], 'localhost', nodes[-2].port)
+
+    # Wait for HTLCs to stabilize.
+    nodes[0].daemon.wait_for_logs(['peer_out WIRE_UPDATE_FAIL_HTLC'] * 3)
+    nodes[0].daemon.wait_for_log('peer_out WIRE_COMMITMENT_SIGNED')
+    nodes[0].daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
+    nodes[-1].daemon.wait_for_logs(['peer_out WIRE_UPDATE_FAIL_HTLC'] * 3)
+    nodes[-1].daemon.wait_for_log('peer_out WIRE_COMMITMENT_SIGNED')
+    nodes[-1].daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
+
+    # At depth 5, midnode+1 will spend its own to-self output.
+    bitcoind.generate_block(4)
+    nodes[mid + 1].wait_for_onchaind_broadcast('OUR_DELAYED_RETURN_TO_WALLET')
+
+    # The three outgoing HTLCs time out at depth 21, 21 and 22 blocks.
+    bitcoind.generate_block(16)
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
+                                           'THEIR_UNILATERAL/OUR_HTLC')
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
+                                           'THEIR_UNILATERAL/OUR_HTLC')
+    bitcoind.generate_block(1)
+    nodes[mid].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
+                                           'THEIR_UNILATERAL/OUR_HTLC')
+
+    # At depth 3 we consider them all settled.
+    bitcoind.generate_block(3)
+
+    # Now, those nodes should have correctly failed the HTLCs
+    for n in nodes[:mid - 1]:
+        with pytest.raises(RpcError, match=r'WIRE_PERMANENT_CHANNEL_FAILURE'):
+            n.rpc.waitsendpay(h, TIMEOUT)
+
+    # Other timeouts are at depths 27,27,28 blocks.
+    bitcoind.generate_block(2)
+    nodes[mid].daemon.wait_for_logs(['Ignoring output.*: THEIR_UNILATERAL/THEIR_HTLC'] * 2)
+    for _ in range(2):
+        nodes[mid + 1].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TX',
+                                                   'OUR_UNILATERAL/OUR_HTLC')
+    bitcoind.generate_block(1)
+    nodes[mid].daemon.wait_for_log('Ignoring output.*: THEIR_UNILATERAL/THEIR_HTLC')
+    nodes[mid + 1].wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TX',
+                                               'OUR_UNILATERAL/OUR_HTLC')
+
+    # At depth 3 we consider them all settled.
+    bitcoind.generate_block(3)
+
+    for n in nodes[mid + 1:]:
+        with pytest.raises(RpcError, match=r'WIRE_PERMANENT_CHANNEL_FAILURE'):
+            n.rpc.waitsendpay(h, TIMEOUT)
+
+    # At depth 5, mid+1 can spend HTLC_TIMEOUT_TX output.
+    bitcoind.generate_block(1)
+    for _ in range(2):
+        nodes[mid + 1].wait_for_onchaind_broadcast('OUR_DELAYED_RETURN_TO_WALLET',
+                                                   'OUR_HTLC_TIMEOUT_TX/DELAYED_OUTPUT_TO_US')
+    bitcoind.generate_block(1)
+    nodes[mid + 1].wait_for_onchaind_broadcast('OUR_DELAYED_RETURN_TO_WALLET',
+                                               'OUR_HTLC_TIMEOUT_TX/DELAYED_OUTPUT_TO_US')
+
+    # At depth 100 they're all done.
+    bitcoind.generate_block(100)
+    nodes[mid].daemon.wait_for_logs(['onchaind complete, forgetting peer'])
+    nodes[mid + 1].daemon.wait_for_logs(['onchaind complete, forgetting peer'])
+
+    # No other channels should have failed.
+    for i in range(len(nodes) - 1):
+        if i != mid:
+            assert only_one(nodes[i].rpc.listpeers(nodes[i + 1].info['id'])['peers'])['connected']
+
+
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_permfail_htlc_in(node_factory, bitcoind, executor):
     # Test case where we fail with unsettled incoming HTLC.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -291,7 +291,7 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
     # l1 will disconnect and not reconnect.
     l1.daemon.wait_for_log('dev_disconnect: -WIRE_REVOKE_AND_ACK')
 
-    # Deadline HTLC expiry minus 1/2 cltv-expiry delta (rounded up) (== cltv - 3).  ctlv is 5+1.
+    # Deadline HTLC expiry minus 1/2 cltv-expiry delta (rounded up) (== cltv - 3).  cltv is 5+1.
     bitcoind.generate_block(2)
     assert not l2.daemon.is_in_log('hit deadline')
     bitcoind.generate_block(1)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1049,7 +1049,6 @@ def test_forward_stats(node_factory, bitcoind):
     assert l3.rpc.getinfo()['msatoshi_fees_collected'] == 0
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for dev_ignore_htlcs")
 def test_htlcs_cltv_only_difference(node_factory, bitcoind):
     # l1 -> l2 -> l3 -> l4

--- a/tools/check-spelling.sh
+++ b/tools/check-spelling.sh
@@ -5,3 +5,8 @@ if git --no-pager grep -nHiE 'l[ightn]{6}g|l[ightn]{8}g|ilghtning|lgihtning|lihg
     echo "Is this warning incorrect? Please teach tools/check-spelling.sh about the exciting new word."
     exit 1
 fi
+
+if git --no-pager grep -nHiE 'ctlv' -- . ':!tools/check-spelling.sh'; then
+    echo "It's check lock time verify, not check time lock verify!" >&2
+    exit 1
+fi

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1551,7 +1551,7 @@ struct htlc_stub *wallet_htlc_stubs(const tal_t *ctx, struct wallet *wallet,
 	struct htlc_stub *stubs;
 	struct sha256 payment_hash;
 	sqlite3_stmt *stmt = db_prepare(wallet->db,
-		"SELECT channel_id, direction, cltv_expiry, payment_hash "
+		"SELECT channel_id, direction, cltv_expiry, channel_htlc_id, payment_hash "
 		"FROM channel_htlcs WHERE channel_id = ?;");
 
 	sqlite3_bind_int64(stmt, 1, chan->dbid);
@@ -1566,8 +1566,9 @@ struct htlc_stub *wallet_htlc_stubs(const tal_t *ctx, struct wallet *wallet,
 		/* FIXME: merge these two enums */
 		stub->owner = sqlite3_column_int(stmt, 1)==DIRECTION_INCOMING?REMOTE:LOCAL;
 		stub->cltv_expiry = sqlite3_column_int(stmt, 2);
+		stub->id = sqlite3_column_int(stmt, 3);
 
-		sqlite3_column_sha256(stmt, 3, &payment_hash);
+		sqlite3_column_sha256(stmt, 4, &payment_hash);
 		ripemd160(&stub->ripemd, payment_hash.u.u8, sizeof(payment_hash.u));
 	}
 	db_stmt_done(stmt);


### PR DESCRIPTION
First, make sure we spell it correctly!  Then, fix channeld's HTLC signature confusion (thanks to https://github.com/lightningnetwork/lightning-rfc/pull/491). Then, fix onchaind's HTLC confusion.

This is all due to a great bug report by molz on #c-lightning on Freenode.