### PR TITLE
pytest: make sure we wait for node announcements in line_graph too.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -833,6 +833,11 @@ class NodeFactory(object):
         wait_for(lambda: both_dirs_ready(nodes[0], scids[-1]))
         wait_for(lambda: both_dirs_ready(nodes[-1], scids[0]))
 
+        # Make sure we have all node announcements, too (just check ends)
+        for n in nodes:
+            for end in (nodes[0], nodes[-1]):
+                wait_for(lambda: 'alias' in only_one(end.rpc.listnodes(n.info['id'])['nodes']))
+
         return nodes
 
     def killall(self, expected_successes):


### PR DESCRIPTION
Occasional failure in test_fulfill_incoming_first where the channel
closed before the final message from dev_disonnect was read.  Cause
was the peer writing a gossip msg and failing due to ECONNRESET, before
it read the final message.

(Managed to reproduce under strace -f, FTW).

This is really a symptom of the fact that line_graph's announce=True
didn't wait for node announcements.  Let's do that.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>