### PR TITLE
closingd: retransmit `shutdown` on reconnect.

### DIFF
--- a/closingd/closing_wire.csv
+++ b/closingd/closing_wire.csv
@@ -25,6 +25,8 @@ closing_init,,next_index_remote,u64
 closing_init,,revocations_received,u64
 closing_init,,channel_reestablish_len,u16
 closing_init,,channel_reestablish,channel_reestablish_len*u8
+closing_init,,final_scriptpubkey_len,u16
+closing_init,,final_scriptpubkey,final_scriptpubkey_len*u8
 
 # We received an offer, save signature.
 closing_received_signature,2002

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -236,7 +236,9 @@ void peer_start_closingd(struct channel *channel,
 				      channel->next_index[LOCAL],
 				      channel->next_index[REMOTE],
 				      num_revocations,
-				      channel_reestablish);
+				      channel_reestablish,
+				      p2wpkh_for_keyidx(tmpctx, ld,
+							channel->final_key_idx));
 
 	/* We don't expect a response: it will give us feedback on
 	 * signatures sent and received, then closing_complete. */


### PR DESCRIPTION
The spec says so, and it's right: with the right pattern of packet loss
(thanks Travis!) the other end can still be in channeld, waiting for our
`shutdown` message.
