### PR TITLE
(Trivial) Wally updates

### DIFF
--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -338,6 +338,7 @@ int main(void)
 	size_t i;
 	const struct chainparams *chainparams = chainparams_for_network("bitcoin");
 
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 

--- a/common/daemon.c
+++ b/common/daemon.c
@@ -128,6 +128,7 @@ void daemon_setup(const char *argv0,
 
 	/* We handle write returning errors! */
 	signal(SIGPIPE, SIG_IGN);
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 
 	setup_tmpctx();

--- a/common/key_derive.c
+++ b/common/key_derive.c
@@ -248,13 +248,13 @@ bool derive_revocation_privkey(const struct secret *base_secret,
 bool bip32_pubkey(const struct ext_key *bip32_base,
 		  struct pubkey *pubkey, u32 index)
 {
+	const uint32_t flags = BIP32_FLAG_KEY_PUBLIC | BIP32_FLAG_SKIP_HASH;
 	struct ext_key ext;
 
 	if (index >= BIP32_INITIAL_HARDENED_CHILD)
 		return false;
 
-	if (bip32_key_from_parent(bip32_base, index,
-				  BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK)
+	if (bip32_key_from_parent(bip32_base, index, flags, &ext) != WALLY_OK)
 		return false;
 
 	if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey->pubkey,

--- a/common/test/run-bolt11.c
+++ b/common/test/run-bolt11.c
@@ -123,6 +123,7 @@ int main(void)
 	u64 msatoshi;
 	const char *badstr;
 
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 

--- a/common/test/run-derive_basepoints.c
+++ b/common/test/run-derive_basepoints.c
@@ -54,6 +54,7 @@ int main(void)
 	const tal_t *ctx = tal(NULL, char);
 	struct info *baseline, *info;
 
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	baseline = new_info(ctx);
 	assert(derive_basepoints(&baseline->seed, &baseline->funding_pubkey,

--- a/common/test/run-features.c
+++ b/common/test/run-features.c
@@ -14,6 +14,7 @@ int main(void)
 	u8 *bits, *lf, *gf;
 
 	setup_locale();
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1073,6 +1073,7 @@ int main(void)
 	struct lightningd *ld;
 
 	setup_tmpctx();
+	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	ld = tal(tmpctx, struct lightningd);
 


### PR DESCRIPTION
You may want to do something else with wally_init, but skipping the wasted hash seems like a no-brainer.