### PR TITLE
Help special needs gcc versions

### DIFF
--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1293,7 +1293,7 @@ static size_t resolve_our_htlc_ourcommit(struct tracked_output *out,
 					 const struct htlc_stub *htlcs,
 					 u8 **htlc_scripts)
 {
-	struct bitcoin_tx *tx;
+	struct bitcoin_tx *tx = NULL;
 	secp256k1_ecdsa_signature localsig;
 	size_t i;
 


### PR DESCRIPTION
This fixes a compilation error on gcc 7.3.0