### PR TITLE
The endless plugin saga (Part 1)

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2451-gfedf5151
+CCAN version: init-2454-gc656dceb

--- a/ccan/ccan/opt/opt.c
+++ b/ccan/ccan/opt/opt.c
@@ -207,14 +207,15 @@ bool opt_parse(int *argc, char *argv[], void (*errlog)(const char *fmt, ...))
 	/* This helps opt_usage. */
 	opt_argv0 = argv[0];
 
-	while ((ret = parse_one(argc, argv, 0, &offset, errlog)) == 1);
+	while ((ret = parse_one(argc, argv, 0, &offset, errlog, false)) == 1);
 
 	/* parse_one returns 0 on finish, -1 on error */
 	return (ret == 0);
 }
 
-bool opt_early_parse(int argc, char *argv[],
-		     void (*errlog)(const char *fmt, ...))
+static bool early_parse(int argc, char *argv[],
+			void (*errlog)(const char *fmt, ...),
+			bool ignore_unknown)
 {
 	int ret;
 	unsigned off = 0;
@@ -226,12 +227,24 @@ bool opt_early_parse(int argc, char *argv[],
 	/* This helps opt_usage. */
 	opt_argv0 = argv[0];
 
-	while ((ret = parse_one(&argc, tmpargv, OPT_EARLY, &off, errlog)) == 1);
+	while ((ret = parse_one(&argc, tmpargv, OPT_EARLY, &off, errlog, ignore_unknown)) == 1);
 
 	opt_alloc.free(tmpargv);
 
 	/* parse_one returns 0 on finish, -1 on error */
 	return (ret == 0);
+}
+
+bool opt_early_parse(int argc, char *argv[],
+		     void (*errlog)(const char *fmt, ...))
+{
+	return early_parse(argc, argv, errlog, false);
+}
+
+bool opt_early_parse_incomplete(int argc, char *argv[],
+				void (*errlog)(const char *fmt, ...))
+{
+	return early_parse(argc, argv, errlog, true);
 }
 
 void opt_free_table(void)

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -287,6 +287,30 @@ bool opt_early_parse(int argc, char *argv[],
 		     void (*errlog)(const char *fmt, ...));
 
 /**
+ * opt_early_parse_incomplete - parse early arguments, ignoring unknown ones.
+ * @argc: argc
+ * @argv: argv array.
+ * @errlog: the function to print errors
+ *
+ * If you have plugins, you might need to do early parsing (eg. to find the
+ * plugin directory) but you don't know what options the plugins will want.
+ *
+ * Thus, this function is just like opt_early_parse, but ignores unknown options.
+ *
+ * Example:
+ *	if (!opt_early_parse_incomplete(argc, argv, opt_log_stderr)) {
+ *		printf("You screwed up, aborting!\n");
+ *		exit(1);
+ *	}
+ *
+ * See Also:
+ *	opt_early_parse()
+ */
+bool opt_early_parse_incomplete(int argc, char *argv[],
+				void (*errlog)(const char *fmt, ...));
+
+
+/**
  * opt_free_table - reset the opt library.
  *
  * This frees the internal memory and returns counters to zero.  Call

--- a/ccan/ccan/opt/private.h
+++ b/ccan/ccan/opt/private.h
@@ -22,6 +22,6 @@ struct opt_alloc {
 extern struct opt_alloc opt_alloc;
 
 int parse_one(int *argc, char *argv[], enum opt_type is_early, unsigned *offset,
-	      void (*errlog)(const char *fmt, ...));
+	      void (*errlog)(const char *fmt, ...), bool unknown_ok);
 
 #endif /* CCAN_OPT_PRIVATE_H */

--- a/ccan/ccan/opt/test/run-early_incomplete.c
+++ b/ccan/ccan/opt/test/run-early_incomplete.c
@@ -1,0 +1,37 @@
+/* With errlog == NULL, we never get a "failure". */
+#include <ccan/tap/tap.h>
+#include <stdlib.h>
+#include <ccan/opt/opt.c>
+#include <ccan/opt/usage.c>
+#include <ccan/opt/helpers.c>
+#include <ccan/opt/parse.c>
+#include "utils.h"
+
+int main(int argc, char *argv[])
+{
+	plan_tests(8);
+
+	/* Simple short args.*/
+	opt_register_noarg("-a", test_noarg, NULL, "All");
+	opt_register_early_noarg("-b|--blong", test_noarg, NULL, "All");
+
+	/* This is OK. */
+	ok1(parse_early_args_incomplete(&argc, &argv, "-c", NULL));
+	ok1(test_cb_called == 0);
+
+	/* Skips letters correctly */
+	ok1(parse_early_args_incomplete(&argc, &argv, "-ca", NULL));
+	ok1(test_cb_called == 0); /* a is not an early arg! */
+
+	test_cb_called = 0;
+	ok1(parse_early_args_incomplete(&argc, &argv, "-bca", NULL));
+	ok1(test_cb_called == 1);
+
+	test_cb_called = 0;
+	ok1(parse_early_args_incomplete(&argc, &argv, "--unknown", "--also-unknown", "--blong", NULL));
+	ok1(test_cb_called == 1);
+
+	/* parse_args allocates argv */
+	free(argv);
+	return exit_status();
+}

--- a/ccan/ccan/opt/test/utils.c
+++ b/ccan/ccan/opt/test/utils.c
@@ -103,6 +103,29 @@ bool parse_early_args(int *argc, char ***argv, ...)
 	return opt_early_parse(*argc, *argv, save_err_output);
 }
 
+bool parse_early_args_incomplete(int *argc, char ***argv, ...)
+{
+	char **a;
+	va_list ap;
+
+	va_start(ap, argv);
+	*argc = 1;
+	a = malloc(sizeof(*a) * (*argc + 1));
+	a[0] = (*argv)[0];
+	while ((a[*argc] = va_arg(ap, char *)) != NULL) {
+		(*argc)++;
+		a = realloc(a, sizeof(*a) * (*argc + 1));
+	}
+
+	if (allocated)
+		free(*argv);
+
+	*argv = a;
+	allocated = true;
+
+	return opt_early_parse_incomplete(*argc, *argv, save_err_output);
+}
+
 struct opt_table short_table[] = {
 	/* Short opts, different args. */
 	OPT_WITHOUT_ARG("-a", test_noarg, "a", "Description of a"),

--- a/ccan/ccan/opt/test/utils.h
+++ b/ccan/ccan/opt/test/utils.h
@@ -5,6 +5,7 @@
 
 bool parse_args(int *argc, char ***argv, ...);
 bool parse_early_args(int *argc, char ***argv, ...);
+bool parse_early_args_incomplete(int *argc, char ***argv, ...);
 extern char *err_output;
 void save_err_output(const char *fmt, ...);
 void reset_options(void);

--- a/contrib/helloworld-plugin/main.py
+++ b/contrib/helloworld-plugin/main.py
@@ -46,7 +46,6 @@ methods = {
     'ping': json_ping,
 }
 
-
 partial = ""
 for l in sys.stdin:
     partial += l

--- a/contrib/helloworld-plugin/main.py
+++ b/contrib/helloworld-plugin/main.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Simple plugin to show how to build new plugins for c-lightning
+
+It demonstrates how a plugin communicates with c-lightning, how it registers
+command line arguments that should be passed through and how it can register
+JSON-RPC commands. We communicate with the main daemon through STDIN and STDOUT,
+reading and writing JSON-RPC requests.
+
+"""
+import json
+import sys
+
+
+def json_hello(request):
+    greeting = "Hello {}".format(request['params']['name'])
+    return greeting
+
+
+def json_init(request):
+    return {
+        "options": [
+            {"name": "greeting", "type": "string", "default": "World"},
+        ],
+        "rpcmethods": [
+            {
+                "name": "hello",
+                "description": "Returns a personalized greeting for {name}",
+            },
+        ]
+    }
+
+
+def json_configure(request):
+    """The main daemon is telling us the relevant cli options
+    """
+    return None
+
+
+def json_ping(request):
+    return "pong"
+
+
+methods = {
+    'hello': json_hello,
+    'init': json_init,
+    'ping': json_ping,
+}
+
+
+partial = ""
+for l in sys.stdin:
+    partial += l
+    try:
+        request = json.loads(partial)
+        result = {
+            "jsonrpc": "2.0",
+            "result": methods[request['method']](request),
+            "id": request['id']
+        }
+        json.dump(result, fp=sys.stdout)
+        sys.stdout.write('\n')
+        sys.stdout.flush()
+        partial = ""
+    except Exception:
+        pass

--- a/contrib/helloworld-plugin/main.py
+++ b/contrib/helloworld-plugin/main.py
@@ -11,17 +11,21 @@ import json
 import sys
 
 
+greeting = "World"
+
+
 def json_hello(request):
     greeting = "Hello {}".format(request['params']['name'])
     return greeting
 
 
 def json_init(request):
+    global greeting
     return {
         "options": [
             {"name": "greeting",
              "type": "string",
-             "default": "World",
+             "default": greeting,
              "description": "What name should I call you?"},
         ],
         "rpcmethods": [
@@ -36,7 +40,10 @@ def json_init(request):
 def json_configure(request):
     """The main daemon is telling us the relevant cli options
     """
-    return None
+    global greeting
+
+    greeting = request['params']['options']['greeting']
+    return "ok"
 
 
 def json_ping(request):
@@ -47,6 +54,7 @@ methods = {
     'hello': json_hello,
     'init': json_init,
     'ping': json_ping,
+    'configure': json_configure,
 }
 
 partial = ""

--- a/contrib/helloworld-plugin/main.py
+++ b/contrib/helloworld-plugin/main.py
@@ -19,7 +19,10 @@ def json_hello(request):
 def json_init(request):
     return {
         "options": [
-            {"name": "greeting", "type": "string", "default": "World"},
+            {"name": "greeting",
+             "type": "string",
+             "default": "World",
+             "description": "What name should I call you?"},
         ],
         "rpcmethods": [
             {

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -176,6 +176,11 @@ Sets configuration file (default:
 \fIPATH\fR
 must exist and be readable (we allow missing files in the default case)\&. Using this inside a configuration file is meaningless\&.
 .RE
+.PP
+\fBplugin\fR=\fIPATH\fR
+.RS 4
+Specify a plugin to run as part of c\-lightning\&. This can be specified multiple times and may enable additional configuration options and JSON\-RPC methods, depending on the plugin\&.
+.RE
 .sp
 Lightning node customization options:
 .PP

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -124,6 +124,11 @@ Lightning daemon options:
     (we allow missing files in the default case).
     Using this inside a configuration file is meaningless.
 
+*plugin*='PATH'::
+    Specify a plugin to run as part of c-lightning. This can be specified
+    multiple times and may enable additional configuration options and JSON-RPC
+    methods, depending on the plugin.
+
 Lightning node customization options:
 
 *rgb*='RRGGBB'::

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,113 @@
+# Plugins
+
+Plugins are a simple yet powerful way to extend the functionality
+provided by c-lightning. They are subprocesses that are started by the
+main `lightningd` daemon and can interact with `lightningd` in a
+variety of ways:
+
+ - **Command line option passthrough** allows plugins to register their
+   own command line options that are exposed through `lightningd` so
+   that only the main process needs to be configured.
+ - **JSON-RPC command passthrough** adds a way for plugins to add their
+   own commands to the JSON-RPC interface.
+ - **Event stream subscriptions** provide plugins with a push-based
+   notification mechanism about events from the `lightningd`.
+ - **Hooks** are a primitive that allows plugins to be notified about
+   internal events in `lightningd` and alter its behavior or inject
+   custom behaviors.
+   
+*Notice: at the time of writing only command line option passthrough
+is implemented, the other features are under active development.*
+
+A plugin may be written in any language, and communicates with
+`lightningd` through the plugin's `stdin` and `stdout`. JSON-RPCv2 is
+used as protocol on top of the two streams, with the plugin acting as
+server and `lightningd` acting as client.
+
+## A day in the life of a plugin
+
+During startup of `lightningd` you can use the `--plugin=` option to
+register one or more plugins that should be started. `lightningd` will
+write JSON-RPC requests to the plugin's `stdin` and will read replies
+from its `stdout`. To initialize the plugin two RPC methods are
+required:
+
+ - `getmanifest` asks the plugin for command line options and JSON-RPC
+   commands that should be passed through
+ - `init` is called after the command line options have been
+   parsed and passes them through with the real values. This is also
+   the signal that `lightningd`'s JSON-RPC over Unix Socket is now up
+   and ready to receive incoming requests from the plugin.
+
+Once those two methods were called `lightningd` will start passing
+through incoming JSON-RPC commands that were registered and the plugin
+may interact with `lightningd` using the JSON-RPC over Unix-Socket
+interface.
+
+### The `getmanifest` method
+
+The `getmanifest` method is required for all plugins and will be called on
+startup without any params. It MUST return a JSON object similar to
+this example:
+
+```json
+{
+	"options": [
+		{
+			"name": "greeting",
+			"type": "string",
+			"default": "World",
+			"description": "What name should I call you?"
+		}
+	],
+	"rpcmethods": [
+		{
+			"name": "hello",
+			"description": "Returns a personalized greeting for {greeting} (set via options)."
+		},
+		{
+			"name": "gettime",
+			"description": "Returns the current time in {timezone}",
+			"params": ["timezone"]
+		}
+	]
+}
+```
+
+The `options` will be added to the list of command line options that
+`lightningd` accepts. The above will add a `--greeting` option with a
+default value of `World` and the specified description. *Notice that
+currently only string options are supported.*
+
+The `rpcmethods` are methods that will be exposed via `lightningd`'s
+JSON-RPC over Unix-Socket interface, just like the builtin
+commands. Any parameters given to the JSON-RPC calls will be passed
+through verbatim.
+
+### The `init` method
+
+The `init` method is required so that `lightningd` can pass back the
+filled command line options and notify the plugin that `lightningd` is
+now ready to receive JSON-RPC commands. The `params` of the call are a
+simple JSON object containing the options:
+
+```json
+{
+	"objects": {
+		"greeting": "World"
+	}
+}
+```
+
+The plugin must respond to `init` calls, however the response can be
+arbitrary and will currently be discarded by `lightningd`. JSON-RPC
+commands were chosen over notifications in order not to force plugins
+to implement notifications which are not that well supported.
+
+## Event stream subscriptions
+
+*TBD*
+
+## Hooks
+
+*TBD*

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -92,9 +92,6 @@ bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDE
 /* Generated stub for fromwire_peektype */
 int fromwire_peektype(const u8 *cursor UNNEEDED)
 { fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
-/* Generated stub for fromwire_u8 */
-u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
-{ fprintf(stderr, "fromwire_u8 called!\n"); abort(); }
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -56,9 +56,6 @@ bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDE
 /* Generated stub for fromwire_peektype */
 int fromwire_peektype(const u8 *cursor UNNEEDED)
 { fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
-/* Generated stub for fromwire_u8 */
-u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
-{ fprintf(stderr, "fromwire_u8 called!\n"); abort(); }
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -54,9 +54,6 @@ bool fromwire_node_announcement(const tal_t *ctx UNNEEDED, const void *p UNNEEDE
 /* Generated stub for fromwire_peektype */
 int fromwire_peektype(const u8 *cursor UNNEEDED)
 { fprintf(stderr, "fromwire_peektype called!\n"); abort(); }
-/* Generated stub for fromwire_u8 */
-u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
-{ fprintf(stderr, "fromwire_u8 called!\n"); abort(); }
 /* Generated stub for fromwire_wireaddr */
 bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct wireaddr *addr UNNEEDED)
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -78,6 +78,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/peer_control.c		\
 	lightningd/peer_htlcs.c			\
 	lightningd/ping.c			\
+	lightningd/plugin.c			\
 	lightningd/subd.c			\
 	lightningd/watch.c
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -596,6 +596,10 @@ int main(int argc, char *argv[])
 	/*~ Handle options and config; move to .lightningd (--lightning-dir) */
 	handle_opts(ld, argc, argv);
 
+	/*~ Initialize all the plugins we just registered, so they can do their
+	 *  thing and tell us about themselves */
+	plugins_init(ld->plugins);
+
 	/*~ Make sure we can reach the subdaemons, and versions match. */
 	test_subdaemons(ld);
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -607,6 +607,11 @@ int main(int argc, char *argv[])
 	/*~ Handle options and config; move to .lightningd (--lightning-dir) */
 	handle_opts(ld, argc, argv);
 
+	/*~ Now that we have collected all the early options, gave
+	 *  plugins a chance to register theirs and collected all
+	 *  remaining options it's time to tell the plugins. */
+	plugins_config(ld->plugins);
+
 	/*~ Make sure we can reach the subdaemons, and versions match. */
 	test_subdaemons(ld);
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -217,7 +217,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 *code. Here we initialize the context that will keep track and control
 	 *the plugins.
 	 */
-	ld->plugins = plugins_new(ld, ld->log);
+	ld->plugins = plugins_new(ld, ld->log_book);
 
 	return ld;
 }

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -593,12 +593,19 @@ int main(int argc, char *argv[])
 	 *  mimic this API here, even though they're on separate lines.*/
 	register_opts(ld);
 
+	/*~ Handle early options, but don't move to --lightning-dir
+	 *  just yet. Plugins may add new options, which is why we are
+	 *  splitting between early args (including --plugin
+	 *  registration) and non-early opts. */
+	handle_early_opts(ld, argc, argv);
+
+	/*~ Initialize all the plugins we just registered, so they can
+	 *  do their thing and tell us about themselves (including
+	 *  options registration). */
+	plugins_init(ld->plugins);
+
 	/*~ Handle options and config; move to .lightningd (--lightning-dir) */
 	handle_opts(ld, argc, argv);
-
-	/*~ Initialize all the plugins we just registered, so they can do their
-	 *  thing and tell us about themselves */
-	plugins_init(ld->plugins);
 
 	/*~ Make sure we can reach the subdaemons, and versions match. */
 	test_subdaemons(ld);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -211,6 +211,14 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->tor_service_password = NULL;
 	ld->max_funding_unconfirmed = 2016;
 
+	/*~ We run a number of plugins (subprocesses that we talk JSON-RPC with)
+	 *alongside this process. This allows us to have an easy way for users
+	 *to add their own tools without having to modify the c-lightning source
+	 *code. Here we initialize the context that will keep track and control
+	 *the plugins.
+	 */
+	ld->plugins = plugins_new(ld);
+
 	return ld;
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -217,7 +217,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 *code. Here we initialize the context that will keep track and control
 	 *the plugins.
 	 */
-	ld->plugins = plugins_new(ld);
+	ld->plugins = plugins_new(ld, ld->log);
 
 	return ld;
 }

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -7,6 +7,7 @@
 #include <ccan/time/time.h>
 #include <ccan/timer/timer.h>
 #include <lightningd/htlc_end.h>
+#include <lightningd/plugin.h>
 #include <stdio.h>
 #include <wallet/txfilter.h>
 #include <wallet/wallet.h>
@@ -203,6 +204,8 @@ struct lightningd {
 	bool use_proxy_always;
 	char *tor_service_password;
 	bool pure_tor_setup;
+
+	struct plugins *plugins;
 };
 
 const struct chainparams *get_chainparams(const struct lightningd *ld);

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -724,7 +724,7 @@ void register_opts(struct lightningd *ld)
 {
 	opt_set_alloc(opt_allocfn, tal_reallocfn, tal_freefn);
 
-	opt_register_early_noarg("--help|-h", opt_lightningd_usage, ld,
+	opt_register_noarg("--help|-h", opt_lightningd_usage, ld,
 				 "Print this message.");
 	opt_register_early_noarg("--test-daemons-only",
 				 test_subdaemons_and_exit,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -971,7 +971,7 @@ static void add_config(struct lightningd *ld,
 			if (ld->proxyaddr)
 				answer = fmt_wireaddr(name0, ld->proxyaddr);
 		} else if (opt->cb_arg == (void *)opt_add_plugin) {
-			/* FIXME: Actually add the plugin options */
+			json_add_opt_plugins(response, ld->plugins);
 #if DEVELOPER
 		} else if (strstarts(name, "dev-")) {
 			/* Ignore dev settings */

--- a/lightningd/options.h
+++ b/lightningd/options.h
@@ -9,6 +9,9 @@ struct lightningd;
 void register_opts(struct lightningd *ld);
 
 /* After this, we're in the .lightning dir, config files parsed. */
+void handle_early_opts(struct lightningd *ld, int argc, char *argv[]);
+
+/* After this we've parsed all options */
 void handle_opts(struct lightningd *ld, int argc, char *argv[]);
 
 /* Derive default color and alias from the pubkey. */

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2,6 +2,8 @@
 
 #include <ccan/list/list.h>
 #include <ccan/tal/str/str.h>
+#include <lightningd/json.h>
+#include <unistd.h>
 
 struct plugin {
 	int stdin, stdout;
@@ -32,4 +34,17 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 
 void plugins_init(struct plugins *plugins)
 {
+}
+
+void json_add_opt_plugins(struct json_stream *response,
+			  const struct plugins *plugins)
+{
+	struct plugin *p;
+	json_object_start(response, "plugin");
+	for (size_t i=0; i<tal_count(plugins->plugins); i++) {
+		p = plugins->plugins[i];
+		json_object_start(response, p->cmd);
+		json_object_end(response);
+	}
+	json_object_end(response);
 }

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1,5 +1,6 @@
 #include "lightningd/plugin.h"
 
+#include <ccan/intmap/intmap.h>
 #include <ccan/io/io.h>
 #include <ccan/list/list.h>
 #include <ccan/pipecmd/pipecmd.h>
@@ -13,6 +14,7 @@ struct plugin {
 	char *cmd;
 	struct io_conn *stdin_conn, *stdout_conn;
 	bool stop;
+	struct plugins *plugins;
 
 	/* Stuff we read */
 	char *buffer;
@@ -23,8 +25,27 @@ struct plugin {
 	const char *outbuf;
 };
 
+struct plugin_request {
+	u64 id;
+	/* Method to be called */
+	const char *method;
+
+	/* JSON encoded params, either a dict or an array */
+	const char *json_params;
+	const char *response;
+	const jsmntok_t *resulttok, *errortok;
+
+	/* The response handler to be called on success or error */
+	void (*cb)(const struct plugin_request *, void *);
+	void *arg;
+};
+
 struct plugins {
 	struct plugin **plugins;
+	size_t pending_init;
+
+	/* Currently pending requests by their request ID */
+	UINTMAP(struct plugin_request *) pending_requests;
 };
 
 struct json_output {
@@ -46,6 +67,7 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 	tal_resize(&plugins->plugins, n+1);
 	p = tal(plugins, struct plugin);
 	plugins->plugins[n] = p;
+	p->plugins = plugins;
 	p->cmd = tal_strdup(p, path);
 }
 
@@ -59,6 +81,13 @@ static bool plugin_read_json_one(struct plugin *plugin)
 {
 	jsmntok_t *toks;
 	bool valid;
+	u64 id;
+	const jsmntok_t *idtok, *resulttok, *errortok;
+	struct plugin_request *request;
+
+	/* FIXME: This could be done more efficiently by storing the
+	 * toks and doing an incremental parse, like lightning-cli
+	 * does. */
 	toks = json_parse_input(plugin->buffer, plugin->used, &valid);
 	if (!toks) {
 		if (!valid) {
@@ -75,7 +104,35 @@ static bool plugin_read_json_one(struct plugin *plugin)
 		return false;
 	}
 
-	/* FIXME(cdecker) Call dispatch to handle this message. */
+	resulttok = json_get_member(plugin->buffer, toks, "result");
+	errortok = json_get_member(plugin->buffer, toks, "error");
+	idtok = json_get_member(plugin->buffer, toks, "id");
+
+	/* FIXME(cdecker) Kill the plugin if either of these fails */
+	if (!idtok) {
+		return false;
+	} else if (!resulttok && !errortok) {
+		return false;
+	}
+
+	/* We only send u64 ids, so if this fails it's a critical error */
+	if (!json_to_u64(plugin->buffer, idtok, &id)) {
+		/* FIXME (cdecker) Log an error message and kill the plugin */
+		return false;
+	}
+
+	request = uintmap_get(&plugin->plugins->pending_requests, id);
+
+	if (!request) {
+		/* FIXME(cdecker) Log an error and kill the plugin */
+		return false;
+	}
+
+	/* We expect the request->cb to copy if needed */
+	request->response = plugin->buffer;
+	request->errortok = errortok;
+	request->resulttok = resulttok;
+	request->cb(request, request->arg);
 
 	/* Move this object out of the buffer */
 	memmove(plugin->buffer, plugin->buffer + toks[0].end,
@@ -126,6 +183,44 @@ static struct io_plan *plugin_write_json(struct io_conn *conn UNUSED,
 			plugin_write_json, plugin);
 }
 
+static void plugin_request_send_(
+    struct plugin *plugin, const char *method TAKES, const char *params TAKES,
+    void (*cb)(const struct plugin_request *, void *), void *arg)
+{
+	static u64 next_request_id = 0;
+	struct plugin_request *req = tal(plugin, struct plugin_request);
+	struct json_output *out = tal(plugin, struct json_output);
+	u64 request_id = next_request_id++;
+
+	req->id = request_id;
+	req->method = tal_strdup(req, method);
+	req->json_params = tal_strdup(req, params);
+	req->cb = cb;
+	req->arg = arg;
+
+	/* Add to map so we can find it later when routing the response */
+	uintmap_add(&plugin->plugins->pending_requests, req->id, req);
+
+	/* Wrap the request in the JSON-RPC request object */
+	out->json = tal_fmt(out, "{"
+			    "\"jsonrpc\": \"2.0\", "
+			    "\"method\": \"%s\", "
+			    "\"params\" : %s, "
+			    "\"id\" : %" PRIu64 " }\n",
+			    method, params, request_id);
+
+	/* Queue and notify the writer */
+	list_add_tail(&plugin->output, &out->list);
+	io_wake(plugin);
+}
+
+#define plugin_request_send(plugin, method, params, cb, arg)                   \
+	plugin_request_send_(                                                  \
+	    (plugin), (method), (params),                                      \
+	    typesafe_cb_preargs(void, void *, (cb), (arg),                     \
+				const struct plugin_request *),                \
+	    (arg))
+
 static struct io_plan *plugin_conn_init(struct io_conn *conn,
 					struct plugin *plugin)
 {
@@ -146,10 +241,24 @@ static struct io_plan *plugin_conn_init(struct io_conn *conn,
 	}
 }
 
+/**
+ * Callback for the plugin_init request.
+ */
+static void plugin_init_cb(const struct plugin_request *req, struct plugin *plugin)
+{
+	/* Check if all plugins are initialized, and break if they are */
+	plugin->plugins->pending_init--;
+	if (plugin->plugins->pending_init == 0)
+		io_break(plugin->plugins);
+}
+
 void plugins_init(struct plugins *plugins)
 {
 	struct plugin *p;
 	char **cmd;
+	plugins->pending_init = tal_count(plugins->plugins);
+	uintmap_init(&plugins->pending_requests);
+
 	/* Spawn the plugin processes before entering the io_loop */
 	for (size_t i=0; i<tal_count(plugins->plugins); i++) {
 		p = plugins->plugins[i];
@@ -166,7 +275,10 @@ void plugins_init(struct plugins *plugins)
 		 * write-only on p->stdout */
 		io_new_conn(p, p->stdout, plugin_conn_init, p);
 		io_new_conn(p, p->stdin, plugin_conn_init, p);
+		plugin_request_send(p, "init", "[]", plugin_init_cb, p);
 	}
+	if (plugins->pending_init > 0)
+		io_loop(NULL, NULL);
 }
 
 void json_add_opt_plugins(struct json_stream *response,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1,6 +1,8 @@
 #include "lightningd/plugin.h"
 
+#include <ccan/io/io.h>
 #include <ccan/list/list.h>
+#include <ccan/pipecmd/pipecmd.h>
 #include <ccan/tal/str/str.h>
 #include <lightningd/json.h>
 #include <unistd.h>
@@ -9,10 +11,25 @@ struct plugin {
 	int stdin, stdout;
 	pid_t pid;
 	char *cmd;
+	struct io_conn *stdin_conn, *stdout_conn;
+	bool stop;
+
+	/* Stuff we read */
+	char *buffer;
+	size_t used, len_read;
+
+	/* Stuff we write */
+	struct list_head output;
+	const char *outbuf;
 };
 
 struct plugins {
 	struct plugin **plugins;
+};
+
+struct json_output {
+	struct list_node list;
+	const char *json;
 };
 
 struct plugins *plugins_new(const tal_t *ctx){
@@ -32,8 +49,124 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 	p->cmd = tal_strdup(p, path);
 }
 
+/**
+ * Try to parse a complete message from the plugin's buffer.
+ *
+ * Internally calls the handler if it was able to fully parse a JSON message,
+ * and returns true in that case.
+ */
+static bool plugin_read_json_one(struct plugin *plugin)
+{
+	jsmntok_t *toks;
+	bool valid;
+	toks = json_parse_input(plugin->buffer, plugin->used, &valid);
+	if (!toks) {
+		if (!valid) {
+			/* FIXME (cdecker) Print error and kill the plugin */
+			return io_close(plugin->stdout_conn);
+		}
+		/* We need more. */
+		return false;
+	}
+
+	/* Empty buffer? (eg. just whitespace). */
+	if (tal_count(toks) == 1) {
+		plugin->used = 0;
+		return false;
+	}
+
+	/* FIXME(cdecker) Call dispatch to handle this message. */
+
+	/* Move this object out of the buffer */
+	memmove(plugin->buffer, plugin->buffer + toks[0].end,
+		tal_count(plugin->buffer) - toks[0].end);
+	plugin->used -= toks[0].end;
+	tal_free(toks);
+	return true;
+}
+
+static struct io_plan *plugin_read_json(struct io_conn *conn UNUSED,
+					struct plugin *plugin)
+{
+	bool success;
+	plugin->used += plugin->len_read;
+	if (plugin->used == tal_count(plugin->buffer))
+		tal_resize(&plugin->buffer, plugin->used * 2);
+
+	/* Read and process all messages from the connection */
+	do {
+		success = plugin_read_json_one(plugin);
+	} while (success);
+
+	/* Now read more from the connection */
+	return io_read_partial(plugin->stdout_conn,
+			       plugin->buffer + plugin->used,
+			       tal_count(plugin->buffer) - plugin->used,
+			       &plugin->len_read, plugin_read_json, plugin);
+}
+
+static struct io_plan *plugin_write_json(struct io_conn *conn UNUSED,
+					 struct plugin *plugin)
+{
+	struct json_output *out;
+	out = list_pop(&plugin->output, struct json_output, list);
+	if (!out) {
+		if (plugin->stop) {
+			return io_close(conn);
+		} else {
+			return io_out_wait(plugin->stdin_conn, plugin,
+					   plugin_write_json, plugin);
+		}
+	}
+
+	/* We have a message we'd like to send */
+	plugin->outbuf = tal_steal(plugin, out->json);
+	tal_free(out);
+	return io_write(conn, plugin->outbuf, strlen(plugin->outbuf),
+			plugin_write_json, plugin);
+}
+
+static struct io_plan *plugin_conn_init(struct io_conn *conn,
+					struct plugin *plugin)
+{
+	plugin->stop = false;
+	if (plugin->stdout == io_conn_fd(conn)) {
+		/* We read from their stdout */
+		plugin->stdout_conn = conn;
+		return io_read_partial(plugin->stdout_conn, plugin->buffer,
+				       tal_bytelen(plugin->buffer),
+				       &plugin->len_read, plugin_read_json,
+				       plugin);
+	} else {
+		/* We write to their stdin */
+		plugin->stdin_conn = conn;
+		/* We don't have anything queued yet, wait for notification */
+		return io_wait(plugin->stdin_conn, plugin, plugin_write_json,
+			       plugin);
+	}
+}
+
 void plugins_init(struct plugins *plugins)
 {
+	struct plugin *p;
+	char **cmd;
+	/* Spawn the plugin processes before entering the io_loop */
+	for (size_t i=0; i<tal_count(plugins->plugins); i++) {
+		p = plugins->plugins[i];
+		cmd = tal_arr(p, char *, 2);
+		cmd[0] = p->cmd;
+		cmd[1] = NULL;
+		p->pid = pipecmdarr(&p->stdout, &p->stdin, NULL, cmd);
+
+		list_head_init(&p->output);
+		p->buffer = tal_arr(p, char, 64);
+		p->used = 0;
+
+		/* Create two connections, one read-only on top of p->stdin, and one
+		 * write-only on p->stdout */
+		io_new_conn(p, p->stdout, plugin_conn_init, p);
+		io_new_conn(p, p->stdin, plugin_conn_init, p);
+	}
 }
 
 void json_add_opt_plugins(struct json_stream *response,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1,0 +1,35 @@
+#include "lightningd/plugin.h"
+
+#include <ccan/list/list.h>
+#include <ccan/tal/str/str.h>
+
+struct plugin {
+	int stdin, stdout;
+	pid_t pid;
+	char *cmd;
+};
+
+struct plugins {
+	struct plugin **plugins;
+};
+
+struct plugins *plugins_new(const tal_t *ctx){
+	struct plugins *p;
+	p = tal(ctx, struct plugins);
+	p->plugins = tal_arr(p, struct plugin *, 0);
+	return p;
+}
+
+void plugin_register(struct plugins *plugins, const char* path TAKES)
+{
+	struct plugin *p;
+	size_t n = tal_count(plugins->plugins);
+	tal_resize(&plugins->plugins, n+1);
+	p = tal(plugins, struct plugin);
+	plugins->plugins[n] = p;
+	p->cmd = tal_strdup(p, path);
+}
+
+void plugins_init(struct plugins *plugins)
+{
+}

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -239,12 +239,14 @@ static void plugin_request_send_(
 	/* Add to map so we can find it later when routing the response */
 	uintmap_add(&plugin->plugins->pending_requests, req->id, req);
 
-	/* Wrap the request in the JSON-RPC request object */
+	/* Wrap the request in the JSON-RPC request object. Terminate
+	 * with an empty line that serves as a hint that the JSON
+	 * object is done. */
 	out->json = tal_fmt(out, "{"
 			    "\"jsonrpc\": \"2.0\", "
 			    "\"method\": \"%s\", "
 			    "\"params\" : %s, "
-			    "\"id\" : %" PRIu64 " }\n",
+			    "\"id\" : %" PRIu64 " }\n\n",
 			    method, params, request_id);
 
 	/* Queue and notify the writer */

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -411,6 +411,10 @@ void plugins_init(struct plugins *plugins)
 		io_loop(NULL, NULL);
 }
 
+void plugins_config(struct plugins *plugins)
+{
+}
+
 void json_add_opt_plugins(struct json_stream *response,
 			  const struct plugins *plugins)
 {

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -16,7 +16,7 @@ struct plugins;
 /**
  * Create a new plugins context.
  */
-struct plugins *plugins_new(const tal_t *ctx, struct log *log);
+struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -38,6 +38,15 @@ void plugins_init(struct plugins *plugins);
 void plugin_register(struct plugins *plugins, const char* path TAKES);
 
 /**
+ * Send the configure message to all plugins.
+ *
+ * Once we've collected all the command line arguments we can go ahead
+ * and send them over to the plugin. This finalizes the initialization
+ * of the plugins and signals that lightningd is now ready to process
+ * incoming JSON-RPC calls and messages.
+ */
+void plugins_config(struct plugins *plugins);
+/**
  * Add the plugin option and their respective options to listconfigs.
  *
  * This adds a dict that maps the plugin name to a dict of configuration options

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -4,6 +4,7 @@
 #include <ccan/take/take.h>
 #include <ccan/tal/tal.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/log.h>
 
 /**
  * A collection of plugins, and some associated information.
@@ -15,7 +16,7 @@ struct plugins;
 /**
  * Create a new plugins context.
  */
-struct plugins *plugins_new(const tal_t *ctx);
+struct plugins *plugins_new(const tal_t *ctx, struct log *log);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <ccan/take/take.h>
 #include <ccan/tal/tal.h>
+#include <lightningd/jsonrpc.h>
 
 /**
  * A collection of plugins, and some associated information.
@@ -34,5 +35,14 @@ void plugins_init(struct plugins *plugins);
  * @param path: The path of the executable for this plugin
  */
 void plugin_register(struct plugins *plugins, const char* path TAKES);
+
+/**
+ * Add the plugin option and their respective options to listconfigs.
+ *
+ * This adds a dict that maps the plugin name to a dict of configuration options
+ * for the corresponding plugins.
+ */
+void json_add_opt_plugins(struct json_stream *response,
+			  const struct plugins *plugins);
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_H */

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -1,0 +1,38 @@
+#ifndef LIGHTNING_LIGHTNINGD_PLUGIN_H
+#define LIGHTNING_LIGHTNINGD_PLUGIN_H
+#include "config.h"
+#include <ccan/take/take.h>
+#include <ccan/tal/tal.h>
+
+/**
+ * A collection of plugins, and some associated information.
+ *
+ * Mainly used as root context for calls in the plugin subsystem.
+ */
+struct plugins;
+
+/**
+ * Create a new plugins context.
+ */
+struct plugins *plugins_new(const tal_t *ctx);
+
+/**
+ * Initialize the registered plugins.
+ *
+ * Initialization includes spinning up the plugins, reading their
+ * manifest, and registering the JSON-RPC passthrough and command line
+ * arguments. In order to read the getmanifest reply from the plugins
+ * we spin up our own io_loop that exits once all plugins have
+ * responded.
+ */
+void plugins_init(struct plugins *plugins);
+
+/**
+ * Register a plugin for initialization and execution.
+ *
+ * @param plugins: Plugin context
+ * @param path: The path of the executable for this plugin
+ */
+void plugin_register(struct plugins *plugins, const char* path TAKES);
+
+#endif /* LIGHTNING_LIGHTNINGD_PLUGIN_H */

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -119,6 +119,9 @@ struct chain_topology *new_topology(struct lightningd *ld UNNEEDED, struct log *
 /* Generated stub for onchaind_replay_channels */
 void onchaind_replay_channels(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "onchaind_replay_channels called!\n"); abort(); }
+/* Generated stub for plugins_new */
+struct plugins *plugins_new(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "plugins_new called!\n"); abort(); }
 /* Generated stub for register_opts */
 void register_opts(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "register_opts called!\n"); abort(); }

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -122,6 +122,9 @@ struct chain_topology *new_topology(struct lightningd *ld UNNEEDED, struct log *
 /* Generated stub for onchaind_replay_channels */
 void onchaind_replay_channels(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "onchaind_replay_channels called!\n"); abort(); }
+/* Generated stub for plugins_config */
+void plugins_config(struct plugins *plugins UNNEEDED)
+{ fprintf(stderr, "plugins_config called!\n"); abort(); }
 /* Generated stub for plugins_init */
 void plugins_init(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -119,6 +119,9 @@ struct chain_topology *new_topology(struct lightningd *ld UNNEEDED, struct log *
 /* Generated stub for onchaind_replay_channels */
 void onchaind_replay_channels(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "onchaind_replay_channels called!\n"); abort(); }
+/* Generated stub for plugins_init */
+void plugins_init(struct plugins *plugins UNNEEDED)
+{ fprintf(stderr, "plugins_init called!\n"); abort(); }
 /* Generated stub for plugins_new */
 struct plugins *plugins_new(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "plugins_new called!\n"); abort(); }

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -129,7 +129,7 @@ void plugins_config(struct plugins *plugins UNNEEDED)
 void plugins_init(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }
 /* Generated stub for plugins_new */
-struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log *log UNNEEDED)
+struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log_book *log_book UNNEEDED)
 { fprintf(stderr, "plugins_new called!\n"); abort(); }
 /* Generated stub for register_opts */
 void register_opts(struct lightningd *ld UNNEEDED)

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -72,6 +72,9 @@ struct log_book *get_log_book(const struct log *log UNNEEDED)
 /* Generated stub for gossip_init */
 void gossip_init(struct lightningd *ld UNNEEDED, int connectd_fd UNNEEDED)
 { fprintf(stderr, "gossip_init called!\n"); abort(); }
+/* Generated stub for handle_early_opts */
+void handle_early_opts(struct lightningd *ld UNNEEDED, int argc UNNEEDED, char *argv[])
+{ fprintf(stderr, "handle_early_opts called!\n"); abort(); }
 /* Generated stub for handle_opts */
 void handle_opts(struct lightningd *ld UNNEEDED, int argc UNNEEDED, char *argv[])
 { fprintf(stderr, "handle_opts called!\n"); abort(); }

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -126,7 +126,7 @@ void onchaind_replay_channels(struct lightningd *ld UNNEEDED)
 void plugins_init(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }
 /* Generated stub for plugins_new */
-struct plugins *plugins_new(const tal_t *ctx UNNEEDED)
+struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log *log UNNEEDED)
 { fprintf(stderr, "plugins_new called!\n"); abort(); }
 /* Generated stub for register_opts */
 void register_opts(struct lightningd *ld UNNEEDED)


### PR DESCRIPTION
This is the first part of the plugin subsystem. It includes the following steps:

 - Creates a sample plugin
 - Adds the `--plugin` cli option to register a plugin
 - Manages the plugin process
 - Sets up connectivity over `stdin` and `stdout` with the plugin and adds processing and multiplexing of JSON-RPC commands (`lightningd` as client to the plugin)
 - Splits the option parsing, asks plugins for any options they'd like to expose, and exposes them
 - Collects options for plugins and then configures the plugin.

Still to be done:
 - [ ] Documentation of the format and protocol that the plugins may talk
 - [ ] Event notifications from `lightningd` to the plugins (probably a separate PR)
 - [ ] Hooks that allow `lightningd` to call out to the plugin on automated actions to change the default behavior (hold HTLCs while waiting for delivery, ...) (definitely another PR).