### PR TITLE
[doc] Remove old GOSSIPING state from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,6 @@ that `state` is `CHANNELD_NORMAL`; after 6 confirmations you can use
 `true`.
 
 ### Different states
-* `GOSSIPING` means that you are connected to a peer but there is no
-  payment channel yet.
 * `OPENINGD` means that `lightning_openingd` is negotiating channel
   opening.
 * `CHANNELD_AWAITING_LOCKIN` means that `lightning_channeld` is waiting


### PR DESCRIPTION
The `GOSSIPING` state was removed some time ago: see [CHANGELOG](https://github.com/ElementsProject/lightning/blame/master/CHANGELOG.md#L133-L136)

I think it's confusing to keep it here since it's not an actual  internal state or text that can be returned from the RPC. 