### PR TITLE
bolt11: accept lightning: prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- JSON API: `pay` and `decodepay` accept and ignore `lightning:` prefixes.
+
 ### Deprecated
 
 Note: You should always set `allow-deprecated-apis=false` to test for

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -467,6 +467,14 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
 
         b11->routes = tal_arr(b11, struct route_info *, 0);
 
+	/* BOLT #11:
+	 *
+	 * If a URI scheme is desired, the current recommendation is to either
+	 * use 'lightning:' as a prefix before the BOLT-11 encoding
+	 */
+	if (strstarts(str, "lightning:") || strstarts(str, "LIGHTNING:"))
+		str += strlen("lightning:");
+
         if (strlen(str) < 8)
                 return decode_fail(b11, fail, "Bad bech32 string");
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1100,3 +1100,22 @@ def test_htlcs_cltv_only_difference(node_factory, bitcoind):
     assert only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected']
     assert only_one(l2.rpc.listpeers(l3.info['id'])['peers'])['connected']
     assert only_one(l3.rpc.listpeers(l4.info['id'])['peers'])['connected']
+
+
+def test_pay_variants(node_factory):
+    l1, l2 = node_factory.line_graph(2)
+
+    # Upper case is allowed
+    b11 = l2.rpc.invoice(123000, 'test_pay_variants upper', 'description')['bolt11'].upper()
+    l1.rpc.decodepay(b11)
+    l1.rpc.pay(b11)
+
+    # lightning: prefix is allowed
+    b11 = 'lightning:' + l2.rpc.invoice(123000, 'test_pay_variants with prefix', 'description')['bolt11']
+    l1.rpc.decodepay(b11)
+    l1.rpc.pay(b11)
+
+    # BOTH is allowed.
+    b11 = 'LIGHTNING:' + l2.rpc.invoice(123000, 'test_pay_variants upper with prefix', 'description')['bolt11'].upper()
+    l1.rpc.decodepay(b11)
+    l1.rpc.pay(b11)


### PR DESCRIPTION
The Blockstream store produces these, for example, so let's ignore them.
