### PR TITLE
channeld: accept update_fee before funding_locked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ changes.
 
 - JSON API: uppercase invoices now parsed correctly (broken in 0.6.2).
 - JSON API: commands are once again read even if one hasn't responded yet (broken in 0.6.2).
+- Protocol: allow lnd to send `update_fee` before `funding_locked`.
 - pylightning: handle multiple simultanous RPC replies reliably.
 
 ### Security

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1660,7 +1660,8 @@ static void peer_in(struct peer *peer, const u8 *msg)
 		if (type != WIRE_FUNDING_LOCKED
 		    && type != WIRE_PONG
 		    && type != WIRE_SHUTDOWN
-		    /* lnd sends this early; it's harmless. */
+		    /* lnd sends these early; it's harmless. */
+		    && type != WIRE_UPDATE_FEE
 		    && type != WIRE_ANNOUNCEMENT_SIGNATURES) {
 			peer_failed(&peer->cs,
 				    &peer->channel_id,


### PR DESCRIPTION
As long as they don't try to send commitment_signed, it's OK.  Just a bit
weird.

Closes: #2100