### PR TITLE
enable add_steal_notifiers only support backtrace library

### DIFF
--- a/common/daemon.c
+++ b/common/daemon.c
@@ -80,7 +80,7 @@ int daemon_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	return poll(fds, nfds, timeout);
 }
 
-#if DEVELOPER
+#if DEVELOPER && BACKTRACE_SUPPORTED
 static void steal_notify(tal_t *child, enum tal_notify_type n, tal_t *newparent)
 {
 	tal_t *p = newparent;


### PR DESCRIPTION
FIx build error on Mac OS:
```
common/daemon.c:101:13: error: function 'add_steal_notifiers' is not needed and will not be emitted
      [-Werror,-Wunneeded-internal-declaration]
```