### PR TITLE
add needed include file

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -7,6 +7,7 @@
 #include <ccan/pipecmd/pipecmd.h>
 #include <ccan/tal/str/str.h>
 #include <lightningd/json.h>
+#include <signal.h>
 #include <unistd.h>
 
 struct plugin {


### PR DESCRIPTION
Fix build error on MacOS:

```
lightningd/plugin.c:111:2: error: implicit declaration of function 'kill' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
        kill(plugin->pid, SIGKILL);
        ^
```