### PR TITLE
fixes make error in the plugin system for mac users 

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -9,6 +9,12 @@
 #include <lightningd/json.h>
 #include <unistd.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
+
 struct plugin {
 	pid_t pid;
 	char *cmd;


### PR DESCRIPTION
I don't know why @brakmic only opened an issue #2090 instead of providing this patch. I believe this enhancement will be useful for any mac user as I just experienced exactly the same problem.