### PR TITLE
Minor cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners are automatically requested for review when someone
+# opens a pull request that modifies code that they own. When someone
+# with admin or owner permissions has enabled required reviews, they
+# also can optionally require approval from a code owner before the
+# author can merge a pull request in the repository.
+
+wallet/                 @cdecker
+*.py                    @cdecker
+
+wallet/invoices.*       @ZmnSCPxj
+lightningd/payalgo.*    @ZmnSCPxj
+
+# See https://help.github.com/articles/about-codeowners/ for more
+# information

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -188,7 +188,6 @@ def test_closing_torture(node_factory, executor, bitcoind):
         wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 0)
 
 
-@unittest.skipIf(not DEVELOPER, "needs dev-override-feerates")
 @unittest.skipIf(SLOW_MACHINE and VALGRIND, "slow test")
 def test_closing_different_fees(node_factory, bitcoind, executor):
     l1 = node_factory.get_node()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -836,6 +836,7 @@ def test_rescan(node_factory, bitcoind):
     assert not l1.daemon.is_in_log(r'Adding block 102')
 
 
+@flaky
 def test_reserve_enforcement(node_factory, executor):
     """Channeld should disallow you spending into your reserve"""
     l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,10 @@
+from bitcoin.rpc import RawProxy as BitcoinProxy
+from btcproxy import BitcoinRpcProxy
+from decimal import Decimal
+from ephemeral_port_reserve import reserve
+from lightning import LightningRpc
+
+import json
 import logging
 import os
 import random
@@ -8,12 +15,6 @@ import string
 import subprocess
 import threading
 import time
-
-from btcproxy import BitcoinRpcProxy
-from bitcoin.rpc import RawProxy as BitcoinProxy
-from decimal import Decimal
-from ephemeral_port_reserve import reserve
-from lightning import LightningRpc
 
 BITCOIND_CONFIG = {
     "regtest": 1,
@@ -864,7 +865,9 @@ class NodeFactory(object):
                     unexpected_fail = True
 
             if leaks is not None and len(leaks) != 0:
-                raise Exception("Node {} has memory leaks: {}"
-                                .format(self.nodes[i].daemon.lightning_dir, leaks))
+                raise Exception("Node {} has memory leaks: {}".format(
+                    self.nodes[i].daemon.lightning_dir,
+                    json.dumps(leaks, sort_keys=True, indent=4)
+                ))
 
         return not unexpected_fail


### PR DESCRIPTION
 - Adds `.clang-format` matching our own formatting rules as closely as I could get it
 - Adds codeowners so PRs get assigned reviewers automatically
 - Pretty printing of memleak output so we can read it a bit better
 - `test_reserve_enforcement` is flaky/leaky
 - One test no longer requires `DEVELOPER=1`