### PR TITLE
JSON-RPC passthrough for plugin (Endless plugin saga Part 2)

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -82,7 +82,15 @@ currently only string options are supported.*
 The `rpcmethods` are methods that will be exposed via `lightningd`'s
 JSON-RPC over Unix-Socket interface, just like the builtin
 commands. Any parameters given to the JSON-RPC calls will be passed
-through verbatim.
+through verbatim. Notice that the `name` and the `description` fields
+are mandatory, while the `long_description` can be omitted (it'll be
+set to `description` if it was not provided).
+
+Plugins are free to register any `name` for their `rpcmethod` as long
+as the name was not previously registered. This includes both built-in
+methods, such as `help` and `getinfo`, as well as methods registered
+by other plugins. If there is a conflict then `lightningd` will report
+an error and exit.
 
 ### The `init` method
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -77,6 +77,18 @@ struct json_connection {
 	struct json_stream **js_arr;
 };
 
+/**
+ * `jsonrpc` encapsulates the entire state of the JSON-RPC interface,
+ * including a list of methods that the interface supports (can be
+ * appended dynamically, e.g., for plugins, and logs. It also serves
+ * as a convenient `tal`-parent for all JSON-RPC related allocations.
+ */
+struct jsonrpc {
+	struct io_listener *rpc_listener;
+	struct json_command **commands;
+	struct log *log;
+};
+
 /* The command itself usually owns the stream, because jcon may get closed.
  * The command transfers ownership once it's done though. */
 static struct json_stream *jcon_new_json_stream(const tal_t *ctx,
@@ -292,10 +304,9 @@ static void json_add_help_command(struct command *cmd,
 static void json_help(struct command *cmd,
 		      const char *buffer, const jsmntok_t *params)
 {
-	unsigned int i;
 	struct json_stream *response;
-	struct json_command **cmdlist = get_cmdlist();
 	const jsmntok_t *cmdtok;
+	struct json_command **commands = cmd->ld->jsonrpc->commands;
 
 	if (!param(cmd, buffer, params,
 		   p_opt("command", json_tok_tok, &cmdtok),
@@ -303,10 +314,10 @@ static void json_help(struct command *cmd,
 		return;
 
 	if (cmdtok) {
-		for (i = 0; i < num_cmdlist; i++) {
-			if (json_tok_streq(buffer, cmdtok, cmdlist[i]->name)) {
+		for (size_t i = 0; i < tal_count(commands); i++) {
+			if (json_tok_streq(buffer, cmdtok, commands[i]->name)) {
 				response = json_stream_success(cmd);
-				json_add_help_command(cmd, response, cmdlist[i]);
+				json_add_help_command(cmd, response, commands[i]);
 				goto done;
 			}
 		}
@@ -320,8 +331,8 @@ static void json_help(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_object_start(response, NULL);
 	json_array_start(response, "help");
-	for (i = 0; i < num_cmdlist; i++) {
-		json_add_help_command(cmd, response, cmdlist[i]);
+	for (size_t i=0; i<tal_count(commands); i++) {
+		json_add_help_command(cmd, response, commands[i]);
 	}
 	json_array_end(response);
 	json_object_end(response);
@@ -330,17 +341,17 @@ done:
 	command_success(cmd, response);
 }
 
-static const struct json_command *find_cmd(const char *buffer,
+static const struct json_command *find_cmd(const struct jsonrpc *rpc,
+					   const char *buffer,
 					   const jsmntok_t *tok)
 {
-	unsigned int i;
-	struct json_command **cmdlist = get_cmdlist();
+	struct json_command **commands = rpc->commands;
 
-	/* cmdlist[i]->name can be NULL in test code. */
-	for (i = 0; i < num_cmdlist; i++)
-		if (cmdlist[i]->name
-		    && json_tok_streq(buffer, tok, cmdlist[i]->name))
-			return cmdlist[i];
+	/* commands[i]->name can be NULL in test code. */
+	for (size_t i=0; i<tal_count(commands); i++)
+          if (commands[i]->name &&
+              json_tok_streq(buffer, tok, commands[i]->name))
+            return commands[i];
 	return NULL;
 }
 
@@ -516,9 +527,9 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 		return;
 	}
 
-	/* This is a convenient tal parent for duration of command
-	 * (which may outlive the conn!). */
-	c = tal(jcon->ld->rpc_listener, struct command);
+	/* Allocate the command off of the `jsonrpc` object and not
+	 * the connection since the command may outlive `conn`. */
+	c = tal(jcon->ld->jsonrpc, struct command);
 	c->jcon = jcon;
 	c->ld = jcon->ld;
 	c->pending = false;
@@ -543,8 +554,8 @@ static void parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 		return;
 	}
 
-	c->json_cmd = find_cmd(jcon->buffer, method);
-	if (!c->json_cmd) {
+        c->json_cmd = find_cmd(jcon->ld->jsonrpc, jcon->buffer, method);
+        if (!c->json_cmd) {
 		command_fail(c, JSONRPC2_METHOD_NOT_FOUND,
 			     "Unknown command '%.*s'",
 			     method->end - method->start,
@@ -713,10 +724,41 @@ static struct io_plan *incoming_jcon_connected(struct io_conn *conn,
 	return jcon_connected(notleak(conn), ld);
 }
 
-void setup_jsonrpc(struct lightningd *ld, const char *rpc_filename)
+bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command)
+{
+	size_t count = tal_count(rpc->commands);
+
+	/* Check that we don't clobber a method */
+	for (size_t i = 0; i < count; i++)
+		if (rpc->commands[i] != NULL &&
+		    streq(rpc->commands[i]->name, command->name))
+			return false;
+
+	*tal_arr_expand(&rpc->commands) = command;
+	return true;
+}
+
+static struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld, int fd)
+{
+	struct jsonrpc *jsonrpc = tal(ctx, struct jsonrpc);
+	struct json_command **commands = get_cmdlist();
+
+	jsonrpc->commands = tal_arr(jsonrpc, struct json_command *, 0);
+	jsonrpc->log = new_log(jsonrpc, ld->log_book, "jsonrpc");
+	for (size_t i=0; i<num_cmdlist; i++) {
+		jsonrpc_command_add(jsonrpc, commands[i]);
+	}
+	jsonrpc->rpc_listener = io_new_listener(
+		ld->rpc_filename, fd, incoming_jcon_connected, ld);
+	log_debug(jsonrpc->log, "Listening on '%s'", ld->rpc_filename);
+	return jsonrpc;
+}
+
+struct jsonrpc *setup_jsonrpc(struct lightningd *ld)
 {
 	struct sockaddr_un addr;
 	int fd, old_umask;
+	const char *rpc_filename = ld->rpc_filename;
 
 	if (streq(rpc_filename, "/dev/tty")) {
 		fd = open(rpc_filename, O_RDWR);
@@ -724,7 +766,7 @@ void setup_jsonrpc(struct lightningd *ld, const char *rpc_filename)
 			err(1, "Opening %s", rpc_filename);
 		/* Technically this is a leak, but there's only one */
 		notleak(io_new_conn(ld, fd, jcon_connected, ld));
-		return;
+		return jsonrpc_new(ld, ld, fd);
 	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -750,8 +792,7 @@ void setup_jsonrpc(struct lightningd *ld, const char *rpc_filename)
 	if (listen(fd, 1) != 0)
 		err(1, "Listening on '%s'", rpc_filename);
 
-	log_debug(ld->log, "Listening on '%s'", rpc_filename);
-	ld->rpc_listener = io_new_listener(ld->rpc_filename, fd, incoming_jcon_connected, ld);
+	return jsonrpc_new(ld, ld, fd);
 }
 
 /**

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -347,11 +347,12 @@ static const struct json_command *find_cmd(const struct jsonrpc *rpc,
 {
 	struct json_command **commands = rpc->commands;
 
-	/* commands[i]->name can be NULL in test code. */
-	for (size_t i=0; i<tal_count(commands); i++)
-          if (commands[i]->name &&
-              json_tok_streq(buffer, tok, commands[i]->name))
-            return commands[i];
+	/* commands[i] can be NULL if the plugin that registered it
+	 * was killed, commands[i]->name can be NULL in test code. */
+	for (size_t i = 0; i < tal_count(commands); i++)
+		if (commands[i] && commands[i]->name &&
+		    json_tok_streq(buffer, tok, commands[i]->name))
+			return commands[i];
 	return NULL;
 }
 
@@ -736,6 +737,18 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command)
 
 	*tal_arr_expand(&rpc->commands) = command;
 	return true;
+}
+
+void jsonrpc_command_remove(struct jsonrpc *rpc, const char *method)
+{
+	// FIXME: Currently leaves NULL entries in the table, if we
+	// restart plugins we should shift them out.
+	for (size_t i=0; i<tal_count(rpc->commands); i++) {
+		struct json_command *cmd = rpc->commands[i];
+		if (cmd && streq(cmd->name, method)) {
+			rpc->commands[i] = tal_free(cmd);
+		}
+	}
 }
 
 struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld)

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -738,7 +738,7 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command)
 	return true;
 }
 
-static struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld, int fd)
+struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld)
 {
 	struct jsonrpc *jsonrpc = tal(ctx, struct jsonrpc);
 	struct json_command **commands = get_cmdlist();
@@ -748,17 +748,18 @@ static struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld, int 
 	for (size_t i=0; i<num_cmdlist; i++) {
 		jsonrpc_command_add(jsonrpc, commands[i]);
 	}
-	jsonrpc->rpc_listener = io_new_listener(
-		ld->rpc_filename, fd, incoming_jcon_connected, ld);
-	log_debug(jsonrpc->log, "Listening on '%s'", ld->rpc_filename);
+	jsonrpc->rpc_listener = NULL;
 	return jsonrpc;
 }
 
-struct jsonrpc *setup_jsonrpc(struct lightningd *ld)
+void jsonrpc_listen(struct jsonrpc *jsonrpc, struct lightningd *ld)
 {
 	struct sockaddr_un addr;
 	int fd, old_umask;
 	const char *rpc_filename = ld->rpc_filename;
+
+	/* Should not initialize it twice. */
+	assert(!jsonrpc->rpc_listener);
 
 	if (streq(rpc_filename, "/dev/tty")) {
 		fd = open(rpc_filename, O_RDWR);
@@ -766,7 +767,7 @@ struct jsonrpc *setup_jsonrpc(struct lightningd *ld)
 			err(1, "Opening %s", rpc_filename);
 		/* Technically this is a leak, but there's only one */
 		notleak(io_new_conn(ld, fd, jcon_connected, ld));
-		return jsonrpc_new(ld, ld, fd);
+		return;
 	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -791,8 +792,9 @@ struct jsonrpc *setup_jsonrpc(struct lightningd *ld)
 
 	if (listen(fd, 1) != 0)
 		err(1, "Listening on '%s'", rpc_filename);
-
-	return jsonrpc_new(ld, ld, fd);
+	jsonrpc->rpc_listener = io_new_listener(
+		ld->rpc_filename, fd, incoming_jcon_connected, ld);
+	log_debug(jsonrpc->log, "Listening on '%s'", ld->rpc_filename);
 }
 
 /**

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -117,5 +117,13 @@ void jsonrpc_listen(struct jsonrpc *rpc, struct lightningd *ld);
  */
 bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command);
 
+/**
+ * Remove a command/method from the JSON-RPC.
+ *
+ * Used to dynamically remove a `struct json_command` from the
+ * JSON-RPC dispatch table by its name.
+ */
+void jsonrpc_command_remove(struct jsonrpc *rpc, const char *method);
+
 AUTODATA_TYPE(json_command, struct json_command);
 #endif /* LIGHTNING_LIGHTNINGD_JSONRPC_H */

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -93,7 +93,15 @@ void PRINTF_FMT(3, 4) command_fail(struct command *cmd, int code,
 void command_still_pending(struct command *cmd);
 
 /* For initialization */
-void setup_jsonrpc(struct lightningd *ld, const char *rpc_filename);
+struct jsonrpc *setup_jsonrpc(struct lightningd *ld);
+
+/**
+ * Add a new command/method to the JSON-RPC interface.
+ *
+ * Returns true if the command was added correctly, false if adding
+ * this would clobber a command name.
+ */
+bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command);
 
 AUTODATA_TYPE(json_command, struct json_command);
 #endif /* LIGHTNING_LIGHTNINGD_JSONRPC_H */

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -92,8 +92,22 @@ void PRINTF_FMT(3, 4) command_fail(struct command *cmd, int code,
 /* Mainly for documentation, that we plan to close this later. */
 void command_still_pending(struct command *cmd);
 
-/* For initialization */
-struct jsonrpc *setup_jsonrpc(struct lightningd *ld);
+/**
+ * Create a new jsonrpc to wrap all related information.
+ *
+ * This doesn't setup the listener yet, see `jsonrpc_listen` for
+ * that. This just creates the container for all jsonrpc-related
+ * information so we can start gathering it before actually starting.
+ */
+struct jsonrpc *jsonrpc_new(const tal_t *ctx, struct lightningd *ld);
+
+
+/**
+ * Start listeing on ld->rpc_filename.
+ *
+ * Sets up the listener effectively starting the RPC interface.
+ */
+void jsonrpc_listen(struct jsonrpc *rpc, struct lightningd *ld);
 
 /**
  * Add a new command/method to the JSON-RPC interface.

--- a/lightningd/jsonrpc_errors.h
+++ b/lightningd/jsonrpc_errors.h
@@ -19,6 +19,9 @@
 /* Developer error in the parameters to param() call */
 #define PARAM_DEV_ERROR                 -2
 
+/* Plugin returned an error */
+#define PLUGIN_ERROR                    -3
+
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 #define PAY_IN_PROGRESS			200
 #define PAY_RHASH_ALREADY_USED		201

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -201,6 +201,13 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->tor_service_password = NULL;
 	ld->max_funding_unconfirmed = 2016;
 
+	/*~ In the next step we will initialize the plugins. This will
+	 *  also populate the JSON-RPC with passthrough methods, hence
+	 *  lightningd needs to have something to put those in. This
+	 *  is that :-)
+	 */
+	ld->jsonrpc = jsonrpc_new(ld, ld);
+
 	/*~ We run a number of plugins (subprocesses that we talk JSON-RPC with)
 	 *alongside this process. This allows us to have an easy way for users
 	 *to add their own tools without having to modify the c-lightning source
@@ -695,7 +702,7 @@ int main(int argc, char *argv[])
 
 	/*~ Create RPC socket: now lightning-cli can send us JSON RPC commands
 	 *  over a UNIX domain socket specified by `ld->rpc_filename`. */
-	ld->jsonrpc = setup_jsonrpc(ld);
+	jsonrpc_listen(ld->jsonrpc, ld);
 
 	/*~ We defer --daemon until we've completed most initialization: that
 	 *  way we'll exit with an error rather than silently exiting 0, then

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -214,7 +214,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 *code. Here we initialize the context that will keep track and control
 	 *the plugins.
 	 */
-	ld->plugins = plugins_new(ld, ld->log_book);
+	ld->plugins = plugins_new(ld, ld->log_book, ld->jsonrpc);
 
 	return ld;
 }
@@ -788,6 +788,7 @@ int main(int argc, char *argv[])
 	tal_free(ld->jsonrpc);
 	db_commit_transaction(ld->wallet->db);
 
+	tal_free(ld->plugins);
 	remove(ld->pidfile);
 
 	/* FIXME: pay can have children off tmpctx which unlink from

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -781,6 +781,8 @@ int main(int argc, char *argv[])
 
 	shutdown_subdaemons(ld);
 
+	tal_free(ld->plugins);
+
 	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
 	 * it might actually be touching the DB in some destructors, e.g.,
 	 * unreserving UTXOs (see #1737) */
@@ -788,7 +790,6 @@ int main(int argc, char *argv[])
 	tal_free(ld->jsonrpc);
 	db_commit_transaction(ld->wallet->db);
 
-	tal_free(ld->plugins);
 	remove(ld->pidfile);
 
 	/* FIXME: pay can have children off tmpctx which unlink from

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -695,7 +695,7 @@ int main(int argc, char *argv[])
 
 	/*~ Create RPC socket: now lightning-cli can send us JSON RPC commands
 	 *  over a UNIX domain socket specified by `ld->rpc_filename`. */
-	setup_jsonrpc(ld, ld->rpc_filename);
+	ld->jsonrpc = setup_jsonrpc(ld);
 
 	/*~ We defer --daemon until we've completed most initialization: that
 	 *  way we'll exit with an error rather than silently exiting 0, then
@@ -778,7 +778,7 @@ int main(int argc, char *argv[])
 	 * it might actually be touching the DB in some destructors, e.g.,
 	 * unreserving UTXOs (see #1737) */
 	db_begin_transaction(ld->wallet->db);
-	tal_free(ld->rpc_listener);
+	tal_free(ld->jsonrpc);
 	db_commit_transaction(ld->wallet->db);
 
 	remove(ld->pidfile);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -84,10 +84,11 @@ struct lightningd {
 	/* Location of the RPC socket. */
 	char *rpc_filename;
 
-	/* The listener for the RPC socket. Can be shut down separately from the
-	 * rest of the daemon to allow a clean shutdown, which frees all pending
-	 * cmds in a DB transaction. */
-	struct io_listener *rpc_listener;
+	/* The root of the jsonrpc interface. Can be shut down
+	 * separately from the rest of the daemon to allow a clean
+	 * shutdown, which frees all pending cmds in a DB
+	 * transaction. */
+	struct jsonrpc *jsonrpc;
 
 	/* Configuration file name */
 	char *config_filename;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -59,6 +59,9 @@ struct plugins {
 	UINTMAP(struct plugin_request *) pending_requests;
 	struct log *log;
 	struct log_book *log_book;
+
+	/* RPC interface to bind JSON-RPC methods to */
+	struct jsonrpc *rpc;
 };
 
 struct json_output {
@@ -75,12 +78,15 @@ struct plugin_opt {
 	char *value;
 };
 
-struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book){
+struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
+			    struct jsonrpc *rpc)
+{
 	struct plugins *p;
 	p = tal(ctx, struct plugins);
 	list_head_init(&p->plugins);
 	p->log_book = log_book;
 	p->log = new_log(p, log_book, "plugin-manager");
+	p->rpc = rpc;
 	return p;
 }
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -178,6 +178,9 @@ static bool plugin_read_json_one(struct plugin *plugin)
 	request->toks = toks;
 	request->cb(request, request->arg);
 
+	tal_free(request);
+	uintmap_del(&plugin->plugins->pending_requests, id);
+
 	/* Move this object out of the buffer */
 	memmove(plugin->buffer, plugin->buffer + toks[0].end,
 		tal_count(plugin->buffer) - toks[0].end);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -33,6 +33,8 @@ struct plugin {
 	struct list_head plugin_opts;
 
 	struct list_node list;
+
+	const char **methods;
 };
 
 struct plugin_request {
@@ -106,6 +108,7 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 	plugin_count++;
 	p->log = new_log(p, plugins->log_book, "plugin-%zu", plugin_count);
 	p->log = plugins->log;
+	p->methods = tal_arr(p, const char *, 0);
 	list_head_init(&p->plugin_opts);
 }
 
@@ -460,6 +463,7 @@ static bool plugin_rpcmethod_add(struct plugin *plugin, const char *buffer,
 			   cmd->name);
 		return false;
 	}
+	*tal_arr_expand(&plugin->methods) = cmd->name;
 	return true;
 }
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -9,6 +9,7 @@
 #include <common/memleak.h>
 #include <errno.h>
 #include <lightningd/json.h>
+#include <lightningd/lightningd.h>
 #include <signal.h>
 #include <unistd.h>
 
@@ -70,6 +71,20 @@ struct plugins {
 struct json_output {
 	struct list_node list;
 	const char *json;
+};
+
+/* Represents a pending JSON-RPC request that was forwarded to a
+ * plugin and is currently waiting for it to return the result. */
+struct plugin_rpc_request {
+	/* The json-serialized ID as it was passed to us by the
+	 * client, will be used to return the result */
+	const char *id;
+
+	const char *method;
+	const char *params;
+
+	struct plugin *plugin;
+	struct command *cmd;
 };
 
 /* Simple storage for plugin options inbetween registering them on the
@@ -399,12 +414,68 @@ static void plugin_rpcmethod_destroy(struct json_command *cmd,
 	jsonrpc_command_remove(rpc, cmd->name);
 }
 
+static void plugin_rpcmethod_cb(const struct plugin_request *req,
+				struct plugin_rpc_request *rpc_req)
+{
+	// Parse
+	// Extract results or error
+	// Construct reply
+	// Return result with appropriate return code.
+}
+
 static void plugin_rpcmethod_dispatch(struct command *cmd, const char *buffer,
 				      const jsmntok_t *params)
 {
-	// FIXME: We could avoid parsing the buffer again if we were
-	// to also pass in the method name.
-	cmd->usage = "[params]";
+	const jsmntok_t *toks = params, *methtok, *idtok;
+	struct plugin_rpc_request *request;
+	struct plugins *plugins = cmd->ld->plugins;
+	struct plugin *plugin;
+
+	if (cmd->mode == CMD_USAGE) {
+		cmd->usage = "[params]";
+		return;
+	}
+
+	/* We're given the params, but we need to walk back to the
+	 * root object, so just walk backwards until the current
+	 * element has no parents, that's going to be the root
+	 * element. */
+	while (toks->parent != -1)
+		toks--;
+
+	methtok = json_get_member(buffer, toks, "method");
+	idtok = json_get_member(buffer, toks, "id");
+	/* We've parsed them before, these should not fail! */
+	assert(idtok != NULL && methtok != NULL);
+
+	request = tal(NULL, struct plugin_rpc_request);
+	request->method = tal_strndup(request, buffer + methtok->start,
+				      methtok->end - methtok->start);
+	request->id = tal_strndup(request, buffer + idtok->start,
+				      idtok->end - idtok->start);
+	request->params = tal_strndup(request, buffer + params->start,
+				      params->end - params->start);
+	request->plugin = NULL;
+	request->cmd = cmd;
+
+	/* Find the plugin that registered this RPC call */
+	list_for_each(&plugins->plugins, plugin, list) {
+		for (size_t i=0; i<tal_count(plugin->methods); i++) {
+			if (streq(request->method, plugin->methods[i])) {
+				request->plugin = plugin;
+				goto found;
+			}
+		}
+	}
+
+found:
+	/* This should never happen, it'd mean that a plugin didn't
+	 * cleanup after dying */
+	assert(request->plugin);
+
+	tal_steal(request->plugin, request);
+	plugin_request_send(request->plugin, request->method, request->params, plugin_rpcmethod_cb, request);
+
 	command_still_pending(cmd);
 }
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -9,6 +9,7 @@
 #include <common/memleak.h>
 #include <errno.h>
 #include <lightningd/json.h>
+#include <lightningd/jsonrpc_errors.h>
 #include <lightningd/lightningd.h>
 #include <signal.h>
 #include <unistd.h>
@@ -417,10 +418,26 @@ static void plugin_rpcmethod_destroy(struct json_command *cmd,
 static void plugin_rpcmethod_cb(const struct plugin_request *req,
 				struct plugin_rpc_request *rpc_req)
 {
-	// Parse
-	// Extract results or error
-	// Construct reply
-	// Return result with appropriate return code.
+	struct json_stream *response;
+	const jsmntok_t *res;
+	assert(req->resulttok || req->errortok);
+
+	if (req->errortok) {
+		res = req->errortok;
+		command_fail(rpc_req->cmd, PLUGIN_ERROR, "%.*s",
+			     res->end - res->start, req->response + res->start);
+		tal_free(rpc_req);
+		return;
+	}
+
+	res = req->resulttok;
+	response = json_stream_success(rpc_req->cmd);
+
+	json_add_member(response, NULL, "%.*s", json_tok_len(res),
+			json_tok_contents(req->response, res));
+
+	command_success(rpc_req->cmd, response);
+	tal_free(rpc_req);
 }
 
 static void plugin_rpcmethod_dispatch(struct command *cmd, const char *buffer,

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -16,7 +16,8 @@ struct plugins;
 /**
  * Create a new plugins context.
  */
-struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book);
+struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
+			    struct jsonrpc *rpc);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -138,7 +138,7 @@ void register_opts(struct lightningd *ld UNNEEDED)
 void setup_color_and_alias(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "setup_color_and_alias called!\n"); abort(); }
 /* Generated stub for setup_jsonrpc */
-void setup_jsonrpc(struct lightningd *ld UNNEEDED, const char *rpc_filename UNNEEDED)
+struct jsonrpc *setup_jsonrpc(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "setup_jsonrpc called!\n"); abort(); }
 /* Generated stub for setup_topology */
 void setup_topology(struct chain_topology *topology UNNEEDED, struct timers *timers UNNEEDED,

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -90,6 +90,12 @@ void htlcs_notify_new_block(struct lightningd *ld UNNEEDED, u32 height UNNEEDED)
 /* Generated stub for json_escape */
 struct json_escaped *json_escape(const tal_t *ctx UNNEEDED, const char *str TAKES UNNEEDED)
 { fprintf(stderr, "json_escape called!\n"); abort(); }
+/* Generated stub for jsonrpc_listen */
+void jsonrpc_listen(struct jsonrpc *rpc UNNEEDED, struct lightningd *ld UNNEEDED)
+{ fprintf(stderr, "jsonrpc_listen called!\n"); abort(); }
+/* Generated stub for jsonrpc_new */
+struct jsonrpc *jsonrpc_new(const tal_t *ctx UNNEEDED, struct lightningd *ld UNNEEDED)
+{ fprintf(stderr, "jsonrpc_new called!\n"); abort(); }
 /* Generated stub for load_channels_from_wallet */
 void load_channels_from_wallet(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "load_channels_from_wallet called!\n"); abort(); }
@@ -137,9 +143,6 @@ void register_opts(struct lightningd *ld UNNEEDED)
 /* Generated stub for setup_color_and_alias */
 void setup_color_and_alias(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "setup_color_and_alias called!\n"); abort(); }
-/* Generated stub for setup_jsonrpc */
-struct jsonrpc *setup_jsonrpc(struct lightningd *ld UNNEEDED)
-{ fprintf(stderr, "setup_jsonrpc called!\n"); abort(); }
 /* Generated stub for setup_topology */
 void setup_topology(struct chain_topology *topology UNNEEDED, struct timers *timers UNNEEDED,
 		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -135,7 +135,8 @@ void plugins_config(struct plugins *plugins UNNEEDED)
 void plugins_init(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }
 /* Generated stub for plugins_new */
-struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log_book *log_book UNNEEDED)
+struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log_book *log_book UNNEEDED,
+			    struct jsonrpc *rpc UNNEEDED)
 { fprintf(stderr, "plugins_new called!\n"); abort(); }
 /* Generated stub for register_opts */
 void register_opts(struct lightningd *ld UNNEEDED)


### PR DESCRIPTION
This is the second major plugin feature: plugins can register RPC methods with `lightningd`'s JSON-RPC interface, and calls to those methods will be transparently routed to the plugin.

The preparatory work requires wrapping the information related to the JSON-RPC in a new struct. This also gives us a clean root object for all related objects as well, which was so far done with the listener object. Furthermore the JSON-RPC instantiation and initialization (listening) was split so we can instantiate and add new methods before starting to listen, and the example plugin now handles exceptions and array-based as well as dict-based arguments correctly (I plan on formalizing this in a utility Plugin class for python plugins once we have plugin -> lightningd notifications for logging).