### PR TITLE
Add missing <signal.h> for kill() and SIGKILL.

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <lightningd/json.h>
 #include <unistd.h>
+#include <signal.h>
 
 struct plugin {
 	pid_t pid;


### PR DESCRIPTION
`kill()` and `SIGKILL `are not declared in `lightningd/plugin.c`. Problem showed up building for FreeBSD.
