### PR TITLE
pylightning: Bump version number to 0.0.5 to make Pypi work again

### DIFF
--- a/contrib/pylightning/setup.py
+++ b/contrib/pylightning/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pylightning',
-      version='0.0.3',
+      version='0.0.5',
       description='Client library for lightningd',
       url='http://github.com/ElementsProject/lightning',
       author='Christian Decker',


### PR DESCRIPTION
Fixes #2135

Signed-off-by: Christian Decker <decker.christian@gmail.com>