### PR TITLE
[plugin] Plugin that depicts the off- and onchain funds in a nicer overview

### DIFF
--- a/contrib/plugins/funds/LICENSE
+++ b/contrib/plugins/funds/LICENSE
@@ -1,0 +1,21 @@
+Note: The code of this plugin is covered by the following (BSD-MIT) license:
+
+	Copyright Rene Pickhardt 2018-2019.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/contrib/plugins/funds/README.md
+++ b/contrib/plugins/funds/README.md
@@ -1,4 +1,4 @@
-# funds overview plugin
+# Funds overview plugin
 
 This plugin extends the c-lightning command line API with the `funds` command.
 Users can get a quick overview of their total funds, the offchain funds in
@@ -16,15 +16,18 @@ to learn about the command line API.
 The easiest call will be `lightning-cli funds` without any additional arguments. 
 
 ## About the plugin
-This plugin was created and is maintained by Rene Pickhardt. Thus Rene Pickhardt
-is the copyright owner of this plugin. It shall serve as an educational resource
-on his Youtube channel at: https://www.youtube.com/user/RenePickhardt
+This plugin was created and is maintained by Rene Pickhardt. It shall serve as
+an educational resource on his Youtube channel at:
+
+https://www.youtube.com/user/RenePickhardt
 
 The plugin is licensed like the rest of c-lightning with BSD-MIT license
-and comes without any warrenty.
+and comes without any warrenty (see LICENSE file)
 
 If you like my work feel free to support me on patreon:
 https://www.patreon.com/renepickhardt
 
 or leave me a tip on my donation page (comming from the donation plugin):
-https://ln.rene-pickhardt.de/donation
+https://ln.rene-pickhardt.de/
+
+The work was partially sponsored by http://fulmo.org/

--- a/contrib/plugins/funds/README.md
+++ b/contrib/plugins/funds/README.md
@@ -1,0 +1,30 @@
+# funds overview plugin
+
+This plugin extends the c-lightning command line API with the `funds` command.
+Users can get a quick overview of their total funds, the offchain funds in
+channels and the onchain funds in unspent transaction outputs. 
+
+run the plugin with:
+
+```
+lightningd --plugin=/path/to/lightning/contrib/plugins/funds/funds.py
+```
+
+Once the plugin is active you can run `lightning-cli help funds`
+to learn about the command line API.
+
+The easiest call will be `lightning-cli funds` without any additional arguments. 
+
+## About the plugin
+This plugin was created and is maintained by Rene Pickhardt. Thus Rene Pickhardt
+is the copyright owner of this plugin. It shall serve as an educational resource
+on his Youtube channel at: https://www.youtube.com/user/RenePickhardt
+
+The plugin is licensed like the rest of c-lightning with BSD-MIT license
+and comes without any warrenty.
+
+If you like my work feel free to support me on patreon:
+https://www.patreon.com/renepickhardt
+
+or leave me a tip on my donation page (comming from the donation plugin):
+https://ln.rene-pickhardt.de/donation

--- a/contrib/plugins/funds/funds.py
+++ b/contrib/plugins/funds/funds.py
@@ -10,6 +10,12 @@ Activate the plugin with:
 Call the plugin with: 
 `lightning-cli funds`
 
+The standard unit to depict the funds is set to satoshis. 
+The unit can be changed by and arguments after `lightning-cli funds` 
+for each call. It is also possible to change the standard unit when 
+starting lightningd just pass `--funds_display_unit={unit}` where
+unit can be s for satoshi, b for bits, m for milliBitcoin and B for BTC.
+
 
 Author: Rene Pickhardt (https://ln.rene-pickhardt.de)
 Development of the plugin was sponsored by fulmo.org
@@ -24,48 +30,52 @@ from os.path import join
 rpc_interface = None
 plugin = Plugin(autopatch=True)
 
+unit_aliases = {
+    "bitcoin": "BTC",
+    "btc": "BTC",
+    "satoshi": "sat",
+    "satoshis": "sat",
+    "bit": "bit",
+    "bits": "bit",
+    "milli": "mBTC",
+    "mbtc": "mBTC",
+    "millibtc": "mBTC",
+    "B": "BTC",
+    "s": "sat",
+    "m": "mBTC",
+    "b": "bit",
+}
+
+unit_divisor = {
+    "sat": 1,
+    "bit": 100,
+    "mBTC": 100*1000,
+    "BTC": 100*1000*1000,
+}
+
 
 @plugin.method("funds")
-def funds(plugin, unit="s"):
+def funds(unit=None, plugin=None):
     """Lists the total funds the lightning node owns off- and onchain in {unit}.
 
-{unit} can take the following values:
-s, satoshi, satoshis to depict satoshis
-b, bit, bits to depict bits
-m, milli, btc to depict milliBitcoin
-B, bitcoin, btc to depict Bitcoins
+    {unit} can take the following values:
+    s, satoshi, satoshis to depict satoshis
+    b, bit, bits to depict bits
+    m, milli, btc to depict milliBitcoin
+    B, bitcoin, btc to depict Bitcoins
 
-When not using Satoshis (default) the comma values are rounded off."""
+    When not using Satoshis (default) the comma values are rounded off."""
 
-    switcher = {
-        "bitcoin": "BTC",
-        "btc": "BTC",
-        "satoshi": "sat",
-        "satoshis": "sat",
-        "bit": "bit",
-        "bits": "bit",
-        "milli": "mBTC",
-        "mbtc": "mBTC",
-        "millibtc": "mBTC",
-        "B": "BTC",
-        "s": "sat",
-        "m": "mBTC",
-        "b": "bit",
-    }
+    plugin.log("call with unit: {}".format(unit), level="debug")
+    if unit is None:
+        unit = plugin.get_option("funds_display_unit")
 
     if unit != "B":
-        unit = switcher.get(unit.lower(), "sat")
+        unit = unit_aliases.get(unit.lower(), "sat")
     else:
         unit = "BTC"
 
-    switcher = {
-        "sat": 1,
-        "bit": 100,
-        "mBTC": 100*1000,
-        "BTC": 100*1000*1000,
-    }
-
-    div = switcher.get(unit, 1)
+    div = unit_divisor.get(unit, 1)
 
     funds = rpc_interface.listfunds()
 
@@ -84,17 +94,18 @@ When not using Satoshis (default) the comma values are rounded off."""
 @plugin.method("init")
 def init(options, configuration, plugin):
     global rpc_interface
-    plugin.log("start initialization of the funds plugin")
-    print(configuration)
+    plugin.log("start initialization of the funds plugin", level="debug")
     basedir = configuration['lightning-dir']
     rpc_filename = configuration['rpc-file']
     path = join(basedir, rpc_filename)
     plugin.log("rpc interface located at {}".format(path))
     rpc_interface = LightningRpc(path)
-
     plugin.log("Funds Plugin successfully initialezed")
+    plugin.log("standard unit is set to {}".format(
+        plugin.get_option("funds_display_unit")), level="debug")
 
 
-plugin.add_option('funds', 'funds',
-                  'Lists the total funds the lightning node owns off- and onchina in {units}')
+# set the standard display unit to satoshis
+plugin.add_option('funds_display_unit', 's',
+                  'pass the unit which should be used by default for the simple funds overview plugin')
 plugin.run()

--- a/contrib/plugins/funds/funds.py
+++ b/contrib/plugins/funds/funds.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+""" This plugin gives you a nicer overview of the funds that you own.
+
+Instead of calling listfunds and adding all outputs and channels
+this plugin does that for you.
+
+Author: Rene Pickhardt (https://ln.rene-pickhardt.de)
+
+"""
+
+import json
+import sys
+
+from lightning.lightning import LightningRpc
+from os.path import join
+
+rpc_interface = None
+
+
+def json_get_funds(request, unit="s"):
+
+    switcher = {
+        "bitcoin": "BTC",
+        "btc": "BTC",
+        "satoshi": "sat",
+        "satoshis": "sat",
+        "bit": "bit",
+        "bits": "bit",
+        "milli": "mBTC",
+        "mbtc": "mBTC",
+        "millibtc": "mBTC",
+        "B": "BTC",
+        "s": "sat",
+        "m": "mBTC",
+        "b": "bit",
+    }
+
+    if unit != "B":
+        unit = switcher.get(unit.lower(), "sat")
+    else:
+        unit = "BTC"
+
+    switcher = {
+        "sat": 1,
+        "bit": 100,
+        "mBTC": 100*1000,
+        "BTC": 100*1000*1000,
+    }
+
+    div = switcher.get(unit, 1)
+
+    funds = rpc_interface.listfunds()
+
+    onchain_value = sum([int(x["value"]) for x in funds["outputs"]])
+    offchain_value = sum([int(x["channel_sat"]) for x in funds["channels"]])
+
+    total_funds = onchain_value + offchain_value
+
+    return {
+        'total_'+unit: total_funds//div,
+        'onchain_'+unit: onchain_value//div,
+        'offchain_'+unit: offchain_value//div,
+    }
+
+
+def json_getmanifest(request):
+
+    verbose = """Lists the total funds the lightning node owns off- and onchain in {unit}.
+
+{unit} can take the following values:
+s, satoshi, satoshis to depict satoshis
+b, bit, bits to depict bits
+m, milli, btc to depict milliBitcoin
+B, bitcoin, btc to depict Bitcoins
+
+When not using Satoshis (default) the comma values are rounded off."""
+
+    return {
+        "options": [
+        ],
+        "rpcmethods": [
+            {
+                "name": "funds",
+                "description": "Lists the total funds the lightning node owns off- and onchain in {unit}",
+                "long_description": verbose
+            },
+        ]
+    }
+
+
+def json_init(request, options, configuration):
+    """The main daemon is telling us the relevant cli options
+    """
+    global rpc_interface
+
+    basedir = request['params']['configuration']['lightning-dir']
+    rpc_filename = request['params']['configuration']['rpc-filename']
+    path = join(basedir, rpc_filename)
+
+    rpc_interface = LightningRpc(path)
+
+    return "ok"
+
+
+methods = {
+    'getmanifest': json_getmanifest,
+    'init': json_init,
+    'funds': json_get_funds,
+}
+
+
+partial = ""
+for l in sys.stdin:
+    try:
+        partial += l
+        request = json.loads(partial)
+    except Exception:
+        continue
+
+    result = None
+    method = methods[request['method']]
+    params = request['params']
+    try:
+        if isinstance(params, dict):
+            result = method(request, **params)
+        else:
+            result = method(request, *params)
+        result = {
+            "jsonrpc": "2.0",
+            "result": result,
+            "id": request['id']
+        }
+    except Exception as e:
+        result = {
+            "jsonrpc": "2.0",
+            "error": "Error while processing {}".format(request['method']),
+            "id": request['id']
+        }
+
+    json.dump(result, fp=sys.stdout)
+    sys.stdout.write('\n')
+    sys.stdout.flush()
+    partial = ""


### PR DESCRIPTION
the plugins directory doesn't seem to work yet. I had to call the plugin explicitly with 
`lightningd --plugin=/Users/rpickhardt/hacken/lightning/plugins/funds.py` not sure though weather this plugin should be a standard plugin anyway. 

you can test the plugin with: 
`lightning-cli funds` and the output should be similar to this: 
`{"total_sat": 200000, "onchain_sat": 100000, "offchain_sat": 100000}`
if you call the plugin with the `m` argument the ammounts are depicted in millibitoins (other units are available via help) eg:
```
lightning-cli funds m
{"total_mBTC": 2, "onchain_mBTC": 1, "offchain_mBTC": 1}
```

I will probably use this plugin as a tutorial for next Mondays youtube video, so that people can learn how easy it is to create plugins in c-lightning (chapeau for @cdecker )

I have prepared a couple more plugins (for example for channel balance overview, an invoice server for donations, maybe even the spontaneous payments one) but I would like to have feedback on this "quicky" first instead of pushing several plugins.

Once the easy ones are there I will transfer my autopilot code to the plugin system. 

I have also some feedback where the current system could be improved to ease up the life of developers. Should I do this as a pull request? 

Also is there a better way to talk to the RPC interface (for example directly via stdout) so that the plugin does not need to know where the rpc-interface is located?