### PR TITLE
plugin: Added .params.configuration to init call

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -45,7 +45,7 @@ def json_getmanifest(request):
     }
 
 
-def json_init(request, options):
+def json_init(request, options, configuration):
     """The main daemon is telling us the relevant cli options
     """
     global greeting

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -214,7 +214,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 *code. Here we initialize the context that will keep track and control
 	 *the plugins.
 	 */
-	ld->plugins = plugins_new(ld, ld->log_book, ld->jsonrpc);
+	ld->plugins = plugins_new(ld, ld->log_book, ld->jsonrpc, ld);
 
 	return ld;
 }

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -17,7 +17,7 @@ struct plugins;
  * Create a new plugins context.
  */
 struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
-			    struct jsonrpc *rpc);
+			    struct jsonrpc *rpc, struct lightningd *ld);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -140,7 +140,7 @@ void plugins_init(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }
 /* Generated stub for plugins_new */
 struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log_book *log_book UNNEEDED,
-			    struct jsonrpc *rpc UNNEEDED)
+			    struct jsonrpc *rpc UNNEEDED, struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "plugins_new called!\n"); abort(); }
 /* Generated stub for register_opts */
 void register_opts(struct lightningd *ld UNNEEDED)


### PR DESCRIPTION
This tells the plugin both the `lightning-dir` as well as the
`rpc-filename` to use to talk to `lightningd`. Prior to this they'd
had to guess.

This was supposed to be in #2131, but I had it stashed and forgot about it :slightly_frowning_face: 