### PR TITLE
Make plugins more talkative (log notifications plugin->lightningd)

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -45,12 +45,27 @@ def json_getmanifest(request):
     }
 
 
+def plugin_log(message, level="info"):
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "log",
+        "params": {
+            "level": level,
+            "message": message,
+        }
+    }
+    json.dump(payload, fp=sys.stdout)
+    sys.stdout.write('\n\n')
+    sys.stdout.flush()
+
+
 def json_init(request, options, configuration):
     """The main daemon is telling us the relevant cli options
     """
     global greeting
-
     greeting = request['params']['options']['greeting']
+    plugin_log("Plugin helloworld.py initialized with greeting \"{}\"".format(greeting), "debug")
+
     return "ok"
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -47,6 +47,10 @@ def test_rpc_passthrough(node_factory):
     cmd = [hlp for hlp in n.rpc.help()['help'] if 'hello' in hlp['command']]
     assert(len(cmd) == 1)
 
+    # While we're at it, let's check that helloworld.py is logging
+    # correctly via the notifications plugin->lightningd
+    assert n.daemon.is_in_log('Plugin helloworld.py initialized')
+
     # Now try to call it and see what it returns:
     greet = n.rpc.hello(name='Sun')
     assert(greet == "Hello Sun")


### PR DESCRIPTION
Adds notification handling to `lightningd` so that we can start injecting logs into the main daemon output. Should make it easier to follow what happens in the plugins.