### PR TITLE
static link sqlite library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLU
 CONFIGURATOR_CC := $(CC)
 
 LDFLAGS = $(PIE_LDFLAGS)
-LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
+LDLIBS = -Wl,-dn -lsqlite3 -Wl,-dy -L/usr/local/lib -lgmp -lm -lz -lpthread -ldl $(COVFLAGS)
 
 default: all-programs all-test-programs
 


### PR DESCRIPTION
Static link sqlite3 library to avoid sqlite3 library version mismatch error: #1375 #1497
```
./lightningd
SQLITE version mismatch: compiled 3011000, now 3022000
```

Before:
```
ldd ./lightningd   
	linux-vdso.so.1 (0x00007fff8d357000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4d75946000)
	libsqlite3.so.0 => /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007f4d7563d000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4d75425000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4d75034000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4d75ce4000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4d74e15000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4d74c11000)

```

After:
```
 ldd lightningd/lightningd
	linux-vdso.so.1 (0x00007ffe968e7000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ff2dc5ce000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff2dc3af000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ff2dc1ab000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ff2dbf93000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff2dbba2000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff2dcda7000)

```