### PR TITLE
python: fix lint errors in plugins

### DIFF
--- a/contrib/plugins/fail/failtimeout.py
+++ b/contrib/plugins/fail/failtimeout.py
@@ -45,7 +45,7 @@ for l in sys.stdin:
             "result": result,
             "id": request['id']
         }
-    except Exception as e:
+    except Exception:
         result = {
             "jsonrpc": "2.0",
             "error": "Error while processing {}".format(request['method']),

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -83,7 +83,7 @@ for l in sys.stdin:
             "result": result,
             "id": request['id']
         }
-    except Exception as e:
+    except Exception:
         result = {
             "jsonrpc": "2.0",
             "error": "Error while processing {}".format(request['method']),


### PR DESCRIPTION
Fixes some lint errors with unused variables when running
make full-check:

    contrib/plugins/fail/failtimeout.py:48:5:
      F841 local variable 'e' is assigned to but never used

    contrib/plugins/helloworld.py:86:5:
      F841 local variable 'e' is assigned to but never used