### PR TITLE
Check system-provided library versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,8 +342,11 @@ tools/headerversions: FORCE tools/headerversions.o $(CCAN_OBJS)
 gen_header_versions.h: tools/headerversions
 	@tools/headerversions $@
 
-# All binaries require the external libs, ccan and external library versions.
-$(ALL_PROGRAMS) $(ALL_TEST_PROGRAMS): $(EXTERNAL_LIBS) $(CCAN_OBJS) gen_header_versions.h
+# Rebuild the world if this changes.
+ALL_GEN_HEADERS += gen_header_versions.h
+
+# All binaries require the external libs, ccan and system library versions.
+$(ALL_PROGRAMS) $(ALL_TEST_PROGRAMS): $(EXTERNAL_LIBS) $(CCAN_OBJS)
 
 # Each test program depends on its own object.
 $(ALL_TEST_PROGRAMS): %: %.o

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -64,6 +64,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <gen_header_versions.h>
 #include <lightningd/bitcoind.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/channel_control.h>
@@ -581,6 +582,17 @@ int main(int argc, char *argv[])
 
 	/*~ What happens in strange locales should stay there. */
 	setup_locale();
+
+	/*~ This checks that the system-installed libraries (usually
+	 * dynamically linked) actually are compatible with the ones we
+	 * compiled with.
+	 *
+	 * The header itself is auto-generated every time the version of the
+	 * installed libraries changes, as we had an sqlite3 version update
+	 * which broke people, and "make" didn't think there was any work to
+	 * do, so rebuilding didn't fix it. */
+	check_linked_library_versions();
+
 	/*~ Every daemon calls this in some form: the hooks are for dumping
 	 * backtraces when we crash (if supported on this platform). */
 	daemon_setup(argv[0], log_backtrace_print, log_backtrace_exit);

--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -12,10 +12,42 @@
 #include <sys/types.h>
 #include <zlib.h>
 
+static const char template[] =
+	"/* Generated file by tools/headerversions, do not edit! */\n"
+	"/* GMP version: %s */\n"
+	"/* SQLITE3 version: %u */\n"
+	"/* ZLIB version: %s */\n"
+	"#include <ccan/err/err.h>\n"
+	"#include <gmp.h>\n"
+	"#include <sqlite3.h>\n"
+	"#include <zlib.h>\n"
+	"\n"
+	"static inline void check_linked_library_versions(void)\n"
+	"{\n"
+	"	char compiled_gmp_version[100];\n"
+	"	if (SQLITE_VERSION_NUMBER != sqlite3_libversion_number())\n"
+	"		errx(1, \"SQLITE version mismatch: compiled %%u, now %%u\",\n"
+	"		     SQLITE_VERSION_NUMBER, sqlite3_libversion_number());\n"
+	"	/* zlib documents that first char alters ABI. Kudos! */\n"
+	"	if (zlibVersion()[0] != ZLIB_VERSION[0])\n"
+	"		errx(1, \"zlib version mismatch: compiled %%s, now %%s\",\n"
+	"		     ZLIB_VERSION, zlibVersion());\n"
+	"	/* GMP doesn't say anything, and we have to assemble our own string. */\n"
+	"	snprintf(compiled_gmp_version,  sizeof(compiled_gmp_version),\n"
+	"		 \"%%u.%%u.%%u\",\n"
+	"		 __GNU_MP_VERSION,\n"
+	"		 __GNU_MP_VERSION_MINOR,\n"
+	"		 __GNU_MP_VERSION_PATCHLEVEL);\n"
+	"	if (strcmp(compiled_gmp_version, gmp_version) != 0)\n"
+	"		errx(1, \"gmp version mismatch: compiled %%s, now %%s\",\n"
+	"		     compiled_gmp_version, gmp_version);\n"
+	"}\n";
+
 int main(int argc, char *argv[])
 {
 	char *file, *new;
 
+	/* We don't bother with setup_locale(); we're a build tool */
 	err_set_progname(argv[0]);
 
 	if (argc != 2)
@@ -25,11 +57,7 @@ int main(int argc, char *argv[])
 	if (!file && errno != ENOENT)
 		err(1, "Reading %s", argv[1]);
 
-	new = tal_fmt(NULL,
-		      "/* Generated file by tools/headerversions, do not edit! */\n"
-		      "/* GMP version: %s */\n"
-		      "/* SQLITE3 version: %u */\n"
-		      "/* ZLIB version: %s */\n",
+	new = tal_fmt(NULL, template,
 		      gmp_version,
 		      sqlite3_libversion_number(),
 		      zlibVersion());

--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -1,0 +1,47 @@
+/* Updates the given file if any library versions have changed.  This
+ * is important for systemwide updates, such as sqlite3. */
+#include <ccan/err/err.h>
+#include <ccan/read_write_all/read_write_all.h>
+#include <ccan/tal/grab_file/grab_file.h>
+#include <ccan/tal/str/str.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <gmp.h>
+#include <sqlite3.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <zlib.h>
+
+int main(int argc, char *argv[])
+{
+	char *file, *new;
+
+	err_set_progname(argv[0]);
+
+	if (argc != 2)
+		errx(1, "Usage: %s <versionheader>", argv[0]);
+
+	file = grab_file(NULL, argv[1]);
+	if (!file && errno != ENOENT)
+		err(1, "Reading %s", argv[1]);
+
+	new = tal_fmt(NULL,
+		      "/* Generated file by tools/headerversions, do not edit! */\n"
+		      "/* GMP version: %s */\n"
+		      "/* SQLITE3 version: %u */\n"
+		      "/* ZLIB version: %s */\n",
+		      gmp_version,
+		      sqlite3_libversion_number(),
+		      zlibVersion());
+	if (!file || !streq(new, file)) {
+		int fd = open(argv[1], O_TRUNC|O_WRONLY|O_CREAT, 0666);
+		if (fd < 0)
+			err(1, "Writing %s", argv[1]);
+		if (!write_all(fd, new, strlen(new)))
+			err(1, "Writing to %s", argv[1]);
+		close(fd);
+	}
+	tal_free(new);
+	tal_free(file);
+	return 0;
+}

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -546,10 +546,6 @@ static struct db *db_open(const tal_t *ctx, char *filename)
 	struct db *db;
 	sqlite3 *sql;
 
-	if (SQLITE_VERSION_NUMBER != sqlite3_libversion_number())
-		db_fatal("SQLITE version mismatch: compiled %u, now %u",
-			 SQLITE_VERSION_NUMBER, sqlite3_libversion_number());
-
 	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 	err = sqlite3_open_v2(filename, &sql, flags, NULL);
 


### PR DESCRIPTION
@arowser 's #2158 PR drew my attention to this problem.  We have two other libraries for which this could be an issue, and generally static linking is a bad idea, as security updates are then omitted.

Unfortunately I can't find a statement on sqlite3's versioning which guarantees ABI compatibility across minor versions, so I'm reluctant to loosen the ABI check.  Though ubuntu obviously thought it ABI compatible...