### PR TITLE
Prefer direct routes when paying - alternate solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - JSON API: `pay` and `decodepay` accept and ignore `lightning:` prefixes.
 - pylightning: Allow either keyword arguments or positional arguments.
 - JSON-RPC: messages are now separated by 2 consecutive newlines.
+- JSON API: `pay` and `getroute` now strongly prefer a direct channel if one exists.
 
 ### Deprecated
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1121,7 +1121,6 @@ def test_pay_variants(node_factory):
     l1.rpc.pay(b11)
 
 
-@unittest.expectedFailure()
 def test_pay_direct(node_factory, bitcoind):
     """Check that we prefer the direct route.
     """

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1119,3 +1119,41 @@ def test_pay_variants(node_factory):
     b11 = 'LIGHTNING:' + l2.rpc.invoice(123000, 'test_pay_variants upper with prefix', 'description')['bolt11'].upper()
     l1.rpc.decodepay(b11)
     l1.rpc.pay(b11)
+
+
+@unittest.expectedFailure()
+def test_pay_direct(node_factory, bitcoind):
+    """Check that we prefer the direct route.
+    """
+    l1, l2, l3 = node_factory.get_nodes(3)
+
+    # Direct channel
+    l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    l1.fund_channel(l3, 10**7)
+    # Indirect route
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.fund_channel(l2, 10**7)
+    l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    c3 = l2.fund_channel(l3, 10**7)
+
+    # Let channels lock in.
+    bitcoind.generate_block(5)
+
+    # Make sure l1 knows the l2->l3 channel.
+    l1.wait_channel_active(c3)
+
+    # Find out how much msatoshi l1 owns on l1->l2 channel.
+    l1l2msatreference = only_one(l1.rpc.getpeer(l2.info['id'])['channels'])['msatoshi_to_us']
+
+    # Try multiple times to ensure that route randomization
+    # will not override our preference for direct route.
+    for i in range(8):
+        inv = l3.rpc.invoice(10000, 'pay{}'.format(i), 'desc')['bolt11']
+
+        l1.rpc.pay(inv)
+
+        # We should have gone the direct route, so
+        # l1->l2 channel msatoshi_to_us should not
+        # have changed.
+        l1l2msat = only_one(l1.rpc.getpeer(l2.info['id'])['channels'])['msatoshi_to_us']
+        assert l1l2msat == l1l2msatreference


### PR DESCRIPTION
Fixes: #2119 

Closes: #2144 

Alternate solution that tweaks `connection_fee` so it gives 0 fees for direct channels.