### PR TITLE
mocks: Drop invalid __sentinel__ value in generated mocks

### DIFF
--- a/tools/mockup.sh
+++ b/tools/mockup.sh
@@ -33,5 +33,5 @@ for SYMBOL; do
     END=$(tail -n "+${LINE}" < "$FILE" | grep -n ';$');
     NUM=${END%%:*}
 
-    tail -n "+${LINE}" < "$FILE" | head -n "$NUM" | sed 's/^extern *//' | sed 's/PRINTF_FMT([^)]*)//' | sed 's/NORETURN//g' | sed 's/,/ UNNEEDED,/g' | sed 's/\([a-z0-9A-Z*_]* [a-z0-9A-Z*_]*\));/\1 UNNEEDED);/' | sed "s/;\$/$STUB/" | sed 's/\s*$//'
+    tail -n "+${LINE}" < "$FILE" | head -n "$NUM" | sed 's/^extern *//' | sed 's/PRINTF_FMT([^)]*)//' | sed 's/NORETURN//g' | sed '/LAST_ARG_NULL//' | sed 's/,/ UNNEEDED,/g' | sed 's/\([a-z0-9A-Z*_]* [a-z0-9A-Z*_]*\));/\1 UNNEEDED);/' | sed "s/;\$/$STUB/" | sed 's/\s*$//'
 done


### PR DESCRIPTION
This was introduced in ed268d6c, which broke the mocks
generation. This just filters out the invalid sentinel value.