### PR TITLE
channeld: fix fee calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ changes.
 - JSON API: uppercase invoices now parsed correctly (broken in 0.6.2).
 - JSON API: commands are once again read even if one hasn't responded yet (broken in 0.6.2).
 - Protocol: allow lnd to send `update_fee` before `funding_locked`.
+- Protocol: fix limit on how much funder can send (fee was 1000x too small)
 - pylightning: handle multiple simultanous RPC replies reliably.
+
 
 ### Security
 

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -125,7 +125,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	 * 2. Calculate the base [commitment transaction
 	 * fee](#fee-calculation).
 	 */
-	base_fee_msat = commit_tx_base_fee(feerate_per_kw, untrimmed) * 1000;
+	base_fee_msat = commit_tx_base_fee_msat(feerate_per_kw, untrimmed);
 
 	SUPERVERBOSE("# base commitment transaction fee = %"PRIu64"\n",
 		     base_fee_msat / 1000);

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -414,7 +414,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 			- commit_tx_num_untrimmed(removing, feerate, dust,
 						  recipient);
 
-		fee_msat = commit_tx_base_fee(feerate, untrimmed) * 1000;
+		fee_msat = commit_tx_base_fee_msat(feerate, untrimmed);
 	} else
 		fee_msat = 0;
 
@@ -718,7 +718,7 @@ bool can_funder_afford_feerate(const struct channel *channel, u32 feerate_per_kw
 			- commit_tx_num_untrimmed(removing, feerate_per_kw, dust,
 						  !channel->funder);
 
-	fee_msat = commit_tx_base_fee(feerate_per_kw, untrimmed) * 1000;
+	fee_msat = commit_tx_base_fee_msat(feerate_per_kw, untrimmed);
 
 	/* BOLT #2:
 	 *

--- a/channeld/test/run-commit_tx.c
+++ b/channeld/test/run-commit_tx.c
@@ -916,8 +916,7 @@ int main(void)
 	/* Now make sure we cover case where funder can't afford the fee;
 	 * its output cannot go negative! */
 	for (;;) {
-		u64 base_fee_msat = commit_tx_base_fee(feerate_per_kw, 0)
-			* 1000;
+		u64 base_fee_msat = commit_tx_base_fee_msat(feerate_per_kw, 0);
 
 		if (base_fee_msat <= to_local_msat) {
 			feerate_per_kw++;

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -92,7 +92,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	 * 2. Calculate the base [commitment transaction
 	 * fee](#fee-calculation).
 	 */
-	base_fee_msat = commit_tx_base_fee(feerate_per_kw, untrimmed) * 1000;
+	base_fee_msat = commit_tx_base_fee_msat(feerate_per_kw, untrimmed);
 
 	/* BOLT #3:
 	 *

--- a/common/initial_commit_tx.h
+++ b/common/initial_commit_tx.h
@@ -18,8 +18,8 @@ u64 commit_number_obscurer(const struct pubkey *opener_payment_basepoint,
 			   const struct pubkey *accepter_payment_basepoint);
 
 /* Helper to calculate the base fee if we have this many htlc outputs */
-static inline u64 commit_tx_base_fee(u32 feerate_per_kw,
-				     size_t num_untrimmed_htlcs)
+static inline u64 commit_tx_base_fee_sat(u32 feerate_per_kw,
+					 size_t num_untrimmed_htlcs)
 {
 	u64 weight;
 
@@ -44,7 +44,14 @@ static inline u64 commit_tx_base_fee(u32 feerate_per_kw,
 	 *    3. Multiply `feerate_per_kw` by `weight`, divide by 1000 (rounding
 	 *    down).
 	 */
-	return feerate_per_kw * weight / 1000;
+	return (feerate_per_kw * weight / 1000);
+}
+
+static inline u64 commit_tx_base_fee_msat(u32 feerate_per_kw,
+					  size_t num_untrimmed_htlcs)
+{
+	return commit_tx_base_fee_sat(feerate_per_kw, num_untrimmed_htlcs)
+		* 1000;
 }
 
 /**

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -184,11 +184,11 @@ void peer_start_closingd(struct channel *channel,
 	 *    fee of the final commitment transaction, as calculated in
 	 *    [BOLT #3](03-transactions.md#fee-calculation).
 	 */
-	feelimit = commit_tx_base_fee(channel->channel_info.feerate_per_kw[LOCAL],
-				      0);
+	feelimit = commit_tx_base_fee_sat(channel->channel_info.feerate_per_kw[LOCAL],
+					  0);
 
 	/* Pick some value above slow feerate (or min possible if unknown) */
-	minfee = commit_tx_base_fee(feerate_min(ld, NULL), 0);
+	minfee = commit_tx_base_fee_sat(feerate_min(ld, NULL), 0);
 
 	/* If we can't determine feerate, start at half unilateral feerate. */
 	feerate = mutual_close_feerate(ld->topology);
@@ -197,7 +197,7 @@ void peer_start_closingd(struct channel *channel,
 		if (feerate < feerate_floor())
 			feerate = feerate_floor();
 	}
-	startfee = commit_tx_base_fee(feerate, 0);
+	startfee = commit_tx_base_fee_sat(feerate, 0);
 
 	if (startfee > feelimit)
 		startfee = feelimit;

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -120,7 +120,7 @@ def test_invoice_preimage(node_factory):
 def test_invoice_routeboost(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice.
     """
-    l1, l2 = node_factory.line_graph(2, fundamount=10**4)
+    l1, l2 = node_factory.line_graph(2, fundamount=2 * (10**4))
 
     # Won't get reference to route until channel is public.
     inv = l2.rpc.invoice(msatoshi=123456, label="inv0", description="?")
@@ -147,8 +147,8 @@ def test_invoice_routeboost(node_factory, bitcoind):
     l1.rpc.pay(inv['bolt11'])
     wait_channel_quiescent(l1, l2)
 
-    # Due to reserve, l1 doesn't have capacity to pay this.
-    inv = l2.rpc.invoice(msatoshi=10**7 - 123456, label="inv2", description="?")
+    # Due to reserve & fees, l1 doesn't have capacity to pay this.
+    inv = l2.rpc.invoice(msatoshi=2 * (10**7) - 123456, label="inv2", description="?")
     # Check warning
     assert 'warning_capacity' in inv
     assert 'warning_offline' not in inv

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -446,7 +446,7 @@ def test_sendpay_cant_afford(node_factory):
         pay(l1, l2, 10**9 + 1)
 
     # This is the fee, which needs to be taken into account for l1.
-    available = 10**9 - 13440
+    available = 10**9 - 13440000
     # Reserve is 1%.
     reserve = 10**7
 


### PR DESCRIPTION
Funder can't spend the fee it needs to pay for the commitment transaction:
we were not converting to millisatoshis, however!

This breaks our routeboost test, which no longer has sufficient funds to make payment.