### PR TITLE
mocks: Fix the mocks generation fix

### DIFF
--- a/tools/mockup.sh
+++ b/tools/mockup.sh
@@ -33,5 +33,5 @@ for SYMBOL; do
     END=$(tail -n "+${LINE}" < "$FILE" | grep -n ';$');
     NUM=${END%%:*}
 
-    tail -n "+${LINE}" < "$FILE" | head -n "$NUM" | sed 's/^extern *//' | sed 's/PRINTF_FMT([^)]*)//' | sed 's/NORETURN//g' | sed '/LAST_ARG_NULL//' | sed 's/,/ UNNEEDED,/g' | sed 's/\([a-z0-9A-Z*_]* [a-z0-9A-Z*_]*\));/\1 UNNEEDED);/' | sed "s/;\$/$STUB/" | sed 's/\s*$//'
+    tail -n "+${LINE}" < "$FILE" | head -n "$NUM" | sed 's/^extern *//' | sed 's/PRINTF_FMT([^)]*)//' | sed 's/NORETURN//g' | sed 's/LAST_ARG_NULL//g' | sed 's/,/ UNNEEDED,/g' | sed 's/\([a-z0-9A-Z*_]* [a-z0-9A-Z*_]*\));/\1 UNNEEDED);/' | sed "s/;\$/$STUB/" | sed 's/\s*$//'
 done


### PR DESCRIPTION
Turns out that I should have tested these with a new dependency
instead of just submitting. `sed` was missing the s command :slightly_frowning_face: 