### PR TITLE
plugin: Add missing context to tal_fmt call on error message

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -848,7 +848,7 @@ char *add_plugin_dir(struct plugins *plugins, const char *dir, bool nonexist_ok)
 	if (!d) {
 		if (nonexist_ok && errno == ENOENT)
 			return NULL;
-		return tal_fmt("Failed to open plugin-dir %s: %s",
+		return tal_fmt(NULL, "Failed to open plugin-dir %s: %s",
 			       dir, strerror(errno));
 	}
 


### PR DESCRIPTION
Seems the context parameter got lost somewhere.

Partial fix for #2179 