### PR TITLE
Fix logging race

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -520,11 +520,13 @@ char *arg_log_to_file(const char *arg, struct lightningd *ld)
 
 void opt_register_logging(struct lightningd *ld)
 {
-	opt_register_arg("--log-level", arg_log_level, show_log_level, ld->log,
-			 "log level (io, debug, info, unusual, broken)");
-	opt_register_arg("--log-prefix", arg_log_prefix, show_log_prefix,
-			 ld->log,
-			 "log prefix");
+	opt_register_early_arg("--log-level",
+			       arg_log_level, show_log_level, ld->log,
+			       "log level (io, debug, info, unusual, broken)");
+	opt_register_early_arg("--log-prefix", arg_log_prefix, show_log_prefix,
+			       ld->log,
+			       "log prefix");
+	/* We want this opened later, once we have moved to lightning dir */
 	opt_register_arg("--log-file=<file>", arg_log_to_file, NULL, ld,
 			 "log to file instead of stdout");
 }

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -502,6 +502,7 @@ static void setup_log_rotation(struct lightningd *ld)
 
 char *arg_log_to_file(const char *arg, struct lightningd *ld)
 {
+	const struct log_entry *i;
 	FILE *logf;
 
 	if (ld->logfile) {
@@ -515,6 +516,12 @@ char *arg_log_to_file(const char *arg, struct lightningd *ld)
 	if (!logf)
 		return tal_fmt(NULL, "Failed to open: %s", strerror(errno));
 	set_log_outfn(ld->log->lr, log_to_file, logf);
+
+	/* Catch up */
+	list_for_each(&ld->log->lr->log, i, list)
+		maybe_print(ld->log, i, 0);
+
+	log_debug(ld->log, "Opened log file %s", arg);
 	return NULL;
 }
 


### PR DESCRIPTION
We need to set logging levels and prefix earlier, otherwise we miss log_debug() events.  But we should also replay any prior log messages when opening the log file.