### PR TITLE
add optional static link options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,11 @@ CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLU
 CONFIGURATOR_CC := $(CC)
 
 LDFLAGS = $(PIE_LDFLAGS)
+ifeq ($(STATIC),1)
+LDLIBS = -static -L/usr/local/lib -lgmp -lsqlite3 -lm -lz -lpthread -ldl $(COVFLAGS)
+else
 LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
+endif
 
 default: all-programs all-test-programs
 

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ CONFIGURATOR_CC := $(CC)
 
 LDFLAGS = $(PIE_LDFLAGS)
 ifeq ($(STATIC),1)
-LDLIBS = -static -L/usr/local/lib -lgmp -lsqlite3 -lm -lz -lpthread -ldl $(COVFLAGS)
+LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp -lsqlite3 -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
 else
 LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
 endif

--- a/configure
+++ b/configure
@@ -10,6 +10,7 @@ CWARNFLAGS=${CWARNFLAGS:--Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-de
 CDEBUGFLAGS=${CDEBUGFLAGS:--std=gnu11 -g -fstack-protector}
 DEVELOPER=${DEVELOPER:-0}
 COMPAT=${COMPAT:-1}
+STATIC=${STATIC:-0}
 CONFIGURATOR_CC=${CONFIGURATOR_CC:-$CC}
 
 CONFIGURATOR=ccan/tools/configurator/configurator
@@ -53,6 +54,8 @@ usage()
     echo "    Compatibility mode, good to disable to see if your software breaks"
     usage_with_default "--enable/disable-valgrind" "(autodetect)"
     echo "    Valgrind binary to use for tests"
+    usage_with_default "--enable/disable-static" "$STATIC" "enable" "disable" 
+    echo "    Static link binary"
     exit 1
 }
 
@@ -109,6 +112,8 @@ for opt in "$@"; do
 	--disable-compat) COMPAT=0;;
 	--enable-valgrind) VALGRIND=1;;
 	--disable-valgrind) VALGRIND=0;;
+	--enable-static) STATIC=1;;
+	--disable-static) STATIC=0;;
 	--help|-h) usage;;
 	*)
 	    echo "Unknown option '$opt'" >&2
@@ -146,6 +151,7 @@ add_var DEVELOPER "$DEVELOPER" $CONFIG_HEADER
 add_var EXPERIMENTAL_FEATURES "$EXPERIMENTAL_FEATURES" $CONFIG_HEADER
 add_var COMPAT "$COMPAT" $CONFIG_HEADER
 add_var PYTEST "$PYTEST"
+add_var STATIC "$STATIC"
 
 # Hack to avoid sha256 name clash with libwally: will be fixed when that
 # becomes a standalone shared lib.


### PR DESCRIPTION
As @NicolasDorier suggestion, in #2175,  add a optional static link for sqlite3, gmp, zlib, its useful in cross build to avoid rebuild these library in raspberry.