### PR TITLE
update pytest check when configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ check:
 	$(MAKE) pytest
 
 pytest: $(ALL_PROGRAMS)
-ifndef PYTEST
+ifeq ($(PYTEST),)
 	@echo "py.test is required to run the integration tests, please install using 'pip3 install -r tests/requirements.txt', and rerun 'configure'."
 	exit 1
 else

--- a/configure
+++ b/configure
@@ -62,7 +62,11 @@ usage()
 
 add_var()
 {
-    echo "Setting $1... $2"
+    if [ -n "$2" ]; then
+        echo "Setting $1... $2"
+    else
+        echo "$1 not found"
+    fi
     echo "$1=$2" >> $CONFIG_VAR_FILE
     [ -z "$3" ] || echo "#define $1 $2" >> "$3"
 }

--- a/configure
+++ b/configure
@@ -82,7 +82,7 @@ find_pytest()
     for p in $PYTHON_BINS; do
         if [ "$(which $p)" != "" ] ; then
             $p --version 2>&1 | grep -q "Python 3." || continue
-            if $p -c "import pytest" ; then
+            if $p -c "import pytest" 2>/dev/null ; then
                 echo "$p -m pytest"
                 return
             fi


### PR DESCRIPTION
If no pytest in system:
1. The configure show importError, its better to hide this message.
```
 ./configure
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named 'pytest'
```
2. configure print PYTEST is null.
```
Setting COMPAT... 1
Setting PYTEST... 
Setting STATIC... 0
```

So this PR hide the pytest check message, and set PYTEST var to 0 if not find pytest.

