### PR TITLE
plugin: Add notifications from lightningd to plugins (Plugin Saga, 3rd reprise)

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -24,5 +24,15 @@ def init(options, configuration, plugin):
     plugin.log("Plugin helloworld.py initialized")
 
 
+@plugin.subscribe("connect")
+def on_connect(id, address, plugin):
+    plugin.log("Received connect event for peer {}".format(id))
+
+
+@plugin.subscribe("disconnect")
+def on_disconnect(id, plugin):
+    plugin.log("Received disconnect event for peer {}".format(id))
+
+
 plugin.add_option('greeting', 'Hello', 'The greeting I should use.')
 plugin.run()

--- a/contrib/pylightning/lightning/plugin.py
+++ b/contrib/pylightning/lightning/plugin.py
@@ -2,6 +2,7 @@ import sys
 import os
 import json
 import inspect
+import re
 import traceback
 
 
@@ -241,6 +242,7 @@ class Plugin(object):
                 continue
 
             doc = inspect.getdoc(func)
+            doc = re.sub('\n+', ' ', doc)
             if not doc:
                 self.log(
                     'RPC method \'{}\' does not have a docstring.'.format(name)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -78,6 +78,10 @@ this example:
 			"description": "Returns the current time in {timezone}",
 			"long_description": "Returns the current time in the timezone that is given as the only parameter.\nThis description may be quite long and is allowed to span multiple lines."
 		}
+	],
+	"subscriptions": [
+		"connect",
+		"disconnect"
 	]
 }
 ```
@@ -109,8 +113,12 @@ simple JSON object containing the options:
 
 ```json
 {
-	"objects": {
+	"options": {
 		"greeting": "World"
+	},
+	"configuration": {
+		 "lightning-dir": "/home/user/.lightning",
+		 "rpc-file": "lightning-rpc"
 	}
 }
 ```
@@ -120,10 +128,98 @@ arbitrary and will currently be discarded by `lightningd`. JSON-RPC
 commands were chosen over notifications in order not to force plugins
 to implement notifications which are not that well supported.
 
-## Event stream subscriptions
+## JSON-RPC passthrough
 
-*TBD*
+Plugins may register their own JSON-RPC methods that are exposed
+through the JSON-RPC provided by `lightningd`. This provides users
+with a single interface to interact with, while allowing the addition
+of custom methods without having to modify the daemon itself.
 
+JSON-RPC methods are registered as part of the `getmanifest`
+result. Each registered method must provide a `name` and a
+`description`. An optional `long_description` may also be
+provided. This information is then added to the internal dispatch
+table, and used to return the help text when using `lightning-cli
+help`, and the methods can be called using the `name`.
+
+For example the above `getmanifest` result will register two methods,
+called `hello` and `gettime`:
+
+```json
+    ...
+	"rpcmethods": [
+		{
+			"name": "hello",
+			"description": "Returns a personalized greeting for {greeting} (set via options)."
+		},
+		{
+			"name": "gettime",
+			"description": "Returns the current time in {timezone}",
+			"long_description": "Returns the current time in the timezone that is given as the only parameter.\nThis description may be quite long and is allowed to span multiple lines."
+		}
+	],
+	...
+```
+
+The RPC call will be passed through unmodified, with the exception of
+the JSON-RPC call `id`, which is internally remapped to a unique
+integer instead, in order to avoid collisions. When passing the result
+back the `id` field is restored to its original value.
+
+## Event notifications
+
+Event notifications allow a plugin to subscribe to events in
+`lightningd`. `lightningd` will then send a push notification if an
+event matching the subscription occurred. A notification is defined in
+the JSON-RPC [specification][jsonrpc-spec] as an RPC call that does
+not include an `id` parameter:
+
+> A Notification is a Request object without an "id" member. A Request
+> object that is a Notification signifies the Client's lack of
+> interest in the corresponding Response object, and as such no
+> Response object needs to be returned to the client. The Server MUST
+> NOT reply to a Notification, including those that are within a batch
+> request.
+>
+> Notifications are not confirmable by definition, since they do not
+> have a Response object to be returned. As such, the Client would not
+> be aware of any errors (like e.g. "Invalid params","Internal
+> error").
+
+Plugins subscribe by returning an array of subscriptions as part of
+the `getmanifest` response. The result for the `getmanifest` call
+above for example subscribes to the two topics `connect` and
+`disconnect`. The topics that are currently defined and the
+corresponding payloads are listed below.
+
+### Notification Types
+
+#### `connect`
+
+A notification for topic `connect` is sent every time a new connection
+to a peer is established.
+
+```json
+{
+	"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
+	"address": "1.2.3.4"
+}
+```
+
+#### `disconnect`
+
+A notification for topic `disconnect` is sent every time a connection
+to a peer was lost.
+
+```json
+{
+	"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+}
+```
 ## Hooks
 
 *TBD*
+
+
+[jsonrpc-spec]: https://www.jsonrpc.org/specification
+[jsonrpc-notification-spec]: https://www.jsonrpc.org/specification#notification

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -73,6 +73,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/log.c			\
 	lightningd/log_status.c			\
 	lightningd/memdump.c			\
+	lightningd/notification.c		\
 	lightningd/onchain_control.c		\
 	lightningd/opening_control.c		\
 	lightningd/options.c			\

--- a/lightningd/json_stream.c
+++ b/lightningd/json_stream.c
@@ -59,6 +59,17 @@ struct json_stream *new_json_stream(const tal_t *ctx, struct command *writer)
 	return js;
 }
 
+struct json_stream *json_stream_dup(const tal_t *ctx, struct json_stream *original)
+{
+	size_t num_elems = membuf_num_elems(&original->outbuf);
+	char *elems = membuf_elems(&original->outbuf);
+	struct json_stream *js = tal_dup(ctx, struct json_stream, original);
+	membuf_init(&js->outbuf, tal_dup_arr(js, char, elems, num_elems, 0),
+		    num_elems, membuf_tal_realloc);
+	membuf_added(&js->outbuf, num_elems);
+	return js;
+}
+
 bool json_stream_still_writing(const struct json_stream *js)
 {
 	return js->writer != NULL;

--- a/lightningd/json_stream.h
+++ b/lightningd/json_stream.h
@@ -24,6 +24,19 @@ struct json_stream;
 struct json_stream *new_json_stream(const tal_t *ctx, struct command *writer);
 
 /**
+ * Duplicate an existing stream.
+ *
+ * Mostly useful when we want to send copies of a given stream to
+ * multiple recipients, that might read at different speeds from the
+ * stream. For example this is used when construcing a single
+ * notification and then duplicating it for the fanout.
+ *
+ * @ctx: tal context for allocation.
+ * @original: the stream to duplicate.
+ */
+struct json_stream *json_stream_dup(const tal_t *ctx, struct json_stream *original);
+
+/**
  * json_stream_close - finished writing to a JSON stream.
  * @js: the json_stream.
  * @writer: object responsible for writing to this stream.

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1004,6 +1004,26 @@ static struct command_result *param_command(struct command *cmd,
 			    tok->end - tok->start, buffer + tok->start);
 }
 
+struct jsonrpc_notification *jsonrpc_notification_start(const tal_t *ctx, const char *method)
+{
+	struct jsonrpc_notification *n = tal(ctx, struct jsonrpc_notification);
+	n->method = tal_strdup(n, method);
+	n->stream = new_json_stream(n, NULL);
+	json_object_start(n->stream, NULL);
+	json_add_string(n->stream, "jsonrpc", "2.0");
+	json_add_string(n->stream, "method", method);
+	json_object_start(n->stream, "params");
+
+	return n;
+}
+
+void jsonrpc_notification_end(struct jsonrpc_notification *n)
+{
+	json_object_end(n->stream); /* closes '.params' */
+	json_object_end(n->stream); /* closes '.' */
+	json_stream_append(n->stream, "\n\n");
+}
+
 /* We add this destructor as a canary to detect cmd failing. */
 static void destroy_command_canary(struct command *cmd, bool *failed)
 {

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -58,6 +58,14 @@ struct json_command {
 	const char *verbose;
 };
 
+struct jsonrpc_notification {
+	/* The topic that this notification is for. Internally this
+	 * will be serialized as "method", hence the different name
+	 * here */
+	const char *method;
+	struct json_stream *stream;
+};
+
 /**
  * json_stream_success - start streaming a successful json result.
  * @cmd: the command we're running.
@@ -161,6 +169,19 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command);
  * JSON-RPC dispatch table by its name.
  */
 void jsonrpc_command_remove(struct jsonrpc *rpc, const char *method);
+
+/**
+ * Begin a JSON-RPC notification with the specified topic.
+ *
+ * Automatically starts the `params` object, hence only key-value
+ * based params are supported at the moment.
+ */
+struct jsonrpc_notification *jsonrpc_notification_start(const tal_t *ctx, const char *topic);
+
+/**
+ * Counterpart to jsonrpc_notification_start.
+ */
+void jsonrpc_notification_end(struct jsonrpc_notification *n);
 
 AUTODATA_TYPE(json_command, struct json_command);
 #endif /* LIGHTNING_LIGHTNINGD_JSONRPC_H */

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -1,0 +1,13 @@
+#include "lightningd/notification.h"
+#include <ccan/array_size/array_size.h>
+
+const char *notification_topics[] = {
+};
+
+bool notifications_have_topic(const char *topic)
+{
+	for (size_t i=0; ARRAY_SIZE(notification_topics); i++)
+		if (streq(topic, notification_topics[i]))
+			return true;
+	return false;
+}

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -2,6 +2,8 @@
 #include <ccan/array_size/array_size.h>
 
 const char *notification_topics[] = {
+	"connect",
+	"disconnect",
 };
 
 bool notifications_have_topic(const char *topic)
@@ -10,4 +12,24 @@ bool notifications_have_topic(const char *topic)
 		if (streq(topic, notification_topics[i]))
 			return true;
 	return false;
+}
+
+void notify_connect(struct lightningd *ld, struct pubkey *nodeid,
+		    struct wireaddr_internal *addr)
+{
+	struct jsonrpc_notification *n =
+	    jsonrpc_notification_start(NULL, notification_topics[0]);
+	json_add_pubkey(n->stream, "id", nodeid);
+	json_add_address_internal(n->stream, "address", addr);
+	jsonrpc_notification_end(n);
+	plugins_notify(ld->plugins, take(n));
+}
+
+void notify_disconnect(struct lightningd *ld, struct pubkey *nodeid)
+{
+	struct jsonrpc_notification *n =
+	    jsonrpc_notification_start(NULL, notification_topics[1]);
+	json_add_pubkey(n->stream, "id", nodeid);
+	jsonrpc_notification_end(n);
+	plugins_notify(ld->plugins, take(n));
 }

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -1,0 +1,9 @@
+#ifndef LIGHTNING_LIGHTNINGD_NOTIFICATION_H
+#define LIGHTNING_LIGHTNINGD_NOTIFICATION_H
+#include "config.h"
+#include <lightningd/jsonrpc.h>
+#include <lightningd/plugin.h>
+
+bool notifications_have_topic(const char *topic);
+
+#endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -2,8 +2,13 @@
 #define LIGHTNING_LIGHTNINGD_NOTIFICATION_H
 #include "config.h"
 #include <lightningd/jsonrpc.h>
+#include <lightningd/lightningd.h>
 #include <lightningd/plugin.h>
 
 bool notifications_have_topic(const char *topic);
+
+void notify_connect(struct lightningd *ld, struct pubkey *nodeid,
+		    struct wireaddr_internal *addr);
+void notify_disconnect(struct lightningd *ld, struct pubkey *nodeid);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -21,6 +21,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/notification.h>
 #include <lightningd/opening_control.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
@@ -85,6 +86,7 @@ static void uncommitted_channel_disconnect(struct uncommitted_channel *uc,
 	subd_send_msg(uc->peer->ld->connectd, msg);
 	if (uc->fc)
 		was_pending(command_fail(uc->fc->cmd, LIGHTNINGD, "%s", desc));
+	notify_disconnect(uc->peer->ld, &uc->peer->id);
 }
 
 void kill_uncommitted_channel(struct uncommitted_channel *uc,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -38,6 +38,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/log.h>
 #include <lightningd/memdump.h>
+#include <lightningd/notification.h>
 #include <lightningd/onchain_control.h>
 #include <lightningd/opening_control.h>
 #include <lightningd/options.h>
@@ -381,6 +382,7 @@ void channel_errmsg(struct channel *channel,
 
 	/* Make sure channel_fail_permanent doesn't tell connectd we died! */
 	channel->connected = false;
+	notify_disconnect(channel->peer->ld, &channel->peer->id);
 
 	/* BOLT #1:
 	 *
@@ -503,6 +505,8 @@ void peer_connected(struct lightningd *ld, const u8 *msg,
 		}
 		abort();
 	}
+
+	notify_connect(ld, &id, &addr);
 
 	/* No err, all good. */
 	error = NULL;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <lightningd/json.h>
 #include <lightningd/lightningd.h>
+#include <lightningd/notification.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -60,6 +61,9 @@ struct plugin {
 	/* Timer to add a timeout to some plugin RPC calls. Used to
 	 * guarantee that `getmanifest` doesn't block indefinitely. */
 	const struct oneshot *timeout_timer;
+
+	/* An array of subscribed topics */
+	char **subscriptions;
 };
 
 struct plugin_request {
@@ -765,6 +769,46 @@ static bool plugin_rpcmethods_add(struct plugin *plugin,
 	return true;
 }
 
+static bool plugin_subscriptions_add(struct plugin *plugin, const char *buffer,
+				     const jsmntok_t *resulttok)
+{
+	const jsmntok_t *subscriptions =
+	    json_get_member(buffer, resulttok, "subscriptions");
+
+	if (!subscriptions) {
+		plugin->subscriptions = NULL;
+		return true;
+	}
+	plugin->subscriptions = tal_arr(plugin, char *, 0);
+	if (subscriptions->type != JSMN_ARRAY) {
+		plugin_kill(plugin, "\"result.subscriptions\" is not an array");
+		return false;
+	}
+
+	for (int i = 0; i < subscriptions->size; i++) {
+		char *topic;
+		const jsmntok_t *s = json_get_arr(subscriptions, i);
+		if (s->type != JSMN_STRING) {
+			plugin_kill(
+			    plugin,
+			    "result.subscriptions[%d] is not a string: %s", i,
+			    plugin->buffer);
+			return false;
+		}
+		topic = json_strdup(plugin, plugin->buffer, s);
+
+		if (!notifications_have_topic(topic)) {
+			plugin_kill(
+			    plugin,
+			    "topic '%s' is not a known notification topic", topic);
+			return false;
+		}
+
+		*tal_arr_expand(&plugin->subscriptions) = topic;
+	}
+	return true;
+}
+
 static void plugin_manifest_timeout(struct plugin *plugin)
 {
 	log_broken(plugin->log, "The plugin failed to respond to \"getmanifest\" in time, terminating.");
@@ -796,8 +840,11 @@ static void plugin_manifest_cb(const struct plugin_request *req,
 	}
 
 	if (!plugin_opts_add(plugin, buffer, resulttok)
-	    || !plugin_rpcmethods_add(plugin, buffer, resulttok))
-		plugin_kill(plugin, "Failed to register options or methods");
+	    || !plugin_rpcmethods_add(plugin, buffer, resulttok)
+	    || !plugin_subscriptions_add(plugin, buffer, resulttok))
+		plugin_kill(
+		    plugin,
+		    "Failed to register options, methods, or subscriptions.");
 	/* Reset timer, it'd kill us otherwise. */
 	tal_free(plugin->timeout_timer);
 }

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1054,3 +1054,28 @@ void json_add_opt_plugins(struct json_stream *response,
 		json_add_string(response, "plugin", p->cmd);
 	}
 }
+
+/**
+ * Determine whether a plugin is subscribed to a given topic/method.
+ */
+static bool plugin_subscriptions_contains(struct plugin *plugin,
+					  const char *method)
+{
+	for (size_t i = 0; i < tal_count(plugin->subscriptions); i++)
+		if (streq(method, plugin->subscriptions[i]))
+			return true;
+
+	return false;
+}
+
+void plugins_notify(struct plugins *plugins,
+		    const struct jsonrpc_notification *n TAKES)
+{
+	struct plugin *p;
+	list_for_each(&plugins->plugins, p, list) {
+		if (plugin_subscriptions_contains(p, n->method))
+			plugin_send(p, json_stream_dup(p, n->stream));
+	}
+	if (taken(n))
+		tal_free(n);
+}

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -79,4 +79,7 @@ char *add_plugin_dir(struct plugins *plugins, const char *dir,
  */
 void clear_plugins(struct plugins *plugins);
 
+void plugins_notify(struct plugins *plugins,
+		    const struct jsonrpc_notification *n TAKES);
+
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_H */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -240,6 +240,13 @@ struct oneshot *new_reltimer_(struct timers *timers UNNEEDED,
 			      struct timerel expire UNNEEDED,
 			      void (*cb)(void *) UNNEEDED, void *arg UNNEEDED)
 { fprintf(stderr, "new_reltimer_ called!\n"); abort(); }
+/* Generated stub for notify_connect */
+void notify_connect(struct lightningd *ld UNNEEDED, struct pubkey *nodeid UNNEEDED,
+		    struct wireaddr_internal *addr UNNEEDED)
+{ fprintf(stderr, "notify_connect called!\n"); abort(); }
+/* Generated stub for notify_disconnect */
+void notify_disconnect(struct lightningd *ld UNNEEDED, struct pubkey *nodeid UNNEEDED)
+{ fprintf(stderr, "notify_disconnect called!\n"); abort(); }
 /* Generated stub for null_response */
 struct json_stream *null_response(struct command *cmd UNNEEDED)
 { fprintf(stderr, "null_response called!\n"); abort(); }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,6 +83,18 @@ def test_plugin_disable(node_factory):
         n.rpc.hello(name='Sun')
 
 
+def test_plugin_notifications(node_factory):
+    l1, l2 = node_factory.get_nodes(2, opts={'plugin': 'contrib/plugins/helloworld.py'})
+
+    l1.connect(l2)
+    l1.daemon.wait_for_log(r'Received connect event')
+    l2.daemon.wait_for_log(r'Received connect event')
+
+    l2.rpc.disconnect(l1.info['id'])
+    l1.daemon.wait_for_log(r'Received disconnect event')
+    l2.daemon.wait_for_log(r'Received disconnect event')
+
+
 def test_failing_plugins():
     fail_plugins = [
         'contrib/plugins/fail/failtimeout.py',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -385,11 +385,17 @@ class LightningNode(object):
         self.may_fail = may_fail
         self.may_reconnect = may_reconnect
 
+    def connect(self, remote_node):
+            self.rpc.connect(remote_node.info['id'], '127.0.0.1', remote_node.daemon.port)
+
+    def is_connected(self, remote_node):
+        return remote_node.info['id'] in [p['id'] for p in self.rpc.listpeers()['peers']]
+
     def openchannel(self, remote_node, capacity, addrtype="p2sh-segwit", confirm=True, wait_for_announce=True, connect=True):
         addr, wallettxid = self.fundwallet(10 * capacity, addrtype)
 
-        if connect and remote_node.info['id'] not in [p['id'] for p in self.rpc.listpeers()['peers']]:
-            self.rpc.connect(remote_node.info['id'], '127.0.0.1', remote_node.daemon.port)
+        if connect and not self.is_connected(remote_node):
+            self.connect(remote_node)
 
         fundingtx = self.rpc.fundchannel(remote_node.info['id'], capacity)
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -292,6 +292,13 @@ void log_add(struct log *log UNNEEDED, const char *fmt UNNEEDED, ...)
 void log_io(struct log *log UNNEEDED, enum log_level dir UNNEEDED, const char *comment UNNEEDED,
 	    const void *data UNNEEDED, size_t len UNNEEDED)
 { fprintf(stderr, "log_io called!\n"); abort(); }
+/* Generated stub for notify_connect */
+void notify_connect(struct lightningd *ld UNNEEDED, struct pubkey *nodeid UNNEEDED,
+		    struct wireaddr_internal *addr UNNEEDED)
+{ fprintf(stderr, "notify_connect called!\n"); abort(); }
+/* Generated stub for notify_disconnect */
+void notify_disconnect(struct lightningd *ld UNNEEDED, struct pubkey *nodeid UNNEEDED)
+{ fprintf(stderr, "notify_disconnect called!\n"); abort(); }
 /* Generated stub for null_response */
 struct json_stream *null_response(struct command *cmd UNNEEDED)
 { fprintf(stderr, "null_response called!\n"); abort(); }


### PR DESCRIPTION
We're nearing the end of the endless plugin saga, with this new feature. It allows plugins to subscribe to a number of notifications/events that will then be streamed from `lightningd` to the plugin when something happens.

Notice that, while this provides the infrastructure, I've only implemented two very simple notification topics (`connect` and `disconnect`). We can (and will) add more as we come up with new use-cases.