### PR TITLE
Do not produce bad onions on malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ changes.
 - JSON API: commands are once again read even if one hasn't responded yet (broken in 0.6.2).
 - Protocol: allow lnd to send `update_fee` before `funding_locked`.
 - Protocol: fix limit on how much funder can send (fee was 1000x too small)
+- Protocol: don't send invalid onion errors if peer says onion was bad.
 - pylightning: handle multiple simultanous RPC replies reliably.
 
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 
 ifeq ($(COMPAT),1)
 # We support compatibility with pre-0.6.
-COMPAT_CFLAGS=-DCOMPAT_V052=1 -DCOMPAT_V060=1 -DCOMPAT_V061=1
+COMPAT_CFLAGS=-DCOMPAT_V052=1 -DCOMPAT_V060=1 -DCOMPAT_V061=1 -DCOMPAT_V062=1
 endif
 
 # Timeout shortly before the 600 second travis silence timeout

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -532,7 +532,6 @@ static struct secret *get_shared_secret(const tal_t *ctx,
 					enum onion_type *why_bad,
 					struct sha256 *next_onion_sha)
 {
-	struct pubkey ephemeral;
 	struct onionpacket *op;
 	struct secret *secret = tal(ctx, struct secret);
 	const u8 *msg;
@@ -545,8 +544,7 @@ static struct secret *get_shared_secret(const tal_t *ctx,
 		return tal_free(secret);
 
 	/* Because wire takes struct pubkey. */
-	ephemeral.pubkey = op->ephemeralkey;
-	msg = hsm_req(tmpctx, towire_hsm_ecdh_req(tmpctx, &ephemeral));
+	msg = hsm_req(tmpctx, towire_hsm_ecdh_req(tmpctx, &op->ephemeralkey));
 	if (!fromwire_hsm_ecdh_resp(msg, secret))
 		status_failed(STATUS_FAIL_HSM_IO, "Reading ecdh response");
 

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -534,9 +534,12 @@ static struct secret *get_shared_secret(const tal_t *ctx,
 	struct onionpacket *op;
 	struct secret *secret = tal(ctx, struct secret);
 	const u8 *msg;
+	/* FIXME: Use this! */
+	enum onion_type why_bad;
 
 	/* We unwrap the onion now. */
-	op = parse_onionpacket(tmpctx, htlc->routing, TOTAL_PACKET_SIZE);
+	op = parse_onionpacket(tmpctx, htlc->routing, TOTAL_PACKET_SIZE,
+			       &why_bad);
 	if (!op)
 		return tal_free(secret);
 

--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -23,6 +23,8 @@ struct htlc {
 
 	/* The routing shared secret (only for incoming) */
 	struct secret *shared_secret;
+	/* If incoming HTLC has shared_secret, this is which BADONION error */
+	enum onion_type why_bad_onion;
 
 	/* FIXME: We could union these together: */
 	/* Routing information sent with this HTLC. */

--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -25,6 +25,8 @@ struct htlc {
 	struct secret *shared_secret;
 	/* If incoming HTLC has shared_secret, this is which BADONION error */
 	enum onion_type why_bad_onion;
+	/* sha256 of next_onion, in case peer says it was malformed. */
+	struct sha256 next_onion_sha;
 
 	/* FIXME: We could union these together: */
 	/* Routing information sent with this HTLC. */

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -23,7 +23,7 @@ struct onionpacket {
 	/* Cleartext information */
 	u8 version;
 	u8 mac[SECURITY_PARAMETER];
-	secp256k1_pubkey ephemeralkey;
+	struct pubkey ephemeralkey;
 
 	/* Encrypted information */
 	u8 routinginfo[ROUTING_INFO_SIZE];

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -9,6 +9,7 @@
 #include <ccan/tal/tal.h>
 #include <secp256k1.h>
 #include <sodium/randombytes.h>
+#include <wire/gen_onion_wire.h>
 #include <wire/wire.h>
 
 #define SECURITY_PARAMETER 32
@@ -148,13 +149,13 @@ u8 *serialize_onionpacket(
  *
  * @ctx: tal context to allocate from
  * @src: buffer to read the packet from
- * @srclen: length of the @src
+ * @srclen: length of the @src (must be TOTAL_PACKET_SIZE)
+ * @why_bad: if NULL return, this is what was wrong with the packet.
  */
-struct onionpacket *parse_onionpacket(
-	const tal_t *ctx,
-	const void *src,
-	const size_t srclen
-	);
+struct onionpacket *parse_onionpacket(const tal_t *ctx,
+				      const void *src,
+				      const size_t srclen,
+				      enum onion_type *why_bad);
 
 struct onionreply {
 	/* Node index in the path that is replying */

--- a/connectd/handshake.h
+++ b/connectd/handshake.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_CONNECTD_HANDSHAKE_H
 #define LIGHTNING_CONNECTD_HANDSHAKE_H
 #include "config.h"
+#include <ccan/tal/tal.h>
 #include <ccan/typesafe_cb/typesafe_cb.h>
 
 struct crypto_state;
@@ -52,5 +53,5 @@ struct io_plan *responder_handshake_(struct io_conn *conn,
 				     void *cbarg);
 
 /* helper which is defined in connect.c */
-bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point);
+struct secret *hsm_do_ecdh(const tal_t *ctx, const struct pubkey *point);
 #endif /* LIGHTNING_CONNECTD_HANDSHAKE_H */

--- a/connectd/test/run-initiator-success.c
+++ b/connectd/test/run-initiator-success.c
@@ -190,10 +190,13 @@ static struct io_plan *success(struct io_conn *conn UNUSED,
 	exit(0);
 }
 
-bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point)
+struct secret *hsm_do_ecdh(const tal_t *ctx, const struct pubkey *point)
 {
-	return secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
-			      ls_priv.secret.data) == 1;
+	struct secret *ss = tal(ctx, struct secret);
+	if (secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
+			   ls_priv.secret.data) != 1)
+		return tal_free(ss);
+	return ss;
 }
 
 int main(void)

--- a/connectd/test/run-responder-success.c
+++ b/connectd/test/run-responder-success.c
@@ -187,10 +187,13 @@ static struct io_plan *success(struct io_conn *conn UNUSED,
 	exit(0);
 }
 
-bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point)
+struct secret *hsm_do_ecdh(const tal_t *ctx, const struct pubkey *point)
 {
-	return secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
-			      ls_priv.secret.data) == 1;
+	struct secret *ss = tal(ctx, struct secret);
+	if (secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
+			   ls_priv.secret.data) != 1)
+		return tal_free(ss);
+	return ss;
 }
 
 int main(void)

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -14,7 +14,8 @@ DEVTOOLS_COMMON_OBJS :=				\
 	common/type_to_string.o			\
 	common/utils.o				\
 	common/version.o			\
-	common/wireaddr.o
+	common/wireaddr.o			\
+	wire/gen_onion_wire.o
 
 devtools-all: $(DEVTOOLS)
 

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -72,12 +72,13 @@ void peer_failed_connection_lost(void)
 	exit(0);
 }
 
-bool hsm_do_ecdh(struct secret *ss, const struct pubkey *point)
+struct secret *hsm_do_ecdh(const tal_t *ctx, const struct pubkey *point)
 {
+	struct secret *ss = tal(ctx, struct secret);
 	if (secp256k1_ecdh(secp256k1_ctx, ss->data, &point->pubkey,
 			   notsosecret.data) != 1)
-		errx(1, "ECDH failed");
-	return true;
+		return tal_free(ss);
+	return ss;
 }
 
 /* We don't want to discard *any* messages. */

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -66,6 +66,7 @@ static void do_decode(int argc, char **argv)
 	memset(hextemp, 0, sizeof(hextemp));
 	u8 shared_secret[32];
 	u8 assocdata[32];
+	enum onion_type why_bad;
 
 	memset(&assocdata, 'B', sizeof(assocdata));
 
@@ -82,10 +83,10 @@ static void do_decode(int argc, char **argv)
 		errx(1, "Invalid onion hex '%s'", hextemp);
 	}
 
-	msg = parse_onionpacket(ctx, serialized, sizeof(serialized));
+	msg = parse_onionpacket(ctx, serialized, sizeof(serialized), &why_bad);
 
 	if (!msg)
-		errx(1, "Error parsing message.");
+		errx(1, "Error parsing message: %s", onion_type_name(why_bad));
 
 	if (!onion_shared_secret(shared_secret, msg, &seckey))
 		errx(1, "Error creating shared secret.");

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -554,8 +554,8 @@ static struct io_plan *handle_ecdh(struct io_conn *conn,
 	if (!fromwire_hsm_ecdh_req(msg_in, &point))
 		return bad_req(conn, c, msg_in);
 
-	/*~ We simply use the secp256k1_ecdh function, which really shouldn't
-	 * fail (iff the point is invalid). */
+	/*~ We simply use the secp256k1_ecdh function: if ss.data is invalid,
+	 * we kill them for bad randomness (~1 in 2^127 if ss.data is random) */
 	node_key(&privkey, NULL);
 	if (secp256k1_ecdh(secp256k1_ctx, ss.data, &point.pubkey,
 			   privkey.secret.data) != 1) {

--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -111,7 +111,7 @@ struct htlc_in *new_htlc_in(const tal_t *ctx,
 			    struct channel *channel, u64 id,
 			    u64 msatoshi, u32 cltv_expiry,
 			    const struct sha256 *payment_hash,
-			    const struct secret *shared_secret,
+			    const struct secret *shared_secret TAKES,
 			    const u8 *onion_routing_packet)
 {
 	struct htlc_in *hin = tal(ctx, struct htlc_in);
@@ -122,7 +122,10 @@ struct htlc_in *new_htlc_in(const tal_t *ctx,
 	hin->msatoshi = msatoshi;
 	hin->cltv_expiry = cltv_expiry;
 	hin->payment_hash = *payment_hash;
-	hin->shared_secret = *shared_secret;
+	if (shared_secret)
+		hin->shared_secret = tal_dup(hin, struct secret, shared_secret);
+	else
+		hin->shared_secret = NULL;
 	memcpy(hin->onion_routing_packet, onion_routing_packet,
 	       sizeof(hin->onion_routing_packet));
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -31,8 +31,8 @@ struct htlc_in {
 	/* Onion information */
 	u8 onion_routing_packet[TOTAL_PACKET_SIZE];
 
-	/* Shared secret for us to send any failure message. */
-	struct secret shared_secret;
+	/* Shared secret for us to send any failure message (NULL if malformed) */
+	struct secret *shared_secret;
 
 	/* If a local error, this is non-zero. */
 	enum onion_type failcode;
@@ -124,7 +124,7 @@ struct htlc_in *new_htlc_in(const tal_t *ctx,
 			    struct channel *channel, u64 id,
 			    u64 msatoshi, u32 cltv_expiry,
 			    const struct sha256 *payment_hash,
-			    const struct secret *shared_secret,
+			    const struct secret *shared_secret TAKES,
 			    const u8 *onion_routing_packet);
 
 /* You need to set the ID, then connect_htlc_out this! */

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -359,10 +359,8 @@ remote_routing_failure(const tal_t *ctx,
 		/* If the error is a BADONION, then it's on behalf of the
 		 * following node. */
 		if (failcode & BADONION) {
-			log_debug(log, "failcode %u => erring_node %s",
-			    failcode,
-			    type_to_string(tmpctx, struct pubkey,
-					   &route_nodes[origin_index + 1]));
+			log_debug(log, "failcode %u from onionreply %s",
+				  failcode, tal_hex(tmpctx, failure->msg));
 			erring_node = &route_nodes[origin_index + 1];
 		} else
 			erring_node = &route_nodes[origin_index];

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -648,7 +648,8 @@ static bool peer_accepted_htlc(struct channel *channel,
 
 	/* channeld tests this, so it should pass. */
 	op = parse_onionpacket(tmpctx, hin->onion_routing_packet,
-			       sizeof(hin->onion_routing_packet));
+			       sizeof(hin->onion_routing_packet),
+			       failcode);
 	if (!op) {
 		channel_internal_error(channel,
 				       "bad onion in got_revoke: %s",

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -646,6 +646,8 @@ static bool peer_accepted_htlc(struct channel *channel,
 		goto out;
 	}
 
+	/* FIXME: Have channeld hand through just the route_step! */
+
 	/* channeld tests this, so it should pass. */
 	op = parse_onionpacket(tmpctx, hin->onion_routing_packet,
 			       sizeof(hin->onion_routing_packet),
@@ -663,8 +665,11 @@ static bool peer_accepted_htlc(struct channel *channel,
 				 hin->payment_hash.u.u8,
 				 sizeof(hin->payment_hash));
 	if (!rs) {
-		*failcode = WIRE_INVALID_ONION_HMAC;
-		goto out;
+		channel_internal_error(channel,
+				       "bad process_onionpacket in got_revoke: %s",
+				       tal_hexstr(channel, hin->onion_routing_packet,
+						  sizeof(hin->onion_routing_packet)));
+		return false;
 	}
 
 	/* Unknown realm isn't a bad onion, it's a normal failure. */

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,6 +8,7 @@ from ephemeral_port_reserve import reserve
 import json
 import os
 import pytest
+import re
 import shutil
 import signal
 import socket
@@ -1137,9 +1138,11 @@ def test_check_command(node_factory):
     sock.close()
 
 
+@unittest.skipIf(not DEVELOPER, "need log_all_io")
 def test_bad_onion(node_factory, bitcoind):
     """Test that we get a reasonable error from sendpay when an onion is bad"""
-    l1, l2, l3, l4 = node_factory.line_graph(4, wait_for_announce=True)
+    l1, l2, l3, l4 = node_factory.line_graph(4, wait_for_announce=True,
+                                             opts={'log_all_io': True})
 
     h = l4.rpc.invoice(123000, 'test_bad_onion', 'description')['payment_hash']
     route = l1.rpc.getroute(l4.info['id'], 123000, 1)['route']
@@ -1162,6 +1165,16 @@ def test_bad_onion(node_factory, bitcoind):
     assert err.value.error['data']['failcode'] == WIRE_INVALID_ONION_HMAC
     assert err.value.error['data']['erring_node'] == mangled_nodeid
     assert err.value.error['data']['erring_channel'] == route[2]['channel']
+
+    # We should see a WIRE_UPDATE_FAIL_MALFORMED_HTLC from l4.
+    line = l4.daemon.is_in_log(r'\[OUT\] 0087')
+    # 008739d3149a5c37e95f9dae718ce46efc60248e110e10117d384870a6762e8e33030000000000000000d7fc52f6c32773aabca55628fe616058aecc44a384e0abfa85c0c48b449dd38dc005
+    # type<--------------channelid---------------------------------------><--htlc-id-----><--------------------------------------------- sha_of_onion --->code
+    sha = re.search(r' 0087.{64}.{16}(.{64})', line).group(1)
+
+    # Should see same sha in onionreply
+    line = l1.daemon.is_in_log(r'failcode .* from onionreply .*')
+    assert re.search(r'onionreply .*{}'.format(sha), line)
 
     # Replace id with a different pubkey, so onion encoded badly at second hop.
     route[1]['id'] = mangled_nodeid

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1137,7 +1137,6 @@ def test_check_command(node_factory):
     sock.close()
 
 
-@pytest.mark.xfail(strict=True)
 def test_bad_onion(node_factory, bitcoind):
     """Test that we get a reasonable error from sendpay when an onion is bad"""
     l1, l2, l3, l4 = node_factory.line_graph(4, wait_for_announce=True)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -367,11 +367,10 @@ struct command_result *param_tok(struct command *cmd UNNEEDED, const char *name 
 				 const jsmntok_t **out UNNEEDED)
 { fprintf(stderr, "param_tok called!\n"); abort(); }
 /* Generated stub for parse_onionpacket */
-struct onionpacket *parse_onionpacket(
-	const tal_t *ctx UNNEEDED,
-	const void *src UNNEEDED,
-	const size_t srclen
-	)
+struct onionpacket *parse_onionpacket(const tal_t *ctx UNNEEDED,
+				      const void *src UNNEEDED,
+				      const size_t srclen UNNEEDED,
+				      enum onion_type *why_bad UNNEEDED)
 { fprintf(stderr, "parse_onionpacket called!\n"); abort(); }
 /* Generated stub for payment_failed */
 void payment_failed(struct lightningd *ld UNNEEDED, const struct htlc_out *hout UNNEEDED,


### PR DESCRIPTION
I was writing a pay test when I got a non-decodable onion.  Turns out our handling of "update_fail_malformed_htlc" (where the next peer can't decrypt the onion) is completely wrong, and results in us packaging up incorrect data.  This is easy to duplicate by simply lying to 'sendpay' about what id the next hop is.

The resulting cleanups and fixes solve this.