### PR TITLE
Add jsonrpc version to command calls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - JSON API: `pay` and `decodepay` accept and ignore `lightning:` prefixes.
 - pylightning: Allow either keyword arguments or positional arguments.
 - JSON-RPC: messages are now separated by 2 consecutive newlines.
+- JSON-RPC: `jsonrpc`:`2.0` now included in json-rpc command calls. complies with spec.
 
 ### Deprecated
 

--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
 
 	idstr = tal_fmt(ctx, "lightning-cli-%i", getpid());
 	cmd = tal_fmt(ctx,
-		      "{ \"method\" : \"%s\", \"id\" : \"%s\", \"params\" : ",
+		      "{ \"jsonrpc\" : \"2.0\", \"method\" : \"%s\", \"id\" : \"%s\", \"params\" :",
 		      method, idstr);
 
 	if (input == DEFAULT_INPUT) {

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -12,7 +12,7 @@
  * done, the `json_connection` needs to drain it (if it's still around).  At
  * that point, the `json_connection` becomes the owner (or it's simply freed).
  */
-/* eg: { "method" : "dev-echo", "params" : [ "hello", "Arabella!" ], "id" : "1" } */
+/* eg: { "jsonrpc":"2.0", "method" : "dev-echo", "params" : [ "hello", "Arabella!" ], "id" : "1" } */
 #include <arpa/inet.h>
 #include <bitcoin/address.h>
 #include <bitcoin/base58.h>


### PR DESCRIPTION
Include the `jsonrpc` version on plugin commands that get called. (this was causing an error)
