### PR TITLE
openingd: make sure we take utxos on success.

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -778,6 +778,9 @@ static u8 *funder_channel(struct state *state,
 
 	peer_billboard(false, "Funding channel: opening negotiation succeeded");
 
+	if (taken(utxos))
+		tal_free(utxos);
+
 	/* BOLT #2:
 	 *
 	 * The recipient:


### PR DESCRIPTION
Otherwise recent additional checks in tal() complain that we're freeing a
take() pointer.  In this case, we're exiting so it's harmless, but it's
still a latent bug.

Reported-by: @cdecker 
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>