### PR TITLE
tools: Add missing unistd.h header

### DIFF
--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -10,6 +10,7 @@
 #include <sqlite3.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <zlib.h>
 
 static const char template[] =


### PR DESCRIPTION
`close` was implicitly defined, include `unistd.h` to define it explicitly so that the FreeBSD compile succeeds. Fixes the following error:

```
tools/headerversions.c:70:3: error: implicit declaration of function 'close' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                close(fd);
                ^
tools/headerversions.c:70:3: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
2 errors generated.
```