### PR TITLE
pylightning: Increase buffer size for big JSON-RPC responses

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -33,7 +33,7 @@ class UnixDomainSocketRpc(object):
             return self._readobj(sock, buff)
         while True:
             try:
-                b = sock.recv(1024)
+                b = sock.recv(max(1024, len(buff)))
                 buff += b
 
                 if b'\n\n' in buff:
@@ -58,7 +58,7 @@ class UnixDomainSocketRpc(object):
             parts = buff.split(b'\n\n', 1)
             if len(parts) == 1:
                 # Didn't read enough.
-                b = sock.recv(1024)
+                b = sock.recv(max(1024, len(buff)))
                 buff += b
                 if len(b) == 0:
                     return {'error': 'Connection to RPC server lost.'}, buff


### PR DESCRIPTION
This was causing `listchannels` to be incredibly slow. The response is
several megabyte in size, and we were only buffering 1Kb on each
iteration.

We can be at most a factor of 2 away from what was actually needed, and it considerably reduces parse time.