### PR TITLE
changed import statement for plugins

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from lightning import Plugin
+from lightning.plugin import Plugin
 
 
 plugin = Plugin(autopatch=True)


### PR DESCRIPTION
example script will not run if the `plugin.py` file from the `lightning` directory is not loaded.