### PR TITLE
[plugin] Improved the example code to encourage usage of optional arguments

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -6,7 +6,7 @@ plugin = Plugin(autopatch=True)
 
 
 @plugin.method("hello")
-def hello(name, plugin):
+def hello(plugin,name = "world"):
     """This is the documentation string for the hello-function.
 
     It gets reported as the description when registering the function
@@ -25,12 +25,12 @@ def init(options, configuration, plugin):
 
 
 @plugin.subscribe("connect")
-def on_connect(id, address, plugin):
+def on_connect(plugin, id, address):
     plugin.log("Received connect event for peer {}".format(id))
 
 
 @plugin.subscribe("disconnect")
-def on_disconnect(id, plugin):
+def on_disconnect(plugin, id):
     plugin.log("Received disconnect event for peer {}".format(id))
 
 

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -6,7 +6,7 @@ plugin = Plugin(autopatch=True)
 
 
 @plugin.method("hello")
-def hello(plugin,name = "world"):
+def hello(plugin, name="world"):
     """This is the documentation string for the hello-function.
 
     It gets reported as the description when registering the function


### PR DESCRIPTION
The example code had the `plugin` argument as the last argument. this disallows arguments that have a standard value. As far as I understand the dispatching code the order of arguments does not matter since it is the name `plugin` that is relevant. Therefor I changed the order so that newbe's don't have to read the entire code and can easily add optional arguments