### PR TITLE
lightningd: don't allow zero cltv HTLCs.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -198,7 +198,7 @@ static bool check_amount(struct htlc_in *hin,
 static bool check_cltv(struct htlc_in *hin,
 		       u32 cltv_expiry, u32 outgoing_cltv_value, u32 delta)
 {
-	if (cltv_expiry - delta >= outgoing_cltv_value)
+	if (delta < cltv_expiry && cltv_expiry - delta >= outgoing_cltv_value)
 		return true;
 	log_debug(hin->key.channel->log, "HTLC %"PRIu64" incorrect CLTV:"
 		  " %u in, %u out, delta reqd %u",


### PR DESCRIPTION
Seems like someone is sending out zero-cltv HTLCs, which is we weren't catching correctly, thus failing on a sanity check.
