### PR TITLE
init: Reap tested subdaemon processes to release OS resources

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -293,6 +293,10 @@ void test_subdaemons(const struct lightningd *ld)
 		    || verstring[strlen(version())] != '\n')
 			errx(1, "%s: bad version '%s'",
 			     subdaemons[i], verstring);
+
+		/*~ finally reap the child process, freeing all OS
+		 *  resources that go with it */
+		waitpid(pid, NULL, 0);
 	}
 }
 


### PR DESCRIPTION
The processes that were used to test the subdaemon versions were not
reaped correctly keeping some resources bound.

Fixes #779
Fixes #978