### PR TITLE
listpeers: include `private` field in `channels` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `num_active_channels` and `num_inactive_channels` fields.
 - JSON API: use `\n\n` to terminate responses, for simplified parsing (pylightning now relies on this)
 - JSON API: `fundchannel` now includes an `announce` option, when false it will keep channel private. Defaults to true.
+- JSON API: `listpeers`'s `channels` now includes a `private` flag to indicate if channel is announced or not.
 - Plugins: Added plugins to `lightningd`, including option passthrough and JSON-RPC passthrough.
 
 ### Changed

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -716,6 +716,8 @@ static void json_add_peer(struct lightningd *ld,
 		json_add_txid(response,
 			      "funding_txid",
 			      &channel->funding_txid);
+		json_add_bool(response, "private",
+				!(channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL));
 		json_add_u64(response, "msatoshi_to_us",
 			     channel->our_msatoshi);
 		json_add_u64(response, "msatoshi_to_us_min",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -805,6 +805,11 @@ def test_private_channel(node_factory):
     assert not l1.daemon.is_in_log('Received node_announcement for node {}'.format(l2.info['id']))
     assert not l2.daemon.is_in_log('Received node_announcement for node {}'.format(l1.info['id']))
 
+    # test for 'private' flag in rpc output
+    assert only_one(only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['channels'])['private']
+    # check non-private channel
+    assert not only_one(only_one(l4.rpc.listpeers(l3.info['id'])['peers'])['channels'])['private']
+
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 for --dev-broadcast-interval")
 def test_channel_reenable(node_factory):


### PR DESCRIPTION
Reveal channel's 'privacy' in `listpeers` output

Suggested-By: @shesek