### PR TITLE
[rpc] Add funding allocation map to listpeers command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - The `short_channel_id` separator has been changed to be `x` to match the specification.
+- JSON API: `listpeers` now includes `funding_allocation_msat`, which returns a map of the amounts initially funded to the channel by each peer, indexed by channel id.
 
 ### Deprecated
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -720,6 +720,21 @@ static void json_add_peer(struct lightningd *ld,
 			      &channel->funding_txid);
 		json_add_bool(response, "private",
 				!(channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL));
+
+		// FIXME @conscott : Modify this when dual-funded channels
+		// are implemented
+		json_object_start(response, "funding_allocation_msat");
+		if (channel->funder == LOCAL) {
+			json_add_u64(response, pubkey_to_hexstr(tmpctx, &p->id), 0);
+			json_add_u64(response, pubkey_to_hexstr(tmpctx, &ld->id),
+					channel->funding_satoshi * 1000);
+		} else {
+			json_add_u64(response, pubkey_to_hexstr(tmpctx, &ld->id), 0);
+			json_add_u64(response, pubkey_to_hexstr(tmpctx, &p->id),
+					channel->funding_satoshi * 1000);
+		}
+		json_object_end(response);
+
 		json_add_u64(response, "msatoshi_to_us",
 			     channel->our_msatoshi);
 		json_add_u64(response, "msatoshi_to_us_min",


### PR DESCRIPTION
A redo of #2207 

The point is the know the initial state of funding allocated to the channel by the funder / fundee. At the moment there are only one-sided channel opens, but dual-funded channels will be available in the near future :crossed_fingers: 

This change also implicitly let's you know who initiated the channel open, which was the original intent of #2207 