### PR TITLE
make: fail build if git isn't present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 #! /usr/bin/make
 VERSION_NAME=Principled Opposition to SegWit
 VERSION=$(shell git describe --always --dirty=-modded --abbrev=7)
+
+ifeq ($(VERSION),)
+$(error "ERROR: git is required for generating version information")
+endif
+
 DISTRO=$(shell lsb_release -is 2>/dev/null || echo unknown)-$(shell lsb_release -rs 2>/dev/null || echo unknown)
 PKGNAME = c-lightning
 


### PR DESCRIPTION
git is needed to generate version information

Add a sanity check so that the build doesn't continue with an empty VERSION. This
is useful for sandboxed build where we might have forgot to include git.

Fixes #2238 