### PR TITLE
misc: Update short_channel_id representation to use 'x' separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- The `short_channel_id` separator has been changed to be `x` to match the specification.
+
 ### Deprecated
 
 Note: You should always set `allow-deprecated-apis=false` to test for

--- a/bitcoin/short_channel_id.c
+++ b/bitcoin/short_channel_id.c
@@ -22,14 +22,22 @@ bool short_channel_id_from_str(const char *str, size_t strlen,
 	memcpy(buf, str, strlen);
 	buf[strlen] = 0;
 
-	matches = sscanf(buf, "%u:%u:%hu", &blocknum, &txnum, &outnum);
+#ifdef COMPAT_V062
+	/* Pre-adelaide format vs. post-adelaide format */
+	if (strchr(buf, ':'))
+		matches = sscanf(buf, "%u:%u:%hu", &blocknum, &txnum, &outnum);
+	else
+		matches = sscanf(buf, "%ux%ux%hu", &blocknum, &txnum, &outnum);
+#else
+	matches = sscanf(buf, "%ux%ux%hu", &blocknum, &txnum, &outnum);
+#endif
 	mk_short_channel_id(dst, blocknum, txnum, outnum);
 	return matches == 3;
 }
 
 char *short_channel_id_to_str(const tal_t *ctx, const struct short_channel_id *scid)
 {
-	return tal_fmt(ctx, "%d:%d:%d",
+	return tal_fmt(ctx, "%dx%dx%d",
 		       short_channel_id_blocknum(scid),
 		       short_channel_id_txnum(scid),
 		       short_channel_id_outnum(scid));

--- a/bitcoin/short_channel_id.c
+++ b/bitcoin/short_channel_id.c
@@ -3,6 +3,25 @@
 #include <stdio.h>
 #include <string.h>
 
+/* BOLT#07:
+ *
+ * The `short_channel_id` is the unique description of the funding
+ * transaction. It is constructed as follows:
+
+ * 1. the most significant 3 bytes: indicating the block height
+ * 2. the next 3 bytes: indicating the transaction index within the block
+ * 3. the least significant 2 bytes: indicating the output index that pays to the channel.
+ *
+ * The standard human readable format for `short_channel_id` is created
+ * by printing the above components, in the order: block height,
+ * transaction index, and output index. Each component is printed as a
+ * decimal number, and separated from each other by the small letter
+ * `x`. For example, a `short_channel_id` might be written as
+ * `539268x845x1`, indicating a channel on the output 1 of the
+ * transaction at index 845 of the block at height 539268.
+*/
+
+
 void mk_short_channel_id(struct short_channel_id *scid,
 			 u32 blocknum, u32 txnum, u16 outnum)
 {

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -3,7 +3,7 @@
  * Expect route 03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf -> 0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae -> 02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06
  *
  * getchannels:
- * {'channels': [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]}
+ * {'channels': [{'active': True, 'short_id': '6990x2x1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, {'active': True, 'short_id': '6989x2x1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6990x2x1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, {'active': True, 'short_id': '6989x2x1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]}
  */
 #include <common/status.h>
 
@@ -186,7 +186,7 @@ int main(void)
 
 	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 
-	nc = get_or_make_connection(rstate, &c, &b, "6990:2:1", 1000);
+	nc = get_or_make_connection(rstate, &c, &b, "6990x2x1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
@@ -195,7 +195,7 @@ int main(void)
 	nc->last_timestamp = 1504064344;
 
 	/* {'active': True, 'short_id': '6989:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
-	nc = get_or_make_connection(rstate, &b, &a, "6989:2:1", 1000);
+	nc = get_or_make_connection(rstate, &b, &a, "6989x2x1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
@@ -204,7 +204,7 @@ int main(void)
 	nc->last_timestamp = 1504064344;
 
 	/* {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 0, 'destination': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'source': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'last_update': 1504064344}, */
-	nc = get_or_make_connection(rstate, &b, &c, "6990:2:1", 1000);
+	nc = get_or_make_connection(rstate, &b, &c, "6990x2x1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
@@ -214,7 +214,7 @@ int main(void)
 	nc->htlc_minimum_msat = 100;
 
 	/* {'active': True, 'short_id': '6989:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}]} */
-	nc = get_or_make_connection(rstate, &a, &b, "6989:2:1", 1000);
+	nc = get_or_make_connection(rstate, &a, &b, "6989x2x1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 10;
 	nc->delay = 5;
@@ -244,7 +244,7 @@ int main(void)
 	assert(!route);
 
 	/* {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 1, 'htlc_maximum_msat': 500000, 'htlc_minimum_msat': 100, 'channel_flags': 0, 'destination': '02cca6c5c966fcf61d121e3a70e03a1cd9eeeea024b26ea666ce974d43b242e636', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}, */
-	nc = get_or_make_connection(rstate, &a, &d, "6991:2:1", 1000);
+	nc = get_or_make_connection(rstate, &a, &d, "6991x2x1", 1000);
 	nc->base_fee = 0;
 	nc->proportional_fee = 0;
 	nc->delay = 5;

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -539,7 +539,7 @@ def test_onchaind_replay(node_factory, bitcoind):
         'msatoshi': 10**8 - 1,
         'id': l2.info['id'],
         'delay': 101,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
     l1.rpc.sendpay([routestep], rhash)
     l1.daemon.wait_for_log('sendrawtx exit 0')
@@ -593,7 +593,7 @@ def test_onchain_dust_out(node_factory, bitcoind, executor):
         'msatoshi': 1,
         'id': l2.info['id'],
         'delay': 5,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
 
     l1.rpc.sendpay([routestep], rhash)
@@ -656,7 +656,7 @@ def test_onchain_timeout(node_factory, bitcoind, executor):
         'msatoshi': 10**8 - 1,
         'id': l2.info['id'],
         'delay': 5,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
 
     l1.rpc.sendpay([routestep], rhash)
@@ -814,7 +814,7 @@ def test_onchain_feechange(node_factory, bitcoind, executor):
         'msatoshi': 10**8 - 1,
         'id': l2.info['id'],
         'delay': 5,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
 
     executor.submit(l1.rpc.sendpay, [routestep], rhash)
@@ -891,7 +891,7 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
         'msatoshi': 10**7 - 1,
         'id': l2.info['id'],
         'delay': 5,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
 
     executor.submit(l1.rpc.sendpay, [routestep], rhash)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -389,7 +389,7 @@ def test_reconnect_sender_add1(node_factory):
     rhash = l2.rpc.invoice(amt, 'test_reconnect_sender_add1', 'desc')['payment_hash']
     assert only_one(l2.rpc.listinvoices('test_reconnect_sender_add1')['invoices'])['status'] == 'unpaid'
 
-    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1:1:1'}]
+    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1x1x1'}]
 
     for i in range(0, len(disconnects)):
         l1.rpc.sendpay(route, rhash)
@@ -424,7 +424,7 @@ def test_reconnect_sender_add(node_factory):
     rhash = l2.rpc.invoice(amt, 'testpayment', 'desc')['payment_hash']
     assert only_one(l2.rpc.listinvoices('testpayment')['invoices'])['status'] == 'unpaid'
 
-    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1:1:1'}]
+    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1x1x1'}]
 
     # This will send commit, so will reconnect as required.
     l1.rpc.sendpay(route, rhash)
@@ -453,7 +453,7 @@ def test_reconnect_receiver_add(node_factory):
     rhash = l2.rpc.invoice(amt, 'testpayment2', 'desc')['payment_hash']
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['status'] == 'unpaid'
 
-    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1:1:1'}]
+    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1x1x1'}]
     l1.rpc.sendpay(route, rhash)
     for i in range(len(disconnects)):
         l1.daemon.wait_for_log('Already have funding locked in')
@@ -485,7 +485,7 @@ def test_reconnect_receiver_fulfill(node_factory):
     rhash = l2.rpc.invoice(amt, 'testpayment2', 'desc')['payment_hash']
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['status'] == 'unpaid'
 
-    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1:1:1'}]
+    route = [{'msatoshi': amt, 'id': l2.info['id'], 'delay': 5, 'channel': '1x1x1'}]
     l1.rpc.sendpay(route, rhash)
     for i in range(len(disconnects)):
         l1.daemon.wait_for_log('Already have funding locked in')

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -553,9 +553,9 @@ def test_gossip_query_channel_range(node_factory, bitcoind):
 
     # Make public channels.
     scid12 = l1.fund_channel(l2, 10**5)
-    block12 = int(scid12.split(':')[0])
+    block12 = int(scid12.split('x')[0])
     scid23 = l2.fund_channel(l3, 10**5)
-    block23 = int(scid23.split(':')[0])
+    block23 = int(scid23.split('x')[0])
     bitcoind.generate_block(5)
 
     # Make sure l2 has received all the gossip.
@@ -747,7 +747,7 @@ def test_query_short_channel_id(node_factory, bitcoind):
     subprocess.run(['kill', '-USR1', l1.subd_pid('openingd')])
 
     # Empty result tests.
-    reply = l1.rpc.dev_query_scids(l2.info['id'], ['1:1:1', '2:2:2'])
+    reply = l1.rpc.dev_query_scids(l2.info['id'], ['1x1x1', '2x2x2'])
     # 0x0105 = query_short_channel_ids
     l1.daemon.wait_for_log(r'\[OUT\] 0105.*0000000100000100010000020000020002')
     assert reply['complete']

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -322,7 +322,7 @@ def test_sendpay(node_factory):
         'msatoshi': amt,
         'id': l2.info['id'],
         'delay': 5,
-        'channel': '1:1:1'
+        'channel': '1x1x1'
     }
 
     # Insufficient funds.
@@ -405,7 +405,7 @@ def test_sendpay(node_factory):
     # Overpaying by "only" a factor of 2 succeeds.
     rhash = l2.rpc.invoice(amt, 'testpayment3', 'desc')['payment_hash']
     assert only_one(l2.rpc.listinvoices('testpayment3')['invoices'])['status'] == 'unpaid'
-    routestep = {'msatoshi': amt * 2, 'id': l2.info['id'], 'delay': 5, 'channel': '1:1:1'}
+    routestep = {'msatoshi': amt * 2, 'id': l2.info['id'], 'delay': 5, 'channel': '1x1x1'}
     l1.rpc.sendpay([routestep], rhash)
     preimage3 = l1.rpc.waitsendpay(rhash)['payment_preimage']
     assert only_one(l2.rpc.listinvoices('testpayment3')['invoices'])['status'] == 'paid'
@@ -438,7 +438,7 @@ def test_sendpay_cant_afford(node_factory):
         if not label:
             label = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(20))
         rhash = ldst.rpc.invoice(amt, label, label)['payment_hash']
-        routestep = {'msatoshi': amt, 'id': ldst.info['id'], 'delay': 5, 'channel': '1:1:1'}
+        routestep = {'msatoshi': amt, 'id': ldst.info['id'], 'delay': 5, 'channel': '1x1x1'}
         lsrc.rpc.sendpay([routestep], rhash)
         lsrc.rpc.waitsendpay(rhash)
 
@@ -634,14 +634,14 @@ def test_decodepay(node_factory):
     assert len(b11['routes'][0]) == 2
     assert b11['routes'][0][0]['pubkey'] == '029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255'
     # 0x010203:0x040506:0x0708
-    assert b11['routes'][0][0]['short_channel_id'] == '66051:263430:1800'
+    assert b11['routes'][0][0]['short_channel_id'] == '66051x263430x1800'
     assert b11['routes'][0][0]['fee_base_msat'] == 1
     assert b11['routes'][0][0]['fee_proportional_millionths'] == 20
     assert b11['routes'][0][0]['cltv_expiry_delta'] == 3
 
     assert b11['routes'][0][1]['pubkey'] == '039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255'
     # 0x030405:0x060708:0x090a
-    assert b11['routes'][0][1]['short_channel_id'] == '197637:395016:2314'
+    assert b11['routes'][0][1]['short_channel_id'] == '197637x395016x2314'
     assert b11['routes'][0][1]['fee_base_msat'] == 2
     assert b11['routes'][0][1]['fee_proportional_millionths'] == 30
     assert b11['routes'][0][1]['cltv_expiry_delta'] == 4

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -526,7 +526,7 @@ class LightningNode(object):
         for out in decoded['vout']:
             if out['scriptPubKey']['type'] == 'witness_v0_scripthash':
                 if out['value'] == Decimal(amount) / 10**8:
-                    scid = "{}:1:{}".format(self.bitcoin.rpc.getblockcount(), out['n'])
+                    scid = "{}x1x{}".format(self.bitcoin.rpc.getblockcount(), out['n'])
                     break
 
         if not scid:
@@ -614,7 +614,7 @@ class LightningNode(object):
             'msatoshi': amt,
             'id': dst.info['id'],
             'delay': 5,
-            'channel': '1:1:1'
+            'channel': '1x1x1'
         }
 
         def wait_pay():


### PR DESCRIPTION
Only the changes in `bitcoin/short_channel_id.c` are important, everything else is just test compat cleanup.

Fixes #2239 