### PR TITLE
added manpage for listforwards command (needs change)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,6 +18,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-listchannels.7 \
+	doc/lightning-listforwards.7 \
 	doc/lightning-listfunds.7 \
 	doc/lightning-listinvoices.7 \
 	doc/lightning-listpays.7 \

--- a/doc/lightning-listforwards.7
+++ b/doc/lightning-listforwards.7
@@ -1,0 +1,129 @@
+'\" t
+.\"     Title: lightning-listforwards
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 05/23/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-LISTFORWA" "7" "05/23/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-listforwards \- Command showing all htlcs and their information\&.
+.SH "SYNOPSIS"
+.sp
+\fBlistforwards\fR
+.SH "DESCRIPTION"
+.sp
+The \fBlistforwards\fR RPC command displays all htlcs that have been attempted to be forwarded by the c\-lightning node\&.
+.SH "RETURN VALUE"
+.sp
+On success one array will be returned: \fIforwards\fR with htlcs that have been processed
+.sp
+Each entry in \fIforwards\fR will include:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIin_channel\fR
+\- the short_channel_id of the channel that recieved the incoming htlc\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIout_channel\fR
+\- the short_channel_id of to which the outgoing htlc is supposed to be forwarded\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIin_msatoshi\fR
+\- amount of msatoshis that are forwarded to this node\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIout_msatoshi\fR
+\- amount of msatoshis to be forwarded\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIfee\fR
+\- fee offered for forwarding the htlc in msatoshi\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIstatus\fR
+\- status can be either
+\fIoffered\fR
+if the routing process is still ongoing,
+\fIsettled\fR
+if the routing process is completed or
+\fIfailed\fR
+if the routing process could not be completed\&.
+.RE
+.SH "AUTHOR"
+.sp
+Rene Pickhardt <r\&.pickhardt@gmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-getinfo(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-listforwards.7.txt
+++ b/doc/lightning-listforwards.7.txt
@@ -1,0 +1,45 @@
+LIGHTNING-LISTFORWARDS(7)
+=========================
+:doctype: manpage
+
+NAME
+----
+lightning-listforwards - Command showing all htlcs and their information.
+
+SYNOPSIS
+--------
+*listforwards* 
+
+DESCRIPTION
+-----------
+The *listforwards* RPC command displays all htlcs that have been attempted to be forwarded by the c-lightning node.
+
+RETURN VALUE
+------------
+On success one array will be returned: 'forwards' with htlcs that have been processed
+
+Each entry in 'forwards' will include: 
+
+- 'in_channel' - the short_channel_id of the channel that recieved the incoming htlc.
+
+- 'out_channel' - the short_channel_id of to which the outgoing htlc is supposed to be forwarded.
+
+- 'in_msatoshi' - amount of msatoshis that are forwarded to this node.
+
+- 'out_msatoshi' - amount of msatoshis to be forwarded.
+
+- 'fee' - fee offered for forwarding the htlc in msatoshi.
+
+- 'status' - status can be either 'offered' if the routing process is still ongoing, 'settled' if the routing process is completed or 'failed' if the routing process could not be completed.
+
+AUTHOR
+------
+Rene Pickhardt <r.pickhardt@gmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-getinfo(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning


### PR DESCRIPTION
I don't understand how manpages are created automatically via the a2x tool. That is why id wrote both files manually. I guess I need only the .7 or the .7.txt file and the other one is automatically created. my machine always creates an xml file and then make produces an error. 
So I need some help and will then redo the PR