### PR TITLE
Do not consider bitcoin-cli as a failed call if it returns error code 1

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -675,7 +675,7 @@ static bool process_getblockhash_for_txout(struct bitcoin_cli *bcli)
 	/* Strip the newline at the end of the previous output */
 	blockhash = tal_strndup(NULL, bcli->output, bcli->output_bytes-1);
 
-	start_bitcoin_cli(bcli->bitcoind, NULL, process_getblock, false,
+	start_bitcoin_cli(bcli->bitcoind, NULL, process_getblock, true,
 			  BITCOIND_LOW_PRIO,
 			  cb, go,
 			  "getblock", take(blockhash), NULL);


### PR DESCRIPTION
It fixes a bad assumption in the code which consider error code  of `bitcoin-cli` different than 0 as a transient issue.

If `bitcoin-cli` returns 1, then [bcli_failure](https://github.com/ElementsProject/lightning/blob/7b7a1b70403009ca726645783bf2144fa275f4d8/lightningd/bitcoind.c#L133) get called, which will try again every second for 1 minute then crash the process.

So what happen on a pruned node?
A gossip come, then c-lightning try to check if the channel exists by fetching the block via `getblock`.
`bitcoin-cli`, not having the block, returns "block-not-found" but also the error code of `bitcoin-cli` is 1.

The caller's callback [process_block](https://github.com/ElementsProject/lightning/blob/7b7a1b70403009ca726645783bf2144fa275f4d8/lightningd/bitcoind.c#L607) expects to process the case where the block is not found.

However, the callback never get called because `bcli_failure` keeps retrying the same command over and over.

This in turn flood the timer queue which make the node eventually crash. (or the 1 min timeout get reached and it kills the process)

Fix #2250