### PR TITLE
plugin: Implement the `htlc_accepted` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `listpeers` status now shows how many confirmations until channel is open (#2405)
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
 - JSON API: `listforwards` now includes the time an HTLC was received and when it was resolved. Both are expressed as UNIX timestamps to facilitate parsing (Issue [#2491](https://github.com/ElementsProject/lightning/issues/2491), PR [#2528](https://github.com/ElementsProject/lightning/pull/2528))
-+- JSON API: new plugin hooks `invoice_payment` for intercepting invoices before they're paid, and `openchannel` for intercepting channel opens.
++- JSON API: new plugin hooks `invoice_payment` for intercepting invoices before they're paid, `openchannel` for intercepting channel opens, and `htlc_accepted` to decide whether to resolve, reject or continue an incoming or forwarded payment..
 - plugin: the `connected` hook can now send an `error_message` to the rejected peer.
 - Protocol: we now enforce `option_upfront_shutdown_script` if a peer negotiates it.
 - JSON API: `listforwards` now includes the local_failed forwards with failcode (Issue [#2435](https://github.com/ElementsProject/lightning/issues/2435), PR [#2524](https://github.com/ElementsProject/lightning/pull/2524))

--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -434,6 +434,8 @@ struct route_step *process_onionpacket(
 	deserialize_hop_data(&step->hop_data, paddedheader);
 
         memcpy(&step->next->mac, step->hop_data.hmac, SECURITY_PARAMETER);
+	step->raw_payload = tal_dup_arr(step, u8, paddedheader + 1,
+					HOP_DATA_SIZE - 1 - HMAC_SIZE, 0);
 
 	memcpy(&step->next->routinginfo, paddedheader + HOP_DATA_SIZE, ROUTING_INFO_SIZE);
 

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -77,6 +77,7 @@ struct route_step {
 	enum route_next_case nextcase;
 	struct onionpacket *next;
 	struct hop_data hop_data;
+	u8 *raw_payload;
 };
 
 /**

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -38,7 +38,7 @@ def on_disconnect(plugin, id):
 def on_htlc_accepted(onion, htlc, plugin):
     plugin.log('on_htlc_accepted called')
     time.sleep(20)
-    return None
+    return {'result': 'continue'}
 
 
 plugin.add_option('greeting', 'Hello', 'The greeting I should use.')

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -35,7 +35,7 @@ def on_disconnect(plugin, id):
 
 
 @plugin.hook("htlc_accepted")
-def on_htlc_accepted(plugin):
+def on_htlc_accepted(onion, htlc, plugin):
     plugin.log('on_htlc_accepted called')
     time.sleep(20)
     return None

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from lightning import Plugin
-
+import time
 
 plugin = Plugin()
 
@@ -32,6 +32,13 @@ def on_connect(plugin, id, address):
 @plugin.subscribe("disconnect")
 def on_disconnect(plugin, id):
     plugin.log("Received disconnect event for peer {}".format(id))
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(plugin):
+    plugin.log('on_htlc_accepted called')
+    time.sleep(20)
+    return None
 
 
 plugin.add_option('greeting', 'Hello', 'The greeting I should use.')

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -308,6 +308,24 @@ void json_add_u64(struct json_stream *result, const char *fieldname,
 	json_add_member(result, fieldname, "%"PRIu64, value);
 }
 
+void json_add_s64(struct json_stream *result, const char *fieldname,
+		  int64_t value)
+{
+	json_add_member(result, fieldname, "%"PRIi64, value);
+}
+
+void json_add_u32(struct json_stream *result, const char *fieldname,
+		  uint32_t value)
+{
+	json_add_member(result, fieldname, "%d", value);
+}
+
+void json_add_s32(struct json_stream *result, const char *fieldname,
+		  int32_t value)
+{
+	json_add_member(result, fieldname, "%d", value);
+}
+
 void json_add_literal(struct json_stream *result, const char *fieldname,
 		      const char *literal, int len)
 {

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -127,6 +127,15 @@ void json_add_num(struct json_stream *result, const char *fieldname,
 /* '"fieldname" : value' or 'value' if fieldname is NULL */
 void json_add_u64(struct json_stream *result, const char *fieldname,
 		  uint64_t value);
+/* '"fieldname" : value' or 'value' if fieldname is NULL */
+void json_add_s64(struct json_stream *result, const char *fieldname,
+		  int64_t value);
+/* '"fieldname" : value' or 'value' if fieldname is NULL */
+void json_add_u32(struct json_stream *result, const char *fieldname,
+		  uint32_t value);
+/* '"fieldname" : value' or 'value' if fieldname is NULL */
+void json_add_s32(struct json_stream *result, const char *fieldname,
+		  int32_t value);
 /* '"fieldname" : true|false' or 'true|false' if fieldname is NULL */
 void json_add_bool(struct json_stream *result, const char *fieldname,
 		   bool value);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -715,6 +715,7 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 {
 	const struct route_step *rs = p->route_step;
 	const struct htlc_in *hin = p->hin;
+	s32 expiry = hin->cltv_expiry, blockheight = p->ld->topology->tip->height;
 	json_object_start(s, "onion");
 
 	if (rs->hop_data.realm == 0x00) {
@@ -732,7 +733,8 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 
 	json_object_start(s, "htlc");
 	json_add_amount_msat_only(s, "amount", hin->msat);
-	json_add_u64(s, "cltv_expiry", hin->cltv_expiry);
+	json_add_u32(s, "cltv_expiry", expiry);
+	json_add_s32(s, "cltv_expiry_relative", expiry - blockheight);
 	json_add_hex(s, "payment_hash", hin->payment_hash.u.u8, sizeof(hin->payment_hash));
 	json_object_end(s);
 }

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -718,6 +718,7 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	s32 expiry = hin->cltv_expiry, blockheight = p->ld->topology->tip->height;
 	json_object_start(s, "onion");
 
+	json_add_hex_talarr (s, "payload", rs->raw_payload);
 	if (rs->hop_data.realm == 0x00) {
 		json_object_start(s, "per_hop_v0");
 		json_add_hex(s, "realm", &rs->hop_data.realm, 1);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -22,6 +22,7 @@
 #include <lightningd/pay.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/peer_htlcs.h>
+#include <lightningd/plugin_hook.h>
 #include <lightningd/subd.h>
 #include <onchaind/gen_onchain_wire.h>
 #include <onchaind/onchain_wire.h>
@@ -612,16 +613,90 @@ static void channel_resolve_reply(struct subd *gossip, const u8 *msg,
 	tal_free(gr);
 }
 
+/**
+ * Data passed to the plugin, and as the context for the hook callback
+ */
+struct htlc_accepted_hook_payload {
+	struct route_step *route_step;
+	struct htlc_in *hin;
+	struct channel *channel;
+	struct lightningd *ld;
+};
+
+/**
+ * Response type from the plugin
+ */
+struct htlc_accepted_hook_response {
+};
+
+/**
+ * Parses the JSON-RPC response into a struct understood by the callback.
+ */
+static struct htlc_accepted_hook_response *
+htlc_accepted_hook_deserialize(const tal_t *ctx, const char *buffer,
+			       const jsmntok_t *toks)
+{
+	return NULL;
+}
+
+static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
+					 struct json_stream *s)
+{
+}
+
+/**
+ * Callback when a plugin answers to the htlc_accepted hook
+ */
+static void
+htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
+			    const char *buffer, const jsmntok_t *toks)
+{
+	struct route_step *rs = request->route_step;
+	struct htlc_in *hin = request->hin;
+	struct channel *channel = request->channel;
+	struct lightningd *ld = request->ld;
+	u8 *req;
+
+	/* TODO(cdecker) Assign to *response once we actually use it */
+	htlc_accepted_hook_deserialize(request, buffer, toks);
+
+	if (rs->nextcase == ONION_FORWARD) {
+		struct gossip_resolve *gr = tal(ld, struct gossip_resolve);
+
+		gr->next_onion = serialize_onionpacket(gr, rs->next);
+		gr->next_channel = rs->hop_data.channel_id;
+		gr->amt_to_forward = rs->hop_data.amt_forward;
+		gr->outgoing_cltv_value = rs->hop_data.outgoing_cltv;
+		gr->hin = hin;
+
+		req = towire_gossip_get_channel_peer(tmpctx, &gr->next_channel);
+		log_debug(channel->log, "Asking gossip to resolve channel %s",
+			  type_to_string(tmpctx, struct short_channel_id,
+					 &gr->next_channel));
+		subd_req(hin, ld->gossip, req, -1, 0,
+			 channel_resolve_reply, gr);
+	} else
+		handle_localpay(hin, hin->cltv_expiry, &hin->payment_hash,
+				rs->hop_data.amt_forward,
+				rs->hop_data.outgoing_cltv);
+	tal_free(request);
+}
+
+REGISTER_PLUGIN_HOOK(htlc_accepted, htlc_accepted_hook_callback,
+		     struct htlc_accepted_hook_payload *,
+		     htlc_accepted_hook_serialize,
+		     struct htlc_accepted_hook_payload *);
+
 /* Everyone is committed to this htlc of theirs */
 static bool peer_accepted_htlc(struct channel *channel,
 			       u64 id,
 			       enum onion_type *failcode)
 {
 	struct htlc_in *hin;
-	u8 *req;
 	struct route_step *rs;
 	struct onionpacket *op;
 	struct lightningd *ld = channel->peer->ld;
+	struct htlc_accepted_hook_payload *hook_payload;
 
 	hin = find_htlc_in(&ld->htlcs_in, channel, id);
 	if (!hin) {
@@ -695,31 +770,23 @@ static bool peer_accepted_htlc(struct channel *channel,
 	}
 
 	/* Unknown realm isn't a bad onion, it's a normal failure. */
+	/* FIXME: if we want hooks to handle foreign realms we should
+	 * move this check to the hook callback. */
 	if (rs->hop_data.realm != 0) {
 		*failcode = WIRE_INVALID_REALM;
 		goto out;
 	}
 
-	if (rs->nextcase == ONION_FORWARD) {
-		struct gossip_resolve *gr = tal(ld, struct gossip_resolve);
+	/* It's time to package up all the information and call the
+	 * hook so plugins can interject if they want */
+	hook_payload = tal(hin, struct htlc_accepted_hook_payload);
+	hook_payload->route_step = tal_steal(hook_payload, rs);
+	hook_payload->ld = ld;
+	hook_payload->hin = hin;
+	hook_payload->channel = channel;
+	plugin_hook_call_htlc_accepted(ld, hook_payload, hook_payload);
 
-		gr->next_onion = serialize_onionpacket(gr, rs->next);
-		gr->next_channel = rs->hop_data.channel_id;
-		gr->amt_to_forward = rs->hop_data.amt_forward;
-		gr->outgoing_cltv_value = rs->hop_data.outgoing_cltv;
-		gr->hin = hin;
-
-		req = towire_gossip_get_channel_peer(tmpctx, &gr->next_channel);
-		log_debug(channel->log, "Asking gossip to resolve channel %s",
-			  type_to_string(tmpctx, struct short_channel_id,
-					 &gr->next_channel));
-		subd_req(hin, ld->gossip, req, -1, 0,
-			 channel_resolve_reply, gr);
-	} else
-		handle_localpay(hin, hin->cltv_expiry, &hin->payment_hash,
-				rs->hop_data.amt_forward,
-				rs->hop_data.outgoing_cltv);
-
+	/* Falling through here is ok, after all the HTLC locked */
 	*failcode = 0;
 out:
 	log_debug(channel->log, "their htlc %"PRIu64" %s",

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1,3 +1,4 @@
+#include <bitcoin/preimage.h>
 #include <bitcoin/tx.h>
 #include <ccan/build_assert/build_assert.h>
 #include <ccan/cast/cast.h>
@@ -624,10 +625,22 @@ struct htlc_accepted_hook_payload {
 	u8 *next_onion;
 };
 
+/* The possible return value types that a plugin may return for the
+ * `htlc_accepted` hook. */
+enum htlc_accepted_result {
+	htlc_accepted_continue,
+	htlc_accepted_fail,
+	htlc_accepted_resolve,
+};
+
 /**
  * Response type from the plugin
  */
 struct htlc_accepted_hook_response {
+	enum htlc_accepted_result result;
+	struct preimage payment_key;
+	enum onion_type failure_code;
+	u8 *channel_update;
 };
 
 /**
@@ -637,7 +650,64 @@ static struct htlc_accepted_hook_response *
 htlc_accepted_hook_deserialize(const tal_t *ctx, const char *buffer,
 			       const jsmntok_t *toks)
 {
-	return NULL;
+	struct htlc_accepted_hook_response *response;
+	const jsmntok_t *resulttok, *failcodetok, *paykeytok, *chanupdtok;
+
+	if (!toks || !buffer)
+		return NULL;
+
+	resulttok = json_get_member(buffer, toks, "result");
+
+	/* If the result is "continue" we can just return NULL since
+	 * this is the default behavior for this hook anyway */
+	if (!resulttok) {
+		fatal("Plugin return value does not contain 'result' key %s",
+		      json_strdup(tmpctx, buffer, toks));
+	}
+
+	if (json_tok_streq(buffer, resulttok, "continue")) {
+		return NULL;
+	}
+
+	response = tal(ctx, struct htlc_accepted_hook_response);
+	if (json_tok_streq(buffer, resulttok, "fail")) {
+		response->result = htlc_accepted_fail;
+		failcodetok = json_get_member(buffer, toks, "failure_code");
+		chanupdtok = json_get_member(buffer, toks, "channel_update");
+		if (failcodetok && !json_to_number(buffer, failcodetok,
+						   &response->failure_code))
+			fatal("Plugin provided a non-numeric failcode "
+			      "in response to an htlc_accepted hook");
+
+		if (!failcodetok)
+			response->failure_code = WIRE_TEMPORARY_NODE_FAILURE;
+
+		if (chanupdtok)
+			response->channel_update =
+			    json_tok_bin_from_hex(response, buffer, chanupdtok);
+		else
+			response->channel_update = NULL;
+
+	} else if (json_tok_streq(buffer, resulttok, "resolve")) {
+		response->result = htlc_accepted_resolve;
+		paykeytok = json_get_member(buffer, toks, "payment_key");
+		if (!paykeytok)
+			fatal(
+			    "Plugin did not specify a 'payment_key' in return "
+			    "value to the htlc_accepted hook: %s",
+			    json_strdup(tmpctx, buffer, resulttok));
+
+		if (!json_to_preimage(buffer, paykeytok,
+				      &response->payment_key))
+			fatal("Plugin specified an invalid 'payment_key': %s",
+			      json_tok_full(buffer, resulttok));
+	} else {
+		fatal("Plugin responded with an unknown result to the "
+		      "htlc_accepted hook: %s",
+		      json_strdup(tmpctx, buffer, resulttok));
+	}
+
+	return response;
 }
 
 static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
@@ -679,29 +749,53 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	struct channel *channel = request->channel;
 	struct lightningd *ld = request->ld;
 	u8 *req;
+	enum htlc_accepted_result result;
+	struct htlc_accepted_hook_response *response;
+	response = htlc_accepted_hook_deserialize(request, buffer, toks);
 
-	/* TODO(cdecker) Assign to *response once we actually use it */
-	htlc_accepted_hook_deserialize(request, buffer, toks);
+	if (response)
+		result = response->result;
+	else
+		result = htlc_accepted_continue;
 
-	if (rs->nextcase == ONION_FORWARD) {
-		struct gossip_resolve *gr = tal(ld, struct gossip_resolve);
+	switch (result) {
+	case htlc_accepted_continue:
+		if (rs->nextcase == ONION_FORWARD) {
+			struct gossip_resolve *gr =
+			    tal(ld, struct gossip_resolve);
 
-		gr->next_onion = tal_steal(gr, request->next_onion);
-		gr->next_channel = rs->hop_data.channel_id;
-		gr->amt_to_forward = rs->hop_data.amt_forward;
-		gr->outgoing_cltv_value = rs->hop_data.outgoing_cltv;
-		gr->hin = hin;
+			gr->next_onion = tal_steal(gr, request->next_onion);
+			serialize_onionpacket(gr, rs->next);
+			gr->next_channel = rs->hop_data.channel_id;
+			gr->amt_to_forward = rs->hop_data.amt_forward;
+			gr->outgoing_cltv_value = rs->hop_data.outgoing_cltv;
+			gr->hin = hin;
 
-		req = towire_gossip_get_channel_peer(tmpctx, &gr->next_channel);
-		log_debug(channel->log, "Asking gossip to resolve channel %s",
-			  type_to_string(tmpctx, struct short_channel_id,
-					 &gr->next_channel));
-		subd_req(hin, ld->gossip, req, -1, 0,
-			 channel_resolve_reply, gr);
-	} else
-		handle_localpay(hin, hin->cltv_expiry, &hin->payment_hash,
-				rs->hop_data.amt_forward,
-				rs->hop_data.outgoing_cltv);
+			req = towire_gossip_get_channel_peer(tmpctx,
+							     &gr->next_channel);
+			log_debug(
+			    channel->log, "Asking gossip to resolve channel %s",
+			    type_to_string(tmpctx, struct short_channel_id,
+					   &gr->next_channel));
+			subd_req(hin, ld->gossip, req, -1, 0,
+				 channel_resolve_reply, gr);
+		} else
+			handle_localpay(hin, hin->cltv_expiry,
+					&hin->payment_hash,
+					rs->hop_data.amt_forward,
+					rs->hop_data.outgoing_cltv);
+
+		break;
+	case htlc_accepted_fail:
+		log_debug(channel->log,
+			  "Failing incoming HTLC as instructed by plugin hook");
+		fail_in_htlc(hin, response->failure_code, NULL, NULL);
+		break;
+	case htlc_accepted_resolve:
+		fulfill_htlc(hin, &response->payment_key);
+		break;
+	}
+
 	tal_free(request);
 }
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -170,11 +170,6 @@ const char *version(void)
 /* Generated stub for wallet_blocks_heights */
 void wallet_blocks_heights(struct wallet *w UNNEEDED, u32 def UNNEEDED, u32 *min UNNEEDED, u32 *max UNNEEDED)
 { fprintf(stderr, "wallet_blocks_heights called!\n"); abort(); }
-/* Generated stub for wallet_invoice_autoclean */
-void wallet_invoice_autoclean(struct wallet * wallet UNNEEDED,
-			      u64 cycle_seconds UNNEEDED,
-			      u64 expired_by UNNEEDED)
-{ fprintf(stderr, "wallet_invoice_autoclean called!\n"); abort(); }
 /* Generated stub for wallet_network_check */
 bool wallet_network_check(struct wallet *w UNNEEDED,
 			  const struct chainparams *chainparams UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -478,11 +478,6 @@ bool wallet_htlcs_load_for_channel(struct wallet *wallet UNNEEDED,
 				   struct htlc_in_map *htlcs_in UNNEEDED,
 				   struct htlc_out_map *htlcs_out UNNEEDED)
 { fprintf(stderr, "wallet_htlcs_load_for_channel called!\n"); abort(); }
-/* Generated stub for wallet_invoice_autoclean */
-void wallet_invoice_autoclean(struct wallet * wallet UNNEEDED,
-			      u64 cycle_seconds UNNEEDED,
-			      u64 expired_by UNNEEDED)
-{ fprintf(stderr, "wallet_invoice_autoclean called!\n"); abort(); }
 /* Generated stub for wallet_invoice_create */
 bool wallet_invoice_create(struct wallet *wallet UNNEEDED,
 			   struct invoice *pinvoice UNNEEDED,

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin):
+    plugin.log("Failing htlc on purpose")
+    plugin.log("onion: %r" % (onion))
+    return {"result": "fail", "failure_code": 16399}
+
+
+plugin.run()

--- a/tests/plugins/hold_htlcs.py
+++ b/tests/plugins/hold_htlcs.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Plugin that holds on to HTLCs for 10 seconds.
+
+Used to test restarts / crashes while HTLCs were accepted, but not yet
+settled/forwarded/
+
+"""
+
+
+from lightning import Plugin
+import time
+
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin):
+    plugin.log("Holding onto an incoming htlc for 10 seconds")
+    time.sleep(10)
+
+    # Give the tester something to look for
+    plugin.log("htlc_accepted hook called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/shortcircuit.py
+++ b/tests/plugins/shortcircuit.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(onion, htlc, plugin):
+    return {"result": "resolve", "payment_key": "00" * 32}
+
+
+plugin.run()

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1125,6 +1125,10 @@ def test_onchain_multihtlc_our_unilateral(node_factory, bitcoind):
 
     # Now, restart and manually reconnect end nodes (so they don't ignore HTLCs)
     # In fact, they'll fail them with WIRE_TEMPORARY_NODE_FAILURE.
+    # TODO Remove our reliance on HTLCs failing on startup and the need for
+    #      this plugin
+    nodes[0].daemon.opts['plugin'] = 'tests/plugins/fail_htlcs.py'
+    nodes[-1].daemon.opts['plugin'] = 'tests/plugins/fail_htlcs.py'
     nodes[0].restart()
     nodes[-1].restart()
 
@@ -1213,6 +1217,10 @@ def test_onchain_multihtlc_their_unilateral(node_factory, bitcoind):
 
     # Now, restart and manually reconnect end nodes (so they don't ignore HTLCs)
     # In fact, they'll fail them with WIRE_TEMPORARY_NODE_FAILURE.
+    # TODO Remove our reliance on HTLCs failing on startup and the need for
+    #      this plugin
+    nodes[0].daemon.opts['plugin'] = 'tests/plugins/fail_htlcs.py'
+    nodes[-1].daemon.opts['plugin'] = 'tests/plugins/fail_htlcs.py'
     nodes[0].restart()
     nodes[-1].restart()
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1,4 +1,5 @@
 from fixtures import *  # noqa: F401,F403
+from flaky import flaky
 from lightning import RpcError
 from utils import only_one, sync_blockheight, wait_for, DEVELOPER, TIMEOUT, VALGRIND, SLOW_MACHINE
 
@@ -1493,6 +1494,7 @@ def test_shutdown(node_factory):
     l1.rpc.stop()
 
 
+@flaky
 @unittest.skipIf(not DEVELOPER, "needs to set upfront_shutdown_script")
 def test_option_upfront_shutdown_script(node_factory, bitcoind):
     l1 = node_factory.get_node(start=False)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,6 +107,26 @@ def test_plugin_disable(node_factory):
         n.rpc.hello(name='Sun')
 
 
+def test_plugin_hook(node_factory, executor):
+    """The helloworld plugin registers a htlc_accepted hook.
+
+    The hook will sleep for a few seconds and log a
+    message. `lightningd` should wait for the response and only then
+    complete the payment.
+
+    """
+    l1, l2 = node_factory.line_graph(2, opts={'plugin': 'contrib/plugins/helloworld.py'})
+    start_time = time.time()
+    f = executor.submit(l1.pay, l2, 100000)
+    l2.daemon.wait_for_log(r'on_htlc_accepted called')
+
+    # The hook will sleep for 20 seconds before answering, so `f`
+    # should take at least that long.
+    f.result()
+    end_time = time.time()
+    assert(end_time >= start_time + 20)
+
+
 def test_plugin_notifications(node_factory):
     l1, l2 = node_factory.get_nodes(2, opts={'plugin': 'contrib/plugins/helloworld.py'})
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -330,3 +330,56 @@ def test_openchannel_hook(node_factory, bitcoind):
     l1.connect(l2)
     with pytest.raises(RpcError, match=r"I don't like odd amounts"):
         l1.rpc.fundchannel(l2.info['id'], 100001)
+
+
+def test_htlc_accepted_hook_fail(node_factory):
+    """Send payments from l1 to l2, but l2 just declines everything.
+
+    l2 is configured with a plugin that'll hook into htlc_accepted and
+    always return failures. The same should also work for forwarded
+    htlcs in the second half.
+
+    """
+    l1, l2, l3 = node_factory.line_graph(3, opts=[
+        {},
+        {'plugin': 'tests/plugins/fail_htlcs.py'},
+        {}
+    ], wait_for_announce=True)
+
+    # This must fail
+    inv = l2.rpc.invoice(1000, "lbl", "desc")['bolt11']
+    with pytest.raises(RpcError) as excinfo:
+        l1.rpc.pay(inv)
+    assert excinfo.value.error['data']['failcode'] == 16399
+    assert excinfo.value.error['data']['erring_index'] == 1
+
+    # And the invoice must still be unpaid
+    inv = l2.rpc.listinvoices("lbl")['invoices']
+    assert len(inv) == 1 and inv[0]['status'] == 'unpaid'
+
+    # Now try with forwarded HTLCs: l2 should still fail them
+    # This must fail
+    inv = l3.rpc.invoice(1000, "lbl", "desc")['bolt11']
+    with pytest.raises(RpcError) as excinfo:
+        l1.rpc.pay(inv)
+
+    # And the invoice must still be unpaid
+    inv = l3.rpc.listinvoices("lbl")['invoices']
+    assert len(inv) == 1 and inv[0]['status'] == 'unpaid'
+
+
+def test_htlc_accepted_hook_resolve(node_factory):
+    """l3 creates an invoice, l2 knows the preimage and will shortcircuit.
+    """
+    l1, l2, l3 = node_factory.line_graph(3, opts=[
+        {},
+        {'plugin': 'tests/plugins/shortcircuit.py'},
+        {}
+    ], wait_for_announce=True)
+
+    inv = l3.rpc.invoice(msatoshi=1000, label="lbl", description="desc", preimage="00" * 32)['bolt11']
+    l1.rpc.pay(inv)
+
+    # And the invoice must still be unpaid
+    inv = l3.rpc.listinvoices("lbl")['invoices']
+    assert len(inv) == 1 and inv[0]['status'] == 'unpaid'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -383,3 +383,38 @@ def test_htlc_accepted_hook_resolve(node_factory):
     # And the invoice must still be unpaid
     inv = l3.rpc.listinvoices("lbl")['invoices']
     assert len(inv) == 1 and inv[0]['status'] == 'unpaid'
+
+
+def test_htlc_accepted_hook_direct_restart(node_factory, executor):
+    """l2 restarts while it is pondering what to do with an HTLC.
+    """
+    l1, l2 = node_factory.line_graph(2, opts=[
+        {'may_reconnect': True},
+        {'may_reconnect': True, 'plugin': 'tests/plugins/hold_htlcs.py'}
+    ])
+
+    i1 = l2.rpc.invoice(msatoshi=1000, label="direct", description="desc")['bolt11']
+    f1 = executor.submit(l1.rpc.pay, i1)
+
+    l2.daemon.wait_for_log(r'Holding onto an incoming htlc for 10 seconds')
+    l2.restart()
+
+    f1.result()
+
+
+def test_htlc_accepted_hook_forward_restart(node_factory, executor):
+    """l2 restarts while it is pondering what to do with an HTLC.
+    """
+    l1, l2, l3 = node_factory.line_graph(3, opts=[
+        {'may_reconnect': True},
+        {'may_reconnect': True, 'plugin': 'tests/plugins/hold_htlcs.py'},
+        {'may_reconnect': True},
+    ], wait_for_announce=True)
+
+    i1 = l3.rpc.invoice(msatoshi=1000, label="direct", description="desc")['bolt11']
+    f1 = executor.submit(l1.rpc.pay, i1)
+
+    l2.daemon.wait_for_log(r'Holding onto an incoming htlc for 10 seconds')
+    l2.restart()
+
+    f1.result()

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -299,9 +299,15 @@ void json_object_end(struct json_stream *js UNNEEDED)
 /* Generated stub for json_object_start */
 void json_object_start(struct json_stream *ks UNNEEDED, const char *fieldname UNNEEDED)
 { fprintf(stderr, "json_object_start called!\n"); abort(); }
+/* Generated stub for json_strdup */
+char *json_strdup(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
+{ fprintf(stderr, "json_strdup called!\n"); abort(); }
 /* Generated stub for json_stream_success */
 struct json_stream *json_stream_success(struct command *cmd UNNEEDED)
 { fprintf(stderr, "json_stream_success called!\n"); abort(); }
+/* Generated stub for json_tok_bin_from_hex */
+u8 *json_tok_bin_from_hex(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
+{ fprintf(stderr, "json_tok_bin_from_hex called!\n"); abort(); }
 /* Generated stub for json_tok_channel_id */
 bool json_tok_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			 struct channel_id *cid UNNEEDED)
@@ -319,6 +325,17 @@ bool json_tok_streq(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, 
 bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			       struct node_id *id UNNEEDED)
 { fprintf(stderr, "json_to_node_id called!\n"); abort(); }
+/* Generated stub for json_to_number */
+bool json_to_number(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		    unsigned int *num UNNEEDED)
+{ fprintf(stderr, "json_to_number called!\n"); abort(); }
+/* Generated stub for json_to_preimage */
+bool json_to_preimage(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, struct preimage *preimage UNNEEDED)
+{ fprintf(stderr, "json_to_preimage called!\n"); abort(); }
+/* Generated stub for json_to_pubkey */
+bool json_to_pubkey(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		    struct pubkey *pubkey UNNEEDED)
+{ fprintf(stderr, "json_to_pubkey called!\n"); abort(); }
 /* Generated stub for json_to_short_channel_id */
 bool json_to_short_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			      struct short_channel_id *scid UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -112,11 +112,6 @@ u32 get_block_height(const struct chain_topology *topo UNNEEDED)
 /* Generated stub for get_chainparams */
 const struct chainparams *get_chainparams(const struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "get_chainparams called!\n"); abort(); }
-/* Generated stub for invoices_autoclean_set */
-void invoices_autoclean_set(struct invoices *invoices UNNEEDED,
-			    u64 cycle_seconds UNNEEDED,
-			    u64 expired_by UNNEEDED)
-{ fprintf(stderr, "invoices_autoclean_set called!\n"); abort(); }
 /* Generated stub for invoices_create */
 bool invoices_create(struct invoices *invoices UNNEEDED,
 		     struct invoice *pinvoice UNNEEDED,
@@ -255,6 +250,10 @@ void json_add_node_id(struct json_stream *response UNNEEDED,
 void json_add_num(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  unsigned int value UNNEEDED)
 { fprintf(stderr, "json_add_num called!\n"); abort(); }
+/* Generated stub for json_add_s32 */
+void json_add_s32(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		  int32_t value UNNEEDED)
+{ fprintf(stderr, "json_add_s32 called!\n"); abort(); }
 /* Generated stub for json_add_short_channel_id */
 void json_add_short_channel_id(struct json_stream *response UNNEEDED,
 			       const char *fieldname UNNEEDED,
@@ -271,6 +270,10 @@ void json_add_timeabs(struct json_stream *result UNNEEDED, const char *fieldname
 void json_add_txid(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		   const struct bitcoin_txid *txid UNNEEDED)
 { fprintf(stderr, "json_add_txid called!\n"); abort(); }
+/* Generated stub for json_add_u32 */
+void json_add_u32(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		  uint32_t value UNNEEDED)
+{ fprintf(stderr, "json_add_u32 called!\n"); abort(); }
 /* Generated stub for json_add_u64 */
 void json_add_u64(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  uint64_t value UNNEEDED)
@@ -332,10 +335,6 @@ bool json_to_number(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 /* Generated stub for json_to_preimage */
 bool json_to_preimage(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, struct preimage *preimage UNNEEDED)
 { fprintf(stderr, "json_to_preimage called!\n"); abort(); }
-/* Generated stub for json_to_pubkey */
-bool json_to_pubkey(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-		    struct pubkey *pubkey UNNEEDED)
-{ fprintf(stderr, "json_to_pubkey called!\n"); abort(); }
 /* Generated stub for json_to_short_channel_id */
 bool json_to_short_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			      struct short_channel_id *scid UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -212,6 +212,12 @@ void json_add_amount_msat_compat(struct json_stream *result UNNEEDED,
 				 const char *msatfieldname)
 
 { fprintf(stderr, "json_add_amount_msat_compat called!\n"); abort(); }
+/* Generated stub for json_add_amount_msat_only */
+void json_add_amount_msat_only(struct json_stream *result UNNEEDED,
+			  const char *msatfieldname UNNEEDED,
+			  struct amount_msat msat)
+
+{ fprintf(stderr, "json_add_amount_msat_only called!\n"); abort(); }
 /* Generated stub for json_add_amount_sat_compat */
 void json_add_amount_sat_compat(struct json_stream *result UNNEEDED,
 				struct amount_sat sat UNNEEDED,


### PR DESCRIPTION
This used to be part of #2237, but since there were some unaddressed concerns I split the two.

This PR builds on top of #2237, and implements the hook for `htlc_accepted` allowing a plugin to decide on what we should be doing with an HTLC that we just added to the commitment:

 - `continue` proceeds as usual with the HTLC, attempting to resolve it if we are the recipient of the payment, or forward it if we just an intermediate hop. This can be used to apply some policy that can't be implemented in `lightningd` itself, or delay resolution to see that we can actually deliver whatever we promised in exchange of the payment.
 - `resolve` claims the HTLC using a provided `payment_key`, this can be used to short-circuit payments, moving processing of the payment out (cross-chain atomic swaps), implement external invoicing functionality.
 - `fail` fails the HTLC directly.

The open questions mentioned above are about how to handle recovery on restart if we got interrupted after the HTLC was accepted, but before the plugin result was processed, i.e., we asked the plugin but couldn't act on its decision yet. The current plan is to just call the plugin again on startup, to ensure we act on its decision, but the downside is that it'd require the hooks to be idempotent.