### PR TITLE
Json tok speedup

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -180,13 +180,13 @@ const jsmntok_t *json_next(const jsmntok_t *tok)
 const jsmntok_t *json_get_member(const char *buffer, const jsmntok_t tok[],
 				 const char *label)
 {
-	const jsmntok_t *t, *end;
+	const jsmntok_t *t;
+	size_t i;
 
 	if (tok->type != JSMN_OBJECT)
 		return NULL;
 
-	end = json_next(tok);
-	for (t = tok + 1; t < end; t = json_next(t+1))
+	json_for_each_obj(i, t, tok)
 		if (json_tok_streq(buffer, t, label))
 			return t + 1;
 
@@ -195,13 +195,13 @@ const jsmntok_t *json_get_member(const char *buffer, const jsmntok_t tok[],
 
 const jsmntok_t *json_get_arr(const jsmntok_t tok[], size_t index)
 {
-	const jsmntok_t *t, *end;
+	const jsmntok_t *t;
+	size_t i;
 
 	if (tok->type != JSMN_ARRAY)
 		return NULL;
 
-	end = json_next(tok);
-	for (t = tok + 1; t < end; t = json_next(t)) {
+	json_for_each_arr(i, t, tok) {
 		if (index == 0)
 			return t;
 		index--;

--- a/common/json.h
+++ b/common/json.h
@@ -51,7 +51,7 @@ bool json_tok_is_num(const char *buffer, const jsmntok_t *tok);
 /* Is this the null primitive? */
 bool json_tok_is_null(const char *buffer, const jsmntok_t *tok);
 
-/* Returns next token with same parent. */
+/* Returns next token with same parent (WARNING: slow!). */
 const jsmntok_t *json_next(const jsmntok_t *tok);
 
 /* Get top-level member. */
@@ -84,5 +84,14 @@ void json_tok_remove(jsmntok_t **tokens, jsmntok_t *tok, size_t num);
 const jsmntok_t *json_delve(const char *buffer,
 			    const jsmntok_t *tok,
 			    const char *guide);
+
+/* Iterator macro for array: i is counter, t is token ptr, arr is JSMN_ARRAY */
+#define json_for_each_arr(i, t, arr) \
+	for (i = 0, t = (arr) + 1; i < (arr)->size; t = json_next(t), i++)
+
+/* Iterator macro for object: i is counter, t is token ptr (t+1 is
+ * contents of obj member), obj is JSMN_OBJECT */
+#define json_for_each_obj(i, t, obj) \
+	for (i = 0, t = (obj) + 1; i < (obj)->size; t = json_next(t+1), i++)
 
 #endif /* LIGHTNING_COMMON_JSON_H */

--- a/common/test/run-json.c
+++ b/common/test/run-json.c
@@ -74,6 +74,11 @@ static void test_json_tok_size(void)
 	assert(toks[0].size == 2);
 	assert(toks[2].size == 2);
 	assert(toks[6].size == 2);
+
+	/* This should *not* parse! (used to give toks[0]->size == 2!) */
+	buf = "{ 'satoshi', '546' }";
+	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	assert(!ok);
 }
 
 static void test_json_delve(void)

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -183,7 +183,7 @@ static void tok_tok(void)
 	{
 		unsigned int n;
 		const jsmntok_t *tok = NULL;
-		struct json *j = json_parse(cmd, "{ 'satoshi', '546' }");
+		struct json *j = json_parse(cmd, "{ 'satoshi': '546' }");
 
 		assert(param(cmd, j->buffer, j->toks,
 			     p_req("satoshi", param_tok, &tok), NULL));

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -331,15 +331,13 @@ static struct command_result *json_getroute(struct command *cmd,
 	*fuzz = *fuzz / 100.0;
 
 	if (excludetok) {
-		const jsmntok_t *t, *end = json_next(excludetok);
+		const jsmntok_t *t;
 		size_t i;
 
 		excluded = tal_arr(cmd, struct short_channel_id_dir,
 				   excludetok->size);
 
-		for (i = 0, t = excludetok + 1;
-		     t < end;
-		     t = json_next(t), i++) {
+		json_for_each_arr(i, t, excludetok) {
 			if (!short_channel_id_dir_from_str(buffer + t->start,
 							   t->end - t->start,
 							   &excluded[i])) {
@@ -486,7 +484,7 @@ static struct command_result *json_dev_query_scids(struct command *cmd,
 {
 	u8 *msg;
 	const jsmntok_t *scidstok;
-	const jsmntok_t *t, *end;
+	const jsmntok_t *t;
 	struct pubkey *id;
 	struct short_channel_id *scids;
 	size_t i;
@@ -498,8 +496,7 @@ static struct command_result *json_dev_query_scids(struct command *cmd,
 		return command_param_failed();
 
 	scids = tal_arr(cmd, struct short_channel_id, scidstok->size);
-	end = json_next(scidstok);
-	for (i = 0, t = scidstok + 1; t < end; t = json_next(t), i++) {
+	json_for_each_arr(i, t, scidstok) {
 		if (!json_to_short_channel_id(buffer, t, &scids[i])) {
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "scid %zu '%.*s' is not an scid",

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -981,8 +981,8 @@ static struct command_result *json_sendpay(struct command *cmd,
 					   const jsmntok_t *params)
 {
 	const jsmntok_t *routetok;
-	const jsmntok_t *t, *end;
-	size_t n_hops;
+	const jsmntok_t *t;
+	size_t i;
 	struct sha256 *rhash;
 	struct route_hop *route;
 	u64 *msatoshi;
@@ -996,11 +996,11 @@ static struct command_result *json_sendpay(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
-	end = json_next(routetok);
-	n_hops = 0;
-	route = tal_arr(cmd, struct route_hop, n_hops);
+	if (routetok->size == 0)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Empty route");
 
-	for (t = routetok + 1; t < end; t = json_next(t)) {
+	route = tal_arr(cmd, struct route_hop, routetok->size);
+	json_for_each_arr(i, t, routetok) {
 		u64 *amount;
 		struct pubkey *id;
 		struct short_channel_id *channel;
@@ -1015,19 +1015,12 @@ static struct command_result *json_sendpay(struct command *cmd,
 			   NULL))
 			return command_param_failed();
 
-		tal_resize(&route, n_hops + 1);
-
-		route[n_hops].amount = *amount;
-		route[n_hops].nodeid = *id;
-		route[n_hops].delay = *delay;
-		route[n_hops].channel_id = *channel;
+		route[i].amount = *amount;
+		route[i].nodeid = *id;
+		route[i].delay = *delay;
+		route[i].channel_id = *channel;
 		/* FIXME: Actually ignored by sending code! */
-		route[n_hops].direction = direction ? *direction : 0;
-		n_hops++;
-	}
-
-	if (n_hops == 0) {
-		return command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Empty route");
+		route[i].direction = direction ? *direction : 0;
 	}
 
 	/* The given msatoshi is the actual payment that the payee is
@@ -1036,8 +1029,8 @@ static struct command_result *json_sendpay(struct command *cmd,
 
 	/* if not: msatoshi <= finalhop.amount <= 2 * msatoshi, fail. */
 	if (msatoshi) {
-		if (!(*msatoshi <= route[n_hops-1].amount &&
-		      route[n_hops-1].amount <= 2 * *msatoshi)) {
+		if (!(*msatoshi <= route[routetok->size-1].amount &&
+		      route[routetok->size-1].amount <= 2 * *msatoshi)) {
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "msatoshi %"PRIu64" out of range",
 					    *msatoshi);
@@ -1045,7 +1038,7 @@ static struct command_result *json_sendpay(struct command *cmd,
 	}
 
 	if (send_payment(cmd, cmd->ld, rhash, route,
-			 msatoshi ? *msatoshi : route[n_hops-1].amount,
+			 msatoshi ? *msatoshi : route[routetok->size-1].amount,
 			 description,
 			 &json_sendpay_on_resolve, cmd))
 		return command_still_pending(cmd);


### PR DESCRIPTION
Built on top of #2215 simply because that's where @cdecker pointed out we weren't using tok->size for iteration and thus doing twice the work we needed to.

So just review the last 4 ("common/test/run-json: check tok->size is as expected" onwards)