### PR TITLE
fundchannel command: return an error when broadcast fails

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -39,6 +39,7 @@
 #define FUND_MAX_EXCEEDED               300
 #define FUND_CANNOT_AFFORD              301
 #define FUND_OUTPUT_IS_DUST             302
+#define FUNDING_BROADCAST_FAIL          303
 
 /* Errors from `invoice` command */
 #define INVOICE_LABEL_ALREADY_EXISTS	900

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/07/2018
+.\"      Date: 01/22/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "12/07/2018" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "01/22/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -93,6 +93,17 @@ The following error codes may occur:
 .IP \(bu 2.3
 .\}
 302\&. The output amount is too small, and would be considered dust\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+303\&. Broadcasting of the funding transaction failed, the internal call to bitcoin\-cli returned with an error\&.
 .RE
 .sp
 Failure may also occur if \fBlightningd\fR and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc\&.)\&.

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -53,6 +53,8 @@ The following error codes may occur:
 * 301. There are not enough funds in the internal wallet (including fees) to
        create the transaction.
 * 302. The output amount is too small, and would be considered dust.
+* 303. Broadcasting of the funding transaction failed, the internal call to
+       bitcoin-cli returned with an error.
 
 Failure may also occur if *lightningd* and the peer cannot agree on channel
 parameters (funding limits, channel reserves, fees, etc.).

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -200,8 +200,8 @@ static void broadcast_done(struct bitcoind *bitcoind,
 	/* No longer needs to be disconnected if channel dies. */
 	tal_del_destructor2(otx->channel, clear_otx_channel, otx);
 
-	if (otx->failed && exitstatus != 0) {
-		otx->failed(otx->channel, exitstatus, msg);
+	if (otx->failed_or_success) {
+		otx->failed_or_success(otx->channel, exitstatus, msg);
 		tal_free(otx);
 	} else {
 		/* For continual rebroadcasting, until channel freed. */
@@ -213,7 +213,7 @@ static void broadcast_done(struct bitcoind *bitcoind,
 
 void broadcast_tx(struct chain_topology *topo,
 		  struct channel *channel, const struct bitcoin_tx *tx,
-		  void (*failed)(struct channel *channel,
+		  void (*failed_or_success)(struct channel *channel,
 				 int exitstatus, const char *err))
 {
 	/* Channel might vanish: topo owns it to start with. */
@@ -223,7 +223,7 @@ void broadcast_tx(struct chain_topology *topo,
 	otx->channel = channel;
 	bitcoin_txid(tx, &otx->txid);
 	otx->hextx = tal_hex(otx, rawtx);
-	otx->failed = failed;
+	otx->failed_or_success = failed_or_success;
 	tal_free(rawtx);
 	tal_add_destructor2(channel, clear_otx_channel, otx);
 

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -37,7 +37,7 @@ struct outgoing_tx {
 	struct channel *channel;
 	const char *hextx;
 	struct bitcoin_txid txid;
-	void (*failed)(struct channel *channel, int exitstatus, const char *err);
+	void (*failed_or_success)(struct channel *channel, int exitstatus, const char *err);
 };
 
 struct block {

--- a/tests/btcproxy.py
+++ b/tests/btcproxy.py
@@ -56,6 +56,7 @@ class BitcoinRpcProxy(object):
         except JSONRPCError as e:
             reply = {
                 "error": e.error,
+                "code": -32603,
                 "id": r['id']
             }
         self.request_count += 1

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1120,7 +1120,8 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     # Fund the channel.
     # The process will complete, but funder will be unable
     # to broadcast and confirm funding tx.
-    l1.rpc.fundchannel(l2.info['id'], 10**6)
+    with pytest.raises(RpcError, match=r'sendrawtransaction disabled'):
+        l1.rpc.fundchannel(l2.info['id'], 10**6)
 
     # Generate blocks until unconfirmed.
     bitcoind.generate_block(blocks)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1112,7 +1112,7 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
     time.sleep(1)
 
     def mock_sendrawtransaction(r):
-        return {'error': 'sendrawtransaction disabled'}
+        return {'id': r['id'], 'error': {'code': 100, 'message': 'sendrawtransaction disabled'}}
 
     # Prevent funder from broadcasting funding tx (any tx really).
     l1.daemon.rpcproxy.mock_rpc('sendrawtransaction', mock_sendrawtransaction)


### PR DESCRIPTION
openingd/json_fund_channel:
    - result fundchannel command now depends on successful or failed broadcast of the funding tx
    - failure returns error code FUNDING_BROADCAST_FAIL
    - don't fail the channel when broadcast failed, but keep in CHANNELD_AWAITING_LOCKIN
    - after fixing the initial broadcast failure, the user could manually rebroadcast the tx and
      keep the channel
    
openingd/opening_funder_finished:
    - broadcast_tx callback function now handles both success and failure
    
jsonrpc: added error code FUNDING_BROADCAST_FAIL
    manpage: added error code returned by fundchannel command
    
This makes the user more aware of broadcast failure, so it hopefully doesn't
try to broadcast new tx's that depend on its change_outputs. Some users have reported (see
issue #2171) a whole sequence of fundings failing, because each funding was using the change
output of the previous one, which would not confirm.