### PR TITLE
plugin: Increase manifest timeout to 60 seconds

### DIFF
--- a/contrib/plugins/fail/failtimeout.py
+++ b/contrib/plugins/fail/failtimeout.py
@@ -9,8 +9,8 @@ import time
 
 
 def json_getmanifest(request):
-    # Timeout is 10 seconds, so wait 11
-    time.sleep(11)
+    # Timeout is 60 seconds, so wait 11
+    time.sleep(61)
     return {
         "options": [
         ],

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -31,7 +31,7 @@
  * hangs we can't do much, so we put an upper bound on the time we're
  * willing to wait. Plugins shouldn't do any initialization in the
  * `getmanifest` call anyway, that's what `init `is for. */
-#define PLUGIN_MANIFEST_TIMEOUT 10
+#define PLUGIN_MANIFEST_TIMEOUT 60
 
 struct plugin {
 	struct list_node list;


### PR DESCRIPTION
Valgrind seems to be slowing the pay-plugin down enough for the 10
seconds timeout to get triggered on a semi-regular basis.

Reported-by: Rusty Russell <@rustyrussell>
Signed-off-by: Christian Decker <decker.christian@gmail.com>