### PR TITLE
libplugin: quick fix for bad JSON produced by plugins on bad paramters.

### DIFF
--- a/common/param.c
+++ b/common/param.c
@@ -53,7 +53,7 @@ static struct command_result *post_check(struct command *cmd,
 	while (first != last && first->required) {
 		if (!first->is_set) {
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-					    "missing required parameter: '%s'",
+					    "missing required parameter: %s",
 					    first->name);
 		}
 		first++;
@@ -124,7 +124,7 @@ static struct command_result *parse_by_name(struct command *cmd,
 		if (!p) {
 			if (!allow_extra) {
 				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-						    "unknown parameter: '%.*s'",
+						    "unknown parameter: %.*s",
 						    t->end - t->start,
 						    buffer + t->start);
 			}
@@ -133,7 +133,7 @@ static struct command_result *parse_by_name(struct command *cmd,
 
 			if (p->is_set) {
 				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-						    "duplicate json names: '%s'",
+						    "duplicate json names: %s",
 						    p->name);
 			}
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,3 +116,6 @@ def test_pay_plugin(node_factory):
 
     res = l1.rpc.pay(bolt11=inv['bolt11'])
     assert res['status'] == 'complete'
+
+    with pytest.raises(RpcError, match=r'missing required parameter'):
+        l1.rpc.call('pay')


### PR DESCRIPTION
Internally libplugin turns ' into ", which causes these messages to produce bad JSON.

The real fix is to remove the '->" convenience substitution and port the JSON creation APIs into common/ from lightningd/

Fixes #2278

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>