### PR TITLE
option_data_loss_protect: reenable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The `short_channel_id` separator has been changed to be `x` to match the specification.
 - JSON API: `listpeers` now includes `funding_allocation_msat`, which returns a map of the amounts initially funded to the channel by each peer, indexed by channel id.
+- `option_data_loss_protect` is now enabled by default.
 
 ### Deprecated
 

--- a/common/features.c
+++ b/common/features.c
@@ -4,9 +4,7 @@
 #include <wire/peer_wire.h>
 
 static const u32 our_localfeatures[] = {
-#if EXPERIMENTAL_FEATURES
 	LOCAL_DATA_LOSS_PROTECT,
-#endif
 	LOCAL_INITIAL_ROUTING_SYNC,
 	LOCAL_GOSSIP_QUERIES
 };

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from fixtures import *  # noqa: F401,F403
 from lightning import RpcError
-from utils import DEVELOPER, only_one, wait_for, sync_blockheight, VALGRIND, EXPERIMENTAL_FEATURES
+from utils import DEVELOPER, only_one, wait_for, sync_blockheight, VALGRIND
 
 
 import os
@@ -1009,10 +1009,7 @@ def test_forget_channel(node_factory):
 
 def test_peerinfo(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'may_reconnect': True})
-    if EXPERIMENTAL_FEATURES:
-        lfeatures = '8a'
-    else:
-        lfeatures = '88'
+    lfeatures = '8a'
     # Gossiping but no node announcement yet
     assert l1.rpc.getpeer(l2.info['id'])['connected']
     assert len(l1.rpc.getpeer(l2.info['id'])['channels']) == 0
@@ -1255,7 +1252,6 @@ def test_funder_simple_reconnect(node_factory, bitcoind):
 
 
 @unittest.skipIf(not DEVELOPER, "needs LIGHTNINGD_DEV_LOG_IO")
-@unittest.skipIf(not EXPERIMENTAL_FEATURES, "needs option_data_loss_protect")
 def test_dataloss_protection(node_factory, bitcoind):
     l1 = node_factory.get_node(may_reconnect=True, log_all_io=True,
                                feerates=(7500, 7500, 7500))


### PR DESCRIPTION
Just removed the bare minimum to get `option_data_loss_protect` to be enabled by default. 

@rustyrussell should I also remove the EXPERIMENTAL_FEATURES flag?