### PR TITLE
make: Add an option to compile with address sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ VG=valgrind -q --error-exitcode=7
 VG_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes --errors-for-leak-kinds=all
 endif
 
+ifneq ($(ASAN),0)
+SANITIZER_FLAGS=-fsanitize=address
+else
+SANITIZER_FLAGS=
+endif
+
 ifeq ($(DEVELOPER),1)
 DEV_CFLAGS=-DCCAN_TAKE_DEBUG=1 -DCCAN_TAL_DEBUG=1
 else
@@ -179,13 +185,13 @@ ALL_PROGRAMS =
 
 CPPFLAGS = -DBINTOPKGLIBEXECDIR='"'$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))'"'
 CWARNFLAGS := -Werror -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition
-CDEBUGFLAGS := -std=gnu11 -g -fstack-protector
+CDEBUGFLAGS := -std=gnu11 -g -fstack-protector $(SANITIZER_FLAGS)
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS)
 
 # We can get configurator to run a different compile cmd to cross-configure.
 CONFIGURATOR_CC := $(CC)
 
-LDFLAGS = $(PIE_LDFLAGS)
+LDFLAGS = $(PIE_LDFLAGS) $(SANITIZER_FLAGS)
 ifeq ($(STATIC),1)
 LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp -lsqlite3 -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
 else

--- a/configure
+++ b/configure
@@ -13,6 +13,7 @@ EXPERIMENTAL_FEATURES=${EXPERIMENTAL_FEATURES:-0}
 COMPAT=${COMPAT:-1}
 STATIC=${STATIC:-0}
 CONFIGURATOR_CC=${CONFIGURATOR_CC:-$CC}
+ASAN=${ASAN:-0}
 
 CONFIGURATOR=ccan/tools/configurator/configurator
 CONFIG_VAR_FILE=config.vars
@@ -55,8 +56,10 @@ usage()
     echo "    Compatibility mode, good to disable to see if your software breaks"
     usage_with_default "--enable/disable-valgrind" "(autodetect)"
     echo "    Valgrind binary to use for tests"
-    usage_with_default "--enable/disable-static" "$STATIC" "enable" "disable" 
+    usage_with_default "--enable/disable-static" "$STATIC" "enable" "disable"
     echo "    Static link binary"
+    usage_with_default "--enable/disable-address-sanitizer" "$ASAN" "enable" "disable"
+    echo "    Compile with address-sanitizer"
     exit 1
 }
 
@@ -119,6 +122,8 @@ for opt in "$@"; do
 	--disable-valgrind) VALGRIND=0;;
 	--enable-static) STATIC=1;;
 	--disable-static) STATIC=0;;
+	--enable-address-sanitizer) ASAN=1;;
+	--disable-address-sanitizer) ASAN=0;;
 	--help|-h) usage;;
 	*)
 	    echo "Unknown option '$opt'" >&2
@@ -139,6 +144,17 @@ if [ -z "$VALGRIND" ]; then
     fi
 fi
 
+if [ "$ASAN" = "1" ]; then
+    if [ "$CC" != "gcc" ] && [ "$CC" != "cc" ]; then
+	echo "Address sanitizer (ASAN) is currently only supported with gcc"
+	exit 1
+    fi
+    if [ "$VALGRIND" = "1" ]; then
+	echo "Address sanitizer (ASAN) and valgrind cannot be enabled at the same time"
+	exit 1
+    fi
+fi
+
 rm -f $CONFIG_VAR_FILE.$$
 $CONFIGURATOR --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" "$CC" $CWARNFLAGS $CDEBUGFLAGS
 mv $CONFIG_VAR_FILE.$$ $CONFIG_VAR_FILE
@@ -154,6 +170,7 @@ add_var EXPERIMENTAL_FEATURES "$EXPERIMENTAL_FEATURES" $CONFIG_HEADER
 add_var COMPAT "$COMPAT" $CONFIG_HEADER
 add_var PYTEST "$PYTEST"
 add_var STATIC "$STATIC"
+add_var ASAN "$ASAN"
 
 # Hack to avoid sha256 name clash with libwally: will be fixed when that
 # becomes a standalone shared lib.


### PR DESCRIPTION
Currently only works with `gcc` due to google/sanitizers#1028, so
configure makes sure we warn if clang with ASAN is attempted.

According to [my benchmarks][benchmarks] the performance degradation
is small enough to have it active always.

Would be nice to eventually get `clang` working as well, since it has some additional sanitizers, such as the memory sanitizer which guards uninitialized values.

Fixes #2277 

[benchmarks]: https://github.com/ElementsProject/lightning/issues/2277#issuecomment-455897417

Signed-off-by: Christian Decker <decker.christian@gmail.com>