### PR TITLE
docs: Changed testnet faucet

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,8 @@ open a channel:
 
 `lightningd` will register the funds once the transaction is confirmed.
 
-If you don't have any testcoins you can get a few from a faucet such as
-[TPs' testnet faucet][tps] or [Kiwi's testnet faucet][kiw].
-You can send it directly to the `lightningd` address.
+You can obtain testcoins from a faucet such as [coinfaucet.eu][cfeu].
+You can send them directly to the `lightningd` address.
 
 You may need to generate a p2sh-segwit address if the faucet does not support
 bech32:
@@ -167,8 +166,7 @@ bech32:
     # Return a p2sh-segwit address
     cli/lightning-cli newaddr p2sh-segwit
 
-[tps]: http://tpfaucet.appspot.com/
-[kiw]: https://testnet.manu.backend.hamburg/faucet
+[cfeu]: https://coinfaucet.eu/en/btc-testnet
 
 Confirm `lightningd` got funds by:
 


### PR DESCRIPTION
The previous faucets don't work and appear abandoned.
This is the only one I found that works  this morning.
Note: This faucet uses 40% of your CPU to mine monero!

Signed-off-by: Mark Beckwith <wythe@intrig.com>