### PR TITLE
remove unused local var in plugin.py

### DIFF
--- a/contrib/pylightning/lightning/plugin.py
+++ b/contrib/pylightning/lightning/plugin.py
@@ -227,7 +227,7 @@ class Plugin(object):
 
         try:
             self._exec_func(func, request)
-        except Exception as _:
+        except Exception:
             self.log(traceback.format_exc())
 
     def notify(self, method, params):


### PR DESCRIPTION
Fix make check-python error:
```
contrib/pylightning/lightning/plugin.py:230:9: F841 local variable '_' is assigned to but never used
```
