### PR TITLE
fix cppcheck error: uninitialized variable

### DIFF
--- a/common/param.c
+++ b/common/param.c
@@ -68,8 +68,8 @@ static struct command_result *parse_by_position(struct command *cmd,
 						bool allow_extra)
 {
 	struct command_result *res;
-	const jsmntok_t *tok;
-	size_t i;
+	const jsmntok_t *tok = NULL;
+	size_t i = 0;
 
 	json_for_each_arr(i, tok, tokens) {
 		/* check for unexpected trailing params */
@@ -115,8 +115,8 @@ static struct command_result *parse_by_name(struct command *cmd,
 					    const jsmntok_t tokens[],
 					    bool allow_extra)
 {
-	size_t i;
-	const jsmntok_t *t;
+	size_t i = 0;
+	const jsmntok_t *t = NULL;
 
 	json_for_each_obj(i, t, tokens) {
 		struct param *p = find_param(params, buffer + t->start,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -330,8 +330,8 @@ static struct command_result *json_getroute(struct command *cmd,
 	*fuzz = *fuzz / 100.0;
 
 	if (excludetok) {
-		const jsmntok_t *t;
-		size_t i;
+		const jsmntok_t *t = NULL;
+		size_t i = 0;
 
 		excluded = tal_arr(cmd, struct short_channel_id_dir,
 				   excludetok->size);
@@ -483,10 +483,10 @@ static struct command_result *json_dev_query_scids(struct command *cmd,
 {
 	u8 *msg;
 	const jsmntok_t *scidstok;
-	const jsmntok_t *t;
+	const jsmntok_t *t = NULL;
 	struct pubkey *id;
 	struct short_channel_id *scids;
-	size_t i;
+	size_t i = 0;
 
 	if (!param(cmd, buffer, params,
 		   p_req("id", param_pubkey, &id),

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -307,8 +307,8 @@ static struct route_info *unpack_route(const tal_t *ctx,
 				       const char *buffer,
 				       const jsmntok_t *routetok)
 {
-	const jsmntok_t *t;
-	size_t i;
+	const jsmntok_t *t = NULL;
+	size_t i = 0;
 	struct route_info *route = tal_arr(ctx, struct route_info, routetok->size);
 
 	json_for_each_arr(i, t, routetok) {
@@ -407,8 +407,8 @@ static struct command_result *json_invoice(struct command *cmd,
 	}
 
 	if (fallbacks) {
-		size_t i;
-		const jsmntok_t *t;
+		size_t i = 0;
+		const jsmntok_t *t = NULL;
 
 		fallback_scripts = tal_arr(cmd, const u8 *, fallbacks->size);
 		json_for_each_arr(i, t, fallbacks) {

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -732,8 +732,8 @@ static struct command_result *json_sendpay(struct command *cmd,
 					   const jsmntok_t *params)
 {
 	const jsmntok_t *routetok;
-	const jsmntok_t *t;
-	size_t i;
+	const jsmntok_t *t = NULL;
+	size_t i = 0;
 	struct sha256 *rhash;
 	struct route_hop *route;
 	u64 *msatoshi;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -345,8 +345,8 @@ static const jsmntok_t *find_worst_channel(const char *buf,
 					   u64 final)
 {
 	u64 prev = final, worstval = 0;
-	const jsmntok_t *worst = NULL, *t;
-	size_t i;
+	const jsmntok_t *worst = NULL, *t = NULL;
+	size_t i = 0;
 
 	json_for_each_arr(i, t, route) {
 		u64 val;
@@ -616,8 +616,8 @@ static struct command_result *add_shadow_route(struct command *cmd,
 {
 	/* Use reservoir sampling across the capable channels. */
 	const jsmntok_t *channels = json_get_member(buf, result, "channels");
-	const jsmntok_t *chan, *best = NULL;
-	size_t i;
+	const jsmntok_t *chan = NULL, *best = NULL;
+	size_t i = 0;
 	u64 sample;
 	u32 cltv, best_cltv;
 
@@ -676,8 +676,8 @@ static struct command_result *listpeers_done(struct command *cmd,
 					     const jsmntok_t *result,
 					     struct pay_command *pc)
 {
-	const jsmntok_t *peers, *peer;
-	size_t i;
+	const jsmntok_t *peers, *peer = NULL;
+	size_t i = 0;
 	char *mods = tal_strdup(tmpctx, "");
 
 	peers = json_get_member(buf, result, "peers");
@@ -686,9 +686,9 @@ static struct command_result *listpeers_done(struct command *cmd,
 			   result->end - result->start, buf);
 
 	json_for_each_arr(i, peer, peers) {
-		const jsmntok_t *chans, *chan;
+		const jsmntok_t *chans, *chan = NULL;
 		bool connected;
-		size_t j;
+		size_t j = 0;
 
 		json_to_bool(buf, json_get_member(buf, peer, "connected"),
 			     &connected);


### PR DESCRIPTION
Fix make check-source error:
```
[common/param.c:74]: (error) Uninitialized variable: tok
[common/param.c:74]: (error) Uninitialized variable: i
[common/param.c:121]: (error) Uninitialized variable: i
[common/param.c:121]: (error) Uninitialized variable: t
[lightningd/gossip_control.c:339]: (error) Uninitialized variable: t
[lightningd/gossip_control.c:339]: (error) Uninitialized variable: i
[lightningd/gossip_control.c:498]: (error) Uninitialized variable: t
[lightningd/gossip_control.c:498]: (error) Uninitialized variable: i
[lightningd/invoice.c:414]: (error) Uninitialized variable: i
[lightningd/invoice.c:414]: (error) Uninitialized variable: t
[lightningd/invoice.c:314]: (error) Uninitialized variable: t
[lightningd/invoice.c:314]: (error) Uninitialized variable: i
[lightningd/pay.c:755]: (error) Uninitialized variable: t
[lightningd/pay.c:755]: (error) Uninitialized variable: i
[plugins/pay.c:351]: (error) Uninitialized variable: t
[plugins/pay.c:351]: (error) Uninitialized variable: i
[plugins/pay.c:624]: (error) Uninitialized variable: chan
[plugins/pay.c:624]: (error) Uninitialized variable: i
[plugins/pay.c:688]: (error) Uninitialized variable: peer
[plugins/pay.c:688]: (error) Uninitialized variable: i
[plugins/pay.c:696]: (error) Uninitialized variable: chan
[plugins/pay.c:696]: (error) Uninitialized variable: j
Makefile:306: recipe for target 'check-cppcheck' failed
make: *** [check-cppcheck] Error 123
```
