### PR TITLE
channeld: prioritize read from peer over write to peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ changes.
 
 - Protocol: handling `query_channel_range` for large numbers of blocks
   (eg. 4 billion) was slow due to a bug.
+- Fixed occasional deadlock with peers when exchanging huge amounts of gossip.
 
 ### Security
 

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2928,6 +2928,10 @@ int main(int argc, char *argv[])
 					      "Can't read command: %s",
 					      strerror(errno));
 			req_in(peer, msg);
+		} else if (FD_ISSET(PEER_FD, &rfds)) {
+			/* This could take forever, but who cares? */
+			msg = sync_crypto_read(tmpctx, &peer->cs, PEER_FD);
+			peer_in(peer, msg);
 		} else if (FD_ISSET(GOSSIP_FD, &rfds)) {
 			msg = wire_sync_read(tmpctx, GOSSIP_FD);
 			/* Gossipd hangs up on us to kill us when a new
@@ -2935,10 +2939,6 @@ int main(int argc, char *argv[])
 			if (!msg)
 				peer_failed_connection_lost();
 			handle_gossip_msg(PEER_FD, &peer->cs, take(msg));
-		} else if (FD_ISSET(PEER_FD, &rfds)) {
-			/* This could take forever, but who cares? */
-			msg = sync_crypto_read(tmpctx, &peer->cs, PEER_FD);
-			peer_in(peer, msg);
 		}
 	}
 

--- a/common/read_peer_msg.c
+++ b/common/read_peer_msg.c
@@ -26,18 +26,18 @@ u8 *peer_or_gossip_sync_read(const tal_t *ctx,
 	select(peer_fd > gossip_fd ? peer_fd + 1 : gossip_fd + 1,
 	       &readfds, NULL, NULL, NULL);
 
-	if (FD_ISSET(gossip_fd, &readfds)) {
-		msg = wire_sync_read(ctx, gossip_fd);
-		if (!msg)
-			status_failed(STATUS_FAIL_GOSSIP_IO,
-				      "Error reading gossip msg: %s",
-				      strerror(errno));
-		*from_gossipd = true;
+	if (FD_ISSET(peer_fd, &readfds)) {
+		msg = sync_crypto_read(ctx, cs, peer_fd);
+		*from_gossipd = false;
 		return msg;
 	}
 
-	msg = sync_crypto_read(ctx, cs, peer_fd);
-	*from_gossipd = false;
+	msg = wire_sync_read(ctx, gossip_fd);
+	if (!msg)
+		status_failed(STATUS_FAIL_GOSSIP_IO,
+			      "Error reading gossip msg: %s",
+			      strerror(errno));
+	*from_gossipd = true;
 	return msg;
 }
 


### PR DESCRIPTION
channeld: prioritize read from peer over write to peer

This solves (or at least reduces probability of) a deadlock in channeld
when there is lot of gossip traffic, see issue #2286. That issue is
almost identical to #1943 (deadlock in openingd) and so is the fix.

I did a simple test, monitoring socket traffic Recv-Q and Send-Q at 1 second interval, using `ss -4 -t -p | egrep "lightning|State"` during startup. The node has one channel with satoshisplace, so I don't know if this problem is specific to that node, but this solved the deadlock for me.

Result after this commit:
```
State   Recv-Q Send-Q Local Address:Port                 Peer Address:Port                
ESTAB 0 107 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_conne",pid=30591,fd=6))
ESTAB 0 106833 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 2242 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 118931 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 192867 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 60478 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 191260 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 71770 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 65781 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 68496 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 622707 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 2916 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 84782 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 24917 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 36609 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 10866 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 794 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 76226 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 1245 5648 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 630629 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 626984 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 486528 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 373345 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
ESTAB 0 0 192.168.1.166:44902 88.98.213.235:9735 users:(("lightning_chann",pid=30628,fd=3))
...
```

Result before this commit:
```
State   Recv-Q Send-Q Local Address:Port                 Peer Address:Port                
ESTAB 133145 124528 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
ESTAB 249555 162176 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
ESTAB 250835 193264 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
ESTAB 250835 193264 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
ESTAB 250835 193264 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
ESTAB 250835 193264 192.168.1.166:45256 88.98.213.235:9735 users:(("lightning_chann",pid=31325,fd=3))
...
```