### PR TITLE
Makefile: fix make install to depend on plugins.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ PKGLIBEXEC_PROGRAMS = \
 	       lightningd/lightning_openingd
 PLUGINS=plugins/pay
 
-install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS)
+install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS)
 	@$(NORMAL_INSTALL)
 	$(INSTALL_PROGRAM) $(BIN_PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(PKGLIBEXEC_PROGRAMS) $(DESTDIR)$(pkglibexecdir)


### PR DESCRIPTION
Otherwise a straight "make install" gives:
	install: cannot stat 'plugins/pay': No such file or directory
	make: *** [Makefile:482: install-program] Error 1

Fixes: #2288
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>