### PR TITLE
Fix docker image build from fresh clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,9 @@ RUN mkdir /opt/litecoin && cd /opt/litecoin \
 ENV LIGHTNINGD_VERSION=master
 
 WORKDIR /opt/lightningd
-COPY . .
+COPY . /tmp/lightning
+RUN git clone --recursive /tmp/lightning . && \
+    git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
 
 ARG DEVELOPER=0
 RUN ./configure && make -j3 DEVELOPER=${DEVELOPER} && cp lightningd/lightning* cli/lightning-cli /usr/bin/

--- a/contrib/linuxarm32v7.Dockerfile
+++ b/contrib/linuxarm32v7.Dockerfile
@@ -82,7 +82,10 @@ RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
 
 COPY --from=downloader /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 WORKDIR /opt/lightningd
-COPY . .
+COPY . /tmp/lightning
+RUN git clone --recursive /tmp/lightning . && \
+    git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
+
 ARG DEVELOPER=0
 RUN ./configure --enable-static && make -j3 DEVELOPER=${DEVELOPER} && cp lightningd/lightning* cli/lightning-cli /usr/bin/
 


### PR DESCRIPTION
This was failing the docker hub builds, since the git-config retains
an absolute path to the worktree location when cloning. Copying it
over from the host system means that this path now points to a
non-existent location, which then interfered with the submodule
initialization.

This fixes it by not using the copy directly, but rather it creates a
clean clone from the copied location, including a submodule init.

Fixes #2309 