### PR TITLE
Add circleci support for building images and pushing to docker when t…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,140 @@
+version: 2
+jobs:
+  # publish jobs require $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS defined
+  linuxamd64_publish:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim "v" from tag
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-amd64 -f Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-amd64
+  linuxarm32v7_publish:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim "v" from tag
+            # Make sure the builder is copy the arm emulator
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            sed -i -e 's/#EnableQEMU //g' "contrib/linuxarm32v7.Dockerfile"
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 -f contrib/linuxarm32v7.Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-arm32v7
+  linuxarm32v7_dev_publish:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim "v" from tag
+            #
+            sudo docker build --build-arg "DEVELOPER=1" -t "$DOCKERHUB_REPO:$LATEST_TAG-dev" .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-dev
+  publish_docker_multiarch:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim "v" from tag
+            sudo docker manifest create --amend $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-amd64 $DOCKERHUB_REPO:$LATEST_TAG-arm32v7
+            sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-amd64 --os linux --arch amd64
+            sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
+            sudo docker manifest push $DOCKERHUB_REPO:$LATEST_TAG -p
+  linuxamd64_dev_build:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker build --build-arg "DEVELOPER=1" -t "temp-dev" .
+  linuxamd64_build:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker build -t "temp" .
+  linuxarm32v7_build:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            sed -i -e 's/#EnableQEMU //g' "contrib/linuxarm32v7.Dockerfile"
+            sudo docker build -t "temp-arm" -f contrib/linuxarm32v7.Dockerfile .
+workflows:
+  version: 2
+  publish:
+    jobs:
+      - linuxamd64_build:
+          filters:
+            branches:
+              only: /.*/
+      - linuxamd64_dev_build:
+          filters:
+            branches:
+              only: /.*/
+      - linuxarm32v7_build:
+          filters:
+            branches:
+              only: /.*/
+      - linuxamd64_publish:
+          filters:
+            # ignore any commit on any branch by default 
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /v.+/
+      - linuxarm32v7_publish:
+          filters:
+            # ignore any commit on any branch by default
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /v.+/
+      - linuxarm32v7_dev_publish:
+          filters:
+            # ignore any commit on any branch by default
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /v.+/
+      - publish_docker_multiarch:
+          requires:
+            - linuxamd64_publish
+            - linuxarm32v7_publish
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.+/
+


### PR DESCRIPTION
The following environment variable which need to be configured in CircleCI
`DOCKERHUB_REPO` (for example `elementsproject/lightning`)
`DOCKERHUB_USER` (for example `nico`)
`DOCKERHUB_PASS` (for example `hello`)

Every time there is a new tagged release with the format like `v1.2.3`, this pull request should automatically do the following on CircleCI:
* Build a docker image for x64, tag it and push (`elementsproject/lightning:1.2.3-amd64`)
* Build a docker image for arm32v7, tag it and push (`elementsproject/lightning:1.2.3-arm32v7`)
* Build a docker image with `DEVELOPER=1`, tag it and push (`elementsproject/lightning:1.2.3-dev`)
* Build a manifest image, tag it and push (`elementsproject/lightning:1.2.3`)

On top of this, every times there is a commit on any branch, it will attempt to build without publishing. Ensuring you did not break the build process. 

It uses the credentials `nico` and `hello` to connect to dockerhub in this example.

As a result, you can run the image `elementsproject/lightning:1.2.3` on both arm7v32 and amd64.

This is a modified version of what I use for BTCPay, still need to test it to be sure it works properly on this repo.

The use of `docker_layer_caching` make builds way faster, especially when debugging. However this seems to be a [premium feature](https://circleci.com/docs/2.0/docker-layer-caching/). However if my memory is correct, this is still enabled for open source projects. (Though I think that for BTCPay, @kukks contacted them directly... my memory is failing me)

To test it:
* Fork your own (ie `nicolasdorier/lightning`)
* Create an account on circleci and attach it to your project
* In the project settings, configure the environment variable DOCKERHUB_REPO, DOCKERHUB_USER, DOCKERHUB_PASS . (I advise you to create a special account for this)
* Pull this PR
* Create a test tag (ie `v9.9.9`)
* Push to your repo
* Circle CI must run the build.

If you have a bug or need to fix something

* Remove the tag, (`git tag -d v9.9.9`)
* Make your change and commit
* Re-tag (`git tag -a v9.9.9 -m v9.9.9.9`)
* Re-push the tags (`git push nicolasdorier --force --tags`)

# Note to maintainers of this repository

After merging this:
* Create an account on circleci
* Attach to this repo (this will give some rights to [CircleCI to this repo](https://circleci.com/docs/2.0/gh-bb-integration/#overview))
* In the advanced settings (which will be https://circleci.com/gh/ElementsProject/lightning/edit#advanced-settings), turn `Build forked pull requests` to `on`
* Setup DOCKERHUB_REPO, DOCKERHUB_USER, DOCKERHUB_PASS environment variables ([not shared on forked pull requests](https://circleci.com/docs/2.0/oss/))
