### PR TITLE
travis: Attempt to setup travis without docker and without sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: c
-dist: trusty
-sudo: true
+dist: xenial
+sudo: false
 
 notifications:
   email: false
 
+addons:
+  apt:
+    packages:
+      - python3-pip
+      - libsqlite3-dev
+      - shellcheck
+      - cppcheck
+      - valgrind
+      - libomp-dev
+
 env:
-  - ARCH=32 SOURCE_CHECK_ONLY=true
   - ARCH=64 SOURCE_CHECK_ONLY=true CDEBUGFLAGS="-std=gnu11 -g -fstack-protector -O3 -flto" LDFLAGS="-O3 -flto"
-  - VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST_GROUP=1 TEST_GROUP_COUNT=2 SOURCE_CHECK_ONLY=false
-  - VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST_GROUP=2 TEST_GROUP_COUNT=2 SOURCE_CHECK_ONLY=false
+#  - VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST_GROUP=1 TEST_GROUP_COUNT=2 SOURCE_CHECK_ONLY=false
+#  - VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST_GROUP=2 TEST_GROUP_COUNT=2 SOURCE_CHECK_ONLY=false
   - VALGRIND=0 ARCH=64 DEVELOPER=1 COMPILER=gcc SOURCE_CHECK_ONLY=false
   - VALGRIND=0 ARCH=64 DEVELOPER=0 COMPILER=gcc COMPAT=0 SOURCE_CHECK_ONLY=false
   - VALGRIND=1 ARCH=64 DEVELOPER=0 COMPILER=gcc TEST_GROUP=1 TEST_GROUP_COUNT=3 SOURCE_CHECK_ONLY=false
@@ -22,15 +31,10 @@ env:
   - VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST_GROUP=4 TEST_GROUP_COUNT=6 SOURCE_CHECK_ONLY=false
   - VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST_GROUP=5 TEST_GROUP_COUNT=6 SOURCE_CHECK_ONLY=false
   - VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST_GROUP=6 TEST_GROUP_COUNT=6 SOURCE_CHECK_ONLY=false
+cache:
+  directories:
+    dependencies
+    external
 
-# Trusty (aka 14.04) is way way too old, so run in docker...
 script:
-  - docker pull cdecker/lightning-ci:${ARCH}bit | tee
-  - env | grep -E '^[A-Z_]+\=' | grep -vi travis | tee /tmp/envlist
-  - echo SLOW_MACHINE=1 >> /tmp/envlist
-  - docker run --rm=true --env-file=/tmp/envlist -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit ./configure CC=${COMPILER:-gcc}
-  - $SOURCE_CHECK_ONLY || docker run --rm=true --env-file=/tmp/envlist -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make -j3
-  - $SOURCE_CHECK_ONLY || docker run --rm=true --env-file=/tmp/envlist -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check
-  - (! $SOURCE_CHECK_ONLY) || git clone https://github.com/lightningnetwork/lightning-rfc.git
-  - (! $SOURCE_CHECK_ONLY) || docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make clean
-  - (! $SOURCE_CHECK_ONLY) || docker run --rm=true -v "${TRAVIS_BUILD_DIR}":/build -t cdecker/lightning-ci:${ARCH}bit make check-source BOLTDIR=lightning-rfc
+  .travis/build.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -x
+set -e
+
+CWD=$(pwd)
+export SLOW_MACHINE=1
+export CC=${COMPILER:-gcc}
+export DEVELOPER=${DEVELOPER:-1}
+export SOURCE_CHECK_ONLY=${SOURCE_CHECK_ONLY:-"false"}
+export COMPAT=${COMPAT:-1}
+export PATH=$CWD/dependencies/bin:"$HOME"/.local/bin:"$PATH"
+
+mkdir -p dependencies/bin || true
+
+# Download bitcoind and bitcoin-cli 
+if [ ! -f dependencies/bin/bitcoind ]; then
+    wget https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
+    tar -xzf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
+    mv bitcoin-0.17.1/bin/* dependencies/bin
+    rm -rf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz bitcoin-0.17.1
+fi
+
+pyenv global 3.7
+pip3 install --user --quiet -r tests/requirements.txt
+pip3 install --quiet \
+     pytest-test-groups==1.0.3
+
+echo "Configuration which is going to be built:"
+echo -en 'travis_fold:start:script.1\\r'
+./configure CC="$CC"
+cat config.vars
+echo -en 'travis_fold:end:script.1\\r'
+
+if [ "$SOURCE_CHECK_ONLY" == "false" ]; then
+    echo -en 'travis_fold:start:script.2\\r'
+    make -j3 > /dev/null
+    echo -en 'travis_fold:end:script.2\\r'
+
+    echo -en 'travis_fold:start:script.3\\r'
+    make check
+    echo -en 'travis_fold:end:script.3\\r'
+else
+    git clone https://github.com/lightningnetwork/lightning-rfc.git
+    make check-source BOLTDIR=lightning-rfc
+fi

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 
 # Timeout shortly before the 600 second travis silence timeout
 # (method=thread to support xdist)
-PYTEST_OPTS := -v --timeout=550 --timeout_method=thread
+PYTEST_OPTS := -v --timeout=550 --timeout_method=thread -p no:logging
 
 # This is where we add new features as bitcoin adds them.
 FEATURES :=


### PR DESCRIPTION
I decided to give a "bare-metal' Travis configuration another go, since I was expecting to gain some performance from not having to run on virtualized hardware, which is required to run `docker` with `sudo`. As a side-effect we also remove the need to run everything through the `docker run` key-hole.

The downside is that we lose the ability to compile for 32bit systems out of the box, but we may be able to regain that later via cross-compilation again.

The results of running `master` with `sudo` and `docker`, are compared with the `bare-metal` version in the table below:

| Job | Configuration                                                                                                | sudo+docker | baremetal          | savings   |
|-----|--------------------------------------------------------------------------------------------------------------|---------------|---------------|-----------|
| 1   | ARCH=32 SOURCE\_CHECK\_ONLY=true                                                                             | 5 min 2 sec   | -             | -         |
| 2   | ARCH=64 SOURCE\_CHECK\_ONLY=true CDEBUGFLAGS="-std=gnu11 -g -fstack-protector -O3 -flto" LDFLAGS="-O3 -flto" | 4 min 37 sec  | 3 min 50 sec  | 0.169675  |
| 3   | VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=1 TEST\_GROUP\_COUNT=2 SOURCE\_CHECK\_ONLY=false     | 17 min 1 sec  | -             | -         |
| 4   | VALGRIND=0 ARCH=32 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=2 TEST\_GROUP\_COUNT=2 SOURCE\_CHECK\_ONLY=false     | 13 min 37 sec | -             | -         |
| 5   | VALGRIND=0 ARCH=64 DEVELOPER=1 COMPILER=gcc SOURCE\_CHECK\_ONLY=false                                        | 20 min 55 sec | 21 min 4 sec  | -0.007171 |
| 6   | VALGRIND=0 ARCH=64 DEVELOPER=0 COMPILER=gcc COMPAT=0 SOURCE\_CHECK\_ONLY=false                               | 46 min 56 sec | 44 min 47 sec | 0.045810  |
| 7   | VALGRIND=1 ARCH=64 DEVELOPER=0 COMPILER=gcc TEST\_GROUP=1 TEST\_GROUP\_COUNT=3 SOURCE\_CHECK\_ONLY=false     | 19 min 19 sec | 17 min 20 sec | 0.102675  |
| 8   | VALGRIND=1 ARCH=64 DEVELOPER=0 COMPILER=gcc TEST\_GROUP=2 TEST\_GROUP\_COUNT=3 SOURCE\_CHECK\_ONLY=false     | 33 min 47 sec | 33 min 1 sec  | 0.022694  |
| 9   | VALGRIND=1 ARCH=64 DEVELOPER=0 COMPILER=gcc TEST\_GROUP=3 TEST\_GROUP\_COUNT=3 SOURCE\_CHECK\_ONLY=false     | 22 min 42 sec | 21 min 40 sec | 0.045521  |
| 10  | VALGRIND=0 ARCH=64 DEVELOPER=1 COMPILER=clang SOURCE\_CHECK\_ONLY=false                                      | 21 min 18 sec | 21 min 3 sec  | 0.011737  |
| 11  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=1 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 27 min 55 sec | 23 min 40 sec | 0.152239  |
| 12  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=2 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 25 min 20 sec | 22 min 19 sec | 0.119079  |
| 13  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=3 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 37 min 4 sec  | 31 min 58 sec | 0.137590  |
| 14  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=4 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 27 min 37 sec | 24 min 57 sec | 0.096560  |
| 15  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=5 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 17 min 57 sec | 15 min 58 sec | 0.110492  |
| 16  | VALGRIND=1 ARCH=64 DEVELOPER=1 COMPILER=gcc TEST\_GROUP=6 TEST\_GROUP\_COUNT=6 SOURCE\_CHECK\_ONLY=false     | 24 min 12 sec | 23 min 19 sec | 0.036501  |

The results are not as impressive as I was hoping, the virtualized environment seems pretty good at running the tests. We still get up to 15% of time savings for some configurations, but I was expecting the results to be more uniform.

If we decide not to go this way, that's fine, I just thought I might share the results for the future.