### PR TITLE
fix: prevent closing stderr causing silent exit(1) crash on misconfig

### DIFF
--- a/ccan/ccan/pipecmd/pipecmd.c
+++ b/ccan/ccan/pipecmd/pipecmd.c
@@ -142,7 +142,8 @@ pid_t pipecmdarr(int *fd_tochild, int *fd_fromchild, int *fd_errfromchild,
 
 	close(tochild[0]);
 	close(fromchild[1]);
-	close(errfromchild[1]);
+	if (errfromchild[1] != STDERR_FILENO)
+		close(errfromchild[1]);
 	close(execfail[1]);
 	/* Child will close this without writing on successful exec. */
 	if (read(execfail[0], &err, sizeof(err)) == sizeof(err)) {


### PR DESCRIPTION
> [lightningd/plugin.c:919](../blob/master/lightningd/plugin.c#L919) will call `pipecmdarr` with `&pipecmd_preserve`.

Using the `pipecmdarr` from [ccan/ccan/pipecmd/pipecmd.c](../blob/master/ccan/ccan/pipecmd/pipecmd.c) function with `&pipecmd_preserve` as third argument (`fd_errfromchild`) will cause a filedescriptor close of stderr (same file, [line 145](../blob/master/ccan/ccan/pipecmd/pipecmd.c#L145)). I can't think of this as intended behaviour, as it will make the programm behave exactly like `/bin/false`. 

When having any 'normal' misconfiguration (like bitcoind-cli missing in $PATH) it will cause some `fprintf(strerr, ...); exit(1)`, the error message will be suppressed and the program aborts with code 1.

Note: This affects also the latest release v0.6.3.
