### PR TITLE
pytest: Stabilize the test_pay_direct test

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -151,7 +151,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     chan12 = l1.fund_channel(l2, 10**5)
     bitcoind.generate_block(5)
 
-    l3.wait_for_routes([chan12])
+    l3.wait_for_channel_updates([chan12])
     after_12 = int(time.time())
     # Full IO logging for l1's channeld
     subprocess.run(['kill', '-USR1', l1.subd_pid('channeld')])
@@ -160,7 +160,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     chan23 = l2.fund_channel(l3, 10**5)
     bitcoind.generate_block(5)
 
-    l1.wait_for_routes([chan23])
+    l1.wait_for_channel_updates([chan23])
     after_23 = int(time.time())
 
     # Make sure l1 has received all the gossip.
@@ -750,7 +750,7 @@ def test_report_routing_failure(node_factory, bitcoind):
         lsrc.rpc.connect(ldst.info['id'], 'localhost', ldst.port)
         c = lsrc.fund_channel(ldst, 10000000)
         bitcoind.generate_block(5)
-        lpayer.wait_for_routes([c])
+        lpayer.wait_for_channel_updates([c])
 
     # Setup
     # Construct lightningd

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1357,12 +1357,15 @@ def test_pay_direct(node_factory, bitcoind):
     # Direct channel l0->l1->l3
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
     # Waiting takes a *long* time if !DEVELOPER.
-    l0.fund_channel(l1, 10**7, wait_for_active=False)
+    c0 = l0.fund_channel(l1, 10**7, wait_for_active=False)
+
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l1.fund_channel(l3, 10**7, wait_for_active=False)
+    c1 = l1.fund_channel(l3, 10**7, wait_for_active=False)
+
     # Indirect route l0->l1->l2->l3
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**7, wait_for_active=False)
+    c2 = l1.fund_channel(l2, 10**7, wait_for_active=False)
+
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     c3 = l2.fund_channel(l3, 10**7, wait_for_active=False)
 
@@ -1372,7 +1375,7 @@ def test_pay_direct(node_factory, bitcoind):
     # Make sure l0 knows the l2->l3 channel.
     # Without DEVELOPER, channel lockin can take 30 seconds to detect,
     # and gossip 2 minutes to propagate
-    wait_for(lambda: l0.is_channel_active(c3), timeout=180)
+    l0.wait_for_channel_updates([c0, c1, c2, c3])
 
     # Find out how much msatoshi l1 owns on l1->l2 channel.
     l1l2msatreference = only_one(l1.rpc.getpeer(l2.info['id'])['channels'])['msatoshi_to_us']


### PR DESCRIPTION
It was waiting for a remote channel, but not for all the interesting
channels we want to check. It can sometimes happen that further away
channels are added before closer ones are added, depending on
propagation path, flush timers and bitcoind poll timers. This now just
checks for all channels, which also reduces the ambiguity of whether
we selected a path solely because we were lacking alternatives.

The rename of `wait_for_route` to `wait_for_channel_updates` is a bit of a drive-by fix, but makes it a bit clearer I think.