### PR TITLE
WIP: json_withdraw/fundchannel: don't create new wallet txs when previous broadcast failed

### DIFF
--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -34,6 +34,13 @@ struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 {
 	struct command_result *res;
 	u64 fee_estimate;
+
+	/* any output in _reserved means a previous wtx wasn't successfully broadcast */
+	if (tal_count(wallet_get_utxos(tmpctx, tx->cmd->ld->wallet,
+			output_state_reserved)))
+		return command_fail(tx->cmd, LIGHTNINGD,
+				"Owned output found in status _reserved, probably the prev_out_tx failed to broadcast");
+
 	if (tx->all_funds) {
 		u64 amount;
 		tx->utxos = wallet_select_all(tx->cmd, tx->cmd->ld->wallet,

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -87,7 +87,7 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
 						     tx, &b->height,
-						     &satoshi_owned);
+						     &satoshi_owned, NULL);
 		}
 
 		/* We did spends first, in case that tells us to watch tx. */
@@ -608,7 +608,9 @@ static void add_tip(struct chain_topology *topo, struct block *b)
 	topo->tip = b;
 	wallet_block_add(topo->ld->wallet, b);
 
+	/* add new utxos to outpointfilter utxoset_outpoints */
 	topo_add_utxos(topo, b);
+	/* update spends in utxoset_outpoints and in owned_outpoints */
 	topo_update_spends(topo, b);
 
 	/* Only keep the transactions we care about. */

--- a/wallet/txfilter.h
+++ b/wallet/txfilter.h
@@ -6,6 +6,10 @@
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 
+/**
+ * txfilter -- Contains scriptpubkeys, usually of owned addresses. The name is
+ * a bit of a misnomer and could better be called scriptpubkey_filter.
+ */
 struct txfilter;
 
 /**

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -462,10 +462,28 @@ void wallet_channel_stats_load(struct wallet *w, u64 cdbid, struct channel_stats
 void wallet_blocks_heights(struct wallet *w, u32 def, u32 *min, u32 *max);
 
 /**
- * wallet_extract_owned_outputs - given a tx, extract all of our outputs
+ * wallet_extract_owned_outputs - given tx, extract outputs we can spent
+ *
+ * @w: wallet to test spent-ability and to store the owned output into
+ * @tx: bitcoin transaction to extract outputs from
+ * @blockheight: confirmation height of `tx`, or NULL
+ * @total_satoshi: variable to store the amount of owned satoshis in this `tx`
+ * @owned_outnums: pointer to tal allocated array to store owned outnums or NULL
+ *
+ * For all outputs in `tx` that wallet `w` can spent:
+ * - add it to 'outputs' table in db if not already there
+ * - set 'confirmation_height' in db to `blockheight`
+ * - when a (non NULL) `blockheight` is given, set the output 'status' in db to
+ *   _available or update it from _reserved to _available
+ * - add it to owned_outpoints filter
+ * - add its amount to `total_satoshis`
+ * - add (expand) its outnum to owned_outnums array
+ *
+ * Returns the number of outputs in `tx` that wallet `w` can spent.
  */
 int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
-				 const u32 *blockheight, u64 *total_satoshi);
+				 const u32 *blockheight, u64 *total_satoshi,
+				 u32 **owned_outnums);
 
 /**
  * wallet_htlc_save_in - store an htlc_in in the database


### PR DESCRIPTION
WIP: This is a follow up of #2274. In addition to returning an error when a `json_withdraw` or `json_fundchannel` broadcast failed, it now also _prohibits_ users from creating new dependent wallet transactions. Not sure how often this happens and by what cause, but this PR protects users from creating more potentially stuck transactions (#2300, #2171).

`json_withdraw` and `json_fundchannel` now use similar procedure:
- Owned change outputs are marked as _reserved until successful broadcast
  OR until confirmation in block
- Owned outputs consumed by tx are marked as _spent before broadcast
- UTXO/coin selection fails when any output in state _reserved

In case broadcast failed:
1. user should fix the problem that caused failure (bitcoind dead?)
2. user should manually rebroadcast, for example by copy-paste rawtx from log and call
   `bitcoin-cli sendrawtransaction <rawtx>` and wait for confirmation. At confirmation,
   owned_txfilter will detect it and update owned output from _reserved to _available.
3. continue normal operation

Considerations:
- Assume that, once tx is signed and valid, it may/will be (manually) broadcast.
- That makes cleanly aborting a `fundchannel` very hard, so better go ahead.
- If user really wants to abort, it should use `dev-rescan` and `dev-forget-channel`
  idea: maybe a mutual closing_tx can be negotiated and stored as backup without any broadcast?

TODO:
- [ ] make listfunds show outputs in _reserved also, so users see funds after a failed broadcast
- [ ] json_withdraw and json_fundchannel should return same error code in case of failed broadcast
- [ ] same for json_close ?
- [ ] add some test vectors to make sure our outputs are eventually picked up when broadcast
  manually