### PR TITLE
doc: fix the command to cross-compile libgmp

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -296,7 +296,7 @@ Download and build gmp:
     wget https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz
     tar xvf gmp-6.1.2.tar.xz 
     cd gmp-6.1.2
-    ./configure --disable-assembly --prefix=$QEMU_LD_PREFIX
+    ./configure --disable-assembly --host=$target_host --prefix=$QEMU_LD_PREFIX
     make
     make install
 


### PR DESCRIPTION
For some reason, without this extra option the `./configure` script in `gmp-6.1.2` would fail with a:

```
configure: error: could not find a working compiler, see config.log for details
```

Adding this option changes one of the first line of output from "host system: x86_64-pc-linux-gnu" to "host system: arm-unknown-linux-gnueabihf".

This issue occurred with the following cross-compiling toolchain, I have not tested that with any other compilers/toolchains.

```
[user@arm-cross-compile gmp-6.1.2]$ arm-linux-gnueabihf-gcc --version
arm-linux-gnueabihf-gcc (Linaro GCC 7.3-2018.05) 7.3.1 20180425 [linaro-7.3-2018.05 revision d29120a424ecfbc167ef90065c0eeb7f91977701]
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```