### PR TITLE
fix: add inline exception for recent cppcheck false positive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ check-includes:
 	@git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs grep -n 'list_for_each' | sed 's/\([^:]*:.*\):.*/uninitvar:\1/' > $@
 
 check-cppcheck: .cppcheck-suppress
-	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs cppcheck -q --language=c --std=c11 --error-exitcode=1 --suppressions-list=.cppcheck-suppress
+	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs cppcheck -q --language=c --std=c11 --error-exitcode=1 --suppressions-list=.cppcheck-suppress --inline-suppr
 
 check-shellcheck:
 	@git ls-files -- "*.sh" | xargs shellcheck

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -900,6 +900,8 @@ u8 *handle_channel_announcement(struct routing_state *rstate,
 	tal_add_destructor2(pending, destroy_pending_cannouncement, rstate);
 
 	/* Success */
+	// MSC: Cppcheck 1.86 gets this false positive
+	// cppcheck-suppress autoVariables
 	*scid = &pending->short_channel_id;
 	return NULL;
 


### PR DESCRIPTION
Recent cppcheck version (at least 1.86) will have a false positive in `gossipd/routing.c` line 903. The cppcheck misunderstands ccan's external memory management by assigning it to a local struct pointer:

```C
struct pending_cannouncement *pending;
pending = tal(rstate, struct pending_cannouncement); 
// ... 
*scid = &pending->short_channel_id;
```

It complains with `[gossipd/routing.c:903]: (error) Address of local auto-variable assigned to a function parameter.` 

When the diff is applied, test are able to run normally, as cppcheck is a required precondition. I didnt find a better way than to add and enable a exception.