### PR TITLE
fix: change type of config->fee_per_satoshi to uint32

### DIFF
--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -40,7 +40,7 @@ struct config {
 
 	/* Fee rates. */
 	u32 fee_base;
-	s32 fee_per_satoshi;
+	u32 fee_per_satoshi;
 
 	/* How long between changing commit and sending COMMIT message. */
 	u32 commit_time_ms;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -373,7 +373,7 @@ static void config_register_opts(struct lightningd *ld)
 			 &ld->config.rescan,
 			 "Number of blocks to rescan from the current head, or "
 			 "absolute blockheight if negative");
-	opt_register_arg("--fee-per-satoshi", opt_set_s32, opt_show_s32,
+	opt_register_arg("--fee-per-satoshi", opt_set_u32, opt_show_u32,
 			 &ld->config.fee_per_satoshi,
 			 "Microsatoshi fee for every satoshi in HTLC");
 	opt_register_arg("--addr", opt_add_addr, NULL,


### PR DESCRIPTION
fix: change type of config->fee_per_satoshi to uint32

This patch will properly set fee_per_satoshi to _unsigned_ integer,
as support for negative fees was removed from overall design.

This change does not break any tests, so I assume its better this way.