### PR TITLE
fix: add information about how many blocks to go until confirmation

### DIFF
--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -62,6 +62,16 @@ channel_init,,last_remote_secret,struct secret
 channel_init,,lflen,u16
 channel_init,,localfeatures,lflen*u8
 
+# ask master how many blocks to go!
+channel_funding_depth,1001
+channel_funding_depth,,funding_txid,struct bitcoin_txid
+
+# reply channeld how many blocks to go!
+channel_funding_depth_reply,1101
+channel_funding_depth_reply,,funding_txid,struct bitcoin_txid
+channel_funding_depth_reply,,minimum_depth,u32
+channel_funding_depth_reply,,funding_depth,u32
+
 # master->channeld funding hit new depth >= lock depth
 channel_funding_locked,1002
 channel_funding_locked,,short_channel_id,struct short_channel_id


### PR DESCRIPTION
issue #2150
add two new wire_channel type to help channeld get funding depth and minimum_depth from master:

* WIRE_CHANNEL__FUNDING_DEPTH = 1001: channeld send to master to ask for the depth of funding
* WIRE_CHANNEL_FUNDING_DEPTH_REPLY = 1101:  master reply to channeld with the depth of funding and minimum_depth

because struct peer and struct channel in channeld don't have the pointer to the topology(it's difficult to get current depth directly) and don't store the minimum_depth, adding a new wire type to get information through io maybe is a valid way.

now the function: billboard_update in channeld/channeld.c can show how many blocks to go when
the situation that funding needs more confirmations happens. 