### PR TITLE
plugin: Connected hook

### DIFF
--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -299,6 +299,11 @@ void json_add_bool(struct json_stream *result, const char *fieldname, bool value
 	json_add_member(result, fieldname, value ? "true" : "false");
 }
 
+void json_add_null(struct json_stream *stream, const char *fieldname)
+{
+	json_add_member(stream, fieldname, "null");
+}
+
 void json_add_hex(struct json_stream *result, const char *fieldname,
 		  const void *data, size_t len)
 {

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -115,6 +115,10 @@ void json_add_u64(struct json_stream *result, const char *fieldname,
 /* '"fieldname" : true|false' or 'true|false' if fieldname is NULL */
 void json_add_bool(struct json_stream *result, const char *fieldname,
 		   bool value);
+
+/* '"fieldname" : null' or 'null' if fieldname is NULL */
+void json_add_null(struct json_stream *stream, const char *fieldname);
+
 /* '"fieldname" : "0189abcdef..."' or "0189abcdef..." if fieldname is NULL */
 void json_add_hex(struct json_stream *result, const char *fieldname,
 		  const void *data, size_t len);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -617,6 +617,15 @@ static void
 peer_connected_serialize(struct peer_connected_hook_payload *payload,
 			 struct json_stream *stream)
 {
+	const struct peer *p = payload->peer;
+	json_object_start(stream, "peer");
+	json_add_pubkey(stream, "id", &p->id);
+	json_add_string(
+	    stream, "addr",
+	    type_to_string(stream, struct wireaddr_internal, &payload->addr));
+	json_add_hex_talarr(stream, "globalfeatures", p->globalfeatures);
+	json_add_hex_talarr(stream, "localfeatures", p->localfeatures);
+	json_object_end(stream); /* .peer */
 }
 
 static struct peer_connected_hook_response *

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -142,6 +142,9 @@ void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 void json_add_log(struct json_stream *result UNNEEDED,
 		  const struct log_book *lr UNNEEDED, enum log_level minlevel UNNEEDED)
 { fprintf(stderr, "json_add_log called!\n"); abort(); }
+/* Generated stub for json_add_null */
+void json_add_null(struct json_stream *stream UNNEEDED, const char *fieldname UNNEEDED)
+{ fprintf(stderr, "json_add_null called!\n"); abort(); }
 /* Generated stub for json_add_num */
 void json_add_num(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  unsigned int value UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -352,6 +352,10 @@ void peer_start_openingd(struct peer *peer UNNEEDED,
 			 int peer_fd UNNEEDED, int gossip_fd UNNEEDED,
 			 const u8 *msg UNNEEDED)
 { fprintf(stderr, "peer_start_openingd called!\n"); abort(); }
+/* Generated stub for plugin_hook_call_ */
+void plugin_hook_call_(struct lightningd *ld UNNEEDED, const struct plugin_hook *hook UNNEEDED,
+		       void *payload UNNEEDED, void *cb_arg UNNEEDED)
+{ fprintf(stderr, "plugin_hook_call_ called!\n"); abort(); }
 /* Generated stub for set_log_outfn_ */
 void set_log_outfn_(struct log_book *lr UNNEEDED,
 		    void (*print)(const char *prefix UNNEEDED,

--- a/tests/plugins/reject.py
+++ b/tests/plugins/reject.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Simple plugin to test the connected_hook.
+
+It can mark some node_ids as rejects and it'll check for each
+connection if it should be disconnected immediately or if it can
+continue.
+
+"""
+
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('peer_connected')
+def on_connected(peer, plugin):
+    if peer['id'] in plugin.reject_ids:
+        print("{} is in reject list, disconnecting".format(peer['id']))
+        return {'result': 'disconnect'}
+
+    print("{} is allowed".format(peer['id']))
+    return {'result': 'continue'}
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    plugin.reject_ids = []
+
+
+@plugin.method('reject')
+def reject(node_id, plugin):
+    """Mark a given node_id as reject for future connections.
+    """
+    print("Rejecting connections from {}".format(node_id))
+    plugin.reject_ids.append(node_id)
+
+
+plugin.run()

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -257,6 +257,10 @@ void json_array_start(struct json_stream *js UNNEEDED, const char *fieldname UNN
 struct json_escaped *json_escaped_string_(const tal_t *ctx UNNEEDED,
 					  const void *bytes UNNEEDED, size_t len UNNEEDED)
 { fprintf(stderr, "json_escaped_string_ called!\n"); abort(); }
+/* Generated stub for json_get_member */
+const jsmntok_t *json_get_member(const char *buffer UNNEEDED, const jsmntok_t tok[] UNNEEDED,
+				 const char *label UNNEEDED)
+{ fprintf(stderr, "json_get_member called!\n"); abort(); }
 /* Generated stub for json_object_end */
 void json_object_end(struct json_stream *js UNNEEDED)
 { fprintf(stderr, "json_object_end called!\n"); abort(); }
@@ -276,6 +280,9 @@ const char *json_tok_full(const char *buffer UNNEEDED, const jsmntok_t *t UNNEED
 /* Generated stub for json_tok_full_len */
 int json_tok_full_len(const jsmntok_t *t UNNEEDED)
 { fprintf(stderr, "json_tok_full_len called!\n"); abort(); }
+/* Generated stub for json_tok_streq */
+bool json_tok_streq(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, const char *str UNNEEDED)
+{ fprintf(stderr, "json_tok_streq called!\n"); abort(); }
 /* Generated stub for json_to_pubkey */
 bool json_to_pubkey(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 		    struct pubkey *pubkey UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -215,6 +215,9 @@ void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 void json_add_log(struct json_stream *result UNNEEDED,
 		  const struct log_book *lr UNNEEDED, enum log_level minlevel UNNEEDED)
 { fprintf(stderr, "json_add_log called!\n"); abort(); }
+/* Generated stub for json_add_null */
+void json_add_null(struct json_stream *stream UNNEEDED, const char *fieldname UNNEEDED)
+{ fprintf(stderr, "json_add_null called!\n"); abort(); }
 /* Generated stub for json_add_num */
 void json_add_num(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  unsigned int value UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -407,6 +407,10 @@ void peer_start_openingd(struct peer *peer UNNEEDED,
 			 int peer_fd UNNEEDED, int gossip_fd UNNEEDED,
 			 const u8 *msg UNNEEDED)
 { fprintf(stderr, "peer_start_openingd called!\n"); abort(); }
+/* Generated stub for plugin_hook_call_ */
+void plugin_hook_call_(struct lightningd *ld UNNEEDED, const struct plugin_hook *hook UNNEEDED,
+		       void *payload UNNEEDED, void *cb_arg UNNEEDED)
+{ fprintf(stderr, "plugin_hook_call_ called!\n"); abort(); }
 /* Generated stub for process_onionpacket */
 struct route_step *process_onionpacket(
 	const tal_t * ctx UNNEEDED,

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -253,7 +253,7 @@ REGISTER_TYPE_TO_HEXSTR(channel_id);
  * (i.e. `funding_output_index` alters the last 2 bytes).
  */
 void derive_channel_id(struct channel_id *channel_id,
-		       struct bitcoin_txid *txid, u16 txout)
+		       const struct bitcoin_txid *txid, u16 txout)
 {
 	BUILD_ASSERT(sizeof(*channel_id) == sizeof(*txid));
 	memcpy(channel_id, txid, sizeof(*channel_id));

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -30,7 +30,7 @@ struct siphash_seed;
 typedef char wirestring;
 
 void derive_channel_id(struct channel_id *channel_id,
-		       struct bitcoin_txid *txid, u16 txout);
+		       const struct bitcoin_txid *txid, u16 txout);
 
 /* Read the type; returns -1 if not long enough.  cursor is a tal ptr. */
 int fromwire_peektype(const u8 *cursor);


### PR DESCRIPTION
This is a simpler example than the `htlc_accepted` hook that I'm still working on, but it already allows us to do quite some interesting things. For example it'd allow us to implement a drain-plugin that allows connections to and from peers we are still negotiating a close with, but reject all connections that could result in a new channel.

It also serves as an example on how hooks are implemented.