### PR TITLE
doc: add configure --enable-dev in testing chapter

### DIFF
--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -168,7 +168,7 @@ pip3 install -r tests/requirements.txt
 Re-run `configure` for the python dependencies
 
 ```
-./configure
+./configure --enable-developer
 ```
 
 Tests are run with: `make check [flags]` where the pertinent flags are:


### PR DESCRIPTION
As a newbie, I forgot to re-enable the dev options that are required to run the tests...