### PR TITLE
pytest: Mark the worst gossip offenders as developer-only tests

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -791,6 +791,7 @@ def test_channel_persistence(node_factory, bitcoind, executor):
     l1.daemon.wait_for_log(' to ONCHAIN')
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_private_channel(node_factory):
     l1, l2 = node_factory.line_graph(2, announce_channels=False, wait_for_announce=False)
     l3, l4 = node_factory.line_graph(2, announce_channels=True, wait_for_announce=True)
@@ -1418,6 +1419,7 @@ def test_fulfill_incoming_first(node_factory, bitcoind):
     l3.daemon.wait_for_log('onchaind complete, forgetting peer')
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_restart_many_payments(node_factory):
     l1 = node_factory.get_node(may_reconnect=True)
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -984,6 +984,7 @@ def test_gossip_notices_close(node_factory, bitcoind):
     assert(l1.rpc.listnodes()['nodes'] == [])
 
 
+@unittest.skipIf(not DEVELOPER, "gossip propagation is slow without DEVELOPER=1")
 def test_getroute_exclude(node_factory, bitcoind):
     """Test getroute's exclude argument"""
     l1, l2, l3, l4 = node_factory.line_graph(4, wait_for_announce=True)

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -172,6 +172,7 @@ def test_invoice_routeboost(node_factory, bitcoind):
     assert 'warning_offline' not in inv
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_invoice_routeboost_private(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice for private channels
     """

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1167,6 +1167,7 @@ def test_pay_variants(node_factory):
     l1.rpc.pay(b11)
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_pay_retry(node_factory, bitcoind):
     """Make sure pay command retries properly. """
     def exhaust_channel(funder, fundee, scid, already_spent=0):
@@ -1341,6 +1342,7 @@ def test_pay_routeboost(node_factory, bitcoind):
         assert [h['channel'] for h in attempts[2]['routehint']] == [r['short_channel_id'] for r in routel3l5]
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_pay_direct(node_factory, bitcoind):
     """Check that we prefer the direct route.
     """


### PR DESCRIPTION
The non-developer tests are failing on Travis due to the long gossip synchronization. I don't think there is much value in testing these in non-developer mode given that the only difference is the longer wait time, so I marked them as `@unittest.skipIf(not DEVELOPER, ...)`.

The alternative would be to split the non-developer tests like we already do with the valgrind tests, but I doubt that anything substantial was ever learned from the disabled test scenarios.