### PR TITLE
Small fixes to docs, json_dev_forget_channel, json_fundchannel and trailing space in logline

### DIFF
--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/22/2019
+.\"      Date: 02/15/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "01/22/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "02/15/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -40,7 +40,7 @@ The \fBfundchannel\fR RPC command opens a payment channel with a peer by committ
 .sp
 \fIsatoshi\fR is the amount in satoshis taken from the internal wallet to fund the channel\&. The string \fIall\fR can be used to specify all available funds (or 16777215 satoshi if more is available)\&. The value cannot be less than the dust limit, currently set to 546, nor more than 16777215 satoshi\&.
 .sp
-\fIfeerate\fR is an optional feerate to use\&. It can be one of the strings \fIurgent\fR, \fInormal\fR or \fIslow\fR to use lightningd\(cqs internal estimates: \fInormal\fR is the default\&.
+\fIfeerate\fR is an optional feerate used for the opening transaction and as initial feerate for commitment and HTLC transactions\&. It can be one of the strings \fIurgent\fR, \fInormal\fR or \fIslow\fR to use lightningd\(cqs internal estimates: \fInormal\fR is the default\&.
 .sp
 \fIannounce\fR is an optional flag that triggers whether to announce this channel or not\&. Defaults to true\&. An unannounced channel is considered private\&.
 .sp

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -27,7 +27,8 @@ The string 'all' can be used to specify all available funds (or 16777215 satoshi
 The value cannot be less than the dust limit, currently set to 546, nor more
 than 16777215 satoshi.
 
-'feerate' is an optional feerate to use.  It can be one of the strings
+'feerate' is an optional feerate used for the opening transaction and as initial feerate for
+commitment and HTLC transactions.  It can be one of the strings
 'urgent', 'normal' or 'slow' to use lightningd's internal estimates:
 'normal' is the default.
 

--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-getroute
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/01/2019
+.\"      Date: 02/16/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-GETROUTE" "7" "02/01/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-GETROUTE" "7" "02/16/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,9 +36,9 @@ lightning-getroute \- Command for routing a payment (low\-level)\&.
 .sp
 The \fBgetroute\fR RPC command attempts to find the best route for the payment of \fImsatoshi\fR to lightning node \fIid\fR, such that the payment will arrive at \fIid\fR with \fIcltv\fR\-blocks to spare (default 9)\&.
 .sp
-There are two considerations for how good a route is: how low the fees are, and how long your payment will get stuck if a node goes down during the process\&. The \fIriskfactor\fR floating\-point field controls this tradeoff; it is the annual cost of your funds being stuck (as a percentage)\&.
+There are two considerations for how good a route is: how low the fees are, and how long your payment will get stuck in a delayed output if a node goes down during the process\&. The \fIriskfactor\fR floating\-point field controls this tradeoff; it is the annual cost of your funds being stuck (as a percentage)\&.
 .sp
-For example, if you thought the inconvenience of having funds stuck was worth 20% per annum interest, \fIriskfactor\fR would be 20\&.
+For example, if you thought the convenience of keeping your funds liquid (not stuck) was worth 20% per annum interest, \fIriskfactor\fR would be 20\&.
 .sp
 If you didn\(cqt care about risk, \fIriskfactor\fR would be zero\&.
 .sp
@@ -75,7 +75,7 @@ risk\-fee = amount x blocks\-timeout x riskfactor / 5259600
 .RE
 .\}
 .sp
-Here are the risk fees in millisatoshis, using various parameters\&. I assume a channel charges the default of 1000 millisatoshis plus 1 part\-per\-million\&. Common delay values on the network at 14 and 144\&.
+Here are the risk fees in millisatoshis, using various parameters\&. I assume a channel charges the default of 1000 millisatoshis plus 1 part\-per\-million\&. Common to_self_delay values on the network at 14 and 144 blocks\&.
 .TS
 allbox tab(:);
 ltB ltB ltB ltB ltB.

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -18,13 +18,13 @@ of 'msatoshi' to lightning node 'id', such that the payment will arrive
 at 'id' with 'cltv'-blocks to spare (default 9).
 
 There are two considerations for how good a route is: how low the
-fees are, and how long your payment will get stuck if a node goes down
+fees are, and how long your payment will get stuck in a delayed output if a node goes down
 during the process.  The 'riskfactor' floating-point field controls
 this tradeoff; it is the annual cost of your funds being stuck (as a
 percentage).
 
-For example, if you thought the inconvenience of having funds stuck was
-worth 20% per annum interest, 'riskfactor' would be 20.
+For example, if you thought the convenience of keeping your funds liquid
+(not stuck) was worth 20% per annum interest, 'riskfactor' would be 20.
 
 If you didn't care about risk, 'riskfactor' would be zero.
 
@@ -58,7 +58,7 @@ risk-fee = amount x blocks-timeout x riskfactor / 5259600
 
 Here are the risk fees in millisatoshis, using various parameters.  I
 assume a channel charges the default of 1000 millisatoshis plus 1
-part-per-million.  Common delay values on the network at 14 and 144.
+part-per-million.  Common to_self_delay values on the network at 14 and 144 blocks.
 
 [options="header"]
 |=======================

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -73,7 +73,7 @@ struct funding_channel {
 	u8 channel_flags;
 
 	/* Variables we need to compose fields in cmd's response */
-	u8 *linear;
+	const char *hextx;
 	struct channel_id cid;
 
 	/* Peer we're trying to reach. */
@@ -245,7 +245,7 @@ static void funding_broadcast_success(struct channel *channel)
 
 	response = json_stream_success(cmd);
 	json_object_start(response, NULL);
-	json_add_hex_talarr(response, "tx", fc->linear);
+	json_add_string(response, "tx", fc->hextx);
 	json_add_txid(response, "txid", &channel->funding_txid);
 	json_add_string(response, "channel_id",
 					type_to_string(tmpctx, struct channel_id, &fc->cid));
@@ -414,7 +414,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 		txfilter_add_scriptpubkey(ld->owned_txfilter, fundingtx->output[!funding_outnum].script);
 
 	/* We need these to compose cmd's response in funding_broadcast_success */
-	fc->linear = linearize_tx(fc->cmd, fundingtx);
+	fc->hextx = tal_hex(fc, linearize_tx(fc->cmd, fundingtx));
 	derive_channel_id(&fc->cid, &channel->funding_txid, funding_outnum);
 
 	/* Send it out and watch for confirms. */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1407,7 +1407,8 @@ static struct command_result *json_dev_forget_channel(struct command *cmd,
 	}
 	if (!forget->channel) {
 		return command_fail(cmd, LIGHTNINGD,
-				    "No channels matching that short_channel_id");
+				    "No channels matching that peer_id%s",
+					scid ? " and that short_channel_id" : "");
 	}
 
 	if (channel_has_htlc_out(forget->channel) ||

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1129,14 +1129,14 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 		utxo->outnum = output;
 		utxo->close_info = NULL;
 
-		utxo->blockheight = blockheight?blockheight:NULL;
+		utxo->blockheight = blockheight ? blockheight : NULL;
 		utxo->spendheight = NULL;
 
-		log_debug(w->log, "Owning output %zu %"PRIu64" (%s) txid %s %s",
+		log_debug(w->log, "Owning output %zu %"PRIu64" (%s) txid %s%s",
 			  output, tx->output[output].amount,
 			  is_p2sh ? "P2SH" : "SEGWIT",
 			  type_to_string(tmpctx, struct bitcoin_txid,
-					 &utxo->txid), blockheight ? "CONFIRMED" : "");
+					 &utxo->txid), blockheight ? " CONFIRMED" : "");
 
 		if (!wallet_add_utxo(w, utxo, is_p2sh ? p2sh_wpkh : our_change)) {
 			/* In case we already know the output, make


### PR DESCRIPTION
Hope this is allowed to bundle in single PR, can make separate if needed.

- doc: improve explanation of getroute command 
(as commented in PR #2307)
- doc: fundchannel command, clarify optional `feerate`
(mentioned in issue #2354)
- remove trailing space in logline and small coding style fix
(as commented in PR #2310)
- lightningd/json_dev_forget_channel: clarify message when both peer_id and scid are given
(mentioned in issue #2298)
- lightningd/json_fundchannel: use json_add_string to add hex_tx to response, similar as in json_withdraw
