### PR TITLE
fix crash with lightning charge and plugin opts

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1027,7 +1027,8 @@ static void add_config(struct lightningd *ld,
 		} else if (opt->cb_arg == (void *)opt_add_plugin) {
 			json_add_opt_plugins(response, ld->plugins);
 		} else if (opt->cb_arg == (void *)opt_add_plugin_dir
-			   || opt->cb_arg == (void *)opt_disable_plugin) {
+			   || opt->cb_arg == (void *)opt_disable_plugin
+			   || opt->cb_arg == (void *)plugin_opt_set) {
 			/* FIXME: We actually treat it as if they specified
 			 * --plugin for each one, so ignore these */
 #if DEVELOPER

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -81,8 +81,6 @@ struct plugins {
 	struct lightningd *ld;
 };
 
-/* Simple storage for plugin options inbetween registering them on the
- * command line and passing them off to the plugin */
 struct plugin_opt {
 	struct list_node list;
 	const char *name;
@@ -463,9 +461,7 @@ static struct io_plan *plugin_stdout_conn_init(struct io_conn *conn,
 			       plugin_read_json, plugin);
 }
 
-/* Callback called when parsing options. It just stores the value in
- * the plugin_opt */
-static char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
+char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
 {
 	tal_free(popt->value);
 	popt->value = tal_strdup(popt, arg);

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -20,7 +20,7 @@ struct plugin;
 
 /**
  * Simple storage for plugin options inbetween registering them on the
- * command line and passing them off to the plugin 
+ * command line and passing them off to the plugin
  */
 struct plugin_opt;
 
@@ -100,8 +100,8 @@ void plugin_request_send(struct plugin *plugin,
 			 struct jsonrpc_request *req TAKES);
 
 /**
- *  Callback called when parsing options. It just stores the value in
- * the plugin_opt 
+ * Callback called when parsing options. It just stores the value in
+ * the plugin_opt
  */
 char *plugin_opt_set(const char *arg, struct plugin_opt *popt);
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -19,6 +19,12 @@ struct plugins;
 struct plugin;
 
 /**
+ * Simple storage for plugin options inbetween registering them on the
+ * command line and passing them off to the plugin 
+ */
+struct plugin_opt;
+
+/**
  * Create a new plugins context.
  */
 struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
@@ -92,5 +98,11 @@ void plugins_notify(struct plugins *plugins,
  */
 void plugin_request_send(struct plugin *plugin,
 			 struct jsonrpc_request *req TAKES);
+
+/**
+ *  Callback called when parsing options. It just stores the value in
+ * the plugin_opt 
+ */
+char *plugin_opt_set(const char *arg, struct plugin_opt *popt);
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_H */


### PR DESCRIPTION
**Problem:** 
when running the daemon that loads a plugin with options, then starting lightning-charge the daemon crashes

**Resolution**
in `options.c`, `add_config` is called with a `opt->cb_arg` of type `plugin_opt_set`, I added a check for this

I am not sure why this is called in this manner so this may not be the desired solution, but I thought it best to show my findings in code rather than open an issue.