### PR TITLE
pytest: fix race in test_pay_direct.

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -328,6 +328,7 @@ remote_routing_failure(const tal_t *ctx,
 		if (failcode & PERM)
 			*pay_errcode = PAY_DESTINATION_PERM_FAIL;
 		else
+			/* FIXME: not right for WIRE_FINAL_EXPIRY_TOO_SOON */
 			*pay_errcode = PAY_TRY_OTHER_ROUTE;
 		erring_node = &route_nodes[origin_index];
 	} else {

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1386,7 +1386,7 @@ def test_pay_direct(node_factory, bitcoind):
     # Try multiple times to ensure that route randomization
     # will not override our preference for direct route.
     for i in range(8):
-        inv = l3.rpc.invoice(15000000, 'pay{}'.format(i), 'desc')['bolt11']
+        inv = l3.rpc.invoice(20000000, 'pay{}'.format(i), 'desc')['bolt11']
 
         l0.rpc.pay(inv)
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1372,6 +1372,9 @@ def test_pay_direct(node_factory, bitcoind):
     # Let channels lock in.
     bitcoind.generate_block(5)
 
+    # Make l1 sees it, so it doesn't produce bad CLTVs.
+    sync_blockheight(bitcoind, [l1])
+
     # Make sure l0 knows the l2->l3 channel.
     # Without DEVELOPER, channel lockin can take 30 seconds to detect,
     # and gossip 2 minutes to propagate


### PR DESCRIPTION
I got a spurious failure because the final node gave a CLTV error and
so it decided to use a different channel.  It should probably handle
this corner case better, but meanwhile make the test robust.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>