### PR TITLE
daemon: Fix issue 2348, db->filenam not being correctly initialized

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -764,6 +764,11 @@ int main(int argc, char *argv[])
 	 * can start talking to us. */
 	plugins_config(ld->plugins);
 
+	/*~ Setting this (global) activates the crash log: we don't usually need
+	 * a backtrace if we fail during startup.  We do this before daemonize,
+	 * in case that runs into trouble. */
+	crashlog = ld->log;
+
 	/*~ We defer --daemon until we've completed most initialization: that
 	 *  way we'll exit with an error rather than silently exiting 0, then
 	 *  realizing we can't start and forcing the confused user to read the
@@ -807,10 +812,6 @@ int main(int argc, char *argv[])
 	/*~ Now that all the notifications for transactions are in place, we
 	 *  can start the poll loop which queries bitcoind for new blocks. */
 	begin_topology(ld->topology);
-
-	/*~ Setting this (global) activates the crash log: we don't usually need
-	 * a backtrace if we fail during startup. */
-	crashlog = ld->log;
 
 	/*~ The root of every backtrace (almost).  This is our main event
 	 *  loop. */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -557,7 +557,7 @@ static struct db *db_open(const tal_t *ctx, char *filename)
 	}
 
 	db = tal(ctx, struct db);
-	db->filename = tal_dup_arr(db, char, filename, strlen(filename), 0);
+	db->filename = tal_strdup(db, filename);
 	db->sql = sql;
 	tal_add_destructor(db, destroy_db);
 	db->in_transaction = NULL;


### PR DESCRIPTION
We were not correctly allocating the `db->filename`, failing to copy the
null-terminator. This was causing and error when reopening the database after
the call to `fork()`.

Fixes #2348 