### PR TITLE
[pylightning] Corrected the size to read from the buffer

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -42,7 +42,7 @@ class UnixDomainSocketRpc(object):
 
                 if len(b) == 0:
                     return {'error': 'Connection to RPC server lost.'}
-                if b' }\n' not in buff:
+                if b' }\n' not in buff[-4:]:
                     continue
                 # Convert late to UTF-8 so glyphs split across recvs do not
                 # impact us


### PR DESCRIPTION
To stop reading when `}\n` caused to fail to read output of call like `listfunds` where we stop to read 1024 bytes after the end of the "outputs" (since it is closed with `}\n`) instead of reading the whole response. It would later cause a JSON error (at `raw_decode(buff)`).