### PR TITLE
Add generated python and pylightning files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.gcno
 *.dSYM
 *.rej
+*.pyc
 .cppcheck-suppress
 TAGS
 tags
@@ -34,3 +35,6 @@ gossip_store
 .pytest_cache
 tools/headerversions
 .tmp.lightningrfc/
+contrib/pylightning/build/
+contrib/pylightning/dist/
+contrib/pylightning/pylightning.egg-info/


### PR DESCRIPTION
Files are generated if you run

```
python3 setup.py install
```
for `contrib/pylightning`