### PR TITLE
channeld: handle funding_locked message before reestablish.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ changes.
 - You can no longer make giant unpayable "wumbo" invoices.
 - CLTV of total route now correctly evaluated when finding best route.
 - `riskfactor` arguments to `pay` and `getroute` now have an effect.
+- Handle lnd sending premature 'funding_locked' message when we're expected 'reestablish';
+  we used to close channel if this happened.
 
 ### Security
 


### PR DESCRIPTION
LND seems to do this occasionally, though fixed in new versions.  Workaround
in the meantime.

I tested this by hacking our code to send it prematurely, and this worked.

Fixes: #2219
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>