### PR TITLE
Pylightning: Raise error if required argument is missing

### DIFF
--- a/contrib/pylightning/lightning/plugin.py
+++ b/contrib/pylightning/lightning/plugin.py
@@ -194,6 +194,9 @@ class Plugin(object):
                 if pos < len(params):
                     # Apply positional args if we have them
                     arguments[k] = params[pos]
+                elif sig.parameters[k].default is inspect.Signature.empty:
+                    # This is a positional arg with no value passed
+                    raise TypeError("Missing required parameter: %s" % sig.parameters[k])
                 else:
                     # For the remainder apply default args
                     arguments[k] = sig.parameters[k].default


### PR DESCRIPTION
At the moment if you have the rpc method
```python
@plugin.method("hello")
def hello(plugin, name, punctuation="!"):
```
And call it from the cli, with
```
lightning-cli hello
```

Currently, the arg for `name` will default to `inspect._empty`, which is a bit clumsy. 

This change instead returns the error message:
```
"Error while processing hello: TypeError('Missing required parameter: name',)"
```