### PR TITLE
Switch to libsodium-dev for ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For the impatient here's the gist of it for Ubuntu and Debian:
     sudo apt-get update
     sudo apt-get install -y \
       autoconf automake build-essential git libtool libgmp-dev \
-      libsqlite3-dev python python3 net-tools zlib1g-dev
+      libsqlite3-dev python python3 net-tools zlib1g-dev libsodium-dev
     git clone https://github.com/ElementsProject/lightning.git
     cd lightning
     ./configure

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -38,7 +38,7 @@ Get dependencies:
     sudo apt-get update
     sudo apt-get install -y \
       autoconf automake build-essential git libtool libgmp-dev \
-      libsqlite3-dev python python3 net-tools zlib1g-dev libsodium \
+      libsqlite3-dev python python3 net-tools zlib1g-dev libsodium-dev \
 	  libbase58-dev
 
 If you don't have Bitcoin installed locally you'll need to install that


### PR DESCRIPTION
`libsodium-dev` was removed in #1462 then added backed in #2319 - BUT as `libsodium`, which is not found. This updates to `libsodium-dev` 