### PR TITLE
Reduce the risk of change chaining transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: New command `paystatus` gives detailed information on `pay` commands.
 - JSON API: `getroute` `riskfactor` argument is simplified; `pay` now defaults to setting it to 10.
 - pylightning: New class 'Millisatoshi' can be used for JSON API, and new '_msat' fields are turned into this on reading.
+- JSON API: `fundchannel` and `withdraw` now have a new parameter `minconf` that limits coinselection to outputs that have at least `minconf` confirmations (default 1). (#2380)
 
 ### Changed
 

--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -57,7 +57,8 @@ static struct command_result *check_amount(const struct wallet_tx *wtx,
 
 struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 					u32 fee_rate_per_kw,
-					size_t out_len)
+					size_t out_len,
+					u32 maxheight)
 {
 	struct command_result *res;
 	struct amount_sat fee_estimate;
@@ -66,6 +67,7 @@ struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 		struct amount_sat amount;
 		tx->utxos = wallet_select_all(tx->cmd, tx->cmd->ld->wallet,
 					      fee_rate_per_kw, out_len,
+					      maxheight,
 					      &amount,
 					      &fee_estimate);
 		res = check_amount(tx, amount);
@@ -88,6 +90,7 @@ struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 	tx->utxos = wallet_select_coins(tx->cmd, tx->cmd->ld->wallet,
 					tx->amount,
 					fee_rate_per_kw, out_len,
+					maxheight,
 					&fee_estimate, &tx->change);
 	res = check_amount(tx, tx->amount);
 	if (res)

--- a/common/wallet_tx.h
+++ b/common/wallet_tx.h
@@ -29,5 +29,6 @@ struct command_result *param_wtx(struct command *cmd,
 
 struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 					u32 fee_rate_per_kw,
-					size_t out_len);
+					size_t out_len,
+					u32 maxheight);
 #endif /* LIGHTNING_COMMON_WALLET_TX_H */

--- a/common/wallet_tx.h
+++ b/common/wallet_tx.h
@@ -31,4 +31,13 @@ struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 					u32 fee_rate_per_kw,
 					size_t out_len,
 					u32 maxheight);
+
+static inline u32 minconf_to_maxheight(u32 minconf, struct lightningd *ld)
+{
+	/* No confirmations is special, we need to disable the check in the
+	 * selection */
+	if (minconf == 0)
+		return 0;
+	return ld->topology->tip->height - minconf + 1;
+}
 #endif /* LIGHTNING_COMMON_WALLET_TX_H */

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -511,17 +511,19 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("listpeers", payload)
 
-    def fundchannel(self, node_id, satoshi, feerate=None, announce=True):
+    def fundchannel(self, node_id, satoshi, feerate=None, announce=True, minconf=None):
         """
         Fund channel with {id} using {satoshi} satoshis
         with feerate of {feerate} (uses default feerate if unset).
         If {announce} is False, don't send channel announcements.
+        Only select outputs with {minconf} confirmations
         """
         payload = {
             "id": node_id,
             "satoshi": satoshi,
             "feerate": feerate,
-            "announce": announce
+            "announce": announce,
+            "minconf": minconf,
         }
         return self.call("fundchannel", payload)
 
@@ -588,15 +590,17 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("dev-memleak")
 
-    def withdraw(self, destination, satoshi, feerate=None):
+    def withdraw(self, destination, satoshi, feerate=None, minconf=None):
         """
         Send to {destination} address {satoshi} (or "all")
-        amount via Bitcoin transaction
+        amount via Bitcoin transaction. Only select outputs
+        with {minconf} confirmations
         """
         payload = {
             "destination": destination,
             "satoshi": satoshi,
-            "feerate": feerate
+            "feerate": feerate,
+            "minconf": minconf,
         }
         return self.call("withdraw", payload)
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -891,7 +891,7 @@ static struct command_result *json_fund_channel(struct command *cmd,
 	}
 
 	res = wtx_select_utxos(&fc->wtx, *feerate_per_kw,
-			       BITCOIN_SCRIPTPUBKEY_P2WSH_LEN);
+			       BITCOIN_SCRIPTPUBKEY_P2WSH_LEN, 0);
 	if (res)
 		return res;
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -845,7 +845,7 @@ static struct command_result *json_fund_channel(struct command *cmd,
 		   p_req("satoshi", param_wtx, &fc->wtx),
 		   p_opt("feerate", param_feerate, &feerate_per_kw),
 		   p_opt_def("announce", param_bool, &announce_channel, true),
-		   p_opt_def("minconf", param_number, &minconf, 0),
+		   p_opt_def("minconf", param_number, &minconf, 1),
 		   NULL))
 		return command_param_failed();
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -215,7 +215,7 @@ def test_closing_different_fees(node_factory, bitcoind, executor):
             peers.append(p)
 
     for p in peers:
-        p.channel = l1.rpc.fundchannel(p.info['id'], 10**6)['channel_id']
+        p.channel = l1.rpc.fundchannel(p.info['id'], 10**6, minconf=0)['channel_id']
         # Technically, this is async to fundchannel returning.
         l1.daemon.wait_for_log('sendrawtx exit 0')
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -471,11 +471,11 @@ def test_withdraw(node_factory, bitcoind):
     assert l1.db_query('SELECT COUNT(*) as c FROM outputs WHERE status=0')[0]['c'] == 6
 
     # Test withdrawal to self.
-    l1.rpc.withdraw(l1.rpc.newaddr('bech32')['address'], 'all')
+    l1.rpc.withdraw(l1.rpc.newaddr('bech32')['address'], 'all', minconf=0)
     bitcoind.generate_block(1)
     assert l1.db_query('SELECT COUNT(*) as c FROM outputs WHERE status=0')[0]['c'] == 1
 
-    l1.rpc.withdraw(waddr, 'all')
+    l1.rpc.withdraw(waddr, 'all', minconf=0)
     assert l1.db_query('SELECT COUNT(*) as c FROM outputs WHERE status=0')[0]['c'] == 0
 
     # This should fail, can't even afford fee.

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -711,7 +711,9 @@ static bool test_wallet_outputs(struct lightningd *ld, const tal_t *ctx)
 		  "wallet_add_utxo with close_info");
 
 	/* Now select them */
-	utxos = wallet_select_coins(w, w, AMOUNT_SAT(2), 0, 21, &fee_estimate, &change_satoshis);
+	utxos = wallet_select_coins(w, w, AMOUNT_SAT(2), 0, 21,
+				    0 /* no confirmations required */,
+				    &fee_estimate, &change_satoshis);
 	CHECK(utxos && tal_count(utxos) == 2);
 
 	u = *utxos[1];

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -319,14 +319,16 @@ const struct utxo **wallet_select_coins(const tal_t *ctx, struct wallet *w,
 					struct amount_sat value,
 					const u32 feerate_per_kw,
 					size_t outscriptlen,
+					u32 maxheight,
 					struct amount_sat *fee_estimate,
 					struct amount_sat *change_satoshi);
 
 const struct utxo **wallet_select_all(const tal_t *ctx, struct wallet *w,
-					const u32 feerate_per_kw,
-					size_t outscriptlen,
-					struct amount_sat *sat,
-					struct amount_sat *fee_estimate);
+				      const u32 feerate_per_kw,
+				      size_t outscriptlen,
+				      u32 maxheight,
+				      struct amount_sat *sat,
+				      struct amount_sat *fee_estimate);
 
 /**
  * wallet_confirm_utxos - Once we've spent a set of utxos, mark them confirmed.

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -139,7 +139,7 @@ static struct command_result *json_withdraw(struct command *cmd,
 	}
 
 	res = wtx_select_utxos(&withdraw->wtx, *feerate_per_kw,
-			       tal_count(withdraw->destination));
+			       tal_count(withdraw->destination), 0);
 	if (res)
 		return res;
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -110,7 +110,7 @@ static struct command_result *json_withdraw(struct command *cmd,
 		   p_req("destination", param_tok, &desttok),
 		   p_req("satoshi", param_wtx, &withdraw->wtx),
 		   p_opt("feerate", param_feerate, &feerate_per_kw),
-		   p_opt_def("minconf", param_number, &minconf, 0),
+		   p_opt_def("minconf", param_number, &minconf, 1),
 		   NULL))
 		return command_param_failed();
 


### PR DESCRIPTION
We had quite a few cases in which one failed transaction (potentially due to insufficient fees) was causing all following transactions to remain in limbo as well.

This PR adds a `minconf` argument inspired by `bitcoind` that allows us to determine how many confirmations an output must have before being considered for coin selection. The default of 1 confirmation mitigates the risk of chainge chaining, with the drawback of failing a few more transactions at selection than strictly necessary.