### PR TITLE
feat: block of newlines when attaching a logfile

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -799,6 +799,7 @@ int main(int argc, char *argv[])
 	 * log.  And tal_hex() is a helper from utils which returns a hex string;
 	 * it's assumed that the argument was allocated with tal or tal_arr
 	 * so it can use tal_bytelen() to get the length. */
+	log_info(ld->log, "--------------------------------------------------");
 	log_info(ld->log, "Server started with public key %s, alias %s (color #%s) and lightningd %s",
 		 type_to_string(tmpctx, struct pubkey, &ld->id),
 		 json_escape(tmpctx, (const char *)ld->alias)->s,

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -504,6 +504,7 @@ char *arg_log_to_file(const char *arg, struct lightningd *ld)
 {
 	const struct log_entry *i;
 	FILE *logf;
+	int size;
 
 	if (ld->logfile) {
 		fclose(ld->log->lr->print_arg);
@@ -516,6 +517,11 @@ char *arg_log_to_file(const char *arg, struct lightningd *ld)
 	if (!logf)
 		return tal_fmt(NULL, "Failed to open: %s", strerror(errno));
 	set_log_outfn(ld->log->lr, log_to_file, logf);
+
+	/* For convenience make a block of empty lines just like Bitcoin Core */
+	size = ftell(logf);
+	if (size > 0)
+		fprintf(logf, "\n\n\n\n");
 
 	/* Catch up */
 	list_for_each(&ld->log->lr->log, i, list)


### PR DESCRIPTION
This will make the logger write 4 newlines to re-attached logfiles.
The newlines wont appear on logfiles that are just created.
Additionally the server prints 50 '-' dashes before printing his
startup message, which also help increase readability on logfile.

This was inspired by the way Bitcoin Core handles logfiles.