### PR TITLE
Build cleanups for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ changes.
 - Protocol: don't send invalid onion errors if peer says onion was bad.
 - Protocol: don't crash when peer sends a 0-block-expiry HTLC.
 - pylightning: handle multiple simultanous RPC replies reliably.
-
+- build: we use `--prefix` as handed to `./configure`
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -436,13 +436,12 @@ unittest/%: %
 	$(VG) $(VG_TEST_ARGS) $* > /dev/null
 
 # Installation directories
-prefix = /usr/local
-exec_prefix = $(prefix)
+exec_prefix = $(PREFIX)
 bindir = $(exec_prefix)/bin
 libexecdir = $(exec_prefix)/libexec
 pkglibexecdir = $(libexecdir)/$(PKGNAME)
 plugindir = $(pkglibexecdir)/plugins
-datadir = $(prefix)/share
+datadir = $(PREFIX)/share
 docdir = $(datadir)/doc/$(PKGNAME)
 mandir = $(datadir)/man
 man1dir = $(mandir)/man1

--- a/configure
+++ b/configure
@@ -145,7 +145,7 @@ if [ -z "$VALGRIND" ]; then
 fi
 
 if [ "$ASAN" = "1" ]; then
-    if [ "$CC" != "gcc" ] && [ "$CC" != "cc" ]; then
+    if [ "$CC" == "clang" ]; then
 	echo "Address sanitizer (ASAN) is currently only supported with gcc"
 	exit 1
     fi

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -70,6 +70,9 @@ if [ -z "$MTIME" ]; then
     exit 1
 fi
 
+# If it's a completely clean directory, we need submodules!
+make submodcheck
+
 rm -rf release
 mkdir -p release
 for target in $TARGETS; do

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -48,7 +48,8 @@ else
     TARGETS=" $* "
 fi
 
-if [ "$(git status --porcelain -u no)" != "" ] && ! $FORCE_UNCLEAN; then
+# `status --porcelain -u no` suppressed modified!  Bug reported...
+if [ "$(git diff --name-only)" != "" ] && ! $FORCE_UNCLEAN; then
     echo "Not a clean git directory" >&2
     exit 1
 fi


### PR DESCRIPTION
I want to merge the repro script immediately before rc1.  That is two commits: one to add the script (ideally that would be rc1), and one to document (using real examples from the previous commit).

Then I'm happy to refine it during the rc process.

So this gets the precursor cleanups out the way.