### PR TITLE
pylightning: Fix missing encode if first pass fails

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -160,7 +160,7 @@ class UnixDomainSocketRpc(object):
                 return objs, buff
             except ValueError:
                 # Probably didn't read enough
-                pass
+                buff = buff.lstrip().encode("UTF-8")
 
     def _readobj(self, sock, buff=b''):
         """Read a JSON object, starting with buff; returns object and any buffer left over"""


### PR DESCRIPTION
Without this the RPC will fail to continue buffering if the response does not
fit in the first read, and if we don't switch over to the non-compat
mode. This was introduced by our mitigation of the UTF-8 misalignment (#2355 ), but I
missed this path.