### PR TITLE
Show addresses for their_unilateral/to_us outputs as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `getroute` `riskfactor` argument is simplified; `pay` now defaults to setting it to 10.
 - pylightning: New class 'Millisatoshi' can be used for JSON API, and new '_msat' fields are turned into this on reading.
 - JSON API: `fundchannel` and `withdraw` now have a new parameter `minconf` that limits coinselection to outputs that have at least `minconf` confirmations (default 1). (#2380)
+- JSON API: `listfunds` now displays addresses for all outputs owned by the wallet (#2387)
 
 ### Changed
 

--- a/common/utxo.c
+++ b/common/utxo.c
@@ -31,6 +31,11 @@ struct utxo *fromwire_utxo(const tal_t *ctx, const u8 **ptr, size_t *max)
 	utxo->amount = fromwire_amount_sat(ptr, max);
 	utxo->keyindex = fromwire_u32(ptr, max);
 	utxo->is_p2sh = fromwire_bool(ptr, max);
+
+	/* No need to tell hsmd about the scriptPubkey, it has all the info to
+	 * derive it from the rest. */
+	utxo->scriptPubkey = NULL;
+
 	if (fromwire_bool(ptr, max)) {
 		utxo->close_info = tal(utxo, struct unilateral_close_info);
 		utxo->close_info->channel_id = fromwire_u64(ptr, max);

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -35,6 +35,9 @@ struct utxo {
 
 	/* NULL if not spent yet, otherwise, the block the spending transaction is in */
 	const u32 *spendheight;
+
+	/* The scriptPubkey if it is known */
+	u8 *scriptPubkey;
 };
 
 void towire_utxo(u8 **pptr, const struct utxo *utxo);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -272,6 +272,7 @@ static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 	u->close_info->channel_id = channel->dbid;
 	u->close_info->peer_id = channel->peer->id;
 	u->spendheight = NULL;
+	u->scriptPubkey = NULL;
 
 	if (!fromwire_onchain_add_utxo(msg, &u->txid, &u->outnum,
 				       &u->close_info->commitment_point,

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -272,11 +272,10 @@ static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 	u->close_info->channel_id = channel->dbid;
 	u->close_info->peer_id = channel->peer->id;
 	u->spendheight = NULL;
-	u->scriptPubkey = NULL;
 
-	if (!fromwire_onchain_add_utxo(msg, &u->txid, &u->outnum,
-				       &u->close_info->commitment_point,
-				       &u->amount, &blockheight)) {
+	if (!fromwire_onchain_add_utxo(
+		u, msg, &u->txid, &u->outnum, &u->close_info->commitment_point,
+		&u->amount, &blockheight, &u->scriptPubkey)) {
 		fatal("onchaind gave invalid add_utxo message: %s", tal_hex(msg, msg));
 	}
 	u->blockheight = blockheight>0?&blockheight:NULL;

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -90,6 +90,8 @@ onchain_add_utxo,,prev_out_index,u32
 onchain_add_utxo,,per_commit_point,struct pubkey
 onchain_add_utxo,,value,struct amount_sat
 onchain_add_utxo,,blockheight,u32
+onchain_add_utxo,,len,u16
+onchain_add_utxo,,scriptpubkey,len*u8
 
 # master -> onchaind: do you have a memleak?
 onchain_dev_memleak,5033

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -2014,7 +2014,6 @@ static void handle_their_cheat(const struct bitcoin_tx *tx,
 						 i, tx->output[i].amount,
 						 OUTPUT_TO_US, NULL, NULL, NULL);
 			ignore_output(out);
-			script[LOCAL] = NULL;
 
 			/* Tell the master that it will want to add
 			 * this UTXO to its outputs */
@@ -2022,7 +2021,9 @@ static void handle_their_cheat(const struct bitcoin_tx *tx,
 						    tmpctx, txid, i,
 						    remote_per_commitment_point,
 						    tx->output[i].amount,
-						    tx_blockheight));
+						    tx_blockheight,
+						    script[LOCAL]));
+			script[LOCAL] = NULL;
 			continue;
 		}
 		if (script[REMOTE]
@@ -2226,7 +2227,6 @@ static void handle_their_unilateral(const struct bitcoin_tx *tx,
 						 i, tx->output[i].amount,
 						 OUTPUT_TO_US, NULL, NULL, NULL);
 			ignore_output(out);
-			script[LOCAL] = NULL;
 
 			/* Tell the master that it will want to add
 			 * this UTXO to its outputs */
@@ -2234,7 +2234,9 @@ static void handle_their_unilateral(const struct bitcoin_tx *tx,
 						    tmpctx, txid, i,
 						    remote_per_commitment_point,
 						    tx->output[i].amount,
-						    tx_blockheight));
+						    tx_blockheight,
+						    script[LOCAL]));
+			script[LOCAL] = NULL;
 			continue;
 		}
 		if (script[REMOTE]
@@ -2355,7 +2357,6 @@ static void handle_unknown_commitment(const struct bitcoin_tx *tx,
 						 i, tx->output[i].amount,
 						 OUTPUT_TO_US, NULL, NULL, NULL);
 			ignore_output(out);
-			local_script = NULL;
 
 			/* Tell the master that it will want to add
 			 * this UTXO to its outputs */
@@ -2363,7 +2364,9 @@ static void handle_unknown_commitment(const struct bitcoin_tx *tx,
 						    tmpctx, txid, i,
 						    possible_remote_per_commitment_point,
 						    tx->output[i].amount,
-						    tx_blockheight));
+						    tx_blockheight,
+						    local_script));
+			local_script = NULL;
 			to_us_output = i;
 		}
 	}

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -124,7 +124,7 @@ u8 *towire_hsm_sign_penalty_to_us(const tal_t *ctx UNNEEDED, const struct secret
 u8 *towire_hsm_sign_remote_htlc_to_us(const tal_t *ctx UNNEEDED, const struct pubkey *remote_per_commitment_point UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_remote_htlc_to_us called!\n"); abort(); }
 /* Generated stub for towire_onchain_add_utxo */
-u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *prev_out_tx UNNEEDED, u32 prev_out_index UNNEEDED, const struct pubkey *per_commit_point UNNEEDED, struct amount_sat value UNNEEDED, u32 blockheight UNNEEDED)
+u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *prev_out_tx UNNEEDED, u32 prev_out_index UNNEEDED, const struct pubkey *per_commit_point UNNEEDED, struct amount_sat value UNNEEDED, u32 blockheight UNNEEDED, const u8 *scriptpubkey UNNEEDED)
 { fprintf(stderr, "towire_onchain_add_utxo called!\n"); abort(); }
 /* Generated stub for towire_onchain_all_irrevocably_resolved */
 u8 *towire_onchain_all_irrevocably_resolved(const tal_t *ctx UNNEEDED)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1469,6 +1469,12 @@ def test_permfail(node_factory, bitcoind):
     # generated some more blocks.
     assert (closetxid, "confirmed") in set([(o['txid'], o['status']) for o in l1.rpc.listfunds()['outputs']])
 
+    # Check that the all the addresses match what we generated ourselves:
+    for o in l1.rpc.listfunds()['outputs']:
+        txout = bitcoind.rpc.gettxout(o['txid'], o['output'])
+        addr = txout['scriptPubKey']['addresses'][0]
+        assert(addr == o['address'])
+
     addr = l1.bitcoin.rpc.getnewaddress()
     l1.rpc.withdraw(addr, "all")
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -358,6 +358,7 @@ char *dbmigrations[] = {
     "ALTER TABLE payments ADD faildirection INTEGER;", /* erring_direction */
     /* Fix dangling peers with no channels. */
     "DELETE FROM peers WHERE id NOT IN (SELECT peer_id FROM channels);",
+    "ALTER TABLE outputs ADD scriptpubkey BLOB;",
     NULL,
 };
 


### PR DESCRIPTION
This was the only type of outputs we didn't show addresses until now, since it was a bit more involved, being derived from a combination of the outpoint and the private key. I decided to add the `scriptPubKey` to the outputs in these cases since otherwise we'd have to go talk to `hsmd` just to derive the pubkey and then hash it in order to generate the address, which is basically already what is in the `scriptPubKey`.

However I haven't found a good and clean way to backfill the missing ones for existing wallets since we don't track the utxos, and we can't call out to the `hsmd` in migrations. The number of affected users is minimal and it falls back gracefully to just not showing the address in those cases, so I decided not to add more code just to cover that corner case that'll quickly disappear :wink: 

Fixes #2080 