### PR TITLE
Don't count uncommitted channels towards num_pending in getinfo

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1291,10 +1291,6 @@ static struct command_result *json_getinfo(struct command *cmd,
     /* Add some peer and channel stats */
     list_for_each(&cmd->ld->peers, peer, list) {
         num_peers++;
-        /* Count towards pending? */
-        if (peer->uncommitted_channel) {
-            pending_channels++;
-        }
 
         list_for_each(&peer->channels, channel, list) {
             if (channel->state == CHANNELD_AWAITING_LOCKIN) {


### PR DESCRIPTION
I orginally added the `num_x_channels` fields to `getinfo`, and wasn't quite sure how to handle the case of `peer->uncommitted_channel`, so I lumped it into `pending_channels`.

I now think this is a bit wrong, as it can stay in this state indefinitely if no channel is made, and it might be misleading to show it as pending. 