### PR TITLE
Installing the Pay plugin in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ VOLUME [ "/root/.lightning" ]
 
 COPY --from=builder /opt/lightningd/cli/lightning-cli /usr/bin
 COPY --from=builder /opt/lightningd/lightningd/lightning* /usr/bin/
+COPY --from=builder /opt/lightningd/plugins/pay /usr/libexec/c-lightning/plugins/
 COPY --from=builder /opt/bitcoin/bin /usr/bin
 COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ services:
       - --bitcoin-rpcconnect=bitcoind
       - --bitcoin-rpcuser=rpcuser
       - --bitcoin-rpcpassword=rpcpass
+      - --plugin-dir=/usr/libexec/c-lightning/plugins
       - --network=testnet
       - --alias=myawesomenode
       - --log-level=debug


### PR DESCRIPTION
This is a proposed fix for #2377.

**Current behavior**
When following instructions in readme.md with using docker image, running `lightning-cli` Pay will generate:  ` { "code" : -32601, "message" : "Unknown command 'pay'" }`

**Proposed fix**
Copy the Pay plugin to `/usr/libexec/c-lightning/plugins/` and use --plugin-dir argument to point to the plugins directory.

**Note to the maintainers**
After applying this fix, the docker image `elementsproject/lightningd` should be updated and uploaded to Dockerhub