### PR TITLE
Use plugin directory in docker-entrypoint

### DIFF
--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 
 if [ "$EXPOSE_TCP" == "true" ]; then
     set -m
-    lightningd "$@" &
+    lightningd --plugin-dir=/usr/libexec/c-lightning/plugins "$@" &
 
     echo "C-Lightning starting"
     while read -r i; do if [ "$i" = "lightning-rpc" ]; then break; fi; done \
@@ -15,5 +15,5 @@ if [ "$EXPOSE_TCP" == "true" ]; then
     socat "TCP4-listen:$LIGHTNINGD_RPC_PORT,fork,reuseaddr" "UNIX-CONNECT:$LIGHTNINGD_DATA/lightning-rpc" &
     fg %-
 else
-    exec lightningd "$@"
+    exec lightningd --plugin-dir=/usr/libexec/c-lightning/plugins "$@"
 fi


### PR DESCRIPTION
Even if the plugin directory exist on the container, by default `lightningd` do not use it.