### PR TITLE
build: libsodium switched case in constants, add check for compat

### DIFF
--- a/configure
+++ b/configure
@@ -168,6 +168,7 @@ code=
 int main(void)
 {
 	printf("%p\n", crypto_aead_chacha20poly1305_ietf_encrypt);
+	printf("%d\n", crypto_aead_chacha20poly1305_ietf_NPUBBYTES);
 	exit(0);
 }
 /*END*/


### PR DESCRIPTION
It seems libsodium broke their public interface at some point by switching
from upper-case IETF in constants to lower-case. This adds a check for the
lower-case version which seems to be what they are going with.

Fixes #2425 

Reported-by: Zoltán Gálli <@gallizoltan>
Signed-off-by: Christian Decker <decker.christian@gmail.com>