### PR TITLE
build: fix uninitialized variable error on gcc 7.4.0

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -658,7 +658,7 @@ static struct command_result *add_shadow_route(struct command *cmd,
 	const jsmntok_t *channels = json_get_member(buf, result, "channels");
 	const jsmntok_t *chan, *best = NULL;
 	size_t i;
-	u64 sample;
+	u64 sample = 0;
 	u32 cltv, best_cltv;
 
 	json_for_each_arr(i, chan, channels) {


### PR DESCRIPTION
`*best` is checked for null before the comparison against the uninitialized
variable ever happens, so this isn't a real issue.

Initialize it to zero so that we don't fail to compile on certain gcc versions.

    plugins/pay.c: In function ‘add_shadow_route’:
    plugins/pay.c:644:18: error: ‘sample’ may be used uninitialized in this function
      if (!best || v > sample) {
                    ~~^~~~~~~~
