### PR TITLE
change the version of bip32 private_key to BIP32_VER_MAIN_PRIVATE

### DIFF
--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -360,7 +360,7 @@ static void populate_secretstuff(void)
 			    "bip32 seed", strlen("bip32 seed"));
 		salt++;
 	} while (bip32_key_from_seed(bip32_seed, sizeof(bip32_seed),
-				     BIP32_VER_TEST_PRIVATE,
+				     BIP32_VER_MAIN_PRIVATE,
 				     0, &master_extkey) != WALLY_OK);
 
 	/* BIP 32:

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -667,7 +667,7 @@ static struct wallet *create_test_wallet(struct lightningd *ld, const tal_t *ctx
 
 	w->bip32_base = tal(w, struct ext_key);
 	CHECK(bip32_key_from_seed(badseed, sizeof(badseed),
-				  BIP32_VER_TEST_PRIVATE, 0,
+				  BIP32_VER_MAIN_PRIVATE, 0,
 				  w->bip32_base) == WALLY_OK);
 
 	CHECK_MSG(w->db, "Failed opening the db");


### PR DESCRIPTION
In libwally-core, the version BIP32_VER_TEST_PRIVATE is for testnet/regtest, and BIP32_VER_MAIN_PRIVATE is for mainnet.
Though the version of bip32 key don't affect the key-generation now, BIP32_VER_MAIN_PRIVATE is more accurate.