### PR TITLE
Fix README to use updated configuration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ network=testnet
 
 For a full list of possible lightningd configuration options, run:
 ```
-lightningd/lightningd --help
+elementsproject/lightningd --help
 ```
 
 ## Further information


### PR DESCRIPTION
Updated documentation to use `elementsproject` docker repo for the configuration options example.

The previous repo, `lightningd`, fails with the following command:

```
$ docker run lightningd/lightningd --help
Unable to find image 'lightningd/lightningd:latest' locally
docker: Error response from daemon: pull access denied for lightningd/lightningd, repository does not exist or may require 'docker login'.
See 'docker run --help'.
```