### PR TITLE
fix: fix a pr2444 introduced valgrind complaint

### DIFF
--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -122,6 +122,7 @@ int main(void)
 	bool ok = true;
 	/* Dummy for migration hooks */
 	struct lightningd *ld = tal(NULL, struct lightningd);
+	ld->config = test_config;
 
 	ok &= test_empty_db_migrate(ld);
 	ok &= test_vars(ld);

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1161,6 +1161,7 @@ int main(void)
 	wally_init(0);
 	secp256k1_ctx = wally_get_secp_context();
 	ld = tal(tmpctx, struct lightningd);
+	ld->config = test_config;
 
 	/* Only elements in ld we should access */
 	list_head_init(&ld->peers);

--- a/wallet/test/test_utils.c
+++ b/wallet/test/test_utils.c
@@ -1,0 +1,25 @@
+#include "test_utils.h"
+
+/*
+ * Copy of lightnind/options.c testnet_config
+ * To reduce code duplication move testnet_config from options.c to options.h.
+ */
+const struct config test_config = {
+	.locktime_blocks = 6,
+	.locktime_max = 14 * 24 * 6,
+	.anchor_confirms = 1,
+	.commitment_fee_min_percent = 0,
+	.commitment_fee_max_percent = 0,
+	.commitment_fee_percent = 500,
+	.cltv_expiry_delta = 6,
+	.cltv_final = 10,
+	.commit_time_ms = 10,
+	.fee_base = 1,
+	.fee_per_satoshi = 10,
+	.broadcast_interval_msec = 60000,
+	.channel_update_interval = 1209600/2,
+	.ignore_fee_limits = true,
+	.rescan = 30,
+	.max_fee_multiplier = 10,
+	.use_dns = true,
+};

--- a/wallet/test/test_utils.h
+++ b/wallet/test/test_utils.h
@@ -1,6 +1,8 @@
 #ifndef LIGHTNING_WALLET_TEST_TEST_UTILS_H
 #define LIGHTNING_WALLET_TEST_TEST_UTILS_H
 
+#include "lightningd/lightningd.h"
+
 /* Definitions "inspired" by libsecp256k1 */
 #define TEST_FAILURE(msg) do { \
     fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, msg); \
@@ -20,5 +22,7 @@
 } while(0)
 
 #define CHECK(cond) CHECK_MSG(cond,"test condition failed");
+
+const struct config test_config;
 
 #endif /* LIGHTNING_WALLET_TEST_TEST_UTILS_H */


### PR DESCRIPTION
PR #2444 introduced a problem where valgrind complained ab usage of otherwise uninitialized space in the `*ld` unittest stub.

We will reuse the testnet config and put it in testuitls.c ...