### PR TITLE
fix: missing closedir in plugin.c

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -887,6 +887,7 @@ char *add_plugin_dir(struct plugins *plugins, const char *dir, bool nonexist_ok)
 		if (fullpath)
 			plugin_register(plugins, take(fullpath));
 	}
+	closedir(d);
 	return NULL;
 }
 


### PR DESCRIPTION
As pointed out by `bitonic-cjp` in the IRC log, there was a closedir missing.

**Note:** I do not check the return code of this operation by intention, as there would not be any meaningful error correction or notification at this point.