### PR TITLE
Fix installing plugins in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG PREFIX=/tmp/lightning_install
-
 FROM alpine:3.7 as builder
 
 RUN apk add --no-cache \
@@ -22,7 +20,6 @@ RUN apk add --no-cache \
      zlib-dev
 
 WORKDIR /opt
-ARG PREFIX
 ARG BITCOIN_VERSION=0.17.0
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
@@ -63,7 +60,7 @@ RUN git clone --recursive /tmp/lightning . && \
     git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
 
 ARG DEVELOPER=0
-RUN ./configure --prefix=$PREFIX && make -j3 DEVELOPER=${DEVELOPER} && make install
+RUN ./configure --prefix=/tmp/lightning_install && make -j3 DEVELOPER=${DEVELOPER} && make install
 
 FROM alpine:3.7
 
@@ -95,8 +92,7 @@ ENV LIGHTNINGD_DATA=/root/.lightning
 ENV LIGHTNINGD_RPC_PORT=9835
 
 VOLUME [ "/root/.lightning" ]
-ARG PREFIX
-COPY --from=builder $PREFIX/ /usr/local/
+COPY --from=builder /tmp/lightning_install/ /usr/local/
 COPY --from=builder /opt/bitcoin/bin /usr/bin
 COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG PREFIX=/tmp/lightning_install
+
 FROM alpine:3.7 as builder
 
 RUN apk add --no-cache \
@@ -20,7 +22,7 @@ RUN apk add --no-cache \
      zlib-dev
 
 WORKDIR /opt
-
+ARG PREFIX
 ARG BITCOIN_VERSION=0.17.0
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
@@ -61,7 +63,7 @@ RUN git clone --recursive /tmp/lightning . && \
     git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
 
 ARG DEVELOPER=0
-RUN ./configure && make -j3 DEVELOPER=${DEVELOPER} && cp lightningd/lightning* cli/lightning-cli /usr/bin/
+RUN ./configure --prefix=$PREFIX && make -j3 DEVELOPER=${DEVELOPER} && make install
 
 FROM alpine:3.7
 
@@ -93,10 +95,8 @@ ENV LIGHTNINGD_DATA=/root/.lightning
 ENV LIGHTNINGD_RPC_PORT=9835
 
 VOLUME [ "/root/.lightning" ]
-
-COPY --from=builder /opt/lightningd/cli/lightning-cli /usr/bin
-COPY --from=builder /opt/lightningd/lightningd/lightning* /usr/bin/
-COPY --from=builder /opt/lightningd/plugins/pay /usr/libexec/c-lightning/plugins/
+ARG PREFIX
+COPY --from=builder $PREFIX/ /usr/local/
 COPY --from=builder /opt/bitcoin/bin /usr/bin
 COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
      zlib-dev
 
 WORKDIR /opt
+
 ARG BITCOIN_VERSION=0.17.0
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ services:
       - --bitcoin-rpcconnect=bitcoind
       - --bitcoin-rpcuser=rpcuser
       - --bitcoin-rpcpassword=rpcpass
-      - --plugin-dir=/usr/libexec/c-lightning/plugins
       - --network=testnet
       - --alias=myawesomenode
       - --log-level=debug

--- a/contrib/linuxarm32v7.Dockerfile
+++ b/contrib/linuxarm32v7.Dockerfile
@@ -5,8 +5,6 @@
 # * final: Copy the binaries required at runtime
 # The resulting image uploaded to dockerhub will only contain what is needed for runtime.
 # From the root of the repository, run "docker build -t yourimage:yourtag -f contrib/linuxarm32v7.Dockerfile ."
-ARG PREFIX=/tmp/lightning_install
-
 FROM debian:stretch-slim as downloader
 
 RUN set -ex \
@@ -17,7 +15,6 @@ RUN set -ex \
 WORKDIR /opt
 
 ARG BITCOIN_VERSION=0.17.0
-ARG PREFIX
 ENV BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION-arm-linux-gnueabihf.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc
@@ -90,7 +87,7 @@ RUN git clone --recursive /tmp/lightning . && \
     git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
 
 ARG DEVELOPER=0
-RUN ./configure --prefix=$PREFIX --enable-static && make -j3 DEVELOPER=${DEVELOPER} && make install
+RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVELOPER=${DEVELOPER} && make install
 
 FROM arm32v7/debian:stretch-slim as final
 COPY --from=downloader /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
@@ -103,8 +100,7 @@ ENV LIGHTNINGD_PORT=9835
 RUN mkdir $LIGHTNINGD_DATA && \
     touch $LIGHTNINGD_DATA/config
 VOLUME [ "/root/.lightning" ]
-ARG PREFIX
-COPY --from=builder $PREFIX/ /usr/local/
+COPY --from=builder /tmp/lightning_install/ /usr/local/
 COPY --from=downloader /opt/bitcoin/bin /usr/bin
 COPY --from=downloader /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh


### PR DESCRIPTION
**Current state**
In docker, the lightning installation is achieved by copying binaries one by one ‘manually’.  As soon as a new binary is added, the dockerfile become outdated. See #2377 

**What has been done**
Binaries are installed into a temporary directory using `configure --prefix=` and `make install`, then the installation directory is copied ‘as-it-is’ to the final image in the second phase of the build. This will guarantee that any new lib/binary/plugin generated from `make install` will be reflected in the docker images, and more important, the docker image configuration is closer to the normal build.

**Note to the maintainers**
Update the official docker image after the merge of this PR.