### PR TITLE
Remove missing config option "port"

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ the file, for example:
 ```
 alias=SLEEPYDRAGON
 rgb=008000
-port=9735
 network=testnet
 ```
 


### PR DESCRIPTION
During installation I noticed that the README suggests using a config option "port=9735". Unfortunately lightningd rejects this option with error "unrecognized option". As this is the default port anyway, I simple removed this option.