### PR TITLE
Fix: fix the version of bip32 private_key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ provide appropriate suffixes for JSON input fields.
 - You can no longer make giant unpayable "wumbo" invoices.
 - CLTV of total route now correctly evaluated when finding best route.
 - `riskfactor` arguments to `pay` and `getroute` now have an effect.
+- Fixed the version of bip32 private_key to BIP32_VER_MAIN_PRIVATE: we used
+  BIP32_VER_MAIN_PRIVATE for bitcoin/litecoin mainnet, and BIP32_VER_TEST_PRIVATE
+  for others. (PR #2436)
 
 ### Security
 

--- a/bitcoin/chainparams.c
+++ b/bitcoin/chainparams.c
@@ -3,6 +3,13 @@
 #include <ccan/str/str.h>
 #include <string.h>
 
+/* Version codes for BIP32 extended keys in libwally-core.
+ * Stolen from wally_bip32.h in libwally-core*/
+#define BIP32_VER_MAIN_PUBLIC  0x0488B21E
+#define BIP32_VER_MAIN_PRIVATE 0x0488ADE4
+#define BIP32_VER_TEST_PUBLIC  0x043587CF
+#define BIP32_VER_TEST_PRIVATE 0x04358394
+
 const struct chainparams networks[] = {
     {.network_name = "bitcoin",
      .bip173_name = "bc",
@@ -21,7 +28,8 @@ const struct chainparams networks[] = {
      .max_payment = AMOUNT_MSAT_INIT(0xFFFFFFFFULL),
      /* "Lightning Charge Powers Developers & Blockstream Store" */
      .when_lightning_became_cool = 504500,
-     .testnet = false},
+     .testnet = false,
+     .bip32_key_version = {.bip32_pubkey_version = BIP32_VER_MAIN_PUBLIC, .bip32_privkey_version = BIP32_VER_MAIN_PRIVATE}},
     {.network_name = "regtest",
      .bip173_name = "bcrt",
      .genesis_blockhash = {{{.u.u8 = {0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59, 0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b, 0xbf, 0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f, 0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f}}}},
@@ -32,7 +40,8 @@ const struct chainparams networks[] = {
      .max_funding = AMOUNT_SAT_INIT((1 << 24) - 1),
      .max_payment = AMOUNT_MSAT_INIT(0xFFFFFFFFULL),
      .when_lightning_became_cool = 1,
-     .testnet = true},
+     .testnet = true,
+     .bip32_key_version = {.bip32_pubkey_version = BIP32_VER_TEST_PUBLIC, .bip32_privkey_version = BIP32_VER_TEST_PRIVATE}},
     {.network_name = "testnet",
      .bip173_name = "tb",
      .genesis_blockhash = {{{.u.u8 = {0x43, 0x49, 0x7f, 0xd7, 0xf8, 0x26, 0x95, 0x71, 0x08, 0xf4, 0xa3, 0x0f, 0xd9, 0xce, 0xc3, 0xae, 0xba, 0x79, 0x97, 0x20, 0x84, 0xe9, 0x0e, 0xad, 0x01, 0xea, 0x33, 0x09, 0x00, 0x00, 0x00, 0x00}}}},
@@ -42,7 +51,8 @@ const struct chainparams networks[] = {
      .dust_limit = { 546 },
      .max_funding = AMOUNT_SAT_INIT((1 << 24) - 1),
      .max_payment = AMOUNT_MSAT_INIT(0xFFFFFFFFULL),
-     .testnet = true},
+     .testnet = true,
+     .bip32_key_version = {.bip32_pubkey_version = BIP32_VER_TEST_PUBLIC, .bip32_privkey_version = BIP32_VER_TEST_PRIVATE}},
     {.network_name = "litecoin",
      .bip173_name = "ltc",
      .genesis_blockhash = {{{.u.u8 = {0xe2, 0xbf, 0x04, 0x7e, 0x7e, 0x5a, 0x19, 0x1a, 0xa4, 0xef, 0x34, 0xd3, 0x14, 0x97, 0x9d, 0xc9, 0x98, 0x6e, 0x0f, 0x19, 0x25, 0x1e, 0xda, 0xba, 0x59, 0x40, 0xfd, 0x1f, 0xe3, 0x65, 0xa7, 0x12 }}}},
@@ -53,7 +63,8 @@ const struct chainparams networks[] = {
      .max_funding = AMOUNT_SAT_INIT(60 * ((1 << 24) - 1)),
      .max_payment = AMOUNT_MSAT_INIT(60 * 0xFFFFFFFFULL),
      .when_lightning_became_cool = 1320000,
-     .testnet = false},
+     .testnet = false,
+     .bip32_key_version = {.bip32_pubkey_version = BIP32_VER_MAIN_PUBLIC, .bip32_privkey_version = BIP32_VER_MAIN_PRIVATE}},
     {.network_name = "litecoin-testnet",
      .bip173_name = "tltc",
      .genesis_blockhash = {{{.u.u8 = { 0xa0, 0x29, 0x3e, 0x4e, 0xeb, 0x3d, 0xa6, 0xe6, 0xf5, 0x6f, 0x81, 0xed, 0x59, 0x5f, 0x57, 0x88, 0x0d, 0x1a, 0x21, 0x56, 0x9e, 0x13, 0xee, 0xfd, 0xd9, 0x51, 0x28, 0x4b, 0x5a, 0x62, 0x66, 0x49 }}}},
@@ -64,7 +75,8 @@ const struct chainparams networks[] = {
      .max_funding = AMOUNT_SAT_INIT(60 * ((1 << 24) - 1)),
      .max_payment = AMOUNT_MSAT_INIT(60 * 0xFFFFFFFFULL),
      .when_lightning_became_cool = 1,
-     .testnet = true}
+     .testnet = true,
+     .bip32_key_version = {.bip32_pubkey_version = BIP32_VER_TEST_PUBLIC, .bip32_privkey_version = BIP32_VER_TEST_PRIVATE}}
 };
 
 const struct chainparams *chainparams_for_network(const char *network_name)

--- a/bitcoin/chainparams.h
+++ b/bitcoin/chainparams.h
@@ -7,6 +7,11 @@
 #include <common/amount.h>
 #include <stdbool.h>
 
+struct bip32_key_version {
+	u32 bip32_pubkey_version;
+	u32 bip32_privkey_version;
+};
+
 struct chainparams {
 	const char *network_name;
 	const char *bip173_name;
@@ -21,6 +26,9 @@ struct chainparams {
 
 	/* Whether this is a test network or not */
 	const bool testnet;
+
+	/* Version codes for BIP32 extended keys in libwally-core*/
+	const struct bip32_key_version bip32_key_version;
 };
 
 /**

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -5,8 +5,10 @@ hsmstatus_client_bad_request,,description,wirestring
 hsmstatus_client_bad_request,,len,u16
 hsmstatus_client_bad_request,,msg,len*u8
 
+#include <bitcoin/chainparams.h>
 # Start the HSM.
 hsm_init,11
+hsm_init,,bip32_key_version,struct bip32_key_version
 
 #include <common/bip32.h>
 hsm_init_reply,111

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <hsmd/gen_hsm_wire.h>
 #include <inttypes.h>
+#include <lightningd/bitcoind.h>
 #include <lightningd/hsm_control.h>
 #include <lightningd/log.h>
 #include <lightningd/log_status.h>
@@ -92,7 +93,8 @@ void hsm_init(struct lightningd *ld)
 		err(1, "Could not subd hsm");
 
 	ld->hsm_fd = fds[0];
-	if (!wire_sync_write(ld->hsm_fd, towire_hsm_init(tmpctx)))
+	if (!wire_sync_write(ld->hsm_fd, towire_hsm_init(tmpctx,
+				  &ld->topology->bitcoind->chainparams->bip32_key_version)))
 		err(1, "Writing init msg to hsm");
 
 	ld->wallet->bip32_base = tal(ld->wallet, struct ext_key);

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -1,4 +1,5 @@
 #include "wire.h"
+#include <bitcoin/chainparams.h>
 #include <bitcoin/preimage.h>
 #include <bitcoin/pubkey.h>
 #include <bitcoin/shadouble.h>
@@ -288,3 +289,9 @@ struct amount_sat fromwire_amount_sat(const u8 **cursor, size_t *max)
 	return sat;
 }
 
+void fromwire_bip32_key_version(const u8** cursor, size_t *max,
+					struct bip32_key_version *version)
+{
+	version->bip32_pubkey_version = fromwire_u32(cursor, max);
+	version->bip32_privkey_version = fromwire_u32(cursor, max);
+}

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -1,5 +1,6 @@
 #include "wire.h"
 #include <assert.h>
+#include <bitcoin/chainparams.h>
 #include <bitcoin/preimage.h>
 #include <bitcoin/shadouble.h>
 #include <bitcoin/tx.h>
@@ -192,4 +193,10 @@ void towire_amount_msat(u8 **pptr, const struct amount_msat msat)
 void towire_amount_sat(u8 **pptr, const struct amount_sat sat)
 {
 	towire_u64(pptr, sat.satoshis); /* Raw: primitive */
+}
+
+void towire_bip32_key_version(u8 **pptr, const struct bip32_key_version *version)
+{
+	towire_u32(pptr, version->bip32_pubkey_version);
+	towire_u32(pptr, version->bip32_privkey_version);
 }

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_WIRE_WIRE_H
 #include "config.h"
 #include <bitcoin/block.h>
+#include <bitcoin/chainparams.h>
 #include <bitcoin/privkey.h>
 #include <bitcoin/pubkey.h>
 #include <bitcoin/shadouble.h>
@@ -73,6 +74,8 @@ void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
 void towire_wirestring(u8 **pptr, const char *str);
 void towire_siphash_seed(u8 **cursor, const struct siphash_seed *seed);
 
+void towire_bip32_key_version(u8 **cursor, const struct bip32_key_version *version);
+
 const u8 *fromwire(const u8 **cursor, size_t *max, void *copy, size_t n);
 u8 fromwire_u8(const u8 **cursor, size_t *max);
 u16 fromwire_u16(const u8 **cursor, size_t *max);
@@ -115,4 +118,6 @@ struct bitcoin_tx *fromwire_bitcoin_tx(const tal_t *ctx,
 				       const u8 **cursor, size_t *max);
 void fromwire_siphash_seed(const u8 **cursor, size_t *max,
 			   struct siphash_seed *seed);
+void fromwire_bip32_key_version(const u8 **cursor, size_t *max,
+				struct bip32_key_version *version);
 #endif /* LIGHTNING_WIRE_WIRE_H */


### PR DESCRIPTION
Thanks for @rustyrussell 's [advice](https://github.com/ElementsProject/lightning/pull/2436#issuecomment-469083795), now I set the version BIP32_VER_TEST_PRIVATE for testnet/regtest to generate BIP32 privkey with libwally-core, and set BIP32_VER_MAIN_PRIVATE for mainnet.
For litecoin, we also set the version like bitcoin else.

There are 3 changes:
1. Add the mainnet flag(bool) paramater in `hsm_init` wire in hsmd/hsm_wire.csv;
2. Add the mainnet flag(bool) paramater in `populate_secretstuff()` and `load_hsm()` function in hsmd/hsmd.c;
3. Set BIP32_VER_MAIN_PRIVATE for mainnet or BIP32_VER_TEST_PRIVATE for testnet/regtest in `bip32_key_from_seed()` corresponding to mainnet flag(bool) paramater in  `populate_secretstuff()` .
