### PR TITLE
Fix: Store remote channel announcement information into wallet DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `newaddr` outputs `bech32` or `p2sh-segwit`, or both with new `all` parameter (#2390)
 - JSON API: `listpeers` status now shows how many confirmations until channel is open (#2405)
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
+- Lightningd: Store channel_announcement information of remote peer into DB (#2409)
 
 ### Changed
 

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -9,6 +9,8 @@ channel_init,,funding_txid,struct bitcoin_txid
 channel_init,,funding_txout,u16
 channel_init,,funding_satoshi,struct amount_sat
 channel_init,,minimum_depth,u32
+channel_init,,remote_announcement_node_sigs,?secp256k1_ecdsa_signature
+channel_init,,remote_announcement_bitcoin_sigs,?secp256k1_ecdsa_signature
 channel_init,,our_config,struct channel_config
 channel_init,,their_config,struct channel_config
 # FIXME: Fix generate-wire.py to allow NUM_SIDES*u32 here.
@@ -92,9 +94,13 @@ channel_fulfill_htlc,,fulfilled_htlc,struct fulfilled_htlc
 channel_fail_htlc,1006
 channel_fail_htlc,,failed_htlc,struct failed_htlc
 
-# When we receive funding_locked.
-channel_got_funding_locked,1019
-channel_got_funding_locked,,next_per_commit_point,struct pubkey
+# We will send it when we receive funding_locked and announcement message
+channel_got_locked_and_announced,1019
+# we set ture iff when we receive remote channel announcement
+channel_got_locked_and_announced,,got_remote_announcement,bool
+channel_got_locked_and_announced,,next_per_commit_point,?struct pubkey
+channel_got_locked_and_announced,,remote_announcement_node_sigs,?secp256k1_ecdsa_signature
+channel_got_locked_and_announced,,remote_announcement_bitcoin_sigs,?secp256k1_ecdsa_signature
 
 # When we send a commitment_signed message, tell master.
 channel_sending_commitsig,1020

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -157,6 +157,9 @@ struct peer {
 
 	/* Additional confirmations need for local lockin. */
 	u32 depth_togo;
+
+	/* It means if we are in reconnection process*/
+	bool reconnected;
 };
 
 static u8 *create_channel_announcement(const tal_t *ctx, struct peer *peer);
@@ -444,8 +447,6 @@ static void announce_channel(struct peer *peer)
 {
 	u8 *cannounce;
 
-	check_short_ids_match(peer);
-
 	cannounce = create_channel_announcement(tmpctx, peer);
 
 	wire_sync_write(GOSSIP_FD, cannounce);
@@ -494,7 +495,27 @@ static void channel_announcement_negotiate(struct peer *peer)
 	/* If we've completed the signature exchange, we can send a real
 	 * announcement, otherwise we send a temporary one */
 	if (peer->have_sigs[LOCAL] && peer->have_sigs[REMOTE])
+	{
+		check_short_ids_match(peer);
+
+		/* After making sure short_channel_ids match, we can send remote
+		 * announcement to MASTER.
+		 * But we won't do this when restart, because we load announcement
+		 * signatures form DB when we reenable Channeld! */
+		if(peer->reconnected == false){
+			/* Ask Master to save remote announcement into DB.
+			 * We will never waste time on waiting for remote peer announcement
+			 * reply when restart.
+			 */
+			wire_sync_write(MASTER_FD,
+					take(towire_channel_got_locked_and_announced(NULL,
+								true,
+								NULL,
+								&peer->announcement_node_sigs[REMOTE],
+								&peer->announcement_bitcoin_sigs[REMOTE])));
+		}
 		announce_channel(peer);
+	}
 }
 
 static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
@@ -532,8 +553,11 @@ static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
 
 	peer->funding_locked[REMOTE] = true;
 	wire_sync_write(MASTER_FD,
-			take(towire_channel_got_funding_locked(NULL,
-						&peer->remote_per_commit)));
+			take(towire_channel_got_locked_and_announced(NULL,
+						false,
+						&peer->remote_per_commit,
+						NULL,
+						NULL)));
 
 	channel_announcement_negotiate(peer);
 	billboard_update(peer);
@@ -542,12 +566,18 @@ static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
 static void handle_peer_announcement_signatures(struct peer *peer, const u8 *msg)
 {
 	struct channel_id chanid;
+	secp256k1_ecdsa_signature *remote_node_sigs;
+	secp256k1_ecdsa_signature *remote_bitcoin_sigs;
+	struct short_channel_id *remote_scid = tal(tmpctx, struct short_channel_id);
+
+	remote_node_sigs = talz(tmpctx, secp256k1_ecdsa_signature);
+	remote_bitcoin_sigs = talz(tmpctx, secp256k1_ecdsa_signature);
 
 	if (!fromwire_announcement_signatures(msg,
 					      &chanid,
-					      &peer->short_channel_ids[REMOTE],
-					      &peer->announcement_node_sigs[REMOTE],
-					      &peer->announcement_bitcoin_sigs[REMOTE]))
+					      remote_scid,
+					      remote_node_sigs,
+					      remote_bitcoin_sigs))
 		peer_failed(&peer->cs,
 			    &peer->channel_id,
 			    "Bad announcement_signatures %s",
@@ -563,8 +593,54 @@ static void handle_peer_announcement_signatures(struct peer *peer, const u8 *msg
 			    type_to_string(tmpctx, struct channel_id, &chanid));
 	}
 
-	peer->have_sigs[REMOTE] = true;
-	billboard_update(peer);
+	/* If we received remote announcement before, now we need to make
+	 * sure the new announcement is same as the old and then ignore it.
+	 */
+	if(peer->have_sigs[REMOTE] == true) {
+
+		/* make sure new short_channel_id must equal the old one */
+		if (!short_channel_id_eq(remote_scid,
+				 &peer->short_channel_ids[REMOTE]))
+			peer_failed(&peer->cs,
+				&peer->channel_id,
+			    	"Wrong announcement: "
+				"first received short_channel_ids: %s"
+			    	" , now second get %s",
+			    	type_to_string(peer, struct short_channel_id,
+						   &peer->short_channel_ids[REMOTE]),
+			    	type_to_string(peer, struct short_channel_id,
+						   remote_scid));
+
+		/* make sure new node signature and bitcoin signature equal
+		 * the old signatures
+		 */
+		if(memcmp(&peer->announcement_node_sigs[REMOTE], remote_node_sigs,
+					  sizeof(peer->announcement_node_sigs[REMOTE])) ||
+					  memcmp(&peer->announcement_bitcoin_sigs[REMOTE],
+					  remote_bitcoin_sigs,
+					  sizeof(peer->announcement_bitcoin_sigs[REMOTE])))
+			peer_failed(&peer->cs,
+			    	&peer->channel_id,
+			    	"Wrong announcement: first received node_sigs %s, "
+				"now second get %s , first received bitcoin_sigs %s,"
+				"now second get %s",
+			    	type_to_string(tmpctx, secp256k1_ecdsa_signature,
+						   &peer->announcement_node_sigs[REMOTE]),
+			    	type_to_string(tmpctx, secp256k1_ecdsa_signature,
+						   remote_node_sigs),
+			    	type_to_string(tmpctx, secp256k1_ecdsa_signature,
+						   &peer->announcement_bitcoin_sigs[REMOTE]),
+			    	type_to_string(tmpctx, secp256k1_ecdsa_signature,
+						   remote_bitcoin_sigs));
+	} else {
+		peer->have_sigs[REMOTE] = true;
+
+		peer->short_channel_ids[REMOTE] = *remote_scid;
+		peer->announcement_node_sigs[REMOTE] = *remote_node_sigs;
+		peer->announcement_bitcoin_sigs[REMOTE] = *remote_bitcoin_sigs;
+
+		billboard_update(peer);
+	}
 
 	channel_announcement_negotiate(peer);
 }
@@ -2723,7 +2799,7 @@ static void req_in(struct peer *peer, const u8 *msg)
 	case WIRE_CHANNEL_SENDING_COMMITSIG_REPLY:
 	case WIRE_CHANNEL_GOT_COMMITSIG_REPLY:
 	case WIRE_CHANNEL_GOT_REVOKE_REPLY:
-	case WIRE_CHANNEL_GOT_FUNDING_LOCKED:
+	case WIRE_CHANNEL_GOT_LOCKED_AND_ANNOUNCED:
 	case WIRE_CHANNEL_GOT_SHUTDOWN:
 	case WIRE_CHANNEL_SHUTDOWN_COMPLETE:
 	case WIRE_CHANNEL_DEV_REENABLE_COMMIT_REPLY:
@@ -2769,12 +2845,13 @@ static void init_channel(struct peer *peer)
 	struct failed_htlc **failed;
 	enum side *failed_sides;
 	struct added_htlc *htlcs;
-	bool reconnected;
 	u8 *funding_signed;
 	const u8 *msg;
 	u32 feerate_per_kw[NUM_SIDES];
 	u32 minimum_depth;
 	struct secret last_remote_per_commit_secret;
+	secp256k1_ecdsa_signature *remote_node_sigs;
+	secp256k1_ecdsa_signature *remote_bitcoin_sigs;
 
 	assert(!(fcntl(MASTER_FD, F_GETFL) & O_NONBLOCK));
 
@@ -2786,6 +2863,8 @@ static void init_channel(struct peer *peer)
 				   &funding_txid, &funding_txout,
 				   &funding,
 				   &minimum_depth,
+				   &remote_node_sigs,
+				   &remote_bitcoin_sigs,
 				   &conf[LOCAL], &conf[REMOTE],
 				   feerate_per_kw,
 				   &peer->feerate_min, &peer->feerate_max,
@@ -2820,7 +2899,7 @@ static void init_channel(struct peer *peer)
 				   &peer->funding_locked[LOCAL],
 				   &peer->funding_locked[REMOTE],
 				   &peer->short_channel_ids[LOCAL],
-				   &reconnected,
+				   &peer->reconnected,
 				   &peer->send_shutdown,
 				   &peer->shutdown_sent[REMOTE],
 				   &peer->final_scriptpubkey,
@@ -2846,6 +2925,20 @@ static void init_channel(struct peer *peer)
 		     peer->revocations_received,
 		     feerate_per_kw[LOCAL], feerate_per_kw[REMOTE],
 		     peer->feerate_min, peer->feerate_max);
+
+	if(remote_node_sigs && remote_bitcoin_sigs) {
+		peer->announcement_node_sigs[REMOTE] = *remote_node_sigs;
+		peer->announcement_bitcoin_sigs[REMOTE] = *remote_bitcoin_sigs;
+		peer->have_sigs[REMOTE] = true;
+
+		tal_steal(tmpctx, remote_node_sigs);
+		tal_steal(tmpctx, remote_bitcoin_sigs);
+		/* Before we store announcement into DB, we have made sure
+		 * remote short_channel_id matched the local. Now we initial
+		 * it directly!
+		 */
+		peer->short_channel_ids[REMOTE] = peer->short_channel_ids[LOCAL];
+	}
 
 	/* First commit is used for opening: if we've sent 0, we're on
 	 * index 1. */
@@ -2903,7 +2996,7 @@ static void init_channel(struct peer *peer)
 	peer->depth_togo = minimum_depth;
 
 	/* OK, now we can process peer messages. */
-	if (reconnected)
+	if (peer->reconnected)
 		peer_reconnect(peer, &last_remote_per_commit_secret);
 
 	/* If we have a funding_signed message, send that immediately */
@@ -2914,6 +3007,8 @@ static void init_channel(struct peer *peer)
 	channel_announcement_negotiate(peer);
 
 	billboard_update(peer);
+
+	peer->reconnected = false;
 }
 
 static void send_shutdown_complete(struct peer *peer)
@@ -2949,6 +3044,7 @@ int main(int argc, char *argv[])
 	peer->last_update_timestamp = 0;
 	/* We actually received it in the previous daemon, but near enough */
 	peer->last_recv = time_now();
+	peer->reconnected = false;
 
 	/* We send these to HSM to get real signatures; don't have valgrind
 	 * complain. */

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -146,6 +146,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    const struct bitcoin_txid *funding_txid,
 			    u16 funding_outnum,
 			    struct amount_sat funding,
+			    struct announcement *remote_announcement,
 			    struct amount_msat push,
 			    bool remote_funding_locked,
 			    /* NULL or stolen */
@@ -215,6 +216,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->funding_txid = *funding_txid;
 	channel->funding_outnum = funding_outnum;
 	channel->funding = funding;
+	channel->remote_announcement = tal_steal(channel, remote_announcement);
 	channel->push = push;
 	channel->remote_funding_locked = remote_funding_locked;
 	channel->scid = tal_steal(channel, scid);

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -14,6 +14,11 @@ struct billboard {
 	const char *transient;
 };
 
+struct announcement {
+	secp256k1_ecdsa_signature announcement_node_sigs;
+	secp256k1_ecdsa_signature announcement_bitcoin_sigs;
+};
+
 struct channel {
 	/* Inside peer->channels. */
 	struct list_node list;
@@ -64,6 +69,9 @@ struct channel {
 	bool remote_funding_locked;
 	/* Channel if locked locally. */
 	struct short_channel_id *scid;
+
+	/* remote peer announcement information */
+	struct announcement *remote_announcement;
 
 	/* Amount going to us, not counting unfinished HTLCs; if we have one. */
 	struct amount_msat our_msat;
@@ -132,6 +140,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    const struct bitcoin_txid *funding_txid,
 			    u16 funding_outnum,
 			    struct amount_sat funding,
+			    struct announcement *remote_announcement,
 			    struct amount_msat push,
 			    bool remote_funding_locked,
 			    /* NULL or stolen */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -198,6 +198,7 @@ wallet_commit_channel(struct lightningd *ld,
 			      funding_txid,
 			      funding_outnum,
 			      funding,
+			      NULL, /* no remote announcement sigs yet */
 			      push,
 			      false, /* !remote_funding_locked */
 			      NULL, /* no scid yet */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -375,6 +375,12 @@ static struct migration dbmigrations[] = {
 	{ "ALTER TABLE channels ADD feerate_base INTEGER;", NULL },
 	{ "ALTER TABLE channels ADD feerate_ppm INTEGER;", NULL },
 	{ NULL, migrate_pr2342_feerate_per_channel },
+	/* store remote announcement into DB*/
+	{ "CREATE TABLE announcement ("
+	  "  channelid INTEGER REFERENCES channels(id) ON DELETE CASCADE"
+	  ", remote_announcement_node_signature BLOB"
+	  ", remote_announcement_bitcoin_signature BLOB"
+	  ");", NULL },
 };
 
 /* Leak tracking. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -24,6 +24,7 @@ struct invoices;
 struct channel;
 struct lightningd;
 struct node_id;
+struct announcement;
 struct oneshot;
 struct peer;
 struct timers;
@@ -545,6 +546,20 @@ bool wallet_htlcs_load_for_channel(struct wallet *wallet,
 				   struct htlc_in_map *htlcs_in,
 				   struct htlc_out_map *htlcs_out);
 
+/**
+ * wallet_announcement_save - Save remote announcement information with channel.
+ *
+ * @wallet: wallet to load from
+ * @channel: remote peer announcement information associated with this channel
+ * @announcement: announcement struct including rannouncement_node_sigs and
+ *	announcement_bitcoin_sigs
+ *
+ * This function is only used to save REMOTE announcement information into DB
+ * when the channel has set the announce_channel bit and don't send the shutdown
+ * message(BOLT#7).
+ */
+void wallet_announcement_save(struct wallet *wallet, struct channel *channel,
+			   struct announcement *announcement);
 
 /* /!\ This is a DB ENUM, please do not change the numbering of any
  * already defined elements (adding is ok) /!\ */


### PR DESCRIPTION
This PR draft tries to fix issue #2409.

We don't store the announcement signatures before, so when restart we may waste much time on waiting for remote announcement reply. So this PR tries to store the remote announcement signatures into DB like what @SimonVrouwe [proposed](https://github.com/ElementsProject/lightning/issues/1778#issuecomment-467807053) (we don't store local announcement signatures because we can drive sigs locally).

Instead of adding a new wire type between Channeld and MASTER, I change the `wire_channel_got_funding_locked` and ask it not only tell MASTER remote funding locked, but also send remote announcement sigs to MASTER and store sigs.

There are 4 changes:

**1. Rename `wire_channel_got_funding_locked` to `wire_channel_got_locked_and_announced`, and add announcement data into the message of this type.** 

Now the message will be like this:
`WIRE_CHANNEL_GOT_LOCKED_AND_ANNOUNCEMENT` + `got_remote_announcement(bool)`  + `next_per_commit_point(pubkey)` + `remote_announcement_node_sigs(signature)` + `remote_announcement_bitcoin_sigs(signature)`
The bool type above means if the message is to tell MASTER announcement or not(instead, to tell MASTER remote funding locked).

There 2 situations that this message will be sent:
-  When Channeld receive remote peer funding_locked message, it will tell MASTER funding got locked remote. We will set the message like this:
   msg: `WIRE_CHANNEL_GOT_LOCKED_AND_ANNOUNCEMENT` + `false` + `next_per_commit_point(pubkey)` + `NULL` + `NULL`
  In this case, the msg equals the original `wire_channel_got_funding_locked`.
- When Channeld receive remote peer announcement message, it will tell MASTER the announcement signatures. We will the set message like this:
   msg: `WIRE_CHANNEL_GOT_LOCKED_AND_ANNOUNCEMENT` + `true`  + `NULL` + `remote_announcement_node_sigs` + `remote_announcement_bitcoin_sigs`
Channeld will check if we received the same announcement before and ignore the same announcement.
Channeld only send `wire_channel_got_locked_and_announced` for announcement when it receives announcement for the first time.

**2. Add announcement struct in channel struct (in lightningd/channeld.h).**
```
struct announcement {
	secp256k1_ecdsa_signature announcement_node_sigs;
	secp256k1_ecdsa_signature announcement_bitcoin_sigs;
};
```
  When MASTER receive announcement signatures, we will put signatures in this struct and store it into DB.

**3. Add announcement table in DB, and add wallet_announcement_save() and
   wallet_announcement_load() function.**
- `announcement table`:
The announcement table store data with the type like: `(channelid, remote_node_sigs, remote_bitcoin_sigs)`.
When we create a new channel and insert channel into DB, the announcement data will be set. If channel doesn't set ANNOUNCEMENT flag or hasn't received remote announcement message, we will set `(channelid, NULL, NULL)` for this channel.
- `wallet_announcement_save()`:
This function will only be called when MASTER receive `wire_channel_got_locked_and_announced` with flag setting true and resolve announcement signatures into announcement struct.
- `wallet_announcement_load()`:
This function will only be called when we initial a channel from DB (this will happen when restart).

**4. Add announcement save and load test in `wallet/test/run_wallet.c`.**

Compared to adding a new announcement wire type between Channeld and Lightningd, this way isn't so direct.
Anyway, it's just a try. What do you think about?