### PR TITLE
Use tini as docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ RUN apk add --no-cache \
      inotify-tools \
      socat \
      bash \
-     zlib-dev
+     zlib-dev \
+     tini
 
 ENV GLIBC_VERSION 2.27-r0
 ENV GLIBC_SHA256 938bceae3b83c53e7fa9cc4135ce45e04aae99256c5e74cf186c794b97473bc7
@@ -99,4 +100,4 @@ COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh
 
 EXPOSE 9735 9835
-ENTRYPOINT  [ "./entrypoint.sh" ]
+ENTRYPOINT  [ "/sbin/tini", "-g", "--", "./entrypoint.sh" ]


### PR DESCRIPTION
All Tini does is spawn a single child (Tini is meant to be run in a container), and wait for it to exit all the while reaping zombies and performing signal forwarding. (See [github](https://github.com/krallin/tini))

This is especially useful as by default Bash running in PID 1 does not forward SIGTERM to child processes.
Luckliy, we use `exec` which mean the signal is directly reaching `lightningd`. However, if the PID is 1, the program need to explicitly handle SIGTERM. (which we did recently, and it works great)

However, lightning might not properly reap zombie processes.
Also, if `EXPOSE_TCP` is used, we are spawning `socat` and running lightningd at the same time without using `exec`, meaning that lightningd will not receive SIGTERM.
