### PR TITLE
Compatible posix sh

### DIFF
--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -30,7 +30,7 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$NAME
     VER=$VERSION_ID
-elif type lsb_release >/dev/null 2>&1; then
+elif command -v lsb_release >/dev/null 2>&1; then
     # linuxbase.org
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)


### PR DESCRIPTION
make check-source error in my ubuntu 18.04

```
In tools/repro-build.sh line 33:
elif type lsb_release >/dev/null 2>&1; then
     ^-- SC2039: In POSIX sh, 'type' is undefined.
```

change `type` to `which` follow  https://wiki.ubuntu.com/DashAsBinSh#type suggestion.