### PR TITLE
Gossip store benchmaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ changes.
 ### Fixed
 
 - `--bind-addr=<path>` fixed for nodes using local sockets (eg. testing).
+- Unannounced local channels were forgotten for routing on restart until reconnection occurred.
 
 ### Security
 

--- a/common/daemon.h
+++ b/common/daemon.h
@@ -11,6 +11,9 @@ void daemon_setup(const char *argv0,
 /* Exposed for lightningd's use. */
 int daemon_poll(struct pollfd *fds, nfds_t nfds, int timeout);
 
+/* Print a backtrace to stderr, and via backtrace_print */
+void send_backtrace(const char *why);
+
 /* Shutdown for a valgrind-clean exit (frees everything) */
 void daemon_shutdown(void);
 

--- a/common/status.c
+++ b/common/status.c
@@ -5,6 +5,7 @@
 #include <ccan/fdpass/fdpass.h>
 #include <ccan/read_write_all/read_write_all.h>
 #include <ccan/tal/str/str.h>
+#include <common/daemon.h>
 #include <common/daemon_conn.h>
 #include <common/gen_status_wire.h>
 #include <common/status.h>
@@ -166,6 +167,10 @@ void status_failed(enum status_failreason reason, const char *fmt, ...)
 	va_start(ap, fmt);
 	str = tal_vfmt(NULL, fmt, ap);
 	va_end(ap);
+
+	/* Give a nice backtrace when this happens! */
+	if (reason == STATUS_FAIL_INTERNAL_ERROR)
+		send_backtrace(str);
 
 	status_send_fatal(take(towire_status_fail(NULL, reason, str)),
 			  -1, -1);

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,6 +1,6 @@
 DEVTOOLS_SRC := devtools/gen_print_wire.c devtools/gen_print_onion_wire.c devtools/print_wire.c
 DEVTOOLS_OBJS := $(DEVTOOLS_SRC:.c=.o)
-DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith
+DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore
 DEVTOOLS_TOOL_SRC := $(DEVTOOLS:=.c)
 DEVTOOLS_TOOL_OBJS := $(DEVTOOLS_TOOL_SRC:.c=.o)
 
@@ -16,7 +16,8 @@ DEVTOOLS_COMMON_OBJS :=				\
 	common/utils.o				\
 	common/version.o			\
 	common/wireaddr.o			\
-	wire/gen_onion_wire.o
+	wire/gen_onion_wire.o			\
+	wire/gen_peer_wire.o
 
 devtools-all: $(DEVTOOLS)
 
@@ -39,6 +40,10 @@ devtools/decodemsg: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN
 devtools/dump-gossipstore: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/dump-gossipstore.o gossipd/gen_gossip_store.o
 
 devtools/dump-gossipstore.o: gossipd/gen_gossip_store.h
+
+devtools/create-gossipstore: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/create-gossipstore.o gossipd/gen_gossip_store.o
+devtools/create-gossipstore.o: gossipd/gen_gossip_store.h
+
 devtools/onion.c: ccan/config.h
 
 devtools/onion: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/onion.o common/sphinx.o

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -42,7 +42,7 @@ devtools/dump-gossipstore: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS)
 devtools/dump-gossipstore.o: gossipd/gen_gossip_store.h
 
 devtools/create-gossipstore: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/create-gossipstore.o gossipd/gen_gossip_store.o
-devtools/create-gossipstore.o: gossipd/gen_gossip_store.h
+devtools/create-gossipstore.o: gossipd/gen_gossip_store.h devtools/create-gossipstore.h
 
 devtools/onion.c: ccan/config.h
 

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -1,0 +1,103 @@
+#include <ccan/crc/crc.h>
+#include <ccan/err/err.h>
+#include <ccan/opt/opt.h>
+#include <ccan/read_write_all/read_write_all.h>
+#include <common/type_to_string.h>
+#include <common/utils.h>
+#include <fcntl.h>
+#include <gossipd/gen_gossip_store.h>
+#include <gossipd/gossip_store.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <wire/gen_peer_wire.h>
+
+int main(int argc, char *argv[])
+{
+	u8 version;
+	beint16_t be_inlen;
+	struct amount_sat sat;
+	bool verbose = false;
+	char *infile = NULL, *outfile = NULL;
+	int infd, outfd;
+
+	setup_locale();
+
+	opt_register_noarg("--verbose|-v", opt_set_bool, &verbose,
+			   "Print progress to stderr");
+	opt_register_arg("--output|-o", opt_set_charp, NULL, &outfile,
+			 "Send output to this file instead of stdout");
+	opt_register_arg("--input|-i", opt_set_charp, NULL, &infile,
+			 "Read input from this file instead of stdin");
+	opt_register_noarg("--help|-h", opt_usage_and_exit,
+			   "default-satoshis\n"
+			   "Create gossip store, from be16 / input messages",
+			   "Print this message.");
+
+	opt_parse(&argc, argv, opt_log_stderr_exit);
+	if (argc != 2)
+		errx(1, "Need default-satoshi argument for channel amounts");
+	if (!parse_amount_sat(&sat, argv[1], strlen(argv[1])))
+		errx(1, "Invalid satoshi amount %s", argv[1]);
+
+	if (infile) {
+		infd = open(infile, O_RDONLY);
+		if (infd < 0)
+			err(1, "opening %s", infile);
+	} else
+		infd = STDIN_FILENO;
+
+	if (outfile) {
+		outfd = open(outfile, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+		if (outfd < 0)
+			err(1, "opening %s", outfile);
+	} else
+		outfd = STDOUT_FILENO;
+
+	version = GOSSIP_STORE_VERSION;
+	if (!write_all(outfd, &version, sizeof(version)))
+		err(1, "Writing version");
+
+	while (read_all(infd, &be_inlen, sizeof(be_inlen))) {
+		u32 msglen = be16_to_cpu(be_inlen);
+		u8 *inmsg = tal_arr(NULL, u8, msglen), *outmsg;
+		beint32_t be_outlen;
+		beint32_t becsum;
+
+		if (!read_all(infd, inmsg, msglen))
+			err(1, "Only read partial message");
+
+		switch (fromwire_peektype(inmsg)) {
+		case WIRE_CHANNEL_ANNOUNCEMENT:
+			outmsg = towire_gossip_store_channel_announcement(inmsg, inmsg, sat);
+			break;
+		case WIRE_CHANNEL_UPDATE:
+			outmsg = towire_gossip_store_channel_update(inmsg, inmsg);
+			break;
+		case WIRE_NODE_ANNOUNCEMENT:
+			outmsg = towire_gossip_store_node_announcement(inmsg, inmsg);
+			break;
+		default:
+			warnx("Unknown message %u (%s)", fromwire_peektype(inmsg),
+			      wire_type_name(fromwire_peektype(inmsg)));
+			tal_free(inmsg);
+			continue;
+		}
+		if (verbose)
+			fprintf(stderr, "%s->%s\n",
+				wire_type_name(fromwire_peektype(inmsg)),
+				gossip_store_type_name(fromwire_peektype(outmsg)));
+
+		becsum = cpu_to_be32(crc32c(0, outmsg, tal_count(outmsg)));
+		be_outlen = cpu_to_be32(tal_count(outmsg));
+		if (!write_all(outfd, &be_outlen, sizeof(be_outlen))
+		    || !write_all(outfd, &becsum, sizeof(becsum))
+		    || !write_all(outfd, outmsg, tal_count(outmsg))) {
+			exit(1);
+		}
+		tal_free(inmsg);
+	}
+	return 0;
+}

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -42,6 +42,7 @@ int main(int argc, char *argv[])
 	int infd, outfd;
        	FILE * scidfd;
 	struct scidsat * scids;
+	unsigned max = -1U;
 
 	setup_locale();
 
@@ -55,6 +56,8 @@ int main(int argc, char *argv[])
 			 "Input for 'scid, satshis' csv");
 	opt_register_arg("--sat", opt_set_charp, NULL, &csat,
 			 "default satoshi value if --scidfile flag not present");
+	opt_register_arg("--max", opt_set_uintval, opt_show_uintval, &max,
+			 "maximum number of messages to read");
 	opt_register_noarg("--help|-h", opt_usage_and_exit,
 			   "Create gossip store, from be16 / input messages",
 			   "Print this message.");
@@ -144,6 +147,8 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 		tal_free(inmsg);
+		if (--max == 0)
+			break;
 	}
 	fprintf(stderr, "channels %d, updates %d, nodes %d\n", channels, updates, nodes);
 	if (scidfile)

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -9,8 +9,6 @@
 #include <gossipd/gen_gossip_store.h>
 #include <gossipd/gossip_store.h>
 #include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -26,7 +24,7 @@ struct scidsat * load_scid_file(FILE * scidfd)
         fscanf(scidfd, "%s\n", title);	
 	struct scidsat * scids = calloc(n, sizeof(scidsat));
 	int i = 0;
-        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) {
+        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
 			i++;
 	}
 	return scids;
@@ -41,7 +39,7 @@ int main(int argc, char *argv[])
 	char *infile = NULL, *outfile = NULL, *scidfile = NULL, *csat = NULL;
 	int infd, outfd;
        	FILE * scidfd;
-	struct scidsat * scids;
+	struct scidsat * scids = NULL;
 	unsigned max = -1U;
 
 	setup_locale();
@@ -113,7 +111,7 @@ int main(int argc, char *argv[])
 
 		switch (fromwire_peektype(inmsg)) {
 		case WIRE_CHANNEL_ANNOUNCEMENT:
-			if (scidfile) {
+			if (scids) {
 				sat = scids[scidi].sat;
 				scidi += 1;
 			}
@@ -151,7 +149,6 @@ int main(int argc, char *argv[])
 			break;
 	}
 	fprintf(stderr, "channels %d, updates %d, nodes %d\n", channels, updates, nodes);
-	if (scidfile)
-                free(scids);
+	free(scids);
 	return 0;
 }

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 		}
 		tal_free(inmsg);
 	}
-        printf("channels %d, updates %d, nodes %d\n", channels, updates, nodes);
+	fprintf(stderr, "channels %d, updates %d, nodes %d\n", channels, updates, nodes);
 	if (scidfile)
                 free(scids);
 	return 0;

--- a/devtools/create-gossipstore.h
+++ b/devtools/create-gossipstore.h
@@ -1,3 +1,5 @@
+#ifndef LIGHTNING_DEVTOOLS_CREATE_GOSSIPSTORE_H
+#define LIGHTNING_DEVTOOLS_CREATE_GOSSIPSTORE_H
 #include <stdlib.h>
 #include <stdio.h>
 #include <common/amount.h>
@@ -8,4 +10,4 @@ struct scidsat {
 } scidsat;
 
 struct scidsat * load_scid_file(FILE * scidfd);
-
+#endif /* LIGHTNING_DEVTOOLS_CREATE_GOSSIPSTORE_H */

--- a/devtools/create-gossipstore.h
+++ b/devtools/create-gossipstore.h
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <common/amount.h>
+
+struct scidsat {
+	char scid[17];
+        struct amount_sat sat;
+} scidsat;
+
+struct scidsat * load_scid_file(FILE * scidfd);
+

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -156,8 +156,7 @@ static bool gossip_store_append(int fd, struct routing_state *rstate, const u8 *
  * Creates a new file, writes all the updates from the `broadcast_state`, and
  * then atomically swaps the files.
  */
-
-static void gossip_store_compact(struct gossip_store *gs)
+bool gossip_store_compact(struct gossip_store *gs)
 {
 	size_t count = 0;
 	u64 index = 0;
@@ -206,7 +205,7 @@ static void gossip_store_compact(struct gossip_store *gs)
 	gs->count = count;
 	close(gs->fd);
 	gs->fd = fd;
-	return;
+	return true;
 
 unlink_disable:
 	unlink(GOSSIP_STORE_TEMP_FILENAME);
@@ -214,6 +213,7 @@ disable:
 	status_trace("Encountered an error while compacting, disabling "
 		     "future compactions.");
 	gs->disable_compaction = true;
+	return false;
 }
 
 void gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg)

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -303,6 +303,7 @@ void gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 	size_t stats[] = {0, 0, 0, 0};
 	int fd = gs->fd;
 	gs->fd = -1;
+	struct timeabs start = time_now();
 
 	if (lseek(fd, known_good, SEEK_SET) < 0) {
 		status_unusual("gossip_store: lseek failure");
@@ -381,6 +382,15 @@ truncate_nomsg:
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Truncating store: %s", strerror(errno));
 out:
+#if DEVELOPER
+	status_info("total store load time: %"PRIu64" msec (%zu entries, %zu bytes)",
+		    time_to_msec(time_between(time_now(), start)),
+		    stats[0] + stats[1] + stats[2] + stats[3],
+		    (size_t)known_good);
+#else
+	status_trace("total store load time: %"PRIu64" msec",
+		     time_to_msec(time_between(time_now(), start)));
+#endif
 	status_trace("gossip_store: Read %zu/%zu/%zu/%zu cannounce/cupdate/nannounce/cdelete from store in %"PRIu64" bytes",
 		     stats[0], stats[1], stats[2], stats[3],
 		     (u64)known_good);

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -39,4 +39,6 @@ void gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg);
 void gossip_store_add_channel_delete(struct gossip_store *gs,
 				     const struct short_channel_id *scid);
 
+/* Expose for dev-compact-gossip-store */
+bool gossip_store_compact(struct gossip_store *gs);
 #endif /* LIGHTNING_GOSSIPD_GOSSIP_STORE_H */

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -14,6 +14,7 @@ gossipctl_init,,alias,32*u8
 gossipctl_init,,update_channel_interval,u32
 gossipctl_init,,num_announcable,u16
 gossipctl_init,,announcable,num_announcable*struct wireaddr
+gossipctl_init,,dev_gossip_time,?u32
 
 # Pass JSON-RPC getnodes call through
 gossip_getnodes_request,3005

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -15,6 +15,7 @@ gossipctl_init,,update_channel_interval,u32
 gossipctl_init,,num_announcable,u16
 gossipctl_init,,announcable,num_announcable*struct wireaddr
 gossipctl_init,,dev_gossip_time,?u32
+gossipctl_init,,dev_unknown_channel_satoshis,?struct amount_sat
 
 # Pass JSON-RPC getnodes call through
 gossip_getnodes_request,3005

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -142,6 +142,13 @@ gossip_dev_memleak,3033
 gossip_dev_memleak_reply,3133
 gossip_dev_memleak_reply,,leak,bool
 
+# master -> gossipd: please rewrite the gossip_store
+gossip_dev_compact_store,3034
+
+# gossipd -> master: ok
+gossip_dev_compact_store_reply,3134
+gossip_dev_compact_store_reply,,success,bool
+
 #include <common/bolt11.h>
 
 # master -> gossipd: get route_info for our incoming channels

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -2490,6 +2490,17 @@ static struct io_plan *dev_gossip_memleak(struct io_conn *conn,
 							      found_leak)));
 	return daemon_conn_read_next(conn, daemon->master);
 }
+
+static struct io_plan *dev_compact_store(struct io_conn *conn,
+					 struct daemon *daemon,
+					 const u8 *msg)
+{
+	bool done = gossip_store_compact(daemon->rstate->store);
+	daemon_conn_send(daemon->master,
+			 take(towire_gossip_dev_compact_store_reply(NULL,
+								    done)));
+	return daemon_conn_read_next(conn, daemon->master);
+}
 #endif /* DEVELOPER */
 
 /*~ lightningd: so, tell me about this channel, so we can forward to it. */
@@ -2749,6 +2760,8 @@ static struct io_plan *recv_req(struct io_conn *conn,
 		return dev_gossip_suppress(conn, daemon, msg);
 	case WIRE_GOSSIP_DEV_MEMLEAK:
 		return dev_gossip_memleak(conn, daemon, msg);
+	case WIRE_GOSSIP_DEV_COMPACT_STORE:
+		return dev_compact_store(conn, daemon, msg);
 #else
 	case WIRE_GOSSIP_QUERY_SCIDS:
 	case WIRE_GOSSIP_SEND_TIMESTAMP_FILTER:
@@ -2756,6 +2769,7 @@ static struct io_plan *recv_req(struct io_conn *conn,
 	case WIRE_GOSSIP_DEV_SET_MAX_SCIDS_ENCODE_SIZE:
 	case WIRE_GOSSIP_DEV_SUPPRESS:
 	case WIRE_GOSSIP_DEV_MEMLEAK:
+	case WIRE_GOSSIP_DEV_COMPACT_STORE:
 		break;
 #endif /* !DEVELOPER */
 
@@ -2770,6 +2784,7 @@ static struct io_plan *recv_req(struct io_conn *conn,
 	case WIRE_GOSSIP_GET_INCOMING_CHANNELS_REPLY:
 	case WIRE_GOSSIP_GET_TXOUT:
 	case WIRE_GOSSIP_DEV_MEMLEAK_REPLY:
+	case WIRE_GOSSIP_DEV_COMPACT_STORE_REPLY:
 		break;
 	}
 

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1859,6 +1859,7 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 				   const u8 *msg)
 {
 	u32 update_channel_interval;
+	u32 *dev_gossip_time;
 
 	if (!fromwire_gossipctl_init(daemon, msg,
 				     /* 60,000 ms
@@ -1871,7 +1872,8 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 				     /* 1 week in seconds
 				      * (unless --dev-channel-update-interval) */
 				     &update_channel_interval,
-				     &daemon->announcable)) {
+				     &daemon->announcable,
+				     &dev_gossip_time)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}
 
@@ -1879,8 +1881,8 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 	daemon->rstate = new_routing_state(daemon,
 					   chainparams_by_chainhash(&daemon->chain_hash),
 					   &daemon->id,
-					   update_channel_interval * 2);
-
+					   update_channel_interval * 2,
+					   dev_gossip_time);
 	/* Load stored gossip messages */
 	gossip_store_load(daemon->rstate, daemon->rstate->store);
 

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1860,6 +1860,7 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 {
 	u32 update_channel_interval;
 	u32 *dev_gossip_time;
+	struct amount_sat *dev_unknown_channel_satoshis;
 
 	if (!fromwire_gossipctl_init(daemon, msg,
 				     /* 60,000 ms
@@ -1873,7 +1874,8 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 				      * (unless --dev-channel-update-interval) */
 				     &update_channel_interval,
 				     &daemon->announcable,
-				     &dev_gossip_time)) {
+				     &dev_gossip_time,
+				     &dev_unknown_channel_satoshis)) {
 		master_badmsg(WIRE_GOSSIPCTL_INIT, msg);
 	}
 
@@ -1882,7 +1884,9 @@ static struct io_plan *gossip_init(struct io_conn *conn,
 					   chainparams_by_chainhash(&daemon->chain_hash),
 					   &daemon->id,
 					   update_channel_interval * 2,
-					   dev_gossip_time);
+					   dev_gossip_time,
+					   dev_unknown_channel_satoshis);
+
 	/* Load stored gossip messages */
 	gossip_store_load(daemon->rstate, daemon->rstate->store);
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -120,11 +120,14 @@ bool node_map_node_eq(const struct node *n, const struct pubkey *key)
 
 static void destroy_node(struct node *node, struct routing_state *rstate)
 {
+	struct chan_map_iter i;
+	struct chan *c;
 	node_map_del(rstate->nodes, node);
 
-	/* These remove themselves from the array. */
-	while (tal_count(node->chans))
-		tal_free(node->chans[0]);
+	/* These remove themselves from the map. */
+	while ((c = chan_map_first(&node->chans, &i)) != NULL)
+		tal_free(c);
+	chan_map_clear(&node->chans);
 }
 
 struct node *get_node(struct routing_state *rstate, const struct pubkey *id)
@@ -141,7 +144,7 @@ static struct node *new_node(struct routing_state *rstate,
 
 	n = tal(rstate, struct node);
 	n->id = *id;
-	n->chans = tal_arr(n, struct chan *, 0);
+	chan_map_init(&n->chans);
 	n->globalfeatures = NULL;
 	n->node_announcement = NULL;
 	n->node_announcement_index = 0;
@@ -156,9 +159,15 @@ static struct node *new_node(struct routing_state *rstate,
 /* We've received a channel_announce for a channel attached to this node */
 static bool node_has_public_channels(struct node *node)
 {
-	for (size_t i = 0; i < tal_count(node->chans); i++)
-		if (is_chan_public(node->chans[i]))
+	struct chan_map_iter i;
+	struct chan *c;
+
+	for (c = chan_map_first(&node->chans, &i);
+	     c;
+	     c = chan_map_next(&node->chans, &i)) {
+		if (is_chan_public(c))
 			return true;
+	}
 	return false;
 }
 
@@ -166,39 +175,33 @@ static bool node_has_public_channels(struct node *node)
  * we only send once we have a channel_update. */
 static bool node_has_broadcastable_channels(struct node *node)
 {
-	for (size_t i = 0; i < tal_count(node->chans); i++) {
-		if (!is_chan_public(node->chans[i]))
+	struct chan_map_iter i;
+	struct chan *c;
+
+	for (c = chan_map_first(&node->chans, &i);
+	     c;
+	     c = chan_map_next(&node->chans, &i)) {
+		if (!is_chan_public(c))
 			continue;
-		if (is_halfchan_defined(&node->chans[i]->half[0])
-		    || is_halfchan_defined(&node->chans[i]->half[1]))
+		if (is_halfchan_defined(&c->half[0])
+		    || is_halfchan_defined(&c->half[1]))
 			return true;
-	}
-	return false;
-}
-
-static bool remove_channel_from_array(struct chan ***chans, const struct chan *c)
-{
-	size_t i, n;
-
-	n = tal_count(*chans);
-	for (i = 0; i < n; i++) {
-		if ((*chans)[i] != c)
-			continue;
-		n--;
-		memmove(*chans + i, *chans + i + 1, sizeof(**chans) * (n - i));
-		tal_resize(chans, n);
-		return true;
 	}
 	return false;
 }
 
 static bool node_announce_predates_channels(const struct node *node)
 {
-	for (size_t i = 0; i < tal_count(node->chans); i++) {
-		if (!is_chan_announced(node->chans[i]))
+	struct chan_map_iter i;
+	struct chan *c;
+
+	for (c = chan_map_first(&node->chans, &i);
+	     c;
+	     c = chan_map_next(&node->chans, &i)) {
+		if (!is_chan_announced(c))
 			continue;
 
-		if (node->chans[i]->channel_announcement_index
+		if (c->channel_announcement_index
 		    < node->node_announcement_index)
 			return false;
 	}
@@ -216,11 +219,11 @@ static u64 persistent_broadcast(struct routing_state *rstate, const u8 *msg, u32
 static void remove_chan_from_node(struct routing_state *rstate,
 				  struct node *node, const struct chan *chan)
 {
-	if (!remove_channel_from_array(&node->chans, chan))
+	if (!chan_map_del(&node->chans, chan))
 		abort();
 
 	/* Last channel?  Simply delete node (and associated announce) */
-	if (tal_count(node->chans) == 0) {
+	if (node->chans.raw.elems == 0) {
 		tal_free(node);
 		return;
 	}
@@ -308,8 +311,8 @@ struct chan *new_chan(struct routing_state *rstate,
 	chan->sat = satoshis;
 	chan->local_disabled = false;
 
-	tal_arr_expand(&n2->chans, chan);
-	tal_arr_expand(&n1->chans, chan);
+	chan_map_add(&n2->chans, chan);
+	chan_map_add(&n1->chans, chan);
 
 	/* Populate with (inactive) connections */
 	init_half_chan(rstate, chan, n1idx);
@@ -520,15 +523,20 @@ find_route(const tal_t *ctx, struct routing_state *rstate,
 		for (n = node_map_first(rstate->nodes, &it);
 		     n;
 		     n = node_map_next(rstate->nodes, &it)) {
-			size_t num_edges = tal_count(n->chans);
-			for (i = 0; i < num_edges; i++) {
-				struct chan *chan = n->chans[i];
+			struct chan_map_iter i;
+			struct chan *chan;
+
+			for (chan = chan_map_first(&n->chans, &i);
+			     chan;
+			     chan = chan_map_next(&n->chans, &i)) {
 				int idx = half_chan_to(n, chan);
 
-				SUPERVERBOSE("Node %s edge %i/%zu",
+				SUPERVERBOSE("Node %s edge %s",
 					     type_to_string(tmpctx, struct pubkey,
 							    &n->id),
-					     i, num_edges);
+					     type_to_string(tmpctx,
+							    struct short_channel_id,
+							    &c->scid));
 
 				if (!hc_is_routable(chan, idx)) {
 					SUPERVERBOSE("...unroutable (local_disabled = %i, is_halfchan_enabled = %i, unroutable_until = %i",
@@ -1669,13 +1677,18 @@ void routing_failure(struct routing_state *rstate,
 				       type_to_string(tmpctx, struct pubkey,
 						      erring_node_pubkey));
 		} else {
+			struct chan_map_iter i;
+			struct chan *c;
+
 			status_trace("Deleting node %s",
 				     type_to_string(tmpctx,
 						    struct pubkey,
 						    &node->id));
-			for (size_t i = 0; i < tal_count(node->chans); ++i) {
+			for (c = chan_map_first(&node->chans, &i);
+			     c;
+			     c = chan_map_next(&node->chans, &i)) {
 				/* Set it up to be pruned. */
-				tal_steal(tmpctx, node->chans[i]);
+				tal_steal(tmpctx, c);
 			}
 		}
 	} else {
@@ -1745,9 +1758,18 @@ void route_prune(struct routing_state *rstate)
 void memleak_remove_routing_tables(struct htable *memtable,
 				   const struct routing_state *rstate)
 {
+	struct node *n;
+	struct node_map_iter nit;
+
 	memleak_remove_htable(memtable, &rstate->nodes->raw);
 	memleak_remove_htable(memtable, &rstate->pending_node_map->raw);
 	memleak_remove_uintmap(memtable, &rstate->broadcasts->broadcasts);
+
+	for (n = node_map_first(rstate->nodes, &nit);
+	     n;
+	     n = node_map_next(rstate->nodes, &nit)) {
+		memleak_remove_htable(memtable, &n->chans.raw);
+	}
 }
 #endif /* DEVELOPER */
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1192,9 +1192,13 @@ bool routing_add_channel_update(struct routing_state *rstate,
 		= tal_dup_arr(chan, u8, update, tal_count(update), 0);
 
 	/* For private channels, we get updates without an announce: don't
-	 * broadcast them! */
-	if (!chan->channel_announce)
+	 * broadcast them!  But save local ones to store anyway. */
+	if (!chan->channel_announce) {
+		if (is_local_channel(rstate, chan))
+			gossip_store_add(rstate->store,
+					 chan->half[direction].channel_update);
 		return true;
+	}
 
 	/* BOLT #7:
 	 *   - MUST consider the `timestamp` of the `channel_announcement` to be

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -218,6 +218,10 @@ struct routing_state {
 #if DEVELOPER
 	/* Override local time for gossip messages */
 	struct timeabs *gossip_time;
+
+	/* Instead of ignoring unknown channels, pretend they're valid
+	 * with this many satoshis (if non-NULL) */
+	const struct amount_sat *dev_unknown_channel_satoshis;
 #endif
 };
 
@@ -240,7 +244,8 @@ struct routing_state *new_routing_state(const tal_t *ctx,
 					const struct chainparams *chainparams,
 					const struct pubkey *local_id,
 					u32 prune_timeout,
-					const u32 *dev_gossip_time);
+					const u32 *dev_gossip_time,
+					const struct amount_sat *dev_unknown_channel_satoshis);
 
 /**
  * Add a new bidirectional channel from id1 to id2 with the given

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -214,6 +214,11 @@ struct routing_state {
 	/* Cache for txout queries that failed. Allows us to skip failed
 	 * checks if we get another announcement for the same scid. */
 	UINTMAP(bool) txout_failures;
+
+#if DEVELOPER
+	/* Override local time for gossip messages */
+	struct timeabs *gossip_time;
+#endif
 };
 
 static inline struct chan *
@@ -234,7 +239,8 @@ struct route_hop {
 struct routing_state *new_routing_state(const tal_t *ctx,
 					const struct chainparams *chainparams,
 					const struct pubkey *local_id,
-					u32 prune_timeout);
+					u32 prune_timeout,
+					const u32 *dev_gossip_time);
 
 /**
  * Add a new bidirectional channel from id1 to id2 with the given
@@ -345,4 +351,12 @@ bool handle_local_add_channel(struct routing_state *rstate, const u8 *msg);
 void memleak_remove_routing_tables(struct htable *memtable,
 				   const struct routing_state *rstate);
 #endif
+
+/**
+ * Get the local time.
+ *
+ * This gets overridden in dev mode so we can use canned (stale) gossip.
+ */
+struct timeabs gossip_time_now(const struct routing_state *rstate);
+
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -95,6 +95,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
+/* Generated stub for towire_gossipd_local_add_channel */
+u8 *towire_gossipd_local_add_channel(const tal_t *ctx UNNEEDED, const struct short_channel_id *short_channel_id UNNEEDED, const struct pubkey *remote_node_id UNNEEDED, struct amount_sat satoshis UNNEEDED)
+{ fprintf(stderr, "towire_gossipd_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_channel_announcement */
 u8 *towire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED, struct amount_sat satoshis UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 	setup_tmpctx();
 
 	me = nodeid(0);
-	rstate = new_routing_state(tmpctx, NULL, &me, 0);
+	rstate = new_routing_state(tmpctx, NULL, &me, 0, NULL);
 	opt_register_noarg("--perfme", opt_set_bool, &perfme,
 			   "Run perfme-start and perfme-stop around benchmark");
 

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 	setup_tmpctx();
 
 	me = nodeid(0);
-	rstate = new_routing_state(tmpctx, NULL, &me, 0, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &me, 0, NULL, NULL);
 	opt_register_noarg("--perfme", opt_set_bool, &perfme,
 			   "Run perfme-start and perfme-stop around benchmark");
 

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -184,7 +184,7 @@ int main(void)
 			   strlen("02cca6c5c966fcf61d121e3a70e03a1cd9eeeea024b26ea666ce974d43b242e636"),
 			   &d);
 
-	rstate = new_routing_state(tmpctx, NULL, &a, 0);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL);
 
 	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -84,6 +84,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
+/* Generated stub for towire_gossipd_local_add_channel */
+u8 *towire_gossipd_local_add_channel(const tal_t *ctx UNNEEDED, const struct short_channel_id *short_channel_id UNNEEDED, const struct pubkey *remote_node_id UNNEEDED, struct amount_sat satoshis UNNEEDED)
+{ fprintf(stderr, "towire_gossipd_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_channel_announcement */
 u8 *towire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED, struct amount_sat satoshis UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -184,7 +184,7 @@ int main(void)
 			   strlen("02cca6c5c966fcf61d121e3a70e03a1cd9eeeea024b26ea666ce974d43b242e636"),
 			   &d);
 
-	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, NULL);
 
 	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -149,14 +149,16 @@ static struct chan *find_channel(struct routing_state *rstate UNUSED,
 					    const struct node *to,
 					    int *idx)
 {
-	int i, n;
+	struct chan_map_iter i;
+	struct chan *c;
 
 	*idx = pubkey_idx(&from->id, &to->id);
 
-	n = tal_count(to->chans);
-	for (i = 0; i < n; i++) {
-		if (to->chans[i]->nodes[*idx] == from)
-			return to->chans[i];
+	for (c = chan_map_first(&to->chans, &i);
+	     c;
+	     c = chan_map_next(&to->chans, &i)) {
+		if (c->nodes[*idx] == from)
+			return c;
 	}
 	return NULL;
 }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -213,7 +213,7 @@ int main(void)
 
 	memset(&tmp, 'a', sizeof(tmp));
 	pubkey_from_privkey(&tmp, &a);
-	rstate = new_routing_state(tmpctx, NULL, &a, 0);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL);
 
 	new_node(rstate, &a);
 

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -82,6 +82,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
+/* Generated stub for towire_gossipd_local_add_channel */
+u8 *towire_gossipd_local_add_channel(const tal_t *ctx UNNEEDED, const struct short_channel_id *short_channel_id UNNEEDED, const struct pubkey *remote_node_id UNNEEDED, struct amount_sat satoshis UNNEEDED)
+{ fprintf(stderr, "towire_gossipd_local_add_channel called!\n"); abort(); }
 /* Generated stub for towire_gossip_store_channel_announcement */
 u8 *towire_gossip_store_channel_announcement(const tal_t *ctx UNNEEDED, const u8 *announcement UNNEEDED, struct amount_sat satoshis UNNEEDED)
 { fprintf(stderr, "towire_gossip_store_channel_announcement called!\n"); abort(); }

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -213,7 +213,7 @@ int main(void)
 
 	memset(&tmp, 'a', sizeof(tmp));
 	pubkey_from_privkey(&tmp, &a);
-	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, NULL);
 
 	new_node(rstate, &a);
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -164,7 +164,13 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    get_offered_globalfeatures(tmpctx),
 	    ld->rgb,
 	    ld->alias, ld->config.channel_update_interval,
-	    ld->announcable);
+	    ld->announcable,
+#if DEVELOPER
+	    ld->dev_gossip_time ? &ld->dev_gossip_time: NULL
+#else
+	    NULL
+#endif
+		);
 	subd_send_msg(ld->gossip, msg);
 }
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -166,8 +166,10 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    ld->alias, ld->config.channel_update_interval,
 	    ld->announcable,
 #if DEVELOPER
-	    ld->dev_gossip_time ? &ld->dev_gossip_time: NULL
+	    ld->dev_gossip_time ? &ld->dev_gossip_time: NULL,
+	    ld->dev_unknown_channel_satoshis
 #else
+	    NULL,
 	    NULL
 #endif
 		);

--- a/lightningd/json_stream.c
+++ b/lightningd/json_stream.c
@@ -116,8 +116,6 @@ static void js_written_some(struct json_stream *js)
 void json_stream_append_part(struct json_stream *js, const char *str, size_t len)
 {
 	mkroom(js, len);
-	if (js->log)
-		log_io(js->log, LOG_IO_OUT, "", str, len);
 	memcpy(membuf_add(&js->outbuf, len), str, len);
 	js_written_some(js);
 }
@@ -148,9 +146,6 @@ static void json_stream_append_vfmt(struct json_stream *js,
 		mkroom(js, fmtlen + 1);
 		vsprintf(membuf_space(&js->outbuf), fmt, ap2);
 	}
-	if (js->log)
-		log_io(js->log, LOG_IO_OUT, "",
-		       membuf_space(&js->outbuf), fmtlen);
 	membuf_added(&js->outbuf, fmtlen);
 	js_written_some(js);
 	va_end(ap2);
@@ -296,6 +291,9 @@ static struct io_plan *json_stream_output_write(struct io_conn *conn,
 	}
 
 	js->reader = conn;
+	if (js->log)
+		log_io(js->log, LOG_IO_OUT, "",
+		       membuf_elems(&js->outbuf), js->len_read);
 	return io_write(conn,
 			membuf_elems(&js->outbuf), js->len_read,
 			json_stream_output_write, js);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -116,6 +116,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_disconnect_fd = -1;
 	ld->dev_subdaemon_fail = false;
 	ld->dev_allow_localhost = false;
+	ld->dev_gossip_time = 0;
 #endif
 
 	/*~ These are CCAN lists: an embedded double-linked list.  It's not

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -117,6 +117,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_subdaemon_fail = false;
 	ld->dev_allow_localhost = false;
 	ld->dev_gossip_time = 0;
+	ld->dev_unknown_channel_satoshis = NULL;
 #endif
 
 	/*~ These are CCAN lists: an embedded double-linked list.  It's not

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -196,6 +196,9 @@ struct lightningd {
 	/* Allow and accept localhost node_announcement addresses */
 	bool dev_allow_localhost;
 
+	/* Timestamp to use for gossipd, iff non-zero */
+	u32 dev_gossip_time;
+
 	/* Things we've marked as not leaking. */
 	const void **notleaks;
 #endif /* DEVELOPER */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -199,6 +199,9 @@ struct lightningd {
 	/* Timestamp to use for gossipd, iff non-zero */
 	u32 dev_gossip_time;
 
+	/* What to override unknown channels with, iff non-NULL */
+	struct amount_sat *dev_unknown_channel_satoshis;
+
 	/* Things we've marked as not leaking. */
 	const void **notleaks;
 #endif /* DEVELOPER */

--- a/lightningd/log.h
+++ b/lightningd/log.h
@@ -50,7 +50,7 @@ struct log_book *get_log_book(const struct log *log);
 					   bool,			\
 					   const struct timeabs *,	\
 					   const char *,		\
-					   const u8 *), (arg))
+					   const u8 *, size_t), (arg))
 
 /* If level == LOG_IO_IN/LOG_IO_OUT, then io contains data */
 void set_log_outfn_(struct log_book *lr,
@@ -59,7 +59,7 @@ void set_log_outfn_(struct log_book *lr,
 				  bool continued,
 				  const struct timeabs *time,
 				  const char *str,
-				  const u8 *io,
+				  const u8 *io, size_t io_len,
 				  void *arg),
 		    void *arg);
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -475,6 +475,10 @@ static void dev_register_opts(struct lightningd *ld)
 	    "--dev-channel-update-interval=<s>", opt_set_u32, opt_show_u32,
 	    &ld->config.channel_update_interval,
 	    "Time in seconds between channel updates for our own channels.");
+
+	opt_register_arg("--dev-gossip-time", opt_set_u32, opt_show_u32,
+			 &ld->dev_gossip_time,
+			 "UNIX time to override gossipd to use.");
 }
 #endif
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -443,6 +443,15 @@ static char *opt_subprocess_debug(const char *optarg, struct lightningd *ld)
 	return NULL;
 }
 
+static char *opt_set_dev_unknown_channel_satoshis(const char *optarg,
+						  struct lightningd *ld)
+{
+	tal_free(ld->dev_unknown_channel_satoshis);
+	ld->dev_unknown_channel_satoshis = tal(ld, struct amount_sat);
+	return opt_set_u64(optarg,
+			   &ld->dev_unknown_channel_satoshis->satoshis); /* Raw: dev code */
+}
+
 static void dev_register_opts(struct lightningd *ld)
 {
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
@@ -479,6 +488,9 @@ static void dev_register_opts(struct lightningd *ld)
 	opt_register_arg("--dev-gossip-time", opt_set_u32, opt_show_u32,
 			 &ld->dev_gossip_time,
 			 "UNIX time to override gossipd to use.");
+	opt_register_arg("--dev-unknown-channel-satoshis",
+			 opt_set_dev_unknown_channel_satoshis, NULL, ld,
+			 "Amount to pretend is in channels which we can't find funding tx for.");
 }
 #endif
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -72,11 +72,11 @@ static void copy_to_parent_log(const char *prefix,
 			       bool continued,
 			       const struct timeabs *time UNUSED,
 			       const char *str,
-			       const u8 *io,
+			       const u8 *io, size_t io_len,
 			       struct log *parent_log)
 {
 	if (level == LOG_IO_IN || level == LOG_IO_OUT)
-		log_io(parent_log, level, prefix, io, tal_count(io));
+		log_io(parent_log, level, prefix, io, io_len);
 	else if (continued)
 		log_add(parent_log, "%s ... %s", prefix, str);
 	else

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -382,7 +382,7 @@ void set_log_outfn_(struct log_book *lr UNNEEDED,
 				  bool continued UNNEEDED,
 				  const struct timeabs *time UNNEEDED,
 				  const char *str UNNEEDED,
-				  const u8 *io UNNEEDED,
+				  const u8 *io UNNEEDED, size_t io_len UNNEEDED,
 				  void *arg) UNNEEDED,
 		    void *arg UNNEEDED)
 { fprintf(stderr, "set_log_outfn_ called!\n"); abort(); }

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1033,7 +1033,6 @@ def test_getroute_exclude(node_factory, bitcoind):
         l1.rpc.getroute(l4.info['id'], 1, 1, exclude=[chan_l2l3, chan_l2l4])
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
 def test_gossip_store_local_channels(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, wait_for_announce=False)
@@ -1059,7 +1058,6 @@ def test_gossip_store_local_channels(node_factory, bitcoind):
     assert len(chans) == 2
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
 def test_gossip_store_private_channels(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, announce_channels=False)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1031,3 +1031,55 @@ def test_getroute_exclude(node_factory, bitcoind):
     # This doesn't
     with pytest.raises(RpcError):
         l1.rpc.getroute(l4.info['id'], 1, 1, exclude=[chan_l2l3, chan_l2l4])
+
+
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
+def test_gossip_store_local_channels(node_factory, bitcoind):
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=False)
+
+    # We see this channel, even though it's not announced, because it's local.
+    wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)
+
+    l2.stop()
+    l1.restart()
+
+    # We should still see local channels!
+    time.sleep(3)  # Make sure store is loaded
+    chans = l1.rpc.listchannels()['channels']
+    assert len(chans) == 2
+
+    # Now compact store
+    l1.rpc.call('dev-compact-gossip-store')
+    l1.restart()
+
+    time.sleep(3)  # Make sure store is loaded
+    # We should still see local channels!
+    chans = l1.rpc.listchannels()['channels']
+    assert len(chans) == 2
+
+
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
+def test_gossip_store_private_channels(node_factory, bitcoind):
+    l1, l2 = node_factory.line_graph(2, announce_channels=False)
+
+    # We see this channel, even though it's not announced, because it's local.
+    wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)
+
+    l2.stop()
+    l1.restart()
+
+    # We should still see local channels!
+    time.sleep(3)  # Make sure store is loaded
+    chans = l1.rpc.listchannels()['channels']
+    assert len(chans) == 2
+
+    # Now compact store
+    l1.rpc.call('dev-compact-gossip-store')
+    l1.restart()
+
+    time.sleep(3)  # Make sure store is loaded
+    # We should still see local channels!
+    chans = l1.rpc.listchannels()['channels']
+    assert len(chans) == 2

--- a/tools/bench-gossipd.sh
+++ b/tools/bench-gossipd.sh
@@ -1,0 +1,175 @@
+#! /bin/sh
+# Needs bitcoind -regtest running.
+
+set -e
+
+DIR=""
+TARGETS=""
+DEFAULT_TARGETS=" store_load_msec vsz_kb store_rewrite_sec listnodes_sec listchannels_sec routing_sec peer_write_all_sec peer_read_all_sec "
+MCP_DIR=../million-channels-project/data/1M/gossip/
+CSV=false
+
+wait_for_start()
+{
+    i=0
+    ID=""
+    while [ -z "$ID" ]; do
+	ID="$($LCLI1 -H getinfo 2>/dev/null | grep '^id=' | cut -d= -f2)"
+	sleep 1
+	i=$((i + 1))
+	if [ $i = 10 ]; then
+	    echo "lightningd didn't start?" >&2
+	    cat "$DIR"/log
+	    exit 1
+	fi
+    done
+    echo "$ID"
+}
+
+print_stat()
+{
+    if $CSV; then
+	sed -e 's/^ *//' -e 's/ *$//' | tr \\012 ,
+    else
+	echo "$1": | tr -d \\n
+	sed -e 's/^ *//' -e 's/ *$//'
+    fi
+}
+
+for arg; do
+    case "$arg" in
+	--dir=*)
+	    DIR="${arg#*=}"
+	    ;;
+	--mcp-dir=*)
+	    MCP_DIR="${arg#*=}"
+	    ;;
+	--csv)
+	    CSV=true
+	    ;;
+	--help)
+	    echo "Usage: tools/bench-gossipd.sh [--dir=<directory>] [--mcp-dir=<directory>] [--csv] [TARGETS]"
+	    echo "Default targets:$DEFAULT_TARGETS"
+	    exit 0
+	    ;;
+	-*)
+	    echo "Unknown arg $arg" >&2
+	    exit 1
+	    ;;
+	*)
+	    TARGETS="$TARGETS $arg"
+	    ;;
+    esac
+done
+
+# Targets must be space-separated for ## trick.
+if [ -z "$TARGETS" ]; then
+    TARGETS="$DEFAULT_TARGETS"
+else
+    TARGETS="$TARGETS "
+fi
+
+if ! bitcoin-cli -regtest ping >/dev/null 2>&1; then
+    bitcoind -regtest > "$DIR"/bitcoind.log &
+
+    while ! bitcoin-cli -regtest ping >/dev/null 2>&1; do sleep 1; done
+fi
+
+LIGHTNINGD="./lightningd/lightningd --network=regtest --dev-gossip-time=1550513768 --dev-unknown-channel-satoshis=100000"
+LCLI1="./cli/lightning-cli --lightning-dir=$DIR"
+
+if [ -z "$DIR" ]; then
+    trap 'rm -rf "$DIR"' 0
+
+    DIR="$(mktemp -d)"
+    ./devtools/create-gossipstore 100000 -i "$MCP_DIR"/1M.gossip -o "$DIR"/gossip_store
+fi
+
+# shellcheck disable=SC2086
+if $CSV; then echo $TARGETS | tr ' ' ,; fi
+
+# First, measure load time.
+rm -f "$DIR"/log "$DIR"/peer
+$LIGHTNINGD --lightning-dir="$DIR" --log-file="$DIR"/log --bind-addr="$DIR"/peer &
+
+rm -f "$DIR"/stats
+ID=$(wait_for_start)
+
+while ! grep -q 'gossipd.*: total store load time' "$DIR"/log 2>/dev/null; do
+    sleep 1
+done
+if [ -z "${TARGETS##* store_load_msec *}" ]; then
+    grep 'gossipd.*: total store load time' "$DIR"/log | cut -d\  -f7 | print_stat store_load_msec
+fi
+
+# How big is gossipd?
+if [ -z "${TARGETS##* vsz_kb *}" ]; then
+    ps -o vsz= -p "$(pidof lightning_gossipd)" | print_stat vsz_kb
+fi
+
+# How long does rewriting the store take?
+if [ -z "${TARGETS##* store_rewrite_sec *}" ]; then
+    # shellcheck disable=SC2086
+    /usr/bin/time --append -f %e $LCLI1 dev-compact-gossip-store 2>&1 > /dev/null | print_stat store_rewrite_sec
+fi
+
+# Now, how long does listnodes take?
+if [ -z "${TARGETS##* listnodes_sec *}" ]; then
+    # shellcheck disable=SC2086
+    /usr/bin/time --append -f %e $LCLI1 listnodes 2>&1 > "$DIR"/listnodes.json | print_stat listnodes_sec
+fi
+
+# Now, how long does listchannels take?
+if [ -z "${TARGETS##* listchannels_sec *}" ]; then
+    # shellcheck disable=SC2086
+    /usr/bin/time --append -f %e $LCLI1 listchannels 2>&1 > "$DIR"/listchannels.json | print_stat listchannels_sec
+fi
+
+# Now, try routing between first and last points.
+if [ -z "${TARGETS##* routing_sec *}" ]; then
+    echo "$DIV" | tr -d \\n; DIV=","
+    # shellcheck disable=SC2046
+    # shellcheck disable=SC2005
+    echo $(grep nodeid "$DIR"/listnodes.json | cut -d'"' -f4 | sort | head -n2) | while read -r from to; do
+	# shellcheck disable=SC2086
+	/usr/bin/time --quiet --append -f %e $LCLI1 getroute $from 1 1 6 $to 2>&1 > /dev/null | print_stat routing_sec # FIXME: this shouldn't fail
+    done
+fi
+
+# Try getting all from the peer.
+if [ -z "${TARGETS##* peer_write_all_sec *}" ]; then
+    ENTRIES=$(sed -n 's/.*gossipd.*: total store load time: [0-9]* msec (\([0-9]*\) entries, [0-9]* bytes)/\1/p' < "$DIR"/log)
+
+    /usr/bin/time --quiet --append -f %e devtools/gossipwith --initial-sync --max-messages=$((ENTRIES - 5)) "$ID"@"$DIR"/peer 2>&1 > /dev/null | print_stat peer_write_all_sec
+fi
+
+if [ -z "${TARGETS##* peer_read_all_sec *}" ]; then
+    # shellcheck disable=SC2086
+    $LCLI1 stop > /dev/null
+    sleep 5
+    # In case they specified dir, don't blow away store.
+    mv "$DIR"/gossip_store "$DIR"/gossip_store.bak
+    rm -f "$DIR"/peer
+
+    $LIGHTNINGD --lightning-dir="$DIR" --log-file="$DIR"/log --bind-addr="$DIR"/peer --log-level=debug &
+    ID=$(wait_for_start)
+
+    # FIXME: Measure this better.
+    EXPECTED=$(find "$DIR"/gossip_store.bak -printf %s)
+
+    START_TIME=$(date +%s)
+    # We send a bad msg at the end, so lightningd hangs up
+    xzcat ../million-channels-project/data/1M/gossip/xa*.xz | devtools/gossipwith --max-messages=1 --stdin "$ID"@"$DIR"/peer 0011 > /dev/null
+
+    while [ "$(find "$DIR"/gossip_store -printf %s)" -lt "$EXPECTED" ]; do
+	sleep 1
+	i=$((i + 1))
+    done
+    END_TIME=$(date +%s)
+
+    echo $((END_TIME - START_TIME)) | print_stat peer_read_all_sec
+    mv "$DIR"/gossip_store.bak "$DIR"/gossip_store
+fi
+
+# shellcheck disable=SC2086
+$LCLI1 stop > /dev/null

--- a/tools/check-includes.sh
+++ b/tools/check-includes.sh
@@ -9,7 +9,7 @@ HEADER_ID_SUFFIX="_H"
 REGEXP_EXCLUDE_FILES_WITH_PREFIX="ccan/"
 for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")
 do
-    HEADER_ID_BASE=$(tr / _ <<< "${HEADER_FILE/%.h/}" | tr "[:lower:]" "[:upper:]")
+    HEADER_ID_BASE=$(tr /- _ <<< "${HEADER_FILE/%.h/}" | tr "[:lower:]" "[:upper:]")
     HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     if [[ $(grep -cE "^#((ifndef|define) ${HEADER_ID}|endif /\\* ${HEADER_ID} \\*/)$" "${HEADER_FILE}") != 3 ]]; then
         echo "${HEADER_FILE} seems to be missing the expected include guard:"

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -620,6 +620,7 @@ void set_log_outfn_(struct log_book *lr UNNEEDED,
 				  const struct timeabs *time UNNEEDED,
 				  const char *str UNNEEDED,
 				  const u8 *io UNNEEDED,
+				  size_t io_len UNNEEDED,
 				  void *arg) UNNEEDED,
 		    void *arg UNNEEDED)
 {

--- a/wire/wire_io.h
+++ b/wire/wire_io.h
@@ -6,7 +6,8 @@
 #include <ccan/short_types/short_types.h>
 
 /* We don't allow > 64M msgs: enough for 483 64k failure msgs. */
-#define WIRE_LEN_LIMIT (1 << 26)
+/* FIXME: Too big, but allows the million-channels project at 327077670 bytes */
+#define WIRE_LEN_LIMIT (1 << 29)
 
 typedef be32 wire_len_t;
 #define wirelen_to_cpu be32_to_cpu


### PR DESCRIPTION
This turned into a bit of an epic, and the last dozen changes are not well tested, but I wanted to upload this to show where I'm going.

It starts with simple cleanups and optimizations, and then it includes utilities to benchmark using the Million Channels Project dataset, which is now reasonable to run.  It proceeds to optimize many places in JSON creation and gossipd, with the eventual effect of leaving the raw gossip messages in the gossip_store, and loading them on demand.  This is much better for low-power platforms.

There are many more optimizations which could  be done: in particular, to routing which may also have a bug (since it can't find any routes at the moment!)