### PR TITLE
fix: openingd memory leaks on failures

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -442,8 +442,8 @@ static u8 *funder_channel(struct state *state,
 	struct pubkey *changekey;
 	struct bitcoin_signature sig;
 	u32 minimum_depth;
-	const u8 *wscript;
-	struct bitcoin_tx *funding;
+	struct bitcoin_tx *funding = 0;
+	const u8 *wscript = 0;
 	struct amount_msat local_msat;
 
 	/*~ For symmetry, we calculate our own reserve even though lightningd
@@ -825,6 +825,10 @@ static u8 *funder_channel(struct state *state,
 fail:
 	if (taken(utxos))
 		tal_free(utxos);
+	if (funding)
+		tal_free(funding);
+	if (wscript)
+		tal_free(wscript);
 	return NULL;
 }
 


### PR DESCRIPTION
Add a testcase that tries to open tiny channels. Currently this raises unpredictive Valgrind issues.

1. Try to establish a channel that is exactly 1 Satoshi to small when accounting for 2 times dust_limit as reservers. This raises a exeption correctly and the test asserts this correctly.
2. Try to establish a channel that should be exactly the minimal amount +-0 Satoshi. This test also raises a exception `openingd/openingd.c +668` where I do think the the `goto fail` handler performs correctly as it leads to raise the valgrind issues. Also I am not sure if the exception should be possible at all, because a code comment quotes that this is a "should not happen exception" (that actually does happen).

