### PR TITLE
correct tx_fee in 32bit system

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -410,7 +410,7 @@ struct amount_sat amount_tx_fee(u32 fee_per_kw, size_t weight)
 
 	/* If this overflows, weight must be > 2^32, which is not a real tx */
 	assert(!mul_overflows_u64(fee_per_kw, weight));
-	fee.satoshis = fee_per_kw * weight / 1000;
+	fee.satoshis = (u64)fee_per_kw * weight / 1000;
 
 	return fee;
 }


### PR DESCRIPTION
run-commit_tx error on 32 bit os.

```
run-commit_tx: channeld/test/run-commit_tx.c:914: main: Assertion `tal_count(newtx->output) != tal_count(tx->output)' failed.
```