### PR TITLE
Fix for reorgs changing short_channel_id after lockin

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -176,7 +176,7 @@ static void billboard_update(const struct peer *peer)
 		funding_status = "Funding transaction locked.";
 	else if (!peer->funding_locked[LOCAL] && !peer->funding_locked[REMOTE])
 		funding_status = tal_fmt(tmpctx,
-					"Funding needs %d confirmations to reach lockin.",
+					"Funding needs %d more confirmations for lockin.",
 					peer->depth_togo);
 	else if (peer->funding_locked[LOCAL] && !peer->funding_locked[REMOTE])
 		funding_status = "We've confirmed funding, they haven't yet.";

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -220,10 +220,12 @@ static bool txw_fire(struct txwatch *txw,
 	else
 		log = txw->topo->log;
 
+	/* We assume zero depth signals a reorganization */
 	log_debug(log,
-		  "Got depth change %u->%u for %s",
+		  "Got depth change %u->%u for %s%s",
 		  txw->depth, depth,
-		  type_to_string(tmpctx, struct bitcoin_txid, &txw->txid));
+		  type_to_string(tmpctx, struct bitcoin_txid, &txw->txid),
+		  depth ? "" : " REORG");
 	txw->depth = depth;
 	r = txw->cb(txw->topo->bitcoind->ld, txw->channel, txid, txw->depth);
 	switch (r) {

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -66,8 +66,8 @@ def test_closing(node_factory, bitcoind):
     ]
     bitcoind.generate_block(1)
 
-    l1.daemon.wait_for_log(r'Owning output .* txid %s' % closetxid)
-    l2.daemon.wait_for_log(r'Owning output .* txid %s' % closetxid)
+    l1.daemon.wait_for_log(r'Owning output.* \(SEGWIT\).* txid %s.* CONFIRMED' % closetxid)
+    l2.daemon.wait_for_log(r'Owning output.* \(SEGWIT\).* txid %s.* CONFIRMED' % closetxid)
 
     # Make sure both nodes have grabbed their close tx funds
     assert closetxid in set([o['txid'] for o in l1.rpc.listfunds()['outputs']])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -868,7 +868,7 @@ def test_blockchaintrack(node_factory, bitcoind):
     """Check that we track the blockchain correctly across reorgs
     """
     l1 = node_factory.get_node(random_hsm=True)
-    addr = l1.rpc.newaddr()['bech32']
+    addr = l1.rpc.newaddr(addresstype='all')['p2sh-segwit']
 
     ######################################################################
     # First failure scenario: rollback on startup doesn't work,
@@ -883,7 +883,7 @@ def test_blockchaintrack(node_factory, bitcoind):
     time.sleep(1)  # mempool is still unpredictable
     bitcoind.generate_block(1)
 
-    l1.daemon.wait_for_log(r'Owning')
+    l1.daemon.wait_for_log(r'Owning output.* \(P2SH\).* CONFIRMED')
     outputs = l1.rpc.listfunds()['outputs']
     assert len(outputs) == 1
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -875,10 +875,10 @@ def test_blockchaintrack(node_factory, bitcoind):
     # and we try to add a block twice when rescanning:
     l1.restart()
 
-    height = bitcoind.rpc.getblockcount()
+    height = bitcoind.rpc.getblockcount()   # 101
 
     # At height 111 we receive an incoming payment
-    hashes = bitcoind.generate_block(9)
+    hashes = bitcoind.generate_block(9)     # 102-110
     bitcoind.rpc.sendtoaddress(addr, 1)
     time.sleep(1)  # mempool is still unpredictable
     bitcoind.generate_block(1)
@@ -903,7 +903,48 @@ def test_blockchaintrack(node_factory, bitcoind):
     l1.daemon.wait_for_log('Adding block {}: '.format(height + 30))
 
     # Our funds got reorged out, we should not have any funds that are confirmed
+    # NOTE: sendtoaddress() sets locktime=103 and the reorg at 102 invalidates that tx
+    # and deletes it from mempool
     assert [o for o in l1.rpc.listfunds()['outputs'] if o['status'] != "unconfirmed"] == []
+
+
+@unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
+def test_funding_reorg_private(node_factory, bitcoind):
+    """Change funding tx height after lockin, between node restart.
+    """
+    # Rescan to detect reorg at restart and may_reconnect so channeld
+    # will restart
+    opts = {'funding-confirms': 2, 'rescan': 10, 'may_reconnect': True}
+    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts=opts)
+    l1.fundwallet(10000000)
+    sync_blockheight(bitcoind, [l1])                # height 102
+    bitcoind.generate_block(3)                      # heights 103-105
+
+    l1.rpc.fundchannel(l2.info['id'], "all", announce=False)
+    bitcoind.generate_block(1)                      # height 106
+    wait_for(lambda: only_one(l1.rpc.listpeers()['peers'][0]['channels'])['status']
+             == ['CHANNELD_AWAITING_LOCKIN:Funding needs 1 more confirmations for lockin.'])
+    bitcoind.generate_block(1)                      # height 107
+    l1.wait_channel_active('106x1x0')
+    l1.stop()
+
+    # Create a fork that changes short_channel_id from 106x1x0 to 108x1x0
+    bitcoind.simple_reorg(106, 2)                   # heights 106-108
+    bitcoind.generate_block(1)                      # height 109 (to reach minimum_depth=2 again)
+    l1.daemon.rpcproxy = bitcoind.get_proxy()       # otherwise complains `address already in use`
+    l1.start()
+
+    # l2 was running, sees last stale block being removed
+    l2.daemon.wait_for_logs([r'Removing stale block {}'.format(106),
+                             r'Got depth change .->{} for .* REORG'.format(0)])
+
+    wait_for(lambda: [c['active'] for c in l2.rpc.listchannels('106x1x0')['channels']] == [False, False])
+    wait_for(lambda: [c['active'] for c in l2.rpc.listchannels('108x1x0')['channels']] == [True, True])
+
+    l1.rpc.close(l2.info['id'])                     # to ignore `Bad gossip order` error in killall
+    bitcoind.generate_block(1)
+    l1.daemon.wait_for_log(r'Deleting channel')
+    l2.daemon.wait_for_log(r'Deleting channel')
 
 
 def test_rescan(node_factory, bitcoind):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -947,6 +947,55 @@ def test_funding_reorg_private(node_factory, bitcoind):
     l2.daemon.wait_for_log(r'Deleting channel')
 
 
+@unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
+def test_funding_reorg_remote_lags(node_factory, bitcoind):
+    """Nodes may disagree about short_channel_id before channel announcement
+    """
+    # may_reconnect so channeld will restart
+    opts = {'funding-confirms': 1, 'may_reconnect': True}
+    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts=opts)
+    l2.may_fail = True                              # mock_rpc causes dev_memleak
+    l1.fundwallet(10000000)
+    sync_blockheight(bitcoind, [l1])                # height 102
+
+    l1.rpc.fundchannel(l2.info['id'], "all")
+    bitcoind.generate_block(5)                      # heights 103 - 107
+    l1.wait_channel_active('103x1x0')
+
+    # Make l2 temporary blind for blocks > 107
+    def no_more_blocks():          # although the mock doesn't imitate exitstatus=8, it suffices
+            return {'code': -8, 'message': 'Block height out of range'}
+
+    l2.daemon.rpcproxy.mock_rpc('getblockhash', no_more_blocks)
+
+    # Reorg changes short_channel_id 103x1x0 to 103x2x0, l1 sees it, restarts channeld
+    bitcoind.simple_reorg(102, 1)                   # heights 102 - 108
+    l1.daemon.wait_for_log(r'Peer transient failure .* short_channel_id changed to 103x2x0 \(was 103x1x0\)')
+
+    # l1 watches at least one more funding confirmation
+    # to depth=7 and sends its announce signature
+    bitcoind.generate_block(1)                      # height 109
+
+    wait_for(lambda: only_one(l2.rpc.listpeers()['peers'][0]['channels'])['status'] == [
+        'CHANNELD_NORMAL:Reconnected, and reestablished.',
+        'CHANNELD_NORMAL:Funding transaction locked. They need our announcement signatures.'])
+
+    # Unblinding l2 brings it back in sync, restarts channeld and sends its announce sig
+    l2.daemon.rpcproxy.mock_rpc('getblockhash', None)
+
+    wait_for(lambda: [c['active'] for c in l2.rpc.listchannels('103x1x0')['channels']] == [False, False])
+    wait_for(lambda: [c['active'] for c in l2.rpc.listchannels('103x2x0')['channels']] == [True, True])
+
+    wait_for(lambda: only_one(l2.rpc.listpeers()['peers'][0]['channels'])['status'] == [
+        'CHANNELD_NORMAL:Reconnected, and reestablished.',
+        'CHANNELD_NORMAL:Funding transaction locked. Channel announced.'])
+
+    l1.rpc.close(l2.info['id'])                     # to ignore `Bad gossip order` error in killall
+    bitcoind.generate_block(1)
+    l1.daemon.wait_for_log(r'Deleting channel')
+    l2.daemon.wait_for_log(r'Deleting channel')
+
+
 def test_rescan(node_factory, bitcoind):
     """Test the rescan option
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -441,7 +441,7 @@ class LightningNode(object):
         addr = self.rpc.newaddr(addrtype)[addrtype]
         txid = self.bitcoin.rpc.sendtoaddress(addr, sats / 10**8)
         self.bitcoin.generate_block(1)
-        self.daemon.wait_for_log('Owning output .* txid {}'.format(txid))
+        self.daemon.wait_for_log('Owning output .* txid {} CONFIRMED'.format(txid))
         return addr, txid
 
     def getactivechannels(self):


### PR DESCRIPTION
Before this PR we calculate `short_channel_id` only once, when the funding tx reaches `minimum_depth` confirmations, the channel will then _lockin_ and can be used locally. For private channels we then stop watching the funding depth.

When `minimum_depth=1`, a chain reorganization of 1 block deep can change funding tx height and/or txindex after lockin. The probability for this to happen is small,  just a fraction of the _orphan rate_ (for bitcoin [0.5%](https://medium.com/@jb395official/orphan-blocks-june-16-2018-a8f4799dcc2c)) and I couldn't find any case of this ever happening.

But if we don't agree with our peer about `scid` a public channel will fail at announce depth or `channel_updates` are not recognized properly, making the channel partially unusable (not routable). If peers agree on the _incorrect_ `scid`, the `channel_announcement` is ignored by other nodes, effectively keeping the channel private.
 
This PR addresses this by always keep watching the funding depth and keep updating `scid` until `ANNOUNCE_MIN_DEPTH`(=6). If `scid` changes, we kill `channeld` so it can restart with the updated `scid`, which adds it to the routing table. This leaves the channel (at least locally) usable with both `scid`s. If the remote node (impl.) still doesn't see the reorg'd `scid` at announce depth, the (public) channel will probably still fail. It is a bit tricky but, after some experimentation, I think this is the most straight forward solution.

A pytest method `simple_reorg` is added to create chain reorgs. ~Three~ Two pytests are included to test different scenarios. Not sure if all these are needed for such unlikely scenarios, please advice. Other commits include small fixes to tighten-up some tests and to give (at least me) insight in the blockchain syncing machinery (`try_extend_tip`) and when it encounters a stale block.

TODO:

- [x] remove commented-out debug code
- [x] test  `short_channel_id` and `depth_togo` (depends on #2405)
~- [ ] move `test_funding_reorgs` to proper place or include/mix it in another test~
- [x] remove (too much) verbosity and keep it concise