### PR TITLE
Docker: Add a graceful shutdown handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,4 +100,4 @@ COPY --from=builder /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh
 
 EXPOSE 9735 9835
-ENTRYPOINT  [ "/sbin/tini", "-g", "--", "./entrypoint.sh" ]
+ENTRYPOINT  [ "/sbin/tini", "--", "./entrypoint.sh" ]

--- a/contrib/linuxarm32v7.Dockerfile
+++ b/contrib/linuxarm32v7.Dockerfile
@@ -111,4 +111,4 @@ COPY --from=downloader /opt/litecoin/bin /usr/bin
 COPY tools/docker-entrypoint.sh entrypoint.sh
 
 EXPOSE 9735 9835
-ENTRYPOINT  [ "/usr/bin/tini", "-g", "--", "./entrypoint.sh" ]
+ENTRYPOINT  [ "/usr/bin/tini", "--", "./entrypoint.sh" ]

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -2,10 +2,20 @@
 
 : "${EXPOSE_TCP:=false}"
 
+# SIGTERM-handler this function gets called on Ctrl+C or if docker trys to stop the container
+term_handler(){
+   echo "*** Stopping C-Lightning Node ***"
+   lightning-cli stop # this will gracefully shutdown the node and then exit
+   exit 0
+}
+
+# Setup signal handlers
+trap 'term_handler' SIGTERM SIGINT
+
 if [ "$EXPOSE_TCP" == "true" ]; then
     set -m
     lightningd "$@" &
-
+    pid="$!"
     echo "C-Lightning starting"
     while read -r i; do if [ "$i" = "lightning-rpc" ]; then break; fi; done \
     < <(inotifywait  -e create,open --format '%f' --quiet "$LIGHTNINGD_DATA" --monitor)
@@ -13,7 +23,11 @@ if [ "$EXPOSE_TCP" == "true" ]; then
     echo "C-Lightning started, RPC available on port $LIGHTNINGD_RPC_PORT"
 
     socat "TCP4-listen:$LIGHTNINGD_RPC_PORT,fork,reuseaddr" "UNIX-CONNECT:$LIGHTNINGD_DATA/lightning-rpc" &
-    fg %-
 else
-    exec lightningd "$@"
+    exec lightningd "$@" &
+    pid="$!"
 fi
+
+# the node got started in background, so we can react on shutdown requests in this script
+# wait for the node to shutdown, so that the container stays alive
+wait $pid


### PR DESCRIPTION
Handle shutdown signals in `docker-entypoint.sh` so that it sends a `stop` message to the node. Otherwise all processes get killed by SIG_TERM and might leave the database in an inconsistend state

Also remove the `-g` flag from `tini`, otherwise all subprocesses get the SIG_TERM again and we have no time to handle it via lightning-cli


Recently we had an issue, where after a `docker-compose up` (only after some configuration changes, but same clightning version), the node reported a lot of channels in inconsistent state and closed them uniliteral (sorry, i dont have the full logs anymore....)

Im not really sure if this is the reason, but it seems, currently a `docker stop` or `docker-compose up` (which implies a stop of the old container), the node (and all its subprocesses) get killed without having enough time to fully sync their state.

This change stops the node via `lightning-cli stop` and then exits