### PR TITLE
Do not overflow the u16 num_channels field in the gossip_getchannels_reply message

### DIFF
--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -21,7 +21,7 @@ gossip_getnodes_request,,id,?struct pubkey
 
 #include <lightningd/gossip_msg.h>
 gossip_getnodes_reply,3105
-gossip_getnodes_reply,,num_nodes,u16
+gossip_getnodes_reply,,num_nodes,u32
 gossip_getnodes_reply,,nodes,num_nodes*struct gossip_getnodes_entry
 
 # Pass JSON-RPC getroute call through

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -46,7 +46,7 @@ gossip_getchannels_request,,short_channel_id,?struct short_channel_id
 gossip_getchannels_request,,source,?struct pubkey
 
 gossip_getchannels_reply,3107
-gossip_getchannels_reply,,num_channels,u16
+gossip_getchannels_reply,,num_channels,u32
 gossip_getchannels_reply,,nodes,num_channels*struct gossip_getchannels_entry
 
 # Ping/pong test.  Waits for a reply if it expects one.

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -308,7 +308,7 @@ class Message(object):
             return
         for f in self.fields:
             if f.name == field.lenvar:
-                if f.fieldtype.name != 'u16':
+                if f.fieldtype.name != 'u16' and options.bolt:
                     raise ValueError('Field {} has non-u16 length variable {} (type {})'
                                      .format(field.name, field.lenvar, f.fieldtype.name))
 


### PR DESCRIPTION
Turns out we now have more than `UINT16_MAX` channels to return, and we were just overflowing that field.

Fixes #2504 