### PR TITLE
Issue #2483 part1: min_capacity_sat config for rejecting tiny channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON API: `newaddr` outputs `bech32` or `p2sh-segwit`, or both with new `all` parameter (#2390)
 - JSON API: `listpeers` status now shows how many confirmations until channel is open (#2405)
+- Config: Adds parameter `min-capacity-sat` to reject tiny channels.
 
 ### Changed
 

--- a/common/amount.c
+++ b/common/amount.c
@@ -370,6 +370,16 @@ bool amount_msat_to_u32(struct amount_msat msat, u32 *millisatoshis)
 	return true;
 }
 
+void amount_msat_from_u64(struct amount_msat *msat, u64 millisatoshis)
+{
+	msat->millisatoshis = millisatoshis;
+}
+
+void amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis)
+{
+	msat->millisatoshis = satoshis * 1000;
+}
+
 bool amount_msat_fee(struct amount_msat *fee,
 		     struct amount_msat amt,
 		     u32 fee_base_msat,

--- a/common/amount.h
+++ b/common/amount.h
@@ -102,6 +102,10 @@ bool amount_msat_less_eq_sat(struct amount_msat msat, struct amount_sat sat);
 WARN_UNUSED_RESULT bool amount_msat_to_u32(struct amount_msat msat,
 					   u32 *millisatoshis);
 
+/* Programatically initialize from various types */
+void amount_msat_from_u64(struct amount_msat *msat, u64 millisatoshis);
+void amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis);
+
 /* Common operation: what is the HTLC fee for given feerate?  Can overflow! */
 WARN_UNUSED_RESULT bool amount_msat_fee(struct amount_msat *fee,
 					struct amount_msat amt,

--- a/common/initial_channel.c
+++ b/common/initial_channel.c
@@ -73,7 +73,8 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const u8 **wscript,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
-				      enum side side)
+				      enum side side,
+				      char** err_reason)
 {
 	struct keyset keyset;
 
@@ -83,8 +84,10 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 	if (!derive_keyset(per_commitment_point,
 			   &channel->basepoints[side],
 			   &channel->basepoints[!side],
-			   &keyset))
+			   &keyset)){
+		*err_reason = "Cannot derive keyset";
 		return NULL;
+	}
 
 	*wscript = bitcoin_redeem_2of2(ctx,
 				       &channel->funding_pubkey[side],
@@ -103,7 +106,8 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				 channel->view[side].owed[!side],
 				 channel->config[!side].channel_reserve,
 				 0 ^ channel->commitment_number_obscurer,
-				 side);
+				 side,
+				 err_reason);
 }
 
 static char *fmt_channel_view(const tal_t *ctx, const struct channel_view *view)

--- a/common/initial_channel.h
+++ b/common/initial_channel.h
@@ -111,6 +111,7 @@ struct channel *new_initial_channel(const tal_t *ctx,
  * @channel: The channel to evaluate
  * @per_commitment_point: Per-commitment point to determine keys
  * @side: which side to get the commitment transaction for
+ * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
  * Returns the unsigned initial commitment transaction for @side, or NULL
  * if the channel size was insufficient to cover fees or reserves.
@@ -119,6 +120,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const u8 **wscript,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
-				      enum side side);
+				      enum side side,
+				      char** err_reason);
 
 #endif /* LIGHTNING_COMMON_INITIAL_CHANNEL_H */

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -72,7 +72,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 				     struct amount_msat other_pay,
 				     struct amount_sat self_reserve,
 				     u64 obscured_commitment_number,
-				     enum side side)
+				     enum side side,
+				     char** err_reason)
 {
 	struct amount_sat base_fee;
 	struct bitcoin_tx *tx;
@@ -112,6 +113,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 		 *   - it considers `feerate_per_kw` too small for timely
 		 *     processing or unreasonably large.
 		 */
+		*err_reason = "Funder cannot afford fee on initial commitment transaction";
 		status_unusual("Funder cannot afford fee"
 			       " on initial commitment transaction");
 		return NULL;
@@ -127,6 +129,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	 */
 	if (!amount_msat_greater_sat(self_pay, self_reserve)
 	    && !amount_msat_greater_sat(other_pay, self_reserve)) {
+		*err_reason = "Neither self amount nor other amount exceed reserve on "
+				   "initial commitment transaction";
 		status_unusual("Neither self amount %s"
 			       " nor other amount %s"
 			       " exceed reserve %s"

--- a/common/initial_commit_tx.h
+++ b/common/initial_commit_tx.h
@@ -61,6 +61,7 @@ static inline struct amount_sat commit_tx_base_fee(u32 feerate_per_kw,
  * @self_reserve: reserve the other side insisted we have
  * @obscured_commitment_number: number to encode in commitment transaction
  * @side: side to generate commitment transaction for.
+ * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
  * We need to be able to generate the remote side's tx to create signatures,
  * but the BOLT is expressed in terms of generating our local commitment
@@ -79,7 +80,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 				     struct amount_msat other_pay,
 				     struct amount_sat self_reserve,
 				     u64 obscured_commitment_number,
-				     enum side side);
+				     enum side side,
+				     char** err_reason);
 
 /* try_subtract_fee - take away this fee from the funder (and return true), or all if insufficient (and return false). */
 bool try_subtract_fee(enum side funder, enum side side,

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/05/2019
+.\"      Date: 03/27/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "03/05/2019" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "03/27/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -194,6 +194,11 @@ The base fee to charge for every payment which passes through\&. Note that milli
 \fBfee\-per\-satoshi\fR=\fIMILLIONTHS\fR
 .RS 4
 This is the proportional fee to charge for every payment which passes through\&. As percentages are too coarse, it\(cqs in millionths, so 10000 is 1%, 1000 is 0\&.1%\&. Changing this value will only affect new channels and not existing ones\&. If you want to change fees for existing channels, use the RPC call lightningd\-setchannelfee(7)\&.
+.RE
+.PP
+\fBmin\-capacity\-sat\fR=\fISATOSHI\fR
+.RS 4
+This value defines the minimal effective channel capacity in satoshi to accept for channel opening requests\&. If a peer tries to open a channel smaller than this, the opening will be rejected\&.
 .RE
 .PP
 \fBignore\-fee\-limits\fR=\fIBOOL\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -151,6 +151,11 @@ Lightning node customization options
     not existing ones.  If you want to change fees for existing channels, use
     the RPC call lightningd-setchannelfee(7).
 
+*min-capacity-sat*='SATOSHI'::
+    This value defines the minimal effective channel capacity in satoshi to
+    accept for channel opening requests. If a peer tries to open a channel
+    smaller than this, the opening will be rejected.
+
 *ignore-fee-limits*='BOOL'::
     Allow nodes which establish channels to us to set any fee they
     want.  This may result in a channel which cannot be closed, should

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -67,6 +67,9 @@ struct config {
 
 	/* Are we allowed to use DNS lookup for peers. */
 	bool use_dns;
+
+	/* Minimal amount of effective funding_satoshis for accepting channels */
+	u64 min_capacity_sat;
 };
 
 struct lightningd {

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -662,8 +662,10 @@ static void channel_config(struct lightningd *ld,
 {
 	/* FIXME: depend on feerate. */
 	*max_to_self_delay = ld->config.locktime_max;
-	/* This is 1c at $1000/BTC */
-	*min_effective_htlc_capacity = AMOUNT_MSAT(1000000);
+
+	/* Take minimal effective capacity from config min_capacity_sat */
+	amount_msat_from_sat_u64(min_effective_htlc_capacity,
+		ld->config.min_capacity_sat);
 
 	/* BOLT #2:
 	 *

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -376,6 +376,9 @@ static void config_register_opts(struct lightningd *ld)
 	opt_register_arg("--fee-per-satoshi", opt_set_u32, opt_show_u32,
 			 &ld->config.fee_per_satoshi,
 			 "Microsatoshi fee for every satoshi in HTLC");
+	opt_register_arg("--min-capacity-sat", opt_set_u64, opt_show_u64,
+			 &ld->config.min_capacity_sat,
+			 "Minimum capacity in satoshis for accepting channels");
 	opt_register_arg("--addr", opt_add_addr, NULL,
 			 ld,
 			 "Set an IP address (v4 or v6) to listen on and announce to the network for incoming connections");
@@ -544,6 +547,9 @@ static const struct config testnet_config = {
 	.max_fee_multiplier = 10,
 
 	.use_dns = true,
+
+	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 1ct */
+	.min_capacity_sat = 1000,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -607,6 +613,9 @@ static const struct config mainnet_config = {
 	.max_fee_multiplier = 10,
 
 	.use_dns = true,
+
+	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 1ct */
+	.min_capacity_sat = 1000,
 };
 
 static void check_config(struct lightningd *ld)

--- a/wallet/test/test_utils.c
+++ b/wallet/test/test_utils.c
@@ -22,4 +22,5 @@ const struct config test_config = {
 	.rescan = 30,
 	.max_fee_multiplier = 10,
 	.use_dns = true,
+	.min_capacity_sat = 1000,
 };


### PR DESCRIPTION
**SUMMARY**
In regards to the IRC meeting logs, as the first part of Issue #2483 I see the need to introduce a config value and switch to automatically reject channel opening requests for tiny channels. The second part of adding a channel accept plugin hook will be in a separate PR that I am already working on. This PR will:

- Remove magic value `min_effective_htlc_capacity = AMOUNT_MSAT(1000000)`
- Introduce `min_capacity_sat` config value and `--min-capacity-sat` config switch.
- Add testcase
- Add doc
- Fix memory leaks discussed in PR #2494.