### PR TITLE
allow plugin opts in config

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -712,7 +712,7 @@ static void opt_parse_from_config(struct lightningd *ld, bool early)
 			if (all_args[i] != NULL) {
 				config_parse_line_number = i + 1;
 				argv[1] = all_args[i];
-				opt_early_parse(argc, argv,
+				opt_early_parse_incomplete(argc, argv,
 						config_log_stderr_exit);
 			}
 		}


### PR DESCRIPTION
This change should allow for plugin options to be included in the config file, currently it crashes, this patch ignores options not known by lightningd on the "early" pass, allowing plugins to be registered with options and use them on the second pass.  It will still crash on unknown options that are not part of lightningd known options or plugin registered options.