### PR TITLE
gossip: Make gossipd a bit less noisy about old timestamps

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1255,7 +1255,7 @@ u8 *handle_channel_update(struct routing_state *rstate, const u8 *update TAKES,
 
 	/* Note: we can consider old timestamps a case of "instant prune" too */
 	if (timestamp < time_now().ts.tv_sec - rstate->prune_timeout) {
-		status_debug("Received channel_update for %s with old time %u",
+		SUPERVERBOSE("Received channel_update for %s with old time %u",
 			     type_to_string(tmpctx, struct short_channel_id,
 					    &short_channel_id),
 			     timestamp);

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -465,8 +465,6 @@ static struct io_plan *sd_msg_read(struct io_conn *conn, struct subd *sd)
 		}
 	}
 
-	log_debug(sd->log, "UPDATE %s", sd->msgname(type));
-
 	/* Might free sd (if returns negative); save/restore sd->conn */
 	sd->conn = NULL;
 	tal_add_destructor2(sd, mark_freed, &freed);


### PR DESCRIPTION
Just wanted to have `gossipd` print less to the logs :wink: 