### PR TITLE
gossip: Cache txout query failures

### DIFF
--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -190,6 +190,10 @@ struct routing_state {
 
 	/* Has one of our own channels been announced? */
 	bool local_channel_announced;
+
+	/* Cache for txout queries that failed. Allows us to skip failed
+	 * checks if we get another announcement for the same scid. */
+	UINTMAP(bool) txout_failures;
 };
 
 static inline struct chan *


### PR DESCRIPTION
If we asked `bitcoind` for a txout and it failed we were not storing that
information anywhere, meaning that when we see the channel announcement the
next time we'd be reaching out to `lightningd` and `bitcoind` again, just to
see it fail again. This adds an in-memory cache for these failures so we can
just ignore these the next time around.

Fixes #2503

Signed-off-by: Christian Decker <decker.christian@gmail.com>