### PR TITLE
Clean Up Case #5 in Tor Documentation

### DIFF
--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -276,7 +276,7 @@ or `--addr=your.onionAddress:port` if you are NOT on an internal network.
 In this case it is difficult to track the node.
 You specify just:
 ```
---bind-addr=yourInternalIPAddress:port --bind-addr=autotor:127.0.0.1:9051
+--bind-addr=yourInternalIPAddress:port --addr=autotor:127.0.0.1:9051
 ```
 In the `lightningd` command line.
 


### PR DESCRIPTION
Case 5 in the Tor documentation currently states that if you use `--bind-addr=autotor:127.0.0.1:9051`, you can get your onion address by running `lightning-cli getinfo`. I have not found that to be the case; with that flag no onion address will be generated at all.

On the other hand, if `--addr=autotor:127.0.0.1:9051` is used instead, an onion address is generated and `lightning-cli getinfo` behaves as the docs say.

This PR simply changes the Tor docs to reflect the above.