### PR TITLE
plugins: patch in empty string when no default given

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -984,6 +984,8 @@ static void plugin_config(struct plugin *plugin)
 	list_for_each(&plugin->plugin_opts, opt, list) {
 		/* Trim the `--` that we added before */
 		name = opt->name + 2;
+		if (!opt->value)
+			opt->value = "";
 		json_add_string(req->stream, name, opt->value);
 	}
 	json_object_end(req->stream); /* end of .params.options */


### PR DESCRIPTION
If a plugin fails to pass in a default value for an option,
c-lightning crashes. this fixes the crash.

Patches #2515