### PR TITLE
Remove Sensitive RPC Data from Logs

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -117,10 +117,10 @@ static char *bcli_args(const tal_t *ctx, struct bitcoin_cli *bcli)
 	char *ret = tal_strdup(ctx, bcli->args[0]);
 
 	for (i = 1; bcli->args[i]; i++) {
-        if (!strstarts(bcli->args[i], "-rpcuser") && !strstarts(bcli->args[i], "-rpcpassword")) {
-            ret = tal_strcat(ctx, take(ret), " ");
-            ret = tal_strcat(ctx, take(ret), bcli->args[i]);
-        }
+            if (!strstarts(bcli->args[i], "-rpcuser") && !strstarts(bcli->args[i], "-rpcpassword")) {
+                ret = tal_strcat(ctx, take(ret), " ");
+                ret = tal_strcat(ctx, take(ret), bcli->args[i]);
+            }
 	}
 	return ret;
 }

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -117,8 +117,10 @@ static char *bcli_args(const tal_t *ctx, struct bitcoin_cli *bcli)
 	char *ret = tal_strdup(ctx, bcli->args[0]);
 
 	for (i = 1; bcli->args[i]; i++) {
-		ret = tal_strcat(ctx, take(ret), " ");
-		ret = tal_strcat(ctx, take(ret), bcli->args[i]);
+        if (!strstarts(bcli->args[i], "-rpcuser") && !strstarts(bcli->args[i], "-rpcpassword")) {
+            ret = tal_strcat(ctx, take(ret), " ");
+            ret = tal_strcat(ctx, take(ret), bcli->args[i]);
+        }
 	}
 	return ret;
 }

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -118,9 +118,9 @@ static char *bcli_args(const tal_t *ctx, struct bitcoin_cli *bcli)
 
 	for (i = 1; bcli->args[i]; i++) {
             ret = tal_strcat(ctx, take(ret), " ");
-            if (strstarts(bcli->args[i], "-rpcpassword") {
+            if (strstarts(bcli->args[i], "-rpcpassword")) {
                     ret = tal_strcat(ctx, take(ret), "-rpcpassword=...");
-            } else if (strstarts(bcli->args[i], "-rpcuser") {
+            } else if (strstarts(bcli->args[i], "-rpcuser")) {
                     ret = tal_strcat(ctx, take(ret), "-rpcuser=...");
             } else {
                 ret = tal_strcat(ctx, take(ret), bcli->args[i]);

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -117,8 +117,12 @@ static char *bcli_args(const tal_t *ctx, struct bitcoin_cli *bcli)
 	char *ret = tal_strdup(ctx, bcli->args[0]);
 
 	for (i = 1; bcli->args[i]; i++) {
-            if (!strstarts(bcli->args[i], "-rpcuser") && !strstarts(bcli->args[i], "-rpcpassword")) {
-                ret = tal_strcat(ctx, take(ret), " ");
+            ret = tal_strcat(ctx, take(ret), " ");
+            if (strstarts(bcli->args[i], "-rpcpassword") {
+                    ret = tal_strcat(ctx, take(ret), "-rpcpassword=...");
+            } else if (strstarts(bcli->args[i], "-rpcuser") {
+                    ret = tal_strcat(ctx, take(ret), "-rpcuser=...");
+            } else {
                 ret = tal_strcat(ctx, take(ret), bcli->args[i]);
             }
 	}


### PR DESCRIPTION
This is a patch to fix #2424.

It modifies the `bcli_args` function to skip any arguments with sensitive RPC username/password data when printing `bitcoin-cli` data to logs.

This is my first code PR to the project; please accept my apologies ahead of time if I inadvertently violated any standards/procedures.