### PR TITLE
Store failcode of local forward failure into DB (completed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: new plugin `invoice_payment` hook for intercepting invoices before they're paid.
 - plugin: the `connected` hook can now send an `error_message` to the rejected peer.
 - Protocol: we now enforce `option_upfront_shutdown_script` if a peer negotiates it.
+- JSON API: `listforwards` now includes the local_failed forwards with failcode (Issue [#2435](https://github.com/ElementsProject/lightning/issues/2435), PR [#2524](https://github.com/ElementsProject/lightning/pull/2524))
 
 ### Changed
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1915,6 +1915,12 @@ static void listforwardings_add_forwardings(struct json_stream *response, struct
 				     "fee", "fee_msat");
 		json_add_string(response, "status", forward_status_name(cur->status));
 
+		if(cur->failcode != 0) {
+			json_add_num(response, "failcode", cur->failcode);
+			json_add_string(response, "failreason",
+					 onion_type_name(cur->failcode));
+		}
+
 #ifdef COMPAT_V070
 		/* If a forwarding doesn't have received_time it was created
 		 * before we added the tracking, do not include it here. */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -380,6 +380,8 @@ static struct migration dbmigrations[] = {
 	{ "ALTER TABLE forwarded_payments ADD received_time INTEGER", NULL },
 	{ "ALTER TABLE forwarded_payments ADD resolved_time INTEGER", NULL },
 	{ "ALTER TABLE channels ADD remote_upfront_shutdown_script BLOB;", NULL },
+	/* PR #2524: Add failcode into forward_payment */
+	{ "ALTER TABLE forwarded_payments ADD failcode INTEGER;", NULL },
 };
 
 /* Leak tracking. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -17,6 +17,7 @@
 #include <lightningd/log.h>
 #include <onchaind/onchain_wire.h>
 #include <wally_bip32.h>
+#include <wire/gen_onion_wire.h>
 
 enum onion_type;
 struct amount_msat;
@@ -171,6 +172,7 @@ struct forwarding {
 	struct amount_msat msat_in, msat_out, fee;
 	struct sha256_double *payment_hash;
 	enum forward_status status;
+	enum onion_type failcode;
 	struct timeabs received_time;
 	/* May not be present if the HTLC was not resolved yet. */
 	struct timeabs *resolved_time;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -128,7 +128,8 @@ static inline enum wallet_output_type wallet_output_type_in_db(enum wallet_outpu
 enum forward_status {
 	FORWARD_OFFERED = 0,
 	FORWARD_SETTLED = 1,
-	FORWARD_FAILED = 2
+	FORWARD_FAILED = 2,
+	FORWARD_LOCAL_FAILED = 3
 };
 
 static inline enum forward_status wallet_forward_status_in_db(enum forward_status s)
@@ -143,6 +144,9 @@ static inline enum forward_status wallet_forward_status_in_db(enum forward_statu
 	case FORWARD_FAILED:
 		BUILD_ASSERT(FORWARD_FAILED == 2);
 		return s;
+	case FORWARD_LOCAL_FAILED:
+		BUILD_ASSERT(FORWARD_LOCAL_FAILED == 3);
+		return s;
 	}
 	fatal("%s: %u is invalid", __func__, s);
 }
@@ -156,6 +160,8 @@ static inline const char* forward_status_name(enum forward_status status)
 		return "settled";
 	case FORWARD_FAILED:
 		return "failed";
+	case FORWARD_LOCAL_FAILED:
+		return "local_failed";
 	}
 	abort();
 }

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1040,7 +1040,8 @@ struct channeltx *wallet_channeltxs_get(struct wallet *w, const tal_t *ctx,
  */
 void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
 				  const struct htlc_out *out,
-				  enum forward_status state);
+				  enum forward_status state,
+				  enum onion_type failcode);
 
 /**
  * Retrieve summary of successful forwarded payments' fees


### PR DESCRIPTION
Store failcode of local forward into DB, and thus listforwards will show the failcode for local failed forwarding payment.(issue #2435 )

- Add a new status for forward payment: FORWARD_LOCAL_FAILED.
  It means we meet failure locally, and we can fetch and store the failcode.

- Add failcode field in `forwarded_payments` table;

- Add failcode arugument in function `wallet_forwarded_payment_add()`;

- Store local failure in forward process by calling `wallet_forwarded_payment_add()`;

Here are 5 case I think we should handle as `local_failed`:

**Case 1**. When Msater resolves the reply about the next peer infor(sent by Gossipd), and need handle unknown next peer failure in `channel_resolve_reply()`.

**Test for this case:** I ask l1 pay to l3 through l2 but close the channel between l2 and l3 after `getroute()`, the payment will fail in l2 because of  `WIRE_UNKNOWN_NEXT_PEER`;

**Case 2**. When Master handle the forward process with the `htlc_in` and the id of next hop, it tries to drive a new `htlc_out` but fails in `forward_htlc()`. 

**Test for this case:** I ask l1 pay to 14 through with no fee, so the payment will fail in l2 becase of `WIRE_FEE_INSUFFICIENT`;

**Case 3**. When we send `htlc_out`, Master asks Channeld to add a new htlc into the outgoing channel but Channeld fails. Master need handle and store this failure in `rcvd_htlc_reply()`. 

**Test for this case:** I ask l1 pay to l5 with 10^8 sat through the channel (l2-->l5) with the max capacity of 10^4 msat , the payment will fail in l2 because of `CHANNEL_ERR_MAX_HTLC_VALUE_EXCEEDED`;

**Case 4**. When Channeld receives a new revoke message, if the state of corresponding htlc is RCVD_ADD_ACK_REVOCATION, Master will tries to resolve onionpacket and handle the failure before resolving the next hop in `peer_got_revoke()`. 

**Test for this case:** I ask l6 pay to l4 through l1 and l2, but we replace the second node_id in `[route]` with the wrong one, so the payment will fail in l2 because of WIRE_INVALID_ONION_KEY;

**Case 5**. When Onchaind finds the htlc time out or missing htlc, Master need handle these failure as `FORWARD_LOCAL_FAILED` in if it's forward payment case. 

**Test for this case:** I ask l1 pay to l4 through l2 with the amount less than the invoice(the payment must fail in l4), and we also ask l5 disconnected before sending update_fail_htlc, so the htlc will be holding until l2 meets timeout and handle it as local_fail.

EDIT: The last commit in Heisei era.