### PR TITLE
unittest: make sure VALGRIND env var set under valgrind.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BOLTVERSION := da71867c840abe057d7a68f358dd9493e0e79110
 -include config.vars
 
 ifneq ($(VALGRIND),0)
-VG=valgrind -q --error-exitcode=7
+VG=VALGRIND=1 valgrind -q --error-exitcode=7
 VG_TEST_ARGS = --track-origins=yes --leak-check=full --show-reachable=yes --errors-for-leak-kinds=all
 endif
 


### PR DESCRIPTION
In particular, `make unittest/bitcoin/test/run-secret_eq_consttime`
didn't set VALGRIND if it was set via config.vars, so runs for a *long*
time.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>