### PR TITLE
hsmd: Add the check of node announcement context before sig generation

### DIFF
--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -1555,7 +1555,10 @@ static struct io_plan *handle_sign_node_announcement(struct io_conn *conn,
 		return bad_req_fmt(conn, c, msg_in,
 				   "Node announcement too short");
 
-	/* FIXME(cdecker) Check the node announcement's content */
+	if (fromwire_peektype(ann) != WIRE_NODE_ANNOUNCEMENT)
+		return bad_req_fmt(conn, c, msg_in,
+				   "Invalid announcement");
+
 	node_key(&node_pkey, NULL);
 	sha256_double(&hash, ann + offset, tal_count(ann) - offset);
 


### PR DESCRIPTION
> /* FIXME(cdecker) Check the node announcement's content */

>  it needs to check that this is actually a node_announcement, but it doesn't need to check anything else. In fact, it could just check fromwire_peektype() and that it is at least 66 bytes long.

So now I add the check for `fromwire_peektype()` before sig generation!