### PR TITLE
closingd: send option_dataloss_protect fields when reestablishing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ changes.
 
 ### Fixed
 
+- protocol: reconnection during closing negotiation now supports
+  `option_data_loss_protect` properly.
 - `--bind-addr=<path>` fixed for nodes using local sockets (eg. testing).
 
 ### Security

--- a/closingd/closing_wire.csv
+++ b/closingd/closing_wire.csv
@@ -27,6 +27,7 @@ closing_init,,channel_reestablish_len,u16
 closing_init,,channel_reestablish,channel_reestablish_len*u8
 closing_init,,final_scriptpubkey_len,u16
 closing_init,,final_scriptpubkey,final_scriptpubkey_len*u8
+closing_init,,last_remote_secret,struct secret
 
 # We received an offer, save signature.
 closing_received_signature,2002


### PR DESCRIPTION
Travis caught an error where this happened: when closingd reconnects it
was sending the reestablish message without the option_dataloss_protect
fields.  That causes the peer to fail the channel!
