### PR TITLE
fix: format specifies type 'long *' but the argument has type 'u64 *'

### DIFF
--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -24,7 +24,7 @@ struct scidsat * load_scid_file(FILE * scidfd)
         fscanf(scidfd, "%s\n", title);	
 	struct scidsat * scids = calloc(n, sizeof(scidsat));
 	int i = 0;
-        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
+        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, (long *)&scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
 			i++;
 	}
 	return scids;


### PR DESCRIPTION
Hi,

This PR fixes the format error in *devtools/create-gossipstore.c*.

```shell
devtools/create-gossipstore.c:27:58: error: format specifies type 'long *' but the argument has type 'u64 *' (aka 'unsigned long long *') [-Werror,-Wformat]
        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
```

My environment:

macOS 10.14.3
clang 8.0.0
XCode 10.2 (10E125)