### PR TITLE
Update 'withdraw' and 'fundchannel' calls documentation

### DIFF
--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/23/2019
+.\"      Date: 04/08/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "02/23/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "04/08/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 lightning-fundchannel \- Command for establishing a lightning channel\&.
 .SH "SYNOPSIS"
 .sp
-\fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR]
+\fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR]
 .SH "DESCRIPTION"
 .sp
 The \fBfundchannel\fR RPC command opens a payment channel with a peer by committing a funding transaction to the blockchain as defined in BOLT #2\&. \fBfundchannel\fR by itself does not attempt to open a connection\&. A connection must first be established using \fBconnect\fR\&. Once the transaction is confirmed, normal channel operations may begin\&. Readiness is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL for the channel\&.
@@ -45,6 +45,8 @@ The \fBfundchannel\fR RPC command opens a payment channel with a peer by committ
 \fIannounce\fR is an optional flag that triggers whether to announce this channel or not\&. Defaults to true\&. An unannounced channel is considered private\&.
 .sp
 Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means the number is interpreted as satoshi\-per\-kilosipa (weight), and \fIperkb\fR means it is interpreted bitcoind\-style as satoshi\-per\-kilobyte\&. Omitting the suffix is equivalent to \fIperkb\fR\&.
+.sp
+\fIminconf\fR specifies the minimum number of confirmations that used outputs should have\&. Default is 1\&.
 .SH "RETURN VALUE"
 .sp
 On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well as the \fIchannel_id\fR of the newly created channel\&. On failure, an error is reported and the channel is not funded\&.

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -8,7 +8,7 @@ lightning-fundchannel - Command for establishing a lightning channel.
 
 SYNOPSIS
 --------
-*fundchannel* 'id' 'satoshi' ['feerate' 'announce']
+*fundchannel* 'id' 'satoshi' ['feerate' 'announce'] ['minconf']
 
 DESCRIPTION
 -----------
@@ -41,6 +41,8 @@ Otherwise, 'feerate' is a number, with an optional suffix:
 'perkw' means the number is interpreted as satoshi-per-kilosipa
 (weight), and 'perkb' means it is interpreted bitcoind-style as
 satoshi-per-kilobyte.  Omitting the suffix is equivalent to 'perkb'.
+
+'minconf' specifies the minimum number of confirmations that used outputs should have. Default is 1.
 
 RETURN VALUE
 ------------

--- a/doc/lightning-withdraw.7
+++ b/doc/lightning-withdraw.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-withdraw
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/23/2019
+.\"      Date: 04/08/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-WITHDRAW" "7" "02/23/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-WITHDRAW" "7" "04/08/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 lightning-withdraw \- Command for withdrawing funds from the internal wallet\&.
 .SH "SYNOPSIS"
 .sp
-\fBwithdraw\fR \fIdestination\fR \fIsatoshi\fR [\fIfeerate\fR]
+\fBwithdraw\fR \fIdestination\fR \fIsatoshi\fR [\fIfeerate\fR] [\fIminconf\fR]
 .SH "DESCRIPTION"
 .sp
 The \fBwithdraw\fR RPC command sends funds from c\-lightning\(cqs internal wallet to the address specified in \fIdestination\fR\&.
@@ -43,6 +43,8 @@ The address can be of any Bitcoin accepted type, including bech32\&.
 \fIfeerate\fR is an optional feerate to use\&. It can be one of the strings \fIurgent\fR, \fInormal\fR or \fIslow\fR to use lightningd\(cqs internal estimates: \fInormal\fR is the default\&.
 .sp
 Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means the number is interpreted as satoshi\-per\-kilosipa (weight), and \fIperkb\fR means it is interpreted bitcoind\-style as satoshi\-per\-kilobyte\&. Omitting the suffix is equivalent to \fIperkb\fR\&.
+.sp
+\fIminconf\fR specifies the minimum number of confirmations that used outputs should have\&. Default is 1\&.
 .SH "RETURN VALUE"
 .sp
 On success, an object with attributes \fItx\fR and \fItxid\fR will be returned\&.

--- a/doc/lightning-withdraw.7.txt
+++ b/doc/lightning-withdraw.7.txt
@@ -9,7 +9,7 @@ internal wallet.
 
 SYNOPSIS
 --------
-*withdraw* 'destination' 'satoshi' ['feerate']
+*withdraw* 'destination' 'satoshi' ['feerate'] ['minconf']
 
 DESCRIPTION
 -----------
@@ -32,6 +32,8 @@ Otherwise, 'feerate' is a number, with an optional suffix:
 'perkw' means the number is interpreted as satoshi-per-kilosipa
 (weight), and 'perkb' means it is interpreted bitcoind-style as
 satoshi-per-kilobyte.  Omitting the suffix is equivalent to 'perkb'.
+
+'minconf' specifies the minimum number of confirmations that used outputs should have. Default is 1.
 
 RETURN VALUE
 ------------


### PR DESCRIPTION
This PR adds the doc for the `minconf` parameter that was not in the detailed help.