### PR TITLE
fix memleak introduced with sqlite3_expanded_sql

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -511,8 +511,11 @@ void db_exec_prepared_(const char *caller, struct db *db, sqlite3_stmt *stmt)
 		db_fatal("%s: %s", caller, sqlite3_errmsg(db->sql));
 
 #if HAVE_SQLITE3_EXPANDED_SQL
+	char *expanded_sql;
+	expanded_sql = sqlite3_expanded_sql(stmt);
 	tal_arr_expand(&db->changes,
-		       tal_strdup(db->changes, sqlite3_expanded_sql(stmt)));
+		       tal_strdup(db->changes, expanded_sql));
+	sqlite3_free(expanded_sql);
 #endif
 	db_stmt_done(stmt);
 }


### PR DESCRIPTION
wallet/test/run-wallet was failing the valgrind check; turns out
`sqlite3_expanded_sql` expects you to manage the memory of strings
it returns. from `sqlite3.h`:

** ^The string returned by sqlite3_expanded_sql(P), on the other hand,
** is obtained from [sqlite3_malloc()] and must be free by the application
** by passing it to [sqlite3_free()].