### PR TITLE
Use SCNu64 instead of ld when scanning for a 64-bit value

### DIFF
--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -28,7 +28,7 @@ struct scidsat * load_scid_file(FILE * scidfd)
 		return NULL;
 	struct scidsat * scids = calloc(n, sizeof(scidsat));
 	int i = 0;
-        while(fscanf(scidfd, "%s ,%ld\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
+        while(fscanf(scidfd, "%s ,%" SCNu64 "\n", scids[i].scid, &scids[i].sat.satoshis) == 2 ) { /* Raw: read from file */
 			i++;
 	}
 	return scids;


### PR DESCRIPTION
This PR fixes the compilation of the current version on Raspberry Pi.