### PR TITLE
Increase min capacity sat default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JSON API: `invoice` expiry defaults to 7 days, and can have s/m/h/d/w suffixes.
+- Config: Increased default amount for minimal channel capacity from 1k sat to 10k sat.
 
 ### Deprecated
 

--- a/common/amount.c
+++ b/common/amount.c
@@ -375,9 +375,12 @@ void amount_msat_from_u64(struct amount_msat *msat, u64 millisatoshis)
 	msat->millisatoshis = millisatoshis;
 }
 
-void amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis)
+WARN_UNUSED_RESULT bool amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis)
 {
-	msat->millisatoshis = satoshis * 1000;
+	if (mul_overflows_u64(satoshis, MSAT_PER_SAT))
+		return false;
+	msat->millisatoshis = satoshis * MSAT_PER_SAT;
+	return true;
 }
 
 bool amount_msat_fee(struct amount_msat *fee,

--- a/common/amount.h
+++ b/common/amount.h
@@ -104,7 +104,7 @@ WARN_UNUSED_RESULT bool amount_msat_to_u32(struct amount_msat msat,
 
 /* Programatically initialize from various types */
 void amount_msat_from_u64(struct amount_msat *msat, u64 millisatoshis);
-void amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis);
+WARN_UNUSED_RESULT bool amount_msat_from_sat_u64(struct amount_msat *msat, u64 satoshis);
 
 /* Common operation: what is the HTLC fee for given feerate?  Can overflow! */
 WARN_UNUSED_RESULT bool amount_msat_fee(struct amount_msat *fee,

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/27/2019
+.\"      Date: 04/11/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "03/27/2019" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "04/11/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -188,17 +188,17 @@ Up to 32 UTF\-8 characters to tag your node\&. Completely silly, since anyone ca
 .PP
 \fBfee\-base\fR=\fIMILLISATOSHI\fR
 .RS 4
-The base fee to charge for every payment which passes through\&. Note that millisatoshis are a very, very small unit! Changing this value will only affect new channels and not existing ones\&. If you want to change fees for existing channels, use the RPC call lightningd\-setchannelfee(7)\&.
+Default: 1000\&. The base fee to charge for every payment which passes through\&. Note that millisatoshis are a very, very small unit! Changing this value will only affect new channels and not existing ones\&. If you want to change fees for existing channels, use the RPC call lightningd\-setchannelfee(7)\&.
 .RE
 .PP
 \fBfee\-per\-satoshi\fR=\fIMILLIONTHS\fR
 .RS 4
-This is the proportional fee to charge for every payment which passes through\&. As percentages are too coarse, it\(cqs in millionths, so 10000 is 1%, 1000 is 0\&.1%\&. Changing this value will only affect new channels and not existing ones\&. If you want to change fees for existing channels, use the RPC call lightningd\-setchannelfee(7)\&.
+Default: 10 (0\&.001%)\&. This is the proportional fee to charge for every payment which passes through\&. As percentages are too coarse, it\(cqs in millionths, so 10000 is 1%, 1000 is 0\&.1%\&. Changing this value will only affect new channels and not existing ones\&. If you want to change fees for existing channels, use the RPC call lightningd\-setchannelfee(7)\&.
 .RE
 .PP
 \fBmin\-capacity\-sat\fR=\fISATOSHI\fR
 .RS 4
-This value defines the minimal effective channel capacity in satoshi to accept for channel opening requests\&. If a peer tries to open a channel smaller than this, the opening will be rejected\&.
+Default: 10000\&. This value defines the minimal effective channel capacity in satoshi to accept for channel opening requests\&. If a peer tries to open a channel smaller than this, the opening will be rejected\&.
 .RE
 .PP
 \fBignore\-fee\-limits\fR=\fIBOOL\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -139,22 +139,23 @@ Lightning node customization options
     and "VAULTERO" are good options, too.
 
 *fee-base*='MILLISATOSHI'::
-    The base fee to charge for every payment which passes through.  Note that
-    millisatoshis are a very, very small unit!  Changing this value will only
+    Default: 1000.  The base fee to charge for every payment which passes
+    through.  Note that millisatoshis are a very, very small unit!
+    Changing this value will only affect new channels and not existing ones.
+    If you want to change fees for existing channels, use the RPC call
+    lightningd-setchannelfee(7).
+
+*fee-per-satoshi*='MILLIONTHS'::
+    Default: 10 (0.001%).  This is the proportional fee to charge for every
+    payment which passes through.  As percentages are too coarse, it's in
+    millionths, so 10000 is 1%, 1000 is 0.1%.  Changing this value will only
     affect new channels and not existing ones.  If you want to change fees for
     existing channels, use the RPC call lightningd-setchannelfee(7).
 
-*fee-per-satoshi*='MILLIONTHS'::
-    This is the proportional fee to charge for every payment which passes
-    through.  As percentages are too coarse, it's in millionths, so 10000
-    is 1%, 1000 is 0.1%.  Changing this value will only affect new channels and
-    not existing ones.  If you want to change fees for existing channels, use
-    the RPC call lightningd-setchannelfee(7).
-
 *min-capacity-sat*='SATOSHI'::
-    This value defines the minimal effective channel capacity in satoshi to
-    accept for channel opening requests. If a peer tries to open a channel
-    smaller than this, the opening will be rejected.
+    Default: 10000.  This value defines the minimal effective channel capacity
+    in satoshi to accept for channel opening requests.  If a peer tries to open
+    a channel smaller than this, the opening will be rejected.
 
 *ignore-fee-limits*='BOOL'::
     Allow nodes which establish channels to us to set any fee they

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -664,8 +664,9 @@ static void channel_config(struct lightningd *ld,
 	*max_to_self_delay = ld->config.locktime_max;
 
 	/* Take minimal effective capacity from config min_capacity_sat */
-	amount_msat_from_sat_u64(min_effective_htlc_capacity,
-		ld->config.min_capacity_sat);
+	if (!amount_msat_from_sat_u64(min_effective_htlc_capacity,
+				ld->config.min_capacity_sat))
+		fatal("amount_msat overflow for config.min_capacity_sat");
 
 	/* BOLT #2:
 	 *

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -660,6 +660,8 @@ static void channel_config(struct lightningd *ld,
 			   u32 *max_to_self_delay,
 			   struct amount_msat *min_effective_htlc_capacity)
 {
+	struct amount_msat dust_limit;
+
 	/* FIXME: depend on feerate. */
 	*max_to_self_delay = ld->config.locktime_max;
 
@@ -667,6 +669,17 @@ static void channel_config(struct lightningd *ld,
 	if (!amount_msat_from_sat_u64(min_effective_htlc_capacity,
 				ld->config.min_capacity_sat))
 		fatal("amount_msat overflow for config.min_capacity_sat");
+	/* Substract 2 * dust_limit, so fundchannel with min value is possible */
+	if (!amount_sat_to_msat(&dust_limit, get_chainparams(ld)->dust_limit))
+		fatal("amount_msat overflow for dustlimit");
+	if (!amount_msat_sub(min_effective_htlc_capacity,
+				*min_effective_htlc_capacity,
+				dust_limit))
+		*min_effective_htlc_capacity = AMOUNT_MSAT(0);
+	if (!amount_msat_sub(min_effective_htlc_capacity,
+				*min_effective_htlc_capacity,
+				dust_limit))
+		*min_effective_htlc_capacity = AMOUNT_MSAT(0);
 
 	/* BOLT #2:
 	 *

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -548,8 +548,8 @@ static const struct config testnet_config = {
 
 	.use_dns = true,
 
-	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 1ct */
-	.min_capacity_sat = 1000,
+	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
+	.min_capacity_sat = 10000,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -614,8 +614,8 @@ static const struct config mainnet_config = {
 
 	.use_dns = true,
 
-	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 1ct */
-	.min_capacity_sat = 1000,
+	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
+	.min_capacity_sat = 10000,
 };
 
 static void check_config(struct lightningd *ld)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -131,11 +131,13 @@ def test_bad_opening(node_factory):
 def test_opening_tiny_channel(node_factory):
     # Test custom min-capacity-sat parameters
     #
-    #       ----> [l2] (1000) - default
+    #       o---> [l2] (1000)   - old default (too little for reserves)
     #      /
-    #  [l1] ----> [l3] (3000) - less than own initial commit tx
+    #  [l1]-----> [l3] (~6000)  - technical minimal value that wont be rejected
     #      \
-    #       ----> [l4] (~6000) - enough to cover own initial commit tx
+    #       o---> [l4] (~10000) - the current default
+    #        \
+    #         o-> [l5] (20000)  - a node with a higher minimal value
     #
     # For each:
     #  1. Try to establish channel 1sat smaller than min_capacity_sat
@@ -151,42 +153,50 @@ def test_opening_tiny_channel(node_factory):
     min_commit_tx_fees = 5430
     min_for_funder = min_commit_tx_fees + dustlimit + 1
 
-    l2_min_capacity = 1000
-    l3_min_capacity = 3000
-    l4_min_capacity = min_for_funder
+    l2_min_capacity = 1000  # the old default of 1k sats
+    l3_min_capacity = min_for_funder  # the absolute technical minimum
+    l4_min_capacity = 10000  # the current default
+    l5_min_capacity = 20000  # a server with more than default minimum
 
-    l1 = node_factory.get_node()
-    l2 = node_factory.get_node()
+    # Outgoing node must have smallest min value, so inbound side of test channels wont be rejected
+    l1 = node_factory.get_node(options={'min-capacity-sat': 1000})
+    l2 = node_factory.get_node(options={'min-capacity-sat': l2_min_capacity})
     l3 = node_factory.get_node(options={'min-capacity-sat': l3_min_capacity})
     l4 = node_factory.get_node(options={'min-capacity-sat': l4_min_capacity})
+    l5 = node_factory.get_node(options={'min-capacity-sat': l5_min_capacity})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
+    l1.rpc.connect(l5.info['id'], 'localhost', l5.port)
 
-    # Open channel with less than default 1000 sats should be rejected
-    with pytest.raises(RpcError, match=r'channel capacity is 999sat, which is below 1000000msat'):
+    # Open channel with one less than 1000 sats should be rejected at l2
+    with pytest.raises(RpcError, match=r'channel capacity is .*sat, which is below .*sat'):
         l1.fund_channel(l2, l2_min_capacity + reserves - 1)
-    # Open a channel with exactly the minimal amount for the fundee.
+    # Open a channel with exactly the minimal amount for the fundee,
     # This will raise an exception at l1, as the funder cannot afford fees for initial_commit_tx.
+    # Note: The old default of 1k sat is below the technical minimum when accounting for dust reserves
+    # This is why this must fail, for this reason the default will be raised to 10k sat.
     with pytest.raises(RpcError, match=r'Funder cannot afford fee on initial commitment transaction'):
         l1.fund_channel(l2, l2_min_capacity + reserves)
 
-    # Open channel with less than custom 3000 sats should be rejected at l3
-    with pytest.raises(RpcError, match=r'channel capacity is 2999sat, which is below 3000000msat'):
+    # Open channel with one less than technical minimum should be rejected at l3
+    with pytest.raises(RpcError, match=r'channel capacity is .*sat, which is below .*sat'):
         l1.fund_channel(l3, l3_min_capacity + reserves - 1)
-    with pytest.raises(RpcError, match=r'Funder cannot afford fee on initial commitment transaction'):
-        l1.fund_channel(l3, l3_min_capacity + reserves)
+    # When amount technical minimum matches exactly, own initial_commit_tx fees can now be covered
+    l1.fund_channel(l3, l3_min_capacity + reserves)
 
-    # Open channel with less than custom ~6000 sats should be rejected at l4
+    # Open channel with one less than default 10k sats should be rejected at l4
     with pytest.raises(RpcError, match=r'channel capacity is .*, which is below .*msat'):
         l1.fund_channel(l4, l4_min_capacity + reserves - 1)
-    # When amount exactly matches, own initial_commit_tx fees can now be covered
+    # This must be possible with enough capacity
     l1.fund_channel(l4, l4_min_capacity + reserves)
 
-    # Also fund channels with minimal funder amount that should not be rejected by own daemon
-    l1.fund_channel(l2, min_for_funder)
-    l1.fund_channel(l3, min_for_funder)
+    # Open channel with less than minimum should be rejected at l5
+    with pytest.raises(RpcError, match=r'channel capacity is .*, which is below .*msat'):
+        l1.fund_channel(l5, l5_min_capacity + reserves - 1)
+    # bigger channels must not be affected
+    l1.fund_channel(l5, l5_min_capacity * 10)
 
 
 def test_second_channel(node_factory):

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -181,7 +181,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # Attach public channel to l1 so it doesn't look like a dead-end.
     l0 = node_factory.get_node()
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    scid = l0.fund_channel(l1, 2 * (10**4))
+    scid = l0.fund_channel(l1, 2 * (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.
@@ -209,7 +209,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # the exposure of private channels.
     l3 = node_factory.get_node()
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l3.fund_channel(l2, (10**4))
+    scid = l3.fund_channel(l2, (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.

--- a/wallet/test/test_utils.c
+++ b/wallet/test/test_utils.c
@@ -22,5 +22,5 @@ const struct config test_config = {
 	.rescan = 30,
 	.max_fee_multiplier = 10,
 	.use_dns = true,
-	.min_capacity_sat = 1000,
+	.min_capacity_sat = 10000,
 };


### PR DESCRIPTION
    The old value of 1000 sat was too small to cover the dust reserves and
    initial commitment fees. This lead to the situation when trying to open
    a channel with minimal amount, the channels got refused because
    they were not able cover the commitment fees.
    
    For this reason the minimal capacity should be increased to i.e. 10k
    satoshi, as the technical minimum that also accounts for fees and
    reserves is somewhere around 6k sat.

    additionally we substract the dust reserves on the fly from that value,
    so that a `cli fundchannel VALUE` is possible with the same VALUE.