### PR TITLE
Lightningd: Refactor and improve incoming channel selection for invoice's route-hint

### DIFF
--- a/common/pseudorand.c
+++ b/common/pseudorand.c
@@ -44,6 +44,13 @@ uint64_t pseudorand_u64(void)
 	return isaac64_next_uint64(&isaac64);
 }
 
+double pseudorand_double(void)
+{
+	init_if_needed();
+
+	return isaac64_next_double(&isaac64);
+}
+
 const struct siphash_seed *siphash_seed(void)
 {
 	init_if_needed();

--- a/common/pseudorand.h
+++ b/common/pseudorand.h
@@ -14,6 +14,12 @@ uint64_t pseudorand(uint64_t max);
 uint64_t pseudorand_u64(void);
 
 /**
+ * pseudorand - pseudo (guessable!) random number between 0 (inclusive) and 1
+ * (exclusive).
+ */
+double pseudorand_double(void);
+
+/**
  * Get the siphash seed for hash tables.
  */
 const struct siphash_seed *siphash_seed(void);

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -176,7 +176,7 @@ def test_invoice_routeboost(node_factory, bitcoind):
 def test_invoice_routeboost_private(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice for private channels
     """
-    l1, l2 = node_factory.line_graph(2, fundamount=10**6, announce_channels=False)
+    l1, l2 = node_factory.line_graph(2, fundamount=16777215, announce_channels=False)
 
     # Attach public channel to l1 so it doesn't look like a dead-end.
     l0 = node_factory.get_node()


### PR DESCRIPTION
This is a follow up of #2532

Fix and refactor `select_inchan` for invoice route-hint, now use fractional excess as weight.

Refactored the weighted-reservoir-sampling algo to make it more straightforward.
It now uses the excess as percentage of capacity as weight. This favors channels that
are more _relatively_ unbalanced to be used for incoming payment.

Now passes test_invoice_routeboost_private() when using max fundamount=16777215.
Hope that this fixes some issues. 