### PR TITLE
gossipd: fix the check for node announcement in broadcast_state_check()

### DIFF
--- a/gossipd/broadcast.c
+++ b/gossipd/broadcast.c
@@ -204,7 +204,7 @@ struct broadcast_state *broadcast_state_check(struct broadcast_state *b,
 						      &timestamp,
 						      &node_id_1, color, alias,
 						      &addresses))
-			if (!uintmap_get(&channels, scid.u64))
+			if (!pubkey_set_get(&pubkeys, &node_id_1))
 				return corrupt(abortstr,
 					       "node announced before channel",
 					       NULL, &node_id_1);


### PR DESCRIPTION
There should check if node_id_1 was stored in pubkeys, other than checking scid.