### PR TITLE
Plugin hook: pass through errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for
 changes.
 
 - JSON API: `newaddr` output field `address`: use `bech32` or `p2sh-segwit` instead.
-- Plugins: the `peer_connected` hook should return `result` directly as a string: `disconnect` or `continue`, not a nested in a `result` sub-object.
+- Plugins: hooks should return JSON-RPC errors to fail hooks.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for
 changes.
 
 - JSON API: `newaddr` output field `address`: use `bech32` or `p2sh-segwit` instead.
+- Plugins: the `peer_connected` hook should return `result` directly as a string: `disconnect` or `continue`, not a nested in a `result` sub-object.
 
 ### Removed
 

--- a/contrib/pylightning/lightning/__init__.py
+++ b/contrib/pylightning/lightning/__init__.py
@@ -1,2 +1,2 @@
 from .lightning import LightningRpc, RpcError, Millisatoshi, __version__
-from .plugin import Plugin, monkey_patch
+from .plugin import Plugin, monkey_patch, PluginError

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -3,7 +3,7 @@ import json
 import logging
 import socket
 
-__version__ = "0.0.7.1"
+__version__ = "0.0.7.2"
 
 
 class RpcError(ValueError):

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -268,6 +268,11 @@ gossiped list of known addresses. In particular this means that the port for
 incoming connections is an ephemeral port, that may not be available for
 reconnections.
 
+The plugin can return an empty `result` object to allow the
+connection, otherwise it should return an `error`; the `message`
+field, if not `null`, will be sent to the peer as the error before
+closing the connection.
+
 #### `db_write`
 
 This hook is called whenever a change is about to be committed to the database.
@@ -285,8 +290,8 @@ It is currently extremely restricted:
 }
 ```
 
-Any response but "true" will cause lightningd to error without
-committing to the database!
+An `error` return will cause lightningd to shutdown without committing to
+the database!
 
 #### `invoice_payment`
 
@@ -304,9 +309,13 @@ This hook is called whenever a valid payment for an unpaid invoice has arrived.
 
 The hook is sparse on purpose, since the plugin can use the JSON-RPC
 `listinvoices` command to get additional details about this invoice.
-It can return a non-zero `failure_code` field as defined for final
-nodes in [BOLT 4][bolt4-failure-codes], or otherwise an empty object
-to accept the payment.
+
+The plugin can return an empty `result` to allow the payment; if it
+returns an `error` then it will be failed using the generic
+`incorrect_or_unknown_payment_details`.  This can be overridden by
+specifying the `failure_code` field in the `error`'s `data` object.
+See valid failure codes as defined for final nodes in [BOLT
+4][bolt4-failure-codes].
 
 [jsonrpc-spec]: https://www.jsonrpc.org/specification
 [jsonrpc-notification-spec]: https://www.jsonrpc.org/specification#notification

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -705,6 +705,12 @@ peer_connected_hook_cb(struct peer_connected_hook_payload *payload,
 			      "hook: %s", buffer);
 		}
 
+		/* FIXME: For 0.7.0, hook had nested results! */
+#ifdef COMPAT_V070
+		if (json_get_member(buffer, resulttok, "result"))
+			resulttok = json_get_member(buffer, resulttok, "result");
+#endif /* COMPAT_V070 */
+
 		if (json_tok_streq(buffer, resulttok, "disconnect")) {
 			close(peer_fd);
 			tal_free(payload);

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -39,9 +39,6 @@ bool plugin_hook_register(struct plugin *plugin, const char *method)
 	return true;
 }
 
-/* FIXME(cdecker): Remove dummy hook, once we have a real one */
-REGISTER_PLUGIN_HOOK(hello, NULL, void *, NULL, void *, NULL, void *);
-
 /**
  * Callback to be passed to the jsonrpc_request.
  *
@@ -53,9 +50,8 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 				 struct plugin_hook_request *r)
 {
 	const jsmntok_t *resulttok = json_get_member(buffer, toks, "result");
-	void *response = r->hook->deserialize_response(r, buffer, resulttok);
 	db_begin_transaction(r->db);
-	r->hook->response_cb(r->cb_arg, response);
+	r->hook->response_cb(r->cb_arg, buffer, resulttok);
 	db_commit_transaction(r->db);
 	tal_free(r);
 }
@@ -87,7 +83,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		 * roundtrip to the serializer and deserializer. If we
 		 * were expecting a default response it should have
 		 * been part of the `cb_arg`. */
-		hook->response_cb(cb_arg, NULL);
+		hook->response_cb(cb_arg, NULL, NULL);
 	}
 }
 
@@ -95,7 +91,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
  * annoying, and to make it clear that it's totally synchronous. */
 
 /* Special synchronous hook for db */
-static struct plugin_hook db_write_hook = { "db_write", NULL, NULL, NULL, NULL };
+static struct plugin_hook db_write_hook = { "db_write", NULL, NULL, NULL };
 AUTODATA(hooks, &db_write_hook);
 
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -49,9 +49,8 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 				 const jsmntok_t *idtok,
 				 struct plugin_hook_request *r)
 {
-	const jsmntok_t *resulttok = json_get_member(buffer, toks, "result");
 	db_begin_transaction(r->db);
-	r->hook->response_cb(r->cb_arg, buffer, resulttok);
+	r->hook->response_cb(r->cb_arg, buffer, toks);
 	db_commit_transaction(r->db);
 	tal_free(r);
 }

--- a/tests/plugins/connected_fail.py
+++ b/tests/plugins/connected_fail.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Simple plugin to test the connected_hook works well with errors.
+
+It can mark some node_ids as rejects and it'll check for each
+connection if it should be disconnected immediately or if it can
+continue.
+
+"""
+
+from lightning import Plugin, PluginError
+
+plugin = Plugin()
+
+
+@plugin.hook('peer_connected')
+def on_connected(peer, plugin):
+    if peer['id'] in plugin.reject_ids:
+        print("{} is disallowed".format(peer['id']))
+        raise PluginError('{} is in reject list, disconnecting'.format(peer['id']))
+
+    print("{} is allowed".format(peer['id']))
+    return {'result': 'continue'}
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    plugin.reject_ids = []
+
+
+@plugin.method('reject')
+def reject(node_id, plugin):
+    """Mark a given node_id as reject for future connections.
+    """
+    print("Rejecting connections from {}".format(node_id))
+    plugin.reject_ids.append(node_id)
+
+
+plugin.run()

--- a/tests/plugins/reject.py
+++ b/tests/plugins/reject.py
@@ -14,6 +14,7 @@ plugin = Plugin()
 
 @plugin.hook('peer_connected')
 def on_connected(peer, plugin):
+    # Note: this is the deprecated method!  Throw PluginError instead
     if peer['id'] in plugin.reject_ids:
         print("{} is in reject list, disconnecting".format(peer['id']))
         return {'result': 'disconnect'}

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -18,9 +18,9 @@ def on_payment(payment, plugin):
     if payment['preimage'].endswith('0'):
         # FIXME: Define this!
         WIRE_TEMPORARY_NODE_FAILURE = 0x2002
-        return {'result': {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}}
+        return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}
 
-    return {'result': {}}
+    return {}
 
 
 plugin.run()

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -4,7 +4,7 @@
 We just refuse to let them pay invoices with preimages divisible by 16.
 """
 
-from lightning import Plugin
+from lightning import Plugin, PluginError
 
 plugin = Plugin()
 
@@ -18,7 +18,8 @@ def on_payment(payment, plugin):
     if payment['preimage'].endswith('0'):
         # FIXME: Define this!
         WIRE_TEMPORARY_NODE_FAILURE = 0x2002
-        return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}
+        raise PluginError("Don't like you!",
+                          data={'failure_code': WIRE_TEMPORARY_NODE_FAILURE})
 
     return {}
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -279,6 +279,11 @@ void json_array_end(struct json_stream *js UNNEEDED)
 /* Generated stub for json_array_start */
 void json_array_start(struct json_stream *js UNNEEDED, const char *fieldname UNNEEDED)
 { fprintf(stderr, "json_array_start called!\n"); abort(); }
+/* Generated stub for json_delve */
+const jsmntok_t *json_delve(const char *buffer UNNEEDED,
+			    const jsmntok_t *tok UNNEEDED,
+			    const char *guide UNNEEDED)
+{ fprintf(stderr, "json_delve called!\n"); abort(); }
 /* Generated stub for json_escaped_string_ */
 struct json_escaped *json_escaped_string_(const tal_t *ctx UNNEEDED,
 					  const void *bytes UNNEEDED, size_t len UNNEEDED)
@@ -306,6 +311,9 @@ const char *json_tok_full(const char *buffer UNNEEDED, const jsmntok_t *t UNNEED
 /* Generated stub for json_tok_full_len */
 int json_tok_full_len(const jsmntok_t *t UNNEEDED)
 { fprintf(stderr, "json_tok_full_len called!\n"); abort(); }
+/* Generated stub for json_tok_is_null */
+bool json_tok_is_null(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
+{ fprintf(stderr, "json_tok_is_null called!\n"); abort(); }
 /* Generated stub for json_tok_streq */
 bool json_tok_streq(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, const char *str UNNEEDED)
 { fprintf(stderr, "json_tok_streq called!\n"); abort(); }


### PR DESCRIPTION
This is how I think it should work: return a JSON RPC error if you want to fail the hook.

I'm not happy with then pylightning changes though: exceptions should be for exceptional events, and I'm not sure that rejecting these hooks counts as an exceptional event (since that's their main purpose!).

But doing otherwise would mean returning an explicit 'result' or 'error' dict, which would be best done by providing helpers to ensure they don't return malformed JSON responses.