### PR TITLE
Plugin API refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
 - JSON API: `listforwards` now includes the time an HTLC was received and when it was resolved. Both are expressed as UNIX timestamps to facilitate parsing (Issue [#2491](https://github.com/ElementsProject/lightning/issues/2491), PR [#2528](https://github.com/ElementsProject/lightning/pull/2528))
 - JSON API: new plugin `invoice_payment` hook for intercepting invoices before they're paid.
+- plugin: the `connected` hook can now send an `error_message` to the rejected peer.
 
 ### Changed
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -268,6 +268,12 @@ gossiped list of known addresses. In particular this means that the port for
 incoming connections is an ephemeral port, that may not be available for
 reconnections.
 
+The returned result must contain a `result` member which is either
+the string `disconnect` or `continue`.  If `disconnect` and
+there's a member `error_message`, that member is sent to the peer
+before disconnection.
+
+
 #### `db_write`
 
 This hook is called whenever a change is about to be committed to the database.

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -141,22 +141,16 @@ static bool hook_gives_failcode(const char *buffer,
 				const jsmntok_t *toks,
 				enum onion_type *failcode)
 {
-	const jsmntok_t *resulttok, *t;
+	const jsmntok_t *t;
 	unsigned int val;
 
 	/* No plugin registered on hook at all? */
 	if (!buffer)
 		return false;
 
-	resulttok = json_get_member(buffer, toks, "result");
-	if (!resulttok)
-		fatal("Invalid invoice_payment_hook response: %.*s",
-		      toks[0].end - toks[1].start, buffer);
-
-	t = json_get_member(buffer, resulttok, "failure_code");
+	t = json_get_member(buffer, toks, "failure_code");
 	if (!t)
 		return false;
-
 
 	if (!json_to_number(buffer, t, &val))
 		fatal("Invalid invoice_payment_hook failure_code: %.*s",

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -706,6 +706,15 @@ peer_connected_hook_cb(struct peer_connected_hook_payload *payload,
 		}
 
 		if (json_tok_streq(buffer, resulttok, "disconnect")) {
+			const jsmntok_t *m = json_get_member(buffer, toks,
+							     "error_message");
+			if (m) {
+				error = towire_errorfmt(tmpctx, NULL,
+							"%.*s",
+							m->end - m->start,
+							buffer + m->start);
+				goto send_error;
+			}
 			close(peer_fd);
 			tal_free(payload);
 			return;

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -39,9 +39,6 @@ bool plugin_hook_register(struct plugin *plugin, const char *method)
 	return true;
 }
 
-/* FIXME(cdecker): Remove dummy hook, once we have a real one */
-REGISTER_PLUGIN_HOOK(hello, NULL, void *, NULL, void *, NULL, void *);
-
 /**
  * Callback to be passed to the jsonrpc_request.
  *
@@ -53,16 +50,14 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 				 struct plugin_hook_request *r)
 {
 	const jsmntok_t *resulttok = json_get_member(buffer, toks, "result");
-	void *response;
 
 	if (!resulttok)
 		fatal("Plugin for %s returned non-result response %.*s",
 		      r->hook->name,
 		      toks->end - toks->start, buffer + toks->end);
 
-	response = r->hook->deserialize_response(r, buffer, resulttok);
 	db_begin_transaction(r->db);
-	r->hook->response_cb(r->cb_arg, response);
+	r->hook->response_cb(r->cb_arg, buffer, resulttok);
 	db_commit_transaction(r->db);
 	tal_free(r);
 }
@@ -94,7 +89,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		 * roundtrip to the serializer and deserializer. If we
 		 * were expecting a default response it should have
 		 * been part of the `cb_arg`. */
-		hook->response_cb(cb_arg, NULL);
+		hook->response_cb(cb_arg, NULL, NULL);
 	}
 }
 
@@ -102,7 +97,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
  * annoying, and to make it clear that it's totally synchronous. */
 
 /* Special synchronous hook for db */
-static struct plugin_hook db_write_hook = { "db_write", NULL, NULL, NULL, NULL };
+static struct plugin_hook db_write_hook = { "db_write", NULL, NULL, NULL };
 AUTODATA(hooks, &db_write_hook);
 
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -53,7 +53,14 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 				 struct plugin_hook_request *r)
 {
 	const jsmntok_t *resulttok = json_get_member(buffer, toks, "result");
-	void *response = r->hook->deserialize_response(r, buffer, resulttok);
+	void *response;
+
+	if (!resulttok)
+		fatal("Plugin for %s returned non-result response %.*s",
+		      r->hook->name,
+		      toks->end - toks->start, buffer + toks->end);
+
+	response = r->hook->deserialize_response(r, buffer, resulttok);
 	db_begin_transaction(r->db);
 	r->hook->response_cb(r->cb_arg, response);
 	db_commit_transaction(r->db);

--- a/tests/plugins/reject.py
+++ b/tests/plugins/reject.py
@@ -16,7 +16,7 @@ plugin = Plugin()
 def on_connected(peer, plugin):
     if peer['id'] in plugin.reject_ids:
         print("{} is in reject list, disconnecting".format(peer['id']))
-        return {'result': 'disconnect'}
+        return {'result': 'disconnect', 'error_message': 'You are in reject list'}
 
     print("{} is allowed".format(peer['id']))
     return {'result': 'continue'}

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -18,9 +18,9 @@ def on_payment(payment, plugin):
     if payment['preimage'].endswith('0'):
         # FIXME: Define this!
         WIRE_TEMPORARY_NODE_FAILURE = 0x2002
-        return {'result': {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}}
+        return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}
 
-    return {'result': {}}
+    return {}
 
 
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -164,6 +164,11 @@ def test_plugin_connected_hook(node_factory):
     l3.connect(l1)
     l1.daemon.wait_for_log(r"{} is in reject list".format(l3.info['id']))
 
+    # FIXME: this error occurs *after* connection, so we connect then drop.
+    l3.daemon.wait_for_log(r"lightning_openingd-{} chan #1: peer_in WIRE_ERROR"
+                           .format(l1.info['id']))
+    l3.daemon.wait_for_log(r"You are in reject list")
+
     peer = l1.rpc.listpeers(l3.info['id'])['peers']
     assert(peer == [] or not peer[0]['connected'])
 


### PR DESCRIPTION
This adds some minor functionality, and cleans up my mistake about the invoice API.

I this the simplification of removing the deserialization step is worthwhile, and I included it because my new fundchannel hook assumes it, but I remove that part if you really dislike it.