### PR TITLE
lightningd: don't abort if funding locks in during shutdown.

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -70,6 +70,14 @@ static void lockin_complete(struct channel *channel)
 	assert(channel->scid);
 	/* We set this once they're locked in. */
 	assert(channel->remote_funding_locked);
+
+	/* We might have already started shutting down */
+	if (channel->state != CHANNELD_AWAITING_LOCKIN) {
+		log_debug(channel->log, "Lockin complete, but state %s",
+			  channel_state_name(channel));
+		return;
+	}
+
 	channel_set_state(channel, CHANNELD_AWAITING_LOCKIN, CHANNELD_NORMAL);
 
 	/* Fees might have changed (and we use IMMEDIATE once we're funded),


### PR DESCRIPTION
For me this happened only under valgrind with
test_option_upfront_shutdown_script (in a pending branch):

==5063==    by 0x51FC076: raise (raise.c:48)
==5063==    by 0x51DD534: abort (abort.c:79)
==5063==    by 0x1292D2: fatal (log.c:647)
==5063==    by 0x116570: channel_set_state (channel.c:340)
==5063==    by 0x116E04: lockin_complete (channel_control.c:73)
==5063==    by 0x116F15: peer_got_funding_locked (channel_control.c:108)
==5063==    by 0x117354: channel_msg (channel_control.c:208)

No CHANGELOG: this was introduced in a recent refactor.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>