### PR TITLE
lightningd: make sure we correctly clear connections from connectd on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ changes.
 - lightning-cli: arguments containing `"` now succeed, rather than causing JSON errors.
 - protocol: handle lnd sending more messages before `reestablish`; don't fail channel, and handle older lnd's spurious empty commitments.
 - Fixed `fundchannel` crash when we have many UTXOs and we skip unconfirmed ones.
+- lightningd: fixed occasional hang on `connect` when peer had sent error.
 
 ### Security
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -388,8 +388,6 @@ void channel_errmsg(struct channel *channel,
 					     err_for_them,
 					     tal_count(err_for_them), 0);
 
-	/* Make sure channel_fail_permanent doesn't tell connectd we died! */
-	channel->connected = false;
 	notify_disconnect(channel->peer->ld, &channel->peer->id);
 
 	/* BOLT #1:


### PR DESCRIPTION
Without this, the connect command hangs in one of my branches.  This logic
is from the old days when gossipd handled connections, and we wanted
to make sure it didn't hang up on this client due to the error.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>