### PR TITLE
channeld: give some tolerance for empty commitments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ changes.
 - `--bind-addr=<path>` fixed for nodes using local sockets (eg. testing).
 - Unannounced local channels were forgotten for routing on restart until reconnection occurred.
 - lightning-cli: arguments containing `"` now succeed, rather than causing JSON errors.
-- protocol: handle lnd sending more messages before `reestablish`; don't fail channel.
+- protocol: handle lnd sending more messages before `reestablish`; don't fail channel, and handle older lnd's spurious empty commitments.
 
 ### Security
 


### PR DESCRIPTION
The spec says not to send a commitment_signed without any changes, but LND does this.  To understand why, you have to understand how LND works.  I haven't read the code, but I'm pretty sure it works like this:

1. lnd slows down to do garbage collection, because it's in Go.
2. When an alert timer goes off, noticing it's not making process, it sends a twitter message to @roasbeef.
3. @roasbeef sshs into the user's machine and binary patches lnd to send a commitment_signed message.
4. Unfortunately he works so fast that various laws of causality are broken, meaning sometimes the commitment_signed is sent before any of these other things happen.

I'm fairly sure that this will stop as @roasbeef ages, or lnd introduces some kind of causality enforcement fix.