### PR TITLE
fix: changelog included setchannelfee for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- JSON API: New command `setchannelfee` sets channel specific routing fees.
 - JSON API: `newaddr` outputs `bech32` or `p2sh-segwit`, or both with new `all` parameter (#2390)
 - JSON API: `listpeers` status now shows how many confirmations until channel is open (#2405)
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
@@ -73,7 +74,6 @@ This release named by Mark Beckwith @wythe.
 - JSON API: `listpayments` is now `listsendpays`.
 - lightning-cli: `help <cmd>` finds man pages even if `make install` not run.
 - pylightning: New class 'Millisatoshi' can be used for JSON API, and new '_msat' fields are turned into this on reading.
-- JSON API: New command `setchannelfee` sets channel specific routing fees.
 
 ### Changed
 


### PR DESCRIPTION
I dont know why this got messed up in the release process,
but `setchannelfee` ist actually scheduled for 0.7.1 and
not contained in 0.7.0.