### PR TITLE
JSON: Add a 'getbalance' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
 - JSON API: `listforwards` now includes the time an HTLC was received and when it was resolved. Both are expressed as UNIX timestamps to facilitate parsing (Issue [#2491](https://github.com/ElementsProject/lightning/issues/2491), PR [#2528](https://github.com/ElementsProject/lightning/pull/2528))
 - JSON API: new plugin `invoice_payment` hook for intercepting invoices before they're paid.
+- JSON API: new command getbalance to efficiently get the total funds managed by C-Lightning.
 
 ### Changed
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -670,3 +670,9 @@ class LightningRpc(UnixDomainSocketRpc):
             "slow": slow
         }
         return self.call("feerates", payload)
+
+    def getbalance(self):
+        """
+        Returns the total balance on chain and on channels
+        """
+        return self.call("getbalance")

--- a/doc/lightning-getbalance.7
+++ b/doc/lightning-getbalance.7
@@ -1,0 +1,60 @@
+'\" t
+.\"     Title: lightning-getbalance
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/17/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-GETBALANCE" "7" "04/17/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-getbalance \- Command showing the total wallet balance\&.
+.SH "SYNOPSIS"
+.sp
+\fBgetbalance\fR
+.SH "DESCRIPTION"
+.sp
+The \fBgetbalance\fR RPC command displays the total funds either on chain or locked on channels\&.
+.SH "RETURN VALUE"
+.sp
+On success an object will be returned with four entries :
+.sp
+{
+    "on_chain" \- The sum of all the wallet utxos, in satoshis\&.
+    "on_chain_msat" \- The sum of all the wallet utxos, in milli satoshis\&.
+    "on_channels" \- The sum of all our satoshis locked in channels, in satoshis\&.
+    "on_channels_msat" \- The sum of all our satoshis locked in channels, in milli satoshis (rounded)\&.
+    "total" \- The sum of on chain and on channels funds, in satoshis.
+    "total_msat" \- The sum of on chain and on channels funds, in milli satoshis.
+
+}
+.sp
+.SH "AUTHOR"
+.sp
+Darosior <darosior@protonmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-listfunds(7), lightning\-newaddr(7), lightning\-fundchannel(7), lightning\-withdraw(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-getbalance.7.txt
+++ b/doc/lightning-getbalance.7.txt
@@ -1,0 +1,43 @@
+LIGHTNING-GETBALANCE(7)
+======================
+:doctype: manpage
+
+NAME
+----
+lightning-getbalance - Command showing the total wallet balance.
+
+SYNOPSIS
+--------
+*getbalance*
+
+DESCRIPTION
+-----------
+The *getbalance* RPC command displays the total funds either on chain or locked on channels.
+
+RETURN VALUE
+------------
+On success an object will be returned with six entries :
+
+- 'on_chain' - The sum of all the wallet utxos, in satoshis.
+
+- 'on_chain_msat' - The sum of all the wallet utxos, in milli satoshis.
+
+- 'on_channels' - The sum of all our satoshis locked in channels, in satoshis.
+
+- 'on_channels_msat' - The sum of all our satoshis locked in channels, in milli satoshis (rounded).
+
+- 'total' - The sum of on chain and on channels funds, in satoshis.
+
+- 'total_msat' - The sum of on chain and on channels funds, in milli satoshis.
+
+AUTHOR
+------
+Darosior <darosior@protonmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-listfunds(7), lightning-newaddr(7), lightning-fundchannel(7), lightning-withdraw(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1284,3 +1284,18 @@ def test_newaddr(node_factory):
     both = l1.rpc.newaddr('all')
     assert both['p2sh-segwit'].startswith('2')
     assert both['bech32'].startswith('bcrt1')
+
+
+def test_getbalance(node_factory):
+    l1, l2 = node_factory.line_graph(2)
+    balance = l1.rpc.getbalance()
+    funds = l1.rpc.listfunds()
+    outputs_value = 0
+    for i in funds["outputs"]:
+        outputs_value += i["value"]
+    channels_sat = 0
+    for i in funds["channels"]:
+        channels_sat += int(i["our_amount_msat"]) // 1000
+    assert balance["on_chain"] == outputs_value
+    assert balance["on_channels"] == channels_sat
+    assert balance["total"] == outputs_value + channels_sat


### PR DESCRIPTION
This PR adds the `getbalance` command to the JSON-RPC interface (along with a manpage and a test).

Why ?
- There is not any concise command to get the total funds managed by C-Lightning
- The only possibility is `listfunds` which you have to parse (or to `less` to at least see utxos)
- It is convenient for bitcoin-core users (same name)