### PR TITLE
wallet: fix crash when we have height requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ changes.
 - Unannounced local channels were forgotten for routing on restart until reconnection occurred.
 - lightning-cli: arguments containing `"` now succeed, rather than causing JSON errors.
 - protocol: handle lnd sending more messages before `reestablish`; don't fail channel, and handle older lnd's spurious empty commitments.
+- Fixed `fundchannel` crash when we have many UTXOs and we skip unconfirmed ones.
 
 ### Security
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -331,13 +331,13 @@ static const struct utxo **wallet_select(const tal_t *ctx, struct wallet *w,
 
 		weight += input_weight;
 
-		if (!amount_sat_add(satoshi_in, *satoshi_in, utxos[i]->amount))
+		if (!amount_sat_add(satoshi_in, *satoshi_in, u->amount))
 			fatal("Overflow in available satoshis %zu/%zu %s + %s",
 			      i, tal_count(available),
 			      type_to_string(tmpctx, struct amount_sat,
 					     satoshi_in),
 			      type_to_string(tmpctx, struct amount_sat,
-					     &utxos[i]->amount));
+					     &u->amount));
 
 		*fee_estimate = amount_tx_fee(feerate_per_kw, weight);
 		if (!amount_sat_add(&needed, sat, *fee_estimate))


### PR DESCRIPTION
68fe5eacdecdf4eae94b376b7c4d4fd954c55a36 introduced a skip in the iteration
of the available funds, which means utxos[i] may be off the end of utxos.

Reported-and-debugged-by: @nitramiz
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>