### PR TITLE
pylightning: Fixing incompatibility issue with Python 2.7

### DIFF
--- a/contrib/pylightning/setup.py
+++ b/contrib/pylightning/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
 import lightning
+import io
 
 
-with open('README.md', encoding='utf-8') as f:
+with io.open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pylightning',


### PR DESCRIPTION
Hi!
I didn't understand if this is the home for pylightning, but here's a quick fix for making pylightning work with Python 2.7. It seems to be a regression from 0.0.7.

Attempting to install pylightning==0.0.7 with Python 2.7 will end up with the following error:

```
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    with open('README.md', encoding='utf-8') as f:
TypeError: 'encoding' is an invalid keyword argument for this function
```

The reason for the error is that the global scope open doesn't have the `encoding` argument in Python 2.7. The solution is to import the `open` function from the `io` package, which makes the script compatible with both Python 2 and 3.

This fix makes the installation of https://github.com/marzig76/fulmo less of a hassle.

Cheers