### PR TITLE
update libwally to latest version 0.6.9

### DIFF
--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -345,8 +345,7 @@ int main(void)
 	const struct chainparams *chainparams = chainparams_for_network("bitcoin");
 
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 
 	feerate_per_kw = tal_arr(tmpctx, u32, NUM_SIDES);

--- a/common/daemon.c
+++ b/common/daemon.c
@@ -149,8 +149,7 @@ void daemon_setup(const char *argv0,
 	/* We handle write returning errors! */
 	signal(SIGPIPE, SIG_IGN);
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 
 	setup_tmpctx();
 	io_poll_override(daemon_poll);

--- a/common/test/run-bolt11.c
+++ b/common/test/run-bolt11.c
@@ -130,8 +130,7 @@ int main(void)
 	const char *badstr;
 
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 
 	/* BOLT #11:

--- a/common/test/run-derive_basepoints.c
+++ b/common/test/run-derive_basepoints.c
@@ -55,8 +55,7 @@ int main(void)
 	struct info *baseline, *info;
 
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 	baseline = new_info(ctx);
 	assert(derive_basepoints(&baseline->seed, &baseline->funding_pubkey,
 				 &baseline->basepoints,

--- a/common/test/run-features.c
+++ b/common/test/run-features.c
@@ -15,8 +15,7 @@ int main(void)
 
 	setup_locale();
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 	setup_tmpctx();
 
 	bits = tal_arr(tmpctx, u8, 0);

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1187,8 +1187,7 @@ int main(void)
 
 	setup_tmpctx();
 	wally_init(0);
-	/* FIXME: https://github.com/ElementsProject/libwally-core/issues/95 */
-	secp256k1_ctx = (secp256k1_context *)wally_get_secp_context();
+	secp256k1_ctx = wally_get_secp_context();
 	ld = tal(tmpctx, struct lightningd);
 	ld->config = test_config;
 


### PR DESCRIPTION
Also removes a workaround caused by bug in libwally (!95) which has
been fixed.

Signed-off-by: Lawrence Nahum <lawrence@greenaddress.it>