### PR TITLE
check: Run `check-manpages` in /tmp/ instead of the user config

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -71,7 +71,7 @@ check: check-manpages
 
 check-manpages: cli/lightning-cli lightningd/lightningd
 	@tools/check-manpage.sh cli/lightning-cli doc/lightning-cli.1.txt
-	@tools/check-manpage.sh lightningd/lightningd doc/lightningd-config.5.txt
+	@tools/check-manpage.sh "lightningd/lightningd --lightning-dir=/tmp/" doc/lightningd-config.5.txt
 
 doc-maintainer-clean:
 	$(RM) doc/deployable-lightning.pdf


### PR DESCRIPTION
If we have plugins configured in the default config location, then
`check-manpages` may fail due to plugin cli options being added to the
`--help` output.