### PR TITLE
Fix bockheight underflow if `minconf` > `blockheight`

### DIFF
--- a/common/wallet_tx.h
+++ b/common/wallet_tx.h
@@ -38,6 +38,12 @@ static inline u32 minconf_to_maxheight(u32 minconf, struct lightningd *ld)
 	 * selection */
 	if (minconf == 0)
 		return 0;
+
+	/* Avoid wrapping around and suddenly allowing any confirmed
+	 * outputs. Since we can't have a coinbase output, and 0 is taken for
+	 * the disable case, we can just clamp to 1. */
+	if (minconf >= ld->topology->tip->height)
+		return 1;
 	return ld->topology->tip->height - minconf + 1;
 }
 #endif /* LIGHTNING_COMMON_WALLET_TX_H */

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -482,7 +482,7 @@ def test_withdraw(node_factory, bitcoind):
     with pytest.raises(RpcError, match=r'Cannot afford transaction'):
         l1.rpc.withdraw(waddr, 'all')
 
-@pytest.mark.xfail(strict=True)
+
 def test_minconf_withdraw(node_factory, bitcoind):
     """Issue 2518: ensure that ridiculous confirmation levels don't overflow
 


### PR DESCRIPTION
We are computing a `maxheight` that coins must have to be considered for coin selection by subtracting the current `minconf` parameter from the current `blockheight`. If the `minconf` parameter is larger than `blockheight` we were wrapping around and suddenly accepting all transactions with at least one confirmation.

We now clamp the `maxheight` requirement to `1` (since `0` is used to indicate no confirmations required), which is safe since we can't end up having an output at that height, resulting in us not selecting any coins which is desired in this case.

Fixes #2518 