### PR TITLE
fix: pylightning msat round multiply and division

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -113,10 +113,10 @@ class Millisatoshi:
         return Millisatoshi(int(self) - int(other))
 
     def __mul__(self, other):
-        return Millisatoshi(int(self) * other)
+        return Millisatoshi(int(int(self) * other))
 
     def __truediv__(self, other):
-        return Millisatoshi(int(self) / other)
+        return Millisatoshi(int(int(self) / other))
 
     def __floordiv__(self, other):
         return Millisatoshi(int(self) // other)


### PR DESCRIPTION
Currently, when a multiplication operator is invoked that
does not result in an even integer result but a floating result,
the pylightning code will raise an exception:

Millisatoshi must be string with msat/sat/btc suffix or int

This is because the internal float result will be used as
contructor argument like this:  return Millisatoshi(10000.5)

This happens especially on fee calculations where small uneven amounts
are calculated.