### PR TITLE
gossipd: fix crash if we truncate store.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -550,13 +550,13 @@ void gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 
 truncate:
 	status_unusual("gossip_store: %s (%s) truncating to %"PRIu64,
-		       bad, tal_hex(msg, msg), (u64)1);
+		       bad, tal_hex(msg, msg), gs->len);
 truncate_nomsg:
 	/* FIXME: We would like to truncate to known_good, except we would
 	 * miss channel_delete msgs.  If we put block numbers into the store
 	 * as we process them, we can know how far we need to roll back if we
 	 * truncate the store */
-	if (ftruncate(gs->fd, 1) != 0)
+	if (ftruncate(gs->fd, gs->len) != 0)
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Truncating store: %s", strerror(errno));
 out:


### PR DESCRIPTION
Entries we've already loaded expect to exist in the store.  We could go back and remove them all, but instead just truncate at the known-good point.

Fixes  #2583