### PR TITLE
gossipd: don't spam with update messages.

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1979,7 +1979,7 @@ u8 *handle_channel_update(struct routing_state *rstate, const u8 *update TAKES,
 		return err;
 	}
 
-	status_trace("Received channel_update for channel %s/%d now %s (from %s)",
+	SUPERVERBOSE("Received channel_update for channel %s/%d now %s (from %s)",
 		     type_to_string(tmpctx, struct short_channel_id,
 				    &short_channel_id),
 		     channel_flags & 0x01,


### PR DESCRIPTION
On my node, this queues over 1M messages to lightningd, and that's with only 10 peers,
nailing the CPU for quite a while.

That could be fixed by making our queue scale, but we shouldn't be hitting this!