### PR TITLE
Fix the description string of CHECK_MSG in run_wallet

### DIFF
--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -992,7 +992,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK_MSG(c2 = wallet_channel_load(w, c1.dbid), tal_fmt(w, "Load from DB"));
 	CHECK_MSG(!wallet_err,
 		  tal_fmt(w, "Load from DB: %s", wallet_err));
-	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v6)");
+	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v3)");
 	tal_free(c2);
 
 	/* Variant 4: update and add remote_shutdown_scriptpubkey */
@@ -1002,7 +1002,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK_MSG(c2 = wallet_channel_load(w, c1.dbid), tal_fmt(w, "Load from DB"));
 	CHECK_MSG(!wallet_err,
 		  tal_fmt(w, "Load from DB: %s", wallet_err));
-	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v8)");
+	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v4)");
 	tal_free(c2);
 
 	db_commit_transaction(w->db);

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -976,7 +976,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 		  tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(c2 = wallet_channel_load(w, c1.dbid), tal_fmt(w, "Load from DB"));
 	CHECK_MSG(!wallet_err,
-		  tal_fmt(w, "Insert into DB: %s", wallet_err));
+		  tal_fmt(w, "Load from DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v2)");
 	tal_free(c2);
 
@@ -991,7 +991,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(c2 = wallet_channel_load(w, c1.dbid), tal_fmt(w, "Load from DB"));
 	CHECK_MSG(!wallet_err,
-		  tal_fmt(w, "Insert into DB: %s", wallet_err));
+		  tal_fmt(w, "Load from DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v6)");
 	tal_free(c2);
 
@@ -1001,7 +1001,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 	CHECK_MSG(!wallet_err, tal_fmt(w, "Insert into DB: %s", wallet_err));
 	CHECK_MSG(c2 = wallet_channel_load(w, c1.dbid), tal_fmt(w, "Load from DB"));
 	CHECK_MSG(!wallet_err,
-		  tal_fmt(w, "Insert into DB: %s", wallet_err));
+		  tal_fmt(w, "Load from DB: %s", wallet_err));
 	CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v8)");
 	tal_free(c2);
 


### PR DESCRIPTION
1. Fix the the description string of `CHECK_MSG` after loading the channel from DB. It should indicate the "`Load from DB`" step;

2. I think the `v6` and `v8` in
```
    CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v6)");
    CHECK_MSG(channelseq(&c1, c2), "Compare loaded with saved (v8)");
```
mean` variant 6` and `variant 8`. They should be `v3` and `v4`.