### PR TITLE
DB: Store the signatures of channel announcement sent from remote peer into DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Protocol: we now enforce `option_upfront_shutdown_script` if a peer negotiates it.
 - JSON API: `listforwards` now includes the local_failed forwards with failcode (Issue [#2435](https://github.com/ElementsProject/lightning/issues/2435), PR [#2524](https://github.com/ElementsProject/lightning/pull/2524))
 - Config: Added a default plugin directory : `lightning_dir/plugins`. Each plugin directory it contains will be added to lightningd on startup.
+- DB: Store the signatures of channel announcement sent from remote peer into DB, and init channel with signatures from DB directly when reenable the channel.
+(Issue [#2409](https://github.com/ElementsProject/lightning/issues/2409))
 
 ### Changed
 

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -64,6 +64,8 @@ channel_init,,lflen,u16
 channel_init,,localfeatures,lflen*u8
 channel_init,,upfront_shutdown_script_len,u16
 channel_init,,upfront_shutdown_script,upfront_shutdown_script_len*u8
+channel_init,,remote_ann_node_sig,?secp256k1_ecdsa_signature
+channel_init,,remote_ann_bitcoin_sig,?secp256k1_ecdsa_signature
 
 # master->channeld funding hit new depth(funding locked if >= lock depth)
 channel_funding_depth,1002

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -185,3 +185,8 @@ channel_fail_fallen_behind,,remote_per_commitment_point,struct pubkey
 channel_specific_feerates,1029
 channel_specific_feerates,,feerate_base,u32
 channel_specific_feerates,,feerate_ppm,u32
+
+# When we receive announcement_signatures for channel announce
+channel_got_announcement,1017
+channel_got_announcement,,remote_ann_node_sig,secp256k1_ecdsa_signature
+channel_got_announcement,,remote_ann_bitcoin_sig,secp256k1_ecdsa_signature

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -382,6 +382,9 @@ static struct migration dbmigrations[] = {
 	{ "ALTER TABLE channels ADD remote_upfront_shutdown_script BLOB;", NULL },
 	/* PR #2524: Add failcode into forward_payment */
 	{ "ALTER TABLE forwarded_payments ADD failcode INTEGER;", NULL },
+	/* remote signatures for channel announcement */
+	{ "ALTER TABLE channels ADD remote_ann_node_sig BLOB;", NULL },
+	{ "ALTER TABLE channels ADD remote_ann_bitcoin_sig BLOB;", NULL },
 };
 
 /* Leak tracking. */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -555,6 +555,21 @@ bool wallet_htlcs_load_for_channel(struct wallet *wallet,
 				   struct htlc_in_map *htlcs_in,
 				   struct htlc_out_map *htlcs_out);
 
+/**
+ * wallet_announcement_save - Save remote announcement information with channel.
+ *
+ * @wallet: wallet to load from
+ * @id: channel database id
+ * @remote_ann_node_sig: location to load remote_ann_node_sig to
+ * @remote_ann_bitcoin_sig: location to load remote_ann_bitcoin_sig to
+ *
+ * This function is only used to save REMOTE announcement information into DB
+ * when the channel has set the announce_channel bit and don't send the shutdown
+ * message(BOLT#7).
+ */
+void wallet_announcement_save(struct wallet *wallet, u64 id,
+			      secp256k1_ecdsa_signature *remote_ann_node_sig,
+			      secp256k1_ecdsa_signature *remote_ann_bitcoin_sig);
 
 /* /!\ This is a DB ENUM, please do not change the numbering of any
  * already defined elements (adding is ok) /!\ */
@@ -1052,4 +1067,17 @@ struct amount_msat wallet_total_forward_fees(struct wallet *w);
  */
 const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
 						       const tal_t *ctx);
+
+/**
+ * Load remote_ann_node_sig and remote_ann_bitcoin_sig
+ *
+ * @ctx: allocation context for the return value
+ * @w: wallet containing the channel
+ * @id: channel database id
+ * @remote_ann_node_sig: location to load remote_ann_node_sig to
+ * @remote_ann_bitcoin_sig: location to load remote_ann_bitcoin_sig to
+ */
+bool wallet_remote_ann_sigs_load(const tal_t *ctx, struct wallet *w, u64 id,
+				 secp256k1_ecdsa_signature **remote_ann_node_sig,
+				 secp256k1_ecdsa_signature **remote_ann_bitcoin_sig);
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
Fixes #2409 
Here I add a new wire type:
**channel_got_announcement (1017)**

When Channeld receives the remote channel announcement signatures, it will generate a msg1 like:
**WIRE_CHANNEL_GOT_ANNOUNCEMENT + remote_ann_node_sig + remote_ann_bitcoin_sig**
and send this msg to Master. (After sending signatures, Channeld will be holding until receive the reply from Master.)
Master resolves msg and stores the signatures into DB. 

Like issue #2409 , the adventage is when we reenable our channel, you can init it with the remote announcement signatures from DB directly other than wasting your time to wait for remote peer's announce reply.