### PR TITLE
fix: pylightning to_btc_str precision

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -81,9 +81,9 @@ class Millisatoshi:
         Return a string of form 12.34567890btc or 12.34567890123btc.
         """
         if self.millisatoshis % 1000:
-            return '{:.8f}btc'.format(self.to_btc())
-        else:
             return '{:.11f}btc'.format(self.to_btc())
+        else:
+            return '{:.8f}btc'.format(self.to_btc())
 
     def to_json(self):
         return self.__repr__()


### PR DESCRIPTION
The old codes if % 1000 statement logic was simply inverted
and produced the opposite output of the intention behind it.

Before Fix:
 - `Millisatoshi('42sat').to_btc_str()` => `0.00000042000btc`
 - `Millisatoshi('42001msat').to_btc_str()` => `0.00000042btc`

After  Fix:
 - `Millisatoshi('42sat').to_btc_str()` => `0.00000042btc`
 - `Millisatoshi('42001msat').to_btc_str()` => `0.00000042001btc`