### PR TITLE
pytest: fix test_bech32_funding

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -290,6 +290,7 @@ class BitcoinD(TailableProc):
             '-server',
             '-logtimestamps',
             '-nolisten',
+            '-txindex',
         ]
         # For up to and including 0.16.1, this needs to be in main section.
         BITCOIND_CONFIG['rpcport'] = rpcport


### PR DESCRIPTION
We try to look up the funding tx, but it's already spent that to fund
the channel, so we need txindex if this test is to work reliably.

It's not clear to me why this *ever* worked, but if fails on my new
ThreadRipper build machine with valgrind:

  >	wallettx = l1.bitcoin.rpc.getrawtransaction(wallettxid, True)
...
  E           bitcoin.rpc.InvalidAddressOrKeyError: {'code': -5, 'message': 'No such mempool transaction. Use -txindex to enable blockchain transaction queries. Use gettransaction for wallet transactions.'}

  /usr/lib/python3/dist-packages/bitcoin/rpc.py:231: InvalidAddressOrKeyError
 
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>