### PR TITLE
openingd: fix hangup when gossipd compacts.

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1348,6 +1348,11 @@ static void handle_gossip_in(struct state *state)
 		status_failed(STATUS_FAIL_GOSSIP_IO,
 			      "Reading gossip: %s", strerror(errno));
 
+	if (fromwire_gossipd_new_store_fd(msg)) {
+		tal_free(msg);
+		new_gossip_store(GOSSIP_STORE_FD, fdpass_recv(GOSSIP_FD));
+		return;
+	}
 	handle_gossip_msg(PEER_FD, GOSSIP_STORE_FD, &state->cs, take(msg));
 }
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1080,3 +1080,18 @@ def test_gossip_store_private_channels(node_factory, bitcoind):
     # We should still see local channels!
     chans = l1.rpc.listchannels()['channels']
     assert len(chans) == 2
+
+
+@unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
+def test_gossip_store_compact(node_factory, bitcoind):
+    l1, l2, l3 = node_factory.line_graph(3, fundchannel=False)
+
+    # Create channel.
+    l2.fund_channel(l3, 10**6)
+
+    # Now compact store.
+    l2.rpc.call('dev-compact-gossip-store')
+
+    # Should still be connected.
+    time.sleep(1)
+    assert len(l2.rpc.listpeers()['peers']) == 2


### PR DESCRIPTION
My raspberry pi node hung up on my other node:
   lightning_openingd-... chan #1: Got bad message from gossipd: 0db1

This is because we didn't handle that message in one path.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>