### PR TITLE
wallet: cleanup the tal context paramater in two functions

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1178,7 +1178,7 @@ void load_channels_from_wallet(struct lightningd *ld)
 	struct peer *peer;
 
 	/* Load peers from database */
-	if (!wallet_channels_load_active(ld, ld->wallet))
+	if (!wallet_channels_load_active(ld->wallet))
 		fatal("Could not load channels from the database");
 
 	/* This is a poor-man's db join :( */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -465,7 +465,7 @@ void wallet_channel_delete(struct wallet *w UNNEEDED, u64 wallet_id UNNEEDED)
 void wallet_channel_save(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED)
 { fprintf(stderr, "wallet_channel_save called!\n"); abort(); }
 /* Generated stub for wallet_channels_load_active */
-bool wallet_channels_load_active(const tal_t *ctx UNNEEDED, struct wallet *w UNNEEDED)
+bool wallet_channels_load_active(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_channels_load_active called!\n"); abort(); }
 /* Generated stub for wallet_channel_stats_load */
 void wallet_channel_stats_load(struct wallet *w UNNEEDED, u64 cdbid UNNEEDED, struct channel_stats *stats UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -891,7 +891,7 @@ static struct channel *wallet_channel_load(struct wallet *w, const u64 dbid)
 	struct channel *channel;
 
 	/* We expect only one peer, but reuse same code */
-	if (!wallet_channels_load_active(w, w))
+	if (!wallet_channels_load_active(w))
 		return NULL;
 	peer = list_top(&w->ld->peers, struct peer, list);
 	CHECK(peer);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -598,7 +598,7 @@ wallet_htlc_sigs_load(const tal_t *ctx, struct wallet *w, u64 channelid)
 /**
  * wallet_stmt2channel - Helper to populate a wallet_channel from a sqlite3_stmt
  */
-static struct channel *wallet_stmt2channel(const tal_t *ctx, struct wallet *w, sqlite3_stmt *stmt)
+static struct channel *wallet_stmt2channel(struct wallet *w, sqlite3_stmt *stmt)
 {
 	bool ok = true;
 	struct channel_info channel_info;
@@ -767,7 +767,7 @@ static const char *channel_fields =
     /*41*/ "last_sent_commit, "
     /*42*/ "feerate_base, feerate_ppm, remote_upfront_shutdown_script";
 
-bool wallet_channels_load_active(const tal_t *ctx, struct wallet *w)
+bool wallet_channels_load_active(struct wallet *w)
 {
 	bool ok = true;
 	sqlite3_stmt *stmt;
@@ -779,7 +779,7 @@ bool wallet_channels_load_active(const tal_t *ctx, struct wallet *w)
 
 	int count = 0;
 	while (db_select_step(w->db, stmt)) {
-		struct channel *c = wallet_stmt2channel(ctx, w, stmt);
+		struct channel *c = wallet_stmt2channel(w, stmt);
 		if (!c) {
 			ok = false;
 			db_stmt_done(stmt);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -435,13 +435,12 @@ bool wallet_channel_config_load(struct wallet *w, const u64 id,
 /**
  * wlalet_channels_load_active -- Load persisted active channels into the peers
  *
- * @ctx: context to allocate peers from
  * @w: wallet to load from
  *
  * Be sure to call this only once on startup since it'll append peers
  * loaded from the database to the list without checking.
  */
-bool wallet_channels_load_active(const tal_t *ctx, struct wallet *w);
+bool wallet_channels_load_active(struct wallet *w);
 
 /**
  * wallet_channel_stats_incr_* - Increase channel statistics.


### PR DESCRIPTION
The paramater `ctx` in `wallet_channels_load_active()` and `wallet_stmt2channel()` is unused.

I guess the original idea is to `tal` channels on the `ctx`(In fact, we'd like to set `ctx` as `ld`).

But we already `tal` channels on `ld` when `new_channel()` is called in `wallet_stmt2channel()`, so the paramater `ctx` is unused and repeated.