### PR TITLE
systemd: wait until network is up

### DIFF
--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -11,6 +11,7 @@
 Description=C-Lightning daemon
 Requires=bitcoind.service
 After=bitcoind.service
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/lightningd --daemon --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid


### PR DESCRIPTION
Prevents error when launching with bind-addr.