### PR TITLE
Fix bash completion

### DIFF
--- a/contrib/lightning-cli.bash-completion
+++ b/contrib/lightning-cli.bash-completion
@@ -31,7 +31,7 @@ _lightning_cli() {
 
             # get the regular commands
             if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
-		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^command=//p')
+		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^[a-z]/&/p' | sed '$ d')
             fi
 
             COMPREPLY=( $( compgen -W "$helpopts $globalcmds" -X "*," -- "$cur" ) )

--- a/contrib/lightning-cli.bash-completion
+++ b/contrib/lightning-cli.bash-completion
@@ -25,13 +25,13 @@ _lightning_cli() {
 
             # get the global options, starting with --
             if [[ -z "$cur" || "$cur" =~ ^- ]]; then
-                globalcmds=$($lightning_cli --help 2>&1 | awk '$1 ~ /^-/ { sub(/,/, ""); print $1}')
+                globalcmds=$($lightning_cli --help 2>&1 | tr '|' '\n' | sed -n -e 's/ .*//' -e 's/\(-[-a-z0-9A-Z]*\).*/\1/p')
             fi
 
 
             # get the regular commands
             if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
-		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^[a-z]/&/p' | sed '$ d')
+		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^\([a-z][a-z-]*\).*/\1/p' | sed '$ d')
             fi
 
             COMPREPLY=( $( compgen -W "$helpopts $globalcmds" -X "*," -- "$cur" ) )


### PR DESCRIPTION
The regex `^command=` is no longer valid to get the command list from the output of `lightning-cli -H help 2>/dev/null`