### PR TITLE
Plugins: add a default 'plugins' directory in the config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugin: the `connected` hook can now send an `error_message` to the rejected peer.
 - Protocol: we now enforce `option_upfront_shutdown_script` if a peer negotiates it.
 - JSON API: `listforwards` now includes the local_failed forwards with failcode (Issue [#2435](https://github.com/ElementsProject/lightning/issues/2435), PR [#2524](https://github.com/ElementsProject/lightning/pull/2524))
+- Config: Added a default plugin directory : `lightning_dir/plugins`. Each plugin directory it contains will be added to lightningd on startup.
 
 ### Changed
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -31,6 +31,12 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
 			    struct lightningd *ld);
 
 /**
+ * Search for `default_dir`, and if it exists add every directory it
+ * contains as a plugin dir.
+ */
+void plugins_add_default_dir(struct plugins *plugins, const char *default_dir);
+
+/**
  * Initialize the registered plugins.
  *
  * Initialization includes spinning up the plugins, reading their


### PR DESCRIPTION
Having a `plugins` directory in the configuration path can be very handy instead of manually adding `--plugin-dir=` or `--plugin=`, and it's easier to have it in the configuration directory than in the installation one.

This PR adds a function that will, if it exists, iterate through `<path_to_config_dir>/plugins` and add, without failing on error, each directory it contains as a new `plugin-dir`.

It permits to, for instance :
```shell
git clone https://github.com/lightningd/plugins ~/.lightning/plugins
```
and have (once requirements installed) all the community curated list of plugins available.