### PR TITLE
lightningd: don't log the response of getlog command

### DIFF
--- a/lightningd/json_stream.c
+++ b/lightningd/json_stream.c
@@ -88,6 +88,13 @@ void json_stream_close(struct json_stream *js, struct command *writer)
 	js->writer = NULL;
 }
 
+void json_stream_log_suppress(struct json_stream *js, const char *cmd_name)
+{
+	/* Really shouldn't be used for anything else */
+	assert(streq(cmd_name, "getlog"));
+	js->log = NULL;
+}
+
 /* FIXME: This, or something prettier (io_replan?) belong in ccan/io! */
 static void adjust_io_write(struct io_conn *conn, ptrdiff_t delta)
 {

--- a/lightningd/json_stream.h
+++ b/lightningd/json_stream.h
@@ -46,6 +46,9 @@ struct json_stream *json_stream_dup(const tal_t *ctx, struct json_stream *origin
  */
 void json_stream_close(struct json_stream *js, struct command *writer);
 
+/* For low-level JSON stream access: */
+void json_stream_log_suppress(struct json_stream *js, const char *cmd_name);
+
 /**
  * json_stream_still_writing - is someone currently writing to this stream?
  * @js: the json_stream.

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -515,6 +515,16 @@ struct json_stream *json_stream_raw_for_cmd(struct command *cmd)
 	return js;
 }
 
+void json_stream_log_suppress_for_cmd(struct json_stream *js,
+				     const struct command *cmd)
+{
+	const char *nm = cmd->json_cmd->name;
+	const char *s = tal_fmt(tmpctx, "Suppressing logging of %s command", nm);
+	log_io(cmd->jcon->log, LOG_IO_OUT, s, NULL, 0);
+	json_stream_log_suppress(js, strdup(nm));
+
+}
+
 static struct json_stream *json_start(struct command *cmd)
 {
 	struct json_stream *js = json_stream_raw_for_cmd(cmd);

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -125,6 +125,8 @@ struct command_result *command_still_pending(struct command *cmd)
 
 /* For low-level JSON stream access: */
 struct json_stream *json_stream_raw_for_cmd(struct command *cmd);
+void json_stream_log_suppress_for_cmd(struct json_stream *js,
+					    const struct command *cmd);
 struct command_result *command_raw_complete(struct command *cmd,
 					    struct json_stream *result);
 

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -766,6 +766,8 @@ static struct command_result *json_getlog(struct command *cmd,
 		return command_param_failed();
 
 	response = json_stream_success(cmd);
+	/* Suppress logging for this stream, to not bloat io logs */
+	json_stream_log_suppress_for_cmd(response, cmd);
 	json_object_start(response, NULL);
 	json_add_time(response, "created_at", log_init_time(lr)->ts);
 	json_add_num(response, "bytes_used", (unsigned int) log_used(lr));


### PR DESCRIPTION
Before this, the response of `getlog io` would blow up quickly
when called multiple times.

closes #2467