### PR TITLE
lightningd/plugin.c: Do not call `closedir` with NULL DIR*.

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -910,8 +910,8 @@ void plugins_add_default_dir(struct plugins *plugins, const char *default_dir)
 				continue;
 			add_plugin_dir(plugins, path_join(tmpctx, default_dir, di->d_name), true);
 		}
+		closedir(d);
 	}
-	closedir(d);
 }
 
 void plugins_init(struct plugins *plugins, const char *dev_plugin_debug)


### PR DESCRIPTION
Fixes: #2667

Really-by: @darwin