### PR TITLE
Small fixups

### DIFF
--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -64,12 +64,12 @@ struct command_result *param_u64(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t *tok,
 				 uint64_t **num);
 
-/* Extra msatoshi amount from this string */
+/* Extract msatoshi amount from this string */
 struct command_result *param_msat(struct command *cmd, const char *name,
 				  const char *buffer, const jsmntok_t *tok,
 				  struct amount_msat **msat);
 
-/* Extra satoshi amount from this string */
+/* Extract satoshi amount from this string */
 struct command_result *param_sat(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t *tok,
 				 struct amount_sat **sat);

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -81,13 +81,13 @@ start_ln() {
 
 stop_ln() {
 	test ! -f /tmp/l1-regtest/lightningd-regtest.pid || \
-		(kill "$(cat /tmp/l1-regtest/lightningd-regtest.pid)" && \
+		(kill "$(cat /tmp/l1-regtest/lightningd-regtest.pid)"; \
 		rm /tmp/l1-regtest/lightningd-regtest.pid)
 	test ! -f /tmp/l2-regtest/lightningd-regtest.pid || \
-		(kill "$(cat /tmp/l2-regtest/lightningd-regtest.pid)" && \
+		(kill "$(cat /tmp/l2-regtest/lightningd-regtest.pid)"; \
 		rm /tmp/l2-regtest/lightningd-regtest.pid)
 	test ! -f "$PATH_TO_BITCOIN/regtest/bitcoind.pid" || \
-		(kill "$(cat "$PATH_TO_BITCOIN/regtest/bitcoind.pid")" && \
+		(kill "$(cat "$PATH_TO_BITCOIN/regtest/bitcoind.pid")"; \
 		rm "$PATH_TO_BITCOIN/regtest/bitcoind.pid")
 }
 


### PR DESCRIPTION
Fixup a spelling whoops; always remove the pid files, even if the process has already died. Especially if the process has already died.