### PR TITLE
External wallet funding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config: Adds parameter `min-capacity-sat` to reject tiny channels.
 - JSON API: `listforwards` now includes the time an HTLC was received and when it was resolved. Both are expressed as UNIX timestamps to facilitate parsing (Issue [#2491](https://github.com/ElementsProject/lightning/issues/2491), PR [#2528](https://github.com/ElementsProject/lightning/pull/2528))
 - JSON API: new plugin hooks `invoice_payment` for intercepting invoices before they're paid, `openchannel` for intercepting channel opens, and `htlc_accepted` to decide whether to resolve, reject or continue an incoming or forwarded payment..
+- JSON API: add three new RPC commands: `fundchannel_start`, `fundchannel_complete` and `fundchannel_cancel`. Allows a user to initiate and complete a channel open using funds that are in a external wallet.
 - plugin: the `connected` hook can now send an `error_message` to the rejected peer.
 - Protocol: we now enforce `option_upfront_shutdown_script` if a peer negotiates it.
 - JSON API: `listforwards` now includes the local_failed forwards with failcode (Issue [#2435](https://github.com/ElementsProject/lightning/issues/2435), PR [#2524](https://github.com/ElementsProject/lightning/pull/2524))

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,4 +1,5 @@
 COMMON_SRC_NOGEN :=				\
+	common/addr.c				\
 	common/amount.c				\
 	common/base32.c				\
 	common/bech32.c				\

--- a/common/addr.c
+++ b/common/addr.c
@@ -1,0 +1,22 @@
+#include "addr.h"
+#include <bitcoin/script.h>
+#include <common/bech32.h>
+
+/* Returns NULL if the script is not a P2WPKH or P2WSH */
+char *encode_scriptpubkey_to_addr(const tal_t *ctx,
+				   const char *hrp,
+				   const u8 *scriptPubkey)
+{
+	char *out;
+	size_t scriptLen = tal_bytelen(scriptPubkey);
+
+        /* Check that scriptPubkey is P2WSH or P2WPKH */
+	if (!is_p2wsh(scriptPubkey, NULL) && !is_p2wpkh(scriptPubkey, NULL))
+                return NULL;
+
+	out = tal_arr(ctx, char, 73 + strlen(hrp));
+	if (!segwit_addr_encode(out, hrp, 0, scriptPubkey + 2, scriptLen - 2))
+		return tal_free(out);
+
+	return out;
+}

--- a/common/addr.h
+++ b/common/addr.h
@@ -1,0 +1,12 @@
+#ifndef LIGHTNING_COMMON_ADDR_H
+#define LIGHTNING_COMMON_ADDR_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+/* Given a P2WSH or P2WPKH scriptPubkey, return a bech32 encoded address */
+char *encode_scriptpubkey_to_addr(const tal_t *ctx,
+                                  const char *hrp,
+                                  const u8 *scriptPubkey);
+
+#endif /* LIGHTNING_COMMON_ADDR_H */

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -516,7 +516,7 @@ class LightningRpc(UnixDomainSocketRpc):
         If {announce} is False, don't send channel announcements.
         Returns a Bech32 {funding_address} for an external wallet
         to create a funding transaction for. Requires a call to
-        'fundchannel_continue' to complete channel establishment
+        'fundchannel_complete' to complete channel establishment
         with peer.
         """
         payload = {
@@ -536,7 +536,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel_cancel", payload)
 
-    def fundchannel_continue(self, node_id, funding_txid, funding_txout):
+    def fundchannel_complete(self, node_id, funding_txid, funding_txout):
         """
         Complete channel establishment with {id}, using {funding_txid} at {funding_txout}
         """
@@ -545,7 +545,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "txid": funding_txid,
             "txout": funding_txout,
         }
-        return self.call("fundchannel_continue", payload)
+        return self.call("fundchannel_complete", payload)
 
     def getinfo(self):
         """

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -527,6 +527,15 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel_start", payload)
 
+    def fundchannel_cancel(self, node_id):
+        """
+        Cancel a 'started' fundchannel with node {id}.
+        """
+        payload = {
+            "id": node_id,
+        }
+        return self.call("fundchannel_cancel", payload)
+
     def fundchannel_continue(self, node_id, funding_txid, funding_txout):
         """
         Complete channel establishment with {id}, using {funding_txid} at {funding_txout}

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -527,13 +527,14 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel_start", payload)
 
-    def fundchannel_continue(self, node_id, funding_txid):
+    def fundchannel_continue(self, node_id, funding_txid, funding_txout):
         """
-        Complete channel establishment with {id}, using {funding_txid}
+        Complete channel establishment with {id}, using {funding_txid} at {funding_txout}
         """
         payload = {
             "id": node_id,
             "txid": funding_txid,
+            "txout": funding_txout,
         }
         return self.call("fundchannel_continue", payload)
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -509,6 +509,24 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel", payload)
 
+    def fundchannel_start(self, node_id, satoshi, feerate=None, announce=True):
+        """
+        Start channel funding with {id} for {satoshi} satoshis
+        with feerate of {feerate} (uses default feerate if unset).
+        If {announce} is False, don't send channel announcements.
+        Returns a Bech32 {funding_address} for an external wallet
+        to create a funding transaction for. Requires a call to
+        'fundchannel_continue' to complete channel establishment
+        with peer.
+        """
+        payload = {
+            "id": node_id,
+            "satoshi": satoshi,
+            "feerate": feerate,
+            "announce": announce,
+        }
+        return self.call("fundchannel_start", payload)
+
     def getinfo(self):
         """
         Show information about this node

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -527,6 +527,16 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundchannel_start", payload)
 
+    def fundchannel_continue(self, node_id, funding_txid):
+        """
+        Complete channel establishment with {id}, using {funding_txid}
+        """
+        payload = {
+            "id": node_id,
+            "txid": funding_txid,
+        }
+        return self.call("fundchannel_continue", payload)
+
     def getinfo(self):
         """
         Show information about this node

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,6 +15,9 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-delinvoice.7 \
 	doc/lightning-disconnect.7 \
 	doc/lightning-fundchannel.7 \
+	doc/lightning-fundchannel_start.7 \
+	doc/lightning-fundchannel_complete.7 \
+	doc/lightning-fundchannel_cancel.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-listchannels.7 \

--- a/doc/lightning-fundchannel_cancel.7
+++ b/doc/lightning-fundchannel_cancel.7
@@ -1,0 +1,53 @@
+'\" t
+.\"     Title: lightning-fundchannel_cancel
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/05/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/05/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-fundchannel_cancel \- Command for completing channel establishment
+.SH "SYNOPSIS"
+.sp
+\fBfundchannel_cancel\fR \fIid\fR
+.SH "DESCRIPTION"
+.sp
+fundchannel_cancel is a lower level RPC command\&. It allows a user to cancel an initiated channel establishment with a connected peer\&.
+.sp
+\fIid\fR is the node id of the remote peer with which to cancel the
+.SH "RETURN VALUE"
+.sp
+On success, returns confirmation that the channel establishment has been canceled\&.
+.sp
+On failure, returns an error\&.
+.SH "AUTHOR"
+.sp
+Lisa Neigut <niftynei@gmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-connect(7), lightning\-fundchannel(7), lightning\-fundchannel_start(7), lightning\-fundchannel_complete(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel_cancel.7.txt
+++ b/doc/lightning-fundchannel_cancel.7.txt
@@ -1,0 +1,37 @@
+LIGHTNING-FUNDCHANNEL_CANCEL(7)
+===============================
+:doctype: manpage
+
+NAME
+----
+lightning-fundchannel_cancel - Command for completing channel establishment
+
+SYNOPSIS
+--------
+*fundchannel_cancel* 'id'
+
+DESCRIPTION
+-----------
+`fundchannel_cancel` is a lower level RPC command. It allows a user to cancel an initiated
+channel establishment with a connected peer.
+
+'id' is the node id of the remote peer with which to cancel the 
+
+RETURN VALUE
+------------
+On success, returns confirmation that the channel establishment has been canceled.
+
+On failure, returns an error.
+
+AUTHOR
+------
+Lisa Neigut <niftynei@gmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-connect(7), lightning-fundchannel(7), lightning-fundchannel_start(7),
+lightning-fundchannel_complete(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel_complete.7
+++ b/doc/lightning-fundchannel_complete.7
@@ -1,0 +1,59 @@
+'\" t
+.\"     Title: lightning-fundchannel_complete
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/05/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/05/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-fundchannel_complete \- Command for completing channel establishment
+.SH "SYNOPSIS"
+.sp
+\fBfundchannel_complete\fR \fIid\fR \fItxid\fR \fItxout\fR
+.SH "DESCRIPTION"
+.sp
+fundchannel_complete is a lower level RPC command\&. It allows a user to complete an initiated channel establishment with a connected peer
+.sp
+\fIid\fR is the node id of the remote peer
+.sp
+\fItxid\fR is the hex string of the funding transaction id\&.
+.sp
+\fItxout\fR is the integer outpoint of the funding output for this channel\&.
+.sp
+Note that the funding transaction should not be broadcast until after channel establishment has been successfully completed, as the commitment transactions for this channel are not secured until this command succesfully completes\&.
+.SH "RETURN VALUE"
+.sp
+On success, returns a confirmation that \fIcommitments_secured\fR and the derived \fIchannel_id\fR\&.
+.sp
+On failure, returns an error\&.
+.SH "AUTHOR"
+.sp
+Lisa Neigut <niftynei@gmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-connect(7), lightning\-fundchannel(7), lightning\-fundchannel_start(7), lightning\-fundchannel_cancel(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel_complete.7.txt
+++ b/doc/lightning-fundchannel_complete.7.txt
@@ -1,0 +1,46 @@
+LIGHTNING-FUNDCHANNEL_COMPLETE(7)
+=================================
+:doctype: manpage
+
+NAME
+----
+lightning-fundchannel_complete - Command for completing channel establishment
+
+SYNOPSIS
+--------
+*fundchannel_complete* 'id' 'txid' 'txout'
+
+DESCRIPTION
+-----------
+`fundchannel_complete` is a lower level RPC command. It allows a user to complete an initiated
+channel establishment with a connected peer
+
+'id' is the node id of the remote peer
+
+'txid' is the hex string of the funding transaction id.
+
+'txout' is the integer outpoint of the funding output for this channel.
+
+Note that the funding transaction should not be broadcast until after channel
+establishment has been successfully completed, as the commitment transactions
+for this channel are not secured until this command succesfully completes.
+
+RETURN VALUE
+------------
+On success, returns a confirmation that 'commitments_secured' and the
+derived 'channel_id'.
+
+On failure, returns an error.
+
+AUTHOR
+------
+Lisa Neigut <niftynei@gmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-connect(7), lightning-fundchannel(7), lightning-fundchannel_start(7),
+lightning-fundchannel_cancel(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel_start.7
+++ b/doc/lightning-fundchannel_start.7
@@ -1,0 +1,59 @@
+'\" t
+.\"     Title: lightning-fundchannel_start
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/05/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/05/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+lightning-fundchannel_start \- Command for initiating channel establishment for a lightning channel
+.SH "SYNOPSIS"
+.sp
+\fBfundchannel_start\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR]
+.SH "DESCRIPTION"
+.sp
+fundchannel_start is a lower level RPC command\&. It allows a user to initiate channel establishment with a connected peer\&.
+.sp
+\fIid\fR is the node id of the remote peer\&.
+.sp
+\fIsatoshi\fR is the satoshi value that the channel will be funded at\&. This value MUST be accurate, otherwise the negotiated commitment transactions will not encompass the correct channel value\&.
+.sp
+\fIfeerate\fR is an optional field\&. Sets the feerate for subsequent commitment transactions\&.
+.sp
+\fIannounce\fR whether or not to annouce this channel\&.
+.SH "RETURN VALUE"
+.sp
+On success, returns the \fIfunding_address\fR for the channel\&.
+.sp
+On failure, returns an error\&.
+.SH "AUTHOR"
+.sp
+Lisa Neigut <niftynei@gmail\&.com> is mainly responsible\&.
+.SH "SEE ALSO"
+.sp
+lightning\-connect(7), lightning\-fundchannel(7), lightning\-fundchannel_complete(7), lightning\-fundchannel_cancel(7)
+.SH "RESOURCES"
+.sp
+Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-fundchannel_start.7.txt
+++ b/doc/lightning-fundchannel_start.7.txt
@@ -1,0 +1,45 @@
+LIGHTNING-FUNDCHANNEL_START(7)
+==============================
+:doctype: manpage
+
+NAME
+----
+lightning-fundchannel_start - Command for initiating channel establishment for a lightning channel
+
+SYNOPSIS
+--------
+*fundchannel_start* 'id' 'satoshi' ['feerate' 'announce']
+
+DESCRIPTION
+-----------
+`fundchannel_start` is a lower level RPC command. It allows a user to initiate channel
+establishment with a connected peer.
+
+'id' is the node id of the remote peer.
+
+'satoshi' is the satoshi value that the channel will be funded at. This value MUST be
+accurate, otherwise the negotiated commitment transactions will not encompass the correct
+channel value.
+
+'feerate' is an optional field. Sets the feerate for subsequent commitment transactions.
+
+'announce' whether or not to annouce this channel.
+
+RETURN VALUE
+------------
+On success, returns the 'funding_address' for the channel.
+
+On failure, returns an error.
+
+AUTHOR
+------
+Lisa Neigut <niftynei@gmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-connect(7), lightning-fundchannel(7), lightning-fundchannel_complete(7),
+lightning-fundchannel_cancel(7)
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -14,6 +14,7 @@ default: lightningd-all
 
 # Common source we use.
 LIGHTNINGD_COMMON_OBJS :=			\
+	common/addr.o				\
 	common/amount.o				\
 	common/base32.o				\
 	common/bech32.o				\

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -88,7 +88,7 @@ struct command_result *param_node_id(struct command *cmd,
 		return NULL;
 
 	return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-			    "'%s' should be a pubkey, not '%.*s'",
+			    "'%s' should be a node id, not '%.*s'",
 			    name, json_tok_full_len(tok),
 			    json_tok_full(buffer, tok));
 }

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1022,7 +1022,7 @@ static unsigned int openingd_msg(struct subd *openingd,
 	case WIRE_OPENING_INIT:
 	case WIRE_OPENING_FUNDER:
 	case WIRE_OPENING_FUNDER_START:
-	case WIRE_OPENING_FUNDER_CONTINUE:
+	case WIRE_OPENING_FUNDER_COMPLETE:
 	case WIRE_OPENING_FUNDER_CANCEL:
 	case WIRE_OPENING_GOT_OFFER_REPLY:
 	case WIRE_OPENING_DEV_MEMLEAK:
@@ -1100,7 +1100,7 @@ void peer_start_openingd(struct peer *peer,
 	subd_send_msg(uc->openingd, take(msg));
 }
 
-static struct command_result *json_fund_channel_continue(struct command *cmd,
+static struct command_result *json_fund_channel_complete(struct command *cmd,
 							 const char *buffer,
 							 const jsmntok_t *obj UNNEEDED,
 							 const jsmntok_t *params)
@@ -1144,7 +1144,7 @@ static struct command_result *json_fund_channel_continue(struct command *cmd,
 
 	/* Update the cmd to the new cmd */
 	peer->uncommitted_channel->fc->cmd = cmd;
-	msg = towire_opening_funder_continue(NULL,
+	msg = towire_opening_funder_complete(NULL,
 					     funding_txid,
 					     funding_txout);
 	subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
@@ -1183,14 +1183,14 @@ static struct command_result *json_fund_channel_cancel(struct command *cmd,
 
 	/**
 	 * there's a question of 'state machinery' here. as is, we're not checking
-	 * to see if you've already called `continue` -- we expect you
-	 * the caller to EITHER pick 'continue' or 'cancel'.
+	 * to see if you've already called `complete` -- we expect you
+	 * the caller to EITHER pick 'complete' or 'cancel'.
 	 * but if for some reason you've decided to test your luck, how much
 	 * 'handling' can we do for that case? the easiest thing to do is to
-	 * say "sorry you've already called continue", we can't cancel this.
+	 * say "sorry you've already called complete", we can't cancel this.
 	 *
 	 * there's also the state you might end up in where you've called
-	 * continue (and it's completed and been passed off to channeld) but
+	 * complete (and it's completed and been passed off to channeld) but
 	 * you've decided (for whatever reason) not to broadcast the transaction
 	 * so your channels have ended up in this 'waiting' state. neither of us
 	 * are actually out any amount of cash, but it'd be nice if there's a way
@@ -1440,14 +1440,14 @@ static const struct json_command fund_channel_cancel_command = {
 };
 AUTODATA(json_command, &fund_channel_cancel_command);
 
-static const struct json_command fund_channel_continue_command = {
-    "fundchannel_continue",
+static const struct json_command fund_channel_complete_command = {
+    "fundchannel_complete",
     "channels",
-    json_fund_channel_continue,
+    json_fund_channel_complete,
     "Complete channel establishment with peer {id} for funding transaction"
     "with {txid}. Returns true on success, false otherwise."
 };
-AUTODATA(json_command, &fund_channel_continue_command);
+AUTODATA(json_command, &fund_channel_complete_command);
 
 #if DEVELOPER
  /* Indented to avoid include ordering check */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -971,6 +971,7 @@ static unsigned int openingd_msg(struct subd *openingd,
 	case WIRE_OPENING_INIT:
 	case WIRE_OPENING_FUNDER:
 	case WIRE_OPENING_FUNDER_START:
+	case WIRE_OPENING_FUNDER_CONTINUE:
 	case WIRE_OPENING_GOT_OFFER_REPLY:
 	case WIRE_OPENING_DEV_MEMLEAK:
 	/* Replies never get here */
@@ -1045,6 +1046,44 @@ void peer_start_openingd(struct peer *peer,
 				  peer->localfeatures,
 				  send_msg);
 	subd_send_msg(uc->openingd, take(msg));
+}
+
+static struct command_result *json_fund_channel_continue(struct command *cmd,
+							 const char *buffer,
+							 const jsmntok_t *obj UNNEEDED,
+							 const jsmntok_t *params)
+{
+	u8 *msg;
+	struct node_id *id;
+	struct bitcoin_txid *funding_txid;
+	struct peer *peer;
+	struct channel *channel;
+
+	if (!param(cmd, buffer, params,
+		   p_req("id", param_node_id, &id),
+		   p_req("txid", param_txid, &funding_txid),
+		   NULL))
+		return command_param_failed();
+
+	peer = peer_by_id(cmd->ld, id);
+	if (!peer) {
+		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
+	}
+
+	channel = peer_active_channel(peer);
+	if (channel)
+		return command_fail(cmd, LIGHTNINGD, "Peer already %s",
+				    channel_state_name(channel));
+
+	if (!peer->uncommitted_channel)
+		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+
+	if (!peer->uncommitted_channel->fc)
+		return command_fail(cmd, LIGHTNINGD, "No channel funding in progress.");
+
+	msg = towire_opening_funder_continue(NULL, funding_txid);
+	subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
+	return command_still_pending(cmd);
 }
 
 static struct command_result *json_fund_channel_start(struct command *cmd,
@@ -1263,6 +1302,15 @@ static const struct json_command fund_channel_start_command = {
     "Returns a bech32 address to use as an output for a funding transaction."
 };
 AUTODATA(json_command, &fund_channel_start_command);
+
+static const struct json_command fund_channel_continue_command = {
+    "fundchannel_continue",
+    "channels",
+    json_fund_channel_continue,
+    "Complete channel establishment with peer {id} for funding transaction"
+    "with {txid}. Returns true on success, false otherwise."
+};
+AUTODATA(json_command, &fund_channel_continue_command);
 
 #if DEVELOPER
  /* Indented to avoid include ordering check */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -284,11 +284,50 @@ static void funding_broadcast_failed_or_success(struct channel *channel,
 	}
 }
 
-static void opening_funder_start_finished(struct subd *openingd, const u8 *resp,
-					  const int *fds,
-					  struct funding_channel *fc)
+static void funding_started_success(struct funding_channel *fc,
+				    u8 *scriptPubkey)
 {
-	// todo: this.
+	struct json_stream *response;
+	struct command *cmd = fc->cmd;
+	char *out;
+
+	response = json_stream_success(cmd);
+	json_object_start(response, NULL);
+	out = encode_scriptpubkey_to_addr(cmd,
+				          get_chainparams(cmd->ld)->bip173_name,
+					  scriptPubkey);
+	if (out)
+		json_add_string(response, "funding_address", out);
+	json_object_end(response);
+	was_pending(command_success(cmd, response));
+}
+
+static void opening_funder_start_replied(struct subd *openingd, const u8 *resp,
+					 const int *fds,
+					 struct funding_channel *fc)
+{
+	u8 *funding_scriptPubkey;
+
+	if (!fromwire_opening_funder_start_reply(resp, resp,
+						 &funding_scriptPubkey)) {
+		log_broken(fc->uc->log,
+			   "bad OPENING_FUNDER_REPLY %s",
+			   tal_hex(resp, resp));
+		was_pending(command_fail(fc->cmd, LIGHTNINGD,
+					 "bad OPENING_FUNDER_REPLY %s",
+					 tal_hex(fc->cmd, resp)));
+		goto failed;
+	}
+
+	// FIXME: save the peer to the database?
+	funding_started_success(fc, funding_scriptPubkey);
+	return;
+
+failed:
+	subd_release_channel(openingd, fc->uc);
+	fc->uc->openingd = NULL;
+	/* Frees fc too, and tmpctx */
+	tal_free(fc->uc);
 }
 
 static void opening_funder_finished(struct subd *openingd, const u8 *resp,
@@ -905,7 +944,7 @@ static unsigned int openingd_msg(struct subd *openingd,
 			tal_free(openingd);
 			return 0;
 		}
-		opening_funder_start_finished(openingd, msg, fds, uc->fc);
+		opening_funder_start_replied(openingd, msg, fds, uc->fc);
 		return 0;
 	case WIRE_OPENING_FUNDER_FAILED:
 		if (!uc->fc) {

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -366,6 +366,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 					   &fc->uc->minimum_depth,
 					   &channel_info.remote_fundingkey,
 					   &expected_txid,
+					   &funding_outnum,
 					   &feerate,
 					   &fc->uc->our_config.channel_reserve,
 					   &remote_upfront_shutdown_script)) {
@@ -1058,13 +1059,22 @@ static struct command_result *json_fund_channel_continue(struct command *cmd,
 	struct bitcoin_txid *funding_txid;
 	struct peer *peer;
 	struct channel *channel;
+	u32 *funding_txout_num;
+	u16 funding_txout;
 
 	if (!param(cmd, buffer, params,
 		   p_req("id", param_node_id, &id),
 		   p_req("txid", param_txid, &funding_txid),
+		   p_req("txout", param_number, &funding_txout_num),
 		   NULL))
 		return command_param_failed();
 
+	if (*funding_txout_num > UINT16_MAX)
+		return command_fail(cmd, LIGHTNINGD,
+				    "Invalid parameter: funding tx vout too large %u",
+				    *funding_txout_num);
+
+	funding_txout = *funding_txout_num;
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
 		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
@@ -1081,7 +1091,9 @@ static struct command_result *json_fund_channel_continue(struct command *cmd,
 	if (!peer->uncommitted_channel->fc)
 		return command_fail(cmd, LIGHTNINGD, "No channel funding in progress.");
 
-	msg = towire_opening_funder_continue(NULL, funding_txid);
+	msg = towire_opening_funder_continue(NULL,
+					     funding_txid,
+					     funding_txout);
 	subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
 	return command_still_pending(cmd);
 }

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -73,6 +73,7 @@ struct funding_channel {
 
 	struct wallet_tx *wtx;
 	struct amount_msat push;
+	struct amount_sat funding;
 	u8 channel_flags;
 
 	/* Variables we need to compose fields in cmd's response */
@@ -132,7 +133,7 @@ void json_add_uncommitted_channel(struct json_stream *response,
 	}
 
 	/* These should never fail. */
-	if (amount_sat_to_msat(&total, uc->fc->wtx->amount)
+	if (amount_sat_to_msat(&total, uc->fc->funding)
 	    && amount_msat_sub(&ours, total, uc->fc->push)) {
 		json_add_amount_msat_compat(response, ours,
 					    "msatoshi_to_us", "to_us_msat");
@@ -1078,6 +1079,7 @@ static struct command_result *json_fund_channel_start(struct command *cmd,
 				    type_to_string(tmpctx, struct amount_sat,
 						   &max_funding_satoshi));
 
+	fc->funding = *amount;
 	if (!feerate_per_kw) {
 		feerate_per_kw = tal(cmd, u32);
 		*feerate_per_kw = opening_feerate(cmd->ld->topology);
@@ -1221,6 +1223,9 @@ static struct command_result *json_fund_channel(struct command *cmd,
 		return res;
 
 	assert(!amount_sat_greater(fc->wtx->amount, max_funding_satoshi));
+	/* Stash total amount in fc as well, as externally funded
+	 * channels don't have a wtx */
+	fc->funding = fc->wtx->amount;
 
 	peer->uncommitted_channel->fc = tal_steal(peer->uncommitted_channel, fc);
 	fc->uc = peer->uncommitted_channel;

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -284,6 +284,13 @@ static void funding_broadcast_failed_or_success(struct channel *channel,
 	}
 }
 
+static void opening_funder_start_finished(struct subd *openingd, const u8 *resp,
+					  const int *fds,
+					  struct funding_channel *fc)
+{
+	// todo: this.
+}
+
 static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 				    const int *fds,
 				    struct funding_channel *fc)
@@ -891,7 +898,15 @@ static unsigned int openingd_msg(struct subd *openingd,
 			return 3;
 		opening_funder_finished(openingd, msg, fds, uc->fc);
 		return 0;
-
+	case WIRE_OPENING_FUNDER_START_REPLY:
+		if (!uc->fc) {
+			log_broken(openingd->log, "Unexpected FUNDER_START_REPLY %s",
+				   tal_hex(tmpctx, msg));
+			tal_free(openingd);
+			return 0;
+		}
+		opening_funder_start_finished(openingd, msg, fds, uc->fc);
+		return 0;
 	case WIRE_OPENING_FUNDER_FAILED:
 		if (!uc->fc) {
 			log_broken(openingd->log, "Unexpected FUNDER_FAILED %s",
@@ -915,6 +930,7 @@ static unsigned int openingd_msg(struct subd *openingd,
 	/* We send these! */
 	case WIRE_OPENING_INIT:
 	case WIRE_OPENING_FUNDER:
+	case WIRE_OPENING_FUNDER_START:
 	case WIRE_OPENING_GOT_OFFER_REPLY:
 	case WIRE_OPENING_DEV_MEMLEAK:
 	/* Replies never get here */
@@ -989,6 +1005,93 @@ void peer_start_openingd(struct peer *peer,
 				  peer->localfeatures,
 				  send_msg);
 	subd_send_msg(uc->openingd, take(msg));
+}
+
+static struct command_result *json_fund_channel_start(struct command *cmd,
+						      const char *buffer,
+						      const jsmntok_t *obj UNNEEDED,
+						      const jsmntok_t *params)
+{
+	struct funding_channel * fc = tal(cmd, struct funding_channel);
+	struct node_id *id;
+	struct peer *peer;
+	struct channel *channel;
+	bool *announce_channel;
+	u32 *feerate_per_kw;
+
+	u8 *msg = NULL;
+	struct amount_sat max_funding_satoshi, *amount;
+
+	max_funding_satoshi = get_chainparams(cmd->ld)->max_funding;
+	fc->cmd = cmd;
+	fc->uc = NULL;
+	if (!param(fc->cmd, buffer, params,
+		   p_req("id", param_node_id, &id),
+		   p_req("satoshi", param_sat, &amount),
+		   p_opt("feerate", param_feerate, &feerate_per_kw),
+		   p_opt_def("announce", param_bool, &announce_channel, true),
+		   NULL))
+		return command_param_failed();
+
+	if (amount_sat_greater(*amount, max_funding_satoshi))
+                return command_fail(cmd, FUND_MAX_EXCEEDED,
+				    "Amount exceeded %s",
+				    type_to_string(tmpctx, struct amount_sat,
+						   &max_funding_satoshi));
+
+	if (!feerate_per_kw) {
+		feerate_per_kw = tal(cmd, u32);
+		*feerate_per_kw = opening_feerate(cmd->ld->topology);
+		if (!*feerate_per_kw) {
+			return command_fail(cmd, LIGHTNINGD,
+					    "Cannot estimate fees");
+		}
+	}
+
+	if (*feerate_per_kw < feerate_floor()) {
+		return command_fail(cmd, LIGHTNINGD,
+				    "Feerate below feerate floor");
+	}
+
+	peer = peer_by_id(cmd->ld, id);
+	if (!peer) {
+		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
+	}
+
+	channel = peer_active_channel(peer);
+	if (channel) {
+		return command_fail(cmd, LIGHTNINGD, "Peer already %s",
+				    channel_state_name(channel));
+	}
+
+	if (!peer->uncommitted_channel) {
+		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+	}
+
+	if (peer->uncommitted_channel->fc) {
+		return command_fail(cmd, LIGHTNINGD, "Already funding channel");
+	}
+
+	fc->push = AMOUNT_MSAT(0);
+	fc->channel_flags = OUR_CHANNEL_FLAGS;
+	if (!*announce_channel) {
+		fc->channel_flags &= ~CHANNEL_FLAGS_ANNOUNCE_CHANNEL;
+		log_info(peer->ld->log, "Will open private channel with node %s",
+			type_to_string(fc, struct node_id, id));
+	}
+
+	assert(!amount_sat_greater(*amount, max_funding_satoshi));
+	peer->uncommitted_channel->fc = tal_steal(peer->uncommitted_channel, fc);
+	fc->uc = peer->uncommitted_channel;
+
+	msg = towire_opening_funder_start(NULL,
+					  *amount,
+					  fc->push,
+					  *feerate_per_kw,
+					  fc->channel_flags);
+
+	subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
+	return command_still_pending(cmd);
 }
 
 /**
@@ -1107,6 +1210,15 @@ static const struct json_command fund_channel_command = {
 	"{feerate}. Only use outputs that have {minconf} confirmations."
 };
 AUTODATA(json_command, &fund_channel_command);
+
+static const struct json_command fund_channel_start_command = {
+    "fundchannel_start",
+    "channels",
+    json_fund_channel_start,
+    "Start fund channel with {id} using {amount} satoshis. "
+    "Returns a bech32 address to use as an output for a funding transaction."
+};
+AUTODATA(json_command, &fund_channel_start_command);
 
 #if DEVELOPER
  /* Indented to avoid include ordering check */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -2,6 +2,7 @@
 #include <bitcoin/privkey.h>
 #include <bitcoin/script.h>
 #include <ccan/tal/str/str.h>
+#include <common/addr.h>
 #include <common/channel_config.h>
 #include <common/funding_tx.h>
 #include <common/json_command.h>

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -90,6 +90,12 @@ opening_funder_start_reply,6102
 opening_funder_start_reply,,script_len,u8
 opening_funder_start_reply,,scriptpubkey,script_len*u8
 
+# master->openingd: continue channel establsihment for a funding
+# tx that will be paid for by an external wallet
+# response to this is a normal `opening_funder_reply` ??
+opening_funder_continue,6012
+opening_funder_continue,,funding_txid,struct bitcoin_txid
+
 # Openingd->master: we failed to negotiation channel
 opening_funder_failed,6004
 opening_funder_failed,,reason,wirestring

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -77,6 +77,19 @@ opening_funder_reply,,our_channel_reserve_satoshis,struct amount_sat
 opening_funder_reply,,shutdown_len,u16
 opening_funder_reply,,shutdown_scriptpubkey,shutdown_len*u8
 
+# master->openingd: start channel establishment for a funding
+# tx that will be paid for by an external wallet
+opening_funder_start,6002
+opening_funder_start,,funding_satoshis,struct amount_sat
+opening_funder_start,,push_msat,struct amount_msat
+opening_funder_start,,feerate_per_kw,u32
+opening_funder_start,,channel_flags,u8
+
+# openingd->master: send back output script for 2-of-2 funding output
+opening_funder_start_reply,6102
+opening_funder_start_reply,,script_len,u8
+opening_funder_start_reply,,scriptpubkey,script_len*u8
+
 # Openingd->master: we failed to negotiation channel
 opening_funder_failed,6004
 opening_funder_failed,,reason,wirestring

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -91,12 +91,12 @@ opening_funder_start_reply,6102
 opening_funder_start_reply,,script_len,u8
 opening_funder_start_reply,,scriptpubkey,script_len*u8
 
-# master->openingd: continue channel establishment for a funding
+# master->openingd: complete channel establishment for a funding
 # tx that will be paid for by an external wallet
 # response to this is a normal `opening_funder_reply` ??
-opening_funder_continue,6012
-opening_funder_continue,,funding_txid,struct bitcoin_txid
-opening_funder_continue,,funding_txout,u16
+opening_funder_complete,6012
+opening_funder_complete,,funding_txid,struct bitcoin_txid
+opening_funder_complete,,funding_txout,u16
 
 #master->openingd: cancel channel establishment for a funding
 opening_funder_cancel,6013

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -80,6 +80,7 @@ opening_funder_reply,,shutdown_scriptpubkey,shutdown_len*u8
 # Openingd->master: we failed to negotiation channel
 opening_funder_failed,6004
 opening_funder_failed,,reason,wirestring
+opening_funder_failed,,is_err,bool
 
 # Openingd->master: they offered channel.
 # This gives their txid and info, means we can send funding_signed: we're done.

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -72,6 +72,7 @@ opening_funder_reply,,their_per_commit_point,struct pubkey
 opening_funder_reply,,minimum_depth,u32
 opening_funder_reply,,remote_fundingkey,struct pubkey
 opening_funder_reply,,funding_txid,struct bitcoin_txid
+opening_funder_reply,,funding_txout,u16
 opening_funder_reply,,feerate_per_kw,u32
 opening_funder_reply,,our_channel_reserve_satoshis,struct amount_sat
 opening_funder_reply,,shutdown_len,u16
@@ -90,11 +91,12 @@ opening_funder_start_reply,6102
 opening_funder_start_reply,,script_len,u8
 opening_funder_start_reply,,scriptpubkey,script_len*u8
 
-# master->openingd: continue channel establsihment for a funding
+# master->openingd: continue channel establishment for a funding
 # tx that will be paid for by an external wallet
 # response to this is a normal `opening_funder_reply` ??
 opening_funder_continue,6012
 opening_funder_continue,,funding_txid,struct bitcoin_txid
+opening_funder_continue,,funding_txout,u16
 
 # Openingd->master: we failed to negotiation channel
 opening_funder_failed,6004

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -98,6 +98,9 @@ opening_funder_continue,6012
 opening_funder_continue,,funding_txid,struct bitcoin_txid
 opening_funder_continue,,funding_txout,u16
 
+#master->openingd: cancel channel establishment for a funding
+opening_funder_cancel,6013
+
 # Openingd->master: we failed to negotiation channel
 opening_funder_failed,6004
 opening_funder_failed,,reason,wirestring

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -73,6 +73,10 @@ struct state {
 	struct basepoints our_points;
 	struct pubkey our_funding_pubkey;
 
+	/* Information we need between funding_start and funding_continue */
+	struct basepoints their_points;
+	struct pubkey their_funding_pubkey;
+
 	/* hsmd gives us our first per-commitment point, and peer tells us
 	 * theirs */
 	struct pubkey first_per_commitment_point[NUM_SIDES];
@@ -472,12 +476,9 @@ static bool setup_channel_funder(struct state *state)
 static u8 *funder_channel_start(struct state *state,
 				 u8 channel_flags)
 {
-	struct channel_id id_in;
 	u8 *msg;
-	struct basepoints theirs;
-	struct pubkey their_funding_pubkey;
-	u32 minimum_depth;
 	u8 *funding_output_script;
+	struct channel_id id_in;
 
 	if (!setup_channel_funder(state))
 		return NULL;
@@ -545,14 +546,14 @@ static u8 *funder_channel_start(struct state *state,
 				     &state->remoteconf.max_htlc_value_in_flight,
 				     &state->remoteconf.channel_reserve,
 				     &state->remoteconf.htlc_minimum,
-				     &minimum_depth,
+				     &state->minimum_depth,
 				     &state->remoteconf.to_self_delay,
 				     &state->remoteconf.max_accepted_htlcs,
-				     &their_funding_pubkey,
-				     &theirs.revocation,
-				     &theirs.payment,
-				     &theirs.delayed_payment,
-				     &theirs.htlc,
+				     &state->their_funding_pubkey,
+				     &state->their_points.revocation,
+				     &state->their_points.payment,
+				     &state->their_points.delayed_payment,
+				     &state->their_points.htlc,
 				     &state->first_per_commitment_point[REMOTE],
 				     &state->remote_upfront_shutdown_script))
 			peer_failed(state->pps,
@@ -563,14 +564,14 @@ static u8 *funder_channel_start(struct state *state,
 				     &state->remoteconf.max_htlc_value_in_flight,
 				     &state->remoteconf.channel_reserve,
 				     &state->remoteconf.htlc_minimum,
-				     &minimum_depth,
+				     &state->minimum_depth,
 				     &state->remoteconf.to_self_delay,
 				     &state->remoteconf.max_accepted_htlcs,
-				     &their_funding_pubkey,
-				     &theirs.revocation,
-				     &theirs.payment,
-				     &theirs.delayed_payment,
-				     &theirs.htlc,
+				     &state->their_funding_pubkey,
+				     &state->their_points.revocation,
+				     &state->their_points.payment,
+				     &state->their_points.delayed_payment,
+				     &state->their_points.htlc,
 				     &state->first_per_commitment_point[REMOTE]))
 		peer_failed(state->pps,
 			    &state->channel_id,
@@ -608,7 +609,7 @@ static u8 *funder_channel_start(struct state *state,
 		scriptpubkey_p2wsh(tmpctx,
 				   bitcoin_redeem_2of2(tmpctx,
 						       &state->our_funding_pubkey,
-						       &their_funding_pubkey));
+						       &state->their_funding_pubkey));
 
 	/* Update the billboard with our infos */
 	peer_billboard(false,
@@ -617,11 +618,252 @@ static u8 *funder_channel_start(struct state *state,
 	return towire_opening_funder_start_reply(state, funding_output_script);
 }
 
-static u8 *funder_channel_continue(struct state *state,
-				   struct bitcoin_txid *funding_txid)
+static bool funder_finalize_channel_setup(struct state *state,
+			struct amount_msat local_msat,
+			struct bitcoin_signature *sig,
+			struct bitcoin_tx **tx)
 {
-	// now the what. ok we've got a funding_txid..
-	return NULL;
+	u8 *msg;
+	struct channel_id id_in;
+	const u8 *wscript;
+	char* err_reason;
+
+	/*~ Now we can initialize the `struct channel`.  This represents
+	 * the current channel state and is how we can generate the current
+	 * commitment transaction.
+	 *
+	 * The routines to support `struct channel` are split into a common
+	 * part (common/initial_channel) which doesn't support HTLCs and is
+	 * enough for us here, and the complete channel support required by
+	 * `channeld` which lives in channeld/full_channel. */
+	state->channel = new_initial_channel(state,
+					     &state->chainparams->genesis_blockhash,
+					     &state->funding_txid,
+					     state->funding_txout,
+					     state->minimum_depth,
+					     state->funding,
+					     local_msat,
+					     state->feerate_per_kw,
+					     &state->localconf,
+					     &state->remoteconf,
+					     &state->our_points,
+					     &state->their_points,
+					     &state->our_funding_pubkey,
+					     &state->their_funding_pubkey,
+					     /* Funder is local */
+					     LOCAL);
+	/* We were supposed to do enough checks above, but just in case,
+	 * new_initial_channel will fail to create absurd channels */
+	if (!state->channel)
+		peer_failed(state->pps,
+			    &state->channel_id,
+			    "could not create channel with given config");
+
+	/* BOLT #2:
+	 *
+	 * ### The `funding_created` Message
+	 *
+	 * This message describes the outpoint which the funder has created
+	 * for the initial commitment transactions.  After receiving the
+	 * peer's signature, via `funding_signed`, it will broadcast the funding
+	 * transaction.
+	 */
+	/* This gives us their first commitment transaction. */
+	*tx = initial_channel_tx(state, &wscript, state->channel,
+				&state->first_per_commitment_point[REMOTE],
+				REMOTE, &err_reason);
+	if (!*tx) {
+		/* This should not happen: we should never create channels we
+		 * can't afford the fees for after reserve. */
+		negotiation_failed(state, true,
+				   "Could not meet their fees and reserve: %s", err_reason);
+		goto fail;
+	}
+
+	/* We ask the HSM to sign their commitment transaction for us: it knows
+	 * our funding key, it just needs the remote funding key to create the
+	 * witness script.  It also needs the amount of the funding output,
+	 * as segwit signatures commit to that as well, even though it doesn't
+	 * explicitly appear in the transaction itself. */
+	msg = towire_hsm_sign_remote_commitment_tx(NULL,
+						   *tx,
+						   &state->channel->funding_pubkey[REMOTE],
+						   state->channel->funding);
+
+	wire_sync_write(HSM_FD, take(msg));
+	msg = wire_sync_read(tmpctx, HSM_FD);
+	if (!fromwire_hsm_sign_tx_reply(msg, sig))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad sign_tx_reply %s",
+			      tal_hex(tmpctx, msg));
+
+	/* You can tell this has been a problem before, since there's a debug
+	 * message here: */
+	status_trace("signature %s on tx %s using key %s",
+		     type_to_string(tmpctx, struct bitcoin_signature, sig),
+		     type_to_string(tmpctx, struct bitcoin_tx, *tx),
+		     type_to_string(tmpctx, struct pubkey,
+				    &state->our_funding_pubkey));
+
+	/* Now we give our peer the signature for their first commitment
+	 * transaction. */
+	msg = towire_funding_created(state, &state->channel_id,
+				     &state->funding_txid,
+				     state->funding_txout,
+				     &sig->s);
+	sync_crypto_write(state->pps, msg);
+
+	/* BOLT #2:
+	 *
+	 * ### The `funding_signed` Message
+	 *
+	 * This message gives the funder the signature it needs for the first
+	 * commitment transaction, so it can broadcast the transaction knowing
+	 * that funds can be redeemed, if need be.
+	 */
+	peer_billboard(false,
+		       "Funding channel: create first tx, now waiting for their signature");
+
+	/* Now they send us their signature for that first commitment
+	 * transaction. */
+	msg = opening_negotiate_msg(tmpctx, state, true);
+	if (!msg)
+		goto fail;
+
+	sig->sighash_type = SIGHASH_ALL;
+	if (!fromwire_funding_signed(msg, &id_in, &sig->s))
+		peer_failed(state->pps,
+			    &state->channel_id,
+			    "Parsing funding_signed: %s", tal_hex(msg, msg));
+
+	/* BOLT #2:
+	 *
+	 * This message introduces the `channel_id` to identify the channel.
+	 * It's derived from the funding transaction by combining the
+	 * `funding_txid` and the `funding_output_index`, using big-endian
+	 * exclusive-OR (i.e. `funding_output_index` alters the last 2
+	 * bytes).
+	 */
+
+	/*~ Back in Milan, we chose to allow multiple channels between peers in
+	 * the protocol.  I insisted that we multiplex these over the same
+	 * socket, and (even though I didn't plan on implementing it anytime
+	 * soon) that we put it into the first version of the protocol
+	 * because it would be painful to add in later.
+	 *
+	 * My logic seemed sound: we treat new connections as an implication
+	 * that the old connection has disconnected, which happens more often
+	 * than you'd hope on modern networks.  However, supporting multiple
+	 * channels via multiple connections would be far easier for us to
+	 * support with our (introduced-since) separate daemon model.
+	 *
+	 * Let this be a lesson: beware premature specification, even if you
+	 * suspect "we'll need it later!". */
+	derive_channel_id(&state->channel_id,
+			  &state->funding_txid, state->funding_txout);
+
+	if (!channel_id_eq(&id_in, &state->channel_id))
+		peer_failed(state->pps, &id_in,
+			    "funding_signed ids don't match: expected %s got %s",
+			    type_to_string(msg, struct channel_id,
+					   &state->channel_id),
+			    type_to_string(msg, struct channel_id, &id_in));
+
+	/* BOLT #2:
+	 *
+	 * The recipient:
+	 *   - if `signature` is incorrect:
+	 *     - MUST fail the channel.
+	 */
+	/* So we create *our* initial commitment transaction, and check the
+	 * signature they sent against that. */
+	*tx = initial_channel_tx(state, &wscript, state->channel,
+				 &state->first_per_commitment_point[LOCAL],
+				 LOCAL, &err_reason);
+	if (!*tx) {
+		negotiation_failed(state, true,
+				   "Could not meet our fees and reserve: %s", err_reason);
+		goto fail;
+	}
+
+	if (!check_tx_sig(*tx, 0, NULL, wscript, &state->their_funding_pubkey, sig)) {
+		peer_failed(state->pps,
+			    &state->channel_id,
+			    "Bad signature %s on tx %s using key %s",
+			    type_to_string(tmpctx, struct bitcoin_signature,
+					   sig),
+			    type_to_string(tmpctx, struct bitcoin_tx, *tx),
+			    type_to_string(tmpctx, struct pubkey,
+					   &state->their_funding_pubkey));
+	}
+
+	peer_billboard(false, "Funding channel: opening negotiation succeeded");
+
+	return true;
+
+fail:
+	tal_free(wscript);
+	return false;
+}
+
+static u8 *funder_channel_continue(struct state *state)
+{
+	struct bitcoin_tx *tx;
+	struct bitcoin_signature sig;
+	struct amount_msat local_msat;
+
+	/* Update the billboard about what we're doing*/
+	peer_billboard(false,
+		       "Funding channel con't: continuing with funding_txid %s",
+		       type_to_string(tmpctx, struct bitcoin_txid, &state->funding_txid));
+
+	/* We recalculate the local_msat from cached values; should
+	 * succeed because we checked it earlier */
+	assert(amount_sat_sub_msat(&local_msat, state->funding, state->push_msat));
+
+	state->channel = new_initial_channel(state,
+					     &state->chainparams->genesis_blockhash,
+					     &state->funding_txid,
+					     state->funding_txout,
+					     state->minimum_depth,
+					     state->funding,
+					     local_msat,
+					     state->feerate_per_kw,
+					     &state->localconf,
+					     &state->remoteconf,
+					     &state->our_points,
+					     &state->their_points,
+					     &state->our_funding_pubkey,
+					     &state->their_funding_pubkey,
+					     /* Funder is local */
+					     LOCAL);
+	/* We were supposed to do enough checks above, but just in case,
+	 * new_initial_channel will fail to create absurd channels */
+	if (!state->channel)
+		peer_failed(state->pps,
+			    &state->channel_id,
+			    "could not create channel with given config");
+
+
+	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx))
+		return NULL;
+
+	return towire_opening_funder_reply(state,
+					   &state->remoteconf,
+					   tx,
+					   &sig,
+					   state->pps,
+					   &state->their_points.revocation,
+					   &state->their_points.payment,
+					   &state->their_points.htlc,
+					   &state->their_points.delayed_payment,
+					   &state->first_per_commitment_point[REMOTE],
+					   state->minimum_depth,
+					   &state->their_funding_pubkey,
+					   &state->funding_txid,
+					   state->funding_txout,
+					   state->feerate_per_kw,
+					   state->localconf.channel_reserve,
+					   state->remote_upfront_shutdown_script);
 }
 
 /*~ OK, let's fund a channel!  Returns the reply for lightningd on success,
@@ -635,16 +877,10 @@ static u8 *funder_channel(struct state *state,
 {
 	struct channel_id id_in;
 	u8 *msg;
-	struct bitcoin_tx *tx;
-	struct basepoints theirs;
-	struct pubkey their_funding_pubkey;
 	struct pubkey *changekey;
 	struct bitcoin_signature sig;
-	u32 minimum_depth;
-	struct bitcoin_tx *funding;
-	const u8 *wscript;
+	struct bitcoin_tx *funding, *tx;
 	struct amount_msat local_msat;
-	char* err_reason;
 
 	if (!setup_channel_funder(state))
 		goto fail;
@@ -723,14 +959,14 @@ static u8 *funder_channel(struct state *state,
 				     &state->remoteconf.max_htlc_value_in_flight,
 				     &state->remoteconf.channel_reserve,
 				     &state->remoteconf.htlc_minimum,
-				     &minimum_depth,
+				     &state->minimum_depth,
 				     &state->remoteconf.to_self_delay,
 				     &state->remoteconf.max_accepted_htlcs,
-				     &their_funding_pubkey,
-				     &theirs.revocation,
-				     &theirs.payment,
-				     &theirs.delayed_payment,
-				     &theirs.htlc,
+				     &state->their_funding_pubkey,
+				     &state->their_points.revocation,
+				     &state->their_points.payment,
+				     &state->their_points.delayed_payment,
+				     &state->their_points.htlc,
 				     &state->first_per_commitment_point[REMOTE],
 				     &state->remote_upfront_shutdown_script))
 			peer_failed(state->pps,
@@ -741,14 +977,14 @@ static u8 *funder_channel(struct state *state,
 				     &state->remoteconf.max_htlc_value_in_flight,
 				     &state->remoteconf.channel_reserve,
 				     &state->remoteconf.htlc_minimum,
-				     &minimum_depth,
+				     &state->minimum_depth,
 				     &state->remoteconf.to_self_delay,
 				     &state->remoteconf.max_accepted_htlcs,
-				     &their_funding_pubkey,
-				     &theirs.revocation,
-				     &theirs.payment,
-				     &theirs.delayed_payment,
-				     &theirs.htlc,
+				     &state->their_funding_pubkey,
+				     &state->their_points.revocation,
+				     &state->their_points.payment,
+				     &state->their_points.delayed_payment,
+				     &state->their_points.htlc,
 				     &state->first_per_commitment_point[REMOTE]))
 		peer_failed(state->pps,
 			    &state->channel_id,
@@ -773,12 +1009,12 @@ static u8 *funder_channel(struct state *state,
 	 *  - if `minimum_depth` is unreasonably large:
 	 *    - MAY reject the channel.
 	 */
-	if (minimum_depth > 10) {
+	if (state->minimum_depth > 10) {
 		/* negotiation_failed just tells peer and lightningd
 		 * (hence fundchannel call) that this opening failed. */
 		negotiation_failed(state, true,
 				   "minimum_depth %u larger than %u",
-				   minimum_depth, 10);
+				   state->minimum_depth, 10);
 		goto fail;
 	}
 
@@ -839,179 +1075,15 @@ static u8 *funder_channel(struct state *state,
 			     cast_const2(const struct utxo **, utxos),
 			     state->funding,
 			     &state->our_funding_pubkey,
-			     &their_funding_pubkey,
+			     &state->their_funding_pubkey,
 			     change, changekey,
 			     bip32_base);
 	bitcoin_txid(funding, &state->funding_txid);
 
-	/*~ Now we can initialize the `struct channel`.  This represents
-	 * the current channel state and is how we can generate the current
-	 * commitment transaction.
-	 *
-	 * The routines to support `struct channel` are split into a common
-	 * part (common/initial_channel) which doesn't support HTLCs and is
-	 * enough for us here, and the complete channel support required by
-	 * `channeld` which lives in channeld/full_channel. */
-	state->channel = new_initial_channel(state,
-					     &state->chainparams->genesis_blockhash,
-					     &state->funding_txid,
-					     state->funding_txout,
-					     minimum_depth,
-					     state->funding,
-					     local_msat,
-					     state->feerate_per_kw,
-					     &state->localconf,
-					     &state->remoteconf,
-					     &state->our_points, &theirs,
-					     &state->our_funding_pubkey,
-					     &their_funding_pubkey,
-					     /* Funder is local */
-					     LOCAL);
-	/* We were supposed to do enough checks above, but just in case,
-	 * new_initial_channel will fail to create absurd channels */
-	if (!state->channel)
-		peer_failed(state->pps,
-			    &state->channel_id,
-			    "could not create channel with given config");
-
-	/* BOLT #2:
-	 *
-	 * ### The `funding_created` Message
-	 *
-	 * This message describes the outpoint which the funder has created
-	 * for the initial commitment transactions.  After receiving the
-	 * peer's signature, via `funding_signed`, it will broadcast the funding
-	 * transaction.
-	 */
-	/* This gives us their first commitment transaction. */
-	tx = initial_channel_tx(state, &wscript, state->channel,
-				&state->first_per_commitment_point[REMOTE],
-				REMOTE, &err_reason);
-	if (!tx) {
-		/* This should not happen: we should never create channels we
-		 * can't afford the fees for after reserve. */
-		negotiation_failed(state, true,
-				   "Could not meet their fees and reserve: %s", err_reason);
-		goto fail_2;
+	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx)) {
+		tal_free(funding);
+		goto fail;
 	}
-
-	/* We ask the HSM to sign their commitment transaction for us: it knows
-	 * our funding key, it just needs the remote funding key to create the
-	 * witness script.  It also needs the amount of the funding output,
-	 * as segwit signatures commit to that as well, even though it doesn't
-	 * explicitly appear in the transaction itself. */
-	msg = towire_hsm_sign_remote_commitment_tx(NULL,
-						   tx,
-						   &state->channel->funding_pubkey[REMOTE],
-						   state->channel->funding);
-
-	wire_sync_write(HSM_FD, take(msg));
-	msg = wire_sync_read(tmpctx, HSM_FD);
-	if (!fromwire_hsm_sign_tx_reply(msg, &sig))
-		status_failed(STATUS_FAIL_HSM_IO, "Bad sign_tx_reply %s",
-			      tal_hex(tmpctx, msg));
-
-	/* You can tell this has been a problem before, since there's a debug
-	 * message here: */
-	status_trace("signature %s on tx %s using key %s",
-		     type_to_string(tmpctx, struct bitcoin_signature, &sig),
-		     type_to_string(tmpctx, struct bitcoin_tx, tx),
-		     type_to_string(tmpctx, struct pubkey,
-				    &state->our_funding_pubkey));
-
-	/* Now we give our peer the signature for their first commitment
-	 * transaction. */
-	msg = towire_funding_created(state, &state->channel_id,
-				     &state->funding_txid,
-				     state->funding_txout,
-				     &sig.s);
-	sync_crypto_write(state->pps, msg);
-
-	/* BOLT #2:
-	 *
-	 * ### The `funding_signed` Message
-	 *
-	 * This message gives the funder the signature it needs for the first
-	 * commitment transaction, so it can broadcast the transaction knowing
-	 * that funds can be redeemed, if need be.
-	 */
-	peer_billboard(false,
-		       "Funding channel: create first tx, now waiting for their signature");
-
-	/* Now they send us their signature for that first commitment
-	 * transaction. */
-	msg = opening_negotiate_msg(tmpctx, state, true);
-	if (!msg)
-		goto fail_2;
-
-	sig.sighash_type = SIGHASH_ALL;
-	if (!fromwire_funding_signed(msg, &id_in, &sig.s))
-		peer_failed(state->pps,
-			    &state->channel_id,
-			    "Parsing funding_signed: %s", tal_hex(msg, msg));
-
-	/* BOLT #2:
-	 *
-	 * This message introduces the `channel_id` to identify the channel.
-	 * It's derived from the funding transaction by combining the
-	 * `funding_txid` and the `funding_output_index`, using big-endian
-	 * exclusive-OR (i.e. `funding_output_index` alters the last 2
-	 * bytes).
-	 */
-
-	/*~ Back in Milan, we chose to allow multiple channels between peers in
-	 * the protocol.  I insisted that we multiplex these over the same
-	 * socket, and (even though I didn't plan on implementing it anytime
-	 * soon) that we put it into the first version of the protocol
-	 * because it would be painful to add in later.
-	 *
-	 * My logic seemed sound: we treat new connections as an implication
-	 * that the old connection has disconnected, which happens more often
-	 * than you'd hope on modern networks.  However, supporting multiple
-	 * channels via multiple connections would be far easier for us to
-	 * support with our (introduced-since) separate daemon model.
-	 *
-	 * Let this be a lesson: beware premature specification, even if you
-	 * suspect "we'll need it later!". */
-	derive_channel_id(&state->channel_id,
-			  &state->funding_txid, state->funding_txout);
-
-	if (!channel_id_eq(&id_in, &state->channel_id))
-		peer_failed(state->pps, &id_in,
-			    "funding_signed ids don't match: expected %s got %s",
-			    type_to_string(msg, struct channel_id,
-					   &state->channel_id),
-			    type_to_string(msg, struct channel_id, &id_in));
-
-	/* BOLT #2:
-	 *
-	 * The recipient:
-	 *   - if `signature` is incorrect:
-	 *     - MUST fail the channel.
-	 */
-	/* So we create *our* initial commitment transaction, and check the
-	 * signature they sent against that. */
-	tx = initial_channel_tx(state, &wscript, state->channel,
-				&state->first_per_commitment_point[LOCAL],
-				LOCAL, &err_reason);
-	if (!tx) {
-		negotiation_failed(state, true,
-				   "Could not meet our fees and reserve: %s", err_reason);
-		goto fail_2;
-	}
-
-	if (!check_tx_sig(tx, 0, NULL, wscript, &their_funding_pubkey, &sig)) {
-		peer_failed(state->pps,
-			    &state->channel_id,
-			    "Bad signature %s on tx %s using key %s",
-			    type_to_string(tmpctx, struct bitcoin_signature,
-					   &sig),
-			    type_to_string(tmpctx, struct bitcoin_tx, tx),
-			    type_to_string(tmpctx, struct pubkey,
-					   &their_funding_pubkey));
-	}
-
-	peer_billboard(false, "Funding channel: opening negotiation succeeded");
 
 	if (taken(utxos))
 		tal_free(utxos);
@@ -1030,22 +1102,19 @@ static u8 *funder_channel(struct state *state,
 					   tx,
 					   &sig,
 					   state->pps,
-					   &theirs.revocation,
-					   &theirs.payment,
-					   &theirs.htlc,
-					   &theirs.delayed_payment,
+					   &state->their_points.revocation,
+					   &state->their_points.payment,
+					   &state->their_points.htlc,
+					   &state->their_points.delayed_payment,
 					   &state->first_per_commitment_point[REMOTE],
-					   minimum_depth,
-					   &their_funding_pubkey,
+					   state->minimum_depth,
+					   &state->their_funding_pubkey,
 					   &state->funding_txid,
 					   state->funding_txout,
 					   state->feerate_per_kw,
 					   state->localconf.channel_reserve,
 					   state->remote_upfront_shutdown_script);
 
-fail_2:
-	tal_free(wscript);
-	tal_free(funding);
 fail:
 	if (taken(utxos))
 		tal_free(utxos);
@@ -1611,7 +1680,9 @@ static u8 *handle_master_in(struct state *state)
 						      &funding_txid,
 						      &funding_txout))
 			master_badmsg(WIRE_OPENING_FUNDER_CONTINUE, msg);
-		return funder_channel_continue(state, &funding_txid);
+		state->funding_txid = funding_txid;
+		state->funding_txout = funding_txout;
+		return funder_channel_continue(state);
 	case WIRE_OPENING_DEV_MEMLEAK:
 #if DEVELOPER
 		handle_dev_memleak(state, msg);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -610,6 +610,10 @@ static u8 *funder_channel_start(struct state *state,
 						       &state->our_funding_pubkey,
 						       &their_funding_pubkey));
 
+	/* Update the billboard with our infos */
+	peer_billboard(false,
+		       "Funding channel start: awaiting funding_txid with output to %s",
+		       tal_hex(tmpctx, funding_output_script));
 	return towire_opening_funder_start_reply(state, funding_output_script);
 }
 

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1683,6 +1683,16 @@ static u8 *handle_master_in(struct state *state)
 		state->funding_txid = funding_txid;
 		state->funding_txout = funding_txout;
 		return funder_channel_continue(state);
+	case WIRE_OPENING_FUNDER_CANCEL:
+		/* We're aborting this, simple */
+		if (!fromwire_opening_funder_cancel(msg))
+			master_badmsg(WIRE_OPENING_FUNDER_CANCEL, msg);
+
+		msg = towire_errorfmt(NULL, &state->channel_id, "Channel open canceled by us");
+		sync_crypto_write(state->pps, take(msg));
+		negotiation_aborted(state, true,
+				    "Channel open canceled by RPC", false);
+		return NULL;
 	case WIRE_OPENING_DEV_MEMLEAK:
 #if DEVELOPER
 		handle_dev_memleak(state, msg);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1038,6 +1038,7 @@ static u8 *funder_channel(struct state *state,
 					   minimum_depth,
 					   &their_funding_pubkey,
 					   &state->funding_txid,
+					   state->funding_txout,
 					   state->feerate_per_kw,
 					   state->localconf.channel_reserve,
 					   state->remote_upfront_shutdown_script);
@@ -1573,6 +1574,7 @@ static u8 *handle_master_in(struct state *state)
 	u32 change_keyindex;
 	u8 channel_flags;
 	struct bitcoin_txid funding_txid;
+	u16 funding_txout;
 	struct utxo **utxos;
 	struct ext_key bip32_base;
 
@@ -1606,7 +1608,8 @@ static u8 *handle_master_in(struct state *state)
 		return NULL;
 	case WIRE_OPENING_FUNDER_CONTINUE:
 		if (!fromwire_opening_funder_continue(msg,
-						      &funding_txid))
+						      &funding_txid,
+						      &funding_txout))
 			master_badmsg(WIRE_OPENING_FUNDER_CONTINUE, msg);
 		return funder_channel_continue(state, &funding_txid);
 	case WIRE_OPENING_DEV_MEMLEAK:

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -73,7 +73,7 @@ struct state {
 	struct basepoints our_points;
 	struct pubkey our_funding_pubkey;
 
-	/* Information we need between funding_start and funding_continue */
+	/* Information we need between funding_start and funding_complete */
 	struct basepoints their_points;
 	struct pubkey their_funding_pubkey;
 
@@ -805,7 +805,7 @@ fail:
 	return false;
 }
 
-static u8 *funder_channel_continue(struct state *state)
+static u8 *funder_channel_complete(struct state *state)
 {
 	struct bitcoin_tx *tx;
 	struct bitcoin_signature sig;
@@ -1675,14 +1675,14 @@ static u8 *handle_master_in(struct state *state)
 		/* We want to keep openingd alive, since we're not done yet */
 		wire_sync_write(REQ_FD, take(msg));
 		return NULL;
-	case WIRE_OPENING_FUNDER_CONTINUE:
-		if (!fromwire_opening_funder_continue(msg,
+	case WIRE_OPENING_FUNDER_COMPLETE:
+		if (!fromwire_opening_funder_complete(msg,
 						      &funding_txid,
 						      &funding_txout))
-			master_badmsg(WIRE_OPENING_FUNDER_CONTINUE, msg);
+			master_badmsg(WIRE_OPENING_FUNDER_COMPLETE, msg);
 		state->funding_txid = funding_txid;
 		state->funding_txout = funding_txout;
-		return funder_channel_continue(state);
+		return funder_channel_complete(state);
 	case WIRE_OPENING_FUNDER_CANCEL:
 		/* We're aborting this, simple */
 		if (!fromwire_opening_funder_cancel(msg))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import time
 import random
+import re
 import shutil
 import unittest
 
@@ -816,6 +817,54 @@ def test_funding_by_utxos(node_factory, bitcoind):
     # Fund another channel with already spent utxos
     with pytest.raises(RpcError, match=r"No matching utxo was found from the wallet"):
         l1.rpc.fundchannel(l3.info["id"], int(0.01 * 10**8), utxos=utxos)
+
+
+# Check a bunch of preliminary states for calling these RPCs
+def test_funding_external_wallet_corners(node_factory, bitcoind):
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node()
+
+    amount = 2**24
+    # Fail to open (too large)
+    with pytest.raises(RpcError, match=r'Amount exceeded 16777215'):
+        l1.rpc.fundchannel_start(l2.info['id'], amount)
+
+    amount = amount - 1
+    fake_txid = '929764844a8f9938b669a60a1d51a11c9e2613c7eb4776e4126f1f20c0a685c3'
+
+    with pytest.raises(RpcError, match=r'Unknown peer'):
+        l1.rpc.fundchannel_start(l2.info['id'], amount)
+
+    with pytest.raises(RpcError, match=r'Unknown peer'):
+        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid)
+
+    # Should not be able to continue without being in progress.
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    with pytest.raises(RpcError, match=r'No channel funding in progress.'):
+        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid)
+
+
+def test_funding_external_wallet(node_factory, bitcoind):
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node()
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    assert(l1.rpc.listpeers()['peers'][0]['id'] == l2.info['id'])
+
+    amount = 2**24 - 1
+    address = l1.rpc.fundchannel_start(l2.info['id'], amount)['funding_address']
+    assert len(address) > 0
+
+    peer = l1.rpc.listpeers()['peers'][0]
+    # Peer should still be connected and in state waiting for funding_txid
+    assert peer['id'] == l2.info['id']
+    r = re.compile('Funding channel start: awaiting funding_txid with output to .*')
+    assert any(r.match(line) for line in peer['channels'][0]['status'])
+    assert 'OPENINGD' in peer['channels'][0]['state']
+
+    # Trying to start a second funding should not work, it's in progress.
+    with pytest.raises(RpcError, match=r'Already funding channel'):
+        l1.rpc.fundchannel_start(l2.info['id'], amount)
 
 
 def test_lockin_between_restart(node_factory, bitcoind):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -831,17 +831,18 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
 
     amount = amount - 1
     fake_txid = '929764844a8f9938b669a60a1d51a11c9e2613c7eb4776e4126f1f20c0a685c3'
+    fake_txout = 0
 
     with pytest.raises(RpcError, match=r'Unknown peer'):
         l1.rpc.fundchannel_start(l2.info['id'], amount)
 
     with pytest.raises(RpcError, match=r'Unknown peer'):
-        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid)
+        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid, fake_txout)
 
     # Should not be able to continue without being in progress.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     with pytest.raises(RpcError, match=r'No channel funding in progress.'):
-        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid)
+        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid, fake_txout)
 
 
 def test_funding_external_wallet(node_factory, bitcoind):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -837,12 +837,12 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
         l1.rpc.fundchannel_start(l2.info['id'], amount)
 
     with pytest.raises(RpcError, match=r'Unknown peer'):
-        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid, fake_txout)
+        l1.rpc.fundchannel_complete(l2.info['id'], fake_txid, fake_txout)
 
     # Should not be able to continue without being in progress.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     with pytest.raises(RpcError, match=r'No channel funding in progress.'):
-        l1.rpc.fundchannel_continue(l2.info['id'], fake_txid, fake_txout)
+        l1.rpc.fundchannel_complete(l2.info['id'], fake_txid, fake_txout)
 
     l1.rpc.fundchannel_start(l2.info['id'], amount)
     with pytest.raises(RpcError, match=r'Already funding channel'):
@@ -886,7 +886,7 @@ def test_funding_external_wallet(node_factory, bitcoind):
     txid = bitcoind.rpc.decoderawtransaction(raw_funded_tx)['txid']
     txout = 1 if funded_tx_obj['changepos'] == 0 else 0
 
-    assert l1.rpc.fundchannel_continue(l2.info['id'], txid, txout)['commitments_secured']
+    assert l1.rpc.fundchannel_complete(l2.info['id'], txid, txout)['commitments_secured']
 
     # Broadcast the transaction manually and confirm that channel locks in
     signed_tx = bitcoind.rpc.signrawtransactionwithwallet(raw_funded_tx)['hex']

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -844,6 +844,14 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     with pytest.raises(RpcError, match=r'No channel funding in progress.'):
         l1.rpc.fundchannel_continue(l2.info['id'], fake_txid, fake_txout)
 
+    l1.rpc.fundchannel_start(l2.info['id'], amount)
+    with pytest.raises(RpcError, match=r'Already funding channel'):
+        l1.rpc.fundchannel(l2.info['id'], amount)
+
+    l1.rpc.fundchannel_cancel(l2.info['id'])
+    # Should be able to 'restart' after canceling
+    l1.rpc.fundchannel_start(l2.info['id'], amount)
+
 
 def test_funding_external_wallet(node_factory, bitcoind):
     l1 = node_factory.get_node()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -288,6 +288,7 @@ class BitcoinD(TailableProc):
             '-logtimestamps',
             '-nolisten',
             '-txindex',
+            '-addresstype=bech32'
         ]
         # For up to and including 0.16.1, this needs to be in main section.
         BITCOIND_CONFIG['rpcport'] = rpcport

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -2,6 +2,7 @@
 #include <bitcoin/base58.h>
 #include <bitcoin/script.h>
 #include <ccan/tal/str/str.h>
+#include <common/addr.h>
 #include <common/bech32.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
@@ -425,26 +426,6 @@ encode_pubkey_to_addr(const tal_t *ctx,
 	return out;
 }
 
-/* Returns NULL if the script is not a P2WPKH */
-static char *
-encode_scriptpubkey_to_addr(const tal_t *ctx,
-			    const struct lightningd *ld,
-			    const u8 *scriptPubkey)
-{
-	char *out;
-	const char *hrp;
-	size_t scriptLen = tal_bytelen(scriptPubkey);
-	bool ok;
-	if (scriptLen != 22 || scriptPubkey[0] != 0x00 || scriptPubkey[1] != 0x14)
-		return NULL;
-	hrp = get_chainparams(ld)->bip173_name;
-	out = tal_arr(ctx, char, 73 + strlen(hrp));
-	ok = segwit_addr_encode(out, hrp, 0, scriptPubkey + 2, scriptLen - 2);
-	if (!ok)
-		return tal_free(out);
-	return out;
-}
-
 enum addrtype {
 	ADDR_P2SH_SEGWIT = 1,
 	ADDR_BECH32 = 2,
@@ -649,7 +630,8 @@ static struct command_result *json_listfunds(struct command *cmd,
 		        json_add_string(response, "address", out);
 		} else if (utxos[i]->scriptPubkey != NULL) {
 			out = encode_scriptpubkey_to_addr(
-			    cmd, cmd->ld, utxos[i]->scriptPubkey);
+			    cmd, get_chainparams(cmd->ld)->bip173_name,
+			    utxos[i]->scriptPubkey);
 			if (out)
 				json_add_string(response, "address", out);
 		}


### PR DESCRIPTION
Adds RPC commands for funding a channel via an external wallet.

There's a lot of caveats around the expected behavior of the wallet (uses SegWit ie non-malleable inputs, doesn't broadcast until `continue` has completed, provides the _correct_ funding amount to `fundchannel_start`) that this doesn't have any way of enforcing. As such, it's behind an experimental flag -- a good plugin could probably paper over the majority of these issues. 

RPCs added are as follows:
 -  `fundchannel_start`. Returns a bech32 address that is the funding tx destination. 
 - `fundchannel_continue`. Takes a funding txid and vout, returns the channel_id and confirmation that we've secured the commitment transactions for this channel.
 - `fundchannel_cancel`. Instead of `continue`, halts the fund channel flow.


Fixes #644 