### PR TITLE
Fix build in distros with older GCCs

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -171,7 +171,7 @@ static void start_commit_timer(struct peer *peer);
 
 static void billboard_update(const struct peer *peer)
 {
-	const char *funding_status, *announce_status, *shutdown_status;
+	const char *funding_status = "", *announce_status = "", *shutdown_status = "";
 
 	if (peer->funding_locked[LOCAL] && peer->funding_locked[REMOTE])
 		funding_status = "Funding transaction locked.";

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -120,7 +120,7 @@ static const struct htlc **include_htlcs(struct channel *channel, enum side side
 		struct preimage preimage;
 		struct sha256 hash;
 		enum channel_add_err e;
-		enum side sender;
+		enum side sender = 0;
 		struct amount_msat msatoshi = AMOUNT_MSAT(0);
 
 		switch (i) {

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 	struct amount_sat sat;
 	bool verbose = false;
 	char *infile = NULL, *outfile = NULL, *csvfile = NULL, *csat = NULL;
-	int infd, outfd, scidi = 0, channels = 0, nodes = 0, updates = 0;
+	int infd = 0, outfd, scidi = 0, channels = 0, nodes = 0, updates = 0;
 	struct scidsat *scidsats = NULL;
 	unsigned max = -1U;
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -988,7 +988,7 @@ find_shorter_route(const tal_t *ctx, struct routing_state *rstate,
 		   struct amount_msat *fee)
 {
 	struct unvisited *unvisited;
-	struct chan **short_route;
+	struct chan **short_route = NULL;
 	struct amount_msat long_cost, short_cost, cost_diff;
 	u64 min_bias, max_bias;
 	double riskfactor;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -977,7 +977,7 @@ json_tok_address_scriptpubkey(const tal_t *cxt,
 	const char *bip173;
 
 	bool parsed;
-	bool right_network;
+	bool right_network = false;
 	u8 addr_version;
 
 	parsed =


### PR DESCRIPTION
Here are the latest line of patches that fixes the build on older GCCs. This is the case on NixOS which still hasn't migrated to a newer version yet.