### PR TITLE
build: set -Wno-error=maybe-uninitialized for gcc 7

### DIFF
--- a/configure
+++ b/configure
@@ -14,6 +14,19 @@ STATIC=${STATIC:-0}
 CONFIGURATOR_CC=${CONFIGURATOR_CC:-$CC}
 ASAN=${ASAN:-0}
 
+[ "$CC" = "gcc" ] && IS_GCC=1 || IS_GCC=0
+
+# older version of gcc give warnings which break the build. Let's create
+# a few helper flags that our build can use to fix these problems.
+if [ $IS_GCC -eq 1 ]; then
+    GCC_VERSION=$(gcc --version | grep ^gcc | sed 's/^.* //g')
+    GCC_MAJOR=$(printf "%s\n" "$GCC_VERSION" | sed -E -n 's/([[:digit:]]+).*/\1/p')
+    if [ $GCC_MAJOR -eq 7 ]; then
+        printf "older gcc detected, setting UNRELIABLE_MAYBE_UNINIT_WARNINGS=1\n"
+        UNRELIABLE_MAYBE_UNINIT_WARNINGS=1
+    fi;
+fi
+
 CONFIGURATOR=ccan/tools/configurator/configurator
 CONFIG_VAR_FILE=config.vars
 CONFIG_HEADER=ccan/config.h
@@ -142,12 +155,15 @@ if [ -z ${COPTFLAGS+x} ]; then
    fi
 fi
 
-# We only enable Werror if we're -O3 or no-optimization.  Otherwise gcc gives
-# false positives.
+# We only enable Werror if we're -O3, no-optimization, or newer gcc
+# versions. Otherwise gcc gives false positives.
 if [ -z ${CWARNFLAGS+x} ]; then
     CWARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition"
     if [ -x ${COPTFLAGS+x} ] || [ -z "${COPTFLAGS##*-O3*}" ]; then
-	CWARNFLAGS="$CWARNFLAGS -Werror"
+        CWARNFLAGS="$CWARNFLAGS -Werror"
+    fi
+    if [ $UNRELIABLE_MAYBE_UNINIT_WARNINGS -eq 1 ]; then
+        CWARNFLAGS="$CWARNFLAGS -Wno-error=maybe-uninitialized"
     fi
 fi
 

--- a/connectd/tor_autoservice.c
+++ b/connectd/tor_autoservice.c
@@ -120,7 +120,7 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 {
 	char *line;
 	char *cookiefile = NULL;
-	int cookiefileerrno = 0;
+	int cookiefileerrno;
 
 	tor_send_cmd(rbuf, "PROTOCOLINFO 1");
 

--- a/devtools/create-gossipstore.c
+++ b/devtools/create-gossipstore.c
@@ -115,6 +115,8 @@ int main(int argc, char *argv[])
 		if (infd < 0)
 			err(1, "opening %s", infile);
 	}
+	else
+		infd = STDIN_FILENO;
 
 	if (outfile) {
 		outfd = open(outfile, O_WRONLY|O_TRUNC|O_CREAT, 0666);

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -171,11 +171,11 @@ int main(int argc, char *argv[])
 {
 	struct io_conn *conn = tal(NULL, struct io_conn);
 	struct wireaddr_internal addr;
-	int af = -1;
+	int af;
 	struct pubkey us, them;
 	const char *err_msg;
 	const char *at;
-	struct addrinfo *ai = NULL;
+	struct addrinfo *ai;
 
 	setup_locale();
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY |

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -988,7 +988,7 @@ find_shorter_route(const tal_t *ctx, struct routing_state *rstate,
 		   struct amount_msat *fee)
 {
 	struct unvisited *unvisited;
-	struct chan **short_route;
+	struct chan **short_route = NULL;
 	struct amount_msat long_cost, short_cost, cost_diff;
 	u64 min_bias, max_bias;
 	double riskfactor;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1063,8 +1063,7 @@ static struct command_result *json_close(struct command *cmd,
 {
 	const jsmntok_t *idtok;
 	struct peer *peer;
-	/* FIXME: gcc 7.3.0 thinks this might not be initialized. */
-	struct channel *channel = NULL;
+	struct channel *channel;
 	unsigned int *timeout;
 	bool *force;
 

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1390,7 +1390,7 @@ static size_t resolve_our_htlc_ourcommit(struct tracked_output *out,
 					 const struct htlc_stub *htlcs,
 					 u8 **htlc_scripts)
 {
-	struct bitcoin_tx *tx = NULL;
+	struct bitcoin_tx *tx;
 	struct bitcoin_signature localsig;
 	size_t i;
 	struct amount_msat htlc_amount;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -664,7 +664,7 @@ static struct command_result *add_shadow_route(struct command *cmd,
 	const jsmntok_t *channels = json_get_member(buf, result, "channels");
 	const jsmntok_t *chan, *best = NULL;
 	size_t i;
-	u64 sample = 0;
+	u64 sample;
 	u32 cltv, best_cltv;
 
 	json_for_each_arr(i, chan, channels) {


### PR DESCRIPTION
Instead of silencing every individual maybe-uninitialized false positive, let's disable that warning error for older gcc versions.

Also revert all of my old build fixup commits. They shouldn't be needed anymore, and they potentially mask real uninitialized errors that could be caught in newer gcc versions.