### PR TITLE
cdecker's weekly cleanups

### DIFF
--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -469,8 +469,6 @@ static struct io_plan *sd_msg_read(struct io_conn *conn, struct subd *sd)
 		}
 	}
 
-	log_debug(sd->log, "UPDATE %s", sd->msgname(type));
-
 	/* Might free sd (if returns negative); save/restore sd->conn */
 	sd->conn = NULL;
 	tal_add_destructor2(sd, mark_freed, &freed);

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -308,7 +308,7 @@ def test_penalty_inhtlc(node_factory, bitcoind, executor):
     l2.daemon.wait_for_log('=WIRE_COMMITMENT_SIGNED-nocommit')
 
     # Make sure l1 got l2's commitment to the HTLC, and sent to master.
-    l1.daemon.wait_for_log('UPDATE WIRE_CHANNEL_GOT_COMMITSIG')
+    l1.daemon.wait_for_log('got commitsig')
 
     # Take our snapshot.
     tx = l1.rpc.dev_sign_last_tx(l2.info['id'])['tx']

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -375,6 +375,8 @@ def test_reconnect_gossiping(node_factory):
     l2 = node_factory.get_node(disconnect=disconnects,
                                may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    # Make sure l2 knows about l1
+    wait_for(lambda: l2.rpc.listpeers(l1.info['id'])['peers'] != [])
 
     l2.rpc.ping(l1.info['id'], 1, 65532)
     wait_for(lambda: l1.rpc.listpeers(l2.info['id'])['peers'] == [])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from fixtures import *  # noqa: F401,F403
+from flaky import flaky  # noqa: F401
 from lightning import RpcError
 from utils import DEVELOPER, only_one, wait_for, sync_blockheight, VALGRIND
 
@@ -565,6 +566,7 @@ def test_reconnect_receiver_fulfill(node_factory):
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['status'] == 'paid'
 
 
+@flaky
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
 def test_shutdown_reconnect(node_factory):
     disconnects = ['-WIRE_SHUTDOWN',

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from fixtures import *  # noqa: F401,F403
-from flaky import flaky
+from flaky import flaky  # noqa: F401
 from lightning import RpcError
 from utils import DEVELOPER, VALGRIND, sync_blockheight, only_one, wait_for, TailableProc
 from ephemeral_port_reserve import reserve

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1,4 +1,5 @@
 from fixtures import *  # noqa: F401,F403
+from flaky import flaky  # noqa: F401
 from lightning import RpcError, Millisatoshi
 from utils import DEVELOPER, wait_for, only_one, sync_blockheight, SLOW_MACHINE
 
@@ -1614,6 +1615,7 @@ def test_pay_routeboost(node_factory, bitcoind):
         assert [h['channel'] for h in attempts[2]['routehint']] == [r['short_channel_id'] for r in routel3l5]
 
 
+@flaky
 @unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_pay_direct(node_factory, bitcoind):
     """Check that we prefer the direct route.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from fixtures import *  # noqa: F401,F403
+from flaky import flaky  # noqa: F401
 from lightning import RpcError, Millisatoshi
 from utils import only_one, wait_for
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -317,6 +317,7 @@ class BitcoinD(TailableProc):
     def get_proxy(self):
         proxy = BitcoinRpcProxy(self)
         self.proxies.append(proxy)
+        proxy.start()
         return proxy
 
     def generate_block(self, numblocks=1):
@@ -384,8 +385,6 @@ class LightningD(TailableProc):
         return self.cmd_prefix + [self.executable] + opts
 
     def start(self):
-        self.rpcproxy.start()
-
         self.opts['bitcoin-rpcport'] = self.rpcproxy.rpcport
         TailableProc.start(self)
         self.wait_for_log("Server started with public key")


### PR DESCRIPTION
Things that don't really fit in anywhere else:

 - Avoid trying to restart the `bitcoind` proxy along with `lightingd`, removes the `unable to bind` warning
 - A small fix to wait for a connection to be recognized before trying to use it
 - Marking some flaky tests as `@flaky` (will do a stabilization pass later, but they were really annoying and were addressed only by restarting instead of fixing them).
 - Remove the `UPDATE <message_type>` spam from `subd` which is really annoying in production.