### PR TITLE
Plugin: accept different option types (str, int, bool)

### DIFF
--- a/contrib/pylightning/lightning/plugin.py
+++ b/contrib/pylightning/lightning/plugin.py
@@ -183,7 +183,7 @@ class Plugin(object):
             return f
         return decorator
 
-    def add_option(self, name, default, description):
+    def add_option(self, name, default, description, opt_type="string"):
         """Add an option that we'd like to register with lightningd.
 
         Needs to be called before `Plugin.run`, otherwise we might not
@@ -194,11 +194,12 @@ class Plugin(object):
             raise ValueError(
                 "Name {} is already used by another option".format(name)
             )
+
         self.options[name] = {
             'name': name,
             'default': default,
             'description': description,
-            'type': 'string',
+            'type': opt_type,
             'value': None,
         }
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -81,11 +81,22 @@ struct plugins {
 	struct lightningd *ld;
 };
 
+/* The value of a plugin option, which can have different types.
+ * The presence of the integer and boolean values will depend of
+ * the option type, but the string value will always be filled.
+ */
+struct plugin_opt_value {
+	char *as_str;
+	int *as_int;
+	bool *as_bool;
+};
+
 struct plugin_opt {
 	struct list_node list;
 	const char *name;
+	const char *type;
 	const char *description;
-	char *value;
+	struct plugin_opt_value *value;
 };
 
 struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
@@ -463,8 +474,13 @@ static struct io_plan *plugin_stdout_conn_init(struct io_conn *conn,
 
 char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
 {
-	tal_free(popt->value);
-	popt->value = tal_strdup(popt, arg);
+	tal_free(popt->value->as_str);
+	popt->value->as_str = tal_strdup(popt, arg);
+	if (streq(popt->type, "int"))
+		*popt->value->as_int = atoi(arg);
+	else if (streq(popt->type, "bool"))
+		*popt->value->as_bool = streq(arg, "true") || streq(arg, "True")
+			|| streq(arg, "1");
 	return NULL;
 }
 
@@ -486,31 +502,48 @@ static bool plugin_opt_add(struct plugin *plugin, const char *buffer,
 		return false;
 	}
 
-	/* FIXME(cdecker) Support numeric and boolean options as well */
-	if (!json_tok_streq(buffer, typetok, "string")) {
-		plugin_kill(plugin,
-			    "Only \"string\" options currently supported");
-		return false;
-	}
-
 	popt = tal(plugin, struct plugin_opt);
+	popt->value = talz(popt, struct plugin_opt_value);
 
 	popt->name = tal_fmt(plugin, "--%.*s", nametok->end - nametok->start,
 			     buffer + nametok->start);
-	popt->value = NULL;
-	if (defaulttok) {
-		popt->value = json_strdup(popt, buffer, defaulttok);
-		popt->description = tal_fmt(
-		    popt, "%.*s (default: %s)", desctok->end - desctok->start,
-		    buffer + desctok->start, popt->value);
+	if (json_tok_streq(buffer, typetok, "string")) {
+		popt->type = "string";
+		if (defaulttok) {
+			popt->value->as_str = json_strdup(popt, buffer, defaulttok);
+			popt->description = tal_fmt(
+					popt, "%.*s (default: %s)", desctok->end - desctok->start,
+					buffer + desctok->start, popt->value->as_str);
+		}
+	} else if (json_tok_streq(buffer, typetok, "int")) {
+		popt->type = "int";
+		popt->value->as_int = talz(popt->value, int);
+		if (defaulttok) {
+			json_to_int(buffer, defaulttok, popt->value->as_int);
+			popt->value->as_str = tal_fmt(popt->value, "%d", *popt->value->as_int);
+			popt->description = tal_fmt(
+					popt, "%.*s (default: %i)", desctok->end - desctok->start,
+					buffer + desctok->start, *popt->value->as_int);
+		}
+	} else if (json_tok_streq(buffer, typetok, "bool")) {
+		popt->type = "bool";
+		popt->value->as_bool = talz(popt->value, bool);
+		if (defaulttok) {
+			json_to_bool(buffer, defaulttok, popt->value->as_bool);
+			popt->value->as_str = tal_fmt(popt->value, *popt->value->as_bool ? "true" : "false");
+			popt->description = tal_fmt(
+					popt, "%.*s (default: %s)", desctok->end - desctok->start,
+					buffer + desctok->start, *popt->value->as_bool ? "true" : "false");
+		}
 	} else {
-		popt->description = json_strdup(popt, buffer, desctok);
+		plugin_kill(plugin, "Only \"string\", \"int\", and \"bool\" options are supported");
+		return false;
 	}
-
+	if (!defaulttok)
+		popt->description = json_strdup(popt, buffer, desctok);
 	list_add_tail(&plugin->plugin_opts, &popt->list);
-
 	opt_register_arg(popt->name, plugin_opt_set, NULL, popt,
-			 popt->description);
+				popt->description);
 	return true;
 }
 
@@ -965,7 +998,6 @@ void plugins_init(struct plugins *plugins, const char *dev_plugin_debug)
 		}
 		tal_free(cmd);
 	}
-
 	while (plugins->pending_manifests > 0) {
 		void *v = io_loop(&plugins->timers, &expired);
 		if (v == plugins)
@@ -1000,8 +1032,9 @@ static void plugin_config(struct plugin *plugin)
 	list_for_each(&plugin->plugin_opts, opt, list) {
 		/* Trim the `--` that we added before */
 		name = opt->name + 2;
-		if (opt->value)
-			json_add_string(req->stream, name, opt->value);
+		if (opt->value->as_str) {
+			json_add_string(req->stream, name, opt->value->as_str);
+		}
 	}
 	json_object_end(req->stream); /* end of .params.options */
 

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -83,10 +83,12 @@ int main(int argc, char *argv[])
 	setup_locale();
 	plugin_main(argv, init, commands, ARRAY_SIZE(commands),
 		    plugin_option("autocleaninvoice-cycle",
+				  "string",
 				  "Perform cleanup of expired invoices every"
 				  " given seconds, or do not autoclean if 0",
 				  u64_option, &cycle_seconds),
 		    plugin_option("autocleaninvoice-expired-by",
+				  "string",
 				  "If expired invoice autoclean enabled,"
 				  " invoices that have expired for at least"
 				  " this given seconds are cleaned",

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -439,11 +439,12 @@ handle_getmanifest(struct command *getmanifest_cmd,
 
 	for (size_t i = 0; i < tal_count(opts); i++) {
 		tal_append_fmt(&params, "{ 'name': '%s',"
-			       "    'type': 'string',"
-			       "    'description': '%s' }%s",
-			       opts[i].name,
-			       opts[i].description,
-			       i == tal_count(opts) - 1 ? "" : ",\n");
+				"    'type': '%s',"
+				"    'description': '%s' }%s",
+				opts[i].name,
+				opts[i].type,
+				opts[i].description,
+				i == tal_count(opts) - 1 ? "" : ",\n");
 	}
 
 	tal_append_fmt(&params,
@@ -505,7 +506,6 @@ static struct command_result *handle_init(struct command *init_cmd,
 					  &rpc_conn,
 					  ".allow-deprecated-apis"),
 				"true");
-
 	opttok = json_get_member(buf, params, "options");
 	json_for_each_obj(i, t, opttok) {
 		char *opt = json_strdup(NULL, buf, t);
@@ -693,6 +693,7 @@ void plugin_main(char *argv[],
 	while ((optname = va_arg(ap, const char *)) != NULL) {
 		struct plugin_option o;
 		o.name = optname;
+		o.type = va_arg(ap, const char *);
 		o.description = va_arg(ap, const char *);
 		o.handle = va_arg(ap, char *(*)(const char *str, void *arg));
 		o.arg = va_arg(ap, void *);

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -28,6 +28,7 @@ struct plugin_command {
 /* Create an array of these, one for each --option you support. */
 struct plugin_option {
 	const char *name;
+	const char *type;
 	const char *description;
 	char *(*handle)(const char *str, void *arg);
 	void *arg;
@@ -118,8 +119,9 @@ struct plugin_timer *plugin_timer(struct plugin_conn *rpc,
 void PRINTF_FMT(2, 3) plugin_log(enum log_level l, const char *fmt, ...);
 
 /* Macro to define arguments */
-#define plugin_option(name, description, set, arg)			\
+#define plugin_option(name, type, description, set, arg)			\
 	(name),								\
+	(type),								\
 	(description),							\
 	typesafe_cb_preargs(char *, void *, (set), (arg), const char *),	\
 	(arg)


### PR DESCRIPTION
This PR adds the possibility to register plugin options of type `int`, `bool` in addition to `string`.