### PR TITLE
test_closing.py: isAlive -> is_alive

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -779,7 +779,7 @@ def test_onchain_middleman(node_factory, bitcoind):
         print("Got err from sendpay thread")
         raise err
     t.join(timeout=1)
-    assert not t.isAlive()
+    assert not t.is_alive()
 
     # Three more, l2 can spend to-us.
     bitcoind.generate_block(3)


### PR DESCRIPTION
This is the warning I got from Python:

isAlive() is deprecated, use is_alive() instead