### PR TITLE
Gossip store fixes

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -644,3 +644,9 @@ out:
 		     gs->len);
 	gs->writable = true;
 }
+
+/* FIXME: Remove */
+bool gossip_store_loading(const struct gossip_store *gs)
+{
+	return !gs->writable;
+}

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -74,4 +74,7 @@ bool gossip_store_compact(struct gossip_store *gs,
  */
 int gossip_store_readonly_fd(struct gossip_store *gs);
 
+/* FIXME: Remove */
+bool gossip_store_loading(const struct gossip_store *gs);
+
 #endif /* LIGHTNING_GOSSIPD_GOSSIP_STORE_H */

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -337,6 +337,12 @@ static void remove_chan_from_node(struct routing_state *rstate,
 	if (!node->bcast.index)
 		return;
 
+	/* FIXME: Remove when we get rid of WIRE_GOSSIP_STORE_CHANNEL_DELETE.
+	 * For the moment, it can cause us to try to write to the store. */
+	(void)WIRE_GOSSIP_STORE_CHANNEL_DELETE;
+	if (gossip_store_loading(rstate->broadcasts->gs))
+		return;
+
 	/* Removed only public channel?  Remove node announcement. */
 	if (!node_has_broadcastable_channels(node)) {
 		broadcast_del(rstate->broadcasts, &node->bcast);

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -944,9 +944,9 @@ def test_gossip_notices_close(node_factory, bitcoind):
 
     bitcoind.generate_block(5)
 
-    # Make sure l1 learns about channel.
+    # Make sure l1 learns about channel and nodes.
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)
-    wait_for(lambda: len(l1.rpc.listnodes()['nodes']) == 2)
+    wait_for(lambda: ['alias' in n for n in l1.rpc.listnodes()['nodes']] == [True, True])
     l1.rpc.disconnect(l2.info['id'])
 
     # Grab channel_announcement from io logs (ends in ')

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1132,7 +1132,6 @@ def test_gossip_store_load_complex(node_factory, bitcoind):
     wait_for(lambda: l2.daemon.is_in_log('gossip_store: Read '))
 
 
-@pytest.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
 def test_gossip_store_compact(node_factory, bitcoind):
     l2 = setup_gossip_store_test(node_factory, bitcoind)


### PR DESCRIPTION
As part of my final gossip optimizations PR, I tightened and added testing.  This revealed existing bugs: in particular, the "bad node_announcement" message we sometimes get loading store.

Fixing this revealed another nasty issue, where we tried to remove from the gossip_store as it was being loaded.  This is worked around for now: it will be fixed properly by rebasing #2644 on top of this....