### PR TITLE
Pass htlc amount exceeded to exception

### DIFF
--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -104,7 +104,8 @@ enum channel_add_err channel_add_htlc(struct channel *channel,
 				      u32 cltv_expiry,
 				      const struct sha256 *payment_hash,
 				      const u8 routing[TOTAL_PACKET_SIZE],
-				      struct htlc **htlcp);
+				      struct htlc **htlcp,
+				      struct amount_sat *htlc_fee);
 
 /**
  * channel_get_htlc: find an HTLC

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -150,7 +150,7 @@ static const struct htlc **include_htlcs(struct channel *channel, enum side side
 		memset(&preimage, i, sizeof(preimage));
 		sha256(&hash, &preimage, sizeof(preimage));
 		e = channel_add_htlc(channel, sender, i, msatoshi, 500+i, &hash,
-				     dummy_routing, NULL);
+				     dummy_routing, NULL, NULL);
 		assert(e == CHANNEL_ERR_ADD_OK);
 		htlcs[i] = channel_get_htlc(channel, sender, i);
 	}
@@ -242,7 +242,7 @@ static void send_and_fulfill_htlc(struct channel *channel,
 	sha256(&rhash, &r, sizeof(r));
 
 	assert(channel_add_htlc(channel, sender, 1337, msatoshi, 900, &rhash,
-				dummy_routing, NULL) == CHANNEL_ERR_ADD_OK);
+				dummy_routing, NULL, NULL) == CHANNEL_ERR_ADD_OK);
 
 	changed_htlcs = tal_arr(channel, const struct htlc *, 0);
 


### PR DESCRIPTION
This will  pass HTLC fee amounts into the "Capacity exception" so they can be catched and parsed by a upper layer plugin (i.e. https://github.com/lightningd/plugins/pull/22 ). This change is useful, because the required HTLC fees cannot be computed/checked in advance.

## Rationale

currently, if a payment is made, the required HTLC onchain fees will be substracted from the `spendable` amount. This is a temporary hedge against the channel balance, if anything goes wrong. This is done in an opaque way, so the upper layers (like plugins) can't know the correct value that needs to be subtracted from the `spendable` amount, in order for the node to make the payment. For example the `drain` plugin has a ugly `while`   `try/except` loop to increase gradually until the `Capacity exceeded` exception is not thrown any more.
