### PR TITLE
 lightningd/channel.c: Transfer peer to connectd only if connectd alive. 

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -408,9 +408,9 @@ static void shutdown_subdaemons(struct lightningd *ld)
 	close(ld->hsm_fd);
 	/*~ The three "global" daemons, which we shutdown explicitly: we
 	 * give them 10 seconds to exit gracefully before killing them.  */
-	subd_shutdown(ld->connectd, 10);
-	subd_shutdown(ld->gossip, 10);
-	subd_shutdown(ld->hsm, 10);
+	ld->connectd = subd_shutdown(ld->connectd, 10);
+	ld->gossip = subd_shutdown(ld->gossip, 10);
+	ld->hsm = subd_shutdown(ld->hsm, 10);
 
 	/* Now we free all the HTLCs */
 	free_htlcs(ld, NULL);

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -748,7 +748,7 @@ void subd_req_(const tal_t *ctx,
 	add_req(ctx, sd, type, num_fds_in, replycb, replycb_data);
 }
 
-void subd_shutdown(struct subd *sd, unsigned int seconds)
+struct subd *subd_shutdown(struct subd *sd, unsigned int seconds)
 {
 	log_debug(sd->log, "Shutting down");
 
@@ -761,7 +761,7 @@ void subd_shutdown(struct subd *sd, unsigned int seconds)
 	/* Wait for a while. */
 	while (seconds) {
 		if (waitpid(sd->pid, NULL, WNOHANG) > 0) {
-			return;
+			return (struct subd*) tal_free(sd);
 		}
 		sleep(1);
 		seconds--;
@@ -770,7 +770,7 @@ void subd_shutdown(struct subd *sd, unsigned int seconds)
 	/* Didn't die?  This will kill it harder */
 	sd->must_not_exit = false;
 	destroy_subd(sd);
-	tal_free(sd);
+	return (struct subd*) tal_free(sd);
 }
 
 void subd_release_channel(struct subd *owner, void *channel)

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -198,8 +198,12 @@ void subd_release_channel(struct subd *owner, void *channel);
  *
  * This closes the fd to the subdaemon, and gives it a little while to exit.
  * The @finished callback will never be called.
+ *
+ * Return value is null, so pattern should be:
+ *
+ * sd = subd_shutdown(sd, 10);
  */
-void subd_shutdown(struct subd *subd, unsigned int seconds);
+struct subd *subd_shutdown(struct subd *subd, unsigned int seconds);
 
 /* Ugly helper to get full pathname of the current binary. */
 const char *find_my_abspath(const tal_t *ctx, const char *argv0);


### PR DESCRIPTION
Fixes #2677 

I am unable to replicate 2677 in a test; it seems to me that there is something that prevents subdaemons of `lightningd` to respond quickly to communications with `lightningd`, but it is not present in our CI.