### PR TITLE
Fix flakes funding_reorg_private openchannel_hook and no_fee_estimate

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1266,6 +1266,7 @@ def test_no_fee_estimate(node_factory, bitcoind, executor):
 
     # Can do mutual close.
     l1.rpc.close(l2.info['id'])
+    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) > 0)
     bitcoind.generate_block(100)
 
     # Can do unilateral close.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -942,6 +942,7 @@ def test_funding_reorg_private(node_factory, bitcoind):
     wait_for(lambda: [c['active'] for c in l2.rpc.listchannels('108x1x0')['channels']] == [True, True])
 
     l1.rpc.close(l2.info['id'])                     # to ignore `Bad gossip order` error in killall
+    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) > 0)
     bitcoind.generate_block(1)
     l1.daemon.wait_for_log(r'Deleting channel')
     l2.daemon.wait_for_log(r'Deleting channel')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -303,6 +303,7 @@ def test_openchannel_hook(node_factory, bitcoind):
 
     # Close it.
     l1.rpc.close(l2.info['id'])
+    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) > 0)
     bitcoind.generate_block(1)
     wait_for(lambda: [c['state'] for c in only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['channels']] == ['ONCHAIN'])
 


### PR DESCRIPTION
We had two tests that had a race condition when closing a channel and then doing `bitcoind.generate_block(1)` that the bitcoind did not have the close tx in the mempool yet.

This PR adds missing `wait_for(lambda: len(bitcoind.rpc.getrawmempool()) > 0)` before calling `generate_block`