### PR TITLE
json-rpc: Annotate transactions of interest and add the `listtransactions` RPC method

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -53,6 +53,7 @@ COMMON_SRC_NOGEN :=				\
 	common/utils.c				\
 	common/utxo.c				\
 	common/version.c			\
+	common/wallet.c				\
 	common/wallet_tx.c			\
 	common/wireaddr.c			\
 	common/wire_error.c			\
@@ -60,7 +61,7 @@ COMMON_SRC_NOGEN :=				\
 
 COMMON_SRC_GEN := common/gen_status_wire.c common/gen_peer_status_wire.c
 
-COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h) common/overflows.h common/htlc.h common/status_levels.h common/json_command.h common/jsonrpc_errors.h common/wallet.h
+COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h) common/overflows.h common/htlc.h common/status_levels.h common/json_command.h common/jsonrpc_errors.h
 COMMON_HEADERS_GEN := common/gen_htlc_state_names.h common/gen_status_wire.h common/gen_peer_status_wire.h
 
 COMMON_HEADERS := $(COMMON_HEADERS_GEN) $(COMMON_HEADERS_NOGEN)

--- a/common/Makefile
+++ b/common/Makefile
@@ -60,7 +60,7 @@ COMMON_SRC_NOGEN :=				\
 
 COMMON_SRC_GEN := common/gen_status_wire.c common/gen_peer_status_wire.c
 
-COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h) common/overflows.h common/htlc.h common/status_levels.h common/json_command.h common/jsonrpc_errors.h
+COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h) common/overflows.h common/htlc.h common/status_levels.h common/json_command.h common/jsonrpc_errors.h common/wallet.h
 COMMON_HEADERS_GEN := common/gen_htlc_state_names.h common/gen_status_wire.h common/gen_peer_status_wire.h
 
 COMMON_HEADERS := $(COMMON_HEADERS_GEN) $(COMMON_HEADERS_NOGEN)

--- a/common/wallet.c
+++ b/common/wallet.c
@@ -1,0 +1,12 @@
+#include <common/wallet.h>
+
+enum wallet_tx_type fromwire_wallet_tx_type(const u8 **cursor, size_t *max)
+{
+	enum wallet_tx_type type = fromwire_u16(cursor, max);
+	return type;
+}
+
+void towire_wallet_tx_type(u8 **pptr, const enum wallet_tx_type type)
+{
+	towire_u16(pptr, type);
+}

--- a/common/wallet.h
+++ b/common/wallet.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_COMMON_WALLET_H
 
 #include "config.h"
+#include <wire/wire.h>
 
 /* Types of transactions we store in the `transactions` table. Mainly used for
  * display purposes later. */
@@ -19,7 +20,8 @@ enum wallet_tx_type {
        TX_CHANNEL_PENALTY = 512,
        TX_CHANNEL_CHEAT = 1024,
 };
-/* Any combination of the above wallet_tx_types */
-typedef unsigned short txtypes;
+
+enum wallet_tx_type fromwire_wallet_tx_type(const u8 **cursor, size_t *max);
+void towire_wallet_tx_type(u8 **pptr, const enum wallet_tx_type type);
 
 #endif /* LIGHTNING_COMMON_WALLET_H */

--- a/common/wallet.h
+++ b/common/wallet.h
@@ -1,0 +1,25 @@
+#ifndef LIGHTNING_COMMON_WALLET_H
+#define LIGHTNING_COMMON_WALLET_H
+
+#include "config.h"
+
+/* Types of transactions we store in the `transactions` table. Mainly used for
+ * display purposes later. */
+enum wallet_tx_type {
+       TX_UNKNOWN = 0,
+       TX_THEIRS = 1,  /* This only affects their funds in the channel */
+       TX_WALLET_DEPOSIT = 2,
+       TX_WALLET_WITHDRAWAL = 4,
+       TX_CHANNEL_FUNDING = 8,
+       TX_CHANNEL_CLOSE = 16,
+       TX_CHANNEL_UNILATERAL = 32,
+       TX_CHANNEL_SWEEP = 64,
+       TX_CHANNEL_HTLC_SUCCESS = 128,
+       TX_CHANNEL_HTLC_TIMEOUT = 256,
+       TX_CHANNEL_PENALTY = 512,
+       TX_CHANNEL_CHEAT = 1024,
+};
+/* Any combination of the above wallet_tx_types */
+typedef unsigned short txtypes;
+
+#endif /* LIGHTNING_COMMON_WALLET_H */

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -52,6 +52,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/utils.o				\
 	common/utxo.o				\
 	common/version.o			\
+	common/wallet.o				\
 	common/wallet_tx.o			\
 	common/wire_error.o			\
 	common/wireaddr.o			\

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -85,16 +85,18 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		}
 
 		owned = AMOUNT_SAT(0);
+		bitcoin_txid(tx, &txid);
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
-						     tx, &b->height,
-						     &owned);
+						     tx, &b->height, &owned);
+			wallet_transaction_add(topo->ld->wallet, tx, b->height,
+					       i);
+			wallet_transaction_annotate(topo->ld->wallet, &txid,
+						    TX_WALLET_DEPOSIT, 0);
 		}
 
 		/* We did spends first, in case that tells us to watch tx. */
-		bitcoin_txid(tx, &txid);
-		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid) ||
-		    !amount_sat_eq(owned, AMOUNT_SAT(0))) {
+		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid)) {
 			wallet_transaction_add(topo->ld->wallet,
 					       tx, b->height, i);
 		}

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -333,7 +333,7 @@ struct channel *channel_by_dbid(struct lightningd *ld, const u64 dbid)
 void channel_set_last_tx(struct channel *channel,
 			 struct bitcoin_tx *tx,
 			 const struct bitcoin_signature *sig,
-			 txtypes txtypes)
+			 enum wallet_tx_type txtypes)
 {
 	channel->last_sig = *sig;
 	tal_free(channel->last_tx);

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -233,6 +233,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->msat_to_us_min = msat_to_us_min;
 	channel->msat_to_us_max = msat_to_us_max;
 	channel->last_tx = tal_steal(channel, last_tx);
+	channel->last_tx_type = TX_UNKNOWN;
 	channel->last_sig = *last_sig;
 	channel->last_htlc_sigs = tal_steal(channel, last_htlc_sigs);
 	channel->channel_info = *channel_info;
@@ -331,11 +332,13 @@ struct channel *channel_by_dbid(struct lightningd *ld, const u64 dbid)
 
 void channel_set_last_tx(struct channel *channel,
 			 struct bitcoin_tx *tx,
-			 const struct bitcoin_signature *sig)
+			 const struct bitcoin_signature *sig,
+			 txtypes txtypes)
 {
 	channel->last_sig = *sig;
 	tal_free(channel->last_tx);
 	channel->last_tx = tal_steal(channel, tx);
+	channel->last_tx_type = txtypes;
 }
 
 void channel_set_state(struct channel *channel,

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -76,7 +76,7 @@ struct channel {
 
 	/* Last tx they gave us. */
 	struct bitcoin_tx *last_tx;
-	txtypes last_tx_type;
+	enum wallet_tx_type last_tx_type;
 	struct bitcoin_signature last_sig;
 	secp256k1_ecdsa_signature *last_htlc_sigs;
 
@@ -203,7 +203,7 @@ struct channel *channel_by_dbid(struct lightningd *ld, const u64 dbid);
 void channel_set_last_tx(struct channel *channel,
 			 struct bitcoin_tx *tx,
 			 const struct bitcoin_signature *sig,
-			 txtypes type);
+			 enum wallet_tx_type type);
 
 static inline bool channel_can_add_htlc(const struct channel *channel)
 {

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -76,6 +76,7 @@ struct channel {
 
 	/* Last tx they gave us. */
 	struct bitcoin_tx *last_tx;
+	txtypes last_tx_type;
 	struct bitcoin_signature last_sig;
 	secp256k1_ecdsa_signature *last_htlc_sigs;
 
@@ -201,7 +202,8 @@ struct channel *channel_by_dbid(struct lightningd *ld, const u64 dbid);
 
 void channel_set_last_tx(struct channel *channel,
 			 struct bitcoin_tx *tx,
-			 const struct bitcoin_signature *sig);
+			 const struct bitcoin_signature *sig,
+			 txtypes type);
 
 static inline bool channel_can_add_htlc(const struct channel *channel)
 {

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -95,8 +95,7 @@ static void peer_received_closing_signature(struct channel *channel,
 
 	/* FIXME: Make sure signature is correct! */
 	if (better_closing_fee(ld, channel, tx)) {
-		channel_set_last_tx(channel, tx, &sig);
-		/* TODO(cdecker) Selectively save updated fields to DB */
+		channel_set_last_tx(channel, tx, &sig, TX_CHANNEL_CLOSE);
 		wallet_channel_save(ld->wallet, channel);
 	}
 

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -394,7 +394,7 @@ enum watch_result onchaind_funding_spent(struct channel *channel,
 					 u32 blockheight)
 {
 	u8 *msg;
-	struct bitcoin_txid our_last_txid;
+	struct bitcoin_txid our_last_txid, txid;
 	struct htlc_stub *stubs;
 	struct lightningd *ld = channel->peer->ld;
 	struct pubkey final_key;
@@ -442,6 +442,7 @@ enum watch_result onchaind_funding_spent(struct channel *channel,
 		return KEEP_WATCHING;
 	}
 	/* This could be a mutual close, but it doesn't matter. */
+	bitcoin_txid(tx, &txid);
 	bitcoin_txid(channel->last_tx, &our_last_txid);
 
 	/* We try to use normal feerate for onchaind spends. */

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -167,7 +167,7 @@ static void handle_onchain_broadcast_tx(struct channel *channel, const u8 *msg)
 	struct bitcoin_tx *tx;
 	struct wallet *w = channel->peer->ld->wallet;
 	struct bitcoin_txid txid;
-	txtypes type;
+	enum wallet_tx_type type;
 
 	if (!fromwire_onchain_broadcast_tx(msg, msg, &tx, &type)) {
 		channel_internal_error(channel, "Invalid onchain_broadcast_tx");
@@ -294,7 +294,7 @@ static void onchain_add_utxo(struct channel *channel, const u8 *msg)
 static void onchain_transaction_annotate(struct channel *channel, const u8 *msg)
 {
 	struct bitcoin_txid txid;
-	txtypes type;
+	enum wallet_tx_type type;
 	if (!fromwire_onchain_transaction_annotate(msg, &txid, &type))
 		fatal("onchaind gave invalid onchain_transaction_annotate "
 		      "message: %s",

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -455,6 +455,8 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 
 	/* Mark consumed outputs as spent */
 	wallet_confirm_utxos(ld->wallet, fc->wtx->utxos);
+	wallet_transaction_annotate(ld->wallet, &funding_txid,
+				    TX_CHANNEL_FUNDING, channel->dbid);
 
 	/* Start normal channel daemon. */
 	peer_start_channeld(channel, pps, NULL, false);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -860,6 +860,8 @@ static enum watch_result funding_depth_cb(struct lightningd *ld,
 	if ((min_depth_reached && !channel->scid) || (depth && channel->scid)) {
 		struct txlocator *loc;
 
+		wallet_transaction_annotate(ld->wallet, txid,
+					    TX_CHANNEL_FUNDING, channel->dbid);
 		loc = wallet_transaction_locate(tmpctx, ld->wallet, txid);
 		if (!mk_short_channel_id(&scid,
 					 loc->blkheight, loc->index,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -344,6 +344,7 @@ register_close_command(struct lightningd *ld,
 void drop_to_chain(struct lightningd *ld, struct channel *channel,
 		   bool cooperative)
 {
+	struct bitcoin_txid txid;
 	/* BOLT #2:
 	 *
 	 * - if `next_remote_revocation_number` is greater than expected
@@ -357,6 +358,9 @@ void drop_to_chain(struct lightningd *ld, struct channel *channel,
 			   " they have a future one");
 	} else {
 		sign_last_tx(channel);
+		bitcoin_txid(channel->last_tx, &txid);
+		wallet_transaction_add(ld->wallet, channel->last_tx, 0, 0);
+		wallet_transaction_annotate(ld->wallet, &txid, channel->last_tx_type, channel->dbid);
 
 		/* Keep broadcasting until we say stop (can fail due to dup,
 		 * if they beat us to the broadcast). */
@@ -916,7 +920,6 @@ static enum watch_result funding_spent(struct channel *channel,
 
 	wallet_channeltxs_add(channel->peer->ld->wallet, channel,
 			      WIRE_ONCHAIN_INIT, &txid, 0, block->height);
-
 	return onchaind_funding_spent(channel, tx, block->height);
 }
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1240,7 +1240,7 @@ static bool peer_save_commitsig_received(struct channel *channel, u64 commitnum,
 	channel->next_index[LOCAL]++;
 
 	/* Update channel->last_sig and channel->last_tx before saving to db */
-	channel_set_last_tx(channel, tx, commit_sig);
+	channel_set_last_tx(channel, tx, commit_sig, TX_CHANNEL_UNILATERAL);
 
 	return true;
 }

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -557,6 +557,10 @@ void wallet_peer_delete(struct wallet *w UNNEEDED, u64 peer_dbid UNNEEDED)
 /* Generated stub for wallet_total_forward_fees */
 struct amount_msat wallet_total_forward_fees(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_total_forward_fees called!\n"); abort(); }
+/* Generated stub for wallet_transaction_add */
+void wallet_transaction_add(struct wallet *w UNNEEDED, const struct bitcoin_tx *tx UNNEEDED,
+			    const u32 blockheight UNNEEDED, const u32 txindex UNNEEDED)
+{ fprintf(stderr, "wallet_transaction_add called!\n"); abort(); }
 /* Generated stub for wallet_transaction_annotate */
 void wallet_transaction_annotate(struct wallet *w UNNEEDED,
 				 const struct bitcoin_txid *txid UNNEEDED, txtypes type UNNEEDED,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -557,6 +557,11 @@ void wallet_peer_delete(struct wallet *w UNNEEDED, u64 peer_dbid UNNEEDED)
 /* Generated stub for wallet_total_forward_fees */
 struct amount_msat wallet_total_forward_fees(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_total_forward_fees called!\n"); abort(); }
+/* Generated stub for wallet_transaction_annotate */
+void wallet_transaction_annotate(struct wallet *w UNNEEDED,
+				 const struct bitcoin_txid *txid UNNEEDED, txtypes type UNNEEDED,
+				 u64 channel_id UNNEEDED)
+{ fprintf(stderr, "wallet_transaction_annotate called!\n"); abort(); }
 /* Generated stub for wallet_transaction_locate */
 struct txlocator *wallet_transaction_locate(const tal_t *ctx UNNEEDED, struct wallet *w UNNEEDED,
 					    const struct bitcoin_txid *txid UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -563,8 +563,8 @@ void wallet_transaction_add(struct wallet *w UNNEEDED, const struct bitcoin_tx *
 { fprintf(stderr, "wallet_transaction_add called!\n"); abort(); }
 /* Generated stub for wallet_transaction_annotate */
 void wallet_transaction_annotate(struct wallet *w UNNEEDED,
-				 const struct bitcoin_txid *txid UNNEEDED, txtypes type UNNEEDED,
-				 u64 channel_id UNNEEDED)
+				 const struct bitcoin_txid *txid UNNEEDED,
+				 enum wallet_tx_type type UNNEEDED, u64 channel_id UNNEEDED)
 { fprintf(stderr, "wallet_transaction_annotate called!\n"); abort(); }
 /* Generated stub for wallet_transaction_locate */
 struct txlocator *wallet_transaction_locate(const tal_t *ctx UNNEEDED, struct wallet *w UNNEEDED,

--- a/onchaind/Makefile
+++ b/onchaind/Makefile
@@ -70,6 +70,7 @@ ONCHAIND_COMMON_OBJS :=				\
 	common/utils.o				\
 	common/utxo.o				\
 	common/version.o			\
+	common/wallet.o				\
 	hsmd/gen_hsm_wire.o
 
 onchaind/gen_onchain_wire.h: $(WIRE_GEN) onchaind/onchain_wire.csv

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -99,3 +99,10 @@ onchain_dev_memleak,5033
 
 onchain_dev_memleak_reply,5133
 onchain_dev_memleak_reply,,leak,bool
+
+# Tell the main daemon what we've been watching, mainly used for transactions
+# that we tracked automatically but only onchaind knows how to classify their
+# transactions.
+onchain_transaction_annotate,5034
+onchain_transaction_annotate,,txid,struct bitcoin_txid
+onchain_transaction_annotate,,type,u16

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -48,6 +48,7 @@ onchain_init_reply,5101
 # onchaind->master: Send out a tx.
 onchain_broadcast_tx,5003
 onchain_broadcast_tx,,tx,struct bitcoin_tx
+onchain_broadcast_tx,,type,u16
 
 # master->onchaind: Notifier that an output has been spent by input_num of tx.
 onchain_spent,5004

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -1,5 +1,6 @@
 #include <common/derive_basepoints.h>
 #include <common/htlc_wire.h>
+#include <common/wallet.h>
 
 # Begin!  Here's the onchain tx which spends funding tx, followed by all HTLCs.
 onchain_init,5001
@@ -48,7 +49,7 @@ onchain_init_reply,5101
 # onchaind->master: Send out a tx.
 onchain_broadcast_tx,5003
 onchain_broadcast_tx,,tx,struct bitcoin_tx
-onchain_broadcast_tx,,type,u16
+onchain_broadcast_tx,,type,enum wallet_tx_type
 
 # master->onchaind: Notifier that an output has been spent by input_num of tx.
 onchain_spent,5004
@@ -105,4 +106,4 @@ onchain_dev_memleak_reply,,leak,bool
 # transactions.
 onchain_transaction_annotate,5034
 onchain_transaction_annotate,,txid,struct bitcoin_txid
-onchain_transaction_annotate,,type,u16
+onchain_transaction_annotate,,type,enum wallet_tx_type

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -458,7 +458,7 @@ static void ignore_output(struct tracked_output *out)
 	out->resolved->tx_type = SELF;
 }
 
-static txtypes onchain_txtype_to_wallet_txtype(enum tx_type t)
+static enum wallet_tx_type onchain_txtype_to_wallet_txtype(enum tx_type t)
 {
 	switch (t) {
 	case FUNDING_TRANSACTION:
@@ -980,7 +980,8 @@ static void steal_htlc_tx(struct tracked_output *out)
 	propose_resolution(out, tx, 0, tx_type);
 }
 
-static void onchain_transaction_annotate(const struct bitcoin_txid *txid, txtypes type)
+static void onchain_transaction_annotate(const struct bitcoin_txid *txid,
+					 enum wallet_tx_type type)
 {
 	u8 *msg = towire_onchain_transaction_annotate(tmpctx, txid, type);
 	wire_sync_write(REQ_FD, take(msg));

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1093,6 +1093,7 @@ static void output_spent(struct tracked_output ***outs,
 	status_trace("Notified about tx %s output %u spend, but we don't care",
 		     type_to_string(tmpctx, struct bitcoin_txid, &txid),
 		     tx->wtx->inputs[input_num].index);
+
 	unwatch_tx(tx);
 }
 

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1396,6 +1396,7 @@ static void handle_mutual_close(const struct bitcoin_txid *txid,
 				struct tracked_output **outs)
 {
 	init_reply("Tracking mutual close transaction");
+	onchain_transaction_annotate(txid, TX_CHANNEL_CLOSE);
 
 	/* BOLT #5:
 	 *
@@ -1691,6 +1692,7 @@ static void handle_our_unilateral(const struct bitcoin_tx *tx,
 	size_t i;
 
 	init_reply("Tracking our own unilateral close");
+	onchain_transaction_annotate(txid, TX_CHANNEL_UNILATERAL);
 
 	/* BOLT #5:
 	 *
@@ -1969,6 +1971,7 @@ static void handle_their_cheat(const struct bitcoin_tx *tx,
 	size_t i;
 
 	init_reply("Tracking their illegal close: taking all funds");
+	onchain_transaction_annotate(txid, TX_CHANNEL_UNILATERAL | TX_CHANNEL_CHEAT | TX_THEIRS);
 
 	/* BOLT #5:
 	 *
@@ -2189,6 +2192,7 @@ static void handle_their_unilateral(const struct bitcoin_tx *tx,
 	size_t i;
 
 	init_reply("Tracking their unilateral close");
+	onchain_transaction_annotate(txid, TX_CHANNEL_UNILATERAL | TX_THEIRS);
 
 	/* HSM can't derive this. */
 	remote_per_commitment_point = this_remote_per_commitment_point;
@@ -2402,6 +2406,8 @@ static void handle_unknown_commitment(const struct bitcoin_tx *tx,
 	struct keyset *ks;
 	int to_us_output = -1;
 	u8 *local_script;
+
+	onchain_transaction_annotate(txid, TX_CHANNEL_UNILATERAL | TX_THEIRS);
 
 	resolved_by_other(outs[0], txid, UNKNOWN_UNILATERAL);
 

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -130,7 +130,7 @@ u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid
 u8 *towire_onchain_all_irrevocably_resolved(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_all_irrevocably_resolved called!\n"); abort(); }
 /* Generated stub for towire_onchain_broadcast_tx */
-u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED)
+u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, u16 type UNNEEDED)
 { fprintf(stderr, "towire_onchain_broadcast_tx called!\n"); abort(); }
 /* Generated stub for towire_onchain_dev_memleak_reply */
 u8 *towire_onchain_dev_memleak_reply(const tal_t *ctx UNNEEDED, bool leak UNNEEDED)

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -130,7 +130,7 @@ u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid
 u8 *towire_onchain_all_irrevocably_resolved(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_all_irrevocably_resolved called!\n"); abort(); }
 /* Generated stub for towire_onchain_broadcast_tx */
-u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, u16 type UNNEEDED)
+u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, enum wallet_tx_type type UNNEEDED)
 { fprintf(stderr, "towire_onchain_broadcast_tx called!\n"); abort(); }
 /* Generated stub for towire_onchain_dev_memleak_reply */
 u8 *towire_onchain_dev_memleak_reply(const tal_t *ctx UNNEEDED, bool leak UNNEEDED)
@@ -148,7 +148,7 @@ u8 *towire_onchain_init_reply(const tal_t *ctx UNNEEDED)
 u8 *towire_onchain_missing_htlc_output(const tal_t *ctx UNNEEDED, const struct htlc_stub *htlc UNNEEDED)
 { fprintf(stderr, "towire_onchain_missing_htlc_output called!\n"); abort(); }
 /* Generated stub for towire_onchain_transaction_annotate */
-u8 *towire_onchain_transaction_annotate(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u16 type UNNEEDED)
+u8 *towire_onchain_transaction_annotate(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, enum wallet_tx_type type UNNEEDED)
 { fprintf(stderr, "towire_onchain_transaction_annotate called!\n"); abort(); }
 /* Generated stub for towire_onchain_unwatch_tx */
 u8 *towire_onchain_unwatch_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -147,6 +147,9 @@ u8 *towire_onchain_init_reply(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_onchain_missing_htlc_output */
 u8 *towire_onchain_missing_htlc_output(const tal_t *ctx UNNEEDED, const struct htlc_stub *htlc UNNEEDED)
 { fprintf(stderr, "towire_onchain_missing_htlc_output called!\n"); abort(); }
+/* Generated stub for towire_onchain_transaction_annotate */
+u8 *towire_onchain_transaction_annotate(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u16 type UNNEEDED)
+{ fprintf(stderr, "towire_onchain_transaction_annotate called!\n"); abort(); }
 /* Generated stub for towire_onchain_unwatch_tx */
 u8 *towire_onchain_unwatch_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)
 { fprintf(stderr, "towire_onchain_unwatch_tx called!\n"); abort(); }

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -385,6 +385,13 @@ static struct migration dbmigrations[] = {
 	/* remote signatures for channel announcement */
 	{ "ALTER TABLE channels ADD remote_ann_node_sig BLOB;", NULL },
 	{ "ALTER TABLE channels ADD remote_ann_bitcoin_sig BLOB;", NULL },
+	/* Additional information for transaction tracking and listing */
+	{ "ALTER TABLE transactions ADD type INTEGER;", NULL },
+	/* Not a foreign key on purpose since we still delete channels from
+	 * the DB which would remove this. It is mainly used to group payments
+	 * in the list view anyway, e.g., show all close and htlc transactions
+	 * as a single bundle. */
+	{ "ALTER TABLE transactions ADD channel_id INTEGER;", NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2528,7 +2528,7 @@ struct channeltx *wallet_channeltxs_get(struct wallet *w, const tal_t *ctx,
 			  ", t.id as txid "
 			  "FROM channeltxs c "
 			  "JOIN transactions t ON t.id == c.transaction_id "
-			  "WHERE channel_id = ? "
+			  "WHERE c.channel_id = ? "
 			  "ORDER BY c.id ASC;");
 	sqlite3_bind_int(stmt, 1, channel_id);
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2416,7 +2416,7 @@ void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
 }
 
 void wallet_transaction_annotate(struct wallet *w,
-				 const struct bitcoin_txid *txid, txtypes type,
+				 const struct bitcoin_txid *txid, enum wallet_tx_type type,
 				 u64 channel_id)
 {
 	sqlite3_stmt *stmt = db_select_prepare(w->db, "type, channel_id FROM transactions WHERE id=?");

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -294,7 +294,7 @@ struct wallet_transaction {
 	u32 blockheight;
 	u32 txindex;
 	u8 *rawtx;
-	txtypes type;
+	enum wallet_tx_type type;
 	u64 channel_id;
 };
 
@@ -1047,8 +1047,8 @@ void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
  * after the fact with a channel number for grouping and a type for filtering.
  */
 void wallet_transaction_annotate(struct wallet *w,
-				 const struct bitcoin_txid *txid, txtypes type,
-				 u64 channel_id);
+				 const struct bitcoin_txid *txid,
+				 enum wallet_tx_type type, u64 channel_id);
 
 /**
  * Get the confirmation height of a transaction we are watching by its

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -11,6 +11,7 @@
 #include <ccan/tal/tal.h>
 #include <common/channel_config.h>
 #include <common/utxo.h>
+#include <common/wallet.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/invoice.h>
@@ -1027,6 +1028,18 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 
 void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
 			    const u32 blockheight, const u32 txindex);
+
+/**
+ * Annotate a transaction in the DB with its type and channel referemce.
+ *
+ * We add transactions when filtering the block, but often know its type only
+ * when we trigger the txwatches, at which point we've already discarded the
+ * full transaction. This function can be used to annotate the transactions
+ * after the fact with a channel number for grouping and a type for filtering.
+ */
+void wallet_transaction_annotate(struct wallet *w,
+				 const struct bitcoin_txid *txid, txtypes type,
+				 u64 channel_id);
 
 /**
  * Get the confirmation height of a transaction we are watching by its

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -289,6 +289,15 @@ struct channeltx {
 	u32 depth;
 };
 
+struct wallet_transaction {
+	struct bitcoin_txid id;
+	u32 blockheight;
+	u32 txindex;
+	u8 *rawtx;
+	txtypes type;
+	u64 channel_id;
+};
+
 /**
  * wallet_new - Constructor for a new sqlite3 based wallet
  *
@@ -1131,4 +1140,14 @@ void add_unreleased_tx(struct wallet *w, struct unreleased_tx *utx);
 
 /* These will touch the db, so need to be explicitly freed. */
 void free_unreleased_txs(struct wallet *w);
+
+/**
+ * Get a list of transactions that we track in the wallet.
+ *
+ * @param ctx: allocation context for the returned list
+ * @param wallet: Wallet to load from.
+ * @return A tal_arr of wallet transactions
+ */
+struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t *ctx);
+
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -802,7 +802,7 @@ struct {
     {0, NULL}
 };
 
-static void json_add_txtypes(struct json_stream *result, const char *fieldname, txtypes value)
+static void json_add_txtypes(struct json_stream *result, const char *fieldname, enum wallet_tx_type value)
 {
 	json_array_start(result, fieldname);
 	for (size_t i=0; wallet_tx_type_display_names[i].name != NULL; i++) {

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -343,10 +343,17 @@ static struct command_result *json_withdraw(struct command *cmd,
 {
 	struct unreleased_tx *utx;
 	struct command_result *res;
+	struct bitcoin_txid txid;
 
 	res = json_prepare_tx(cmd, buffer, params, &utx);
 	if (res)
 		return res;
+
+	/* Store the transaction in the DB and annotate it as a withdrawal */
+	bitcoin_txid(utx->tx, &txid);
+	wallet_transaction_add(cmd->ld->wallet, utx->tx, 0, 0);
+	wallet_transaction_annotate(cmd->ld->wallet, &txid,
+				    TX_WALLET_WITHDRAWAL, 0);
 
 	return broadcast_and_wait(cmd, utx);
 }


### PR DESCRIPTION
This PR extends the capabilities of our internal transaction tracking by annotating transactions of interest with a transaction type and a `channel_id`. This allows us to group transactions by the channel they affected, trace the on-chain footprint of a channel (improving our debuggability) and showing on-chain transaction history in wallet UIs.

 - The `channel_id` in the `transactions` table is not a foreign key into the `channels` table since we delete entries from that table, which would reset that grouping key. I found it better to keep them set, resulting in them being more of a grouping key rather than a real reference to a channel.
 - Transactions are inserted and then annotated with their type aposteriori since we add transactions in the main daemon based on `tx_watches` or `txo_watches` but only subdaemons (`onchaind` in particular) know their type. It's further complicated by the fact that some watch callbacks actually require the transaction to be in the `transactions` table before being called. The two alternatives I have tried were:
   - Have the `tx_watch` and `txo_watch` entries be marked with `type` and `channel_id` so that we can insert them with the correct values right away. This failed since for `onchaind` we automatically track descendants of a tracked transaction, and we'd have to ask `onchaind` for its type anyway.
    - Have the callbacks for the watches insert the transaction and annotate them at the same time. This also fails for `onchaind`, but in some places where we call `wallet_transaction_add` directly followed by `wallet_transaction_annotate` this worked out fine. I found the overhead small enough to warrant not combining the two into a single call.
 - I had a teardown test during testing that'd check that no `TX_UNKNOWN` transactions are left in the DB in the end, but decided against including it since it produced some false positives for tests where the node gets killed (mainly cheat attempts) and it was triggering on remote sweep transactions as well, which we just unwatch right away again. If desired I can include that teardown test again, but it'll need instrumentation to avoid false positives.
 - I need to rework the way we confirm transactions a bit, since recording a `tx_watch` for each of the transactions is a bit messy, and I'd like to merge the `transactions` and `channeltxs` tables in a future PR.

Open questions:
 - There are no migrations attempting to infer the type of existing transactions in the table yet. I'm not sure we want to spend extra cycles on that since we are now tracking more transactions that will not be present anyway (withdrawals were not tracked at all), and it is bound to reverse-engineer in an automated fashion what type a transaction had. What do the others think? Is keeping them `TX_UNKNOWN` good enough or how much work should we invest here?
 - Like mentioned above I'd like to revamp the way we track confirmations. That'd be for another PR, or would you prefer we include it here?