### PR TITLE
fundchannel: add the possibility to fund a channel with specific utxos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: the command objects that `help` outputs now contain a new string field : `category` (can be "bitcoin", "channels", "network", "payment", "plugins", "utility", "developer" for native commands, or any other new category set by a plugin).
 - Plugins: a plugin can now set the category of a newly created RPC command. This possibility has been added to libplugin.c and pylightning.
 - CLI: the human readable help is now more human and more readable : commands are sorted alphabetically and ordered by categories.
+- JSON API: A new parameter is added to `fundchannel`, which now accepts an utxo array to use to fund the channel.
 
 ### Deprecated
 

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -75,3 +75,19 @@ bool json_to_txid(const char *buffer, const jsmntok_t *tok,
 	return bitcoin_txid_from_hex(buffer + tok->start,
 				     tok->end - tok->start, txid);
 }
+
+bool split_tok(const char *buffer, const jsmntok_t *tok,
+				char split,
+				jsmntok_t *a,
+				jsmntok_t *b)
+{
+	const char *p = memchr(buffer + tok->start, split, tok->end - tok->start);
+	if (!p)
+		return false;
+
+	*a = *b = *tok;
+	a->end = p - buffer;
+	b->start = p + 1 - buffer;
+
+	return true;
+}

--- a/common/json_helpers.h
+++ b/common/json_helpers.h
@@ -39,4 +39,10 @@ bool json_to_msat(const char *buffer, const jsmntok_t *tok,
 /* Extract a bitcoin txid from this */
 bool json_to_txid(const char *buffer, const jsmntok_t *tok,
 		  struct bitcoin_txid *txid);
+
+/* Split a json token into 2 tokens given a splitting character */
+bool split_tok(const char *buffer, const jsmntok_t *tok,
+				char split,
+				jsmntok_t *a,
+				jsmntok_t *b);
 #endif /* LIGHTNING_COMMON_JSON_HELPERS_H */

--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -1,4 +1,7 @@
+#include <ccan/ccan/opt/opt.h>
+#include <ccan/tal/str/str.h>
 #include <common/json_command.h>
+#include <common/json_helpers.h>
 #include <common/jsonrpc_errors.h>
 #include <common/wallet_tx.h>
 #include <inttypes.h>
@@ -23,13 +26,14 @@ struct command_result *param_wtx(struct command *cmd,
 		return NULL;
 	}
 	wtx->all_funds = false;
+
 	if (!parse_amount_sat(&wtx->amount,
 			      buffer + tok->start, tok->end - tok->start))
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				    "'%s' should be satoshis or 'all', not '%.*s'",
-				    name,
-				    tok->end - tok->start,
-				    buffer + tok->start);
+					"'%s' should be an amount in satoshis or all, not '%.*s'",
+					name,
+					tok->end - tok->start,
+					buffer + tok->start);
 
 	if (amount_sat_greater(wtx->amount, max))
                 return command_fail(wtx->cmd, FUND_MAX_EXCEEDED,
@@ -37,6 +41,66 @@ struct command_result *param_wtx(struct command *cmd,
 				    type_to_string(tmpctx, struct amount_sat,
 						   &max));
         return NULL;
+}
+
+struct command_result *param_utxos(struct command *cmd,
+				 const char *name,
+				 const char *buffer,
+				 const jsmntok_t *tok,
+				 const struct utxo ***utxos)
+{
+	size_t i;
+	const jsmntok_t *curr;
+	struct bitcoin_txid **txids = tal_arr(cmd, struct bitcoin_txid*, 0);
+	unsigned int **outnums = tal_arr(cmd, unsigned int*, 0);
+
+	json_for_each_arr(i, curr, tok) {
+		jsmntok_t txid_tok, outnum_tok;
+		if (!split_tok(buffer, curr, ':', &txid_tok, &outnum_tok))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+								"Could not decode the outpoint from \"%s\""
+								" The utxos should be specified as"
+								" 'txid:output_index'.",
+								json_strdup(tmpctx, buffer, curr));
+
+		struct bitcoin_txid *txid = tal(txids, struct bitcoin_txid);
+		unsigned int *outnum = tal(txids, unsigned int);
+		if (!json_to_txid(buffer, (const jsmntok_t*)&txid_tok, txid)) {
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+								"Could not get a txid out of \"%s\"",
+								json_strdup(tmpctx, buffer, &txid_tok));
+		}
+		if(!json_to_number(buffer, (const jsmntok_t*)&outnum_tok, outnum))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+								"Could not get a vout out of \"%s\"",
+								json_strdup(tmpctx, buffer, &outnum_tok));
+
+		tal_arr_expand(&txids, txid);
+		tal_arr_expand(&outnums, outnum);
+	}
+
+	if (!tal_count(txids) || !tal_count(outnums))
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+							"Please specify an array of 'txid:output_index',"
+							" not \"%.*s\"",
+							tok->end - tok->start,
+							buffer + tok->start);
+
+	*utxos = wallet_select_specific(cmd, cmd->ld->wallet, txids, outnums);
+	tal_free(txids);
+	tal_free(outnums);
+
+	if (!*utxos)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+							"Could not decode all of the outpoints. The utxos"
+							" should be specified as an array of "
+							" 'txid:output_index'.");
+	if (tal_count(*utxos) == 0)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+							"No matching utxo was found from the wallet."
+							"You can get a list of the wallet utxos with"
+							" the `listfunds` RPC call.");
+	return NULL;
 }
 
 static struct command_result *check_amount(const struct wallet_tx *wtx,
@@ -103,4 +167,65 @@ struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 		tx->change_key_index = wallet_get_newindex(tx->cmd->ld);
 	}
 	return NULL;
+}
+
+struct command_result *wtx_from_utxos(struct wallet_tx *tx,
+					u32 fee_rate_per_kw,
+					size_t out_len,
+					u32 maxheight,
+					const struct utxo **utxos)
+{
+	size_t weight;
+	struct amount_sat total_amount, fee_estimate;
+
+	tx->change = AMOUNT_SAT(0);
+	tx->change_key_index = 0;
+	total_amount = AMOUNT_SAT(0);
+
+	/* The transaction has `tal_count(tx.utxos)` inputs and one output */
+	/* (version + in count + out count + locktime)  (index + value + script length) */
+	weight = 4 * (4 + 1 + 1 + 4) + 4 * (8 + 1 + out_len);
+	for (size_t i = 0; i < tal_count(utxos); i++) {
+		if (!*utxos[i]->blockheight || *utxos[i]->blockheight > maxheight) {
+			tal_arr_remove(&utxos, i);
+			continue;
+		}
+		/* txid + index + sequence + script_len */
+		weight += (32 + 4 + 4 + 1) * 4;
+		/* P2SH variants include push of <0 <20-byte-key-hash>> */
+		if (utxos[i]->is_p2sh)
+			weight += 23 * 4;
+		/* Account for witness (1 byte count + sig + key) */
+		weight += 1 + (1 + 73 + 1 + 33);
+		if (!amount_sat_add(&total_amount, total_amount, utxos[i]->amount))
+			fatal("Overflow when computing input amount");
+	}
+	tx->utxos = utxos;
+
+	if (!tx->all_funds && amount_sat_less(tx->amount, total_amount)
+			&& !amount_sat_sub(&tx->change, total_amount, tx->amount))
+		fatal("Overflow when computing change");
+	if (amount_sat_greater_eq(tx->change, get_chainparams(tx->cmd->ld)->dust_limit)) {
+		tx->change_key_index = wallet_get_newindex(tx->cmd->ld);
+		/* Add the change output's weight */
+		weight += (8 + 1 + out_len) * 4;
+	}
+
+	fee_estimate = amount_tx_fee(fee_rate_per_kw, weight);
+
+	if (tx->all_funds || amount_sat_eq(tx->change, AMOUNT_SAT(0))) {
+		tx->amount = total_amount;
+		if (!amount_sat_sub(&tx->amount, tx->amount, fee_estimate))
+			return command_fail(tx->cmd, FUND_CANNOT_AFFORD,
+								"Cannot afford transaction with %s sats of fees",
+								type_to_string(tmpctx, struct amount_sat,
+									&fee_estimate));
+	} else {
+		if (!amount_sat_sub(&tx->change, tx->change, fee_estimate))
+			return command_fail(tx->cmd, FUND_CANNOT_AFFORD,
+								"Cannot afford transaction with %s sats of fees",
+								type_to_string(tmpctx, struct amount_sat,
+									&fee_estimate));
+	}
+	return check_amount(tx, tx->amount);
 }

--- a/common/wallet_tx.h
+++ b/common/wallet_tx.h
@@ -27,10 +27,22 @@ struct command_result *param_wtx(struct command *cmd,
 				 const jsmntok_t *tok,
 				 struct wallet_tx *wtx);
 
+struct command_result *param_utxos(struct command *cmd,
+				 const char *name,
+				 const char *buffer,
+				 const jsmntok_t *tok,
+				 const struct utxo ***utxos);
+
 struct command_result *wtx_select_utxos(struct wallet_tx *tx,
 					u32 fee_rate_per_kw,
 					size_t out_len,
 					u32 maxheight);
+
+struct command_result *wtx_from_utxos(struct wallet_tx *tx,
+					u32 fee_rate_per_kw,
+					size_t out_len,
+					u32 maxheight,
+					const struct utxo **utxos);
 
 static inline u32 minconf_to_maxheight(u32 minconf, struct lightningd *ld)
 {

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -490,12 +490,14 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("feerates", payload)
 
-    def fundchannel(self, node_id, satoshi, feerate=None, announce=True, minconf=None):
+    def fundchannel(self, node_id, satoshi, feerate=None, announce=True, minconf=None, utxos=None):
         """
-        Fund channel with {id} using {satoshi} satoshis
-        with feerate of {feerate} (uses default feerate if unset).
+        Fund channel with {id} using {satoshi} satoshis with feerate
+        of {feerate} (uses default feerate if unset).
         If {announce} is False, don't send channel announcements.
-        Only select outputs with {minconf} confirmations
+        Only select outputs with {minconf} confirmations.
+        If {utxos} is specified (as a list of 'txid:vout' strings),
+        fund a channel from these specifics utxos.
         """
         payload = {
             "id": node_id,
@@ -503,6 +505,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "feerate": feerate,
             "announce": announce,
             "minconf": minconf,
+            "utxos": utxos
         }
         return self.call("fundchannel", payload)
 

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -7,7 +7,7 @@
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "05/24/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "06/07/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 lightning-fundchannel \- Command for establishing a lightning channel\&.
 .SH "SYNOPSIS"
 .sp
-\fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR]
+\fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR] [\fIutxos\fR]
 .SH "DESCRIPTION"
 .sp
 The \fBfundchannel\fR RPC command opens a payment channel with a peer by committing a funding transaction to the blockchain as defined in BOLT #2\&. \fBfundchannel\fR by itself does not attempt to open a connection\&. A connection must first be established using \fBconnect\fR\&. Once the transaction is confirmed, normal channel operations may begin\&. Readiness is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL for the channel\&.
@@ -47,6 +47,8 @@ The \fBfundchannel\fR RPC command opens a payment channel with a peer by committ
 Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means the number is interpreted as satoshi\-per\-kilosipa (weight), and \fIperkb\fR means it is interpreted bitcoind\-style as satoshi\-per\-kilobyte\&. Omitting the suffix is equivalent to \fIperkb\fR\&.
 .sp
 \fIminconf\fR specifies the minimum number of confirmations that used outputs should have\&. Default is 1\&.
+.sp
+\fIutxos\fR specifies the utxos to be used to fund the channel, as an array of "txid:vout"\&.
 .SH "RETURN VALUE"
 .sp
 On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well as the \fIchannel_id\fR of the newly created channel\&. On failure, an error is reported and the channel is not funded\&.

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -8,7 +8,7 @@ lightning-fundchannel - Command for establishing a lightning channel.
 
 SYNOPSIS
 --------
-*fundchannel* 'id' 'satoshi' ['feerate' 'announce'] ['minconf']
+*fundchannel* 'id' 'satoshi' ['feerate' 'announce'] ['minconf'] ['utxos']
 
 DESCRIPTION
 -----------
@@ -44,6 +44,8 @@ Otherwise, 'feerate' is a number, with an optional suffix:
 satoshi-per-kilobyte.  Omitting the suffix is equivalent to 'perkb'.
 
 'minconf' specifies the minimum number of confirmations that used outputs should have. Default is 1.
+
+'utxos' specifies the utxos to be used to fund the channel, as an array of "txid:vout".
 
 RETURN VALUE
 ------------

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -372,6 +372,15 @@ const struct utxo **wallet_select_all(const tal_t *ctx, struct wallet *w,
 				      struct amount_sat *fee_estimate);
 
 /**
+ * wallet_select_specific - Select utxos given an array of txids and an array of outputs index
+ *
+ * Returns an array of `utxo` structs.
+ */
+const struct utxo **wallet_select_specific(const tal_t *ctx, struct wallet *w,
+					struct bitcoin_txid **txids,
+					u32 **outnums);
+
+/**
  * wallet_confirm_utxos - Once we've spent a set of utxos, mark them confirmed.
  *
  * May be called once the transaction spending these UTXOs has been


### PR DESCRIPTION
Fixes #2682 .

This PR adds the possibility to specify a list of outpoints (`[\"txid:vout\", \"txid:vout\"]`) as the second parameter of the `fundchannel` call in addition to `'all'` or an amount in satoshis.