### PR TITLE
Test generate block wait mempool

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -992,7 +992,7 @@ def test_funding_reorg_remote_lags(node_factory, bitcoind):
         'CHANNELD_NORMAL:Funding transaction locked. Channel announced.'])
 
     l1.rpc.close(l2.info['id'])                     # to ignore `Bad gossip order` error in killall
-    bitcoind.generate_block(1)
+    bitcoind.generate_block(1, True)
     l1.daemon.wait_for_log(r'Deleting channel')
     l2.daemon.wait_for_log(r'Deleting channel')
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -299,9 +299,9 @@ def test_openchannel_hook(node_factory, bitcoind):
 
     # Get some funds.
     addr = l1.rpc.newaddr()['bech32']
-    bitcoind.rpc.sendtoaddress(addr, 10)
+    txid = bitcoind.rpc.sendtoaddress(addr, 10)
     numfunds = len(l1.rpc.listfunds()['outputs'])
-    bitcoind.generate_block(1)
+    bitcoind.generate_block(1, txid)
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) > numfunds)
 
     # Even amount: works.
@@ -322,9 +322,8 @@ def test_openchannel_hook(node_factory, bitcoind):
     l2.daemon.wait_for_log('reject_odd_funding_amounts.py to_self_delay=5')
 
     # Close it.
-    l1.rpc.close(l2.info['id'])
-    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) > 0)
-    bitcoind.generate_block(1)
+    txid = l1.rpc.close(l2.info['id'])['txid']
+    bitcoind.generate_block(1, txid)
     wait_for(lambda: [c['state'] for c in only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['channels']] == ['ONCHAIN'])
 
     # Odd amount: fails


### PR DESCRIPTION
This will add an optional wait_for_mempool parametr to the `generate_block` function in the BitcoinD testsuite. Can help fix flaky tests and reduces code cuplications for all the `wait_for(lambda: len(self.rpc.getrawmempool()) > 0`

The new `wait_for_mempool` parameter can be:

- `True` to wait for 1 transaction in mempool
- `int > 0` to wait for N transactions in the mempool
- `"tx_id_str"` to wait for only one specific transaction ID
- `["tx_id_str_1", "tx_id_str_2", ...]` to wait for N specific transaction IDs