### PR TITLE
newaddr: fix return value for deprecated "address" field.

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1402,6 +1402,14 @@ def test_newaddr(node_factory):
     assert both['bech32'].startswith('bcrt1')
 
 
+def test_newaddr_deprecated(node_factory):
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
+    p2sh = l1.rpc.newaddr('p2sh-segwit')
+    assert p2sh['address'].startswith('2')
+    bech32 = l1.rpc.newaddr('bech32')
+    assert bech32['address'].startswith('bcrt1')
+
+
 def test_bitcoind_fail_first(node_factory, bitcoind, executor):
     """Make sure we handle spurious bitcoin-cli failures during startup
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -339,8 +339,9 @@ static struct command_result *json_newaddr(struct command *cmd,
 
 	response = json_stream_success(cmd);
 	json_object_start(response, NULL);
-	if (deprecated_apis)
-		json_add_string(response, "address", bech32 ? bech32 : p2sh);
+	if (deprecated_apis && *addrtype != ADDR_ALL)
+		json_add_string(response, "address",
+				*addrtype & ADDR_BECH32 ? bech32 : p2sh);
 	if (*addrtype & ADDR_BECH32)
 		json_add_string(response, "bech32", bech32);
 	if (*addrtype & ADDR_P2SH_SEGWIT)


### PR DESCRIPTION
It would always return bech32; fix that, and don't bother printing
it if they use the (new) 'all' parameter.

This API was introduced in 3e67c09d5e6022300d785fbf5be76aeaa756c822,
which means it wasn't in a release so no CHANGELOG entry necessary.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>