### PR TITLE
plugin: A new notification type 'warning'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DB: Store the signatures of channel announcement sent from remote peer into DB, and init channel with signatures from DB directly when reenable the channel.
 (Issue [#2409](https://github.com/ElementsProject/lightning/issues/2409))
 - JSON API: new withdraw methods `txprepare`, `txsend` and `txdiscard`.
+- plugin: the `warning` notification can now detect any `LOG_UNUSUAL`/`LOG_BROKEN` level event.
 
 ### Changed
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -218,6 +218,35 @@ to a peer was lost.
 	"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
 }
 ```
+
+#### `warning`
+
+A notification for topic `warning` is sent every time a new `BROKEN`
+/`UNUSUAL` level(in plugins, we use `error`/`warn`) log generated,
+which means an unusual/borken thing happens, such as channel failed,
+message resolving failed...
+
+```json
+{
+	"warning": {
+	"level": "warn",
+	"time": "1559743608.565342521",
+	"source": "lightningd(17652): 0821f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c chan #7854:",
+	"log": "Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: sent ERROR bad reestablish dataloss msg"
+  }
+}
+```
+1. `level` is `warn` or `error`: `warn` means something seems bad happened
+ and it's under control, but we'd better check it; `error` means something
+extremely bad is out of control, and it may lead to crash;
+2. `time` is the second since epoch;
+3. `source` means where the event happened, it may have the following
+forms:  
+`<node_id> chan #<db_id_of_channel>:`,`lightningd(<lightningd_pid>):`,
+`plugin-<plugin_name>:`, `<daemon_name>(<daemon_pid>):`, `jsonrpc:`,
+`jcon fd <error_fd_to_jsonrpc>:`, `plugin-manager`;
+4. `log` is the context of the original log entry.
+
 ## Hooks
 
 Hooks allow a plugin to define custom behavior for `lightningd`

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -429,3 +429,14 @@ void json_add_timeabs(struct json_stream *result, const char *fieldname,
 	json_add_member(result, fieldname, "%" PRIu64 ".%03" PRIu64,
 			(u64)t.ts.tv_sec, (u64)t.ts.tv_nsec / 1000000);
 }
+
+void json_add_time(struct json_stream *result, const char *fieldname,
+			  struct timespec ts)
+{
+	char timebuf[100];
+
+	snprintf(timebuf, sizeof(timebuf), "%lu.%09u",
+		(unsigned long)ts.tv_sec,
+		(unsigned)ts.tv_nsec);
+	json_add_string(result, fieldname, timebuf);
+}

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -204,4 +204,8 @@ enum address_parse_result json_tok_address_scriptpubkey(const tal_t *ctx,
 void json_add_timeabs(struct json_stream *result, const char *fieldname,
 		      struct timeabs t);
 
+/* used in log.c and notification.c*/
+void json_add_time(struct json_stream *result, const char *fieldname,
+			  struct timespec ts);
+
 #endif /* LIGHTNING_LIGHTNINGD_JSON_H */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -155,7 +155,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 * book to hold all the entries (and trims as necessary), and multiple
 	 * log objects which each can write into it, each with a unique
 	 * prefix. */
-	ld->log_book = new_log_book(20*1024*1024, LOG_INFORM);
+	ld->log_book = new_log_book(ld, 20*1024*1024, LOG_INFORM);
 	/*~ Note the tal context arg (by convention, the first argument to any
 	 * allocation function): ld->log will be implicitly freed when ld
 	 * is. */

--- a/lightningd/log.h
+++ b/lightningd/log.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_LOG_H
 #define LIGHTNING_LIGHTNINGD_LOG_H
 #include "config.h"
+#include <ccan/list/list.h>
 #include <ccan/tal/tal.h>
 #include <ccan/time/time.h>
 #include <ccan/typesafe_cb/typesafe_cb.h>
@@ -13,6 +14,39 @@ struct command;
 struct json_stream;
 struct lightningd;
 struct timerel;
+
+struct log_entry {
+	struct list_node list;
+	struct timeabs time;
+	enum log_level level;
+	unsigned int skipped;
+	const char *prefix;
+	char *log;
+	/* Iff LOG_IO */
+	const u8 *io;
+};
+
+struct log_book {
+	size_t mem_used;
+	size_t max_mem;
+	void (*print)(const char *prefix,
+		      enum log_level level,
+		      bool continued,
+		      const struct timeabs *time,
+		      const char *str,
+		      const u8 *io, size_t io_len,
+		      void *arg);
+	void *print_arg;
+	enum log_level print_level;
+	struct timeabs init_time;
+
+	struct list_head log;
+};
+
+struct log {
+	struct log_book *lr;
+	const char *prefix;
+};
 
 /* We can have a single log book, with multiple logs in it: it's freed by
  * the last struct log itself. */

--- a/lightningd/log_status.c
+++ b/lightningd/log_status.c
@@ -6,10 +6,13 @@ bool log_status_msg(struct log *log, const u8 *msg)
 	char *entry, *who;
 	u8 *data;
  	enum log_level level;
+	bool call_notifier;
 
 	if (fromwire_status_log(msg, msg, &level, &entry)) {
 		if (level != LOG_IO_IN && level != LOG_IO_OUT) {
-			log_(log, level, "%s", entry);
+			call_notifier = (level == LOG_BROKEN ||
+			         level == LOG_UNUSUAL)? true : false;
+			log_(log, level, call_notifier, "%s", entry);
 			return true;
 		}
 	} else if (fromwire_status_io(msg, msg, &level, &who, &data)) {

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -1,9 +1,11 @@
 #include "lightningd/notification.h"
 #include <ccan/array_size/array_size.h>
+#include <lightningd/json.h>
 
 const char *notification_topics[] = {
 	"connect",
 	"disconnect",
+	"warning"
 };
 
 bool notifications_have_topic(const char *topic)
@@ -30,6 +32,31 @@ void notify_disconnect(struct lightningd *ld, struct node_id *nodeid)
 	struct jsonrpc_notification *n =
 	    jsonrpc_notification_start(NULL, notification_topics[1]);
 	json_add_node_id(n->stream, "id", nodeid);
+	jsonrpc_notification_end(n);
+	plugins_notify(ld->plugins, take(n));
+}
+
+/*'warning' is based on LOG_UNUSUAL/LOG_BROKEN level log
+ *(in plugin module, they're 'warn'/'error' level). */
+void notify_warning(struct lightningd *ld, struct log_entry *l)
+{
+	struct jsonrpc_notification *n =
+	    jsonrpc_notification_start(NULL, notification_topics[2]);
+	json_object_start(n->stream, "warning");
+	/* Choose "BROKEN"/"UNUSUAL" to keep consistent with the habit
+	 * of plugin. But this may confuses the users who want to 'getlog'
+	 * with the level indicated by notifications. It is the duty of a
+	 * plugin to eliminate this misunderstanding.
+	 */
+	json_add_string(n->stream, "level",
+			l->level == LOG_BROKEN ? "error"
+			: "warn");
+	/* unsuaul/broken event is rare, plugin pay more attentions on
+	 * the absolute time, like when channels failed. */
+	json_add_time(n->stream, "time", l->time.ts);
+	json_add_string(n->stream, "source", l->prefix);
+	json_add_string(n->stream, "log", l->log);
+	json_object_end(n->stream); /* .warning */
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
+#include <lightningd/log.h>
 #include <lightningd/plugin.h>
 
 bool notifications_have_topic(const char *topic);
@@ -10,5 +11,7 @@ bool notifications_have_topic(const char *topic);
 void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 		    struct wireaddr_internal *addr);
 void notify_disconnect(struct lightningd *ld, struct node_id *nodeid);
+
+void notify_warning(struct lightningd *ld, struct log_entry *l);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -81,7 +81,7 @@ static void copy_to_parent_log(const char *prefix,
 	else if (continued)
 		log_add(parent_log, "%s ... %s", prefix, str);
 	else
-		log_(parent_log, level, "%s %s", prefix, str);
+		log_(parent_log, level, false, "%s %s", prefix, str);
 }
 
 static void peer_update_features(struct peer *peer,
@@ -119,7 +119,7 @@ struct peer *new_peer(struct lightningd *ld, u64 dbid,
 #endif
 
 	/* Max 128k per peer. */
-	peer->log_book = new_log_book(128*1024, get_log_level(ld->log_book));
+	peer->log_book = new_log_book(peer->ld, 128*1024, get_log_level(ld->log_book));
 	set_log_outfn(peer->log_book, copy_to_parent_log, ld->log);
 	list_add_tail(&ld->peers, &peer->list);
 	tal_add_destructor(peer, destroy_peer);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -196,6 +196,7 @@ static void plugin_log_handle(struct plugin *plugin, const jsmntok_t *paramstok)
 {
 	const jsmntok_t *msgtok, *leveltok;
 	enum log_level level;
+	bool call_notifier;
 	msgtok = json_get_member(plugin->buffer, paramstok, "message");
 	leveltok = json_get_member(plugin->buffer, paramstok, "level");
 
@@ -222,7 +223,8 @@ static void plugin_log_handle(struct plugin *plugin, const jsmntok_t *paramstok)
 		return;
 	}
 
-	log_(plugin->log, level, "%.*s", msgtok->end - msgtok->start,
+	call_notifier = (level == LOG_BROKEN || level == LOG_UNUSUAL)? true : false;
+	log_(plugin->log, level, call_notifier, "%.*s", msgtok->end - msgtok->start,
 	     plugin->buffer + msgtok->start);
 }
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -106,7 +106,7 @@ void jsonrpc_setup(struct lightningd *ld UNNEEDED)
 void load_channels_from_wallet(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "load_channels_from_wallet called!\n"); abort(); }
 /* Generated stub for log_ */
-void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, const char *fmt UNNEEDED, ...)
+void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, bool call_notifier UNNEEDED, const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "log_ called!\n"); abort(); }
 /* Generated stub for log_backtrace_exit */
@@ -125,7 +125,7 @@ bool log_status_msg(struct log *log UNNEEDED, const u8 *msg UNNEEDED)
 struct log *new_log(const tal_t *ctx UNNEEDED, struct log_book *record UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "new_log called!\n"); abort(); }
 /* Generated stub for new_log_book */
-struct log_book *new_log_book(size_t max_mem UNNEEDED,
+struct log_book *new_log_book(struct lightningd *ld UNNEEDED, size_t max_mem UNNEEDED,
 			      enum log_level printlevel UNNEEDED)
 { fprintf(stderr, "new_log_book called!\n"); abort(); }
 /* Generated stub for new_topology */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -244,7 +244,7 @@ void kill_uncommitted_channel(struct uncommitted_channel *uc UNNEEDED,
 			      const char *why UNNEEDED)
 { fprintf(stderr, "kill_uncommitted_channel called!\n"); abort(); }
 /* Generated stub for log_ */
-void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, const char *fmt UNNEEDED, ...)
+void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, bool call_notifier UNNEEDED, const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "log_ called!\n"); abort(); }
 /* Generated stub for log_add */
@@ -262,7 +262,7 @@ struct bolt11 *new_bolt11(const tal_t *ctx UNNEEDED,
 struct log *new_log(const tal_t *ctx UNNEEDED, struct log_book *record UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "new_log called!\n"); abort(); }
 /* Generated stub for new_log_book */
-struct log_book *new_log_book(size_t max_mem UNNEEDED,
+struct log_book *new_log_book(struct lightningd *ld UNNEEDED, size_t max_mem UNNEEDED,
 			      enum log_level printlevel UNNEEDED)
 { fprintf(stderr, "new_log_book called!\n"); abort(); }
 /* Generated stub for new_reltimer_ */

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -39,7 +39,7 @@ bool json_to_txid(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 		  struct bitcoin_txid *txid UNNEEDED)
 { fprintf(stderr, "json_to_txid called!\n"); abort(); }
 /* Generated stub for log_ */
-void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, const char *fmt UNNEEDED, ...)
+void log_(struct log *log UNNEEDED, enum log_level level UNNEEDED, bool call_notifier UNNEEDED, const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "log_ called!\n"); abort(); }
 /* Generated stub for log_io */

--- a/tests/plugins/pretend_badlog.py
+++ b/tests/plugins/pretend_badlog.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""This plugin is used to check that warning(unusual/broken level log) calls are working correctly.
+"""
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    plugin.log("initialized")
+
+
+@plugin.subscribe("warning")
+def notify_warning(plugin, warning):
+    plugin.log("Received warning")
+    plugin.log("level: {}".format(warning['level']))
+    plugin.log("time: {}".format(warning['time']))
+    plugin.log("source: {}".format(warning['source']))
+    plugin.log("log: {}".format(warning['log']))
+
+
+@plugin.method("pretendbad")
+def pretend_bad(event, level, plugin):
+    """Log an specified level entry.
+    And in plugin, we use 'warn'/'error' instead of
+    'unusual'/'broken'
+    """
+    plugin.log("{}".format(event), level)
+
+
+plugin.run()

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -3,7 +3,7 @@
 static void db_test_fatal(const char *fmt, ...);
 #define db_fatal db_test_fatal
 
-static void db_log_(struct log *log UNUSED, enum log_level level UNUSED, const char *fmt UNUSED, ...)
+static void db_log_(struct log *log UNUSED, enum log_level level UNUSED, bool call_notifier UNUSED, const char *fmt UNUSED, ...)
 {
 }
 #define log_ db_log_

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -4,7 +4,7 @@ static void wallet_test_fatal(const char *fmt, ...);
 #define db_fatal wallet_test_fatal
 #include "test_utils.h"
 
-static void db_log_(struct log *log UNUSED, enum log_level level UNUSED, const char *fmt UNUSED, ...)
+static void db_log_(struct log *log UNUSED, enum log_level level UNUSED, bool call_notifier UNUSED, const char *fmt UNUSED, ...)
 {
 }
 #define log_ db_log_
@@ -647,7 +647,7 @@ struct log *new_log(const tal_t *ctx UNNEEDED, struct log_book *record UNNEEDED,
 	return NULL;
 }
 
-struct log_book *new_log_book(size_t max_mem UNNEEDED,
+struct log_book *new_log_book(struct lightningd *ld UNNEEDED, size_t max_mem UNNEEDED,
 			      enum log_level printlevel UNNEEDED)
 {
 	return NULL;


### PR DESCRIPTION
This notification bases on `LOG_BROKEN` and `LOG_UNUSUAL` level log. Hope it can help to deal with #2305 .

## Introduction
A notification for topic `warning` is sent every time a new `BROKEN`/`UNUSUAL` level(in plugins, we use `error`/`warn`) log generated, which means an unusual/borken thing happens, such as channel failed,
message resolving failed...

```json
{
	"warning": {
	"level": "warn",
	"time": "1559743608.565342521",
	"source": "lightningd(17652): 0821f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c chan #7854:",
	"log": "Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: sent ERROR bad reestablish dataloss msg"
  }
}
```
1. `level` is `warn` or `error`:
`warn` means something seems bad happened and it's under control, but we'd better check it;
`error` means something extremely bad is out of control, and it may lead to crash;
2. `time` is the second since epoch;
3. `source`, in fact, is the `prefix` of the log_entry. It means where the event happened, it may have the following forms:  
`<node_id> chan #<db_id_of_channel>:`, `lightningd(<lightningd_pid>):`, `plugin-<plugin_name>:`, `<daemon_name>(<daemon_pid>):`, `jsonrpc:`, `jcon fd <error_fd_to_jsonrpc>:`, `plugin-manager`;
4. `log` is the context of the original log entry.

### Note:
1. The main code uses `UNUSUAL`/`BROKEN`, and plugin module uses `warn`/`error`, considering the consistency with plugin, warning choose `warn`/`error`. But users who use c-lightning with plugins may want to `getlog` with specified level when receive warning. It's the duty for plugin dev to turn `warn`/`error` into `UNUSUAL`/`BROKEN` and present it to the users, or pass it directly to `getlog`.
2. About time, `json_log()` in `log` module uses the Relative Time, from the time when `log_book` inited to the time when this event happend. But I consider the `UNUSUAL`/`BROKEN` event is rare, and it is very likely to happen after running for a long time, so for users, they will pay more attention to Absolute Time.

## Related Changes
1. Remove the definitions of `log`, `log_book`, `log_entry` from `log.c` to `log.h`, then they can be used in warning declaration and definition.
2. Add a pointer to `struct lightningd` in `struct log_book`. This may affect the independence of the `log` module, but storing a pointer to `ld` is more direct;
3. Add a `bool` type parameter in `log_()` and `lov()`, this `bool` flag indicates if now we are in copy process.
The process of copying `log_book` of every peer to the `log_book` of `ld` is usually included in `log_()` and `lov()`, and it may lead to repeated `warning` notification. So a `bool`, which explicitly indicates if the `warning` notification is disabled during this call, is necessary.


I named this notification as `unusual_event`, but after many hesitations, I finally choose `warning`, because it looks more visually impactful.

Thanks for cdecker, jb55 and m-schmoock, the discussion of this notification on IRC helpd me :)