### PR TITLE
Travis: set all vars inside build.sh, and increase parallelism for DEVELOPER=0

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,6 +8,12 @@ export DEVELOPER=${DEVELOPER:-1}
 export SOURCE_CHECK_ONLY=${SOURCE_CHECK_ONLY:-"false"}
 export COMPAT=${COMPAT:-1}
 export PATH=$CWD/dependencies/bin:"$HOME"/.local/bin:"$PATH"
+export TIMEOUT=180
+export PYTEST_PAR=2
+# If we're not in developer mode, tests spend a lot of time waiting for gossip!
+if [ "$DEVELOPER" = 0 ]; then
+    PYTEST_PAR=4
+fi
 
 mkdir -p dependencies/bin || true
 


### PR DESCRIPTION
We currently set TIMEOUT and PYTEST_PAR in our Travis instance directly,
which is a bit unhelpful.  In particular, parallelism should be increased
when DEVELOPER isn't set since we spend 60 seconds waiting for gossip in
many cases.

If this doesn't stop timeouts, I'll have to mark more tests SLOW_MACHINE :(

331.24s call     tests/test_connection.py::test_opening_tiny_channel
245.45s call     tests/test_gossip.py::test_gossip_store_load_complex
215.35s call     tests/test_invoices.py::test_invoice_routeboost
194.04s call     tests/test_plugin.py::test_htlc_accepted_hook_forward_restart
182.62s call     tests/test_plugin.py::test_htlc_accepted_hook_fail
182.02s call     tests/test_plugin.py::test_htlc_accepted_hook_resolve
182.01s call     tests/test_pay.py::test_pay_limits
159.10s call     tests/test_gossip.py::test_gossip_notices_close
153.94s call     tests/test_connection.py::test_peerinfo
121.62s call     tests/test_invoices.py::test_invoice_preimage
121.46s call     tests/test_gossip.py::test_gossipwith
120.76s call     tests/test_pay.py::test_setchannelfee_all
120.61s call     tests/test_connection.py::test_second_channel
120.42s call     tests/test_closing.py::test_closing_id
120.39s call     tests/test_gossip.py::test_gossip_addresses
120.39s call     tests/test_gossip.py::test_gossip_weirdalias

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>