### PR TITLE
plugin: Fix how we send the shared_secret to the plugin in htlc_accepted.

### DIFF
--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -440,3 +440,9 @@ void json_add_time(struct json_stream *result, const char *fieldname,
 		(unsigned)ts.tv_nsec);
 	json_add_string(result, fieldname, timebuf);
 }
+
+void json_add_secret(struct json_stream *response, const char *fieldname,
+		     const struct secret *secret)
+{
+	json_add_hex(response, fieldname, secret, sizeof(struct secret));
+}

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -5,6 +5,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_JSON_H
 #define LIGHTNING_LIGHTNINGD_JSON_H
 #include "config.h"
+#include <bitcoin/privkey.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 #include <ccan/time/time.h>
@@ -41,6 +42,11 @@ void json_add_route(struct json_stream *r, char const *n,
 void json_add_pubkey(struct json_stream *response,
 		     const char *fieldname,
 		     const struct pubkey *key);
+
+/* '"fieldname" : "89abcdef..."' or "89abcdef..." if fieldname is NULL */
+void json_add_secret(struct json_stream *response,
+		     const char *fieldname,
+		     const struct secret *secret);
 
 /* '"fieldname" : "0289abcdef..."' or "0289abcdef..." if fieldname is NULL */
 void json_add_node_id(struct json_stream *response,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -721,7 +721,7 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	}
 
 	json_add_hex_talarr(s, "next_onion", p->next_onion);
-	json_add_hex(s, "shared_secret", &hin->shared_secret, sizeof(hin->shared_secret));
+	json_add_secret(s, "shared_secret", hin->shared_secret);
 	json_object_end(s);
 
 	json_object_start(s, "htlc");

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -254,6 +254,11 @@ void json_add_num(struct json_stream *result UNNEEDED, const char *fieldname UNN
 void json_add_s32(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  int32_t value UNNEEDED)
 { fprintf(stderr, "json_add_s32 called!\n"); abort(); }
+/* Generated stub for json_add_secret */
+void json_add_secret(struct json_stream *response UNNEEDED,
+		     const char *fieldname UNNEEDED,
+		     const struct secret *secret UNNEEDED)
+{ fprintf(stderr, "json_add_secret called!\n"); abort(); }
 /* Generated stub for json_add_short_channel_id */
 void json_add_short_channel_id(struct json_stream *response UNNEEDED,
 			       const char *fieldname UNNEEDED,


### PR DESCRIPTION
~Found this while trying to do some magic on top of `shared_secret`, turns out we were not keeping the secret around long enough, so now we just stash it in the `htlc_accepted_payload`.~

I had confused pointer and pointee :frowning_face: 