### PR TITLE
gossip: bump version to remove lingering issues with master.

### DIFF
--- a/common/gossip_store.h
+++ b/common/gossip_store.h
@@ -10,7 +10,7 @@ struct per_peer_state;
 /**
  * gossip_store -- On-disk storage related information
  */
-#define GOSSIP_STORE_VERSION 5
+#define GOSSIP_STORE_VERSION 6
 
 /**
  * Bit of length we use to mark a deleted record.

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -861,7 +861,7 @@ def test_gossip_store_load(node_factory):
     """Make sure we can read canned gossip store"""
     l1 = node_factory.get_node(start=False)
     with open(os.path.join(l1.daemon.lightning_dir, 'gossip_store'), 'wb') as f:
-        f.write(bytearray.fromhex("05"        # GOSSIP_STORE_VERSION
+        f.write(bytearray.fromhex("06"        # GOSSIP_STORE_VERSION
                                   "000001b0"  # len
                                   "dc5bef89"  # csum
                                   "5b8d9b44"  # timestamp


### PR DESCRIPTION
There were several gossip breakages in master; bumping version means
upgrades get a clean store (not just those upgrading from stable version).

Fixes: #2719
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>