### PR TITLE
ASAN fixes

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -161,7 +161,7 @@ static void bcli_failure(struct bitcoind *bitcoind,
 	bitcoind->error_count++;
 
 	/* Retry in 1 second (not a leak!) */
-	new_reltimer(&bitcoind->ld->timers, notleak(bcli), time_from_sec(1),
+	new_reltimer(bitcoind->ld->timers, notleak(bcli), time_from_sec(1),
 		     retry_bcli, bcli);
 }
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -855,6 +855,11 @@ static void destroy_chain_topology(struct chain_topology *topo)
 
 	while ((otx = list_pop(&topo->outgoing_txs, struct outgoing_tx, list)))
 		tal_free(otx);
+
+	/* htable uses malloc, so it would leak here */
+	txwatch_hash_clear(&topo->txwatches);
+	txowatch_hash_clear(&topo->txowatches);
+	block_map_clear(&topo->block_map);
 }
 
 struct chain_topology *new_topology(struct lightningd *ld, struct log *log)

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -222,7 +222,7 @@ void delay_then_reconnect(struct channel *channel, u32 seconds_delay,
 
 	/* We fuzz the timer by up to 1 second, to avoid getting into
 	 * simultanous-reconnect deadlocks with peer. */
-	notleak(new_reltimer(&ld->timers, d,
+	notleak(new_reltimer(ld->timers, d,
 			     timerel_add(time_from_sec(seconds_delay),
 					 time_from_usec(pseudorand(1000000))),
 			     maybe_reconnect, d));

--- a/lightningd/io_loop_with_timers.c
+++ b/lightningd/io_loop_with_timers.c
@@ -21,7 +21,7 @@ void *io_loop_with_timers(struct lightningd *ld)
 		 * It will only exit if there's an expired timer, *or* someone
 		 * calls io_break, or if there are no more file descriptors
 		 * (which never happens in our code). */
-		retval = io_loop(&ld->timers, &expired);
+		retval = io_loop(ld->timers, &expired);
 
 		/*~ Notice that timers are called here in the event loop like
 		 * anything else, so there are no weird concurrency issues. */

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -876,6 +876,11 @@ static bool jsonrpc_command_add_perm(struct lightningd *ld,
 	return true;
 }
 
+static void destroy_jsonrpc(struct jsonrpc *jsonrpc)
+{
+	strmap_clear(&jsonrpc->usagemap);
+}
+
 void jsonrpc_setup(struct lightningd *ld)
 {
 	struct json_command **commands = get_cmdlist();
@@ -890,6 +895,7 @@ void jsonrpc_setup(struct lightningd *ld)
 			      commands[i]->name);
 	}
 	ld->jsonrpc->rpc_listener = NULL;
+	tal_add_destructor(ld->jsonrpc, destroy_jsonrpc);
 }
 
 bool command_usage_only(const struct command *cmd)

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -265,7 +265,7 @@ static void slowcmd_finish(struct slowcmd *sc)
 static void slowcmd_start(struct slowcmd *sc)
 {
 	sc->js = json_stream_success(sc->cmd);
-	new_reltimer(&sc->cmd->ld->timers, sc, time_from_msec(*sc->msec),
+	new_reltimer(sc->cmd->ld->timers, sc, time_from_msec(*sc->msec),
 		     slowcmd_finish, sc);
 }
 
@@ -282,7 +282,7 @@ static struct command_result *json_slowcmd(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
-	new_reltimer(&cmd->ld->timers, sc, time_from_msec(0), slowcmd_start, sc);
+	new_reltimer(cmd->ld->timers, sc, time_from_msec(0), slowcmd_start, sc);
 	return command_still_pending(cmd);
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -851,6 +851,10 @@ int main(int argc, char *argv[])
 	free_unreleased_txs(ld->wallet);
 	db_commit_transaction(ld->wallet->db);
 
+	/* Clean our our HTLC maps, since they use malloc. */
+	htlc_in_map_clear(&ld->htlcs_in);
+	htlc_out_map_clear(&ld->htlcs_out);
+
 	remove(ld->pidfile);
 
 	/* FIXME: pay can have children off tmpctx which unlink from

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -112,7 +112,7 @@ struct lightningd {
 	u8 *rgb; /* tal_len() == 3. */
 
 	/* Any pending timers. */
-	struct timers timers;
+	struct timers *timers;
 
 	/* Port we're listening on */
 	u16 portnum;

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -209,7 +209,7 @@ static void report_leak_info(struct command *cmd, struct subd *leaker)
 	leak_info->leaker = leaker;
 
 	/* Leak detection in a reply handler thinks we're leaking conn. */
-	notleak(new_reltimer(&leak_info->cmd->ld->timers, leak_info->cmd,
+	notleak(new_reltimer(leak_info->cmd->ld->timers, leak_info->cmd,
 			     time_from_sec(0),
 			     report_leak_info2, leak_info));
 }

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -921,7 +921,7 @@ static struct command_result *json_waitsendpay(struct command *cmd,
 		return res;
 
 	if (timeout)
-		new_reltimer(&cmd->ld->timers, cmd, time_from_sec(*timeout),
+		new_reltimer(cmd->ld->timers, cmd, time_from_sec(*timeout),
 			     &waitsendpay_timeout, cmd);
 	return command_still_pending(cmd);
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -336,7 +336,7 @@ register_close_command(struct lightningd *ld,
 	tal_add_destructor2(channel,
 			    &destroy_close_command_on_channel_destroy,
 			    cc);
-	new_reltimer(&ld->timers, cc, time_from_sec(timeout),
+	new_reltimer(ld->timers, cc, time_from_sec(timeout),
 		     &close_command_timeout, cc);
 }
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -456,7 +456,7 @@ enum onion_type send_htlc_out(struct channel *out,
 
 	/* Give channel 30 seconds to commit (first) htlc. */
 	if (!out->htlc_timeout)
-		out->htlc_timeout = new_reltimer(&out->peer->ld->timers,
+		out->htlc_timeout = new_reltimer(out->peer->ld->timers,
 						 out, time_from_sec(30),
 						 htlc_offer_timeout,
 						 out);

--- a/wallet/txfilter.c
+++ b/wallet/txfilter.c
@@ -65,10 +65,16 @@ struct outpointfilter {
 	struct outpointset *set;
 };
 
+static void destroy_txfilter(struct txfilter *filter)
+{
+	scriptpubkeyset_clear(&filter->scriptpubkeyset);
+}
+
 struct txfilter *txfilter_new(const tal_t *ctx)
 {
 	struct txfilter *filter = tal(ctx, struct txfilter);
 	scriptpubkeyset_init(&filter->scriptpubkeyset);
+	tal_add_destructor(filter, destroy_txfilter);
 	return filter;
 }
 
@@ -132,10 +138,16 @@ void outpointfilter_remove(struct outpointfilter *of, const struct bitcoin_txid 
 	outpointset_del(of->set, &op);
 }
 
+static void destroy_outpointfilter(struct outpointfilter *opf)
+{
+	outpointset_clear(opf->set);
+}
+
 struct outpointfilter *outpointfilter_new(tal_t *ctx)
 {
 	struct outpointfilter *opf = tal(ctx, struct outpointfilter);
 	opf->set = tal(opf, struct outpointset);
 	outpointset_init(opf->set);
+	tal_add_destructor(opf, destroy_outpointfilter);
 	return opf;
 }


### PR DESCRIPTION
Reported-by: @niftynei 

None of these are unconstrained memory leaks, but it's nice to clean up on exit.

We could override the htable alloc routines to use tal off the htable, but that actually means each htable would have to be tal'ocated itself, which they currently are not (they're inside structures).  So we do this instead.