### PR TITLE
Fix compile error caused by merge.

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -266,11 +266,9 @@ static void funding_success(struct channel *channel)
 	struct command *cmd = fc->cmd;
 
 	response = json_stream_success(cmd);
-	json_object_start(response, NULL);
 	json_add_string(response, "channel_id",
 			type_to_string(tmpctx, struct channel_id, &fc->cid));
 	json_add_bool(response, "commitments_secured", true);
-	json_object_end(response);
 	was_pending(command_success(cmd, response));
 }
 
@@ -309,13 +307,11 @@ static void funding_started_success(struct funding_channel *fc,
 	char *out;
 
 	response = json_stream_success(cmd);
-	json_object_start(response, NULL);
 	out = encode_scriptpubkey_to_addr(cmd,
 				          get_chainparams(cmd->ld)->bip173_name,
 					  scriptPubkey);
 	if (out)
 		json_add_string(response, "funding_address", out);
-	json_object_end(response);
 	was_pending(command_success(cmd, response));
 }
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -690,9 +690,7 @@ static void opening_funder_failed(struct subd *openingd, const u8 *msg,
 		was_pending(command_fail(uc->fc->cmd, LIGHTNINGD, "%s", desc));
 	else {
 		response = json_stream_success(uc->fc->cmd);
-		json_stream_append(response, "\"");
-		json_stream_append(response, desc);
-		json_stream_append(response, "\"");
+		json_add_string(response, "cancelled", desc);
 		was_pending(command_success(uc->fc->cmd, response));
 	}
 


### PR DESCRIPTION
Compile broke because we were using low-level JSON primitives here (which, incidentally, would produce bad JSON now, since we can't just put a raw string inside an object!).

Tests broke because I changed the api of json_stream_success without changing the name :(