### PR TITLE
openingd: in handle_peer_in fix missing `default` case in switch

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1556,7 +1556,8 @@ static u8 *handle_peer_in(struct state *state)
 	case WIRE_REVOKE_AND_ACK:
 	case WIRE_UPDATE_FEE:
 	case WIRE_ANNOUNCEMENT_SIGNATURES:
-		/* Standard cases */
+	/* Standard cases */
+	default:
 		if (handle_peer_gossip_or_error(state->pps,
 						&state->channel_id, msg))
 			return NULL;


### PR DESCRIPTION
Unless we are just _not interested_ in incoming gossip or errors from peers in _openingd_ stadium, I think this  should be correct.

Found this when doing tests with `devtools/gossipwith` and It explains the many lines like
`chan #1172: Peer connection lost` in my logs.

**edit**: Not sure, but I suspect `gossipwith` did work so far because it is only used to receive gossip?