### PR TITLE
gossipd: don't catch pending node_announcements more than once.

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1343,7 +1343,15 @@ static void process_pending_node_announcement(struct routing_state *rstate,
 			status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				      "pending node_announcement %s malformed?",
 				      tal_hex(tmpctx, pna->node_announcement));
+		/* Never send this again. */
+		pna->node_announcement = tal_free(pna->node_announcement);
 	}
+
+	/* We don't need to catch any more node_announcements, since we've
+	 * accepted the public channel now.  But other pending announcements
+	 * may still hold a reference they use in
+	 * del_pending_node_announcement, so simply delete it from the map. */
+	pending_node_map_del(rstate->pending_node_map, pna);
 }
 
 static struct pending_cannouncement *


### PR DESCRIPTION
We catch node_announcements for nodes where we haven't finished
analyzing the channel_announcement yet (either because we're still
checking UTXO, or in this case, because we're waiting for a channel_update).

But we reference count the pending_node_announce, so if we have
multiple channels pending, we might try to insert it twice.  Clear it
so this doesn't happen.

There's a second bug where we continue to catch node_announcements
until *all* the channel_announcements are no longer pending; this is fixed
by removing it from the map.

Fixes: #2735
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>