### PR TITLE
lightningd: restore ' ' before '}' for older pylightning.

### DIFF
--- a/lightningd/json_stream.c
+++ b/lightningd/json_stream.c
@@ -160,6 +160,15 @@ void json_object_end(struct json_stream *js)
 		js_oom(js);
 }
 
+void json_object_compat_end(struct json_stream *js)
+{
+	/* In 0.7.1 we upgraded pylightning to no longer need this. */
+#ifdef COMPAT_V070
+	json_stream_append(js, " ", 1);
+#endif
+	json_object_end(js);
+}
+
 void json_add_member(struct json_stream *js,
 		     const char *fieldname,
 		     bool quote,

--- a/lightningd/json_stream.h
+++ b/lightningd/json_stream.h
@@ -65,10 +65,12 @@ bool json_stream_still_writing(const struct json_stream *js);
 void json_array_start(struct json_stream *js, const char *fieldname);
 /* '"fieldname" : { ' or '{ ' if fieldname is NULL */
 void json_object_start(struct json_stream *ks, const char *fieldname);
-/* ' ], ' */
+/* '],' */
 void json_array_end(struct json_stream *js);
-/* ' }, ' */
+/* '},' */
 void json_object_end(struct json_stream *js);
+/* ' },' */
+void json_object_compat_end(struct json_stream *js);
 
 /**
  * json_stream_append - literally insert this string into the json_stream.

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -455,7 +455,7 @@ struct command_result *command_success(struct command *cmd,
 	assert(cmd);
 	assert(cmd->json_stream == result);
 	json_object_end(result);
-	json_object_end(result);
+	json_object_compat_end(result);
 
 	return command_raw_complete(cmd, result);
 }
@@ -466,7 +466,7 @@ struct command_result *command_failed(struct command *cmd,
 	assert(cmd->json_stream == result);
 	/* Have to close error */
 	json_object_end(result);
-	json_object_end(result);
+	json_object_compat_end(result);
 
 	return command_raw_complete(cmd, result);
 }
@@ -512,7 +512,7 @@ static void json_command_malformed(struct json_connection *jcon,
 	json_add_member(js, "code", false, "%d", JSONRPC2_INVALID_REQUEST);
 	json_add_string(js, "message", error);
 	json_object_end(js);
-	json_object_end(js);
+	json_object_compat_end(js);
 
 	json_stream_close(js, NULL);
 }


### PR DESCRIPTION
It needs this in compat mode to detect old (pre-0.6.3) end of JSON.
But it always does the first command in compat mode.

This was never really reliable, since the first command could be to
a plugin for which we simply pass through the JSON (though, carefully
appending the expected '\n\n' if not already there).

Reported-by: @laanwj
Fixes: #2749 
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

(Tested by reverting adc4bf181735c943727d96842216806fe9a6ad16)