### PR TITLE
Simplified gossip_store recovery

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -485,8 +485,18 @@ static bool get_node_announcement(const tal_t *ctx,
 			      n->bcast.index, tal_hex(tmpctx, msg));
 		return false;
 	}
-	assert(node_id_eq(&id, &n->id));
-	assert(timestamp == n->bcast.timestamp);
+
+	if (!node_id_eq(&id, &n->id) || timestamp != n->bcast.timestamp) {
+		status_broken("Wrong node_announcement @%u:"
+			      " expected %s timestamp %u "
+			      " got %s timestamp %u",
+			      n->bcast.index,
+			      type_to_string(tmpctx, struct node_id, &n->id),
+			      timestamp,
+			      type_to_string(tmpctx, struct node_id, &id),
+			      n->bcast.timestamp);
+		return false;
+	}
 
 	*wireaddrs = read_addresses(ctx, addresses);
 	tal_free(addresses);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -2163,8 +2163,8 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 							&node_id));
 			return false;
 		} else if (timestamp <= pna->timestamp)
-			/* Ignore old ones: they're OK though. */
-			return true;
+			/* Ignore old ones: they're OK (unless from store). */
+			return index == 0;
 
 		SUPERVERBOSE("Deferring node_announcement for node %s",
 			     type_to_string(tmpctx, struct node_id, &node_id));
@@ -2184,7 +2184,8 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 	}
 	if (node->bcast.index && node->bcast.timestamp >= timestamp) {
 		SUPERVERBOSE("Ignoring node announcement, it's outdated.");
-		return true;
+		/* OK unless we're loading from store */
+		return index == 0;
 	}
 
 	/* Harmless if it was never added */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -437,12 +437,8 @@ struct wireaddr *read_addresses(const tal_t *ctx, const u8 *ser);
 void remove_channel_from_store(struct routing_state *rstate,
 			       struct chan *chan);
 
-/* gossip_store wants to delete any dangling entries immediately after
- * load; return 0 if no more, otherwise index into store.
- *
- * Must call remove_unfinalized_node_announce first, because removing
- * unupdated channels may delete associatd node_announcements. */
-u32 remove_unfinalized_node_announce(struct routing_state *rstate);
-u32 remove_unupdated_channel_announce(struct routing_state *rstate);
+/* Returns an error string if there are unfinalized entries after load */
+const char *unfinalized_entries(const tal_t *ctx, struct routing_state *rstate);
 
+void remove_all_gossip(struct routing_state *rstate);
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -945,8 +945,8 @@ def test_gossip_store_load_amount_truncated(node_factory):
 
     l1.start()
     # May preceed the Started msg waited for in 'start'.
-    wait_for(lambda: l1.daemon.is_in_log(r'Deleting un-amounted channel_announcement @1'))
-    wait_for(lambda: l1.daemon.is_in_log(r'gossip_store: Read 0/0/0/0 cannounce/cupdate/nannounce/cdelete from store \(1 deleted\) in 445 bytes'))
+    wait_for(lambda: l1.daemon.is_in_log(r'gossip_store: dangling channel_announcement'))
+    wait_for(lambda: l1.daemon.is_in_log(r'gossip_store: Read 0/0/0/0 cannounce/cupdate/nannounce/cdelete from store \(0 deleted\) in 1 bytes'))
     assert not l1.daemon.is_in_log('gossip_store.*truncating')
 
     # Extra sanity check if we can.

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1266,9 +1266,9 @@ def test_gossip_store_load_no_channel_update(node_factory):
                                   "00000000"  # timestamp
                                   "1005"      # WIRE_GOSSIP_STORE_CHANNEL_AMOUNT
                                   "0000000001000000"
-                                  "00000082"  # len
-                                  "fd421aeb"  # csum
-                                  "5b8d9b44"  # timestamp
+                                  "00000095"  # len
+                                  "f036515e"  # csum
+                                  "5aab817c"  # timestamp
                                   "0101"      # WIRE_NODE_ANNOUNCEMENT
                                   "cf5d870bc7ecabcb7cd16898ef66891e5f0c6c5851bd85b670f03d325bc44d7544d367cd852e18ec03f7f4ff369b06860a3b12b07b29f36fb318ca11348bf8ec00005aab817c03f113414ebdc6c1fb0f33c99cd5a1d09dd79e7fdf2468cf1fe1af6674361695d23974b250757a7a6c6549544300000000000000000000000000000000000000000000000007010566933e2607"))
 
@@ -1279,3 +1279,5 @@ def test_gossip_store_load_no_channel_update(node_factory):
 
     with open(os.path.join(l1.daemon.lightning_dir, 'gossip_store'), "rb") as f:
         assert bytearray(f.read()) == bytearray.fromhex("07")
+
+    assert not l1.daemon.is_in_log('gossip_store.*truncating')


### PR DESCRIPTION
I cannot reproduce #2750 on my nodes.  However, they seem to mainly be caused by us attempting to recover a gossip_store which we've truncated.  Instead, this discards all gossip when that happens.

It should also make any corruption easier to diagnose, as the last patch means we save the corrupt gossip_store to `gossip_store.corrupt` for later diagnosis.