### PR TITLE
gossipd: truncate gossip_store.tmp for compaction.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -235,7 +235,7 @@ bool gossip_store_compact(struct gossip_store *gs)
 	    "Compacting gossip_store with %zu entries, %zu of which are stale",
 	    gs->count, gs->deleted);
 
-	fd = open(GOSSIP_STORE_TEMP_FILENAME, O_RDWR|O_APPEND|O_CREAT, 0600);
+	fd = open(GOSSIP_STORE_TEMP_FILENAME, O_RDWR|O_TRUNC|O_CREAT, 0600);
 
 	if (fd < 0) {
 		status_broken(

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1198,6 +1198,20 @@ def setup_gossip_store_test(node_factory, bitcoind):
     return l2
 
 
+@unittest.skipIf(not DEVELOPER, "need dev-compact-gossip-store")
+def test_gossip_store_compact_noappend(node_factory, bitcoind):
+    l2 = setup_gossip_store_test(node_factory, bitcoind)
+
+    # It should truncate this, not leave junk!
+    with open(os.path.join(l2.daemon.lightning_dir, 'gossip_store.tmp'), 'wb') as f:
+        f.write(bytearray.fromhex("07deadbeef"))
+
+    l2.rpc.call('dev-compact-gossip-store')
+    l2.restart()
+    wait_for(lambda: l2.daemon.is_in_log('gossip_store: Read '))
+    assert not l2.daemon.is_in_log('gossip_store:.*truncate')
+
+
 def test_gossip_store_load_complex(node_factory, bitcoind):
     l2 = setup_gossip_store_test(node_factory, bitcoind)
 


### PR DESCRIPTION
If something went wrong and there was an old one, we were appending to it!

Reported-by: @SimonVrouwe
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>