### PR TITLE
json-rpc: Disable `listtransactions` for the 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: New command `setchannelfee` sets channel specific routing fees.
 - JSON API: new withdraw methods `txprepare`, `txsend` and `txdiscard`.
 - JSON API: add three new RPC commands: `fundchannel_start`, `fundchannel_complete` and `fundchannel_cancel`. Allows a user to initiate and complete a channel open using funds that are in a external wallet.
-- JSON API: new `listtransactions` command to show wallet history.
 - Plugin: new hooks `db_write` for intercepting database writes, `invoice_payment` for intercepting invoices before they're paid, `openchannel` for intercepting channel opens, and `htlc_accepted` to decide whether to resolve, reject or continue an incoming or forwarded payment..
 - Plugin: new notification `warning` to report any `LOG_UNUSUAL`/`LOG_BROKEN` level event.
 - Plugin: Added a default plugin directory : `lightning_dir/plugins`. Each plugin directory it contains will be added to lightningd on startup.

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -751,6 +751,7 @@ static const struct json_command dev_rescan_output_command = {
 };
 AUTODATA(json_command, &dev_rescan_output_command);
 
+#if EXPERIMENTAL_FEATURES
 struct {
 	enum wallet_tx_type t;
 	const char *name;
@@ -826,3 +827,4 @@ static const struct json_command listtransactions_command = {
     "it closes the channel and returns funds to the wallet."
 };
 AUTODATA(json_command, &listtransactions_command);
+#endif


### PR DESCRIPTION
Given the number of open issues with the `listtransactions` RPC method I think it is probably best if we disable the method for the 0.7.1 release, and then fix it up for the next release.