### PR TITLE
Don't delete channels once they are resolved, just mark them closed.

### DIFF
--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -113,7 +113,7 @@ static void destroy_channel(struct channel *channel)
 void delete_channel(struct channel *channel)
 {
 	struct peer *peer = channel->peer;
-	wallet_channel_delete(channel->peer->ld->wallet, channel->dbid);
+	wallet_channel_close(channel->peer->ld->wallet, channel->dbid);
 	tal_free(channel);
 
 	maybe_delete_peer(peer);

--- a/lightningd/channel_state.h
+++ b/lightningd/channel_state.h
@@ -26,8 +26,11 @@ enum channel_state {
 	FUNDING_SPEND_SEEN,
 
 	/* On chain */
-	ONCHAIN
+	ONCHAIN,
+
+	/* Final state after we have fully settled on-chain */
+	CLOSED
 };
-#define CHANNEL_STATE_MAX ONCHAIN
+#define CHANNEL_STATE_MAX CLOSED
 
 #endif /* LIGHTNING_LIGHTNINGD_CHANNEL_STATE_H */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -826,7 +826,10 @@ peer_connected_hook_cb(struct peer_connected_hook_payload *payload,
 		case ONCHAIN:
 		case FUNDING_SPEND_SEEN:
 		case CLOSINGD_COMPLETE:
-			/* Channel is supposed to be active! */
+			/* Channel is supposed to be active!*/
+			abort();
+		case CLOSED:
+			/* Channel should not have been loaded */
 			abort();
 
 		/* We consider this "active" but we only send an error */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -461,9 +461,9 @@ void txfilter_add_scriptpubkey(struct txfilter *filter UNNEEDED, const u8 *scrip
 /* Generated stub for version */
 const char *version(void)
 { fprintf(stderr, "version called!\n"); abort(); }
-/* Generated stub for wallet_channel_delete */
-void wallet_channel_delete(struct wallet *w UNNEEDED, u64 wallet_id UNNEEDED)
-{ fprintf(stderr, "wallet_channel_delete called!\n"); abort(); }
+/* Generated stub for wallet_channel_close */
+void wallet_channel_close(struct wallet *w UNNEEDED, u64 wallet_id UNNEEDED)
+{ fprintf(stderr, "wallet_channel_close called!\n"); abort(); }
 /* Generated stub for wallet_channel_save */
 void wallet_channel_save(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED)
 { fprintf(stderr, "wallet_channel_save called!\n"); abort(); }

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -92,6 +92,10 @@ def test_closing(node_factory, bitcoind):
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 0)
     wait_for(lambda: len(l2.rpc.listchannels()['channels']) == 0)
 
+    # The entry in the channels table should still be there
+    assert l1.db_query("SELECT count(*) as c FROM channels;")[0]['c'] == 1
+    assert l2.db_query("SELECT count(*) as c FROM channels;")[0]['c'] == 1
+
 
 def test_closing_while_disconnected(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1234,6 +1234,10 @@ def test_forget_channel(node_factory):
     l1.restart()
     assert len(l1.rpc.listpeers()['peers']) == 0
 
+    # The entry in the channels table should still be there
+    assert l1.db_query("SELECT count(*) as c FROM channels;")[0]['c'] == 1
+    assert l2.db_query("SELECT count(*) as c FROM channels;")[0]['c'] == 1
+
 
 def test_peerinfo(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'may_reconnect': True})

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -850,8 +850,7 @@ bool wallet_channels_load_active(struct wallet *w)
 	sqlite3_stmt *stmt;
 
 	/* We load all channels */
-	stmt = db_select(w->db, "%s FROM channels;", channel_fields);
-
+	stmt = db_select(w->db, "%s FROM channels WHERE state < %d;", channel_fields, CLOSED);
 	w->max_channel_dbid = 0;
 
 	int count = 0;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -454,9 +454,9 @@ void wallet_channel_save(struct wallet *w, struct channel *chan);
 void wallet_channel_insert(struct wallet *w, struct channel *chan);
 
 /**
- * wallet_channel_delete -- After resolving a channel, forget about it
+ * After fully resolving a channel, only keep a lightweight stub
  */
-void wallet_channel_delete(struct wallet *w, u64 wallet_id);
+void wallet_channel_close(struct wallet *w, u64 wallet_id);
 
 /**
  * wallet_peer_delete -- After no more channels in peer, forget about it


### PR DESCRIPTION
Since we are starting to have some tables that reference the `channels` table using foreign keys and these survive the channel I think it's a good idea to keep a minimal version of the channels around. This ensures that foreign key relationships aren't broken once we fully resolve a channel, including access to channel-related fields, and it can allow us to recover some information about old channels for debugging or display purposes.

Fixes #2028