### PR TITLE
lightningd: fix occasional missing txid detection.

### DIFF
--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -9,7 +9,9 @@
 
 struct channel;
 struct htlc_in;
+struct htlc_in_map;
 struct htlc_out;
+struct htlc_out_map;
 struct htlc_stub;
 struct lightningd;
 

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -578,6 +578,7 @@ struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   enum watch_result (*cb)(struct lightningd *ld UNNEEDED,
 						   struct channel *channel UNNEEDED,
 						   const struct bitcoin_txid * UNNEEDED,
+						   const struct bitcoin_tx * UNNEEDED,
 						   unsigned int depth))
 { fprintf(stderr, "watch_txid called!\n"); abort(); }
 /* Generated stub for watch_txo */

--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -47,6 +47,7 @@ struct txwatch *watch_txid(const tal_t *ctx,
 			   enum watch_result (*cb)(struct lightningd *ld,
 						   struct channel *channel,
 						   const struct bitcoin_txid *,
+						   const struct bitcoin_tx *,
 						   unsigned int depth));
 
 struct txwatch *watch_tx(const tal_t *ctx,
@@ -56,6 +57,7 @@ struct txwatch *watch_tx(const tal_t *ctx,
 			 enum watch_result (*cb)(struct lightningd *ld,
 						 struct channel *channel,
 						 const struct bitcoin_txid *,
+						 const struct bitcoin_tx *,
 						 unsigned int depth));
 
 struct txowatch *watch_txo(const tal_t *ctx,
@@ -82,6 +84,11 @@ void txowatch_fire(const struct txowatch *txow,
 
 bool watching_txid(const struct chain_topology *topo,
 		   const struct bitcoin_txid *txid);
+
+/* FIXME: Implement bitcoin_tx_dup() so we tx arg can be TAKEN */
+void txwatch_inform(const struct chain_topology *topo,
+		    const struct bitcoin_txid *txid,
+		    const struct bitcoin_tx *tx_may_steal);
 
 void watch_topology_changed(struct chain_topology *topo);
 #endif /* LIGHTNING_LIGHTNINGD_WATCH_H */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -569,6 +569,7 @@ struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   enum watch_result (*cb)(struct lightningd *ld UNNEEDED,
 						   struct channel *channel UNNEEDED,
 						   const struct bitcoin_txid * UNNEEDED,
+						   const struct bitcoin_tx * UNNEEDED,
 						   unsigned int depth))
 { fprintf(stderr, "watch_txid called!\n"); abort(); }
 /* Generated stub for watch_txo */


### PR DESCRIPTION
I was working on rewriting our (somewhat chaotic) tx watching code
for 0.7.2, when I found this bug: we don't always notice the funding
tx in corner cases where more than one block is detected at
once.

This is just the one commit needed to fix the problem: it has some
unnecessary changes, but I'd prefer not to diverge too far from my
cleanup-txwatch branch.

Fixes: #2352
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>