### PR TITLE
makefiles: fix quotation of BINTOPKGLIBEXECDIR macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ WIRE_GEN := tools/generate-wire.py
 
 ALL_PROGRAMS =
 
-CPPFLAGS = -DBINTOPKGLIBEXECDIR='"'$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))'"'
+CPPFLAGS = -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\""
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS)
 
 # We can get configurator to run a different compile cmd to cross-configure.


### PR DESCRIPTION
It fixes this error that happens in some configurations:

```
configure: creating ./config.status
./config.status: command substitution: line 547: unexpected EOF while looking for matching `"'
./config.status: command substitution: line 548: syntax error: unexpected end of file
./config.status: line 546: LDFLAGS=  -Og: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 688: -e: command not found
./config.status: line 700: -e: command not found
./config.status: line 700: -e: command not found
./config.status: line 700: -e: command not found
./config.status: line 700: -e: command not found
```

See:
https://github.com/ElementsProject/lightning/issues/1454
https://github.com/ElementsProject/lightning/issues/2618
