### PR TITLE
peer_control: fix autodata compile issue.

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -114,7 +114,6 @@ struct peer *new_peer(struct lightningd *ld, u64 dbid,
 	peer->globalfeatures = peer->localfeatures = NULL;
 	list_head_init(&peer->channels);
 	peer->direction = node_id_idx(&peer->ld->id, &peer->id);
-
 #if DEVELOPER
 	peer->ignore_htlcs = false;
 #endif


### PR DESCRIPTION
Caused by merge, and two files with autodata on same line.

Edit by ZmnSCPxj:

Fixes: #2782 
