### PR TITLE
gossipd: fail clearly if we can't open/create gossip_store.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -167,6 +167,10 @@ struct gossip_store *gossip_store_new(struct routing_state *rstate,
 	gs->writable = true;
 	gossip_store_compact_offline();
 	gs->fd = open(GOSSIP_STORE_FILENAME, O_RDWR|O_APPEND|O_CREAT, 0600);
+	if (gs->fd < 0)
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "Opening gossip_store store: %s",
+			      strerror(errno));
 	gs->rstate = rstate;
 	gs->disable_compaction = false;
 	gs->len = sizeof(gs->version);


### PR DESCRIPTION
Otherwise we fail at the write, and then it's not clear
*why* we couldn't open file:

lightning_gossipd: Writing version to store: Bad file descriptor (version v0.7.1-16-g7ea5c5c)
0x560dcf1a3779 send_backtrace common/daemon.c:40
0x560dcf1a634d status_failed common/status.c:192
0x560dcf19726a gossip_store_new gossipd/gossip_store.c:195
0x560dcf199fd0 new_routing_state gossipd/routing.c:177
0x560dcf1a098b gossip_init gossipd/gossipd.c:2113
0x560dcf1a197a recv_req gossipd/gossipd.c:2946
0x560dcf1a38cd handle_read common/daemon_conn.c:31
0x560dcf1bae2c next_plan ccan/ccan/io/io.c:59
0x560dcf1bb314 do_plan ccan/ccan/io/io.c:407
0x560dcf1bb341 io_ready ccan/ccan/io/io.c:417
0x560dcf1bcb13 io_loop ccan/ccan/io/poll.c:445
0x560dcf1a1ba0 main gossipd/gossipd.c:3073

Reported-by: @JavierRSobrino
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>