### PR TITLE
Plugin: Another new notification type, forward_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lightningd: add support for `signet` networks using the `--network=signet` or `--signet` startup option
 - JSON API: `listfunds` now returns also `funding_output` for `channels`
 - plugins: plugins can now suggest `lightning-cli` default to -H for responses.
+- Plugin: new notification `forward_event` offered/settled/failed/local_failed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugins: a new boolean field can be added to a plugin manifest, `dynamic`. It allows a plugin to tell if it can be started or stopped "on-the-fly".
 - lightningd: check bitcoind version when setup topology and confirm the version not older than v0.15.0.
 - startup: space out reconnections on startup if we have more than 5 peers.
+- JSON API: `listforwards` includes the 'payment_hash' field.
 
 ### Deprecated
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -514,7 +514,7 @@ static void gossipd_incoming_channels_reply(struct subd *gossipd,
 	details = wallet_invoice_details(info, wallet, invoice);
 
 	response = json_stream_success(info->cmd);
-	json_add_hex(response, "payment_hash", details->rhash.u.u8,
+	json_add_hex(response, "payment_hash", &details->rhash,
 		     sizeof(details->rhash));
 	json_add_u64(response, "expires_at", details->expiry_time);
 	json_add_string(response, "bolt11", details->bolt11);

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -10,6 +10,7 @@
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <lightningd/plugin.h>
+#include <wallet/wallet.h>
 
 bool notifications_have_topic(const char *topic);
 
@@ -25,5 +26,12 @@ void notify_invoice_payment(struct lightningd *ld, struct amount_msat amount,
 void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
 			   struct amount_sat *funding_sat, struct bitcoin_txid *funding_txid,
 			   bool *funding_locked);
+
+void notify_forward_event(struct lightningd *ld,
+			  const struct htlc_in *in,
+			  const struct htlc_out *out,
+			  enum forward_status state,
+			  enum onion_type failcode,
+			  struct timeabs *resolved_time);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2114,6 +2114,9 @@ static void listforwardings_add_forwardings(struct json_stream *response, struct
 		const struct forwarding *cur = &forwardings[i];
 		json_object_start(response, NULL);
 
+		json_add_hex(response, "payment_hash",
+			     cur->payment_hash,
+			     sizeof(*cur->payment_hash));
 		json_add_short_channel_id(response, "in_channel", &cur->channel_in);
 		json_add_short_channel_id(response, "out_channel", &cur->channel_out);
 		json_add_amount_msat_compat(response,

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -14,6 +14,8 @@ struct htlc_out;
 struct htlc_out_map;
 struct htlc_stub;
 struct lightningd;
+struct forwarding;
+struct json_stream;
 
 /* FIXME: Define serialization primitive for this? */
 struct channel_info {
@@ -69,4 +71,8 @@ void htlcs_reconnect(struct lightningd *ld,
 void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage);
 void fail_htlc(struct htlc_in *hin, enum onion_type failcode);
 
+/* This json process will be both used in 'notify_forward_event()'
+ * and 'listforwardings_add_forwardings()'*/
+void json_format_forwarding_object(struct json_stream *response, const char *fieldname,
+				   const struct forwarding *cur);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/tests/plugins/forward_payment_status.py
+++ b/tests/plugins/forward_payment_status.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""This plugin is used to check that forward_event calls are working correctly.
+"""
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+def check(forward, dbforward):
+    # After finding the corresponding notification record, this function will
+    # make some changes on mutative fields of this record to make this record
+    # same as the ideal format with given status.
+    record = forward
+    if record['status'] == 'offered':
+        if dbforward['status'] == 'local_failed':
+            record['failcode'] = dbforward['failcode']
+            record['failreason'] = dbforward['failreason']
+        elif dbforward['status'] != 'offered':
+            record['resolved_time'] = dbforward['resolved_time']
+    record['status'] = dbforward['status']
+    if record == dbforward:
+        return True
+    else:
+        return False
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    plugin.forward_list = []
+
+
+@plugin.subscribe("forward_event")
+def notify_warning(plugin, forward_event):
+    # One forward payment may have many notification records for different status,
+    # but one forward payment has only one record in 'listforwards' eventrually.
+    plugin.log("receive a forward recored, status: {}, payment_hash: {}".format(forward_event['status'], forward_event['payment_hash']))
+    plugin.forward_list.append(forward_event)
+
+
+@plugin.method('recordcheck')
+def record_lookup(payment_hash, status, dbforward, plugin):
+    # Check if we received all notifications when forward changed.
+    # This check is based on the records of 'listforwards'
+    plugin.log("recordcheck: payment_hash: {}, status: {}".format(payment_hash, status))
+    for forward in plugin.forward_list:
+        if forward['payment_hash'] == payment_hash and forward['status'] == status:
+            plugin.log("record exists")
+            check_result = check(forward, dbforward)
+            return check_result
+    plugin.log("no record")
+    return False
+
+
+plugin.run()

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -375,6 +375,9 @@ void notify_connect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UNNEE
 /* Generated stub for notify_disconnect */
 void notify_disconnect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UNNEEDED)
 { fprintf(stderr, "notify_disconnect called!\n"); abort(); }
+/* Generated stub for notify_forward_event */
+void notify_forward_event(struct lightningd *ld UNNEEDED, const struct htlc_in *in UNNEEDED, const struct htlc_out *out UNNEEDED, enum forward_status state UNNEEDED, enum onion_type failcode UNNEEDED, struct timeabs *resolved_time UNNEEDED)
+{ fprintf(stderr, "notify_disconnect called!\n"); abort(); }
 /* Generated stub for onchaind_funding_spent */
 enum watch_result onchaind_funding_spent(struct channel *channel UNNEEDED,
 					 const struct bitcoin_tx *tx UNNEEDED,


### PR DESCRIPTION
# Introduction
A notification for topic `forward_event` is sent every time the status of a forward payment is set. The json format is same as the API `listforwards`.
Now when the forwad payment status changes, we'll store forward payments with the new status into DB. This notification will notify subscribers after storing operation.

```json
{
  "forward_event": {
  "payment_hash": "f5a6a059a25d1e329d9b094aeeec8c2191ca037d3f5b0662e21ae850debe8ea2",
  "in_channel": "103x2x1",
  "out_channel": "103x1x1",
  "in_msatoshi": 100001001,
  "in_msat": "100001001msat",
  "out_msatoshi": 100000000,
  "out_msat": "100000000msat",
  "fee": 1001,
  "fee_msat": "1001msat",
  "status": "settled",
  "received_time": 1560696342.368,
  "resolved_time": 1560696342.556
  }
}
```
or

```json
{
  "forward_event": {
  "payment_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
  "in_channel": "103x2x1",
  "out_channel": "110x1x0",
  "in_msatoshi": 100001001,
  "in_msat": "100001001msat",
  "out_msatoshi": 100000000,
  "out_msat": "100000000msat",
  "fee": 1001,
  "fee_msat": "1001msat",
  "status": "local_failed",
  "failcode": 16392,
  "failreason": "WIRE_PERMANENT_CHANNEL_FAILURE",
  "received_time": 1560696343.052
  }
}
```
#### ~~EDIT: change the "forward_event" fieldname in json to "forward_payment".~~

# Related Changes
- Set the fee to 0 when forward doesn't have out channel with `LOCAL_FAILED` status;
- API: `listforwards` include `payment_hash` field;
- JSON: Warp the process of forward payment json object and use it in notification.


### A Related Question
I am confused about the difference of `struct sha256` and `struct sha256_double`: these two struct are both used to store `payment_hash`, maybe we need a cleanup to unify their usage for `payment_hash`.