### PR TITLE
bash-completion: include underscores

### DIFF
--- a/contrib/lightning-cli.bash-completion
+++ b/contrib/lightning-cli.bash-completion
@@ -31,7 +31,7 @@ _lightning_cli() {
 
             # get the regular commands
             if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
-		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^\([a-z][a-z-]*\).*/\1/p' | sed '$ d')
+		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^\([a-z][a-z_-]*\).*/\1/p' | sed '$ d')
             fi
 
             COMPREPLY=( $( compgen -W "$helpopts $globalcmds" -X "*," -- "$cur" ) )


### PR DESCRIPTION
`fundchannel_start` etc are not included in the bash-completion as
they include underscores in their names. this fixes this by including
underscores.