### PR TITLE
tests: log funder_faileds as unusual not broken

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1005,7 +1005,7 @@ static unsigned int openingd_msg(struct subd *openingd,
 		return 0;
 	case WIRE_OPENING_FUNDER_FAILED:
 		if (!uc->fc) {
-			log_broken(openingd->log, "Unexpected FUNDER_FAILED %s",
+			log_unusual(openingd->log, "Unexpected FUNDER_FAILED %s",
 				   tal_hex(tmpctx, msg));
 			tal_free(openingd);
 			return 0;


### PR DESCRIPTION
test_funding_cancel_race explicitly attempts to trigger this via a race
condition; this conflicts with our post-test checks that no broken
logs were logged. as a middle ground, we log it as unusual, not broken,
as it's possible for it to attempt to fail if it was begun at the same
time as the complete is (hence it's not *actually* broken, yet still unusual)