### PR TITLE
gossipd: fix inverted test in debug print.

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -2496,10 +2496,10 @@ void route_prune(struct routing_state *rstate)
 			    "Pruning channel %s from network view (ages %"PRIu64" and %"PRIu64"s)",
 			    type_to_string(tmpctx, struct short_channel_id,
 					   &chan->scid),
-			    is_halfchan_defined(&chan->half[0]) ? 0
-			    : now - chan->half[0].bcast.timestamp,
-			    is_halfchan_defined(&chan->half[1]) ? 0
-			    : now - chan->half[1].bcast.timestamp);
+			    is_halfchan_defined(&chan->half[0])
+			    ? now - chan->half[0].bcast.timestamp : 0,
+			    is_halfchan_defined(&chan->half[1])
+			    ? now - chan->half[1].bcast.timestamp : 0);
 
 			/* This may perturb iteration so do outside loop. */
 			tal_arr_expand(&pruned, chan);


### PR DESCRIPTION
==1503== Use of uninitialised value of size 8
==1503==    at 0x566786B: _itoa_word (_itoa.c:179)
==1503==    by 0x566AF0D: vfprintf (vfprintf.c:1642)
==1503==    by 0x569790F: vsnprintf (vsnprintf.c:114)
==1503==    by 0x156CCB: do_vfmt (str.c:66)
==1503==    by 0x156DB1: tal_vfmt_ (str.c:92)
==1503==    by 0x1289CD: status_vfmt (status.c:141)
==1503==    by 0x128AAC: status_fmt (status.c:151)
==1503==    by 0x118E05: route_prune (routing.c:2495)
==1503==    by 0x11DE2D: gossip_refresh_network (gossipd.c:1997)
==1503==    by 0x1292B8: timer_expired (timeout.c:39)
==1503==    by 0x12088C: main (gossipd.c:3075)

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>