### PR TITLE
plugins/pay: fix crash when we reach retry timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ changes.
 
 ### Fixed
 
+- Plugin: `pay` no longer crashes on timeout.
+
 ### Security
 
 ## [0.7.1] - 2019-06-29: "The Unfailing Twitter Consensus Algorithm"

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -232,11 +232,13 @@ static struct command_result *waitsendpay_expired(struct command *cmd,
 	json_out_start(data, NULL, '{');
 	json_out_start(data, "attempts", '[');
 	for (size_t i = 0; i < tal_count(pc->ps->attempts); i++) {
+		json_out_start(data, NULL, '{');
 		if (pc->ps->attempts[i].route)
 			json_out_add_raw(data, "route",
 					 pc->ps->attempts[i].route);
 		json_out_add_splice(data, "failure",
 				    pc->ps->attempts[i].failure);
+		json_out_end(data, '}');
 	}
 	json_out_end(data, ']');
 	json_out_end(data, '}');


### PR DESCRIPTION
```
pay: ccan/ccan/json_out/json_out.c:144: check_fieldname: Assertion `!fieldname' failed.
pay: FATAL SIGNAL 6 (version v0.7.1rc4-1-gf1bea55)
0x11d914 send_backtrace
        common/daemon.c:40
0x11d9ba crashdump
        common/daemon.c:53
0x5430f1f ???
        ???:0
0x5430e97 ???
        ???:0
0x5432800 ???
        ???:0
0x5422399 ???
        ???:0
0x5422411 ???
        ???:0
0x1325c3 check_fieldname
        ccan/ccan/json_out/json_out.c:144
0x132627 json_out_member_direct
        ccan/ccan/json_out/json_out.c:162
0x10c4a4 json_out_add_raw_len
        plugins/pay.c:122
0x10c4f9 json_out_add_raw
        plugins/pay.c:130
0x10c9ae waitsendpay_expired
        plugins/pay.c:236
0x10ce39 waitsendpay_error
        plugins/pay.c:322
0x111aa7 handle_rpc_reply
        plugins/libplugin.c:431
```
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>