### PR TITLE
param: implement helpers for multiplex commands.

### DIFF
--- a/common/json_tok.c
+++ b/common/json_tok.c
@@ -78,6 +78,13 @@ struct command_result *param_string(struct command *cmd, const char *name,
 	return NULL;
 }
 
+struct command_result *param_ignore(struct command *cmd, const char *name,
+				    const char *buffer, const jsmntok_t *tok,
+				    const void *unused)
+{
+	return NULL;
+}
+
 struct command_result *param_label(struct command *cmd, const char *name,
 				   const char * buffer, const jsmntok_t *tok,
 				   struct json_escape **label)

--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -85,4 +85,8 @@ struct command_result *param_tok(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t * tok,
 				 const jsmntok_t **out);
 
+/* Ignore the token.  Not usually used. */
+struct command_result *param_ignore(struct command *cmd, const char *name,
+				    const char *buffer, const jsmntok_t *tok,
+				    const void *unused);
 #endif /* LIGHTNING_COMMON_JSON_TOK_H */

--- a/common/param.h
+++ b/common/param.h
@@ -58,13 +58,25 @@ typedef struct command_result *(*param_cbx)(struct command *cmd,
 					    const jsmntok_t *tok,
 					    void **arg);
 
+/**
+ * Parse the first json value.
+ *
+ * name...: NULL-terminated array of valid values.
+ *
+ * Returns subcommand: if it returns NULL if you should return
+ * command_param_failed() immediately.
+ */
+const char *param_subcommand(struct command *cmd, const char *buffer,
+			     const jsmntok_t tokens[],
+			     const char *name, ...) LAST_ARG_NULL;
+
 /*
  * Add a required parameter.
  */
 #define p_req(name, cbx, arg)                                \
 	      name"",                                        \
 	      true,                                          \
-	      (cbx),                                         \
+	      (param_cbx)(cbx),				     \
 	      (arg) + 0*sizeof((cbx)((struct command *)NULL, \
 			       (const char *)NULL,           \
 			       (const char *)NULL,           \
@@ -77,7 +89,7 @@ typedef struct command_result *(*param_cbx)(struct command *cmd,
 #define p_opt(name, cbx, arg)                                   \
 	      name"",                                           \
 	      false,                                            \
-	      (cbx),                                            \
+	      (param_cbx)(cbx),                                 \
 	      ({ *arg = NULL;                                   \
 		 (arg) + 0*sizeof((cbx)((struct command *)NULL, \
 		                  (const char *)NULL,           \
@@ -91,7 +103,7 @@ typedef struct command_result *(*param_cbx)(struct command *cmd,
 #define p_opt_def(name, cbx, arg, def)				    \
 		  name"",					    \
 		  false,					    \
-		  (cbx),				 	    \
+		  (param_cbx)(cbx),				    \
 		  ({ (*arg) = tal((cmd), typeof(**arg));            \
 		     (**arg) = (def);                               \
 		     (arg) + 0*sizeof((cbx)((struct command *)NULL, \

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -70,6 +70,11 @@ struct command_result *param_feerate_estimate(struct command *cmd UNNEEDED,
 					      u32 **feerate_per_kw UNNEEDED,
 					      enum feerate feerate UNNEEDED)
 { fprintf(stderr, "param_feerate_estimate called!\n"); abort(); }
+/* Generated stub for param_ignore */
+struct command_result *param_ignore(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				    const void *unused UNNEEDED)
+{ fprintf(stderr, "param_ignore called!\n"); abort(); }
 /* Generated stub for param_number */
 struct command_result *param_number(struct command *cmd UNNEEDED, const char *name UNNEEDED,
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
@@ -80,6 +85,11 @@ struct command_result *param_sha256(struct command *cmd UNNEEDED, const char *na
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				    struct sha256 **hash UNNEEDED)
 { fprintf(stderr, "param_sha256 called!\n"); abort(); }
+/* Generated stub for param_subcommand */
+const char *param_subcommand(struct command *cmd UNNEEDED, const char *buffer UNNEEDED,
+			     const jsmntok_t tokens[] UNNEEDED,
+			     const char *name UNNEEDED, ...)
+{ fprintf(stderr, "param_subcommand called!\n"); abort(); }
 /* Generated stub for param_tok */
 struct command_result *param_tok(struct command *cmd UNNEEDED, const char *name UNNEEDED,
 				 const char *buffer UNNEEDED, const jsmntok_t * tok UNNEEDED,


### PR DESCRIPTION
Our previous param support was a bit limited in this case, and we want it for #2771 

We replace some dev- commands with a multiplexer, so we can exercise it