### PR TITLE
Plugins: a notification for invoice payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - build: now requires `python3-mako` to be installed, i.e. `sudo apt-get install python3-mako`
+- plugins: a new notification type `invoice_payment` (sent when an invoice is paid) has been added
 
 ### Deprecated
 

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -34,6 +34,14 @@ def on_disconnect(plugin, id):
     plugin.log("Received disconnect event for peer {}".format(id))
 
 
+@plugin.subscribe("invoice_payment")
+def on_payment(plugin, invoice_payment):
+    plugin.log("Received invoice_payment event for label {}, preimage {},"
+               " and amount of {}".format(invoice_payment.get("label"),
+                                          invoice_payment.get("preimage"),
+                                          invoice_payment.get("msat")))
+
+
 @plugin.hook("htlc_accepted")
 def on_htlc_accepted(onion, htlc, plugin):
     plugin.log('on_htlc_accepted called')

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -223,6 +223,21 @@ to a peer was lost.
 }
 ```
 
+#### `invoice_payment`
+
+A notification for topic `invoice_payment` is sent every time an invoie is paid.
+
+```json
+{
+	"invoice_payment": {
+		"label": "unique-label-for-invoice",
+		"preimage": "0000000000000000000000000000000000000000000000000000000000000000",
+		"msat": "10000msat"
+	}
+}
+```
+
+
 #### `warning`
 
 A notification for topic `warning` is sent every time a new `BROKEN`

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -1,7 +1,4 @@
 #include "invoice.h"
-#include "json.h"
-#include "jsonrpc.h"
-#include "lightningd.h"
 #include <bitcoin/address.h>
 #include <bitcoin/base58.h>
 #include <bitcoin/script.h>
@@ -25,7 +22,11 @@
 #include <inttypes.h>
 #include <lightningd/channel.h>
 #include <lightningd/hsm_control.h>
+#include <lightningd/json.h>
+#include <lightningd/jsonrpc.h>
+#include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/notification.h>
 #include <lightningd/options.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/peer_htlcs.h>
@@ -172,6 +173,10 @@ invoice_payment_hook_cb(struct invoice_payment_hook_payload *payload,
 	struct lightningd *ld = payload->ld;
 	struct invoice invoice;
 	enum onion_type failcode;
+
+	/* We notify here to benefit from the payload and because the hook callback is
+	 * called even if the hook is not registered. */
+	notify_invoice_payment(ld, payload->msat, payload->preimage, payload->label);
 
 	tal_del_destructor2(payload->hin, invoice_payload_remove_hin, payload);
 	/* We want to free this, whatever happens. */

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -1,6 +1,8 @@
 #ifndef LIGHTNING_LIGHTNINGD_NOTIFICATION_H
 #define LIGHTNING_LIGHTNINGD_NOTIFICATION_H
 #include "config.h"
+#include <ccan/json_escape/json_escape.h>
+#include <common/amount.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
@@ -13,5 +15,8 @@ void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 void notify_disconnect(struct lightningd *ld, struct node_id *nodeid);
 
 void notify_warning(struct lightningd *ld, struct log_entry *l);
+
+void notify_invoice_payment(struct lightningd *ld, struct amount_msat amount,
+			    struct preimage preimage, const struct json_escape *label);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -287,6 +287,10 @@ void notify_connect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UNNEE
 /* Generated stub for notify_disconnect */
 void notify_disconnect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UNNEEDED)
 { fprintf(stderr, "notify_disconnect called!\n"); abort(); }
+/* Generated stub for notify_invoice_payment */
+void notify_invoice_payment(struct lightningd *ld UNNEEDED, struct amount_msat amount UNNEEDED,
+			    struct preimage preimage UNNEEDED, const struct json_escape *label UNNEEDED)
+{ fprintf(stderr, "notify_invoice_payment called!\n"); abort(); }
 /* Generated stub for onchaind_funding_spent */
 enum watch_result onchaind_funding_spent(struct channel *channel UNNEEDED,
 					 const struct bitcoin_tx *tx UNNEEDED,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -476,3 +476,21 @@ def test_warning_notification(node_factory):
     l1.daemon.wait_for_log('plugin-pretend_badlog.py time: *')
     l1.daemon.wait_for_log('plugin-pretend_badlog.py source: plugin-pretend_badlog.py')
     l1.daemon.wait_for_log('plugin-pretend_badlog.py log: Test warning notification\\(for broken event\\)')
+
+
+def test_invoice_payment_notification(node_factory):
+    """
+    Test the 'invoice_payment' notification
+    """
+    opts = [{}, {"plugin": "contrib/plugins/helloworld.py"}]
+    l1, l2 = node_factory.line_graph(2, opts=opts)
+
+    msats = 12345
+    preimage = '1' * 64
+    label = "a_descriptive_label"
+    inv1 = l2.rpc.invoice(msats, label, 'description', preimage=preimage)
+    l1.rpc.pay(inv1['bolt11'])
+
+    l2.daemon.wait_for_log(r"Received invoice_payment event for label {},"
+                           " preimage {}, and amount of {}msat"
+                           .format(label, preimage, msats))


### PR DESCRIPTION
As discussed on IRC, a plugin might want to be notified on invoice payment without needing `lightningd` to wait for his response.
This PR adds an `invoice_payment` notification type similar to the same named hook.