### PR TITLE
Plugins: remove the 'warning' object from the 'warning' notification

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -232,12 +232,10 @@ message resolving failed...
 
 ```json
 {
-	"warning": {
 	"level": "warn",
 	"time": "1559743608.565342521",
 	"source": "lightningd(17652): 0821f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c chan #7854:",
 	"log": "Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: sent ERROR bad reestablish dataloss msg"
-  }
 }
 ```
 1. `level` is `warn` or `error`: `warn` means something seems bad happened

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -42,7 +42,6 @@ void notify_warning(struct lightningd *ld, struct log_entry *l)
 {
 	struct jsonrpc_notification *n =
 	    jsonrpc_notification_start(NULL, notification_topics[2]);
-	json_object_start(n->stream, "warning");
 	/* Choose "BROKEN"/"UNUSUAL" to keep consistent with the habit
 	 * of plugin. But this may confuses the users who want to 'getlog'
 	 * with the level indicated by notifications. It is the duty of a
@@ -56,7 +55,6 @@ void notify_warning(struct lightningd *ld, struct log_entry *l)
 	json_add_time(n->stream, "time", l->time.ts);
 	json_add_string(n->stream, "source", l->prefix);
 	json_add_string(n->stream, "log", l->log);
-	json_object_end(n->stream); /* .warning */
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }

--- a/tests/plugins/pretend_badlog.py
+++ b/tests/plugins/pretend_badlog.py
@@ -12,12 +12,12 @@ def init(configuration, options, plugin):
 
 
 @plugin.subscribe("warning")
-def notify_warning(plugin, warning):
+def notify_warning(plugin, level, time, source, log):
     plugin.log("Received warning")
-    plugin.log("level: {}".format(warning['level']))
-    plugin.log("time: {}".format(warning['time']))
-    plugin.log("source: {}".format(warning['source']))
-    plugin.log("log: {}".format(warning['log']))
+    plugin.log("level: {}".format(level))
+    plugin.log("time: {}".format(time))
+    plugin.log("source: {}".format(source))
+    plugin.log("log: {}".format(log))
 
 
 @plugin.method("pretendbad")


### PR DESCRIPTION
It's more a proposition than a merge request, but the changes were trivial so I made it a PR.

The `warning` object from the `warning` notification type seems redundant, and all other notifications types don't have a "framing" object.
It changes the API but since this type was not added long ago..

What do you think @trueptolemy ?