### PR TITLE
Plugins: standard object wrapper for hooks and notifications

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -25,13 +25,13 @@ def init(options, configuration, plugin):
 
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address):
-    plugin.log("Received connect event for peer {}".format(id))
+def on_connect(plugin, connect):
+    plugin.log("Received connect event for peer {}".format(connect.get("id")))
 
 
 @plugin.subscribe("disconnect")
-def on_disconnect(plugin, id):
-    plugin.log("Received disconnect event for peer {}".format(id))
+def on_disconnect(plugin, disconnect):
+    plugin.log("Received disconnect event for peer {}".format(disconnect.get("id")))
 
 
 @plugin.subscribe("invoice_payment")
@@ -43,7 +43,7 @@ def on_payment(plugin, invoice_payment):
 
 
 @plugin.hook("htlc_accepted")
-def on_htlc_accepted(onion, htlc, plugin):
+def on_htlc_accepted(htlc_accepted, plugin):
     plugin.log('on_htlc_accepted called')
     time.sleep(20)
     return {'result': 'continue'}

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -237,8 +237,10 @@ to a peer is established.
 
 ```json
 {
-	"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
-	"address": "1.2.3.4"
+	"connect": {
+		"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
+		"address": "1.2.3.4"
+	}
 }
 ```
 
@@ -249,7 +251,9 @@ to a peer was lost.
 
 ```json
 {
-	"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+	"disconnect": {
+		"id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+	}
 }
 ```
 
@@ -277,11 +281,11 @@ message resolving failed...
 ```json
 {
 	"warning": {
-	"level": "warn",
-	"time": "1559743608.565342521",
-	"source": "lightningd(17652): 0821f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c chan #7854:",
-	"log": "Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: sent ERROR bad reestablish dataloss msg"
-  }
+		"level": "warn",
+		"time": "1559743608.565342521",
+		"source": "lightningd(17652): 0821f80652fb840239df8dc99205792bba2e559a05469915804c08420230e23c7c chan #7854:",
+		"log": "Peer permanent failure in CHANNELD_NORMAL: lightning_channeld: sent ERROR bad reestablish dataloss msg"
+	}
 }
 ```
 1. `level` is `warn` or `error`: `warn` means something seems bad happened
@@ -330,12 +334,12 @@ the cryptographic handshake. The parameters have the following structure if ther
 
 ```json
 {
-  "peer": {
-	"id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-	"addr": "34.239.230.56:9735",
-	"globalfeatures": "",
-	"localfeatures": ""
-  }
+	"peer_connected": {
+		"id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+		"addr": "34.239.230.56:9735",
+		"globalfeatures": "",
+		"localfeatures": ""
+	}
 }
 ```
 
@@ -365,7 +369,9 @@ It is currently extremely restricted:
 
 ```json
 {
-  "writes": [ "PRAGMA foreign_keys = ON" ]
+	"db_write": {
+		"writes": [ "PRAGMA foreign_keys = ON" ]
+	}
 }
 ```
 
@@ -400,19 +406,19 @@ and it has passed basic sanity checks:
 
 ```json
 {
-  "openchannel": {
-	"id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
-	"funding_satoshis": "100000000msat",
-	"push_msat": "0msat",
-	"dust_limit_satoshis": "546000msat",
-	"max_htlc_value_in_flight_msat": "18446744073709551615msat",
-	"channel_reserve_satoshis": "1000000msat",
-	"htlc_minimum_msat": "0msat",
-	"feerate_per_kw": 7500,
-	"to_self_delay": 5,
-	"max_accepted_htlcs": 483,
-	"channel_flags": 1
-  }
+	"openchannel": {
+		"id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+		"funding_satoshis": "100000000msat",
+		"push_msat": "0msat",
+		"dust_limit_satoshis": "546000msat",
+		"max_htlc_value_in_flight_msat": "18446744073709551615msat",
+		"channel_reserve_satoshis": "1000000msat",
+		"htlc_minimum_msat": "0msat",
+		"feerate_per_kw": 7500,
+		"to_self_delay": 5,
+		"max_accepted_htlcs": 483,
+		"channel_flags": 1
+	}
 }
 ```
 
@@ -433,23 +439,25 @@ The payload of the hook call has the following format:
 
 ```json
 {
-  "onion": {
-    "payload": "",
-    "per_hop_v0": {
-      "realm": "00",
-      "short_channel_id": "1x2x3",
-      "forward_amount": "42msat",
-      "outgoing_cltv_value": 500014
-    }
-  },
-  "next_onion": "[1365bytes of serialized onion]",
-  "shared_secret": "0000000000000000000000000000000000000000000000000000000000000000",
-  "htlc": {
-    "amount": "43msat",
-    "cltv_expiry": 500028,
-    "cltv_expiry_relative": 10,
-    "payment_hash": "0000000000000000000000000000000000000000000000000000000000000000"
-  }
+	"htlc_accepted": {
+		"onion": {
+			"payload": "",
+			"per_hop_v0": {
+				"realm": "00",
+				"short_channel_id": "1x2x3",
+				"forward_amount": "42msat",
+				"outgoing_cltv_value": 500014
+			}
+		},
+		"next_onion": "[1365bytes of serialized onion]",
+		"shared_secret": "0000000000000000000000000000000000000000000000000000000000000000",
+		"htlc": {
+			"amount": "43msat",
+			"cltv_expiry": 500028,
+			"cltv_expiry_relative": 10,
+			"payment_hash": "0000000000000000000000000000000000000000000000000000000000000000"
+		}
+	}
 }
 ```
 
@@ -492,7 +500,7 @@ The hook response must have one of the following formats:
 
 ```json
 {
-  "result": "continue"
+	"result": "continue"
 }
 ```
 
@@ -503,8 +511,8 @@ usual checks such as sufficient fees and CLTV deltas are still enforced.
 
 ```json
 {
-  "result": "fail",
-  "failure_code": 4301
+	"result": "fail",
+	"failure_code": 4301
 }
 ```
 
@@ -513,8 +521,8 @@ usual checks such as sufficient fees and CLTV deltas are still enforced.
 
 ```json
 {
-  "result": "resolve",
-  "payment_key": "0000000000000000000000000000000000000000000000000000000000000000"
+	"result": "resolve",
+	"payment_key": "0000000000000000000000000000000000000000000000000000000000000000"
 }
 ```
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -118,14 +118,14 @@ static void
 invoice_payment_serialize(struct invoice_payment_hook_payload *payload,
 			  struct json_stream *stream)
 {
-	json_object_start(stream, "payment");
+	json_object_start(stream, "invoice_payment");
 	json_add_escaped_string(stream, "label", payload->label);
 	json_add_hex(stream, "preimage",
 		     &payload->preimage, sizeof(payload->preimage));
 	json_add_string(stream, "msat",
 			type_to_string(tmpctx, struct amount_msat,
 				       &payload->msat));
-	json_object_end(stream); /* .payment */
+	json_object_end(stream); /* .invoice_payment */
 }
 
 /* Peer dies?  Remove hin ptr from payload so we know to ignore plugin return */

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -23,8 +23,10 @@ void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 {
 	struct jsonrpc_notification *n =
 	    jsonrpc_notification_start(NULL, "connect");
+	json_object_start(n->stream, "connect");
 	json_add_node_id(n->stream, "id", nodeid);
 	json_add_address_internal(n->stream, "address", addr);
+	json_object_end(n->stream);
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }
@@ -33,7 +35,9 @@ void notify_disconnect(struct lightningd *ld, struct node_id *nodeid)
 {
 	struct jsonrpc_notification *n =
 	    jsonrpc_notification_start(NULL, "disconnect");
+	json_object_start(n->stream, "disconnect");
 	json_add_node_id(n->stream, "id", nodeid);
+	json_object_end(n->stream);
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }
@@ -53,7 +57,7 @@ void notify_warning(struct lightningd *ld, struct log_entry *l)
 	json_add_string(n->stream, "level",
 			l->level == LOG_BROKEN ? "error"
 			: "warn");
-	/* unsuaul/broken event is rare, plugin pay more attentions on
+	/* unusual/broken event is rare, plugin pay more attentions on
 	 * the absolute time, like when channels failed. */
 	json_add_time(n->stream, "time", l->time.ts);
 	json_add_string(n->stream, "source", l->prefix);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -780,14 +780,14 @@ peer_connected_serialize(struct peer_connected_hook_payload *payload,
 			 struct json_stream *stream)
 {
 	const struct peer *p = payload->peer;
-	json_object_start(stream, "peer");
+	json_object_start(stream, "peer_connected");
 	json_add_node_id(stream, "id", &p->id);
 	json_add_string(
 	    stream, "addr",
 	    type_to_string(stream, struct wireaddr_internal, &payload->addr));
 	json_add_hex_talarr(stream, "globalfeatures", p->globalfeatures);
 	json_add_hex_talarr(stream, "localfeatures", p->localfeatures);
-	json_object_end(stream); /* .peer */
+	json_object_end(stream); /* .peer_connected */
 }
 
 static void

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -707,8 +707,9 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	const struct route_step *rs = p->route_step;
 	const struct htlc_in *hin = p->hin;
 	s32 expiry = hin->cltv_expiry, blockheight = p->ld->topology->tip->height;
-	json_object_start(s, "onion");
+	json_object_start(s, "htlc_accepted");
 
+	json_object_start(s, "onion");
 	json_add_hex_talarr (s, "payload", rs->raw_payload);
 	if (rs->hop_data.realm == 0x00) {
 		json_object_start(s, "per_hop_v0");
@@ -728,6 +729,8 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	json_add_u32(s, "cltv_expiry", expiry);
 	json_add_s32(s, "cltv_expiry_relative", expiry - blockheight);
 	json_add_hex(s, "payment_hash", hin->payment_hash.u.u8, sizeof(hin->payment_hash));
+	json_object_end(s);
+
 	json_object_end(s);
 }
 

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -169,12 +169,14 @@ void plugin_hook_db_sync(struct db *db, const char **changes, const char *final)
 	ph_req->hook = hook;
 	ph_req->db = db;
 
+	json_object_start(req->stream, "db_write");
 	json_array_start(req->stream, "writes");
 	for (size_t i = 0; i < tal_count(changes); i++)
 		json_add_string(req->stream, NULL, changes[i]);
 	if (final)
 		json_add_string(req->stream, NULL, final);
 	json_array_end(req->stream);
+	json_object_end(req->stream);
 	jsonrpc_request_end(req);
 
 	plugin_request_send(hook->plugin, req);

--- a/tests/plugins/dblog.py
+++ b/tests/plugins/dblog.py
@@ -24,7 +24,8 @@ def init(configuration, options, plugin):
 
 
 @plugin.hook('db_write')
-def db_write(plugin, writes):
+def db_write(plugin, db_write):
+    writes = db_write.get("writes")
     if not plugin.initted:
         plugin.log("deferring {} commands".format(len(writes)))
         plugin.sqlite_pre_init_cmds += writes

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -6,9 +6,9 @@ plugin = Plugin()
 
 
 @plugin.hook("htlc_accepted")
-def on_htlc_accepted(htlc, onion, plugin):
+def on_htlc_accepted(plugin, htlc_accepted):
     plugin.log("Failing htlc on purpose")
-    plugin.log("onion: %r" % (onion))
+    plugin.log("onion: %r" % (htlc_accepted.get("onion")))
     return {"result": "fail", "failure_code": 16399}
 
 

--- a/tests/plugins/hold_htlcs.py
+++ b/tests/plugins/hold_htlcs.py
@@ -17,17 +17,17 @@ plugin = Plugin()
 
 
 @plugin.hook("htlc_accepted")
-def on_htlc_accepted(htlc, onion, plugin):
+def on_htlc_accepted(htlc_accepted, plugin):
     # Stash the onion so the test can check it
     fname = os.path.join(tempfile.mkdtemp(), "onion.json")
     with open(fname, 'w') as f:
-        f.write(json.dumps(onion))
+        f.write(json.dumps(htlc_accepted.get("onion")))
 
     plugin.log("Holding onto an incoming htlc for 10 seconds")
 
     time.sleep(10)
 
-    print("Onion written to {}".format(fname))
+    plugin.log("Onion written to {}".format(fname))
 
     # Give the tester something to look for
     plugin.log("htlc_accepted hook called")

--- a/tests/plugins/hold_invoice.py
+++ b/tests/plugins/hold_invoice.py
@@ -9,7 +9,7 @@ plugin = Plugin()
 
 
 @plugin.hook('invoice_payment')
-def on_payment(payment, plugin):
+def on_payment(invoice_payment, plugin):
     time.sleep(float(plugin.get_option('holdtime')))
     return {}
 

--- a/tests/plugins/reject.py
+++ b/tests/plugins/reject.py
@@ -13,12 +13,12 @@ plugin = Plugin()
 
 
 @plugin.hook('peer_connected')
-def on_connected(peer, plugin):
-    if peer['id'] in plugin.reject_ids:
-        print("{} is in reject list, disconnecting".format(peer['id']))
+def on_connected(peer_connected, plugin):
+    if peer_connected['id'] in plugin.reject_ids:
+        print("{} is in reject list, disconnecting".format(peer_connected['id']))
         return {'result': 'disconnect', 'error_message': 'You are in reject list'}
 
-    print("{} is allowed".format(peer['id']))
+    print("{} is allowed".format(peer_connected['id']))
     return {'result': 'continue'}
 
 

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -10,12 +10,12 @@ plugin = Plugin()
 
 
 @plugin.hook('invoice_payment')
-def on_payment(payment, plugin):
-    print("label={}".format(payment['label']))
-    print("msat={}".format(payment['msat']))
-    print("preimage={}".format(payment['preimage']))
+def on_payment(invoice_payment, plugin):
+    print("label={}".format(invoice_payment['label']))
+    print("msat={}".format(invoice_payment['msat']))
+    print("preimage={}".format(invoice_payment['preimage']))
 
-    if payment['preimage'].endswith('0'):
+    if invoice_payment['preimage'].endswith('0'):
         # FIXME: Define this!
         WIRE_TEMPORARY_NODE_FAILURE = 0x2002
         return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}

--- a/tests/plugins/shortcircuit.py
+++ b/tests/plugins/shortcircuit.py
@@ -6,7 +6,7 @@ plugin = Plugin()
 
 
 @plugin.hook("htlc_accepted")
-def on_htlc_accepted(onion, htlc, plugin):
+def on_htlc_accepted(htlc_accepted, plugin):
     return {"result": "resolve", "payment_key": "00" * 32}
 
 


### PR DESCRIPTION
This is a follow-up to #2823 in which I wanted to remove the wrapping object. It ended up that it was actually more convenient to have one : this PR either adds or rename the top object of each notification and hook so that each one has a standard form : 
```
{
    "notification_name": {
        "a": 1,
        "b": 2
    }
}
```