### PR TITLE
Install python3-mako in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
      python \
      python-dev \
      python3 \
+     python3-mako \
      sqlite-dev \
      wget \
      git \


### PR DESCRIPTION
Fixes #2824 .

Maybe we prefer a requirements.txt instead ?