### PR TITLE
bolt-gen: use ordered-dict for fields

### DIFF
--- a/tools/generate-bolts.py
+++ b/tools/generate-bolts.py
@@ -18,6 +18,7 @@
 #   subtypedata,<subtypename>,<fieldname>,<typename>,[<count>]
 
 from argparse import ArgumentParser, REMAINDER
+from collections import OrderedDict
 import copy
 import fileinput
 from mako.template import Template
@@ -98,7 +99,7 @@ class Field(object):
 
 class FieldSet(object):
     def __init__(self):
-        self.fields = {}
+        self.fields = OrderedDict()
         self.optional_fields = False
         self.len_fields = {}
 


### PR DESCRIPTION
Use ordered dict for fields, whose order matters when iterated
through (especially for argument lists).  see #2830 

Reported-By: @mocacinno