### PR TITLE
plugins: don't crash if getmanifest times out.

### DIFF
--- a/lightningd/io_loop_with_timers.c
+++ b/lightningd/io_loop_with_timers.c
@@ -26,9 +26,12 @@ void *io_loop_with_timers(struct lightningd *ld)
 		/*~ Notice that timers are called here in the event loop like
 		 * anything else, so there are no weird concurrency issues. */
 		if (expired) {
-			db_begin_transaction(ld->wallet->db);
+			/* This routine is legal in early startup, too. */
+			if (ld->wallet)
+				db_begin_transaction(ld->wallet->db);
 			timer_expired(ld, expired);
-			db_commit_transaction(ld->wallet->db);
+			if (ld->wallet)
+				db_commit_transaction(ld->wallet->db);
 		}
 	}
 


### PR DESCRIPTION
I mean, we still crash, but we give an error now :)

lightningd: FATAL SIGNAL 11 (version v0.7.1-82-g92c38a0)
0x5592e75e19c8 send_backtrace
	common/daemon.c:40
0x5592e75e1a6e crashdump
	common/daemon.c:53
0x7fad1514ef5f ???
	???:0
0x5592e75b2f3a io_loop_with_timers
	lightningd/io_loop_with_timers.c:29
0x5592e75d8a54 plugins_init
	lightningd/plugin.c:1018
0x5592e75b8e22 main
	lightningd/lightningd.c:671
0x7fad15131b6a ???
	???:0
0x5592e75a10f9 ???
	???:0
0xffffffffffffffff ???
	???:0
Segmentation fault (core dumped)

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>