### PR TITLE
plugins: log PID of starting plugins, and some other small fixes

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -508,7 +508,7 @@ static void dev_register_opts(struct lightningd *ld)
 {
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
 			   &ld->reconnect,
-			   "Disable automatic reconnect attempts");
+			   "Disable automatic reconnect-attempts by this node, but accept incoming");
 	opt_register_noarg("--dev-fail-on-subdaemon-fail", opt_set_bool,
 			   &ld->dev_subdaemon_fail, opt_hidden);
 	opt_register_early_arg("--dev-debugger=<subprocess>", opt_subprocess_debug, NULL,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -989,6 +989,8 @@ void plugins_init(struct plugins *plugins, const char *dev_plugin_debug)
 		if (p->pid == -1)
 			fatal("error starting plugin '%s': %s", p->cmd,
 			      strerror(errno));
+		else
+			log_debug(plugins->log, "started(%u) %s", p->pid, p->cmd);
 		p->buffer = tal_arr(p, char, 64);
 		p->stop = false;
 


### PR DESCRIPTION
A few things I had in my TODO list:

~openingd: Fix the _fall through_ in `handle_peer_in` switch. It now errs when receiving msg type that is a protocol violation, which happens in `test_fee_limits`. So fixed that too and, while at it, also solved a FIXUP.~

~openingd: in  `handle_peer_in`, tidy up  the switch statement. Now easier to follow and more redundant.~

**EDIT2**: Dropped the above

pytest: solved a FIXUP in `test_fee_limits` 

Improve the description of `dev-no-reconnect`, it took me a while to figure out its behavior.

Log PID's of plugins, I needed this for the dbbackup plugin, but maybe it is also useful for debugging