### PR TITLE
Plugins: 'channel_opened' notification type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - build: now requires `python3-mako` to be installed, i.e. `sudo apt-get install python3-mako`
 - plugins: a new notification type `invoice_payment` (sent when an invoice is paid) has been added
+- plugins: a new 'channel_opened' notification type is added, which is emitted when a peer succesfully funds a channel to us
 
 ### Deprecated
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -200,6 +200,23 @@ corresponding payloads are listed below.
 
 ### Notification Types
 
+#### `channel_opened`
+
+A notification for topic `channel_opened` is sent if a peer successfully funded a channel
+with us. It contains the peer id, the funding amount (in millisatoshis), the funding
+transaction id, and a boolean indicating if the funding transaction has been included
+into a block.
+```
+{
+	"channel_opened": {
+		"id": "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+		"funding_satoshis": "100000000msat",
+		"funding_txid": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+		"funding_locked": false
+	}
+}
+```
+
 #### `connect`
 
 A notification for topic `connect` is sent every time a new connection
@@ -237,7 +254,6 @@ A notification for topic `invoice_payment` is sent every time an invoie is paid.
 }
 ```
 
-
 #### `warning`
 
 A notification for topic `warning` is sent every time a new `BROKEN`
@@ -265,6 +281,7 @@ forms:
 `plugin-<plugin_name>:`, `<daemon_name>(<daemon_pid>):`, `jsonrpc:`,
 `jcon fd <error_fd_to_jsonrpc>:`, `plugin-manager`;
 4. `log` is the context of the original log entry.
+
 
 ## Hooks
 

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -21,7 +21,7 @@ void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 		    struct wireaddr_internal *addr)
 {
 	struct jsonrpc_notification *n =
-	    jsonrpc_notification_start(NULL, notification_topics[0]);
+	    jsonrpc_notification_start(NULL, "connect");
 	json_add_node_id(n->stream, "id", nodeid);
 	json_add_address_internal(n->stream, "address", addr);
 	jsonrpc_notification_end(n);
@@ -31,7 +31,7 @@ void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 void notify_disconnect(struct lightningd *ld, struct node_id *nodeid)
 {
 	struct jsonrpc_notification *n =
-	    jsonrpc_notification_start(NULL, notification_topics[1]);
+	    jsonrpc_notification_start(NULL, "disconnect");
 	json_add_node_id(n->stream, "id", nodeid);
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
@@ -42,7 +42,7 @@ void notify_disconnect(struct lightningd *ld, struct node_id *nodeid)
 void notify_warning(struct lightningd *ld, struct log_entry *l)
 {
 	struct jsonrpc_notification *n =
-	    jsonrpc_notification_start(NULL, notification_topics[2]);
+	    jsonrpc_notification_start(NULL, "warning");
 	json_object_start(n->stream, "warning");
 	/* Choose "BROKEN"/"UNUSUAL" to keep consistent with the habit
 	 * of plugin. But this may confuses the users who want to 'getlog'
@@ -66,8 +66,8 @@ void notify_invoice_payment(struct lightningd *ld, struct amount_msat amount,
 			    struct preimage preimage, const struct json_escape *label)
 {
 	struct jsonrpc_notification *n =
-		jsonrpc_notification_start(NULL, notification_topics[3]);
-	json_object_start(n->stream, notification_topics[3]);
+		jsonrpc_notification_start(NULL, "invoice_payment");
+	json_object_start(n->stream, "invoice_payment");
 	json_add_string(n->stream, "msat",
 			type_to_string(tmpctx, struct amount_msat, &amount));
 	json_add_hex(n->stream, "preimage", &preimage, sizeof(preimage));

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -1,8 +1,11 @@
 #ifndef LIGHTNING_LIGHTNINGD_NOTIFICATION_H
 #define LIGHTNING_LIGHTNINGD_NOTIFICATION_H
 #include "config.h"
+#include <bitcoin/short_channel_id.h>
+#include <bitcoin/tx.h>
 #include <ccan/json_escape/json_escape.h>
 #include <common/amount.h>
+#include <common/node_id.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
@@ -18,5 +21,9 @@ void notify_warning(struct lightningd *ld, struct log_entry *l);
 
 void notify_invoice_payment(struct lightningd *ld, struct amount_msat amount,
 			    struct preimage preimage, const struct json_escape *label);
+
+void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
+			   struct amount_sat *funding_sat, struct bitcoin_txid *funding_txid,
+			   bool *funding_locked);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -659,6 +659,10 @@ static void opening_fundee_finished(struct subd *openingd,
 
 	channel_watch_funding(ld, channel);
 
+	/* Tell plugins about the success */
+	notify_channel_opened(ld, &channel->peer->id, &channel->funding,
+			   &channel->funding_txid, &channel->remote_funding_locked);
+
 	/* On to normal operation! */
 	peer_start_channeld(channel, pps, funding_signed, false);
 

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Plugin to be used to test miscellaneous notifications.
+
+Only used for 'channel_opened' for now.
+"""
+
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.init()
+def init(plugin, options, configuration):
+    plugin.log("misc_notifications initialized")
+
+
+@plugin.subscribe("channel_opened")
+def channel_opened(plugin, channel_opened):
+    plugin.log("A channel was opened to us by {}, with an amount"
+               " of {} and the following funding transaction id: {}"
+               .format(channel_opened["id"], channel_opened["amount"],
+                       channel_opened["funding_txid"]))
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -494,3 +494,16 @@ def test_invoice_payment_notification(node_factory):
     l2.daemon.wait_for_log(r"Received invoice_payment event for label {},"
                            " preimage {}, and amount of {}msat"
                            .format(label, preimage, msats))
+
+
+def test_channel_opened_notification(node_factory):
+    """
+    Test the 'channel_opened' notification sent at channel funding success.
+    """
+    opts = [{}, {"plugin": "tests/plugins/misc_notifications.py"}]
+    amount = 10**6
+    l1, l2 = node_factory.line_graph(2, fundchannel=True, fundamount=amount,
+                                     opts=opts)
+    l2.daemon.wait_for_log(r"A channel was opened to us by {}, "
+                           "with an amount of {}*"
+                           .format(l1.info["id"], amount))


### PR DESCRIPTION
This adds a new notification type : `channelopened`.

This notification is emitted if a peer successfully opened a channel to us, and sends the id of the peer, the funding amount, and the feerate.