### PR TITLE
tools: fix 32 bit compile error

### DIFF
--- a/devtools/print_wire.c
+++ b/devtools/print_wire.c
@@ -198,7 +198,7 @@ void printwire_tlvs(const char *fieldname, const u8 **cursor, size_t *plen,
 			printf("}\n");
 			*plen -= length;
 		} else
-			printf("**TYPE #%ld UNKNOWN for TLV %s**\n", type, fieldname);
+			printf("**TYPE #%"PRIu64" UNKNOWN for TLV %s**\n", type, fieldname);
 	}
 	return;
 

--- a/tools/test/enum.c
+++ b/tools/test/enum.c
@@ -8,7 +8,7 @@ void towire_test_enum(u8 **pptr, const enum test_enum test_enum)
 
 enum test_enum fromwire_test_enum(const u8 **cursor, size_t *max)
 {
-	printf("fromwire_test_enum at %ld\n", *max);
+	printf("fromwire_test_enum at %zu\n", *max);
 	return TEST_ONE;
 }
 


### PR DESCRIPTION
```
tools/test/enum.c: In function ‘fromwire_test_enum’:
tools/test/enum.c:11:34: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘size_t {aka unsigned int}’ [-Werror=format=]
  printf("fromwire_test_enum at %ld\n", *max);
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>