### PR TITLE
RPC: Return output idx for a funding tx in a channel information in listfunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Lightningd: add support for `signet` networks using the `--network=signet` or `--signet` startup option
+- JSON API: `listfunds` now returns also `funding_output` for `channels`
 
 ### Changed
 

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listfunds
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/09/2019
+.\"      Date: 07/25/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTFUNDS" "7" "05/09/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTFUNDS" "7" "07/25/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -60,7 +60,8 @@ Each entry in \fIoutputs\fR will include:
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIoutput\fR (the index of the output in the transaction)
+\fIoutput\fR
+(the index of the output in the transaction)
 .RE
 .sp
 .RS 4
@@ -71,21 +72,21 @@ Each entry in \fIoutputs\fR will include:
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIvalue\fR (the output value in satoshis)
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.sp -1
-.IP \(bu 2.3
-.\}
-\fIamount_sat\fR
-(the same as
 \fIvalue\fR
-, but in millisatoshis with
+(the output value in satoshis)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIamount_msat\fR
+(the same as
+\fIvalue\fR, but in millisatoshi with
 \fImsat\fR
 appended)
 .RE
@@ -109,7 +110,11 @@ appended)
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIstatus\fR (whether \fIunconfirmed\fR, \fIconfirmed\fR, or \fIspent\fR)
+\fIstatus\fR
+(whether
+\fIunconfirmed\fR,
+\fIconfirmed\fR, or
+\fIspent\fR)
 .RE
 .sp
 Each entry in \fIchannels\fR will include:
@@ -200,6 +205,18 @@ appended\&.
 .\}
 \fIfunding_txid\fR
 \- funding transaction id\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIfunding_output\fR
+\- the index of the output in the funding transaction\&.
 .RE
 .SH "AUTHOR"
 .sp

--- a/doc/lightning-listfunds.7.txt
+++ b/doc/lightning-listfunds.7.txt
@@ -55,6 +55,8 @@ number and output index of the channel funding transaction).
 
 - 'funding_txid' - funding transaction id.
 
+- 'funding_output' - the index of the output in the funding transaction.
+
 AUTHOR
 ------
 Felix <fixone@gmail.com> is mainly responsible.

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -657,6 +657,8 @@ static struct command_result *json_listfunds(struct command *cmd,
 						   "amount_msat");
 			json_add_txid(response, "funding_txid",
 				      &c->funding_txid);
+			json_add_num(response, "funding_output",
+				      c->funding_outnum);
 			json_object_end(response);
 		}
 	}


### PR DESCRIPTION
I am [working on a plug-in](https://github.com/kristapsk/lightning-feereport) that emulates `lncli feereport` command of LND for c-lightning. It needs to return `chan_point` for each channel, so I need not only channel funding txid, but also output index. This information is present anyways, why not to return, and, besides, it is already returned for onchain UTXOs.