### PR TITLE
Handle relative paths for lightningd startup options

### DIFF
--- a/common/configdir.c
+++ b/common/configdir.c
@@ -3,12 +3,21 @@
 #include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
 #include <errno.h>
+#include <lightningd/lightningd.h>
+
 
 /* Override a tal string; frees the old one. */
 char *opt_set_talstr(const char *arg, char **p)
 {
 	tal_free(*p);
 	return opt_set_charp(tal_strdup(NULL, arg), p);
+}
+
+char *opt_set_path_talstr(const char *arg, char **p)
+{
+	if (arg[0] != '/')
+		arg = path_join(tmpctx, path_cwd(tmpctx), arg);
+	return opt_set_talstr(arg, p);
 }
 
 char *default_configdir(const tal_t *ctx)

--- a/common/configdir.h
+++ b/common/configdir.h
@@ -6,6 +6,9 @@
 /* Helper for options which are tal() strings. */
 char *opt_set_talstr(const char *arg, char **p);
 
+/* Helper for options which are tal() strings and a path. */
+char *opt_set_path_talstr(const char *arg, char **p);
+
 /* The default configuration dir: ~/.lightning */
 char *default_configdir(const tal_t *ctx);
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -298,6 +298,8 @@ static char *opt_add_proxy_addr(const char *arg, struct lightningd *ld)
 
 static char *opt_add_plugin(const char *arg, struct lightningd *ld)
 {
+	if (arg[0] != '/')
+		arg = path_join(tmpctx, path_cwd(tmpctx), arg);
 	plugin_register(ld->plugins, arg);
 	return NULL;
 }
@@ -311,6 +313,8 @@ static char *opt_disable_plugin(const char *arg, struct lightningd *ld)
 
 static char *opt_add_plugin_dir(const char *arg, struct lightningd *ld)
 {
+	if (arg[0] != '/')
+		arg = path_join(tmpctx, path_cwd(tmpctx), arg);
 	return add_plugin_dir(ld->plugins, arg, false);
 }
 
@@ -814,7 +818,7 @@ static void register_opts(struct lightningd *ld)
 
 	opt_register_arg("--bitcoin-cli", opt_set_talstr, NULL,
 			 &ld->topology->bitcoind->cli,
-			 "bitcoin-cli pathname");
+			 "bitcoin-cli absolute pathname");
 	opt_register_arg("--bitcoin-rpcuser", opt_set_talstr, NULL,
 			 &ld->topology->bitcoind->rpcuser,
 			 "bitcoind RPC username");
@@ -833,7 +837,7 @@ static void register_opts(struct lightningd *ld)
 			 "how long to keep trying to contact bitcoind "
 			 "before fatally exiting");
 
-	opt_register_arg("--pid-file=<file>", opt_set_talstr, opt_show_charp,
+	opt_register_arg("--pid-file=<file>", opt_set_path_talstr, opt_show_charp,
 			 &ld->pidfile,
 			 "Specify pid file");
 


### PR DESCRIPTION
This joins the current working directory to the options argument if the option argument needs to be a path and if the provided argument is not an absolute path.