### PR TITLE
wire gen fixups

### DIFF
--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -46,14 +46,16 @@ towire_${f.type_obj.name}(${ptr}, ${f.name});
 towire_${f.type_obj.name}(${ptr}, ${'' if f.type_obj.is_assignable() else '&'}${fieldname});
 % endif
 </%def>
-## Subtype and TLV-msg fromwire_
+## Subtype and TLV-msg fromwire
 <%def name="fromwire_subtype_field(fieldname, f, ctx)">\
 <%
     type_ = f.type_obj.name
     typename = f.type_obj.type_name()
+    if f.type_obj.is_varsize():
+	typename += ' *'
 %>\
 % if f.is_varlen():
-${'*' if f.type_obj.is_varsize() else ''}${fieldname} = ${f.len_field} ? tal_arr(${ctx}, ${typename}, ${f.len_field}) : NULL;
+${fieldname} = ${f.len_field} ? tal_arr(${ctx}, ${typename}, ${f.len_field}) : NULL;
 % endif
 % if f.is_array() or f.is_varlen():
     % if f.type_obj.has_array_helper():

--- a/wire/tlvstream.c
+++ b/wire/tlvstream.c
@@ -143,6 +143,9 @@ void towire_tlvs(u8 **pptr,
 		 size_t num_types,
 		 const void *record)
 {
+	if (!record)
+		return;
+
 	for (size_t i = 0; i < num_types; i++) {
 		u8 *val;
 		if (i != 0)


### PR DESCRIPTION
- Small fix for the way 'variable-length, variable-sized' subtype objects are allocated. Discovered while working on wire-tests for the dual-funding proposal that nests witness_elements into witness_stacks.

- Allow `towire_`'s to pass NULL in for the TLV field, if they want to.
