### PR TITLE
Added possibility to configure max_concurrent_htlcs value 

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -367,6 +367,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	enum side sender = htlc_state_owner(state), recipient = !sender;
 	const struct htlc **committed, **adding, **removing;
 	const struct channel_view *view;
+	u32 min_concurrent_htlcs;
 
 	htlc = tal(tmpctx, struct htlc);
 
@@ -443,8 +444,16 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	 *     HTLCs to its local commitment transaction...
 	 *     - SHOULD fail the channel.
 	 */
+	/* Also we should not add more htlc's than sender or recipient
+	 * configured.  This mitigates attacks in which a peer can force the
+	 * funder of the channel to pay unnecessary onchain fees during a fee
+	 * spike with large commitment transactions.
+	 */
+	min_concurrent_htlcs = channel->config[recipient].max_accepted_htlcs;
+	if (min_concurrent_htlcs > channel->config[sender].max_accepted_htlcs)
+		min_concurrent_htlcs = channel->config[sender].max_accepted_htlcs;
 	if (tal_count(committed) - tal_count(removing) + tal_count(adding)
-	    > channel->config[recipient].max_accepted_htlcs) {
+	    > min_concurrent_htlcs) {
 		return CHANNEL_ERR_TOO_MANY_HTLCS;
 	}
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 08/04/2019
+.\"      Date: 08/09/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "08/04/2019" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "08/09/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -255,6 +255,11 @@ Limits on what onchain fee range we\(cqll allow when a node opens a channel with
 \fIestimatesmartfee 2\fR\&. If they\(cqre outside this range, we abort their opening attempt\&. Note that
 \fBcommit\-fee\-max\fR
 can (should!) be greater than 100\&.
+.RE
+.PP
+\fBmax\-concurrent\-htlcs\fR=\fIINTEGER\fR
+.RS 4
+Number of HTLCs one channel can handle concurrently in each direction\&. Should be between 1 and 483 (default 30)\&.
 .RE
 .PP
 \fBcltv\-delta\fR=\fIBLOCKS\fR

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -205,6 +205,10 @@ Lightning channel and HTLC options
     they're outside this range, we abort their opening attempt.  Note
     that *commit-fee-max* can (should!) be greater than 100.
 
+*max-concurrent-htlcs*='INTEGER'::
+    Number of HTLCs one channel can handle concurrently in each direction.
+    Should be between 1 and 483 (default 30).
+
 *cltv-delta*='BLOCKS'::
     The number of blocks between incoming payments and outgoing payments:
     this needs to be enough to make sure that if we have to, we can close

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -42,6 +42,9 @@ struct config {
 	u32 fee_base;
 	u32 fee_per_satoshi;
 
+	/* htlcs per channel */
+	u32 max_concurrent_htlcs;
+
 	/* How long between changing commit and sending COMMIT message. */
 	u32 commit_time_ms;
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -835,13 +835,7 @@ static void channel_config(struct lightningd *ld,
 	 */
 	 ours->to_self_delay = ld->config.locktime_blocks;
 
-	 /* BOLT #2:
-	  *
-	  * The receiving node MUST fail the channel if:
-	  *...
-	  *   - `max_accepted_htlcs` is greater than 483.
-	  */
-	 ours->max_accepted_htlcs = 483;
+	 ours->max_accepted_htlcs = ld->config.max_concurrent_htlcs;
 
 	 /* This is filled in by lightning_openingd, for consistency. */
 	 ours->channel_reserve = AMOUNT_SAT(UINT64_MAX);


### PR DESCRIPTION
Eclair has a default value of 30 and I thought why not going with their value and while doing so make it configureable.

@cdecker suggested to call the option  `max_concurrent_htlcs` instead of the name in the BOLTs `max_concurrent_htlcs`

Here is the relevant line in eclair:

https://github.com/ACINQ/eclair/blob/9afb26e09c69dd5d6a14732baf5dcdf2b7a9142b/eclair-core/src/main/resources/reference.conf#L62
