### PR TITLE
Add optional start_time and end_time filtering parameters to listforwards

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -128,6 +128,17 @@ bool json_to_bool(const char *buffer, const jsmntok_t *tok, bool *b)
 	return false;
 }
 
+bool json_to_timeabs(const char *buffer, const jsmntok_t *tok, struct timeabs *t)
+{
+	uint64_t u64;
+
+	if (!json_to_u64(buffer, tok, &u64))
+		return false;
+	*t = timeval_to_timeabs(timerel_to_timeval(time_from_sec(u64)));
+
+	return true;
+}
+
 u8 *json_tok_bin_from_hex(const tal_t *ctx, const char *buffer, const jsmntok_t *tok)
 {
 	u8 *result;

--- a/common/json.h
+++ b/common/json.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <bitcoin/preimage.h>
 #include <ccan/tal/tal.h>
+#include <ccan/time/time.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -44,6 +45,9 @@ bool json_to_int(const char *buffer, const jsmntok_t *tok, int *num);
 
 /* Extract boolean from this */
 bool json_to_bool(const char *buffer, const jsmntok_t *tok, bool *b);
+
+/* Extract timestamp from this */
+bool json_to_timeabs(const char *buffer, const jsmntok_t *tok, struct timeabs *t);
 
 /* Is this a number? [0..9]+ */
 bool json_tok_is_num(const char *buffer, const jsmntok_t *tok);

--- a/common/json_tok.c
+++ b/common/json_tok.c
@@ -187,3 +187,16 @@ struct command_result *param_sat(struct command *cmd, const char *name,
 			    name, tok->end - tok->start, buffer + tok->start);
 }
 
+struct command_result *param_timestamp(struct command *cmd, const char *name,
+				 const char *buffer, const jsmntok_t *tok,
+				 struct timeabs **t)
+{
+	*t = tal(cmd, struct timeabs);
+	if (json_to_timeabs(buffer, tok, *t))
+		return NULL;
+
+	return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				"'%s' should be an UNIX timestamp, not '%.*s'",
+				name, tok->end - tok->start, buffer + tok->start);
+}
+

--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -3,6 +3,7 @@
 #define LIGHTNING_COMMON_JSON_TOK_H
 #include "config.h"
 #include <ccan/short_types/short_types.h>
+#include <ccan/time/time.h>
 #include <common/json.h>
 
 struct amount_msat;
@@ -73,6 +74,11 @@ struct command_result *param_msat(struct command *cmd, const char *name,
 struct command_result *param_sat(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t *tok,
 				 struct amount_sat **sat);
+
+/* Extract UNIX timestamp from this string */
+struct command_result *param_timestamp(struct command *cmd, const char *name,
+				 const char *buffer, const jsmntok_t *tok,
+				 struct timeabs **t);
 
 /*
  * Set the address of @out to @tok.  Used as a callback by handlers that

--- a/doc/lightning-listforwards.7
+++ b/doc/lightning-listforwards.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listforwards
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/15/2019
+.\"      Date: 07/27/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTFORWA" "7" "07/15/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTFORWA" "7" "07/27/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,10 +31,12 @@
 lightning-listforwards \- Command showing all htlcs and their information\&.
 .SH "SYNOPSIS"
 .sp
-\fBlistforwards\fR
+\fBlistforwards\fR [\fIstart_time\fR] [\fIend_time\fR]
 .SH "DESCRIPTION"
 .sp
 The \fBlistforwards\fR RPC command displays all htlcs that have been attempted to be forwarded by the c\-lightning node\&.
+.sp
+Optional \fIstart_time\fR (defaults to 0) and \fIend_time\fR (defaults to now) parameters can be used to return only htlcs with \fIreceived_time\fR between \fIstart_time\fR and \fIend_time\fR, format is UNIX timestamp\&.
 .SH "RETURN VALUE"
 .sp
 On success one array will be returned: \fIforwards\fR with htlcs that have been processed

--- a/doc/lightning-listforwards.7.txt
+++ b/doc/lightning-listforwards.7.txt
@@ -8,11 +8,15 @@ lightning-listforwards - Command showing all htlcs and their information.
 
 SYNOPSIS
 --------
-*listforwards* 
+*listforwards* ['start_time'] ['end_time']
 
 DESCRIPTION
 -----------
 The *listforwards* RPC command displays all htlcs that have been attempted to be forwarded by the c-lightning node.
+
+Optional 'start_time' (defaults to 0) and 'end_time' (defaults to now)
+parameters can be used to return only htlcs with 'received_time' between
+'start_time' and 'end_time', format is UNIX timestamp.
 
 RETURN VALUE
 ------------

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -399,6 +399,11 @@ struct command_result *param_bool(struct command *cmd UNNEEDED, const char *name
 				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				  bool **b UNNEEDED)
 { fprintf(stderr, "param_bool called!\n"); abort(); }
+/* Generated stub for param_timestamp */
+struct command_result *param_timestamp(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				  struct timeabs **t UNNEEDED)
+{ fprintf(stderr, "param_timestamp called!\n"); abort(); }
 /* Generated stub for param_loglevel */
 struct command_result *param_loglevel(struct command *cmd UNNEEDED,
 				      const char *name UNNEEDED,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1115,7 +1115,9 @@ struct amount_msat wallet_total_forward_fees(struct wallet *w);
  * Retrieve a list of all forwarded_payments
  */
 const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
-						       const tal_t *ctx);
+						       const tal_t *ctx,
+						       struct timeabs* start_time,
+						       struct timeabs* end_time);
 
 /**
  * Load remote_ann_node_sig and remote_ann_bitcoin_sig


### PR DESCRIPTION
It's useful especially in case of a lot of forwarding happening through node. In my [feereport plugin](https://github.com/kristapsk/lightning-feereport) I'm only interested in last 30 days of forwards, not whole history.

Also adds generic support for time parameters. Currently accepts integer timestamps, but can be modified to support decimals and even human readable time strings in the future.

Couldn't get `tools/update-mocks.sh` working, modified `wallet/test/run-wallet.c` by hand.

Tested with my mainnet node.