### PR TITLE
FreeBSD: fix build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ coverage: coverage/coverage.info
 # We make libwallycore.la a dependency, so that it gets built normally, without ncc.
 # Ncc can't handle the libwally source code (yet).
 ncc: external/libwally-core/src/libwallycore.la
-	make CC="ncc -ncgcc -ncld -ncfabs" AR=nccar LD=nccld
+	$(MAKE) CC="ncc -ncgcc -ncld -ncfabs" AR=nccar LD=nccld
 
 # Ignore test/ directories.
 TAGS: FORCE

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -135,7 +135,7 @@ OS version: FreeBSD 11.1-RELEASE or above
 Get dependencies:
 
     # pkg install -y \
-      autoconf automake git gmp asciidoc gmake libtool python python3 sqlite3 libsodium
+      autoconf automake git gmp asciidoc gmake libtool python python3 sqlite3 libsodium py36-mako bash
 
 If you don't have Bitcoin installed locally you'll need to install that
 as well:

--- a/tools/mockup.sh
+++ b/tools/mockup.sh
@@ -20,6 +20,8 @@ for SYMBOL; do
     # has notleak_ as a declaration, and then an inline).
     WHERE=$(grep -nH "^[a-zA-Z0-9_ (),]* [*]*$SYMBOL(" ./*/*.h | head -n1)
     if [ x"$WHERE" != x ]; then
+	# \n on RHS is a GNU extension, and we want to work on FreeBSD
+	# shellcheck disable=SC1004
 	STUB='\
 { fprintf(stderr, "'$SYMBOL' called!\\n"); abort(); }'
     else

--- a/tools/mockup.sh
+++ b/tools/mockup.sh
@@ -20,7 +20,8 @@ for SYMBOL; do
     # has notleak_ as a declaration, and then an inline).
     WHERE=$(grep -nH "^[a-zA-Z0-9_ (),]* [*]*$SYMBOL(" ./*/*.h | head -n1)
     if [ x"$WHERE" != x ]; then
-	STUB='\n{ fprintf(stderr, "'$SYMBOL' called!\\n"); abort(); }'
+	STUB='\
+{ fprintf(stderr, "'$SYMBOL' called!\\n"); abort(); }'
     else
 	echo "/* Could not find declaration for $SYMBOL */"
 	continue

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -31,7 +31,7 @@ tools/test/gen_test.h:
 
 tools/test/gen_test.c:
 	$(BOLT_GEN) --page impl ${@:.c=.h} test_type < tools/test/test_cases > $@
-	@tools/update-mocks.sh "$@"
+	@MAKE=$(MAKE) tools/update-mocks.sh "$@"
 
 tools/test/gen_print.h: wire/gen_onion_wire.h
 	$(BOLT_GEN) -P --page header $@ test_type < tools/test/test_cases > $@

--- a/tools/update-mocks.sh
+++ b/tools/update-mocks.sh
@@ -18,7 +18,7 @@ if [ -n "$START" ]; then
     head -n "$START" "${BASE}.old" > "$FILE"
     tail -n +"$END" "${BASE}.old" >> "$FILE"
     # Try to make binary.
-    if ! make "${FILE/%.c/}" 2> "${BASE}.err" >/dev/null; then
+    if ! $MAKE "${FILE/%.c/}" 2> "${BASE}.err" >/dev/null; then
 	tools/mockup.sh < "${BASE}.err" >> "${BASE}.stubs"
 	# If there are no link errors, maybe compile fail for other reason?
 	if ! grep -F -q 'Generated stub for' "${BASE}.stubs"; then


### PR DESCRIPTION
This makes it build for me on FreeBSD 11:
1. $(MAKE) has to passed through into update-mocks.
2. FreeBSD sed doesn't turn \n into a newline on RHS.
3. Bash and mako dependencies were missing from INSTALL.md

Fixes: #2850
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>