### PR TITLE
plugins: document and extend the ~/.lightning/plugins/ dir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - build: now requires `python3-mako` to be installed, i.e. `sudo apt-get install python3-mako`
+- plugins: if the config directory has a `plugins` subdirectory, those are loaded.
 - plugins: a new notification type `invoice_payment` (sent when an invoice is paid) has been added
 - plugins: a new 'channel_opened' notification type is added, which is emitted when a peer succesfully funds a channel to us
 - rpc: a new rpc command is added, `plugin`. It allows one to manage plugins without restarting `lightningd`.

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -2,12 +2,12 @@
 .\"     Title: lightningd-config
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 06/30/2019
+.\"      Date: 07/29/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNINGD\-CONFIG" "5" "06/30/2019" "\ \&" "\ \&"
+.TH "LIGHTNINGD\-CONFIG" "5" "07/29/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -455,7 +455,7 @@ to authenticate to the Tor control port\&.
 .RE
 .SS "Lightning Plugins"
 .sp
-lightningd(8) supports plugins, which offer additional configuration options and JSON\-RPC methods, depending on the plugin\&. Some are supplied by default (usually located in \fBlibexec/c\-lightning/plugins/\fR), but you can add your own, too\&.
+lightningd(8) supports plugins, which offer additional configuration options and JSON\-RPC methods, depending on the plugin\&. Some are supplied by default (usually located in \fBlibexec/c\-lightning/plugins/\fR)\&. If a \fBplugins\fR directory exists under \fIlightning\-dir\fR that is searched for plugins along with any immediate subdirectories)\&. You can specify additional paths too:
 .PP
 \fBplugin\fR=\fIPATH\fR
 .RS 4

--- a/doc/lightningd-config.5.txt
+++ b/doc/lightningd-config.5.txt
@@ -328,7 +328,9 @@ Lightning Plugins
 lightningd(8) supports plugins, which offer additional configuration
 options and JSON-RPC methods, depending on the plugin.  Some are
 supplied by default (usually located in
-*libexec/c-lightning/plugins/*), but you can add your own, too.
+*libexec/c-lightning/plugins/*).  If a *plugins* directory exists
+under 'lightning-dir' that is searched for plugins along with
+any immediate subdirectories).  You can specify additional paths too:
 
 *plugin*='PATH'::
     Specify a plugin to run as part of c-lightning. This can be specified

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -909,6 +909,9 @@ void plugins_add_default_dir(struct plugins *plugins, const char *default_dir)
 	DIR *d = opendir(default_dir);
 	if (d) {
 		struct dirent *di;
+
+		/* Add this directory itself, and recurse down once. */
+		add_plugin_dir(plugins, default_dir, true);
 		while ((di = readdir(d)) != NULL) {
 			if (streq(di->d_name, ".") || streq(di->d_name, ".."))
 				continue;


### PR DESCRIPTION
Load any plugins directly as well as subdirs.

@darosior What do you think?  Completely untested!