### PR TITLE
libplugin: add new 'getmanifest' field and pass configuration to init callback

### DIFF
--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -90,7 +90,7 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
 		    plugin_option("autocleaninvoice-cycle",
 				  "string",
 				  "Perform cleanup of expired invoices every"

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -65,7 +65,8 @@ static struct command_result *json_autocleaninvoice(struct command *cmd,
 					   expired_by, cycle_seconds));
 }
 
-static void init(struct plugin_conn *prpc)
+static void init(struct plugin_conn *prpc,
+		  const char *buf UNUSED, const jsmntok_t *config UNUSED)
 {
 	rpc = prpc;
 

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -473,7 +473,8 @@ static struct command_result *
 handle_getmanifest(struct command *getmanifest_cmd,
 		   const struct plugin_command *commands,
 		   size_t num_commands,
-		   const struct plugin_option *opts)
+		   const struct plugin_option *opts,
+		   const enum plugin_restartability restartability)
 {
 	struct json_out *params = json_out_new(tmpctx);
 
@@ -501,6 +502,7 @@ handle_getmanifest(struct command *getmanifest_cmd,
 		json_out_end(params, '}');
 	}
 	json_out_end(params, ']');
+	json_out_addstr(params, "dynamic", restartability == PLUGIN_RESTARTABLE ? "true" : "false");
 	json_out_end(params, '}');
 	json_out_finished(params);
 
@@ -699,6 +701,7 @@ void plugin_log(enum log_level l, const char *fmt, ...)
 
 void plugin_main(char *argv[],
 		 void (*init)(struct plugin_conn *rpc),
+		 const enum plugin_restartability restartability,
 		 const struct plugin_command *commands,
 		 size_t num_commands, ...)
 {
@@ -749,7 +752,7 @@ void plugin_main(char *argv[],
 		plugin_err("Expected getmanifest not %s", cmd->methodname);
 
 	membuf_consume(&request_conn.mb, reqlen);
-	handle_getmanifest(cmd, commands, num_commands, opts);
+	handle_getmanifest(cmd, commands, num_commands, opts, restartability);
 
 	cmd = read_json_request(tmpctx, &request_conn, &rpc_conn,
 				&params, &reqlen);

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -16,6 +16,11 @@ struct plugin_conn;
 
 extern bool deprecated_apis;
 
+enum plugin_restartability {
+	PLUGIN_STATIC,
+	PLUGIN_RESTARTABLE
+};
+
 /* Create an array of these, one for each command you support. */
 struct plugin_command {
 	const char *name;
@@ -148,6 +153,7 @@ char *charp_option(const char *arg, char **p);
 /* The main plugin runner: append with 0 or more plugin_option(), then NULL. */
 void NORETURN LAST_ARG_NULL plugin_main(char *argv[],
 					void (*init)(struct plugin_conn *rpc),
+					const enum plugin_restartability restartability,
 					const struct plugin_command *commands,
 					size_t num_commands, ...);
 #endif /* LIGHTNING_PLUGINS_LIBPLUGIN_H */

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -152,7 +152,8 @@ char *charp_option(const char *arg, char **p);
 
 /* The main plugin runner: append with 0 or more plugin_option(), then NULL. */
 void NORETURN LAST_ARG_NULL plugin_main(char *argv[],
-					void (*init)(struct plugin_conn *rpc),
+					void (*init)(struct plugin_conn *rpc,
+						     const char *buf, const jsmntok_t *),
 					const enum plugin_restartability restartability,
 					const struct plugin_command *commands,
 					size_t num_commands, ...);

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1271,7 +1271,8 @@ static struct command_result *json_listpays(struct command *cmd,
 			   take(json_out_obj(NULL, "bolt11", b11str)));
 }
 
-static void init(struct plugin_conn *rpc)
+static void init(struct plugin_conn *rpc,
+		  const char *buf UNUSED, const jsmntok_t *config UNUSED)
 {
 	const char *field;
 

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1311,5 +1311,5 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, commands, ARRAY_SIZE(commands), NULL);
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands), NULL);
 }


### PR DESCRIPTION
This adds the management of the two fields added in #2771 to libplugin and defaults the `dynamic` field to `false` for `pay` and `autoclean`.

For the `startup` field in `init` I added the configuration JSON token to the plugin's callback : so that if we add new fields they can be accessed too.