### PR TITLE
devtools: fix credit script.

### DIFF
--- a/devtools/credit
+++ b/devtools/credit
@@ -30,7 +30,7 @@ while read LINE; do
     if [ $(grep -ci -- "$NAME\|$EMAIL" /tmp/prev-authors.$$) = 0 ]; then
 	NOTES="$NOTES""NEW COMMITTER "
     fi
-    if ! grep -q -- "$NAME" /tmp/namers.$$; then
+    if ! grep -qi -- "$NAME" /tmp/namers.$$; then
 	if [ -z "$NAMER" ]; then
 	    NAMER="$NAME"
 	    NOTES="$NOTES""*NEXT NAMER* "


### PR DESCRIPTION
Lisa's git name is lower-case, whereas CHANGELOG.md uses upper case,
so it doesn't realize she's named a commit already.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>