### PR TITLE
added mako dependency to tests/requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ Flask==1.0.2
 cheroot==6.5.4
 ephemeral-port-reserve==1.1.0
 flaky==3.5.3
+mako==1.0.14
 pytest-benchmark==3.2.2
 pytest-forked==1.0.1
 pytest-xdist==1.26.0


### PR DESCRIPTION
this should partially fix #2879 

this dependency seems to be needed in `tools/generate-wire.py`