### PR TITLE
Disabled uninitialized warnings with GCC

### DIFF
--- a/ccan/ccan/tal/path/path.c
+++ b/ccan/ccan/tal/path/path.c
@@ -321,8 +321,17 @@ fail_take_to:
 			goto fail;
 	}
 
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	if (ret)
 		ret[len] = '\0';
+#pragma GCC diagnostic pop
 
 out:
 	if (taken(linkname))

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -208,8 +208,17 @@ static void billboard_update(const struct peer *peer)
 			shutdown_status = tal_fmt(tmpctx,
 						  " Shutdown messages exchanged.");
 	}
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	peer_billboard(false, "%s%s%s", funding_status,
 		       announce_status, shutdown_status);
+#pragma GCC diagnostic pop
 }
 
 static const u8 *hsm_req(const tal_t *ctx, const u8 *req TAKES)

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -152,7 +152,16 @@ static const struct htlc **include_htlcs(struct channel *channel, enum side side
 		e = channel_add_htlc(channel, sender, i, msatoshi, 500+i, &hash,
 				     dummy_routing, NULL, NULL);
 		assert(e == CHANNEL_ERR_ADD_OK);
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 		htlcs[i] = channel_get_htlc(channel, sender, i);
+#pragma GCC diagnostic pop
 	}
 	tal_free(dummy_routing);
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1076,12 +1076,21 @@ json_tok_address_scriptpubkey(const tal_t *cxt,
 
 	tal_free(addrz);
 
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	if (parsed) {
 		if (right_network)
 			return ADDRESS_PARSE_SUCCESS;
 		else
 			return ADDRESS_PARSE_WRONG_NETWORK;
 	}
+#pragma GCC diagnostic pop
 
 	return ADDRESS_PARSE_UNRECOGNIZED;
 }

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -776,7 +776,16 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	case htlc_accepted_fail:
 		log_debug(channel->log,
 			  "Failing incoming HTLC as instructed by plugin hook");
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 		fail_in_htlc(hin, failure_code, NULL, NULL);
+#pragma GCC diagnostic pop
 		break;
 	case htlc_accepted_resolve:
 		fulfill_htlc(hin, &payment_preimage);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -199,12 +199,21 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 			return command_fail(cmd, LIGHTNINGD, "Keys generation failure");
 	}
 
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	(*utx)->tx = withdraw_tx(*utx, (*utx)->wtx->utxos,
 				 (*utx)->destination, (*utx)->wtx->amount,
 				 changekey, (*utx)->wtx->change,
 				 cmd->ld->wallet->bip32_base,
 				 &(*utx)->change_outnum);
 	bitcoin_txid((*utx)->tx, &(*utx)->txid);
+#pragma GCC diagnostic pop
 
 	return NULL;
 }

--- a/wire/tlvstream.c
+++ b/wire/tlvstream.c
@@ -78,6 +78,14 @@ bool fromwire_tlvs(const u8 **cursor, size_t *max,
 		 *  - if decoded `type`s are not monotonically-increasing:
 		 *    - MUST fail to parse the `tlv_stream`.
 		 */
+#pragma GCC diagnostic push
+#if defined(__has_warning) /* Clang */
+#if __has_warning("-Wmaybe-uninitialized")
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#else /* GCC */
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 		if (!first && type <= prev_type) {
 			if (type == prev_type)
 				SUPERVERBOSE("duplicate tlv type");
@@ -85,6 +93,7 @@ bool fromwire_tlvs(const u8 **cursor, size_t *max,
 				SUPERVERBOSE("invalid ordering");
 			goto fail;
 		}
+#pragma GCC diagnostic pop
 
 		/* BOLT-EXPERIMENTAL #1:
 		 * - if `type` is known:


### PR DESCRIPTION
### Changed
- Hide some false positive warnings by #pragma directive.
- Compatible both GCC and Clang. Fixed #2881