### PR TITLE
Permuteroute

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -566,6 +566,24 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("getroute", payload)
 
+    def permuteroute(self, route, erring_index, exclude=[], fromid=None, maxhops=20):
+        """
+        Modify an existing failing {route}, with a known failing
+        channel after the {erring_index} hop.
+        {exclude} is an optional array of scid/direction to exclude.
+        If specified the route starts from {fromid} otherwise use
+        this node as source.
+        Limit the number of hops in the route to {maxhops}.
+        """
+        payload = {
+            "route": route,
+            "erring_index": erring_index,
+            "exclude": exclude,
+            "fromid": fromid,
+            "maxhops": maxhops
+        }
+        return self.call("permuteroute", payload)
+
     def help(self, command=None):
         """
         Show available commands, or just {command} if supplied.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,6 +29,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-listsendpays.7 \
 	doc/lightning-newaddr.7 \
 	doc/lightning-pay.7 \
+	doc/lightning-permuteroute.7 \
 	doc/lightning-sendpay.7 \
 	doc/lightning-setchannelfee.7 \
 	doc/lightning-txprepare.7 \

--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-getroute
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 03/01/2019
+.\"      Date: 08/01/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-GETROUTE" "7" "03/01/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-GETROUTE" "7" "08/01/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -526,7 +526,7 @@ The final \fIid\fR will be the destination \fIid\fR given in the input\&. The di
 Rusty Russell <rusty@rustcorp\&.com\&.au> is mainly responsible\&.
 .SH "SEE ALSO"
 .sp
-lightning\-pay(7), lightning\-sendpay(7)\&.
+lightning\-pay(7), lightning\-sendpay(7), lightning\-permuteroute(7)\&.
 .SH "RESOURCES"
 .sp
 Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-getroute.7.txt
+++ b/doc/lightning-getroute.7.txt
@@ -137,7 +137,7 @@ Rusty Russell <rusty@rustcorp.com.au> is mainly responsible.
 
 SEE ALSO
 --------
-lightning-pay(7), lightning-sendpay(7).
+lightning-pay(7), lightning-sendpay(7), lightning-permuteroute(7).
 
 RESOURCES
 ---------

--- a/doc/lightning-pay.7
+++ b/doc/lightning-pay.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-pay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/23/2019
+.\"      Date: 08/01/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-PAY" "7" "05/23/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-PAY" "7" "08/01/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -252,7 +252,7 @@ The \fIdata\fR field of errors will include statistics \fIgetroute_tries\fR and 
 Rusty Russell <rusty@rustcorp\&.com\&.au> is mainly responsible\&.
 .SH "SEE ALSO"
 .sp
-lightning\-listpays(7), lightning\-decodepay(7), lightning\-listinvoice(7), lightning\-delinvoice(7), lightning\-getroute(7), lightning\-invoice(7)\&.
+lightning\-listpays(7), lightning\-decodepay(7), lightning\-listinvoice(7), lightning\-delinvoice(7), lightning\-getroute(7), lightning\-permuteroute(7), lightning\-invoice(7)\&.
 .SH "RESOURCES"
 .sp
 Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-pay.7.txt
+++ b/doc/lightning-pay.7.txt
@@ -144,7 +144,8 @@ SEE ALSO
 --------
 lightning-listpays(7), lightning-decodepay(7),
 lightning-listinvoice(7), lightning-delinvoice(7),
-lightning-getroute(7), lightning-invoice(7).
+lightning-getroute(7), lightning-permuteroute(7),
+lightning-invoice(7).
 
 RESOURCES
 ---------

--- a/doc/lightning-permuteroute.7.txt
+++ b/doc/lightning-permuteroute.7.txt
@@ -1,0 +1,62 @@
+LIGHTNING-PERMUTEROUTE(7)
+=========================
+:doctype: manpage
+
+NAME
+----
+lightning-permuteroute - Command for changing a failing payment route (low-level).
+
+SYNOPSIS
+--------
+*permuteroute* 'route' 'erring_index' ['exclude'] ['fromid'] ['maxhops']
+
+DESCRIPTION
+-----------
+The *permuteroute* RPC command attempts to quickly find an alternative,
+"good enough" route for the payment, given a 'route' that is known to
+have failed.
+The 'route' is the same format returned by lightning-getroute(7) and
+accepted by lightning-sendpay(7).
+
+'erring_index' is the point at which the payment failed, and should
+be the 'erring_index' returned by lightning-sendpay(7) for channel-level
+failures or 'erring_index' minus 1 for node-level failures.
+
+'exclude' is a JSON array of short-channel-id/direction (e.g.
+[ "564334x877x1/0", "564195x1292x0/1" ]) which should be excluded from
+consideration for routing.
+The default is not to exclude any channels.
+
+'fromid' is the node to start the route from: default is this node.
+
+'maxhops' is the maximum number of channels to return; default is 20.
+
+The *permuteroute* command is intended for a quick-and-dirty attempt
+to create an alternative route.
+In particular, it is unlikely to get the best route.
+If the command fails or returns a route which costs too high, you
+should fall back on the slower lightning-getroute(7).
+
+RETURN VALUE
+------------
+
+On success, a "route" array is returned.
+Each array element contains 'id' (the node being routed through),
+'msatoshi' (the millisatoshis sent),
+'amount_msat' (the same, with 'msat' appended),
+and 'delay' (the number of blocks to timeout at this node).
+
+On failure, returns an error with code 205 (route not found).
+You should fall back to lightning-getroute(7) if so.
+
+AUTHOR
+------
+ZmnSCPxj <ZmnSCPxj@protonmail.com> is mainly responsible.
+
+SEE ALSO
+--------
+lightning-pay(7), lightning-sendpay(7), lightning-getroute(7).
+
+RESOURCES
+---------
+Main web site: https://github.com/ElementsProject/lightning

--- a/doc/lightning-sendpay.7
+++ b/doc/lightning-sendpay.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-sendpay
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/23/2019
+.\"      Date: 08/01/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-SENDPAY" "7" "02/23/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-SENDPAY" "7" "08/01/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -185,7 +185,7 @@ has the UPDATE bit set, as per BOLT #4\&.
 Rusty Russell <rusty@rustcorp\&.com\&.au> is mainly responsible\&.
 .SH "SEE ALSO"
 .sp
-lightning\-listinvoice(7), lightning\-delinvoice(7), lightning\-getroute(7), lightning\-invoice(7), lightning\-pay(7), lightning\-waitsendpay(7)\&.
+lightning\-listinvoice(7), lightning\-delinvoice(7), lightning\-getroute(7), lightning\-permuteroute(7), lightning\-invoice(7), lightning\-pay(7), lightning\-waitsendpay(7)\&.
 .SH "RESOURCES"
 .sp
 Main web site: https://github\&.com/ElementsProject/lightning

--- a/doc/lightning-sendpay.7.txt
+++ b/doc/lightning-sendpay.7.txt
@@ -101,7 +101,8 @@ Rusty Russell <rusty@rustcorp.com.au> is mainly responsible.
 SEE ALSO
 --------
 lightning-listinvoice(7), lightning-delinvoice(7),
-lightning-getroute(7), lightning-invoice(7),
+lightning-getroute(7), lightning-permuteroute(7),
+lightning-invoice(7),
 lightning-pay(7), lightning-waitsendpay(7).
 
 RESOURCES

--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -16,6 +16,7 @@ LIGHTNINGD_GOSSIP_HEADERS_WSRC := gossipd/gen_gossip_wire.h \
 	gossipd/gen_gossip_peerd_wire.h \
 	gossipd/gen_gossip_store.h			\
 	gossipd/gossip_store.h				\
+	gossipd/permuteroute.h				\
 	gossipd/routing.h
 LIGHTNINGD_GOSSIP_HEADERS := $(LIGHTNINGD_GOSSIP_HEADERS_WSRC) gossipd/broadcast.h
 LIGHTNINGD_GOSSIP_SRC := $(LIGHTNINGD_GOSSIP_HEADERS_WSRC:.h=.c) gossipd/gossipd.c

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -42,6 +42,22 @@ msgtype,gossip_getroute_reply,3106
 msgdata,gossip_getroute_reply,num_hops,u16,
 msgdata,gossip_getroute_reply,hops,route_hop,num_hops
 
+# Pass JSON-RPC permuteroute call through.
+# Master -> gossipd
+msgtype,gossip_permuteroute_request,3035
+msgdata,gossip_permuteroute_request,num_hops,u16,
+msgdata,gossip_permuteroute_request,hops,route_hop,num_hops
+msgdata,gossip_permuteroute_request,permute_after,u32,
+msgdata,gossip_permuteroute_request,num_excluded,u16,
+msgdata,gossip_permuteroute_request,excluded,short_channel_id_dir,num_excluded
+msgdata,gossip_permuteroute_request,source,?node_id,
+msgdata,gossip_permuteroute_request,max_hops,u32,
+
+# gossipd -> Master
+msgtype,gossip_permuteroute_reply,3135
+msgdata,gossip_permuteroute_reply,num_hops,u16,
+msgdata,gossip_permuteroute_reply,hops,route_hop,num_hops
+
 msgtype,gossip_getchannels_request,3007
 msgdata,gossip_getchannels_request,short_channel_id,?short_channel_id,
 msgdata,gossip_getchannels_request,source,?node_id,

--- a/gossipd/permuteroute.c
+++ b/gossipd/permuteroute.c
@@ -1,0 +1,460 @@
+#include "permuteroute.h"
+#include <common/status.h>
+#include <common/type_to_string.h>
+#include <gossipd/routing.h>
+
+/*~ In theory, this could have been built as a plugin on top
+ * of `getroute`.
+ * However, the `max_hops` argument of `getroute` does not
+ * limit the graph that the `getroute` algorithm traverses;
+ * instead, it scans the entire graph, and if the resulting
+ * route is longer than `max_hops` will ***re-scan*** the
+ * entire graph with a tweaked cost function until it finds
+ * a route that fits.
+ *
+ * As the speed of `permuteroute` is due solely to restricting
+ * the graph we scan, we just use a depth-first iterative
+ * algorithm until we reach any node after the point at which
+ * the payment fails.
+ *
+ * Arguably a Djikstra with limited hops would be better, but
+ * simplicity wins for this case as we can avoid heap
+ * allocations and keep data in hot stack memory.
+ */
+
+/*~ Glossary:
+ *
+ * Pivot node - the node which signalled the routing failure
+ * for a channel-level failure, and from which we start the
+ * search to heal the route.
+ *
+ * Return node - the node to which we found a route from the
+ * pivot.
+ *
+ * Prefix - the part of the path from the payer to the pivot.
+ *
+ * Postfix - the part of the path from the return node to the
+ * payee.
+ */
+
+/*~ Possibly stores the results of a successful healing of the
+ * original route.
+ *
+ * This is intended to be stack-allocated instead of tal-allocated.
+ *
+ * Our model is that the current route is broken at permute_after,
+ * i.e. the channel indexed by permute_after in current_route has
+ * failed, and the node indexed by permute_after was not reached
+ * (but every node before permute_after was reached).
+ * Our "pivot" is the node just before the failing channel.
+ * Our "return" is the node at or after the failing channel where
+ * we go back to the original route to the destination.
+ */
+struct permute_route_results {
+	/* The routing state.  */
+	struct routing_state *rstate;
+
+	/* The current (failing) route.  */
+	const struct route_hop *current_route;
+
+	/* The index of current_route, whose channel is
+	 * failing (the node before this index is the
+	 * pivot).  */
+	int permute_after;
+
+	/* The amount we target to pass through.  */
+	struct amount_msat amount;
+
+	/* The route that heals from the pivot to the
+	 * return node.  */
+	int subroute_len;
+	struct chan *subroute[PERMUTE_ROUTE_DISTANCE];
+
+	/* The node after the broken channel where we
+	 * return to the original route.  */
+	struct node *return_node;
+	/* The index of the current_route where we
+	 * returned.
+	 * permute_after <= return_index < tal_count(current_route)
+	 */
+	int return_index;
+};
+/* Initialize the results.  */
+static inline void
+permute_route_results_init(struct permute_route_results *results,
+			   struct routing_state *rstate,
+			   const struct route_hop *current_route,
+			   int permute_after,
+			   struct amount_msat amount)
+{
+	results->rstate = rstate;
+	results->current_route = current_route;
+	results->permute_after = permute_after;
+	results->amount = amount;
+	results->subroute_len = 0;
+	results->return_node = NULL;
+	results->return_index = -1;
+}
+
+/*~ Represents the currently-scanning set.
+ *
+ * This is a singly-linked list, allocated off the stack, with
+ * recursive calls allowing multiple instances of the structure.
+ *
+ * This will contain enough information to recover a route
+ * if we have reached a goal node.
+ */
+struct permute_route_scan {
+	const struct permute_route_scan *prev;
+	unsigned int depth;
+	struct node *node;
+	struct chan *next;
+};
+/* Determine if the given node is already in the currently-scanning
+ * set.
+ */
+static inline bool
+permute_route_scanning_duplicate(const struct permute_route_scan *scan,
+				 struct node *n)
+{
+	for (; scan; scan = scan->prev)
+		if (scan->node == n)
+			return true;
+	return false;
+}
+
+/* Determine if we have reached any of the goals.  */
+static bool
+permute_route_reached_goal(struct permute_route_results *results,
+			   const struct permute_route_scan *scan,
+			   struct node *n)
+{
+	/* No subroute yet.  */
+	if (!scan)
+		return false;
+
+	for (int i = results->permute_after;
+	     i < tal_count(results->current_route);
+	     ++i) {
+		if (node_id_eq(&results->current_route[i].nodeid, &n->id)) {
+			/* Found!  */
+			status_info("permute_route: Return to node %s "
+				    "at %d of original path, "
+				    "%u hops from pivot.",
+				    type_to_string(tmpctx, struct node_id,
+						   &n->id),
+				    i, scan->depth);
+
+			/* Update results.  */
+			results->return_node = n;
+			results->return_index = i;
+			results->subroute_len = scan->depth;
+			for (int i = scan->depth - 1; i >= 0; --i) {
+				assert(scan);
+				results->subroute[i] = scan->next;
+				scan = scan->prev;
+			}
+			assert(!scan);
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Recursive depth-first search.
+ *
+ * Most C ABIs indicate the first few arguments as passed
+ * over registers.
+ * Thus recursive functions should keep data common
+ * throughout the recursion in the first few arguments.
+ */
+static bool
+permute_route_search(struct permute_route_results *results,
+		     const struct permute_route_scan *scan,
+		     struct node *node)
+{
+	assert(results);
+	assert(node);
+
+	/* If we reached a node we already reached before, give up.  */
+	if (permute_route_scanning_duplicate(scan, node))
+		return false;
+	/* If we reached a goal node, succeed now.  */
+	if (permute_route_reached_goal(results, scan, node))
+		return true;
+	/* If depth is reached, give up now.  */
+	if (scan && scan->depth == PERMUTE_ROUTE_DISTANCE)
+		return false;
+
+	/* Allocate our own scan structure and iterate over our
+	 * channels.
+	 */
+	{
+		struct permute_route_scan myscan;
+		struct chan_map_iter it;
+		struct chan *c;
+
+		struct routing_state *rstate = results->rstate;
+		struct amount_msat amount = results->amount;
+
+		/* Make a scan node.  */
+		myscan.prev = scan;
+		myscan.depth = scan ? (scan->depth + 1) : 1;
+		myscan.node = node;
+
+		/* Go through our channels.  */
+		for (c = first_chan(node, &it);
+		     c;
+		     c = next_chan(node, &it)) {
+			int idx = (c->nodes[1] == node);
+			struct half_chan *hc = half_chan_from(node, c);
+
+			bool found;
+
+			/* If not enabled, skip.  */
+			if (!hc_is_routable(rstate, c, idx))
+				continue;
+			/* If no capacity, skip.
+			 * (Excluded channels have 0 htlc_maximum).
+			 */
+			if (!hc_can_carry(hc, amount))
+				continue;
+
+			/* Recurse.  */
+			myscan.next = c;
+			found = permute_route_search(results, &myscan,
+						     other_node(node, c));
+			if (found)
+				return true;
+		}
+	}
+
+	/* Reached here?  Give up.  */
+	return false;
+}
+
+static struct route_hop *
+permute_and_build_route(const tal_t *ctx,
+			struct routing_state *rstate,
+			const struct route_hop *current_route,
+			u32 permute_after,
+			struct node *pivot,
+			struct node *source,
+			struct chan **prefix,
+			u32 max_hops)
+{
+	struct permute_route_results results;
+	bool found;
+
+	struct chan **new_prefix;
+	int prefix_len;
+
+	struct node *n;
+
+	int return_index;
+	char *err;
+	struct route_hop *new_route;
+
+	int postfix_index;
+	int prefound_len;
+	int postfix_len;
+	int new_route_len;
+
+	permute_route_results_init(&results,
+				   rstate,
+				   current_route,
+				   permute_after,
+				   /* Use this as a proxy for how much
+				    * to deliver across the healed
+				    * route.
+				    */
+				   current_route[0].amount);
+
+	found = permute_route_search(&results, NULL, pivot);
+	if (!found)
+		return NULL;
+
+	assert(0 < results.subroute_len);
+	assert(results.subroute_len <= PERMUTE_ROUTE_DISTANCE);
+
+	/* Extend the prefix with the subroute found.  */
+	prefix_len = tal_count(prefix);
+	new_prefix = prefix;
+	tal_resize(&new_prefix, prefix_len + results.subroute_len);
+	/* Fill in the new extension.  */
+	for (int i = 0; i < results.subroute_len; ++i)
+		new_prefix[prefix_len + i] = results.subroute[i];
+
+	/* Smoothen the prefix.  */
+	smoothen_route(source, &new_prefix, &n);
+	assert(n == results.return_node);
+
+	/* Construct the prefix as route_hop structures.
+	 *
+	 * We deliver the same amount and delay to the
+	 * return node as on the current route, letting
+	 * us just copy the current route *after* the
+	 * return node seamlessly.
+	 *
+	 * Might return an error.
+	 */
+	return_index = results.return_index;
+	err = generate_route_hops(ctx,
+				  &new_route, &n,
+				  new_prefix, results.return_node,
+				  current_route[return_index].amount,
+				  current_route[return_index].delay);
+	if (err) {
+		status_unusual("permute_route: generate_route_hops: %s", err);
+		return NULL;
+	}
+	assert(n == source);
+	status_info("permute_route: Generated %d-hop route "
+		    "to return node %s "
+		    "giving %s (%"PRIu32" delay)",
+		    (int) tal_count(new_route),
+		    type_to_string(tmpctx, struct node_id,
+				   &results.return_node->id),
+		    type_to_string(tmpctx, struct amount_msat,
+				   &current_route[return_index].amount),
+		    current_route[return_index].delay);
+
+	/* Compute final size of route.  */
+	postfix_index = return_index + 1;
+	prefound_len = tal_count(new_route);
+	postfix_len = tal_count(current_route) - postfix_index;
+	new_route_len = prefound_len + postfix_len;
+	if (new_route_len > max_hops) {
+		status_info("permute_route: Route length %d > max_hops %"PRIu32"",
+			    new_route_len, max_hops);
+		return tal_free(new_route);
+	}
+
+	/* Fill in the postfix.  */
+	tal_resize(&new_route, new_route_len);
+	for (int i = 0; i < postfix_len; ++i)
+		new_route[prefound_len + i] = current_route[postfix_index + i];
+
+	status_info("permute_route: Generated %d-hop route.",
+		    (int)tal_count(new_route));
+
+	return new_route;
+}
+
+struct route_hop *permute_route(const tal_t *ctx,
+				struct routing_state *rstate,
+				const struct route_hop *current_route,
+				u32 permute_after,
+				const struct node_id *source_id,
+				const struct short_channel_id_dir *excluded TAKES,
+				u32 max_hops)
+{
+	struct route_hop *new_route;
+
+	struct node *source;
+	const struct node_id *pivot_id;
+	struct node *pivot;
+	struct chan **prefix;
+
+	struct exclusion_memento *exclusion_mem;
+
+	/* No input?  No output.  */
+	if (!current_route || tal_count(current_route) == 0) {
+		status_unusual("permute_route: empty input route");
+		return NULL;
+	}
+
+	/* Locate source.  */
+	if (!source_id)
+		source = get_node(rstate, &rstate->local_id);
+	else
+		source = get_node(rstate, source_id);
+	if (!source) {
+		status_info("permute_route: cannot find %s",
+			    type_to_string(tmpctx, struct node_id,
+					   source_id ? source_id : &rstate->local_id));
+		return NULL;
+	}
+
+	/*~ The pivot is the specific node from which we start
+	 * our search.
+	 *
+	 * permute_after indicates how many successful channel
+	 * hops occurred.
+	 * Thus if it is 0, we should pivot around the source,
+	 * else we should pivot around permute_after - 1 in
+	 * the route.
+	 *
+	 * We cannot permute_after at route length, as that
+	 * implies that the entire route succeeded and there
+	 * would be no reason to permute the route.
+	 */
+	if (permute_after == 0)
+		pivot = source;
+	else if (permute_after < tal_count(current_route)) {
+		pivot_id = &current_route[permute_after - 1].nodeid;
+
+		/* If pivot not found, fail.  */
+		pivot = get_node(rstate, pivot_id);
+		if (!pivot) {
+			status_info("permute_route: cannot find pivot %s",
+				    type_to_string(tmpctx, struct node_id,
+						   pivot_id));
+			return NULL;
+		}
+	} else {
+		status_unusual("permute_route: permute_after %d >= "
+			       "input route length %d?",
+			       (int) permute_after,
+			       (int) tal_count(current_route));
+		return NULL;
+	}
+
+	/*~ The prefix is the part of the route from source to
+	 * pivot node.
+	 *
+	 * The exact sequence of channels in the prefix will
+	 * be the same as in the current route, but the amount
+	 * passing through them will change, thus we only
+	 * retain the channels into the prefix array.
+	 *
+	 * We need to re-verify the channels on the prefix
+	 * are still existing in our map, as we need to
+	 * recompute the fees.
+	 */
+	prefix = tal_arr(tmpctx, struct chan *, permute_after);
+	for (int i = 0; i < permute_after; ++i) {
+		const struct short_channel_id *cid;
+		struct chan *c;
+		int dir;
+
+		cid = &current_route[i].channel_id;
+		c = get_channel(rstate, cid);
+
+		dir = current_route[i].direction;
+
+		if (!c || !hc_is_routable(rstate, c, dir)) {
+			status_unusual("permute_route: not routable %s/%u",
+				       type_to_string(tmpctx,
+						      struct short_channel_id,
+						      cid),
+				       dir);
+			tal_free(prefix);
+			return NULL;
+		}
+
+		prefix[i] = c;
+	}
+
+	/* Exclude, then actually permute route.  */
+	exclusion_mem = exclude_channels(rstate, excluded);
+	new_route = permute_and_build_route(ctx, rstate,
+					    current_route, permute_after,
+					    pivot, source, prefix,
+					    max_hops);
+	restore_excluded_channels(exclusion_mem);
+
+	return new_route;
+}

--- a/gossipd/permuteroute.h
+++ b/gossipd/permuteroute.h
@@ -1,0 +1,86 @@
+#ifndef LIGHTNING_GOSSIPD_PERMUTEROUTE_H
+#define LIGHTNING_GOSSIPD_PERMUTEROUTE_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+struct node_id;
+struct route_hop;
+struct routing_state;
+struct short_channel_id_dir;
+
+/**
+ * permute_route - Modify the given route, avoiding excluded channels,
+ * and return a new route to the same destination.
+ * This is used to quickly modify a failing route without having to
+ * use the computationally-heavy getroute.
+ *
+ * permute_route scans an area around one node of up to 3 hops away
+ * from that node.
+ * This greatly reduces the time needed to generate a new route.
+ *
+ * @ctx - The tal context to allocate the new route from.
+ * @rstate - The routing state to scan.
+ * @current_route - The route to modify, a tal_arr.
+ * @permute_after - Indicates that the first permute_after hops
+ * succeeded.
+ * The algorithm will search the area around the last node that
+ * succeeded, trying to reconnect to any node in the remaining
+ * part of the route.
+ * From 0 (indicating it failed at the first hop at the source)
+ * to tal_count(current_route) - 1.
+ * @source - The source of the route.
+ * @excluded - A tal_arr of channel-directions that will not be
+ * considered.
+ * @max_hops - If the resulting route would exceed this, fail anyway.
+ */
+struct route_hop *permute_route(const tal_t *ctx,
+				struct routing_state *rstate,
+				const struct route_hop *current_route,
+				u32 permute_after,
+				const struct node_id *source,
+				const struct short_channel_id_dir *excluded,
+				u32 max_hops);
+
+/* The maximum number of hops to scan to heal the route.  */
+#define PERMUTE_ROUTE_DISTANCE (3)
+
+/*~
+ * The permute_route algorithm was inspired by JIT-Routing of
+ * Rene Pickhardt.
+ *
+ * In JIT-Routing, a node that would fail to transmit over a
+ * channel due to capacity issue, may instead perform a
+ * rebalance of its channels.
+ *
+ * Unlike failing and then forcing the source to recompute a
+ * new route, JIT-Routing can quickly find a route by simply
+ * restricting itself to searching the nearby channels and
+ * nodes to find a circular route, specifically only up to
+ * the friend-of-a-friend graph.
+ *
+ * JIT-Routing would effectively modify the route by sending
+ * money over an alternate route, then healing to continue
+ * the routing.
+ *
+ * permute_route basically "simulates" a JIT-Routing occurring
+ * at the failure point, scanning only the local area around
+ * the node reporting the error until it finds an alternate
+ * sub-route that attaches to the remaining part of the route.
+ * This takes advantage of the speed of the local scan used
+ * by the JIT-Routing, by restricting ourselves to scanning
+ * only up to 3 hops away until we find a point to attach
+ * to, and finishing the scan as soon as we find this point.
+ *
+ * Assuming the original route was optimal in terms of fees
+ * and lock time, then the resulting route is only a mild
+ * degradation, since we would basically replace one failing
+ * channel with up to 3 channels.
+ * The intent is that, *only* if the resulting route is
+ * too expensive, do we bother to use the more
+ * computationally-heavy getroute.
+ *
+ * See also: https://theory.stanford.edu/~amitp/GameProgramming/MovingObstacles.html#path-splicing
+ */
+
+#endif /* LIGHTNING_GOSSIPD_PERMUTEROUTE_H */

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -477,16 +477,6 @@ static WARN_UNUSED_RESULT bool risk_add_fee(struct amount_msat *risk,
 	return true;
 }
 
-/* Check that we can fit through this channel's indicated
- * maximum_ and minimum_msat requirements.
- */
-static bool hc_can_carry(const struct half_chan *hc,
-			 struct amount_msat requiredcap)
-{
-	return amount_msat_greater_eq(hc->htlc_maximum, requiredcap) &&
-		amount_msat_less_eq(hc->htlc_minimum, requiredcap);
-}
-
 /* Theoretically, this could overflow. */
 static bool fuzz_fee(u64 *fee,
 		     const struct short_channel_id *scid,
@@ -614,14 +604,6 @@ static bool costs_less(struct amount_msat totala,
 	if (costb)
 		*costb = sumb;
 	return amount_msat_less(suma, sumb);
-}
-
-/* Determine if the given half_chan is routable */
-static bool hc_is_routable(struct routing_state *rstate,
-			   const struct chan *chan, int idx)
-{
-	return is_halfchan_enabled(&chan->half[idx])
-		&& !is_chan_local_disabled(rstate, chan);
 }
 
 static void unvisited_add(struct unvisited *unvisited, struct amount_msat cost,

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -506,4 +506,20 @@ hc_can_carry(const struct half_chan *hc,
 		amount_msat_less_eq(hc->htlc_minimum, requiredcap);
 }
 
+/**
+ * smoothen_route - Remove any loops from a route (a tal_arr of
+ * pointers to chan, starting at the source node).
+ * This functions is relevant when routes are concatenated, where
+ * each sub-part of the route was derived separately from other
+ * parts of the route, possibly passing through a node multiple
+ * times.
+ *
+ * @source - the starting node of the route.
+ * @route - the route to modify in place.
+ * @destination - the last node in the route, output.
+ */
+void smoothen_route(struct node *source,
+		    struct chan ***route,
+		    struct node **destination);
+
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -459,4 +459,33 @@ exclude_channels(struct routing_state *rstate,
  */
 void restore_excluded_channels(struct exclusion_memento *memento);
 
+/* Generate a tal_arr of route_hops from an array of
+ * chans and the destination node.
+ * Returns an error string if an error occurred, NULL if
+ * no error.
+ *
+ * @ctx - parent to tal the error string or hops array from.
+ * @hops - output; where to put the generated hops array.
+ * NULLed if errored.
+ * @source - output; the source we ended up in while traversing
+ * the channels array.
+ * NULLed if errored.
+ * @chans - a tal_arr of channels along the route, from source
+ * to destination.
+ * @destination - the destination to come from.
+ * @final_msat - the amount that needs to reach the destination.
+ * @final_cltv - the timelock that needst to reach the
+ * destination.
+ */
+char *generate_route_hops(const tal_t *ctx,
+			  /* outputs.  */
+			  struct route_hop **hops,
+			  struct node **source,
+			  /* inputs.  */
+			  struct chan **chans,
+			  struct node *destination,
+			  struct amount_msat final_msat,
+			  u32 final_cltv);
+
+
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -116,12 +116,15 @@ struct node {
 	} chans;
 
 	/* Temporary data for routefinding. */
-	struct {
-		/* Total to get to here from target. */
-		struct amount_msat total;
-		/* Total risk premium of this route. */
-		struct amount_msat risk;
-	} dijkstra;
+	union {
+		/* For `getroute` Dijkstra algo.  16 bytes.  */
+		struct {
+			/* Total to get to here from target. */
+			struct amount_msat total;
+			/* Total risk premium of this route. */
+			struct amount_msat risk;
+		} dijkstra;
+	} s;
 };
 
 const struct node_id *node_map_keyof_node(const struct node *n);

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -441,4 +441,22 @@ void remove_channel_from_store(struct routing_state *rstate,
 const char *unfinalized_entries(const tal_t *ctx, struct routing_state *rstate);
 
 void remove_all_gossip(struct routing_state *rstate);
+
+/* Used to set up exclusions and remove them. */
+struct exclusion_memento;
+
+/* Set up exclusions, saving the needed data in a memento to be
+ * restored later.
+ * The exclusions must be restored before returning to the
+ * mainloop.
+ */
+struct exclusion_memento *
+exclude_channels(struct routing_state *rstate,
+		 const struct short_channel_id_dir *excluded TAKES);
+
+/* Restore excluded channels.
+ * This will also tal_free the given memento.
+ */
+void restore_excluded_channels(struct exclusion_memento *memento);
+
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -487,5 +487,23 @@ char *generate_route_hops(const tal_t *ctx,
 			  struct amount_msat final_msat,
 			  u32 final_cltv);
 
+/* Determine if the given half_chan is routable */
+static inline bool
+hc_is_routable(struct routing_state *rstate,
+	       const struct chan *chan, int idx)
+{
+	return is_halfchan_enabled(&chan->half[idx])
+		&& !is_chan_local_disabled(rstate, chan);
+}
+/* Check that we can fit through this channel's indicated
+ * maximum_ and minimum_msat requirements.
+ */
+static inline bool
+hc_can_carry(const struct half_chan *hc,
+	     struct amount_msat requiredcap)
+{
+	return amount_msat_greater_eq(hc->htlc_maximum, requiredcap) &&
+		amount_msat_less_eq(hc->htlc_minimum, requiredcap);
+}
 
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -124,6 +124,12 @@ struct node {
 			/* Total risk premium of this route. */
 			struct amount_msat risk;
 		} dijkstra;
+		/* For `permuteroute` breadth-first algo.  10 bytes.  */
+		struct {
+			struct chan *prev_chan;
+			bool visited;
+			u8 depth;
+		} permuteroute;
 	} s;
 };
 

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -235,6 +235,74 @@ struct command_result *param_feerate(struct command *cmd, const char *name,
 	return NULL;
 }
 
+struct command_result *param_route(struct command *cmd, const char *name,
+				   const char *buffer, const jsmntok_t *tok,
+				   struct route_hop **route)
+{
+	struct command_result *result;
+	const jsmntok_t *routetok;
+	const jsmntok_t *t;
+	size_t i;
+
+	result = param_array(cmd, name, buffer, tok, &routetok);
+	if (result)
+		return result;
+
+	if (routetok->size == 0)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Empty route");
+
+	*route = tal_arr(cmd, struct route_hop, routetok->size);
+	json_for_each_arr(i, t, routetok) {
+		struct amount_msat *msat, *amount_msat;
+		struct node_id *id;
+		struct short_channel_id *channel;
+		unsigned *delay, *direction;
+
+		if (!param(cmd, buffer, t,
+			   /* Only *one* of these is required */
+			   p_opt("msatoshi", param_msat, &msat),
+			   p_opt("amount_msat", param_msat, &amount_msat),
+			   /* These three actually required */
+			   p_opt("id", param_node_id, &id),
+			   p_opt("delay", param_number, &delay),
+			   p_opt("channel", param_short_channel_id, &channel),
+			   p_opt("direction", param_number, &direction),
+			   NULL))
+			return command_param_failed();
+
+		if (!msat && !amount_msat)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "route[%zi]: must have msatoshi"
+					    " or amount_msat", i);
+		if (!id || !channel || !delay)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "route[%zi]: must have id, channel"
+					    " and delay", i);
+		if (msat && amount_msat && !amount_msat_eq(*msat, *amount_msat))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "route[%zi]: msatoshi %s != amount_msat %s",
+					    i,
+					    type_to_string(tmpctx,
+							   struct amount_msat,
+							   msat),
+					    type_to_string(tmpctx,
+							   struct amount_msat,
+							   amount_msat));
+		if (!msat)
+			msat = amount_msat;
+
+		(*route)[i].amount = *msat;
+		(*route)[i].nodeid = *id;
+		(*route)[i].delay = *delay;
+		(*route)[i].channel_id = *channel;
+		/* FIXME: Actually ignored by sendpay code! */
+		(*route)[i].direction = direction ? *direction : 0;
+	}
+
+	return NULL;
+}
+
 bool
 json_tok_channel_id(const char *buffer, const jsmntok_t *tok,
 		    struct channel_id *cid)

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -96,6 +96,11 @@ struct command_result *param_feerate(struct command *cmd, const char *name,
 				     const char *buffer, const jsmntok_t *tok,
 				     u32 **feerate);
 
+/* Extract a route. */
+struct command_result *param_route(struct command *cmd, const char *name,
+				   const char *buffer, const jsmntok_t *tok,
+				   struct route_hop **route);
+
 /* '"fieldname" : "1234:5:6"' */
 void json_add_short_channel_id(struct json_stream *response,
 			       const char *fieldname,

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -74,6 +74,11 @@ struct oneshot *new_reltimer_(struct timers *timers UNNEEDED,
 bool param(struct command *cmd UNNEEDED, const char *buffer UNNEEDED,
 	   const jsmntok_t params[] UNNEEDED, ...)
 { fprintf(stderr, "param called!\n"); abort(); }
+/* Generated stub for param_array */
+struct command_result *param_array(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				   const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				   const jsmntok_t **arr UNNEEDED)
+{ fprintf(stderr, "param_array called!\n"); abort(); }
 /* Generated stub for param_feerate_estimate */
 struct command_result *param_feerate_estimate(struct command *cmd UNNEEDED,
 					      u32 **feerate_per_kw UNNEEDED,
@@ -84,6 +89,11 @@ struct command_result *param_ignore(struct command *cmd UNNEEDED, const char *na
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				    const void *unused UNNEEDED)
 { fprintf(stderr, "param_ignore called!\n"); abort(); }
+/* Generated stub for param_msat */
+struct command_result *param_msat(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				  struct amount_msat **msat UNNEEDED)
+{ fprintf(stderr, "param_msat called!\n"); abort(); }
 /* Generated stub for param_number */
 struct command_result *param_number(struct command *cmd UNNEEDED, const char *name UNNEEDED,
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,


### PR DESCRIPTION
This is a new command/routing heuristic, inspired  by @renepickhardt JIT-Routing.

It turns out to be an actual technique used in real-time strategy games (whose pathfinding issues actually surprisingly match that of LN: low acceptable latency for UX, dynamically-changing world, incomplete information (at least the really good games will not let your units know the "real" state of the world, only what your fog-of-war knows), large maps).

I will be posting a very lengthy article on lightning-dev mailinglist regarding permuteroute and other heuristics inspired by real-time strategy game techniques.

This is incomplete.  Help wanted.

* [x] Test for `permuteroute`, especially for route smoothing (i.e. backing out of a node when all alternatives are excluded).
* [x] Modify `pay` plugin to use `permuteroute` and fall back on `getroute` if failed / too expensive.