### PR TITLE
channeld: delay sending channel_announcement by 60 seconds.

### DIFF
--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -67,6 +67,7 @@ msgdata,channel_init,upfront_shutdown_script_len,u16,
 msgdata,channel_init,upfront_shutdown_script,u8,upfront_shutdown_script_len
 msgdata,channel_init,remote_ann_node_sig,?secp256k1_ecdsa_signature,
 msgdata,channel_init,remote_ann_bitcoin_sig,?secp256k1_ecdsa_signature,
+msgdata,channel_init,announce_delay,u32,
 
 # master->channeld funding hit new depth(funding locked if >= lock depth)
 msgtype,channel_funding_depth,1002

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -424,7 +424,10 @@ void peer_start_channeld(struct channel *channel,
 				      channel->peer->localfeatures,
 				      channel->remote_upfront_shutdown_script,
 				      remote_ann_node_sig,
-				      remote_ann_bitcoin_sig);
+				      remote_ann_bitcoin_sig,
+				      /* Delay announce by 60 seconds after
+				       * seeing block (adjustable if dev) */
+				      ld->topology->poll_seconds * 2);
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(channel->owner, take(initmsg));


### PR DESCRIPTION
We currently send channel_announcement as soon as we and our
peer agree it's 6 blocks deep.  In theory, our other peers might
not have seen that block yet though, so delay a little.

This is mitigated by two factors:
1. lnd will stash any "not ready yet" channel_announcements anyway.
2. c-lightning doesn't enforce the 6 depth minimum at all.

We should not rely on other nodes' generosity or laxity, however!

Next release, we can start enforcing the depth limit, and maybe stashing
ones which don't quite make it (or simply enforce depth 5, not 6).

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>