### PR TITLE
Remove trailing 'dev-rhash' code, updates about 'dev' command

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -366,7 +366,10 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         Crash lightningd by calling fatal()
         """
-        return self.call("dev-crash")
+        payload = {
+            "subcommand": "crash"
+        }
+        return self.call("dev", payload)
 
     def dev_fail(self, peer_id):
         """
@@ -427,9 +430,10 @@ class LightningRpc(UnixDomainSocketRpc):
         Show SHA256 of {secret}
         """
         payload = {
+            "subcommand": "rhash",
             "secret": secret
         }
-        return self.call("dev-rhash", payload)
+        return self.call("dev", payload)
 
     def dev_sign_last_tx(self, peer_id):
         """
@@ -439,6 +443,16 @@ class LightningRpc(UnixDomainSocketRpc):
             "id": peer_id
         }
         return self.call("dev-sign-last-tx", payload)
+
+    def dev_slowcmd(self, msec=None):
+        """
+        Torture test for slow commands, optional {msec}
+        """
+        payload = {
+            "subcommand": "slowcmd",
+            "msec": msec
+        }
+        return self.call("dev", payload)
 
     def disconnect(self, peer_id, force=False):
         """

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -223,34 +223,6 @@ static const struct json_command stop_command = {
 AUTODATA(json_command, &stop_command);
 
 #if DEVELOPER
-static struct command_result *json_rhash(struct command *cmd,
-					 const char *buffer,
-					 const jsmntok_t *obj UNUSED,
-					 const jsmntok_t *params)
-{
-	struct json_stream *response;
-	struct sha256 *secret;
-
-	if (!param(cmd, buffer, params,
-		   p_req("secret", param_sha256, &secret),
-		   NULL))
-		return command_param_failed();
-
-	/* Hash in place. */
-	sha256(secret, secret, sizeof(*secret));
-	response = json_stream_success(cmd);
-	json_add_hex(response, "rhash", secret, sizeof(*secret));
-	return command_success(cmd, response);
-}
-
-static const struct json_command dev_rhash_command = {
-	"dev-rhash",
-	"developer",
-	json_rhash,
-	"Show SHA256 of {secret}"
-};
-AUTODATA(json_command, &dev_rhash_command);
-
 struct slowcmd {
 	struct command *cmd;
 	unsigned *msec;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -296,7 +296,13 @@ static const struct json_command dev_command = {
 	"dev",
 	"developer",
 	json_dev,
-	"Developer command test multiplexer"
+	"Developer command test multiplexer",
+	.verbose = "dev rhash {secret}\n"
+	"	Show SHA256 of {secret}\n"
+	"dev crash\n"
+	"	Crash lightningd by calling fatal()\n"
+	"dev slowcmd {msec}\n"
+	"	Torture test for slow commands, optional {msec}\n"
 };
 AUTODATA(json_command, &dev_command);
 #endif /* DEVELOPER */


### PR DESCRIPTION
This removes the trailing `dev-rhash` code in lightningd/jsonrpc.c since it was replaced by `dev` in #2814. It updates Pylightning accordingly to #2814 changes (as in #2771 three methods `dev_rhash`, `dev_slowcmd` and `dev_crash` have been prefered upon a `dev` method with a subcommand parameter).
This finally adds a verbose description to the dev command and a CHANGELOG line for JSON API changes.