### PR TITLE
Help in testdir

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -672,10 +672,6 @@ int main(int argc, char *argv[])
 	 *  say --daemonize. */
 	handle_early_opts(ld, argc, argv);
 
-	/*~ Now create the PID file: this errors out if there's already a
-	 * daemon running, so we call before doing almost anything else. */
-	pidfile_create(ld);
-
 	/*~ Initialize all the plugins we just registered, so they can
 	 *  do their thing and tell us about themselves (including
 	 *  options registration). */
@@ -683,6 +679,10 @@ int main(int argc, char *argv[])
 
 	/*~ Handle options and config; move to .lightningd (--lightning-dir) */
 	handle_opts(ld, argc, argv);
+
+	/*~ Now create the PID file: this errors out if there's already a
+	 * daemon running, so we call before doing almost anything else. */
+	pidfile_create(ld);
 
 	/*~ Make sure we can reach the subdaemons, and versions match. */
 	test_subdaemons(ld);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,7 +14,7 @@ import time
 import unittest
 
 
-def test_option_passthrough(node_factory):
+def test_option_passthrough(node_factory, directory):
     """ Ensure that registering options works.
 
     First attempts without the plugin and then with the plugin.
@@ -23,12 +23,14 @@ def test_option_passthrough(node_factory):
 
     help_out = subprocess.check_output([
         'lightningd/lightningd',
+        '--lightning-dir={}'.format(directory),
         '--help'
     ]).decode('utf-8')
     assert('--greeting' not in help_out)
 
     help_out = subprocess.check_output([
         'lightningd/lightningd',
+        '--lightning-dir={}'.format(directory),
         '--plugin={}'.format(plugin_path),
         '--help'
     ]).decode('utf-8')
@@ -205,7 +207,7 @@ def test_plugin_connect_notifications(node_factory):
     l2.daemon.wait_for_log(r'Received disconnect event')
 
 
-def test_failing_plugins():
+def test_failing_plugins(directory):
     fail_plugins = [
         os.path.join(os.getcwd(), 'contrib/plugins/fail/failtimeout.py'),
         os.path.join(os.getcwd(), 'contrib/plugins/fail/doesnotexist.py'),
@@ -215,6 +217,7 @@ def test_failing_plugins():
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_output([
                 'lightningd/lightningd',
+                '--lightning-dir={}'.format(directory),
                 '--plugin={}'.format(p),
                 '--help',
             ])


### PR DESCRIPTION
This is a followup to #2892. Since we now attempt to lock the PID file before
starting plugins we need to make sure that we actually use a unique lightning
directory for anything that attempts to call `--help`. If not we may be
conflicting with a `lightningd` that is running against that directory.

The we also defer creating the PID until we actually want to start. This was causing `--help` to fail if we already had a `lightningd` running
with the same `--lightning-dir`.