### PR TITLE
doc: fix up documentation about when we move into lightning-dir.

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -41,10 +41,10 @@ will read replies from its `stdout`. To initialize the plugin two RPC
 methods are required:
 
  - `getmanifest` asks the plugin for command line options and JSON-RPC
-   commands that should be passed through.  Note that can be run before
+   commands that should be passed through.  This can be run before
    `lightningd` checks that it is the sole user of the `lightning-dir`
    directory (for `--help`) so your plugin should not touch files at this
-   point).
+   point.
  - `init` is called after the command line options have been
    parsed and passes them through with the real values (if specified). This is also
    the signal that `lightningd`'s JSON-RPC over Unix Socket is now up

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -41,7 +41,10 @@ will read replies from its `stdout`. To initialize the plugin two RPC
 methods are required:
 
  - `getmanifest` asks the plugin for command line options and JSON-RPC
-   commands that should be passed through
+   commands that should be passed through.  Note that can be run before
+   `lightningd` checks that it is the sole user of the `lightning-dir`
+   directory (for `--help`) so your plugin should not touch files at this
+   point).
  - `init` is called after the command line options have been
    parsed and passes them through with the real values (if specified). This is also
    the signal that `lightningd`'s JSON-RPC over Unix Socket is now up

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -665,11 +665,11 @@ int main(int argc, char *argv[])
 	if (!ld->daemon_dir)
 		errx(1, "Could not find daemons");
 
-	/*~ Handle early options, but don't move to --lightning-dir
-	 *  just yet. Plugins may add new options, which is why we are
-	 *  splitting between early args (including --plugin
-	 *  registration) and non-early opts.  This also forks if they
-	 *  say --daemonize. */
+	/*~ Handle early options; this moves us into --lightning-dir.
+	 * Plugins may add new options, which is why we are splitting
+	 * between early args (including --plugin registration) and
+	 * non-early opts.  This also forks if they say
+	 * --daemonize. */
 	handle_early_opts(ld, argc, argv);
 
 	/*~ Now create the PID file: this errors out if there's already a
@@ -681,7 +681,7 @@ int main(int argc, char *argv[])
 	 *  options registration). */
 	plugins_init(ld->plugins, ld->dev_debug_subprocess);
 
-	/*~ Handle options and config; move to .lightningd (--lightning-dir) */
+	/*~ Handle options and config. */
 	handle_opts(ld, argc, argv);
 
 	/*~ Make sure we can reach the subdaemons, and versions match. */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -668,8 +668,7 @@ int main(int argc, char *argv[])
 	/*~ Handle early options; this moves us into --lightning-dir.
 	 * Plugins may add new options, which is why we are splitting
 	 * between early args (including --plugin registration) and
-	 * non-early opts.  This also forks if they say
-	 * --daemonize. */
+	 * non-early opts.  This also forks if they say --daemon. */
 	handle_early_opts(ld, argc, argv);
 
 	/*~ Now create the PID file: this errors out if there's already a


### PR DESCRIPTION
And make sure that plugins know that they should not touch things until their init call.
