### PR TITLE
Backfill blocks in the database as needed for gossip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ changes.
 - Plugin: `disconnect` notifier now called if remote side disconnects.
 - channeld: ignore, and simply try reconnecting if lnd sends "sync error".
 - Protocol: we now correctly ignore unknown odd messages.
+- wallet: We will now backfill blocks below our wallet start height on demand when we require them to verify gossip messages. This fixes an issue where we would not remove channels on spend that were opened below that start height because we weren't tracking the funding output.
 
 ### Security
 

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -787,7 +787,7 @@ void bitcoind_gettxout(struct bitcoind *bitcoind,
  * process the various steps. */
 struct filteredblock_call {
 	struct list_node list;
-	void (*cb)(struct bitcoind *bitcoind, struct filteredblock *fb,
+	void (*cb)(struct bitcoind *bitcoind, const struct filteredblock *fb,
 		   void *arg);
 	void *arg;
 
@@ -914,7 +914,7 @@ process_getfiltered_block_final(struct bitcoind *bitcoind,
 
 void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
 				void (*cb)(struct bitcoind *bitcoind,
-					   struct filteredblock *fb,
+					   const struct filteredblock *fb,
 					   void *arg),
 				void *arg)
 {

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -555,8 +555,6 @@ static bool process_gettxout(struct bitcoin_cli *bcli)
 	/* As of at least v0.15.1.0, bitcoind returns "success" but an empty
 	   string on a spent gettxout */
 	if (*bcli->exitstatus != 0 || bcli->output_bytes == 0) {
-		log_debug(bcli->bitcoind->log, "%s: not unspent output?",
-			  bcli_args(tmpctx, bcli));
 		cb(bcli->bitcoind, NULL, bcli->cb_arg);
 		return true;
 	}

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -852,8 +852,6 @@ static void process_getfilteredblock_step2(struct bitcoind *bitcoind,
 		}
 	}
 
-	call->result->outpoints = tal_arr(call->result, struct filteredblock_outpoint *, 0);
-	call->current_outpoint = 0;
 	if (tal_count(call->outpoints) == 0) {
 		/* If there were no outpoints to check, we can short-circuit
 		 * and just call the callback. */
@@ -897,6 +895,8 @@ void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
 	assert(call->cb != NULL);
 	call->start_time = time_now();
 	call->result->height = height;
+	call->result->outpoints = tal_arr(call->result, struct filteredblock_outpoint *, 0);
+	call->current_outpoint = 0;
 
 	bitcoind_getblockhash(bitcoind, height, process_getfilteredblock_step1, call);
 }

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -846,7 +846,7 @@ static void process_getfilteredblock_step2(struct bitcoind *bitcoind,
 				/* This is an interesting output, remember it. */
 				o = tal(call->outpoints, struct filteredblock_outpoint);
 				bitcoin_txid(tx, &o->txid);
-				o->satoshis = bitcoin_tx_output_get_amount(tx, j);
+				o->amount = bitcoin_tx_output_get_amount(tx, j);
 				o->txindex = i;
 				o->outnum = j;
 				o->scriptPubKey = tal_steal(o, script);

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -67,6 +67,23 @@ struct bitcoind {
 	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
 };
 
+/* A single outpoint in a filtered block */
+struct filteredblock_outpoint {
+	struct bitcoin_txid txid;
+	u32 outnum;
+	u32 txindex;
+	const u8 *scriptPubKey;
+	struct amount_sat satoshis;
+};
+
+/* A struct representing a block with most of the parts filtered out. */
+struct filteredblock {
+	struct bitcoin_blkid id;
+	u32 height;
+	struct bitcoin_blkid prev_hash;
+	struct filteredblock_outpoint **outpoints;
+};
+
 struct bitcoind *new_bitcoind(const tal_t *ctx,
 			      struct lightningd *ld,
 			      struct log *log);
@@ -131,6 +148,20 @@ void bitcoind_getblockhash_(struct bitcoind *bitcoind,
 						   struct bitcoind *,	\
 						   const struct bitcoin_blkid *), \
 			       (arg))
+
+void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
+				void (*cb)(struct bitcoind *bitcoind,
+					   struct filteredblock *fb,
+					   void *arg),
+				void *arg);
+#define bitcoind_getfilteredblock(bitcoind_, height, cb, arg)		\
+	bitcoind_getfilteredblock_((bitcoind_),				\
+				   (height),				\
+				   typesafe_cb_preargs(void, void *,	\
+						       (cb), (arg),	\
+						       struct bitcoind *, \
+						       const struct filteredblock *), \
+				   (arg))
 
 void bitcoind_getrawblock_(struct bitcoind *bitcoind,
 			   const struct bitcoin_blkid *blockid,

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -75,7 +75,7 @@ struct filteredblock_outpoint {
 	u32 outnum;
 	u32 txindex;
 	const u8 *scriptPubKey;
-	struct amount_sat satoshis;
+	struct amount_sat amount;
 };
 
 /* A struct representing a block with most of the parts filtered out. */

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -65,6 +65,8 @@ struct bitcoind {
 
 	/* Passthrough parameters for bitcoin-cli */
 	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
+
+	struct list_head pending_getfilteredblock;
 };
 
 /* A single outpoint in a filtered block */

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -153,7 +153,7 @@ void bitcoind_getblockhash_(struct bitcoind *bitcoind,
 
 void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
 				void (*cb)(struct bitcoind *bitcoind,
-					   struct filteredblock *fb,
+					   const struct filteredblock *fb,
 					   void *arg),
 				void *arg);
 #define bitcoind_getfilteredblock(bitcoind_, height, cb, arg)		\

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -82,7 +82,7 @@ static void got_filteredblock(struct bitcoind *bitcoind,
 	}
 
 	if (fbo) {
-		txo.amount = fbo->satoshis;
+		txo.amount = fbo->amount;
 		txo.script = (u8 *)fbo->scriptPubKey;
 		got_txout(bitcoind, &txo, scid);
 	} else

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -67,7 +67,9 @@ static void got_filteredblock(struct bitcoind *bitcoind,
 	struct filteredblock_outpoint *fbo = NULL, *o;
 	struct bitcoin_tx_output txo;
 
-	wallet_filteredblock_add(bitcoind->ld->wallet, fb);
+	/* Only fill in blocks that we are not going to scan later. */
+	if (bitcoind->ld->topology->min_blockheight > fb->height)
+		wallet_filteredblock_add(bitcoind->ld->wallet, fb);
 
 	u32 outnum = short_channel_id_outnum(scid);
 	u32 txindex = short_channel_id_txnum(scid);

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -60,10 +60,9 @@ static void got_txout(struct bitcoind *bitcoind,
 }
 
 static void got_filteredblock(struct bitcoind *bitcoind,
-		      struct filteredblock *fb,
-		      void *arg)
+		      const struct filteredblock *fb,
+		      struct short_channel_id *scid)
 {
-	struct short_channel_id *scid = (struct short_channel_id *)arg;
 	struct filteredblock_outpoint *fbo = NULL, *o;
 	struct bitcoin_tx_output txo;
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -59,6 +59,34 @@ static void got_txout(struct bitcoind *bitcoind,
 	tal_free(scid);
 }
 
+static void got_filteredblock(struct bitcoind *bitcoind,
+		      struct filteredblock *fb,
+		      void *arg)
+{
+	struct short_channel_id *scid = (struct short_channel_id *)arg;
+	struct filteredblock_outpoint *fbo = NULL, *o;
+	struct bitcoin_tx_output txo;
+
+	wallet_filteredblock_add(bitcoind->ld->wallet, fb);
+
+	u32 outnum = short_channel_id_outnum(scid);
+	u32 txindex = short_channel_id_txnum(scid);
+	for (size_t i=0; i<tal_count(fb->outpoints); i++) {
+		o = fb->outpoints[i];
+		if (o->txindex == txindex && o->outnum == outnum) {
+			fbo = o;
+			break;
+		}
+	}
+
+	if (fbo) {
+		txo.amount = fbo->satoshis;
+		txo.script = (u8 *)fbo->scriptPubKey;
+		got_txout(bitcoind, &txo, scid);
+	} else
+		got_txout(bitcoind, NULL, scid);
+}
+
 static void get_txout(struct subd *gossip, const u8 *msg)
 {
 	struct short_channel_id *scid = tal(gossip, struct short_channel_id);
@@ -80,21 +108,16 @@ static void get_txout(struct subd *gossip, const u8 *msg)
 			      towire_gossip_get_txout_reply(
 				  scid, scid, op->sat, op->scriptpubkey));
 		tal_free(scid);
-	} else if (blockheight >= topo->min_blockheight &&
-		   blockheight <= topo->max_blockheight) {
-		/* We should have known about this outpoint since it is included
-		 * in the range in the DB. The fact that we don't means that
-		 * this is either a spent outpoint or an invalid one. Return a
+	} else if (wallet_have_block(gossip->ld->wallet, blockheight)) {
+		/* We should have known about this outpoint since its header
+		 * is in the DB. The fact that we don't means that this is
+		 * either a spent outpoint or an invalid one. Return a
 		 * failure. */
 		subd_send_msg(gossip, take(towire_gossip_get_txout_reply(
 						   NULL, scid, AMOUNT_SAT(0), NULL)));
 		tal_free(scid);
 	} else {
-		bitcoind_getoutput(topo->bitcoind,
-				   short_channel_id_blocknum(scid),
-				   short_channel_id_txnum(scid),
-				   short_channel_id_outnum(scid),
-				   got_txout, scid);
+		bitcoind_getfilteredblock(topo->bitcoind, short_channel_id_blocknum(scid), got_filteredblock, scid);
 	}
 }
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,8 @@
 from fixtures import *  # noqa: F401,F403
+from utils import wait_for
+
+
+import pytest
 
 
 def test_db_dangling_peer_fix(node_factory):
@@ -15,3 +19,57 @@ def test_db_dangling_peer_fix(node_factory):
     # Make sure l2 has register connection
     l2.daemon.wait_for_log('Handed peer, entering loop')
     l2.fund_channel(l1, 200000, wait_for_active=True)
+
+
+@pytest.mark.xfail(strict=True)
+def test_block_backfill(node_factory, bitcoind):
+    """Test whether we backfill data from the blockchain correctly.
+
+    For normal operation we will process any block after the initial start
+    height, or rescan height, but for gossip we actually also need to backfill
+    the blocks we skipped initially. We do so on-demand, whenever we see a
+    channel_announcement referencing a blockheight we haven't processed yet,
+    we fetch the entire block, extract P2WSH outputs and ask `bitcoin
+    gettxout` for each of them. We then store the block header in the `blocks`
+    table and the unspent outputs in the `utxoset` table.
+
+    The test consist of two nodes opening a channel at height X, and an
+    unrelated P2WSH transaction being sent at the same height (will be used to
+    check for completeness of the backfill). Then a second node starts at
+    height X+100 and connect to one of the nodes. It should not have the block
+    in its DB before connecting. After connecting it should sync the gossip,
+    triggering a backfill of block X, and all associated P2WSH outputs.
+
+    """
+    # Need to manually open the channels later since otherwise we can't have a
+    # tx in the same block (`line_graph` with `fundchannel=True` generates
+    # blocks).
+    l1, l2 = node_factory.line_graph(2, fundchannel=False)
+
+    # Get some funds to l1
+    addr = l1.rpc.newaddr()['bech32']
+    bitcoind.rpc.sendtoaddress(addr, 1)
+    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) == 1)
+    bitcoind.generate_block(1)
+    l1.daemon.wait_for_log(r'Owning')
+
+    # Now send the needle we will go looking for later:
+    bitcoind.rpc.sendtoaddress('bcrt1qtwxd8wg5eanumk86vfeujvp48hfkgannf77evggzct048wggsrxsum2pmm', 1)
+    l1.rpc.fundchannel(l2.info['id'], 10**6, announce=True)
+    wait_for(lambda: len(bitcoind.rpc.getrawmempool()) == 2)
+
+    # Confirm and get some distance between the funding and the l3 wallet birth date
+    bitcoind.generate_block(100)
+    wait_for(lambda: len(l1.rpc.listnodes()['nodes']) == 2)
+
+    # Start the tester node, and connect it to l1. l0 should sync the gossip
+    # and call out to `bitcoind` to backfill the block.
+    l3 = node_factory.get_node()
+    heights = [r['height'] for r in l3.db_query("SELECT height FROM blocks")]
+    assert(103 not in heights)
+
+    l3.rpc.connect(l1.info['id'], 'localhost', l1.port)
+
+    wait_for(lambda: len(l3.rpc.listnodes()['nodes']) == 2)
+    heights = [r['height'] for r in l3.db_query("SELECT height FROM blocks")]
+    assert(103 in heights)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,9 +2,6 @@ from fixtures import *  # noqa: F401,F403
 from utils import wait_for
 
 
-import pytest
-
-
 def test_db_dangling_peer_fix(node_factory):
     # This was taken from test_fail_unconfirmed() node.
     l1 = node_factory.get_node(dbfile='dangling-peer.sqlite3.xz')
@@ -21,7 +18,6 @@ def test_db_dangling_peer_fix(node_factory):
     l2.fund_channel(l1, 200000, wait_for_active=True)
 
 
-@pytest.mark.xfail(strict=True)
 def test_block_backfill(node_factory, bitcoind):
     """Test whether we backfill data from the blockchain correctly.
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2411,7 +2411,7 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 	outpointfilter_add(w->utxoset_outpoints, &txid, outnum);
 }
 
-void wallet_filteredblock_add(struct wallet *w, struct filteredblock *fb)
+void wallet_filteredblock_add(struct wallet *w, const struct filteredblock *fb)
 {
 	if (wallet_have_block(w, fb->height))
 		return;

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2441,7 +2441,7 @@ void wallet_filteredblock_add(struct wallet *w, struct filteredblock *fb)
 		sqlite3_bind_int(stmt, 5, o->txindex);
 		sqlite3_bind_blob(stmt, 6, o->scriptPubKey,
 				  tal_count(o->scriptPubKey), SQLITE_TRANSIENT);
-		sqlite3_bind_amount_sat(stmt, 7, o->satoshis);
+		sqlite3_bind_amount_sat(stmt, 7, o->amount);
 		db_exec_prepared(w->db, stmt);
 
 		outpointfilter_add(w->utxoset_outpoints, &o->txid, o->outnum);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1170,6 +1170,6 @@ struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t
  *
  * This can be used to backfill the blocks and still unspent UTXOs that were before our wallet birth height.
  */
-void wallet_filteredblock_add(struct wallet *w, struct filteredblock *fb);
+void wallet_filteredblock_add(struct wallet *w, const struct filteredblock *fb);
 
 #endif /* LIGHTNING_WALLET_WALLET_H */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -12,6 +12,7 @@
 #include <common/channel_config.h>
 #include <common/utxo.h>
 #include <common/wallet.h>
+#include <lightningd/bitcoind.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/invoice.h>
@@ -1024,6 +1025,11 @@ void wallet_block_remove(struct wallet *w, struct block *b);
 void wallet_blocks_rollback(struct wallet *w, u32 height);
 
 /**
+ * Return whether we have a block for the given height.
+ */
+bool wallet_have_block(struct wallet *w, u32 blockheight);
+
+/**
  * Mark an outpoint as spent, both in the owned as well as the UTXO set
  *
  * Given the outpoint (txid, outnum), and the blockheight, mark the
@@ -1158,5 +1164,12 @@ void free_unreleased_txs(struct wallet *w);
  * @return A tal_arr of wallet transactions
  */
 struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t *ctx);
+
+/**
+ * Add a filteredblock to the blocks and utxoset tables.
+ *
+ * This can be used to backfill the blocks and still unspent UTXOs that were before our wallet birth height.
+ */
+void wallet_filteredblock_add(struct wallet *w, struct filteredblock *fb);
 
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
As noted in #2756 we were not closing old channels, i.e., channels below our
wallet birth height.The cause was that the outpoints where not re-initialized
upon restart, since we didn't store the result of the txout lookup in the
database at all, hence not looking for spends.

This PR addresses this by extending the way we backfill the blocks in the
database on demand as we get `channel_announcements`. Instead of fetching the
block header, the list of transaction IDs and then checking the single txout,
we now fetch the raw block, filter out any uninteresting outpoint, i.e., not
outpoints that are not P2WSH, and then look up all of the remaining outpoints
in `bitcoind`s UTXO.

This is much more involved, since we process the entire blocks and look up all
of the outpoints, instead of just the one we suspect to be present (which we
were told about by the `channel_announcement`), but it results in a more
complete view of the current UTXO that might be of interest.

So what we do here is basically implement our own version of the dreaded IBD
:wink:, but there are a number of advantages:

 - We minimize the number of `getblockhash` and `getblock` calls, whereas
   these were called for each potential channel in the legacy version we now
   just call them once, minimizing the impact of someone flooding us with
   bogus `channel_announcement`s.
 - Should we ever truncate the `gossip_store` then sync is incredibly fast.
 - Should we get a trickle of `channel_announcement`s they don't result in a
   call to `bitcoind` at all if we've seen a prior announcement for the same
   blockheight.
 - This table can easily be seeded and bundled with the download if we ever
   chose to.

To put a measure on how slow it really is I ran a number of experiments:

 - `ex1` is the baseline experiment with the previous method of
   `getblockhash` + `getblock true` + `gettxout` only for the specific
   outpoint. This obviously is fast, since we don't parse the entire block,
   and just fetch a single `txout`.
 - `ex2` is the implementation of `getfilteredblock` but without writing to
   the database, and therefore without looking up outpoints in the DB
   either. This has to be worse since we do a lot more work for each
   announcement but don't get any of the benefit.
 - `ex3` is the implementation with the lookup and storing the block and
   outpoints in the DB. Should be slightly better, but most requests are
   already queued before we get the results and could make use of the previous
   results.
 - `ex4` adds queuing of requests. The main goal is to reduce the pressure on
   `bitcoind`, but it also clears all pending requests for the same block once
   we get a result.
 - `ex5` gets up to 22k channels and then restarts to test how well resuming
   works if we nuke the `gossip_store` inbetween restarts. It catches right up
   in <30 seconds and continues from there.

The plot below shows the various times to catch up with the 32k channels in
the network starting from a fresh `--lightning-dir`:

![getfiltered-benchmarks](https://user-images.githubusercontent.com/120117/62565503-38875600-b887-11e9-8e56-e74412810d06.png)

([plot source][gist])

We could potentiall parallelize the `gettxout` calls again, keeping the
overall `getfilteredblock` concurrency limited, to avoid duplicate work. One
final consideration that is in favor of limiting the concurrency of
`getfilteredblock` is the fact that the two initial calls (`getblockhash` and
`getblock`) have a high call priority and may crowd out other, more important,
calls such as our blockchain head tracking. I didn't want to expose the
priority in those calls, but that might also be an option for later, such that
the head tailing can skip the backfill queue.

Closes #2756 

[gist]: https://gist.github.com/cdecker/7747f9f42dd3e4ffa9621d6a54cf7644