### PR TITLE
Bitcoin syncing checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ changes.
 - channeld: ignore, and simply try reconnecting if lnd sends "sync error".
 - Protocol: we now correctly ignore unknown odd messages.
 - wallet: We will now backfill blocks below our wallet start height on demand when we require them to verify gossip messages. This fixes an issue where we would not remove channels on spend that were opened below that start height because we weren't tracking the funding output.
+- Detect when we're still syncing with bitcoin network: don't send or receive
+  HTLCs or allow `fundchannel`.
 
 ### Security
 

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -40,6 +40,7 @@
 #define FUND_CANNOT_AFFORD              301
 #define FUND_OUTPUT_IS_DUST             302
 #define FUNDING_BROADCAST_FAIL          303
+#define FUNDING_STILL_SYNCING_BITCOIN   304
 
 /* Errors from `invoice` command */
 #define INVOICE_LABEL_ALREADY_EXISTS	900

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-fundchannel
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/24/2019
+.\"      Date: 08/07/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-FUNDCHANN" "7" "06/07/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-FUNDCHANN" "7" "08/07/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -108,6 +108,17 @@ The following error codes may occur:
 .IP \(bu 2.3
 .\}
 303\&. Broadcasting of the funding transaction failed, the internal call to bitcoin\-cli returned with an error\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+304\&. We\(cqre still syncing with the bitcoin network\&. Retry later\&.
 .RE
 .sp
 Failure may also occur if \fBlightningd\fR and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc\&.)\&.

--- a/doc/lightning-fundchannel.7.txt
+++ b/doc/lightning-fundchannel.7.txt
@@ -62,6 +62,7 @@ The following error codes may occur:
 * 302. The output amount is too small, and would be considered dust.
 * 303. Broadcasting of the funding transaction failed, the internal call to
        bitcoin-cli returned with an error.
+* 304. We're still syncing with the bitcoin network.  Retry later.
 
 Failure may also occur if *lightningd* and the peer cannot agree on channel
 parameters (funding limits, channel reserves, fees, etc.).

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -43,6 +43,9 @@ struct bitcoind {
 	/* Main lightningd structure */
 	struct lightningd *ld;
 
+	/* Is bitcoind synced?  If not, we retry. */
+	bool synced;
+
 	/* How many high/low prio requests are we running (it's ratelimited) */
 	size_t num_requests[BITCOIND_NUM_PRIO];
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1279,6 +1279,11 @@ static struct command_result *json_fund_channel_start(struct command *cmd,
 				    "Feerate below feerate floor");
 	}
 
+	if (!topology_synced(cmd->ld->topology)) {
+		return command_fail(cmd, FUNDING_STILL_SYNCING_BITCOIN,
+				    "Still syncing with bitcoin network");
+	}
+
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
 		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
@@ -1369,6 +1374,11 @@ static struct command_result *json_fund_channel(struct command *cmd,
 	if (*feerate_per_kw < feerate_floor()) {
 		return command_fail(cmd, LIGHTNINGD,
 				    "Feerate below feerate floor");
+	}
+
+	if (!topology_synced(cmd->ld->topology)) {
+		return command_fail(cmd, FUNDING_STILL_SYNCING_BITCOIN,
+				    "Still syncing with bitcoin network");
 	}
 
 	peer = peer_by_id(cmd->ld, id);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1480,6 +1480,11 @@ static struct command_result *json_getinfo(struct command *cmd,
 				wallet_total_forward_fees(cmd->ld->wallet),
 				"msatoshi_fees_collected",
 				"fees_collected_msat");
+
+    if (!cmd->ld->topology->bitcoind->synced)
+	    json_add_string(response, "warning_bitcoind_sync",
+			    "Bitcoind is not up-to-date with network.");
+
     return command_success(cmd, response);
 }
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1484,6 +1484,9 @@ static struct command_result *json_getinfo(struct command *cmd,
     if (!cmd->ld->topology->bitcoind->synced)
 	    json_add_string(response, "warning_bitcoind_sync",
 			    "Bitcoind is not up-to-date with network.");
+    else if (!topology_synced(cmd->ld->topology))
+	    json_add_string(response, "warning_lightningd_sync",
+			    "Still loading latest blocks from bitcoind.");
 
     return command_success(cmd, response);
 }

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -449,6 +449,12 @@ enum onion_type send_htlc_out(struct channel *out,
 		return WIRE_TEMPORARY_CHANNEL_FAILURE;
 	}
 
+	if (!topology_synced(out->peer->ld->topology)) {
+		log_info(out->log, "Attempt to send HTLC but still syncing"
+			 " with bitcoin network");
+		return WIRE_TEMPORARY_CHANNEL_FAILURE;
+	}
+
 	/* Make peer's daemon own it, catch if it dies. */
 	hout = new_htlc_out(out->owner, out, amount, cltv,
 			    payment_hash, onion_routing_packet, in == NULL, in);

--- a/tests/btcproxy.py
+++ b/tests/btcproxy.py
@@ -40,9 +40,13 @@ class BitcoinRpcProxy(object):
 
         # If we have set a mock for this method reply with that instead of
         # forwarding the request.
-        if method in self.mocks and type(method) == dict:
+        if method in self.mocks and type(self.mocks[method]) == dict:
+            ret = {}
+            ret['id'] = r['id']
+            ret['error'] = None
+            ret['result'] = self.mocks[method]
             self.mock_counts[method] += 1
-            return self.mocks[method]
+            return ret
         elif method in self.mocks and callable(self.mocks[method]):
             self.mock_counts[method] += 1
             return self.mocks[method](r)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -122,7 +122,7 @@ def test_bitcoin_ibd(node_factory, bitcoind):
     l1 = node_factory.get_node(start=False)
     l1.daemon.rpcproxy.mock_rpc('getblockchaininfo', info)
 
-    l1.start()
+    l1.start(wait_for_bitcoind_sync=False)
 
     # This happens before the Starting message start() waits for.
     assert l1.daemon.is_in_log('Waiting for initial block download')
@@ -153,7 +153,7 @@ def test_lightningd_still_loading(node_factory, bitcoind, executor):
         }
 
     # Start it, establish channel, get extra funds.
-    l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})
+    l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True, 'wait_for_bitcoind_sync': False})
     # Extra funds, for second channel attempt.
     bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'], 1.0)
     # Balance l1<->l2 channel
@@ -173,7 +173,7 @@ def test_lightningd_still_loading(node_factory, bitcoind, executor):
     slow_blockid = bitcoind.rpc.getblockhash(bitcoind.rpc.getblockcount())
     l1.daemon.rpcproxy.mock_rpc('getblock', mock_getblock)
 
-    l1.start()
+    l1.start(wait_for_bitcoind_sync=False)
 
     # It will warn about being out-of-sync.
     assert 'warning_bitcoind_sync' not in l1.rpc.getinfo()

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -524,6 +524,13 @@ void subd_req_(const tal_t *ctx UNNEEDED,
 /* Generated stub for subd_send_msg */
 void subd_send_msg(struct subd *sd UNNEEDED, const u8 *msg_out UNNEEDED)
 { fprintf(stderr, "subd_send_msg called!\n"); abort(); }
+/* Generated stub for topology_add_sync_waiter_ */
+void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
+			       struct chain_topology *topo UNNEEDED,
+			       void (*cb)(struct chain_topology *topo UNNEEDED,
+					  void *arg) UNNEEDED,
+			       void *arg UNNEEDED)
+{ fprintf(stderr, "topology_add_sync_waiter_ called!\n"); abort(); }
 /* Generated stub for towire_channel_dev_memleak */
 u8 *towire_channel_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channel_dev_memleak called!\n"); abort(); }


### PR DESCRIPTION
This adds warning fields in getinfo, as well as preventing obviously-problematic operations when we're not synced.  We assume once we're synced, we stay synced, however.

Fixes: #2770 
