### PR TITLE
lightningd: don't say 'killing channel' when HTLC times out.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -421,10 +421,10 @@ static void htlc_offer_timeout(struct channel *channel)
 		return;
 
 	log_unusual(channel->owner->log,
-		    "Adding HTLC too slow: killing channel");
+		    "Adding HTLC too slow: killing connection");
 	tal_free(channel->owner);
 	channel_set_billboard(channel, false,
-			      "Adding HTLC timed out: killed channel");
+			      "Adding HTLC timed out: killed connection");
 }
 
 enum onion_type send_htlc_out(struct channel *out,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -936,7 +936,7 @@ def test_htlc_send_timeout(node_factory, bitcoind):
     assert not l2.daemon.is_in_log(r'channeld.*:\[IN\] 0013')
     assert not l2.daemon.is_in_log(r'channeld.*:\[OUT\] 0084')
     # L2 killed the channel with l3 because it was too slow.
-    l2.daemon.wait_for_log('channeld-{}.*Adding HTLC too slow: killing channel'.format(l3.info['id']))
+    l2.daemon.wait_for_log('channeld-{}.*Adding HTLC too slow: killing connection'.format(l3.info['id']))
 
 
 def test_ipv4_and_ipv6(node_factory):


### PR DESCRIPTION
We're actually only killing the connection.  I saw this in my logs, but it was all OK.
