### PR TITLE
cli: restore 0.7.0-style whitespace printing.

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -337,7 +337,7 @@ static void print_json(const char *str, const jsmntok_t *tok, const char *indent
 			else
 				printf(",\n%s", next_indent);
 			print_json(str, t, next_indent);
-			printf(" : ");
+			printf(": ");
 			print_json(str, t + 1, next_indent);
 			first = false;
 		}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -658,6 +658,20 @@ def test_cli(node_factory):
     j = json.loads(out)
     assert only_one(j['invoices'])['label'] == 'l"[]{}'
 
+    # For those using shell scripts (you know who you are Rene), make sure we're maintaining whitespace
+    lines = [l for l in out.splitlines() if '"bolt11"' not in l and '"payment_hash"' not in l and '"expires_at"' not in l]
+    assert lines == ['{',
+                     '   "invoices": [',
+                     '      {',
+                     r'         "label": "l\"[]{}",',
+                     '         "msatoshi": 123000,',
+                     '         "amount_msat": "123000msat",',
+                     '         "status": "unpaid",',
+                     r'         "description": "d\"[]{}",',
+                     '      }',
+                     '   ]',
+                     '}']
+
 
 def test_daemon_option(node_factory):
     """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -330,7 +330,7 @@ def test_utf8_passthrough(node_factory, executor):
                                    .format(l1.daemon.lightning_dir),
                                    'utf8', 'ナンセンス 1杯']).decode('utf-8')
     assert '\\u' not in out
-    assert out == '{\n   "utf8" : "ナンセンス 1杯"\n}\n'
+    assert out == '{\n   "utf8": "ナンセンス 1杯"\n}\n'
 
 
 def test_invoice_payment_hook(node_factory):


### PR DESCRIPTION
@renepickhardt has a shell script we broke (see https://github.com/renepickhardt/lightning-helpers/blob/master/listfunds/listfunds.sh).  While we still produce perfectly valid JSON, we should not gratuitously change tool output.

Plus, I prefer the missing space before the ':'.

I've tested that his script now works again.