### PR TITLE
Some very tiny changes 

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -69,7 +69,7 @@ alias bt-cli='bitcoin-cli -regtest'
 start_ln() {
 	# Start bitcoind in the background
 	test -f "$PATH_TO_BITCOIN/regtest/bitcoind.pid" || \
-		bitcoind -daemon -regtest
+		bitcoind -daemon -regtest -txindex
 
 	# Start the lightning nodes
 	test -f /tmp/l1-regtest/lightningd-regtest.pid || \

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -368,7 +368,7 @@ int main(int argc, char *argv[])
 	if (!per_commit_point(&localseed, &local_per_commit_point, commitnum))
 		errx(1, "Bad deriving local per-commitment-point");
 
-	local_txs = channel_txs(chainparams, NULL, &htlcmap, &wscripts, channel,
+	local_txs = channel_txs(NULL, chainparams, &htlcmap, &wscripts, channel,
 				&local_per_commit_point, commitnum, LOCAL);
 
 	printf("## local_commitment\n"
@@ -469,7 +469,7 @@ int main(int argc, char *argv[])
 	/* Create the remote commitment tx */
 	if (!per_commit_point(&remoteseed, &remote_per_commit_point, commitnum))
 		errx(1, "Bad deriving remote per-commitment-point");
-	remote_txs = channel_txs(chainparams, NULL, &htlcmap, &wscripts, channel,
+	remote_txs = channel_txs(NULL, chainparams, &htlcmap, &wscripts, channel,
 				 &remote_per_commit_point, commitnum, REMOTE);
 	remote_txs[0]->input_amounts[0]
 		= tal_dup(remote_txs[0], struct amount_sat, &funding_amount);


### PR DESCRIPTION
Fixes a parameter mis-ordering in `mkcommit`; adds a flag to the `contrib/startup_regtest.sh`.