### PR TITLE
fundchannel_start crash: Add a test

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -920,6 +920,7 @@ def test_funding_cancel_race(node_factory, bitcoind, executor):
 def test_funding_external_wallet(node_factory, bitcoind):
     l1 = node_factory.get_node()
     l2 = node_factory.get_node()
+    l3 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     assert(l1.rpc.listpeers()['peers'][0]['id'] == l2.info['id'])
@@ -965,6 +966,11 @@ def test_funding_external_wallet(node_factory, bitcoind):
         node.daemon.wait_for_log(r'State changed from CHANNELD_AWAITING_LOCKIN to CHANNELD_NORMAL')
         channel = node.rpc.listpeers()['peers'][0]['channels'][0]
         assert amount * 1000 == channel['msatoshi_total']
+
+    # Test that we don't crash if peer disconnects after fundchannel_start
+    l2.connect(l3)
+    l2.rpc.fundchannel_start(l3.info["id"], amount)
+    l3.rpc.close(l2.info["id"])
 
 
 def test_lockin_between_restart(node_factory, bitcoind):


### PR DESCRIPTION
As per https://github.com/ElementsProject/lightning/pull/2931#pullrequestreview-273008099.
This tests using the reproducible informations given by @rsbondi in https://github.com/ElementsProject/lightning/issues/2831#issuecomment-517023112