### PR TITLE
lightingd: increase listen queue on rpc socket.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -950,7 +950,7 @@ void jsonrpc_listen(struct jsonrpc *jsonrpc, struct lightningd *ld)
 		err(1, "Binding rpc socket to '%s'", rpc_filename);
 	umask(old_umask);
 
-	if (listen(fd, 1) != 0)
+	if (listen(fd, 128) != 0)
 		err(1, "Listening on '%s'", rpc_filename);
 	jsonrpc->rpc_listener = io_new_listener(
 		ld->rpc_filename, fd, incoming_jcon_connected, ld);


### PR DESCRIPTION
I suspect multiple plugins trying to connect at the same
time are overrunning the 1-deep listen queue:

From man listen(2):

       The backlog argument defines the maximum length to which the  queue  of
       pending  connections  for sockfd may grow.  If a connection request ar‐
       rives when the queue is full, the client may receive an error  with  an
       indication  of ECONNREFUSED

Fixes: #2922
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>