### PR TITLE
Cleanup for `payment_hash`

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -49,7 +49,7 @@ static void json_add_invoice(struct json_stream *response,
 {
 	json_add_escaped_string(response, "label", inv->label);
 	json_add_string(response, "bolt11", inv->bolt11);
-	json_add_hex(response, "payment_hash", &inv->rhash, sizeof(inv->rhash));
+	json_add_sha256(response, "payment_hash", &inv->rhash);
 	if (inv->msat)
 		json_add_amount_msat_compat(response, *inv->msat,
 					    "msatoshi", "amount_msat");
@@ -514,8 +514,7 @@ static void gossipd_incoming_channels_reply(struct subd *gossipd,
 	details = wallet_invoice_details(info, wallet, invoice);
 
 	response = json_stream_success(info->cmd);
-	json_add_hex(response, "payment_hash", &details->rhash,
-		     sizeof(details->rhash));
+	json_add_sha256(response, "payment_hash", &details->rhash);
 	json_add_u64(response, "expires_at", details->expiry_time);
 	json_add_string(response, "bolt11", details->bolt11);
 
@@ -1083,9 +1082,8 @@ static struct command_result *json_decodepay(struct command *cmd,
                 json_add_escaped_string(response, "description", take(esc));
 	}
         if (b11->description_hash)
-                json_add_hex(response, "description_hash",
-                             b11->description_hash,
-                             sizeof(*b11->description_hash));
+                json_add_sha256(response, "description_hash",
+                                b11->description_hash);
 	json_add_num(response, "min_final_cltv_expiry",
 		     b11->min_final_cltv_expiry);
         if (tal_count(b11->fallbacks)) {
@@ -1145,8 +1143,7 @@ static struct command_result *json_decodepay(struct command *cmd,
                 json_array_end(response);
         }
 
-	json_add_hex(response, "payment_hash",
-                     &b11->payment_hash, sizeof(b11->payment_hash));
+	json_add_sha256(response, "payment_hash", &b11->payment_hash);
 
 	json_add_string(response, "signature",
                         type_to_string(cmd, secp256k1_ecdsa_signature,

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -472,3 +472,9 @@ void json_add_secret(struct json_stream *response, const char *fieldname,
 {
 	json_add_hex(response, fieldname, secret, sizeof(struct secret));
 }
+
+void json_add_sha256(struct json_stream *result, const char *fieldname,
+		     const struct sha256 *hash)
+{
+	json_add_hex(result, fieldname, hash, sizeof(*hash));
+}

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -214,4 +214,7 @@ void json_add_timeabs(struct json_stream *result, const char *fieldname,
 void json_add_time(struct json_stream *result, const char *fieldname,
 			  struct timespec ts);
 
+void json_add_sha256(struct json_stream *result, const char *fieldname,
+		     const struct sha256 *hash);
+
 #endif /* LIGHTNING_LIGHTNINGD_JSON_H */

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -287,7 +287,7 @@ static struct command_result *json_dev(struct command *cmd UNUSED,
 		/* Hash in place. */
 		sha256(secret, secret, sizeof(*secret));
 		response = json_stream_success(cmd);
-		json_add_hex(response, "rhash", secret, sizeof(*secret));
+		json_add_sha256(response, "rhash", secret);
 		return command_success(cmd, response);
 	}
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -120,8 +120,7 @@ void notify_forward_event(struct lightningd *ld,
 		cur->msat_out = AMOUNT_MSAT(0);
 		cur->fee = AMOUNT_MSAT(0);
 	}
-	cur->payment_hash = tal(cur, struct sha256_double);
-	cur->payment_hash->sha = in->payment_hash;
+	cur->payment_hash = tal_dup(cur, struct sha256, &in->payment_hash);
 	cur->status = state;
 	cur->failcode = failcode;
 	cur->received_time = in->received_time;

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -76,7 +76,7 @@ json_add_payment_fields(struct json_stream *response,
 			const struct wallet_payment *t)
 {
 	json_add_u64(response, "id", t->id);
-	json_add_hex(response, "payment_hash", &t->payment_hash, sizeof(t->payment_hash));
+	json_add_sha256(response, "payment_hash", &t->payment_hash);
 	json_add_node_id(response, "destination", &t->destination);
 	json_add_amount_msat_compat(response, t->msatoshi,
 				    "msatoshi", "amount_msat");

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -479,8 +479,7 @@ static void json_add_htlcs(struct lightningd *ld,
 		json_add_amount_msat_compat(response, hin->msat,
 					    "msatoshi", "amount_msat");
 		json_add_u64(response, "expiry", hin->cltv_expiry);
-		json_add_hex(response, "payment_hash",
-			     &hin->payment_hash, sizeof(hin->payment_hash));
+		json_add_sha256(response, "payment_hash", &hin->payment_hash);
 		json_add_string(response, "state",
 				htlc_state_name(hin->hstate));
 		if (htlc_is_trimmed(REMOTE, hin->msat, local_feerate,
@@ -501,8 +500,7 @@ static void json_add_htlcs(struct lightningd *ld,
 		json_add_amount_msat_compat(response, hout->msat,
 					    "msatoshi", "amount_msat");
 		json_add_u64(response, "expiry", hout->cltv_expiry);
-		json_add_hex(response, "payment_hash",
-			     &hout->payment_hash, sizeof(hout->payment_hash));
+		json_add_sha256(response, "payment_hash", &hout->payment_hash);
 		json_add_string(response, "state",
 				htlc_state_name(hout->hstate));
 		if (htlc_is_trimmed(LOCAL, hout->msat, local_feerate,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -734,7 +734,7 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	json_add_amount_msat_only(s, "amount", hin->msat);
 	json_add_u32(s, "cltv_expiry", expiry);
 	json_add_s32(s, "cltv_expiry_relative", expiry - blockheight);
-	json_add_hex(s, "payment_hash", hin->payment_hash.u.u8, sizeof(hin->payment_hash));
+	json_add_sha256(s, "payment_hash", &hin->payment_hash);
 	json_object_end(s);
 }
 
@@ -2151,9 +2151,7 @@ void json_format_forwarding_object(struct json_stream *response,
 
 	/* See 6d333f16cc0f3aac7097269bf0985b5fa06d59b4: we may have deleted HTLC. */
 	if (cur->payment_hash)
-		json_add_hex(response, "payment_hash",
-					    cur->payment_hash,
-					    sizeof(*cur->payment_hash));
+		json_add_sha256(response, "payment_hash", cur->payment_hash);
 	json_add_short_channel_id(response, "in_channel", &cur->channel_in);
 
 	/* This can be unknown if we failed before channel lookup */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -166,6 +166,10 @@ void json_add_escaped_string(struct json_stream *result UNNEEDED,
 void json_add_hex(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  const void *data UNNEEDED, size_t len UNNEEDED)
 { fprintf(stderr, "json_add_hex called!\n"); abort(); }
+/* Generated stub for json_add_sha256 */
+void json_add_sha256(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		     const struct sha256 *hash UNNEEDED)
+{ fprintf(stderr, "json_add_sha256 called!\n"); abort(); }
 /* Generated stub for json_add_hex_talarr */
 void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 			 const char *fieldname UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -243,6 +243,10 @@ void json_add_bool(struct json_stream *result UNNEEDED, const char *fieldname UN
 void json_add_hex(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  const void *data UNNEEDED, size_t len UNNEEDED)
 { fprintf(stderr, "json_add_hex called!\n"); abort(); }
+/* Generated stub for json_add_sha256 */
+void json_add_sha256(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		     const struct sha256 *hash UNNEEDED)
+{ fprintf(stderr, "json_add_sha256 called!\n"); abort(); }
 /* Generated stub for json_add_hex_talarr */
 void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 			 const char *fieldname UNNEEDED,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2851,8 +2851,8 @@ const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
 		}
 
 		if (sqlite3_column_type(stmt, 3) != SQLITE_NULL) {
-			cur->payment_hash = tal(ctx, struct sha256_double);
-			sqlite3_column_sha256_double(stmt, 3, cur->payment_hash);
+			cur->payment_hash = tal(ctx, struct sha256);
+			sqlite3_column_sha256(stmt, 3, cur->payment_hash);
 		} else {
 			cur->payment_hash = NULL;
 		}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -190,7 +190,7 @@ static inline const char* forward_status_name(enum forward_status status)
 struct forwarding {
 	struct short_channel_id channel_in, channel_out;
 	struct amount_msat msat_in, msat_out, fee;
-	struct sha256_double *payment_hash;
+	struct sha256 *payment_hash;
 	enum forward_status status;
 	enum onion_type failcode;
 	struct timeabs received_time;


### PR DESCRIPTION
As [discussed](https://github.com/ElementsProject/lightning/pull/2799#discussion_r301034098), now the `payment_hash` use `struct sha256`.