### PR TITLE
Plugin: Use `autodata` to register notifications

### DIFF
--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -5,7 +5,6 @@
 #include <lightningd/peer_htlcs.h>
 
 const char *notification_topics[] = {
-	"invoice_payment",
 	"channel_opened",
 	"forward_event"
 };
@@ -119,17 +118,33 @@ void notify_warning(struct lightningd *ld, struct log_entry *l)
 	plugins_notify(ld->plugins, take(n));
 }
 
+static void invoice_payment_notification_serialize(struct json_stream *stream,
+						   struct amount_msat amount,
+						   struct preimage preimage,
+						   const struct json_escape *label)
+{
+	json_object_start(stream, "invoice_payment");
+	json_add_string(stream, "msat",
+			type_to_string(tmpctx, struct amount_msat, &amount));
+	json_add_hex(stream, "preimage", &preimage, sizeof(preimage));
+	json_add_escaped_string(stream, "label", label);
+	json_object_end(stream);
+}
+
+REGISTER_NOTIFICATION(invoice_payment,
+		      invoice_payment_notification_serialize)
+
 void notify_invoice_payment(struct lightningd *ld, struct amount_msat amount,
 			    struct preimage preimage, const struct json_escape *label)
 {
-	struct jsonrpc_notification *n =
-		jsonrpc_notification_start(NULL, "invoice_payment");
-	json_object_start(n->stream, "invoice_payment");
-	json_add_string(n->stream, "msat",
-			type_to_string(tmpctx, struct amount_msat, &amount));
-	json_add_hex(n->stream, "preimage", &preimage, sizeof(preimage));
-	json_add_escaped_string(n->stream, "label", label);
-	json_object_end(n->stream);
+	void (*serialize)(struct json_stream *,
+			  struct amount_msat,
+			  struct preimage,
+			  const struct json_escape *) = invoice_payment_notification_gen.serialize;
+
+	struct jsonrpc_notification *n
+		= jsonrpc_notification_start(NULL, invoice_payment_notification_gen.topic);
+	serialize(n->stream, amount, preimage, label);
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -5,7 +5,6 @@
 #include <lightningd/peer_htlcs.h>
 
 const char *notification_topics[] = {
-	"warning",
 	"invoice_payment",
 	"channel_opened",
 	"forward_event"
@@ -85,25 +84,37 @@ void notify_disconnect(struct lightningd *ld, struct node_id *nodeid)
 
 /*'warning' is based on LOG_UNUSUAL/LOG_BROKEN level log
  *(in plugin module, they're 'warn'/'error' level). */
-void notify_warning(struct lightningd *ld, struct log_entry *l)
+static void warning_notification_serialize(struct json_stream *stream,
+					   struct log_entry *l)
 {
-	struct jsonrpc_notification *n =
-	    jsonrpc_notification_start(NULL, "warning");
-	json_object_start(n->stream, "warning");
+	json_object_start(stream, "warning");
 	/* Choose "BROKEN"/"UNUSUAL" to keep consistent with the habit
 	 * of plugin. But this may confuses the users who want to 'getlog'
 	 * with the level indicated by notifications. It is the duty of a
 	 * plugin to eliminate this misunderstanding.
 	 */
-	json_add_string(n->stream, "level",
+	json_add_string(stream, "level",
 			l->level == LOG_BROKEN ? "error"
 			: "warn");
 	/* unsuaul/broken event is rare, plugin pay more attentions on
 	 * the absolute time, like when channels failed. */
-	json_add_time(n->stream, "time", l->time.ts);
-	json_add_string(n->stream, "source", l->prefix);
-	json_add_string(n->stream, "log", l->log);
-	json_object_end(n->stream); /* .warning */
+	json_add_time(stream, "time", l->time.ts);
+	json_add_string(stream, "source", l->prefix);
+	json_add_string(stream, "log", l->log);
+	json_object_end(stream); /* .warning */
+}
+
+REGISTER_NOTIFICATION(warning,
+		      warning_notification_serialize);
+
+void notify_warning(struct lightningd *ld, struct log_entry *l)
+{
+	void (*serialize)(struct json_stream *,
+			  struct log_entry *) = warning_notification_gen.serialize;
+
+	struct jsonrpc_notification *n
+		= jsonrpc_notification_start(NULL, warning_notification_gen.topic);
+	serialize(n->stream, l);
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -13,8 +13,26 @@ const char *notification_topics[] = {
 	"forward_event"
 };
 
+static struct notification *find_notification_by_topic(const char* topic)
+{
+	static struct notification **notilist = NULL;
+	static size_t num_notis;
+	if (!notilist)
+		notilist = autodata_get(notifications, &num_notis);
+
+	for (size_t i=0; i<num_notis; i++)
+		if (streq(notilist[i]->topic, topic))
+			return notilist[i];
+	return NULL;
+}
+
 bool notifications_have_topic(const char *topic)
 {
+	struct notification *noti = find_notification_by_topic(topic);
+	if (noti)
+		return true;
+
+	/* TODO: Remove this block after making all notifications registered. */
 	for (size_t i=0; i<ARRAY_SIZE(notification_topics); i++)
 		if (streq(topic, notification_topics[i]))
 			return true;
@@ -131,3 +149,7 @@ void notify_forward_event(struct lightningd *ld,
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }
+
+/* TODO: It's a dummy notification. Will be removed when we have a 'real' one
+ * in this file. */
+REGISTER_JSON_INTERNAL_COMMAND(hello_notification, NULL, void *);

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <bitcoin/short_channel_id.h>
 #include <bitcoin/tx.h>
+#include <ccan/autodata/autodata.h>
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/time/time.h>
 #include <common/amount.h>
@@ -16,6 +17,22 @@
 #include <wire/gen_onion_wire.h>
 
 bool notifications_have_topic(const char *topic);
+
+struct notification {
+	const char *topic;
+	/* the serialization interface */
+	void *serialize;
+};
+
+AUTODATA_TYPE(notifications, struct notification);
+
+/* FIXME: Find a way to avoid back-to-back declaration and definition */
+#define REGISTER_NOTIFICATION(topic, serialize)                                  \
+	struct notification topic##_notification_gen = {                         \
+		stringify(topic),                                                \
+		serialize,                                                       \
+	};                                                                       \
+	AUTODATA(notifications, &topic##_notification_gen);
 
 void notify_connect(struct lightningd *ld, struct node_id *nodeid,
 		    struct wireaddr_internal *addr);

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -73,8 +73,9 @@ void htlcs_resubmit(struct lightningd *ld, struct htlc_in_map *unprocessed);
 void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage);
 void fail_htlc(struct htlc_in *hin, enum onion_type failcode);
 
-/* This json process will be both used in 'notify_forward_event()'
- * and 'listforwardings_add_forwardings()'*/
+/* This json process will be used as the serialize method for
+ * forward_event_notification_gen and be used in
+ * `listforwardings_add_forwardings()`. */
 void json_format_forwarding_object(struct json_stream *response, const char *fieldname,
 				   const struct forwarding *cur);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */


### PR DESCRIPTION
I remember @rustyrussell  [said](https://github.com/ElementsProject/lightning/pull/2799#discussion_r308490161),  we should avoid the extra line change in `const char *notification_topics[]` when we plan to add new notifications(in fact, I want to add `sendpay_success` and `sendpay_failure` notifications).

I guess using `autodata` to register notifications is an available way and I rewrite notification interfaces.