### PR TITLE
plugin: `sendpay_success` and `sendpay_failure` notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bolt11: support for parsing feature bits (field `9`).
 
 - Protocol: we now retransmit `funding_locked` upon reconnection while closing if there was no update
+- Plugin: new notifications `sendpay_success` and `sendpay_failure`.
+
 ### Changed
 
 - JSON API: `txprepare` now uses `outputs` as parameter other than `destination` and `satoshi`

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -384,6 +384,68 @@ or
    only `settled` and `failed` case contain `resolved_time`;
  - The `failcode` and `failreason` are defined in [BOLT 4][bolt4-failure-codes].
 
+#### `sendpay_success`
+
+A notification for topic `sendpay_success` is sent every time a sendpay
+success(with `complete` status). The json is same as the return value of
+command `sendpay`/`waitsendpay` when these cammand succeeds.
+
+```json
+{
+	"sendpay_success": {
+  "id": 1,
+  "payment_hash": "5c85bf402b87d4860f4a728e2e58a2418bda92cd7aea0ce494f11670cfbfb206",
+  "destination": "035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d",
+  "msatoshi": 100000000,
+  "amount_msat": "100000000msat",
+  "msatoshi_sent": 100001001,
+  "amount_sent_msat": "100001001msat",
+  "created_at": 1561390572,
+  "status": "complete",
+  "payment_preimage": "9540d98095fd7f37687ebb7759e733934234d4f934e34433d4998a37de3733ee"
+  }
+}
+```
+`sendpay` doesn't wait for the result of sendpay and `waitsendpay`
+returns the result of sendpay in specified time or timeout, but
+`sendpay_success` will always return the result anytime when sendpay
+successes if is was subscribed.
+
+#### `sendpay_failure`
+
+A notification for topic `sendpay_failure` is sent every time a sendpay
+success(with `failed` status). The json is same as the return value of
+command `sendpay`/`waitsendpay` when this cammand fails.
+
+```json
+{
+  "sendpay_failure": {
+  "code": 204,
+  "message": "failed: WIRE_UNKNOWN_NEXT_PEER (reply from remote)",
+  "data": {
+    "id": 2,
+    "payment_hash": "9036e3bdbd2515f1e653cb9f22f8e4c49b73aa2c36e937c926f43e33b8db8851",
+    "destination": "035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d",
+    "msatoshi": 100000000,
+    "amount_msat": "100000000msat",
+    "msatoshi_sent": 100001001,
+    "amount_sent_msat": "100001001msat",
+    "created_at": 1561395134,
+    "status": "failed",
+    "erring_index": 1,
+    "failcode": 16394,
+    "failcodename": "WIRE_UNKNOWN_NEXT_PEER",
+    "erring_node": "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59",
+    "erring_channel": "103x2x1",
+    "erring_direction": 0
+    }
+  }
+}
+```
+`sendpay` doesn't wait for the result of sendpay and `waitsendpay`
+returns the result of sendpay in specified time or timeout, but
+`sendpay_failure` will always return the result anytime when sendpay
+fails if is was subscribed.
 
 ## Hooks
 

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -227,3 +227,27 @@ void notify_forward_event(struct lightningd *ld,
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }
+
+static void sendpay_success_notification_serialize(struct json_stream *stream,
+						   const struct wallet_payment *payment)
+{
+	json_object_start(stream, "sendpay_success");
+	json_add_payment_fields(stream, payment);
+	json_object_end(stream); /* .sendpay_success */
+}
+
+REGISTER_NOTIFICATION(sendpay_success,
+		      sendpay_success_notification_serialize);
+
+void notify_sendpay_success(struct lightningd *ld,
+			    const struct wallet_payment *payment)
+{
+	void (*serialize)(struct json_stream *,
+			  const struct wallet_payment *) = sendpay_success_notification_gen.serialize;
+
+	struct jsonrpc_notification *n =
+	    jsonrpc_notification_start(NULL, "sendpay_success");
+	serialize(n->stream, payment);
+	jsonrpc_notification_end(n);
+	plugins_notify(ld->plugins, take(n));
+}

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -58,4 +58,11 @@ void notify_forward_event(struct lightningd *ld,
 void notify_sendpay_success(struct lightningd *ld,
 			    const struct wallet_payment *payment);
 
+void notify_sendpay_failure(struct lightningd *ld,
+			    const struct wallet_payment *payment,
+			    int pay_errcode,
+			    const u8 *onionreply,
+			    const struct routing_failure *fail,
+			    char *errmsg);
+
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -12,6 +12,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/pay.h>
 #include <lightningd/plugin.h>
 #include <wallet/wallet.h>
 #include <wire/gen_onion_wire.h>
@@ -53,5 +54,8 @@ void notify_forward_event(struct lightningd *ld,
 			  enum forward_status state,
 			  enum onion_type failcode,
 			  struct timeabs *resolved_time);
+
+void notify_sendpay_success(struct lightningd *ld,
+			    const struct wallet_payment *payment);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -12,6 +12,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/notification.h>
 #include <lightningd/options.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/peer_htlcs.h>
@@ -113,6 +114,7 @@ static struct command_result *sendpay_success(struct command *cmd,
 
 	assert(payment->status == PAYMENT_COMPLETE);
 
+	notify_sendpay_success(cmd->ld, payment);
 	response = json_stream_success(cmd);
 	json_add_payment_fields(response, payment);
 	return command_success(cmd, response);
@@ -182,6 +184,13 @@ sendpay_fail(struct command *cmd,
 				 onion_type_name(fail->failcode),
 				 details);
 	}
+
+	notify_sendpay_failure(cmd->ld,
+			       payment,
+			       pay_errcode,
+			       onionreply,
+			       fail,
+			       errmsg);
 
 	data = json_stream_fail(cmd, pay_errcode,
 				errmsg);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -73,9 +73,8 @@ add_waitsendpay_waiter(struct lightningd *ld,
 }
 
 /* Outputs fields, not a separate object*/
-static void
-json_add_payment_fields(struct json_stream *response,
-			const struct wallet_payment *t)
+void json_add_payment_fields(struct json_stream *response,
+			     const struct wallet_payment *t)
 {
 	json_add_u64(response, "id", t->id);
 	json_add_sha256(response, "payment_hash", &t->payment_hash);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -531,7 +531,7 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 			    pay_errcode, hout->failuremsg, fail, failmsg);
 }
 
-/* Wait for a payment. If cmd is deleted, then json_waitsendpay_on_resolve
+/* Wait for a payment. If cmd is deleted, then wait_payment()
  * no longer be called.
  * Return callback if we called already, otherwise NULL. */
 static struct command_result *wait_payment(struct lightningd *ld,

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -142,10 +142,14 @@ json_add_routefail_info(struct json_stream *js,
 }
 
 void json_sendpay_fail_fields(struct json_stream *js,
+			      const struct wallet_payment *payment,
 			      int pay_errcode,
 			      const u8 *onionreply,
 			      const struct routing_failure *fail)
 {
+	/* "immediate_routing_failure" is before payment creation. */
+	if (payment)
+		json_add_payment_fields(js, payment);
 	if (pay_errcode == PAY_UNPARSEABLE_ONION)
 		json_add_hex_talarr(js, "onionreply", onionreply);
 	else
@@ -161,6 +165,7 @@ void json_sendpay_fail_fields(struct json_stream *js,
 /* onionreply used if pay_errcode == PAY_UNPARSEABLE_ONION */
 static struct command_result *
 sendpay_fail(struct command *cmd,
+	     const struct wallet_payment *payment,
 	     int pay_errcode,
 	     const u8 *onionreply,
 	     const struct routing_failure *fail,
@@ -181,6 +186,7 @@ sendpay_fail(struct command *cmd,
 	data = json_stream_fail(cmd, pay_errcode,
 				errmsg);
 	json_sendpay_fail_fields(data,
+				 payment,
 				 pay_errcode,
 				 onionreply,
 				 fail);
@@ -202,6 +208,7 @@ json_sendpay_in_progress(struct command *cmd,
 
 static void tell_waiters_failed(struct lightningd *ld,
 				const struct sha256 *payment_hash,
+				const struct wallet_payment *payment,
 				int pay_errcode,
 				const u8 *onionreply,
 				const struct routing_failure *fail,
@@ -215,7 +222,8 @@ static void tell_waiters_failed(struct lightningd *ld,
 		if (!sha256_eq(payment_hash, &pc->payment_hash))
 			continue;
 
-		sendpay_fail(pc->cmd, pay_errcode, onionreply, fail, details);
+		sendpay_fail(pc->cmd, payment,
+			     pay_errcode, onionreply, fail, details);
 	}
 }
 
@@ -510,8 +518,8 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 				    failmsg,
 				    fail ? fail->channel_dir : 0);
 
-	tell_waiters_failed(ld, &hout->payment_hash, pay_errcode,
-			    hout->failuremsg, fail, failmsg);
+	tell_waiters_failed(ld, &hout->payment_hash, payment,
+			    pay_errcode, hout->failuremsg, fail, failmsg);
 }
 
 /* Wait for a payment. If cmd is deleted, then json_waitsendpay_on_resolve
@@ -567,7 +575,9 @@ static struct command_result *wait_payment(struct lightningd *ld,
 					    "Payment failure reason unknown");
 		} else if (failonionreply) {
 			/* failed to parse returned onion error */
-			return sendpay_fail(cmd, PAY_UNPARSEABLE_ONION,
+			return sendpay_fail(cmd,
+					    payment,
+					    PAY_UNPARSEABLE_ONION,
 					    failonionreply,
 					    NULL, faildetail);
 		} else {
@@ -583,6 +593,7 @@ static struct command_result *wait_payment(struct lightningd *ld,
 			/* FIXME: We don't store this! */
 			fail->msg = NULL;
 			return sendpay_fail(cmd,
+					    payment,
 					    faildestperm
 					    ? PAY_DESTINATION_PERM_FAIL
 					    : PAY_TRY_OTHER_ROUTE,
@@ -721,8 +732,8 @@ send_payment(struct lightningd *ld,
 						 &route[0].channel_id,
 						 &channel->peer->id);
 
-		return sendpay_fail(cmd, PAY_TRY_OTHER_ROUTE, NULL,
-				    fail, "First peer not ready");
+		return sendpay_fail(cmd, payment, PAY_TRY_OTHER_ROUTE,
+				    NULL, fail, "First peer not ready");
 	}
 
 	/* Copy channels used along the route. */

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_PAY_H
 #define LIGHTNING_LIGHTNINGD_PAY_H
 #include "config.h"
+#include <ccan/short_types/short_types.h>
 
 struct htlc_out;
 struct lightningd;
@@ -8,6 +9,7 @@ struct preimage;
 struct sha256;
 struct json_stream;
 struct wallet_payment;
+struct routing_failure;
 
 void payment_succeeded(struct lightningd *ld, struct htlc_out *hout,
 		       const struct preimage *rval);
@@ -21,5 +23,11 @@ void payment_store(struct lightningd *ld, const struct sha256 *payment_hash);
 /* This json will be also used in 'sendpay_success' notifictaion. */
 void json_add_payment_fields(struct json_stream *response,
 			     const struct wallet_payment *t);
+
+/* This json will be also used in 'sendpay_failure' notifictaion. */
+void json_sendpay_fail_fields(struct json_stream *js,
+			      int pay_errcode,
+			      const u8 *onionreply,
+			      const struct routing_failure *fail);
 
 #endif /* LIGHTNING_LIGHTNINGD_PAY_H */

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -6,6 +6,8 @@ struct htlc_out;
 struct lightningd;
 struct preimage;
 struct sha256;
+struct json_stream;
+struct wallet_payment;
 
 void payment_succeeded(struct lightningd *ld, struct htlc_out *hout,
 		       const struct preimage *rval);
@@ -15,5 +17,9 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 
 /* Inform payment system to save the payment. */
 void payment_store(struct lightningd *ld, const struct sha256 *payment_hash);
+
+/* This json will be also used in 'sendpay_success' notifictaion. */
+void json_add_payment_fields(struct json_stream *response,
+			     const struct wallet_payment *t);
 
 #endif /* LIGHTNING_LIGHTNINGD_PAY_H */

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -26,6 +26,7 @@ void json_add_payment_fields(struct json_stream *response,
 
 /* This json will be also used in 'sendpay_failure' notifictaion. */
 void json_sendpay_fail_fields(struct json_stream *js,
+			      const struct wallet_payment *t,
 			      int pay_errcode,
 			      const u8 *onionreply,
 			      const struct routing_failure *fail);

--- a/tests/plugins/sendpay_notifications.py
+++ b/tests/plugins/sendpay_notifications.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""This plugin is used to check that sendpay_success and sendpay_failure calls are working correctly.
+"""
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    plugin.success_list = []
+    plugin.failure_list = []
+
+
+@plugin.subscribe("sendpay_success")
+def notify_sendpay_success(plugin, sendpay_success):
+    plugin.log("receive a sendpay_success recored, id: {}, payment_hash: {}".format(sendpay_success['id'], sendpay_success['payment_hash']))
+    plugin.success_list.append(sendpay_success)
+
+
+@plugin.subscribe("sendpay_failure")
+def notify_sendpay_failure(plugin, sendpay_failure):
+    plugin.log("receive a sendpay_failure recored, id: {}, payment_hash: {}".format(sendpay_failure['data']['id'],
+               sendpay_failure['data']['payment_hash']))
+    plugin.failure_list.append(sendpay_failure)
+
+
+@plugin.method('listsendpays_plugin')
+def record_lookup(plugin):
+    return {'sendpay_success': plugin.success_list,
+            'sendpay_failure': plugin.failure_list}
+
+
+plugin.run()


### PR DESCRIPTION
Long long ago, @ZmnSCPxj [mentioned](https://github.com/ElementsProject/lightning/pull/2188#issuecomment-448423897) `sendpay_success` and `sendpay_failure` notifications.

My first thought was to combine these two case into one notification type, `sendpay_result`.
But I found the `json` fields are two different between `sendpay` success and failure, so finally I divided `sendpay_result` into `sendpay_success` and `sendpay_failure` again.

For these two notification type, I still use the original notification interface, because I'm not sure whether #2944 is valid.

~I pre-present these ideas here though I'll wait for 0.7.3 to add `CHANGELOG`,~