### PR TITLE
devtools: make clean should remove devtools/gen_print_onion_wire.[c,h,o]

### DIFF
--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -75,4 +75,4 @@ check-source: $(DEVTOOLS_SRC:%=check-src-include-order/%) $(DEVTOOLS_TOOLS_SRC:%
 clean: devtools-clean
 
 devtools-clean:
-	$(RM) $(DEVTOOLS_OBJS) $(DEVTOOLS_TOOL_OBJS) devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/gen_print_wire.[c,h,o]
+	$(RM) $(DEVTOOLS_OBJS) $(DEVTOOLS_TOOL_OBJS) devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/gen_print_wire.[c,h,o] devtools/gen_print_onion_wire.[c,h,o]


### PR DESCRIPTION
Reported-by: @JavierRSobrino
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>