### PR TITLE
ccan: update to fix shutdown slowness after plugin load.

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2484-ge16aa40b
+CCAN version: init-2486-g46cfc3ad

--- a/ccan/ccan/htable/htable.h
+++ b/ccan/ccan/htable/htable.h
@@ -76,6 +76,15 @@ bool htable_init_sized(struct htable *ht,
 		       void *priv, size_t size);
 
 /**
+ * htable_count - count number of entries in a hash table.
+ * @ht: the hash table
+ */
+static inline size_t htable_count(const struct htable *ht)
+{
+	return ht->elems;
+}
+
+/**
  * htable_clear - empty a hash table.
  * @ht: the hash table to clear
  *

--- a/ccan/ccan/htable/htable_type.h
+++ b/ccan/ccan/htable/htable_type.h
@@ -25,6 +25,9 @@
  *	void <name>_clear(struct <name> *);
  *	bool <name>_copy(struct <name> *dst, const struct <name> *src);
  *
+ * Count entries:
+ *	size_t <name>_count(const struct <name> *ht);
+ *
  * Add function only fails if we run out of memory:
  *	bool <name>_add(struct <name> *ht, const <type> *e);
  *
@@ -68,6 +71,10 @@
 						      size_t s)		\
 	{								\
 		return htable_init_sized(&ht->raw, name##_hash, NULL, s); \
+	}								\
+	static inline UNNEEDED size_t name##_count(const struct name *ht) \
+	{								\
+		return htable_count(&ht->raw);				\
 	}								\
 	static inline UNNEEDED void name##_clear(struct name *ht)	\
 	{								\

--- a/ccan/ccan/htable/test/run-type.c
+++ b/ccan/ccan/htable/test/run-type.c
@@ -65,7 +65,7 @@ static void find_vals(const struct htable_obj *ht,
 			return;
 		}
 	}
-	pass("Found %u numbers in hash", i);
+	ok1(htable_obj_count(ht) == i);
 }
 
 static void del_vals(struct htable_obj *ht,
@@ -116,12 +116,13 @@ int main(void)
 	void *p;
 	struct htable_obj_iter iter;
 
-	plan_tests(29);
+	plan_tests(32);
 	for (i = 0; i < NUM_VALS; i++)
 		val[i].key = i;
 	dne = i;
 
 	htable_obj_init(&ht);
+	ok1(htable_obj_count(&ht) == 0);
 	ok1(ht_max(&ht.raw) == 0);
 	ok1(ht.raw.bits == 0);
 
@@ -205,6 +206,8 @@ int main(void)
 	}
 
 	htable_obj_clear(&ht);
+	ok1(htable_obj_count(&ht) == 0);
 	htable_obj_clear(&ht2);
+	ok1(htable_obj_count(&ht2) == 0);
 	return exit_status();
 }

--- a/ccan/ccan/htable/test/run.c
+++ b/ccan/ccan/htable/test/run.c
@@ -67,7 +67,7 @@ static void find_vals(struct htable *ht,
 			return;
 		}
 	}
-	pass("Found %llu numbers in hash", (long long)i);
+	ok1(htable_count(ht) == i);
 }
 
 static void del_vals(struct htable *ht,
@@ -105,12 +105,13 @@ int main(void)
 	void *p;
 	struct htable_iter iter;
 
-	plan_tests(36);
+	plan_tests(38);
 	for (i = 0; i < NUM_VALS; i++)
 		val[i] = i;
 	dne = i;
 
 	htable_init(&ht, hash, NULL);
+	ok1(htable_count(&ht) == 0);
 	ok1(ht_max(&ht) == 0);
 	ok1(ht.bits == 0);
 
@@ -207,6 +208,8 @@ int main(void)
 	ok1(htable_init_sized(&ht, hash, NULL, 1025));
 	ok1(ht_max(&ht) >= 1025);
 	htable_clear(&ht);
-	
+
+	ok1(htable_count(&ht) == 0);
+
 	return exit_status();
 }

--- a/ccan/ccan/pipecmd/pipecmd.c
+++ b/ccan/ccan/pipecmd/pipecmd.c
@@ -137,6 +137,13 @@ pid_t pipecmdarr(int *fd_tochild, int *fd_fromchild, int *fd_errfromchild,
 				goto child_errno_fail;
 			close(errfromchild[1]);
 		}
+
+		/* Make (fairly!) sure all other fds are closed. */
+		int max = sysconf(_SC_OPEN_MAX);
+		for (int i = 3; i < max; i++)
+			if (i != execfail[1])
+				close(i);
+
 		execvp(arr[0], arr);
 
 	child_errno_fail:

--- a/ccan/ccan/pipecmd/pipecmd.h
+++ b/ccan/ccan/pipecmd/pipecmd.h
@@ -20,7 +20,8 @@
  * If @errfd == @outfd (and non-NULL) they will be shared.
  * If @infd, @outfd or @errfd is &pipecmd_preserve, it is unchanged.
  *
- * The return value is the pid of the child, or -1.
+ * The return value is the pid of the child, or -1.  All other file-descriptors
+ * are closed in the child.
  */
 pid_t pipecmd(int *infd, int *outfd, int *errfd, const char *cmd, ...);
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -122,6 +122,7 @@ def test_invoice_preimage(node_factory):
         l2.rpc.invoice(123456, 'inv2', '?', preimage=invoice_preimage)
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_invoice_routeboost(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice.
     """

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2049,6 +2049,7 @@ def test_setchannelfee_all(node_factory, bitcoind):
     assert result['channels'][1]['short_channel_id'] == scid3
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_channel_spendable(node_factory, bitcoind):
     """Test that spendable_msat is accurate"""
     sats = 10**6
@@ -2101,6 +2102,7 @@ def test_channel_spendable(node_factory, bitcoind):
     l2.rpc.waitsendpay(payment_hash, TIMEOUT)
 
 
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_channel_spendable_large(node_factory, bitcoind):
     """Test that spendable_msat is accurate for large channels"""
     # This is almost the max allowable spend.


### PR DESCRIPTION
Dynamic plugins were keeping fds open; they should not have these
at all anyway, but worse, they interfere with operation because
we don't notice they're closed.

The symptom was that shutdown of the test_plugin_slowinit and
test_plugin_command was 30 seconds (10 seconds grace to kill each daemon).