### PR TITLE
rpc: fix crash 'listforwards' when payment_hash is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for
 changes.
 
 - Plugin: using startup-relative paths for `plugin` and `plugin-dir`: they're now relative to `lightning-dir`.
+- JSON API: `listforwards` removed dummy (zero) fields for `out_msat`, `fee_msat`, `in_channel` and `out_channel` if unknown (i.e. deleted from db, or `status` is `local-failed`.
 
 ### Removed
 

--- a/doc/lightning-listforwards.7
+++ b/doc/lightning-listforwards.7
@@ -2,12 +2,12 @@
 .\"     Title: lightning-listforwards
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/15/2019
+.\"      Date: 08/15/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "LIGHTNING\-LISTFORWA" "7" "07/15/2019" "\ \&" "\ \&"
+.TH "LIGHTNING\-LISTFORWA" "7" "08/15/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -61,18 +61,6 @@ Each entry in \fIforwards\fR will include:
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIout_channel\fR
-\- the short_channel_id of to which the outgoing htlc is supposed to be forwarded\&.
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.sp -1
-.IP \(bu 2.3
-.\}
 \fIin_msatoshi\fR,
 \fIin_msat\fR
 \- amount of msatoshis that are forwarded to this node\&.
@@ -86,10 +74,31 @@ Each entry in \fIforwards\fR will include:
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIout_msatoshi\fR,
-\fIout_msat\fR
-\- amount of msatoshis to be forwarded\&.
+\fIstatus\fR
+\- status can be either
+\fIoffered\fR
+if the routing process is still ongoing,
+\fIsettled\fR
+if the routing process is completed,
+\fIfailed\fR
+if the routing process could not be completed, or
+\fIlocal_failed\fR
+if the node failed the forward itself\&.
 .RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIreceived_time\fR
+\- timestamp when incoming htlc was received\&.
+.RE
+.sp
+The following additional fields are usually present, but will not be for some variants of status \fIlocal_failed\fR (if it failed before we determined these):
 .sp
 .RS 4
 .ie n \{\
@@ -112,14 +121,8 @@ Each entry in \fIforwards\fR will include:
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIstatus\fR
-\- status can be either
-\fIoffered\fR
-if the routing process is still ongoing,
-\fIsettled\fR
-if the routing process is completed or
-\fIfailed\fR
-if the routing process could not be completed\&.
+\fIout_channel\fR
+\- the short_channel_id of to which the outgoing htlc is supposed to be forwarded\&.
 .RE
 .sp
 .RS 4
@@ -130,9 +133,26 @@ if the routing process could not be completed\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-\fIreceived_time\fR
-\- timestamp when incoming htlc was received\&.
+\fIout_msatoshi\fR,
+\fIout_msat\fR
+\- amount of msatoshis to be forwarded\&.
 .RE
+.sp
+The following fields may be offered, but for old forgotten HTLCs they will be omitted:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIpayment_hash\fR
+\- the payment_hash belonging to the HTLC\&.
+.RE
+.sp
+If the status is not \fIoffered\fR, the following additional fields are present:
 .sp
 .RS 4
 .ie n \{\

--- a/doc/lightning-listforwards.7.txt
+++ b/doc/lightning-listforwards.7.txt
@@ -22,17 +22,26 @@ Each entry in 'forwards' will include:
 
 - 'in_channel' - the short_channel_id of the channel that recieved the incoming htlc.
 
-- 'out_channel' - the short_channel_id of to which the outgoing htlc is supposed to be forwarded.
-
 - 'in_msatoshi', 'in_msat' - amount of msatoshis that are forwarded to this node.
 
-- 'out_msatoshi', 'out_msat' - amount of msatoshis to be forwarded.
+- 'status' - status can be either 'offered' if the routing process is still ongoing, 'settled' if the routing process is completed, 'failed' if the routing process could not be completed, or 'local_failed' if the node failed the forward itself.
+
+- 'received_time' - timestamp when incoming htlc was received.
+
+The following additional fields are usually present, but will not be for some
+variants of status 'local_failed' (if it failed before we determined these):
 
 - 'fee', 'fee_msat' - fee offered for forwarding the htlc in msatoshi.
 
-- 'status' - status can be either 'offered' if the routing process is still ongoing, 'settled' if the routing process is completed or 'failed' if the routing process could not be completed.
+- 'out_channel' - the short_channel_id of to which the outgoing htlc is supposed to be forwarded.
 
-- 'received_time' - timestamp when incoming htlc was received.
+- 'out_msatoshi', 'out_msat' - amount of msatoshis to be forwarded.
+
+The following fields may be offered, but for old forgotten HTLCs they will be omitted:
+
+- 'payment_hash' - the payment_hash belonging to the HTLC.
+
+If the status is not 'offered', the following additional fields are present:
 
 - 'resolved_time' - timestamp when htlc was resolved (settled or failed).
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2148,9 +2148,11 @@ void json_format_forwarding_object(struct json_stream *response,
 {
 	json_object_start(response, fieldname);
 
-	json_add_hex(response, "payment_hash",
-				    cur->payment_hash,
-				    sizeof(*cur->payment_hash));
+	/* See 6d333f16cc0f3aac7097269bf0985b5fa06d59b4 */
+	if (cur->payment_hash)
+		json_add_hex(response, "payment_hash",
+					    cur->payment_hash,
+					    sizeof(*cur->payment_hash));
 	json_add_short_channel_id(response, "in_channel", &cur->channel_in);
 	json_add_short_channel_id(response, "out_channel", &cur->channel_out);
 	json_add_amount_msat_compat(response,


### PR DESCRIPTION
There's a forward on one of my node's that's missing a payment_hash, which caused a crash when calling `listforwards`. This patch fixes the crash, not sure what the root cause is.

```
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): FATAL SIGNAL 11 (version v0.7.2rc1)
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: common/daemon.c:45 (send_backtrace) 0x563349d07879
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: common/daemon.c:53 (crashdump) 0x563349d078c9
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: (null):0 ((null)) 0x7efd7b996f1f
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: ccan/ccan/str/hex/hex.c:59 (hex_encode) 0x563349d57fec
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/json.c:380 (json_add_hex) 0x563349cd9dd3
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/peer_htlcs.c:2151 (json_format_forwarding_object) 0x563349cfa7ac
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/peer_htlcs.c:2198 (listforwardings_add_forwardings) 0x563349cfa99d
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/peer_htlcs.c:2216 (json_listforwards) 0x563349cfaa55
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/jsonrpc.c:650 (parse_request) 0x563349cdc184
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: lightningd/jsonrpc.c:748 (read_json) 0x563349cdc5ae
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x563349d4bbe5
2019-08-14T17:50:39.100Z **BROKEN** lightningd(11355): backtrace: ccan/ccan/io/io.c:407 (do_plan) 0x563349d4c762
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: ccan/ccan/io/io.c:417 (io_ready) 0x563349d4c7a0
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: ccan/ccan/io/poll.c:445 (io_loop) 0x563349d4e7f5
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: lightningd/io_loop_with_timers.c:24 (io_loop_with_timers) 0x563349cd8afe
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: lightningd/lightningd.c:834 (main) 0x563349cded3a
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: (null):0 ((null)) 0x7efd7b979b96
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: (null):0 ((null)) 0x563349cc5909
2019-08-14T17:50:39.101Z **BROKEN** lightningd(11355): backtrace: (null):0 ((null)) 0xffffffffffffffff
```