### PR TITLE
Fix crash when failing add_htlc with UPDATE failcode

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -782,7 +782,7 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	case htlc_accepted_fail:
 		log_debug(channel->log,
 			  "Failing incoming HTLC as instructed by plugin hook");
-		fail_in_htlc(hin, failure_code, NULL, NULL);
+		fail_in_htlc(hin, failure_code, NULL, &hop_data->channel_id);
 		break;
 	case htlc_accepted_resolve:
 		fulfill_htlc(hin, &payment_preimage);


### PR DESCRIPTION
Returning an UPDATE failcode from a plugin hook crashes, since the next hop's channel id
was passed in as NULL. Fixed by passing in channel id for next hop.

```
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): FATAL SIGNAL 11 (version v0.7.2rc1-8-gbf3b77a-modded)
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): backtrace: common/daemon.c:45 (send_backtrace) 0x55fef4ef036f
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): backtrace: common/daemon.c:53 (crashdump) 0x55fef4ef03bf
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): backtrace: (null):0 ((null)) 0x7f7762401f1f
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): backtrace: lightningd/peer_htlcs.c:104 (fail_in_htlc) 0x55fef4edd9d7
2019-08-15T00:19:49.639Z **BROKEN** lightningd(17070): backtrace: lightningd/peer_htlcs.c:785 (htlc_accepted_hook_callback) 0x55fef4edf2c7
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/plugin_hook.c:86 (plugin_hook_callback) 0x55fef4ee765f
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/plugin.c:251 (plugin_response_handle) 0x55fef4ee44b2
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/plugin.c:341 (plugin_read_json_one) 0x55fef4ee4637
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/plugin.c:366 (plugin_read_json) 0x55fef4ee4764
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x55fef4f38c7a
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: ccan/ccan/io/io.c:407 (do_plan) 0x55fef4f397f7
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: ccan/ccan/io/io.c:417 (io_ready) 0x55fef4f39835
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: ccan/ccan/io/poll.c:445 (io_loop) 0x55fef4f3b88a
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/io_loop_with_timers.c:24 (io_loop_with_timers) 0x55fef4ec0afe
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: lightningd/lightningd.c:834 (main) 0x55fef4ec6f5a
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: (null):0 ((null)) 0x7f77623e4b96
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: (null):0 ((null)) 0x55fef4ead909
2019-08-15T00:19:49.640Z **BROKEN** lightningd(17070): backtrace: (null):0 ((null)) 0xffffffffffffffff
```