### PR TITLE
Makefile: fix occasional race where we fail to compile tools/tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,7 @@ clean: wire-clean
 	$(RM) gen_*.h ccan/tools/configurator/configurator
 	$(RM) ccan/ccan/cdump/tools/cdump-enumstr.o
 	$(RM) check-bolt tools/check-bolt tools/*.o
+	$(RM) tools/headerversions
 	find . -name '*gcda' -delete
 	find . -name '*gcno' -delete
 	find . -name '*.nccout' -delete

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -9,34 +9,34 @@ check-units: check-tools
 
 TOOL_TEST_INCL_SRC := tools/test/enum.c
 TOOL_GEN_SRC := tools/test/gen_test.c tools/test/gen_print.c
+TOOL_GEN_OBJS := $(TOOL_GEN_SRC:.c=.o)
 TOOL_GEN_HEADER := tools/test/gen_test.h tools/test/gen_print.h
 TOOL_TEST_SRC := $(wildcard tools/test/run-*.c)
 TOOL_TEST_OBJS := $(TOOL_TEST_SRC:.c=.o)
 TOOL_TEST_PROGRAMS := $(TOOL_TEST_OBJS:.o=)
 
 TOOL_TEST_COMMON_OBJS :=		\
-	common/utils.o			\
-	tools/test/enum.o
+	common/utils.o
 
 TOOLS_WIRE_DEPS := $(BOLT_DEPS) tools/test/test_cases $(wildcard tools/gen/*_template)
 
-$(TOOL_TEST_SRC) $(TOOL_GEN_SRC): $(TOOL_GEN_HEADER)
-$(TOOL_TEST_OBJS): $(TOOL_GEN_SRC)
-$(TOOL_TEST_PROGRAMS): $(TOOL_TEST_COMMON_OBJS) $(TOOL_GEN_SRC:.c=.o)
-$(TOOL_GEN_SRC) $(TOOL_GEN_HEADER): $(TOOLS_WIRE_DEPS)
-$(TOOL_GEN_SRC:.c=.o): $(TOOL_TEST_INCL_SRC:.c=.o)
+$(TOOL_TEST_OBJS) $(TOOL_GEN_OBJS): $(TOOL_GEN_HEADER)
+$(TOOL_TEST_PROGRAMS): $(TOOL_TEST_COMMON_OBJS) $(TOOL_GEN_SRC:.c=.o) tools/test/enum.o
 
-tools/test/gen_test.h:
+tools/test/gen_test.h: $(TOOLS_WIRE_DEPS)
 	$(BOLT_GEN) --page header $@ test_type < tools/test/test_cases > $@
 
-tools/test/gen_test.c:
-	$(BOLT_GEN) --page impl ${@:.c=.h} test_type < tools/test/test_cases > $@
-	@MAKE=$(MAKE) tools/update-mocks.sh "$@"
+# Parallel make sometimes tries to use file before update-mocks, so split.
+tools/test/gen_test.c.tmp.c: $(TOOLS_WIRE_DEPS)
+	$(BOLT_GEN) --page impl tools/test/gen_test.h test_type < tools/test/test_cases > $@
 
-tools/test/gen_print.h: wire/gen_onion_wire.h
+tools/test/gen_test.c: tools/test/gen_test.c.tmp.c
+	@MAKE=$(MAKE) tools/update-mocks.sh "$<" && mv "$<" "$@"
+
+tools/test/gen_print.h: wire/gen_onion_wire.h $(TOOLS_WIRE_DEPS)
 	$(BOLT_GEN) -P --page header $@ test_type < tools/test/test_cases > $@
 
-tools/test/gen_print.c:
+tools/test/gen_print.c: $(TOOLS_WIRE_DEPS)
 	echo '#include "gen_test.h"' > $@
 	$(BOLT_GEN) -P --page impl ${@:.c=.h} test_type < tools/test/test_cases >> $@
 
@@ -52,4 +52,5 @@ tools-update-mocks: $(TOOL_TEST_SRC:%=update-mocks/%)
 clean: tools-test-clean
 
 tools-test-clean:
-	$(RM) $(TOOL_GEN_HEADER) $(TOOL_GEN_SRC) $(TOOL_TEST_OBJS)
+	$(RM) $(TOOL_GEN_HEADER) $(TOOL_GEN_SRC) $(TOOL_TEST_OBJS) $(TOOL_TEST_PROGRAMS)
+	$(RM) $(TOOL_GEN_SRC:.c=.o) tools/test/enum.o


### PR DESCRIPTION
This simplifies the dependencies:
1. Objs depend on headers, not other objs.
2. Programs depend on objs.
3. A .o file will generally implicitly depend on the .c file it's built from.
4. If a file has a build line, it's often better to list all deps there.
5. I spotted some missing 'make clean' files.

The particular problem in this case seems to be that make would use
tools/test/gen_test.c before it was ready.  It's probably confused by
the use of recursive make via update-mocks, so explicitly split that
into two stages.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>