### PR TITLE
Release scripts and docs update, with YA build fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #! /usr/bin/make
 
 # Extract version from git, or if we're from a zipfile, use dirname
-VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's,.*/lightning-\([0-9.rc]*\)$$,\1,p')
+VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's,.*/clightning-\(v[0-9.rc]*\)$$,\1,p')
 
 ifeq ($(VERSION),)
 $(error "ERROR: git is required for generating version information")

--- a/doc/MAKING-RELEASES.md
+++ b/doc/MAKING-RELEASES.md
@@ -17,8 +17,7 @@ Here's a checklist for the release process.
 1. Check that CHANGELOG.md is well formatted, ordered in areas,
    covers all signficant changes, and sub-ordered approximately by user impact
    & coolness.
-2. Update the CHANGELOG.md with [Unreleased] changed to -rc1, and add a new
-   footnote.
+2. Update the CHANGELOG.md with [Unreleased] changed to -rc1.
 3. Create a PR with the above.
 
 ### Releasing -rc1
@@ -28,21 +27,35 @@ Here's a checklist for the release process.
 3. Update the /topic on #c-lightning on Freenode.
 4. Prepare draft release notes (see devtools/credit), and share with team for editing.
 5. Upgrade your personal nodes to the rc1, to help testing.
+6. Test `tools/build-release.sh` to build the non-reprodicible images
+   and reproducible zipfile.
+7. Use the zipfile to produce a [reproducible build](REPRODUCIBLE.md).
+
+### Releasing -rc2, etc
+
+1. Change rc1 to rc2 in CHANGELOG.md.
+2. Add a PR with the rc2.
+3. Tag it `git pull && git tag -s v<VERSION>rc2 && git push --tags`
+4. Update the /topic on #c-lightning on Freenode.
+5. Upgrade your personal nodes to the rc2.
 
 ### Tagging the Release
 
-1. Update the CHANGELOG.md; remove -rc1 in both places, and move the
-   [Unreleased] footnote URL from the previous version to the
-   about-to-be-released version.
-2. Commit that, then `git tag -s v<VERSION>  && git push --tags`.
-3. Run `tools/build-release.sh` to create the images, `SHA256SUMS` and
-   signatures into release/.
-4. Upload the files resulting files to github and
+1. Update the CHANGELOG.md; remove -rcN in both places, and add an
+   [Unreleased] footnote URL from this new version to HEAD.
+2. Add a PR with that release.
+3. Merge the PR, then `git pull && git tag -s v<VERSION> && git push --tags`.
+4. Run `tools/build-release.sh` to build the non-reprodicible images
+   and reproducible zipfile.
+5. Use the zipfile to produce a [reproducible build](REPRODUCIBLE.md).
+6. Create the checksums for signing: `sha256sum release/* > release/SHA256SUMS`
+7. Create the first signature with `gpg -sb --armor release/SHA256SUMS`
+8. Upload the files resulting files to github and
    save as a draft.
    (https://github.com/ElementsProject/lightning/releases/)
-5. Ping the rest of the team to check the SHA256SUMS file and have them
+9. Ping the rest of the team to check the SHA256SUMS file and have them send their
    `gpg -sb --armor SHA256SUMS`.
-6. Append the signatures into a file called `SHA256SUMS.asc`, verify
+10. Append the signatures into a file called `SHA256SUMS.asc`, verify
    with `gpg --verify SHA256SUMS.asc` and include the file in the draft
    release.
 

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -13,7 +13,8 @@ if [ x"$1" = x"--inside-docker" ]; then
     exit 0
 fi
 
-ALL_TARGETS="bin-Fedora-28-amd64 bin-Ubuntu-16.04-amd64 bin-Ubuntu-16.04-i386 zipfile sign"
+# bin-Ubuntu-16.04-amd64 was superceded by the reproducible built 18.04 version.
+ALL_TARGETS="bin-Fedora-28-amd64 bin-Ubuntu-16.04-i386 zipfile"
 
 FORCE_VERSION=
 FORCE_UNCLEAN=false

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -30,7 +30,7 @@ tools/test/gen_test.h: $(TOOLS_WIRE_DEPS)
 tools/test/gen_test.c.tmp.c: $(TOOLS_WIRE_DEPS)
 	$(BOLT_GEN) --page impl tools/test/gen_test.h test_type < tools/test/test_cases > $@
 
-tools/test/gen_test.c: tools/test/gen_test.c.tmp.c $(EXTERNAL_HEADERS)
+tools/test/gen_test.c: tools/test/gen_test.c.tmp.c $(EXTERNAL_HEADERS) tools/test/gen_test.h
 	@MAKE=$(MAKE) tools/update-mocks.sh "$<" && mv "$<" "$@"
 
 tools/test/gen_print.h: wire/gen_onion_wire.h $(TOOLS_WIRE_DEPS)


### PR DESCRIPTION
You can apply the first two one-liners (by hand) temporarily to fix up the reproducible build for the v0.7.2 release too.

Fixes #2970