### PR TITLE
systemd: After=network-online.target

### DIFF
--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -12,6 +12,7 @@ Description=C-Lightning daemon
 Requires=bitcoind.service
 After=bitcoind.service
 Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/lightningd --daemon --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid


### PR DESCRIPTION
I added `Wants=network-online.target` in #2643, but it looks like that's not enough. Adding `After` seems to help, at least on Ubuntu 18.04.