### PR TITLE
wire-gen: ensure that tlv messages are correctly ordered

### DIFF
--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -203,7 +203,7 @@ static void fromwire_${msg.struct_name()}(const u8 **cursor, size_t *plen, void 
 <% static = '' if tlv.name in options.expose_tlv_type else 'static '
 %>\
 ${static}const struct tlv_record_type tlvs_${tlv.name}[] = {
-    % for msg in tlv.messages.values():
+    % for msg in tlv.ordered_msgs():
 	{ ${msg.number}, towire_${msg.struct_name()}, fromwire_${msg.struct_name()} },
     % endfor
 };

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -377,6 +377,9 @@ class Tlv(object):
     def find_message(self, name):
         return self.messages[name]
 
+    def ordered_msgs(self):
+        return sorted(self.messages.values(), key=lambda item: int(item.number))
+
 
 class Master(object):
     types = {}


### PR DESCRIPTION
Our TLV serializer relies on TLV outputs to be ordered by type
number. Prior to this commit we relied on 1) the ordering in the
RFC to be correct and 2) users to be using a version of Python that
respects stable ordering of dicts (i.e. Python 3.7+)

Instead of relying on these implicitly, we now explicitly sort messages
by type number when the TLV sets.

Resolves #2956.

Thanks-To: @ScottTre for the sort function
Reported-By: @ZmnSCPxj