### PR TITLE
contrib: make stricter shellcheck from Ubuntu 18.04 happy

### DIFF
--- a/contrib/bootstrap-node.sh
+++ b/contrib/bootstrap-node.sh
@@ -4,6 +4,7 @@
 set -e
 
 # If lightning-cli not in their path, assume it's in subdir.
+# shellcheck disable=SC2039
 if type lightning-cli >/dev/null 2>&1; then
     LCLI=lightning-cli
 elif [ -x cli/lightning-cli ]; then

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -38,7 +38,9 @@ fi
 
 if [ -z "$PATH_TO_LIGHTNING" ]; then
 	# Already installed maybe?  Prints
+	# shellcheck disable=SC2039
 	type lightning-cli || return
+	# shellcheck disable=SC2039
 	type lightningd || return
 	LCLI=lightning-cli
 	LIGHTNINGD=lightningd


### PR DESCRIPTION
In contrib/bootstrap-node.sh line 7:
if type lightning-cli >/dev/null 2>&1; then
   ^-- SC2039: In POSIX sh, 'type' is undefined.

In contrib/startup_regtest.sh line 41:
	type lightning-cli || return
        ^-- SC2039: In POSIX sh, 'type' is undefined.

In contrib/startup_regtest.sh line 42:
	type lightningd || return
        ^-- SC2039: In POSIX sh, 'type' is undefined.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>