### PR TITLE
WIP lightningd/plugin: add sync'd init for static plugins at startup and handle init errors

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1024,8 +1024,6 @@ void plugins_init(struct plugins *plugins, const char *dev_plugin_debug)
 
 	if (plugins->pending_manifests > 0)
 		io_loop_with_timers(plugins->ld);
-	// There won't be io_loop anymore to wait for plugins
-	plugins->startup = false;
 }
 
 static void plugin_config_cb(const char *buffer,
@@ -1100,9 +1098,12 @@ void plugins_config(struct plugins *plugins)
 		}
 	}
 
-	/* At start-up, wait for non-dynamic plugins to initialize */
+	/* Wait here for any static plugins to initialize, which implies startup.*/
 	if (plugins->pending_sync_configs > 0)
 		io_loop_with_timers(plugins->ld);
+
+	/* Close the startup window (if any) */
+	plugins->startup = false;
 }
 
 void json_add_opt_plugins(struct json_stream *response,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -837,6 +837,8 @@ static void plugin_manifest_cb(const char *buffer,
 	dynamictok = json_get_member(buffer, resulttok, "dynamic");
 	if (dynamictok && json_to_bool(buffer, dynamictok, &dynamic_plugin))
 		plugin->dynamic = dynamic_plugin;
+	else
+		plugin->dynamic = false;
 
 	if (!plugin_opts_add(plugin, buffer, resulttok) ||
 	    !plugin_rpcmethods_add(plugin, buffer, resulttok) ||

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -29,8 +29,14 @@ struct plugin {
 
 	enum plugin_state plugin_state;
 
-	/* If this plugin can be restarted without restarting lightningd and don't
-	 * wait for their initialization */
+	/* dynamic=True: plugin can be stopped/started via RPC at runtime and it
+	 * expects lightningd to be up-and-running during init.
+	 *
+	 * dynamic=False: when lightningd starts up, it will wait for the plugin's
+	 * init-result and will shutdown when that is an error. A static plugin
+	 * cannot be stopped but *can* be started via RPC. It should check the
+	 * `startup` field in its init call, which may return an error to kill the
+	 * plugin. Static plugins shouldn't make RPC calls during init. */
 	bool dynamic;
 	bool signal_startup;
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -29,7 +29,8 @@ struct plugin {
 
 	enum plugin_state plugin_state;
 
-	/* If this plugin can be restarted without restarting lightningd */
+	/* If this plugin can be restarted without restarting lightningd and don't
+	 * wait for their initialization */
 	bool dynamic;
 	bool signal_startup;
 
@@ -50,7 +51,8 @@ struct plugin {
 	const char **methods;
 
 	/* Timer to add a timeout to some plugin RPC calls. Used to
-	 * guarantee that `getmanifest` doesn't block indefinitely. */
+	 * guarantee that `getmanifest` and some `init` (for non-dynamic plugins)
+	 * doesn't block indefinitely */
 	const struct oneshot *timeout_timer;
 
 	/* An array of subscribed topics */
@@ -65,6 +67,7 @@ struct plugin {
 struct plugins {
 	struct list_head plugins;
 	size_t pending_manifests;
+	size_t pending_sync_configs;
 	bool startup;
 
 	/* Currently pending requests by their request ID */

--- a/tests/plugins/static_2.py
+++ b/tests/plugins/static_2.py
@@ -14,8 +14,12 @@ plugin = Plugin(dynamic=False)
 def init(configuration, options, plugin):
     plugin.log("init startup={}".format(configuration['startup']))
 
+    # we don't like to be started at run-time
+    if not configuration['startup']:
+        raise Exception
 
-@plugin.method('world')
+
+@plugin.method('static_2')
 def reject(plugin):
     """Mark a given node_id as reject for future connections.
     """


### PR DESCRIPTION
Some static  (`dynamic=false`) [plugins](https://github.com/lightningd/plugins/pull/40) would like to make assumptions about the startup stage `lightningd` is in while the plugin is initializing. For example to assure certain db transactions haven't happened yet.

This PR makes the `init` of all **static** plugins synchronous, i.e. `lightningd's` startup waits until it has received the `init` response of all static plugins. That response can now contain an `error`, which is handled as follow:
- if the plugin is static and `lightning` is starting up, then abort the startup by killing `lightningd`
- if not starting up, the plugin is killed

As I understand, the `dynamic` member currently only determines the behavior of `plugin` stop/start command. Note however that an unloaded (fresh) static plugins can still be started using that command. In that case, `init` can check the `startup` field and now return an error to have itself cleanly killed.

This PR add a rule to static plugins: they cannot make **any** RPC calls from their `init`. ~Which seems to make sense, as an RPC call would just wait for `lightningd` to be up-and-running, which contradicts the static requirement? But haven't checked this with other plugins.~

**edit**: This last part of the story is not so solid and I also misunderstood the call-back system. Maybe I shouldn't try to redefine (hijack) the _static_ property. And perhaps there are other tricks I can use for this particular [plugin](https://github.com/lightningd/plugins/pull/40), like using the `db_write` hook itself to block `lightningd`'s startup in combination with threading. But that needs some further study.

TODO:
- [ ] complete the `json` error handling
- [ ] add tests

Please give feedback!