### PR TITLE
Adding TRACE loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1-rc4]
+## [0.7.1-rc5]
 
 ### Added
 
@@ -378,7 +378,7 @@ There predate the BOLT specifications, and are only of vague historic interest:
 6. [0.5.1] - 2016-10-21
 7. [0.5.2] - 2016-11-21: "Bitcoin Savings & Trust Daily Interest II"
 
-[0.7.1-rc4]: https://github.com/ElementsProject/lightning/compare/v0.7.0...HEAD
+[0.7.1-rc5]: https://github.com/ElementsProject/lightning/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/ElementsProject/lightning/releases/tag/v0.7.0
 [0.6.3]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.3
 [0.6.2]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1-rc5]
+## [0.7.1] - 2019-06-29: "The Unfailing Twitter Consensus Algorithm"
+
+This release named by (C-Lightning Core Team member) Lisa Neigut @niftynei.
 
 ### Added
 
@@ -378,7 +380,7 @@ There predate the BOLT specifications, and are only of vague historic interest:
 6. [0.5.1] - 2016-10-21
 7. [0.5.2] - 2016-11-21: "Bitcoin Savings & Trust Daily Interest II"
 
-[0.7.1-rc5]: https://github.com/ElementsProject/lightning/compare/v0.7.0...HEAD
+[0.7.1]: https://github.com/ElementsProject/lightning/releases/tag/v0.7.1
 [0.7.0]: https://github.com/ElementsProject/lightning/releases/tag/v0.7.0
 [0.6.3]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.3
 [0.6.2]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.2

--- a/common/status.c
+++ b/common/status.c
@@ -132,7 +132,11 @@ void status_vfmt(enum log_level level, const char *fmt, va_list ap)
 			size_t n = traces_suppressed;
 			traces_suppressed = 0;
 			/* Careful: recursion! */
-			status_debug("...[%zu debug messages suppressed]...", n);
+			if (level == LOG_DBG) {
+				status_debug("...[%zu debug messages suppressed]...", n);
+			} else {
+				status_trace("...[%zu trace messages suppressed]...", n);
+			}
 		} else if (traces_suppressed || qlen > TRACE_QUEUE_LIMIT) {
 			traces_suppressed++;
 			return;

--- a/common/status.c
+++ b/common/status.c
@@ -124,7 +124,7 @@ void status_vfmt(enum log_level level, const char *fmt, va_list ap)
 
 	/* We only suppress async debug msgs.  IO messages are even spammier
 	 * but they only occur when explicitly asked for */
-	if (level == LOG_DBG && status_conn) {
+	if ((level == LOG_DBG || level == LOG_TRACE) && status_conn) {
 		size_t qlen = daemon_conn_queue_length(status_conn);
 
 		/* Once suppressing, we keep suppressing until we're empty */

--- a/common/status.h
+++ b/common/status.h
@@ -39,9 +39,8 @@ void status_io(enum log_level iodir, const char *who,
 	status_fmt(LOG_UNUSUAL, __VA_ARGS__)
 #define status_broken( ...)			\
 	status_fmt(LOG_BROKEN, __VA_ARGS__)
-
-/* FIXME: Transition */
-#define status_trace(...) status_debug(__VA_ARGS__)
+#define status_trace( ...)			\
+	status_fmt(LOG_TRACE, __VA_ARGS__)
 
 /* Send a failure status code with printf-style msg, and exit. */
 void status_failed(enum status_failreason code,

--- a/common/status_levels.h
+++ b/common/status_levels.h
@@ -6,7 +6,9 @@ enum log_level {
 	/* Logging all IO. */
 	LOG_IO_OUT,
 	LOG_IO_IN,
-	/* Gory details which are mainly good for debugging. */
+	/* Trace details which are mainly good for debugging. */
+	LOG_TRACE,
+	/* Basic details which are mainly good for debugging. */
 	LOG_DBG,
 	/* Information about what's going in. */
 	LOG_INFORM,

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -367,6 +367,7 @@ static void log_one_line(unsigned int skipped,
 		prefix,
 		level == LOG_IO_IN ? "IO_IN"
 		: level == LOG_IO_OUT ? "IO_OUT"
+		: level == LOG_TRACE ? "TRACE"
 		: level == LOG_DBG ? "DEBUG"
 		: level == LOG_INFORM ? "INFO"
 		: level == LOG_UNUSUAL ? "UNUSUAL"
@@ -396,6 +397,7 @@ static struct {
 	enum log_level level;
 } log_levels[] = {
 	{ "IO", LOG_IO_OUT },
+	{ "TRACE", LOG_TRACE },
 	{ "DEBUG", LOG_DBG },
 	{ "INFO", LOG_INFORM },
 	{ "UNUSUAL", LOG_UNUSUAL },
@@ -662,6 +664,7 @@ static void log_to_json(unsigned int skipped,
 			: level == LOG_UNUSUAL ? "UNUSUAL"
 			: level == LOG_INFORM ? "INFO"
 			: level == LOG_DBG ? "DEBUG"
+			: level == LOG_TRACE ? "TRACE"
 			: level == LOG_IO_IN ? "IO_IN"
 			: level == LOG_IO_OUT ? "IO_OUT"
 			: "UNKNOWN");
@@ -698,6 +701,8 @@ struct command_result *param_loglevel(struct command *cmd,
 	*level = tal(cmd, enum log_level);
 	if (json_tok_streq(buffer, tok, "io"))
 		**level = LOG_IO_OUT;
+	else if (json_tok_streq(buffer, tok, "trace"))
+		**level = LOG_TRACE;
 	else if (json_tok_streq(buffer, tok, "debug"))
 		**level = LOG_DBG;
 	else if (json_tok_streq(buffer, tok, "info"))
@@ -706,7 +711,7 @@ struct command_result *param_loglevel(struct command *cmd,
 		**level = LOG_UNUSUAL;
 	else {
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				    "'%s' should be 'io', 'debug', 'info', or "
+				    "'%s' should be 'io', 'trace', 'debug', 'info', or "
 				    "'unusual', not '%.*s'",
 				    name,
 				    json_tok_full_len(tok),

--- a/lightningd/log.h
+++ b/lightningd/log.h
@@ -61,6 +61,7 @@ struct log_book *new_log_book(struct lightningd *ld, size_t max_mem,
 /* With different entry points */
 struct log *new_log(const tal_t *ctx, struct log_book *record, const char *fmt, ...) PRINTF_FMT(3,4);
 
+#define log_trace(log, ...) log_((log), LOG_TRACE, false, __VA_ARGS__)
 #define log_debug(log, ...) log_((log), LOG_DBG, false, __VA_ARGS__)
 #define log_info(log, ...) log_((log), LOG_INFORM, false, __VA_ARGS__)
 #define log_unusual(log, ...) log_((log), LOG_UNUSUAL, true, __VA_ARGS__)

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -216,6 +216,8 @@ static void plugin_log_handle(struct plugin *plugin, const jsmntok_t *paramstok)
 		level = LOG_INFORM;
 	else if (json_tok_streq(plugin->buffer, leveltok, "debug"))
 		level = LOG_DBG;
+	else if (json_tok_streq(plugin->buffer, leveltok, "trace"))
+		level = LOG_TRACE;
 	else if (json_tok_streq(plugin->buffer, leveltok, "warn"))
 		level = LOG_UNUSUAL;
 	else if (json_tok_streq(plugin->buffer, leveltok, "error"))

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -665,7 +665,8 @@ static void plugin_logv(enum log_level l, const char *fmt, va_list ap)
 
 	json_out_start(jout, "params", '{');
 	json_out_addstr(jout, "level",
-			l == LOG_DBG ? "debug"
+			l == LOG_TRACE ? "trace"
+			: l == LOG_DBG ? "debug"
 			: l == LOG_INFORM ? "info"
 			: l == LOG_UNUSUAL ? "warn"
 			: "error");


### PR DESCRIPTION
Hi! Just checking if you might be interested in this direction regarding the logging. I made a small addition to the code to try to enable TRACE loglevel so that trace messages wouldn't fill up the log on the DEBUG level (for example gosspid is too active for prod logging in my opinion when trace messages go into debug).

I modified what I found at first, but there could still be some places missing that my grep shotgun didn't initially find, so I hope someone more knowledgeable would take a good look before even considering accepting anything into master. 

I've been running 0.7.1 with these changes for a week without any noticeable problems so at least in normal conditions it seems to work ok. Haven't done any extensive testing yet though.
