### PR TITLE
Fundchannel: extend `fundchannel_cancel` to work before funding broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON API: `txprepare` now uses `outputs` as parameter other than `destination` and `satoshi`
 - Build: Now requires [`gettext`](https://www.gnu.org/software/gettext/)
+- JSON API: `fundchannel_cancel` is extended to work before funding broadcast.
 
 ### Deprecated
 

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -198,3 +198,10 @@ msgdata,channel_specific_feerates,feerate_ppm,u32,
 msgtype,channel_got_announcement,1017
 msgdata,channel_got_announcement,remote_ann_node_sig,secp256k1_ecdsa_signature,
 msgdata,channel_got_announcement,remote_ann_bitcoin_sig,secp256k1_ecdsa_signature,
+
+# Ask channeld to send a error message. Used in forgetting channel case.
+msgtype,channel_send_error,1008
+msgdata,channel_send_error,reason,wirestring,
+
+# Tell master channeld has sent the error message.
+msgtype,channel_send_error_reply,1108

--- a/doc/lightning-fundchannel_cancel.7
+++ b/doc/lightning-fundchannel_cancel.7
@@ -7,11 +7,18 @@ lightning-fundchannel_cancel - Command for completing channel establishment
 
 .SH DESCRIPTION
 
-\fBfundchannel_cancel\fR is a lower level RPC command\. It allows a user to
-cancel an initiated channel establishment with a connected peer\.
+\fBfundchannel_cancel\fR is a lower level RPC command\. It allows channel funder
+to cancel a channel before funding broadcast with a connected peer\.
 
+\fIid\fR is the node id of the remote peer with which to cancel\.
 
-\fIid\fR is the node id of the remote peer with which to cancel the
+Note that the funding transaction MUST NOT be broadcast before
+\fBfundchannel_cancel\fR\. Broadcasting transaction before \fBfundchannel_cancel\fR
+WILL lead to unrecoverable loss of funds\.
+
+If \fBfundchannel_cancel\fR is called after \fBfundchannel_complete\fR, the remote
+peer may disconnect when command succeeds\. In this case, user need to connect
+to remote peer again before opening channel\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-fundchannel_cancel.7.md
+++ b/doc/lightning-fundchannel_cancel.7.md
@@ -9,10 +9,18 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-`fundchannel_cancel` is a lower level RPC command. It allows a user to
-cancel an initiated channel establishment with a connected peer.
+`fundchannel_cancel` is a lower level RPC command. It allows channel funder
+to cancel a channel before funding broadcast with a connected peer.
 
-*id* is the node id of the remote peer with which to cancel the
+*id* is the node id of the remote peer with which to cancel.
+
+Note that the funding transaction MUST NOT be broadcast before
+`fundchannel_cancel`. Broadcasting transaction before `fundchannel_cancel`
+WILL lead to unrecoverable loss of funds.
+
+If `fundchannel_cancel` is called after `fundchannel_complete`, the remote
+peer may disconnect when command succeeds. In this case, user need to connect
+to remote peer again before opening channel.
 
 RETURN VALUE
 ------------

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -362,7 +362,7 @@ void channel_fail_permanent(struct channel *channel, const char *fmt, ...)
 	struct channel_id cid;
 
 	va_start(ap, fmt);
-	why = tal_vfmt(channel, fmt, ap);
+	why = tal_vfmt(tmpctx, fmt, ap);
 	va_end(ap);
 
 	log_unusual(channel->log, "Peer permanent failure in %s: %s",
@@ -383,6 +383,33 @@ void channel_fail_permanent(struct channel *channel, const char *fmt, ...)
 	if (channel_active(channel))
 		channel_set_state(channel, channel->state, AWAITING_UNILATERAL);
 
+	tal_free(why);
+}
+
+void channel_fail_forget(struct channel *channel, const char *fmt, ...)
+{
+	va_list ap;
+	char *why;
+	struct channel_id cid;
+
+	assert(channel->funder == REMOTE &&
+	       channel->state == CHANNELD_AWAITING_LOCKIN);
+	va_start(ap, fmt);
+	why = tal_vfmt(tmpctx, fmt, ap);
+	va_end(ap);
+
+	log_unusual(channel->log, "Peer permanent failure in %s: %s, "
+		    "forget channel",
+		    channel_state_name(channel), why);
+
+	if (!channel->error) {
+		derive_channel_id(&cid,
+				  &channel->funding_txid,
+				  channel->funding_outnum);
+		channel->error = towire_errorfmt(channel, &cid, "%s", why);
+	}
+
+	delete_channel(channel);
 	tal_free(why);
 }
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -120,6 +120,9 @@ struct channel {
 
 	/* Was this negotiated with `option_static_remotekey? */
 	bool option_static_remotekey;
+
+	/* Any commands trying to forget us. */
+	struct command **forgets;
 };
 
 struct channel *new_channel(struct peer *peer, u64 dbid,

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -187,6 +187,9 @@ PRINTF_FMT(2,3) void channel_fail_reconnect_later(struct channel *channel,
 
 /* Channel has failed, give up on it. */
 void channel_fail_permanent(struct channel *channel, const char *fmt, ...);
+/* Forget the channel. This is only used for the case when we "receive" error
+ * during CHANNELD_AWAITING_LOCKIN if we are "fundee". */
+void channel_fail_forget(struct channel *channel, const char *fmt, ...);
 /* Permanent error, but due to internal problems, not peer. */
 void channel_internal_error(struct channel *channel, const char *fmt, ...);
 

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -23,4 +23,11 @@ bool channel_tell_depth(struct lightningd *ld,
 void channel_notify_new_block(struct lightningd *ld,
 			      u32 block_height);
 
+/* Cancel the channel after `fundchannel_complete` succeeds
+ * but before funding broadcasts. */
+struct command_result *cancel_channel_before_broadcast(struct command *cmd,
+						       const char *buffer,
+						       struct peer *peer,
+						       const jsmntok_t *cidtok);
+
 #endif /* LIGHTNING_LIGHTNINGD_CHANNEL_CONTROL_H */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -295,7 +295,8 @@ static void funding_success(struct channel *channel)
 	/* Well, those cancels didn't work! */
 	for (size_t i = 0; i < tal_count(fc->cancels); i++)
 		was_pending(command_fail(fc->cancels[i], LIGHTNINGD,
-					 "Funding succeeded before cancel"));
+					 "Funding succeeded before cancel. "
+					 "Try fundchannel_cancel again."));
 
 	response = json_stream_success(cmd);
 	json_add_string(response, "channel_id",
@@ -1189,7 +1190,7 @@ static struct command_result *json_fund_channel_complete(struct command *cmd,
 }
 
 /**
- * json_fund_channel_cancel - Entrypoint for cancelling an in flight channel-funding
+ * json_fund_channel_cancel - Entrypoint for cancelling a channel which funding isn't broadcast
  */
 static struct command_result *json_fund_channel_cancel(struct command *cmd,
 						       const char *buffer,
@@ -1199,10 +1200,12 @@ static struct command_result *json_fund_channel_cancel(struct command *cmd,
 
 	struct node_id *id;
 	struct peer *peer;
+	const jsmntok_t *cidtok;
 	u8 *msg;
 
 	if (!param(cmd, buffer, params,
 		   p_req("id", param_node_id, &id),
+		   p_opt("channel_id", param_tok, &cidtok),
 		   NULL))
 		return command_param_failed();
 
@@ -1211,40 +1214,18 @@ static struct command_result *json_fund_channel_cancel(struct command *cmd,
 		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
 	}
 
-	if (!peer->uncommitted_channel) {
-		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+	if (peer->uncommitted_channel) {
+		if(!peer->uncommitted_channel->fc || !peer->uncommitted_channel->fc->inflight)
+			return command_fail(cmd, LIGHTNINGD, "No channel funding in progress.");
+
+		/* Make sure this gets notified if we succeed or cancel */
+		tal_arr_expand(&peer->uncommitted_channel->fc->cancels, cmd);
+		msg = towire_opening_funder_cancel(NULL);
+		subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
+		return command_still_pending(cmd);
 	}
 
-	if (!peer->uncommitted_channel->fc || !peer->uncommitted_channel->fc->inflight)
-		return command_fail(cmd, LIGHTNINGD, "No channel funding in progress.");
-
-	/**
-	 * there's a question of 'state machinery' here. as is, we're not checking
-	 * to see if you've already called `complete` -- we expect you
-	 * the caller to EITHER pick 'complete' or 'cancel'.
-	 * but if for some reason you've decided to test your luck, how much
-	 * 'handling' can we do for that case? the easiest thing to do is to
-	 * say "sorry you've already called complete", we can't cancel this.
-	 *
-	 * there's also the state you might end up in where you've called
-	 * complete (and it's completed and been passed off to channeld) but
-	 * you've decided (for whatever reason) not to broadcast the transaction
-	 * so your channels have ended up in this 'waiting' state. neither of us
-	 * are actually out any amount of cash, but it'd be nice if there's a way
-	 * to signal to c-lightning (+ your peer) that this channel is dead on arrival.
-	 * ... but also if you then broadcast this tx you'd be in trouble cuz we're
-	 * both going to forget about it. the meta question here is how 'undoable'
-	 * should we make any of this. how much tools do we give you, reader?
-	 *
-	 * for now, let's settle for the EITHER / OR case and disregard the larger
-	 * question about 'how long cancelable'.
-	 */
-
-	/* Make sure this gets notified if we succeed or cancel */
-	tal_arr_expand(&peer->uncommitted_channel->fc->cancels, cmd);
-	msg = towire_opening_funder_cancel(NULL);
-	subd_send_msg(peer->uncommitted_channel->openingd, take(msg));
-	return command_still_pending(cmd);
+	return cancel_channel_before_broadcast(cmd, buffer, peer, cidtok);
 }
 
 /**

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -441,9 +441,18 @@ void channel_errmsg(struct channel *channel,
 	 *    - MUST fail the channel referred to by the error message,
 	 *      if that channel is with the sending node.
 	 */
-	channel_fail_permanent(channel, "%s: %s ERROR %s",
-			       channel->owner->name,
-			       err_for_them ? "sent" : "received", desc);
+
+	/* We should immediately forget the channel if we receive error during
+	 * CHANNELD_AWAITING_LOCKIN if we are fundee. */
+	if (!err_for_them && channel->funder == REMOTE
+	    && channel->state == CHANNELD_AWAITING_LOCKIN)
+		channel_fail_forget(channel, "%s: %s ERROR %s",
+				    channel->owner->name,
+				    err_for_them ? "sent" : "received", desc);
+	else
+		channel_fail_permanent(channel, "%s: %s ERROR %s",
+				       channel->owner->name,
+				       err_for_them ? "sent" : "received", desc);
 }
 
 struct peer_connected_hook_payload {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1022,6 +1022,11 @@ def test_funding_external_wallet(node_factory, bitcoind):
 
     l1.daemon.wait_for_log(r'Funding tx {} depth 1 of 1'.format(txid))
 
+    # Check that tx is broadcast by a third party can be catched.
+    # Only when the transaction (broadcast by a third pary) is onchain, we can catch it.
+    with pytest.raises(RpcError, match=r'.* been broadcast.*'):
+        l1.rpc.fundchannel_cancel(l2.info['id'])
+
     for node in [l1, l2]:
         node.daemon.wait_for_log(r'State changed from CHANNELD_AWAITING_LOCKIN to CHANNELD_NORMAL')
         channel = node.rpc.listpeers()['peers'][0]['channels'][0]

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2847,6 +2847,23 @@ void wallet_transaction_annotate(struct wallet *w,
 	db_exec_prepared_v2(take(stmt));
 }
 
+bool wallet_transaction_type(struct wallet *w, const struct bitcoin_txid *txid,
+			     enum wallet_tx_type *type)
+{
+	struct db_stmt *stmt = db_prepare_v2(w->db, SQL("SELECT type FROM transactions WHERE id=?"));
+	db_bind_sha256(stmt, 0, &txid->shad.sha);
+	db_query_prepared(stmt);
+
+	if (!db_step(stmt)) {
+		tal_free(stmt);
+		return false;
+	}
+
+	*type = db_column_int(stmt, 0);
+	tal_free(stmt);
+	return true;
+}
+
 u32 wallet_transaction_height(struct wallet *w, const struct bitcoin_txid *txid)
 {
 	u32 blockheight;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1067,6 +1067,16 @@ void wallet_transaction_annotate(struct wallet *w,
 				 enum wallet_tx_type type, u64 channel_id);
 
 /**
+ * Get the type of a transaction we are watching by its
+ * txid.
+ *
+ * Returns false if the transaction was not stored in DB.
+ * Returns true if the transaction exists and sets the `type` parameter.
+ */
+bool wallet_transaction_type(struct wallet *w, const struct bitcoin_txid *txid,
+			     enum wallet_tx_type *type);
+
+/**
  * Get the confirmation height of a transaction we are watching by its
  * txid. Returns 0 if the transaction was not part of any block.
  */

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -397,6 +397,10 @@ static struct command_result *json_txsend(struct command *cmd,
 	/* We're the owning cmd now. */
 	utx->wtx->cmd = cmd;
 
+	wallet_transaction_add(cmd->ld->wallet, utx->tx, 0, 0);
+	wallet_transaction_annotate(cmd->ld->wallet, &utx->txid,
+				    TX_UNKNOWN, 0);
+
 	return broadcast_and_wait(cmd, utx);
 }
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -458,16 +458,14 @@ static struct command_result *json_withdraw(struct command *cmd,
 {
 	struct unreleased_tx *utx;
 	struct command_result *res;
-	struct bitcoin_txid txid;
 
 	res = json_prepare_tx(cmd, buffer, params, &utx, true);
 	if (res)
 		return res;
 
 	/* Store the transaction in the DB and annotate it as a withdrawal */
-	bitcoin_txid(utx->tx, &txid);
 	wallet_transaction_add(cmd->ld->wallet, utx->tx, 0, 0);
-	wallet_transaction_annotate(cmd->ld->wallet, &txid,
+	wallet_transaction_annotate(cmd->ld->wallet, &utx->txid,
 				    TX_WALLET_WITHDRAWAL, 0);
 
 	return broadcast_and_wait(cmd, utx);


### PR DESCRIPTION
Fix #2740 
This PR try to make `fundchannel_cancel` can work after `fundchannel_complete` and before funding broadcast.

### Process
The extended process is:
For funder:
- At the first, funder used `funderchannel_complete`; 
- Then funder calls `funderchannel_cancel`:
  - funder check if the `fundchannel` process completed ==>
  - If completed, funder check if its clightning has broadcast the funding and check if the funding has been onchain ==>
  - If these 2 check pass, funder ask its `channeld` send a error message to fundee ==> 
  - After sending error message, the funder delete(forget) the channel(also delete the peer, it's the limit of `delete_channel()`)

For fundee:
- After funder's `funderchannel_complete`, the channel state is `AWAITING_LOCKIN`. And the fundee begin to wait for funding locked both locally and remotely
- During `AWAITING_LOCKIN`, when fundee receives the error message from funder, fundee will delete(forget) the channel(also delete the peer, because of the limit of #2741 )

### Limits
But here's also some limits:
- **The check for funding broadcast can't completely ensure that the funding transaction isn't broadcast.** We can't know the case if the funding is broadcast by external wallet but the transaction hasn't been onchain.
This also ask caller to use `fundchannel_cancel` correctly: must be before funding broadcast.
- If `fundchannel_cancel` is called after `fundchannel_complete` and we cancel the channel successfully. **Then we must reconnect with the remote peer before `fundchannel_start` again.**
Like #2741 said, when the peer receive error message or when the peer deletes the channels, the peer will disconnect with the remote peer.
The main reason for this is `channel_set_owner(channel, NULL, false)` moves responsibility for the connection to connectd not openingd. If we want to keep connection, rolling back from `channeld` to `openingd` is necessary.

### Open Question
In f77d6c7 (Fix: Store the transaction(broadcast by `txsend`) into DB), I add the label `TX_UNKNOWN`
for the transaction broadcast by `txsend`.
I think maybe we can add optional string field for `txsend` command to specific the label. What do you think about it?

### Unfinished
- [x] Update document

- [x] Add CHANGELOG

~**Note**:  9ebb521 is duplicated with a commit of #2964 , just for making travis-ci happy~


Thanks for @ZmnSCPxj and @niftynei's explanation, direction and help!