### PR TITLE
WIP: lightningd/plugin: add field `early_conf`, allow plugin early (sync) config or abort

### DIFF
--- a/contrib/pylightning/lightning/plugin.py
+++ b/contrib/pylightning/lightning/plugin.py
@@ -99,7 +99,7 @@ class Plugin(object):
 
     """
 
-    def __init__(self, stdout=None, stdin=None, autopatch=True, dynamic=True):
+    def __init__(self, stdout=None, stdin=None, autopatch=True, dynamic=True, early_conf=False):
         self.methods = {'init': Method('init', self._init, MethodType.RPCMETHOD)}
         self.options = {}
 
@@ -121,8 +121,9 @@ class Plugin(object):
         self.rpc_filename = None
         self.lightning_dir = None
         self.rpc = None
-        self.startup = True
+        self.startup = None
         self.dynamic = dynamic
+        self.early_conf = early_conf
         self.child_init = None
 
         self.write_lock = RLock()
@@ -527,7 +528,8 @@ class Plugin(object):
             'rpcmethods': methods,
             'subscriptions': list(self.subscriptions.keys()),
             'hooks': hooks,
-            'dynamic': self.dynamic
+            'dynamic': self.dynamic,
+            'early_conf': self.early_conf
         }
 
     def _init(self, options, configuration, request):

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -686,6 +686,9 @@ int main(int argc, char *argv[])
 	/*~ Make sure we can reach the subdaemons, and versions match. */
 	test_subdaemons(ld);
 
+	/* Some *restricted* plugins may init (or abort) early before db touched */
+	plugins_early_config(ld->plugins);
+
 	/*~ Our "wallet" code really wraps the db, which is more than a simple
 	 * bitcoin wallet (though it's that too).  It also stores channel
 	 * states, invoices, payments, blocks and bitcoin transactions. */

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -32,6 +32,8 @@ struct plugin {
 	/* If this plugin can be restarted without restarting lightningd */
 	bool dynamic;
 	bool signal_startup;
+	/* Plugin initializes early, blocking lightningd, but is very restricted */
+	bool early_config;
 
 	/* Stuff we read */
 	char *buffer;
@@ -65,6 +67,7 @@ struct plugin {
 struct plugins {
 	struct list_head plugins;
 	size_t pending_manifests;
+	size_t pending_early_configs;
 	bool startup;
 
 	/* Currently pending requests by their request ID */
@@ -159,6 +162,14 @@ void PRINTF_FMT(2,3) plugin_kill(struct plugin *plugin, char *fmt, ...);
  * incoming JSON-RPC calls and messages.
  */
 void plugins_config(struct plugins *plugins);
+
+/**
+ * Sync'ed version of above, only for some very *limited* plugins that have set
+ * `early_config` in their getmanifest response to indicate they want to be
+ * initialized early.
+ */
+void plugins_early_config(struct plugins *plugins);
+
 /**
  * Add the plugin option and their respective options to listconfigs.
  *

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -140,6 +140,9 @@ void per_peer_state_set_fds_arr(struct per_peer_state *pps UNNEEDED, const int *
 /* Generated stub for plugins_config */
 void plugins_config(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_config called!\n"); abort(); }
+/* Generated stub for plugins_early_config */
+void plugins_early_config(struct plugins *plugins UNNEEDED)
+{ fprintf(stderr, "plugins_early_config called!\n"); abort(); }
 /* Generated stub for plugins_init */
 void plugins_init(struct plugins *plugins UNNEEDED, const char *dev_plugin_debug UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }


### PR DESCRIPTION
Another proposal to address issues raised in #2988, but now add a new plugins category `early_conf`. Plugins that set `early_conf = True` in `getmanifest` will initialize early in lightningd's startup, i.e. before the database is touched.

Useful to make a backup [plugin](https://github.com/lightningd/plugins/pull/40) more bulletproof. The  plugin now doesn't need to worry about db writes that happen before `init` or have to think about what their importance may be when crashing. It can now also safely copy the db during `init` without missing any `PRAGMA` statements (see #3007) or other that doesn't persist in the db (file).

Additionally this PR allows plugin `init` to return an `error`, which is handled as follow:
- At startup (meaning: not started via rpc `plugin start`) an init-error from `early_conf` plugin kills lightningd and aborts lightningd startup early.
- Outside startup (when started via `plugin start` cmd) an init-error from the plugin (any type) makes lightningd kill the plugin.

So `early_conf` plugins can now shutdown `lightningd` before anything happened, this wasn't possible before without hacks.

~Plugins that don't like to be started via rpc `plugin start` can check the configuration['startup'] field and return an init-error and be killed. However, plugins that register the (sync) `db_write` hook (which happens _before_ `init` is called) should then just _pass_ the hook calls when not fully initialized, or maybe it's `manifest` can check `startup = False` field and then not register the hook.~
**edit:** Plugins that are _freshly_ started via rpc `plugin start` and have set `dynamic=False` or `early_conf=True` in their manifest, should probably be killed by lightningd ASAP (in `plugin_manifest_cb`), so that no hook etc. is registered.

TODO:
- [ ] complete json error handling
- [ ] add tests
- [ ] update docs