### PR TITLE
JSON-API: `getroute` supports excluding `node`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build: Now requires [`gettext`](https://www.gnu.org/software/gettext/)
 - JSON API: `fundchannel_cancel` is extended to work before funding broadcast.
 - JSON API: The parameter `exclude` of `getroute` now also support node-id.
+- JSON-API: `pay` can exclude error nodes if the failcode of `sendpay` has the NODE bit set
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `txprepare` now uses `outputs` as parameter other than `destination` and `satoshi`
 - Build: Now requires [`gettext`](https://www.gnu.org/software/gettext/)
 - JSON API: `fundchannel_cancel` is extended to work before funding broadcast.
+- JSON API: The parameter `exclude` of `getroute` now also support node-id.
 
 ### Deprecated
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -596,8 +596,8 @@ class LightningRpc(UnixDomainSocketRpc):
         {cltv} (default 9). If specified search from {fromid} otherwise use
         this node as source. Randomize the route with up to {fuzzpercent}
         (0.0 -> 100.0, default 5.0). {exclude} is an optional array of
-        scid/direction to exclude. Limit the number of hops in the route to
-        {maxhops}.
+        scid/direction or node-id to exclude. Limit the number of hops in the
+        route to {maxhops}.
         """
         payload = {
             "id": node_id,

--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -45,8 +45,10 @@ default is 5\.0, or up to 5% fee distortion\.
 
 
 \fIexclude\fR is a JSON array of short-channel-id/direction (e\.g\. [
-"564334x877x1/0", "564195x1292x0/1" ]) which should be excluded from
-consideration for routing\. The default is not to exclude any channels\.
+"564334x877x1/0", "564195x1292x0/1" ]) or node-id which should be excluded
+from consideration for routing\. The default is not to exclude any channels
+or nodes\. Note if the source or destination is excluded, the command result
+is undefined\.
 
 
 \fImaxhops\fR is the maximum number of channels to return; default is 20\.

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -40,8 +40,10 @@ route generated. 0.0 means the exact fee of that channel is used, while
 default is 5.0, or up to 5% fee distortion.
 
 *exclude* is a JSON array of short-channel-id/direction (e.g. \[
-"564334x877x1/0", "564195x1292x0/1" \]) which should be excluded from
-consideration for routing. The default is not to exclude any channels.
+"564334x877x1/0", "564195x1292x0/1" \]) or node-id which should be excluded
+from consideration for routing. The default is not to exclude any channels
+or nodes. Note if the source or destination is excluded, the command result
+is undefined.
 
 *maxhops* is the maximum number of channels to return; default is 20.
 

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -39,7 +39,7 @@ msgdata,gossip_getroute_request,riskfactor_by_million,u64,
 msgdata,gossip_getroute_request,final_cltv,u32,
 msgdata,gossip_getroute_request,fuzz,double,
 msgdata,gossip_getroute_request,num_excluded,u16,
-msgdata,gossip_getroute_request,excluded,short_channel_id_dir,num_excluded
+msgdata,gossip_getroute_request,excluded,exclude_entry,num_excluded
 msgdata,gossip_getroute_request,max_hops,u32,
 
 msgtype,gossip_getroute_reply,3106

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -2488,7 +2488,7 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 	u8 *out;
 	struct route_hop *hops;
 	double fuzz;
-	struct short_channel_id_dir *excluded;
+	struct exclude_entry **excluded;
 
 	/* To choose between variations, we need to know how much we're
 	 * sending (eliminates too-small channels, and also effects the fees

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -268,6 +268,19 @@ struct route_hop {
 	u32 delay;
 };
 
+enum exclude_entry_type {
+	EXCLUDE_CHANNEL = 1,
+	EXCLUDE_NODE = 2
+};
+
+struct exclude_entry {
+	enum exclude_entry_type type;
+	union {
+		struct short_channel_id_dir chan_id;
+		struct node_id node_id;
+	} u;
+};
+
 struct routing_state *new_routing_state(const tal_t *ctx,
 					const struct chainparams *chainparams,
 					const struct node_id *local_id,

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -348,7 +348,7 @@ struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    u32 final_cltv,
 			    double fuzz,
 			    u64 seed,
-			    const struct short_channel_id_dir *excluded,
+			    struct exclude_entry **excluded,
 			    size_t max_hops);
 /* Disable channel(s) based on the given routing failure. */
 void routing_failure(struct routing_state *rstate,

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -87,7 +87,7 @@ bool fromwire_gossip_get_incoming_channels(const tal_t *ctx UNNEEDED, const void
 bool fromwire_gossip_getnodes_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **id UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getnodes_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_getroute_request */
-bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct short_channel_id_dir **excluded UNNEEDED, u32 *max_hops UNNEEDED)
+bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getroute_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_get_txout_reply */
 bool fromwire_gossip_get_txout_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct amount_sat *satoshis UNNEEDED, u8 **outscript UNNEEDED)
@@ -140,7 +140,7 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    u32 final_cltv UNNEEDED,
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
-			    const struct short_channel_id_dir *excluded UNNEEDED,
+			    struct exclude_entry **excluded UNNEEDED,
 			    size_t max_hops UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */

--- a/gossipd/test/run-extended-info.c
+++ b/gossipd/test/run-extended-info.c
@@ -110,7 +110,7 @@ bool fromwire_gossip_get_incoming_channels(const tal_t *ctx UNNEEDED, const void
 bool fromwire_gossip_getnodes_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **id UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getnodes_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_getroute_request */
-bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct short_channel_id_dir **excluded UNNEEDED, u32 *max_hops UNNEEDED)
+bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getroute_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_get_txout_reply */
 bool fromwire_gossip_get_txout_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct amount_sat *satoshis UNNEEDED, u8 **outscript UNNEEDED)
@@ -163,7 +163,7 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    u32 final_cltv UNNEEDED,
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
-			    const struct short_channel_id_dir *excluded UNNEEDED,
+			    struct exclude_entry **excluded UNNEEDED,
 			    size_t max_hops UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -313,7 +313,7 @@ static struct command_result *json_getroute(struct command *cmd,
 	struct amount_msat *msat;
 	unsigned *cltv;
 	double *riskfactor;
-	struct short_channel_id_dir *excluded;
+	const struct exclude_entry **excluded;
 	u32 *max_hops;
 
 	/* Higher fuzz means that some high-fee paths can be discounted
@@ -343,19 +343,31 @@ static struct command_result *json_getroute(struct command *cmd,
 		const jsmntok_t *t;
 		size_t i;
 
-		excluded = tal_arr(cmd, struct short_channel_id_dir,
-				   excludetok->size);
+		excluded = tal_arr(cmd, const struct exclude_entry *, 0);
 
 		json_for_each_arr(i, t, excludetok) {
+			struct exclude_entry *entry = tal(excluded, struct exclude_entry);
+			struct short_channel_id_dir *chan_id = tal(tmpctx, struct short_channel_id_dir);
 			if (!short_channel_id_dir_from_str(buffer + t->start,
 							   t->end - t->start,
-							   &excluded[i])) {
-				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-						    "%.*s is not a valid"
-						    " short_channel_id/direction",
-						    t->end - t->start,
-						    buffer + t->start);
+							   chan_id)) {
+				struct node_id *node_id = tal(tmpctx, struct node_id);
+
+				if (!json_to_node_id(buffer, t, node_id))
+					return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+							    "%.*s is not a valid"
+							    " short_channel_id/node_id",
+							    t->end - t->start,
+							    buffer + t->start);
+
+				entry->type = EXCLUDE_NODE;
+				entry->u.node_id = *node_id;
+			} else {
+				entry->type = EXCLUDE_CHANNEL;
+				entry->u.chan_id = *chan_id;
 			}
+
+			tal_arr_expand(&excluded, entry);
 		}
 	} else {
 		excluded = NULL;
@@ -379,7 +391,7 @@ static const struct json_command getroute_command = {
 	"If specified search from {fromid} otherwise use this node as source. "
 	"Randomize the route with up to {fuzzpercent} (default 5.0). "
 	"{exclude} an array of short-channel-id/direction (e.g. [ '564334x877x1/0', '564195x1292x0/1' ]) "
-	"from consideration. "
+	"or node-id from consideration. "
 	"Set the {maxhops} the route can take (default 20)."
 };
 AUTODATA(json_command, &getroute_command);

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -195,3 +195,33 @@ void towire_peer_features(u8 **pptr, const struct peer_features *pf)
 	towire_u16(pptr, tal_count(pf->globalfeatures));
 	towire_u8_array(pptr, pf->globalfeatures, tal_count(pf->globalfeatures));
 }
+
+struct exclude_entry *fromwire_exclude_entry(const tal_t *ctx,
+					     const u8 **pptr, size_t *max)
+{
+	struct exclude_entry *entry = tal(ctx, struct exclude_entry);
+	entry->type = fromwire_u8(pptr, max);
+	switch (entry->type) {
+		case EXCLUDE_CHANNEL:
+			fromwire_short_channel_id_dir(pptr, max, &entry->u.chan_id);
+			return entry;
+		case EXCLUDE_NODE:
+			fromwire_node_id(pptr, max, &entry->u.node_id);
+			return entry;
+		default:
+			fromwire_fail(pptr, max);
+			return NULL;
+	}
+}
+
+void towire_exclude_entry(u8 **pptr, const struct exclude_entry *entry)
+{
+	assert(entry->type == EXCLUDE_CHANNEL ||
+	       entry->type == EXCLUDE_NODE);
+
+	towire_u8(pptr, entry->type);
+	if (entry->type == EXCLUDE_CHANNEL)
+		towire_short_channel_id_dir(pptr, &entry->u.chan_id);
+	else
+		towire_node_id(pptr, &entry->u.node_id);
+}

--- a/lightningd/gossip_msg.h
+++ b/lightningd/gossip_msg.h
@@ -61,4 +61,9 @@ fromwire_gossip_getchannels_entry(const tal_t *ctx,
 void towire_gossip_getchannels_entry(
     u8 **pptr, const struct gossip_getchannels_entry *entry);
 
+struct exclude_entry *
+fromwire_exclude_entry(const tal_t *ctx,
+		       const u8 **pptr, size_t *max);
+void towire_exclude_entry(u8 **pptr, const struct exclude_entry *entry);
+
 #endif /* LIGHTNING_LIGHTNINGD_GOSSIP_MSG_H */

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -9,7 +9,9 @@ plugin = Plugin()
 def on_htlc_accepted(onion, plugin, **kwargs):
     plugin.log("Failing htlc on purpose")
     plugin.log("onion: %r" % (onion))
-    return {"result": "fail", "failure_code": 16399}
+    # FIXME: Define this!
+    WIRE_TEMPORARY_NODE_FAILURE = 0x2002
+    return {"result": "fail", "failure_code": WIRE_TEMPORARY_NODE_FAILURE}
 
 
 plugin.run()

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -217,6 +217,7 @@ class Type(FieldSet):
         'wirestring',
         'per_peer_state',
         'bitcoin_tx_output',
+        'exclude_entry',
     ]
 
     # Some BOLT types are re-typed based on their field name


### PR DESCRIPTION
Fixed #2894 

Following @ZmnSCPxj 's nice and clear proposal in #2894 , now `getroute` supports excluding `node`s by excluding all incoming channels of nodes.

- [x] Add the modification to `pay` to also exclude nodes if the failcode has the NODE bit set.