### PR TITLE
Pylightning: pass through non-ascii characters in the JSON input formatting

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -172,7 +172,7 @@ class UnixDomainSocketRpc(object):
         self.next_id = 0
 
     def _writeobj(self, sock, obj):
-        s = json.dumps(obj, cls=self.encoder_cls)
+        s = json.dumps(obj, ensure_ascii=False, cls=self.encoder_cls)
         sock.sendall(bytearray(s, 'UTF-8'))
 
     def _readobj(self, sock, buff=b''):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2000,7 +2000,6 @@ def test_new_node_is_mainnet(node_factory):
     assert os.path.isfile(os.path.join(basedir, "lightningd-bitcoin.pid"))
 
 
-@pytest.mark.xfail(strict=True)
 def test_unicode_rpc(node_factory):
     node = node_factory.get_node()
     desc = "Some candy 🍬 and a nice glass of milk 🥛."

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1998,3 +1998,15 @@ def test_new_node_is_mainnet(node_factory):
     assert not os.path.isfile(os.path.join(basedir, "hsm_secret"))
     assert not os.path.isfile(os.path.join(netdir, "lightningd-bitcoin.pid"))
     assert os.path.isfile(os.path.join(basedir, "lightningd-bitcoin.pid"))
+
+
+@pytest.mark.xfail(strict=True)
+def test_unicode_rpc(node_factory):
+    node = node_factory.get_node()
+    desc = "Some candy 🍬 and a nice glass of milk 🥛."
+
+    node.rpc.invoice(msatoshi=42, label=desc, description=desc)
+    invoices = node.rpc.listinvoices()['invoices']
+    assert(len(invoices) == 1)
+    assert(invoices[0]['description'] == desc)
+    assert(invoices[0]['label'] == desc)


### PR DESCRIPTION
Addresses issue #2753, which describes the problem and exception that was being seen.

This change enables non-ascii characters such as emojis to be included in the description field via pylightning:

Have done a bit of testing by passing in ascii strings:  `\ud83d\udc7d` `\\\\udc74`  and  `\\udc7d` seem to work as being interpreted as literal ascii rather than some unicode character, which is what is intended. I suspect the JSON encoding/decoding is handling this correctly in this mode.