### PR TITLE
pylightning: adds Millisatoshi __radd__ method

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -157,6 +157,9 @@ class Millisatoshi:
     def __mod__(self, other):
         return Millisatoshi(int(self) % other)
 
+    def __radd__(self, other):
+        return Millisatoshi(int(self) + int(other))
+
 
 class UnixDomainSocketRpc(object):
     def __init__(self, socket_path, executor=None, logger=logging, encoder_cls=json.JSONEncoder, decoder=json.JSONDecoder()):

--- a/contrib/pylightning/tests/test_millisatoshi.py
+++ b/contrib/pylightning/tests/test_millisatoshi.py
@@ -1,0 +1,6 @@
+from lightning import Millisatoshi
+
+
+def test_sum_radd():
+    result = sum([Millisatoshi(1), Millisatoshi(2), Millisatoshi(3)])
+    assert int(result) == 6

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -213,6 +213,11 @@ There are three kinds of tests:
   `DEBUG_SUBD=<subdaemon>` and `TIMEOUT=<seconds>` can be useful for debugging
   subdaemons on individual tests.
 
+* **pylightning tests** - will check contrib pylightning for codestyle and run
+  the tests in `contrib/pylightning/tests` afterwards:
+
+  `make check-python`.
+
 Our Travis CI instance (see `.travis.yml`) runs all these for each
 pull request.
 


### PR DESCRIPTION
This is useful when using stuff like `sum()` on an array of Millisatoshis etc. that would otherwise throw an TypeError, i.e.:

```
$ lightning-cli helpme
"Error while processing helpme: TypeError(\"unsupported operand type(s) for +: 'int' and 'Millisatoshi'\")"
```

I tested this RP with a version of the `helpme` plugin that was iterating on a `Millisatoshi` list.
Also a unittest is in-place that can/should be enriched with further `Millisatoshi` related tests.