### PR TITLE
Track withdrawal change

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -8,7 +8,6 @@ import pytest
 import time
 
 
-@pytest.mark.xfail
 def test_withdraw(node_factory, bitcoind):
     amount = 1000000
     # Don't get any funds from previous runs.

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1372,6 +1372,11 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 			tal_free(utxo);
 			continue;
 		}
+
+		/* This is an unconfirmed change output, we should track it */
+		if (!is_p2sh && !blockheight)
+			txfilter_add_scriptpubkey(w->ld->owned_txfilter, script);
+
 		outpointfilter_add(w->owned_outpoints, &utxo->txid, utxo->outnum);
 
 		if (!amount_sat_add(total, *total, utxo->amount))


### PR DESCRIPTION
Change outputs from withdrawn (and tx_prepare'd) transactions aren't being marked as confirmed since they aren't being added to our txfilter; this fixes this.
