### PR TITLE
listfunds: add 'blockheight' for confirmed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- JSON API: `listfunds` now lists a blockheight for confirmed transactions
 
 ### Changed
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -310,7 +310,7 @@ static const struct utxo **wallet_select(const tal_t *ctx, struct wallet *w,
 
 		/* If we require confirmations check that we have a
 		 * confirmation height and that it is below the required
-		 * maxheight (current_height - minconf */
+		 * maxheight (current_height - minconf) */
 		if (maxheight != 0 &&
 		    (!u->blockheight || *u->blockheight > maxheight))
 			continue;

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -629,9 +629,10 @@ static struct command_result *json_listfunds(struct command *cmd,
 
 		if (utxos[i]->spendheight)
 			json_add_string(response, "status", "spent");
-		else if (utxos[i]->blockheight)
+		else if (utxos[i]->blockheight) {
 			json_add_string(response, "status", "confirmed");
-		else
+			json_add_num(response, "blockheight", *utxos[i]->blockheight);
+		} else
 			json_add_string(response, "status", "unconfirmed");
 
 		json_object_end(response);


### PR DESCRIPTION
I thought I was going to need this for the `fundchannel` branch, but it ended up being extra. It's a nice thing to expose anyway, as plugins and other apps might need it.