### PR TITLE
lightningd/options: Make a specified lightning_dir absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ changes.
 
 ### Fixed
 
+- Relative `--lightning_dir` is now working again.
+
 ### Security
 
 ## [0.7.2.1] - 2019-08-19: "Nakamoto's Pre-approval by US Congress"

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -543,9 +543,8 @@ static void pidfile_create(const struct lightningd *ld)
 	int pid_fd;
 	char *pid;
 
-	/* Create PID file: relative to .config dir unless absolute. */
-	pid_fd = open(path_join(tmpctx, ld->config_dir, ld->pidfile),
-		      O_WRONLY|O_CREAT, 0640);
+	/* Create PID file: relative to .config dir. */
+	pid_fd = open(ld->pidfile, O_WRONLY|O_CREAT, 0640);
 	if (pid_fd < 0)
 		err(1, "Failed to open PID file");
 


### PR DESCRIPTION
This adds a custom `option_set_` function for the `config_dir` in order to handle relative paths for the `--lightning-dir` option.
Fixes #3023.