### PR TITLE
Test fixture fixes and a memleak

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -828,30 +828,6 @@ static u8 *funder_channel_complete(struct state *state)
 	 * succeed because we checked it earlier */
 	assert(amount_sat_sub_msat(&local_msat, state->funding, state->push_msat));
 
-	state->channel = new_initial_channel(state,
-					     &state->chainparams->genesis_blockhash,
-					     &state->funding_txid,
-					     state->funding_txout,
-					     state->minimum_depth,
-					     state->funding,
-					     local_msat,
-					     state->feerate_per_kw,
-					     &state->localconf,
-					     &state->remoteconf,
-					     &state->our_points,
-					     &state->their_points,
-					     &state->our_funding_pubkey,
-					     &state->their_funding_pubkey,
-					     /* Funder is local */
-					     LOCAL);
-	/* We were supposed to do enough checks above, but just in case,
-	 * new_initial_channel will fail to create absurd channels */
-	if (!state->channel)
-		peer_failed(state->pps,
-			    &state->channel_id,
-			    "could not create channel with given config");
-
-
 	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx))
 		return NULL;
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -127,10 +127,6 @@ def node_factory(request, directory, test_name, bitcoind, executor):
         err_count += printCrashLog(node)
     check_errors(request, err_count, "{} nodes had crash.log files")
 
-    for node in [n for n in nf.nodes if not n.allow_broken_log]:
-        err_count += checkBroken(node)
-    check_errors(request, err_count, "{} nodes had BROKEN messages")
-
     for node in nf.nodes:
         err_count += checkReconnect(node)
     check_errors(request, err_count, "{} nodes had unexpected reconnections")
@@ -152,6 +148,10 @@ def node_factory(request, directory, test_name, bitcoind, executor):
         err_count += checkMemleak(node)
     if err_count:
         raise ValueError("{} nodes had memleak messages".format(err_count))
+
+    for node in [n for n in nf.nodes if not n.allow_broken_log]:
+        err_count += checkBroken(node)
+    check_errors(request, err_count, "{} nodes had BROKEN messages")
 
     if not ok:
         request.node.has_errors = True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -967,6 +967,7 @@ class NodeFactory(object):
     def killall(self, expected_successes):
         """Returns true if every node we expected to succeed actually succeeded"""
         unexpected_fail = False
+        err_msgs = []
         for i in range(len(self.nodes)):
             leaks = None
             # leak detection upsets VALGRIND by reading uninitialized mem.
@@ -985,9 +986,10 @@ class NodeFactory(object):
                     unexpected_fail = True
 
             if leaks is not None and len(leaks) != 0:
-                raise Exception("Node {} has memory leaks: {}".format(
+                unexpected_fail = True
+                err_msgs.append("Node {} has memory leaks: {}".format(
                     self.nodes[i].daemon.lightning_dir,
                     json.dumps(leaks, sort_keys=True, indent=4)
                 ))
 
-        return not unexpected_fail
+        return not unexpected_fail, err_msgs


### PR DESCRIPTION
Fixup a few gotchas with the test fixtures around it deleting log files and not killing all the nodes properly  on memleak errors.

Also fixes a memleak error in `openingd`; exposed by the fundchannel plugin move.