### PR TITLE
pytest: Collect errors in teardowns and allow running in ramdisk

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,7 +29,9 @@ __attempts = {}
 
 @pytest.fixture(scope="session")
 def test_base_dir():
-    directory = tempfile.mkdtemp(prefix='ltests-')
+    d = os.getenv("TEST_DIR", "/tmp")
+
+    directory = tempfile.mkdtemp(prefix='ltests-', dir=d)
     print("Running tests in {}".format(directory))
 
     yield directory

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -147,6 +147,7 @@ def teardown_checks(request):
         request.node.has_errors = True
         raise ValueError(str(errors))
 
+
 @pytest.fixture
 def node_factory(request, directory, test_name, bitcoind, executor, teardown_checks):
     nf = NodeFactory(
@@ -157,7 +158,6 @@ def node_factory(request, directory, test_name, bitcoind, executor, teardown_che
     )
 
     yield nf
-    err_count = 0
     ok, errs = nf.killall([not n.may_fail for n in nf.nodes])
 
     for e in errs:


### PR DESCRIPTION
My machine would accumulate a number of zombie lightningd and bitcoind
processes over time while testing. Investigating this showed that if a fixture
raised an exception during fixture teardown then other fixtures that have not
been torn down would linger around. The issue is that pytest treats exceptions
in fixtures as non-recoverable and therefore will not catch them and call the
remaining ones.

The first commit adds a new fixture, that is there just to collect eventual errors
from other fixtures and ensure that anything that needs to clean up something,
e.g., processes started by the fixture, are cleaned up before we raise an
eventual exception. This is achieved by making any fixture that needs cleaning
up dependent on the teardown_checks fixture, which also serves as central
point to collect errors and printer of eventual errors.

The last commit also adds the ability to select which directory to use as a root
directory for all tests. If you set this to `/dev/shm` you can get quite a speed
increase (roughly halving the test time in my benchmarks on a beefy test
machine).