### PR TITLE
Fix build if pwritev does not exist (Mac)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ changes.
 ### Fixed
 
 - Relative `--lightning_dir` is now working again.
+- Build: MacOS now builds again (missing pwritev).
 
 ### Security
 

--- a/configure
+++ b/configure
@@ -292,6 +292,29 @@ code=
 #error "Not modern GCC"
 #endif
 /*END*/
+var=HAVE_PWRITEV
+desc=pwritev() defined
+style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
+code=
+#include <sys/uio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int main(void)
+{
+	struct iovec iov[2];
+	int fd = open("/dev/null", O_WRONLY);
+
+	iov[0].iov_base = "hello";
+	iov[0].iov_len = 5;
+	iov[1].iov_base = " world";
+	iov[1].iov_len = 6;
+	if (pwritev(fd, iov, 2, 0) == 11)
+		return 0;
+	return 1;
+}
+/*END*/
 EOF
 mv $CONFIG_VAR_FILE.$$ $CONFIG_VAR_FILE
 


### PR DESCRIPTION
(tested locally by turning `#if HAVE_PWRITEV` into `#if 0`)
Fixes: #3041