### PR TITLE
jsonrpc: add more fields to listfunds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- JSON API: `listfunds` now lists a blockheight for confirmed transactions
+- JSON API: `listfunds` now lists a blockheight for confirmed transactions,
+  and has `connected` and `state` fields for channels, like `listpeers`.
 - JSON API: `fundchannel_start` now includes field `scriptpubkey`
 - JSON API: `txprepare` and `withdraw` now accept an optional parameter `utxos`, a list of utxos to include in the prepared transaction
 

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -60,6 +60,11 @@ appended\.
 .IP \[bu]
 \fIfunding_output\fR - the index of the output in the funding
 transaction\.
+.IP \[bu]
+\fIconnected\fR - whether the channel peer is connected\.
+.IP \[bu]
+\fIstate\fR - the channel state, in particular \fICHANNELD_NORMAL\fR means the
+channel can be used normally\.
 
 .SH AUTHOR
 

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -45,6 +45,9 @@ Each entry in *channels* will include:
 -   *funding\_txid* - funding transaction id.
 -   *funding\_output* - the index of the output in the funding
     transaction.
+-   *connected* - whether the channel peer is connected.
+-   *state* - the channel state, in particular *CHANNELD_NORMAL* means the
+    channel can be used normally.
 
 AUTHOR
 ------

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -771,6 +771,11 @@ static struct command_result *json_listfunds(struct command *cmd,
 		list_for_each(&p->channels, c, list) {
 			json_object_start(response, NULL);
 			json_add_node_id(response, "peer_id", &p->id);
+			/* Mirrors logic in listpeers */
+			json_add_bool(response, "connected",
+				      channel_active(c) && c->connected);
+			json_add_string(response, "state",
+					channel_state_name(c));
 			if (c->scid)
 				json_add_short_channel_id(response,
 							  "short_channel_id",


### PR DESCRIPTION
This avoids having to correlate with listpeers for the most pertinent information.

Closes: #2882 