### PR TITLE
fix macOS build & update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,15 +188,15 @@ BOLT_DEPS := $(BOLT_GEN)
 
 ALL_PROGRAMS =
 
-CPPFLAGS = -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\""
+CPPFLAGS += -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\""
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS)
 
 # We can get configurator to run a different compile cmd to cross-configure.
 CONFIGURATOR_CC := $(CC)
 
-LDFLAGS = $(PIE_LDFLAGS) $(SANITIZER_FLAGS) $(COPTFLAGS)
+LDFLAGS += $(PIE_LDFLAGS) $(SANITIZER_FLAGS) $(COPTFLAGS)
 ifeq ($(STATIC),1)
-LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp -lsqlite3 -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
+LDLIBS = -L/usr/local/lib -Wl,-lgmp -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
 else
 LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
 endif

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -180,7 +180,23 @@ To Build on macOS
 
 Assuming you have Xcode and Homebrew installed. Install dependencies:
 
-    $ brew install autoconf automake libtool python3 gmp gnu-sed
+    $ brew install autoconf automake libtool python3 gmp gnu-sed gettext
+    $ ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
+    $ export PATH="/usr/local/opt:$PATH"
+
+If you need SQLite (or get a SQLite mismatch build error):
+
+    $ brew install sqlite
+    $ export LDFLAGS="-L/usr/local/opt/sqlite/lib"
+    $ export CPPFLAGS="-I/usr/local/opt/sqlite/include"
+
+If you need Python 3.x for mako (or get a mako build error):
+
+    $ brew install pyenv
+    $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+    $ source ~/.bash_profile
+    $ pyenv install 3.7.4
+    $ pip install --upgrade pip
 
 If you don't have bitcoind installed locally you'll need to install that
 as well:
@@ -196,6 +212,11 @@ Clone lightning:
 
     $ git clone https://github.com/ElementsProject/lightning.git
     $ cd lightning
+
+Configure Python 3.x & get mako:
+
+    $ pyenv local 3.7.4
+    $ pip install mako
 
 Build lightning:
 


### PR DESCRIPTION
Makefile wasn't respecting adding things to LDFLAGS or CPPFLAGS. Besides general goodness, this is necessary to add the proper include paths to avoid a sqlite mismatch error when running the build with a newer version of sqlite installed (e.g. via brew).

Removed -dn & -dy from LDLIBS because clang doesn't understand them and they will cause --enable-static to fail on macOS. Since these are just debugging flags, and can still be passed in if someone really needs them, seems fine.

v0.7.2 wants Python 3.x + mako and make wants xgettext. I updated the docs to reflect  instructions for these additional dependencies to fix those breaks. 