### PR TITLE
Postgresql driver for the multi-database abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.gcno
 *.dSYM
 *.rej
+*.po
 *.pyc
 .cppcheck-suppress
 TAGS

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,11 @@ else
 LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
 endif
 
+# If we have the postgres client library we need to link against it as well
+ifeq ($(HAVE_POSTGRES),1)
+LDLIBS += -lpq
+endif
+
 default: all-programs all-test-programs
 
 ccan/config.h: config.vars configure ccan/tools/configurator/configurator.c

--- a/configure
+++ b/configure
@@ -273,6 +273,20 @@ int main(void)
 	return 0;
 }
 /*END*/
+var=HAVE_POSTGRES
+desc=postgres
+style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
+link=-lpq
+code=
+#include <postgresql/libpq-fe.h>
+#include <stdio.h>
+
+int main(void)
+{
+	printf("libpq version %d\n", PQlibVersion());
+	return 0;
+}
+/*END*/
 var=HAVE_GCC
 desc=compiler is GCC
 style=OUTSIDE_MAIN

--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -10,8 +10,12 @@ class Sqlite3Rewriter(object):
         return query
 
 
+class PostgresRewriter(Sqlite3Rewriter):
+    pass
+
 rewriters = {
     "sqlite3": Sqlite3Rewriter(),
+    "postgres": PostgresRewriter(),
 }
 
 template = Template("""#ifndef LIGHTNINGD_WALLET_GEN_DB_${f.upper()}

--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -77,7 +77,7 @@ def extract_queries(pofile):
         query = c[i][7:][:-1]
 
         queries.append({
-            'name': name,
+            'name': query,
             'query': query,
             'placeholders': query.count('?'),
             'readonly': "true" if query.upper().startswith("SELECT") else "false",

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -149,6 +149,12 @@ is a relative path, it is relative to the starting directory, not
 readable (we allow missing files in the default case)\. Using this inside
 a configuration file is meaningless\.
 
+
+ \fBwallet\fR=\fIDSN\fR
+Identify the location of the wallet\. This is a fully qualified data source
+name, including a scheme such as \fBsqlite3\fR or \fBpostgres\fR followed by the
+connection parameters\.
+
 .SH Lightning node customization options
 
  \fBalias\fR=\fIRRGGBB\fR

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -128,6 +128,11 @@ is a relative path, it is relative to the starting directory, not
 readable (we allow missing files in the default case). Using this inside
 a configuration file is meaningless.
 
+ **wallet**=*DSN*
+Identify the location of the wallet. This is a fully qualified data source
+name, including a scheme such as `sqlite3` or `postgres` followed by the
+connection parameters.
+
 ### Lightning node customization options
 
  **alias**=*RRGGBB*

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -228,6 +228,8 @@ struct lightningd {
 	const char *original_directory;
 
 	struct plugins *plugins;
+
+	char *wallet_dsn;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -808,6 +808,11 @@ static void handle_minimal_config_opts(struct lightningd *ld,
 			       opt_ignore_talstr, opt_show_charp,
 			       &ld->config_dir,
 			       "Set working directory. All other files are relative to this");
+
+	ld->wallet_dsn = tal_fmt(ld, "sqlite3://%s/lightningd.sqlite3", ld->config_dir);
+	opt_register_early_arg("--wallet", opt_set_talstr, NULL,
+			       &ld->wallet_dsn,
+			       "Location of the wallet database.");
 }
 
 static void register_opts(struct lightningd *ld)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-sqlparse==0.3.0
 mako==1.0.14
 mrkd==0.1.5

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,0 +1,169 @@
+from ephemeral_port_reserve import reserve
+
+import logging
+import os
+import psycopg2
+import random
+import shutil
+import signal
+import sqlite3
+import string
+import subprocess
+import time
+
+
+class Sqlite3Db(object):
+    def __init__(self, path):
+        self.path = path
+
+    def get_dsn(self):
+        """SQLite3 doesn't provide a DSN, resulting in no CLI-option.
+        """
+        return None
+
+    def query(self, query):
+        orig = os.path.join(self.path)
+        copy = self.path + ".copy"
+        shutil.copyfile(orig, copy)
+        db = sqlite3.connect(copy)
+
+        db.row_factory = sqlite3.Row
+        c = db.cursor()
+        c.execute(query)
+        rows = c.fetchall()
+
+        result = []
+        for row in rows:
+            result.append(dict(zip(row.keys(), row)))
+
+        db.commit()
+        c.close()
+        db.close()
+        return result
+
+    def execute(self, query):
+        db = sqlite3.connect(self.path)
+        c = db.cursor()
+        c.execute(query)
+        db.commit()
+        c.close()
+        db.close()
+
+
+class PostgresDb(object):
+    def __init__(self, dbname, port):
+        self.dbname = dbname
+        self.port = port
+
+        self.conn = psycopg2.connect("dbname={dbname} user=postgres host=localhost port={port}".format(
+            dbname=dbname, port=port
+        ))
+        cur = self.conn.cursor()
+        cur.execute('SELECT 1')
+        cur.close()
+
+    def get_dsn(self):
+        return "postgres://postgres:password@localhost:{port}/{dbname}".format(
+            port=self.port, dbname=self.dbname
+        )
+
+    def query(self, query):
+        cur = self.conn.cursor()
+        cur.execute(query)
+
+        # Collect the results into a list of dicts.
+        res = []
+        for r in cur:
+            t = {}
+            # Zip the column definition with the value to get its name.
+            for c, v in zip(cur.description, r):
+                t[c.name] = v
+            res.append(t)
+        cur.close()
+        return res
+
+    def execute(self, query):
+        with self.conn, self.conn.cursor() as cur:
+            cur.execute(query)
+
+
+class SqliteDbProvider(object):
+    def __init__(self, directory):
+        self.directory = directory
+
+    def start(self):
+        pass
+
+    def get_db(self, node_directory, testname, node_id):
+        path = os.path.join(
+            node_directory,
+            'lightningd.sqlite3'
+        )
+        return Sqlite3Db(path)
+
+    def stop(self):
+        pass
+
+
+class PostgresDbProvider(object):
+    def __init__(self, directory):
+        self.directory = directory
+        self.port = None
+        self.proc = None
+        print("Starting PostgresDbProvider")
+
+    def start(self):
+        passfile = os.path.join(self.directory, "pgpass.txt")
+        self.pgdir = os.path.join(self.directory, 'pgsql')
+        # Need to write a tiny file containing the password so `initdb` can pick it up
+        with open(passfile, 'w') as f:
+            f.write('cltest\n')
+        subprocess.check_call([
+            '/usr/lib/postgresql/10/bin/initdb',
+            '--pwfile={}'.format(passfile),
+            '--pgdata={}'.format(self.pgdir),
+            '--auth=trust',
+            '--username=postgres',
+        ])
+        self.port = reserve()
+        self.proc = subprocess.Popen([
+            '/usr/lib/postgresql/10/bin/postgres',
+            '-k', '/tmp/',  # So we don't use /var/lib/...
+            '-D', self.pgdir,
+            '-p', str(self.port),
+            '-F',
+            '-i',
+        ])
+        # Hacky but seems to work ok (might want to make the postgres proc a TailableProc as well if too flaky).
+        time.sleep(1)
+        self.conn = psycopg2.connect("dbname=template1 user=postgres host=localhost port={}".format(self.port))
+
+        # Required for CREATE DATABASE to work
+        self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+    def get_db(self, node_directory, testname, node_id):
+        # Random suffix to avoid collisions on repeated tests
+        nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+        dbname = "{}_{}_{}".format(testname, node_id, nonce)
+
+        cur = self.conn.cursor()
+        cur.execute("CREATE DATABASE {};".format(dbname))
+        cur.close()
+        db = PostgresDb(dbname, self.port)
+        return db
+
+    def stop(self):
+        # Send fast shutdown signal see [1] for details:
+        #
+        # SIGINT
+        #
+        # This is the Fast Shutdown mode. The server disallows new connections
+        # and sends all existing server processes SIGTERM, which will cause
+        # them to abort their current transactions and exit promptly. It then
+        # waits for all server processes to exit and finally shuts down. If
+        # the server is in online backup mode, backup mode will be terminated,
+        # rendering the backup useless.
+        #
+        # [1] https://www.postgresql.org/docs/9.1/server-shutdown.html
+        self.proc.send_signal(signal.SIGINT)
+        self.proc.wait()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ pytest-xdist==1.29.0
 python-bitcoinlib==0.10.1
 tqdm==4.32.2
 pytest-timeout==1.3.3
+psycopg2==2.8.3

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1550,7 +1550,7 @@ def test_option_upfront_shutdown_script(node_factory, bitcoind):
     wait_for(lambda: [c['state'] for c in only_one(l2.rpc.listpeers()['peers'])['channels']] == ['ONCHAIN', 'ONCHAIN'])
 
     # Figure out what address it will try to use.
-    keyidx = int(l1.db_query("SELECT val FROM vars WHERE name='bip32_max_index';")[0]['val'])
+    keyidx = int(l1.db_query("SELECT intval FROM vars WHERE name='bip32_max_index';")[0]['intval'])
 
     # Expect 1 for change address, 1 for the channel final address,
     # which are discarded as the 'scratch' tx that the fundchannel

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1627,6 +1627,7 @@ def test_funder_simple_reconnect(node_factory, bitcoind):
     l1.pay(l2, 200000000)
 
 
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "sqlite3-specific DB rollback")
 @unittest.skipIf(not DEVELOPER, "needs LIGHTNINGD_DEV_LOG_IO")
 def test_dataloss_protection(node_factory, bitcoind):
     l1 = node_factory.get_node(may_reconnect=True, log_all_io=True,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1583,8 +1583,9 @@ def test_no_fee_estimate(node_factory, bitcoind, executor):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.fundchannel(l2.info['id'], 10**6, 'slow')
 
-    # Can withdraw (use urgent feerate).
-    l1.rpc.withdraw(l2.rpc.newaddr()['bech32'], 'all', 'urgent')
+    # Can withdraw (use urgent feerate). `minconf` may be needed depending on
+    # the previous `fundchannel` selecting all confirmed outputs.
+    l1.rpc.withdraw(l2.rpc.newaddr()['bech32'], 'all', 'urgent', minconf=0)
 
 
 @unittest.skipIf(not DEVELOPER, "needs --dev-disconnect")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,7 @@
 from fixtures import *  # noqa: F401,F403
 from utils import wait_for, sync_blockheight, COMPAT
 
+import os
 import unittest
 
 
@@ -116,6 +117,7 @@ def test_max_channel_id(node_factory, bitcoind):
 
 
 @unittest.skipIf(not COMPAT, "needs COMPAT to convert obsolete db")
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This test is based on a sqlite3 snapshot")
 def test_scid_upgrade(node_factory):
 
     # Created through the power of sed "s/X'\([0-9]*\)78\([0-9]*\)78\([0-9]*\)'/X'\13A\23A\3'/"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -61,6 +61,7 @@ def test_names(node_factory):
                                   .format(key, alias, color))
 
 
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This migration is based on a sqlite3 snapshot")
 def test_db_upgrade(node_factory):
     l1 = node_factory.get_node()
     l1.stop()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -969,12 +969,11 @@ def test_reserve_enforcement(node_factory, executor):
     l2.stop()
 
     # They should both aim for 1%.
-    reserves = l2.db_query('SELECT channel_reserve_satoshis FROM channel_configs')
+    reserves = l2.db.query('SELECT channel_reserve_satoshis FROM channel_configs')
     assert reserves == [{'channel_reserve_satoshis': 10**6 // 100}] * 2
 
     # Edit db to reduce reserve to 0 so it will try to violate it.
-    l2.db_query('UPDATE channel_configs SET channel_reserve_satoshis=0',
-                use_copy=False)
+    l2.db.execute('UPDATE channel_configs SET channel_reserve_satoshis=0')
 
     l2.start()
     wait_for(lambda: only_one(l2.rpc.listpeers(l1.info['id'])['peers'])['connected'])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -290,6 +290,7 @@ def test_async_rpcmethod(node_factory, executor):
     assert [r.result() for r in results] == [42] * len(results)
 
 
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "Only sqlite3 implements the db_write_hook currently")
 def test_db_hook(node_factory, executor):
     """This tests the db hook."""
     dbfile = os.path.join(node_factory.directory, "dblog.sqlite3")

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -12,6 +12,7 @@ WALLET_LIB_SRC :=		\
 	wallet/walletrpc.c
 
 WALLET_DB_DRIVERS :=		\
+	wallet/db_postgres.c	\
 	wallet/db_sqlite3.c
 
 WALLET_LIB_OBJS := $(WALLET_LIB_SRC:.c=.o) $(WALLET_DB_DRIVERS:.c=.o)
@@ -29,7 +30,9 @@ check-source-bolt: $(WALLET_LIB_SRC:%=bolt-check/%) $(WALLET_LIB_HEADERS:%=bolt-
 
 clean: wallet-clean
 
+# Each database driver depends on its rewritten statements.
 wallet/db_sqlite3.c: wallet/gen_db_sqlite3.c
+wallet/db_postgres.c: wallet/gen_db_postgres.c
 
 # The following files contain SQL-annotated statements that we need to extact
 SQL_FILES := 				\
@@ -42,12 +45,13 @@ SQL_FILES := 				\
 wallet/statements.po: $(SQL_FILES)
 	xgettext -kNAMED_SQL -kSQL --add-location --no-wrap --omit-header -o $@ $(SQL_FILES)
 
-wallet/gen_db_sqlite3.c:  wallet/statements.po devtools/sql-rewrite.py
-	 devtools/sql-rewrite.py wallet/statements.po sqlite3 > wallet/gen_db_sqlite3.c
+wallet/gen_db_%.c:  wallet/statements.po devtools/sql-rewrite.py
+	devtools/sql-rewrite.py wallet/statements.po $* > wallet/gen_db_$*.c
 
 wallet-clean:
 	$(RM) $(WALLET_LIB_OBJS)
 	$(RM) wallet/statements.po
 	$(RM) wallet/gen_db_sqlite3.c
+	$(RM) wallet/gen_db_postgres.c
 
 include wallet/test/Makefile

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -502,7 +502,7 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
 
 	/* Look up the query by its ID */
 	for (size_t i = 0; i < db->config->num_queries; i++) {
-		if (streq(query_id, db->config->queries[i].query)) {
+		if (streq(query_id, db->config->queries[i].name)) {
 			stmt->query = &db->config->queries[i];
 			break;
 		}

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -55,6 +55,13 @@ static struct migration dbmigrations[] = {
 	 ", PRIMARY KEY (shachain_id, pos)"
 	 ");"),
      NULL},
+    {SQL("CREATE TABLE peers ("
+	 "  id INTEGER"
+	 ", node_id BLOB UNIQUE" /* pubkey */
+	 ", address TEXT"
+	 ", PRIMARY KEY (id)"
+	 ");"),
+     NULL},
     {SQL("CREATE TABLE channels ("
 	 "  id INTEGER," /* chan->id */
 	 "  peer_id INTEGER REFERENCES peers(id) ON DELETE CASCADE,"
@@ -95,13 +102,6 @@ static struct migration dbmigrations[] = {
 	 "  closing_fee_received INTEGER,"
 	 "  closing_sig_received BLOB,"
 	 "  PRIMARY KEY (id)"
-	 ");"),
-     NULL},
-    {SQL("CREATE TABLE peers ("
-	 "  id INTEGER"
-	 ", node_id BLOB UNIQUE" /* pubkey */
-	 ", address TEXT"
-	 ", PRIMARY KEY (id)"
 	 ");"),
      NULL},
     {SQL("CREATE TABLE channel_configs ("

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -41,40 +41,40 @@ static struct migration dbmigrations[] = {
 	 ");"),
      NULL},
     {SQL("CREATE TABLE shachains ("
-	 "  id INTEGER"
-	 ", min_index INTEGER"
-	 ", num_valid INTEGER"
+	 "  id BIGSERIAL"
+	 ", min_index BIGINT"
+	 ", num_valid BIGINT"
 	 ", PRIMARY KEY (id)"
 	 ");"),
      NULL},
     {SQL("CREATE TABLE shachain_known ("
-	 "  shachain_id INTEGER REFERENCES shachains(id) ON DELETE CASCADE"
+	 "  shachain_id BIGINT REFERENCES shachains(id) ON DELETE CASCADE"
 	 ", pos INTEGER"
-	 ", idx INTEGER"
+	 ", idx BIGINT"
 	 ", hash BLOB"
 	 ", PRIMARY KEY (shachain_id, pos)"
 	 ");"),
      NULL},
     {SQL("CREATE TABLE peers ("
-	 "  id INTEGER"
+	 "  id BIGSERIAL"
 	 ", node_id BLOB UNIQUE" /* pubkey */
 	 ", address TEXT"
 	 ", PRIMARY KEY (id)"
 	 ");"),
      NULL},
     {SQL("CREATE TABLE channels ("
-	 "  id INTEGER," /* chan->id */
-	 "  peer_id INTEGER REFERENCES peers(id) ON DELETE CASCADE,"
+	 "  id BIGSERIAL," /* chan->id */
+	 "  peer_id BIGINT REFERENCES peers(id) ON DELETE CASCADE,"
 	 "  short_channel_id TEXT,"
-	 "  channel_config_local INTEGER,"
-	 "  channel_config_remote INTEGER,"
+	 "  channel_config_local BIGINT,"
+	 "  channel_config_remote BIGINT,"
 	 "  state INTEGER,"
 	 "  funder INTEGER,"
 	 "  channel_flags INTEGER,"
 	 "  minimum_depth INTEGER,"
-	 "  next_index_local INTEGER,"
-	 "  next_index_remote INTEGER,"
-	 "  next_htlc_id INTEGER, "
+	 "  next_index_local BIGINT,"
+	 "  next_index_remote BIGINT,"
+	 "  next_htlc_id BIGINT,"
 	 "  funding_tx_id BLOB,"
 	 "  funding_tx_outnum INTEGER,"
 	 "  funding_satoshi BIGINT,"
@@ -92,10 +92,10 @@ static struct migration dbmigrations[] = {
 	 "  local_feerate_per_kw INTEGER,"
 	 "  remote_feerate_per_kw INTEGER,"
 	 /* END channel_info */
-	 "  shachain_remote_id INTEGER,"
+	 "  shachain_remote_id BIGINT,"
 	 "  shutdown_scriptpubkey_remote BLOB,"
-	 "  shutdown_keyidx_local INTEGER,"
-	 "  last_sent_commit_state INTEGER,"
+	 "  shutdown_keyidx_local BIGINT,"
+	 "  last_sent_commit_state BIGINT,"
 	 "  last_sent_commit_id INTEGER,"
 	 "  last_tx BLOB,"
 	 "  last_sig BLOB,"
@@ -105,7 +105,7 @@ static struct migration dbmigrations[] = {
 	 ");"),
      NULL},
     {SQL("CREATE TABLE channel_configs ("
-	 "  id INTEGER,"
+	 "  id BIGSERIAL,"
 	 "  dust_limit_satoshis BIGINT,"
 	 "  max_htlc_value_in_flight_msat BIGINT,"
 	 "  channel_reserve_satoshis BIGINT,"
@@ -116,11 +116,11 @@ static struct migration dbmigrations[] = {
 	 ");"),
      NULL},
     {SQL("CREATE TABLE channel_htlcs ("
-	 "  id INTEGER,"
-	 "  channel_id INTEGER REFERENCES channels(id) ON DELETE CASCADE,"
-	 "  channel_htlc_id INTEGER,"
+	 "  id BIGSERIAL,"
+	 "  channel_id BIGINT REFERENCES channels(id) ON DELETE CASCADE,"
+	 "  channel_htlc_id BIGINT,"
 	 "  direction INTEGER,"
-	 "  origin_htlc INTEGER,"
+	 "  origin_htlc BIGINT,"
 	 "  msatoshi BIGINT,"
 	 "  cltv_expiry INTEGER,"
 	 "  payment_hash BLOB,"
@@ -135,7 +135,7 @@ static struct migration dbmigrations[] = {
 	 ");"),
      NULL},
     {SQL("CREATE TABLE invoices ("
-	 "  id INTEGER,"
+	 "  id BIGSERIAL,"
 	 "  state INTEGER,"
 	 "  msatoshi BIGINT,"
 	 "  payment_hash BLOB,"
@@ -147,7 +147,7 @@ static struct migration dbmigrations[] = {
 	 ");"),
      NULL},
     {SQL("CREATE TABLE payments ("
-	 "  id INTEGER,"
+	 "  id BIGSERIAL,"
 	 "  timestamp INTEGER,"
 	 "  status INTEGER,"
 	 "  payment_hash BLOB,"
@@ -162,7 +162,7 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE invoices ADD expiry_time BIGINT;"), NULL},
     {SQL("UPDATE invoices SET expiry_time=9223372036854775807;"), NULL},
     /* Add pay_index field to paid invoices (initially, same order as id). */
-    {SQL("ALTER TABLE invoices ADD pay_index INTEGER;"), NULL},
+    {SQL("ALTER TABLE invoices ADD pay_index BIGINT;"), NULL},
     {SQL("CREATE UNIQUE INDEX invoices_pay_index ON invoices(pay_index);"),
      NULL},
     {SQL("UPDATE invoices SET pay_index=id WHERE state=1;"),
@@ -177,10 +177,10 @@ static struct migration dbmigrations[] = {
     /* Create first_block field; initialize from channel id if any.
      * This fails for channels still awaiting lockin, but that only applies to
      * pre-release software, so it's forgivable. */
-    {SQL("ALTER TABLE channels ADD first_blocknum INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD first_blocknum BIGINT;"), NULL},
     {SQL("UPDATE channels SET first_blocknum=1 WHERE short_channel_id IS NOT NULL;"),
      NULL},
-    {SQL("ALTER TABLE outputs ADD COLUMN channel_id INTEGER;"), NULL},
+    {SQL("ALTER TABLE outputs ADD COLUMN channel_id BIGINT;"), NULL},
     {SQL("ALTER TABLE outputs ADD COLUMN peer_id BLOB;"), NULL},
     {SQL("ALTER TABLE outputs ADD COLUMN commitment_point BLOB;"), NULL},
     {SQL("ALTER TABLE invoices ADD COLUMN msatoshi_received BIGINT;"), NULL},
@@ -192,7 +192,7 @@ static struct migration dbmigrations[] = {
      * rename & copy, which works because there are no triggers etc. */
     {SQL("ALTER TABLE payments RENAME TO temp_payments;"), NULL},
     {SQL("CREATE TABLE payments ("
-	 "  id INTEGER,"
+	 "  id BIGSERIAL,"
 	 "  timestamp INTEGER,"
 	 "  status INTEGER,"
 	 "  payment_hash BLOB,"
@@ -212,7 +212,7 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE payments ADD COLUMN path_secrets BLOB;"), NULL},
     /* Create time-of-payment of invoice, default already-paid
      * invoices to current time. */
-    {SQL("ALTER TABLE invoices ADD paid_timestamp INTEGER;"), NULL},
+    {SQL("ALTER TABLE invoices ADD paid_timestamp BIGINT;"), NULL},
     {SQL("UPDATE invoices"
 	 "   SET paid_timestamp = CURRENT_TIMESTAMP()"
 	 " WHERE state = 1;"),
@@ -222,7 +222,7 @@ static struct migration dbmigrations[] = {
      * because we cannot safely save them as blobs due to byteorder
      * concerns. */
     {SQL("ALTER TABLE payments ADD COLUMN route_nodes BLOB;"), NULL},
-    {SQL("ALTER TABLE payments ADD COLUMN route_channels TEXT;"), NULL},
+    {SQL("ALTER TABLE payments ADD COLUMN route_channels BLOB;"), NULL},
     {SQL("CREATE TABLE htlc_sigs (channelid INTEGER REFERENCES channels(id) ON "
 	 "DELETE CASCADE, signature BLOB);"),
      NULL},
@@ -308,14 +308,14 @@ static struct migration dbmigrations[] = {
 	 " WHERE status <> 0;"),
      NULL}, /* PAYMENT_PENDING */
     /* -- Routing statistics -- */
-    {SQL("ALTER TABLE channels ADD in_payments_offered INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD in_payments_fulfilled INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD in_msatoshi_offered BIGINT;"), NULL},
-    {SQL("ALTER TABLE channels ADD in_msatoshi_fulfilled BIGINT;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_payments_offered INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_payments_fulfilled INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_msatoshi_offered BIGINT;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_msatoshi_fulfilled BIGINT;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_payments_offered INTEGER DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_payments_fulfilled INTEGER DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_msatoshi_offered BIGINT DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_msatoshi_fulfilled BIGINT DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_payments_offered INTEGER DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_payments_fulfilled INTEGER DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_msatoshi_offered BIGINT DEFAULT 0;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_msatoshi_fulfilled BIGINT DEFAULT 0;"), NULL},
     {SQL("UPDATE channels"
 	 "   SET  in_payments_offered = 0,  in_payments_fulfilled = 0"
 	 "     ,  in_msatoshi_offered = 0,  in_msatoshi_fulfilled = 0"
@@ -372,8 +372,8 @@ static struct migration dbmigrations[] = {
     /* -- Detailed payment faiure ends -- */
     {SQL("CREATE TABLE channeltxs ("
 	 /* The id serves as insertion order and short ID */
-	 "  id INTEGER"
-	 ", channel_id INTEGER REFERENCES channels(id) ON DELETE CASCADE"
+	 "  id BIGSERIAL"
+	 ", channel_id BIGINT REFERENCES channels(id) ON DELETE CASCADE"
 	 ", type INTEGER"
 	 ", transaction_id BLOB REFERENCES transactions(id) ON DELETE CASCADE"
 	 /* The input_num is only used by the txo_watch, 0 if txwatch */
@@ -410,10 +410,10 @@ static struct migration dbmigrations[] = {
      * deleted when the HTLC entries or the channel entries are
      * deleted to avoid unexpected drops in statistics. */
     {SQL("CREATE TABLE forwarded_payments ("
-	 "  in_htlc_id INTEGER REFERENCES channel_htlcs(id) ON DELETE SET NULL"
-	 ", out_htlc_id INTEGER REFERENCES channel_htlcs(id) ON DELETE SET NULL"
-	 ", in_channel_scid INTEGER"
-	 ", out_channel_scid INTEGER"
+	 "  in_htlc_id BIGINT REFERENCES channel_htlcs(id) ON DELETE SET NULL"
+	 ", out_htlc_id BIGINT REFERENCES channel_htlcs(id) ON DELETE SET NULL"
+	 ", in_channel_scid BIGINT"
+	 ", out_channel_scid BIGINT"
 	 ", in_msatoshi BIGINT"
 	 ", out_msatoshi BIGINT"
 	 ", state INTEGER"
@@ -433,9 +433,9 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE channels ADD feerate_base INTEGER;"), NULL},
     {SQL("ALTER TABLE channels ADD feerate_ppm INTEGER;"), NULL},
     {NULL, migrate_pr2342_feerate_per_channel},
-    {SQL("ALTER TABLE channel_htlcs ADD received_time INTEGER"), NULL},
-    {SQL("ALTER TABLE forwarded_payments ADD received_time INTEGER"), NULL},
-    {SQL("ALTER TABLE forwarded_payments ADD resolved_time INTEGER"), NULL},
+    {SQL("ALTER TABLE channel_htlcs ADD received_time BIGINT"), NULL},
+    {SQL("ALTER TABLE forwarded_payments ADD received_time BIGINT"), NULL},
+    {SQL("ALTER TABLE forwarded_payments ADD resolved_time BIGINT"), NULL},
     {SQL("ALTER TABLE channels ADD remote_upfront_shutdown_script BLOB;"),
      NULL},
     /* PR #2524: Add failcode into forward_payment */
@@ -444,12 +444,12 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE channels ADD remote_ann_node_sig BLOB;"), NULL},
     {SQL("ALTER TABLE channels ADD remote_ann_bitcoin_sig BLOB;"), NULL},
     /* Additional information for transaction tracking and listing */
-    {SQL("ALTER TABLE transactions ADD type INTEGER;"), NULL},
+    {SQL("ALTER TABLE transactions ADD type BIGINT;"), NULL},
     /* Not a foreign key on purpose since we still delete channels from
      * the DB which would remove this. It is mainly used to group payments
      * in the list view anyway, e.g., show all close and htlc transactions
      * as a single bundle. */
-    {SQL("ALTER TABLE transactions ADD channel_id INTEGER;"), NULL},
+    {SQL("ALTER TABLE transactions ADD channel_id BIGINT;"), NULL},
     /* Convert pre-Adelaide short_channel_ids */
     {SQL("UPDATE channels"
 	 " SET short_channel_id = REPLACE(short_channel_id, ':', 'x')"
@@ -457,8 +457,8 @@ static struct migration dbmigrations[] = {
     {SQL("UPDATE payments SET failchannel = REPLACE(failchannel, ':', 'x')"
 	 " WHERE failchannel IS NOT NULL;"), NULL },
     /* option_static_remotekey is nailed at creation time. */
-    {SQL("ALTER TABLE channels ADD COLUMN option_static_remotekey BOOLEAN"
-	 " DEFAULT FALSE;"), NULL },
+    {SQL("ALTER TABLE channels ADD COLUMN option_static_remotekey INTEGER"
+	 " DEFAULT 0;"), NULL },
     {SQL("ALTER TABLE vars ADD COLUMN intval INTEGER"), NULL},
     {SQL("ALTER TABLE vars ADD COLUMN blobval BLOB"), NULL},
     {SQL("UPDATE vars SET intval = CAST(val AS INTEGER) WHERE name IN ('bip32_max_index', 'last_processed_block', 'next_pay_index')"), NULL},

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -26,9 +26,9 @@ static struct migration dbmigrations[] = {
     {SQL("CREATE TABLE version (version INTEGER)"), NULL},
     {SQL("INSERT INTO version VALUES (1)"), NULL},
     {SQL("CREATE TABLE outputs ("
-	 "  prev_out_tx CHAR(64)"
+	 "  prev_out_tx BLOB"
 	 ", prev_out_index INTEGER"
-	 ", value INTEGER"
+	 ", value BIGINT"
 	 ", type INTEGER"
 	 ", status INTEGER"
 	 ", keyindex INTEGER"
@@ -77,10 +77,10 @@ static struct migration dbmigrations[] = {
 	 "  next_htlc_id INTEGER, "
 	 "  funding_tx_id BLOB,"
 	 "  funding_tx_outnum INTEGER,"
-	 "  funding_satoshi INTEGER,"
+	 "  funding_satoshi BIGINT,"
 	 "  funding_locked_remote INTEGER,"
-	 "  push_msatoshi INTEGER,"
-	 "  msatoshi_local INTEGER," /* our_msatoshi */
+	 "  push_msatoshi BIGINT,"
+	 "  msatoshi_local BIGINT," /* our_msatoshi */
 	 /* START channel_info */
 	 "  fundingkey_remote BLOB,"
 	 "  revocation_basepoint_remote BLOB,"
@@ -106,10 +106,10 @@ static struct migration dbmigrations[] = {
      NULL},
     {SQL("CREATE TABLE channel_configs ("
 	 "  id INTEGER,"
-	 "  dust_limit_satoshis INTEGER,"
-	 "  max_htlc_value_in_flight_msat INTEGER,"
-	 "  channel_reserve_satoshis INTEGER,"
-	 "  htlc_minimum_msat INTEGER,"
+	 "  dust_limit_satoshis BIGINT,"
+	 "  max_htlc_value_in_flight_msat BIGINT,"
+	 "  channel_reserve_satoshis BIGINT,"
+	 "  htlc_minimum_msat BIGINT,"
 	 "  to_self_delay INTEGER,"
 	 "  max_accepted_htlcs INTEGER,"
 	 "  PRIMARY KEY (id)"
@@ -121,7 +121,7 @@ static struct migration dbmigrations[] = {
 	 "  channel_htlc_id INTEGER,"
 	 "  direction INTEGER,"
 	 "  origin_htlc INTEGER,"
-	 "  msatoshi INTEGER,"
+	 "  msatoshi BIGINT,"
 	 "  cltv_expiry INTEGER,"
 	 "  payment_hash BLOB,"
 	 "  payment_key BLOB,"
@@ -137,7 +137,7 @@ static struct migration dbmigrations[] = {
     {SQL("CREATE TABLE invoices ("
 	 "  id INTEGER,"
 	 "  state INTEGER,"
-	 "  msatoshi INTEGER,"
+	 "  msatoshi BIGINT,"
 	 "  payment_hash BLOB,"
 	 "  payment_key BLOB,"
 	 "  label TEXT,"
@@ -153,7 +153,7 @@ static struct migration dbmigrations[] = {
 	 "  payment_hash BLOB,"
 	 "  direction INTEGER,"
 	 "  destination BLOB,"
-	 "  msatoshi INTEGER,"
+	 "  msatoshi BIGINT,"
 	 "  PRIMARY KEY (id),"
 	 "  UNIQUE (payment_hash)"
 	 ");"),
@@ -183,7 +183,7 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE outputs ADD COLUMN channel_id INTEGER;"), NULL},
     {SQL("ALTER TABLE outputs ADD COLUMN peer_id BLOB;"), NULL},
     {SQL("ALTER TABLE outputs ADD COLUMN commitment_point BLOB;"), NULL},
-    {SQL("ALTER TABLE invoices ADD COLUMN msatoshi_received INTEGER;"), NULL},
+    {SQL("ALTER TABLE invoices ADD COLUMN msatoshi_received BIGINT;"), NULL},
     /* Normally impossible, so at least we'll know if databases are ancient. */
     {SQL("UPDATE invoices SET msatoshi_received=0 WHERE state=1;"), NULL},
     {SQL("ALTER TABLE channels ADD COLUMN last_was_revoke INTEGER;"), NULL},
@@ -197,7 +197,7 @@ static struct migration dbmigrations[] = {
 	 "  status INTEGER,"
 	 "  payment_hash BLOB,"
 	 "  destination BLOB,"
-	 "  msatoshi INTEGER,"
+	 "  msatoshi BIGINT,"
 	 "  PRIMARY KEY (id),"
 	 "  UNIQUE (payment_hash)"
 	 ");"),
@@ -310,12 +310,12 @@ static struct migration dbmigrations[] = {
     /* -- Routing statistics -- */
     {SQL("ALTER TABLE channels ADD in_payments_offered INTEGER;"), NULL},
     {SQL("ALTER TABLE channels ADD in_payments_fulfilled INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD in_msatoshi_offered INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD in_msatoshi_fulfilled INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_msatoshi_offered BIGINT;"), NULL},
+    {SQL("ALTER TABLE channels ADD in_msatoshi_fulfilled BIGINT;"), NULL},
     {SQL("ALTER TABLE channels ADD out_payments_offered INTEGER;"), NULL},
     {SQL("ALTER TABLE channels ADD out_payments_fulfilled INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_msatoshi_offered INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD out_msatoshi_fulfilled INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_msatoshi_offered BIGINT;"), NULL},
+    {SQL("ALTER TABLE channels ADD out_msatoshi_fulfilled BIGINT;"), NULL},
     {SQL("UPDATE channels"
 	 "   SET  in_payments_offered = 0,  in_payments_fulfilled = 0"
 	 "     ,  in_msatoshi_offered = 0,  in_msatoshi_fulfilled = 0"
@@ -325,7 +325,7 @@ static struct migration dbmigrations[] = {
      NULL},
     /* -- Routing statistics ends --*/
     /* Record the msatoshi actually sent in a payment. */
-    {SQL("ALTER TABLE payments ADD msatoshi_sent INTEGER;"), NULL},
+    {SQL("ALTER TABLE payments ADD msatoshi_sent BIGINT;"), NULL},
     {SQL("UPDATE payments SET msatoshi_sent = msatoshi;"), NULL},
     /* Delete dangling utxoset entries due to Issue #1280  */
     {SQL("DELETE FROM utxoset WHERE blockheight IN ("
@@ -344,8 +344,8 @@ static struct migration dbmigrations[] = {
 	 "max_possible_feerate=250000;"),
      NULL},
     /* -- Min and max msatoshi_to_us -- */
-    {SQL("ALTER TABLE channels ADD msatoshi_to_us_min INTEGER;"), NULL},
-    {SQL("ALTER TABLE channels ADD msatoshi_to_us_max INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD msatoshi_to_us_min BIGINT;"), NULL},
+    {SQL("ALTER TABLE channels ADD msatoshi_to_us_max BIGINT;"), NULL},
     {SQL("UPDATE channels"
 	 "   SET msatoshi_to_us_min = msatoshi_local"
 	 "     , msatoshi_to_us_max = msatoshi_local"
@@ -414,8 +414,8 @@ static struct migration dbmigrations[] = {
 	 ", out_htlc_id INTEGER REFERENCES channel_htlcs(id) ON DELETE SET NULL"
 	 ", in_channel_scid INTEGER"
 	 ", out_channel_scid INTEGER"
-	 ", in_msatoshi INTEGER"
-	 ", out_msatoshi INTEGER"
+	 ", in_msatoshi BIGINT"
+	 ", out_msatoshi BIGINT"
 	 ", state INTEGER"
 	 ", UNIQUE(in_htlc_id, out_htlc_id)"
 	 ");"),
@@ -457,11 +457,11 @@ static struct migration dbmigrations[] = {
     {SQL("UPDATE payments SET failchannel = REPLACE(failchannel, ':', 'x')"
 	 " WHERE failchannel IS NOT NULL;"), NULL },
     /* option_static_remotekey is nailed at creation time. */
-    {SQL("ALTER TABLE channels ADD COLUMN option_static_remotekey"
+    {SQL("ALTER TABLE channels ADD COLUMN option_static_remotekey BOOLEAN"
 	 " DEFAULT FALSE;"), NULL },
     {SQL("ALTER TABLE vars ADD COLUMN intval INTEGER"), NULL},
     {SQL("ALTER TABLE vars ADD COLUMN blobval BLOB"), NULL},
-    {SQL("UPDATE vars SET intval = CAST(val AS INTEGER) WHERE name IN (\"bip32_max_index\", \"last_processed_block\", \"next_pay_index\")"), NULL},
+    {SQL("UPDATE vars SET intval = CAST(val AS INTEGER) WHERE name IN ('bip32_max_index', 'last_processed_block', 'next_pay_index')"), NULL},
     {SQL("UPDATE vars SET blobval = CAST(val AS BLOB) WHERE name = 'genesis_hash'"), NULL},
 };
 

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -40,7 +40,7 @@ struct db;
  * devtools/sql-rewrite.py needs to change as well, since they need to
  * generate identical names to work correctly.
  */
-#define SQL(x) NAMED_SQL( __FILE__ ":" stringify(__LINE__) ":" stringify(__COUNTER__), x)
+#define SQL(x) NAMED_SQL( __FILE__ ":" stringify(__COUNTER__), x)
 
 
 /**

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -85,6 +85,8 @@ struct db_stmt {
 	void *inner_stmt;
 
 	bool executed;
+
+	int row;
 };
 
 struct db_config {

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -55,7 +55,7 @@ enum db_binding_type {
 struct db_binding {
 	enum db_binding_type type;
 	union {
-		int i;
+		s32 i;
 		u64 u64;
 		const char* text;
 		const u8 *blob;

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -15,7 +15,6 @@
 struct db {
 	char *filename;
 	const char *in_transaction;
-	sqlite3 *sql;
 
 	/* DB-specific context */
 	void *conn;

--- a/wallet/db_postgres.c
+++ b/wallet/db_postgres.c
@@ -1,0 +1,36 @@
+#include <wallet/db_common.h>
+#include "gen_db_postgres.c"
+#include <ccan/ccan/tal/str/str.h>
+#include <lightningd/log.h>
+#include <sqlite3.h>
+#include <stdio.h>
+
+#if HAVE_POSTGRES
+
+struct db_config db_postgres_config = {
+	.name = "postgres",
+	.queries = NULL,
+	.num_queries = DB_POSTGRES_QUERY_COUNT,
+	.exec_fn = NULL,
+	.query_fn = NULL,
+	.step_fn = NULL,
+	.begin_tx_fn = NULL,
+	.commit_tx_fn = NULL,
+	.stmt_free_fn = NULL,
+
+	.column_is_null_fn = NULL,
+	.column_u64_fn = NULL,
+	.column_int_fn = NULL,
+	.column_bytes_fn = NULL,
+	.column_blob_fn = NULL,
+	.column_text_fn = NULL,
+
+	.last_insert_id_fn = NULL,
+	.count_changes_fn = NULL,
+	.setup_fn = NULL,
+	.teardown_fn = NULL,
+};
+
+AUTODATA(db_backends, &db_postgres_config);
+
+#endif

--- a/wallet/db_postgres.c
+++ b/wallet/db_postgres.c
@@ -1,34 +1,263 @@
 #include <wallet/db_common.h>
 #include "gen_db_postgres.c"
 #include <ccan/ccan/tal/str/str.h>
+#include <ccan/endian/endian.h>
 #include <lightningd/log.h>
 #include <sqlite3.h>
 #include <stdio.h>
 
 #if HAVE_POSTGRES
+/* Indented in order not to trigger the inclusion order check */
+  #include <postgresql/libpq-fe.h>
+
+/* Cherry-picked from here: libpq/src/interfaces/ecpg/ecpglib/pg_type.h */
+#define BYTEAOID		17
+#define INT8OID			20
+#define INT4OID			23
+#define TEXTOID			25
+
+static bool db_postgres_setup(struct db *db)
+{
+	db->conn = PQconnectdb(db->filename);
+
+	if (PQstatus(db->conn) != CONNECTION_OK) {
+		db->error = tal_fmt(db, "Could not connect to %s: %s", db->filename, PQerrorMessage(db->conn));
+		db->conn = NULL;
+		return false;
+	}
+	return true;
+}
+
+static bool db_postgres_begin_tx(struct db *db)
+{
+	assert(db->conn);
+	PGresult *res;
+	res = PQexec(db->conn, "BEGIN;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+		db->error = tal_fmt(db, "BEGIN command failed: %s",
+				    PQerrorMessage(db->conn));
+		PQclear(res);
+		return false;
+	}
+	PQclear(res);
+	return true;
+}
+
+static bool db_postgres_commit_tx(struct db *db)
+{
+	assert(db->conn);
+	PGresult *res;
+	res = PQexec(db->conn, "COMMIT;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+		db->error = tal_fmt(db, "COMMIT command failed: %s",
+				    PQerrorMessage(db->conn));
+		PQclear(res);
+		return false;
+	}
+	PQclear(res);
+	return true;
+}
+
+static PGresult *db_postgres_do_exec(struct db_stmt *stmt)
+{
+	int slots = stmt->query->placeholders;
+	const char *paramValues[slots];
+	int paramLengths[slots];
+	int paramFormats[slots];
+	Oid paramTypes[slots];
+	int resultFormat = 1; /* We always want binary results. */
+
+	/* Since we pass in raw pointers to elements converted to network
+	 * byte-order we need a place to temporarily stash them. */
+	s32 ints[slots];
+	u64 u64s[slots];
+
+	for (size_t i=0; i<slots; i++) {
+		struct db_binding *b = &stmt->bindings[i];
+
+		switch (b->type) {
+		case DB_BINDING_UNINITIALIZED:
+			db_fatal("DB binding not initialized: position=%zu, "
+				 "query=\"%s\n",
+				 i, stmt->query->query);
+		case DB_BINDING_UINT64:
+			paramLengths[i] = 8;
+			paramFormats[i] = 1;
+			u64s[i] = cpu_to_be64(b->v.u64);
+			paramValues[i] = (char*)&u64s[i];
+			paramTypes[i] = INT8OID;
+			break;
+		case DB_BINDING_INT:
+			paramLengths[i] = 4;
+			paramFormats[i] = 1;
+			ints[i] = cpu_to_be32(b->v.i);
+			paramValues[i] = (char*)&ints[i];
+			paramTypes[i] = INT4OID;
+			break;
+		case DB_BINDING_BLOB:
+			paramLengths[i] = b->len;
+			paramFormats[i] = 1;
+			paramValues[i] = (char*)b->v.blob;
+			paramTypes[i] = BYTEAOID;
+			break;
+		case DB_BINDING_TEXT:
+			paramLengths[i] = b->len;
+			paramFormats[i] = 1;
+			paramValues[i] = (char*)b->v.text;
+			paramTypes[i] = TEXTOID;
+			break;
+		case DB_BINDING_NULL:
+			paramLengths[i] = 0;
+			paramFormats[i] = 1;
+			paramValues[i] = NULL;
+			paramTypes[i] = 0;
+			break;
+		}
+	}
+	return PQexecParams(stmt->db->conn, stmt->query->query, slots,
+			    paramTypes, paramValues, paramLengths, paramFormats,
+			    resultFormat);
+}
+
+static bool db_postgres_query(struct db_stmt *stmt)
+{
+	stmt->inner_stmt = db_postgres_do_exec(stmt);
+	int res;
+	res = PQresultStatus(stmt->inner_stmt);
+
+	if (res != PGRES_EMPTY_QUERY && res != PGRES_TUPLES_OK) {
+		stmt->error = PQerrorMessage(stmt->db->conn);
+		PQclear(stmt->inner_stmt);
+		stmt->inner_stmt = NULL;
+		return false;
+	}
+	stmt->row = -1;
+	return true;
+}
+
+static bool db_postgres_step(struct db_stmt *stmt)
+{
+	stmt->row++;
+	if (stmt->row >= PQntuples(stmt->inner_stmt)) {
+		return false;
+	}
+	return true;
+}
+
+static bool db_postgres_column_is_null(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	return PQgetisnull(res, stmt->row, col);
+}
+
+static u64 db_postgres_column_u64(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	be64 bin;
+	size_t expected = sizeof(bin), actual = PQgetlength(res, stmt->row, col);
+
+	if (expected != actual)
+		db_fatal(
+		    "u64 field doesn't match size: expected %zu, actual %zu\n",
+		    expected, actual);
+
+	memcpy(&bin, PQgetvalue(res, stmt->row, col), sizeof(bin));
+	return be64_to_cpu(bin);
+}
+
+static s64 db_postgres_column_int(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	be32 bin;
+	size_t expected = sizeof(bin), actual = PQgetlength(res, stmt->row, col);
+
+	if (expected != actual)
+		db_fatal(
+		    "s32 field doesn't match size: expected %zu, actual %zu\n",
+		    expected, actual);
+
+	memcpy(&bin, PQgetvalue(res, stmt->row, col), sizeof(bin));
+	return be32_to_cpu(bin);
+}
+
+static size_t db_postgres_column_bytes(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult *)stmt->inner_stmt;
+	return PQgetlength(res, stmt->row, col);
+}
+
+static const void *db_postgres_column_blob(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	return PQgetvalue(res, stmt->row, col);
+}
+
+static const unsigned char *db_postgres_column_text(struct db_stmt *stmt, int col)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	return (unsigned char*)PQgetvalue(res, stmt->row, col);
+}
+
+static void db_postgres_stmt_free(struct db_stmt *stmt)
+{
+	if (stmt->inner_stmt)
+		PQclear(stmt->inner_stmt);
+	stmt->inner_stmt = NULL;
+}
+
+static bool db_postgres_exec(struct db_stmt *stmt)
+{
+	bool ok;
+	stmt->inner_stmt = db_postgres_do_exec(stmt);
+	ok = PQresultStatus(stmt->inner_stmt) == PGRES_COMMAND_OK;
+
+	if (!ok)
+		stmt->error = PQerrorMessage(stmt->db->conn);
+
+	return ok;
+}
+
+static u64 db_postgres_last_insert_id(struct db_stmt *stmt)
+{
+	PGresult *res = PQexec(stmt->db->conn, "SELECT lastval()");
+	int id = atoi(PQgetvalue(res, 0, 0));
+	PQclear(res);
+	return id;
+}
+
+static size_t db_postgres_count_changes(struct db_stmt *stmt)
+{
+	PGresult *res = (PGresult*)stmt->inner_stmt;
+	char *count = PQcmdTuples(res);
+	return atoi(count);
+}
+
+static void db_postgres_teardown(struct db *db)
+{
+}
 
 struct db_config db_postgres_config = {
-	.name = "postgres",
-	.queries = NULL,
-	.num_queries = DB_POSTGRES_QUERY_COUNT,
-	.exec_fn = NULL,
-	.query_fn = NULL,
-	.step_fn = NULL,
-	.begin_tx_fn = NULL,
-	.commit_tx_fn = NULL,
-	.stmt_free_fn = NULL,
+    .name = "postgres",
+    .queries = db_postgres_queries,
+    .num_queries = DB_POSTGRES_QUERY_COUNT,
+    .exec_fn = db_postgres_exec,
+    .query_fn = db_postgres_query,
+    .step_fn = db_postgres_step,
+    .begin_tx_fn = &db_postgres_begin_tx,
+    .commit_tx_fn = &db_postgres_commit_tx,
+    .stmt_free_fn = db_postgres_stmt_free,
 
-	.column_is_null_fn = NULL,
-	.column_u64_fn = NULL,
-	.column_int_fn = NULL,
-	.column_bytes_fn = NULL,
-	.column_blob_fn = NULL,
-	.column_text_fn = NULL,
+    .column_is_null_fn = db_postgres_column_is_null,
+    .column_u64_fn = db_postgres_column_u64,
+    .column_int_fn = db_postgres_column_int,
+    .column_bytes_fn = db_postgres_column_bytes,
+    .column_blob_fn = db_postgres_column_blob,
+    .column_text_fn = db_postgres_column_text,
 
-	.last_insert_id_fn = NULL,
-	.count_changes_fn = NULL,
-	.setup_fn = NULL,
-	.teardown_fn = NULL,
+    .last_insert_id_fn = db_postgres_last_insert_id,
+    .count_changes_fn = db_postgres_count_changes,
+    .setup_fn = db_postgres_setup,
+    .teardown_fn = db_postgres_teardown,
 };
 
 AUTODATA(db_backends, &db_postgres_config);

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -568,7 +568,7 @@ void invoices_waitany(const tal_t *ctx,
 	stmt = db_prepare_v2(invoices->db,
 			     SQL("SELECT id"
 				 "  FROM invoices"
-				 " WHERE pay_index NOT NULL"
+				 " WHERE pay_index IS NOT NULL"
 				 "   AND pay_index > ?"
 				 " ORDER BY pay_index ASC LIMIT 1;"));
 	db_bind_u64(stmt, 0, lastpay_index);

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -49,14 +49,16 @@ void plugin_hook_db_sync(struct db *db UNNEEDED, const char **changes UNNEEDED, 
 static struct db *create_test_db(void)
 {
 	struct db *db;
-	char filename[] = "/tmp/ldb-XXXXXX";
+	char *dsn, filename[] = "/tmp/ldb-XXXXXX";
 
 	int fd = mkstemp(filename);
 	if (fd == -1)
 		return NULL;
 	close(fd);
 
-	db = db_open(NULL, filename);
+	dsn = tal_fmt(NULL, "sqlite3://%s", filename);
+	db = db_open(NULL, dsn);
+	tal_free(dsn);
 	return db;
 }
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -727,14 +727,16 @@ static void cleanup_test_wallet(struct wallet *w, char *filename)
 
 static struct wallet *create_test_wallet(struct lightningd *ld, const tal_t *ctx)
 {
-	char *filename = tal_fmt(ctx, "/tmp/ldb-XXXXXX");
+	char *dsn, *filename = tal_fmt(ctx, "/tmp/ldb-XXXXXX");
 	int fd = mkstemp(filename);
 	struct wallet *w = tal(ctx, struct wallet);
 	static unsigned char badseed[BIP32_ENTROPY_LEN_128];
 	CHECK_MSG(fd != -1, "Unable to generate temp filename");
 	close(fd);
 
-	w->db = db_open(w, filename);
+	dsn = tal_fmt(NULL, "sqlite3://%s", filename);
+	w->db = db_open(w, dsn);
+	tal_free(dsn);
 	tal_add_destructor2(w, cleanup_test_wallet, filename);
 
 	list_head_init(&w->unstored_payments);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2483,7 +2483,7 @@ bool wallet_network_check(struct wallet *w,
 {
 	struct bitcoin_blkid chainhash;
 	struct db_stmt *stmt = db_prepare_v2(
-	    w->db, SQL("SELECT val FROM vars WHERE name='genesis_hash'"));
+	    w->db, SQL("SELECT blobval FROM vars WHERE name='genesis_hash'"));
 	db_query_prepared(stmt);
 
 	if (db_step(stmt)) {
@@ -2507,7 +2507,7 @@ bool wallet_network_check(struct wallet *w,
 		tal_free(stmt);
 		/* Still a pristine wallet, claim it for the chain
 		 * that we are running */
-		stmt = db_prepare_v2(w->db, SQL("INSERT INTO vars (name, val) "
+		stmt = db_prepare_v2(w->db, SQL("INSERT INTO vars (name, blobval) "
 						"VALUES ('genesis_hash', ?);"));
 		db_bind_sha256d(stmt, 0, &chainparams->genesis_blockhash.shad);
 		db_exec_prepared_v2(take(stmt));


### PR DESCRIPTION
This is the counterpart to #2924. It implements the postgresql driver for `lightningd`, the changes to the query rewriting script and the changes to the testing framework to select the DB to test against.

The tests can be run, if you have postgresql installed, using the `TEST_DB_PROVIDER=postgres` environment variable. The tests pass, with one exception `test_reserve_enforcement`, which I am still investigating, and the tests are a bit flaky when running in parallel.

Sadly I had to modify the migrations in order to add the information that `sqlite3` just glossed over (field size, foreign key enforcement in a transaction, autoincrement primary keys). Changing the migrations is something that I warned against back when I created the migration system, however it is safe to do here since we only reorder one single migration pair (since postgres requires the dependency table `peers` to be created before the dependent table `channels`, safe because it was part of the same git commit back in the day and there is no way someone has a DB with one table but not the other), and some changes in types.

The type changes are limited to the `INTEGER` changing to `BIGSERIAL` if it is the primary key, or `BIGINT` if it is backing a `u64`. There are one or two occurrences where I had to change from `TEXT` to `BLOB` (which then gets translated to `BYTEA` for postgres), since `TEXT` requires the contents to be valid UTF-8 strings, which public keys are not.

Finally, I was planning on using `sqlparse` to make the statement rewriting context aware, and safer than simple query-replace, but I found it rather cumbersome to work with, and we are just replacing a couple of types and placeholders anyway, so I ripped that dependency out again in this PR.

Some things that I will try to address before removing the draft status:

 - [x] Auto-detect the location of the `initdb` and the `postgres` binaries instead of hardcoding the path
 - [x] Fix `test_reserve_enforcement`
 - [x] Run `valgrind` with postgres to ensure that everything is still memory-safe.

Looking forward to the feedback :wink: 