### PR TITLE
Bring back `fundchannel`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,7 @@ PKGLIBEXEC_PROGRAMS = \
 	       lightningd/lightning_hsmd \
 	       lightningd/lightning_onchaind \
 	       lightningd/lightning_openingd
-PLUGINS=plugins/pay plugins/autoclean
+PLUGINS=plugins/pay plugins/autoclean plugins/fundchannel
 
 install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS)
 	@$(NORMAL_INSTALL)


### PR DESCRIPTION
Looks like it was struck by lightning.

Fixes #3059.