### PR TITLE
Pay plugin: Fix the traversal order in `find_worst_channel`

### DIFF
--- a/common/status.c
+++ b/common/status.c
@@ -61,11 +61,18 @@ void status_setup_sync(int fd)
 #endif
 }
 
+static void destroy_daemon_conn(struct daemon_conn *dc UNUSED)
+{
+	status_conn = NULL;
+}
+
 void status_setup_async(struct daemon_conn *master)
 {
 	assert(status_fd == -1);
 	assert(!status_conn);
 	status_conn = master;
+
+	tal_add_destructor(master, destroy_daemon_conn);
 
 	setup_logging_sighandler();
 #if DEVELOPER


### PR DESCRIPTION
Related with my ['question' comment](https://github.com/ElementsProject/lightning/issues/2665#issuecomment-531479284)

I guess the original idea is to use the reverse order to traverse the entire route collection to find the worst channel/hop. I think it's the reason of the 'abnormal performance' in `test_pay_limits` if I'm right...

But the reverse order is hard to implement for our json interface, so I fix the logic with `json_for_each_arr`.