### PR TITLE
Refactor dynamic plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `fundchannel_cancel` is extended to work before funding broadcast.
 - JSON API: The parameter `exclude` of `getroute` now also support node-id.
 - JSON-API: `pay` can exclude error nodes if the failcode of `sendpay` has the NODE bit set
+- JSON API: The `plugin` command now returns on error. A timeout of 20 seconds is added to `start` and `startdir`
+            subcommands at the end of which the plugin is errored if it did not complete the handshake with `lightningd`.
+- JSON API: The `plugin` command does not allow to start static plugins after `lightningd` startup anymore.
 
 ### Deprecated
 

--- a/contrib/plugins/cowsay.sh
+++ b/contrib/plugins/cowsay.sh
@@ -24,6 +24,9 @@ echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"dynamic":true,"options":[],"rpcme
 # Eg. {"jsonrpc":"2.0","id":5,"method":"init","params":{"options":{},"configuration":{"lightning-dir":"/home/rusty/.lightning","rpc-file":"lightning-rpc","startup":false}}}\n\n
 read -r JSON
 read -r _
+id=$(echo "$JSON" | sed 's/.*"id" *: *\([0-9]*\),.*/\1/')
+
+echo '{"jsonrpc":"2.0","id":'"$id"',"result":{}}'
 
 # eg. { "jsonrpc" : "2.0", "method" : "cowsay", "id" : 6, "params" :[ "hello"] }
 while read -r JSON; do

--- a/doc/lightning-plugin.7
+++ b/doc/lightning-plugin.7
@@ -14,16 +14,18 @@ optionally one or two parameters which describes the plugin on which the
 action has to be taken\.
 
 
-The \fIstart\fR command takes a path as parameter and will load the plugin
-available from this path\.
+The \fIstart\fR command takes a path as the first parameter and will load the
+plugin available from this path\. It will wait for the plugin to complete
+the handshake with \fBlightningd\fR for 20 seconds at the most\.
 
 
-The \fIstop\fR command takes a plugin name as parameter and will kill and
+The \fIstop\fR command takes a plugin name as parameter\. It will kill and
 unload the specified plugin\.
 
 
-The \fIstartdir\fR command takes a directory path as parameter and will load
-all plugins this directory contains\.
+The \fIstartdir\fR command takes a directory path as first parameter and will
+load all plugins this directory contains\. It will wait for each plugin to
+complete the handshake with \fBlightningd\fR for 20 seconds at the most\.
 
 
 The \fIrescan\fR command starts all not-already-loaded plugins from the
@@ -34,20 +36,21 @@ The \fIlist\fR command will return all the active plugins\.
 
 .SH RETURN VALUE
 
-On success, this returns an array \fIplugins\fR of objects, one by plugin\.
+On success, all subcommands but \fIstop\fR return an array \fIplugins\fR of
+objects, one by plugin\.
 Each object contains the name of the plugin (\fIname\fR field) and its
 status (\fIactive\fR boolean field)\. Since plugins are configured
 asynchronously, a freshly started plugin may not appear immediately\.
 
+
+On error, the reason why the action could not be taken upon the
+plugin is returned\.
+
 .SH AUTHOR
 
-Antoine Poinsot \fI<darosior@protonmail.com\fR> is mainly responsible\.
+Antoine Poinsot (\fIdarosior@protonmail.com\fR) is mainly responsible\.
 
 .SH RESOURCES
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
-
-.HL
-
-Last updated 2019-07-29 12:57:57 CEST
 

--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -15,14 +15,16 @@ restart lightningd. It takes 1 to 3 parameters: a command
 optionally one or two parameters which describes the plugin on which the
 action has to be taken.
 
-The *start* command takes a path as parameter and will load the plugin
-available from this path.
+The *start* command takes a path as the first parameter and will load the
+plugin available from this path. It will wait for the plugin to complete
+the handshake with `lightningd` for 20 seconds at the most.
 
-The *stop* command takes a plugin name as parameter and will kill and
+The *stop* command takes a plugin name as parameter. It will kill and
 unload the specified plugin.
 
-The *startdir* command takes a directory path as parameter and will load
-all plugins this directory contains.
+The *startdir* command takes a directory path as first parameter and will
+load all plugins this directory contains. It will wait for each plugin to
+complete the handshake with `lightningd` for 20 seconds at the most.
 
 The *rescan* command starts all not-already-loaded plugins from the
 default plugins directory (by default *~/.lightning/plugins*).
@@ -32,10 +34,14 @@ The *list* command will return all the active plugins.
 RETURN VALUE
 ------------
 
-On success, this returns an array *plugins* of objects, one by plugin.
+On success, all subcommands but *stop* return an array *plugins* of
+objects, one by plugin.
 Each object contains the name of the plugin (*name* field) and its
 status (*active* boolean field). Since plugins are configured
 asynchronously, a freshly started plugin may not appear immediately.
+
+On error, the reason why the action could not be taken upon the
+plugin is returned.
 
 AUTHOR
 ------

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -943,18 +943,19 @@ void clear_plugins(struct plugins *plugins)
 		tal_free(p);
 }
 
-void plugins_add_default_dir(struct plugins *plugins, const char *default_dir)
+void plugins_add_default_dir(struct plugins *plugins)
 {
-	DIR *d = opendir(default_dir);
+	DIR *d = opendir(plugins->default_dir);
 	if (d) {
 		struct dirent *di;
 
 		/* Add this directory itself, and recurse down once. */
-		add_plugin_dir(plugins, default_dir, true);
+		add_plugin_dir(plugins, plugins->default_dir, true);
 		while ((di = readdir(d)) != NULL) {
 			if (streq(di->d_name, ".") || streq(di->d_name, ".."))
 				continue;
-			add_plugin_dir(plugins, path_join(tmpctx, default_dir, di->d_name), true);
+			add_plugin_dir(plugins, path_join(tmpctx, plugins->default_dir,
+			                                  di->d_name), true);
 		}
 		closedir(d);
 	}
@@ -968,8 +969,8 @@ void plugins_init(struct plugins *plugins, const char *dev_plugin_debug)
 	struct jsonrpc_request *req;
 
 	plugins->pending_manifests = 0;
-	plugins_add_default_dir(plugins,
-				path_join(tmpctx, plugins->ld->config_dir, "plugins"));
+	plugins->default_dir = path_join(plugins, plugins->ld->config_dir, "plugins");
+	plugins_add_default_dir(plugins);
 
 	setenv("LIGHTNINGD_PLUGIN", "1", 1);
 	setenv("LIGHTNINGD_VERSION", version(), 1);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -61,7 +61,7 @@ static void destroy_plugin(struct plugin *p)
 	list_del(&p->list);
 }
 
-void plugin_register(struct plugins *plugins, const char* path TAKES)
+struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES)
 {
 	struct plugin *p, *p_temp;
 
@@ -70,7 +70,7 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 		if (streq(path, p_temp->cmd)) {
 			if (taken(path))
 				tal_free(path);
-			return;
+			return NULL;
 		}
 	}
 
@@ -107,6 +107,7 @@ void plugin_register(struct plugins *plugins, const char* path TAKES)
 
 	list_add_tail(&plugins->plugins, &p->list);
 	tal_add_destructor(p, destroy_plugin);
+	return p;
 }
 
 bool plugin_paths_match(const char *cmd, const char *name)
@@ -435,8 +436,8 @@ static void plugin_conn_finish(struct io_conn *conn, struct plugin *plugin)
 		tal_free(plugin);
 }
 
-static struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
-					      struct plugin *plugin)
+struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
+                                       struct plugin *plugin)
 {
 	/* We write to their stdin */
 	/* We don't have anything queued yet, wait for notification */
@@ -445,8 +446,8 @@ static struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
 	return io_wait(plugin->stdin_conn, plugin, plugin_write_json, plugin);
 }
 
-static struct io_plan *plugin_stdout_conn_init(struct io_conn *conn,
-					       struct plugin *plugin)
+struct io_plan *plugin_stdout_conn_init(struct io_conn *conn,
+                                        struct plugin *plugin)
 {
 	/* We read from their stdout */
 	plugin->stdout_conn = conn;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1,21 +1,10 @@
 #include <ccan/array_size/array_size.h>
 #include <ccan/list/list.h>
 #include <ccan/opt/opt.h>
-#include <ccan/pipecmd/pipecmd.h>
-#include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
 #include <ccan/utf8/utf8.h>
-#include <common/json_command.h>
-#include <common/jsonrpc_errors.h>
-#include <common/memleak.h>
-#include <common/param.h>
-#include <common/timeout.h>
 #include <common/version.h>
-#include <dirent.h>
-#include <errno.h>
-#include <lightningd/io_loop_with_timers.h>
 #include <lightningd/json.h>
-#include <lightningd/lightningd.h>
 #include <lightningd/notification.h>
 #include <lightningd/options.h>
 #include <lightningd/plugin.h>
@@ -23,7 +12,6 @@
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 /* How many seconds may the plugin take to reply to the `getmanifest
  * call`? This is the maximum delay to `lightningd --help` and until

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -3,10 +3,23 @@
 #include "config.h"
 #include <ccan/intmap/intmap.h>
 #include <ccan/io/io.h>
+#include <ccan/pipecmd/pipecmd.h>
 #include <ccan/take/take.h>
+#include <ccan/tal/path/path.h>
 #include <ccan/tal/tal.h>
+#include <common/json_command.h>
+#include <common/jsonrpc_errors.h>
+#include <common/memleak.h>
+#include <common/param.h>
+#include <common/timeout.h>
+#include <dirent.h>
+#include <errno.h>
+#include <lightningd/io_loop_with_timers.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <unistd.h>
+
 
 enum plugin_state {
 	UNCONFIGURED,

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -130,7 +130,7 @@ void plugins_init(struct plugins *plugins, const char *dev_plugin_debug);
  * @param plugins: Plugin context
  * @param path: The path of the executable for this plugin
  */
-void plugin_register(struct plugins *plugins, const char* path TAKES);
+struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES);
 
 /**
  * Returns true if the provided name matches a plugin command
@@ -203,6 +203,14 @@ void plugin_request_send(struct plugin *plugin,
  */
 char *plugin_opt_set(const char *arg, struct plugin_opt *popt);
 
+/**
+ * Helpers to initialize a connection to a plugin; we read from their
+ * stdout, and write to their stdin.
+ */
+struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
+                                       struct plugin *plugin);
+struct io_plan *plugin_stdout_conn_init(struct io_conn *conn,
+                                        struct plugin *plugin);
 
 /**
  * Needed for I/O logging for plugin messages.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -159,6 +159,20 @@ void PRINTF_FMT(2,3) plugin_kill(struct plugin *plugin, char *fmt, ...);
  * incoming JSON-RPC calls and messages.
  */
 void plugins_config(struct plugins *plugins);
+
+/**
+ * Read and treat (populate options, methods, ...) the `getmanifest` response.
+ */
+bool plugin_parse_getmanifest_response(const char *buffer,
+                                       const jsmntok_t *toks,
+                                       const jsmntok_t *idtok,
+                                       struct plugin *plugin);
+
+/**
+ * This populates the jsonrpc request with the plugin/lightningd specifications
+ */
+void plugin_populate_init_request(struct plugin *p, struct jsonrpc_request *req);
+
 /**
  * Add the plugin option and their respective options to listconfigs.
  *

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -84,6 +84,7 @@ struct plugins {
 	struct log_book *log_book;
 
 	struct lightningd *ld;
+	const char *default_dir;
 };
 
 /* The value of a plugin option, which can have different types.
@@ -115,10 +116,9 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
 			    struct lightningd *ld);
 
 /**
- * Search for `default_dir`, and if it exists add every directory it
- * contains as a plugin dir.
+ * Recursively add all plugins from the default plugins directory.
  */
-void plugins_add_default_dir(struct plugins *plugins, const char *default_dir);
+void plugins_add_default_dir(struct plugins *plugins);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -181,7 +181,7 @@ void *plugin_exclusive_loop(struct plugin *plugin);
  * Add a directory to the plugin path to automatically load plugins.
  */
 char *add_plugin_dir(struct plugins *plugins, const char *dir,
-		     bool nonexist_ok);
+		     bool error_ok);
 
 /**
  * Clear all plugins registered so far.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -10,7 +10,6 @@
 
 enum plugin_state {
 	UNCONFIGURED,
-	CONFIGURING,
 	CONFIGURED
 };
 
@@ -31,7 +30,6 @@ struct plugin {
 
 	/* If this plugin can be restarted without restarting lightningd */
 	bool dynamic;
-	bool signal_startup;
 
 	/* Stuff we read */
 	char *buffer;
@@ -108,8 +106,6 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
  * contains as a plugin dir.
  */
 void plugins_add_default_dir(struct plugins *plugins, const char *default_dir);
-
-void plugins_start(struct plugins *plugins, const char *dev_plugin_debug);
 
 /**
  * Initialize the registered plugins.

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -223,8 +223,7 @@ plugin_dynamic_rescan_plugins(struct command *cmd)
 	struct plugin *p;
 
 	/* This will not fail on "already registered" error. */
-	plugins_add_default_dir(cmd->ld->plugins,
-	                        path_join(tmpctx, cmd->ld->config_dir, "plugins"));
+	plugins_add_default_dir(cmd->ld->plugins);
 
 	found = false;
 	list_for_each(&cmd->ld->plugins->plugins, p, list) {

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -1,15 +1,5 @@
-#include <ccan/pipecmd/pipecmd.h>
-#include <ccan/tal/path/path.h>
-#include <common/json_command.h>
-#include <common/jsonrpc_errors.h>
-#include <common/param.h>
-#include <common/timeout.h>
-#include <dirent.h>
-#include <errno.h>
-#include <lightningd/io_loop_with_timers.h>
 #include <lightningd/plugin_control.h>
 #include <lightningd/plugin_hook.h>
-#include <unistd.h>
 
 /* A dummy structure used to give multiple arguments to callbacks. */
 struct dynamic_plugin {

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -164,6 +164,38 @@ plugin_dynamic_start(struct command *cmd, const char *plugin_path)
 }
 
 /**
+ * Called when trying to start a plugin directory through RPC, it registers
+ * all contained plugins recursively and then starts them.
+ */
+static struct command_result *
+plugin_dynamic_startdir(struct command *cmd, const char *dir_path)
+{
+	const char *err;
+	struct plugin *p;
+	/* If the directory is empty */
+	bool found;
+
+	err = add_plugin_dir(cmd->ld->plugins, dir_path, false);
+	if (err)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS, "%s", err);
+
+	found = false;
+	list_for_each(&cmd->ld->plugins->plugins, p, list) {
+		if (p->plugin_state == UNCONFIGURED) {
+			found = true;
+			struct dynamic_plugin *dp = tal(cmd, struct dynamic_plugin);
+			dp->plugin = p;
+			dp->cmd = cmd;
+			plugin_start(dp);
+		}
+	}
+	if (!found)
+		plugin_dynamic_list_plugins(cmd);
+
+	return command_still_pending(cmd);
+}
+
+/**
  * A plugin command which permits to control plugins without restarting
  * lightningd. It takes a subcommand, and an optional subcommand parameter.
  */
@@ -233,7 +265,7 @@ static struct command_result *json_plugin_control(struct command *cmd,
 			return command_param_failed();
 
 		if (access(dir_path, F_OK) == 0)
-			add_plugin_dir(cmd->ld->plugins, dir_path, true);
+			return plugin_dynamic_startdir(cmd, dir_path);
 		else
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 						   "Could not open %s", dir_path);

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -1,12 +1,167 @@
+#include <ccan/pipecmd/pipecmd.h>
 #include <ccan/tal/path/path.h>
 #include <common/json_command.h>
 #include <common/jsonrpc_errors.h>
 #include <common/param.h>
+#include <common/timeout.h>
 #include <dirent.h>
 #include <errno.h>
+#include <lightningd/io_loop_with_timers.h>
 #include <lightningd/plugin_control.h>
 #include <lightningd/plugin_hook.h>
 #include <unistd.h>
+
+/* A dummy structure used to give multiple arguments to callbacks. */
+struct dynamic_plugin {
+	struct plugin *plugin;
+	struct command *cmd;
+};
+
+/**
+ * Returned by all subcommands on success.
+ */
+static struct command_result *plugin_dynamic_list_plugins(struct command *cmd)
+{
+	struct json_stream *response;
+	struct plugin *p;
+
+	response = json_stream_success(cmd);
+	json_array_start(response, "plugins");
+	list_for_each(&cmd->ld->plugins->plugins, p, list) {
+		json_object_start(response, NULL);
+		json_add_string(response, "name", p->cmd);
+		json_add_bool(response, "active",
+		              p->plugin_state == CONFIGURED);
+		json_object_end(response);
+	}
+	json_array_end(response);
+	return command_success(cmd, response);
+}
+
+/**
+ * Returned by all subcommands on error.
+ */
+static struct command_result *
+plugin_dynamic_error(struct dynamic_plugin *dp, const char *error)
+{
+	plugin_kill(dp->plugin, "%s: %s", dp->plugin->cmd, error);
+	return command_fail(dp->cmd, JSONRPC2_INVALID_PARAMS,
+	                    "%s: %s", dp->plugin->cmd, error);
+}
+
+static void plugin_dynamic_timeout(struct dynamic_plugin *dp)
+{
+	plugin_dynamic_error(dp, "Timed out while waiting for plugin response");
+}
+
+static void plugin_dynamic_config_callback(const char *buffer,
+                                           const jsmntok_t *toks,
+                                           const jsmntok_t *idtok,
+                                           struct dynamic_plugin *dp)
+{
+	struct plugin *p;
+
+	dp->plugin->plugin_state = CONFIGURED;
+	/* Reset the timer only now so that we are either configured, or
+	 * killed. */
+	tal_free(dp->plugin->timeout_timer);
+
+	list_for_each(&dp->plugin->plugins->plugins, p, list) {
+		if (p->plugin_state != CONFIGURED)
+			return;
+	}
+
+	/* No plugin unconfigured left, return the plugin list */
+	was_pending(plugin_dynamic_list_plugins(dp->cmd));
+}
+
+/**
+ * Send the init message to the plugin. We don't care about its response,
+ * but it's considered the last part of the handshake : once it responds
+ * it is considered configured.
+ */
+static void plugin_dynamic_config(struct dynamic_plugin *dp)
+{
+	struct jsonrpc_request *req;
+
+	req = jsonrpc_request_start(dp->plugin, "init", dp->plugin->log,
+	                            plugin_dynamic_config_callback, dp);
+	plugin_populate_init_request(dp->plugin, req);
+	jsonrpc_request_end(req);
+	plugin_request_send(dp->plugin, req);
+}
+
+static void plugin_dynamic_manifest_callback(const char *buffer,
+                                             const jsmntok_t *toks,
+                                             const jsmntok_t *idtok,
+                                             struct dynamic_plugin *dp)
+{
+	if (!plugin_parse_getmanifest_response(buffer, toks, idtok, dp->plugin))
+		return was_pending(plugin_dynamic_error(dp, "Gave a bad response to getmanifest"));
+
+	if (!dp->plugin->dynamic)
+		return was_pending(plugin_dynamic_error(dp, "Not a dynamic plugin"));
+
+	/* We got the manifest, now send the init message */
+	plugin_dynamic_config(dp);
+}
+
+/**
+ * This starts a plugin : spawns the process, connect its stdout and stdin,
+ * then sends it a getmanifest request.
+ */
+static struct command_result *plugin_start(struct dynamic_plugin *dp)
+{
+	int stdin, stdout;
+	char **p_cmd;
+	struct jsonrpc_request *req;
+	struct plugin *p = dp->plugin;
+
+	p->dynamic = true;
+	p_cmd = tal_arrz(NULL, char *, 2);
+	p_cmd[0] = p->cmd;
+	p->pid = pipecmdarr(&stdin, &stdout, &pipecmd_preserve, p_cmd);
+	if (p->pid == -1)
+		return plugin_dynamic_error(dp, "Error running command");
+	else
+		log_debug(dp->cmd->ld->plugins->log, "started(%u) %s", p->pid, p->cmd);
+	tal_free(p_cmd);
+	p->buffer = tal_arr(p, char, 64);
+	p->stop = false;
+	/* Give the plugin 20 seconds to respond to `getmanifest`, so we don't hang
+	 * too long on the RPC caller. */
+	p->timeout_timer = new_reltimer(dp->cmd->ld->timers, dp,
+	                                time_from_sec(20),
+	                                plugin_dynamic_timeout, dp);
+
+	/* Create two connections, one read-only on top of the plugin's stdin, and one
+	 * write-only on its stdout. */
+	io_new_conn(p, stdout, plugin_stdout_conn_init, p);
+	io_new_conn(p, stdin, plugin_stdin_conn_init, p);
+	req = jsonrpc_request_start(p, "getmanifest", p->log,
+	                            plugin_dynamic_manifest_callback, dp);
+	jsonrpc_request_end(req);
+	plugin_request_send(p, req);
+	return command_still_pending(dp->cmd);
+}
+
+/**
+ * Called when trying to start a plugin through RPC, it starts the plugin and
+ * will give a result 20 seconds later at the most.
+ */
+static struct command_result *
+plugin_dynamic_start(struct command *cmd, const char *plugin_path)
+{
+	struct dynamic_plugin *dp;
+
+	dp = tal(cmd, struct dynamic_plugin);
+	dp->cmd = cmd;
+	dp->plugin = plugin_register(cmd->ld->plugins, plugin_path);
+	if (!dp->plugin)
+		return plugin_dynamic_error(dp, "Is already registered");
+
+	return plugin_start(dp);
+}
 
 /**
  * A plugin command which permits to control plugins without restarting
@@ -63,7 +218,7 @@ static struct command_result *json_plugin_control(struct command *cmd,
 			return command_param_failed();
 
 		if (access(plugin_path, X_OK) == 0)
-			plugin_register(cmd->ld->plugins, plugin_path);
+			return plugin_dynamic_start(cmd, plugin_path);
 		else
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 						   "%s is not executable: %s",
@@ -97,10 +252,6 @@ static struct command_result *json_plugin_control(struct command *cmd,
 			return command_param_failed();
 		/* Don't do anything as we return the plugin list anyway */
 	}
-
-	/* The config function is called once we got the manifest,
-	 * in 'plugin_manifest_cb'.*/
-	plugins_start(cmd->ld->plugins, cmd->ld->dev_debug_subprocess);
 
 	response = json_stream_success(cmd);
 	json_array_start(response, "plugins");

--- a/lightningd/plugin_control.h
+++ b/lightningd/plugin_control.h
@@ -1,7 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_PLUGIN_CONTROL_H
 #define LIGHTNING_LIGHTNINGD_PLUGIN_CONTROL_H
 #include "config.h"
-#include <lightningd/lightningd.h>
+#include <lightningd/plugin.h>
 
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_CONTROL_H */

--- a/tests/plugins/broken.py
+++ b/tests/plugins/broken.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Simple plugin to test that lightningd doesnt crash if it starts a
+misbehaving plugin via RPC.
+"""
+
+from lightning import Plugin
+import an_unexistent_module_that_will_make_me_crash
+
+plugin = Plugin(dynamic=False)
+
+
+@plugin.init()
+def init(options, configuration, plugin):
+    plugin.log("broken.py initializing {}".format(configuration))
+    # We need to actually use the import to pass source checks..
+    an_unexistent_module_that_will_make_me_crash.hello()
+
+
+plugin.run()

--- a/tests/plugins/slow_init.py
+++ b/tests/plugins/slow_init.py
@@ -8,7 +8,7 @@ plugin = Plugin()
 @plugin.init()
 def init(options, configuration, plugin):
     plugin.log("slow_init.py initializing {}".format(configuration))
-    time.sleep(1)
+    time.sleep(2)
 
 
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -94,11 +94,10 @@ def test_plugin_dir(node_factory):
 
 
 def test_plugin_slowinit(node_factory):
-    """Tests the 'plugin' RPC command when init is slow"""
+    """Tests that the 'plugin' RPC command times out if plugin doesnt respond"""
     n = node_factory.get_node()
 
     n.rpc.plugin_start(os.path.join(os.getcwd(), "tests/plugins/slow_init.py"))
-    n.daemon.wait_for_log("slow_init.py initializing.* 'startup': False")
 
     # It's not actually configured yet, see what happens;
     # make sure 'rescan' and 'list' controls dont crash
@@ -116,42 +115,47 @@ def test_plugin_command(node_factory):
     assert(len(cmd) == 0)
 
     # Add the 'contrib/plugins' test dir
-    time.sleep(2)
     n.rpc.plugin_startdir(directory=os.path.join(os.getcwd(), "contrib/plugins"))
-    n.daemon.wait_for_log(r"Plugin helloworld.py initialized")
     # Make sure that the 'hello' command from the helloworld.py plugin
     # is now available.
     cmd = [hlp for hlp in n.rpc.help()["help"] if "hello" in hlp["command"]]
     assert(len(cmd) == 1)
 
-    # Make sure 'rescan' and 'list' controls dont crash
+    # Make sure 'rescan' and 'list' subcommands dont crash
     n.rpc.plugin_rescan()
     n.rpc.plugin_list()
-    time.sleep(1)
 
     # Make sure the plugin behaves normally after stop and restart
-    n.rpc.plugin_stop(plugin="helloworld.py")
+    assert("Successfully stopped helloworld.py." == n.rpc.plugin_stop(plugin="helloworld.py")[''])
     n.daemon.wait_for_log(r"Killing plugin: helloworld.py")
-    time.sleep(1)
     n.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "contrib/plugins/helloworld.py"))
     n.daemon.wait_for_log(r"Plugin helloworld.py initialized")
     assert("Hello world" == n.rpc.call(method="hello"))
 
     # Now stop the helloworld plugin
-    n.rpc.plugin_stop(plugin="helloworld.py")
+    assert("Successfully stopped helloworld.py." == n.rpc.plugin_stop(plugin="helloworld.py")[''])
     n.daemon.wait_for_log(r"Killing plugin: helloworld.py")
-    time.sleep(1)
     # Make sure that the 'hello' command from the helloworld.py plugin
     # is not available anymore.
     cmd = [hlp for hlp in n.rpc.help()["help"] if "hello" in hlp["command"]]
     assert(len(cmd) == 0)
 
-    # Test that we cannot stop a plugin with 'dynamic' set to False in
+    # Test that we cannot start a plugin with 'dynamic' set to False in
     # getmanifest
-    n.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "tests/plugins/static.py"))
-    n.daemon.wait_for_log(r"Static plugin initialized.")
-    with pytest.raises(RpcError, match=r"plugin cannot be managed when lightningd is up"):
-        n.rpc.plugin_stop(plugin="static.py")
+    with pytest.raises(RpcError, match=r"Not a dynamic plugin"):
+        n.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "tests/plugins/static.py"))
+
+    # Test that we cannot stop a started plugin with 'dynamic' flag set to
+    # False
+    n2 = node_factory.get_node(options={
+        "plugin": os.path.join(os.getcwd(), "tests/plugins/static.py")
+    })
+    with pytest.raises(RpcError, match=r"static.py cannot be managed when lightningd is up"):
+        n2.rpc.plugin_stop(plugin="static.py")
+
+    # Test that we don't crash when starting a broken plugin
+    with pytest.raises(RpcError, match=r"Timed out while waiting for plugin response"):
+        n2.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "tests/plugins/broken.py"))
 
 
 def test_plugin_disable(node_factory):


### PR DESCRIPTION
#2996, the discussion in #3013, and the `lightningd` crash due to dynamic plugin errors as mentioned by @jb55 on IRC (,[and some plugin developers not that fine with the current implementation](https://github.com/ElementsProject/lightning/pull/2771#issuecomment-523299808),) made me think that I was wrong in how I implemented dynamic plugins. Since we had to fix the dynamic plugins crashes anyway, I rewrited it all to separate runtime paths of dynamic plugins from startup (and potentially critic) plugins at the expense of some code duplication.

This PR :
- removes dynamic-plugins-specific logic from lightningd/plugin.
- removes the middle state were plugins could end up on error : at startup they are either started or killed, via RPC they are either started or killed.
- removes the possibility to start non-dynamic plugins.
- makes the RPC commands wait for the startup to end : if you run `plugin start X` you don't have to poll `plugin list` to know if your plugin has been started or ... (??).