### PR TITLE
Update doc/Makefile to place lightningd manpages first in readthedocs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -91,6 +91,6 @@ doc-clean:
 	$(RM) doc/deployable-lightning.{aux,bbl,blg,dvi,log,out,tex}
 
 doc/index.rst:
-	(grep -v '^   lightning.*\.[0-9]\.md>$$' $@; for m in $$(cd doc && ls lightning*.[0-9].md | sort); do echo "   $$(echo $$m | sed 's/.[0-9].md//') <$$m>"; done) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@
+	(grep -v '^   lightning.*\.[0-9]\.md>$$' $@; for m in $$(cd doc && echo "$$(ls lightningd*.[0-9].md | sort)\n$$(ls lightning-*.[0-9].md | sort)"); do echo "   $$(echo $$m | sed 's/.[0-9].md//') <$$m>"; done) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@
 
 .PHONY: doc/index.rst


### PR DESCRIPTION
Being already placed first in doc/index.rst, running `make doc-all` would mix them with `lightning-` commands (alphabetical order). This updates the rule in the Makefile to first append `lightningd` manpages, and then `lightning-` ones.

Off-subject of this PR, but about markdown manpages : I noticed some formatting errors due to `mrkd`. Since [the upstream repo is still active](https://github.com/refi64/mrkd/pull/1) I'll propose some other modifications to (hopefully) fix them and ask the maintainer to make a new release so we can finally use it normally.