### PR TITLE
plugins: Return `command_param_failed()` if `param()` fail

### DIFF
--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -46,7 +46,7 @@ static struct command_result *json_autocleaninvoice(struct command *cmd,
 		   p_opt_def("cycle_seconds", param_u64, &cycle, 3600),
 		   p_opt_def("expired_by", param_u64, &exby, 86400),
 		   NULL))
-		return NULL;
+		return command_param_failed();
 
 	cycle_seconds = *cycle;
 	expired_by = *exby;

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -386,7 +386,7 @@ static struct command_result *json_fundchannel(struct command *cmd,
 		   p_opt_def("minconf", param_number, &fr->minconf, 1),
 		   p_opt("utxos", param_string, &fr->utxo_str),
 		   NULL))
-		return NULL;
+		return command_param_failed();
 
 	fr->funding_all = streq(fr->funding_str, "all");
 

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -636,7 +636,7 @@ static void setup_command_usage(const struct plugin_command *commands,
 
 		usage_cmd->methodname = commands[i].name;
 		res = commands[i].handle(usage_cmd, NULL, NULL);
-		assert(res == NULL);
+		assert(res == &complete);
 		assert(strmap_get(&usagemap, commands[i].name));
 	}
 }

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1018,7 +1018,7 @@ static struct command_result *json_pay(struct command *cmd,
 			     maxdelay_default),
 		   p_opt_def("exemptfee", param_msat, &exemptfee, AMOUNT_MSAT(5000)),
 		   NULL))
-		return NULL;
+		return command_param_failed();
 
 	b11 = bolt11_decode(cmd, b11str, NULL, &fail);
 	if (!b11) {
@@ -1149,7 +1149,7 @@ static struct command_result *json_paystatus(struct command *cmd,
 	if (!param(cmd, buf, params,
 		   p_opt("bolt11", param_string, &b11str),
 		   NULL))
-		return NULL;
+		return command_param_failed();
 
 	ret = json_out_new(NULL);
 	json_out_start(ret, NULL, '{');
@@ -1271,7 +1271,7 @@ static struct command_result *json_listpays(struct command *cmd,
 	if (!param(cmd, buf, params,
 		   p_opt("bolt11", param_string, &b11str),
 		   NULL))
-		return NULL;
+		return command_param_failed();
 
 	return send_outreq(cmd, "listsendpays",
 			   listsendpays_done, forward_error,


### PR DESCRIPTION
~For `usage` request, we should return NULL when `param()` fails (it must fail).~
~For normal, we'd better return `command_param_failed()` and free `command`.~

Ok, I find I made a mistake.
Now I think we should return `command_param_failed()` whether it's the `usage` case or not.