### PR TITLE
JSON-API: Add the `maxscannodes` parameter in `getroute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `fundchannel_cancel` is extended to work before funding broadcast.
 - JSON API: The parameter `exclude` of `getroute` now also support node-id.
 - JSON-API: `pay` can exclude error nodes if the failcode of `sendpay` has the NODE bit set
+- JSON-API: `getroute` has a new parameter `maxscannodes` to limit the number of scanning node
 
 ### Deprecated
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -590,7 +590,7 @@ class LightningRpc(UnixDomainSocketRpc):
         res = self.call("listpeers", payload)
         return res.get("peers") and res["peers"][0] or None
 
-    def getroute(self, node_id, msatoshi, riskfactor, cltv=9, fromid=None, fuzzpercent=None, exclude=[], maxhops=20):
+    def getroute(self, node_id, msatoshi, riskfactor, cltv=9, fromid=None, fuzzpercent=None, exclude=[], maxhops=20, maxscannodes=None):
         """
         Show route to {id} for {msatoshi}, using {riskfactor} and optional
         {cltv} (default 9). If specified search from {fromid} otherwise use
@@ -607,7 +607,8 @@ class LightningRpc(UnixDomainSocketRpc):
             "fromid": fromid,
             "fuzzpercent": fuzzpercent,
             "exclude": exclude,
-            "maxhops": maxhops
+            "maxhops": maxhops,
+            "maxscannodes": maxscannodes
         }
         return self.call("getroute", payload)
 

--- a/doc/lightning-getroute.7
+++ b/doc/lightning-getroute.7
@@ -4,7 +4,7 @@ lightning-getroute - Command for routing a payment (low-level)
 .SH SYNOPSIS
 
 \fBgetroute\fR \fIid\fR \fImsatoshi\fR \fIriskfactor\fR [\fIcltv\fR] [\fIfromid\fR]
-[\fIfuzzpercent\fR] [\fIexclude\fR] [\fImaxhops\fR]
+[\fIfuzzpercent\fR] [\fIexclude\fR] [\fImaxhops\fR] [\fImaxscannodes\fR]
 
 .SH DESCRIPTION
 
@@ -52,6 +52,10 @@ is undefined\.
 
 
 \fImaxhops\fR is the maximum number of channels to return; default is 20\.
+
+\fImaxscannodes\fR sets an upper bound the number of nodes examined in route
+traversal, to limit time spend\. The default is no limit\. It excludes the
+source node\.
 
 .SH RISKFACTOR EFFECT ON ROUTING
 

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -5,7 +5,7 @@ SYNOPSIS
 --------
 
 **getroute** *id* *msatoshi* *riskfactor* \[*cltv*\] \[*fromid*\]
-\[*fuzzpercent*\] \[*exclude*\] \[*maxhops*\]
+\[*fuzzpercent*\] \[*exclude*\] \[*maxhops*\] \[*maxscannodes*\]
 
 DESCRIPTION
 -----------
@@ -46,6 +46,10 @@ or nodes. Note if the source or destination is excluded, the command result
 is undefined.
 
 *maxhops* is the maximum number of channels to return; default is 20.
+
+*maxscannodes* sets an upper bound the number of nodes examined in route
+traversal, to limit time spend. The default is no limit. It excludes the
+source node.
 
 RISKFACTOR EFFECT ON ROUTING
 ----------------------------

--- a/gossipd/gossip_constants.h
+++ b/gossipd/gossip_constants.h
@@ -13,6 +13,9 @@
  */
 #define ROUTING_MAX_HOPS 20
 
+/* The limitation on how many nodes getroute will scan. */
+#define ROUTING_MAX_SCAN_NODES UINT32_MAX
+
 /* BOLT #7:
  *
  * The `flags` bitfield...individual bits:

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -41,6 +41,7 @@ msgdata,gossip_getroute_request,fuzz,double,
 msgdata,gossip_getroute_request,num_excluded,u16,
 msgdata,gossip_getroute_request,excluded,exclude_entry,num_excluded
 msgdata,gossip_getroute_request,max_hops,u32,
+msgdata,gossip_getroute_request,max_nodes,u32,
 
 msgtype,gossip_getroute_reply,3106
 msgdata,gossip_getroute_reply,num_hops,u16,

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -2484,7 +2484,7 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 	struct amount_msat msat;
 	u32 final_cltv;
 	u64 riskfactor_by_million;
-	u32 max_hops;
+	u32 max_hops, max_nodes;
 	u8 *out;
 	struct route_hop *hops;
 	double fuzz;
@@ -2506,7 +2506,8 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 					      &msat, &riskfactor_by_million,
 					      &final_cltv, &fuzz,
 					      &excluded,
-					      &max_hops))
+					      &max_hops,
+					      &max_nodes))
 		master_badmsg(WIRE_GOSSIP_GETROUTE_REQUEST, msg);
 
 	status_debug("Trying to find a route from %s to %s for %s",
@@ -2518,7 +2519,7 @@ static struct io_plan *getroute_req(struct io_conn *conn, struct daemon *daemon,
 	/* routing.c does all the hard work; can return NULL. */
 	hops = get_route(tmpctx, daemon->rstate, source, &destination,
 			 msat, riskfactor_by_million / 1000000.0, final_cltv,
-			 fuzz, pseudorand_u64(), excluded, max_hops);
+			 fuzz, pseudorand_u64(), excluded, max_hops, max_nodes);
 
 	out = towire_gossip_getroute_reply(NULL, hops);
 	daemon_conn_send(daemon->master, take(out));

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -349,7 +349,8 @@ struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    double fuzz,
 			    u64 seed,
 			    struct exclude_entry **excluded,
-			    size_t max_hops);
+			    size_t max_hops,
+			    size_t max_nodes);
 /* Disable channel(s) based on the given routing failure. */
 void routing_failure(struct routing_state *rstate,
 		     const struct node_id *erring_node,

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -222,6 +222,7 @@ int main(int argc, char *argv[])
 				   riskfactor,
 				   0.75, &base_seed,
 				   ROUTING_MAX_HOPS,
+				   ROUTING_MAX_SCAN_NODES,
 				   &fee);
 		num_hops = tal_count(route);
 		assert(num_hops < ARRAY_SIZE(route_lengths));

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -87,7 +87,7 @@ bool fromwire_gossip_get_incoming_channels(const tal_t *ctx UNNEEDED, const void
 bool fromwire_gossip_getnodes_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **id UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getnodes_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_getroute_request */
-bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED)
+bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED, u32 *max_nodes UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getroute_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_get_txout_reply */
 bool fromwire_gossip_get_txout_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct amount_sat *satoshis UNNEEDED, u8 **outscript UNNEEDED)
@@ -141,7 +141,8 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
 			    struct exclude_entry **excluded UNNEEDED,
-			    size_t max_hops UNNEEDED)
+			    size_t max_hops UNNEEDED,
+			    size_t max_nodes UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */
 const char *gossip_peerd_wire_type_name(int e UNNEEDED)

--- a/gossipd/test/run-extended-info.c
+++ b/gossipd/test/run-extended-info.c
@@ -110,7 +110,7 @@ bool fromwire_gossip_get_incoming_channels(const tal_t *ctx UNNEEDED, const void
 bool fromwire_gossip_getnodes_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **id UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getnodes_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_getroute_request */
-bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED)
+bool fromwire_gossip_getroute_request(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **source UNNEEDED, struct node_id *destination UNNEEDED, struct amount_msat *msatoshi UNNEEDED, u64 *riskfactor_by_million UNNEEDED, u32 *final_cltv UNNEEDED, double *fuzz UNNEEDED, struct exclude_entry ***excluded UNNEEDED, u32 *max_hops UNNEEDED, u32 *max_nodes UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_getroute_request called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_get_txout_reply */
 bool fromwire_gossip_get_txout_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, struct amount_sat *satoshis UNNEEDED, u8 **outscript UNNEEDED)
@@ -164,7 +164,8 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
 			    struct exclude_entry **excluded UNNEEDED,
-			    size_t max_hops UNNEEDED)
+			    size_t max_hops UNNEEDED,
+			    size_t max_nodes UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */
 const char *gossip_peerd_wire_type_name(int e UNNEEDED)

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -177,7 +177,7 @@ int main(void)
 	nc->bcast.timestamp = 1504064344;
 
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(100000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &b));
@@ -186,19 +186,19 @@ int main(void)
 
 	/* We should not be able to find a route that exceeds our own capacity */
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(1000001), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(!route);
 
 	/* Now test with a query that exceeds the channel capacity after adding
 	 * some fees */
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(999999), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(!route);
 
 	/* This should fail to return a route because it is smaller than these
 	 * htlc_minimum_msat on the last channel. */
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(1), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(!route);
 
 	/* {'active': True, 'short_id': '6990:2:1/0', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 1, 'htlc_maximum_msat': 500000, 'htlc_minimum_msat': 100, 'channel_flags': 0, 'destination': '02cca6c5c966fcf61d121e3a70e03a1cd9eeeea024b26ea666ce974d43b242e636', 'source': '03c173897878996287a8100469f954dd820fcd8941daed91c327f168f3329be0bf', 'last_update': 1504064344}, */
@@ -214,13 +214,13 @@ int main(void)
 
 	/* This should route correctly at the max_msat level */
 	route = find_route(tmpctx, rstate, &a, &d, AMOUNT_MSAT(500000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 
 	/* This should fail to return a route because it's larger than the
 	 * htlc_maximum_msat on the last channel. */
 	route = find_route(tmpctx, rstate, &a, &d, AMOUNT_MSAT(500001), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(!route);
 
 	tal_free(tmpctx);

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -183,7 +183,7 @@ int main(void)
 	add_connection(rstate, &a, &b, 1, 1, 1);
 
 	route = find_route(tmpctx, rstate, &a, &b, AMOUNT_MSAT(1000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 1);
 	assert(amount_msat_eq(fee, AMOUNT_MSAT(0)));
@@ -199,7 +199,7 @@ int main(void)
 	add_connection(rstate, &b, &c, 1, 1, 1);
 
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(1000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(amount_msat_eq(fee, AMOUNT_MSAT(1)));
@@ -215,7 +215,7 @@ int main(void)
 
 	/* Will go via D for small amounts. */
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(1000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &d));
@@ -224,7 +224,7 @@ int main(void)
 
 	/* Will go via B for large amounts. */
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(3000000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &b));
@@ -234,7 +234,7 @@ int main(void)
 	/* Make B->C inactive, force it back via D */
 	get_connection(rstate, &b, &c)->channel_flags |= ROUTING_FLAGS_DISABLED;
 	route = find_route(tmpctx, rstate, &a, &c, AMOUNT_MSAT(3000000), riskfactor, 0.0, NULL,
-			   ROUTING_MAX_HOPS, &fee);
+			   ROUTING_MAX_HOPS, ROUTING_MAX_SCAN_NODES, &fee);
 	assert(route);
 	assert(tal_count(route) == 2);
 	assert(channel_is_between(route[0], &a, &d));

--- a/gossipd/test/run-overlong.c
+++ b/gossipd/test/run-overlong.c
@@ -152,7 +152,7 @@ int main(void)
 
 		route = find_route(tmpctx, rstate, &ids[0], &ids[NUM_NODES-1],
 				   AMOUNT_MSAT(1000), 0, 0.0, NULL,
-				   i, &fee);
+				   i, ROUTING_MAX_SCAN_NODES, &fee);
 		assert(route);
 		assert(tal_count(route) == i);
 		if (i != ROUTING_MAX_HOPS)

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -314,7 +314,7 @@ static struct command_result *json_getroute(struct command *cmd,
 	unsigned *cltv;
 	double *riskfactor;
 	const struct exclude_entry **excluded;
-	u32 *max_hops;
+	u32 *max_hops, *max_nodes;
 
 	/* Higher fuzz means that some high-fee paths can be discounted
 	 * for an even larger value, increasing the scope for route
@@ -333,6 +333,8 @@ static struct command_result *json_getroute(struct command *cmd,
 		   p_opt("exclude", param_array, &excludetok),
 		   p_opt_def("maxhops", param_number, &max_hops,
 			     ROUTING_MAX_HOPS),
+		   p_opt_def("maxscannodes", param_number, &max_nodes,
+			     ROUTING_MAX_SCAN_NODES),
 		   NULL))
 		return command_param_failed();
 
@@ -378,7 +380,8 @@ static struct command_result *json_getroute(struct command *cmd,
 						 *riskfactor * 1000000.0,
 						 *cltv, fuzz,
 						 excluded,
-						 *max_hops);
+						 *max_hops,
+						 *max_nodes);
 	subd_req(ld->gossip, ld->gossip, req, -1, 0, json_getroute_reply, cmd);
 	return command_still_pending(cmd);
 }

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1057,6 +1057,23 @@ def test_gossip_notices_close(node_factory, bitcoind):
     assert(l1.rpc.listnodes()['nodes'] == [])
 
 
+def test_getroute_limit_scan_nodes(node_factory):
+    """Test the `maxscannodes` parameter of `getroute` can work
+    """
+    l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True)
+
+    # Scan 0 node.
+    with pytest.raises(RpcError):
+        l1.rpc.getroute(l3.info['id'], 1, 1, maxscannodes=0)
+
+    # Scan 1 node(just l2).
+    with pytest.raises(RpcError):
+        l1.rpc.getroute(l3.info['id'], 1, 1, maxscannodes=1)
+
+    # Scan 2 nodes(l2 and l3).
+    l1.rpc.getroute(l3.info['id'], 1, 1, maxscannodes=2)
+
+
 def test_getroute_exclude_duplicate(node_factory):
     """Test that accidentally duplicating the same channel or same node
     in the exclude list will not have permanent effects.


### PR DESCRIPTION
This is proposed by @ZmnSCPxj . The idea is based on his [comment](https://github.com/ElementsProject/lightning/pull/2890#issuecomment-519499783).
Limitting the number of scanning node can get the partial result of `getroute` quickly. This partial route will be used in `permuteroute`(#2890 and #3001 ).

It's better to post this change before `routetricks` plugin.