### PR TITLE
JSON-API: `fundchannel` and `fundchannel_start` use `amount` as fieldname to replace `satoshi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note: You should always set `allow-deprecated-apis=false` to test for
 changes.
+- JSON-API: `fundchannel` now uses `amount` as the parameter name to replace `satoshi`
+- JSON-API: `fundchannel_start` now uses `amount` as the parameter name to replace `satoshi`
 
 ### Removed
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -540,16 +540,11 @@ class LightningRpc(UnixDomainSocketRpc):
 
         return _fundchannel(node_id, *args, **kwargs)
 
-    def fundchannel_start(self, node_id, satoshi, feerate=None, announce=True):
-        """
-        Start channel funding with {id} for {satoshi} satoshis
-        with feerate of {feerate} (uses default feerate if unset).
-        If {announce} is False, don't send channel announcements.
-        Returns a Bech32 {funding_address} for an external wallet
-        to create a funding transaction for. Requires a call to
-        'fundchannel_complete' to complete channel establishment
-        with peer.
-        """
+    def _deprecated_fundchannel_start(self, node_id, satoshi, feerate=None, announce=True):
+        warnings.warn("fundchannel_start: the 'satoshi' field is renamed 'amount' : expect removal"
+                      " in Mid-2020",
+                      DeprecationWarning)
+
         payload = {
             "id": node_id,
             "satoshi": satoshi,
@@ -557,6 +552,31 @@ class LightningRpc(UnixDomainSocketRpc):
             "announce": announce,
         }
         return self.call("fundchannel_start", payload)
+
+    def fundchannel_start(self, node_id, *args, **kwargs):
+        """
+        Start channel funding with {id} for {amount} satoshis
+        with feerate of {feerate} (uses default feerate if unset).
+        If {announce} is False, don't send channel announcements.
+        Returns a Bech32 {funding_address} for an external wallet
+        to create a funding transaction for. Requires a call to
+        'fundchannel_complete' to complete channel establishment
+        with peer.
+        """
+
+        if 'satoshi' in kwargs:
+            return self._deprecated_fundchannel_start(node_id, *args, **kwargs)
+
+        def _fundchannel_start(node_id, amount, feerate=None, announce=True):
+            payload = {
+                "id": node_id,
+                "amount": amount,
+                "feerate": feerate,
+                "announce": announce
+            }
+            return self.call("fundchannel_start", payload)
+
+        return _fundchannel_start(node_id, *args, **kwargs)
 
     def fundchannel_cancel(self, node_id):
         """

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -3,7 +3,7 @@
 lightning-fundchannel - Command for establishing a lightning channel
 .SH SYNOPSIS
 
-\fBfundchannel\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR]
+\fBfundchannel\fR \fIid\fR \fIamount\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR]
 [\fIutxos\fR]
 
 .SH DESCRIPTION
@@ -20,7 +20,7 @@ for the channel\.
 \fIid\fR is the peer id obtained from \fBconnect\fR\.
 
 
-\fIsatoshi\fR is the amount in satoshis taken from the internal wallet to
+\fIamount\fR is the amount in satoshis taken from the internal wallet to
 fund the channel\. The string \fIall\fR can be used to specify all available
 funds (or 16777215 satoshi if more is available)\. Otherwise, it is in
 satoshi precision; it can be a whole number, a whole number ending in

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -4,7 +4,7 @@ lightning-fundchannel -- Command for establishing a lightning channel
 SYNOPSIS
 --------
 
-**fundchannel** *id* *satoshi* \[*feerate* *announce*\] \[*minconf*\]
+**fundchannel** *id* *amount* \[*feerate* *announce*\] \[*minconf*\]
 \[*utxos*\]
 
 DESCRIPTION
@@ -20,7 +20,7 @@ for the channel.
 
 *id* is the peer id obtained from **connect**.
 
-*satoshi* is the amount in satoshis taken from the internal wallet to
+*amount* is the amount in satoshis taken from the internal wallet to
 fund the channel. The string *all* can be used to specify all available
 funds (or 16777215 satoshi if more is available). Otherwise, it is in
 satoshi precision; it can be a whole number, a whole number ending in

--- a/doc/lightning-fundchannel_start.7
+++ b/doc/lightning-fundchannel_start.7
@@ -3,7 +3,7 @@
 lightning-fundchannel_start - Command for initiating channel establishment for a lightning channel
 .SH SYNOPSIS
 
-\fBfundchannel_start\fR \fIid\fR \fIsatoshi\fR [\fIfeerate\fR \fIannounce\fR]
+\fBfundchannel_start\fR \fIid\fR \fIamount\fR [\fIfeerate\fR \fIannounce\fR]
 
 .SH DESCRIPTION
 
@@ -14,7 +14,7 @@ initiate channel establishment with a connected peer\.
 \fIid\fR is the node id of the remote peer\.
 
 
-\fIsatoshi\fR is the satoshi value that the channel will be funded at\. This
+\fIamount\fR is the satoshi value that the channel will be funded at\. This
 value MUST be accurate, otherwise the negotiated commitment transactions
 will not encompass the correct channel value\.
 

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -4,7 +4,7 @@ lightning-fundchannel\_start -- Command for initiating channel establishment for
 SYNOPSIS
 --------
 
-**fundchannel\_start** *id* *satoshi* \[*feerate* *announce*\]
+**fundchannel\_start** *id* *amount* \[*feerate* *announce*\]
 
 DESCRIPTION
 -----------
@@ -14,7 +14,7 @@ initiate channel establishment with a connected peer.
 
 *id* is the node id of the remote peer.
 
-*satoshi* is the satoshi value that the channel will be funded at. This
+*amount* is the satoshi value that the channel will be funded at. This
 value MUST be accurate, otherwise the negotiated commitment transactions
 will not encompass the correct channel value.
 

--- a/doc/lightning-txprepare.7
+++ b/doc/lightning-txprepare.7
@@ -31,13 +31,30 @@ number, a whole number ending in \fIsat\fR, a whole number ending in \fI000msat\
 or a number with 1 to 8 decimal places ending in \fIbtc\fR\.
 
 
-\fBtxprepare\fR is similar to the first part of a \fBwithdraw\fR command, but
-supports multiple outputs and uses \fIoutputs\fR as parameter\. The second part
-is provided by \fBtxsend\fR\.
+\fIfeerate\fR is an optional feerate to use\. It can be one of the strings
+\fIurgent\fR (aim for next block), \fInormal\fR (next 4 blocks or so) or \fIslow\fR
+(next 100 blocks or so) to use lightningd’s internal estimates: \fInormal\fR
+is the default\.
+
+
+Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means
+the number is interpreted as satoshi-per-kilosipa (weight), and \fIperkb\fR
+means it is interpreted bitcoind-style as satoshi-per-kilobyte\. Omitting
+the suffix is equivalent to \fIperkb\fR\.
+
+
+\fIminconf\fR specifies the minimum number of confirmations that used
+outputs should have\. Default is 1\.
 
 
 \fIutxos\fR specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout"\. These must be drawn from the node's available UTXO set\.
+
+
+\fBtxprepare\fR is similar to the first part of a \fBwithdraw\fR command, but
+supports multiple outputs and uses \fIoutputs\fR as parameter\. The second part
+is provided by \fBtxsend\fR\.
+
 
 .SH RETURN VALUE
 

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -29,12 +29,25 @@ all available funds. Otherwise, it is in amount precision; it can be a whole
 number, a whole number ending in *sat*, a whole number ending in *000msat*,
 or a number with 1 to 8 decimal places ending in *btc*.
 
-**txprepare** is similar to the first part of a **withdraw** command, but
-supports multiple outputs and uses *outputs* as parameter. The second part
-is provided by **txsend**.
+*feerate* is an optional feerate to use. It can be one of the strings
+*urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
+(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
+is the default.
+
+Otherwise, *feerate* is a number, with an optional suffix: *perkw* means
+the number is interpreted as satoshi-per-kilosipa (weight), and *perkb*
+means it is interpreted bitcoind-style as satoshi-per-kilobyte. Omitting
+the suffix is equivalent to *perkb*.
+
+*minconf* specifies the minimum number of confirmations that used
+outputs should have. Default is 1.
 
 *utxos* specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout". These must be drawn from the node's available UTXO set.
+
+**txprepare** is similar to the first part of a **withdraw** command, but
+supports multiple outputs and uses *outputs* as parameter. The second part
+is provided by **txsend**.
 
 RETURN VALUE
 ------------

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -300,10 +300,10 @@ static struct command_result *parse_fallback(struct command *cmd,
 	enum address_parse_result fallback_parse;
 
 	fallback_parse
-		= json_tok_address_scriptpubkey(cmd,
-						get_chainparams(cmd->ld),
-						buffer, fallback,
-						fallback_script);
+		= json_to_address_scriptpubkey(cmd,
+					       get_chainparams(cmd->ld),
+					       buffer, fallback,
+					       fallback_script);
 	if (fallback_parse == ADDRESS_PARSE_UNRECOGNIZED) {
 		return command_fail(cmd, LIGHTNINGD,
 				    "Fallback address not valid");

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -196,7 +196,7 @@ enum address_parse_result {
 /* Return result of address parsing and fills in *scriptpubkey
  * allocated off ctx if ADDRESS_PARSE_SUCCESS
  */
-enum address_parse_result json_tok_address_scriptpubkey(const tal_t *ctx,
+enum address_parse_result json_to_address_scriptpubkey(const tal_t *ctx,
 			     const struct chainparams *chainparams,
 			     const char *buffer,
 			     const jsmntok_t *tok, const u8 **scriptpubkey);

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -999,10 +999,10 @@ static const char *segwit_addr_net_decode(int *witness_version,
 }
 
 enum address_parse_result
-json_tok_address_scriptpubkey(const tal_t *ctx,
-			      const struct chainparams *chainparams,
-			      const char *buffer,
-			      const jsmntok_t *tok, const u8 **scriptpubkey)
+json_to_address_scriptpubkey(const tal_t *ctx,
+			     const struct chainparams *chainparams,
+			     const char *buffer,
+			     const jsmntok_t *tok, const u8 **scriptpubkey)
 {
 	struct bitcoin_address destination;
 	int witness_version;

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -233,12 +233,12 @@ struct json_stream *json_stream_fail(struct command *cmd UNNEEDED,
 /* Generated stub for json_stream_success */
 struct json_stream *json_stream_success(struct command *cmd UNNEEDED)
 { fprintf(stderr, "json_stream_success called!\n"); abort(); }
-/* Generated stub for json_tok_address_scriptpubkey */
-enum address_parse_result json_tok_address_scriptpubkey(const tal_t *ctx UNNEEDED,
+/* Generated stub for json_to_address_scriptpubkey */
+enum address_parse_result json_to_address_scriptpubkey(const tal_t *ctx UNNEEDED,
 			     const struct chainparams *chainparams UNNEEDED,
 			     const char *buffer UNNEEDED,
 			     const jsmntok_t *tok UNNEEDED, const u8 **scriptpubkey UNNEEDED)
-{ fprintf(stderr, "json_tok_address_scriptpubkey called!\n"); abort(); }
+{ fprintf(stderr, "json_to_address_scriptpubkey called!\n"); abort(); }
 /* Generated stub for json_tok_channel_id */
 bool json_tok_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			 struct channel_id *cid UNNEEDED)

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -312,7 +312,11 @@ static struct command_result *fundchannel_start(struct command *cmd,
 
 	json_out_start(ret, NULL, '{');
 	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
-	json_out_addstr(ret, "satoshi", fr->funding_str);
+
+	if (deprecated_apis)
+		json_out_addstr(ret, "satoshi", fr->funding_str);
+	else
+		json_out_addstr(ret, "amount", fr->funding_str);
 
 	if (fr->feerate_str)
 		json_out_addstr(ret, "feerate", fr->feerate_str);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -80,10 +80,10 @@ static struct command_result *param_bitcoin_address(struct command *cmd,
 						    const u8 **scriptpubkey)
 {
 	/* Parse address. */
-	switch (json_tok_address_scriptpubkey(cmd,
-					      get_chainparams(cmd->ld),
-					      buffer, tok,
-					      scriptpubkey)) {
+	switch (json_to_address_scriptpubkey(cmd,
+					     get_chainparams(cmd->ld),
+					     buffer, tok,
+					     scriptpubkey)) {
 	case ADDRESS_PARSE_UNRECOGNIZED:
 		return command_fail(cmd, LIGHTNINGD,
 				    "Could not parse destination address, "
@@ -345,10 +345,10 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 					    "The output format must be "
 					    "{destination: amount}");
 
-		res = json_tok_address_scriptpubkey(cmd,
-						    get_chainparams(cmd->ld),
-						    buffer, &t[1],
-						    &destination);
+		res = json_to_address_scriptpubkey(cmd,
+						   get_chainparams(cmd->ld),
+						   buffer, &t[1],
+						   &destination);
 		if (res == ADDRESS_PARSE_UNRECOGNIZED)
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Could not parse destination address");


### PR DESCRIPTION
Based to the [comment](https://github.com/ElementsProject/lightning/pull/2964#discussion_r317824584) with @niftynei .
As she said, it's better to rename `satoshi` to `amount`. `satoshi` is a bit confusing that you can specify the `satoshi` field as `2.999btc`.