### PR TITLE
cleanup: Use `u32` as the type of `max_hops` and `cltv`

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1042,7 +1042,7 @@ find_shorter_route(const tal_t *ctx, struct routing_state *rstate,
 		   struct node *src, struct node *dst,
 		   const struct node *me,
 		   struct amount_msat msat,
-		   size_t max_hops,
+		   u32 max_hops,
 		   double fuzz, const struct siphash_seed *base_seed,
 		   struct chan **long_route,
 		   struct amount_msat *fee)
@@ -1165,7 +1165,7 @@ find_route(const tal_t *ctx, struct routing_state *rstate,
 	   struct amount_msat msat,
 	   double riskfactor,
 	   double fuzz, const struct siphash_seed *base_seed,
-	   size_t max_hops,
+	   u32 max_hops,
 	   struct amount_msat *fee)
 {
 	struct node *src, *dst;
@@ -2337,7 +2337,7 @@ struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    u32 final_cltv,
 			    double fuzz, u64 seed,
 			    struct exclude_entry **excluded,
-			    size_t max_hops)
+			    u32 max_hops)
 {
 	struct chan **route;
 	struct amount_msat total_amount;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -349,7 +349,7 @@ struct route_hop *get_route(const tal_t *ctx, struct routing_state *rstate,
 			    double fuzz,
 			    u64 seed,
 			    struct exclude_entry **excluded,
-			    size_t max_hops);
+			    u32 max_hops);
 /* Disable channel(s) based on the given routing failure. */
 void routing_failure(struct routing_state *rstate,
 		     const struct node_id *erring_node,

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -141,7 +141,7 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
 			    struct exclude_entry **excluded UNNEEDED,
-			    size_t max_hops UNNEEDED)
+			    u32 max_hops UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */
 const char *gossip_peerd_wire_type_name(int e UNNEEDED)

--- a/gossipd/test/run-extended-info.c
+++ b/gossipd/test/run-extended-info.c
@@ -164,7 +164,7 @@ struct route_hop *get_route(const tal_t *ctx UNNEEDED, struct routing_state *rst
 			    double fuzz UNNEEDED,
 			    u64 seed UNNEEDED,
 			    struct exclude_entry **excluded UNNEEDED,
-			    size_t max_hops UNNEEDED)
+			    u32 max_hops UNNEEDED)
 { fprintf(stderr, "get_route called!\n"); abort(); }
 /* Generated stub for gossip_peerd_wire_type_name */
 const char *gossip_peerd_wire_type_name(int e UNNEEDED)

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -311,7 +311,7 @@ static struct command_result *json_getroute(struct command *cmd,
 	struct node_id *source;
 	const jsmntok_t *excludetok;
 	struct amount_msat *msat;
-	unsigned *cltv;
+	u32 *cltv;
 	double *riskfactor;
 	const struct exclude_entry **excluded;
 	u32 *max_hops;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -178,6 +178,14 @@ static void attempt_failed_tok(struct pay_command *pc, const char *method,
 	failed_end(failed);
 }
 
+/* Helper to add a u32. */
+static void json_out_add_u32(struct json_out *jout,
+			     const char *fieldname,
+			     u32 val)
+{
+	json_out_add(jout, fieldname, false, "%"PRIu32, val);
+}
+
 /* Helper to add a u64. */
 static void json_out_add_u64(struct json_out *jout,
 			     const char *fieldname,
@@ -708,7 +716,7 @@ static struct command_result *start_pay_attempt(struct command *cmd,
 {
 	struct amount_msat msat;
 	const char *dest;
-	size_t max_hops = ROUTING_MAX_HOPS;
+	u32 max_hops = ROUTING_MAX_HOPS;
 	u32 cltv;
 	struct pay_attempt *attempt;
 	va_list ap;
@@ -767,8 +775,8 @@ static struct command_result *start_pay_attempt(struct command *cmd,
 	json_out_addstr(params, "id", dest);
 	json_out_addstr(params, "msatoshi",
 			type_to_string(tmpctx, struct amount_msat, &msat));
-	json_out_add_u64(params, "cltv", cltv);
-	json_out_add_u64(params, "maxhops", max_hops);
+	json_out_add_u32(params, "cltv", cltv);
+	json_out_add_u32(params, "maxhops", max_hops);
 	json_out_add(params, "riskfactor", false, "%f", pc->riskfactor);
 	if (tal_count(pc->excludes) != 0) {
 		json_out_start(params, "exclude", '[');


### PR DESCRIPTION
Add I think this deserve a new helper: `json_out_add_u32`