### PR TITLE
pylightning: Fix the parameter `label` of `sendpay` 

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -804,17 +804,36 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("plugin", payload)
 
-    def sendpay(self, route, payment_hash, description=None, msatoshi=None):
-        """
-        Send along {route} in return for preimage of {payment_hash}
-        """
+    def _deprecated_sendpay(self, route, payment_hash, description, msatoshi=None):
+        warnings.warn("sendpay: the 'description' field is renamed 'label' : expect removal"
+                      " in early-2020",
+                      DeprecationWarning)
         payload = {
             "route": route,
             "payment_hash": payment_hash,
-            "description": description,
+            "label": description,
             "msatoshi": msatoshi,
         }
         return self.call("sendpay", payload)
+
+    def sendpay(self, route, payment_hash, *args, **kwargs):
+        """
+        Send along {route} in return for preimage of {payment_hash}
+        """
+
+        if 'description' in kwargs:
+            return self._deprecated_sendpay(route, payment_hash, *args, **kwargs)
+
+        def _sendpay(route, payment_hash, label=None, msatoshi=None):
+            payload = {
+                "route": route,
+                "payment_hash": payment_hash,
+                "label": label,
+                "msatoshi": msatoshi,
+            }
+            return self.call("sendpay", payload)
+
+        return _sendpay(route, payment_hash, *args, **kwargs)
 
     def setchannelfee(self, id, base=None, ppm=None):
         """


### PR DESCRIPTION
`description` is renamed as `label` in 0.7.0, so now use `label` as the field name in pylightning.