### PR TITLE
Change default behavior of autotor onions to Version 3 onions.

### DIFF
--- a/connectd/connect_wire.csv
+++ b/connectd/connect_wire.csv
@@ -13,6 +13,7 @@ msgdata,connectctl_init,use_tor_proxy_always,bool,
 msgdata,connectctl_init,dev_allow_localhost,bool,
 msgdata,connectctl_init,use_dns,bool,
 msgdata,connectctl_init,tor_password,wirestring,
+msgdata,connectctl_init,use_v3_autotor,bool,
 
 # Connectd->master, here are the addresses I bound, can announce.
 msgtype,connectctl_init_reply,2100

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -148,6 +148,9 @@ struct daemon {
 
 	/* File descriptors to listen on once we're activated. */
 	struct listen_fd *listen_fds;
+
+	/* Allow to define the default behavior of tot services calls*/
+	bool use_v3_autotor;
 };
 
 /* Peers we're trying to reach: we iterate through addrs until we succeed
@@ -1114,14 +1117,16 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 				tor_autoservice(tmpctx,
 						&proposed_wireaddr[i].u.torservice,
 						tor_password,
-						binding);
+						binding,
+						daemon->use_v3_autotor);
 			continue;
 		};
 		add_announcable(announcable,
 				tor_autoservice(tmpctx,
 						&proposed_wireaddr[i].u.torservice,
 						tor_password,
-						binding));
+						binding,
+						daemon->use_v3_autotor));
 	}
 
 	/* Sort and uniquify. */
@@ -1153,7 +1158,8 @@ static struct io_plan *connect_init(struct io_conn *conn,
 		&proposed_listen_announce,
 		&proxyaddr, &daemon->use_proxy_always,
 		&daemon->dev_allow_localhost, &daemon->use_dns,
-		&tor_password)) {
+		&tor_password,
+		&daemon->use_v3_autotor)) {
 		/* This is a helper which prints the type expected and the actual
 		 * message, then exits (it should never be called!). */
 		master_badmsg(WIRE_CONNECTCTL_INIT, msg);

--- a/connectd/tor_autoservice.c
+++ b/connectd/tor_autoservice.c
@@ -227,7 +227,8 @@ find_local_address(const struct wireaddr_internal *bindings)
 struct wireaddr *tor_autoservice(const tal_t *ctx,
 				 const struct wireaddr *tor_serviceaddr,
 				 const char *tor_password,
-				 const struct wireaddr_internal *bindings)
+				 const struct wireaddr_internal *bindings,
+				 const bool use_v3_autotor)
 {
 	int fd;
 	const struct wireaddr *laddr;
@@ -235,7 +236,6 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	struct addrinfo *ai_tor;
 	struct rbuf rbuf;
 	char *buffer;
-	bool use_v3_autotor;
 
 	laddr = find_local_address(bindings);
 	ai_tor = wireaddr_to_addrinfo(tmpctx, tor_serviceaddr);
@@ -249,8 +249,6 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 
 	buffer = tal_arr(tmpctx, char, rbuf_good_size(fd));
 	rbuf_init(&rbuf, fd, buffer, tal_count(buffer), buf_resize);
-
-	use_v3_autotor = true;
 
 	negotiate_auth(&rbuf, tor_password);
 	onion = make_onion(ctx, &rbuf, laddr, use_v3_autotor);

--- a/connectd/tor_autoservice.c
+++ b/connectd/tor_autoservice.c
@@ -73,17 +73,42 @@ static void discard_remaining_response(struct rbuf *rbuf)
 
 static struct wireaddr *make_onion(const tal_t *ctx,
 				   struct rbuf *rbuf,
-				   const struct wireaddr *local)
+				   const struct wireaddr *local,
+				   bool use_v3_autotor)
 {
 	char *line;
 	struct wireaddr *onion;
 
-//V3 tor after 3.3.3.aplha FIXME: TODO SAIBATO
-//sprintf((char *)reach->buffer,"ADD_ONION NEW:ED25519-V3 Port=9735,127.0.0.1:9735\r\n");
-	tor_send_cmd(rbuf,
+/* Now that V3 is out of Beta default to V3 autoservice onions if version is above 0.4
+*/
+	tor_send_cmd(rbuf, "PROTOCOLINFO 1");
+
+	while ((line = tor_response_line(rbuf)) != NULL) {
+
+		if (!strstarts(line, "VERSION Tor="))
+			continue;
+
+		if (use_v3_autotor)
+			if(strstr(line, "\"0.0") ||
+				strstr(line, "\"0.1") ||
+				strstr(line, "\"0.2") ||
+				strstr(line, "\"0.3")) {
+						use_v3_autotor = false;
+						status_unusual("Autotor: fallback to try a V2 onion service, your Tor version is smaller than 0.4.x.x");
+			}
+	};
+
+	if (!use_v3_autotor) {
+		tor_send_cmd(rbuf,
 		     tal_fmt(tmpctx, "ADD_ONION NEW:RSA1024 Port=%d,%s Flags=DiscardPK,Detach",
 			     /* FIXME: We *could* allow user to set Tor port */
 			     DEFAULT_PORT, fmt_wireaddr(tmpctx, local)));
+	} else {
+		tor_send_cmd(rbuf,
+		     tal_fmt(tmpctx, "ADD_ONION NEW:ED25519-V3 Port=%d,%s Flags=DiscardPK,Detach",
+			     /* FIXME: We *could* allow user to set Tor port */
+			     DEFAULT_PORT, fmt_wireaddr(tmpctx, local)));
+	}
 
 	while ((line = tor_response_line(rbuf)) != NULL) {
 		const char *name;
@@ -210,6 +235,7 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	struct addrinfo *ai_tor;
 	struct rbuf rbuf;
 	char *buffer;
+	bool use_v3_autotor;
 
 	laddr = find_local_address(bindings);
 	ai_tor = wireaddr_to_addrinfo(tmpctx, tor_serviceaddr);
@@ -224,8 +250,10 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	buffer = tal_arr(tmpctx, char, rbuf_good_size(fd));
 	rbuf_init(&rbuf, fd, buffer, tal_count(buffer), buf_resize);
 
+	use_v3_autotor = true;
+
 	negotiate_auth(&rbuf, tor_password);
-	onion = make_onion(ctx, &rbuf, laddr);
+	onion = make_onion(ctx, &rbuf, laddr, use_v3_autotor);
 
 	/*on the other hand we can stay connected until ln finish to keep onion alive and then vanish */
 	//because when we run with Detach flag as we now do every start of LN creates a new addr while the old

--- a/connectd/tor_autoservice.h
+++ b/connectd/tor_autoservice.h
@@ -9,6 +9,7 @@
 struct wireaddr *tor_autoservice(const tal_t *ctx,
 				 const struct wireaddr *tor_serviceaddr,
 				 const char *tor_password,
-				 const struct wireaddr_internal *bindings);
+				 const struct wireaddr_internal *bindings,
+				 const bool use_v3_autotor);
 
 #endif /* LIGHTNING_CONNECTD_TOR_AUTOSERVICE_H */

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -374,10 +374,11 @@ Always use the \fBproxy\fR, even to connect to normal IP addresses (you
 can still connect to Unix domain sockets manually)\. This also disables
 all DNS lookups, to avoid leaking information\.
 
-
  \fBdisable-dns\fR
 Disable the DNS bootstrapping mechanism to find a node by its node ID\.
 
+ \fBenable-autotor-v2-mode\fR
+Try to get a v2 onion address from the Tor service call, default is v3\.
 
  \fBtor-service-password\fR=\fIPASSWORD\fR
 Set a Tor control password, which may be needed for \fIautotor:\fR to

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -313,6 +313,9 @@ all DNS lookups, to avoid leaking information.
  **disable-dns**
 Disable the DNS bootstrapping mechanism to find a node by its node ID.
 
+ **enable-autotor-v2-mode**
+Try to get a v2 onion address from the Tor service call, default is v3.
+
  **tor-service-password**=*PASSWORD*
 Set a Tor control password, which may be needed for *autotor:* to
 authenticate to the Tor control port.

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -366,7 +366,8 @@ int connectd_init(struct lightningd *ld)
 	    listen_announce,
 	    ld->proxyaddr, ld->use_proxy_always || ld->pure_tor_setup,
 	    IFDEV(ld->dev_allow_localhost, false), ld->config.use_dns,
-	    ld->tor_service_password ? ld->tor_service_password : "");
+	    ld->tor_service_password ? ld->tor_service_password : "",
+	    ld->config.use_v3_autotor);
 
 	subd_req(ld->connectd, ld->connectd, take(msg), -1, 0,
 		 connect_init_done, NULL);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -67,6 +67,10 @@ struct config {
 
 	/* Minimal amount of effective funding_satoshis for accepting channels */
 	u64 min_capacity_sat;
+
+	/* Allow to define the default behavior of tot services calls*/
+	bool use_v3_autotor;
+
 };
 
 struct lightningd {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -482,6 +482,8 @@ static const struct config testnet_config = {
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
+
+	.use_v3_autotor = true,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -541,6 +543,8 @@ static const struct config mainnet_config = {
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
+
+	.use_v3_autotor = true,
 };
 
 static void check_config(struct lightningd *ld)
@@ -972,6 +976,9 @@ static void register_opts(struct lightningd *ld)
 
 	opt_register_noarg("--disable-dns", opt_set_invbool, &ld->config.use_dns,
 			   "Disable DNS lookups of peers");
+
+	opt_register_noarg("--enable-autotor-v2-mode", opt_set_invbool, &ld->config.use_v3_autotor,
+			   "Try to get a v2 onion address from the Tor service call, default is v3");
 
 	opt_register_logging(ld);
 	opt_register_version();

--- a/wallet/test/test_utils.c
+++ b/wallet/test/test_utils.c
@@ -23,4 +23,5 @@ const struct config test_config = {
 	.max_fee_multiplier = 10,
 	.use_dns = true,
 	.min_capacity_sat = 10000,
+	.use_v3_autotor = true,
 };


### PR DESCRIPTION
Since V3 onions are now supported on most platforms and distros we can default to V3 on autotor service onions.