### PR TITLE
JAON-API: Add a `txtype` parameter for `txprepare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and has `connected` and `state` fields for channels, like `listpeers`.
 - JSON API: `fundchannel_start` now includes field `scriptpubkey`
 - JSON API: `txprepare` and `withdraw` now accept an optional parameter `utxos`, a list of utxos to include in the prepared transaction
+- JSON API: `txprepare` now accept an optional parameter `txtype` to specify the use of the transaction
 
 - bolt11: support for parsing feature bits (field `9`).
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -880,7 +880,7 @@ class LightningRpc(UnixDomainSocketRpc):
 
         return self.call("withdraw", payload)
 
-    def txprepare(self, outputs, feerate=None, minconf=None, utxos=None):
+    def txprepare(self, outputs, feerate=None, minconf=None, utxos=None, txtype=None):
         """
         Prepare a bitcoin transaction which sends to [outputs].
         The format of output is like [{address1: amount1},
@@ -895,6 +895,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "feerate": feerate,
             "minconf": minconf,
             "utxos": utxos,
+            "txtype": txtype,
         }
         return self.call("txprepare", payload)
 

--- a/doc/lightning-txprepare.7
+++ b/doc/lightning-txprepare.7
@@ -3,7 +3,7 @@
 
 .SH SYNOPSIS
 
-\fBtxprepare\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR]
+\fBtxprepare\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR] [\fItxtype\fR]
 
 .SH DESCRIPTION
 
@@ -38,6 +38,11 @@ is provided by \fBtxsend\fR\.
 
 \fIutxos\fR specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout"\. These must be drawn from the node's available UTXO set\.
+
+
+\fItxtype\fR is a string and specifies what the use of this transaction is\. It can
+be "withdrawal", "funding" or "unknown"\. If no value is provided the default of
+"unknown" is used\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -4,7 +4,7 @@ lightning-txprepare -- Command to prepare to withdraw funds from the internal wa
 SYNOPSIS
 --------
 
-**txprepare** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\]
+**txprepare** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\] \[*txtype*\]
 
 DESCRIPTION
 -----------
@@ -35,6 +35,10 @@ is provided by **txsend**.
 
 *utxos* specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout". These must be drawn from the node's available UTXO set.
+
+*txtype* is a string and specifies what the use of this transaction is. It can
+be "withdrawal", "funding" or "unknown". If no value is provided the default of
+"unknown" is used.
 
 RETURN VALUE
 ------------

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -257,6 +257,7 @@ static struct json_out *txprepare(struct command *cmd,
 		json_out_add(ret, "minconf", false, "%u", *fr->minconf);
 	if (fr->utxo_str)
 		json_out_add_raw_len(ret, "utxos", fr->utxo_str, strlen(fr->utxo_str));
+	json_out_addstr(ret, "txtype", "funding");
 	json_out_end(ret, '}');
 
 	return ret;

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -886,7 +886,7 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     bitcoind.generate_block(1)
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 1)
     # Create the funding transaction
-    prep = l1.rpc.txprepare([{funding_addr: amount2}])
+    prep = l1.rpc.txprepare([{funding_addr: amount2}], txtype="funding")
     decode = bitcoind.rpc.decoderawtransaction(prep['unsigned_tx'])
     assert decode['txid'] == prep['txid']
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -65,6 +65,7 @@ struct unreleased_tx {
 	struct bitcoin_txid txid;
 	/* Index of change output, or -1 if none. */
 	int change_outnum;
+	enum wallet_tx_type txtype;
 };
 
 /* Possible states for tracked outputs in the database. Not sure yet


### PR DESCRIPTION
As I mentioned in #3006 :

> Open Question
> In f77d6c7 (Fix: Store the transaction(broadcast by txsend) into DB), I add the label TX_UNKNOWN
> for the transaction broadcast by txsend.
> I think maybe we can add optional string field for txsend command to specific the label. What do you think about it?

But then I thought we should add the optional string field `txtype` in `txprepare` other than `txsend`.

For now, `txprepare` is used for withdrawal, funding channel or other unknown things. 
So `txtype` should only support these 3 types: "withdrawal", "funding" and "unknown".