### PR TITLE
pylightning: Responses may not be dict

### DIFF
--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -229,7 +229,9 @@ class UnixDomainSocketRpc(object):
         sock.close()
 
         self.logger.debug("Received response for %s call: %r", method, resp)
-        if "error" in resp:
+        if not isinstance(resp, dict):
+            raise ValueError("Malformed response, response is not a dictionary %s." % resp)
+        elif "error" in resp:
             raise RpcError(method, payload, resp['error'])
         elif "result" not in resp:
             raise ValueError("Malformed response, \"result\" missing.")


### PR DESCRIPTION
Sometimes when calling getinfo before the node has started I get an int (concretely 2019) instead of a dict in resp, resulting in a TypeError when ```"error" in resp``` is checked, for ints are not iterable in that way.

Not a big deal, but I think a ValueError like when no "result" field is present would be more appropriate and clear.
