### PR TITLE
Fix ubuntu install documentation

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -47,15 +47,15 @@ as well:
     sudo apt-get update
     sudo apt-get install -y bitcoind
 
-For development or running tests, get additional dependencies:
-
-    sudo apt-get install -y valgrind python3-pip
-    sudo pip3 install -r tests/requirements.txt -r doc/requirements.txt
-
 Clone lightning:
 
     git clone https://github.com/ElementsProject/lightning.git
     cd lightning
+    
+For development or running tests, get additional dependencies:
+
+    sudo apt-get install -y valgrind python3-pip
+    sudo pip3 install -r tests/requirements.txt -r doc/requirements.txt
 
 Build lightning:
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -54,7 +54,7 @@ Clone lightning:
     
 For development or running tests, get additional dependencies:
 
-    sudo apt-get install -y valgrind python3-pip
+    sudo apt-get install -y valgrind python3-pip python-dev libpq-dev
     sudo pip3 install -r tests/requirements.txt -r doc/requirements.txt
 
 Build lightning:

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -54,7 +54,7 @@ Clone lightning:
     
 For development or running tests, get additional dependencies:
 
-    sudo apt-get install -y valgrind python3-pip python-dev libpq-dev
+    sudo apt-get install -y valgrind python3-pip libpq-dev
     sudo pip3 install -r tests/requirements.txt -r doc/requirements.txt
 
 Build lightning:


### PR DESCRIPTION
Add missing dependencies in the developers' sections and re-order sections so that command can be copy-pasted in the order they appear in the documentation.