### PR TITLE
Different error when trying to pay an invoice from another network

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1043,6 +1043,14 @@ static struct command_result *json_pay(struct command *cmd,
 				    "Invalid bolt11: %s", fail);
 	}
 
+	if (!b11->chain) {
+		return command_fail(cmd, PAY_ROUTE_NOT_FOUND, "Invoice is for an unknown network");
+	}
+
+	if (b11->chain != chainparams) {
+		return command_fail(cmd, PAY_ROUTE_NOT_FOUND, "Invoice is for another network %s", b11->chain->network_name);
+	}
+
 	if (time_now().ts.tv_sec > b11->timestamp + b11->expiry) {
 		return command_fail(cmd, PAY_INVOICE_EXPIRED, "Invoice expired");
 	}


### PR DESCRIPTION
When trying to pay an invoice from another network, I get the error message 'Could not find a route' (code 205).
That's not bad, it has to fail trying to find a route indeed.
But I think it would be nicer if it returned an error explicitly pointing out that the invoice to pay doesn't correspond with the network/chain this node is operating with.

The code I have doesn't seem to be working though, so any advice on this is very welcomed, assuming of course the concept makes sense in the first place.

I'm testing this with https://github.com/jtimon/multi-ln-demo/pull/4 
This is where I check the error: https://github.com/jtimon/multi-ln-demo/blob/master/multiln/bin/demo.py#L114

I don't expect people to run that, but I'm basically using the method pay() from contrib/pylightning.
I'm confused because pay seems to be a plugin and not have the normal cmd argument with which to call get_chainparams().

Again, any tips welcomed.