### PR TITLE
Set the rlimit for NOFILE to 1024 to reduce the subprocess cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,29 +48,26 @@ RUN mkdir /opt/litecoin && cd /opt/litecoin \
 FROM debian:stretch-slim as builder
 
 ENV LIGHTNINGD_VERSION=master
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential git libtool python python3 python3-mako wget gnupg dirmngr git gettext
-
-RUN wget -q https://zlib.net/zlib-1.2.11.tar.gz \
-&& tar xvf zlib-1.2.11.tar.gz \
-&& cd zlib-1.2.11 \
-&& ./configure \
-&& make \
-&& make install && cd .. && rm zlib-1.2.11.tar.gz && rm -rf zlib-1.2.11
-
-RUN apt-get install -y --no-install-recommends unzip tclsh \
-&& wget -q https://www.sqlite.org/2018/sqlite-src-3260000.zip \
-&& unzip sqlite-src-3260000.zip \
-&& cd sqlite-src-3260000 \
-&& ./configure --enable-static --disable-readline --disable-threadsafe --disable-load-extension \
-&& make \
-&& make install && cd .. && rm sqlite-src-3260000.zip && rm -rf sqlite-src-3260000
-
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-&& tar xvf gmp-6.1.2.tar.xz \
-&& cd gmp-6.1.2 \
-&& ./configure --disable-assembly \
-&& make \
-&& make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    autoconf \
+    automake \
+    build-essential \
+    git \
+    libtool \
+    python \
+    python3 \
+    python3-mako \
+    wget \
+    gnupg \
+    dirmngr \
+    git \
+    gettext \
+    unzip \
+    tclsh \
+    libsqlite3-dev \
+    libgmp-dev \
+    zlib1g-dev
 
 WORKDIR /opt/lightningd
 COPY . /tmp/lightning
@@ -82,7 +79,12 @@ RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVE
 
 FROM debian:stretch-slim as final
 COPY --from=downloader /opt/tini /usr/bin/tini
-RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-tools \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    socat \
+    inotify-tools \
+    libgmp10 \
+    libsqlite3-0 \
+    zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LIGHTNINGD_DATA=/root/.lightning

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -76,6 +76,7 @@
 #include <lightningd/options.h>
 #include <onchaind/onchain_wire.h>
 #include <signal.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -629,6 +630,11 @@ int main(int argc, char *argv[])
 	struct timers *timers;
 	const char *stop_response;
 	struct htlc_in_map *unprocessed_htlcs;
+	struct rlimit nofile = {1024, 1024};
+
+	/*~ Make sure that we limit ourselves to something reasonable. Modesty
+	 *  is a virtue. */
+	setrlimit(RLIMIT_NOFILE, &nofile);
 
 	/*~ What happens in strange locales should stay there. */
 	setup_locale();


### PR DESCRIPTION
This should limit the overhead introduced by 25ddb8082369451024f471bc2d77fa7e7207cc47, specifically the loop calling syscalls here:

https://github.com/ElementsProject/lightning/blob/25ddb8082369451024f471bc2d77fa7e7207cc47/ccan/ccan/pipecmd/pipecmd.c#L141-L145

In some environments this would be way larger (e.g., running as root in docker), resulting in way more `close()` calls than intended. This PR limits the number of concurrent open fds, so we have to check and close a smaller range.

Ping @NicolasDorier 

Fixes #2977 
Fixes #3074 