### PR TITLE
Revert "docker: Use system libraries, don't bring your own"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,26 +48,29 @@ RUN mkdir /opt/litecoin && cd /opt/litecoin \
 FROM debian:stretch-slim as builder
 
 ENV LIGHTNINGD_VERSION=master
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    autoconf \
-    automake \
-    build-essential \
-    git \
-    libtool \
-    python \
-    python3 \
-    python3-mako \
-    wget \
-    gnupg \
-    dirmngr \
-    git \
-    gettext \
-    unzip \
-    tclsh \
-    libsqlite3-dev \
-    libgmp-dev \
-    zlib1g-dev
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential git libtool python python3 python3-mako wget gnupg dirmngr git gettext
+
+RUN wget -q https://zlib.net/zlib-1.2.11.tar.gz \
+&& tar xvf zlib-1.2.11.tar.gz \
+&& cd zlib-1.2.11 \
+&& ./configure \
+&& make \
+&& make install && cd .. && rm zlib-1.2.11.tar.gz && rm -rf zlib-1.2.11
+
+RUN apt-get install -y --no-install-recommends unzip tclsh \
+&& wget -q https://www.sqlite.org/2018/sqlite-src-3260000.zip \
+&& unzip sqlite-src-3260000.zip \
+&& cd sqlite-src-3260000 \
+&& ./configure --enable-static --disable-readline --disable-threadsafe --disable-load-extension \
+&& make \
+&& make install && cd .. && rm sqlite-src-3260000.zip && rm -rf sqlite-src-3260000
+
+RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
+&& tar xvf gmp-6.1.2.tar.xz \
+&& cd gmp-6.1.2 \
+&& ./configure --disable-assembly \
+&& make \
+&& make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
 
 WORKDIR /opt/lightningd
 COPY . /tmp/lightning
@@ -79,12 +82,7 @@ RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVE
 
 FROM debian:stretch-slim as final
 COPY --from=downloader /opt/tini /usr/bin/tini
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    socat \
-    inotify-tools \
-    libgmp10 \
-    libsqlite3-0 \
-    zlib1g \
+RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-tools \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LIGHTNINGD_DATA=/root/.lightning


### PR DESCRIPTION
This was working up to the latest release because it was statically linked to the c-lightning binary.
Also, this does not fix arm32 and arm64.

The reason why I was "building my own" was because of docker cache layers, you might end up in a situation where you compiled on the build image on a different version of dependency that what end up installed in the runtime image. This happened to me already.

The cause of https://github.com/ElementsProject/lightning/issues/3074 comes from somewhere else.
Probably a change in the build system which does not build statically anymore?

Changelog-None