### PR TITLE
Dedicated flag to decrease prune timeout

### DIFF
--- a/common/gossip_constants.h
+++ b/common/gossip_constants.h
@@ -63,16 +63,16 @@
  *     - MAY prune the channel.
  *     - MAY ignore the channel.
  */
-#define GOSSIP_PRUNE_INTERVAL(dev_fast_gossip_flag) \
-	DEV_FAST_GOSSIP(dev_fast_gossip_flag, 90, 1209600)
+#define GOSSIP_PRUNE_INTERVAL(dev_fast_gossip_prune_flag) \
+	DEV_FAST_GOSSIP(dev_fast_gossip_prune_flag, 60, 1209600)
 
 /* How long after seeing lockin until we announce the channel. */
 #define GOSSIP_ANNOUNCE_DELAY(dev_fast_gossip_flag) \
 	DEV_FAST_GOSSIP(dev_fast_gossip_flag, 1, 60)
 
 /* How long before deadline should we send refresh update? 1 day normally */
-#define GOSSIP_BEFORE_DEADLINE(dev_fast_gossip_flag) \
-	DEV_FAST_GOSSIP(dev_fast_gossip_flag, 30, 24*60*60)
+#define GOSSIP_BEFORE_DEADLINE(dev_fast_gossip_prune_flag) \
+	DEV_FAST_GOSSIP(dev_fast_gossip_prune_flag, 30, 24*60*60)
 
 /* How many seconds per token?  Normally 1 hour. */
 #define GOSSIP_TOKEN_TIME(dev_fast_gossip_flag) \

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -14,6 +14,7 @@ msgdata,gossipctl_init,num_announcable,u16,
 msgdata,gossipctl_init,announcable,wireaddr,num_announcable
 msgdata,gossipctl_init,dev_gossip_time,?u32,
 msgdata,gossipctl_init,dev_fast_gossip,bool,
+msgdata,gossipctl_init,dev_fast_gossip_prune,bool,
 
 # In developer mode, we can mess with time.
 msgtype,gossip_dev_set_time,3001

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -223,6 +223,7 @@ static void memleak_help_routing_tables(struct htable *memtable,
 	memleak_remove_htable(memtable, &rstate->pending_node_map->raw);
 	memleak_remove_htable(memtable, &rstate->pending_cannouncements.raw);
 	memleak_remove_htable(memtable, &rstate->local_chan_map.raw);
+	memleak_remove_uintmap(memtable, &rstate->unupdated_chanmap);
 
 	for (n = node_map_first(rstate->nodes, &nit);
 	     n;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -286,6 +286,9 @@ struct routing_state {
 
 	/* Speed up gossip. */
 	bool dev_fast_gossip;
+
+	/* Speed up pruning. */
+	bool dev_fast_gossip_prune;
 #endif
 };
 
@@ -322,7 +325,8 @@ struct routing_state *new_routing_state(const tal_t *ctx,
 					const struct node_id *local_id,
 					struct list_head *peers,
 					const u32 *dev_gossip_time TAKES,
-					bool dev_fast_gossip);
+					bool dev_fast_gossip,
+					bool dev_fast_gossip_prune);
 
 /**
  * Add a new bidirectional channel from id1 to id2 with the given

--- a/gossipd/test/run-bench-find_route.c
+++ b/gossipd/test/run-bench-find_route.c
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
 	setup_tmpctx();
 
 	me = nodeid(0);
-	rstate = new_routing_state(tmpctx, NULL, &me, 0, NULL, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &me, 0, NULL, false, false);
 	opt_register_noarg("--perfme", opt_set_bool, &perfme,
 			   "Run perfme-start and perfme-stop around benchmark");
 

--- a/gossipd/test/run-find_route-specific.c
+++ b/gossipd/test/run-find_route-specific.c
@@ -146,7 +146,7 @@ int main(void)
 			   strlen("02cca6c5c966fcf61d121e3a70e03a1cd9eeeea024b26ea666ce974d43b242e636"),
 			   &d);
 
-	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, false, false);
 
 	/* [{'active': True, 'short_id': '6990:2:1/1', 'fee_per_kw': 10, 'delay': 5, 'message_flags': 0, 'channel_flags': 1, 'destination': '0230ad0e74ea03976b28fda587bb75bdd357a1938af4424156a18265167f5e40ae', 'source': '02ea622d5c8d6143f15ed3ce1d501dd0d3d09d3b1c83a44d0034949f8a9ab60f06', 'last_update': 1504064344}, */
 

--- a/gossipd/test/run-find_route.c
+++ b/gossipd/test/run-find_route.c
@@ -181,7 +181,7 @@ int main(void)
 
 	memset(&tmp, 'a', sizeof(tmp));
 	node_id_from_privkey(&tmp, &a);
-	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &a, 0, NULL, false, false);
 
 	new_node(rstate, &a);
 

--- a/gossipd/test/run-overlong.c
+++ b/gossipd/test/run-overlong.c
@@ -105,7 +105,7 @@ int main(void)
 		node_id_from_privkey(&tmp, &ids[i]);
 	}
 	/* We are node 0 */
-	rstate = new_routing_state(tmpctx, NULL, &ids[0], 0, NULL, NULL);
+	rstate = new_routing_state(tmpctx, NULL, &ids[0], 0, NULL, false, false);
 
 	for (size_t i = 0; i < NUM_NODES; i++) {
 		struct chan *chan;

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -289,12 +289,7 @@ void peer_start_closingd(struct channel *channel,
 				      p2wpkh_for_keyidx(tmpctx, ld,
 							channel->final_key_idx),
 				      &last_remote_per_commit_secret,
-#if DEVELOPER
-				      ld->dev_fast_gossip
-#else
-				      false
-#endif
-		);
+				      IFDEV(ld->dev_fast_gossip, false));
 
 	/* We don't expect a response: it will give us feedback on
 	 * signatures sent and received, then closing_complete. */

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -219,7 +219,8 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    ld->alias,
 	    ld->announcable,
 	    IFDEV(ld->dev_gossip_time ? &ld->dev_gossip_time: NULL, NULL),
-	    IFDEV(ld->dev_fast_gossip, false));
+	    IFDEV(ld->dev_fast_gossip, false),
+	    IFDEV(ld->dev_fast_gossip_prune, false));
 	subd_send_msg(ld->gossip, msg);
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -120,6 +120,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_allow_localhost = false;
 	ld->dev_gossip_time = 0;
 	ld->dev_fast_gossip = false;
+	ld->dev_fast_gossip_prune = false;
 	ld->dev_force_privkey = NULL;
 	ld->dev_force_bip32_seed = NULL;
 	ld->dev_force_channel_secrets = NULL;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -203,6 +203,7 @@ struct lightningd {
 
 	/* Speedup gossip propagation, for testing. */
 	bool dev_fast_gossip;
+	bool dev_fast_gossip_prune;
 
 	/* Things we've marked as not leaking. */
 	const void **notleaks;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -416,7 +416,10 @@ static void dev_register_opts(struct lightningd *ld)
 
 	opt_register_noarg("--dev-fast-gossip", opt_set_bool,
 			   &ld->dev_fast_gossip,
-			   "Make gossip broadcast 1 second, pruning 14 seconds");
+			   "Make gossip broadcast 1 second, etc");
+	opt_register_noarg("--dev-fast-gossip-prune", opt_set_bool,
+			   &ld->dev_fast_gossip_prune,
+			   "Make gossip pruning 30 seconds");
 
 	opt_register_arg("--dev-gossip-time", opt_set_u32, opt_show_u32,
 			 &ld->dev_gossip_time,


### PR DESCRIPTION
I tried increasing the prune interval, but we still had issues with --dev-fast-gossip reducing the gossip timeout causing unexpected "bad gossip" messages.

We can't make it too big, or our prune test will simply time out, so return to the original version where we had a setting for this test specifically.