### PR TITLE
Add compability to current formalism to short_channel_id-to-txid.sh 

### DIFF
--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 set -e
 

--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 set -e
 

--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -2,13 +2,22 @@
 
 set -e
 
-if [ "$#" != 1 ]; then
-    echo Usage: "$0" "short:channel:id" >&2
+if [ "$#" != 1 ]
+then
+    echo Usage: "$0" "shortchannelid (e.g. 532046x1702x0 or 532046:1702:0)" >&2
     echo Uses bitcoin-cli to extract the actual txid >&2
-    exit 1
+    exit -1
 fi
 
-BLOCK=$(echo "$1" | cut -d: -f1)
+# Try to segment using both x and : as delimiters (compatibility with the old shortchannelid standard)
+BLOCK=$(echo "$1" | cut -dx -f1)
+TXNUM=$(echo "$1" | cut -dx -f2)
+
+if [ "$BLOCK" == "$1" -a "$TXNUM" == "$1" ]
+then
+    BLOCK=$(echo "$1" | cut -d: -f1)
+    TXNUM=$(echo "$1" | cut -d: -f2)
+fi
 TXNUM=$(echo "$1" | cut -d: -f2)
 
 bitcoin-cli getblock "$(bitcoin-cli getblockhash "$BLOCK")" true | grep '^    "' | head -n "$((TXNUM + 1))" | tail -n 1 | tr -dc '0-9a-f\n'

--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/bash
 
 set -e
 
@@ -6,7 +6,7 @@ if [ "$#" != 1 ]
 then
     echo Usage: "$0" "shortchannelid (e.g. 532046x1702x0 or 532046:1702:0)" >&2
     echo Uses bitcoin-cli to extract the actual txid >&2
-    exit -1
+    exit 1
 fi
 
 # Try to segment using both x and : as delimiters (compatibility with the old shortchannelid standard)
@@ -21,8 +21,8 @@ fi
 
 if [ "$BLOCK" == "$1" -a "$TXNUM" == "$1" ]
 then
-    echo The provided shortchannelid is invalid. Valid examples: 532046x1702x0 or 532046:1702:0
-    exit -1
+    echo The provided shortchannelid is invalid. Valid examples: 532046x1702x0 or 532046:1702:0 >&2
+    exit 1
 fi
 
 bitcoin-cli getblock "$(bitcoin-cli getblockhash "$BLOCK")" true | grep '^    "' | head -n "$((TXNUM + 1))" | tail -n 1 | tr -dc '0-9a-f\n'

--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -18,7 +18,11 @@ then
     BLOCK=$(echo "$1" | cut -d: -f1)
     TXNUM=$(echo "$1" | cut -d: -f2)
 fi
-TXNUM=$(echo "$1" | cut -d: -f2)
+
+if [ "$BLOCK" == "$1" -a "$TXNUM" == "$1" ]
+then
+    echo The provided shortchannelid is invalid. Valid examples: 532046x1702x0 or 532046:1702:0
+    exit -1
+fi
 
 bitcoin-cli getblock "$(bitcoin-cli getblockhash "$BLOCK")" true | grep '^    "' | head -n "$((TXNUM + 1))" | tail -n 1 | tr -dc '0-9a-f\n'
-

--- a/contrib/short_channel_id-to-txid.sh
+++ b/contrib/short_channel_id-to-txid.sh
@@ -13,13 +13,13 @@ fi
 BLOCK=$(echo "$1" | cut -dx -f1)
 TXNUM=$(echo "$1" | cut -dx -f2)
 
-if [ "$BLOCK" == "$1" -a "$TXNUM" == "$1" ]
+if [ "$BLOCK" = "$1" ] && [ "$TXNUM" = "$1" ]
 then
     BLOCK=$(echo "$1" | cut -d: -f1)
     TXNUM=$(echo "$1" | cut -d: -f2)
 fi
 
-if [ "$BLOCK" == "$1" -a "$TXNUM" == "$1" ]
+if [ "$BLOCK" = "$1" ] && [ "$TXNUM" = "$1" ]
 then
     echo The provided shortchannelid is invalid. Valid examples: 532046x1702x0 or 532046:1702:0 >&2
     exit 1


### PR DESCRIPTION
Currently, short_channel_id-to-txid.sh is able to convert only sid based on the old formalism (with : as delimiter). This pull requests adds compatibility with the new standard (with : as deliminer) and slightly improves error messages in case an invalid sid is provided.