### PR TITLE
[dev-suppress-gossip] - Set new peers to GOSSIP_NONE with flag enabled

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -561,6 +561,12 @@ static enum gossip_level peer_gossip_level(const struct daemon *daemon,
 	if (!gossip_queries_feature)
 		return GOSSIP_HIGH;
 
+#if DEVELOPER
+	/* Don't ask new peers for new gossip is dev-suppress-gossip has been set*/
+	if (suppress_gossip)
+	    return GOSSIP_NONE;
+#endif
+
 	/* Figure out how many we have at each level. */
 	memset(gossip_levels, 0, sizeof(gossip_levels));
 	list_for_each(&daemon->peers, peer, list)


### PR DESCRIPTION
After the dev-suppress-gossip flag has been set via RPC this PR forces gossipd to set gossip level to GOSSIP_NONE for new peers we connect to.

Currently setting this flag does not appear to suppress gossip.

Signed-off-by: willcl-ark <will8clark@gmail.com>