### PR TITLE
channeld: reject wumbo payments with more style.

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2642,11 +2642,11 @@ static void handle_offer_htlc(struct peer *peer, const u8 *inmsg)
 		status_failed(STATUS_FAIL_MASTER_IO,
 			      "Duplicate HTLC %"PRIu64, peer->htlc_id);
 
-	/* FIXME: Fuzz the boundaries a bit to avoid probing? */
 	case CHANNEL_ERR_MAX_HTLC_VALUE_EXCEEDED:
-		failcode = WIRE_TEMPORARY_CHANNEL_FAILURE;
-		failmsg = tal_fmt(inmsg, "Maximum value exceeded");
+		failcode = WIRE_REQUIRED_CHANNEL_FEATURE_MISSING;
+		failmsg = tal_fmt(inmsg, "Mini mode: maximum value exceeded");
 		goto failed;
+	/* FIXME: Fuzz the boundaries a bit to avoid probing? */
 	case CHANNEL_ERR_CHANNEL_CAPACITY_EXCEEDED:
 		failcode = WIRE_TEMPORARY_CHANNEL_FAILURE;
 		failmsg = tal_fmt(inmsg, "Capacity exceeded - HTLC fee: %s", fmt_amount_sat(inmsg, &htlc_fee));

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -440,10 +440,13 @@ static enum channel_add_err add_htlc(struct channel *channel,
 
 	/* BOLT #2:
 	 *
+	 * A sending node:
+	 *...
 	 * - for channels with `chain_hash` identifying the Bitcoin blockchain:
 	 *    - MUST set the four most significant bytes of `amount_msat` to 0.
 	 */
-	if (amount_msat_greater(htlc->amount, channel->chainparams->max_payment)) {
+	if (sender == LOCAL
+	    && amount_msat_greater(htlc->amount, channel->chainparams->max_payment)) {
 		return CHANNEL_ERR_MAX_HTLC_VALUE_EXCEEDED;
 	}
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -526,6 +526,13 @@ static void forward_htlc(struct htlc_in *hin,
 		goto fail;
 	}
 
+	if (amount_msat_greater(amt_to_forward,
+				get_chainparams(ld)->max_payment)) {
+		/* ENOWUMBO! */
+		failcode = WIRE_REQUIRED_CHANNEL_FEATURE_MISSING;
+		goto fail;
+	}
+
 	/* BOLT #2:
 	 *
 	 * An offering node:


### PR DESCRIPTION
WIRE_REQUIRED_CHANNEL_FEATURE_MISSING anticipates a glorious Wumbo future,
and is closer to correct (it's a PERM failure).

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>