### PR TITLE
hsm_secret encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Protocol: no longer ask for `initial_routing_sync` (only affects ancient peers).
 - Protocol: nodes now announce features in `node_announcement` broadcasts.
 
+- Wallet: we now support the encryption of the BIP32 master seed (a.k.a. `hsm_secret`).
+
 ### Changed
 
 - JSON API: `txprepare` now uses `outputs` as parameter other than `destination` and `satoshi`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can start `lightningd` with the following command:
 lightningd --network=bitcoin --log-level=debug
 ```
 
-This creates a `.lightning/` subdirectory in your home directory: see `man -l doc/lightningd.8`.
+This creates a `.lightning/` subdirectory in your home directory: see `man -l doc/lightningd.8` (or https://lightning.readthedocs.io/) for more runtime options.
 
 ### Using The JSON-RPC Interface
 
@@ -101,6 +101,8 @@ Useful commands:
 Once you've started for the first time, there's a script called
 `contrib/bootstrap-node.sh` which will connect you to other nodes on
 the lightning network.
+
+You can encrypt the BIP32 root seed (what is stored in `hsm_secret`) by passing the `--encrypted-hsm` startup argument. You can start `lightningd` with `--encrypted-hsm` on an already existing `lightning-dir` (with a not encrypted `hsm_secret`). If you pass that option, you __will not__ be able to start `lightningd` (with the same wallet) again without the password, so please beware with your password management. Also beware of not feeling too safe with an encrypted `hsm_secret`: unlike for `bitcoind` where the wallet encryption can restrict the usage of some RPC command, `lightningd` always need to access keys from the wallet which is thus __not locked__ (yet), even with an encrypted BIP32 master seed.
 
 There are also numerous plugins available for c-lightning which add
 capabilities: in particular there's a collection at:

--- a/common/daemon.c
+++ b/common/daemon.c
@@ -11,6 +11,7 @@
 #include <common/utils.h>
 #include <common/version.h>
 #include <signal.h>
+#include <sodium.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -145,6 +146,12 @@ void daemon_setup(const char *argv0,
 	if (getenv("LIGHTNINGD_DEV_MEMLEAK"))
 		memleak_init();
 #endif
+
+	/* We rely on libsodium for some of the crypto stuff, so we'd better
+	 * not start if it cannot do its job correctly. */
+	if (sodium_init() == -1)
+		errx(1, "Could not initialize libsodium. Maybe not enough entropy"
+		         " available ?");
 
 	/* We handle write returning errors! */
 	signal(SIGPIPE, SIG_IGN);

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -155,6 +155,12 @@ Identify the location of the wallet\. This is a fully qualified data source
 name, including a scheme such as \fBsqlite3\fR or \fBpostgres\fR followed by the
 connection parameters\.
 
+
+ \fBencrypted-hsm\fR
+If set, you will be prompted to enter a password used to encrypt the \fBhsm_secret\fR\.
+Note that once you encrypt the \fBhsm_secret\fR this option will be mandatory for
+\fBlightningd\fR to start\.
+
 .SH Lightning node customization options
 
  \fBalias\fR=\fIRRGGBB\fR
@@ -374,11 +380,14 @@ Always use the \fBproxy\fR, even to connect to normal IP addresses (you
 can still connect to Unix domain sockets manually)\. This also disables
 all DNS lookups, to avoid leaking information\.
 
+
  \fBdisable-dns\fR
 Disable the DNS bootstrapping mechanism to find a node by its node ID\.
 
+
  \fBenable-autotor-v2-mode\fR
 Try to get a v2 onion address from the Tor service call, default is v3\.
+
 
  \fBtor-service-password\fR=\fIPASSWORD\fR
 Set a Tor control password, which may be needed for \fIautotor:\fR to

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -133,6 +133,11 @@ Identify the location of the wallet. This is a fully qualified data source
 name, including a scheme such as `sqlite3` or `postgres` followed by the
 connection parameters.
 
+ **encrypted-hsm**
+If set, you will be prompted to enter a password used to encrypt the `hsm_secret`.
+Note that once you encrypt the `hsm_secret` this option will be mandatory for
+`lightningd` to start.
+
 ### Lightning node customization options
 
  **alias**=*RRGGBB*

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -10,6 +10,7 @@ msgdata,hsmstatus_client_bad_request,msg,u8,len
 msgtype,hsm_init,11
 msgdata,hsm_init,bip32_key_version,bip32_key_version,
 msgdata,hsm_init,chainparams,chainparams,
+msgdata,hsm_init,hsm_encryption_key,?secret,
 msgdata,hsm_init,dev_force_privkey,?privkey,
 msgdata,hsm_init,dev_force_bip32_seed,?secret,
 msgdata,hsm_init,dev_force_channel_secrets,?secrets,

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -580,6 +580,7 @@ static struct io_plan *init_hsm(struct io_conn *conn,
 	struct secret *seed;
 	struct secrets *secrets;
 	struct sha256 *shaseed;
+	struct secret *hsm_encryption_key;
 
 	/* This must be lightningd. */
 	assert(is_lightningd(c));
@@ -589,7 +590,7 @@ static struct io_plan *init_hsm(struct io_conn *conn,
 	 * an extension of the simple comma-separated format output by the
 	 * BOLT tools/extract-formats.py tool. */
 	if (!fromwire_hsm_init(NULL, msg_in, &bip32_key_version, &chainparams,
-			       &privkey, &seed, &secrets, &shaseed))
+	                       &hsm_encryption_key, &privkey, &seed, &secrets, &shaseed))
 		return bad_req(conn, c, msg_in);
 
 #if DEVELOPER

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -96,6 +96,7 @@ void hsm_init(struct lightningd *ld)
 	if (!wire_sync_write(ld->hsm_fd, towire_hsm_init(tmpctx,
 							 &ld->topology->bitcoind->chainparams->bip32_key_version,
 							 chainparams,
+							 ld->config.keypass,
 							 IFDEV(ld->dev_force_privkey, NULL),
 							 IFDEV(ld->dev_force_bip32_seed, NULL),
 							 IFDEV(ld->dev_force_channel_secrets, NULL),

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -106,6 +106,9 @@ void hsm_init(struct lightningd *ld)
 	ld->wallet->bip32_base = tal(ld->wallet, struct ext_key);
 	msg = wire_sync_read(tmpctx, ld->hsm_fd);
 	if (!fromwire_hsm_init_reply(msg,
-				     &ld->id, ld->wallet->bip32_base))
+				     &ld->id, ld->wallet->bip32_base)) {
+		if (ld->config.keypass)
+			errx(1, "Wrong password for encrypted hsm_secret.");
 		errx(1, "HSM did not give init reply");
+	}
 }

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -234,6 +234,11 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	/*~ This is set when a JSON RPC command comes in to shut us down. */
 	ld->stop_conn = NULL;
 
+	/*~ This is used to signal that `hsm_secret` is encrypted, and will
+	 * be set to `true` if the `--encrypted` option is passed at startup.
+	 */
+	ld->encrypted_hsm = false;
+
 	return ld;
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -76,6 +76,7 @@
 #include <lightningd/options.h>
 #include <onchaind/onchain_wire.h>
 #include <signal.h>
+#include <sodium.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -719,6 +720,11 @@ int main(int argc, char *argv[])
 	 * doesn't really make sense, but we can't call it the Badly-named
 	 * Daemon Software Module. */
 	hsm_init(ld);
+
+	/*~ If hsm_secret is encrypted, we don't need its encryption key
+	 * anymore. Note that sodium_munlock() also zeroes the memory.*/
+	if (ld->config.keypass)
+		sodium_munlock(ld->config.keypass->data, sizeof(ld->config.keypass->data));
 
 	/*~ Our default color and alias are derived from our node id, so we
 	 * can only set those now (if not set by config options). */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -71,6 +71,8 @@ struct config {
 	/* Allow to define the default behavior of tot services calls*/
 	bool use_v3_autotor;
 
+	/* This is the key we use to encrypt `hsm_secret`. */
+	struct secret *keypass;
 };
 
 struct lightningd {
@@ -235,6 +237,8 @@ struct lightningd {
 	struct plugins *plugins;
 
 	char *wallet_dsn;
+
+	bool encrypted_hsm;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.


### PR DESCRIPTION
This adds a new startup option which allows one to encrypt its `hsm_secret`, bearer of all its secrets. This uses the already-included (and amazing!) [`libsodium`](https://download.libsodium.org/doc/) with defaults (i.e. [Argon2id](https://github.com/p-h-c/phc-winner-argon2) for deriving a key out of the provided password, and [XChacha20_Poly1305](https://tools.ietf.org/html/draft-arciszewski-xchacha-03) for stream encryption).

This and https://github.com/ElementsProject/lightning/pull/2925 put, I think, the basis to have wallet locking. A plugin using the `rpc_command` hook to restrict the use of some RPC commands against a password, which can easily be bypassed if [it / `lightningd`] is killed, but not with an encrypted `hsm_secret`.