### PR TITLE
Make `listtransactions` non-experimental but keep annotations hidden for now

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -427,7 +427,7 @@ struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx, const u8 **cursor,
 	/* We don't know the input amounts yet, so set them all to NULL */
 	tx->input_amounts =
 	    tal_arrz(tx, struct amount_sat *, tx->wtx->inputs_allocation_len);
-	tx->chainparams = NULL;
+	tx->chainparams = chainparams;
 
 	*cursor += wsize;
 	*max -= wsize;

--- a/common/wallet.h
+++ b/common/wallet.h
@@ -21,6 +21,14 @@ enum wallet_tx_type {
        TX_CHANNEL_CHEAT = 1024,
 };
 
+/* What part of a transaction are we annotating? The entire transaction, an
+ * input or an output. */
+enum wallet_tx_annotation_type {
+	TX_ANNOTATION = 0,
+	OUTPUT_ANNOTATION = 1,
+	INPUT_ANNOTATION = 2,
+};
+
 enum wallet_tx_type fromwire_wallet_tx_type(const u8 **cursor, size_t *max);
 void towire_wallet_tx_type(u8 **pptr, const enum wallet_tx_type type);
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -92,8 +92,6 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 						     tx, &b->height, &owned);
 			wallet_transaction_add(topo->ld->wallet, tx, b->height,
 					       i);
-			wallet_transaction_annotate(topo->ld->wallet, &txid,
-						    TX_WALLET_DEPOSIT, 0);
 		}
 
 		/* We did spends first, in case that tells us to watch tx. */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1018,8 +1018,8 @@ static enum watch_result funding_depth_cb(struct lightningd *ld,
 	if ((min_depth_reached && !channel->scid) || (depth && channel->scid)) {
 		struct txlocator *loc;
 
-		wallet_transaction_annotate(ld->wallet, txid,
-					    TX_CHANNEL_FUNDING, channel->dbid);
+		wallet_annotate_txout(ld->wallet, txid, channel->funding_outnum,
+				      TX_CHANNEL_FUNDING, channel->dbid);
 		loc = wallet_transaction_locate(tmpctx, ld->wallet, txid);
 		if (!mk_short_channel_id(&scid,
 					 loc->blkheight, loc->index,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -474,6 +474,10 @@ void txfilter_add_scriptpubkey(struct txfilter *filter UNNEEDED, const u8 *scrip
 /* Generated stub for version */
 const char *version(void)
 { fprintf(stderr, "version called!\n"); abort(); }
+/* Generated stub for wallet_annotate_txout */
+void wallet_annotate_txout(struct wallet *w UNNEEDED, const struct bitcoin_txid *txid UNNEEDED,
+			   int outnum UNNEEDED, enum wallet_tx_type type UNNEEDED, u64 channel UNNEEDED)
+{ fprintf(stderr, "wallet_annotate_txout called!\n"); abort(); }
 /* Generated stub for wallet_channel_close */
 void wallet_channel_close(struct wallet *w UNNEEDED, u64 wallet_id UNNEEDED)
 { fprintf(stderr, "wallet_channel_close called!\n"); abort(); }

--- a/onchaind/onchain_wire.csv
+++ b/onchaind/onchain_wire.csv
@@ -108,6 +108,13 @@ msgdata,onchain_dev_memleak_reply,leak,bool,
 # Tell the main daemon what we've been watching, mainly used for transactions
 # that we tracked automatically but only onchaind knows how to classify their
 # transactions.
-msgtype,onchain_transaction_annotate,5034
-msgdata,onchain_transaction_annotate,txid,bitcoin_txid,
-msgdata,onchain_transaction_annotate,type,enum wallet_tx_type,
+msgtype,onchain_annotate_txout,5035
+msgdata,onchain_annotate_txout,txid,bitcoin_txid,
+msgdata,onchain_annotate_txout,outnum,u32,
+msgdata,onchain_annotate_txout,type,enum wallet_tx_type,
+
+msgtype,onchain_annotate_txin,5036
+msgdata,onchain_annotate_txin,txid,bitcoin_txid,
+msgdata,onchain_annotate_txin,innum,u32,
+msgdata,onchain_annotate_txin,type,enum wallet_tx_type,
+

--- a/onchaind/test/run-grind_feerate-bug.c
+++ b/onchaind/test/run-grind_feerate-bug.c
@@ -137,6 +137,12 @@ u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid
 /* Generated stub for towire_onchain_all_irrevocably_resolved */
 u8 *towire_onchain_all_irrevocably_resolved(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_all_irrevocably_resolved called!\n"); abort(); }
+/* Generated stub for towire_onchain_annotate_txin */
+u8 *towire_onchain_annotate_txin(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u32 innum UNNEEDED, enum wallet_tx_type type UNNEEDED)
+{ fprintf(stderr, "towire_onchain_annotate_txin called!\n"); abort(); }
+/* Generated stub for towire_onchain_annotate_txout */
+u8 *towire_onchain_annotate_txout(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u32 outnum UNNEEDED, enum wallet_tx_type type UNNEEDED)
+{ fprintf(stderr, "towire_onchain_annotate_txout called!\n"); abort(); }
 /* Generated stub for towire_onchain_broadcast_tx */
 u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, enum wallet_tx_type type UNNEEDED)
 { fprintf(stderr, "towire_onchain_broadcast_tx called!\n"); abort(); }
@@ -155,9 +161,6 @@ u8 *towire_onchain_init_reply(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_onchain_missing_htlc_output */
 u8 *towire_onchain_missing_htlc_output(const tal_t *ctx UNNEEDED, const struct htlc_stub *htlc UNNEEDED)
 { fprintf(stderr, "towire_onchain_missing_htlc_output called!\n"); abort(); }
-/* Generated stub for towire_onchain_transaction_annotate */
-u8 *towire_onchain_transaction_annotate(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, enum wallet_tx_type type UNNEEDED)
-{ fprintf(stderr, "towire_onchain_transaction_annotate called!\n"); abort(); }
 /* Generated stub for towire_onchain_unwatch_tx */
 u8 *towire_onchain_unwatch_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)
 { fprintf(stderr, "towire_onchain_unwatch_tx called!\n"); abort(); }

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -153,6 +153,12 @@ u8 *towire_onchain_add_utxo(const tal_t *ctx UNNEEDED, const struct bitcoin_txid
 /* Generated stub for towire_onchain_all_irrevocably_resolved */
 u8 *towire_onchain_all_irrevocably_resolved(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_all_irrevocably_resolved called!\n"); abort(); }
+/* Generated stub for towire_onchain_annotate_txin */
+u8 *towire_onchain_annotate_txin(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u32 innum UNNEEDED, enum wallet_tx_type type UNNEEDED)
+{ fprintf(stderr, "towire_onchain_annotate_txin called!\n"); abort(); }
+/* Generated stub for towire_onchain_annotate_txout */
+u8 *towire_onchain_annotate_txout(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, u32 outnum UNNEEDED, enum wallet_tx_type type UNNEEDED)
+{ fprintf(stderr, "towire_onchain_annotate_txout called!\n"); abort(); }
 /* Generated stub for towire_onchain_broadcast_tx */
 u8 *towire_onchain_broadcast_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, enum wallet_tx_type type UNNEEDED)
 { fprintf(stderr, "towire_onchain_broadcast_tx called!\n"); abort(); }
@@ -171,9 +177,6 @@ u8 *towire_onchain_init_reply(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_onchain_missing_htlc_output */
 u8 *towire_onchain_missing_htlc_output(const tal_t *ctx UNNEEDED, const struct htlc_stub *htlc UNNEEDED)
 { fprintf(stderr, "towire_onchain_missing_htlc_output called!\n"); abort(); }
-/* Generated stub for towire_onchain_transaction_annotate */
-u8 *towire_onchain_transaction_annotate(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED, enum wallet_tx_type type UNNEEDED)
-{ fprintf(stderr, "towire_onchain_transaction_annotate called!\n"); abort(); }
 /* Generated stub for towire_onchain_unwatch_tx */
 u8 *towire_onchain_unwatch_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)
 { fprintf(stderr, "towire_onchain_unwatch_tx called!\n"); abort(); }

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -472,8 +472,16 @@ def test_transaction_annotations(node_factory, bitcoind):
     assert(output['type'] == 'deposit' and output['satoshis'] == '1000000000msat')
 
     # ... and all other output should be change, and have no annotations
-    types = set([o['type'] for i, o in enumerate(tx['outputs']) if i != idx])
-    assert(set([None]) == types)
+    types = []
+    for i, o in enumerate(tx['outputs']):
+        if i == idx:
+            continue
+        if 'type' in o:
+            types.append(o['type'])
+        else:
+            types.append(None)
+
+    assert(set([None]) == set(types))
 
     ##########################################################################
     # Let's now open a channel. The opener should get the funding transaction

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -463,6 +463,18 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE vars ADD COLUMN blobval BLOB"), NULL},
     {SQL("UPDATE vars SET intval = CAST(val AS INTEGER) WHERE name IN ('bip32_max_index', 'last_processed_block', 'next_pay_index')"), NULL},
     {SQL("UPDATE vars SET blobval = CAST(val AS BLOB) WHERE name = 'genesis_hash'"), NULL},
+    {SQL("CREATE TABLE transaction_annotations ("
+	 /* Not making this a reference since we usually filter the TX by
+	  * walking its inputs and outputs, and only afterwards storing it in
+	  * the DB. Having a reference here would point into the void until we
+	  * add the matching TX. */
+	 "  txid BLOB"
+	 ", idx INTEGER" /* 0 when location is the tx, the index of the output or input otherwise */
+	 ", location INTEGER" /* The transaction itself, the output at idx, or the input at idx */
+	 ", type INTEGER"
+	 ", channel BIGINT REFERENCES channels(id)"
+	 ", UNIQUE(txid, idx)"
+	 ");"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2946,7 +2946,11 @@ bool wallet_transaction_type(struct wallet *w, const struct bitcoin_txid *txid,
 		return false;
 	}
 
-	*type = db_column_u64(stmt, 0);
+	if (!db_column_is_null(stmt, 0))
+		*type = db_column_u64(stmt, 0);
+	else
+		*type = 0;
+
 	tal_free(stmt);
 	return true;
 }

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1577,6 +1577,8 @@ int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
 			      type_to_string(tmpctx, struct amount_sat, total),
 			      type_to_string(tmpctx, struct amount_sat,
 					     &utxo->amount));
+
+		wallet_annotate_txout(w, &utxo->txid, output, TX_WALLET_DEPOSIT, 0);
 		tal_free(utxo);
 		num_utxos++;
 	}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -219,6 +219,11 @@ enum wallet_payment_status {
 	PAYMENT_FAILED = 2
 };
 
+struct tx_annotation {
+	enum wallet_tx_type type;
+	struct short_channel_id channel;
+};
+
 static inline enum wallet_payment_status wallet_payment_status_in_db(enum wallet_payment_status w)
 {
 	switch (w) {
@@ -295,8 +300,17 @@ struct wallet_transaction {
 	u32 blockheight;
 	u32 txindex;
 	u8 *rawtx;
-	enum wallet_tx_type type;
-	u64 channel_id;
+
+	/* Fully parsed transaction */
+	const struct bitcoin_tx *tx;
+
+	struct tx_annotation annotation;
+
+	/* tal_arr containing the annotation types, if any, for the respective
+	 * inputs and outputs. 0 if there are no annotations for the
+	 * element. */
+	struct tx_annotation *input_annotations;
+	struct tx_annotation *output_annotations;
 };
 
 /**
@@ -1179,7 +1193,7 @@ void free_unreleased_txs(struct wallet *w);
  *
  * @param ctx: allocation context for the returned list
  * @param wallet: Wallet to load from.
- * @return A tal_arr of wallet transactions
+ * @return A tal_arr of wallet annotated transactions
  */
 struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t *ctx);
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1055,6 +1055,12 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
 			    const u32 blockheight, const u32 txindex);
 
+void wallet_annotate_txout(struct wallet *w, const struct bitcoin_txid *txid,
+			   int outnum, enum wallet_tx_type type, u64 channel);
+
+void wallet_annotate_txin(struct wallet *w, const struct bitcoin_txid *txid,
+			  int innum, enum wallet_tx_type type, u64 channel);
+
 /**
  * Annotate a transaction in the DB with its type and channel referemce.
  *

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -905,6 +905,14 @@ struct {
     {0, NULL}
 };
 
+static const char *txtype_to_string(enum wallet_tx_type t)
+{
+	for (size_t i=0; wallet_tx_type_display_names[i].name != NULL; i++)
+		if (t == wallet_tx_type_display_names[i].t)
+			return wallet_tx_type_display_names[i].name;
+	return NULL;
+}
+
 static void json_add_txtypes(struct json_stream *result, const char *fieldname, enum wallet_tx_type value)
 {
 	json_array_start(result, fieldname);
@@ -913,6 +921,92 @@ static void json_add_txtypes(struct json_stream *result, const char *fieldname, 
 			json_add_string(result, NULL, wallet_tx_type_display_names[i].name);
 	}
 	json_array_end(result);
+}
+
+static void json_transaction_details(struct json_stream *response,
+				     const struct wallet_transaction *tx)
+{
+	struct wally_tx *wtx = tx->tx->wtx;
+
+		json_object_start(response, NULL);
+		json_add_txid(response, "hash", &tx->id);
+		json_add_hex_talarr(response, "rawtx", tx->rawtx);
+		json_add_u64(response, "blockheight", tx->blockheight);
+		json_add_num(response, "txindex", tx->txindex);
+
+		if (tx->annotation.type != 0)
+			json_add_txtypes(response, "type", tx->annotation.type);
+		else
+			json_add_null(response, "type");
+
+		if (tx->annotation.channel.u64 != 0)
+			json_add_short_channel_id(response, "channel", &tx->annotation.channel);
+		else
+			json_add_null(response, "channel");
+
+		json_add_u32(response, "locktime", wtx->locktime);
+		json_add_u32(response, "version", wtx->version);
+
+		json_array_start(response, "inputs");
+		for (size_t i=0; i<wtx->num_inputs; i++) {
+			struct wally_tx_input *in = &wtx->inputs[i];
+			struct tx_annotation *ann = &tx->output_annotations[i];
+			const char *txtype = txtype_to_string(ann->type);
+			json_object_start(response, NULL);
+			json_add_hex(response, "txid", in->txhash, sizeof(in->txhash));
+			json_add_u32(response, "index", in->index);
+			json_add_u32(response, "sequence", in->sequence);
+
+			if (txtype != NULL)
+				json_add_string(response, "type", txtype);
+			else
+				json_add_null(response, "type");
+			if (ann->channel.u64 != 0)
+				json_add_short_channel_id(response, "channel", &ann->channel);
+			else
+				json_add_null(response, "channel");
+
+
+			json_object_end(response);
+		}
+		json_array_end(response);
+
+		json_array_start(response, "outputs");
+		for (size_t i=0; i<wtx->num_outputs; i++) {
+			struct wally_tx_output *out = &wtx->outputs[i];
+			struct tx_annotation *ann = &tx->output_annotations[i];
+			const char *txtype = txtype_to_string(ann->type);
+			struct amount_asset amt = bitcoin_tx_output_get_amount(tx->tx, i);
+			struct amount_sat sat;
+
+			/* TODO We should eventually handle non-bitcoin assets as well. */
+			if (amount_asset_is_main(&amt))
+				sat = amount_asset_to_sat(&amt);
+			else
+				sat = AMOUNT_SAT(0);
+
+			json_object_start(response, NULL);
+
+			json_add_u32(response, "index", i);
+			json_add_amount_sat_only(response, "satoshis", sat);
+
+			if (txtype != NULL)
+				json_add_string(response, "type", txtype);
+			else
+				json_add_null(response, "type");
+
+			if (ann->channel.u64 != 0)
+				json_add_short_channel_id(response, "channel", &ann->channel);
+			else
+				json_add_null(response, "channel");
+
+			json_add_hex(response, "scriptPubKey", out->script, out->script_len);
+
+			json_object_end(response);
+		}
+		json_array_end(response);
+
+		json_object_end(response);
 }
 
 static struct command_result *json_listtransactions(struct command *cmd,
@@ -930,14 +1024,9 @@ static struct command_result *json_listtransactions(struct command *cmd,
 
 	response = json_stream_success(cmd);
 	json_array_start(response, "transactions");
-	for (size_t i=0; i<tal_count(txs); i++) {
-		json_object_start(response, NULL);
-		json_add_txid(response, "hash", &txs[i].id);
-		json_add_hex_talarr(response, "rawtx", txs[i].rawtx);
-		json_add_u64(response, "blockheight", txs[i].blockheight);
-		json_add_num(response, "txindex", txs[i].txindex);
-		json_object_end(response);
-	}
+	for (size_t i=0; i<tal_count(txs); i++)
+		json_transaction_details(response, &txs[i]);
+
 	json_array_end(response);
 	return command_success(cmd, response);
 }

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -907,7 +907,7 @@ struct {
 #if EXPERIMENTAL_FEATURES
 static const char *txtype_to_string(enum wallet_tx_type t)
 {
-	for (size_t i=0; wallet_tx_type_display_names[i].name != NULL; i++)
+	for (size_t i = 0; wallet_tx_type_display_names[i].name != NULL; i++)
 		if (t == wallet_tx_type_display_names[i].t)
 			return wallet_tx_type_display_names[i].name;
 	return NULL;
@@ -916,7 +916,7 @@ static const char *txtype_to_string(enum wallet_tx_type t)
 static void json_add_txtypes(struct json_stream *result, const char *fieldname, enum wallet_tx_type value)
 {
 	json_array_start(result, fieldname);
-	for (size_t i=0; wallet_tx_type_display_names[i].name != NULL; i++) {
+	for (size_t i = 0; wallet_tx_type_display_names[i].name != NULL; i++) {
 		if (value & wallet_tx_type_display_names[i].t)
 			json_add_string(result, NULL, wallet_tx_type_display_names[i].name);
 	}
@@ -936,19 +936,15 @@ static void json_transaction_details(struct json_stream *response,
 #if EXPERIMENTAL_FEATURES
 		if (tx->annotation.type != 0)
 			json_add_txtypes(response, "type", tx->annotation.type);
-		else
-			json_add_null(response, "type");
 
 		if (tx->annotation.channel.u64 != 0)
 			json_add_short_channel_id(response, "channel", &tx->annotation.channel);
-		else
-			json_add_null(response, "channel");
 #endif
 		json_add_u32(response, "locktime", wtx->locktime);
 		json_add_u32(response, "version", wtx->version);
 
 		json_array_start(response, "inputs");
-		for (size_t i=0; i<wtx->num_inputs; i++) {
+		for (size_t i = 0; i < wtx->num_inputs; i++) {
 			struct wally_tx_input *in = &wtx->inputs[i];
 			json_object_start(response, NULL);
 			json_add_hex(response, "txid", in->txhash, sizeof(in->txhash));
@@ -959,12 +955,8 @@ static void json_transaction_details(struct json_stream *response,
 			const char *txtype = txtype_to_string(ann->type);
 			if (txtype != NULL)
 				json_add_string(response, "type", txtype);
-			else
-				json_add_null(response, "type");
 			if (ann->channel.u64 != 0)
 				json_add_short_channel_id(response, "channel", &ann->channel);
-			else
-				json_add_null(response, "channel");
 #endif
 
 			json_object_end(response);
@@ -972,7 +964,7 @@ static void json_transaction_details(struct json_stream *response,
 		json_array_end(response);
 
 		json_array_start(response, "outputs");
-		for (size_t i=0; i<wtx->num_outputs; i++) {
+		for (size_t i = 0; i < wtx->num_outputs; i++) {
 			struct wally_tx_output *out = &wtx->outputs[i];
 			struct amount_asset amt = bitcoin_tx_output_get_amount(tx->tx, i);
 			struct amount_sat sat;
@@ -993,13 +985,9 @@ static void json_transaction_details(struct json_stream *response,
 			const char *txtype = txtype_to_string(ann->type);
 			if (txtype != NULL)
 				json_add_string(response, "type", txtype);
-			else
-				json_add_null(response, "type");
 
 			if (ann->channel.u64 != 0)
 				json_add_short_channel_id(response, "channel", &ann->channel);
-			else
-				json_add_null(response, "channel");
 #endif
 			json_add_hex(response, "scriptPubKey", out->script, out->script_len);
 
@@ -1025,7 +1013,7 @@ static struct command_result *json_listtransactions(struct command *cmd,
 
 	response = json_stream_success(cmd);
 	json_array_start(response, "transactions");
-	for (size_t i=0; i<tal_count(txs); i++)
+	for (size_t i = 0; i < tal_count(txs); i++)
 		json_transaction_details(response, &txs[i]);
 
 	json_array_end(response);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -936,12 +936,6 @@ static struct command_result *json_listtransactions(struct command *cmd,
 		json_add_hex_talarr(response, "rawtx", txs[i].rawtx);
 		json_add_u64(response, "blockheight", txs[i].blockheight);
 		json_add_num(response, "txindex", txs[i].txindex);
-		json_add_txtypes(response, "type", txs[i].type);
-		if (txs[i].channel_id != 0) {
-			json_add_num(response, "channel_id", txs[i].channel_id);
-		} else {
-			json_add_null(response, "channel_id");
-		}
 		json_object_end(response);
 	}
 	json_array_end(response);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -886,7 +886,6 @@ static const struct json_command dev_rescan_output_command = {
 };
 AUTODATA(json_command, &dev_rescan_output_command);
 
-#if EXPERIMENTAL_FEATURES
 struct {
 	enum wallet_tx_type t;
 	const char *name;
@@ -905,6 +904,7 @@ struct {
     {0, NULL}
 };
 
+#if EXPERIMENTAL_FEATURES
 static const char *txtype_to_string(enum wallet_tx_type t)
 {
 	for (size_t i=0; wallet_tx_type_display_names[i].name != NULL; i++)
@@ -922,7 +922,7 @@ static void json_add_txtypes(struct json_stream *result, const char *fieldname, 
 	}
 	json_array_end(result);
 }
-
+#endif
 static void json_transaction_details(struct json_stream *response,
 				     const struct wallet_transaction *tx)
 {
@@ -933,7 +933,7 @@ static void json_transaction_details(struct json_stream *response,
 		json_add_hex_talarr(response, "rawtx", tx->rawtx);
 		json_add_u64(response, "blockheight", tx->blockheight);
 		json_add_num(response, "txindex", tx->txindex);
-
+#if EXPERIMENTAL_FEATURES
 		if (tx->annotation.type != 0)
 			json_add_txtypes(response, "type", tx->annotation.type);
 		else
@@ -943,20 +943,20 @@ static void json_transaction_details(struct json_stream *response,
 			json_add_short_channel_id(response, "channel", &tx->annotation.channel);
 		else
 			json_add_null(response, "channel");
-
+#endif
 		json_add_u32(response, "locktime", wtx->locktime);
 		json_add_u32(response, "version", wtx->version);
 
 		json_array_start(response, "inputs");
 		for (size_t i=0; i<wtx->num_inputs; i++) {
 			struct wally_tx_input *in = &wtx->inputs[i];
-			struct tx_annotation *ann = &tx->output_annotations[i];
-			const char *txtype = txtype_to_string(ann->type);
 			json_object_start(response, NULL);
 			json_add_hex(response, "txid", in->txhash, sizeof(in->txhash));
 			json_add_u32(response, "index", in->index);
 			json_add_u32(response, "sequence", in->sequence);
-
+#if EXPERIMENTAL_FEATURES
+			struct tx_annotation *ann = &tx->output_annotations[i];
+			const char *txtype = txtype_to_string(ann->type);
 			if (txtype != NULL)
 				json_add_string(response, "type", txtype);
 			else
@@ -965,7 +965,7 @@ static void json_transaction_details(struct json_stream *response,
 				json_add_short_channel_id(response, "channel", &ann->channel);
 			else
 				json_add_null(response, "channel");
-
+#endif
 
 			json_object_end(response);
 		}
@@ -974,8 +974,6 @@ static void json_transaction_details(struct json_stream *response,
 		json_array_start(response, "outputs");
 		for (size_t i=0; i<wtx->num_outputs; i++) {
 			struct wally_tx_output *out = &wtx->outputs[i];
-			struct tx_annotation *ann = &tx->output_annotations[i];
-			const char *txtype = txtype_to_string(ann->type);
 			struct amount_asset amt = bitcoin_tx_output_get_amount(tx->tx, i);
 			struct amount_sat sat;
 
@@ -990,6 +988,9 @@ static void json_transaction_details(struct json_stream *response,
 			json_add_u32(response, "index", i);
 			json_add_amount_sat_only(response, "satoshis", sat);
 
+#if EXPERIMENTAL_FEATURES
+			struct tx_annotation *ann = &tx->output_annotations[i];
+			const char *txtype = txtype_to_string(ann->type);
 			if (txtype != NULL)
 				json_add_string(response, "type", txtype);
 			else
@@ -999,7 +1000,7 @@ static void json_transaction_details(struct json_stream *response,
 				json_add_short_channel_id(response, "channel", &ann->channel);
 			else
 				json_add_null(response, "channel");
-
+#endif
 			json_add_hex(response, "scriptPubKey", out->script, out->script_len);
 
 			json_object_end(response);
@@ -1043,4 +1044,3 @@ static const struct json_command listtransactions_command = {
     "it closes the channel and returns funds to the wallet."
 };
 AUTODATA(json_command, &listtransactions_command);
-#endif


### PR DESCRIPTION
We've been promising `listtransactions` for a while now, but it was kept back due to the annotations not being too useful since they don't have any association with inputs and outputs, and channel references could get clobbered if a transaction is associated with multiple transactions (splice anyone?).

This PR attempts to fix both of these by associating the annotations with the inputs and outputs that really give a transaction that facette (no longer clobbering channel references). Since the migration is not complete we still hide the annotation in `listtransactions` so people don't rely on them just yet, but we make `listtransactions` itself available.

`listtransactions` has details attached to each transaction, in the same format as `bitcoin-cli`'s `decoderawtransaction`, but I decided not to use the internal names (`vin`, `vout`, ...) instead opting for slightly longer but more descriptive names.

There is only one source of transactions that hasn't been migrated due to time, and that's `onchain_broadcast_transaction` which needs a bit more work, but is also mostly covered by explicit annotations created by `onchaind` while tracking the close.

In a followup PR I will:

 - Make annotations not experimental
 - Migrate all annotations from tx-based to input- or output-based (unless we want to keep transaction annotations for `txprepare` and `txsend`)
 -  Extend the `test_transaction_annotations` test to test for more annotations

Since this PR touches SQL queries I tested it against both DB backends :wink: 

Closes #2766 

Not assigning milestone since this is rather short-notice before the feature freeze.