### PR TITLE
travis: Force flaky on travis, they are becoming really annoying

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -38,6 +38,12 @@ echo -en 'travis_fold:start:script.1\\r'
 cat config.vars
 echo -en 'travis_fold:end:script.1\\r'
 
+cat > pytest.ini << EOF
+[pytest]
+addopts=-p no:logging --color=no --force-flaky
+EOF
+
+
 if [ "$SOURCE_CHECK_ONLY" == "false" ]; then
     echo -en 'travis_fold:start:script.2\\r'
     make -j3 > /dev/null


### PR DESCRIPTION
Flaky tests send wrong signals, and we restart anyway. We should rather track
flakiness an open issues when they become too regular.

I have a script that is already scraping the travis results for failed tests, and I plan
to add a small dashboard, or even have it file issues for tests that are detected as
flaky. For now this just forces all tests to be treated as flaky so they are retried on
failure, but still leave a trace in the logs which can be picked up by my script.