### PR TITLE
lightningd: initialize the chainparams global in main.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -665,6 +665,10 @@ int main(int argc, char *argv[])
 	 * variables. */
 	ld = new_lightningd(NULL);
 
+	/*~ The global chainparams is needed to init subdaemons, and defaults
+	 * to testnet. */
+	chainparams = chainparams_for_network("testnet");
+
 	/* Figure out where our daemons are first. */
 	ld->daemon_dir = find_daemon_dir(ld, argv[0]);
 	if (!ld->daemon_dir)


### PR DESCRIPTION
Fix #3134. What is fun is that I noticed it while locally testing https://github.com/ElementsProject/lightning/pull/3132, but that all Travis tests pass (we always pass a `--network` at daemon startup).

This makes it `testnet` by default but maybe we want to default to mainnet ? :-) 