### PR TITLE
Make lightning-dir absolute

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -860,6 +860,8 @@ static void handle_minimal_config_opts(struct lightningd *ld,
 			       &ld->config_dir,
 			       "Set working directory. All other files are relative to this");
 
+	ld->config_dir = path_join(ld, path_cwd(tmpctx), take(ld->config_dir));
+
 	ld->wallet_dsn = tal_fmt(ld, "sqlite3://%s/lightningd.sqlite3", ld->config_dir);
 	opt_register_early_arg("--wallet", opt_set_talstr, NULL,
 			       &ld->wallet_dsn,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1633,3 +1633,16 @@ def test_list_features_only(node_factory):
                 'option_gossip_queries_ex/odd',
                 'option_static_remotekey/odd']
     assert features == expected
+
+
+def test_relative_config_dir(node_factory):
+    l1 = node_factory.get_node(start=False)
+    initial_dir = os.getcwd()
+    lndir = l1.daemon.opts.get("lightning-dir")[:-1]
+    *root_dir, l1.daemon.opts["lightning-dir"] = lndir.split('/')
+    os.chdir('/'.join(root_dir))
+    l1.daemon.executable = os.path.join(initial_dir, l1.daemon.executable)
+    l1.start()
+    assert os.path.isabs(l1.rpc.listconfigs()["lightning-dir"])
+    l1.stop()
+    os.chdir(initial_dir)


### PR DESCRIPTION
This fixes #3136 and also makes it easier for plugins (to which we pass `ld->config_dir`).