### PR TITLE
lightningd: fix sizeof() argument correctly.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1392,7 +1392,7 @@ static bool channel_added_their_htlc(struct channel *channel,
 
 	/* FIXME: Our wire generator can't handle optional elems in arrays,
 	 * so we translate all-zero-shared-secret to NULL. */
-	if (memeqzero(shared_secret, sizeof(shared_secret)))
+	if (memeqzero(shared_secret, sizeof(*shared_secret)))
 		shared_secret = NULL;
 
 	/* This stays around even if we fail it immediately: it *is*


### PR DESCRIPTION
c25ce826abc2a362eebb055c199e2bd693b5a13c claimed to fix this, but didn't;
this is the correct fix.

@yashbhutwala 