### PR TITLE
Add `close_to` param for specifying upfront shutdown script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: `fundchannel_start` now includes field `scriptpubkey`
 - JSON API: New method `listtransactions`
 - JSON API: `signmessage` will now create a signature from your node on a message; `checkmessage` will verify it.
+- JSON API: `fundchannel_start` now accepts an optional parameter `close_to`, the address to which these channel funds should be sent to on close. Returns `using_close_to` if will use.
 - Plugin: new notifications `sendpay_success` and `sendpay_failure`.
 - Protocol: nodes now announce features in `node_announcement` broadcasts.
 - Protocol: we now offer `option_gossip_queries_ex` for finegrained gossip control.

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2790,8 +2790,6 @@ static void handle_shutdown_cmd(struct peer *peer, const u8 *inmsg)
 	if (!fromwire_channel_send_shutdown(peer, inmsg, &local_shutdown_script))
 		master_badmsg(WIRE_CHANNEL_SEND_SHUTDOWN, inmsg);
 
-	/* FIXME: When we support local upfront_shutdown_script, local_shutdown_script
-	 * must equal to the local upfront_shutdown_script. */
 	tal_free(peer->final_scriptpubkey);
 	peer->final_scriptpubkey = local_shutdown_script;
 

--- a/contrib/pylightning/lightning/lightning.py
+++ b/contrib/pylightning/lightning/lightning.py
@@ -568,12 +568,13 @@ class LightningRpc(UnixDomainSocketRpc):
         if 'satoshi' in kwargs:
             return self._deprecated_fundchannel_start(node_id, *args, **kwargs)
 
-        def _fundchannel_start(node_id, amount, feerate=None, announce=True):
+        def _fundchannel_start(node_id, amount, feerate=None, announce=True, close_to=None):
             payload = {
                 "id": node_id,
                 "amount": amount,
                 "feerate": feerate,
-                "announce": announce
+                "announce": announce,
+                "close_to": close_to,
             }
             return self.call("fundchannel_start", payload)
 

--- a/doc/lightning-fundchannel_start.7
+++ b/doc/lightning-fundchannel_start.7
@@ -3,7 +3,7 @@
 lightning-fundchannel_start - Command for initiating channel establishment for a lightning channel
 .SH SYNOPSIS
 
-\fBfundchannel_start\fR \fIid\fR \fIamount\fR [\fIfeerate\fR \fIannounce\fR]
+\fBfundchannel_start\fR \fIid\fR \fIamount\fR [\fIfeerate\fR \fIannounce\fR \fIclose_to\fR]
 
 .SH DESCRIPTION
 
@@ -26,6 +26,11 @@ commitment transactions\.
 \fIannounce\fR whether or not to announce this channel\.
 
 
+\fIclose_to\fR is a Bitcoin address to which the channel funds should be sent to
+on close\. Only valid if both peers have negotiated \fBoption_upfront_shutdown_script\fR\.
+Returns \fBclose_to\fR set to closing script iff is negotiated\.
+
+
 Note that the funding transaction MUST NOT be broadcast until after
 channel establishment has been successfully completed by running
 \fBfundchannel_complete\fR, as the commitment transactions for this channel
@@ -35,6 +40,8 @@ transaction before that can lead to unrecoverable loss of funds\.
 .SH RETURN VALUE
 
 On success, returns the \fIfunding_address\fR and the \fIscriptpubkey\fR for the channel funding output\.
+If a \fBclose_to\fR address was provided, will close to this address iff the \fBclose_to\fR address is
+returned in the response\. Otherwise, the peer does not support \fBoption_upfront_shutdownscript\fR\.
 
 
 On failure, returns an error\.
@@ -51,8 +58,4 @@ lightning-fundchannel_\fBcomplete\fR(7), lightning-fundchannel_\fBcancel\fR(7)
 .SH RESOURCES
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
-
-.HL
-
-Last updated 2019-06-12 11:16:20 CEST
 

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -4,7 +4,7 @@ lightning-fundchannel\_start -- Command for initiating channel establishment for
 SYNOPSIS
 --------
 
-**fundchannel\_start** *id* *amount* \[*feerate* *announce*\]
+**fundchannel\_start** *id* *amount* \[*feerate* *announce* *close_to*\]
 
 DESCRIPTION
 -----------
@@ -23,6 +23,10 @@ commitment transactions.
 
 *announce* whether or not to announce this channel.
 
+*close_to* is a Bitcoin address to which the channel funds should be sent to
+on close. Only valid if both peers have negotiated `option_upfront_shutdown_script`.
+Returns `close_to` set to closing script iff is negotiated.
+
 Note that the funding transaction MUST NOT be broadcast until after
 channel establishment has been successfully completed by running
 `fundchannel_complete`, as the commitment transactions for this channel
@@ -33,6 +37,8 @@ RETURN VALUE
 ------------
 
 On success, returns the *funding\_address* and the *scriptpubkey* for the channel funding output.
+If a `close_to` address was provided, will close to this address iff the `close_to` address is
+returned in the response. Otherwise, the peer does not support `option_upfront_shutdownscript`.
 
 On failure, returns an error.
 

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -170,7 +170,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    const struct channel_info *channel_info,
 			    /* NULL or stolen */
 			    u8 *remote_shutdown_scriptpubkey,
-			    u8 *local_shutdown_scriptpubkey,
+			    const u8 *local_shutdown_scriptpubkey,
 			    u64 final_key_idx,
 			    bool last_was_revoke,
 			    /* NULL or stolen */

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -89,8 +89,8 @@ struct channel {
 	/* Our funding tx pubkey. */
 	struct pubkey local_funding_pubkey;
 
-	/* Their scriptpubkey if they sent shutdown. */
-	u8 *shutdown_scriptpubkey[NUM_SIDES];
+	/* scriptpubkey for shutdown, if applicable. */
+	const u8 *shutdown_scriptpubkey[NUM_SIDES];
 	/* Address for any final outputs */
 	u64 final_key_idx;
 
@@ -157,7 +157,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    const struct channel_info *channel_info,
 			    /* NULL or stolen */
 			    u8 *remote_shutdown_scriptpubkey,
-			    u8 *local_shutdown_scriptpubkey,
+			    const u8 *local_shutdown_scriptpubkey,
 			    u64 final_key_idx,
 			    bool last_was_revoke,
 			    /* NULL or stolen */

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -65,11 +65,12 @@ msgdata,opening_funder_reply,our_channel_reserve_satoshis,amount_sat,
 msgdata,opening_funder_reply,shutdown_len,u16,
 msgdata,opening_funder_reply,shutdown_scriptpubkey,u8,shutdown_len
 
-# master->openingd: start channel establishment for a funding
-# tx that will be paid for by an external wallet
+# master->openingd: start channel establishment for a funding tx
 msgtype,opening_funder_start,6002
 msgdata,opening_funder_start,funding_satoshis,amount_sat,
 msgdata,opening_funder_start,push_msat,amount_msat,
+msgdata,opening_funder_start,len_upfront,u16,
+msgdata,opening_funder_start,upfront_shutdown_script,u8,len_upfront
 msgdata,opening_funder_start,feerate_per_kw,u32,
 msgdata,opening_funder_start,channel_flags,u8,
 
@@ -77,6 +78,7 @@ msgdata,opening_funder_start,channel_flags,u8,
 msgtype,opening_funder_start_reply,6102
 msgdata,opening_funder_start_reply,script_len,u8,
 msgdata,opening_funder_start_reply,scriptpubkey,u8,script_len
+msgdata,opening_funder_start_reply,upfront_shutdown_negotiated,bool,
 
 # master->openingd: complete channel establishment for a funding
 # tx that will be paid for by an external wallet

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1071,6 +1071,86 @@ def test_funding_cancel_race(node_factory, bitcoind, executor):
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', "External wallet support doesn't work with elements yet.")
+def test_funding_close_upfront(node_factory, bitcoind):
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node()
+
+    def _fundchannel(l1, l2, close_to):
+        l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+        assert(l1.rpc.listpeers()['peers'][0]['id'] == l2.info['id'])
+
+        amount = 2**24 - 1
+        resp = l1.rpc.fundchannel_start(l2.info['id'], amount, close_to=close_to)
+        address = resp['funding_address']
+
+        if close_to:
+            assert resp['close_to']
+        else:
+            assert 'close_to' not in resp
+
+        peer = l1.rpc.listpeers()['peers'][0]
+        # Peer should still be connected and in state waiting for funding_txid
+        assert peer['id'] == l2.info['id']
+        r = re.compile('Funding channel start: awaiting funding_txid with output to .*')
+        assert any(r.match(line) for line in peer['channels'][0]['status'])
+        assert 'OPENINGD' in peer['channels'][0]['state']
+
+        # 'Externally' fund the address from fundchannel_start
+        addr_scriptpubkey = bitcoind.rpc.getaddressinfo(address)['scriptPubKey']
+        txout = CMutableTxOut(amount, bytearray.fromhex(addr_scriptpubkey))
+        unfunded_tx = CMutableTransaction([], [txout])
+        hextx = binascii.hexlify(unfunded_tx.serialize()).decode('utf8')
+
+        funded_tx_obj = bitcoind.rpc.fundrawtransaction(hextx)
+        raw_funded_tx = funded_tx_obj['hex']
+        txid = bitcoind.rpc.decoderawtransaction(raw_funded_tx)['txid']
+        txout = 1 if funded_tx_obj['changepos'] == 0 else 0
+
+        assert l1.rpc.fundchannel_complete(l2.info['id'], txid, txout)['commitments_secured']
+
+        # Broadcast the transaction manually and confirm that channel locks in
+        signed_tx = bitcoind.rpc.signrawtransactionwithwallet(raw_funded_tx)['hex']
+        assert txid == bitcoind.rpc.decoderawtransaction(signed_tx)['txid']
+
+        bitcoind.rpc.sendrawtransaction(signed_tx)
+        bitcoind.generate_block(1)
+
+        for node in [l1, l2]:
+            node.daemon.wait_for_log(r'State changed from CHANNELD_AWAITING_LOCKIN to CHANNELD_NORMAL')
+            channel = node.rpc.listpeers()['peers'][0]['channels'][0]
+            assert amount * 1000 == channel['msatoshi_total']
+
+    # check that normal peer close works
+    _fundchannel(l1, l2, None)
+    assert l1.rpc.close(l2.info['id'])['type'] == 'mutual'
+
+    # check that you can provide a closing address upfront
+    addr = l1.rpc.newaddr()['bech32']
+    _fundchannel(l1, l2, addr)
+    resp = l1.rpc.close(l2.info['id'])
+    assert resp['type'] == 'mutual'
+    assert only_one(only_one(bitcoind.rpc.decoderawtransaction(resp['tx'])['vout'])['scriptPubKey']['addresses']) == addr
+
+    # check that passing in the same addr to close works
+    _fundchannel(l1, l2, addr)
+    resp = l1.rpc.close(l2.info['id'], destination=addr)
+    assert resp['type'] == 'mutual'
+    assert only_one(only_one(bitcoind.rpc.decoderawtransaction(resp['tx'])['vout'])['scriptPubKey']['addresses']) == addr
+
+    # check that remote peer closing works as expected
+    _fundchannel(l1, l2, addr)
+    resp = l2.rpc.close(l1.info['id'])
+    assert resp['type'] == 'mutual'
+    assert only_one(only_one(bitcoind.rpc.decoderawtransaction(resp['tx'])['vout'])['scriptPubKey']['addresses']) == addr
+
+    # check that passing in a different addr to close causes an RPC error
+    addr2 = l1.rpc.newaddr()['bech32']
+    _fundchannel(l1, l2, addr)
+    with pytest.raises(RpcError, match=r'does not match previous shutdown script'):
+        l1.rpc.close(l2.info['id'], destination=addr2)
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', "External wallet support doesn't work with elements yet.")
 def test_funding_external_wallet(node_factory, bitcoind):
     l1 = node_factory.get_node()
     l2 = node_factory.get_node()


### PR DESCRIPTION
Allow users to specify the `upfront_shutdown_script` via a new parameter on `fundchannel_start`.