### PR TITLE
generate a static tor onion address persistent unique to the node id

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -2,6 +2,7 @@ COMMON_SRC_NOGEN :=				\
 	common/addr.c				\
 	common/amount.c				\
 	common/base32.c				\
+	common/base64.c				\
 	common/bech32.c				\
 	common/bech32_util.c			\
 	common/bigsize.c			\

--- a/common/base64.c
+++ b/common/base64.c
@@ -1,0 +1,37 @@
+#include <common/base64.h>
+#include <sodium.h>
+#include <sodium/utils.h>
+
+/* Decode/encode from/to base64, base64 helper functions.
+ * We import base64 from libsodium to generate tor V3 ED25519-V3 onions from blobs
+*/
+
+char *b64_encode(const tal_t *ctx, const u8 *data, size_t len)
+{
+	char *str = tal_arr(ctx, char, sodium_base64_encoded_len(len, sodium_base64_VARIANT_ORIGINAL) + 1);
+
+	str = sodium_bin2base64(str,  tal_count(str), data,
+								len, sodium_base64_VARIANT_ORIGINAL);
+	return str;
+}
+
+u8 *b64_decode(const tal_t *ctx, const char *str, size_t len)
+{
+	size_t bin_len = len + 1;
+
+	u8 *ret = tal_arr(ctx, u8, bin_len);
+
+	if (!sodium_base642bin(ret,
+				tal_count(ret),
+				(const char * const)str,
+				len,
+				NULL,
+				&bin_len,
+				NULL,
+				sodium_base64_VARIANT_ORIGINAL))
+			return tal_free(ret);
+
+	ret[bin_len] = 0;
+	tal_resize(&ret, bin_len + 1);
+	return ret;
+}

--- a/common/base64.h
+++ b/common/base64.h
@@ -1,0 +1,10 @@
+#ifndef LIGHTNING_COMMON_BASE64_H
+#define LIGHTNING_COMMON_BASE64_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+char *b64_encode(const tal_t *ctx, const u8 *data, size_t len);
+u8 *b64_decode(const tal_t *ctx, const char *str, size_t len);
+
+#endif /* LIGHTNING_COMMON_BASE64_H */

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -43,6 +43,8 @@ struct sockaddr_un;
 #define	TOR_V2_ADDRLEN 10
 #define	TOR_V3_ADDRLEN 35
 #define	LARGEST_ADDRLEN TOR_V3_ADDRLEN
+#define	TOR_V3_BLOBLEN 64
+#define	STATIC_TOR_MAGIC_STRING "gen-default-toraddress"
 
 enum wire_addr_type {
 	ADDR_TYPE_IPV4 = 1,
@@ -110,6 +112,7 @@ enum wireaddr_internal_type {
 	ADDR_INTERNAL_AUTOTOR,
 	ADDR_INTERNAL_FORPROXY,
 	ADDR_INTERNAL_WIREADDR,
+	ADDR_INTERNAL_STATICTOR,
 };
 
 /* For internal use, where we can also supply a local socket, wildcard. */
@@ -120,8 +123,13 @@ struct wireaddr_internal {
 		struct wireaddr wireaddr;
 		/* ADDR_INTERNAL_ALLPROTO */
 		u16 port;
-		/* ADDR_INTERNAL_AUTOTOR */
-		struct wireaddr torservice;
+		/* ADDR_INTERNAL_AUTOTOR
+		 * ADDR_INTERNAL_STATICTOR */
+		struct torservice {
+			struct wireaddr address;
+			u16 port;
+			u8 blob[TOR_V3_BLOBLEN + 1];
+		} torservice;
 		/* ADDR_INTERNAL_FORPROXY */
 		struct unresolved {
 			char name[256];

--- a/connectd/Makefile
+++ b/connectd/Makefile
@@ -39,6 +39,7 @@ LIGHTNINGD_HEADERS_GEN += $(LIGHTNINGD_CONNECT_HEADERS)
 CONNECTD_COMMON_OBJS :=				\
 	common/amount.o				\
 	common/base32.o				\
+	common/base64.o				\
 	common/bech32.o				\
 	common/bech32_util.o			\
 	common/bigsize.o			\

--- a/connectd/tor_autoservice.c
+++ b/connectd/tor_autoservice.c
@@ -7,6 +7,7 @@
 #include <ccan/str/hex/hex.h>
 #include <ccan/tal/grab_file/grab_file.h>
 #include <ccan/tal/str/str.h>
+#include <common/base64.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/wireaddr.h>
@@ -21,10 +22,6 @@
 #include <unistd.h>
 #include <wire/wire.h>
 
-#define MAX_TOR_COOKIE_LEN 32
-#define MAX_TOR_SERVICE_READBUFFER_LEN 255
-#define MAX_TOR_ONION_V2_ADDR_LEN 16
-#define MAX_TOR_ONION_V3_ADDR_LEN 56
 
 static void *buf_resize(struct membuf *mb, void *buf, size_t len)
 {
@@ -43,6 +40,30 @@ static void tor_send_cmd(struct rbuf *rbuf, const char *cmd)
 	if (!write_all(rbuf->fd, "\r\n", 2))
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Writing CRLF to Tor socket");
+}
+
+static char *tor_response_line_wfail(struct rbuf *rbuf)
+{
+	char *line = NULL;
+
+	while ((line = rbuf_read_str(rbuf, '\n')) != NULL) {
+		status_io(LOG_IO_IN, NULL, "torcontrol", line, strlen(line));
+
+		/* Weird response */
+		if (!strstarts(line, "250") && !strstarts(line, "550"))
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "Tor returned '%s'", line);
+
+		/* Last line */
+		if (strstarts(line, "250 ") || strstarts(line, "550 "))
+			break;
+
+		return line + 4;
+	}
+	if (line)
+		return line + 4;
+	else
+		return NULL;
 }
 
 static char *tor_response_line(struct rbuf *rbuf)
@@ -74,13 +95,14 @@ static void discard_remaining_response(struct rbuf *rbuf)
 static struct wireaddr *make_onion(const tal_t *ctx,
 				   struct rbuf *rbuf,
 				   const struct wireaddr *local,
-				   bool use_v3_autotor)
+				   bool use_v3_autotor,
+				   u16 port)
 {
 	char *line;
 	struct wireaddr *onion;
 
-/* Now that V3 is out of Beta default to V3 autoservice onions if version is above 0.4
-*/
+	/* Now that V3 is out of Beta default to V3 autoservice onions if version is above 0.4
+	*/
 	tor_send_cmd(rbuf, "PROTOCOLINFO 1");
 
 	while ((line = tor_response_line(rbuf)) != NULL) {
@@ -101,13 +123,11 @@ static struct wireaddr *make_onion(const tal_t *ctx,
 	if (!use_v3_autotor) {
 		tor_send_cmd(rbuf,
 		     tal_fmt(tmpctx, "ADD_ONION NEW:RSA1024 Port=%d,%s Flags=DiscardPK,Detach",
-			     /* FIXME: We *could* allow user to set Tor port */
-			     DEFAULT_PORT, fmt_wireaddr(tmpctx, local)));
+			     port, fmt_wireaddr(tmpctx, local)));
 	} else {
 		tor_send_cmd(rbuf,
 		     tal_fmt(tmpctx, "ADD_ONION NEW:ED25519-V3 Port=%d,%s Flags=DiscardPK,Detach",
-			     /* FIXME: We *could* allow user to set Tor port */
-			     DEFAULT_PORT, fmt_wireaddr(tmpctx, local)));
+			     port, fmt_wireaddr(tmpctx, local)));
 	}
 
 	while ((line = tor_response_line(rbuf)) != NULL) {
@@ -122,15 +142,60 @@ static struct wireaddr *make_onion(const tal_t *ctx,
 
 		name = tal_fmt(tmpctx, "%s.onion", line);
 		onion = tal(ctx, struct wireaddr);
-		if (!parse_wireaddr(name, onion, DEFAULT_PORT, false, NULL))
+		if (!parse_wireaddr(name, onion, local->port, false, NULL))
 			status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				      "Tor gave bad onion name '%s'", name);
-		status_info("New autotor service onion address: \"%s:%d\"", name, DEFAULT_PORT);
+		status_info("New autotor service onion address: \"%s:%d\" bound from extern port:%d", name, local->port, port);
 		discard_remaining_response(rbuf);
 		return onion;
 	}
 	status_failed(STATUS_FAIL_INTERNAL_ERROR,
 		      "Tor didn't give us a ServiceID");
+}
+
+static struct wireaddr *make_fixed_onion(const tal_t *ctx,
+				   struct rbuf *rbuf,
+				   const struct wireaddr *local, const u8 *blob, u16 port)
+{
+	char *line;
+	struct wireaddr *onion;
+	char *blob64;
+
+	blob64 = b64_encode(tmpctx, blob, 64);
+
+	tor_send_cmd(rbuf,
+			 tal_fmt(tmpctx, "ADD_ONION ED25519-V3:%s Port=%d,%s Flags=DiscardPK",
+			 blob64, port, fmt_wireaddr(tmpctx, local)));
+
+	while ((line = tor_response_line_wfail(rbuf))) {
+		const char *name;
+		if (strstarts(line, "Onion address collision"))
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "Tor address in use");
+
+		if (!strstarts(line, "ServiceID="))
+			continue;
+		line += strlen("ServiceID=");
+		/* Strip the trailing CR */
+		if (strchr(line, '\r'))
+			*strchr(line, '\r') = '\0';
+
+		name = tal_fmt(tmpctx, "%s.onion", line);
+		onion = tal(ctx, struct wireaddr);
+		if (!parse_wireaddr(name, onion, local->port, false, NULL))
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "Tor gave bad onion name '%s'", name);
+		#ifdef SUPERVERBOSE
+		 status_info("Static Tor service onion address: \"%s:%d,%s\"from blob %s base64 %s ",
+						name, port ,fmt_wireaddr(tmpctx, local), blob ,blob64);
+		#else
+		status_info("Static Tor service onion address: \"%s:%d,%s\" bound from extern port %d ",
+						name, port ,fmt_wireaddr(tmpctx, local), port);
+		#endif
+		discard_remaining_response(rbuf);
+		return onion;
+	}
+	return NULL;
 }
 
 /* https://gitweb.torproject.org/torspec.git/tree/control-spec.txt:
@@ -210,7 +275,7 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 }
 
 /* We need to have a bound address we can tell Tor to connect to */
-static const struct wireaddr *
+const struct wireaddr *
 find_local_address(const struct wireaddr_internal *bindings)
 {
 	for (size_t i = 0; i < tal_count(bindings); i++) {
@@ -226,7 +291,7 @@ find_local_address(const struct wireaddr_internal *bindings)
 }
 
 struct wireaddr *tor_autoservice(const tal_t *ctx,
-				 const struct wireaddr *tor_serviceaddr,
+				 const struct wireaddr_internal *tor_serviceaddr,
 				 const char *tor_password,
 				 const struct wireaddr_internal *bindings,
 				 const bool use_v3_autotor)
@@ -239,7 +304,7 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	char *buffer;
 
 	laddr = find_local_address(bindings);
-	ai_tor = wireaddr_to_addrinfo(tmpctx, tor_serviceaddr);
+	ai_tor = wireaddr_to_addrinfo(tmpctx, &tor_serviceaddr->u.torservice.address);
 
 	fd = socket(ai_tor->ai_family, SOCK_STREAM, 0);
 	if (fd < 0)
@@ -252,7 +317,7 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	rbuf_init(&rbuf, fd, buffer, tal_count(buffer), buf_resize);
 
 	negotiate_auth(&rbuf, tor_password);
-	onion = make_onion(ctx, &rbuf, laddr, use_v3_autotor);
+	onion = make_onion(ctx, &rbuf, laddr, use_v3_autotor, tor_serviceaddr->u.torservice.port);
 
 	/*on the other hand we can stay connected until ln finish to keep onion alive and then vanish */
 	//because when we run with Detach flag as we now do every start of LN creates a new addr while the old
@@ -261,5 +326,44 @@ struct wireaddr *tor_autoservice(const tal_t *ctx,
 	//FIXME: SAIBATO we might not want to close this conn
 	close(fd);
 
+	return onion;
+}
+
+struct wireaddr *tor_fixed_service(const tal_t *ctx,
+				 const struct wireaddr_internal *tor_serviceaddr,
+				 const char *tor_password,
+				 const u8 *blob,
+				 const struct wireaddr *bind,
+				 const u8 index)
+{
+	int fd;
+	const struct wireaddr *laddr;
+	struct wireaddr *onion;
+	struct addrinfo *ai_tor;
+	struct rbuf rbuf;
+	char *buffer;
+
+	laddr = bind;
+	ai_tor = wireaddr_to_addrinfo(tmpctx, &tor_serviceaddr->u.torservice.address);
+
+	fd = socket(ai_tor->ai_family, SOCK_STREAM, 0);
+	if (fd < 0)
+		err(1, "Creating stream socket for Tor");
+
+	if (connect(fd, ai_tor->ai_addr, ai_tor->ai_addrlen) != 0)
+		err(1, "Connecting stream socket to Tor service");
+
+	buffer = tal_arr(tmpctx, char, rbuf_good_size(fd));
+	rbuf_init(&rbuf, fd, buffer, tal_count(buffer), buf_resize);
+
+	negotiate_auth(&rbuf, tor_password);
+
+	onion = make_fixed_onion(ctx, &rbuf, laddr, blob, tor_serviceaddr->u.torservice.port);
+	/*on the other hand we can stay connected until ln finish to keep onion alive and then vanish
+	* because when we run with Detach flag as we now do every start of LN creates a new addr while the old
+	* stays valid until reboot this might not be desired so we can also drop Detach and use the
+	* read_partial to keep it open until LN drops
+	* DO NOT CLOSE FD TO KEEP ADDRESS ALIVE AS WE DO NOT DETACH WITH STATIC ADDRESS
+	*/
 	return onion;
 }

--- a/connectd/tor_autoservice.h
+++ b/connectd/tor_autoservice.h
@@ -7,9 +7,20 @@
 #include <stdlib.h>
 
 struct wireaddr *tor_autoservice(const tal_t *ctx,
-				 const struct wireaddr *tor_serviceaddr,
+				 const struct wireaddr_internal *tor_serviceaddr,
 				 const char *tor_password,
 				 const struct wireaddr_internal *bindings,
 				 const bool use_v3_autotor);
+
+struct wireaddr *tor_fixed_service(const tal_t *ctx,
+				 const struct wireaddr_internal *tor_serviceaddr,
+				 const char *tor_password,
+				 const u8 *blob,
+				 const struct wireaddr *bind,
+				 const u8 index);
+
+const struct wireaddr *
+find_local_address(const struct wireaddr_internal *bindings);
+
 
 #endif /* LIGHTNING_CONNECTD_TOR_AUTOSERVICE_H */

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -281,6 +281,7 @@ int main(int argc, char *argv[])
 		break;
 	case ADDR_INTERNAL_ALLPROTO:
 	case ADDR_INTERNAL_AUTOTOR:
+	case ADDR_INTERNAL_STATICTOR:
 	case ADDR_INTERNAL_FORPROXY:
 		opt_usage_exit_fail("Don't support proxy use");
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -337,7 +337,8 @@ precisely control where to bind and what to announce with the
 \fIautolisten\fR logic, so you must specifiy exactly what you want!
 
 
- \fBaddr\fR=\fI[IPADDRESS[:PORT]]|autotor:TORIPADDRESS[:TORPORT]\fR
+ \fBaddr\fR=\fI[IPADDRESS\[:PORT\]\]|autotor:TORIPADDRESS\[:SERVICEPORT\]\[/torport=TORPORT\]|statictor:TORIPADDRESS\[:SERVICEPORT\]\[/torport=TORPORT\]\[/torblob=\[blob\]\]\fR
+
 Set an IP address (v4 or v6) or automatic Tor address to listen on and
 (maybe) announce as our node address\.
 
@@ -355,6 +356,18 @@ IPv4 or IPv6 address of the Tor control port (default port 9051),
 and this will be used to configure a Tor hidden service for port
 9735.  The Tor hidden service will be configured to point to the
 first IPv4 or IPv6 address we bind to.
+
+If the argument begins with 'statictor:' then it is followed by the
+IPv4 or IPv6 address of the Tor control port (default port 9051),
+and this will be used to configure a static Tor hidden service for port
+9735.  The Tor hidden service will be configured to point to the
+first IPv4 or IPv6 address we bind to and is by default unique to
+your nodes id. You can add the text '/torblob=BLOB' followed by up to
+64 Bytes of text to generate from this text a v3 onion service
+address text unique to the first 32 Byte of this text.
+You can also use an postfix '/torport=TORPORT' to select the external
+tor binding. The result is that over tor your node is accessible by a port
+defined by you and possible different from your local node port assignment
 
 This option can be used multiple times to add more addresses, and
 its use disables autolisten.  If necessary, and 'always-use-proxy'

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -276,7 +276,8 @@ precisely control where to bind and what to announce with the
 *bind-addr* and *announce-addr* options. These will **disable** the
 *autolisten* logic, so you must specifiy exactly what you want!
 
- **addr**=*\[IPADDRESS\[:PORT\]\]|autotor:TORIPADDRESS\[:TORPORT\]*
+ **addr**=*\[IPADDRESS\[:PORT\]\]|autotor:TORIPADDRESS\[:SERVICEPORT\]\[/torport=TORPORT\]|statictor:TORIPADDRESS\[:SERVICEPORT\]\[/torport=TORPORT\]\[/torblob=\[blob\]\]*
+
 Set an IP address (v4 or v6) or automatic Tor address to listen on and
 (maybe) announce as our node address.
 
@@ -292,6 +293,18 @@ Set an IP address (v4 or v6) or automatic Tor address to listen on and
     and this will be used to configure a Tor hidden service for port
     9735.  The Tor hidden service will be configured to point to the
     first IPv4 or IPv6 address we bind to.
+
+    If the argument begins with 'statictor:' then it is followed by the
+    IPv4 or IPv6 address of the Tor control port (default port 9051),
+    and this will be used to configure a static Tor hidden service for port
+    9735.  The Tor hidden service will be configured to point to the
+    first IPv4 or IPv6 address we bind to and is by default unique to
+    your nodes id. You can add the text '/torblob=BLOB' followed by up to
+    64 Bytes of text to generate from this text a v3 onion service
+    address text unique to the first 32 Byte of this text.
+    You can also use an postfix '/torport=TORPORT' to select the external
+    tor binding. The result is that over tor your node is accessible by a port
+    defined by you and possible different from your local node port assignment
 
     This option can be used multiple times to add more addresses, and
     its use disables autolisten.  If necessary, and 'always-use-proxy'

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -17,6 +17,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/addr.o				\
 	common/amount.o				\
 	common/base32.o				\
+	common/base64.o				\
 	common/bech32.o				\
 	common/bech32_util.o			\
 	common/bigsize.o			\

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -249,7 +249,13 @@ void json_add_address_internal(struct json_stream *response,
 	case ADDR_INTERNAL_AUTOTOR:
 		json_object_start(response, fieldname);
 		json_add_string(response, "type", "Tor generated address");
-		json_add_address(response, "service", &addr->u.torservice);
+		json_add_address(response, "service", &addr->u.torservice.address);
+		json_object_end(response);
+		return;
+	case ADDR_INTERNAL_STATICTOR:
+		json_object_start(response, fieldname);
+		json_add_string(response, "type", "Tor from blob generated static address");
+		json_add_address(response, "service", &addr->u.torservice.address);
 		json_object_end(response);
 		return;
 	case ADDR_INTERNAL_FORPROXY:

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -68,7 +68,7 @@ struct config {
 	/* Minimal amount of effective funding_satoshis for accepting channels */
 	u64 min_capacity_sat;
 
-	/* Allow to define the default behavior of tot services calls*/
+	/* Allow to define the default behavior of tor services calls*/
 	bool use_v3_autotor;
 
 	/* This is the key we use to encrypt `hsm_secret`. */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -9,6 +9,7 @@
 #include <ccan/str/hex/hex.h>
 #include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
+#include <common/base64.h>
 #include <common/derive_basepoints.h>
 #include <common/features.h>
 #include <common/json_command.h>
@@ -134,6 +135,10 @@ static char *opt_add_announce_addr(const char *arg, struct lightningd *ld)
 
 	/* Check for autotor and reroute the call to --addr  */
 	if (strstarts(arg, "autotor:"))
+		return opt_add_addr(arg, ld);
+
+	/* Check for statictor and reroute the call to --addr  */
+	if (strstarts(arg, "statictor:"))
 		return opt_add_addr(arg, ld);
 
 	err = opt_add_addr_withtype(arg, ld, ADDR_ANNOUNCE, false);
@@ -598,6 +603,7 @@ static const struct config mainnet_config = {
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
 
+	/* Allow to define the default behavior of tor services calls*/
 	.use_v3_autotor = true,
 };
 


### PR DESCRIPTION
We now can generate a V3 tor service address from a blob 
 
 --addr=**statictor**:127.0.0.1:9051[/**torblob**=[blob]]

Or generate a unique static tor address bound to our node id /pub key     

 --addr=**statictor**:127.0.0.1:9051

TODO:

- [x] Documentation

- [x] Write some simple py-tests 

EDIT: With this you are able to keep your public known or group known tor address static
          and independent of torrc file or the tor instance ( if multiple ), in case you have to  
          move your node to an other PC or system/phone, as long as there is a tor service
          your node will be reachable even if ip, NAT, firewall have changed by that static V3 address.

EDIT: related issues #2476  #3085

EDIT_2:

With this PR we can now also select the extern tor port we assign our local port to 

 --addr=**statictor**:127.0.0.1:9051[/**torblob**=[blob]][/**torport**=EXTERNPORT]

Or generate a unique static tor address bound to our node id /pub key     

 --addr=**statictor**:127.0.0.1:9051[/**torport**=EXTERNPORT]
