### PR TITLE
Makefile: fix static linking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,10 @@ CONFIGURATOR_CC := $(CC)
 
 LDFLAGS += $(PIE_LDFLAGS) $(SANITIZER_FLAGS) $(COPTFLAGS)
 ifeq ($(STATIC),1)
-LDLIBS = -L/usr/local/lib -Wl,-lgmp -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
+# For MacOS, Jacob Rapoport <jacob@rumblemonkey.com> changed this to:
+#  -L/usr/local/lib -Wl,-lgmp -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
+# But that doesn't static link.
+LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp -lsqlite3 -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
 else
 LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
 endif

--- a/configure
+++ b/configure
@@ -145,7 +145,7 @@ usage()
     usage_with_default "--enable/disable-valgrind" "(autodetect)"
     echo "    Valgrind binary to use for tests"
     usage_with_default "--enable/disable-static" "$STATIC" "enable" "disable"
-    echo "    Static link binary"
+    echo "    Static link sqlite3, gmp and zlib libraries"
     usage_with_default "--enable/disable-address-sanitizer" "$ASAN" "enable" "disable"
     echo "    Compile with address-sanitizer"
     exit 1


### PR DESCRIPTION
And update --enable-static, since it doesn't actually create a static
binary since 65fa1c4f39418d1728cae09bd20e9c0c9476bbff.

This might break static building on MacOS, but that AFAICT is a secondary priority.

Closes: #3102 
@NicolasDorier does this actually fix it for you?