### PR TITLE
gossip seeker fixes

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1955,7 +1955,8 @@ bool handle_pending_cannouncement(struct daemon *daemon,
 
 static void update_pending(struct pending_cannouncement *pending,
 			   u32 timestamp, const u8 *update,
-			   const u8 direction)
+			   const u8 direction,
+			   struct peer *peer)
 {
 	SUPERVERBOSE("Deferring update for pending channel %s/%d",
 		     type_to_string(tmpctx, struct short_channel_id,
@@ -1968,6 +1969,9 @@ static void update_pending(struct pending_cannouncement *pending,
 		}
 		pending->updates[direction] = tal_dup_arr(pending, u8, update, tal_count(update), 0);
 		pending->update_timestamps[direction] = timestamp;
+		clear_softref(pending, &pending->update_peer_softref[direction]);
+		set_softref(pending, &pending->update_peer_softref[direction],
+			    peer);
 	}
 }
 
@@ -2312,7 +2316,7 @@ u8 *handle_channel_update(struct routing_state *rstate, const u8 *update TAKES,
 					    struct short_channel_id,
 					    &short_channel_id),
 			     direction);
-		update_pending(pending, timestamp, serialized, direction);
+		update_pending(pending, timestamp, serialized, direction, peer);
 		return NULL;
 	}
 

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -358,6 +358,7 @@ static struct short_channel_id *stale_scids_remove(const tal_t *ctx,
 		(*query_flags)[i] = *qf;
 		uintmap_del(&seeker->stale_scids, scid);
 		tal_free(qf);
+		i++;
 	}
 	tal_resize(&scids, i);
 	tal_resize(query_flags, i);

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -77,7 +77,7 @@ struct seeker {
 	bool unknown_nodes;
 
 	/* Peers we've asked to stream us gossip */
-	struct peer *gossiper_softref[3];
+	struct peer *gossiper_softref[5];
 
 	/* A peer that told us about unknown gossip. */
 	struct peer *preferred_peer_softref;


### PR DESCRIPTION
1. We were tending to give up on streaming gossip too soon when we have no gossip_store,
   since we didn't count channel_updates on new channels correctly.
2. Our node_announcement probe was a bit useless: make it sample randomly instead.
3. Choose 5, not 3, peers to stream us gossip in steady-state.  This is less aggressive until we
    have evidence that 3 is sufficient (if it is!), or we move to a more dynamic basis.