### PR TITLE
Fix peer_gossip_probe_nannounces compilation error on OSX 10.14.6

### DIFF
--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -563,7 +563,7 @@ static void peer_gossip_probe_nannounces(struct seeker *seeker)
 
 	peer = random_seeker(seeker, peer_can_take_scid_query);
 	set_state(seeker, PROBING_NANNOUNCES, peer,
-		  "Probing for %zu scids at offset %zu",
+		  "Probing for %zu scids at offset %llu",
 		  tal_count(seeker->nannounce_scids), seeker->nannounce_offset);
 	if (!peer)
 		return;


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/3162

I don't understand enough to know the implications of this change, but I do know that with it it builds on OSX 10.14.6 OK.



Signed-off-by: willcl-ark <will8clark@gmail.com>