### PR TITLE
Enable the user  to select the autotor extern onion port

### DIFF
--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -121,7 +121,10 @@ struct wireaddr_internal {
 		/* ADDR_INTERNAL_ALLPROTO */
 		u16 port;
 		/* ADDR_INTERNAL_AUTOTOR */
-		struct wireaddr torservice;
+		struct torservice {
+			struct wireaddr torservice_address;
+			u16 port;
+		} torservice;
 		/* ADDR_INTERNAL_FORPROXY */
 		struct unresolved {
 			char name[256];

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1102,7 +1102,7 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 			continue;
 		if (!(proposed_listen_announce[i] & ADDR_ANNOUNCE)) {
 				tor_autoservice(tmpctx,
-						&proposed_wireaddr[i].u.torservice,
+						&proposed_wireaddr[i],
 						tor_password,
 						binding,
 						daemon->use_v3_autotor);
@@ -1110,7 +1110,7 @@ static struct wireaddr_internal *setup_listeners(const tal_t *ctx,
 		};
 		add_announcable(announcable,
 				tor_autoservice(tmpctx,
-						&proposed_wireaddr[i].u.torservice,
+						&proposed_wireaddr[i],
 						tor_password,
 						binding,
 						daemon->use_v3_autotor));

--- a/connectd/tor_autoservice.h
+++ b/connectd/tor_autoservice.h
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 
 struct wireaddr *tor_autoservice(const tal_t *ctx,
-				 const struct wireaddr *tor_serviceaddr,
+				 const struct wireaddr_internal *tor_serviceaddr,
 				 const char *tor_password,
 				 const struct wireaddr_internal *bindings,
 				 const bool use_v3_autotor);

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -277,7 +277,7 @@ void json_add_address_internal(struct json_stream *response,
 	case ADDR_INTERNAL_AUTOTOR:
 		json_object_start(response, fieldname);
 		json_add_string(response, "type", "Tor generated address");
-		json_add_address(response, "service", &addr->u.torservice);
+		json_add_address(response, "service", &addr->u.torservice.torservice_address);
 		json_object_end(response);
 		return;
 	case ADDR_INTERNAL_FORPROXY:


### PR DESCRIPTION
Enable the local bound onion to reroute to an extern
custom port

EDIT:
in the form
 --addr=**autotor:**[TORSERVICEIP][:TORSEVICEPORT]**:torport:**[EXTERNPORT]]


Signed-off-by: Saibato <saibato.naga@pm.me>