### PR TITLE
hsm encryption fixups

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -398,6 +398,8 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	printf("Enter hsm_secret password : ");
 	if (getline(&passwd, &passwd_size, stdin) < 0)
 		return "Could not read password from stdin.";
+	if(passwd[strlen(passwd) - 1] == '\n')
+		passwd[strlen(passwd) - 1] = '\0';
 	if (tcsetattr(fileno(stdin), TCSAFLUSH, &current_term) != 0)
 		return "Could not restore terminal options.";
 	printf("\n");
@@ -416,7 +418,6 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	                  crypto_pwhash_ALG_ARGON2ID13) != 0)
 		return "Could not derive a key from the password.";
 	free(passwd);
-
 	return NULL;
 }
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -379,7 +379,7 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	struct termios current_term, temp_term;
 	char *passwd = NULL;
 	size_t passwd_size = 0;
-	u8 salt[11] = "c-lightning";
+	u8 salt[16] = "c-lightning\0\0\0\0\0";
 	ld->encrypted_hsm = true;
 
 	ld->config.keypass = tal(NULL, struct secret);


### PR DESCRIPTION
~~Noticed it while working on decryption with an `hsmtools` plugin.. This can be workarounded but since the encryption functionality was not merged long time ago and we haven't released yet, probably better to just correct it now.~~

Some `hsm_secret` encryption corrections : 
- don't take the newline character into account when deriving the encryption key
- correct the salt length (...)