### PR TITLE
gossipd: don't crash if we're forced to discard corrupt gossip store.

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -2978,6 +2978,9 @@ void remove_all_gossip(struct routing_state *rstate)
 	/* Now free all the channels. */
 	while ((c = uintmap_first(&rstate->chanmap, &index)) != NULL) {
 		uintmap_del(&rstate->chanmap, index);
+#if DEVELOPER
+		c->sat.satoshis = (u64)c; /* Raw: dev-hack */
+#endif
 		tal_free(c);
 	}
 


### PR DESCRIPTION
When we're in remove_all_gossip, we *don't* call free_chan, but free it
manually.  This trips over the developer-mode check that we called free_chan!
Make it also insert the magic so that destroy_chan_check passes:

lightning_gossipd: gossipd/routing.c:496: destroy_chan_check: Assertion `chan->sat.satoshis == (u64)chan' failed.
lightning_gossipd: FATAL SIGNAL 6 (version v0.7.3rc2-2-gf89d7c1)
0x5632436a4544 send_backtrace
	common/daemon.c:41
0x5632436a45ea crashdump
	common/daemon.c:54
0x7f053c3c7f5f ???
	???:0
0x7f053c3c7ed7 ???
	???:0
0x7f053c3a9534 ???
	???:0
0x7f053c3a940e ???
	???:0
0x7f053c3b9011 ???
	???:0
0x563243698b9d destroy_chan_check
	gossipd/routing.c:496
0x5632436dca46 notify
	ccan/ccan/tal/tal.c:235
0x5632436dcf35 del_tree
	ccan/ccan/tal/tal.c:397
0x5632436dd2c1 tal_free
	ccan/ccan/tal/tal.c:481
0x56324369f004 remove_all_gossip
	gossipd/routing.c:2981
0x563243692f5d gossip_store_load
	gossipd/gossip_store.c:772
0x56324368eff4 gossip_init
	gossipd/gossipd.c:872
0x563243690cbb recv_req
	gossipd/gossipd.c:1580
0x5632436a4a69 handle_read
	common/daemon_conn.c:31
0x5632436cc7ae next_plan
	ccan/ccan/io/io.c:59
0x5632436cd32b do_plan
	ccan/ccan/io/io.c:407
0x5632436cd369 io_ready
	ccan/ccan/io/io.c:417
0x5632436cf52f io_loop
	ccan/ccan/io/poll.c:445
0x56324369102f main
	gossipd/gossipd.c:1700

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>