### PR TITLE
hsmtools: a plugin for all things hsm_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ c-lightning is a lighweight, highly customizable and [standard compliant][std] i
 	* [Configuration File](#configuration-file)
 * [Further Information](#further-information)
     * [Pruning](#pruning)
+    * [HD wallet encryption](#hd-wallet-encryption)
 	* [Developers](#developers)
 
 ## Project Status
@@ -101,8 +102,6 @@ Useful commands:
 Once you've started for the first time, there's a script called
 `contrib/bootstrap-node.sh` which will connect you to other nodes on
 the lightning network.
-
-You can encrypt the BIP32 root seed (what is stored in `hsm_secret`) by passing the `--encrypted-hsm` startup argument. You can start `lightningd` with `--encrypted-hsm` on an already existing `lightning-dir` (with a not encrypted `hsm_secret`). If you pass that option, you __will not__ be able to start `lightningd` (with the same wallet) again without the password, so please beware with your password management. Also beware of not feeling too safe with an encrypted `hsm_secret`: unlike for `bitcoind` where the wallet encryption can restrict the usage of some RPC command, `lightningd` always need to access keys from the wallet which is thus __not locked__ (yet), even with an encrypted BIP32 master seed.
 
 There are also numerous plugins available for c-lightning which add
 capabilities: in particular there's a collection at:
@@ -201,6 +200,13 @@ The lightning daemon will poll `bitcoind` for new blocks that it hasn't processe
 If `bitcoind` prunes a block that c-lightning has not processed yet, e.g., c-lightning was not running for a prolonged period, then `bitcoind` will not be able to serve the missing blocks, hence c-lightning will not be able to synchronize anymore and will be stuck.
 In order to avoid this situation you should be monitoring the gap between c-lightning's blockheight using `lightning-cli getinfo` and `bitcoind`'s blockheight using `bitcoin-cli getblockchaininfo`.
 If the two blockheights drift apart it might be necessary to intervene.
+
+
+### HD wallet encryption
+
+You can encrypt the `hsm_secret` content (which is used to derive the HD wallet's master key) by passing the `--encrypted-hsm` startup argument, or by using the `encrypthsm` RPC call. You can unencrypt an encrypted `hsm_secret` using the `decrypthsm` RPC call.
+
+If you encrypt your `hsm_secret`, you will have to pass the `--encrypted-hsm` startup option to `lightningd`. Once your `hsm_secret` is encrypted, you __will not__ be able to access your funds without your password, so please beware with your password management. Also beware of not feeling too safe with an encrypted `hsm_secret`: unlike for `bitcoind` where the wallet encryption can restrict the usage of some RPC command, `lightningd` always need to access keys from the wallet which is thus __not locked__ (yet), even with an encrypted BIP32 master seed.
 
 ### Developers
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,9 +13,11 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-close.7 \
 	doc/lightning-connect.7 \
 	doc/lightning-decodepay.7 \
+	doc/lightning-decrypthsm.7 \
 	doc/lightning-delexpiredinvoice.7 \
 	doc/lightning-delinvoice.7 \
 	doc/lightning-disconnect.7 \
+	doc/lightning-encrypthsm.7 \
 	doc/lightning-fundchannel.7 \
 	doc/lightning-fundchannel_start.7 \
 	doc/lightning-fundchannel_complete.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,9 +36,11 @@ c-lightning Documentation
    lightning-close <lightning-close.7.md>
    lightning-connect <lightning-connect.7.md>
    lightning-decodepay <lightning-decodepay.7.md>
+   lightning-decrypthsm <lightning-decrypthsm.7.md>
    lightning-delexpiredinvoice <lightning-delexpiredinvoice.7.md>
    lightning-delinvoice <lightning-delinvoice.7.md>
    lightning-disconnect <lightning-disconnect.7.md>
+   lightning-encrypthsm <lightning-encrypthsm.7.md>
    lightning-fundchannel <lightning-fundchannel.7.md>
    lightning-fundchannel_cancel <lightning-fundchannel_cancel.7.md>
    lightning-fundchannel_complete <lightning-fundchannel_complete.7.md>

--- a/doc/lightning-decrypthsm.7
+++ b/doc/lightning-decrypthsm.7
@@ -1,0 +1,39 @@
+.TH "LIGHTNING-DECRYPTHSM" "7" "" "" "lightning-decrypthsm"
+.SH NAME
+lightning-encrypthsm - Decrypt your hsm_secret
+.SH SYNOPSIS
+
+\fBdecrypthsm\fR \fIpassword\fR
+
+.SH DESCRIPTION
+
+The \fBhsm_secret\fR file in your lightning-dir comports a seed from which is
+derived the HD wallet master key\. If you previously encrypted it using the
+\fB--encrypted-hsm\fR startup option or the \fBencrypthsm\fR RPC command, you can decrypt it
+by using the \fBdecrypthsm\fR RPC command with the same \fIpassword\fR used to encrypt it\.
+
+.SH RETURN VALUE
+
+An error can be returned in two main cases:
+
+.RS
+.IP \[bu]
+decryption failed, in which case the error description will give more details
+.IP \[bu]
+hsm_secret failure (either opening, creating, or writing), in which case the JSONRPC
+  error field will be populated with the errno\.
+
+.RE
+.SH AUTHOR
+
+Antoine Poinsot \fI<darosior@protonmail.com\fR>\.
+
+.SH SEE ALSO
+
+\fBlightning-encrypthsm\fR(7)
+\fBlightningd-config\fR(5)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-decrypthsm.7.md
+++ b/doc/lightning-decrypthsm.7.md
@@ -1,0 +1,39 @@
+lightning-encrypthsm -- Decrypt your hsm_secret
+===============================================
+
+SYNOPSIS
+--------
+
+**decrypthsm** *password*
+
+DESCRIPTION
+-----------
+
+The `hsm_secret` file in your lightning-dir comports a seed from which is
+derived the HD wallet master key. If you previously encrypted it using the
+`--encrypted-hsm` startup option or the `encrypthsm` RPC command, you can decrypt it
+by using the **decrypthsm** RPC command with the same *password* used to encrypt it.
+
+RETURN VALUE
+------------
+
+An error can be returned in two main cases:
+- decryption failed, in which case the error description will give more details
+- hsm_secret failure (either opening, creating, or writing), in which case the JSONRPC
+    error field will be populated with the errno.
+
+AUTHOR
+------
+
+Antoine Poinsot <<darosior@protonmail.com>>.
+
+SEE ALSO
+--------
+
+lightning-encrypthsm(7)
+lightningd-config(5)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-encrypthsm.7.md
+++ b/doc/lightning-encrypthsm.7.md
@@ -1,0 +1,51 @@
+lightning-encrypthsm -- Encrypt your hsm_secret
+===============================================
+
+SYNOPSIS
+--------
+
+**encrypthsm** *password*
+
+DESCRIPTION
+-----------
+
+The `hsm_secret` file in your lightning-dir comports a seed from which is
+derived the HD wallet master key.
+
+The **encrypthsm** command allows you to encrypt this seed with a provided *password*.
+
+Note however that the RPC connection is not encrypted and that your password will be
+transmitted in clear (in addition to being in your command history if you use the CLI).
+You can use the `--encrypted-hsm` startup option, which hide your password as you type
+it, as an alternative.
+
+Once your `hsm_secret` is encrypted, you will have to explicitly start `lightningd` with
+the `--encrypted-hsm` option.
+
+The algorithm used to derive the encryption key from the password is
+[Argon2id](https://github.com/p-h-c/phc-winner-argon2). The seed is then encrypted using
+[xChacha20Poly1305](https://tools.ietf.org/html/draft-arciszewski-xchacha-03).
+
+RETURN VALUE
+------------
+
+An error can be returned in two main cases:
+- encryption failed, in which case the error description will give more details
+- hsm_secret failure (either opening, creating, or writing), in which case the JSONRPC
+    error field will be populated with the errno.
+
+AUTHOR
+------
+
+Antoine Poinsot <<darosior@protonmail.com>>.
+
+SEE ALSO
+--------
+
+lightning-decrypthsm(7)
+lightningd-config(5)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -7,6 +7,9 @@ PLUGIN_AUTOCLEAN_OBJS := $(PLUGIN_AUTOCLEAN_SRC:.c=.o)
 PLUGIN_FUNDCHANNEL_SRC := plugins/fundchannel.c
 PLUGIN_FUNDCHANNEL_OBJS := $(PLUGIN_FUNDCHANNEL_SRC:.c=.o)
 
+PLUGIN_HSMTOOLS_SRC := plugins/hsmtools.c
+PLUGIN_HSMTOOLS_OBJS := $(PLUGIN_HSMTOOLS_SRC:.c=.o)
+
 PLUGIN_LIB_SRC := plugins/libplugin.c
 PLUGIN_LIB_HEADER := plugins/libplugin.h
 PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
@@ -47,17 +50,20 @@ plugins/autoclean: bitcoin/chainparams.o $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_LIB_O
 
 plugins/fundchannel: common/addr.o $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
-$(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
+plugins/hsmtools: bitcoin/chainparams.o bitcoin/privkey.o $(PLUGIN_HSMTOOLS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+
+$(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_HSMTOOLS_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
 
 # Make sure these depend on everything.
-ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel
-ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
+ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel plugins/hsmtools
+ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_HSMTOOLS_OBJS) $(PLUGIN_LIB_OBJS)
 
-check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%)
-check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%)
-check-whitespace: $(PLUGIN_PAY_SRC:%=check-whitespace/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-whitespace/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-whitespace/%)
+check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%) # $(PLUGIN_HSMTOOLS_SRC:%=check-src-include-order/%)
+check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%) # $(PLUGIN_HSMTOOLS_SRC:%bolt-check/%)
+check-whitespace: $(PLUGIN_PAY_SRC:%=check-whitespace/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-whitespace/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-whitespace/%) # $(PLUGIN_HSMTOOLS_SRC:%=check-whitespace/%)
+
 
 clean: plugin-clean
 
 plugin-clean:
-	$(RM) $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
+	$(RM) $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_HSMTOOLS_OBJS) $(PLUGIN_LIB_OBJS)

--- a/plugins/hsmtools.c
+++ b/plugins/hsmtools.c
@@ -1,0 +1,134 @@
+#include <bitcoin/privkey.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/noerr/noerr.h>
+#include <ccan/read_write_all/read_write_all.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <plugins/libplugin.h>
+#include <sodium.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+static void init(struct plugin_conn *rpc UNUSED,
+                 const char *buffer UNUSED,
+                 const jsmntok_t *config UNUSED)
+{
+	if (sodium_init() == -1)
+		plugin_err("Could not initialize libsodium.");
+	plugin_log(LOG_INFORM, "hsmtools initialized.");
+}
+
+static struct command_result *json_decrypt_hsm(struct command *cmd,
+                                               const char *buffer,
+                                               const jsmntok_t *params)
+{
+	int fd;
+	const char *passwd;
+	struct stat st;
+	struct secret key, hsm_secret;
+	u8 salt[16] = "c-lightning\0\0\0\0\0";
+	crypto_secretstream_xchacha20poly1305_state crypto_state;
+	u8 header[crypto_secretstream_xchacha20poly1305_HEADERBYTES];
+	/* The cipher size is static with xchacha20poly1305. */
+	u8 cipher[sizeof(struct secret) + crypto_secretstream_xchacha20poly1305_ABYTES];
+
+	if (!param(cmd, buffer, params,
+		   p_req("password", param_string, &passwd),
+		   NULL))
+		return command_param_failed();
+
+	/* We can use a relative path as libplugin chdir into lightning_dir
+	 * before calling us. */
+	if (stat("hsm_secret", &st) != 0)
+		return command_done_err(cmd, errno, "Could not stat hsm_secret", NULL);
+	if (st.st_size <= 32)
+		return command_done_err(cmd, errno, "hsm_secret is not encrypted", NULL);
+	fd = open("hsm_secret", O_RDONLY);
+	if (fd < 0)
+		return command_done_err(cmd, errno, "Could not open hsm_secret", NULL);
+
+	if (!read_all(fd, header, crypto_secretstream_xchacha20poly1305_HEADERBYTES))
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not read cipher header", NULL);
+	if (!read_all(fd, cipher, sizeof(cipher)))
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not read cipher body", NULL);
+
+	/* Derive the encryption key from the password provided, and try to decrypt
+	 * the cipher. */
+	if (crypto_pwhash(key.data, sizeof(key.data), passwd, strlen(passwd), salt,
+	                  crypto_pwhash_argon2id_OPSLIMIT_MODERATE,
+	                  crypto_pwhash_argon2id_MEMLIMIT_MODERATE,
+	                  crypto_pwhash_ALG_ARGON2ID13) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not derive a key from the password.", NULL);
+	if (crypto_secretstream_xchacha20poly1305_init_pull(&crypto_state, header,
+	                                                    key.data) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not initialize the crypto state", NULL);
+	if (crypto_secretstream_xchacha20poly1305_pull(&crypto_state, hsm_secret.data,
+	                                               NULL, 0, cipher, sizeof(cipher),
+	                                               NULL, 0) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not retrieve the seed. Wrong password ?", NULL);
+	close(fd);
+
+	/* Create a backup file, "just in case". */
+	rename("hsm_secret", "hsm_secret.backup");
+	fd = open("hsm_secret", O_CREAT|O_EXCL|O_WRONLY, 0400);
+	if (fd < 0)
+		return command_done_err(cmd, errno, "Could not open new hsm_secret", NULL);
+
+	if (!write_all(fd, &hsm_secret, sizeof(hsm_secret))) {
+		unlink_noerr("hsm_secret");
+		close(fd);
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Failure writing plaintext seed to hsm_secret.",
+		                        NULL);
+	}
+	/* Be as paranoïd as in hsmd with the file state on disk. */
+	if (fsync(fd) != 0) {
+		unlink_noerr("hsm_secret");
+		close(fd);
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Could not fsync hsm_secret.", NULL);
+	}
+	if (close(fd) != 0) {
+		unlink_noerr("hsm_secret");
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Could not close hsm_secret.", NULL);
+	}
+	fd = open(".", O_RDONLY);
+	if (fd < 0 || fsync(fd) != 0) {
+		unlink_noerr("hsm_secret");
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Could not make sure hsm_secret exists.", NULL);
+	}
+	close(fd);
+	unlink_noerr("hsm_secret.backup");
+
+	return command_success_str(cmd, "Succesfully decrypted hsm_secret, be "
+	                                "careful now.");
+}
+
+static const struct plugin_command commands[] = {
+	{
+		"decrypthsm",
+		"utility",
+		"Decrypt an encrypted hsm_secret.",
+		"Decrypt the seed used to derive the HD wallet master seed stored in"
+		" hsm_secret, previously encrypted using {password}.",
+		json_decrypt_hsm
+	}
+};
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands), NULL);
+}

--- a/plugins/hsmtools.c
+++ b/plugins/hsmtools.c
@@ -19,6 +19,27 @@ static void init(struct plugin_conn *rpc UNUSED,
 	plugin_log(LOG_INFORM, "hsmtools initialized.");
 }
 
+static bool ensure_hsm_secret_exists(int fd)
+{
+	if (fsync(fd) != 0) {
+		close(fd);
+		return false;
+	}
+	if (close(fd) != 0)
+		return false;
+
+	fd = open(".", O_RDONLY);
+	if (fd < 0)
+		return false;
+	if (fsync(fd) != 0) {
+		close(fd);
+		return false;
+	}
+
+	close(fd);
+	return true;
+}
+
 static struct command_result *json_decrypt_hsm(struct command *cmd,
                                                const char *buffer,
                                                const jsmntok_t *params)
@@ -88,32 +109,108 @@ static struct command_result *json_decrypt_hsm(struct command *cmd,
 		                        "Failure writing plaintext seed to hsm_secret.",
 		                        NULL);
 	}
+
 	/* Be as paranoïd as in hsmd with the file state on disk. */
-	if (fsync(fd) != 0) {
-		unlink_noerr("hsm_secret");
-		close(fd);
-		rename("hsm_secret.backup", "hsm_secret");
-		return command_done_err(cmd, errno,
-		                        "Could not fsync hsm_secret.", NULL);
-	}
-	if (close(fd) != 0) {
+	if (!ensure_hsm_secret_exists(fd)) {
 		unlink_noerr("hsm_secret");
 		rename("hsm_secret.backup", "hsm_secret");
 		return command_done_err(cmd, errno,
-		                        "Could not close hsm_secret.", NULL);
+		                        "Could not ensure hsm_secret existence.", NULL);
 	}
-	fd = open(".", O_RDONLY);
-	if (fd < 0 || fsync(fd) != 0) {
-		unlink_noerr("hsm_secret");
-		rename("hsm_secret.backup", "hsm_secret");
-		return command_done_err(cmd, errno,
-		                        "Could not make sure hsm_secret exists.", NULL);
-	}
-	close(fd);
 	unlink_noerr("hsm_secret.backup");
 
 	return command_success_str(cmd, "Succesfully decrypted hsm_secret, be "
 	                                "careful now.");
+}
+
+
+static struct command_result *json_encrypt_hsm(struct command *cmd,
+                                               const char *buffer,
+                                               const jsmntok_t *params)
+{
+	int fd;
+	const char *passwd;
+	struct stat st;
+	struct secret key, hsm_secret;
+	u8 salt[16] = "c-lightning\0\0\0\0\0";
+	crypto_secretstream_xchacha20poly1305_state crypto_state;
+	u8 header[crypto_secretstream_xchacha20poly1305_HEADERBYTES];
+	/* The cipher size is static with xchacha20poly1305. */
+	u8 cipher[sizeof(struct secret) + crypto_secretstream_xchacha20poly1305_ABYTES];
+
+	if (!param(cmd, buffer, params,
+		   p_req("password", param_string, &passwd),
+		   NULL))
+		return command_param_failed();
+
+	/* We can use a relative path as libplugin chdir into lightning_dir
+	 * before calling us. */
+	if (stat("hsm_secret", &st) != 0)
+		return command_done_err(cmd, errno, "Could not stat hsm_secret", NULL);
+	if (st.st_size > 32)
+		return command_done_err(cmd, errno, "hsm_secret is already encrypted", NULL);
+	fd = open("hsm_secret", O_RDONLY);
+	if (fd < 0)
+		return command_done_err(cmd, errno, "Could not open hsm_secret", NULL);
+	if (!read_all(fd, &hsm_secret, sizeof(hsm_secret)))
+		return command_done_err(cmd, errno, "Could not read hsm_secret", NULL);
+
+	/* Derive the encryption key from the password provided, and try to encrypt
+	 * the seed. */
+	if (crypto_pwhash(key.data, sizeof(key.data), passwd, strlen(passwd), salt,
+	                  crypto_pwhash_argon2id_OPSLIMIT_MODERATE,
+	                  crypto_pwhash_argon2id_MEMLIMIT_MODERATE,
+	                  crypto_pwhash_ALG_ARGON2ID13) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not derive a key from the password.", NULL);
+	if (crypto_secretstream_xchacha20poly1305_init_push(&crypto_state, header,
+	                                                    key.data) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not initialize the crypto state", NULL);
+	if (crypto_secretstream_xchacha20poly1305_push(&crypto_state, cipher,
+	                                               NULL, hsm_secret.data,
+	                                               sizeof(hsm_secret.data),
+	                                               NULL, 0, 0) != 0)
+		return command_done_err(cmd, PLUGIN_ERROR,
+		                        "Could not encrypt the seed.", NULL);
+
+	/* Create a backup file, "just in case". */
+	rename("hsm_secret", "hsm_secret.backup");
+	fd = open("hsm_secret", O_CREAT|O_EXCL|O_WRONLY, 0400);
+	if (fd < 0)
+		return command_done_err(cmd, errno,
+		                        "Could not open new hsm_secret", NULL);
+
+	/* Write the encrypted hsm_secret. */
+	if (!write_all(fd, header, sizeof(header))
+		|| !write_all(fd, cipher, sizeof(cipher))) {
+		unlink_noerr("hsm_secret");
+		close(fd);
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Failure writing cipher to hsm_secret.", NULL);
+	}
+	if (!write_all(fd, cipher, sizeof(cipher))) {
+		unlink_noerr("hsm_secret");
+		close(fd);
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Failure writing cipher to hsm_secret.", NULL);
+	}
+
+	/* Be as paranoïd as in hsmd with the file state on disk. */
+	if (!ensure_hsm_secret_exists(fd)) {
+		unlink_noerr("hsm_secret");
+		rename("hsm_secret.backup", "hsm_secret");
+		return command_done_err(cmd, errno,
+		                        "Could not ensure hsm_secret existence.", NULL);
+	}
+	unlink_noerr("hsm_secret.backup");
+
+	return command_success_str(cmd,
+	                           "Succesfully encrypted hsm_secret. You'll now "
+	                           "have to pass the --encrypted-hsm startup "
+	                           "option.");
 }
 
 static const struct plugin_command commands[] = {
@@ -124,6 +221,14 @@ static const struct plugin_command commands[] = {
 		"Decrypt the seed used to derive the HD wallet master seed stored in"
 		" hsm_secret, previously encrypted using {password}.",
 		json_decrypt_hsm
+	},
+	{
+		"encrypthsm",
+		"utility",
+		"Encrypt hsm_secret content.",
+		"Encrypt the seed used to derive the HD wallet master seed (what is stored in hsm_secret)"
+		" with {password}.",
+		json_encrypt_hsm
 	}
 };
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -567,7 +567,7 @@ def test_transaction_annotations(node_factory, bitcoind):
 
 
 @unittest.skipIf(VALGRIND, "It does not play well with prompt and key derivation.")
-def test_hsm_secret_encryption(node_factory, executor):
+def test_hsm_secret_encryption(node_factory):
     l1 = node_factory.get_node()
     password = "reckful\n"
     # We need to simulate a terminal to use termios in `lightningd`.
@@ -588,7 +588,6 @@ def test_hsm_secret_encryption(node_factory, executor):
     l1.daemon.start(stdin=slave_fd, stderr=subprocess.STDOUT,
                     wait_for_initialized=False)
     time.sleep(3 if SLOW_MACHINE else 1)
-    os.write(master_fd, password[2:].encode("utf-8"))
     err = "hsm_secret is encrypted, you need to pass the --encrypted-hsm startup option."
     assert l1.daemon.is_in_log(err)
 


### PR DESCRIPTION
This not really all things since I wanted to also move `signmessage` and `checkmessage` to the plugin, but then if the `hsm_secret` is encrypted the user would need to also pass its encryption password. What do you think ? (They can also be added later)

So this comports only two calls ATM : `decrypthsm` and `encrypthsm`. This also moves the encryption doc in the README to the "Further information" part.