### PR TITLE
db: Be a bit more pedantic about accessing null columns in the database

### DIFF
--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -97,9 +97,9 @@ struct command_result *param_utxos(struct command *cmd,
 							" 'txid:output_index'.");
 	if (tal_count(*utxos) == 0)
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-							"No matching utxo was found from the wallet."
+							"No matching utxo was found from the wallet. "
 							"You can get a list of the wallet utxos with"
-							" the `listfunds` RPC call.");
+							" the `listfunds` RPC call.");
 	return NULL;
 }
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -562,6 +562,7 @@ bool db_step(struct db_stmt *stmt)
 
 u64 db_column_u64(struct db_stmt *stmt, int col)
 {
+	assert(!db_column_is_null(stmt, col));
 	return stmt->db->config->column_u64_fn(stmt, col);
 }
 
@@ -575,11 +576,13 @@ int db_column_int_or_default(struct db_stmt *stmt, int col, int def)
 
 int db_column_int(struct db_stmt *stmt, int col)
 {
+	assert(!db_column_is_null(stmt, col));
 	return stmt->db->config->column_int_fn(stmt, col);
 }
 
 size_t db_column_bytes(struct db_stmt *stmt, int col)
 {
+	assert(!db_column_is_null(stmt, col));
 	return stmt->db->config->column_bytes_fn(stmt, col);
 }
 
@@ -590,11 +593,13 @@ int db_column_is_null(struct db_stmt *stmt, int col)
 
 const void *db_column_blob(struct db_stmt *stmt, int col)
 {
+	assert(!db_column_is_null(stmt, col));
 	return stmt->db->config->column_blob_fn(stmt, col);
 }
 
 const unsigned char *db_column_text(struct db_stmt *stmt, int col)
 {
+	assert(!db_column_is_null(stmt, col));
 	return stmt->db->config->column_text_fn(stmt, col);
 }
 
@@ -1136,11 +1141,13 @@ struct bitcoin_tx *db_column_tx(const tal_t *ctx, struct db_stmt *stmt, int col)
 void *db_column_arr_(const tal_t *ctx, struct db_stmt *stmt, int col,
 			  size_t bytes, const char *label, const char *caller)
 {
-	size_t sourcelen = db_column_bytes(stmt, col);
+	size_t sourcelen;
 	void *p;
 
 	if (db_column_is_null(stmt, col))
 		return NULL;
+
+	sourcelen = db_column_bytes(stmt, col);
 
 	if (sourcelen % bytes != 0)
 		db_fatal("%s: column size %zu not a multiple of %s (%zu)",

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -565,6 +565,14 @@ u64 db_column_u64(struct db_stmt *stmt, int col)
 	return stmt->db->config->column_u64_fn(stmt, col);
 }
 
+int db_column_int_or_default(struct db_stmt *stmt, int col, int def)
+{
+	if (db_column_is_null(stmt, col))
+		return def;
+	else
+		return db_column_int(stmt, col);
+}
+
 int db_column_int(struct db_stmt *stmt, int col)
 {
 	return stmt->db->config->column_int_fn(stmt, col);
@@ -1141,6 +1149,16 @@ void *db_column_arr_(const tal_t *ctx, struct db_stmt *stmt, int col,
 	p = tal_arr_label(ctx, char, sourcelen, label);
 	memcpy(p, db_column_blob(stmt, col), sourcelen);
 	return p;
+}
+
+void db_column_amount_msat_or_default(struct db_stmt *stmt, int col,
+				      struct amount_msat *msat,
+				      struct amount_msat def)
+{
+	if (db_column_is_null(stmt, col))
+		*msat = def;
+	else
+		msat->millisatoshis = db_column_u64(stmt, col); /* Raw: low level function */
 }
 
 void db_column_amount_msat(struct db_stmt *stmt, int col,

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -658,12 +658,12 @@ void db_commit_transaction(struct db *db)
 	bool ok;
 	assert(db->in_transaction);
 	db_assert_no_outstanding_statements(db);
+	db_report_changes(db, NULL, 0);
 	ok = db->config->commit_tx_fn(db);
 
 	if (!ok)
 		db_fatal("Failed to commit DB transaction: %s", db->error);
 
-	db_report_changes(db, NULL, 0);
 	db->in_transaction = NULL;
 }
 

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -159,6 +159,13 @@ struct bitcoin_tx *db_column_tx(const tal_t *ctx, struct db_stmt *stmt, int col)
 void *db_column_arr_(const tal_t *ctx, struct db_stmt *stmt, int col,
 		     size_t bytes, const char *label, const char *caller);
 
+
+/* Some useful default variants */
+int db_column_int_or_default(struct db_stmt *stmt, int col, int def);
+void db_column_amount_msat_or_default(struct db_stmt *stmt, int col,
+				      struct amount_msat *msat,
+				      struct amount_msat def);
+
 /**
  * db_exec_prepared -- Execute a prepared statement
  *

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1143,14 +1143,14 @@ void wallet_channel_stats_load(struct wallet *w,
 	/* This must succeed, since we know the channel exists */
 	assert(res);
 
-	stats->in_payments_offered = db_column_int(stmt, 0);
-	stats->in_payments_fulfilled = db_column_int(stmt, 1);
-	db_column_amount_msat(stmt, 2, &stats->in_msatoshi_offered);
-	db_column_amount_msat(stmt, 3, &stats->in_msatoshi_fulfilled);
-	stats->out_payments_offered = db_column_int(stmt, 4);
-	stats->out_payments_fulfilled = db_column_int(stmt, 5);
-	db_column_amount_msat(stmt, 6, &stats->out_msatoshi_offered);
-	db_column_amount_msat(stmt, 7, &stats->out_msatoshi_fulfilled);
+	stats->in_payments_offered = db_column_int_or_default(stmt, 0, 0);
+	stats->in_payments_fulfilled = db_column_int_or_default(stmt, 1, 0);
+	db_column_amount_msat_or_default(stmt, 2, &stats->in_msatoshi_offered, AMOUNT_MSAT(0));
+	db_column_amount_msat_or_default(stmt, 3, &stats->in_msatoshi_fulfilled, AMOUNT_MSAT(0));
+	stats->out_payments_offered = db_column_int_or_default(stmt, 4, 0);
+	stats->out_payments_fulfilled = db_column_int_or_default(stmt, 5, 0);
+	db_column_amount_msat_or_default(stmt, 6, &stats->out_msatoshi_offered, AMOUNT_MSAT(0));
+	db_column_amount_msat_or_default(stmt, 7, &stats->out_msatoshi_fulfilled, AMOUNT_MSAT(0));
 	tal_free(stmt);
 }
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1790,7 +1790,7 @@ static bool wallet_stmt2htlc_out(struct channel *channel,
 	       sizeof(out->onion_routing_packet));
 
 	out->failuremsg = db_column_arr(out, stmt, 8, u8);
-	out->failcode = db_column_int(stmt, 9);
+	out->failcode = db_column_int_or_default(stmt, 9, 0);
 
 	if (!db_column_is_null(stmt, 10)) {
 		out->origin_htlc_id = db_column_u64(stmt, 10);


### PR DESCRIPTION
As far as I know this could only be tickled when migrating a DB over from sqlite3, but better be safe than sorry. I added `_or_default` access functions for `int` and `amount_msat` and will add more as the need arises. Furthermore I added checks for null fields when accessing them, so we always have to explicitly say whether we are ok with a default value or not.

This also includes a drive-by fix of a test that was broken because it was making assumptions on the UTXO selection being used.

Fixes https://github.com/fiatjaf/mcldsp/issues/1