### PR TITLE
add gettext to build release script

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -35,6 +35,7 @@ RUN apt-get -qq update && \
 	shellcheck \
 	libxml2-utils \
 	wget \
+	gettext \
 	xsltproc \
 	zlib1g-dev && \
 	rm -rf /var/lib/apt/lists/*

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -23,6 +23,7 @@ RUN apt-get -qq update && \
 	libprotobuf-c-dev \
 	libsqlite3-dev \
 	libgmp-dev \
+	gettext \
 	git \
 	python \
 	python3 \


### PR DESCRIPTION
new dependency for this release means we need it for the release builds. I couldn't figure out how to add it for the fedora builds, but this seems to fix the breaks.