### PR TITLE
Revert "gossipd: query_messages: fail the connection if peer says it does not have up-to-date infos"

### DIFF
--- a/gossipd/queries.c
+++ b/gossipd/queries.c
@@ -682,10 +682,6 @@ const u8 *handle_reply_channel_range(struct peer *peer, const u8 *msg)
 
 	scids = decode_short_ids(tmpctx, encoded);
 	if (!scids) {
-		if (complete == 0)
-			return towire_errorfmt(peer, NULL,
-			                       "No up to date infos about this network: %s",
-			                       tal_hex(tmpctx, msg));
 		return towire_errorfmt(peer, NULL,
 				       "Bad reply_channel_range encoding %s",
 				       tal_hex(tmpctx, encoded));
@@ -815,11 +811,6 @@ const u8 *handle_reply_short_channel_ids_end(struct peer *peer, const u8 *msg)
 				       "unexpected reply_short_channel_ids_end: %s",
 				       tal_hex(tmpctx, msg));
 	}
-
-	if (complete == 0)
-		return towire_errorfmt(peer, NULL,
-		                       "No up to date infos about this network: %s",
-		                       tal_hex(tmpctx, msg));
 
 	peer->scid_query_outstanding = false;
 	if (peer->scid_query_cb)


### PR DESCRIPTION
This reverts commit 7fd2f6db6dd326cdbcfd96f052850b4638f5fc93.

We want to set 'complete' to false in future if we don't know
everything!