### PR TITLE
Make pedantic checks less fatal, fix an upgrade related null field access

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -186,6 +186,7 @@ def node_factory(request, directory, test_name, bitcoind, executor, db_provider,
     map_node_error(nf.nodes, checkBadGossip, "had bad gossip messages")
     map_node_error(nf.nodes, lambda n: n.daemon.is_in_log('Bad reestablish'), "had bad reestablish")
     map_node_error(nf.nodes, lambda n: n.daemon.is_in_log('bad hsm request'), "had bad hsm requests")
+    map_node_error(nf.nodes, lambda n: n.daemon.is_in_log(r'Accessing a null column'), "Accessing a null column")
     map_node_error(nf.nodes, checkMemleak, "had memleak messages")
 
     if not ok:

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -562,7 +562,10 @@ bool db_step(struct db_stmt *stmt)
 
 u64 db_column_u64(struct db_stmt *stmt, int col)
 {
-	assert(!db_column_is_null(stmt, col));
+	if (db_column_is_null(stmt, col)) {
+		log_broken(stmt->db->log, "Accessing a null column %d in query %s", col, stmt->query->query);
+		return 0;
+	}
 	return stmt->db->config->column_u64_fn(stmt, col);
 }
 
@@ -576,13 +579,19 @@ int db_column_int_or_default(struct db_stmt *stmt, int col, int def)
 
 int db_column_int(struct db_stmt *stmt, int col)
 {
-	assert(!db_column_is_null(stmt, col));
+	if (db_column_is_null(stmt, col)) {
+		log_broken(stmt->db->log, "Accessing a null column %d in query %s", col, stmt->query->query);
+		return 0;
+	}
 	return stmt->db->config->column_int_fn(stmt, col);
 }
 
 size_t db_column_bytes(struct db_stmt *stmt, int col)
 {
-	assert(!db_column_is_null(stmt, col));
+	if (db_column_is_null(stmt, col)) {
+		log_broken(stmt->db->log, "Accessing a null column %d in query %s", col, stmt->query->query);
+		return 0;
+	}
 	return stmt->db->config->column_bytes_fn(stmt, col);
 }
 
@@ -593,13 +602,19 @@ int db_column_is_null(struct db_stmt *stmt, int col)
 
 const void *db_column_blob(struct db_stmt *stmt, int col)
 {
-	assert(!db_column_is_null(stmt, col));
+	if (db_column_is_null(stmt, col)) {
+		log_broken(stmt->db->log, "Accessing a null column %d in query %s", col, stmt->query->query);
+		return NULL;
+	}
 	return stmt->db->config->column_blob_fn(stmt, col);
 }
 
 const unsigned char *db_column_text(struct db_stmt *stmt, int col)
 {
-	assert(!db_column_is_null(stmt, col));
+	if (db_column_is_null(stmt, col)) {
+		log_broken(stmt->db->log, "Accessing a null column %d in query %s", col, stmt->query->query);
+		return NULL;
+	}
 	return stmt->db->config->column_text_fn(stmt, col);
 }
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -477,6 +477,9 @@ static struct migration dbmigrations[] = {
 	 ");"), NULL},
     {SQL("ALTER TABLE channels ADD shutdown_scriptpubkey_local BLOB;"),
 	 NULL},
+    /* See https://github.com/ElementsProject/lightning/issues/3189 */
+    {SQL("UPDATE forwarded_payments SET received_time=0 WHERE received_time IS NULL;"),
+	 NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -772,7 +772,7 @@ static int db_get_version(struct db *db)
 /**
  * db_migrate - Apply all remaining migrations from the current version
  */
-static void db_migrate(struct lightningd *ld, struct db *db, struct log *log)
+static void db_migrate(struct lightningd *ld, struct db *db)
 {
 	/* Attempt to read the version from the database */
 	int current, orig, available;
@@ -784,12 +784,12 @@ static void db_migrate(struct lightningd *ld, struct db *db, struct log *log)
 	available = ARRAY_SIZE(dbmigrations) - 1;
 
 	if (current == -1)
-		log_info(log, "Creating database");
+		log_info(db->log, "Creating database");
 	else if (available < current)
 		db_fatal("Refusing to migrate down from version %u to %u",
 			 current, available);
 	else if (current != available)
-		log_info(log, "Updating database from version %u to %u",
+		log_info(db->log, "Updating database from version %u to %u",
 			 current, available);
 
 	while (current < available) {
@@ -826,7 +826,8 @@ static void db_migrate(struct lightningd *ld, struct db *db, struct log *log)
 struct db *db_setup(const tal_t *ctx, struct lightningd *ld, struct log *log)
 {
 	struct db *db = db_open(ctx, ld->wallet_dsn);
-	db_migrate(ld, db, log);
+	db->log = log;
+	db_migrate(ld, db);
 	return db;
 }
 

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -28,6 +28,8 @@ struct db {
 	/* List of statements that have been created but not executed yet. */
 	struct list_head pending_statements;
 	char *error;
+
+	struct log *log;
 };
 
 struct db_query {

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -69,7 +69,7 @@ static bool test_empty_db_migrate(struct lightningd *ld)
 	db_begin_transaction(db);
 	CHECK(db_get_version(db) == -1);
 	db_commit_transaction(db);
-	db_migrate(ld, db, NULL);
+	db_migrate(ld, db);
 	db_begin_transaction(db);
 	CHECK(db_get_version(db) == ARRAY_SIZE(dbmigrations) - 1);
 	db_commit_transaction(db);
@@ -113,7 +113,7 @@ static bool test_vars(struct lightningd *ld)
 	struct db *db = create_test_db();
 	char *varname = "testvar";
 	CHECK(db);
-	db_migrate(ld, db, NULL);
+	db_migrate(ld, db);
 
 	db_begin_transaction(db);
 	/* Check default behavior */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -772,7 +772,7 @@ static struct wallet *create_test_wallet(struct lightningd *ld, const tal_t *ctx
 				  w->bip32_base) == WALLY_OK);
 
 	CHECK_MSG(w->db, "Failed opening the db");
-	db_migrate(ld, w->db, w->log);
+	db_migrate(ld, w->db);
 	CHECK_MSG(!wallet_err, "DB migration failed");
 	w->max_channel_dbid = 0;
 


### PR DESCRIPTION
Reverts the `assert` into a warning that we can watch for in the tests and logs, so we can fix them as they come up and then re-arm the asserts once we're happy that we have caught all of them. On postgres we'll still catch them given the field length check,

We also fix an upgrade related null field (which was the real cause for #3189), where we'd have a null field if a payment was forwarded inbetween commits 66a47d2 (which started tracking forwardings) and d901304 (which added the received_time column). Since this is a rare thing, and we can't really just remove a compat check later, I opted to just set these cases to 0.

Fixes #3189