### PR TITLE
Fix build fail on 32bit OS.

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -493,7 +493,7 @@ static void remove_chan_from_node(struct routing_state *rstate,
 /* We make sure that free_chan is called on this chan! */
 static void destroy_chan_check(struct chan *chan)
 {
-	assert(chan->sat.satoshis == (u64)chan); /* Raw: dev-hack */
+	assert(chan->sat.satoshis == (unsigned long)chan); /* Raw: dev-hack */
 }
 #endif
 
@@ -507,7 +507,7 @@ void free_chan(struct routing_state *rstate, struct chan *chan)
 	uintmap_del(&rstate->chanmap, chan->scid.u64);
 
 #if DEVELOPER
-	chan->sat.satoshis = (u64)chan; /* Raw: dev-hack */
+	chan->sat.satoshis = (unsigned long)chan; /* Raw: dev-hack */
 #endif
 	tal_free(chan);
 }
@@ -2979,7 +2979,7 @@ void remove_all_gossip(struct routing_state *rstate)
 	while ((c = uintmap_first(&rstate->chanmap, &index)) != NULL) {
 		uintmap_del(&rstate->chanmap, index);
 #if DEVELOPER
-		c->sat.satoshis = (u64)c; /* Raw: dev-hack */
+		c->sat.satoshis = (unsigned long)c; /* Raw: dev-hack */
 #endif
 		tal_free(c);
 	}


### PR DESCRIPTION
Fix build error on 32bit linux:
```
gossipd/routing.c:496:31: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  assert(chan->sat.satoshis == (u64)chan); /* Raw: dev-hack */
                               ^
gossipd/routing.c:496:31: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  assert(chan->sat.satoshis == (u64)chan); /* Raw: dev-hack */
                               ^
gossipd/routing.c: In function ‘free_chan’:
gossipd/routing.c:510:23: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  chan->sat.satoshis = (u64)chan; /* Raw: dev-hack */
                       ^
gossipd/routing.c: In function ‘remove_all_gossip’:
gossipd/routing.c:2982:21: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   c->sat.satoshis = (u64)c; /* Raw: dev-hack */
```