### PR TITLE
json-rpc: show lightning-dir in getinfo

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1715,6 +1715,7 @@ static struct command_result *json_getinfo(struct command *cmd,
 				wallet_total_forward_fees(cmd->ld->wallet),
 				"msatoshi_fees_collected",
 				"fees_collected_msat");
+    json_add_string(response, "lightning-dir", cmd->ld->config_dir);
 
     if (!cmd->ld->topology->bitcoind->synced)
 	    json_add_string(response, "warning_bitcoind_sync",


### PR DESCRIPTION
Close #3208

i named it `lightning-dir` instead of `lightningd-dir`
or did you meant lightningd-dir where the executable is after compiling? @niftynei