### PR TITLE
wallet: always create signatures with low r-value

### DIFF
--- a/bitcoin/signature.h
+++ b/bitcoin/signature.h
@@ -47,7 +47,7 @@ struct bitcoin_signature {
 };
 
 /**
- * sign_hash - produce a raw secp256k1 signature.
+ * sign_hash - produce a raw secp256k1 signature (with low R value).
  * @p: secret key
  * @h: hash to sign.
  * @sig: signature to fill in and return.


### PR DESCRIPTION
Close #3210 
  * in contrast to Core I didnt include `bool grind` as a function argument. I can do that too if wanted - calling sign_hash() would require that arg everywhere, since C doesnt support default arguments.