### PR TITLE
pytest: fix flaky 'Bad gossip' errors

### DIFF
--- a/common/gossip_store.h
+++ b/common/gossip_store.h
@@ -18,6 +18,15 @@ struct per_peer_state;
 #define GOSSIP_STORE_LEN_DELETED_BIT 0x80000000U
 
 /**
+ * Bit of length we use to mark an important record.
+ */
+#define GOSSIP_STORE_LEN_PUSH_BIT 0x40000000U
+
+/* Mask for extracting just the length part of len field */
+#define GOSSIP_STORE_LEN_MASK \
+	(~(GOSSIP_STORE_LEN_PUSH_BIT | GOSSIP_STORE_LEN_DELETED_BIT))
+
+/**
  * gossip_hdr -- On-disk format header.
  */
 struct gossip_hdr {

--- a/devtools/dump-gossipstore.c
+++ b/devtools/dump-gossipstore.c
@@ -55,11 +55,12 @@ int main(int argc, char *argv[])
 		struct amount_sat sat;
 		u32 msglen = be32_to_cpu(hdr.len);
 		u8 *msg, *inner;
-		bool deleted;
+		bool deleted, push;
 
 		deleted = (msglen & GOSSIP_STORE_LEN_DELETED_BIT);
+		push = (msglen & GOSSIP_STORE_LEN_PUSH_BIT);
 
-		msglen &= ~GOSSIP_STORE_LEN_DELETED_BIT;
+		msglen &= GOSSIP_STORE_LEN_MASK;
 		msg = tal_arr(NULL, u8, msglen);
 		if (read(fd, msg, msglen) != msglen)
 			errx(1, "%zu: Truncated file?", off);
@@ -68,7 +69,9 @@ int main(int argc, char *argv[])
 		    != crc32c(be32_to_cpu(hdr.timestamp), msg, msglen))
 			warnx("Checksum verification failed");
 
-		printf("%zu: %s", off, deleted ? "DELETED " : "");
+		printf("%zu: %s%s", off,
+		       deleted ? "DELETED " : "",
+		       push ? "PUSH " : "");
 		if (deleted && !print_deleted) {
 			printf("\n");
 			goto end;

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -202,13 +202,12 @@ static void update_own_node_announcement(struct daemon *daemon)
 
 	/* This injects it into the routing code in routing.c; it should not
 	 * reject it! */
-	err = handle_node_announcement(daemon->rstate, nannounce,
+	err = handle_node_announcement(daemon->rstate, take(nannounce),
 				       NULL, NULL);
 	if (err)
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "rejected own node announcement: %s",
 			      tal_hex(tmpctx, err));
-	push_gossip(daemon, take(nannounce));
 }
 
 /* Should we announce our own node?  Called at strategic places. */
@@ -398,9 +397,6 @@ static void update_local_channel(struct local_cupdate *lc /* frees! */)
 			       * tmpctx, so it's actually OK. */
 			      tal_hex(tmpctx, update),
 			      tal_hex(tmpctx, msg));
-
-	if (is_chan_public(chan))
-		push_gossip(daemon, take(update));
 
 	tal_free(lc);
 }

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -35,9 +35,15 @@ u64 gossip_store_add_private_update(struct gossip_store *gs, const u8 *update);
 
 /**
  * Add a gossip message to the gossip_store (and optional addendum)
+ * @gs: gossip store
+ * @gossip_msg: the gossip message to insert.
+ * @timestamp: the timestamp for filtering of this messsage.
+ * @push: true if this should be sent to peers despite any timestamp filters.
+ * @addendum: another message to append immediately after this
+ *            (for appending amounts to channel_announcements for internal use).
  */
 u64 gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg,
-		     u32 timestamp, const u8 *addendum);
+		     u32 timestamp, bool push, const u8 *addendum);
 
 
 /**

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -402,21 +402,6 @@ static u8 *handle_node_announce(struct peer *peer, const u8 *msg)
 	return err;
 }
 
-/*~ Large peers often turn off gossip msgs (using timestamp_filter) from most
- * of their peers, however if the gossip is about us, we should spray it to
- * everyone whether they've set the filter or not, otherwise it might not
- * propagate! */
-void push_gossip(struct daemon *daemon, const u8 *msg TAKES)
-{
-	struct peer *peer;
-
-	if (taken(msg))
-		tal_steal(tmpctx, msg);
-
-	list_for_each(&daemon->peers, peer, list)
-		queue_peer_msg(peer, msg);
-}
-
 static bool handle_local_channel_announcement(struct daemon *daemon,
 					      struct peer *peer,
 					      const u8 *msg)
@@ -441,7 +426,6 @@ static bool handle_local_channel_announcement(struct daemon *daemon,
 		return false;
 	}
 
-	push_gossip(daemon, take(cannouncement));
 	return true;
 }
 

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -125,9 +125,6 @@ void peer_supplied_good_gossip(struct peer *peer, size_t amount);
 struct peer *random_peer(struct daemon *daemon,
 			 bool (*check_peer)(const struct peer *peer));
 
-/* Push this gossip out to all peers immediately. */
-void push_gossip(struct daemon *daemon, const u8 *msg TAKES);
-
 /* Queue a gossip message for the peer: the subdaemon on the other end simply
  * forwards it to the peer. */
 void queue_peer_msg(struct peer *peer, const u8 *msg TAKES);

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -485,6 +485,7 @@ static void remove_chan_from_node(struct routing_state *rstate,
 		node->bcast.index = gossip_store_add(rstate->gs,
 						     announce,
 						     node->bcast.timestamp,
+						     false,
 						     NULL);
 	}
 }
@@ -1562,6 +1563,7 @@ static void add_channel_announce_to_broadcast(struct routing_state *rstate,
 					      u32 index)
 {
 	u8 *addendum = towire_gossip_store_channel_amount(tmpctx, chan->sat);
+	bool is_local = is_local_channel(rstate, chan);
 
 	chan->bcast.timestamp = timestamp;
 	/* 0, unless we're loading from store */
@@ -1571,8 +1573,9 @@ static void add_channel_announce_to_broadcast(struct routing_state *rstate,
 		chan->bcast.index = gossip_store_add(rstate->gs,
 						     channel_announce,
 						     chan->bcast.timestamp,
+						     is_local,
 						     addendum);
-	rstate->local_channel_announced |= is_local_channel(rstate, chan);
+	rstate->local_channel_announced |= is_local;
 }
 
 bool routing_add_channel_announcement(struct routing_state *rstate,
@@ -2187,6 +2190,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 		hc->bcast.index
 			= gossip_store_add(rstate->gs, update,
 					   hc->bcast.timestamp,
+					   is_local_channel(rstate, chan),
 					   NULL);
 		if (hc->bcast.timestamp > rstate->last_timestamp
 		    && hc->bcast.timestamp < time_now().ts.tv_sec)
@@ -2528,7 +2532,10 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 	else {
 		node->bcast.index
 			= gossip_store_add(rstate->gs, msg,
-					   node->bcast.timestamp, NULL);
+					   node->bcast.timestamp,
+					   node_id_eq(&node_id,
+						      &rstate->local_id),
+					   NULL);
 		peer_supplied_good_gossip(peer, 1);
 	}
 	return true;
@@ -2919,7 +2926,7 @@ bool handle_local_add_channel(struct routing_state *rstate,
 	/* Create new (unannounced) channel */
 	chan = new_chan(rstate, &scid, &rstate->local_id, &remote_node_id, sat);
 	if (!index)
-		index = gossip_store_add(rstate->gs, msg, 0, NULL);
+		index = gossip_store_add(rstate->gs, msg, 0, false, NULL);
 	chan->bcast.index = index;
 	return true;
 }

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -75,9 +75,6 @@ void *notleak_(const void *ptr UNNEEDED, bool plus_children UNNEEDED)
 /* Generated stub for peer_supplied_good_gossip */
 void peer_supplied_good_gossip(struct peer *peer UNNEEDED, size_t amount UNNEEDED)
 { fprintf(stderr, "peer_supplied_good_gossip called!\n"); abort(); }
-/* Generated stub for push_gossip */
-void push_gossip(struct daemon *daemon UNNEEDED, const u8 *msg TAKES UNNEEDED)
-{ fprintf(stderr, "push_gossip called!\n"); abort(); }
 /* Generated stub for queue_peer_from_store */
 void queue_peer_from_store(struct peer *peer UNNEEDED,
 			   const struct broadcastable *bcast UNNEEDED)

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -16,7 +16,7 @@ bool fromwire_wireaddr(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct 
 { fprintf(stderr, "fromwire_wireaddr called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, const u8 *addendum UNNEEDED)
+		     u32 timestamp UNNEEDED, bool push UNNEEDED, const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */
 u64 gossip_store_add_private_update(struct gossip_store *gs UNNEEDED, const u8 *update UNNEEDED)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -79,6 +79,10 @@ def test_block_backfill(node_factory, bitcoind, chainparams):
     # Make sure we also have the needle we added to the haystack above
     assert(31337 in [r['satoshis'] for r in l3.db_query("SELECT satoshis FROM utxoset")])
 
+    # Make sure that l3 doesn't ask for more gossip and get a reply about
+    # the closed channel (hence Bad gossip msgs in log).
+    l3.daemon.wait_for_log('seeker: state = NORMAL')
+
     # Now close the channel and make sure `l3` cleans up correctly:
     txid = l1.rpc.close(l2.info['id'])['txid']
     bitcoind.generate_block(1, wait_for_mempool=txid)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -137,7 +137,7 @@ def test_announce_address(node_factory, bitcoind):
 def test_gossip_timestamp_filter(node_factory, bitcoind):
     # Updates get backdated 5 seconds with --dev-fast-gossip.
     backdate = 5
-    l1, l2, l3 = node_factory.line_graph(3, fundchannel=False)
+    l1, l2, l3, l4 = node_factory.line_graph(4, fundchannel=False)
 
     before_anything = int(time.time())
 
@@ -156,10 +156,10 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     l1.wait_for_channel_updates([chan23])
     after_23 = int(time.time())
 
-    # Make sure l1 has received all the gossip.
-    wait_for(lambda: ['alias' in node for node in l1.rpc.listnodes()['nodes']] == [True, True, True])
+    # Make sure l4 has received all the gossip.
+    wait_for(lambda: ['alias' in node for node in l4.rpc.listnodes()['nodes']] == [True, True, True])
 
-    msgs = l1.query_gossip('gossip_timestamp_filter',
+    msgs = l4.query_gossip('gossip_timestamp_filter',
                            '06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f',
                            '0', '0xFFFFFFFF',
                            filters=['0109'])
@@ -172,14 +172,14 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     assert types == Counter(['0100'] * 2 + ['0102'] * 4 + ['0101'] * 3)
 
     # Now timestamp which doesn't overlap (gives nothing).
-    msgs = l1.query_gossip('gossip_timestamp_filter',
+    msgs = l4.query_gossip('gossip_timestamp_filter',
                            '06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f',
                            '0', before_anything - backdate,
                            filters=['0109'])
     assert msgs == []
 
     # Now choose range which will only give first update.
-    msgs = l1.query_gossip('gossip_timestamp_filter',
+    msgs = l4.query_gossip('gossip_timestamp_filter',
                            '06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f',
                            before_anything - backdate,
                            after_12 - before_anything + 1,
@@ -193,7 +193,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     assert types['0102'] == 2
 
     # Now choose range which will only give second update.
-    msgs = l1.query_gossip('gossip_timestamp_filter',
+    msgs = l4.query_gossip('gossip_timestamp_filter',
                            '06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f',
                            after_12 - backdate,
                            after_23 - after_12 + 1,


### PR DESCRIPTION
One real test fix, and a rework of our slightly-broken "push this msg through despite timestamp_filter" option which was causing many more "Bad gossip" order messages.