### PR TITLE
TAGS: reformat to fix when PRINTF_FMT() used.

### DIFF
--- a/ccan/ccan/json_out/json_out.h
+++ b/ccan/ccan/json_out/json_out.h
@@ -87,11 +87,11 @@ bool json_out_end(struct json_out *jout, char type);
  * If the resulting string requires escaping, and @quote is true, we
  * call json_escape().
  */
-PRINTF_FMT(4,5)
 bool json_out_add(struct json_out *jout,
 		  const char *fieldname,
 		  bool quote,
-		  const char *fmt, ...);
+		  const char *fmt, ...)
+	PRINTF_FMT(4,5);
 
 /**
  * json_out_addv - add a formatted member (vararg variant)

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -558,13 +558,25 @@ struct io_plan *connection_out(struct io_conn *conn, struct connecting *connect)
 				   handshake_out_success, connect);
 }
 
-/*~ When we've exhausted all addresses without success, we come here. */
-static void PRINTF_FMT(5,6)
-	connect_failed(struct daemon *daemon,
-		       const struct node_id *id,
-		       u32 seconds_waited,
-		       const struct wireaddr_internal *addrhint,
-		       const char *errfmt, ...)
+/*~ When we've exhausted all addresses without success, we come here.
+ *
+ * Note that gcc gets upset if we put the PRINTF_FMT at the end like this if
+ * it's an actual function definition, but etags gets confused and ignores the
+ * rest of the file if we put PRINTF_FMT at the front.  So we put it at the
+ * end, in a gratuitous declaration.
+ */
+static void connect_failed(struct daemon *daemon,
+			   const struct node_id *id,
+			   u32 seconds_waited,
+			   const struct wireaddr_internal *addrhint,
+			   const char *errfmt, ...)
+	PRINTF_FMT(5,6);
+
+static void connect_failed(struct daemon *daemon,
+			   const struct node_id *id,
+			   u32 seconds_waited,
+			   const struct wireaddr_internal *addrhint,
+			   const char *errfmt, ...)
 {
 	u8 *msg;
 	va_list ap;

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -115,10 +115,14 @@ static bool selected_peer(struct seeker *seeker, struct peer *peer)
 #define set_state(seeker, state, peer, ...)				\
 	set_state_((seeker), (state), (peer), stringify(state), __VA_ARGS__)
 
-static void PRINTF_FMT(5,6)
-	set_state_(struct seeker *seeker, enum seeker_state state,
-		   struct peer *peer,
-		   const char *statename, const char *fmt, ...)
+static void set_state_(struct seeker *seeker, enum seeker_state state,
+		       struct peer *peer,
+		       const char *statename, const char *fmt, ...)
+PRINTF_FMT(5,6);
+
+static void set_state_(struct seeker *seeker, enum seeker_state state,
+		       struct peer *peer,
+		       const char *statename, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -142,11 +142,16 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c);
  * and closes the client connection.  This should never happen, of course, but
  * we definitely want to log if it does.
  */
-static PRINTF_FMT(4,5)
-	struct io_plan *bad_req_fmt(struct io_conn *conn,
-				    struct client *c,
-				    const u8 *msg_in,
-				    const char *fmt, ...)
+static struct io_plan *bad_req_fmt(struct io_conn *conn,
+				   struct client *c,
+				   const u8 *msg_in,
+				   const char *fmt, ...)
+	PRINTF_FMT(4,5);
+
+static struct io_plan *bad_req_fmt(struct io_conn *conn,
+				   struct client *c,
+				   const u8 *msg_in,
+				   const char *fmt, ...)
 {
 	va_list ap;
 	char *str;

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -183,11 +183,11 @@ const char *channel_state_str(enum channel_state state);
 void channel_set_owner(struct channel *channel, struct subd *owner);
 
 /* Channel has failed, but can try again. */
-PRINTF_FMT(2,3) void channel_fail_reconnect(struct channel *channel,
-					      const char *fmt, ...);
+void channel_fail_reconnect(struct channel *channel,
+			    const char *fmt, ...) PRINTF_FMT(2,3);
 /* Channel has failed, but can try again after a minute. */
-PRINTF_FMT(2,3) void channel_fail_reconnect_later(struct channel *channel,
-						  const char *fmt,...);
+void channel_fail_reconnect_later(struct channel *channel,
+				  const char *fmt,...) PRINTF_FMT(2,3);
 
 /* Channel has failed, give up on it. */
 void channel_fail_permanent(struct channel *channel, const char *fmt, ...);

--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -58,8 +58,10 @@ void connect_htlc_out(struct htlc_out_map *map, struct htlc_out *hend)
 	htlc_out_map_add(map, hend);
 }
 
-static void *PRINTF_FMT(2,3)
-	corrupt(const char *abortstr, const char *fmt, ...)
+static void *corrupt(const char *abortstr, const char *fmt, ...)
+	PRINTF_FMT(2,3);
+
+static void *corrupt(const char *abortstr, const char *fmt, ...)
 {
 	if (abortstr) {
 		char *p;

--- a/lightningd/json_stream.h
+++ b/lightningd/json_stream.h
@@ -90,11 +90,10 @@ void json_stream_append(struct json_stream *js, const char *str, size_t len);
  * The resulting string from @fmt is escaped if quote is true:
  * see json_member_direct to avoid quoting.
  */
-PRINTF_FMT(4,5)
 void json_add_member(struct json_stream *js,
 		     const char *fieldname,
 		     bool quote,
-		     const char *fmt, ...);
+		     const char *fmt, ...) PRINTF_FMT(4,5);
 
 /**
  * json_member_direct - start a generic member.

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -140,7 +140,7 @@ struct log_book *new_log_book(struct lightningd *ld, size_t max_mem,
 }
 
 /* With different entry points */
-struct log *PRINTF_FMT(3,4)
+struct log *
 new_log(const tal_t *ctx, struct log_book *record, const char *fmt, ...)
 {
 	struct log *log = tal(ctx, struct log);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -135,7 +135,7 @@ bool plugin_remove(struct plugins *plugins, const char *name)
 	return removed;
 }
 
-void PRINTF_FMT(2,3) plugin_kill(struct plugin *plugin, char *fmt, ...)
+void plugin_kill(struct plugin *plugin, char *fmt, ...)
 {
 	char *msg;
 	va_list ap;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -157,7 +157,7 @@ bool plugin_remove(struct plugins *plugins, const char *name);
 /**
  * Kill a plugin process, with an error message.
  */
-void PRINTF_FMT(2,3) plugin_kill(struct plugin *plugin, char *fmt, ...);
+void plugin_kill(struct plugin *plugin, char *fmt, ...) PRINTF_FMT(2,3);
 
 /**
  * Send the configure message to all plugins.

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -142,7 +142,7 @@ struct plugin_timer *plugin_timer(struct plugin_conn *rpc,
 				  struct command_result *(*cb)(void));
 
 /* Log something */
-void PRINTF_FMT(2, 3) plugin_log(enum log_level l, const char *fmt, ...);
+void plugin_log(enum log_level l, const char *fmt, ...) PRINTF_FMT(2, 3);
 
 /* Macro to define arguments */
 #define plugin_option(name, type, description, set, arg)			\


### PR DESCRIPTION
I was wondering why TAGS was missing some functions, and finally
tracked it down: PRINTF_FMT() confuses etags if it's at the start
of a function, and it ignores the rest of the file.

So we put PRINTF_FMT at the end, but that doesn't work for
*definitions*, only *declarations*.  So we remove it from definitions
and add gratuitous declarations in the few static places.1

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>