### PR TITLE
change psycopg2 to psycopg2-binary

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ pytest-xdist==1.29.0
 python-bitcoinlib==0.10.1
 tqdm==4.32.2
 pytest-timeout==1.3.3
-psycopg2==2.8.3
+psycopg2-binary==2.8.3


### PR DESCRIPTION
psycopg2 need libpq-dev and python-dev, psycopg2-binary not requiring a compiler or external libraries