### PR TITLE
dev: add option flag for specifying temporary channel id

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -126,6 +126,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_force_bip32_seed = NULL;
 	ld->dev_force_channel_secrets = NULL;
 	ld->dev_force_channel_secrets_shaseed = NULL;
+	ld->dev_force_tmp_channel_id = NULL;
 #endif
 
 	/*~ These are CCAN lists: an embedded double-linked list.  It's not

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -223,6 +223,8 @@ struct lightningd {
 	/* These are the forced channel secrets for the node. */
 	struct secrets *dev_force_channel_secrets;
 	struct sha256 *dev_force_channel_secrets_shaseed;
+
+	struct channel_id *dev_force_tmp_channel_id;
 #endif /* DEVELOPER */
 
 	/* tor support */

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -965,6 +965,7 @@ void peer_start_openingd(struct peer *peer,
 				  feature_negotiated(peer->features,
 						     OPT_STATIC_REMOTEKEY),
 				  send_msg,
+				  IFDEV(peer->ld->dev_force_tmp_channel_id, NULL),
 				  IFDEV(peer->ld->dev_fast_gossip, false));
 	subd_send_msg(uc->openingd, take(msg));
 }

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -449,6 +449,17 @@ static char *opt_force_bip32_seed(const char *optarg, struct lightningd *ld)
 	return NULL;
 }
 
+static char *opt_force_tmp_channel_id(const char *optarg, struct lightningd *ld)
+{
+	tal_free(ld->dev_force_tmp_channel_id);
+	ld->dev_force_tmp_channel_id = tal(ld, struct channel_id);
+	if (!hex_decode(optarg, strlen(optarg),
+			ld->dev_force_tmp_channel_id,
+			sizeof(*ld->dev_force_tmp_channel_id)))
+		return tal_fmt(NULL, "Unable to parse channel id '%s'", optarg);
+	return NULL;
+}
+
 static char *opt_force_channel_secrets(const char *optarg,
 				       struct lightningd *ld)
 {
@@ -535,6 +546,8 @@ static void dev_register_opts(struct lightningd *ld)
 			 "Maximum number of blocks we wait for a channel "
 			 "funding transaction to confirm, if we are the "
 			 "fundee.");
+	opt_register_arg("--dev-force-tmp-channel-id", opt_force_tmp_channel_id, NULL, ld,
+			 "Force the temporary channel id, instead of random");
 }
 #endif /* DEVELOPER */
 

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -24,6 +24,7 @@ msgdata,opening_init,option_static_remotekey,bool,
 # Optional msg to send.
 msgdata,opening_init,len,u16,
 msgdata,opening_init,msg,u8,len
+msgdata,opening_init,dev_temporary_channel_id,?byte,32
 msgdata,opening_init,dev_fast_gossip,bool,
 
 # Openingd->master: they offered channel, should we continue?


### PR DESCRIPTION
--dev-force-tmp-channel-id flag takes a 64-character hex string
to use as the temporary channel id. Useful for spec tests where we want
to test the 'opener's side of things.