### PR TITLE
Fix python 3.4 syntax error in sql-rewrite.py

### DIFF
--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -12,7 +12,7 @@ DEBUG = False
 def eprint(*args, **kwargs):
     if not DEBUG:
         return
-    print(*args, **kwargs, file=sys.stderr)
+    print(*args, file=sys.stderr, **kwargs)
 
 
 class Rewriter(object):


### PR DESCRIPTION
On python 3.4.2 having kwargs after unpacking a dict in a function call seems to be a syntax error. I know it's an old python version but if it doesn't break anything else it might be worth changing.

![2019-11-02-125824_5760x1080_scrot](https://user-images.githubusercontent.com/1876998/68070581-b36de900-fd70-11e9-9ae5-008c5ad1836c.png)
