### PR TITLE
config file: fix line count in error message

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -747,7 +747,7 @@ static void opt_parse_from_config(struct lightningd *ld, bool early)
 		return;
 	}
 
-	lines = tal_strsplit(contents, contents, "\r\n", STR_NO_EMPTY);
+	lines = tal_strsplit(contents, contents, "\r\n", STR_EMPTY_OK);
 
 	/* We have to keep all_args around, since opt will point into it */
 	all_args = notleak(tal_arr(ld, char *, tal_count(lines) - 1));


### PR DESCRIPTION
## Abstract

The current master throws a false line number

```
gorazd@gorazd-MS-7C37:~/Projects/lightning$ ./lightningd/lightningd
lightning config file line 3: line6: unrecognized option
```
for the following config file
```

network=regtest

log-level=info

line6
```

It should be:
```
gorazd@gorazd-MS-7C37:~/Projects/lightning$ ./lightningd/lightningd
lightning config file line 6: line6: unrecognized option
```

## Other

Changelog-None