### PR TITLE
display a warning if the user use --proxy and hidden service and not …

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -606,3 +606,30 @@ bool all_tor_addresses(const struct wireaddr_internal *wireaddr)
 	}
 	return true;
 }
+
+bool some_tor_addresses(const struct wireaddr_internal *wireaddr)
+{
+	for (int i = 0; i < tal_count(wireaddr); i++) {
+		switch (wireaddr[i].itype) {
+		case ADDR_INTERNAL_SOCKNAME:
+			continue;
+		case ADDR_INTERNAL_FORPROXY:
+			continue;
+		case ADDR_INTERNAL_ALLPROTO:
+			continue;
+		case ADDR_INTERNAL_AUTOTOR:
+			return true;
+		case ADDR_INTERNAL_WIREADDR:
+			switch (wireaddr[i].u.wireaddr.type) {
+			case ADDR_TYPE_IPV4:
+			case ADDR_TYPE_IPV6:
+				continue;
+			case ADDR_TYPE_TOR_V2:
+			case ADDR_TYPE_TOR_V3:
+				return true;
+			}
+		}
+		abort();
+	}
+	return false;
+}

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -157,4 +157,6 @@ struct addrinfo *wireaddr_internal_to_addrinfo(const tal_t *ctx,
 
 bool all_tor_addresses(const struct wireaddr_internal *wireaddr);
 
+bool some_tor_addresses(const struct wireaddr_internal *wireaddr);
+
 #endif /* LIGHTNING_COMMON_WIREADDR_H */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -672,6 +672,16 @@ static void check_config(struct lightningd *ld)
 
 	if (ld->use_proxy_always && !ld->proxyaddr)
 		fatal("--always-use-proxy needs --proxy");
+
+	if (ld->proxyaddr && (!ld->use_proxy_always || ld->config.use_dns)) {
+		if (tal_count(ld->proposed_wireaddr) != 0 && some_tor_addresses(ld->proposed_wireaddr)) {
+			log_unusual(ld->log, "WARNING: Your Tor setup use a hidden service address."
+						" --always-use-proxy=%s and --disable-dns %s"
+						" is not recommended, please set --always-use-proxy=true and use --disable-dns, we hope you know what you are doing!"
+						" c-lightning try to help you and detected that you have configured a possible dns leak of your"
+						" hidden service",ld->use_proxy_always?"true":"false", ld->config.use_dns?"not set":"set");
+		}
+	}
 }
 
 static void setup_default_config(struct lightningd *ld)


### PR DESCRIPTION
…disables dns

As @bitcoin-software reported the default behavior is in UX therms
not what the users expects if --proxy is configured.  Users tent to associate
with the term proxy, that all traffic is routed trough the proxy.

We should warn the user also in the logs and on startup, if he not selects also --use-always-proxy=true
and --disable-dns, when having defined and used also a hidden service.

The default behavior is that ipv4/6 FQDN will be resolved locally,
since we use tor socks5 proxy for onion address with the socks4a improvement,
the user could and should let Tor do the dns.

Changelog-Changed: Warn the users that he had configed a possible tor dns/ip leak
