### PR TITLE
We state not to do 'any local DNS' if --always-use-proxy flag is set,…

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -200,8 +200,8 @@ static bool broken_resolver(struct daemon *daemon)
 	const char *hostname = "nxdomain-test.doesntexist";
 	int err;
 
-	/* If they told us to never do DNS queries, don't even do this one */
-	if (!daemon->use_dns) {
+	/* If they told us to never do DNS queries, don't even do this one and also not if we just say that we don't */
+	if (!daemon->use_dns || daemon->use_proxy_always) {
 		daemon->broken_resolver_response = NULL;
 		return false;
 	}


### PR DESCRIPTION
… so we should do this

Even if it is on startup only once ...
Like @bitcoin-software indicated the expected UX should be in
line with what a user expects the software will do
so we should not dns if we say so with a flag that suggest that.

Signed-off-by: Saibato <saibato.naga@pm.me>