### PR TITLE
pytest: fix `make pytest`

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -10,7 +10,7 @@ export SOURCE_CHECK_ONLY=${SOURCE_CHECK_ONLY:-"false"}
 export COMPAT=${COMPAT:-1}
 export PATH=$CWD/dependencies/bin:"$HOME"/.local/bin:"$PATH"
 export PYTEST_PAR=2
-export PYTHONPATH=$PWD/contrib/pylightning:$PYTHONPATH
+
 # If we're not in developer mode, tests spend a lot of time waiting for gossip!
 # But if we're under valgrind, we can run out of memory!
 if [ "$DEVELOPER" = 0 ] && [ "$VALGRIND" = 0 ]; then

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ ifeq ($(PYTEST),)
 	exit 1
 else
 # Explicitly hand DEVELOPER and VALGRIND so you can override on make cmd line.
-	PYTHONPATH=`pwd`/contrib/pyln-client:`pwd`/contrib/pyln-testing:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
+	PYTHONPATH=`pwd`/contrib/pyln-client:`pwd`/contrib/pyln-testing:`pwd`/contrib/pylightning:$$PYTHONPATH TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.


### PR DESCRIPTION
Travis adds the correct PYTHONPATH, but "make check" doesn't.

Changelog-None