### PR TITLE
dev: add option to prevent HTLC timeouts.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -127,6 +127,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_force_channel_secrets = NULL;
 	ld->dev_force_channel_secrets_shaseed = NULL;
 	ld->dev_force_tmp_channel_id = NULL;
+	ld->dev_no_htlc_timeout = false;
 #endif
 
 	/*~ These are CCAN lists: an embedded double-linked list.  It's not

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -225,6 +225,10 @@ struct lightningd {
 	struct sha256 *dev_force_channel_secrets_shaseed;
 
 	struct channel_id *dev_force_tmp_channel_id;
+
+	/* For slow tests (eg protocol tests) don't die if HTLC not
+	 * committed in 30 secs */
+	bool dev_no_htlc_timeout;
 #endif /* DEVELOPER */
 
 	/* tor support */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -548,6 +548,9 @@ static void dev_register_opts(struct lightningd *ld)
 			 "fundee.");
 	opt_register_arg("--dev-force-tmp-channel-id", opt_force_tmp_channel_id, NULL, ld,
 			 "Force the temporary channel id, instead of random");
+	opt_register_noarg("--dev-no-htlc-timeout", opt_set_bool,
+			   &ld->dev_no_htlc_timeout,
+			   "Don't kill channeld if HTLCs not confirmed within 30 seconds");
 }
 #endif /* DEVELOPER */
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -463,7 +463,7 @@ enum onion_type send_htlc_out(struct channel *out,
 	tal_add_destructor(hout, destroy_hout_subd_died);
 
 	/* Give channel 30 seconds to commit (first) htlc. */
-	if (!out->htlc_timeout)
+	if (!out->htlc_timeout && !IFDEV(out->peer->ld->dev_no_htlc_timeout, 0))
 		out->htlc_timeout = new_reltimer(out->peer->ld->timers,
 						 out, time_from_sec(30),
 						 htlc_offer_timeout,


### PR DESCRIPTION
This is required for the protocol tests, which can be slow.

Changelog-None