### PR TITLE
plugin: Pass the full raw_payload including realm to htlc_accepted

### DIFF
--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -580,7 +580,7 @@ static void sphinx_parse_payload(struct route_step *step, const u8 *src)
 	}
 
 	/* Copy common pieces over */
-	step->raw_payload = tal_dup_arr(step, u8, src + vsize, raw_size, 0);
+	step->raw_payload = tal_dup_arr(step, u8, src, raw_size + vsize, 0);
 	memcpy(step->next->mac, src + hop_size - HMAC_SIZE, HMAC_SIZE);
 
 	/* And now try to parse whatever the payload contains so we can use it
@@ -737,9 +737,6 @@ struct route_step *process_onionpacket(
 		if (shift_size >= ROUTING_INFO_SIZE)
 			return tal_free(step);
 	}
-
-	step->raw_payload = tal_dup_arr(step, u8, paddedheader + 1,
-					shift_size - 1 - HMAC_SIZE, 0);
 
 	/* Copy the hmac from the last HMAC_SIZE bytes */
         memcpy(&step->next->mac, paddedheader + shift_size - HMAC_SIZE, HMAC_SIZE);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -539,8 +539,8 @@ def test_htlc_accepted_hook_forward_restart(node_factory, executor):
         assert re.match(r'^020203e80401..0608................$', onion['payload'])
     else:
         assert onion['type'] == 'legacy'
-        assert re.match(r'^00006700000.000100000000000003e8000000..000000000000000000000000$', onion['payload'])
-        assert len(onion['payload']) == 64
+        assert re.match(r'^0000006700000.000100000000000003e8000000..000000000000000000000000$', onion['payload'])
+        assert len(onion['payload']) == 66
     assert len(onion['shared_secret']) == 64
     assert onion['forward_amount'] == '1000msat'
     assert len(onion['next_onion']) == 2 * (1300 + 32 + 33 + 1)


### PR DESCRIPTION
So far we've only handled legacy payloads, which meant we could drop the realm
byte since it was always 0x00. Once we start handling TLV payloads the first
byte, i.e., the former realm byte, is important since it gives us the length
of the payload. This is a breaking change, however I don't think there's
anyone using the `raw_payload` as of yet.

Changelog-Changed: JSON-RPC: the `raw_payload` now includes the first byte, i.e., the realm byte, of the payload as well. This allows correct decoding of a TLV payload in the plugins.