### PR TITLE
lightningd: fix uninitialized variable

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -213,6 +213,10 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->tor_service_password = NULL;
 	ld->max_funding_unconfirmed = 2016;
 
+	/*~ This is initialized later, but the plugin loop examines this,
+	 * so set it to NULL explicitly now. */
+	ld->wallet = NULL;
+
 	/*~ In the next step we will initialize the plugins. This will
 	 *  also populate the JSON-RPC with passthrough methods, hence
 	 *  lightningd needs to have something to put those in. This


### PR DESCRIPTION
==1310== Conditional jump or move depends on uninitialised value(s)
==1310==    at 0x127C7F: io_loop_with_timers (io_loop_with_timers.c:30)
==1310==    by 0x14F0E1: plugins_init (plugin.c:1019)
==1310==    by 0x12E4B1: main (lightningd.c:694)
==1310==

Changelog-None