### PR TITLE
fix: listtx set txindex only if blockheight is known

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3461,16 +3461,18 @@ struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t
 			cur->tx = db_column_tx(txs, stmt, 1);
 			cur->rawtx = tal_dup_arr(txs, u8, db_column_blob(stmt, 1),
 						 db_column_bytes(stmt, 1), 0);
-            /* TX may be unconfirmed. */
-            if (!db_column_is_null(stmt, 2) || !db_column_is_null(stmt, 3)) {
-                /* assert incomplete information */
-                assert(!db_column_is_null(stmt, 2) && !db_column_is_null(stmt, 3));
-                cur->blockheight = db_column_int(stmt, 2);
-                cur->txindex = db_column_int(stmt, 3);
-            } else {
-                cur->blockheight = 0;
-                cur->txindex = 0;
-            }
+			/* TX may be unconfirmed. */
+			if (!db_column_is_null(stmt, 2)) {
+				cur->blockheight = db_column_int(stmt, 2);
+				if (!db_column_is_null(stmt, 3)) {
+					cur->txindex = db_column_int(stmt, 3);
+				} else {
+					cur->txindex = 0;
+				}
+			} else {
+				cur->blockheight = 0;
+				cur->txindex = 0;
+			}
 			if (!db_column_is_null(stmt, 4))
 				cur->annotation.type = db_column_u64(stmt, 4);
 			else


### PR DESCRIPTION
This will patch the `listtransactions` command in a way that the hard assert regarding `txindex` and blockheight is removed (https://github.com/ElementsProject/lightning/issues/3265). We will now set the `txindex` only if a blockheight is known.

**Also:** I do not believe the missing blockheights are reorg artifacts for two reasons:
- The `txindex` we have in the DB are the correct onchain `txindex` when looking up the proper block. Incase of a reorg artifact they are expected to be different, as they would have been replaced by a block with different index. If this is still reorg related, the reorg code does not write the correct blockheight BUT the txindex into the DB, which would be bad.
- they are too many to be a coincident., in my case 4 transactions on two nodes: mainnet and testnet.

We might investigate this further. SQL command to check this:
```
> sqlite3 ~/.lightning/lightningd.sqlite3

SELECT  HEX(t.id), t.blockheight, t.txindex FROM transactions t WHERE t.txindex > 0 and t.blockheight IS NULL;

(my mainnet node)
CB785ABCC3971F94607A270009D161460D1D63C8E915CFEC933320DF37ED372F||1663
5E35A558D3061E6EC6D91A89346639DEDAAA704281A4F7B597D63EB6591307B8||855
```


**Note:** Additionally, I replaced the TABs with BLANKs in this block that got messed up last time, sorry I used a new IDE.

---------------------

Alternatively we could set the `blockheight` and `txindex` only if both are known, since having a `blockheight` without `txindex` is also not very meaningful:

```C
               if (!db_column_is_null(stmt, 2) && !db_column_is_null(stmt, 3)) {
                       cur->blockheight = db_column_int(stmt, 2);
                       cur->txindex = db_column_int(stmt, 3);
               } else {
                       cur->blockheight = 0;
                       cur->txindex = 0;
               }
```

Changelog-None