### PR TITLE
openchannel hook: add new `close_to` field

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -577,6 +577,21 @@ the string `reject` or `continue`.  If `reject` and
 there's a member `error_message`, that member is sent to the peer
 before disconnection.
 
+For a 'continue'd result, you can also include a `close_to` address,
+which will be used as the output address for a mutual close transaction.
+
+e.g.
+
+```json
+{
+    "result": "continue",
+    "close_to": "bc1qlq8srqnz64wgklmqvurv7qnr4rvtq2u96hhfg2"
+}
+```
+
+Note that `close_to` must be a valid address for the current chain; an invalid address will cause the node to exit with an error.
+
+
 #### `htlc_accepted`
 
 The `htlc_accepted` hook is called whenever an incoming HTLC is accepted, and

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -455,7 +455,7 @@ static void opening_fundee_finished(struct subd *openingd,
 	u32 feerate;
 	u8 channel_flags;
 	struct channel *channel;
-	u8 *remote_upfront_shutdown_script;
+	u8 *remote_upfront_shutdown_script, *local_upfront_shutdown_script;
 	struct per_peer_state *pps;
 
 	log_debug(uc->log, "Got opening_fundee_finish_response");
@@ -482,6 +482,7 @@ static void opening_fundee_finished(struct subd *openingd,
 					   &feerate,
 					   &funding_signed,
 				           &uc->our_config.channel_reserve,
+					   &local_upfront_shutdown_script,
 				           &remote_upfront_shutdown_script)) {
 		log_broken(uc->log, "bad OPENING_FUNDEE_REPLY %s",
 			   tal_hex(reply, reply));
@@ -510,7 +511,7 @@ static void opening_fundee_finished(struct subd *openingd,
 					channel_flags,
 					&channel_info,
 					feerate,
-					NULL,
+					local_upfront_shutdown_script,
 					remote_upfront_shutdown_script);
 	if (!channel) {
 		uncommitted_channel_disconnect(uc, "Commit channel failed");
@@ -753,6 +754,7 @@ static void openchannel_hook_cb(struct openchannel_hook_payload *payload,
 			    const jsmntok_t *toks)
 {
 	struct subd *openingd = payload->openingd;
+	const u8 *our_upfront_shutdown_script;
 	const char *errmsg = NULL;
 
 	/* We want to free this, whatever happens. */
@@ -782,14 +784,41 @@ static void openchannel_hook_cb(struct openchannel_hook_payload *payload,
 			log_debug(openingd->ld->log,
 				  "openchannel_hook_cb says '%s'",
 				  errmsg);
+			our_upfront_shutdown_script = NULL;
 		} else if (!json_tok_streq(buffer, t, "continue"))
 			fatal("Plugin returned an invalid result for the "
 			      "openchannel hook: %.*s",
 			      t->end - t->start, buffer + t->start);
-	}
+
+		/* Check for a 'close_to' address passed back */
+		if (!errmsg) {
+			t = json_get_member(buffer, toks, "close_to");
+			if (t) {
+				switch (json_to_address_scriptpubkey(tmpctx, chainparams,
+								     buffer, t,
+								     &our_upfront_shutdown_script)) {
+					case ADDRESS_PARSE_UNRECOGNIZED:
+						fatal("Plugin returned an invalid response to the"
+						      " openchannel.close_to hook: %.*s",
+						      t->end - t->start, buffer + t->start);
+					case ADDRESS_PARSE_WRONG_NETWORK:
+						fatal("Plugin returned invalid response to the"
+						      " openchannel.close_to hook: address %s is"
+						      " not on network %s",
+						      tal_hex(NULL, our_upfront_shutdown_script),
+						      chainparams->network_name);
+					case ADDRESS_PARSE_SUCCESS:
+						errmsg = NULL;
+				}
+			} else
+				our_upfront_shutdown_script = NULL;
+		}
+	} else
+		our_upfront_shutdown_script = NULL;
 
 	subd_send_msg(openingd,
-		      take(towire_opening_got_offer_reply(NULL, errmsg)));
+		      take(towire_opening_got_offer_reply(NULL, errmsg,
+							  our_upfront_shutdown_script)));
 }
 
 REGISTER_PLUGIN_HOOK(openchannel,
@@ -808,7 +837,7 @@ static void opening_got_offer(struct subd *openingd,
 	if (peer_active_channel(uc->peer)) {
 		subd_send_msg(openingd,
 			      take(towire_opening_got_offer_reply(NULL,
-					  "Already have active channel")));
+					  "Already have active channel", NULL)));
 		return;
 	}
 

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -44,6 +44,8 @@ msgdata,opening_got_offer,shutdown_scriptpubkey,u8,shutdown_len
 # master->openingd: optional rejection message
 msgtype,opening_got_offer_reply,6105
 msgdata,opening_got_offer_reply,rejection,?wirestring,
+msgdata,opening_got_offer_reply,shutdown_len,u16,
+msgdata,opening_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
 
 # Openingd->master: we've successfully offered channel.
 # This gives their sig, means we can broadcast tx: we're done.
@@ -118,8 +120,10 @@ msgdata,opening_fundee,feerate_per_kw,u32,
 msgdata,opening_fundee,msglen,u16,
 msgdata,opening_fundee,funding_signed_msg,u8,msglen
 msgdata,opening_fundee,our_channel_reserve_satoshis,amount_sat,
-msgdata,opening_fundee,shutdown_len,u16,
-msgdata,opening_fundee,shutdown_scriptpubkey,u8,shutdown_len
+msgdata,opening_fundee,local_shutdown_len,u16,
+msgdata,opening_fundee,local_shutdown_scriptpubkey,u8,local_shutdown_len
+msgdata,opening_fundee,remote_shutdown_len,u16,
+msgdata,opening_fundee,remote_shutdown_scriptpubkey,u8,remote_shutdown_len
 
 # master -> openingd: do you have a memleak?
 msgtype,opening_dev_memleak,6033

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -881,7 +881,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	struct bitcoin_signature theirsig, sig;
 	struct bitcoin_tx *local_commit, *remote_commit;
 	struct bitcoin_blkid chain_hash;
-	u8 *msg;
+	u8 *msg, *our_upfront_shutdown_script;
 	const u8 *wscript;
 	u8 channel_flags;
 	char* err_reason;
@@ -1068,7 +1068,8 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	wire_sync_write(REQ_FD, take(msg));
 	msg = wire_sync_read(tmpctx, REQ_FD);
 
-	if (!fromwire_opening_got_offer_reply(tmpctx, msg, &err_reason))
+	if (!fromwire_opening_got_offer_reply(NULL, msg, &err_reason,
+					      &our_upfront_shutdown_script))
 		master_badmsg(WIRE_OPENING_GOT_OFFER_REPLY, msg);
 
 	/* If they give us a reason to reject, do so. */
@@ -1078,6 +1079,9 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 		sync_crypto_write(state->pps, take(errmsg));
 		return NULL;
 	}
+
+	if (!our_upfront_shutdown_script)
+		our_upfront_shutdown_script = dev_upfront_shutdown_script(state);
 
 	/* OK, we accept! */
 	msg = towire_accept_channel_option_upfront_shutdown_script(NULL, &state->channel_id,
@@ -1094,7 +1098,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 				    &state->our_points.delayed_payment,
 				    &state->our_points.htlc,
 				    &state->first_per_commitment_point[LOCAL],
-				    dev_upfront_shutdown_script(tmpctx));
+				    our_upfront_shutdown_script);
 
 	sync_crypto_write(state->pps, take(msg));
 
@@ -1263,6 +1267,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 				     state->feerate_per_kw,
 				     msg,
 				     state->localconf.channel_reserve,
+				     our_upfront_shutdown_script,
 				     state->remote_upfront_shutdown_script);
 }
 

--- a/tests/plugins/accepter_close_to.py
+++ b/tests/plugins/accepter_close_to.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Simple plugin to test the openchannel_hook's
+   'close_to' address functionality.
+
+   If the funding amount is:
+      - a multiple of 11: we send back a valid address (regtest)
+      - a multiple of 7: we send back an empty address
+      - a multiple of 5: we send back an address for the wrong chain (mainnet)
+      - otherwise: we don't include the close_to
+"""
+
+from lightning import Plugin, Millisatoshi
+
+plugin = Plugin()
+
+
+@plugin.hook('openchannel')
+def on_openchannel(openchannel, plugin, **kwargs):
+    # - a multiple of 11: we send back a valid address (regtest)
+    if Millisatoshi(openchannel['funding_satoshis']).to_satoshi() % 11 == 0:
+        return {'result': 'continue', 'close_to': 'bcrt1q7gtnxmlaly9vklvmfj06amfdef3rtnrdazdsvw'}
+
+    # - a multiple of 7: we send back an empty address
+    if Millisatoshi(openchannel['funding_satoshis']).to_satoshi() % 7 == 0:
+        return {'result': 'continue', 'close_to': ''}
+
+    # - a multiple of 5: we send back an address for the wrong chain (mainnet)
+    if Millisatoshi(openchannel['funding_satoshis']).to_satoshi() % 5 == 0:
+        return {'result': 'continue', 'close_to': 'bc1qlq8srqnz64wgklmqvurv7qnr4rvtq2u96hhfg2'}
+
+    # - otherwise: we don't include the close_to
+    return {'result': 'continue'}
+
+
+plugin.run()


### PR DESCRIPTION
I wanted to add this to dual_funding, but decided that it's better to not cram too much more into that than need be, so instead did this off of master.  This is more of a 'nice to have' now, but will be much more important come dual funded channels.

Rounds out the application of `upfront_shutdown_script`, allowing
an accepting node to specify a close_to address.

Prior to this, only the opening node could specify one.

Changelog-Added: Plugins: Allow the 'accepter' to specify an upfront_shutdown_script for
a channel via a `close_to` field in the result.