### PR TITLE
feat: restructure plugin and options in listconfigs #3206

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -742,10 +742,23 @@ def test_listconfigs(node_factory, bitcoind, chainparams):
 
     # Test one at a time.
     for c in configs.keys():
-        if c.startswith('#'):
+        if c.startswith('#') or c.startswith('plugins'):
             continue
         oneconfig = l1.rpc.listconfigs(config=c)
         assert(oneconfig[c] == configs[c])
+
+
+def test_listconfigs_plugins(node_factory, bitcoind, chainparams):
+    l1 = node_factory.get_node()
+
+    # assert that we have pay plugin and that plugins have a name and path
+    configs = l1.rpc.listconfigs()
+    assert configs['plugins']
+    assert len([p for p in configs['plugins'] if p['name'] == "pay"]) == 1
+    for p in configs['plugins']:
+        assert p['name'] and len(p['name']) > 0
+        assert p['path'] and len(p['path']) > 0
+        assert os.path.isfile(p['path']) and os.access(p['path'], os.X_OK)
 
 
 def test_multirpc(node_factory):


### PR DESCRIPTION
Addresses https://github.com/ElementsProject/lightning/issues/3206 and https://github.com/ElementsProject/lightning/issues/3281

This will restructure the `lightning-cli listconfigs` output in a way that plugins are not duplicated and have their options within a substructure like this:

```JSON
{
   "# version": "v0.7.3-141-gabdc4af",
   "lightning-dir": "/home/will/.lightning",
   "wallet": "sqlite3:///home/will/.lightning/lightningd.sqlite3",
   "plugins": [
      {
         "name": "autoclean",
         "path": "/home/will/projects/lightning.git/lightningd/../plugins/autoclean",
         "options": {
            "autocleaninvoice-cycle": null,
            "autocleaninvoice-expired-by": null
         }
      },
      {
         "name": "fundchannel",
         "path": "/home/will/projects/lightning.git/lightningd/../plugins/fundchannel"
      },
      {
         "name": "pay",
         "path": "/home/will/projects/lightning.git/lightningd/../plugins/pay"
      },
      {
         "name": "sendinvoiceless.py",
         "path": "/home/will/.lightning/plugins/sendinvoiceless/sendinvoiceless.py",
         "options": {
            "cltv-final": "10",
            "fee-base": "null",
            "fee-per-satoshi": "null"
         }
      },
      {
         "name": "rebalance.py",
         "path": "/home/will/.lightning/plugins/rebalance/rebalance.py",
         "options": {
            "cltv-final": "10"
         }
      },
      {
         "name": "summary.py",
         "path": "/home/will/.lightning/plugins/summary/summary.py",
         "options": {
            "summary-currency": "USD",
            "summary-currency-prefix": "USD $"
         }
      },
      {
         "name": "drain.py",
         "path": "/home/will/.lightning/plugins/drain/drain.py",
         "options": {
            "cltv-final": "10"
         }
      }
   ],
   "network": "testnet",
   "allow-deprecated-apis": false,
   "..." : "..."
}
```