### PR TITLE
Cleanups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 Makefile text eol=lf
 configure text eol=lf
 .gitmodules text eol=lf
+# The following files are generated and should not be shown in the
+# diffs by default on Github.
+doc/lightning*.7 linguist-generated=true
+

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1075,7 +1075,7 @@ class NodeFactory(object):
             leaks = None
             # leak detection upsets VALGRIND by reading uninitialized mem.
             # If it's dead, we'll catch it below.
-            if not VALGRIND:
+            if not VALGRIND and DEVELOPER:
                 try:
                     # This also puts leaks in log.
                     leaks = self.nodes[i].rpc.dev_memleak()['leaks']

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -535,7 +535,7 @@ def test_htlc_accepted_hook_forward_restart(node_factory, executor):
     onion = json.load(open(fname))
     if EXPERIMENTAL_FEATURES:
         assert onion['type'] == 'tlv'
-        assert re.match(r'^020203e80401..0608................$', onion['payload'])
+        assert re.match(r'^11020203e80401..0608................$', onion['payload'])
     else:
         assert onion['type'] == 'legacy'
         assert re.match(r'^0000006700000.000100000000000003e8000000..000000000000000000000000$', onion['payload'])

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -676,5 +676,6 @@ def test_fundchannel_listtransaction(node_factory, bitcoind):
     # next call warned about SQL Accessing a null column
     # and crashed the daemon for accessing random memory or null
     txs = l1.rpc.listtransactions()['transactions']
-    assert txs[0]['hash'] == txid
-    assert txs[0]['blockheight'] == 0
+
+    tx = [t for t in txs if t['hash'] == txid][0]
+    assert tx['blockheight'] == 0


### PR DESCRIPTION
Just a couple of cleanups that didn't fit anywhere else:

 - Fix for the TLV check in `EXPERIMENTAL_FEATURES` mode
 - Memory leak check works only in developer mode
 - A test was not prepared to handle PGSQLs out-of-order results
 - Teaching github to leave generated man-pages out of the diff (we have the source for that anyway)