### PR TITLE
don't enforce description_hash checking

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -704,7 +704,7 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
         if (!have_p)
                 return decode_fail(b11, fail, "No valid 'p' field found");
 
-        if (have_h) {
+        if (have_h && description) {
                 struct sha256 sha;
 
                 /* BOLT #11:
@@ -713,9 +713,6 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
 		 * in the `h` field exactly matches the hashed
 		 * description.
                  */
-                if (!description)
-                        return decode_fail(b11, fail,
-                                           "h: no description to check");
                 sha256(&sha, description, strlen(description));
                 if (!sha256_eq(b11->description_hash, &sha))
                         return decode_fail(b11, fail,


### PR DESCRIPTION
Although BOLT11 says "a reader MUST check" I'm not sure "reader" refers specifically to the Lightning server.

Sometimes the reader may be an application and the application may want to decode the invoice first before looking for the full description somewhere else and then proceeding to check either on its own or by calling `decodepay` again.

Sometimes the reader is a final payer, but there are some circumstances, like a custodial wallet provider or some other [odd situations](https://devpost.com/software/txawaitbot) in which the Lightning server is not the _final payer_ and thus not the "reader" that should care about this.

Sometimes the "full description" is not a UTF-8 string. In these cases they may still be checked against the `description_hash` but it will be impossible to pass it to lightningd.

I don't know, just think that failing when a `description` to be checked is not given is too brutal.

Changelog-None