### PR TITLE
deprecate --always-use-proxy 

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -780,7 +780,7 @@ static void try_connect_one_addr(struct connecting *connect)
 
 	/* This creates the new connection using our fd, with the initialization
 	 * function one of the above. */
-	if (use_proxy)
+	if (use_proxy || connect->daemon->use_proxy_always)
 		notleak(io_new_conn(connect, fd, conn_proxy_init, connect));
 	else
 		notleak(io_new_conn(connect, fd, conn_init, connect));

--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -187,8 +187,12 @@ proxy.
 **You can always add this option, also in the other use cases, to add outgoing 
 Tor capabilities.**
 
-If you want to `connect` to nodes ONLY via the Tor proxy, you have to add the 
-`--always-use-proxy=true` option.
+If you want to `connect` to nodes ONLY via the Tor proxy, you have to add the
+`--always-use-proxy=true` option ( will be depredicated ).
+
+If you want to `connect` to nodes not ONLY via the Tor proxy, you have to add the
+`--tor-proxy-only-tor` option.
+
 
 You can announce your public IP address through the usual method:
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -357,9 +357,9 @@ and this will be used to configure a Tor hidden service for port
 first IPv4 or IPv6 address we bind to.
 
 This option can be used multiple times to add more addresses, and
-its use disables autolisten.  If necessary, and 'always-use-proxy'
-is not specified, a DNS lookup may be done to resolve 'IPADDRESS'
-or 'TORIPADDRESS'.
+its use disables autolisten.  If necessary, and 'tor-proxy-only-tor'
+is specified or 'always-use-proxy' (deprecated) is not spcified,
+a DNS lookup may be done to resolve 'IPADDRESS' or 'TORIPADDRESS'.
 
 
 .RE
@@ -379,8 +379,9 @@ interfaces, '::' means 'bind to all IPv6 interfaces'.  'PORT' is
 not specified, 9735 is used.
 
 This option can be used multiple times to add more addresses, and
-its use disables autolisten.  If necessary, and 'always-use-proxy'
-is not specified, a DNS lookup may be done to resolve 'IPADDRESS'.
+its use disables autolisten.  If necessary, and 'tor-proxy-only-tor'
+is specified or 'always-use-proxy' (deprecated) is not spcified,
+a DNS lookup may be done to resolve 'IPADDRESS'.
 
 
 .RE
@@ -402,8 +403,8 @@ its use disables autolisten.  The spec says you can't announce
 more that one address of the same type (eg. two IPv4 or two IPv6
 addresses) so `lightningd` will refuse if you specify more than one.
 
-If necessary, and 'always-use-proxy' is not specified, a DNS
-lookup may be done to resolve 'IPADDRESS'.
+If necessary, and 'tor-proxy-only-tor' is specified or 'always-use-proxy' (deprecated)
+is not spcified, a DNS lookup may be done to resolve 'IPADDRESS'.
 
 
 .RE
@@ -422,15 +423,21 @@ no \fIaddr\fR, \fIbind-addr\fR or \fIannounce-addr\fR options are specified\. Se
 this to \fIfalse\fR disables that\.
 
 
- \fBproxy\fR=\fIIPADDRESS[:PORT]\fR
-Set a socks proxy to use to connect to Tor nodes (or for all connections
-if \fBalways-use-proxy\fR is set)\.
+ \fBproxy\fR=\fIIPADDRESS\[:PORT\]\fR
+Set the Tor proxy to use to connect to Tor nodes (or for all connections
+if \fIalways-use-proxy\fR is set. WARNING deprecated).
 
 
  \fBalways-use-proxy\fR=\fIBOOL\fR
-Always use the \fBproxy\fR, even to connect to normal IP addresses (you
-can still connect to Unix domain sockets manually)\. This also disables
-all DNS lookups, to avoid leaking information\.
+Always use the **proxy**, even to connect to normal IP addresses (you
+can still connect to Unix domain sockets manually). This also disables
+all DNS lookups, to avoid leaking information.
+
+
+ \fBtor-proxy-only-tor\fR
+Do not always use the \fBproxy\fR, and connect to normal IP addresses not
+over the proxy (you can still connect to Unix domain sockets manually).
+This also enables DNS lookups, and will leak information to the DNS system.
 
 
  \fBdisable-dns\fR

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -294,9 +294,10 @@ Set an IP address (v4 or v6) or automatic Tor address to listen on and
     first IPv4 or IPv6 address we bind to.
 
     This option can be used multiple times to add more addresses, and
-    its use disables autolisten.  If necessary, and 'always-use-proxy'
-    is not specified, a DNS lookup may be done to resolve 'IPADDRESS'
-    or 'TORIPADDRESS'.
+    its use disables autolisten.  If necessary, and 'tor-proxy-only-tor'
+    is specified or 'always-use-proxy' (deprecated) is not spcified,
+    a DNS lookup may be done to resolve 'IPADDRESS' or 'TORIPADDRESS'.
+
 
  **bind-addr**=*\[IPADDRESS\[:PORT\]\]|SOCKETPATH*
 Set an IP address or UNIX domain socket to listen to, but do not
@@ -309,8 +310,9 @@ beginning with a */*.
     not specified, 9735 is used.
 
     This option can be used multiple times to add more addresses, and
-    its use disables autolisten.  If necessary, and 'always-use-proxy'
-    is not specified, a DNS lookup may be done to resolve 'IPADDRESS'.
+    its use disables autolisten.  If necessary, and 'tor-proxy-only-tor'
+    is specified or 'always-use-proxy' (deprecated) is not spcified,
+    a DNS lookup may be done to resolve 'IPADDRESS'.
 
  **announce-addr**=*IPADDRESS\[:PORT\]|TORADDRESS.onion\[:PORT\]*
 Set an IP (v4 or v6) address or Tor address to announce; a Tor address
@@ -325,8 +327,8 @@ is distinguished by ending in *.onion*. *PORT* defaults to 9735.
     more that one address of the same type (eg. two IPv4 or two IPv6
     addresses) so `lightningd` will refuse if you specify more than one.
 
-    If necessary, and 'always-use-proxy' is not specified, a DNS
-    lookup may be done to resolve 'IPADDRESS'.
+    If necessary, and 'tor-proxy-only-tor' is specified or 'always-use-proxy' (deprecated)
+    is not spcified, a DNS lookup may be done to resolve 'IPADDRESS'.
 
  **offline**
 Do not bind to any ports, and do not try to reconnect to any peers. This
@@ -339,13 +341,18 @@ no *addr*, *bind-addr* or *announce-addr* options are specified. Setting
 this to *false* disables that.
 
  **proxy**=*IPADDRESS\[:PORT\]*
-Set a socks proxy to use to connect to Tor nodes (or for all connections
-if **always-use-proxy** is set).
+Set the Tor proxy to use to connect to Tor nodes (or for all connections
+if **always-use-proxy** is set. WARNING deprecated).
 
  **always-use-proxy**=*BOOL*
 Always use the **proxy**, even to connect to normal IP addresses (you
 can still connect to Unix domain sockets manually). This also disables
 all DNS lookups, to avoid leaking information.
+
+ **tor-proxy-only-tor**
+Do not always use the **proxy**, and connect to normal IP addresses not
+over the proxy  (you can still connect to Unix domain sockets manually).
+This also enables DNS lookups, and will leak information to the DNS system.
 
  **disable-dns**
 Disable the DNS bootstrapping mechanism to find a node by its node ID.

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -207,6 +207,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->daemon_parent_fd = -1;
 	ld->proxyaddr = NULL;
 	ld->use_proxy_always = false;
+	ld->tor_proxy_only_tor = false;
 	ld->pure_tor_setup = false;
 	ld->tor_service_password = NULL;
 	ld->max_funding_unconfirmed = 2016;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -234,6 +234,7 @@ struct lightningd {
 	/* tor support */
 	struct wireaddr *proxyaddr;
 	bool use_proxy_always;
+	bool tor_proxy_only_tor;
 	char *tor_service_password;
 	bool pure_tor_setup;
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1438,14 +1438,14 @@ def test_configfile_before_chdir(node_factory):
     config = os.path.join(os.path.basename(l1.daemon.lightning_dir[:-1]), TEST_NETWORK, "test_configfile")
     # Test both an early arg and a normal arg.
     with open(config, 'wb') as f:
-        f.write(b'always-use-proxy=true\n')
+        f.write(b'tor-proxy-only-tor\n')
         f.write(b'proxy=127.0.0.1:100\n')
     l1.daemon.opts['conf'] = config
 
     # Update executable to point to right place
     l1.daemon.executable = os.path.join(olddir, l1.daemon.executable)
     l1.start()
-    assert l1.rpc.listconfigs()['always-use-proxy']
+    assert l1.rpc.listconfigs()['tor-proxy-only-tor'] == 'true'
     assert l1.rpc.listconfigs()['proxy'] == '127.0.0.1:100'
     os.chdir(olddir)
 


### PR DESCRIPTION
The proxy can be assumed in a later version to be a Tor proxy by default.

Therefore we can then by default disable all local dns lookup and resolve all names over Tor, if the proxy option is used.
Mark therefore now the  --always-use-proxy deprecated and define a new option  --tor-proxy-only-tor
The user can override this later default behavior with the new option --tor-proxy-only-tor
