### PR TITLE
tool/hsmtool: add a 'guesstoremote' command

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,7 +14,7 @@ tools/headerversions: FORCE tools/headerversions.o $(CCAN_OBJS)
 
 tools/check-bolt: tools/check-bolt.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS)
 
-tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bigsize.o common/derive_basepoints.o common/node_id.o common/type_to_string.o  wire/fromwire.o wire/towire.o
+tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bech32.o common/bigsize.o common/derive_basepoints.o common/node_id.o common/type_to_string.o wire/fromwire.o wire/towire.o
 
 clean: tools-clean
 

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -365,25 +365,25 @@ int main(int argc, char *argv[])
 	setup_locale();
 	err_set_progname(argv[0]);
 
-	method = argv[1];
+	method = argc > 1 ? argv[1] : NULL;
 	if (!method)
 		show_usage();
 
 	if (streq(method, "decrypt")) {
-		if (!argv[2] || !argv[3])
+		if (argc < 3)
 			show_usage();
 		return decrypt_hsm(argv[2], argv[3]);
 	}
 
 	if (streq(method, "encrypt")) {
-		if (!argv[2] || !argv[3])
+		if (argc < 3)
 			show_usage();
 		return encrypt_hsm(argv[2], argv[3]);
 	}
 
 	if (streq(method, "dumpcommitments")) {
 		/*   node_id    channel_id   depth    hsm_secret  ?password? */
-		if (!(argv[2] && argv[3] && argv[4] && argv[5]))
+		if (argc < 5)
 			show_usage();
 		struct node_id node_id;
 		if (!node_id_from_hexstr(argv[2], strlen(argv[2]), &node_id))


### PR DESCRIPTION
This is the `static_remotekey`-only version of #3217 (since I noticed `to_remote` keys are (/were) actually derived from the *local* `per_commitment_point`, by the way if someone [could explains me why](https://github.com/ElementsProject/lightning/issues/2665#issuecomment-547409859) I'd be interested ^^).

I added a note to the README about it since all major implementations [will](https://github.com/ACINQ/eclair/pull/1141) implement it, it's likely that most of the newly created channels will enable `option_static_remotekey` in the near future and that this might be useful.