### PR TITLE
cleanup: Stabilize the hsm encryption tests and fix dependencies

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -47,7 +47,8 @@ def directory(request, test_base_dir, test_name):
     # determine whether we succeeded or failed. Outcome can be None if the
     # failure occurs during the setup phase, hence the use to getattr instead
     # of accessing it directly.
-    outcome = getattr(request.node, 'rep_call', None).outcome
+    rep_call = getattr(request.node, 'rep_call', None)
+    outcome = 'passed' if rep_call is None else rep_call.outcome
     failed = not outcome or request.node.has_errors or outcome != 'passed'
 
     if not failed:

--- a/contrib/pyln-testing/requirements.txt
+++ b/contrib/pyln-testing/requirements.txt
@@ -3,3 +3,4 @@ Flask==1.1.1
 cheroot==6.5.5
 ephemeral-port-reserve==1.1.1
 python-bitcoinlib==0.10.1
+psycopg2-binary==2.8.3

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -331,7 +331,12 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	temp_term.c_lflag &= ~ECHO;
 	if (tcsetattr(fileno(stdin), TCSAFLUSH, &temp_term) != 0)
 		return "Could not disable password echoing.";
-	printf("Enter hsm_secret password : ");
+	printf("The hsm_secret is encrypted with a password. In order to "
+	       "decrypt it and start the node you must provide the password.\n");
+	printf("Enter hsm_secret password: ");
+	/* If we don't flush we might end up being buffered and we might seem
+	 * to hang while we wait for the password. */
+	fflush(stdout);
 	if (getline(&passwd, &passwd_size, stdin) < 0)
 		return "Could not read password from stdin.";
 	if(passwd[strlen(passwd) - 1] == '\n')


### PR DESCRIPTION
Just my usual collection of cleanups:

 - Add `psycopg2-binary` instead of `psycopg2` as a `pyln-testing` dependency
 - Fix our implicit reliance on `conftest.py` annotating our tests for directory clean
 - Stabilize the hsm encryption and decryption tests

Changelog-None