### PR TITLE
'invoice' command returning preimage.

### DIFF
--- a/doc/lightning-invoice.7
+++ b/doc/lightning-invoice.7
@@ -84,6 +84,7 @@ not\.
 
 The following error codes may occur:
 
+.RS
 .IP \[bu]
 -1: Catchall nonspecific error\.
 .IP \[bu]
@@ -91,9 +92,11 @@ The following error codes may occur:
 .IP \[bu]
 901: An invoice with the given \fIpreimage\fR already exists\.
 
+.RE
 
 One of the following warnings may occur (on success):
 
+.RS
 .IP \[bu]
 \fIwarning_offline\fR if no channel with a currently connected peer has
   the incoming capacity to pay this invoice
@@ -102,6 +105,7 @@ One of the following warnings may occur (on success):
   incoming capacity and has a peer that is publicly connected (i\.e\.
   not a dead end)
 
+.RE
 .SH AUTHOR
 
 Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.

--- a/doc/lightning-listinvoices.7
+++ b/doc/lightning-listinvoices.7
@@ -12,17 +12,16 @@ if it exists, or the status of all invoices if given no argument\.
 
 .SH RETURN VALUE
 
-On success, an array \fIinvoices\fR of objects is returned\. Each object
-contains \fIlabel\fR, \fIpayment_hash\fR, \fIstatus\fR (one of \fIunpaid\fR, \fIpaid\fR or
-\fIexpired\fR), and \fIexpiry_time\fR (a UNIX timestamp)\. If the \fImsatoshi\fR
-argument to \fBlightning-invoice\fR(7) was not "any", there will be an
-\fImsatoshi\fR field as a number, and \fIamount_msat\fR as the same number
-ending in \fImsat\fR\. If the invoice \fIstatus\fR is \fIpaid\fR, there will be a
-\fIpay_index\fR field and an \fImsatoshi_received\fR field (which may be
-slightly greater than \fImsatoshi\fR as some overpaying is permitted to
-allow clients to obscure payment paths); there will also be an
-\fIamount_received_msat\fR field with the same number as
-\fImsatoshi_received\fR but ending in \fImsat\fR\.
+On success, an array \fIinvoices\fR of objects is returned\. Each object contains
+\fIlabel\fR, \fIpayment_hash\fR, \fIstatus\fR (one of \fIunpaid\fR, \fIpaid\fR or \fIexpired\fR),
+\fIpayment_preimage\fR (for paid invoices), and \fIexpiry_time\fR (a UNIX
+timestamp)\.  If the \fImsatoshi\fR argument to \fBlightning-invoice\fR(7) was not "any",
+there will be an \fImsatoshi\fR field as a number, and \fIamount_msat\fR as the same
+number ending in \fImsat\fR\. If the invoice \fIstatus\fR is \fIpaid\fR, there will be a
+\fIpay_index\fR field and an \fImsatoshi_received\fR field (which may be slightly
+greater than \fImsatoshi\fR as some overpaying is permitted to allow clients to
+obscure payment paths); there will also be an \fIamount_received_msat\fR field
+with the same number as \fImsatoshi_received\fR but ending in \fImsat\fR\.
 
 .SH AUTHOR
 

--- a/doc/lightning-listinvoices.7.md
+++ b/doc/lightning-listinvoices.7.md
@@ -15,17 +15,16 @@ if it exists, or the status of all invoices if given no argument.
 RETURN VALUE
 ------------
 
-On success, an array *invoices* of objects is returned. Each object
-contains *label*, *payment\_hash*, *status* (one of *unpaid*, *paid* or
-*expired*), and *expiry\_time* (a UNIX timestamp). If the *msatoshi*
-argument to lightning-invoice(7) was not "any", there will be an
-*msatoshi* field as a number, and *amount\_msat* as the same number
-ending in *msat*. If the invoice *status* is *paid*, there will be a
-*pay\_index* field and an *msatoshi\_received* field (which may be
-slightly greater than *msatoshi* as some overpaying is permitted to
-allow clients to obscure payment paths); there will also be an
-*amount\_received\_msat* field with the same number as
-*msatoshi\_received* but ending in *msat*.
+On success, an array *invoices* of objects is returned. Each object contains
+*label*, *payment\_hash*, *status* (one of *unpaid*, *paid* or *expired*),
+*payment\_preimage* (for paid invoices), and *expiry\_time* (a UNIX
+timestamp).  If the *msatoshi* argument to lightning-invoice(7) was not "any",
+there will be an *msatoshi* field as a number, and *amount\_msat* as the same
+number ending in *msat*. If the invoice *status* is *paid*, there will be a
+*pay\_index* field and an *msatoshi\_received* field (which may be slightly
+greater than *msatoshi* as some overpaying is permitted to allow clients to
+obscure payment paths); there will also be an *amount\_received\_msat* field
+with the same number as *msatoshi\_received* but ending in *msat*.
 
 AUTHOR
 ------

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -61,6 +61,7 @@ static void json_add_invoice(struct json_stream *response,
 					    "msatoshi_received",
 					    "amount_received_msat");
 		json_add_u64(response, "paid_at", inv->paid_timestamp);
+		json_add_preimage(response, "payment_preimage", &inv->r);
 	}
 	if (inv->description)
 		json_add_string(response, "description", inv->description);
@@ -572,7 +573,6 @@ static void gossipd_incoming_channels_reply(struct subd *gossipd,
 	json_add_sha256(response, "payment_hash", &details->rhash);
 	json_add_u64(response, "expires_at", details->expiry_time);
 	json_add_string(response, "bolt11", details->bolt11);
-	json_add_preimage(response, "preimage", &details->r);
 
 	/* Warn if there's not sufficient incoming capacity. */
 	if (tal_count(info->b11->routes) == 0) {

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -138,8 +138,7 @@ invoice_payment_serialize(struct invoice_payment_hook_payload *payload,
 {
 	json_object_start(stream, "payment");
 	json_add_escaped_string(stream, "label", payload->label);
-	json_add_hex(stream, "preimage",
-		     &payload->preimage, sizeof(payload->preimage));
+	json_add_preimage(stream, "preimage", &payload->preimage);
 	json_add_string(stream, "msat",
 			type_to_string(tmpctx, struct amount_msat,
 				       &payload->msat));
@@ -573,6 +572,7 @@ static void gossipd_incoming_channels_reply(struct subd *gossipd,
 	json_add_sha256(response, "payment_hash", &details->rhash);
 	json_add_u64(response, "expires_at", details->expiry_time);
 	json_add_string(response, "bolt11", details->bolt11);
+	json_add_preimage(response, "preimage", &details->r);
 
 	/* Warn if there's not sufficient incoming capacity. */
 	if (tal_count(info->b11->routes) == 0) {

--- a/lightningd/json.c
+++ b/lightningd/json.c
@@ -438,6 +438,12 @@ void json_add_sha256(struct json_stream *result, const char *fieldname,
 	json_add_hex(result, fieldname, hash, sizeof(*hash));
 }
 
+void json_add_preimage(struct json_stream *result, const char *fieldname,
+		     const struct preimage *preimage)
+{
+	json_add_hex(result, fieldname, preimage, sizeof(*preimage));
+}
+
 /**
  * segwit_addr_net_decode - Try to decode a Bech32 address and detect
  * testnet/mainnet/regtest/signet

--- a/lightningd/json.h
+++ b/lightningd/json.h
@@ -27,6 +27,7 @@ struct json_stream;
 struct pubkey;
 struct node_id;
 struct sha256;
+struct preimage;
 struct short_channel_id;
 struct wallet_payment;
 struct wallet_tx;
@@ -205,6 +206,9 @@ void json_add_time(struct json_stream *result, const char *fieldname,
 
 void json_add_sha256(struct json_stream *result, const char *fieldname,
 		     const struct sha256 *hash);
+
+void json_add_preimage(struct json_stream *result, const char *fieldname,
+		     const struct preimage *preimage);
 
 struct command_result *param_bitcoin_address(struct command *cmd,
 					     const char *name,

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -108,9 +108,8 @@ void json_add_payment_fields(struct json_stream *response,
 		break;
 	}
 	if (t->payment_preimage)
-		json_add_hex(response, "payment_preimage",
-			     t->payment_preimage,
-			     sizeof(*t->payment_preimage));
+		json_add_preimage(response, "payment_preimage",
+                    t->payment_preimage);
 	if (t->label)
 		json_add_string(response, "label", t->label);
 	if (t->bolt11)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -170,10 +170,6 @@ void json_add_escaped_string(struct json_stream *result UNNEEDED,
 			     const char *fieldname UNNEEDED,
 			     const struct json_escape *esc TAKES UNNEEDED)
 { fprintf(stderr, "json_add_escaped_string called!\n"); abort(); }
-/* Generated stub for json_add_hex */
-void json_add_hex(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
-		  const void *data UNNEEDED, size_t len UNNEEDED)
-{ fprintf(stderr, "json_add_hex called!\n"); abort(); }
 /* Generated stub for json_add_hex_talarr */
 void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 			 const char *fieldname UNNEEDED,
@@ -194,6 +190,10 @@ void json_add_node_id(struct json_stream *response UNNEEDED,
 void json_add_num(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
 		  unsigned int value UNNEEDED)
 { fprintf(stderr, "json_add_num called!\n"); abort(); }
+/* Generated stub for json_add_preimage */
+void json_add_preimage(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		     const struct preimage *preimage UNNEEDED)
+{ fprintf(stderr, "json_add_preimage called!\n"); abort(); }
 /* Generated stub for json_add_secret */
 void json_add_secret(struct json_stream *response UNNEEDED,
 		     const char *fieldname UNNEEDED,

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -517,6 +517,7 @@ def test_sendpay(node_factory):
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['status'] == 'paid'
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['pay_index'] == 1
     assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['msatoshi_received'] == rs['msatoshi']
+    assert only_one(l2.rpc.listinvoices('testpayment2')['invoices'])['payment_preimage'] == preimage
 
     # Balances should reflect it.
     def check_balances():


### PR DESCRIPTION
I'm sorry for this silly PR, but this has been bugging me for a long time. Being able to see the preimages of invoices issued is good for overall understanding of the protocol and for easy checking of payment proofs from others, not to mention other advanced uses (which may be covered by passing your own preimage to `invoice` as the docs imply, but still).

The point is that this doesn't hurt and makes everything better.

---

### Some useless context

On https://t.me/lntxbot I like to show a lot of debugging information (because I'm crazy and I think users will want to understand what is happening): ![2019-11-25-231518_445x806_scrot](https://user-images.githubusercontent.com/1653275/69593905-71d00700-0fd9-11ea-9d74-cc2123ea1be1.png)

However, because I can't get the preimages my invoices are using from the `invoice` command to show these preimages I have to generate them on my own using a probably-not-so-safe generator and store them in not-so-optimal ways instead of having `lightningd` generate them for me.

**edit**: just realized the above image is from the sender side, not the receiver, so completely unrelated.