### PR TITLE
lightningd: fix reference to out-of-scope var.

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1081,6 +1081,7 @@ static void add_config(struct lightningd *ld,
 {
 	char *name0 = tal_strndup(response, name, len);
 	const char *answer = NULL;
+	char buf[OPT_SHOW_LEN + sizeof("...")];
 
 	if (opt->type & OPT_NOARG) {
 		if (opt->desc == opt_hidden) {
@@ -1117,7 +1118,6 @@ static void add_config(struct lightningd *ld,
 		if (opt->desc == opt_hidden) {
 			/* Ignore hidden options (deprecated) */
 		} else if (opt->show) {
-			char buf[OPT_SHOW_LEN + sizeof("...")];
 			strcpy(buf + OPT_SHOW_LEN, "...");
 			opt->show(buf, opt->u.carg);
 


### PR DESCRIPTION
cppcheck found this:

	[lightningd/options.c:1137] -> [lightningd/options.c:1120] -> [lightningd/options.c:1193]: (error) Using pointer to local variable 'buf' that is out of scope.

Indeed, answer can point into buf, which is no longer in scope at the end.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None