### PR TITLE
Dont crash on bad sphinx

### DIFF
--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -603,7 +603,11 @@ static bool sphinx_parse_payload(struct route_step *step, const u8 *src)
 		fromwire_varint(&tlv, &max);
 
 		if (!fromwire_tlv_payload(&tlv, &max, step->payload.tlv)) {
-			/* FIXME: record offset of violation for error! */
+			return false;
+		}
+
+		/* FIXME: record offset of violation for error! */
+		if (!tlv_payload_is_valid(step->payload.tlv, NULL)) {
 			return false;
 		}
 	}

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -71,7 +71,6 @@ struct hop_data_legacy {
 enum sphinx_payload_type {
 	SPHINX_V0_PAYLOAD = 0,
 	SPHINX_TLV_PAYLOAD = 1,
-	SPHINX_INVALID_PAYLOAD = 254,
 	SPHINX_RAW_PAYLOAD = 255,
 };
 


### PR DESCRIPTION
Found the missing validity check by inspection :(

Clearly, we need to call the validity *by default*, and have a special "don't check validity" version for the one case where that is wanted.