### PR TITLE
doc: feerate is not obvious, refer to fundchannel documentation:

### DIFF
--- a/doc/lightning-fundchannel_start.7
+++ b/doc/lightning-fundchannel_start.7
@@ -20,7 +20,7 @@ will not encompass the correct channel value\.
 
 
 \fIfeerate\fR is an optional field\. Sets the feerate for subsequent
-commitment transactions\.
+commitment transactions: see \fBfundchannel\fR\.
 
 
 \fIannounce\fR whether or not to announce this channel\.

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -19,7 +19,7 @@ value MUST be accurate, otherwise the negotiated commitment transactions
 will not encompass the correct channel value.
 
 *feerate* is an optional field. Sets the feerate for subsequent
-commitment transactions.
+commitment transactions: see **fundchannel**.
 
 *announce* whether or not to announce this channel.
 


### PR DESCRIPTION
It has a whole *two paragraphs* on it:

*feerate* is an optional feerate used for the opening transaction and as
initial feerate for commitment and HTLC transactions. It can be one of
the strings *urgent* (aim for next block), *normal* (next 4 blocks or
so) or *slow* (next 100 blocks or so) to use lightningd’s internal
estimates: *normal* is the default.

Otherwise, *feerate* is a number, with an optional suffix: *perkw* means
the number is interpreted as satoshi-per-kilosipa (weight), and *perkb*
means it is interpreted bitcoind-style as satoshi-per-kilobyte. Omitting
the suffix is equivalent to *perkb*.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>