### PR TITLE
Fix rpc command hook: the missing id

### DIFF
--- a/tests/plugins/rpc_command.py
+++ b/tests/plugins/rpc_command.py
@@ -21,6 +21,9 @@ def on_rpc_command(plugin, rpc_command, **kwargs):
         # Don't allow this command to be executed
         return {"return": {"error": {"code": -1,
                                      "message": "You cannot do this"}}}
+    elif request["method"] == "help":
+        request["method"] = "autocleaninvoice"
+        return {"replace": request}
     return {"continue": True}
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -761,6 +761,7 @@ def test_sendpay_notifications(node_factory, bitcoind):
     assert results['sendpay_failure'][0] == err.value.error
 
 
+@pytest.mark.xfail(strict=True)
 def test_rpc_command_hook(node_factory):
     """Test the `sensitive_command` hook"""
     plugin = os.path.join(os.getcwd(), "tests/plugins/rpc_command.py")
@@ -778,6 +779,9 @@ def test_rpc_command_hook(node_factory):
     # The plugin sends a custom response to "listfunds"
     funds = l1.rpc.listfunds()
     assert funds[0] == "Custom result"
+
+    # Test command redirection to a plugin
+    l1.rpc.call('help', [0])
 
     # Test command which removes plugin itself!
     l1.rpc.plugin_stop('rpc_command.py')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -761,7 +761,6 @@ def test_sendpay_notifications(node_factory, bitcoind):
     assert results['sendpay_failure'][0] == err.value.error
 
 
-@pytest.mark.xfail(strict=True)
 def test_rpc_command_hook(node_factory):
     """Test the `sensitive_command` hook"""
     plugin = os.path.join(os.getcwd(), "tests/plugins/rpc_command.py")


### PR DESCRIPTION
We need the id field if we redirect to another plugin (which subs the id), yet we handed the wrong argument so we didn't actually give it the full array.

We also didn't check it exists in the response, nor document it.

This adds that test case, and ratchets up the sanity checks for the hook.

Changelog-None