### PR TITLE
doc: add 'id' to rpc_command

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -703,6 +703,7 @@ the received JSON-RPC request to the registered plugin,
 ```json
 {
     "rpc_command": {
+        "id": 3,
         "method": "method_name",
         "params": {
             "param_1": [],
@@ -727,6 +728,7 @@ Replace the request made to `lightningd`:
 ```json
 {
     "replace": {
+        "id": 3,
         "method": "method_name",
         "params": {
             "param_1": [],


### PR DESCRIPTION
It's required, so at least hint about its presence!

Changelog-None