### PR TITLE
ccan: fix read_all() to always set errno on failure

### DIFF
--- a/ccan/ccan/read_write_all/read_write_all.c
+++ b/ccan/ccan/read_write_all/read_write_all.c
@@ -26,12 +26,20 @@ bool read_all(int fd, void *data, size_t size)
 		ssize_t done;
 
 		done = read(fd, data, size);
-		if (done < 0 && errno == EINTR)
-			continue;
-		if (done <= 0)
+
+		switch (done) {
+		case -1:
+			if (errno == EINTR) {
+				continue;
+			}
 			return false;
-		data = (char *)data + done;
-		size -= done;
+		case 0:
+			errno = EBADMSG;
+			return false;
+		default:
+			data = (char *)data + done;
+			size -= done;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
read(2) will return 0 to designate end-of-file and in this case it will
not set errno.

This is not considered as an error condition by read(2) itself, but all
callers of read_all() expect that exactly the requested number of bytes
will be read into the buffer, not less, so set errno to EBADMSG
"Bad message" in this case.

Related to https://github.com/ElementsProject/lightning/issues/3185