### PR TITLE
Fixup fundchannel_cancel

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -698,14 +698,10 @@ static void process_check_funding_broadcast(struct bitcoind *bitcoind,
 		return;
 	}
 
-	const char *error_reason = "Cancel channel by our RPC "
-				   "command before funding "
-				   "transaction broadcast.";
-	/* Set error so we don't try to reconnect. */
-	cancel->error = towire_errorfmt(cancel, NULL, "%s", error_reason);
-
-	subd_send_msg(cancel->owner,
-		      take(towire_channel_send_error(NULL, error_reason)));
+	char *error_reason = "Cancel channel by our RPC "
+			     "command before funding "
+			     "transaction broadcast.";
+	forget_channel(cancel, error_reason);
 }
 
 struct command_result *cancel_channel_before_broadcast(struct command *cmd,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -726,6 +726,11 @@ struct command_result *cancel_channel_before_broadcast(struct command *cmd,
 					    buffer + cidtok->start);
 	}
 
+	if (cancel_channel->funder == REMOTE)
+		return command_fail(cmd, LIGHTNINGD,
+				    "Cannot cancel channel that was "
+				    "initiated by peer");
+
 	/* Check if we broadcast the transaction. (We store the transaction type into DB
 	 * before broadcast). */
 	enum wallet_tx_type type;

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -30,4 +30,7 @@ struct command_result *cancel_channel_before_broadcast(struct command *cmd,
 						       struct peer *peer,
 						       const jsmntok_t *cidtok);
 
+/* Forget a channel. Deletes the channel and handles all
+ * associated waiting commands, if present. Notifies peer if available */
+void forget_channel(struct channel *channel, const char *err_msg);
 #endif /* LIGHTNING_LIGHTNINGD_CHANNEL_CONTROL_H */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1030,7 +1030,12 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
 
     # Be sure fundchannel_complete is successful
     assert l1.rpc.fundchannel_complete(l2.info['id'], prep['txid'], txout)['commitments_secured']
-    # Canceld channel after fundchannel_complete
+
+    # Peer shouldn't be able to cancel channel
+    with pytest.raises(RpcError, match=r'Cannot cancel channel that was initiated by peer'):
+        l2.rpc.fundchannel_cancel(l1.info['id'])
+
+    # We can cancel channel after fundchannel_complete
     assert l1.rpc.fundchannel_cancel(l2.info['id'])['cancelled']
 
     # l2 won't give up, since it considers error "soft".

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1038,9 +1038,6 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     # We can cancel channel after fundchannel_complete
     assert l1.rpc.fundchannel_cancel(l2.info['id'])['cancelled']
 
-    # l2 won't give up, since it considers error "soft".
-    l2.rpc.dev_forget_channel(l1.info['id'])
-
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.fundchannel_start(l2.info['id'], amount)['funding_address']
     assert l1.rpc.fundchannel_complete(l2.info['id'], prep['txid'], txout)['commitments_secured']

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1061,6 +1061,8 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     # we have to connect again, because we got disconnected when everything errored
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.fundchannel_start(l2.info['id'], amount)['funding_address']
+    # A successful funding_complete will always have a commitments_secured that is true,
+    # otherwise it would have failed
     assert l1.rpc.fundchannel_complete(l2.info['id'], prep['txid'], txout)['commitments_secured']
     l1.rpc.txsend(prep['txid'])
     with pytest.raises(RpcError, match=r'.* been broadcast.*'):


### PR DESCRIPTION
There's a few small, subtle bugs currently in `fundchannel_cancel`:
-  one: the remote peer can call `fundchannel_cancel` while waiting for lockin. it's debatable whether or not this is desirable. for now it seems prudent to remove the capability altogether.
- two: if you attempt to cancel a channel while the peer is offline, your node will crash

this PR addresses both of these issues. note that `forget_channel` is currently exposed because in a later commit (in the dual funding branch) i'm using it elsewhere.