### PR TITLE
cli: allow to specify only the --rpc-file option

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -9,6 +9,7 @@
 #include <ccan/opt/opt.h>
 #include <ccan/read_write_all/read_write_all.h>
 #include <ccan/str/str.h>
+#include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
 #include <common/configdir.h>
 #include <common/json.h>
@@ -490,6 +491,13 @@ int main(int argc, char *argv[])
 		try_exec_man(page, dirname(argv[0]));
 
 		tal_free(page);
+	}
+
+	/* If an absolute path to the RPC socket is given, it takes over other
+	 * configuration options. */
+	if (path_is_abs(rpc_filename)) {
+		net_dir = path_dirname(ctx, rpc_filename);
+		rpc_filename = path_basename(ctx, rpc_filename);
 	}
 
 	if (chdir(net_dir) != 0)


### PR DESCRIPTION
fixes  #3352

I at first made the `--rpc-file` option take over the `--lightning_dir` one, but we don't seem to be using the config dir in the cli anyway, so ..