### PR TITLE
travis: Make python environment selection less picky

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -27,7 +27,7 @@ if [ ! -f dependencies/bin/bitcoind ]; then
     rm -rf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz bitcoin-0.17.1
 fi
 
-pyenv global 3.7.1
+pyenv global 3.7
 pip3 install --user --quiet -r requirements.txt -r tests/requirements.txt -r doc/requirements.txt
 pip3 install --quiet \
      pytest-test-groups==1.0.3


### PR DESCRIPTION
Travis seems to have upgraded to a newer minor version of python3, so let's be
way less picky about which exact version we want to run against.

Changelog-None