### PR TITLE
Add a `data_version` to the `db_write` hook an implement optimistic locking

### DIFF
--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -156,13 +156,14 @@ static void db_hook_response(const char *buffer, const jsmntok_t *toks,
 	io_break(ph_req);
 }
 
-void plugin_hook_db_sync(struct db *db, const char **changes, const char *final)
+void plugin_hook_db_sync(struct db *db)
 {
 	const struct plugin_hook *hook = &db_write_hook;
 	struct jsonrpc_request *req;
 	struct plugin_hook_request *ph_req;
 	void *ret;
 
+	const char **changes = db_changes(db);
 	if (!hook->plugin)
 		return;
 
@@ -177,8 +178,6 @@ void plugin_hook_db_sync(struct db *db, const char **changes, const char *final)
 	json_array_start(req->stream, "writes");
 	for (size_t i = 0; i < tal_count(changes); i++)
 		json_add_string(req->stream, NULL, changes[i]);
-	if (final)
-		json_add_string(req->stream, NULL, final);
 	json_array_end(req->stream);
 	jsonrpc_request_end(req);
 

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -175,6 +175,8 @@ void plugin_hook_db_sync(struct db *db)
 	ph_req->hook = hook;
 	ph_req->db = db;
 
+	json_add_num(req->stream, "data_version", db_data_version_get(db));
+
 	json_array_start(req->stream, "writes");
 	for (size_t i = 0; i < tal_count(changes); i++)
 		json_add_string(req->stream, NULL, changes[i]);

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -108,8 +108,7 @@ bool plugin_hook_unregister(struct plugin *plugin, const char *method);
 /* Unregister all hooks a plugin has registered for */
 void plugin_hook_unregister_all(struct plugin *plugin);
 
-/* Special sync plugin hook for db: changes[] are SQL statements, with optional
- * final command appended. */
-void plugin_hook_db_sync(struct db *db, const char **changes, const char *final);
+/* Special sync plugin hook for db. */
+void plugin_hook_db_sync(struct db *db);
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_HOOK_H */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -905,8 +905,6 @@ static void db_migrate(struct lightningd *ld, struct db *db)
 	int current, orig, available;
 	struct db_stmt *stmt;
 
-	db_begin_transaction(db);
-
 	orig = current = db_get_version(db);
 	available = ARRAY_SIZE(dbmigrations) - 1;
 
@@ -947,14 +945,18 @@ static void db_migrate(struct lightningd *ld, struct db *db)
 		tal_free(stmt);
 	}
 
-	db_commit_transaction(db);
 }
 
 struct db *db_setup(const tal_t *ctx, struct lightningd *ld)
 {
 	struct db *db = db_open(ctx, ld->wallet_dsn);
 	db->log = new_log(db, ld->log_book, NULL, "database");
+
+	db_begin_transaction(db);
+
 	db_migrate(ld, db);
+
+	db_commit_transaction(db);
 	return db;
 }
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -589,6 +589,7 @@ static struct migration dbmigrations[] = {
 	 " SELECT id, 11, local_feerate_per_kw FROM channels WHERE funder = 1 and local_feerate_per_kw != remote_feerate_per_kw;"),
      NULL},
     /* FIXME: Remove now-unused local_feerate_per_kw and remote_feerate_per_kw from channels */
+    {SQL("INSERT INTO vars (name, intval) VALUES ('data_version', 0);"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -764,7 +764,7 @@ static void db_report_changes(struct db *db, const char *final, size_t min)
 	assert(tal_count(db->changes) >= min);
 
 	if (tal_count(db->changes) > min)
-		plugin_hook_db_sync(db, db->changes, final);
+		plugin_hook_db_sync(db);
 	db->changes = tal_free(db->changes);
 }
 
@@ -1398,4 +1398,9 @@ void db_changes_add(struct db_stmt *stmt, const char * expanded)
 	}
 
 	tal_arr_expand(&db->changes, tal_strdup(db->changes, expanded));
+}
+
+const char **db_changes(struct db *db)
+{
+	return db->changes;
 }

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -224,4 +224,9 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
 #define db_prepare_v2(db,query)						\
 	db_prepare_v2_(__FILE__ ":" stringify(__LINE__), db, query)
 
+/**
+ * Access pending changes that have been added to the current transaction.
+ */
+const char **db_changes(struct db *db);
+
 #endif /* LIGHTNING_WALLET_DB_H */

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -229,4 +229,7 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
  */
 const char **db_changes(struct db *db);
 
+/* Get the current data version. */
+u32 db_data_version_get(struct db *db);
+
 #endif /* LIGHTNING_WALLET_DB_H */

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -34,6 +34,10 @@ struct db {
 	/* Were there any modifying statements in the current transaction?
 	 * Used to bump the data_version in the DB.*/
 	bool dirty;
+
+	/* The current DB version we expect to update if changes are
+	 * committed. */
+	u32 data_version;
 };
 
 struct db_query {

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -30,6 +30,10 @@ struct db {
 	char *error;
 
 	struct log *log;
+
+	/* Were there any modifying statements in the current transaction?
+	 * Used to bump the data_version in the DB.*/
+	bool dirty;
 };
 
 struct db_query {

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -73,8 +73,9 @@ static bool test_empty_db_migrate(struct lightningd *ld)
 	CHECK(db);
 	db_begin_transaction(db);
 	CHECK(db_get_version(db) == -1);
-	db_commit_transaction(db);
 	db_migrate(ld, db);
+	db_commit_transaction(db);
+
 	db_begin_transaction(db);
 	CHECK(db_get_version(db) == ARRAY_SIZE(dbmigrations) - 1);
 	db_commit_transaction(db);
@@ -118,9 +119,9 @@ static bool test_vars(struct lightningd *ld)
 	struct db *db = create_test_db();
 	char *varname = "testvar";
 	CHECK(db);
-	db_migrate(ld, db);
 
 	db_begin_transaction(db);
+	db_migrate(ld, db);
 	/* Check default behavior */
 	CHECK(db_get_intvar(db, varname, 42) == 42);
 

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -63,6 +63,7 @@ static struct db *create_test_db(void)
 
 	dsn = tal_fmt(NULL, "sqlite3://%s", filename);
 	db = db_open(NULL, dsn);
+	db->data_version = 0;
 	tal_free(dsn);
 	return db;
 }
@@ -107,6 +108,10 @@ static bool test_primitives(void)
 	CHECK_MSG(db_err, "Failing SQL command");
 	tal_free(stmt);
 	db_err = tal_free(db_err);
+
+	/* We didn't migrate the DB, so don't have the vars table. Pretend we
+	 * didn't change anything so we don't bump the data_version. */
+	db->dirty = false;
 	db_commit_transaction(db);
 	CHECK(!db->in_transaction);
 	tal_free(db);

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -47,7 +47,7 @@ static void db_test_fatal(const char *fmt, ...)
 	va_end(ap);
 }
 
-void plugin_hook_db_sync(struct db *db UNNEEDED, const char **changes UNNEEDED, const char *final UNNEEDED)
+void plugin_hook_db_sync(struct db *db UNNEEDED)
 {
 }
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -749,6 +749,7 @@ static struct wallet *create_test_wallet(struct lightningd *ld, const tal_t *ctx
 	CHECK_MSG(w->db, "Failed opening the db");
 	db_begin_transaction(w->db);
 	db_migrate(ld, w->db);
+	w->db->data_version = 0;
 	db_commit_transaction(w->db);
 	CHECK_MSG(!wallet_err, "DB migration failed");
 	w->max_channel_dbid = 0;

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -747,7 +747,9 @@ static struct wallet *create_test_wallet(struct lightningd *ld, const tal_t *ctx
 				  w->bip32_base) == WALLY_OK);
 
 	CHECK_MSG(w->db, "Failed opening the db");
+	db_begin_transaction(w->db);
 	db_migrate(ld, w->db);
+	db_commit_transaction(w->db);
 	CHECK_MSG(!wallet_err, "DB migration failed");
 	w->max_channel_dbid = 0;
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -650,7 +650,7 @@ u8 *wire_sync_read(const tal_t *ctx UNNEEDED, int fd UNNEEDED)
 {
 	return NULL;
 }
-void plugin_hook_db_sync(struct db *db UNNEEDED, const char **changes UNNEEDED, const char *final UNNEEDED)
+void plugin_hook_db_sync(struct db *db UNNEEDED)
 {
 }
 bool fromwire_hsm_get_channel_basepoints_reply(const void *p UNNEEDED,


### PR DESCRIPTION
Currently the `db_write` hook is a simple sink to which we write, but a plugin
has no way of telling whether there were any gaps or whether the `lightningd`
database lost some updates. This PR introduces a numeric `data_version` that
is incremented on any dirty transaction. A ditry transaction is a DB
transaction that performed some changes on the underlying database.

The `data_version` is guaranteed to change between successive changes, however
it does not guarantee monotonicity (i.e., it can wrap around at 2**32). Its
goal is to assert to a plugin that no changes to the DB have been performed by
c-lightning between successive calls to `db_write`. The `data_version`
persists across restarts so a plugin can check whether it matches a backup
after startup.

In addition this PR implements an optimistic locking strategy. The
`data_version` is incremented only if it matches what we expect from
startup. If it doesn't match we `abort()` since there might be another
instance writing to the database. This is not really important for `sqlite3`
which is already protected through the use of the pid file, but in `postgres`
we may not have such alternative protection mechanism against concurrent
instances.

It is not meant as a graceful shutdown, but rather a last resort protection. I
expect that some other locking mechanism is implemented in a wrapper for
c-lightning that'd start the instance only after acquiring ownership. As a
standalone though it should be sufficient to protect against concurrent
instances by serializing all write operations, and `abort()`ing the loser of
the write race.

As a minor detail the order in which the increment and the reporting is
currently done the plugin gets the version number after the transaction would
be applied, but that doesn't really matter, as long as the values differ
between calls.

The lock provides linearizability of DB modifications: if a database is
changed under the feet of a running process that process will `abort()`, which
from a global point of view is as if it had crashed right after the last
successful commit. Any process that also changed the DB must've started
between the last successful commit and the unsuccessful one since otherwise
its counters would not have matched (which would also have aborted that
transaction). So this reduces all the possible timelines to an equivalent
where the first process died, and the second process recovered from the DB.
