### PR TITLE
fix: normalize pip requirements

### DIFF
--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -55,7 +55,7 @@ RUN pip3 install --upgrade pip && \
     python3 -m pip install \
 	CherryPy==17.3.0 \
 	Flask==1.0.2 \
-	cheroot==6.5.2 \
+	cheroot==8.2.1 \
 	ephemeral-port-reserve==1.1.0 \
 	flaky==3.4.0 \
 	pytest-benchmark==3.1.1 \
@@ -63,7 +63,7 @@ RUN pip3 install --upgrade pip && \
 	pytest-timeout==1.3.3 \
 	pytest-xdist==1.22.2 \
 	pytest==3.8.1 \
-	python-bitcoinlib==0.7.0 \
+	python-bitcoinlib==0.10.2 \
 	tqdm==4.26.0 \
 	pytest-test-groups==1.0.3 \
 	flake8==3.5.0 \

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -33,4 +33,4 @@ RUN wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_
     rm -rf bitcoin.tar.gz bitcoin-$BITCOIN_VERSION
 
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.7.0 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0
+    python3 -m pip install python-bitcoinlib==0.10.2 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -55,7 +55,7 @@ RUN pip3 install --upgrade pip && \
     python3 -m pip install \
 	CherryPy==17.3.0 \
 	Flask==1.0.2 \
-	cheroot==6.5.2 \
+	cheroot==8.2.1 \
 	ephemeral-port-reserve==1.1.0 \
 	flaky==3.4.0 \
 	pytest-benchmark==3.1.1 \
@@ -63,7 +63,7 @@ RUN pip3 install --upgrade pip && \
 	pytest-timeout==1.3.3 \
 	pytest-xdist==1.22.2 \
 	pytest==3.8.1 \
-	python-bitcoinlib==0.7.0 \
+	python-bitcoinlib==0.10.2 \
 	tqdm==4.26.0 \
 	pytest-test-groups==1.0.3 \
 	flake8==3.5.0 \

--- a/contrib/pyln-testing/requirements.txt
+++ b/contrib/pyln-testing/requirements.txt
@@ -1,6 +1,6 @@
-pytest==5.0.1
+pytest==5.3.1
 Flask==1.1.1
-cheroot==6.5.5
+cheroot==8.2.1
 ephemeral-port-reserve==1.1.1
-python-bitcoinlib==0.10.1
+python-bitcoinlib==0.10.2
 psycopg2-binary==2.8.4


### PR DESCRIPTION
This will change some `requirements.txt` of pyln-testing in a way that
it does not require different package version i.e. to `tests/requirements.txt`.

The reason for this is that users are not forced to hassle with pyenv
or virtualenv and could just use `--user`.

```bash
pip install --user -r tests/requirements.txt -r contrib/pyln-testing/requirements.txt  # ...
```

Changelog-None