### PR TITLE
Update bitcoin-core version

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -21,10 +21,10 @@ mkdir -p dependencies/bin || true
 
 # Download bitcoind and bitcoin-cli 
 if [ ! -f dependencies/bin/bitcoind ]; then
-    wget https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
-    tar -xzf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
-    mv bitcoin-0.17.1/bin/* dependencies/bin
-    rm -rf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz bitcoin-0.17.1
+    wget https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-x86_64-linux-gnu.tar.gz
+    tar -xzf bitcoin-0.18.1-x86_64-linux-gnu.tar.gz
+    mv bitcoin-0.18.1/bin/* dependencies/bin
+    rm -rf bitcoin-0.18.1-x86_64-linux-gnu.tar.gz bitcoin-0.18.1
 fi
 
 pyenv global 3.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget -qO /opt/tini "https://github.com/krallin/tini/releases/download/v0.18.
     && echo "12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855 /opt/tini" | sha256sum -c - \
     && chmod +x /opt/tini
 
-ARG BITCOIN_VERSION=0.17.0
+ARG BITCOIN_VERSION=0.18.1
 ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc

--- a/contrib/Dockerfile.builder
+++ b/contrib/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.17.0
+ENV BITCOIN_VERSION 0.18.1
 
 WORKDIR /build
 

--- a/contrib/Dockerfile.builder.fedora
+++ b/contrib/Dockerfile.builder.fedora
@@ -1,6 +1,6 @@
 FROM fedora:29
 
-ENV BITCOIN_VERSION 0.17.0
+ENV BITCOIN_VERSION 0.18.1
 WORKDIR /tmp
 
 RUN dnf update -y && \

--- a/contrib/Dockerfile.builder.i386
+++ b/contrib/Dockerfile.builder.i386
@@ -2,7 +2,7 @@ FROM i386/ubuntu:16.04
 MAINTAINER Christian Decker <decker.christian@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.17.0
+ENV BITCOIN_VERSION 0.18.1
 
 WORKDIR /build
 

--- a/contrib/linuxarm32v7.Dockerfile
+++ b/contrib/linuxarm32v7.Dockerfile
@@ -18,7 +18,7 @@ RUN wget -qO /opt/tini "https://github.com/krallin/tini/releases/download/v0.18.
     && echo "01b54b934d5f5deb32aa4eb4b0f71d0e76324f4f0237cc262d59376bf2bdc269 /opt/tini" | sha256sum -c - \
     && chmod +x /opt/tini
 
-ARG BITCOIN_VERSION=0.17.0
+ARG BITCOIN_VERSION=0.18.1
 ENV BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION-arm-linux-gnueabihf.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc

--- a/contrib/linuxarm64v8.Dockerfile
+++ b/contrib/linuxarm64v8.Dockerfile
@@ -18,7 +18,7 @@ RUN wget -qO /opt/tini "https://github.com/krallin/tini/releases/download/v0.18.
     && echo "7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019 /opt/tini" | sha256sum -c - \
     && chmod +x /opt/tini
 
-ARG BITCOIN_VERSION=0.17.0
+ARG BITCOIN_VERSION=0.18.1
 ENV BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION-aarch64-linux-gnu.tar.gz
 ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
 ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS.asc


### PR DESCRIPTION
Bitcoin-core v0.18.X is now the more widely used, so seems better to run the tests again this version ?

source: https://luke.dashjr.org/programs/bitcoin/files/charts/software.html

Changelog-None