### PR TITLE
connectd: check all chain hashs of the network array in `init`

### DIFF
--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -79,7 +79,9 @@ static struct io_plan *peer_init_received(struct io_conn *conn,
 			status_peer_debug(&peer->id,
 			                  "No common chain with this peer '%s', closing",
 			                  tal_hex(tmpctx, msg));
-			return io_close(conn);
+			msg = towire_errorfmt(NULL, NULL, "No common network");
+			msg = cryptomsg_encrypt_msg(NULL, &peer->cs, take(msg));
+			return io_write(conn, msg, tal_count(msg), io_close_cb, NULL);
 		}
 	}
 

--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -75,12 +75,6 @@ static struct io_plan *peer_init_received(struct io_conn *conn,
 	 *    - MAY fail the connection.
 	 */
 	if (tlvs->networks) {
-		if (!tlvs->networks->chains) {
-			status_peer_debug(&peer->id,
-			                  "bad networks TLV in init '%s', closing",
-			                  tal_hex(tmpctx, msg));
-			return io_close(conn);
-		}
 		if (!contains_common_chain(tlvs->networks->chains)) {
 			status_peer_debug(&peer->id,
 			                  "No common chain with this peer '%s', closing",

--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -30,7 +30,7 @@ struct peer {
 static bool contains_common_chain(struct bitcoin_blkid *chains)
 {
 	for (size_t i = 0; i < tal_count(chains); i++) {
-		if (bitcoin_blkid_eq(&chains[0], &chainparams->genesis_blockhash))
+		if (bitcoin_blkid_eq(&chains[i], &chainparams->genesis_blockhash))
 			return true;
 	}
 	return false;


### PR DESCRIPTION
As per https://github.com/lightningnetwork/lightning-rfc/pull/682#issuecomment-566066644.

We would always check against the first element of the array.. Once again my bad.

This also cleans up a redundant check as [pointed out](https://github.com/ElementsProject/lightning/pull/3300#discussion_r352380389) by @rustyrussell.

Changelog-None