### PR TITLE
lightningd: Added --alt-subdaemon command to allow alternate subdaemons.

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -126,8 +126,7 @@ by \fI--conf\fR\.
  \fBalt-subdaemon\fR=\fISUBDAEMON\fR:\fIPATH\fR
 Specifies an alternate subdaemon binary\.  If the supplied path
 is relative the subdaemon binary is found in the working directory\.
-This option may be specified multiple times, but only once for
-each subdaemon\.
+This option may be specified multiple times\.
 
 
  So, \fBalt-subdaemon=lightning_hsmd:remote_signer\fR would use a

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -123,6 +123,18 @@ is only valid on the command-line, or in a configuration file specified
 by \fI--conf\fR\.
 
 
+ \fBalt-subdaemon\fR=\fISUBDAEMON\fR:\fIPATH\fR
+Specifies an alternate subdaemon binary\.  If the supplied path
+is relative the subdaemon binary is found in the working directory\.
+This option may be specified multiple times, but only once for
+each subdaemon\.
+
+
+ So, \fBalt-subdaemon=lightning_hsmd:remote_signer\fR would use a
+hypothetical remote signing proxy instead of the standard \fIlightning_hsmd\fR
+binary\.
+
+
  \fBpid-file\fR=\fIPATH\fR
 Specify pid file to write to\.
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -125,13 +125,13 @@ by \fI--conf\fR\.
 
  \fBsubdaemon\fR=\fISUBDAEMON\fR:\fIPATH\fR
 Specifies an alternate subdaemon binary\.
-Current subdaemons are \fIchannel\fR, \fIclosing\fR,
-\fIconnect\fR, \fIgossip\fR, \fIhsm\fR, \fIonchain\fR, and \fIopening\fR\.
+Current subdaemons are \fIchanneld\fR, \fIclosingd\fR,
+\fIconnectd\fR, \fIgossipd\fR, \fIhsmd\fR, \fIonchaind\fR, and \fIopeningd\fR\.
 If the supplied path is relative the subdaemon binary is found in the
 working directory\. This option may be specified multiple times\.
 
 
- So, \fBsubdaemon=lightning_hsmd:remote_signer\fR would use a
+ So, \fBsubdaemon=hsmd:remote_signer\fR would use a
 hypothetical remote signing proxy instead of the standard \fIlightning_hsmd\fR
 binary\.
 

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -123,13 +123,15 @@ is only valid on the command-line, or in a configuration file specified
 by \fI--conf\fR\.
 
 
- \fBalt-subdaemon\fR=\fISUBDAEMON\fR:\fIPATH\fR
-Specifies an alternate subdaemon binary\.  If the supplied path
-is relative the subdaemon binary is found in the working directory\.
-This option may be specified multiple times\.
+ \fBsubdaemon\fR=\fISUBDAEMON\fR:\fIPATH\fR
+Specifies an alternate subdaemon binary\.
+Current subdaemons are \fIchannel\fR, \fIclosing\fR,
+\fIconnect\fR, \fIgossip\fR, \fIhsm\fR, \fIonchain\fR, and \fIopening\fR\.
+If the supplied path is relative the subdaemon binary is found in the
+working directory\. This option may be specified multiple times\.
 
 
- So, \fBalt-subdaemon=lightning_hsmd:remote_signer\fR would use a
+ So, \fBsubdaemon=lightning_hsmd:remote_signer\fR would use a
 hypothetical remote signing proxy instead of the standard \fIlightning_hsmd\fR
 binary\.
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -107,6 +107,16 @@ Sets the working directory. All files (except *--conf* and
 is only valid on the command-line, or in a configuration file specified
 by *--conf*.
 
+ **alt-subdaemon**=*SUBDAEMON*:*PATH*
+Specifies an alternate subdaemon binary.  If the supplied path
+is relative the subdaemon binary is found in the working directory.
+This option may be specified multiple times, but only once for
+each subdaemon.
+
+ So, **alt-subdaemon=lightning_hsmd:remote_signer** would use a
+hypothetical remote signing proxy instead of the standard *lightning_hsmd*
+binary.
+
  **pid-file**=*PATH*
 Specify pid file to write to.
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -110,8 +110,7 @@ by *--conf*.
  **alt-subdaemon**=*SUBDAEMON*:*PATH*
 Specifies an alternate subdaemon binary.  If the supplied path
 is relative the subdaemon binary is found in the working directory.
-This option may be specified multiple times, but only once for
-each subdaemon.
+This option may be specified multiple times.
 
  So, **alt-subdaemon=lightning_hsmd:remote_signer** would use a
 hypothetical remote signing proxy instead of the standard *lightning_hsmd*

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -109,12 +109,12 @@ by *--conf*.
 
  **subdaemon**=*SUBDAEMON*:*PATH*
 Specifies an alternate subdaemon binary.
-Current subdaemons are *channel*, *closing*,
-*connect*, *gossip*, *hsm*, *onchain*, and *opening*.
+Current subdaemons are *channeld*, *closingd*,
+*connectd*, *gossipd*, *hsmd*, *onchaind*, and *openingd*.
 If the supplied path is relative the subdaemon binary is found in the
 working directory. This option may be specified multiple times.
 
- So, **subdaemon=lightning_hsmd:remote_signer** would use a
+ So, **subdaemon=hsmd:remote_signer** would use a
 hypothetical remote signing proxy instead of the standard *lightning_hsmd*
 binary.
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -107,12 +107,14 @@ Sets the working directory. All files (except *--conf* and
 is only valid on the command-line, or in a configuration file specified
 by *--conf*.
 
- **alt-subdaemon**=*SUBDAEMON*:*PATH*
-Specifies an alternate subdaemon binary.  If the supplied path
-is relative the subdaemon binary is found in the working directory.
-This option may be specified multiple times.
+ **subdaemon**=*SUBDAEMON*:*PATH*
+Specifies an alternate subdaemon binary.
+Current subdaemons are *channel*, *closing*,
+*connect*, *gossip*, *hsm*, *onchain*, and *opening*.
+If the supplied path is relative the subdaemon binary is found in the
+working directory. This option may be specified multiple times.
 
- So, **alt-subdaemon=lightning_hsmd:remote_signer** would use a
+ So, **subdaemon=lightning_hsmd:remote_signer** would use a
 hypothetical remote signing proxy instead of the standard *lightning_hsmd*
 binary.
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -57,6 +57,7 @@
 /*~ This is common code: routines shared by one or more executables
  *  (separate daemons, or the lightning-cli program). */
 #include <common/daemon.h>
+#include <common/memleak.h>
 #include <common/timeout.h>
 #include <common/utils.h>
 #include <common/version.h>

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -72,6 +72,7 @@
 #include <lightningd/io_loop_with_timers.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/log.h>
+#include <lightningd/memdump.h>
 #include <lightningd/onchain_control.h>
 #include <lightningd/options.h>
 #include <onchaind/onchain_wire.h>
@@ -329,7 +330,7 @@ const char *subdaemon_path(const struct lightningd *ld, const char *name)
 	const char *alt = strmap_get(&ld->alt_subdaemons, name);
 	if (alt) {
 		/* Is the alternate path absolute? */
-		if (alt[0] == '/')
+		if (path_is_abs(alt))
 			dpath = tal_strdup(tmpctx, alt);
 		else
 			dpath = path_join(tmpctx, ld->daemon_dir, alt);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -320,8 +320,7 @@ const char *subdaemon_path(const tal_t *ctx, const struct lightningd *ld, const 
 	 */
 	size_t pfxlen = strlen("lightning_");
 	assert(strlen(name) > pfxlen);
-	const char *short_name =
-		tal_strndup(ctx, name + pfxlen, strlen(name) - pfxlen);
+	const char *short_name = tal_strdup(ctx, name + pfxlen);
 
 	/* Is there an alternate path for this subdaemon? */
 	const char *dpath;

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -291,12 +291,12 @@ static const char *subdaemons[] = {
 	"lightning_openingd"
 };
 
-/* Return true if called with a recognized subdaemon e.g. "hsm" */
+/* Return true if called with a recognized subdaemon e.g. "hsmd" */
 bool is_subdaemon(const char *sdname)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(subdaemons); i++)
 		/* Skip the "lightning_" prefix in the table */
-		if (strncmp(sdname, subdaemons[i] + 10, strlen(sdname)) == 0)
+		if (streq(sdname, subdaemons[i] + strlen("lightning_")))
 			return true;
 	return false;
 }
@@ -316,11 +316,12 @@ static void memleak_help_alt_subdaemons(struct htable *memtable,
 
 const char *subdaemon_path(const tal_t *ctx, const struct lightningd *ld, const char *name)
 {
-	/* Strip the leading "lightning_" and following 'd' before looking
-	 * in alt_subdaemons
+	/* Strip the leading "lightning_" before looking in alt_subdaemons.
 	 */
-	assert(strlen(name) > 10 + 1);	/* len("lightning_") + len("d") */
-	const char *short_name = tal_strndup(ctx, name + 10, strlen(name) - 11);
+	size_t pfxlen = strlen("lightning_");
+	assert(strlen(name) > pfxlen);
+	const char *short_name =
+		tal_strndup(ctx, name + pfxlen, strlen(name) - pfxlen);
 
 	/* Is there an alternate path for this subdaemon? */
 	const char *dpath;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -270,7 +270,7 @@ extern bool tal_oom_ok;
 bool is_subdaemon(const char *sdname);
 
 /* Returns the path to the subdaemon. Considers alternate subdaemon paths. */
-const char *subdaemon_path(const struct lightningd *ld, const char *name);
+const char *subdaemon_path(const tal_t *ctx, const struct lightningd *ld, const char *name);
 
 /* Check we can run subdaemons, and check their versions */
 void test_subdaemons(const struct lightningd *ld);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -4,6 +4,7 @@
 #include <bitcoin/chainparams.h>
 #include <bitcoin/privkey.h>
 #include <ccan/container_of/container_of.h>
+#include <ccan/strmap/strmap.h>
 #include <ccan/time/time.h>
 #include <ccan/timer/timer.h>
 #include <lightningd/htlc_end.h>
@@ -257,11 +258,19 @@ struct lightningd {
 
 	/* Outstanding waitblockheight commands.  */
 	struct list_head waitblockheight_commands;
+
+	STRMAP(const char *) alt_subdaemons;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.
  * Use only on carefully tested code! */
 extern bool tal_oom_ok;
+
+/* Return true if called with a recognized subdaemon, eg: "lightning_hsmd" */
+bool is_subdaemon(const char *sdname);
+
+/* Returns the path to the subdaemon. Considers alternate subdaemon paths. */
+const char *subdaemon_path(const struct lightningd *ld, const char *name);
 
 /* Check we can run subdaemons, and check their versions */
 void test_subdaemons(const struct lightningd *ld);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -78,6 +78,8 @@ struct config {
 	struct secret *keypass;
 };
 
+typedef STRMAP(const char *) alt_subdaemon_map;
+
 struct lightningd {
 	/* The directory to find all the subdaemons. */
 	const char *daemon_dir;
@@ -259,7 +261,7 @@ struct lightningd {
 	/* Outstanding waitblockheight commands.  */
 	struct list_head waitblockheight_commands;
 
-	STRMAP(const char *) alt_subdaemons;
+	alt_subdaemon_map alt_subdaemons;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -266,7 +266,7 @@ struct lightningd {
  * Use only on carefully tested code! */
 extern bool tal_oom_ok;
 
-/* Return true if called with a recognized subdaemon, eg: "lightning_hsmd" */
+/* Returns true if called with a recognized subdaemon, eg: "lightning_hsmd" */
 bool is_subdaemon(const char *sdname);
 
 /* Returns the path to the subdaemon. Considers alternate subdaemon paths. */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -268,7 +268,7 @@ struct lightningd {
  * Use only on carefully tested code! */
 extern bool tal_oom_ok;
 
-/* Returns true if called with a recognized subdaemon, eg: "lightning_hsmd" */
+/* Returns true if called with a recognized subdaemon, eg: "hsm" */
 bool is_subdaemon(const char *sdname);
 
 /* Returns the path to the subdaemon. Considers alternate subdaemon paths. */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -268,7 +268,7 @@ struct lightningd {
  * Use only on carefully tested code! */
 extern bool tal_oom_ok;
 
-/* Returns true if called with a recognized subdaemon, eg: "hsm" */
+/* Returns true if called with a recognized subdaemon, eg: "hsmd" */
 bool is_subdaemon(const char *sdname);
 
 /* Returns the path to the subdaemon. Considers alternate subdaemon paths. */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -235,7 +235,8 @@ static char *opt_alt_subdaemon(const char *arg, struct lightningd *ld)
 	subdaemon = tal_strdup(ld, argbuf);
 
 	/* Remove any preexisting alt subdaemon mapping. */
-	prevname = strmap_del(&ld->alt_subdaemons, subdaemon, (const char **) &prevval);
+	prevname = strmap_del(&ld->alt_subdaemons, subdaemon,
+			      (const char **) &prevval);
 	if (prevname) {
 		tal_free(prevname);
 		tal_free(prevval);

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -217,7 +217,7 @@ static char *opt_add_addr(const char *arg, struct lightningd *ld)
 
 static char *opt_alt_subdaemon(const char *arg, struct lightningd *ld)
 {
-	/* example arg: "hsmd:rmthsmd" */
+	/* example arg: "lightning_hsmd:remote_hsmd" */
 	char *argbuf = tal_strdup(ld, arg);
 	char *colon = strchr(argbuf, ':');
 	if (!colon)

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -217,32 +217,21 @@ static char *opt_add_addr(const char *arg, struct lightningd *ld)
 
 static char *opt_alt_subdaemon(const char *arg, struct lightningd *ld)
 {
-	// example arg: "hsmd:rmthsmd"
+	/* example arg: "hsmd:rmthsmd" */
 	char *argbuf = tal_strdup(ld, arg);
 	char *colon = strchr(argbuf, ':');
 	if (!colon)
-	{
-		tal_free(argbuf);
 		return tal_fmt(NULL, "argument must contain \':\'");
-	}
 	*colon = '\0';
 
 	if (!is_subdaemon(argbuf))
-	{
-		char *ret = tal_fmt(NULL, "%s is not a subdaemon", argbuf);
-		tal_free(argbuf);
-		return ret;
-	}
+		return tal_fmt(NULL, "%s is not a subdaemon", argbuf);
+
 	char *subdaemon = tal_strdup(ld, argbuf);
 	char *sdpath = tal_strdup(ld, colon+1);
 	if (!strmap_add(&ld->alt_subdaemons, subdaemon, sdpath))
-	{
-		tal_free(sdpath);
-		tal_free(subdaemon);
-		char *ret = tal_fmt(NULL, "%s already exists", argbuf);
-		tal_free(argbuf);
-		return ret;
-	}
+		return tal_fmt(NULL, "%s already exists", argbuf);
+
 	tal_free(argbuf);
 	return NULL;
 }

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -215,6 +215,38 @@ static char *opt_add_addr(const char *arg, struct lightningd *ld)
 	return opt_add_addr_withtype(arg, ld, ADDR_LISTEN_AND_ANNOUNCE, true);
 }
 
+static char *opt_alt_subdaemon(const char *arg, struct lightningd *ld)
+{
+	// example arg: "hsmd:rmthsmd"
+	char *argbuf = tal_strdup(ld, arg);
+	char *colon = strchr(argbuf, ':');
+	if (!colon)
+	{
+		tal_free(argbuf);
+		return tal_fmt(NULL, "argument must contain \':\'");
+	}
+	*colon = '\0';
+
+	if (!is_subdaemon(argbuf))
+	{
+		char *ret = tal_fmt(NULL, "%s is not a subdaemon", argbuf);
+		tal_free(argbuf);
+		return ret;
+	}
+	char *subdaemon = tal_strdup(ld, argbuf);
+	char *sdpath = tal_strdup(ld, colon+1);
+	if (!strmap_add(&ld->alt_subdaemons, subdaemon, sdpath))
+	{
+		tal_free(sdpath);
+		tal_free(subdaemon);
+		char *ret = tal_fmt(NULL, "%s already exists", argbuf);
+		tal_free(argbuf);
+		return ret;
+	}
+	tal_free(argbuf);
+	return NULL;
+}
+
 static char *opt_add_bind_addr(const char *arg, struct lightningd *ld)
 {
 	struct wireaddr_internal addr;
@@ -878,6 +910,16 @@ static void register_opts(struct lightningd *ld)
 			 &ld->rpc_filemode,
 			 "Set the file mode (permissions) for the "
 			 "JSON-RPC socket");
+
+	opt_register_arg("--alt-subdaemon", opt_alt_subdaemon, NULL,
+			 ld, "Arg specified as SUBDAEMON:PATH. "
+			 "Specifies an alternate subdaemon binary. "
+			 "If the supplied path is relative the subdaemon "
+			 "binary is found in the working directory. "
+			 "This option may be specified multiple times, "
+			 "but only once for each subdaemon. For example, "
+			 "--alt-subdaemon=lightning_hsmd:remote_signer "
+			 "would use a hypothetical remote signing subdaemon.");
 
 	opt_register_logging(ld);
 	opt_register_version();

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -220,7 +220,7 @@ static char *opt_subdaemon(const char *arg, struct lightningd *ld)
 	char *subdaemon;
 	char *sdpath;
 
-	/* example arg: "hsm:remote_hsmd" */
+	/* example arg: "hsmd:remote_hsmd" */
 
 	size_t colonoff = strcspn(arg, ":");
 	if (!arg[colonoff])
@@ -913,7 +913,7 @@ static void register_opts(struct lightningd *ld)
 			 "binary is found in the working directory. "
 			 "This option may be specified multiple times. "
 			 "For example, "
-			 "--subdaemon=hsm:remote_signer "
+			 "--subdaemon=hsmd:remote_signer "
 			 "would use a hypothetical remote signing subdaemon.");
 
 	opt_register_logging(ld);

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -215,12 +215,12 @@ static char *opt_add_addr(const char *arg, struct lightningd *ld)
 	return opt_add_addr_withtype(arg, ld, ADDR_LISTEN_AND_ANNOUNCE, true);
 }
 
-static char *opt_alt_subdaemon(const char *arg, struct lightningd *ld)
+static char *opt_subdaemon(const char *arg, struct lightningd *ld)
 {
 	char *subdaemon;
 	char *sdpath;
 
-	/* example arg: "lightning_hsmd:remote_hsmd" */
+	/* example arg: "hsm:remote_hsmd" */
 
 	size_t colonoff = strcspn(arg, ":");
 	if (!arg[colonoff])
@@ -906,14 +906,14 @@ static void register_opts(struct lightningd *ld)
 			 "Set the file mode (permissions) for the "
 			 "JSON-RPC socket");
 
-	opt_register_arg("--alt-subdaemon", opt_alt_subdaemon, NULL,
+	opt_register_arg("--subdaemon", opt_subdaemon, NULL,
 			 ld, "Arg specified as SUBDAEMON:PATH. "
 			 "Specifies an alternate subdaemon binary. "
 			 "If the supplied path is relative the subdaemon "
 			 "binary is found in the working directory. "
 			 "This option may be specified multiple times. "
 			 "For example, "
-			 "--alt-subdaemon=lightning_hsmd:remote_signer "
+			 "--subdaemon=hsm:remote_signer "
 			 "would use a hypothetical remote signing subdaemon.");
 
 	opt_register_logging(ld);
@@ -1179,9 +1179,9 @@ static bool json_add_opt_alt_subdaemon(const char *member,
 	return true;
 }
 
-static void json_add_opt_alt_subdaemons(struct json_stream *response,
-					const char *name0,
-					alt_subdaemon_map *alt_subdaemons)
+static void json_add_opt_subdaemons(struct json_stream *response,
+				    const char *name0,
+				    alt_subdaemon_map *alt_subdaemons)
 {
 	struct json_add_opt_alt_subdaemon_args args;
 	args.name0 = name0;
@@ -1283,8 +1283,8 @@ static void add_config(struct lightningd *ld,
 					   ld->proposed_listen_announce,
 					   ADDR_ANNOUNCE);
 			return;
-		} else if (opt->cb_arg == (void *)opt_alt_subdaemon) {
-			json_add_opt_alt_subdaemons(response, name0,
+		} else if (opt->cb_arg == (void *)opt_subdaemon) {
+			json_add_opt_subdaemons(response, name0,
 						    &ld->alt_subdaemons);
 			return;
 		} else if (opt->cb_arg == (void *)opt_add_proxy_addr) {

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -649,7 +649,7 @@ static struct subd *new_subd(struct lightningd *ld,
 	disconnect_fd = ld->dev_disconnect_fd;
 #endif /* DEVELOPER */
 
-	const char *path = subdaemon_path(ld, name);
+	const char *path = subdaemon_path(tmpctx, ld, name);
 
 	sd->pid = subd(path, name, debug_subd,
 		       &msg_fd, disconnect_fd,

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -136,7 +136,7 @@ static void close_taken_fds(va_list *ap)
 }
 
 /* We use sockets, not pipes, because fds are bidir. */
-static int subd(const char *dir, const char *name,
+static int subd(const char *path, const char *name,
 		const char *debug_subdaemon,
 		int *msgfd, int dev_disconnect_fd,
 		bool io_logging,
@@ -202,7 +202,7 @@ static int subd(const char *dir, const char *name,
 				close(i);
 
 		num_args = 0;
-		args[num_args++] = path_join(NULL, dir, name);
+		args[num_args++] = tal_strdup(NULL, path);
 		if (io_logging)
 			args[num_args++] = "--log-io";
 #if DEVELOPER
@@ -649,7 +649,9 @@ static struct subd *new_subd(struct lightningd *ld,
 	disconnect_fd = ld->dev_disconnect_fd;
 #endif /* DEVELOPER */
 
-	sd->pid = subd(ld->daemon_dir, name, debug_subd,
+	const char *path = subdaemon_path(ld, name);
+
+	sd->pid = subd(path, name, debug_subd,
 		       &msg_fd, disconnect_fd,
 		       /* We only turn on subdaemon io logging if we're going
 			* to print it: too stressful otherwise! */

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -133,6 +133,9 @@ bool log_status_msg(struct log *log UNNEEDED,
  		    const struct node_id *node_id UNNEEDED,
 		    const u8 *msg UNNEEDED)
 { fprintf(stderr, "log_status_msg called!\n"); abort(); }
+/* Generated stub for memleak_remove_strmap_ */
+void memleak_remove_strmap_(struct htable *memtable UNNEEDED, const struct strmap *m UNNEEDED)
+{ fprintf(stderr, "memleak_remove_strmap_ called!\n"); abort(); }
 /* Generated stub for new_log */
 struct log *new_log(const tal_t *ctx UNNEEDED, struct log_book *record UNNEEDED,
 		    const struct node_id *default_node_id UNNEEDED,


### PR DESCRIPTION
This PR adds --alt-subdaemon to facilitate substituting a standard subdaemon with an alternate.

Examples:

    # Use remote_hsmd instead of lightning_hsmd for signing:
    lightningd --alt-subdaemon=lightning_hsmd:remote_hsmd ...

    # Same as previous but daemon is located w/ absolute path:
    lightningd --alt-subdaemon=lightning_hsmd:/some/where/remote_hsmd ...
