### PR TITLE
plugin_control: more descriptive key for 'plugin stop' result

### DIFF
--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -1,3 +1,4 @@
+#include <lightningd/options.h>
 #include <lightningd/plugin_control.h>
 #include <lightningd/plugin_hook.h>
 
@@ -206,7 +207,11 @@ plugin_dynamic_stop(struct command *cmd, const char *plugin_name)
 			plugin_kill(p, "%s stopped by lightningd via RPC", plugin_name);
 			tal_free(p);
 			response = json_stream_success(cmd);
-			json_add_string(response, "",
+			if (deprecated_apis)
+				json_add_string(response, "",
+			                    take(tal_fmt(NULL, "Successfully stopped %s.",
+			                                 plugin_name)));
+			json_add_string(response, "result",
 			                take(tal_fmt(NULL, "Successfully stopped %s.",
 			                             plugin_name)));
 			return command_success(cmd, response);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -127,14 +127,16 @@ def test_plugin_command(node_factory):
     n.rpc.plugin_list()
 
     # Make sure the plugin behaves normally after stop and restart
-    assert("Successfully stopped helloworld.py." == n.rpc.plugin_stop(plugin="helloworld.py")[''])
+    assert("Successfully stopped helloworld.py."
+           == n.rpc.plugin_stop(plugin="helloworld.py")["result"])
     n.daemon.wait_for_log(r"Killing plugin: helloworld.py")
     n.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "contrib/plugins/helloworld.py"))
     n.daemon.wait_for_log(r"Plugin helloworld.py initialized")
     assert("Hello world" == n.rpc.call(method="hello"))
 
     # Now stop the helloworld plugin
-    assert("Successfully stopped helloworld.py." == n.rpc.plugin_stop(plugin="helloworld.py")[''])
+    assert("Successfully stopped helloworld.py."
+           == n.rpc.plugin_stop(plugin="helloworld.py")["result"])
     n.daemon.wait_for_log(r"Killing plugin: helloworld.py")
     # Make sure that the 'hello' command from the helloworld.py plugin
     # is not available anymore.


### PR DESCRIPTION
I found the json output
```
{
   "": "Successfully stopped reckless.py."
}
```
a bit weird.