### PR TITLE
"plugin start": spawn plugin processes with a non-0 umask

### DIFF
--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -249,6 +249,8 @@ struct lightningd {
 	char *wallet_dsn;
 
 	bool encrypted_hsm;
+
+	mode_t initial_umask;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.


### PR DESCRIPTION
Since they are currently spawned with a umask of 0 (set when daemonizing), plugins will create files with 666 and directory with 777 permissions. This might not be a big deal but `22` may be a more expected default for plugin developers ?