### PR TITLE
Do not move the socket file during migration

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -881,6 +881,7 @@ static void promote_missing_files(struct lightningd *ld)
 		if (streq(d->d_name, ".")
 		    || streq(d->d_name, "..")
 		    || streq(d->d_name, "config")
+		    || streq(d->d_name, "lightning-rpc")
 		    || strends(d->d_name, ".pid"))
 			continue;
 


### PR DESCRIPTION
While no side effect, it confused me a lot on #3378 