### PR TITLE
pytest: test lightning-rpc path after migration

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1914,6 +1914,10 @@ def test_testnet_upgrade(node_factory):
     assert not os.path.isfile(os.path.join(netdir, "config"))
     assert os.path.isfile(os.path.join(basedir, "config"))
 
+    # The RPC socket should now be created in <lightning_dir>/<netdir>
+    assert "lightning-rpc" in os.listdir(netdir)
+    assert "lightning-rpc" not in os.listdir(basedir)
+
     restore_valgrind(l1, netdir)
 
 
@@ -1959,6 +1963,10 @@ def test_regtest_upgrade(node_factory):
     assert os.path.isfile(os.path.join(basedir, "lightningd-{}.pid".format(TEST_NETWORK)))
     assert not os.path.isfile(os.path.join(netdir, "config"))
     assert os.path.isfile(os.path.join(basedir, "config"))
+
+    # The RPC socket should now be created in <lightning_dir>/<netdir>
+    assert "lightning-rpc" in os.listdir(netdir)
+    assert "lightning-rpc" not in os.listdir(basedir)
 
     # Should restart fine
     l1.restart()


### PR DESCRIPTION
This is a formalisation of the behavior observed by @NicolasDorier in #3378. The `lightning-rpc` socket is not created in the same path for each network: hence one of this tests pass (`regtest`), not the other one (`testnet`).