### PR TITLE
build: fix version extraction from non-git directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #! /usr/bin/make
 
 # Extract version from git, or if we're from a zipfile, use dirname
-VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's,.*/clightning-\(v[0-9.rc]*\)$$,\1,p')
+VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc]*\)$$|\1|gp')
 
 ifeq ($(VERSION),)
 $(error "ERROR: git is required for generating version information")


### PR DESCRIPTION
https://github.com/ElementsProject/lightning/releases/download/v0.8.0/clightning-v0.8.0.zip
extracts into "clightning-v0.8.0".

https://github.com/ElementsProject/lightning/archive/v0.8.0.tar.gz
extracts into "lightning-0.8.0".

Tweak the regular expression in the Makefile to support both (extract
0.8.0 from either one). Also, downloading an arbitrary version, based on
git commit id:

https://codeload.github.com/ElementsProject/lightning/tar.gz/eb2b225c?dummy=/filename_this_is_irrelevant.tar.gz
extracts into "lightning-eb2b225c".

so, support extracting "eb2b225c" from that.

Changelog-None