### PR TITLE
txprepare fixes

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -990,7 +990,7 @@ class LightningRpc(UnixDomainSocketRpc):
         if 'destination' in kwargs or 'satoshi' in kwargs:
             return self._deprecated_txprepare(*args, **kwargs)
 
-        if not isinstance(args[0], list):
+        if len(args) and not isinstance(args[0], list):
             return self._deprecated_txprepare(*args, **kwargs)
 
         def _txprepare(outputs, feerate=None, minconf=None, utxos=None):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -277,7 +277,7 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     bitcoind.generate_block(1)
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 10)
 
-    prep = l1.rpc.txprepare([{addr: Millisatoshi(amount * 3 * 1000)}])
+    prep = l1.rpc.txprepare(outputs=[{addr: Millisatoshi(amount * 3 * 1000)}])
     decode = bitcoind.rpc.decoderawtransaction(prep['unsigned_tx'])
     assert decode['txid'] == prep['txid']
     # 4 inputs, 2 outputs (3 if we have a fee output).

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -262,7 +262,6 @@ def test_deprecated_txprepare(node_factory, bitcoind):
     l1.rpc.call('txprepare', {'destination': addr, 'satoshi': Millisatoshi(amount * 100)})
 
 
-@pytest.mark.xfail
 def test_txprepare_multi(node_factory, bitcoind):
     amount = 10000000
     l1 = node_factory.get_node(random_hsm=True)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -262,6 +262,22 @@ def test_deprecated_txprepare(node_factory, bitcoind):
     l1.rpc.call('txprepare', {'destination': addr, 'satoshi': Millisatoshi(amount * 100)})
 
 
+@pytest.mark.xfail
+def test_txprepare_multi(node_factory, bitcoind):
+    amount = 10000000
+    l1 = node_factory.get_node(random_hsm=True)
+
+    bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'], amount / 10**8)
+    bitcoind.generate_block(1)
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 1)
+
+    outputs = []
+    for i in range(9):
+        outputs.append({l1.rpc.newaddr()['bech32']: Millisatoshi(amount * 100)})
+    prep = l1.rpc.txprepare(outputs=outputs)
+    l1.rpc.txdiscard(prep['txid'])
+
+
 def test_txprepare(node_factory, bitcoind, chainparams):
     amount = 1000000
     l1 = node_factory.get_node(random_hsm=True)


### PR DESCRIPTION
Fixes two crashes/bugs I found in `txprepare`:
 1) using `txprepare` in keywords mode in `pyln-client` would crash (fails an check for what version of the API you're using) 
 2) crash when attempting to specify more than two outputs