### PR TITLE
wallet: remove edgecase around transaction checks

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -990,7 +990,7 @@ static enum watch_result funding_depth_cb(struct lightningd *ld,
 	struct short_channel_id scid;
 
 	/* Sanity check */
-	if (tx && !check_funding_tx(tx, channel)) {
+	if (!check_funding_tx(tx, channel)) {
 		channel_internal_error(channel, "Bad tx %s: %s",
 				       type_to_string(tmpctx,
 						      struct bitcoin_txid, txid),

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -300,8 +300,12 @@ void watch_topology_changed(struct chain_topology *topo)
 			u32 depth;
 
 			depth = get_tx_depth(topo, &w->txid);
-			if (depth)
+			if (depth) {
+				if (!w->tx)
+					w->tx = wallet_transaction_get(w, topo->ld->wallet,
+								       &w->txid);
 				needs_rerun |= txw_fire(w, &w->txid, depth);
+			}
 		}
 	} while (needs_rerun);
 }

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1122,6 +1122,15 @@ bool wallet_transaction_type(struct wallet *w, const struct bitcoin_txid *txid,
 			     enum wallet_tx_type *type);
 
 /**
+ * Get the transaction from the database
+ *
+ * Looks up a transaction we have in the database and returns it, or NULL if
+ * not found.
+ */
+struct bitcoin_tx *wallet_transaction_get(const tal_t *ctx, struct wallet *w,
+					  const struct bitcoin_txid *txid);
+
+/**
  * Get the confirmation height of a transaction we are watching by its
  * txid. Returns 0 if the transaction was not part of any block.
  */


### PR DESCRIPTION
we don't populate the tx item when we're running a transaction check from deep chain (prior to a chain replay). this change allows us to remove the null check on `tx` where we do verification on the funding tx.

I'm not sure this is a desirable change; these transactions have been seen and processed by c-lightning already, so the check is redundant. On the other hand, I think removing the possibility of skipping the check is worth the added lookup as it decreases the risk of new code changes inadvertently disabling it by failing to populate `tx`.

Changelog-None