### PR TITLE
common: add 2 specific error codes wrt funding

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -41,6 +41,8 @@
 #define FUND_OUTPUT_IS_DUST             302
 #define FUNDING_BROADCAST_FAIL          303
 #define FUNDING_STILL_SYNCING_BITCOIN   304
+#define FUNDING_PEER_NOT_CONNECTED      305
+#define FUNDING_UNKNOWN_PEER            306
 
 /* Errors from `invoice` command */
 #define INVOICE_LABEL_ALREADY_EXISTS	900

--- a/doc/lightning-disconnect.7
+++ b/doc/lightning-disconnect.7
@@ -40,30 +40,17 @@ connection\.
 
 On success, an empty object is returned\.
 
-.SH ERRORS
 
-If \fIid\fR is invalid, an error message will be returned:
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
-.nf
 .RS
-{ "code" : -1, "message" : "Peer not connected" }
-
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: Catchall nonspecific error\.
 
 .RE
-
-.fi
-
-If the peer has an active channel and \fIforce\fR is not set, an error
-message will be returned:
-
-.nf
-.RS
-{ "code" : -1, "message" : "Peer is in state CHANNELD_NORMAL" }
-
-
-.RE
-
-.fi
 .SH AUTHOR
 
 Michael Hawkins \fI<michael.hawkins@protonmail.com\fR>\.

--- a/doc/lightning-disconnect.7.md
+++ b/doc/lightning-disconnect.7.md
@@ -35,17 +35,11 @@ RETURN VALUE
 
 On success, an empty object is returned.
 
-ERRORS
-------
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
 
-If *id* is invalid, an error message will be returned:
-
-    { "code" : -1, "message" : "Peer not connected" }
-
-If the peer has an active channel and *force* is not set, an error
-message will be returned:
-
-    { "code" : -1, "message" : "Peer is in state CHANNELD_NORMAL" }
+- -32602: If the given parameters are wrong.
+- -1: Catchall nonspecific error.
 
 AUTHOR
 ------

--- a/doc/lightning-fundchannel_cancel.7
+++ b/doc/lightning-fundchannel_cancel.7
@@ -10,11 +10,14 @@ lightning-fundchannel_cancel - Command for completing channel establishment
 \fBfundchannel_cancel\fR is a lower level RPC command\. It allows channel funder
 to cancel a channel before funding broadcast with a connected peer\.
 
+
 \fIid\fR is the node id of the remote peer with which to cancel\.
+
 
 Note that the funding transaction MUST NOT be broadcast before
 \fBfundchannel_cancel\fR\. Broadcasting transaction before \fBfundchannel_cancel\fR
 WILL lead to unrecoverable loss of funds\.
+
 
 If \fBfundchannel_cancel\fR is called after \fBfundchannel_complete\fR, the remote
 peer may disconnect when command succeeds\. In this case, user need to connect
@@ -26,8 +29,18 @@ On success, returns confirmation that the channel establishment has been
 canceled\.
 
 
-On failure, returns an error\.
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
+.RS
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: Catchall nonspecific error\.
+.IP \[bu]
+306: Unknown peer id\.
+
+.RE
 .SH AUTHOR
 
 Lisa Neigut \fI<niftynei@gmail.com\fR> is mainly responsible\.

--- a/doc/lightning-fundchannel_cancel.7.md
+++ b/doc/lightning-fundchannel_cancel.7.md
@@ -28,7 +28,12 @@ RETURN VALUE
 On success, returns confirmation that the channel establishment has been
 canceled.
 
-On failure, returns an error.
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
+
+- -32602: If the given parameters are wrong.
+- -1: Catchall nonspecific error.
+- 306: Unknown peer id.
 
 AUTHOR
 ------

--- a/doc/lightning-fundchannel_complete.7
+++ b/doc/lightning-fundchannel_complete.7
@@ -32,8 +32,20 @@ On success, returns a confirmation that \fIcommitments_secured\fR and the
 derived \fIchannel_id\fR\.
 
 
-On failure, returns an error\.
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
+.RS
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: Catchall nonspecific error\.
+.IP \[bu]
+305: Peer is not connected\.
+.IP \[bu]
+306: Unknown peer id\.
+
+.RE
 .SH AUTHOR
 
 Lisa Neigut \fI<niftynei@gmail.com\fR> is mainly responsible\.
@@ -46,8 +58,4 @@ lightning-fundchannel_\fBstart\fR(7), lightning-fundchannel_\fBcancel\fR(7)
 .SH RESOURCES
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
-
-.HL
-
-Last updated 2019-06-12 11:16:20 CEST
 

--- a/doc/lightning-fundchannel_complete.7.md
+++ b/doc/lightning-fundchannel_complete.7.md
@@ -30,7 +30,13 @@ RETURN VALUE
 On success, returns a confirmation that *commitments\_secured* and the
 derived *channel\_id*.
 
-On failure, returns an error.
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
+
+- -32602: If the given parameters are wrong.
+- -1: Catchall nonspecific error.
+- 305: Peer is not connected.
+- 306: Unknown peer id.
 
 AUTHOR
 ------

--- a/doc/lightning-fundchannel_start.7
+++ b/doc/lightning-fundchannel_start.7
@@ -50,8 +50,26 @@ If a \fBclose_to\fR address was provided, will close to this address iff the \fB
 returned in the response\. Otherwise, the peer does not support \fBoption_upfront_shutdownscript\fR\.
 
 
-On failure, returns an error\.
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
+.RS
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: Catchall nonspecific error\.
+.IP \[bu]
+300: The amount exceeded the maximum configured funding amount\.
+.IP \[bu]
+301: The provided \fBpush_msat\fR is greater than the provided \fBamount\fR\.
+.IP \[bu]
+304: Still syncing with bitcoin network
+.IP \[bu]
+305: Peer is not connected\.
+.IP \[bu]
+306: Unknown peer id\.
+
+.RE
 .SH AUTHOR
 
 Lisa Neigut \fI<niftynei@gmail.com\fR> is mainly responsible\.

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -45,7 +45,16 @@ On success, returns the *funding\_address* and the *scriptpubkey* for the channe
 If a `close_to` address was provided, will close to this address iff the `close_to` address is
 returned in the response. Otherwise, the peer does not support `option_upfront_shutdownscript`.
 
-On failure, returns an error.
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
+
+- -32602: If the given parameters are wrong.
+- -1: Catchall nonspecific error.
+- 300: The amount exceeded the maximum configured funding amount.
+- 301: The provided `push_msat` is greater than the provided `amount`.
+- 304: Still syncing with bitcoin network
+- 305: Peer is not connected.
+- 306: Unknown peer id.
 
 AUTHOR
 ------

--- a/doc/lightning-listchannels.7
+++ b/doc/lightning-listchannels.7
@@ -32,6 +32,7 @@ list of 0 or more objects\.
 
 Each object in the list contains the following data:
 
+.RS
 .IP \[bu]
 \fIsource\fR : The node providing entry to the channel, specifying the
 fees charged for using the channel in that direction\.
@@ -79,27 +80,20 @@ through this channel\.
 \fIhtlc_maximum_msat\fR : The maximum payment which can be send
 through this channel\.
 
+.RE
 
 If \fIshort_channel_id\fR or \fIsource\fR is supplied and no matching channels
 are found, a "channels" object with an empty list is returned\.
 
-.SH ERRORS
 
-If \fIshort_channel_id\fR is not a valid short_channel_id, an error
-message will be returned:
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
-.nf
 .RS
-{ "code" : -32602,
-  "message" : "'short_channel_id' should be a short channel id, not '...'" }
-
+.IP \[bu]
+-32602: If the given parameters are wrong\.
 
 .RE
-
-.fi
-
-Similarly if \fIsource\fR is not a valid pubkey\.
-
 .SH AUTHOR
 
 Michael Hawkins \fI<michael.hawkins@protonmail.com\fR>\.
@@ -115,6 +109,7 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
 Lightning RFC site
 
+.RS
 .IP \[bu]
 
 BOLT #2:
@@ -128,7 +123,4 @@ BOLT #7:
 
 
 
-.HL
-
-Last updated 2019-06-12 11:16:20 CEST
-
+.RE

--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -65,16 +65,10 @@ through this channel.
 If *short\_channel\_id* or *source* is supplied and no matching channels
 are found, a "channels" object with an empty list is returned.
 
-ERRORS
-------
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
 
-If *short\_channel\_id* is not a valid short\_channel\_id, an error
-message will be returned:
-
-    { "code" : -32602,
-      "message" : "'short_channel_id' should be a short channel id, not '...'" }
-
-Similarly if *source* is not a valid pubkey.
+- -32602: If the given parameters are wrong.
 
 AUTHOR
 ------

--- a/doc/lightning-listpeers.7
+++ b/doc/lightning-listpeers.7
@@ -67,29 +67,15 @@ peer at the specified \fIlevel\fR
 If \fIid\fR is supplied and no matching nodes are found, a "peers" object
 with an empty list is returned\.
 
-.SH ERRORS
 
-If \fIid\fR is not a valid public key, an error message will be returned:
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
-.nf
 .RS
-{ "code" : -32602, "message" : "'id' should be a pubkey, not '...'" }
-
+.IP \[bu]
+-32602: If the given parameters are wrong\.
 
 .RE
-
-.fi
-
-If \fIlevel\fR is not a valid log level, an error message will be returned:
-
-.nf
-.RS
-{ "code" : -32602, "message" : "'level' should be 'io', 'debug', 'info', or 'unusual', not '...'" }
-
-
-.RE
-
-.fi
 .SH AUTHOR
 
 Michael Hawkins \fI<michael.hawkins@protonmail.com\fR>\.

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -53,16 +53,10 @@ peer at the specified *level*
 If *id* is supplied and no matching nodes are found, a "peers" object
 with an empty list is returned.
 
-ERRORS
-------
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
 
-If *id* is not a valid public key, an error message will be returned:
-
-    { "code" : -32602, "message" : "'id' should be a pubkey, not '...'" }
-
-If *level* is not a valid log level, an error message will be returned:
-
-    { "code" : -32602, "message" : "'level' should be 'io', 'debug', 'info', or 'unusual', not '...'" }
+- -32602: If the given parameters are wrong.
 
 AUTHOR
 ------

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1024,7 +1024,7 @@ static struct command_result *json_fund_channel_complete(struct command *cmd,
 	funding_txout = *funding_txout_num;
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
-		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
+		return command_fail(cmd, FUNDING_UNKNOWN_PEER, "Unknown peer");
 	}
 
 	channel = peer_active_channel(peer);
@@ -1033,7 +1033,8 @@ static struct command_result *json_fund_channel_complete(struct command *cmd,
 				    channel_state_name(channel));
 
 	if (!peer->uncommitted_channel)
-		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+		return command_fail(cmd, FUNDING_PEER_NOT_CONNECTED,
+				    "Peer not connected");
 
 	if (!peer->uncommitted_channel->fc || !peer->uncommitted_channel->fc->inflight)
 		return command_fail(cmd, LIGHTNINGD, "No channel funding in progress.");
@@ -1071,7 +1072,7 @@ static struct command_result *json_fund_channel_cancel(struct command *cmd,
 
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
-		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
+		return command_fail(cmd, FUNDING_UNKNOWN_PEER, "Unknown peer");
 	}
 
 	if (peer->uncommitted_channel) {
@@ -1185,7 +1186,7 @@ static struct command_result *json_fund_channel_start(struct command *cmd,
 
 	peer = peer_by_id(cmd->ld, id);
 	if (!peer) {
-		return command_fail(cmd, LIGHTNINGD, "Unknown peer");
+		return command_fail(cmd, FUNDING_UNKNOWN_PEER, "Unknown peer");
 	}
 
 	channel = peer_active_channel(peer);
@@ -1195,7 +1196,8 @@ static struct command_result *json_fund_channel_start(struct command *cmd,
 	}
 
 	if (!peer->uncommitted_channel) {
-		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+		return command_fail(cmd, FUNDING_PEER_NOT_CONNECTED,
+				    "Peer not connected");
 	}
 
 	if (peer->uncommitted_channel->fc) {


### PR DESCRIPTION
Add "peer not connected" and "unknown peer" as error codes, so that
users can check against numeric error codes instead of textual error
messages.

Will ease https://github.com/ElementsProject/lightning/issues/3366

Changelog-None