### PR TITLE
Always notify if a `sendpay` payment attempt is resolved

### DIFF
--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -285,14 +285,14 @@ void notify_sendpay_failure(struct lightningd *ld,
 			    int pay_errcode,
 			    const u8 *onionreply,
 			    const struct routing_failure *fail,
-			    char *errmsg)
+			    const char *errmsg)
 {
 	void (*serialize)(struct json_stream *,
 			  const struct wallet_payment *,
 			  int,
 			  const u8 *,
 			  const struct routing_failure *,
-			  char *) = sendpay_failure_notification_gen.serialize;
+			  const char *) = sendpay_failure_notification_gen.serialize;
 
 	struct jsonrpc_notification *n =
 	    jsonrpc_notification_start(NULL, "sendpay_failure");

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -63,6 +63,6 @@ void notify_sendpay_failure(struct lightningd *ld,
 			    int pay_errcode,
 			    const u8 *onionreply,
 			    const struct routing_failure *fail,
-			    char *errmsg);
+			    const char *errmsg);
 
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -18,8 +18,7 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 		    const char *localfail);
 
 /* Inform payment system to save the payment. */
-void payment_store(struct lightningd *ld,
-		   const struct sha256 *payment_hash, u64 partid);
+void payment_store(struct lightningd *ld, struct wallet_payment *payment);
 
 /* This json will be also used in 'sendpay_success' notifictaion. */
 void json_add_payment_fields(struct json_stream *response,

--- a/tests/plugins/sendpay_notifications.py
+++ b/tests/plugins/sendpay_notifications.py
@@ -14,13 +14,13 @@ def init(configuration, options, plugin):
 
 @plugin.subscribe("sendpay_success")
 def notify_sendpay_success(plugin, sendpay_success):
-    plugin.log("receive a sendpay_success recored, id: {}, payment_hash: {}".format(sendpay_success['id'], sendpay_success['payment_hash']))
+    plugin.log("Received a sendpay_success: id={}, payment_hash={}".format(sendpay_success['id'], sendpay_success['payment_hash']))
     plugin.success_list.append(sendpay_success)
 
 
 @plugin.subscribe("sendpay_failure")
 def notify_sendpay_failure(plugin, sendpay_failure):
-    plugin.log("receive a sendpay_failure recored, id: {}, payment_hash: {}".format(sendpay_failure['data']['id'],
+    plugin.log("Received a sendpay_failure: id={}, payment_hash={}".format(sendpay_failure['data']['id'],
                sendpay_failure['data']['payment_hash']))
     plugin.failure_list.append(sendpay_failure)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -758,7 +758,6 @@ def test_sendpay_notifications(node_factory, bitcoind):
     assert results['sendpay_failure'][0] == err.value.error
 
 
-@pytest.mark.xfail(strict=True)
 def test_sendpay_notifications_nowaiter(node_factory):
     opts = [{'plugin': os.path.join(os.getcwd(), 'tests/plugins/sendpay_notifications.py')},
             {},

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -486,7 +486,7 @@ void payment_failed(struct lightningd *ld UNNEEDED, const struct htlc_out *hout 
 { fprintf(stderr, "payment_failed called!\n"); abort(); }
 /* Generated stub for payment_store */
 void payment_store(struct lightningd *ld UNNEEDED,
-		   const struct sha256 *payment_hash UNNEEDED, u64 partid UNNEEDED)
+		   struct wallet_payment *payment UNNEEDED)
 { fprintf(stderr, "payment_store called!\n"); abort(); }
 /* Generated stub for payment_succeeded */
 void payment_succeeded(struct lightningd *ld UNNEEDED, struct htlc_out *hout UNNEEDED,
@@ -1282,8 +1282,9 @@ static bool test_payment_crud(struct lightningd *ld, const tal_t *ctx)
 	t->partid = 0;
 
 	db_begin_transaction(w->db);
-	wallet_payment_setup(w, tal_dup(NULL, struct wallet_payment, t));
-	wallet_payment_store(w, &t->payment_hash, 0);
+	t2 = tal_dup(NULL, struct wallet_payment, t);
+	wallet_payment_setup(w, t2);
+	wallet_payment_store(w, take(t2));
 	t2 = wallet_payment_by_hash(ctx, w, &t->payment_hash, 0);
 	CHECK(t2 != NULL);
 	CHECK(t2->status == t->status);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -941,8 +941,7 @@ void wallet_payment_setup(struct wallet *wallet, struct wallet_payment *payment)
  * Stores the payment in the database.
  */
 void wallet_payment_store(struct wallet *wallet,
-			  const struct sha256 *payment_hash,
-			  u64 partid);
+			  struct wallet_payment *payment TAKES);
 
 /**
  * wallet_payment_delete - Remove a payment


### PR DESCRIPTION
Sendpay notifications would get sent only if we have an active watcher, and multiple times if we have more than one watcher. This kind of defeats the point since we can't just fire and forget sendpay and wait for the notification if that notification is bound to the watchers.

This PR fixes that by pulling the notification out of the watcher loop, concentrating the error message allocation in a single place, and inverting ownership of `wallet_payment_store`. This also reduces a couple of useless allocations, since we don't store, free, then reload the `wallet_payment` anymore.

Fixes #3403 
