### PR TITLE
pyln-client/LightningRpc: fixed logger in super()

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -357,7 +357,7 @@ class LightningRpc(UnixDomainSocketRpc):
             return obj
 
     def __init__(self, socket_path, executor=None, logger=logging):
-        super().__init__(socket_path, executor, logging, self.LightningJSONEncoder, self.LightningJSONDecoder())
+        super().__init__(socket_path, executor, logger, self.LightningJSONEncoder, self.LightningJSONDecoder())
 
     def autocleaninvoice(self, cycle_seconds=None, expired_by=None):
         """


### PR DESCRIPTION
Little fix for `pyln-client`'s `super().__init__` call. Now passing `logger` instead of `logging`, otherwise keyword argument `logger` was not used.