### PR TITLE
doc: also build docs when building everything else

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ ifeq ($(HAVE_POSTGRES),1)
 LDLIBS += -lpq
 endif
 
-default: all-programs all-test-programs
+default: all-programs all-test-programs doc-all
 
 ccan/config.h: config.vars configure ccan/tools/configurator/configurator.c
 	./configure --reconfigure


### PR DESCRIPTION
Before this change `make` would build everything but the docs.
They would be built during `make install` which is unexpected.

Add a dependency to `doc-all` to the `default` target so that docs are
build together with the rest of the programs. Leave the `install-data`
as is, to still build the docs if they are not built yet during install.

Changelog-None