### PR TITLE
remove `--silent` flag from patch in wire/Makefile

### DIFF
--- a/wire/Makefile
+++ b/wire/Makefile
@@ -53,10 +53,10 @@ EXPERIMENTAL_PEER_PATCHES := $(wildcard wire/extracted_peer_experimental_*)
 EXPERIMENTAL_ONION_PATCHES := $(wildcard wire/extracted_onion_experimental_*)
 
 wire/gen_peer_wire_csv: wire/extracted_peer_wire_csv $(EXPERIMENTAL_PEER_PATCHES)
-	@set -e; trap "rm -f $@.$$$$" 0; cp $< $@.$$$$; for exp in $(EXPERIMENTAL_PEER_PATCHES); do patch --silent $@.$$$$ $$exp; done; mv $@.$$$$ $@
+	@set -e; trap "rm -f $@.$$$$" 0; cp $< $@.$$$$; for exp in $(EXPERIMENTAL_PEER_PATCHES); do patch $@.$$$$ $$exp; done; mv $@.$$$$ $@
 
 wire/gen_onion_wire_csv: wire/extracted_onion_wire_csv $(EXPERIMENTAL_ONION_PATCHES)
-	@set -e; trap "rm -f $@.$$$$" 0; cp $< $@.$$$$; for exp in $(EXPERIMENTAL_ONION_PATCHES); do patch --silent $@.$$$$ $$exp; done; mv $@.$$$$ $@
+	@set -e; trap "rm -f $@.$$$$" 0; cp $< $@.$$$$; for exp in $(EXPERIMENTAL_ONION_PATCHES); do patch $@.$$$$ $$exp; done; mv $@.$$$$ $@
 
 else # /* EXPERIMENTAL_FEATURES */
 wire/gen_peer_wire_csv: wire/extracted_peer_wire_csv


### PR DESCRIPTION
It's been brought to my attention that BusyBox's `patch` binary doesn't support the `--silent` option. (nor `quiet`, as of patch `020abc8856f94d6e355f4daa972ac75fb05ae113` on the busybox master branch).

This patch removes the silent flag from the patch command used to build the wire csv files. Only affects experimental builds.

Changelog-None