### PR TITLE
sphinx: Actually use the pad stream to generate the packet

### DIFF
--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -23,6 +23,7 @@ struct bitcoin_block_hdr {
 	le32 timestamp;
 	le32 target;
 	le32 nonce;
+	struct sha256_double hash;
 };
 
 struct elements_block_proof {

--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -425,7 +425,7 @@ struct onionpacket *create_onionpacket(
 	/* Note that this is just hop_payloads: the rest of the packet is
 	 * overwritten below or above anyway. */
 	generate_key(padkey, "pad", 3, sp->session_key);
-	generate_cipher_stream(stream, padkey, ROUTING_INFO_SIZE);
+	generate_cipher_stream(packet->routinginfo, padkey, ROUTING_INFO_SIZE);
 
 	generate_header_padding(filler, sizeof(filler), sp, params);
 

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -220,15 +220,16 @@ static void runtest(const char *filename)
 		json_to_pubkey(buffer, pubkeytok, &pubkey);
 		if (!typetok || json_tok_streq(buffer, typetok, "legacy")) {
 			/* Legacy has a single 0 prepended as "realm" byte */
-			full = tal_arrz(ctx, u8, 1);
+			full = tal_arrz(ctx, u8, 33);
+			memcpy(full + 1, payload, tal_bytelen(payload));
 		} else {
 			/* TLV has length prepended */
 			full = tal_arr(ctx, u8, 0);
 			towire_bigsize(&full, tal_bytelen(payload));
+			prepended = tal_bytelen(full);
+			tal_resize(&full, prepended + tal_bytelen(payload));
+			memcpy(full + prepended, payload, tal_bytelen(payload));
 		}
-		prepended = tal_bytelen(full);
-		tal_resize(&full, prepended + tal_bytelen(payload));
-		memcpy(full + prepended, payload, tal_bytelen(payload));
 		sphinx_add_hop(path, &pubkey, full);
 	}
 	res = create_onionpacket(ctx, path, &shared_secrets);

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2479,7 +2479,7 @@ def test_createonion_rpc(node_factory):
     # The trailer is generated using the filler and can be ued as a
     # checksum. This trailer is from the test-vector in the specs.
     print(res)
-    assert(res['onion'].endswith('be89e4701eb870f8ed64fafa446c78df3ea'))
+    assert(res['onion'].endswith('9400f45a48e6dc8ddbaeb3'))
 
 
 @unittest.skipIf(not DEVELOPER, "gossip propagation is slow without DEVELOPER=1")


### PR DESCRIPTION
Turns out https://github.com/ElementsProject/lightning/pull/3246 did not actually do anything. We flipped two buffers and were not actually using the chacha20 stream. The buffer we were initializing with the chacha20 stream was simply being overwritten in the next iteration. We need to initialize the `packet->routinginfo` instead.

Keeping this as a draft until we've resolved the broken test-vectors in lightningnetwork/lightning-rfc#697

Changelog-None