### PR TITLE
sphinx: use struct secret for shared secret.

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -602,7 +602,7 @@ static struct secret *get_shared_secret(const tal_t *ctx,
 
 	/* We make sure we can parse onion packet, so we know if shared secret
 	 * is actually valid (this checks hmac). */
-	rs = process_onionpacket(tmpctx, &op, secret->data,
+	rs = process_onionpacket(tmpctx, &op, secret,
 				 htlc->rhash.u.u8,
 				 sizeof(htlc->rhash));
 	if (!rs) {

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -107,12 +107,12 @@ struct onionpacket *create_onionpacket(
 /**
  * onion_shared_secret - calculate ECDH shared secret between nodes.
  *
- * @secret: the shared secret (32 bytes long)
+ * @secret: the shared secret
  * @pubkey: the public key of the other node
  * @privkey: the private key of this node (32 bytes long)
  */
 bool onion_shared_secret(
-	u8 *secret,
+	struct secret *secret,
 	const struct onionpacket *packet,
 	const struct privkey *privkey);
 
@@ -130,7 +130,7 @@ bool onion_shared_secret(
 struct route_step *process_onionpacket(
 	const tal_t * ctx,
 	const struct onionpacket *packet,
-	const u8 *shared_secret,
+	const struct secret *shared_secret,
 	const u8 *assocdata,
 	const size_t assocdatalen
 	);

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -105,7 +105,7 @@ static struct route_step *decode_with_privkey(const tal_t *ctx, const u8 *onion,
 	struct route_step *step;
 	struct onionpacket packet;
 	enum onion_type why_bad;
-	u8 shared_secret[32];
+	struct secret shared_secret;
 	if (!hex_decode(hexprivkey, strlen(hexprivkey), &seckey, sizeof(seckey)))
 		errx(1, "Invalid private key hex '%s'", hexprivkey);
 
@@ -114,10 +114,10 @@ static struct route_step *decode_with_privkey(const tal_t *ctx, const u8 *onion,
 	if (why_bad != 0)
 		errx(1, "Error parsing message: %s", onion_type_name(why_bad));
 
-	if (!onion_shared_secret(shared_secret, &packet, &seckey))
+	if (!onion_shared_secret(&shared_secret, &packet, &seckey))
 		errx(1, "Error creating shared secret.");
 
-	step = process_onionpacket(ctx, &packet, shared_secret, assocdata,
+	step = process_onionpacket(ctx, &packet, &shared_secret, assocdata,
 				   tal_bytelen(assocdata));
 	return step;
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -946,7 +946,7 @@ static bool peer_accepted_htlc(struct channel *channel, u64 id,
 		return false;
 	}
 
-	rs = process_onionpacket(tmpctx, &op, hin->shared_secret->data,
+	rs = process_onionpacket(tmpctx, &op, hin->shared_secret,
 				 hin->payment_hash.u.u8,
 				 sizeof(hin->payment_hash));
 	if (!rs) {

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -523,7 +523,7 @@ void plugin_hook_call_(struct lightningd *ld UNNEEDED, const struct plugin_hook 
 struct route_step *process_onionpacket(
 	const tal_t * ctx UNNEEDED,
 	const struct onionpacket *packet UNNEEDED,
-	const u8 *shared_secret UNNEEDED,
+	const struct secret *shared_secret UNNEEDED,
 	const u8 *assocdata UNNEEDED,
 	const size_t assocdatalen
 	)


### PR DESCRIPTION
Generally I prefer structures over u8, since the size is enforced at
runtime; and in several places we were doing conversions as the code
using Sphinx does treat struct secret as type of the secret.

Note that passing an array is the same as passing the address, so
changing from 'u8 secret[32]' to 'struct secret secret' means various
'secret' parameters change to '&secret'.  Technically, '&secret' also
would have worked before, since '&' is a noop on array, but that's
always seemed a bit weird.

Changelog-None