### PR TITLE
lightningd/jsonrpc.c: Set JSON-RPC socket permissions by command line.

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -188,6 +188,14 @@ cause it to reopen this file (useful for log rotation)\.
 Set JSON-RPC socket (or /dev/tty), such as for \fBlightning-cli\fR(1)\.
 
 
+ \fBrpc-file-mode\fR=\fIMODE\fR
+Set JSON-RPC socket file mode, as a 4-digit octal number\.
+Default is 0600, meaning only the user that launched lightningd
+can command it\.
+Set to 0660 to allow users with the same group to access the RPC
+as well\.
+
+
  \fBdaemon\fR
 Run in the background, suppress stdout and stderr\.
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -149,6 +149,13 @@ cause it to reopen this file (useful for log rotation).
  **rpc-file**=*PATH*
 Set JSON-RPC socket (or /dev/tty), such as for lightning-cli(1).
 
+ **rpc-file-mode**=*MODE*
+Set JSON-RPC socket file mode, as a 4-digit octal number.
+Default is 0600, meaning only the user that launched lightningd
+can command it.
+Set to 0660 to allow users with the same group to access the RPC
+as well.
+
  **daemon**
 Run in the background, suppress stdout and stderr.
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -78,7 +78,6 @@
 #include <signal.h>
 #include <sodium.h>
 #include <sys/resource.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -253,6 +252,16 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 * initial_umask anyway as we might rely on it later (`plugin start`). */
 	ld->initial_umask = umask(0);
 	umask(ld->initial_umask);
+
+	/*~ This is the mode of the created JSON-RPC socket file, in
+	 * traditional Unix octal. 0600 means only the user that ran
+	 * lightningd can invoke RPC on it. Changing it to 0660 may
+	 * be sensible if you run lightningd in its own system user,
+	 * and just let specific users (add the group of the
+	 * lightningd runner as an ancillary group) access its
+	 * RPC. Can be overridden with `--rpc-file-mode`.
+	 */
+	ld->rpc_filemode = 0600;
 
 	return ld;
 }

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -10,6 +10,7 @@
 #include <lightningd/htlc_set.h>
 #include <lightningd/plugin.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <wallet/txfilter.h>
 #include <wallet/wallet.h>
 
@@ -91,6 +92,8 @@ struct lightningd {
 
 	/* Location of the RPC socket. */
 	char *rpc_filename;
+	/* Mode of the RPC filename. */
+	mode_t rpc_filemode;
 
 	/* The root of the jsonrpc interface. Can be shut down
 	 * separately from the rest of the daemon to allow a clean


### PR DESCRIPTION
Fixes: #1366

Arguably also works for #3394.  It is probably more sensible to set permissions via this patch and `--rpc-file-mode`, since this will work in a new install or if you place the RPC file in a `tmpfs` (which might make more sense as well, so that at startup the rpc file does not exist yet, so you can wait on the file existing to determine if you can now connect to it and the correct lightningd already is listening).