### PR TITLE
Implement dynafed block header support for elements >= 0.18.1

### DIFF
--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -91,27 +91,7 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 void bitcoin_block_blkid(const struct bitcoin_block *b,
 			 struct bitcoin_blkid *out)
 {
-	struct sha256_ctx shactx;
-
-	sha256_init(&shactx);
-	sha256_le32(&shactx, b->hdr.version);
-	sha256_update(&shactx, &b->hdr.prev_hash, sizeof(b->hdr.prev_hash));
-	sha256_update(&shactx, &b->hdr.merkle_hash, sizeof(b->hdr.merkle_hash));
-	sha256_le32(&shactx, b->hdr.timestamp);
-
-        if (is_elements(chainparams)) {
-		size_t clen = tal_bytelen(b->elements_hdr->proof.challenge);
-		sha256_le32(&shactx, b->elements_hdr->block_height);
-
-		sha256_varint(&shactx, clen);
-		sha256_update(&shactx, b->elements_hdr->proof.challenge, clen);
-		/* The solution is skipped, since that'd create a circular
-		 * dependency apparently */
-	} else {
-		sha256_le32(&shactx, b->hdr.target);
-		sha256_le32(&shactx, b->hdr.nonce);
-	}
-	sha256_double_done(&shactx, &out->shad);
+	*out = b->hdr.hash;
 }
 
 /* We do the same hex-reversing crud as txids. */

--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -60,7 +60,7 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 		b->hdr.nonce = pull_le32(&p, &len);
 		sha256_le32(&shactx, b->hdr.nonce);
 	}
-	sha256_double_done(&shactx, &b->hdr.hash);
+	sha256_double_done(&shactx, &b->hdr.hash.shad);
 
 	num = pull_varint(&p, &len);
 	b->tx = tal_arr(b, struct bitcoin_tx *, num);

--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -52,8 +52,11 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 	if (is_elements(chainparams)) {
 		b->elements_hdr = tal(b, struct elements_block_hdr);
 		b->elements_hdr->block_height = pull_le32(&p, &len);
+		sha256_le32(&shactx, b->elements_hdr->block_height);
 
 		size_t challenge_len = pull_varint(&p, &len);
+		sha256_varint(&shactx, challenge_len);
+		sha256_update(&shactx, p, challenge_len);
 		b->elements_hdr->proof.challenge = tal_arr(b->elements_hdr, u8, challenge_len);
 		pull(&p, &len, b->elements_hdr->proof.challenge, challenge_len);
 

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -23,7 +23,7 @@ struct bitcoin_block_hdr {
 	le32 timestamp;
 	le32 target;
 	le32 nonce;
-	struct sha256_double hash;
+	struct bitcoin_blkid hash;
 };
 
 struct elements_block_proof {

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -10,6 +10,12 @@
 
 struct chainparams;
 
+enum dynafed_params_type {
+	DYNAFED_PARAMS_NULL,
+	DYNAFED_PARAMS_COMPACT,
+	DYNAFED_PARAMS_FULL,
+};
+
 struct bitcoin_blkid {
 	struct sha256_double shad;
 };

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -32,19 +32,8 @@ struct bitcoin_block_hdr {
 	struct bitcoin_blkid hash;
 };
 
-struct elements_block_proof {
-	u8 *challenge;
-	u8 *solution;
-};
-
-struct elements_block_hdr {
-	u32 block_height;
-	struct elements_block_proof proof;
-};
-
 struct bitcoin_block {
 	struct bitcoin_block_hdr hdr;
-	struct elements_block_hdr *elements_hdr;
 	/* tal_count shows now many */
 	struct bitcoin_tx **tx;
 };

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -443,17 +443,6 @@ class ElementsD(BitcoinD):
         self.rpc = SimpleBitcoinProxy(btc_conf_file=self.conf_file)
         self.prefix = 'elementsd'
 
-    def generate_block(self, numblocks=1, wait_for_mempool=0):
-        if wait_for_mempool:
-            if isinstance(wait_for_mempool, str):
-                wait_for_mempool = [wait_for_mempool]
-            if isinstance(wait_for_mempool, list):
-                wait_for(lambda: all(txid in self.rpc.getrawmempool() for txid in wait_for_mempool))
-            else:
-                wait_for(lambda: len(self.rpc.getrawmempool()) >= wait_for_mempool)
-        # As of 0.16, generate() is removed; use generatetoaddress.
-        return self.rpc.generate(numblocks)
-
     def getnewaddress(self):
         """Need to get an address and then make it unconfidential
         """


### PR DESCRIPTION
This implements support for the upcoming `elementsd` dynafed block header
format, which is slightly different from either the bitcoin block header
format as well as the `elementsd` <= 0.17.0 block header format. A couple of
fields were added, 3 different serialization formats for the information
(`null`, `compact` and `full`) and some of those fields are not hashed into
the block hash, since they'd be self-referential (like the pre-0.18.0 solution
field).

In order to implement this I chose to also simplify the block hash generation,
to happen in parallel with the deserialization. This has a couple of
side-effects:

 - The block hash is computed only once, instead of multiple times when we
   call `bitcoin_block_blkid`. For compatibility I left that function, but it
   now just copies over the cached hash instead of re-serializing it.
 - We do not need any serialization code for the block header, since we are
   just consumers of blocks, and we don't have to generate new ones from its
   constituent parts.
 - We don't need to carry block header fields around that are otherwise of no
   use to us. It always felt weird having to remember constituent parts only
   to be able to re-serialize the header. Now we can just feed it into the
   hashing algorithm and skip the actual fields. This also ends up saving us a
   couple of allocations.
   
There are a couple of drive-by fixes, such as weening off of `elementsd`'s
deprecated `generate` RPC in favor of `generatetoaddress`, but they should be
minor.

Fixes #3362