### PR TITLE
Use dedicated type for error codes

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -68,7 +68,14 @@ COMMON_SRC_NOGEN :=				\
 
 COMMON_SRC_GEN := common/gen_status_wire.c common/gen_peer_status_wire.c
 
-COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h) common/overflows.h common/htlc.h common/status_levels.h common/json_command.h common/jsonrpc_errors.h common/gossip_constants.h
+COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h)	\
+	common/errcode.h				\
+	common/gossip_constants.h			\
+	common/htlc.h					\
+	common/json_command.h				\
+	common/jsonrpc_errors.h				\
+	common/overflows.h				\
+	common/status_levels.h
 COMMON_HEADERS_GEN := common/gen_htlc_state_names.h common/gen_status_wire.h common/gen_peer_status_wire.h
 
 COMMON_HEADERS := $(COMMON_HEADERS_GEN) $(COMMON_HEADERS_NOGEN)

--- a/common/errcode.h
+++ b/common/errcode.h
@@ -1,0 +1,13 @@
+#ifndef LIGHTNING_COMMON_ERRCODE_H
+#define LIGHTNING_COMMON_ERRCODE_H
+
+#include "config.h"
+
+#include <ccan/short_types/short_types.h>
+#include <inttypes.h>
+
+typedef s32 errcode_t;
+
+#define PRIerrcode PRId32
+
+#endif /* LIGHTNING_COMMON_ERRCODE_H */

--- a/common/json.h
+++ b/common/json.h
@@ -3,7 +3,9 @@
 #include "config.h"
 #include <bitcoin/preimage.h>
 #include <bitcoin/privkey.h>
+#include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
+#include <common/errcode.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -37,6 +39,9 @@ bool json_to_number(const char *buffer, const jsmntok_t *tok,
 bool json_to_u64(const char *buffer, const jsmntok_t *tok,
 		 uint64_t *num);
 
+/* Extract signed 64 bit integer from this (may be a string, or a number literal) */
+bool json_to_s64(const char *buffer, const jsmntok_t *tok, s64 *num);
+
 /* Extract number from this (may be a string, or a number literal) */
 bool json_to_u32(const char *buffer, const jsmntok_t *tok,
                  uint32_t *num);
@@ -50,6 +55,9 @@ bool json_to_double(const char *buffer, const jsmntok_t *tok, double *num);
 
 /* Extract signed integer from this (may be a string, or a number literal) */
 bool json_to_int(const char *buffer, const jsmntok_t *tok, int *num);
+
+/* Extract an error code from this (may be a string, or a number literal) */
+bool json_to_errcode(const char *buffer, const jsmntok_t *tok, errcode_t *errcode);
 
 /* Extract boolean from this */
 bool json_to_bool(const char *buffer, const jsmntok_t *tok, bool *b);

--- a/common/json_command.h
+++ b/common/json_command.h
@@ -4,13 +4,14 @@
 #define LIGHTNING_COMMON_JSON_COMMAND_H
 #include "config.h"
 #include <ccan/compiler/compiler.h>
+#include <common/errcode.h>
 #include <stdbool.h>
 
 struct command;
 struct command_result;
 
 /* Caller supplied this: param assumes it can call it. */
-struct command_result *command_fail(struct command *cmd, int code,
+struct command_result *command_fail(struct command *cmd, errcode_t code,
 				    const char *fmt, ...)
 	PRINTF_FMT(3, 4) WARN_UNUSED_RESULT;
 

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -3,55 +3,59 @@
  */
 #ifndef LIGHTNING_COMMON_JSONRPC_ERRORS_H
 #define LIGHTNING_COMMON_JSONRPC_ERRORS_H
+
 #include "config.h"
 
+#include <common/errcode.h>
+
 /* Standard errors defined by JSON-RPC 2.0 standard */
-#define JSONRPC2_INVALID_REQUEST	-32600
-#define JSONRPC2_METHOD_NOT_FOUND	-32601
-#define JSONRPC2_INVALID_PARAMS		-32602
+static const errcode_t JSONRPC2_INVALID_REQUEST = -32600;
+static const errcode_t JSONRPC2_METHOD_NOT_FOUND = -32601;
+static const errcode_t JSONRPC2_INVALID_PARAMS = -32602;
 
 /* Uncategorized error.
  * FIXME: This should be replaced in all places
  * with a specific error code, and then removed.
  */
-#define LIGHTNINGD                      -1
+static const errcode_t LIGHTNINGD = -1;
 
 /* Developer error in the parameters to param() call */
-#define PARAM_DEV_ERROR                 -2
+static const errcode_t PARAM_DEV_ERROR = -2;
 
 /* Plugin returned an error */
-#define PLUGIN_ERROR                    -3
+static const errcode_t PLUGIN_ERROR = -3;
 
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
-#define PAY_IN_PROGRESS			200
-#define PAY_RHASH_ALREADY_USED		201
-#define PAY_UNPARSEABLE_ONION		202
-#define PAY_DESTINATION_PERM_FAIL	203
-#define PAY_TRY_OTHER_ROUTE		204
-#define PAY_ROUTE_NOT_FOUND		205
-#define PAY_ROUTE_TOO_EXPENSIVE		206
-#define PAY_INVOICE_EXPIRED             207
-#define PAY_NO_SUCH_PAYMENT		208
-#define PAY_UNSPECIFIED_ERROR		209
-#define PAY_STOPPED_RETRYING		210
+static const errcode_t PAY_IN_PROGRESS = 200;
+static const errcode_t PAY_RHASH_ALREADY_USED = 201;
+static const errcode_t PAY_UNPARSEABLE_ONION = 202;
+static const errcode_t PAY_DESTINATION_PERM_FAIL = 203;
+static const errcode_t PAY_TRY_OTHER_ROUTE = 204;
+static const errcode_t PAY_ROUTE_NOT_FOUND = 205;
+static const errcode_t PAY_ROUTE_TOO_EXPENSIVE = 206;
+static const errcode_t PAY_INVOICE_EXPIRED = 207;
+static const errcode_t PAY_NO_SUCH_PAYMENT = 208;
+static const errcode_t PAY_UNSPECIFIED_ERROR = 209;
+static const errcode_t PAY_STOPPED_RETRYING = 210;
 
 /* `fundchannel` or `withdraw` errors */
-#define FUND_MAX_EXCEEDED               300
-#define FUND_CANNOT_AFFORD              301
-#define FUND_OUTPUT_IS_DUST             302
-#define FUNDING_BROADCAST_FAIL          303
-#define FUNDING_STILL_SYNCING_BITCOIN   304
-#define FUNDING_PEER_NOT_CONNECTED      305
-#define FUNDING_UNKNOWN_PEER            306
+static const errcode_t FUND_MAX_EXCEEDED = 300;
+static const errcode_t FUND_CANNOT_AFFORD = 301;
+static const errcode_t FUND_OUTPUT_IS_DUST = 302;
+static const errcode_t FUNDING_BROADCAST_FAIL = 303;
+static const errcode_t FUNDING_STILL_SYNCING_BITCOIN = 304;
+static const errcode_t FUNDING_PEER_NOT_CONNECTED = 305;
+static const errcode_t FUNDING_UNKNOWN_PEER = 306;
 
 /* `connect` errors */
-#define CONNECT_NO_KNOWN_ADDRESS	400
-#define CONNECT_ALL_ADDRESSES_FAILED	401
+static const errcode_t CONNECT_NO_KNOWN_ADDRESS = 400;
+static const errcode_t CONNECT_ALL_ADDRESSES_FAILED = 401;
 
 /* Errors from `invoice` command */
-#define INVOICE_LABEL_ALREADY_EXISTS	900
-#define INVOICE_PREIMAGE_ALREADY_EXISTS	901
-#define INVOICE_HINTS_GAVE_NO_ROUTES	902
-#define INVOICE_WAIT_TIMED_OUT		904
+static const errcode_t INVOICE_LABEL_ALREADY_EXISTS = 900;
+static const errcode_t INVOICE_PREIMAGE_ALREADY_EXISTS = 901;
+static const errcode_t INVOICE_HINTS_GAVE_NO_ROUTES = 902;
+static const errcode_t INVOICE_EXPIRED_DURING_WAIT = 903;
+static const errcode_t INVOICE_WAIT_TIMED_OUT = 904;
 
 #endif /* LIGHTNING_COMMON_JSONRPC_ERRORS_H */

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -5,6 +5,7 @@
 #include "../param.c"
 #include <ccan/array_size/array_size.h>
 #include <ccan/err/err.h>
+#include <common/errcode.h>
 #include <common/json.h>
 #include <setjmp.h>
 #include <signal.h>
@@ -28,7 +29,7 @@ struct command_result {
 static struct command_result cmd_failed;
 
 struct command_result *command_fail(struct command *cmd,
-				    int code, const char *fmt, ...)
+				    errcode_t code, const char *fmt, ...)
 {
 	failed = true;
 	va_list ap;

--- a/connectd/connect_wire.csv
+++ b/connectd/connect_wire.csv
@@ -44,7 +44,7 @@ msgdata,connectctl_connect_to_peer,addrhint,?wireaddr_internal,
 # Connectd->master: connect failed.
 msgtype,connectctl_connect_failed,2020
 msgdata,connectctl_connect_failed,id,node_id,
-msgdata,connectctl_connect_failed,failcode,int,
+msgdata,connectctl_connect_failed,failcode,errcode_t,
 msgdata,connectctl_connect_failed,failreason,wirestring,
 msgdata,connectctl_connect_failed,seconds_to_delay,u32,
 msgdata,connectctl_connect_failed,addrhint,?wireaddr_internal,

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -29,6 +29,7 @@
 #include <common/cryptomsg.h>
 #include <common/daemon_conn.h>
 #include <common/decode_array.h>
+#include <common/errcode.h>
 #include <common/features.h>
 #include <common/jsonrpc_errors.h>
 #include <common/memleak.h>
@@ -566,7 +567,7 @@ static void connect_failed(struct daemon *daemon,
 			   const struct node_id *id,
 			   u32 seconds_waited,
 			   const struct wireaddr_internal *addrhint,
-			   int errcode,
+			   errcode_t errcode,
 			   const char *errfmt, ...)
 	PRINTF_FMT(6,7);
 
@@ -574,7 +575,7 @@ static void connect_failed(struct daemon *daemon,
 			   const struct node_id *id,
 			   u32 seconds_waited,
 			   const struct wireaddr_internal *addrhint,
-			   int errcode,
+			   errcode_t errcode,
 			   const char *errfmt, ...)
 {
 	u8 *msg;

--- a/doc/lightning-waitinvoice.7
+++ b/doc/lightning-waitinvoice.7
@@ -16,14 +16,18 @@ On success, an invoice description will be returned as per
 \fBlightning-listinvoice\fR(7)\. The \fIstatus\fR field will be \fIpaid\fR\.
 
 
-If the invoice is deleted while unpaid, or the invoice does not exist,
-this command will return with an error with code -1\.
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
 
+.RS
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: If the invoice is deleted while unpaid, or the invoice does not exist\.
+.IP \[bu]
+903: If the invoice expires before being paid, or is already expired\.
 
-If the invoice expires before being paid, or is already expired, this
-command will return with an error with code -2, with the data being the
-invoice data as per \fBlistinvoice\fR\.
-
+.RE
 .SH AUTHOR
 
 Christian Decker \fI<decker.christian@gmail.com\fR> is mainly
@@ -37,8 +41,4 @@ responsible\.
 .SH RESOURCES
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
-
-.HL
-
-Last updated 2019-04-07 14:23:17 CEST
 

--- a/doc/lightning-waitinvoice.7.md
+++ b/doc/lightning-waitinvoice.7.md
@@ -18,12 +18,12 @@ RETURN VALUE
 On success, an invoice description will be returned as per
 lightning-listinvoice(7). The *status* field will be *paid*.
 
-If the invoice is deleted while unpaid, or the invoice does not exist,
-this command will return with an error with code -1.
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
 
-If the invoice expires before being paid, or is already expired, this
-command will return with an error with code -2, with the data being the
-invoice data as per **listinvoice**.
+- -32602: If the given parameters are wrong.
+- -1: If the invoice is deleted while unpaid, or the invoice does not exist.
+- 903: If the invoice expires before being paid, or is already expired.
 
 AUTHOR
 ------

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -2,6 +2,7 @@
 #include <ccan/fdpass/fdpass.h>
 #include <ccan/list/list.h>
 #include <ccan/tal/str/str.h>
+#include <common/errcode.h>
 #include <common/features.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
@@ -231,7 +232,7 @@ void delay_then_reconnect(struct channel *channel, u32 seconds_delay,
 static void connect_failed(struct lightningd *ld, const u8 *msg)
 {
 	struct node_id id;
-	int errcode;
+	errcode_t errcode;
 	char *errmsg;
 	struct connect *c;
 	u32 seconds_to_delay;

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -82,8 +82,7 @@ static struct command_result *tell_waiter(struct command *cmd,
 		json_add_invoice(response, details);
 		return command_success(cmd, response);
 	} else {
-		/* FIXME: -2 should be a constant in jsonrpc_errors.h.  */
-		response = json_stream_fail(cmd, -2,
+		response = json_stream_fail(cmd, INVOICE_EXPIRED_DURING_WAIT,
 					    "invoice expired during wait");
 		json_add_invoice(response, details);
 		json_object_end(response);

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -4,6 +4,7 @@
 #include <bitcoin/chainparams.h>
 #include <ccan/autodata/autodata.h>
 #include <ccan/list/list.h>
+#include <common/errcode.h>
 #include <common/json.h>
 #include <lightningd/json_stream.h>
 #include <stdarg.h>
@@ -96,7 +97,7 @@ struct json_stream *json_stream_success(struct command *cmd);
  * You need to json_object_end() once you're done!
  */
 struct json_stream *json_stream_fail(struct command *cmd,
-				     int code,
+				     errcode_t code,
 				     const char *errmsg);
 
 /**
@@ -108,7 +109,7 @@ struct json_stream *json_stream_fail(struct command *cmd,
  * This is used by command_fail(), which doesn't add any JSON data.
  */
 struct json_stream *json_stream_fail_nodata(struct command *cmd,
-					    int code,
+					    errcode_t code,
 					    const char *errmsg);
 
 /* These returned values are never NULL. */

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -254,7 +254,7 @@ void notify_sendpay_success(struct lightningd *ld,
 
 static void sendpay_failure_notification_serialize(struct json_stream *stream,
 						   const struct wallet_payment *payment,
-						   int pay_errcode,
+						   errcode_t pay_errcode,
 						   const struct onionreply *onionreply,
 						   const struct routing_failure *fail,
 						   char *errmsg)
@@ -263,7 +263,7 @@ static void sendpay_failure_notification_serialize(struct json_stream *stream,
 
 	/* In line with the format of json error returned
 	 * by sendpay_fail(). */
-	json_add_member(stream, "code", false, "%d", pay_errcode);
+	json_add_member(stream, "code", false, "%" PRIerrcode, pay_errcode);
 	json_add_string(stream, "message", errmsg);
 
 	json_object_start(stream, "data");
@@ -282,14 +282,14 @@ REGISTER_NOTIFICATION(sendpay_failure,
 
 void notify_sendpay_failure(struct lightningd *ld,
 			    const struct wallet_payment *payment,
-			    int pay_errcode,
+			    errcode_t pay_errcode,
 			    const struct onionreply *onionreply,
 			    const struct routing_failure *fail,
 			    const char *errmsg)
 {
 	void (*serialize)(struct json_stream *,
 			  const struct wallet_payment *,
-			  int,
+			  errcode_t,
 			  const struct onionreply *,
 			  const struct routing_failure *,
 			  const char *) = sendpay_failure_notification_gen.serialize;

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -7,6 +7,7 @@
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/time/time.h>
 #include <common/amount.h>
+#include <common/errcode.h>
 #include <common/node_id.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/jsonrpc.h>
@@ -62,7 +63,7 @@ void notify_sendpay_success(struct lightningd *ld,
 
 void notify_sendpay_failure(struct lightningd *ld,
 			    const struct wallet_payment *payment,
-			    int pay_errcode,
+			    errcode_t pay_errcode,
 			    const struct onionreply *onionreply,
 			    const struct routing_failure *fail,
 			    const char *errmsg);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -172,7 +172,7 @@ json_add_routefail_info(struct json_stream *js,
 
 void json_sendpay_fail_fields(struct json_stream *js,
 			      const struct wallet_payment *payment,
-			      int pay_errcode,
+			      errcode_t pay_errcode,
 			      const struct onionreply *onionreply,
 			      const struct routing_failure *fail)
 {
@@ -191,7 +191,7 @@ void json_sendpay_fail_fields(struct json_stream *js,
 					fail->msg);
 }
 
-static const char *sendpay_errmsg_fmt(const tal_t *ctx, int pay_errcode,
+static const char *sendpay_errmsg_fmt(const tal_t *ctx, errcode_t pay_errcode,
 				      const struct routing_failure *fail,
 				      const char *details)
 {
@@ -210,7 +210,7 @@ static const char *sendpay_errmsg_fmt(const tal_t *ctx, int pay_errcode,
 static struct command_result *
 sendpay_fail(struct command *cmd,
 	     const struct wallet_payment *payment,
-	     int pay_errcode,
+	     errcode_t pay_errcode,
 	     const struct onionreply *onionreply,
 	     const struct routing_failure *fail,
 	     const char *errmsg)
@@ -243,7 +243,7 @@ json_sendpay_in_progress(struct command *cmd,
 static void tell_waiters_failed(struct lightningd *ld,
 				const struct sha256 *payment_hash,
 				const struct wallet_payment *payment,
-				int pay_errcode,
+				errcode_t pay_errcode,
 				const struct onionreply *onionreply,
 				const struct routing_failure *fail,
 				const char *details)
@@ -377,7 +377,7 @@ remote_routing_failure(const tal_t *ctx,
 		       const u8 *failuremsg,
 		       int origin_index,
 		       struct log *log,
-		       int *pay_errcode)
+		       errcode_t *pay_errcode)
 {
 	enum onion_type failcode = fromwire_peektype(failuremsg);
 	struct routing_failure *routing_failure;
@@ -515,7 +515,7 @@ void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
 	struct wallet_payment *payment;
 	struct routing_failure* fail = NULL;
 	const char *failmsg;
-	int pay_errcode;
+	errcode_t pay_errcode;
 
 	payment = wallet_payment_by_hash(tmpctx, ld->wallet,
 					 &hout->payment_hash,
@@ -631,7 +631,7 @@ static struct command_result *wait_payment(struct lightningd *ld,
 	char *faildetail;
 	struct routing_failure *fail;
 	int faildirection;
-	int rpcerrorcode;
+	errcode_t rpcerrorcode;
 
 	payment = wallet_payment_by_hash(tmpctx, ld->wallet,
 					 payment_hash, partid);

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -2,6 +2,7 @@
 #define LIGHTNING_LIGHTNINGD_PAY_H
 #include "config.h"
 #include <ccan/short_types/short_types.h>
+#include <common/errcode.h>
 
 struct htlc_out;
 struct lightningd;
@@ -28,7 +29,7 @@ void json_add_payment_fields(struct json_stream *response,
 /* This json will be also used in 'sendpay_failure' notifictaion. */
 void json_sendpay_fail_fields(struct json_stream *js,
 			      const struct wallet_payment *t,
-			      int pay_errcode,
+			      errcode_t pay_errcode,
 			      const struct onionreply *onionreply,
 			      const struct routing_failure *fail);
 

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -2,6 +2,7 @@
 #include "../invoice.c"
 #include "../peer_control.c"
 #include <ccan/alignof/alignof.h>
+#include <common/errcode.h>
 
 bool deprecated_apis = false;
 
@@ -50,7 +51,7 @@ bool channel_tell_depth(struct lightningd *ld UNNEEDED,
 bool command_check_only(const struct command *cmd UNNEEDED)
 { fprintf(stderr, "command_check_only called!\n"); abort(); }
 /* Generated stub for command_fail */
-struct command_result *command_fail(struct command *cmd UNNEEDED, int code UNNEEDED,
+struct command_result *command_fail(struct command *cmd UNNEEDED, errcode_t code UNNEEDED,
 				    const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "command_fail called!\n"); abort(); }

--- a/lightningd/test/run-log-pruning.c
+++ b/lightningd/test/run-log-pruning.c
@@ -8,7 +8,7 @@ size_t bigsize_get(const u8 *p UNNEEDED, size_t max UNNEEDED, bigsize_t *val UNN
 size_t bigsize_put(u8 buf[BIGSIZE_MAX_LEN] UNNEEDED, bigsize_t v UNNEEDED)
 { fprintf(stderr, "bigsize_put called!\n"); abort(); }
 /* Generated stub for command_fail */
-struct command_result *command_fail(struct command *cmd UNNEEDED, int code UNNEEDED,
+struct command_result *command_fail(struct command *cmd UNNEEDED, errcode_t code UNNEEDED,
 				    const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "command_fail called!\n"); abort(); }

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -251,14 +251,14 @@ command_success_str(struct command *cmd, const char *str)
 }
 
 struct command_result *command_done_err(struct command *cmd,
-					int code,
+					errcode_t code,
 					const char *errmsg,
 					const struct json_out *data)
 {
 	struct json_out *jout = start_json_rpc(cmd, *cmd->id);
 
 	json_out_start(jout, "error", '{');
-	json_out_add(jout, "code", false, "%d", code);
+	json_out_add(jout, "code", false, "%" PRIerrcode, code);
 	json_out_addstr(jout, "message", errmsg);
 
 	if (data)
@@ -305,7 +305,7 @@ struct command_result *forward_result(struct command *cmd,
 
 /* Called by param() directly if it's malformed. */
 struct command_result *command_fail(struct command *cmd,
-				    int code, const char *fmt, ...)
+				    errcode_t code, const char *fmt, ...)
 {
 	va_list ap;
 	struct command_result *res;

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -4,6 +4,7 @@
 #include "config.h"
 
 #include <ccan/time/time.h>
+#include <common/errcode.h>
 #include <common/json.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
@@ -74,7 +75,7 @@ void NORETURN plugin_err(const char *fmt, ...);
  * NULL, data can be NULL; otherwise it must be a JSON object. */
 struct command_result *WARN_UNUSED_RESULT
 command_done_err(struct command *cmd,
-		 int code,
+		 errcode_t code,
 		 const char *errmsg,
 		 const struct json_out *data);
 

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -7,6 +7,7 @@
 #include <ccan/tal/str/str.h>
 #include <common/amount.h>
 #include <common/bolt11.h>
+#include <common/errcode.h>
 #include <common/features.h>
 #include <common/gossip_constants.h>
 #include <common/pseudorand.h>
@@ -425,13 +426,14 @@ static struct command_result *waitsendpay_error(struct command *cmd,
 {
 	struct pay_attempt *attempt = current_attempt(pc);
 	const jsmntok_t *codetok, *failcodetok, *nodeidtok, *scidtok, *dirtok;
-	int code, failcode;
+	errcode_t code;
+	int failcode;
 	bool node_err = false;
 
 	attempt_failed_tok(pc, "waitsendpay", buf, error);
 
 	codetok = json_get_member(buf, error, "code");
-	if (!json_to_int(buf, codetok, &code))
+	if (!json_to_errcode(buf, codetok, &code))
 		plugin_err("waitsendpay error gave no 'code'? '%.*s'",
 			   error->end - error->start, buf + error->start);
 
@@ -849,13 +851,13 @@ static struct command_result *getroute_error(struct command *cmd,
 					     const jsmntok_t *error,
 					     struct pay_command *pc)
 {
-	int code;
+	errcode_t code;
 	const jsmntok_t *codetok;
 
 	attempt_failed_tok(pc, "getroute", buf, error);
 
 	codetok = json_get_member(buf, error, "code");
-	if (!json_to_int(buf, codetok, &code))
+	if (!json_to_errcode(buf, codetok, &code))
 		plugin_err("getroute error gave no 'code'? '%.*s'",
 			   error->end - error->start, buf + error->start);
 

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -185,7 +185,7 @@ class Type(FieldSet):
         'bool',
         'amount_sat',
         'amount_msat',
-        'int',
+        'errcode_t',
         'bigsize',
         'varint'
     ]
@@ -200,7 +200,7 @@ class Type(FieldSet):
         'secp256k1_ecdsa_recoverable_signature',
         'wirestring',
         'double',
-        'int',
+        'errcode_t',
         'bigsize',
         'varint',
     ]

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -20,6 +20,7 @@ static void db_log_(struct log *log UNUSED, enum log_level level UNUSED, const s
 #include <ccan/mem/mem.h>
 #include <ccan/tal/str/str.h>
 #include <common/amount.h>
+#include <common/errcode.h>
 #include <common/memleak.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -61,7 +62,7 @@ bool channel_tell_depth(struct lightningd *ld UNNEEDED,
 bool command_check_only(const struct command *cmd UNNEEDED)
 { fprintf(stderr, "command_check_only called!\n"); abort(); }
 /* Generated stub for command_fail */
-struct command_result *command_fail(struct command *cmd UNNEEDED, int code UNNEEDED,
+struct command_result *command_fail(struct command *cmd UNNEEDED, errcode_t code UNNEEDED,
 				    const char *fmt UNNEEDED, ...)
 
 { fprintf(stderr, "command_fail called!\n"); abort(); }

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -9,8 +9,10 @@
 #include <ccan/crypto/siphash24/siphash24.h>
 #include <ccan/endian/endian.h>
 #include <ccan/mem/mem.h>
+#include <ccan/short_types/short_types.h>
 #include <ccan/tal/str/str.h>
 #include <common/amount.h>
+#include <common/errcode.h>
 #include <common/node_id.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
@@ -165,12 +167,12 @@ bool fromwire_bool(const u8 **cursor, size_t *max)
 	return ret;
 }
 
-int fromwire_int(const u8 **cursor, size_t *max)
+errcode_t fromwire_errcode_t(const u8 **cursor, size_t *max)
 {
-	int ret;
+	errcode_t ret;
 
-	if (!fromwire(cursor, max, &ret, sizeof(ret)))
-		return 0;
+	ret = (s32)fromwire_u32(cursor, max);
+
 	return ret;
 }
 

--- a/wire/towire.c
+++ b/wire/towire.c
@@ -10,6 +10,7 @@
 #include <ccan/mem/mem.h>
 #include <ccan/tal/tal.h>
 #include <common/amount.h>
+#include <common/errcode.h>
 #include <common/node_id.h>
 #include <common/utils.h>
 
@@ -87,9 +88,9 @@ void towire_bool(u8 **pptr, bool v)
 	towire(pptr, &val, sizeof(val));
 }
 
-void towire_int(u8 **pptr, int v)
+void towire_errcode_t(u8 **pptr, errcode_t v)
 {
-	towire(pptr, &v, sizeof(v));
+	towire_u32(pptr, (u32)v);
 }
 
 void towire_bigsize(u8 **pptr, const bigsize_t val)

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -13,6 +13,7 @@
 #include <ccan/structeq/structeq.h>
 #include <common/amount.h>
 #include <common/bigsize.h>
+#include <common/errcode.h>
 #include <common/node_id.h>
 #include <secp256k1_recovery.h>
 #include <stdlib.h>
@@ -79,7 +80,7 @@ void towire_tu64(u8 **pptr, u64 v);
 void towire_double(u8 **pptr, const double *v);
 void towire_pad(u8 **pptr, size_t num);
 void towire_bool(u8 **pptr, bool v);
-void towire_int(u8 **pptr, int v);
+void towire_errcode_t(u8 **pptr, errcode_t v);
 void towire_bigsize(u8 **pptr, const bigsize_t val);
 
 void towire_u8_array(u8 **pptr, const u8 *arr, size_t num);
@@ -102,7 +103,7 @@ u32 fromwire_tu32(const u8 **cursor, size_t *max);
 u64 fromwire_tu64(const u8 **cursor, size_t *max);
 void fromwire_double(const u8 **cursor, size_t *max, double *v);
 bool fromwire_bool(const u8 **cursor, size_t *max);
-int fromwire_int(const u8 **cursor, size_t *max);
+errcode_t fromwire_errcode_t(const u8 **cursor, size_t *max);
 bigsize_t fromwire_bigsize(const u8 **cursor, size_t *max);
 void fromwire_secret(const u8 **cursor, size_t *max, struct secret *secret);
 void fromwire_privkey(const u8 **cursor, size_t *max, struct privkey *privkey);


### PR DESCRIPTION
Before this patch we used `int` for error codes. The problem with
`int` is that we try to pass it to/from wire and the size of `int` is
not defined by the standard. So a sender with 4-byte `int` would write
4 bytes to the wire and a receiver with 2-byte `int` (for example) would
read just 2 bytes from the wire.

To resolve this:

* Introduce an error code type with a known size:
  `typedef int32_t errcode_t`.

* Change all error code macros to constants of type `errcode_t`.
  Constants also play better with gdb - it would visualize the name of
  the constant instead of the numeric value.

* Change all functions that take error codes to take the new type
  `errcode_t` instead of `int`.

* Introduce towire / fromwire functions to send / receive the newly added
  type `errcode_t` and use it instead of `towire_int()`.

In addition:

* Remove the now unneeded `towire_int()`.

* Replace a hardcoded error code `-2` with a new constant
  `INVOICE_EXPIRED_DURING_WAIT` (903).

Changelog-Changed: The waitinvoice command would now return error code 903 to designate that the invoice expired during wait, instead of the previous -2