### PR TITLE
pyln: actually specify jsonrpc in requests

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -285,6 +285,7 @@ class UnixDomainSocketRpc(object):
         # FIXME: we open a new socket for every readobj call...
         sock = UnixSocket(self.socket_path)
         self._writeobj(sock, {
+            "jsonrpc": "2.0",
             "method": method,
             "params": payload,
             "id": self.next_id,


### PR DESCRIPTION
We were not specifying the `jsonrpc` field in JSONRPC request produced by pyln. Uncovered this while refactoring libplugin, it made plugins crash (during functional tests, but not by-hand tests!) if we check for its presence.