### PR TITLE
.github/CODEOWNERS: Remove nonexistent module.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,6 @@ wallet/                 @cdecker
 *.py                    @cdecker
 
 wallet/invoices.*       @ZmnSCPxj
-lightningd/payalgo.*    @ZmnSCPxj
 
 common/param.*          @wythe
 common/json.*           @wythe


### PR DESCRIPTION
This was factored out into a separate `plugins/pay`, though I
am still not prepared to take over that.

ChangeLog-none