### PR TITLE
lightningd: fix memleak false positive.

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1119,7 +1119,7 @@ static void add_config(struct lightningd *ld,
 		       const struct opt_table *opt,
 		       const char *name, size_t len)
 {
-	char *name0 = tal_strndup(response, name, len);
+	char *name0 = tal_strndup(tmpctx, name, len);
 	const char *answer = NULL;
 	char buf[OPT_SHOW_LEN + sizeof("...")];
 
@@ -1234,7 +1234,6 @@ static void add_config(struct lightningd *ld,
 		struct json_escape *esc = json_escape(NULL, answer);
 		json_add_escaped_string(response, name0, take(esc));
 	}
-	tal_free(name0);
 }
 
 static struct command_result *json_listconfigs(struct command *cmd,


### PR DESCRIPTION
json_listconfigs() returns in the middle; the name0 is not always freed.

It will be freed later with the response, but our memleak detection doesn't
know that, and Travis caught it:

```
           Global errors:
E            - Node /tmp/ltests-5mfrzh5v/test_hsmtool_secret_decryption_1/lightning-1/ has memory leaks: [
E               {
E                   "backtrace": [
E                       "ccan/ccan/tal/tal.c:437 (tal_alloc_)",
E                       "ccan/ccan/tal/tal.c:466 (tal_alloc_arr_)",
E                       "ccan/ccan/tal/tal.c:794 (tal_dup_)",
E                       "ccan/ccan/tal/str/str.c:32 (tal_strndup_)",
E                       "lightningd/options.c:1122 (add_config)",
E                       "lightningd/options.c:1282 (json_listconfigs)",
E                       "lightningd/jsonrpc.c:588 (command_exec)",
E                       "lightningd/jsonrpc.c:679 (rpc_command_hook_callback)",
E                       "lightningd/plugin_hook.c:123 (plugin_hook_call_)",
E                       "lightningd/jsonrpc.c:729 (plugin_hook_call_rpc_command)",
E                       "lightningd/jsonrpc.c:736 (call_rpc_command_hook)",
E                       "common/timeout.c:39 (timer_expired)",
E                       "lightningd/io_loop_with_timers.c:32 (io_loop_with_timers)",
E                       "lightningd/lightningd.c:871 (main)"
E                   ],
E                   "label": "lightningd/options.c:1122:char[]",
E                   "parents": [
E                       "lightningd/json_stream.c:49:struct json_stream",
E                       "ccan/ccan/io/io.c:91:struct io_conn",
E                       "lightningd/lightningd.c:104:struct lightningd"
E                   ],
E                   "value": "0x5569ada057a8"
E               }
E           ]
```

Changelog-None

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>