### PR TITLE
json-rpc: Check that sendpay with mpp has all the details it needs

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2601,7 +2601,6 @@ def test_partial_payment(node_factory, bitcoind, executor):
     with pytest.raises(RpcError, match=r'Already have parallel payment in progress'):
         l1.rpc.sendpay(route=r124,
                        payment_hash=inv['payment_hash'],
-                       msatoshi=1000,
                        payment_secret=paysecret)
 
     # It will not allow a parallel with different msatoshi!


### PR DESCRIPTION
We were implicitly assuming a multi-part payment if the `msatoshi` argument
was specified, but then didn't check that we have all the pieces in place for
mpp. This adds a couple of additional checks to the arguments and makes it
more explicit what it means to do an mpp.

Fixes #3431

Reported-by: Sergei Tikhomirov <@s-tikhomirov>