### PR TITLE
doc/: Doc clarifications regarding connecting and funding.

### DIFF
--- a/doc/lightning-connect.7
+++ b/doc/lightning-connect.7
@@ -25,6 +25,10 @@ If not specified, the \fIport\fR defaults to 9735\.
 If \fIhost\fR is not specified, the connection will be attempted to an IP
 belonging to \fIid\fR obtained through gossip with other already connected
 peers\.
+This can fail if your C-lightning node is a fresh install that has not
+connected to any peers yet (your node has no gossip yet),
+or if the target \fIid\fR is a fresh install that has no channels yet
+(nobody will gossip about a node until it has one published channel)\.
 
 
 If \fIhost\fR begins with a \fI/\fR it is interpreted as a local path, and the

--- a/doc/lightning-connect.7.md
+++ b/doc/lightning-connect.7.md
@@ -23,6 +23,10 @@ If not specified, the *port* defaults to 9735.
 If *host* is not specified, the connection will be attempted to an IP
 belonging to *id* obtained through gossip with other already connected
 peers.
+This can fail if your C-lightning node is a fresh install that has not
+connected to any peers yet (your node has no gossip yet),
+or if the target *id* is a fresh install that has no channels yet
+(nobody will gossip about a node until it has one published channel).
 
 If *host* begins with a */* it is interpreted as a local path, and the
 connection will be made to that local socket (see **bind-addr** in

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -10,8 +10,13 @@ lightning-fundchannel - Command for establishing a lightning channel
 
 The \fBfundchannel\fR RPC command opens a payment channel with a peer by
 committing a funding transaction to the blockchain as defined in BOLT
-#2\. \fBfundchannel\fR by itself does not attempt to open a connection\. A
-connection must first be established using \fBconnect\fR\. Once the
+#2\.
+If not already connected, \fBfundchannel\fR will automatically attempt
+to connect if C-lightning knows a way to contact the node (either from
+normal gossip, or from a previous \fBconnect\fR call)\.
+This auto-connection can fail if C-lightning does not know how to contact
+the target node; see \fBlightning-connect\fR(7)\.
+Once the
 transaction is confirmed, normal channel operations may begin\. Readiness
 is indicated by \fBlistpeers\fR reporting a \fIstate\fR of CHANNELD_NORMAL
 for the channel\.

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -12,8 +12,13 @@ DESCRIPTION
 
 The **fundchannel** RPC command opens a payment channel with a peer by
 committing a funding transaction to the blockchain as defined in BOLT
-\#2. **fundchannel** by itself does not attempt to open a connection. A
-connection must first be established using **connect**. Once the
+\#2.
+If not already connected, **fundchannel** will automatically attempt
+to connect if C-lightning knows a way to contact the node (either from
+normal gossip, or from a previous **connect** call).
+This auto-connection can fail if C-lightning does not know how to contact
+the target node; see lightning-connect(7).
+Once the
 transaction is confirmed, normal channel operations may begin. Readiness
 is indicated by **listpeers** reporting a *state* of CHANNELD\_NORMAL
 for the channel.

--- a/doc/lightningd.8
+++ b/doc/lightningd.8
@@ -36,21 +36,23 @@ options\.
 
 .SH LOGGING AND COMMANDING C-LIGHTNING
 
-By default, C-Lightning will log to the standard output.
-To log to a specific file, use \fB--log-file\fR=\fIPATH\fR.
+By default, C-Lightning will log to the standard output\.
+To log to a specific file, use \fB--log-file\fR=\fIPATH\fR\.
 Sending SIGHUP will cause C-Lightning to reopen this file,
-for example to do log rotation.
+for example to do log rotation\.
+
 
 C-Lightning will set up a Unix domain socket for receiving
-commands.
+commands\.
 By default this will be the file \fBlightning-rpc\fR in your
-specified \fBlightning-dir\fR.
-You can use lightning-cli(1) to send commands to C-Lightning
+specified \fBlightning-dir\fR\.
+You can use \fBlightning-cli\fR(1) to send commands to C-Lightning
 once \fBlightningd\fR has started; you need to match the
-\fB--lightning-dir\fR and \fB--rpc-file\fR options between them.
+\fB--lightning-dir\fR and \fB--rpc-file\fR options between them\.
+
 
 Commands for C-Lightning are described in various manpages
-in section 7, with the common prefix \fBlightning-\fR.
+in section 7, with the common prefix \fBlightning-\fR\.
 
 .SH QUICK START
 
@@ -174,11 +176,11 @@ key is a long hex string, like so:
 
 
 After determining a public key, use \fBlightning-connect\fR(7) to connect to
-that public key:
+that public key at that IP:
 
 .nf
 .RS
-$ lightning-cli connect $PUBLICKEY
+$ lightning-cli connect $PUBLICKEY $IP
 
 
 .RE

--- a/doc/lightningd.8.md
+++ b/doc/lightningd.8.md
@@ -127,9 +127,9 @@ key is a long hex string, like so:
 (this example public key is not used as of this writing)
 
 After determining a public key, use lightning-connect(7) to connect to
-that public key:
+that public key at that IP:
 
-    $ lightning-cli connect $PUBLICKEY
+    $ lightning-cli connect $PUBLICKEY $IP
 
 Then open a channel to that node using lightning-fundchannel(7):
 


### PR DESCRIPTION
ChangeLog-Fixed: Clarified about connection in documentation.  Also, `fundchannel`  already `connect`s if your node knows how to contact the desired peer for a few versions now, so clarify documentation about this as well.