### PR TITLE
lightningd: fix reorg bug where we don't fire watches.

### DIFF
--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -85,7 +85,8 @@ HTABLE_DEFINE_TYPE(struct block, keyof_block_map, hash_sha, block_eq, block_map)
 struct chain_topology {
 	struct lightningd *ld;
 	struct block *root;
-	struct block *prev_tip, *tip;
+	struct block *tip;
+	struct bitcoin_blkid prev_tip;
 	struct block_map block_map;
 	u32 feerate[NUM_FEERATES];
 	bool feerate_uninitialized;


### PR DESCRIPTION
Note to the reader: this is a classic bug, and yes, it was me who made it (and realized what it was once I finally tracked it down, since I've made it before!).  Learn from my mistakes: comparing with a freed pointer is always dangerous, even if you think it's OK!

If the same memory gets reallocated, our "has the tip changed?" test
gets a false negative.  This happened for me about one time in 10,
causing tests/test_misc.py::test_funding_reorg_remote_lags to fail.

Changelog-None
