### PR TITLE
Add CONFIGURATOR_WRAPPER

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2488-g7aac849a
+CCAN version: init-2491-ga1f9c169

--- a/ccan/ccan/bitmap/bitmap.h
+++ b/ccan/ccan/bitmap/bitmap.h
@@ -21,7 +21,7 @@ typedef unsigned long bitmap_word;
 /*
  * We wrap each word in a structure for type checking.
  */
-typedef struct {
+typedef struct bitmap {
 	bitmap_word w;
 } bitmap;
 

--- a/ccan/ccan/json_out/json_out.h
+++ b/ccan/ccan/json_out/json_out.h
@@ -87,11 +87,11 @@ bool json_out_end(struct json_out *jout, char type);
  * If the resulting string requires escaping, and @quote is true, we
  * call json_escape().
  */
+PRINTF_FMT(4,5)
 bool json_out_add(struct json_out *jout,
 		  const char *fieldname,
 		  bool quote,
-		  const char *fmt, ...)
-	PRINTF_FMT(4,5);
+		  const char *fmt, ...);
 
 /**
  * json_out_addv - add a formatted member (vararg variant)

--- a/configure
+++ b/configure
@@ -230,7 +230,7 @@ fi
 require 'python3-mako' "You need the mako module for python3: see doc/INSTALL.md" python3 -c 'import mako'
 
 rm -f $CONFIG_VAR_FILE.$$
-$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib <<EOF
+$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib <<EOF
 var=HAVE_GOOD_LIBSODIUM
 desc=libsodium with IETF chacha20 variants
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE


### PR DESCRIPTION
This was necessary for cross-compiling. Otherwise the configurator will be compiled for the host architecture.

Here are my scripts for cross compiling with docker, if you want to reproduce:

https://github.com/NickeZ/bitbox-base/commit/cf7c4e851638d547891351bf57dca8197310239e

Thanks