### PR TITLE
wallet: set nLockTime to the tip for withdrawal transactions

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -380,7 +380,8 @@ static void bitcoin_tx_destroy(struct bitcoin_tx *tx)
 
 struct bitcoin_tx *bitcoin_tx(const tal_t *ctx,
 			      const struct chainparams *chainparams,
-			      varint_t input_count, varint_t output_count)
+			      varint_t input_count, varint_t output_count,
+			      u32 nlocktime)
 {
 	struct bitcoin_tx *tx = tal(ctx, struct bitcoin_tx);
 	assert(chainparams);
@@ -396,7 +397,7 @@ struct bitcoin_tx *bitcoin_tx(const tal_t *ctx,
 	tal_add_destructor(tx, bitcoin_tx_destroy);
 
 	tx->input_amounts = tal_arrz(tx, struct amount_sat*, input_count);
-	tx->wtx->locktime = 0;
+	tx->wtx->locktime = nlocktime;
 	tx->wtx->version = 2;
 	tx->chainparams = chainparams;
 	return tx;

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -57,7 +57,8 @@ size_t bitcoin_tx_weight(const struct bitcoin_tx *tx);
  * zeroed with inputs' sequence_number set to FFFFFFFF) */
 struct bitcoin_tx *bitcoin_tx(const tal_t *ctx,
 			      const struct chainparams *chainparams,
-			      varint_t input_count, varint_t output_count);
+			      varint_t input_count, varint_t output_count,
+			      u32 nlocktime);
 
 /* This takes a raw bitcoin tx in hex. */
 struct bitcoin_tx *bitcoin_tx_from_hex(const tal_t *ctx, const char *hex,

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -146,7 +146,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 #endif
 
 	/* Worst-case sizing: both to-local and to-remote outputs. */
-	tx = bitcoin_tx(ctx, chainparams, 1, untrimmed + 2);
+	tx = bitcoin_tx(ctx, chainparams, 1, untrimmed + 2, 0);
 
 	/* We keep track of which outputs have which HTLCs */
 	*htlcmap = tal_arr(tx, const struct htlc *, tx->wtx->outputs_allocation_len);

--- a/common/close_tx.c
+++ b/common/close_tx.c
@@ -34,7 +34,7 @@ struct bitcoin_tx *create_close_tx(const tal_t *ctx,
 	 * * txin count: 1
 	 */
 	/* Now create close tx: one input, two outputs. */
-	tx = bitcoin_tx(ctx, chainparams, 1, 2);
+	tx = bitcoin_tx(ctx, chainparams, 1, 2, 0);
 
 	/* Our input spends the anchor tx output. */
 	bitcoin_tx_add_input(tx, anchor_txid, anchor_index,

--- a/common/funding_tx.c
+++ b/common/funding_tx.c
@@ -26,7 +26,8 @@ struct bitcoin_tx *funding_tx(const tal_t *ctx,
 	struct bitcoin_tx *tx;
 	bool has_change = !amount_sat_eq(change, AMOUNT_SAT(0));
 
-	tx = tx_spending_utxos(ctx, chainparams, utxomap, bip32_base, has_change, 1);
+	tx = tx_spending_utxos(ctx, chainparams, utxomap, bip32_base,
+			       has_change, 1, 0, BITCOIN_TX_DEFAULT_SEQUENCE);
 
 
 	wscript = bitcoin_redeem_2of2(tx, local_fundingkey, remote_fundingkey);

--- a/common/htlc_tx.c
+++ b/common/htlc_tx.c
@@ -15,7 +15,10 @@ static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 				  struct amount_sat htlc_fee,
 				  u32 locktime)
 {
-	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams, 1, 1);
+	/* BOLT #3:
+	 * * locktime: `0` for HTLC-success, `cltv_expiry` for HTLC-timeout
+	 */
+	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams, 1, 1, locktime);
 	u8 *wscript;
 	struct amount_sat amount;
 
@@ -33,11 +36,6 @@ static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 	 * * version: 2
 	 */
 	assert(tx->wtx->version == 2);
-
-	/* BOLT #3:
-	 * * locktime: `0` for HTLC-success, `cltv_expiry` for HTLC-timeout
-	 */
-	tx->wtx->locktime = locktime;
 
 	/* BOLT #3:
 	 * * txin count: 1

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -145,7 +145,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 
 
 	/* Worst-case sizing: both to-local and to-remote outputs. */
-	tx = bitcoin_tx(ctx, chainparams, 1, untrimmed + 2);
+	tx = bitcoin_tx(ctx, chainparams, 1, untrimmed + 2, 0);
 
 	/* This could be done in a single loop, but we follow the BOLT
 	 * literally to make comments in test vectors clearer. */

--- a/common/utxo.c
+++ b/common/utxo.c
@@ -62,14 +62,17 @@ struct bitcoin_tx *tx_spending_utxos(const tal_t *ctx,
 				     const struct utxo **utxos,
 				     const struct ext_key *bip32_base,
 				     bool add_change_output,
-				     size_t num_output)
+				     size_t num_output,
+				     u32 nlocktime,
+				     u32 nsequence)
 {
 	struct pubkey key;
 	u8 *script;
 
 	assert(num_output);
 	size_t outcount = add_change_output ? 1 + num_output : num_output;
-	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams, tal_count(utxos), outcount);
+	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams, tal_count(utxos),
+					   outcount, nlocktime);
 
 	for (size_t i = 0; i < tal_count(utxos); i++) {
 		if (utxos[i]->is_p2sh && bip32_base) {
@@ -80,8 +83,7 @@ struct bitcoin_tx *tx_spending_utxos(const tal_t *ctx,
 		}
 
 		bitcoin_tx_add_input(tx, &utxos[i]->txid, utxos[i]->outnum,
-				     BITCOIN_TX_DEFAULT_SEQUENCE,
-		 		     utxos[i]->amount, script);
+				     nsequence, utxos[i]->amount, script);
 	}
 
 	return tx;

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -52,6 +52,8 @@ struct bitcoin_tx *tx_spending_utxos(const tal_t *ctx,
 				     const struct utxo **utxos,
 				     const struct ext_key *bip32_base,
 				     bool add_change_output,
-				     size_t num_output);
+				     size_t num_output,
+				     u32 nlocktime,
+				     u32 nsequence);
 
 #endif /* LIGHTNING_COMMON_UTXO_H */

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -16,14 +16,15 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct pubkey *changekey,
 			       struct amount_sat change,
 			       const struct ext_key *bip32_base,
-			       int *change_outnum)
+			       int *change_outnum, u32 nlocktime)
 {
 	struct bitcoin_tx *tx;
 	int output_count;
 
 	tx = tx_spending_utxos(ctx, chainparams, utxos, bip32_base,
 			       !amount_sat_eq(change, AMOUNT_SAT(0)),
-			       tal_count(outputs));
+			       tal_count(outputs), nlocktime,
+			       BITCOIN_TX_DEFAULT_SEQUENCE - 1);
 
 	output_count = bitcoin_tx_add_multi_outputs(tx, outputs);
 	assert(output_count == tal_count(outputs));

--- a/common/withdraw_tx.h
+++ b/common/withdraw_tx.h
@@ -25,6 +25,7 @@ struct utxo;
  * @change: (in) amount to send as change.
  * @bip32_base: (in) bip32 base for key derivation, or NULL.
  * @change_outnum: (out) set to output index of change output or -1 if none, unless NULL.
+ * @nlocktime: (in) the value to set as the transaction's nLockTime.
  */
 struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct chainparams *chainparams,
@@ -33,6 +34,6 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct pubkey *changekey,
 			       struct amount_sat change,
 			       const struct ext_key *bip32_base,
-			       int *change_outnum);
+			       int *change_outnum, u32 nlocktime);
 
 #endif /* LIGHTNING_COMMON_WITHDRAW_TX_H */

--- a/devtools/mkclose.c
+++ b/devtools/mkclose.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 	    || !pubkey_from_privkey(&funding_privkey[REMOTE], &funding_pubkey[REMOTE]))
 		errx(1, "Bad deriving funding pubkeys");
 
-	tx = bitcoin_tx(NULL, chainparams, 1, 2);
+	tx = bitcoin_tx(NULL, chainparams, 1, 2, 0);
 
 	/* Our input spends the anchor tx output. */
 	bitcoin_tx_add_input(tx, &funding_txid, funding_outnum,

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -74,6 +74,7 @@ msgdata,hsm_sign_withdrawal,num_outputs,u16,
 msgdata,hsm_sign_withdrawal,outputs,bitcoin_tx_output,num_outputs
 msgdata,hsm_sign_withdrawal,num_inputs,u16,
 msgdata,hsm_sign_withdrawal,inputs,utxo,num_inputs
+msgdata,hsm_sign_withdrawal,nlocktime,u32,
 
 msgtype,hsm_sign_withdrawal_reply,107
 msgdata,hsm_sign_withdrawal_reply,tx,bitcoin_tx,

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -1643,10 +1643,11 @@ static struct io_plan *handle_sign_withdrawal_tx(struct io_conn *conn,
 	struct bitcoin_tx *tx;
 	struct pubkey changekey;
 	struct bitcoin_tx_output **outputs;
+	u32 nlocktime;
 
 	if (!fromwire_hsm_sign_withdrawal(tmpctx, msg_in, &satoshi_out,
 					  &change_out, &change_keyindex,
-					  &outputs, &utxos))
+					  &outputs, &utxos, &nlocktime))
 		return bad_req(conn, c, msg_in);
 
 	if (!bip32_pubkey(&secretstuff.bip32, &changekey, change_keyindex))
@@ -1655,7 +1656,7 @@ static struct io_plan *handle_sign_withdrawal_tx(struct io_conn *conn,
 
 	tx = withdraw_tx(tmpctx, c->chainparams,
 			 cast_const2(const struct utxo **, utxos), outputs,
-			 &changekey, change_out, NULL, NULL);
+			 &changekey, change_out, NULL, NULL, nlocktime);
 
 	sign_all_inputs(tx, utxos);
 

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -330,8 +330,7 @@ static struct bitcoin_tx *tx_to_us(const tal_t *ctx,
 	u8 *msg;
 	u8 **witness;
 
-	tx = bitcoin_tx(ctx, out->chainparams, 1, 1);
-	tx->wtx->locktime = locktime;
+	tx = bitcoin_tx(ctx, out->chainparams, 1, 1, locktime);
 	bitcoin_tx_add_input(tx, &out->txid, out->outnum, to_self_delay,
 			     out->sat, NULL);
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -10,6 +10,7 @@
 #include <common/jsonrpc_errors.h>
 #include <common/key_derive.h>
 #include <common/param.h>
+#include <common/pseudorand.h>
 #include <common/status.h>
 #include <common/utils.h>
 #include <common/utxo.h>
@@ -288,9 +289,11 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 		 *   native segwit, nlocktime set to tip, and sequence set to
 		 *   0xFFFFFFFE by default. Other wallets are likely to implement
 		 *   this too).
-		 * FIXME: Do we want to also fuzz this like bitcoind does ?
 		 */
 		locktime = cmd->ld->topology->tip->height;
+		/* Eventually fuzz it too. */
+		if (pseudorand(10) == 0)
+			locktime -= (u32)pseudorand(100);
 	}
 
 	if (!feerate_per_kw) {


### PR DESCRIPTION
This sets the nLockTime to the tip (and accordingly each input's nSequence to
0xfffffffe) for withdrawal transactions.

Even if the anti fee-sniping argument might not be valid until some time yet,
this makes our regular wallet transactions far less distinguishable from
bitcoind's ones since it now defaults to using native Segwit transactions
(like us). Moreover other wallets are likely to implement this (if they
haven't already).

Changelog-Added: wallet: withdrawal transactions now sets nlocktime to the current tip.