### PR TITLE
lightningd: disallow `msatoshi` arg to sendpay unless exact when non-…

### DIFF
--- a/doc/lightning-sendpay.7
+++ b/doc/lightning-sendpay.7
@@ -29,8 +29,8 @@ The \fIlabel\fR and \fIbolt11\fR parameters, if provided, will be returned in
 \fIwaitsendpay\fR and \fIlistsendpays\fR results\.
 
 
-The \fImsatoshi\fR amount, if provided, is the amount that will be recorded
-as the target payment value\. If not specified, it will be the final
+The \fImsatoshi\fR amount must be provided if \fIpartid\fR is non-zero, otherwise
+it must be equal to the final
 amount to the destination\. By default it is in millisatoshi precision; it can be a whole number, or a whole number
 ending in \fImsat\fR or \fIsat\fR, or a number with three decimal places ending
 in \fIsat\fR, or a number with 1 to 11 decimal places ending in \fIbtc\fR\.

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -27,8 +27,8 @@ definite failure.
 The *label* and *bolt11* parameters, if provided, will be returned in
 *waitsendpay* and *listsendpays* results.
 
-The *msatoshi* amount, if provided, is the amount that will be recorded
-as the target payment value. If not specified, it will be the final
+The *msatoshi* amount must be provided if *partid* is non-zero, otherwise
+it must be equal to the final
 amount to the destination. By default it is in millisatoshi precision; it can be a whole number, or a whole number
 ending in *msat* or *sat*, or a number with three decimal places ending
 in *sat*, or a number with 1 to 11 decimal places ending in *btc*.


### PR DESCRIPTION
…MPP.

Using it with a different value to the amount sent causes a crash in 0.8.0,
which is effectively deprecating it, so let's disallow it now.

Changelog-Changed: If the optional `msatoshi` param to sendpay for non-MPP is set, it must be the exact amount sent to the final recipient.
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Fixes: #3431 
Closes: #3450 