### PR TITLE
lightningd: remove things we deprecated 6 months ago.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2179,7 +2179,7 @@ void json_format_forwarding_object(struct json_stream *response,
 	json_add_short_channel_id(response, "in_channel", &cur->channel_in);
 
 	/* This can be unknown if we failed before channel lookup */
-	if (cur->channel_out.u64 != 0 || deprecated_apis)
+	if (cur->channel_out.u64 != 0)
 		json_add_short_channel_id(response, "out_channel",
 					  &cur->channel_out);
 	json_add_amount_msat_compat(response,
@@ -2187,7 +2187,7 @@ void json_format_forwarding_object(struct json_stream *response,
 				    "in_msatoshi", "in_msat");
 
 	/* These can be unset (aka zero) if we failed before channel lookup */
-	if (cur->channel_out.u64 != 0 || deprecated_apis) {
+	if (cur->channel_out.u64 != 0) {
 		json_add_amount_msat_compat(response,
 					    cur->msat_out,
 					    "out_msatoshi",  "out_msat");

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -69,23 +69,6 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES)
 	p->plugins = plugins;
 	p->cmd = tal_strdup(p, path);
 
-	/* Fix up old-style relative paths */
-	if (deprecated_apis
-	    && !path_is_abs(p->cmd)
-	    && access(p->cmd, X_OK) != 0) {
-		char *oldpath = path_join(tmpctx,
-					  plugins->ld->original_directory,
-					  p->cmd);
-		if (access(oldpath, X_OK) == 0) {
-			log_unusual(plugins->log, "DEPRECATED WARNING:"
-				    " plugin is now relative to"
-				    " lightning-dir, please change to"
-				    " plugin=%s",
-				    oldpath);
-			tal_free(p->cmd);
-			p->cmd = tal_steal(p, oldpath);
-		}
-	}
 	p->plugin_state = UNCONFIGURED;
 	p->js_arr = tal_arr(p, struct json_stream *, 0);
 	p->used = 0;

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -710,25 +710,6 @@ def test_forward_event_notification(node_factory, bitcoind, executor):
     assert plugin_stats[5] == expect
 
 
-def test_plugin_deprecated_relpath(node_factory):
-    """Test that we can use old-style relative plugin paths with deprecated-apis"""
-    l1 = node_factory.get_node(options={'plugin-dir': 'contrib/plugins',
-                                        'plugin': 'tests/plugins/millisatoshis.py',
-                                        'allow-deprecated-apis': True})
-
-    plugins = l1.rpc.plugin_list()['plugins']
-    assert ('helloworld.py', True) in [(os.path.basename(p['name']), p['active']) for p in plugins]
-    assert ('millisatoshis.py', True) in [(os.path.basename(p['name']), p['active']) for p in plugins]
-
-    assert l1.daemon.is_in_log('DEPRECATED WARNING.*plugin-dir={}'
-                               .format(os.path.join(os.getcwd(),
-                                                    'contrib/plugins')))
-
-    assert l1.daemon.is_in_log('DEPRECATED WARNING.*plugin={}'
-                               .format(os.path.join(os.getcwd(),
-                                                    'tests/plugins/millisatoshis.py')))
-
-
 def test_sendpay_notifications(node_factory, bitcoind):
     """ test 'sendpay_success' and 'sendpay_failure' notifications
     """


### PR DESCRIPTION
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Removed: Relative plugin paths are not relative to startup (deprecated v0.7.2.1)
Changelog-Removed: Dummy fields in listforwards (deprecated v0.7.2.1)