### PR TITLE
HTLC error cleanup

### DIFF
--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -87,8 +87,9 @@ msgdata,channel_offer_htlc,onion_routing_packet,u8,1366
 # Reply; synchronous since IDs have to increment.
 msgtype,channel_offer_htlc_reply,1104
 msgdata,channel_offer_htlc_reply,id,u64,
-# Zero failure code means success.,
-msgdata,channel_offer_htlc_reply,failure_code,u16,
+# Empty failure message means success.
+msgdata,channel_offer_htlc_reply,len,u16,
+msgdata,channel_offer_htlc_reply,failuremsg,u8,len
 msgdata,channel_offer_htlc_reply,failurestr,wirestring,
 
 # Main daemon found out the preimage for an HTLC

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -49,7 +49,6 @@ msgdata,channel_init,num_failed_in,u16,
 msgdata,channel_init,failed_in,failed_htlc,num_failed_in
 msgdata,channel_init,num_failed_out,u16,
 msgdata,channel_init,failed_out,u64,num_failed_out
-msgdata,channel_init,failheight,u32,
 msgdata,channel_init,local_funding_locked,bool,
 msgdata,channel_init,remote_funding_locked,bool,
 msgdata,channel_init,funding_short_id,short_channel_id,
@@ -100,7 +99,6 @@ msgdata,channel_fulfill_htlc,fulfilled_htlc,fulfilled_htlc,
 # Main daemon says HTLC failed
 msgtype,channel_fail_htlc,1006
 msgdata,channel_fail_htlc,failed_htlc,failed_htlc,
-msgdata,channel_fail_htlc,failheight,u32,
 
 # When we receive funding_locked.
 msgtype,channel_got_funding_locked,1019
@@ -130,7 +128,6 @@ msgdata,channel_got_commitsig,htlc_signature,secp256k1_ecdsa_signature,num_htlcs
 # RCVD_ADD_COMMIT: we're now committed to their new offered HTLCs.
 msgdata,channel_got_commitsig,num_added,u16,
 msgdata,channel_got_commitsig,added,added_htlc,num_added
-msgdata,channel_got_commitsig,shared_secret,secret,num_added
 # RCVD_REMOVE_COMMIT: we're now no longer committed to these HTLCs.
 msgdata,channel_got_commitsig,num_fulfilled,u16,
 msgdata,channel_got_commitsig,fulfilled,fulfilled_htlc,num_fulfilled

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -45,9 +45,10 @@ msgdata,channel_init,htlc_states,enum htlc_state,num_htlcs
 msgdata,channel_init,num_fulfilled,u16,
 msgdata,channel_init,fulfilled,fulfilled_htlc,num_fulfilled
 msgdata,channel_init,fulfilled_sides,enum side,num_fulfilled
-msgdata,channel_init,num_failed,u16,
-msgdata,channel_init,failed,failed_htlc,num_failed
-msgdata,channel_init,failed_sides,enum side,num_failed
+msgdata,channel_init,num_failed_in,u16,
+msgdata,channel_init,failed_in,failed_htlc,num_failed_in
+msgdata,channel_init,num_failed_out,u16,
+msgdata,channel_init,failed_out,u64,num_failed_out
 msgdata,channel_init,failheight,u32,
 msgdata,channel_init,local_funding_locked,bool,
 msgdata,channel_init,remote_funding_locked,bool,

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3005,8 +3005,8 @@ static void init_channel(struct peer *peer)
 	enum htlc_state *hstates;
 	struct fulfilled_htlc *fulfilled;
 	enum side *fulfilled_sides;
-	struct failed_htlc **failed;
-	enum side *failed_sides;
+	struct failed_htlc **failed_in;
+	u64 *failed_out;
 	struct added_htlc *htlcs;
 	bool reconnected;
 	u8 *funding_signed;
@@ -3060,8 +3060,8 @@ static void init_channel(struct peer *peer)
 				   &hstates,
 				   &fulfilled,
 				   &fulfilled_sides,
-				   &failed,
-				   &failed_sides,
+				   &failed_in,
+				   &failed_out,
 				   &failheight,
 				   &peer->funding_locked[LOCAL],
 				   &peer->funding_locked[REMOTE],
@@ -3143,8 +3143,9 @@ static void init_channel(struct peer *peer)
 	if (!channel_force_htlcs(peer->channel, htlcs, hstates,
 				 fulfilled, fulfilled_sides,
 				 cast_const2(const struct failed_htlc **,
-					     failed),
-				 failed_sides, failheight))
+					     failed_in),
+				 failed_out,
+				 failheight))
 		status_failed(STATUS_FAIL_INTERNAL_ERROR,
 			      "Could not restore HTLCs");
 
@@ -3157,8 +3158,8 @@ static void init_channel(struct peer *peer)
 	tal_free(hstates);
 	tal_free(fulfilled);
 	tal_free(fulfilled_sides);
-	tal_free(failed);
-	tal_free(failed_sides);
+	tal_free(failed_in);
+	tal_free(failed_out);
 	tal_free(remote_ann_node_sig);
 	tal_free(remote_ann_bitcoin_sig);
 

--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -22,26 +22,11 @@ struct htlc {
 	/* The preimage which hashes to rhash (if known) */
 	struct preimage *r;
 
-	/* The routing shared secret (only for incoming) */
-	struct secret *shared_secret;
-	/* If incoming HTLC has shared_secret, this is which BADONION error */
-	enum onion_type why_bad_onion;
-	/* sha256 of next_onion, in case peer says it was malformed. */
-	struct sha256 next_onion_sha;
+	/* If they fail the HTLC, we store why here. */
+	const struct failed_htlc *failed;
 
-	/* FIXME: We could union these together: */
-	/* Routing information sent with this HTLC. */
+	/* Routing information sent with this HTLC (outgoing only). */
 	const u8 *routing;
-
-	/* Failure message we received or generated. */
-	const struct onionreply *fail;
-	/* For a local failure, we might have to generate fail ourselves
-	 * (or, if BADONION we send a update_fail_malformed_htlc). */
-	enum onion_type failcode;
-	/* If failcode & UPDATE, this is channel which failed. Otherwise NULL. */
-	const struct short_channel_id *failed_scid;
-	/* Block height it failed at */
-	u32 failblock;
 };
 
 static inline bool htlc_has(const struct htlc *h, int flag)

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -1188,8 +1188,8 @@ bool channel_force_htlcs(struct channel *channel,
 			 const enum htlc_state *hstates,
 			 const struct fulfilled_htlc *fulfilled,
 			 const enum side *fulfilled_sides,
-			 const struct failed_htlc **failed,
-			 const enum side *failed_sides,
+			 const struct failed_htlc **failed_in,
+			 const u64 *failed_out,
 			 u32 failheight)
 {
 	size_t i;
@@ -1206,12 +1206,6 @@ bool channel_force_htlcs(struct channel *channel,
 	if (tal_count(fulfilled) != tal_count(fulfilled_sides)) {
 		status_broken("#fulfilled sides %zu != #fulfilled %zu",
 			     tal_count(fulfilled_sides), tal_count(fulfilled));
-		return false;
-	}
-
-	if (tal_count(failed) != tal_count(failed_sides)) {
-		status_broken("#failed sides %zu != #failed %zu",
-			     tal_count(failed_sides), tal_count(failed));
 		return false;
 	}
 
@@ -1282,56 +1276,86 @@ bool channel_force_htlcs(struct channel *channel,
 				  &fulfilled[i].payment_preimage);
 	}
 
-	for (i = 0; i < tal_count(failed); i++) {
+	for (i = 0; i < tal_count(failed_in); i++) {
 		struct htlc *htlc;
-		htlc = channel_get_htlc(channel, failed_sides[i],
-					failed[i]->id);
+		htlc = channel_get_htlc(channel, REMOTE, failed_in[i]->id);
 		if (!htlc) {
-			status_broken("Fail %s HTLC %"PRIu64" not found",
-				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id);
+			status_broken("Fail in HTLC %"PRIu64" not found",
+				     failed_in[i]->id);
 			return false;
 		}
 		if (htlc->r) {
-			status_broken("Fail %s HTLC %"PRIu64" already fulfilled",
-				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id);
+			status_broken("Fail in HTLC %"PRIu64" already fulfilled",
+				     failed_in[i]->id);
 			return false;
 		}
 		if (htlc->fail) {
-			status_broken("Fail %s HTLC %"PRIu64" already failed",
-				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id);
+			status_broken("Fail in HTLC %"PRIu64" already failed_in",
+				     failed_in[i]->id);
 			return false;
 		}
 		if (htlc->failcode) {
-			status_broken("Fail %s HTLC %"PRIu64" already fail %u",
-				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id, htlc->failcode);
+			status_broken("Fail in HTLC %"PRIu64" already fail %u",
+				     failed_in[i]->id, htlc->failcode);
 			return false;
 		}
 		if (!htlc_has(htlc, HTLC_REMOVING)) {
-			status_broken("Fail %s HTLC %"PRIu64" state %s",
-				     failed_sides[i] == LOCAL ? "out" : "in",
-				     failed[i]->id,
+			status_broken("Fail in HTLC %"PRIu64" state %s",
+				     failed_in[i]->id,
 				     htlc_state_name(htlc->state));
 			return false;
 		}
-		htlc->failcode = failed[i]->failcode;
-		/* We assume they all failed at the same height, which is
+		htlc->failcode = failed_in[i]->failcode;
+		/* We assume they all failed_in at the same height, which is
 		 * not necessarily true in case of restart.  But it's only
 		 * a hint. */
 		htlc->failblock = failheight;
-		if (failed[i]->failreason)
-			htlc->fail = dup_onionreply(htlc, failed[i]->failreason);
+		if (failed_in[i]->failreason)
+			htlc->fail = dup_onionreply(htlc, failed_in[i]->failreason);
 		else
 			htlc->fail = NULL;
-		if (failed[i]->scid)
+		if (failed_in[i]->scid)
 			htlc->failed_scid = tal_dup(htlc,
 						    struct short_channel_id,
-						    failed[i]->scid);
+						    failed_in[i]->scid);
 		else
 			htlc->failed_scid = NULL;
+	}
+
+	for (i = 0; i < tal_count(failed_out); i++) {
+		struct htlc *htlc;
+
+		htlc = channel_get_htlc(channel, LOCAL, failed_out[i]);
+		if (!htlc) {
+			status_broken("Fail out HTLC %"PRIu64" not found",
+				      failed_out[i]);
+			return false;
+		}
+		if (htlc->r) {
+			status_broken("Fail out HTLC %"PRIu64" already fulfilled",
+				      failed_out[i]);
+			return false;
+		}
+		if (htlc->fail) {
+			status_broken("Fail out HTLC %"PRIu64" already failed",
+				      failed_out[i]);
+			return false;
+		}
+		if (htlc->failcode) {
+			status_broken("Fail out HTLC %"PRIu64" already fail %u",
+				      failed_out[i], htlc->failcode);
+			return false;
+		}
+		if (!htlc_has(htlc, HTLC_REMOVING)) {
+			status_broken("Fail out HTLC %"PRIu64" state %s",
+				      failed_out[i],
+				      htlc_state_name(htlc->state));
+			return false;
+		}
+
+		/* Now, we don't really care why our htlcs failed: lightningd
+		 * already knows.  Just mark it failed using anything. */
+		htlc->fail = tal(htlc, struct onionreply);
 	}
 
 	/* You'd think, since we traverse HTLCs in ID order, this would never

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -231,9 +231,8 @@ size_t num_channel_htlcs(const struct channel *channel);
  * @hstates: the states for the htlcs (tal_arr of same size)
  * @fulfilled: htlcs of those which are fulfilled
  * @fulfilled_sides: sides for ids in @fulfilled
- * @failed_in: incoming htlcs which are failed
+ * @failed_in: incoming htlcs which are failed (stolen!)
  * @failed_out: outgoing htlc ids which are failed
- * @failheight: block number which htlcs failed at.
  *
  * This is used for restoring a channel state.
  */
@@ -243,8 +242,7 @@ bool channel_force_htlcs(struct channel *channel,
 			 const struct fulfilled_htlc *fulfilled,
 			 const enum side *fulfilled_sides,
 			 const struct failed_htlc **failed_in,
-			 const u64 *failed_out,
-			 u32 failheight);
+			 const u64 *failed_out);
 
 /**
  * dump_htlcs: debugging dump of all HTLCs

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -231,8 +231,8 @@ size_t num_channel_htlcs(const struct channel *channel);
  * @hstates: the states for the htlcs (tal_arr of same size)
  * @fulfilled: htlcs of those which are fulfilled
  * @fulfilled_sides: sides for ids in @fulfilled
- * @failed: htlcs of those which are failed
- * @failed_sides: sides for ids in @failed
+ * @failed_in: incoming htlcs which are failed
+ * @failed_out: outgoing htlc ids which are failed
  * @failheight: block number which htlcs failed at.
  *
  * This is used for restoring a channel state.
@@ -242,8 +242,8 @@ bool channel_force_htlcs(struct channel *channel,
 			 const enum htlc_state *hstates,
 			 const struct fulfilled_htlc *fulfilled,
 			 const enum side *fulfilled_sides,
-			 const struct failed_htlc **failed,
-			 const enum side *failed_sides,
+			 const struct failed_htlc **failed_in,
+			 const u64 *failed_out,
 			 u32 failheight);
 
 /**

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -21,10 +21,6 @@ size_t bigsize_get(const u8 *p UNNEEDED, size_t max UNNEEDED, bigsize_t *val UNN
 /* Generated stub for bigsize_put */
 size_t bigsize_put(u8 buf[BIGSIZE_MAX_LEN] UNNEEDED, bigsize_t v UNNEEDED)
 { fprintf(stderr, "bigsize_put called!\n"); abort(); }
-/* Generated stub for dup_onionreply */
-struct onionreply *dup_onionreply(const tal_t *ctx UNNEEDED,
-				  const struct onionreply *r TAKES UNNEEDED)
-{ fprintf(stderr, "dup_onionreply called!\n"); abort(); }
 /* Generated stub for memleak_add_helper_ */
 void memleak_add_helper_(const tal_t *p UNNEEDED, void (*cb)(struct htable *memtable UNNEEDED,
 						    const tal_t *)){ }

--- a/common/htlc_wire.h
+++ b/common/htlc_wire.h
@@ -27,11 +27,17 @@ struct fulfilled_htlc {
 
 struct failed_htlc {
 	u64 id;
-	/* Either this is 0 and failreason non-NULL, or vice versa. */
-	enum onion_type failcode;
-	const struct onionreply *failreason;
-	/* Non-NULL if failcode & UPDATE */
-	struct short_channel_id *scid;
+
+	/* If this is non-NULL, then the onion was malformed and this is the
+	 * SHA256 of what we got: send update_fail_malformed_htlc, using
+	 * failcode. */
+	struct sha256 *sha256_of_onion;
+	/* WIRE_INVALID_ONION_VERSION, WIRE_INVALID_ONION_KEY or
+	 * WIRE_INVALID_ONION_HMAC (ie. must have BADONION) */
+	enum onion_type badonion;
+
+	/* Otherwise, this is the onion ready to send to them. */
+	const struct onionreply *onion;
 };
 
 struct changed_htlc {

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -393,8 +393,7 @@ int main(int argc, char *argv[])
 				   option_static_remotekey,
 				   fee_payer);
 
-	if (!channel_force_htlcs(channel, htlcs, hstates, NULL, NULL, NULL, NULL,
-				 0))
+	if (!channel_force_htlcs(channel, htlcs, hstates, NULL, NULL, NULL, NULL))
 		errx(1, "Cannot add HTLCs");
 
 	u8 *funding_wscript = bitcoin_redeem_2of2(NULL,

--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -41,6 +41,8 @@ class Sqlite3Rewriter(Rewriter):
             r'BIGSERIAL': 'INTEGER',
             r'CURRENT_TIMESTAMP\(\)': "strftime('%s', 'now')",
             r'INSERT INTO[ \t]+(.*)[ \t]+ON CONFLICT.*DO NOTHING;': 'INSERT OR IGNORE INTO \\1;',
+            # Rewrite "decode('abcd', 'hex')" to become "x'abcd'"
+            r'decode\((.*),\s*[\'\"]hex[\'\"]\)': 'x\\1',
         }
         return self.rewrite_types(query, typemapping)
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -636,8 +636,8 @@ This hook is called whenever a valid payment for an unpaid invoice has arrived.
 
 The hook is sparse on purpose, since the plugin can use the JSON-RPC
 `listinvoices` command to get additional details about this invoice.
-It can return a non-zero `failure_code` field as defined for final
-nodes in [BOLT 4][bolt4-failure-codes], a `result` field with the string
+It can return a `failure_message` field as defined for final
+nodes in [BOLT 4][bolt4-failure-messages], a `result` field with the string
 `reject` to fail it with `incorrect_or_unknown_payment_details`, or a
 `result` field with the string `continue` to accept the payment.
 
@@ -763,12 +763,12 @@ usual checks such as sufficient fees and CLTV deltas are still enforced.
 ```json
 {
   "result": "fail",
-  "failure_code": 4301
+  "failure_message": "2002"
 }
 ```
 
-`fail` will tell `lightningd` to fail the HTLC with a given numeric
-`failure_code` (please refer to the [spec][bolt4-failure-codes] for details).
+`fail` will tell `lightningd` to fail the HTLC with a given hex-encoded
+`failure_message` (please refer to the [spec][bolt4-failure-messages] for details: `incorrect_or_unknown_payment_details` is the most common).
 
 ```json
 {
@@ -899,7 +899,7 @@ compatibility should the semantics be changed in future.
 [jsonrpc-spec]: https://www.jsonrpc.org/specification
 [jsonrpc-notification-spec]: https://www.jsonrpc.org/specification#notification
 [bolt4]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md
-[bolt4-failure-codes]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#failure-messages
+[bolt4-failure-messages]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#failure-messages
 [bolt2-open-channel]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-open_channel-message
 [sendcustommsg]: lightning-dev-sendcustommsg.7.html
 [oddok]: https://github.com/lightningnetwork/lightning-rfc/blob/master/00-introduction.md#its-ok-to-be-odd

--- a/gossipd/gossip_wire.csv
+++ b/gossipd/gossip_wire.csv
@@ -80,6 +80,8 @@ msgdata,gossip_get_channel_peer,channel_id,short_channel_id,
 
 msgtype,gossip_get_channel_peer_reply,3109
 msgdata,gossip_get_channel_peer_reply,peer_id,?node_id,
+msgdata,gossip_get_channel_peer_reply,stripped_update_len,u16,
+msgdata,gossip_get_channel_peer_reply,stripped_update,u8,stripped_update_len
 
 # gossipd->master: we're closing this channel.
 msgtype,gossip_local_channel_close,3027

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -2055,7 +2055,7 @@ int main(int argc, char *argv[])
 	status_setup_async(status_conn);
 	uintmap_init(&clients);
 
-	master = new_client(NULL, NULL, NULL, 0, HSM_CAP_MASTER | HSM_CAP_SIGN_GOSSIP,
+	master = new_client(NULL, NULL, NULL, 0, HSM_CAP_MASTER | HSM_CAP_SIGN_GOSSIP | HSM_CAP_ECDH,
 			    REQ_FD);
 
 	/* First client == lightningd. */

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -265,6 +265,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 		= tal_steal(channel, remote_upfront_shutdown_script);
 	channel->option_static_remotekey = option_static_remotekey;
 	channel->forgets = tal_arr(channel, struct command *, 0);
+	channel->stripped_update = NULL;
 
 	list_add_tail(&peer->channels, &channel->list);
 	tal_add_destructor(channel, destroy_channel);

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -123,6 +123,9 @@ struct channel {
 
 	/* Any commands trying to forget us. */
 	struct command **forgets;
+
+	/* Lastest channel_update from gossipd, if any: type stripped! */
+	const u8 *stripped_update;
 };
 
 struct channel *new_channel(struct peer *peer, u64 dbid,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -493,9 +493,6 @@ void peer_start_channeld(struct channel *channel,
 				      htlcs, htlc_states,
 				      fulfilled_htlcs, fulfilled_sides,
 				      failed_in, failed_out,
-				      /* This is an approximation, but failing
-				       * on restart is a corner case */
-				      get_block_height(ld->topology),
 				      channel->scid != NULL,
 				      channel->remote_funding_locked,
 				      &scid,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -369,8 +369,8 @@ void peer_start_channeld(struct channel *channel,
 	enum htlc_state *htlc_states;
 	struct fulfilled_htlc *fulfilled_htlcs;
 	enum side *fulfilled_sides;
-	const struct failed_htlc **failed_htlcs;
-	enum side *failed_sides;
+	const struct failed_htlc **failed_in;
+	u64 *failed_out;
 	struct short_channel_id scid;
 	u64 num_revocations;
 	struct lightningd *ld = channel->peer->ld;
@@ -409,7 +409,7 @@ void peer_start_channeld(struct channel *channel,
 	}
 
 	peer_htlcs(tmpctx, channel, &htlcs, &htlc_states, &fulfilled_htlcs,
-		   &fulfilled_sides, &failed_htlcs, &failed_sides);
+		   &fulfilled_sides, &failed_in, &failed_out);
 
 	if (channel->scid) {
 		scid = *channel->scid;
@@ -492,7 +492,7 @@ void peer_start_channeld(struct channel *channel,
 				      channel->next_htlc_id,
 				      htlcs, htlc_states,
 				      fulfilled_htlcs, fulfilled_sides,
-				      failed_htlcs, failed_sides,
+				      failed_in, failed_out,
 				      /* This is an approximation, but failing
 				       * on restart is a corner case */
 				      get_block_height(ld->topology),

--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -192,13 +192,13 @@ struct htlc_out *htlc_out_check(const struct htlc_out *hout,
 			if (hout->in->preimage)
 				return corrupt(abortstr,
 					       "Output failmsg, input preimage");
-		} else if (hout->failcode) {
+		} else if (hout->failmsg) {
 			if (hout->in->failonion)
 				return corrupt(abortstr,
-					       "Output failcode, input failonion");
+					       "Output failmsg, input failonion");
 			if (hout->in->preimage)
 				return corrupt(abortstr,
-					       "Output failcode, input preimage");
+					       "Output failmsg, input preimage");
 		} else if (hout->preimage) {
 			if (hout->in->failonion)
 				return corrupt(abortstr,
@@ -226,11 +226,11 @@ struct htlc_out *htlc_out_check(const struct htlc_out *hout,
 			return corrupt(abortstr, "Still adding, has preimage");
 		if (hout->failonion)
 			return corrupt(abortstr, "Still adding, has failmsg");
-		if (hout->failcode)
-			return corrupt(abortstr, "Still adding, has failcode");
+		if (hout->failmsg)
+			return corrupt(abortstr, "Still adding, has failmsg");
 	} else if (hout->hstate >= RCVD_REMOVE_HTLC
 		   && hout->hstate <= RCVD_REMOVE_ACK_REVOCATION) {
-		if (!hout->preimage && !hout->failonion && !hout->failcode)
+		if (!hout->preimage && !hout->failonion && !hout->failmsg)
 			return corrupt(abortstr, "Removing, no resolution");
 	} else
 		return corrupt(abortstr, "Bad state %s",
@@ -285,7 +285,7 @@ struct htlc_out *new_htlc_out(const tal_t *ctx,
 	       sizeof(hout->onion_routing_packet));
 
 	hout->hstate = SENT_ADD_HTLC;
-	hout->failcode = 0;
+	hout->failmsg = NULL;
 	hout->failonion = NULL;
 	hout->preimage = NULL;
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -36,15 +36,11 @@ struct htlc_in {
 	/* Shared secret for us to send any failure message (NULL if malformed) */
 	struct secret *shared_secret;
 
-	/* FIXME: Use failed_htlc here */
-	/* If a local error, this is non-zero. */
-	enum onion_type failcode;
+	/* If we couldn't decode the onion, this contains the error code.. */
+	enum onion_type badonion;
 
-	/* For a remote error. */
+	/* Otherwise, this contains the failure message to send. */
 	const struct onionreply *failonion;
-
-	/* If failcode & UPDATE, this is the channel which failed. */
-	struct short_channel_id failoutchannel;
 
 	/* If they fulfilled, here's the preimage. */
 	struct preimage *preimage;

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -40,7 +40,7 @@ struct htlc_in {
 	enum onion_type failcode;
 
 	/* For a remote error. */
-	const struct onionreply *failuremsg;
+	const struct onionreply *failonion;
 
 	/* If failcode & UPDATE, this is the channel which failed. */
 	struct short_channel_id failoutchannel;
@@ -72,7 +72,7 @@ struct htlc_out {
 	enum onion_type failcode;
 
 	/* For a remote error. */
-	const struct onionreply *failuremsg;
+	const struct onionreply *failonion;
 
 	/* If we fulfilled, here's the preimage. */
 	/* FIXME: This is basically unused, except as a bool! */

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -36,6 +36,7 @@ struct htlc_in {
 	/* Shared secret for us to send any failure message (NULL if malformed) */
 	struct secret *shared_secret;
 
+	/* FIXME: Use failed_htlc here */
 	/* If a local error, this is non-zero. */
 	enum onion_type failcode;
 
@@ -68,6 +69,7 @@ struct htlc_out {
 	/* Onion information */
 	u8 onion_routing_packet[TOTAL_PACKET_SIZE];
 
+	/* FIXME: Use failed_htlc here */
 	/* If a local error, this is non-zero. */
 	enum onion_type failcode;
 

--- a/lightningd/htlc_end.h
+++ b/lightningd/htlc_end.h
@@ -69,9 +69,8 @@ struct htlc_out {
 	/* Onion information */
 	u8 onion_routing_packet[TOTAL_PACKET_SIZE];
 
-	/* FIXME: Use failed_htlc here */
-	/* If a local error, this is non-zero. */
-	enum onion_type failcode;
+	/* If a local error, this is non-NULL. */
+	const u8 *failmsg;
 
 	/* For a remote error. */
 	const struct onionreply *failonion;

--- a/lightningd/htlc_set.h
+++ b/lightningd/htlc_set.h
@@ -49,7 +49,7 @@ void htlc_set_add(struct lightningd *ld,
 		  const struct secret *payment_secret);
 
 /* Fail every htlc in the set: frees set */
-void htlc_set_fail(struct htlc_set *set, enum onion_type failcode);
+void htlc_set_fail(struct htlc_set *set, const u8 *failmsg TAKES);
 
 /* Fulfill every htlc in the set: frees set */
 void htlc_set_fulfill(struct htlc_set *set, const struct preimage *preimage);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1970,22 +1970,20 @@ static void add_fulfill(u64 id, enum side side,
 
 static void add_fail(struct htlc_in *hin,
 		     enum onion_type failcode,
-		     const u8 *failing_channel_update,
 		     const struct onionreply *failonion,
 		     const struct failed_htlc ***failed_htlcs)
 {
 	struct failed_htlc *newf;
 
-	if ((failcode & UPDATE) && !failing_channel_update) {
-		/* We don't save the outgoing channel which failed; probably
-		 * not worth it for this corner case.  So we can't set
-		 * hin->failoutchannel to tell channeld what update to send,
-		 * thus we turn those into a WIRE_TEMPORARY_NODE_FAILURE. */
+	/* We don't save the outgoing channel which failed; probably
+	 * not worth it for this corner case.  So we can't set
+	 * hin->failoutchannel to tell channeld what update to send,
+	 * thus we turn those into a WIRE_TEMPORARY_NODE_FAILURE. */
+	if (failcode & UPDATE)
 		failcode = WIRE_TEMPORARY_NODE_FAILURE;
-	}
 
 	newf = mk_failed_htlc(*failed_htlcs, hin, failcode, failonion,
-			      failing_channel_update);
+			      NULL);
 	tal_arr_expand(failed_htlcs, newf);
 }
 
@@ -2025,7 +2023,6 @@ void peer_htlcs(const tal_t *ctx,
 
 		if (hin->failonion || hin->failcode)
 			add_fail(hin, hin->failcode,
-				 NULL,
 				 hin->failonion, failed_in);
 		if (hin->preimage)
 			add_fulfill(hin->key.id, REMOTE, hin->preimage,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -76,7 +76,7 @@ static bool htlc_in_update_state(struct channel *channel,
 
 	wallet_htlc_update(channel->peer->ld->wallet,
 			   hin->dbid, newstate, hin->preimage,
-			   hin->failcode, hin->failonion);
+			   hin->failcode, hin->failonion, NULL);
 
 	hin->hstate = newstate;
 	return true;
@@ -91,7 +91,8 @@ static bool htlc_out_update_state(struct channel *channel,
 		return false;
 
 	wallet_htlc_update(channel->peer->ld->wallet, hout->dbid, newstate,
-			   hout->preimage, hout->failcode, hout->failonion);
+			   hout->preimage, hout->failcode, hout->failonion,
+			   NULL);
 
 	hout->hstate = newstate;
 	return true;
@@ -1100,7 +1101,8 @@ static void fulfill_our_htlc_out(struct channel *channel, struct htlc_out *hout,
 	htlc_out_check(hout, __func__);
 
 	wallet_htlc_update(ld->wallet, hout->dbid, hout->hstate,
-			   hout->preimage, hout->failcode, hout->failonion);
+			   hout->preimage, hout->failcode, hout->failonion,
+			   NULL);
 	/* Update channel stats */
 	wallet_channel_stats_incr_out_fulfilled(ld->wallet,
 						channel->dbid,
@@ -1281,7 +1283,8 @@ void onchain_failed_our_htlc(const struct channel *channel,
 	hout->hstate = RCVD_REMOVE_HTLC;
 	htlc_out_check(hout, __func__);
 	wallet_htlc_update(ld->wallet, hout->dbid, hout->hstate,
-			   hout->preimage, hout->failcode, hout->failonion);
+			   hout->preimage, hout->failcode, hout->failonion,
+			   NULL);
 
 	if (hout->am_origin) {
 		assert(why != NULL);

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -47,13 +47,15 @@ void peer_got_revoke(struct channel *channel, const u8 *msg);
 void update_per_commit_point(struct channel *channel,
 			     const struct pubkey *per_commitment_point);
 
-enum onion_type send_htlc_out(struct channel *out,
-			      struct amount_msat amount, u32 cltv,
-			      const struct sha256 *payment_hash,
-			      u64 partid,
-			      const u8 *onion_routing_packet,
-			      struct htlc_in *in,
-			      struct htlc_out **houtp);
+/* Returns NULL on success, otherwise failmsg */
+const u8 *send_htlc_out(const tal_t *ctx,
+			struct channel *out,
+			struct amount_msat amount, u32 cltv,
+			const struct sha256 *payment_hash,
+			u64 partid,
+			const u8 *onion_routing_packet,
+			struct htlc_in *in,
+			struct htlc_out **houtp);
 
 void onchain_failed_our_htlc(const struct channel *channel,
 			     const struct htlc_stub *htlc,

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -35,8 +35,8 @@ void peer_htlcs(const tal_t *ctx,
 		enum htlc_state **htlc_states,
 		struct fulfilled_htlc **fulfilled_htlcs,
 		enum side **fulfilled_sides,
-		const struct failed_htlc ***failed_htlcs,
-		enum side **failed_sides);
+		const struct failed_htlc ***failed_in,
+		u64 **failed_out);
 
 void free_htlcs(struct lightningd *ld, const struct channel *channel);
 

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -71,11 +71,15 @@ void htlcs_resubmit(struct lightningd *ld,
 
 /* For HTLCs which terminate here, invoice payment calls one of these. */
 void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage);
-void fail_htlc(struct htlc_in *hin, enum onion_type failcode);
+void local_fail_in_htlc(struct htlc_in *hin, const u8 *failmsg TAKES);
 
 /* This json process will be used as the serialize method for
  * forward_event_notification_gen and be used in
  * `listforwardings_add_forwardings()`. */
 void json_format_forwarding_object(struct json_stream *response, const char *fieldname,
 				   const struct forwarding *cur);
+
+/* Helper to create (common) WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS */
+const u8 *failmsg_incorrect_or_unknown(const tal_t *ctx,
+				       const struct htlc_in *hin);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -92,6 +92,10 @@ char *encode_scriptpubkey_to_addr(const tal_t *ctx UNNEEDED,
 				  const struct chainparams *chainparams UNNEEDED,
 				  const u8 *scriptPubkey UNNEEDED)
 { fprintf(stderr, "encode_scriptpubkey_to_addr called!\n"); abort(); }
+/* Generated stub for failmsg_incorrect_or_unknown */
+const u8 *failmsg_incorrect_or_unknown(const tal_t *ctx UNNEEDED,
+				       const struct htlc_in *hin UNNEEDED)
+{ fprintf(stderr, "failmsg_incorrect_or_unknown called!\n"); abort(); }
 /* Generated stub for fatal */
 void   fatal(const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "fatal called!\n"); abort(); }
@@ -147,7 +151,7 @@ bool htlc_is_trimmed(enum side htlc_owner UNNEEDED,
 		     enum side side UNNEEDED)
 { fprintf(stderr, "htlc_is_trimmed called!\n"); abort(); }
 /* Generated stub for htlc_set_fail */
-void htlc_set_fail(struct htlc_set *set UNNEEDED, enum onion_type failcode UNNEEDED)
+void htlc_set_fail(struct htlc_set *set UNNEEDED, const u8 *failmsg TAKES UNNEEDED)
 { fprintf(stderr, "htlc_set_fail called!\n"); abort(); }
 /* Generated stub for htlc_set_fulfill */
 void htlc_set_fulfill(struct htlc_set *set UNNEEDED, const struct preimage *preimage UNNEEDED)
@@ -436,6 +440,9 @@ u8 *towire_hsm_sign_invoice(const tal_t *ctx UNNEEDED, const u8 *u5bytes UNNEEDE
 /* Generated stub for towire_onchain_dev_memleak */
 u8 *towire_onchain_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_dev_memleak called!\n"); abort(); }
+/* Generated stub for towire_temporary_node_failure */
+u8 *towire_temporary_node_failure(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_temporary_node_failure called!\n"); abort(); }
 /* Generated stub for txfilter_add_scriptpubkey */
 void txfilter_add_scriptpubkey(struct txfilter *filter UNNEEDED, const u8 *script TAKES UNNEEDED)
 { fprintf(stderr, "txfilter_add_scriptpubkey called!\n"); abort(); }

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -9,9 +9,8 @@ plugin = Plugin()
 def on_htlc_accepted(onion, plugin, **kwargs):
     plugin.log("Failing htlc on purpose")
     plugin.log("onion: %r" % (onion))
-    # FIXME: Define this!
-    WIRE_TEMPORARY_NODE_FAILURE = 0x2002
-    return {"result": "fail", "failure_code": WIRE_TEMPORARY_NODE_FAILURE}
+    # WIRE_TEMPORARY_NODE_FAILURE = 0x2002
+    return {"result": "fail", "failure_message": "2002"}
 
 
 plugin.run()

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -16,9 +16,8 @@ def on_payment(payment, plugin, **kwargs):
     print("preimage={}".format(payment['preimage']))
 
     if payment['preimage'].endswith('0'):
-        # FIXME: Define this!
-        WIRE_TEMPORARY_NODE_FAILURE = 0x2002
-        return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}
+        # WIRE_TEMPORARY_NODE_FAILURE = 0x2002
+        return {'failure_message': "2002"}
 
     return {'result': 'continue'}
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -592,6 +592,10 @@ static struct migration dbmigrations[] = {
      NULL},
     /* FIXME: Remove now-unused local_feerate_per_kw and remote_feerate_per_kw from channels */
     {SQL("INSERT INTO vars (name, intval) VALUES ('data_version', 0);"), NULL},
+    /* For outgoing HTLCs, we now keep a localmsg instead of a failcode.
+     * Turn anything in transition into a WIRE_TEMPORARY_NODE_FAILURE. */
+    {SQL("ALTER TABLE channel_htlcs ADD localfailmsg BLOB;"), NULL},
+    {SQL("UPDATE channel_htlcs SET localfailmsg=decode('2002', 'hex') WHERE malformed_onion != 0 AND direction = 1;"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -127,7 +127,8 @@ static struct migration dbmigrations[] = {
 	 "  payment_hash BLOB,"
 	 "  payment_key BLOB,"
 	 "  routing_onion BLOB,"
-	 "  failuremsg BLOB,"
+	 "  failuremsg BLOB," /* Note: This is in fact the failure onionreply,
+			       * but renaming columns is hard! */
 	 "  malformed_onion INTEGER,"
 	 "  hstate INTEGER,"
 	 "  shared_secret BLOB,"

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1326,7 +1326,7 @@ static bool test_htlc_crud(struct lightningd *ld, const tal_t *ctx)
 		transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, SENT_REMOVE_HTLC, NULL, 0, onionreply, NULL)),
 	    "Update HTLC with failonion failed");
 	CHECK_MSG(
-		transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, SENT_REMOVE_HTLC, NULL, 0x2002, NULL, NULL)),
+		transaction_wrap(w->db, wallet_htlc_update(w, in.dbid, SENT_REMOVE_HTLC, NULL, WIRE_INVALID_ONION_VERSION, NULL, NULL)),
 	    "Update HTLC with failcode failed");
 
 	CHECK_MSG(transaction_wrap(w->db, wallet_htlc_save_out(w, chan, &out)),

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -82,6 +82,11 @@ struct command_result *command_success(struct command *cmd UNNEEDED,
 /* Generated stub for connect_succeeded */
 void connect_succeeded(struct lightningd *ld UNNEEDED, const struct node_id *id UNNEEDED)
 { fprintf(stderr, "connect_succeeded called!\n"); abort(); }
+/* Generated stub for create_onionreply */
+struct onionreply *create_onionreply(const tal_t *ctx UNNEEDED,
+				     const struct secret *shared_secret UNNEEDED,
+				     const u8 *failure_msg UNNEEDED)
+{ fprintf(stderr, "create_onionreply called!\n"); abort(); }
 /* Generated stub for delay_then_reconnect */
 void delay_then_reconnect(struct channel *channel UNNEEDED, u32 seconds_delay UNNEEDED,
 			  const struct wireaddr_internal *addrhint TAKES UNNEEDED)
@@ -98,7 +103,7 @@ void   fatal(const char *fmt UNNEEDED, ...)
 bool fromwire_channel_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEEDED)
 { fprintf(stderr, "fromwire_channel_dev_memleak_reply called!\n"); abort(); }
 /* Generated stub for fromwire_channel_got_commitsig */
-bool fromwire_channel_got_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct bitcoin_signature *signature UNNEEDED, secp256k1_ecdsa_signature **htlc_signature UNNEEDED, struct added_htlc **added UNNEEDED, struct secret **shared_secret UNNEEDED, struct fulfilled_htlc **fulfilled UNNEEDED, struct failed_htlc ***failed UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_tx **tx UNNEEDED)
+bool fromwire_channel_got_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct bitcoin_signature *signature UNNEEDED, secp256k1_ecdsa_signature **htlc_signature UNNEEDED, struct added_htlc **added UNNEEDED, struct fulfilled_htlc **fulfilled UNNEEDED, struct failed_htlc ***failed UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_tx **tx UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_channel_got_revoke */
 bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED)
@@ -118,6 +123,9 @@ bool fromwire_custommsg_in(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8
 /* Generated stub for fromwire_gossip_get_channel_peer_reply */
 bool fromwire_gossip_get_channel_peer_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **peer_id UNNEEDED, u8 **stripped_update UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_get_channel_peer_reply called!\n"); abort(); }
+/* Generated stub for fromwire_hsm_ecdh_resp */
+bool fromwire_hsm_ecdh_resp(const void *p UNNEEDED, struct secret *ss UNNEEDED)
+{ fprintf(stderr, "fromwire_hsm_ecdh_resp called!\n"); abort(); }
 /* Generated stub for fromwire_hsm_sign_commitment_tx_reply */
 bool fromwire_hsm_sign_commitment_tx_reply(const void *p UNNEEDED, struct bitcoin_signature *sig UNNEEDED)
 { fprintf(stderr, "fromwire_hsm_sign_commitment_tx_reply called!\n"); abort(); }
@@ -569,14 +577,20 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 					  void *arg) UNNEEDED,
 			       void *arg UNNEEDED)
 { fprintf(stderr, "topology_add_sync_waiter_ called!\n"); abort(); }
+/* Generated stub for towire_amount_below_minimum */
+u8 *towire_amount_below_minimum(const tal_t *ctx UNNEEDED, struct amount_msat htlc_msat UNNEEDED, const u8 *channel_update UNNEEDED)
+{ fprintf(stderr, "towire_amount_below_minimum called!\n"); abort(); }
 /* Generated stub for towire_channel_dev_memleak */
 u8 *towire_channel_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channel_dev_memleak called!\n"); abort(); }
 /* Generated stub for towire_channel_dev_reenable_commit */
 u8 *towire_channel_dev_reenable_commit(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channel_dev_reenable_commit called!\n"); abort(); }
+/* Generated stub for towire_channel_disabled */
+u8 *towire_channel_disabled(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_channel_disabled called!\n"); abort(); }
 /* Generated stub for towire_channel_fail_htlc */
-u8 *towire_channel_fail_htlc(const tal_t *ctx UNNEEDED, const struct failed_htlc *failed_htlc UNNEEDED, u32 failheight UNNEEDED)
+u8 *towire_channel_fail_htlc(const tal_t *ctx UNNEEDED, const struct failed_htlc *failed_htlc UNNEEDED)
 { fprintf(stderr, "towire_channel_fail_htlc called!\n"); abort(); }
 /* Generated stub for towire_channel_fulfill_htlc */
 u8 *towire_channel_fulfill_htlc(const tal_t *ctx UNNEEDED, const struct fulfilled_htlc *fulfilled_htlc UNNEEDED)
@@ -613,18 +627,81 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
+/* Generated stub for towire_expiry_too_far */
+u8 *towire_expiry_too_far(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_expiry_too_far called!\n"); abort(); }
+/* Generated stub for towire_expiry_too_soon */
+u8 *towire_expiry_too_soon(const tal_t *ctx UNNEEDED, const u8 *channel_update UNNEEDED)
+{ fprintf(stderr, "towire_expiry_too_soon called!\n"); abort(); }
+/* Generated stub for towire_fee_insufficient */
+u8 *towire_fee_insufficient(const tal_t *ctx UNNEEDED, struct amount_msat htlc_msat UNNEEDED, const u8 *channel_update UNNEEDED)
+{ fprintf(stderr, "towire_fee_insufficient called!\n"); abort(); }
+/* Generated stub for towire_final_incorrect_cltv_expiry */
+u8 *towire_final_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expiry UNNEEDED)
+{ fprintf(stderr, "towire_final_incorrect_cltv_expiry called!\n"); abort(); }
+/* Generated stub for towire_final_incorrect_htlc_amount */
+u8 *towire_final_incorrect_htlc_amount(const tal_t *ctx UNNEEDED, struct amount_msat incoming_htlc_amt UNNEEDED)
+{ fprintf(stderr, "towire_final_incorrect_htlc_amount called!\n"); abort(); }
 /* Generated stub for towire_gossip_get_channel_peer */
 u8 *towire_gossip_get_channel_peer(const tal_t *ctx UNNEEDED, const struct short_channel_id *channel_id UNNEEDED)
 { fprintf(stderr, "towire_gossip_get_channel_peer called!\n"); abort(); }
+/* Generated stub for towire_hsm_ecdh_req */
+u8 *towire_hsm_ecdh_req(const tal_t *ctx UNNEEDED, const struct pubkey *point UNNEEDED)
+{ fprintf(stderr, "towire_hsm_ecdh_req called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_commitment_tx */
 u8 *towire_hsm_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, struct amount_sat funding_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_commitment_tx called!\n"); abort(); }
+/* Generated stub for towire_incorrect_cltv_expiry */
+u8 *towire_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expiry UNNEEDED, const u8 *channel_update UNNEEDED)
+{ fprintf(stderr, "towire_incorrect_cltv_expiry called!\n"); abort(); }
+/* Generated stub for towire_incorrect_or_unknown_payment_details */
+u8 *towire_incorrect_or_unknown_payment_details(const tal_t *ctx UNNEEDED, struct amount_msat htlc_msat UNNEEDED, u32 height UNNEEDED)
+{ fprintf(stderr, "towire_incorrect_or_unknown_payment_details called!\n"); abort(); }
+/* Generated stub for towire_invalid_onion_hmac */
+u8 *towire_invalid_onion_hmac(const tal_t *ctx UNNEEDED, const struct sha256 *sha256_of_onion UNNEEDED)
+{ fprintf(stderr, "towire_invalid_onion_hmac called!\n"); abort(); }
+/* Generated stub for towire_invalid_onion_key */
+u8 *towire_invalid_onion_key(const tal_t *ctx UNNEEDED, const struct sha256 *sha256_of_onion UNNEEDED)
+{ fprintf(stderr, "towire_invalid_onion_key called!\n"); abort(); }
+/* Generated stub for towire_invalid_onion_payload */
+u8 *towire_invalid_onion_payload(const tal_t *ctx UNNEEDED, varint type UNNEEDED, u16 offset UNNEEDED)
+{ fprintf(stderr, "towire_invalid_onion_payload called!\n"); abort(); }
+/* Generated stub for towire_invalid_onion_version */
+u8 *towire_invalid_onion_version(const tal_t *ctx UNNEEDED, const struct sha256 *sha256_of_onion UNNEEDED)
+{ fprintf(stderr, "towire_invalid_onion_version called!\n"); abort(); }
+/* Generated stub for towire_invalid_realm */
+u8 *towire_invalid_realm(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_invalid_realm called!\n"); abort(); }
+/* Generated stub for towire_mpp_timeout */
+u8 *towire_mpp_timeout(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_mpp_timeout called!\n"); abort(); }
 /* Generated stub for towire_onchain_dev_memleak */
 u8 *towire_onchain_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_onchain_dev_memleak called!\n"); abort(); }
 /* Generated stub for towire_onchain_known_preimage */
 u8 *towire_onchain_known_preimage(const tal_t *ctx UNNEEDED, const struct preimage *preimage UNNEEDED)
 { fprintf(stderr, "towire_onchain_known_preimage called!\n"); abort(); }
+/* Generated stub for towire_permanent_channel_failure */
+u8 *towire_permanent_channel_failure(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_permanent_channel_failure called!\n"); abort(); }
+/* Generated stub for towire_permanent_node_failure */
+u8 *towire_permanent_node_failure(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_permanent_node_failure called!\n"); abort(); }
+/* Generated stub for towire_required_channel_feature_missing */
+u8 *towire_required_channel_feature_missing(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_required_channel_feature_missing called!\n"); abort(); }
+/* Generated stub for towire_required_node_feature_missing */
+u8 *towire_required_node_feature_missing(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_required_node_feature_missing called!\n"); abort(); }
+/* Generated stub for towire_temporary_channel_failure */
+u8 *towire_temporary_channel_failure(const tal_t *ctx UNNEEDED, const u8 *channel_update UNNEEDED)
+{ fprintf(stderr, "towire_temporary_channel_failure called!\n"); abort(); }
+/* Generated stub for towire_temporary_node_failure */
+u8 *towire_temporary_node_failure(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_temporary_node_failure called!\n"); abort(); }
+/* Generated stub for towire_unknown_next_peer */
+u8 *towire_unknown_next_peer(const tal_t *ctx UNNEEDED)
+{ fprintf(stderr, "towire_unknown_next_peer called!\n"); abort(); }
 /* Generated stub for watch_txid */
 struct txwatch *watch_txid(const tal_t *ctx UNNEEDED,
 			   struct chain_topology *topo UNNEEDED,
@@ -653,6 +730,11 @@ bool wire_type_is_defined(u16 type UNNEEDED)
 /* Generated stub for wire_type_name */
 const char *wire_type_name(int e UNNEEDED)
 { fprintf(stderr, "wire_type_name called!\n"); abort(); }
+/* Generated stub for wrap_onionreply */
+struct onionreply *wrap_onionreply(const tal_t *ctx UNNEEDED,
+				   const struct secret *shared_secret UNNEEDED,
+				   const struct onionreply *reply UNNEEDED)
+{ fprintf(stderr, "wrap_onionreply called!\n"); abort(); }
 /* AUTOGENERATED MOCKS END */
 
 #if DEVELOPER

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -109,7 +109,7 @@ bool fromwire_channel_got_commitsig(const tal_t *ctx UNNEEDED, const void *p UNN
 bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_revoke called!\n"); abort(); }
 /* Generated stub for fromwire_channel_offer_htlc_reply */
-bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u16 *failure_code UNNEEDED, wirestring **failurestr UNNEEDED)
+bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)
 { fprintf(stderr, "fromwire_channel_offer_htlc_reply called!\n"); abort(); }
 /* Generated stub for fromwire_channel_sending_commitsig */
 bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, secp256k1_ecdsa_signature **htlc_sigs UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -116,7 +116,7 @@ bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UN
 bool fromwire_custommsg_in(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **msg UNNEEDED)
 { fprintf(stderr, "fromwire_custommsg_in called!\n"); abort(); }
 /* Generated stub for fromwire_gossip_get_channel_peer_reply */
-bool fromwire_gossip_get_channel_peer_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **peer_id UNNEEDED)
+bool fromwire_gossip_get_channel_peer_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id **peer_id UNNEEDED, u8 **stripped_update UNNEEDED)
 { fprintf(stderr, "fromwire_gossip_get_channel_peer_reply called!\n"); abort(); }
 /* Generated stub for fromwire_hsm_sign_commitment_tx_reply */
 bool fromwire_hsm_sign_commitment_tx_reply(const void *p UNNEEDED, struct bitcoin_signature *sig UNNEEDED)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1904,13 +1904,6 @@ static bool wallet_stmt2htlc_out(struct wallet *wallet,
 
 static void fixup_hin(struct wallet *wallet, struct htlc_in *hin)
 {
-	/* We don't save the outgoing channel which failed; probably not worth
-	 * it for this corner case.  So we can't set hin->failoutchannel to
-	 * tell channeld what update to send, thus we turn those into a
-	 * WIRE_TEMPORARY_NODE_FAILURE. */
-	if (hin->failcode & UPDATE)
-		hin->failcode = WIRE_TEMPORARY_NODE_FAILURE;
-
 	/* We didn't used to save failcore, failonion... */
 #ifdef COMPAT_V061
 	/* We care about HTLCs being removed only, not those being added. */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1882,7 +1882,12 @@ static bool wallet_stmt2htlc_out(struct wallet *wallet,
 	else
 		out->failonion = db_column_onionreply(out, stmt, 8);
 
-	out->failcode = db_column_int_or_default(stmt, 9, 0);
+	if (db_column_is_null(stmt, 14))
+		out->failmsg = NULL;
+	else
+		out->failmsg = tal_dup_arr(out, u8, db_column_blob(stmt, 14),
+					   db_column_bytes(stmt, 14), 0);
+
 	out->in = NULL;
 
 	if (!db_column_is_null(stmt, 10)) {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -581,7 +581,7 @@ void wallet_htlc_save_out(struct wallet *wallet,
  * @new_state: the state we should transition to
  * @payment_key: the `payment_key` which hashes to the `payment_hash`,
  *   or NULL if unknown.
- * @failcode: the current failure code, or 0.
+ * @badonion: the current BADONION failure code, or 0.
  * @failonion: the current failure onion message (from peer), or NULL.
  * @failmsg: the current local failure message, or NULL.
  *
@@ -592,7 +592,7 @@ void wallet_htlc_save_out(struct wallet *wallet,
 void wallet_htlc_update(struct wallet *wallet, const u64 htlc_dbid,
 			const enum htlc_state new_state,
 			const struct preimage *payment_key,
-			enum onion_type failcode,
+			enum onion_type badonion,
 			const struct onionreply *failonion,
 			const u8 *failmsg);
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -582,17 +582,17 @@ void wallet_htlc_save_out(struct wallet *wallet,
  * @payment_key: the `payment_key` which hashes to the `payment_hash`,
  *   or NULL if unknown.
  * @failcode: the current failure code, or 0.
- * @failuremsg: the current failure message (from peer), or NULL.
+ * @failonion: the current failure message (from peer), or NULL.
  *
  * Used to update the state of an HTLC, either a `struct htlc_in` or a
  * `struct htlc_out` and optionally set the `payment_key` should the
- * HTLC have been settled, or `failcode`/`failuremsg` if failed.
+ * HTLC have been settled, or `failcode`/`failonion` if failed.
  */
 void wallet_htlc_update(struct wallet *wallet, const u64 htlc_dbid,
 			const enum htlc_state new_state,
 			const struct preimage *payment_key,
 			enum onion_type failcode,
-			const struct onionreply *failuremsg);
+			const struct onionreply *failonion);
 
 /**
  * wallet_htlcs_load_in_for_channel - Load incoming HTLCs associated with chan from DB.

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -582,7 +582,8 @@ void wallet_htlc_save_out(struct wallet *wallet,
  * @payment_key: the `payment_key` which hashes to the `payment_hash`,
  *   or NULL if unknown.
  * @failcode: the current failure code, or 0.
- * @failonion: the current failure message (from peer), or NULL.
+ * @failonion: the current failure onion message (from peer), or NULL.
+ * @failmsg: the current local failure message, or NULL.
  *
  * Used to update the state of an HTLC, either a `struct htlc_in` or a
  * `struct htlc_out` and optionally set the `payment_key` should the
@@ -592,7 +593,8 @@ void wallet_htlc_update(struct wallet *wallet, const u64 htlc_dbid,
 			const enum htlc_state new_state,
 			const struct preimage *payment_key,
 			enum onion_type failcode,
-			const struct onionreply *failonion);
+			const struct onionreply *failonion,
+			const u8 *failmsg);
 
 /**
  * wallet_htlcs_load_in_for_channel - Load incoming HTLCs associated with chan from DB.


### PR DESCRIPTION
Our HTLC error paths are confusing: channeld can detect an incoming HTLC error because it tries to decrypt the onion.  This work is done again anyway by lightningd.  In many places we have both an onionreply (if we're forwarding an error from a peer) and an error code, which we try to convert in a giant demuxer which is incomplete and growing in complexity.

By the end of this series, we have HTLC errors as follows:

* incoming htlcs: badonion if non-decodable, otherwise failonion ready to send to prev peer.
* outgoing htlcs: raw failmsg if we or channeld generated it, failonion if we got it from peer.

If we forward an outgoing htlc error back to an incoming, we convert the failmsg to an onion (this requires the incoming HTLC secret), and the onion becomes the incomijng htlc failonion.

This is, frankly, much clearer that what we had before, though it's a painful transition in several ways.
