### PR TITLE
lightningd/: Hooks now support a consistent interface for 'no operation'.

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -473,6 +473,10 @@ Hooks are considered to be an advanced feature due to the fact that
 carefully, and make sure your plugins always return a valid response
 to any hook invocation.
 
+As a convention, for all hooks, returning the object
+`{ "result" : "continue" }` results in `lightningd` behaving exactly as if
+no plugin is registered on the hook.
+
 ### Hook Types
 
 #### `peer_connected`
@@ -571,7 +575,8 @@ and:
 The "rolling up" of the database could be done periodically as well
 if the log of SQL statements has grown large.
 
-Any response but "true" will cause lightningd to error without
+Any response other than `{"result": "continue"}` will cause lightningd
+to error without
 committing to the database!
 This is the expected way to halt and catch fire.
 
@@ -592,8 +597,9 @@ This hook is called whenever a valid payment for an unpaid invoice has arrived.
 The hook is sparse on purpose, since the plugin can use the JSON-RPC
 `listinvoices` command to get additional details about this invoice.
 It can return a non-zero `failure_code` field as defined for final
-nodes in [BOLT 4][bolt4-failure-codes], or otherwise an empty object
-to accept the payment.
+nodes in [BOLT 4][bolt4-failure-codes], a `result` field with the string
+`reject` to fail it with `incorrect_or_unknown_payment_details`, or a
+`result` field with the string `continue` to accept the payment.
 
 
 #### `openchannel`
@@ -769,7 +775,7 @@ Let `lightningd` execute the command with
 
 ```json
 {
-    "continue": true
+    "result" : "continue"
 }
 ```
 Replace the request made to `lightningd`:
@@ -839,7 +845,8 @@ details). The plugin must implement the parsing of the message, including the
 type prefix, since c-lightning does not know how to parse the message.
 
 The result for this hook is currently being discarded. For future uses of the
-result we suggest just returning a `null`. This will ensure backward
+result we suggest just returning `{'result': 'continue'}`.
+This will ensure backward
 compatibility should the semantics be changed in future.
 
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -9,6 +9,7 @@
 #include <common/amount.h>
 #include <common/bech32.h>
 #include <common/bolt11.h>
+#include <common/configdir.h>
 #include <common/features.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
@@ -161,10 +162,12 @@ static void invoice_payload_remove_set(struct htlc_set *set,
 	payload->set = NULL;
 }
 
-static bool hook_gives_failcode(const char *buffer,
+static bool hook_gives_failcode(struct log *log,
+				const char *buffer,
 				const jsmntok_t *toks,
 				enum onion_type *failcode)
 {
+	const jsmntok_t *resulttok;
 	const jsmntok_t *t;
 	unsigned int val;
 
@@ -172,9 +175,39 @@ static bool hook_gives_failcode(const char *buffer,
 	if (!buffer)
 		return false;
 
+	resulttok = json_get_member(buffer, toks, "result");
+	if (resulttok) {
+		if (json_tok_streq(buffer, resulttok, "continue")) {
+			return false;
+		} else if (json_tok_streq(buffer, resulttok, "reject")) {
+			*failcode = WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS;
+			return true;
+		} else
+			fatal("Invalid invoice_payment hook result: %.*s",
+			      toks[0].end - toks[0].start, buffer);
+	}
+
 	t = json_get_member(buffer, toks, "failure_code");
-	if (!t)
+#ifdef COMPAT_V080
+	if (!t && deprecated_apis) {
+		static bool warned = false;
+		if (!warned) {
+			warned = true;
+			log_unusual(log,
+				    "Plugin did not return object with "
+				    "'result' or 'failure_code' fields.  "
+				    "This is now deprecated and you should "
+				    "return {'result': 'continue' } or "
+				    "{'result': 'reject'} or "
+				    "{'failure_code': 42} instead.");
+		}
 		return false;
+	}
+#endif /* defined(COMPAT_V080) */
+	if (!t)
+		fatal("Invalid invoice_payment_hook response, expecting "
+		      "'result' or 'failure_code' field: %.*s",
+		      toks[0].end - toks[0].start, buffer);
 
 	if (!json_to_number(buffer, t, &val))
 		fatal("Invalid invoice_payment_hook failure_code: %.*s",
@@ -222,7 +255,7 @@ invoice_payment_hook_cb(struct invoice_payment_hook_payload *payload,
 	}
 
 	/* Did we have a hook result? */
-	if (hook_gives_failcode(buffer, toks, &failcode)) {
+	if (hook_gives_failcode(ld->log, buffer, toks, &failcode)) {
 		htlc_set_fail(payload->set, failcode);
 		return;
 	}

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -1,8 +1,10 @@
 #include <ccan/io/io.h>
+#include <common/configdir.h>
 #include <common/memleak.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/plugin_hook.h>
 #include <wallet/db.h>
+#include <wallet/db_common.h>
 
 /* Struct containing all the information needed to deserialize and
  * dispatch an eventual plugin_hook response. */
@@ -136,21 +138,49 @@ static void db_hook_response(const char *buffer, const jsmntok_t *toks,
 			     struct plugin_hook_request *ph_req)
 {
 	const jsmntok_t *resulttok;
-	bool resp;
 
 	resulttok = json_get_member(buffer, toks, "result");
 	if (!resulttok)
 		fatal("Plugin returned an invalid response to the db_write "
 		      "hook: %s", buffer);
 
-	/* We expect result: True.  Anything else we abort. */
-	if (!json_to_bool(buffer, resulttok, &resp))
+#ifdef COMPAT_V080
+	/* For back-compatibility we allow to return a simple Boolean true.  */
+	if (deprecated_apis) {
+		bool resp;
+		if (json_to_bool(buffer, resulttok, &resp)) {
+			static bool warned = false;
+			/* If it fails, we must not commit to our db. */
+			if (!resp)
+				fatal("Plugin returned failed db_write: %s.",
+				      buffer);
+			if (!warned) {
+				warned = true;
+				log_unusual(ph_req->db->log,
+					    "Plugin returned 'true' to "
+					    "'db_hook'.  "
+					    "This is now deprecated and "
+					    "you should return "
+					    "{'result': 'continue'} "
+					    "instead.");
+			}
+			/* Resume.  */
+			io_break(ph_req);
+			return;
+		}
+	}
+#endif /* defined(COMPAT_V080) */
+
+	/* We expect result: { 'result' : 'continue' }.
+	 * Anything else we abort.
+	 */
+	resulttok = json_get_member(buffer, resulttok, "result");
+	if (resulttok) {
+		if (!json_tok_streq(buffer, resulttok, "continue"))
+			fatal("Plugin returned failed db_write: %s.", buffer);
+	} else
 		fatal("Plugin returned an invalid result to the db_write "
 		      "hook: %s", buffer);
-
-	/* If it fails, we must not commit to our db. */
-	if (!resp)
-		fatal("Plugin returned failed db_write: %s.", buffer);
 
 	/* We're done, exit exclusive loop. */
 	io_break(ph_req);

--- a/tests/plugins/dblog.py
+++ b/tests/plugins/dblog.py
@@ -47,7 +47,7 @@ def db_write(plugin, writes, **kwargs):
 
         plugin.conn.execute("COMMIT;")
 
-    return True
+    return {"result": "continue"}
 
 
 plugin.add_option('dblog-file', None, 'The db file to create.')

--- a/tests/plugins/hold_invoice.py
+++ b/tests/plugins/hold_invoice.py
@@ -11,7 +11,7 @@ plugin = Plugin()
 @plugin.hook('invoice_payment')
 def on_payment(payment, plugin, **kwargs):
     time.sleep(float(plugin.get_option('holdtime')))
-    return {}
+    return {'result': 'continue'}
 
 
 plugin.add_option('holdtime', '10', 'The time to hold invoice for.')

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -20,7 +20,7 @@ def on_payment(payment, plugin, **kwargs):
         WIRE_TEMPORARY_NODE_FAILURE = 0x2002
         return {'failure_code': WIRE_TEMPORARY_NODE_FAILURE}
 
-    return {}
+    return {'result': 'continue'}
 
 
 plugin.run()

--- a/tests/plugins/rpc_command.py
+++ b/tests/plugins/rpc_command.py
@@ -24,7 +24,7 @@ def on_rpc_command(plugin, rpc_command, **kwargs):
     elif request["method"] == "help":
         request["method"] = "autocleaninvoice"
         return {"replace": request}
-    return {"continue": True}
+    return {"result": "continue"}
 
 
 plugin.run()


### PR DESCRIPTION

Changelog-Changed: The hooks `db_write`, `invoice_payment`, and `rpc_command` now accept `{ "result": "continue" }` to mean "do default action", in addition to `true` (`db_write`), `{}` (`invoice_payment`), and `{"continue": true}` (`rpc_command`). Eventually the older "default" indicators will be deprecated, but for now they will be supported, but logged as `UNUSUAL` level.