### PR TITLE
libplugin: use json stream helpers and add sanity tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ include doc/Makefile
 include devtools/Makefile
 include tools/Makefile
 include plugins/Makefile
+include tests/plugins/Makefile
 
 # Git doesn't maintain timestamps, so we only regen if git says we should.
 CHANGED_FROM_GIT = [ x"`git log $@ | head -n1`" != x"`git log $< | head -n1`" -o x"`git diff $<`" != x"" ]

--- a/ccan/ccan/opt/opt.c
+++ b/ccan/ccan/opt/opt.c
@@ -176,6 +176,23 @@ void _opt_register(const char *names, enum opt_type type,
 	add_opt(&opt);
 }
 
+bool opt_unregister(const char *names)
+{
+	int found = -1, i;
+
+	for (i = 0; i < opt_count; i++) {
+		if (opt_table[i].type == OPT_SUBTABLE)
+			continue;
+		if (strcmp(opt_table[i].names, names) == 0)
+			found = i;
+	}
+	if (found == -1)
+		return false;
+	opt_count--;
+	memmove(&opt_table[found], &opt_table[found+1], opt_count - found);
+	return true;
+}
+
 void opt_register_table(const struct opt_table entry[], const char *desc)
 {
 	unsigned int i, start = opt_count;

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -229,6 +229,15 @@ void opt_register_table(const struct opt_table *table, const char *desc);
 		      (arg), (desc))
 
 /**
+ * opt_unregister - unregister an option.
+ * @names: the names it was registered with.
+ *
+ * This undoes opt_register[_early]_[no]arg.  Returns true if the option was
+ * found, otherwise false.
+ */
+bool opt_unregister(const char *names);
+
+/**
  * opt_parse - parse arguments.
  * @argc: pointer to argc
  * @argv: argv array.

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -73,6 +73,7 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES)
 	p->js_arr = tal_arr(p, struct json_stream *, 0);
 	p->used = 0;
 	p->subscriptions = NULL;
+	p->dynamic = false;
 
 	p->log = new_log(p, plugins->log_book, NULL, "plugin-%s",
 			 path_basename(tmpctx, p->cmd));
@@ -810,22 +811,22 @@ static void plugin_manifest_timeout(struct plugin *plugin)
 	fatal("Can't recover from plugin failure, terminating.");
 }
 
-
 bool plugin_parse_getmanifest_response(const char *buffer,
                                        const jsmntok_t *toks,
                                        const jsmntok_t *idtok,
                                        struct plugin *plugin)
 {
 	const jsmntok_t *resulttok, *dynamictok;
-	bool dynamic_plugin;
 
 	resulttok = json_get_member(buffer, toks, "result");
 	if (!resulttok || resulttok->type != JSMN_OBJECT)
 		return false;
 
 	dynamictok = json_get_member(buffer, resulttok, "dynamic");
-	if (dynamictok && json_to_bool(buffer, dynamictok, &dynamic_plugin))
-		plugin->dynamic = dynamic_plugin;
+	if (dynamictok && !json_to_bool(buffer, dynamictok, &plugin->dynamic))
+		plugin_kill(plugin, "Bad 'dynamic' field ('%.*s')",
+			    json_tok_full_len(dynamictok),
+			    json_tok_full(buffer, dynamictok));
 
 	if (!plugin_opts_add(plugin, buffer, resulttok) ||
 	    !plugin_rpcmethods_add(plugin, buffer, resulttok) ||

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -487,7 +487,7 @@ static bool plugin_opt_add(struct plugin *plugin, const char *buffer,
 	popt = tal(plugin, struct plugin_opt);
 	popt->value = talz(popt, struct plugin_opt_value);
 
-	popt->name = tal_fmt(plugin, "--%.*s", nametok->end - nametok->start,
+	popt->name = tal_fmt(popt, "--%.*s", nametok->end - nametok->start,
 			     buffer + nametok->start);
 	if (json_tok_streq(buffer, typetok, "string")) {
 		popt->type = "string";

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -115,7 +115,7 @@ static struct command_result *plugin_start(struct dynamic_plugin *dp)
 	struct jsonrpc_request *req;
 	struct plugin *p = dp->plugin;
 
-	p->dynamic = true;
+	p->dynamic = false;
 	p_cmd = tal_arrz(NULL, char *, 2);
 	p_cmd[0] = p->cmd;
 	/* In case the plugin create files, this is a better default. */

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -23,16 +23,13 @@ static struct command_result *ignore(struct command *timer,
 
 static struct command_result *do_clean(struct plugin *p)
 {
-	struct json_out *params = json_out_new(NULL);
-	json_out_start(params, NULL, '{');
-	json_out_add(params, "maxexpirytime", false, "%"PRIu64,
-		     time_now().ts.tv_sec - expired_by);
-	json_out_end(params, '}');
-	json_out_finished(params);
-
 	/* FIXME: delexpiredinvoice should be in our plugin too! */
-	return send_outreq(p, NULL, "delexpiredinvoice", ignore, ignore, p,
-			   take(params));
+	struct out_req *req = jsonrpc_request_start(p, NULL, "delexpiredinvoice",
+						    ignore, ignore, p);
+	json_add_u64(req->js, "maxexpirytime",
+		     time_now().ts.tv_sec - expired_by);
+
+	return send_outreq(p, req);
 }
 
 static struct command_result *json_autocleaninvoice(struct command *cmd,

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -87,17 +87,15 @@ static struct command_result *finish(struct command *cmd,
 				     const jsmntok_t *result,
 				     struct funding_req *fr)
 {
-	struct json_out *out;
+	struct json_stream *out;
 
-	out = json_out_new(NULL);
-	json_out_start(out, NULL, '{');
-	copy_member(out, buf, result, "tx");
-	json_out_addstr(out, "txid",
+	out = jsonrpc_stream_success(cmd);
+	json_add_tok(out, "tx", json_get_member(buf, result, "tx"), buf);
+	json_add_string(out, "txid",
 			type_to_string(tmpctx, struct bitcoin_txid, &fr->tx_id));
-	json_out_addstr(out, "channel_id", fr->chanstr);
-	json_out_end(out, '}');
+	json_add_string(out, "channel_id", fr->chanstr);
 
-	return command_success(cmd, out);
+	return command_finished(cmd, out);
 }
 
 /* We're ready to broadcast the transaction */

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -5,6 +5,7 @@
 #include <ccan/tal/str/str.h>
 #include <common/addr.h>
 #include <common/amount.h>
+#include <common/json_stream.h>
 #include <common/json_tok.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
@@ -50,32 +51,6 @@ static void json_out_add_raw_len(struct json_out *jout,
 	memcpy(p, jsonstr, len);
 }
 
-/* Helper to add a boolean to a json_out */
-static void json_out_addbool(struct json_out *jout,
-		             const char *fieldname,
-			     const bool val)
-{
-	if (val)
-		json_out_add(jout, fieldname, false, "true");
-	else
-		json_out_add(jout, fieldname, false, "false");
-}
-
-/* Copy field and member to output, if it exists: return member */
-static const jsmntok_t *copy_member(struct json_out *ret,
-				    const char *buf, const jsmntok_t *obj,
-				    const char *membername)
-{
-	const jsmntok_t *m = json_get_member(buf, obj, membername);
-	if (!m)
-		return NULL;
-
-	/* Literal copy: it's already JSON escaped, and may be a string. */
-	json_out_add_raw_len(ret, membername,
-			     json_tok_full(buf, m), json_tok_full_len(m));
-	return m;
-}
-
 static struct command_result *send_prior(struct command *cmd,
 					 const char *buf,
 					 const jsmntok_t *error,
@@ -89,23 +64,20 @@ static struct command_result *tx_abort(struct command *cmd,
 				       const jsmntok_t *error,
 				       struct funding_req *fr)
 {
-	struct json_out *ret;
+	struct out_req *req;
 
 	/* We stash the error so we can return it after we've cleaned up */
 	fr->error = json_strdup(fr, buf, error);
 
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL,  '{');
-	json_out_addstr(ret, "txid",
+	req = jsonrpc_request_start(cmd->plugin, cmd, "txdiscard",
+				    send_prior, send_prior, fr);
+	json_add_string(req->js, "txid",
 			type_to_string(tmpctx, struct bitcoin_txid, &fr->tx_id));
-	json_out_end(ret, '}');
 
 	/* We need to call txdiscard, and forward the actual cause for the
 	 * error after we've cleaned up. We swallow any errors returned by
 	 * this call, as we don't really care if it succeeds or not */
-	return send_outreq(cmd->plugin, cmd, "txdiscard",
-			   send_prior, send_prior,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 /* We're basically done, we just need to format the output to match
@@ -135,7 +107,7 @@ static struct command_result *send_tx(struct command *cmd,
 				      struct funding_req *fr)
 {
 
-	struct json_out *ret;
+	struct out_req *req;
 	const jsmntok_t *tok;
 	bool commitments_secured;
 
@@ -149,15 +121,12 @@ static struct command_result *send_tx(struct command *cmd,
 	tok = json_get_member(buf, result, "channel_id");
 	fr->chanstr = json_strdup(fr, buf, tok);
 
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, "txid",
+	req = jsonrpc_request_start(cmd->plugin, cmd, "txsend",
+				    finish, tx_abort, fr);
+	json_add_string(req->js, "txid",
 			type_to_string(tmpctx, struct bitcoin_txid, &fr->tx_id));
-	json_out_end(ret, '}');
 
-	return send_outreq(cmd->plugin, cmd, "txsend",
-			   finish, tx_abort,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 static struct command_result *tx_prepare_done(struct command *cmd,
@@ -167,7 +136,7 @@ static struct command_result *tx_prepare_done(struct command *cmd,
 {
 	const jsmntok_t *txid_tok;
 	const jsmntok_t *tx_tok;
-	struct json_out *ret;
+	struct out_req *req;
 	const struct bitcoin_tx *tx;
 	const char *hex;
 	u32 outnum;
@@ -206,17 +175,14 @@ static struct command_result *tx_prepare_done(struct command *cmd,
 	if (!bitcoin_txid_from_hex(hex, strlen(hex), &fr->tx_id))
 		plugin_err(cmd->plugin, "Unable to parse txid %s", hex);
 
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
+	req = jsonrpc_request_start(cmd->plugin, cmd, "fundchannel_complete",
+				    send_tx, tx_abort, fr);
+	json_add_string(req->js, "id", node_id_to_hexstr(tmpctx, fr->id));
 	/* Note that hex is reused from above */
-	json_out_addstr(ret, "txid", hex);
-	json_out_add(ret, "txout", false, "%u", outnum);
-	json_out_end(ret, '}');
+	json_add_string(req->js, "txid", hex);
+	json_add_u32(req->js, "txout", outnum);
 
-	return send_outreq(cmd->plugin, cmd, "fundchannel_complete",
-			   send_tx, tx_abort,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 static struct command_result *cancel_start(struct command *cmd,
@@ -224,59 +190,51 @@ static struct command_result *cancel_start(struct command *cmd,
 					   const jsmntok_t *error,
 					   struct funding_req *fr)
 {
-	struct json_out *ret;
+	struct out_req *req;
 
 	/* We stash the error so we can return it after we've cleaned up */
 	fr->error = json_strdup(fr, buf, error);
 
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
-	json_out_end(ret, '}');
+	req = jsonrpc_request_start(cmd->plugin, cmd, "fundchannel_cancel",
+				    send_prior, send_prior, fr);
+	json_add_string(req->js, "id", node_id_to_hexstr(tmpctx, fr->id));
 
-	return send_outreq(cmd->plugin, cmd, "fundchannel_cancel",
-			   send_prior, send_prior,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
-static struct json_out *txprepare(struct command *cmd,
-				  struct funding_req *fr,
-				  const char *destination)
+static void txprepare(struct json_stream *js,
+		      struct funding_req *fr,
+		      const char *destination)
 {
-	struct json_out *ret;
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL, '{');
-
 	/* Add the 'outputs' */
-	json_out_start(ret, "outputs", '[');
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, destination, fr->funding_str);
-	json_out_end(ret, '}');
-	json_out_end(ret, ']');
+	json_array_start(js, "outputs");
+	json_object_start(js, NULL);
+	json_add_string(js, destination, fr->funding_str);
+	json_object_end(js);
+	json_array_end(js);
 
 	if (fr->feerate_str)
-		json_out_addstr(ret, "feerate", fr->feerate_str);
+		json_add_string(js, "feerate", fr->feerate_str);
 	if (fr->minconf)
-		json_out_add(ret, "minconf", false, "%u", *fr->minconf);
+		json_add_u32(js, "minconf", *fr->minconf);
 	if (fr->utxo_str)
-		json_out_add_raw_len(ret, "utxos", fr->utxo_str, strlen(fr->utxo_str));
-	json_out_end(ret, '}');
-
-	return ret;
+		json_out_add_raw_len(js->jout, "utxos", fr->utxo_str,
+				     strlen(fr->utxo_str));
 }
 
 static struct command_result *prepare_actual(struct command *cmd,
-						     const char *buf,
-						     const jsmntok_t *result,
-						     struct funding_req *fr)
+					     const char *buf,
+					     const jsmntok_t *result,
+					     struct funding_req *fr)
 {
-	struct json_out *ret;
+	struct out_req *req;
 
-	ret = txprepare(cmd, fr, fr->funding_addr);
+	req = jsonrpc_request_start(cmd->plugin, cmd, "txprepare",
+				    tx_prepare_done, cancel_start,
+				    fr);
+	txprepare(req->js, fr, fr->funding_addr);
 
-	return send_outreq(cmd->plugin, cmd, "txprepare",
-			   tx_prepare_done, cancel_start,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 static struct command_result *fundchannel_start_done(struct command *cmd,
@@ -284,7 +242,7 @@ static struct command_result *fundchannel_start_done(struct command *cmd,
 						     const jsmntok_t *result,
 						     struct funding_req *fr)
 {
-	struct json_out *ret;
+	struct out_req *req;
 
 	/* Save the outscript so we can fund the outnum later */
 	fr->out_script = json_tok_bin_from_hex(fr, buf,
@@ -295,44 +253,39 @@ static struct command_result *fundchannel_start_done(struct command *cmd,
 				       json_get_member(buf, result, "funding_address"));
 
 	/* Now that we're ready to go, cancel the reserved tx */
-	ret = json_out_new(NULL);
-	json_out_start(ret, NULL,  '{');
-	json_out_addstr(ret, "txid",
+	req = jsonrpc_request_start(cmd->plugin, cmd, "txdiscard",
+				    prepare_actual, cancel_start,
+				    fr);
+	json_add_string(req->js, "txid",
 			type_to_string(tmpctx, struct bitcoin_txid, &fr->tx_id));
-	json_out_end(ret, '}');
 
-	return send_outreq(cmd->plugin, cmd, "txdiscard",
-			   prepare_actual, cancel_start,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 static struct command_result *fundchannel_start(struct command *cmd,
                                                 struct funding_req *fr)
 {
-	struct json_out *ret = json_out_new(NULL);
+	struct out_req *req = jsonrpc_request_start(cmd->plugin, cmd,
+						    "fundchannel_start",
+						    fundchannel_start_done,
+						    tx_abort, fr);
 
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
+	json_add_string(req->js, "id", node_id_to_hexstr(tmpctx, fr->id));
 
 	if (deprecated_apis)
-		json_out_addstr(ret, "satoshi", fr->funding_str);
+		json_add_string(req->js, "satoshi", fr->funding_str);
 	else
-		json_out_addstr(ret, "amount", fr->funding_str);
+		json_add_string(req->js, "amount", fr->funding_str);
 
 	if (fr->feerate_str)
-		json_out_addstr(ret, "feerate", fr->feerate_str);
+		json_add_string(req->js, "feerate", fr->feerate_str);
 	if (fr->announce_channel)
-		json_out_addbool(ret, "announce", *fr->announce_channel);
+		json_add_bool(req->js, "announce", *fr->announce_channel);
 	if (fr->push_msat)
-		json_out_addstr(ret, "push_msat",
+		json_add_string(req->js, "push_msat",
 				type_to_string(tmpctx, struct amount_msat, fr->push_msat));
 
-	json_out_end(ret, '}');
-	json_out_finished(ret);
-
-	return send_outreq(cmd->plugin, cmd, "fundchannel_start",
-			   fundchannel_start_done, tx_abort,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 static struct command_result *post_dryrun(struct command *cmd,
@@ -391,31 +344,28 @@ static struct command_result *exec_dryrun(struct command *cmd,
 					  const jsmntok_t *result,
 					  struct funding_req *fr)
 {
-	struct json_out *ret;
+	struct out_req *req = jsonrpc_request_start(cmd->plugin, cmd, "txprepare",
+						    post_dryrun, forward_error,
+						    fr);
 
 	/* Now that we've tried connecting, we do a 'dry-run' of txprepare,
 	 * so we can get an accurate idea of the funding amount */
-	ret = txprepare(cmd, fr, placeholder_funding_addr);
+	txprepare(req->js, fr, placeholder_funding_addr);
 
-	return send_outreq(cmd->plugin, cmd, "txprepare",
-			   post_dryrun, forward_error,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 
 }
 
 static struct command_result *connect_to_peer(struct command *cmd,
                                               struct funding_req *fr)
 {
-	struct json_out *ret = json_out_new(NULL);
+	struct out_req *req = jsonrpc_request_start(cmd->plugin, cmd, "connect",
+						    exec_dryrun, forward_error,
+						    fr);
 
-	json_out_start(ret, NULL, '{');
-	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
-	json_out_end(ret, '}');
-	json_out_finished(ret);
+	json_add_string(req->js, "id", node_id_to_hexstr(tmpctx, fr->id));
 
-	return send_outreq(cmd->plugin, cmd, "connect",
-			   exec_dryrun, forward_error,
-			   fr, take(ret));
+	return send_outreq(cmd->plugin, req);
 }
 
 /* We will use 'id' and 'amount' to build a output: {id: amount}.

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -591,8 +591,7 @@ handle_getmanifest(struct command *getmanifest_cmd)
 		json_add_string(params, NULL, p->hook_subs[i].name);
 	json_array_end(params);
 
-	json_add_string(params, "dynamic",
-			p->restartability == PLUGIN_RESTARTABLE ? "true" : "false");
+	json_add_bool(params, "dynamic", p->restartability == PLUGIN_RESTARTABLE);
 
 	return command_finished(getmanifest_cmd, params);
 }

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -70,6 +70,25 @@ struct plugin_hook {
 	                                 const jsmntok_t *params);
 };
 
+/* Helper to create a JSONRPC2 response stream with a "result" object. */
+struct json_stream *jsonrpc_stream_success(struct command *cmd);
+
+/* Helper to create a JSONRPC2 response stream with an "error" object. */
+struct json_stream *jsonrpc_stream_fail(struct command *cmd,
+					int code,
+					const char *err);
+
+/* Helper to create a JSONRPC2 response stream with an "error" object,
+ * to which will be added a "data" object. */
+struct json_stream *jsonrpc_stream_fail_data(struct command *cmd,
+					     int code,
+					     const char *err);
+
+/* This command is finished, here's the response (the content of the
+ * "result" or "error" field) */
+struct command_result *WARN_UNUSED_RESULT
+command_finished(struct command *cmd, struct json_stream *response);
+
 /* Helper to create a zero or single-value JSON object; if @str is NULL,
  * object is empty. */
 struct json_out *json_out_obj(const tal_t *ctx,

--- a/tests/plugins/Makefile
+++ b/tests/plugins/Makefile
@@ -1,0 +1,18 @@
+PLUGIN_TESTLIBPLUGIN_SRC := tests/plugins/test_libplugin.c
+PLUGIN_TESTLIBPLUGIN_OBJS := $(PLUGIN_TESTLIBPLUGIN_SRC:.c=.o)
+
+tests/plugins/test_libplugin: bitcoin/chainparams.o $(PLUGIN_TESTLIBPLUGIN_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+
+$(PLUGIN_TESTLIBPLUGIN_OBJS): $(PLUGIN_LIB_HEADER)
+
+# Make sure these depend on everything.
+ALL_PROGRAMS += tests/plugins/test_libplugin
+ALL_OBJS += $(PLUGIN_TESTLIBPLUGIN_OBJS)
+
+check-source: $(PLUGIN_TESTLIBPLUGIN_SRC:%=check-src-include-order/%)
+check-whitespace: $(PLUGIN_TESTLIBPLUGIN_SRC:%=check-whitespace/%)
+
+clean: test-plugin-clean
+
+test-plugin-clean:
+	$(RM) $(PLUGIN_TESTLIBPLUGIN_OBJS)

--- a/tests/plugins/test_libplugin.c
+++ b/tests/plugins/test_libplugin.c
@@ -1,0 +1,52 @@
+#include <ccan/array_size/array_size.h>
+#include <plugins/libplugin.h>
+
+
+const char *name_option;
+
+
+static struct command_result *json_helloworld(struct command *cmd,
+					      const char *buf,
+					      const jsmntok_t *params)
+{
+	const char *name;
+
+	if (!param(cmd, buf, params,
+		   p_opt("name", param_string, &name),
+		   NULL))
+		return command_param_failed();
+
+	if (!name)
+		name = name_option ? name_option : tal_strdup(tmpctx, "world");
+
+	return command_success_str(cmd, tal_fmt(tmpctx, "hello %s", name));
+}
+
+static void init(struct plugin *p,
+		  const char *buf UNUSED, const jsmntok_t *config UNUSED)
+{
+	plugin_log(p, LOG_DBG, "test_libplugin initialised!");
+}
+
+static const struct plugin_command commands[] = { {
+		"helloworld",
+		"utils",
+		"Say hello to the world.",
+		"Returns 'hello world' by default, 'hello {name}' if the name"
+		" option was set, and 'hello {name}' if the name parameter "
+		"was passed (takes over the option)",
+		json_helloworld,
+	}
+};
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
+	            NULL, 0, NULL, 0,
+		    plugin_option("name",
+				  "string",
+				  "Who to say hello to.",
+				  charp_option, &name_option),
+		    NULL);
+}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -813,3 +813,9 @@ def test_libplugin(node_factory):
     assert l1.rpc.call("helloworld") == "hello test_opt"
     # But param takes over!
     assert l1.rpc.call("helloworld", {"name": "test"}) == "hello test"
+
+    # Test hooks and notifications
+    l2 = node_factory.get_node()
+    l2.connect(l1)
+    assert l1.daemon.is_in_log("{} peer_connected".format(l2.info["id"]))
+    l1.daemon.wait_for_log("{} connected".format(l2.info["id"]))

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -819,3 +819,6 @@ def test_libplugin(node_factory):
     l2.connect(l1)
     assert l1.daemon.is_in_log("{} peer_connected".format(l2.info["id"]))
     l1.daemon.wait_for_log("{} connected".format(l2.info["id"]))
+
+    # Test RPC calls FIXME: test concurrent ones ?
+    assert l1.rpc.call("testrpc") == l1.rpc.getinfo()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -791,7 +791,6 @@ def test_rpc_command_hook(node_factory):
     l1.rpc.plugin_stop('rpc_command.py')
 
 
-@pytest.mark.xfail(strict=True)
 def test_libplugin(node_factory):
     """Sanity checks for plugins made with libplugin"""
     plugin = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -789,3 +789,28 @@ def test_rpc_command_hook(node_factory):
 
     # Test command which removes plugin itself!
     l1.rpc.plugin_stop('rpc_command.py')
+
+
+@pytest.mark.xfail(strict=True)
+def test_libplugin(node_factory):
+    """Sanity checks for plugins made with libplugin"""
+    plugin = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")
+    l1 = node_factory.get_node(options={"plugin": plugin})
+
+    # Test startup
+    assert l1.daemon.is_in_log("test_libplugin initialised!")
+    # Test dynamic startup
+    l1.rpc.plugin_stop(plugin)
+    l1.rpc.plugin_start(plugin)
+    l1.rpc.check("helloworld")
+
+    # Test commands
+    assert l1.rpc.call("helloworld") == "hello world"
+    assert l1.rpc.call("helloworld", {"name": "test"}) == "hello test"
+    l1.stop()
+    l1.daemon.opts["plugin"] = plugin
+    l1.daemon.opts["name"] = "test_opt"
+    l1.start()
+    assert l1.rpc.call("helloworld") == "hello test_opt"
+    # But param takes over!
+    assert l1.rpc.call("helloworld", {"name": "test"}) == "hello test"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -791,6 +791,7 @@ def test_rpc_command_hook(node_factory):
     l1.rpc.plugin_stop('rpc_command.py')
 
 
+@flaky
 def test_libplugin(node_factory):
     """Sanity checks for plugins made with libplugin"""
     plugin = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")


### PR DESCRIPTION
This is a follow-up to #3443 (based on it and implements the first of the left TODOs).

This moves all plugins from "raw" `jout`s to using higher-level `json_stream` helpers.
This also adds sanity functional tests for libplugin plugins, which uncovered a bug.