### PR TITLE
libplugin: make deprecated_apis a global, don't expose struct plugin

### DIFF
--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -8,7 +8,6 @@
 
 static u64 cycle_seconds = 0, expired_by = 86400;
 static struct plugin_timer *cleantimer;
-static struct rpc_conn *rpc;
 
 static struct command_result *do_clean(struct plugin *p);
 
@@ -69,8 +68,6 @@ static struct command_result *json_autocleaninvoice(struct command *cmd,
 static void init(struct plugin *p,
 		  const char *buf UNUSED, const jsmntok_t *config UNUSED)
 {
-	rpc = p->rpc_conn;
-
 	if (cycle_seconds) {
 		plugin_log(p, LOG_INFORM, "autocleaning every %"PRIu64" seconds", cycle_seconds);
 		cleantimer = plugin_timer(p, time_from_sec(cycle_seconds),

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -314,7 +314,7 @@ static struct command_result *fundchannel_start(struct command *cmd,
 	json_out_start(ret, NULL, '{');
 	json_out_addstr(ret, "id", node_id_to_hexstr(tmpctx, fr->id));
 
-	if (cmd->plugin->deprecated_apis)
+	if (deprecated_apis)
 		json_out_addstr(ret, "satoshi", fr->funding_str);
 	else
 		json_out_addstr(ret, "amount", fr->funding_str);
@@ -446,7 +446,7 @@ static struct command_result *json_fundchannel(struct command *cmd,
 	struct funding_req *fr = tal(cmd, struct funding_req);
 
 	/* For generating help, give new-style. */
-	if (!params || !cmd->plugin->deprecated_apis || params->type == JSMN_ARRAY) {
+	if (!params || !deprecated_apis || params->type == JSMN_ARRAY) {
 		if (!param(cmd, buf, params,
 			   p_req("id", param_node_id, &fr->id),
 			   p_req("amount", param_string_check_sat, &fr->funding_str),

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -21,6 +21,8 @@
 
 const struct chainparams *chainparams;
 
+bool deprecated_apis;
+
 struct plugin_timer {
 	struct timer timer;
 	struct command_result *(*cb)(struct plugin *p);
@@ -666,7 +668,7 @@ static struct command_result *handle_init(struct command *cmd,
 			   strerror(errno));
 
 	param_obj = json_out_obj(NULL, "config", "allow-deprecated-apis");
-	p->deprecated_apis = streq(rpc_delve(tmpctx, p, "listconfigs",
+	deprecated_apis = streq(rpc_delve(tmpctx, p, "listconfigs",
 					  take(param_obj),
 					  ".allow-deprecated-apis"),
 				  "true");

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -17,6 +17,7 @@
 #include <common/status_levels.h>
 
 struct json_out;
+struct plugin;
 struct rpc_conn;
 
 extern bool deprecated_apis;
@@ -24,56 +25,6 @@ extern bool deprecated_apis;
 enum plugin_restartability {
 	PLUGIN_STATIC,
 	PLUGIN_RESTARTABLE
-};
-
-struct plugin {
-	/* lightningd interaction */
-	struct io_conn *stdin_conn;
-	struct io_conn *stdout_conn;
-
-	/* To read from lightningd */
-	char *buffer;
-	size_t used, len_read;
-
-	/* To write to lightningd */
-	struct json_stream **js_arr;
-
-	/* Asynchronous RPC interaction */
-	struct io_conn *io_rpc_conn;
-	struct json_stream **rpc_js_arr;
-	char *rpc_buffer;
-	size_t rpc_used, rpc_len_read;
-	/* Tracking async RPC requests */
-	UINTMAP(struct out_req *) out_reqs;
-	u64 next_outreq_id;
-
-	/* Synchronous RPC interaction */
-	struct rpc_conn *rpc_conn;
-
-	/* Plugin informations */
-	enum plugin_restartability restartability;
-	const struct plugin_command *commands;
-	size_t num_commands;
-	const struct plugin_notification *notif_subs;
-	size_t num_notif_subs;
-	const struct plugin_hook *hook_subs;
-	size_t num_hook_subs;
-	struct plugin_option *opts;
-
-	/* Anything special to do at init ? */
-	void (*init)(struct plugin *p,
-		     const char *buf, const jsmntok_t *);
-	/* Has the manifest been sent already ? */
-	bool manifested;
-	/* Has init been received ? */
-	bool initialized;
-
-	/* Map from json command names to usage strings: we don't put this inside
-	 * struct json_command as it's good practice to have those const. */
-	STRMAP(const char *) usagemap;
-	/* Timers */
-	struct timers timers;
-	size_t in_timer;
 };
 
 struct command {

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -19,6 +19,8 @@
 struct json_out;
 struct rpc_conn;
 
+extern bool deprecated_apis;
+
 enum plugin_restartability {
 	PLUGIN_STATIC,
 	PLUGIN_RESTARTABLE
@@ -72,8 +74,6 @@ struct plugin {
 	/* Timers */
 	struct timers timers;
 	size_t in_timer;
-
-	bool deprecated_apis;
 };
 
 struct command {


### PR DESCRIPTION
A follow-up to #3443, requested [here](https://github.com/ElementsProject/lightning/pull/3443#discussion_r374413965).
Changelog-None