### PR TITLE
Implement `getecdh`

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -58,4 +58,7 @@ static const errcode_t INVOICE_HINTS_GAVE_NO_ROUTES = 902;
 static const errcode_t INVOICE_EXPIRED_DURING_WAIT = 903;
 static const errcode_t INVOICE_WAIT_TIMED_OUT = 904;
 
+/* Errors from HSM crypto operations. */
+static const errcode_t HSM_ECDH_FAILED = 800;
+
 #endif /* LIGHTNING_COMMON_JSONRPC_ERRORS_H */

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1126,3 +1126,15 @@ class LightningRpc(UnixDomainSocketRpc):
             "pubkey": pubkey,
         }
         return self.call("checkmessage", payload)
+
+    def getecdh(self, point, **kwargs):
+        """
+        Compute the Elliptic Curve Diffie Hellman shared
+        secret point from this node private key and an
+        input {point}.
+        """
+        payload = {
+            "point": point
+        }
+        payload.update({k: v for k, v in kwargs.items()})
+        return self.call("getecdh", payload)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,6 +22,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-fundchannel_start.7 \
 	doc/lightning-fundchannel_complete.7 \
 	doc/lightning-fundchannel_cancel.7 \
+	doc/lightning-getecdh.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-listchannels.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,6 +43,7 @@ c-lightning Documentation
    lightning-fundchannel_cancel <lightning-fundchannel_cancel.7.md>
    lightning-fundchannel_complete <lightning-fundchannel_complete.7.md>
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
+   lightning-getecdh <lightning-getecdh.7.md>
    lightning-getroute <lightning-getroute.7.md>
    lightning-invoice <lightning-invoice.7.md>
    lightning-listchannels <lightning-listchannels.7.md>

--- a/doc/lightning-getecdh.7
+++ b/doc/lightning-getecdh.7
@@ -1,0 +1,101 @@
+.TH "LIGHTNING-GETECDH" "7" "" "" "lightning-getecdh"
+.SH NAME
+lightning-getecdh - Command for computing an ECDH
+.SH SYNOPSIS
+
+\fBgetecdh\fR \fIpoint\fR
+
+.SH DESCRIPTION
+
+The \fBgetecdh\fR RPC command computes a shared secret from a
+given public \fIpoint\fR, and the secret key of this node\.
+The \fIpoint\fR is a hexadecimal string of the compressed public
+key DER-encoding of the SECP256K1 point\.
+
+.SH RETURN VALUE
+
+On success, \fBgetecdh\fR returns a field \fIshared_secret\fR,
+which is a hexadecimal string of the compressed public key
+DER-encoding of the SECP256K1 point that is the shared secret
+generated using the Elliptic Curve Diffie-Hellman algorithm\.
+This field is 33 bytes (66 hexadecimal characters in a string)\.
+
+
+This command may fail if communications with the HSM has a
+problem;
+by default lightningd uses a software "HSM" which should
+never fail in this way\.
+(As of the time of this writing there is no true hardware
+HSM that lightningd can use, but we are leaving this
+possibilty open in the future\.)
+In that case, it will return with an error code of 800\.
+
+.SH CRYPTOGRAPHIC STANDARDS
+
+This is a cryptographic primitive and is only a small part of a
+full cryptographic suite of algorithms\.
+The returned shared secret is simply the product of the given
+\fIpoint\fR and the node secret key, returned as a DER compressed
+public key\.
+
+
+If you know the secret key behind \fIpoint\fR, you do not need to
+even call \fBgetecdh\fR, you can just multiply the secret key with
+the node public key\.
+
+
+Standards vary on their definition of ECDH key agreement\.
+
+.RS
+.IP 1\.
+In Lightning BOLT specs, the product of the secret key and
+the point is DER-encoded as a compressed public key, and the
+encoded form is hashed with 256-bit SHA-2, with the resulting
+hash considered as the shared secret key\.
+To work with \fBgetecdh\fR, just SHA-256 hash the returned
+\fIshared_secret\fR\.
+.IP 2\.
+In SECG SEC-1 ECIES, the X coordinate of the product of
+the secret key and the point is the shared secret key\.
+To work with \fBgetecdh\fR, just drop the first byte of
+the returned \fIshared_secret\fR, since the compressed DER
+encoding is just the sign of the Y coordinate followed by
+the full 256-bit X coordinate\.
+
+.RE
+
+Typically, a sender will generate an ephemeral secret key
+and multiply it with the node public key,
+then use the result to derive an encryption key
+for a symmetric encryption scheme
+to encrypt a message that can be read only by that node\.
+Then the ephemeral secret key is multiplied
+by the standard generator point,
+and the ephemeral public key and the encrypted message is
+sent to the node,
+which then uses \fBgetecdh\fR to derive the same key\.
+
+
+The above sketch elides important details like
+key derivation function, stream encryption scheme,
+message authentication code, and so on\.
+You should follow an established standard and avoid
+rolling your own crypto\.
+
+.SH AUTHOR
+
+ZmnSCPxj \fI<ZmnSCPxj@protonmail.com\fR> is mainly responsible\.
+
+.SH SEE ALSO
+.SH RESOURCES
+.RS
+.IP \[bu]
+BOLT 4: \fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#shared-secret\fR
+.IP \[bu]
+BOLT 8: \fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md#handshake-state\fR
+.IP \[bu]
+SECG SEC-1 ECIES: \fIhttps://secg.org/sec1-v2.pdf\fR
+.IP \[bu]
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+
+.RE

--- a/doc/lightning-getecdh.7.md
+++ b/doc/lightning-getecdh.7.md
@@ -1,0 +1,95 @@
+lightning-getecdh -- Command for computing an ECDH
+==================================================
+
+SYNOPSIS
+--------
+
+**getecdh** *point*
+
+DESCRIPTION
+-----------
+
+The **getecdh** RPC command computes a shared secret from a
+given public *point*, and the secret key of this node.
+The *point* is a hexadecimal string of the compressed public
+key DER-encoding of the SECP256K1 point.
+
+RETURN VALUE
+------------
+
+On success, **getecdh** returns a field *shared\_secret*,
+which is a hexadecimal string of the compressed public key
+DER-encoding of the SECP256K1 point that is the shared secret
+generated using the Elliptic Curve Diffie-Hellman algorithm.
+This field is 33 bytes (66 hexadecimal characters in a string).
+
+This command may fail if communications with the HSM has a
+problem;
+by default lightningd uses a software "HSM" which should
+never fail in this way.
+(As of the time of this writing there is no true hardware
+HSM that lightningd can use, but we are leaving this
+possibilty open in the future.)
+In that case, it will return with an error code of 800.
+
+CRYPTOGRAPHIC STANDARDS
+-----------------------
+
+This is a cryptographic primitive and is only a small part of a
+full cryptographic suite of algorithms.
+The returned shared secret is simply the product of the given
+*point* and the node secret key, returned as a DER compressed
+public key.
+
+If you know the secret key behind *point*, you do not need to
+even call **getecdh**, you can just multiply the secret key with
+the node public key.
+
+Standards vary on their definition of ECDH key agreement.
+
+1. In Lightning BOLT specs, the product of the secret key and
+   the point is DER-encoded as a compressed public key, and the
+   encoded form is hashed with 256-bit SHA-2, with the resulting
+   hash considered as the shared secret key.
+   To work with **getecdh**, just SHA-256 hash the returned
+   *shared\_secret*.
+2. In SECG SEC-1 ECIES, the X coordinate of the product of
+   the secret key and the point is the shared secret key.
+   To work with **getecdh**, just drop the first byte of
+   the returned *shared\_secret*, since the compressed DER
+   encoding is just the sign of the Y coordinate followed by
+   the full 256-bit X coordinate.
+
+Typically, a sender will generate an ephemeral secret key
+and multiply it with the node public key,
+then use the result to derive an encryption key
+for a symmetric encryption scheme
+to encrypt a message that can be read only by that node.
+Then the ephemeral secret key is multiplied
+by the standard generator point,
+and the ephemeral public key and the encrypted message is
+sent to the node,
+which then uses **getecdh** to derive the same key.
+
+The above sketch elides important details like
+key derivation function, stream encryption scheme,
+message authentication code, and so on.
+You should follow an established standard and avoid
+rolling your own crypto.
+
+AUTHOR
+------
+
+ZmnSCPxj <<ZmnSCPxj@protonmail.com>> is mainly responsible.
+
+SEE ALSO
+--------
+
+RESOURCES
+---------
+
+* BOLT 4: <https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#shared-secret>
+* BOLT 8: <https://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md#handshake-state>
+* SECG SEC-1 ECIES: <https://secg.org/sec1-v2.pdf>
+* Main web site: <https://github.com/ElementsProject/lightning>
+

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -89,11 +89,11 @@ msgdata,hsm_sign_invoice,hrp,u8,hrplen
 msgtype,hsm_sign_invoice_reply,108
 msgdata,hsm_sign_invoice_reply,sig,secp256k1_ecdsa_recoverable_signature,
 
-# Give me ECDH(node-id-secret,point)
-msgtype,hsm_ecdh_req,1
+# Give me ECDH(node-id-secret,point), return point
+msgtype,hsm_ecdh_req,99
 msgdata,hsm_ecdh_req,point,pubkey,
-msgtype,hsm_ecdh_resp,100
-msgdata,hsm_ecdh_resp,ss,secret,
+msgtype,hsm_ecdh_resp,199
+msgdata,hsm_ecdh_resp,ss,pubkey,
 
 msgtype,hsm_cannouncement_sig_req,2
 msgdata,hsm_cannouncement_sig_req,calen,u16,

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -750,8 +750,8 @@ static struct io_plan *handle_ecdh(struct io_conn *conn,
 	if (!fromwire_hsm_ecdh_req(msg_in, &point))
 		return bad_req(conn, c, msg_in);
 
-	/*~ We simply use the secp256k1_ecdh function: if ss.data is invalid,
-	 * we kill them for bad randomness (~1 in 2^127 if ss.data is random) */
+	/*~ We simply use the secp256k1_ecdh function: if privkey.secret.data is invalid,
+	 * we kill them for bad randomness (~1 in 2^127 if privkey.secret.data is random) */
 	node_key(&privkey, NULL);
 	if (secp256k1_ecdh(secp256k1_ctx, ss.data, &point.pubkey,
 			   privkey.secret.data, NULL, NULL) != 1) {

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -2079,7 +2079,8 @@ int main(int argc, char *argv[])
 	status_setup_async(status_conn);
 	uintmap_init(&clients);
 
-	master = new_client(NULL, NULL, NULL, 0, HSM_CAP_MASTER | HSM_CAP_SIGN_GOSSIP,
+	master = new_client(NULL, NULL, NULL, 0,
+			    HSM_CAP_MASTER | HSM_CAP_SIGN_GOSSIP | HSM_CAP_ECDH,
 			    REQ_FD);
 
 	/* First client == lightningd. */

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -5,6 +5,8 @@
 #include <ccan/fdpass/fdpass.h>
 #include <ccan/io/io.h>
 #include <ccan/take/take.h>
+#include <common/jsonrpc_errors.h>
+#include <common/param.h>
 #include <common/status.h>
 #include <common/utils.h>
 #include <errno.h>
@@ -12,6 +14,8 @@
 #include <inttypes.h>
 #include <lightningd/bitcoind.h>
 #include <lightningd/hsm_control.h>
+#include <lightningd/json.h>
+#include <lightningd/jsonrpc.h>
 #include <lightningd/log.h>
 #include <lightningd/log_status.h>
 #include <string.h>
@@ -123,3 +127,42 @@ void hsm_init(struct lightningd *ld)
 		errx(1, "HSM did not give init reply");
 	}
 }
+
+static struct command_result *json_getecdh(struct command *cmd,
+					   const char *buffer,
+					   const jsmntok_t *obj UNNEEDED,
+					   const jsmntok_t *params)
+{
+	struct lightningd *ld = cmd->ld;
+	struct pubkey *point;
+	struct pubkey ss;
+	u8 *msg;
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params,
+		   p_req("point", &param_pubkey, &point),
+		   NULL))
+		return command_param_failed();
+
+	msg = towire_hsm_ecdh_req(NULL, point);
+	if (!wire_sync_write(ld->hsm_fd, take(msg)))
+		return command_fail(cmd, HSM_ECDH_FAILED,
+				    "Failed to request ECDH to HSM");
+	msg = wire_sync_read(tmpctx, ld->hsm_fd);
+	if (!fromwire_hsm_ecdh_resp(msg, &ss))
+		return command_fail(cmd, HSM_ECDH_FAILED,
+				    "Failed HSM response for ECDH");
+
+	response = json_stream_success(cmd);
+	json_add_pubkey(response, "shared_secret", &ss);
+	return command_success(cmd, response);
+}
+
+static const struct json_command getecdh_command = {
+	"getecdh",
+	"utility", /* FIXME: Or "crypto"?  */
+	&json_getecdh,
+	"Compute the Elliptic Curve Diffie Hellman shared secret point from "
+	"this node private key and an input {point}."
+};
+AUTODATA(json_command, &getecdh_command);

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,6 +11,8 @@ from pyln.testing.utils import (
 )
 from ephemeral_port_reserve import reserve
 
+import binascii
+import hashlib
 import json
 import os
 import pytest
@@ -2148,3 +2150,30 @@ def test_sendcustommsg(node_factory):
     l4.daemon.wait_for_log(
         r'Got a custom message {serialized} from peer {peer_id}'.format(
             serialized=serialized, peer_id=l2.info['id']))
+
+
+@unittest.skipIf(not DEVELOPER, "needs --dev-force-privkey")
+def test_getecdh(node_factory):
+    """
+    Test getecdh command.
+    """
+    # From BOLT 8 test vectors.
+    options = [
+        {"dev-force-privkey": "1212121212121212121212121212121212121212121212121212121212121212"},
+        {}
+    ]
+    l1, l2 = node_factory.get_nodes(2, opts=options)
+
+    # Check BOLT 8 test vectors.
+    shared_secret = l1.rpc.getecdh("028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7")['shared_secret']
+    assert (hashlib.sha256(binascii.unhexlify(shared_secret)).hexdigest()
+            == "1e2fb3c8fe8fb9f262f649f64d26ecf0f2c0a805a767cf02dc2d77a6ef1fdcc3")
+
+    # Clear the forced privkey of l1.
+    del l1.daemon.opts["dev-force-privkey"]
+    l1.restart()
+
+    # l1 and l2 can generate the same shared secret
+    # knowing only the public key of the other.
+    assert (l1.rpc.getecdh(l2.info["id"])["shared_secret"]
+            == l2.rpc.getecdh(l1.info["id"])["shared_secret"])


### PR DESCRIPTION
This will eventually be a basis for a full #3118 implementation that can be placed in a plugin.

@devrandom @ksedgwic please notice change in `hsmd` interface.  I took the liberty of changing the exact message number for the `ecdh` request and response, so that you can write an alternate `hsmd` that can work with both old and new `ecdh` request types (a specific `lightningd` version will use one or the other, but you might want an alternate `hsmd` to work with older versions as well).  The difference is that the old `ecdh` request used the BOLT standard specifically (convert to DER, hash with SHA256) in the `hsmd` side, the new `ecdh` request just does convert to DER on sending back.  This is because the ECIES standard uses the X coord of the point, not the hash of the DER-compressed format, so to support ECIES, we give the point from `hsmd`.

Closes #3490

I think this is better than #3490.