### PR TITLE
Bitcoin backend generalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ PKGLIBEXEC_PROGRAMS = \
 	       lightningd/lightning_hsmd \
 	       lightningd/lightning_onchaind \
 	       lightningd/lightning_openingd
-PLUGINS=plugins/pay plugins/autoclean plugins/fundchannel
+PLUGINS=plugins/pay plugins/autoclean plugins/fundchannel plugins/bcli
 
 install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS)
 	@$(NORMAL_INSTALL)

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -51,6 +51,9 @@ static const errcode_t FUNDING_UNKNOWN_PEER = 306;
 static const errcode_t CONNECT_NO_KNOWN_ADDRESS = 400;
 static const errcode_t CONNECT_ALL_ADDRESSES_FAILED = 401;
 
+/* bitcoin-cli plugin errors */
+#define BCLI_ERROR                      400
+
 /* Errors from `invoice` command */
 static const errcode_t INVOICE_LABEL_ALREADY_EXISTS = 900;
 static const errcode_t INVOICE_PREIMAGE_ALREADY_EXISTS = 901;

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -495,33 +495,6 @@ void bitcoind_estimate_fees_(struct bitcoind *bitcoind,
 	do_one_estimatefee(bitcoind, efee);
 }
 
-static bool process_sendrawtx(struct bitcoin_cli *bcli)
-{
-	void (*cb)(struct bitcoind *bitcoind,
-		   int, const char *msg, void *) = bcli->cb;
-	const char *msg = tal_strndup(bcli, bcli->output,
-				      bcli->output_bytes);
-
-	log_debug(bcli->bitcoind->log, "sendrawtx exit %u, gave %s",
-		  *bcli->exitstatus, msg);
-
-	cb(bcli->bitcoind, *bcli->exitstatus, msg, bcli->cb_arg);
-	return true;
-}
-
-void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
-			 const char *hextx,
-			 void (*cb)(struct bitcoind *bitcoind,
-				    int exitstatus, const char *msg, void *),
-			 void *arg)
-{
-	log_debug(bitcoind->log, "sendrawtransaction: %s", hextx);
-	start_bitcoin_cli(bitcoind, NULL, process_sendrawtx, true,
-			  BITCOIND_HIGH_PRIO,
-			  cb, arg,
-			  "sendrawtransaction", hextx, NULL);
-}
-
 static bool process_rawblock(struct bitcoin_cli *bcli)
 {
 	struct bitcoin_block *blk;
@@ -565,6 +538,85 @@ static void bitcoin_plugin_error(struct bitcoind *bitcoind, const char *buf,
 	fatal("%s error: bad response to %s (%s), response was %.*s",
 	      p->cmd, method, reason,
 	      toks->end - toks->start, buf + toks->start);
+}
+
+/* `sendrawtransaction`
+ *
+ * Send a transaction to the Bitcoin backend plugin. If the broadcast was
+ * not successful on its end, the plugin will populate the `errmsg` with
+ * the reason.
+ *
+ * Plugin response:
+ * {
+ *	"success": <true|false>,
+ *	"errmsg": "<not empty if !success>"
+ * }
+ */
+
+struct sendrawtx_call {
+	struct bitcoind *bitcoind;
+	void (*cb)(struct bitcoind *bitcoind,
+		   bool success,
+		   const char *err_msg,
+		   void *);
+	void *cb_arg;
+};
+
+static void sendrawtx_callback(const char *buf, const jsmntok_t *toks,
+			       const jsmntok_t *idtok,
+			       struct sendrawtx_call *call)
+{
+	const jsmntok_t *resulttok, *successtok, *errtok;
+	bool success = false;
+
+	resulttok = json_get_member(buf, toks, "result");
+	if (!resulttok)
+		bitcoin_plugin_error(call->bitcoind, buf, toks,
+				     "sendrawtransaction",
+				     "bad 'result' field");
+
+	successtok = json_get_member(buf, resulttok, "success");
+	if (!successtok || !json_to_bool(buf, successtok, &success))
+		bitcoin_plugin_error(call->bitcoind, buf, toks,
+				     "sendrawtransaction",
+				     "bad 'success' field");
+
+	errtok = json_get_member(buf, resulttok, "errmsg");
+	if (!success && !errtok)
+		bitcoin_plugin_error(call->bitcoind, buf, toks,
+				     "sendrawtransaction",
+				     "bad 'errmsg' field");
+
+	db_begin_transaction(call->bitcoind->ld->wallet->db);
+	call->cb(call->bitcoind, success,
+		 errtok ? json_strdup(tmpctx, buf, errtok) : NULL,
+		 call->cb_arg);
+	db_commit_transaction(call->bitcoind->ld->wallet->db);
+
+	tal_free(call);
+}
+
+void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
+			 const char *hextx,
+			 void (*cb)(struct bitcoind *bitcoind,
+				    bool success, const char *err_msg, void *),
+			 void *cb_arg)
+{
+	struct jsonrpc_request *req;
+	struct sendrawtx_call *call = tal(bitcoind, struct sendrawtx_call);
+
+	call->bitcoind = bitcoind;
+	call->cb = cb;
+	call->cb_arg = cb_arg;
+	log_debug(bitcoind->log, "sendrawtransaction: %s", hextx);
+
+	req = jsonrpc_request_start(bitcoind, "sendrawtransaction",
+				    bitcoind->log, sendrawtx_callback,
+				    call);
+	json_add_string(req->stream, "tx", hextx);
+	jsonrpc_request_end(req);
+	plugin_request_send(strmap_get(&bitcoind->pluginsmap,
+				       "sendrawtransaction"), req);
 }
 
 /* `getrawblockbyheight`

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -80,6 +80,9 @@ void bitcoind_check_commands(struct bitcoind *bitcoind)
 	for (i = 0; i < ARRAY_SIZE(methods); i++) {
 		p = find_plugin_for_command(bitcoind->ld, methods[i]);
 		if (p == NULL) {
+			/* For testing .. */
+			log_debug(bitcoind->ld->log, "Missing a Bitcoin plugin"
+						     " command");
 			fatal("Could not access the plugin for %s, is a "
 			      "Bitcoin plugin (by default plugins/bcli) "
 			      "registered ?", methods[i]);

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -1011,6 +1011,7 @@ static bool process_getblockchaininfo(struct bitcoin_cli *bcli)
 
 static void destroy_bitcoind(struct bitcoind *bitcoind)
 {
+	strmap_clear(&bitcoind->pluginsmap);
 	/* Suppresses the callbacks from bcli_finished as we free conns. */
 	bitcoind->shutdown = true;
 }
@@ -1146,6 +1147,7 @@ struct bitcoind *new_bitcoind(const tal_t *ctx,
 {
 	struct bitcoind *bitcoind = tal(ctx, struct bitcoind);
 
+	strmap_init(&bitcoind->pluginsmap);
 	bitcoind->cli = NULL;
 	bitcoind->datadir = NULL;
 	bitcoind->ld = ld;

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -166,12 +166,19 @@ void bitcoind_getrawblockbyheight_(struct bitcoind *bitcoind,
 							  struct bitcoin_block *),\
 				      (arg))
 
-void bitcoind_gettxout(struct bitcoind *bitcoind,
-		       const struct bitcoin_txid *txid, const u32 outnum,
-		       void (*cb)(struct bitcoind *bitcoind,
-				  const struct bitcoin_tx_output *txout,
-				  void *arg),
-		       void *arg);
+void bitcoind_getutxout_(struct bitcoind *bitcoind,
+			 const struct bitcoin_txid *txid, const u32 outnum,
+			 void (*cb)(struct bitcoind *bitcoind,
+				    const struct bitcoin_tx_output *txout,
+				    void *arg),
+			 void *arg);
+#define bitcoind_getutxout(bitcoind_, txid_, vout_, cb, arg)		\
+	bitcoind_getutxout_((bitcoind_), (txid_), (vout_),		\
+			    typesafe_cb_preargs(void, void *,		\
+					        (cb), (arg),		\
+					        struct bitcoind *,	\
+					        struct bitcoin_tx_output *),\
+			    (arg))
 
 void bitcoind_getclientversion(struct bitcoind *bitcoind);
 

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -118,22 +118,6 @@ void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
 						bool, const char *),	\
 			    (arg))
 
-/* blkid is NULL if call fails. */
-void bitcoind_getblockhash_(struct bitcoind *bitcoind,
-			    u32 height,
-			    void (*cb)(struct bitcoind *bitcoind,
-				       const struct bitcoin_blkid *blkid,
-				       void *arg),
-			    void *arg);
-#define bitcoind_getblockhash(bitcoind_, height, cb, arg)		\
-	bitcoind_getblockhash_((bitcoind_),				\
-			       (height),				\
-			       typesafe_cb_preargs(void, void *,	\
-						   (cb), (arg),		\
-						   struct bitcoind *,	\
-						   const struct bitcoin_blkid *), \
-			       (arg))
-
 void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
 				void (*cb)(struct bitcoind *bitcoind,
 					   const struct filteredblock *fb,
@@ -147,20 +131,6 @@ void bitcoind_getfilteredblock_(struct bitcoind *bitcoind, u32 height,
 						       struct bitcoind *, \
 						       const struct filteredblock *), \
 				   (arg))
-
-void bitcoind_getrawblock_(struct bitcoind *bitcoind,
-			   const struct bitcoin_blkid *blockid,
-			   void (*cb)(struct bitcoind *bitcoind,
-				      struct bitcoin_block *blk,
-				      void *arg),
-			   void *arg);
-#define bitcoind_getrawblock(bitcoind_, blkid, cb, arg)			\
-	bitcoind_getrawblock_((bitcoind_), (blkid),			\
-			      typesafe_cb_preargs(void, void *,		\
-						  (cb), (arg),		\
-						  struct bitcoind *,	\
-						  struct bitcoin_block *), \
-			      (arg))
 
 void bitcoind_getchaininfo_(struct bitcoind *bitcoind,
 			    const bool first_call,

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -89,8 +89,6 @@ struct bitcoind *new_bitcoind(const tal_t *ctx,
 			      struct lightningd *ld,
 			      struct log *log);
 
-void wait_for_bitcoind(struct bitcoind *bitcoind);
-
 void bitcoind_estimate_fees_(struct bitcoind *bitcoind,
 			     const u32 blocks[], const char *estmode[],
 			     size_t num_estimates,
@@ -119,20 +117,6 @@ void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
 						struct bitcoind *,	\
 						int, const char *),	\
 			    (arg))
-
-void bitcoind_getblockcount_(struct bitcoind *bitcoind,
-			     void (*cb)(struct bitcoind *bitcoind,
-					u32 blockcount,
-					void *arg),
-			     void *arg);
-
-#define bitcoind_getblockcount(bitcoind_, cb, arg)			\
-	bitcoind_getblockcount_((bitcoind_),				\
-				typesafe_cb_preargs(void, void *,	\
-						    (cb), (arg),	\
-						    struct bitcoind *,	\
-						    u32 blockcount),	\
-				(arg))
 
 /* blkid is NULL if call fails. */
 void bitcoind_getblockhash_(struct bitcoind *bitcoind,
@@ -177,6 +161,40 @@ void bitcoind_getrawblock_(struct bitcoind *bitcoind,
 						  struct bitcoind *,	\
 						  struct bitcoin_block *), \
 			      (arg))
+
+void bitcoind_getchaininfo_(struct bitcoind *bitcoind,
+			    const bool first_call,
+			    void (*cb)(struct bitcoind *bitcoind,
+				       const char *chain,
+				       u32 headercount,
+				       u32 blockcount,
+				       const bool ibd,
+				       const bool first_call, void *),
+			    void *cb_arg);
+#define bitcoind_getchaininfo(bitcoind_, first_call_, cb, arg)		   \
+	bitcoind_getchaininfo_((bitcoind_), (first_call_),		   \
+			      typesafe_cb_preargs(void, void *,		   \
+						  (cb), (arg),		   \
+						  struct bitcoind *,	   \
+						  const char *, u32, u32,  \
+						  const bool, const bool), \
+			      (arg))
+
+void bitcoind_getrawblockbyheight_(struct bitcoind *bitcoind,
+				   u32 height,
+				   void (*cb)(struct bitcoind *bitcoind,
+					      struct bitcoin_blkid *blkid,
+					      struct bitcoin_block *blk,
+					      void *arg),
+				   void *arg);
+#define bitcoind_getrawblockbyheight(bitcoind_, height_, cb, arg)		\
+	bitcoind_getrawblockbyheight_((bitcoind_), (height_),			\
+				      typesafe_cb_preargs(void, void *,		\
+							  (cb), (arg),		\
+							  struct bitcoind *,	\
+							  struct bitcoin_blkid *, \
+							  struct bitcoin_block *),\
+				      (arg))
 
 void bitcoind_gettxout(struct bitcoind *bitcoind,
 		       const struct bitcoin_txid *txid, const u32 outnum,

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -19,47 +19,18 @@ struct ripemd160;
 struct bitcoin_tx;
 struct bitcoin_block;
 
-enum bitcoind_prio {
-	BITCOIND_LOW_PRIO,
-	BITCOIND_HIGH_PRIO
-};
-#define BITCOIND_NUM_PRIO (BITCOIND_HIGH_PRIO+1)
-
 struct bitcoind {
-	/* eg. "bitcoin-cli" */
-	char *cli;
-
-	/* -datadir arg for bitcoin-cli. */
-	char *datadir;
-
 	/* Where to do logging. */
 	struct log *log;
 
 	/* Main lightningd structure */
 	struct lightningd *ld;
 
-	/* Is bitcoind synced?  If not, we retry. */
+	/* Is our Bitcoin backend synced?  If not, we retry. */
 	bool synced;
-
-	/* How many high/low prio requests are we running (it's ratelimited) */
-	size_t num_requests[BITCOIND_NUM_PRIO];
-
-	/* Pending requests (high and low prio). */
-	struct list_head pending[BITCOIND_NUM_PRIO];
-
-	/* If non-zero, time we first hit a bitcoind error. */
-	unsigned int error_count;
-	struct timemono first_error_time;
 
 	/* Ignore results, we're shutting down. */
 	bool shutdown;
-
-	/* How long to keep trying to contact bitcoind
-	 * before fatally exiting. */
-	u64 retry_timeout;
-
-	/* Passthrough parameters for bitcoin-cli */
-	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
 
 	struct list_head pending_getfilteredblock;
 

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -107,7 +107,7 @@ void bitcoind_estimate_fees_(struct bitcoind *bitcoind,
 void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
 			 const char *hextx,
 			 void (*cb)(struct bitcoind *bitcoind,
-				    int exitstatus, const char *msg, void *),
+				    bool success, const char *msg, void *),
 			 void *arg);
 
 #define bitcoind_sendrawtx(bitcoind_, hextx, cb, arg)			\
@@ -115,7 +115,7 @@ void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
 			    typesafe_cb_preargs(void, void *,		\
 						(cb), (arg),		\
 						struct bitcoind *,	\
-						int, const char *),	\
+						bool, const char *),	\
 			    (arg))
 
 /* blkid is NULL if call fails. */

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -5,6 +5,7 @@
 #include <bitcoin/tx.h>
 #include <ccan/list/list.h>
 #include <ccan/short_types/short_types.h>
+#include <ccan/strmap/strmap.h>
 #include <ccan/tal/tal.h>
 #include <ccan/time/time.h>
 #include <ccan/typesafe_cb/typesafe_cb.h>
@@ -61,6 +62,10 @@ struct bitcoind {
 	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
 
 	struct list_head pending_getfilteredblock;
+
+	/* Map each method to a plugin, so we can have multiple plugins
+	 * handling different functionalities. */
+	STRMAP(struct plugin *) pluginsmap;
 };
 
 /* A single outpoint in a filtered block */

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -182,4 +182,6 @@ void bitcoind_gettxout(struct bitcoind *bitcoind,
 
 void bitcoind_getclientversion(struct bitcoind *bitcoind);
 
+void bitcoind_check_commands(struct bitcoind *bitcoind);
+
 #endif /* LIGHTNING_LIGHTNINGD_BITCOIND_H */

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -127,13 +127,13 @@ struct txs_to_broadcast {
 
 /* We just sent the last entry in txs[].  Shrink and send the next last. */
 static void broadcast_remainder(struct bitcoind *bitcoind,
-				int exitstatus, const char *msg,
+				bool success, const char *msg,
 				struct txs_to_broadcast *txs)
 {
 	/* These are expected. */
 	if (strstr(msg, "txn-mempool-conflict")
 	    || strstr(msg, "transaction already in block chain")
-	    || exitstatus)
+	    || !success)
 		log_debug(bitcoind->log,
 			  "Expected error broadcasting tx %s: %s",
 			  txs->txs[txs->cursor], msg);
@@ -174,7 +174,7 @@ static void rebroadcast_txs(struct chain_topology *topo, struct command *cmd)
 
 	/* Let this do the dirty work. */
 	txs->cursor = (size_t)-1;
-	broadcast_remainder(topo->bitcoind, 0, "", txs);
+	broadcast_remainder(topo->bitcoind, true, "", txs);
 }
 
 static void destroy_outgoing_tx(struct outgoing_tx *otx)
@@ -190,7 +190,7 @@ static void clear_otx_channel(struct channel *channel, struct outgoing_tx *otx)
 }
 
 static void broadcast_done(struct bitcoind *bitcoind,
-			   int exitstatus, const char *msg,
+			   bool success, const char *msg,
 			   struct outgoing_tx *otx)
 {
 	/* Channel gone?  Stop. */
@@ -203,7 +203,7 @@ static void broadcast_done(struct bitcoind *bitcoind,
 	tal_del_destructor2(otx->channel, clear_otx_channel, otx);
 
 	if (otx->failed_or_success) {
-		otx->failed_or_success(otx->channel, exitstatus, msg);
+		otx->failed_or_success(otx->channel, success, msg);
 		tal_free(otx);
 	} else {
 		/* For continual rebroadcasting, until channel freed. */
@@ -216,7 +216,7 @@ static void broadcast_done(struct bitcoind *bitcoind,
 void broadcast_tx(struct chain_topology *topo,
 		  struct channel *channel, const struct bitcoin_tx *tx,
 		  void (*failed_or_success)(struct channel *channel,
-				 int exitstatus, const char *err))
+					    bool success, const char *err))
 {
 	/* Channel might vanish: topo owns it to start with. */
 	struct outgoing_tx *otx = tal(topo, struct outgoing_tx);
@@ -985,7 +985,7 @@ check_chain(struct bitcoind *bitcoind, const char *chain,
 
 static void retry_check_chain(struct chain_topology *topo)
 {
-	bitcoind_getchaininfo(topo->bitcoind, true, check_chain, topo);
+	bitcoind_getchaininfo(topo->bitcoind, false, check_chain, topo);
 }
 
 void setup_topology(struct chain_topology *topo,

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -955,6 +955,9 @@ void setup_topology(struct chain_topology *topo,
 	topo->min_blockheight = min_blockheight;
 	topo->max_blockheight = max_blockheight;
 
+	/* This waits for bitcoind. */
+	bitcoind_check_commands(topo->bitcoind);
+
 	/* Make sure bitcoind is started, and ready */
 	wait_for_bitcoind(topo->bitcoind);
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -1001,6 +1001,9 @@ void setup_topology(struct chain_topology *topo,
 	/* This waits for bitcoind. */
 	bitcoind_check_commands(topo->bitcoind);
 
+	/* For testing.. */
+	log_debug(topo->ld->log, "All Bitcoin plugin commands registered");
+
 	/* Sanity checks, then topology initialization. */
 	bitcoind_getchaininfo(topo->bitcoind, true, check_chain, topo);
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -961,8 +961,6 @@ void setup_topology(struct chain_topology *topo,
 	/* Make sure bitcoind is started, and ready */
 	wait_for_bitcoind(topo->bitcoind);
 
-	bitcoind_getclientversion(topo->bitcoind);
-
 	bitcoind_getblockcount(topo->bitcoind, get_init_blockhash, topo);
 
 	tal_add_destructor(topo, destroy_chain_topology);

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -37,7 +37,7 @@ struct outgoing_tx {
 	struct channel *channel;
 	const char *hextx;
 	struct bitcoin_txid txid;
-	void (*failed_or_success)(struct channel *channel, int exitstatus, const char *err);
+	void (*failed_or_success)(struct channel *channel, bool success, const char *err);
 };
 
 struct block {
@@ -166,7 +166,7 @@ struct command_result *param_feerate_estimate(struct command *cmd,
 void broadcast_tx(struct chain_topology *topo,
 		  struct channel *channel, const struct bitcoin_tx *tx,
 		  void (*failed)(struct channel *channel,
-				 int exitstatus,
+				 bool success,
 				 const char *err));
 
 struct chain_topology *new_topology(struct lightningd *ld, struct log *log);

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -774,11 +774,11 @@ struct command_result *cancel_channel_before_broadcast(struct command *cmd,
 	/* Note: The above check and this check can't completely ensure that
 	 * the funding transaction isn't broadcast. We can't know if the funding
 	 * is broadcast by external wallet and the transaction hasn't been onchain. */
-	bitcoind_gettxout(cmd->ld->topology->bitcoind,
-			  &cancel_channel->funding_txid,
-			  cancel_channel->funding_outnum,
-			  process_check_funding_broadcast,
-			  notleak(cc));
+	bitcoind_getutxout(cmd->ld->topology->bitcoind,
+			   &cancel_channel->funding_txid,
+			   cancel_channel->funding_outnum,
+			   process_check_funding_broadcast,
+			   notleak(cc));
 	return command_still_pending(cmd);
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -839,10 +839,6 @@ int main(int argc, char *argv[])
 	else if (max_blockheight != UINT32_MAX)
 		max_blockheight -= ld->config.rescan;
 
-	/*~ Tell the wallet to start figuring out what to do for any reserved
-	 * unspent outputs we may have crashed with. */
-	wallet_clean_utxos(ld->wallet, ld->topology->bitcoind);
-
 	/*~ That's all of the wallet db operations for now. */
 	db_commit_transaction(ld->wallet->db);
 
@@ -851,10 +847,14 @@ int main(int argc, char *argv[])
 	setup_topology(ld->topology, ld->timers,
 		       min_blockheight, max_blockheight);
 
+	db_begin_transaction(ld->wallet->db);
+	/*~ Tell the wallet to start figuring out what to do for any reserved
+	 * unspent outputs we may have crashed with. */
+	wallet_clean_utxos(ld->wallet, ld->topology->bitcoind);
+
 	/*~ Pull peers, channels and HTLCs from db. Needs to happen after the
 	 *  topology is initialized since some decisions rely on being able to
 	 *  know the blockheight. */
-	db_begin_transaction(ld->wallet->db);
 	unconnected_htlcs_in = load_channels_from_wallet(ld);
 	db_commit_transaction(ld->wallet->db);
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -789,34 +789,10 @@ static void register_opts(struct lightningd *ld)
 
 	opt_register_noarg("--help|-h", opt_lightningd_usage, ld,
 				 "Print this message.");
-	opt_register_arg("--bitcoin-datadir", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->datadir,
-			 "-datadir arg for bitcoin-cli");
 	opt_register_arg("--rgb", opt_set_rgb, NULL, ld,
 			 "RRGGBB hex color for node");
 	opt_register_arg("--alias", opt_set_alias, NULL, ld,
 			 "Up to 32-byte alias for node");
-
-	opt_register_arg("--bitcoin-cli", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->cli,
-			 "bitcoin-cli pathname");
-	opt_register_arg("--bitcoin-rpcuser", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->rpcuser,
-			 "bitcoind RPC username");
-	opt_register_arg("--bitcoin-rpcpassword", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->rpcpass,
-			 "bitcoind RPC password");
-	opt_register_arg("--bitcoin-rpcconnect", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->rpcconnect,
-			 "bitcoind RPC host to connect to");
-	opt_register_arg("--bitcoin-rpcport", opt_set_talstr, NULL,
-			 &ld->topology->bitcoind->rpcport,
-			 "bitcoind RPC port");
-	opt_register_arg("--bitcoin-retry-timeout",
-			 opt_set_u64, opt_show_u64,
-			 &ld->topology->bitcoind->retry_timeout,
-			 "how long to keep trying to contact bitcoind "
-			 "before fatally exiting");
 
 	opt_register_arg("--pid-file=<file>", opt_set_talstr, opt_show_charp,
 			 &ld->pidfile,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2263,10 +2263,10 @@ static struct command_result *json_dev_forget_channel(struct command *cmd,
 				    "or `dev-fail` instead.");
 	}
 
-	bitcoind_gettxout(cmd->ld->topology->bitcoind,
-			  &forget->channel->funding_txid,
-			  forget->channel->funding_outnum,
-			  process_dev_forget_channel, forget);
+	bitcoind_getutxout(cmd->ld->topology->bitcoind,
+			   &forget->channel->funding_txid,
+			   forget->channel->funding_outnum,
+			   process_dev_forget_channel, forget);
 	return command_still_pending(cmd);
 }
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -181,6 +181,13 @@ bool plugin_remove(struct plugins *plugins, const char *name);
 void plugin_kill(struct plugin *plugin, char *fmt, ...) PRINTF_FMT(2,3);
 
 /**
+ * Returns the plugin which registers the command with name {cmd_name}
+ */
+struct plugin *find_plugin_for_command(struct lightningd *ld,
+				       const char *cmd_name);
+
+
+/**
  * Send the configure message to all plugins.
  *
  * Once we've collected all the command line arguments we can go ahead

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -13,14 +13,14 @@ size_t bigsize_get(const u8 *p UNNEEDED, size_t max UNNEEDED, bigsize_t *val UNN
 /* Generated stub for bigsize_put */
 size_t bigsize_put(u8 buf[BIGSIZE_MAX_LEN] UNNEEDED, bigsize_t v UNNEEDED)
 { fprintf(stderr, "bigsize_put called!\n"); abort(); }
-/* Generated stub for bitcoind_gettxout */
-void bitcoind_gettxout(struct bitcoind *bitcoind UNNEEDED,
-		       const struct bitcoin_txid *txid UNNEEDED, const u32 outnum UNNEEDED,
-		       void (*cb)(struct bitcoind *bitcoind UNNEEDED,
-				  const struct bitcoin_tx_output *txout UNNEEDED,
-				  void *arg) UNNEEDED,
-		       void *arg UNNEEDED)
-{ fprintf(stderr, "bitcoind_gettxout called!\n"); abort(); }
+/* Generated stub for bitcoind_getutxout_ */
+void bitcoind_getutxout_(struct bitcoind *bitcoind UNNEEDED,
+			 const struct bitcoin_txid *txid UNNEEDED, const u32 outnum UNNEEDED,
+			 void (*cb)(struct bitcoind *bitcoind UNNEEDED,
+				    const struct bitcoin_tx_output *txout UNNEEDED,
+				    void *arg) UNNEEDED,
+			 void *arg UNNEEDED)
+{ fprintf(stderr, "bitcoind_getutxout_ called!\n"); abort(); }
 /* Generated stub for bolt11_decode */
 struct bolt11 *bolt11_decode(const tal_t *ctx UNNEEDED, const char *str UNNEEDED,
 			     const char *description UNNEEDED, char **fail UNNEEDED)
@@ -90,7 +90,7 @@ struct fee_states *dup_fee_states(const tal_t *ctx UNNEEDED,
 /* Generated stub for encode_scriptpubkey_to_addr */
 char *encode_scriptpubkey_to_addr(const tal_t *ctx UNNEEDED,
 				  const struct chainparams *chainparams UNNEEDED,
-                                  const u8 *scriptPubkey UNNEEDED)
+				  const u8 *scriptPubkey UNNEEDED)
 { fprintf(stderr, "encode_scriptpubkey_to_addr called!\n"); abort(); }
 /* Generated stub for fatal */
 void   fatal(const char *fmt UNNEEDED, ...)
@@ -198,6 +198,10 @@ enum address_parse_result json_to_address_scriptpubkey(const tal_t *ctx UNNEEDED
 			     const char *buffer UNNEEDED,
 			     const jsmntok_t *tok UNNEEDED, const u8 **scriptpubkey UNNEEDED)
 { fprintf(stderr, "json_to_address_scriptpubkey called!\n"); abort(); }
+/* Generated stub for json_tok_channel_id */
+bool json_tok_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+			 struct channel_id *cid UNNEEDED)
+{ fprintf(stderr, "json_tok_channel_id called!\n"); abort(); }
 /* Generated stub for json_to_node_id */
 bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			       struct node_id *id UNNEEDED)
@@ -206,10 +210,6 @@ bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 bool json_to_short_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			      struct short_channel_id *scid UNNEEDED)
 { fprintf(stderr, "json_to_short_channel_id called!\n"); abort(); }
-/* Generated stub for json_tok_channel_id */
-bool json_tok_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-			 struct channel_id *cid UNNEEDED)
-{ fprintf(stderr, "json_tok_channel_id called!\n"); abort(); }
 /* Generated stub for kill_uncommitted_channel */
 void kill_uncommitted_channel(struct uncommitted_channel *uc UNNEEDED,
 			      const char *why UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -38,7 +38,7 @@ char *bolt11_encode_(const tal_t *ctx UNNEEDED,
 void broadcast_tx(struct chain_topology *topo UNNEEDED,
 		  struct channel *channel UNNEEDED, const struct bitcoin_tx *tx UNNEEDED,
 		  void (*failed)(struct channel *channel UNNEEDED,
-				 int exitstatus UNNEEDED,
+				 bool success UNNEEDED,
 				 const char *err))
 { fprintf(stderr, "broadcast_tx called!\n"); abort(); }
 /* Generated stub for channel_tell_depth */

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -7,6 +7,9 @@ PLUGIN_AUTOCLEAN_OBJS := $(PLUGIN_AUTOCLEAN_SRC:.c=.o)
 PLUGIN_FUNDCHANNEL_SRC := plugins/fundchannel.c
 PLUGIN_FUNDCHANNEL_OBJS := $(PLUGIN_FUNDCHANNEL_SRC:.c=.o)
 
+PLUGIN_BCLI_SRC := plugins/bcli.c
+PLUGIN_BCLI_OBJS := $(PLUGIN_BCLI_SRC:.c=.o)
+
 PLUGIN_LIB_SRC := plugins/libplugin.c
 PLUGIN_LIB_HEADER := plugins/libplugin.h
 PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
@@ -51,11 +54,13 @@ plugins/autoclean: bitcoin/chainparams.o $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_LIB_O
 
 plugins/fundchannel: common/addr.o $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
-$(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
+plugins/bcli: bitcoin/chainparams.o $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+
+$(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
 
 # Make sure these depend on everything.
-ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel
-ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
+ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel plugins/bcli
+ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS)
 
 check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%)
 check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%)

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -1,0 +1,755 @@
+#include <bitcoin/base58.h>
+#include <bitcoin/block.h>
+#include <bitcoin/feerate.h>
+#include <bitcoin/script.h>
+#include <bitcoin/shadouble.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/cast/cast.h>
+#include <ccan/io/io.h>
+#include <ccan/json_out/json_out.h>
+#include <ccan/pipecmd/pipecmd.h>
+#include <ccan/str/hex/hex.h>
+#include <ccan/take/take.h>
+#include <ccan/tal/grab_file/grab_file.h>
+#include <ccan/tal/path/path.h>
+#include <ccan/tal/str/str.h>
+#include <common/json_helpers.h>
+#include <common/memleak.h>
+#include <common/utils.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <plugins/libplugin.h>
+
+/* Bitcoind's web server has a default of 4 threads, with queue depth 16.
+ * It will *fail* rather than queue beyond that, so we must not stress it!
+ *
+ * This is how many request for each priority level we have.
+ */
+#define BITCOIND_MAX_PARALLEL 4
+
+enum bitcoind_prio {
+	BITCOIND_LOW_PRIO,
+	BITCOIND_HIGH_PRIO
+};
+#define BITCOIND_NUM_PRIO (BITCOIND_HIGH_PRIO+1)
+
+struct bitcoind {
+	/* eg. "bitcoin-cli" */
+	char *cli;
+
+	/* -datadir arg for bitcoin-cli. */
+	char *datadir;
+
+	/* Is bitcoind synced?  If not, we retry. */
+	bool synced;
+
+	/* How many high/low prio requests are we running (it's ratelimited) */
+	size_t num_requests[BITCOIND_NUM_PRIO];
+
+	/* Pending requests (high and low prio). */
+	struct list_head pending[BITCOIND_NUM_PRIO];
+
+	/* If non-zero, time we first hit a bitcoind error. */
+	unsigned int error_count;
+	struct timemono first_error_time;
+
+	/* How long to keep trying to contact bitcoind
+	 * before fatally exiting. */
+	u64 retry_timeout;
+
+	/* Passthrough parameters for bitcoin-cli */
+	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
+};
+
+static struct bitcoind *bitcoind;
+
+struct bitcoin_cli {
+	struct list_node list;
+	int fd;
+	int *exitstatus;
+	pid_t pid;
+	const char **args;
+	struct timeabs start;
+	enum bitcoind_prio prio;
+	char *output;
+	size_t output_bytes;
+	size_t new_output;
+	struct command_result *(*process)(struct bitcoin_cli *);
+	struct command *cmd;
+	/* Used to stash content between multiple calls */
+	void *stash;
+};
+
+/* Add the n'th arg to *args, incrementing n and keeping args of size n+1 */
+static void add_arg(const char ***args, const char *arg)
+{
+	tal_arr_expand(args, arg);
+}
+
+static const char **gather_args(const tal_t *ctx, const char *cmd, const char **cmd_args)
+{
+	const char **args = tal_arr(ctx, const char *, 1);
+
+	args[0] = bitcoind->cli ? bitcoind->cli : chainparams->cli;
+	if (chainparams->cli_args)
+		add_arg(&args, chainparams->cli_args);
+	if (bitcoind->datadir)
+		add_arg(&args, tal_fmt(args, "-datadir=%s", bitcoind->datadir));
+	if (bitcoind->rpcconnect)
+		add_arg(&args,
+			tal_fmt(args, "-rpcconnect=%s", bitcoind->rpcconnect));
+	if (bitcoind->rpcport)
+		add_arg(&args,
+			tal_fmt(args, "-rpcport=%s", bitcoind->rpcport));
+	if (bitcoind->rpcuser)
+		add_arg(&args, tal_fmt(args, "-rpcuser=%s", bitcoind->rpcuser));
+	if (bitcoind->rpcpass)
+		add_arg(&args,
+			tal_fmt(args, "-rpcpassword=%s", bitcoind->rpcpass));
+
+	add_arg(&args, cmd);
+	for (size_t i = 0; i < tal_count(cmd_args); i++)
+		add_arg(&args, cmd_args[i]);
+	add_arg(&args, NULL);
+
+	return args;
+}
+
+static struct io_plan *read_more(struct io_conn *conn, struct bitcoin_cli *bcli)
+{
+	bcli->output_bytes += bcli->new_output;
+	if (bcli->output_bytes == tal_count(bcli->output))
+		tal_resize(&bcli->output, bcli->output_bytes * 2);
+	return io_read_partial(conn, bcli->output + bcli->output_bytes,
+			       tal_count(bcli->output) - bcli->output_bytes,
+			       &bcli->new_output, read_more, bcli);
+}
+
+static struct io_plan *output_init(struct io_conn *conn, struct bitcoin_cli *bcli)
+{
+	bcli->output_bytes = bcli->new_output = 0;
+	bcli->output = tal_arr(bcli, char, 100);
+	return read_more(conn, bcli);
+}
+
+static void next_bcli(enum bitcoind_prio prio);
+
+/* For printing: simple string of args (no secrets!) */
+static char *args_string(const tal_t *ctx, const char **args)
+{
+	size_t i;
+	char *ret = tal_strdup(ctx, args[0]);
+
+	for (i = 1; args[i]; i++) {
+		ret = tal_strcat(ctx, take(ret), " ");
+		if (strstarts(args[i], "-rpcpassword")) {
+			ret = tal_strcat(ctx, take(ret), "-rpcpassword=...");
+		} else if (strstarts(args[i], "-rpcuser")) {
+			ret = tal_strcat(ctx, take(ret), "-rpcuser=...");
+		} else {
+			ret = tal_strcat(ctx, take(ret), args[i]);
+		}
+	}
+	return ret;
+}
+
+static char *bcli_args(struct bitcoin_cli *bcli)
+{
+    return args_string(bcli, bcli->args);
+}
+
+static void retry_bcli(void *cb_arg)
+{
+	struct bitcoin_cli *bcli = cb_arg;
+	list_add_tail(&bitcoind->pending[bcli->prio], &bcli->list);
+	next_bcli(bcli->prio);
+}
+
+/* We allow 60 seconds of spurious errors, eg. reorg. */
+static void bcli_failure(struct bitcoin_cli *bcli,
+                         int exitstatus)
+{
+	struct timerel t;
+
+	if (!bitcoind->error_count)
+		bitcoind->first_error_time = time_mono();
+
+	t = timemono_between(time_mono(), bitcoind->first_error_time);
+	if (time_greater(t, time_from_sec(bitcoind->retry_timeout)))
+		plugin_err(bcli->cmd->plugin,
+		           "%s exited %u (after %u other errors) '%.*s'; "
+		           "we have been retrying command for "
+		           "--bitcoin-retry-timeout=%"PRIu64" seconds; "
+		           "bitcoind setup or our --bitcoin-* configs broken?",
+		           bcli_args(bcli),
+		           exitstatus,
+		           bitcoind->error_count,
+		           (int)bcli->output_bytes,
+		           bcli->output,
+		           bitcoind->retry_timeout);
+
+	plugin_log(bcli->cmd->plugin, LOG_UNUSUAL, "%s exited with status %u",
+		   bcli_args(bcli), exitstatus);
+	bitcoind->error_count++;
+
+	/* Retry in 1 second (not a leak!) */
+	plugin_timer(bcli->cmd->plugin, time_from_sec(1), retry_bcli, bcli);
+}
+
+static void bcli_finished(struct io_conn *conn UNUSED, struct bitcoin_cli *bcli)
+{
+	int ret, status;
+	struct command_result *res;
+	enum bitcoind_prio prio = bcli->prio;
+	u64 msec = time_to_msec(time_between(time_now(), bcli->start));
+
+	/* If it took over 10 seconds, that's rather strange. */
+	if (msec > 10000)
+		plugin_log(bcli->cmd->plugin, LOG_UNUSUAL,
+		           "bitcoin-cli: finished %s (%"PRIu64" ms)",
+		           bcli_args(bcli), msec);
+
+	assert(bitcoind->num_requests[prio] > 0);
+
+	/* FIXME: If we waited for SIGCHILD, this could never hang! */
+	while ((ret = waitpid(bcli->pid, &status, 0)) < 0 && errno == EINTR);
+	if (ret != bcli->pid)
+		plugin_err(bcli->cmd->plugin, "%s %s", bcli_args(bcli),
+		           ret == 0 ? "not exited?" : strerror(errno));
+
+	if (!WIFEXITED(status))
+		plugin_err(bcli->cmd->plugin, "%s died with signal %i",
+		           bcli_args(bcli),
+		           WTERMSIG(status));
+
+	/* Implicit nonzero_exit_ok == false */
+	if (!bcli->exitstatus) {
+		if (WEXITSTATUS(status) != 0) {
+			bcli_failure(bcli, WEXITSTATUS(status));
+			bitcoind->num_requests[prio]--;
+			goto done;
+		}
+	} else
+		*bcli->exitstatus = WEXITSTATUS(status);
+
+	if (WEXITSTATUS(status) == 0)
+		bitcoind->error_count = 0;
+
+	bitcoind->num_requests[bcli->prio]--;
+
+	res = bcli->process(bcli);
+	if (!res)
+		bcli_failure(bcli, WEXITSTATUS(status));
+	else
+		tal_free(bcli);
+
+done:
+	next_bcli(prio);
+}
+
+static void next_bcli(enum bitcoind_prio prio)
+{
+	struct bitcoin_cli *bcli;
+	struct io_conn *conn;
+
+	if (bitcoind->num_requests[prio] >= BITCOIND_MAX_PARALLEL)
+		return;
+
+	bcli = list_pop(&bitcoind->pending[prio], struct bitcoin_cli, list);
+	if (!bcli)
+		return;
+
+	bcli->pid = pipecmdarr(NULL, &bcli->fd, &bcli->fd,
+			       cast_const2(char **, bcli->args));
+	if (bcli->pid < 0)
+		plugin_err(bcli->cmd->plugin, "%s exec failed: %s",
+			   bcli->args[0], strerror(errno));
+
+	bcli->start = time_now();
+
+	bitcoind->num_requests[prio]++;
+
+	conn = io_new_conn(bcli, bcli->fd, output_init, bcli);
+	io_set_finish(conn, bcli_finished, bcli);
+}
+
+/* If ctx is non-NULL, and is freed before we return, we don't call process().
+ * process returns false() if it's a spurious error, and we should retry. */
+static void
+start_bitcoin_cli(const tal_t *ctx,
+		  struct command *cmd,
+		  struct command_result *(*process)(struct bitcoin_cli *),
+		  bool nonzero_exit_ok,
+		  enum bitcoind_prio prio,
+		  char *method, const char **method_args,
+		  void *stash)
+{
+	struct bitcoin_cli *bcli = tal(bitcoind, struct bitcoin_cli);
+
+	bcli->process = process;
+	bcli->cmd = cmd;
+	bcli->prio = prio;
+
+	if (nonzero_exit_ok)
+		bcli->exitstatus = tal(bcli, int);
+	else
+		bcli->exitstatus = NULL;
+
+	bcli->args = gather_args(bcli, method, method_args);
+	bcli->stash = stash;
+
+	list_add_tail(&bitcoind->pending[bcli->prio], &bcli->list);
+	next_bcli(bcli->prio);
+}
+
+static struct command_result *process_getutxout(struct bitcoin_cli *bcli)
+{
+	const jsmntok_t *tokens, *valuetok, *scriptpubkeytok, *hextok;
+	struct json_stream *response;
+	bool valid;
+	struct bitcoin_tx_output output;
+	char *err;
+
+	/* As of at least v0.15.1.0, bitcoind returns "success" but an empty
+	   string on a spent txout. */
+	if (*bcli->exitstatus != 0 || bcli->output_bytes == 0) {
+		response = jsonrpc_stream_success(bcli->cmd);
+		json_add_null(response, "amount");
+		json_add_null(response, "script");
+
+		return command_finished(bcli->cmd, response);
+	}
+
+	tokens = json_parse_input(bcli->output, bcli->output,
+				  bcli->output_bytes, &valid);
+	if (!tokens) {
+		err = tal_fmt(bcli, "%s: %s response", bcli_args(bcli),
+			      valid ? "partial" : "invalid");
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	if (tokens[0].type != JSMN_OBJECT) {
+		err = tal_fmt(bcli, "%s: gave non-object (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	valuetok = json_get_member(bcli->output, tokens, "value");
+	if (!valuetok) {
+		err = tal_fmt(bcli,"%s: had no value member (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	if (!json_to_bitcoin_amount(bcli->output, valuetok, &output.amount.satoshis)) {/* Raw: talking to bitcoind */
+		err = tal_fmt(bcli, "%s: had bad value (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	scriptpubkeytok = json_get_member(bcli->output, tokens, "scriptPubKey");
+	if (!scriptpubkeytok) {
+		err = tal_fmt(bcli, "%s: had no scriptPubKey member (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	hextok = json_get_member(bcli->output, scriptpubkeytok, "hex");
+	if (!hextok) {
+		err = tal_fmt(bcli, "%s: had no scriptPubKey->hex member (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	output.script = tal_hexdata(bcli, bcli->output + hextok->start,
+	                            hextok->end - hextok->start);
+	if (!output.script) {
+		err = tal_fmt(bcli, "%s: scriptPubKey->hex invalid hex (%.*s)?",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	response = jsonrpc_stream_success(bcli->cmd);
+	json_add_amount_sat_only(response, "amount", output.amount);
+	json_add_string(response, "script",
+			tal_hexstr(response, output.script, sizeof(output.script)));
+
+	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *process_getblockchaininfo(struct bitcoin_cli *bcli)
+{
+	const jsmntok_t *tokens, *chaintok, *headerstok, *blockstok, *ibdtok;
+	struct json_stream *response;
+	bool valid, ibd;
+	u32 headers, blocks;
+	char *err;
+
+	tokens = json_parse_input(bcli, bcli->output, bcli->output_bytes,
+	                          &valid);
+	if (!tokens) {
+		err = tal_fmt(bcli->cmd, "%s: %s response (%.*s)",
+			      bcli_args(bcli), valid ? "partial" : "invalid",
+			      (int)bcli->output_bytes, bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	if (tokens[0].type != JSMN_OBJECT) {
+		err = tal_fmt(bcli->cmd, "%s: gave non-object (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	chaintok = json_get_member(bcli->output, tokens, "chain");
+	if (!chaintok) {
+		err = tal_fmt(bcli->cmd, "%s: bad 'chain' field (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	headerstok = json_get_member(bcli->output, tokens, "headers");
+	if (!headerstok || !json_to_number(bcli->output, headerstok, &headers)) {
+		err = tal_fmt(bcli->cmd, "%s: bad 'headers' field (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	blockstok = json_get_member(bcli->output, tokens, "blocks");
+	if (!blockstok || !json_to_number(bcli->output, blockstok, &blocks)) {
+		err = tal_fmt(bcli->cmd, "%s: bad 'blocks' field (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	ibdtok = json_get_member(bcli->output, tokens, "initialblockdownload");
+	if (!ibdtok || !json_to_bool(bcli->output, ibdtok, &ibd)) {
+		err = tal_fmt(bcli->cmd, "%s: bad 'initialblockdownload' field (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	response = jsonrpc_stream_success(bcli->cmd);
+	json_add_string(response, "chain",
+			json_strdup(response, bcli->output, chaintok));
+	json_add_u32(response, "headercount", headers);
+	json_add_u32(response, "blockcount", blocks);
+	json_add_bool(response, "ibd", ibd);
+
+	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *process_estimatefee(struct bitcoin_cli *bcli)
+{
+	const jsmntok_t *tokens, *feeratetok = NULL;
+	struct json_stream *response;
+	bool valid;
+	u64 feerate;
+	char *err;
+
+	if (*bcli->exitstatus != 0)
+		goto end;
+
+	tokens = json_parse_input(bcli->output, bcli->output,
+	                          (int)bcli->output_bytes, &valid);
+	if (!tokens) {
+		err = tal_fmt(bcli->cmd, "%s: %s response (%.*s)",
+			      bcli_args(bcli), valid ? "partial" : "invalid",
+			      (int)bcli->output_bytes, bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	if (tokens[0].type != JSMN_OBJECT) {
+		err = tal_fmt(bcli->cmd, "%s: gave non-object (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	feeratetok = json_get_member(bcli->output, tokens, "feerate");
+	if (feeratetok &&
+	    !json_to_bitcoin_amount(bcli->output, feeratetok, &feerate)) {
+		err = tal_fmt(bcli->cmd, "%s: bad 'feerate' field (%.*s)",
+			      bcli_args(bcli), (int)bcli->output_bytes,
+			      bcli->output);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+end:
+	response = jsonrpc_stream_success(bcli->cmd);
+	if (feeratetok)
+		json_add_u64(response, "feerate", feerate);
+	else
+		json_add_null(response, "feerate");
+
+	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcli)
+{
+	struct json_stream *response;
+
+	plugin_log(bcli->cmd->plugin, LOG_DBG, "sendrawtx exit %i (%s)",
+		   *bcli->exitstatus, bcli_args(bcli));
+
+	response = jsonrpc_stream_success(bcli->cmd);
+	json_add_bool(response, "success", *bcli->exitstatus == 0);
+	json_add_string(response, "errmsg",
+			bcli->exitstatus ? tal_strndup(bcli, bcli->output,
+						       bcli->output_bytes-1) : "");
+
+	return command_finished(bcli->cmd, response);
+}
+
+struct getrawblock_stash {
+	const char *block_hash;
+	u32 block_height;
+	const char *block_hex;
+};
+
+static struct command_result *process_getrawblock(struct bitcoin_cli *bcli)
+{
+	struct json_stream *response;
+	struct getrawblock_stash *stash = bcli->stash;
+
+	/* -1 to strip \n. */
+	stash->block_hex = tal_fmt(stash, "%.*s",
+	                           (int)bcli->output_bytes-1, bcli->output);
+
+	response = jsonrpc_stream_success(bcli->cmd);
+	json_add_string(response, "blockhash", stash->block_hash);
+	json_add_string(response, "block", stash->block_hex);
+
+	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *
+getrawblockbyheight_notfound(struct bitcoin_cli *bcli)
+{
+	struct json_stream *response;
+
+	response = jsonrpc_stream_success(bcli->cmd);
+	json_add_null(response, "blockhash");
+	json_add_null(response, "block");
+
+	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *process_getblockhash(struct bitcoin_cli *bcli)
+{
+	const char *err, **params;
+	struct getrawblock_stash *stash = bcli->stash;
+
+	/* If it failed with error 8, give an empty response. */
+	if (bcli->exitstatus && *bcli->exitstatus != 0) {
+		/* Other error means we have to retry. */
+		if (*bcli->exitstatus != 8)
+			return NULL;
+		return getrawblockbyheight_notfound(bcli);
+	}
+
+	/* `-1` to strip the newline character. */
+	stash->block_hash = tal_strndup(stash, bcli->output,
+					bcli->output_bytes-1);
+	if (!stash->block_hash || strlen(stash->block_hash) != 64) {
+		err = tal_fmt(bcli->cmd, "%s: bad blockhash '%s'",
+			      bcli_args(bcli), stash->block_hash);
+		return command_done_err(bcli->cmd, BCLI_ERROR, err, NULL);
+	}
+
+	params = tal_arr(bcli->cmd, const char *, 2);
+	params[0] = stash->block_hash;
+	/* Non-verbose: raw block. */
+	params[1] = "0";
+	start_bitcoin_cli(NULL, bcli->cmd, process_getrawblock, false,
+			  BITCOIND_HIGH_PRIO, "getblock", params, stash);
+
+	return command_still_pending(bcli->cmd);
+}
+
+/* Get a raw block given its height.
+ * Calls `getblockhash` then `getblock` to retrieve it from bitcoin_cli.
+ * Will return early with null fields if block isn't known (yet).
+ */
+static struct command_result *getrawblockbyheight(struct command *cmd,
+                                                  const char *buf,
+                                                  const jsmntok_t *toks)
+{
+	struct getrawblock_stash *stash;
+	u32 *height;
+	const char **params;
+
+	/* bitcoin-cli wants a string. */
+	if (!param(cmd, buf, toks,
+	           p_req("height", param_number, &height),
+	           NULL))
+		return command_param_failed();
+
+	stash = tal(cmd, struct getrawblock_stash);
+	stash->block_height = *height;
+
+	params = tal_arr(cmd, const char *, 1);
+	params[0] = tal_fmt(params, "%u", *height);
+	start_bitcoin_cli(NULL, cmd, process_getblockhash, true,
+			  BITCOIND_LOW_PRIO, "getblockhash", params, stash);
+
+	return command_still_pending(cmd);
+}
+
+/* Get infos about the block chain.
+ * Calls `getblockchaininfo` and returns headers count, blocks count,
+ * the chain id, and whether this is initialblockdownload.
+ */
+static struct command_result *getchaininfo(struct command *cmd,
+                                           const char *buf UNUSED,
+                                           const jsmntok_t *toks UNUSED)
+{
+	if (!param(cmd, buf, toks, NULL))
+	    return command_param_failed();
+
+	start_bitcoin_cli(NULL, cmd, process_getblockchaininfo, false,
+			  BITCOIND_HIGH_PRIO, "getblockchaininfo", NULL, NULL);
+
+	return command_still_pending(cmd);
+}
+
+/* Get current feerate.
+ * Calls `estimatesmartfee` and returns the feerate as btc/k*VBYTE*.
+ */
+static struct command_result *getfeerate(struct command *cmd,
+                                         const char *buf UNUSED,
+                                         const jsmntok_t *toks UNUSED)
+{
+	u32 *blocks;
+	const char **params = tal_arr(cmd, const char *, 2);
+
+	if (!param(cmd, buf, toks,
+		   p_req("blocks", param_number, &blocks),
+		   p_req("mode", param_string, &params[1]),
+		   NULL))
+	    return command_param_failed();
+
+	params[0] = tal_fmt(params, "%u", *blocks);
+	start_bitcoin_cli(NULL, cmd, process_estimatefee, true,
+			  BITCOIND_LOW_PRIO, "estimatesmartfee", params, NULL);
+
+	return command_still_pending(cmd);
+}
+
+/* Send a transaction to the Bitcoin network.
+ * Calls `sendrawtransaction` using the first parameter as the raw tx.
+ */
+static struct command_result *sendrawtransaction(struct command *cmd,
+                                                 const char *buf,
+                                                 const jsmntok_t *toks)
+{
+	const char **params = tal_arr(cmd, const char *, 1);
+
+	/* bitcoin-cli wants strings. */
+	if (!param(cmd, buf, toks,
+	           p_req("tx", param_string, &params[0]),
+	           NULL))
+		return command_param_failed();
+
+	start_bitcoin_cli(NULL, cmd, process_sendrawtransaction, true,
+			  BITCOIND_HIGH_PRIO, "sendrawtransaction", params, NULL);
+
+	return command_still_pending(cmd);
+}
+
+static struct command_result *getutxout(struct command *cmd,
+                                       const char *buf,
+                                       const jsmntok_t *toks)
+{
+	const char **params = tal_arr(cmd, const char *, 2);
+
+	/* bitcoin-cli wants strings. */
+	if (!param(cmd, buf, toks,
+	           p_req("txid", param_string, &params[0]),
+	           p_req("vout", param_string, &params[1]),
+	           NULL))
+		return command_param_failed();
+
+	start_bitcoin_cli(NULL, cmd, process_getutxout, true,
+			  BITCOIND_HIGH_PRIO, "gettxout", params, NULL);
+
+	return command_still_pending(cmd);
+}
+
+/* Initialize the global context when handshake is done. */
+static void init(struct plugin *p UNUSED, const char *buffer UNUSED,
+                 const jsmntok_t *config UNUSED)
+{
+	bitcoind = tal(NULL, struct bitcoind);
+
+	bitcoind->cli = NULL;
+	bitcoind->datadir = NULL;
+	for (size_t i = 0; i < BITCOIND_NUM_PRIO; i++) {
+		bitcoind->num_requests[i] = 0;
+		list_head_init(&bitcoind->pending[i]);
+	}
+	bitcoind->error_count = 0;
+	bitcoind->retry_timeout = 60;
+	bitcoind->rpcuser = NULL;
+	bitcoind->rpcpass = NULL;
+	bitcoind->rpcconnect = NULL;
+	bitcoind->rpcport = NULL;
+}
+
+static const struct plugin_command commands[] = {
+	{
+		"getrawblockbyheight",
+		"bitcoin",
+		"Get the bitcoin block at a given height",
+		"",
+		getrawblockbyheight
+	},
+	{
+		"getchaininfo",
+		"bitcoin",
+		"Get the chain id, the header count, the block count,"
+		" and whether this is IBD.",
+		"",
+		getchaininfo
+	},
+	{
+		"getfeerate",
+		"bitcoin",
+		"Get the Bitcoin feerate in btc/kilo-vbyte.",
+		"",
+		getfeerate
+	},
+	{
+		"sendrawtransaction",
+		"bitcoin",
+		"Send a raw transaction to the Bitcoin network.",
+		"",
+		sendrawtransaction
+	},
+	{
+		"getutxout",
+		"bitcoin",
+		"Get informations about an output, identified by a {txid} an a {vout}",
+		"",
+		getutxout
+	},
+};
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+
+	/* FIXME: handle bitcoind options at init */
+	plugin_main(argv, init, PLUGIN_STATIC, commands, ARRAY_SIZE(commands),
+	            NULL, 0, NULL, 0, NULL);
+}

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -217,6 +217,12 @@ command_finished(struct command *cmd, struct json_stream *response)
 	return command_complete(cmd, response);
 }
 
+struct command_result *WARN_UNUSED_RESULT
+command_still_pending(struct command *cmd)
+{
+	return &pending;
+}
+
 struct json_out *json_out_obj(const tal_t *ctx,
 			      const char *fieldname,
 			      const char *str)

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -138,6 +138,10 @@ struct json_stream *jsonrpc_stream_fail_data(struct command *cmd,
 struct command_result *WARN_UNUSED_RESULT
 command_finished(struct command *cmd, struct json_stream *response);
 
+/* Helper for a command that'll be finished in a callback. */
+struct command_result *WARN_UNUSED_RESULT
+command_still_pending(struct command *cmd);
+
 /* Helper to create a zero or single-value JSON object; if @str is NULL,
  * object is empty. */
 struct json_out *json_out_obj(const tal_t *ctx,

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -212,7 +212,8 @@ struct command_result *timer_complete(struct plugin *p);
  */
 struct plugin_timer *plugin_timer(struct plugin *p,
 				  struct timerel t,
-				  struct command_result *(*cb)(struct plugin *p));
+				  void (*cb)(void *cb_arg),
+				  void *cb_arg);
 
 /* Log something */
 void plugin_log(struct plugin *p, enum log_level l, const char *fmt, ...) PRINTF_FMT(3, 4);

--- a/tests/plugins/bitcoin/part1.py
+++ b/tests/plugins/bitcoin/part1.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+This registers part of the Bitcoin backend methods.
+We only use it for testing startup and we don't care about the actual values.
+"""
+import time
+
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.method("getfeerate")
+def getfeerate(plugin, **kwargs):
+    time.sleep(1)
+    return {}
+
+
+@plugin.method("getrawblockbyheight")
+def getblock(plugin, **kwargs):
+    time.sleep(1)
+    return {}
+
+
+@plugin.method("getchaininfo")
+def getchaininfo(plugin, **kwargs):
+    time.sleep(1)
+    return {}
+
+
+# We don't use these options, but it allows us to get to the expected failure.
+plugin.add_option("bitcoin-rpcuser", "", "")
+plugin.add_option("bitcoin-rpcpassword", "", "")
+plugin.add_option("bitcoin-rpcport", "", "")
+
+plugin.run()

--- a/tests/plugins/bitcoin/part2.py
+++ b/tests/plugins/bitcoin/part2.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+This registers part of the Bitcoin backend methods.
+We only use it for testing startup and we don't care about the actual values.
+"""
+import time
+
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.method("sendrawtransaction")
+def sendtx(plugin, **kwargs):
+    time.sleep(1)
+    return {}
+
+
+@plugin.method("getutxout")
+def gettxout(plugin, **kwargs):
+    time.sleep(1)
+    return {}
+
+
+plugin.run()

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -328,7 +328,7 @@ def test_closing_specified_destination(node_factory, bitcoind, chainparams):
     # Both nodes should have disabled the channel in their view
     wait_for(lambda: len(l1.getactivechannels()) == 0)
 
-    assert bitcoind.rpc.getmempoolinfo()['size'] == 3
+    wait_for(lambda: bitcoind.rpc.getmempoolinfo()['size'] == 3)
 
     # Now grab the close transaction
     closetxs = {}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -932,3 +932,84 @@ def test_hook_chaining(node_factory):
     assert(l2.daemon.is_in_log(
         r'plugin-hook-chain-even.py: htlc_accepted called for payment_hash {}'.format(hash3)
     ))
+
+
+def test_bitcoin_backend(node_factory, bitcoind):
+    """
+    This tests interaction with the Bitcoin backend, but not specifically bcli
+    """
+    l1 = node_factory.get_node(start=False, options={"disable-plugin": "bcli"},
+                               may_fail=True, allow_broken_log=True)
+
+    # We don't start if we haven't all the required methods registered.
+    plugin = os.path.join(os.getcwd(), "tests/plugins/bitcoin/part1.py")
+    l1.daemon.opts["plugin"] = plugin
+    try:
+        l1.daemon.start()
+    except ValueError:
+        assert l1.daemon.is_in_log("Missing a Bitcoin plugin command")
+        # Now we should start if all the commands are registered, even if they
+        # are registered by two distincts plugins.
+        del l1.daemon.opts["plugin"]
+        l1.daemon.opts["plugin-dir"] = os.path.join(os.getcwd(),
+                                                    "tests/plugins/bitcoin/")
+        try:
+            l1.daemon.start()
+        except ValueError:
+            msg = "All Bitcoin plugin commands registered"
+            assert l1.daemon.is_in_log(msg)
+        else:
+            raise Exception("We registered all commands but couldn't start!")
+    else:
+        raise Exception("We could start without all commands registered !!")
+
+    # But restarting with just bcli is ok
+    del l1.daemon.opts["plugin-dir"]
+    del l1.daemon.opts["disable-plugin"]
+    l1.start()
+    assert l1.daemon.is_in_log("bitcoin-cli initialized and connected to"
+                               " bitcoind")
+
+
+def test_bcli(node_factory, bitcoind, chainparams):
+    """
+    This tests the bcli plugin, used to gather Bitcoin data from a local
+    bitcoind.
+    Mostly sanity checks of the interface..
+    """
+    l1, l2 = node_factory.get_nodes(2)
+
+    # We cant stop it dynamically
+    with pytest.raises(RpcError):
+        l1.rpc.plugin_stop("bcli")
+
+    # Failure case of feerate is tested in test_misc.py
+    assert "feerate" in l1.rpc.call("getfeerate", {"blocks": 3,
+                                                   "mode": "CONSERVATIVE"})
+
+    resp = l1.rpc.call("getchaininfo")
+    assert resp["chain"] == chainparams['name']
+    for field in ["headercount", "blockcount", "ibd"]:
+        assert field in resp
+
+    # We shouldn't get upset if we ask for an unknown-yet block
+    resp = l1.rpc.call("getrawblockbyheight", {"height": 500})
+    assert resp["blockhash"] is resp["block"] is None
+    resp = l1.rpc.call("getrawblockbyheight", {"height": 50})
+    assert resp["blockhash"] is not None and resp["blockhash"] is not None
+    # Some other bitcoind-failure cases for this call are covered in
+    # tests/test_misc.py
+
+    l1.fundwallet(10**5)
+    l1.connect(l2)
+    txid = l1.rpc.fundchannel(l2.info["id"], 10**4)["txid"]
+    txo = l1.rpc.call("getutxout", {"txid": txid, "vout": 0})
+    assert (Millisatoshi(txo["amount"]) == Millisatoshi(10**4 * 10**3)
+            and txo["script"].startswith("0020"))
+    l1.rpc.close(l2.info["id"])
+    # When output is spent, it should give us null !
+    txo = l1.rpc.call("getutxout", {"txid": txid, "vout": 0})
+    assert txo["amount"] is txo["script"] is None
+
+    resp = l1.rpc.call("sendrawtransaction", {"tx": "dummy"})
+    assert not resp["success"] and "decode failed" in resp["errmsg"]

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -37,14 +37,14 @@ size_t bigsize_get(const u8 *p UNNEEDED, size_t max UNNEEDED, bigsize_t *val UNN
 /* Generated stub for bigsize_put */
 size_t bigsize_put(u8 buf[BIGSIZE_MAX_LEN] UNNEEDED, bigsize_t v UNNEEDED)
 { fprintf(stderr, "bigsize_put called!\n"); abort(); }
-/* Generated stub for bitcoind_gettxout */
-void bitcoind_gettxout(struct bitcoind *bitcoind UNNEEDED,
-		       const struct bitcoin_txid *txid UNNEEDED, const u32 outnum UNNEEDED,
-		       void (*cb)(struct bitcoind *bitcoind UNNEEDED,
-				  const struct bitcoin_tx_output *txout UNNEEDED,
-				  void *arg) UNNEEDED,
-		       void *arg UNNEEDED)
-{ fprintf(stderr, "bitcoind_gettxout called!\n"); abort(); }
+/* Generated stub for bitcoind_getutxout_ */
+void bitcoind_getutxout_(struct bitcoind *bitcoind UNNEEDED,
+			 const struct bitcoin_txid *txid UNNEEDED, const u32 outnum UNNEEDED,
+			 void (*cb)(struct bitcoind *bitcoind UNNEEDED,
+				    const struct bitcoin_tx_output *txout UNNEEDED,
+				    void *arg) UNNEEDED,
+			 void *arg UNNEEDED)
+{ fprintf(stderr, "bitcoind_getutxout_ called!\n"); abort(); }
 /* Generated stub for broadcast_tx */
 void broadcast_tx(struct chain_topology *topo UNNEEDED,
 		  struct channel *channel UNNEEDED, const struct bitcoin_tx *tx UNNEEDED,
@@ -89,7 +89,7 @@ void delay_then_reconnect(struct channel *channel UNNEEDED, u32 seconds_delay UN
 /* Generated stub for encode_scriptpubkey_to_addr */
 char *encode_scriptpubkey_to_addr(const tal_t *ctx UNNEEDED,
 				  const struct chainparams *chainparams UNNEEDED,
-                                  const u8 *scriptPubkey UNNEEDED)
+				  const u8 *scriptPubkey UNNEEDED)
 { fprintf(stderr, "encode_scriptpubkey_to_addr called!\n"); abort(); }
 /* Generated stub for fatal */
 void   fatal(const char *fmt UNNEEDED, ...)
@@ -343,21 +343,6 @@ enum address_parse_result json_to_address_scriptpubkey(const tal_t *ctx UNNEEDED
 /* Generated stub for json_to_bool */
 bool json_to_bool(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, bool *b UNNEEDED)
 { fprintf(stderr, "json_to_bool called!\n"); abort(); }
-/* Generated stub for json_to_node_id */
-bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-			       struct node_id *id UNNEEDED)
-{ fprintf(stderr, "json_to_node_id called!\n"); abort(); }
-/* Generated stub for json_to_number */
-bool json_to_number(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-		    unsigned int *num UNNEEDED)
-{ fprintf(stderr, "json_to_number called!\n"); abort(); }
-/* Generated stub for json_to_preimage */
-bool json_to_preimage(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, struct preimage *preimage UNNEEDED)
-{ fprintf(stderr, "json_to_preimage called!\n"); abort(); }
-/* Generated stub for json_to_short_channel_id */
-bool json_to_short_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-			      struct short_channel_id *scid UNNEEDED)
-{ fprintf(stderr, "json_to_short_channel_id called!\n"); abort(); }
 /* Generated stub for json_tok_bin_from_hex */
 u8 *json_tok_bin_from_hex(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
 { fprintf(stderr, "json_tok_bin_from_hex called!\n"); abort(); }
@@ -374,6 +359,21 @@ int json_tok_full_len(const jsmntok_t *t UNNEEDED)
 /* Generated stub for json_tok_streq */
 bool json_tok_streq(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, const char *str UNNEEDED)
 { fprintf(stderr, "json_tok_streq called!\n"); abort(); }
+/* Generated stub for json_to_node_id */
+bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+			       struct node_id *id UNNEEDED)
+{ fprintf(stderr, "json_to_node_id called!\n"); abort(); }
+/* Generated stub for json_to_number */
+bool json_to_number(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		    unsigned int *num UNNEEDED)
+{ fprintf(stderr, "json_to_number called!\n"); abort(); }
+/* Generated stub for json_to_preimage */
+bool json_to_preimage(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, struct preimage *preimage UNNEEDED)
+{ fprintf(stderr, "json_to_preimage called!\n"); abort(); }
+/* Generated stub for json_to_short_channel_id */
+bool json_to_short_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+			      struct short_channel_id *scid UNNEEDED)
+{ fprintf(stderr, "json_to_short_channel_id called!\n"); abort(); }
 /* Generated stub for kill_uncommitted_channel */
 void kill_uncommitted_channel(struct uncommitted_channel *uc UNNEEDED,
 			      const char *why UNNEEDED)
@@ -587,12 +587,12 @@ u8 *towire_channel_got_revoke_reply(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_channel_offer_htlc */
 u8 *towire_channel_offer_htlc(const tal_t *ctx UNNEEDED, struct amount_msat amount_msat UNNEEDED, u32 cltv_expiry UNNEEDED, const struct sha256 *payment_hash UNNEEDED, const u8 onion_routing_packet[1366])
 { fprintf(stderr, "towire_channel_offer_htlc called!\n"); abort(); }
-/* Generated stub for towire_channel_send_shutdown */
-u8 *towire_channel_send_shutdown(const tal_t *ctx UNNEEDED, const u8 *shutdown_scriptpubkey UNNEEDED)
-{ fprintf(stderr, "towire_channel_send_shutdown called!\n"); abort(); }
 /* Generated stub for towire_channel_sending_commitsig_reply */
 u8 *towire_channel_sending_commitsig_reply(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channel_sending_commitsig_reply called!\n"); abort(); }
+/* Generated stub for towire_channel_send_shutdown */
+u8 *towire_channel_send_shutdown(const tal_t *ctx UNNEEDED, const u8 *shutdown_scriptpubkey UNNEEDED)
+{ fprintf(stderr, "towire_channel_send_shutdown called!\n"); abort(); }
 /* Generated stub for towire_channel_specific_feerates */
 u8 *towire_channel_specific_feerates(const tal_t *ctx UNNEEDED, u32 feerate_base UNNEEDED, u32 feerate_ppm UNNEEDED)
 { fprintf(stderr, "towire_channel_specific_feerates called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -49,7 +49,7 @@ void bitcoind_gettxout(struct bitcoind *bitcoind UNNEEDED,
 void broadcast_tx(struct chain_topology *topo UNNEEDED,
 		  struct channel *channel UNNEEDED, const struct bitcoin_tx *tx UNNEEDED,
 		  void (*failed)(struct channel *channel UNNEEDED,
-				 int exitstatus UNNEEDED,
+				 bool success UNNEEDED,
 				 const char *err))
 { fprintf(stderr, "broadcast_tx called!\n"); abort(); }
 /* Generated stub for channel_tell_depth */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3599,8 +3599,8 @@ static void process_utxo_result(struct bitcoind *bitcoind,
 	/* If we have more, resolve them too. */
 	tal_arr_remove(&utxos, 0);
 	if (tal_count(utxos) != 0) {
-		bitcoind_gettxout(bitcoind, &utxos[0]->txid, utxos[0]->outnum,
-				  process_utxo_result, utxos);
+		bitcoind_getutxout(bitcoind, &utxos[0]->txid, utxos[0]->outnum,
+				   process_utxo_result, utxos);
 	} else
 		tal_free(utxos);
 }
@@ -3610,8 +3610,8 @@ void wallet_clean_utxos(struct wallet *w, struct bitcoind *bitcoind)
 	struct utxo **utxos = wallet_get_utxos(NULL, w, output_state_reserved);
 
 	if (tal_count(utxos) != 0) {
-		bitcoind_gettxout(bitcoind, &utxos[0]->txid, utxos[0]->outnum,
-				  process_utxo_result, notleak(utxos));
+		bitcoind_getutxout(bitcoind, &utxos[0]->txid, utxos[0]->outnum,
+				   process_utxo_result, notleak(utxos));
 	} else
 		tal_free(utxos);
 }

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -43,7 +43,7 @@
  * available outputs.
  */
 static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
-					int exitstatus, const char *msg,
+					bool success, const char *msg,
 					struct unreleased_tx *utx)
 {
 	struct command *cmd = utx->wtx->cmd;
@@ -53,7 +53,7 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
 	/* FIXME: This won't be necessary once we use ccan/json_out! */
 	/* Massage output into shape so it doesn't kill the JSON serialization */
 	char *output = tal_strjoin(cmd, tal_strsplit(cmd, msg, "\n", STR_NO_EMPTY), " ", STR_NO_TRAIL);
-	if (exitstatus == 0) {
+	if (success) {
 		/* Mark used outputs as spent */
 		wallet_confirm_utxos(ld->wallet, utx->wtx->utxos);
 
@@ -66,7 +66,7 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
 
 		struct json_stream *response = json_stream_success(cmd);
 		json_add_tx(response, "tx", utx->tx);
-		json_add_string(response, "txid", output);
+		json_add_txid(response, "txid", &utx->txid);
 		was_pending(command_success(cmd, response));
 	} else {
 		was_pending(command_fail(cmd, LIGHTNINGD,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -930,7 +930,7 @@ static void process_utxo_result(struct bitcoind *bitcoind,
 		json_array_end(rescan->response);
 		was_pending(command_success(rescan->cmd, rescan->response));
 	} else {
-		bitcoind_gettxout(
+		bitcoind_getutxout(
 		    bitcoind->ld->topology->bitcoind, &rescan->utxos[0]->txid,
 		    rescan->utxos[0]->outnum, process_utxo_result, rescan);
 	}
@@ -956,7 +956,7 @@ static struct command_result *json_dev_rescan_outputs(struct command *cmd,
 		json_array_end(rescan->response);
 		return command_success(cmd, rescan->response);
 	}
-	bitcoind_gettxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
+	bitcoind_getutxout(cmd->ld->topology->bitcoind, &rescan->utxos[0]->txid,
 			  rescan->utxos[0]->outnum, process_utxo_result,
 			  rescan);
 	return command_still_pending(cmd);


### PR DESCRIPTION
This standardizes our requests for Bitcoin data as a set of commands plugins can register, and makes our `bitcoind` interaction through `bitcoin-cli` the default plugin, which registers all of these commands.

This makes it possible to not rely on a bitcoin-core backend, which can help for instance for mobile integration (cf #3484).

See #3354 for some design decisions, but here is a summary:
- Separated plugins can register different calls, which allows plugins specialization (credits to @cdecker)
- Uses JSON-RPC commands instead of hooks (see #3354).
- Needs 5 commands to be registered by our plugin(s):
  -  `getchaininfo` - called at startup to get infos about our network, and about the block chain.
  -  `getrawblockatheight` - get the block at that height in hex format, along with its id.
  -  `sendrawtransaction` - self explanatory
  -  `gettxout` - get the amount and the scriptPubkey of this txo.
  -  `getfeerate` - get the feerate in **btc/kVB**, because we *love* vbytes for fee-sensitive Bitcoin applications. Params are `bitcoind`-style.

This is based on #3480 as it uses its higher-level JSONRPC helpers for plugins.

### TODO
- [x] bcli-specific functional tests
- ~~interface documentation, for helping Bitcoin L1 developers to develop a plugin to serve as a C-lightning Bitcoin backend :)~~

### Next
- Add the possibility for the Bitcoin plugin to send notifications to `lightningd` (like "got a new block")
- Add a Bitcoin backend plugin for [insert Bitcoin data source]