### PR TITLE
Allow hook chaining for the `htlc_accepted` hook

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -237,9 +237,8 @@ above for example subscribes to the two topics `connect` and
 `disconnect`. The topics that are currently defined and the
 corresponding payloads are listed below.
 
-### Notification Types
 
-#### `channel_opened`
+### `channel_opened`
 
 A notification for topic `channel_opened` is sent if a peer successfully funded a channel
 with us. It contains the peer id, the funding amount (in millisatoshis), the funding
@@ -257,7 +256,7 @@ into a block.
 }
 ```
 
-#### `connect`
+### `connect`
 
 A notification for topic `connect` is sent every time a new connection
 to a peer is established.
@@ -269,7 +268,7 @@ to a peer is established.
 }
 ```
 
-#### `disconnect`
+### `disconnect`
 
 A notification for topic `disconnect` is sent every time a connection
 to a peer was lost.
@@ -280,7 +279,7 @@ to a peer was lost.
 }
 ```
 
-#### `invoice_payment`
+### `invoice_payment`
 
 A notification for topic `invoice_payment` is sent every time an invoie is paid.
 
@@ -294,7 +293,7 @@ A notification for topic `invoice_payment` is sent every time an invoie is paid.
 }
 ```
 
-#### `warning`
+### `warning`
 
 A notification for topic `warning` is sent every time a new `BROKEN`
 /`UNUSUAL` level(in plugins, we use `error`/`warn`) log generated,
@@ -322,7 +321,7 @@ forms:
 `jcon fd <error_fd_to_jsonrpc>:`, `plugin-manager`;
 4. `log` is the context of the original log entry.
 
-#### `forward_event`
+### `forward_event`
 
 A notification for topic `forward_event` is sent every time the status
 of a forward payment is set. The json format is same as the API
@@ -405,7 +404,7 @@ or
    only `settled` and `failed` case contain `resolved_time`;
  - The `failcode` and `failreason` are defined in [BOLT 4][bolt4-failure-codes].
 
-#### `sendpay_success`
+### `sendpay_success`
 
 A notification for topic `sendpay_success` is sent every time a sendpay
 succeeds (with `complete` status). The json is the same as the return value of
@@ -432,7 +431,7 @@ returns the result of sendpay in specified time or timeout, but
 `sendpay_success` will always return the result anytime when sendpay
 successes if is was subscribed.
 
-#### `sendpay_failure`
+### `sendpay_failure`
 
 A notification for topic `sendpay_failure` is sent every time a sendpay
 completes with `failed` status. The JSON is same as the return value of
@@ -497,9 +496,7 @@ As a convention, for all hooks, returning the object
 `{ "result" : "continue" }` results in `lightningd` behaving exactly as if
 no plugin is registered on the hook.
 
-### Hook Types
-
-#### `peer_connected`
+### `peer_connected`
 
 This hook is called whenever a peer has connected and successfully completed
 the cryptographic handshake. The parameters have the following structure if there is a channel with the peer:
@@ -527,7 +524,7 @@ there's a member `error_message`, that member is sent to the peer
 before disconnection.
 
 
-#### `db_write`
+### `db_write`
 
 This hook is called whenever a change is about to be committed to the database.
 It is currently extremely restricted:
@@ -600,7 +597,7 @@ to error without
 committing to the database!
 This is the expected way to halt and catch fire.
 
-#### `invoice_payment`
+### `invoice_payment`
 
 This hook is called whenever a valid payment for an unpaid invoice has arrived.
 
@@ -622,7 +619,7 @@ nodes in [BOLT 4][bolt4-failure-codes], a `result` field with the string
 `result` field with the string `continue` to accept the payment.
 
 
-#### `openchannel`
+### `openchannel`
 
 This hook is called whenever a remote peer tries to fund a channel to us,
 and it has passed basic sanity checks:
@@ -668,7 +665,7 @@ e.g.
 Note that `close_to` must be a valid address for the current chain; an invalid address will cause the node to exit with an error.
 
 
-#### `htlc_accepted`
+### `htlc_accepted`
 
 The `htlc_accepted` hook is called whenever an incoming HTLC is accepted, and
 its result determines how `lightningd` should treat that HTLC.
@@ -770,7 +767,7 @@ may see the same HTLC again during startup. It is therefore paramount that the
 plugin is idempotent if it talks to an external system.
 
 
-#### `rpc_command`
+### `rpc_command`
 
 The `rpc_command` hook allows a plugin to take over any RPC command. It sends
 the received JSON-RPC request to the registered plugin,
@@ -837,7 +834,7 @@ Return a custom error to the request sender:
 ```
 
 
-#### `custommsg`
+### `custommsg`
 
 The `custommsg` plugin hook is the receiving counterpart to the
 [`dev-sendcustommsg`][sendcustommsg] RPC method and allows plugins to handle

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -269,6 +269,7 @@ invoice_payment_hook_cb(struct invoice_payment_hook_payload *payload,
 }
 
 REGISTER_PLUGIN_HOOK(invoice_payment,
+		     PLUGIN_HOOK_SINGLE,
 		     invoice_payment_hook_cb,
 		     struct invoice_payment_hook_payload *,
 		     invoice_payment_serialize,

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -753,7 +753,8 @@ rpc_command_hook_callback(struct rpc_command_hook_payload *p,
 	                         "Bad response to 'rpc_command' hook."));
 }
 
-REGISTER_PLUGIN_HOOK(rpc_command, rpc_command_hook_callback,
+REGISTER_PLUGIN_HOOK(rpc_command, PLUGIN_HOOK_SINGLE,
+		     rpc_command_hook_callback,
                      struct rpc_command_hook_payload *,
                      rpc_command_hook_serialize,
                      struct rpc_command_hook_payload *);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -821,6 +821,7 @@ static void openchannel_hook_cb(struct openchannel_hook_payload *payload,
 }
 
 REGISTER_PLUGIN_HOOK(openchannel,
+		     PLUGIN_HOOK_SINGLE,
 		     openchannel_hook_cb,
 		     struct openchannel_hook_payload *,
 		     openchannel_hook_serialize,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -908,7 +908,8 @@ send_error:
 	tal_free(payload);
 }
 
-REGISTER_PLUGIN_HOOK(peer_connected, peer_connected_hook_cb,
+REGISTER_PLUGIN_HOOK(peer_connected, PLUGIN_HOOK_SINGLE,
+		     peer_connected_hook_cb,
 		     struct peer_connected_hook_payload *,
 		     peer_connected_serialize,
 		     struct peer_connected_hook_payload *);
@@ -2393,8 +2394,9 @@ static void custommsg_payload_serialize(struct custommsg_payload *payload,
 	json_add_node_id(stream, "peer_id", &payload->peer_id);
 }
 
-REGISTER_PLUGIN_HOOK(custommsg, custommsg_callback, struct custommsg_payload *,
-		     custommsg_payload_serialize, struct custommsg_payload *);
+REGISTER_PLUGIN_HOOK(custommsg, PLUGIN_HOOK_SINGLE, custommsg_callback,
+		     struct custommsg_payload *, custommsg_payload_serialize,
+		     struct custommsg_payload *);
 
 void handle_custommsg_in(struct lightningd *ld, const struct node_id *peer_id,
 			 const u8 *msg)

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -873,7 +873,8 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	tal_free(request);
 }
 
-REGISTER_PLUGIN_HOOK(htlc_accepted, htlc_accepted_hook_callback,
+REGISTER_PLUGIN_HOOK(htlc_accepted, PLUGIN_HOOK_SINGLE,
+		     htlc_accepted_hook_callback,
 		     struct htlc_accepted_hook_payload *,
 		     htlc_accepted_hook_serialize,
 		     struct htlc_accepted_hook_payload *);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -873,7 +873,7 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	tal_free(request);
 }
 
-REGISTER_PLUGIN_HOOK(htlc_accepted, PLUGIN_HOOK_SINGLE,
+REGISTER_PLUGIN_HOOK(htlc_accepted, PLUGIN_HOOK_CHAIN,
 		     htlc_accepted_hook_callback,
 		     struct htlc_accepted_hook_payload *,
 		     htlc_accepted_hook_serialize,

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -13,6 +13,7 @@ struct plugin_hook_request {
 	int current_plugin;
 	const struct plugin_hook *hook;
 	void *cb_arg;
+	void *payload;
 	struct db *db;
 };
 
@@ -129,6 +130,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		ph_req->hook = hook;
 		ph_req->cb_arg = cb_arg;
 		ph_req->db = ld->wallet->db;
+		ph_req->payload = payload;
 		ph_req->current_plugin = 0;
 		ph_req->plugin = hook->plugins[ph_req->current_plugin];
 

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -87,6 +87,9 @@ void plugin_hook_unregister_all(struct plugin *plugin)
 		plugin_hook_unregister(plugin, hooks[i]->name);
 }
 
+/* Mutual recursion */
+static void plugin_hook_call_next(struct plugin_hook_request *ph_req);
+
 /**
  * Callback to be passed to the jsonrpc_request.
  *
@@ -97,22 +100,34 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 				 const jsmntok_t *idtok,
 				 struct plugin_hook_request *r)
 {
-	const jsmntok_t *resulttok = json_get_member(buffer, toks, "result");
+	const jsmntok_t *resulttok, *resrestok;
 	struct db *db = r->db;
 	struct plugin_destroyed *pd;
+	bool more_plugins = r->current_plugin + 1 < tal_count(r->hook->plugins);
+
+	resulttok = json_get_member(buffer, toks, "result");
 
 	if (!resulttok)
 		fatal("Plugin for %s returned non-result response %.*s",
-		      r->hook->name,
-		      toks->end - toks->start, buffer + toks->start);
+		      r->hook->name, toks->end - toks->start,
+		      buffer + toks->start);
 
-	/* If command is "plugin stop", this can free r! */
-	pd = plugin_detect_destruction(r->plugin);
-	db_begin_transaction(db);
-	r->hook->response_cb(r->cb_arg, buffer, resulttok);
-	db_commit_transaction(db);
-	if (!was_plugin_destroyed(pd))
-		tal_free(r);
+	resrestok = json_get_member(buffer, resulttok, "result");
+
+	/* If this is a hook response containing a `continue` and we have more
+	 * plugins queue the next call. */
+	if (resrestok && json_tok_streq(buffer, resrestok, "continue") &&
+	    more_plugins) {
+		plugin_hook_call_next(r);
+	} else {
+		/* If command is "plugin stop", this can free r! */
+		pd = plugin_detect_destruction(r->plugin);
+		db_begin_transaction(db);
+		r->hook->response_cb(r->cb_arg, buffer, resulttok);
+		db_commit_transaction(db);
+		if (!was_plugin_destroyed(pd))
+			tal_free(r);
+	}
 }
 
 static void plugin_hook_call_next(struct plugin_hook_request *ph_req)

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -130,7 +130,8 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
  * annoying, and to make it clear that it's totally synchronous. */
 
 /* Special synchronous hook for db */
-static struct plugin_hook db_write_hook = { "db_write", NULL, NULL, NULL };
+static struct plugin_hook db_write_hook = {"db_write", PLUGIN_HOOK_SINGLE, NULL,
+					   NULL, NULL};
 AUTODATA(hooks, &db_write_hook);
 
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -59,8 +59,9 @@ struct plugin_hook {
 	void (*response_cb)(void *arg, const char *buffer, const jsmntok_t *toks);
 	void (*serialize_payload)(void *src, struct json_stream *dest);
 
-	/* Which plugin has registered this hook? */
-	struct plugin *plugin;
+	/* Which plugins have registered this hook? This is a `tal_arr`
+	 * initialized at creation. */
+	struct plugin **plugins;
 };
 AUTODATA_TYPE(hooks, struct plugin_hook);
 
@@ -107,7 +108,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 	    typesafe_cb_cast(void (*)(void *, struct json_stream *),           \
 			     void (*)(payload_type, struct json_stream *),     \
 			     serialize_payload),                               \
-	    NULL, /* .plugin */                                                \
+	    NULL, /* .plugins */                                               \
 	};                                                                     \
 	AUTODATA(hooks, &name##_hook_gen);                                     \
 	PLUGIN_HOOK_CALL_DEF(name, payload_type, response_cb_arg_type);

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -44,8 +44,18 @@
  * and callback have the correct type.
  */
 
+enum plugin_hook_type {
+	PLUGIN_HOOK_SINGLE,
+	PLUGIN_HOOK_CHAIN,
+};
+
 struct plugin_hook {
 	const char *name;
+
+	/* Which type of plugin is this? It'll determine how many plugins can
+	 * register this hook, and how the hooks are called. */
+	enum plugin_hook_type type;
+
 	void (*response_cb)(void *arg, const char *buffer, const jsmntok_t *toks);
 	void (*serialize_payload)(void *src, struct json_stream *dest);
 
@@ -84,14 +94,16 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
  * response_cb function accepts the deserialized response format and
  * an arbitrary extra argument used to maintain context.
  */
-#define REGISTER_PLUGIN_HOOK(name, response_cb, response_cb_arg_type,          \
+#define REGISTER_PLUGIN_HOOK(name, type, response_cb, response_cb_arg_type,    \
 			     serialize_payload, payload_type)                  \
 	struct plugin_hook name##_hook_gen = {                                 \
 	    stringify(name),                                                   \
-	    typesafe_cb_cast(void (*)(void *, const char *, const jsmntok_t *),\
-			     void (*)(response_cb_arg_type,		       \
-				      const char *, const jsmntok_t *),	       \
-			     response_cb),                                     \
+	    type,                                                              \
+	    typesafe_cb_cast(                                                  \
+		void (*)(void *, const char *, const jsmntok_t *),             \
+		void (*)(response_cb_arg_type, const char *,                   \
+			 const jsmntok_t *),                                   \
+		response_cb),                                                  \
 	    typesafe_cb_cast(void (*)(void *, struct json_stream *),           \
 			     void (*)(payload_type, struct json_stream *),     \
 			     serialize_payload),                               \

--- a/tests/plugins/hook-chain-even.py
+++ b/tests/plugins/hook-chain-even.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+from hashlib import sha256
+from binascii import hexlify
+
+"""A simple plugin that accepts invoices with "BB"*32 preimages
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    preimage = b"\xBB" * 32
+    payment_hash = sha256(preimage).hexdigest()
+    preimage = hexlify(preimage).decode('ASCII')
+    print("htlc_accepted called for payment_hash {}".format(htlc['payment_hash']))
+
+    if htlc['payment_hash'] == payment_hash:
+        return {'result': 'resolve', 'payment_key': preimage}
+    else:
+        return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/hook-chain-odd.py
+++ b/tests/plugins/hook-chain-odd.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+from hashlib import sha256
+from binascii import hexlify
+
+"""A simple plugin that accepts invoices with "AA"*32 preimages
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    preimage = b"\xAA" * 32
+    payment_hash = sha256(preimage).hexdigest()
+    preimage = hexlify(preimage).decode('ASCII')
+    print("htlc_accepted called for payment_hash {}".format(htlc['payment_hash']))
+
+    if htlc['payment_hash'] == payment_hash:
+        return {'result': 'resolve', 'payment_key': preimage}
+    else:
+        return {'result': 'continue'}
+
+
+plugin.run()


### PR DESCRIPTION
This pull request creates the infrastructure for registering multiple plugins
for a given hook and showcases this new capability with the `htlc_accepted`
hook. The `htlc_accepted` hook was chosen due to its relative simple semantics
and because it currently is the hook with the most plugins making.

Before you could only use a single plugin that registers the `htlc_accepted`
hook at a time, which was severely limiting its uses. With this you can
finally run multiple at the same time.

The `htlc_accepted` hook returns one of the following three outcomes:

 - `{"result": "continue"}`: the plugin signals that it could not handle the
   HTLC internally, so the chain continues. If there are more plugins that
   have registered for this hook they get called, otherwise we handle
   internally.
 - `{"result": "fail", ...}`: the plugin decided that the HTLC should be
   rejected, with the given parameters. This exits the call chain and fails
   the HTLC. If there are more plugins they will not get called.
 - `{"result": "resolve", ...}`: similar to the previous case, the plugin
   knows the preimage and choses to resolve this HTLC. The call chain is
   exited, and no further plugins are called.

## Future steps

The following details are as of yet not addressed in this pull request, but I
plan to continue working on these in new PRs:

 - Allow plugins to provide a numeric priority which determines the order in
   which the plugins should be called
 - Allow more hooks to be chained. We currently only enable `htlc_accepted` to
   register multiple times, and we will enable more as the need arises and the
   semantics are clarified.
 - Potentially we could add a `fanout` type that calls all hooks in parallel,
   and collected the results again. One potential candidate is the `db_write`
   hook whose results can be combined into all `continue`s or at least one
   `fail`.

---

## Related issues

 - Allow plugin hook chaining (#2796)
 - Bitcoin backend plugins planning (#3354)
 - Add a `sendcustommsg` RPC call and a `custommsg` plugin hook for
   experimental protocol extensions (#3315)
