### PR TITLE
Fix regression in hsmd for elements-based chains

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -102,6 +102,7 @@ int elements_tx_add_fee_output(struct bitcoin_tx *tx)
 {
 	struct amount_sat fee = bitcoin_tx_compute_fee(tx);
 	int pos = -1;
+	struct witscript *w;
 
 	/* If we aren't using elements, we don't add explicit fee outputs */
 	if (!chainparams->is_elements || amount_sat_eq(fee, AMOUNT_SAT(0)))
@@ -116,6 +117,9 @@ int elements_tx_add_fee_output(struct bitcoin_tx *tx)
 	}
 
 	if (pos == -1) {
+		w = tal(tx->output_witscripts, struct witscript);
+		w->ptr = tal_arr(w, u8, 0);
+		tx->output_witscripts[tx->wtx->num_outputs] = w;
 		return bitcoin_tx_add_output(tx, NULL, fee);
 	} else {
 		bitcoin_tx_output_set_amount(tx, pos, fee);

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -269,7 +269,6 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 
 	assert(n <= tx->wtx->outputs_allocation_len);
 	tal_resize(htlcmap, n);
-	tal_resize(&(tx->output_witscripts), n);
 
 	/* BOLT #3:
 	 *
@@ -307,6 +306,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
 
 	elements_tx_add_fee_output(tx);
+	tal_resize(&(tx->output_witscripts), tx->wtx->num_outputs);
 
 	return tx;
 }

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -207,8 +207,6 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 
 	assert(n <= tx->wtx->num_outputs);
 
-	tal_resize(&(tx->output_witscripts), n);
-
 	/* BOLT #3:
 	 *
 	 * 7. Sort the outputs into [BIP 69+CLTV
@@ -244,6 +242,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
 
 	elements_tx_add_fee_output(tx);
+	tal_resize(&(tx->output_witscripts), tx->wtx->num_outputs);
+
 	assert(bitcoin_tx_check(tx));
 
 	return tx;


### PR DESCRIPTION
Consider this a minimal fix of #3487, there are a couple of other places in which we don't `tal_resize` the `output_witscript` array to the correct length, but I'll fix those up in a cleanup PR.

Closes #3487 

Changelog-None