### PR TITLE
pyln-testing: add wait_for_htlcs helper

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -790,6 +790,15 @@ class LightningNode(object):
         if time.time() > start_time + timeout:
             raise ValueError("Error waiting for a route to destination {}".format(destination))
 
+    # This helper waits for all HTLCs to settle
+    def wait_for_htlcs(self):
+        peers = self.rpc.listpeers()['peers']
+        for p, peer in enumerate(peers):
+            if 'channels' in peer:
+                for c, channel in enumerate(peer['channels']):
+                    if 'htlcs' in channel:
+                        wait_for(lambda: len(self.rpc.listpeers()['peers'][p]['channels'][c]['htlcs']) == 0)
+
     def pay(self, dst, amt, label=None):
         if not label:
             label = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(20))

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2299,8 +2299,8 @@ def test_channel_drainage(node_factory, bitcoind):
     l1.rpc.waitsendpay(payment_hash, 10)
 
     # wait until totally settled
-    wait_for(lambda: len(l1.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 0)
-    wait_for(lambda: len(l2.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 0)
+    l1.wait_for_htlcs()
+    l2.wait_for_htlcs()
 
     # But we can get more!  By using a trimmed htlc output; this doesn't cause
     # an increase in tx fee, so it's allowed.
@@ -2311,8 +2311,8 @@ def test_channel_drainage(node_factory, bitcoind):
     l1.rpc.waitsendpay(payment_hash, TIMEOUT)
 
     # wait until totally settled
-    wait_for(lambda: len(l1.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 0)
-    wait_for(lambda: len(l2.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 0)
+    l1.wait_for_htlcs()
+    l2.wait_for_htlcs()
 
     # Now, l1 is paying fees, but it can't afford a larger tx, so any
     # attempt to add an HTLC which is not trimmed will fail.


### PR DESCRIPTION
This will add and use a simple wait_for_htlcs() helper that will resolve once
all HTLCs on all channels resolve. Just something I found out to be useful when writing some plugin tests.