### PR TITLE
doc/lightning-listchannels.7.md: Fix factual errors.

### DIFF
--- a/doc/lightning-listchannels.7
+++ b/doc/lightning-listchannels.7
@@ -66,18 +66,20 @@ settlement on-chain\.
 channel_update message was received\.
 .IP \[bu]
 \fIbase_fee_millisatoshi\fR : The base fee (in millisatoshi) charged
-for the HTLC (BOLT #2)\.
+for the HTLC (BOLT #7; equivalent to \fBfee_base_msat\fR)\.
 .IP \[bu]
 \fIfee_per_millionth\fR : The amount (in millionths of a satoshi)
-charged per transferred satoshi (BOLT #2)\.
+charged per transferred satoshi (BOLT #7; equivalent to
+\fBfee_proportional_millionths\fR)\.
 .IP \[bu]
-\fIdelay\fR : The number of blocks delay required to wait for on-chain
-settlement when unilaterally closing the channel (BOLT #2)\.
+\fIdelay\fR : The number of blocks of additional delay required when
+forwarding an HTLC in this direction\. (BOLT #7; equivalent to
+\fBcltv_expiry_delta\fR)\.
 .IP \[bu]
-\fIhtlc_minimum_msat\fR : The minimum payment which can be send
+\fIhtlc_minimum_msat\fR : The minimum payment which can be sent
 through this channel\.
 .IP \[bu]
-\fIhtlc_maximum_msat\fR : The maximum payment which can be send
+\fIhtlc_maximum_msat\fR : The maximum payment which can be sent
 through this channel\.
 
 .RE
@@ -111,16 +113,7 @@ Lightning RFC site
 
 .RS
 .IP \[bu]
-
-BOLT #2:
-\fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md\fR
-
-
-.IP \[bu]
-
 BOLT #7:
 \fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md\fR
-
-
 
 .RE

--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -52,14 +52,16 @@ settlement on-chain.
 - *last\_update* : Unix timestamp (seconds) showing when the last
 channel\_update message was received.
 - *base\_fee\_millisatoshi* : The base fee (in millisatoshi) charged
-for the HTLC (BOLT \#2).
+for the HTLC (BOLT \#7; equivalent to `fee_base_msat`).
 - *fee\_per\_millionth* : The amount (in millionths of a satoshi)
-charged per transferred satoshi (BOLT \#2).
-- *delay* : The number of blocks delay required to wait for on-chain
-settlement when unilaterally closing the channel (BOLT \#2).
-- *htlc\_minimum\_msat* : The minimum payment which can be send
+charged per transferred satoshi (BOLT \#7; equivalent to
+`fee_proportional_millionths`).
+- *delay* : The number of blocks of additional delay required when
+forwarding an HTLC in this direction. (BOLT \#7; equivalent to
+`cltv_expiry_delta`).
+- *htlc\_minimum\_msat* : The minimum payment which can be sent
 through this channel.
-- *htlc\_maximum\_msat* : The maximum payment which can be send
+- *htlc\_maximum\_msat* : The maximum payment which can be sent
 through this channel.
 
 If *short\_channel\_id* or *source* is supplied and no matching channels
@@ -86,9 +88,6 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 Lightning RFC site
-
--   BOLT \#2:
-    <https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md>
 
 -   BOLT \#7:
     <https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md>


### PR DESCRIPTION
Changelog-Fixed: Fixed factual errors in `lightning-listchannels.7` documentation.

`delay` is ***not*** the unilateral close delay for that channel-direction!