### PR TITLE
Channel lockup corner case workaround

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -553,7 +553,10 @@ static struct amount_sat commit_txfee(const struct channel *channel,
 			num_untrimmed_htlcs++;
 	}
 
-	return commit_tx_base_fee(local_feerate, num_untrimmed_htlcs);
+	/* Funder is conservative: makes sure it allows an extra HTLC
+	 * even if feerate increases 50% */
+	return commit_tx_base_fee(local_feerate + local_feerate / 2,
+				  num_untrimmed_htlcs + 1);
 }
 
 static void subtract_offered_htlcs(const struct channel *channel,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2207,7 +2207,7 @@ def test_change_chaining(node_factory, bitcoind):
 def test_feerate_spam(node_factory, chainparams):
     l1, l2 = node_factory.line_graph(2)
 
-    slack = 25000000 if not chainparams['elements'] else 35000000
+    slack = 35000000
     # Pay almost everything to l2.
     l1.pay(l2, 10**9 - slack)
 
@@ -2218,8 +2218,8 @@ def test_feerate_spam(node_factory, chainparams):
     # Now change feerates to something l1 can't afford.
     l1.set_feerates((100000, 100000, 100000))
 
-    # It will raise as far as it can (20000)
-    l1.daemon.wait_for_log('Setting REMOTE feerate to 20000')
+    # It will raise as far as it can (34000)
+    l1.daemon.wait_for_log('Setting REMOTE feerate to 34000')
     l1.daemon.wait_for_log('peer_out WIRE_UPDATE_FEE')
 
     # But it won't do it again once it's at max.

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -128,7 +128,7 @@ def test_invoice_preimage(node_factory):
 def test_invoice_routeboost(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice.
     """
-    l0, l1, l2 = node_factory.line_graph(3, fundamount=2 * (10**4), wait_for_announce=True)
+    l0, l1, l2 = node_factory.line_graph(3, fundamount=2 * (10**5), wait_for_announce=True)
 
     # Check routeboost.
     # Make invoice and pay it
@@ -150,7 +150,7 @@ def test_invoice_routeboost(node_factory, bitcoind):
     wait_channel_quiescent(l1, l2)
 
     # Due to reserve & fees, l1 doesn't have capacity to pay this.
-    inv = l2.rpc.invoice(msatoshi=2 * (10**7) - 123456, label="inv2", description="?")
+    inv = l2.rpc.invoice(msatoshi=2 * (10**8) - 123456, label="inv2", description="?")
     # Check warning
     assert 'warning_capacity' in inv
     assert 'warning_offline' not in inv


### PR DESCRIPTION
This is a previously-discussed problem (as shown in https://github.com/lightningnetwork/lightning-rfc/issues/728 ) but @m-schmoock wrote a proof-of-concept in #3498 so I am pushing a mitigation for the imminent release.

The funder pays the onchain fees: this keeps it simple.  If the funder has spent all their funds, they obv. can't use the channel, but the fundee also cannot: most implementations will not add an HTLC if the funder could not afford the resulting fee (c-lightning included).  If we were to loosen that, I'm not sure how other implementations would respond :(

The simplest workaround is to keep a little extra around if we're the funder.  It's still possible to get into a state (particularly with fee changes) where we're stuck, but this makes it less likely.