### PR TITLE
[DRAFT] channeld: allow fundee dip into funder reserves, once.

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2333,6 +2333,34 @@ def test_channel_drainage(node_factory, bitcoind):
     l2.rpc.waitsendpay(payment_hash, TIMEOUT)
 
 
+@pytest.mark.xfail(strict=True)    
+def test_lockup_drain(node_factory, bitcoind):
+    """Try to get channel into a state where funder can't afford fees on additional HTLC, so fundee can't add HTLC"""
+    l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})
+
+    # l1 sends all the money to l2 until even 1 msat can't get through.
+    total = 0
+    msat = 16**9
+    while msat != 0:
+        try:
+            l1.pay(l2, msat)
+            print("l1->l2: {}".format(msat))
+            total += msat
+        except RpcError as e:
+            msat //= 2
+
+    # Even if feerate now increases 1.5x (22500), l2 should be able to send
+    # non-dust HTLC to l1.
+    l1.set_feerates([22500] * 3, False)
+    # Restart forces fast fee adjustment (otherwise it's smoothed and takes
+    # a very long time!).
+    l1.restart();
+    wait_for(lambda: only_one(l1.rpc.listpeers()['peers'])['connected'])
+    assert(l1.rpc.feerates('perkw')['perkw']['normal'] == 22500)
+
+    l2.pay(l1, total // 2)
+
+
 def test_error_returns_blockheight(node_factory, bitcoind):
     """Test that incorrect_or_unknown_payment_details returns block height"""
     l1, l2 = node_factory.line_graph(2)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2320,20 +2320,15 @@ def test_channel_drainage(node_factory, bitcoind):
 
     # feerate_per_kw = 15000, so htlc_timeout_fee = 663 * 15000 / 1000 = 9945.
     # dust_limit is 546.  So it's trimmed if < 9945 + 546.
-    amount = Millisatoshi("10491sat")
-    route = l2.rpc.getroute(l1.info['id'], amount, riskfactor=1, fuzzpercent=0)['route']
-    l2.rpc.sendpay(route, payment_hash)
-    with pytest.raises(RpcError, match=r"Capacity exceeded.*'erring_index': 0"):
-        l2.rpc.waitsendpay(payment_hash, TIMEOUT)
 
-    # But if it's trimmed, we're ok.
-    amount -= 1
+    # But we allow a single HTLC addition to break into reserve, so this
+    # actually works.
+    amount = Millisatoshi("10491sat")
     route = l2.rpc.getroute(l1.info['id'], amount, riskfactor=1, fuzzpercent=0)['route']
     l2.rpc.sendpay(route, payment_hash)
     l2.rpc.waitsendpay(payment_hash, TIMEOUT)
 
 
-@pytest.mark.xfail(strict=True)    
 def test_lockup_drain(node_factory, bitcoind):
     """Try to get channel into a state where funder can't afford fees on additional HTLC, so fundee can't add HTLC"""
     l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})


### PR DESCRIPTION
This is an alternative to #3500, but it requires acks from the other implementations before I'd consider releasing it into the wild.

The spec does NOT prohibit the fundee from adding an HTLC if the funder can't afford the fee, (due to races, it cannot!) though implementations try to avoid it.  We do too, but this code skips that check if this is the only HTLC we're adding, so we don't get stuck.

Not sure how other implementations will respond to this, so waiting for discussion around https://github.com/lightningnetwork/lightning-rfc/issues/728