### PR TITLE
pytest: make the libplugin test non flaky

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -793,7 +793,6 @@ def test_rpc_command_hook(node_factory):
     l1.rpc.plugin_stop('rpc_command.py')
 
 
-@flaky
 def test_libplugin(node_factory):
     """Sanity checks for plugins made with libplugin"""
     plugin = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")


### PR DESCRIPTION
I'm pretty sure #3502 fixed the reason I made `test_libplugin` @flaky.