### PR TITLE
pay: fix crash when we paystatus too soon.

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1454,7 +1454,7 @@ static struct command_result *json_paystatus(struct command *cmd,
 		if (ps->exclusions)
 			json_add_string(ret, "local_exclusions", ps->exclusions);
 
-		assert(tal_count(ps->attempts));
+		/* If it's in listpeers right now, this can be 0 */
 		json_array_start(ret, "attempts");
 		for (size_t i = 0; i < tal_count(ps->attempts); i++)
 			add_attempt(ret, ps, &ps->attempts[i]);


### PR DESCRIPTION
If the attempt hasn't started yet, we can have an empty 'attempts' array
(while it's in listpeers, for example):

```
pay: plugins/pay.c:1457: json_paystatus: Assertion `tal_count(ps->attempts)' failed.
pay: FATAL SIGNAL 6 (version v0.8.1rc1-1-g946af3f)
0x55e895110543 send_backtrace
	common/daemon.c:39
0x55e8951105e9 crashdump
	common/daemon.c:52
0x7f92b0928f1f ???
	???:0
0x7f92b0928e97 ???
	???:0
0x7f92b092a800 ???
	???:0
0x7f92b091a399 ???
	???:0
0x7f92b091a411 ???
	???:0
0x55e895100012 json_paystatus
	plugins/pay.c:1457
0x55e895103aaa ld_command_handle
	plugins/libplugin.c:968
0x55e895103bd4 ld_read_json_one
	plugins/libplugin.c:1011
0x55e895103cd2 ld_read_json
	plugins/libplugin.c:1030
0x55e895124cbd next_plan
	ccan/ccan/io/io.c:59
0x55e89512583a do_plan
	ccan/ccan/io/io.c:407
0x55e895125878 io_ready
	ccan/ccan/io/io.c:417
0x55e895127a3e io_loop
	ccan/ccan/io/poll.c:445
0x55e895104593 plugin_main
	plugins/libplugin.c:1194
0x55e895100cbc main
	plugins/pay.c:1697
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>