### PR TITLE
db: put scids in forwards even if we didn't actually send.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release named by Vasil Dimov @vasild.
 
  - JSON API: The hooks `db_write`, `invoice_payment`, and `rpc_command` now accept `{ "result": "continue" }` to mean "do default action". ([3475](https://github.com/ElementsProject/lightning/pull/3475))
  - Plugin: Multiple plugins can now register for the htlc_accepted hook. ([3489](https://github.com/ElementsProject/lightning/pull/3489))
+ - JSON API: `listforwards` now shows `out_channel` even if we couldn't forward.
  - JSON API: `funchannel_cancel`: only the opener of a fundchannel can cancel the channel open ([3336](https://github.com/ElementsProject/lightning/pull/3336))
  - JSON API: `sendpay` optional `msatoshi` param for non-MPP (if set), must be the exact amount sent to the final recipient. ([3470](https://github.com/ElementsProject/lightning/pull/3470))
  - JSON API: `waitinvoice` now returns error code 903 to designate that the invoice expired during wait, instead of the previous -2 ([3441](https://github.com/ElementsProject/lightning/pull/3441))

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -53,7 +53,10 @@ void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
 
 void notify_forward_event(struct lightningd *ld,
 			  const struct htlc_in *in,
-			  const struct htlc_out *out,
+			  /* May be NULL if we don't know. */
+			  const struct short_channel_id *scid_out,
+			  /* May be NULL. */
+			  const struct amount_msat *amount_out,
 			  enum forward_status state,
 			  enum onion_type failcode,
 			  struct timeabs *resolved_time);

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -388,7 +388,10 @@ void notify_disconnect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UN
 /* Generated stub for notify_forward_event */
 void notify_forward_event(struct lightningd *ld UNNEEDED,
 			  const struct htlc_in *in UNNEEDED,
-			  const struct htlc_out *out UNNEEDED,
+			  /* May be NULL if we don't know. */
+			  const struct short_channel_id *scid_out UNNEEDED,
+			  /* May be NULL. */
+			  const struct amount_msat *amount_out UNNEEDED,
 			  enum forward_status state UNNEEDED,
 			  enum onion_type failcode UNNEEDED,
 			  struct timeabs *resolved_time UNNEEDED)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3365,6 +3365,7 @@ static bool wallet_forwarded_payment_update(struct wallet *w,
 }
 
 void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
+				  const struct short_channel_id *scid_out,
 				  const struct htlc_out *out,
 				  enum forward_status state,
 				  enum onion_type failcode)
@@ -3432,7 +3433,8 @@ void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
 	db_exec_prepared_v2(take(stmt));
 
 notify:
-	notify_forward_event(w->ld, in, out, state, failcode, resolved_time);
+	notify_forward_event(w->ld, in, scid_out, out ? &out->msat : NULL,
+			     state, failcode, resolved_time);
 }
 
 struct amount_msat wallet_total_forward_fees(struct wallet *w)

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1173,6 +1173,7 @@ struct channeltx *wallet_channeltxs_get(struct wallet *w, const tal_t *ctx,
  * Add of update a forwarded_payment
  */
 void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,
+				  const struct short_channel_id *scid_out,
 				  const struct htlc_out *out,
 				  enum forward_status state,
 				  enum onion_type failcode);


### PR DESCRIPTION
If the peer is not connected, or other error which means we don't actually create an outgoing HTLC, we don't record the short_channel_id.  This is unhelpful!

Pass the scid down to the wallet code, and explicitly hand the scid and amount down to the notification code rather than handing it the htlc_out (which it doesn't need).
