### PR TITLE
lightningd, openingd: remove active code inside assert().

### DIFF
--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -191,8 +191,9 @@ static void forward_event_notification_serialize(struct json_stream *stream,
 		cur->channel_out = *scid_out;
 		if (amount_out) {
 			cur->msat_out = *amount_out;
-			assert(amount_msat_sub(&cur->fee,
-					       in->msat, *amount_out));
+			if (!amount_msat_sub(&cur->fee,
+					     in->msat, *amount_out))
+				abort();
 		} else {
 			cur->msat_out = AMOUNT_MSAT(0);
 			cur->fee = AMOUNT_MSAT(0);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -852,7 +852,13 @@ static u8 *funder_channel_complete(struct state *state)
 
 	/* We recalculate the local_msat from cached values; should
 	 * succeed because we checked it earlier */
-	assert(amount_sat_sub_msat(&local_msat, state->funding, state->push_msat));
+	if (!amount_sat_sub_msat(&local_msat, state->funding, state->push_msat))
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "push_msat %s > funding %s?",
+			      type_to_string(tmpctx, struct amount_msat,
+					     &state->push_msat),
+			      type_to_string(tmpctx, struct amount_sat,
+					     &state->funding));
 
 	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx))
 		return NULL;


### PR DESCRIPTION
We don't compile with NDEBUG defined, but if we did, this code would
vanish.  I did a quick audit, inspired by @ZmnSCPxj.

I actually hacked up something to compile with NDEBUG (many unused vars
resulted, and of course unit tests are allowed to rely on assert()), and
after this the testsuite still passes.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>