### PR TITLE
cleanup requirements and minor stuff

### DIFF
--- a/contrib/pyln-proto/requirements.txt
+++ b/contrib/pyln-proto/requirements.txt
@@ -1,5 +1,5 @@
 bitstring==3.1.6
 cryptography==2.8
-coincurve==12.0.0
+coincurve==13.0.0
 base58==1.0.2
 secp256k1==0.13.2

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -824,7 +824,8 @@ class LightningNode(object):
         # sendpay is async now
         self.rpc.sendpay([routestep], rhash)
         # wait for sendpay to comply
-        self.rpc.waitsendpay(rhash)
+        result = self.rpc.waitsendpay(rhash)
+        assert(result.get('status') == 'complete')
 
     # Note: this feeds through the smoother in update_feerate, so changing
     # it on a running daemon may not give expected result!

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -160,8 +160,14 @@ Testing
 Install `valgrind` and the python dependencies for best results:
 
 ```
-sudo apt install valgrind cppcheck shellcheck
-pip3 install -r tests/requirements.txt
+sudo apt install valgrind cppcheck shellcheck libsecp256k1-dev
+pip3 install --user \
+         -r requirements.txt \
+         -r contrib/pyln-client/requirements.txt \
+         -r contrib/pyln-proto/requirements.txt \
+         -r contrib/pyln-testing/requirements.txt \
+         -r tests/requirements.txt \
+         -r doc/requirements.txt
 ```
 
 Re-run `configure` for the python dependencies


### PR DESCRIPTION
- update dependency coincurve to version 13
- points out in HACKING that all requirements.txt are required
- testutils  ln.pay()  now checks return status of waitsendpay