### PR TITLE
lightningd: fix crash when plugin has been unloaded and we abort cmd.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -145,10 +145,8 @@ static void destroy_jcon(struct json_connection *jcon)
 {
 	struct command *c;
 
-	list_for_each(&jcon->commands, c, list) {
-		log_debug(jcon->log, "Abandoning command %s", c->json_cmd->name);
+	list_for_each(&jcon->commands, c, list)
 		c->jcon = NULL;
-	}
 
 	/* Make sure this happens last! */
 	tal_free(jcon->log);


### PR DESCRIPTION
I reproduced this by putting a sleep(60) in the pay plugin, then
'lightning-cli pay', 'lightning-cli plugin stop pay' and then ^C
the `lightning-cli pay`:

2020-02-14T00:33:11.217Z INFO plugin-pay: Killing plugin: pay stopped by lightningd via RPC
2020-02-14T00:33:15.250Z DEBUG lightningd: Still waiting for initial block download
==5157== Invalid read of size 8
==5157==    at 0x12A29C: destroy_jcon (jsonrpc.c:149)
==5157==    by 0x1C6F2A: notify (tal.c:235)
==5157==    by 0x1C7441: del_tree (tal.c:397)
==5157==    by 0x1C7493: del_tree (tal.c:407)
==5157==    by 0x1C77DD: tal_free (tal.c:481)
==5157==    by 0x1B7380: io_close (io.c:450)
==5157==    by 0x1B71A7: do_plan (io.c:401)
==5157==    by 0x1B7214: io_ready (io.c:417)
==5157==    by 0x1B94AC: io_loop (poll.c:445)
==5157==    by 0x1291C9: io_loop_with_timers (io_loop_with_timers.c:24)
==5157==    by 0x12EC7E: main (lightningd.c:928)
==5157==  Address 0x4ebab98 is 40 bytes inside a block of size 88 free'd
==5157==    at 0x483BA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5157==    by 0x1C750F: del_tree (tal.c:416)
==5157==    by 0x1C7493: del_tree (tal.c:407)
==5157==    by 0x1C77DD: tal_free (tal.c:481)
==5157==    by 0x153856: clear_plugin (plugin_control.c:209)
==5157==    by 0x1538FF: plugin_dynamic_stop (plugin_control.c:225)
==5157==    by 0x153C51: json_plugin_control (plugin_control.c:295)
==5157==    by 0x12B4EC: command_exec (jsonrpc.c:588)
==5157==    by 0x12B8AB: rpc_command_hook_callback (jsonrpc.c:679)
==5157==    by 0x154575: plugin_hook_call_ (plugin_hook.c:170)
==5157==    by 0x12BCD3: plugin_hook_call_rpc_command (jsonrpc.c:756)
==5157==    by 0x12BD04: call_rpc_command_hook (jsonrpc.c:764)
==5157==  Block was alloc'd at
==5157==    at 0x483A7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5157==    by 0x1C6F98: allocate (tal.c:245)
==5157==    by 0x1C7559: tal_alloc_ (tal.c:423)
==5157==    by 0x15135A: plugin_rpcmethod_add (plugin.c:706)
==5157==    by 0x151600: plugin_rpcmethods_add (plugin.c:756)
==5157==    by 0x151BDD: plugin_parse_getmanifest_response (plugin.c:893)
==5157==    by 0x151C9C: plugin_manifest_cb (plugin.c:915)
==5157==    by 0x14FFB9: plugin_response_handle (plugin.c:258)
==5157==    by 0x150165: plugin_read_json_one (plugin.c:356)
==5157==    by 0x1502BC: plugin_read_json (plugin.c:388)
==5157==    by 0x1B65ED: next_plan (io.c:59)
==5157==    by 0x1B71D2: do_plan (io.c:407)

Fixes: #3509
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None