### PR TITLE
doc/lightning-listpeers.7.md: Clarify `spendable_msat`.

### DIFF
--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -154,11 +154,16 @@ state, or in various circumstances:
   a number followed by a string unit.
   The peer imposes this on us, default is 1% of the total channel capacity.
 * *spendable\_msat*: A string describing an ***estimate*** of how much we
-  can send out over this channel;
+  can send out over this channel in a single payment (or payment-part for
+  multi-part payments);
   a number followed by a string unit.
   This is an ***estimate***, which can be wrong because adding HTLCs requires
   an increase in fees paid to onchain miners, and onchain fees change
   dynamically according to onchain activity.
+  For a sufficiently-large channel with capacity on your side, this can
+  be limited by the rules imposed under certain blockchains;
+  for example, individual Bitcoin mainnet payment-parts cannot exceed
+  42.94967295 mBTC.
 * *minimum\_htlc\_in\_msat*: A string describing the minimum amount that
   an HTLC must have before we accept it.
 * *their\_to\_self\_delay*: The number of blocks that the peer must wait


### PR DESCRIPTION
Fixes: #3524

ChangeLog-none