### PR TITLE
Removing duplicated wscript generation for channel txs

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -304,7 +304,7 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 
 	/* Generating and saving witness script required to spend
 	 * the funding output */
-	*funding_wscript = bitcoin_redeem_2of2(*funding_wscript,
+	*funding_wscript = bitcoin_redeem_2of2(ctx,
 					      &channel->funding_pubkey[side],
 					      &channel->funding_pubkey[!side]);
 

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -50,7 +50,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  * @ctx: tal context to allocate return value from.
  * @channel: The channel to evaluate
  * @htlc_map: Pointer to htlcs for each tx output (allocated off @ctx).
- * @wscripts: Pointer to array of wscript for each tx returned (alloced off @ctx)
+ * @funding_wscript: Pointer to wscript for the funding tx output
  * @per_commitment_point: Per-commitment point to determine keys
  * @commitment_number: The index of this commitment.
  * @side: which side to get the commitment transaction for
@@ -61,7 +61,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				const struct htlc ***htlcmap,
-				const u8 ***wscripts,
+				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,
 				u64 commitment_number,

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -355,7 +355,7 @@ int main(void)
 	struct channel_config *local_config, *remote_config;
 	struct amount_msat to_local, to_remote;
 	const struct htlc **htlc_map, **htlcs;
-	const u8 *funding_wscript, **wscripts;
+	const u8 *funding_wscript, *funding_wscript_alt;
 	size_t i;
 
 	wally_init(0);
@@ -521,16 +521,15 @@ int main(void)
 			   NULL, &htlc_map, 0x2bb038521914 ^ 42, LOCAL);
 
 	txs = channel_txs(tmpctx,
-			  &htlc_map, &wscripts,
+			  &htlc_map, &funding_wscript_alt,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
 	assert(tal_count(htlc_map) == 2);
-	assert(tal_count(wscripts) == 1);
-	assert(scripteq(wscripts[0], funding_wscript));
+	assert(scripteq(funding_wscript_alt, funding_wscript));
 	tx_must_be_eq(txs[0], raw_tx);
 
 	txs2 = channel_txs(tmpctx,
-			   &htlc_map, &wscripts,
+			   &htlc_map, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -557,10 +556,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &wscripts,
+	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
-	txs2 = channel_txs(tmpctx, &htlc_map, &wscripts,
+	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -575,10 +574,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &wscripts,
+	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 6);
-	txs2 = channel_txs(tmpctx, &htlc_map, &wscripts,
+	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -644,12 +643,12 @@ int main(void)
 		    to_local, to_remote, htlcs, &htlc_map, 0x2bb038521914 ^ 42,
 		    LOCAL);
 
-		txs = channel_txs(tmpctx, &htlc_map, &wscripts,
+		txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 				  lchannel, &local_per_commitment_point, 42,
 				  LOCAL);
 		tx_must_be_eq(txs[0], raw_tx);
 
-		txs2 = channel_txs(tmpctx, &htlc_map, &wscripts,
+		txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
 				   rchannel, &local_per_commitment_point,
 				   42, REMOTE);
 		txs_must_be_eq(txs, txs2);

--- a/common/htlc_tx.c
+++ b/common/htlc_tx.c
@@ -65,6 +65,12 @@ static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
 
+	tx->output_witscripts[0] =
+			tal(tx->output_witscripts, struct witscript);
+	tx->output_witscripts[0]->ptr =
+			tal_dup_arr(tx->output_witscripts[0], u8,
+				    wscript, tal_count(wscript), 0);
+
 	tal_free(wscript);
 
 	return tx;


### PR DESCRIPTION
`struct bitcoin_tx` has a field to keep a witness script for each of its outputs (`output_witscripts`); and it is used throughout the code. However, in `channel_txs` a special array for keeping the witness scripts for all HTLC outputs is added and passed through the call stack. It appeared to me that this functionality is duplicated and contradicts the other parts of the code. After brief discussion with @cdecker today I tried to do my best in order to remove unnecessary script generation code and duplicated script objects passed around channel functions (we still have to pass the funding output witness script, since we don't pass around `bitcoin_tx` for the funding tx). 

This is my first PR, so pls don't judge if I'm done smth in a wrong way :)