### PR TITLE
Handle plugins being terminated correctly

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -740,6 +740,7 @@ int main(int argc, char *argv[])
 	 * valgrind will warn us if we make decisions based on uninitialized
 	 * variables. */
 	ld = new_lightningd(NULL);
+	ld->state = LD_STATE_RUNNING;
 
 	/* Figure out where our daemons are first. */
 	ld->daemon_dir = find_daemon_dir(ld, argv[0]);
@@ -931,6 +932,7 @@ int main(int argc, char *argv[])
 	 *  shut down.
 	 */
 	assert(io_loop_ret == ld);
+	ld->state = LD_STATE_SHUTDOWN;
 
 	/* Keep this fd around, to write final response at the end. */
 	stop_fd = io_conn_fd(ld->stop_conn);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -80,6 +80,11 @@ struct config {
 
 typedef STRMAP(const char *) alt_subdaemon_map;
 
+enum lightningd_state {
+	LD_STATE_RUNNING,
+	LD_STATE_SHUTDOWN,
+};
+
 struct lightningd {
 	/* The directory to find all the subdaemons. */
 	const char *daemon_dir;
@@ -262,6 +267,8 @@ struct lightningd {
 	struct list_head waitblockheight_commands;
 
 	alt_subdaemon_map alt_subdaemons;
+
+	enum lightningd_state state;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -439,14 +439,8 @@ static struct io_plan *plugin_write_json(struct io_conn *conn,
  */
 static void plugin_conn_finish(struct io_conn *conn, struct plugin *plugin)
 {
-	if (conn == plugin->stdin_conn)
-		plugin->stdin_conn = NULL;
-
-	else if (conn == plugin->stdout_conn)
-		plugin->stdout_conn = NULL;
-
-	if (plugin->stdin_conn == NULL && plugin->stdout_conn == NULL)
-		tal_free(plugin);
+	plugin->stdout_conn = NULL;
+	tal_free(plugin);
 }
 
 struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
@@ -454,8 +448,8 @@ struct io_plan *plugin_stdin_conn_init(struct io_conn *conn,
 {
 	/* We write to their stdin */
 	/* We don't have anything queued yet, wait for notification */
+	plugin->stdin_conn = tal_steal(plugin, conn);
 	plugin->stdin_conn = conn;
-	io_set_finish(conn, plugin_conn_finish, plugin);
 	return io_wait(plugin->stdin_conn, plugin, plugin_write_json, plugin);
 }
 

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -32,6 +32,9 @@ static struct command_result *plugin_dynamic_list_plugins(struct command *cmd)
 	return command_success(cmd, response);
 }
 
+/* Mutual recursion. */
+static void plugin_dynamic_crash(struct plugin *plugin, struct dynamic_plugin *dp);
+
 /**
  * Returned by all subcommands on error.
  */
@@ -42,6 +45,8 @@ plugin_dynamic_error(struct dynamic_plugin *dp, const char *error)
 		plugin_kill(dp->plugin, "%s", error);
 	else
 		log_info(dp->cmd->ld->log, "%s", error);
+
+	tal_del_destructor2(dp->plugin, plugin_dynamic_crash, dp);
 	return command_fail(dp->cmd, JSONRPC2_INVALID_PARAMS,
 	                    "%s: %s", dp->plugin ? dp->plugin->cmd : "unknown plugin",
 	                    error);
@@ -50,6 +55,11 @@ plugin_dynamic_error(struct dynamic_plugin *dp, const char *error)
 static void plugin_dynamic_timeout(struct dynamic_plugin *dp)
 {
 	plugin_dynamic_error(dp, "Timed out while waiting for plugin response");
+}
+
+static void plugin_dynamic_crash(struct plugin *p, struct dynamic_plugin *dp)
+{
+	plugin_dynamic_error(dp, "Plugin exited before completing handshake.");
 }
 
 static void plugin_dynamic_config_callback(const char *buffer,
@@ -63,6 +73,7 @@ static void plugin_dynamic_config_callback(const char *buffer,
 	/* Reset the timer only now so that we are either configured, or
 	 * killed. */
 	tal_free(dp->plugin->timeout_timer);
+	tal_del_destructor2(dp->plugin, plugin_dynamic_crash, dp);
 
 	list_for_each(&dp->plugin->plugins->plugins, p, list) {
 		if (p->plugin_state != CONFIGURED)
@@ -133,8 +144,20 @@ static struct command_result *plugin_start(struct dynamic_plugin *dp)
 	/* Give the plugin 20 seconds to respond to `getmanifest`, so we don't hang
 	 * too long on the RPC caller. */
 	p->timeout_timer = new_reltimer(dp->cmd->ld->timers, dp,
-	                                time_from_sec((10)),
+	                                time_from_sec((20)),
 	                                plugin_dynamic_timeout, dp);
+
+	/* Besides the timeout we could also have the plugin crash before
+	 * completing the handshake. In that case we'll get notified and we
+	 * can clean up the `struct dynamic_plugin` and return an appropriate
+	 * error.
+	 *
+	 * The destructor is deregistered in the following places:
+	 *
+	 *  - plugin_dynamic_error in case of a timeout or a crash
+	 *  - plugin_dynamic_config_callback if the handshake completes
+	 */
+	tal_add_destructor2(p, plugin_dynamic_crash, dp);
 
 	/* Create two connections, one read-only on top of the plugin's stdin, and one
 	 * write-only on its stdout. */

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -1,4 +1,5 @@
 #include <ccan/io/io.h>
+#include <ccan/list/list.h>
 #include <common/configdir.h>
 #include <common/memleak.h>
 #include <lightningd/jsonrpc.h>
@@ -9,12 +10,25 @@
 /* Struct containing all the information needed to deserialize and
  * dispatch an eventual plugin_hook response. */
 struct plugin_hook_request {
+	struct list_head call_chain;
 	struct plugin *plugin;
 	int current_plugin;
 	const struct plugin_hook *hook;
 	void *cb_arg;
 	void *payload;
 	struct db *db;
+};
+
+/* A link in the plugin_hook call chain (there's a joke in there about
+ * computer scientists and naming...). The purpose is to act both as a list
+ * from which elements can be popped off as we progress along the chain as
+ * well as have a way for plugins to notify about their untimely demise during
+ * a hook call.
+ */
+struct plugin_hook_call_link {
+	struct list_node list;
+	struct plugin *plugin;
+	struct plugin_hook_request *req;
 };
 
 static struct plugin_hook *plugin_hook_by_name(const char *name)
@@ -89,6 +103,43 @@ void plugin_hook_unregister_all(struct plugin *plugin)
 
 /* Mutual recursion */
 static void plugin_hook_call_next(struct plugin_hook_request *ph_req);
+static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
+				 const jsmntok_t *idtok,
+				 struct plugin_hook_request *r);
+
+/* We get notified if a plugin was killed while it was part of a call
+ * chain. If it was still to be called we just remove it from the list,
+ * otherwise it was the plugin that was currently handling the hook call, and
+ * we need to fail over to the next plugin.
+*/
+static void plugin_hook_killed(struct plugin_hook_call_link *link)
+{
+	struct plugin_hook_call_link *head;
+
+	head = list_top(&link->req->call_chain, struct plugin_hook_call_link,
+			list);
+
+	/* If we are the head of the call chain, then the plugin died while it
+	 * was handling the hook call. Pretend it didn't get the memo by
+	 * calling the next one instead. This is correct since it is
+	 * equivalent to the plugin dying before the hook invokation, assuming
+	 * the plugin has not commmitted any changes internally. This is the
+	 * weakest assumption we can make short of restarting the plugin and
+	 * calling the hook again (potentially crashing the plugin the same
+	 * way again.
+	 */
+	if (link == head) {
+		/* Call next will unlink, so we don't need to. This is treated
+		 * equivalent to the plugin returning a continue-result.
+		 */
+		link->req->current_plugin--;
+		plugin_hook_callback(NULL, NULL, NULL, link->req);
+	} else {
+		/* The plugin is in the list waiting to be called, just remove
+		 * it from the list. */
+		list_del(&link->list);
+	}
+}
 
 /**
  * Callback to be passed to the jsonrpc_request.
@@ -102,22 +153,42 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 {
 	const jsmntok_t *resulttok, *resrestok;
 	struct db *db = r->db;
-	bool more_plugins = r->current_plugin + 1 < tal_count(r->hook->plugins);
+	bool more_plugins, cont;
+	struct plugin_hook_call_link *last;
 
-	resulttok = json_get_member(buffer, toks, "result");
+	/* Pop the head off the call chain and continue with the next */
+	last = list_pop(&r->call_chain, struct plugin_hook_call_link, list);
+	assert(last != NULL);
+	tal_del_destructor(last, plugin_hook_killed);
+	tal_free(last);
 
-	if (!resulttok)
-		fatal("Plugin for %s returned non-result response %.*s",
-		      r->hook->name, toks->end - toks->start,
-		      buffer + toks->start);
+	if (buffer) {
+		resulttok = json_get_member(buffer, toks, "result");
 
-	resrestok = json_get_member(buffer, resulttok, "result");
+		if (!resulttok)
+			fatal("Plugin for %s returned non-result response %.*s",
+			      r->hook->name, toks->end - toks->start,
+			      buffer + toks->start);
+
+		resrestok = json_get_member(buffer, resulttok, "result");
+	} else {
+		/* Buffer and / or resulttok could be used by the reponse_cb
+		 * to identify no-result responses. So make sure both are
+		 * set */
+		resulttok = NULL;
+		/* cppcheck isn't smart enough to notice that `resrestok`
+		 * doesn't need to be initialized in the expression
+		 * initializing `cont`, so set it to NULL to shut it up. */
+		resrestok = NULL;
+	}
+
+	more_plugins = r->current_plugin + 1 < tal_count(r->hook->plugins);
+	cont = buffer == NULL || (resrestok && json_tok_streq(buffer, resrestok, "continue"));
 
 	/* If this is a hook response containing a `continue` and we have more
 	 * plugins queue the next call. In that case we discard the remainder
 	 * of the result, and let the next plugin decide. */
-	if (resrestok && json_tok_streq(buffer, resrestok, "continue") &&
-	    more_plugins) {
+	if (cont && more_plugins) {
 		plugin_hook_call_next(r);
 	} else {
 		db_begin_transaction(db);
@@ -148,6 +219,7 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		       void *payload, void *cb_arg)
 {
 	struct plugin_hook_request *ph_req;
+	struct plugin_hook_call_link *link;
 	if (tal_count(hook->plugins)) {
 		/* If we have a plugin that has registered for this
 		 * hook, serialize and call it */
@@ -160,6 +232,16 @@ void plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		ph_req->db = ld->wallet->db;
 		ph_req->payload = tal_steal(ph_req, payload);
 		ph_req->current_plugin = -1;
+
+		list_head_init(&ph_req->call_chain);
+		for (size_t i=0; i<tal_count(hook->plugins); i++) {
+			/* We allocate this off of the plugin so we get notified if the plugin dies. */
+			link = tal(hook->plugins[i], struct plugin_hook_call_link);
+			link->plugin = hook->plugins[i];
+			link->req = ph_req;
+			tal_add_destructor(link, plugin_hook_killed);
+			list_add_tail(&ph_req->call_chain, &link->list);
+		}
 		plugin_hook_call_next(ph_req);
 	} else {
 		/* If no plugin has registered for this hook, just

--- a/tests/plugins/hook-crash.py
+++ b/tests/plugins/hook-crash.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from pyln.client import Plugin
+import sys
+
+
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(plugin, htlc, onion, **kwargs):
+    """We die silently, i.e., without returning a response
+
+    `lightningd` should detect that and recover.
+    """
+    plugin.log("Plugin is about to crash...")
+    sys.exit(1)
+
+
+plugin.run()

--- a/tests/plugins/slow_init.py
+++ b/tests/plugins/slow_init.py
@@ -8,7 +8,7 @@ plugin = Plugin()
 @plugin.init()
 def init(options, configuration, plugin):
     plugin.log("slow_init.py initializing {}".format(configuration))
-    time.sleep(11)
+    time.sleep(21)
 
 
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1014,7 +1014,6 @@ def test_bcli(node_factory, bitcoind, chainparams):
     assert not resp["success"] and "decode failed" in resp["errmsg"]
 
 
-@pytest.mark.xfail(strict=True)
 def test_hook_crash(node_factory, executor, bitcoind):
     """Verify that we fail over if a plugin crashes while handling a hook.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -161,7 +161,7 @@ def test_plugin_command(node_factory):
         n2.rpc.plugin_stop(plugin="static.py")
 
     # Test that we don't crash when starting a broken plugin
-    with pytest.raises(RpcError, match=r"Timed out while waiting for plugin response"):
+    with pytest.raises(RpcError, match=r"Plugin exited before completing handshake."):
         n2.rpc.plugin_start(plugin=os.path.join(os.getcwd(), "tests/plugins/broken.py"))
 
 


### PR DESCRIPTION
Due to a bug in our plugin cleanup logic we'd be waiting for both the plugin's
`stdout` and `stdin` to get closed before cleaning it up. However, since we
only poll `stdout` for incoming messages from the plugin, and not poll its
`stdin`, we'd defer cleaning up indefinitely, until we either send something
to the plugin or we shut down the node entirely. This means that we'd also not
detect crashes in a reasonable time, and a plugin crashing while handling a
hook event could hang forever.

This PR first demonstrates this issue using a plugin that exits as soon as it
`htlc_accepted` hook is called, and then proceeds to fix the issue. We take
the closing of a plugin's `stdout` as the sole signal that the plugin is
exiting and trigger the cleanup immediately. This then surfaced a number of
issue where we had memory either lingering around or the `tal_free` order
being incorrect, resulting in a number of use-after-free issues. So I had to
dive in and clean things up a bit.

In order to facilitate skipping a crashed plugin I changed the call chain for
hook events to be a list instead of an array. Each hook event now has a list
of plugins that are still to call, and we pop off elements as we receive
responses or plugins exit.

Another issue was that we'd now be falsely detecting a node shutdown during
hook calls as the plugin exiting spontaneously. To facilitate these back out
cases in future I added a state variable that indicates whether we are
operational or we are shutting down. This used to be detected through a number
of side-effects that weren't well documented (variables being set to `NULL`
etc), so making this explicit should make this clearer.