### PR TITLE
fix: check source

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -897,6 +897,7 @@ htlc_accepted_hook_deserialize(const tal_t *ctx,
 		      json_strdup(tmpctx, buffer, resulttok));
 	}
 
+	/* cppcheck-suppress uninitvar - false positive on fatal() above */
 	return result;
 }
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -62,9 +62,9 @@ $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_
 ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel plugins/bcli
 ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS)
 
-check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%)
-check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%)
-check-whitespace: $(PLUGIN_PAY_SRC:%=check-whitespace/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-whitespace/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-whitespace/%)
+check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%) $(PLUGIN_BCLI_SRC:%=check-src-include-order/%)
+check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%) $(PLUGIN_BCLI_SRC:%=bolt-check/%)
+check-whitespace: $(PLUGIN_PAY_SRC:%=check-whitespace/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-whitespace/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-whitespace/%) $(PLUGIN_BCLI_SRC:%=check-whitespace/%)
 
 clean: plugin-clean
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3741,6 +3741,7 @@ struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t
 			else
 				fatal("Transaction annotations are only available for inputs and outputs. Value %d", loc);
 
+			/* cppcheck-suppress uninitvar - false positive on fatal() above */
 			ann->type = db_column_int(stmt, 8);
 			if (!db_column_is_null(stmt, 9))
 				db_column_short_channel_id(stmt, 9, &ann->channel);


### PR DESCRIPTION
- adds BCLI to check-source targets
- fixes two false positive check-source errors on uninitialized variable usage

`make check-source` fails on `Cppcheck 1.90` with two false positives that ignore the `NORETURN` directive on `fatal()`: 

```C
$> cppcheck wallet/wallet.c lightningd/peer_htlcs.c

Checking lightningd/peer_htlcs.c ...
lightningd/peer_htlcs.c:900:9: error: Uninitialized variable: result [uninitvar]
 return result;
        ^
Checking wallet/wallet.c ...
wallet/wallet.c:3744:4: error: Uninitialized variable: ann [uninitvar]
   ann->type = db_column_int(stmt, 8);
   ^
```