### PR TITLE
wire: add fromwire_tal_bytes() helper.

### DIFF
--- a/common/onionreply.c
+++ b/common/onionreply.c
@@ -12,8 +12,8 @@ struct onionreply *fromwire_onionreply(const tal_t *ctx,
 				       const u8 **cursor, size_t *max)
 {
 	struct onionreply *r = tal(ctx, struct onionreply);
-	r->contents = tal_arr(r, u8, fromwire_u16(cursor, max));
-	fromwire_u8_array(cursor, max, r->contents, tal_count(r->contents));
+	r->contents = fromwire_tal_arrn(r, cursor, max,
+					fromwire_u16(cursor, max));
 	if (!*cursor)
 		return tal_free(r);
 	return r;

--- a/devtools/print_wire.c
+++ b/devtools/print_wire.c
@@ -104,10 +104,9 @@ static void printwire_addresses(const u8 **cursor, size_t *plen, size_t len)
 static void printwire_encoded_short_ids(const u8 **cursor, size_t *plen, size_t len)
 {
 	struct short_channel_id *scids;
-	u8 *arr = tal_arr(tmpctx, u8, len);
+	u8 *arr = fromwire_tal_arrn(tmpctx, cursor, plen, len);
 
-	fromwire_u8_array(cursor, plen, arr, len);
-	if (!*cursor)
+	if (!arr)
 		return;
 
 	printf("[");

--- a/lightningd/gossip_msg.c
+++ b/lightningd/gossip_msg.c
@@ -21,8 +21,7 @@ struct gossip_getnodes_entry *fromwire_gossip_getnodes_entry(const tal_t *ctx,
 	}
 
 	flen = fromwire_u16(pptr, max);
-	entry->features = tal_arr(entry, u8, flen);
-	fromwire_u8_array(pptr, max, entry->features, flen);
+	entry->features = fromwire_tal_arrn(entry, pptr, max, flen);
 
 	numaddresses = fromwire_u8(pptr, max);
 

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -136,6 +136,8 @@ struct amount_sat fromwire_amount_sat(const u8 **cursor, size_t *max);
 void fromwire_pad(const u8 **cursor, size_t *max, size_t num);
 
 void fromwire_u8_array(const u8 **cursor, size_t *max, u8 *arr, size_t num);
+u8 *fromwire_tal_arrn(const tal_t *ctx,
+		       const u8 **cursor, size_t *max, size_t num);
 char *fromwire_wirestring(const tal_t *ctx, const u8 **cursor, size_t *max);
 struct bitcoin_tx *fromwire_bitcoin_tx(const tal_t *ctx,
 				       const u8 **cursor, size_t *max);


### PR DESCRIPTION
Does the allocation and copying; this is useful because we can avoid being fooled into doing giant allocations.

This will be useful for #3557

Changelog-None