### PR TITLE
tests: fix flake in libplugin test.

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -819,7 +819,7 @@ def test_libplugin(node_factory):
     # Test hooks and notifications
     l2 = node_factory.get_node()
     l2.connect(l1)
-    assert l1.daemon.is_in_log("{} peer_connected".format(l2.info["id"]))
+    l1.daemon.wait_for_log("{} peer_connected".format(l2.info["id"]))
     l1.daemon.wait_for_log("{} connected".format(l2.info["id"]))
 
     # Test RPC calls FIXME: test concurrent ones ?


### PR DESCRIPTION
My test machine is fast enough that we might not have seen the plugin msg yet:

```

>       assert l1.daemon.is_in_log("{} peer_connected".format(l2.info["id"]))
E       AssertionError: assert None
E        +  where None = <bound method TailableProc.is_in_log of <pyln.testing.utils.LightningD object at 0x7fba75945cd0>>('022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 peer_connected')
E        +    where <bound method TailableProc.is_in_log of <pyln.testing.utils.LightningD object at 0x7fba75945cd0>> = <pyln.testing.utils.LightningD object at 0x7fba75945cd0>.is_in_log
E        +      where <pyln.testing.utils.LightningD object at 0x7fba75945cd0> = <fixtures.LightningNode object at 0x7fba74382b90>.daemon
E        +    and   '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 peer_connected' = <built-in method format of str object at 0x7fba7ce9de40>('022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59')
E        +      where <built-in method format of str object at 0x7fba7ce9de40> = '{} peer_connected'.format

tests/test_plugin.py:822: AssertionError
```