### PR TITLE
Return the correct error when the TLV payload was not valid

### DIFF
--- a/common/onion.c
+++ b/common/onion.c
@@ -205,7 +205,9 @@ size_t onion_payload_length(const u8 *raw_payload, size_t len,
 }
 
 struct onion_payload *onion_decode(const tal_t *ctx,
-				    const struct route_step *rs)
+				   const struct route_step *rs,
+				   u64 *failtlvtype,
+				   size_t *failtlvpos)
 {
 	struct onion_payload *p = tal(ctx, struct onion_payload);
 	const u8 *cursor = rs->raw_payload;
@@ -245,9 +247,10 @@ struct onion_payload *onion_decode(const tal_t *ctx,
 		if (!fromwire_tlv_payload(&cursor, &max, tlv))
 			goto fail;
 
-		if (!tlv_payload_is_valid(tlv, failtlvpos))
+		if (!tlv_payload_is_valid(tlv, failtlvpos)) {
+			*failtlvtype = tlv->fields[*failtlvpos].numtype;
 			goto fail;
-
+		}
 
 		/* BOLT #4:
 		 *

--- a/common/onion.h
+++ b/common/onion.h
@@ -59,6 +59,8 @@ size_t onion_payload_length(const u8 *raw_payload, size_t len,
  * If the payload is not valid, returns NULL.
  */
 struct onion_payload *onion_decode(const tal_t *ctx,
-				   const struct route_step *rs);
+				   const struct route_step *rs,
+				   u64 *failtlvtype,
+				   size_t *failtlvpos);
 
 #endif /* LIGHTNING_COMMON_ONION_H */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -981,9 +981,12 @@ htlc_accepted_hook_callback(struct htlc_accepted_hook_payload *request,
 	case htlc_accepted_continue:
 		/* *Now* we barf if it failed to decode */
 		if (!request->payload) {
-			log_debug(channel->log, "Failing HTLC because of an invalid payload");
-			local_fail_in_htlc_badonion(hin,
-						    WIRE_INVALID_ONION_PAYLOAD);
+			log_debug(channel->log,
+				  "Failing HTLC because of an invalid payload");
+			local_fail_in_htlc(hin,
+					   take(towire_invalid_onion_payload(
+					       NULL, request->failtlvtype,
+					       request->failtlvpos)));
 		} else if (rs->nextcase == ONION_FORWARD) {
 			forward_htlc(hin, hin->cltv_expiry,
 				     request->payload->amt_to_forward,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -780,6 +780,8 @@ struct htlc_accepted_hook_payload {
 	struct channel *channel;
 	struct lightningd *ld;
 	u8 *next_onion;
+	u64 failtlvtype;
+	size_t failtlvpos;
 };
 
 /* The possible return value types that a plugin may return for the
@@ -1116,7 +1118,9 @@ static bool peer_accepted_htlc(const tal_t *ctx,
 	hook_payload = tal(hin, struct htlc_accepted_hook_payload);
 
 	hook_payload->route_step = tal_steal(hook_payload, rs);
-	hook_payload->payload = onion_decode(hook_payload, rs);
+	hook_payload->payload = onion_decode(hook_payload, rs,
+					     &hook_payload->failtlvtype,
+					     &hook_payload->failtlvpos);
 	hook_payload->ld = ld;
 	hook_payload->hin = hin;
 	hook_payload->channel = channel;

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2806,7 +2806,6 @@ caused a crash in 0.8.0, so we then disallowed it.
     assert inv['amount_received_msat'] == Millisatoshi(1001)
 
 
-@pytest.mark.xfail(strict=True)
 def test_reject_invalid_payload(node_factory):
     """Send an onion payload with an unknown even type.
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3,6 +3,7 @@ from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from flaky import flaky  # noqa: F401
 from pyln.client import RpcError, Millisatoshi
+from pyln.proto.onion import TlvPayload
 from utils import (
     DEVELOPER, wait_for, only_one, sync_blockheight, SLOW_MACHINE, TIMEOUT,
     VALGRIND
@@ -2803,3 +2804,35 @@ caused a crash in 0.8.0, so we then disallowed it.
     inv = only_one(l2.rpc.listinvoices('inv')['invoices'])
     assert inv['status'] == 'paid'
     assert inv['amount_received_msat'] == Millisatoshi(1001)
+
+
+@pytest.mark.xfail(strict=True)
+def test_reject_invalid_payload(node_factory):
+    """Send an onion payload with an unknown even type.
+
+    Recipient l2 should reject it the incoming HTLC with an invalid onion
+    payload error.
+
+    """
+
+    l1, l2 = node_factory.line_graph(2)
+    amt = 10**3
+    route = l1.rpc.getroute(l2.info['id'], amt, 10)['route']
+    inv = l2.rpc.invoice(amt, "lbl", "desc")
+
+    first_hop = route[0]
+
+    # A TLV payload with an unknown even type:
+    payload = TlvPayload()
+    payload.add_field(0xB000, b'Hi there')
+    hops = [{"pubkey": l2.info['id'], "payload": payload.to_hex()}]
+    onion = l1.rpc.createonion(hops=hops, assocdata=inv['payment_hash'])
+    l1.rpc.sendonion(onion=onion['onion'],
+                     first_hop=first_hop,
+                     payment_hash=inv['payment_hash'],
+                     shared_secrets=onion['shared_secrets'])
+
+    l2.daemon.wait_for_log(r'Failing HTLC because of an invalid payload')
+
+    with pytest.raises(RpcError, match=r'WIRE_INVALID_ONION_PAYLOAD'):
+        l1.rpc.waitsendpay(inv['payment_hash'])

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -411,7 +411,9 @@ enum watch_result onchaind_funding_spent(struct channel *channel UNNEEDED,
 { fprintf(stderr, "onchaind_funding_spent called!\n"); abort(); }
 /* Generated stub for onion_decode */
 struct onion_payload *onion_decode(const tal_t *ctx UNNEEDED,
-				   const struct route_step *rs UNNEEDED)
+				   const struct route_step *rs UNNEEDED,
+				   u64 *failtlvtype UNNEEDED,
+				   size_t *failtlvpos UNNEEDED)
 { fprintf(stderr, "onion_decode called!\n"); abort(); }
 /* Generated stub for onion_type_name */
 const char *onion_type_name(int e UNNEEDED)
@@ -654,6 +656,9 @@ u8 *towire_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expiry UNNE
 /* Generated stub for towire_incorrect_or_unknown_payment_details */
 u8 *towire_incorrect_or_unknown_payment_details(const tal_t *ctx UNNEEDED, struct amount_msat htlc_msat UNNEEDED, u32 height UNNEEDED)
 { fprintf(stderr, "towire_incorrect_or_unknown_payment_details called!\n"); abort(); }
+/* Generated stub for towire_invalid_onion_payload */
+u8 *towire_invalid_onion_payload(const tal_t *ctx UNNEEDED, varint type UNNEEDED, u16 offset UNNEEDED)
+{ fprintf(stderr, "towire_invalid_onion_payload called!\n"); abort(); }
 /* Generated stub for towire_invalid_realm */
 u8 *towire_invalid_realm(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_invalid_realm called!\n"); abort(); }


### PR DESCRIPTION
Fixes a minor memory leak, return the necessary information when checking the TLV payload for validity and do not return using `local_fail_in_htlc_badonion` when the real issue is `INVALID_ONION_PAYLOAD`.

Changelog-None