### PR TITLE
Fix broken tests on elements and various cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ ifeq ($(PYTEST),)
 	exit 1
 else
 # Explicitly hand DEVELOPER and VALGRIND so you can override on make cmd line.
-	PYTHONPATH=`pwd`/contrib/pyln-client:`pwd`/contrib/pyln-testing:`pwd`/contrib/pylightning:`pwd`/contrib/pyln-proto/:$(PYTHONPATH) TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
+	PYTHONPATH=`pwd`/contrib/pyln-client:`pwd`/contrib/pyln-testing:`pwd`/contrib/pyln-proto/:$(PYTHONPATH) TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -98,7 +98,17 @@ static struct amount_sat bitcoin_tx_compute_fee(const struct bitcoin_tx *tx)
 	return fee;
 }
 
-int elements_tx_add_fee_output(struct bitcoin_tx *tx)
+/**
+ * Add an explicit fee output if necessary.
+ *
+ * An explicit fee output is only necessary if we are using an elements
+ * transaction, and we have a non-zero fee. This method may be called multiple
+ * times.
+ *
+ * Returns the position of the fee output, or -1 in the case of non-elements
+ * transactions.
+ */
+static int elements_tx_add_fee_output(struct bitcoin_tx *tx)
 {
 	struct amount_sat fee = bitcoin_tx_compute_fee(tx);
 	int pos;

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -156,6 +156,15 @@ void bitcoin_tx_input_get_txid(const struct bitcoin_tx *tx, int innum,
  */
 bool bitcoin_tx_check(const struct bitcoin_tx *tx);
 
+
+/**
+ * Finalize a transaction by truncating overallocated and temporary
+ * fields. This includes adding a fee output for elements transactions or
+ * adjusting an existing fee output, and resizing metadata arrays for inputs
+ * and outputs.
+ */
+void bitcoin_tx_finalize(struct bitcoin_tx *tx);
+
 /**
  * Add an explicit fee output if necessary.
  *

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -165,16 +165,4 @@ bool bitcoin_tx_check(const struct bitcoin_tx *tx);
  */
 void bitcoin_tx_finalize(struct bitcoin_tx *tx);
 
-/**
- * Add an explicit fee output if necessary.
- *
- * An explicit fee output is only necessary if we are using an elements
- * transaction, and we have a non-zero fee. This method may be called multiple
- * times.
- *
- * Returns the position of the fee output, or -1 in the case of non-elements
- * transactions.
- */
-int elements_tx_add_fee_output(struct bitcoin_tx *tx);
-
 #endif /* LIGHTNING_BITCOIN_TX_H */

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -305,8 +305,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	u32 sequence = (0x80000000 | ((obscured_commitment_number>>24) & 0xFFFFFF));
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
 
-	elements_tx_add_fee_output(tx);
-	tal_resize(&(tx->output_witscripts), tx->wtx->num_outputs);
+	bitcoin_tx_finalize(tx);
+	assert(bitcoin_tx_check(tx));
 
 	return tx;
 }

--- a/common/close_tx.c
+++ b/common/close_tx.c
@@ -60,8 +60,8 @@ struct bitcoin_tx *create_close_tx(const tal_t *ctx,
 		return tal_free(tx);
 
 	permute_outputs(tx, NULL, NULL);
-	elements_tx_add_fee_output(tx);
 
+	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
 	return tx;
 }

--- a/common/funding_tx.c
+++ b/common/funding_tx.c
@@ -50,7 +50,7 @@ struct bitcoin_tx *funding_tx(const tal_t *ctx,
 
 	permute_inputs(tx, (const void **)utxomap);
 
-	elements_tx_add_fee_output(tx);
+	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
 	return tx;
 }

--- a/common/htlc_tx.c
+++ b/common/htlc_tx.c
@@ -61,7 +61,9 @@ static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 	wscript = bitcoin_wscript_htlc_tx(tx, to_self_delay, revocation_pubkey,
 					  local_delayedkey);
 	bitcoin_tx_add_output(tx, scriptpubkey_p2wsh(tx, wscript), amount);
-	elements_tx_add_fee_output(tx);
+
+	bitcoin_tx_finalize(tx);
+	assert(bitcoin_tx_check(tx));
 
 	tal_free(wscript);
 

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -241,9 +241,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 	sequence = (0x80000000 | ((obscured_commitment_number>>24) & 0xFFFFFF));
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
 
-	elements_tx_add_fee_output(tx);
-	tal_resize(&(tx->output_witscripts), tx->wtx->num_outputs);
-
+	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
 
 	return tx;

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -52,7 +52,8 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 		*change_outnum = -1;
 
 	permute_inputs(tx, (const void **)utxos);
-	elements_tx_add_fee_output(tx);
+
+	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
 	return tx;
 }

--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from lightning import Plugin
+from pyln.client import Plugin
 import time
 
 plugin = Plugin()

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -55,7 +55,12 @@ def directory(request, test_base_dir, test_name):
     failed = not outcome or request.node.has_errors or outcome != 'passed'
 
     if not failed:
-        shutil.rmtree(directory)
+        try:
+            shutil.rmtree(directory)
+        except Exception:
+            files = [os.path.join(dp, f) for dp, dn, fn in os.walk(directory) for f in fn]
+            print("Directory still contains files:", files)
+            raise
     else:
         logging.debug("Test execution failed, leaving the test directory {} intact.".format(directory))
 

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -1,12 +1,13 @@
 from concurrent import futures
 from pyln.testing.db import SqliteDbProvider, PostgresDbProvider
-from pyln.testing.utils import NodeFactory, BitcoinD, ElementsD, env, DEVELOPER, LightningNode
+from pyln.testing.utils import NodeFactory, BitcoinD, ElementsD, env, DEVELOPER, LightningNode, TEST_DEBUG
 
 import logging
 import os
 import pytest
 import re
 import shutil
+import sys
 import tempfile
 
 
@@ -26,6 +27,18 @@ def test_base_dir():
 
     if os.listdir(directory) == []:
         shutil.rmtree(directory)
+
+
+@pytest.fixture(autouse=True)
+def setup_logging():
+    logger = logging.getLogger()
+    before_handlers = list(logger.handlers)
+
+    if TEST_DEBUG:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+    yield
+    logger.handlers = before_handlers
 
 
 @pytest.fixture

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -41,6 +41,9 @@ def directory(request, test_base_dir, test_name):
     directory = os.path.join(test_base_dir, "{}_{}".format(test_name, __attempts[test_name]))
     request.node.has_errors = False
 
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
     yield directory
 
     # This uses the status set in conftest.pytest_runtest_makereport to

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -17,7 +17,6 @@ import sqlite3
 import string
 import struct
 import subprocess
-import sys
 import threading
 import time
 
@@ -67,10 +66,6 @@ DEVELOPER = env("DEVELOPER", "0") == "1"
 TEST_DEBUG = env("TEST_DEBUG", "0") == "1"
 SLOW_MACHINE = env("SLOW_MACHINE", "0") == "1"
 TIMEOUT = int(env("TIMEOUT", 180 if SLOW_MACHINE else 60))
-
-
-if TEST_DEBUG:
-    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
 
 def wait_for(success, timeout=TIMEOUT):

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -148,7 +148,7 @@ static bool grind_htlc_tx_fee(struct amount_sat *fee,
 			break;
 
 		bitcoin_tx_output_set_amount(tx, 0, out);
-		elements_tx_add_fee_output(tx);
+		bitcoin_tx_finalize(tx);
 		if (!check_tx_sig(tx, 0, NULL, wscript,
 				  &keyset->other_htlc_key, remotesig))
 			continue;
@@ -196,7 +196,7 @@ static bool set_htlc_timeout_fee(struct bitcoin_tx *tx,
 			      type_to_string(tmpctx, struct bitcoin_tx, tx));
 
 	bitcoin_tx_output_set_amount(tx, 0, amount);
-	elements_tx_add_fee_output(tx);
+	bitcoin_tx_finalize(tx);
 	return check_tx_sig(tx, 0, NULL, wscript,
 			    &keyset->other_htlc_key, remotesig);
 }
@@ -240,7 +240,7 @@ static void set_htlc_success_fee(struct bitcoin_tx *tx,
 			      type_to_string(tmpctx, struct amount_sat, &fee),
 			      type_to_string(tmpctx, struct bitcoin_tx, tx));
 	bitcoin_tx_output_set_amount(tx, 0, amt);
-	elements_tx_add_fee_output(tx);
+	bitcoin_tx_finalize(tx);
 
 	if (check_tx_sig(tx, 0, NULL, wscript,
 			 &keyset->other_htlc_key, remotesig))
@@ -372,7 +372,7 @@ static struct bitcoin_tx *tx_to_us(const tal_t *ctx,
 					     &amt));
 	}
 	bitcoin_tx_output_set_amount(tx, 0, amt);
-	elements_tx_add_fee_output(tx);
+	bitcoin_tx_finalize(tx);
 
 	if (!wire_sync_write(HSM_FD, take(hsm_sign_msg(NULL, tx, wscript))))
 		status_failed(STATUS_FAIL_HSM_IO, "Writing sign request to hsm");

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,5 @@
 from utils import DEVELOPER, TEST_NETWORK  # noqa: F401,F403
-from pyln.testing.fixtures import directory, test_base_dir, test_name, chainparams, node_factory, bitcoind, teardown_checks, db_provider, executor  # noqa: F401,F403
+from pyln.testing.fixtures import directory, test_base_dir, test_name, chainparams, node_factory, bitcoind, teardown_checks, db_provider, executor, setup_logging  # noqa: F401,F403
 from pyln.testing import utils
 
 import pytest

--- a/tests/plugins/accepter_close_to.py
+++ b/tests/plugins/accepter_close_to.py
@@ -9,7 +9,7 @@
       - otherwise: we don't include the close_to
 """
 
-from lightning import Plugin, Millisatoshi
+from pyln.client import Plugin, Millisatoshi
 
 plugin = Plugin()
 

--- a/tests/plugins/asynctest.py
+++ b/tests/plugins/asynctest.py
@@ -6,7 +6,7 @@ stashed away, and are only resolved on the fifth invocation. All calls
 will then return the argument of the fifth call.
 
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/broken.py
+++ b/tests/plugins/broken.py
@@ -3,7 +3,7 @@
 misbehaving plugin via RPC.
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 import an_unexistent_module_that_will_make_me_crash
 
 plugin = Plugin(dynamic=False)

--- a/tests/plugins/dblog.py
+++ b/tests/plugins/dblog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """This plugin is used to check that db_write calls are working correctly.
 """
-from lightning import Plugin, RpcError
+from pyln.client import Plugin, RpcError
 import sqlite3
 
 plugin = Plugin()

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/forward_payment_status.py
+++ b/tests/plugins/forward_payment_status.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """This plugin is used to check that forward_event calls are working correctly.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/hold_htlcs.py
+++ b/tests/plugins/hold_htlcs.py
@@ -7,7 +7,7 @@ settled/forwarded/
 """
 
 
-from lightning import Plugin
+from pyln.client import Plugin
 import json
 import os
 import tempfile

--- a/tests/plugins/hold_invoice.py
+++ b/tests/plugins/hold_invoice.py
@@ -2,7 +2,7 @@
 """Simple plugin to allow testing while closing of HTLC is delayed.
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 import time
 
 plugin = Plugin()

--- a/tests/plugins/millisatoshis.py
+++ b/tests/plugins/millisatoshis.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from lightning import Plugin, Millisatoshi
+from pyln.client import Plugin, Millisatoshi
 
 
 plugin = Plugin(autopatch=True)

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -4,7 +4,7 @@
 Only used for 'channel_opened' for now.
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/options.py
+++ b/tests/plugins/options.py
@@ -3,7 +3,7 @@
 
 The plugin offers 3 options, one of each supported type.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/pretend_badlog.py
+++ b/tests/plugins/pretend_badlog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """This plugin is used to check that warning(unusual/broken level log) calls are working correctly.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/print_htlc_onion.py
+++ b/tests/plugins/print_htlc_onion.py
@@ -5,7 +5,7 @@ We use this to check whether they're TLV or not
 
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/reject.py
+++ b/tests/plugins/reject.py
@@ -7,7 +7,7 @@ continue.
 
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/reject_odd_funding_amounts.py
+++ b/tests/plugins/reject_odd_funding_amounts.py
@@ -4,7 +4,7 @@
 We just refuse to let them open channels with an odd amount of millisatoshis.
 """
 
-from lightning import Plugin, Millisatoshi
+from pyln.client import Plugin, Millisatoshi
 
 plugin = Plugin()
 

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -4,7 +4,7 @@
 We just refuse to let them pay invoices with preimages divisible by 16.
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/rpc_command.py
+++ b/tests/plugins/rpc_command.py
@@ -2,7 +2,7 @@
 """
 This plugin is used to test the `rpc_command` hook.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/sendpay_notifications.py
+++ b/tests/plugins/sendpay_notifications.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """This plugin is used to check that sendpay_success and sendpay_failure calls are working correctly.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/shortcircuit.py
+++ b/tests/plugins/shortcircuit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tests/plugins/slow_init.py
+++ b/tests/plugins/slow_init.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from lightning import Plugin
+from pyln.client import Plugin
 import time
 
 plugin = Plugin()

--- a/tests/plugins/static.py
+++ b/tests/plugins/static.py
@@ -5,7 +5,7 @@ A plugin started with dynamic to False cannot be controlled after lightningd
 has been started.
 """
 
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin(dynamic=False)
 

--- a/tests/plugins/utf8.py
+++ b/tests/plugins/utf8.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from lightning import Plugin
+from pyln.client import Plugin
 
 
 plugin = Plugin()

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -465,7 +465,7 @@ def test_closing_fee(node_factory, bitcoind, chainparams):
         'funder_feerate_per_kw': 29006,
         'fundee_feerate_per_kw': 27625,
         'close_initiated_by': 'funder',
-        'expected_close_fee': 20333
+        'expected_close_fee': 33533 if chainparams['elements'] else 20333
     }
 
     closing_fee(node_factory, bitcoind, chainparams, opts)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2207,7 +2207,11 @@ def test_change_chaining(node_factory, bitcoind):
 def test_feerate_spam(node_factory, chainparams):
     l1, l2 = node_factory.line_graph(2)
 
-    slack = 45000000
+    # We constrain the value the funder has at its disposal so we get the
+    # REMOTE feerate we are looking for below. This may be fragile and depends
+    # on the transactions we generate.
+    slack = 45000000 if not chainparams['elements'] else 68000000
+
     # Pay almost everything to l2.
     l1.pay(l2, 10**9 - slack)
 

--- a/tests/test_onion.py
+++ b/tests/test_onion.py
@@ -30,7 +30,6 @@ pubkeys = [
 def test_onion(directory, oniontool):
     """ Generate a 5 hop onion and then decode it.
     """
-    os.makedirs(directory)
     tempfile = os.path.join(directory, 'onion')
     out = subprocess.check_output(
         [oniontool, 'generate'] + pubkeys
@@ -53,7 +52,6 @@ def test_onion(directory, oniontool):
 def test_rendezvous_onion(directory, oniontool):
     """Create a compressed onion, decompress it at the RV node and then forward normally.
     """
-    os.makedirs(directory)
     tempfile = os.path.join(directory, 'onion')
     out = subprocess.check_output(
         [oniontool, '--rendezvous-id', pubkeys[0], 'generate'] + pubkeys

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -403,8 +403,10 @@ static const struct utxo **wallet_select(const tal_t *ctx, struct wallet *w,
 		 * confirmation height and that it is below the required
 		 * maxheight (current_height - minconf) */
 		if (maxheight != 0 &&
-		    (!u->blockheight || *u->blockheight > maxheight))
+		    (!u->blockheight || *u->blockheight > maxheight)) {
+			tal_free(u);
 			continue;
+		}
 
 		tal_arr_expand(&utxos, u);
 


### PR DESCRIPTION
This was supposed to be a regular cleanup PR, but given that a couple of tests broke along the way for `liquid-regtest`, it took me a bit longer.

 - Create test directory: some tests, especially those testing tools, will not create the working directory themselves, so we create it when the fixture is created.
 - Strengthened a couple of tx creation tests, mainly minimizing the array allocation sizes and ensuring everything is set up correctly (subsumes chain specific modifications).
 - MIgrate away from deprecate `pylightning` dependency towards `pyln-client`
 - There is a lingering test failure in which we fail to remove the working directory. I added a printing of the file listing to see what files are causing that issue. It then rethrows the error so we don't just swallow it.

There is one more thing I need to find before un-drafting:

 - [x] If running with `DEVELOPER=1`, `TEST_DB_PROVIDER=postgres` and `VALGRIND=1` there is a memory leak when retrieving UTXOs for `txprepare`.

Changelog-None