### PR TITLE
feat: receivable_msat to listpeers

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1,4 +1,5 @@
 from bitcoin.rpc import RawProxy as BitcoinProxy
+from pyln.client import RpcError
 from pyln.testing.btcproxy import BitcoinRpcProxy
 from collections import OrderedDict
 from decimal import Decimal
@@ -816,6 +817,7 @@ class LightningNode(object):
                     if 'htlcs' in channel:
                         wait_for(lambda: len(self.rpc.listpeers()['peers'][p]['channels'][c]['htlcs']) == 0)
 
+    # This sends money to a directly connected peer
     def pay(self, dst, amt, label=None):
         if not label:
             label = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(20))
@@ -843,6 +845,18 @@ class LightningNode(object):
         # wait for sendpay to comply
         result = self.rpc.waitsendpay(rhash)
         assert(result.get('status') == 'complete')
+
+    # This helper sends all money to a peer until even 1 msat can't get through.
+    def drain(self, peer):
+        total = 0
+        msat = 16**9
+        while msat != 0:
+            try:
+                self.pay(peer, msat)
+                total += msat
+            except RpcError:
+                msat //= 2
+        return total
 
     # Note: this feeds through the smoother in update_feerate, so changing
     # it on a running daemon may not give expected result!
@@ -872,6 +886,15 @@ class LightningNode(object):
         # We wait until all three levels have been called.
         if wait_for_effect:
             wait_for(lambda: self.daemon.rpcproxy.mock_counts['estimatesmartfee'] >= 3)
+
+    # force new feerates by restarting and thus skipping slow smoothed process
+    # Note: testnode must be created with: opts={'may_reconnect': True}
+    def force_feerates(self, rate):
+        assert(self.may_reconnect)
+        self.set_feerates([rate] * 3, False)
+        self.restart()
+        self.daemon.wait_for_log('peer_out WIRE_UPDATE_FEE')
+        assert(self.rpc.feerates('perkw')['perkw']['normal'] == rate)
 
     def wait_for_onchaind_broadcast(self, name, resolve=None):
         """Wait for onchaind to drop tx name to resolve (if any)"""

--- a/doc/lightning-listpeers.7
+++ b/doc/lightning-listpeers.7
@@ -204,15 +204,15 @@ via this channel;
 a number followed by a string unit\.
 The peer imposes this on us, default is 1% of the total channel capacity\.
 .IP \[bu]
-\fIspendable_msat\fR: A string describing an \fB\fIestimate\fR\fR of how much we
-can send out over this channel in a single payment (or payment-part for
-multi-part payments);
+\fIspendable_msat\fR and \fIreceivable_msat\fR: A string describing an
+\fB\fIestimate\fR\fR of how much we can send or receive over this channel in a
+single payment (or payment-part for multi-part payments);
 a number followed by a string unit\.
 This is an \fB\fIestimate\fR\fR, which can be wrong because adding HTLCs requires
 an increase in fees paid to onchain miners, and onchain fees change
 dynamically according to onchain activity\.
-For a sufficiently-large channel with capacity on your side, this can
-be limited by the rules imposed under certain blockchains;
+For a sufficiently-large channel, this can be limited by the rules imposed
+under certain blockchains;
 for example, individual Bitcoin mainnet payment-parts cannot exceed
 42\.94967295 mBTC\.
 .IP \[bu]

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -153,15 +153,15 @@ state, or in various circumstances:
   via this channel;
   a number followed by a string unit.
   The peer imposes this on us, default is 1% of the total channel capacity.
-* *spendable\_msat*: A string describing an ***estimate*** of how much we
-  can send out over this channel in a single payment (or payment-part for
-  multi-part payments);
+* *spendable\_msat* and *receivable\_msat*: A string describing an
+  ***estimate*** of how much we can send or receive over this channel in a
+  single payment (or payment-part for multi-part payments);
   a number followed by a string unit.
   This is an ***estimate***, which can be wrong because adding HTLCs requires
   an increase in fees paid to onchain miners, and onchain fees change
   dynamically according to onchain activity.
-  For a sufficiently-large channel with capacity on your side, this can
-  be limited by the rules imposed under certain blockchains;
+  For a sufficiently-large channel, this can be limited by the rules imposed
+  under certain blockchains;
   for example, individual Bitcoin mainnet payment-parts cannot exceed
   42.94967295 mBTC.
 * *minimum\_htlc\_in\_msat*: A string describing the minimum amount that

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -509,10 +509,10 @@ static void json_add_sat_only(struct json_stream *result,
 				type_to_string(tmpctx, struct amount_msat, &msat));
 }
 
-/* Fee a commitment transaction would currently cost when spending */
-/* This is quite a lot of work to figure out what it would cost us! */
-static struct amount_sat commit_txfee_spend(const struct channel *channel,
-					   struct amount_msat spendable)
+/* Fee a commitment transaction would currently cost */
+static struct amount_sat commit_txfee(const struct channel *channel,
+				      struct amount_msat amount,
+				      enum side side)
 {
 	/* FIXME: make per-channel htlc maps! */
 	const struct htlc_in *hin;
@@ -520,72 +520,17 @@ static struct amount_sat commit_txfee_spend(const struct channel *channel,
 	const struct htlc_out *hout;
 	struct htlc_out_map_iter outi;
 	struct lightningd *ld = channel->peer->ld;
-	u32 local_feerate = get_feerate(channel->channel_info.fee_states,
-					channel->funder, LOCAL);
 	size_t num_untrimmed_htlcs = 0;
-
-	/* Assume we tried to spend "spendable" */
-	if (!htlc_is_trimmed(LOCAL, spendable,
-			     local_feerate, channel->our_config.dust_limit,
-			     LOCAL))
-		num_untrimmed_htlcs++;
-
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
-	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
-		if (hin->key.channel != channel)
-			continue;
-		if (!htlc_is_trimmed(REMOTE, hin->msat, local_feerate,
-				     channel->our_config.dust_limit,
-				     LOCAL))
-			num_untrimmed_htlcs++;
-	}
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
-	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
-		if (hout->key.channel != channel)
-			continue;
-		if (!htlc_is_trimmed(LOCAL, hout->msat, local_feerate,
-				     channel->our_config.dust_limit,
-				     LOCAL))
-			num_untrimmed_htlcs++;
-	}
-
-	/*
-	 * BOLT-95c74fef2fe590cb8adbd7b848743a229ffe825a #2:
-	 * Adding an HTLC: update_add_htlc
-	 *
-	 * A sending node:
-	 *   - if it is responsible for paying the Bitcoin fee:
-	 *     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to
-	 *       its commitment transaction, its remaining balance doesn't allow
-	 *       it to pay the fee for a future additional non-dust HTLC at
-	 *       `N*feerate_per_kw` while maintaining its channel reserve
-	 *       ("fee spike buffer"), where `N` is a parameter chosen by the
-	 *       implementation (`N = 2` is recommended to ensure
-	 *       predictability).
-	 */
-	return commit_tx_base_fee(local_feerate * 2, num_untrimmed_htlcs + 1);
-}
-
-/* Fee a commitment transaction would currently cost when receiving */
-static struct amount_sat commit_txfee_recv(const struct channel *channel,
-					   struct amount_msat receivable)
-{
-	/* FIXME: make per-channel htlc maps! */
-	const struct htlc_in *hin;
-	struct htlc_in_map_iter ini;
-	const struct htlc_out *hout;
-	struct htlc_out_map_iter outi;
-	struct lightningd *ld = channel->peer->ld;
 	u32 feerate = get_feerate(channel->channel_info.fee_states,
-				  channel->funder, REMOTE);
-	size_t num_untrimmed_htlcs = 0;
+				  channel->funder, side);
+	struct amount_sat dust_limit;
+	if (side == LOCAL)
+		dust_limit = channel->our_config.dust_limit;
+	if (side == REMOTE)
+		dust_limit = channel->channel_info.their_config.dust_limit;
 
-	/* Assume we tried to receive "receivable" */
-	if (!htlc_is_trimmed(REMOTE, receivable, feerate,
-			     channel->channel_info.their_config.dust_limit,
-			     REMOTE))
+	/* Assume we tried to add "amount" */
+	if (!htlc_is_trimmed(side, amount, feerate, dust_limit, side))
 		num_untrimmed_htlcs++;
 
 	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
@@ -593,9 +538,8 @@ static struct amount_sat commit_txfee_recv(const struct channel *channel,
 	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
 		if (hin->key.channel != channel)
 			continue;
-		if (!htlc_is_trimmed(LOCAL, hin->msat, feerate,
-				     channel->channel_info.their_config.dust_limit,
-				     REMOTE))
+		if (!htlc_is_trimmed(!side, hin->msat, feerate, dust_limit,
+				     side))
 			num_untrimmed_htlcs++;
 	}
 	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
@@ -603,29 +547,26 @@ static struct amount_sat commit_txfee_recv(const struct channel *channel,
 	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
 		if (hout->key.channel != channel)
 			continue;
-		if (!htlc_is_trimmed(REMOTE, hout->msat, feerate,
-				     channel->channel_info.their_config.dust_limit,
-				     REMOTE))
+		if (!htlc_is_trimmed(side, hout->msat, feerate, dust_limit,
+				     side))
 			num_untrimmed_htlcs++;
 	}
 
 	/*
-	 * BOLT-95c74fef2fe590cb8adbd7b848743a229ffe825a #2:
+	 * BOLT-f5490f17d17ff49dc26ee459432b3c9db4fda8a9 #2:
 	 * Adding an HTLC: update_add_htlc
 	 *
 	 * A sending node:
 	 *   - if it is responsible for paying the Bitcoin fee:
-	 *     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to
-	 *       its commitment transaction, its remaining balance doesn't allow
-	 *       it to pay the fee for a future additional non-dust HTLC at
-	 *       `N*feerate_per_kw` while maintaining its channel reserve
-	 *       ("fee spike buffer"), where `N` is a parameter chosen by the
-	 *       implementation (`N = 2` is recommended to ensure
-	 *       predictability).
+	 *     - SHOULD NOT offer amount_msat if, after adding that HTLC to its
+	 *       commitment transaction, its remaining balance doesn't allow it
+	 *       to pay the fee for a future additional non-dust HTLC at a
+	 *       higher feerate while maintaining its channel reserve
+	 *       ("fee spike buffer"). A buffer of 2*feerate_per_kw is
+	 *       recommended to ensure predictability.
 	 */
 	return commit_tx_base_fee(2 * feerate, num_untrimmed_htlcs + 1);
 }
-
 
 static void subtract_offered_htlcs(const struct channel *channel,
 				   struct amount_msat *amount)
@@ -793,7 +734,8 @@ static void json_add_channel(struct lightningd *ld,
 	/* If we're funder, subtract txfees we'll need to spend this */
 	if (channel->funder == LOCAL) {
 		if (!amount_msat_sub_sat(&spendable, spendable,
-					 commit_txfee_spend(channel, spendable)))
+					 commit_txfee(channel, spendable,
+						      LOCAL)))
 			spendable = AMOUNT_MSAT(0);
 	}
 
@@ -824,7 +766,8 @@ static void json_add_channel(struct lightningd *ld,
 	/* If they're funder, subtract txfees they'll need to spend this */
 	if (channel->funder == REMOTE) {
 		if (!amount_msat_sub_sat(&receivable, receivable,
-					 commit_txfee_recv(channel, receivable)))
+					 commit_txfee(channel,
+						      receivable, REMOTE)))
 			receivable = AMOUNT_MSAT(0);
 	}
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -509,9 +509,10 @@ static void json_add_sat_only(struct json_stream *result,
 				type_to_string(tmpctx, struct amount_msat, &msat));
 }
 
+/* Fee a commitment transaction would currently cost when spending */
 /* This is quite a lot of work to figure out what it would cost us! */
-static struct amount_sat commit_txfee(const struct channel *channel,
-				      struct amount_msat spendable)
+static struct amount_sat commit_txfee_spend(const struct channel *channel,
+					   struct amount_msat spendable)
 {
 	/* FIXME: make per-channel htlc maps! */
 	const struct htlc_in *hin;
@@ -566,6 +567,65 @@ static struct amount_sat commit_txfee(const struct channel *channel,
 	 */
 	return commit_tx_base_fee(local_feerate * 2, num_untrimmed_htlcs + 1);
 }
+
+/* Fee a commitment transaction would currently cost when receiving */
+static struct amount_sat commit_txfee_recv(const struct channel *channel,
+					   struct amount_msat receivable)
+{
+	/* FIXME: make per-channel htlc maps! */
+	const struct htlc_in *hin;
+	struct htlc_in_map_iter ini;
+	const struct htlc_out *hout;
+	struct htlc_out_map_iter outi;
+	struct lightningd *ld = channel->peer->ld;
+	u32 feerate = get_feerate(channel->channel_info.fee_states,
+				  channel->funder, REMOTE);
+	size_t num_untrimmed_htlcs = 0;
+
+	/* Assume we tried to receive "receivable" */
+	if (!htlc_is_trimmed(REMOTE, receivable, feerate,
+			     channel->channel_info.their_config.dust_limit,
+			     REMOTE))
+		num_untrimmed_htlcs++;
+
+	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	     hin;
+	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+		if (hin->key.channel != channel)
+			continue;
+		if (!htlc_is_trimmed(LOCAL, hin->msat, feerate,
+				     channel->channel_info.their_config.dust_limit,
+				     REMOTE))
+			num_untrimmed_htlcs++;
+	}
+	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	     hout;
+	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+		if (hout->key.channel != channel)
+			continue;
+		if (!htlc_is_trimmed(REMOTE, hout->msat, feerate,
+				     channel->channel_info.their_config.dust_limit,
+				     REMOTE))
+			num_untrimmed_htlcs++;
+	}
+
+	/*
+	 * BOLT-95c74fef2fe590cb8adbd7b848743a229ffe825a #2:
+	 * Adding an HTLC: update_add_htlc
+	 *
+	 * A sending node:
+	 *   - if it is responsible for paying the Bitcoin fee:
+	 *     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to
+	 *       its commitment transaction, its remaining balance doesn't allow
+	 *       it to pay the fee for a future additional non-dust HTLC at
+	 *       `N*feerate_per_kw` while maintaining its channel reserve
+	 *       ("fee spike buffer"), where `N` is a parameter chosen by the
+	 *       implementation (`N = 2` is recommended to ensure
+	 *       predictability).
+	 */
+	return commit_tx_base_fee(2 * feerate, num_untrimmed_htlcs + 1);
+}
+
 
 static void subtract_offered_htlcs(const struct channel *channel,
 				   struct amount_msat *amount)
@@ -733,7 +793,7 @@ static void json_add_channel(struct lightningd *ld,
 	/* If we're funder, subtract txfees we'll need to spend this */
 	if (channel->funder == LOCAL) {
 		if (!amount_msat_sub_sat(&spendable, spendable,
-					 commit_txfee(channel, spendable)))
+					 commit_txfee_spend(channel, spendable)))
 			spendable = AMOUNT_MSAT(0);
 	}
 
@@ -764,7 +824,7 @@ static void json_add_channel(struct lightningd *ld,
 	/* If they're funder, subtract txfees they'll need to spend this */
 	if (channel->funder == REMOTE) {
 		if (!amount_msat_sub_sat(&receivable, receivable,
-					 commit_txfee(channel, receivable)))
+					 commit_txfee_recv(channel, receivable)))
 			receivable = AMOUNT_MSAT(0);
 	}
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2218,7 +2218,7 @@ def test_channel_spendable(node_factory, bitcoind):
     payment_hash = l1.rpc.invoice('any', 'inv', 'for testing')['payment_hash']
     amount = l2.rpc.listpeers()['peers'][0]['channels'][0]['spendable_msat']
 
-    # Turns out we this won't route, as it's over max - reserve:
+    # Turns out we won't route this, as it's over max - reserve:
     route = l2.rpc.getroute(l1.info['id'], amount + 1, riskfactor=1, fuzzpercent=0)['route']
     l2.rpc.sendpay(route, payment_hash)
 
@@ -2238,6 +2238,59 @@ def test_channel_spendable(node_factory, bitcoind):
 
 
 @unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
+def test_channel_receivable(node_factory, bitcoind):
+    """Test that receivable_msat is accurate"""
+    sats = 10**6
+    l1, l2 = node_factory.line_graph(2, fundamount=sats, wait_for_announce=True,
+                                     opts={'plugin': os.path.join(os.getcwd(), 'tests/plugins/hold_invoice.py'), 'holdtime': str(TIMEOUT / 2)})
+
+    payment_hash = l2.rpc.invoice('any', 'inv', 'for testing')['payment_hash']
+
+    # We should be able to receive this much, and not one msat more!
+    amount = l2.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat']
+    route = l1.rpc.getroute(l2.info['id'], amount + 1, riskfactor=1, fuzzpercent=0)['route']
+    l1.rpc.sendpay(route, payment_hash)
+
+    # This should fail locally with "capacity exceeded"
+    with pytest.raises(RpcError, match=r"Capacity exceeded.*'erring_index': 0"):
+        l1.rpc.waitsendpay(payment_hash, TIMEOUT)
+
+    # Exact amount should succeed.
+    route = l1.rpc.getroute(l2.info['id'], amount, riskfactor=1, fuzzpercent=0)['route']
+    l1.rpc.sendpay(route, payment_hash)
+
+    # Amount should drop to 0 once HTLC is sent; we have time, thanks to
+    # hold_invoice.py plugin.
+    wait_for(lambda: len(l2.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 1)
+    assert l2.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat'] == Millisatoshi(0)
+    l1.rpc.waitsendpay(payment_hash, TIMEOUT)
+
+    # Make sure l2 thinks it's all over.
+    wait_for(lambda: len(l2.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 0)
+    # Now, reverse should work similarly.
+    payment_hash = l1.rpc.invoice('any', 'inv', 'for testing')['payment_hash']
+    amount = l1.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat']
+
+    # Turns out we won't route this, as it's over max - reserve:
+    route = l2.rpc.getroute(l1.info['id'], amount + 1, riskfactor=1, fuzzpercent=0)['route']
+    l2.rpc.sendpay(route, payment_hash)
+
+    # This should fail locally with "capacity exceeded"
+    with pytest.raises(RpcError, match=r"Capacity exceeded.*'erring_index': 0"):
+        l2.rpc.waitsendpay(payment_hash, TIMEOUT)
+
+    # Exact amount should succeed.
+    route = l2.rpc.getroute(l1.info['id'], amount, riskfactor=1, fuzzpercent=0)['route']
+    l2.rpc.sendpay(route, payment_hash)
+
+    # Amount should drop to 0 once HTLC is sent; we have time, thanks to
+    # hold_invoice.py plugin.
+    wait_for(lambda: len(l1.rpc.listpeers()['peers'][0]['channels'][0]['htlcs']) == 1)
+    assert l1.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat'] == Millisatoshi(0)
+    l2.rpc.waitsendpay(payment_hash, TIMEOUT)
+
+
+@unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 def test_channel_spendable_large(node_factory, bitcoind):
     """Test that spendable_msat is accurate for large channels"""
     # This is almost the max allowable spend.
@@ -2248,26 +2301,30 @@ def test_channel_spendable_large(node_factory, bitcoind):
     payment_hash = l2.rpc.invoice('any', 'inv', 'for testing')['payment_hash']
 
     # We should be able to spend this much, and not one msat more!
-    amount = l1.rpc.listpeers()['peers'][0]['channels'][0]['spendable_msat']
+    spendable = l1.rpc.listpeers()['peers'][0]['channels'][0]['spendable_msat']
+
+    # receivable from the other side should calculate to the exact same amount
+    receivable = l2.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat']
+    assert spendable == receivable
 
     # route or waitsendpay fill fail.
     with pytest.raises(RpcError):
-        route = l1.rpc.getroute(l2.info['id'], amount + 1, riskfactor=1, fuzzpercent=0)['route']
+        route = l1.rpc.getroute(l2.info['id'], spendable + 1, riskfactor=1, fuzzpercent=0)['route']
         l1.rpc.sendpay(route, payment_hash)
         l1.rpc.waitsendpay(payment_hash, TIMEOUT)
 
-    print(l2.rpc.listchannels())
     # Exact amount should succeed.
-    route = l1.rpc.getroute(l2.info['id'], amount, riskfactor=1, fuzzpercent=0)['route']
+    route = l1.rpc.getroute(l2.info['id'], spendable, riskfactor=1, fuzzpercent=0)['route']
     l1.rpc.sendpay(route, payment_hash)
     l1.rpc.waitsendpay(payment_hash, TIMEOUT)
 
 
-def test_channel_spendable_capped(node_factory, bitcoind):
-    """Test that spendable_msat is capped at 2^32-1"""
+def test_channel_spendable_receivable_capped(node_factory, bitcoind):
+    """Test that spendable_msat and receivable_msat is capped at 2^32-1"""
     sats = 16777215
     l1, l2 = node_factory.line_graph(2, fundamount=sats, wait_for_announce=False)
     assert l1.rpc.listpeers()['peers'][0]['channels'][0]['spendable_msat'] == Millisatoshi(0xFFFFFFFF)
+    assert l2.rpc.listpeers()['peers'][0]['channels'][0]['receivable_msat'] == Millisatoshi(0xFFFFFFFF)
 
 
 def test_lockup_drain(node_factory, bitcoind):


### PR DESCRIPTION
This adds the `receivable_msat` amount to the `lightning-cli listpeers` output. The logic is similar to `spendable_msat` and applies for the maximum possible amount in one HTLC in that situation.

Adds code, test and manpage - Closes #3555 