### PR TITLE
travis: do not cache ./external

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ env:
 cache:
   directories:
     - dependencies
-    - external
 
 script:
   .travis/build.sh


### PR DESCRIPTION
Caching the `./external` directory means that any changes to
`external/Makefile` or any updates of the submodules in `./external/*`
would not be picked up and travis would run with old instances of those,
possibly "activating" such changes after weeks or months when the cache
is pruned eventually.

Changelog-None