### PR TITLE
Pass typed plugin option data to plugin in init

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -250,6 +250,9 @@ class Plugin(object):
                 "Name {} is already used by another option".format(name)
             )
 
+        if opt_type not in ["string", "int", "bool"]:
+            raise ValueError('{} not in supported type set (string, int, bool)')
+
         self.options[name] = {
             'name': name,
             'default': default,

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -990,7 +990,7 @@ class NodeFactory(object):
 
     def get_node(self, node_id=None, options=None, dbfile=None,
                  feerates=(15000, 7500, 3750), start=True,
-                 wait_for_bitcoind_sync=True, **kwargs):
+                 wait_for_bitcoind_sync=True, expect_fail=False, **kwargs):
 
         node_id = self.get_node_id() if not node_id else node_id
         port = self.get_next_port()
@@ -1021,8 +1021,15 @@ class NodeFactory(object):
 
         if start:
             try:
-                node.start(wait_for_bitcoind_sync)
+                # Capture stderr if we're failing
+                if expect_fail:
+                    stderr = subprocess.PIPE
+                else:
+                    stderr = None
+                node.start(wait_for_bitcoind_sync, stderr=stderr)
             except Exception:
+                if expect_fail:
+                    return node
                 node.daemon.stop()
                 raise
         return node

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1128,11 +1128,13 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 		name = opt->name + 2;
 		if (opt->value->as_bool) {
 			json_add_bool(req->stream, name, *opt->value->as_bool);
-			continue;
+			if (!deprecated_apis)
+				continue;
 		}
 		if (opt->value->as_int) {
 			json_add_s64(req->stream, name, *opt->value->as_int);
-			continue;
+			if (!deprecated_apis)
+				continue;
 		}
 		if (opt->value->as_str) {
 			json_add_string(req->stream, name, opt->value->as_str);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1102,6 +1102,14 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 	list_for_each(&plugin->plugin_opts, opt, list) {
 		/* Trim the `--` that we added before */
 		name = opt->name + 2;
+		if (opt->value->as_bool) {
+			json_add_bool(req->stream, name, *opt->value->as_bool);
+			continue;
+		}
+		if (opt->value->as_int) {
+			json_add_s64(req->stream, name, *opt->value->as_int);
+			continue;
+		}
 		if (opt->value->as_str) {
 			json_add_string(req->stream, name, opt->value->as_str);
 		}

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -114,7 +114,7 @@ struct plugins {
  */
 struct plugin_opt_value {
 	char *as_str;
-	int *as_int;
+	s64 *as_int;
 	bool *as_bool;
 };
 

--- a/tests/plugins/options.py
+++ b/tests/plugins/options.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""This plugin is used to check that plugin options are parsed properly.
+
+The plugin offers 3 options, one of each supported type.
+"""
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.init()
+def init(configuration, options, plugin):
+    for name, val in options.items():
+        plugin.log("option {} {} {}".format(name, val, type(val)))
+
+
+plugin.add_option('str_opt', 'i am a string', 'an example string option')
+plugin.add_option('int_opt', 7, 'an example int type option', opt_type='int')
+plugin.add_option('bool_opt', True, 'an example bool type option', opt_type='bool')
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -55,7 +55,7 @@ def test_option_types(node_factory):
         'plugin': plugin_path,
         'str_opt': 'ok',
         'int_opt': 22,
-        'bool_opt': 1,
+        'bool_opt': True,
     })
 
     n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
@@ -82,6 +82,7 @@ def test_option_types(node_factory):
     }, expect_fail=True, may_fail=True)
 
     # the node should fail to start, and we get a stderr msg
+    assert not n.daemon.running
     assert n.daemon.is_in_stderr('bool_opt: ! does not parse as type bool')
 
     # What happens if we give it a bad int-option?
@@ -93,7 +94,23 @@ def test_option_types(node_factory):
     }, may_fail=True, expect_fail=True)
 
     # the node should fail to start, and we get a stderr msg
+    assert not n.daemon.running
     assert n.daemon.is_in_stderr('--int_opt: notok does not parse as type int')
+
+    plugin_path = os.path.join(os.getcwd(), 'tests/plugins/options.py')
+    n = node_factory.get_node(options={
+        'plugin': plugin_path,
+        'str_opt': 'ok',
+        'int_opt': 22,
+        'bool_opt': 1,
+    })
+
+    n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
+    n.daemon.is_in_log(r"option int_opt 22 <class 'int'>")
+    n.daemon.is_in_log(r"option int_opt 22 <class 'str'>")
+    n.daemon.is_in_log(r"option bool_opt True <class 'bool'>")
+    n.daemon.is_in_log(r"option bool_opt true <class 'str'>")
+    n.stop()
 
 
 def test_millisatoshi_passthrough(node_factory):


### PR DESCRIPTION
We're only passing string values of plugin options to plugins, despite soliticting a type from the plugin during the manifest pass. 

In this PR, I will now pass the values down to plugins as the type they've specified.

Additionally, makes the input option parsing stricter and adds a new testing feature where we can capture stderr logs to verify error messages in. If you want to.