### PR TITLE
bitcoin-cli reference confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ open a channel:
 ```bash
 # Returns an address <address>
 lightning-cli newaddr
-
-# Returns a transaction id <txid>
-bitcoin-cli sendtoaddress <address> <amount_in_bitcoins>
 ```
 
 `lightningd` will register the funds once the transaction is confirmed.


### PR DESCRIPTION
If the user has a funded bitcoin-cli, they will send from that wallet, if not they will send from a different wallet. 
It seems easier to follow funding instructions without bitcoin-cli reference