### PR TITLE
quick fix: a blank plugin option should be true, not false

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -250,8 +250,8 @@ class Plugin(object):
                 "Name {} is already used by another option".format(name)
             )
 
-        if opt_type not in ["string", "int", "bool"]:
-            raise ValueError('{} not in supported type set (string, int, bool)')
+        if opt_type not in ["string", "int", "bool", "flag"]:
+            raise ValueError('{} not in supported type set (string, int, bool, flag)')
 
         self.options[name] = {
             'name': name,
@@ -260,6 +260,15 @@ class Plugin(object):
             'type': opt_type,
             'value': None,
         }
+
+    def add_flag_option(self, name, description):
+        """Add a flag option that we'd like to register with lightningd.
+
+        Needs to be called before `Plugin.run`, otherwise we might not
+        end up getting it set.
+
+        """
+        self.add_option(name, None, description, opt_type="flag")
 
     def get_option(self, name):
         if name not in self.options:

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -104,7 +104,7 @@ this example:
 The `options` will be added to the list of command line options that
 `lightningd` accepts. The above will add a `--greeting` option with a
 default value of `World` and the specified description. *Notice that
-currently string, (unsigned) integers, and bool options are supported.*
+currently string, integers, bool, and flag options are supported.*
 
 The `rpcmethods` are methods that will be exposed via `lightningd`'s
 JSON-RPC over Unix-Socket interface, just like the builtin
@@ -138,6 +138,48 @@ as the name was not previously registered. This includes both built-in
 methods, such as `help` and `getinfo`, as well as methods registered
 by other plugins. If there is a conflict then `lightningd` will report
 an error and exit.
+
+#### Types of Options
+
+There are currently four supported option 'types':
+  - string: a string
+  - bool: a boolean
+  - int: parsed as a signed integer (64-bit)
+  - flag: no-arg flag option. Is boolean under the hood. Defaults to false.
+
+Nota bene: if a `flag` type option is not set, it will not appear
+in the options set that is passed to the plugin.
+
+Here's an example option set, as sent in response to `getmanifest`
+
+```json
+  "options": [
+    {
+      "name": "greeting",
+      "type": "string",
+      "default": "World",
+      "description": "What name should I call you?"
+    },
+    {
+      "name": "run-hot",
+      "type": "flag",
+      "default": None,  // defaults to false
+      "description": "If set, overclocks plugin"
+    },
+    {
+      "name": "is_online",
+      "type": "bool",
+      "default": false,
+      "description": "Set to true if plugin can use network"
+    },
+    {
+      "name": "service-port",
+      "type": "int",
+      "default": 6666,
+      "description": "Port to use to connect to 3rd-party service"
+    }
+  ],
+```
 
 ### The `init` method
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1272,7 +1272,8 @@ static void add_config(struct lightningd *ld,
 			json_add_opt_log_levels(response, ld->log);
 		} else if (opt->cb_arg == (void *)opt_add_plugin_dir
 			   || opt->cb_arg == (void *)opt_disable_plugin
-			   || opt->cb_arg == (void *)plugin_opt_set) {
+			   || opt->cb_arg == (void *)plugin_opt_set
+			   || opt->cb_arg == (void *)plugin_opt_flag_set) {
 			/* FIXME: We actually treat it as if they specified
 			 * --plugin for each one, so ignore these */
 #if DEVELOPER

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -497,7 +497,7 @@ char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
 		if (streq(arg, "true") || streq(arg, "True") || streq(arg, "1")) {
 			*popt->value->as_bool = true;
 		} else if (streq(arg, "false") || streq(arg, "False")
-				|| streq(arg, "0") || streq(arg, "")) {
+				|| streq(arg, "0")) {
 			*popt->value->as_bool = false;
 		} else
 			return tal_fmt(tmpctx, "%s does not parse as type %s",

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -255,6 +255,12 @@ void plugin_request_send(struct plugin *plugin,
 char *plugin_opt_set(const char *arg, struct plugin_opt *popt);
 
 /**
+ * Callback called when plugin flag-type options.It just stores
+ * the value in the plugin_opt
+ */
+char *plugin_opt_flag_set(struct plugin_opt *popt);
+
+/**
  * Helpers to initialize a connection to a plugin; we read from their
  * stdout, and write to their stdin.
  */

--- a/tests/plugins/options.py
+++ b/tests/plugins/options.py
@@ -17,4 +17,5 @@ def init(configuration, options, plugin):
 plugin.add_option('str_opt', 'i am a string', 'an example string option')
 plugin.add_option('int_opt', 7, 'an example int type option', opt_type='int')
 plugin.add_option('bool_opt', True, 'an example bool type option', opt_type='bool')
+plugin.add_flag_option('flag_opt', 'an example flag type option')
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -58,9 +58,9 @@ def test_option_types(node_factory):
         'bool_opt': True,
     })
 
-    n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
-    n.daemon.is_in_log(r"option int_opt 22 <class 'int'>")
-    n.daemon.is_in_log(r"option bool_opt True <class 'bool'>")
+    assert n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
+    assert n.daemon.is_in_log(r"option int_opt 22 <class 'int'>")
+    assert n.daemon.is_in_log(r"option bool_opt True <class 'bool'>")
     n.stop()
 
     # A blank bool_opt should default to false
@@ -70,7 +70,7 @@ def test_option_types(node_factory):
         'bool_opt': '',
     })
 
-    n.daemon.is_in_log(r"option bool_opt False <class 'bool'>")
+    assert n.daemon.is_in_log(r"option bool_opt True <class 'bool'>")
     n.stop()
 
     # What happens if we give it a bad bool-option?
@@ -103,13 +103,15 @@ def test_option_types(node_factory):
         'str_opt': 'ok',
         'int_opt': 22,
         'bool_opt': 1,
+        'allow-deprecated-apis': True
     })
 
-    n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
-    n.daemon.is_in_log(r"option int_opt 22 <class 'int'>")
-    n.daemon.is_in_log(r"option int_opt 22 <class 'str'>")
-    n.daemon.is_in_log(r"option bool_opt True <class 'bool'>")
-    n.daemon.is_in_log(r"option bool_opt true <class 'str'>")
+    # because of how the python json parser works, since we're adding the deprecated
+    # string option after the 'typed' option in the JSON, the string option overwrites
+    # the earlier typed option in JSON parsing, resulting in a option set of only strings
+    assert n.daemon.is_in_log(r"option str_opt ok <class 'str'>")
+    assert n.daemon.is_in_log(r"option int_opt 22 <class 'str'>")
+    assert n.daemon.is_in_log(r"option bool_opt 1 <class 'str'>")
     n.stop()
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -69,7 +69,7 @@ def test_option_types(node_factory):
     n = node_factory.get_node(options={
         'plugin': plugin_path, 'str_opt': 'ok',
         'int_opt': 22,
-        'bool_opt': '',
+        'bool_opt': 'true',
         'flag_opt': None,
     })
 


### PR DESCRIPTION
Fix a syntactic mistake i made in #3582 

Also fix the option interop test so that it actually verifies the log messages. 