### PR TITLE
Bump htlc resolution transactions feerate

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -275,7 +275,7 @@ def test_htlc_sig_persistence(node_factory, bitcoind, executor):
     """
     # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(options={'dev-no-reconnect': None},
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -326,7 +326,7 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
     # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
                                options={'dev-no-reconnect': None},
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -393,7 +393,7 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
     # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
                                options={'dev-no-reconnect': None},
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1280,11 +1280,11 @@ def test_htlc_send_timeout(node_factory, bitcoind):
     """Test that we don't commit an HTLC to an unreachable node."""
     # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(options={'log-level': 'io'},
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     # Blackhole it after it sends HTLC_ADD to l3.
     l2 = node_factory.get_node(disconnect=['0WIRE_UPDATE_ADD_HTLC'],
                                options={'log-level': 'io'},
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l3 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -1384,7 +1384,7 @@ def test_feerates(node_factory):
 
     # Now try setting them, one at a time.
     # Set CONSERVATIVE/2 feerate, for max and unilateral_close
-    l1.set_feerates((15000, 0, 0), True)
+    l1.set_feerates((15000, 0, 0, 0), True)
     wait_for(lambda: len(l1.rpc.feerates('perkw')['perkw']) == 3)
     feerates = l1.rpc.feerates('perkw')
     assert feerates['perkw']['unilateral_close'] == 15000
@@ -1393,13 +1393,27 @@ def test_feerates(node_factory):
     assert feerates['perkw']['max_acceptable'] == 15000 * 10
     assert feerates['perkw']['min_acceptable'] == 253
 
+    # Set CONSERVATIVE/3 feerate, for htlc_resolution and penalty
+    l1.set_feerates((15000, 11000, 0, 0), True)
+    wait_for(lambda: len(l1.rpc.feerates('perkw')['perkw']) == 5)
+    feerates = l1.rpc.feerates('perkw')
+    assert feerates['perkw']['unilateral_close'] == 15000
+    assert feerates['perkw']['htlc_resolution'] == 11000
+    assert feerates['perkw']['penalty'] == 11000
+    assert feerates['warning'] == 'Some fee estimates unavailable: bitcoind startup?'
+    assert 'perkb' not in feerates
+    assert feerates['perkw']['max_acceptable'] == 15000 * 10
+    assert feerates['perkw']['min_acceptable'] == 253
+
     # Set ECONOMICAL/4 feerate, for all but min
-    l1.set_feerates((15000, 6250, 0), True)
+    l1.set_feerates((15000, 11000, 6250, 0), True)
     wait_for(lambda: len(l1.rpc.feerates('perkb')['perkb']) == len(types) + 2)
     feerates = l1.rpc.feerates('perkb')
     assert feerates['perkb']['unilateral_close'] == 15000 * 4
+    assert feerates['perkb']['htlc_resolution'] == 11000 * 4
+    assert feerates['perkb']['penalty'] == 11000 * 4
     for t in types:
-        if t != "unilateral_close":
+        if t not in ("unilateral_close", "htlc_resolution", "penalty"):
             assert feerates['perkb'][t] == 25000
     assert feerates['warning'] == 'Some fee estimates unavailable: bitcoind startup?'
     assert 'perkw' not in feerates
@@ -1407,12 +1421,14 @@ def test_feerates(node_factory):
     assert feerates['perkb']['min_acceptable'] == 253 * 4
 
     # Set ECONOMICAL/100 feerate for min
-    l1.set_feerates((15000, 6250, 5000), True)
+    l1.set_feerates((15000, 11000, 6250, 5000), True)
     wait_for(lambda: len(l1.rpc.feerates('perkw')['perkw']) >= len(types) + 2)
     feerates = l1.rpc.feerates('perkw')
     assert feerates['perkw']['unilateral_close'] == 15000
+    assert feerates['perkw']['htlc_resolution'] == 11000
+    assert feerates['perkw']['penalty'] == 11000
     for t in types:
-        if t != "unilateral_close":
+        if t not in ("unilateral_close", "htlc_resolution", "penalty"):
             assert feerates['perkw'][t] == 25000 // 4
     assert 'warning' not in feerates
     assert 'perkb' not in feerates

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -247,7 +247,7 @@ def test_pay_disconnect(node_factory, bitcoind):
     l1.daemon.wait_for_log('peer_out WIRE_CHANNEL_REESTABLISH')
 
     # Make l2 upset by asking for crazy fee.
-    l1.set_feerates((10**6, 1000**6, 1000**6), False)
+    l1.set_feerates((10**6, 1000**6, 1000**6, 1000**6), False)
 
     # Wait for l1 notice
     l1.daemon.wait_for_log(r'Peer transient failure in CHANNELD_NORMAL: channeld: .*: update_fee \d+ outside range 1875-75000')
@@ -330,7 +330,7 @@ def test_payment_success_persistence(node_factory, bitcoind, executor):
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
                                may_reconnect=True,
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -375,7 +375,7 @@ def test_payment_failed_persistence(node_factory, executor):
     l1 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'],
                                options={'dev-no-reconnect': None},
                                may_reconnect=True,
-                               feerates=(7500, 7500, 7500))
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
@@ -579,7 +579,7 @@ def test_sendpay(node_factory):
 def test_sendpay_cant_afford(node_factory):
     # Set feerates the same so we don't have to wait for update.
     l1, l2 = node_factory.line_graph(2, fundamount=10**6,
-                                     opts={'feerates': (15000, 15000, 15000)})
+                                     opts={'feerates': (15000, 15000, 15000, 15000)})
 
     # Can't pay more than channel capacity.
     with pytest.raises(RpcError):
@@ -1570,7 +1570,7 @@ def test_pay_retry(node_factory, bitcoind, executor, chainparams):
     # We connect every node to l5; in a line and individually.
     # Keep fixed fees so we can easily calculate exhaustion
     l1, l2, l3, l4, l5 = node_factory.line_graph(5, fundchannel=False,
-                                                 opts={'feerates': (7500, 7500, 7500)})
+                                                 opts={'feerates': (7500, 7500, 7500, 7500)})
 
     # scid12
     l1.fund_channel(l2, 10**6, wait_for_active=False)


### PR DESCRIPTION
This builds upon #3570 to, now that we have a specific feerate for them, bump the feerate estimation target for HTLC resolution and penalty transactions.