### PR TITLE
wallet: allow to withdraw with unconfirmed utxos

### DIFF
--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -205,7 +205,8 @@ struct command_result *wtx_from_utxos(struct wallet_tx *tx,
 	/* + segwit marker + flag */
 	weight = 4 * (4 + 1 + 1 + 4) + 4 * (8 + 1 + out_len) + 1 + 1;
 	for (size_t i = 0; i < tal_count(utxos); i++) {
-		if (!utxos[i]->blockheight || *utxos[i]->blockheight > maxheight) {
+		if (maxheight > 0 &&
+		    (!utxos[i]->blockheight || *utxos[i]->blockheight > maxheight)) {
 			tal_arr_remove(&utxos, i);
 			continue;
 		}

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -165,6 +165,12 @@ def test_withdraw(node_factory, bitcoind):
     for utxo in utxos:
         assert utxo in vins
 
+    # Try passing unconfirmed utxos
+    unconfirmed_utxos = [l1.rpc.withdraw(l1.rpc.newaddr()["bech32"], 10**5)
+                         for _ in range(5)]
+    uutxos = [u["txid"] + ":0" for u in unconfirmed_utxos]
+    l1.rpc.withdraw(waddr, "all", minconf=0, utxos=uutxos)
+
 
 def test_minconf_withdraw(node_factory, bitcoind):
     """Issue 2518: ensure that ridiculous confirmation levels don't overflow


### PR DESCRIPTION
We were not taking into account the `minconf` param if the utxos were explicitly passed.