### PR TITLE
gossipd: fix compilation warnings with clang 10

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -648,7 +648,7 @@ static WARN_UNUSED_RESULT bool risk_add_fee(struct amount_msat *risk,
 
 	/* Won't overflow on add, just lose precision */
 	r = (double)riskbias + riskfactor * delay * msat.millisatoshis + risk->millisatoshis; /* Raw: to double */
-	if (r > UINT64_MAX)
+	if (r > (double)UINT64_MAX)
 		return false;
 	risk->millisatoshis = r; /* Raw: from double */
 	return true;
@@ -682,7 +682,7 @@ static bool fuzz_fee(u64 *fee,
 	 * 2*fuzz*rand              random number between 0.0 -> 2*fuzz
 	 * 2*fuzz*rand - fuzz       random number between -fuzz -> +fuzz
 	 */
-	fee_scale = 1.0 + (2.0 * fuzz * h / UINT64_MAX) - fuzz;
+	fee_scale = 1.0 + (2.0 * fuzz * h / (double)UINT64_MAX) - fuzz;
 	fuzzed_fee = *fee * fee_scale;
 	if (fee_scale > 1.0 && fuzzed_fee < *fee)
 		return false;


### PR DESCRIPTION
```
clang10 -DBINTOPKGLIBEXECDIR="\"../libexec/c-lightning\"" -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror -std=gnu11 -g -fstack-protector  -I ccan -I external/libwally-core/include/ -I external/libwally-core/src/secp256k1/include/ -I external/jsmn/ -I external/libbacktrace/ -I external/libbacktrace-build -I . -I/usr/local/include   -DCCAN_TAKE_DEBUG=1 -DCCAN_TAL_DEBUG=1 -DCCAN_JSON_OUT_DEBUG=1 -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS   -DBUILD_ELEMENTS=1 -DBINTOPKGLIBEXECDIR="\"../libexec/c-lightning\""  -c -o gossipd/routing.o gossipd/routing.c
gossipd/routing.c:651:10: error: implicit conversion from 'unsigned long' to 'double' changes value
      from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]
        if (r > UINT64_MAX)
              ~ ^~~~~~~~~~
```

It is ok to change the values because they are approximate anyway. Thus,
explicitly typecast to `double` to silence the warning without changing
behavior.

Changelog-None