### PR TITLE
Onion messages (EXPERIMENTAL)

### DIFF
--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -208,3 +208,20 @@ msgdata,channel_send_error,reason,wirestring,
 
 # Tell master channeld has sent the error message.
 msgtype,channel_send_error_reply,1108
+
+# Tell lightningd we got a onion message (for us, or to fwd)
+msgtype,got_onionmsg_to_us,1142
+msgdata,got_onionmsg_to_us,reply_blinding,?pubkey,
+msgdata,got_onionmsg_to_us,reply_path_len,u16,
+msgdata,got_onionmsg_to_us,reply_path,onionmsg_path,reply_path_len
+
+msgtype,got_onionmsg_forward,1143
+msgdata,got_onionmsg_forward,next_scid,?short_channel_id,
+msgdata,got_onionmsg_forward,next_node_id,?node_id,
+msgdata,got_onionmsg_forward,next_blinding,?pubkey,
+msgdata,got_onionmsg_forward,next_onion,u8,1366
+
+# Lightningd tells us to send a onion message.
+msgtype,send_onionmsg,1040
+msgdata,send_onionmsg,onion,u8,1366
+msgdata,send_onionmsg,blinding,?pubkey,

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1692,6 +1692,10 @@ static void peer_in(struct peer *peer, const u8 *msg)
 	case WIRE_SHUTDOWN:
 		handle_peer_shutdown(peer, msg);
 		return;
+#if EXPERIMENTAL_FEATURES
+	case WIRE_ONION_MESSAGE:
+		break;
+#endif
 
 	case WIRE_INIT:
 	case WIRE_OPEN_CHANNEL:

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,6 +1,10 @@
 DEVTOOLS_SRC := devtools/gen_print_wire.c devtools/gen_print_onion_wire.c devtools/print_wire.c
 DEVTOOLS_OBJS := $(DEVTOOLS_SRC:.c=.o)
 DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore devtools/mkcommit devtools/mkfunding devtools/mkclose devtools/mkgossip devtools/mkencoded devtools/checkchannels devtools/mkquery devtools/lightning-checkmessage
+ifeq ($(EXPERIMENTAL_FEATURES),1)
+DEVTOOLS += devtools/blindedpath
+endif
+
 DEVTOOLS_TOOL_SRC := $(DEVTOOLS:=.c)
 DEVTOOLS_TOOL_OBJS := $(DEVTOOLS_TOOL_SRC:.c=.o)
 
@@ -65,6 +69,8 @@ devtools/create-gossipstore.o: gossipd/gen_gossip_store.h
 devtools/onion.c: ccan/config.h
 
 devtools/onion: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/onion.o common/sphinx.o
+
+devtools/blindedpath: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/blindedpath.o common/sphinx.o
 
 devtools/gossipwith: $(DEVTOOLS_OBJS) $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o wire/gen_peer_wire.o devtools/gossipwith.o common/cryptomsg.o common/cryptomsg.o common/crypto_sync.o
 

--- a/devtools/blindedpath.c
+++ b/devtools/blindedpath.c
@@ -1,0 +1,316 @@
+#include "config.h"
+#include <assert.h>
+#include <bitcoin/privkey.h>
+#include <ccan/err/err.h>
+#include <ccan/mem/mem.h>
+#include <ccan/opt/opt.h>
+#include <ccan/str/hex/hex.h>
+#include <ccan/tal/tal.h>
+#include <common/hmac.h>
+#include <common/sphinx.h>
+#include <common/type_to_string.h>
+#include <common/utils.h>
+#include <common/version.h>
+#include <secp256k1.h>
+#include <secp256k1_ecdh.h>
+#include <sodium/crypto_auth_hmacsha256.h>
+#include <sodium/crypto_aead_chacha20poly1305.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Tal wrappers for opt. */
+static void *opt_allocfn(size_t size)
+{
+	return tal_arr_label(NULL, char, size, TAL_LABEL("opt_allocfn", ""));
+}
+
+static void *tal_reallocfn(void *ptr, size_t size)
+{
+	if (!ptr)
+		return opt_allocfn(size);
+	tal_resize_(&ptr, 1, size, false);
+	return ptr;
+}
+
+static void tal_freefn(void *ptr)
+{
+	tal_free(ptr);
+}
+
+/* E(i-1) = H(E(i) || ss(i)) * E(i) */
+static struct sha256 hash_e_and_ss(const struct pubkey *e,
+				   const struct secret *ss)
+{
+	u8 der[PUBKEY_CMPR_LEN];
+	struct sha256_ctx shactx;
+	struct sha256 h;
+
+	pubkey_to_der(der, e);
+	sha256_init(&shactx);
+	sha256_update(&shactx, der, sizeof(der));
+	sha256_update(&shactx, ss->data, sizeof(ss->data));
+	sha256_done(&shactx, &h);
+
+	return h;
+}
+
+/* E(i-1) = H(E(i) || ss(i)) * E(i) */
+static struct pubkey next_pubkey(const struct pubkey *pk,
+				 const struct sha256 *h)
+{
+	struct pubkey ret;
+
+	ret = *pk;
+	if (secp256k1_ec_pubkey_tweak_mul(secp256k1_ctx, &ret.pubkey, h->u.u8)
+	    != 1)
+		abort();
+
+	return ret;
+}
+
+/* e(i+1) = H(E(i) || ss(i)) * e(i) */
+static struct privkey next_privkey(const struct privkey *e,
+				   const struct sha256 *h)
+{
+	struct privkey ret;
+
+	ret = *e;
+	if (secp256k1_ec_privkey_tweak_mul(secp256k1_ctx, ret.secret.data,
+					   h->u.u8) != 1)
+		abort();
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	bool first = false;
+
+	setup_locale();
+
+	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY |
+						 SECP256K1_CONTEXT_SIGN);
+
+	opt_set_alloc(opt_allocfn, tal_reallocfn, tal_freefn);
+	opt_register_noarg("--help|-h", opt_usage_and_exit,
+			   "\n\n\tcreate <nodeid>[/<scid>]...\n"
+			   "\tunwrap <privkey> <onion> <blinding>\n",
+			   "Show this message");
+	opt_register_noarg("--first-node", opt_set_bool, &first,
+			   "Don't try to tweak key to unwrap onion");
+	opt_register_version();
+
+	opt_parse(&argc, argv, opt_log_stderr_exit);
+	setup_tmpctx();
+
+	if (argc < 2)
+		errx(1, "You must specify create or unwrap");
+	if (streq(argv[1], "create")) {
+		struct privkey e;
+		struct pubkey *pk_e, *b, *nodes;
+		struct secret *rho;
+		size_t num = argc - 2;
+
+		if (argc < 3)
+			errx(1, "create requires at least one nodeid");
+
+		/* P(i) */
+		nodes = tal_arr(tmpctx, struct pubkey, num);
+		/* E(i) */
+		pk_e = tal_arr(tmpctx, struct pubkey, num);
+		/* B(i) */
+		b = tal_arr(tmpctx, struct pubkey, num);
+		/* rho(i) */
+		rho = tal_arr(tmpctx, struct secret, num);
+
+		/* Randomness, chosen with a fair dice roll! */
+		memset(&e, 6, sizeof(e));
+		if (!pubkey_from_privkey(&e, &pk_e[0]))
+			abort();
+
+		for (size_t i = 0; i < num; i++) {
+			struct secret ss;
+			struct secret hmac;
+			struct sha256 h;
+
+			if (!pubkey_from_hexstr(argv[2+i],
+						strcspn(argv[2+i], "/"),
+						&nodes[i]))
+				errx(1, "%s not a valid pubkey", argv[2+i]);
+
+			if (secp256k1_ecdh(secp256k1_ctx, ss.data,
+					   &nodes[i].pubkey, e.secret.data, NULL, NULL) != 1)
+				abort();
+
+			subkey_from_hmac("blinded_node_id", &ss, &hmac);
+			b[i] = nodes[i];
+			if (i != 0) {
+				if (secp256k1_ec_pubkey_tweak_mul(secp256k1_ctx,
+					  &b[i].pubkey, hmac.data) != 1)
+					abort();
+			}
+			subkey_from_hmac("rho", &ss, &rho[i]);
+			h = hash_e_and_ss(&pk_e[i], &ss);
+			if (i != num-1)
+				pk_e[i+1] = next_pubkey(&pk_e[i], &h);
+			e = next_privkey(&e, &h);
+		}
+
+		/* Print initial blinding factor */
+		printf("Blinding: %s\n",
+		       type_to_string(tmpctx, struct pubkey, &pk_e[0]));
+
+		for (size_t i = 0; i < num - 1; i++) {
+			u8 *p;
+			u8 buf[BIGSIZE_MAX_LEN];
+			const unsigned char npub[crypto_aead_chacha20poly1305_ietf_NPUBBYTES] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+			struct tlv_onionmsg_payload *inner, *outer;
+			int ret;
+
+			/* Inner is encrypted */
+			inner = tlv_onionmsg_payload_new(tmpctx);
+			/* FIXME: Use /scid for encblob if specified */
+			inner->next_node_id = tal(inner, struct tlv_onionmsg_payload_next_node_id);
+			inner->next_node_id->node_id = nodes[i+1];
+			p = tal_arr(tmpctx, u8, 0);
+			towire_encmsg_tlvs(&p, inner);
+
+			outer = tlv_onionmsg_payload_new(tmpctx);
+			outer->enctlv = tal(outer, struct tlv_onionmsg_payload_enctlv);
+			outer->enctlv->enctlv = tal_arr(tmpctx, u8, tal_count(p)
+				      + crypto_aead_chacha20poly1305_ietf_ABYTES);
+			ret = crypto_aead_chacha20poly1305_ietf_encrypt(outer->enctlv->enctlv, NULL,
+									p,
+									tal_bytelen(p),
+									NULL, 0,
+									NULL, npub,
+									rho[i].data);
+			assert(ret == 0);
+
+			p = tal_arr(tmpctx, u8, 0);
+			towire_onionmsg_payload(&p, outer);
+			ret = bigsize_put(buf, tal_bytelen(p));
+
+			/* devtools/onion wants length explicitly prepended */
+			printf("%s/%.*s%s ",
+			       type_to_string(tmpctx, struct pubkey, &b[i]),
+			       ret * 2,
+			       tal_hexstr(tmpctx, buf, ret),
+			       tal_hex(tmpctx, p));
+		}
+		/* No payload for last node */
+		printf("%s/00\n",
+		       type_to_string(tmpctx, struct pubkey, &b[num-1]));
+	} else if (streq(argv[1], "unwrap")) {
+		struct privkey privkey;
+		struct pubkey blinding;
+		u8 onion[TOTAL_PACKET_SIZE], *dec;
+		struct onionpacket op;
+		struct secret ss, onion_ss;
+		struct secret hmac, rho;
+		struct route_step *rs;
+		const u8 *cursor;
+		struct tlv_onionmsg_payload *outer;
+		size_t max, len;
+		struct pubkey res;
+		struct sha256 h;
+		int ret;
+		const unsigned char npub[crypto_aead_chacha20poly1305_ietf_NPUBBYTES] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+		if (argc != 5)
+			errx(1, "unwrap requires privkey, onion and blinding");
+
+		if (!hex_decode(argv[2], strlen(argv[2]), &privkey,
+				sizeof(privkey)))
+			errx(1, "Invalid private key hex '%s'", argv[2]);
+
+		if (!hex_decode(argv[3], strlen(argv[3]), onion,
+				sizeof(onion)))
+			errx(1, "Invalid onion %s", argv[3]);
+
+		if (!pubkey_from_hexstr(argv[4], strlen(argv[4]), &blinding))
+			errx(1, "Invalid blinding %s", argv[4]);
+
+		if (parse_onionpacket(onion, sizeof(onion), &op) != 0)
+			errx(1, "Unparsable onion");
+
+		/*   ss(r) = H(k(r) * E(r)) */
+		if (secp256k1_ecdh(secp256k1_ctx, ss.data, &blinding.pubkey,
+				   privkey.secret.data, NULL, NULL) != 1)
+			abort();
+
+		subkey_from_hmac("rho", &ss, &rho);
+
+		/* b(i) = HMAC256("blinded_node_id", ss(i)) * k(i) */
+		subkey_from_hmac("blinded_node_id", &ss, &hmac);
+
+		/* We instead tweak the *ephemeral* key from the onion
+		 * and use our raw privkey: this models how lightningd
+		 * will do it, since hsmd knows only how to ECDH with
+		 * our real key */
+		res = op.ephemeralkey;
+		if (!first) {
+			if (secp256k1_ec_pubkey_tweak_mul(secp256k1_ctx,
+							  &res.pubkey,
+							  hmac.data) != 1)
+				abort();
+		}
+
+		if (secp256k1_ecdh(secp256k1_ctx, onion_ss.data,
+				   &res.pubkey,
+				   privkey.secret.data, NULL, NULL) != 1)
+			abort();
+
+		rs = process_onionpacket(tmpctx, &op, &onion_ss, NULL, 0, false);
+		if (!rs)
+			errx(1, "Could not process onionpacket");
+
+		cursor = rs->raw_payload;
+		max = tal_bytelen(cursor);
+		len = fromwire_bigsize(&cursor, &max);
+
+		/* Always true since we're non-legacy */
+		assert(len == max);
+		outer = tlv_onionmsg_payload_new(tmpctx);
+		if (!fromwire_onionmsg_payload(&cursor, &max, outer))
+			errx(1, "Invalid payload %s",
+			     tal_hex(tmpctx, rs->raw_payload));
+
+		if (rs->nextcase == ONION_END) {
+			printf("TERMINAL\n");
+			return 0;
+		}
+
+		/* Look for enctlv */
+		if (!outer->enctlv)
+			errx(1, "No enctlv field");
+
+		if (tal_bytelen(outer->enctlv->enctlv)
+		    < crypto_aead_chacha20poly1305_ietf_ABYTES)
+			errx(1, "enctlv field too short");
+
+		dec = tal_arr(tmpctx, u8,
+			      tal_bytelen(outer->enctlv->enctlv)
+			      - crypto_aead_chacha20poly1305_ietf_ABYTES);
+		ret = crypto_aead_chacha20poly1305_ietf_decrypt(dec, NULL,
+								NULL,
+								outer->enctlv->enctlv,
+								tal_bytelen(outer->enctlv->enctlv),
+								NULL, 0,
+								npub,
+								rho.data);
+		if (ret != 0)
+			errx(1, "Failed to decrypt enctlv field");
+
+		printf("Contents: %s\n", tal_hex(tmpctx, dec));
+
+		/* E(i-1) = H(E(i) || ss(i)) * E(i) */
+		h = hash_e_and_ss(&blinding, &ss);
+		res = next_pubkey(&blinding, &h);
+		printf("Next blinding: %s\n",
+		       type_to_string(tmpctx, struct pubkey, &res));
+		printf("Next onion: %s\n", tal_hex(tmpctx, serialize_onionpacket(tmpctx, rs->next)));
+	} else
+		errx(1, "Either create or unwrap!");
+}

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -488,6 +488,9 @@ static struct io_plan *peer_msg_in(struct io_conn *conn,
 	case WIRE_CHANNEL_REESTABLISH:
 	case WIRE_ANNOUNCEMENT_SIGNATURES:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
+#if EXPERIMENTAL_FEATURES
+	case WIRE_ONION_MESSAGE:
+#endif
 		status_broken("peer %s: relayed unexpected msg of type %s",
 			      type_to_string(tmpctx, struct node_id, &peer->id),
 			      wire_type_name(fromwire_peektype(msg)));

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -75,6 +75,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/channel_control.c		\
 	lightningd/closing_control.c		\
 	lightningd/connect_control.c		\
+	lightningd/onion_message.c		\
 	lightningd/gossip_control.c		\
 	lightningd/gossip_msg.c			\
 	lightningd/hsm_control.c		\

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -21,6 +21,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/onion_message.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
 #include <wire/gen_common_wire.h>
@@ -319,11 +320,17 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_CHANNEL_SEND_ERROR_REPLY:
 		handle_error_channel(sd->channel, msg);
 		break;
+#if EXPERIMENTAL_FEATURES
+	case WIRE_GOT_ONIONMSG_TO_US:
+		handle_onionmsg_to_us(sd->channel, msg);
+		break;
+	case WIRE_GOT_ONIONMSG_FORWARD:
+		handle_onionmsg_forward(sd->channel, msg);
+		break;
+#else
 	case WIRE_GOT_ONIONMSG_TO_US:
 	case WIRE_GOT_ONIONMSG_FORWARD:
-		/* FIXME */
-		break;
-
+#endif
 	/* And we never get these from channeld. */
 	case WIRE_CHANNEL_INIT:
 	case WIRE_CHANNEL_FUNDING_DEPTH:

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -319,6 +319,10 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_CHANNEL_SEND_ERROR_REPLY:
 		handle_error_channel(sd->channel, msg);
 		break;
+	case WIRE_GOT_ONIONMSG_TO_US:
+	case WIRE_GOT_ONIONMSG_FORWARD:
+		/* FIXME */
+		break;
 
 	/* And we never get these from channeld. */
 	case WIRE_CHANNEL_INIT:
@@ -334,7 +338,8 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_CHANNEL_FEERATES:
 	case WIRE_CHANNEL_SPECIFIC_FEERATES:
 	case WIRE_CHANNEL_DEV_MEMLEAK:
-	/* Replies go to requests. */
+	case WIRE_SEND_ONIONMSG:
+		/* Replies go to requests. */
 	case WIRE_CHANNEL_OFFER_HTLC_REPLY:
 	case WIRE_CHANNEL_DEV_REENABLE_COMMIT_REPLY:
 	case WIRE_CHANNEL_DEV_MEMLEAK_REPLY:

--- a/lightningd/onion_message.c
+++ b/lightningd/onion_message.c
@@ -1,4 +1,5 @@
 #include <channeld/gen_channel_wire.h>
+#include <common/json_helpers.h>
 #include <lightningd/channel.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/onion_message.h>
@@ -84,4 +85,242 @@ void handle_onionmsg_forward(struct channel *channel, const u8 *msg)
 	make_peer_send(ld, outchan,
 		       take(towire_send_onionmsg(NULL, onion, next_blinding)));
 }
+
+struct hop {
+	struct pubkey id;
+	struct short_channel_id *scid;
+	struct pubkey *blinding;
+	u8 *enctlv;
+	u8 *rawtlv;
+};
+
+static struct command_result *param_hops(struct command *cmd,
+					 const char *name,
+					 const char *buffer,
+					 const jsmntok_t *tok,
+					 struct hop **hops)
+{
+	size_t i;
+	const jsmntok_t *t;
+
+	if (tok->type != JSMN_ARRAY || tok->size == 0)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s must be an (non-empty) array", name);
+
+	*hops = tal_arr(cmd, struct hop, tok->size);
+	json_for_each_arr(i, t, tok) {
+		const jsmntok_t *tid, *tscid, *tblinding, *tenctlv, *trawtlv;
+
+		tid = json_get_member(buffer, t, "id");
+		if (!tid)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s[%zu] does not have 'id'",
+					    name, i);
+		tscid = json_get_member(buffer, t, "short_channel_id");
+		tblinding = json_get_member(buffer, t, "blinding");
+		tenctlv = json_get_member(buffer, t, "enctlv");
+		trawtlv = json_get_member(buffer, t, "rawtlv");
+
+		if (trawtlv && (tscid || tblinding || tenctlv))
+		    return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					"%s[%zu] has 'rawtlv' with other fields",
+					name, i);
+
+		if (tblinding) {
+			(*hops)[i].blinding = tal(*hops, struct pubkey);
+			if (!json_to_pubkey(buffer, tblinding,
+					    (*hops)[i].blinding))
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+						    "%s[%zu] 'blinding' is invalid", name, i);
+		} else
+			(*hops)[i].blinding = NULL;
+
+		if (!json_to_pubkey(buffer, tid, &(*hops)[i].id))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s[%zu] 'id' is invalid", name, i);
+		if (tscid) {
+			(*hops)[i].scid = tal(*hops, struct short_channel_id);
+			if (!json_to_short_channel_id(buffer, tscid,
+						      (*hops)[i].scid))
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+						    "%s[%zu] 'short_channel_id' is invalid", name, i);
+		} else
+			(*hops)[i].scid = NULL;
+
+		if (tenctlv) {
+			(*hops)[i].enctlv =
+				json_tok_bin_from_hex(*hops, buffer, tenctlv);
+			if (!(*hops)[i].enctlv)
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+						    "%s[%zu] 'enctlv' is invalid", name, i);
+		} else
+			(*hops)[i].enctlv = NULL;
+
+		if (trawtlv) {
+			(*hops)[i].rawtlv =
+				json_tok_bin_from_hex(*hops, buffer, trawtlv);
+			if (!(*hops)[i].rawtlv)
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+						    "%s[%zu] 'rawtlv' is invalid", name, i);
+		} else
+			(*hops)[i].rawtlv = NULL;
+	}
+	return NULL;
+}
+
+static struct command_result *param_reply_path(struct command *cmd,
+					       const char *name,
+					       const char *buffer,
+					       const jsmntok_t *tok,
+					       struct tlv_onionmsg_payload_reply_path **reply_path)
+{
+	const jsmntok_t *tblinding, *tpath, *t;
+	size_t i;
+
+	*reply_path = tal(cmd, struct tlv_onionmsg_payload_reply_path);
+	tblinding = json_get_member(buffer, tok, "blinding");
+	if (!tblinding)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s has no 'blinding'", name);
+	if (!json_to_pubkey(buffer, tblinding, &(*reply_path)->blinding))
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s 'blinding' invalid pubkey", name);
+
+	tpath = json_get_member(buffer, tok, "path");
+	if (!tpath || tpath->type != JSMN_ARRAY)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s has no 'path' array", name);
+
+	(*reply_path)->path = tal_arr(*reply_path, struct onionmsg_path *,
+				      tpath->size);
+	json_for_each_arr(i, t, tpath) {
+		const jsmntok_t *tid, *tenctlv;
+		struct onionmsg_path *path;
+
+		path = (*reply_path)->path[i] = tal((*reply_path)->path,
+						    struct onionmsg_path);
+		tid = json_get_member(buffer, t, "id");
+		if (!tid)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s path[%zu] 'id' is missing",
+					    name, i);
+		if (!json_to_pubkey(buffer, tid, &path->node_id))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s path[%zu] 'id' is invalid",
+					    name, i);
+
+		tenctlv = json_get_member(buffer, t, "enctlv");
+		if (!tenctlv) {
+			/* Optional for final destination */
+			if (i != tpath->size - 1)
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s path[%zu] 'enctlv' is missing",
+					    name, i);
+			path->enctlv = NULL;
+		} else {
+			path->enctlv = json_tok_bin_from_hex(path,
+							     buffer, tenctlv);
+			if (!path->enctlv)
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s path[%zu] 'enctlv' is invalid",
+					    name, i);
+		}
+	}
+
+	return NULL;
+}
+
+/* Generate ->rawtlv if not already supplied. */
+static void populate_tlvs(struct hop *hops,
+			  struct tlv_onionmsg_payload_reply_path *reply_path)
+{
+	for (size_t i = 0; i < tal_count(hops); i++) {
+		struct tlv_onionmsg_payload *tlv;
+
+		if (hops[i].rawtlv)
+			continue;
+
+		tlv = tlv_onionmsg_payload_new(tmpctx);
+		/* If they don't give scid, use next node id */
+		if (hops[i].scid) {
+			tlv->next_short_channel_id = tal(tlv, struct tlv_onionmsg_payload_next_short_channel_id);
+			tlv->next_short_channel_id->short_channel_id = *hops[i].scid;
+		} else if (i != tal_count(hops)-1) {
+			tlv->next_node_id = tal(tlv, struct tlv_onionmsg_payload_next_node_id);
+			tlv->next_node_id->node_id = hops[i+1].id;
+		}
+		if (hops[i].blinding) {
+			tlv->blinding = tal(tlv, struct tlv_onionmsg_payload_blinding);
+			tlv->blinding->blinding = *hops[i].blinding;
+		}
+		if (hops[i].enctlv) {
+			tlv->enctlv = tal(tlv, struct tlv_onionmsg_payload_enctlv);
+			tlv->enctlv->enctlv = hops[i].enctlv;
+		}
+
+		if (i == tal_count(hops)-1 && reply_path)
+			tlv->reply_path = reply_path;
+
+		hops[i].rawtlv = tal_arr(hops, u8, 0);
+		towire_onionmsg_payload(&hops[i].rawtlv, tlv);
+	}
+}
+
+static struct command_result *json_send_onion_message(struct command *cmd,
+						      const char *buffer,
+						      const jsmntok_t *obj UNNEEDED,
+						      const jsmntok_t *params)
+{
+	struct hop *hops;
+	struct tlv_onionmsg_payload_reply_path *reply_path;
+	struct sphinx_path *sphinx_path;
+	struct onionpacket *op;
+	struct secret *path_secrets;
+	struct channel *first_hop;
+	struct node_id first_id;
+
+	if (!param(cmd, buffer, params,
+		   p_req("hops", param_hops, &hops),
+		   p_opt("reply_path", param_reply_path, &reply_path),
+		   NULL))
+		return command_param_failed();
+
+	/* FIXME: Allow sending to non-channel peers! */
+	node_id_from_pubkey(&first_id, &hops[0].id);
+	first_hop = active_channel_by_id(cmd->ld, &first_id, NULL);
+	if (!first_hop)
+		return command_fail(cmd, LIGHTNINGD, "Unknown first peer");
+
+	/* Create an onion which encodes this. */
+	populate_tlvs(hops, reply_path);
+	sphinx_path = sphinx_path_new(cmd, NULL);
+	for (size_t i = 0; i < tal_count(hops); i++) {
+		/* FIXME: Remove legacy, then length prefix can be removed! */
+		u8 *tlv_with_len = tal_arr(NULL, u8, 0);
+		towire_bigsize(&tlv_with_len, tal_bytelen(hops[i].rawtlv));
+		towire_u8_array(&tlv_with_len,
+				hops[i].rawtlv, tal_bytelen(hops[i].rawtlv));
+		sphinx_add_hop(sphinx_path, &hops[i].id, take(tlv_with_len));
+	}
+	op = create_onionpacket(tmpctx, sphinx_path, &path_secrets);
+	if (!op)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Creating onion failed (tlvs too long?)");
+
+	if (!make_peer_send(cmd->ld, first_hop,
+			    take(towire_send_onionmsg(NULL,
+						      serialize_onionpacket(tmpctx, op),
+						      NULL))))
+		return command_fail(cmd, LIGHTNINGD, "First peer not ready");
+
+	return command_success(cmd, json_stream_success(cmd));
+}
+
+static const struct json_command send_onion_message_command = {
+	"sendonionmessage",
+	"utility",
+	json_send_onion_message,
+	"Send message over {hops} (id, [short_channel_id], [blinding], [enctlv], [rawtlv]) with optional {reply_path} (blinding, path[id, enctlv])"
+};
+AUTODATA(json_command, &send_onion_message_command);
 #endif /* EXPERIMENTAL_FEATURES */

--- a/lightningd/onion_message.c
+++ b/lightningd/onion_message.c
@@ -1,0 +1,87 @@
+#include <channeld/gen_channel_wire.h>
+#include <lightningd/channel.h>
+#include <lightningd/lightningd.h>
+#include <lightningd/onion_message.h>
+#include <lightningd/peer_control.h>
+#include <lightningd/subd.h>
+
+#if EXPERIMENTAL_FEATURES
+/* Returns false if we can't tell it */
+static bool make_peer_send(struct lightningd *ld,
+			   struct channel *dst, const u8 *msg TAKES)
+{
+	/* Take ownership of msg (noop if it's taken) */
+	msg = tal_dup_talarr(tmpctx, u8, msg);
+
+	if (!dst) {
+		log_debug(ld->log, "Can't send %s: no channel",
+			  channel_wire_type_name(fromwire_peektype(msg)));
+		return false;
+	}
+
+	if (!dst->owner) {
+		log_debug(ld->log, "Can't send %s: not connected",
+			  channel_wire_type_name(fromwire_peektype(msg)));
+		return false;
+	}
+
+	/* FIXME: We should allow this for closingd too, and we should
+	 * allow incoming via openingd!. */
+	if (!streq(dst->owner->name, "channeld")) {
+		log_debug(ld->log, "Can't send %s: owned by %s",
+			  channel_wire_type_name(fromwire_peektype(msg)),
+			  dst->owner->name);
+		return false;
+	}
+	subd_send_msg(dst->owner, take(msg));
+	return true;
+}
+
+void handle_onionmsg_to_us(struct channel *channel, const u8 *msg)
+{
+	struct pubkey *reply_blinding;
+	struct onionmsg_path **reply_path;
+
+	if (!fromwire_got_onionmsg_to_us(msg, msg,
+					 &reply_blinding, &reply_path)) {
+		channel_internal_error(channel, "bad got_onionmsg_tous: %s",
+				       tal_hex(tmpctx, msg));
+		return;
+	}
+
+	log_info(channel->log, "Got onionmsg%s%s",
+		 reply_blinding ? " reply_blinding": "",
+		 reply_path ? " reply_path": "");
+}
+
+void handle_onionmsg_forward(struct channel *channel, const u8 *msg)
+{
+	struct lightningd *ld = channel->peer->ld;
+	struct short_channel_id *next_scid;
+	struct node_id *next_node;
+	struct pubkey *next_blinding;
+	u8 onion[TOTAL_PACKET_SIZE];
+	struct channel *outchan;
+
+	if (!fromwire_got_onionmsg_forward(msg, msg, &next_scid, &next_node,
+					   &next_blinding, onion)) {
+		channel_internal_error(channel, "bad got_onionmsg_forward: %s",
+				       tal_hex(tmpctx, msg));
+		return;
+	}
+
+	if (next_scid)
+		outchan = active_channel_by_scid(ld, next_scid);
+	else if (next_node) {
+		struct peer *p = peer_by_id(ld, next_node);
+		if (p)
+			outchan = peer_active_channel(p);
+		else
+			outchan = NULL;
+	} else
+		outchan = NULL;
+
+	make_peer_send(ld, outchan,
+		       take(towire_send_onionmsg(NULL, onion, next_blinding)));
+}
+#endif /* EXPERIMENTAL_FEATURES */

--- a/lightningd/onion_message.h
+++ b/lightningd/onion_message.h
@@ -1,0 +1,11 @@
+#ifndef LIGHTNING_LIGHTNINGD_ONION_MESSAGE_H
+#define LIGHTNING_LIGHTNINGD_ONION_MESSAGE_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+
+struct channel;
+
+void handle_onionmsg_to_us(struct channel *channel, const u8 *msg);
+void handle_onionmsg_forward(struct channel *channel, const u8 *msg);
+
+#endif /* LIGHTNING_LIGHTNINGD_ONION_MESSAGE_H */

--- a/tests/plugins/onionmessage-reply.py
+++ b/tests/plugins/onionmessage-reply.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+This plugin is used to test the `onion_message` hook.
+"""
+from lightning import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("onion_message")
+def on_onion_message(plugin, onion_message, **kwargs):
+    if 'reply_path' not in onion_message:
+        plugin.log("no reply path")
+        return
+
+    plugin.rpc.call('sendonionmessage', [onion_message['reply_path']])
+    plugin.log("Sent reply via {}".format(onion_message['reply_path']))
+    return {"result": "continue"}
+
+
+plugin.run()

--- a/tools/check-spelling.sh
+++ b/tools/check-spelling.sh
@@ -6,7 +6,7 @@ if git --no-pager grep -nHiE 'l[ightn]{6}g|l[ightn]{8}g|ilghtning|lgihtning|lihg
     exit 1
 fi
 
-if git --no-pager grep -nHiE 'ctlv' -- . ':!tools/check-spelling.sh'; then
+if git --no-pager grep -nHiE 'ctlv' | grep -v 'enctlv' -- . ':!tools/check-spelling.sh'; then
     echo "It's check lock time verify, not check time lock verify!" >&2
     exit 1
 fi

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -226,6 +226,7 @@ class Type(FieldSet):
         'onionreply',
         'witscript',
         'feature_set',
+        'onionmsg_path',
     ]
 
     # Some BOLT types are re-typed based on their field name

--- a/wire/extracted_onion_experimental_1b1c9a71038bd72453cabefd3ace17ce8b8dd96e
+++ b/wire/extracted_onion_experimental_1b1c9a71038bd72453cabefd3ace17ce8b8dd96e
@@ -1,0 +1,28 @@
+--- wire/extracted_onion_wire_csv	2020-03-25 10:24:12.861645774 +1030
++++ -	2020-03-26 13:47:13.498294435 +1030
+@@ -8,6 +8,25 @@
+ tlvtype,tlv_payload,payment_data,8
+ tlvdata,tlv_payload,payment_data,payment_secret,byte,32
+ tlvdata,tlv_payload,payment_data,total_msat,tu64,
++tlvtype,onionmsg_payload,next_node_id,4
++tlvdata,onionmsg_payload,next_node_id,node_id,point,
++tlvtype,onionmsg_payload,next_short_channel_id,6
++tlvdata,onionmsg_payload,next_short_channel_id,short_channel_id,short_channel_id,
++tlvtype,onionmsg_payload,reply_path,8
++tlvdata,onionmsg_payload,reply_path,blinding,point,
++tlvdata,onionmsg_payload,reply_path,path,onionmsg_path,...
++tlvtype,onionmsg_payload,enctlv,10
++tlvdata,onionmsg_payload,enctlv,enctlv,byte,...
++tlvtype,onionmsg_payload,blinding,12
++tlvdata,onionmsg_payload,blinding,blinding,point,
++tlvtype,encmsg_tlvs,next_node_id,4
++tlvdata,encmsg_tlvs,next_node_id,node_id,point,
++tlvtype,encmsg_tlvs,next_short_channel_id,6
++tlvdata,encmsg_tlvs,next_short_channel_id,short_channel_id,short_channel_id,
++subtype,onionmsg_path
++subtypedata,onionmsg_path,node_id,point,
++subtypedata,onionmsg_path,enclen,u16,
++subtypedata,onionmsg_path,enctlv,byte,enclen
+ msgtype,invalid_realm,PERM|1
+ msgtype,temporary_node_failure,NODE|2
+ msgtype,permanent_node_failure,PERM|NODE|2

--- a/wire/extracted_peer_experimental_1b1c9a71038bd72453cabefd3ace17ce8b8dd96e
+++ b/wire/extracted_peer_experimental_1b1c9a71038bd72453cabefd3ace17ce8b8dd96e
@@ -1,0 +1,11 @@
+--- wire/extracted_peer_wire_csv	2020-03-11 10:30:35.744376417 +1030
++++ -	2020-03-26 13:47:13.409755567 +1030
+@@ -211,3 +211,8 @@
+ msgdata,gossip_timestamp_filter,chain_hash,chain_hash,
+ msgdata,gossip_timestamp_filter,first_timestamp,u32,
+ msgdata,gossip_timestamp_filter,timestamp_range,u32,
++msgtype,onion_message,385,option_onion_messages
++msgdata,onion_message,onionmsg,byte,1366
++msgdata,onion_message,onion_message_tlvs,onion_message_tlvs,
++tlvtype,onion_message_tlvs,blinding,2
++tlvdata,onion_message_tlvs,blinding,blinding,point,

--- a/wire/peer_wire.c
+++ b/wire/peer_wire.c
@@ -31,6 +31,9 @@ static bool unknown_type(enum wire_type t)
 	case WIRE_QUERY_CHANNEL_RANGE:
 	case WIRE_REPLY_CHANNEL_RANGE:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
+#if EXPERIMENTAL_FEATURES
+	case WIRE_ONION_MESSAGE:
+#endif
 		return false;
 	}
 	return true;
@@ -68,6 +71,9 @@ bool is_msg_for_gossipd(const u8 *cursor)
 	case WIRE_CHANNEL_REESTABLISH:
 	case WIRE_ANNOUNCEMENT_SIGNATURES:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
+#if EXPERIMENTAL_FEATURES
+	case WIRE_ONION_MESSAGE:
+#endif
 		break;
 	}
 	return false;

--- a/wire/wire.h
+++ b/wire/wire.h
@@ -153,4 +153,18 @@ struct witscript *fromwire_witscript(const tal_t *ctx,
 void fromwire_chainparams(const u8 **cursor, size_t *max,
 			  const struct chainparams **chainparams);
 
+#if !EXPERIMENTAL_FEATURES
+/* Stubs, as this subtype is only defined when EXPERIMENTAL_FEATURES */
+struct onionmsg_path;
+
+static inline void towire_onionmsg_path(u8 **p, const struct onionmsg_path *onionmsg_path)
+{
+}
+
+static inline struct onionmsg_path *
+fromwire_onionmsg_path(const tal_t *ctx, const u8 **cursor, size_t *plen)
+{
+	return NULL;
+}
+#endif /* EXPERIMENTAL_FEATURES */
 #endif /* LIGHTNING_WIRE_WIRE_H */


### PR DESCRIPTION
Based on #3599 this implements simple messaging across the lightning network.  There are no contents defined yet, except for those required for routing and replies, but the intent is to use this mechanism for offers.

The specification for messaging is in https://github.com/lightningnetwork/lightning-rfc/pull/759 but the blinded path implementation is stolen straight from https://github.com/lightningnetwork/lightning-rfc/blob/route-blinding/proposals/route-blinding.md.

We use route blinding for two things: one, you can place them inside an onion to send to an otherwise unknown destination, and also you can include a path for the recipient to use to reply.  Both are implemented here.

TODO:
1. We need to add a feature bit, so you know how to route these.
2. We still need to implement decoy decoding: if we use a decoy route, we need to check that it's actually included as specified.

Changelog-None