### PR TITLE
Enable watchtower plugins via the `commitment_revocation` hook

### DIFF
--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -69,6 +69,7 @@ CHANNELD_COMMON_OBJS :=				\
 	common/onionreply.o			\
 	common/peer_billboard.o			\
 	common/peer_failed.o			\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/permute_tx.o			\
 	common/ping.o				\

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -100,9 +100,12 @@ msgdata,channel_fail_htlc,failed_htlc,failed_htlc,
 msgtype,channel_got_funding_locked,1019
 msgdata,channel_got_funding_locked,next_per_commit_point,pubkey,
 
+#include <common/penalty_base.h>
+
 # When we send a commitment_signed message, tell master.
 msgtype,channel_sending_commitsig,1020
 msgdata,channel_sending_commitsig,commitnum,u64,
+msgdata,channel_sending_commitsig,pbase,?penalty_base,
 msgdata,channel_sending_commitsig,fee_states,fee_states,
 # SENT_ADD_COMMIT, SENT_REMOVE_ACK_COMMIT, SENT_ADD_ACK_COMMIT, SENT_REMOVE_COMMIT
 msgdata,channel_sending_commitsig,num_changed,u16,
@@ -113,6 +116,11 @@ msgdata,channel_sending_commitsig,htlc_sigs,secp256k1_ecdsa_signature,num_htlc_s
 
 # Wait for reply, to make sure it's on disk before we send commit.
 msgtype,channel_sending_commitsig_reply,1120
+
+# When we reconnect and resend the commitment we also need to tell the master
+# the commitment details so it can create the penalty once we get the revoke.
+msgtype,channel_resending_commitsig,1130
+msgdata,channel_resending_commitsig,pbase,?penalty_base,
 
 # When we have a commitment_signed message, tell master to remember.
 msgtype,channel_got_commitsig,1021

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -94,6 +94,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			     struct amount_msat other_pay,
 			     const struct htlc **htlcs,
 			     const struct htlc ***htlcmap,
+			     struct wally_tx_output *direct_outputs[NUM_SIDES],
 			     u64 obscured_commitment_number,
 			     enum side side)
 {
@@ -102,7 +103,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	struct bitcoin_tx *tx;
 	size_t i, n, untrimmed;
 	u32 *cltvs;
-
+	struct htlc *dummy_to_local = (struct htlc *)0x01,
+		*dummy_to_remote = (struct htlc *)0x02;
 	if (!amount_msat_add(&total_pay, self_pay, other_pay))
 		abort();
 	assert(!amount_msat_greater_sat(total_pay, funding));
@@ -215,7 +217,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		struct amount_sat amount = amount_msat_to_sat_round_down(self_pay);
 
 		bitcoin_tx_add_output(tx, p2wsh, amount);
-		(*htlcmap)[n] = NULL;
+		/* Add a dummy entry to the htlcmap so we can recognize it later */
+		(*htlcmap)[n] = direct_outputs ? dummy_to_local : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
 		SUPERVERBOSE("# to-local amount %s wscript %s\n",
@@ -248,7 +251,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		 */
 		int pos = bitcoin_tx_add_output(tx, p2wpkh, amount);
 		assert(pos == n);
-		(*htlcmap)[n] = NULL;
+		(*htlcmap)[n] = direct_outputs ? dummy_to_remote : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
 		SUPERVERBOSE("# to-remote amount %s P2WPKH(%s)\n",
@@ -304,6 +307,20 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	 */
 	u32 sequence = (0x80000000 | ((obscured_commitment_number>>24) & 0xFFFFFF));
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
+
+	/* Identify the direct outputs (to_us, to_them). */
+	if (direct_outputs != NULL) {
+		direct_outputs[LOCAL] = direct_outputs[REMOTE] = NULL;
+		for (size_t i = 0; i < tx->wtx->num_outputs; i++) {
+			if ((*htlcmap)[i] == dummy_to_local) {
+				(*htlcmap)[i] = NULL;
+				direct_outputs[LOCAL] = tx->wtx->outputs + i;
+			} else if ((*htlcmap)[i] == dummy_to_remote) {
+				(*htlcmap)[i] = NULL;
+				direct_outputs[REMOTE] = tx->wtx->outputs + i;
+			}
+		}
+	}
 
 	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));

--- a/channeld/commit_tx.h
+++ b/channeld/commit_tx.h
@@ -37,6 +37,7 @@ size_t commit_tx_num_untrimmed(const struct htlc **htlcs,
  * @htlcs: tal_arr of htlcs committed by transaction (some may be trimmed)
  * @htlc_map: outputed map of outnum->HTLC (NULL for direct outputs).
  * @obscured_commitment_number: number to encode in commitment transaction
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @side: side to generate commitment transaction for.
  *
  * We need to be able to generate the remote side's tx to create signatures,
@@ -56,6 +57,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			     struct amount_msat other_pay,
 			     const struct htlc **htlcs,
 			     const struct htlc ***htlcmap,
+			     struct wally_tx_output *direct_outputs[NUM_SIDES],
 			     u64 obscured_commitment_number,
 			     enum side side);
 

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -272,6 +272,7 @@ static void add_htlcs(struct bitcoin_tx ***txs,
 /* FIXME: We could cache these. */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				const struct htlc ***htlcmap,
+				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,
@@ -299,8 +300,9 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 	    channel->config[!side].to_self_delay, &keyset,
 	    channel_feerate(channel, side),
 	    channel->config[side].dust_limit, channel->view[side].owed[side],
-	    channel->view[side].owed[!side], committed, htlcmap,
-	    commitment_number ^ channel->commitment_number_obscurer, side);
+	    channel->view[side].owed[!side], committed, htlcmap, direct_outputs,
+	    commitment_number ^ channel->commitment_number_obscurer,
+	    side);
 
 	/* Generating and saving witness script required to spend
 	 * the funding output */

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -50,6 +50,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  * @ctx: tal context to allocate return value from.
  * @channel: The channel to evaluate
  * @htlc_map: Pointer to htlcs for each tx output (allocated off @ctx).
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @funding_wscript: Pointer to wscript for the funding tx output
  * @per_commitment_point: Per-commitment point to determine keys
  * @commitment_number: The index of this commitment.
@@ -61,6 +62,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				const struct htlc ***htlcmap,
+				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,

--- a/channeld/test/run-commit_tx.c
+++ b/channeld/test/run-commit_tx.c
@@ -732,7 +732,7 @@ int main(void)
 		       dust_limit,
 		       to_local,
 		       to_remote,
-		       NULL, &htlc_map, commitment_number ^ cn_obscurer,
+		       NULL, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       LOCAL);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
@@ -744,7 +744,7 @@ int main(void)
 			dust_limit,
 			to_local,
 			to_remote,
-			NULL, &htlc_map2, commitment_number ^ cn_obscurer,
+			NULL, &htlc_map2, NULL, commitment_number ^ cn_obscurer,
 			REMOTE);
 	tx_must_be_eq(tx, tx2);
 	report(tx, wscript, &x_remote_funding_privkey, &remote_funding_pubkey,
@@ -788,7 +788,7 @@ int main(void)
 		       dust_limit,
 		       to_local,
 		       to_remote,
-		       htlcs, &htlc_map, commitment_number ^ cn_obscurer,
+		       htlcs, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       LOCAL);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
@@ -800,7 +800,7 @@ int main(void)
 			dust_limit,
 			to_local,
 			to_remote,
-			inv_htlcs, &htlc_map2,
+			inv_htlcs, &htlc_map2, NULL,
 			commitment_number ^ cn_obscurer,
 			REMOTE);
 	tx_must_be_eq(tx, tx2);
@@ -832,7 +832,7 @@ int main(void)
 				  dust_limit,
 				  to_local,
 				  to_remote,
-				  htlcs, &htlc_map,
+				  htlcs, &htlc_map, NULL,
 				  commitment_number ^ cn_obscurer,
 				  LOCAL);
 		/* This is what it would look like for peer generating it! */
@@ -845,7 +845,7 @@ int main(void)
 				dust_limit,
 				to_local,
 				to_remote,
-				inv_htlcs, &htlc_map2,
+				inv_htlcs, &htlc_map2, NULL,
 				commitment_number ^ cn_obscurer,
 				REMOTE);
 		tx_must_be_eq(newtx, tx2);
@@ -877,7 +877,7 @@ int main(void)
 			       dust_limit,
 			       to_local,
 			       to_remote,
-			       htlcs, &htlc_map,
+			       htlcs, &htlc_map, NULL,
 			       commitment_number ^ cn_obscurer,
 			       LOCAL);
 		report(tx, wscript,
@@ -914,7 +914,7 @@ int main(void)
 				  dust_limit,
 				  to_local,
 				  to_remote,
-				  htlcs, &htlc_map,
+				  htlcs, &htlc_map, NULL,
 				  commitment_number ^ cn_obscurer,
 				  LOCAL);
 		report(newtx, wscript,
@@ -973,7 +973,7 @@ int main(void)
 			       dust_limit,
 			       to_local,
 			       to_remote,
-			       htlcs, &htlc_map,
+			       htlcs, &htlc_map, NULL,
 			       commitment_number ^ cn_obscurer,
 			       LOCAL);
 		report(tx, wscript,

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -519,10 +519,10 @@ int main(void)
 			   local_config->dust_limit,
 			   to_local,
 			   to_remote,
-			   NULL, &htlc_map, 0x2bb038521914 ^ 42, LOCAL);
+			   NULL, &htlc_map, NULL, 0x2bb038521914 ^ 42, LOCAL);
 
 	txs = channel_txs(tmpctx,
-			  &htlc_map, &funding_wscript_alt,
+			  &htlc_map, NULL, &funding_wscript_alt,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
 	assert(tal_count(htlc_map) == 2);
@@ -530,7 +530,7 @@ int main(void)
 	tx_must_be_eq(txs[0], raw_tx);
 
 	txs2 = channel_txs(tmpctx,
-			   &htlc_map, &funding_wscript,
+			   &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -557,10 +557,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
-	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -575,10 +575,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 6);
-	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -641,15 +641,15 @@ int main(void)
 		    tmpctx, &funding_txid, funding_output_index,
 		    funding_amount, LOCAL, remote_config->to_self_delay,
 		    &keyset, feerate_per_kw[LOCAL], local_config->dust_limit,
-		    to_local, to_remote, htlcs, &htlc_map, 0x2bb038521914 ^ 42,
-		    LOCAL);
+		    to_local, to_remote, htlcs, &htlc_map, NULL,
+		    0x2bb038521914 ^ 42, LOCAL);
 
-		txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+		txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 				  lchannel, &local_per_commitment_point, 42,
 				  LOCAL);
 		tx_must_be_eq(txs[0], raw_tx);
 
-		txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+		txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 				   rchannel, &local_per_commitment_point,
 				   42, REMOTE);
 		txs_must_be_eq(txs, txs2);

--- a/common/Makefile
+++ b/common/Makefile
@@ -47,6 +47,7 @@ COMMON_SRC_NOGEN :=				\
 	common/onion.c				\
 	common/onionreply.c			\
 	common/param.c				\
+	common/penalty_base.c			\
 	common/per_peer_state.c			\
 	common/peer_billboard.c			\
 	common/peer_failed.c			\

--- a/common/initial_channel.c
+++ b/common/initial_channel.c
@@ -71,6 +71,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
 				      enum side side,
+				      struct wally_tx_output *direct_outputs[NUM_SIDES],
 				      char** err_reason)
 {
 	struct keyset keyset;
@@ -105,6 +106,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				 channel->view[side].owed[!side],
 				 channel->config[!side].channel_reserve,
 				 0 ^ channel->commitment_number_obscurer,
+				 direct_outputs,
 				 side,
 				 err_reason);
 }

--- a/common/initial_channel.h
+++ b/common/initial_channel.h
@@ -106,6 +106,7 @@ struct channel *new_initial_channel(const tal_t *ctx,
  * @channel: The channel to evaluate
  * @per_commitment_point: Per-commitment point to determine keys
  * @side: which side to get the commitment transaction for
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
  * Returns the unsigned initial commitment transaction for @side, or NULL
@@ -116,6 +117,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
 				      enum side side,
+				      struct wally_tx_output *direct_outputs[NUM_SIDES],
 				      char** err_reason);
 
 /**

--- a/common/initial_commit_tx.h
+++ b/common/initial_commit_tx.h
@@ -84,6 +84,7 @@ static inline struct amount_sat commit_tx_base_fee(u32 feerate_per_kw,
  * @other_pay: amount to pay directly to the other side
  * @self_reserve: reserve the other side insisted we have
  * @obscured_commitment_number: number to encode in commitment transaction
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @side: side to generate commitment transaction for.
  * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
@@ -104,6 +105,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 				     struct amount_msat other_pay,
 				     struct amount_sat self_reserve,
 				     u64 obscured_commitment_number,
+				     struct wally_tx_output *direct_outputs[NUM_SIDES],
 				     enum side side,
 				     char** err_reason);
 

--- a/common/penalty_base.c
+++ b/common/penalty_base.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <common/penalty_base.h>
+#include <wire/wire.h>
+
+/* txout must be within tx! */
+struct penalty_base *penalty_base_new(const tal_t *ctx,
+				      u64 commitment_num,
+				      const struct bitcoin_tx *tx,
+				      const struct wally_tx_output *txout)
+{
+	struct penalty_base *pbase = tal(ctx, struct penalty_base);
+
+	pbase->commitment_num = commitment_num;
+	bitcoin_txid(tx, &pbase->txid);
+	pbase->outnum = txout - tx->wtx->outputs;
+	assert(pbase->outnum < tx->wtx->num_outputs);
+	pbase->amount.satoshis = txout->satoshi; /* Raw: from wally_tx_output */
+
+	return pbase;
+}
+
+void towire_penalty_base(u8 **pptr, const struct penalty_base *pbase)
+{
+	towire_u64(pptr, pbase->commitment_num);
+	towire_bitcoin_txid(pptr, &pbase->txid);
+	towire_u32(pptr, pbase->outnum);
+	towire_amount_sat(pptr, pbase->amount);
+}
+
+void fromwire_penalty_base(const u8 **pptr, size_t *max,
+			   struct penalty_base *pbase)
+{
+	pbase->commitment_num = fromwire_u64(pptr, max);
+	fromwire_bitcoin_txid(pptr, max, &pbase->txid);
+	pbase->outnum = fromwire_u32(pptr, max);
+	pbase->amount = fromwire_amount_sat(pptr, max);
+}

--- a/common/penalty_base.h
+++ b/common/penalty_base.h
@@ -1,0 +1,30 @@
+#ifndef LIGHTNING_COMMON_PENALTY_BASE_H
+#define LIGHTNING_COMMON_PENALTY_BASE_H
+#include "config.h"
+#include <bitcoin/tx.h>
+#include <ccan/short_types/short_types.h>
+#include <common/amount.h>
+
+/* To create a penalty, all we need are these. */
+struct penalty_base {
+	/* The remote commitment index. */
+	u64 commitment_num;
+	/* The remote commitment txid. */
+	struct bitcoin_txid txid;
+	/* The remote commitment's "to-local" output. */
+	u32 outnum;
+	/* The amount of the remote commitment's "to-local" output. */
+	struct amount_sat amount;
+};
+
+/* txout must be within tx! */
+struct penalty_base *penalty_base_new(const tal_t *ctx,
+				      u64 commitment_num,
+				      const struct bitcoin_tx *tx,
+				      const struct wally_tx_output *txout);
+
+void towire_penalty_base(u8 **pptr, const struct penalty_base *pbase);
+void fromwire_penalty_base(const u8 **ptr, size_t *max,
+			   struct penalty_base *pbase);
+
+#endif /* LIGHTNING_COMMON_PENALTY_BASE_H */

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -397,8 +397,9 @@ int main(int argc, char *argv[])
 	if (!per_commit_point(&localseed, &local_per_commit_point, commitnum))
 		errx(1, "Bad deriving local per-commitment-point");
 
-	local_txs = channel_txs(NULL, &htlcmap, &funding_wscript, channel,
-				&local_per_commit_point, commitnum, LOCAL);
+	local_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+				&local_per_commit_point, commitnum,
+				LOCAL);
 
 	printf("## local_commitment\n"
 	       "# input amount %s, funding_wscript %s, pubkey %s\n",
@@ -511,8 +512,9 @@ int main(int argc, char *argv[])
 	/* Create the remote commitment tx */
 	if (!per_commit_point(&remoteseed, &remote_per_commit_point, commitnum))
 		errx(1, "Bad deriving remote per-commitment-point");
-	remote_txs = channel_txs(NULL, &htlcmap, &funding_wscript, channel,
-				 &remote_per_commit_point, commitnum, REMOTE);
+	remote_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+				 &remote_per_commit_point, commitnum,
+				 REMOTE);
 	remote_txs[0]->input_amounts[0]
 		= tal_dup(remote_txs[0], struct amount_sat, &funding_amount);
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -985,6 +985,28 @@ This will ensure backward
 compatibility should the semantics be changed in future.
 
 
+### `commitment_revocation`
+
+The `commitment_revocation` hook is called whenever a peer has sent a
+revocation for a prior channel state. The hook includes the commitment
+transaction hash that was revoked as well as a matching penalty transaction
+that can be used to punish the peer if it ever attempts to publish the revoked
+commitment. The primary use-case for this hook is to implement watchtower
+plugins that hand the penalty transaction to a remote watchtower that will
+monitor the blockchain during our absence.
+
+The payload has the following format:
+
+```json
+{
+	"commitment_txid": "df5ffe895c778e10f7742a6c5b8a0cefbe9465df58b92fadeb883752c8107c8f",
+	"penalty_tx": "0200000000010115360fd932a9c60e2f7f[...]f0ce1f271291714e5752ae993ed620"
+}
+```
+
+The result returned by the plugin is currently ignored, but should always
+return `{"result": "continue"}` in case additional handling is added in the
+future.
 
 ## Bitcoin backend
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -590,6 +590,45 @@ there's a member `error_message`, that member is sent to the peer
 before disconnection.
 
 
+### `commitment_revocation`
+
+This hook is called whenever a channel state is updated, and the old state was
+revoked. State updates in Lightning consist of the following steps:
+
+ 1. Proposal of a new state commitment in the form of a commitment transaction
+ 2. Exchange of signatures for the agreed upon commitment transaction
+ 3. Verification that the signatures match the commitment transaction
+ 4. Exchange of revocation secrets that could be used to penalize an eventual misbehaving party
+
+The `commitment_revocation` hook is used to inform the plugin about the state
+transition being completed, and deliver the penalty transaction. The penalty
+transaction could then be sent to a watchtower that automaticaly reacts in
+case one party attempts to settle using a revoked commitment.
+
+The payload consists of the following information:
+
+```json
+{
+	"commitment_txid": "58eea2cf538cfed79f4d6b809b920b40bb6b35962c4bb4cc81f5550a7728ab05",
+	"penalty_tx": "02000000000101...ac00000000"
+}
+```
+
+Notice that the `commitment_txid` could also be extracted from the sole input
+of the `penalty_tx`, however it is enclosed so plugins don't have to include
+the logic to parse transactions.
+
+Not included are the `htlc_success` and `htlc_failure` transactions that
+may also be spending `commitment_tx` outputs. This is because these
+transactions are much more dynamic and have a predictable timeout, allowing
+wallets to ensure a quick checkin when the CLTV of the HTLC is about to
+expire.
+
+The `commitment_revocation` hook is a chained hook, i.e., multiple plugins can
+register it, and they will be called in the order they were registered in.
+Plugins should always return `{"result": "continue"}`, otherwise subsequent
+hook subscribers would not get called.
+
 ### `db_write`
 
 This hook is called whenever a change is about to be committed to the database.

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -145,6 +145,10 @@ msgdata,hsm_sign_penalty_to_us,tx,bitcoin_tx,
 msgdata,hsm_sign_penalty_to_us,wscript_len,u16,
 msgdata,hsm_sign_penalty_to_us,wscript,u8,wscript_len
 msgdata,hsm_sign_penalty_to_us,input_amount,amount_sat,
+# If this is the master requesting a signature on behalf of a peer-client
+# (typically onchaind) these fields are set. They are double checked in hsmd.
+msgdata,hsm_sign_penalty_to_us,node_id,?node_id,
+msgdata,hsm_sign_penalty_to_us,channel_dbid,?u64,
 
 # Onchaind asks HSM to sign a local HTLC success or HTLC timeout tx.
 msgtype,hsm_sign_local_htlc_tx,16

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -54,6 +54,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/onion.o				\
 	common/onionreply.o			\
 	common/param.o				\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/permute_tx.o			\
 	common/pseudorand.o			\

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -42,6 +42,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/htlc_trim.o			\
 	common/htlc_wire.o			\
 	common/key_derive.o			\
+	common/keyset.o				\
 	common/io_lock.o			\
 	common/json.o				\
 	common/json_helpers.o			\
@@ -103,6 +104,7 @@ LIGHTNINGD_SRC :=				\
 	lightningd/plugin_control.c		\
 	lightningd/plugin_hook.c		\
 	lightningd/subd.c			\
+	lightningd/watchtower.c			\
 	lightningd/watch.c
 
 LIGHTNINGD_SRC_NOHDR :=				\

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -3,8 +3,10 @@
 #include <ccan/tal/str/str.h>
 #include <common/closing_fee.h>
 #include <common/fee_states.h>
+#include <common/htlc_tx.h>
 #include <common/json_command.h>
 #include <common/jsonrpc_errors.h>
+#include <common/keyset.h>
 #include <common/utils.h>
 #include <common/wire_error.h>
 #include <connectd/gen_connect_wire.h>
@@ -277,6 +279,9 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	txfilter_add_scriptpubkey(peer->ld->owned_txfilter,
 				  take(p2wpkh_for_keyidx(NULL, peer->ld,
 							 channel->final_key_idx)));
+
+	channel->prev_commitment = NULL;
+	channel->next_commitment = NULL;
 
 	return channel;
 }

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -129,6 +129,9 @@ struct channel {
 
 	/* Any commands trying to forget us. */
 	struct command **forgets;
+
+	struct penalty_base *prev_commitment;
+	struct penalty_base *next_commitment;
 };
 
 struct channel *new_channel(struct peer *peer, u64 dbid,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -285,6 +285,11 @@ void forget_channel(struct channel *channel, const char *why)
 		forget(channel);
 }
 
+static void handle_channel_resending_commitsig(struct channel *channel,
+					       const u8 *msg)
+{
+}
+
 static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 {
 	enum channel_wire_type t = fromwire_peektype(msg);
@@ -331,6 +336,11 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_GOT_ONIONMSG_TO_US:
 	case WIRE_GOT_ONIONMSG_FORWARD:
 #endif
+
+	case WIRE_CHANNEL_RESENDING_COMMITSIG:
+		handle_channel_resending_commitsig(sd->channel, msg);
+		break;
+
 	/* And we never get these from channeld. */
 	case WIRE_CHANNEL_INIT:
 	case WIRE_CHANNEL_FUNDING_DEPTH:

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -288,6 +288,16 @@ void forget_channel(struct channel *channel, const char *why)
 static void handle_channel_resending_commitsig(struct channel *channel,
 					       const u8 *msg)
 {
+	struct penalty_base *pbase;
+	/* Clear previous state, might be stale due to reconnect and restart
+	 * at a previous commit. */
+	if (!fromwire_channel_resending_commitsig(
+		    msg, msg, &pbase))
+		channel_internal_error(channel,
+				       "bad channel_resending_commitsig %s",
+				       tal_hex(channel, msg));
+	tal_free(channel->next_commitment);
+	channel->next_commitment = tal_steal(channel, pbase);
 }
 
 static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -11,6 +11,7 @@
 #include <common/jsonrpc_errors.h>
 #include <common/key_derive.h>
 #include <common/param.h>
+#include <common/penalty_base.h>
 #include <common/per_peer_state.h>
 #include <common/utils.h>
 #include <common/wallet_tx.h>
@@ -369,6 +370,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	struct lightningd *ld = openingd->ld;
 	u8 *remote_upfront_shutdown_script;
 	struct per_peer_state *pps;
+	struct penalty_base *pbase;
 
 	/* This is a new channel_info.their_config so set its ID to 0 */
 	channel_info.their_config.id = 0;
@@ -376,6 +378,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	if (!fromwire_opening_funder_reply(resp, resp,
 					   &channel_info.their_config,
 					   &remote_commit,
+					   &pbase,
 					   &remote_commit_sig,
 					   &pps,
 					   &channel_info.theirbase.revocation,
@@ -459,6 +462,7 @@ static void opening_fundee_finished(struct subd *openingd,
 	struct channel *channel;
 	u8 *remote_upfront_shutdown_script, *local_upfront_shutdown_script;
 	struct per_peer_state *pps;
+	struct penalty_base *pbase;
 
 	log_debug(uc->log, "Got opening_fundee_finish_response");
 
@@ -466,26 +470,27 @@ static void opening_fundee_finished(struct subd *openingd,
 	channel_info.their_config.id = 0;
 
 	if (!fromwire_opening_fundee(tmpctx, reply,
-					   &channel_info.their_config,
-					   &remote_commit,
-					   &remote_commit_sig,
-					   &pps,
-					   &channel_info.theirbase.revocation,
-					   &channel_info.theirbase.payment,
-					   &channel_info.theirbase.htlc,
-					   &channel_info.theirbase.delayed_payment,
-					   &channel_info.remote_per_commit,
-					   &channel_info.remote_fundingkey,
-					   &funding_txid,
-					   &funding_outnum,
-					   &funding,
-					   &push,
-					   &channel_flags,
-					   &feerate,
-					   &funding_signed,
-				           &uc->our_config.channel_reserve,
-					   &local_upfront_shutdown_script,
-				           &remote_upfront_shutdown_script)) {
+				     &channel_info.their_config,
+				     &remote_commit,
+				     &pbase,
+				     &remote_commit_sig,
+				     &pps,
+				     &channel_info.theirbase.revocation,
+				     &channel_info.theirbase.payment,
+				     &channel_info.theirbase.htlc,
+				     &channel_info.theirbase.delayed_payment,
+				     &channel_info.remote_per_commit,
+				     &channel_info.remote_fundingkey,
+				     &funding_txid,
+				     &funding_outnum,
+				     &funding,
+				     &push,
+				     &channel_flags,
+				     &feerate,
+				     &funding_signed,
+				     &uc->our_config.channel_reserve,
+				     &local_upfront_shutdown_script,
+				     &remote_upfront_shutdown_script)) {
 		log_broken(uc->log, "bad OPENING_FUNDEE_REPLY %s",
 			   tal_hex(reply, reply));
 		uncommitted_channel_disconnect(uc, LOG_BROKEN,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -427,6 +427,9 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 		goto cleanup;
 	}
 
+	/* Remember the commit_txid so we can build a penalty later. */
+	channel->next_commitment = tal_steal(channel, pbase);
+
 	/* Watch for funding confirms */
 	channel_watch_funding(ld, channel);
 
@@ -537,6 +540,9 @@ static void opening_fundee_finished(struct subd *openingd,
 	/* Tell plugins about the success */
 	notify_channel_opened(ld, &channel->peer->id, &channel->funding,
 			      &channel->funding_txid, &channel->remote_funding_locked);
+
+	/* Remember the commit_txid so we can build a penalty later. */
+	channel->next_commitment = tal_steal(channel, pbase);
 
 	/* On to normal operation! */
 	peer_start_channeld(channel, pps, funding_signed, false);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1668,11 +1668,13 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 	struct bitcoin_signature commit_sig;
 	secp256k1_ecdsa_signature *htlc_sigs;
 	struct lightningd *ld = channel->peer->ld;
+	struct penalty_base *pbase;
 
 	channel->htlc_timeout = tal_free(channel->htlc_timeout);
 
 	if (!fromwire_channel_sending_commitsig(msg, msg,
 						&commitnum,
+						&pbase,
 						&fee_states,
 						&changed_htlcs,
 						&commit_sig, &htlc_sigs)

--- a/lightningd/watchtower.c
+++ b/lightningd/watchtower.c
@@ -1,0 +1,128 @@
+#include "watchtower.h"
+
+#include <bitcoin/feerate.h>
+#include <bitcoin/script.h>
+#include <bitcoin/signature.h>
+#include <bitcoin/tx.h>
+#include <common/htlc_tx.h>
+#include <common/key_derive.h>
+#include <common/keyset.h>
+#include <hsmd/gen_hsm_wire.h>
+#include <lightningd/channel.h>
+#include <lightningd/peer_control.h>
+#include <wire/wire_sync.h>
+
+static const u8 ONE = 0x1;
+
+const struct bitcoin_tx *
+penalty_tx_create(const tal_t *ctx, struct lightningd *ld,
+		  const struct channel *channel,
+		  const struct secret *revocation_preimage,
+		  const struct bitcoin_txid *commitment_txid,
+		  s16 to_them_outnum, struct amount_sat to_them_sats)
+{
+	u8 *wscript;
+	struct bitcoin_tx *tx;
+	struct keyset keyset;
+	size_t weight;
+	u8 *msg;
+	struct amount_sat fee, min_out, amt;
+	struct bitcoin_signature sig;
+	u32 locktime = 0;
+	bool option_static_remotekey = channel->option_static_remotekey;
+	struct pubkey final_key;
+	u8 **witness;
+	u32 remote_to_self_delay = channel->channel_info.their_config.to_self_delay;
+	const struct amount_sat dust_limit = channel->our_config.dust_limit;
+	u32 feerate_per_kw = try_get_feerate(ld->topology, FEERATE_PENALTY);
+	BUILD_ASSERT(sizeof(struct secret) == sizeof(*revocation_preimage));
+	const struct secret remote_per_commitment_secret = *revocation_preimage;
+	struct pubkey remote_per_commitment_point;
+	struct basepoints basepoints[NUM_SIDES];
+	u64 channel_dbid = channel->dbid;
+	basepoints[LOCAL] = channel->local_basepoints;
+	basepoints[REMOTE] = channel->channel_info.theirbase;
+
+	if (to_them_outnum == -1 ||
+	    amount_sat_less_eq(to_them_sats, dust_limit)) {
+		log_unusual(channel->log,
+			    "Cannot create penalty transaction because there "
+			    "is no non-dust to_them output in the commitment.");
+		return NULL;
+	}
+
+	if (!pubkey_from_secret(&remote_per_commitment_secret, &remote_per_commitment_point))
+		fatal("Failed derive from per_commitment_secret %s",
+		      type_to_string(tmpctx, struct secret,
+				     &remote_per_commitment_secret));
+
+	if (!bip32_pubkey(ld->wallet->bip32_base, &final_key,
+			  channel->final_key_idx)) {
+		fatal("Could not derive onchain key %" PRIu64,
+		      channel->final_key_idx);
+	}
+
+	if (!derive_keyset(&remote_per_commitment_point,
+			   &basepoints[REMOTE],
+			   &basepoints[LOCAL],
+			   option_static_remotekey,
+			   &keyset))
+		abort(); /* TODO(cdecker) Handle a bit more gracefully */
+	wscript = bitcoin_wscript_to_local(tmpctx, remote_to_self_delay,
+					   &keyset.self_revocation_key,
+					   &keyset.self_delayed_payment_key);
+
+	tx = bitcoin_tx(ctx, chainparams, 1, 1, locktime);
+	bitcoin_tx_add_input(tx, commitment_txid, to_them_outnum, 0xFFFFFFFF,
+			     to_them_sats, NULL);
+
+	bitcoin_tx_add_output(tx, scriptpubkey_p2wpkh(tx, &final_key),
+			      to_them_sats);
+
+	/* Worst-case sig is 73 bytes */
+	weight = bitcoin_tx_weight(tx) + 1 + 3 + 73 + 0 + tal_count(wscript);
+	weight = elements_add_overhead(weight, 1, 1);
+	fee = amount_tx_fee(feerate_per_kw, weight);
+
+	if (!amount_sat_add(&min_out, dust_limit, fee))
+		log_broken(channel->log,
+			      "Cannot add dust_limit %s and fee %s",
+			      type_to_string(tmpctx, struct amount_sat, &dust_limit),
+			      type_to_string(tmpctx, struct amount_sat, &fee));
+
+	if (amount_sat_less(to_them_sats, min_out)) {
+		/* FIXME: We should use SIGHASH_NONE so others can take it */
+		fee = amount_tx_fee(feerate_floor(), weight);
+	}
+
+	/* This can only happen if feerate_floor() is still too high; shouldn't
+	 * happen! */
+	if (!amount_sat_sub(&amt, to_them_sats, fee)) {
+		amt = dust_limit;
+		log_broken(channel->log,
+			   "TX can't afford minimal feerate"
+			   "; setting output to %s",
+			   type_to_string(tmpctx, struct amount_sat, &amt));
+	}
+	bitcoin_tx_output_set_amount(tx, 0, amt);
+	bitcoin_tx_finalize(tx);
+
+	u8 *hsm_sign_msg =
+	    towire_hsm_sign_penalty_to_us(ctx, &remote_per_commitment_secret, tx,
+					  wscript, *tx->input_amounts[0],
+					  &channel->peer->id, &channel_dbid);
+
+	if (!wire_sync_write(ld->hsm_fd, take(hsm_sign_msg)))
+		log_broken(channel->log, "Writing sign request to hsm");
+
+	msg = wire_sync_read(tmpctx, ld->hsm_fd);
+	if (!msg || !fromwire_hsm_sign_tx_reply(msg, &sig)) {
+		fatal("Reading sign_tx_reply: %s", tal_hex(tmpctx, msg));
+	}
+
+	witness = bitcoin_witness_sig_and_element(tx, &sig, &ONE, sizeof(ONE),
+						  wscript);
+
+	bitcoin_tx_input_set_witness(tx, 0, take(witness));
+	return tx;
+}

--- a/lightningd/watchtower.h
+++ b/lightningd/watchtower.h
@@ -1,0 +1,16 @@
+#ifndef LIGHTNING_LIGHTNINGD_WATCHTOWER_H
+#define LIGHTNING_LIGHTNINGD_WATCHTOWER_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+#include <common/derive_basepoints.h>
+#include <lightningd/lightningd.h>
+
+const struct bitcoin_tx *
+penalty_tx_create(const tal_t *ctx, struct lightningd *ld,
+		  const struct channel *channel,
+		  const struct secret *revocation_preimage,
+		  const struct bitcoin_txid *commitment_txid,
+		  s16 to_them_outnum, struct amount_sat to_them_sats);
+
+#endif /* LIGHTNING_LIGHTNINGD_WATCHTOWER_H */

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -305,7 +305,8 @@ static u8 *penalty_to_us(const tal_t *ctx,
 			 const u8 *wscript)
 {
 	return towire_hsm_sign_penalty_to_us(ctx, remote_per_commitment_secret,
-					     tx, wscript, *tx->input_amounts[0]);
+					     tx, wscript, *tx->input_amounts[0],
+					     NULL, NULL);
 }
 
 /*

--- a/onchaind/test/run-grind_feerate-bug.c
+++ b/onchaind/test/run-grind_feerate-bug.c
@@ -133,7 +133,7 @@ u8 *towire_hsm_get_per_commitment_point(const tal_t *ctx UNNEEDED, u64 n UNNEEDE
 u8 *towire_hsm_sign_delayed_payment_to_us(const tal_t *ctx UNNEEDED, u64 commit_num UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_delayed_payment_to_us called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_penalty_to_us */
-u8 *towire_hsm_sign_penalty_to_us(const tal_t *ctx UNNEEDED, const struct secret *revocation_secret UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)
+u8 *towire_hsm_sign_penalty_to_us(const tal_t *ctx UNNEEDED, const struct secret *revocation_secret UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED, const struct node_id *node_id UNNEEDED, u64 *channel_dbid UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_penalty_to_us called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_remote_htlc_to_us */
 u8 *towire_hsm_sign_remote_htlc_to_us(const tal_t *ctx UNNEEDED, const struct pubkey *remote_per_commitment_point UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -151,7 +151,7 @@ u8 *towire_hsm_sign_delayed_payment_to_us(const tal_t *ctx UNNEEDED, u64 commit_
 u8 *towire_hsm_sign_local_htlc_tx(const tal_t *ctx UNNEEDED, u64 commit_num UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_local_htlc_tx called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_penalty_to_us */
-u8 *towire_hsm_sign_penalty_to_us(const tal_t *ctx UNNEEDED, const struct secret *revocation_secret UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)
+u8 *towire_hsm_sign_penalty_to_us(const tal_t *ctx UNNEEDED, const struct secret *revocation_secret UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED, const struct node_id *node_id UNNEEDED, u64 *channel_dbid UNNEEDED)
 { fprintf(stderr, "towire_hsm_sign_penalty_to_us called!\n"); abort(); }
 /* Generated stub for towire_hsm_sign_remote_htlc_to_us */
 u8 *towire_hsm_sign_remote_htlc_to_us(const tal_t *ctx UNNEEDED, const struct pubkey *remote_per_commitment_point UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const u8 *wscript UNNEEDED, struct amount_sat input_amount UNNEEDED)

--- a/openingd/Makefile
+++ b/openingd/Makefile
@@ -63,6 +63,7 @@ OPENINGD_COMMON_OBJS :=				\
 	common/memleak.o			\
 	common/msg_queue.o			\
 	common/onionreply.o			\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/peer_billboard.o			\
 	common/peer_failed.o			\

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -49,11 +49,13 @@ msgdata,opening_got_offer_reply,rejection,?wirestring,
 msgdata,opening_got_offer_reply,shutdown_len,u16,
 msgdata,opening_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
 
+#include <common/penalty_base.h>
 # Openingd->master: we've successfully offered channel.
 # This gives their sig, means we can broadcast tx: we're done.
 msgtype,opening_funder_reply,6101
 msgdata,opening_funder_reply,their_config,channel_config,
 msgdata,opening_funder_reply,first_commit,bitcoin_tx,
+msgdata,opening_funder_reply,pbase,?penalty_base,
 msgdata,opening_funder_reply,first_commit_sig,bitcoin_signature,
 msgdata,opening_funder_reply,pps,per_peer_state,
 msgdata,opening_funder_reply,revocation_basepoint,pubkey,
@@ -104,6 +106,7 @@ msgdata,opening_funder_failed,reason,wirestring,
 msgtype,opening_fundee,6003
 msgdata,opening_fundee,their_config,channel_config,
 msgdata,opening_fundee,first_commit,bitcoin_tx,
+msgdata,opening_fundee,pbase,?penalty_base,
 msgdata,opening_fundee,first_commit_sig,bitcoin_signature,
 msgdata,opening_fundee,pps,per_peer_state,
 msgdata,opening_fundee,revocation_basepoint,pubkey,

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -31,6 +31,7 @@
 #include <common/overflows.h>
 #include <common/peer_billboard.h>
 #include <common/peer_failed.h>
+#include <common/penalty_base.h>
 #include <common/pseudorand.h>
 #include <common/read_peer_msg.h>
 #include <common/status.h>
@@ -659,12 +660,14 @@ static u8 *funder_channel_start(struct state *state, u8 channel_flags)
 static bool funder_finalize_channel_setup(struct state *state,
 					  struct amount_msat local_msat,
 					  struct bitcoin_signature *sig,
-					  struct bitcoin_tx **tx)
+					  struct bitcoin_tx **tx,
+					  struct penalty_base **pbase)
 {
 	u8 *msg;
 	struct channel_id id_in;
 	const u8 *wscript;
 	char *err_reason;
+	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 	/*~ Now we can initialize the `struct channel`.  This represents
 	 * the current channel state and is how we can generate the current
@@ -710,7 +713,7 @@ static bool funder_finalize_channel_setup(struct state *state,
 	/* This gives us their first commitment transaction. */
 	*tx = initial_channel_tx(state, &wscript, state->channel,
 				&state->first_per_commitment_point[REMOTE],
-				REMOTE, &err_reason);
+				REMOTE, direct_outputs, &err_reason);
 	if (!*tx) {
 		/* This should not happen: we should never create channels we
 		 * can't afford the fees for after reserve. */
@@ -718,6 +721,11 @@ static bool funder_finalize_channel_setup(struct state *state,
 				   "Could not meet their fees and reserve: %s", err_reason);
 		goto fail;
 	}
+
+	if (direct_outputs[LOCAL])
+		*pbase = penalty_base_new(state, 0, *tx, direct_outputs[LOCAL]);
+	else
+		*pbase = NULL;
 
 	/* We ask the HSM to sign their commitment transaction for us: it knows
 	 * our funding key, it just needs the remote funding key to create the
@@ -820,7 +828,7 @@ static bool funder_finalize_channel_setup(struct state *state,
 	 * signature they sent against that. */
 	*tx = initial_channel_tx(state, &wscript, state->channel,
 				 &state->first_per_commitment_point[LOCAL],
-				 LOCAL, &err_reason);
+				 LOCAL, direct_outputs, &err_reason);
 	if (!*tx) {
 		negotiation_failed(state, true,
 				   "Could not meet our fees and reserve: %s", err_reason);
@@ -849,9 +857,11 @@ fail:
 
 static u8 *funder_channel_complete(struct state *state)
 {
+	/* Remote commitment tx */
 	struct bitcoin_tx *tx;
 	struct bitcoin_signature sig;
 	struct amount_msat local_msat;
+	struct penalty_base *pbase;
 
 	/* Update the billboard about what we're doing*/
 	peer_billboard(false,
@@ -868,12 +878,14 @@ static u8 *funder_channel_complete(struct state *state)
 			      type_to_string(tmpctx, struct amount_sat,
 					     &state->funding));
 
-	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx))
+	if (!funder_finalize_channel_setup(state, local_msat, &sig, &tx,
+					   &pbase))
 		return NULL;
 
 	return towire_opening_funder_reply(state,
 					   &state->remoteconf,
 					   tx,
+					   pbase,
 					   &sig,
 					   state->pps,
 					   &state->their_points.revocation,
@@ -903,6 +915,8 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	const u8 *wscript;
 	u8 channel_flags;
 	char* err_reason;
+	struct wally_tx_output *direct_outputs[NUM_SIDES];
+	struct penalty_base *pbase;
 
 	/* BOLT #2:
 	 *
@@ -1185,7 +1199,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	 */
 	local_commit = initial_channel_tx(state, &wscript, state->channel,
 					  &state->first_per_commitment_point[LOCAL],
-					  LOCAL, &err_reason);
+					  LOCAL, NULL, &err_reason);
 	/* This shouldn't happen either, AFAICT. */
 	if (!local_commit) {
 		negotiation_failed(state, false,
@@ -1245,7 +1259,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	 */
 	remote_commit = initial_channel_tx(state, &wscript, state->channel,
 					   &state->first_per_commitment_point[REMOTE],
-					   REMOTE, &err_reason);
+					   REMOTE, direct_outputs, &err_reason);
 	if (!remote_commit) {
 		negotiation_failed(state, false,
 				   "Could not meet their fees and reserve: %s", err_reason);
@@ -1272,9 +1286,16 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	assert(sig.sighash_type == SIGHASH_ALL);
 	msg = towire_funding_signed(state, &state->channel_id, &sig.s);
 
+	if (direct_outputs[LOCAL] != NULL)
+		pbase = penalty_base_new(tmpctx, 0, remote_commit,
+					 direct_outputs[LOCAL]);
+	else
+		pbase = NULL;
+
 	return towire_opening_fundee(state,
 				     &state->remoteconf,
 				     local_commit,
+				     pbase,
 				     &theirsig,
 				     state->pps,
 				     &theirs.revocation,

--- a/tests/plugins/watchtower.py
+++ b/tests/plugins/watchtower.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('commitment_revocation')
+def on_commitment_revocation(commitment_txid, penalty_tx, plugin, **kwargs):
+    with open('watchtower.csv', 'a') as f:
+        f.write("{}, {}\n".format(commitment_txid, penalty_tx))
+
+
+plugin.run()

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -596,6 +596,12 @@ static struct migration dbmigrations[] = {
      * Turn anything in transition into a WIRE_TEMPORARY_NODE_FAILURE. */
     {SQL("ALTER TABLE channel_htlcs ADD localfailmsg BLOB;"), NULL},
     {SQL("UPDATE channel_htlcs SET localfailmsg=decode('2002', 'hex') WHERE malformed_onion != 0 AND direction = 1;"), NULL},
+    {SQL("ALTER TABLE channels ADD prev_penalty_base_txid BLOB;"), NULL},
+    {SQL("ALTER TABLE channels ADD prev_penalty_base_outnum INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD prev_penalty_base_amount BIGINT;"), NULL},
+    {SQL("ALTER TABLE channels ADD next_penalty_base_txid BLOB;"), NULL},
+    {SQL("ALTER TABLE channels ADD next_penalty_base_outnum INTEGER;"), NULL},
+    {SQL("ALTER TABLE channels ADD next_penalty_base_amount BIGINT;"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -122,7 +122,7 @@ bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEED
 bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)
 { fprintf(stderr, "fromwire_channel_offer_htlc_reply called!\n"); abort(); }
 /* Generated stub for fromwire_channel_sending_commitsig */
-bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, secp256k1_ecdsa_signature **htlc_sigs UNNEEDED)
+bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct penalty_base **pbase UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, secp256k1_ecdsa_signature **htlc_sigs UNNEEDED)
 { fprintf(stderr, "fromwire_channel_sending_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_connect_peer_connected */
 bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -740,6 +740,17 @@ bool dev_disconnect_permanent(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "dev_disconnect_permanent called!\n"); abort(); }
 #endif
 
+const struct bitcoin_tx *
+penalty_tx_create(const tal_t *ctx, struct lightningd *ld,
+                 const struct channel *channel,
+                 const struct secret *revocation_preimage,
+                 const struct bitcoin_txid *commitment_txid,
+                 s16 to_them_outnum, struct amount_sat to_them_sats)
+{
+	fprintf(stderr, "penalty_tx_create called!\n");
+	abort();
+}
+
 /* Fake stubs to talk to hsm */
 u8 *towire_hsm_get_channel_basepoints(const tal_t *ctx UNNEEDED, const struct node_id *peerid UNNEEDED, u64 dbid UNNEEDED)
 {


### PR DESCRIPTION
Implements the `commitment_revocation` hook for watchtowers. Commitments are
forwarded from `openingd` and `channeld`, and tracked in `lightningd`. Upon
receiving a revocation `lightningd` generates the penalty transaction and
calls the hook so plugins can postprocess it, e.g., encrypt it, and then push
it to the watchtower.

The result of the hook is currently not used, and we don't actually wait for
the hook call to complete before telling `channeld` that it can continue. This
matches the save path in the DB, since we'd simply be replaying the
commitment/revocation if we reconnect anyway. Should synchronous operation be
required we can move the `channel_got_revoce_reply` to hook callback, but for
the sake of simplicity I left it were it is for the time being.

The penalty transaction is generated in `lightningd`, not `channeld` which
required forwarding information from `channeld` about the
`commitment_transaction` to `lightningd`, and requires `lightningd` to call
out to `hsmd` for the signature, instead of `channeld`. The decision to have
`lightningd` create the penalty transaction has the following reasons:

 - `channeld` may not have all the information about the previous commit,
   i.e., in case we come from `openingd` the first commitment is negotiated in
   `openingd` so we'd have to funnel that information through `lightningd`
   anyway.
 - `lightningd` will also deliver the hook call, and it can avoid building and
   signing the penalty tx if there are no subscribers, avoiding the tx
   generation and the request to `hsmd` altogether (not yet implemented).

Included in the `commitment_revocation` hook call is the fully signed penalty
transaction, as well as the commitment transaction hash the penalty
transaction is spending from, i.e., the transaction whose broadcast should
trigger the release of the penalty transaction. The commitment transaction
hash could also be extracted from the penalty transaction (it's its only input
after all), but this allows treating the penalty transaction as an opaque blob
and avoids parsing the transaction in the plugin.

**Not included** are the `htlc_success` and `htlc_failure` transactions that
may also be spending `commitment_tx` outputs. This is because these
transactions are much more dynamic and have a predictable timeout, allowing
wallets to ensure a quick checkin when the CLTV of the HTLC is about to
expire.

## Open Questions

 - Naming: as always finding good names is hard, and I wanted to make the hook
   name descriptive for what it does, not what it can be used for, so calling
   it `watchtower` seemed inapropriate. I'm open for better suggestions though
   :wink:
 - What extra information would be good to have?
 - Would it make sense to also include `htlc_success` and `htlc_timeout`
   transactions, despite not having the full information regarding fees and
   aggregations available?
 - Since we don't use any of the specialties of hooks in this case, would it
   make sense to define a notification instead? I went with the hook for now
   mainly so we can eventually make it synchronous.

Closes #3422
Closes #1353
Closes #3645 
Closes #3659