### PR TITLE
bcli: don't get upset at 0-value outputs

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -181,6 +181,7 @@ bool parse_amount_msat(struct amount_msat *msat, const char *s, size_t slen)
  *  [0-9]+ => satoshi.
  *  [0-9]+sat => satoshi.
  *  [0-9]+000msat => satoshi.
+ *  0msat => 0 satoshi
  *  [0-9]+.[0-9]{1,8}btc => satoshi.
  */
 bool parse_amount_sat(struct amount_sat *sat, const char *s, size_t slen)
@@ -198,8 +199,12 @@ bool parse_amount_sat(struct amount_sat *sat, const char *s, size_t slen)
 	if (!post_decimal_ptr && memeqstr(suffix_ptr, suffix_len, "sat"))
 		return from_number(&sat->satoshis, s, whole_number_len, 0);
 	if (!post_decimal_ptr && memeqstr(suffix_ptr, suffix_len, "msat")) {
-		if (!memends(s, whole_number_len, "000", strlen("000")))
+		if (!memends(s, whole_number_len, "000", strlen("000"))) {
+			if (memeqstr(s, whole_number_len, "0"))
+				return from_number(&sat->satoshis, s,
+						   whole_number_len, 0);
 			return false;
+		}
 		return from_number(&sat->satoshis, s, whole_number_len - 3, 0);
 	}
 	if (post_decimal_ptr && memeqstr(suffix_ptr, suffix_len, "btc"))

--- a/common/test/run-amount.c
+++ b/common/test/run-amount.c
@@ -101,7 +101,7 @@ int main(void)
 	PASS_SAT(&sat, "1000msat", 1);
 	PASS_SAT(&sat, "1000000msat", 1000);
 	PASS_SAT(&sat, "2100000000000000000msat", 2100000000000000ULL);
-	FAIL_SAT(&sat, "0msat");
+	PASS_SAT(&sat, "0msat", 0);
 	FAIL_SAT(&sat, "100msat");
 	FAIL_SAT(&sat, "2000000000000000999msat");
 	FAIL_SAT(&sat, "-1000msat");


### PR DESCRIPTION
Calling `bitcoind_getutxo()` on testnet transaction https://blockstream.info/testnet/tx/eca4cefef2a98de5df67a6630c63af5a72ab57583e0f3bf066d976f28213f447?expand crashed my node.
EDIT: found another one https://blockstream.info/testnet/tx/21f95a5dd990e9caba09cbafe73514d9322bd8d28d70204dd2b5cce5c9c3f2a8 ^^

Fixes  #3610