### PR TITLE
Plugin implementation of `keysend` spontaneous payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ contrib/pylightning/pylightning.egg-info/
 contrib/pyln-*/build/
 contrib/pyln-*/dist/
 contrib/pyln-*/pyln_*.egg-info/
+plugins/keysend

--- a/common/features.c
+++ b/common/features.c
@@ -19,6 +19,14 @@ struct feature_style {
 	enum feature_copy_style copy_style[NUM_FEATURE_PLACE];
 };
 
+const char *feature_place_names[] = {
+	"init",
+	NULL,
+	"node",
+	"channel",
+	"invoice"
+};
+
 static const struct feature_style feature_styles[] = {
 	{ OPT_DATA_LOSS_PROTECT,
 	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT,

--- a/common/features.h
+++ b/common/features.h
@@ -13,6 +13,8 @@ enum feature_place {
 };
 #define NUM_FEATURE_PLACE (BOLT11_FEATURE+1)
 
+extern const char *feature_place_names[NUM_FEATURE_PLACE];
+
 /* The complete set of features for all contexts */
 struct feature_set {
 	u8 *bits[NUM_FEATURE_PLACE];

--- a/contrib/pyln-proto/pyln/proto/onion.py
+++ b/contrib/pyln-proto/pyln/proto/onion.py
@@ -184,11 +184,27 @@ class TlvField(object):
 
 
 class Tu32Field(TlvField):
-    pass
+    def to_bytes(self):
+        raw = struct.pack("!I", self.value)
+        while len(raw) > 1 and raw[0] == 0:
+            raw = raw[1:]
+        b = BytesIO()
+        varint_encode(self.typenum, b)
+        varint_encode(len(raw), b)
+        b.write(raw)
+        return b.getvalue()
 
 
 class Tu64Field(TlvField):
-    pass
+    def to_bytes(self):
+        raw = struct.pack("!Q", self.value)
+        while len(raw) > 1 and raw[0] == 0:
+            raw = raw[1:]
+        b = BytesIO()
+        varint_encode(self.typenum, b)
+        varint_encode(len(raw), b)
+        b.write(raw)
+        return b.getvalue()
 
 
 class ShortChannelIdField(TlvField):

--- a/contrib/pyln-proto/tests/test_onion.py
+++ b/contrib/pyln-proto/tests/test_onion.py
@@ -30,3 +30,31 @@ def test_tlv_payload():
     ))
 
     assert(payload.to_bytes() == tlv)
+
+
+def test_tu_fields():
+    pairs = [
+        (0, b'\x01\x01\x00'),
+        (1 << 8, b'\x01\x02\x01\x00'),
+        (1 << 16, b'\x01\x03\x01\x00\x00'),
+        (1 << 24, b'\x01\x04\x01\x00\x00\x00'),
+        ((1 << 32) - 1, b'\x01\x04\xFF\xFF\xFF\xFF'),
+    ]
+
+    # These should work for Tu32
+    for i, o in pairs:
+        f = onion.Tu32Field(1, i)
+        assert(f.to_bytes() == o)
+
+    # And these should work for Tu64
+    pairs += [
+        (1 << 32, b'\x01\x05\x01\x00\x00\x00\x00'),
+        (1 << 40, b'\x01\x06\x01\x00\x00\x00\x00\x00'),
+        (1 << 48, b'\x01\x07\x01\x00\x00\x00\x00\x00\x00'),
+        (1 << 56, b'\x01\x08\x01\x00\x00\x00\x00\x00\x00\x00'),
+        ((1 << 64) - 1, b'\x01\x08\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'),
+    ]
+
+    for i, o in pairs:
+        f = onion.Tu64Field(1, i)
+        assert(f.to_bytes() == o)

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -804,8 +804,10 @@ if we're the recipient, or attempt to forward it otherwise. Notice that the
 usual checks such as sufficient fees and CLTV deltas are still enforced.
 
 It can also replace the `onion.payload` by specifying a `payload` in
-the response.  This will be re-parsed; it's useful for removing onion
-fields which a plugin doesn't want lightningd to consider.
+the response.  Note that this is always a TLV-style payload, so unlike
+`onion.payload` there is no length prefix (and it must be at least 4
+hex digits long).  This will be re-parsed; it's useful for removing
+onion fields which a plugin doesn't want lightningd to consider.
 
 
 ```json

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -803,6 +803,11 @@ This means that the plugin does not want to do anything special and
 if we're the recipient, or attempt to forward it otherwise. Notice that the
 usual checks such as sufficient fees and CLTV deltas are still enforced.
 
+It can also replace the `onion.payload` by specifying a `payload` in
+the response.  This will be re-parsed; it's useful for removing onion
+fields which a plugin doesn't want lightningd to consider.
+
+
 ```json
 {
   "result": "fail",

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -314,15 +314,22 @@ invoice_check_payment(const tal_t *ctx,
 	 *    - MUST fail the HTLC.
 	 */
 	if (feature_is_set(details->features, COMPULSORY_FEATURE(OPT_VAR_ONION))
-	    && !payment_secret)
+	    && !payment_secret) {
+		log_debug(ld->log, "Attept to pay %s without secret",
+			  type_to_string(tmpctx, struct sha256, &details->rhash));
 		return tal_free(details);
+	}
 
 	if (payment_secret) {
 		struct secret expected;
 
 		invoice_secret(&details->r, &expected);
-		if (!secret_eq_consttime(payment_secret, &expected))
+		if (!secret_eq_consttime(payment_secret, &expected)) {
+			log_debug(ld->log, "Attept to pay %s with wrong secret",
+				  type_to_string(tmpctx, struct sha256,
+						 &details->rhash));
 			return tal_free(details);
+		}
 	}
 
 	/* BOLT #4:

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -997,7 +997,7 @@ int main(int argc, char *argv[])
 	shutdown_subdaemons(ld);
 
 	/* Remove plugins. */
-	ld->plugins = tal_free(ld->plugins);
+	plugins_free(ld->plugins);
 
 	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
 	 * it might actually be touching the DB in some destructors, e.g.,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -896,9 +896,6 @@ static void plugin_manifest_timeout(struct plugin *plugin)
 	fatal("Can't recover from plugin failure, terminating.");
 }
 
-/* List of JSON keys matching `enum feature_place`. */
-static const char *plugin_feature_place_names[] = {"init", NULL, "node", "channel", "invoice"};
-
 bool plugin_parse_getmanifest_response(const char *buffer,
                                        const jsmntok_t *toks,
                                        const jsmntok_t *idtok,
@@ -922,16 +919,16 @@ bool plugin_parse_getmanifest_response(const char *buffer,
 		bool have_featurebits = false;
 		struct feature_set *fset = talz(tmpctx, struct feature_set);
 
-		BUILD_ASSERT(ARRAY_SIZE(plugin_feature_place_names)
+		BUILD_ASSERT(ARRAY_SIZE(feature_place_names)
 			     == ARRAY_SIZE(fset->bits));
 
 		for (int i = 0; i < ARRAY_SIZE(fset->bits); i++) {
 			/* We don't allow setting the obs global init */
-			if (!plugin_feature_place_names[i])
+			if (!feature_place_names[i])
 				continue;
 
 			tok = json_get_member(buffer, featurestok,
-					      plugin_feature_place_names[i]);
+					      feature_place_names[i]);
 
 			if (!tok)
 				continue;
@@ -1214,9 +1211,9 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 	json_add_string(req->stream, "network", chainparams->network_name);
 	json_object_start(req->stream, "feature_set");
 	for (enum feature_place fp = 0; fp < NUM_FEATURE_PLACE; fp++) {
-		if (plugin_feature_place_names[fp]) {
+		if (feature_place_names[fp]) {
 			json_add_hex_talarr(req->stream,
-					    plugin_feature_place_names[fp],
+					    feature_place_names[fp],
 					    ld->our_features->bits[fp]);
 		}
 	}

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -56,6 +56,19 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
 	return p;
 }
 
+void plugins_free(struct plugins *plugins)
+{
+	struct plugin *p;
+	/* Plugins are usually the unit of allocation, and they are internally
+	 * consistent, so let's free each plugin first. */
+	while (!list_empty(&plugins->plugins)) {
+		p = list_pop(&plugins->plugins, struct plugin, list);
+		tal_free(p);
+	}
+
+	tal_free(plugins);
+}
+
 static void destroy_plugin(struct plugin *p)
 {
 	struct plugin_rpccall *call;

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -190,6 +190,9 @@ void per_peer_state_set_fds_arr(struct per_peer_state *pps UNNEEDED, const int *
 /* Generated stub for plugins_config */
 void plugins_config(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_config called!\n"); abort(); }
+/* Generated stub for plugins_free */
+void plugins_free(struct plugins *plugins UNNEEDED)
+{ fprintf(stderr, "plugins_free called!\n"); abort(); }
 /* Generated stub for plugins_init */
 void plugins_init(struct plugins *plugins UNNEEDED, const char *dev_plugin_debug UNNEEDED)
 { fprintf(stderr, "plugins_init called!\n"); abort(); }

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -10,6 +10,9 @@ PLUGIN_FUNDCHANNEL_OBJS := $(PLUGIN_FUNDCHANNEL_SRC:.c=.o)
 PLUGIN_BCLI_SRC := plugins/bcli.c
 PLUGIN_BCLI_OBJS := $(PLUGIN_BCLI_SRC:.c=.o)
 
+PLUGIN_KEYSEND_SRC := plugins/keysend.c
+PLUGIN_KEYSEND_OBJS := $(PLUGIN_KEYSEND_SRC:.c=.o)
+
 PLUGIN_LIB_SRC := plugins/libplugin.c
 PLUGIN_LIB_HEADER := plugins/libplugin.h
 PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
@@ -56,11 +59,13 @@ plugins/fundchannel: common/addr.o $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
 
 plugins/bcli: bitcoin/chainparams.o $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
+plugins/keysend: bitcoin/chainparams.o $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+
 $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
 
 # Make sure these depend on everything.
-ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel plugins/bcli
-ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS)
+ALL_PROGRAMS += plugins/pay plugins/autoclean plugins/fundchannel plugins/bcli plugins/keysend
+ALL_OBJS += $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS)
 
 check-source: $(PLUGIN_PAY_SRC:%=check-src-include-order/%) $(PLUGIN_AUTOCLEAN_SRC:%=check-src-include-order/%) $(PLUGIN_FUNDCHANNEL_SRC:%=check-src-include-order/%) $(PLUGIN_BCLI_SRC:%=check-src-include-order/%)
 check-source-bolt: $(PLUGIN_PAY_SRC:%=bolt-check/%) $(PLUGIN_AUTOCLEAN_SRC:%=bolt-check/%) $(PLUGIN_FUNDCHANNEL_SRC:%=bolt-check/%) $(PLUGIN_BCLI_SRC:%=bolt-check/%)

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -59,7 +59,7 @@ plugins/fundchannel: common/addr.o $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
 
 plugins/bcli: bitcoin/chainparams.o $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
-plugins/keysend: bitcoin/chainparams.o wire/gen_onion_wire.o $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+plugins/keysend: bitcoin/chainparams.o wire/tlvstream.o wire/gen_onion_wire.o $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
 $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -59,7 +59,7 @@ plugins/fundchannel: common/addr.o $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_LIB_OBJS)
 
 plugins/bcli: bitcoin/chainparams.o $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
-plugins/keysend: bitcoin/chainparams.o $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+plugins/keysend: bitcoin/chainparams.o wire/gen_onion_wire.o $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
 $(PLUGIN_PAY_OBJS) $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_FUNDCHANNEL_OBJS) $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS): $(PLUGIN_LIB_HEADER)
 

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -88,7 +88,7 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands, ARRAY_SIZE(commands),
 	            NULL, 0, NULL, 0,
 		    plugin_option("autocleaninvoice-cycle",
 				  "string",

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -947,7 +947,7 @@ int main(int argc, char *argv[])
 	bitcoind->rpcport = NULL;
 	bitcoind->max_fee_multiplier = 10;
 
-	plugin_main(argv, init, PLUGIN_STATIC, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, PLUGIN_STATIC, NULL, commands, ARRAY_SIZE(commands),
 		    NULL, 0, NULL, 0,
 		    plugin_option("bitcoin-datadir",
 				  "string",

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -446,6 +446,6 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
-	            NULL, 0, NULL, 0, NULL);
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands,
+		    ARRAY_SIZE(commands), NULL, 0, NULL, 0, NULL);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -18,17 +18,13 @@ static struct command_result *
 htlc_accepted_continue(struct command *cmd, struct tlv_tlv_payload *payload)
 {
 	struct json_stream *response;
-	u8 *binpayload, *rawpayload;
 	response = jsonrpc_stream_success(cmd);
 
 	json_add_string(response, "result", "continue");
 	if (payload) {
-		binpayload = tal_arr(cmd, u8, 0);
+		u8 *binpayload = tal_arr(cmd, u8, 0);
 		towire_tlvstream_raw(&binpayload, payload->fields);
-		rawpayload = tal_arr(cmd, u8, 0);
-		towire_bigsize(&rawpayload, tal_bytelen(binpayload));
-		towire(&rawpayload, binpayload, tal_bytelen(binpayload));
-		json_add_string(response, "payload", tal_hex(cmd, rawpayload));
+		json_add_string(response, "payload", tal_hex(cmd, binpayload));
 	}
 	return command_finished(cmd, response);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -131,4 +131,7 @@ int main(int argc, char *argv[])
 	setup_locale();
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
 	            NULL, 0, hooks, ARRAY_SIZE(hooks), NULL);
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands,
+		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
+		    NULL);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -1,5 +1,8 @@
 #include <ccan/array_size/array_size.h>
 #include <plugins/libplugin.h>
+#include <wire/gen_onion_wire.h>
+
+#define PREIMAGE_TLV_TYPE 5482373484
 
 static void init(struct plugin *p, const char *buf UNUSED,
 		 const jsmntok_t *config UNUSED)
@@ -9,10 +12,108 @@ static void init(struct plugin *p, const char *buf UNUSED,
 static const struct plugin_command commands[] = {
 };
 
+static struct command_result *htlc_accepted_continue(struct command *cmd)
+{
+	struct json_stream *response;
+	response = jsonrpc_stream_success(cmd);
+	json_add_string(response, "result", "continue");
+	return command_finished(cmd, response);
+}
+
+static struct command_result *htlc_accepted_resolve(struct command *cmd,
+						    char *hexpreimage)
+{
+	struct json_stream *response;
+	response = jsonrpc_stream_success(cmd);
+	json_add_string(response, "result", "resolve");
+	json_add_string(response, "payment_key", hexpreimage);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *htlc_accepted_call(struct command *cmd, const char *buf,
+					  const jsmntok_t *params)
+{
+	const jsmntok_t *payloadt = json_delve(buf, params, ".onion.payload");
+	const jsmntok_t *payment_hash_tok = json_delve(buf, params, ".htlc.payment_hash");
+	const u8 *rawpayload;
+	size_t max;
+	struct tlv_tlv_payload *payload;
+	struct tlv_field *preimage_field = NULL;
+	char *hexpreimage, *hexpaymenthash;
+	struct sha256 payment_hash;
+	bigsize_t s;
+
+	if (!payloadt)
+		return htlc_accepted_continue(cmd);
+
+	rawpayload = json_tok_bin_from_hex(cmd, buf, payloadt);
+	max = tal_bytelen(rawpayload);
+	payload = tlv_tlv_payload_new(cmd);
+
+	s = fromwire_varint(&rawpayload, &max);
+	if (s != max) {
+		return htlc_accepted_continue(cmd);
+	}
+	fromwire_tlv_payload(&rawpayload, &max, payload);
+
+	/* Try looking for the field that contains the preimage */
+	for (int i=0; i<tal_count(payload->fields); i++) {
+		if (payload->fields[i].numtype == PREIMAGE_TLV_TYPE) {
+			preimage_field = &payload->fields[i];
+			break;
+		}
+	}
+
+	/* If we don't have a preimage field then this is not a keysend, let
+	 * someone else take care of it. */
+	if (preimage_field == NULL)
+		return htlc_accepted_continue(cmd);
+
+	/* If the preimage is not 32 bytes long then we can't accept the
+	 * payment. */
+	if (preimage_field->length != 32) {
+		plugin_log(cmd->plugin, LOG_UNUSUAL,
+			   "Sender specified a preimage that is %zu bytes long, "
+			   "we expected 32 bytes. Ignoring this HTLC.",
+			   preimage_field->length);
+		return htlc_accepted_continue(cmd);
+	}
+
+	hexpreimage = tal_hex(cmd, preimage_field->value);
+
+	/* If the preimage doesn't hash to the payment_hash we must continue,
+	 * maybe someone else knows how to handle these. */
+	sha256(&payment_hash, preimage_field->value, preimage_field->length);
+	hexpaymenthash = tal_hexstr(cmd, &payment_hash, sizeof(payment_hash));
+	if (!json_tok_streq(buf, payment_hash_tok, hexpaymenthash)) {
+		plugin_log(
+		    cmd->plugin, LOG_UNUSUAL,
+		    "Preimage provided by the sender does not match the "
+		    "payment_hash: SHA256(%s)=%s != %.*s. Ignoring keysend.",
+		    hexpreimage, hexpaymenthash,
+		    payment_hash_tok->end - payment_hash_tok->start,
+		    buf + payment_hash_tok->start);
+		return htlc_accepted_continue(cmd);
+	}
+
+	/* Finally we can resolve the payment with the preimage. */
+	plugin_log(cmd->plugin, LOG_INFORM,
+		   "Resolving incoming HTLC with preimage for payment_hash %s "
+		   "provided in the onion payload.",
+		   hexpaymenthash);
+	return htlc_accepted_resolve(cmd, hexpreimage);
+}
+
+static const struct plugin_hook hooks[] = {
+	{
+		"htlc_accepted",
+		htlc_accepted_call
+	},
+};
 
 int main(int argc, char *argv[])
 {
 	setup_locale();
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
-	            NULL, 0, NULL, 0, NULL);
+	            NULL, 0, hooks, ARRAY_SIZE(hooks), NULL);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -1,0 +1,18 @@
+#include <ccan/array_size/array_size.h>
+#include <plugins/libplugin.h>
+
+static void init(struct plugin *p, const char *buf UNUSED,
+		 const jsmntok_t *config UNUSED)
+{
+}
+
+static const struct plugin_command commands[] = {
+};
+
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
+	            NULL, 0, NULL, 0, NULL);
+}

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -3,6 +3,7 @@
 #include <wire/gen_onion_wire.h>
 
 #define PREIMAGE_TLV_TYPE 5482373484
+#define KEYSEND_FEATUREBIT 55
 
 static void init(struct plugin *p, const char *buf UNUSED,
 		 const jsmntok_t *config UNUSED)
@@ -128,10 +129,14 @@ static const struct plugin_hook hooks[] = {
 
 int main(int argc, char *argv[])
 {
+	struct feature_set features;
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
-	            NULL, 0, hooks, ARRAY_SIZE(hooks), NULL);
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands,
+
+	for (int i=0; i<ARRAY_SIZE(features.bits); i++)
+		features.bits[i] = tal_arr(NULL, u8, 0);
+	set_feature_bit(&features.bits[NODE_ANNOUNCE_FEATURE], KEYSEND_FEATUREBIT);
+
+	plugin_main(argv, init, PLUGIN_STATIC, &features, commands,
 		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
 		    NULL);
 }

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -9,6 +9,7 @@
 #include <ccan/time/time.h>
 #include <ccan/timer/timer.h>
 #include <common/errcode.h>
+#include <common/features.h>
 #include <common/json.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
@@ -245,6 +246,7 @@ void NORETURN LAST_ARG_NULL plugin_main(char *argv[],
 					void (*init)(struct plugin *p,
 						     const char *buf, const jsmntok_t *),
 					const enum plugin_restartability restartability,
+					struct feature_set *features,
 					const struct plugin_command *commands,
 					size_t num_commands,
 					const struct plugin_notification *notif_subs,

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1712,6 +1712,6 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
-	            NULL, 0, NULL, 0, NULL);
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands,
+		    ARRAY_SIZE(commands), NULL, 0, NULL, 0, NULL);
 }

--- a/tests/plugins/keysend.py
+++ b/tests/plugins/keysend.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Temporary keysend plugin until we implement it in C
+
+This plugin is just used to test the ability to receive keysend payments until
+we implement it in `plugins/keysend.c`. Most of this code is borrowed from the
+noise plugin.
+
+"""
+
+from pyln.client import Plugin, RpcError
+from pyln.proto.onion import TlvPayload, Tu32Field, Tu64Field
+from binascii import hexlify
+import os
+import hashlib
+import struct
+
+
+plugin = Plugin()
+TLV_KEYSEND_PREIMAGE = 5482373484
+
+
+def serialize_payload(n, blockheight):
+    """Serialize a legacy payload.
+    """
+    block, tx, out = n['channel'].split('x')
+    payload = hexlify(struct.pack(
+        "!cQQL", b'\x00',
+        int(block) << 40 | int(tx) << 16 | int(out),
+        int(n['amount_msat']),
+        blockheight + n['delay'])).decode('ASCII')
+    payload += "00" * 12
+    return payload
+
+
+def buildpath(plugin, node_id, payload, amt, exclusions):
+    blockheight = plugin.rpc.getinfo()['blockheight']
+    route = plugin.rpc.getroute(node_id, amt, 10, exclude=exclusions)['route']
+    first_hop = route[0]
+    # Need to shift the parameters by one hop
+    hops = []
+    for h, n in zip(route[:-1], route[1:]):
+        # We tell the node h about the parameters to use for n (a.k.a. h + 1)
+        hops.append({
+            "type": "legacy",
+            "pubkey": h['id'],
+            "payload": serialize_payload(n, blockheight)
+        })
+
+    pl = TlvPayload()
+    pl.fields.append(Tu64Field(2, amt))
+    pl.fields.append(Tu32Field(4, route[-1]['delay']))
+
+    for f in payload.fields:
+        pl.add_field(f.typenum, f.value)
+
+    # The last hop has a special payload:
+    hops.append({
+        "type": "tlv",
+        "pubkey": route[-1]['id'],
+        "payload": hexlify(pl.to_bytes()).decode('ASCII'),
+    })
+    print(f"Keysend payload {hexlify(pl.to_bytes())}")
+    return first_hop, hops, route
+
+
+def deliver(node_id, payload, amt, payment_hash, max_attempts=5):
+    """Do your best to deliver `payload` to `node_id`.
+    """
+    exclusions = []
+    payment_hash = hexlify(payment_hash).decode('ASCII')
+
+    for attempt in range(max_attempts):
+        plugin.log("Starting attempt {} to deliver message to {}".format(attempt, node_id))
+
+        first_hop, hops, route = buildpath(plugin, node_id, payload, amt, exclusions)
+        onion = plugin.rpc.createonion(hops=hops, assocdata=payment_hash)
+
+        plugin.rpc.sendonion(
+            onion=onion['onion'],
+            first_hop=first_hop,
+            payment_hash=payment_hash,
+            shared_secrets=onion['shared_secrets'],
+        )
+        try:
+            plugin.rpc.waitsendpay(payment_hash=payment_hash)
+            return {'route': route, 'payment_hash': payment_hash, 'attempt': attempt}
+        except RpcError as e:
+            failcode = e.error['data']['failcode']
+            failingidx = e.error['data']['erring_index']
+            if failcode == 16399 or failingidx == len(hops):
+                return {
+                    'route': route,
+                    'payment_hash': payment_hash,
+                    'attempt': attempt + 1
+                }
+
+            plugin.log("Retrying delivery.")
+
+            # TODO Store the failing channel in the exclusions
+    raise ValueError('Could not reach destination {node_id}'.format(node_id=node_id))
+
+
+@plugin.method('keysend')
+def keysend(node_id, amount, plugin):
+    payload = TlvPayload()
+    payment_key = os.urandom(32)
+    payment_hash = hashlib.sha256(payment_key).digest()
+    payload.add_field(TLV_KEYSEND_PREIMAGE, payment_key)
+    res = deliver(
+        node_id,
+        payload,
+        amt=amount,
+        payment_hash=payment_hash
+    )
+    return res
+
+
+plugin.run()

--- a/tests/plugins/replace_payload.py
+++ b/tests/plugins/replace_payload.py
@@ -13,11 +13,16 @@ plugin = Plugin()
 def on_htlc_accepted(htlc, onion, plugin, **kwargs):
     # eg. '2902017b04016d0821fff5b6bd5018c8731aa0496c3698ef49f132ef9a3000c94436f4957e79a2f8827b'
     # (but values change depending on pay's randomness!)
+    print("payload was:{}".format(onion['payload']))
+    assert onion['payload'][0:2] == '29'
+
     if plugin.replace_payload == 'corrupt_secret':
+        # Note: we don't include length prefix in returned payload, since it doesn't
+        # support the pre-TLV legacy form.
         if onion['payload'][18] == '0':
-            newpayload = onion['payload'][:18] + '1' + onion['payload'][19:]
+            newpayload = onion['payload'][2:18] + '1' + onion['payload'][19:]
         else:
-            newpayload = onion['payload'][:18] + '0' + onion['payload'][19:]
+            newpayload = onion['payload'][2:18] + '0' + onion['payload'][19:]
     else:
         newpayload = plugin.replace_payload
     print("payload was:{}".format(onion['payload']))

--- a/tests/plugins/replace_payload.py
+++ b/tests/plugins/replace_payload.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Plugin that replaces HTLC payloads.
+
+This feature is important if we want to accept an HTLC tlv field not
+accepted by lightningd.
+"""
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin, **kwargs):
+    # eg. '2902017b04016d0821fff5b6bd5018c8731aa0496c3698ef49f132ef9a3000c94436f4957e79a2f8827b'
+    # (but values change depending on pay's randomness!)
+    if plugin.replace_payload == 'corrupt_secret':
+        if onion['payload'][18] == '0':
+            newpayload = onion['payload'][:18] + '1' + onion['payload'][19:]
+        else:
+            newpayload = onion['payload'][:18] + '0' + onion['payload'][19:]
+    else:
+        newpayload = plugin.replace_payload
+    print("payload was:{}".format(onion['payload']))
+    print("payload now:{}".format(newpayload))
+
+    return {'result': 'continue', 'payload': newpayload}
+
+
+@plugin.method('setpayload')
+def setpayload(plugin, payload: bool):
+    plugin.replace_payload = payload
+    return {}
+
+
+plugin.run()

--- a/tests/plugins/test_libplugin.c
+++ b/tests/plugins/test_libplugin.c
@@ -123,7 +123,7 @@ static const struct plugin_notification notifs[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, PLUGIN_RESTARTABLE, NULL, commands, ARRAY_SIZE(commands),
 	            notifs, ARRAY_SIZE(notifs), hooks, ARRAY_SIZE(hooks),
 		    plugin_option("name",
 				  "string",

--- a/wire/tlvstream.c
+++ b/wire/tlvstream.c
@@ -1,0 +1,21 @@
+#include <wire/tlvstream.h>
+#include <wire/wire.h>
+
+void towire_tlvstream_raw(u8 **pptr, const struct tlv_field *fields)
+{
+	if (!fields)
+		return;
+
+	for (size_t i = 0; i < tal_count(fields); i++) {
+		const struct tlv_field *field = &fields[i];
+		/* BOLT #1:
+		 *
+		 * The sending node:
+		 ...
+		 *  - MUST minimally encode `type` and `length`.
+		 */
+		towire_bigsize(pptr, field->numtype);
+		towire_bigsize(pptr, field->length);
+		towire(pptr, field->value, field->length);
+	}
+}

--- a/wire/tlvstream.h
+++ b/wire/tlvstream.h
@@ -34,4 +34,7 @@ void towire_tlvs(u8 **pptr,
 		 size_t num_types,
 		 const void *record);
 
+/* Given any tlvstream serialize the raw fields (untyped ones). */
+void towire_tlvstream_raw(u8 **pptr, const struct tlv_field *fields);
+
 #endif /* LIGHTNING_WIRE_TLVSTREAM_H */


### PR DESCRIPTION
The `keysend` plugin implements the ability to receive spontaneous payments by
including the `payment_preimage` in the onion payload, thus giving the
recipient the ability to claim the payment without having to exchange invoices
first. This sometimes erroneously called a sphinx-send, and can lead to
confusion with the onion routing protocol based on the sphinx paper.

The plugin has the ability to extract the preimage from the payload and will
tell `lightningd` to resolve the HTLC with the provided preimage. As proposed
by @rustyrussell, in order to keep track of funds, `lightningd` will create an
ad-hoc invoice that is immediately fulfilled via the resolved HTLC. This
ensures that we have an entry in the incoming payments, even though we didn't
really have a matching invoice. The ad-hoc invoice is generated whenever a
plugin tells `lightningd` to resolve an HTLC, so that these payments
terminated by plugins now always leave an accounting entry in the database.

Due to the uniqueness constraint on `payment_hash` in the `invoices` table we
cannot always insert an invoice that matches the resolved HTLC, in which case
we will simply not add an entry. This should happen rarely since re-using a
`payment_hash` is inherently insecure, e.g., it allows any node involved in
routing the first payment to grab the second payment. Alternatively we could
also reject the payment due to this protocol violation on the sender side,
however that'd be handing the funds to a (so far) well behaved node that
forwarded the payment despite being able to grab it, leaving the sender out of
pocket, and the recipient without the funds it could have gotten.

Since ad-hoc invoices do not need a `features` fields and `bolt11` string,
which in turn would require asking the `hsmd` for a signature, we made those
two fields nullable (changelog warning added).

Sending support for `keysend` payments will be added in a separate pull
request since it requires abstracting the internals of the `pay` plugin so we
can reuse them here.

As a side note: the keysend plugin will make sure it understands all the
mandatory TLV fields, and issue a `continue` otherwise. This was done in order
to allow alternative plugins to terminate keysends that have additional
information. One example is the `noise` plugin that terminates `keysend`
payments that are sent along a chat message (which has a mandatory TLV-type)
and associates the message with the incoming payment.