### PR TITLE
Fix fundchannel in deprecated-apis=false mode ('satoshi' param in fundchannel_start)

### DIFF
--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -270,8 +270,6 @@ static struct command_result *fundchannel_start(struct command *cmd,
 
 	json_add_string(req->js, "id", node_id_to_hexstr(tmpctx, fr->id));
 
-	if (deprecated_apis)
-		json_add_string(req->js, "satoshi", fr->funding_str);
 	json_add_string(req->js, "amount", fr->funding_str);
 
 	if (fr->feerate_str)


### PR DESCRIPTION
Noticed while testing #3611 https://github.com/ElementsProject/lightning/pull/3603/commits/49e21538cc99e8f7340d174f02b853cc582dfd2a kept `satoshi` but did not make `fundchannel_start` accept it again.

Note that we run the functional tests with deprecated-apis=false so we did not catch this, but users run with deprecated-apis=true..