### PR TITLE
pyln-testing: Also test against deprecated apis

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -66,6 +66,7 @@ TEST_NETWORK = env("TEST_NETWORK", 'regtest')
 DEVELOPER = env("DEVELOPER", "0") == "1"
 TEST_DEBUG = env("TEST_DEBUG", "0") == "1"
 SLOW_MACHINE = env("SLOW_MACHINE", "0") == "1"
+DEPRECATED_APIS = env("DEPRECATED_APIS", "0") == "1"
 TIMEOUT = int(env("TIMEOUT", 180 if SLOW_MACHINE else 60))
 
 
@@ -479,7 +480,8 @@ class LightningD(TailableProc):
         opts = {
             'lightning-dir': lightning_dir,
             'addr': '127.0.0.1:{}'.format(port),
-            'allow-deprecated-apis': 'false',
+            'allow-deprecated-apis': '{}'.format("true" if DEPRECATED_APIS
+                                                 else "false"),
             'network': TEST_NETWORK,
             'ignore-fee-limits': 'false',
             'bitcoin-rpcuser': BITCOIND_CONFIG['rpcuser'],

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,8 +6,8 @@ from flaky import flaky  # noqa: F401
 from pyln.client import RpcError
 from threading import Event
 from pyln.testing.utils import (
-    DEVELOPER, TIMEOUT, VALGRIND, sync_blockheight, only_one, wait_for,
-    TailableProc, env
+    DEVELOPER, TIMEOUT, VALGRIND, DEPRECATED_APIS, sync_blockheight, only_one,
+    wait_for, TailableProc, env
 )
 from ephemeral_port_reserve import reserve
 from utils import EXPERIMENTAL_FEATURES
@@ -743,6 +743,7 @@ def test_address(node_factory):
     l2.rpc.connect(l1.info['id'], l1.daemon.opts['addr'])
 
 
+@unittest.skipIf(DEPRECATED_APIS, "Tests the --allow-deprecated-apis config")
 def test_listconfigs(node_factory, bitcoind, chainparams):
     # Make extremely long entry, check it works
     l1 = node_factory.get_node(options={'log-prefix': 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'})
@@ -1352,7 +1353,10 @@ def test_ipv4_and_ipv6(node_factory):
         assert int(bind[0]['port']) == port
 
 
-@unittest.skipIf(not DEVELOPER, "Without DEVELOPER=1 we snap to FEERATE_FLOOR on testnets")
+@unittest.skipIf(
+    not DEVELOPER or DEPRECATED_APIS, "Without DEVELOPER=1 we snap to "
+    "FEERATE_FLOOR on testnets, and we test the new API."
+)
 def test_feerates(node_factory):
     l1 = node_factory.get_node(options={'log-level': 'io'}, start=False)
     l1.daemon.rpcproxy.mock_rpc('estimatesmartfee', {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,7 +5,8 @@ from hashlib import sha256
 from pyln.client import RpcError, Millisatoshi
 from pyln.proto import Invoice
 from utils import (
-    DEVELOPER, only_one, sync_blockheight, TIMEOUT, wait_for, TEST_NETWORK, expected_features
+    DEVELOPER, only_one, sync_blockheight, TIMEOUT, wait_for, TEST_NETWORK,
+    DEPRECATED_APIS, expected_features
 )
 
 import json
@@ -46,6 +47,7 @@ def test_option_passthrough(node_factory, directory):
     n.stop()
 
 
+@unittest.skipIf(DEPRECATED_APIS, "We test the new API.")
 def test_option_types(node_factory):
     """Ensure that desired types of options are
        respected in output """
@@ -914,7 +916,9 @@ def test_libplugin(node_factory):
     assert l1.rpc.call("testrpc") == l1.rpc.getinfo()
 
 
-@unittest.skipIf(not DEVELOPER, "needs LIGHTNINGD_DEV_LOG_IO")
+@unittest.skipIf(
+    not DEVELOPER or DEPRECATED_APIS, "needs LIGHTNINGD_DEV_LOG_IO and new API"
+)
 def test_plugin_feature_announce(node_factory):
     """Check that features registered by plugins show up in messages.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from pyln.testing.utils import TEST_NETWORK, SLOW_MACHINE, TIMEOUT, VALGRIND, DEVELOPER  # noqa: F401
+from pyln.testing.utils import TEST_NETWORK, SLOW_MACHINE, TIMEOUT, VALGRIND, DEVELOPER, DEPRECATED_APIS  # noqa: F401
 from pyln.testing.utils import env, only_one, wait_for, write_config, TailableProc, sync_blockheight, wait_channel_quiescent, get_tx_p2wsh_outnum  # noqa: F401
 
 


### PR DESCRIPTION
This adds a new environment var, `DEPRECATED_APIS`, to allow to quickly run the functional tests against the `lightningd` API users will likely use.

I wanted to also add a Travis job, but am not sure if it's possible to run another one at all. At least we can still set this locally.