### PR TITLE
pay: Speed up `pay` and fix the shadow route construction

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1104,6 +1104,7 @@ static struct command_result *shadow_route(struct command *cmd,
 
 	req = jsonrpc_request_start(cmd->plugin, cmd, "listchannels",
 				    add_shadow_route, forward_error, pc);
+	json_add_string(req->js, "source", pc->shadow_dest);
 	return send_outreq(cmd->plugin, req);
 }
 


### PR DESCRIPTION
The shadow route algorithm is extending the route randomly using channels
adjacent to the current destination, in the hope to create a plausible route
extension. However, instead of only retrieving the channels adjacent to the
destination it was retrieving all channels in the entire topology, and
selecting a random channel from there. This resulted in a very large request
for all channels being processed, and then mostly not being used, but also in
shadow extensions to the path which were not plausible (they didn't extend the
real path, just random edges). This is fixed by restricting the call to
`listchannels` to the channels with the current destination as source.

On my laptop retrieving all channels in the current mainnet takes
approximately 1.2 seconds, and given the geometric series expansion of the 50%
extension probability this indeed would result in an overhead of 1.2 seconds
to the `pay` command. In contrast specifying a source results in an overhead
of ~30ms.

So good news everyone, your pay commands just shaved 1.17 seconds off their
runtime.