### PR TITLE
lightningd: don't log BROKEN when we don't have a channel update.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -157,14 +157,10 @@ static void failmsg_update_reply(struct subd *gossipd,
 	u8 *stripped_update;
 	struct failed_htlc *failed_htlc;
 
-	/* In theory, we could have no update because channel suddenly closed,
-	 * but it's v. unlikely */
+	/* This can happen because channel never got properly announced.*/
 	if (!fromwire_gossip_get_stripped_cupdate_reply(msg, msg,
 							&stripped_update)
 	    || !tal_count(stripped_update)) {
-		log_broken(gossipd->log,
-			   "bad fromwire_gossip_get_stripped_cupdate %s",
-			   tal_hex(msg, msg));
 		failmsg = towire_temporary_node_failure(NULL);
 	} else {
 		/* End of failmsg is two zero bytes (empty update). */


### PR DESCRIPTION
This happened on my testnet node because I've been failing to reconnect to
a node which created a channel and never exchanged announcement sigs.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None (change was introduced since last release)