### PR TITLE
devtools/decodemsg: don't crash if we have multiple tlv options.

### DIFF
--- a/tools/gen/print_impl_template
+++ b/tools/gen/print_impl_template
@@ -138,9 +138,8 @@ ${print_fieldset(msg.fields.values(), False, '&cursor', '&plen')}
 
 void print${options.enum_name}_tlv_message(const char *tlv_name, const u8 *msg) {
 % if bool(tlvs):
-	size_t plen;
+	size_t plen = tal_count(msg);
     % for tlv_name in tlvs:
-	plen = tal_count(msg);
 	if (strcmp(tlv_name, "${tlv_name}") == 0) {
 		printwire_tlvs(tlv_name, &msg, &plen, print_tlvs_${tlv_name}, ARRAY_SIZE(print_tlvs_${tlv_name}));
 	}


### PR DESCRIPTION
We call tal_count(msg) after we've moved msg, and that causes an abort.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>