### PR TITLE
lightningd: allow htlc_accepted hook to replace onion payload.

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -803,6 +803,11 @@ This means that the plugin does not want to do anything special and
 if we're the recipient, or attempt to forward it otherwise. Notice that the
 usual checks such as sufficient fees and CLTV deltas are still enforced.
 
+It can also replace the `onion.payload` by specifying a `payload` in
+the response.  This will be re-parsed; it's useful for removing onion
+fields which a plugin doesn't want lightningd to consider.
+
+
 ```json
 {
   "result": "fail",

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -316,15 +316,22 @@ invoice_check_payment(const tal_t *ctx,
 	 *    - MUST fail the HTLC.
 	 */
 	if (feature_is_set(details->features, COMPULSORY_FEATURE(OPT_VAR_ONION))
-	    && !payment_secret)
+	    && !payment_secret) {
+		log_debug(ld->log, "Attept to pay %s without secret",
+			  type_to_string(tmpctx, struct sha256, &details->rhash));
 		return tal_free(details);
+	}
 
 	if (payment_secret) {
 		struct secret expected;
 
 		invoice_secret(&details->r, &expected);
-		if (!secret_eq_consttime(payment_secret, &expected))
+		if (!secret_eq_consttime(payment_secret, &expected)) {
+			log_debug(ld->log, "Attept to pay %s with wrong secret",
+				  type_to_string(tmpctx, struct sha256,
+						 &details->rhash));
 			return tal_free(details);
+		}
 	}
 
 	/* BOLT #4:

--- a/tests/plugins/replace_payload.py
+++ b/tests/plugins/replace_payload.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Plugin that replaces HTLC payloads.
+
+This feature is important if we want to accept an HTLC tlv field not
+accepted by lightningd.
+"""
+
+
+from pyln.client import Plugin
+import json
+import os
+import tempfile
+import time
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin, **kwargs):
+    # eg. '2902017b04016d0821fff5b6bd5018c8731aa0496c3698ef49f132ef9a3000c94436f4957e79a2f8827b'
+    # (but values change depending on pay's randomness!)
+    if plugin.replace_payload == 'corrupt_secret':
+        if onion['payload'][18] == '0':
+            newpayload = onion['payload'][:18] + '1' + onion['payload'][19:]
+        else:
+            newpayload = onion['payload'][:18] + '0' + onion['payload'][19:]
+    else:
+        newpayload = plugin.replace_payload
+    print("payload was:{}".format(onion['payload']))
+    print("payload now:{}".format(newpayload))
+
+    return {'result': 'continue', 'payload': newpayload}
+
+
+@plugin.method('setpayload')
+def setpayload(plugin, payload: bool):
+    plugin.replace_payload = payload
+    return {}
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1168,3 +1168,23 @@ def test_feature_set(node_factory):
     assert fs['node'] == expected_features()
     assert fs['channel'] == ''
     assert 'invoice' in fs
+
+
+def test_replacement_payload(node_factory):
+    """Test that htlc_accepted plugin hook can replace payload"""
+    plugin = os.path.join(os.path.dirname(__file__), 'plugins/replace_payload.py')
+    l1, l2 = node_factory.line_graph(2, opts=[{}, {"plugin": plugin}])
+
+    # Replace with an invalid payload.
+    l2.rpc.call('setpayload', ['0000'])
+    inv = l2.rpc.invoice(123, 'test_replacement_payload', 'test_replacement_payload')['bolt11']
+    with pytest.raises(RpcError, match=r"WIRE_INVALID_ONION_PAYLOAD \(reply from remote\)"):
+        l1.rpc.pay(inv)
+
+    # Replace with valid payload, but corrupt payment_secret
+    l2.rpc.call('setpayload', ['corrupt_secret'])
+
+    with pytest.raises(RpcError, match=r"WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS \(reply from remote\)"):
+        l1.rpc.pay(inv)
+
+    assert l2.daemon.wait_for_log("Attept to pay.*with wrong secret")


### PR DESCRIPTION
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-added: `htlc_accepted` hook can now offer a replacement onion `payload`.