### PR TITLE
libplugin: fix compilation issue on recent gccs.

### DIFF
--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -20,8 +20,6 @@
 
 #define READ_CHUNKSIZE 4096
 
-const struct chainparams *chainparams;
-
 bool deprecated_apis;
 
 struct plugin_timer {


### PR DESCRIPTION
They now use -fno-common by default, so duplicated variables cause
a link error:

/usr/bin/ld: common/utils.o:(.bss+0x10): multiple definition of `chainparams'; plugins/libplugin.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:408: plugins/autoclean] Error 1

This was introduced in 9ebfdf0b8c8faa0267cbc4c55474b968c2467c32.

Fixes: #3597
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Fixed: Multiple definition of chainparams on Fedora (or other really recent gcc)