### PR TITLE
common/json_stream.c: Implement a `json_add_jsonstr` to add already-JSON strings to `json_stream` objects

### DIFF
--- a/common/json_stream.c
+++ b/common/json_stream.c
@@ -162,6 +162,18 @@ void json_add_member(struct json_stream *js,
 	va_end(ap);
 }
 
+void json_add_jsonstr(struct json_stream *js,
+		      const char *fieldname,
+		      const char *jsonstr)
+{
+	char *p;
+	size_t len = strlen(jsonstr);
+
+	p = json_member_direct(js, fieldname, len);
+
+	memcpy(p, jsonstr, len);
+}
+
 /* This is where we read the json_stream and write it to conn */
 static struct io_plan *json_stream_output_write(struct io_conn *conn,
 						struct json_stream *js)

--- a/common/json_stream.h
+++ b/common/json_stream.h
@@ -115,6 +115,18 @@ void json_add_member(struct json_stream *js,
 		     const char *fmt, ...) PRINTF_FMT(4,5);
 
 /**
+ * json_add_jsonstr - add a JSON entity in a string that is already
+ * JSON-formatted.
+ * @js: the json_stream.
+ * @fieldname: fieldname (if in object), otherwise must be NULL.
+ * @jsonstr: the JSON entity, must be non-NULL, a null-terminated
+ * string that is already formatted in JSON.
+ */
+void json_add_jsonstr(struct json_stream *js,
+		      const char *fieldname,
+		      const char *jsonstr);
+
+/**
  * json_member_direct - start a generic member.
  * @js: the json_stream.
  * @fieldname: fieldname (if in object), otherwise must be NULL.

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -44,17 +44,6 @@ struct funding_req {
 	const char *error;
 };
 
-/* Helper to copy JSON object directly into a json_out */
-static void json_out_add_raw_len(struct json_out *jout,
-				 const char *fieldname,
-				 const char *jsonstr, size_t len)
-{
-	char *p;
-
-	p = json_out_member_direct(jout, fieldname, len);
-	memcpy(p, jsonstr, len);
-}
-
 static struct command_result *send_prior(struct command *cmd,
 					 const char *buf,
 					 const jsmntok_t *error,
@@ -220,8 +209,7 @@ static void txprepare(struct json_stream *js,
 	if (fr->minconf)
 		json_add_u32(js, "minconf", *fr->minconf);
 	if (fr->utxo_str)
-		json_out_add_raw_len(js->jout, "utxos", fr->utxo_str,
-				     strlen(fr->utxo_str));
+		json_add_jsonstr(js, "utxos", fr->utxo_str);
 }
 
 static struct command_result *prepare_actual(struct command *cmd,


### PR DESCRIPTION
Also incidentally fixes #3613