### PR TITLE
channeld: defer first update_fee until we have an HTLC to send.

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2749,7 +2749,12 @@ static void handle_feerates(struct peer *peer, const u8 *inmsg)
 	 */
 	if (peer->channel->funder == LOCAL) {
 		peer->desired_feerate = feerate;
-		start_commit_timer(peer);
+		/* Don't do this for the first feerate, wait until something else
+		 * happens.  LND seems to get upset in some cases otherwise:
+		 * see https://github.com/ElementsProject/lightning/issues/3596 */
+		if (peer->next_index[LOCAL] != 1
+		    || peer->next_index[REMOTE] != 1)
+			start_commit_timer(peer);
 	} else {
 		/* BOLT #2:
 		 *

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -228,6 +228,9 @@ def test_pay_disconnect(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, opts={'dev-max-fee-multiplier': 5,
                                               'may_reconnect': True})
 
+    # Dummy payment to kick off update_fee messages
+    l1.pay(l2, 1000)
+
     inv = l2.rpc.invoice(123000, 'test_pay_disconnect', 'description')
     rhash = inv['payment_hash']
 


### PR DESCRIPTION
Sending update_fee immediately after channel establishment seems to
upset LND, so work around it by deferring it.  The reason we increase
the fee after establishment is because now we might need to close the
channel in a hurry due to htlcs, but until there are htlcs that's
unnecessary.

Workaround for #3596
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>