### PR TITLE
pyln-testing: specify fallbackfee for newer versions of bitcoind

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1,3 +1,4 @@
+from bitcoin.core import COIN
 from bitcoin.rpc import RawProxy as BitcoinProxy
 from pyln.client import RpcError
 from pyln.testing.btcproxy import BitcoinRpcProxy
@@ -25,6 +26,7 @@ BITCOIND_CONFIG = {
     "regtest": 1,
     "rpcuser": "rpcuser",
     "rpcpassword": "rpcpass",
+    "fallbackfee": Decimal(1000) / COIN,
 }
 
 


### PR DESCRIPTION
The last versions (I think since 0.19.0.1 but not sure) of `bitcoind` disabled the fallbackfee by default, it screwed up my scripts but I just noticed `pyln` too now I installed it globally..