### PR TITLE
Weekly cleanups

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -616,7 +616,7 @@ struct bolt11 *bolt11_decode(const tal_t *ctx, const char *str,
 		 */
 		b11->msat = NULL;
 	} else {
-		u64 m10 = 10;
+		u64 m10 = 10 * MSAT_PER_BTC; /* Pico satoshis in a Bitcoin */
 		u64 amount;
 		char *end;
 

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1011,7 +1011,8 @@ class NodeFactory(object):
 
     def get_node(self, node_id=None, options=None, dbfile=None,
                  feerates=(15000, 11000, 7500, 3750), start=True,
-                 wait_for_bitcoind_sync=True, expect_fail=False, **kwargs):
+                 wait_for_bitcoind_sync=True, expect_fail=False,
+                 cleandir=True, **kwargs):
 
         node_id = self.get_node_id() if not node_id else node_id
         port = self.get_next_port()
@@ -1019,7 +1020,7 @@ class NodeFactory(object):
         lightning_dir = os.path.join(
             self.directory, "lightning-{}/".format(node_id))
 
-        if os.path.exists(lightning_dir):
+        if cleandir and os.path.exists(lightning_dir):
             shutil.rmtree(lightning_dir)
 
         # Get the DB backend DSN we should be using for this test and this

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -976,8 +976,8 @@ The plugin, if fee estimation succeeds, must respond with the following fields:
     - `delayed_to_us` (number), used for resolving our output from our unilateral close
     - `htlc_resolution` (number), used for resolving HTLCs after an unilateral close
     - `penalty` (number), used for resolving revoked transactions
-    - `min` (number), used as the minimum acceptable feerate
-    - `max` (number), used as the maximum acceptable feerate
+    - `min_acceptable` (number), used as the minimum acceptable feerate
+    - `max_acceptable` (number), used as the maximum acceptable feerate
 
 
 ### `getrawblockbyheight`

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -227,6 +227,30 @@ name, including a scheme such as \fBsqlite3\fR or \fBpostgres\fR followed by the
 connection parameters\.
 
 
+The default wallet corresponds to the following DSN:
+
+.nf
+.RS
+--wallet=sqlite3://$HOME/.lightning/bitcoin/lightningd.sqlite3
+.RE
+
+.fi
+
+The following is an example of a postgresql wallet DSN:
+
+.nf
+.RS
+--wallet=postgres://user:pass@localhost:5432/db_name
+.RE
+
+.fi
+
+This will connect to a the DB server running on \fBlocalhost\fR port \fB5432\fR,
+authenticate with username \fBuser\fR and password \fBpass\fR, and then use the
+database \fBdb_name\fR\. The database must exist, but the schema will be managed
+automatically by \fBlightningd\fR\.
+
+
  \fBencrypted-hsm\fR
 If set, you will be prompted to enter a password used to encrypt the \fBhsm_secret\fR\.
 Note that once you encrypt the \fBhsm_secret\fR this option will be mandatory for
@@ -283,7 +307,7 @@ extremely busy node for you to even notice\.
 
  \fBlarge-channels\fR
 Removes capacity limits for channel creation\.  Version 1\.0 of the specification
-limited channel sizes to 16777216 satoshi\.  With this option (which your
+limited channel sizes to 16777215 satoshi\.  With this option (which your
 node will advertize to peers), your node will accept larger incoming channels
 and if the peer supports it, will open larger channels\.  Note: this option
 is spelled \fBlarge-channels\fR but it's pronounced \fBwumbo\fR\.

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -182,6 +182,23 @@ Identify the location of the wallet. This is a fully qualified data source
 name, including a scheme such as `sqlite3` or `postgres` followed by the
 connection parameters.
 
+The default wallet corresponds to the following DSN:
+
+```
+--wallet=sqlite3://$HOME/.lightning/bitcoin/lightningd.sqlite3
+```
+
+The following is an example of a postgresql wallet DSN:
+
+```
+--wallet=postgres://user:pass@localhost:5432/db_name
+```
+
+This will connect to a the DB server running on `localhost` port `5432`,
+authenticate with username `user` and password `pass`, and then use the
+database `db_name`. The database must exist, but the schema will be managed
+automatically by `lightningd`.
+
  **encrypted-hsm**
 If set, you will be prompted to enter a password used to encrypt the `hsm_secret`.
 Note that once you encrypt the `hsm_secret` this option will be mandatory for

--- a/plugins/fundchannel.c
+++ b/plugins/fundchannel.c
@@ -433,7 +433,7 @@ static void init(struct plugin *p,
 static const struct plugin_command commands[] = { {
 		"fundchannel",
 		"channels",
-		"Fund channel with {id} using {satoshi} (or 'all'), at optional {feerate}. "
+		"Fund channel with {id} using {amount} (or 'all'), at optional {feerate}. "
 		"Only use outputs that have {minconf} confirmations.",
 		"Initiaties a channel open with node 'id'. Must "
 		"be connected to the node and have enough funds available at the requested minimum confirmation "

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -922,6 +922,18 @@ def test_decodepay(node_factory):
     with pytest.raises(RpcError, match='unknown feature.*100'):
         l1.rpc.decodepay('lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q4pqqqqqqqqqqqqqqqqqqszk3ed62snp73037h4py4gry05eltlp0uezm2w9ajnerhmxzhzhsu40g9mgyx5v3ad4aqwkmvyftzk4k9zenz90mhjcy9hcevc7r3lx2sphzfxz7')
 
+    # Example of an invoice without a multiplier suffix to the amount. This
+    # should then be interpreted as 7 BTC according to the spec:
+    #
+    #   `amount`: optional number in that currency, followed by an optional
+    #   `multiplier` letter. The unit encoded here is the 'social' convention of
+    #   a payment unit -- in the case of Bitcoin the unit is 'bitcoin' NOT
+    #   satoshis.
+    b11 = "lnbcrt71p0g4u8upp5xn4k45tsp05akmn65s5k2063d5fyadhjse9770xz5sk7u4x6vcmqdqqcqzynxqrrssx94cf4p727jamncsvcd8m99n88k423ruzq4dxwevfatpp5gx2mksj2swshjlx4pe3j5w9yed5xjktrktzd3nc2a04kq8yu84l7twhwgpxjn3pw"
+    b11 = l1.rpc.decodepay(b11)
+    sat_per_btc = 10**8
+    assert(b11['msatoshi'] == 7 * sat_per_btc * 1000)
+
     with pytest.raises(RpcError):
         l1.rpc.decodepay('1111111')
 


### PR DESCRIPTION

 - Fixes a wrongly interpreted multiplier-less amount
 - Allow directory reuse in `node_factory` (needed by some plugins that prepare the node directory before the node first starts, e.g., the backup plugin dropping a `backup.lock` file so the backend is ensured to stay the same).
 - Remove the `satoshi` parameter from the `fundchannel_start` docs
 - Add a demo of how the wallet DSN looks like for postgresql