### PR TITLE
plugin: Ensure RPC passthrough calls are terminated when plugin dies

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -25,6 +25,9 @@ static const errcode_t PARAM_DEV_ERROR = -2;
 /* Plugin returned an error */
 static const errcode_t PLUGIN_ERROR = -3;
 
+/* Plugin terminated while handling a request. */
+static const errcode_t PLUGIN_TERMINATED = -4;
+
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 static const errcode_t PAY_IN_PROGRESS = 200;
 static const errcode_t PAY_RHASH_ALREADY_USED = 201;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -66,6 +66,10 @@ struct plugin {
 
 	/* An array of subscribed topics */
 	char **subscriptions;
+
+	/* An array of currently pending RPC method calls, to be killed if the
+	 * plugin exits. */
+	struct list_head pending_rpccalls;
 };
 
 /**

--- a/tests/plugins/hook-crash.py
+++ b/tests/plugins/hook-crash.py
@@ -7,6 +7,12 @@ import sys
 plugin = Plugin()
 
 
+@plugin.async_method('hold-rpc-call')
+def hold_rpc_call(plugin, request):
+    """Simply never return, it should still get an error when the plugin crashes
+    """
+
+
 @plugin.hook('htlc_accepted')
 def on_htlc_accepted(plugin, htlc, onion, **kwargs):
     """We die silently, i.e., without returning a response

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1143,6 +1143,9 @@ def test_hook_crash(node_factory, executor, bitcoind):
 
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2 * len(perm))
 
+    # Start an RPC call that should error once the plugin crashes.
+    f1 = executor.submit(nodes[0].rpc.hold_rpc_call)
+
     futures = []
     for n in nodes:
         inv = n.rpc.invoice(123, "lbl", "desc")['bolt11']
@@ -1157,6 +1160,10 @@ def test_hook_crash(node_factory, executor, bitcoind):
 
     # Collect the results:
     [f.result(TIMEOUT) for f in futures]
+
+    # Make sure the RPC call was terminated with the correct error
+    with pytest.raises(RpcError, match=r'Plugin terminated before replying'):
+        f1.result(10)
 
 
 def test_feature_set(node_factory):


### PR DESCRIPTION
We now track all pending RPC passthrough calls, and terminate them with an
error if the plugin dies.

Changelog-Fixed: JSON-RPC: Pending RPC method calls are now terminated if the handling plugin exits prematurely.

Closes #3496 