### PR TITLE
Reflect that Tor version must be  >= 0.3.2.2-alpha to reach V3 onions.

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -633,6 +633,13 @@ static void connect_failed(struct daemon *daemon,
 	status_peer_debug(id, "Failed connected out: %s", errmsg);
 }
 
+/* add errors to error list */
+void add_errors_to_error_list(struct connecting *connect, const char *error)
+{
+	tal_append_fmt(&connect->errors,
+		       "%s. ", error);
+}
+
 /*~ This is the destructor for the (unsuccessful) connection.  We accumulate
  * the errors which occurred, so we can report to lightningd properly in case
  * they all fail, and try the next address.
@@ -650,11 +657,12 @@ static void destroy_io_conn(struct io_conn *conn, struct connecting *connect)
 		if (streq(connect->connstate, "Cryptographic handshake"))
 			errstr = "peer closed connection (wrong key?)";
 	}
-	tal_append_fmt(&connect->errors,
-		       "%s: %s: %s. ",
+
+	add_errors_to_error_list(connect,
+		       tal_fmt(tmpctx, "%s: %s: %s",
 		       type_to_string(tmpctx, struct wireaddr_internal,
 				      &connect->addrs[connect->addrnum]),
-		       connect->connstate, errstr);
+		       connect->connstate, errstr));
 	connect->addrnum++;
 	try_connect_one_addr(connect);
 }

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -13,6 +13,9 @@ struct wireaddr_internal;
 /* Called by io_tor_connect once it has a connection out. */
 struct io_plan *connection_out(struct io_conn *conn, struct connecting *connect);
 
+/* add erros to error list */
+void add_errors_to_error_list(struct connecting *connect, const char *error);
+
 /* Called by peer_exchange_initmsg if successful. */
 struct io_plan *peer_connected(struct io_conn *conn,
 			       struct daemon *daemon,

--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -2,6 +2,16 @@
 
 To use any Tor features with c-lightning you must have Tor installed and running.
 
+Please note that nodes with V3 onion address i.e `vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion`
+will not be reachable over Tor if your Tor version is below 0.3.2.2-alpha
+
+Connections to nodes with old Tor V2 address form with less than 10 char prefix before .onion
+i.e.`3fyb44wdhnd2ghhl.onion` should work with any version of Tor.
+
+You can check your installed Tor version with `tor --version` or `sudo tor --version`
+
+If Tor is not installed you can install it on Debian based Linux systems (Ubuntu, Debian, etc) with the following command:
+
 ```bash
 sudo apt install tor
 ```


### PR DESCRIPTION
- Reflect in TOR.md that we need a Tor version >= 0.3.2.2-alpha if we want to reach Tor V3 onions 
- change the error response  

fix #3642 reported by @thestick613