### PR TITLE
pytest: fix flaky test_excluded_adjacent_routehint

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2953,7 +2953,7 @@ def test_excluded_adjacent_routehint(node_factory, bitcoind):
     l1, l2, l3 = node_factory.line_graph(3)
 
     # We'll be forced to use routehint, since we don't know about l3.
-    wait_for(lambda: l3.channel_state(l2) == 'CHANNELD_NORMAL')
+    wait_for(lambda: len(l3.rpc.listchannels(source=l2.info['id'])['channels']) == 1)
     inv = l3.rpc.invoice(10**3, "lbl", "desc", exposeprivatechannels=l2.get_channel_scid(l3))
 
     # This will make it reject the routehint.


### PR DESCRIPTION
We weren't actually waiting until l3 got the channel_update from l2,
so it might not be able to create the routehint.

Changelog-None