### PR TITLE
Cleanups

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -871,7 +871,9 @@ class LightningNode(object):
             elif params == [100, 'ECONOMICAL']:
                 feerate = feerates[3] * 4
             else:
-                raise ValueError()
+                raise ValueError("Don't have a feerate set for {}/{}.".format(
+                    params[0], params[1],
+                ))
             return {
                 'id': r['id'],
                 'error': None,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -572,7 +572,7 @@ static void init_txfilter(struct wallet *w, struct txfilter *filter)
 
 	bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
 	/*~ One of the C99 things I unequivocally approve: for-loop scope. */
-	for (u64 i = 0; i <= bip32_max_index; i++) {
+	for (u64 i = 0; i <= bip32_max_index + w->keyscan_gap; i++) {
 		if (bip32_key_from_parent(w->bip32_base, i, BIP32_FLAG_KEY_PUBLIC, &ext) != WALLY_OK) {
 			abort();
 		}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -50,6 +50,9 @@ struct wallet {
 
 	/* Unreleased txs, waiting for txdiscard/txsend */
 	struct list_head unreleased_txs;
+
+	/* How many keys should we look ahead at most? */
+	u64 keyscan_gap;
 };
 
 /* A transaction we've txprepared, but  haven't signed and released yet */


### PR DESCRIPTION

 - I had some issues with the feerates in the btcproxy, now logging and returning a more meaningful exception to trace them.
 - Added a key scan gap that'll add 50 keys to the keyset we scan for, should be good for restoring on-chain funds from the secret only (though channels cannot be recovered this way, so not sure we want to encourage this).