### PR TITLE
changelog: use correct format for label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.8.2-rc1] - 2020-04-16: "A Scalable Ethereum Blockchain"
+## [0.8.2rc1] - 2020-04-16: "A Scalable Ethereum Blockchain"
 
 This release named by @arowser.
 
@@ -712,7 +712,7 @@ There predate the BOLT specifications, and are only of vague historic interest:
 6. [0.5.1] - 2016-10-21
 7. [0.5.2] - 2016-11-21: "Bitcoin Savings & Trust Daily Interest II"
 
-[0.8.2-rc1]: https://github.com/ElementsProject/lightning/releases/tag/v0.8.2-rc1
+[0.8.2rc1]: https://github.com/ElementsProject/lightning/releases/tag/v0.8.2rc1
 [0.8.1]: https://github.com/ElementsProject/lightning/releases/tag/v0.8.1
 [0.8.0]: https://github.com/ElementsProject/lightning/releases/tag/v0.8.0
 [0.7.3]: https://github.com/ElementsProject/lightning/releases/tag/v0.7.3


### PR DESCRIPTION
The reproducible build won't work with `-`'s in the version label.