### PR TITLE
lightningd: fix false positive on leak detection.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -845,7 +845,7 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 				    jcon->buffer + method->start);
 	}
 
-	rpc_hook = tal(NULL, struct rpc_command_hook_payload);
+	rpc_hook = tal(c, struct rpc_command_hook_payload);
 	rpc_hook->cmd = c;
 	/* Duplicate since we might outlive the connection */
 	rpc_hook->buffer = tal_dup_talarr(rpc_hook, char, jcon->buffer);


### PR DESCRIPTION
Commit 9aedb0c61f changed this from allocating off `c` to allocating
off NULL, knowing that it's tal_steal() in the callback.  But before
that, it can be detected as a mem leak:

```
    @pytest.fixture
    def teardown_checks(request):
        """A simple fixture to collect errors during teardown.

        We need to collect the errors and raise them as the very last step in the
        fixture tree, otherwise some fixtures may not be cleaned up
        correctly. Require this fixture in all other fixtures that need to either
        cleanup before reporting an error or want to add an error that is to be
        reported.

        """
        errors = TeardownErrors()
        yield errors

        if errors.has_errors():
            # Format a nice list of everything that went wrong and raise an exception
            request.node.has_errors = True
>           raise ValueError(str(errors))
E           ValueError:
E           Node errors:
E           Global errors:
E            - Node /tmp/ltests-iz9y1chb/test_hsmtool_secret_decryption_1/lightning-1/ has memory leaks: [
E               {
E                   "backtrace": [
E                       "ccan/ccan/tal/tal.c:442 (tal_alloc_)",
E                       "lightningd/jsonrpc.c:848 (parse_request)",
E                       "lightningd/jsonrpc.c:941 (read_json)",
E                       "ccan/ccan/io/io.c:59 (next_plan)",
E                       "ccan/ccan/io/io.c:407 (do_plan)",
E                  avis/build/ElementsProject/lightning/lightningd/../plugins/pay
```

Reported-by: @niftynei
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>