### PR TITLE
Watchtowers attempt 3: the full channelding

### DIFF
--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -16,14 +16,17 @@ LIGHTNINGD_CHANNEL_HEADERS_NOGEN :=			\
 	channeld/channeld_htlc.h		\
 	channeld/commit_tx.h			\
 	channeld/full_channel.h			\
-	channeld/full_channel_error.h
+	channeld/full_channel_error.h		\
+	channeld/watchtower.h
 
 LIGHTNINGD_CHANNEL_HEADERS := $(LIGHTNINGD_CHANNEL_HEADERS_GEN) $(LIGHTNINGD_CHANNEL_HEADERS_NOGEN)
 
 LIGHTNINGD_CHANNEL_SRC := channeld/channeld.c	\
 	channeld/commit_tx.c			\
-	channeld/full_channel.c		\
-	channeld/gen_channel_wire.c
+	channeld/full_channel.c			\
+	channeld/gen_channel_wire.c		\
+	channeld/watchtower.c
+
 LIGHTNINGD_CHANNEL_OBJS := $(LIGHTNINGD_CHANNEL_SRC:.c=.o)
 
 # Make sure these depend on everything.

--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -69,6 +69,7 @@ CHANNELD_COMMON_OBJS :=				\
 	common/onionreply.o			\
 	common/peer_billboard.o			\
 	common/peer_failed.o			\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/permute_tx.o			\
 	common/ping.o				\

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -18,6 +18,7 @@ msgdata,channel_init,their_config,channel_config,
 msgdata,channel_init,fee_states,fee_states,
 msgdata,channel_init,feerate_min,u32,
 msgdata,channel_init,feerate_max,u32,
+msgdata,channel_init,feerate_penalty,u32,
 msgdata,channel_init,first_commit_sig,bitcoin_signature,
 msgdata,channel_init,per_peer_state,per_peer_state,
 msgdata,channel_init,remote_fundingkey,pubkey,
@@ -178,6 +179,7 @@ msgtype,channel_feerates,1027
 msgdata,channel_feerates,feerate,u32,
 msgdata,channel_feerates,min_feerate,u32,
 msgdata,channel_feerates,max_feerate,u32,
+msgdata,channel_feerates,penalty_feerate,u32,
 
 # master -> channeld: do you have a memleak?
 msgtype,channel_dev_memleak,1033

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -100,9 +100,12 @@ msgdata,channel_fail_htlc,failed_htlc,failed_htlc,
 msgtype,channel_got_funding_locked,1019
 msgdata,channel_got_funding_locked,next_per_commit_point,pubkey,
 
+#include <common/penalty_base.h>
+
 # When we send a commitment_signed message, tell master.
 msgtype,channel_sending_commitsig,1020
 msgdata,channel_sending_commitsig,commitnum,u64,
+msgdata,channel_sending_commitsig,pbase,?penalty_base,
 msgdata,channel_sending_commitsig,fee_states,fee_states,
 # SENT_ADD_COMMIT, SENT_REMOVE_ACK_COMMIT, SENT_ADD_ACK_COMMIT, SENT_REMOVE_COMMIT
 msgdata,channel_sending_commitsig,num_changed,u16,

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -65,6 +65,8 @@ msgdata,channel_init,remote_ann_bitcoin_sig,?secp256k1_ecdsa_signature,
 msgdata,channel_init,option_static_remotekey,bool,
 msgdata,channel_init,dev_fast_gossip,bool,
 msgdata,channel_init,dev_fail_process_onionpacket,bool,
+msgdata,channel_init,num_penalty_bases,u32,
+msgdata,channel_init,pbases,penalty_base,num_penalty_bases
 
 # master->channeld funding hit new depth(funding locked if >= lock depth)
 msgtype,channel_funding_depth,1002

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -154,6 +154,7 @@ msgdata,channel_got_revoke,fee_states,fee_states,
 msgdata,channel_got_revoke,num_changed,u16,
 msgdata,channel_got_revoke,changed,changed_htlc,num_changed
 msgdata,channel_got_revoke,pbase,?penalty_base,
+msgdata,channel_got_revoke,penalty_tx,?bitcoin_tx,
 # Wait for reply, to make sure it's on disk before we continue
 # (eg. if we sent another commitment_signed, that would implicitly ack).
 msgtype,channel_got_revoke_reply,1122

--- a/channeld/channel_wire.csv
+++ b/channeld/channel_wire.csv
@@ -153,6 +153,7 @@ msgdata,channel_got_revoke,next_per_commit_point,pubkey,
 msgdata,channel_got_revoke,fee_states,fee_states,
 msgdata,channel_got_revoke,num_changed,u16,
 msgdata,channel_got_revoke,changed,changed_htlc,num_changed
+msgdata,channel_got_revoke,pbase,?penalty_base,
 # Wait for reply, to make sure it's on disk before we continue
 # (eg. if we sent another commitment_signed, that would implicitly ack).
 msgtype,channel_got_revoke_reply,1122

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -84,6 +84,9 @@ struct peer {
 	/* Tolerable amounts for feerate (only relevant for fundee). */
 	u32 feerate_min, feerate_max;
 
+	/* Feerate to be used when creating penalty transactions. */
+	u32 feerate_penalty;
+
 	/* Local next per-commit point. */
 	struct pubkey next_local_per_commit;
 
@@ -2816,7 +2819,8 @@ static void handle_feerates(struct peer *peer, const u8 *inmsg)
 
 	if (!fromwire_channel_feerates(inmsg, &feerate,
 				       &peer->feerate_min,
-				       &peer->feerate_max))
+				       &peer->feerate_max,
+				       &peer->feerate_penalty))
 		master_badmsg(WIRE_CHANNEL_FEERATES, inmsg);
 
 	/* BOLT #2:
@@ -3110,7 +3114,9 @@ static void init_channel(struct peer *peer)
 				   &minimum_depth,
 				   &conf[LOCAL], &conf[REMOTE],
 				   &fee_states,
-				   &peer->feerate_min, &peer->feerate_max,
+				   &peer->feerate_min,
+				   &peer->feerate_max,
+				   &peer->feerate_penalty,
 				   &peer->their_commit_sig,
 				   &peer->pps,
 				   &funding_pubkey[REMOTE],

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1368,13 +1368,31 @@ static void handle_peer_commit_sig(struct peer *peer, const u8 *msg)
 			       &commit_sig, htlc_sigs, changed_htlcs, txs[0]);
 }
 
-static u8 *got_revoke_msg(const tal_t *ctx, u64 revoke_num,
+/* Pops the penalty base for the given commitnum from our internal list. There
+ * may not be one, in which case we return NULL and leave the list
+ * unmodified. */
+static struct penalty_base *
+penalty_base_by_commitnum(const tal_t *ctx, struct peer *peer, u64 commitnum)
+{
+	struct penalty_base *res = NULL;
+	for (size_t i = 0; i < tal_count(peer->pbases); i++) {
+		if (peer->pbases[i]->commitment_num == commitnum) {
+			res = tal_steal(ctx, peer->pbases[i]);
+			tal_arr_remove(&peer->pbases, i);
+			break;
+		}
+	}
+	return res;
+}
+
+static u8 *got_revoke_msg(struct peer *peer, u64 revoke_num,
 			  const struct secret *per_commitment_secret,
 			  const struct pubkey *next_per_commit_point,
 			  const struct htlc **changed_htlcs,
 			  const struct fee_states *fee_states)
 {
 	u8 *msg;
+	struct penalty_base *pbase;
 	struct changed_htlc *changed = tal_arr(tmpctx, struct changed_htlc, 0);
 
 	for (size_t i = 0; i < tal_count(changed_htlcs); i++) {
@@ -1390,8 +1408,10 @@ static u8 *got_revoke_msg(const tal_t *ctx, u64 revoke_num,
 		tal_arr_expand(&changed, c);
 	}
 
-	msg = towire_channel_got_revoke(ctx, revoke_num, per_commitment_secret,
-					next_per_commit_point, fee_states, changed);
+	pbase = penalty_base_by_commitnum(tmpctx, peer, revoke_num);
+	msg = towire_channel_got_revoke(peer, revoke_num, per_commitment_secret,
+					next_per_commit_point, fee_states,
+					changed, pbase);
 	return msg;
 }
 
@@ -1448,7 +1468,7 @@ static void handle_peer_revoke_and_ack(struct peer *peer, const u8 *msg)
 		status_debug("No commits outstanding after recv revoke_and_ack");
 
 	/* Tell master about things this locks in, wait for response */
-	msg = got_revoke_msg(NULL, peer->revocations_received++,
+	msg = got_revoke_msg(peer, peer->revocations_received++,
 			     &old_commit_secret, &next_per_commit,
 			     changed_htlcs,
 			     peer->channel->fee_states);

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -820,20 +820,16 @@ static u8 *master_wait_sync_reply(const tal_t *ctx,
 /* Returns HTLC sigs, sets commit_sig */
 static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 						  const struct peer *peer,
+						  struct bitcoin_tx **txs,
+						  const u8 *funding_wscript,
+						  const struct htlc **htlc_map,
 						  u64 commit_index,
 						  struct bitcoin_signature *commit_sig)
 {
 	size_t i;
-	struct bitcoin_tx **txs;
-	const u8 *funding_wscript;
-	const struct htlc **htlc_map;
 	struct pubkey local_htlckey;
 	const u8 *msg;
 	secp256k1_ecdsa_signature *htlc_sigs;
-
-	txs = channel_txs(tmpctx, &htlc_map,
-			  &funding_wscript, peer->channel, &peer->remote_per_commit,
-			  commit_index, REMOTE);
 
 	msg = towire_hsm_sign_remote_commitment_tx(NULL, txs[0],
 						   &peer->channel->funding_pubkey[REMOTE],
@@ -930,6 +926,10 @@ static void send_commit(struct peer *peer)
 	const struct htlc **changed_htlcs;
 	struct bitcoin_signature commit_sig;
 	secp256k1_ecdsa_signature *htlc_sigs;
+	struct bitcoin_tx **txs;
+	const u8 *funding_wscript;
+	const struct htlc **htlc_map;
+	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 #if DEVELOPER
 	/* Hack to suppress all commit sends if dev_disconnect says to */
@@ -1020,8 +1020,13 @@ static void send_commit(struct peer *peer)
 		return;
 	}
 
-	htlc_sigs = calc_commitsigs(tmpctx, peer, peer->next_index[REMOTE],
-				    &commit_sig);
+	txs = channel_txs(tmpctx, &htlc_map, direct_outputs,
+			  &funding_wscript, peer->channel, &peer->remote_per_commit,
+			  peer->next_index[REMOTE], REMOTE);
+
+	htlc_sigs =
+	    calc_commitsigs(tmpctx, peer, txs, funding_wscript, htlc_map,
+			    peer->next_index[REMOTE], &commit_sig);
 
 	status_debug("Telling master we're about to commit...");
 	/* Tell master to save this next commit to database, then wait. */
@@ -1261,7 +1266,7 @@ static void handle_peer_commit_sig(struct peer *peer, const u8 *msg)
 	commit_sig.sighash_type = SIGHASH_ALL;
 
 	txs =
-	    channel_txs(tmpctx, &htlc_map,
+	    channel_txs(tmpctx, &htlc_map, NULL,
 			&funding_wscript, peer->channel, &peer->next_local_per_commit,
 			peer->next_index[LOCAL], LOCAL);
 
@@ -2018,6 +2023,10 @@ static void resend_commitment(struct peer *peer, const struct changed_htlc *last
 	struct bitcoin_signature commit_sig;
 	secp256k1_ecdsa_signature *htlc_sigs;
 	u8 *msg;
+	struct bitcoin_tx **txs;
+	const u8 *funding_wscript;
+	const struct htlc **htlc_map;
+	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 	status_debug("Retransmitting commitment, feerate LOCAL=%u REMOTE=%u",
 		     channel_feerate(peer->channel, LOCAL),
@@ -2101,7 +2110,11 @@ static void resend_commitment(struct peer *peer, const struct changed_htlc *last
 	}
 
 	/* Re-send the commitment_signed itself. */
-	htlc_sigs = calc_commitsigs(tmpctx, peer, peer->next_index[REMOTE]-1,
+	txs = channel_txs(tmpctx, &htlc_map, direct_outputs,
+			  &funding_wscript, peer->channel, &peer->remote_per_commit,
+			  peer->next_index[REMOTE]-1, REMOTE);
+
+	htlc_sigs = calc_commitsigs(tmpctx, peer, txs, funding_wscript, htlc_map, peer->next_index[REMOTE]-1,
 				    &commit_sig);
 	msg = towire_commitment_signed(NULL, &peer->channel_id,
 				       &commit_sig.s, htlc_sigs);

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -170,6 +170,9 @@ struct peer {
 
 	/* Empty commitments.  Spec violation, but a minor one. */
 	u64 last_empty_commitment;
+
+	/* Penalty bases for this channel / peer. */
+	struct penalty_base **pbases;
 };
 
 static u8 *create_channel_announcement(const tal_t *ctx, struct peer *peer);
@@ -1032,6 +1035,10 @@ static void send_commit(struct peer *peer)
 	if (direct_outputs[LOCAL] != NULL) {
 		pbase = penalty_base_new(tmpctx, peer->next_index[REMOTE],
 					 txs[0], direct_outputs[LOCAL]);
+
+		/* Add the penalty_base to our in-memory list as well, so we
+		 * can find it again later. */
+		tal_arr_expand(&peer->pbases, tal_steal(peer, pbase));
 	}  else
 		pbase = NULL;
 
@@ -3085,6 +3092,7 @@ static void init_channel(struct peer *peer)
 	secp256k1_ecdsa_signature *remote_ann_node_sig;
 	secp256k1_ecdsa_signature *remote_ann_bitcoin_sig;
 	bool option_static_remotekey;
+	struct penalty_base *pbases;
 #if !DEVELOPER
 	bool dev_fail_process_onionpacket; /* Ignored */
 #endif
@@ -3143,9 +3151,18 @@ static void init_channel(struct peer *peer)
 				   &remote_ann_bitcoin_sig,
 				   &option_static_remotekey,
 				   &dev_fast_gossip,
-				   &dev_fail_process_onionpacket)) {
+				   &dev_fail_process_onionpacket,
+				   &pbases)) {
 		master_badmsg(WIRE_CHANNEL_INIT, msg);
 	}
+
+	/* Keeping an array of pointers is better since it allows us to avoid
+	 * extra allocations later. */
+	peer->pbases = tal_arr(peer, struct penalty_base *, 0);
+	for (size_t i=0; i<tal_count(pbases); i++)
+		tal_arr_expand(&peer->pbases,
+			       tal_dup(peer, struct penalty_base, &pbases[i]));
+	tal_free(pbases);
 
 	/* stdin == requests, 3 == peer, 4 = gossip, 5 = gossip_store, 6 = HSM */
 	per_peer_state_set_fds(peer->pps, 3, 4, 5);

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -94,6 +94,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			     struct amount_msat other_pay,
 			     const struct htlc **htlcs,
 			     const struct htlc ***htlcmap,
+			     struct wally_tx_output *direct_outputs[NUM_SIDES],
 			     u64 obscured_commitment_number,
 			     enum side side)
 {
@@ -102,7 +103,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	struct bitcoin_tx *tx;
 	size_t i, n, untrimmed;
 	u32 *cltvs;
-
+	struct htlc *dummy_to_local = (struct htlc *)0x01,
+		*dummy_to_remote = (struct htlc *)0x02;
 	if (!amount_msat_add(&total_pay, self_pay, other_pay))
 		abort();
 	assert(!amount_msat_greater_sat(total_pay, funding));
@@ -215,7 +217,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		struct amount_sat amount = amount_msat_to_sat_round_down(self_pay);
 
 		bitcoin_tx_add_output(tx, p2wsh, amount);
-		(*htlcmap)[n] = NULL;
+		/* Add a dummy entry to the htlcmap so we can recognize it later */
+		(*htlcmap)[n] = direct_outputs ? dummy_to_local : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
 		SUPERVERBOSE("# to-local amount %s wscript %s\n",
@@ -248,7 +251,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		 */
 		int pos = bitcoin_tx_add_output(tx, p2wpkh, amount);
 		assert(pos == n);
-		(*htlcmap)[n] = NULL;
+		(*htlcmap)[n] = direct_outputs ? dummy_to_remote : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
 		SUPERVERBOSE("# to-remote amount %s P2WPKH(%s)\n",
@@ -304,6 +307,20 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	 */
 	u32 sequence = (0x80000000 | ((obscured_commitment_number>>24) & 0xFFFFFF));
 	bitcoin_tx_add_input(tx, funding_txid, funding_txout, sequence, funding, NULL);
+
+	/* Identify the direct outputs (to_us, to_them). */
+	if (direct_outputs != NULL) {
+		direct_outputs[LOCAL] = direct_outputs[REMOTE] = NULL;
+		for (size_t i = 0; i < tx->wtx->num_outputs; i++) {
+			if ((*htlcmap)[i] == dummy_to_local) {
+				(*htlcmap)[i] = NULL;
+				direct_outputs[LOCAL] = tx->wtx->outputs + i;
+			} else if ((*htlcmap)[i] == dummy_to_remote) {
+				(*htlcmap)[i] = NULL;
+				direct_outputs[REMOTE] = tx->wtx->outputs + i;
+			}
+		}
+	}
 
 	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));

--- a/channeld/commit_tx.h
+++ b/channeld/commit_tx.h
@@ -37,6 +37,7 @@ size_t commit_tx_num_untrimmed(const struct htlc **htlcs,
  * @htlcs: tal_arr of htlcs committed by transaction (some may be trimmed)
  * @htlc_map: outputed map of outnum->HTLC (NULL for direct outputs).
  * @obscured_commitment_number: number to encode in commitment transaction
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @side: side to generate commitment transaction for.
  *
  * We need to be able to generate the remote side's tx to create signatures,
@@ -56,6 +57,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			     struct amount_msat other_pay,
 			     const struct htlc **htlcs,
 			     const struct htlc ***htlcmap,
+			     struct wally_tx_output *direct_outputs[NUM_SIDES],
 			     u64 obscured_commitment_number,
 			     enum side side);
 

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -272,6 +272,7 @@ static void add_htlcs(struct bitcoin_tx ***txs,
 /* FIXME: We could cache these. */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				const struct htlc ***htlcmap,
+				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,
@@ -299,8 +300,9 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 	    channel->config[!side].to_self_delay, &keyset,
 	    channel_feerate(channel, side),
 	    channel->config[side].dust_limit, channel->view[side].owed[side],
-	    channel->view[side].owed[!side], committed, htlcmap,
-	    commitment_number ^ channel->commitment_number_obscurer, side);
+	    channel->view[side].owed[!side], committed, htlcmap, direct_outputs,
+	    commitment_number ^ channel->commitment_number_obscurer,
+	    side);
 
 	/* Generating and saving witness script required to spend
 	 * the funding output */

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -50,6 +50,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  * @ctx: tal context to allocate return value from.
  * @channel: The channel to evaluate
  * @htlc_map: Pointer to htlcs for each tx output (allocated off @ctx).
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @funding_wscript: Pointer to wscript for the funding tx output
  * @per_commitment_point: Per-commitment point to determine keys
  * @commitment_number: The index of this commitment.
@@ -61,6 +62,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				const struct htlc ***htlcmap,
+				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,

--- a/channeld/test/run-commit_tx.c
+++ b/channeld/test/run-commit_tx.c
@@ -732,7 +732,7 @@ int main(void)
 		       dust_limit,
 		       to_local,
 		       to_remote,
-		       NULL, &htlc_map, commitment_number ^ cn_obscurer,
+		       NULL, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       LOCAL);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
@@ -744,7 +744,7 @@ int main(void)
 			dust_limit,
 			to_local,
 			to_remote,
-			NULL, &htlc_map2, commitment_number ^ cn_obscurer,
+			NULL, &htlc_map2, NULL, commitment_number ^ cn_obscurer,
 			REMOTE);
 	tx_must_be_eq(tx, tx2);
 	report(tx, wscript, &x_remote_funding_privkey, &remote_funding_pubkey,
@@ -788,7 +788,7 @@ int main(void)
 		       dust_limit,
 		       to_local,
 		       to_remote,
-		       htlcs, &htlc_map, commitment_number ^ cn_obscurer,
+		       htlcs, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       LOCAL);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
@@ -800,7 +800,7 @@ int main(void)
 			dust_limit,
 			to_local,
 			to_remote,
-			inv_htlcs, &htlc_map2,
+			inv_htlcs, &htlc_map2, NULL,
 			commitment_number ^ cn_obscurer,
 			REMOTE);
 	tx_must_be_eq(tx, tx2);
@@ -832,7 +832,7 @@ int main(void)
 				  dust_limit,
 				  to_local,
 				  to_remote,
-				  htlcs, &htlc_map,
+				  htlcs, &htlc_map, NULL,
 				  commitment_number ^ cn_obscurer,
 				  LOCAL);
 		/* This is what it would look like for peer generating it! */
@@ -845,7 +845,7 @@ int main(void)
 				dust_limit,
 				to_local,
 				to_remote,
-				inv_htlcs, &htlc_map2,
+				inv_htlcs, &htlc_map2, NULL,
 				commitment_number ^ cn_obscurer,
 				REMOTE);
 		tx_must_be_eq(newtx, tx2);
@@ -877,7 +877,7 @@ int main(void)
 			       dust_limit,
 			       to_local,
 			       to_remote,
-			       htlcs, &htlc_map,
+			       htlcs, &htlc_map, NULL,
 			       commitment_number ^ cn_obscurer,
 			       LOCAL);
 		report(tx, wscript,
@@ -914,7 +914,7 @@ int main(void)
 				  dust_limit,
 				  to_local,
 				  to_remote,
-				  htlcs, &htlc_map,
+				  htlcs, &htlc_map, NULL,
 				  commitment_number ^ cn_obscurer,
 				  LOCAL);
 		report(newtx, wscript,
@@ -973,7 +973,7 @@ int main(void)
 			       dust_limit,
 			       to_local,
 			       to_remote,
-			       htlcs, &htlc_map,
+			       htlcs, &htlc_map, NULL,
 			       commitment_number ^ cn_obscurer,
 			       LOCAL);
 		report(tx, wscript,

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -519,10 +519,10 @@ int main(void)
 			   local_config->dust_limit,
 			   to_local,
 			   to_remote,
-			   NULL, &htlc_map, 0x2bb038521914 ^ 42, LOCAL);
+			   NULL, &htlc_map, NULL, 0x2bb038521914 ^ 42, LOCAL);
 
 	txs = channel_txs(tmpctx,
-			  &htlc_map, &funding_wscript_alt,
+			  &htlc_map, NULL, &funding_wscript_alt,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
 	assert(tal_count(htlc_map) == 2);
@@ -530,7 +530,7 @@ int main(void)
 	tx_must_be_eq(txs[0], raw_tx);
 
 	txs2 = channel_txs(tmpctx,
-			   &htlc_map, &funding_wscript,
+			   &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -557,10 +557,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 1);
-	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -575,10 +575,10 @@ int main(void)
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			  lchannel, &local_per_commitment_point, 42, LOCAL);
 	assert(tal_count(txs) == 6);
-	txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 			   rchannel, &local_per_commitment_point, 42, REMOTE);
 	txs_must_be_eq(txs, txs2);
 
@@ -641,15 +641,15 @@ int main(void)
 		    tmpctx, &funding_txid, funding_output_index,
 		    funding_amount, LOCAL, remote_config->to_self_delay,
 		    &keyset, feerate_per_kw[LOCAL], local_config->dust_limit,
-		    to_local, to_remote, htlcs, &htlc_map, 0x2bb038521914 ^ 42,
-		    LOCAL);
+		    to_local, to_remote, htlcs, &htlc_map, NULL,
+		    0x2bb038521914 ^ 42, LOCAL);
 
-		txs = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+		txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 				  lchannel, &local_per_commitment_point, 42,
 				  LOCAL);
 		tx_must_be_eq(txs[0], raw_tx);
 
-		txs2 = channel_txs(tmpctx, &htlc_map, &funding_wscript,
+		txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
 				   rchannel, &local_per_commitment_point,
 				   42, REMOTE);
 		txs_must_be_eq(txs, txs2);

--- a/channeld/watchtower.c
+++ b/channeld/watchtower.c
@@ -1,0 +1,120 @@
+#include "watchtower.h"
+
+#include <bitcoin/feerate.h>
+#include <bitcoin/script.h>
+#include <bitcoin/signature.h>
+#include <bitcoin/tx.h>
+#include <common/htlc_tx.h>
+#include <common/key_derive.h>
+#include <common/keyset.h>
+#include <common/status.h>
+#include <common/type_to_string.h>
+#include <hsmd/gen_hsm_wire.h>
+#include <wire/wire_sync.h>
+
+static const u8 ONE = 0x1;
+#define HSM_FD 6
+
+const struct bitcoin_tx *
+penalty_tx_create(const tal_t *ctx,
+		  const struct channel *channel,
+		  u32 penalty_feerate,
+		  u8 *final_scriptpubkey,
+		  const struct secret *revocation_preimage,
+		  const struct bitcoin_txid *commitment_txid,
+		  s16 to_them_outnum, struct amount_sat to_them_sats)
+{
+	u8 *wscript;
+	struct bitcoin_tx *tx;
+	struct keyset keyset;
+	size_t weight;
+	u8 *msg;
+	struct amount_sat fee, min_out, amt;
+	struct bitcoin_signature sig;
+	u32 locktime = 0;
+	bool option_static_remotekey = channel->option_static_remotekey;
+	u8 **witness;
+	u32 remote_to_self_delay = channel->config[REMOTE].to_self_delay;
+	const struct amount_sat dust_limit = channel->config[LOCAL].dust_limit;
+	BUILD_ASSERT(sizeof(struct secret) == sizeof(*revocation_preimage));
+	const struct secret remote_per_commitment_secret = *revocation_preimage;
+	struct pubkey remote_per_commitment_point;
+	const struct basepoints *basepoints = channel->basepoints;
+
+	if (to_them_outnum == -1 ||
+	    amount_sat_less_eq(to_them_sats, dust_limit)) {
+		status_unusual(
+			    "Cannot create penalty transaction because there "
+			    "is no non-dust to_them output in the commitment.");
+		return NULL;
+	}
+
+	if (!pubkey_from_secret(&remote_per_commitment_secret, &remote_per_commitment_point))
+		status_broken("Failed derive from per_commitment_secret %s",
+		      type_to_string(tmpctx, struct secret,
+				     &remote_per_commitment_secret));
+
+	if (!derive_keyset(&remote_per_commitment_point,
+			   &basepoints[REMOTE],
+			   &basepoints[LOCAL],
+			   option_static_remotekey,
+			   &keyset))
+		abort(); /* TODO(cdecker) Handle a bit more gracefully */
+
+	wscript = bitcoin_wscript_to_local(tmpctx, remote_to_self_delay,
+					   &keyset.self_revocation_key,
+					   &keyset.self_delayed_payment_key);
+
+	tx = bitcoin_tx(ctx, chainparams, 1, 1, locktime);
+	bitcoin_tx_add_input(tx, commitment_txid, to_them_outnum, 0xFFFFFFFF,
+			     to_them_sats, NULL);
+
+	bitcoin_tx_add_output(tx, final_scriptpubkey, to_them_sats);
+
+	/* Worst-case sig is 73 bytes */
+	weight = bitcoin_tx_weight(tx) + 1 + 3 + 73 + 0 + tal_count(wscript);
+	weight = elements_add_overhead(weight, 1, 1);
+	fee = amount_tx_fee(penalty_feerate, weight);
+
+	if (!amount_sat_add(&min_out, dust_limit, fee))
+		status_broken(
+			      "Cannot add dust_limit %s and fee %s",
+			      type_to_string(tmpctx, struct amount_sat, &dust_limit),
+			      type_to_string(tmpctx, struct amount_sat, &fee));
+
+	if (amount_sat_less(to_them_sats, min_out)) {
+		/* FIXME: We should use SIGHASH_NONE so others can take it */
+		fee = amount_tx_fee(feerate_floor(), weight);
+	}
+
+	/* This can only happen if feerate_floor() is still too high; shouldn't
+	 * happen! */
+	if (!amount_sat_sub(&amt, to_them_sats, fee)) {
+		amt = dust_limit;
+		status_broken(
+			   "TX can't afford minimal feerate"
+			   "; setting output to %s",
+			   type_to_string(tmpctx, struct amount_sat, &amt));
+	}
+	bitcoin_tx_output_set_amount(tx, 0, amt);
+	bitcoin_tx_finalize(tx);
+
+	u8 *hsm_sign_msg =
+	    towire_hsm_sign_penalty_to_us(ctx, &remote_per_commitment_secret, tx,
+					  wscript, *tx->input_amounts[0]);
+
+	if (!wire_sync_write(HSM_FD, take(hsm_sign_msg)))
+		status_broken("Writing sign request to hsm");
+
+	msg = wire_sync_read(tmpctx, HSM_FD);
+	if (!msg || !fromwire_hsm_sign_tx_reply(msg, &sig)) {
+		status_broken("Reading sign_tx_reply: %s", tal_hex(tmpctx, msg));
+		abort();
+	}
+
+	witness = bitcoin_witness_sig_and_element(tx, &sig, &ONE, sizeof(ONE),
+						  wscript);
+
+	bitcoin_tx_input_set_witness(tx, 0, take(witness));
+	return tx;
+}

--- a/channeld/watchtower.h
+++ b/channeld/watchtower.h
@@ -1,0 +1,18 @@
+#ifndef LIGHTNING_CHANNELD_WATCHTOWER_H
+#define LIGHTNING_CHANNELD_WATCHTOWER_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+#include <common/derive_basepoints.h>
+#include <common/initial_channel.h>
+
+const struct bitcoin_tx *
+penalty_tx_create(const tal_t *ctx,
+		  const struct channel *channel,
+		  u32 penalty_feerate,
+		  u8 *final_scriptpubkey,
+		  const struct secret *revocation_preimage,
+		  const struct bitcoin_txid *commitment_txid,
+		  s16 to_them_outnum, struct amount_sat to_them_sats);
+
+#endif /* LIGHTNING_CHANNELD_WATCHTOWER_H */

--- a/common/Makefile
+++ b/common/Makefile
@@ -47,6 +47,7 @@ COMMON_SRC_NOGEN :=				\
 	common/onion.c				\
 	common/onionreply.c			\
 	common/param.c				\
+	common/penalty_base.c			\
 	common/per_peer_state.c			\
 	common/peer_billboard.c			\
 	common/peer_failed.c			\

--- a/common/initial_channel.c
+++ b/common/initial_channel.c
@@ -71,6 +71,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
 				      enum side side,
+				      struct wally_tx_output *direct_outputs[NUM_SIDES],
 				      char** err_reason)
 {
 	struct keyset keyset;
@@ -105,6 +106,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				 channel->view[side].owed[!side],
 				 channel->config[!side].channel_reserve,
 				 0 ^ channel->commitment_number_obscurer,
+				 direct_outputs,
 				 side,
 				 err_reason);
 }

--- a/common/initial_channel.h
+++ b/common/initial_channel.h
@@ -106,6 +106,7 @@ struct channel *new_initial_channel(const tal_t *ctx,
  * @channel: The channel to evaluate
  * @per_commitment_point: Per-commitment point to determine keys
  * @side: which side to get the commitment transaction for
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
  * Returns the unsigned initial commitment transaction for @side, or NULL
@@ -116,6 +117,7 @@ struct bitcoin_tx *initial_channel_tx(const tal_t *ctx,
 				      const struct channel *channel,
 				      const struct pubkey *per_commitment_point,
 				      enum side side,
+				      struct wally_tx_output *direct_outputs[NUM_SIDES],
 				      char** err_reason);
 
 /**

--- a/common/initial_channel.h
+++ b/common/initial_channel.h
@@ -5,6 +5,7 @@
 
 #include <bitcoin/pubkey.h>
 #include <bitcoin/shadouble.h>
+#include <bitcoin/tx.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 #include <common/amount.h>

--- a/common/initial_commit_tx.h
+++ b/common/initial_commit_tx.h
@@ -84,6 +84,7 @@ static inline struct amount_sat commit_tx_base_fee(u32 feerate_per_kw,
  * @other_pay: amount to pay directly to the other side
  * @self_reserve: reserve the other side insisted we have
  * @obscured_commitment_number: number to encode in commitment transaction
+ * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @side: side to generate commitment transaction for.
  * @err_reason: When NULL is returned, this will point to a human readable reason.
  *
@@ -104,6 +105,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 				     struct amount_msat other_pay,
 				     struct amount_sat self_reserve,
 				     u64 obscured_commitment_number,
+				     struct wally_tx_output *direct_outputs[NUM_SIDES],
 				     enum side side,
 				     char** err_reason);
 

--- a/common/penalty_base.c
+++ b/common/penalty_base.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <common/penalty_base.h>
+#include <wire/wire.h>
+
+/* txout must be within tx! */
+struct penalty_base *penalty_base_new(const tal_t *ctx,
+				      u64 commitment_num,
+				      const struct bitcoin_tx *tx,
+				      const struct wally_tx_output *txout)
+{
+	struct penalty_base *pbase = tal(ctx, struct penalty_base);
+
+	pbase->commitment_num = commitment_num;
+	bitcoin_txid(tx, &pbase->txid);
+	pbase->outnum = txout - tx->wtx->outputs;
+	assert(pbase->outnum < tx->wtx->num_outputs);
+	pbase->amount.satoshis = txout->satoshi; /* Raw: from wally_tx_output */
+
+	return pbase;
+}
+
+void towire_penalty_base(u8 **pptr, const struct penalty_base *pbase)
+{
+	towire_u64(pptr, pbase->commitment_num);
+	towire_bitcoin_txid(pptr, &pbase->txid);
+	towire_u32(pptr, pbase->outnum);
+	towire_amount_sat(pptr, pbase->amount);
+}
+
+void fromwire_penalty_base(const u8 **pptr, size_t *max,
+			   struct penalty_base *pbase)
+{
+	pbase->commitment_num = fromwire_u64(pptr, max);
+	fromwire_bitcoin_txid(pptr, max, &pbase->txid);
+	pbase->outnum = fromwire_u32(pptr, max);
+	pbase->amount = fromwire_amount_sat(pptr, max);
+}

--- a/common/penalty_base.h
+++ b/common/penalty_base.h
@@ -1,0 +1,30 @@
+#ifndef LIGHTNING_COMMON_PENALTY_BASE_H
+#define LIGHTNING_COMMON_PENALTY_BASE_H
+#include "config.h"
+#include <bitcoin/tx.h>
+#include <ccan/short_types/short_types.h>
+#include <common/amount.h>
+
+/* To create a penalty, all we need are these. */
+struct penalty_base {
+	/* The remote commitment index. */
+	u64 commitment_num;
+	/* The remote commitment txid. */
+	struct bitcoin_txid txid;
+	/* The remote commitment's "to-local" output. */
+	u32 outnum;
+	/* The amount of the remote commitment's "to-local" output. */
+	struct amount_sat amount;
+};
+
+/* txout must be within tx! */
+struct penalty_base *penalty_base_new(const tal_t *ctx,
+				      u64 commitment_num,
+				      const struct bitcoin_tx *tx,
+				      const struct wally_tx_output *txout);
+
+void towire_penalty_base(u8 **pptr, const struct penalty_base *pbase);
+void fromwire_penalty_base(const u8 **ptr, size_t *max,
+			   struct penalty_base *pbase);
+
+#endif /* LIGHTNING_COMMON_PENALTY_BASE_H */

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -397,8 +397,9 @@ int main(int argc, char *argv[])
 	if (!per_commit_point(&localseed, &local_per_commit_point, commitnum))
 		errx(1, "Bad deriving local per-commitment-point");
 
-	local_txs = channel_txs(NULL, &htlcmap, &funding_wscript, channel,
-				&local_per_commit_point, commitnum, LOCAL);
+	local_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+				&local_per_commit_point, commitnum,
+				LOCAL);
 
 	printf("## local_commitment\n"
 	       "# input amount %s, funding_wscript %s, pubkey %s\n",
@@ -511,8 +512,9 @@ int main(int argc, char *argv[])
 	/* Create the remote commitment tx */
 	if (!per_commit_point(&remoteseed, &remote_per_commit_point, commitnum))
 		errx(1, "Bad deriving remote per-commitment-point");
-	remote_txs = channel_txs(NULL, &htlcmap, &funding_wscript, channel,
-				 &remote_per_commit_point, commitnum, REMOTE);
+	remote_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+				 &remote_per_commit_point, commitnum,
+				 REMOTE);
 	remote_txs[0]->input_amounts[0]
 		= tal_dup(remote_txs[0], struct amount_sat, &funding_amount);
 

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -53,6 +53,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/onion.o				\
 	common/onionreply.o			\
 	common/param.o				\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/permute_tx.o			\
 	common/pseudorand.o			\

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -42,6 +42,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/htlc_trim.o			\
 	common/htlc_wire.o			\
 	common/key_derive.o			\
+	common/keyset.o				\
 	common/io_lock.o			\
 	common/json.o				\
 	common/json_helpers.o			\

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -385,6 +385,7 @@ void peer_start_channeld(struct channel *channel,
 	bool reached_announce_depth;
 	struct secret last_remote_per_commit_secret;
 	secp256k1_ecdsa_signature *remote_ann_node_sig, *remote_ann_bitcoin_sig;
+	struct penalty_base *pbases;
 
 	hsmfd = hsm_get_client_fd(ld, &channel->peer->id,
 				  channel->dbid,
@@ -463,6 +464,9 @@ void peer_start_channeld(struct channel *channel,
 		return;
 	}
 
+	pbases = wallet_penalty_base_load_for_channel(
+	    tmpctx, channel->peer->ld->wallet, channel->dbid);
+
 	initmsg = towire_channel_init(tmpctx,
 				      chainparams,
  				      ld->our_features,
@@ -517,7 +521,8 @@ void peer_start_channeld(struct channel *channel,
 				       * negotiated now! */
 				      channel->option_static_remotekey,
 				      IFDEV(ld->dev_fast_gossip, false),
-				      IFDEV(dev_fail_process_onionpacket, false));
+				      IFDEV(dev_fail_process_onionpacket, false),
+				      pbases);
 
 	/* We don't expect a response: we are triggered by funding_depth_cb. */
 	subd_send_msg(channel->owner, take(initmsg));

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -392,7 +392,8 @@ void peer_start_channeld(struct channel *channel,
 				  HSM_CAP_SIGN_GOSSIP
 				  | HSM_CAP_ECDH
 				  | HSM_CAP_COMMITMENT_POINT
-				  | HSM_CAP_SIGN_REMOTE_TX);
+				  | HSM_CAP_SIGN_REMOTE_TX
+				  | HSM_CAP_SIGN_ONCHAIN_TX);
 
 	channel_set_owner(channel,
 			  new_channel_subd(ld,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -38,7 +38,8 @@ static void update_feerates(struct lightningd *ld, struct channel *channel)
 
 	msg = towire_channel_feerates(NULL, feerate,
 				      feerate_min(ld, NULL),
-				      feerate_max(ld, NULL));
+				      feerate_max(ld, NULL),
+				      try_get_feerate(ld->topology, FEERATE_PENALTY));
 	subd_send_msg(channel->owner, take(msg));
 }
 
@@ -480,6 +481,7 @@ void peer_start_channeld(struct channel *channel,
 				      channel->channel_info.fee_states,
 				      feerate_min(ld, NULL),
 				      feerate_max(ld, NULL),
+				      try_get_feerate(ld->topology, FEERATE_PENALTY),
 				      &channel->last_sig,
 				      pps,
 				      &channel->channel_info.remote_fundingkey,
@@ -819,7 +821,8 @@ static struct command_result *json_dev_feerate(struct command *cmd,
 
 	msg = towire_channel_feerates(NULL, *feerate,
 				      feerate_min(cmd->ld, NULL),
-				      feerate_max(cmd->ld, NULL));
+				      feerate_max(cmd->ld, NULL),
+				      try_get_feerate(cmd->ld->topology, FEERATE_PENALTY));
 	subd_send_msg(channel->owner, take(msg));
 
 	response = json_stream_success(cmd);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -11,6 +11,7 @@
 #include <common/jsonrpc_errors.h>
 #include <common/key_derive.h>
 #include <common/param.h>
+#include <common/penalty_base.h>
 #include <common/per_peer_state.h>
 #include <common/utils.h>
 #include <common/wallet_tx.h>
@@ -374,6 +375,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	struct lightningd *ld = openingd->ld;
 	u8 *remote_upfront_shutdown_script;
 	struct per_peer_state *pps;
+	struct penalty_base *pbase;
 
 	/* This is a new channel_info.their_config so set its ID to 0 */
 	channel_info.their_config.id = 0;
@@ -381,6 +383,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	if (!fromwire_opening_funder_reply(resp, resp,
 					   &channel_info.their_config,
 					   &remote_commit,
+					   &pbase,
 					   &remote_commit_sig,
 					   &pps,
 					   &channel_info.theirbase.revocation,
@@ -464,6 +467,7 @@ static void opening_fundee_finished(struct subd *openingd,
 	struct channel *channel;
 	u8 *remote_upfront_shutdown_script, *local_upfront_shutdown_script;
 	struct per_peer_state *pps;
+	struct penalty_base *pbase;
 
 	log_debug(uc->log, "Got opening_fundee_finish_response");
 
@@ -471,26 +475,27 @@ static void opening_fundee_finished(struct subd *openingd,
 	channel_info.their_config.id = 0;
 
 	if (!fromwire_opening_fundee(tmpctx, reply,
-					   &channel_info.their_config,
-					   &remote_commit,
-					   &remote_commit_sig,
-					   &pps,
-					   &channel_info.theirbase.revocation,
-					   &channel_info.theirbase.payment,
-					   &channel_info.theirbase.htlc,
-					   &channel_info.theirbase.delayed_payment,
-					   &channel_info.remote_per_commit,
-					   &channel_info.remote_fundingkey,
-					   &funding_txid,
-					   &funding_outnum,
-					   &funding,
-					   &push,
-					   &channel_flags,
-					   &feerate,
-					   &funding_signed,
-				           &uc->our_config.channel_reserve,
-					   &local_upfront_shutdown_script,
-				           &remote_upfront_shutdown_script)) {
+				     &channel_info.their_config,
+				     &remote_commit,
+				     &pbase,
+				     &remote_commit_sig,
+				     &pps,
+				     &channel_info.theirbase.revocation,
+				     &channel_info.theirbase.payment,
+				     &channel_info.theirbase.htlc,
+				     &channel_info.theirbase.delayed_payment,
+				     &channel_info.remote_per_commit,
+				     &channel_info.remote_fundingkey,
+				     &funding_txid,
+				     &funding_outnum,
+				     &funding,
+				     &push,
+				     &channel_flags,
+				     &feerate,
+				     &funding_signed,
+				     &uc->our_config.channel_reserve,
+				     &local_upfront_shutdown_script,
+				     &remote_upfront_shutdown_script)) {
 		log_broken(uc->log, "bad OPENING_FUNDEE_REPLY %s",
 			   tal_hex(reply, reply));
 		uncommitted_channel_disconnect(uc, LOG_BROKEN,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -438,6 +438,9 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	/* Needed for the success statement */
 	derive_channel_id(&fc->cid, &channel->funding_txid, funding_txout);
 
+	if (pbase)
+		wallet_penalty_base_add(ld->wallet, channel->dbid, pbase);
+
 	funding_success(channel);
 	peer_start_channeld(channel, pps, NULL, false);
 
@@ -542,6 +545,9 @@ static void opening_fundee_finished(struct subd *openingd,
 	/* Tell plugins about the success */
 	notify_channel_opened(ld, &channel->peer->id, &channel->funding,
 			      &channel->funding_txid, &channel->remote_funding_locked);
+
+	if (pbase)
+		wallet_penalty_base_add(ld->wallet, channel->dbid, pbase);
 
 	/* On to normal operation! */
 	peer_start_channeld(channel, pps, funding_signed, false);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1669,11 +1669,13 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 	struct bitcoin_signature commit_sig;
 	secp256k1_ecdsa_signature *htlc_sigs;
 	struct lightningd *ld = channel->peer->ld;
+	struct penalty_base *pbase;
 
 	channel->htlc_timeout = tal_free(channel->htlc_timeout);
 
 	if (!fromwire_channel_sending_commitsig(msg, msg,
 						&commitnum,
+						&pbase,
 						&fee_states,
 						&changed_htlcs,
 						&commit_sig, &htlc_sigs)

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1982,12 +1982,14 @@ void peer_got_revoke(struct channel *channel, const u8 *msg)
 	size_t i;
 	struct lightningd *ld = channel->peer->ld;
 	struct fee_states *fee_states;
+	struct penalty_base *pbase;
 
 	if (!fromwire_channel_got_revoke(msg, msg,
 					 &revokenum, &per_commitment_secret,
 					 &next_per_commitment_point,
 					 &fee_states,
-					 &changed)
+					 &changed,
+					 &pbase)
 	    || !fee_states_valid(fee_states, channel->opener)) {
 		channel_internal_error(channel, "bad fromwire_channel_got_revoke %s",
 				    tal_hex(channel, msg));

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1731,6 +1731,9 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 	channel->last_sent_commit = tal_steal(channel, changed_htlcs);
 	wallet_channel_save(ld->wallet, channel);
 
+	if (pbase)
+		wallet_penalty_base_add(ld->wallet, channel->dbid, pbase);
+
 	/* Tell it we've got it, and to go ahead with commitment_signed. */
 	subd_send_msg(channel->owner,
 		      take(towire_channel_sending_commitsig_reply(msg)));

--- a/openingd/Makefile
+++ b/openingd/Makefile
@@ -63,6 +63,7 @@ OPENINGD_COMMON_OBJS :=				\
 	common/memleak.o			\
 	common/msg_queue.o			\
 	common/onionreply.o			\
+	common/penalty_base.o			\
 	common/per_peer_state.o			\
 	common/peer_billboard.o			\
 	common/peer_failed.o			\

--- a/openingd/opening_wire.csv
+++ b/openingd/opening_wire.csv
@@ -49,11 +49,13 @@ msgdata,opening_got_offer_reply,rejection,?wirestring,
 msgdata,opening_got_offer_reply,shutdown_len,u16,
 msgdata,opening_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
 
+#include <common/penalty_base.h>
 # Openingd->master: we've successfully offered channel.
 # This gives their sig, means we can broadcast tx: we're done.
 msgtype,opening_funder_reply,6101
 msgdata,opening_funder_reply,their_config,channel_config,
 msgdata,opening_funder_reply,first_commit,bitcoin_tx,
+msgdata,opening_funder_reply,pbase,?penalty_base,
 msgdata,opening_funder_reply,first_commit_sig,bitcoin_signature,
 msgdata,opening_funder_reply,pps,per_peer_state,
 msgdata,opening_funder_reply,revocation_basepoint,pubkey,
@@ -104,6 +106,7 @@ msgdata,opening_funder_failed,reason,wirestring,
 msgtype,opening_fundee,6003
 msgdata,opening_fundee,their_config,channel_config,
 msgdata,opening_fundee,first_commit,bitcoin_tx,
+msgdata,opening_fundee,pbase,?penalty_base,
 msgdata,opening_fundee,first_commit_sig,bitcoin_signature,
 msgdata,opening_fundee,pps,per_peer_state,
 msgdata,opening_fundee,revocation_basepoint,pubkey,

--- a/tests/plugins/watchtower.py
+++ b/tests/plugins/watchtower.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('commitment_revocation')
+def on_commitment_revocation(commitment_txid, penalty_tx, plugin, **kwargs):
+    with open('watchtower.csv', 'a') as f:
+        f.write("{}, {}\n".format(commitment_txid, penalty_tx))
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1270,6 +1270,78 @@ def test_replacement_payload(node_factory):
     assert l2.daemon.wait_for_log("Attept to pay.*with wrong secret")
 
 
+@unittest.skipIf(not DEVELOPER, "Requires dev_sign_last_tx")
+def test_watchtower(node_factory, bitcoind, directory, chainparams):
+    """Test watchtower hook.
+
+    l1 and l2 open a channel, make a couple of updates and then l1 cheats on
+    l2 while that one is offline. The watchtower plugin meanwhile stashes all
+    the penalty transactions and we release the one matching the offending
+    commitment transaction.
+
+    """
+    p = os.path.join(os.path.dirname(__file__), "plugins/watchtower.py")
+    l1, l2 = node_factory.line_graph(
+        2,
+        opts=[{'may_fail': True, 'allow_broken_log': True}, {'plugin': p}]
+    )
+
+    # Force a new commitment
+    l1.rpc.pay(l2.rpc.invoice(25000000, 'lbl1', 'desc1')['bolt11'])
+
+    tx = l1.rpc.dev_sign_last_tx(l2.info['id'])['tx']
+
+    # Now make sure it is out of date
+    l1.rpc.pay(l2.rpc.invoice(25000000, 'lbl2', 'desc2')['bolt11'])
+
+    # l2 stops watching the chain, allowing the watchtower to react
+    l2.stop()
+
+    # Now l1 cheats
+    bitcoind.rpc.sendrawtransaction(tx)
+    time.sleep(1)
+    bitcoind.generate_block(1)
+
+    wt_file = os.path.join(
+        l2.daemon.lightning_dir,
+        chainparams['name'],
+        'watchtower.csv'
+    )
+
+    cheat_tx = bitcoind.rpc.decoderawtransaction(tx)
+    for l in open(wt_file, 'r'):
+        txid, penalty = l.strip().split(', ')
+        if txid == cheat_tx['txid']:
+            # This one should succeed, since it is a response to the cheat_tx
+            bitcoind.rpc.sendrawtransaction(penalty)
+            break
+
+    # Need this to check that l2 gets the funds
+    penalty_meta = bitcoind.rpc.decoderawtransaction(penalty)
+
+    time.sleep(1)
+    bitcoind.generate_block(1)
+
+    # Make sure l2's normal penalty_tx doesn't reach the network
+    def mock_sendrawtransaction(tx):
+        print("NOT broadcasting", tx)
+
+    l2.daemon.rpcproxy.mock_rpc('sendrawtransaction', mock_sendrawtransaction)
+
+    # Restart l2, and it should continue where the watchtower left off:
+    l2.start()
+
+    # l2 will still try to broadcast its latest commitment tx, but it'll fail
+    # since l1 has cheated. All commitments share the same prefix, so look for
+    # that.
+    penalty_prefix = tx[:(4 + 1 + 36) * 2]  # version, txin_count, first txin in hex
+    l2.daemon.wait_for_log(r'Expected error broadcasting tx {}'.format(penalty_prefix))
+
+    # Now make sure the penalty output ends up in our wallet
+    fund_txids = [o['txid'] for o in l2.rpc.listfunds()['outputs']]
+    assert(penalty_meta['txid'] in fund_txids)
+
+
 def test_plugin_fail(node_factory):
     """Test that a plugin which fails (not during a command)"""
     plugin = os.path.join(os.path.dirname(__file__), 'plugins/fail_by_itself.py')

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -599,6 +599,14 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE channel_htlcs ADD localfailmsg BLOB;"), NULL},
     {SQL("UPDATE channel_htlcs SET localfailmsg=decode('2002', 'hex') WHERE malformed_onion != 0 AND direction = 1;"), NULL},
     {SQL("ALTER TABLE channels ADD our_funding_satoshi BIGINT DEFAULT 0;"), migrate_our_funding},
+    {SQL("CREATE TABLE penalty_bases ("
+	 "  channel_id BIGINT REFERENCES channels(id) ON DELETE CASCADE"
+	 ", commitnum BIGINT"
+	 ", txid BLOB"
+	 ", outnum INTEGER"
+	 ", amount BIGINT"
+	 ", PRIMARY KEY (channel_id, commitnum)"
+	 ");"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -116,7 +116,7 @@ bool fromwire_channel_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEE
 bool fromwire_channel_got_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct bitcoin_signature *signature UNNEEDED, secp256k1_ecdsa_signature **htlc_signature UNNEEDED, struct added_htlc **added UNNEEDED, struct fulfilled_htlc **fulfilled UNNEEDED, struct failed_htlc ***failed UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_tx **tx UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_channel_got_revoke */
-bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED)
+bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct penalty_base **pbase UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_revoke called!\n"); abort(); }
 /* Generated stub for fromwire_channel_offer_htlc_reply */
 bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -122,7 +122,7 @@ bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEED
 bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)
 { fprintf(stderr, "fromwire_channel_offer_htlc_reply called!\n"); abort(); }
 /* Generated stub for fromwire_channel_sending_commitsig */
-bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, secp256k1_ecdsa_signature **htlc_sigs UNNEEDED)
+bool fromwire_channel_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct penalty_base **pbase UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, secp256k1_ecdsa_signature **htlc_sigs UNNEEDED)
 { fprintf(stderr, "fromwire_channel_sending_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_connect_peer_connected */
 bool fromwire_connect_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -116,7 +116,7 @@ bool fromwire_channel_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEE
 bool fromwire_channel_got_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct fee_states **fee_states UNNEEDED, struct bitcoin_signature *signature UNNEEDED, secp256k1_ecdsa_signature **htlc_signature UNNEEDED, struct added_htlc **added UNNEEDED, struct fulfilled_htlc **fulfilled UNNEEDED, struct failed_htlc ***failed UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_tx **tx UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_channel_got_revoke */
-bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct penalty_base **pbase UNNEEDED)
+bool fromwire_channel_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *revokenum UNNEEDED, struct secret *per_commitment_secret UNNEEDED, struct pubkey *next_per_commit_point UNNEEDED, struct fee_states **fee_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct penalty_base **pbase UNNEEDED, struct bitcoin_tx **penalty_tx UNNEEDED)
 { fprintf(stderr, "fromwire_channel_got_revoke called!\n"); abort(); }
 /* Generated stub for fromwire_channel_offer_htlc_reply */
 bool fromwire_channel_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3786,3 +3786,64 @@ struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t
 	tal_free(stmt);
 	return txs;
 }
+
+void wallet_penalty_base_add(struct wallet *w, u64 chan_id,
+			     const struct penalty_base *pb)
+{
+	struct db_stmt *stmt;
+	stmt = db_prepare_v2(w->db,
+			     SQL("INSERT INTO penalty_bases ("
+				 "  channel_id"
+				 ", commitnum"
+				 ", txid"
+				 ", outnum"
+				 ", amount"
+				 ") VALUES (?, ?, ?, ?, ?);"));
+
+	db_bind_u64(stmt, 0, chan_id);
+	db_bind_u64(stmt, 1, pb->commitment_num);
+	db_bind_txid(stmt, 2, &pb->txid);
+	db_bind_int(stmt, 3, pb->outnum);
+	db_bind_amount_sat(stmt, 4, &pb->amount);
+
+	db_exec_prepared_v2(take(stmt));
+}
+
+struct penalty_base *wallet_penalty_base_load_for_channel(const tal_t *ctx,
+							  struct wallet *w,
+							  u64 chan_id)
+{
+	struct db_stmt *stmt;
+	struct penalty_base *res = tal_arr(ctx, struct penalty_base, 0);
+	stmt = db_prepare_v2(
+		w->db,
+		SQL("SELECT commitnum, txid, outnum, amount "
+		    "FROM penalty_bases "
+		    "WHERE channel_id = ?"));
+
+	db_bind_u64(stmt, 0, chan_id);
+	db_query_prepared(stmt);
+
+	while (db_step(stmt)) {
+		struct penalty_base pb;
+		pb.commitment_num = db_column_u64(stmt, 0);
+		db_column_txid(stmt, 1, &pb.txid);
+		pb.outnum = db_column_int(stmt, 2);
+		db_column_amount_sat(stmt, 3, &pb.amount);
+		tal_arr_expand(&res, pb);
+	}
+	tal_free(stmt);
+	return res;
+}
+
+void wallet_penalty_base_delete(struct wallet *w, u64 chan_id, u64 commitnum)
+{
+	struct db_stmt *stmt;
+	stmt = db_prepare_v2(
+		w->db,
+		SQL("DELETE FROM penalty_bases "
+		    "WHERE channel_id = ? AND commitnum = ?"));
+	db_bind_u64(stmt, 0, chan_id);
+	db_bind_u64(stmt, 1, commitnum);
+	db_exec_prepared_v2(take(stmt));
+}

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -10,6 +10,7 @@
 #include <ccan/list/list.h>
 #include <ccan/tal/tal.h>
 #include <common/channel_config.h>
+#include <common/penalty_base.h>
 #include <common/utxo.h>
 #include <common/wallet.h>
 #include <lightningd/bitcoind.h>
@@ -1250,5 +1251,29 @@ struct wallet_transaction *wallet_transactions_get(struct wallet *w, const tal_t
  * This can be used to backfill the blocks and still unspent UTXOs that were before our wallet birth height.
  */
 void wallet_filteredblock_add(struct wallet *w, const struct filteredblock *fb);
+
+/**
+ * Store a penalty base in the database.
+ *
+ * Required to eventually create a penalty transaction when we get a
+ * revocation.
+ */
+void wallet_penalty_base_add(struct wallet *w, u64 chan_id,
+			     const struct penalty_base *pb);
+
+/**
+ * Retrieve all pending penalty bases for a given channel.
+ *
+ * This list should stay relatively small since we remove items from it as we
+ * get revocations. We retrieve this list whenever we start a new `channeld`.
+ */
+struct penalty_base *wallet_penalty_base_load_for_channel(const tal_t *ctx,
+							  struct wallet *w,
+							  u64 chan_id);
+
+/**
+ * Delete a penalty_base, after we created and delivered it to the hook.
+ */
+void wallet_penalty_base_delete(struct wallet *w, u64 chan_id, u64 commitnum);
 
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
This is the third variant of the watchtower hook, the channelding. The main
difference with respect to #3645 is that the penalty transaction is now
created by `channeld` which already has a contextualized connection to `hsmd`,
so we can now drop the changes to the `hsmd` wire protocol, and just add the
penalty creation capability to the connection between `hsmd` and
`channeld`. It also removes the need to synchronously talk to the `hsmd` from
`lightningd` which was a bit ugly.

![flow](https://user-images.githubusercontent.com/120117/79887972-065d5a80-83fc-11ea-8056-60b6709d0e17.png)

Closes #3601
Closes #3645

Fixes #3422
Fixes #1353