### PR TITLE
feerates: de-dupe min_ max_ printing twice when `feerates` called

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -516,8 +516,7 @@ static struct command_result *json_feerates(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_object_start(response, json_feerate_style_name(*style));
 	for (size_t i = 0; i < ARRAY_SIZE(feerates); i++) {
-		if (!feerates[i] || feerates[i] == FEERATE_MIN
-		    || feerates[i] == FEERATE_MAX)
+		if (!feerates[i] || i == FEERATE_MIN || i == FEERATE_MAX)
 			continue;
 		json_add_num(response, feerate_name(i),
 			     feerate_to_style(feerates[i], *style));


### PR DESCRIPTION
We want to compare to `i`, the enum counter, not feerates[i], the
feerate value.

Without this fix, `feerates` appears as:
```
{
   "perkw": {
      "opening": 253,
      "mutual_close": 253,
      "unilateral_close": 253,
      "delayed_to_us": 253,
      "htlc_resolution": 253,
      "penalty": 253,
      "min_acceptable": 253,
      "max_acceptable": 2500,
      "min_acceptable": 253,
      "max_acceptable": 4294967295,
      "urgent": 253,
      "normal": 253,
      "slow": 506
   },
   "onchain_fee_estimates": {
      "opening_channel_satoshis": 177,
      "mutual_close_satoshis": 170,
      "unilateral_close_satoshis": 151,
      "htlc_timeout_satoshis": 167,
      "htlc_success_satoshis": 177
   }
}
```

bug introduced in "chaintopology: better feerate targets differentiation"