### PR TITLE
pyln-proto: Use only coincurve for libsecp256k1 bindings

### DIFF
--- a/contrib/pyln-proto/requirements.txt
+++ b/contrib/pyln-proto/requirements.txt
@@ -2,4 +2,3 @@ bitstring==3.1.6
 cryptography==2.8
 coincurve==13.0.0
 base58==1.0.2
-secp256k1==0.13.2

--- a/contrib/pyln-proto/tests/test_invoice.py
+++ b/contrib/pyln-proto/tests/test_invoice.py
@@ -1,6 +1,7 @@
 from pyln.proto import Invoice
 from decimal import Decimal
 from bitstring import ConstBitStream
+import binascii
 
 
 def test_decode():
@@ -13,3 +14,14 @@ def test_decode():
     assert(inv.amount == Decimal('0.000001'))
     assert(inv.featurebits == ConstBitStream('0x28200'))
     print(inv)
+
+
+def test_encode():
+    inv = Invoice(paymenthash=binascii.unhexlify("76272b9b95b14eb6bece3cd051006d8aabac63c3a50bd7ea2bb53612b0a9324b"),
+                  amount=Decimal('0.000001'),
+                  tags=[('d', 'test_pay_routeboost2'),
+                        ('x', 604800)],
+                  date=1579298293)
+    privkey = 'c28a9f80738f770d527803a566cf6fc3edf6cea586c4fc4a5223a5ad797e1ac3'
+    i = inv.encode(privkey)
+    assert(i == 'lnbc1u1p0zyt04pp5wcnjhxu4k98td0kw8ng9zqrd3246cc7r559a063tk5mp9v9fxf9sdpqw3jhxazlwpshjhmjda6hgetzdahhxapjxqyjw5q0s43wfg4f6yl200hc805kc9u97dp7m6j98fz33uzf4t6kp73trcz8fxkrpass063j2j4quxjr4th2r72lk27tm2aw383zgnl8zpgajsq5kmll8')


### PR DESCRIPTION
secp256k1 Python library is not maintained anymore and coincurve was
already used in the `wire` module.

Changelog-None
Signed-off-by: Michal Rostecki <mrostecki@mailfence.com>