### PR TITLE
libplugin: It's featurebits, not features

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -119,12 +119,12 @@ The `dynamic` indicates if the plugin can be managed after `lightningd`
 has been started. Critical plugins that should not be stopped should set it
 to false.
 
-The `features` object allows the plugin to register featurebits that should be
+The `featurebits` object allows the plugin to register featurebits that should be
 announced in a number of places in [the protocol][bolt9]. They can be used to signal
 support for custom protocol extensions to direct peers, remote nodes and in
 invoices. Custom protocol extensions can be implemented for example using the
 `sendcustommsg` method and the `custommsg` hook, or the `sendonion` method and
-the `htlc_accepted` hook. The keys in the `features` object are `node` for
+the `htlc_accepted` hook. The keys in the `featurebits` object are `node` for
 features that should be announced via the `node_announcement` to all nodes in
 the network, `init` for features that should be announced to direct peers
 during the connection setup, `channel` for features which should apply to `channel_announcement`, and `invoice` for features that should be

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -604,7 +604,7 @@ handle_getmanifest(struct command *getmanifest_cmd)
 	json_array_end(params);
 
 	if (p->our_features != NULL) {
-		json_object_start(params, "features");
+		json_object_start(params, "featurebits");
 		for (size_t i = 0; i < NUM_FEATURE_PLACE; i++) {
 			u8 *f = p->our_features->bits[i];
 			const char *fieldname = feature_place_names[i];

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2961,12 +2961,18 @@ def test_excluded_adjacent_routehint(node_factory, bitcoind):
         l1.rpc.pay(bolt11=inv['bolt11'], maxfeepercent=0, exemptfee=0)
 
 
+@pytest.mark.xfail(strict=True)
 def test_keysend(node_factory):
     # Use a temporary python plugin until we implement a native one
     plugin_path = os.path.join(os.getcwd(), 'tests/plugins/keysend.py')
     opts = {'plugin': plugin_path}
     amt = 10000
     l1, l2, l3 = node_factory.line_graph(3, opts=opts, wait_for_announce=True)
+
+    # The keysend featurebit must be set in the announcement, i.e., l1 should
+    # learn that l3 supports keysends.
+    features = l1.rpc.listnodes(l3.info['id'])['nodes'][0]['features']
+    assert(int(features, 16) >> 55 & 0x01 == 1)
 
     # Send an indirect one from l1 to l3
     l1.rpc.keysend(l3.info['id'], amt)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2961,7 +2961,6 @@ def test_excluded_adjacent_routehint(node_factory, bitcoind):
         l1.rpc.pay(bolt11=inv['bolt11'], maxfeepercent=0, exemptfee=0)
 
 
-@pytest.mark.xfail(strict=True)
 def test_keysend(node_factory):
     # Use a temporary python plugin until we implement a native one
     plugin_path = os.path.join(os.getcwd(), 'tests/plugins/keysend.py')


### PR DESCRIPTION
The documentation was wrong, and I copied my mistake to `libplugin` where it
was then ignored instead of ORed into the node's featurebits. This fixes both.