### PR TITLE
pyln: Set $HOME when running tests to avoid accessing real configs

### DIFF
--- a/contrib/pyln-proto/pyln/proto/__init__.py
+++ b/contrib/pyln-proto/pyln/proto/__init__.py
@@ -2,7 +2,7 @@ from .invoice import Invoice
 from .onion import OnionPayload, TlvPayload, LegacyOnionPayload
 from .wire import LightningConnection, LightningServerSocket
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 __all__ = [
     "Invoice",

--- a/contrib/pyln-proto/setup.py
+++ b/contrib/pyln-proto/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from pyln import proto
 import io
 
 
@@ -10,7 +9,7 @@ with io.open('requirements.txt', encoding='utf-8') as f:
     requirements = [r for r in f.read().split('\n') if len(r)]
 
 setup(name='pyln-proto',
-      version=proto.__version__,
+      version='0.0.2',
       description='Pure python implementation of the Lightning Network protocol',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -488,6 +488,9 @@ class LightningD(TailableProc):
             'ignore-fee-limits': 'false',
             'bitcoin-rpcuser': BITCOIND_CONFIG['rpcuser'],
             'bitcoin-rpcpassword': BITCOIND_CONFIG['rpcpassword'],
+
+            # Make sure we don't touch any existing config files in the user's $HOME
+            'bitcoin-datadir': lightning_dir,
         }
 
         for k, v in opts.items():

--- a/tests/plugins/bitcoin/part1.py
+++ b/tests/plugins/bitcoin/part1.py
@@ -33,5 +33,6 @@ def getchaininfo(plugin, **kwargs):
 plugin.add_option("bitcoin-rpcuser", "", "")
 plugin.add_option("bitcoin-rpcpassword", "", "")
 plugin.add_option("bitcoin-rpcport", "", "")
+plugin.add_option("bitcoin-datadir", "", "")
 
 plugin.run()


### PR DESCRIPTION
Sets the `$HOME` environment variable so that things that rely on user
configurations in the home directory, e.g., `bitcoin-cli`, will not find the
user's real configuration.

Fixes #3669
Fixes #3668 