### PR TITLE
Weekly cleanups

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -21,6 +21,7 @@ import struct
 import subprocess
 import threading
 import time
+import warnings
 
 BITCOIND_CONFIG = {
     "regtest": 1,
@@ -871,9 +872,10 @@ class LightningNode(object):
             elif params == [100, 'ECONOMICAL']:
                 feerate = feerates[3] * 4
             else:
-                raise ValueError("Don't have a feerate set for {}/{}.".format(
+                warnings.warn("Don't have a feerate set for {}/{}.".format(
                     params[0], params[1],
                 ))
+                feerate = 42
             return {
                 'id': r['id'],
                 'error': None,


### PR DESCRIPTION
Just two tiny fixes:

 - Using `liquid-regtest` we were having some issues checking amounts in the penalty tests. Now instead we make sure that we have the outputs that we expect instead of just checking the sum of their values. This is more fine-grained and more likely to detect a missing output being swept into our wallet.
 - The testing framework was breaking when running against some branches because the fee estimation was asking for configurations that do not match what we expect. Now we return a constant (42, what else) and queue a warning which gets collected by `pytest` and highlighted in the final summary. This allows us to still be warned, but not break the tests right away.

Cheers 😊