### PR TITLE
bugfix: don't truncate the `script` fetched from getutxout

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -381,8 +381,7 @@ static struct command_result *process_getutxout(struct bitcoin_cli *bcli)
 
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_amount_sat_only(response, "amount", output.amount);
-	json_add_string(response, "script",
-			tal_hexstr(response, output.script, sizeof(output.script)));
+	json_add_string(response, "script", tal_hex(response, output.script));
 
 	return command_finished(bcli->cmd, response);
 }


### PR DESCRIPTION
`sizeof` doesn't work as expected on pointers to arrays. found while working on the dual-funding branch. currently unused.