### PR TITLE
docker: fixed inotifywait stall on regtest/testnet

### DIFF
--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "$EXPOSE_TCP" == "true" ]; then
 
     echo "C-Lightning starting"
     while read -r i; do if [ "$i" = "lightning-rpc" ]; then break; fi; done \
-    < <(inotifywait  -e create,open --format '%f' --quiet "$LIGHTNINGD_DATA" --monitor)
+    < <(inotifywait -r -e create,open --format '%f' --quiet "$LIGHTNINGD_DATA" --monitor)
     echo "C-Lightning started"
     echo "C-Lightning started, RPC available on port $LIGHTNINGD_RPC_PORT"
 


### PR DESCRIPTION
added -r flag to inotifywait call in tools/docker-entrypoint.sh to
recursively watch LIGHTNINGD_DATA directory for when lightning-rpc file is created.