### PR TITLE
lightningd/bitcoind: remove unused BITCOIN_INIT_TIMEOUT

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -30,11 +30,6 @@
 #include <lightningd/chaintopology.h>
 #include <lightningd/plugin.h>
 
-/* How many seconds will we wait for our Bitcoin plugin to respond to `init` ?
- * Note that bcli waits for bitcoind to be warmed up before responding, so it
- * shouldn't be too low. */
-#define BITCOIN_INIT_TIMEOUT 30
-
 /* The names of the requests we can make to our Bitcoin backend. */
 static const char *methods[] = {"getchaininfo", "getrawblockbyheight",
                                 "sendrawtransaction", "getutxout",


### PR DESCRIPTION
The define is a leftover from the init fixed timeout hack that was
removed recently (commit 678591d851).

Changelog-None