### PR TITLE
tools/generate-wire: no more lonely messages!

### DIFF
--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -74,7 +74,7 @@ static struct io_plan *peer_init_received(struct io_conn *conn,
 	 *    - MAY fail the connection.
 	 */
 	if (tlvs->networks) {
-		if (!contains_common_chain(tlvs->networks->chains)) {
+		if (!contains_common_chain(tlvs->networks)) {
 			status_peer_debug(&peer->id,
 			                  "No common chain with this peer '%s', closing",
 			                  tal_hex(tmpctx, msg));
@@ -160,9 +160,8 @@ struct io_plan *peer_exchange_initmsg(struct io_conn *conn,
 	 *     channels for.
 	 */
 	tlvs = tlv_init_tlvs_new(tmpctx);
-	tlvs->networks = tal(tlvs, struct tlv_init_tlvs_networks);
-	tlvs->networks->chains = tal_arr(tlvs->networks, struct bitcoin_blkid, 1);
-	tlvs->networks->chains[0] = chainparams->genesis_blockhash;
+	tlvs->networks = tal_dup_arr(tlvs, struct bitcoin_blkid,
+				     &chainparams->genesis_blockhash, 1, 0);
 
 	/* Initially, there were two sets of feature bits: global and local.
 	 * Local affected peer nodes only, global affected everyone.  Both were

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -156,9 +156,8 @@ static struct io_plan *handshake_success(struct io_conn *conn,
 		struct tlv_init_tlvs *tlvs = NULL;
 		if (chainparams) {
 			tlvs = tlv_init_tlvs_new(NULL);
-			tlvs->networks = tal(tlvs, struct tlv_init_tlvs_networks);
-			tlvs->networks->chains = tal_arr(tlvs->networks, struct bitcoin_blkid, 1);
-			tlvs->networks->chains[0] = chainparams->genesis_blockhash;
+			tlvs->networks = tal_arr(tlvs, struct bitcoin_blkid, 1);
+			tlvs->networks[0] = chainparams->genesis_blockhash;
 		}
 			msg = towire_init(NULL, NULL, features, tlvs);
 

--- a/devtools/mkquery.c
+++ b/devtools/mkquery.c
@@ -49,9 +49,8 @@ int main(int argc, char *argv[])
 			tlvs = NULL;
 		else if (argc == 6) {
 			tlvs = tlv_query_channel_range_tlvs_new(ctx);
-			tlvs->query_option = tal(tlvs, struct tlv_query_channel_range_tlvs_query_option);
-			tlvs->query_option->query_option_flags
-				= strtol(argv[5], NULL, 0);
+			tlvs->query_option = tal(tlvs, varint);
+			*tlvs->query_option = strtol(argv[5], NULL, 0);
 		} else
 			usage();
 		msg = towire_query_channel_range(ctx, &chainhash,

--- a/gossipd/queries.c
+++ b/gossipd/queries.c
@@ -348,7 +348,7 @@ static void reply_channel_range(struct peer *peer,
 				u32 first_blocknum, u32 number_of_blocks,
 				const u8 *encoded_scids,
 				struct tlv_reply_channel_range_tlvs_timestamps_tlv *timestamps,
-				struct tlv_reply_channel_range_tlvs_checksums_tlv *checksums)
+				struct channel_update_checksums *checksums)
 {
 	/* BOLT #7:
 	 *
@@ -437,7 +437,7 @@ static bool queue_channel_ranges(struct peer *peer,
 	struct routing_state *rstate = peer->daemon->rstate;
 	u8 *encoded_scids = encoding_start(tmpctx);
 	struct tlv_reply_channel_range_tlvs_timestamps_tlv *tstamps;
-	struct tlv_reply_channel_range_tlvs_checksums_tlv *csums;
+	struct channel_update_checksums *csums;
 	struct short_channel_id scid;
 	bool scid_ok;
 
@@ -464,10 +464,7 @@ static bool queue_channel_ranges(struct peer *peer,
 		tstamps = NULL;
 
 	if (query_option_flags & QUERY_ADD_CHECKSUMS) {
-		csums = tal(tmpctx,
-			    struct tlv_reply_channel_range_tlvs_checksums_tlv);
-		csums->checksums
-			= tal_arr(csums, struct channel_update_checksums, 0);
+		csums = tal_arr(tmpctx, struct channel_update_checksums, 0);
 	} else
 		csums = NULL;
 
@@ -509,7 +506,7 @@ static bool queue_channel_ranges(struct peer *peer,
 					   &cs.checksum_node_id_2);
 
 		if (csums)
-			tal_arr_expand(&csums->checksums, cs);
+			tal_arr_expand(&csums, cs);
 		if (tstamps)
 			encoding_add_timestamps(&tstamps->encoded_timestamps,
 						&ts);
@@ -520,7 +517,7 @@ static bool queue_channel_ranges(struct peer *peer,
 	/* If either of these can't fit in max_encoded_bytes by itself,
 	 * it's over. */
 	if (csums) {
-		extension_bytes += tlv_len(csums->checksums);
+		extension_bytes += tlv_len(csums);
 	}
 
 	if (tstamps) {
@@ -585,7 +582,7 @@ const u8 *handle_query_channel_range(struct peer *peer, const u8 *msg)
 				       tal_hex(tmpctx, msg));
 	}
 	if (tlvs->query_option)
-		query_option_flags = tlvs->query_option->query_option_flags;
+		query_option_flags = *tlvs->query_option;
 	else
 		query_option_flags = 0;
 
@@ -1036,9 +1033,8 @@ bool query_channel_range(struct daemon *daemon,
 
 	if (qflags) {
 		tlvs = tlv_query_channel_range_tlvs_new(tmpctx);
-		tlvs->query_option
-			= tal(tlvs, struct tlv_query_channel_range_tlvs_query_option);
-		tlvs->query_option->query_option_flags = qflags;
+		tlvs->query_option = tal(tlvs, varint);
+		*tlvs->query_option = qflags;
 	} else
 		tlvs = NULL;
 	status_peer_debug(&peer->id,

--- a/gossipd/test/run-extended-info.c
+++ b/gossipd/test/run-extended-info.c
@@ -341,9 +341,8 @@ static u8 *test_query_channel_range(const char *test_vector, const jsmntok_t *ob
 	json_for_each_arr(i, t, opt) {
 		assert(json_tok_streq(test_vector, t,
 				      "WANT_TIMESTAMPS | WANT_CHECKSUMS"));
-		tlvs->query_option = tal(tlvs,
-					struct tlv_query_channel_range_tlvs_query_option);
-		tlvs->query_option->query_option_flags =
+		tlvs->query_option = tal(tlvs, varint);
+		*tlvs->query_option =
 			QUERY_ADD_TIMESTAMPS | QUERY_ADD_CHECKSUMS;
 	}
 	msg = towire_query_channel_range(NULL, &chain_hash, firstBlockNum, numberOfBlocks, tlvs);
@@ -411,11 +410,7 @@ static u8 *test_reply_channel_range(const char *test_vector, const jsmntok_t *ob
 	if (opt) {
 		const jsmntok_t *cstok;
 		tlvs->checksums_tlv
-			= tal(tlvs, struct tlv_reply_channel_range_tlvs_checksums_tlv);
-
-		tlvs->checksums_tlv->checksums
-			= tal_arr(tlvs->checksums_tlv,
-				  struct channel_update_checksums, 0);
+			= tal_arr(tlvs, struct channel_update_checksums, 0);
 
 		cstok = json_get_member(test_vector, opt, "checksums");
 		json_for_each_arr(i, t, cstok) {
@@ -428,7 +423,7 @@ static u8 *test_reply_channel_range(const char *test_vector, const jsmntok_t *ob
 					      json_get_member(test_vector, t,
 							      "checksum2"),
 					      &cs.checksum_node_id_2));
-			tal_arr_expand(&tlvs->checksums_tlv->checksums, cs);
+			tal_arr_expand(&tlvs->checksums_tlv, cs);
 		}
 	}
 

--- a/lightningd/onion_message.c
+++ b/lightningd/onion_message.c
@@ -300,20 +300,19 @@ static void populate_tlvs(struct hop *hops,
 		tlv = tlv_onionmsg_payload_new(tmpctx);
 		/* If they don't give scid, use next node id */
 		if (hops[i].scid) {
-			tlv->next_short_channel_id = tal(tlv, struct tlv_onionmsg_payload_next_short_channel_id);
-			tlv->next_short_channel_id->short_channel_id = *hops[i].scid;
+			tlv->next_short_channel_id
+				= tal_dup(tlv, struct short_channel_id,
+					  hops[i].scid);
 		} else if (i != tal_count(hops)-1) {
-			tlv->next_node_id = tal(tlv, struct tlv_onionmsg_payload_next_node_id);
-			tlv->next_node_id->node_id = hops[i+1].id;
+			tlv->next_node_id = tal_dup(tlv, struct pubkey,
+						    &hops[i+1].id);
 		}
 		if (hops[i].blinding) {
-			tlv->blinding = tal(tlv, struct tlv_onionmsg_payload_blinding);
-			tlv->blinding->blinding = *hops[i].blinding;
+			tlv->blinding = tal_dup(tlv, struct pubkey,
+						hops[i].blinding);
 		}
-		if (hops[i].enctlv) {
-			tlv->enctlv = tal(tlv, struct tlv_onionmsg_payload_enctlv);
-			tlv->enctlv->enctlv = hops[i].enctlv;
-		}
+		/* Note: tal_dup_talarr returns NULL for NULL */
+		tlv->enctlv = tal_dup_talarr(tlv, u8, hops[i].enctlv);
 
 		if (i == tal_count(hops)-1 && reply_path)
 			tlv->reply_path = reply_path;

--- a/tools/gen/header_template
+++ b/tools/gen/header_template
@@ -68,7 +68,11 @@ struct ${tlv.struct_name()} {
 	/* TODO The following explicit fields could just point into the
 	 * tlv_field entries above to save on memory. */
     % for msg in tlv.messages.values():
+        % if msg.singleton():
+	${msg.singleton().type_obj.type_name()} *${msg.name};
+	% else:
         struct ${msg.struct_name()} *${msg.name};
+	% endif
     % endfor
 };
 % endfor

--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -46,26 +46,28 @@ bool ${enum_set['name']}_is_defined(u16 type)
 % endfor
 ## START PARTIALS
 ## Subtype and TLV-msg towire_
-<%def name="towire_subtype_field(fieldname, f, ptr)">\
+<%def name="towire_subtype_field(fieldname, f, type_obj, is_single_ptr, ptr)">\
 % if f.is_array() or f.is_varlen():
-    % if f.type_obj.has_array_helper():
-towire_${f.type_obj.name}_array(${ptr}, ${fieldname}, ${f.size('tal_count(' + fieldname + ')')});
+    % if type_obj.has_array_helper():
+towire_${type_obj.name}_array(${ptr}, ${fieldname}, ${f.size('tal_count(' + fieldname + ')')});
     % else:
 	for (size_t i = 0; i < ${f.size('tal_count(' + fieldname + ')')}; i++)
-	% if f.type_obj.is_assignable() or f.type_obj.has_len_fields():
-		towire_${f.type_obj.name}(${ptr}, ${fieldname}[i]);
+	% if type_obj.is_assignable() or type_obj.has_len_fields():
+		towire_${type_obj.name}(${ptr}, ${fieldname}[i]);
 	% else:
-		towire_${f.type_obj.name}(${ptr}, ${fieldname} + i);
+		towire_${type_obj.name}(${ptr}, ${fieldname} + i);
 	% endif
     % endif
 % elif f.len_field_of:
-towire_${f.type_obj.name}(${ptr}, ${f.name});
+towire_${type_obj.name}(${ptr}, ${f.name});
+% elif is_single_ptr:
+towire_${type_obj.name}(${ptr}, ${'*' if type_obj.is_assignable() else ''}${fieldname});
 % else:
-towire_${f.type_obj.name}(${ptr}, ${'' if f.type_obj.is_assignable() else '&'}${fieldname});
+towire_${type_obj.name}(${ptr}, ${'' if type_obj.is_assignable() else '&'}${fieldname});
 % endif
 </%def>
 ## Subtype and TLV-msg fromwire
-<%def name="fromwire_subtype_field(fieldname, f, ctx)">\
+<%def name="fromwire_subtype_field(fieldname, f, ctx, is_ptr)">\
 <%
     type_ = f.type_obj.name
     typename = f.type_obj.type_name()
@@ -100,6 +102,10 @@ ${fieldname} = ${f.size('*plen')} ? tal_arr(${ctx}, ${typename}, 0) : NULL;
 	}
     % endif
 % else:
+    % if is_ptr:
+    ${fieldname} = tal(${ctx}, ${typename});
+    <% fieldname = '*' + fieldname %>
+    % endif
     % if f.type_obj.is_assignable():
 ${ f.name if f.len_field_of else fieldname} = fromwire_${type_}(cursor, plen);
     % elif f.type_obj.is_varsize():
@@ -132,9 +138,9 @@ ${static}void towire_${subtype.name}(u8 **p, const ${subtype.type_name()} *${sub
 	/*${c} */
 	    % endfor
 <%
-    fieldname = '{}->{}'.format(subtype.name,f.name)
+   fieldname = '{}->{}'.format(subtype.name,f.name)
 %>\
-	${towire_subtype_field(fieldname, f, 'p')}\
+	${towire_subtype_field(fieldname, f, f.type_obj, False, 'p')}\
 	% endfor
 }
 % if subtype.is_varsize():
@@ -160,7 +166,7 @@ ${static}void fromwire_${subtype.name}(${'const tal_t *ctx, ' if subtype.needs_c
     fieldname = '{}->{}'.format(subtype.name,f.name)
     ctx = subtype.name
 %> \
-	${fromwire_subtype_field(fieldname, f, ctx)}\
+	${fromwire_subtype_field(fieldname, f, ctx, False)}\
 	% endfor
 % if subtype.is_varsize():
 
@@ -205,8 +211,15 @@ static u8 *towire_${msg.struct_name()}(const tal_t *ctx, const void *vrecord)
 
 	ptr = tal_arr(ctx, u8, 0);
 	% for f in msg.fields.values():
-<% fieldname = 'r->{}->{}'.format(msg.name, f.name) %>\
-	${towire_subtype_field(fieldname, f, '&ptr')}\
+<%
+    if msg.singleton():
+        fieldname = 'r->{}'.format(msg.name)
+	type_obj = msg.singleton().type_obj
+    else:
+        fieldname = 'r->{}->{}'.format(msg.name, f.name)
+	type_obj = f.type_obj
+%>
+	${towire_subtype_field(fieldname, f, type_obj, msg.singleton(), '&ptr')}\
 	% endfor
 	return ptr;
 }
@@ -218,13 +231,19 @@ static void fromwire_${msg.struct_name()}(const u8 **cursor, size_t *plen, void 
 	${f.type_obj.type_name()} ${f.name};
 	% endfor
 
+	% if not msg.singleton():
 	r->${msg.name} = tal(r, struct ${msg.struct_name()});
+	% endif
 	% for f in msg.fields.values():
 <%
-    fieldname = 'r->{}->{}'.format(msg.name, f.name)
-    ctx = 'r->{}'.format(msg.name)
+    if msg.singleton():
+        fieldname = 'r->{}'.format(msg.name)
+        ctx = 'r'
+    else:
+        fieldname = 'r->{}->{}'.format(msg.name, f.name)
+        ctx = 'r->{}'.format(msg.name)
 %>\
-	${fromwire_subtype_field(fieldname, f, ctx)}\
+	${fromwire_subtype_field(fieldname, f, ctx, msg.singleton())}\
 	% endfor
 }
     % endfor

--- a/wire/test/run-peer-wire.c
+++ b/wire/test/run-peer-wire.c
@@ -858,12 +858,12 @@ static bool init_eq(const struct msg_init *a,
 	if (!a->tlvs->networks)
 		return true;
 
-	if (tal_count(a->tlvs->networks->chains)
-	    != tal_count(b->tlvs->networks->chains))
+	if (tal_count(a->tlvs->networks)
+	    != tal_count(b->tlvs->networks))
 		return false;
-	for (size_t i = 0; i < tal_count(a->tlvs->networks->chains); i++)
-		if (!bitcoin_blkid_eq(&a->tlvs->networks->chains[i],
-				      &b->tlvs->networks->chains[i]))
+	for (size_t i = 0; i < tal_count(a->tlvs->networks); i++)
+		if (!bitcoin_blkid_eq(&a->tlvs->networks[i],
+				      &b->tlvs->networks[i]))
 			return false;
 	return true;
 }
@@ -1078,9 +1078,8 @@ int main(void)
 		init.localfeatures = tal_arr(ctx, u8, 2);
 		memset(init.localfeatures, 2, 2);
 		init.tlvs = tlv_init_tlvs_new(ctx);
-		init.tlvs->networks = tal(init.tlvs, struct tlv_init_tlvs_networks);
-		init.tlvs->networks->chains = tal_arr(ctx, struct bitcoin_blkid, 1);
-		init.tlvs->networks->chains[0] = chains[i]->genesis_blockhash;
+		init.tlvs->networks = tal_arr(init.tlvs, struct bitcoin_blkid, 1);
+		init.tlvs->networks[0] = chains[i]->genesis_blockhash;
 		msg = towire_struct_init(ctx, &init);
 		init2 = fromwire_struct_init(ctx, msg);
 		assert(init_eq(&init, init2));

--- a/wire/test/run-tlvstream.c
+++ b/wire/test/run-tlvstream.c
@@ -294,19 +294,19 @@ struct valid_stream {
 	const struct tlv_n1 expect;
 };
 
-static struct tlv_n1_tlv1 tlv1_0 = { .amount_msat = 0 };
-static struct tlv_n1_tlv1 tlv1_1 = { .amount_msat = 1 };
-static struct tlv_n1_tlv1 tlv1_256 = { .amount_msat = 256 };
-static struct tlv_n1_tlv1 tlv1_65536 = { .amount_msat = 65536 };
-static struct tlv_n1_tlv1 tlv1_16777216 = { .amount_msat = 16777216 };
-static struct tlv_n1_tlv1 tlv1_4294967296 = { .amount_msat = 4294967296ULL };
-static struct tlv_n1_tlv1 tlv1_1099511627776 = { .amount_msat = 1099511627776ULL};
-static struct tlv_n1_tlv1 tlv1_281474976710656 = { .amount_msat = 281474976710656ULL };
-static struct tlv_n1_tlv1 tlv1_72057594037927936 = { .amount_msat = 72057594037927936ULL };
-static struct tlv_n1_tlv2 tlv2_0x0x550 = { .scid.u64 = 0x000000000226 };
+static u64 tlv1_0 = 0;
+static u64 tlv1_1 = 1;
+static u64 tlv1_256 = 256;
+static u64 tlv1_65536 = 65536;
+static u64 tlv1_16777216 = 16777216;
+static u64 tlv1_4294967296 = 4294967296ULL;
+static u64 tlv1_1099511627776 = 1099511627776UL;
+static u64 tlv1_281474976710656 = 281474976710656ULL;
+static u64 tlv1_72057594037927936 = 72057594037927936ULL;
+static struct short_channel_id tlv2_0x0x550 = { .u64 = 0x000000000226 };
 /* filled in at runtime. */
 static struct tlv_n1_tlv3 tlv3_node_id;
-static struct tlv_n1_tlv4 tlv4_550 = { .cltv_delta = 550 };
+static u16 tlv4_550 = 550;
 
 static struct valid_stream valid_streams[] = {
 	/* Valid but no (known) content. */
@@ -338,7 +338,7 @@ static bool tlv_n1_eq(const struct tlv_n1 *a, const struct tlv_n1 *b)
 	if (a->tlv1) {
 		if (!b->tlv1)
 			return false;
-		if (a->tlv1->amount_msat != b->tlv1->amount_msat)
+		if (*a->tlv1 != *b->tlv1)
 			return false;
 	} else if (b->tlv1)
 		return false;
@@ -346,7 +346,7 @@ static bool tlv_n1_eq(const struct tlv_n1 *a, const struct tlv_n1 *b)
 	if (a->tlv2) {
 		if (!b->tlv2)
 			return false;
-		if (!short_channel_id_eq(&a->tlv2->scid, &b->tlv2->scid))
+		if (!short_channel_id_eq(a->tlv2, b->tlv2))
 			return false;
 	} else if (b->tlv2)
 		return false;
@@ -368,7 +368,7 @@ static bool tlv_n1_eq(const struct tlv_n1 *a, const struct tlv_n1 *b)
 	if (a->tlv4) {
 		if (!b->tlv4)
 			return false;
-		if (a->tlv4->cltv_delta != b->tlv4->cltv_delta)
+		if (*a->tlv4 != *b->tlv4)
 			return false;
 	} else if (b->tlv4)
 		return false;


### PR DESCRIPTION
When we have only a single member in a TLV (e.g. an optional u64),
wrapping it in a struct is awkward.  This changes it to directly
access those fields.

This is not only more elegant (60 fewer lines), it would also be
more cache friendly.  That's right: cache hot singles!

[I blame @niftynei for the nomenclature which lead to these awful puns, FWIW!]