### PR TITLE
doc: remove bitcoin PPA from install instructions

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -41,12 +41,13 @@ Get dependencies:
       gettext
 
 If you don't have Bitcoin installed locally you'll need to install that
-as well:
+as well. It's now available via [snapd](https://snapcraft.io/bitcoin-core).
 
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:bitcoin/bitcoin
-    sudo apt-get update
-    sudo apt-get install -y bitcoind
+    sudo apt-get install snapd
+    sudo snap install bitcoin-core
+    # Snap does some weird things with binary names; you'll
+    # want to add a link to them so everything works as expected
+    sudo ln -s /snap/bitcoin-core/current/bin/bitcoin{d,-cli} /usr/local/bin/
 
 Clone lightning:
 


### PR DESCRIPTION
the PPA is no longer maintained, the new hotness is the snapd install.
except that snapd does some weirdness with the binary names, calling it
bitcoin-core.daemon and bitcoin-core.cli. To get around this, you can
create a symbolic link to the snap binaries, which is what we outline
here.