### PR TITLE
Fix bash completion

### DIFF
--- a/contrib/lightning-cli.bash-completion
+++ b/contrib/lightning-cli.bash-completion
@@ -31,7 +31,7 @@ _lightning_cli() {
 
             # get the regular commands
             if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
-		helpopts=$($lightning_cli -H help 2>/dev/null | sed -n 's/^\([a-z][a-z_-]*\).*/\1/p' | sed '$ d')
+		helpopts=$($lightning_cli help 2>/dev/null | sed -n 's/^\([a-z][a-z_-]*\).*/\1/p' | sed '$ d')
             fi
 
             COMPREPLY=( $( compgen -W "$helpopts $globalcmds" -X "*," -- "$cur" ) )


### PR DESCRIPTION
At some point lightning-cli help defaulted to human readable format, the additional -H broke the bash completion.

```
lightning-cli -H help
help=command=autocleaninvoice [cycle_seconds] [expired_by]
category=plugin
description=Set up autoclean of expired invoices.
verbose=Perform cleanup every {cycle_seconds} (default 3600), or disable autoclean if 0. Clean up expired invoices that have expired for {expired_by} seconds (default 86400).
command=balance [unit]
category=plugin
description=List detailed onchain and channel balance information
verbose=List detailed onchain and channel balance information
command=channelstats
category=plugin
description=List detailed channel stats for local node
verbose=List detailed channel stats for local node
command=check command_to_check
category=utility
description=Don't run {command_to_check}, just verify parameters.
verbose=check command_to_check [parameters...]
```