### PR TITLE
devtools/credit: check if tag exists first

### DIFF
--- a/devtools/credit
+++ b/devtools/credit
@@ -13,6 +13,10 @@ if [ "$#" != 1 ]; then
 fi
 PREV_TAG="$1"
 
+if [ -z $(git tag -l "$PREV_TAG") ]; then
+    echo "Error: couldn't find tag '$PREV_TAG'!"
+    exit 1
+fi
 git log "$PREV_TAG".. --format="%an|%ae" | sort | uniq -c | sort -rn > /tmp/authors.$$
 sed -n 's/.*[Nn]amed by //p' < CHANGELOG.md > /tmp/namers.$$
 git log "$PREV_TAG" --format="%an|%ae" | sort -u > /tmp/prev-authors.$$


### PR DESCRIPTION
Output on master branch for a non-existing tag:
```
$ ./devtools/credit v1337
fatal: ambiguous argument 'v1337..': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'v1337': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'v1337': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
./devtools/credit: 47: ./devtools/credit: arithmetic expression: expecting primary: " ( 1589109411 -  ) / (3600*24) "
```

Output on PR branch:
```
$ ./devtools/credit v1337
Error: couldn't find tag 'v1337'!
```