### PR TITLE
pytest: extend timeout for test_payment_duplicate_uncommitted

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -448,8 +448,8 @@ def test_payment_duplicate_uncommitted(node_factory, executor):
     l1.rpc.dev_reenable_commit(l2.info['id'])
 
     # These should succeed.
-    fut.result(10)
-    fut2.result(10)
+    fut.result(TIMEOUT)
+    fut2.result(TIMEOUT)
 
 
 @unittest.skipIf(not DEVELOPER, "Too slow without --dev-fast-gossip")


### PR DESCRIPTION
We've been seeing some Travis timeouts under VALGRIND, with the
10 second timeout here: use TIMEOUT as per standard.

Changelog-None