### PR TITLE
pyln: fix incorrect python syntax?

### DIFF
--- a/contrib/pyln-proto/pyln/proto/bech32.py
+++ b/contrib/pyln-proto/pyln/proto/bech32.py
@@ -117,5 +117,5 @@ def decode(hrp, addr):
 def encode(hrp, witver, witprog):
     """Encode a segwit address."""
     ret = bech32_encode(hrp, [witver] + convertbits(witprog, 8, 5))
-    assert decode(hrp, ret) is not (None, None)
+    assert decode(hrp, ret) != (None, None)
     return ret


### PR DESCRIPTION
```python
contrib/pyln-proto/pyln/proto/bech32.py:120
  /home/rusty/devel/cvs/lightning/contrib/pyln-proto/pyln/proto/bech32.py:120: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    assert decode(hrp, ret) is not (None, None)
```

I think this warning is correct (though I don't see the warning once I installed coincurve:
are we suppressing warnings?)

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None