### PR TITLE
Config: revive --commit-fee

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -332,8 +332,8 @@ opens a channel before the channel is usable\.
 
 
  \fBcommit-fee\fR=\fIPERCENT\fR
-The percentage of \fIestimatesmartfee 2\fR to use for the bitcoin
-transaction which funds a channel: can be greater than 100\.
+The percentage of \fIestimatesmartfee 2/CONSERVATIVE\fR to use for the commitment
+transactions: default is 100\.
 
 
  \fBcommit-fee-min\fR=\fIPERCENT\fR

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -270,8 +270,8 @@ Confirmations required for the funding transaction when the other side
 opens a channel before the channel is usable.
 
  **commit-fee**=*PERCENT*
-The percentage of *estimatesmartfee 2* to use for the bitcoin
-transaction which funds a channel: can be greater than 100.
+The percentage of *estimatesmartfee 2/CONSERVATIVE* to use for the commitment
+transactions: default is 100.
 
  **commit-fee-min**=*PERCENT*
  **commit-fee-max**=*PERCENT*

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -32,9 +32,6 @@ struct config {
 	/* Minimum percent of fee rate we'll accept. */
 	u32 commitment_fee_min_percent;
 
-	/* Percent of fee rate we'll use. */
-	u32 commitment_fee_percent;
-
 	/* Minimum CLTV to subtract from incoming HTLCs to outgoing */
 	u32 cltv_expiry_delta;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -571,9 +571,6 @@ static const struct config testnet_config = {
 	.commitment_fee_min_percent = 0,
 	.commitment_fee_max_percent = 0,
 
-	/* We offer to pay 5 times 2-block fee */
-	.commitment_fee_percent = 500,
-
 	/* Testnet blockspace is free. */
 	.max_concurrent_htlcs = 483,
 
@@ -618,9 +615,6 @@ static const struct config mainnet_config = {
 	/* Insist between 2 and 20 times the 2-block fee. */
 	.commitment_fee_min_percent = 200,
 	.commitment_fee_max_percent = 2000,
-
-	/* We offer to pay 5 times 2-block fee */
-	.commitment_fee_percent = 500,
 
 	/* While up to 483 htlcs are possible we do 30 by default (as eclair does) to save blockspace */
 	.max_concurrent_htlcs = 30,
@@ -820,9 +814,6 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--commit-fee-max=<percent>", opt_set_u32, opt_show_u32,
 			 &ld->config.commitment_fee_max_percent,
 			 "Maximum percentage of fee to accept for commitment (0 for unlimited)");
-	opt_register_arg("--commit-fee=<percent>", opt_set_u32, opt_show_u32,
-			 &ld->config.commitment_fee_percent,
-			 "Percentage of fee to request for their commitment");
 	opt_register_arg("--cltv-delta", opt_set_u32, opt_show_u32,
 			 &ld->config.cltv_expiry_delta,
 			 "Number of blocks for cltv_expiry_delta");

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2375,3 +2375,16 @@ def test_getsharedsecret(node_factory):
     # knowing only the public key of the other.
     assert (l1.rpc.getsharedsecret(l2.info["id"])["shared_secret"]
             == l2.rpc.getsharedsecret(l1.info["id"])["shared_secret"])
+
+
+def test_commitfee_option(node_factory):
+    """Sanity check for the --commit-fee startup option."""
+    l1, l2 = node_factory.get_nodes(2, opts=[{"commit-fee": "200"}, {}])
+
+    mock_wu = 5000
+    for l in [l1, l2]:
+        l.set_feerates((mock_wu, 0, 0, 0), True)
+    l1_commit_fees = l1.rpc.call("estimatefees")["unilateral_close"]
+    l2_commit_fees = l2.rpc.call("estimatefees")["unilateral_close"]
+
+    assert l1_commit_fees == 2 * l2_commit_fees == 2 * 4 * mock_wu  # WU->VB

--- a/wallet/test/test_utils.c
+++ b/wallet/test/test_utils.c
@@ -10,7 +10,6 @@ const struct config test_config = {
 	.anchor_confirms = 1,
 	.commitment_fee_min_percent = 0,
 	.commitment_fee_max_percent = 0,
-	.commitment_fee_percent = 500,
 	.cltv_expiry_delta = 6,
 	.cltv_final = 10,
 	.commit_time_ms = 10,


### PR DESCRIPTION
It has been ignored for quite some time apparently (a quick `git log -S` tells me we don't use it since `88bb38f63b46eeac6ea3f3a29b71dd9aca6cacd0`, but not sure though) and the doc was wrong.