### PR TITLE
hsmd: fix missing return bug

### DIFF
--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -1007,7 +1007,7 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 						    &output_witscripts,
 						    &remote_per_commit,
 						    &option_static_remotekey))
-		bad_req(conn, c, msg_in);
+		return bad_req(conn, c, msg_in);
 	tx->chainparams = c->chainparams;
 
 	/* Basic sanity checks. */


### PR DESCRIPTION
One must `return` the bad_req, otherwise you continue onward, usually
with bad or unexpected results.

introduced in 6b6b7eac61491c8a7ed4c6e939570221f1286f7e
Changelog-None