### PR TITLE
Initial PSBT support 

### DIFF
--- a/bitcoin/Makefile
+++ b/bitcoin/Makefile
@@ -7,6 +7,7 @@ BITCOIN_SRC :=					\
 	bitcoin/locktime.c			\
 	bitcoin/preimage.c			\
 	bitcoin/privkey.c			\
+	bitcoin/psbt.c				\
 	bitcoin/pubkey.c			\
 	bitcoin/pullpush.c			\
 	bitcoin/script.c			\
@@ -26,6 +27,7 @@ BITCOIN_HEADERS := bitcoin/address.h		\
 	bitcoin/locktime.h			\
 	bitcoin/preimage.h			\
 	bitcoin/privkey.h			\
+	bitcoin/psbt.h				\
 	bitcoin/pubkey.h			\
 	bitcoin/pullpush.h			\
 	bitcoin/script.h			\

--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -1,0 +1,90 @@
+#include <assert.h>
+#include <bitcoin/psbt.h>
+#include <ccan/tal/tal.h>
+#include <string.h>
+#include <wally_psbt.h>
+#include <wally_transaction.h>
+
+#define MAKE_ROOM(arr, pos, num)				\
+	memmove((arr) + (pos) + 1, (arr) + (pos),		\
+		sizeof(*(arr)) * ((num) - ((pos) + 1)))
+
+#define REMOVE_ELEM(arr, pos, num)				\
+	memmove((arr) + (pos), (arr) + (pos) + 1,		\
+		sizeof(*(arr)) * ((num) - ((pos) + 1)))
+
+struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt,
+					struct wally_tx_input *input,
+				       	size_t insert_at)
+{
+	struct wally_tx *tx;
+	struct wally_tx_input tmp_in;
+
+	tx = psbt->tx;
+	assert(insert_at <= tx->num_inputs);
+	wally_tx_add_input(tx, input);
+	tmp_in = tx->inputs[tx->num_inputs - 1];
+	MAKE_ROOM(tx->inputs, insert_at, tx->num_inputs);
+	tx->inputs[insert_at] = tmp_in;
+
+    	if (psbt->inputs_allocation_len < tx->num_inputs) {
+		struct wally_psbt_input *p = tal_arr(psbt, struct wally_psbt_input, tx->num_inputs);
+		memcpy(p, psbt->inputs, sizeof(*psbt->inputs) * psbt->inputs_allocation_len);
+		tal_free(psbt->inputs);
+
+		psbt->inputs = p;
+		psbt->inputs_allocation_len = tx->num_inputs;
+	}
+
+	psbt->num_inputs += 1;
+	MAKE_ROOM(psbt->inputs, insert_at, psbt->num_inputs);
+	memset(&psbt->inputs[insert_at], 0, sizeof(psbt->inputs[insert_at]));
+	return &psbt->inputs[insert_at];
+}
+
+void psbt_rm_input(struct wally_psbt *psbt,
+		   size_t remove_at)
+{
+	assert(remove_at < psbt->tx->num_inputs);
+	wally_tx_remove_input(psbt->tx, remove_at);
+	REMOVE_ELEM(psbt->inputs, remove_at, psbt->num_inputs);
+	psbt->num_inputs -= 1;
+}
+
+struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt,
+					  struct wally_tx_output *output,
+					  size_t insert_at)
+{
+	struct wally_tx *tx;
+	struct wally_tx_output tmp_out;
+
+	tx = psbt->tx;
+	assert(insert_at <= tx->num_outputs);
+	wally_tx_add_output(tx, output);
+	tmp_out = tx->outputs[tx->num_outputs - 1];
+	MAKE_ROOM(tx->outputs, insert_at, tx->num_outputs);
+	tx->outputs[insert_at] = tmp_out;
+
+    	if (psbt->outputs_allocation_len < tx->num_outputs) {
+		struct wally_psbt_output *p = tal_arr(psbt, struct wally_psbt_output, tx->num_outputs);
+		memcpy(p, psbt->outputs, sizeof(*psbt->outputs) * psbt->outputs_allocation_len);
+		tal_free(psbt->outputs);
+
+		psbt->outputs = p;
+		psbt->outputs_allocation_len = tx->num_outputs;
+	}
+
+	psbt->num_outputs += 1;
+	MAKE_ROOM(psbt->outputs, insert_at, psbt->num_outputs);
+	memset(&psbt->outputs[insert_at], 0, sizeof(psbt->outputs[insert_at]));
+	return &psbt->outputs[insert_at];
+}
+
+void psbt_rm_output(struct wally_psbt *psbt,
+		    size_t remove_at)
+{
+	assert(remove_at < psbt->tx->num_outputs);
+	wally_tx_remove_output(psbt->tx, remove_at);
+	REMOVE_ELEM(psbt->outputs, remove_at, psbt->num_outputs);
+	psbt->num_outputs -= 1;
+}

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -1,12 +1,19 @@
 #ifndef LIGHTNING_BITCOIN_PSBT_H
 #define LIGHTNING_BITCOIN_PSBT_H
 #include "config.h"
+#include <ccan/tal/tal.h>
 #include <stddef.h>
 
 struct wally_tx_input;
 struct wally_tx_output;
 struct wally_psbt;
 struct wally_psbt_input;
+struct wally_tx;
+
+void psbt_destroy(struct wally_psbt *psbt);
+
+struct wally_psbt *new_psbt(const tal_t *ctx,
+			    const struct wally_tx *wtx);
 
 struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt,
 					struct wally_tx_input *input,

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -1,0 +1,25 @@
+#ifndef LIGHTNING_BITCOIN_PSBT_H
+#define LIGHTNING_BITCOIN_PSBT_H
+#include "config.h"
+#include <stddef.h>
+
+struct wally_tx_input;
+struct wally_tx_output;
+struct wally_psbt;
+struct wally_psbt_input;
+
+struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt,
+					struct wally_tx_input *input,
+					size_t insert_at);
+
+void psbt_rm_input(struct wally_psbt *psbt,
+		   size_t remove_at);
+
+struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt,
+					  struct wally_tx_output *output,
+					  size_t insert_at);
+
+void psbt_rm_output(struct wally_psbt *psbt,
+		    size_t remove_at);
+
+#endif /* LIGHTNING_BITCOIN_PSBT_H */

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_BITCOIN_PSBT_H
 #define LIGHTNING_BITCOIN_PSBT_H
 #include "config.h"
+#include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
 #include <stddef.h>
 
@@ -29,4 +30,7 @@ struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt,
 void psbt_rm_output(struct wally_psbt *psbt,
 		    size_t remove_at);
 
+void towire_psbt(u8 **pptr, const struct wally_psbt *psbt);
+struct wally_psbt *fromwire_psbt(const tal_t *ctx,
+				 const u8 **curosr, size_t *max);
 #endif /* LIGHTNING_BITCOIN_PSBT_H */

--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -42,6 +42,11 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for psbt_add_output */
+struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
+					  struct wally_tx_output *output UNNEEDED,
+					  size_t insert_at UNNEEDED)
+{ fprintf(stderr, "psbt_add_output called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }

--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -27,6 +27,9 @@ bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 				       struct amount_sat a UNNEEDED,
 				       struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_sub called!\n"); abort(); }
+/* Generated stub for fromwire */
+const u8 *fromwire(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, void *copy UNNEEDED, size_t n UNNEEDED)
+{ fprintf(stderr, "fromwire called!\n"); abort(); }
 /* Generated stub for fromwire_amount_sat */
 struct amount_sat fromwire_amount_sat(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_amount_sat called!\n"); abort(); }
@@ -43,6 +46,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }
@@ -52,6 +58,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u8_array */
 void towire_u8_array(u8 **pptr UNNEEDED, const u8 *arr UNNEEDED, size_t num UNNEEDED)
 { fprintf(stderr, "towire_u8_array called!\n"); abort(); }

--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -1,4 +1,5 @@
 #include "../block.c"
+#include "../psbt.c"
 #include "../pullpush.c"
 #include "../shadouble.c"
 #include "../tx.c"
@@ -42,16 +43,6 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
-/* Generated stub for psbt_add_input */
-struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt UNNEEDED,
-					struct wally_tx_input *input UNNEEDED,
-					size_t insert_at UNNEEDED)
-{ fprintf(stderr, "psbt_add_input called!\n"); abort(); }
-/* Generated stub for psbt_add_output */
-struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
-					  struct wally_tx_output *output UNNEEDED,
-					  size_t insert_at UNNEEDED)
-{ fprintf(stderr, "psbt_add_output called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }

--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -42,6 +42,11 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for psbt_add_input */
+struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt UNNEEDED,
+					struct wally_tx_input *input UNNEEDED,
+					size_t insert_at UNNEEDED)
+{ fprintf(stderr, "psbt_add_input called!\n"); abort(); }
 /* Generated stub for psbt_add_output */
 struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
 					  struct wally_tx_output *output UNNEEDED,

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <bitcoin/psbt.c>
 #include <bitcoin/pullpush.c>
 #include <bitcoin/shadouble.c>
 #include <bitcoin/tx.c>
@@ -43,16 +44,6 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
-/* Generated stub for psbt_add_input */
-struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt UNNEEDED,
-					struct wally_tx_input *input UNNEEDED,
-					size_t insert_at UNNEEDED)
-{ fprintf(stderr, "psbt_add_input called!\n"); abort(); }
-/* Generated stub for psbt_add_output */
-struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
-					  struct wally_tx_output *output UNNEEDED,
-					  size_t insert_at UNNEEDED)
-{ fprintf(stderr, "psbt_add_output called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -43,6 +43,11 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for psbt_add_input */
+struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt UNNEEDED,
+					struct wally_tx_input *input UNNEEDED,
+					size_t insert_at UNNEEDED)
+{ fprintf(stderr, "psbt_add_input called!\n"); abort(); }
 /* Generated stub for psbt_add_output */
 struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
 					  struct wally_tx_output *output UNNEEDED,

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -28,6 +28,9 @@ bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 				       struct amount_sat a UNNEEDED,
 				       struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_sub called!\n"); abort(); }
+/* Generated stub for fromwire */
+const u8 *fromwire(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, void *copy UNNEEDED, size_t n UNNEEDED)
+{ fprintf(stderr, "fromwire called!\n"); abort(); }
 /* Generated stub for fromwire_amount_sat */
 struct amount_sat fromwire_amount_sat(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_amount_sat called!\n"); abort(); }
@@ -44,6 +47,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }
@@ -53,6 +59,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u8_array */
 void towire_u8_array(u8 **pptr UNNEEDED, const u8 *arr UNNEEDED, size_t num UNNEEDED)
 { fprintf(stderr, "towire_u8_array called!\n"); abort(); }

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -43,6 +43,11 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for psbt_add_output */
+struct wally_psbt_output *psbt_add_output(struct wally_psbt *psbt UNNEEDED,
+					  struct wally_tx_output *output UNNEEDED,
+					  size_t insert_at UNNEEDED)
+{ fprintf(stderr, "psbt_add_output called!\n"); abort(); }
 /* Generated stub for towire_amount_sat */
 void towire_amount_sat(u8 **pptr UNNEEDED, const struct amount_sat sat UNNEEDED)
 { fprintf(stderr, "towire_amount_sat called!\n"); abort(); }

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -492,6 +492,19 @@ void bitcoin_tx_finalize(struct bitcoin_tx *tx)
 	assert(bitcoin_tx_check(tx));
 }
 
+char *bitcoin_tx_to_psbt_base64(const tal_t *ctx, struct bitcoin_tx *tx)
+{
+	char *serialized_psbt, *ret_val;
+	int ret;
+
+	ret = wally_psbt_to_base64(tx->psbt, &serialized_psbt);
+	assert(ret == WALLY_OK);
+
+	ret_val = tal_strdup(ctx, serialized_psbt);
+	wally_free_string(serialized_psbt);
+	return ret_val;
+}
+
 struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx, const u8 **cursor,
 				   size_t *max)
 {

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -168,6 +168,7 @@ int bitcoin_tx_add_input(struct bitcoin_tx *tx, const struct bitcoin_txid *txid,
 				  NULL /* Empty witness stack */, &input);
 	input->features = chainparams->is_elements ? WALLY_TX_IS_ELEMENTS : 0;
 	wally_tx_add_input(tx->wtx, input);
+	psbt_add_input(tx->psbt, input, i);
 	wally_tx_input_free(input);
 
 	/* Now store the input amount if we know it, so we can sign later */

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -233,8 +233,7 @@ const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
 		return NULL;
 	}
 
-	res = tal_arr(ctx, u8, output->script_len);
-	memcpy(res, output->script, output->script_len);
+	res = tal_dup_arr(ctx, u8, output->script, output->script_len, 0);
 	return res;
 }
 

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -217,6 +217,10 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 		assert(ret == WALLY_OK);
 	} else {
 		output->satoshi = satoshis;
+
+		/* update the global tx for the psbt also */
+		output = &tx->psbt->tx->outputs[outnum];
+		output->satoshi = satoshis;
 	}
 }
 

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -652,6 +652,10 @@ struct bitcoin_tx *fromwire_bitcoin_tx(const tal_t *ctx,
 	if (!tx)
 		return fromwire_fail(cursor, max);
 
+	/* pull_bitcoin_tx sets the psbt */
+	tal_free(tx->psbt);
+	tx->psbt = fromwire_psbt(tx, cursor, max);
+
 	input_amts_len = fromwire_u16(cursor, max);
 
 	/* They must give us none or all */
@@ -682,6 +686,7 @@ void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx)
 	u8 *lin = linearize_tx(tmpctx, tx);
 	towire_u8_array(pptr, lin, tal_count(lin));
 
+	towire_psbt(pptr, tx->psbt);
 	/* We only want to 'save' the amounts if every amount
 	 * has been populated */
 	for (i = 0; i < tal_count(tx->input_amounts); i++) {

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -30,9 +30,6 @@ struct bitcoin_tx {
 	struct amount_sat **input_amounts;
 	struct wally_tx *wtx;
 
-	/* Need the output wscripts in the HSM to validate transaction */
-	struct witscript **output_witscripts;
-
 	/* Keep a reference to the ruleset we have to abide by */
 	const struct chainparams *chainparams;
 
@@ -78,6 +75,7 @@ struct bitcoin_tx *pull_bitcoin_tx(const tal_t *ctx,
 				   const u8 **cursor, size_t *max);
 /* Add one output to tx. */
 int bitcoin_tx_add_output(struct bitcoin_tx *tx, const u8 *script,
+			  u8 *wscript,
 			  struct amount_sat amount);
 
 /* Add mutiple output to tx. */
@@ -109,6 +107,15 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
  */
 const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
 
+/**
+ * Helper to get a witness script for an output.
+ */
+struct witscript *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
+
+/**
+ * Helper to get all witness scripts for a transaction.
+ */
+const struct witscript **bitcoin_tx_get_witscripts(const tal_t *ctx, const struct bitcoin_tx *tx);
 /** bitcoin_tx_output_get_amount_sat - Helper to get transaction output's amount
  *
  * Internally we use a `wally_tx` to represent the transaction. The

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -195,4 +195,8 @@ void towire_bitcoin_txid(u8 **pptr, const struct bitcoin_txid *txid);
 void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
 void towire_bitcoin_tx_output(u8 **pptr, const struct bitcoin_tx_output *output);
 
+/*
+ * Get the base64 string encoded PSBT of a bitcoin transaction.
+ */
+char *bitcoin_tx_to_psbt_base64(const tal_t *ctx, struct bitcoin_tx *tx);
 #endif /* LIGHTNING_BITCOIN_TX_H */

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -14,10 +14,6 @@
 #define BITCOIN_TX_DEFAULT_SEQUENCE 0xFFFFFFFF
 struct wally_psbt;
 
-struct witscript {
-    u8 *ptr;
-};
-
 struct bitcoin_txid {
 	struct sha256_double shad;
 };
@@ -110,12 +106,8 @@ const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx
 /**
  * Helper to get a witness script for an output.
  */
-struct witscript *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
+u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
 
-/**
- * Helper to get all witness scripts for a transaction.
- */
-const struct witscript **bitcoin_tx_get_witscripts(const tal_t *ctx, const struct bitcoin_tx *tx);
 /** bitcoin_tx_output_get_amount_sat - Helper to get transaction output's amount
  *
  * Internally we use a `wally_tx` to represent the transaction. The
@@ -199,12 +191,8 @@ struct bitcoin_tx *fromwire_bitcoin_tx(const tal_t *ctx,
 				       const u8 **cursor, size_t *max);
 struct bitcoin_tx_output *fromwire_bitcoin_tx_output(const tal_t *ctx,
 						     const u8 **cursor, size_t *max);
-struct witscript *fromwire_witscript(const tal_t *ctx,
-				     const u8 **cursor, size_t *max);
-
 void towire_bitcoin_txid(u8 **pptr, const struct bitcoin_txid *txid);
 void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
 void towire_bitcoin_tx_output(u8 **pptr, const struct bitcoin_tx_output *output);
-void towire_witscript(u8 **pptr, const struct witscript *script);
 
 #endif /* LIGHTNING_BITCOIN_TX_H */

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -8,9 +8,11 @@
 #include <ccan/structeq/structeq.h>
 #include <ccan/tal/tal.h>
 #include <common/amount.h>
+#include <wally_psbt.h>
 #include <wally_transaction.h>
 
 #define BITCOIN_TX_DEFAULT_SEQUENCE 0xFFFFFFFF
+struct wally_psbt;
 
 struct witscript {
     u8 *ptr;
@@ -33,6 +35,9 @@ struct bitcoin_tx {
 
 	/* Keep a reference to the ruleset we have to abide by */
 	const struct chainparams *chainparams;
+
+	/* psbt struct */
+	struct wally_psbt *psbt;
 };
 
 struct bitcoin_tx_output {

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -837,14 +837,12 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 	size_t i;
 	struct pubkey local_htlckey;
 	const u8 *msg;
-	const struct witscript **ws;
 	secp256k1_ecdsa_signature *htlc_sigs;
 
-	ws = bitcoin_tx_get_witscripts(tmpctx, txs[0]);
 	msg = towire_hsm_sign_remote_commitment_tx(NULL, txs[0],
 						   &peer->channel->funding_pubkey[REMOTE],
 						   *txs[0]->input_amounts[0],
-						   ws, &peer->remote_per_commit,
+						   &peer->remote_per_commit,
 						   peer->channel->option_static_remotekey);
 
 	msg = hsm_req(tmpctx, take(msg));
@@ -880,11 +878,11 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 
 	for (i = 0; i < tal_count(htlc_sigs); i++) {
 		struct bitcoin_signature sig;
-		struct witscript *w;
+		u8 *wscript;
 
-		w = bitcoin_tx_output_get_witscript(tmpctx, txs[0],
-						    txs[i+1]->wtx->inputs[0].index);
-		msg = towire_hsm_sign_remote_htlc_tx(NULL, txs[i + 1], w->ptr,
+		wscript = bitcoin_tx_output_get_witscript(tmpctx, txs[0],
+							  txs[i+1]->wtx->inputs[0].index);
+		msg = towire_hsm_sign_remote_htlc_tx(NULL, txs[i + 1], wscript,
 						     *txs[i+1]->input_amounts[0],
 						     &peer->remote_per_commit);
 
@@ -899,10 +897,10 @@ static secp256k1_ecdsa_signature *calc_commitsigs(const tal_t *ctx,
 			     type_to_string(tmpctx, struct bitcoin_signature,
 					    &sig),
 			     type_to_string(tmpctx, struct bitcoin_tx, txs[1+i]),
-			     tal_hex(tmpctx, w->ptr),
+			     tal_hex(tmpctx, wscript),
 			     type_to_string(tmpctx, struct pubkey,
 					    &local_htlckey));
-		assert(check_tx_sig(txs[1+i], 0, NULL, w->ptr,
+		assert(check_tx_sig(txs[1+i], 0, NULL, wscript,
 				    &local_htlckey,
 				    &sig));
 	}
@@ -1349,23 +1347,23 @@ static void handle_peer_commit_sig(struct peer *peer, const u8 *msg)
 	 */
 	for (i = 0; i < tal_count(htlc_sigs); i++) {
 		struct bitcoin_signature sig;
-		struct witscript *w;
+		u8 *wscript;
 
-		w = bitcoin_tx_output_get_witscript(tmpctx, txs[0],
-						    txs[i+1]->wtx->inputs[0].index);
+		wscript = bitcoin_tx_output_get_witscript(tmpctx, txs[0],
+							  txs[i+1]->wtx->inputs[0].index);
 
 		/* SIGHASH_ALL is implied. */
 		sig.s = htlc_sigs[i];
 		sig.sighash_type = SIGHASH_ALL;
 
-		if (!check_tx_sig(txs[1+i], 0, NULL, w->ptr,
+		if (!check_tx_sig(txs[1+i], 0, NULL, wscript,
 				  &remote_htlckey, &sig))
 			peer_failed(peer->pps,
 				    &peer->channel_id,
 				    "Bad commit_sig signature %s for htlc %s wscript %s key %s",
 				    type_to_string(msg, struct bitcoin_signature, &sig),
 				    type_to_string(msg, struct bitcoin_tx, txs[1+i]),
-				    tal_hex(msg, w->ptr),
+				    tal_hex(msg, wscript),
 				    type_to_string(msg, struct pubkey,
 						   &remote_htlckey));
 	}

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -237,7 +237,6 @@ static void add_htlcs(struct bitcoin_tx ***txs,
 	for (i = 0; i < tal_count(htlcmap); i++) {
 		const struct htlc *htlc = htlcmap[i];
 		struct bitcoin_tx *tx;
-		struct witscript *witscript;
 
 		if (!htlc)
 			continue;
@@ -256,13 +255,6 @@ static void add_htlcs(struct bitcoin_tx ***txs,
 					     feerate_per_kw,
 					     keyset);
 		}
-		/* Re-use the previously-generated witness script */
-		witscript = (*txs)[0]->output_witscripts[i];
-		tx->output_witscripts[0] =
-		        tal(tx->output_witscripts, struct witscript);
-		tx->output_witscripts[0]->ptr =
-			tal_dup_arr(tx->output_witscripts[0], u8,
-				    witscript->ptr, tal_count(witscript->ptr), 0);
 
 		/* Append to array. */
 		tal_arr_expand(txs, tx);

--- a/channeld/watchtower.c
+++ b/channeld/watchtower.c
@@ -71,7 +71,7 @@ penalty_tx_create(const tal_t *ctx,
 	bitcoin_tx_add_input(tx, commitment_txid, to_them_outnum, 0xFFFFFFFF,
 			     to_them_sats, NULL);
 
-	bitcoin_tx_add_output(tx, final_scriptpubkey, to_them_sats);
+	bitcoin_tx_add_output(tx, final_scriptpubkey, NULL, to_them_sats);
 
 	/* Worst-case sig is 73 bytes */
 	weight = bitcoin_tx_weight(tx) + 1 + 3 + 73 + 0 + tal_count(wscript);

--- a/common/close_tx.c
+++ b/common/close_tx.c
@@ -44,14 +44,14 @@ struct bitcoin_tx *create_close_tx(const tal_t *ctx,
 	if (amount_sat_greater_eq(to_us, dust_limit)) {
 		script = tal_dup_talarr(tx, u8, our_script);
 		/* One output is to us. */
-		bitcoin_tx_add_output(tx, script, to_us);
+		bitcoin_tx_add_output(tx, script, NULL, to_us);
 		num_outputs++;
 	}
 
 	if (amount_sat_greater_eq(to_them, dust_limit)) {
 		script = tal_dup_talarr(tx, u8, their_script);
 		/* Other output is to them. */
-		bitcoin_tx_add_output(tx, script, to_them);
+		bitcoin_tx_add_output(tx, script, NULL, to_them);
 		num_outputs++;
 	}
 

--- a/common/funding_tx.c
+++ b/common/funding_tx.c
@@ -33,7 +33,7 @@ struct bitcoin_tx *funding_tx(const tal_t *ctx,
 	wscript = bitcoin_redeem_2of2(tx, local_fundingkey, remote_fundingkey);
 	SUPERVERBOSE("# funding witness script = %s\n",
 		     tal_hex(wscript, wscript));
-	bitcoin_tx_add_output(tx, scriptpubkey_p2wsh(tx, wscript), funding);
+	bitcoin_tx_add_output(tx, scriptpubkey_p2wsh(tx, wscript), wscript, funding);
 	tal_free(wscript);
 
 	if (has_change) {
@@ -41,7 +41,7 @@ struct bitcoin_tx *funding_tx(const tal_t *ctx,
 		map[0] = int2ptr(0);
 		map[1] = int2ptr(1);
 		bitcoin_tx_add_output(tx, scriptpubkey_p2wpkh(tx, changekey),
-				      change);
+				      NULL, change);
 		permute_outputs(tx, NULL, map);
 		*outnum = (map[0] == int2ptr(0) ? 0 : 1);
 	} else {

--- a/common/htlc_tx.c
+++ b/common/htlc_tx.c
@@ -60,16 +60,11 @@ static struct bitcoin_tx *htlc_tx(const tal_t *ctx,
 
 	wscript = bitcoin_wscript_htlc_tx(tx, to_self_delay, revocation_pubkey,
 					  local_delayedkey);
-	bitcoin_tx_add_output(tx, scriptpubkey_p2wsh(tx, wscript), amount);
+	bitcoin_tx_add_output(tx, scriptpubkey_p2wsh(tx, wscript),
+			      wscript, amount);
 
 	bitcoin_tx_finalize(tx);
 	assert(bitcoin_tx_check(tx));
-
-	tx->output_witscripts[0] =
-			tal(tx->output_witscripts, struct witscript);
-	tx->output_witscripts[0]->ptr =
-			tal_dup_arr(tx->output_witscripts[0], u8,
-				    wscript, tal_count(wscript), 0);
 
 	tal_free(wscript);
 

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -176,13 +176,8 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 		u8 *wscript = to_self_wscript(tmpctx, to_self_delay, keyset);
 		amount = amount_msat_to_sat_round_down(self_pay);
 		int pos = bitcoin_tx_add_output(
-		    tx, scriptpubkey_p2wsh(tx, wscript), amount);
+		    tx, scriptpubkey_p2wsh(tx, wscript), wscript, amount);
 		assert(pos == n);
-		tx->output_witscripts[n] =
-			tal(tx->output_witscripts, struct witscript);
-		tx->output_witscripts[n]->ptr =
-			tal_dup_arr(tx->output_witscripts[n], u8,
-				    wscript, tal_count(wscript), 0);
 		output_order[n] = dummy_local;
 		n++;
 	}
@@ -204,7 +199,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 		amount = amount_msat_to_sat_round_down(other_pay);
 		int pos = bitcoin_tx_add_output(
 		    tx, scriptpubkey_p2wpkh(tx, &keyset->other_payment_key),
-		    amount);
+		    NULL, amount);
 		assert(pos == n);
 		output_order[n] = dummy_remote;
 		n++;

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -240,6 +240,15 @@ void json_add_tx(struct json_stream *result,
 	json_add_hex_talarr(result, fieldname, linearize_tx(tmpctx, tx));
 }
 
+void json_add_psbt(struct json_stream *stream,
+		   const char *fieldname,
+		   struct bitcoin_tx *tx)
+{
+	const char *psbt_b64;
+	psbt_b64 = bitcoin_tx_to_psbt_base64(tx, tx);
+	json_add_string(stream, fieldname, take(psbt_b64));
+}
+
 void json_add_amount_msat_compat(struct json_stream *result,
 				 struct amount_msat msat,
 				 const char *rawfieldname,

--- a/common/json_helpers.h
+++ b/common/json_helpers.h
@@ -137,4 +137,10 @@ void json_add_preimage(struct json_stream *result, const char *fieldname,
 void json_add_tx(struct json_stream *result,
 		 const char *fieldname,
 		 const struct bitcoin_tx *tx);
+
+/* '"fieldname" : "cHNidP8BAJoCAAAAAljo..." or "cHNidP8BAJoCAAAAAljo..." if fieldname is NULL */
+void json_add_psbt(struct json_stream *stream,
+		   const char *fieldname,
+		   struct bitcoin_tx *tx);
+
 #endif /* LIGHTNING_COMMON_JSON_HELPERS_H */

--- a/common/permute_tx.c
+++ b/common/permute_tx.c
@@ -1,6 +1,7 @@
 #include "permute_tx.h"
 #include <stdbool.h>
 #include <string.h>
+#include <wally_psbt.h>
 
 static bool input_better(const struct wally_tx_input *a,
 			 const struct wally_tx_input *b)

--- a/common/test/run-amount.c
+++ b/common/test/run-amount.c
@@ -27,6 +27,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -49,6 +52,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-bigsize.c
+++ b/common/test/run-bigsize.c
@@ -58,6 +58,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -105,6 +108,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-cryptomsg.c
+++ b/common/test/run-cryptomsg.c
@@ -53,6 +53,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -78,6 +81,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-derive_basepoints.c
+++ b/common/test/run-derive_basepoints.c
@@ -54,6 +54,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -79,6 +82,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-features.c
+++ b/common/test/run-features.c
@@ -53,6 +53,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -78,6 +81,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-gossip_rcvd_filter.c
+++ b/common/test/run-gossip_rcvd_filter.c
@@ -49,6 +49,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -52,6 +52,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -80,6 +83,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-json_remove.c
+++ b/common/test/run-json_remove.c
@@ -50,6 +50,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -97,6 +100,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-key_derive.c
+++ b/common/test/run-key_derive.c
@@ -55,6 +55,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -80,6 +83,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-lock.c
+++ b/common/test/run-lock.c
@@ -54,6 +54,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -79,6 +82,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/test/run-softref.c
+++ b/common/test/run-softref.c
@@ -51,6 +51,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -76,6 +79,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -38,7 +38,7 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			map[i] = int2ptr(i);
 
 		bitcoin_tx_add_output(tx, scriptpubkey_p2wpkh(tmpctx, changekey),
-				      change);
+				      NULL, change);
 
 		assert(tx->wtx->num_outputs == output_count);
 		permute_outputs(tx, NULL, map);

--- a/connectd/test/run-initiator-success.c
+++ b/connectd/test/run-initiator-success.c
@@ -57,6 +57,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -82,6 +85,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/connectd/test/run-responder-success.c
+++ b/connectd/test/run-responder-success.c
@@ -57,6 +57,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -82,6 +85,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/devtools/mkclose.c
+++ b/devtools/mkclose.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 		u8 *script = scriptpubkey_p2wpkh(NULL, &outkey[LOCAL]);
 		printf("# local witness script: %s\n", tal_hex(NULL, script));
 		/* One output is to us. */
-		bitcoin_tx_add_output(tx, script,
+		bitcoin_tx_add_output(tx, script, NULL,
 				      amount_msat_to_sat_round_down(local_msat));
 		num_outputs++;
 	} else
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 		u8 *script = scriptpubkey_p2wpkh(NULL, &outkey[REMOTE]);
 		printf("# remote witness script: %s\n", tal_hex(NULL, script));
 		/* Other output is to them. */
-		bitcoin_tx_add_output(tx, script,
+		bitcoin_tx_add_output(tx, script, NULL,
 				      amount_msat_to_sat_round_down(remote_msat));
 		num_outputs++;
 	} else

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -465,6 +465,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < tal_count(htlcmap); i++) {
 		struct bitcoin_signature local_htlc_sig, remote_htlc_sig;
 		struct amount_sat amt;
+		struct witscript *w;
 
 		if (!htlcmap[i])
 			continue;
@@ -476,17 +477,15 @@ int main(int argc, char *argv[])
 		local_txs[1+i]->input_amounts[0]
 			= tal_dup(local_txs[1+i], struct amount_sat, &amt);
 
-		printf("# wscript: %s\n", tal_hex(NULL, local_txs[1+i]->output_witscripts[1+i]->ptr));
+		w = bitcoin_tx_output_get_witscript(NULL, local_txs[1+i], 1+i);
+		printf("# wscript: %s\n", tal_hex(NULL, w->ptr));
 
-		bitcoin_tx_hash_for_sig(local_txs[1+i], 0,
-					local_txs[1+i]->output_witscripts[1+i]->ptr,
+		bitcoin_tx_hash_for_sig(local_txs[1+i], 0, w->ptr,
 					SIGHASH_ALL, &hash);
-		sign_tx_input(local_txs[1+i], 0, NULL,
-			      local_txs[1+i]->output_witscripts[1+i]->ptr,
+		sign_tx_input(local_txs[1+i], 0, NULL, w->ptr,
 			      &local_htlc_privkey, &local_htlc_pubkey,
 			      SIGHASH_ALL, &local_htlc_sig);
-		sign_tx_input(local_txs[1+i], 0, NULL,
-			      local_txs[1+i]->output_witscripts[1+i]->ptr,
+		sign_tx_input(local_txs[1+i], 0, NULL, w->ptr,
 			      &remote_htlc_privkey, &remote_htlc_pubkey,
 			      SIGHASH_ALL, &remote_htlc_sig);
 		printf("localsig_on_local output %zu: %s\n",
@@ -498,13 +497,13 @@ int main(int argc, char *argv[])
 			witness = bitcoin_witness_htlc_timeout_tx(NULL,
 								  &local_htlc_sig,
 								  &remote_htlc_sig,
-								  local_txs[1+i]->output_witscripts[1+i]->ptr);
+								  w->ptr);
 		else
 			witness = bitcoin_witness_htlc_success_tx(NULL,
 								  &local_htlc_sig,
 								  &remote_htlc_sig,
 								  preimage_of(&htlcmap[i]->rhash, cast_const2(const struct existing_htlc **, htlcs)),
-								  local_txs[1+i]->output_witscripts[1+i]->ptr);
+								  w->ptr);
 		bitcoin_tx_input_set_witness(local_txs[1+i], 0, witness);
 		printf("htlc tx for output %zu: %s\n",
 		       i, tal_hex(NULL, linearize_tx(NULL, local_txs[1+i])));
@@ -581,6 +580,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < tal_count(htlcmap); i++) {
 		struct bitcoin_signature local_htlc_sig, remote_htlc_sig;
 		struct amount_sat amt;
+		struct witscript *w;
 
 		if (!htlcmap[i])
 			continue;
@@ -592,16 +592,14 @@ int main(int argc, char *argv[])
 		remote_txs[1+i]->input_amounts[0]
 			= tal_dup(remote_txs[1+i], struct amount_sat, &amt);
 
-		printf("# wscript: %s\n", tal_hex(NULL, remote_txs[1+i]->output_witscripts[1+i]->ptr));
-		bitcoin_tx_hash_for_sig(remote_txs[1+i], 0,
-					remote_txs[1+i]->output_witscripts[1+i]->ptr,
+		w = bitcoin_tx_output_get_witscript(NULL, remote_txs[1+i], 1+i);
+		printf("# wscript: %s\n", tal_hex(NULL, w->ptr));
+		bitcoin_tx_hash_for_sig(remote_txs[1+i], 0, w->ptr,
 					SIGHASH_ALL, &hash);
-		sign_tx_input(remote_txs[1+i], 0, NULL,
-			      remote_txs[1+i]->output_witscripts[1+i]->ptr,
+		sign_tx_input(remote_txs[1+i], 0, NULL, w->ptr,
 			      &local_htlc_privkey, &local_htlc_pubkey,
 			      SIGHASH_ALL, &local_htlc_sig);
-		sign_tx_input(remote_txs[1+i], 0, NULL,
-			      remote_txs[1+i]->output_witscripts[1+i]->ptr,
+		sign_tx_input(remote_txs[1+i], 0, NULL, w->ptr,
 			      &remote_htlc_privkey, &remote_htlc_pubkey,
 			      SIGHASH_ALL, &remote_htlc_sig);
 		printf("localsig_on_remote output %zu: %s\n",
@@ -613,13 +611,13 @@ int main(int argc, char *argv[])
 			witness = bitcoin_witness_htlc_timeout_tx(NULL,
 								  &remote_htlc_sig,
 								  &local_htlc_sig,
-								  remote_txs[1+i]->output_witscripts[1+i]->ptr);
+								  w->ptr);
 		else
 			witness = bitcoin_witness_htlc_success_tx(NULL,
 								  &remote_htlc_sig,
 								  &local_htlc_sig,
 								  preimage_of(&htlcmap[i]->rhash, cast_const2(const struct existing_htlc **, htlcs)),
-								  remote_txs[1+i]->output_witscripts[1+i]->ptr);
+								  w->ptr);
 		bitcoin_tx_input_set_witness(remote_txs[1+i], 0, witness);
 		printf("htlc tx for output %zu: %s\n",
 		       i, tal_hex(NULL, linearize_tx(NULL, remote_txs[1+i])));

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -465,7 +465,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < tal_count(htlcmap); i++) {
 		struct bitcoin_signature local_htlc_sig, remote_htlc_sig;
 		struct amount_sat amt;
-		struct witscript *w;
+		u8 *wscript;
 
 		if (!htlcmap[i])
 			continue;
@@ -477,15 +477,15 @@ int main(int argc, char *argv[])
 		local_txs[1+i]->input_amounts[0]
 			= tal_dup(local_txs[1+i], struct amount_sat, &amt);
 
-		w = bitcoin_tx_output_get_witscript(NULL, local_txs[1+i], 1+i);
-		printf("# wscript: %s\n", tal_hex(NULL, w->ptr));
+		wscript = bitcoin_tx_output_get_witscript(NULL, local_txs[1+i], 1+i);
+		printf("# wscript: %s\n", tal_hex(NULL, wscript));
 
-		bitcoin_tx_hash_for_sig(local_txs[1+i], 0, w->ptr,
+		bitcoin_tx_hash_for_sig(local_txs[1+i], 0, wscript,
 					SIGHASH_ALL, &hash);
-		sign_tx_input(local_txs[1+i], 0, NULL, w->ptr,
+		sign_tx_input(local_txs[1+i], 0, NULL, wscript,
 			      &local_htlc_privkey, &local_htlc_pubkey,
 			      SIGHASH_ALL, &local_htlc_sig);
-		sign_tx_input(local_txs[1+i], 0, NULL, w->ptr,
+		sign_tx_input(local_txs[1+i], 0, NULL, wscript,
 			      &remote_htlc_privkey, &remote_htlc_pubkey,
 			      SIGHASH_ALL, &remote_htlc_sig);
 		printf("localsig_on_local output %zu: %s\n",
@@ -497,13 +497,13 @@ int main(int argc, char *argv[])
 			witness = bitcoin_witness_htlc_timeout_tx(NULL,
 								  &local_htlc_sig,
 								  &remote_htlc_sig,
-								  w->ptr);
+								  wscript);
 		else
 			witness = bitcoin_witness_htlc_success_tx(NULL,
 								  &local_htlc_sig,
 								  &remote_htlc_sig,
 								  preimage_of(&htlcmap[i]->rhash, cast_const2(const struct existing_htlc **, htlcs)),
-								  w->ptr);
+								  wscript);
 		bitcoin_tx_input_set_witness(local_txs[1+i], 0, witness);
 		printf("htlc tx for output %zu: %s\n",
 		       i, tal_hex(NULL, linearize_tx(NULL, local_txs[1+i])));
@@ -580,7 +580,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < tal_count(htlcmap); i++) {
 		struct bitcoin_signature local_htlc_sig, remote_htlc_sig;
 		struct amount_sat amt;
-		struct witscript *w;
+		u8 *wscript;
 
 		if (!htlcmap[i])
 			continue;
@@ -592,14 +592,14 @@ int main(int argc, char *argv[])
 		remote_txs[1+i]->input_amounts[0]
 			= tal_dup(remote_txs[1+i], struct amount_sat, &amt);
 
-		w = bitcoin_tx_output_get_witscript(NULL, remote_txs[1+i], 1+i);
-		printf("# wscript: %s\n", tal_hex(NULL, w->ptr));
-		bitcoin_tx_hash_for_sig(remote_txs[1+i], 0, w->ptr,
+		wscript = bitcoin_tx_output_get_witscript(NULL, remote_txs[1+i], 1+i);
+		printf("# wscript: %s\n", tal_hex(NULL, wscript));
+		bitcoin_tx_hash_for_sig(remote_txs[1+i], 0, wscript,
 					SIGHASH_ALL, &hash);
-		sign_tx_input(remote_txs[1+i], 0, NULL, w->ptr,
+		sign_tx_input(remote_txs[1+i], 0, NULL, wscript,
 			      &local_htlc_privkey, &local_htlc_pubkey,
 			      SIGHASH_ALL, &local_htlc_sig);
-		sign_tx_input(remote_txs[1+i], 0, NULL, w->ptr,
+		sign_tx_input(remote_txs[1+i], 0, NULL, wscript,
 			      &remote_htlc_privkey, &remote_htlc_pubkey,
 			      SIGHASH_ALL, &remote_htlc_sig);
 		printf("localsig_on_remote output %zu: %s\n",
@@ -611,13 +611,13 @@ int main(int argc, char *argv[])
 			witness = bitcoin_witness_htlc_timeout_tx(NULL,
 								  &remote_htlc_sig,
 								  &local_htlc_sig,
-								  w->ptr);
+								  wscript);
 		else
 			witness = bitcoin_witness_htlc_success_tx(NULL,
 								  &remote_htlc_sig,
 								  &local_htlc_sig,
 								  preimage_of(&htlcmap[i]->rhash, cast_const2(const struct existing_htlc **, htlcs)),
-								  w->ptr);
+								  wscript);
 		bitcoin_tx_input_set_witness(remote_txs[1+i], 0, witness);
 		printf("htlc tx for output %zu: %s\n",
 		       i, tal_hex(NULL, linearize_tx(NULL, remote_txs[1+i])));

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -159,8 +159,6 @@ msgtype,hsm_sign_remote_commitment_tx,19
 msgdata,hsm_sign_remote_commitment_tx,tx,bitcoin_tx,
 msgdata,hsm_sign_remote_commitment_tx,remote_funding_key,pubkey,
 msgdata,hsm_sign_remote_commitment_tx,funding_amount,amount_sat,
-msgdata,hsm_sign_remote_commitment_tx,num_witscripts,u16,
-msgdata,hsm_sign_remote_commitment_tx,output_witscripts,witscript,num_witscripts
 msgdata,hsm_sign_remote_commitment_tx,remote_per_commit,pubkey,
 msgdata,hsm_sign_remote_commitment_tx,option_static_remotekey,bool,
 

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -996,7 +996,6 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 	struct bitcoin_signature sig;
 	struct secrets secrets;
 	const u8 *funding_wscript;
-	struct witscript **output_witscripts;
 	struct pubkey remote_per_commit;
 	bool option_static_remotekey;
 
@@ -1004,7 +1003,6 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &funding,
-						    &output_witscripts,
 						    &remote_per_commit,
 						    &option_static_remotekey))
 		return bad_req(conn, c, msg_in);
@@ -1015,8 +1013,6 @@ static struct io_plan *handle_sign_remote_commitment_tx(struct io_conn *conn,
 		return bad_req_fmt(conn, c, msg_in, "tx must have 1 input");
 	if (tx->wtx->num_outputs == 0)
 		return bad_req_fmt(conn, c, msg_in, "tx must have > 0 outputs");
-	if (tal_count(output_witscripts) != tx->wtx->num_outputs)
-		return bad_req_fmt(conn, c, msg_in, "tx must have matching witscripts");
 
 	get_channel_seed(&c->id, c->dbid, &channel_seed);
 	derive_basepoints(&channel_seed,

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -495,7 +495,7 @@ static void set_htlc_success_fee(struct bitcoin_tx *tx,
 		if (!grind_htlc_tx_fee(&fee, tx, remotesig, wscript, weight))
 			status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				      "htlc_success_fee can't be found "
-				      " for tx %s, signature %s, wscript %s",
+				      "for tx %s, signature %s, wscript %s",
 				      type_to_string(tmpctx, struct bitcoin_tx,
 						     tx),
 				      type_to_string(tmpctx,
@@ -611,7 +611,7 @@ static struct bitcoin_tx *tx_to_us(const tal_t *ctx,
 			     out->sat, NULL);
 
 	bitcoin_tx_add_output(
-	    tx, scriptpubkey_p2wpkh(tx, &our_wallet_pubkey), out->sat);
+	    tx, scriptpubkey_p2wpkh(tx, &our_wallet_pubkey), NULL, out->sat);
 
 	/* Worst-case sig is 73 bytes */
 	weight = bitcoin_tx_weight(tx) + 1 + 3 + 73 + 0 + tal_count(wscript);

--- a/onchaind/test/run-grind_feerate-bug.c
+++ b/onchaind/test/run-grind_feerate-bug.c
@@ -75,6 +75,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -272,6 +275,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -76,6 +76,9 @@ u8 *fromwire_tal_arrn(const tal_t *ctx UNNEEDED,
 /* Generated stub for fromwire_u16 */
 u16 fromwire_u16(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u16 called!\n"); abort(); }
+/* Generated stub for fromwire_u32 */
+u32 fromwire_u32(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
+{ fprintf(stderr, "fromwire_u32 called!\n"); abort(); }
 /* Generated stub for fromwire_u64 */
 u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u64 called!\n"); abort(); }
@@ -290,6 +293,9 @@ void towire_sha256(u8 **pptr UNNEEDED, const struct sha256 *sha256 UNNEEDED)
 /* Generated stub for towire_u16 */
 void towire_u16(u8 **pptr UNNEEDED, u16 v UNNEEDED)
 { fprintf(stderr, "towire_u16 called!\n"); abort(); }
+/* Generated stub for towire_u32 */
+void towire_u32(u8 **pptr UNNEEDED, u32 v UNNEEDED)
+{ fprintf(stderr, "towire_u32 called!\n"); abort(); }
 /* Generated stub for towire_u64 */
 void towire_u64(u8 **pptr UNNEEDED, u64 v UNNEEDED)
 { fprintf(stderr, "towire_u64 called!\n"); abort(); }

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -667,6 +667,7 @@ static bool funder_finalize_channel_setup(struct state *state,
 	struct channel_id id_in;
 	const u8 *wscript;
 	char *err_reason;
+	const struct witscript **ws;
 	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 	/*~ Now we can initialize the `struct channel`.  This represents
@@ -732,11 +733,12 @@ static bool funder_finalize_channel_setup(struct state *state,
 	 * witness script.  It also needs the amount of the funding output,
 	 * as segwit signatures commit to that as well, even though it doesn't
 	 * explicitly appear in the transaction itself. */
+	ws = bitcoin_tx_get_witscripts(tmpctx, *tx);
 	msg = towire_hsm_sign_remote_commitment_tx(NULL,
 						   *tx,
 						   &state->channel->funding_pubkey[REMOTE],
 						   state->channel->funding,
-						   (const struct witscript **) (*tx)->output_witscripts,
+						   ws,
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey);
 
@@ -911,6 +913,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	struct bitcoin_signature theirsig, sig;
 	struct bitcoin_tx *local_commit, *remote_commit;
 	struct bitcoin_blkid chain_hash;
+	const struct witscript **ws;
 	u8 *msg;
 	const u8 *wscript;
 	u8 channel_flags;
@@ -1267,11 +1270,12 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	}
 
 	/* Make HSM sign it */
+	ws = bitcoin_tx_get_witscripts(tmpctx, remote_commit);
 	msg = towire_hsm_sign_remote_commitment_tx(NULL,
 						   remote_commit,
 						   &state->channel->funding_pubkey[REMOTE],
 						   state->channel->funding,
-						   (const struct witscript **) remote_commit->output_witscripts,
+						   ws,
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey);
 

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -667,7 +667,6 @@ static bool funder_finalize_channel_setup(struct state *state,
 	struct channel_id id_in;
 	const u8 *wscript;
 	char *err_reason;
-	const struct witscript **ws;
 	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 	/*~ Now we can initialize the `struct channel`.  This represents
@@ -733,12 +732,10 @@ static bool funder_finalize_channel_setup(struct state *state,
 	 * witness script.  It also needs the amount of the funding output,
 	 * as segwit signatures commit to that as well, even though it doesn't
 	 * explicitly appear in the transaction itself. */
-	ws = bitcoin_tx_get_witscripts(tmpctx, *tx);
 	msg = towire_hsm_sign_remote_commitment_tx(NULL,
 						   *tx,
 						   &state->channel->funding_pubkey[REMOTE],
 						   state->channel->funding,
-						   ws,
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey);
 
@@ -913,7 +910,6 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	struct bitcoin_signature theirsig, sig;
 	struct bitcoin_tx *local_commit, *remote_commit;
 	struct bitcoin_blkid chain_hash;
-	const struct witscript **ws;
 	u8 *msg;
 	const u8 *wscript;
 	u8 channel_flags;
@@ -1270,12 +1266,10 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	}
 
 	/* Make HSM sign it */
-	ws = bitcoin_tx_get_witscripts(tmpctx, remote_commit);
 	msg = towire_hsm_sign_remote_commitment_tx(NULL,
 						   remote_commit,
 						   &state->channel->funding_pubkey[REMOTE],
 						   state->channel->funding,
-						   ws,
 						   &state->first_per_commitment_point[REMOTE],
 						   state->channel->option_static_remotekey);
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -20,6 +20,7 @@ PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
 PLUGIN_COMMON_OBJS :=				\
 	bitcoin/base58.o			\
 	bitcoin/privkey.o			\
+	bitcoin/psbt.o				\
 	bitcoin/pubkey.o			\
 	bitcoin/pullpush.o			\
 	bitcoin/script.o			\

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -302,6 +302,7 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 10)
 
     prep = l1.rpc.txprepare(outputs=[{addr: Millisatoshi(amount * 3 * 1000)}])
+    assert prep['psbt']
     decode = bitcoind.rpc.decoderawtransaction(prep['unsigned_tx'])
     assert decode['txid'] == prep['txid']
     # 4 inputs, 2 outputs (3 if we have a fee output).

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -231,7 +231,6 @@ class Type(FieldSet):
         'exclude_entry',
         'fee_states',
         'onionreply',
-        'witscript',
         'feature_set',
         'onionmsg_path',
         'route_hop',

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -443,6 +443,7 @@ static struct command_result *json_txprepare(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_add_tx(response, "unsigned_tx", utx->tx);
 	json_add_txid(response, "txid", &utx->txid);
+	json_add_psbt(response, "psbt", utx->tx);
 	return command_success(cmd, response);
 }
 static const struct json_command txprepare_command = {

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -249,4 +249,3 @@ void fromwire_siphash_seed(const u8 **cursor, size_t *max,
 {
 	fromwire(cursor, max, seed, sizeof(*seed));
 }
-


### PR DESCRIPTION
First pass at including PSBT structs into the transaction mechanics. We now can carry witness scripts around in the psbt instead of serializing them separately as `witscripts`, so we strip the `witscript` support.

Finally, as a showpiece, we return the PBST version of the transaction from `txprepare`.
