### PR TITLE
listtransactions: represent txids as little endian

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2388,3 +2388,16 @@ def test_commitfee_option(node_factory):
     l2_commit_fees = l2.rpc.call("estimatefees")["unilateral_close"]
 
     assert l1_commit_fees == 2 * l2_commit_fees == 2 * 4 * mock_wu  # WU->VB
+
+
+@pytest.mark.xfail(strict=True)
+def test_listtransactions(node_factory):
+    """Sanity check for the listtransactions RPC command"""
+    l1, l2 = node_factory.get_nodes(2, opts=[{}, {}])
+
+    wallettxid = l1.openchannel(l2, 10**4)["wallettxid"]
+    txids = [i["txid"] for tx in l1.rpc.listtransactions()["transactions"]
+             for i in tx["inputs"]]
+    # The txid of the transaction funding the channel is present, and
+    # represented as little endian (like bitcoind and explorers).
+    assert wallettxid in txids

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2390,7 +2390,6 @@ def test_commitfee_option(node_factory):
     assert l1_commit_fees == 2 * l2_commit_fees == 2 * 4 * mock_wu  # WU->VB
 
 
-@pytest.mark.xfail(strict=True)
 def test_listtransactions(node_factory):
     """Sanity check for the listtransactions RPC command"""
     l1, l2 = node_factory.get_nodes(2, opts=[{}, {}])

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -1035,9 +1035,12 @@ static void json_transaction_details(struct json_stream *response,
 
 		json_array_start(response, "inputs");
 		for (size_t i = 0; i < wtx->num_inputs; i++) {
+			struct bitcoin_txid prevtxid;
 			struct wally_tx_input *in = &wtx->inputs[i];
+			bitcoin_tx_input_get_txid(tx->tx, i, &prevtxid);
+
 			json_object_start(response, NULL);
-			json_add_hex(response, "txid", in->txhash, sizeof(in->txhash));
+			json_add_txid(response, "txid", &prevtxid);
 			json_add_u32(response, "index", in->index);
 			json_add_u32(response, "sequence", in->sequence);
 #if EXPERIMENTAL_FEATURES


### PR DESCRIPTION
This made my copy/paste to Esplora cumbersome :/

Was this intended ? If so maybe the changelog line is wrong and the old behaviour should be guarded behind `deprecated_apis` ...