### PR TITLE
Added hsm_new_channel and hsm_ready_channel messages.

### DIFF
--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -21,6 +21,16 @@ msgtype,hsm_init_reply,111
 msgdata,hsm_init_reply,node_id,node_id,
 msgdata,hsm_init_reply,bip32,ext_key,
 
+# Declare a new channel.
+msgtype,hsm_new_channel,25
+# Which identity to use for requests
+msgdata,hsm_new_channel,id,node_id,
+# Database id for this client.
+msgdata,hsm_new_channel,dbid,u64,
+
+# No value returned.
+msgtype,hsm_new_channel_reply,125
+
 # Get a new HSM FD, with the specified capabilities
 msgtype,hsm_client_hsmfd,9
 # Which identity to use for requests
@@ -41,6 +51,26 @@ msgdata,hsm_get_channel_basepoints,dbid,u64,
 msgtype,hsm_get_channel_basepoints_reply,110
 msgdata,hsm_get_channel_basepoints_reply,basepoints,basepoints,
 msgdata,hsm_get_channel_basepoints_reply,funding_pubkey,pubkey,
+
+# Provide channel parameters.
+msgtype,hsm_ready_channel,24
+msgdata,hsm_ready_channel,is_outbound,bool,
+msgdata,hsm_ready_channel,channel_value,amount_sat,
+msgdata,hsm_ready_channel,push_value,amount_msat,
+msgdata,hsm_ready_channel,funding_txid,bitcoin_txid,
+msgdata,hsm_ready_channel,funding_txout,u16,
+msgdata,hsm_ready_channel,local_to_self_delay,u16,
+msgdata,hsm_ready_channel,local_shutdown_script_len,u16,
+msgdata,hsm_ready_channel,local_shutdown_script,u8,local_shutdown_script_len
+msgdata,hsm_ready_channel,remote_basepoints,basepoints,
+msgdata,hsm_ready_channel,remote_funding_pubkey,pubkey,
+msgdata,hsm_ready_channel,remote_to_self_delay,u16,
+msgdata,hsm_ready_channel,remote_shutdown_script_len,u16,
+msgdata,hsm_ready_channel,remote_shutdown_script,u8,remote_shutdown_script_len
+msgdata,hsm_ready_channel,option_static_remotekey,bool,
+
+# No value returned.
+msgtype,hsm_ready_channel_reply,124
 
 # Return signature for a funding tx.
 #include <common/utxo.h>

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -670,6 +670,26 @@ static bool funder_finalize_channel_setup(struct state *state,
 	char *err_reason;
 	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
+	/*~ Channel is ready; Report the channel parameters to the signer. */
+	msg = towire_hsm_ready_channel(NULL,
+				       true,	/* is_outbound */
+				       state->funding,
+				       state->push_msat,
+				       &state->funding_txid,
+				       state->funding_txout,
+				       state->localconf.to_self_delay,
+				       state->upfront_shutdown_script[LOCAL],
+				       &state->their_points,
+				       &state->their_funding_pubkey,
+				       state->remoteconf.to_self_delay,
+				       state->upfront_shutdown_script[REMOTE],
+				       state->option_static_remotekey);
+	wire_sync_write(HSM_FD, take(msg));
+	msg = wire_sync_read(tmpctx, HSM_FD);
+	if (!fromwire_hsm_ready_channel_reply(msg))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
+			      tal_hex(tmpctx, msg));
+
 	/*~ Now we can initialize the `struct channel`.  This represents
 	 * the current channel state and is how we can generate the current
 	 * commitment transaction.
@@ -1172,6 +1192,26 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 			    type_to_string(msg, struct channel_id,
 					   &state->channel_id),
 			    type_to_string(msg, struct channel_id, &id_in));
+
+	/*~ Channel is ready; Report the channel parameters to the signer. */
+	msg = towire_hsm_ready_channel(NULL,
+				       false,	/* is_outbound */
+				       state->funding,
+				       state->push_msat,
+				       &state->funding_txid,
+				       state->funding_txout,
+				       state->localconf.to_self_delay,
+				       state->upfront_shutdown_script[LOCAL],
+				       &theirs,
+				       &their_funding_pubkey,
+				       state->remoteconf.to_self_delay,
+				       state->upfront_shutdown_script[REMOTE],
+				       state->option_static_remotekey);
+	wire_sync_write(HSM_FD, take(msg));
+	msg = wire_sync_read(tmpctx, HSM_FD);
+	if (!fromwire_hsm_ready_channel_reply(msg))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
+			      tal_hex(tmpctx, msg));
 
 	/* Now we can create the channel structure. */
 	state->channel = new_initial_channel(state,


### PR DESCRIPTION
This PR adds two new messages to the `hsm_wire.csv`.  The first message, `hsm_new_channel` is sent from `lightningd` when an uncommited channel is created.  The second message, `hsm_ready_channel` is sent by `openingd` when the complete set of static channel parameters has been negotiated.

Since these parameters are static for the channel, the upcoming remote signer API will require them early.  This PR provides them early to the HSM daemon process so that this can be achieved.
