### PR TITLE
sort listinvoices and listsendpays by order of creation.

### DIFF
--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -441,7 +441,8 @@ bool invoices_iterate(struct invoices *invoices,
 						       ", bolt11"
 						       ", description"
 						       ", features"
-						       " FROM invoices;"));
+						       " FROM invoices"
+						       " ORDER BY id;"));
 		db_query_prepared(stmt);
 		it->p = stmt;
 	} else

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2797,7 +2797,8 @@ wallet_payment_list(const tal_t *ctx,
 						     ", failonionreply"
 						     ", total_msat"
 						     ", partid"
-						     " FROM payments;"));
+						     " FROM payments"
+						     " ORDER BY id;"));
 	}
 	db_query_prepared(stmt);
 


### PR DESCRIPTION
I don't know about SQLite, but Postgres doesn't guarantee that rows are ordered by the id or insertion order, so I'm constantly getting bizarre sortings (like `125346`) that cause confusion when listing invoices and payments. This is an easy fix.

Changelog-None