### PR TITLE
paymod: Payments reimagined (part 01)

### DIFF
--- a/doc/lightning-sendonion.7
+++ b/doc/lightning-sendonion.7
@@ -31,13 +31,13 @@ further details\.
 The \fIfirst_hop\fR parameter instructs c-lightning which peer to send the onion
 to\. It is a JSON dictionary that corresponds to the first element of the route
 array returned by \fIgetroute\fR\. The following is a minimal example telling
-c-lightning to use channel \fB103x1x1\fR to add an HTLC for 1002 millisatoshis and
-a delay of 21 blocks on top of the current blockheight:
+c-lightning to use any available channel to \fB022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59\fR
+to add an HTLC for 1002 millisatoshis and a delay of 21 blocks on top of the current blockheight:
 
 .nf
 .RS
 {
-  "channel": "103x1x1",
+  "id": "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59",
   "direction": 1,
   "amount_msat": "1002msat",
   "delay": 21,

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -30,12 +30,12 @@ further details.
 The *first_hop* parameter instructs c-lightning which peer to send the onion
 to. It is a JSON dictionary that corresponds to the first element of the route
 array returned by *getroute*. The following is a minimal example telling
-c-lightning to use channel `103x1x1` to add an HTLC for 1002 millisatoshis and
-a delay of 21 blocks on top of the current blockheight:
+c-lightning to use any available channel to `022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59`
+to add an HTLC for 1002 millisatoshis and a delay of 21 blocks on top of the current blockheight:
 
 ```json
 {
-  "channel": "103x1x1",
+  "id": "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59",
   "direction": 1,
   "amount_msat": "1002msat",
   "delay": 21,

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -52,6 +52,8 @@ PLUGIN_COMMON_OBJS :=				\
 	common/version.o			\
 	common/wireaddr.o			\
 	wire/fromwire.o				\
+	wire/gen_onion_wire.o			\
+	wire/tlvstream.o			\
 	wire/towire.o
 
 plugins/pay: bitcoin/chainparams.o $(PLUGIN_PAY_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -13,8 +13,8 @@ PLUGIN_BCLI_OBJS := $(PLUGIN_BCLI_SRC:.c=.o)
 PLUGIN_KEYSEND_SRC := plugins/keysend.c
 PLUGIN_KEYSEND_OBJS := $(PLUGIN_KEYSEND_SRC:.c=.o)
 
-PLUGIN_LIB_SRC := plugins/libplugin.c
-PLUGIN_LIB_HEADER := plugins/libplugin.h
+PLUGIN_LIB_SRC := plugins/libplugin.c plugins/libplugin-pay.c
+PLUGIN_LIB_HEADER := plugins/libplugin.h plugins/libplugin-pay.h
 PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
 
 PLUGIN_COMMON_OBJS :=				\

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1,4 +1,5 @@
 #include <plugins/libplugin-pay.h>
+#include <stdio.h>
 
 struct payment *payment_new(tal_t *ctx, struct command *cmd,
 			    struct payment *parent,
@@ -144,3 +145,19 @@ void payment_continue(struct payment *p)
 	 * `payment_continue` after the final state. */
 	abort();
 }
+
+static inline struct dummy_data *
+dummy_data_init(struct payment *p)
+{
+	return tal(p, struct dummy_data);
+}
+
+static inline void dummy_step_cb(struct dummy_data *dd,
+				 struct payment *p)
+{
+	fprintf(stderr, "dummy_step_cb called for payment %p at step %d\n", p, p->step);
+	payment_continue(p);
+}
+
+REGISTER_PAYMENT_MODIFIER(dummy, struct dummy_data *, dummy_data_init,
+			  dummy_step_cb);

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -579,8 +579,12 @@ static void payment_finished(struct payment *p)
 	assert((result.leafstates & PAYMENT_STEP_SUCCESS) == 0 ||
 	       result.preimage != NULL);
 
-	if (p->parent == NULL) {
-		assert(p->cmd != NULL);
+	if (p->parent == NULL && cmd == NULL) {
+		/* This is the tree root, but we already reported success or
+		 * failure, so noop. */
+		return;
+
+	}  else if (p->parent == NULL) {
 		if (payment_is_success(p)) {
 			assert(result.treestates & PAYMENT_STEP_SUCCESS);
 			assert(result.leafstates & PAYMENT_STEP_SUCCESS);

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1,0 +1,146 @@
+#include <plugins/libplugin-pay.h>
+
+struct payment *payment_new(tal_t *ctx, struct command *cmd,
+			    struct payment *parent,
+			    struct payment_modifier **mods)
+{
+	struct payment *p = tal(ctx, struct payment);
+	p->children = tal_arr(p, struct payment *, 0);
+	p->parent = parent;
+	p->modifiers = mods;
+	p->cmd = cmd;
+	p->start_time = time_now();
+	p->partid = partid++;
+
+	/* Copy over the relevant pieces of information. */
+	if (parent != NULL) {
+		tal_arr_expand(&parent->children, p);
+		p->destination = p->getroute_destination = parent->destination;
+		p->amount = parent->amount;
+		p->payment_hash = parent->payment_hash;
+	}
+
+	/* Initialize all modifier data so we can point to the fields when
+	 * wiring into the param() call in a JSON-RPC handler. The callback
+	 * can also just `memcpy` the parent if this outside access is not
+	 * required. */
+	p->modifier_data = tal_arr(p, void *, 0);
+	for (size_t i=0; mods[i] != NULL; i++) {
+		if (mods[i]->data_init != NULL)
+			tal_arr_expand(&p->modifier_data,
+				       mods[i]->data_init(p));
+		else
+			tal_arr_expand(&p->modifier_data, NULL);
+	}
+
+	return p;
+}
+
+void payment_start(struct payment *p)
+{
+	p->step = PAYMENT_STEP_INITIALIZED;
+	p->current_modifier = -1;
+	payment_continue(p);
+}
+
+static void payment_getroute(struct payment *p)
+{
+	p->step = PAYMENT_STEP_GOT_ROUTE;
+	return payment_continue(p);
+}
+
+static void payment_compute_onion_payloads(struct payment *p)
+{
+	p->step = PAYMENT_STEP_ONION_PAYLOAD;
+	/* Now allow all the modifiers to mess with the payloads, before we
+	 * serialize via a call to createonion in the next step. */
+	payment_continue(p);
+}
+
+static void payment_sendonion(struct payment *p)
+{
+	p->step = PAYMENT_STEP_FAILED;
+	return payment_continue(p);
+}
+
+/* Mutual recursion. */
+static void payment_finished(struct payment *p);
+
+/* Function to bubble up completions to the root, which actually holds on to
+ * the command that initiated the flow. */
+static struct command_result *payment_child_finished(struct payment *parent,
+						     struct payment *child)
+{
+	/* TODO implement logic to wait for all parts instead of bubbling up
+	 * directly. */
+
+	/* Should we continue bubbling up? */
+	if (parent->parent == NULL) {
+		assert(parent->cmd != NULL);
+		return payment_finished(parent);
+	} else {
+		return payment_child_finished(parent->parent, parent);
+	}
+}
+
+/* This function is called whenever a payment ends up in a final state, or all
+ * leafs in the subtree rooted in the payment are all in a final state. It is
+ * called only once, and it is guaranteed to be called in post-order
+ * traversal, i.e., all children are finished before the parent is called. */
+static void payment_finished(struct payment *p)
+{
+	/* TODO If this is a success bubble it back up through the part
+	 * tree. If it is a failure, decide here whether to split, retry or
+	 * split (maybe in a modifier instead?). */
+	if (p->parent == NULL)
+		return command_fail(p->cmd, JSONRPC2_INVALID_REQUEST, "Not functional yet");
+	else
+		return payment_child_finished(p->parent, p);
+}
+
+void payment_continue(struct payment *p)
+{
+	struct payment_modifier *mod;
+	void *moddata;
+	/* If we are in the middle of calling the modifiers, continue calling
+	 * them, otherwise we can continue with the payment state-machine. */
+	p->current_modifier++;
+	mod = p->modifiers[p->current_modifier];
+
+	if (mod != NULL) {
+		/* There is another modifier, so call it. */
+		moddata = p->modifier_data[p->current_modifier];
+		return mod->post_step_cb(moddata, p);
+	} else {
+		/* There are no more modifiers, so reset the call chain and
+		 * proceed to the next state. */
+		p->current_modifier = -1;
+		switch (p->step) {
+		case PAYMENT_STEP_INITIALIZED:
+			payment_getroute(p);
+			return;
+
+		case PAYMENT_STEP_GOT_ROUTE:
+			payment_compute_onion_payloads(p);
+			return;
+
+		case PAYMENT_STEP_ONION_PAYLOAD:
+			payment_sendonion(p);
+			return;
+
+		case PAYMENT_STEP_SUCCESS:
+		case PAYMENT_STEP_FAILED:
+			payment_finished(p);
+			return;
+
+		case PAYMENT_STEP_RETRY:
+		case PAYMENT_STEP_SPLIT:
+			/* Do nothing, we'll get pinged by a child succeeding
+			 * or failing. */
+			return;
+		}
+	}
+	/* We should never get here, it'd mean one of the state machine called
+	 * `payment_continue` after the final state. */
+	abort();
+}

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -146,6 +146,19 @@ void payment_continue(struct payment *p)
 	abort();
 }
 
+void *payment_mod_get_data(const struct payment *p,
+			   const struct payment_modifier *mod)
+{
+	for (size_t i = 0; p->modifiers[i] != NULL; i++)
+		if (p->modifiers[i] == mod)
+			return p->modifier_data[i];
+
+	/* If we ever get here it means that we asked for the data for a
+	 * non-existent modifier. This is a compile-time/wiring issue, so we
+	 * better check that modifiers match the data we ask for. */
+	abort();
+}
+
 static inline struct dummy_data *
 dummy_data_init(struct payment *p)
 {

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -46,9 +46,23 @@ struct createonion_response {
 	struct secret *shared_secrets;
 };
 
+/* States returned by listsendpays, waitsendpay, etc. */
+enum payment_result_state {
+	PAYMENT_PENDING,
+	PAYMENT_COMPLETE,
+	PAYMENT_FAILED,
+};
+
 /* A parsed version of the possible outcomes that a sendpay / payment may
- * result in. */
+ * result in. It excludes the redundant fields such as payment_hash and partid
+ * which are already present in the `struct payment` itself. */
 struct payment_result {
+	/* DB internal id */
+	u64 id;
+	u32 partid;
+	enum payment_result_state state;
+	struct amount_msat amount_sent;
+	struct preimage *payment_preimage;
 };
 
 /* Relevant information about a local channel so we can  exclude them early. */
@@ -142,6 +156,8 @@ struct payment {
 	struct payment_modifier **modifiers;
 	void **modifier_data;
 	int current_modifier;
+
+	struct payment_result *result;
 };
 
 struct payment_modifier {

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -120,6 +120,9 @@ struct payment_modifier {
 	void (*post_step_cb)(void *data, struct payment *p);
 };
 
+void *payment_mod_get_data(const struct payment *payment,
+			   const struct payment_modifier *mod);
+
 #define REGISTER_PAYMENT_MODIFIER(name, data_type, data_init_cb, step_cb)      \
 	struct payment_modifier name##_pay_mod = {                             \
 	    stringify(name),                                                   \
@@ -129,12 +132,22 @@ struct payment_modifier {
 			     void (*)(data_type, struct payment *), step_cb),  \
 	};
 
+/* The UNUSED marker is used to shut some compilers up. */
+#define REGISTER_PAYMENT_MODIFIER_HEADER(name, data_type)                      \
+	extern struct payment_modifier name##_pay_mod;                         \
+	UNUSED static inline data_type *payment_mod_##name##_get_data(         \
+	    const struct payment *p)                                           \
+	{                                                                      \
+		return payment_mod_get_data(p, &name##_pay_mod);               \
+	}
+
 struct dummy_data {
 	unsigned int *dummy_param;
 };
 
 /* List of globally available payment modifiers. */
 extern struct payment_modifier dummy_pay_mod;
+REGISTER_PAYMENT_MODIFIER_HEADER(retry, struct retry_mod_data);
 
 struct payment *payment_new(tal_t *ctx, struct command *cmd,
 			    struct payment *parent,

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -119,6 +119,9 @@ struct payment {
 	/* Payment hash extracted from the invoice if any. */
 	struct sha256 *payment_hash;
 
+	/* Payment secret, from the invoice if any. */
+	struct secret *payment_secret;
+
 	u32 partid;
 	u32 next_partid;
 

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -103,6 +103,7 @@ enum payment_step {
 struct payment {
 	/* The command that triggered this payment. */
 	struct command *cmd;
+	struct list_node list;
 
 	const char *json_buffer;
 	const jsmntok_t *json_toks;

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -1,0 +1,68 @@
+#ifndef LIGHTNING_PLUGINS_LIBPLUGIN_PAY_H
+#define LIGHTNING_PLUGINS_LIBPLUGIN_PAY_H
+#include "config.h"
+
+#include <plugins/libplugin.h>
+
+enum route_hop_style {
+	ROUTE_HOP_LEGACY = 1,
+	ROUTE_HOP_TLV = 2,
+};
+
+struct route_hop {
+	struct short_channel_id channel_id;
+	int direction;
+	struct node_id nodeid;
+	struct amount_msat amount;
+	u32 delay;
+	struct pubkey *blinding;
+	enum route_hop_style style;
+};
+
+/* A parsed version of the possible outcomes that a sendpay / payment may
+ * result in. */
+struct payment_result {
+};
+
+/* Relevant information about a local channel so we can  exclude them early. */
+struct channel_status {
+};
+
+struct payment {
+
+	/* Real destination we want to route to */
+	struct node_id *destination;
+
+	/* Payment hash extracted from the invoice if any. */
+	struct sha256 *payment_hash;
+
+	u32 partid;
+
+	/* Destination we should ask `getroute` for. This might differ from
+	 * the above destination if we use rendez-vous routing of blinded
+	 * paths to amend the route later in a mixin. */
+	struct node_id  *getroute_destination;
+
+	/* Target amount to be delivered at the destination */
+	struct amount_msat amount;
+
+	/* tal_arr of route_hops we decoded from the `getroute` call. Exposed
+	 * here so it can be amended by mixins. */
+	struct route_hop *route;
+
+	struct channel_status *peer_channels;
+
+	/* The blockheight at which the payment attempt was
+	 * started.  */
+	u32 start_block;
+
+	struct timeabs start_time, end_time;
+	struct timeabs deadline;
+
+	struct amount_msat extra_budget;
+
+	struct short_channel_id *exclusions;
+
+};
+
+#endif /* LIGHTNING_PLUGINS_LIBPLUGIN_PAY_H */

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -117,6 +117,7 @@ struct payment {
 	struct sha256 *payment_hash;
 
 	u32 partid;
+	u32 next_partid;
 
 	/* Destination we should ask `getroute` for. This might differ from
 	 * the above destination if we use rendez-vous routing of blinded
@@ -205,5 +206,6 @@ struct payment *payment_new(tal_t *ctx, struct command *cmd,
 
 void payment_start(struct payment *p);
 void payment_continue(struct payment *p);
+struct payment *payment_root(struct payment *p);
 
 #endif /* LIGHTNING_PLUGINS_LIBPLUGIN_PAY_H */

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -101,8 +101,10 @@ enum payment_step {
 };
 
 struct payment {
-	/* The command that triggered this payment. */
+	/* The command that triggered this payment. Only set for the root
+	 * payment. */
 	struct command *cmd;
+	struct plugin *plugin;
 	struct list_node list;
 
 	const char *json_buffer;

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -19,6 +19,27 @@ struct route_hop {
 	enum route_hop_style style;
 };
 
+struct legacy_payload {
+	struct short_channel_id scid;
+	struct amount_msat forward_amt;
+	u32 outgoing_cltv;
+};
+
+/* struct holding the information necessary to call createonion */
+struct createonion_hop {
+	struct node_id pubkey;
+
+	enum route_hop_style style;
+	struct tlv_tlv_payload *tlv_payload;
+	struct legacy_payload *legacy_payload;
+};
+
+struct createonion_request {
+	struct createonion_hop *hops;
+	u8 *assocdata;
+	struct secret *session_key;
+};
+
 /* A parsed version of the possible outcomes that a sendpay / payment may
  * result in. */
 struct payment_result {
@@ -81,6 +102,8 @@ struct payment {
 	 * the above destination if we use rendez-vous routing of blinded
 	 * paths to amend the route later in a mixin. */
 	struct node_id  *getroute_destination;
+
+	struct createonion_request *createonion_request;
 
 	/* Target amount to be delivered at the destination */
 	struct amount_msat amount;

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -145,6 +145,10 @@ struct dummy_data {
 	unsigned int *dummy_param;
 };
 
+struct retry_mod_data {
+	int retries;
+};
+
 /* List of globally available payment modifiers. */
 extern struct payment_modifier dummy_pay_mod;
 REGISTER_PAYMENT_MODIFIER_HEADER(retry, struct retry_mod_data);

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -129,6 +129,10 @@ struct payment_modifier {
 			     void (*)(data_type, struct payment *), step_cb),  \
 	};
 
+struct dummy_data {
+	unsigned int *dummy_param;
+};
+
 /* List of globally available payment modifiers. */
 extern struct payment_modifier dummy_pay_mod;
 

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <plugins/libplugin.h>
+#include <wire/gen_onion_wire.h>
 
 enum route_hop_style {
 	ROUTE_HOP_LEGACY = 1,
@@ -38,6 +39,11 @@ struct createonion_request {
 	struct createonion_hop *hops;
 	u8 *assocdata;
 	struct secret *session_key;
+};
+
+struct createonion_response {
+	u8 *onion;
+	struct secret *shared_secrets;
 };
 
 /* A parsed version of the possible outcomes that a sendpay / payment may
@@ -104,6 +110,7 @@ struct payment {
 	struct node_id  *getroute_destination;
 
 	struct createonion_request *createonion_request;
+	struct createonion_response *createonion_response;
 
 	/* Target amount to be delivered at the destination */
 	struct amount_msat amount;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -27,6 +27,8 @@ static struct node_id my_id;
 static unsigned int maxdelay_default;
 static LIST_HEAD(pay_status);
 
+static LIST_HEAD(payments);
+
 struct pay_attempt {
 	/* What we changed when starting this attempt. */
 	const char *why;
@@ -1719,7 +1721,7 @@ static struct command_result *json_paymod(struct command *cmd,
 	struct bolt11 *b11;
 	char *fail;
 	struct dummy_data *ddata;
-	p = payment_new(cmd, cmd, NULL /* No parent */, paymod_mods);
+	p = payment_new(NULL, cmd, NULL /* No parent */, paymod_mods);
 
 	ddata = (struct dummy_data*)p->modifier_data[0];
 
@@ -1763,6 +1765,7 @@ static struct command_result *json_paymod(struct command *cmd,
 	p->destination = p->getroute_destination = &b11->receiver_id;
 	p->payment_hash = tal_dup(p, struct sha256, &b11->payment_hash);
 	payment_start(p);
+	list_add_tail(&payments, &p->list);
 
 	return command_still_pending(cmd);
 }

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1764,6 +1764,7 @@ static struct command_result *json_paymod(struct command *cmd,
 	p->json_toks = params;
 	p->destination = p->getroute_destination = &b11->receiver_id;
 	p->payment_hash = tal_dup(p, struct sha256, &b11->payment_hash);
+	p->payment_secret = tal_dup(p, struct secret, b11->payment_secret);
 	payment_start(p);
 	list_add_tail(&payments, &p->list);
 

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1704,8 +1704,9 @@ static void init(struct plugin *p,
 }
 
 #if DEVELOPER
-struct payment_modifier *paymod_mods[2] = {
+struct payment_modifier *paymod_mods[3] = {
 	&dummy_pay_mod,
+	&retry_pay_mod,
 	NULL,
 };
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3043,3 +3043,17 @@ def test_invalid_onion_channel_update(node_factory):
 
     # l1 should still be alive afterwards.
     assert l1.rpc.getinfo()['id'] == l1id
+
+
+@unittest.skipIf(not DEVELOPER, "paymod is only available to developers for now.")
+def test_pay_modifiers(node_factory):
+    l1, l2 = node_factory.line_graph(2, opts=[{}, {}])
+
+    # Make sure that the dummy param is in the help (and therefore assigned to
+    # the modifier data).
+    hlp = l1.rpc.help("paymod")['help'][0]
+    assert(hlp['command'] == 'paymod bolt11 [dummy]')
+
+    inv = l2.rpc.invoice(123, 'lbl', 'desc')['bolt11']
+    with pytest.raises(RpcError, match="Not functional yet"):
+        l1.rpc.paymod(inv)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1,7 +1,8 @@
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from flaky import flaky  # noqa: F401
+from hashlib import sha256
 from pyln.client import RpcError, Millisatoshi
 from pyln.proto.onion import TlvPayload
 from utils import (
@@ -3055,5 +3056,6 @@ def test_pay_modifiers(node_factory):
     assert(hlp['command'] == 'paymod bolt11 [dummy]')
 
     inv = l2.rpc.invoice(123, 'lbl', 'desc')['bolt11']
-    with pytest.raises(RpcError, match="Not functional yet"):
-        l1.rpc.paymod(inv)
+    r = l1.rpc.paymod(inv)
+    assert(r['status'] == 'complete')
+    assert(sha256(unhexlify(r['payment_preimage'])).hexdigest() == r['payment_hash'])

--- a/tools/gen/header_template
+++ b/tools/gen/header_template
@@ -119,6 +119,18 @@ bool ${tlv.name}_is_valid(const struct ${tlv.struct_name()} *record,
 #define TLVS_${tlv.name.upper()}_ARRAY_SIZE ${len(tlv.messages)}
 extern const struct tlv_record_type tlvs_${tlv.name}[];
 
+<%!
+    def upper(text):
+        return text.upper()
+%>
+
+/* Define an enum with the constants */
+enum ${tlv.name}_types {
+% for msg in tlv.ordered_msgs():
+	${msg.struct_name()|upper} = ${msg.number},
+% endfor
+};
+
 % endif
 % endfor
 % if options.expose_subtypes and bool(subtypes):

--- a/wire/tlvstream.h
+++ b/wire/tlvstream.h
@@ -1,10 +1,9 @@
 #ifndef LIGHTNING_WIRE_TLVSTREAM_H
 #define LIGHTNING_WIRE_TLVSTREAM_H
 #include "config.h"
+#include <bitcoin/short_channel_id.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
-#include <stdbool.h>
-#include <stdlib.h>
 
 struct tlv_record_type {
 	u64 type;
@@ -36,5 +35,20 @@ void towire_tlvs(u8 **pptr,
 
 /* Given any tlvstream serialize the raw fields (untyped ones). */
 void towire_tlvstream_raw(u8 **pptr, const struct tlv_field *fields);
+
+
+
+/* Generic primitive setters for tlvstreams. */
+void tlvstream_set_raw(struct tlv_field **stream, u64 type, u8 *value TAKES);
+void tlvstream_set_short_channel_id(struct tlv_field **stream, u64 type,
+				    struct short_channel_id *value);
+void tlvstream_set_tu64(struct tlv_field **stream, u64 type, u64 value);
+void tlvstream_set_tu32(struct tlv_field **stream, u64 type, u32 value);
+
+/* Generic primitive gettes for tlvstreams. */
+bool tlvstream_get_short_channel_id(struct tlv_field *stream, u64 type,
+				    struct short_channel_id *value);
+bool tlvstream_get_tu64(struct tlv_field *stream, u64 type, u64 *value);
+bool tlvstream_get_tu32(struct tlv_field *stream, u64 type, u32 *value);
 
 #endif /* LIGHTNING_WIRE_TLVSTREAM_H */


### PR DESCRIPTION
_This is only a partial implementation of the new payment flow, but given the
looming release deadline and the sheer size of the change, I thought it's best
to get some code reviews in now_

## Design

The current payment flow is a multi-step process in the `pay` plugin (and some
others) that grew organically as logic and more features were added over the
time. This PR is my attempt to reimagine and consolidate the payment flow, to
consolidate some commonalities, better compartmentalize the existing addons,
and facilitate future modifications of the flow.

In order to get to this lofty goal I separated the logic into two separate
parts: the `payment` which consists of the core functionality required to
perform a payment, and `payment_modifier`s which have associated data and are
called at each step of the payment flow to allow them to modify the payment
behavior. The core payment flow consists of the following steps:

![base-payment-state-machine](https://user-images.githubusercontent.com/120117/83260159-9344c200-a1b9-11ea-8b29-8bdc10cce366.png)

<details>

```
digraph {
  initialized -> got_route -> sendonion -> failed;
  sendonion -> success;
}
```

</details>

After each step is complete all modifiers registered with the flow will be
called, and they are allowed to modify their local data and the data of the
payment in order to fulfill their purpose. In particular they are allowed to
set a payment into any state, including two states (`retry` and `split`) that
are not part of the core flow. These are indications that the payment failed,
but was retried with different parameters or was split into multiple
sub-payments, e.g., in MPP.

This brings us to the structure of payments: payments and their sub-payments
are organized in a tree, with the inner nodes representing failed attempts
that have been retried in some form, and leafs representing the currently
active or final attempts. The root of the tree is the original attempt and
serves as a coordination point for all sub-payments, aggregating information
that is shared among all attempts such as a list of `channel_hint`s used to
compute exclusions, and the invoice information that initiated the payment
flow.

This structure allows modifiers to implement almost arbitrary logic, while
keeping the core logic clean. Modifiers (both planned and implemented)
include:

 - `final_cltv`: the invoice can specify a final CLTV offset that just adds to
   the route CLTV deltas, so calling after `got_route` we can adjust them to
   match.
 - `routehints`: these change the destination for which we call `getroute` and
   once in `got_route` we can append the current routehint to form complete
   route.
 - `waitblockheight`: if a node reports that our CLTV is too low we can infer
   the height we should be at and then wait to reach that height before
   re-attempting.
 - `shadow_route`: since this is just an offset applied to the values we can
   compute the shadow route and then adjust the amount passed to the
   `getroute` call.
 - `retry`: if a payment fails we can just retry for a fixed number of times
   with different routes.
 - `split`: this is the core functionality of MPP, splitting a payment into
   multiple sub-payments if it fails.
 - `keysend` is just adjusting the TLV payload passed to `createonion` to
   include the preimage.
   
There are certainly some suboptimal solutions, however I think this structure
can be used to better experiment and implement future extensions rather than
having to weave the functionality into the existing flow (keysend sending
functionality for example would not have any need for the `routehints`
modifier, but the rest is shared).


## Testing

The functionality is implemented in parallel to the existing `json_pay`
infrastructure, but is planned to become a drop-in replacement, allowing us to
eventually remove the old implementation and just use the new one. To test the
new flow you can use `lightning-cli paymod [args]` instead of `lightning-cli
pay [args]` though some modifiers are not implemented yet, and some are in the
next parts of this PR.

I am testing feature parity by changing `pay.c` to use `json_paymod` instead
of `json_pay`, allowing me to run the existing (unmodified) tests against the
new logic.

## The ugly parts:

I'm calling these out because I am currently not addressing them and they
aren't a high priority, but we should clean these up eventually, and they may
cause reviewers to stumble a bit:

 - Modifiers need to call `payment_continue(p)` to advance the state-machine,
   and I forgot that a couple of times. Something like we do with
   `command_still_pending` and friends would be nice.
 - The RPC calls being bound to an originating `command` instance is rather
   strange, even though it doesn't do much (you can pass `NULL` to it), since
   we now potentially have multiple concurrent RPC calls in flight, if one of
   them were to respond to the original `cmd` it'd break things. Making the
   RPC interface independent of having a `command` instance would be a good
   idea.
 - I started actually parsing the JSON-RPC request and responses into
   `struct`s to facilitate modifying them, however the functions and struct
   definitions are spread all over the place. I'd like to consolidate them
   under `common/` eventually, so we can use them on both the `lightningd` and
   the plugin side, and not have to replicate the extraction of data from JSON
   responses all over the place.

## Next up

I have most of the functionality implemented, and we're down to 12 failing
tests in my [development branch][pay-reorg-branch]. I'll publish the next part
as soon as it settles down, i.e., doesn't get changed anymore, and I'll defer
cleanups and renaming to a last cleanup part in order not to delay the overall
progress and release.

Given the very new and unproven nature I'd propose we release this for
`keysend` sending support directly, but gate the replacement of the `pay`
command behind either a `!COMPAT_090` or the `DEVELOPER` flag. This would
minimize the impact to the majority of users, but still allow us to collect
experience from `keysend` and users that opted into testing it. However it'd
also mean that `mpp-pay` is a separate command or a developer-only command for
this release.

Changelog-None

[pay-reorg-branch]: https://github.com/cdecker/lightning/tree/pay-reorg