### PR TITLE
PSBTs, Meet the HSM

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -5,7 +5,9 @@
 #include <bitcoin/signature.h>
 #include <ccan/cast/cast.h>
 #include <ccan/ccan/array_size/array_size.h>
+#include <ccan/tal/str/str.h>
 #include <common/amount.h>
+#include <common/type_to_string.h>
 #include <common/utils.h>
 #include <string.h>
 #include <wally_psbt.h>
@@ -309,6 +311,28 @@ struct amount_sat psbt_input_get_amount(struct wally_psbt *psbt,
 
 	return val;
 }
+
+bool psbt_from_b64(const char *b64str, struct wally_psbt **psbt)
+{
+	int wally_err;
+	wally_err = wally_psbt_from_base64(b64str, psbt);
+	return wally_err == WALLY_OK;
+}
+
+char *psbt_to_b64(const tal_t *ctx, const struct wally_psbt *psbt)
+{
+	char *serialized_psbt, *ret_val;
+	int ret;
+
+	ret = wally_psbt_to_base64(cast_const(struct wally_psbt *, psbt),
+				   &serialized_psbt);
+	assert(ret == WALLY_OK);
+
+	ret_val = tal_strdup(ctx, serialized_psbt);
+	wally_free_string(serialized_psbt);
+	return ret_val;
+}
+REGISTER_TYPE_TO_STRING(wally_psbt, psbt_to_b64);
 
 const u8 *psbt_get_bytes(const tal_t *ctx, const struct wally_psbt *psbt,
 			 size_t *bytes_written)

--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -312,6 +312,17 @@ void psbt_input_set_prev_utxo_wscript(struct wally_psbt *psbt, size_t in,
 	psbt_input_set_prev_utxo(psbt, in, scriptPubkey, amt);
 }
 
+bool psbt_input_set_redeemscript(struct wally_psbt *psbt, size_t in,
+				 const u8 *redeemscript)
+{
+	int wally_err;
+	assert(psbt->num_inputs > in);
+	wally_err = wally_psbt_input_set_redeem_script(&psbt->inputs[in],
+						       cast_const(u8 *, redeemscript),
+						       tal_bytelen(redeemscript));
+	return wally_err == WALLY_OK;
+}
+
 struct amount_sat psbt_input_get_amount(struct wally_psbt *psbt,
 					size_t in)
 {

--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -424,7 +424,7 @@ struct wally_psbt *psbt_from_bytes(const tal_t *ctx, const u8 *bytes,
 	return psbt;
 }
 
-void towire_psbt(u8 **pptr, const struct wally_psbt *psbt)
+void towire_wally_psbt(u8 **pptr, const struct wally_psbt *psbt)
 {
 	/* Let's include the PSBT bytes */
 	size_t bytes_written;
@@ -434,8 +434,8 @@ void towire_psbt(u8 **pptr, const struct wally_psbt *psbt)
 	tal_free(pbt_bytes);
 }
 
-struct wally_psbt *fromwire_psbt(const tal_t *ctx,
-				 const u8 **cursor, size_t *max)
+struct wally_psbt *fromwire_wally_psbt(const tal_t *ctx,
+				       const u8 **cursor, size_t *max)
 {
 	struct wally_psbt *psbt;
 	u32 psbt_byte_len;

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -49,9 +49,9 @@ void psbt_rm_output(struct wally_psbt *psbt,
 void psbt_input_add_pubkey(struct wally_psbt *psbt, size_t in,
 			   const struct pubkey *pubkey);
 
-void psbt_input_set_partial_sig(struct wally_psbt *psbt, size_t in,
-				const struct pubkey *pubkey,
-				const struct bitcoin_signature *sig);
+WARN_UNUSED_RESULT bool psbt_input_set_partial_sig(struct wally_psbt *psbt, size_t in,
+						   const struct pubkey *pubkey,
+						   const struct bitcoin_signature *sig);
 
 void psbt_input_set_prev_utxo(struct wally_psbt *psbt, size_t in,
 			      const u8 *wscript, struct amount_sat amt);

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -57,6 +57,8 @@ void psbt_input_set_prev_utxo(struct wally_psbt *psbt, size_t in,
 			      const u8 *wscript, struct amount_sat amt);
 void psbt_input_set_prev_utxo_wscript(struct wally_psbt *psbt, size_t in,
 			              const u8 *wscript, struct amount_sat amt);
+bool psbt_input_set_redeemscript(struct wally_psbt *psbt, size_t in,
+				 const u8 *redeemscript);
 struct amount_sat psbt_input_get_amount(struct wally_psbt *psbt,
 					size_t in);
 

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -70,7 +70,7 @@ const u8 *psbt_get_bytes(const tal_t *ctx, const struct wally_psbt *psbt,
 			 size_t *bytes_written);
 struct wally_psbt *psbt_from_bytes(const tal_t *ctx, const u8 *bytes,
 				   size_t byte_len);
-void towire_psbt(u8 **pptr, const struct wally_psbt *psbt);
-struct wally_psbt *fromwire_psbt(const tal_t *ctx,
-				 const u8 **curosr, size_t *max);
+void towire_wally_psbt(u8 **pptr, const struct wally_psbt *psbt);
+struct wally_psbt *fromwire_wally_psbt(const tal_t *ctx,
+				       const u8 **cursor, size_t *max);
 #endif /* LIGHTNING_BITCOIN_PSBT_H */

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -32,6 +32,8 @@ struct wally_psbt *new_psbt(const tal_t *ctx,
  */
 bool psbt_is_finalized(struct wally_psbt *psbt);
 
+struct wally_tx *psbt_finalize(struct wally_psbt *psbt, bool finalize_in_place);
+
 struct wally_psbt_input *psbt_add_input(struct wally_psbt *psbt,
 					struct wally_tx_input *input,
 					size_t insert_at);

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -60,6 +60,8 @@ void psbt_input_set_prev_utxo_wscript(struct wally_psbt *psbt, size_t in,
 struct amount_sat psbt_input_get_amount(struct wally_psbt *psbt,
 					size_t in);
 
+bool psbt_from_b64(const char *b64str, struct wally_psbt **psbt);
+char *psbt_to_b64(const tal_t *ctx, const struct wally_psbt *psbt);
 const u8 *psbt_get_bytes(const tal_t *ctx, const struct wally_psbt *psbt,
 			 size_t *bytes_written);
 struct wally_psbt *psbt_from_bytes(const tal_t *ctx, const u8 *bytes,

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -494,11 +494,6 @@ void bitcoin_tx_finalize(struct bitcoin_tx *tx)
 	assert(bitcoin_tx_check(tx));
 }
 
-char *bitcoin_tx_to_psbt_base64(const tal_t *ctx, struct bitcoin_tx *tx)
-{
-	return psbt_to_b64(ctx, tx->psbt);
-}
-
 struct bitcoin_tx *bitcoin_tx_with_psbt(const tal_t *ctx, struct wally_psbt *psbt STEALS)
 {
 	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams,

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -32,6 +32,16 @@ int wally_tx_clone(struct wally_tx *tx, struct wally_tx **output)
 	return ret;
 }
 
+struct bitcoin_tx_output *new_tx_output(const tal_t *ctx,
+					struct amount_sat amount,
+					const u8 *script)
+{
+	struct bitcoin_tx_output *output = tal(ctx, struct bitcoin_tx_output);
+	output->amount = amount;
+	output->script = tal_dup_arr(output, u8, script, tal_count(script), 0);
+	return output;
+}
+
 int bitcoin_tx_add_output(struct bitcoin_tx *tx, const u8 *script,
 			  u8 *wscript, struct amount_sat amount)
 {

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -486,15 +486,7 @@ void bitcoin_tx_finalize(struct bitcoin_tx *tx)
 
 char *bitcoin_tx_to_psbt_base64(const tal_t *ctx, struct bitcoin_tx *tx)
 {
-	char *serialized_psbt, *ret_val;
-	int ret;
-
-	ret = wally_psbt_to_base64(tx->psbt, &serialized_psbt);
-	assert(ret == WALLY_OK);
-
-	ret_val = tal_strdup(ctx, serialized_psbt);
-	wally_free_string(serialized_psbt);
-	return ret_val;
+	return psbt_to_b64(ctx, tx->psbt);
 }
 
 struct bitcoin_tx *bitcoin_tx_with_psbt(const tal_t *ctx, struct wally_psbt *psbt STEALS)

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -652,7 +652,7 @@ struct bitcoin_tx *fromwire_bitcoin_tx(const tal_t *ctx,
 
 	/* pull_bitcoin_tx sets the psbt */
 	tal_free(tx->psbt);
-	tx->psbt = fromwire_psbt(tx, cursor, max);
+	tx->psbt = fromwire_wally_psbt(tx, cursor, max);
 
 	return tx;
 }
@@ -667,7 +667,7 @@ void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx)
 	u8 *lin = linearize_tx(tmpctx, tx);
 	towire_u8_array(pptr, lin, tal_count(lin));
 
-	towire_psbt(pptr, tx->psbt);
+	towire_wally_psbt(pptr, tx->psbt);
 }
 
 struct bitcoin_tx_output *fromwire_bitcoin_tx_output(const tal_t *ctx,

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -220,10 +220,5 @@ void towire_bitcoin_txid(u8 **pptr, const struct bitcoin_txid *txid);
 void towire_bitcoin_tx(u8 **pptr, const struct bitcoin_tx *tx);
 void towire_bitcoin_tx_output(u8 **pptr, const struct bitcoin_tx_output *output);
 
-/*
- * Get the base64 string encoded PSBT of a bitcoin transaction.
- */
-char *bitcoin_tx_to_psbt_base64(const tal_t *ctx, struct bitcoin_tx *tx);
-
 int wally_tx_clone(struct wally_tx *tx, struct wally_tx **output);
 #endif /* LIGHTNING_BITCOIN_TX_H */

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -35,6 +35,10 @@ struct bitcoin_tx_output {
 	u8 *script;
 };
 
+struct bitcoin_tx_output *new_tx_output(const tal_t *ctx,
+					struct amount_sat amount,
+					const u8 *script);
+
 /* SHA256^2 the tx in legacy format. */
 void bitcoin_txid(const struct bitcoin_tx *tx, struct bitcoin_txid *txid);
 void wally_txid(const struct wally_tx *wtx, struct bitcoin_txid *txid);

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1291,8 +1291,11 @@ static void handle_peer_commit_sig(struct peer *peer, const u8 *msg)
 			peer->next_index[LOCAL], LOCAL);
 
 	/* Set the commit_sig on the commitment tx psbt */
-	psbt_input_set_partial_sig(txs[0]->psbt, 0,
-	    &peer->channel->funding_pubkey[REMOTE], &commit_sig);
+	if (!psbt_input_set_partial_sig(txs[0]->psbt, 0,
+					&peer->channel->funding_pubkey[REMOTE],
+					&commit_sig))
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "Unable to set signature internally");
 
 	if (!derive_simple_key(&peer->channel->basepoints[REMOTE].htlc,
 			       &peer->next_local_per_commit, &remote_htlckey))

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <bitcoin/preimage.h>
 #include <bitcoin/privkey.h>
+#include <bitcoin/psbt.h>
 #include <bitcoin/pubkey.h>
 #include <bitcoin/short_channel_id.h>
 #include <ccan/ccan/str/hex/hex.h>
@@ -242,10 +243,10 @@ void json_add_tx(struct json_stream *result,
 
 void json_add_psbt(struct json_stream *stream,
 		   const char *fieldname,
-		   struct bitcoin_tx *tx)
+		   struct wally_psbt *psbt)
 {
 	const char *psbt_b64;
-	psbt_b64 = bitcoin_tx_to_psbt_base64(tx, tx);
+	psbt_b64 = psbt_to_b64(NULL, psbt);
 	json_add_string(stream, fieldname, take(psbt_b64));
 }
 

--- a/common/json_helpers.h
+++ b/common/json_helpers.h
@@ -141,6 +141,6 @@ void json_add_tx(struct json_stream *result,
 /* '"fieldname" : "cHNidP8BAJoCAAAAAljo..." or "cHNidP8BAJoCAAAAAljo..." if fieldname is NULL */
 void json_add_psbt(struct json_stream *stream,
 		   const char *fieldname,
-		   struct bitcoin_tx *tx);
+		   struct wally_psbt *psbt);
 
 #endif /* LIGHTNING_COMMON_JSON_HELPERS_H */

--- a/common/type_to_string.h
+++ b/common/type_to_string.h
@@ -4,6 +4,7 @@
 #include "utils.h"
 #include <ccan/autodata/autodata.h>
 #include <secp256k1.h>
+#include <wally_psbt.h>
 
 /* This must match the type_to_string_ cases. */
 union printable_types {
@@ -35,6 +36,7 @@ union printable_types {
 	const struct amount_sat *amount_sat;
 	const struct fee_states *fee_states;
 	const char *charp_;
+	const struct wally_psbt *wally_psbt;
 };
 
 #define type_to_string(ctx, type, ptr)					\

--- a/common/withdraw_tx.c
+++ b/common/withdraw_tx.c
@@ -3,6 +3,7 @@
 #include <bitcoin/pubkey.h>
 #include <bitcoin/script.h>
 #include <ccan/ptrint/ptrint.h>
+#include <common/key_derive.h>
 #include <common/permute_tx.h>
 #include <common/utils.h>
 #include <common/utxo.h>
@@ -13,44 +14,20 @@ struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct chainparams *chainparams,
 			       const struct utxo **utxos,
 			       struct bitcoin_tx_output **outputs,
-			       const struct pubkey *changekey,
-			       struct amount_sat change,
 			       const struct ext_key *bip32_base,
-			       int *change_outnum, u32 nlocktime)
+			       u32 nlocktime)
 {
 	struct bitcoin_tx *tx;
 	int output_count;
 
 	tx = tx_spending_utxos(ctx, chainparams, utxos, bip32_base,
-			       !amount_sat_eq(change, AMOUNT_SAT(0)),
-			       tal_count(outputs), nlocktime,
+			       false, tal_count(outputs), nlocktime,
 			       BITCOIN_TX_DEFAULT_SEQUENCE - 1);
 
 	output_count = bitcoin_tx_add_multi_outputs(tx, outputs);
 	assert(output_count == tal_count(outputs));
 
-	if (!amount_sat_eq(change, AMOUNT_SAT(0))) {
-		/* Add one to the output_count, for the change */
-		output_count++;
-
-		const void *map[output_count];
-		for (size_t i = 0; i < output_count; i++)
-			map[i] = int2ptr(i);
-
-		bitcoin_tx_add_output(tx, scriptpubkey_p2wpkh(tmpctx, changekey),
-				      NULL, change);
-
-		assert(tx->wtx->num_outputs == output_count);
-		permute_outputs(tx, NULL, map);
-
-		/* The change is the last output added, so the last position
-		 * in the map */
-		if (change_outnum)
-			*change_outnum = ptr2int(map[output_count - 1]);
-
-	} else if (change_outnum)
-		*change_outnum = -1;
-
+	permute_outputs(tx, NULL, (const void **)outputs);
 	permute_inputs(tx, (const void **)utxos);
 
 	bitcoin_tx_finalize(tx);

--- a/common/withdraw_tx.h
+++ b/common/withdraw_tx.h
@@ -21,19 +21,14 @@ struct utxo;
  * @chainparams: (in) the params for the created transaction.
  * @utxos: (in/out) tal_arr of UTXO pointers to spend (permuted to match)
  * @outputs: (in) tal_arr of bitcoin_tx_output, scriptPubKeys with amount to send to.
- * @changekey: (in) key to send change to (only used if change_satoshis != 0).
- * @change: (in) amount to send as change.
  * @bip32_base: (in) bip32 base for key derivation, or NULL.
- * @change_outnum: (out) set to output index of change output or -1 if none, unless NULL.
  * @nlocktime: (in) the value to set as the transaction's nLockTime.
  */
 struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct chainparams *chainparams,
 			       const struct utxo **utxos,
 			       struct bitcoin_tx_output **outputs,
-			       const struct pubkey *changekey,
-			       struct amount_sat change,
 			       const struct ext_key *bip32_base,
-			       int *change_outnum, u32 nlocktime);
+			       u32 nlocktime);
 
 #endif /* LIGHTNING_COMMON_WITHDRAW_TX_H */

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -54,15 +54,14 @@ msgtype,hsm_node_announcement_sig_reply,106
 msgdata,hsm_node_announcement_sig_reply,signature,secp256k1_ecdsa_signature,
 
 # Sign a withdrawal request
+#include <bitcoin/psbt.h>
 msgtype,hsm_sign_withdrawal,7
-msgdata,hsm_sign_withdrawal,num_outputs,u16,
-msgdata,hsm_sign_withdrawal,outputs,bitcoin_tx_output,num_outputs
 msgdata,hsm_sign_withdrawal,num_inputs,u16,
 msgdata,hsm_sign_withdrawal,inputs,utxo,num_inputs
-msgdata,hsm_sign_withdrawal,nlocktime,u32,
+msgdata,hsm_sign_withdrawal,psbt,wally_psbt,
 
 msgtype,hsm_sign_withdrawal_reply,107
-msgdata,hsm_sign_withdrawal_reply,tx,bitcoin_tx,
+msgdata,hsm_sign_withdrawal_reply,psbt,wally_psbt,
 
 # Sign an invoice
 msgtype,hsm_sign_invoice,8

--- a/hsmd/hsm_wire.csv
+++ b/hsmd/hsm_wire.csv
@@ -55,9 +55,6 @@ msgdata,hsm_node_announcement_sig_reply,signature,secp256k1_ecdsa_signature,
 
 # Sign a withdrawal request
 msgtype,hsm_sign_withdrawal,7
-msgdata,hsm_sign_withdrawal,satoshi_out,amount_sat,
-msgdata,hsm_sign_withdrawal,change_out,amount_sat,
-msgdata,hsm_sign_withdrawal,change_keyindex,u32,
 msgdata,hsm_sign_withdrawal,num_outputs,u16,
 msgdata,hsm_sign_withdrawal,outputs,bitcoin_tx_output,num_outputs
 msgdata,hsm_sign_withdrawal,num_inputs,u16,

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -1576,26 +1576,18 @@ static struct io_plan *handle_sign_withdrawal_tx(struct io_conn *conn,
 						 struct client *c,
 						 const u8 *msg_in)
 {
-	struct amount_sat satoshi_out, change_out;
-	u32 change_keyindex;
 	struct utxo **utxos;
 	struct bitcoin_tx *tx;
-	struct pubkey changekey;
 	struct bitcoin_tx_output **outputs;
 	u32 nlocktime;
 
-	if (!fromwire_hsm_sign_withdrawal(tmpctx, msg_in, &satoshi_out,
-					  &change_out, &change_keyindex,
+	if (!fromwire_hsm_sign_withdrawal(tmpctx, msg_in,
 					  &outputs, &utxos, &nlocktime))
 		return bad_req(conn, c, msg_in);
 
-	if (!bip32_pubkey(&secretstuff.bip32, &changekey, change_keyindex))
-		return bad_req_fmt(conn, c, msg_in,
-				   "Failed to get key %u", change_keyindex);
-
 	tx = withdraw_tx(tmpctx, c->chainparams,
-			 cast_const2(const struct utxo **, utxos), outputs,
-			 &changekey, change_out, NULL, NULL, nlocktime);
+			 cast_const2(const struct utxo **, utxos),
+			 outputs, NULL, nlocktime);
 
 	sign_all_inputs(tx, utxos);
 

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -846,10 +846,11 @@ static bool funder_finalize_channel_setup(struct state *state,
 	}
 
 	/* We save their sig to our first commitment tx */
-	psbt_input_set_partial_sig((*tx)->psbt, 0,
-				   &state->their_funding_pubkey,
-				   sig);
-
+	if (!psbt_input_set_partial_sig((*tx)->psbt, 0,
+					&state->their_funding_pubkey,
+					sig))
+		status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			      "Unable to set signature internally");
 
 	peer_billboard(false, "Funding channel: opening negotiation succeeded");
 

--- a/tests/plugins/onionmessage-reply.py
+++ b/tests/plugins/onionmessage-reply.py
@@ -2,7 +2,7 @@
 """
 This plugin is used to test the `onion_message` hook.
 """
-from lightning import Plugin
+from pyln.client import Plugin
 
 plugin = Plugin()
 

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -235,6 +235,7 @@ class Type(FieldSet):
         'onionmsg_path',
         'route_hop',
         'tx_parts',
+        'wally_psbt',
     ]
 
     # Some BOLT types are re-typed based on their field name

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1173,8 +1173,9 @@ void migrate_last_tx_to_psbt(struct lightningd *ld, struct db *db)
 			abort();
 
 		last_sig.sighash_type = SIGHASH_ALL;
-		psbt_input_set_partial_sig(last_tx->psbt, 0,
-		    &remote_funding_pubkey, &last_sig);
+		if (!psbt_input_set_partial_sig(last_tx->psbt, 0,
+						&remote_funding_pubkey, &last_sig))
+			abort();
 		psbt_input_add_pubkey(last_tx->psbt, 0,
 		    &local_funding_pubkey);
 		psbt_input_add_pubkey(last_tx->psbt, 0,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -67,8 +67,6 @@ struct unreleased_tx {
 	/* The tx itself (unsigned initially) */
 	struct bitcoin_tx *tx;
 	struct bitcoin_txid txid;
-	/* Index of change output, or -1 if none. */
-	int change_outnum;
 };
 
 /* Possible states for tracked outputs in the database. Not sure yet

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -442,7 +442,7 @@ static struct command_result *json_txprepare(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_add_tx(response, "unsigned_tx", utx->tx);
 	json_add_txid(response, "txid", &utx->txid);
-	json_add_psbt(response, "psbt", utx->tx);
+	json_add_psbt(response, "psbt", utx->tx->psbt);
 	return command_success(cmd, response);
 }
 static const struct json_command txprepare_command = {

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -80,16 +80,13 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
 static struct command_result *broadcast_and_wait(struct command *cmd,
 						 struct unreleased_tx *utx)
 {
-	struct bitcoin_tx *signed_tx;
+	struct wally_psbt *signed_psbt;
+	struct wally_tx *signed_wtx;
 	struct bitcoin_txid signed_txid;
 
 	/* FIXME: hsm will sign almost anything, but it should really
 	 * fail cleanly (not abort!) and let us report the error here. */
-	u8 *msg = towire_hsm_sign_withdrawal(cmd,
-					     cast_const2(const struct bitcoin_tx_output **,
-							 utx->outputs),
-					     utx->wtx->utxos,
-					     utx->tx->wtx->locktime);
+	u8 *msg = towire_hsm_sign_withdrawal(cmd, utx->wtx->utxos, utx->tx->psbt);
 
 	if (!wire_sync_write(cmd->ld->hsm_fd, take(msg)))
 		fatal("Could not write sign_withdrawal to HSM: %s",
@@ -97,25 +94,39 @@ static struct command_result *broadcast_and_wait(struct command *cmd,
 
 	msg = wire_sync_read(cmd, cmd->ld->hsm_fd);
 
-	if (!fromwire_hsm_sign_withdrawal_reply(utx, msg, &signed_tx))
+	if (!fromwire_hsm_sign_withdrawal_reply(utx, msg, &signed_psbt))
 		fatal("HSM gave bad sign_withdrawal_reply %s",
 		      tal_hex(tmpctx, msg));
-	signed_tx->chainparams = utx->tx->chainparams;
+
+	signed_wtx = psbt_finalize(signed_psbt, true);
+
+	if (!signed_wtx) {
+		/* Have the utx persist past this command */
+		tal_steal(cmd->ld->wallet, utx);
+		add_unreleased_tx(cmd->ld->wallet, utx);
+		return command_fail(cmd, LIGHTNINGD,
+				    "PSBT is not finalized %s",
+				    type_to_string(tmpctx,
+						   struct wally_psbt,
+						   signed_psbt));
+	}
 
 	/* Sanity check */
-	bitcoin_txid(signed_tx, &signed_txid);
+	wally_txid(signed_wtx, &signed_txid);
 	if (!bitcoin_txid_eq(&signed_txid, &utx->txid))
 		fatal("HSM changed txid: unsigned %s, signed %s",
 		      tal_hex(tmpctx, linearize_tx(tmpctx, utx->tx)),
-		      tal_hex(tmpctx, linearize_tx(tmpctx, signed_tx)));
+		      tal_hex(tmpctx, linearize_wtx(tmpctx, signed_wtx)));
 
 	/* Replace unsigned tx by signed tx. */
-	tal_free(utx->tx);
-	utx->tx = signed_tx;
+	wally_tx_free(utx->tx->wtx);
+	utx->tx->wtx = tal_steal(utx->tx, signed_wtx);
+	tal_free(utx->tx->psbt);
+	utx->tx->psbt = tal_steal(utx->tx, signed_psbt);
 
 	/* Now broadcast the transaction */
 	bitcoind_sendrawtx(cmd->ld->topology->bitcoind,
-			   tal_hex(tmpctx, linearize_tx(tmpctx, signed_tx)),
+			   tal_hex(tmpctx, linearize_tx(tmpctx, utx->tx)),
 			   wallet_withdrawal_broadcast, utx);
 
 	return command_still_pending(cmd);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -86,9 +86,6 @@ static struct command_result *broadcast_and_wait(struct command *cmd,
 	/* FIXME: hsm will sign almost anything, but it should really
 	 * fail cleanly (not abort!) and let us report the error here. */
 	u8 *msg = towire_hsm_sign_withdrawal(cmd,
-					     utx->wtx->amount,
-					     utx->wtx->change,
-					     utx->wtx->change_key_index,
 					     cast_const2(const struct bitcoin_tx_output **,
 							 utx->outputs),
 					     utx->wtx->utxos,
@@ -312,10 +309,8 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 	 * Support only one output. */
 	if (destination) {
 		outputs = tal_arr(tmpctx, struct bitcoin_tx_output *, 1);
-		outputs[0] = tal(outputs, struct bitcoin_tx_output);
-		outputs[0]->script = tal_steal(outputs[0],
-					       cast_const(u8 *, destination));
-		outputs[0]->amount = (*utx)->wtx->amount;
+		outputs[0] = new_tx_output(outputs, (*utx)->wtx->amount,
+					   destination);
 		out_len = tal_count(outputs[0]->script);
 
 		goto create_tx;
@@ -357,11 +352,9 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 					    "'%.*s' is a invalid satoshi amount",
 					    t[2].end - t[2].start, buffer + t[2].start);
 
+		outputs[i] = new_tx_output(outputs, *amount,
+					   cast_const(u8 *, destination));
 		out_len += tal_count(destination);
-		outputs[i] = tal(outputs, struct bitcoin_tx_output);
-		outputs[i]->amount = *amount;
-		outputs[i]->script = tal_steal(outputs[i],
-					       cast_const(u8 *, destination));
 
 		/* In fact, the maximum amount of bitcoin satoshi is 2.1e15.
 		 * It can't be equal to/bigger than 2^64.
@@ -387,8 +380,6 @@ static struct command_result *json_prepare_tx(struct command *cmd,
 	}
 
 create_tx:
-	(*utx)->outputs = tal_steal(*utx, outputs);
-
 	if (chosen_utxos)
 		result = wtx_from_utxos((*utx)->wtx, *feerate_per_kw,
 					out_len, maxheight,
@@ -405,19 +396,27 @@ create_tx:
 	if ((*utx)->wtx->all_funds)
 		outputs[0]->amount = (*utx)->wtx->amount;
 
+	/* Add the change as the last output */
 	if (!amount_sat_eq((*utx)->wtx->change, AMOUNT_SAT(0))) {
+		struct bitcoin_tx_output *change_output;
+
 		changekey = tal(tmpctx, struct pubkey);
 		if (!bip32_pubkey(cmd->ld->wallet->bip32_base, changekey,
 				  (*utx)->wtx->change_key_index))
 			return command_fail(cmd, LIGHTNINGD, "Keys generation failure");
-	} else
-		changekey = NULL;
+
+		change_output = new_tx_output(outputs, (*utx)->wtx->change,
+					      scriptpubkey_p2wpkh(tmpctx, changekey));
+		tal_arr_expand(&outputs, change_output);
+	}
+
+	(*utx)->outputs = tal_steal(*utx, outputs);
 	(*utx)->tx = withdraw_tx(*utx, chainparams,
-				 (*utx)->wtx->utxos, (*utx)->outputs,
-				 changekey, (*utx)->wtx->change,
+				 (*utx)->wtx->utxos,
+				 (*utx)->outputs,
 				 cmd->ld->wallet->bip32_base,
-				 &(*utx)->change_outnum,
 				 locktime);
+
 	bitcoin_txid((*utx)->tx, &(*utx)->txid);
 
 	return NULL;


### PR DESCRIPTION
Updates the HSM withdrawal to take a PSBT and utxo set. We sign the inputs that we've got utxos for, and return a psbt with the attached signatures.

This 'fully' integrates the PSBTs with our HSM for the first time, and gets us ready for a `signpsbt` command (coming soon).

Note that this is built atop #3740 
(new content begins at 
965014d), and requires https://github.com/ElementsProject/libwally-core/pull/203 to be merged in order to pass tests (as there's a number of P2SH-P2WPKH bugs in the existing libwally-psbt implementation)

Changelog-None