### PR TITLE
listfunds: also list reserved outputs

### DIFF
--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -20,6 +20,7 @@ channels\.
 
 Each entry in \fIoutputs\fR will include:
 
+.RS
 .IP \[bu]
 \fItxid\fR
 .IP \[bu]
@@ -33,10 +34,14 @@ appended)
 \fIaddress\fR
 .IP \[bu]
 \fIstatus\fR (whether \fIunconfirmed\fR, \fIconfirmed\fR, or \fIspent\fR)
+.IP \[bu]
+\fIreserved\fR (whether this is UTXO is currently reserved for an in-flight tx)
 
+.RE
 
 Each entry in \fIchannels\fR will include:
 
+.RS
 .IP \[bu]
 \fIpeer_id\fR - the peer with which the channel is opened\.
 .IP \[bu]
@@ -66,6 +71,7 @@ transaction\.
 \fIstate\fR - the channel state, in particular \fICHANNELD_NORMAL\fR means the
 channel can be used normally\.
 
+.RE
 .SH AUTHOR
 
 Felix \fI<fixone@gmail.com\fR> is mainly responsible\.

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -28,6 +28,7 @@ Each entry in *outputs* will include:
     appended)
 -   *address*
 -   *status* (whether *unconfirmed*, *confirmed*, or *spent*)
+-   *reserved* (whether this is UTXO is currently reserved for an in-flight tx)
 
 Each entry in *channels* will include:
 -   *peer\_id* - the peer with which the channel is opened.


### PR DESCRIPTION
Currently 'listfunds' lies, a teensy eeinsy bit, in that it doesn't list
all of the funds in a wallet (it omits reserved wallet UTXOs). This
change makes the reserved outputs visible by listing them in the
'outputs' section along with a new field, 'reserved', which denotes the
UTXO's state

Changelog-Changed: JSON-RPC: `listfunds` 'outputs' now includes reserved outputs, designated as 'reserved' = true