### PR TITLE
PSBT RPC calls

### DIFF
--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -22,6 +22,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -23,6 +23,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -121,7 +121,9 @@ struct amount_sat bitcoin_tx_compute_fee_w_inputs(const struct bitcoin_tx *tx,
 
 		ok = amount_sat_sub(&input_val, input_val,
 				    amount_asset_to_sat(&asset));
-		assert(ok);
+		if (!ok)
+			return AMOUNT_SAT(0);
+
 	}
 	return input_val;
 }

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -265,22 +265,26 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 	}
 }
 
-const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
-				       const struct bitcoin_tx *tx, int outnum)
+const u8 *wally_tx_output_get_script(const tal_t *ctx,
+				     const struct wally_tx_output *output)
 {
-	const struct wally_tx_output *output;
-	u8 *res;
-	assert(outnum < tx->wtx->num_outputs);
-	output = &tx->wtx->outputs[outnum];
-
 	if (output->script == NULL) {
 		/* This can happen for coinbase transactions and pegin
 		 * transactions */
 		return NULL;
 	}
 
-	res = tal_dup_arr(ctx, u8, output->script, output->script_len, 0);
-	return res;
+	return tal_dup_arr(ctx, u8, output->script, output->script_len, 0);
+}
+
+const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
+				       const struct bitcoin_tx *tx, int outnum)
+{
+	const struct wally_tx_output *output;
+	assert(outnum < tx->wtx->num_outputs);
+	output = &tx->wtx->outputs[outnum];
+
+	return wally_tx_output_get_script(ctx, output);
 }
 
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx,

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -127,6 +127,15 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
 
 /**
+ * Helper to get the script of a script's output as a tal_arr
+ *
+ * The script attached to a `wally_tx_output` is not a `tal_arr`, so in order to keep the
+ * comfort of being able to call `tal_bytelen` and similar on a script we just
+ * return a `tal_arr` clone of the original script.
+ */
+const u8 *wally_tx_output_get_script(const tal_t *ctx,
+				     const struct wally_tx_output *output);
+/**
  * Helper to get a witness script for an output.
  */
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);

--- a/cli/test/run-large-input.c
+++ b/cli/test/run-large-input.c
@@ -47,6 +47,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/cli/test/run-remove-hint.c
+++ b/cli/test/run-remove-hint.c
@@ -50,6 +50,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-bigsize.c
+++ b/common/test/run-bigsize.c
@@ -27,6 +27,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-cryptomsg.c
+++ b/common/test/run-cryptomsg.c
@@ -22,6 +22,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-derive_basepoints.c
+++ b/common/test/run-derive_basepoints.c
@@ -23,6 +23,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-features.c
+++ b/common/test/run-features.c
@@ -22,6 +22,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-gossip_rcvd_filter.c
+++ b/common/test/run-gossip_rcvd_filter.c
@@ -19,6 +19,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -21,6 +21,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-json_remove.c
+++ b/common/test/run-json_remove.c
@@ -19,6 +19,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-key_derive.c
+++ b/common/test/run-key_derive.c
@@ -24,6 +24,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-lock.c
+++ b/common/test/run-lock.c
@@ -23,6 +23,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-softref.c
+++ b/common/test/run-softref.c
@@ -20,6 +20,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/common/test/run-sphinx.c
+++ b/common/test/run-sphinx.c
@@ -36,6 +36,9 @@ void amount_msat_from_u64(struct amount_msat *msat UNNEEDED, u64 millisatoshis U
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/connectd/test/run-initiator-success.c
+++ b/connectd/test/run-initiator-success.c
@@ -26,6 +26,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/connectd/test/run-responder-success.c
+++ b/connectd/test/run-responder-success.c
@@ -26,6 +26,9 @@ struct amount_sat amount_asset_to_sat(struct amount_asset *asset UNNEEDED)
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_less */
+bool amount_sat_less(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
+{ fprintf(stderr, "amount_sat_less called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1129,6 +1129,24 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("unreserveinputs", payload)
 
+    def signpsbt(self, psbt):
+        """
+        Add internal wallet's signatures to PSBT
+        """
+        payload = {
+            "psbt": psbt,
+        }
+        return self.call("signpsbt", payload)
+
+    def sendpsbt(self, psbt):
+        """
+        Finalize extract and broadcast a PSBT
+        """
+        payload = {
+            "psbt": psbt,
+        }
+        return self.call("sendpsbt", payload)
+
     def signmessage(self, message):
         """
         Sign a message with this node's secret key.

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1107,6 +1107,28 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("txsend", payload)
 
+    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None):
+        """
+        Reserve UTXOs and return a psbt for a 'stub' transaction that
+        spends the reserved UTXOs.
+        """
+        payload = {
+            "outputs": outputs,
+            "feerate": feerate,
+            "minconf": minconf,
+            "utxos": utxos,
+        }
+        return self.call("reserveinputs", payload)
+
+    def unreserveinputs(self, psbt):
+        """
+        Unreserve UTXOs that were previously reserved.
+        """
+        payload = {
+            "psbt": psbt,
+        }
+        return self.call("unreserveinputs", payload)
+
     def signmessage(self, message):
         """
         Sign a message with this node's secret key.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -35,6 +35,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-newaddr.7 \
 	doc/lightning-pay.7 \
 	doc/lightning-plugin.7 \
+	doc/lightning-reserveinputs.7 \
 	doc/lightning-sendonion.7 \
 	doc/lightning-sendpay.7 \
 	doc/lightning-setchannelfee.7 \
@@ -42,11 +43,12 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-txprepare.7 \
 	doc/lightning-txdiscard.7 \
 	doc/lightning-txsend.7 \
+	doc/lightning-unreserveinputs.7 \
 	doc/lightning-waitinvoice.7 \
 	doc/lightning-waitanyinvoice.7 \
 	doc/lightning-waitblockheight.7 \
 	doc/lightning-waitsendpay.7 \
-	doc/lightning-withdraw.7 
+	doc/lightning-withdraw.7
 
 doc-all: $(MANPAGES) doc/index.rst
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -57,6 +57,7 @@ c-lightning Documentation
    lightning-newaddr <lightning-newaddr.7.md>
    lightning-pay <lightning-pay.7.md>
    lightning-plugin <lightning-plugin.7.md>
+   lightning-reserveinputs <lightning-reserveinputs.7.md>
    lightning-sendonion <lightning-sendonion.7.md>
    lightning-sendpay <lightning-sendpay.7.md>
    lightning-setchannelfee <lightning-setchannelfee.7.md>
@@ -64,6 +65,7 @@ c-lightning Documentation
    lightning-txdiscard <lightning-txdiscard.7.md>
    lightning-txprepare <lightning-txprepare.7.md>
    lightning-txsend <lightning-txsend.7.md>
+   lightning-unreserveinputs <lightning-unreserveinputs.7.md>
    lightning-waitanyinvoice <lightning-waitanyinvoice.7.md>
    lightning-waitblockheight <lightning-waitblockheight.7.md>
    lightning-waitinvoice <lightning-waitinvoice.7.md>

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -1,0 +1,85 @@
+.TH "LIGHTNING-RESERVEINPUTS" "7" "" "" "lightning-reserveinputs"
+.SH NAME
+lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spends
+.SH SYNOPSIS
+
+\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR]
+
+.SH DESCRIPTION
+
+The \fBreserveinputs\fR RPC command creates an unsigned PSBT which
+spends funds from c-lightning’s internal wallet to the outputs specified
+in \fIoutputs\fR\.
+
+
+The \fIoutputs\fR is the array of output that include \fIdestination\fR
+and \fIamount\fR({\fIdestination\fR: \fIamount\fR})\. Its format is like:
+[{address1: amount1}, {address2: amount2}]
+or
+[{address: \fIall\fR}]\.
+It supports any number of outputs\.
+
+
+The \fIdestination\fR of output is the address which can be of any Bitcoin accepted
+type, including bech32\.
+
+
+The \fIamount\fR of output is the amount to be sent from the internal wallet
+(expressed, as name suggests, in amount)\. The string \fIall\fR can be used to specify
+all available funds\. Otherwise, it is in amount precision; it can be a whole
+number, a whole number ending in \fIsat\fR, a whole number ending in \fI000msat\fR,
+or a number with 1 to 8 decimal places ending in \fIbtc\fR\.
+
+
+\fIfeerate\fR is an optional feerate to use\. It can be one of the strings
+\fIurgent\fR (aim for next block), \fInormal\fR (next 4 blocks or so) or \fIslow\fR
+(next 100 blocks or so) to use lightningd’s internal estimates: \fInormal\fR
+is the default\.
+
+
+Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means
+the number is interpreted as satoshi-per-kilosipa (weight), and \fIperkb\fR
+means it is interpreted bitcoind-style as satoshi-per-kilobyte\. Omitting
+the suffix is equivalent to \fIperkb\fR\.
+
+
+\fIminconf\fR specifies the minimum number of confirmations that reserved UTXOs 
+should have\. Default is 1\.
+
+
+\fIutxos\fR specifies the utxos to be used to fund the transaction, as an array
+of "txid:vout"\. These must be drawn from the node's available UTXO set\.
+
+.SH RETURN VALUE
+
+On success, an object with attributes \fIpsbt\fR and \fIfeerate_per_kw\fR will be
+returned\. The inputs of the \fIpsbt\fR have been marked as reserved in the internal wallet\.
+
+
+On failure, an error is reported and no UTXOs are reserved\.
+
+
+The following error codes may occur:
+
+.RS
+.IP \[bu]
+-1: Catchall nonspecific error\.
+.IP \[bu]
+301: There are not enough funds in the internal wallet (including
+fees) to create the transaction\.
+.IP \[bu]
+302: The dust limit is not met\.
+
+.RE
+.SH AUTHOR
+
+niftynei \fI<niftynei@gmail.com\fR> is mainly responsible\.
+
+.SH SEE ALSO
+
+\fBlightning-unreserveinputs\fR(7), \fBlightning-signpsbt\fR(7), \fBlightning-sendpsbt\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -1,0 +1,76 @@
+lightning-reserveinputs -- Construct a transaction and reserve the UTXOs it spends
+==================================================================================
+
+SYNOPSIS
+--------
+
+**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\]
+
+DESCRIPTION
+-----------
+
+The **reserveinputs** RPC command creates an unsigned PSBT which
+spends funds from c-lightning’s internal wallet to the outputs specified
+in *outputs*.
+
+The *outputs* is the array of output that include *destination*
+and *amount*(\{*destination*: *amount*\}). Its format is like:
+\[\{address1: amount1\}, \{address2: amount2\}\]
+or
+\[\{address: *all*\}\].
+It supports any number of outputs.
+
+The *destination* of output is the address which can be of any Bitcoin accepted
+type, including bech32.
+
+The *amount* of output is the amount to be sent from the internal wallet
+(expressed, as name suggests, in amount). The string *all* can be used to specify
+all available funds. Otherwise, it is in amount precision; it can be a whole
+number, a whole number ending in *sat*, a whole number ending in *000msat*,
+or a number with 1 to 8 decimal places ending in *btc*.
+
+*feerate* is an optional feerate to use. It can be one of the strings
+*urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
+(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
+is the default.
+
+Otherwise, *feerate* is a number, with an optional suffix: *perkw* means
+the number is interpreted as satoshi-per-kilosipa (weight), and *perkb*
+means it is interpreted bitcoind-style as satoshi-per-kilobyte. Omitting
+the suffix is equivalent to *perkb*.
+
+*minconf* specifies the minimum number of confirmations that reserved UTXOs 
+should have. Default is 1.
+
+*utxos* specifies the utxos to be used to fund the transaction, as an array
+of "txid:vout". These must be drawn from the node's available UTXO set.
+
+
+RETURN VALUE
+------------
+
+On success, an object with attributes *psbt* and *feerate_per_kw* will be
+returned. The inputs of the *psbt* have been marked as reserved in the internal wallet.
+
+On failure, an error is reported and no UTXOs are reserved.
+
+The following error codes may occur:
+- -1: Catchall nonspecific error.
+- 301: There are not enough funds in the internal wallet (including
+fees) to create the transaction.
+- 302: The dust limit is not met.
+
+AUTHOR
+------
+
+niftynei <<niftynei@gmail.com>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-unreserveinputs(7), lightning-signpsbt(7), lightning-sendpsbt(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-unreserveinputs.7
+++ b/doc/lightning-unreserveinputs.7
@@ -1,0 +1,48 @@
+.TH "LIGHTNING-UNRESERVEINPUTS" "7" "" "" "lightning-unreserveinputs"
+.SH NAME
+lightning-unreserveinputs - Release reserved UTXOs
+.SH SYNOPSIS
+
+\fBunreserveinputs\fR \fIpsbt\fR
+
+.SH DESCRIPTION
+
+The \fBunreserveinputs\fR RPC command releases UTXOs which were previously 
+marked as reserved, generally by \fBlightning-reserveinputs\fR(7)\.
+
+
+The inputs to unreserve are the inputs specified in the passed-in \fIpsbt\fR\.
+
+.SH RETURN VALUE
+
+On success, an object with \fIoutputs\fR will be returned\.
+
+
+\fIoutputs\fR will include an entry for each input specified in the \fIpsbt\fR,
+indicating the \fItxid\fR and \fIvout\fR for that input plus a boolean result
+ \fIunreserved\fR, which will be true if that UTXO was successfully unreserved
+by this call\.
+
+
+Note that restarting lightningd will unreserve all UTXOs by default\.
+
+
+The following error codes may occur:
+
+.RS
+.IP \[bu]
+-1: An unparseable PSBT\.
+
+.RE
+.SH AUTHOR
+
+niftynei \fI<niftynei@gmail.com\fR> is mainly responsible\.
+
+.SH SEE ALSO
+
+\fBlightning-unreserveinputs\fR(7), \fBlightning-signpsbt\fR(7), \fBlightning-sendpsbt\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-unreserveinputs.7.md
+++ b/doc/lightning-unreserveinputs.7.md
@@ -1,0 +1,45 @@
+lightning-unreserveinputs -- Release reserved UTXOs
+===================================================
+
+SYNOPSIS
+--------
+
+**unreserveinputs** *psbt*
+
+DESCRIPTION
+-----------
+
+The **unreserveinputs** RPC command releases UTXOs which were previously 
+marked as reserved, generally by lightning-reserveinputs(7).
+
+The inputs to unreserve are the inputs specified in the passed-in *psbt*.
+
+RETURN VALUE
+------------
+
+On success, an object with *outputs* will be returned.
+
+*outputs* will include an entry for each input specified in the *psbt*,
+indicating the *txid* and *vout* for that input plus a boolean result
+ *unreserved*, which will be true if that UTXO was successfully unreserved
+by this call.
+
+Note that restarting lightningd will unreserve all UTXOs by default.
+
+The following error codes may occur:
+- -1: An unparseable PSBT.
+
+AUTHOR
+------
+
+niftynei <<niftynei@gmail.com>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-unreserveinputs(7), lightning-signpsbt(7), lightning-sendpsbt(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -92,7 +92,7 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		bitcoin_txid(tx, &txid);
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
-						     tx, &b->height, &owned);
+						     tx->wtx, &b->height, &owned);
 			wallet_transaction_add(topo->ld->wallet, tx, b->height,
 					       i);
 		}

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -436,6 +436,131 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     assert decode['vout'][changenum]['scriptPubKey']['type'] == 'witness_v0_keyhash'
 
 
+def test_reserveinputs(node_factory, bitcoind, chainparams):
+    """
+    Reserve inputs is basically the same as txprepare, with the
+    slight exception that 'reserveinputs' doesn't keep the
+    unsent transaction around
+    """
+    amount = 1000000
+    total_outs = 12
+    l1 = node_factory.get_node(feerates=(7500, 7500, 7500, 7500))
+    addr = chainparams['example_addr']
+
+    # Add a medley of funds to withdraw later, bech32 + p2sh-p2wpkh
+    for i in range(total_outs // 2):
+        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'],
+                                   amount / 10**8)
+        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr('p2sh-segwit')['p2sh-segwit'],
+                                   amount / 10**8)
+
+    bitcoind.generate_block(1)
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == total_outs)
+
+    utxo_count = 8
+    sent = Decimal('0.01') * (utxo_count - 1)
+    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}])
+    assert reserved['feerate_per_kw'] == 7500
+    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
+    out_found = False
+
+    assert len(psbt['inputs']) == utxo_count
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if not x['reserved']]) == total_outs - utxo_count
+    assert len([x for x in outputs if x['reserved']]) == utxo_count
+    total_outs -= utxo_count
+    saved_input = psbt['tx']['vin'][0]
+
+    # We should have two outputs
+    for vout in psbt['tx']['vout']:
+        if vout['scriptPubKey']['addresses'][0] == addr:
+            assert vout['value'] == sent
+            out_found = True
+    assert out_found
+
+    # Do it again, but for too many inputs
+    utxo_count = 12 - utxo_count + 1
+    sent = Decimal('0.01') * (utxo_count - 1)
+    with pytest.raises(RpcError, match=r"Cannot afford transaction"):
+        reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}])
+
+    utxo_count -= 1
+    sent = Decimal('0.01') * (utxo_count - 1)
+    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}], feerate='10000perkw')
+
+    assert reserved['feerate_per_kw'] == 10000
+    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
+
+    assert len(psbt['inputs']) == utxo_count
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if not x['reserved']]) == total_outs - utxo_count == 0
+    assert len([x for x in outputs if x['reserved']]) == 12
+
+    # No more available
+    with pytest.raises(RpcError, match=r"Cannot afford transaction"):
+        reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * 1)}], feerate='253perkw')
+
+    # Unreserve three, from different psbts
+    unreserve_utxos = [
+        {
+            'txid': saved_input['txid'],
+            'vout': saved_input['vout'],
+            'sequence': saved_input['sequence']
+        }, {
+            'txid': psbt['tx']['vin'][0]['txid'],
+            'vout': psbt['tx']['vin'][0]['vout'],
+            'sequence': psbt['tx']['vin'][0]['sequence']
+        }, {
+            'txid': psbt['tx']['vin'][1]['txid'],
+            'vout': psbt['tx']['vin'][1]['vout'],
+            'sequence': psbt['tx']['vin'][1]['sequence']
+        }]
+    unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
+
+    unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
+    assert unreserved['all_unreserved']
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if not x['reserved']]) == len(unreserved['outputs'])
+    for i in range(len(unreserved['outputs'])):
+        un = unreserved['outputs'][i]
+        u_utxo = unreserve_utxos[i]
+        assert un['txid'] == u_utxo['txid'] and un['vout'] == u_utxo['vout'] and un['unreserved']
+
+    # Try unreserving the same utxos again, plus one that's not included
+    # We expect this to be a no-op.
+    unreserve_utxos.append({'txid': 'b' * 64, 'vout': 0, 'sequence': 0})
+    unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
+    unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
+    assert not unreserved['all_unreserved']
+    for un in unreserved['outputs']:
+        assert not un['unreserved']
+    assert len([x for x in l1.rpc.listfunds()['outputs'] if not x['reserved']]) == 3
+
+    # passing in an empty string should fail
+    with pytest.raises(RpcError, match=r"should be a PSBT, not "):
+        l1.rpc.unreserveinputs('')
+
+    # reserve one of the utxos that we just unreserved
+    utxos = []
+    utxos.append(saved_input['txid'] + ":" + str(saved_input['vout']))
+    reserved = l1.rpc.reserveinputs([{addr: Millisatoshi(amount * 0.5 * 1000)}], feerate='253perkw', utxos=utxos)
+    assert len([x for x in l1.rpc.listfunds()['outputs'] if not x['reserved']]) == 2
+    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
+    assert len(psbt['inputs']) == 1
+    vin = psbt['tx']['vin'][0]
+    assert vin['txid'] == saved_input['txid'] and vin['vout'] == saved_input['vout']
+
+    # reserve them all!
+    reserved = l1.rpc.reserveinputs([{addr: 'all'}])
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if not x['reserved']]) == 0
+    assert len([x for x in outputs if x['reserved']]) == 12
+
+    # FIXME: restart the node, nothing will remain reserved
+    l1.restart()
+    assert len(l1.rpc.listfunds()['outputs']) == 12
+
+
 def test_txsend(node_factory, bitcoind, chainparams):
     amount = 1000000
     l1 = node_factory.get_node(random_hsm=True)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,3 +1,4 @@
+from bitcoin.rpc import JSONRPCError
 from decimal import Decimal
 from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
@@ -518,7 +519,7 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
 
     unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
-    assert unreserved['all_unreserved']
+    assert all([x['unreserved'] for x in unreserved['outputs']])
     outputs = l1.rpc.listfunds()['outputs']
     assert len([x for x in outputs if not x['reserved']]) == len(unreserved['outputs'])
     for i in range(len(unreserved['outputs'])):
@@ -531,7 +532,7 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     unreserve_utxos.append({'txid': 'b' * 64, 'vout': 0, 'sequence': 0})
     unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
     unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
-    assert not unreserved['all_unreserved']
+    assert not any([x['unreserved'] for x in unreserved['outputs']])
     for un in unreserved['outputs']:
         assert not un['unreserved']
     assert len([x for x in l1.rpc.listfunds()['outputs'] if not x['reserved']]) == 3
@@ -559,6 +560,122 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     # FIXME: restart the node, nothing will remain reserved
     l1.restart()
     assert len(l1.rpc.listfunds()['outputs']) == 12
+
+
+def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
+    """
+    Tests for the sign + send psbt RPCs
+    """
+    amount = 1000000
+    total_outs = 12
+    l1 = node_factory.get_node(feerates=(7500, 7500, 7500, 7500))
+    l2 = node_factory.get_node()
+    addr = chainparams['example_addr']
+
+    # Add a medley of funds to withdraw later, bech32 + p2sh-p2wpkh
+    for i in range(total_outs // 2):
+        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'],
+                                   amount / 10**8)
+        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr('p2sh-segwit')['p2sh-segwit'],
+                                   amount / 10**8)
+    bitcoind.generate_block(1)
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == total_outs)
+
+    # Make a PSBT out of our inputs
+    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(3 * amount * 1000)}])
+    assert len([x for x in l1.rpc.listfunds()['outputs'] if x['reserved']]) == 4
+    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
+    saved_input = psbt['tx']['vin'][0]
+
+    # Go ahead and unreserve the UTXOs, we'll use a smaller
+    # set of them to create a second PSBT that we'll attempt to sign
+    # and broadcast (to disastrous results)
+    l1.rpc.unreserveinputs(reserved['psbt'])
+
+    # Re-reserve one of the utxos we just unreserved
+    utxos = []
+    utxos.append(saved_input['txid'] + ":" + str(saved_input['vout']))
+    second_reservation = l1.rpc.reserveinputs([{addr: Millisatoshi(amount * 0.5 * 1000)}], feerate='253perkw', utxos=utxos)
+
+    # We require the utxos be reserved before signing them
+    with pytest.raises(RpcError, match=r"Aborting PSBT signing. UTXO .* is not reserved"):
+        l1.rpc.signpsbt(reserved['psbt'])['signed_psbt']
+
+    # Now we unreserve the singleton, so we can reserve it again
+    l1.rpc.unreserveinputs(second_reservation['psbt'])
+
+    # We re-reserve the first set...
+    utxos = []
+    for vin in psbt['tx']['vin']:
+        utxos.append(vin['txid'] + ':' + str(vin['vout']))
+    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(3 * amount * 1000)}], utxos=utxos)
+    # Sign + send the PSBT we've created
+    signed_psbt = l1.rpc.signpsbt(reserved['psbt'])['signed_psbt']
+    broadcast_tx = l1.rpc.sendpsbt(signed_psbt)
+
+    # Check that it was broadcast successfully
+    l1.daemon.wait_for_log(r'sendrawtx exit 0 .* sendrawtransaction {}'.format(broadcast_tx['tx']))
+    bitcoind.generate_block(1)
+
+    # We expect a change output to be added to the wallet
+    expected_outs = total_outs - 4 + 1
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == expected_outs)
+
+    # Let's try *sending* a PSBT that can't be finalized (it's unsigned)
+    with pytest.raises(RpcError, match=r"PSBT not finalizeable"):
+        l1.rpc.sendpsbt(second_reservation['psbt'])
+
+    # Now we try signing a PSBT with an output that's already been spent
+    with pytest.raises(RpcError, match=r"Aborting PSBT signing. UTXO {} is not reserved".format(utxos[0])):
+        l1.rpc.signpsbt(second_reservation['psbt'])
+
+    # Queue up another node, to make some PSBTs for us
+    for i in range(total_outs // 2):
+        bitcoind.rpc.sendtoaddress(l2.rpc.newaddr()['bech32'],
+                                   amount / 10**8)
+        bitcoind.rpc.sendtoaddress(l2.rpc.newaddr('p2sh-segwit')['p2sh-segwit'],
+                                   amount / 10**8)
+    # Create a PSBT using L2
+    bitcoind.generate_block(1)
+    wait_for(lambda: len(l2.rpc.listfunds()['outputs']) == total_outs)
+    l2_reserved = l2.rpc.reserveinputs(outputs=[{addr: Millisatoshi(3 * amount * 1000)}])
+
+    # Try to get L1 to sign it
+    with pytest.raises(RpcError, match=r"No wallet inputs to sign"):
+        l1.rpc.signpsbt(l2_reserved['psbt'])
+
+    # Add some of our own PSBT inputs to it
+    l1_reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(3 * amount * 1000)}])
+    joint_psbt = bitcoind.rpc.joinpsbts([l1_reserved['psbt'], l2_reserved['psbt']])
+
+    half_signed_psbt = l1.rpc.signpsbt(joint_psbt)['signed_psbt']
+    totally_signed = l2.rpc.signpsbt(half_signed_psbt)['signed_psbt']
+
+    broadcast_tx = l1.rpc.sendpsbt(totally_signed)
+    l1.daemon.wait_for_log(r'sendrawtx exit 0 .* sendrawtransaction {}'.format(broadcast_tx['tx']))
+
+    # Send a PSBT that's not ours
+    l2_reserved = l2.rpc.reserveinputs(outputs=[{addr: Millisatoshi(3 * amount * 1000)}])
+    l2_signed_psbt = l2.rpc.signpsbt(l2_reserved['psbt'])['signed_psbt']
+    l1.rpc.sendpsbt(l2_signed_psbt)
+
+    # Re-try sending the same tx?
+    bitcoind.generate_block(1)
+    sync_blockheight(bitcoind, [l1])
+    # Expect an error here
+    with pytest.raises(JSONRPCError, match=r"Transaction already in block chain"):
+        bitcoind.rpc.sendrawtransaction(broadcast_tx['tx'])
+
+    # Try an empty PSBT
+    with pytest.raises(RpcError, match=r"should be a PSBT, not"):
+        l1.rpc.signpsbt('')
+    with pytest.raises(RpcError, match=r"should be a PSBT, not"):
+        l1.rpc.sendpsbt('')
+
+    # Try a modified (invalid) PSBT string
+    modded_psbt = l2_reserved['psbt'][:-3] + 'A' + l2_reserved['psbt'][-3:]
+    with pytest.raises(RpcError, match=r"should be a PSBT, not"):
+        l1.rpc.signpsbt(modded_psbt)
 
 
 def test_txsend(node_factory, bitcoind, chainparams):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -6,7 +6,7 @@ from flaky import flaky  # noqa: F401
 from pyln.client import RpcError, Millisatoshi
 from utils import (
     only_one, wait_for, sync_blockheight, EXPERIMENTAL_FEATURES, COMPAT,
-    VALGRIND
+    VALGRIND, check_coin_moves
 )
 
 import os
@@ -568,7 +568,9 @@ def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
     """
     amount = 1000000
     total_outs = 12
-    l1 = node_factory.get_node(feerates=(7500, 7500, 7500, 7500))
+    coin_mvt_plugin = os.path.join(os.getcwd(), 'tests/plugins/coin_movements.py')
+    l1 = node_factory.get_node(options={'plugin': coin_mvt_plugin},
+                               feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node()
     addr = chainparams['example_addr']
 
@@ -676,6 +678,41 @@ def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
     modded_psbt = l2_reserved['psbt'][:-3] + 'A' + l2_reserved['psbt'][-3:]
     with pytest.raises(RpcError, match=r"should be a PSBT, not"):
         l1.rpc.signpsbt(modded_psbt)
+
+    wallet_coin_mvts = [
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        # Nicely splits out withdrawals and chain fees, because it's all our tx
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 988255000, 'tag': 'withdrawal'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 3000000000, 'tag': 'withdrawal'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 11745000, 'tag': 'chain_fees'},
+        {'type': 'chain_mvt', 'credit': 988255000, 'debit': 0, 'tag': 'deposit'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
+        # Note that this is technically wrong since we paid 11745sat in fees
+        # but since it includes inputs / outputs from a second node, we can't
+        # do proper acccounting for it.
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 4000000000, 'tag': 'withdrawal'},
+        {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'chain_fees'},
+        {'type': 'chain_mvt', 'credit': 988255000, 'debit': 0, 'tag': 'deposit'},
+    ]
+    check_coin_moves(l1, 'wallet', wallet_coin_mvts)
 
 
 def test_txsend(node_factory, bitcoind, chainparams):

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -355,6 +355,15 @@ struct utxo *wallet_utxo_get(const tal_t *ctx, struct wallet *w,
 	return utxo;
 }
 
+bool wallet_unreserve_output(struct wallet *w,
+			     const struct bitcoin_txid *txid,
+			     const u32 outnum)
+{
+	return wallet_update_output_status(w, txid, outnum,
+					   output_state_reserved,
+					   output_state_available);
+}
+
 /**
  * unreserve_utxo - Mark a reserved UTXO as available again
  */
@@ -374,6 +383,11 @@ static void destroy_utxos(const struct utxo **utxos, struct wallet *w)
 {
 	for (size_t i = 0; i < tal_count(utxos); i++)
 		unreserve_utxo(w, utxos[i]);
+}
+
+void wallet_persist_utxo_reservation(struct wallet *w, const struct utxo **utxos)
+{
+	tal_del_destructor2(utxos, destroy_utxos, w);
 }
 
 void wallet_confirm_utxos(struct wallet *w, const struct utxo **utxos)

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -560,7 +560,7 @@ void wallet_blocks_heights(struct wallet *w, u32 def, u32 *min, u32 *max);
 /**
  * wallet_extract_owned_outputs - given a tx, extract all of our outputs
  */
-int wallet_extract_owned_outputs(struct wallet *w, const struct bitcoin_tx *tx,
+int wallet_extract_owned_outputs(struct wallet *w, const struct wally_tx *tx,
 				 const u32 *blockheight,
 				 struct amount_sat *total);
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1246,6 +1246,20 @@ void add_unreleased_tx(struct wallet *w, struct unreleased_tx *utx);
 /* These will touch the db, so need to be explicitly freed. */
 void free_unreleased_txs(struct wallet *w);
 
+/* wallet_persist_utxo_reservation - Removes destructor
+ *
+ * Persists the reservation in the database (until a restart)
+ * instead of clearing the reservation when the utxo object
+ * is destroyed */
+void wallet_persist_utxo_reservation(struct wallet *w, const struct utxo **utxos);
+
+/* wallet_unreserve_output - Unreserve a utxo
+ *
+ * We unreserve utxos so that they can be spent elsewhere.
+ * */
+bool wallet_unreserve_output(struct wallet *w,
+			     const struct bitcoin_txid *txid,
+			     const u32 outnum);
 /**
  * Get a list of transactions that we track in the wallet.
  *

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -1158,3 +1158,103 @@ static const struct json_command listtransactions_command = {
     "it closes the channel and returns funds to the wallet."
 };
 AUTODATA(json_command, &listtransactions_command);
+
+static struct command_result *json_reserveinputs(struct command *cmd,
+						 const char *buffer,
+						 const jsmntok_t *obj UNNEEDED,
+						 const jsmntok_t *params)
+{
+	struct command_result *res;
+	struct json_stream *response;
+	struct unreleased_tx *utx;
+
+	u32 feerate;
+
+	res = json_prepare_tx(cmd, buffer, params, false, &utx, &feerate);
+	if (res)
+		return res;
+
+	/* Unlike json_txprepare, we don't keep the utx object
+	 * around, so we remove the auto-cleanup that happens
+	 * when the utxo objects are free'd */
+	wallet_persist_utxo_reservation(cmd->ld->wallet, utx->wtx->utxos);
+
+	response = json_stream_success(cmd);
+	json_add_psbt(response, "psbt", utx->tx->psbt);
+	json_add_u32(response, "feerate_per_kw", feerate);
+	return command_success(cmd, response);
+}
+static const struct json_command reserveinputs_command = {
+	"reserveinputs",
+	"bitcoin",
+	json_reserveinputs,
+	"Reserve inputs and pass back the resulting psbt",
+	false
+};
+AUTODATA(json_command, &reserveinputs_command);
+
+static struct command_result *param_psbt(struct command *cmd,
+					 const char *name,
+					 const char *buffer,
+					 const jsmntok_t *tok,
+					 struct wally_psbt **psbt)
+{
+	/* Pull out the token into a string, then pass to
+	 * the PSBT parser; PSBT parser can't handle streaming
+	 * atm as it doesn't accept a len value */
+	char *psbt_buff = json_strdup(cmd, buffer, tok);
+	if (psbt_from_b64(psbt_buff, psbt))
+		return NULL;
+
+	return command_fail(cmd, LIGHTNINGD, "'%s' should be a PSBT, not '%.*s'",
+			    name, json_tok_full_len(tok),
+			    json_tok_full(buffer, tok));
+}
+
+static struct command_result *json_unreserveinputs(struct command *cmd,
+						   const char *buffer,
+						   const jsmntok_t *obj UNNEEDED,
+						   const jsmntok_t *params)
+{
+	struct json_stream *response;
+	struct wally_psbt *psbt;
+	bool all_unreserved;
+
+	/* for each input in the psbt, attempt to 'unreserve' it */
+	if (!param(cmd, buffer, params,
+		   p_req("psbt", param_psbt, &psbt),
+		   NULL))
+		return command_param_failed();
+
+	response = json_stream_success(cmd);
+	all_unreserved = psbt->tx->num_inputs != 0;
+	json_array_start(response, "outputs");
+	for (size_t i = 0; i < psbt->tx->num_inputs; i++) {
+		struct wally_tx_input *in;
+		struct bitcoin_txid txid;
+		bool unreserved;
+
+		in = &psbt->tx->inputs[i];
+		wally_tx_input_get_txid(in, &txid);
+		unreserved = wallet_unreserve_output(cmd->ld->wallet,
+						     &txid, in->index);
+		json_object_start(response, NULL);
+		json_add_txid(response, "txid", &txid);
+		json_add_u64(response, "vout", in->index);
+		json_add_bool(response, "unreserved", unreserved);
+		json_object_end(response);
+		all_unreserved &= unreserved;
+	}
+	json_array_end(response);
+
+	json_add_bool(response, "all_unreserved", all_unreserved);
+	return command_success(cmd, response);
+}
+static const struct json_command unreserveinputs_command = {
+	"unreserveinputs",
+	"bitcoin",
+	json_unreserveinputs,
+	"Unreserve inputs, freeing them up to be reused",
+	false
+};
+AUTODATA(json_command, &unreserveinputs_command);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -59,7 +59,7 @@ static void wallet_withdrawal_broadcast(struct bitcoind *bitcoind UNUSED,
 		wallet_confirm_utxos(ld->wallet, utx->wtx->utxos);
 
 		/* Extract the change output and add it to the DB */
-		wallet_extract_owned_outputs(ld->wallet, utx->tx, NULL, &change);
+		wallet_extract_owned_outputs(ld->wallet, utx->tx->wtx, NULL, &change);
 
 		/* Note normally, change_satoshi == withdraw->wtx->change, but
 		 * not if we're actually making a payment to ourselves! */

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -140,8 +140,9 @@ static struct command_result *broadcast_and_wait(struct command *cmd,
 static struct command_result *json_prepare_tx(struct command *cmd,
 					      const char *buffer,
 					      const jsmntok_t *params,
+					      bool for_withdraw,
 					      struct unreleased_tx **utx,
-					      bool for_withdraw)
+					      u32 *feerate)
 {
 	u32 *feerate_per_kw = NULL;
 	struct command_result *result;
@@ -430,6 +431,8 @@ create_tx:
 
 	bitcoin_txid((*utx)->tx, &(*utx)->txid);
 
+	if (feerate)
+		*feerate = *feerate_per_kw;
 	return NULL;
 }
 
@@ -442,7 +445,7 @@ static struct command_result *json_txprepare(struct command *cmd,
 	struct command_result *res;
 	struct json_stream *response;
 
-	res = json_prepare_tx(cmd, buffer, params, &utx, false);
+	res = json_prepare_tx(cmd, buffer, params, false, &utx, NULL);
 	if (res)
 		return res;
 
@@ -569,7 +572,7 @@ static struct command_result *json_withdraw(struct command *cmd,
 	struct unreleased_tx *utx;
 	struct command_result *res;
 
-	res = json_prepare_tx(cmd, buffer, params, &utx, true);
+	res = json_prepare_tx(cmd, buffer, params, true, &utx, NULL);
 	if (res)
 		return res;
 


### PR DESCRIPTION
These are the base RPC calls that we'll need for constructing a transaction iteratively. ~As a PR, this is built ontop of #3762. New commits start at https://github.com/ElementsProject/lightning/commit/569efe8ba540cadc453694d22a8f0ed281802851~

Added RPC methods:
- reserveinputs
- unreserveinputs
- signpsbt
- sendpsbt 