### PR TITLE
common/utils.c: Correctly handle NULL `take`n pointer in `tal_dup_talarr`.

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -142,9 +142,12 @@ void tal_arr_remove_(void *p, size_t elemsize, size_t n)
     tal_resize((char **)p, len - elemsize);
 }
 
-void *tal_dup_talarr_(const tal_t *ctx, const tal_t *src, const char *label)
+void *tal_dup_talarr_(const tal_t *ctx, const tal_t *src TAKES, const char *label)
 {
-	if (!src)
+	if (!src) {
+		/* Correctly handle TAKES on a NULL `src`.  */
+		(void) taken(src);
 		return NULL;
+	}
 	return tal_dup_(ctx, src, 1, tal_bytelen(src), 0, label);
 }

--- a/tests/plugins/fail_htlcs_invalid.py
+++ b/tests/plugins/fail_htlcs_invalid.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(onion, plugin, **kwargs):
+    plugin.log("Failing htlc on purpose with invalid onion failure")
+    plugin.log("onion: %r" % (onion))
+    # WIRE_TEMPORARY_CHANNEL_FAILURE = 0x1007
+    # This failure code should be followed by a
+    # `channel_update`; we deliberately return
+    # a 0-length `channel_update` to trigger
+    # issue #3757 reported by @sumBTC.
+    return {"result": "fail", "failure_message": "10070000"}
+
+
+plugin.run()

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3019,7 +3019,6 @@ def test_keysend(node_factory):
     assert(inv['msatoshi_received'] >= amt)
 
 
-@pytest.mark.xfail(strict=True)
 def test_invalid_onion_channel_update(node_factory):
     '''
     Some onion failures "should" send a `channel_update`.


### PR DESCRIPTION
Fixes: #3757

Reported-by: @sumBTC