### PR TITLE
lightningd/opening_control.c: `fundchannel_cancel` no longer requires a `channel_id` argument.

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -49,6 +49,8 @@ static const errcode_t FUNDING_BROADCAST_FAIL = 303;
 static const errcode_t FUNDING_STILL_SYNCING_BITCOIN = 304;
 static const errcode_t FUNDING_PEER_NOT_CONNECTED = 305;
 static const errcode_t FUNDING_UNKNOWN_PEER = 306;
+static const errcode_t FUNDING_NOTHING_TO_CANCEL = 307;
+static const errcode_t FUNDING_CANCEL_NOT_SAFE = 308;
 
 /* `connect` errors */
 static const errcode_t CONNECT_NO_KNOWN_ADDRESS = 400;

--- a/doc/lightning-fundchannel_cancel.7
+++ b/doc/lightning-fundchannel_cancel.7
@@ -36,9 +36,13 @@ with \fBcode\fR being one of the following:
 .IP \[bu]
 -32602: If the given parameters are wrong\.
 .IP \[bu]
--1: Catchall nonspecific error\.
-.IP \[bu]
 306: Unknown peer id\.
+.IP \[bu]
+307: No channel currently being funded that can be cancelled\.
+.IP \[bu]
+308: It is unsafe to cancel the channel: the funding transaction
+has been broadcast, or there are HTLCs already in the channel, or
+the peer was the initiator and not us\.
 
 .RE
 .SH AUTHOR

--- a/doc/lightning-fundchannel_cancel.7.md
+++ b/doc/lightning-fundchannel_cancel.7.md
@@ -32,8 +32,11 @@ On error the returned object will contain `code` and `message` properties,
 with `code` being one of the following:
 
 - -32602: If the given parameters are wrong.
-- -1: Catchall nonspecific error.
 - 306: Unknown peer id.
+- 307: No channel currently being funded that can be cancelled.
+- 308: It is unsafe to cancel the channel: the funding transaction
+  has been broadcast, or there are HTLCs already in the channel, or
+  the peer was the initiator and not us.
 
 AUTHOR
 ------

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -26,9 +26,7 @@ void channel_notify_new_block(struct lightningd *ld,
 /* Cancel the channel after `fundchannel_complete` succeeds
  * but before funding broadcasts. */
 struct command_result *cancel_channel_before_broadcast(struct command *cmd,
-						       const char *buffer,
-						       struct peer *peer,
-						       const jsmntok_t *cidtok);
+						       struct peer *peer);
 
 /* Forget a channel. Deletes the channel and handles all
  * associated waiting commands, if present. Notifies peer if available */


### PR DESCRIPTION
Fixes: #3785

Changelog-Changed: `fundchannel_cancel` no longer requires its undocumented `channel_id` argument after `fundchannel_complete`.

Note: this implies changes in #3763.