### PR TITLE
Add a 'reservation expiration' mechanism

### DIFF
--- a/common/utxo.h
+++ b/common/utxo.h
@@ -39,6 +39,9 @@ struct utxo {
 	/* NULL if not spent yet, otherwise, the block the spending transaction is in */
 	const u32 *spendheight;
 
+	/* Block this utxo becomes unreserved, if applicable */
+	const u32 *reserved_til;
+
 	/* The scriptPubkey if it is known */
 	u8 *scriptPubkey;
 

--- a/common/wallet_tx.c
+++ b/common/wallet_tx.c
@@ -91,11 +91,6 @@ struct command_result *param_utxos(struct command *cmd,
 	tal_free(txids);
 	tal_free(outnums);
 
-	if (!*utxos)
-		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-							"Could not decode all of the outpoints. The utxos"
-							" should be specified as an array of "
-							" 'txid:output_index'.");
 	if (tal_count(*utxos) == 0)
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 							"No matching utxo was found from the wallet. "

--- a/common/withdraw_tx.h
+++ b/common/withdraw_tx.h
@@ -19,6 +19,7 @@ struct utxo;
  *
  * @ctx: context to tal from.
  * @chainparams: (in) the params for the created transaction.
+ * @allow_rbf: (in) bool to signal whether to flag the sequence as RBF'able
  * @utxos: (in/out) tal_arr of UTXO pointers to spend (permuted to match)
  * @outputs: (in) tal_arr of bitcoin_tx_output, scriptPubKeys with amount to send to.
  * @bip32_base: (in) bip32 base for key derivation, or NULL.
@@ -26,6 +27,7 @@ struct utxo;
  */
 struct bitcoin_tx *withdraw_tx(const tal_t *ctx,
 			       const struct chainparams *chainparams,
+			       bool allow_rbf,
 			       const struct utxo **utxos,
 			       struct bitcoin_tx_output **outputs,
 			       const struct ext_key *bip32_base,

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1107,7 +1107,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("txsend", payload)
 
-    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None, expire_after=None):
+    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None, expire_after=None, allow_rbf=None):
         """
         Reserve UTXOs and return a psbt for a 'stub' transaction that
         spends the reserved UTXOs.
@@ -1118,6 +1118,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "minconf": minconf,
             "utxos": utxos,
             "expire_after": expire_after,
+            "allow_rbf": allow_rbf,
         }
         return self.call("reserveinputs", payload)
 

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1107,7 +1107,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("txsend", payload)
 
-    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None):
+    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None, expire_after=None):
         """
         Reserve UTXOs and return a psbt for a 'stub' transaction that
         spends the reserved UTXOs.
@@ -1117,6 +1117,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "feerate": feerate,
             "minconf": minconf,
             "utxos": utxos,
+            "expire_after": expire_after,
         }
         return self.call("reserveinputs", payload)
 

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -3,7 +3,7 @@
 lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spends
 .SH SYNOPSIS
 
-\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR] [\fIexpire_after\fR]
+\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR] [\fIexpire_after\fR] [\fIallow_rbf\fR]
 
 .SH DESCRIPTION
 
@@ -54,6 +54,10 @@ of "txid:vout"\. These must be drawn from the node's available UTXO set\.
 \fIexpire_after\fR specifies the number of blocks after which the UTXOs reserved
 by this command will be eligible for re-use\. Defaults to 144 blocks\.
 Can be disabled by passing in 0\.
+
+
+\fIallow_rbf\fR, if flagged on, will set the sequence for each input to permit
+it to be RBF'd\. Defaults to true\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -3,7 +3,7 @@
 lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spends
 .SH SYNOPSIS
 
-\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR]
+\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR] [\fIexpire_after\fR]
 
 .SH DESCRIPTION
 
@@ -49,6 +49,11 @@ should have\. Default is 1\.
 
 \fIutxos\fR specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout"\. These must be drawn from the node's available UTXO set\.
+
+
+\fIexpire_after\fR specifies the number of blocks after which the UTXOs reserved
+by this command will be eligible for re-use\. Defaults to 144 blocks\.
+Can be disabled by passing in 0\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -4,7 +4,7 @@ lightning-reserveinputs -- Construct a transaction and reserve the UTXOs it spen
 SYNOPSIS
 --------
 
-**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\] \[*expire_after*\]
+**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\] \[*expire_after*\] \[*allow_rbf*\]
 
 DESCRIPTION
 -----------
@@ -48,6 +48,9 @@ of "txid:vout". These must be drawn from the node's available UTXO set.
 *expire_after* specifies the number of blocks after which the UTXOs reserved
 by this command will be eligible for re-use. Defaults to 144 blocks.
 Can be disabled by passing in 0.
+
+*allow_rbf*, if flagged on, will set the sequence for each input to permit
+it to be RBF'd. Defaults to true.
 
 
 RETURN VALUE

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -4,7 +4,7 @@ lightning-reserveinputs -- Construct a transaction and reserve the UTXOs it spen
 SYNOPSIS
 --------
 
-**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\]
+**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\] \[*expire_after*\]
 
 DESCRIPTION
 -----------
@@ -44,6 +44,10 @@ should have. Default is 1.
 
 *utxos* specifies the utxos to be used to fund the transaction, as an array
 of "txid:vout". These must be drawn from the node's available UTXO set.
+
+*expire_after* specifies the number of blocks after which the UTXOs reserved
+by this command will be eligible for re-use. Defaults to 144 blocks.
+Can be disabled by passing in 0.
 
 
 RETURN VALUE

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -37,7 +37,6 @@
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/version.h>
-#include <common/withdraw_tx.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <hsmd/capabilities.h>

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -571,6 +571,20 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     outputs = l1.rpc.listfunds()['outputs']
     assert len([x for x in outputs if not x['reserved']]) == 12
 
+    # try setting the default reserved to 5 blocks
+    reserved = l1.rpc.reserveinputs([{addr: 'all'}], expire_after=5)
+    bitcoind.generate_block(5)
+    sync_blockheight(bitcoind, [l1])
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if not x['reserved']]) == 12
+
+    # try turning off the default reservation
+    reserved = l1.rpc.reserveinputs([{addr: 'all'}], expire_after=0)
+    bitcoind.generate_block(144)
+    sync_blockheight(bitcoind, [l1])
+    outputs = l1.rpc.listfunds()['outputs']
+    assert len([x for x in outputs if x['reserved']]) == 12
+
 
 def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
     """

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -437,7 +437,6 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     assert decode['vout'][changenum]['scriptPubKey']['type'] == 'witness_v0_keyhash'
 
 
-@pytest.mark.xfail
 def test_reserveinputs(node_factory, bitcoind, chainparams):
     """
     Reserve inputs is basically the same as txprepare, with the

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -563,9 +563,11 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     outputs = l1.rpc.listfunds()['outputs']
     assert len([x for x in outputs if x['reserved']]) == 12
 
-    # move the blockchain forward 24 blocks (default reserved value)
-    bitcoind.generate_block(24)
-    l1.restart()
+    # move the blockchain forward 144 blocks (default reserved value)
+    l1.stop()
+    bitcoind.generate_block(144)
+    l1.start()
+    sync_blockheight(bitcoind, [l1])
     # everything should be back to unreserved now
     outputs = l1.rpc.listfunds()['outputs']
     assert len([x for x in outputs if not x['reserved']]) == 12

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -617,6 +617,7 @@ static struct migration dbmigrations[] = {
     /* We track the counter for coin_moves, as a convenience for notification consumers */
     {SQL("INSERT INTO vars (name, intval) VALUES ('coin_moves_count', 0);"), NULL},
     {NULL, migrate_last_tx_to_psbt},
+    {SQL("ALTER TABLE outputs ADD reserved_til INTEGER DEFAULT NULL;"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -902,6 +902,10 @@ static bool test_wallet_outputs(struct lightningd *ld, const tal_t *ctx)
 	struct node_id id;
 	struct amount_sat fee_estimate, change_satoshis;
 	const struct utxo **utxos;
+	u32 expires_at = 30;
+
+	/* Set the chaintip height to 15 */
+	ld->topology->tip->height = 15;
 	CHECK(w);
 
 	memset(&u, 0, sizeof(u));
@@ -966,6 +970,61 @@ static bool test_wallet_outputs(struct lightningd *ld, const tal_t *ctx)
 					      output_state_spent),
 		  "could not change output state ignoring oldstate");
 
+	/* Check for 'reserved' state changes */
+	utxos = wallet_select_coins(w, w, true, AMOUNT_SAT(1), 0, 21,
+				    0 /* no confirmations required */,
+				    &fee_estimate, &change_satoshis);
+	CHECK(utxos && tal_count(utxos) == 1);
+
+	u = *utxos[0];
+
+	/* Add expiration to reservation */
+	CHECK_MSG(wallet_output_reservation_update(w, &u, expires_at),
+		  "could not add high watermark for reserved output");
+
+	/* Usually we'd remove the reservation on free, but
+	 * we want to do some things with it, so check that
+	 * we can short-circuit this by calling persist */
+	wallet_persist_utxo_reservation(w, utxos);
+	tal_free(utxos);
+
+	/* Now should be unable to select 1 sat amount */
+	CHECK_MSG(!wallet_select_coins(w, w, true, AMOUNT_SAT(1), 0, 21,
+				       0 /* no confirmations required */,
+				       &fee_estimate, &change_satoshis),
+	          "too many utxos available");
+
+	/* Get reserved utxos */
+	utxos = (const struct utxo **)wallet_get_utxos(w, w, output_state_reserved);
+	CHECK(utxos && tal_count(utxos) == 1);
+
+	/* Check that reserved_til is set */
+	CHECK(*utxos[0]->reserved_til == expires_at);
+
+	/* Expire the lease! */
+	ld->topology->tip->height = expires_at;
+
+	utxos = wallet_select_coins(w, w, true, AMOUNT_SAT(1), 0, 21,
+				    0 /* no confirmations required */,
+				    &fee_estimate, &change_satoshis);
+	CHECK_MSG(utxos && tal_count(utxos) == 1, "utxo count is incorrect");
+
+	/* Check freeing them resets them to available */
+	tal_free(utxos);
+
+	/* There should be no reserved utxos */
+	utxos = (const struct utxo **)wallet_get_utxos(w, w, output_state_reserved);
+	CHECK(tal_count(utxos) == 0);
+
+	/* check that we can mark as spent */
+	utxos = wallet_select_coins(w, w, true, AMOUNT_SAT(1), 0, 21,
+				    0 /* no confirmations required */,
+				    &fee_estimate, &change_satoshis);
+	CHECK_MSG(utxos && tal_count(utxos) == 1, "utxo count is incorrect");
+	wallet_confirm_utxos(w, utxos);
+
+	tal_free(utxos);
+
 	/* Attempt to save an UTXO with close_info set, no commitment_point */
 	memset(&u.txid, 2, sizeof(u.txid));
 	u.amount = AMOUNT_SAT(5);
@@ -980,9 +1039,9 @@ static bool test_wallet_outputs(struct lightningd *ld, const tal_t *ctx)
 	utxos = wallet_select_coins(w, w, true, AMOUNT_SAT(5), 0, 21,
 				    0 /* no confirmations required */,
 				    &fee_estimate, &change_satoshis);
-	CHECK(utxos && tal_count(utxos) == 2);
+	CHECK(utxos && tal_count(utxos) == 1);
 
-	u = *utxos[1];
+	u = *utxos[0];
 	CHECK(u.close_info->channel_id == 42 &&
 	      u.close_info->commitment_point == NULL &&
 	      node_id_eq(&u.close_info->peer_id, &id));
@@ -1481,6 +1540,9 @@ int main(int argc, const char *argv[])
 
 	/* Only elements in ld we should access */
 	list_head_init(&ld->peers);
+	ld->topology = tal(ld, struct chain_topology);
+	ld->topology->tip = tal(ld, struct block);
+
 	node_id_from_hexstr("02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66, &ld->id);
 	/* Accessed in peer destructor sanity check */
 	htlc_in_map_init(&ld->htlcs_in);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1261,6 +1261,20 @@ bool wallet_unreserve_output(struct wallet *w,
 			     const struct bitcoin_txid *txid,
 			     const u32 outnum);
 /**
+ * wallet_output_reservation_update - Add an expiration for a utxo reservation
+ * Will be returned to available upon expiration.
+ *
+ * Output must currently be in `reserved` state. Passing in 0 for `reserve_til`
+ * will expire the current reservation (if any)
+ *
+ * @w - wallet
+ * @utxo - output to update
+ * @reserve_til - block number to consider reservation expired */
+bool wallet_output_reservation_update(struct wallet *w,
+				      const struct utxo *utxo,
+				      const u32 reserve_til);
+
+/**
  * Get a list of transactions that we track in the wallet.
  *
  * @param ctx: allocation context for the returned list

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -1210,6 +1210,13 @@ static struct command_result *json_reserveinputs(struct command *cmd,
 	 * around, so we remove the auto-cleanup that happens
 	 * when the utxo objects are free'd */
 	wallet_persist_utxo_reservation(cmd->ld->wallet, utx->wtx->utxos);
+	/* Set the lease on these utxos to expire in ~24 hours,
+	 * or 24 blocks */
+	u32 expires_at = cmd->ld->topology->tip->height + 6 * 24;
+	for (size_t i = 0; i < tal_count(utx->wtx->utxos); i++)
+		wallet_output_reservation_update(cmd->ld->wallet,
+						 utx->wtx->utxos[i],
+						 expires_at);
 
 	response = json_stream_success(cmd);
 	json_add_psbt(response, "psbt", utx->tx->psbt);

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -881,8 +881,12 @@ static struct command_result *json_outputs(struct command *cmd,
 		} else
 			json_add_string(response, "status", "unconfirmed");
 
-		json_add_bool(response, "reserved",
-			      utxos[i]->status == output_state_reserved);
+		bool reserved = utxos[i]->status == output_state_reserved;
+		if (reserved && utxos[i]->reserved_til) {
+			reserved =
+			    *utxos[i]->reserved_til > get_block_height(cmd->ld->topology);
+		}
+		json_add_bool(response, "reserved", reserved);
 		json_object_end(response);
 	}
 


### PR DESCRIPTION
It's useful to be able to 'retire' reservations on utxos after a certain time lapse. It's also useful to be able to RBF transactions. This PR lets us do both now, by adding two new parameters to `reserveinputs`. 

- `expire_after` which will functionally 'unreserve' a utxo after that many blocks have passed, and
- `allow_rbf` which if set will create a psbt that has all of its inputs set to be rbf'able. 

RBF'ability forced a few not so nice state breaks in the output status (you have to be able to select utxos that are marked as 'spent' but not in a block yet, etc). But hey, RBF, here it is!

Built ontop of the as of yet unmerged #3775 (new commits start at https://github.com/ElementsProject/lightning/commit/37ba229563002e2962e0d18348c2d6509f1895fa)