### PR TITLE
pyln-proto, pyln-spec: fix 'make prod-release' target.

### DIFF
--- a/contrib/pyln-proto/Makefile
+++ b/contrib/pyln-proto/Makefile
@@ -39,7 +39,7 @@ test-release: check $(ARTEFACTS)
 	testpypi/bin/pytest tests
 	rm -rf testpypi
 
-prod-release: test $(ARTEFACTS)
+prod-release: test-release $(ARTEFACTS)
 	python3 -m twine upload $(ARTEFACTS)
 
 clean:

--- a/contrib/pyln-spec/Makefile
+++ b/contrib/pyln-spec/Makefile
@@ -66,7 +66,7 @@ test-release-bolt%: $(ARTEFACTS)
 
 test-release: check $(foreach b,$(BOLTS),test-release-bolt$b)
 
-prod-release: test $(ARTEFACTS)
+prod-release: test-release $(ARTEFACTS)
 	python3 -m twine upload $(ARTEFACTS)
 
 refresh: $(CODE_DIRS:%=%/gen_csv_version.py) $(CODE_DIRS:%=%/gen_version.py)


### PR DESCRIPTION
    rusty$ make prod-release
    make: *** No rule to make target 'test', needed by 'prod-release'.  Stop.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None