### PR TITLE
build: Make it possible to build without gcc

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -9,7 +9,7 @@ ifdef BUILD
 CROSSCOMPILE_OPTS := --host="$(MAKE_HOST)" --build="$(BUILD)"
 TARGET_DIR := external/"$(MAKE_HOST)"
 else
-TARGET_DIR := external/"$(shell gcc -dumpmachine)"
+TARGET_DIR := external/"$(shell ${CC} -dumpmachine)"
 endif
 
 LIBSODIUM_HEADERS := external/libsodium/src/libsodium/include/sodium.h


### PR DESCRIPTION
The external Makefile hardcodes gcc to get the machine spec. This should use the configured C compiler instead.

This bug was introduced in 601464416b7d437409ceb8f7373115d2f14b21d1.