### PR TITLE
external/Makefile: fix spurious rebuilds.

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -7,9 +7,9 @@ SUBMODULES =					\
 TOP := ../..
 ifdef BUILD
 CROSSCOMPILE_OPTS := --host="$(MAKE_HOST)" --build="$(BUILD)"
-TARGET_DIR := external/"$(MAKE_HOST)"
+TARGET_DIR := external/$(MAKE_HOST)
 else
-TARGET_DIR := external/"$(shell ${CC} -dumpmachine)"
+TARGET_DIR := external/$(shell ${CC} -dumpmachine)
 endif
 
 LIBSODIUM_HEADERS := external/libsodium/src/libsodium/include/sodium.h


### PR DESCRIPTION
Quote marks are not special to make: as it can't find
external/"x86_64-linux-gnu"/libwally-core-build/src/libwallycore.la
it always insists on rebuilding it (which rebuilds the world).

If we have spaces in TARGET_DIR, we're in trouble already.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>