### PR TITLE
Cleanups

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -10,6 +10,7 @@ export SOURCE_CHECK_ONLY=${SOURCE_CHECK_ONLY:-"false"}
 export COMPAT=${COMPAT:-1}
 export PATH=$CWD/dependencies/bin:"$HOME"/.local/bin:"$PATH"
 export PYTEST_PAR=2
+export PYTEST_SENTRY_ALWAYS_REPORT=1
 
 # If we're not in developer mode, tests spend a lot of time waiting for gossip!
 # But if we're under valgrind, we can run out of memory!
@@ -40,6 +41,10 @@ pip3 install --user -U --quiet --progress-bar off \
      -r contrib/pyln-proto/requirements.txt \
      -r contrib/pyln-testing/requirements.txt
 
+pip3 install --user -U --quiet --progress-bar off \
+     pytest-sentry \
+     pytest-rerunfailures
+
 echo "Configuration which is going to be built:"
 echo -en 'travis_fold:start:script.1\\r'
 ./configure CC="$CC"
@@ -48,7 +53,7 @@ echo -en 'travis_fold:end:script.1\\r'
 
 cat > pytest.ini << EOF
 [pytest]
-addopts=-p no:logging --color=no --force-flaky
+addopts=-p no:logging --color=no --reruns=5
 EOF
 
 if [ "$TARGET_HOST" == "arm-linux-gnueabihf" ] || [ "$TARGET_HOST" == "aarch64-linux-gnu" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVE
 
 FROM debian:stretch-slim as final
 COPY --from=downloader /opt/tini /usr/bin/tini
-RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-tools \
+RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-tools python3 python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LIGHTNINGD_DATA=/root/.lightning


### PR DESCRIPTION
Just my weekly cleanups. The main change is the last one where I enable `pytest-rerunfailures` which reruns any failures up to five times. Since that'd risk masking flaky tests, I also added `pytest-sentry` which will report all failures to a sentry instance, so we can track flakes and failures. This should considerably reduce the number of times we need to restart Travis.

Fixes #3765
