### PR TITLE
Reserve/unreserve/fundpsbt

### DIFF
--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -12,6 +12,10 @@
 #include <wally_transaction.h>
 
 #define BITCOIN_TX_DEFAULT_SEQUENCE 0xFFFFFFFF
+
+/* BIP 125: Any nsequence < 0xFFFFFFFE is replacable.
+ * And bitcoind uses this value. */
+#define BITCOIN_TX_RBF_SEQUENCE 0xFFFFFFFD
 struct wally_psbt;
 
 struct bitcoin_txid {

--- a/common/utxo.c
+++ b/common/utxo.c
@@ -76,7 +76,6 @@ struct bitcoin_tx *tx_spending_utxos(const tal_t *ctx,
 	struct pubkey key;
 	u8 *scriptSig, *scriptPubkey, *redeemscript;
 
-	assert(num_output);
 	size_t outcount = add_change_output ? 1 + num_output : num_output;
 	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams, tal_count(utxos),
 					   outcount, nlocktime);

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -39,6 +39,9 @@ struct utxo {
 	/* NULL if not spent yet, otherwise, the block the spending transaction is in */
 	const u32 *spendheight;
 
+	/* Block this utxo becomes unreserved, if applicable */
+	u32 *reserved_til;
+
 	/* The scriptPubkey if it is known */
 	u8 *scriptPubkey;
 

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1126,6 +1126,18 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("unreserveinputs", payload)
 
+    def fundpsbt(self, satoshi, feerate, minconf=None, reserve=True):
+        """
+        Create a PSBT with inputs sufficient to give an output of satoshi.
+        """
+        payload = {
+            "satoshi": satoshi,
+            "feerate": feerate,
+            "minconf": minconf,
+            "reserve": reserve,
+        }
+        return self.call("fundpsbt", payload)
+
     def signpsbt(self, psbt):
         """
         Add internal wallet's signatures to PSBT

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1107,22 +1107,19 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("txsend", payload)
 
-    def reserveinputs(self, outputs, feerate=None, minconf=None, utxos=None):
+    def reserveinputs(self, psbt, exclusive=True):
         """
-        Reserve UTXOs and return a psbt for a 'stub' transaction that
-        spends the reserved UTXOs.
+        Reserve any inputs in this psbt.
         """
         payload = {
-            "outputs": outputs,
-            "feerate": feerate,
-            "minconf": minconf,
-            "utxos": utxos,
+            "psbt": psbt,
+            "exclusive": exclusive,
         }
         return self.call("reserveinputs", payload)
 
     def unreserveinputs(self, psbt):
         """
-        Unreserve UTXOs that were previously reserved.
+        Unreserve (or reduce reservation) on any UTXOs in this psbt were previously reserved.
         """
         payload = {
             "psbt": psbt,

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,6 +23,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-fundchannel_start.7 \
 	doc/lightning-fundchannel_complete.7 \
 	doc/lightning-fundchannel_cancel.7 \
+	doc/lightning-fundpsbt.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-getsharedsecret.7 \
 	doc/lightning-hsmtool.8 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ c-lightning Documentation
    lightning-fundchannel_cancel <lightning-fundchannel_cancel.7.md>
    lightning-fundchannel_complete <lightning-fundchannel_complete.7.md>
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
+   lightning-fundpsbt <lightning-fundpsbt.7.md>
    lightning-getroute <lightning-getroute.7.md>
    lightning-getsharedsecret <lightning-getsharedsecret.7.md>
    lightning-hsmtool <lightning-hsmtool.8.md>

--- a/doc/lightning-fundpsbt.7
+++ b/doc/lightning-fundpsbt.7
@@ -1,0 +1,76 @@
+.TH "LIGHTNING-FUNDPSBT" "7" "" "" "lightning-fundpsbt"
+.SH NAME
+lightning-fundpsbt - Command to populate PSBT inputs from the wallet
+.SH SYNOPSIS
+
+\fBfundpsbt\fR \fIsatoshi\fR \fIfeerate\fR [\fIminconf\fR] [\fIreserve\fR]
+
+.SH DESCRIPTION
+
+\fBfundpsbt\fR is a low-level RPC command which creates a PSBT using unreserved
+inputs in the wallet, optionally reserving them as well\.
+
+
+\fIsatoshi\fR is the minimum satoshi value of the output(s) needed (or the
+string "all" meaning use all unreserved inputs)\.  If a value, it can
+be a whole number, a whole number ending in \fIsat\fR, a whole number
+ending in \fI000msat\fR, or a number with 1 to 8 decimal places ending in
+\fIbtc\fR\.
+
+
+You calculate the value by starting with the amount you want to pay
+and adding the fee which will be needed to pay for the base of the
+transaction plus that output, and any other outputs and inputs you
+will add to the final transaction\.
+
+
+\fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means the
+number is interpreted as satoshi-per-kilosipa (weight), and \fIperkb\fR
+means it is interpreted bitcoind-style as
+satoshi-per-kilobyte\. Omitting the suffix is equivalent to \fIperkb\fR\.
+
+
+\fIminconf\fR specifies the minimum number of confirmations that used
+outputs should have\. Default is 1\.
+
+
+\fIreserve\fR is a boolean: if true (the default), then \fIreserveinputs\fR is
+called (successfully, with \fIexclusive\fR true) on the returned PSBT\.
+
+.SH RETURN VALUE
+
+On success, returns the \fIpsbt\fR containing the inputs, and
+\fIexcess_msat\fR containing the amount above \fIsatoshi\fR which is
+available\.  This could be zero, or dust\.  If \fIsatoshi\fR was "all",
+then \fIexcess_msat\fR is the entire amount once fees are subtracted
+for the weights of the inputs\.
+
+
+If \fIreserve\fR was true, then a \fIreservations\fR array is returned,
+exactly like \fIreserveinputs\fR\.
+
+
+On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
+with \fBcode\fR being one of the following:
+
+.RS
+.IP \[bu]
+-32602: If the given parameters are wrong\.
+.IP \[bu]
+-1: Catchall nonspecific error\.
+.IP \[bu]
+301: Insufficient UTXOs to meet \fIsatoshi\fR value\.
+
+.RE
+.SH AUTHOR
+
+Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
+
+.SH SEE ALSO
+
+\fBlightning-reserveinputs\fR(7), \fBlightning-unreserveinputs\fR(7)\.
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -1,0 +1,69 @@
+lightning-fundpsbt -- Command to populate PSBT inputs from the wallet
+================================================================
+
+SYNOPSIS
+--------
+
+**fundpsbt** *satoshi* *feerate* \[*minconf*\] \[*reserve*\]
+
+DESCRIPTION
+-----------
+
+`fundpsbt` is a low-level RPC command which creates a PSBT using unreserved
+inputs in the wallet, optionally reserving them as well.
+
+*satoshi* is the minimum satoshi value of the output(s) needed (or the
+string "all" meaning use all unreserved inputs).  If a value, it can
+be a whole number, a whole number ending in *sat*, a whole number
+ending in *000msat*, or a number with 1 to 8 decimal places ending in
+*btc*.
+
+You calculate the value by starting with the amount you want to pay
+and adding the fee which will be needed to pay for the base of the
+transaction plus that output, and any other outputs and inputs you
+will add to the final transaction.
+
+*feerate* is a number, with an optional suffix: *perkw* means the
+number is interpreted as satoshi-per-kilosipa (weight), and *perkb*
+means it is interpreted bitcoind-style as
+satoshi-per-kilobyte. Omitting the suffix is equivalent to *perkb*.
+
+*minconf* specifies the minimum number of confirmations that used
+outputs should have. Default is 1.
+
+*reserve* is a boolean: if true (the default), then *reserveinputs* is
+called (successfully, with *exclusive* true) on the returned PSBT.
+
+RETURN VALUE
+------------
+
+On success, returns the *psbt* containing the inputs, and
+*excess_msat* containing the amount above *satoshi* which is
+available.  This could be zero, or dust.  If *satoshi* was "all",
+then *excess_msat* is the entire amount once fees are subtracted
+for the weights of the inputs.
+
+If *reserve* was true, then a *reservations* array is returned,
+exactly like *reserveinputs*.
+
+On error the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
+
+- -32602: If the given parameters are wrong.
+- -1: Catchall nonspecific error.
+- 301: Insufficient UTXOs to meet *satoshi* value.
+
+AUTHOR
+------
+
+Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-reserveinputs(7), lightning-unreserveinputs(7).
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -3,13 +3,18 @@
 lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spends
 .SH SYNOPSIS
 
-\fBreserveinputs\fR \fIpsbt\fR
+\fBreserveinputs\fR \fIpsbt\fR [\fIexclusive\fR]
 
 .SH DESCRIPTION
 
 The \fBreserveinputs\fR RPC command places (or increases) reservations on any
 inputs specified in \fIpsbt\fR which are known to lightningd\.  It will fail
 with an error it any of the inputs are known to be spent\.
+
+
+Normally the command will fail (with no reservations made) if an input
+is already reserved\.  If \fIexclusive\fR is set to \fIFalse\fR, then existing
+reservations are simply extended, rather than causing failure\.
 
 .SH RETURN VALUE
 
@@ -37,7 +42,7 @@ The following error codes may occur:
 
 .RS
 .IP \[bu]
--32602: Invalid parameter, such as specifying a spent input in \fIpsbt\fR\.
+-32602: Invalid parameter, such as specifying a spent/reserved input in \fIpsbt\fR\.
 
 .RE
 .SH AUTHOR

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -9,7 +9,8 @@ lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spend
 
 The \fBreserveinputs\fR RPC command places (or increases) reservations on any
 inputs specified in \fIpsbt\fR which are known to lightningd\.  It will fail
-with an error it any of the inputs are known to be spent\.
+with an error if any of the inputs are known to be spent, and ignore inputs
+which are unknown\.
 
 
 Normally the command will fail (with no reservations made) if an input
@@ -18,7 +19,7 @@ reservations are simply extended, rather than causing failure\.
 
 .SH RETURN VALUE
 
-On success, an \fIreservations\fR array is returned, with an entry for each input
+On success, a \fIreservations\fR array is returned, with an entry for each input
 which was reserved:
 
 .RS

--- a/doc/lightning-reserveinputs.7
+++ b/doc/lightning-reserveinputs.7
@@ -3,58 +3,32 @@
 lightning-reserveinputs - Construct a transaction and reserve the UTXOs it spends
 .SH SYNOPSIS
 
-\fBreserveinputs\fR \fIoutputs\fR [\fIfeerate\fR] [\fIminconf\fR] [\fIutxos\fR]
+\fBreserveinputs\fR \fIpsbt\fR
 
 .SH DESCRIPTION
 
-The \fBreserveinputs\fR RPC command creates an unsigned PSBT which
-spends funds from c-lightning’s internal wallet to the outputs specified
-in \fIoutputs\fR\.
-
-
-The \fIoutputs\fR is the array of output that include \fIdestination\fR
-and \fIamount\fR({\fIdestination\fR: \fIamount\fR})\. Its format is like:
-[{address1: amount1}, {address2: amount2}]
-or
-[{address: \fIall\fR}]\.
-It supports any number of outputs\.
-
-
-The \fIdestination\fR of output is the address which can be of any Bitcoin accepted
-type, including bech32\.
-
-
-The \fIamount\fR of output is the amount to be sent from the internal wallet
-(expressed, as name suggests, in amount)\. The string \fIall\fR can be used to specify
-all available funds\. Otherwise, it is in amount precision; it can be a whole
-number, a whole number ending in \fIsat\fR, a whole number ending in \fI000msat\fR,
-or a number with 1 to 8 decimal places ending in \fIbtc\fR\.
-
-
-\fIfeerate\fR is an optional feerate to use\. It can be one of the strings
-\fIurgent\fR (aim for next block), \fInormal\fR (next 4 blocks or so) or \fIslow\fR
-(next 100 blocks or so) to use lightningd’s internal estimates: \fInormal\fR
-is the default\.
-
-
-Otherwise, \fIfeerate\fR is a number, with an optional suffix: \fIperkw\fR means
-the number is interpreted as satoshi-per-kilosipa (weight), and \fIperkb\fR
-means it is interpreted bitcoind-style as satoshi-per-kilobyte\. Omitting
-the suffix is equivalent to \fIperkb\fR\.
-
-
-\fIminconf\fR specifies the minimum number of confirmations that reserved UTXOs 
-should have\. Default is 1\.
-
-
-\fIutxos\fR specifies the utxos to be used to fund the transaction, as an array
-of "txid:vout"\. These must be drawn from the node's available UTXO set\.
+The \fBreserveinputs\fR RPC command places (or increases) reservations on any
+inputs specified in \fIpsbt\fR which are known to lightningd\.  It will fail
+with an error it any of the inputs are known to be spent\.
 
 .SH RETURN VALUE
 
-On success, an object with attributes \fIpsbt\fR and \fIfeerate_per_kw\fR will be
-returned\. The inputs of the \fIpsbt\fR have been marked as reserved in the internal wallet\.
+On success, an \fIreservations\fR array is returned, with an entry for each input
+which was reserved:
 
+.RS
+.IP \[bu]
+\fItxid\fR is the input transaction id\.
+.IP \[bu]
+\fIvout\fR is the input index\.
+.IP \[bu]
+\fIwas_reserved\fR indicates whether the input was already reserved\.
+.IP \[bu]
+\fIreserved\fR indicates that the input is now reserved (i\.e\. true)\.
+.IP \[bu]
+\fIreserved_to_block\fR indicates what blockheight the reservation will expire\.
+
+.RE
 
 On failure, an error is reported and no UTXOs are reserved\.
 
@@ -63,12 +37,7 @@ The following error codes may occur:
 
 .RS
 .IP \[bu]
--1: Catchall nonspecific error\.
-.IP \[bu]
-301: There are not enough funds in the internal wallet (including
-fees) to create the transaction\.
-.IP \[bu]
-302: The dust limit is not met\.
+-32602: Invalid parameter, such as specifying a spent input in \fIpsbt\fR\.
 
 .RE
 .SH AUTHOR

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -11,7 +11,8 @@ DESCRIPTION
 
 The **reserveinputs** RPC command places (or increases) reservations on any
 inputs specified in *psbt* which are known to lightningd.  It will fail
-with an error it any of the inputs are known to be spent.
+with an error if any of the inputs are known to be spent, and ignore inputs
+which are unknown.
 
 Normally the command will fail (with no reservations made) if an input
 is already reserved.  If *exclusive* is set to *False*, then existing
@@ -21,7 +22,7 @@ reservations are simply extended, rather than causing failure.
 RETURN VALUE
 ------------
 
-On success, an *reservations* array is returned, with an entry for each input
+On success, a *reservations* array is returned, with an entry for each input
 which was reserved:
 
 - *txid* is the input transaction id.

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -4,7 +4,7 @@ lightning-reserveinputs -- Construct a transaction and reserve the UTXOs it spen
 SYNOPSIS
 --------
 
-**reserveinputs** *psbt*
+**reserveinputs** *psbt* [*exclusive*]
 
 DESCRIPTION
 -----------
@@ -12,6 +12,10 @@ DESCRIPTION
 The **reserveinputs** RPC command places (or increases) reservations on any
 inputs specified in *psbt* which are known to lightningd.  It will fail
 with an error it any of the inputs are known to be spent.
+
+Normally the command will fail (with no reservations made) if an input
+is already reserved.  If *exclusive* is set to *False*, then existing
+reservations are simply extended, rather than causing failure.
 
 
 RETURN VALUE
@@ -29,7 +33,7 @@ which was reserved:
 On failure, an error is reported and no UTXOs are reserved.
 
 The following error codes may occur:
-- -32602: Invalid parameter, such as specifying a spent input in *psbt*.
+- -32602: Invalid parameter, such as specifying a spent/reserved input in *psbt*.
 
 AUTHOR
 ------

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -4,61 +4,32 @@ lightning-reserveinputs -- Construct a transaction and reserve the UTXOs it spen
 SYNOPSIS
 --------
 
-**reserveinputs** *outputs* \[*feerate*\] \[*minconf*\] \[*utxos*\]
+**reserveinputs** *psbt*
 
 DESCRIPTION
 -----------
 
-The **reserveinputs** RPC command creates an unsigned PSBT which
-spends funds from c-lightning’s internal wallet to the outputs specified
-in *outputs*.
-
-The *outputs* is the array of output that include *destination*
-and *amount*(\{*destination*: *amount*\}). Its format is like:
-\[\{address1: amount1\}, \{address2: amount2\}\]
-or
-\[\{address: *all*\}\].
-It supports any number of outputs.
-
-The *destination* of output is the address which can be of any Bitcoin accepted
-type, including bech32.
-
-The *amount* of output is the amount to be sent from the internal wallet
-(expressed, as name suggests, in amount). The string *all* can be used to specify
-all available funds. Otherwise, it is in amount precision; it can be a whole
-number, a whole number ending in *sat*, a whole number ending in *000msat*,
-or a number with 1 to 8 decimal places ending in *btc*.
-
-*feerate* is an optional feerate to use. It can be one of the strings
-*urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
-(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
-is the default.
-
-Otherwise, *feerate* is a number, with an optional suffix: *perkw* means
-the number is interpreted as satoshi-per-kilosipa (weight), and *perkb*
-means it is interpreted bitcoind-style as satoshi-per-kilobyte. Omitting
-the suffix is equivalent to *perkb*.
-
-*minconf* specifies the minimum number of confirmations that reserved UTXOs 
-should have. Default is 1.
-
-*utxos* specifies the utxos to be used to fund the transaction, as an array
-of "txid:vout". These must be drawn from the node's available UTXO set.
+The **reserveinputs** RPC command places (or increases) reservations on any
+inputs specified in *psbt* which are known to lightningd.  It will fail
+with an error it any of the inputs are known to be spent.
 
 
 RETURN VALUE
 ------------
 
-On success, an object with attributes *psbt* and *feerate_per_kw* will be
-returned. The inputs of the *psbt* have been marked as reserved in the internal wallet.
+On success, an *reservations* array is returned, with an entry for each input
+which was reserved:
+
+- *txid* is the input transaction id.
+- *vout* is the input index.
+- *was_reserved* indicates whether the input was already reserved.
+- *reserved* indicates that the input is now reserved (i.e. true).
+- *reserved_to_block* indicates what blockheight the reservation will expire.
 
 On failure, an error is reported and no UTXOs are reserved.
 
 The following error codes may occur:
-- -1: Catchall nonspecific error.
-- 301: There are not enough funds in the internal wallet (including
-fees) to create the transaction.
-- 302: The dust limit is not met.
+- -32602: Invalid parameter, such as specifying a spent input in *psbt*.
 
 AUTHOR
 ------

--- a/doc/lightning-unreserveinputs.7
+++ b/doc/lightning-unreserveinputs.7
@@ -7,31 +7,40 @@ lightning-unreserveinputs - Release reserved UTXOs
 
 .SH DESCRIPTION
 
-The \fBunreserveinputs\fR RPC command releases UTXOs which were previously 
-marked as reserved, generally by \fBlightning-reserveinputs\fR(7)\.
+The \fBunreserveinputs\fR RPC command releases (or reduces reservation)
+on UTXOs which were previously marked as reserved, generally by
+\fBlightning-reserveinputs\fR(7)\.
 
 
 The inputs to unreserve are the inputs specified in the passed-in \fIpsbt\fR\.
 
 .SH RETURN VALUE
 
-On success, an object with \fIoutputs\fR will be returned\.
+On success, an \fIreservations\fR array is returned, with an entry for each input
+which was reserved:
 
+.RS
+.IP \[bu]
+\fItxid\fR is the input transaction id\.
+.IP \[bu]
+\fIvout\fR is the input index\.
+.IP \[bu]
+\fIwas_reserved\fR indicates whether the input was already reserved (generally true)
+.IP \[bu]
+\fIreserved\fR indicates that the input is now reserved (may still be true, if it was previously reserved for a long time)\.
+.IP \[bu]
+\fIreserved_to_block\fR (if \fIreserved\fR is still true) indicates what blockheight the reservation will expire\.
 
-\fIoutputs\fR will include an entry for each input specified in the \fIpsbt\fR,
-indicating the \fItxid\fR and \fIvout\fR for that input plus a boolean result
- \fIunreserved\fR, which will be true if that UTXO was successfully unreserved
-by this call\.
+.RE
 
-
-Note that restarting lightningd will unreserve all UTXOs by default\.
+On failure, an error is reported and no UTXOs are unreserved\.
 
 
 The following error codes may occur:
 
 .RS
 .IP \[bu]
--1: An unparseable PSBT\.
+-32602: Invalid parameter, i\.e\. an unparseable PSBT\.
 
 .RE
 .SH AUTHOR

--- a/doc/lightning-unreserveinputs.7.md
+++ b/doc/lightning-unreserveinputs.7.md
@@ -9,25 +9,28 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **unreserveinputs** RPC command releases UTXOs which were previously 
-marked as reserved, generally by lightning-reserveinputs(7).
+The **unreserveinputs** RPC command releases (or reduces reservation)
+on UTXOs which were previously marked as reserved, generally by
+lightning-reserveinputs(7).
 
 The inputs to unreserve are the inputs specified in the passed-in *psbt*.
 
 RETURN VALUE
 ------------
 
-On success, an object with *outputs* will be returned.
+On success, an *reservations* array is returned, with an entry for each input
+which was reserved:
 
-*outputs* will include an entry for each input specified in the *psbt*,
-indicating the *txid* and *vout* for that input plus a boolean result
- *unreserved*, which will be true if that UTXO was successfully unreserved
-by this call.
+- *txid* is the input transaction id.
+- *vout* is the input index.
+- *was_reserved* indicates whether the input was already reserved (generally true)
+- *reserved* indicates that the input is now reserved (may still be true, if it was previously reserved for a long time).
+- *reserved_to_block* (if *reserved* is still true) indicates what blockheight the reservation will expire.
 
-Note that restarting lightningd will unreserve all UTXOs by default.
+On failure, an error is reported and no UTXOs are unreserved.
 
 The following error codes may occur:
-- -1: An unparseable PSBT.
+- -32602: Invalid parameter, i.e. an unparseable PSBT.
 
 AUTHOR
 ------

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -307,7 +307,6 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 10)
 
     prep = l1.rpc.txprepare(outputs=[{addr: Millisatoshi(amount * 3 * 1000)}])
-    assert prep['psbt']
     decode = bitcoind.rpc.decoderawtransaction(prep['unsigned_tx'])
     assert decode['txid'] == prep['txid']
     # 4 inputs, 2 outputs (3 if we have a fee output).

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -438,130 +438,52 @@ def test_txprepare(node_factory, bitcoind, chainparams):
 
 
 def test_reserveinputs(node_factory, bitcoind, chainparams):
-    """
-    Reserve inputs is basically the same as txprepare, with the
-    slight exception that 'reserveinputs' doesn't keep the
-    unsent transaction around
-    """
     amount = 1000000
     total_outs = 12
     l1 = node_factory.get_node(feerates=(7500, 7500, 7500, 7500))
-    addr = chainparams['example_addr']
 
+    outputs = []
     # Add a medley of funds to withdraw later, bech32 + p2sh-p2wpkh
     for i in range(total_outs // 2):
-        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'],
-                                   amount / 10**8)
-        bitcoind.rpc.sendtoaddress(l1.rpc.newaddr('p2sh-segwit')['p2sh-segwit'],
-                                   amount / 10**8)
+        txid = bitcoind.rpc.sendtoaddress(l1.rpc.newaddr()['bech32'],
+                                          amount / 10**8)
+        outputs.append((txid, bitcoind.rpc.gettransaction(txid)['details'][0]['vout']))
+        txid = bitcoind.rpc.sendtoaddress(l1.rpc.newaddr('p2sh-segwit')['p2sh-segwit'],
+                                          amount / 10**8)
+        outputs.append((txid, bitcoind.rpc.gettransaction(txid)['details'][0]['vout']))
 
     bitcoind.generate_block(1)
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == total_outs)
 
-    utxo_count = 8
-    sent = Decimal('0.01') * (utxo_count - 1)
-    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}])
-    assert reserved['feerate_per_kw'] == 7500
-    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
-    out_found = False
+    assert not any(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
 
-    assert len(psbt['inputs']) == utxo_count
-    outputs = l1.rpc.listfunds()['outputs']
-    assert len([x for x in outputs if not x['reserved']]) == total_outs - utxo_count
-    assert len([x for x in outputs if x['reserved']]) == utxo_count
-    total_outs -= utxo_count
-    saved_input = psbt['tx']['vin'][0]
+    # Try reserving one at a time.
+    for out in outputs:
+        psbt = bitcoind.rpc.createpsbt([{'txid': out[0], 'vout': out[1]}], [])
+        l1.rpc.reserveinputs(psbt)
 
-    # We should have two outputs
-    for vout in psbt['tx']['vout']:
-        if chainparams['elements'] and vout['scriptPubKey']['type'] == 'fee':
-            continue
-        if vout['scriptPubKey']['addresses'][0] == addr:
-            assert vout['value'] == sent
-            out_found = True
-    assert out_found
+    assert all(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
 
-    # Do it again, but for too many inputs
-    utxo_count = 12 - utxo_count + 1
-    sent = Decimal('0.01') * (utxo_count - 1)
-    with pytest.raises(RpcError, match=r"Cannot afford transaction"):
-        reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}])
+    # Unreserve as a batch.
+    psbt = bitcoind.rpc.createpsbt([{'txid': out[0], 'vout': out[1]} for out in outputs], [])
+    l1.rpc.unreserveinputs(psbt)
+    assert not any(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
 
-    utxo_count -= 1
-    sent = Decimal('0.01') * (utxo_count - 1)
-    reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * (utxo_count - 1) * 1000)}], feerate='10000perkw')
+    # Reserve twice fails unless exclusive.
+    l1.rpc.reserveinputs(psbt)
+    with pytest.raises(RpcError, match=r"already reserved"):
+        l1.rpc.reserveinputs(psbt)
+    l1.rpc.reserveinputs(psbt, False)
+    l1.rpc.unreserveinputs(psbt)
+    assert all(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
 
-    assert reserved['feerate_per_kw'] == 10000
-    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
-
-    assert len(psbt['inputs']) == utxo_count
-    outputs = l1.rpc.listfunds()['outputs']
-    assert len([x for x in outputs if not x['reserved']]) == total_outs - utxo_count == 0
-    assert len([x for x in outputs if x['reserved']]) == 12
-
-    # No more available
-    with pytest.raises(RpcError, match=r"Cannot afford transaction"):
-        reserved = l1.rpc.reserveinputs(outputs=[{addr: Millisatoshi(amount * 1)}], feerate='253perkw')
-
-    # Unreserve three, from different psbts
-    unreserve_utxos = [
-        {
-            'txid': saved_input['txid'],
-            'vout': saved_input['vout'],
-            'sequence': saved_input['sequence']
-        }, {
-            'txid': psbt['tx']['vin'][0]['txid'],
-            'vout': psbt['tx']['vin'][0]['vout'],
-            'sequence': psbt['tx']['vin'][0]['sequence']
-        }, {
-            'txid': psbt['tx']['vin'][1]['txid'],
-            'vout': psbt['tx']['vin'][1]['vout'],
-            'sequence': psbt['tx']['vin'][1]['sequence']
-        }]
-    unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
-
-    unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
-    assert all([x['unreserved'] for x in unreserved['outputs']])
-    outputs = l1.rpc.listfunds()['outputs']
-    assert len([x for x in outputs if not x['reserved']]) == len(unreserved['outputs'])
-    for i in range(len(unreserved['outputs'])):
-        un = unreserved['outputs'][i]
-        u_utxo = unreserve_utxos[i]
-        assert un['txid'] == u_utxo['txid'] and un['vout'] == u_utxo['vout'] and un['unreserved']
-
-    # Try unreserving the same utxos again, plus one that's not included
-    # We expect this to be a no-op.
-    unreserve_utxos.append({'txid': 'b' * 64, 'vout': 0, 'sequence': 0})
-    unreserve_psbt = bitcoind.rpc.createpsbt(unreserve_utxos, [])
-    unreserved = l1.rpc.unreserveinputs(unreserve_psbt)
-    assert not any([x['unreserved'] for x in unreserved['outputs']])
-    for un in unreserved['outputs']:
-        assert not un['unreserved']
-    assert len([x for x in l1.rpc.listfunds()['outputs'] if not x['reserved']]) == 3
-
-    # passing in an empty string should fail
-    with pytest.raises(RpcError, match=r"should be a PSBT, not "):
-        l1.rpc.unreserveinputs('')
-
-    # reserve one of the utxos that we just unreserved
-    utxos = []
-    utxos.append(saved_input['txid'] + ":" + str(saved_input['vout']))
-    reserved = l1.rpc.reserveinputs([{addr: Millisatoshi(amount * 0.5 * 1000)}], feerate='253perkw', utxos=utxos)
-    assert len([x for x in l1.rpc.listfunds()['outputs'] if not x['reserved']]) == 2
-    psbt = bitcoind.rpc.decodepsbt(reserved['psbt'])
-    assert len(psbt['inputs']) == 1
-    vin = psbt['tx']['vin'][0]
-    assert vin['txid'] == saved_input['txid'] and vin['vout'] == saved_input['vout']
-
-    # reserve them all!
-    reserved = l1.rpc.reserveinputs([{addr: 'all'}])
-    outputs = l1.rpc.listfunds()['outputs']
-    assert len([x for x in outputs if not x['reserved']]) == 0
-    assert len([x for x in outputs if x['reserved']]) == 12
-
-    # FIXME: restart the node, nothing will remain reserved
+    # Stays reserved across restarts.
     l1.restart()
-    assert len(l1.rpc.listfunds()['outputs']) == 12
+    assert all(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
+
+    # Final unreserve works.
+    l1.rpc.unreserveinputs(psbt)
+    assert not any(o['reserved'] for o in l1.rpc.listfunds()['outputs'])
 
 
 @pytest.mark.xfail(strict=True)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -564,6 +564,7 @@ def test_reserveinputs(node_factory, bitcoind, chainparams):
     assert len(l1.rpc.listfunds()['outputs']) == 12
 
 
+@pytest.mark.xfail(strict=True)
 def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
     """
     Tests for the sign + send psbt RPCs

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -11,11 +11,14 @@ WALLET_LIB_SRC :=		\
 	wallet/wallet.c		\
 	wallet/walletrpc.c
 
+WALLET_LIB_SRC_NOHDR :=		\
+	wallet/reservation.c
+
 WALLET_DB_DRIVERS :=		\
 	wallet/db_postgres.c	\
 	wallet/db_sqlite3.c
 
-WALLET_LIB_OBJS := $(WALLET_LIB_SRC:.c=.o) $(WALLET_DB_DRIVERS:.c=.o)
+WALLET_LIB_OBJS := $(WALLET_LIB_SRC:.c=.o) $(WALLET_LIB_SRC_NOHDR:.c=.o) $(WALLET_DB_DRIVERS:.c=.o)
 WALLET_LIB_HEADERS := $(WALLET_LIB_SRC:.c=.h)
 
 # Make sure these depend on everything.

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -617,6 +617,7 @@ static struct migration dbmigrations[] = {
     /* We track the counter for coin_moves, as a convenience for notification consumers */
     {SQL("INSERT INTO vars (name, intval) VALUES ('coin_moves_count', 0);"), NULL},
     {NULL, migrate_last_tx_to_psbt},
+    {SQL("ALTER TABLE outputs ADD reserved_til INTEGER DEFAULT NULL;"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -1,0 +1,154 @@
+/* Dealing with reserving UTXOs */
+#include <common/json_command.h>
+#include <common/json_helpers.h>
+#include <common/jsonrpc_errors.h>
+#include <lightningd/jsonrpc.h>
+#include <lightningd/lightningd.h>
+#include <wallet/wallet.h>
+#include <wallet/walletrpc.h>
+
+static bool was_reserved(enum output_status oldstatus,
+			 const u32 *reserved_til,
+			 u32 current_height)
+{
+	if (oldstatus != output_state_reserved)
+		return false;
+
+	return *reserved_til > current_height;
+}
+
+static void json_add_reservestatus(struct json_stream *response,
+				   const struct utxo *utxo,
+				   enum output_status oldstatus,
+				   u32 old_res,
+				   u32 current_height)
+{
+	json_object_start(response, NULL);
+	json_add_txid(response, "txid", &utxo->txid);
+	json_add_u32(response, "vout", utxo->outnum);
+	json_add_bool(response, "was_reserved",
+		      was_reserved(oldstatus, &old_res, current_height));
+	json_add_bool(response, "reserved",
+		      is_reserved(utxo, current_height));
+	if (utxo->reserved_til)
+		json_add_u32(response, "reserved_to_block",
+			     *utxo->reserved_til);
+	json_object_end(response);
+}
+
+static struct command_result *json_reserveinputs(struct command *cmd,
+						 const char *buffer,
+						 const jsmntok_t *obj UNNEEDED,
+						 const jsmntok_t *params)
+{
+	struct json_stream *response;
+	struct wally_psbt *psbt;
+	struct utxo **utxos = tal_arr(cmd, struct utxo *, 0);
+
+	if (!param(cmd, buffer, params,
+		   p_req("psbt", param_psbt, &psbt),
+		   NULL))
+		return command_param_failed();
+
+	for (size_t i = 0; i < psbt->tx->num_inputs; i++) {
+		struct bitcoin_txid txid;
+		struct utxo *utxo;
+
+		wally_tx_input_get_txid(&psbt->tx->inputs[i], &txid);
+		utxo = wallet_utxo_get(cmd, cmd->ld->wallet,
+				       &txid, psbt->tx->inputs[i].index);
+		if (!utxo)
+			continue;
+		if (utxo->status == output_state_spent)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "%s:%u already spent",
+					    type_to_string(tmpctx,
+							   struct bitcoin_txid,
+							   &utxo->txid),
+					    utxo->outnum);
+		tal_arr_expand(&utxos, utxo);
+	}
+
+	response = json_stream_success(cmd);
+	json_array_start(response, "reservations");
+	for (size_t i = 0; i < tal_count(utxos); i++) {
+		enum output_status oldstatus;
+		u32 old_res;
+
+		oldstatus = utxos[i]->status;
+		old_res = utxos[i]->reserved_til ? *utxos[i]->reserved_til : 0;
+
+		if (!wallet_reserve_utxo(cmd->ld->wallet,
+					 utxos[i],
+					 get_block_height(cmd->ld->topology))) {
+			fatal("Unable to reserve %s:%u!",
+			      type_to_string(tmpctx,
+					     struct bitcoin_txid,
+					     &utxos[i]->txid),
+			      utxos[i]->outnum);
+		}
+		json_add_reservestatus(response, utxos[i], oldstatus, old_res,
+				       get_block_height(cmd->ld->topology));
+	}
+	json_array_end(response);
+	return command_success(cmd, response);
+}
+
+static const struct json_command reserveinputs_command = {
+	"reserveinputs",
+	"bitcoin",
+	json_reserveinputs,
+	"Reserve utxos (or increase their reservation)",
+	false
+};
+AUTODATA(json_command, &reserveinputs_command);
+
+static struct command_result *json_unreserveinputs(struct command *cmd,
+						   const char *buffer,
+						   const jsmntok_t *obj UNNEEDED,
+						   const jsmntok_t *params)
+{
+	struct json_stream *response;
+	struct wally_psbt *psbt;
+
+	if (!param(cmd, buffer, params,
+		   p_req("psbt", param_psbt, &psbt),
+		   NULL))
+		return command_param_failed();
+
+	response = json_stream_success(cmd);
+	json_array_start(response, "reservations");
+	for (size_t i = 0; i < psbt->tx->num_inputs; i++) {
+		struct bitcoin_txid txid;
+		struct utxo *utxo;
+		enum output_status oldstatus;
+		u32 old_res;
+
+		wally_tx_input_get_txid(&psbt->tx->inputs[i], &txid);
+		utxo = wallet_utxo_get(cmd, cmd->ld->wallet,
+				       &txid, psbt->tx->inputs[i].index);
+		if (!utxo || utxo->status != output_state_reserved)
+			continue;
+
+		oldstatus = utxo->status;
+		old_res = *utxo->reserved_til;
+
+		wallet_unreserve_utxo(cmd->ld->wallet,
+				      utxo,
+				      get_block_height(cmd->ld->topology));
+
+		json_add_reservestatus(response, utxo, oldstatus, old_res,
+				       get_block_height(cmd->ld->topology));
+	}
+	json_array_end(response);
+	return command_success(cmd, response);
+}
+
+static const struct json_command unreserveinputs_command = {
+	"unreserveinputs",
+	"bitcoin",
+	json_unreserveinputs,
+	"Unreserve utxos (or at least, reduce their reservation)",
+	false
+};
+AUTODATA(json_command, &unreserveinputs_command);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -392,6 +392,23 @@ bool wallet_add_onchaind_utxo(struct wallet *w,
 			      /* NULL if option_static_remotekey */
 			      const struct pubkey *commitment_point);
 
+/**
+ * wallet_reserve_utxo - set a reservation on a UTXO.
+ *
+ * If the reservation is already reserved, refreshes the reservation,
+ * otherwise if it's not available, returns false.
+ */
+bool wallet_reserve_utxo(struct wallet *w,
+			 struct utxo *utxo,
+			 u32 reservation_blocknum);
+
+/* wallet_unreserve_utxo - make a reserved UTXO available again.
+ *
+ * Must be reserved.
+ */
+void wallet_unreserve_utxo(struct wallet *w, struct utxo *utxo,
+			   u32 current_height);
+
 /** wallet_utxo_get - Retrive a utxo.
  *
  * Returns a utxo, or NULL if not found.

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -375,6 +375,29 @@ struct utxo **wallet_get_unconfirmed_closeinfo_utxos(const tal_t *ctx,
 						     struct wallet *w);
 
 /**
+ * wallet_find_utxo - Select an available UTXO (does not reserve it!).
+ * @ctx: tal context
+ * @w: wallet
+ * @current_blockheight: current chain length.
+ * @amount_we_are_short: optional amount.
+ * @feerate_per_kw: feerate we are using.
+ * @maxheight: zero (if caller doesn't care) or maximum blockheight to accept.
+ * @excludes: UTXOs not to consider.
+ *
+ * If @amount_we_are_short is not NULL, we try to get something very close
+ * (i.e. when we add this input, we will add => @amount_we_are_short, but
+ * less than @amount_we_are_short + dustlimit).
+ *
+ * Otherwise we give a random UTXO.
+ */
+struct utxo *wallet_find_utxo(const tal_t *ctx, struct wallet *w,
+			      unsigned current_blockheight,
+			      struct amount_sat *amount_we_are_short,
+			      unsigned feerate_per_kw,
+			      u32 maxheight,
+			      const struct utxo **excludes);
+
+/**
  * wallet_add_onchaind_utxo - Add a UTXO with spending info from onchaind.
  *
  * Usually we add UTXOs by looking at transactions, but onchaind tells

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -490,7 +490,6 @@ static struct command_result *json_txprepare(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_add_tx(response, "unsigned_tx", utx->tx);
 	json_add_txid(response, "txid", &utx->txid);
-	json_add_psbt(response, "psbt", utx->tx->psbt);
 	return command_success(cmd, response);
 }
 static const struct json_command txprepare_command = {

--- a/wallet/walletrpc.h
+++ b/wallet/walletrpc.h
@@ -9,4 +9,7 @@ void json_add_utxos(struct json_stream *response,
 		    struct wallet *wallet,
 		    struct utxo **utxos);
 
+/* We evaluate reserved timeouts lazily, so use this. */
+bool is_reserved(const struct utxo *utxo, u32 current_height);
+
 #endif /* LIGHTNING_WALLET_WALLETRPC_H */

--- a/wallet/walletrpc.h
+++ b/wallet/walletrpc.h
@@ -1,9 +1,12 @@
 #ifndef LIGHTNING_WALLET_WALLETRPC_H
 #define LIGHTNING_WALLET_WALLETRPC_H
 #include "config.h"
+#include <common/json.h>
 
+struct command;
 struct json_stream;
 struct utxo;
+struct wally_psbt;
 
 void json_add_utxos(struct json_stream *response,
 		    struct wallet *wallet,
@@ -12,4 +15,9 @@ void json_add_utxos(struct json_stream *response,
 /* We evaluate reserved timeouts lazily, so use this. */
 bool is_reserved(const struct utxo *utxo, u32 current_height);
 
+struct command_result *param_psbt(struct command *cmd,
+				  const char *name,
+				  const char *buffer,
+				  const jsmntok_t *tok,
+				  struct wally_psbt **psbt);
 #endif /* LIGHTNING_WALLET_WALLETRPC_H */


### PR DESCRIPTION
~~(Note: this fails due to libwally failing to marshal 0-output psbts, but should otherwise be complete).~~ -- Fixed in master by @niftynei !

Based on #3821

This changes the (newly-introduced!) reserveinputs and unreserveinputs to be far more primitive, and adds fundpsbt which is a low-level psbt creator.  Unfortunately, the rework I had planned which migrates everything else on top of these will not be finished before the release.

Nonetheless, it's better to ship with these APIs now, so progress can continue: shortly after 0.9.0 I will complete the rewrite which makes txprepare/txdiscard/txcancel a plugin on top of these, and @ZmnSCPxj can do the same for multiwithdraw and multifundchannel!

Closes: #3789 
Fixes: #3415