### PR TITLE
paymod: Activate the new payment flow for good (part 04)

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,9 +12,8 @@ export PATH=$CWD/dependencies/bin:"$HOME"/.local/bin:"$PATH"
 export PYTEST_PAR=2
 export PYTEST_SENTRY_ALWAYS_REPORT=1
 
-# If we're not in developer mode, tests spend a lot of time waiting for gossip!
-# But if we're under valgrind, we can run out of memory!
-if [ "$DEVELOPER" = 0 ] && [ "$VALGRIND" = 0 ]; then
+# Allow up to 4 concurrent tests when not under valgrind, which might run out of memory.
+if [ "$VALGRIND" = 0 ]; then
     PYTEST_PAR=4
 fi
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1645,9 +1645,13 @@ REGISTER_PAYMENT_MODIFIER(routehints, struct routehints_data *,
 
 static struct exemptfee_data *exemptfee_data_init(struct payment *p)
 {
-	struct exemptfee_data *d = tal(p, struct exemptfee_data);
-	d->amount = AMOUNT_MSAT(5000);
-	return d;
+	if (p->parent == NULL) {
+		struct exemptfee_data *d = tal(p, struct exemptfee_data);
+		d->amount = AMOUNT_MSAT(5000);
+		return d;
+	} else {
+		return payment_mod_exemptfee_get_data(p->parent);
+	}
 }
 
 static void exemptfee_cb(struct exemptfee_data *d, struct payment *p)

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1084,7 +1084,7 @@ static void payment_finished(struct payment *p)
 			return;
 		} else if (result.failure == NULL || result.failure->failcode < NODE) {
 			/* This is failing because we have no more routes to try */
-			ret = jsonrpc_stream_fail(cmd, PAY_ROUTE_NOT_FOUND,
+			ret = jsonrpc_stream_fail(cmd, PAY_STOPPED_RETRYING,
 						  NULL);
 			json_add_string(
 			    ret, "message",

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1661,17 +1661,18 @@ static struct exemptfee_data *exemptfee_data_init(struct payment *p)
 
 static void exemptfee_cb(struct exemptfee_data *d, struct payment *p)
 {
-	if (p->step != PAYMENT_STEP_INITIALIZED)
+	if (p->step != PAYMENT_STEP_INITIALIZED || p->parent != NULL)
 		return payment_continue(p);
 
 	if (amount_msat_greater_eq(d->amount, p->constraints.fee_budget)) {
-		p->constraints.fee_budget = d->amount;
-		p->start_constraints->fee_budget = d->amount;
 		plugin_log(
 		    p->plugin, LOG_INFORM,
-		    "Payment amount is below exemption threshold, "
+		    "Payment fee constraint %s is below exemption threshold, "
 		    "allowing a maximum fee of %s",
-		    type_to_string(tmpctx, struct amount_msat, &p->constraints.fee_budget));
+		    type_to_string(tmpctx, struct amount_msat, &p->constraints.fee_budget),
+		    type_to_string(tmpctx, struct amount_msat, &d->amount));
+		p->constraints.fee_budget = d->amount;
+		p->start_constraints->fee_budget = d->amount;
 	}
 	return payment_continue(p);
 }

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1973,7 +1973,7 @@ static void waitblockheight_cb(void *d, struct payment *p)
 	struct out_req *req;
 	struct timeabs now = time_now();
 	struct timerel remaining;
-	u32 blockheight;
+	u32 blockheight = p->start_block;
 	int failcode;
 	const u8 *raw_message;
 	if (p->step != PAYMENT_STEP_FAILED)
@@ -1990,7 +1990,7 @@ static void waitblockheight_cb(void *d, struct payment *p)
 	raw_message = p->result->raw_message;
 	remaining = time_between(p->deadline, now);
 
-	if (failcode != 17 /* Former final_expiry_too_soon */) {
+	if (failcode == 17 /* Former final_expiry_too_soon */) {
 		blockheight = p->start_block + 1;
 	}  else {
 		/* If it's incorrect_or_unknown_payment_details, that tells us
@@ -2006,7 +2006,7 @@ static void waitblockheight_cb(void *d, struct payment *p)
 	 * waiting, and it is likely just some other error. Notice that
 	 * start_block gets set by the initial getinfo call for each
 	 * attempt.*/
-	if (blockheight < p->start_block)
+	if (blockheight <= p->start_block)
 		return payment_continue(p);
 
 	plugin_log(p->plugin, LOG_INFORM,

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1039,6 +1039,7 @@ static void payment_finished(struct payment *p)
 	struct payment_tree_result result = payment_collect_result(p);
 	struct json_stream *ret;
 	struct command *cmd = p->cmd;
+	const char *msg;
 
 	/* Either none of the leaf attempts succeeded yet, or we have a
 	 * preimage. */
@@ -1085,15 +1086,13 @@ static void payment_finished(struct payment *p)
 			return;
 		} else if (result.failure == NULL || result.failure->failcode < NODE) {
 			/* This is failing because we have no more routes to try */
+			msg = tal_fmt(cmd,
+				      "Ran out of routes to try after "
+				      "%d attempt%s: see `paystatus`",
+				      result.attempts,
+				      result.attempts == 1 ? "" : "s");
 			ret = jsonrpc_stream_fail(cmd, PAY_STOPPED_RETRYING,
-						  NULL);
-			json_add_string(
-			    ret, "message",
-			    tal_fmt(cmd,
-				    "Ran out of routes to try after "
-				    "%d attempt%s: see `paystatus`",
-				    result.attempts,
-				    result.attempts == 1 ? "" : "s"));
+						  msg);
 			payment_json_add_attempts(ret, "attempts", p);
 			if (command_finished(cmd, ret)) {/* Ignore result. */}
 			return;

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2016,6 +2016,12 @@ static void waitblockheight_cb(void *d, struct payment *p)
 		   " seconds to catch up to block %d before retrying.",
 		   time_to_sec(remaining), blockheight);
 
+	/* Set temporarily set the state of the payment to not failed, so
+	 * interim status queries don't show this as terminally failed. We're
+	 * in control for this payment so nobody else could be fooled by
+	 * this. The callback will set it to retry anyway. */
+	payment_set_step(p, PAYMENT_STEP_RETRY);
+
 	req = jsonrpc_request_start(p->plugin, NULL, "waitblockheight",
 				    waitblockheight_rpc_cb,
 				    waitblockheight_rpc_cb, p);

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1015,6 +1015,11 @@ static void payment_add_attempt(struct json_stream *s, const char *fieldname, st
 	if (p->failreason != NULL)
 		json_add_string(s, "failreason", p->failreason);
 
+	json_add_u64(s, "partid", p->partid);
+	json_add_amount_msat_only(s, "amount", p->amount);
+	if (p->parent != NULL)
+		json_add_u64(s, "parent_partid", p->parent->partid);
+
 	json_object_end(s);
 	for (size_t i=0; i<tal_count(p->children); i++) {
 		payment_add_attempt(s, fieldname, p->children[i], recurse);

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1269,7 +1269,7 @@ static struct pay_status *add_pay_status(struct pay_command *pc,
 	return ps;
 }
 
-#ifndef COMPAT_V090
+#ifndef COMPAT_090
 UNUSED
 #endif
 static struct command_result *json_pay(struct command *cmd,
@@ -1847,9 +1847,6 @@ struct payment_modifier *paymod_mods[] = {
 	NULL,
 };
 
-#if !DEVELOPER
-UNUSED
-#endif
 static struct command_result *json_paymod(struct command *cmd,
 					  const char *buf,
 					  const jsmntok_t *params)
@@ -1962,17 +1959,17 @@ static struct command_result *json_paymod(struct command *cmd,
 	return command_still_pending(cmd);
 }
 
-static const struct plugin_command commands[] = { {
-		"pay",
+static const struct plugin_command commands[] = {
+#ifdef COMPAT_v090
+	{
+		"legacypay",
 		"payment",
 		"Send payment specified by {bolt11} with {amount}",
 		"Try to send a payment, retrying {retry_for} seconds before giving up",
-#ifdef COMPAT_V090
 		json_pay
-#else
-		json_paymod
+	},
 #endif
-	}, {
+	{
 		"paystatus",
 		"payment",
 		"Detail status of attempts to pay {bolt11}, or all",
@@ -1985,15 +1982,13 @@ static const struct plugin_command commands[] = { {
 		"Covers old payments (failed and succeeded) and current ones.",
 		json_listpays
 	},
-#if DEVELOPER
 	{
-		"paymod",
+		"pay",
 		"payment",
 		"Send payment specified by {bolt11}",
-		"Experimental implementation of pay using modifiers",
+		"Attempt to pay the {bolt11} invoice.",
 		json_paymod
 	},
-#endif
 };
 
 int main(int argc, char *argv[])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1401,7 +1401,7 @@ def test_htlc_send_timeout(node_factory, bitcoind, compat):
     err = excinfo.value
     # Complains it stopped after several attempts.
     # FIXME: include in pylightning
-    PAY_STOPPED_RETRYING = 210 if compat('090') else 205
+    PAY_STOPPED_RETRYING = 210
     assert err.error['code'] == PAY_STOPPED_RETRYING
 
     status = only_one(l1.rpc.call('paystatus')['pay'])

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1680,8 +1680,6 @@ def test_pay_routeboost(node_factory, bitcoind, compat):
     l1, l2 = node_factory.line_graph(2, announce_channels=True, wait_for_announce=True)
     l3, l4, l5 = node_factory.line_graph(3, announce_channels=False, wait_for_announce=False)
 
-    PAY_ROUTE_NOT_FOUND = 205
-
     # This should a "could not find a route" because that's true.
     error = r'Ran out of routes'
 


### PR DESCRIPTION
This is the last step in activating the new payment flow.

 - It removes all the `compat` changes to tests done in the previous parts and now uses the updated RPC everywhere
 - Added a `legacy` option to `pay` (and `legacypay` in order not to cause param failures) to fall back on the old implementation should there be an issue.
 - Fixed a tiny regression with flapping payment status if we happen to wait for the blockheights to match up.

We informally decided to activate the new payment flow for everybody and provide an escape hatch, for users that require the legacy payment model.

## Open questions
 - [x] Do we need a `legacypay` exposed via JSON-RPC at all, or should we only expose via `legacy` flag on the `pay` command?

Changelog-None