### PR TITLE
ccan: update so we can compile with -O2 on Ubuntu.

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2495-gc910bdce
+CCAN version: init-2500-gcbc7cbf1

--- a/ccan/ccan/htable/htable.c
+++ b/ccan/ccan/htable/htable.c
@@ -365,6 +365,20 @@ void htable_delval_(struct htable *ht, struct htable_iter *i)
 	ht->deleted++;
 }
 
+void *htable_pick_(const struct htable *ht, size_t seed, struct htable_iter *i)
+{
+	void *e;
+	struct htable_iter unwanted;
+
+	if (!i)
+		i = &unwanted;
+	i->off = seed % ((size_t)1 << ht->bits);
+	e = htable_next(ht, i);
+	if (!e)
+		e = htable_first(ht, i);
+	return e;
+}
+
 struct htable *htable_check(const struct htable *ht, const char *abortstr)
 {
 	void *p;

--- a/ccan/ccan/htable/htable.h
+++ b/ccan/ccan/htable/htable.h
@@ -268,6 +268,19 @@ void *htable_prev_(const struct htable *htable, struct htable_iter *i);
 void htable_delval_(struct htable *ht, struct htable_iter *i);
 
 /**
+ * htable_pick - set iterator to a random valid entry.
+ * @ht: the htable
+ * @seed: a random number to use.
+ * @i: the htable_iter which is output (or NULL).
+ *
+ * Usually used with htable_delval to delete a random entry.  Returns
+ * NULL iff the table is empty, otherwise a random entry.
+ */
+#define htable_pick(htable, seed, i)					\
+	htable_pick_(htable_debug(htable, HTABLE_LOC), seed, i)
+void *htable_pick_(const struct htable *ht, size_t seed, struct htable_iter *i);
+
+/**
  * htable_set_allocator - set calloc/free functions.
  * @alloc: allocator to use, must zero memory!
  * @free: unallocator to use (@p is NULL or a return from @alloc)

--- a/ccan/ccan/htable/htable_type.h
+++ b/ccan/ccan/htable/htable_type.h
@@ -35,6 +35,9 @@
  *	bool <name>_del(struct <name> *ht, const <type> *e);
  *	bool <name>_delkey(struct <name> *ht, const <keytype> *k);
  *
+ * Delete by iterator:
+ *	bool <name>_delval(struct <name> *ht, struct <name>_iter *i);
+ *
  * Find and return the (first) matching element, or NULL:
  *	type *<name>_get(const struct @name *ht, const <keytype> *k);
  *
@@ -48,7 +51,8 @@
  *	type *<name>_first(const struct <name> *ht, struct <name>_iter *i);
  *	type *<name>_next(const struct <name> *ht, struct <name>_iter *i);
  *	type *<name>_prev(const struct <name> *ht, struct <name>_iter *i);
- *
+ *      type *<name>_pick(const struct <name> *ht, size_t seed,
+ *                        struct <name>_iter *i);
  * It's currently safe to iterate over a changing hashtable, but you might
  * miss an element.  Iteration isn't very efficient, either.
  *
@@ -145,6 +149,18 @@
 		if (elem)						\
 			return name##_del(ht, elem);			\
 		return false;						\
+	}								\
+	static inline UNNEEDED void name##_delval(struct name *ht,	\
+						  struct name##_iter *iter) \
+	{								\
+		htable_delval(&ht->raw, &iter->i);			\
+	}								\
+	static inline UNNEEDED type *name##_pick(const struct name *ht,	\
+						size_t seed,		\
+						struct name##_iter *iter) \
+	{								\
+		/* Note &iter->i == NULL iff iter is NULL */		\
+		return htable_pick(&ht->raw, seed, &iter->i);			\
 	}								\
 	static inline UNNEEDED type *name##_first(const struct name *ht, \
 					 struct name##_iter *iter)	\

--- a/ccan/ccan/htable/test/run-type.c
+++ b/ccan/ccan/htable/test/run-type.c
@@ -116,7 +116,7 @@ int main(void)
 	void *p;
 	struct htable_obj_iter iter;
 
-	plan_tests(32);
+	plan_tests(35);
 	for (i = 0; i < NUM_VALS; i++)
 		val[i].key = i;
 	dne = i;
@@ -128,6 +128,7 @@ int main(void)
 
 	/* We cannot find an entry which doesn't exist. */
 	ok1(!htable_obj_get(&ht, &dne));
+	ok1(!htable_obj_pick(&ht, 0, NULL));
 
 	/* Fill it, it should increase in size. */
 	add_vals(&ht, val, NUM_VALS);
@@ -142,6 +143,8 @@ int main(void)
 	/* Find all. */
 	find_vals(&ht, val, NUM_VALS);
 	ok1(!htable_obj_get(&ht, &dne));
+	ok1(htable_obj_pick(&ht, 0, NULL));
+	ok1(htable_obj_pick(&ht, 0, &iter));
 
 	/* Walk once, should get them all. */
 	i = 0;

--- a/ccan/ccan/htable/test/run.c
+++ b/ccan/ccan/htable/test/run.c
@@ -105,7 +105,7 @@ int main(void)
 	void *p;
 	struct htable_iter iter;
 
-	plan_tests(38);
+	plan_tests(43);
 	for (i = 0; i < NUM_VALS; i++)
 		val[i] = i;
 	dne = i;
@@ -134,6 +134,12 @@ int main(void)
 	/* Mask should be set. */
 	ok1(check_mask(&ht, val, 1));
 
+	/* htable_pick should always return that value */
+	ok1(htable_pick(&ht, 0, NULL) == val);
+	ok1(htable_pick(&ht, 1, NULL) == val);
+	ok1(htable_pick(&ht, 0, &iter) == val);
+	ok1(get_raw_ptr(&ht, ht.table[iter.off]) == val);
+	
 	/* This should increase it again. */
 	add_vals(&ht, val, 1, 1);
 	ok1(ht.bits == 2);
@@ -210,6 +216,7 @@ int main(void)
 	htable_clear(&ht);
 
 	ok1(htable_count(&ht) == 0);
+	ok1(htable_pick(&ht, 0, NULL) == NULL);
 
 	return exit_status();
 }

--- a/ccan/ccan/tal/tal.h
+++ b/ccan/ccan/tal/tal.h
@@ -131,10 +131,11 @@ void *tal_free(const tal_t *p);
 /**
  * tal_steal - change the parent of a tal-allocated pointer.
  * @ctx: The new parent.
- * @ptr: The tal allocated object to move.
+ * @ptr: The tal allocated object to move, or NULL.
  *
  * This may need to perform an allocation, in which case it may fail; thus
- * it can return NULL, otherwise returns @ptr.
+ * it can return NULL, otherwise returns @ptr.  If @ptr is NULL, this function does
+ * nothing.
  */
 #if HAVE_STATEMENT_EXPR
 /* Weird macro avoids gcc's 'warning: value computed is not used'. */

--- a/ccan/tools/configurator/configurator.c
+++ b/ccan/tools/configurator/configurator.c
@@ -411,7 +411,7 @@ static const struct test base_tests[] = {
 	  "int main(int argc, char *argv[]) {\n"
 	  "	(void)argc;\n"
 	  "     char pad[sizeof(int *) * 1];\n"
-	  "	strncpy(pad, argv[0], sizeof(pad));\n"
+	  "	memcpy(pad, argv[0], sizeof(pad));\n"
 	  "	int *x = (int *)pad, *y = (int *)(pad + 1);\n"
 	  "	return *x == *y;\n"
 	  "}\n" },


### PR DESCRIPTION
Otherwise we get a configurator failure:

    In file included from /usr/include/string.h:495,
                     from configuratortest.c:2:
    In function ‘strncpy’,
        inlined from ‘main’ at configuratortest.c:6:2:
    /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound 8 equals destination size [-Wstringop-truncation]
      106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None