### PR TITLE
wire: locale-independent patch order for EXPERIMENTAL_FEATURES patches

### DIFF
--- a/wire/Makefile
+++ b/wire/Makefile
@@ -50,8 +50,8 @@ wire/extracted_onion_experimental_csv:
 	@touch $@
 
 ifeq ($(EXPERIMENTAL_FEATURES),1)
-EXPERIMENTAL_PEER_PATCHES := $(wildcard wire/extracted_peer_experimental_*)
-EXPERIMENTAL_ONION_PATCHES := $(wildcard wire/extracted_onion_experimental_*)
+EXPERIMENTAL_PEER_PATCHES := $(sort $(wildcard wire/extracted_peer_experimental_*))
+EXPERIMENTAL_ONION_PATCHES := $(sort $(wildcard wire/extracted_onion_experimental_*))
 
 wire/gen_peer_wire_csv: wire/extracted_peer_wire_csv $(EXPERIMENTAL_PEER_PATCHES)
 	@set -e; trap "rm -f $@.$$$$" 0; cp $< $@.$$$$; for exp in $(EXPERIMENTAL_PEER_PATCHES); do patch $@.$$$$ $$exp >/dev/null ; done; mv $@.$$$$ $@

--- a/wire/extracted_onion_experimental_badonion_blinding
+++ b/wire/extracted_onion_experimental_badonion_blinding
@@ -3,7 +3,7 @@ index 58f278f38..253a50012 100644
 --- a/wire/extracted_onion_wire_csv
 +++ b/wire/extracted_onion_wire_csv
 @@ -71,3 +71,4 @@ msgtype,invalid_onion_payload,PERM|22
- msgdata,invalid_onion_payload,type,varint,
+ msgdata,invalid_onion_payload,type,bigsize,
  msgdata,invalid_onion_payload,offset,u16,
  msgtype,mpp_timeout,23
 +msgtype,invalid_onion_blinding,BADONION|PERM|24


### PR DESCRIPTION
(cherry-picked from anchor-outputs, since it just hit me on my local machine)

Also, remove fuzz caused by varint->bigsize change.

For some reason my build machine sorts patches into another order, and fails
to patch:

	patching file wire/gen_onion_wire_csv.104951
	Hunk #1 succeeded at 52 with fuzz 1 (offset -19 lines).
	patching file wire/gen_onion_wire_csv.104951
	Hunk #1 FAILED at 8.
	1 out of 1 hunk FAILED -- saving rejects to file wire/gen_onion_wire_csv.104951.rej
	make: *** [wire/Makefile:60: wire/gen_onion_wire_csv] Error 1

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None