### PR TITLE
Misc externally-visible cleanups (nothing urgent)

### DIFF
--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -69,6 +69,7 @@ unrecoverable once pushed\.
 .SH RETURN VALUE
 
 On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well
+as the \fIoutnum\fR indicating the output index which creates the channel, as well
 as the \fIchannel_id\fR of the newly created channel\. On failure, an error
 is reported and the channel is not funded\.
 

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -64,6 +64,7 @@ RETURN VALUE
 ------------
 
 On success, the *tx* and *txid* of the transaction is returned, as well
+as the *outnum* indicating the output index which creates the channel, as well
 as the *channel\_id* of the newly created channel. On failure, an error
 is reported and the channel is not funded.
 

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -35,6 +35,8 @@ appended)
 .IP \[bu]
 \fIscriptpubkey\fR (the ScriptPubkey of the output, in hex)
 .IP \[bu]
+\fIredeemscript\fR (the redeemscript of the output, in hex, only if it's p2sh-wrapped)
+.IP \[bu]
 \fIstatus\fR (whether \fIunconfirmed\fR, \fIconfirmed\fR, or \fIspent\fR)
 .IP \[bu]
 \fIreserved\fR (whether this is UTXO is currently reserved for an in-flight tx)

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -28,6 +28,7 @@ Each entry in *outputs* will include:
     appended)
 -   *address*
 -   *scriptpubkey* (the ScriptPubkey of the output, in hex)
+-   *redeemscript* (the redeemscript of the output, in hex, only if it's p2sh-wrapped)
 -   *status* (whether *unconfirmed*, *confirmed*, or *spent*)
 -   *reserved* (whether this is UTXO is currently reserved for an in-flight tx)
 

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -83,7 +83,7 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 			txo = txowatch_hash_get(&topo->txowatches, &out);
 			if (txo) {
 				wallet_transaction_add(topo->ld->wallet,
-						       tx, b->height, i);
+						       tx->wtx, b->height, i);
 				txowatch_fire(txo, tx, j, b);
 			}
 		}
@@ -93,14 +93,14 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
 						     tx->wtx, &b->height, &owned);
-			wallet_transaction_add(topo->ld->wallet, tx, b->height,
-					       i);
+			wallet_transaction_add(topo->ld->wallet, tx->wtx,
+					       b->height, i);
 		}
 
 		/* We did spends first, in case that tells us to watch tx. */
 		if (watching_txid(topo, &txid) || we_broadcast(topo, &txid)) {
 			wallet_transaction_add(topo->ld->wallet,
-					       tx, b->height, i);
+					       tx->wtx, b->height, i);
 		}
 
 		txwatch_inform(topo, &txid, tx);
@@ -235,7 +235,7 @@ void broadcast_tx(struct chain_topology *topo,
 	log_debug(topo->log, "Broadcasting txid %s",
 		  type_to_string(tmpctx, struct bitcoin_txid, &otx->txid));
 
-	wallet_transaction_add(topo->ld->wallet, tx, 0, 0);
+	wallet_transaction_add(topo->ld->wallet, tx->wtx, 0, 0);
 	bitcoind_sendrawtx(topo->bitcoind, otx->hextx, broadcast_done, otx);
 }
 

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -229,7 +229,7 @@ static void handle_onchain_broadcast_tx(struct channel *channel, const u8 *msg)
 	tx->chainparams = chainparams;
 
 	bitcoin_txid(tx, &txid);
-	wallet_transaction_add(w, tx, 0, 0);
+	wallet_transaction_add(w, tx->wtx, 0, 0);
 	wallet_transaction_annotate(w, &txid, type, channel->dbid);
 
 	/* We don't really care if it fails, we'll respond via watch. */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -356,7 +356,7 @@ void drop_to_chain(struct lightningd *ld, struct channel *channel,
 	} else {
 		sign_last_tx(channel);
 		bitcoin_txid(channel->last_tx, &txid);
-		wallet_transaction_add(ld->wallet, channel->last_tx, 0, 0);
+		wallet_transaction_add(ld->wallet, channel->last_tx->wtx, 0, 0);
 		wallet_transaction_annotate(ld->wallet, &txid, channel->last_tx_type, channel->dbid);
 
 		/* Keep broadcasting until we say stop (can fail due to dup,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -620,7 +620,7 @@ void wallet_peer_delete(struct wallet *w UNNEEDED, u64 peer_dbid UNNEEDED)
 struct amount_msat wallet_total_forward_fees(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_total_forward_fees called!\n"); abort(); }
 /* Generated stub for wallet_transaction_add */
-void wallet_transaction_add(struct wallet *w UNNEEDED, const struct bitcoin_tx *tx UNNEEDED,
+void wallet_transaction_add(struct wallet *w UNNEEDED, const struct wally_tx *tx UNNEEDED,
 			    const u32 blockheight UNNEEDED, const u32 txindex UNNEEDED)
 { fprintf(stderr, "wallet_transaction_add called!\n"); abort(); }
 /* Generated stub for wallet_transaction_annotate */

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1211,13 +1211,16 @@ def test_bcli(node_factory, bitcoind, chainparams):
 
     l1.fundwallet(10**5)
     l1.connect(l2)
-    txid = l1.rpc.fundchannel(l2.info["id"], 10**4)["txid"]
-    txo = l1.rpc.call("getutxout", {"txid": txid, "vout": 0})
+    fc = l1.rpc.fundchannel(l2.info["id"], 10**4)
+    txo = l1.rpc.call("getutxout", {"txid": fc['txid'], "vout": fc['outnum']})
     assert (Millisatoshi(txo["amount"]) == Millisatoshi(10**4 * 10**3)
             and txo["script"].startswith("0020"))
     l1.rpc.close(l2.info["id"])
     # When output is spent, it should give us null !
-    wait_for(lambda: l1.rpc.call("getutxout", {"txid": txid, "vout": 0})['amount'] is None)
+    wait_for(lambda: l1.rpc.call("getutxout", {
+        "txid": fc['txid'],
+        "vout": fc['outnum']
+    })['amount'] is None)
 
     resp = l1.rpc.call("sendrawtransaction", {"tx": "dummy"})
     assert not resp["success"] and "decode failed" in resp["errmsg"]

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1440,9 +1440,9 @@ void db_bind_timeabs(struct db_stmt *stmt, int col, struct timeabs t)
 	db_bind_u64(stmt, col, timestamp);
 }
 
-void db_bind_tx(struct db_stmt *stmt, int col, const struct bitcoin_tx *tx)
+void db_bind_tx(struct db_stmt *stmt, int col, const struct wally_tx *tx)
 {
-	u8 *ser = linearize_tx(stmt, tx);
+	u8 *ser = linearize_wtx(stmt, tx);
 	assert(ser);
 	db_bind_blob(stmt, col, ser, tal_count(ser));
 }

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -118,7 +118,7 @@ void db_bind_short_channel_id_arr(struct db_stmt *stmt, int col,
 void db_bind_signature(struct db_stmt *stmt, int col,
 		       const secp256k1_ecdsa_signature *sig);
 void db_bind_timeabs(struct db_stmt *stmt, int col, struct timeabs t);
-void db_bind_tx(struct db_stmt *stmt, int col, const struct bitcoin_tx *tx);
+void db_bind_tx(struct db_stmt *stmt, int col, const struct wally_tx *tx);
 void db_bind_psbt(struct db_stmt *stmt, int col, const struct wally_psbt *psbt);
 void db_bind_amount_msat(struct db_stmt *stmt, int pos,
 			 const struct amount_msat *msat);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3380,14 +3380,14 @@ struct outpoint *wallet_outpoint_for_scid(struct wallet *w, tal_t *ctx,
 	return op;
 }
 
-void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
+void wallet_transaction_add(struct wallet *w, const struct wally_tx *tx,
 			    const u32 blockheight, const u32 txindex)
 {
 	struct bitcoin_txid txid;
 	struct db_stmt *stmt = db_prepare_v2(
 	    w->db, SQL("SELECT blockheight FROM transactions WHERE id=?"));
 
-	bitcoin_txid(tx, &txid);
+	wally_txid(tx, &txid);
 	db_bind_txid(stmt, 0, &txid);
 	db_query_prepared(stmt);
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1165,7 +1165,7 @@ void wallet_utxoset_add(struct wallet *w, const struct bitcoin_tx *tx,
 			const u32 txindex, const u8 *scriptpubkey,
 			struct amount_sat sat);
 
-void wallet_transaction_add(struct wallet *w, const struct bitcoin_tx *tx,
+void wallet_transaction_add(struct wallet *w, const struct wally_tx *tx,
 			    const u32 blockheight, const u32 txindex);
 
 void wallet_annotate_txout(struct wallet *w, const struct bitcoin_txid *txid,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -543,7 +543,7 @@ static struct command_result *json_txsend(struct command *cmd,
 	/* We're the owning cmd now. */
 	utx->wtx->cmd = cmd;
 
-	wallet_transaction_add(cmd->ld->wallet, utx->tx, 0, 0);
+	wallet_transaction_add(cmd->ld->wallet, utx->tx->wtx, 0, 0);
 	wallet_transaction_annotate(cmd->ld->wallet, &utx->txid,
 				    TX_UNKNOWN, 0);
 
@@ -610,7 +610,7 @@ static struct command_result *json_withdraw(struct command *cmd,
 		return res;
 
 	/* Store the transaction in the DB and annotate it as a withdrawal */
-	wallet_transaction_add(cmd->ld->wallet, utx->tx, 0, 0);
+	wallet_transaction_add(cmd->ld->wallet, utx->tx->wtx, 0, 0);
 	wallet_transaction_annotate(cmd->ld->wallet, &utx->txid,
 				    TX_WALLET_WITHDRAWAL, 0);
 
@@ -1309,6 +1309,7 @@ static struct command_result *json_sendpsbt(struct command *cmd,
 	struct wally_tx *w_tx;
 	struct tx_broadcast *txb;
 	struct utxo **utxos;
+	struct bitcoin_txid txid;
 
 	if (!param(cmd, buffer, params,
 		   p_req("psbt", param_psbt, &psbt),
@@ -1335,6 +1336,12 @@ static struct command_result *json_sendpsbt(struct command *cmd,
 	txb->wtx = tal_steal(txb, w_tx);
 	txb->cmd = cmd;
 	txb->expected_change = NULL;
+
+	/* FIXME: Do this *after* successful broadcast! */
+	wallet_transaction_add(cmd->ld->wallet, txb->wtx, 0, 0);
+	wally_txid(txb->wtx, &txid);
+	wallet_transaction_annotate(cmd->ld->wallet, &txid,
+				    TX_UNKNOWN, 0);
 
 	/* Now broadcast the transaction */
 	bitcoind_sendrawtx(cmd->ld->topology->bitcoind,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -868,6 +868,14 @@ static void json_add_utxo(struct json_stream *response,
 	json_add_amount_sat_compat(response, utxo->amount,
 				   "value", "amount_msat");
 
+	if (utxo->is_p2sh) {
+		struct pubkey key;
+		bip32_pubkey(wallet->bip32_base, &key, utxo->keyindex);
+
+		json_add_hex_talarr(response, "redeemscript",
+				    bitcoin_redeem_p2sh_p2wpkh(tmpctx, &key));
+	}
+
 	json_add_hex_talarr(response, "scriptpubkey", utxo->scriptPubkey);
 	out = encode_scriptpubkey_to_addr(tmpctx, chainparams,
 					  utxo->scriptPubkey);


### PR DESCRIPTION
(Based on #3843 see last 3 commits)

This adds some more info to our JSON outputs, and pushes transactions from sendpsbt into the wallet (otherwise they're not noticed, which confuses various tests once we port the other things onto it).

We could argue that *signpsbt* is where we should notify the wallet (and maybe, bump reservation on the inputs?), since they might not use *sendpsbt* through us, though we'll notice the tx when it's onchain.  @niftynei @cdecker  thoughts?