### PR TITLE
lightningd/invoice.c: Improve programmatic error reporting for `delinvoice`.

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -59,12 +59,14 @@ static const errcode_t CONNECT_ALL_ADDRESSES_FAILED = 401;
 /* bitcoin-cli plugin errors */
 #define BCLI_ERROR                      400
 
-/* Errors from `invoice` command */
+/* Errors from `invoice` or `delinvoice` commands */
 static const errcode_t INVOICE_LABEL_ALREADY_EXISTS = 900;
 static const errcode_t INVOICE_PREIMAGE_ALREADY_EXISTS = 901;
 static const errcode_t INVOICE_HINTS_GAVE_NO_ROUTES = 902;
 static const errcode_t INVOICE_EXPIRED_DURING_WAIT = 903;
 static const errcode_t INVOICE_WAIT_TIMED_OUT = 904;
+static const errcode_t INVOICE_NOT_FOUND = 905;
+static const errcode_t INVOICE_STATUS_UNEXPECTED = 906;
 
 /* Errors from HSM crypto operations. */
 static const errcode_t HSM_ECDH_FAILED = 800;

--- a/doc/lightning-delinvoice.7
+++ b/doc/lightning-delinvoice.7
@@ -19,6 +19,21 @@ The caller should be particularly aware of the error case caused by the
 On success, an invoice description will be returned as per
 \fBlightning-listinvoice\fR(7)\.
 
+.SH ERRORS
+
+The following errors may be reported:
+
+.RS
+.IP \[bu]
+-1:  Database error\.
+.IP \[bu]
+905:  An invoice with that label does not exist\.
+.IP \[bu]
+906:  The invoice \fIstatus\fR does not match the parameter\.
+An error object will be returned as error \fIdata\fR, containing
+\fIcurrent_status\fR and \fIexpected_status\fR fields\.
+
+.RE
 .SH AUTHOR
 
 Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.

--- a/doc/lightning-delinvoice.7.md
+++ b/doc/lightning-delinvoice.7.md
@@ -21,6 +21,19 @@ RETURN VALUE
 On success, an invoice description will be returned as per
 lightning-listinvoice(7).
 
+ERRORS
+------
+
+The following errors may be reported:
+
+- -1:  Database error.
+- 905:  An invoice with that label does not exist.
+- 906:  The invoice *status* does not match the parameter.
+  An error object will be returned as error *data*, containing
+  *current_status* and *expected_status* fields.
+  This is most likely due to the *status* of the invoice
+  changing just before this command is invoked.
+
 AUTHOR
 ------
 


### PR DESCRIPTION
Changelog-Changed: JSON-RPC: `delinvoice` will now report specific error codes 905 for failing to find the invoice, 906 for the invoice status not matching the parameter.