### PR TITLE
Add missing test dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 Flask==1.1.1
 Sphinx==1.8.4
+base58==1.0.2
+bitstring==3.1.6
 cheroot==8.2.1
+coincurve==13.0.0
 commonmark==0.8.1
+cryptography==2.8
 ephemeral-port-reserve==1.1.1
 flake8==3.7.8
 flaky==3.6.1


### PR DESCRIPTION
Supplements the consolidation in b68066e

Gets rid of complaints when running (on `v0.9.0rc2`)):

```sh
./configure --enable-developer
make
make check
```