### PR TITLE
More pytest optimizations

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -174,6 +174,7 @@ def teardown_checks(request):
 @pytest.fixture
 def node_factory(request, directory, test_name, bitcoind, executor, db_provider, teardown_checks, node_cls):
     nf = NodeFactory(
+        request,
         test_name,
         bitcoind,
         executor,

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1095,9 +1095,11 @@ class NodeFactory(object):
 
         bitcoind.generate_block(1)
         sync_blockheight(bitcoind, nodes)
+        txids = []
         for src, dst in connections:
-            tx = src.rpc.fundchannel(dst.info['id'], fundamount, announce=announce_channels)
-            wait_for(lambda: tx['txid'] in bitcoind.rpc.getrawmempool())
+            txids.append(src.rpc.fundchannel(dst.info['id'], fundamount, announce=announce_channels)['txid'])
+
+        wait_for(lambda: set(txids).issubset(set(bitcoind.rpc.getrawmempool())))
 
         # Confirm all channels and wait for them to become usable
         bitcoind.generate_block(1)

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -959,7 +959,11 @@ class LightningNode(object):
 class NodeFactory(object):
     """A factory to setup and start `lightningd` daemons.
     """
-    def __init__(self, testname, bitcoind, executor, directory, db_provider, node_cls):
+    def __init__(self, request, testname, bitcoind, executor, directory, db_provider, node_cls):
+        if request.node.get_closest_marker("slow_test") and SLOW_MACHINE:
+            self.valgrind = False
+        else:
+            self.valgrind = VALGRIND
         self.testname = testname
         self.next_id = 1
         self.nodes = []
@@ -969,7 +973,6 @@ class NodeFactory(object):
         self.lock = threading.Lock()
         self.db_provider = db_provider
         self.node_cls = node_cls
-        self.valgrind = VALGRIND
 
     def split_options(self, opts):
         """Split node options from cli options

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1094,8 +1094,8 @@ class NodeFactory(object):
             bitcoind.rpc.sendtoaddress(addr, (fundamount + 1000000) / 10**8)
 
         bitcoind.generate_block(1)
+        sync_blockheight(bitcoind, nodes)
         for src, dst in connections:
-            wait_for(lambda: len(src.rpc.listfunds()['outputs']) > 0)
             tx = src.rpc.fundchannel(dst.info['id'], fundamount, announce=announce_channels)
             wait_for(lambda: tx['txid'] in bitcoind.rpc.getrawmempool())
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1519,6 +1519,7 @@ def test_onchain_their_unilateral_out(node_factory, bitcoind):
 
     bitcoind.generate_block(5)
     l1.wait_channel_active(c12)
+    sync_blockheight(bitcoind, [l1, l2])
 
     route = l2.rpc.getroute(l1.info['id'], 10**8, 1)["route"]
     assert len(route) == 1
@@ -1545,8 +1546,8 @@ def test_onchain_their_unilateral_out(node_factory, bitcoind):
     l1.daemon.wait_for_log(' to ONCHAIN')
     l2.daemon.wait_for_log('THEIR_UNILATERAL/OUR_HTLC')
 
-    # l2 should wait til to_self_delay (6), then fulfill onchain
-    l1.bitcoin.generate_block(5)
+    # l2 should wait til to_self_delay (10), then fulfill onchain
+    l1.bitcoin.generate_block(9)
     l2.wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
                                    'THEIR_UNILATERAL/OUR_HTLC')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,8 +5,8 @@ from fixtures import TEST_NETWORK
 from flaky import flaky  # noqa: F401
 from pyln.client import RpcError, Millisatoshi
 from utils import (
-    DEVELOPER, only_one, wait_for, sync_blockheight, VALGRIND, TIMEOUT,
-    SLOW_MACHINE, expected_peer_features, expected_node_features,
+    DEVELOPER, only_one, wait_for, sync_blockheight, TIMEOUT,
+    expected_peer_features, expected_node_features,
     expected_channel_features,
     check_coin_moves, first_channel_id, account_balance
 )
@@ -140,6 +140,7 @@ def test_bad_opening(node_factory):
 
 @unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
 @unittest.skipIf(TEST_NETWORK != 'regtest', "Fee computation and limits are network specific")
+@pytest.mark.slow_test
 def test_opening_tiny_channel(node_factory):
     # Test custom min-capacity-sat parameters
     #
@@ -990,7 +991,7 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
 def test_funding_cancel_race(node_factory, bitcoind, executor):
     l1 = node_factory.get_node()
 
-    if VALGRIND or SLOW_MACHINE:
+    if node_factory.valgrind:
         num = 5
     else:
         num = 100
@@ -1051,7 +1052,7 @@ def test_funding_cancel_race(node_factory, bitcoind, executor):
     assert num_cancel == len(nodes)
 
     # We should have raced at least once!
-    if not VALGRIND:
+    if not node_factory.valgrind:
         assert num_cancel > 0
         assert num_complete > 0
 
@@ -1994,11 +1995,12 @@ def test_fulfill_incoming_first(node_factory, bitcoind):
 
 
 @unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
+@pytest.mark.slow_test
 def test_restart_many_payments(node_factory, bitcoind):
     l1 = node_factory.get_node(may_reconnect=True)
 
     # On my laptop, these take 89 seconds and 12 seconds
-    if VALGRIND:
+    if node_factory.valgrind:
         num = 2
     else:
         num = 5
@@ -2235,9 +2237,10 @@ def test_feerate_stress(node_factory, executor):
 
 
 @unittest.skipIf(not DEVELOPER, "need dev_disconnect")
+@pytest.mark.slow_test
 def test_pay_disconnect_stress(node_factory, executor):
     """Expose race in htlc restoration in channeld: 50% chance of failure"""
-    if SLOW_MACHINE and VALGRIND:
+    if node_factory.valgrind:
         NUM_RUNS = 2
     else:
         NUM_RUNS = 5

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -183,7 +183,8 @@ def test_invoice_routeboost(node_factory, bitcoind):
 def test_invoice_routeboost_private(node_factory, bitcoind):
     """Test routeboost 'r' hint in bolt11 invoice for private channels
     """
-    l1, l2 = node_factory.line_graph(2, fundamount=16777215, announce_channels=False)
+    l1, l2, l3 = node_factory.get_nodes(3)
+    node_factory.join_nodes([l1, l2], fundamount=16777215, announce_channels=False)
 
     scid = l1.get_channel_scid(l2)
 
@@ -245,7 +246,6 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
 
     # The existence of a public channel, even without capacity, will suppress
     # the exposure of private channels.
-    l3 = node_factory.get_node()
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
     scid2 = l3.fund_channel(l2, (10**5))
     bitcoind.generate_block(5)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2174,7 +2174,7 @@ def test_unix_socket_path_length(node_factory, bitcoind, directory, executor, db
     os.makedirs(lightning_dir)
     db = db_provider.get_db(lightning_dir, "test_unix_socket_path_length", 1)
 
-    l1 = LightningNode(1, lightning_dir, bitcoind, executor, db=db, port=node_factory.get_next_port())
+    l1 = LightningNode(1, lightning_dir, bitcoind, executor, VALGRIND, db=db, port=node_factory.get_next_port())
 
     # `LightningNode.start()` internally calls `LightningRpc.getinfo()` which
     # exercises the socket logic, and raises an issue if it fails.

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5,8 +5,8 @@ from flaky import flaky  # noqa: F401
 from pyln.client import RpcError, Millisatoshi
 from pyln.proto.onion import TlvPayload
 from utils import (
-    DEVELOPER, wait_for, only_one, sync_blockheight, SLOW_MACHINE, TIMEOUT,
-    VALGRIND, EXPERIMENTAL_FEATURES
+    DEVELOPER, wait_for, only_one, sync_blockheight, TIMEOUT,
+    EXPERIMENTAL_FEATURES
 )
 import copy
 import os
@@ -1303,7 +1303,8 @@ def test_forward_stats(node_factory, bitcoind):
     assert 'received_time' in stats['forwards'][2] and 'resolved_time' not in stats['forwards'][2]
 
 
-@unittest.skipIf(not DEVELOPER or (VALGRIND and SLOW_MACHINE), "Gossip too slow without DEVELOPER, and too stressful if VALGRIND on slow machines")
+@unittest.skipIf(not DEVELOPER, "too slow without --dev-fast-gossip")
+@pytest.mark.slow_test
 def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     """Check that we track forwarded payments correctly.
 
@@ -1522,7 +1523,8 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     assert 'received_time' in stats['forwards'][3] and 'resolved_time' not in stats['forwards'][4]
 
 
-@unittest.skipIf(not DEVELOPER or SLOW_MACHINE, "needs DEVELOPER=1 for dev_ignore_htlcs, and temporarily disabled on Travis")
+@unittest.skipIf(not DEVELOPER, "too slow without --dev-fast-gossip")
+@pytest.mark.slow_test
 def test_htlcs_cltv_only_difference(node_factory, bitcoind):
     # l1 -> l2 -> l3 -> l4
     # l4 ignores htlcs, so they stay.
@@ -1599,7 +1601,7 @@ def test_pay_variants(node_factory):
 
 
 @unittest.skipIf(not DEVELOPER, "gossip without DEVELOPER=1 is slow")
-@unittest.skipIf(VALGRIND and SLOW_MACHINE, "Travis times out under valgrind")
+@pytest.mark.slow_test
 def test_pay_retry(node_factory, bitcoind, executor, chainparams):
     """Make sure pay command retries properly. """
 
@@ -1683,7 +1685,7 @@ def test_pay_retry(node_factory, bitcoind, executor, chainparams):
 
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1 otherwise gossip takes 5 minutes!")
-@unittest.skipIf(VALGRIND, "temporarily disabled due to timeouts")
+@pytest.mark.slow_test
 def test_pay_routeboost(node_factory, bitcoind, compat):
     """Make sure we can use routeboost information. """
     # l1->l2->l3--private-->l4

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -789,13 +789,14 @@ def test_forward_event_notification(node_factory, bitcoind, executor):
     amount = 10**8
     disconnects = ['-WIRE_UPDATE_FAIL_HTLC', 'permfail']
 
-    l1, l2, l3 = node_factory.line_graph(3, opts=[
+    l1, l2, l3, l4, l5 = node_factory.get_nodes(5, opts=[
         {},
         {'plugin': os.path.join(os.getcwd(), 'tests/plugins/forward_payment_status.py')},
-        {}
-    ], wait_for_announce=True)
-    l4 = node_factory.get_node()
-    l5 = node_factory.get_node(disconnect=disconnects)
+        {},
+        {},
+        {'disconnect': disconnects}])
+
+    node_factory.join_nodes([l1, l2, l3], wait_for_announce=True)
     l2.openchannel(l4, 10**6, wait_for_announce=False)
     l2.openchannel(l5, 10**6, wait_for_announce=True)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -774,6 +774,9 @@ def test_channel_opened_notification(node_factory):
     amount = 10**6
     l1, l2 = node_factory.line_graph(2, fundchannel=True, fundamount=amount,
                                      opts=opts)
+
+    # Might have already passed, so reset start.
+    l2.daemon.logsearch_start = 0
     l2.daemon.wait_for_log(r"A channel was opened to us by {}, "
                            "with an amount of {}*"
                            .format(l1.info["id"], amount))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from pyln.testing.utils import TEST_NETWORK, SLOW_MACHINE, TIMEOUT, VALGRIND, DEVELOPER, DEPRECATED_APIS  # noqa: F401
+from pyln.testing.utils import TEST_NETWORK, TIMEOUT, VALGRIND, DEVELOPER, DEPRECATED_APIS  # noqa: F401
 from pyln.testing.utils import env, only_one, wait_for, write_config, TailableProc, sync_blockheight, wait_channel_quiescent, get_tx_p2wsh_outnum  # noqa: F401
 import bitstring
 from pyln.client import Millisatoshi


### PR DESCRIPTION
1. A flake fix for  test_restart_many_payments.
2. A flake fix for test_onchain_their_unilateral_out
3. Mass conversion to get_nodes() which batches, vs. individual get_node() calls.
4. Turn off valgrind for SLOW_MACHINE slow tests, rather than skipping them entirely.

Changelog-None