### PR TITLE
paymod: fix typo which can cause memory overrun.

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1756,7 +1756,7 @@ static bool routehint_excluded(struct payment *p,
 	 * are suggesting we use it the other way.  Very unlikely though! */
 	for (size_t i = 0; i < tal_count(routehint); i++) {
 		const struct route_info *r = &routehint[i];
-		for (size_t j=0; tal_count(nodes); j++)
+		for (size_t j = 0; j < tal_count(nodes); j++)
 			if (node_id_eq(&r->pubkey, &nodes[j]))
 			    return true;
 


### PR DESCRIPTION
Split out from #3866 since it was unrelated and needs to go in independently.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None
Closes #3866