### PR TITLE
Iterate through all the routehints in the specified

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1356,7 +1356,6 @@ static void payment_finished(struct payment *p)
 			json_add_hex_talarr(ret, "raw_message",
 					    result.failure->raw_message);
 			json_add_num(ret, "created_at", p->start_time.ts.tv_sec);
-			json_add_string(ret, "message", result.failure->message);
 			json_add_node_id(ret, "destination", p->destination);
 			json_add_sha256(ret, "payment_hash", p->payment_hash);
 

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -296,6 +296,11 @@ struct routehints_data {
 	/* Current routehint, if any. */
 	struct route_info *current_routehint;
 
+	/* Position of the current routehint in the routehints
+	 * array. Inherited and incremented on child payments and reset on
+	 * split. */
+	int offset;
+
 	/* We modify the CLTV in the getroute call, so we need to remember
 	 * what the final cltv delta was so we re-apply it correctly. */
 	u32 final_cltv;

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -255,6 +255,13 @@ struct payment {
 
 	/* Human readable explanation of why this payment failed. */
 	const char *failreason;
+
+	/* If a failed getroute call can be retried for this payment. Allows
+	 * us for example to signal to any retry modifier that we can retry
+	 * despite getroute not returning a usable route. This can be the case
+	 * if we switch any of the parameters such as destination or
+	 * amount. */
+	bool failroute_retry;
 };
 
 struct payment_modifier {

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -232,6 +232,9 @@ struct payment {
 	struct channel_hint *channel_hints;
 	struct node_id *excluded_nodes;
 
+	/* Optional temporarily excluded channel (i.e. this routehint) */
+	struct short_channel_id *temp_exclusion;
+
 	struct payment_result *result;
 
 	/* Did something happen that will cause all future attempts to fail?

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -299,6 +299,9 @@ struct routehints_data {
 	/* We modify the CLTV in the getroute call, so we need to remember
 	 * what the final cltv delta was so we re-apply it correctly. */
 	u32 final_cltv;
+
+	/* Is the destination reachable without any routehints? */
+	bool destination_reachable;
 };
 
 struct exemptfee_data {

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -106,10 +106,11 @@ def test_pay_limits(node_factory, compat):
     # It should have retried two more times (one without routehint and one with routehint)
     status = l1.rpc.call('paystatus', {'bolt11': inv['bolt11']})['pay'][0]['attempts']
 
-    # Will directly exclude channels and routehints that don't match our
-    # fee expectations. The first attempt notices that and terminates
-    # directly.
-    assert(len(status) == 1)
+    # We have an internal test to see if we can reach the destination directly
+    # without a routehint, that will enable a NULL-routehint. We will then try
+    # with the provided routehint, and the NULL routehint, resulting in 2
+    # attempts.
+    assert(len(status) == 2)
     assert(status[0]['failure']['code'] == 205)
 
     failmsg = r'CLTV delay exceeds our CLTV budget'
@@ -121,7 +122,7 @@ def test_pay_limits(node_factory, compat):
     # Should also have retried two more times.
     status = l1.rpc.call('paystatus', {'bolt11': inv['bolt11']})['pay'][1]['attempts']
 
-    assert(len(status) == 1)
+    assert(len(status) == 2)
     assert(status[0]['failure']['code'] == 205)
 
     # This works, because fee is less than exemptfee.


### PR DESCRIPTION
This PR re-establishes the old behavior of testing each routehint in the order they were specified, but keeps the routehints immutable, so each sub-payment decides whether to skip one or not:

 - The root payment performs an initial `getroute` test for 1sat to see if the destination could be reached directly, if that's the case it add a `NULL` routehint to the end of the routehint array. This way using or not using a routehint is handled identically.
 - Each payment has an offset internally that indexes into the root routehint array. When starting a new attempt it'll select the next working routehint by skipping the ones that might be known to fail due to a channel hint.
   - On retry the child payment increments the parent's offset by 1 and continues from there
   - On split the child payment reset the offset to 0, so it and its children iterate from the start, considering all routehints since the constraints have changed (amount has changed)
 - Since the retry mod has a circuit breaker that does not retry if the call to `getroute` failed we have to signal that we have more options to try before retries should terminate.

Since I was at it I also added a bit more debug information to see what is going on, and the tests finally work :+1:

Changelog-None