### PR TITLE
lightningd/chaintopology.h: Remove unused `txnums` field from `struct block`.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -840,7 +840,6 @@ static struct block *new_block(struct chain_topology *topo,
 
 	b->hdr = blk->hdr;
 
-	b->txnums = tal_arr(b, u32, 0);
 	b->full_txs = tal_steal(b, blk->tx);
 
 	return b;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -60,10 +60,7 @@ struct block {
 	/* Key for hash table */
 	struct bitcoin_blkid blkid;
 
-	/* And their associated index in the block */
-	u32 *txnums;
-
-	/* Full copy of txs (trimmed to txs list in connect_block) */
+	/* Full copy of txs (freed in filter_block_txs) */
 	struct bitcoin_tx **full_txs;
 };
 


### PR DESCRIPTION
Related to #3858

Code related to this field was last updated in 2017.  It is initialized to a pointless 0-length array, in code that was last touched in 2016.  No other code reads from it, writes to it, or even does something like extend the array.

Removing since I want to change the interface between `bcli` and `lightningd`, which implies that the `struct block` would actually be reported in JSON form by `bcli` to `lightningd`, and since `txnums` is unused anyway, we can remove it and simplify what we will eventually need from `bcli`.