### PR TITLE
A proposed solution to fix json null value for bolt11 key when is used the pay plugin

### DIFF
--- a/doc/lightning-sendonion.7
+++ b/doc/lightning-sendonion.7
@@ -3,7 +3,7 @@
 lightning-sendonion - Send a payment with a custom onion packet
 .SH SYNOPSIS
 
-\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR]
+\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR] [\fIpartid\fR] [\fIbolt11\fR]
 
 .SH DESCRIPTION
 
@@ -80,6 +80,14 @@ externally\. The following is an example of a 3 hop onion:
 If \fIshared_secrets\fR is not provided the c-lightning node does not know how
 long the route is, which channels or nodes are involved, and what an eventual
 error could have been\. It can therefore be used for oblivious payments\.
+
+
+The \fIpartid\fR value, if provided and non-zero, allows for multiple parallel
+partial payments with the same \fIpayment_hash\fR\.
+
+
+The \fIbolt11\fR parameter, if provided, will be returned in
+\fIwaitsendpay\fR and \fIlistsendpays\fR results\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -4,7 +4,7 @@ lightning-sendonion -- Send a payment with a custom onion packet
 SYNOPSIS
 --------
 
-**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\]
+**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\] \[*partid*\] \[*bolt11*\]
 
 DESCRIPTION
 -----------
@@ -71,6 +71,12 @@ externally. The following is an example of a 3 hop onion:
 If *shared_secrets* is not provided the c-lightning node does not know how
 long the route is, which channels or nodes are involved, and what an eventual
 error could have been. It can therefore be used for oblivious payments.
+
+The *partid* value, if provided and non-zero, allows for multiple parallel
+partial payments with the same *payment_hash*.
+
+The *bolt11* parameter, if provided, will be returned in
+*waitsendpay* and *listsendpays* results.
 
 RETURN VALUE
 ------------

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1183,7 +1183,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 	struct route_hop *first_hop;
 	struct sha256 *payment_hash;
 	struct lightningd *ld = cmd->ld;
-	const char *label;
+	const char *label, *b11str;
 	struct secret *path_secrets;
 	u64 *partid;
 
@@ -1194,6 +1194,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 		   p_opt("label", param_escaped_string, &label),
 		   p_opt("shared_secrets", param_secrets_array, &path_secrets),
 		   p_opt_def("partid", param_u64, &partid, 0),
+		   p_opt("bolt11", param_string, &b11str),
 		   NULL))
 		return command_param_failed();
 
@@ -1207,7 +1208,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 
 	return send_payment_core(ld, cmd, payment_hash, *partid,
 				 first_hop, AMOUNT_MSAT(0), AMOUNT_MSAT(0),
-				 label, NULL, &packet, NULL, NULL, NULL,
+				 label, b11str, &packet, NULL, NULL, NULL,
 				 path_secrets);
 }
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -28,6 +28,7 @@ struct payment *payment_new(tal_t *ctx, struct command *cmd,
 	p->route = NULL;
 	p->temp_exclusion = NULL;
 	p->failroute_retry = false;
+	p->bolt11 = NULL;
 
 	/* Copy over the relevant pieces of information. */
 	if (parent != NULL) {
@@ -1039,6 +1040,9 @@ static struct command_result *payment_createonion_success(struct command *cmd,
 
 	if (p->label)
 		json_add_string(req->js, "label", p->label);
+
+	if (p->bolt11)
+		json_add_string(req->js, "bolt11", p->bolt11);
 
 	send_outreq(p->plugin, req);
 	return command_still_pending(cmd);

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3195,7 +3195,6 @@ def test_pay_fail_unconfirmed_channel(node_factory, bitcoind):
     l1.rpc.pay(invl2)
 
 
-@pytest.mark.xfail(strict=True)    
 def test_bolt11_null_after_pay(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2)
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3193,3 +3193,27 @@ def test_pay_fail_unconfirmed_channel(node_factory, bitcoind):
 
     # Now l1 can pay to l2.
     l1.rpc.pay(invl2)
+
+
+@pytest.mark.xfail(strict=True)    
+def test_bolt11_null_after_pay(node_factory, bitcoind):
+    l1, l2 = node_factory.get_nodes(2)
+
+    amount_sat = 10 ** 6
+    # pay a generic bolt11 and test if the label bol11 is null
+    # inside the command listpays
+
+    # create l2->l1 channel.
+    l2.fundwallet(amount_sat * 5)
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l2.rpc.fundchannel(l1.info['id'], amount_sat * 3)
+
+    # Let the channel confirm.
+    bitcoind.generate_block(6)
+    sync_blockheight(bitcoind, [l1, l2])
+
+    invl1 = l1.rpc.invoice(Millisatoshi(amount_sat * 2 * 1000), 'j', 'j')['bolt11']
+    l2.rpc.pay(invl1)
+
+    pays = l2.rpc.listpays()["pays"]
+    assert pays[0]["bolt11"] == invl1


### PR DESCRIPTION
This PR proposed a solution to fix the problem mentioned at the following PR https://github.com/ElementsProject/lightning/pull/3876 

I can have some idea bug in my mind, so if this PR is wrong, I'm so sorry.

The json below is an example of use cases when I used the command keysend and pay (json_paymod).

```json
{
   "pays": [
      {
         "bolt11": "lnbcrt100n1p03chsnpp5n72j2e0ykwz7ue37e60qn623z9elq4fguv52ny7jjqmv990zajeqdql2pshjmt9de6zqamfw35zqurp09kk2eqxqyjw5qcqp2sp5h0renl745kd7c86z2g49lkuhua3j66an80szd58qdpeyzhdkrl3srzjqfnup6dhq3xls5v5pw0ksgrx0gcerqpr2pd6y6ckhstql6qfncta6qq24qqqqqgqqqqqqqqpqqqqqzsqqc9qy9qsqfy8e5x6aya75n3ayd5e8rsvkmepgq9gwf8v9ram560y5vlrapk9pwjxcfewfpvvnw97v49xzlce6zqmc5znv0ke6e3un5lm4hk8uewqq5dug0s",
         "status": "complete",
         "preimage": "c0c09fb65814b71f56c0a0faa9bf223b1d9667df90b55648a7c023e200c66b70",
         "amount_sent_msat": "10000msat"
      },
      {
         "bolt11": "(null)",
         "status": "failed",
         "label": "Pay with keysend",
         "amount_sent_msat": "0msat"
      },
      {
         "bolt11": "lnbcrt50n1p0s5zvvpp5ylm3y040va7wu08tjw7kegzq0ku2zqav99u6tzfdd7mh6w8elecsdpsg3jhvgz5v4ehggrwv4mjqunsvvsxxmmdd4skuepqw3jhxapnxqyjw5qcqp2sp5jxrwha4g0rjdxf3cs8gc9rqs5zunu3670v5mpppw0zajw7f4yrsq9qy9qsqf043ey32l952hq6rry34r9vugh2kdydr7hnuujpfadt5gxykguf5lsj8rczr7c3kpc6e0ldjw3r3nwehetwfd2f4djwtnjztjwzrnjqqaj8fg2",
         "status": "complete",
         "preimage": "391f288bc4425328742aafe26a01d02a07ce8b7420003aacd3ef4b2741284523",
         "amount_sent_msat": "5000msat"
      },
      {
         "bolt11": "(null)",
         "status": "complete",
         "label": "Pay with keysend",
         "preimage": "459906aba846e9f3ba6b0e67313bf2210c09e06319fe0bc991428310d1bb2eca",
         "amount_sent_msat": "10000msat"
      }
   ]
}
```