### PR TITLE
Annotate payments initiated using sendonion with the amount at the destination

### DIFF
--- a/doc/lightning-sendonion.7
+++ b/doc/lightning-sendonion.7
@@ -3,7 +3,7 @@
 lightning-sendonion - Send a payment with a custom onion packet
 .SH SYNOPSIS
 
-\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR] [\fIpartid\fR] [\fIbolt11\fR]
+\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR] [\fIpartid\fR] [\fIbolt11\fR] [\fImsatoshi\fR]
 
 .SH DESCRIPTION
 
@@ -88,6 +88,10 @@ partial payments with the same \fIpayment_hash\fR\.
 
 The \fIbolt11\fR parameter, if provided, will be returned in
 \fIwaitsendpay\fR and \fIlistsendpays\fR results\.
+
+
+The \fImsatoshi\fR parameter is used to annotate the payment, and is returned by
+\fIwaitsendpay\fR and \fIlistsendpays\fR\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -4,7 +4,7 @@ lightning-sendonion -- Send a payment with a custom onion packet
 SYNOPSIS
 --------
 
-**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\] \[*partid*\] \[*bolt11*\]
+**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\] \[*partid*\] \[*bolt11*\] \[*msatoshi*\]
 
 DESCRIPTION
 -----------
@@ -77,6 +77,9 @@ partial payments with the same *payment_hash*.
 
 The *bolt11* parameter, if provided, will be returned in
 *waitsendpay* and *listsendpays* results.
+
+The *msatoshi* parameter is used to annotate the payment, and is returned by
+*waitsendpay* and *listsendpays*.
 
 RETURN VALUE
 ------------

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1179,6 +1179,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 	struct lightningd *ld = cmd->ld;
 	const char *label, *b11str;
 	struct secret *path_secrets;
+	struct amount_msat *msat;
 	u64 *partid;
 
 	if (!param(cmd, buffer, params,
@@ -1189,6 +1190,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 		   p_opt("shared_secrets", param_secrets_array, &path_secrets),
 		   p_opt_def("partid", param_u64, &partid, 0),
 		   p_opt("bolt11", param_string, &b11str),
+		   p_opt_def("msatoshi", param_msat, &msat, AMOUNT_MSAT(0)),
 		   NULL))
 		return command_param_failed();
 
@@ -1201,7 +1203,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 				    failcode);
 
 	return send_payment_core(ld, cmd, payment_hash, *partid,
-				 first_hop, AMOUNT_MSAT(0), AMOUNT_MSAT(0),
+				 first_hop, *msat, AMOUNT_MSAT(0),
 				 label, b11str, &packet, NULL, NULL, NULL,
 				 path_secrets);
 }

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1029,6 +1029,7 @@ static struct command_result *payment_createonion_success(struct command *cmd,
 	json_object_end(req->js);
 
 	json_add_sha256(req->js, "payment_hash", p->payment_hash);
+	json_add_amount_msat_only(req->js, "msatoshi", p->amount);
 
 	json_array_start(req->js, "shared_secrets");
 	secrets = p->createonion_response->shared_secrets;

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3195,6 +3195,7 @@ def test_pay_fail_unconfirmed_channel(node_factory, bitcoind):
     l1.rpc.pay(invl2)
 
 
+@pytest.mark.xfail(strict=True)
 def test_bolt11_null_after_pay(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2)
 
@@ -3211,8 +3212,10 @@ def test_bolt11_null_after_pay(node_factory, bitcoind):
     bitcoind.generate_block(6)
     sync_blockheight(bitcoind, [l1, l2])
 
-    invl1 = l1.rpc.invoice(Millisatoshi(amount_sat * 2 * 1000), 'j', 'j')['bolt11']
+    amt = Millisatoshi(amount_sat * 2 * 1000)
+    invl1 = l1.rpc.invoice(amt, 'j', 'j')['bolt11']
     l2.rpc.pay(invl1)
 
     pays = l2.rpc.listpays()["pays"]
-    assert pays[0]["bolt11"] == invl1
+    assert(pays[0]["bolt11"] == invl1)
+    assert('amount_msat' in pays[0] and pays[0]['amount_msat'] == amt)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3195,7 +3195,6 @@ def test_pay_fail_unconfirmed_channel(node_factory, bitcoind):
     l1.rpc.pay(invl2)
 
 
-@pytest.mark.xfail(strict=True)
 def test_bolt11_null_after_pay(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2)
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2749,8 +2749,16 @@ static struct wallet_payment *wallet_stmt2payment(const tal_t *ctx,
 	else
 		payment->failonion = NULL;
 
-	db_column_amount_msat(stmt, 14, &payment->total_msat);
-	payment->partid = db_column_u64(stmt, 15);
+	if (!db_column_is_null(stmt, 14))
+		db_column_amount_msat(stmt, 14, &payment->total_msat);
+	else
+		payment->total_msat = AMOUNT_MSAT(0);
+
+	if (!db_column_is_null(stmt, 15))
+		payment->partid = db_column_u64(stmt, 15);
+	else
+		payment->partid = 0;
+
 	return payment;
 }
 


### PR DESCRIPTION
Since we use `sendonion` in the new payment flow we end up not knowing the amount received by the destination, only the amount we sent (which includes fees).

This PR adds an optional annotation that tells us what the intended amount to be sent is.

Notice that it is still possible to call `sendonion` without the annotation and readers calling `listpays` or `listsendpays` should fall back to the amount being sent if the amount at the destination is unknown. The amount_sent is always guaranteed to be known and set.

Closes https://github.com/shesek/spark-wallet/issues/146
Changelog-None