### PR TITLE
Update format response from listpay is the payment was did with keysend

### DIFF
--- a/doc/lightning-listpays.7
+++ b/doc/lightning-listpays.7
@@ -3,12 +3,12 @@
 lightning-listpays - Command for querying payment status
 .SH SYNOPSIS
 
-\fBlistpays\fR [bolt11]
+\fBlistpays\fR [bolt11] [payment_hash]
 
 .SH DESCRIPTION
 
 The \fBlistpay\fR RPC command gets the status of all \fIpay\fR commands, or a
-single one if \fIbolt11\fR is specified\.
+single one if either \fIbolt11\fR or \fIpayment_hash\fR was specified\.
 
 .SH RETURN VALUE
 
@@ -16,7 +16,11 @@ On success, an array of objects is returned\. Each object contains:
 
 
  \fIbolt11\fR
-the \fIbolt11\fR argument given to \fIpay\fR (see below for exceptions)\.
+the \fIbolt11\fR invoice if provided to \fBpay\fR\.
+
+
+ \fIpayment_hash\fR
+the \fIpayment_hash\fR of the payment\.
 
 
  \fIstatus\fR
@@ -24,11 +28,11 @@ one of \fIcomplete\fR, \fIfailed\fR or \fIpending\fR\.
 
 
  \fIpayment_preimage\fR
-(if \fIstatus\fR is \fIcomplete\fR) proves payment was received\.
+if \fIstatus\fR is \fIcomplete\fR\.
 
 
  \fIlabel\fR
-optional \fIlabel\fR, if provided to \fIpay\fR\.
+optional \fIlabel\fR, if provided to \fIpay\fR or \fIsendonion\fR\.
 
 
  \fIamount_sent_msat\fR

--- a/doc/lightning-listpays.7.md
+++ b/doc/lightning-listpays.7.md
@@ -4,13 +4,13 @@ lightning-listpays -- Command for querying payment status
 SYNOPSIS
 --------
 
-**listpays** \[bolt11\]
+**listpays** \[bolt11\] \[payment_hash\]
 
 DESCRIPTION
 -----------
 
 The **listpay** RPC command gets the status of all *pay* commands, or a
-single one if *bolt11* is specified.
+single one if either *bolt11* or *payment_hash* was specified.
 
 RETURN VALUE
 ------------
@@ -18,16 +18,19 @@ RETURN VALUE
 On success, an array of objects is returned. Each object contains:
 
  *bolt11*
-the *bolt11* argument given to *pay* (see below for exceptions).
+the *bolt11* invoice if provided to `pay`.
+
+ *payment_hash*
+the *payment_hash* of the payment.
 
  *status*
 one of *complete*, *failed* or *pending*.
 
  *payment\_preimage*
-(if *status* is *complete*) proves payment was received.
+if *status* is *complete*.
 
  *label*
-optional *label*, if provided to *pay*.
+optional *label*, if provided to *pay* or *sendonion*.
 
  *amount\_sent\_msat*
 total amount sent, in "NNNmsat" format.

--- a/doc/lightning-sendonion.7
+++ b/doc/lightning-sendonion.7
@@ -3,7 +3,8 @@
 lightning-sendonion - Send a payment with a custom onion packet
 .SH SYNOPSIS
 
-\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR] [\fIpartid\fR] [\fIbolt11\fR] [\fImsatoshi\fR]
+\fBsendonion\fR \fIonion\fR \fIfirst_hop\fR \fIpayment_hash\fR [\fIlabel\fR] [\fIshared_secrets\fR] [\fIpartid\fR] [\fIbolt11\fR]
+[\fIdestination\fR] [\fImsatoshi\fR]
 
 .SH DESCRIPTION
 
@@ -88,6 +89,9 @@ partial payments with the same \fIpayment_hash\fR\.
 
 The \fIbolt11\fR parameter, if provided, will be returned in
 \fIwaitsendpay\fR and \fIlistsendpays\fR results\.
+
+
+The \fIdestination\fR parameter, if provided, will be returned in \fBlistpays\fR result\.
 
 
 The \fImsatoshi\fR parameter is used to annotate the payment, and is returned by

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -4,7 +4,8 @@ lightning-sendonion -- Send a payment with a custom onion packet
 SYNOPSIS
 --------
 
-**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\] \[*partid*\] \[*bolt11*\] \[*msatoshi*\]
+**sendonion** *onion* *first_hop* *payment_hash* \[*label*\] \[*shared_secrets*\] \[*partid*\] \[*bolt11*\]
+\[*msatoshi*\] \[*destination*\]
 
 DESCRIPTION
 -----------
@@ -77,6 +78,8 @@ partial payments with the same *payment_hash*.
 
 The *bolt11* parameter, if provided, will be returned in
 *waitsendpay* and *listsendpays* results.
+
+The *destination* parameter, if provided, will be returned in **listpays** result.
 
 The *msatoshi* parameter is used to annotate the payment, and is returned by
 *waitsendpay* and *listsendpays*.

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1178,6 +1178,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 	struct sha256 *payment_hash;
 	struct lightningd *ld = cmd->ld;
 	const char *label, *b11str;
+	struct node_id *destination;
 	struct secret *path_secrets;
 	struct amount_msat *msat;
 	u64 *partid;
@@ -1191,6 +1192,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 		   p_opt_def("partid", param_u64, &partid, 0),
 		   p_opt("bolt11", param_string, &b11str),
 		   p_opt_def("msatoshi", param_msat, &msat, AMOUNT_MSAT(0)),
+		   p_opt("destination", param_node_id, &destination),
 		   NULL))
 		return command_param_failed();
 
@@ -1204,7 +1206,7 @@ static struct command_result *json_sendonion(struct command *cmd,
 
 	return send_payment_core(ld, cmd, payment_hash, *partid,
 				 first_hop, *msat, AMOUNT_MSAT(0),
-				 label, b11str, &packet, NULL, NULL, NULL,
+				 label, b11str, &packet, destination, NULL, NULL,
 				 path_secrets);
 }
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1041,6 +1041,9 @@ static struct command_result *payment_createonion_success(struct command *cmd,
 	if (p->bolt11)
 		json_add_string(req->js, "bolt11", p->bolt11);
 
+	if (p->destination)
+		json_add_node_id(req->js, "destination", p->destination);
+
 	send_outreq(p->plugin, req);
 	return command_still_pending(cmd);
 }

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1736,7 +1736,10 @@ static void add_new_entry(struct json_stream *ret,
 			  const struct pay_mpp *pm)
 {
 	json_object_start(ret, NULL);
-	json_add_string(ret, "bolt11", pm->b11);
+	if (pm->b11)
+		json_add_string(ret, "bolt11", pm->b11);
+
+	json_add_sha256(ret, "payment_hash", pm->payment_hash);
 	json_add_string(ret, "status", pm->status);
 	json_add_u32(ret, "created_at", pm->timestamp);
 
@@ -1854,11 +1857,13 @@ static struct command_result *json_listpays(struct command *cmd,
 					    const jsmntok_t *params)
 {
 	const char *b11str;
+	struct sha256 *payment_hash;
 	struct out_req *req;
 
 	/* FIXME: would be nice to parse as a bolt11 so check worked in future */
 	if (!param(cmd, buf, params,
 		   p_opt("bolt11", param_string, &b11str),
+		   p_opt("payment_hash", param_sha256, &payment_hash),
 		   NULL))
 		return command_param_failed();
 
@@ -1867,6 +1872,9 @@ static struct command_result *json_listpays(struct command *cmd,
 				    cast_const(char *, b11str));
 	if (b11str)
 		json_add_string(req->js, "bolt11", b11str);
+
+	if (payment_hash)
+		json_add_sha256(req->js, "payment_hash", payment_hash);
 	return send_outreq(cmd->plugin, req);
 }
 
@@ -2054,7 +2062,7 @@ static const struct plugin_command commands[] = {
 	}, {
 		"listpays",
 		"payment",
-		"List result of payment {bolt11}, or all",
+		"List result of payment {bolt11} or {payment_hash}, or all",
 		"Covers old payments (failed and succeeded) and current ones.",
 		json_listpays
 	},

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3261,6 +3261,8 @@ def test_listpay_result_with_paymod(node_factory, bitcoind):
     l2.rpc.keysend(l3.info['id'], amount_sat * 2, "keysend_l3")
 
     assert 'bolt11' in l1.rpc.listpays()['pays'][0]
+    assert 'bolt11' not in l2.rpc.listpays()['pays'][0]
     assert 'payment_hash' in l2.rpc.listpays()['pays'][0]
     assert 'payment_hash' in l1.rpc.listpays()['pays'][0]
-    assert 'bolt11' not in l2.rpc.listpays()['pays'][0]
+    assert 'destination' in l1.rpc.listpays()['pays'][0]
+    assert 'destination' in l2.rpc.listpays()['pays'][0]


### PR DESCRIPTION
Hi all.

This PR proposes an update to the response of the `listpay` command, discussed inside [this issue](https://github.com/ElementsProject/lightning/issues/3880). In particular, the `listpays` could return a `bolt11: (null)` propriety if the payment was made with `keysend` or if the payment was didi during the [rc3 bug](https://github.com/ElementsProject/lightning/pull/3878).

In addition, this PR proposes the change inside the parameters accepted by `listpay`. In fact, the command could lose the meaning if I want to use `listpay` to filter the payment that I made with `keysend`. In other words, I can not require with `listpays` a single payment if it is made with `keysend`.

## Examples

### keysend payment

```json
{
      "payment_hash": "7cdf931c7a23efb6815ff239517ef6d373bb8d040caefba96314368afd93252d",
      "status": "complete",
      "preimage": "9a4f8576e0380394ab791b35e08793533b7d1d3303c383d91fda14a13978e7db",
      "amount_sent_msat": "1000msat"
  },
```

### invoice payment

```json
      {
         "bolt11": "lntb10n1p03cskapp5f730rvqpqelvqmtljkuxjku2ek00qnqmf5g3pcaefc06q6rmk8sqdp9ve5hsatsta3x7mr5xyckuatvd30hgam9d3mx2xqyjw5qcqp2sp5nh2swvkuup2qrekvlmstswh8kdjjh7chyuelp7sgy0hvtz9dzhqqrzjqdsdeghn2vmdxqmy8flmzu46vxzmjzr258aavp36z3rs2redmg8cwxe0fyqqq2qqqqqqqqqpqqqqqzsqqc9qy9qsqu7l2057sh8zvpw56ftu87semua2a6a4ftjscvvfewz0gj92dsylx7whv30heqy0zr6jy6udtad57m93q3pmyezfcf4pntjqstks0v5qpedegh0",
         "status": "complete",
         "preimage": "7516ea2e790e5e8edb02709682e445d38aea07c7e772db9441b5091908d19c23",
         "amount_sent_msat": "1000msat"
      }
```

In addition, I see inside the format description of the documentation, that reported an old description for the old payment. I think that this description could be removed or ~signed~.

P.S: Maybe, in this PR the signature `Changelog-None` is not correct?

## Update

After a first review, the response format is changed, now the `payment_hash` is printed every time and the bolt11 is printed only if the value is not `null`