### PR TITLE
Explictly check at startup that we don't support `bitcoind`'s `blocksonly` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Don't hesitate to reach out to us on IRC at [#lightning-dev @ freenode.net][irc1
 
 ## Getting Started
 
-c-lightning only works on Linux and Mac OS, and requires a locally (or remotely) running `bitcoind` (version 0.16 or above) that is fully caught up with the network you're testing on.
+c-lightning only works on Linux and Mac OS, and requires a locally (or remotely) running `bitcoind` (version 0.16 or above) that is fully caught up with the network you're running on, and relays transactions (ie with `blocksonly=0`).
 Pruning (`prune=n` option in `bitcoin.conf`) is partially supported, see [here](#pruning) for more details.
 
 ### Installation

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1026,8 +1026,8 @@ class NodeFactory(object):
 
     def get_node(self, node_id=None, options=None, dbfile=None,
                  feerates=(15000, 11000, 7500, 3750), start=True,
-                 wait_for_bitcoind_sync=True, expect_fail=False,
-                 cleandir=True, **kwargs):
+                 wait_for_bitcoind_sync=True, may_fail=False,
+                 expect_fail=False, cleandir=True, **kwargs):
 
         node_id = self.get_node_id() if not node_id else node_id
         port = self.get_next_port()
@@ -1043,7 +1043,8 @@ class NodeFactory(object):
         db = self.db_provider.get_db(os.path.join(lightning_dir, TEST_NETWORK), self.testname, node_id)
         node = self.node_cls(
             node_id, lightning_dir, self.bitcoind, self.executor, db=db,
-            port=port, options=options, **kwargs
+            port=port, options=options, may_fail=may_fail or expect_fail,
+            **kwargs
         )
 
         # Regtest estimatefee are unusable, so override.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -128,6 +128,18 @@ def test_bitcoin_failure(node_factory, bitcoind):
     bitcoind.generate_block(5)
     sync_blockheight(bitcoind, [l1])
 
+    # We refuse to start if bitcoind is in `blocksonly`
+    l1.stop()
+    bitcoind.stop()
+    bitcoind.cmd_line += ["-blocksonly"]
+    bitcoind.start()
+
+    l2 = node_factory.get_node(start=False, expect_fail=True)
+    with pytest.raises(ValueError):
+        l2.start(stderr=subprocess.PIPE)
+    assert l2.daemon.is_in_stderr(r".*deactivating transaction relay is not"
+                                  " supported.") is not None
+
 
 def test_bitcoin_ibd(node_factory, bitcoind):
     """Test that we recognize bitcoin in initial download mode"""


### PR DESCRIPTION
This adds a sanity check function to `bcli` which we could extend with other sanity checks in the future.

This was [brought up](https://github.com/ElementsProject/lightning/issues/3858#issuecomment-665619664) by @ZmnSCPxj.