### PR TITLE
plugins/libplugin-pay.c: Properly handle exclusions for routehints with two hops or more.

### DIFF
--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -232,8 +232,8 @@ struct payment {
 	struct channel_hint *channel_hints;
 	struct node_id *excluded_nodes;
 
-	/* Optional temporarily excluded channel (i.e. this routehint) */
-	struct short_channel_id *temp_exclusion;
+	/* Optional temporarily excluded channels/nodes (i.e. this routehint) */
+	const char **temp_exclusion;
 
 	struct payment_result *result;
 


### PR DESCRIPTION

Arguably a low-priority bug since no current node ever generates routehints longer
than one hop.

However, it is possible as an edge case, if the destination is directly accessible
*and* supports multiple channels, that we route through the destination, one of the
*other* channels it has not in the routehint, to the entry point, and then through
the routehint.

This change removes the risk of the above edge case.

Changelog-None: arguably a low-priority bug.