### PR TITLE
channel: Base the channel forget timeout on the headercount

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -932,6 +932,15 @@ u32 get_block_height(const struct chain_topology *topo)
 	return topo->tip->height;
 }
 
+u32 get_network_blockheight(const struct chain_topology *topo)
+{
+	if (topo->tip->height > topo->headercount)
+		return topo->tip->height;
+	else
+		return topo->headercount;
+}
+
+
 u32 try_get_feerate(const struct chain_topology *topo, enum feerate feerate)
 {
 	return topo->feerate[feerate];
@@ -1068,6 +1077,8 @@ check_chain(struct bitcoind *bitcoind, const char *chain,
 	if (!streq(chain, chainparams->bip70_name))
 		fatal("Wrong network! Our Bitcoin backend is running on '%s',"
 		      " but we expect '%s'.", chain, chainparams->bip70_name);
+
+	topo->headercount = headercount;
 
 	if (first_call) {
 		/* Has the Bitcoin backend gone backward ? */

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -123,6 +123,10 @@ struct chain_topology {
 	/* Transactions/txos we are watching. */
 	struct txwatch_hash txwatches;
 	struct txowatch_hash txowatches;
+
+	/* The number of headers known to the bitcoin backend at startup. Not
+	 * updated after the initial check. */
+	u32 headercount;
 };
 
 /* Information relevant to locating a TX in a blockchain. */
@@ -142,6 +146,13 @@ size_t get_tx_depth(const struct chain_topology *topo,
 
 /* Get highest block number. */
 u32 get_block_height(const struct chain_topology *topo);
+
+/* Get the highest block number in the network that we are aware of. Unlike
+ * `get_block_height` this takes into consideration the block header counter
+ * in the bitcoin backend as well. If an absolute time is required, rather
+ * than our current scan position this is preferable since it is far less
+ * likely to lag behind the rest of the network.*/
+u32 get_network_blockheight(const struct chain_topology *topo);
 
 /* Get fee rate in satoshi per kiloweight, or 0 if unavailable! */
 u32 try_get_feerate(const struct chain_topology *topo, enum feerate feerate);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -265,7 +265,7 @@ wallet_commit_channel(struct lightningd *ld,
 			      NULL, /* No commit sent yet */
 			      /* If we're fundee, could be a little before this
 			       * in theory, but it's only used for timing out. */
-			      get_block_height(ld->topology),
+			      get_network_blockheight(ld->topology),
 			      feerate, feerate,
 			      /* We are connected */
 			      true,


### PR DESCRIPTION
We were basing the 2016 block timeout on the blockchain height that we had
processed at the time completed the funding, which could lag considerably
behind the network-wide blockheight. For example this could happen if we
started with `--rescan` from a low height, taking some time to catch up.

This means that we could end up forgetting channels even before reaching the
network blockheight. This patch instead uses the headercount reported by the
backend plugin if we aren't caught up yet. While the chances of this happening
are still there, the window it might happen are much reduced, since headers
can be synced in a couple of minutes.