### PR TITLE
Makefile: Remove gen_version.h from ALL_GEN_HEADERS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,6 @@ CCAN_HEADERS :=						\
 	$(CCANDIR)/ccan/typesafe_cb/typesafe_cb.h	\
 	$(CCANDIR)/ccan/utf8/utf8.h
 
-ALL_GEN_HEADERS += gen_version.h
-
 CDUMP_OBJS := ccan-cdump.o ccan-strmap.o
 
 BOLT_GEN := tools/generate-wire.py

--- a/common/Makefile
+++ b/common/Makefile
@@ -96,6 +96,9 @@ COMMON_OBJS := $(COMMON_SRC:.c=.o)
 # Common objects depends on bitcoin/ external/ and ccan
 $(COMMON_OBJS): $(CCAN_HEADERS) $(BITCOIN_HEADERS) $(EXTERNAL_HEADERS) $(COMMON_HEADERS_GEN)
 
+# Only common/version.c can include this header.
+common/version.o: gen_version.h
+
 ALL_GEN_HEADERS += $(COMMON_HEADERS_GEN)
 ALL_OBJS += $(COMMON_OBJS)
 

--- a/common/version.c
+++ b/common/version.c
@@ -1,6 +1,8 @@
-#include "gen_version.h"
 #include "version.h"
 #include <stdio.h>
+
+/* Only common/version.c can safely include this.  */
+# include "gen_version.h"
 
 const char *version(void)
 {


### PR DESCRIPTION
This prevents recompiling everything when you are changing just a doc, or
touching only one file among hundreds of sources, just because the
`gen_version.h` is changed, especially since only one source actually
depends on that header.