### PR TITLE
pay: Add timestamp of first part to `listpays`

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3221,6 +3221,7 @@ def test_bolt11_null_after_pay(node_factory, bitcoind):
     pays = l2.rpc.listpays()["pays"]
     assert(pays[0]["bolt11"] == invl1)
     assert('amount_msat' in pays[0] and pays[0]['amount_msat'] == amt)
+    assert('created_at' in pays[0])
 
 
 def test_mpp_presplit_routehint_conflict(node_factory, bitcoind):


### PR DESCRIPTION
Reported-By: Nadav Ivgi <@shesek>
Changelog-Added: JSON-RPC: The result returned by `listpays` now includes the timestamp of the first part of the payment