### PR TITLE
plugin: don't mark all plugins as important when registering one

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -154,9 +154,6 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES,
 		if (streq(path, p_temp->cmd)) {
 			if (taken(path))
 				tal_free(path);
-		 	/* If added as "important", upgrade to "important".  */
-			if (important)
-				p_temp->important = true;
 			return NULL;
 		}
 	}


### PR DESCRIPTION
I skimmed through #3890 after merge and i think this is wrong as it would mark some or all of the already registered plugins as important when we register a new important plugin.

This follows the discussion with @ZmnSCPxj here https://github.com/ElementsProject/lightning/pull/3890/files#r466741870.