### PR TITLE
Invoice round robin

### DIFF
--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -110,6 +110,8 @@ static void destroy_channel(struct channel *channel)
 	channel_set_owner(channel, NULL);
 
 	list_del_from(&channel->peer->channels, &channel->list);
+
+	list_del(&channel->rr_list);
 }
 
 void delete_channel(struct channel *channel STEALS)
@@ -275,6 +277,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->forgets = tal_arr(channel, struct command *, 0);
 
 	list_add_tail(&peer->channels, &channel->list);
+	list_add_tail(&peer->ld->rr_channels, &channel->rr_list);
 	tal_add_destructor(channel, destroy_channel);
 
 	/* Make sure we see any spends using this key */

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -136,6 +136,9 @@ struct channel {
 
 	/* Any commands trying to forget us. */
 	struct command **forgets;
+
+	/* Our position in the round-robin list.  */
+	struct list_node rr_list;
 };
 
 struct channel *new_channel(struct peer *peer, u64 dbid,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -285,6 +285,11 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 */
 	ld->exit_code = NULL;
 
+	/*~ We maintain a round-robin list of channels.
+	 * This round-robin list of channels is used to ensure that
+	 * each invoice we generate has a different set of channels.  */
+	list_head_init(&ld->rr_channels);
+
 	return ld;
 }
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -274,6 +274,9 @@ struct lightningd {
 
 	/* If non-NULL, contains the exit code to use.  */
 	int *exit_code;
+
+	/* The round-robin list of channels, for use when doing MPP.  */
+	struct list_head rr_channels;
 };
 
 /* Turning this on allows a tal allocation to return NULL, rather than aborting.

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -306,16 +306,26 @@ struct routehints_data {
 	/* What we did about routehints (if anything) */
 	const char *routehint_modifications;
 
-	/* Any remaining routehints to try. */
+	/* Array of routehints to try. */
 	struct route_info **routehints;
 
 	/* Current routehint, if any. */
 	struct route_info *current_routehint;
 
 	/* Position of the current routehint in the routehints
-	 * array. Inherited and incremented on child payments and reset on
-	 * split. */
+	 * array. Inherited on retry (and possibly incremented),
+	 * reset to 0 on split. */
 	int offset;
+	/* Base of the current routehint.
+	 * This is randomized to start routehints at a random point
+	 * on each split, to reduce the chances of multiple splits
+	 * going to the same routehint.
+	 * The sum of base + offset is used as the index into the
+	 * routehints array (wraps around).
+	 * offset is used to determine if we have run out of
+	 * routehints, base is used for randomization.
+	 */
+	int base;
 
 	/* We modify the CLTV in the getroute call, so we need to remember
 	 * what the final cltv delta was so we re-apply it correctly. */

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -172,7 +172,7 @@ def test_invoice_routeboost(node_factory, bitcoind):
     # Due to reserve & fees, l1 doesn't have capacity to pay this.
     inv = l2.rpc.invoice(msatoshi=2 * (10**8) - 123456, label="inv2", description="?")
     # Check warning
-    assert 'warning_capacity' in inv
+    assert 'warning_capacity' in inv or 'warning_mpp_capacity' in inv
     assert 'warning_offline' not in inv
     assert 'warning_deadends' not in inv
 
@@ -233,7 +233,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
 
     # If we explicitly say not to, it won't expose.
     inv = l2.rpc.invoice(msatoshi=123456, label="inv1", description="?", exposeprivatechannels=False)
-    assert 'warning_capacity' in inv
+    assert 'warning_capacity' in inv or 'warning_mpp_capacity' in inv
     assert 'warning_offline' not in inv
     assert 'warning_deadends' not in inv
     assert 'routes' not in l1.rpc.decodepay(inv['bolt11'])
@@ -306,7 +306,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # Ask it explicitly to use a channel it can't (insufficient capacity)
     inv = l2.rpc.invoice(msatoshi=(10**5) * 1000 + 1, label="inv5", description="?", exposeprivatechannels=scid2)
     assert 'warning_deadends' not in inv
-    assert 'warning_capacity' in inv
+    assert 'warning_capacity' in inv or 'warning_mpp_capacity' in inv
     assert 'warning_offline' not in inv
 
     # Give it two options and it will pick one with suff capacity.

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3378,7 +3378,7 @@ def test_mpp_waitblockheight_routehint_conflict(node_factory, bitcoind, executor
 @unittest.skipIf(VALGRIND, "runs 7 nodes")
 @unittest.skipIf(not DEVELOPER, "channel setup very slow (~10 minutes) if not DEVELOPER")
 @pytest.mark.slow_test
-@pytest.mark.xfail(strict=True)
+@flaky
 def test_mpp_interference_2(node_factory, bitcoind, executor):
     '''
     We create a "public network" that looks like so.

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1498,6 +1498,7 @@ int main(int argc, const char *argv[])
 
 	/* Only elements in ld we should access */
 	list_head_init(&ld->peers);
+	list_head_init(&ld->rr_channels);
 	node_id_from_hexstr("02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66, &ld->id);
 	/* Accessed in peer destructor sanity check */
 	htlc_in_map_init(&ld->htlcs_in);


### PR DESCRIPTION
This implements part of my suggestions in #3894.

The drawback is that unpublished nodes with this commit could potentially be harder to pay by other implementations that do not have any MPP at all yet.

This change basically embraces MPP and holds onto it tight and whispers lovingly into its ears "I want the whole world to have MPP".  On the other hand it does show that our MPP impl seems to be working nicely enough.

It was implementing this that revealed #3908 , if you are curious.  Yet another reason to abolish unpublished channels....

There is yet another bug in our MPP that this code also reveals, which is basically that if we get a blockheight disagreement between payee and payer, we are too aggressive with advancing the routehint pointer.  I will make a new test and fix for that latent bug.