### PR TITLE
Waitblockheight MPP bugs

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -384,6 +384,7 @@ static struct command_result *payment_getroute_result(struct command *cmd,
 	/* Ensure that our fee and CLTV budgets are respected. */
 	if (amount_msat_greater(fee, p->constraints.fee_budget)) {
 		payment_exclude_most_expensive(p);
+		p->route = tal_free(p->route);
 		payment_fail(
 		    p, "Fee exceeds our fee budget: %s > %s, discarding route",
 		    type_to_string(tmpctx, struct amount_msat, &fee),
@@ -393,9 +394,11 @@ static struct command_result *payment_getroute_result(struct command *cmd,
 	}
 
 	if (p->route[0].delay > p->constraints.cltv_budget) {
+		u32 delay = p->route[0].delay;
 		payment_exclude_longest_delay(p);
+		p->route = tal_free(p->route);
 		payment_fail(p, "CLTV delay exceeds our CLTV budget: %d > %d",
-			     p->route[0].delay, p->constraints.cltv_budget);
+			     delay, p->constraints.cltv_budget);
 		return command_still_pending(cmd);
 	}
 
@@ -1760,12 +1763,17 @@ static struct route_info **filter_routehints(struct routehints_data *d,
 	return tal_steal(d, hints);
 }
 
+static bool route_msatoshi(struct amount_msat *total,
+			   const struct amount_msat msat,
+			   const struct route_info *route, size_t num_route);
+
 static bool routehint_excluded(struct payment *p,
 			       const struct route_info *routehint)
 {
 	const struct node_id *nodes = payment_get_excluded_nodes(tmpctx, p);
 	const struct short_channel_id_dir *chans =
 	    payment_get_excluded_channels(tmpctx, p);
+	const struct channel_hint *hints = payment_root(p)->channel_hints;
 
 	/* Note that we ignore direction here: in theory, we could have
 	 * found that one direction of a channel is unavailable, but they
@@ -1779,6 +1787,41 @@ static bool routehint_excluded(struct payment *p,
 		for (size_t j = 0; j < tal_count(chans); j++)
 			if (short_channel_id_eq(&chans[j].scid, &r->short_channel_id))
 				return true;
+
+		/* Skip the capacity check if this is the last hop
+		 * in the routehint.
+		 * The last hop in the routehint delivers the exact
+		 * final amount to the destination, which
+		 * payment_get_excluded_channels uses for excluding
+		 * already.
+		 * Thus, the capacity check below only really matters
+		 * for multi-hop routehints.
+		 */
+		if (i == tal_count(routehint) - 1)
+			continue;
+
+		/* Check our capacity fits.  */
+		struct amount_msat needed_capacity;
+		if (!route_msatoshi(&needed_capacity, p->amount,
+				    r + 1, tal_count(routehint) - i - 1))
+			return true;
+		/* Why do we scan the hints again if
+		 * payment_get_excluded_channels already does?
+		 * Because payment_get_excluded_channels checks the
+		 * amount at destination, but we know that we are
+		 * a specific distance from the destination and we
+		 * know the exact capacity we need to send via this
+		 * channel, which is greater than the destination.
+		 */
+		for (size_t j = 0; j < tal_count(hints); j++) {
+			if (!short_channel_id_eq(&hints[j].scid.scid, &r->short_channel_id))
+				continue;
+			/* We exclude on equality because we set the estimate
+			 * to the smallest failed attempt.  */
+			if (amount_msat_greater_eq(needed_capacity,
+						   hints[j].estimated_capacity))
+				return true;
+		}
 	}
 	return false;
 }
@@ -2044,9 +2087,14 @@ static struct routehints_data *routehint_data_init(struct payment *p)
 		pd = payment_mod_routehints_get_data(payment_root(p));
 		d->destination_reachable = pd->destination_reachable;
 		d->routehints = pd->routehints;
-		if (p->parent->step == PAYMENT_STEP_RETRY)
-			d->offset = pd->offset + 1;
-		else
+		pd = payment_mod_routehints_get_data(p->parent);
+		if (p->parent->step == PAYMENT_STEP_RETRY) {
+			d->offset = pd->offset;
+			/* If the previous try failed to route, advance
+			 * to the next routehint.  */
+			if (!p->parent->route)
+				++d->offset;
+		} else
 			d->offset = 0;
 		return d;
 	} else {

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -721,12 +721,50 @@ static void report_tampering(struct payment *p,
 	}
 }
 
+static bool
+failure_is_blockheight_disagreement(const struct payment *p,
+				    u32 *blockheight)
+{
+	struct amount_msat unused;
+
+	assert(p && p->result);
+
+	if (p->result->failcode == 17 /* Former final_expiry_too_soon */)
+		*blockheight = p->start_block + 1;
+	else if (!fromwire_incorrect_or_unknown_payment_details(
+			p->result->raw_message,
+			&unused, blockheight))
+		/* If it's incorrect_or_unknown_payment_details, that tells us
+		 * what height they're at */
+		return false;
+
+	/* If we are already at the desired blockheight there is no point in
+	 * waiting, and it is likely just some other error. Notice that
+	 * start_block gets set by the initial getinfo call for each
+	 * attempt.*/
+	if (*blockheight <= p->start_block)
+		return false;
+
+	return true;
+}
+
 static struct command_result *
 handle_final_failure(struct command *cmd,
 		     struct payment *p,
 		     const struct node_id *final_id,
 		     enum onion_type failcode)
 {
+	u32 unused;
+
+	/* Need to check for blockheight disagreement case here,
+	 * otherwise we would set the abort flag too eagerly.
+	 */
+	if (failure_is_blockheight_disagreement(p, &unused)) {
+		plugin_log(p->plugin, LOG_DBG,
+			   "Blockheight disagreement, not aborting.");
+		goto nonerror;
+	}
+
 	/* We use an exhaustive switch statement here so you get a compile
 	 * warning when new ones are added, and can think about where they go */
 	switch (failcode) {
@@ -805,8 +843,10 @@ error:
 	p->result->code = PAY_DESTINATION_PERM_FAIL;
 	payment_root(p)->abort = true;
 
+nonerror:
 	payment_fail(p, "%s", p->result->message);
 	return command_still_pending(cmd);
+
 }
 
 
@@ -2508,9 +2548,7 @@ static void waitblockheight_cb(void *d, struct payment *p)
 	struct out_req *req;
 	struct timeabs now = time_now();
 	struct timerel remaining;
-	u32 blockheight = p->start_block;
-	int failcode;
-	const u8 *raw_message;
+	u32 blockheight;
 	if (p->step != PAYMENT_STEP_FAILED)
 		return payment_continue(p);
 
@@ -2521,27 +2559,10 @@ static void waitblockheight_cb(void *d, struct payment *p)
 	if (time_after(now, p->deadline))
 		return payment_continue(p);
 
-	failcode = p->result->failcode;
-	raw_message = p->result->raw_message;
 	remaining = time_between(p->deadline, now);
 
-	if (failcode == 17 /* Former final_expiry_too_soon */) {
-		blockheight = p->start_block + 1;
-	}  else {
-		/* If it's incorrect_or_unknown_payment_details, that tells us
-		 * what height they're at */
-		struct amount_msat unused;
-		const void *ptr = raw_message;
-		if (!fromwire_incorrect_or_unknown_payment_details(
-			ptr, &unused, &blockheight))
-			return payment_continue(p);
-	}
-
-	/* If we are already at the desired blockheight there is no point in
-	 * waiting, and it is likely just some other error. Notice that
-	 * start_block gets set by the initial getinfo call for each
-	 * attempt.*/
-	if (blockheight <= p->start_block)
+	/* *Was* it a blockheight disagreement that caused the failure?  */
+	if (!failure_is_blockheight_disagreement(p, &blockheight))
 		return payment_continue(p);
 
 	plugin_log(p->plugin, LOG_INFORM,

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1076,6 +1076,7 @@ static void payment_add_hop_onion_payload(struct payment *p,
 	u32 cltv = p->start_block + next->delay + 1;
 	u64 msat = next->amount.millisatoshis; /* Raw: TLV payload generation*/
 	struct tlv_field **fields;
+	struct payment *root = payment_root(p);
 	static struct short_channel_id all_zero_scid = {.u64 = 0};
 
 	/* This is the information of the node processing this payload, while
@@ -1111,8 +1112,9 @@ static void payment_add_hop_onion_payload(struct payment *p,
 
 		if (payment_secret != NULL) {
 			assert(final);
-			tlvstream_set_tlv_payload_data(fields, payment_secret,
-						       msat);
+			tlvstream_set_tlv_payload_data(
+			    fields, payment_secret,
+			    root->amount.millisatoshis); /* Raw: TLV payload generation*/
 		}
 		break;
 	}

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3308,7 +3308,6 @@ def test_listpays_ongoing_attempt(node_factory, bitcoind, executor):
     l1.rpc.listpays()
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(not DEVELOPER, "needs use_shadow")
 def test_mpp_waitblockheight_routehint_conflict(node_factory, bitcoind, executor):
     '''

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3306,3 +3306,52 @@ def test_listpays_ongoing_attempt(node_factory, bitcoind, executor):
     # Now restart and see if we still can aggregate things correctly.
     l1.restart()
     l1.rpc.listpays()
+
+
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(not DEVELOPER, "needs use_shadow")
+def test_mpp_waitblockheight_routehint_conflict(node_factory, bitcoind, executor):
+    '''
+    We have a bug where a blockheight disagreement between us and
+    the receiver causes us to advance through the routehints a bit
+    too aggressively.
+    '''
+    l1, l2, l3 = node_factory.get_nodes(3)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1l2 = l1.fund_channel(l2, 10**7, announce_channel=True)
+    l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    l2.fund_channel(l3, 10**7, announce_channel=False)
+
+    bitcoind.generate_block(6)
+    sync_blockheight(bitcoind, [l1, l2, l3])
+
+    # Wait for l3 to learn about l1->l2, otherwise it will think
+    # l2 is a deadend and not add it to the routehint.
+    wait_for(lambda: len(l3.rpc.listchannels(l1l2)['channels']) >= 2)
+
+    # Now make the l1 payer stop receiving blocks.
+    def no_more_blocks(req):
+        return {"result": None,
+                "error": {"code": -8, "message": "Block height out of range"}, "id": req['id']}
+    l1.daemon.rpcproxy.mock_rpc('getblockhash', no_more_blocks)
+
+    # Increase blockheight by 2, like in test_blockheight_disagreement.
+    bitcoind.generate_block(2)
+    sync_blockheight(bitcoind, [l3])
+
+    inv = l3.rpc.invoice(Millisatoshi(2 * 10000 * 1000), 'i', 'i', exposeprivatechannels=True)['bolt11']
+
+    # Have l1 pay l3
+    def pay(l1, inv):
+        l1.rpc.dev_pay(inv, use_shadow=False)
+    fut = executor.submit(pay, l1, inv)
+
+    # Make sure l1 sends out the HTLC.
+    l1.daemon.wait_for_logs([r'NEW:: HTLC LOCAL'])
+
+    # Unblock l1 from new blocks.
+    l1.daemon.rpcproxy.mock_rpc('getblockhash', None)
+
+    # pay command should complete without error
+    fut.result(TIMEOUT)


### PR DESCRIPTION
So I stumbled on a bug where the payee has a longer chain than the payer while developing #3913.

I wrote this little test plus fix, but it looks like we still have issues with being too aggressive in returning a *transient* error permanently!

Here are logs on the payer, after the (partial fix) is done on the payer side:

```
b'2020-08-09T07:12:07.387Z DEBUG plugin-pay: Added a channel hint for 103x1x1/1: enabled true, estimated capacity 4294967295msat'
b"2020-08-09T07:12:07.388Z DEBUG plugin-pay: After filtering routehints we're left with 1 usable hints"
b'2020-08-09T07:12:07.388Z DEBUG plugin-pay: Asking gossipd whether 035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d is reachable without routehints.'
b'2020-08-09T07:12:07.391Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:07.391Z DEBUG plugin-pay: The destination is not directly reachable excluding attempts without routehints'
b'2020-08-09T07:12:07.391Z INFO plugin-pay: Split into 3 sub-payments due to initial size (20000000msat > 10000000msat)'
b'2020-08-09T07:12:07.395Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:07.396Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:07.396Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:07.699Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:07.700Z INFO plugin-pay: Remote node appears to be on a longer chain, which causes CLTV timeouts to be incorrect. Waiting up to 59 seconds to catch up to block 113 before retrying.'
b'2020-08-09T07:12:07.700Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:07.700Z INFO plugin-pay: Remote node appears to be on a longer chain, which causes CLTV timeouts to be incorrect. Waiting up to 59 seconds to catch up to block 113 before retrying.'
b'2020-08-09T07:12:07.700Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:07.700Z INFO plugin-pay: Remote node appears to be on a longer chain, which causes CLTV timeouts to be incorrect. Waiting up to 59 seconds to catch up to block 113 before retrying.'
b'2020-08-09T07:12:08.226Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:08.227Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:08.227Z DEBUG plugin-pay: Using routehint 022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59 (105x1x1) cltv_delta=6'
b'2020-08-09T07:12:08.558Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:08.559Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:08.559Z INFO plugin-pay: failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'
b'2020-08-09T07:12:08.678Z INFO plugin-pay: Killing plugin: Plugin exited before completing handshake.'
```

And here are the relevant logs on the payee:

```
b'2020-08-09T07:12:07.558Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/peer_htlcs.c:503'
b'2020-08-09T07:12:07.562Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/peer_htlcs.c:503'
b'2020-08-09T07:12:07.566Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/peer_htlcs.c:503'
b'2020-08-09T07:12:08.421Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/htlc_set.c:113'
b'2020-08-09T07:12:08.425Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/htlc_set.c:113'
b'2020-08-09T07:12:08.429Z DEBUG lightningd: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: lightningd/htlc_set.c:113'
```

I find it very strange that payee still thinks there is some problem with the incoming payment.  So it looks like we have yet another bug.... LOL

@cdecker for help at the payer side (I think it is a genuine bug as I find the logic of the `d->offset` fairly weird) and @rustyrussell for help at the payee side (I have no idea about how the `htlc_set` works, and why the source of the error is different in the initial case (where the payer genuinely has the wrong blockheight) then in the second case (where the payer should have advanced its view of the blockheight already)).