### PR TITLE
Fix aggregation of partial payments in the pay-plugin

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2661,6 +2661,11 @@ static void presplit_cb(struct presplit_mod_data *d, struct payment *p)
 			struct payment *c =
 			    payment_new(p, NULL, p, p->modifiers);
 
+			/* Annotate the subpayments with the bolt11 string,
+			 * they'll be used when aggregating the payments
+			 * again. */
+			c->bolt11 = tal_strdup(c, p->bolt11);
+
 			/* Get ~ target, but don't exceed amt */
 			c->amount = fuzzed_near(target, amt);
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -36,6 +36,7 @@ struct payment *payment_new(tal_t *ctx, struct command *cmd,
 		tal_arr_expand(&parent->children, p);
 		p->destination = parent->destination;
 		p->amount = parent->amount;
+		p->label = parent->label;
 		p->payment_hash = parent->payment_hash;
 		p->partid = payment_root(p->parent)->next_partid++;
 		p->plugin = parent->plugin;


### PR DESCRIPTION
This fixes #3915, which could crash if the presplit modifier skipped the root payment, which was also the only payment annotated with the bolt11 string. It is addressed in two ways: we now annotate the first level of children in presplit (all other splits or skips act after the attempt was sent to `lightnignd` and thus there is at least one partial payment with the bolt11 annotation), and secondly we now aggregate via the `payment_hash` which is guaranteed to be non-null for all current payments, whereas the bolt11 string is only non-null if the payment was annotated with it.

Fixes #3915 
Fixes #3931 