### PR TITLE
pytest: fix race in test_bcli.

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1217,8 +1217,7 @@ def test_bcli(node_factory, bitcoind, chainparams):
             and txo["script"].startswith("0020"))
     l1.rpc.close(l2.info["id"])
     # When output is spent, it should give us null !
-    txo = l1.rpc.call("getutxout", {"txid": txid, "vout": 0})
-    assert txo["amount"] is txo["script"] is None
+    wait_for(lambda: l1.rpc.call("getutxout", {"txid": txid, "vout": 0})['amount'] is None)
 
     resp = l1.rpc.call("sendrawtransaction", {"tx": "dummy"})
     assert not resp["success"] and "decode failed" in resp["errmsg"]


### PR DESCRIPTION
On my test machine, we queried bitcoind before the close tx was sent:

```
        # When output is spent, it should give us null !
        txo = l1.rpc.call("getutxout", {"txid": txid, "vout": 0})
>       assert txo["amount"] is txo["script"] is None
E       AssertionError: assert '20000000msat' is '00205b8cd3b914cf67cdd8fa6273c930353dd36476734fbd962102c2df53b90880cd'

tests/test_plugin.py:1221: AssertionError
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None