### PR TITLE
Fixed doc missed

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,12 +54,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-waitblockheight.7 \
 	doc/lightning-waitsendpay.7 \
 	doc/lightning-withdraw.7 \
-	doc/lightning-ping.7 \
-	doc/lihgtning-signpsbt.7 \
-	doc/lightning-sendpsbt.7 \
-	doc/lightning-getinfo.7 \
-	doc/lightning-listtransactions.7 \
-	doc/lightning-listnodes.7
+	doc/lightning-ping.7 
 
 doc-all: $(MANPAGES) doc/index.rst
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,7 +53,13 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-waitanyinvoice.7 \
 	doc/lightning-waitblockheight.7 \
 	doc/lightning-waitsendpay.7 \
-	doc/lightning-withdraw.7
+	doc/lightning-withdraw.7 \
+	doc/lightning-ping.7 \
+	doc/lihgtning-signpsbt.7 \
+	doc/lightning-sendpsbt.7 \
+	doc/lightning-getinfo.7 \
+	doc/lightning-listtransactions.7 \
+	doc/lightning-listnodes.7
 
 doc-all: $(MANPAGES) doc/index.rst
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,16 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-waitblockheight.7 \
 	doc/lightning-waitsendpay.7 \
 	doc/lightning-withdraw.7 \
-	doc/lightning-ping.7 
+	doc/lightning-ping.7 \
+	doc/lightning-stop.7 \
+	doc/lightning-signpsbt.7 \
+	doc/lightning-sendpsbt.7 \
+	doc/lightning-getinfo.7 \
+	doc/lightning-listtransactions.7 \
+	doc/lightning-listnodes.7 \
+	doc/lightning-listconfigs.7 \
+	doc/lightning-help.7 \
+	doc/lightning-getlog.7 
 
 doc-all: $(MANPAGES) doc/index.rst
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,12 +47,15 @@ c-lightning Documentation
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
    lightning-fundpsbt <lightning-fundpsbt.7.md>
    lightning-getinfo <lightning-getinfo.7.md>
+   lightning-getlog <lightning-getlog.7.md>
    lightning-getroute <lightning-getroute.7.md>
    lightning-getsharedsecret <lightning-getsharedsecret.7.md>
+   lightning-help <lightning-help.7.md>
    lightning-hsmtool <lightning-hsmtool.8.md>
    lightning-invoice <lightning-invoice.7.md>
    lightning-keysend <lightning-keysend.7.md>
    lightning-listchannels <lightning-listchannels.7.md>
+   lightning-listconfigs <lightning-listconfigs.7.md>
    lightning-listforwards <lightning-listforwards.7.md>
    lightning-listfunds <lightning-listfunds.7.md>
    lightning-listinvoices <lightning-listinvoices.7.md>
@@ -63,6 +66,7 @@ c-lightning Documentation
    lightning-listtransactions <lightning-listtransactions.7.md>
    lightning-newaddr <lightning-newaddr.7.md>
    lightning-pay <lightning-pay.7.md>
+   lightning-ping <lightning-ping.7.md>
    lightning-plugin <lightning-plugin.7.md>
    lightning-reserveinputs <lightning-reserveinputs.7.md>
    lightning-sendonion <lightning-sendonion.7.md>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -58,6 +58,7 @@ c-lightning Documentation
    lightning-listpays <lightning-listpays.7.md>
    lightning-listpeers <lightning-listpeers.7.md>
    lightning-listsendpays <lightning-listsendpays.7.md>
+   lightning-listtransactions <lightning-listtransactions.7.md>
    lightning-newaddr <lightning-newaddr.7.md>
    lightning-pay <lightning-pay.7.md>
    lightning-plugin <lightning-plugin.7.md>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,6 +70,7 @@ c-lightning Documentation
    lightning-setchannelfee <lightning-setchannelfee.7.md>
    lightning-signmessage <lightning-signmessage.7.md>
    lightning-signpsbt <lightning-signpsbt.7.md>
+   lightning-stop <lightning-stop.7.md>
    lightning-txdiscard <lightning-txdiscard.7.md>
    lightning-txprepare <lightning-txprepare.7.md>
    lightning-txsend <lightning-txsend.7.md>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,6 +46,7 @@ c-lightning Documentation
    lightning-fundchannel_complete <lightning-fundchannel_complete.7.md>
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
    lightning-fundpsbt <lightning-fundpsbt.7.md>
+   lightning-getinfo <lightning-getinfo.7.md>
    lightning-getroute <lightning-getroute.7.md>
    lightning-getsharedsecret <lightning-getsharedsecret.7.md>
    lightning-hsmtool <lightning-hsmtool.8.md>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,6 +69,7 @@ c-lightning Documentation
    lightning-sendpsbt <lightning-sendpsbt.7.md>
    lightning-setchannelfee <lightning-setchannelfee.7.md>
    lightning-signmessage <lightning-signmessage.7.md>
+   lightning-signpsbt <lightning-signpsbt.7.md>
    lightning-txdiscard <lightning-txdiscard.7.md>
    lightning-txprepare <lightning-txprepare.7.md>
    lightning-txsend <lightning-txsend.7.md>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,6 +55,7 @@ c-lightning Documentation
    lightning-listforwards <lightning-listforwards.7.md>
    lightning-listfunds <lightning-listfunds.7.md>
    lightning-listinvoices <lightning-listinvoices.7.md>
+   lightning-listnodes <lightning-listnodes.7.md>
    lightning-listpays <lightning-listpays.7.md>
    lightning-listpeers <lightning-listpeers.7.md>
    lightning-listsendpays <lightning-listsendpays.7.md>
@@ -65,6 +66,7 @@ c-lightning Documentation
    lightning-reserveinputs <lightning-reserveinputs.7.md>
    lightning-sendonion <lightning-sendonion.7.md>
    lightning-sendpay <lightning-sendpay.7.md>
+   lightning-sendpsbt <lightning-sendpsbt.7.md>
    lightning-setchannelfee <lightning-setchannelfee.7.md>
    lightning-signmessage <lightning-signmessage.7.md>
    lightning-txdiscard <lightning-txdiscard.7.md>

--- a/doc/lightning-getinfo.7
+++ b/doc/lightning-getinfo.7
@@ -1,0 +1,122 @@
+.TH "LIGHTNING-GETINFO" "7" "" "" "lightning-getinfo"
+.SH NAME
+lightning-getinfo - Command to receive all information about the c-lightning node\.
+.SH SYNOPSIS
+
+\fBgetinfo\fR
+
+.SH DESCRIPTION
+
+The \fBgetinfo\fR is a RPC command which is possible receive all node informations\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "getinfo",
+  "params": {}
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, an object with the following information is returned:
+
+.RS
+.IP \[bu]
+\fIid\fR: A string that rappresents the public key of the node\. It will rappresent the node on the public network\.
+.IP \[bu]
+\fIalias\fR: A string that rappresents the alias of the node, by default is calculate from the public key (node id)\.
+.IP \[bu]
+\fIcolor\fR: A string that rappresents the color of the node\.
+.IP \[bu]
+\fInum_peers\fR: An integer that rappresents the number of peer connect to the node\.
+.IP \[bu]
+\fInum_pending_channels\fR: An integer that rappresents the number of channel with pending status\.
+.IP \[bu]
+\fInum_active_channels\fR: A integer that rappresents the number of channel with the active status\.
+.IP \[bu]
+\fInum_inactive_channels\fR: A integer that rappresents the number of channel with the inactive status\.
+.IP \[bu]
+\fIaddress\fR: An array that rappresents all addresses of the node, each object inside the array contains the following proprieties:.RS
+.IP \[bu]
+\fItype\fR: A string that rappresents the type of the address (ipv4 or ipv6)\.
+.IP \[bu]
+\fIaddress\fR: A string that rappresents the value of the address\.
+.IP \[bu]
+\fIport\fR: An integer that rappresents the port where the node are listening with this address\.
+
+.RE
+
+.IP \[bu]
+\fIbinding\fR: An array that rappresents all addresses where the node is binded\. Each object contains the same object type of the address propriety above\.
+.IP \[bu]
+\fIversion\fR: A string that rappresents the version of the node\.
+.IP \[bu]
+\fIblockheight\fR: An integer that rappresents the blockchain height\.
+.IP \[bu]
+\fInetwork\fR: A string that rappresents the type of network on the node are working (i\.e: bitcoin, testnet, regtest)\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters or some error happened during the command process\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "id": "02bf811f7571754f0b51e6d41a8885f5561041a7b14fac093e4cffb95749de1a8d",
+   "alias": "SLICKERGOPHER",
+   "color": "02bf81",
+   "num_peers": 0,
+   "num_pending_channels": 0,
+   "num_active_channels": 0,
+   "num_inactive_channels": 0,
+   "address": [
+      {
+         "type": "torv3",
+         "address": "fp463inc4w3lamhhduytrwdwq6q6uzugtaeapylqfc43agrdnnqsheyd.onion",
+         "port": 9736
+      },
+      {
+         "type": "torv3",
+         "address": "ifnntp5ak4homxrti2fp6ckyllaqcike447ilqfrgdw64ayrmkyashid.onion",
+         "port": 9736
+      }
+   ],
+   "binding": [
+      {
+         "type": "ipv4",
+         "address": "127.0.0.1",
+         "port": 9736
+      }
+   ],
+   "version": "0.9.0",
+   "blockheight": 644297,
+   "network": "bitcoin",
+   "msatoshi_fees_collected": 0,
+   "fees_collected_msat": "0msat",
+   "lightning-dir": "/media/vincent/Maxtor/C-lightning/node/bitcoin"
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-connect\fR(7), \fBlightning-fundchannel\fR(7), \fBlightning-listconfigs\fR(7)\.
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-getinfo.7
+++ b/doc/lightning-getinfo.7
@@ -7,7 +7,7 @@ lightning-getinfo - Command to receive all information about the c-lightning nod
 
 .SH DESCRIPTION
 
-The \fBgetinfo\fR is a RPC command which is possible receive all node informations\.
+The \fBgetinfo\fR gives a summary of the current running node\.
 
 .SH EXAMPLE JSON REQUEST
 .nf
@@ -26,38 +26,38 @@ On success, an object with the following information is returned:
 
 .RS
 .IP \[bu]
-\fIid\fR: A string that rappresents the public key of the node\. It will rappresent the node on the public network\.
+\fIid\fR: A string that represents the public key of the node\. It will represents the node on the public network\.
 .IP \[bu]
-\fIalias\fR: A string that rappresents the alias of the node, by default is calculate from the public key (node id)\.
+\fIalias\fR: A string that represents the alias of the node, by default is calculate from the public key (node id)\.  This is just for fun; the name can be anything and is not unique!
 .IP \[bu]
-\fIcolor\fR: A string that rappresents the color of the node\.
+\fIcolor\fR: A string that represents the preferred color of the node\.
 .IP \[bu]
-\fInum_peers\fR: An integer that rappresents the number of peer connect to the node\.
+\fInum_peers\fR: An integer that represents the number of peer connect to the node\.
 .IP \[bu]
-\fInum_pending_channels\fR: An integer that rappresents the number of channel with pending status\.
+\fInum_pending_channels\fR: An integer that represents the number of channel which are still awaiting opening confirmation\.
 .IP \[bu]
-\fInum_active_channels\fR: A integer that rappresents the number of channel with the active status\.
+\fInum_active_channels\fR: A integer that represents the number of channel which are currently open\.
 .IP \[bu]
-\fInum_inactive_channels\fR: A integer that rappresents the number of channel with the inactive status\.
+\fInum_inactive_channels\fR: A integer that represents the number of channel which are closing\.
 .IP \[bu]
-\fIaddress\fR: An array that rappresents all addresses of the node, each object inside the array contains the following proprieties:.RS
+\fIaddress\fR: An array that represents all published addresses of the node, each object inside the array contains the following proprieties:.RS
 .IP \[bu]
-\fItype\fR: A string that rappresents the type of the address (ipv4 or ipv6)\.
+\fItype\fR: A string that represents the type of the address (currently \fBipv4\fR, \fBipv6\fR, \fBtorv3\fR or \fBtorv4\fR)\.
 .IP \[bu]
-\fIaddress\fR: A string that rappresents the value of the address\.
+\fIaddress\fR: A string that represents the value of the address\.
 .IP \[bu]
-\fIport\fR: An integer that rappresents the port where the node are listening with this address\.
+\fIport\fR: An integer that represents the port where the node is listening with this address\.
 
 .RE
 
 .IP \[bu]
-\fIbinding\fR: An array that rappresents all addresses where the node is binded\. Each object contains the same object type of the address propriety above\.
+\fIbinding\fR: An array that represents all addresses where the node is binded\. Each object contains the same object type of the address propriety above\.
 .IP \[bu]
-\fIversion\fR: A string that rappresents the version of the node\.
+\fIversion\fR: A string that represents the version of the node\.
 .IP \[bu]
-\fIblockheight\fR: An integer that rappresents the blockchain height\.
+\fIblockheight\fR: An integer that represents the blockchain height\.
 .IP \[bu]
-\fInetwork\fR: A string that rappresents the type of network on the node are working (i\.e: bitcoin, testnet, regtest)\.
+\fInetwork\fR: A string that represents the type of network on the node are working (e\.g: \fBbitcoin\fR, \fBtestnet\fR, or \fBregtest\fR)\.
 
 .RE
 
@@ -120,3 +120,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:9e6a0e0c25569bfc9d23b07e84392a3f70f6c94a86cd482fbf48c3d668a1796d

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -1,0 +1,105 @@
+lightning-getinfo -- Command to receive all information about the c-lightning node.
+============================================================
+
+SYNOPSIS
+--------
+
+**getinfo**
+
+DESCRIPTION
+-----------
+
+The **getinfo** is a RPC command which is possible receive all node informations.
+
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "getinfo",
+  "params": {}
+}
+```
+
+RETURN VALUE
+------------
+
+On success, an object with the following information is returned:
+
+- *id*: A string that rappresents the public key of the node. It will rappresent the node on the public network.
+- *alias*: A string that rappresents the alias of the node, by default is calculate from the public key (node id).
+- *color*: A string that rappresents the color of the node.
+- *num_peers*: An integer that rappresents the number of peer connect to the node.
+- *num_pending_channels*: An integer that rappresents the number of channel with pending status.
+- *num_active_channels*: A integer that rappresents the number of channel with the active status.
+- *num_inactive_channels*: A integer that rappresents the number of channel with the inactive status.
+- *address*: An array that rappresents all addresses of the node, each object inside the array contains the following proprieties:
+  - *type*: A string that rappresents the type of the address (ipv4 or ipv6).
+  - *address*: A string that rappresents the value of the address.
+  - *port*: An integer that rappresents the port where the node are listening with this address.
+- *binding*: An array that rappresents all addresses where the node is binded and is ready to receive message. Each object contains the same object type of the address propriety above.
+- *version*: A string that rappresents the version of the node.
+- *blockheight*: An integera that rappresents the blockchain height.
+- *network*: A string that rappresents the type of network on the node are working (i.e: bitcoin, testnet, regtest).
+
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters or some error happened during the command process.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+   "id": "02bf811f7571754f0b51e6d41a8885f5561041a7b14fac093e4cffb95749de1a8d",
+   "alias": "SLICKERGOPHER",
+   "color": "02bf81",
+   "num_peers": 0,
+   "num_pending_channels": 0,
+   "num_active_channels": 0,
+   "num_inactive_channels": 0,
+   "address": [
+      {
+         "type": "torv3",
+         "address": "fp463inc4w3lamhhduytrwdwq6q6uzugtaeapylqfc43agrdnnqsheyd.onion",
+         "port": 9736
+      },
+      {
+         "type": "torv3",
+         "address": "ifnntp5ak4homxrti2fp6ckyllaqcike447ilqfrgdw64ayrmkyashid.onion",
+         "port": 9736
+      }
+   ],
+   "binding": [
+      {
+         "type": "ipv4",
+         "address": "127.0.0.1",
+         "port": 9736
+      }
+   ],
+   "version": "0.9.0",
+   "blockheight": 644297,
+   "network": "bitcoin",
+   "msatoshi_fees_collected": 0,
+   "fees_collected_msat": "0msat",
+   "lightning-dir": "/media/vincent/Maxtor/C-lightning/node/bitcoin"
+}
+
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+
+SEE ALSO
+------
+
+lightning-connect(7), lightning-fundchannel(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **getinfo** is a RPC command which is possible receive all node informations.
+The **getinfo** gives a summary of the current running node.
 
 
 EXAMPLE JSON REQUEST
@@ -27,21 +27,21 @@ RETURN VALUE
 
 On success, an object with the following information is returned:
 
-- *id*: A string that rappresents the public key of the node. It will rappresent the node on the public network.
-- *alias*: A string that rappresents the alias of the node, by default is calculate from the public key (node id).
-- *color*: A string that rappresents the color of the node.
-- *num_peers*: An integer that rappresents the number of peer connect to the node.
-- *num_pending_channels*: An integer that rappresents the number of channel with pending status.
-- *num_active_channels*: A integer that rappresents the number of channel with the active status.
-- *num_inactive_channels*: A integer that rappresents the number of channel with the inactive status.
-- *address*: An array that rappresents all addresses of the node, each object inside the array contains the following proprieties:
-  - *type*: A string that rappresents the type of the address (ipv4 or ipv6).
-  - *address*: A string that rappresents the value of the address.
-  - *port*: An integer that rappresents the port where the node are listening with this address.
-- *binding*: An array that rappresents all addresses where the node is binded. Each object contains the same object type of the address propriety above.
-- *version*: A string that rappresents the version of the node.
-- *blockheight*: An integer that rappresents the blockchain height.
-- *network*: A string that rappresents the type of network on the node are working (i.e: bitcoin, testnet, regtest).
+- *id*: A string that represents the public key of the node. It will represents the node on the public network.
+- *alias*: A string that represents the alias of the node, by default is calculate from the public key (node id).  This is just for fun; the name can be anything and is not unique!
+- *color*: A string that represents the preferred color of the node.
+- *num_peers*: An integer that represents the number of peer connect to the node.
+- *num_pending_channels*: An integer that represents the number of channel which are still awaiting opening confirmation.
+- *num_active_channels*: A integer that represents the number of channel which are currently open.
+- *num_inactive_channels*: A integer that represents the number of channel which are closing.
+- *address*: An array that represents all published addresses of the node, each object inside the array contains the following proprieties:
+  - *type*: A string that represents the type of the address (currently `ipv4`, `ipv6`, `torv3` or `torv4`).
+  - *address*: A string that represents the value of the address.
+  - *port*: An integer that represents the port where the node is listening with this address.
+- *binding*: An array that represents all addresses where the node is binded. Each object contains the same object type of the address propriety above.
+- *version*: A string that represents the version of the node.
+- *blockheight*: An integer that represents the blockchain height.
+- *network*: A string that represents the type of network on the node are working (e.g: `bitcoin`, `testnet`, or `regtest`).
 
 On failure, one of the following error codes may be returned:
 

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -45,7 +45,7 @@ On success, an object with the following information is returned:
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters or some error happened during the command process.
+- -32602: Error in given parameters or some error happened during the command process.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -38,9 +38,9 @@ On success, an object with the following information is returned:
   - *type*: A string that rappresents the type of the address (ipv4 or ipv6).
   - *address*: A string that rappresents the value of the address.
   - *port*: An integer that rappresents the port where the node are listening with this address.
-- *binding*: An array that rappresents all addresses where the node is binded and is ready to receive message. Each object contains the same object type of the address propriety above.
+- *binding*: An array that rappresents all addresses where the node is binded. Each object contains the same object type of the address propriety above.
 - *version*: A string that rappresents the version of the node.
-- *blockheight*: An integera that rappresents the blockchain height.
+- *blockheight*: An integer that rappresents the blockchain height.
 - *network*: A string that rappresents the type of network on the node are working (i.e: bitcoin, testnet, regtest).
 
 On failure, one of the following error codes may be returned:
@@ -97,7 +97,7 @@ Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version o
 SEE ALSO
 ------
 
-lightning-connect(7), lightning-fundchannel(7)
+lightning-connect(7), lightning-fundchannel(7), lightning-listconfigs(7).
 
 RESOURCES
 ---------

--- a/doc/lightning-getlog.7
+++ b/doc/lightning-getlog.7
@@ -1,0 +1,96 @@
+.TH "LIGHTNING-GETLOG" "7" "" "" "lightning-getlog"
+.SH NAME
+lightning-getlog - Command to show logs\.
+.SH SYNOPSIS
+
+\fBgetlog\fR [level]
+
+.SH DESCRIPTION
+
+The \fBgetlog\fR the RPC command to show logs, with optional log \fIlevel\fR\.
+
+.RS
+.IP \[bu]
+\fIlevel\fR: A string that rappresent the log level (info, unusual, debug, io)\.
+
+.RE
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "getlog",
+  "params": {
+    "level": "debug"
+  }
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, a object will be return with the following parameters:
+
+.RS
+.IP \[bu]
+\fIcreated_at\fR: An floating point value that rappresent the {}\. 
+.IP \[bu]
+\fIbytes_used\fR: A string that rappresent the dimension in bytes of the log file\.
+.IP \[bu]
+\fIbytes_max\fR: An integer that rappresent the max dimension in bytes of log file\.
+.IP \[bu]
+\fIlog\fR: An array of object where each elements contains the following proprieties:.RS
+.IP \[bu]
+\fItype\fR: A string that rappresent the log level\. The propriety can have an value equal to SKIPPED\.
+.IP \[bu]
+\fItime\fR: A floating point value that rappresent the time\.
+.IP \[bu]
+\fIsource\fR: A string that rappresent the source of line\.
+.IP \[bu]
+\fIlog\fR: A string that rappresent the content of line\.
+
+.RE
+
+.IP \[bu]
+\fInum_skipped\fR: An integer that it is present only if the log level is equal to SKIPPED\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "created_at": "1598192543.820753463",
+   "bytes_used": 89285843,
+   "bytes_max": 104857600,
+   "log": [
+      {
+         "type": "SKIPPED",
+         "num_skipped": 45
+      },
+      {
+         "type": "INFO",
+         "time": "0.453627568",
+         "source": "plugin-autopilot.py",
+         "log": "RPC method 'autopilot-run-once' does not have a docstring."
+      }
+   ]
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-getlog.7
+++ b/doc/lightning-getlog.7
@@ -3,7 +3,7 @@
 lightning-getlog - Command to show logs\.
 .SH SYNOPSIS
 
-\fBgetlog\fR [level]
+\fBgetlog\fR [\fIlevel\fR]
 
 .SH DESCRIPTION
 
@@ -11,7 +11,7 @@ The \fBgetlog\fR the RPC command to show logs, with optional log \fIlevel\fR\.
 
 .RS
 .IP \[bu]
-\fIlevel\fR: A string that rappresent the log level (info, unusual, debug, io)\.
+\fIlevel\fR: A string that represents the log level (\fIbroken\fR, \fIunusual\fR, \fIinfo\fR, \fIdebug\fR, or \fIio\fR)\.  The default is \fIinfo\fR\.
 
 .RE
 .SH EXAMPLE JSON REQUEST
@@ -33,21 +33,21 @@ On success, a object will be return with the following parameters:
 
 .RS
 .IP \[bu]
-\fIcreated_at\fR: An floating point value that rappresent the {}\. 
+\fIcreated_at\fR: An floating point value that represents the UNIX timestamp when logging began\. 
 .IP \[bu]
-\fIbytes_used\fR: A string that rappresent the dimension in bytes of the log file\.
+\fIbytes_used\fR: A string that represents the dimension in bytes of the log file\.
 .IP \[bu]
-\fIbytes_max\fR: An integer that rappresent the max dimension in bytes of log file\.
+\fIbytes_max\fR: An integer that represents the max dimension in bytes of log file\.
 .IP \[bu]
-\fIlog\fR: An array of object where each elements contains the following proprieties:.RS
+\fIlog\fR: An array of objects where each element contains the following proprieties:.RS
 .IP \[bu]
-\fItype\fR: A string that rappresent the log level\. The propriety can have an value equal to SKIPPED\.
+\fItype\fR: A string that represents the log level\. The propriety can have an value equal to SKIPPED to indicate the existence of omitted entries\.
 .IP \[bu]
-\fItime\fR: A floating point value that rappresent the time\.
+\fItime\fR: A floating point value that represents the time since \fIcreated_at\fR\.
 .IP \[bu]
-\fIsource\fR: A string that rappresent the source of line\.
+\fIsource\fR: A string that represents the source of line\.
 .IP \[bu]
-\fIlog\fR: A string that rappresent the content of line\.
+\fIlog\fR: A string that represents the content of line\.
 
 .RE
 
@@ -94,3 +94,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:789e23927120d0fefd374592a3c655244fd6c28a122368bdd8da2f3cdde66798

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -43,7 +43,7 @@ On success, a object will be return with the following parameters:
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters.
+- -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -1,0 +1,79 @@
+lightning-getlog -- Command to show logs.
+=========================================
+
+SYNOPSIS
+--------
+
+**getlog** \[level\]
+
+DESCRIPTION
+-----------
+
+The **getlog** the RPC command to show logs, with optional log *level*.
+
+- *level*: A string that rappresent the log level (info, unusual, debug, io).
+
+EXAMPLE JSON REQUEST
+--------------------
+```json
+{
+  "id": 82,
+  "method": "getlog",
+  "params": {
+    "level": "debug"
+  }
+}
+```
+
+RETURN VALUE
+------------
+
+On success, a object will be return with the following parameters:
+
+- *created_at*: An floating point value that rappresent the {}. 
+- *bytes_used*: A string that rappresent the dimension in bytes of the log file.
+- *bytes_max*: An integer that rappresent the max dimension in bytes of log file.
+- *log*: An array of object where each elements contains the following proprieties:
+ - *type*: A string that rappresent the log level. The propriety can have an value equal to SKIPPED.
+ - *time*: A floating point value that rappresent the time.
+ - *source*: A string that rappresent the source of line.
+ - *log*: A string that rappresent the content of line.
+- *num_skipped*: An integer that it is present only if the log level is equal to SKIPPED.
+ 
+
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters.
+
+EXAMPLE JSON RESPONSE
+---------------------
+
+```json
+{
+   "created_at": "1598192543.820753463",
+   "bytes_used": 89285843,
+   "bytes_max": 104857600,
+   "log": [
+      {
+         "type": "SKIPPED",
+         "num_skipped": 45
+      },
+      {
+         "type": "INFO",
+         "time": "0.453627568",
+         "source": "plugin-autopilot.py",
+         "log": "RPC method 'autopilot-run-once' does not have a docstring."
+      }
+   ]
+}
+```
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -4,14 +4,14 @@ lightning-getlog -- Command to show logs.
 SYNOPSIS
 --------
 
-**getlog** \[level\]
+**getlog** \[*level*\]
 
 DESCRIPTION
 -----------
 
 The **getlog** the RPC command to show logs, with optional log *level*.
 
-- *level*: A string that rappresent the log level (info, unusual, debug, io).
+- *level*: A string that represents the log level (*broken*, *unusual*, *info*, *debug*, or *io*).  The default is *info*.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -30,14 +30,14 @@ RETURN VALUE
 
 On success, a object will be return with the following parameters:
 
-- *created_at*: An floating point value that rappresent the {}. 
-- *bytes_used*: A string that rappresent the dimension in bytes of the log file.
-- *bytes_max*: An integer that rappresent the max dimension in bytes of log file.
-- *log*: An array of object where each elements contains the following proprieties:
- - *type*: A string that rappresent the log level. The propriety can have an value equal to SKIPPED.
- - *time*: A floating point value that rappresent the time.
- - *source*: A string that rappresent the source of line.
- - *log*: A string that rappresent the content of line.
+- *created_at*: An floating point value that represents the UNIX timestamp when logging began. 
+- *bytes_used*: A string that represents the dimension in bytes of the log file.
+- *bytes_max*: An integer that represents the max dimension in bytes of log file.
+- *log*: An array of objects where each element contains the following proprieties:
+ - *type*: A string that represents the log level. The propriety can have an value equal to SKIPPED to indicate the existence of omitted entries.
+ - *time*: A floating point value that represents the time since *created_at*.
+ - *source*: A string that represents the source of line.
+ - *log*: A string that represents the content of line.
 - *num_skipped*: An integer that it is present only if the log level is equal to SKIPPED.
  
 

--- a/doc/lightning-help.7
+++ b/doc/lightning-help.7
@@ -3,11 +3,16 @@
 lightning-help - Command to return all information about RPC commands\.
 .SH SYNOPSIS
 
-\fBhelp\fR
+\fBhelp\fR [\fIcommand\\\fR]
 
 .SH DESCRIPTION
 
-The \fBhelp\fR is a RPC command which is possible consult all information about the RPC commands\.
+The \fBhelp\fR is a RPC command which is possible consult all information about the RPC commands, or a specific command if \fIcommand\fR is given\.
+
+
+Note that the \fBlightning-cli\fR(1) tool will prefer to list a man page when a
+specific \fIcommand\fR is specified, and will only return the JSON if the man
+page is not found\.
 
 .SH EXAMPLE JSON REQUEST
 .nf
@@ -26,13 +31,13 @@ On success, a object will be return with the following proprieties:
 
 .RS
 .IP \[bu]
-\fIcommand\fR: A string that rappresent the stucture of the command\.
+\fIcommand\fR: A string that represents the stucture of the command\.
 .IP \[bu]
-\fIcategory\fR: A string that rappresent the category\.
+\fIcategory\fR: A string that represents the category\.
 .IP \[bu]
-\fIdescription\fR: A string that rappresent the description\.
+\fIdescription\fR: A string that represents the description\.
 .IP \[bu]
-\fIverbose\fR: A string that rappresent the verbode description\.
+\fIverbose\fR: A string that represents the verbode description\.
 
 .RE
 
@@ -67,3 +72,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:cbd027bd9117d2e71167ab1c9d95a63c90b8e9c556dd75e951d4913a2891cb37

--- a/doc/lightning-help.7
+++ b/doc/lightning-help.7
@@ -1,0 +1,69 @@
+.TH "LIGHTNING-HELP" "7" "" "" "lightning-help"
+.SH NAME
+lightning-help - Command to return all information about RPC commands\.
+.SH SYNOPSIS
+
+\fBhelp\fR
+
+.SH DESCRIPTION
+
+The \fBhelp\fR is a RPC command which is possible consult all information about the RPC commands\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "help",
+  "params": {}
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, a object will be return with the following proprieties:
+
+.RS
+.IP \[bu]
+\fIcommand\fR: A string that rappresent the stucture of the command\.
+.IP \[bu]
+\fIcategory\fR: A string that rappresent the category\.
+.IP \[bu]
+\fIdescription\fR: A string that rappresent the description\.
+.IP \[bu]
+\fIverbose\fR: A string that rappresent the verbode description\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+    "help": [
+      {
+        "command": "autocleaninvoice [cycle_seconds] [expired_by]",
+        "category": "plugin",
+        "description": "Set up autoclean of expired invoices. ",
+        "verbose": "Perform cleanup every {cycle_seconds} (default 3600), or disable autoclean if 0. Clean up expired invoices that have expired for {expired_by} seconds (default 86400). "
+      }
+    ]
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -1,0 +1,62 @@
+lightning-help -- Command to return all information about RPC commands.
+=======================================================================
+
+SYNOPSIS
+--------
+
+**help**
+
+DESCRIPTION
+-----------
+
+The **help** is a RPC command which is possible consult all information about the RPC commands.
+
+EXAMPLE JSON REQUEST
+--------------------
+```json
+{
+  "id": 82,
+  "method": "help",
+  "params": {}
+}
+```
+
+RETURN VALUE
+------------
+
+On success, a object will be return with the following proprieties:
+
+- *command*: A string that rappresent the stucture of the command.
+- *category*: A string that rappresent the category.
+- *description*: A string that rappresent the description.
+- *verbose*: A string that rappresent the verbode description.
+
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters.
+
+EXAMPLE JSON RESPONSE
+---------------------
+
+```json
+{
+    "help": [
+      {
+        "command": "autocleaninvoice [cycle_seconds] [expired_by]",
+        "category": "plugin",
+        "description": "Set up autoclean of expired invoices. ",
+        "verbose": "Perform cleanup every {cycle_seconds} (default 3600), or disable autoclean if 0. Clean up expired invoices that have expired for {expired_by} seconds (default 86400). "
+      }
+    ]
+}
+```
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -33,7 +33,7 @@ On success, a object will be return with the following proprieties:
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters.
+- -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -4,12 +4,16 @@ lightning-help -- Command to return all information about RPC commands.
 SYNOPSIS
 --------
 
-**help**
+**help** \[*command\*]
 
 DESCRIPTION
 -----------
 
-The **help** is a RPC command which is possible consult all information about the RPC commands.
+The **help** is a RPC command which is possible consult all information about the RPC commands, or a specific command if *command* is given.
+
+Note that the lightning-cli(1) tool will prefer to list a man page when a
+specific *command* is specified, and will only return the JSON if the man
+page is not found.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -26,10 +30,10 @@ RETURN VALUE
 
 On success, a object will be return with the following proprieties:
 
-- *command*: A string that rappresent the stucture of the command.
-- *category*: A string that rappresent the category.
-- *description*: A string that rappresent the description.
-- *verbose*: A string that rappresent the verbode description.
+- *command*: A string that represents the stucture of the command.
+- *category*: A string that represents the category.
+- *description*: A string that represents the description.
+- *verbose*: A string that represents the verbode description.
 
 On failure, one of the following error codes may be returned:
 

--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -1,0 +1,236 @@
+.TH "LIGHTNING-LISTCONFIGS" "7" "" "" "lightning-listconfigs"
+.SH NAME
+lightning-listconfigs - Command to list all configuration options\.
+.SH SYNOPSIS
+
+\fBlistconfigs\fR [config]
+
+.SH DESCRIPTION
+
+The \fBlistconfigs\fR teh RPC command to list all configuration options, or with \fIconfig\fR, just that one\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "listconfigs",
+  "params": {}
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, an object with the following proprieties is returned:
+
+.RS
+.IP \[bu]
+\fI# version\fR: A string that rappresents the version of node\.
+.IP \[bu]
+\fIlightning-di\fR: A string that rappresents the work dir of the node\.
+.IP \[bu]
+\fInetwork\fR: A string that rappresents the network (e\.g: bitcoin)\.
+.IP \[bu]
+\fIallow-deprecated-apis\fR: A boolean value that rappresent if the deprecated api are avaible on the node\.
+.IP \[bu]
+\fIrpc-file\fR: A string that rappresent the location of the rpc file\.
+.IP \[bu]
+\fIplugins\fR: A array that rappresent the no important plugin registered\. Each object contains the following proprieties:.RS
+.IP \[bu]
+\fIpath\fR: A string that rappresent the path of plugin\.
+.IP \[bu]
+\fIname\fR: A string that rappresent the name of plugin\.
+.IP \[bu]
+\fIoptions\fR: A object that contains all options accepted from comand line, if the plugin accepted parameters from command line\.
+
+.RE
+
+.IP \[bu]
+\fIimportant-plugins\fR: An array that rappresent all important pluging registered to the node\. Each object contains the same proprieties of \fIplugin\fR array\.
+.IP \[bu]
+\fIdisable-plugin\fR: An array of string that rappresent the name of plugin disabled\.
+.IP \[bu]
+\fIalways-use-proxy\fR: A boolean value that rappresent if the node utilize always the proxy\.
+.IP \[bu]
+\fIdaemon\fR: A boolean value is the node have the daemon propriety enabled\.
+.IP \[bu]
+\fIwallet\fR: A string that rappresent the location of wallet with database url convention\.
+.IP \[bu]
+\fIwumbo\fR: A boolean value that rappresent the value of wumbo propriety\.
+.IP \[bu]
+\fIrgb\fR: A string that rappresent the color of the node\.
+.IP \[bu]
+\fIalias\fR: A string that rappresent the alias of the node\.
+.IP \[bu]
+\fIpid-file\fR: A string that rappresent the location of the pid file\.
+.IP \[bu]
+\fIignore-fee-limits\fR: A boolean value that rappresent is the node ignore the fee limit\.
+.IP \[bu]
+\fIwatchtime-blocks\fR: An integer that rappresent the watchtime of the blocks\.
+.IP \[bu]
+\fImax-locktime-blocks\fR: A integer that rappresent that max locktime for blocks\.
+.IP \[bu]
+\fIfunding-confirms\fR: An integer that rappresent the number of funding transaction confermation\.
+.IP \[bu]
+\fIcommit-fee-min\fR: A integer that rappresent the minimum commit fee\.
+.IP \[bu]
+\fIcommit-fee-max\fR: A integer that rappresent the maximum commit fee\.
+.IP \[bu]
+\fIcltv-delta\fR: An integer that rappresent the value of cltv delta\.
+.IP \[bu]
+\fIcltv-final\fR: An integer that rappresent the value of cltv final\.
+.IP \[bu]
+\fIcommit-time\fR: An integer that rappresent the value of commit time\.
+.IP \[bu]
+\fIfee-base\fR: A integer that rappresent the value of fee base\.
+.IP \[bu]
+\fIrescan\fR: A integer that rappresent the number of block that the node must rescan before to run\.
+.IP \[bu]
+\fIfee-per-satoshi\fR: An integer that rappresent the fee for satoshi\.
+.IP \[bu]
+\fImax-concurrent-htlcs\fR: A integer that rappresent the number of HTLCs one channel can handle concurrently in each direction\.
+.IP \[bu]
+\fImin-capacity-sat\fR: A integer that rappresent the minimal effective channel capacity in satoshi to accept for channel opening requests\.
+.IP \[bu]
+\fIaddr\fR: A string that rappresent the address where the node are listen\.
+.IP \[bu]
+\fIbind-addr\fR: A string that rappresent the address or UNIX domine socket where the node are listen\.
+.IP \[bu]
+\fIannounce-addr\fR: A string that rappresent the address where the node is annunced\.
+.IP \[bu]
+\fIoffline\fR: A boolean value that rappresent if the node is offline\.
+.IP \[bu]
+\fIautolisten\fR: A boolean value that rappresent if the autolisten is enabled\.
+.IP \[bu]
+\fIproxy\fR: A string that rappresent the proxy address\.
+.IP \[bu]
+\fIdisable-dns\fR: A boolean value that rappresent if the dns is disabled\.
+.IP \[bu]
+\fIenable-autotor-v2-mode\fR: A boolean value that rappresent if the Tor v2 is enabled\.
+.IP \[bu]
+\fIencrypted-hsm\fR: A boolean value that rappresent if the wallet is encrypted\. 
+.IP \[bu]
+\fIrpc-file-mode\fR: A string that rappresent the value rpc-file-mode\.
+.IP \[bu]
+\fIlog-level\fR: A string that rappresent the level of log\.
+.IP \[bu]
+
+\fIlog-prefix\fR: A string that rappresent the log prefix\.
+On failure, one of the following error codes may be returned:
+
+
+.IP \[bu]
+
+-32602: Error in given parameters or field with \fIconfig\fR name doesn't exist\.
+
+
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "# version": "v0.9.0-1",
+   "lightning-dir": "/media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev",
+   "network": "testnet",
+   "allow-deprecated-apis": true,
+   "rpc-file": "lightning-rpc",
+   "plugins": [
+      {
+         "path": "/home/vincent/Github/plugins/sauron/sauron.py",
+         "name": "sauron.py",
+         "options": {
+            "sauron-api-endpoint": "http://blockstream.info/testnet/api/",
+            "sauron-tor-proxy": ""
+         }
+      },
+      {
+         "path": "/home/vincent/Github/reckless/reckless.py",
+         "name": "reckless.py"
+      }
+   ],
+   "important-plugins": [
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/autoclean",
+         "name": "autoclean",
+         "options": {
+            "autocleaninvoice-cycle": null,
+            "autocleaninvoice-expired-by": null
+         }
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/fundchannel",
+         "name": "fundchannel"
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/keysend",
+         "name": "keysend"
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/pay",
+         "name": "pay",
+         "options": {
+            "disable-mpp": false
+         }
+      }
+   ],
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/autoclean",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/fundchannel",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/keysend",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/pay",
+   "plugin": "/home/vincent/Github/plugins/sauron/sauron.py",
+   "plugin": "/home/vincent/Github/reckless/reckless.py",
+   "disable-plugin": [
+      "bcli"
+   ],
+   "always-use-proxy": false,
+   "daemon": "false",
+   "wallet": "sqlite3:///media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev/testnet/lightningd.sqlite3",
+   "wumbo": false,
+   "wumbo": false,
+   "rgb": "03ad98",
+   "alias": "BRUCEWAYN-TES-DEV",
+   "pid-file": "/media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev/lightningd-testne...",
+   "ignore-fee-limits": true,
+   "watchtime-blocks": 6,
+   "max-locktime-blocks": 2016,
+   "funding-confirms": 1,
+   "commit-fee-min": 0,
+   "commit-fee-max": 0,
+   "cltv-delta": 6,
+   "cltv-final": 10,
+   "commit-time": 10,
+   "fee-base": 1,
+   "rescan": 30,
+   "fee-per-satoshi": 10,
+   "max-concurrent-htlcs": 483,
+   "min-capacity-sat": 10000,
+   "addr": "autotor:127.0.0.1:9051",
+   "bind-addr": "127.0.0.1:9735",
+   "announce-addr": "fp463inc4w3lamhhduytrwdwq6q6uzugtaeapylqfc43agrdnnqsheyd.onion:9735",
+   "offline": "false",
+   "autolisten": true,
+   "proxy": "127.0.0.1:9050",
+   "disable-dns": "false",
+   "enable-autotor-v2-mode": "false",
+   "encrypted-hsm": false,
+   "rpc-file-mode": "0600",
+   "log-level": "DEBUG",
+   "log-prefix": "lightningd",
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-getinfo\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -7,7 +7,7 @@ lightning-listconfigs - Command to list all configuration options\.
 
 .SH DESCRIPTION
 
-The \fBlistconfigs\fR teh RPC command to list all configuration options, or with \fIconfig\fR, just that one\.
+The \fBlistconfigs\fR RPC command to list all configuration options, or with \fIconfig\fR, just that one\.
 
 .SH EXAMPLE JSON REQUEST
 .nf
@@ -24,100 +24,29 @@ The \fBlistconfigs\fR teh RPC command to list all configuration options, or with
 .fi
 .SH RETURN VALUE
 
-On success, an object with the following proprieties is returned:
+On success, an object is returned with members reflecting the
+corresponding \fBlightningd-config\fR(5) options which were specified in
+the configuration file(s) and command line\.
+
+
+Additional members include:
 
 .RS
 .IP \[bu]
-\fI# version\fR: A string that rappresents the version of node\.
+\fI# version\fR: A string that represents the version of node\.
 .IP \[bu]
-\fIlightning-dir\fR: A string that rappresents the work dir of the node\.
+\fIplugins\fR: A array that represents the non-important plugin registered\. Each object contains the following members:.RS
 .IP \[bu]
-\fInetwork\fR: A string that rappresents the network (e\.g: bitcoin)\.
+\fIpath\fR: A string that represents the path of plugin\.
 .IP \[bu]
-\fIallow-deprecated-apis\fR: A boolean value that rappresent if the deprecated api are avaible on the node\.
+\fIname\fR: A string that represents the name of plugin\.
 .IP \[bu]
-\fIrpc-file\fR: A string that rappresent the location of the rpc file\.
-.IP \[bu]
-\fIplugins\fR: A array that rappresent the no important plugin registered\. Each object contains the following proprieties:.RS
-.IP \[bu]
-\fIpath\fR: A string that rappresent the path of plugin\.
-.IP \[bu]
-\fIname\fR: A string that rappresent the name of plugin\.
-.IP \[bu]
-\fIoptions\fR: A object that contains all options accepted from comand line, if the plugin accepted parameters from command line\.
+\fIoptions\fR: A object that contains all options accepted from command line or configuration file, if the plugin has opitions
 
 .RE
 
 .IP \[bu]
-\fIimportant-plugins\fR: An array that rappresent all important pluging registered to the node\. Each object contains the same proprieties of \fIplugin\fR array\.
-.IP \[bu]
-\fIdisable-plugin\fR: An array of string that rappresent the name of plugin disabled\.
-.IP \[bu]
-\fIalways-use-proxy\fR: A boolean value that rappresent if the node utilize always the proxy\.
-.IP \[bu]
-\fIdaemon\fR: A boolean value is the node have the daemon propriety enabled\.
-.IP \[bu]
-\fIwallet\fR: A string that rappresent the location of wallet with database url convention\.
-.IP \[bu]
-\fIwumbo\fR: A boolean value that rappresent the value of wumbo propriety\.
-.IP \[bu]
-\fIrgb\fR: A string that rappresent the color of the node\.
-.IP \[bu]
-\fIalias\fR: A string that rappresent the alias of the node\.
-.IP \[bu]
-\fIpid-file\fR: A string that rappresent the location of the pid file\.
-.IP \[bu]
-\fIignore-fee-limits\fR: A boolean value that rappresent is the node ignore the fee limit\.
-.IP \[bu]
-\fIwatchtime-blocks\fR: An integer that rappresent the watchtime of the blocks\.
-.IP \[bu]
-\fImax-locktime-blocks\fR: A integer that rappresent that max locktime for blocks\.
-.IP \[bu]
-\fIfunding-confirms\fR: An integer that rappresent the number of funding transaction confermation\.
-.IP \[bu]
-\fIcommit-fee-min\fR: A integer that rappresent the minimum commit fee\.
-.IP \[bu]
-\fIcommit-fee-max\fR: A integer that rappresent the maximum commit fee\.
-.IP \[bu]
-\fIcltv-delta\fR: An integer that rappresent the value of cltv delta\.
-.IP \[bu]
-\fIcltv-final\fR: An integer that rappresent the value of cltv final\.
-.IP \[bu]
-\fIcommit-time\fR: An integer that rappresent the value of commit time\.
-.IP \[bu]
-\fIfee-base\fR: A integer that rappresent the value of fee base\.
-.IP \[bu]
-\fIrescan\fR: A integer that rappresent the number of block that the node must rescan before to run\.
-.IP \[bu]
-\fIfee-per-satoshi\fR: An integer that rappresent the fee for satoshi\.
-.IP \[bu]
-\fImax-concurrent-htlcs\fR: A integer that rappresent the number of HTLCs one channel can handle concurrently in each direction\.
-.IP \[bu]
-\fImin-capacity-sat\fR: A integer that rappresent the minimal effective channel capacity in satoshi to accept for channel opening requests\.
-.IP \[bu]
-\fIaddr\fR: A string that rappresent the address where the node are listen\.
-.IP \[bu]
-\fIbind-addr\fR: A string that rappresent the address or UNIX domine socket where the node are listen\.
-.IP \[bu]
-\fIannounce-addr\fR: A string that rappresent the address where the node is annunced\.
-.IP \[bu]
-\fIoffline\fR: A boolean value that rappresent if the node is offline\.
-.IP \[bu]
-\fIautolisten\fR: A boolean value that rappresent if the autolisten is enabled\.
-.IP \[bu]
-\fIproxy\fR: A string that rappresent the proxy address\.
-.IP \[bu]
-\fIdisable-dns\fR: A boolean value that rappresent if the dns is disabled\.
-.IP \[bu]
-\fIenable-autotor-v2-mode\fR: A boolean value that rappresent if the Tor v2 is enabled\.
-.IP \[bu]
-\fIencrypted-hsm\fR: A boolean value that rappresent if the wallet is encrypted\. 
-.IP \[bu]
-\fIrpc-file-mode\fR: A string that rappresent the value rpc-file-mode\.
-.IP \[bu]
-\fIlog-level\fR: A string that rappresent the level of log\.
-.IP \[bu]
-\fIlog-prefix\fR: A string that rappresent the log prefix\.i
+\fIimportant-plugins\fR: An array that represents all important plugins registered to the node\. Each object contains the same members as the \fIplugin\fR array\.
 
 .RE
 
@@ -229,9 +158,10 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 .SH SEE ALSO
 
-\fBlightning-getinfo\fR(7)
+\fBlightning-getinfo\fR(7), \fBlightningd-config\fR(5)
 
 .SH RESOURCES
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:19542af1d9c13e31ec6fada46f85a080433c2c7a863779a8b9e3ac86a5903b48

--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -15,7 +15,9 @@ The \fBlistconfigs\fR teh RPC command to list all configuration options, or with
 {
   "id": 82,
   "method": "listconfigs",
-  "params": {}
+  "params": {
+    "config": "network"
+  }
 }
 .RE
 
@@ -28,7 +30,7 @@ On success, an object with the following proprieties is returned:
 .IP \[bu]
 \fI# version\fR: A string that rappresents the version of node\.
 .IP \[bu]
-\fIlightning-di\fR: A string that rappresents the work dir of the node\.
+\fIlightning-dir\fR: A string that rappresents the work dir of the node\.
 .IP \[bu]
 \fInetwork\fR: A string that rappresents the network (e\.g: bitcoin)\.
 .IP \[bu]
@@ -115,16 +117,15 @@ On success, an object with the following proprieties is returned:
 .IP \[bu]
 \fIlog-level\fR: A string that rappresent the level of log\.
 .IP \[bu]
+\fIlog-prefix\fR: A string that rappresent the log prefix\.i
 
-\fIlog-prefix\fR: A string that rappresent the log prefix\.
+.RE
+
 On failure, one of the following error codes may be returned:
 
-
+.RS
 .IP \[bu]
-
 -32602: Error in given parameters or field with \fIconfig\fR name doesn't exist\.
-
-
 
 .RE
 .SH EXAMPLE JSON RESPONSE

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -18,7 +18,9 @@ EXAMPLE JSON REQUEST
 {
   "id": 82,
   "method": "listconfigs",
-  "params": {}
+  "params": {
+    "config": "network"
+  }
 }
 ```
 
@@ -28,7 +30,7 @@ RETURN VALUE
 On success, an object with the following proprieties is returned:
 
 - *# version*: A string that rappresents the version of node.
-- *lightning-di*: A string that rappresents the work dir of the node.
+- *lightning-dir*: A string that rappresents the work dir of the node.
 - *network*: A string that rappresents the network (e.g: bitcoin).
 - *allow-deprecated-apis*: A boolean value that rappresent if the deprecated api are avaible on the node.
 - *rpc-file*: A string that rappresent the location of the rpc file.
@@ -70,7 +72,9 @@ On success, an object with the following proprieties is returned:
 - *encrypted-hsm*: A boolean value that rappresent if the wallet is encrypted. 
 - *rpc-file-mode*: A string that rappresent the value rpc-file-mode.
 - *log-level*: A string that rappresent the level of log.
-- *log-prefix*: A string that rappresent the log prefix.
+- *log-prefix*: A string that rappresent the log prefix.i
+
+
 On failure, one of the following error codes may be returned:
 
 - -32602: Error in given parameters or field with *config* name doesn't exist.

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -1,0 +1,187 @@
+lightning-listconfigs -- Command to list all configuration options.
+================================================================
+
+SYNOPSIS
+--------
+
+**listconfigs** \[config\]
+
+DESCRIPTION
+-----------
+
+The **listconfigs** teh RPC command to list all configuration options, or with *config*, just that one.
+
+EXAMPLE JSON REQUEST
+--------------------
+
+```json
+{
+  "id": 82,
+  "method": "listconfigs",
+  "params": {}
+}
+```
+
+RETURN VALUE
+------------
+
+On success, an object with the following proprieties is returned:
+
+- *# version*: A string that rappresents the version of node.
+- *lightning-di*: A string that rappresents the work dir of the node.
+- *network*: A string that rappresents the network (e.g: bitcoin).
+- *allow-deprecated-apis*: A boolean value that rappresent if the deprecated api are avaible on the node.
+- *rpc-file*: A string that rappresent the location of the rpc file.
+- *plugins*: A array that rappresent the no important plugin registered. Each object contains the following proprieties:
+   - *path*: A string that rappresent the path of plugin.
+   - *name*: A string that rappresent the name of plugin.
+   - *options*: A object that contains all options accepted from comand line, if the plugin accepted parameters from command line.
+- *important-plugins*: An array that rappresent all important pluging registered to the node. Each object contains the same proprieties of *plugin* array.
+- *disable-plugin*: An array of string that rappresent the name of plugin disabled.
+- *always-use-proxy*: A boolean value that rappresent if the node utilize always the proxy.
+- *daemon*: A boolean value is the node have the daemon propriety enabled.
+- *wallet*: A string that rappresent the location of wallet with database url convention.
+- *wumbo*: A boolean value that rappresent the value of wumbo propriety.
+- *rgb*: A string that rappresent the color of the node.
+- *alias*: A string that rappresent the alias of the node.
+- *pid-file*: A string that rappresent the location of the pid file.
+- *ignore-fee-limits*: A boolean value that rappresent is the node ignore the fee limit.
+- *watchtime-blocks*: An integer that rappresent the watchtime of the blocks.
+- *max-locktime-blocks*: A integer that rappresent that max locktime for blocks.
+- *funding-confirms*: An integer that rappresent the number of funding transaction confermation.
+- *commit-fee-min*: A integer that rappresent the minimum commit fee.
+- *commit-fee-max*: A integer that rappresent the maximum commit fee.
+- *cltv-delta*: An integer that rappresent the value of cltv delta.
+- *cltv-final*: An integer that rappresent the value of cltv final.
+- *commit-time*: An integer that rappresent the value of commit time.
+- *fee-base*: A integer that rappresent the value of fee base.
+- *rescan*: A integer that rappresent the number of block that the node must rescan before to run.
+- *fee-per-satoshi*: An integer that rappresent the fee for satoshi.
+- *max-concurrent-htlcs*: A integer that rappresent the number of HTLCs one channel can handle concurrently in each direction.
+- *min-capacity-sat*: A integer that rappresent the minimal effective channel capacity in satoshi to accept for channel opening requests.
+- *addr*: A string that rappresent the address where the node are listen.
+- *bind-addr*: A string that rappresent the address or UNIX domine socket where the node are listen.
+- *announce-addr*: A string that rappresent the address where the node is annunced.
+- *offline*: A boolean value that rappresent if the node is offline.
+- *autolisten*: A boolean value that rappresent if the autolisten is enabled.
+- *proxy*: A string that rappresent the proxy address.
+- *disable-dns*: A boolean value that rappresent if the dns is disabled.
+- *enable-autotor-v2-mode*: A boolean value that rappresent if the Tor v2 is enabled.
+- *encrypted-hsm*: A boolean value that rappresent if the wallet is encrypted. 
+- *rpc-file-mode*: A string that rappresent the value rpc-file-mode.
+- *log-level*: A string that rappresent the level of log.
+- *log-prefix*: A string that rappresent the log prefix.
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters or field with *config* name doesn't exist.
+
+EXAMPLE JSON RESPONSE
+---------------------
+
+```json
+{
+   "# version": "v0.9.0-1",
+   "lightning-dir": "/media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev",
+   "network": "testnet",
+   "allow-deprecated-apis": true,
+   "rpc-file": "lightning-rpc",
+   "plugins": [
+      {
+         "path": "/home/vincent/Github/plugins/sauron/sauron.py",
+         "name": "sauron.py",
+         "options": {
+            "sauron-api-endpoint": "http://blockstream.info/testnet/api/",
+            "sauron-tor-proxy": ""
+         }
+      },
+      {
+         "path": "/home/vincent/Github/reckless/reckless.py",
+         "name": "reckless.py"
+      }
+   ],
+   "important-plugins": [
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/autoclean",
+         "name": "autoclean",
+         "options": {
+            "autocleaninvoice-cycle": null,
+            "autocleaninvoice-expired-by": null
+         }
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/fundchannel",
+         "name": "fundchannel"
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/keysend",
+         "name": "keysend"
+      },
+      {
+         "path": "/home/vincent/Github/lightning/lightningd/../plugins/pay",
+         "name": "pay",
+         "options": {
+            "disable-mpp": false
+         }
+      }
+   ],
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/autoclean",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/fundchannel",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/keysend",
+   "important-plugin": "/home/vincent/Github/lightning/lightningd/../plugins/pay",
+   "plugin": "/home/vincent/Github/plugins/sauron/sauron.py",
+   "plugin": "/home/vincent/Github/reckless/reckless.py",
+   "disable-plugin": [
+      "bcli"
+   ],
+   "always-use-proxy": false,
+   "daemon": "false",
+   "wallet": "sqlite3:///media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev/testnet/lightningd.sqlite3",
+   "wumbo": false,
+   "wumbo": false,
+   "rgb": "03ad98",
+   "alias": "BRUCEWAYN-TES-DEV",
+   "pid-file": "/media/vincent/Maxtor/sanboxTestWrapperRPC/lightning_dir_dev/lightningd-testne...",
+   "ignore-fee-limits": true,
+   "watchtime-blocks": 6,
+   "max-locktime-blocks": 2016,
+   "funding-confirms": 1,
+   "commit-fee-min": 0,
+   "commit-fee-max": 0,
+   "cltv-delta": 6,
+   "cltv-final": 10,
+   "commit-time": 10,
+   "fee-base": 1,
+   "rescan": 30,
+   "fee-per-satoshi": 10,
+   "max-concurrent-htlcs": 483,
+   "min-capacity-sat": 10000,
+   "addr": "autotor:127.0.0.1:9051",
+   "bind-addr": "127.0.0.1:9735",
+   "announce-addr": "fp463inc4w3lamhhduytrwdwq6q6uzugtaeapylqfc43agrdnnqsheyd.onion:9735",
+   "offline": "false",
+   "autolisten": true,
+   "proxy": "127.0.0.1:9050",
+   "disable-dns": "false",
+   "enable-autotor-v2-mode": "false",
+   "encrypted-hsm": false,
+   "rpc-file-mode": "0600",
+   "log-level": "DEBUG",
+   "log-prefix": "lightningd",
+}
+
+```
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+SEE ALSO
+--------
+
+lightning-getinfo(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **listconfigs** teh RPC command to list all configuration options, or with *config*, just that one.
+The **listconfigs** RPC command to list all configuration options, or with *config*, just that one.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -27,53 +27,18 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, an object with the following proprieties is returned:
+On success, an object is returned with members reflecting the
+corresponding lightningd-config(5) options which were specified in
+the configuration file(s) and command line.
 
-- *# version*: A string that rappresents the version of node.
-- *lightning-dir*: A string that rappresents the work dir of the node.
-- *network*: A string that rappresents the network (e.g: bitcoin).
-- *allow-deprecated-apis*: A boolean value that rappresent if the deprecated api are avaible on the node.
-- *rpc-file*: A string that rappresent the location of the rpc file.
-- *plugins*: A array that rappresent the no important plugin registered. Each object contains the following proprieties:
-   - *path*: A string that rappresent the path of plugin.
-   - *name*: A string that rappresent the name of plugin.
-   - *options*: A object that contains all options accepted from comand line, if the plugin accepted parameters from command line.
-- *important-plugins*: An array that rappresent all important pluging registered to the node. Each object contains the same proprieties of *plugin* array.
-- *disable-plugin*: An array of string that rappresent the name of plugin disabled.
-- *always-use-proxy*: A boolean value that rappresent if the node utilize always the proxy.
-- *daemon*: A boolean value is the node have the daemon propriety enabled.
-- *wallet*: A string that rappresent the location of wallet with database url convention.
-- *wumbo*: A boolean value that rappresent the value of wumbo propriety.
-- *rgb*: A string that rappresent the color of the node.
-- *alias*: A string that rappresent the alias of the node.
-- *pid-file*: A string that rappresent the location of the pid file.
-- *ignore-fee-limits*: A boolean value that rappresent is the node ignore the fee limit.
-- *watchtime-blocks*: An integer that rappresent the watchtime of the blocks.
-- *max-locktime-blocks*: A integer that rappresent that max locktime for blocks.
-- *funding-confirms*: An integer that rappresent the number of funding transaction confermation.
-- *commit-fee-min*: A integer that rappresent the minimum commit fee.
-- *commit-fee-max*: A integer that rappresent the maximum commit fee.
-- *cltv-delta*: An integer that rappresent the value of cltv delta.
-- *cltv-final*: An integer that rappresent the value of cltv final.
-- *commit-time*: An integer that rappresent the value of commit time.
-- *fee-base*: A integer that rappresent the value of fee base.
-- *rescan*: A integer that rappresent the number of block that the node must rescan before to run.
-- *fee-per-satoshi*: An integer that rappresent the fee for satoshi.
-- *max-concurrent-htlcs*: A integer that rappresent the number of HTLCs one channel can handle concurrently in each direction.
-- *min-capacity-sat*: A integer that rappresent the minimal effective channel capacity in satoshi to accept for channel opening requests.
-- *addr*: A string that rappresent the address where the node are listen.
-- *bind-addr*: A string that rappresent the address or UNIX domine socket where the node are listen.
-- *announce-addr*: A string that rappresent the address where the node is annunced.
-- *offline*: A boolean value that rappresent if the node is offline.
-- *autolisten*: A boolean value that rappresent if the autolisten is enabled.
-- *proxy*: A string that rappresent the proxy address.
-- *disable-dns*: A boolean value that rappresent if the dns is disabled.
-- *enable-autotor-v2-mode*: A boolean value that rappresent if the Tor v2 is enabled.
-- *encrypted-hsm*: A boolean value that rappresent if the wallet is encrypted. 
-- *rpc-file-mode*: A string that rappresent the value rpc-file-mode.
-- *log-level*: A string that rappresent the level of log.
-- *log-prefix*: A string that rappresent the log prefix.i
+Additional members include:
 
+- *# version*: A string that represents the version of node.
+- *plugins*: A array that represents the non-important plugin registered. Each object contains the following members:
+   - *path*: A string that represents the path of plugin.
+   - *name*: A string that represents the name of plugin.
+   - *options*: A object that contains all options accepted from command line or configuration file, if the plugin has opitions
+- *important-plugins*: An array that represents all important plugins registered to the node. Each object contains the same members as the *plugin* array.
 
 On failure, one of the following error codes may be returned:
 
@@ -183,7 +148,7 @@ Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version o
 SEE ALSO
 --------
 
-lightning-getinfo(7)
+lightning-getinfo(7), lightningd-config(5)
 
 RESOURCES
 ---------

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -73,7 +73,7 @@ On success, an object with the following proprieties is returned:
 - *log-prefix*: A string that rappresent the log prefix.
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters or field with *config* name doesn't exist.
+- -32602: Error in given parameters or field with *config* name doesn't exist.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -88,4 +88,4 @@ Felix \fI<fixone@gmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:3f4f346ab97ae18e5c38a641def243716c07979c81168e093f7b6b8089c9bd1d
+\" SHA256STAMP:d7b4a30a1ca19e772529fbe517fb73e8c0d5c07ec3c05969ab614a4abc1865a4

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -82,7 +82,7 @@ Felix \fI<fixone@gmail.com\fR> is mainly responsible\.
 
 .SH SEE ALSO
 
-\fBlightning-newaddr\fR(7), \fBlightning-fundchannel\fR(7), \fBlightning-withdraw\fR(7)
+\fBlightning-newaddr\fR(7), \fBlightning-fundchannel\fR(7), \fBlightning-withdraw\fR(7), \fBlightning-listtransactions\fR(7)
 
 .SH RESOURCES
 

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -60,7 +60,7 @@ Felix <<fixone@gmail.com>> is mainly responsible.
 SEE ALSO
 --------
 
-lightning-newaddr(7), lightning-fundchannel(7), lightning-withdraw(7)
+lightning-newaddr(7), lightning-fundchannel(7), lightning-withdraw(7), lightning-listtransactions(7)
 
 RESOURCES
 ---------

--- a/doc/lightning-listnodes.7
+++ b/doc/lightning-listnodes.7
@@ -1,13 +1,13 @@
 .TH "LIGHTNING-LISTNODES" "7" "" "" "lightning-listnodes"
 .SH NAME
-lightning-listnodes - Command to get the list of nodes in the own node network\.
+lightning-listnodes - Command to get the list of nodes in the known network\.
 .SH SYNOPSIS
 
 \fBlistnodes\fR [id]
 
 .SH DESCRIPTION
 
-The \fBlistnodes\fR command returns nodes in the own node network, or a single one if the node \fIid\fR was specified\.
+The \fBlistnodes\fR command returns nodes the node has learned about via gossip messages, or a single one if the node \fIid\fR was specified\.
 
 .SH EXAMPLE JSON REQUEST
 .nf
@@ -28,23 +28,30 @@ On success, the command will return a list of nodes, each object represents a no
 
 .RS
 .IP \[bu]
-\fInodeid\fR: A string that rappresents the node id\.
+\fInodeid\fR: A string that represents the node id\.
+
+.RE
+
+For nodes which have sent a node_announcement message, the following
+are also returned:
+
+.RS
 .IP \[bu]
-\fIalias\fR: A string that rappresents alias of the node on the network\.
+\fIalias\fR: A string that represents alias of the node on the network\.
 .IP \[bu]
-\fIcolor\fR: A string that rappresents the personal color of the node\.
+\fIcolor\fR: A string that represents the personal color of the node\.
 .IP \[bu]
-\fIlast_timestamp\fR: An integer that rappresent the last timestamp\.
+\fIlast_timestamp\fR: An integer that represents the timestamp of the last-received node_announcement message\.
 .IP \[bu]
-\fIfeatures\fR: A string that rappresent the features value\.
+\fIfeatures\fR: A string that represents the features value\.
 .IP \[bu]
-\fIaddresses\fR: An array that rappresent the addreses avaible\. Each address is rappresented with an object with the following properties:.RS
+\fIaddresses\fR: An array that represents the addreses avaible\. Each address is represented with an object with the following properties:.RS
 .IP \[bu]
-\fItype\fR: A string that rappresent the address type (ipv4 or ipv6)\.
+\fItype\fR: A string that represents the address type (ipv4 or ipv6)\.
 .IP \[bu]
-\fIaddress\fR: A string that rappresent the address value\.
+\fIaddress\fR: A string that represents the address value\.
 .IP \[bu]
-\fIport\fR: An integer that rappresent the port number where the node are listening\.
+\fIport\fR: An integer that represents the port number where the node are listening\.
 
 .RE
 
@@ -94,3 +101,4 @@ FIXME:
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:901b147ccbfe0a18310a44ca848b623e83fa3c68912dacadefd045d4a2095523

--- a/doc/lightning-listnodes.7
+++ b/doc/lightning-listnodes.7
@@ -1,0 +1,96 @@
+.TH "LIGHTNING-LISTNODES" "7" "" "" "lightning-listnodes"
+.SH NAME
+lightning-listnodes - Command to get the list of nodes in the own node network\.
+.SH SYNOPSIS
+
+\fBlistnodes\fR [id]
+
+.SH DESCRIPTION
+
+The \fBlistnodes\fR command returns nodes in the own node network, or a single one if the node \fIid\fR was specified\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "listnodes",
+  "params": {
+    "id": "02e29856dab8ddd9044c18486e4cab79ec717b490447af2d4831e290e48d57638a"
+  }
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, the command will return a list of nodes, each object represents a node, with the following details:
+
+.RS
+.IP \[bu]
+\fInodeid\fR: A string that rappresents the node id\.
+.IP \[bu]
+\fIalias\fR: A string that rappresents alias of the node on the network\.
+.IP \[bu]
+\fIcolor\fR: A string that rappresents the personal color of the node\.
+.IP \[bu]
+\fIlast_timestamp\fR: An integer that rappresent the last timestamp\.
+.IP \[bu]
+\fIfeatures\fR: A string that rappresent the features value\.
+.IP \[bu]
+\fIaddresses\fR: An array that rappresent the addreses avaible\. Each address is rappresented with an object with the following properties:.RS
+.IP \[bu]
+\fItype\fR: A string that rappresent the address type (ipv4 or ipv6)\.
+.IP \[bu]
+\fIaddress\fR: A string that rappresent the address value\.
+.IP \[bu]
+\fIport\fR: An integer that rappresent the port number where the node are listening\.
+
+.RE
+
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "nodes": [
+      {
+         "nodeid": "02e29856dab8ddd9044c14586e4cab79ec717b490447af2d4831e290e48d58638a",
+         "alias": "some_alias",
+         "color": "68f442",
+         "last_timestamp": 1597213741,
+         "features": "02a2a1",
+         "addresses": [
+            {
+               "type": "ipv4",
+               "address": "zzz.yy.xx.xx",
+               "port": 9735
+            }
+         ]
+      }
+    ]
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+FIXME: 
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -1,4 +1,4 @@
-lightning-listnodes -- Command to get the list of nodes in the own node network.
+lightning-listnodes -- Command to get the list of nodes in the known network.
 ============================================================
 
 SYNOPSIS
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **listnodes** command returns nodes in the own node network, or a single one if the node *id* was specified.
+The **listnodes** command returns nodes the node has learned about via gossip messages, or a single one if the node *id* was specified.
 
 EXAMPLE JSON REQUEST
 ------------
@@ -28,15 +28,19 @@ RETURN VALUE
 
 On success, the command will return a list of nodes, each object represents a node, with the following details:
 
-- *nodeid*: A string that rappresents the node id.
-- *alias*: A string that rappresents alias of the node on the network.
-- *color*: A string that rappresents the personal color of the node.
-- *last_timestamp*: An integer that rappresent the last timestamp.
-- *features*: A string that rappresent the features value.
-- *addresses*: An array that rappresent the addreses avaible. Each address is rappresented with an object with the following properties:
-  - *type*: A string that rappresent the address type (ipv4 or ipv6).
-  - *address*: A string that rappresent the address value.
-  - *port*: An integer that rappresent the port number where the node are listening.
+- *nodeid*: A string that represents the node id.
+
+For nodes which have sent a node_announcement message, the following
+are also returned:
+
+- *alias*: A string that represents alias of the node on the network.
+- *color*: A string that represents the personal color of the node.
+- *last_timestamp*: An integer that represents the timestamp of the last-received node_announcement message.
+- *features*: A string that represents the features value.
+- *addresses*: An array that represents the addreses avaible. Each address is represented with an object with the following properties:
+  - *type*: A string that represents the address type (ipv4 or ipv6).
+  - *address*: A string that represents the address value.
+  - *port*: An integer that represents the port number where the node are listening.
   
 On failure, one of the following error codes may be returned:
  

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -1,4 +1,4 @@
-lightning-listnodes -- Command to get the list of nodes in the own node network
+lightning-listnodes -- Command to get the list of nodes in the own node network.
 ============================================================
 
 SYNOPSIS
@@ -32,9 +32,9 @@ On success, the command will return a list of nodes, each object represents a no
 - *alias*: A string that rappresents alias of the node on the network.
 - *color*: A string that rappresents the personal color of the node.
 - *last_timestamp*: An integer that rappresent the last timestamp.
-- *features*: An string that rappresent the features value.
-- *addresses*: An array that rappresent the addreses avaible, each address is rappresented with an object with the following properties:
-  - *type*: A string that rappresent the type of address (ipv4 or ipv6).
+- *features*: A string that rappresent the features value.
+- *addresses*: An array that rappresent the addreses avaible. Each address is rappresented with an object with the following properties:
+  - *type*: A string that rappresent the address type (ipv4 or ipv6).
   - *address*: A string that rappresent the address value.
   - *port*: An integer that rappresent the port number where the node are listening.
   

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -40,7 +40,7 @@ On success, the command will return a list of nodes, each object represents a no
   
 On failure, one of the following error codes may be returned:
  
-- -32602. Error in given parameters.
+- -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -1,0 +1,82 @@
+lightning-listnodes -- Command to get the list of nodes in the own node network
+============================================================
+
+SYNOPSIS
+--------
+
+**listnodes** \[id\]
+
+DESCRIPTION
+-----------
+
+The **listnodes** command returns nodes in the own node network, or a single one if the node *id* was specified.
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "listnodes",
+  "params": {
+    "id": "02e29856dab8ddd9044c18486e4cab79ec717b490447af2d4831e290e48d57638a"
+  }
+}
+```
+
+RETURN VALUE
+------------
+
+On success, the command will return a list of nodes, each object represents a node, with the following details:
+
+- *nodeid*: A string that rappresents the node id.
+- *alias*: A string that rappresents alias of the node on the network.
+- *color*: A string that rappresents the personal color of the node.
+- *last_timestamp*: An integer that rappresent the last timestamp.
+- *features*: An string that rappresent the features value.
+- *addresses*: An array that rappresent the addreses avaible, each address is rappresented with an object with the following properties:
+  - *type*: A string that rappresent the type of address (ipv4 or ipv6).
+  - *address*: A string that rappresent the address value.
+  - *port*: An integer that rappresent the port number where the node are listening.
+  
+On failure, one of the following error codes may be returned:
+ 
+- -32602. Error in given parameters.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+   "nodes": [
+      {
+         "nodeid": "02e29856dab8ddd9044c14586e4cab79ec717b490447af2d4831e290e48d58638a",
+         "alias": "some_alias",
+         "color": "68f442",
+         "last_timestamp": 1597213741,
+         "features": "02a2a1",
+         "addresses": [
+            {
+               "type": "ipv4",
+               "address": "zzz.yy.xx.xx",
+               "port": 9735
+            }
+         ]
+      }
+    ]
+}
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+SEE ALSO
+--------
+
+FIXME: 
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-listtransactions.7
+++ b/doc/lightning-listtransactions.7
@@ -26,34 +26,34 @@ On success, the command will return a list of transactions, each object represen
 
 .RS
 .IP \[bu]
-\fIhash\fR: A string that rappresents the hash of transaction, which the caller can use to find it on the blockchain\.
+\fIhash\fR: A string that represents the hash of transaction, which the caller can use to find it on the blockchain\.
 .IP \[bu]
-\fIrawtx\fR: A string that rappresents the hexadecimal dump of the transaction\.
+\fIrawtx\fR: A string that represents the hexadecimal dump of the transaction\.
 .IP \[bu]
-\fIblockheight\fR: An integer that rappresents the block height that contains the transaction on the blockchain\.
+\fIblockheight\fR: An integer that represents the block height that contains the transaction on the blockchain\.
 .IP \[bu]
-\fItxindex\fR: An integer that rappresent the transaction index inside the block\.
+\fItxindex\fR: An integer that represents the transaction index inside the block\.
 .IP \[bu]
-\fIlocktime\fR: An integer that rappresent the locktime\.
+\fIlocktime\fR: An integer that represents the nLocktime field\.
 .IP \[bu]
-\fIversion\fR: An integer that rappresent the version\.
+\fIversion\fR: An integer that represents the nVersion field\.
 .IP \[bu]
-\fIinputs\fR: A list of spent transaction outputs, each spent transaction output is rappresented with an object with the following properties:.RS
+\fIinputs\fR: A list of spent transaction outputs, each spent transaction output is represented with an object with the following properties:.RS
 .IP \[bu]
-\fItxid\fR: A string that rappresent the hash of transaction\. This is the output index of the transaction output being spent\.
+\fItxid\fR: A string that represents the hash of transaction\. This is the output index of the transaction output being spent\.
 .IP \[bu]
-\fIindex\fR: An integer that rappresent the index of transaction\.
+\fIindex\fR: An integer that represents the index of transaction\.
 .IP \[bu]
-\fIsequence\fR: An integer that rappresent the sequence number\.
+\fIsequence\fR: An integer that represents the nSequence field\.
 
 .RE
 
 .IP \[bu]
-\fIoutputs\fR: A list of transactions, each transaction is rappresented with an object with the following proprieties:.RS
+\fIoutputs\fR: A list of transactions, each transaction is represented with an object with the following proprieties:.RS
 .IP \[bu]
-\fIindex\fR: An integer that rappresent the index of transaction\.
+\fIindex\fR: An integer that represents the index of transaction\.
 .IP \[bu]
-\fIsatoshis\fR: A string that rappresent the amount in millisatoshi\.
+\fIsatoshis\fR: A string that represents the amount in millisatoshi\.
 .IP \[bu]
 \fIscriptPubKey\fR: A string that contains the lock script in hexadecimal dump form\.
 
@@ -118,3 +118,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:88c68faf136cd7ce305bab0b89813d1c0122b8f31688a2dc9c064f7cba480a1d

--- a/doc/lightning-listtransactions.7
+++ b/doc/lightning-listtransactions.7
@@ -1,0 +1,120 @@
+.TH "LIGHTNING-LISTTRANSACTIONS" "7" "" "" "lightning-listtransactions"
+.SH NAME
+lightning-listtransactions - Command to get the list of transactions that was stored in the wallet\.
+.SH SYNOPSIS
+
+\fBlisttransactions\fR
+
+.SH DESCRIPTION
+
+The \fBlisttransactions\fR command returns transactions tracked in the wallet\. This includes deposits, withdrawals and transactions related to channels\. A transaction may have multiple types, e\.g\., a transaction may both be a close and a deposit if it closes the channel and returns funds to the wallet\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "listtransactions",
+  "params": {}
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, the command will return a list of transactions, each object represents a transaction, with the following details:
+
+.RS
+.IP \[bu]
+\fIhash\fR: A string that rappresents the hash of transaction, which the caller can use to find it on the blockchain\.
+.IP \[bu]
+\fIrawtx\fR: A string that rappresents the hexadecimal dump of the transaction\.
+.IP \[bu]
+\fIblockheight\fR: An integer that rappresents the block height that contains the transaction on the blockchain\.
+.IP \[bu]
+\fItxindex\fR: An integer that rappresent the transaction index inside the block\.
+.IP \[bu]
+\fIlocktime\fR: An integer that rappresent the locktime\.
+.IP \[bu]
+\fIversion\fR: An integer that rappresent the version\.
+.IP \[bu]
+\fIinputs\fR: A list of spent transaction outputs, each spent transaction output is rappresented with an object with the following properties:.RS
+.IP \[bu]
+\fItxid\fR: A string that rappresent the hash of transaction\. This is the output index of the transaction output being spent\.
+.IP \[bu]
+\fIindex\fR: An integer that rappresent the index of transaction\.
+.IP \[bu]
+\fIsequence\fR: An integer that rappresent the sequence number\.
+
+.RE
+
+.IP \[bu]
+\fIoutputs\fR: A list of transactions, each transaction is rappresented with an object with the following proprieties:.RS
+.IP \[bu]
+\fIindex\fR: An integer that rappresent the index of transaction\.
+.IP \[bu]
+\fIsatoshis\fR: A string that rappresent the amount in millisatoshi\.
+.IP \[bu]
+\fIscriptPubKey\fR: A string that contains the lock script in hexadecimal dump form\.
+
+.RE
+
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "transactions": [
+      {
+         "hash": "05985072bbe20747325e69a159fe08176cc1bbc96d25e8848edad2dddc1165d0",
+         "rawtx": "02000000027032912651fc25a3e0893acd5f9640598707e2dfef92143bb5a4020e335442800100000017160014a5f48b9aa3cb8ca6cc1040c11e386745bb4dc932ffffffffd229a4b4f78638ebcac10a68b0561585a5d6e4d3b769ad0a909e9b9afaeae24e00000000171600145c83da9b685f9142016c6f5eb5f98a45cfa6f686ffffffff01915a01000000000017a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf8700000000",
+         "blockheight": 0,
+         "txindex": 0,
+         "locktime": 0,
+         "version": 2,
+         "inputs": [
+            {
+               "txid": "804254330e02a4b53b1492efdfe207875940965fcd3a89e0a325fc5126913270",
+               "index": 1,
+               "sequence": 4294967295
+            },
+            {
+               "txid": "4ee2eafa9a9b9e900aad69b7d3e4d6a5851556b0680ac1caeb3886f7b4a429d2",
+               "index": 0,
+               "sequence": 4294967295
+            }
+         ],
+         "outputs": [
+            {
+               "index": 0,
+               "satoshis": "88721000msat",
+               "scriptPubKey": "a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf87"
+            }
+         ]
+      }
+    ]
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-newaddr\fR(7), \fBlightning-listfunds\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -26,19 +26,19 @@ RETURN VALUE
 
 On success, the command will return a list of transactions, each object represents a transaction, with the following details:
 
-- *hash*: A string that rappresents the hash of transaction, which the caller can use to find it on the blockchain.
-- *rawtx*: A string that rappresents the hexadecimal dump of the transaction.
-- *blockheight*: An integer that rappresents the block height that contains the transaction on the blockchain.
-- *txindex*: An integer that rappresent the transaction index inside the block.
-- *locktime*: An integer that rappresent the locktime.
-- *version*: An integer that rappresent the version.
-- *inputs*: A list of spent transaction outputs, each spent transaction output is rappresented with an object with the following properties:
-  - *txid*: A string that rappresent the hash of transaction. This is the output index of the transaction output being spent.
-  - *index*: An integer that rappresent the index of transaction.
-  - *sequence*: An integer that rappresent the sequence number.
-- *outputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
-  - *index*: An integer that rappresent the index of transaction.
-  - *satoshis*: A string that rappresent the amount in millisatoshi.
+- *hash*: A string that represents the hash of transaction, which the caller can use to find it on the blockchain.
+- *rawtx*: A string that represents the hexadecimal dump of the transaction.
+- *blockheight*: An integer that represents the block height that contains the transaction on the blockchain.
+- *txindex*: An integer that represents the transaction index inside the block.
+- *locktime*: An integer that represents the nLocktime field.
+- *version*: An integer that represents the nVersion field.
+- *inputs*: A list of spent transaction outputs, each spent transaction output is represented with an object with the following properties:
+  - *txid*: A string that represents the hash of transaction. This is the output index of the transaction output being spent.
+  - *index*: An integer that represents the index of transaction.
+  - *sequence*: An integer that represents the nSequence field.
+- *outputs*: A list of transactions, each transaction is represented with an object with the following proprieties:
+  - *index*: An integer that represents the index of transaction.
+  - *satoshis*: A string that represents the amount in millisatoshi.
   - *scriptPubKey*: A string that contains the lock script in hexadecimal dump form.
   
 On failure, one of the following error codes may be returned:

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -1,4 +1,4 @@
-lightning-listtransactions -- Command to get the list of transactions that was stored in the wallet
+lightning-listtransactions -- Command to get the list of transactions that was stored in the wallet.
 ============================================================
 
 SYNOPSIS
@@ -37,9 +37,9 @@ On success, the command will return a list of transactions, each object represen
   - *index*: An integer that rappresent the index of transaction.
   - *sequence*: An integer that rappresent the sequence number.
 - *outputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
-  - *index*: An integer that rappresent the index of transaction. This is the output index of the transaction output.
-  - *satoshis*: A string that rappresent the amount in millisatoshi that contains the transaction.
-  - *scriptPubKey*: A string that contains the lock script in hexadecimal dump form..
+  - *index*: An integer that rappresent the index of transaction.
+  - *satoshis*: A string that rappresent the amount in millisatoshi.
+  - *scriptPubKey*: A string that contains the lock script in hexadecimal dump form.
   
 On failure, one of the following error codes may be returned:
  -32602. Error in given parameters.

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -1,0 +1,100 @@
+lightning-listtransactions -- Command to get the list of transactions that was stored in the wallet
+============================================================
+
+SYNOPSIS
+--------
+
+**listtransactions**
+
+DESCRIPTION
+-----------
+
+The **listtransactions** command returns transactions tracked in the wallet. This includes deposits, withdrawals and transactions related to channels. A transaction may have multiple types, e.g., a transaction may both be a close and a deposit if it closes the channel and returns funds to the wallet.
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "listtransactions",
+  "params": {}
+}
+```
+
+RETURN VALUE
+------------
+
+On success, the command will return a list of transactions, each object rappresent the transaction with all details.
+
+- *hash*: A string that rappresent  the hash of transaction, with the caller can use to find it on blockchain.
+- *rawtx*: A string that rappresent the hexdecimal of transaction.
+- *blockheight*: An integer that rappresent the block height that contains the transaction on blockchain.
+- *txindex*: An integer that rappresent the transaction index inside the block.
+- *locktime*: An integer that rappresent the locktime.
+- *version*: An integer that rappresent the version.
+- *inputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
+  - *txid*: A string that rappresent the hash of transaction.
+  - *index*: An integer that rappresent the index of transaction.
+  - *sequence*: A integera that rappresent the sequence.
+- *outputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
+  - *index*: An integer that rappresent the index of transaction.
+  - *satoshis*: A string that rappresent the amount in millisatoshi that contains the transaction.
+  - *scriptPubKey*: A string that contains the lock script.
+  
+On failure, an error is returned and any result was returned.
+
+The following error codes may occur:
+
+- -32602: parameter is malformed;
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+   "transactions": [
+      {
+         "hash": "05985072bbe20747325e69a159fe08176cc1bbc96d25e8848edad2dddc1165d0",
+         "rawtx": "02000000027032912651fc25a3e0893acd5f9640598707e2dfef92143bb5a4020e335442800100000017160014a5f48b9aa3cb8ca6cc1040c11e386745bb4dc932ffffffffd229a4b4f78638ebcac10a68b0561585a5d6e4d3b769ad0a909e9b9afaeae24e00000000171600145c83da9b685f9142016c6f5eb5f98a45cfa6f686ffffffff01915a01000000000017a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf8700000000",
+         "blockheight": 0,
+         "txindex": 0,
+         "locktime": 0,
+         "version": 2,
+         "inputs": [
+            {
+               "txid": "804254330e02a4b53b1492efdfe207875940965fcd3a89e0a325fc5126913270",
+               "index": 1,
+               "sequence": 4294967295
+            },
+            {
+               "txid": "4ee2eafa9a9b9e900aad69b7d3e4d6a5851556b0680ac1caeb3886f7b4a429d2",
+               "index": 0,
+               "sequence": 4294967295
+            }
+         ],
+         "outputs": [
+            {
+               "index": 0,
+               "satoshis": "88721000msat",
+               "scriptPubKey": "a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf87"
+            }
+         ]
+      }
+    ]
+}
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing of this rpc command.
+
+SEE ALSO
+--------
+
+FIXME: add somethings.
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -42,7 +42,7 @@ On success, the command will return a list of transactions, each object represen
   - *scriptPubKey*: A string that contains the lock script in hexadecimal dump form.
   
 On failure, one of the following error codes may be returned:
- -32602. Error in given parameters.
+- -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -24,28 +24,25 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, the command will return a list of transactions, each object rappresent the transaction with all details.
+On success, the command will return a list of transactions, each object represents a transaction, with the following details:
 
-- *hash*: A string that rappresent  the hash of transaction, with the caller can use to find it on blockchain.
-- *rawtx*: A string that rappresent the hexdecimal of transaction.
-- *blockheight*: An integer that rappresent the block height that contains the transaction on blockchain.
+- *hash*: A string that rappresents the hash of transaction, which the caller can use to find it on the blockchain.
+- *rawtx*: A string that rappresents the hexadecimal dump of the transaction.
+- *blockheight*: An integer that rappresents the block height that contains the transaction on the blockchain.
 - *txindex*: An integer that rappresent the transaction index inside the block.
 - *locktime*: An integer that rappresent the locktime.
 - *version*: An integer that rappresent the version.
-- *inputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
-  - *txid*: A string that rappresent the hash of transaction.
+- *inputs*: A list of spent transaction outputs, each spent transaction output is rappresented with an object with the following properties:
+  - *txid*: A string that rappresent the hash of transaction. This is the output index of the transaction output being spent.
   - *index*: An integer that rappresent the index of transaction.
-  - *sequence*: A integera that rappresent the sequence.
+  - *sequence*: An integer that rappresent the sequence number.
 - *outputs*: A list of transactions, each transaction is rappresented with an object with the following proprieties:
-  - *index*: An integer that rappresent the index of transaction.
+  - *index*: An integer that rappresent the index of transaction. This is the output index of the transaction output.
   - *satoshis*: A string that rappresent the amount in millisatoshi that contains the transaction.
-  - *scriptPubKey*: A string that contains the lock script.
+  - *scriptPubKey*: A string that contains the lock script in hexadecimal dump form..
   
-On failure, an error is returned and any result was returned.
-
-The following error codes may occur:
-
-- -32602: parameter is malformed;
+On failure, one of the following error codes may be returned:
+ -32602. Error in given parameters.
 
 EXAMPLE JSON RESPONSE
 -----
@@ -87,12 +84,12 @@ EXAMPLE JSON RESPONSE
 AUTHOR
 ------
 
-Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing of this rpc command.
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
 
 SEE ALSO
 --------
 
-FIXME: add somethings.
+lightning-newaddr(7), lightning-listfunds(7)
 
 RESOURCES
 ---------

--- a/doc/lightning-newaddr.7
+++ b/doc/lightning-newaddr.7
@@ -41,7 +41,7 @@ Felix \fI<fixone@gmail.com\fR> is mainly responsible\.
 
 .SH SEE ALSO
 
-\fBlightning-listfunds\fR(7), \fBlightning-fundchannel\fR(7), \fBlightning-withdraw\fR(7)
+\fBlightning-listfunds\fR(7), \fBlightning-fundchannel\fR(7), \fBlightning-withdraw\fR(7), \fBlightning-listtransactions\fR(7)
 
 .SH RESOURCES
 

--- a/doc/lightning-newaddr.7
+++ b/doc/lightning-newaddr.7
@@ -47,4 +47,4 @@ Felix \fI<fixone@gmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:5629893e244874b3685b217aed66f4768e140444fc58e14be719e40598494e26
+\" SHA256STAMP:00cbee36ae0e616fc3610191dfb1c14cb112971d9900fb8549ec66e4f700942f

--- a/doc/lightning-newaddr.7.md
+++ b/doc/lightning-newaddr.7.md
@@ -44,7 +44,7 @@ Felix <<fixone@gmail.com>> is mainly responsible.
 SEE ALSO
 --------
 
-lightning-listfunds(7), lightning-fundchannel(7), lightning-withdraw(7)
+lightning-listfunds(7), lightning-fundchannel(7), lightning-withdraw(7), lightning-listtransactions(7)
 
 RESOURCES
 ---------

--- a/doc/lightning-ping.7
+++ b/doc/lightning-ping.7
@@ -7,15 +7,15 @@ lightning-ping - Command to check if a node is up\.
 
 .SH DESCRIPTION
 
-The \fBping\fR command check if the node with id is ready to talk\. It accept the following parameter:
+The \fBping\fR command checks if the node with \fIid\fR is ready to talk\. It accepts the following parameters:
 
 .RS
 .IP \[bu]
-\fIid\fR: A string that rappresent the node id;
+\fIid\fR: A string that represents the node id;
 .IP \[bu]
-\fIlen\fR: A integer that rappresent the lenght of {\.\.\.}, by default is 128;
+\fIlen\fR: A integer that represents the length of the ping (default 128);
 .IP \[bu]
-\fIpongbytes\fR: An integer that rappresent the lenght of {}, by default is 128\.
+\fIpongbytes\fR: An integer that represents the length of the reply (default 128)\.
 
 .RE
 .SH EXAMPLE JSON REQUEST
@@ -38,7 +38,7 @@ On success, the command will return an object with a single string\.
 
 .RS
 .IP \[bu]
-\fItotlen\fR: A string that rappresent the answer lenght of {}\.
+\fItotlen\fR: A string that represents the answer length of the reply message (including header)
 
 .RE
 
@@ -46,7 +46,7 @@ On failure, one of the following error codes may be returned:
 
 .RS
 .IP \[bu]
--32602: Error in given parameters or unknow peer\.
+-32602: Error in given parameters or unknown peer\.
 
 .RE
 .SH EXAMPLE JSON RESPONSE
@@ -70,3 +70,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:eac5506bc761a2a9570a92c7e533b4c6ba72c56c4d69dce773887a9f88ea7ac2

--- a/doc/lightning-ping.7
+++ b/doc/lightning-ping.7
@@ -1,0 +1,72 @@
+.TH "LIGHTNING-PING" "7" "" "" "lightning-ping"
+.SH NAME
+lightning-ping - Command to check if a node is up\.
+.SH SYNOPSIS
+
+\fBping\fR \fIid\fR [len] [pongbytes]
+
+.SH DESCRIPTION
+
+The \fBping\fR command check if the node with id is ready to talk\. It accept the following parameter:
+
+.RS
+.IP \[bu]
+\fIid\fR: A string that rappresent the node id;
+.IP \[bu]
+\fIlen\fR: A integer that rappresent the lenght of {\.\.\.}, by default is 128;
+.IP \[bu]
+\fIpongbytes\fR: An integer that rappresent the lenght of {}, by default is 128\.
+
+.RE
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "ping",
+  "params": {
+    "len": 128,
+    "pongbytes": 128
+  }
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, the command will return an object with a single string\.
+
+.RS
+.IP \[bu]
+\fItotlen\fR: A string that rappresent the answer lenght of {}\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters or unknow peer\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+   "totlen": 132
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-connect\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -9,11 +9,11 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **ping** command check if the node with id is ready to talk. It accept the following parameter:
+The **ping** command checks if the node with *id* is ready to talk. It accepts the following parameters:
 
-- *id*: A string that rappresent the node id;
-- *len*: A integer that rappresent the lenght of {...}, by default is 128;
-- *pongbytes*: An integer that rappresent the lenght of {}, by default is 128.
+- *id*: A string that represents the node id;
+- *len*: A integer that represents the length of the ping (default 128);
+- *pongbytes*: An integer that represents the length of the reply (default 128).
 
 EXAMPLE JSON REQUEST
 ------------
@@ -33,11 +33,11 @@ RETURN VALUE
 
 On success, the command will return an object with a single string.
 
-- *totlen*: A string that rappresent the answer lenght of {}.
+- *totlen*: A string that represents the answer length of the reply message (including header)
 
 On failure, one of the following error codes may be returned:
 
-- -32602: Error in given parameters or unknow peer.
+- -32602: Error in given parameters or unknown peer.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -1,0 +1,64 @@
+lightning-ping -- Command to check if a node is up.
+============================================================
+
+SYNOPSIS
+--------
+
+**ping** *id* \[len\] \[pongbytes\]
+
+DESCRIPTION
+-----------
+
+The **ping** command check if the node with id is ready to talk. It accept the following parameter:
+
+- *id*: A string that rappresent the node id;
+- *len*: A integer that rappresent the lenght of {...}, by default is 128;
+- *pongbytes*: An integer that rappresent the lenght of {}, by default is 128.
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "ping",
+  "params": {
+    "len": 128,
+    "pongbytes": 128
+  }
+}
+```
+
+RETURN VALUE
+------------
+
+On success, the command will return an object with a single string.
+
+- *totlen*: A string that rappresent the answer lenght of {}.
+
+On failure, one of the following error codes may be returned:
+ -32602. Error in given parameters or unknow peer.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+   "totlen": 132
+}
+
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+SEE ALSO
+--------
+
+lightning-connect(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -36,7 +36,8 @@ On success, the command will return an object with a single string.
 - *totlen*: A string that rappresent the answer lenght of {}.
 
 On failure, one of the following error codes may be returned:
- -32602. Error in given parameters or unknow peer.
+
+- -32602: Error in given parameters or unknow peer.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-sendpsbt.7
+++ b/doc/lightning-sendpsbt.7
@@ -1,0 +1,70 @@
+.TH "LIGHTNING-SENDPSBT" "7" "" "" "lightning-sendpsbt"
+.SH NAME
+lightning-sendpsbt - Command to finalize, extract and send a partially signed bitcoin transaction (PSBT)\.
+.SH SYNOPSIS
+
+\fBsendpsbt\fR \fIpsbt\fR
+
+.SH DESCRIPTION
+
+The \fBsendpsbt\fR is a low-level RPC command which sent a PSBT\.
+
+.RS
+.IP \[bu]
+\fIpsbt\fR: A string that rappresent psbt value\.
+
+.RE
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "sendpsbt",
+  "params": {
+    "psbt": "some_psbt"
+  }
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, the tx and txid of the transaction are returned, as well as the channel_id of the newly created channel\.
+
+.RS
+.IP \[bu]
+\fItxid\fR: A string that rappresent the hash of transaction\.
+.IP \[bu]
+\fItx\fR: A string that rappresent the hexadecimal dump of the transaction\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters or some error happened during the command process\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+    "txid": "05985072bbe20747325e69a159fe08176cc1bbc96d25e8848edad2dddc1165d0",
+    "tx": "02000000027032912651fc25a3e0893acd5f9640598707e2dfef92143bb5a4020e335442800100000017160014a5f48b9aa3cb8ca6cc1040c11e386745bb4dc932ffffffffd229a4b4f78638ebcac10a68b0561585a5d6e4d3b769ad0a909e9b9afaeae24e00000000171600145c83da9b685f9142016c6f5eb5f98a45cfa6f686ffffffff01915a01000000000017a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf8700000000",
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-fundpsbt\fR(7), \fBlightning-signpsbt\fR(7), \fBlightning-listtransactions\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-sendpsbt.7
+++ b/doc/lightning-sendpsbt.7
@@ -7,11 +7,11 @@ lightning-sendpsbt - Command to finalize, extract and send a partially signed bi
 
 .SH DESCRIPTION
 
-The \fBsendpsbt\fR is a low-level RPC command which sent a PSBT\.
+The \fBsendpsbt\fR is a low-level RPC command which sends a fully-signed PSBT\.
 
 .RS
 .IP \[bu]
-\fIpsbt\fR: A string that rappresent psbt value\.
+\fIpsbt\fR: A string that represents psbt value\.
 
 .RE
 .SH EXAMPLE JSON REQUEST
@@ -29,13 +29,13 @@ The \fBsendpsbt\fR is a low-level RPC command which sent a PSBT\.
 .fi
 .SH RETURN VALUE
 
-On success, the tx and txid of the transaction are returned, as well as the channel_id of the newly created channel\.
+On success, the tx and txid of the transaction are returned\.
 
 .RS
 .IP \[bu]
-\fItxid\fR: A string that rappresent the hash of transaction\.
+\fItxid\fR: A string that represents the hash of transaction\.
 .IP \[bu]
-\fItx\fR: A string that rappresent the hexadecimal dump of the transaction\.
+\fItx\fR: A string that represents the hexadecimal dump of the transaction\.
 
 .RE
 
@@ -68,3 +68,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:795058b68607af4148d2866faa88b3743269e1641725c95efcabdbe82c886420

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -1,0 +1,63 @@
+lightning-sendpsbt -- Command to finalize, extract and send a partially signed bitcoin transaction (PSBT).
+============================================================
+
+SYNOPSIS
+--------
+
+**sendpsbt** \[psbt\]
+
+DESCRIPTION
+-----------
+
+The **sendpsbt** is a low-level RPC command which sent a PSBT.
+
+- *psbt*: A string that rappresent the hexadecimal of the psbt. It is required to run the **sendpsbt** command. The called can build a psbt with a the command *fundpsbt*
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "sendpsbt",
+  "params": {
+    "psbt": "some_psbt"
+  }
+}
+```
+
+RETURN VALUE
+------------
+
+On success, the tx and txid of the transaction is returned, as well as the channel_id of the newly created channel.
+
+- *txid*: A string that rappresent the hash of transaction which the caller can use to find it on the blockchain.
+- *tx*: A string that rappresent the hexadecimal dump of the transaction.
+
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters or some error happened during the command process.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+    "txid": "05985072bbe20747325e69a159fe08176cc1bbc96d25e8848edad2dddc1165d0",
+    "tx": "02000000027032912651fc25a3e0893acd5f9640598707e2dfef92143bb5a4020e335442800100000017160014a5f48b9aa3cb8ca6cc1040c11e386745bb4dc932ffffffffd229a4b4f78638ebcac10a68b0561585a5d6e4d3b769ad0a909e9b9afaeae24e00000000171600145c83da9b685f9142016c6f5eb5f98a45cfa6f686ffffffff01915a01000000000017a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf8700000000",
+}
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+SEE ALSO
+--------
+
+lightning-fundpsbt(7), lightning-listtransactions(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -4,14 +4,14 @@ lightning-sendpsbt -- Command to finalize, extract and send a partially signed b
 SYNOPSIS
 --------
 
-**sendpsbt** \[psbt\]
+**sendpsbt** psbt
 
 DESCRIPTION
 -----------
 
 The **sendpsbt** is a low-level RPC command which sent a PSBT.
 
-- *psbt*: A string that rappresent the hexadecimal of the psbt. It is required to run the **sendpsbt** command. The called can build a psbt with a the command *fundpsbt*
+- *psbt*: A string that rappresent the hexadecimal of the psbt. It is required to run the **sendpsbt** command. The caller can build a psbt with command *fundpsbt*.
 
 EXAMPLE JSON REQUEST
 ------------
@@ -28,7 +28,7 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, the tx and txid of the transaction is returned, as well as the channel_id of the newly created channel.
+On success, the tx and txid of the transaction are returned, as well as the channel_id of the newly created channel.
 
 - *txid*: A string that rappresent the hash of transaction which the caller can use to find it on the blockchain.
 - *tx*: A string that rappresent the hexadecimal dump of the transaction.

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -1,10 +1,10 @@
 lightning-sendpsbt -- Command to finalize, extract and send a partially signed bitcoin transaction (PSBT).
-============================================================
+==========================================================================================================
 
 SYNOPSIS
 --------
 
-**sendpsbt** psbt
+**sendpsbt** *psbt*
 
 DESCRIPTION
 -----------
@@ -14,7 +14,8 @@ The **sendpsbt** is a low-level RPC command which sent a PSBT.
 - *psbt*: A string that rappresent the hexadecimal of the psbt. It is required to run the **sendpsbt** command. The caller can build a psbt with command *fundpsbt*.
 
 EXAMPLE JSON REQUEST
-------------
+--------------------
+
 ```json
 {
   "id": 82,
@@ -38,14 +39,14 @@ On failure, one of the following error codes may be returned:
 - -32602. Error in given parameters or some error happened during the command process.
 
 EXAMPLE JSON RESPONSE
------
+---------------------
+
 ```json
 {
     "txid": "05985072bbe20747325e69a159fe08176cc1bbc96d25e8848edad2dddc1165d0",
     "tx": "02000000027032912651fc25a3e0893acd5f9640598707e2dfef92143bb5a4020e335442800100000017160014a5f48b9aa3cb8ca6cc1040c11e386745bb4dc932ffffffffd229a4b4f78638ebcac10a68b0561585a5d6e4d3b769ad0a909e9b9afaeae24e00000000171600145c83da9b685f9142016c6f5eb5f98a45cfa6f686ffffffff01915a01000000000017a9143a4dfd59e781f9c3018e7d0a9b7a26d58f8d22bf8700000000",
 }
 ```
-
 
 AUTHOR
 ------
@@ -55,7 +56,7 @@ Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version o
 SEE ALSO
 --------
 
-lightning-fundpsbt(7), lightning-listtransactions(7)
+lightning-fundpsbt(7), lightning-signpsbt(7), lightning-listtransactions(7)
 
 RESOURCES
 ---------

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -9,9 +9,9 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **sendpsbt** is a low-level RPC command which sent a PSBT.
+The **sendpsbt** is a low-level RPC command which sends a fully-signed PSBT.
 
-- *psbt*: A string that rappresent psbt value.
+- *psbt*: A string that represents psbt value.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -29,10 +29,10 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, the tx and txid of the transaction are returned, as well as the channel_id of the newly created channel.
+On success, the tx and txid of the transaction are returned.
 
-- *txid*: A string that rappresent the hash of transaction.
-- *tx*: A string that rappresent the hexadecimal dump of the transaction.
+- *txid*: A string that represents the hash of transaction.
+- *tx*: A string that represents the hexadecimal dump of the transaction.
 
 On failure, one of the following error codes may be returned:
 

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -11,7 +11,7 @@ DESCRIPTION
 
 The **sendpsbt** is a low-level RPC command which sent a PSBT.
 
-- *psbt*: A string that rappresent the hexadecimal of the psbt. It is required to run the **sendpsbt** command. The caller can build a psbt with command *fundpsbt*.
+- *psbt*: A string that rappresent psbt value.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -31,12 +31,12 @@ RETURN VALUE
 
 On success, the tx and txid of the transaction are returned, as well as the channel_id of the newly created channel.
 
-- *txid*: A string that rappresent the hash of transaction which the caller can use to find it on the blockchain.
+- *txid*: A string that rappresent the hash of transaction.
 - *tx*: A string that rappresent the hexadecimal dump of the transaction.
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters or some error happened during the command process.
+- -32602: Error in given parameters or some error happened during the command process.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-signpsbt.7
+++ b/doc/lightning-signpsbt.7
@@ -1,0 +1,67 @@
+.TH "LIGHTNING-SIGNPSBT" "7" "" "" "lightning-signpsbt"
+.SH NAME
+lightning-signpsbt - Command to sign a wallet's inputs on a provided bitcoin transaction (PSBT)\.
+.SH SYNOPSIS
+
+\fBsignpsbt\fR \fIpsbt\fR
+
+.SH DESCRIPTION
+
+The \fBsignpsbt\fR is a low-level RPC command which sign a PSBT\.
+
+.RS
+.IP \[bu]
+\fIpsbt\fR: A string that rappresent the psbt value\.
+
+.RE
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "signpsbt",
+  "params": {
+    "psbt": "some_psbt"
+  }
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, a object will be return with a string\.
+
+.RS
+.IP \[bu]
+\fIpsbt\fR: A string that rappresent the psbt value\.
+
+.RE
+
+On failure, one of the following error codes may be returned:
+
+.RS
+.IP \[bu]
+-32602: Error in given parameters or there aren't wallet's inputs to sign\.
+
+.RE
+.SH EXAMPLE JSON RESPONSE
+.nf
+.RS
+{
+    "psbt": "some_psbt"
+}
+.RE
+
+.fi
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH SEE ALSO
+
+\fBlightning-fundpsbt\fR(7), \fBlightning-sendpsbt\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-signpsbt.7
+++ b/doc/lightning-signpsbt.7
@@ -3,17 +3,29 @@
 lightning-signpsbt - Command to sign a wallet's inputs on a provided bitcoin transaction (PSBT)\.
 .SH SYNOPSIS
 
-\fBsignpsbt\fR \fIpsbt\fR
+\fBsignpsbt\fR \fIpsbt\fR [\fIsignonly\fR]
 
 .SH DESCRIPTION
 
-The \fBsignpsbt\fR is a low-level RPC command which sign a PSBT\.
+\fBsignpsbt\fR is a low-level RPC command which signs a PSBT as defined by
+BIP-174\.
 
 .RS
 .IP \[bu]
-\fIpsbt\fR: A string that rappresent the psbt value\.
+\fIpsbt\fR: A string that represents the PSBT value\.
+.IP \[bu]
+\fIsignonly\fR: An optional array of input numbers to sign\.
 
 .RE
+
+By default, all known inputs are signed, and others ignored: with
+\fIsignonly\fR, only those inputs are signed, and an error is returned if
+one of them cannot be signed\.
+
+
+Note that the command will fail if there are no inputs to sign, or
+if the inputs to be signed were not previously reserved\.
+
 .SH EXAMPLE JSON REQUEST
 .nf
 .RS
@@ -29,11 +41,11 @@ The \fBsignpsbt\fR is a low-level RPC command which sign a PSBT\.
 .fi
 .SH RETURN VALUE
 
-On success, a object will be return with a string\.
+On success, a object will be returned with a string\.
 
 .RS
 .IP \[bu]
-\fIpsbt\fR: A string that rappresent the psbt value\.
+\fIpsbt\fR: A string that represents the psbt value with all inputs  signed transaction\.
 
 .RE
 
@@ -41,7 +53,7 @@ On failure, one of the following error codes may be returned:
 
 .RS
 .IP \[bu]
--32602: Error in given parameters or there aren't wallet's inputs to sign\.
+-32602: Error in given parameters, or there aren't wallet's inputs to sign, or we couldn't sign all of \fIsignonly\fR, or inputs are not reserved\.
 
 .RE
 .SH EXAMPLE JSON RESPONSE
@@ -65,3 +77,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:5d7f12bed20a73dabf41d219ccd960e4e36a4674e8528d95ef26f7c8c55b1a0f

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -1,5 +1,5 @@
 lightning-signpsbt -- Command to sign a wallet's inputs on a provided bitcoin transaction (PSBT).
-============================================================
+=================================================================================================
 
 SYNOPSIS
 --------
@@ -14,7 +14,7 @@ The **signpsbt** is a low-level RPC command which sign a PSBT.
 - *psbt*: A string that rappresent the hexadecimal of the psbt.
 
 EXAMPLE JSON REQUEST
-------------
+--------------------
 ```json
 {
   "id": 82,
@@ -37,13 +37,13 @@ On failure, one of the following error codes may be returned:
 - -32602. Error in given parameters or there aren't wallet's inputs to sign.
 
 EXAMPLE JSON RESPONSE
------
+---------------------
+
 ```json
 {
     "psbt": "some_psbt"
 }
 ```
-
 
 AUTHOR
 ------

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -11,7 +11,7 @@ DESCRIPTION
 
 The **signpsbt** is a low-level RPC command which sign a PSBT.
 
-- *psbt*: A string that rappresent the hexadecimal of the psbt.
+- *psbt*: A string that rappresent the psbt value.
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -30,11 +30,11 @@ RETURN VALUE
 
 On success, a object will be return with a string.
 
-- *psbt*: A string that rappresent the hexadecimal dump of the psbt.
+- *psbt*: A string that rappresent the psbt value.
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters or there aren't wallet's inputs to sign.
+- -32602: Error in given parameters or there aren't wallet's inputs to sign.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -4,7 +4,7 @@ lightning-signpsbt -- Command to sign a wallet's inputs on a provided bitcoin tr
 SYNOPSIS
 --------
 
-**signpsbt** \[psbt\]
+**signpsbt** *psbt*
 
 DESCRIPTION
 -----------
@@ -28,13 +28,13 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, a object will be return with a string that rappresent the hexadecimal value of psbt.
+On success, a object will be return with a string.
 
 - *psbt*: A string that rappresent the hexadecimal dump of the psbt.
 
 On failure, one of the following error codes may be returned:
 
-- -32602. Error in given parameters or there isn't wallet inputs to sign.
+- -32602. Error in given parameters or there aren't wallet's inputs to sign.
 
 EXAMPLE JSON RESPONSE
 -----

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -1,0 +1,61 @@
+lightning-signpsbt -- Command to sign a wallet's inputs on a provided bitcoin transaction (PSBT).
+============================================================
+
+SYNOPSIS
+--------
+
+**signpsbt** \[psbt\]
+
+DESCRIPTION
+-----------
+
+The **signpsbt** is a low-level RPC command which sign a PSBT.
+
+- *psbt*: A string that rappresent the hexadecimal of the psbt.
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "signpsbt",
+  "params": {
+    "psbt": "some_psbt"
+  }
+}
+```
+
+RETURN VALUE
+------------
+
+On success, a object will be return with a string that rappresent the hexadecimal value of psbt.
+
+- *psbt*: A string that rappresent the hexadecimal dump of the psbt.
+
+On failure, one of the following error codes may be returned:
+
+- -32602. Error in given parameters or there isn't wallet inputs to sign.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{
+    "psbt": "some_psbt"
+}
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+SEE ALSO
+--------
+
+lightning-fundpsbt(7), lightning-sendpsbt(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -4,14 +4,24 @@ lightning-signpsbt -- Command to sign a wallet's inputs on a provided bitcoin tr
 SYNOPSIS
 --------
 
-**signpsbt** *psbt*
+**signpsbt** *psbt* [*signonly*]
 
 DESCRIPTION
 -----------
 
-The **signpsbt** is a low-level RPC command which sign a PSBT.
+**signpsbt** is a low-level RPC command which signs a PSBT as defined by
+BIP-174.
 
-- *psbt*: A string that rappresent the psbt value.
+- *psbt*: A string that represents the PSBT value.
+- *signonly*: An optional array of input numbers to sign.
+
+By default, all known inputs are signed, and others ignored: with
+*signonly*, only those inputs are signed, and an error is returned if
+one of them cannot be signed.
+
+Note that the command will fail if there are no inputs to sign, or
+if the inputs to be signed were not previously reserved.
+
 
 EXAMPLE JSON REQUEST
 --------------------
@@ -28,13 +38,13 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, a object will be return with a string.
+On success, a object will be returned with a string.
 
-- *psbt*: A string that rappresent the psbt value.
+- *psbt*: A string that represents the psbt value with all inputs  signed transaction.
 
 On failure, one of the following error codes may be returned:
 
-- -32602: Error in given parameters or there aren't wallet's inputs to sign.
+- -32602: Error in given parameters, or there aren't wallet's inputs to sign, or we couldn't sign all of *signonly*, or inputs are not reserved.
 
 EXAMPLE JSON RESPONSE
 ---------------------

--- a/doc/lightning-stop.7
+++ b/doc/lightning-stop.7
@@ -1,13 +1,13 @@
 .TH "LIGHTNING-STOP" "7" "" "" "lightning-stop"
 .SH NAME
-lightning-stop - Command to shut-off c-lightning node\.
+lightning-stop - Command to shutdown the c-lightning node\.
 .SH SYNOPSIS
 
 \fBstop\fR
 
 .SH DESCRIPTION
 
-The \fBstop\fR is a RPC command to shut-off the c-lightning node\.
+The \fBstop\fR is a RPC command to shut off the c-lightning node\.
 
 .SH EXAMPLE JSON REQUEST
 .nf
@@ -22,7 +22,8 @@ The \fBstop\fR is a RPC command to shut-off the c-lightning node\.
 .fi
 .SH RETURN VALUE
 
-On success, the command will return a empty object\.
+On success, the command will return a empty object\.  Once it has returned,
+the daemon has cleaned up completely, and if desired may be restarted\.
 
 .SH AUTHOR
 
@@ -32,3 +33,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
+\" SHA256STAMP:b080fabf70873cb5383ea28d79fba5be5abe1a60ebd9bf280419d2e590dfb762

--- a/doc/lightning-stop.7
+++ b/doc/lightning-stop.7
@@ -1,0 +1,34 @@
+.TH "LIGHTNING-STOP" "7" "" "" "lightning-stop"
+.SH NAME
+lightning-stop - Command to shut-off c-lightning node\.
+.SH SYNOPSIS
+
+\fBstop\fR
+
+.SH DESCRIPTION
+
+The \fBstop\fR is a RPC command to shut-off the c-lightning node\.
+
+.SH EXAMPLE JSON REQUEST
+.nf
+.RS
+{
+  "id": 82,
+  "method": "stop",
+  "params": {}
+}
+.RE
+
+.fi
+.SH RETURN VALUE
+
+On success, the command will return a empty object\.
+
+.SH AUTHOR
+
+Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command\.
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -1,4 +1,4 @@
-lightning-stop -- Command to shut-off c-lightning node.
+lightning-stop -- Command to shutdown the c-lightning node.
 ============================================================
 
 SYNOPSIS
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **stop** is a RPC command to shut-off the c-lightning node.
+The **stop** is a RPC command to shut off the c-lightning node.
 
 EXAMPLE JSON REQUEST
 ------------
@@ -24,7 +24,8 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, the command will return a empty object.
+On success, the command will return a empty object.  Once it has returned,
+the daemon has cleaned up completely, and if desired may be restarted.
 
 
 AUTHOR

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -1,0 +1,45 @@
+lightning-stop -- Command to shut off c-lightning node.
+============================================================
+
+SYNOPSIS
+--------
+
+**stop**
+
+DESCRIPTION
+-----------
+
+The **stop** is a RPC to shut off the c-lightning node.
+
+EXAMPLE JSON REQUEST
+------------
+```json
+{
+  "id": 82,
+  "method": "stop",
+  "params": {}
+}
+```
+
+RETURN VALUE
+------------
+
+On success, the command will return a emptu object.
+
+EXAMPLE JSON RESPONSE
+-----
+```json
+{}
+```
+
+
+AUTHOR
+------
+
+Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page, but many others did the hard work of actually implementing this rpc command.
+
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -1,4 +1,4 @@
-lightning-stop -- Command to shut off c-lightning node.
+lightning-stop -- Command to shut-off c-lightning node.
 ============================================================
 
 SYNOPSIS
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **stop** is a RPC to shut off the c-lightning node.
+The **stop** is a RPC command to shut-off the c-lightning node.
 
 EXAMPLE JSON REQUEST
 ------------
@@ -24,13 +24,7 @@ EXAMPLE JSON REQUEST
 RETURN VALUE
 ------------
 
-On success, the command will return a emptu object.
-
-EXAMPLE JSON RESPONSE
------
-```json
-{}
-```
+On success, the command will return a empty object.
 
 
 AUTHOR


### PR DESCRIPTION
All commands without documentation are

~There are a couple of other commands such as `stop`, `ping`, `listconfigs`, `getlog`, `getinfo`, but I don't think these need a documentation file~

The complete list here 
```
   "commands": [
      "getinfo",
      "getlog",
      "help",
      "listconfigs",
      "listnodes",
      "ping",
      "sendpsbt",
      "signpsbt",
      "stop"
   ]
```

## Update 

The complete list of the commands is.

 - [X] listtransactions
 - [X] listnodes
 - [X] signpsbt
 - [X] sendpsbt
 - [X] getinfo
 - [X] getlog
 - [X] help
 - [X] listconfigs
 - [X] ping
 - [X] stop
