### PR TITLE
Add a new param to listsendpays and listpays to only return last n entries

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -786,7 +786,7 @@ send_payment_core(struct lightningd *ld,
 	bool have_complete = false;
 
 	/* Now, do we already have one or more payments? */
-	payments = wallet_payment_list(tmpctx, ld->wallet, rhash);
+	payments = wallet_payment_list(tmpctx, ld->wallet, rhash, NULL);
 	for (size_t i = 0; i < tal_count(payments); i++) {
 		log_debug(ld->log, "Payment %zu/%zu: %s %s",
 			  i, tal_count(payments),
@@ -1450,10 +1450,12 @@ static struct command_result *json_listsendpays(struct command *cmd,
 	struct json_stream *response;
 	struct sha256 *rhash;
 	const char *b11str;
+	u32 *limit_reverse;
 
 	if (!param(cmd, buffer, params,
 		   p_opt("bolt11", param_string, &b11str),
 		   p_opt("payment_hash", param_sha256, &rhash),
+		   p_opt("limit_reverse", param_number, &limit_reverse),
 		   NULL))
 		return command_param_failed();
 
@@ -1475,7 +1477,7 @@ static struct command_result *json_listsendpays(struct command *cmd,
 		rhash = &b11->payment_hash;
 	}
 
-	payments = wallet_payment_list(cmd, cmd->ld->wallet, rhash);
+	payments = wallet_payment_list(cmd, cmd->ld->wallet, rhash, limit_reverse);
 
 	response = json_stream_success(cmd);
 

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1876,11 +1876,13 @@ static struct command_result *json_listpays(struct command *cmd,
 	const char *b11str;
 	struct sha256 *payment_hash;
 	struct out_req *req;
+	u32 *limit_reverse;
 
 	/* FIXME: would be nice to parse as a bolt11 so check worked in future */
 	if (!param(cmd, buf, params,
 		   p_opt("bolt11", param_string, &b11str),
 		   p_opt("payment_hash", param_sha256, &payment_hash),
+		   p_opt("limit_reverse", param_number, &limit_reverse),
 		   NULL))
 		return command_param_failed();
 
@@ -1892,6 +1894,9 @@ static struct command_result *json_listpays(struct command *cmd,
 
 	if (payment_hash)
 		json_add_sha256(req->js, "payment_hash", payment_hash);
+
+	if (limit_reverse)
+		json_add_num(req->js, "limit_reverse", *limit_reverse);
 
 	return send_outreq(cmd->plugin, req);
 }

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3049,7 +3049,7 @@ wallet_payment_list(const tal_t *ctx,
 						     " FROM payments"
 						     " ORDER BY id DESC"
 						     " LIMIT ?"
-						     ") ORDER BY id ASC;"));
+						     ")x ORDER BY id ASC;"));
 		db_bind_int(stmt, 0, limit_at);
 	}
 	db_query_prepared(stmt);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1102,10 +1102,12 @@ void wallet_payment_set_failinfo(struct wallet *wallet,
  * wallet_payment_list - Retrieve a list of payments
  *
  * payment_hash: optional filter for only this payment hash.
+ * limit_reverse: return only the latest x entries.
  */
 const struct wallet_payment **wallet_payment_list(const tal_t *ctx,
 						  struct wallet *wallet,
-						  const struct sha256 *payment_hash);
+						  const struct sha256 *payment_hash,
+						  u32 *limit_reverse);
 
 /**
  * wallet_htlc_sigs_save - Store the latest HTLC sigs for the channel


### PR DESCRIPTION
The amount of things returned from these commands can grow so much that it becomes very slow to get a response. Specially now that `listpays` is doing heavy computation for each `listsendpays` entry it is very very slow.

This change would also benefit wallets like Spark that want to list only the latest payments in their UI.

This PR is just a naïve proof of concept, because I don't know what is the best way to achieve what I'm asking or if it is a desired change. If the idea is good it could also be done on `listinvoices`, `listforwards`.