### PR TITLE
Implement a factory for paymod-based payments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,7 @@ common/json.*           @wythe
 common/json_tok.*       @wythe
 common/wallet_tx.*      @wythe
 
+plugins/libplugin-paymake.*        @ZmnSCPxj
+
 # See https://help.github.com/articles/about-codeowners/ for more
 # information

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -140,6 +140,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_force_tmp_channel_id = NULL;
 	ld->dev_no_htlc_timeout = false;
 	ld->dev_no_version_checks = false;
+	ld->dev_disable_paymods = tal_arr(ld, char *, 0);
 #endif
 
 	/*~ These are CCAN lists: an embedded double-linked list.  It's not

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -242,6 +242,9 @@ struct lightningd {
 	bool dev_no_htlc_timeout;
 
 	bool dev_no_version_checks;
+
+	/* List of names of paymods to disable.  */
+	char **dev_disable_paymods;
 #endif /* DEVELOPER */
 
 	/* tor support */

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -17,8 +17,8 @@ PLUGIN_LIB_SRC := plugins/libplugin.c
 PLUGIN_LIB_HEADER := plugins/libplugin.h
 PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
 
-PLUGIN_PAY_LIB_SRC := plugins/libplugin-pay.c
-PLUGIN_PAY_LIB_HEADER := plugins/libplugin-pay.h
+PLUGIN_PAY_LIB_SRC := plugins/libplugin-pay.c plugins/libplugin-paymake.c
+PLUGIN_PAY_LIB_HEADER := plugins/libplugin-pay.h plugins/libplugin-paymake.h
 PLUGIN_PAY_LIB_OBJS := $(PLUGIN_PAY_LIB_SRC:.c=.o)
 
 PLUGIN_ALL_SRC :=				\

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -8,7 +8,7 @@
 
 #define DEFAULT_FINAL_CLTV_DELTA 9
 
-struct payment *payment_new(tal_t *ctx, struct command *cmd,
+struct payment *payment_new(const tal_t *ctx, struct command *cmd,
 			    struct payment *parent,
 			    struct payment_modifier **mods)
 {

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2224,6 +2224,9 @@ static struct shadow_route_data *shadow_route_init(struct payment *p)
 #endif
 	} else {
 		d->fuzz_amount = true;
+#if DEVELOPER
+		d->use_shadow = true;
+#endif
 	}
 	return d;
 }

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -371,7 +371,7 @@ REGISTER_PAYMENT_MODIFIER_HEADER(adaptive_splitter, struct adaptive_split_mod_da
  * overhead. */
 REGISTER_PAYMENT_MODIFIER_HEADER(local_channel_hints, void);
 
-struct payment *payment_new(tal_t *ctx, struct command *cmd,
+struct payment *payment_new(const tal_t *ctx, struct command *cmd,
 			    struct payment *parent,
 			    struct payment_modifier **mods);
 

--- a/plugins/libplugin-paymake.c
+++ b/plugins/libplugin-paymake.c
@@ -1,0 +1,246 @@
+#include "libplugin-paymake.h"
+#include <ccan/array_size/array_size.h>
+#include <ccan/str/str.h>
+#include <ccan/tal/str/str.h>
+#include <plugins/libplugin-pay.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct paymod_desc {
+	const char *name;
+	struct payment_modifier *mod;
+	bool disabled;
+};
+
+/* Canonical list of paymods in the correct order they should run in.  */
+static const struct paymod_desc canonical_paymods[] = {
+	{"local_channel_hints", &local_channel_hints_pay_mod},
+	{"exemptfee", &exemptfee_pay_mod},
+	{"directpay", &directpay_pay_mod},
+	{"shadowroute", &shadowroute_pay_mod},
+	/* These two paymods must be executed in the exact order
+	 * specified below.
+	 */
+	{"routehints", &routehints_pay_mod},
+	{"presplit", &presplit_pay_mod},
+	{"waitblockheight", &waitblockheight_pay_mod},
+	{"retry", &retry_pay_mod},
+	{"adaptive_splitter", &adaptive_splitter_pay_mod}
+};
+/* Canonical list of paymods involved in MPP.  */
+static const char *const mpp_paymods[] = {
+	"presplit",
+	"adaptive_splitter"
+};
+
+/* Create an initial copy of the paymods.  */
+static struct paymod_desc *
+initial_paymod_list(const tal_t *ctx)
+{
+	struct paymod_desc *rv = tal_dup_arr(ctx, struct paymod_desc,
+					     canonical_paymods,
+					     ARRAY_SIZE(canonical_paymods),
+					     0);
+	for (size_t i = 0; i < tal_count(rv); ++i)
+		rv[i].disabled = false;
+	return rv;
+}
+
+/* From a list of paymods descriptions, create a sequenced list of
+ * paymods.  */
+static struct payment_modifier **
+finalize_paymod_list(const tal_t *ctx,
+		     const struct paymod_desc *paymod_list TAKES)
+{
+	struct payment_modifier **rv = tal_arr(ctx, struct payment_modifier *,
+					       0);
+
+	for (size_t i = 0; i < tal_count(paymod_list); ++i)
+		if (!paymod_list[i].disabled)
+			tal_arr_expand(&rv, paymod_list[i].mod);
+	/* Add NULL terminator.  */
+	tal_arr_expand(&rv, NULL);
+
+	if (taken(paymod_list))
+		tal_free(paymod_list);
+	return rv;
+}
+
+void paymake_global_init(struct plugin *plugin,
+			 const char *buf, const jsmntok_t *t)
+{
+	/* Do nothing.  */
+}
+
+struct paymake {
+	struct command *cmd;
+
+	struct paymod_desc *paymod_list;
+
+	bool fuzz_amount;
+};
+
+struct paymake *paymake_new(const tal_t *ctx, struct command *cmd)
+{
+	struct paymake *pm = tal(ctx, struct paymake);
+	pm->cmd = cmd;
+	pm->paymod_list = initial_paymod_list(pm);
+	pm->fuzz_amount = true;
+	return pm;
+}
+
+struct payment *paymake_create(const tal_t *ctx, struct paymake *pm)
+{
+	struct payment_modifier **mods;
+	struct payment *p;
+	bool remove_fuzz_amount = false;
+
+	if (!pm->paymod_list)
+		/* Misuse of API.  */
+		abort();
+
+	/* Check if the shadowroute paymod is enabled.
+	 * If it is not enabled anyway, no amount fuzzing
+	 * will happen either.  */
+	if (!pm->fuzz_amount && !is_dev_disabled_paymod("shadowroute")) {
+		for (size_t i = 0; i < tal_count(pm->paymod_list); ++i) {
+			if (pm->paymod_list[i].disabled)
+				continue;
+			if (pm->paymod_list[i].mod != &shadowroute_pay_mod)
+				continue;
+			/* Paymod is not disabled and is the shadowroute
+			 * paymod, so we should remove amount fuzzing from
+			 * its data later after construction.  */
+			remove_fuzz_amount = true;
+			break;
+		}
+	}
+
+	mods = finalize_paymod_list(tmpctx, take(pm->paymod_list));
+	/* Prevent this paymake from being used in the future.  */
+	pm->paymod_list = NULL;
+
+	p = payment_new(ctx, pm->cmd, NULL, mods);
+	/* Give responsibility of the payment modifiers array to the
+	 * payment.  */
+	tal_steal(p, mods);
+
+	/* Modify the fuzz_amount field of shadowroute, if appropriate.  */
+	if (remove_fuzz_amount)
+		payment_mod_shadowroute_get_data(p)->fuzz_amount = false;
+
+	return p;
+}
+
+void paymake_disable_all_paymods(struct paymake *pm)
+{
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+
+	for (size_t i = 0; i < tal_count(pm->paymod_list); ++i)
+		pm->paymod_list[i].disabled = true;
+}
+
+void paymake_disable_paymod(struct paymake *pm, const char *paymod_name)
+{
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+
+	for (size_t i = 0; i < tal_count(pm->paymod_list); ++i)
+		if (streq(paymod_name, pm->paymod_list[i].name)) {
+			pm->paymod_list[i].disabled = true;
+			return;
+		}
+
+	/* Unknown name, misuse of API.  */
+	abort();
+}
+
+void paymake_enable_paymod(struct paymake *pm, const char *paymod_name)
+{
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+
+	for (size_t i = 0; i < tal_count(pm->paymod_list); ++i)
+		if (streq(paymod_name, pm->paymod_list[i].name)) {
+			pm->paymod_list[i].disabled = false;
+			return;
+		}
+
+	/* Unknown name, misuse of API.  */
+	abort();
+}
+
+void paymake_disable_mpp_paymods(struct paymake *pm)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(mpp_paymods); ++i)
+		paymake_disable_paymod(pm, mpp_paymods[i]);
+}
+
+void paymake_disable_amount_fuzz(struct paymake *pm)
+{
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+	pm->fuzz_amount = false;
+}
+
+void paymake_prepend_paymod(struct paymake *pm,
+			    const char *paymod_name TAKES,
+			    struct payment_modifier *paymod)
+{
+	struct paymod_desc desc;
+
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+
+	desc.name = tal_strdup(pm, paymod_name);
+	desc.mod = paymod;
+	desc.disabled = false;
+
+	/* Prepend.  */
+	tal_resize(&pm->paymod_list, tal_count(pm->paymod_list) + 1);
+	memmove(&pm->paymod_list[1], &pm->paymod_list[0],
+		(tal_count(pm->paymod_list) - 1) * sizeof(*pm->paymod_list));
+	pm->paymod_list[0] = desc;
+}
+
+void paymake_append_paymod(struct paymake *pm,
+			   const char *paymod_name TAKES,
+			   struct payment_modifier *paymod)
+{
+	struct paymod_desc desc;
+
+	if (!pm->paymod_list)
+		/* Misuse of API.
+		 * This function MUST NOT be used after paymake_create.
+		 * which specifically clears pm->paymod_list.
+		 */
+		abort();
+
+	desc.name = tal_strdup(pm, paymod_name);
+	desc.mod = paymod;
+	desc.disabled = false;
+
+	/* Append.  */
+	tal_arr_expand(&pm->paymod_list, desc);
+}

--- a/plugins/libplugin-paymake.h
+++ b/plugins/libplugin-paymake.h
@@ -1,0 +1,119 @@
+#ifndef LIGHTNING_PLUGINS_LIBPLUGIN_PAYMAKE_H
+#define LIGHTNING_PLUGINS_LIBPLUGIN_PAYMAKE_H
+#include "config.h"
+
+#include <ccan/take/take.h>
+#include <common/json.h>
+
+struct command;
+struct payment;
+struct payment_modifier;
+struct plugin;
+
+/** struct paymake
+ *
+ * @brief a factory for `struct payment` objects.
+ *
+ * @desc an opaque type interacted with via the API in this
+ * header file.
+ * This allows to set up the root of a payment tree.
+ */
+struct paymake;
+
+/** paymake_global_init
+ *
+ * @brief must be called in your plugin `init` callback.
+ */
+void paymake_global_init(struct plugin *, const char *buf, const jsmntok_t *t);
+
+/** paymake_new
+ *
+ * @brief Create root payment factory.
+ *
+ * @param ctx - the context to allocate the *factory* from.
+ * Note that the root payment constructed by the factory is
+ * *not* allocated off this context!
+ * It is suggested you use `tmpctx` for this; `struct paymake`
+ * is intended as a temporary object.
+ * @param cmd - the command to pass to the constructed payment
+ * later.
+ * May be NULL.
+ *
+ * @desc This creates a root payment factory whose list of
+ * payment modifiers is the canonical list of payment modifiers.
+ */
+struct paymake *paymake_new(const tal_t *ctx, struct command *cmd);
+
+/** paymake_disable_all_paymods
+ *
+ * @brief Disable all paymods for the factory.
+ * Re-enable with `paymake_enable_paymod`.
+ */
+void paymake_disable_all_paymods(struct paymake *pm);
+
+/** paymake_disable_paymod
+ *
+ * @brief Disable a specific named paymod.
+ * This will abort() if the name does not match anything
+ * canonically known by the `paymake` system, or a new
+ * one registered by your plugin.
+ */
+void paymake_disable_paymod(struct paymake *pm, const char *paymod_name);
+
+/** paymake_enable_paymod
+ *
+ * @brief Enable a specific named paymod.
+ * This will abort() if the name does not match anything
+ * canonically known by the `paymake` system, or a new
+ * one registered by your plugin.
+ */
+void paymake_enable_paymod(struct paymake *pm, const char *paymod_name);
+
+/** paymake_disable_mpp_paymods
+ *
+ * @brief Disable all MPP-related paymods.
+ * Re-enable with `paymake_enable_paymod`.
+ */
+void paymake_disable_mpp_paymods(struct paymake *pm);
+
+/** paymake_disable_amount_fuzz
+ *
+ * @brief Disable amount fuzzing at the shadow route paymod,
+ * if the paymod is enabled.
+ */
+void paymake_disable_amount_fuzz(struct paymake *pm);
+
+/** paymake_prepend_paymod
+ *
+ * @brief Prepend a non-standard payment modifier to the
+ * current list of payment modifiers.
+ * Also implicitly enables the given paymod.
+ */
+void paymake_prepend_paymod(struct paymake *pm,
+			    const char *paymod_name TAKES,
+			    struct payment_modifier *paymod);
+
+/** paymake_append_paymod
+ *
+ * @brief Append a non-standard payment modifier to the
+ * current list of payment modifiers.
+ * Also implicitly enables the given paymod.
+ */
+void paymake_append_paymod(struct paymake *pm,
+			   const char *paymod_name TAKES,
+			   struct payment_modifier *paymod);
+
+/** paymake_create
+ *
+ * @brief Construct the root payment.
+ * After this call, the `struct paymake` is now unusable
+ * and can only be `tal_free`d.
+ *
+ * @param ctx - the context to allocate the `struct payment`
+ * off of.
+ * @param pm - the factory whose parameters are to be used for
+ * constructing the root payment.
+ */
+struct payment *paymake_create(const tal_t *ctx, struct paymake *pm);
+
+#endif /* LIGHTNING_PLUGINS_LIBPLUGIN_PAYMAKE_H */

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -71,7 +71,7 @@ def test_pay(node_factory):
 
 @unittest.skipIf(not DEVELOPER, "needs to deactivate shadow routing")
 def test_pay_amounts(node_factory):
-    l1, l2 = node_factory.line_graph(2)
+    l1, l2 = node_factory.line_graph(2, opts={"dev-disable-paymods": "shadowroute"})
     inv = l2.rpc.invoice(Millisatoshi("123sat"), 'test_pay_amounts', 'description')['bolt11']
 
     invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
@@ -79,7 +79,7 @@ def test_pay_amounts(node_factory):
     assert isinstance(invoice['amount_msat'], Millisatoshi)
     assert invoice['amount_msat'] == Millisatoshi(123000)
 
-    l1.rpc.dev_pay(inv, use_shadow=False)
+    l1.rpc.pay(inv)
 
     invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
     assert isinstance(invoice['amount_received_msat'], Millisatoshi)


### PR DESCRIPTION
This gives us the nice capability to disable specific paymods at the command line for testing and experimentation.  For example, instead of a `use_shadow` parameter guarded by `DEVELOPER=1`, which requires our test harness to provide a `dev_pay` RPC, we can just `--dev-disable-paymods=shadowroute` to disable shadowroutes completely.