### PR TITLE
fundpsbt/utxopsbt: let caller specify locktime, signpsbt: signing restrictions.

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1140,6 +1140,21 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fundpsbt", payload)
 
+    def utxopsbt(self, satoshi, feerate, startweight, utxos, reserve=True, reservedok=False, locktime=None):
+        """
+        Create a PSBT with given inputs, to give an output of satoshi.
+        """
+        payload = {
+            "satoshi": satoshi,
+            "feerate": feerate,
+            "startweight": startweight,
+            "utxos": utxos,
+            "reserve": reserve,
+            "reservedok": reservedok,
+            "locktime": locktime,
+        }
+        return self.call("utxopsbt", payload)
+
     def signpsbt(self, psbt):
         """
         Add internal wallet's signatures to PSBT

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1155,12 +1155,13 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("utxopsbt", payload)
 
-    def signpsbt(self, psbt):
+    def signpsbt(self, psbt, signonly=None):
         """
         Add internal wallet's signatures to PSBT
         """
         payload = {
             "psbt": psbt,
+            "signonly": signonly,
         }
         return self.call("signpsbt", payload)
 

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1126,7 +1126,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("unreserveinputs", payload)
 
-    def fundpsbt(self, satoshi, feerate, startweight, minconf=None, reserve=True):
+    def fundpsbt(self, satoshi, feerate, startweight, minconf=None, reserve=True, locktime=None):
         """
         Create a PSBT with inputs sufficient to give an output of satoshi.
         """
@@ -1136,6 +1136,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "startweight": startweight,
             "minconf": minconf,
             "reserve": reserve,
+            "locktime": locktime,
         }
         return self.call("fundpsbt", payload)
 

--- a/doc/lightning-fundpsbt.7
+++ b/doc/lightning-fundpsbt.7
@@ -3,7 +3,7 @@
 lightning-fundpsbt - Command to populate PSBT inputs from the wallet
 .SH SYNOPSIS
 
-\fBfundpsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR [\fIminconf\fR] [\fIreserve\fR]
+\fBfundpsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR [\fIminconf\fR] [\fIreserve\fR] [\fIlocktime\fR]
 
 .SH DESCRIPTION
 
@@ -38,6 +38,10 @@ outputs should have\. Default is 1\.
 
 \fIreserve\fR is a boolean: if true (the default), then \fIreserveinputs\fR is
 called (successfully, with \fIexclusive\fR true) on the returned PSBT\.
+
+
+\fIlocktime\fR is an optional locktime: if not set, it is set to a recent
+block height\.
 
 .SH EXAMPLE USAGE
 

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -4,7 +4,7 @@ lightning-fundpsbt -- Command to populate PSBT inputs from the wallet
 SYNOPSIS
 --------
 
-**fundpsbt** *satoshi* *feerate* *startweight* \[*minconf*\] \[*reserve*\]
+**fundpsbt** *satoshi* *feerate* *startweight* \[*minconf*\] \[*reserve*\] \[*locktime*\]
 
 DESCRIPTION
 -----------
@@ -35,6 +35,9 @@ outputs should have. Default is 1.
 
 *reserve* is a boolean: if true (the default), then *reserveinputs* is
 called (successfully, with *exclusive* true) on the returned PSBT.
+
+*locktime* is an optional locktime: if not set, it is set to a recent
+block height.
 
 EXAMPLE USAGE
 -------------

--- a/doc/lightning-utxopsbt.7
+++ b/doc/lightning-utxopsbt.7
@@ -3,7 +3,7 @@
 lightning-utxopsbt - Command to populate PSBT inputs from given UTXOs
 .SH SYNOPSIS
 
-\fButxopsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR \fIutxos\fR [\fIreserve\fR] [\fIreservedok\fR]
+\fButxopsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR \fIutxos\fR [\fIreserve\fR] [\fIreservedok\fR] [\fIlocktime\fR]
 
 .SH DESCRIPTION
 
@@ -26,6 +26,10 @@ is equivalent to setting it to zero)\.
 
 Unless \fIreservedok\fR is set to true (default is false) it will also fail
 if any of the \fIutxos\fR are already reserved\.
+
+
+\fIlocktime\fR is an optional locktime: if not set, it is set to a recent
+block height\.
 
 .SH RETURN VALUE
 

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -4,7 +4,7 @@ lightning-utxopsbt -- Command to populate PSBT inputs from given UTXOs
 SYNOPSIS
 --------
 
-**utxopsbt** *satoshi* *feerate* *startweight* *utxos* \[*reserve*\] \[*reservedok*\]
+**utxopsbt** *satoshi* *feerate* *startweight* *utxos* \[*reserve*\] \[*reservedok*\] \[*locktime*\]
 
 DESCRIPTION
 -----------
@@ -25,6 +25,9 @@ is equivalent to setting it to zero).
 
 Unless *reservedok* is set to true (default is false) it will also fail
 if any of the *utxos* are already reserved.
+
+*locktime* is an optional locktime: if not set, it is set to a recent
+block height.
 
 RETURN VALUE
 ------------

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -427,7 +427,7 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 	u32 *feerate_per_kw, *weight;
 	bool all, *reserve, *reserved_ok;
 	struct amount_sat *amount, input, excess;
-	u32 current_height;
+	u32 current_height, *locktime;
 
 	if (!param(cmd, buffer, params,
 		   p_req("satoshi", param_sat_or_all, &amount),
@@ -436,6 +436,7 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 		   p_req("utxos", param_txout, &utxos),
 		   p_opt_def("reserve", param_bool, &reserve, true),
 		   p_opt_def("reservedok", param_bool, &reserved_ok, false),
+		   p_opt("locktime", param_number, &locktime),
 		   NULL))
 		return command_param_failed();
 
@@ -479,7 +480,7 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 	}
 
 	return finish_psbt(cmd, utxos, *feerate_per_kw, *weight, excess,
-			   *reserve, NULL);
+			   *reserve, locktime);
 }
 static const struct json_command utxopsbt_command = {
 	"utxopsbt",


### PR DESCRIPTION
Required for dual funding where the opener sets it.

Changelog-Added: JSON-RPC: fundpsbt takes a new `locktime` parameter
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>