### PR TITLE
JSON optimizations, cleanups and listsendpays optimizations

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -585,6 +585,17 @@ again:
 	return toks;
 }
 
+jsmntok_t *json_parse_simple(const tal_t *ctx, const char *input, int len)
+{
+	bool valid;
+	jsmntok_t *toks;
+
+	toks = json_parse_input(ctx, input, len, &valid);
+	if (toks && !valid)
+		toks = tal_free(toks);
+	return toks;
+}
+
 const char *jsmntype_to_string(jsmntype_t t)
 {
 	switch (t) {

--- a/common/json.h
+++ b/common/json.h
@@ -89,6 +89,10 @@ const jsmntok_t *json_get_arr(const jsmntok_t tok[], size_t index);
 jsmntok_t *json_parse_input(const tal_t *ctx,
 			    const char *input, int len, bool *valid);
 
+/* Simplified version of above which parses only a complete, valid
+ * JSON string */
+jsmntok_t *json_parse_simple(const tal_t *ctx, const char *input, int len);
+
 /* Convert a jsmntype_t enum to a human readable string. */
 const char *jsmntype_to_string(jsmntype_t t);
 

--- a/common/json.h
+++ b/common/json.h
@@ -85,9 +85,35 @@ const jsmntok_t *json_get_member(const char *buffer, const jsmntok_t tok[],
 /* Get index'th array member. */
 const jsmntok_t *json_get_arr(const jsmntok_t tok[], size_t index);
 
-/* If input is complete and valid, return tokens. */
-jsmntok_t *json_parse_input(const tal_t *ctx,
-			    const char *input, int len, bool *valid);
+/* Allocate a starter array of tokens for json_parse_input */
+jsmntok_t *toks_alloc(const tal_t *ctx);
+
+/* Reset a token array to reuse it. */
+void toks_reset(jsmntok_t *toks);
+
+/**
+ * json_parse_input: parse and validate JSON.
+ * @parser: parser initialized with jsmn_init.
+ * @toks: tallocated array from toks_alloc()
+ * @input, @len: input string.
+ * @complete: set to true if the valid JSON is complete, or NULL if must be.
+ *
+ * This returns false if the JSON is invalid, true otherwise.
+ * If it returns true, *@complete indicates that (*@toks)[0] points to a
+ * valid, complete JSON element.  If @complete is NULL, then incomplete
+ * JSON returns false (i.e. is considered invalid).
+ *
+ * *@toks is resized to the complete set of tokens, with a dummy
+ * terminator (type == -1) at the end.
+ *
+ * If it returns true, and *@complete is false, you can append more
+ * data to @input and call it again (with the same perser) and the parser
+ * will continue where it left off.
+*/
+bool json_parse_input(jsmn_parser *parser,
+		      jsmntok_t **toks,
+		      const char *input, int len,
+		      bool *complete);
 
 /* Simplified version of above which parses only a complete, valid
  * JSON string */

--- a/common/test/run-json.c
+++ b/common/test/run-json.c
@@ -104,34 +104,47 @@ static int test_json_tok_millionths(void)
 
 static void test_json_tok_size(void)
 {
-	const jsmntok_t *toks;
+	jsmntok_t *toks;
 	char *buf;
-	bool ok;
+	bool ok, complete;
+	jsmn_parser parser;
 
 	buf = "[\"e1\", [\"e2\", \"e3\"]]";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	toks = toks_alloc(tmpctx);
+	jsmn_init(&parser);
+	ok = json_parse_input(&parser, &toks, buf, strlen(buf), &complete);
 	assert(ok);
+	assert(complete);
 	/* size only counts *direct* children */
 	assert(toks[0].size == 2);
 	assert(toks[2].size == 2);
 
 	buf = "[[\"e1\", \"e2\"], \"e3\"]";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	toks_reset(toks);
+	jsmn_init(&parser);
+	ok = json_parse_input(&parser, &toks, buf, strlen(buf), &complete);
 	assert(ok);
+	assert(complete);
 	/* size only counts *direct* children */
 	assert(toks[0].size == 2);
 	assert(toks[1].size == 2);
 
 	buf = "{\"e1\" : {\"e2\": 2, \"e3\": 3}}";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	toks_reset(toks);
+	jsmn_init(&parser);
+	ok = json_parse_input(&parser, &toks, buf, strlen(buf), &complete);
 	assert(ok);
+	assert(complete);
 	/* size only counts *direct* children */
 	assert(toks[0].size == 1);
 	assert(toks[2].size == 2);
 
 	buf = "{\"e1\" : {\"e2\": 2, \"e3\": 3}, \"e4\" : {\"e5\": 5, \"e6\": 6}}";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	toks_reset(toks);
+	jsmn_init(&parser);
+	ok = json_parse_input(&parser, &toks, buf, strlen(buf), &complete);
 	assert(ok);
+	assert(complete);
 	/* size only counts *direct* children */
 	assert(toks[0].size == 2);
 	assert(toks[2].size == 2);
@@ -139,7 +152,9 @@ static void test_json_tok_size(void)
 
 	/* This should *not* parse! (used to give toks[0]->size == 3!) */
 	buf = "{ \"\" \"\" \"\" }";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
+	toks_reset(toks);
+	jsmn_init(&parser);
+	ok = json_parse_input(&parser, &toks, buf, strlen(buf), &complete);
 	assert(!ok);
 
 	/* This should *not* parse! (used to give toks[0]->size == 2!) */

--- a/common/test/run-json.c
+++ b/common/test/run-json.c
@@ -144,19 +144,18 @@ static void test_json_tok_size(void)
 
 	/* This should *not* parse! (used to give toks[0]->size == 2!) */
 	buf = "{ 'satoshi', '546' }";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
-	assert(!ok);
+	toks = json_parse_simple(tmpctx, buf, strlen(buf));
+	assert(!toks);
 }
 
 static void test_json_delve(void)
 {
 	const jsmntok_t *toks, *t;
 	char *buf;
-	bool ok;
 
 	buf = "{\"1\":\"one\", \"2\":\"two\", \"3\":[\"three\", {\"deeper\": 17}]}";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
-	assert(ok);
+	toks = json_parse_simple(tmpctx, buf, strlen(buf));
+	assert(toks);
 	assert(toks->size == 3);
 
 	t = json_delve(buf, toks, ".1");
@@ -227,8 +226,8 @@ static void test_json_delve(void)
 		"  }\n"
 		"}\n"
 		"\n";
-	toks = json_parse_input(tmpctx, buf, strlen(buf), &ok);
-	assert(ok);
+	toks = json_parse_simple(tmpctx, buf, strlen(buf));
+	assert(toks);
 	assert(toks->size == 4);
 
 	t = json_delve(buf, toks, ".rpcfile");

--- a/common/test/run-json_remove.c
+++ b/common/test/run-json_remove.c
@@ -148,9 +148,8 @@ static struct json *json_parse(const tal_t * ctx, const char *str)
 	struct json *j = tal(ctx, struct json);
 	j->buffer = tal_strdup(j, str);
 	convert_quotes(j->buffer);
-	bool ok;
-	j->toks = json_parse_input(j, j->buffer, strlen(j->buffer), &ok);
-	assert(ok);
+	j->toks = json_parse_simple(j, j->buffer, strlen(j->buffer));
+	assert(j->toks);
 	j->toks = json_tok_copy(j, j->toks);
 	return j;
 }

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -204,7 +204,6 @@ static char *opt_set_node_id(const char *arg, struct node_id *node_id)
 static void runtest(const char *filename)
 {
 	const tal_t *ctx = tal(NULL, u8);
-	bool valid;
 	char *buffer = grab_file(ctx, filename);
 	const jsmntok_t *toks, *session_key_tok, *associated_data_tok, *gentok,
 		*hopstok, *hop, *payloadtok, *pubkeytok, *typetok, *oniontok, *decodetok;
@@ -217,8 +216,8 @@ static void runtest(const char *filename)
 	struct route_step *step;
 	char *hexprivkey;
 
-	toks = json_parse_input(ctx, buffer, strlen(buffer), &valid);
-	if (!valid)
+	toks = json_parse_simple(ctx, buffer, strlen(buffer));
+	if (!toks)
 		errx(1, "File is not a valid JSON file.");
 
 	gentok = json_get_member(buffer, toks, "generate");

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -56,6 +56,8 @@ struct plugin {
 	/* Stuff we read */
 	char *buffer;
 	size_t used, len_read;
+	jsmn_parser parser;
+	jsmntok_t *toks;
 
 	/* Our json_streams. Since multiple streams could start
 	 * returning data at once, we always service these in order,

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -132,11 +132,12 @@ static int test_json_filter(void)
 	struct json_stream *result = new_json_stream(NULL, NULL, NULL);
 	jsmntok_t *toks;
 	const jsmntok_t *x;
-	bool valid;
+	bool valid, complete;
 	int i;
 	char *badstr = tal_arr(result, char, 256);
 	const char *str;
 	size_t len;
+	jsmn_parser parser;
 
 	/* Fill with junk, and nul-terminate (256 -> 0) */
 	for (i = 1; i < 257; i++)
@@ -150,9 +151,11 @@ static int test_json_filter(void)
 	str = json_out_contents(result->jout, &len);
 	str = tal_strndup(result, str, len);
 
-	toks = json_parse_input(str, str, strlen(str), &valid);
+	toks = toks_alloc(str);
+	jsmn_init(&parser);
+	valid = json_parse_input(&parser, &toks, str, strlen(str), &complete);
 	assert(valid);
-	assert(toks);
+	assert(complete);
 
 	assert(toks[0].type == JSMN_OBJECT);
 	x = json_get_member(str, toks, "x");
@@ -240,32 +243,54 @@ static void test_json_partial(void)
 /* Test that we can segment and parse a stream of json objects correctly. */
 static void test_json_stream(void)
 {
-	bool valid;
+	bool valid, complete;
 	char *input, *talstr;
 	jsmntok_t *toks;
+	jsmn_parser parser;
 
 	/* Multiple full messages in a single buffer (happens when buffer
 	 * boundary coincides with message boundary, or read returned after
 	 * timeout. */
 	input = "{\"x\":\"x\"}{\"y\":\"y\"}";
 	talstr = tal_strndup(NULL, input, strlen(input));
-	toks = json_parse_input(talstr, talstr, strlen(talstr), &valid);
-	assert(toks);
+	toks = toks_alloc(NULL);
+	jsmn_init(&parser);
+	valid = json_parse_input(&parser, &toks, talstr, strlen(talstr), &complete);
 	assert(tal_count(toks) == 4);
 	assert(toks[0].start == 0 && toks[0].end == 9);
 	assert(valid);
+	assert(complete);
 	tal_free(talstr);
 
 	/* Multiple messages, and the last one is partial, far more likely than
 	 * accidentally getting the boundaries to match. */
 	input = "{\"x\":\"x\"}{\"y\":\"y\"}{\"z\":\"z";
 	talstr = tal_strndup(NULL, input, strlen(input));
-	toks = json_parse_input(talstr, talstr, strlen(talstr), &valid);
+	toks_reset(toks);
+	jsmn_init(&parser);
+	valid = json_parse_input(&parser, &toks, talstr, strlen(talstr), &complete);
 	assert(toks);
 	assert(tal_count(toks) == 4);
 	assert(toks[0].start == 0 && toks[0].end == 9);
 	assert(valid);
+	assert(complete);
 	tal_free(talstr);
+
+	/* We can do this incrementally, too. */
+	toks_reset(toks);
+	input = "{\"x\":\"x\"}";
+	jsmn_init(&parser);
+	for (size_t i = 0; i <= strlen(input); i++) {
+		valid = json_parse_input(&parser, &toks, input, i, &complete);
+		assert(valid);
+		if (i == strlen(input))
+			assert(complete);
+		else
+			assert(!complete);
+	}
+	assert(tal_count(toks) == 4);
+	assert(toks[0].start == 0 && toks[0].end == 9);
+	tal_free(toks);
 }
 
 int main(void)

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1858,10 +1858,11 @@ static struct command_result *listsendpays_done(struct command *cmd,
 		}
 	}
 
-	/* Now we've collapsed them, provide summary (free mem as we go). */
-	while ((pm = pay_map_first(&pay_map, &it)) != NULL) {
+	/* Now we've collapsed them, provide summary. */
+	for (pm = pay_map_first(&pay_map, &it);
+	     pm;
+	     pm = pay_map_next(&pay_map, &it)) {
 		add_new_entry(ret, buf, pm);
-		pay_map_del(&pay_map, pm);
 	}
 	pay_map_clear(&pay_map);
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1498,7 +1498,6 @@ void db_column_node_id(struct db_stmt *stmt, int col, struct node_id *dest)
 {
 	assert(db_column_bytes(stmt, col) == sizeof(dest->k));
 	memcpy(dest->k, db_column_blob(stmt, col), sizeof(dest->k));
-	assert(node_id_valid(dest));
 }
 
 struct node_id *db_column_node_id_arr(const tal_t *ctx, struct db_stmt *stmt,
@@ -1510,11 +1509,8 @@ struct node_id *db_column_node_id_arr(const tal_t *ctx, struct db_stmt *stmt,
 	assert(n * sizeof(ret->k) == (size_t)db_column_bytes(stmt, col));
 	ret = tal_arr(ctx, struct node_id, n);
 
-	for (size_t i = 0; i < n; i++) {
+	for (size_t i = 0; i < n; i++)
 		memcpy(ret[i].k, arr + i * sizeof(ret[i].k), sizeof(ret[i].k));
-		if (!node_id_valid(&ret[i]))
-			return tal_free(ret);
-	}
 
 	return ret;
 }


### PR DESCRIPTION
@fiatjaf reported in #3941 that `listspays` was slow, and indeed, it was.

I created 50,000 payments, and ran some tests.

* With no optimization:
    * `listsendpays` takes 0.983 seconds
    * `listpays` takes 52.415 seconds
* With `-O3 -flto`:
    * `listsendpays` takes 0.628 seconds
    * `listpays` takes 43.104 seconds

After these optimizations (mostly FIXMEs!) the results are:

* With no optimization:
    * `listsendpays` takes 0.676 seconds
    * `listpays` takes 1.545 seconds.
* With `-O3 -flto`:
    * `listsendpays` takes 0.416 seconds
    * `listpays` takes 0.971 seconds.