### PR TITLE
listpeers: add `features` array using BOLT9 names.

### DIFF
--- a/doc/lightning-listpeers.7
+++ b/doc/lightning-listpeers.7
@@ -129,6 +129,8 @@ a number followed by a string unit\.
 .IP \[bu]
 \fItotal_msat\fR: A string describing the total capacity of the channel;
 a number followed by a string unit\.
+.IP \[bu]
+\fIfeatures\fR: An array of feature names supported by this channel\.
 
 .RE
 

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -95,6 +95,7 @@ The objects in the *channels* array will have at least these fields:
   a number followed by a string unit.
 * *total\_msat*: A string describing the total capacity of the channel;
   a number followed by a string unit.
+* *features*: An array of feature names supported by this channel.
 
 These fields may exist if the channel has gotten beyond the `"OPENINGD"`
 state, or in various circumstances:

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -155,6 +155,18 @@ void json_add_uncommitted_channel(struct json_stream *response,
 		json_add_amount_msat_compat(response, total,
 					    "msatoshi_total", "total_msat");
 	}
+
+	json_array_start(response, "features");
+	if (feature_negotiated(uc->peer->ld->our_features,
+			       uc->peer->their_features,
+			       OPT_STATIC_REMOTEKEY))
+		json_add_string(response, NULL, "option_static_remotekey");
+
+	if (feature_negotiated(uc->peer->ld->our_features,
+			       uc->peer->their_features,
+			       OPT_ANCHOR_OUTPUTS))
+		json_add_string(response, NULL, "option_anchor_outputs");
+	json_array_end(response);
 	json_object_end(response);
 }
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -672,6 +672,13 @@ static void json_add_channel(struct lightningd *ld,
 	    response, "private",
 	    !(channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL));
 
+	json_array_start(response, "features");
+	if (channel->option_static_remotekey)
+		json_add_string(response, NULL, "option_static_remotekey");
+	if (channel->option_anchor_outputs)
+		json_add_string(response, NULL, "option_anchor_outputs");
+	json_array_end(response);
+
 	// FIXME @conscott : Modify this when dual-funded channels
 	// are implemented
 	json_object_start(response, "funding_allocation_msat");


### PR DESCRIPTION
It's actually not possible to currently tell if you're using anchor_outputs
with a peer (since it depends on whether you both supported it at *channel open*).

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-added: JSON-RPC: `listpeers` shows `features` list for each channel.