### PR TITLE
invoice: don't allow zero-value invoices.

### DIFF
--- a/doc/lightning-invoice.7
+++ b/doc/lightning-invoice.7
@@ -16,7 +16,7 @@ invoice, if any exists\.
 
 
 The \fImsatoshi\fR parameter can be the string "any", which creates an
-invoice that can be paid with any amount\. Otherwise it is in
+invoice that can be paid with any amount\. Otherwise it is a positive value in
 millisatoshi precision; it can be a whole number, or a whole number
 ending in \fImsat\fR or \fIsat\fR, or a number with three decimal places ending
 in \fIsat\fR, or a number with 1 to 11 decimal places ending in \fIbtc\fR\.

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -17,7 +17,7 @@ lightning daemon can use to pay this invoice. This token includes a
 invoice, if any exists.
 
 The *msatoshi* parameter can be the string "any", which creates an
-invoice that can be paid with any amount. Otherwise it is in
+invoice that can be paid with any amount. Otherwise it is a positive value in
 millisatoshi precision; it can be a whole number, or a whole number
 ending in *msat* or *sat*, or a number with three decimal places ending
 in *sat*, or a number with 1 to 11 decimal places ending in *btc*.

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -59,6 +59,26 @@ def test_invoice(node_factory, chainparams):
     l2.rpc.invoice(4294967295, 'inv3', '?')
 
 
+def test_invoice_zeroval(node_factory):
+    """A zero value invoice is unpayable, did you mean 'any'?"""
+    l1 = node_factory.get_node()
+
+    with pytest.raises(RpcError, match=r"positive .* not '0'"):
+        l1.rpc.invoice(0, 'inv', '?')
+
+    with pytest.raises(RpcError, match=r"positive .* not '0msat'"):
+        l1.rpc.invoice('0msat', 'inv', '?')
+
+    with pytest.raises(RpcError, match=r"positive .* not '0sat'"):
+        l1.rpc.invoice('0sat', 'inv', '?')
+
+    with pytest.raises(RpcError, match=r"positive .* not '0.00000000btc'"):
+        l1.rpc.invoice('0.00000000btc', 'inv', '?')
+
+    with pytest.raises(RpcError, match=r"positive .* not '0.00000000000btc'"):
+        l1.rpc.invoice('0.00000000000btc', 'inv', '?')
+
+
 def test_invoice_weirdstring(node_factory):
     l1 = node_factory.get_node()
 


### PR DESCRIPTION
You can't pay them anyway, and at least one person used 0 instead of "any".

Closes: #3808
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Changed: JSON-RPC: `invoice` no longer accepts zero amounts (did you mean "any"?)