### PR TITLE
.gitignore: Add missing gitignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ contrib/pyln-*/dist/
 contrib/pyln-*/pyln_*.egg-info/
 plugins/keysend
 release/
+*_wiregen.[ch]


### PR DESCRIPTION
Recent merged PR added a bunch of wiregen files.