### PR TITLE
gossipd: Make gossipd shut up

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -759,18 +759,9 @@ class LightningNode(object):
                                 get_tx_p2wsh_outnum(self.bitcoin, tx, amount))
 
         if wait_for_active:
-            # We wait until gossipd sees both local updates, as well as status NORMAL,
-            # so it can definitely route through.
-            self.daemon.wait_for_logs([r'update for channel {}/0 now ACTIVE'
-                                       .format(scid),
-                                       r'update for channel {}/1 now ACTIVE'
-                                       .format(scid),
-                                       'to CHANNELD_NORMAL'])
-            l2.daemon.wait_for_logs([r'update for channel {}/0 now ACTIVE'
-                                     .format(scid),
-                                     r'update for channel {}/1 now ACTIVE'
-                                     .format(scid),
-                                     'to CHANNELD_NORMAL'])
+            self.wait_channel_active(scid)
+            l2.wait_channel_active(scid)
+
         return scid
 
     def subd_pid(self, subd, peerid=None):

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1110,7 +1110,7 @@ def test_onchaind_replay(node_factory, bitcoind):
     }
     l1.rpc.sendpay([routestep], rhash)
     l1.daemon.wait_for_log('sendrawtx exit 0')
-    bitcoind.generate_block(1)
+    bitcoind.generate_block(1, wait_for_mempool=1)
 
     # Wait for nodes to notice the failure, this seach needle is after the
     # DB commit so we're sure the tx entries in onchaindtxs have been added

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1347,7 +1347,7 @@ def test_onchain_middleman(node_factory, bitcoind):
 
     # l2 will drop to chain.
     l2.daemon.wait_for_log('sendrawtx exit 0')
-    l1.bitcoin.generate_block(1)
+    l1.bitcoin.generate_block(1, wait_for_mempool=1)
     l2.daemon.wait_for_log(' to ONCHAIN')
     l1.daemon.wait_for_log(' to ONCHAIN')
     l2.daemon.wait_for_log('OUR_UNILATERAL/THEIR_HTLC')

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -295,6 +295,7 @@ def test_pay_get_error_with_update(node_factory):
     # Make sure that l2 has seen disconnect, considers channel disabled.
     wait_for(lambda: [c['active'] for c in l2.rpc.listchannels(chanid2)['channels']] == [False, False])
 
+    assert(l1.is_channel_active(chanid2))
     l1.rpc.sendpay(route, inv['payment_hash'])
     with pytest.raises(RpcError, match=r'WIRE_TEMPORARY_CHANNEL_FAILURE'):
         l1.rpc.waitsendpay(inv['payment_hash'])
@@ -306,7 +307,7 @@ def test_pay_get_error_with_update(node_factory):
     l1.daemon.wait_for_log(r'Extracted channel_update 0102.*from onionreply 10070088[0-9a-fA-F]{88}')
 
     # And now monitor for l1 to apply the channel_update we just extracted
-    l1.daemon.wait_for_log(r'Received channel_update for channel {}/. now DISABLED'.format(chanid2))
+    wait_for(lambda: not l1.is_channel_active(chanid2))
 
 
 @unittest.skipIf(not DEVELOPER, "needs to deactivate shadow routing")


### PR DESCRIPTION
We are logging way too much from gossipd, causing noisy logs. This PR reduces
logs for incoming messages to those that actually caused a change in our
internal state (duplicate and old messages are just dropped silently now).

Most of the changes are related to tests breaking due to the reduced logging,
and the fixups required to get them working again. We fix them by polling for
the desired resulting state rather than observing the ephemeral state changes
represented by the logs. This may slow down some of the tests, since we now
poll, but that time is likely going to be used by concurrent tests anyway, and
we end up with more stable tests, that don't rely on implicit log ordering..

Changelog-Changed: gossipd: The `gossipd` is now a lot quieter, and will log only when a message changed our network topology.