### PR TITLE
blocksync: Some performance improvements on top of #3957

### DIFF
--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -208,9 +208,11 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 
 	num = pull_varint(&p, &len);
 	b->tx = tal_arr(b, struct bitcoin_tx *, num);
+	b->txids = tal_arr(b, struct bitcoin_txid, num);
 	for (i = 0; i < num; i++) {
 		b->tx[i] = pull_bitcoin_tx(b->tx, &p, &len);
 		b->tx[i]->chainparams = chainparams;
+		bitcoin_txid(b->tx[i], &b->txids[i]);
 	}
 
 	/* We should end up not overrunning, nor have extra */

--- a/bitcoin/block.h
+++ b/bitcoin/block.h
@@ -36,6 +36,7 @@ struct bitcoin_block {
 	struct bitcoin_block_hdr hdr;
 	/* tal_count shows now many */
 	struct bitcoin_tx **tx;
+	struct bitcoin_txid *txids;
 };
 
 struct bitcoin_block *

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -91,7 +91,7 @@ static void filter_block_txs(struct chain_topology *topo, struct block *b)
 		}
 
 		owned = AMOUNT_SAT(0);
-		bitcoin_txid(tx, &txid);
+		txid = b->txids[i];
 		if (txfilter_match(topo->bitcoind->ld->owned_txfilter, tx)) {
 			wallet_extract_owned_outputs(topo->bitcoind->ld->wallet,
 						     tx->wtx, &b->height, &owned);
@@ -748,7 +748,7 @@ static void topo_update_spends(struct chain_topology *topo, struct block *b)
 		struct bitcoin_txid txid;
 		struct amount_sat inputs_total = AMOUNT_SAT(0);
 
-		bitcoin_txid(tx, &txid);
+		txid = b->txids[i];
 
 		for (size_t j = 0; j < tx->wtx->num_inputs; j++) {
 			const struct wally_tx_input *input = &tx->wtx->inputs[j];
@@ -843,6 +843,7 @@ static struct block *new_block(struct chain_topology *topo,
 	b->hdr = blk->hdr;
 
 	b->full_txs = tal_steal(b, blk->tx);
+	b->txids = tal_steal(b, blk->txids);
 
 	return b;
 }

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -62,6 +62,7 @@ struct block {
 
 	/* Full copy of txs (freed in filter_block_txs) */
 	struct bitcoin_tx **full_txs;
+	struct bitcoin_txid *txids;
 };
 
 /* Hash blocks by sha */

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -618,9 +618,9 @@ static struct command_result *process_getrawblock(struct bitcoin_cli *bcli)
 	struct json_stream *response;
 	struct getrawblock_stash *stash = bcli->stash;
 
-	/* -1 to strip \n. */
-	stash->block_hex = tal_fmt(stash, "%.*s",
-	                           (int)bcli->output_bytes-1, bcli->output);
+	/* -1 to strip \n and steal onto the stash. */
+	bcli->output[bcli->output_bytes-1] = 0x00;
+	stash->block_hex = tal_steal(stash, bcli->output);
 
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_string(response, "blockhash", stash->block_hash);


### PR DESCRIPTION
Inspired by #3957 I took some time to benchmark and improve the block sync
time as well. It's not as impressive as the 30x that #3957 achieved but it has
some incremental gains. The benchmarks use the following code, with a local
`bitcoind` and the default `bcli` backend:

```python3
from pyln.client import LightningRpc
import time
import subprocess

startheight = 600000
numblocks = 1000
targetheight = startheight + numblocks
proc = subprocess.Popen([
    'lightningd/lightningd',
    '--network=bitcoin',
    '--log-level=debug',
    '--rescan=-{}'.format(startheight),
    '--lightning-dir=/tmp/ll'
])
time.sleep(5)
rpc = LightningRpc('/tmp/ll/bitcoin/lightning-rpc')

def height():
    return rpc.getinfo()['blockheight']

def rate(first, last):
    if first == last:
        return 0
    return (last[1] - first[1]) / (last[0] - first[0])

start = (time.time(), height())
heights = []
while True:
    heights.append((time.time(), height()))
    if len(heights) > 30:
        heights = heights[-30:]
    first = heights[0]
    last = heights[-1]

    print("Speed: {:2f} blocks / s, overall {:2f} blocks / s".format(
        rate(first, last),
        rate(start, last)
    ))
    time.sleep(1)

    if last[1] >= targetheight:
        break

rpc.stop()
proc.wait()
```

The following are the performance gains achieved by individual commits (and compared to #3957):

| Scenario            | TTS 1000 blocks | Blocks / second | Speedup |
|---------------------|-----------------|-----------------|---------|
| pre-3957 (bf5e994)  |            8:01 |        2.073498 |       - |
| post-3957 (128adf0) |            7:28 |        2.224472 |      7% |
| commit 1 (68f3f30)  |            5:42 |        2.923359 |     41% |
| commit 2 (dc0859e)  |            5:00 |        3.321625 |     60% |
| commit 3 (0e4c6b6)  |            3:07 |        5.357775 |    158% |

And here are the flamegraphs that I used to guide the changes:
![flamegraph-pre-3957](https://user-images.githubusercontent.com/120117/91332899-1ed7ea00-e7cd-11ea-8c47-2e1c9f04e4b5.png)
![flamegraph-post-3957](https://user-images.githubusercontent.com/120117/91332909-226b7100-e7cd-11ea-8a29-bb7da395f510.png)
![flamegraph-68f3f30](https://user-images.githubusercontent.com/120117/91333011-475fe400-e7cd-11ea-9508-84f293ff8e1b.png)
![flamegraph-dc0859e](https://user-images.githubusercontent.com/120117/91333014-49c23e00-e7cd-11ea-87bc-9376a9f838b6.png)
![flamegraph-0e4c6b6](https://user-images.githubusercontent.com/120117/91333023-4c249800-e7cd-11ea-8f1a-cbcd20a2e3e2.png)