### PR TITLE
paymod: Scale presplit amounts to support larger payments while maintaining size buckets for privacy

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3472,7 +3472,6 @@ def test_mpp_interference_2(node_factory, bitcoind, executor):
     p3.result(TIMEOUT)
 
 
-@pytest.mark.xfail(strict=True)
 def test_large_mpp_presplit(node_factory):
     """Make sure that ludicrous amounts don't saturate channels
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3470,3 +3470,36 @@ def test_mpp_interference_2(node_factory, bitcoind, executor):
     # Both payments should succeed.
     p2.result(TIMEOUT)
     p3.result(TIMEOUT)
+
+
+@pytest.mark.xfail(strict=True)
+def test_large_mpp_presplit(node_factory):
+    """Make sure that ludicrous amounts don't saturate channels
+
+    We aim to have at most PRESPLIT_MAX_SPLITS HTLCs created directly from the
+    `presplit` modifier. The modifier will scale up its target size to
+    guarantee this, while still bucketizing payments that are in the following
+    range:
+
+    ```
+    target_size = PRESPLIT_MAX_SPLITS^{n} + MPP_TARGET_SIZE
+    target_size < amount <= target_size * PRESPLIT_MAX_SPLITS
+    ```
+
+    """
+    PRESPLIT_MAX_SPLITS = 16
+    MPP_TARGET_SIZE = 10 ** 7
+    amt = 400 * MPP_TARGET_SIZE
+
+    l1, l2, l3 = node_factory.line_graph(
+        3, fundamount=10**8, wait_for_announce=True,
+        opts={'wumbo': None}
+    )
+
+    inv = l3.rpc.invoice(amt, 'lbl', 'desc')['bolt11']
+    p = l1.rpc.pay(inv)
+
+    assert(p['parts'] <= PRESPLIT_MAX_SPLITS)
+    inv = l3.rpc.listinvoices()['invoices'][0]
+
+    assert(inv['msatoshi'] == inv['msatoshi_received'])


### PR DESCRIPTION
This proposal is a simple solution to #3926 and an alternative to
#3942/#3951. It is very much in the spirit of the original `presplit` payment
modifier in that it will create parts with a fixed size (not considering the
amount fuzzing to obfuscate the remainder), mostly independently of the total
amount. I think this is import to make it harder for observers to invert the
split and derive the original amount.

The change consists in adjusting the target amount for the individual parts
upwards should the current split result in too many parts. We use powers of 16
as a step size between buckets, resulting in at most 16 parts, and all
payments whose total amount is in the range of `x < amount <= 16*x` result in
the same part amount.


Why 16 as the upper limit of parts? Because it is approximately 1/2 of the
HTLCs available to a single channel, giving us some room to use adaptively
split should that be necessary. At the same time it is large enough such that
the resulting partial amounts are not too specific to the total amount, and
it's a power of two which means after log2(16) adaptive splits the amounts of
the parts mix with the a smaller payment's parts again. This is mostly in
preparation for PTLCs which give us decorrelation, but I think we can already
expect a benefit in amounts snapping to buckets.

Notice that none of the parameters are set in stone, and I'm happy to adjust
should better parameters be found.

Closes #3951
Closes #3942
Fixes #3926