### PR TITLE
configure: Use pg_config to locate the header location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ BOLT_DEPS := $(BOLT_GEN)
 ALL_PROGRAMS =
 
 CPPFLAGS += -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\""
-CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) -DBUILD_ELEMENTS=1
+CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(POSTGRES_INCLUDE) $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) -DBUILD_ELEMENTS=1
 # If CFLAGS is already set in the environment of make (to whatever value, it
 # does not matter) then it would export it to subprocesses with the above value
 # we set, including CWARNFLAGS which by default contains -Wall -Werror. This

--- a/configure
+++ b/configure
@@ -229,8 +229,14 @@ fi
 # Doesn't set a var, but makes sure it exists
 require 'python3-mako' "You need the mako module for python3: see doc/INSTALL.md" python3 -c 'import mako'
 
+POSTGRES_INCLUDE=""
+if command -v pg_config 2> /dev/null; then
+    POSTGRES_INCLUDE="-I$(pg_config --includedir)"
+fi
+
 rm -f $CONFIG_VAR_FILE.$$
-$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib <<EOF
+$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib $POSTGRES_INCLUDE <<EOF
+
 var=HAVE_GOOD_LIBSODIUM
 desc=libsodium with IETF chacha20 variants
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
@@ -286,7 +292,7 @@ desc=postgres
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
 link=-lpq
 code=
-#include <postgresql/libpq-fe.h>
+#include <libpq-fe.h>
 #include <stdio.h>
 
 int main(void)
@@ -353,6 +359,7 @@ add_var CONFIGURATOR_CC "$CONFIGURATOR_CC"
 add_var CWARNFLAGS "$CWARNFLAGS"
 add_var CDEBUGFLAGS "$CDEBUGFLAGS"
 add_var COPTFLAGS "$COPTFLAGS"
+add_var POSTGRES_INCLUDE "$POSTGRES_INCLUDE"
 add_var VALGRIND "$VALGRIND"
 add_var DEVELOPER "$DEVELOPER" $CONFIG_HEADER
 add_var EXPERIMENTAL_FEATURES "$EXPERIMENTAL_FEATURES" $CONFIG_HEADER

--- a/wallet/db_postgres.c
+++ b/wallet/db_postgres.c
@@ -8,7 +8,7 @@
 
 #if HAVE_POSTGRES
 /* Indented in order not to trigger the inclusion order check */
-  #include <postgresql/libpq-fe.h>
+  #include <libpq-fe.h>
 
 /* Cherry-picked from here: libpq/src/interfaces/ecpg/ecpglib/pg_type.h */
 #define BYTEAOID		17


### PR DESCRIPTION
We were using an ubuntu specific path to look for the headers for postgresql, which meant that on some other operating systems they would not get picked up. This uses the `pg_config` tool as detailed by the `libpq` [docs] to locate the header location in a portable way.

Fixes #3937 

[docs]: https://www.postgresql.org/docs/9.2/libpq-build.html