### PR TITLE
travis: use bitcoind v0.20.1

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -22,10 +22,10 @@ mkdir -p dependencies/bin || true
 
 # Download bitcoind and bitcoin-cli 
 if [ ! -f dependencies/bin/bitcoind ]; then
-    wget https://storage.googleapis.com/c-lightning-tests/bitcoin-0.18.1-x86_64-linux-gnu.tar.bz2
-    tar -xjf bitcoin-0.18.1-x86_64-linux-gnu.tar.bz2
-    mv bitcoin-0.18.1/bin/* dependencies/bin
-    rm -rf bitcoin-0.18.1-x86_64-linux-gnu.tar.gz bitcoin-0.18.1
+    wget https://storage.googleapis.com/c-lightning-tests/bitcoin-0.20.1-x86_64-linux-gnu.tar.bz2
+    tar -xjf bitcoin-0.20.1-x86_64-linux-gnu.tar.bz2
+    mv bitcoin-0.20.1/bin/* dependencies/bin
+    rm -rf bitcoin-0.20.1-x86_64-linux-gnu.tar.gz bitcoin-0.20.1
 fi
 
 pyenv global 3.7


### PR DESCRIPTION
Prior to v0.20.1, PSBT parsing is stricter and doesn't allow both a
witness_utxo and non_witness_utxo to be set.

Changelog-None.

Requires https://drive.google.com/file/d/1oN9Jkcf-K3mXjqJQNsJSVRp-NV8gGzkQ/view?usp=sharing to be uploaded to https://storage.googleapis.com/c-lightning-tests/bitcoin-0.20.1-x86_64-linux-gnu.tar.bz2. cc @cdecker is this a drive you have access to?