### PR TITLE
configure: Use pg_config to locate the library location too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ endif
 
 # If we have the postgres client library we need to link against it as well
 ifeq ($(HAVE_POSTGRES),1)
-LDLIBS += -lpq
+LDLIBS += $(POSTGRES_LDLIBS)
 endif
 
 default: show-flags all-programs all-test-programs doc-all

--- a/configure
+++ b/configure
@@ -230,8 +230,10 @@ fi
 require 'python3-mako' "You need the mako module for python3: see doc/INSTALL.md" python3 -c 'import mako'
 
 POSTGRES_INCLUDE=""
-if command -v pg_config 2> /dev/null; then
-    POSTGRES_INCLUDE="-I$(pg_config --includedir)"
+POSTGRES_LDLIBS=""
+if command -v "${PG_CONFIG-pg_config}" >/dev/null; then
+    POSTGRES_INCLUDE="-I$("${PG_CONFIG-pg_config}" --includedir)"
+    POSTGRES_LDLIBS="-L$("${PG_CONFIG-pg_config}" --libdir) -lpq"
 fi
 
 rm -f $CONFIG_VAR_FILE.$$
@@ -290,7 +292,7 @@ int main(void)
 var=HAVE_POSTGRES
 desc=postgres
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
-link=-lpq
+link=$POSTGRES_LDLIBS
 code=
 #include <libpq-fe.h>
 #include <stdio.h>
@@ -360,6 +362,7 @@ add_var CWARNFLAGS "$CWARNFLAGS"
 add_var CDEBUGFLAGS "$CDEBUGFLAGS"
 add_var COPTFLAGS "$COPTFLAGS"
 add_var POSTGRES_INCLUDE "$POSTGRES_INCLUDE"
+add_var POSTGRES_LDLIBS "$POSTGRES_LDLIBS"
 add_var VALGRIND "$VALGRIND"
 add_var DEVELOPER "$DEVELOPER" $CONFIG_HEADER
 add_var EXPERIMENTAL_FEATURES "$EXPERIMENTAL_FEATURES" $CONFIG_HEADER

--- a/configure
+++ b/configure
@@ -8,6 +8,13 @@ CONFIG_VAR_FILE=config.vars
 CONFIG_HEADER=ccan/config.h
 BASE_WARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror"
 
+# You can set PG_CONFIG in the environment to direct configure to call
+# a specific 'pg_config' binary. If you set it to an empty string, then
+# PostgreSQL support will be explicitly disabled, even if a 'pg_config'
+# binary exists in your PATH. If you leave it unset, then the following
+# line enables the automagic detection that most users want.
+: ${PG_CONFIG=pg_config}
+
 usage_with_default()
 {
     if [ $# = 4 ]; then
@@ -231,9 +238,9 @@ require 'python3-mako' "You need the mako module for python3: see doc/INSTALL.md
 
 POSTGRES_INCLUDE=""
 POSTGRES_LDLIBS=""
-if command -v "${PG_CONFIG-pg_config}" >/dev/null; then
-    POSTGRES_INCLUDE="-I$("${PG_CONFIG-pg_config}" --includedir)"
-    POSTGRES_LDLIBS="-L$("${PG_CONFIG-pg_config}" --libdir) -lpq"
+if command -v "${PG_CONFIG}" >/dev/null; then
+    POSTGRES_INCLUDE="-I$("${PG_CONFIG}" --includedir)"
+    POSTGRES_LDLIBS="-L$("${PG_CONFIG}" --libdir) -lpq"
 fi
 
 rm -f $CONFIG_VAR_FILE.$$


### PR DESCRIPTION
On some systems (e.g., Gentoo), there can be multiple major versions of the PostgreSQL client library installed in parallel. There exists a separate `pg_config` and `libpq.so*` for each major version. This Pull Request adds support to C-Lightning's build system to allow the user to choose a specific version of the PostgreSQL client library to build and link against.

**Summary of proposed changes:**

* Introduce a `POSTGRES_LDLIBS` config variable, analogous to the existing `POSTGRES_INCLUDE` variable, and use it in place of `-lpq`, both in `Makefile` and in the Configurator script.
* When running `configure`, allow the user to override the name of `pg_config` by setting the `PG_CONFIG` environment variable. If unset, the default continues to be `pg_config`, which preserves the existing behavior.
* The above changes have the happy side-effect that setting `PG_CONFIG` to an empty string will now cause Configurator's test for PostgreSQL to fail, so C-Lightning will be built without PostgreSQL support, even if a PostgreSQL client library is present on the build system. (The Gentoo ebuild has been hacking the Configurator test code by inserting an `#error` directive to force the test to fail when the user has requested that C-Lightning not support PostgreSQL. That hack is no longer necessary with the changes in this PR.)