### PR TITLE
IO-level logging for plugins

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -505,9 +505,12 @@ class Plugin(object):
         Returns the last partial message that was not complete yet.
         """
         for payload in msgs[:-1]:
+            raw_req = payload.decode("utf8")
+            self.log(raw_req, level="io")
+
             # Note that we use function annotations to do Millisatoshi conversions
             # in _exec_func, so we don't use LightningJSONDecoder here.
-            request = self._parse_request(json.loads(payload.decode('utf8')))
+            request = self._parse_request(json.loads(raw_req))
 
             # If this has an 'id'-field, it's a request and returns a
             # result. Otherwise it's a notification and it doesn't

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -284,6 +284,8 @@ static const char *plugin_log_handle(struct plugin *plugin,
 		level = LOG_UNUSUAL;
 	else if (json_tok_streq(plugin->buffer, leveltok, "error"))
 		level = LOG_BROKEN;
+	else if (json_tok_streq(plugin->buffer, leveltok, "io"))
+		level = LOG_IO_IN;
 	else {
 		return tal_fmt(plugin,
 			       "Unknown log-level %.*s, valid values are "

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1121,6 +1121,9 @@ static bool ld_read_json_one(struct plugin *plugin)
 		return false;
 	}
 
+	plugin_log(plugin, LOG_IO_IN, "%.*s", (int)plugin->len_read,
+	       plugin->buffer + plugin->used);
+
 	/* FIXME: Spark doesn't create proper jsonrpc 2.0!  So we don't
 	 * check for "jsonrpc" here. */
 	ld_command_handle(plugin, cmd, plugin->toks);


### PR DESCRIPTION
Just small things that i found useful when debugging a plugin crash:
- Allow plugins to log as `io` (i was pretty sure it was allowed)
- Log incoming requests in libplugin and pyln, we log in lightningd/plugin the requests coming from the plugins. However we cannot log the outgoing ones in lightningd/plugin without moving around the `jout` struct: instead, just log the incoming requests from the point of view of the plugin.