### PR TITLE
Allow building without SQLite3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ BOLT_DEPS := $(BOLT_GEN)
 ALL_PROGRAMS =
 
 CPPFLAGS += -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\""
-CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(POSTGRES_INCLUDE) $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) -DBUILD_ELEMENTS=1
+CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I/usr/local/include $(SQLITE3_CFLAGS) $(POSTGRES_INCLUDE) $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) -DBUILD_ELEMENTS=1
 # If CFLAGS is already set in the environment of make (to whatever value, it
 # does not matter) then it would export it to subprocesses with the above value
 # we set, including CWARNFLAGS which by default contains -Wall -Werror. This
@@ -221,9 +221,9 @@ ifeq ($(STATIC),1)
 # For MacOS, Jacob Rapoport <jacob@rumblemonkey.com> changed this to:
 #  -L/usr/local/lib -Wl,-lgmp -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
 # But that doesn't static link.
-LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp -lsqlite3 -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
+LDLIBS = -L/usr/local/lib -Wl,-dn -lgmp $(SQLITE3_LDLIBS) -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
 else
-LDLIBS = -L/usr/local/lib -lm -lgmp -lsqlite3 -lz $(COVFLAGS)
+LDLIBS = -L/usr/local/lib -lm -lgmp $(SQLITE3_LDLIBS) -lz $(COVFLAGS)
 endif
 
 # If we have the postgres client library we need to link against it as well

--- a/configure
+++ b/configure
@@ -8,6 +8,8 @@ CONFIG_VAR_FILE=config.vars
 CONFIG_HEADER=ccan/config.h
 BASE_WARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror"
 
+: ${PKG_CONFIG=pkg-config}
+
 # You can set PG_CONFIG in the environment to direct configure to call
 # a specific 'pg_config' binary. If you set it to an empty string, then
 # PostgreSQL support will be explicitly disabled, even if a 'pg_config'
@@ -236,6 +238,13 @@ fi
 # Doesn't set a var, but makes sure it exists
 require 'python3-mako' "You need the mako module for python3: see doc/INSTALL.md" python3 -c 'import mako'
 
+SQLITE3_CFLAGS=""
+SQLITE3_LDLIBS="-lsqlite3"
+if command -v "${PKG_CONFIG}" >/dev/null; then
+    SQLITE3_CFLAGS="$("${PKG_CONFIG}" --silence-errors --cflags sqlite3 || :)"
+    SQLITE3_LDLIBS="$("${PKG_CONFIG}" --silence-errors --libs sqlite3 || :)"
+fi
+
 POSTGRES_INCLUDE=""
 POSTGRES_LDLIBS=""
 if command -v "${PG_CONFIG}" >/dev/null; then
@@ -244,7 +253,7 @@ if command -v "${PG_CONFIG}" >/dev/null; then
 fi
 
 rm -f $CONFIG_VAR_FILE.$$
-$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib $POSTGRES_INCLUDE <<EOF
+$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib $SQLITE3_CFLAGS $POSTGRES_INCLUDE <<EOF
 
 var=HAVE_GOOD_LIBSODIUM
 desc=libsodium with IETF chacha20 variants
@@ -271,7 +280,7 @@ int main(void)
 var=HAVE_SQLITE3_EXPANDED_SQL
 desc=sqlite3_expanded_sql
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
-link=-lsqlite3
+link=$SQLITE3_LDLIBS
 code=
 #include <sqlite3.h>
 #include <stdio.h>
@@ -285,7 +294,7 @@ int main(void)
 var=HAVE_SQLITE3
 desc=sqlite3
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
-link=-lsqlite3
+link=$SQLITE3_LDLIBS
 code=
 #include <sqlite3.h>
 #include <stdio.h>
@@ -368,6 +377,8 @@ add_var CONFIGURATOR_CC "$CONFIGURATOR_CC"
 add_var CWARNFLAGS "$CWARNFLAGS"
 add_var CDEBUGFLAGS "$CDEBUGFLAGS"
 add_var COPTFLAGS "$COPTFLAGS"
+add_var SQLITE3_CFLAGS "$SQLITE3_CFLAGS"
+add_var SQLITE3_LDLIBS "$SQLITE3_LDLIBS"
 add_var POSTGRES_INCLUDE "$POSTGRES_INCLUDE"
 add_var POSTGRES_LDLIBS "$POSTGRES_LDLIBS"
 add_var VALGRIND "$VALGRIND"

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,6 +1,9 @@
 DEVTOOLS_SRC := devtools/gen_print_wire.c devtools/gen_print_onion_wire.c devtools/print_wire.c
 DEVTOOLS_OBJS := $(DEVTOOLS_SRC:.c=.o)
-DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore devtools/mkcommit devtools/mkfunding devtools/mkclose devtools/mkgossip devtools/mkencoded devtools/checkchannels devtools/mkquery devtools/lightning-checkmessage devtools/topology devtools/route
+DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore devtools/mkcommit devtools/mkfunding devtools/mkclose devtools/mkgossip devtools/mkencoded devtools/mkquery devtools/lightning-checkmessage devtools/topology devtools/route
+ifeq ($(HAVE_SQLITE3),1)
+DEVTOOLS += devtools/checkchannels
+endif
 ifeq ($(EXPERIMENTAL_FEATURES),1)
 DEVTOOLS += devtools/blindedpath
 endif

--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -1,5 +1,6 @@
 /* Updates the given file if any library versions have changed.  This
  * is important for systemwide updates, such as sqlite3. */
+#include "config.h"
 #include <ccan/err/err.h>
 #include <ccan/read_write_all/read_write_all.h>
 #include <ccan/tal/grab_file/grab_file.h>
@@ -7,7 +8,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <gmp.h>
-#include <sqlite3.h>
+#if HAVE_SQLITE3
+# include <sqlite3.h>
+# define IF_SQLITE3(...) __VA_ARGS__
+#else
+# define IF_SQLITE3(...)
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -16,19 +22,21 @@
 static const char template[] =
 	"/* Generated file by tools/headerversions, do not edit! */\n"
 	"/* GMP version: %s */\n"
-	"/* SQLITE3 version: %u */\n"
+	IF_SQLITE3("/* SQLITE3 version: %u */\n")
 	"/* ZLIB version: %s */\n"
 	"#include <ccan/err/err.h>\n"
 	"#include <gmp.h>\n"
-	"#include <sqlite3.h>\n"
+	IF_SQLITE3("#include <sqlite3.h>\n")
 	"#include <zlib.h>\n"
 	"\n"
 	"static inline void check_linked_library_versions(void)\n"
 	"{\n"
 	"	char compiled_gmp_version[100];\n"
+	IF_SQLITE3(
 	"	if (SQLITE_VERSION_NUMBER != sqlite3_libversion_number())\n"
 	"		errx(1, \"SQLITE version mismatch: compiled %%u, now %%u\",\n"
 	"		     SQLITE_VERSION_NUMBER, sqlite3_libversion_number());\n"
+	)
 	"	/* zlib documents that first char alters ABI. Kudos! */\n"
 	"	if (zlibVersion()[0] != ZLIB_VERSION[0])\n"
 	"		errx(1, \"zlib version mismatch: compiled %%s, now %%s\",\n"
@@ -60,7 +68,7 @@ int main(int argc, char *argv[])
 
 	new = tal_fmt(NULL, template,
 		      gmp_version,
-		      sqlite3_libversion_number(),
+		      IF_SQLITE3(sqlite3_libversion_number(),)
 		      zlibVersion());
 	if (!file || !streq(new, file)) {
 		int fd = open(argv[1], O_TRUNC|O_WRONLY|O_CREAT, 0666);

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -4,7 +4,6 @@
 #include <ccan/autodata/autodata.h>
 #include <ccan/list/list.h>
 #include <ccan/short_types/short_types.h>
-#include <sqlite3.h>
 #include <stdbool.h>
 
 /* For testing, we want to catch fatal messages. */

--- a/wallet/db_postgres.c
+++ b/wallet/db_postgres.c
@@ -3,7 +3,6 @@
 #include <ccan/ccan/tal/str/str.h>
 #include <ccan/endian/endian.h>
 #include <lightningd/log.h>
-#include <sqlite3.h>
 #include <stdio.h>
 
 #if HAVE_POSTGRES

--- a/wallet/db_sqlite3.c
+++ b/wallet/db_sqlite3.c
@@ -2,10 +2,10 @@
 #include "gen_db_sqlite3.c"
 #include <ccan/ccan/tal/str/str.h>
 #include <lightningd/log.h>
-#include <sqlite3.h>
 #include <stdio.h>
 
 #if HAVE_SQLITE3
+#include <sqlite3.h>
 
 #if !HAVE_SQLITE3_EXPANDED_SQL
 /* Prior to sqlite3 v3.14, we have to use tracing to dump statements */


### PR DESCRIPTION
**Summary of proposed changes:**

* Introduce `SQLITE3_CFLAGS` and `SQLITE3_LDLIBS` config variables, whose values are automagically populated by calling out to `pkg-config`. If `pkg-config` is not found, then the new variables are defaulted as `SQLITE3_CFLAGS=` and `SQLITE3_LDLIBS=-lsqlite3`, which allows `configure` to continue working as before on systems lacking `pkg-config`.
    * When running `configure`, allow the user to override the name of `pkg-config` by setting the `PKG_CONFIG` environment variable. If unset, the default is `pkg-config`, which means to use the system default (i.e., in `$PATH`) copy of `pkg-config`. Cross-compiling users would set the `PKG_CONFIG` environment variable to the path of a `pkg-config` binary that provides information about packages built for the target system.
* Pass `$SQLITE3_CFLAGS` to Configurator, and add it to `CFLAGS` in `Makefile`.
* Pass `$SQLITE3_LDLIBS` in place of `-lsqlite3`, both in `Makefile` and in the Configurator script.
* Tweak a few source files so that they compile successfully when `HAVE_SQLITE3=0`.
* Omit `devtools/checkchannels` from build when `HAVE_SQLITE3=0`, as that tool requires SQLite3.