### PR TITLE
Fixed plugin behaviors with options type

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -605,6 +605,8 @@ char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
 		if (*popt->value->as_int != l)
 			return tal_fmt(tmpctx, "%s does not parse as type %s (overflowed)",
 				       popt->value->as_str, popt->type);
+		tal_free(popt->value->as_str);
+		popt->value->as_str = NULL;
 	} else if (streq(popt->type, "bool")) {
 		/* valid values are 'true', 'True', '1', '0', 'false', 'False', or '' */
 		if (streq(arg, "true") || streq(arg, "True") || streq(arg, "1")) {
@@ -615,6 +617,8 @@ char *plugin_opt_set(const char *arg, struct plugin_opt *popt)
 		} else
 			return tal_fmt(tmpctx, "%s does not parse as type %s",
 				       popt->value->as_str, popt->type);
+		tal_free(popt->value->as_str);
+		popt->value->as_str = NULL;
 	}
 
 	return NULL;
@@ -1422,13 +1426,11 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 			json_add_bool(req->stream, name, *opt->value->as_bool);
 			if (!deprecated_apis)
 				continue;
-		}
-		if (opt->value->as_int) {
+		}else if (opt->value->as_int) {
 			json_add_s64(req->stream, name, *opt->value->as_int);
 			if (!deprecated_apis)
 				continue;
-		}
-		if (opt->value->as_str) {
+		}else if (opt->value->as_str) {
 			json_add_string(req->stream, name, opt->value->as_str);
 		}
 	}


### PR DESCRIPTION
Hi all!

With this PR I'm trying to fix the behavior of the plugin option types. I noted during a plugin developing that the propriety with different type from `string` and `flag` had a wrong conversion in json form. This because the code below override the `bool` and int `type` with a string

```c
	popt->value->as_str = tal_strdup(popt, arg);
	if (streq(popt->type, "int")) {
		errno = 0;
		l = strtoll(arg, &endp, 0);
		if (errno || *endp)
			return tal_fmt(tmpctx, "%s does not parse as type %s",
				       popt->value->as_str, popt->type);
		*popt->value->as_int = l;

		/* Check if the number did not fit in `s64` (in case `long long`
		 * is a bigger type). */
		if (*popt->value->as_int != l)
			return tal_fmt(tmpctx, "%s does not parse as type %s (overflowed)",
				       popt->value->as_str, popt->type);
	} else if (streq(popt->type, "bool")) {
		/* valid values are 'true', 'True', '1', '0', 'false', 'False', or '' */
		if (streq(arg, "true") || streq(arg, "True") || streq(arg, "1")) {
			*popt->value->as_bool = true;
		} else if (streq(arg, "false") || streq(arg, "False")
				|| streq(arg, "0")) {
			*popt->value->as_bool = false;
		} else
			return tal_fmt(tmpctx, "%s does not parse as type %s",
				       popt->value->as_str, popt->type);
	}
```

This proposal is a draft solution because I'm pretty sure that it is possible to write the code cleaner! such as:

In this case, is good has a complete if-else and not use the propriety by default string? after check, if the type is `int` or `boolean`?
