### PR TITLE
feat: some driveby improvements

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -106,11 +106,11 @@ static const char *level_prefix(enum log_level level)
 	switch (level) {
 	case LOG_IO_OUT:
 	case LOG_IO_IN:
-		return "IO";
+		return "IO     ";
 	case LOG_DBG:
-		return "DEBUG";
+		return "DEBUG  ";
 	case LOG_INFORM:
-		return "INFO";
+		return "INFO   ";
 	case LOG_UNUSUAL:
 		return "UNUSUAL";
 	case LOG_BROKEN:


### PR DESCRIPTION
Some driveby additions. This PR does:

- align common log level (except \*\*BROKEN\*\*)
- adds: `is_in_log()` can now also have a list or a list of patterns
- adds: `was_in_log()` as a look-back function that works similar to wait_for_log but without waiting/blocking.
- test: `test_pyln_loghelpers`