### PR TITLE
Cleanups to derived resouces

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,8 @@ configure text eol=lf
 # The following files are generated and should not be shown in the
 # diffs by default on Github.
 doc/lightning*.7 linguist-generated=true
+wallet/db_*_sqlgen.c linguist-generated=true
+wallet/statements_gettextgen.po linguist-generated=true
+*_wiregen.? linguist-generated=true
+*_printgen.? linguist-generated=true
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -100,7 +100,6 @@ check-manpages: all-programs
 	@tools/check-manpage.sh "lightningd/lightningd --lightning-dir=/tmp/" doc/lightningd-config.5.md
 
 doc-maintainer-clean:
-	$(RM) doc/deployable-lightning.pdf
 	$(RM) $(MANPAGES)
 
 doc-clean:

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -42,14 +42,11 @@ wallet/statements_gettextgen.po: $(SQL_FILES) FORCE
 wallet/db_%_sqlgen.c: wallet/statements_gettextgen.po devtools/sql-rewrite.py FORCE
 	@if $(call SHA256STAMP_CHANGED,); then $(call VERBOSE,"sql-rewrite $@",devtools/sql-rewrite.py wallet/statements_gettextgen.po $* > $@ && $(call SHA256STAMP,,//)); fi
 
-clean: wallet-clean
-wallet-clean:
-	$(RM) wallet/statements.po
-	$(RM) wallet/gen_db_sqlite3.c
-	$(RM) wallet/gen_db_postgres.c
-
-maintainer-clean: wallet_maintainer-clean
+maintainer-clean: wallet-maintainer-clean
 wallet-maintainer-clean:
+	$(RM) wallet/statements.po
 	$(RM) wallet/statements_gettextgen.po
+	$(RM) wallet/db_sqlite3_sqlgen.c
+	$(RM) wallet/db_postgres_sqlgen.c
 
 include wallet/test/Makefile


### PR DESCRIPTION
If I understand the `maintainer` / `developer` split correctly it should be possible for a developer not to have all the python dependencies to generate some of the derived files that are now checked in. Contrary to this the generated DB files where cleaned up with `make clean`, so I moved them to the `maintainer-clean` target instead (and fixed the `wallet-maintainer-clean` target which had a typo).

I then added the derived files to the `.gitattributes` file which will collapse these derived diffs in the Github interface, to cut down on he noise when reviewing changes.

Finally, `maintainer-clean` was deleting the `deployable-lightning.pdf` file which would not get regenerated, and has heavy dependencies to rebuild. I removed that cleanup of a document that hasn't seen any changes for years.