### PR TITLE
chore: .gitignore _exp_ wiregen

### DIFF
--- a/wire/.gitignore
+++ b/wire/.gitignore
@@ -1,0 +1,4 @@
+
+# Ignore experimental wiregen
+*_exp_*
+


### PR DESCRIPTION
Just so we don't have untracked git changes all over the place when building experimental features.