### PR TITLE
Added proxy information to plugin configuration

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -214,6 +214,14 @@ simple JSON object containing the options:
         "channel": "",
         "invoice": "028200"
     }
+    "startup": true,
+    "proxy": {
+        "type": "ipv4",
+        "address": "127.0.0.1",
+        "port": 9050
+    }
+    "torv3-enabled": true,
+    "use_proxy_always": false
   }
 }
 ```

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -6,6 +6,7 @@
 #include <common/features.h>
 #include <common/utils.h>
 #include <common/version.h>
+#include <common/json_helpers.h>
 #include <lightningd/json.h>
 #include <lightningd/notification.h>
 #include <lightningd/options.h>
@@ -1452,6 +1453,11 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 	json_add_string(req->stream, "rpc-file", ld->rpc_filename);
 	json_add_bool(req->stream, "startup", plugin->plugins->startup);
 	json_add_string(req->stream, "network", chainparams->network_name);
+	if (ld->proxyaddr) {
+		json_add_address(req->stream, "proxy", ld->proxyaddr);
+		json_add_bool(req->stream, "torv3-enabled", ld->config.use_v3_autotor);
+		json_add_bool(req->stream, "use_proxy_always", ld->use_proxy_always);
+	}
 	json_object_start(req->stream, "feature_set");
 	for (enum feature_place fp = 0; fp < NUM_FEATURE_PLACE; fp++) {
 		if (feature_place_names[fp]) {


### PR DESCRIPTION
Hi all!

With this PR, I'm proposing my idea to add a couple of the information to the proxy during the plugin configuration.

Inside my test to develop a new plugin, I noted the necessity to know if the node has the proxy enabled, the solution was to add a plugin option but I think this is redundant propriety during the node setup!

Another solution is to use the `listconfigs` to set up the connection inside the plugin but in some cases the method plugin call before to start some plugin methods! For instance, an alternative backend bitcoin/element that overrides the plugin `bcli` 

I hope that I'm losing nothings.