### PR TITLE
log: align level tags IO DEBUG INFO and UNUSUAL

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -106,11 +106,11 @@ static const char *level_prefix(enum log_level level)
 	switch (level) {
 	case LOG_IO_OUT:
 	case LOG_IO_IN:
-		return "IO";
+		return "IO     ";
 	case LOG_DBG:
-		return "DEBUG";
+		return "DEBUG  ";
 	case LOG_INFORM:
-		return "INFO";
+		return "INFO   ";
 	case LOG_UNUSUAL:
 		return "UNUSUAL";
 	case LOG_BROKEN:


### PR DESCRIPTION
This aligns all log TAGs except \*\*BROKEN\*\* which would require too many spaces for all the other logs.
This makes reading the logs with human eyes easier as the log message payload always starts at the same character of a line.

Additionally, I suggest replacing "UNUSUAL" with "WARN" and "\*\*BROKEN\*\*" with "FATAL" which seems more standard and is shorter.

Changelog-None