### PR TITLE
Re-enable ASAN when building with clang

### DIFF
--- a/configure
+++ b/configure
@@ -223,10 +223,6 @@ $CC ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -o $CONFIGURATOR $CONF
 echo "done"
 
 if [ "$ASAN" = "1" ]; then
-    if [ "$CC" = "clang" ]; then
-	echo "Address sanitizer (ASAN) is currently only supported with gcc"
-	exit 1
-    fi
     if [ "$VALGRIND" = "1" ]; then
 	echo "Address sanitizer (ASAN) and valgrind cannot be enabled at the same time"
 	exit 1

--- a/contrib/sanitizer_suppressions/asan
+++ b/contrib/sanitizer_suppressions/asan
@@ -1,0 +1,3 @@
+# process_check_funding_broadcast is racy as it operates on a data that may be
+# freed under its feet
+interceptor_via_fun:process_check_funding_broadcast

--- a/contrib/sanitizer_suppressions/lsan
+++ b/contrib/sanitizer_suppressions/lsan
@@ -1,0 +1,3 @@
+# Clang would detect false positive here, due to padding. See https://github.com/ElementsProject/lightning/pull/2285
+leak:ccan/ccan/autodata/autodata.c
+leak:ccan/ccan/htable/htable.c

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -853,7 +853,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 	struct penalty_base *pbase;
 	struct amount_msat our_msats;
 	struct amount_sat total;
-	u8 msg_type;
+	enum dualopend_wire msg_type;
 
 	state->our_role = ACCEPTER;
 	open_tlv = tlv_opening_tlvs_new(tmpctx);


### PR DESCRIPTION
I'm looking at including some fuzz targets, and will probably use clang along with its address sanitizer (and hopefully many others!).

This removes the restriction on only using gcc with ASAN, by using suppressions instead when using clang (see #2285 for the reason).
This also enables ASAN on non-already-under-valgrind Travis jobs.