### PR TITLE
Avoid compile error on macos mojave

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -180,7 +180,7 @@ static void estimatefees_callback(const char *buf, const jsmntok_t *toks,
 				     "estimatefees",
 				     "bad 'result' field");
 
-	for (enum feerate f = 0; f < NUM_FEERATES; f++) {
+	for (int f = 0; f < NUM_FEERATES; f++) {
 		feeratetok = json_get_member(buf, resulttok, feerate_name(f));
 		if (!feeratetok)
 			bitcoin_plugin_error(call->bitcoind, buf, toks,

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -350,7 +350,7 @@ static void add_feerate_history(struct chain_topology *topo,
 /* Did the the feerate change since we last estimated it ? */
 static bool feerate_changed(struct chain_topology *topo, u32 old_feerates[])
 {
-	for (enum feerate f = 0; f < NUM_FEERATES; f++) {
+	for (int f = 0; f < NUM_FEERATES; f++) {
 		if (try_get_feerate(topo, f) != old_feerates[f])
 			return true;
 	}


### PR DESCRIPTION
Fixing the following error by changing 'enum feerate' to int.

lightningd/bitcoind.c:183:29: error: result of comparison of constant 8 with expression of type 'enum feerate' is always true [-Werror,-Wtautological-constant-out-of-range-compare]
        for (enum feerate f = 0; f < NUM_FEERATES; f++) {
