### PR TITLE
feat: notification channel_state_changed

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -800,6 +800,15 @@ class LightningNode(object):
         channel = peers[0]['channels'][0]
         return channel['short_channel_id']
 
+    def get_channel_id(self, other):
+        """Get the channel_id for the channel to the other node.
+        """
+        peers = self.rpc.listpeers(other.info['id'])['peers']
+        if not peers or 'channels' not in peers[0]:
+            return None
+        channel = peers[0]['channels'][0]
+        return channel['channel_id']
+
     def is_channel_active(self, chanid):
         channels = self.rpc.listchannels(chanid)['channels']
         active = [(c['short_channel_id'], c['channel_flags']) for c in channels if c['active']]

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -322,6 +322,24 @@ into a block.
 }
 ```
 
+### `channel_state_changed`
+
+A notification for topic `channel_state_changed` is sent every time a channel
+changes its state. The notification includes the peer and channel ids as well
+as the old and the new channel states.
+
+```json
+{
+    "channel_state_changed": {
+        "peer_id": "03bc9337c7a28bb784d67742ebedd30a93bacdf7e4ca16436ef3798000242b2251",
+        "channel_id": "a2d0851832f0e30a0cf778a826d72f077ca86b69f72677e0267f23f63a0599b4",
+        "short_channel_id" : "561820x1020x1",
+        "old_state": "CHANNELD_NORMAL",
+        "new_state": "CHANNELD_SHUTTING_DOWN"
+    }
+}
+```
+
 ### `connect`
 
 A notification for topic `connect` is sent every time a new connection

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -399,13 +399,15 @@ void channel_set_state(struct channel *channel,
 	wallet_channel_save(channel->peer->ld->wallet, channel);
 
 	/* plugin notification channel_state_changed */
-	derive_channel_id(&cid, &channel->funding_txid, channel->funding_outnum);
-	notify_channel_state_changed(channel->peer->ld,
-				     &channel->peer->id,
-				     &cid,
-				     channel->scid,
-				     old_state,
-				     state);
+	if (state != old_state) {  /* see issue #4029 */
+		derive_channel_id(&cid, &channel->funding_txid, channel->funding_outnum);
+		notify_channel_state_changed(channel->peer->ld,
+					     &channel->peer->id,
+					     &cid,
+					     channel->scid,
+					     old_state,
+					     state);
+	}
 }
 
 void channel_fail_permanent(struct channel *channel, const char *fmt, ...)

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -7,9 +7,11 @@
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/time/time.h>
 #include <common/amount.h>
+#include <common/channel_id.h>
 #include <common/coin_mvt.h>
 #include <common/errcode.h>
 #include <common/node_id.h>
+#include <lightningd/channel_state.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
@@ -54,6 +56,13 @@ void notify_invoice_creation(struct lightningd *ld, struct amount_msat *amount,
 void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
 			   struct amount_sat *funding_sat, struct bitcoin_txid *funding_txid,
 			   bool *funding_locked);
+
+void notify_channel_state_changed(struct lightningd *ld,
+				  struct node_id *peer_id,
+				  struct channel_id *cid,
+				  struct short_channel_id *scid,
+				  enum channel_state old_state,
+				  enum channel_state new_state);
 
 void notify_forward_event(struct lightningd *ld,
 			  const struct htlc_in *in,

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -15,11 +15,16 @@ def init(plugin, options, configuration):
 
 
 @plugin.subscribe("channel_opened")
-def channel_opened(plugin, channel_opened):
+def channel_opened(plugin, channel_opened, **kwargs):
     plugin.log("A channel was opened to us by {}, with an amount"
                " of {} and the following funding transaction id: {}"
                .format(channel_opened["id"], channel_opened["amount"],
                        channel_opened["funding_txid"]))
+
+
+@plugin.subscribe("channel_state_changed")
+def channel_state_changed(plugin, channel_state_changed, **kwargs):
+    plugin.log("channel_state_changed {}".format(channel_state_changed))
 
 
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -736,14 +736,6 @@ def test_channel_state_changed_unilateral(node_factory, bitcoind):
     assert(event['peer_id'] == peer_id)
     assert(event['channel_id'] == cid)
     assert(event['short_channel_id'] == scid)
-    assert(event['old_state'] == "AWAITING_UNILATERAL")  # this actually happens
-    assert(event['new_state'] == "AWAITING_UNILATERAL")  # note: same states
-
-    msg = l2.daemon.wait_for_log("channel_state_changed.*new_state.*")
-    event = ast.literal_eval(re.findall(".*({.*}).*", msg)[0])
-    assert(event['peer_id'] == peer_id)
-    assert(event['channel_id'] == cid)
-    assert(event['short_channel_id'] == scid)
     assert(event['old_state'] == "AWAITING_UNILATERAL")
     assert(event['new_state'] == "FUNDING_SPEND_SEEN")
 

--- a/wallet/db_postgres_sqlgen.c
+++ b/wallet/db_postgres_sqlgen.c
@@ -1648,4 +1648,4 @@ struct db_query db_postgres_queries[] = {
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_POSTGRES */
 
-// SHA256STAMP:e55a8febb74330a9167e8498b26e556609d95b7ca6ef984da1fa200e53e36a7e
+// SHA256STAMP:4c9787464f33fe9bfd209efbd84daebeb5584d52daa1d83f4c34f9a0a6108b46

--- a/wallet/db_sqlite3_sqlgen.c
+++ b/wallet/db_sqlite3_sqlgen.c
@@ -1648,4 +1648,4 @@ struct db_query db_sqlite3_queries[] = {
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_SQLITE3 */
 
-// SHA256STAMP:e55a8febb74330a9167e8498b26e556609d95b7ca6ef984da1fa200e53e36a7e
+// SHA256STAMP:4c9787464f33fe9bfd209efbd84daebeb5584d52daa1d83f4c34f9a0a6108b46

--- a/wallet/statements_gettextgen.po
+++ b/wallet/statements_gettextgen.po
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "not a valid SQL statement"
 msgstr ""
 
-#: wallet/test/run-wallet.c:1351
+#: wallet/test/run-wallet.c:1359
 msgid "INSERT INTO channels (id) VALUES (1);"
 msgstr ""
-#  SHA256STAMP:de15ae770286fe050f7b2d712bcc2a3311a8737e920353bb8c7d8dbf0188db69
+#  SHA256STAMP:108fcc46e6fa6e190b27773161a9c6bf9a83cb25e9d3164fa40e9de9e6f98644

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -428,6 +428,14 @@ void notify_chain_mvt(struct lightningd *ld UNNEEDED, const struct chain_coin_mv
 /* Generated stub for notify_channel_mvt */
 void notify_channel_mvt(struct lightningd *ld UNNEEDED, const struct channel_coin_mvt *mvt UNNEEDED)
 { fprintf(stderr, "notify_channel_mvt called!\n"); abort(); }
+/* Generated stub for notify_channel_state_changed */
+void notify_channel_state_changed(struct lightningd *ld UNNEEDED,
+				  struct node_id *peer_id UNNEEDED,
+				  struct channel_id *cid UNNEEDED,
+				  struct short_channel_id *scid UNNEEDED,
+				  enum channel_state old_state UNNEEDED,
+				  enum channel_state new_state UNNEEDED)
+{ fprintf(stderr, "notify_channel_state_changed called!\n"); abort(); }
 /* Generated stub for notify_connect */
 void notify_connect(struct lightningd *ld UNNEEDED, struct node_id *nodeid UNNEEDED,
 		    struct wireaddr_internal *addr UNNEEDED)


### PR DESCRIPTION
## Summary
This adds a new plugin notification message `channel_state_changed` that is called when a channel changes its state.

This PR contains code, test and doc.
Addresses #4018 

## Example message
```json
{
    "channel_state_changed": {
        "peer_id": "03bc9337c7a28bb784d67742ebedd30a93bacdf7e4ca16436ef3798000242b2251",
        "channel_id": "a2d0851832f0e30a0cf778a826d72f077ca86b69f72677e0267f23f63a0599b4",
        "short_channel_id" : "561820x1020x1",
        "old_state": "CHANNELD_NORMAL",
        "new_state": "CHANNELD_SHUTTING_DOWN"
    }
}
```

## Future thoughts
@fiatjaf added the question if it would be possible to have some kind of a 'reason' for a state changed operation. From a user or plugin developer perspective, this is mostly the distinction if a channel was closed by remote or by the user or for other (internal) reasons. We could add an string indication to this event, i.e. `"reason" : "USER"` or `"reason" : "REMOTE"`  or `"reason" : "OTHER"` . Also, this only makes sens for state changes from CHANNELD_NORMAL to some CLOSING state. Maybe AWAITING_LOCKIN can also be caused by the user if its a local funding thats ongoing.

## Note
When unilaterally closing a channel it happens that the state changes two times to the same value `AWAITING_UNILATERAL`.
I don't think this is intended, but current test reflect that.

