### PR TITLE
elementsd: add a fee output to a fund/utxopsbt for elements transactions

### DIFF
--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -296,6 +296,12 @@ static struct command_result *finish_psbt(struct command *cmd,
 	psbt = psbt_using_utxos(cmd, utxos, cmd->ld->wallet->bip32_base,
 				*locktime, BITCOIN_TX_RBF_SEQUENCE);
 
+	/* Add a fee output if this is elements */
+	if (is_elements(chainparams)) {
+		struct amount_sat est_fee =
+			amount_tx_fee(feerate_per_kw, weight);
+		psbt_append_output(psbt, NULL, est_fee);
+	}
 	response = json_stream_success(cmd);
 	json_add_psbt(response, "psbt", psbt);
 	json_add_num(response, "feerate_per_kw", feerate_per_kw);


### PR DESCRIPTION
fundpsbt / utxopsbt create a (typically) output-less PSBT,
however for elements we require the fees to be encapsulated in an
output.

this patch updates fundpsbt / utxopsbt to add a fee output for elements
transactions. includes test updates.

Fixes #3998

Changelog-Changed: `utxopsbt` and `fundpsbt` now include a fee output iif on an Elements chain