### PR TITLE
Makefile: fix typo which can cause build failures.

### DIFF
--- a/connectd/test/Makefile
+++ b/connectd/test/Makefile
@@ -10,7 +10,7 @@ CONNECTD_TEST_COMMON_OBJS :=			\
 	common/type_to_string.o			\
 	common/utils.o
 
-ALL_C_SOURCES += $(CONNECT_TEST_SRC)
+ALL_C_SOURCES += $(CONNECTD_TEST_SRC)
 ALL_TEST_PROGRAMS += $(CONNECTD_TEST_PROGRAMS)
 
 update-mocks: $(CONNECTD_TEST_SRC:%=update-mocks/%)

--- a/external/Makefile
+++ b/external/Makefile
@@ -19,6 +19,7 @@ LIBWALLY_HEADERS := external/libwally-core/include/wally_bip32.h		\
 			external/libwally-core/include/wally_psbt.h	\
 			external/libwally-core/include/wally_crypto.h
 LIBSECP_HEADERS := external/libwally-core/src/secp256k1/include/secp256k1_ecdh.h		\
+		external/libwally-core/src/secp256k1/include/secp256k1_recovery.h		\
 		external/libwally-core/src/secp256k1/include/secp256k1.h
 JSMN_HEADERS := external/jsmn/jsmn.h
 GHEAP_HEADERS := external/gheap/gheap.h


### PR DESCRIPTION
And add secp_recovery to headers, while we're at it.

```
./wire/wire.h:7:10: fatal error: secp256k1_recovery.h: No such file or directory
 #include <secp256k1_recovery.h>
          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Makefile:254: recipe for target 'connectd/test/run-initiator-success.o' failed
make: *** [connectd/test/run-initiator-success.o] Error 1
m
```

Changelog-None