### PR TITLE
4013 fixups

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -26,5 +26,6 @@ clean: tools-clean
 
 tools-clean:
 	$(RM) tools/headerversions
+	$(RM) tools/headerversions.o
 
 include tools/test/Makefile


### PR DESCRIPTION
The fixups from #4013 (a mem fix detected by ASAN and a build cleanup), so they are part of 0.9.1 even if it takes more time to make Travis happy with ASAN builds.