### PR TITLE
pyln: Add safe fallback results for hooks

### DIFF
--- a/tests/plugins/htlc_accepted-crash.py
+++ b/tests/plugins/htlc_accepted-crash.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(plugin, **kwargs):
+    plugin.log("Crashing on purpose...")
+    raise ValueError()
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1743,7 +1743,6 @@ def test_dev_builtin_plugins_unimportant(node_factory):
     n.rpc.plugin_stop(plugin="pay")
 
 
-@pytest.mark.xfail(strict=True)
 def test_htlc_accepted_hook_crash(node_factory, executor):
     """Test that we do not hang incoming HTLCs if the hook plugin crashes.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1741,3 +1741,33 @@ def test_important_plugin(node_factory):
 def test_dev_builtin_plugins_unimportant(node_factory):
     n = node_factory.get_node(options={"dev-builtin-plugins-unimportant": None})
     n.rpc.plugin_stop(plugin="pay")
+
+
+@pytest.mark.xfail(strict=True)
+def test_htlc_accepted_hook_crash(node_factory, executor):
+    """Test that we do not hang incoming HTLCs if the hook plugin crashes.
+
+    Reproduces #3748.
+    """
+    plugin = os.path.join(os.getcwd(), 'tests/plugins/htlc_accepted-crash.py')
+    l1 = node_factory.get_node()
+    l2 = node_factory.get_node(
+        options={'plugin': plugin},
+        allow_broken_log=True
+    )
+    l1.connect(l2)
+    l1.fund_channel(l2, 10**6)
+
+    i = l2.rpc.invoice(500, "crashpls", "crashpls")['bolt11']
+
+    # This should still succeed
+
+    f = executor.submit(l1.rpc.pay, i)
+
+    l2.daemon.wait_for_log(r'Crashing on purpose...')
+    l2.daemon.wait_for_log(
+        r'Hook handler for htlc_accepted failed with an exception.'
+    )
+
+    with pytest.raises(RpcError, match=r'failed: WIRE_TEMPORARY_NODE_FAILURE'):
+        f.result(10)


### PR DESCRIPTION
Hooks do not tolerate failures at all. If we return a JSON-RPC error to a hook
call the only thing the main daemon can really do is to crash. This commit
adds a mapping of error to a safe fallback result, including a warning to the
node operator that this should be addressed in the plugin. The warning is
reported as a `**BROKEN**` message, and should therefore fail any testing done
on the plugin.

The alternatives would have been

 - Allow plugins to return errors on hook calls, requiring a similar mapping inside `lightningd`. But I don't like relaxing the requirements on this. It feels magic enough as it is, but prevents us from accidentally hanging due to a plugin.
 - Killing the plugin outright, which is basically just going to use the default action, which in case of security related hooks is bad.

Fixes #3748
