### PR TITLE
Elements PSBT / test fixup

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -327,7 +327,13 @@ void psbt_elements_normalize_fees(struct wally_psbt *psbt)
 	for (size_t i = 0; i < psbt->num_outputs; i++) {
 		asset = wally_tx_output_get_amount(&psbt->tx->outputs[i]);
 		if (elements_wtx_output_is_fee(psbt->tx, i)) {
-			fee_output_idx = i;
+			if (fee_output_idx == psbt->num_outputs) {
+				fee_output_idx = i;
+				continue;
+			}
+			/* We already have at least one fee output,
+			 * remove this one */
+			psbt_rm_output(psbt, i--);
 			continue;
 		}
 		if (!amount_asset_is_main(&asset))

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -69,6 +69,14 @@ bool psbt_is_finalized(const struct wally_psbt *psbt);
 void psbt_txid(const struct wally_psbt *psbt, struct bitcoin_txid *txid,
 	       struct wally_tx **wtx);
 
+/* psbt_elements_normalize_fees - Figure out the fee output for a PSET
+ *
+ * Adds a fee output if not present, or updates it to include the diff
+ * between inputs - outputs. Unlike bitcoin, elements requires every
+ * satoshi to be accounted for in an output.
+ */
+void psbt_elements_normalize_fees(struct wally_psbt *psbt);
+
 struct wally_tx *psbt_finalize(struct wally_psbt *psbt, bool finalize_in_place);
 
 /* psbt_make_key - Create a new, proprietary c-lightning key

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -98,11 +98,16 @@ int bitcoin_tx_add_multi_outputs(struct bitcoin_tx *tx,
 	return tx->wtx->num_outputs;
 }
 
+bool elements_wtx_output_is_fee(const struct wally_tx *tx, int outnum)
+{
+	assert(outnum < tx->num_outputs);
+	return chainparams->is_elements &&
+		tx->outputs[outnum].script_len == 0;
+}
+
 bool elements_tx_output_is_fee(const struct bitcoin_tx *tx, int outnum)
 {
-	assert(outnum < tx->wtx->num_outputs);
-	return chainparams->is_elements &&
-	       tx->wtx->outputs[outnum].script_len == 0;
+	return elements_wtx_output_is_fee(tx->wtx, outnum);
 }
 
 struct amount_sat bitcoin_tx_compute_fee_w_inputs(const struct bitcoin_tx *tx,

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -213,6 +213,11 @@ void bitcoin_tx_finalize(struct bitcoin_tx *tx);
 /**
  * Returns true if the given outnum is a fee output
  */
+bool elements_wtx_output_is_fee(const struct wally_tx *tx, int outnum);
+
+/**
+ * Returns true if the given outnum is a fee output
+ */
 bool elements_tx_output_is_fee(const struct bitcoin_tx *tx, int outnum);
 
 /**

--- a/plugins/txprepare.c
+++ b/plugins/txprepare.c
@@ -191,6 +191,10 @@ static struct command_result *finish_txprepare(struct command *cmd,
 		psbt_add_output(txp->psbt, out, i);
 	}
 
+	/* If this is elements, we should normalize
+	 * the PSBT fee output */
+	psbt_elements_normalize_fees(txp->psbt);
+
 	utx = tal(NULL, struct unreleased_tx);
 	utx->psbt = tal_steal(utx, txp->psbt);
 	psbt_txid(txp->psbt, &utx->txid, &utx->tx);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1488,8 +1488,10 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
         l2_wallet_mvts = [
             {'type': 'chain_mvt', 'credit': 2000000000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'chain_mvt', 'credit': 0, 'debit': 0, 'tag': 'spend_track'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 991900000, 'tag': 'withdrawal'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 1000000000, 'tag': 'withdrawal'},
+            [
+                {'type': 'chain_mvt', 'credit': 0, 'debit': 991900000, 'tag': 'withdrawal'},
+                {'type': 'chain_mvt', 'credit': 0, 'debit': 1000000000, 'tag': 'withdrawal'},
+            ],
             {'type': 'chain_mvt', 'credit': 0, 'debit': 8100000, 'tag': 'chain_fees'},
             {'type': 'chain_mvt', 'credit': 991900000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'chain_mvt', 'credit': 100001000, 'debit': 0, 'tag': 'deposit'},

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -367,6 +367,8 @@ def test_txprepare(node_factory, bitcoind, chainparams):
     assert len(decode['vout']) == 3 if chainparams['feeoutput'] else 2
     # Change output pos is random.
     for vout in decode['vout']:
+        if vout['scriptPubKey']['type'] == 'fee':
+            continue
         if vout['scriptPubKey']['addresses'] == [addr]:
             changeout = vout
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -618,8 +618,6 @@ def test_utxopsbt(node_factory, bitcoind):
                     reservedok=True)
 
 
-@unittest.skipIf(TEST_NETWORK == 'liquid-regtest',
-                 "See ElementsProject/lightning#3998")
 def test_sign_and_send_psbt(node_factory, bitcoind, chainparams):
     """
     Tests for the sign + send psbt RPCs

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -280,6 +280,16 @@ static struct wally_psbt *psbt_using_utxos(const tal_t *ctx,
 				  NULL, redeemscript);
 
 		psbt_input_set_wit_utxo(psbt, i, scriptPubkey, utxos[i]->amount);
+		if (is_elements(chainparams)) {
+			struct amount_asset asset;
+			/* FIXME: persist asset tags */
+			asset = amount_sat_to_asset(&utxos[i]->amount,
+						    chainparams->fee_asset_tag);
+			/* FIXME: persist nonces */
+			psbt_elements_input_set_asset(psbt,
+						      psbt->num_inputs - 1,
+						      &asset);
+		}
 	}
 
 	return psbt;


### PR DESCRIPTION
We should be using the `elements` tx_output, which includes the value + asset info required by the PSBT's sighash signing algorithm. 

This fixes that, plus adds back in some 'nice to have' extra PSET info (value + assset fields) for PSBTs constructed by `utxopsbt` / `fundpsbt`.

Finally, we allow the `test_sign_and_send` test to run on travis!

Edit: there were some other elements failures, those should be fixed now.