### PR TITLE
pay: fix handling of legacy vs tlv encoding.

### DIFF
--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -52,17 +52,8 @@ static struct keysend_data *keysend_init(struct payment *p)
 }
 
 static void keysend_cb(struct keysend_data *d, struct payment *p) {
-	struct route_hop *last_hop;
 	struct createonion_hop *last_payload;
 	size_t hopcount;
-
-	if (p->step == PAYMENT_STEP_GOT_ROUTE) {
-		/* Force the last step to be a TLV, we might not have an
-		 * announcement and it still supports it. Required later when
-		 * we adjust the payload. */
-		last_hop = &p->route[tal_count(p->route) - 1];
-		last_hop->style = ROUTE_HOP_TLV;
-	}
 
 	if (p->step != PAYMENT_STEP_ONION_PAYLOAD)
 		return payment_continue(p);
@@ -143,6 +134,7 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 	p->json_buffer = tal_steal(p, buf);
 	p->json_toks = params;
 	p->destination = tal_steal(p, destination);
+	p->destination_has_tlv = true;
 	p->payment_secret = NULL;
 	p->amount = *msat;
 	p->invoice = NULL;

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -169,6 +169,8 @@ struct payment {
 
 	/* Real destination we want to route to */
 	struct node_id *destination;
+	/* Do we know for sure that this supports OPT_VAR_ONION? */
+	bool destination_has_tlv;
 
 	/* Payment hash extracted from the invoice if any. */
 	struct sha256 *payment_hash;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -2021,6 +2021,7 @@ static struct command_result *json_paymod(struct command *cmd,
 	p->json_buffer = tal_steal(p, buf);
 	p->json_toks = params;
 	p->destination = &b11->receiver_id;
+	p->destination_has_tlv = feature_offered(b11->features, OPT_VAR_ONION);
 	p->payment_hash = tal_dup(p, struct sha256, &b11->payment_hash);
 	p->payment_secret = b11->payment_secret
 				? tal_dup(p, struct secret, b11->payment_secret)


### PR DESCRIPTION
As revealed by the failure of tests in #3936, where we ended up trying
to send a partial payment using legacy style, we are not handling
style properly.

1. BOLT9 has features, so we can *know* that the destination supports
   MPP.  We may not have seen a node_announcement.
2. We can't assume that nodes inside routehints support TLV.
3. We can't assume direct peers support TLV.

The keysend code tried to fix this up, so I'm not sure that this caused
the issue in #3968, though.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>