### PR TITLE
pyln: Bump proto version to match pyln-bolt*

### DIFF
--- a/contrib/pyln-proto/pyln/proto/__init__.py
+++ b/contrib/pyln-proto/pyln/proto/__init__.py
@@ -3,7 +3,7 @@ from .invoice import Invoice
 from .onion import OnionPayload, TlvPayload, LegacyOnionPayload
 from .wire import LightningConnection, LightningServerSocket
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 __all__ = [
     "Invoice",

--- a/contrib/pyln-proto/setup.py
+++ b/contrib/pyln-proto/setup.py
@@ -9,7 +9,7 @@ with io.open('requirements.txt', encoding='utf-8') as f:
     requirements = [r for r in f.read().split('\n') if len(r)]
 
 setup(name='pyln-proto',
-      version='0.8.3',
+      version='0.8.4',
       description='Pure python implementation of the Lightning Network protocol',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Since pyln-bolt* specify the 0.8.4 version which we didn't upload, and the
requirements.txt specify `==0.8.4`, we need to backfill that version, even if we
could just bump it directly to 0.9.1.

Changelog-None