### PR TITLE
plugins/pay: handle case where amount_msat is 'null'.

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1719,7 +1719,8 @@ static void add_amount_sent(struct plugin *p,
 
 	/* If this is an unannotated partial payment we drop out estimate for
 	 * all parts. */
-	if (msattok == NULL) {
+	/* FIXME: with deprecated_apis, amount_msat can be 'null' */
+	if (msattok == NULL || !json_to_msat(buf, msattok, &recv)) {
 		mpp->amount = tal_free(mpp->amount);
 		return;
 	}
@@ -1730,7 +1731,6 @@ static void add_amount_sent(struct plugin *p,
 	if (mpp->amount == NULL)
 		return;
 
-	json_to_msat(buf, msattok, &recv);
 	if (!amount_msat_add(mpp->amount, *mpp->amount, recv))
 		plugin_log(p, LOG_BROKEN,
 			   "Cannot add amount_msat for %s: %s + %s",


### PR DESCRIPTION
Deprecated, but this can happen:

```
==1578== Conditional jump or move depends on uninitialised value(s)
==1578== at 0x12B30E: amount_msat_add (amount.c:224)
==1578== by 0x11270B: add_amount_sent (pay.c:1734)
==1578== by 0x112D89: listsendpays_done (pay.c:1831)
==1578== by 0x114F4B: handle_rpc_reply (libplugin.c:555)
==1578== by 0x115704: rpc_read_response_one (libplugin.c:685)
==1578== by 0x115821: rpc_conn_read_response (libplugin.c:705)
==1578== by 0x148E40: next_plan (io.c:59)
==1578== by 0x1499BD: do_plan (io.c:407)
==1578== by 0x1499FB: io_ready (io.c:417)
==1578== by 0x14BBC1: io_loop (poll.c:445)
==1578== by 0x117A82: plugin_main (libplugin.c:1322)
==1578== by 0x113ABC: main (pay.c:2096)
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None