### PR TITLE
pyln: Sets remote_pubkey for LightningConnection if node is not the initiator

### DIFF
--- a/contrib/pyln-proto/pyln/proto/wire.py
+++ b/contrib/pyln-proto/pyln/proto/wire.py
@@ -267,8 +267,9 @@ class LightningConnection(object):
             raise ValueError("Unsupported handshake version {}, only version "
                              "0 is supported.".format(v))
         rs = decryptWithAD(self.temp_k2, self.nonce(1), h.digest(), c)
+        self.remote_pubkey = PublicKey(rs)
         h.update(c)
-        se = ecdh(self.handshake['e'], PublicKey(rs))
+        se = ecdh(self.handshake['e'], self.remote_pubkey)
 
         self.chaining_key, self.temp_k3 = hkdf_two_keys(
             se.raw, self.chaining_key


### PR DESCRIPTION
In the current version of `LightningConnection`,  `remote_pubkey` is set to `None` at the begining of the handshake if the node is not initiator. However, it is never set to the counterparty pubkey after the handshake is completed. 

This sets `remote_pubkey` to ``rs`` in act three from the receiver side so the pubkey of the initiator is known by the receiver after the handshake. 
