### PR TITLE
lightningd: don't declare local vars stdin and stdout.

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -303,7 +303,9 @@ WARN_UNUSED_RESULT bool amount_msat_scale(struct amount_msat *val,
 {
 	double scaled = sat.millisatoshis * scale;
 
-	if (scaled > UINT64_MAX)
+	/* If mantissa is < 64 bits, a naive "if (scaled >
+	 * UINT64_MAX)" doesn't work.  Stick to powers of 2. */
+	if (scaled >= (double)((u64)1 << 63) * 2)
 		return false;
 	val->millisatoshis = scaled;
 	return true;


### PR DESCRIPTION
OpenBSD uses macros for these, and gets upset.

Fixes: #4044
Changelog-None