### PR TITLE
feat: log to stdout if not --daemon

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -250,7 +250,7 @@ struct log_book *new_log_book(struct lightningd *ld, size_t max_mem)
 	lr->num_entries = 0;
 	lr->max_mem = max_mem;
 	lr->outf = stdout;
-	lr->echo = true; /* todo: only if not ld --daemon */
+	lr->echo = false;
 	lr->default_print_level = NULL;
 	list_head_init(&lr->print_filters);
 	lr->init_time = time_now();
@@ -719,8 +719,10 @@ void opt_register_logging(struct lightningd *ld)
 			       "also log to file instead of just stdout");
 }
 
-void logging_options_parsed(struct log_book *lr)
+void logging_options_parsed(struct log_book *lr, struct lightningd *ld)
 {
+	lr->echo = ld->daemon_parent_fd == -1;
+
 	/* If they didn't set an explicit level, set to info */
 	if (!lr->default_print_level) {
 		lr->default_print_level = tal(lr, enum log_level);

--- a/lightningd/log.h
+++ b/lightningd/log.h
@@ -88,5 +88,5 @@ struct log_entry {
 /* For options.c's listconfig */
 char *opt_log_level(const char *arg, struct log *log);
 void json_add_opt_log_levels(struct json_stream *response, struct log *log);
-void logging_options_parsed(struct log_book *lr);
+void logging_options_parsed(struct log_book *lr, struct lightningd *ld);
 #endif /* LIGHTNING_LIGHTNINGD_LOG_H */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1130,7 +1130,7 @@ void handle_early_opts(struct lightningd *ld, int argc, char *argv[])
 	opt_early_parse_incomplete(argc, argv, opt_log_stderr_exit);
 
 	/* Finalize the logging subsystem now. */
-	logging_options_parsed(ld->log_book);
+	logging_options_parsed(ld->log_book, ld);
 }
 
 void handle_opts(struct lightningd *ld, int argc, char *argv[])


### PR DESCRIPTION
### Summary
If `--daemon` is not set, we should also log to stdout, regardless of the `log_file` config settings.

### Rationales:
 - This matches (at least my) expectation, I found it strange that the `stdout` output without `--daemon` was suppressed because of certain values of in the default user config file laying around.
 - Better for `systemd` scripts and such, that usually catch `stdout` per default.
 - Better for debugging environments inside IDE's and such.