### PR TITLE
`hsm_secret` generation from a seed-phrase

### DIFF
--- a/doc/lightning-hsmtool.8
+++ b/doc/lightning-hsmtool.8
@@ -51,6 +51,10 @@ and is usually no greater than the number of channels that the node has
 ever had\.
 Specify \fIpassword\fR if the \fBhsm_secret\fR is encrypted\.
 
+
+\fBgeneratehsm\fR \fIhsm_secret_path\fR
+Generates a new hsm_secret using BIP39\.
+
 .SH BUGS
 
 You should report bugs on our github issues page, and maybe submit a fix
@@ -76,4 +80,4 @@ Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:11b3e6c050eb31e7faac10e8b75c3f7b7d57269f7f8c47c67f6d115b7a479c09
+\" SHA256STAMP:918981692d3840344e15c539b007b473d5ea0ad481145eccff092bf61ec6ddb0

--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -48,6 +48,9 @@ and is usually no greater than the number of channels that the node has
 ever had.
 Specify *password* if the `hsm_secret` is encrypted.
 
+**generatehsm** *hsm\_secret\_path*
+Generates a new hsm_secret using BIP39.
+
 BUGS
 ----
 


### PR DESCRIPTION
Add `generatehsm` method to hsmtool to derivate BIP32 seeds from a
mnemonic using the BIP39 standard.

The new method uses libwally for the BIP39 to BIP32 derivation. It also
fails if an hsm_secret file already exists, so we do not overwrite
someone else's wallet without noticing.

It allows the use of passphrases, the ECHO mode in the terminal is
disable for higher security.