### PR TITLE
fix: duplicated channel_state_changed events

### DIFF
--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -564,7 +564,8 @@ enum watch_result onchaind_funding_spent(struct channel *channel,
 	channel_fail_permanent(channel, "Funding transaction spent");
 
 	/* We could come from almost any state. */
-	channel_set_state(channel, channel->state, FUNDING_SPEND_SEEN);
+	if (channel->state != FUNDING_SPEND_SEEN)
+		channel_set_state(channel, channel->state, FUNDING_SPEND_SEEN);
 
 	hsmfd = hsm_get_client_fd(ld, &channel->peer->id,
 				  channel->dbid,


### PR DESCRIPTION
This fixes occurrences where current code paths were setting the same channel state twice.
This happened on:
 - `tests/test_plugin.py::test_channel_state_changed_unilateral`  => `AWAITING_UNILATERAL`
 - `tests/test_connection.py::test_fail_unconfirmed`  => `FUNDING_SPEND_SEEN`

It also adds a \*\*BROKEN\*\* log if this happens for any other reason in the future.
I also checked that the (now skipped) `wallet_channel_save` did produce exactly the same statements twice for these two occurrences. Maybe we should implement a solution to `/* TODO(cdecker) Selectively save updated fields to DB */` (channel.c line 402) or something like a `channel_is_dirty` function.

**Update**: 
While I was thinking about this I'm now a bit unsure if this is the right approach, specifically since `channel_set_state` also saves channel and config to DB. Suppressing duplicated state updates (and thus the DB update) may be problematic on regorgs while the node was offline and i.e. spending or closing TX has changed blockheight while `lightningd` was waiting for enough confirmations...

I think a better way would be if we detect and allow (and not log BROKEN) duplicated updates if DB state differed in any way.
What do you think?


Addresses #4029