### PR TITLE
db: Add support for key-value pair DSNs in postgresql

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -281,3 +281,20 @@ def test_optimistic_locking(node_factory, bitcoind):
         l1.rpc.newaddr()
 
     assert(l1.daemon.is_in_log(r'Optimistic lock on the database failed'))
+
+
+@unittest.skipIf(os.environ.get('TEST_DB_PROVIDER', None) != 'postgres', "Only applicable to postgres")
+def test_psql_key_value_dsn(node_factory, db_provider, monkeypatch):
+    from pyln.testing.db import PostgresDb
+
+    # Override get_dsn method to use the key-value style DSN
+    def get_dsn(self):
+        print("hello")
+        return "postgres://host=127.0.0.1 port={port} user=postgres password=password dbname={dbname}".format(
+            port=self.port, dbname=self.dbname
+        )
+
+    monkeypatch.setattr(PostgresDb, "get_dsn", get_dsn)
+    l1 = node_factory.get_node()
+    opt = [o for o in l1.daemon.cmd_line if '--wallet' in o][0]
+    assert('host=127.0.0.1' in opt)


### PR DESCRIPTION
It turns out that it isn't always possible to express the connection
parameters in a URI-style DSN. The postgresql primitives provide an
alternative in the form of key-value DSNs [1], which allow for a far wider
range of possible configuration parameters. Specifically in my case I wanted
to have mutual authentication using TLS/SSL server and client certificates, on
top of password authentication.

With this change we still use the `scheme://` portion of the DSN to select
which backend to use, while we attempt to parse the connection string without
it first (which is the key-value option) and if that fails we fall back to the
full URI connection. Since we only attempt to parse, and don't directly
connect we don't actually connect twice.

So this is now a possibility:

``` text
postgres://sslmode=verify-ca \
	sslrootcert=server-ca.pem \
	sslcert=client-cert.pem \
	sslkey=client-key.pem \
	host=12.345.678.9 \
	port=5432 \
	user=postgres \
	dbname=cln \
	password=helloworld"
```

[1]: https://www.postgresql.org/docs/9.1/libpq-connect.html