### PR TITLE
fix: openchannel_hook log BROKEN on duplicated close_to

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -683,9 +683,9 @@ openchannel_hook_deserialize(struct openchannel_hook_payload *payload,
 	if (t_closeto) {
 		/* First plugin can set close_to. Log others. */
 		if (payload->our_upfront_shutdown_script != NULL) {
-			log_unusual(openingd->ld->log,
-				    "openchannel_hook close_to address was"
-				    " already set by other plugin. Ignoring!");
+			log_broken(openingd->ld->log,
+				   "openchannel_hook close_to address was"
+				   " already set by other plugin. Ignoring!");
 			return true;
 		}
 		switch (json_to_address_scriptpubkey(tmpctx, chainparams,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -587,7 +587,7 @@ def test_openchannel_hook_error_handling(node_factory, bitcoind):
     # next fundchannel should fail fatal() for l2
     with pytest.raises(RpcError, match=r'Owning subdaemon openingd died'):
         l1.rpc.fundchannel(l2.info['id'], 100004)
-    assert l2.daemon.is_in_log("Plugin rejected openchannel but also set close_to")
+    assert l2.daemon.is_in_log("BROKEN.*Plugin rejected openchannel but also set close_to")
 
 
 def test_openchannel_hook_chaining(node_factory, bitcoind):


### PR DESCRIPTION
... As discussed in yesterdays meeting, log BROKEN here is better, as a reliant plugin may behave incorrectly if that happens.