### PR TITLE
dual-openingd: msg_type should be dualopend_wire not u8

### DIFF
--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -853,7 +853,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 	struct penalty_base *pbase;
 	struct amount_msat our_msats;
 	struct amount_sat total;
-	u8 msg_type;
+	enum dualopend_wire msg_type;
 
 	state->our_role = ACCEPTER;
 	open_tlv = tlv_opening_tlvs_new(tmpctx);


### PR DESCRIPTION
```
openingd/dualopend.c:958:42: error: result of comparison of constant 'WIRE_DUAL_OPEN_FAIL' (7003) with expression of type 'u8' (aka 'unsigned char') is always false
      [-Werror,-Wtautological-constant-out-of-range-compare]
        if ((msg_type = fromwire_peektype(msg)) == WIRE_DUAL_OPEN_FAIL) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~
```
Found while rebasing #4013