### PR TITLE
Libwally: neaten tal capture.

### DIFF
--- a/bitcoin/base58.c
+++ b/bitcoin/base58.c
@@ -24,13 +24,12 @@ static char *to_base58(const tal_t *ctx, u8 version,
 	buf[0] = version;
 	memcpy(buf + 1, rmd, sizeof(*rmd));
 
-	if (wally_base58_from_bytes((const unsigned char *) buf, total_length, BASE58_FLAG_CHECKSUM, &out) != WALLY_OK) {
-		return NULL;
-	}else{
-		char *res = tal_strdup(ctx, out);
-		wally_free_string(out);
-		return res;
-	}
+	if (wally_base58_from_bytes((const unsigned char *) buf,
+				    total_length, BASE58_FLAG_CHECKSUM, &out)
+	    != WALLY_OK)
+		out = NULL;
+
+	return tal_steal(ctx, out);
 }
 
 char *bitcoin_to_base58(const tal_t *ctx, const struct chainparams *chainparams,

--- a/bitcoin/base58.c
+++ b/bitcoin/base58.c
@@ -24,12 +24,14 @@ static char *to_base58(const tal_t *ctx, u8 version,
 	buf[0] = version;
 	memcpy(buf + 1, rmd, sizeof(*rmd));
 
+	tal_wally_start();
 	if (wally_base58_from_bytes((const unsigned char *) buf,
 				    total_length, BASE58_FLAG_CHECKSUM, &out)
 	    != WALLY_OK)
 		out = NULL;
+	tal_wally_end(tal_steal(ctx, out));
 
-	return tal_steal(ctx, out);
+	return out;
 }
 
 char *bitcoin_to_base58(const tal_t *ctx, const struct chainparams *chainparams,

--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -645,15 +645,13 @@ struct wally_psbt *psbt_from_b64(const tal_t *ctx,
 
 char *psbt_to_b64(const tal_t *ctx, const struct wally_psbt *psbt)
 {
-	char *serialized_psbt, *ret_val;
+	char *serialized_psbt;
 	int ret;
 
 	ret = wally_psbt_to_base64(psbt, 0, &serialized_psbt);
 	assert(ret == WALLY_OK);
 
-	ret_val = tal_strdup(ctx, serialized_psbt);
-	wally_free_string(serialized_psbt);
-	return ret_val;
+	return tal_steal(ctx, serialized_psbt);
 }
 REGISTER_TYPE_TO_STRING(wally_psbt, psbt_to_b64);
 

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -79,8 +79,22 @@ void psbt_txid(const tal_t *ctx,
  */
 void psbt_elements_normalize_fees(struct wally_psbt *psbt);
 
-struct wally_tx *psbt_finalize(const tal_t *ctx,
-			       struct wally_psbt *psbt, bool finalize_in_place);
+/**
+ * psbt_finalize - finalize this psbt.
+ *
+ * Returns false if we can't, otherwise returns true and psbt_is_finalized()
+ * is true.
+ */
+bool psbt_finalize(struct wally_psbt *psbt);
+
+/**
+ * psbt_final_tx - extract transaction from finalized psbt.
+ * @ctx: context to tallocate return
+ * @psbt: psbt to extract.
+ *
+ * If @psbt isn't final, or we can't extract tx, returns NULL.
+ */
+struct wally_tx *psbt_final_tx(const tal_t *ctx, const struct wally_psbt *psbt);
 
 /* psbt_make_key - Create a new, proprietary c-lightning key
  *

--- a/common/daemon.c
+++ b/common/daemon.c
@@ -81,19 +81,13 @@ void send_backtrace(const char *why)
 int daemon_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
 	const char *t;
-	char *wally_leak;
 
 	t = taken_any();
 	if (t)
 		errx(1, "Outstanding taken pointers: %s", t);
 
-	wally_leak = tal_first(wally_tal_ctx);
-	if (wally_leak) {
-		/* Trigger valgrind to tell us about this! */
-		tal_free(wally_leak);
-		*wally_leak = 0;
-		errx(1, "Outstanding wally allocations");
-	}
+	if (wally_tal_ctx)
+		errx(1, "Outstanding tal_wally_start!");
 
 	clean_tmpctx();
 

--- a/common/psbt_open.c
+++ b/common/psbt_open.c
@@ -66,8 +66,11 @@ static const u8 *linearize_input(const tal_t *ctx,
 	struct wally_psbt *psbt = create_psbt(NULL, 1, 0, 0);
 	size_t byte_len;
 
+	tal_wally_start();
 	if (wally_tx_add_input(psbt->tx, tx_in) != WALLY_OK)
 		abort();
+	tal_wally_end(psbt->tx);
+
 	psbt->inputs[0] = *in;
 	psbt->num_inputs++;
 
@@ -104,8 +107,10 @@ static const u8 *linearize_output(const tal_t *ctx,
 	memset(&txid, 0, sizeof(txid));
 	psbt_append_input(psbt, &txid, 0, 0, NULL, NULL, NULL);
 
+	tal_wally_start();
 	if (wally_tx_add_output(psbt->tx, tx_out) != WALLY_OK)
 		abort();
+	tal_wally_end(psbt->tx);
 
 	psbt->outputs[0] = *out;
 	psbt->num_outputs++;

--- a/common/setup.c
+++ b/common/setup.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <ccan/ccan/err/err.h>
 #include <common/memleak.h>
 #include <common/setup.h>
@@ -7,6 +8,7 @@
 
 static void *wally_tal(size_t size)
 {
+	assert(wally_tal_ctx);
 	return tal_arr_label(wally_tal_ctx, u8, size, "wally_tal");
 }
 
@@ -33,7 +35,6 @@ void common_setup(const char *argv0)
 		     " available ?");
 
 	/* We set up Wally, the bitcoin wallet lib */
-	wally_tal_ctx = tal_label(NULL, char, "wally_ctx_notleak");
 	wally_init(0);
 	wally_set_operations(&wally_tal_ops);
 	secp256k1_ctx = wally_get_secp_context();

--- a/common/test/exp-run-psbt_diff.c
+++ b/common/test/exp-run-psbt_diff.c
@@ -136,8 +136,10 @@ int main(int argc, const char *argv[])
 
 	/* Create two psbts! */
 	end = create_psbt(tmpctx, 1, 1, 0);
+	tal_wally_start();
 	if (wally_psbt_clone_alloc(end, flags, &start) != WALLY_OK)
 		abort();
+	tal_wally_end(tmpctx);
 	diff_count(start, end, 0, 0);
 	diff_count(end, start, 0, 0);
 
@@ -147,22 +149,28 @@ int main(int argc, const char *argv[])
 	diff_count(end, start, 0, 1);
 
 	/* Add another one, before previous */
+	tal_wally_start();
 	if (wally_psbt_clone_alloc(end, flags, &start) != WALLY_OK)
 		abort();
+	tal_wally_end(tmpctx);
 	add_in_out_with_serial(end, 5, 2);
 	diff_count(start, end, 1, 0);
 	diff_count(end, start, 0, 1);
 
 	/* Add another, at end */
+	tal_wally_start();
 	if (wally_psbt_clone_alloc(end, flags, &start) != WALLY_OK)
 		abort();
+	tal_wally_end(tmpctx);
 	add_in_out_with_serial(end, 15, 3);
 	diff_count(start, end, 1, 0);
 	diff_count(end, start, 0, 1);
 
 	/* Add another, in middle */
+	tal_wally_start();
 	if (wally_psbt_clone_alloc(end, flags, &start) != WALLY_OK)
 		abort();
+	tal_wally_end(tmpctx);
 	add_in_out_with_serial(end, 11, 4);
 	diff_count(start, end, 1, 0);
 	diff_count(end, start, 0, 1);
@@ -171,8 +179,10 @@ int main(int argc, const char *argv[])
 	 * (we accomplish this by removing and then
 	 * readding an input/output with the same serial_id
 	 * but different value) */
+	tal_wally_start();
 	if (wally_psbt_clone_alloc(end, flags, &start) != WALLY_OK)
 		abort();
+	tal_wally_end(tmpctx);
 	psbt_rm_output(end, 0);
 	psbt_rm_input(end, 0);
 	add_in_out_with_serial(end, 5, 5);

--- a/common/utils.h
+++ b/common/utils.h
@@ -84,8 +84,11 @@ void setup_tmpctx(void);
 /* Free any children of tmpctx. */
 void clean_tmpctx(void);
 
-/* Steal any wally allocations onto this context. */
-void tal_gather_wally(const tal_t *ctx);
+/* Call this before any libwally function which allocates. */
+void tal_wally_start(void);
+/* Then call this to reparent everything onto this parent (which must
+ * have been tal_steal() if it was allocated by libwally here) */
+void tal_wally_end(const tal_t *parent);
 
 /* Define sha256_eq. */
 STRUCTEQ_DEF(sha256, 0, u);

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -1582,6 +1582,7 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 							scriptpubkey_p2wsh(psbt, wscript),
 							utxo->amount);
 			}
+			tal_wally_start();
 			if (wally_psbt_sign(psbt, privkey.secret.data,
 					    sizeof(privkey.secret.data),
 					    EC_FLAG_GRIND_R) != WALLY_OK)
@@ -1591,10 +1592,9 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 							     &pubkey),
 					      type_to_string(tmpctx, struct wally_psbt,
 							     psbt));
-
+			tal_wally_end(psbt);
 		}
 	}
-	tal_gather_wally(psbt);
 }
 
 /*~ lightningd asks us to sign a withdrawal; same as above but in theory

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -614,7 +614,7 @@ openchannel2_sign_hook_cb(struct openchannel2_psbt_payload *payload STEALS)
 	tal_steal(tmpctx, payload);
 
 	/* Finalize it, if not already. It shouldn't work entirely */
-	psbt_finalize(tmpctx, payload->psbt, true);
+	psbt_finalize(payload->psbt);
 
 	if (!psbt_side_finalized(payload->ld->log, payload->psbt, REMOTE))
 		fatal("Plugin must return a 'psbt' with signatures for their inputs"

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -151,10 +151,12 @@ static struct command_result *json_unreserveinputs(struct command *cmd,
 		wally_tx_input_get_txid(&psbt->tx->inputs[i], &txid);
 		utxo_tx = wallet_transaction_get(psbt, cmd->ld->wallet,
 						 &txid);
-		if (utxo_tx)
+		if (utxo_tx) {
+			tal_wally_start();
 			wally_psbt_input_set_utxo(&psbt->inputs[i],
 						  utxo_tx->wtx);
-		else
+			tal_wally_end(psbt);
+		} else
 			log_broken(cmd->ld->log,
 				   "No transaction found for UTXO %s",
 				   type_to_string(tmpctx, struct bitcoin_txid,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -812,7 +812,9 @@ static struct command_result *json_sendpsbt(struct command *cmd,
 
 	sending = tal(cmd, struct sending_psbt);
 	sending->cmd = cmd;
-	sending->wtx = psbt_finalize(sending, psbt, true);
+
+	psbt_finalize(psbt);
+	sending->wtx = psbt_final_tx(sending, psbt);
 	if (!sending->wtx)
 		return command_fail(cmd, LIGHTNINGD,
 				    "PSBT not finalizeable %s",


### PR DESCRIPTION
This captures *all* libwally allocations, and also maintains logical structure around psbt and tx allocations (i.e. tx owns it parts, psbt owns its parts).

Changelog-None