### PR TITLE
pytest: Add test for failcode conversion

### DIFF
--- a/tests/plugins/htlc_accepted-failcode.py
+++ b/tests/plugins/htlc_accepted-failcode.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""A simply plugin that fails HTLCs with a configurable failcode.
+
+"""
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(htlc, onion, plugin, **kwargs):
+    res = {"result": "fail"}
+
+    if plugin.failmsg is not None:
+        res['failure_message'] = plugin.failmsg
+
+    if plugin.failcode is not None:
+        res['failure_code'] = plugin.failcode
+
+    return res
+
+
+@plugin.method('setfailcode')
+def setfailcode(plugin, code=None, msg=None):
+    """Sets the failcode to return when receiving an incoming HTLC.
+    """
+    plugin.failcode = code
+    plugin.failmsg = msg
+
+
+@plugin.init()
+def on_init(**kwargs):
+    plugin.failcode = None
+    plugin.failmsg = None
+
+
+plugin.run()


### PR DESCRIPTION
We added a conversion of failcodes that do not have sufficient information in
faac4b28ad. That means that a failcode that'd require additional information
in order to be a correct error to return in an onion is mapped to a generic
one since we can't backfill the information.

This tests that the mapping is performed correctly and replicates the
situation in #4070

Closes #4070
Changelog-None