### PR TITLE
chore: reduce log buffer from 100MB to 10MB

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -180,7 +180,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 * book to hold all the entries (and trims as necessary), and multiple
 	 * log objects which each can write into it, each with a unique
 	 * prefix. */
-	ld->log_book = new_log_book(ld, 100*1024*1024);
+	ld->log_book = new_log_book(ld, 10*1024*1024);
 	/*~ Note the tal context arg (by convention, the first argument to any
 	 * allocation function): ld->log will be implicitly freed when ld
 	 * is. */


### PR DESCRIPTION
The 100MB log buffer has been the biggest memory footprint for the daemon.
Keeping 10MB for emergency log dumps seems sufficient.
This has been mentioned in the last developer meeting.

**Update:** As @rustyrussell points out the log buffer always contains everything regardless of the config (io, esp and debug, ...). An average log entry has about 170Bytes, lets say 200Bytes with certain overhead. A well connected node may produce something like up to ~2 events per second depending on usage. Thus a 10MB buffer will last for ~8Hrs.

Changelog-Changed: In-memory log buffer reduced from 100MB to 10MB