### PR TITLE
pyln: Add a fixture for createwallet

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -349,6 +349,7 @@ class BitcoinD(TailableProc):
             '-logtimestamps',
             '-nolisten',
             '-txindex',
+            '-wallet="test"',
             '-addresstype=bech32'
         ]
         # For up to and including 0.16.1, this needs to be in main section.


### PR DESCRIPTION
When testing against current master (`209900`), I got errors about a non-existing wallet.

```
$ pytest tests
...
E           bitcoin.rpc.JSONRPCError: {'code': -32601, 'message': 'Method not found (wallet method is disabled because no wallet is loaded)'}
```

Changelog-None