### PR TITLE
pytest: Rename all fund_channel to fundchannel

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -133,7 +133,7 @@ def test_closing_id(node_factory):
 
     # Close by full channel ID.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
     cid = l2.rpc.listpeers()['peers'][0]['channels'][0]['channel_id']
     l2.rpc.close(cid)
     wait_for(lambda: not only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'])
@@ -142,7 +142,7 @@ def test_closing_id(node_factory):
     # Close by peer ID.
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l1.daemon.wait_for_log("Handed peer, entering loop")
-    l2.fund_channel(l1, 10**6)
+    l2.fundchannel(l1, 10**6)
     pid = l1.info['id']
     l2.rpc.close(pid)
     wait_for(lambda: not only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'])
@@ -306,9 +306,9 @@ def test_closing_specified_destination(node_factory, bitcoind, chainparams):
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    chan12 = l1.fund_channel(l2, 10**6)
-    chan13 = l1.fund_channel(l3, 10**6)
-    chan14 = l1.fund_channel(l4, 10**6)
+    chan12 = l1.fundchannel(l2, 10**6)
+    chan13 = l1.fundchannel(l3, 10**6)
+    chan14 = l1.fundchannel(l4, 10**6)
 
     l1.pay(l2, 100000000)
     l1.pay(l3, 100000000)
@@ -1011,7 +1011,7 @@ def test_penalty_rbf_normal(node_factory, bitcoind, executor, chainparams):
                                options={'watchtime-blocks': to_self_delay})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**7)
+    l1.fundchannel(l2, 10**7)
 
     # Trigger an HTLC being added.
     t = executor.submit(l1.pay, l2, 1000000 * 1000)
@@ -1117,7 +1117,7 @@ def test_penalty_rbf_burn(node_factory, bitcoind, executor, chainparams):
                                options={'watchtime-blocks': to_self_delay})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**7)
+    l1.fundchannel(l2, 10**7)
 
     # Trigger an HTLC being added.
     t = executor.submit(l1.pay, l2, 1000000 * 1000)
@@ -1524,8 +1524,8 @@ def test_onchain_middleman(node_factory, bitcoind):
     # l2 connects to both, so l1 can't reconnect and thus l2 drops to chain
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.fund_channel(l1, 10**6)
-    c23 = l2.fund_channel(l3, 10**6)
+    l2.fundchannel(l1, 10**6)
+    c23 = l2.fundchannel(l3, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     # Make sure routes finalized.
@@ -1614,8 +1614,8 @@ def test_onchain_middleman_their_unilateral_in(node_factory, bitcoind):
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
-    l2.fund_channel(l1, 10**6)
-    c23 = l2.fund_channel(l3, 10**6)
+    l2.fundchannel(l1, 10**6)
+    c23 = l2.fundchannel(l3, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     # Make sure routes finalized.
@@ -1862,7 +1862,7 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(disconnect=disconnects, options={'plugin': coin_mvt_plugin})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     rhash = l2.rpc.invoice(10**8, 'onchain_timeout', 'desc')['payment_hash']
@@ -1985,7 +1985,7 @@ def test_permfail_new_commit(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     # This will fail at l2's end.
     t = executor.submit(l1.pay, l2, 200000000)
@@ -2287,7 +2287,7 @@ def test_permfail_htlc_in(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(disconnect=disconnects)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     # This will fail at l2's end.
     t = executor.submit(l1.pay, l2, 200000000)
@@ -2334,7 +2334,7 @@ def test_permfail_htlc_out(node_factory, bitcoind, executor):
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.daemon.wait_for_log('openingd-chan#1: Handed peer, entering loop'.format(l1.info['id']))
-    l2.fund_channel(l1, 10**6)
+    l2.fundchannel(l1, 10**6)
 
     # This will fail at l2's end.
     t = executor.submit(l2.pay, l1, 200000000)
@@ -2495,7 +2495,7 @@ def test_option_upfront_shutdown_script(node_factory, bitcoind, executor):
 
     l2 = node_factory.get_node()
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 1000000, False)
+    l1.fundchannel(l2, 1000000, False)
 
     # This will block, as l12 will send an error but l2 will retry.
     fut = executor.submit(l1.rpc.close, l2.info['id'])
@@ -2512,7 +2512,7 @@ def test_option_upfront_shutdown_script(node_factory, bitcoind, executor):
 
     # Works when l2 closes channel, too.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 1000000, False)
+    l1.fundchannel(l2, 1000000, False)
 
     l2.rpc.close(l1.info['id'])
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -79,7 +79,7 @@ def test_reconnect_channel_peers(node_factory, executor):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
     l2.restart()
 
     # Should reconnect.
@@ -181,23 +181,23 @@ def test_opening_tiny_channel(node_factory):
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
     with pytest.raises(RpcError, match=r'They sent error.*channel capacity is .*, which is below .*msat'):
-        l1.fund_channel(l2, l2_min_capacity + overhead - 1)
-    l1.fund_channel(l2, l2_min_capacity + overhead)
+        l1.fundchannel(l2, l2_min_capacity + overhead - 1)
+    l1.fundchannel(l2, l2_min_capacity + overhead)
 
     with pytest.raises(RpcError, match=r'They sent error.*channel capacity is .*, which is below .*msat'):
-        l1.fund_channel(l3, l3_min_capacity + overhead - 1)
-    l1.fund_channel(l3, l3_min_capacity + overhead)
+        l1.fundchannel(l3, l3_min_capacity + overhead - 1)
+    l1.fundchannel(l3, l3_min_capacity + overhead)
 
     with pytest.raises(RpcError, match=r'They sent error.*channel capacity is .*, which is below .*msat'):
-        l1.fund_channel(l4, l4_min_capacity + overhead - 1)
-    l1.fund_channel(l4, l4_min_capacity + overhead)
+        l1.fundchannel(l4, l4_min_capacity + overhead - 1)
+    l1.fundchannel(l4, l4_min_capacity + overhead)
 
     # Note that this check applies locally too, so you can't open it if
     # you would reject it.
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
     with pytest.raises(RpcError, match=r"'message': 'channel capacity.* is .*, which is below .*msat"):
-        l3.fund_channel(l2, l3_min_capacity + overhead - 1)
-    l3.fund_channel(l2, l3_min_capacity + overhead)
+        l3.fundchannel(l2, l3_min_capacity + overhead - 1)
+    l3.fundchannel(l2, l3_min_capacity + overhead)
 
 
 def test_second_channel(node_factory):
@@ -205,8 +205,8 @@ def test_second_channel(node_factory):
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l1.fund_channel(l2, 10**6)
-    l1.fund_channel(l3, 10**6)
+    l1.fundchannel(l2, 10**6)
+    l1.fundchannel(l3, 10**6)
 
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
@@ -401,7 +401,7 @@ def test_reconnect_no_update(node_factory, executor):
 
     # For channeld reconnection
     l1.rpc.connect(l2.info["id"], "localhost", l2.port)
-    fundchannel_exec = executor.submit(l1.fund_channel, l2, 10**6, False)
+    fundchannel_exec = executor.submit(l1.fundchannel, l2, 10**6, False)
     l1.daemon.wait_for_log(r"channeld.* Retransmitting funding_locked for channel")
     l1.stop()
 
@@ -465,7 +465,7 @@ def test_reconnect_normal(node_factory):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
 
 @unittest.skipIf(not DEVELOPER, "needs DEVELOPER=1")
@@ -482,7 +482,7 @@ def test_reconnect_sender_add1(node_factory):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     amt = 200000000
     rhash = l2.rpc.invoice(amt, 'test_reconnect_sender_add1', 'desc')['payment_hash']
@@ -517,7 +517,7 @@ def test_reconnect_sender_add(node_factory):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     amt = 200000000
     rhash = l2.rpc.invoice(amt, 'testpayment', 'desc')['payment_hash']
@@ -546,7 +546,7 @@ def test_reconnect_receiver_add(node_factory):
                                may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     amt = 200000000
     rhash = l2.rpc.invoice(amt, 'testpayment2', 'desc')['payment_hash']
@@ -578,7 +578,7 @@ def test_reconnect_receiver_fulfill(node_factory):
                                may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     amt = 200000000
     rhash = l2.rpc.invoice(amt, 'testpayment2', 'desc')['payment_hash']
@@ -602,7 +602,7 @@ def test_shutdown_reconnect(node_factory):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    chan = l1.fund_channel(l2, 10**6)
+    chan = l1.fundchannel(l2, 10**6)
     l1.pay(l2, 200000000)
 
     assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 0
@@ -1540,7 +1540,7 @@ def test_channel_persistence(node_factory, bitcoind, executor):
     for n in (l1, l2):
         assert(n.db_query('SELECT COUNT(id) as count FROM channels;')[0]['count'] == 0)
 
-    l1.fund_channel(l2, 100000)
+    l1.fundchannel(l2, 100000)
 
     peers = l1.rpc.listpeers()['peers']
     assert(only_one(peers[0]['channels'])['state'] == 'CHANNELD_NORMAL')
@@ -1703,7 +1703,7 @@ def test_fee_limits(node_factory, bitcoind):
     # Trying to open a channel with too low a fee-rate is denied
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
     with pytest.raises(RpcError, match='They sent error .* feerate_per_kw 253 below minimum'):
-        l1.fund_channel(l4, 10**6)
+        l1.fundchannel(l4, 10**6)
 
     # Restore to normal.
     l1.stop()
@@ -1712,7 +1712,7 @@ def test_fee_limits(node_factory, bitcoind):
 
     # Try with node which sets --ignore-fee-limits
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    chan = l1.fund_channel(l3, 10**6)
+    chan = l1.fundchannel(l3, 10**6)
 
     # Kick off fee adjustment using HTLC.
     l1.pay(l3, 1000)
@@ -1745,7 +1745,7 @@ def test_update_fee_reconnect(node_factory, bitcoind):
     l2 = node_factory.get_node(may_reconnect=True,
                                feerates=(14000, 15000, 14000, 3750))
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chan = l1.fund_channel(l2, 10**6)
+    chan = l1.fundchannel(l2, 10**6)
 
     # Make an HTLC just to get us to do feechanges.
     l1.pay(l2, 1000)
@@ -1795,7 +1795,7 @@ def test_multiple_channels(node_factory):
 
         l1.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
         l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
-        chan = l1.fund_channel(l2, 10**6)
+        chan = l1.fundchannel(l2, 10**6)
 
         l1.rpc.close(chan)
 
@@ -1846,7 +1846,7 @@ def test_peerinfo(node_factory, bitcoind):
     assert l1.rpc.getpeer(l2.info['id'])['features'] == lfeatures
 
     # Fund a channel to force a node announcement
-    chan = l1.fund_channel(l2, 10**6)
+    chan = l1.fundchannel(l2, 10**6)
     # Now proceed to funding-depth and do a full gossip round
     bitcoind.generate_block(5)
     l1.daemon.wait_for_logs(['Received node_announcement for node ' + l2.info['id']])
@@ -1912,7 +1912,7 @@ def test_disconnectpeer(node_factory, bitcoind):
         l2.rpc.disconnect(l1.info['id'])
 
     # Fund channel l1 -> l3
-    l1.fund_channel(l3, 10**6)
+    l1.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # disconnecting a non gossiping peer results in error
@@ -2011,7 +2011,7 @@ def test_no_fee_estimate(node_factory, bitcoind, executor):
 
     # But can accept incoming connections.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l2.fund_channel(l1, 10**6)
+    l2.fundchannel(l1, 10**6)
 
     # Can do HTLCs.
     l2.pay(l1, 10**5)
@@ -2023,7 +2023,7 @@ def test_no_fee_estimate(node_factory, bitcoind, executor):
 
     # Can do unilateral close.
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.fund_channel(l1, 10**6)
+    l2.fundchannel(l1, 10**6)
     l2.pay(l1, 10**9 // 2)
     l1.rpc.dev_fail(l2.info['id'])
     l1.daemon.wait_for_log('Failing due to dev-fail command')
@@ -2052,7 +2052,7 @@ def test_opener_feerate_reconnect(node_factory, bitcoind):
                                feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node(disconnect=disconnects, may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     # Need a payment otherwise it won't update fee.
     l1.pay(l2, 10**9 // 2)
@@ -2076,7 +2076,7 @@ def test_opener_simple_reconnect(node_factory, bitcoind):
                                feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     l1.rpc.disconnect(l2.info['id'], True)
 
@@ -2104,7 +2104,7 @@ def test_dataloss_protection(node_factory, bitcoind):
                            + format(len(lf) // 2, '04x')
                            + lf)
 
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
     l2.stop()
 
     # Save copy of the db.
@@ -2357,7 +2357,7 @@ def test_fail_unconfirmed(node_factory, bitcoind, executor):
 
     # First one, we close by mutual agreement.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 200000, wait_for_active=True)
+    l1.fundchannel(l2, 200000, wait_for_active=True)
     l1.rpc.close(l2.info['id'])
 
     # Make sure it's closed
@@ -2390,7 +2390,7 @@ def test_fail_unconfirmed(node_factory, bitcoind, executor):
     l1.start()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 200000, wait_for_active=True)
+    l1.fundchannel(l2, 200000, wait_for_active=True)
 
 
 def test_change_chaining(node_factory, bitcoind):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,7 +27,7 @@ def test_db_dangling_peer_fix(node_factory, bitcoind):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     # Make sure l2 has register connection
     l2.daemon.wait_for_log('Handed peer, entering loop')
-    l2.fund_channel(l1, 200000, wait_for_active=True)
+    l2.fundchannel(l1, 200000, wait_for_active=True)
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', "Address is network specific")

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -34,8 +34,8 @@ def test_gossip_pruning(node_factory, bitcoind):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
-    scid1 = l1.fund_channel(l2, 10**6)
-    scid2 = l2.fund_channel(l3, 10**6)
+    scid1 = l1.fundchannel(l2, 10**6)
+    scid2 = l2.fundchannel(l3, 10**6)
 
     bitcoind.generate_block(6)
 
@@ -80,7 +80,7 @@ def test_gossip_disable_channels(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2, opts=opts)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fund_channel(l2, 10**6)
+    scid = l1.fundchannel(l2, 10**6)
     bitcoind.generate_block(5)
 
     def count_active(node):
@@ -121,7 +121,7 @@ def test_announce_address(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2, opts=[opts, {}])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fund_channel(l2, 10**6)
+    scid = l1.fundchannel(l2, 10**6)
     bitcoind.generate_block(5)
 
     l1.wait_channel_active(scid)
@@ -146,7 +146,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     before_anything = int(time.time())
 
     # Make a public channel.
-    chan12 = l1.fund_channel(l2, 10**5)
+    chan12 = l1.fundchannel(l2, 10**5)
     bitcoind.generate_block(5)
 
     l3.wait_for_channel_updates([chan12])
@@ -154,7 +154,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
 
     # Make another one, different timestamp.
     time.sleep(1)
-    chan23 = l2.fund_channel(l3, 10**5)
+    chan23 = l2.fundchannel(l3, 10**5)
     bitcoind.generate_block(5)
 
     l1.wait_for_channel_updates([chan23])
@@ -229,7 +229,7 @@ def test_connect_by_gossip(node_factory, bitcoind):
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
     # Nodes are gossiped only if they have channels
-    chanid = l2.fund_channel(l3, 10**6)
+    chanid = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Let channel reach announcement depth
@@ -334,8 +334,8 @@ def test_gossip_badsig(node_factory):
     # l2 connects to both, so l1 can't reconnect and thus l2 drops to chain
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.fund_channel(l1, 10**6)
-    l2.fund_channel(l3, 10**6)
+    l2.fundchannel(l1, 10**6)
+    l2.fundchannel(l3, 10**6)
 
     # Wait for route propagation.
     l1.bitcoin.generate_block(5)
@@ -362,7 +362,7 @@ def test_gossip_weirdalias(node_factory, bitcoind):
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.daemon.wait_for_log('openingd-chan#1: Handed peer, entering loop')
-    l2.fund_channel(l1, 10**6)
+    l2.fundchannel(l1, 10**6)
     bitcoind.generate_block(6)
 
     # They should gossip together.
@@ -391,12 +391,12 @@ def test_gossip_persistence(node_factory, bitcoind):
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l3.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    scid12 = l1.fund_channel(l2, 10**6)
-    scid23 = l2.fund_channel(l3, 10**6)
+    scid12 = l1.fundchannel(l2, 10**6)
+    scid23 = l2.fundchannel(l3, 10**6)
 
     # Make channels public, except for l3 -> l4, which is kept local-only for now
     bitcoind.generate_block(5)
-    scid34 = l3.fund_channel(l4, 10**6)
+    scid34 = l3.fundchannel(l4, 10**6)
     bitcoind.generate_block(1)
 
     def active(node):
@@ -485,7 +485,7 @@ def test_gossip_no_empty_announcements(node_factory, bitcoind):
                                              fundchannel=False)
 
     # Make an announced-but-not-updated channel.
-    l3.fund_channel(l4, 10**5)
+    l3.fundchannel(l4, 10**5)
     bitcoind.generate_block(5)
 
     # 0x0100 = channel_announcement, which goes to l2 before l3 dies.
@@ -727,7 +727,7 @@ def test_gossip_query_channel_range(node_factory, bitcoind, chainparams):
     assert len(msgs) == 8
 
     # This should actually be large enough for zlib to kick in!
-    scid34 = l3.fund_channel(l4, 10**5)
+    scid34 = l3.fundchannel(l4, 10**5)
     bitcoind.generate_block(5)
     l2.daemon.wait_for_log('Received node_announcement for node ' + l4.info['id'])
 
@@ -780,7 +780,7 @@ def test_report_routing_failure(node_factory, bitcoind):
 
     def fund_from_to_payer(lsrc, ldst, lpayer):
         lsrc.rpc.connect(ldst.info['id'], 'localhost', ldst.port)
-        c = lsrc.fund_channel(ldst, 10000000)
+        c = lsrc.fundchannel(ldst, 10000000)
         bitcoind.generate_block(5)
         lpayer.wait_for_channel_updates([c])
 
@@ -798,7 +798,7 @@ def test_report_routing_failure(node_factory, bitcoind):
         src.rpc.connect(dst.info['id'], 'localhost', dst.port)
         print("src={}, dst={}".format(src.daemon.lightning_dir,
                                       dst.daemon.lightning_dir))
-        channels.append(src.fund_channel(dst, 10**6))
+        channels.append(src.fundchannel(dst, 10**6))
     bitcoind.generate_block(5)
 
     for c in channels:
@@ -833,8 +833,8 @@ def test_query_short_channel_id(node_factory, bitcoind, chainparams):
     assert msgs[0] == '0106{}01'.format(chain_hash)
 
     # Make channels public.
-    scid12 = l1.fund_channel(l2, 10**5)
-    scid23 = l2.fund_channel(l3, 10**5)
+    scid12 = l1.fundchannel(l2, 10**5)
+    scid23 = l2.fundchannel(l3, 10**5)
     bitcoind.generate_block(5)
 
     # It will know about everything.
@@ -899,7 +899,7 @@ def test_gossip_addresses(node_factory, bitcoind):
     l2 = node_factory.get_node()
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 100000)
+    l1.fundchannel(l2, 100000)
     bitcoind.generate_block(6)
     l2.daemon.wait_for_log('Received node_announcement for node {}'
                            .format(l1.info['id']))
@@ -1196,7 +1196,7 @@ def test_getroute_exclude(node_factory, bitcoind):
 
     # Now, create an alternate (better) route.
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid = l2.fund_channel(l4, 1000000, wait_for_active=False)
+    scid = l2.fundchannel(l4, 1000000, wait_for_active=False)
     bitcoind.generate_block(5)
 
     # We don't wait above, because we care about it hitting l1.
@@ -1231,9 +1231,9 @@ def test_getroute_exclude(node_factory, bitcoind):
         l1.rpc.getroute(l4.info['id'], 1, 1, exclude=[l3.info['id'], chan_l2l4])
 
     l1.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid15 = l1.fund_channel(l5, 1000000, wait_for_active=False)
+    scid15 = l1.fundchannel(l5, 1000000, wait_for_active=False)
     l5.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid54 = l5.fund_channel(l4, 1000000, wait_for_active=False)
+    scid54 = l5.fundchannel(l4, 1000000, wait_for_active=False)
     bitcoind.generate_block(5)
 
     # We don't wait above, because we care about it hitting l1.
@@ -1315,7 +1315,7 @@ def setup_gossip_store_test(node_factory, bitcoind):
     l1, l2, l3 = node_factory.line_graph(3, fundchannel=False)
 
     # Create channel.
-    scid23 = l2.fund_channel(l3, 10**6)
+    scid23 = l2.fundchannel(l3, 10**6)
 
     # Have that channel announced.
     bitcoind.generate_block(5)
@@ -1328,7 +1328,7 @@ def setup_gossip_store_test(node_factory, bitcoind):
     wait_for(lambda: sum([c['base_fee_millisatoshi'] for c in l2.rpc.listchannels()['channels']]) == 21)
 
     # Create another channel, which will stay private.
-    scid12 = l1.fund_channel(l2, 10**6)
+    scid12 = l1.fundchannel(l2, 10**6)
 
     # Now insert channel_update for previous channel; now they're both past the
     # node announcements.

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -211,7 +211,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # Attach public channel to l1 so it doesn't look like a dead-end.
     l0 = node_factory.get_node()
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    scid_dummy = l0.fund_channel(l1, 2 * (10**5))
+    scid_dummy = l0.fundchannel(l1, 2 * (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.
@@ -267,7 +267,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # The existence of a public channel, even without capacity, will suppress
     # the exposure of private channels.
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid2 = l3.fund_channel(l2, (10**5))
+    scid2 = l3.fundchannel(l2, (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -43,7 +43,7 @@ def test_stop_pending_fundchannel(node_factory, executor):
     os.kill(l2.daemon.proc.pid, signal.SIGSTOP)
 
     # The fundchannel call will not terminate so run it in a future
-    executor.submit(l1.fund_channel, l2, 10**6)
+    executor.submit(l1.fundchannel, l2, 10**6)
     l1.daemon.wait_for_log('peer_out WIRE_OPEN_CHANNEL')
 
     l1.rpc.stop()
@@ -277,7 +277,7 @@ def test_ping(node_factory):
         l1.daemon.wait_for_log(r'Got pong 1000 bytes \({}\.\.\.\)'
                                .format(l2.info['version']), timeout=1)
 
-    l1.fund_channel(l2, 10**5)
+    l1.fundchannel(l2, 10**5)
 
     # channeld pinging
     ping_tests(l1, l2)
@@ -296,7 +296,7 @@ def test_htlc_sig_persistence(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(disconnect=['+WIRE_COMMITMENT_SIGNED'])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
     f = executor.submit(l1.pay, l2, 31337000)
     l1.daemon.wait_for_log(r'HTLC out 0 RCVD_ADD_ACK_COMMIT->SENT_ADD_ACK_REVOCATION')
     l1.stop()
@@ -347,7 +347,7 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chanid = l1.fund_channel(l2, 10**6)
+    chanid = l1.fundchannel(l2, 10**6)
 
     # Wait for route propagation.
     l1.wait_channel_active(chanid)
@@ -414,7 +414,7 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chanid = l1.fund_channel(l2, 10**6)
+    chanid = l1.fundchannel(l2, 10**6)
 
     l1.wait_channel_active(chanid)
     sync_blockheight(bitcoind, [l1, l2])

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -175,9 +175,9 @@ def test_pay_exclude_node(node_factory, bitcoind):
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
     l4.rpc.connect(l5.info['id'], 'localhost', l5.port)
     l5.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    scid14 = l1.fund_channel(l4, 10**6, wait_for_active=False)
-    scid45 = l4.fund_channel(l5, 10**6, wait_for_active=False)
-    scid53 = l5.fund_channel(l3, 10**6, wait_for_active=False)
+    scid14 = l1.fundchannel(l4, 10**6, wait_for_active=False)
+    scid45 = l4.fundchannel(l5, 10**6, wait_for_active=False)
+    scid53 = l5.fundchannel(l3, 10**6, wait_for_active=False)
     bitcoind.generate_block(5)
 
     l1.daemon.wait_for_logs([r'update for channel {}/0 now ACTIVE'
@@ -349,7 +349,7 @@ def test_payment_success_persistence(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    chanid = l1.fund_channel(l2, 100000)
+    chanid = l1.fundchannel(l2, 100000)
 
     inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1')
 
@@ -394,7 +394,7 @@ def test_payment_failed_persistence(node_factory, executor):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 100000)
+    l1.fundchannel(l2, 100000)
 
     # Expires almost immediately, so it will fail.
     inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1', 5)
@@ -437,7 +437,7 @@ def test_payment_duplicate_uncommitted(node_factory, executor):
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.fund_channel(l2, 100000)
+    l1.fundchannel(l2, 100000)
 
     inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1')
 
@@ -1109,8 +1109,8 @@ def test_forward_different_fees_and_cltv(node_factory, bitcoind):
     l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
     l3.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
 
-    c1 = l1.fund_channel(l2, 10**6)
-    c2 = l2.fund_channel(l3, 10**6)
+    c1 = l1.fundchannel(l2, 10**6)
+    c2 = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Make sure l1 has seen announce for all channels.
@@ -1215,8 +1215,8 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
     l3.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
 
-    c1 = l1.fund_channel(l2, 10**6)
-    c2 = l2.fund_channel(l3, 10**6)
+    c1 = l1.fundchannel(l2, 10**6)
+    c2 = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Make sure l1 has seen announce for all channels.
@@ -1380,11 +1380,11 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
     l2.rpc.connect(l5.info['id'], 'localhost', l5.port)
     l6.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    c12 = l1.fund_channel(l2, 10**6)
-    c23 = l2.fund_channel(l3, 10**6)
-    c24 = l2.fund_channel(l4, 10**6)
-    c25 = l2.fund_channel(l5, 10**4 * 3)
-    l6.fund_channel(l1, 10**6)
+    c12 = l1.fundchannel(l2, 10**6)
+    c23 = l2.fundchannel(l3, 10**6)
+    c24 = l2.fundchannel(l4, 10**6)
+    c25 = l2.fundchannel(l5, 10**4 * 3)
+    l6.fundchannel(l1, 10**6)
 
     # Make sure routes finalized.
     bitcoind.generate_block(5)
@@ -1648,19 +1648,19 @@ def test_pay_retry(node_factory, bitcoind, executor, chainparams):
                                                  opts={'feerates': (7500, 7500, 7500, 7500), 'disable-mpp': None})
 
     # scid12
-    l1.fund_channel(l2, 10**6, wait_for_active=False)
+    l1.fundchannel(l2, 10**6, wait_for_active=False)
     # scid23
-    l2.fund_channel(l3, 10**6, wait_for_active=False)
+    l2.fundchannel(l3, 10**6, wait_for_active=False)
     # scid34
-    l3.fund_channel(l4, 10**6, wait_for_active=False)
-    scid45 = l4.fund_channel(l5, 10**6, wait_for_active=False)
+    l3.fundchannel(l4, 10**6, wait_for_active=False)
+    scid45 = l4.fundchannel(l5, 10**6, wait_for_active=False)
 
     l1.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid15 = l1.fund_channel(l5, 10**6, wait_for_active=False)
+    scid15 = l1.fundchannel(l5, 10**6, wait_for_active=False)
     l2.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid25 = l2.fund_channel(l5, 10**6, wait_for_active=False)
+    scid25 = l2.fundchannel(l5, 10**6, wait_for_active=False)
     l3.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid35 = l3.fund_channel(l5, 10**6, wait_for_active=False)
+    scid35 = l3.fundchannel(l5, 10**6, wait_for_active=False)
 
     # Make sure l1 sees all 7 channels
     bitcoind.generate_block(5)
@@ -1719,7 +1719,7 @@ def test_pay_routeboost(node_factory, bitcoind, compat):
         l1.rpc.pay(l5.rpc.invoice(10**8, 'test_retry', 'test_retry')['bolt11'])
 
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    scidl2l3 = l2.fund_channel(l3, 10**6)
+    scidl2l3 = l2.fundchannel(l3, 10**6)
 
     # Make sure l1 knows about the 2->3 channel.
     bitcoind.generate_block(5)
@@ -1787,7 +1787,7 @@ def test_pay_routeboost(node_factory, bitcoind, compat):
         # Finally, it should fall back to second routehint if first fails.
         # (Note, this is not public because it's not 6 deep)
         l3.rpc.connect(l5.info['id'], 'localhost', l5.port)
-        scid35 = l3.fund_channel(l5, 10**6)
+        scid35 = l3.fundchannel(l5, 10**6)
         l4.stop()
         routel3l5 = [{'id': l3.info['id'],
                       'short_channel_id': scid35,
@@ -1957,9 +1957,9 @@ def test_setchannelfee_state(node_factory, bitcoind):
 
     # connection and funding
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l0.fund_channel(l1, 1000000, wait_for_active=True)
+    l0.fundchannel(l1, 1000000, wait_for_active=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fund_channel(l2, 1000000, wait_for_active=False)
+    scid = l1.fundchannel(l2, 1000000, wait_for_active=False)
 
     # try setting the fee in state AWAITING_LOCKIN should be possible
     # assert(l1.channel_state(l2) == "CHANNELD_AWAITING_LOCKIN")
@@ -2153,8 +2153,8 @@ def test_setchannelfee_all(node_factory, bitcoind):
     l1, l2, l3 = node_factory.get_nodes(3, opts={'fee-base': DEF_BASE, 'fee-per-satoshi': DEF_PPM})
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l1.fund_channel(l2, 1000000)
-    l1.fund_channel(l3, 1000000)
+    l1.fundchannel(l2, 1000000)
+    l1.fundchannel(l3, 1000000)
 
     # get short channel id
     scid2 = l1.get_channel_scid(l2)
@@ -2581,13 +2581,13 @@ def test_partial_payment(node_factory, bitcoind, executor):
 
     # Two routes to l4: one via l2, and one via l3.
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1.fund_channel(l2, 100000)
+    l1.fundchannel(l2, 100000)
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l1.fund_channel(l3, 100000)
+    l1.fundchannel(l3, 100000)
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid24 = l2.fund_channel(l4, 100000)
+    scid24 = l2.fundchannel(l4, 100000)
     l3.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid34 = l3.fund_channel(l4, 100000)
+    scid34 = l3.fundchannel(l4, 100000)
     bitcoind.generate_block(5)
 
     # Wait until l1 knows about all channels.
@@ -3133,8 +3133,8 @@ def test_mpp_adaptive(node_factory, bitcoind):
     l3.connect(l4)
 
     # First roadblock right away on an outgoing channel
-    l2.fund_channel(l1, amt)
-    l2.fund_channel(l4, amt, wait_for_active=True)
+    l2.fundchannel(l1, amt)
+    l2.fundchannel(l4, amt, wait_for_active=True)
     l2.rpc.pay(l1.rpc.invoice(
         amt + 99999000 - 1,  # Slightly less than amt + reserve
         label="reb l1->l2",
@@ -3142,8 +3142,8 @@ def test_mpp_adaptive(node_factory, bitcoind):
     )['bolt11'])
 
     # Second path fails only after the first hop
-    l1.fund_channel(l3, amt)
-    l4.fund_channel(l3, amt, wait_for_active=True)
+    l1.fundchannel(l3, amt)
+    l4.fundchannel(l3, amt, wait_for_active=True)
     l4.rpc.pay(l3.rpc.invoice(
         amt + 99999000 - 1,  # Slightly less than amt + reserve
         label="reb l3->l4",
@@ -3247,9 +3247,9 @@ def test_mpp_presplit_routehint_conflict(node_factory, bitcoind):
     l1, l2, l3 = node_factory.get_nodes(3)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1l2 = l1.fund_channel(l2, 10**7, announce_channel=True)
+    l1l2 = l1.fundchannel(l2, 10**7, announce_channel=True)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.fund_channel(l3, 10**7, announce_channel=False)
+    l2.fundchannel(l3, 10**7, announce_channel=False)
 
     bitcoind.generate_block(6)
     sync_blockheight(bitcoind, [l1, l2, l3])
@@ -3400,9 +3400,9 @@ def test_mpp_waitblockheight_routehint_conflict(node_factory, bitcoind, executor
     l1, l2, l3 = node_factory.get_nodes(3)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1l2 = l1.fund_channel(l2, 10**7, announce_channel=True)
+    l1l2 = l1.fundchannel(l2, 10**7, announce_channel=True)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.fund_channel(l3, 10**7, announce_channel=False)
+    l2.fundchannel(l3, 10**7, announce_channel=False)
 
     bitcoind.generate_block(6)
     sync_blockheight(bitcoind, [l1, l2, l3])
@@ -3496,10 +3496,10 @@ def test_mpp_interference_2(node_factory, bitcoind, executor):
     l7.rpc.connect(l1.info['id'], 'localhost', l1.port)
     # The order in which the routes are built should not matter so
     # shuffle them.
-    incoming_builders = [lambda: l5.fund_channel(l1, int((unit * 7).to_satoshi()), announce_channel=False),
-                         lambda: l6.fund_channel(l1, int((unit * 5).to_satoshi()), announce_channel=False),
-                         lambda: l4.fund_channel(l1, int((unit * 3).to_satoshi()), announce_channel=False),
-                         lambda: l7.fund_channel(l1, int((unit * 2).to_satoshi()), announce_channel=False)]
+    incoming_builders = [lambda: l5.fundchannel(l1, int((unit * 7).to_satoshi()), announce_channel=False),
+                         lambda: l6.fundchannel(l1, int((unit * 5).to_satoshi()), announce_channel=False),
+                         lambda: l4.fundchannel(l1, int((unit * 3).to_satoshi()), announce_channel=False),
+                         lambda: l7.fundchannel(l1, int((unit * 2).to_satoshi()), announce_channel=False)]
     random.shuffle(incoming_builders)
     for b in incoming_builders:
         b()
@@ -3509,10 +3509,10 @@ def test_mpp_interference_2(node_factory, bitcoind, executor):
     l2.rpc.connect(l6.info['id'], 'localhost', l6.port)
     l3.rpc.connect(l7.info['id'], 'localhost', l7.port)
     l3.rpc.connect(l6.info['id'], 'localhost', l6.port)
-    l2.fund_channel(l4, int((unit * 6).to_satoshi()), announce_channel=False)
-    l2.fund_channel(l6, int((unit * 6).to_satoshi()), announce_channel=False)
-    l3.fund_channel(l7, int((unit * 6).to_satoshi()), announce_channel=False)
-    l3.fund_channel(l6, int((unit * 6).to_satoshi()), announce_channel=False)
+    l2.fundchannel(l4, int((unit * 6).to_satoshi()), announce_channel=False)
+    l2.fundchannel(l6, int((unit * 6).to_satoshi()), announce_channel=False)
+    l3.fundchannel(l7, int((unit * 6).to_satoshi()), announce_channel=False)
+    l3.fundchannel(l6, int((unit * 6).to_satoshi()), announce_channel=False)
 
     # Now wait for the buyers to learn the entire public network.
     bitcoind.generate_block(5)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1874,7 +1874,7 @@ def test_htlc_accepted_hook_crash(node_factory, executor):
         allow_broken_log=True
     )
     l1.connect(l2)
-    l1.fund_channel(l2, 10**6)
+    l1.fundchannel(l2, 10**6)
 
     i = l2.rpc.invoice(500, "crashpls", "crashpls")['bolt11']
 


### PR DESCRIPTION
See 668debb74f5d666d3bbe827ab0a406ee8afade73

Before this change warning were produced:

```
$ pytest tests
...
.../src/lightning-fixtures/contrib/pyln-testing/pyln/testing/utils.py:744: DeprecationWarning: LightningNode.fund_channel is deprecated in favor of LightningNode.fundchannel
    warnings.warn("LightningNode.fund_channel is deprecated in favor of "
```

Changelog-None