### PR TITLE
pyln: Plugin methods and hooks refuse to set results twice

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -69,6 +69,7 @@ class Request(dict):
         self.plugin = plugin
         self.state = RequestState.PENDING
         self.id = req_id
+        self.termination_tb: Optional[str] = None
 
     def getattr(self, key: str) -> Union[Method, Any, int]:
         if key == "params":
@@ -84,21 +85,27 @@ class Request(dict):
 
     def set_result(self, result: Any) -> None:
         if self.state != RequestState.PENDING:
+            assert(self.termination_tb is not None)
             raise ValueError(
                 "Cannot set the result of a request that is not pending, "
-                "current state is {state}".format(state=self.state))
+                "current state is {state}. Request previously terminated at\n"
+                "{tb}".format(state=self.state, tb=self.termination_tb))
         self.result = result
         self._write_result({
             'jsonrpc': '2.0',
             'id': self.id,
             'result': self.result
         })
+        self.state = RequestState.FINISHED
+        self.termination_tb = "".join(traceback.extract_stack().format()[:-1])
 
     def set_exception(self, exc: Exception) -> None:
         if self.state != RequestState.PENDING:
+            assert(self.termination_tb is not None)
             raise ValueError(
                 "Cannot set the exception of a request that is not pending, "
-                "current state is {state}".format(state=self.state))
+                "current state is {state}. Request previously terminated at\n"
+                "{tb}".format(state=self.state, tb=self.termination_tb))
         self.exc = exc
         self._write_result({
             'jsonrpc': '2.0',
@@ -111,6 +118,8 @@ class Request(dict):
                 "traceback": traceback.format_exc(),
             },
         })
+        self.state = RequestState.FAILED
+        self.termination_tb = "".join(traceback.extract_stack().format()[:-1])
 
     def _write_result(self, result: dict) -> None:
         self.plugin._write_locked(result)


### PR DESCRIPTION
We had a couple of instances where a plugin would be killed by `lightningd`
because we were returning a result of an exception twice, and it was hard to
trace down the logic error in the user plugin that caused that. This patch
adds a traceback the first time we return a result/exception, and raise an
exception with a stacktrace of the first termination when a second one comes
in.

This can still terminate the plugin, but the programmer gets a clear
indication where the result was set, and can potentially even recover from it.

Changelog-Added: pyln: Plugin method and hook requests prevent the plugin developer from accidentally setting the result multiple times, and will raise an exception detailing where the result was first set.