### PR TITLE
Add mypy typing verification to `make check-python`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,14 +386,20 @@ check-spelling:
 
 PYSRC=$(shell git ls-files "*.py" | grep -v /text.py) contrib/pylightning/lightning-pay
 
-check-python:
+# Some tests in pyln will need to find lightningd to run, so have a PATH that
+# allows it to find that
+PYLN_PATH=$(shell pwd)/lightningd:$(PATH)
+check-pyln-%:  $(BIN_PROGRAMS)
+	@(cd contrib/$(shell echo $@ | cut -b 7-) && PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(MAKE) check)
+
+check-python: check-pyln-client
 	@# E501 line too long (N > 79 characters)
 	@# E731 do not assign a lambda expression, use a def
 	@# W503: line break before binary operator
 	@flake8 --ignore=E501,E731,W503 ${PYSRC}
 
-	PYTHONPATH=contrib/pyln-client:$$PYTHONPATH $(PYTEST) contrib/pyln-client/
-	PYTHONPATH=contrib/pyln-proto:$$PYTHONPATH $(PYTEST) contrib/pyln-proto/
+	PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-testing/tests/
+	PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
 
 check-includes:
 	@tools/check-includes.sh

--- a/Makefile
+++ b/Makefile
@@ -393,13 +393,12 @@ PYLN_PATH=$(shell pwd)/lightningd:$(PATH)
 check-pyln-%:  $(BIN_PROGRAMS)
 	@(cd contrib/$(shell echo $@ | cut -b 7-) && PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(MAKE) check)
 
-check-python: check-pyln-client
+check-python: check-pyln-client check-pyln-testing
 	@# E501 line too long (N > 79 characters)
 	@# E731 do not assign a lambda expression, use a def
 	@# W503: line break before binary operator
 	@flake8 --ignore=E501,E731,W503 ${PYSRC}
 
-	PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-testing/tests/
 	PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
 
 check-includes:

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ endif
 # Timeout shortly before the 600 second travis silence timeout
 # (method=thread to support xdist)
 PYTEST_OPTS := -v --timeout=550 --timeout_method=thread -p no:logging
+PYTHONPATH=$(shell pwd)/contrib/pyln-client:$(shell pwd)/contrib/pyln-testing:$(shell pwd)/contrib/pyln-proto/
 
 # This is where we add new features as bitcoin adds them.
 FEATURES :=
@@ -339,7 +340,7 @@ ifeq ($(PYTEST),)
 	exit 1
 else
 # Explicitly hand DEVELOPER and VALGRIND so you can override on make cmd line.
-	PYTHONPATH=`pwd`/contrib/pyln-client:`pwd`/contrib/pyln-testing:`pwd`/contrib/pyln-proto/:$(PYTHONPATH) TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
+	PYTHONPATH=$(PYTHONPATH) TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
 endif
 
 # Keep includes in alpha order.
@@ -398,8 +399,8 @@ check-python: check-pyln-client
 	@# W503: line break before binary operator
 	@flake8 --ignore=E501,E731,W503 ${PYSRC}
 
-	PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-testing/tests/
-	PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
+	PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-testing/tests/
+	PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
 
 check-includes:
 	@tools/check-includes.sh

--- a/contrib/pyln-client/Makefile
+++ b/contrib/pyln-client/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make
 
 .PHONY: bdist sdist release check check-source check-flake8 check-mypy
-PKG=proto
+PKG=client
 VERSION = $(shell python3 -c 'from pyln import ${PKG};print(${PKG}.__version__)')
 
 # You can set these variables from the command line.
@@ -25,7 +25,7 @@ check-pytest:
 	pytest tests
 
 check-mypy:
-	mypy --namespace-packages tests pyln
+	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages tests pyln
 
 $(SDIST_FILE):
 	python3 setup.py sdist

--- a/contrib/pyln-proto/pyln/proto/invoice.py
+++ b/contrib/pyln-proto/pyln/proto/invoice.py
@@ -59,20 +59,20 @@ def unshorten_amount(amount):
 
 
 # Bech32 spits out array of 5-bit values.  Shim here.
-def u5_to_bitarray(arr):
+def u5_to_bitarray(arr: bytes):
     ret = bitstring.BitArray()
     for a in arr:
         ret += bitstring.pack("uint:5", a)
     return ret
 
 
-def bitarray_to_u5(barr):
+def bitarray_to_u5(barr) -> bytes:
     assert barr.len % 5 == 0
     ret = []
     s = bitstring.ConstBitStream(barr)
     while s.pos != s.len:
         ret.append(s.read(5).uint)
-    return ret
+    return bytes(ret)
 
 
 def encode_fallback(fallback, currency):

--- a/contrib/pyln-proto/pyln/proto/zbase32.py
+++ b/contrib/pyln-proto/pyln/proto/zbase32.py
@@ -1,4 +1,4 @@
-import bitstring
+import bitstring  # type: ignore
 
 
 zbase32_chars = b'ybndrfg8ejkmcpqxot1uwisza345h769'

--- a/contrib/pyln-testing/Makefile
+++ b/contrib/pyln-testing/Makefile
@@ -1,23 +1,31 @@
-#! /usr/bin/make
+#!/usr/bin/make
 
 .PHONY: bdist sdist release check check-source check-flake8 check-mypy
-VERSION = $(shell python3 -c 'from pyln import testing;print(testing.__version__)')
+PKG=testing
+VERSION = $(shell python3 -c 'from pyln import ${PKG};print(${PKG}.__version__)')
 
-SDIST_FILE = "dist/pyln-testing-$(VERSION).tar.gz"
-BDIST_FILE = "dist/pyln_testing-$(VERSION)-py3-none-any.whl"
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = docs
+BUILDDIR      = build
+
+SDIST_FILE = "dist/pyln-${PKG}-$(VERSION).tar.gz"
+BDIST_FILE = "dist/pyln_${PKG}-$(VERSION)-py3-none-any.whl"
 ARTEFACTS = $(BDIST_FILE) $(SDIST_FILE)
 
-check:
-#	pytest
+check: check-source check-pytest
 
 check-source: check-flake8 check-mypy
 
 check-flake8:
 	flake8 --ignore=E501,E731,W503
 
-# mypy . does not recurse.  I have no idea why...
+check-pytest:
+	pytest tests
+
 check-mypy:
-	mypy --ignore-missing-imports `find pyln/testing -name '*.py'`
+	mypy --namespace-packages tests pyln
 
 $(SDIST_FILE):
 	python3 setup.py sdist
@@ -30,12 +38,12 @@ test-release: check $(ARTEFACTS)
 
 	# Create a test virtualenv, install from the testpypi and run the
 	# tests against it (make sure not to use any virtualenv that may have
-	# pyln-testing already installed).
+	# pyln-${PKG} already installed).
 	virtualenv testpypi --python=/usr/bin/python3 --download --always-copy --clear
 	# Install the requirements from the prod repo, they are not being kept up to date on the test repo
 	testpypi/bin/python3 -m pip install -r requirements.txt flaky pytest-timeout
-	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-testing
-	testpypi/bin/python3 -c "from pyln import testing;assert(testing.__version__ == '$(VERSION)')"
+	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}
+	testpypi/bin/python3 -c "from pyln import ${PKG};assert(${PKG}.__version__ == '$(VERSION)')"
 	testpypi/bin/pytest tests
 	rm -rf testpypi
 

--- a/contrib/pyln-testing/Makefile
+++ b/contrib/pyln-testing/Makefile
@@ -25,7 +25,7 @@ check-pytest:
 	pytest tests
 
 check-mypy:
-	mypy --namespace-packages tests pyln
+	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages tests pyln
 
 $(SDIST_FILE):
 	python3 setup.py sdist

--- a/contrib/pyln-testing/pyln/testing/btcproxy.py
+++ b/contrib/pyln-testing/pyln/testing/btcproxy.py
@@ -1,10 +1,10 @@
 """ A bitcoind proxy that allows instrumentation and canned responses
 """
 from flask import Flask, request
-from bitcoin.rpc import JSONRPCError
-from bitcoin.rpc import RawProxy as BitcoinProxy
-from cheroot.wsgi import Server
-from cheroot.wsgi import PathInfoDispatcher
+from bitcoin.rpc import JSONRPCError  # type: ignore
+from bitcoin.rpc import RawProxy as BitcoinProxy  # type: ignore
+from cheroot.wsgi import Server  # type: ignore
+from cheroot.wsgi import PathInfoDispatcher  # type: ignore
 
 import decimal
 import flask

--- a/contrib/pyln-testing/pyln/testing/db.py
+++ b/contrib/pyln-testing/pyln/testing/db.py
@@ -1,9 +1,9 @@
-from ephemeral_port_reserve import reserve
+from ephemeral_port_reserve import reserve  # type: ignore
 from glob import glob
 
 import logging
 import os
-import psycopg2
+import psycopg2  # type: ignore
 import random
 import re
 import shutil
@@ -12,18 +12,19 @@ import sqlite3
 import string
 import subprocess
 import time
+from typing import Dict, List, Optional, Union
 
 
 class Sqlite3Db(object):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.path = path
 
-    def get_dsn(self):
+    def get_dsn(self) -> None:
         """SQLite3 doesn't provide a DSN, resulting in no CLI-option.
         """
         return None
 
-    def query(self, query):
+    def query(self, query: str) -> Union[List[Dict[str, Union[int, bytes]]], List[Dict[str, Optional[int]]], List[Dict[str, str]], List[Dict[str, Union[str, int]]], List[Dict[str, int]]]:
         orig = os.path.join(self.path)
         copy = self.path + ".copy"
         shutil.copyfile(orig, copy)
@@ -43,7 +44,7 @@ class Sqlite3Db(object):
         db.close()
         return result
 
-    def execute(self, query):
+    def execute(self, query: str) -> None:
         db = sqlite3.connect(self.path)
         c = db.cursor()
         c.execute(query)
@@ -90,20 +91,20 @@ class PostgresDb(object):
 
 
 class SqliteDbProvider(object):
-    def __init__(self, directory):
+    def __init__(self, directory: str) -> None:
         self.directory = directory
 
-    def start(self):
+    def start(self) -> None:
         pass
 
-    def get_db(self, node_directory, testname, node_id):
+    def get_db(self, node_directory: str, testname: str, node_id: int) -> Sqlite3Db:
         path = os.path.join(
             node_directory,
             'lightningd.sqlite3'
         )
         return Sqlite3Db(path)
 
-    def stop(self):
+    def stop(self) -> None:
         pass
 
 

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1,10 +1,10 @@
-from bitcoin.core import COIN
-from bitcoin.rpc import RawProxy as BitcoinProxy
+from bitcoin.core import COIN  # type: ignore
+from bitcoin.rpc import RawProxy as BitcoinProxy  # type: ignore
 from pyln.client import RpcError
 from pyln.testing.btcproxy import BitcoinRpcProxy
 from collections import OrderedDict
 from decimal import Decimal
-from ephemeral_port_reserve import reserve
+from ephemeral_port_reserve import reserve  # type: ignore
 from pyln.client import LightningRpc
 from pyln.client import Millisatoshi
 


### PR DESCRIPTION
This adds `mypy` verification to `pyln-client` and `pyln-testing`, while also restructuring the Makefiles a bit.

I added the verification to the pyln module Makefiles and call it from the main Makefile in order to maintain logical separation between the main codebase and the python modules, which we might end up splitting out into a separate repository eventually.

I started annotating `pyln-proto` but the `messages` and `invoice` module turned out to be a rather deep rabbit-hole that need more refactoring. It is integrated into the main Makefile and progress can be checked with `make check-pyln-proto`, so I'll spin this out into a separate issue.

I chose to ignore any external dependency that doesn't have annotation stubs in the [typeshed](https://github.com/python/typeshed) repository since creating those stubs would be another major time drain.

`pyln-spec` doesn't have any type-annotations yet, so we don't run them either :wink:

Fixes #4085
Changelog-None