### PR TITLE
Re-enable postgres test configuration after addressing issue 4080

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ env:
 
   # Various other configurations
   - VALGRIND=0 ARCH=64 DEVELOPER=1 NETWORK=liquid-regtest
-  # FIXME: this fails almost all the time!
-#  - VALGRIND=0 ARCH=64 DEVELOPER=1 DB=postgres
+  - VALGRIND=0 ARCH=64 DEVELOPER=1 DB=postgres
   - VALGRIND=0 ARCH=arm32v7 DEVELOPER=1 TARGET_HOST=arm-linux-gnueabihf
   - VALGRIND=0 ARCH=arm64v8 DEVELOPER=1 TARGET_HOST=aarch64-linux-gnu
 cache:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -56,7 +56,7 @@ if [ "$NO_PYTHON" != 1 ]; then
 
    cat > pytest.ini << EOF
 [pytest]
-addopts=-p no:logging --color=no --reruns=5
+addopts=-p no:logging --color=no --reruns=2 -x
 EOF
 fi
 

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -26,8 +26,16 @@ def test_base_dir():
 
     yield directory
 
-    if os.listdir(directory) == []:
+    # Now check if any test directory is left because the corresponding test
+    # failed. If there are no such tests we can clean up the root test
+    # directory.
+    contents = [d for d in os.listdir(directory) if os.path.isdir(d) and d.startswith('test_')]
+    if contents == []:
         shutil.rmtree(directory)
+    else:
+        print("Leaving base_dir {} intact, it still has test sub-directories with failure details: {}".format(
+            directory, contents
+        ))
 
 
 @pytest.fixture(autouse=True)

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -316,7 +316,7 @@ providers = {
 }
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def db_provider(test_base_dir):
     provider = providers[os.getenv('TEST_DB_PROVIDER', 'sqlite3')](test_base_dir)
     provider.start()


### PR DESCRIPTION
This should help locate and fix any issue that was casing the `TEST_DB_PROVIDER=postgres` test configuration on Travis CI to fail. In order to do this we reduce `--reruns` from 5 to 2, potentially showing more flaky tests, but we should address them anyway, and we fail on the first error we get, since the rest of the test run is doomed anyway, and the extra information about which other tests would also fail is not worth the extra wait time.

The `db_provider` fixture goes from being session-scoped to being test-scoped, so we start and stop a separate instance of postgresql on each test, but measuring the performance impact showed a mere slowdown of 20 seconds on a 1250 second overall test-time, so negligible. On the upside it massively improves test isolation, and we no longer have to worry about scheduling two tests with huge numbers of nodes concurrently exhausting the connection backlog of the shared postgresql instance. This change has absolutely no impact on `TEST_DB_PROVIDER=sqlite3` configurations.

It also turns out that we weren't cleaning the temporary test directory in postgres configurations because the postgres server was leaving its data directory in there, blocking the cleanup. This is now fixed.

Fixes #4080
Changelog-None