### PR TITLE
Change mutual close feerate to be much less aggressive.

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -343,14 +343,6 @@ The percentage of \fIestimatesmartfee 2/CONSERVATIVE\fR to use for the commitmen
 transactions: default is 100\.
 
 
- \fBcommit-fee-min\fR=\fIPERCENT\fR
- \fBcommit-fee-max\fR=\fIPERCENT\fR
-Limits on what onchain fee range we’ll allow when a node opens a channel
-with us, as a percentage of \fIestimatesmartfee 2\fR\. If they’re outside
-this range, we abort their opening attempt\. Note that \fBcommit-fee-max\fR
-can (should!) be greater than 100\.
-
-
  \fBmax-concurrent-htlcs\fR=\fIINTEGER\fR
 Number of HTLCs one channel can handle concurrently in each direction\.
 Should be between 1 and 483 (default 30)\.
@@ -589,4 +581,4 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 
-\" SHA256STAMP:8e80667950a40a059a3a320a095c2313bc99b00de06bb892c47f22cf458d6493
+\" SHA256STAMP:9d72136e5abae6cb8f36899ebaeed6644ea566e95ec1a6f8b13cc911ed64a294

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -280,13 +280,6 @@ opens a channel before the channel is usable.
 The percentage of *estimatesmartfee 2/CONSERVATIVE* to use for the commitment
 transactions: default is 100.
 
- **commit-fee-min**=*PERCENT*
- **commit-fee-max**=*PERCENT*
-Limits on what onchain fee range we’ll allow when a node opens a channel
-with us, as a percentage of *estimatesmartfee 2*. If they’re outside
-this range, we abort their opening attempt. Note that **commit-fee-max**
-can (should!) be greater than 100.
-
  **max-concurrent-htlcs**=*INTEGER*
 Number of HTLCs one channel can handle concurrently in each direction.
 Should be between 1 and 483 (default 30).

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -26,12 +26,6 @@ struct config {
 	/* How many confirms until we consider an anchor "settled". */
 	u32 anchor_confirms;
 
-	/* Maximum percent of fee rate we'll accept. */
-	u32 commitment_fee_max_percent;
-
-	/* Minimum percent of fee rate we'll accept. */
-	u32 commitment_fee_min_percent;
-
 	/* Minimum CLTV to subtract from incoming HTLCs to outgoing */
 	u32 cltv_expiry_delta;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -610,10 +610,6 @@ static const struct config testnet_config = {
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 1,
 
-	/* Testnet fees are crazy, allow infinite feerange. */
-	.commitment_fee_min_percent = 0,
-	.commitment_fee_max_percent = 0,
-
 	/* Testnet blockspace is free. */
 	.max_concurrent_htlcs = 483,
 
@@ -657,10 +653,6 @@ static const struct config mainnet_config = {
 
 	/* We're fairly trusting, under normal circumstances. */
 	.anchor_confirms = 3,
-
-	/* Insist between 2 and 20 times the 2-block fee. */
-	.commitment_fee_min_percent = 200,
-	.commitment_fee_max_percent = 2000,
 
 	/* While up to 483 htlcs are possible we do 30 by default (as eclair does) to save blockspace */
 	.max_concurrent_htlcs = 30,
@@ -707,13 +699,6 @@ static const struct config mainnet_config = {
 
 static void check_config(struct lightningd *ld)
 {
-	/* We do this by ensuring it's less than the minimum we would accept. */
-	if (ld->config.commitment_fee_max_percent != 0
-	    && ld->config.commitment_fee_max_percent
-	    < ld->config.commitment_fee_min_percent)
-		fatal("Commitment fee invalid min-max %u-%u",
-		      ld->config.commitment_fee_min_percent,
-		      ld->config.commitment_fee_max_percent);
 	/* BOLT #2:
 	 *
 	 * The receiving node MUST fail the channel if:
@@ -861,12 +846,6 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--funding-confirms", opt_set_u32, opt_show_u32,
 			 &ld->config.anchor_confirms,
 			 "Confirmations required for funding transaction");
-	opt_register_arg("--commit-fee-min=<percent>", opt_set_u32, opt_show_u32,
-			 &ld->config.commitment_fee_min_percent,
-			 "Minimum percentage of fee to accept for commitment");
-	opt_register_arg("--commit-fee-max=<percent>", opt_set_u32, opt_show_u32,
-			 &ld->config.commitment_fee_max_percent,
-			 "Maximum percentage of fee to accept for commitment (0 for unlimited)");
 	opt_register_arg("--cltv-delta", opt_set_u32, opt_show_u32,
 			 &ld->config.cltv_expiry_delta,
 			 "Number of blocks for cltv_expiry_delta");

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -498,7 +498,7 @@ static struct command_result *estimatefees_final_step(struct bitcoin_cli *bcli)
 
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_u64(response, "opening", stash->normal);
-	json_add_u64(response, "mutual_close", stash->normal);
+	json_add_u64(response, "mutual_close", stash->slow);
 	json_add_u64(response, "unilateral_close",
 		     stash->very_urgent * bitcoind->commit_fee_percent / 100);
 	json_add_u64(response, "delayed_to_us", stash->normal);

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -19,7 +19,7 @@ import unittest
 def test_closing(node_factory, bitcoind, chainparams):
     l1, l2 = node_factory.line_graph(2)
     chan = l1.get_channel_scid(l2)
-    fee = basic_fee(7500) if not chainparams['elements'] else 8955
+    fee = basic_fee(3750) if not chainparams['elements'] else 4477
 
     l1.pay(l2, 200000000)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1484,15 +1484,16 @@ def test_feerates(node_factory):
     assert feerates['perkw']['max_acceptable'] == 15000 * 10
     assert feerates['perkw']['min_acceptable'] == 253
 
-    # Set ECONOMICAL/4 feerate, for all but min
+    # Set ECONOMICAL/4 feerate, for all but min (so, no mutual_close feerate)
     l1.set_feerates((15000, 11000, 6250, 0), True)
-    wait_for(lambda: len(l1.rpc.feerates('perkb')['perkb']) == len(types) + 2)
+    wait_for(lambda: len(l1.rpc.feerates('perkb')['perkb']) == len(types) - 1 + 2)
     feerates = l1.rpc.feerates('perkb')
     assert feerates['perkb']['unilateral_close'] == 15000 * 4
     assert feerates['perkb']['htlc_resolution'] == 11000 * 4
     assert feerates['perkb']['penalty'] == 11000 * 4
+    assert 'mutual_close' not in feerates['perkb']
     for t in types:
-        if t not in ("unilateral_close", "htlc_resolution", "penalty"):
+        if t not in ("unilateral_close", "htlc_resolution", "penalty", "mutual_close"):
             assert feerates['perkb'][t] == 25000
     assert feerates['warning_missing_feerates'] == 'Some fee estimates unavailable: bitcoind startup?'
     assert 'perkw' not in feerates
@@ -1506,8 +1507,9 @@ def test_feerates(node_factory):
     assert feerates['perkw']['unilateral_close'] == 15000
     assert feerates['perkw']['htlc_resolution'] == 11000
     assert feerates['perkw']['penalty'] == 11000
+    assert feerates['perkw']['mutual_close'] == 5000
     for t in types:
-        if t not in ("unilateral_close", "htlc_resolution", "penalty"):
+        if t not in ("unilateral_close", "htlc_resolution", "penalty", "mutual_close"):
             assert feerates['perkw'][t] == 25000 // 4
     assert 'warning' not in feerates
     assert 'perkb' not in feerates

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1598,8 +1598,8 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
             {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'channel_mvt', 'credit': 0, 'debit': 100000000, 'tag': 'routed'},
             {'type': 'channel_mvt', 'credit': 50000501, 'debit': 0, 'tag': 'routed'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 8955501, 'tag': 'chain_fees'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 941045000, 'tag': 'withdrawal'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 4477501, 'tag': 'chain_fees'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 945523000, 'tag': 'withdrawal'},
         ]
 
         l2_wallet_mvts = [
@@ -1612,7 +1612,7 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
             {'type': 'chain_mvt', 'credit': 0, 'debit': 8100000, 'tag': 'chain_fees'},
             {'type': 'chain_mvt', 'credit': 991900000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'chain_mvt', 'credit': 100001000, 'debit': 0, 'tag': 'deposit'},
-            {'type': 'chain_mvt', 'credit': 941045000, 'debit': 0, 'tag': 'deposit'},
+            {'type': 'chain_mvt', 'credit': 945523000, 'debit': 0, 'tag': 'deposit'},
         ]
     elif EXPERIMENTAL_FEATURES:
         # option_anchor_outputs
@@ -1620,8 +1620,8 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
             {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'channel_mvt', 'credit': 0, 'debit': 100000000, 'tag': 'routed'},
             {'type': 'channel_mvt', 'credit': 50000501, 'debit': 0, 'tag': 'routed'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 8430501, 'tag': 'chain_fees'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 941570000, 'tag': 'withdrawal'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 4215501, 'tag': 'chain_fees'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 945785000, 'tag': 'withdrawal'},
         ]
 
         l2_wallet_mvts = [
@@ -1635,15 +1635,15 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
             {'type': 'chain_mvt', 'credit': 0, 'debit': 4575000, 'tag': 'chain_fees'},
             {'type': 'chain_mvt', 'credit': 995425000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'chain_mvt', 'credit': 100001000, 'debit': 0, 'tag': 'deposit'},
-            {'type': 'chain_mvt', 'credit': 941570000, 'debit': 0, 'tag': 'deposit'},
+            {'type': 'chain_mvt', 'credit': 945785000, 'debit': 0, 'tag': 'deposit'},
         ]
     else:
         l2_l3_mvts = [
             {'type': 'chain_mvt', 'credit': 1000000000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'channel_mvt', 'credit': 0, 'debit': 100000000, 'tag': 'routed'},
             {'type': 'channel_mvt', 'credit': 50000501, 'debit': 0, 'tag': 'routed'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 5430501, 'tag': 'chain_fees'},
-            {'type': 'chain_mvt', 'credit': 0, 'debit': 944570000, 'tag': 'withdrawal'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 2715501, 'tag': 'chain_fees'},
+            {'type': 'chain_mvt', 'credit': 0, 'debit': 947285000, 'tag': 'withdrawal'},
         ]
 
         l2_wallet_mvts = [
@@ -1657,7 +1657,7 @@ def test_coin_movement_notices(node_factory, bitcoind, chainparams):
             {'type': 'chain_mvt', 'credit': 0, 'debit': 4575000, 'tag': 'chain_fees'},
             {'type': 'chain_mvt', 'credit': 995425000, 'debit': 0, 'tag': 'deposit'},
             {'type': 'chain_mvt', 'credit': 100001000, 'debit': 0, 'tag': 'deposit'},
-            {'type': 'chain_mvt', 'credit': 944570000, 'debit': 0, 'tag': 'deposit'},
+            {'type': 'chain_mvt', 'credit': 947285000, 'debit': 0, 'tag': 'deposit'},
         ]
 
     l1, l2, l3 = node_factory.line_graph(3, opts=[


### PR DESCRIPTION
Using bitcoind's `estimatesmartfee 4 ECONOMICAL` is extremely aggressive for mutual close; particularly since you can use CPFP if you really want to speed it along.  Drop to `100 ECONOMICAL` (i.e. "slow") by default.