### PR TITLE
pytest: fix flaky test.

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1736,6 +1736,7 @@ def test_onchain_their_unilateral_out(node_factory, bitcoind):
     l2.bitcoin.generate_block(9)
     l1.wait_for_onchaind_broadcast('OUR_HTLC_TIMEOUT_TO_US',
                                    'THEIR_UNILATERAL/OUR_HTLC')
+    l2.daemon.wait_for_log('Ignoring output .*_UNILATERAL/THEIR_HTLC')
 
     err = q.get(timeout=10)
     if err:


### PR DESCRIPTION
l2 only gives up 100 blocks after it ignores the HTLC, so sometimes
this test fails.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>