### PR TITLE
openingd/: Fail `fundchannel_start` if we already are, or will become, the fundee.

### DIFF
--- a/lightningd/opening_common.c
+++ b/lightningd/opening_common.c
@@ -55,6 +55,8 @@ new_uncommitted_channel(struct peer *peer)
 	uc->peer->uncommitted_channel = uc;
 	tal_add_destructor(uc, destroy_uncommitted_channel);
 
+	uc->got_offer = false;
+
 	return uc;
 }
 

--- a/lightningd/opening_common.h
+++ b/lightningd/opening_common.h
@@ -46,6 +46,11 @@ struct uncommitted_channel {
 	/* Public key for funding tx. */
 	struct pubkey local_funding_pubkey;
 
+	/* If true, we are already in fundee-mode and any future
+	 * `fundchannel_start` on our end should fail.
+	 */
+	bool got_offer;
+
 	/* These are *not* filled in by new_uncommitted_channel: */
 
 	/* Minimum funding depth (if opener == REMOTE). */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2759,3 +2759,20 @@ def test_channel_opener(node_factory):
     l1.rpc.close(l2.rpc.getinfo()["id"])
     assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'local')
     assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'remote')
+
+
+@pytest.mark.xfail(strict=True)
+def test_fundchannel_start_alternate(node_factory, executor):
+    ''' Test to see what happens if two nodes start channeling to
+    each other alternately.
+    Issue #4108
+    '''
+    l1, l2 = node_factory.get_nodes(2)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    l1.rpc.fundchannel_start(l2.info['id'], 100000)
+
+    fut = executor.submit(l2.rpc.fundchannel_start, l1.info['id'], 100000)
+    with pytest.raises(RpcError):
+        fut.result(10)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2761,7 +2761,6 @@ def test_channel_opener(node_factory):
     assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'remote')
 
 
-@pytest.mark.xfail(strict=True)
 def test_fundchannel_start_alternate(node_factory, executor):
     ''' Test to see what happens if two nodes start channeling to
     each other alternately.


### PR DESCRIPTION
Fixes: #4108

Requesting review from nifty and rusty, since my grasp of the openingd is not good.

As well, there may be a similar issue in dual-funding, so please consider as well for that point-of-view, I am much more ignorant about the dual-funding flow than openingd flow.