### PR TITLE
Fuzz testing integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ test/test_protocol
 test/test_sphinx
 tests/.pytest.restart
 tests/plugins/test_libplugin
+tests/fuzz/fuzz-*
+!tests/fuzz/fuzz-*.c
 gossip_store
 .pytest_cache
 tools/headerversions

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ ifneq ($(ASAN),0)
 SANITIZER_FLAGS += -fsanitize=address
 endif
 
+ifneq ($(UBSAN),0)
+SANITIZER_FLAGS += -fsanitize=undefined
+endif
+
 ifneq ($(FUZZING), 0)
 SANITIZER_FLAGS += -fsanitize=fuzzer-no-link
 endif

--- a/common/base64.c
+++ b/common/base64.c
@@ -14,24 +14,3 @@ char *b64_encode(const tal_t *ctx, const u8 *data, size_t len)
 								len, sodium_base64_VARIANT_ORIGINAL);
 	return str;
 }
-
-u8 *b64_decode(const tal_t *ctx, const char *str, size_t len)
-{
-	size_t bin_len = len + 1;
-
-	u8 *ret = tal_arr(ctx, u8, bin_len);
-
-	if (!sodium_base642bin(ret,
-				tal_count(ret),
-				(const char * const)str,
-				len,
-				NULL,
-				&bin_len,
-				NULL,
-				sodium_base64_VARIANT_ORIGINAL))
-			return tal_free(ret);
-
-	ret[bin_len] = 0;
-	tal_resize(&ret, bin_len + 1);
-	return ret;
-}

--- a/common/base64.h
+++ b/common/base64.h
@@ -5,6 +5,5 @@
 #include <ccan/tal/tal.h>
 
 char *b64_encode(const tal_t *ctx, const u8 *data, size_t len);
-u8 *b64_decode(const tal_t *ctx, const char *str, size_t len);
 
 #endif /* LIGHTNING_COMMON_BASE64_H */

--- a/common/test/run-amount.c
+++ b/common/test/run-amount.c
@@ -128,7 +128,6 @@ int main(void)
 	PASS_MSAT(&msat, "1.234567890btc", 123456789000);
 	PASS_MSAT(&msat, "1.2345678901btc", 123456789010);
 	PASS_MSAT(&msat, "1.23456789012btc", 123456789012);
-	FAIL_MSAT(&msat, "1btc");
 	FAIL_MSAT(&msat, "1.000000000000btc");
 	FAIL_MSAT(&msat, "-1.23456789btc");
 	FAIL_MSAT(&msat, "-1.23456789012btc");
@@ -177,7 +176,6 @@ int main(void)
 	PASS_SAT(&sat, "1.2345678btc", 123456780);
 	PASS_SAT(&sat, "1.23456789btc", 123456789);
 	FAIL_SAT(&sat, "1.234567890btc");
-	FAIL_SAT(&sat, "1btc");
 	FAIL_SAT(&sat, "-1.23456789btc");
 
 	/* Overflowingly big. */

--- a/configure
+++ b/configure
@@ -120,6 +120,7 @@ set_defaults()
     CONFIGURATOR_CC=${CONFIGURATOR_CC-$CC}
     VALGRIND=${VALGRIND:-$(default_valgrind_setting)}
     TEST_NETWORK=${TEST_NETWORK:-regtest}
+    FUZZING=${FUZZING:-0}
 }
 
 usage()
@@ -155,6 +156,7 @@ usage()
     echo "    Static link sqlite3, gmp and zlib libraries"
     usage_with_default "--enable/disable-address-sanitizer" "$ASAN" "enable" "disable"
     echo "    Compile with address-sanitizer"
+    usage_with_default "--enable/disable-fuzzing" "$FUZZING" "enable" "disable"
     exit 1
 }
 
@@ -206,6 +208,8 @@ for opt in "$@"; do
 	--disable-static) STATIC=0;;
 	--enable-address-sanitizer) ASAN=1;;
 	--disable-address-sanitizer) ASAN=0;;
+	--enable-fuzzing) FUZZING=1;;
+	--disable-fuzzing) FUZZING=0;;
 	--help|-h) usage;;
 	*)
 	    echo "Unknown option '$opt'" >&2
@@ -228,6 +232,18 @@ if [ "$ASAN" = "1" ]; then
 	exit 1
     fi
 fi
+
+if [ "$FUZZING" = "1" ]; then
+	case "$CC" in
+		(*"clang"*)
+			;;
+		(*)
+			echo "Fuzzing is currently only supported with clang."
+			exit 1
+			;;
+	esac
+fi
+
 
 SQLITE3_CFLAGS=""
 SQLITE3_LDLIBS="-lsqlite3"
@@ -400,6 +416,7 @@ add_var ASAN "$ASAN"
 add_var TEST_NETWORK "$TEST_NETWORK"
 add_var HAVE_PYTHON3_MAKO "$HAVE_PYTHON3_MAKO"
 add_var SHA256SUM "$SHA256SUM"
+add_var FUZZING "$FUZZING"
 
 # Hack to avoid sha256 name clash with libwally: will be fixed when that
 # becomes a standalone shared lib.

--- a/configure
+++ b/configure
@@ -115,6 +115,7 @@ set_defaults()
     COMPAT=${COMPAT:-1}
     STATIC=${STATIC:-0}
     ASAN=${ASAN:-0}
+    UBSAN=${UBSAN:-0}
     PYTEST=${PYTEST-$(default_pytest)}
     COPTFLAGS=${COPTFLAGS-$(default_coptflags "$DEVELOPER")}
     CONFIGURATOR_CC=${CONFIGURATOR_CC-$CC}
@@ -156,6 +157,8 @@ usage()
     echo "    Static link sqlite3, gmp and zlib libraries"
     usage_with_default "--enable/disable-address-sanitizer" "$ASAN" "enable" "disable"
     echo "    Compile with address-sanitizer"
+    usage_with_default "--enable/disable-ub-sanitizer" "$UBSAN" "enable" "disable"
+    echo "    Compile with undefined behaviour sanitizer"
     usage_with_default "--enable/disable-fuzzing" "$FUZZING" "enable" "disable"
     exit 1
 }
@@ -208,6 +211,8 @@ for opt in "$@"; do
 	--disable-static) STATIC=0;;
 	--enable-address-sanitizer) ASAN=1;;
 	--disable-address-sanitizer) ASAN=0;;
+	--enable-ub-sanitizer) UBSAN=1;;
+	--disable-ub-sanitize) UBSAN=0;;
 	--enable-fuzzing) FUZZING=1;;
 	--disable-fuzzing) FUZZING=0;;
 	--help|-h) usage;;
@@ -413,6 +418,7 @@ add_var COMPAT "$COMPAT" $CONFIG_HEADER
 add_var PYTEST "$PYTEST"
 add_var STATIC "$STATIC"
 add_var ASAN "$ASAN"
+add_var UBSAN "$UBSAN"
 add_var TEST_NETWORK "$TEST_NETWORK"
 add_var HAVE_PYTHON3_MAKO "$HAVE_PYTHON3_MAKO"
 add_var SHA256SUM "$SHA256SUM"

--- a/contrib/sanitizer_suppressions/asan
+++ b/contrib/sanitizer_suppressions/asan
@@ -1,3 +1,0 @@
-# process_check_funding_broadcast is racy as it operates on a data that may be
-# freed under its feet
-interceptor_via_fun:process_check_funding_broadcast

--- a/doc/FUZZING.md
+++ b/doc/FUZZING.md
@@ -1,0 +1,69 @@
+# Fuzz testing
+
+C-lightning currently supports coverage-guided fuzz testing using [LLVM's libfuzzer](https://www.llvm.org/docs/LibFuzzer.html)
+when built with `clang`.
+
+The goal of fuzzing is to generate mutated -and often unexpected- inputs (`seed`s) to pass
+to (parts of) a program (`target`) in order to make sure the codepaths used:
+- do not crash
+- are valid (if combined with sanitizers)
+The generated seeds can be stored and form a `corpus`, which we try to optimise (don't
+store two seeds that lead to the same codepath).
+
+For more info about fuzzing see [here](https://github.com/google/fuzzing/tree/master/docs),
+and for more about `libfuzzer` in particular see [here](https://www.llvm.org/docs/LibFuzzer.html).
+
+
+## Build the fuzz targets
+
+In order to build the C-lightning binaries with code coverage you will need a recent
+[clang](http://clang.llvm.org/). The more recent the compiler version the better.
+
+Then you'll need to enable support at configuration time. You likely want to enable
+a few sanitizers for bug detections as well as experimental features for an extended
+coverage (not required though).
+
+```
+DEVELOPER=1 EXPERIMENTAL_FEATURES=1 ASAN=1 UBSAN=1 VALGRIND=0 FUZZING=1 CC=clang ./configure && make
+```
+
+The targets will be built in `tests/fuzz/` as `fuzz-` binaries.
+
+
+## Run one or more target(s)
+
+You can run each target independently. Pass `-help=1` to see available options, for
+example:
+```
+./tests/fuzz/fuzz-addr -help=1
+```
+
+Otherwise, you can use the Python runner to either run the targets against a given seed
+corpus:
+```
+./tests/fuzz/run.py fuzz_corpus -j2
+```
+Or extend this corpus:
+```
+./tests/fuzz/run.py fuzz_corpus -j2 --generate --runs 12345
+```
+
+The latter will run all targets two by two `12345` times.
+
+If you want to contribute new seeds, be sure to merge your corpus with the main one:
+```
+./tests/fuzz/run.py my_locally_extended_fuzz_corpus -j2 --generate --runs 12345
+./tests/fuzz/run.py main_fuzz_corpus --merge_dir my_locally_extended_fuzz_corpus
+```
+
+
+## Write new fuzzing targets
+
+In order to write a new target:
+ - include the `libfuzz.h` header
+ - fill two functions: `init()` for static stuff and `run()` which will be called
+     repeatedly with mutated data.
+ - read about [what makes a good fuzz target](https://github.com/google/fuzzing/blob/master/docs/good-fuzz-target.md).
+
+A simple example is [`fuzz-addr`](tests/fuzz/fuzz-addr.c). It setups the chainparams and
+context (wally, tmpctx, ..) in `init()` then bruteforces the bech32 encoder in `run()`.

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -13,6 +13,7 @@ FUZZ_COMMON_OBJS :=					\
 	common/base32.o					\
 	common/base64.o					\
 	common/bech32.o					\
+	common/bip32.o					\
 	common/bigsize.o				\
 	common/json.o					\
 	common/json_stream.o				\

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -15,6 +15,7 @@ FUZZ_COMMON_OBJS :=					\
 	common/bech32.o					\
 	common/bip32.o					\
 	common/bigsize.o				\
+	common/channel_id.o				\
 	common/json.o					\
 	common/json_stream.o				\
 	common/wireaddr.o				\

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -7,12 +7,7 @@ FUZZ_TARGETS_SRC := $(wildcard tests/fuzz/fuzz-*.c)
 FUZZ_TARGETS_OBJS := $(FUZZ_TARGETS_SRC:.c=.o)
 FUZZ_TARGETS_BIN := $(FUZZ_TARGETS_SRC:.c=)
 
-FUZZ_COMMON_OBJS :=			\
-	common/utils.o
-$(FUZZ_TARGETS_OBJS): $(COMMON_HEADERS) $(WIRE_HEADERS) $(COMMON_SRC)
-$(FUZZ_TARGETS_BIN): $(LIBFUZZ_OBJS) $(FUZZ_COMMON_OBJS) $(BITCOIN_OBJS)
-
-tests/fuzz/fuzz-addr:					\
+FUZZ_COMMON_OBJS :=					\
 	common/amount.o					\
 	common/addr.o					\
 	common/base32.o					\
@@ -22,9 +17,12 @@ tests/fuzz/fuzz-addr:					\
 	common/json_stream.o				\
 	common/wireaddr.o				\
 	common/type_to_string.o				\
+	common/utils.o					\
 	wire/fromwire.o					\
 	wire/onion_wiregen.o				\
 	wire/towire.o
+$(FUZZ_TARGETS_OBJS): $(COMMON_HEADERS) $(WIRE_HEADERS) $(COMMON_SRC)
+$(FUZZ_TARGETS_BIN): $(LIBFUZZ_OBJS) $(FUZZ_COMMON_OBJS) $(BITCOIN_OBJS)
 
 ALL_C_SOURCES += $(FUZZ_TARGETS_SRC) $(LIBFUZZ_SRC)
 ALL_FUZZ_TARGETS += $(FUZZ_TARGETS_BIN)

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -1,0 +1,30 @@
+LIBFUZZ_SRC := tests/fuzz/libfuzz.c
+LIBFUZZ_HEADERS := $(LIBFUZZ_SRC:.c=.h)
+LIBFUZZ_OBJS := $(LIBFUZZ_SRC:.c=.o)
+
+
+FUZZ_TARGETS_SRC := $(wildcard tests/fuzz/fuzz-*.c)
+FUZZ_TARGETS_OBJS := $(FUZZ_TARGETS_SRC:.c=.o)
+FUZZ_TARGETS_BIN := $(FUZZ_TARGETS_SRC:.c=)
+
+FUZZ_COMMON_OBJS :=			\
+	common/utils.o
+$(FUZZ_TARGETS_OBJS): $(COMMON_HEADERS) $(WIRE_HEADERS) $(COMMON_SRC)
+$(FUZZ_TARGETS_BIN): $(LIBFUZZ_OBJS) $(FUZZ_COMMON_OBJS) $(BITCOIN_OBJS)
+
+tests/fuzz/fuzz-addr:					\
+	common/amount.o					\
+	common/addr.o					\
+	common/base32.o					\
+	common/bech32.o					\
+	common/bigsize.o				\
+	common/json.o					\
+	common/json_stream.o				\
+	common/wireaddr.o				\
+	common/type_to_string.o				\
+	wire/fromwire.o					\
+	wire/onion_wiregen.o				\
+	wire/towire.o
+
+ALL_C_SOURCES += $(FUZZ_TARGETS_SRC) $(LIBFUZZ_SRC)
+ALL_FUZZ_TARGETS += $(FUZZ_TARGETS_BIN)

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -11,6 +11,7 @@ FUZZ_COMMON_OBJS :=					\
 	common/amount.o					\
 	common/addr.o					\
 	common/base32.o					\
+	common/base64.o					\
 	common/bech32.o					\
 	common/bigsize.o				\
 	common/json.o					\

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -15,10 +15,13 @@ FUZZ_COMMON_OBJS :=					\
 	common/bech32.o					\
 	common/bip32.o					\
 	common/bigsize.o				\
+	common/close_tx.o				\
 	common/channel_id.o				\
+	common/permute_tx.o				\
 	common/json.o					\
 	common/json_stream.o				\
 	common/wireaddr.o				\
+	common/setup.o					\
 	common/type_to_string.o				\
 	common/utils.o					\
 	wire/fromwire.o					\

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -7,7 +7,7 @@ FUZZ_TARGETS_SRC := $(wildcard tests/fuzz/fuzz-*.c)
 FUZZ_TARGETS_OBJS := $(FUZZ_TARGETS_SRC:.c=.o)
 FUZZ_TARGETS_BIN := $(FUZZ_TARGETS_SRC:.c=)
 
-FUZZ_COMMON_OBJS :=					\
+FUZZ_COMMON_OBJS := \
 	common/amount.o					\
 	common/addr.o					\
 	common/base32.o					\
@@ -15,18 +15,40 @@ FUZZ_COMMON_OBJS :=					\
 	common/bech32.o					\
 	common/bip32.o					\
 	common/bigsize.o				\
+	common/channel_config.o				\
 	common/close_tx.o				\
 	common/channel_id.o				\
+	common/daemon.o					\
+	common/daemon_conn.o				\
+	common/derive_basepoints.o			\
+	common/fee_states.o				\
+	common/htlc_state.o				\
 	common/permute_tx.o				\
+	common/initial_channel.o			\
+	common/initial_commit_tx.o			\
 	common/json.o					\
 	common/json_stream.o				\
+	common/key_derive.o				\
+	common/keyset.o					\
+	common/msg_queue.o				\
+	common/memleak.o				\
+	common/node_id.o				\
 	common/wireaddr.o				\
 	common/setup.o					\
+	common/status.o					\
+	common/status_wire.o				\
+	common/status_wiregen.o				\
 	common/type_to_string.o				\
 	common/utils.o					\
+	common/version.o				\
 	wire/fromwire.o					\
 	wire/onion_wiregen.o				\
-	wire/towire.o
+	wire/peer_wire.o				\
+	wire/peer_wiregen.o				\
+	wire/towire.o					\
+	wire/wire_io.o					\
+	wire/wire_sync.o
+
 $(FUZZ_TARGETS_OBJS): $(COMMON_HEADERS) $(WIRE_HEADERS) $(COMMON_SRC)
 $(FUZZ_TARGETS_BIN): $(LIBFUZZ_OBJS) $(FUZZ_COMMON_OBJS) $(BITCOIN_OBJS)
 

--- a/tests/fuzz/fuzz-addr.c
+++ b/tests/fuzz/fuzz-addr.c
@@ -1,0 +1,22 @@
+#include "common/utils.h"
+#include <stdint.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/ccan/tal/tal.h>
+#include <common/addr.h>
+#include <common/setup.h>
+
+void init(int *argc, char ***argv)
+{
+	chainparams = chainparams_for_network("bitcoin");
+	common_setup("fuzzer");
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	uint8_t *script_pubkey = tal_dup_arr(tmpctx, uint8_t, data, size, 0);
+
+	encode_scriptpubkey_to_addr(tmpctx, chainparams, script_pubkey);
+
+	clean_tmpctx();
+}

--- a/tests/fuzz/fuzz-amount.c
+++ b/tests/fuzz/fuzz-amount.c
@@ -1,0 +1,61 @@
+#include <assert.h>
+#include <stdint.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/tal/tal.h>
+#include <common/amount.h>
+#include <common/utils.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	struct amount_msat msat;
+	struct amount_sat sat;
+	char *string;
+	uint8_t *buf;
+	const char *fmt_msat, *fmt_msatbtc, *fmt_sat, *fmt_satbtc;
+
+
+	/* We should not crash when parsing any string. */
+
+	string = tal_arr(NULL, char, size);
+	for (size_t i = 0; i < size; i++)
+		string[i] = (char) data[i] % (CHAR_MAX + 1);
+
+	parse_amount_msat(&msat, string, tal_count(string));
+	parse_amount_sat(&sat, string, tal_count(string));
+	tal_free(string);
+
+
+	/* Same with the wire primitives. */
+
+	buf = tal_arr(NULL, uint8_t, 8);
+
+	msat = fromwire_amount_msat(&data, &size);
+	towire_amount_msat(&buf, msat);
+	sat = fromwire_amount_sat(&data, &size);
+	towire_amount_sat(&buf, sat);
+
+	tal_free(buf);
+
+
+	/* Format should inconditionally produce valid amount strings according to our
+	 * parser */
+
+	fmt_msat = fmt_amount_msat(NULL, &msat);
+	fmt_msatbtc = fmt_amount_msat_btc(NULL, &msat, true);
+	assert(parse_amount_msat(&msat, fmt_msat, tal_count(fmt_msat)));
+	assert(parse_amount_msat(&msat, fmt_msatbtc, tal_count(fmt_msatbtc)));
+	tal_free(fmt_msat);
+	tal_free(fmt_msatbtc);
+
+	fmt_sat = fmt_amount_sat(NULL, &sat);
+	fmt_satbtc = fmt_amount_sat_btc(NULL, &sat, true);
+	assert(parse_amount_sat(&sat, fmt_sat, tal_count(fmt_sat)));
+	assert(parse_amount_sat(&sat, fmt_satbtc, tal_count(fmt_satbtc)));
+	tal_free(fmt_sat);
+	tal_free(fmt_satbtc);
+}

--- a/tests/fuzz/fuzz-base32-64.c
+++ b/tests/fuzz/fuzz-base32-64.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <common/base32.h>
+#include <common/base64.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	char *encoded;
+	uint8_t *decoded;
+
+	encoded = b32_encode(NULL, data, size);
+	decoded = b32_decode(NULL, encoded, strlen(encoded));
+	assert(memcmp(decoded, data, size) == 0);
+	tal_free(encoded);
+	tal_free(decoded);
+
+	encoded = b64_encode(NULL, data, size);
+	tal_free(encoded);
+}

--- a/tests/fuzz/fuzz-bech32.c
+++ b/tests/fuzz/fuzz-bech32.c
@@ -1,0 +1,50 @@
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <common/bech32.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	const char hrp_inv[5] = "lnbc\0", hrp_addr[3] = "bc\0";
+	char *bech32_str, *hrp_out, *addr;
+	uint8_t *data_out;
+	size_t data_out_len;
+	int wit_version;
+
+	/* Buffer size is defined in each function's doc comment. */
+	bech32_str = malloc(size + strlen(hrp_inv) + 8);
+	/* FIXME: needs a dictionary / a startup seed corpus to pass this more
+	 * frequently. */
+	if (bech32_encode(bech32_str, hrp_inv, data, size, size) == 1) {
+		hrp_out = malloc(strlen(bech32_str) - 6);
+		data_out = malloc(strlen(bech32_str) - 8);
+		bech32_decode(hrp_out, data_out, &data_out_len, bech32_str, size);
+		free(hrp_out);
+		free(data_out);
+	}
+	free(bech32_str);
+
+	data_out = malloc(size);
+
+	/* This is also used as part of sign and check message. */
+	data_out_len = 0;
+	bech32_convert_bits(data_out, &data_out_len, 8, data, size, 5, 1);
+	data_out_len = 0;
+	bech32_convert_bits(data_out, &data_out_len, 8, data, size, 5, 0);
+
+	addr = malloc(73 + strlen(hrp_addr));
+	wit_version = 0;
+	if (segwit_addr_encode(addr, hrp_addr, wit_version, data, size) == 1)
+		segwit_addr_decode(&wit_version, data_out, &data_out_len, hrp_addr, addr);
+	wit_version = 1;
+	if (segwit_addr_encode(addr, hrp_addr, wit_version, data, size) == 1)
+		segwit_addr_decode(&wit_version, data_out, &data_out_len, hrp_addr, addr);
+	free(addr);
+
+	free(data_out);
+}

--- a/tests/fuzz/fuzz-bigsize.c
+++ b/tests/fuzz/fuzz-bigsize.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/tal/tal.h>
+#include <common/bigsize.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	uint8_t *wire_buff, buff[BIGSIZE_MAX_LEN];
+	const uint8_t **wire_chunks, *wire_ptr;
+	size_t wire_max;
+
+	wire_chunks = get_chunks(NULL, data, size, 8);
+	for (size_t i = 0; i < tal_count(wire_chunks); i++) {
+		wire_max = tal_count(wire_chunks[i]);
+		wire_ptr = wire_chunks[i];
+
+		bigsize_t bs = fromwire_bigsize(&wire_ptr, &wire_max);
+		if (bs != 0) {
+			/* We have a valid bigsize type, now we should not error. */
+			assert(bigsize_put(buff, bs) > 0);
+			assert(bigsize_len(bs));
+
+			wire_buff = tal_arr(NULL, uint8_t, 8);
+			towire_bigsize(&wire_buff, bs);
+			tal_free(wire_buff);
+		}
+	}
+	tal_free(wire_chunks);
+}

--- a/tests/fuzz/fuzz-bip32.c
+++ b/tests/fuzz/fuzz-bip32.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/tal/tal.h>
+#include <common/bip32.h>
+#include <wally_bip32.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	struct ext_key xkey;
+	struct bip32_key_version version;
+	u8 *wire_buff;
+	const uint8_t **xkey_chunks, **ver_chunks, *wire_ptr;
+	size_t wire_max;
+
+	if (size < BIP32_SERIALIZED_LEN)
+		return;
+
+	xkey_chunks = get_chunks(NULL, data, size, BIP32_SERIALIZED_LEN);
+	for (size_t i = 0; i < tal_count(xkey_chunks); i++) {
+		wire_max = tal_bytelen(xkey_chunks[i]);
+		wire_ptr = xkey_chunks[i];
+
+		fromwire_ext_key(&wire_ptr, &wire_max, &xkey);
+		if (wire_ptr) {
+			wire_buff = tal_arr(NULL, uint8_t, BIP32_SERIALIZED_LEN);
+			towire_ext_key(&wire_buff, &xkey);
+			tal_free(wire_buff);
+		}
+	}
+	tal_free(xkey_chunks);
+
+	ver_chunks = get_chunks(NULL, data, size, 4);
+	for (size_t i = 0; i < tal_count(ver_chunks); i++) {
+		wire_max = tal_bytelen(ver_chunks[i]);
+		wire_ptr = ver_chunks[i];
+
+		fromwire_bip32_key_version(&wire_ptr, &wire_max, &version);
+		if (wire_ptr) {
+			wire_buff = tal_arr(NULL, uint8_t, 4);
+			towire_bip32_key_version(&wire_buff, &version);
+			tal_free(wire_buff);
+		}
+	}
+	tal_free(ver_chunks);
+}

--- a/tests/fuzz/fuzz-channel_id.c
+++ b/tests/fuzz/fuzz-channel_id.c
@@ -1,0 +1,70 @@
+#include <assert.h>
+#include <bitcoin/pubkey.h>
+#include <bitcoin/tx.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/tal/tal.h>
+#include <common/channel_id.h>
+#include <wire/wire.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	struct channel_id chan_id;
+	struct pubkey basepoint_1, basepoint_2;
+	struct bitcoin_txid txid;
+	uint16_t vout;
+	const uint8_t **v1_chunks, **v2_chunks, **marshal_chunks;
+	const uint8_t *wire_ptr;
+	size_t wire_max;
+	uint8_t *wire_buf;
+
+	if (size < 34)
+		return;
+
+	/* 32 (txid) + 2 (vout ala LN) */
+	v1_chunks = get_chunks(NULL, data, size, 34);
+	for (size_t i = 0; i < tal_count(v1_chunks); i++) {
+		wire_ptr = v1_chunks[i];
+		wire_max = 32;
+		fromwire_bitcoin_txid(&wire_ptr, &wire_max, &txid);
+		assert(wire_ptr);
+		wire_max = 2;
+		vout = fromwire_u16(&wire_ptr, &wire_max);
+		derive_channel_id(&chan_id, &txid, vout);
+	}
+	tal_free(v1_chunks);
+
+	v2_chunks = get_chunks(NULL, data, size, PUBKEY_CMPR_LEN * 2);
+	for (size_t i = 0; i < tal_count(v2_chunks); i++) {
+		wire_ptr = v2_chunks[i];
+		wire_max = PUBKEY_CMPR_LEN;
+		fromwire_pubkey(&wire_ptr, &wire_max, &basepoint_1);
+		if (!wire_ptr)
+			continue;
+
+		wire_max = PUBKEY_CMPR_LEN;
+		fromwire_pubkey(&wire_ptr, &wire_max, &basepoint_2);
+		if (!wire_ptr)
+			continue;
+
+		derive_channel_id_v2(&chan_id, &basepoint_1, &basepoint_2);
+	}
+	tal_free(v2_chunks);
+
+	marshal_chunks = get_chunks(NULL, data, size, 32);
+	for (size_t i = 0; i < tal_count(marshal_chunks); i++) {
+		wire_ptr = marshal_chunks[i];
+		wire_max = tal_count(marshal_chunks[i]);
+		fromwire_channel_id(&wire_ptr, &wire_max, &chan_id);
+		wire_buf = tal_arr(NULL, uint8_t, tal_count(marshal_chunks[i]));
+		towire_channel_id(&wire_buf, &chan_id);
+		tal_free(wire_buf);
+	}
+	tal_free(marshal_chunks);
+}

--- a/tests/fuzz/fuzz-close_tx.c
+++ b/tests/fuzz/fuzz-close_tx.c
@@ -1,0 +1,92 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <bitcoin/pubkey.h>
+#include <bitcoin/chainparams.h>
+#include <bitcoin/script.h>
+#include <bitcoin/tx.h>
+#include <ccan/tal/tal.h>
+#include <common/amount.h>
+#include <common/close_tx.h>
+#include <common/setup.h>
+#include <common/utils.h>
+#include <wire/wire.h>
+
+void init(int *argc, char ***argv)
+{
+	common_setup("fuzzer");
+	chainparams = chainparams_for_network("bitcoin");
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	const uint8_t *wire_ptr;
+	size_t wire_max, min_size, script_size;
+	struct bitcoin_txid txid;
+	uint32_t vout;
+	struct amount_sat funding, to_us, to_them, dust_limit, max;
+	const uint8_t *our_script, *their_script, *funding_script;
+	struct pubkey *pk1, *pk2;
+
+	/* create_close_tx wants:
+	 * - 3 scripts: 3 * N bytes
+	 * - 1 txid: 32 bytes
+	 * - 1 u32: 4 bytes
+	 * - 4 amount_sat: 4 * 8 bytes
+	 *
+	 * Since both output scripts size are not restricted, we also try
+	 * to vary their length.
+	 * Therefore, we allocate the entire remaining bytes to scripts.
+	 */
+	min_size = 8 * 3 + 4 + 32;
+	if (size < min_size + 2)
+		return;
+
+	script_size = (size - min_size) / 2;
+	wire_ptr = data;
+
+	wire_max = 8;
+	to_us = fromwire_amount_sat(&wire_ptr, &wire_max);
+	assert(wire_ptr);
+	wire_max = 8;
+	to_them = fromwire_amount_sat(&wire_ptr, &wire_max);
+	assert(wire_ptr);
+	wire_max = 8;
+	dust_limit = fromwire_amount_sat(&wire_ptr, &wire_max);
+	/* The funding must be > to_us + to_them (TODO: we could simulate some fees) .. */
+	if (!(amount_sat_add(&funding, to_us, to_them)))
+		return;
+	/* .. And < max_btc as we assert it's not nonsensical! */
+	max = AMOUNT_SAT((u32)WALLY_SATOSHI_PER_BTC * WALLY_BTC_MAX);
+	if (amount_sat_greater(funding, max)) {
+		funding = max;
+		to_us = amount_sat_div(max, 2);
+		to_them = amount_sat_div(max, 2);
+	}
+
+	wire_max = 4;
+	vout = fromwire_u32(&wire_ptr, &wire_max);
+	wire_max = 32;
+	fromwire_bitcoin_txid(&wire_ptr, &wire_max, &txid);
+
+	our_script = tal_dup_arr(tmpctx, const uint8_t, wire_ptr, script_size, 0);
+	their_script = tal_dup_arr(tmpctx, const uint8_t, wire_ptr + script_size,
+				   script_size, 0);
+
+	/* We assert it's valid, so we can't throw garbage at the funding script.. */
+	pk1 = tal(tmpctx, struct pubkey);
+	pk2 = tal(tmpctx, struct pubkey);
+	pubkey_from_hexstr("034fede2c619f647fe7c01d40ae22e4c285291ca2ffb47937bbfb7d6e8285a081f",
+			   PUBKEY_CMPR_LEN, pk1);
+	pubkey_from_hexstr("028dfe31019dd61fa04c76ad065410e5d063ac2949c04c14b214c1b363e517452f",
+			   PUBKEY_CMPR_LEN, pk2);
+	funding_script = bitcoin_redeem_2of2(tmpctx, pk1, pk2);
+
+	create_close_tx(tmpctx, chainparams, our_script,
+			their_script, funding_script, &txid,
+			vout, funding, to_us, to_them, dust_limit);
+
+	clean_tmpctx();
+}

--- a/tests/fuzz/fuzz-initial_channel.c
+++ b/tests/fuzz/fuzz-initial_channel.c
@@ -1,0 +1,80 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <bitcoin/pubkey.h>
+#include <bitcoin/chainparams.h>
+#include <bitcoin/script.h>
+#include <bitcoin/tx.h>
+#include <ccan/tal/tal.h>
+#include <common/amount.h>
+#include <common/fee_states.h>
+#include <common/initial_channel.h>
+#include <common/setup.h>
+#include <common/status.h>
+#include <common/utils.h>
+#include <stdio.h>
+#include <wire/wire.h>
+
+void init(int *argc, char ***argv)
+{
+	common_setup("fuzzer");
+	int devnull = open("/dev/null", O_WRONLY);
+	status_setup_sync(devnull);
+	chainparams = chainparams_for_network("bitcoin");
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	struct channel_id cid;
+	struct bitcoin_txid funding_txid;
+	u32 funding_txout, minimum_depth;
+	struct amount_sat funding, max;
+	struct amount_msat local_msatoshi;
+	u32 feerate_per_kw;
+	struct channel_config local, remote;
+	struct basepoints local_basepoints, remote_basepoints;
+	struct pubkey local_funding_pubkey, remote_funding_pubkey;
+	bool option_static_remotekey, option_anchor_outputs;
+	struct channel *channel;
+
+	fromwire_channel_id(&data, &size, &cid);
+	fromwire_bitcoin_txid(&data, &size, &funding_txid);
+	funding_txout = fromwire_u32(&data, &size);
+	minimum_depth = fromwire_u32(&data, &size);
+	funding = fromwire_amount_sat(&data, &size);
+	local_msatoshi = fromwire_amount_msat(&data, &size);
+	max = AMOUNT_SAT((u32)WALLY_SATOSHI_PER_BTC * WALLY_BTC_MAX);
+	if (amount_sat_greater(funding, max))
+		funding = max;
+	feerate_per_kw = fromwire_u32(&data, &size);
+	fromwire_channel_config(&data, &size, &local);
+	fromwire_channel_config(&data, &size, &remote);
+	fromwire_basepoints(&data, &size, &local_basepoints);
+	fromwire_basepoints(&data, &size, &remote_basepoints);
+	fromwire_pubkey(&data, &size, &local_funding_pubkey);
+	fromwire_pubkey(&data, &size, &remote_funding_pubkey);
+	option_anchor_outputs = fromwire_bool(&data, &size);
+	option_static_remotekey = option_anchor_outputs || fromwire_bool(&data, &size);
+
+	/* TODO: determine if it makes sense to check at each step for libfuzzer
+	 * to deduce pertinent inputs */
+	if (!data || !size)
+		return;
+
+	for (enum side opener = 0; opener < NUM_SIDES; opener++) {
+		channel = new_initial_channel(tmpctx, &cid, &funding_txid, funding_txout,
+					      minimum_depth, funding, local_msatoshi,
+					      take(new_fee_states(NULL, opener, &feerate_per_kw)),
+					      &local, &remote, &local_basepoints,
+					      &remote_basepoints, &local_funding_pubkey,
+					      &remote_funding_pubkey, option_static_remotekey,
+					      option_anchor_outputs, opener);
+
+		/* TODO: make initial_channel_tx() work with ASAN.. */
+	}
+
+	clean_tmpctx();
+}

--- a/tests/fuzz/libfuzz.c
+++ b/tests/fuzz/libfuzz.c
@@ -1,5 +1,9 @@
 #include <tests/fuzz/libfuzz.h>
 
+#include <ccan/tal/tal.h>
+#include <common/utils.h>
+#include <string.h>
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 int LLVMFuzzerInitialize(int *argc, char ***argv);
 
@@ -13,4 +17,17 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 	init(argc, argv);
 
 	return 0;
+}
+
+const uint8_t **get_chunks(const void *ctx, const uint8_t *data,
+			  size_t data_size, size_t chunk_size)
+{
+	size_t n_chunks = data_size / chunk_size;
+	const uint8_t **chunks = tal_arr(ctx, const uint8_t *, n_chunks);
+
+	for (size_t i = 0; i < n_chunks; i++)
+		chunks[i] = tal_dup_arr(chunks, const uint8_t,
+					data + i * chunk_size, chunk_size, 0);
+
+	return chunks;
 }

--- a/tests/fuzz/libfuzz.c
+++ b/tests/fuzz/libfuzz.c
@@ -1,0 +1,16 @@
+#include <tests/fuzz/libfuzz.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+int LLVMFuzzerInitialize(int *argc, char ***argv);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	run(data, size);
+
+	return 0;
+}
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+	init(argc, argv);
+
+	return 0;
+}

--- a/tests/fuzz/libfuzz.h
+++ b/tests/fuzz/libfuzz.h
@@ -1,0 +1,18 @@
+#ifndef LIGHTNING_TESTS_FUZZ_LIBFUZZ_H
+#define LIGHTNING_TESTS_FUZZ_LIBFUZZ_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Called once before running the target. Use it to setup the testing
+ * environment. */
+void init(int *argc, char ***argv);
+
+/* The actual target called multiple times with mutated data. */
+void run(const uint8_t *data, size_t size);
+
+/* Copy an array of chunks from data. */
+const uint8_t **get_chunks(const void *ctx, const uint8_t *data,
+			  size_t data_size, size_t chunk_size);
+
+#endif /* LIGHTNING_TESTS_FUZZ_LIBFUZZ_H */

--- a/tests/fuzz/run.py
+++ b/tests/fuzz/run.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import os
+import re
+import subprocess
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def job(command):
+    """Takes a list of str, and runs it as a subprocess."""
+    command_line = " ".join(command)
+    logging.debug(f"Running '{command_line}'\n")
+    res = subprocess.run(command, check=True, stderr=subprocess.PIPE,
+                         universal_newlines=True).stderr
+    logging.debug(f"Command '{command_line} output:\n'{res}'")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run the fuzz targets a given amount of times, or generate"
+                    " new seeds.",
+    )
+    parser.add_argument(
+        "seed_dir",
+        help="The parent directory for the seed corpora of each target.",
+    )
+    parser.add_argument("-g", "--generate", action="store_true")
+    parser.add_argument(
+        "-j",
+        "--par",
+        type=int,
+        default=1,
+        help="How many targets to run in parallel.",
+    )
+    parser.add_argument(
+        "-n",
+        "--runs",
+        default=100000,
+        help="How many times to run each target (if generating).",
+    )
+    parser.add_argument(
+        "-m",
+        "--merge_dir",
+        default=None,
+        help="The parent directory to merge each target corpus from.",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    target_dir = os.path.abspath(os.path.dirname(__file__))
+    targets = [os.path.join(target_dir, f) for f in os.listdir(target_dir)
+               if re.compile(r"^fuzz-[\w-]*$").findall(f)]
+    with ThreadPoolExecutor(max_workers=args.par) as pool:
+        jobs = []
+        runs = args.runs if args.generate else 1
+
+        for target in targets:
+            seed_dir = os.path.join(args.seed_dir, os.path.basename(target))
+            os.makedirs(seed_dir, exist_ok=True)
+            command = [
+                target,
+                f"-runs={runs}" if args.merge_dir is None else "-merge=1",
+                seed_dir,
+            ]
+            if args.merge_dir is not None:
+                input_target = os.path.join(args.merge_dir,
+                                            os.path.basename(target))
+                if not os.path.exists(input_target):
+                    continue
+                command.append(input_target)
+            jobs.append(pool.submit(job, command))
+
+        for completed in as_completed(jobs):
+            completed.result()


### PR DESCRIPTION
This introduces coverage-guided fuzz testing using [libfuzzer](https://www.llvm.org/docs/LibFuzzer.html).

## Why

We've been[ talking about it](https://github.com/ElementsProject/lightning/issues/2662) for some time now, and i'm sure it could help us to uncover trivial bugs with minimal overhead, more sneaky ones more easily than with unit tests, and finally to avoid regressions by maintaining a seed corpus to ran patches against.

Going further, [structure-aware fuzzing](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md) could help us with [Bitcoin Script creation](https://github.com/jonasnick/bitcoinconsensus_testcases) or even with the state machine  which while more intrusive because crypto seems plausible because of the daemons separation and messages.

For now, this PR only introduces the basis for integration with primitives and rudimentary targets (i focused on `common/`). Still, this found some bugs (eg amounts string parsing / formatting) and new targets could help with e.g. our JSON parser or the [gossip store](https://github.com/ElementsProject/lightning/issues?q=is%3Aissue+corrupt+gossip_store).


## Integration

This extends our `tests/` directory by moving the Python functional tests to the `tests/functional/` subdirectory (sorry for the conflicts..) and creates a new sub: `tests/fuzz/`.

Inspired by the unit tests, all targets are named `fuzz-[target_name]`.
Not inspired by the unit tests, all targets are built in `tests/fuzz/`. Even though there are only `common/`-specific targets for now, i think it makes sense to keep them contained in a single directory.

A `libfuzz.h` abstracts out the interface to libFuzzer for potential future support for other fuzzers, and `run.py` allows to manage them in batches. This was inspired by the integration in bitcoin-core but i guess it's a pretty common pattern.


## What next

- a)
I propose to create a new repository (eg in https://github.com/lightningd/ ?) for tracking the seed corpus that we could update if we generate new coverage locally.
This could be pulled in a new CI job that checks PRs against each [target + seeds] once to check for regression. What do you think about using Github Action for this ?
- b)
Write more targets
- c)
Generate more coverage
- d)
Go to b) :)