### PR TITLE
openingd: patch test_opening_tiny_channel under EXP_FEAT

### DIFF
--- a/openingd/common.c
+++ b/openingd/common.c
@@ -69,7 +69,6 @@ bool check_config_bounds(const tal_t *ctx,
 	 */
 	/* (We simply include in "reserve" here if they opened). */
 	if (option_anchor_outputs
-	    && !am_opener
 	    && !amount_sat_add(&reserve, reserve, AMOUNT_SAT(660))) {
 		*err_reason = tal_fmt(ctx,
 				      "cannot add anchors to reserve %s",


### PR DESCRIPTION
`test_opening_tiny_channel` fails if EXPERIMENTAL_FEATURES is on because
we don't include the anchor in our reserve if we're the channel opener.

Seems fine to include in all cases?