### PR TITLE
Expose `close_to` up through `multifundchannel` + `fundchannel`

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -657,12 +657,13 @@ class LightningRpc(UnixDomainSocketRpc):
         Only select outputs with {minconf} confirmations.
         If {utxos} is specified (as a list of 'txid:vout' strings),
         fund a channel from these specifics utxos.
+        {close_to} is a valid Bitcoin address.
         """
 
         if 'satoshi' in kwargs:
             return self._deprecated_fundchannel(node_id, *args, **kwargs)
 
-        def _fundchannel(node_id, amount, feerate=None, announce=True, minconf=None, utxos=None, push_msat=None):
+        def _fundchannel(node_id, amount, feerate=None, announce=True, minconf=None, utxos=None, push_msat=None, close_to=None):
             payload = {
                 "id": node_id,
                 "amount": amount,
@@ -670,7 +671,8 @@ class LightningRpc(UnixDomainSocketRpc):
                 "announce": announce,
                 "minconf": minconf,
                 "utxos": utxos,
-                "push_msat": push_msat
+                "push_msat": push_msat,
+                "close_to": close_to,
             }
             return self.call("fundchannel", payload)
 

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -754,7 +754,8 @@ class LightningNode(object):
                       "LightningNode.fundchannel", category=DeprecationWarning)
         return self.fundchannel(l2, amount, wait_for_active, announce_channel)
 
-    def fundchannel(self, l2, amount, wait_for_active=True, announce_channel=True):
+    def fundchannel(self, l2, amount, wait_for_active=True,
+                    announce_channel=True, **kwargs):
         # Give yourself some funds to work with
         addr = self.rpc.newaddr()['bech32']
 
@@ -775,7 +776,9 @@ class LightningNode(object):
         wait_for(lambda: has_funds_on_addr(addr))
 
         # Now go ahead and open a channel
-        res = self.rpc.fundchannel(l2.info['id'], amount, announce=announce_channel)
+        res = self.rpc.fundchannel(l2.info['id'], amount,
+                                   announce=announce_channel,
+                                   **kwargs)
         wait_for(lambda: res['txid'] in self.bitcoin.rpc.getrawmempool())
         self.bitcoin.generate_block(1)
 

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -790,7 +790,7 @@ class LightningNode(object):
             self.wait_channel_active(scid)
             l2.wait_channel_active(scid)
 
-        return scid
+        return scid, res
 
     def subd_pid(self, subd, peerid=None):
         """Get the process id of the given subdaemon, eg channeld or gossipd"""

--- a/doc/lightning-fundchannel.7
+++ b/doc/lightning-fundchannel.7
@@ -4,7 +4,7 @@ lightning-fundchannel - Command for establishing a lightning channel
 .SH SYNOPSIS
 
 \fBfundchannel\fR \fIid\fR \fIamount\fR [\fIfeerate\fR \fIannounce\fR] [\fIminconf\fR]
-[\fIutxos\fR] [\fIpush_msat\fR]
+[\fIutxos\fR] [\fIpush_msat\fR] [\fIclose_to\fR]
 
 .SH DESCRIPTION
 
@@ -66,12 +66,22 @@ open\. Note that this is a gift to the peer -- these satoshis are
 added to the initial balance of the peer at channel start and are largely
 unrecoverable once pushed\.
 
+
+\fIclose_to\fR is a Bitcoin address to which the channel funds should be sent to
+on close\. Only valid if both peers have negotiated \fBoption_upfront_shutdown_script\fR\.
+Returns \fBclose_to\fR set to closing script iff is negotiated\.
+
 .SH RETURN VALUE
 
 On success, the \fItx\fR and \fItxid\fR of the transaction is returned, as well
 as the \fIoutnum\fR indicating the output index which creates the channel, as well
 as the \fIchannel_id\fR of the newly created channel\. On failure, an error
 is reported and the channel is not funded\.
+
+
+If a \fBclose_to\fR address was provided, will close to this address
+iff the \fBclose_to\fR script is returned in the response\. Otherwise,
+the peer does not support \fBoption_upfront_shutdownscript\fR\.
 
 
 The following error codes may occur:
@@ -102,4 +112,4 @@ channel parameters (funding limits, channel reserves, fees, etc\.)\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:f885008c6e60738b1ec9c5def19cc0877b0f9a72498ffa60e9fb3277ed9d9919
+\" SHA256STAMP:05dff04e52740da20760c2501ed7958d646750284f6a55904ca39c4ca69c46fc

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -5,7 +5,7 @@ SYNOPSIS
 --------
 
 **fundchannel** *id* *amount* \[*feerate* *announce*\] \[*minconf*\]
-\[*utxos*\] \[*push_msat*\]
+\[*utxos*\] \[*push_msat*\] \[*close_to*\]
 
 DESCRIPTION
 -----------
@@ -60,6 +60,10 @@ open. Note that this is a gift to the peer -- these satoshis are
 added to the initial balance of the peer at channel start and are largely
 unrecoverable once pushed.
 
+*close_to* is a Bitcoin address to which the channel funds should be sent to
+on close. Only valid if both peers have negotiated `option_upfront_shutdown_script`.
+Returns `close_to` set to closing script iff is negotiated.
+
 RETURN VALUE
 ------------
 
@@ -67,6 +71,10 @@ On success, the *tx* and *txid* of the transaction is returned, as well
 as the *outnum* indicating the output index which creates the channel, as well
 as the *channel\_id* of the newly created channel. On failure, an error
 is reported and the channel is not funded.
+
+If a `close_to` address was provided, will close to this address
+iff the `close_to` script is returned in the response. Otherwise,
+the peer does not support `option_upfront_shutdownscript`.
 
 The following error codes may occur:
 - -1: Catchall nonspecific error.

--- a/doc/lightning-multifundchannel.7
+++ b/doc/lightning-multifundchannel.7
@@ -53,6 +53,11 @@ If set to \fBfalse\fR, the channel is unpublished\.
 node\.
 This is a gift to the peer, and you do not get a proof-of-payment
 out of this\.
+.IP \[bu]
+\fIclose_to\fR is a Bitcoin address to which the channel funds should be sent to
+on close\. Only valid if both peers have negotiated
+\fBoption_upfront_shutdown_script\fR\.  Returns \fBclose_to\fR set to
+closing script iff is negotiated\.
 
 .RE
 
@@ -167,4 +172,4 @@ ZmnSCPxj \fI<ZmnSCPxj@protonmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:c4bf503a2f8d981131960bedc07e9f08a0b65246964852a34df4292a9a36b663
+\" SHA256STAMP:70be8ab919df4a69f18103dcf3d1067e4b1d7466eb69ca474ffae3ea1f8d0ae1

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -47,6 +47,10 @@ Readiness is indicated by **listpeers** reporting a *state* of
   node.
   This is a gift to the peer, and you do not get a proof-of-payment
   out of this.
+* *close_to* is a Bitcoin address to which the channel funds should be sent to
+  on close. Only valid if both peers have negotiated
+  `option_upfront_shutdown_script`.  Returns `close_to` set to
+  closing script iff is negotiated.
 
 There must be at least one entry in *destinations*;
 it cannot be an empty array.

--- a/plugins/spender/fundchannel.c
+++ b/plugins/spender/fundchannel.c
@@ -41,6 +41,7 @@ json_fundchannel(struct command *cmd,
 	const jsmntok_t *minconf;
 	const jsmntok_t *utxos;
 	const jsmntok_t *push_msat;
+	const jsmntok_t *close_to;
 
 	struct out_req *req;
 
@@ -52,6 +53,7 @@ json_fundchannel(struct command *cmd,
 		   p_opt("minconf", param_tok, &minconf),
 		   p_opt("utxos", param_tok, &utxos),
 		   p_opt("push_msat", param_tok, &push_msat),
+		   p_opt("close_to", param_tok, &close_to),
 		   NULL))
 		return command_param_failed();
 
@@ -67,6 +69,8 @@ json_fundchannel(struct command *cmd,
 		json_add_tok(req->js, "announce", announce, buf);
 	if (push_msat)
 		json_add_tok(req->js, "push_msat", push_msat, buf);
+	if (close_to)
+		json_add_tok(req->js, "close_to", close_to, buf);
 	json_object_end(req->js);
 	json_array_end(req->js);
 	if (feerate)
@@ -92,6 +96,7 @@ fundchannel_get_result(struct command *cmd,
 	const jsmntok_t *channel_ids_obj;
 	const jsmntok_t *channel_id;
 	const jsmntok_t *outnum;
+	const jsmntok_t *close_to_script;
 
 	struct json_stream *out;
 
@@ -108,6 +113,10 @@ fundchannel_get_result(struct command *cmd,
 	ok = ok && channel_id;
 	outnum = ok ? json_get_member(buf, channel_ids_obj, "outnum") : NULL;
 	ok = ok && outnum;
+	close_to_script = ok ? json_get_member(buf, channel_ids_obj,
+					       "close_to")
+			     : NULL;
+
 
 	if (!ok)
 		plugin_err(cmd->plugin,
@@ -120,5 +129,7 @@ fundchannel_get_result(struct command *cmd,
 	json_add_tok(out, "txid", txid, buf);
 	json_add_tok(out, "channel_id", channel_id, buf);
 	json_add_tok(out, "outnum", outnum, buf);
+	if (close_to_script)
+		json_add_tok(out, "close_to", close_to_script, buf);
 	return command_finished(cmd, out);
 }

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -306,9 +306,9 @@ def test_closing_specified_destination(node_factory, bitcoind, chainparams):
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    chan12 = l1.fundchannel(l2, 10**6)
-    chan13 = l1.fundchannel(l3, 10**6)
-    chan14 = l1.fundchannel(l4, 10**6)
+    chan12, _ = l1.fundchannel(l2, 10**6)
+    chan13, _ = l1.fundchannel(l3, 10**6)
+    chan14, _ = l1.fundchannel(l4, 10**6)
 
     l1.pay(l2, 100000000)
     l1.pay(l3, 100000000)
@@ -1536,7 +1536,7 @@ def test_onchain_middleman(node_factory, bitcoind):
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l2.fundchannel(l1, 10**6)
-    c23 = l2.fundchannel(l3, 10**6)
+    c23, _ = l2.fundchannel(l3, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     # Make sure routes finalized.
@@ -1626,7 +1626,7 @@ def test_onchain_middleman_their_unilateral_in(node_factory, bitcoind):
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
     l2.fundchannel(l1, 10**6)
-    c23 = l2.fundchannel(l3, 10**6)
+    c23, _ = l2.fundchannel(l3, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     # Make sure routes finalized.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -406,7 +406,7 @@ def test_reconnect_no_update(node_factory, executor):
     l1.stop()
 
     # For closingd reconnection
-    scid = fundchannel_exec.result()
+    scid, _ = fundchannel_exec.result()
     l1.daemon.start()
     executor.submit(l1.rpc.close, scid, 0)
     l2.daemon.wait_for_log(r"closingd.* Retransmitting funding_locked for channel")
@@ -602,7 +602,7 @@ def test_shutdown_reconnect(node_factory):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    chan = l1.fundchannel(l2, 10**6)
+    chan, _ = l1.fundchannel(l2, 10**6)
     l1.pay(l2, 200000000)
 
     assert l1.bitcoin.rpc.getmempoolinfo()['size'] == 0
@@ -1721,7 +1721,7 @@ def test_fee_limits(node_factory, bitcoind):
 
     # Try with node which sets --ignore-fee-limits
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    chan = l1.fundchannel(l3, 10**6)
+    chan, _ = l1.fundchannel(l3, 10**6)
 
     # Kick off fee adjustment using HTLC.
     l1.pay(l3, 1000)
@@ -1754,7 +1754,7 @@ def test_update_fee_reconnect(node_factory, bitcoind):
     l2 = node_factory.get_node(may_reconnect=True,
                                feerates=(14000, 15000, 14000, 3750))
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chan = l1.fundchannel(l2, 10**6)
+    chan, _ = l1.fundchannel(l2, 10**6)
 
     # Make an HTLC just to get us to do feechanges.
     l1.pay(l2, 1000)
@@ -1804,7 +1804,7 @@ def test_multiple_channels(node_factory):
 
         l1.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
         l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
-        chan = l1.fundchannel(l2, 10**6)
+        chan, _ = l1.fundchannel(l2, 10**6)
 
         l1.rpc.close(chan)
 
@@ -1855,7 +1855,7 @@ def test_peerinfo(node_factory, bitcoind):
     assert l1.rpc.getpeer(l2.info['id'])['features'] == lfeatures
 
     # Fund a channel to force a node announcement
-    chan = l1.fundchannel(l2, 10**6)
+    chan, _ = l1.fundchannel(l2, 10**6)
     # Now proceed to funding-depth and do a full gossip round
     bitcoind.generate_block(5)
     l1.daemon.wait_for_logs(['Received node_announcement for node ' + l2.info['id']])

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -34,8 +34,8 @@ def test_gossip_pruning(node_factory, bitcoind):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
-    scid1 = l1.fundchannel(l2, 10**6)
-    scid2 = l2.fundchannel(l3, 10**6)
+    scid1, _ = l1.fundchannel(l2, 10**6)
+    scid2, _ = l2.fundchannel(l3, 10**6)
 
     bitcoind.generate_block(6)
 
@@ -80,7 +80,7 @@ def test_gossip_disable_channels(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2, opts=opts)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fundchannel(l2, 10**6)
+    scid, _ = l1.fundchannel(l2, 10**6)
     bitcoind.generate_block(5)
 
     def count_active(node):
@@ -121,7 +121,7 @@ def test_announce_address(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2, opts=[opts, {}])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fundchannel(l2, 10**6)
+    scid, _ = l1.fundchannel(l2, 10**6)
     bitcoind.generate_block(5)
 
     l1.wait_channel_active(scid)
@@ -146,7 +146,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
     before_anything = int(time.time())
 
     # Make a public channel.
-    chan12 = l1.fundchannel(l2, 10**5)
+    chan12, _ = l1.fundchannel(l2, 10**5)
     bitcoind.generate_block(5)
 
     l3.wait_for_channel_updates([chan12])
@@ -154,7 +154,7 @@ def test_gossip_timestamp_filter(node_factory, bitcoind):
 
     # Make another one, different timestamp.
     time.sleep(1)
-    chan23 = l2.fundchannel(l3, 10**5)
+    chan23, _ = l2.fundchannel(l3, 10**5)
     bitcoind.generate_block(5)
 
     l1.wait_for_channel_updates([chan23])
@@ -229,7 +229,7 @@ def test_connect_by_gossip(node_factory, bitcoind):
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
     # Nodes are gossiped only if they have channels
-    chanid = l2.fundchannel(l3, 10**6)
+    chanid, _ = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Let channel reach announcement depth
@@ -391,12 +391,12 @@ def test_gossip_persistence(node_factory, bitcoind):
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l3.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    scid12 = l1.fundchannel(l2, 10**6)
-    scid23 = l2.fundchannel(l3, 10**6)
+    scid12, _ = l1.fundchannel(l2, 10**6)
+    scid23, _ = l2.fundchannel(l3, 10**6)
 
     # Make channels public, except for l3 -> l4, which is kept local-only for now
     bitcoind.generate_block(5)
-    scid34 = l3.fundchannel(l4, 10**6)
+    scid34, _ = l3.fundchannel(l4, 10**6)
     bitcoind.generate_block(1)
 
     def active(node):
@@ -727,7 +727,7 @@ def test_gossip_query_channel_range(node_factory, bitcoind, chainparams):
     assert len(msgs) == 8
 
     # This should actually be large enough for zlib to kick in!
-    scid34 = l3.fundchannel(l4, 10**5)
+    scid34, _ = l3.fundchannel(l4, 10**5)
     bitcoind.generate_block(5)
     l2.daemon.wait_for_log('Received node_announcement for node ' + l4.info['id'])
 
@@ -780,7 +780,7 @@ def test_report_routing_failure(node_factory, bitcoind):
 
     def fund_from_to_payer(lsrc, ldst, lpayer):
         lsrc.rpc.connect(ldst.info['id'], 'localhost', ldst.port)
-        c = lsrc.fundchannel(ldst, 10000000)
+        c, _ = lsrc.fundchannel(ldst, 10000000)
         bitcoind.generate_block(5)
         lpayer.wait_for_channel_updates([c])
 
@@ -798,7 +798,8 @@ def test_report_routing_failure(node_factory, bitcoind):
         src.rpc.connect(dst.info['id'], 'localhost', dst.port)
         print("src={}, dst={}".format(src.daemon.lightning_dir,
                                       dst.daemon.lightning_dir))
-        channels.append(src.fundchannel(dst, 10**6))
+        c, _ = src.fundchannel(dst, 10**6)
+        channels.append(c)
     bitcoind.generate_block(5)
 
     for c in channels:
@@ -833,8 +834,8 @@ def test_query_short_channel_id(node_factory, bitcoind, chainparams):
     assert msgs[0] == '0106{}01'.format(chain_hash)
 
     # Make channels public.
-    scid12 = l1.fundchannel(l2, 10**5)
-    scid23 = l2.fundchannel(l3, 10**5)
+    scid12, _ = l1.fundchannel(l2, 10**5)
+    scid23, _ = l2.fundchannel(l3, 10**5)
     bitcoind.generate_block(5)
 
     # It will know about everything.
@@ -1196,7 +1197,7 @@ def test_getroute_exclude(node_factory, bitcoind):
 
     # Now, create an alternate (better) route.
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid = l2.fundchannel(l4, 1000000, wait_for_active=False)
+    scid, _ = l2.fundchannel(l4, 1000000, wait_for_active=False)
     bitcoind.generate_block(5)
 
     # We don't wait above, because we care about it hitting l1.
@@ -1231,9 +1232,9 @@ def test_getroute_exclude(node_factory, bitcoind):
         l1.rpc.getroute(l4.info['id'], 1, 1, exclude=[l3.info['id'], chan_l2l4])
 
     l1.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid15 = l1.fundchannel(l5, 1000000, wait_for_active=False)
+    scid15, _ = l1.fundchannel(l5, 1000000, wait_for_active=False)
     l5.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid54 = l5.fundchannel(l4, 1000000, wait_for_active=False)
+    scid54, _ = l5.fundchannel(l4, 1000000, wait_for_active=False)
     bitcoind.generate_block(5)
 
     # We don't wait above, because we care about it hitting l1.
@@ -1315,7 +1316,7 @@ def setup_gossip_store_test(node_factory, bitcoind):
     l1, l2, l3 = node_factory.line_graph(3, fundchannel=False)
 
     # Create channel.
-    scid23 = l2.fundchannel(l3, 10**6)
+    scid23, _ = l2.fundchannel(l3, 10**6)
 
     # Have that channel announced.
     bitcoind.generate_block(5)
@@ -1328,7 +1329,7 @@ def setup_gossip_store_test(node_factory, bitcoind):
     wait_for(lambda: sum([c['base_fee_millisatoshi'] for c in l2.rpc.listchannels()['channels']]) == 21)
 
     # Create another channel, which will stay private.
-    scid12 = l1.fundchannel(l2, 10**6)
+    scid12, _ = l1.fundchannel(l2, 10**6)
 
     # Now insert channel_update for previous channel; now they're both past the
     # node announcements.

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -211,7 +211,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # Attach public channel to l1 so it doesn't look like a dead-end.
     l0 = node_factory.get_node()
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    scid_dummy = l0.fundchannel(l1, 2 * (10**5))
+    scid_dummy, _ = l0.fundchannel(l1, 2 * (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.
@@ -267,7 +267,7 @@ def test_invoice_routeboost_private(node_factory, bitcoind):
     # The existence of a public channel, even without capacity, will suppress
     # the exposure of private channels.
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid2 = l3.fundchannel(l2, (10**5))
+    scid2, _ = l3.fundchannel(l2, (10**5))
     bitcoind.generate_block(5)
 
     # Make sure channel is totally public.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -347,7 +347,7 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chanid = l1.fundchannel(l2, 10**6)
+    chanid, _ = l1.fundchannel(l2, 10**6)
 
     # Wait for route propagation.
     l1.wait_channel_active(chanid)
@@ -414,7 +414,7 @@ def test_htlc_in_timeout(node_factory, bitcoind, executor):
     l2 = node_factory.get_node()
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    chanid = l1.fundchannel(l2, 10**6)
+    chanid, _ = l1.fundchannel(l2, 10**6)
 
     l1.wait_channel_active(chanid)
     sync_blockheight(bitcoind, [l1, l2])

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -175,9 +175,9 @@ def test_pay_exclude_node(node_factory, bitcoind):
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
     l4.rpc.connect(l5.info['id'], 'localhost', l5.port)
     l5.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    scid14 = l1.fundchannel(l4, 10**6, wait_for_active=False)
-    scid45 = l4.fundchannel(l5, 10**6, wait_for_active=False)
-    scid53 = l5.fundchannel(l3, 10**6, wait_for_active=False)
+    scid14, _ = l1.fundchannel(l4, 10**6, wait_for_active=False)
+    scid45, _ = l4.fundchannel(l5, 10**6, wait_for_active=False)
+    scid53, _ = l5.fundchannel(l3, 10**6, wait_for_active=False)
     bitcoind.generate_block(5)
 
     l1.daemon.wait_for_logs([r'update for channel {}/0 now ACTIVE'
@@ -349,7 +349,7 @@ def test_payment_success_persistence(node_factory, bitcoind, executor):
     l2 = node_factory.get_node(may_reconnect=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    chanid = l1.fundchannel(l2, 100000)
+    chanid, _ = l1.fundchannel(l2, 100000)
 
     inv1 = l2.rpc.invoice(1000, 'inv1', 'inv1')
 
@@ -1109,8 +1109,8 @@ def test_forward_different_fees_and_cltv(node_factory, bitcoind):
     l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
     l3.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
 
-    c1 = l1.fundchannel(l2, 10**6)
-    c2 = l2.fundchannel(l3, 10**6)
+    c1, _ = l1.fundchannel(l2, 10**6)
+    c2, _ = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Make sure l1 has seen announce for all channels.
@@ -1215,8 +1215,8 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     l2.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
     l3.daemon.wait_for_log('openingd-.*: Handed peer, entering loop')
 
-    c1 = l1.fundchannel(l2, 10**6)
-    c2 = l2.fundchannel(l3, 10**6)
+    c1, _ = l1.fundchannel(l2, 10**6)
+    c2, _ = l2.fundchannel(l3, 10**6)
     bitcoind.generate_block(5)
 
     # Make sure l1 has seen announce for all channels.
@@ -1380,10 +1380,10 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
     l2.rpc.connect(l5.info['id'], 'localhost', l5.port)
     l6.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    c12 = l1.fundchannel(l2, 10**6)
-    c23 = l2.fundchannel(l3, 10**6)
-    c24 = l2.fundchannel(l4, 10**6)
-    c25 = l2.fundchannel(l5, 10**4 * 3)
+    c12, _ = l1.fundchannel(l2, 10**6)
+    c23, _ = l2.fundchannel(l3, 10**6)
+    c24, _ = l2.fundchannel(l4, 10**6)
+    c25, _ = l2.fundchannel(l5, 10**4 * 3)
     l6.fundchannel(l1, 10**6)
 
     # Make sure routes finalized.
@@ -1653,14 +1653,14 @@ def test_pay_retry(node_factory, bitcoind, executor, chainparams):
     l2.fundchannel(l3, 10**6, wait_for_active=False)
     # scid34
     l3.fundchannel(l4, 10**6, wait_for_active=False)
-    scid45 = l4.fundchannel(l5, 10**6, wait_for_active=False)
+    scid45, _ = l4.fundchannel(l5, 10**6, wait_for_active=False)
 
     l1.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid15 = l1.fundchannel(l5, 10**6, wait_for_active=False)
+    scid15, _ = l1.fundchannel(l5, 10**6, wait_for_active=False)
     l2.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid25 = l2.fundchannel(l5, 10**6, wait_for_active=False)
+    scid25, _ = l2.fundchannel(l5, 10**6, wait_for_active=False)
     l3.rpc.connect(l5.info['id'], 'localhost', l5.port)
-    scid35 = l3.fundchannel(l5, 10**6, wait_for_active=False)
+    scid35, _ = l3.fundchannel(l5, 10**6, wait_for_active=False)
 
     # Make sure l1 sees all 7 channels
     bitcoind.generate_block(5)
@@ -1719,7 +1719,7 @@ def test_pay_routeboost(node_factory, bitcoind, compat):
         l1.rpc.pay(l5.rpc.invoice(10**8, 'test_retry', 'test_retry')['bolt11'])
 
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    scidl2l3 = l2.fundchannel(l3, 10**6)
+    scidl2l3, _ = l2.fundchannel(l3, 10**6)
 
     # Make sure l1 knows about the 2->3 channel.
     bitcoind.generate_block(5)
@@ -1787,7 +1787,7 @@ def test_pay_routeboost(node_factory, bitcoind, compat):
         # Finally, it should fall back to second routehint if first fails.
         # (Note, this is not public because it's not 6 deep)
         l3.rpc.connect(l5.info['id'], 'localhost', l5.port)
-        scid35 = l3.fundchannel(l5, 10**6)
+        scid35, _ = l3.fundchannel(l5, 10**6)
         l4.stop()
         routel3l5 = [{'id': l3.info['id'],
                       'short_channel_id': scid35,
@@ -1959,7 +1959,7 @@ def test_setchannelfee_state(node_factory, bitcoind):
     l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l0.fundchannel(l1, 1000000, wait_for_active=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid = l1.fundchannel(l2, 1000000, wait_for_active=False)
+    scid, _ = l1.fundchannel(l2, 1000000, wait_for_active=False)
 
     # try setting the fee in state AWAITING_LOCKIN should be possible
     # assert(l1.channel_state(l2) == "CHANNELD_AWAITING_LOCKIN")
@@ -2601,9 +2601,9 @@ def test_partial_payment(node_factory, bitcoind, executor):
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.fundchannel(l3, 100000)
     l2.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid24 = l2.fundchannel(l4, 100000)
+    scid24, _ = l2.fundchannel(l4, 100000)
     l3.rpc.connect(l4.info['id'], 'localhost', l4.port)
-    scid34 = l3.fundchannel(l4, 100000)
+    scid34, _ = l3.fundchannel(l4, 100000)
     bitcoind.generate_block(5)
 
     # Wait until l1 knows about all channels.
@@ -3263,7 +3263,7 @@ def test_mpp_presplit_routehint_conflict(node_factory, bitcoind):
     l1, l2, l3 = node_factory.get_nodes(3)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1l2 = l1.fundchannel(l2, 10**7, announce_channel=True)
+    l1l2, _ = l1.fundchannel(l2, 10**7, announce_channel=True)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l2.fundchannel(l3, 10**7, announce_channel=False)
 
@@ -3416,7 +3416,7 @@ def test_mpp_waitblockheight_routehint_conflict(node_factory, bitcoind, executor
     l1, l2, l3 = node_factory.get_nodes(3)
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    l1l2 = l1.fundchannel(l2, 10**7, announce_channel=True)
+    l1l2, _ = l1.fundchannel(l2, 10**7, announce_channel=True)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l2.fundchannel(l3, 10**7, announce_channel=False)
 


### PR DESCRIPTION
We've had `close_to` available on `fundchannel_start` for a while now. This wires it all the way through to general `fundchannel` users.