### PR TITLE
cleanups for some dual-funding related code, II of III

### DIFF
--- a/doc/lightning-openchannel_init.7
+++ b/doc/lightning-openchannel_init.7
@@ -48,7 +48,9 @@ sent on close\. Only valid if both peers have negotiated
 On success, returns the \fIchannel_id\fR for this channel; an updated
 incomplete \fIinitialpsbt\fR for this funding transaction; and the flag
 \fIcommitments_secured\fR, which indiciates the completeness of the 
-passed back \fIpsbt\fR\. (Will always be false)\.
+passed back \fIpsbt\fR\. (Will always be false)\. Also returns the
+\fIfunding_serial\fR, indicating the serial_id of the funding output
+in the \fIpsbt\fR\.
 
 
 If the peer does not support \fBoption_dual_fund\fR, this command
@@ -94,4 +96,4 @@ lightning-fundchannel_\fBstart\fR(7), lightning-fundchannel_\fBcomplete\fR(7),
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:a06dc67176c3c9863e4fc3048de7d0172eb79d091479415eb639335b3d096860
+\" SHA256STAMP:d73cf35c01e641d80688352058111421d9213b0a23043e9cdc807398442efd7a

--- a/doc/lightning-openchannel_init.7.md
+++ b/doc/lightning-openchannel_init.7.md
@@ -45,7 +45,9 @@ RETURN VALUE
 On success, returns the *channel_id* for this channel; an updated
 incomplete *initialpsbt* for this funding transaction; and the flag
 *commitments_secured*, which indiciates the completeness of the 
-passed back *psbt*. (Will always be false).
+passed back *psbt*. (Will always be false). Also returns the
+*funding_serial*, indicating the serial\_id of the funding output
+in the *psbt*.
 
 If the peer does not support `option_dual_fund`, this command
 will return an error.

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1057,7 +1057,9 @@ static struct command_result *json_open_channel_update(struct command *cmd,
 
 	if (!uc)
 		return command_fail(cmd, FUNDING_UNKNOWN_CHANNEL,
-				    "Unknown channel");
+				    "Unknown channel %s",
+				    type_to_string(tmpctx, struct channel_id,
+						   cid));
 
 	if (!uc->fc || !uc->fc->inflight)
 		return command_fail(cmd, LIGHTNINGD,

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -52,7 +52,6 @@ static void handle_signed_psbt(struct lightningd *ld,
 			    rcvd->pps,
 			    rcvd->commitment_msg,
 			    psbt, false);
-	tal_free(rcvd->uc);
 }
 
 /* ~Map of the Territory~

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -635,12 +635,13 @@ static void opener_psbt_changed(struct subd *dualopend,
 				const u8 *msg)
 {
 	struct channel_id cid;
+	u16 funding_serial;
 	struct wally_psbt *psbt;
 	struct json_stream *response;
 	struct command *cmd = uc->fc->cmd;
 
 	if (!fromwire_dual_open_psbt_changed(cmd, msg,
-					     &cid,
+					     &cid, &funding_serial,
 					     &psbt)) {
 		log_broken(dualopend->log,
 			   "Malformed dual_open_psbt_changed %s",
@@ -654,6 +655,7 @@ static void opener_psbt_changed(struct subd *dualopend,
 			type_to_string(tmpctx, struct channel_id, &cid));
 	json_add_psbt(response, "psbt", psbt);
 	json_add_bool(response, "commitments_secured", false);
+	json_add_num(response, "funding_serial", funding_serial);
 
 	uc->cid = cid;
 	uc->fc->inflight = true;
@@ -900,6 +902,7 @@ failed:
 static void accepter_psbt_changed(struct subd *dualopend,
 				  const u8 *msg)
 {
+	u16 unused;
 	struct openchannel2_psbt_payload *payload =
 		tal(dualopend, struct openchannel2_psbt_payload);
 	payload->dualopend = dualopend;
@@ -908,6 +911,7 @@ static void accepter_psbt_changed(struct subd *dualopend,
 
 	if (!fromwire_dual_open_psbt_changed(payload, msg,
 					     &payload->rcvd->cid,
+					     &unused,
 					     &payload->psbt)) {
 		log_broken(dualopend->log, "Malformed dual_open_psbt_changed %s",
 			   tal_hex(tmpctx, msg));

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -678,7 +678,7 @@ static void accepter_commit_received(struct subd *dualopend,
 	struct per_peer_state *pps;
 	u16 funding_outnum;
 	u32 feerate;
-	struct amount_sat total_funding, funding_ours, channel_reserve;
+	struct amount_sat total_funding, funding_ours;
 	u8 channel_flags, *remote_upfront_shutdown_script,
 	   *local_upfront_shutdown_script, *commitment_msg;
 	struct penalty_base *pbase;
@@ -711,7 +711,7 @@ static void accepter_commit_received(struct subd *dualopend,
 					    &channel_flags,
 					    &feerate,
 					    &commitment_msg,
-					    &channel_reserve,
+					    &uc->our_config.channel_reserve,
 					    &local_upfront_shutdown_script,
 					    &remote_upfront_shutdown_script)) {
 		log_broken(uc->log, "bad WIRE_DUAL_OPEN_COMMIT_RCVD %s",
@@ -796,7 +796,7 @@ static void opener_commit_received(struct subd *dualopend,
 	struct json_stream *response;
 	u16 funding_outnum;
 	u32 feerate;
-	struct amount_sat total_funding, funding_ours, channel_reserve;
+	struct amount_sat total_funding, funding_ours;
 	u8 channel_flags, *remote_upfront_shutdown_script,
 	   *local_upfront_shutdown_script, *commitment_msg;
 	struct penalty_base *pbase;
@@ -828,7 +828,7 @@ static void opener_commit_received(struct subd *dualopend,
 					    &channel_flags,
 					    &feerate,
 					    &commitment_msg,
-					    &channel_reserve,
+					    &uc->our_config.channel_reserve,
 					    &local_upfront_shutdown_script,
 					    &remote_upfront_shutdown_script)) {
 		log_broken(uc->log, "bad WIRE_DUAL_OPEN_COMMIT_RCVD %s",
@@ -844,6 +844,9 @@ static void opener_commit_received(struct subd *dualopend,
 	/* We shouldn't have a commitment message, this is an
 	 * accepter flow item */
 	assert(!commitment_msg);
+
+	/* old_remote_per_commit not valid yet, copy valid one. */
+	channel_info.old_remote_per_commit = channel_info.remote_per_commit;
 
 	per_peer_state_set_fds_arr(pps, fds);
 	if (peer_active_channel(uc->peer)) {

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -902,7 +902,9 @@ static bool run_tx_interactive(struct state *state,
 				peer_failed(state->pps, &state->channel_id,
 					    "Unable to add input");
 
+			tal_wally_start();
 			wally_psbt_input_set_utxo(in, tx->wtx);
+			tal_wally_end(psbt);
 
 			if (is_elements(chainparams)) {
 				struct amount_asset asset;

--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -86,6 +86,7 @@ msgdata,dual_open_commit_rcvd,remote_shutdown_scriptpubkey,u8,remote_shutdown_le
 # dualopend->master: peer updated the psbt
 msgtype,dual_open_psbt_changed,7107
 msgdata,dual_open_psbt_changed,channel_id,channel_id,
+msgdata,dual_open_psbt_changed,funding_serial,u16,
 msgdata,dual_open_psbt_changed,psbt,wally_psbt,
 
 # master->dualopend: we updated the psbt

--- a/openingd/dualopend_wiregen.c
+++ b/openingd/dualopend_wiregen.c
@@ -310,17 +310,18 @@ bool fromwire_dual_open_commit_rcvd(const tal_t *ctx, const void *p, struct chan
 
 /* WIRE: DUAL_OPEN_PSBT_CHANGED */
 /* dualopend->master: peer updated the psbt */
-u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, const struct wally_psbt *psbt)
+u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u16 funding_serial, const struct wally_psbt *psbt)
 {
 	u8 *p = tal_arr(ctx, u8, 0);
 
 	towire_u16(&p, WIRE_DUAL_OPEN_PSBT_CHANGED);
 	towire_channel_id(&p, channel_id);
+	towire_u16(&p, funding_serial);
 	towire_wally_psbt(&p, psbt);
 
 	return memcheck(p, tal_count(p));
 }
-bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, struct wally_psbt **psbt)
+bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u16 *funding_serial, struct wally_psbt **psbt)
 {
 	const u8 *cursor = p;
 	size_t plen = tal_count(p);
@@ -328,6 +329,7 @@ bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct cha
 	if (fromwire_u16(&cursor, &plen) != WIRE_DUAL_OPEN_PSBT_CHANGED)
 		return false;
  	fromwire_channel_id(&cursor, &plen, channel_id);
+ 	*funding_serial = fromwire_u16(&cursor, &plen);
  	*psbt = fromwire_wally_psbt(ctx, &cursor, &plen);
 	return cursor != NULL;
 }
@@ -477,4 +479,4 @@ bool fromwire_dual_open_dev_memleak_reply(const void *p, bool *leak)
  	*leak = fromwire_bool(&cursor, &plen);
 	return cursor != NULL;
 }
-// SHA256STAMP:37f122e865f6e2432cffb5ae82c77ca2f8a3714baed0c9724a92541092f3aa54
+// SHA256STAMP:ed548e8b85302ef620646a1aab503b1279fece3b9d9aeedd47a371fa2a9fbe56

--- a/openingd/dualopend_wiregen.h
+++ b/openingd/dualopend_wiregen.h
@@ -75,8 +75,8 @@ bool fromwire_dual_open_commit_rcvd(const tal_t *ctx, const void *p, struct chan
 
 /* WIRE: DUAL_OPEN_PSBT_CHANGED */
 /*  dualopend->master: peer updated the psbt */
-u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, const struct wally_psbt *psbt);
-bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, struct wally_psbt **psbt);
+u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u16 funding_serial, const struct wally_psbt *psbt);
+bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u16 *funding_serial, struct wally_psbt **psbt);
 
 /* WIRE: DUAL_OPEN_PSBT_UPDATED */
 /*  master->dualopend: we updated the psbt */
@@ -109,4 +109,4 @@ bool fromwire_dual_open_dev_memleak_reply(const void *p, bool *leak);
 
 
 #endif /* LIGHTNING_OPENINGD_DUALOPEND_WIREGEN_H */
-// SHA256STAMP:37f122e865f6e2432cffb5ae82c77ca2f8a3714baed0c9724a92541092f3aa54
+// SHA256STAMP:ed548e8b85302ef620646a1aab503b1279fece3b9d9aeedd47a371fa2a9fbe56


### PR DESCRIPTION
This one's mostly small fixes found while running some tests. Plus we completely rework `check_balances`, the method that needed some help anyway.

Based on #4133, start at 3262c3a