### PR TITLE
cleanups for some dual-funding related code, III of III

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -512,6 +512,20 @@ static void announce_channel(struct peer *peer)
 	send_channel_update(peer, 0);
 }
 
+#if EXPERIMENTAL_FEATURES
+static enum tx_role our_tx_role(const struct peer *peer)
+{
+	return peer->channel->opener == LOCAL ?
+		TX_INITIATOR : TX_ACCEPTER;
+}
+#endif
+
+static enum tx_role their_tx_role(const struct peer *peer)
+{
+	return peer->channel->opener == LOCAL ?
+		TX_ACCEPTER : TX_INITIATOR;
+}
+
 static void channel_announcement_negotiate(struct peer *peer)
 {
 	/* Don't do any announcement work if we're shutting down */
@@ -592,6 +606,13 @@ static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
 	if (peer->shutdown_sent[LOCAL])
 		return;
 
+	if (peer->psbt && !psbt_side_finalized(peer->psbt,
+					       their_tx_role(peer)))
+		peer_failed(peer->pps,
+			    &peer->channel_id,
+			    "Rcvd `funding_locked` from peer but "
+			    "have not received `tx_signatures`");
+
 	peer->old_remote_per_commit = peer->remote_per_commit;
 	if (!fromwire_funding_locked(msg, &chanid,
 				     &peer->remote_per_commit))
@@ -608,6 +629,7 @@ static void handle_peer_funding_locked(struct peer *peer, const u8 *msg)
 					   &peer->channel_id));
 
 	peer->funding_locked[REMOTE] = true;
+	peer->psbt = tal_free(peer->psbt);
 	wire_sync_write(MASTER_FD,
 			take(towire_channeld_got_funding_locked(NULL,
 						&peer->remote_per_commit)));
@@ -2037,8 +2059,7 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	const struct witness_stack **ws;
 
 	size_t j = 0;
-	enum tx_role role = peer->channel->opener == REMOTE
-		? TX_INITIATOR : TX_ACCEPTER;
+	enum tx_role their_role = their_tx_role(peer);
 
 	if (!fromwire_tx_signatures(tmpctx, msg, &cid, &txid,
 				    cast_const3(
@@ -2074,6 +2095,15 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 		return;
 	}
 
+	/* This check only works if they've got inputs we need sigs for.
+	 * In the case where they send duplicate tx_sigs but have no
+	 * sigs, we'll end up re-notifying */
+	if (tal_count(ws) && psbt_side_finalized(peer->psbt, their_role)) {
+		status_info("Got duplicate WIRE_TX_SIGNATURES, "
+			    "already have their sigs. Ignoring");
+		return;
+	}
+
 	/* We put the PSBT + sigs all together */
 	for (size_t i = 0; i < peer->psbt->num_inputs; i++) {
 		struct wally_psbt_input *in =
@@ -2088,7 +2118,7 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 							peer->psbt));
 			return;
 		}
-		if (in_serial % 2 != role)
+		if (in_serial % 2 != their_role)
 			continue;
 
 		if (j == tal_count(ws))
@@ -2105,8 +2135,6 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	 * as soon as we've got our sigs */
 	wire_sync_write(MASTER_FD,
 			take(towire_channeld_funding_sigs(NULL, peer->psbt)));
-
-	peer->psbt = tal_free(peer->psbt);
 }
 #endif /* EXPERIMENTAL_FEATURES */
 
@@ -2767,9 +2795,8 @@ static void peer_reconnect(struct peer *peer,
 
 #if EXPERIMENTAL_FEATURES
 	/* Send our tx_sigs again */
-	enum tx_role role = peer->channel->opener == LOCAL
-		? TX_INITIATOR : TX_ACCEPTER;
-	if (peer->psbt && psbt_side_finalized(peer->psbt, role)
+	if (peer->psbt && psbt_side_finalized(peer->psbt,
+					      our_tx_role(peer))
 		&& !peer->funding_locked[REMOTE])
 		sync_crypto_write(peer->pps,
 			take(psbt_to_tx_sigs_msg(NULL, peer->channel,
@@ -2967,13 +2994,6 @@ static void handle_funding_depth(struct peer *peer, const u8 *msg)
 					    &depth))
 		master_badmsg(WIRE_CHANNELD_FUNDING_DEPTH, msg);
 
-	/* We were waiting for them to send us their
-	 * `tx_signatures`, but they never did. As a
-	 * result we'll still have the psbt */
-	if (peer->psbt) {
-		return;
-	}
-
 	/* Too late, we're shutting down! */
 	if (peer->shutdown_sent[LOCAL])
 		return;
@@ -2982,6 +3002,18 @@ static void handle_funding_depth(struct peer *peer, const u8 *msg)
 		peer->depth_togo = peer->channel->minimum_depth - depth;
 
 	} else {
+		/* We were waiting for them to send us their
+		 * `tx_signatures`, but they never did. As a
+		 * result we'll still have the psbt */
+		if (peer->psbt && !psbt_side_finalized(peer->psbt,
+						       their_tx_role(peer))) {
+			peer_failed(peer->pps, &peer->channel_id,
+				    "Funding tx reached funding depth %d "
+				    "but we haven't received peer's "
+				    "tx_signatures",
+				    depth);
+		}
+
 		peer->depth_togo = 0;
 
 		assert(scid);
@@ -3565,11 +3597,9 @@ static void init_channel(struct peer *peer)
 		sync_crypto_write(peer->pps, take(fwd_msg));
 
 #if EXPERIMENTAL_FEATURES
-	enum tx_role role;
-	role = opener == LOCAL ? TX_INITIATOR : TX_ACCEPTER;
 	/* peer_reconnect does this if needed */
 	if (!reconnected && peer->psbt &&
-			psbt_side_finalized(peer->psbt, role))
+			psbt_side_finalized(peer->psbt, our_tx_role(peer)))
 		sync_crypto_write(peer->pps,
 			take(psbt_to_tx_sigs_msg(NULL, peer->channel,
 						 peer->psbt)));

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2003,6 +2003,9 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	const struct witness_stack **ws;
 	const struct wally_tx *wtx;
 	size_t j = 0;
+	enum tx_role role = peer->channel->opener == REMOTE
+		? TX_INITIATOR : TX_ACCEPTER;
+
 
 	if (!fromwire_tx_signatures(tmpctx, msg, &cid, &txid,
 				    cast_const3(
@@ -2041,11 +2044,17 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	for (size_t i = 0; i < peer->psbt->num_inputs; i++) {
 		struct wally_psbt_input *in =
 			&peer->psbt->inputs[i];
+		u16 in_serial;
 		const struct witness_element **elem;
-		/* Really we should check serial parity, but we can
-		 * cheat and only check that the final witness
-		 * stack hasn't been set yet */
-		if (in->final_witness)
+
+		if (!psbt_get_serial_id(&in->unknowns, &in_serial)) {
+			status_broken("PSBT input %zu missing serial_id %s",
+				      i, type_to_string(tmpctx,
+							struct wally_psbt,
+							peer->psbt));
+			return;
+		}
+		if (in_serial % 2 != role)
 			continue;
 
 		if (j == tal_count(ws))

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2006,14 +2006,14 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	enum tx_role role = peer->channel->opener == REMOTE
 		? TX_INITIATOR : TX_ACCEPTER;
 
-
 	if (!fromwire_tx_signatures(tmpctx, msg, &cid, &txid,
 				    cast_const3(
 					 struct witness_stack ***,
 					 &ws)))
 		peer_failed(peer->pps,
 			    &peer->channel_id,
-			    "Bad tx_signatures %s", tal_hex(msg, msg));
+			    "Bad tx_signatures %s",
+			    tal_hex(msg, msg));
 
 	/* Maybe they didn't get our funding_locked message ? */
 	if (peer->funding_locked[LOCAL]) {
@@ -2745,11 +2745,13 @@ static void peer_reconnect(struct peer *peer,
 
 #if EXPERIMENTAL_FEATURES
 	/* Send our tx_sigs again */
-	if (peer->psbt && !peer->funding_locked[REMOTE]) {
+	enum tx_role role = peer->channel->opener == LOCAL
+		? TX_INITIATOR : TX_ACCEPTER;
+	if (peer->psbt && psbt_side_finalized(peer->psbt, role)
+		&& !peer->funding_locked[REMOTE])
 		sync_crypto_write(peer->pps,
 			take(psbt_to_tx_sigs_msg(NULL, peer->channel,
 						 peer->psbt)));
-	}
 #endif /* EXPERIMENTAL_FEATURES */
 
 	/* BOLT #2:
@@ -3533,12 +3535,14 @@ static void init_channel(struct peer *peer)
 		sync_crypto_write(peer->pps, take(fwd_msg));
 
 #if EXPERIMENTAL_FEATURES
+	enum tx_role role;
+	role = opener == LOCAL ? TX_INITIATOR : TX_ACCEPTER;
 	/* peer_reconnect does this if needed */
-	if (!reconnected && peer->psbt) {
+	if (!reconnected && peer->psbt &&
+			psbt_side_finalized(peer->psbt, role))
 		sync_crypto_write(peer->pps,
 			take(psbt_to_tx_sigs_msg(NULL, peer->channel,
 						 peer->psbt)));
-	}
 #endif /* EXPERIMENTAL_FEATURES */
 
 	/* Reenable channel */

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -75,8 +75,13 @@ msgdata,channeld_init,num_penalty_bases,u32,
 msgdata,channeld_init,pbases,penalty_base,num_penalty_bases
 msgdata,channeld_init,psbt,wally_psbt,
 
-msgtype,channeld_funding_tx,1010
-msgdata,channeld_funding_tx,funding_tx,wally_tx,
+# channeld->master received tx_sigs from peer
+msgtype,channeld_funding_sigs,1010
+msgdata,channeld_funding_sigs,signed_psbt,wally_psbt,
+
+# master->channeld send our tx_sigs to peer
+msgtype,channeld_send_tx_sigs,1011
+msgdata,channeld_send_tx_sigs,signed_psbt,wally_psbt,
 
 # master->channeld funding hit new depth(funding locked if >= lock depth)
 msgtype,channeld_funding_depth,1002

--- a/channeld/channeld_wiregen.h
+++ b/channeld/channeld_wiregen.h
@@ -23,7 +23,10 @@
 enum channeld_wire {
         /*  Begin!  (passes gossipd-client fd) */
         WIRE_CHANNELD_INIT = 1000,
-        WIRE_CHANNELD_FUNDING_TX = 1010,
+        /*  channeld->master received tx_sigs from peer */
+        WIRE_CHANNELD_FUNDING_SIGS = 1010,
+        /*  master->channeld send our tx_sigs to peer */
+        WIRE_CHANNELD_SEND_TX_SIGS = 1011,
         /*  master->channeld funding hit new depth(funding locked if >= lock depth) */
         WIRE_CHANNELD_FUNDING_DEPTH = 1002,
         /*  Tell channel to offer this htlc */
@@ -95,9 +98,15 @@ bool channeld_wire_is_defined(u16 type);
 u8 *towire_channeld_init(const tal_t *ctx, const struct chainparams *chainparams, const struct feature_set *our_features, const struct channel_id *channel_id, const struct bitcoin_txid *funding_txid, u16 funding_txout, struct amount_sat funding_satoshi, u32 minimum_depth, const struct channel_config *our_config, const struct channel_config *their_config, const struct fee_states *fee_states, u32 feerate_min, u32 feerate_max, u32 feerate_penalty, const struct bitcoin_signature *first_commit_sig, const struct per_peer_state *per_peer_state, const struct pubkey *remote_fundingkey, const struct basepoints *remote_basepoints, const struct pubkey *remote_per_commit, const struct pubkey *old_remote_per_commit, enum side opener, u32 fee_base, u32 fee_proportional, struct amount_msat local_msatoshi, const struct basepoints *our_basepoints, const struct pubkey *our_funding_pubkey, const struct node_id *local_node_id, const struct node_id *remote_node_id, u32 commit_msec, u16 cltv_delta, bool last_was_revoke, const struct changed_htlc *last_sent_commit, u64 next_index_local, u64 next_index_remote, u64 revocations_received, u64 next_htlc_id, const struct existing_htlc **htlcs, bool local_funding_locked, bool remote_funding_locked, const struct short_channel_id *funding_short_id, bool reestablish, bool send_shutdown, bool remote_shutdown_received, const u8 *final_scriptpubkey, u8 flags, const u8 *init_peer_pkt, bool reached_announce_depth, const struct secret *last_remote_secret, const u8 *their_features, const u8 *upfront_shutdown_script, const secp256k1_ecdsa_signature *remote_ann_node_sig, const secp256k1_ecdsa_signature *remote_ann_bitcoin_sig, bool option_static_remotekey, bool option_anchor_outputs, bool dev_fast_gossip, bool dev_fail_process_onionpacket, const struct penalty_base *pbases, const struct wally_psbt *psbt);
 bool fromwire_channeld_init(const tal_t *ctx, const void *p, const struct chainparams **chainparams, struct feature_set **our_features, struct channel_id *channel_id, struct bitcoin_txid *funding_txid, u16 *funding_txout, struct amount_sat *funding_satoshi, u32 *minimum_depth, struct channel_config *our_config, struct channel_config *their_config, struct fee_states **fee_states, u32 *feerate_min, u32 *feerate_max, u32 *feerate_penalty, struct bitcoin_signature *first_commit_sig, struct per_peer_state **per_peer_state, struct pubkey *remote_fundingkey, struct basepoints *remote_basepoints, struct pubkey *remote_per_commit, struct pubkey *old_remote_per_commit, enum side *opener, u32 *fee_base, u32 *fee_proportional, struct amount_msat *local_msatoshi, struct basepoints *our_basepoints, struct pubkey *our_funding_pubkey, struct node_id *local_node_id, struct node_id *remote_node_id, u32 *commit_msec, u16 *cltv_delta, bool *last_was_revoke, struct changed_htlc **last_sent_commit, u64 *next_index_local, u64 *next_index_remote, u64 *revocations_received, u64 *next_htlc_id, struct existing_htlc ***htlcs, bool *local_funding_locked, bool *remote_funding_locked, struct short_channel_id *funding_short_id, bool *reestablish, bool *send_shutdown, bool *remote_shutdown_received, u8 **final_scriptpubkey, u8 *flags, u8 **init_peer_pkt, bool *reached_announce_depth, struct secret *last_remote_secret, u8 **their_features, u8 **upfront_shutdown_script, secp256k1_ecdsa_signature **remote_ann_node_sig, secp256k1_ecdsa_signature **remote_ann_bitcoin_sig, bool *option_static_remotekey, bool *option_anchor_outputs, bool *dev_fast_gossip, bool *dev_fail_process_onionpacket, struct penalty_base **pbases, struct wally_psbt **psbt);
 
-/* WIRE: CHANNELD_FUNDING_TX */
-u8 *towire_channeld_funding_tx(const tal_t *ctx, const struct wally_tx *funding_tx);
-bool fromwire_channeld_funding_tx(const tal_t *ctx, const void *p, struct wally_tx **funding_tx);
+/* WIRE: CHANNELD_FUNDING_SIGS */
+/*  channeld->master received tx_sigs from peer */
+u8 *towire_channeld_funding_sigs(const tal_t *ctx, const struct wally_psbt *signed_psbt);
+bool fromwire_channeld_funding_sigs(const tal_t *ctx, const void *p, struct wally_psbt **signed_psbt);
+
+/* WIRE: CHANNELD_SEND_TX_SIGS */
+/*  master->channeld send our tx_sigs to peer */
+u8 *towire_channeld_send_tx_sigs(const tal_t *ctx, const struct wally_psbt *signed_psbt);
+bool fromwire_channeld_send_tx_sigs(const tal_t *ctx, const void *p, struct wally_psbt **signed_psbt);
 
 /* WIRE: CHANNELD_FUNDING_DEPTH */
 /*  master->channeld funding hit new depth(funding locked if >= lock depth) */
@@ -237,4 +246,4 @@ bool fromwire_send_onionmsg(const tal_t *ctx, const void *p, u8 onion[1366], str
 
 
 #endif /* LIGHTNING_CHANNELD_CHANNELD_WIREGEN_H */
-// SHA256STAMP:5614b61d80352e94f974d018c391102579d76c5db11648d18ed0dd198ab6838a
+// SHA256STAMP:0ddc4d686d50049ed4c8500919e415dde43baea52adc651b8a606765b09ab001

--- a/common/psbt_open.c
+++ b/common/psbt_open.c
@@ -219,6 +219,7 @@ void psbt_sort_by_serial_id(struct wally_psbt *psbt)
 		struct type##_set a;				\
 		a.type = from->type##s[index];			\
 		a.tx_##type = from->tx->type##s[index]; 	\
+		a.idx = index;					\
 		tal_arr_expand(&add_to, a);			\
 	} while (0)
 

--- a/common/psbt_open.h
+++ b/common/psbt_open.h
@@ -19,11 +19,15 @@ struct wally_map;
 struct input_set {
 	struct wally_tx_input tx_input;
 	struct wally_psbt_input input;
+	/* index on PSBT of this input */
+	size_t idx;
 };
 
 struct output_set {
 	struct wally_tx_output tx_output;
 	struct wally_psbt_output output;
+	/* index on PSBT of this output */
+	size_t idx;
 };
 
 struct psbt_changeset {

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -653,6 +653,22 @@ at the time lightningd broadcasts the notification.
 
 `coin_type` is the BIP173 name for the coin which moved.
 
+### `openchannel_peer_sigs`
+
+When opening a channel with a peer using the collaborative transaction protocol
+(`opt_dual_fund`), this notification is fired when the peer sends us their funding
+transaction signatures, `tx_signatures`. We update the in-progress PSBT and return it
+here, with the peer's signatures attached.
+
+```json
+{
+	"openchannel_peer_sigs": {
+		"channel_id": "<hex of a channel id (note, v2 format)>",
+		"signed_psbt": "<Base64 serialized PSBT of funding transaction,
+				with peer's sigs>"
+	}
+}
+```
 
 ## Hooks
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -151,10 +151,6 @@ struct channel {
 
 	/* PSBT, for v2 channels. Saved until it's sent */
 	struct wally_psbt *psbt;
-
-	/* Stashed pps, saved until channeld is started.
-	 * Needed only for v2 channel open flow */
-	struct per_peer_state *pps;
 };
 
 struct channel *new_channel(struct peer *peer, u64 dbid,

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -150,7 +150,7 @@ struct channel {
 	u64 rr_number;
 
 	/* PSBT, for v2 channels. Saved until it's sent */
-	const struct wally_psbt *psbt;
+	struct wally_psbt *psbt;
 
 	/* Stashed pps, saved until channeld is started.
 	 * Needed only for v2 channel open flow */

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -25,6 +25,7 @@
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
+#include <lightningd/notification.h>
 #include <lightningd/onion_message.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
@@ -449,6 +450,10 @@ static void peer_tx_sigs_msg(struct channel *channel, const u8 *msg)
 	}
 
 	wallet_channel_save(ld->wallet, channel);
+
+	/* Send notification with peer's signed PSBT */
+	notify_openchannel_peer_sigs(ld, &channel->cid,
+				     channel->psbt);
 }
 
 void forget_channel(struct channel *channel, const char *why)

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -889,14 +889,14 @@ static void opener_commit_received(struct subd *dualopend,
 	json_add_bool(response, "commitments_secured", true);
 	/* For convenience sake, we include the funding outnum */
 	json_add_num(response, "funding_outnum", funding_outnum);
-	was_pending(command_success(uc->fc->cmd, response));
-
 	/* Now that we've got the final PSBT, save it */
 	channel->psbt = tal_steal(channel, psbt);
 	wallet_channel_save(uc->fc->cmd->ld->wallet, channel);
 
 	peer_start_channeld(channel, pps,
 			    NULL, psbt, false);
+
+	was_pending(command_success(uc->fc->cmd, response));
 	goto cleanup;
 
 failed:

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -43,7 +43,9 @@ static void handle_signed_psbt(struct lightningd *ld,
 			       struct commit_rcvd *rcvd)
 {
 	/* Now that we've got the signed PSBT, save it */
-	rcvd->channel->psbt = tal_steal(rcvd->channel, psbt);
+	rcvd->channel->psbt =
+		tal_steal(rcvd->channel,
+			  cast_const(struct wally_psbt *, psbt));
 	wallet_channel_save(ld->wallet, rcvd->channel);
 
 	channel_watch_funding(ld, rcvd->channel);

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -887,6 +887,8 @@ static void opener_commit_received(struct subd *dualopend,
 			type_to_string(tmpctx, struct channel_id, &cid));
 	json_add_psbt(response, "psbt", psbt);
 	json_add_bool(response, "commitments_secured", true);
+	/* For convenience sake, we include the funding outnum */
+	json_add_num(response, "funding_outnum", funding_outnum);
 	was_pending(command_success(uc->fc->cmd, response));
 
 	/* Now that we've got the final PSBT, save it */

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -467,3 +467,31 @@ void notify_coin_mvt(struct lightningd *ld,
 	jsonrpc_notification_end(n);
 	plugins_notify(ld->plugins, take(n));
 }
+
+static void openchannel_peer_sigs_serialize(struct json_stream *stream,
+					    const struct channel_id *cid,
+					    const struct wally_psbt *psbt)
+{
+	json_object_start(stream, "openchannel_peer_sigs");
+	json_add_channel_id(stream, "channel_id", cid);
+	json_add_psbt(stream, "signed_psbt", psbt);
+	json_object_end(stream);
+}
+
+REGISTER_NOTIFICATION(openchannel_peer_sigs,
+		      openchannel_peer_sigs_serialize);
+
+void notify_openchannel_peer_sigs(struct lightningd *ld,
+				  const struct channel_id *cid,
+				  const struct wally_psbt *psbt)
+{
+	void (*serialize)(struct json_stream *,
+			  const struct channel_id *cid,
+			  const struct wally_psbt *) = openchannel_peer_sigs_notification_gen.serialize;
+
+	struct jsonrpc_notification *n =
+		jsonrpc_notification_start(NULL, "openchannel_peer_sigs");
+	serialize(n->stream, cid, psbt);
+	jsonrpc_notification_end(n);
+	plugins_notify(ld->plugins, take(n));
+}

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -19,9 +19,11 @@
 #include <lightningd/pay.h>
 #include <lightningd/plugin.h>
 #include <wallet/wallet.h>
+#include <wally_psbt.h>
 #include <wire/onion_wire.h>
 
 struct onionreply;
+struct wally_psbt;
 
 bool notifications_have_topic(const char *topic);
 
@@ -86,4 +88,8 @@ void notify_sendpay_failure(struct lightningd *ld,
 
 void notify_coin_mvt(struct lightningd *ld,
 		     const struct coin_mvt *mvt);
+
+void notify_openchannel_peer_sigs(struct lightningd *ld,
+				  const struct channel_id *cid,
+				  const struct wally_psbt *psbt);
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */


### PR DESCRIPTION
This one's actually a big logical change. Prior to this (in #4069), we would wait until the user provided the signatures for `openchannel_signed` before we opened up a channeld and sent them to our peer. 

The problem with this is that we wouldn't receive the peer's sigs until after we've sent our sigs.  To make this work with `multifundchannel` (coming soon, watch this spaceTM), we need to be able to collect all of our peer's sigs first, collate them for all the other peer's we're signing with, and then present the collected sigs (ours plus all the other nodes) to the peers.

To do this, we go ahead and jump directly into channeld after we've collected the `commitment_sigs` from our peer. We can now call `openchannel_signed` at our leisure -- ideally as soon as you've got all the signatures you need!

Note that this impacts our reconnect logic in channeld; we'll send the tx_sigs *and* funding_locked on reconnect until we've gotten a funding_locked from the peer.

Right, so to summarize

- `openchannel_signed` is no longer a blocker for starting channeld
- There's some logic in `channeld` now around whether we've sent sigs to our peer yet or not and whether we've gotten them back from the peer (or not)
- If the peer sends us `funding_locked` but we haven't gotten `tx_sigs` from them yet, we'll close the channel
- There's now a notification when we receive sigs from the peer

Built on top of #4134, this commit set starts at 22bf555