### PR TITLE
chore: adds env NO_PYTHON check to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,16 +271,24 @@ SHA256STAMP = echo '$(1) SHA256STAMP:'`cat $(sort $(filter-out FORCE,$^)) | $(SH
 
 # generate-wire.py --page [header|impl] hdrfilename wirename < csv > file
 %_wiregen.h: %_wire.csv $(WIRE_GEN_DEPS)
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"wiregen $@",tools/generate-wire.py --page header $($@_args) $@ `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); fi
+	@if $(call SHA256STAMP_CHANGED); then if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"wiregen $@",tools/generate-wire.py --page header $($@_args) $@ `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); \
+	fi
 
 %_wiregen.c: %_wire.csv $(WIRE_GEN_DEPS)
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"wiregen $@",tools/generate-wire.py --page impl $($@_args) ${@:.c=.h} `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); fi
+	@if $(call SHA256STAMP_CHANGED); then if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"wiregen $@",tools/generate-wire.py --page impl $($@_args) ${@:.c=.h} `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); \
+	fi
 
 %_printgen.h: %_wire.csv $(WIRE_GEN_DEPS)
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"printgen $@",tools/generate-wire.py -s -P --page header $($@_args) $@ `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); fi
+	@if $(call SHA256STAMP_CHANGED); then if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"printgen $@",tools/generate-wire.py -s -P --page header $($@_args) $@ `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); \
+	fi
 
 %_printgen.c: %_wire.csv $(WIRE_GEN_DEPS)
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"printgen $@",tools/generate-wire.py -s -P --page impl $($@_args) ${@:.c=.h} `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); fi
+	@if $(call SHA256STAMP_CHANGED); then  if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"printgen $@",tools/generate-wire.py -s -P --page impl $($@_args) ${@:.c=.h} `basename $< .csv | sed 's/_exp_/_/'` < $< > $@ && $(call SHA256STAMP,//)); \
+	fi
 
 include external/Makefile
 include bitcoin/Makefile

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -37,10 +37,14 @@ SQL_FILES := 				\
 	wallet/test/run-wallet.c	\
 
 wallet/statements_gettextgen.po: $(SQL_FILES) FORCE
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"xgettext $@",xgettext -kNAMED_SQL -kSQL --add-location --no-wrap --omit-header -o $@ $(SQL_FILES) && $(call SHA256STAMP,# )); fi
+	@if $(call SHA256STAMP_CHANGED); then if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"xgettext $@",xgettext -kNAMED_SQL -kSQL --add-location --no-wrap --omit-header -o $@ $(SQL_FILES) && $(call SHA256STAMP,# )); \
+	fi
 
 wallet/db_%_sqlgen.c: wallet/statements_gettextgen.po devtools/sql-rewrite.py FORCE
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE,"sql-rewrite $@",devtools/sql-rewrite.py wallet/statements_gettextgen.po $* > $@ && $(call SHA256STAMP,//)); fi
+	@if $(call SHA256STAMP_CHANGED); then if [ "$$NO_PYTHON" == 1 ]; then echo "Error: NO_PYTHON on $@"; exit 1; fi; \
+		$(call VERBOSE,"sql-rewrite $@",devtools/sql-rewrite.py wallet/statements_gettextgen.po $* > $@ && $(call SHA256STAMP,//)); \
+	fi
 
 maintainer-clean: wallet-maintainer-clean
 wallet-maintainer-clean:


### PR DESCRIPTION
This adds an environment variable $NO_PYTHON check to Makefiles so that:
 - It checks and runs into an defined error instead of some python hickup:
   `ModuleNotFoundError: No module named 'mako'`
 - makes it possible to manually export this environment variable NO_PYTHON=1
   to run the same testcase that travis is running on job 1 which causes
   so much pain ;)

Note: also we can use this to sure by bisecting each commit of a branch the correct SQL generations are being committed.

Changelog-None