### PR TITLE
pyln: Adds some improvements to pyln.proto.zbase32

### DIFF
--- a/contrib/pyln-proto/pyln/proto/zbase32.py
+++ b/contrib/pyln-proto/pyln/proto/zbase32.py
@@ -24,6 +24,7 @@ zbase32_revchars = [
 
 
 def _message_to_bitarray(message):
+    """Encodes a message as a bitarray with length multiple of 5."""
     barr = bitstring.ConstBitStream(message)
     padding_len = 5 - (len(barr) % 5)
     if padding_len < 5:
@@ -33,6 +34,7 @@ def _message_to_bitarray(message):
 
 
 def _bitarray_to_message(barr):
+    """Decodes a bitarray with length multiple of 5 to a byte message (removing the padded zeros if found)."""
     padding_len = len(barr) % 8
     if padding_len > 0:
         return bitstring.Bits(bin=barr.bin[:-padding_len]).bytes
@@ -41,6 +43,7 @@ def _bitarray_to_message(barr):
 
 
 def _bitarray_to_u5(barr):
+    """Converts a bitarray in a list of uint5."""
     ret = []
     while barr.pos != barr.len:
         ret.append(barr.read(5).uint)
@@ -48,6 +51,7 @@ def _bitarray_to_u5(barr):
 
 
 def _u5_to_bitarray(arr):
+    """Converts a list of uint5 values to a bitarray."""
     ret = bitstring.BitArray()
     for a in arr:
         ret += bitstring.pack("uint:5", a)
@@ -55,6 +59,7 @@ def _u5_to_bitarray(arr):
 
 
 def is_zbase32_encoded(message):
+    """Checks if a message is zbase32 encoded."""
     if isinstance(message, str):
         message = message.encode("ASCII")
     elif not isinstance(message, bytes):
@@ -63,6 +68,7 @@ def is_zbase32_encoded(message):
 
 
 def encode(message):
+    """Encodes a message (str or bytes) to zbase32."""
     if isinstance(message, str):
         message = message.encode('ASCII')
     elif not isinstance(message, bytes):
@@ -75,6 +81,7 @@ def encode(message):
 
 
 def decode(message):
+    """Decodes a message (str or bytes) from zbase32."""
     if isinstance(message, str):
         message = message.encode('ASCII')
     elif not isinstance(message, bytes):

--- a/contrib/pyln-proto/pyln/proto/zbase32.py
+++ b/contrib/pyln-proto/pyln/proto/zbase32.py
@@ -1,4 +1,5 @@
 import bitstring  # type: ignore
+from typing import Union
 
 
 zbase32_chars = b'ybndrfg8ejkmcpqxot1uwisza345h769'
@@ -23,7 +24,7 @@ zbase32_revchars = [
 ]
 
 
-def _message_to_bitarray(message):
+def _message_to_bitarray(message: bytes) -> bitstring.ConstBitStream:
     """Encodes a message as a bitarray with length multiple of 5."""
     barr = bitstring.ConstBitStream(message)
     padding_len = 5 - (len(barr) % 5)
@@ -42,7 +43,7 @@ def _bitarray_to_message(barr):
         return barr.bytes
 
 
-def _bitarray_to_u5(barr):
+def _bitarray_to_u5(barr: bitstring.ConstBitStream) -> list:
     """Converts a bitarray in a list of uint5."""
     ret = []
     while barr.pos != barr.len:
@@ -50,7 +51,7 @@ def _bitarray_to_u5(barr):
     return ret
 
 
-def _u5_to_bitarray(arr):
+def _u5_to_bitarray(arr: list) -> bitstring.BitArray:
     """Converts a list of uint5 values to a bitarray."""
     ret = bitstring.BitArray()
     for a in arr:
@@ -58,7 +59,7 @@ def _u5_to_bitarray(arr):
     return ret
 
 
-def is_zbase32_encoded(message):
+def is_zbase32_encoded(message: Union[str, bytes]) -> bool:
     """Checks if a message is zbase32 encoded."""
     if isinstance(message, str):
         message = message.encode("ASCII")
@@ -67,7 +68,7 @@ def is_zbase32_encoded(message):
     return set(message).issubset(zbase32_chars)
 
 
-def encode(message):
+def encode(message: Union[str, bytes]) -> bytes:
     """Encodes a message (str or bytes) to zbase32."""
     if isinstance(message, str):
         message = message.encode('ASCII')
@@ -80,7 +81,7 @@ def encode(message):
     return bytes(res)
 
 
-def decode(message):
+def decode(message: Union[str, bytes]) -> bytes:
     """Decodes a message (str or bytes) from zbase32."""
     if isinstance(message, str):
         message = message.encode('ASCII')

--- a/contrib/pyln-proto/tests/test_primitives.py
+++ b/contrib/pyln-proto/tests/test_primitives.py
@@ -1,5 +1,4 @@
-from binascii import hexlify, unhexlify
-from pyln.proto import zbase32
+from binascii import unhexlify
 from pyln.proto.primitives import ShortChannelId
 
 
@@ -19,12 +18,3 @@ def test_short_channel_id():
     assert(expected.to_bytes() == b)
     assert(str(expected) == s)
     assert(expected.to_int() == num)
-
-
-def test_zbase32():
-    zb32 = b'd75qtmgijm79rpooshmgzjwji9gj7dsdat8remuskyjp9oq1ugkaoj6orbxzhuo4njtyh96e3aq84p1tiuz77nchgxa1s4ka4carnbiy'
-    b = zbase32.decode(zb32)
-    assert(hexlify(b) == b'1f76e8acd54afbf23610b7166ba689afcc9e8ec3c44e442e765012dfc1d299958827d0205f7e4e1a12620e7fc8ce1c7d3651acefde899c33f12b6958d3304106a0')
-
-    enc = zbase32.encode(b)
-    assert(enc == zb32)

--- a/contrib/pyln-proto/tests/test_zbase32.py
+++ b/contrib/pyln-proto/tests/test_zbase32.py
@@ -73,6 +73,10 @@ def test_is_zbase32_encoded():
 
 
 def test_encode():
+    message = '1f76e8acd54afbf23610b7166ba689afcc9e8ec3c44e442e765012dfc1d299958827d0205f7e4e1a12620e7fc8ce1c7d3651acefde899c33f12b6958d3304106a0'
+    zbase32_message = b'd75qtmgijm79rpooshmgzjwji9gj7dsdat8remuskyjp9oq1ugkaoj6orbxzhuo4njtyh96e3aq84p1tiuz77nchgxa1s4ka4carnbiy'
+    assert(zbase32.encode(bytes.fromhex(message)) == zbase32_message)
+
     for message, expected_zbase32_message in zip(messages, zbase32_messages):
         zbase32_message = zbase32.encode(message)
         assert isinstance(zbase32_message, bytes)
@@ -87,6 +91,10 @@ def test_encode_wrong_inputs():
 
 
 def test_decode():
+    zbase32_message = b'd75qtmgijm79rpooshmgzjwji9gj7dsdat8remuskyjp9oq1ugkaoj6orbxzhuo4njtyh96e3aq84p1tiuz77nchgxa1s4ka4carnbiy'
+    message = '1f76e8acd54afbf23610b7166ba689afcc9e8ec3c44e442e765012dfc1d299958827d0205f7e4e1a12620e7fc8ce1c7d3651acefde899c33f12b6958d3304106a0'
+    assert(zbase32.decode(zbase32_message) == bytes.fromhex(message))
+
     for expected_message, zbase32_message in zip(messages, zbase32_messages):
         message = zbase32.decode(zbase32_message)
         assert isinstance(message, bytes)

--- a/contrib/pyln-proto/tests/test_zbase32.py
+++ b/contrib/pyln-proto/tests/test_zbase32.py
@@ -1,0 +1,106 @@
+import pytest
+import bitstring
+from pyln.proto import zbase32
+
+not_str_bytes = [1, dict(), None, 3.4, object()]
+messages = [b'this', b'is', b'a', b'split', b'message:', b'lightning', b'rocks']
+zbase32_messages = [b'qtwg1ha', b'pf3o', b'cr', b'qpaga4mw', b'pi1zgh5bc71uw', b'ptwsq4dwp3wsh3a', b'qjzsg45u']
+not_zbase32_messages = ['00', '[]', 'vv', '1234']
+
+
+def test_message_to_bitarray():
+    # This is an internal function and the input is supposed to be bytes. Not testing unexpected inputs.
+    dummy_messages = [b'a' * i for i in range(1, 6)]
+    for message in dummy_messages:
+        not_padded_barr = bitstring.Bits(message)
+        barr = zbase32._message_to_bitarray(message)
+        assert isinstance(barr, bitstring.ConstBitStream)
+
+        for i in range(len(barr)):
+            # Then first len(not_padded_barr) bits are equal
+            if i < len(not_padded_barr):
+                assert not_padded_barr.bin[i] == barr.bin[i]
+            # The remaining are zeros
+            else:
+                assert barr.bin[i] == '0'
+
+
+def test_bitarray_to_message():
+    # This is an internal function and the input is supposed to be BitArray. Not testing unexpected inputs.
+    dummy_messages = [b'b' * i for i in range(1, 6)]
+
+    for message in dummy_messages:
+        barr = bitstring.Bits(message)
+        not_padded_message = zbase32._bitarray_to_message(bitstring.BitArray(message))
+        assert isinstance(not_padded_message, bytes)
+
+        not_padded_barr = bitstring.Bits(not_padded_message)
+        for i in range(len(not_padded_barr)):
+            # Then first len(pre_padded_barr) bits are equal
+            if i < len(not_padded_barr):
+                assert not_padded_barr.bin[i] == barr.bin[i]
+            # The remaining are zeros
+            else:
+                assert barr.bin[i] == '0'
+
+
+def test_bitarray_to_u5():
+    # This is an internal function and the input is supposed to be ConstBitStream of length multiple of 5.
+    # Not testing unexpected inputs.
+    barrs = [zbase32._message_to_bitarray(message) for message in messages]
+
+    for barr in barrs:
+        u5 = zbase32._bitarray_to_u5(barr)
+        assert isinstance(u5, list)
+        assert all(x in range(0, 31) for x in u5)
+
+
+def test_u5_to_bitarray():
+    # This is an internal function and the input is supposed to be a list of ints 0-31. Not testing unexpected inputs.
+    u5s = [[0, 1, 2, 3, 4, 5], [15, 30, 24, 17, 8, 3, 21], [0], [28, 11]]
+
+    for u5 in u5s:
+        bitarray = zbase32._u5_to_bitarray(u5)
+        assert isinstance(bitarray, bitstring.BitArray)
+
+
+def test_is_zbase32_encoded():
+    for message in zbase32_messages:
+        assert zbase32.is_zbase32_encoded(message)
+
+    for message in not_zbase32_messages:
+        assert not zbase32.is_zbase32_encoded(message)
+
+
+def test_encode():
+    for message, expected_zbase32_message in zip(messages, zbase32_messages):
+        zbase32_message = zbase32.encode(message)
+        assert isinstance(zbase32_message, bytes)
+        assert zbase32_message == expected_zbase32_message
+
+
+def test_encode_wrong_inputs():
+    # Message must be either str or bytes, any other type will be rejected
+    for m in not_str_bytes:
+        with pytest.raises(TypeError, match='message must be string or bytes'):
+            zbase32.encode(m)
+
+
+def test_decode():
+    for expected_message, zbase32_message in zip(messages, zbase32_messages):
+        message = zbase32.decode(zbase32_message)
+        assert isinstance(message, bytes)
+        assert message == expected_message
+
+
+def test_decode_wrong_inputs():
+    # Message must be either str or bytes, any other type will be rejected
+
+    for m in not_str_bytes:
+        with pytest.raises(TypeError, match='message must be string or bytes'):
+            zbase32.decode(m)
+
+    # Message must also be zbase32 encoded, otherwise it will be rejected
+    for m in not_zbase32_messages:
+        with pytest.raises(ValueError, match='message is not zbase32 encoded'):
+            zbase32.decode(m)


### PR DESCRIPTION
Before this PR, `zbase32.encode` could only be used for messages with length multiple of 5. This is because zbase32 encoding uses blocks of 5-bit words for the encoding. However, arbitrary length messages should be encodable as well by properly padding them to match the expected length.

The additions to this PR could be summarised as follows:

- Add helper functions to encode / decode arbitrary length data by padding / cutting the provided data (`_message_to_bitarray` and `_bitarray_to_message`).
- Mark any function that is not supposed to be used publicly as "private".
- Adds input checking to the public functions (`encode`, `decode`, `is_zbased32_encoded`) and raise exceptions accordingly.
- Add short descriptions to each function.
- Add tests for the whole module.

Changelog-None