### PR TITLE
Make check fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ TAGS
 tags
 ccan/tools/configurator/configurator
 ccan/ccan/cdump/tools/cdump-enumstr
-gen_*
+*_gen.c
+*_gen.h
 cli/lightning-cli
 tools/check-bolt
 tools/hsmtool

--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,27 @@ ALL_NONGEN_HEADERS := $(filter-out %gen.h,$(ALL_C_HEADERS))
 ALL_NONGEN_SOURCES := $(filter-out %gen.c,$(ALL_C_SOURCES))
 ALL_NONGEN_SRCFILES := $(ALL_NONGEN_HEADERS) $(ALL_NONGEN_SOURCES)
 
+# Programs to install in bindir and pkglibexecdir.
+# TODO: $(EXEEXT) support for Windows?  Needs more coding for
+# the individual Makefiles, however.
+BIN_PROGRAMS = \
+	       cli/lightning-cli \
+	       lightningd/lightningd \
+	       tools/lightning-hsmtool
+PKGLIBEXEC_PROGRAMS = \
+	       lightningd/lightning_channeld \
+	       lightningd/lightning_closingd \
+	       lightningd/lightning_connectd \
+	       lightningd/lightning_gossipd \
+	       lightningd/lightning_hsmd \
+	       lightningd/lightning_onchaind \
+	       lightningd/lightning_openingd
+
+# Only build dualopend if experimental features is on
+ifeq ($(EXPERIMENTAL_FEATURES),1)
+PKGLIBEXEC_PROGRAMS += lightningd/lightning_dualopend
+endif
+
 # Don't delete these intermediaries.
 .PRECIOUS: $(ALL_GEN_HEADERS) $(ALL_GEN_SOURCES)
 
@@ -419,7 +440,7 @@ PYSRC=$(shell git ls-files "*.py" | grep -v /text.py) contrib/pylightning/lightn
 # Some tests in pyln will need to find lightningd to run, so have a PATH that
 # allows it to find that
 PYLN_PATH=$(shell pwd)/lightningd:$(PATH)
-check-pyln-%:  $(BIN_PROGRAMS)
+check-pyln-%: $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS)
 	@(cd contrib/$(shell echo $@ | cut -b 7-) && PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(MAKE) check)
 
 check-python: check-pyln-client check-pyln-testing
@@ -603,27 +624,6 @@ installdirs:
 	$(MKDIR_P) $(DESTDIR)$(man7dir)
 	$(MKDIR_P) $(DESTDIR)$(man8dir)
 	$(MKDIR_P) $(DESTDIR)$(docdir)
-
-# Programs to install in bindir and pkglibexecdir.
-# TODO: $(EXEEXT) support for Windows?  Needs more coding for
-# the individual Makefiles, however.
-BIN_PROGRAMS = \
-	       cli/lightning-cli \
-	       lightningd/lightningd \
-	       tools/lightning-hsmtool
-PKGLIBEXEC_PROGRAMS = \
-	       lightningd/lightning_channeld \
-	       lightningd/lightning_closingd \
-	       lightningd/lightning_connectd \
-	       lightningd/lightning_gossipd \
-	       lightningd/lightning_hsmd \
-	       lightningd/lightning_onchaind \
-	       lightningd/lightning_openingd
-
-# Only build dualopend if experimental features is on
-ifeq ($(EXPERIMENTAL_FEATURES),1)
-PKGLIBEXEC_PROGRAMS += lightningd/lightning_dualopend
-endif
 
 # $(PLUGINS) is defined in plugins/Makefile.
 

--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,11 @@ check-hdr-include-order/%: %
 check-makefile:
 	@if [ x"$(CCANDIR)/config.h `find $(CCANDIR)/ccan -name '*.h' | grep -v /test/ | $(SORT) | tr '\n' ' '`" != x"$(CCAN_HEADERS) " ]; then echo CCAN_HEADERS incorrect; exit 1; fi
 
+# We exclude test files, which need to do weird include tricks!
+SRC_TO_CHECK := $(filter-out $(ALL_TEST_PROGRAMS:=.c), $(ALL_NONGEN_SOURCES))
+check-src-includes: $(SRC_TO_CHECK:%=check-src-include-order/%)
+check-hdr-includes: $(ALL_NONGEN_HEADERS:%=check-hdr-include-order/%)
+
 # Experimental quotes quote the exact version.
 ifeq ($(EXPERIMENTAL_FEATURES),1)
 CHECK_BOLT_PREFIX=--prefix="BOLT-$(BOLTVERSION)"
@@ -425,7 +430,7 @@ check-python: check-pyln-client check-pyln-testing
 
 	PATH=$(PYLN_PATH) PYTHONPATH=$(PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
 
-check-includes:
+check-includes: check-src-includes check-hdr-includes
 	@tools/check-includes.sh
 
 # cppcheck gets confused by list_for_each(head, i, list): thinks i is uninit.

--- a/bitcoin/Makefile
+++ b/bitcoin/Makefile
@@ -38,20 +38,15 @@ BITCOIN_HEADERS := bitcoin/address.h		\
 	bitcoin/tx_parts.h			\
 	bitcoin/varint.h
 
-check-source: $(BITCOIN_SRC:%=check-src-include-order/%)		\
-	$(BITCOIN_HEADERS:%=check-hdr-include-order/%)
-
 # Bitcoin objects depends on bitcoin/ external/ and ccan
 $(BITCOIN_OBJS): $(CCAN_HEADERS) $(BITCOIN_HEADERS) $(EXTERNAL_HEADERS)
-
-check-source-bolt: $(BITCOIN_SRC:%=bolt-check/%) $(BITCOIN_HEADERS:%=bolt-check/%)
 
 check-makefile: check-bitcoin-makefile
 
 check-bitcoin-makefile:
 	@if [ "`echo bitcoin/*.h`" != "$(BITCOIN_HEADERS)" ]; then echo BITCOIN_HEADERS incorrect; exit 1; fi
 
-check-whitespace: $(BITCOIN_SRC:%=check-whitespace/%) $(BITCOIN_HEADERS:%=check-whitespace/%) check-whitespace/bitcoin/Makefile
+check-whitespace: check-whitespace/bitcoin/Makefile
 
 clean: bitcoin-clean
 

--- a/channeld/Makefile
+++ b/channeld/Makefile
@@ -1,7 +1,7 @@
 #! /usr/bin/make
 
 CHANNELD_HEADERS :=			\
-	channeld/gen_full_channel_error_names.h	\
+	channeld/full_channel_error_names_gen.h	\
 	channeld/channeld_wiregen.h		\
 	channeld/channeld_htlc.h		\
 	channeld/commit_tx.h			\
@@ -96,7 +96,7 @@ ifeq ($(EXPERIMENTAL_FEATURES),1)
 CHANNELD_COMMON_OBJS += common/psbt_internal.o
 endif
 
-channeld/gen_full_channel_error_names.h: channeld/full_channel_error.h ccan/ccan/cdump/tools/cdump-enumstr
+channeld/full_channel_error_names_gen.h: channeld/full_channel_error.h ccan/ccan/cdump/tools/cdump-enumstr
 	ccan/ccan/cdump/tools/cdump-enumstr channeld/full_channel_error.h > $@
 
 lightningd/lightning_channeld: $(CHANNELD_OBJS) $(WIRE_ONION_OBJS) $(CHANNELD_COMMON_OBJS) $(WIRE_OBJS) $(BITCOIN_OBJS) $(HSMD_CLIENT_OBJS)

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -47,9 +47,9 @@
 #include <common/peer_billboard.h>
 #include <common/peer_failed.h>
 #include <common/ping.h>
+#include <common/private_channel_announcement.h>
 #include <common/psbt_internal.h>
 #include <common/psbt_open.h>
-#include <common/private_channel_announcement.h>
 #include <common/read_peer_msg.h>
 #include <common/sphinx.h>
 #include <common/status.h>
@@ -60,8 +60,8 @@
 #include <common/wire_error.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <gossipd/gossipd_peerd_wiregen.h>
 #include <gossipd/gossip_store_wiregen.h>
+#include <gossipd/gossipd_peerd_wiregen.h>
 #include <hsmd/hsmd_wiregen.h>
 #include <inttypes.h>
 #include <secp256k1.h>

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <string.h>
   /* Needs to be at end, since it doesn't include its own hdrs */
-  #include "gen_full_channel_error_names.h"
+  #include "full_channel_error_names_gen.h"
 
 #if DEVELOPER
 static void memleak_help_htlcmap(struct htable *memtable,

--- a/channeld/full_channel_error.h
+++ b/channeld/full_channel_error.h
@@ -1,6 +1,7 @@
 /* Error enums separated out for easy autogen of names*/
 #ifndef LIGHTNING_CHANNELD_FULL_CHANNEL_ERROR_H
 #define LIGHTNING_CHANNELD_FULL_CHANNEL_ERROR_H
+#include "config.h"
 
 enum channel_add_err {
 	/* All OK! */

--- a/common/Makefile
+++ b/common/Makefile
@@ -119,9 +119,6 @@ common/gossip_store.o: gossipd/gossip_store_wiregen.h
 check-source-bolt: $(COMMON_SRC_NOGEN:%=bolt-check/%) $(COMMON_HEADERS:%=bolt-check/%)
 check-whitespace: $(COMMON_SRC_NOGEN:%=check-whitespace/%) $(COMMON_HEADERS:%=check-whitespace/%)
 
-check-source: $(COMMON_SRC_NOGEN:%=check-src-include-order/%)		\
-	$(COMMON_HEADERS_NOGEN:%=check-hdr-include-order/%)
-
 clean: common-clean
 
 common-clean:

--- a/common/Makefile
+++ b/common/Makefile
@@ -95,7 +95,7 @@ COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h)	\
 	common/overflows.h				\
 	common/status_levels.h				\
 	common/tx_roles.h
-COMMON_HEADERS_GEN := common/gen_htlc_state_names.h common/status_wiregen.h common/peer_status_wiregen.h
+COMMON_HEADERS_GEN := common/htlc_state_names_gen.h common/status_wiregen.h common/peer_status_wiregen.h
 
 COMMON_HEADERS := $(COMMON_HEADERS_GEN) $(COMMON_HEADERS_NOGEN)
 COMMON_SRC := $(COMMON_SRC_NOGEN) $(COMMON_SRC_GEN)
@@ -106,12 +106,12 @@ COMMON_OBJS := $(COMMON_SRC:.c=.o)
 $(COMMON_OBJS): $(CCAN_HEADERS) $(BITCOIN_HEADERS) $(EXTERNAL_HEADERS) $(COMMON_HEADERS_GEN)
 
 # Only common/version.c can include this header.
-common/version.o: gen_version.h
+common/version.o: version_gen.h
 
 ALL_C_HEADERS += $(COMMON_HEADERS)
 ALL_C_SOURCES += $(COMMON_SRC)
 
-common/gen_htlc_state_names.h: common/htlc_state.h ccan/ccan/cdump/tools/cdump-enumstr
+common/htlc_state_names_gen.h: common/htlc_state.h ccan/ccan/cdump/tools/cdump-enumstr
 	ccan/ccan/cdump/tools/cdump-enumstr common/htlc_state.h > $@
 
 common/gossip_store.o: gossipd/gossip_store_wiregen.h

--- a/common/htlc_state.c
+++ b/common/htlc_state.c
@@ -1,6 +1,6 @@
 #include <ccan/array_size/array_size.h>
 #include <common/htlc.h>
-  #include "gen_htlc_state_names.h"
+  #include "htlc_state_names_gen.h"
 
 const char *htlc_state_name(enum htlc_state s)
 {

--- a/common/version.c
+++ b/common/version.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 /* Only common/version.c can safely include this.  */
-# include "gen_version.h"
+# include "version_gen.h"
 
 const char *version(void)
 {

--- a/devtools/blindedpath.c
+++ b/devtools/blindedpath.c
@@ -15,8 +15,8 @@
 #include <common/version.h>
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
-#include <sodium/crypto_auth_hmacsha256.h>
 #include <sodium/crypto_aead_chacha20poly1305.h>
+#include <sodium/crypto_auth_hmacsha256.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/devtools/decodemsg.c
+++ b/devtools/decodemsg.c
@@ -6,11 +6,11 @@
 #include <stdio.h>
 #include <unistd.h>
 #if EXPERIMENTAL_FEATURES
-#include <wire/onion_exp_printgen.h>
-#include <wire/peer_exp_printgen.h>
+  #include <wire/onion_exp_printgen.h>
+  #include <wire/peer_exp_printgen.h>
 #else
-#include <wire/onion_printgen.h>
-#include <wire/peer_printgen.h>
+  #include <wire/onion_printgen.h>
+  #include <wire/peer_printgen.h>
 #endif
 
 int main(int argc, char *argv[])

--- a/devtools/dump-gossipstore.c
+++ b/devtools/dump-gossipstore.c
@@ -1,12 +1,12 @@
 #include <ccan/crc32c/crc32c.h>
 #include <ccan/err/err.h>
 #include <ccan/opt/opt.h>
+#include <common/gossip_store.h>
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <fcntl.h>
-#include <common/gossip_store.h>
-#include <gossipd/gossipd_peerd_wiregen.h>
 #include <gossipd/gossip_store_wiregen.h>
+#include <gossipd/gossipd_peerd_wiregen.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -42,7 +42,7 @@ static struct io_plan *simple_close(struct io_conn *conn)
 	return NULL;
 }
 
-#include "../connectd/handshake.c"
+  #include "../connectd/handshake.c"
 
 /* This makes the handshake prototypes work. */
 struct io_conn {

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -12,8 +12,8 @@
 #include <bitcoin/script.h>
 #include <bitcoin/tx.h>
 #include <ccan/cast/cast.h>
-#include <ccan/opt/opt.h>
 #include <ccan/err/err.h>
+#include <ccan/opt/opt.h>
 #include <ccan/str/hex/hex.h>
 #include <ccan/tal/str/str.h>
 #include <channeld/full_channel.h>

--- a/devtools/mkgossip.c
+++ b/devtools/mkgossip.c
@@ -21,8 +21,8 @@
 #include <common/type_to_string.h>
 #include <common/utils.h>
 #include <inttypes.h>
-#include <wire/peer_wire.h>
 #include <stdio.h>
+#include <wire/peer_wire.h>
 
 static bool verbose = false;
 

--- a/devtools/mkquery.c
+++ b/devtools/mkquery.c
@@ -11,8 +11,8 @@
 #include <common/gossip_constants.h>
 #include <common/utils.h>
 #include <inttypes.h>
-#include <wire/peer_wire.h>
 #include <stdio.h>
+#include <wire/peer_wire.h>
 
 static void usage(void)
 {

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -50,7 +50,7 @@ LIGHTNINGD_SRC_NOHDR :=				\
 LIGHTNINGD_HEADERS :=				\
 	$(LIGHTNINGD_SRC:.c=.h)			\
 	lightningd/channel_state.h		\
-	lightningd/gen_channel_state_names.h
+	lightningd/channel_state_names_gen.h
 
 LIGHTNINGD_OBJS := $(LIGHTNINGD_SRC:.c=.o) $(LIGHTNINGD_SRC_NOHDR:.c=.o)
 $(LIGHTNINGD_OBJS): $(LIGHTNINGD_HEADERS) $(LIGHTNINGD_CONTROL_HEADERS)
@@ -129,9 +129,9 @@ LIGHTNINGD_HEADERS = $(LIGHTNINGD_HEADERS_NOGEN) $(LIGHTNINGD_HEADERS_GEN) $(WAL
 $(LIGHTNINGD_OBJS): $(LIGHTNINGD_HEADERS) $(WALLET_HDRS)
 
 # Only the plugin component needs to depend on this header.
-lightningd/plugin.o: plugins/gen_list_of_builtin_plugins.h
+lightningd/plugin.o: plugins/list_of_builtin_plugins_gen.h
 
-lightningd/gen_channel_state_names.h: lightningd/channel_state.h ccan/ccan/cdump/tools/cdump-enumstr
+lightningd/channel_state_names_gen.h: lightningd/channel_state.h ccan/ccan/cdump/tools/cdump-enumstr
 	ccan/ccan/cdump/tools/cdump-enumstr lightningd/channel_state.h > $@
 
 lightningd/lightningd: $(LIGHTNINGD_OBJS) $(WALLET_OBJS) $(LIGHTNINGD_COMMON_OBJS) $(BITCOIN_OBJS) $(WIRE_OBJS) $(WIRE_ONION_OBJS) $(LIGHTNINGD_CONTROL_OBJS) $(HSMD_CLIENT_OBJS)

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -19,8 +19,8 @@
 #include <lightningd/lightningd.h>
 #include <lightningd/log.h>
 #include <lightningd/notification.h>
-#include <lightningd/opening_control.h>
 #include <lightningd/opening_common.h>
+#include <lightningd/opening_control.h>
 #include <lightningd/peer_control.h>
 #include <lightningd/subd.h>
 #include <wire/wire_sync.h>

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -12,8 +12,8 @@
 #include <hsmd/hsmd_wiregen.h>
 #include <inttypes.h>
 #include <lightningd/channel.h>
+#include <lightningd/channel_state_names_gen.h>
 #include <lightningd/connect_control.h>
-#include <lightningd/gen_channel_state_names.h>
 #include <lightningd/hsm_control.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -66,7 +66,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <gen_header_versions.h>
+#include <header_versions_gen.h>
 #include <lightningd/bitcoind.h>
 #include <lightningd/chaintopology.h>
 #include <lightningd/channel_control.h>

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 
 /* Only this file can include this generated header! */
-# include <plugins/gen_list_of_builtin_plugins.h>
+# include <plugins/list_of_builtin_plugins_gen.h>
 
 /* How many seconds may the plugin take to reply to the `getmanifest`
  * call? This is the maximum delay to `lightningd --help` and until

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -4,9 +4,9 @@
 #include <ccan/tal/str/str.h>
 #include <ccan/utf8/utf8.h>
 #include <common/features.h>
+#include <common/json_helpers.h>
 #include <common/utils.h>
 #include <common/version.h>
-#include <common/json_helpers.h>
 #include <lightningd/json.h>
 #include <lightningd/notification.h>
 #include <lightningd/options.h>

--- a/onchaind/Makefile
+++ b/onchaind/Makefile
@@ -2,7 +2,7 @@
 
 ONCHAIND_HEADERS :=				\
 	onchaind/onchaind_wiregen.h		\
-	onchaind/gen_onchain_types_names.h	\
+	onchaind/onchain_types_names_gen.h	\
 	onchaind/onchain_types.h		\
 	onchaind/onchaind_wire.h
 
@@ -11,7 +11,7 @@ ONCHAIND_SRC := onchaind/onchaind.c	\
 	onchaind/onchaind_wire.c	\
 	onchaind/onchaind.c
 
-onchaind/gen_onchain_types_names.h: onchaind/onchain_types.h ccan/ccan/cdump/tools/cdump-enumstr
+onchaind/onchain_types_names_gen.h: onchaind/onchain_types.h ccan/ccan/cdump/tools/cdump-enumstr
 	ccan/ccan/cdump/tools/cdump-enumstr onchaind/onchain_types.h > $@
 
 ONCHAIND_OBJS := $(ONCHAIND_SRC:.c=.o)

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <wire/wire_sync.h>
-  #include "gen_onchain_types_names.h"
+  #include "onchain_types_names_gen.h"
 
 /* stdin == requests */
 #define REQ_FD STDIN_FILENO

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -42,8 +42,8 @@
 #include <common/setup.h>
 #include <common/status.h>
 #include <common/subdaemon.h>
-#include <common/type_to_string.h>
 #include <common/tx_roles.h>
+#include <common/type_to_string.h>
 #include <common/utils.h>
 #include <common/version.h>
 #include <common/wire_error.h>

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -58,7 +58,7 @@ PLUGINS :=					\
 
 # Make sure these depend on everything.
 ALL_C_SOURCES += $(PLUGIN_ALL_SRC)
-ALL_C_HEADERS += 
+ALL_C_HEADERS += $(PLUGIN_ALL_HEADER)
 ALL_PROGRAMS += $(PLUGINS)
 
 PLUGIN_COMMON_OBJS :=				\

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -118,6 +118,6 @@ plugins/spenderp: bitcoin/chainparams.o $(PLUGIN_SPENDER_OBJS) $(PLUGIN_LIB_OBJS
 $(PLUGIN_ALL_OBJS): $(PLUGIN_LIB_HEADER)
 
 # Generated from PLUGINS definition in plugins/Makefile
-ALL_C_HEADERS += plugins/gen_list_of_builtin_plugins.h
-plugins/gen_list_of_builtin_plugins.h: plugins/Makefile Makefile
+ALL_C_HEADERS += plugins/list_of_builtin_plugins_gen.h
+plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile
 	@$(call VERBOSE,GEN $@,echo "static const char *list_of_builtin_plugins[] = { $(foreach d,$(notdir $(PLUGINS)),\"$d\",) NULL };" > $@)

--- a/plugins/spender/main.c
+++ b/plugins/spender/main.c
@@ -1,8 +1,8 @@
 #include <common/utils.h>
 #include <plugins/libplugin.h>
-#include <plugins/spender/multiwithdraw.h>
 #include <plugins/spender/fundchannel.h>
 #include <plugins/spender/multifundchannel.h>
+#include <plugins/spender/multiwithdraw.h>
 
 /*~ The spender plugin contains various commands that handle
  * spending from the onchain wallet.  */

--- a/tools/check-bolt.c
+++ b/tools/check-bolt.c
@@ -8,8 +8,8 @@
 #include <ccan/tal/str/str.h>
 #include <ccan/tal/tal.h>
 #include <common/utils.h>
-#include <sys/types.h>
 #include <dirent.h>
+#include <sys/types.h>
 
 static bool verbose = false;
 

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -3,8 +3,8 @@
 #include <ccan/err/err.h>
 #include <ccan/noerr/noerr.h>
 #include <ccan/read_write_all/read_write_all.h>
-#include <ccan/tal/path/path.h>
 #include <ccan/str/str.h>
+#include <ccan/tal/path/path.h>
 #include <common/bech32.h>
 #include <common/derive_basepoints.h>
 #include <common/node_id.h>

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -11,9 +11,9 @@ ifeq ($(HAVE_PYTHON3_MAKO),1)
 check-units: check-tools
 
 TOOL_TEST_INCL_SRC := tools/test/enum.c
-TOOL_GEN_SRC := tools/test/gen_test.c tools/test/gen_print.c
+TOOL_GEN_SRC := tools/test/test_gen.c tools/test/print_gen.c
 TOOL_GEN_OBJS := $(TOOL_GEN_SRC:.c=.o)
-TOOL_GEN_HEADER := tools/test/gen_test.h tools/test/gen_print.h
+TOOL_GEN_HEADER := tools/test/test_gen.h tools/test/print_gen.h
 TOOL_TEST_SRC := $(wildcard tools/test/run-*.c)
 TOOL_TEST_OBJS := $(TOOL_TEST_SRC:.c=.o)
 # Don't require update-mocks hack unless developer mode.
@@ -35,22 +35,22 @@ TOOLS_WIRE_DEPS := $(BOLT_DEPS) tools/test/test_cases $(wildcard tools/gen/*_tem
 $(TOOL_TEST_OBJS) $(TOOL_GEN_OBJS): $(TOOL_GEN_HEADER)
 $(TOOL_TEST_PROGRAMS): $(TOOL_TEST_COMMON_OBJS) $(TOOL_GEN_SRC:.c=.o) tools/test/enum.o
 
-tools/test/gen_test.h: $(TOOLS_WIRE_DEPS) tools/test/Makefile
+tools/test/test_gen.h: $(TOOLS_WIRE_DEPS) tools/test/Makefile
 	$(BOLT_GEN) --page header $@ test_type < tools/test/test_cases > $@
 
-.INTERMEDIATE: tools/test/gen_test.c.tmp.c
+.INTERMEDIATE: tools/test/test_gen.c.tmp.c
 # Parallel make sometimes tries to use file before update-mocks, so split.
-tools/test/gen_test.c.tmp.c: $(TOOLS_WIRE_DEPS)
-	$(BOLT_GEN) --page impl tools/test/gen_test.h test_type < tools/test/test_cases > $@
+tools/test/test_gen.c.tmp.c: $(TOOLS_WIRE_DEPS)
+	$(BOLT_GEN) --page impl tools/test/test_gen.h test_type < tools/test/test_cases > $@
 
-tools/test/gen_test.c: tools/test/gen_test.c.tmp.c $(EXTERNAL_HEADERS) tools/test/gen_test.h
+tools/test/test_gen.c: tools/test/test_gen.c.tmp.c $(EXTERNAL_HEADERS) tools/test/test_gen.h
 	@MAKE=$(MAKE) tools/update-mocks.sh "$<" $(SUPPRESS_OUTPUT) && mv "$<" "$@"
 
-tools/test/gen_print.h: wire/onion$(EXP)_wiregen.h $(TOOLS_WIRE_DEPS)
+tools/test/print_gen.h: wire/onion$(EXP)_wiregen.h $(TOOLS_WIRE_DEPS)
 	$(BOLT_GEN) -P --page header $@ test_type < tools/test/test_cases > $@
 
-tools/test/gen_print.c: $(TOOLS_WIRE_DEPS)
-	echo '#include "gen_test.h"' > $@
+tools/test/print_gen.c: $(TOOLS_WIRE_DEPS)
+	echo '#include "test_gen.h"' > $@
 	$(BOLT_GEN) -P --page impl ${@:.c=.h} test_type < tools/test/test_cases >> $@
 
 ALL_TEST_PROGRAMS += $(TOOL_TEST_PROGRAMS)

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -14,14 +14,14 @@ TOOL_TEST_INCL_SRC := tools/test/enum.c
 TOOL_GEN_SRC := tools/test/test_gen.c tools/test/print_gen.c
 TOOL_GEN_OBJS := $(TOOL_GEN_SRC:.c=.o)
 TOOL_GEN_HEADER := tools/test/test_gen.h tools/test/print_gen.h
-TOOL_TEST_SRC := $(wildcard tools/test/run-*.c)
-TOOL_TEST_OBJS := $(TOOL_TEST_SRC:.c=.o)
 # Don't require update-mocks hack unless developer mode.
 ifeq ($(DEVELOPER),1)
-TOOL_TEST_PROGRAMS := $(TOOL_TEST_OBJS:.o=)
+TOOL_TEST_SRC := $(wildcard tools/test/run-*.c)
 else
-TOOL_TEST_PROGRAMS :=
+TOOL_TEST_SRC :=
 endif
+TOOL_TEST_OBJS := $(TOOL_TEST_SRC:.c=.o)
+TOOL_TEST_PROGRAMS := $(TOOL_TEST_OBJS:.o=)
 
 # Get dependencies correct
 ALL_C_SOURCES += $(TOOL_GEN_SRC) $(TOOL_TEST_SRC)

--- a/tools/test/run-test-wire.c
+++ b/tools/test/run-test-wire.c
@@ -1,5 +1,5 @@
-#include "gen_test.h"
-#include "gen_print.h"
+#include "test_gen.h"
+#include "print_gen.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/wallet/db_postgres.c
+++ b/wallet/db_postgres.c
@@ -1,9 +1,9 @@
-#include <wallet/db_common.h>
 #include "db_postgres_sqlgen.c"
 #include <ccan/ccan/tal/str/str.h>
 #include <ccan/endian/endian.h>
 #include <lightningd/log.h>
 #include <stdio.h>
+#include <wallet/db_common.h>
 
 #if HAVE_POSTGRES
 /* Indented in order not to trigger the inclusion order check */

--- a/wallet/db_sqlite3.c
+++ b/wallet/db_sqlite3.c
@@ -1,11 +1,11 @@
-#include <wallet/db_common.h>
 #include "db_sqlite3_sqlgen.c"
 #include <ccan/ccan/tal/str/str.h>
 #include <lightningd/log.h>
 #include <stdio.h>
+#include <wallet/db_common.h>
 
 #if HAVE_SQLITE3
-#include <sqlite3.h>
+  #include <sqlite3.h>
 
 #if !HAVE_SQLITE3_EXPANDED_SQL
 /* Prior to sqlite3 v3.14, we have to use tracing to dump statements */


### PR DESCRIPTION
We weren't doing include checks over all files, but fixing it revealed that there's no neat way of separating out gen_ files so I had to rename them...