### PR TITLE
dual_open: correct silent enum conversions

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -259,7 +259,19 @@ static const u8 *hsm_req(const tal_t *ctx, const u8 *req TAKES)
 	return msg;
 }
 
+static enum tx_role their_tx_role(const struct peer *peer)
+{
+	return peer->channel->opener == LOCAL ?
+		TX_ACCEPTER : TX_INITIATOR;
+}
+
 #if EXPERIMENTAL_FEATURES
+static enum tx_role our_tx_role(const struct peer *peer)
+{
+	return peer->channel->opener == LOCAL ?
+		TX_INITIATOR : TX_ACCEPTER;
+}
+
 static const u8 *psbt_to_tx_sigs_msg(const tal_t *ctx,
 				     struct channel *channel,
 				     const struct wally_psbt *psbt)
@@ -516,20 +528,6 @@ static void announce_channel(struct peer *peer)
 			take(towire_gossipd_local_channel_announcement(NULL,
 								       cannounce)));
 	send_channel_update(peer, 0);
-}
-
-#if EXPERIMENTAL_FEATURES
-static enum tx_role our_tx_role(const struct peer *peer)
-{
-	return peer->channel->opener == LOCAL ?
-		TX_INITIATOR : TX_ACCEPTER;
-}
-#endif
-
-static enum tx_role their_tx_role(const struct peer *peer)
-{
-	return peer->channel->opener == LOCAL ?
-		TX_ACCEPTER : TX_INITIATOR;
 }
 
 static void channel_announcement_negotiate(struct peer *peer)

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -468,7 +468,7 @@ openchannel2_changed_deserialize(struct openchannel2_psbt_payload *payload,
 		return false;
 
 	/* Add serials to PSBT, before checking for required fields */
-	psbt_add_serials(psbt, REMOTE);
+	psbt_add_serials(psbt, TX_ACCEPTER);
 
 	if (!psbt_has_required_fields(psbt))
 		fatal("Plugin supplied PSBT that's missing required fields. %s",


### PR DESCRIPTION
We were silently converting a side enum (3 variants) to a tx_role enum
(2 variants).

Signed-off-by: Antoine Poinsot <darosior@protonmail.com>

Changelog-None