### PR TITLE
Prelim patches for dual-funding/multifundchannel

### DIFF
--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -261,16 +261,28 @@ u8 *bitcoin_redeem_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key)
 	return script;
 }
 
-u8 *bitcoin_scriptsig_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key)
+u8 *bitcoin_scriptsig_redeem(const tal_t *ctx,
+			     const u8 *redeemscript TAKES)
 {
-	u8 *redeemscript = bitcoin_redeem_p2sh_p2wpkh(ctx, key), *script;
+	u8 *script;
 
 	/* BIP141: The scriptSig must be exactly a push of the BIP16
 	 * redeemScript or validation fails. */
 	script = tal_arr(ctx, u8, 0);
-	script_push_bytes(&script, redeemscript, tal_count(redeemscript));
-	tal_free(redeemscript);
+	script_push_bytes(&script, redeemscript,
+			  tal_count(redeemscript));
+
+	if (taken(redeemscript))
+		tal_free(redeemscript);
+
 	return script;
+}
+
+u8 *bitcoin_scriptsig_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key)
+{
+	u8 *redeemscript =
+		bitcoin_redeem_p2sh_p2wpkh(NULL, key);
+	return bitcoin_scriptsig_redeem(ctx, take(redeemscript));
 }
 
 u8 **bitcoin_witness_p2wpkh(const tal_t *ctx,

--- a/bitcoin/script.h
+++ b/bitcoin/script.h
@@ -43,6 +43,10 @@ u8 *bitcoin_redeem_p2pkh(const tal_t *ctx, const struct pubkey *pubkey,
 /* Create the redeemscript for a P2SH + P2WPKH. */
 u8 *bitcoin_redeem_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key);
 
+/* Create the scriptsig for a redeemscript */
+u8 *bitcoin_scriptsig_redeem(const tal_t *ctx,
+			     const u8 *redeemscript TAKES);
+
 /* Create scriptsig for p2sh-p2wpkh */
 u8 *bitcoin_scriptsig_p2sh_p2wpkh(const tal_t *ctx, const struct pubkey *key);
 

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2134,7 +2134,7 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 
 		elem = cast_const2(const struct witness_element **,
 				   ws[j++]->witness_element);
-		psbt_input_set_final_witness_stack(peer->psbt, in, elem);
+		psbt_finalize_input(peer->psbt, in, elem);
 	}
 
 	/* Send to the peer controller, who will broadcast the funding_tx

--- a/common/psbt_internal.h
+++ b/common/psbt_internal.h
@@ -12,15 +12,17 @@ struct witness_element;
 #endif /* EXPERIMENTAL_FEATURES */
 
 #if EXPERIMENTAL_FEATURES
-/* psbt_input_set_final_witness_stack - Set the witness stack for PSBT input
+/* psbt_finalize_input - Finalize an input with a given witness stack
  *
+ * Sets the given witness elements onto the PSBT. Also finalizes
+ * the redeem_script, if any.
  * @ctx - the context to allocate onto
  * @in - input to set final_witness for
  * @witness_element - elements to add to witness stack
  */
-void psbt_input_set_final_witness_stack(const tal_t *ctx,
-					struct wally_psbt_input *in,
-					const struct witness_element **elements);
+void psbt_finalize_input(const tal_t *ctx,
+			 struct wally_psbt_input *in,
+			 const struct witness_element **elements);
 /* psbt_to_witness_stacks - Take all sigs on a PSBT and copy to a
  * 			    witness_stack
  *

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -650,6 +650,10 @@ fetch_psbt_changes(struct state *state, const struct wally_psbt *psbt)
 		status_failed(STATUS_FAIL_MASTER_IO, "%s", err);
 	else if (fromwire_dual_open_psbt_updated(state, msg, &updated_psbt)) {
 		return updated_psbt;
+#if DEVELOPER
+	} else if (fromwire_dual_open_dev_memleak(msg)) {
+		handle_dev_memleak(state, msg);
+#endif /* DEVELOPER */
 	} else
 		master_badmsg(fromwire_peektype(msg), msg);
 
@@ -1953,8 +1957,8 @@ static u8 *handle_master_in(struct state *state)
 	case WIRE_DUAL_OPEN_DEV_MEMLEAK:
 #if DEVELOPER
 		handle_dev_memleak(state, msg);
-		return NULL;
 #endif
+		return NULL;
 	case WIRE_DUAL_OPEN_OPENER_INIT:
 		return opener_start(state, msg);
 	/* mostly handled inline */
@@ -1975,8 +1979,8 @@ static u8 *handle_master_in(struct state *state)
 #if DEVELOPER
 	case WIRE_CUSTOMMSG_OUT:
 		dualopend_send_custommsg(state, msg);
-		return NULL;
 #else
+		return NULL;
 	case WIRE_CUSTOMMSG_OUT:
 #endif
 	/* We send these. */


### PR DESCRIPTION
Few small things before we get into "dual-funding over multifundchannel" fun.

- 'finalize' the redeemscript (if present) at the same time that we set final witness-scripts. libwally `finalize` ignores unfinalized redeemscripts if `final_witness_stack` field is set.
- correctly handle dev-memleak calls that are made while we're doing tx output/input updates.

Changelog-None