### PR TITLE
gossmap: fix return of gossmap_xxx_has_feature, rename.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -140,7 +140,7 @@ static int map_feature_test(const struct gossmap *map,
 
 	assert(COMPULSORY_FEATURE(compulsory_bit) == compulsory_bit);
 	if (bytenum >= len)
-		return false;
+		return -1;
 
 	/* Note reversed! */
 	bits = map_u8(map, offset + len - 1 - bytenum);
@@ -876,7 +876,7 @@ u8 *gossmap_node_get_announce(const tal_t *ctx,
  *     * [`point`:`node_id_1`]
  *     * [`point`:`node_id_2`]
  */
-int gossmap_chan_has_feature(const struct gossmap *map,
+int gossmap_chan_get_feature(const struct gossmap *map,
 			     const struct gossmap_chan *c,
 			     int fbit)
 {
@@ -903,7 +903,7 @@ int gossmap_chan_has_feature(const struct gossmap *map,
  *    * [`u16`:`addrlen`]
  *    * [`addrlen*byte`:`addresses`]
  */
-int gossmap_node_has_feature(const struct gossmap *map,
+int gossmap_node_get_feature(const struct gossmap *map,
 			     const struct gossmap_node *n,
 			     int fbit)
 {

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -90,12 +90,12 @@ u8 *gossmap_node_get_announce(const tal_t *ctx,
 			      const struct gossmap_node *n);
 
 /* Return the feature bit (odd or even), or -1 if neither. */
-int gossmap_chan_has_feature(const struct gossmap *map,
+int gossmap_chan_get_feature(const struct gossmap *map,
 			     const struct gossmap_chan *c,
 			     int fbit);
 
 /* Return the feature bit (odd or even), or -1 if neither (or no announcement) */
-int gossmap_node_has_feature(const struct gossmap *map,
+int gossmap_node_get_feature(const struct gossmap *map,
 			     const struct gossmap_node *n,
 			     int fbit);
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -652,7 +652,7 @@ static struct route_hop *route_hops_from_route(const tal_t *ctx,
 		/* nodeid is nodeid of *dst* */
 		dst = gossmap_nth_node(gossmap, r[i]->c, !r[i]->dir);
 		gossmap_node_get_id(gossmap, dst, &hops[i].nodeid);
-		if (gossmap_node_has_feature(gossmap, dst, OPT_VAR_ONION) != -1)
+		if (gossmap_node_get_feature(gossmap, dst, OPT_VAR_ONION) != -1)
 			hops[i].style = ROUTE_HOP_TLV;
 		else
 			hops[i].style = ROUTE_HOP_LEGACY;


### PR DESCRIPTION
1. One place returned false instead of -1.
2. The names implied it returned a bool, and it doesn't.

Fix both, and curse C's loose typing a little.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None