### PR TITLE
Updates to dual-funding spec

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2114,7 +2114,7 @@ static void handle_tx_sigs(struct peer *peer, const u8 *msg)
 	for (size_t i = 0; i < peer->psbt->num_inputs; i++) {
 		struct wally_psbt_input *in =
 			&peer->psbt->inputs[i];
-		u16 in_serial;
+		u64 in_serial;
 		const struct witness_element **elem;
 
 		if (!psbt_get_serial_id(&in->unknowns, &in_serial)) {

--- a/common/psbt_internal.c
+++ b/common/psbt_internal.c
@@ -25,7 +25,7 @@ psbt_to_witness_stacks(const tal_t *ctx,
 		       enum tx_role side_to_stack)
 {
 	size_t stack_index;
-	u16 serial_id;
+	u64 serial_id;
 	const struct witness_stack **stacks
 		= tal_arr(ctx, const struct witness_stack *, psbt->num_inputs);
 

--- a/common/psbt_open.c
+++ b/common/psbt_open.c
@@ -9,10 +9,10 @@
 #include <common/pseudorand.h>
 #include <common/utils.h>
 
-bool psbt_get_serial_id(const struct wally_map *map, u16 *serial_id)
+bool psbt_get_serial_id(const struct wally_map *map, u64 *serial_id)
 {
 	size_t value_len;
-	beint16_t bev;
+	beint64_t bev;
 	void *result = psbt_get_lightning(map, PSBT_TYPE_SERIAL_ID, &value_len);
 	if (!result)
 		return false;
@@ -21,14 +21,14 @@ bool psbt_get_serial_id(const struct wally_map *map, u16 *serial_id)
 		return false;
 
 	memcpy(&bev, result, value_len);
-	*serial_id = be16_to_cpu(bev);
+	*serial_id = be64_to_cpu(bev);
 	return true;
 }
 
 static int compare_serials(const struct wally_map *map_a,
 			   const struct wally_map *map_b)
 {
-	u16 serial_left, serial_right;
+	u64 serial_left, serial_right;
 	bool ok;
 
 	ok = psbt_get_serial_id(map_a, &serial_left);
@@ -324,10 +324,10 @@ struct psbt_changeset *psbt_get_changeset(const tal_t *ctx,
 
 void psbt_input_set_serial_id(const tal_t *ctx,
 			      struct wally_psbt_input *input,
-			      u16 serial_id)
+			      u64 serial_id)
 {
 	u8 *key = psbt_make_key(tmpctx, PSBT_TYPE_SERIAL_ID, NULL);
-	beint16_t bev = cpu_to_be16(serial_id);
+	beint64_t bev = cpu_to_be64(serial_id);
 
 	psbt_input_set_unknown(ctx, input, key, &bev, sizeof(bev));
 }
@@ -335,17 +335,17 @@ void psbt_input_set_serial_id(const tal_t *ctx,
 
 void psbt_output_set_serial_id(const tal_t *ctx,
 			       struct wally_psbt_output *output,
-			       u16 serial_id)
+			       u64 serial_id)
 {
 	u8 *key = psbt_make_key(tmpctx, PSBT_TYPE_SERIAL_ID, NULL);
-	beint16_t bev = cpu_to_be16(serial_id);
+	beint64_t bev = cpu_to_be64(serial_id);
 	psbt_output_set_unknown(ctx, output, key, &bev, sizeof(bev));
 }
 
-int psbt_find_serial_input(struct wally_psbt *psbt, u16 serial_id)
+int psbt_find_serial_input(struct wally_psbt *psbt, u64 serial_id)
 {
 	for (size_t i = 0; i < psbt->num_inputs; i++) {
-		u16 in_serial;
+		u64 in_serial;
 		if (!psbt_get_serial_id(&psbt->inputs[i].unknowns, &in_serial))
 			continue;
 		if (in_serial == serial_id)
@@ -354,10 +354,10 @@ int psbt_find_serial_input(struct wally_psbt *psbt, u16 serial_id)
 	return -1;
 }
 
-int psbt_find_serial_output(struct wally_psbt *psbt, u16 serial_id)
+int psbt_find_serial_output(struct wally_psbt *psbt, u64 serial_id)
 {
 	for (size_t i = 0; i < psbt->num_outputs; i++) {
-		u16 out_serial;
+		u64 out_serial;
 		if (!psbt_get_serial_id(&psbt->outputs[i].unknowns, &out_serial))
 			continue;
 		if (out_serial == serial_id)
@@ -366,14 +366,14 @@ int psbt_find_serial_output(struct wally_psbt *psbt, u16 serial_id)
 	return -1;
 }
 
-static u16 get_random_serial(enum tx_role role)
+static u64 get_random_serial(enum tx_role role)
 {
-	return pseudorand(1 << 15) << 1 | role;
+	return pseudorand_u64() << 1 | role;
 }
 
-u16 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role)
+u64 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role)
 {
-	u16 serial_id;
+	u64 serial_id;
 
 	while ((serial_id = get_random_serial(role)) &&
 		psbt_find_serial_input(psbt, serial_id) != -1) {
@@ -383,9 +383,9 @@ u16 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role)
 	return serial_id;
 }
 
-u16 psbt_new_output_serial(struct wally_psbt *psbt, enum tx_role role)
+u64 psbt_new_output_serial(struct wally_psbt *psbt, enum tx_role role)
 {
-	u16 serial_id;
+	u64 serial_id;
 
 	while ((serial_id = get_random_serial(role)) &&
 		psbt_find_serial_output(psbt, serial_id) != -1) {
@@ -397,7 +397,7 @@ u16 psbt_new_output_serial(struct wally_psbt *psbt, enum tx_role role)
 
 bool psbt_has_required_fields(struct wally_psbt *psbt)
 {
-	u16 serial_id;
+	u64 serial_id;
 	for (size_t i = 0; i < psbt->num_inputs; i++) {
 		struct wally_psbt_input *input = &psbt->inputs[i];
 
@@ -428,7 +428,7 @@ bool psbt_has_required_fields(struct wally_psbt *psbt)
 
 bool psbt_side_finalized(const struct wally_psbt *psbt, enum tx_role role)
 {
-	u16 serial_id;
+	u64 serial_id;
 	for (size_t i = 0; i < psbt->num_inputs; i++) {
 		if (!psbt_get_serial_id(&psbt->inputs[i].unknowns,
 					&serial_id)) {
@@ -446,7 +446,7 @@ bool psbt_side_finalized(const struct wally_psbt *psbt, enum tx_role role)
 /* Adds serials to inputs + outputs that don't have one yet */
 void psbt_add_serials(struct wally_psbt *psbt, enum tx_role role)
 {
-	u16 serial_id;
+	u64 serial_id;
 	for (size_t i = 0; i < psbt->num_inputs; i++) {
 		/* Skip ones that already have a serial id */
 		if (psbt_get_serial_id(&psbt->inputs[i].unknowns, &serial_id))

--- a/common/psbt_open.h
+++ b/common/psbt_open.h
@@ -48,7 +48,7 @@ struct psbt_changeset {
  * Returns false if serial_id is not present
  */
 WARN_UNUSED_RESULT bool psbt_get_serial_id(const struct wally_map *map,
-					   u16 *serial_id);
+					   u64 *serial_id);
 
 /* psbt_sort_by_serial_id - Sort PSBT by serial_ids
  *
@@ -82,7 +82,7 @@ struct psbt_changeset *psbt_get_changeset(const tal_t *ctx,
  */
 void psbt_input_set_serial_id(const tal_t *ctx,
 			      struct wally_psbt_input *input,
-			       u16 serial_id);
+			       u64 serial_id);
 /* psbt_output_set_serial_id - Sets a serial id on given output
  *
  * @ctx - tal context for allocations
@@ -91,7 +91,7 @@ void psbt_input_set_serial_id(const tal_t *ctx,
  */
 void psbt_output_set_serial_id(const tal_t *ctx,
 			       struct wally_psbt_output *output,
-			       u16 serial_id);
+			       u64 serial_id);
 
 /* psbt_sort_by_serial_id - Sorts the inputs + outputs by serial_id
  *
@@ -108,7 +108,7 @@ void psbt_sort_by_serial_id(struct wally_psbt *psbt);
  *
  * Returns index of input with matching serial if found or -1
  */
-int psbt_find_serial_input(struct wally_psbt *psbt, u16 serial_id);
+int psbt_find_serial_input(struct wally_psbt *psbt, u64 serial_id);
 
 /* psbt_find_serial_output - Checks outputs for provided serial_id
  *
@@ -117,7 +117,7 @@ int psbt_find_serial_input(struct wally_psbt *psbt, u16 serial_id);
  *
  * Returns index of output with matching serial if found or -1
  */
-int psbt_find_serial_output(struct wally_psbt *psbt, u16 serial_id);
+int psbt_find_serial_output(struct wally_psbt *psbt, u64 serial_id);
 
 /* psbt_new_input_serial - Generate a new serial for an input for {role}
  *
@@ -126,7 +126,7 @@ int psbt_find_serial_output(struct wally_psbt *psbt, u16 serial_id);
  *
  * Returns a new, unique serial of the correct parity for the specified {role}
  */
-u16 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role);
+u64 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role);
 
 /* psbt_new_output_serial - Generate a new serial for an output for {role}
  *
@@ -135,7 +135,7 @@ u16 psbt_new_input_serial(struct wally_psbt *psbt, enum tx_role role);
  *
  * Returns a new, unique serial of the correct parity for the specified {role}
  */
-u16 psbt_new_output_serial(struct wally_psbt *psbt, enum tx_role role);
+u64 psbt_new_output_serial(struct wally_psbt *psbt, enum tx_role role);
 
 /* psbt_has_required_fields - Validates psbt field completion
  *

--- a/common/test/exp-run-psbt_diff.c
+++ b/common/test/exp-run-psbt_diff.c
@@ -42,9 +42,9 @@ u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_u8 */
 u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u8 called!\n"); abort(); }
-/* Generated stub for pseudorand */
-uint64_t pseudorand(uint64_t max UNNEEDED)
-{ fprintf(stderr, "pseudorand called!\n"); abort(); }
+/* Generated stub for pseudorand_u64 */
+uint64_t pseudorand_u64(void)
+{ fprintf(stderr, "pseudorand_u64 called!\n"); abort(); }
 /* Generated stub for towire */
 void towire(u8 **pptr UNNEEDED, const void *data UNNEEDED, size_t len UNNEEDED)
 { fprintf(stderr, "towire called!\n"); abort(); }

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -307,7 +307,7 @@ static bool psbt_side_contribs_changed(struct wally_psbt *orig,
 				       enum side opener_side)
 {
 	struct psbt_changeset *cs;
-	u16 serial_id;
+	u64 serial_id;
 	bool ok;
 
 	cs = psbt_get_changeset(tmpctx, orig, new);
@@ -636,7 +636,7 @@ static void opener_psbt_changed(struct subd *dualopend,
 				const u8 *msg)
 {
 	struct channel_id cid;
-	u16 funding_serial;
+	u64 funding_serial;
 	struct wally_psbt *psbt;
 	struct json_stream *response;
 	struct command *cmd = uc->fc->cmd;
@@ -656,7 +656,7 @@ static void opener_psbt_changed(struct subd *dualopend,
 			type_to_string(tmpctx, struct channel_id, &cid));
 	json_add_psbt(response, "psbt", psbt);
 	json_add_bool(response, "commitments_secured", false);
-	json_add_num(response, "funding_serial", funding_serial);
+	json_add_u64(response, "funding_serial", funding_serial);
 
 	uc->cid = cid;
 	uc->fc->inflight = true;
@@ -911,7 +911,7 @@ cleanup:
 static void accepter_psbt_changed(struct subd *dualopend,
 				  const u8 *msg)
 {
-	u16 unused;
+	u64 unused;
 	struct openchannel2_psbt_payload *payload =
 		tal(dualopend, struct openchannel2_psbt_payload);
 	payload->dualopend = dualopend;

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -100,7 +100,7 @@ struct state {
 	enum tx_role our_role;
 
 	u32 feerate_per_kw_funding;
-	u32 feerate_per_kw;
+	u32 feerate_per_kw_commitment;
 
 	struct bitcoin_txid funding_txid;
 	u16 funding_txout;
@@ -1108,7 +1108,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 				    &state->remoteconf.dust_limit,
 				    &state->remoteconf.max_htlc_value_in_flight,
 				    &state->remoteconf.htlc_minimum,
-				    &state->feerate_per_kw,
+				    &state->feerate_per_kw_commitment,
 				    &state->remoteconf.to_self_delay,
 				    &state->remoteconf.max_accepted_htlcs,
 				    &state->tx_locktime,
@@ -1176,7 +1176,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 					 feerate_max,
 					 feerate_min,
 					 feerate_best,
-					 state->feerate_per_kw,
+					 state->feerate_per_kw_commitment,
 					 state->remoteconf.to_self_delay,
 					 state->remoteconf.max_accepted_htlcs,
 					 channel_flags,
@@ -1240,7 +1240,8 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 	/* Now that we know the total of the channel, we can set the reserve */
 	set_reserve(state, total);
 
-	if (!check_config_bounds(tmpctx, total, state->feerate_per_kw,
+	if (!check_config_bounds(tmpctx, total,
+				 state->feerate_per_kw_commitment,
 				 state->max_to_self_delay,
 				 state->min_effective_htlc_capacity,
 				 &state->remoteconf,
@@ -1352,7 +1353,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 					     our_msats,
 					     take(new_fee_states(
 							     NULL, REMOTE,
-							     &state->feerate_per_kw)),
+							     &state->feerate_per_kw_commitment)),
 					     &state->localconf,
 					     &state->remoteconf,
 					     &state->our_points, &state->their_points,
@@ -1465,7 +1466,7 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 					    total,
 					    state->accepter_funding,
 					    channel_flags,
-					    state->feerate_per_kw,
+					    state->feerate_per_kw_commitment,
 					    msg,
 					    state->localconf.channel_reserve,
 					    state->upfront_shutdown_script[LOCAL],
@@ -1497,7 +1498,7 @@ static u8 *opener_start(struct state *state, u8 *msg)
 					  &psbt,
 					  &state->opener_funding,
 					  &state->upfront_shutdown_script[LOCAL],
-					  &state->feerate_per_kw,
+					  &state->feerate_per_kw_commitment,
 					  &state->feerate_per_kw_funding,
 					  &channel_flags))
 		master_badmsg(WIRE_DUAL_OPEN_OPENER_INIT, msg);
@@ -1548,7 +1549,7 @@ static u8 *opener_start(struct state *state, u8 *msg)
 				   state->localconf.dust_limit,
 				   state->localconf.max_htlc_value_in_flight,
 				   state->localconf.htlc_minimum,
-				   state->feerate_per_kw,
+				   state->feerate_per_kw_commitment,
 				   state->localconf.to_self_delay,
 				   state->localconf.max_accepted_htlcs,
 				   state->tx_locktime,
@@ -1679,7 +1680,8 @@ static u8 *opener_start(struct state *state, u8 *msg)
 	 * set the reserve */
 	set_reserve(state, total);
 
-	if (!check_config_bounds(tmpctx, total, state->feerate_per_kw,
+	if (!check_config_bounds(tmpctx, total,
+				 state->feerate_per_kw_commitment,
 				 state->max_to_self_delay,
 				 state->min_effective_htlc_capacity,
 				 &state->remoteconf,
@@ -1738,7 +1740,7 @@ static u8 *opener_start(struct state *state, u8 *msg)
 					     total,
 					     our_msats,
 					     take(new_fee_states(NULL, LOCAL,
-								 &state->feerate_per_kw)),
+								 &state->feerate_per_kw_commitment)),
 					     &state->localconf,
 					     &state->remoteconf,
 					     &state->our_points,
@@ -1889,7 +1891,7 @@ static u8 *opener_start(struct state *state, u8 *msg)
 					    total,
 					    state->opener_funding,
 					    channel_flags,
-					    state->feerate_per_kw,
+					    state->feerate_per_kw_commitment,
 					    NULL,
 					    state->localconf.channel_reserve,
 					    state->upfront_shutdown_script[LOCAL],

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -1162,40 +1162,20 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 		return NULL;
 	}
 
-	/* BOLT #2:
-	 *
-	 * The receiving node MUST fail the channel if:
-	 *...
-	 *  - it considers `feerate_per_kw` too small for timely processing or
-	 *    unreasonably large.
-	 */
-	if (state->feerate_per_kw_funding < state->min_feerate) {
-		negotiation_failed(state, false,
-				   "feerate_per_kw_funding %u below minimum %u",
-				   state->feerate_per_kw_funding, state->min_feerate);
-		return NULL;
-	}
-
-	if (state->feerate_per_kw_funding > state->max_feerate) {
-		negotiation_failed(state, false,
-				   "feerate_per_kw_funding %u above maximum %u",
-				   state->feerate_per_kw_funding, state->max_feerate);
-		return NULL;
-	}
-
 	/* We can figure out the channel id now */
 	derive_channel_id_v2(&state->channel_id,
 			     &state->our_points.revocation,
 			     &state->their_points.revocation);
 
 	/* FIXME: pass the podle back also */
-	/* FIXME: pass back the feerate options */
 	msg = towire_dual_open_got_offer(NULL,
 					 state->opener_funding,
 					 state->remoteconf.dust_limit,
 					 state->remoteconf.max_htlc_value_in_flight,
 					 state->remoteconf.htlc_minimum,
-					 state->feerate_per_kw_funding,
+					 feerate_max,
+					 feerate_min,
+					 feerate_best,
 					 state->feerate_per_kw,
 					 state->remoteconf.to_self_delay,
 					 state->remoteconf.max_accepted_htlcs,
@@ -1216,7 +1196,9 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 		return NULL;
 	}
 	if (!fromwire_dual_open_got_offer_reply(state, msg,
-						&state->accepter_funding, &psbt,
+						&state->accepter_funding,
+						&state->feerate_per_kw_funding,
+						&psbt,
 						&state->upfront_shutdown_script[LOCAL]))
 		master_badmsg(WIRE_DUAL_OPEN_GOT_OFFER_REPLY, msg);
 
@@ -1280,8 +1262,6 @@ static u8 *accepter_start(struct state *state, const u8 *oc2_msg)
 				    tal_count(state->upfront_shutdown_script[LOCAL]), 0);
 	}
 
-	/* FIXME: actually look up a good feerate */
-	state->feerate_per_kw_funding = feerate_best;
 	msg = towire_accept_channel2(tmpctx, &state->channel_id,
 				     state->accepter_funding,
 				     state->feerate_per_kw_funding,
@@ -1513,7 +1493,6 @@ static u8 *opener_start(struct state *state, u8 *msg)
 	secp256k1_ecdsa_signature *htlc_sigs;
 	u32 feerate_min, feerate_max, feerate_best;
 
-	/* FIXME: get these from opener !? */
 	if (!fromwire_dual_open_opener_init(state, msg,
 					  &psbt,
 					  &state->opener_funding,
@@ -1527,8 +1506,26 @@ static u8 *opener_start(struct state *state, u8 *msg)
 	state->tx_locktime = psbt->tx->locktime;
 	open_tlv = tlv_opening_tlvs_new(tmpctx);
 
-	feerate_min = state->feerate_per_kw_funding - 1;
-	feerate_max = state->feerate_per_kw_funding + 1;
+	feerate_min = state->min_feerate;
+	feerate_max = state->max_feerate;
+	if (state->feerate_per_kw_funding > state->max_feerate) {
+		status_info("Selected funding feerate %d is greater than"
+			    " current suggested max %d, adjusing max upwards"
+			    " to match.",
+			    state->feerate_per_kw_funding,
+			    state->max_feerate);
+
+		feerate_max = state->feerate_per_kw_funding;
+	}
+	if (state->feerate_per_kw_funding < state->min_feerate) {
+		status_info("Selected funding feerate %d is less than"
+			    " current suggested min %d, adjusing min downwards"
+			    " to match.",
+			    state->feerate_per_kw_funding,
+			    state->min_feerate);
+
+		feerate_min = state->feerate_per_kw_funding;
+	}
 	feerate_best = state->feerate_per_kw_funding;
 
 	if (state->upfront_shutdown_script[LOCAL]) {

--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -36,7 +36,9 @@ msgdata,dual_open_got_offer,opener_funding,amount_sat,
 msgdata,dual_open_got_offer,dust_limit_satoshis,amount_sat,
 msgdata,dual_open_got_offer,max_htlc_value_in_flight_msat,amount_msat,
 msgdata,dual_open_got_offer,htlc_minimum_msat,amount_msat,
-msgdata,dual_open_got_offer,feerate_per_kw_funding,u32,
+msgdata,dual_open_got_offer,feerate_funding_max,u32,
+msgdata,dual_open_got_offer,feerate_funding_min,u32,
+msgdata,dual_open_got_offer,feerate_funding_best,u32,
 msgdata,dual_open_got_offer,feerate_per_kw,u32,
 msgdata,dual_open_got_offer,to_self_delay,u16,
 msgdata,dual_open_got_offer,max_accepted_htlcs,u16,
@@ -48,6 +50,7 @@ msgdata,dual_open_got_offer,shutdown_scriptpubkey,u8,shutdown_len
 # master->dualopend: reply back with our first funding info/contribs
 msgtype,dual_open_got_offer_reply,7105
 msgdata,dual_open_got_offer_reply,accepter_funding,amount_sat,
+msgdata,dual_open_got_offer_reply,feerate_funding,u32,
 msgdata,dual_open_got_offer_reply,psbt,wally_psbt,
 msgdata,dual_open_got_offer_reply,shutdown_len,u16,
 msgdata,dual_open_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len

--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -86,7 +86,7 @@ msgdata,dual_open_commit_rcvd,remote_shutdown_scriptpubkey,u8,remote_shutdown_le
 # dualopend->master: peer updated the psbt
 msgtype,dual_open_psbt_changed,7107
 msgdata,dual_open_psbt_changed,channel_id,channel_id,
-msgdata,dual_open_psbt_changed,funding_serial,u16,
+msgdata,dual_open_psbt_changed,funding_serial,u64,
 msgdata,dual_open_psbt_changed,psbt,wally_psbt,
 
 # master->dualopend: we updated the psbt

--- a/openingd/dualopend_wiregen.c
+++ b/openingd/dualopend_wiregen.c
@@ -310,18 +310,18 @@ bool fromwire_dual_open_commit_rcvd(const tal_t *ctx, const void *p, struct chan
 
 /* WIRE: DUAL_OPEN_PSBT_CHANGED */
 /* dualopend->master: peer updated the psbt */
-u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u16 funding_serial, const struct wally_psbt *psbt)
+u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u64 funding_serial, const struct wally_psbt *psbt)
 {
 	u8 *p = tal_arr(ctx, u8, 0);
 
 	towire_u16(&p, WIRE_DUAL_OPEN_PSBT_CHANGED);
 	towire_channel_id(&p, channel_id);
-	towire_u16(&p, funding_serial);
+	towire_u64(&p, funding_serial);
 	towire_wally_psbt(&p, psbt);
 
 	return memcheck(p, tal_count(p));
 }
-bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u16 *funding_serial, struct wally_psbt **psbt)
+bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u64 *funding_serial, struct wally_psbt **psbt)
 {
 	const u8 *cursor = p;
 	size_t plen = tal_count(p);
@@ -329,7 +329,7 @@ bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct cha
 	if (fromwire_u16(&cursor, &plen) != WIRE_DUAL_OPEN_PSBT_CHANGED)
 		return false;
  	fromwire_channel_id(&cursor, &plen, channel_id);
- 	*funding_serial = fromwire_u16(&cursor, &plen);
+ 	*funding_serial = fromwire_u64(&cursor, &plen);
  	*psbt = fromwire_wally_psbt(ctx, &cursor, &plen);
 	return cursor != NULL;
 }
@@ -479,4 +479,4 @@ bool fromwire_dual_open_dev_memleak_reply(const void *p, bool *leak)
  	*leak = fromwire_bool(&cursor, &plen);
 	return cursor != NULL;
 }
-// SHA256STAMP:ed548e8b85302ef620646a1aab503b1279fece3b9d9aeedd47a371fa2a9fbe56
+// SHA256STAMP:b1bf5b7fc522f2b0d940704f6f9e1699db093da76ca88d3ce7c925d40569ab14

--- a/openingd/dualopend_wiregen.h
+++ b/openingd/dualopend_wiregen.h
@@ -59,13 +59,13 @@ bool fromwire_dual_open_init(const tal_t *ctx, const void *p, const struct chain
 
 /* WIRE: DUAL_OPEN_GOT_OFFER */
 /*  dualopend->master: they offered channel */
-u8 *towire_dual_open_got_offer(const tal_t *ctx, struct amount_sat opener_funding, struct amount_sat dust_limit_satoshis, struct amount_msat max_htlc_value_in_flight_msat, struct amount_msat htlc_minimum_msat, u32 feerate_per_kw_funding, u32 feerate_per_kw, u16 to_self_delay, u16 max_accepted_htlcs, u8 channel_flags, u32 locktime, const u8 *shutdown_scriptpubkey);
-bool fromwire_dual_open_got_offer(const tal_t *ctx, const void *p, struct amount_sat *opener_funding, struct amount_sat *dust_limit_satoshis, struct amount_msat *max_htlc_value_in_flight_msat, struct amount_msat *htlc_minimum_msat, u32 *feerate_per_kw_funding, u32 *feerate_per_kw, u16 *to_self_delay, u16 *max_accepted_htlcs, u8 *channel_flags, u32 *locktime, u8 **shutdown_scriptpubkey);
+u8 *towire_dual_open_got_offer(const tal_t *ctx, struct amount_sat opener_funding, struct amount_sat dust_limit_satoshis, struct amount_msat max_htlc_value_in_flight_msat, struct amount_msat htlc_minimum_msat, u32 feerate_funding_max, u32 feerate_funding_min, u32 feerate_funding_best, u32 feerate_per_kw, u16 to_self_delay, u16 max_accepted_htlcs, u8 channel_flags, u32 locktime, const u8 *shutdown_scriptpubkey);
+bool fromwire_dual_open_got_offer(const tal_t *ctx, const void *p, struct amount_sat *opener_funding, struct amount_sat *dust_limit_satoshis, struct amount_msat *max_htlc_value_in_flight_msat, struct amount_msat *htlc_minimum_msat, u32 *feerate_funding_max, u32 *feerate_funding_min, u32 *feerate_funding_best, u32 *feerate_per_kw, u16 *to_self_delay, u16 *max_accepted_htlcs, u8 *channel_flags, u32 *locktime, u8 **shutdown_scriptpubkey);
 
 /* WIRE: DUAL_OPEN_GOT_OFFER_REPLY */
 /*  master->dualopend: reply back with our first funding info/contribs */
-u8 *towire_dual_open_got_offer_reply(const tal_t *ctx, struct amount_sat accepter_funding, const struct wally_psbt *psbt, const u8 *our_shutdown_scriptpubkey);
-bool fromwire_dual_open_got_offer_reply(const tal_t *ctx, const void *p, struct amount_sat *accepter_funding, struct wally_psbt **psbt, u8 **our_shutdown_scriptpubkey);
+u8 *towire_dual_open_got_offer_reply(const tal_t *ctx, struct amount_sat accepter_funding, u32 feerate_funding, const struct wally_psbt *psbt, const u8 *our_shutdown_scriptpubkey);
+bool fromwire_dual_open_got_offer_reply(const tal_t *ctx, const void *p, struct amount_sat *accepter_funding, u32 *feerate_funding, struct wally_psbt **psbt, u8 **our_shutdown_scriptpubkey);
 
 /* WIRE: DUAL_OPEN_COMMIT_RCVD */
 /*  dualopend->master: ready to commit channel open to database and */
@@ -109,4 +109,4 @@ bool fromwire_dual_open_dev_memleak_reply(const void *p, bool *leak);
 
 
 #endif /* LIGHTNING_OPENINGD_DUALOPEND_WIREGEN_H */
-// SHA256STAMP:b1bf5b7fc522f2b0d940704f6f9e1699db093da76ca88d3ce7c925d40569ab14
+// SHA256STAMP:f08f0c25f359d5c8f843d78c94eca9b0543b39e62a34983f6572adf92ff02aaa

--- a/openingd/dualopend_wiregen.h
+++ b/openingd/dualopend_wiregen.h
@@ -75,8 +75,8 @@ bool fromwire_dual_open_commit_rcvd(const tal_t *ctx, const void *p, struct chan
 
 /* WIRE: DUAL_OPEN_PSBT_CHANGED */
 /*  dualopend->master: peer updated the psbt */
-u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u16 funding_serial, const struct wally_psbt *psbt);
-bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u16 *funding_serial, struct wally_psbt **psbt);
+u8 *towire_dual_open_psbt_changed(const tal_t *ctx, const struct channel_id *channel_id, u64 funding_serial, const struct wally_psbt *psbt);
+bool fromwire_dual_open_psbt_changed(const tal_t *ctx, const void *p, struct channel_id *channel_id, u64 *funding_serial, struct wally_psbt **psbt);
 
 /* WIRE: DUAL_OPEN_PSBT_UPDATED */
 /*  master->dualopend: we updated the psbt */
@@ -109,4 +109,4 @@ bool fromwire_dual_open_dev_memleak_reply(const void *p, bool *leak);
 
 
 #endif /* LIGHTNING_OPENINGD_DUALOPEND_WIREGEN_H */
-// SHA256STAMP:ed548e8b85302ef620646a1aab503b1279fece3b9d9aeedd47a371fa2a9fbe56
+// SHA256STAMP:b1bf5b7fc522f2b0d940704f6f9e1699db093da76ca88d3ce7c925d40569ab14

--- a/wire/extracted_peer_experimental_dual_fund_more
+++ b/wire/extracted_peer_experimental_dual_fund_more
@@ -1,0 +1,50 @@
+--- wire/peer_exp_wire.csv	2020-09-16 20:59:05.170975876 -0500
++++ -	2020-10-22 16:56:33.413063210 -0500
+@@ -33,7 +33,7 @@
+ tlvdata,n2,tlv2,cltv_expiry,tu32,
+ msgtype,tx_add_input,66
+ msgdata,tx_add_input,channel_id,channel_id,
+-msgdata,tx_add_input,serial_id,u16,
++msgdata,tx_add_input,serial_id,u64,
+ msgdata,tx_add_input,prevtx_len,u16,
+ msgdata,tx_add_input,prevtx,byte,prevtx_len
+ msgdata,tx_add_input,prevtx_vout,u32,
+@@ -48,16 +48,16 @@
+ tlvdata,tx_add_input_tlvs,podle_proof,sig,byte,32
+ msgtype,tx_add_output,67
+ msgdata,tx_add_output,channel_id,channel_id,
+-msgdata,tx_add_output,serial_id,u16,
++msgdata,tx_add_output,serial_id,u64,
+ msgdata,tx_add_output,sats,u64,
+ msgdata,tx_add_output,scriptlen,u16,
+ msgdata,tx_add_output,script,byte,scriptlen
+ msgtype,tx_remove_input,68
+ msgdata,tx_remove_input,channel_id,channel_id,
+-msgdata,tx_remove_input,serial_id,u16,
++msgdata,tx_remove_input,serial_id,u64,
+ msgtype,tx_remove_output,69
+ msgdata,tx_remove_output,channel_id,channel_id,
+-msgdata,tx_remove_output,serial_id,u16,
++msgdata,tx_remove_output,serial_id,u64,
+ msgtype,tx_complete,70
+ msgdata,tx_complete,channel_id,channel_id,
+ msgtype,tx_signatures,71
+@@ -125,7 +125,9 @@
+ msgtype,open_channel2,64
+ msgdata,open_channel2,chain_hash,chain_hash,
+ msgdata,open_channel2,podle_h2,sha256,
+-msgdata,open_channel2,feerate_per_kw_funding,u32,
++msgdata,open_channel2,feerate_funding_max,u32,
++msgdata,open_channel2,feerate_funding_min,u32,
++msgdata,open_channel2,feerate_funding_best,u32,
+ msgdata,open_channel2,funding_satoshis,u64,
+ msgdata,open_channel2,dust_limit_satoshis,u64,
+ msgdata,open_channel2,max_htlc_value_in_flight_msat,u64,
+@@ -148,6 +150,7 @@
+ msgtype,accept_channel2,65
+ msgdata,accept_channel2,channel_id,channel_id,
+ msgdata,accept_channel2,funding_satoshis,u64,
++msgdata,accept_channel2,feerate_funding,u32,
+ msgdata,accept_channel2,dust_limit_satoshis,u64,
+ msgdata,accept_channel2,max_htlc_value_in_flight_msat,u64,
+ msgdata,accept_channel2,htlc_minimum_msat,u64,


### PR DESCRIPTION
Here, we incorporate two new changes to the draft spec:
- `serial_id` goes from a u16 to u64 (this is to avoid collisions when doing multifundchannels)
- We update the feerate protocol. Instead of the opener setting a 'firm' feerate, we allow the accepter to choose a feerate within a provided range. This PR includes updates turn the current 'implicit' acceptable range to be explicit (in the role of the opener). In the accepter case, we merely delegate the decision to the plugin via the `openchannel2` hook.

Changelog-None.