### PR TITLE
Order specifications for hooks

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -47,9 +47,9 @@ void clear_softref_(const tal_t *outer, size_t outersize, void **ptr);
 /* Note: p is never a complex expression, otherwise this multi-evaluates! */
 #define tal_arr_expand(p, s)						\
 	do {								\
-		size_t n = tal_count(*(p));				\
-		tal_resize((p), n+1);					\
-		(*(p))[n] = (s);					\
+		size_t n_ = tal_count(*(p));				\
+		tal_resize((p), n_+1);					\
+		(*(p))[n_] = (s);					\
 	} while(0)
 
 /**

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -688,11 +688,15 @@ The call semantics of the hooks, i.e., when and how hooks are called, depend
 on the hook type. Most hooks are currently set to `single`-mode. In this mode
 only a single plugin can register the hook, and that plugin will get called
 for each event of that type. If a second plugin attempts to register the hook
-it gets killed and a corresponding log entry will be added to the logs. In
-`chain`-mode multiple plugins can register for the hook type and they are
-called in any order which meets their `before` and `after` requirements
-if a matching event is triggered. Each plugin can then
-handle the event or defer by returning a `continue` result like the following:
+it gets killed and a corresponding log entry will be added to the logs.
+
+In `chain`-mode multiple plugins can register for the hook type and
+they are called in any order they are loaded (i.e. cmdline order
+first, configuration order file second: though note that the order of
+plugin directories is implementation-dependent), overriden only by
+`before` and `after` requirements the plugin's hook registrations specify.
+Each plugin can then handle the event or defer by returning a
+`continue` result like the following:
 
 ```json
 {

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -93,8 +93,8 @@ example:
     "disconnect"
   ],
   "hooks": [
-    "openchannel",
-    "htlc_accepted"
+    { "name": "openchannel", "before": ["another_plugin"] },
+    { "name": "htlc_accepted" }
   ],
   "features": {
     "node": "D0000000",
@@ -678,13 +678,20 @@ declares that it'd like to be consulted on what to do next for certain
 events in the daemon. A hook can then decide how `lightningd` should
 react to the given event.
 
+When hooks are registered, they can optionally specify "before" and
+"after" arrays of plugin names, which control what order they will be
+called in.  If a plugin name is unknown, it is ignored, otherwise if the
+hook calls cannot be ordered to satisfy the specifications of all
+plugin hooks, the plugin registration will fail.
+
 The call semantics of the hooks, i.e., when and how hooks are called, depend
 on the hook type. Most hooks are currently set to `single`-mode. In this mode
 only a single plugin can register the hook, and that plugin will get called
 for each event of that type. If a second plugin attempts to register the hook
 it gets killed and a corresponding log entry will be added to the logs. In
 `chain`-mode multiple plugins can register for the hook type and they are
-called sequentially if a matching event is triggered. Each plugin can then
+called in any order which meets their `before` and `after` requirements
+if a matching event is triggered. Each plugin can then
 handle the event or defer by returning a `continue` result like the following:
 
 ```json

--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -519,14 +519,17 @@ additional paths too:
 
  \fBplugin\fR=\fIPATH\fR
 Specify a plugin to run as part of c-lightning\. This can be specified
-multiple times to add multiple plugins\.
+multiple times to add multiple plugins\.  Note that unless plugins themselves
+specify ordering requirements for being called on various hooks, plugins will
+be ordered by commandline, then config file\.
 
 
  \fBplugin-dir\fR=\fIDIRECTORY\fR
 Specify a directory to look for plugins; all executable files not
 containing punctuation (other than \fI\.\fR, \fI-\fR or \fI_) in 'DIRECTORY\fR are
 loaded\. \fIDIRECTORY\fR must exist; this can be specified multiple times to
-add multiple directories\.
+add multiple directories\.  The ordering of plugins within a directory
+is currently unspecified\.
 
 
  \fBclear-plugins\fR
@@ -581,4 +584,4 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 
-\" SHA256STAMP:6b275a3227db6565ad3c5369b95d3eefe9472864b8ed9e6c5c768981cdf23b8f
+\" SHA256STAMP:c927bd3afb61288bb67d941d113cdeefe1363b0c7a28936ef30d43af3ce66098

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -427,13 +427,16 @@ additional paths too:
 
  **plugin**=*PATH*
 Specify a plugin to run as part of c-lightning. This can be specified
-multiple times to add multiple plugins.
+multiple times to add multiple plugins.  Note that unless plugins themselves
+specify ordering requirements for being called on various hooks, plugins will
+be ordered by commandline, then config file.
 
  **plugin-dir**=*DIRECTORY*
 Specify a directory to look for plugins; all executable files not
 containing punctuation (other than *.*, *-* or *\_) in 'DIRECTORY* are
 loaded. *DIRECTORY* must exist; this can be specified multiple times to
-add multiple directories.
+add multiple directories.  The ordering of plugins within a directory
+is currently unspecified.
 
  **clear-plugins**
 This option clears all *plugin*, *important-plugin*, and *plugin-dir* options

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1078,9 +1078,12 @@ static const char *plugin_hooks_add(struct plugin *plugin, const char *buffer,
 			name = json_strdup(tmpctx, buffer, nametok);
 			beforetok = json_get_member(buffer, t, "before");
 			aftertok = json_get_member(buffer, t, "after");
-		} else {
+		} else if (deprecated_apis) {
 			name = json_strdup(tmpctx, plugin->buffer, t);
 			beforetok = aftertok = NULL;
+		} else {
+			return tal_fmt(plugin,
+				    "hooks must be an array of objects");
 		}
 
 		hook = plugin_hook_register(plugin, name);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1064,7 +1064,7 @@ static const char *plugin_hooks_add(struct plugin *plugin, const char *buffer,
 		return NULL;
 
 	json_for_each_arr(i, t, hookstok) {
-		char *name;
+		char *name, *depfail;
 		struct plugin_hook *hook;
 
 		if (t->type == JSMN_OBJECT) {
@@ -1093,6 +1093,12 @@ static const char *plugin_hooks_add(struct plugin *plugin, const char *buffer,
 		}
 
 		plugin_hook_add_deps(hook, plugin, buffer, beforetok, aftertok);
+		depfail = plugin_hook_make_ordered(tmpctx, hook);
+		if (depfail)
+			return tal_fmt(plugin,
+				       "Cannot correctly order hook %s:"
+				       "conflicts in %s",
+				       name, depfail);
 		tal_free(name);
 	}
 	return NULL;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -58,6 +58,7 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
 	p->json_cmds = tal_arr(p, struct command *, 0);
 	p->blacklist = tal_arr(p, const char *, 0);
 	p->shutdown = false;
+	p->plugin_idx = 0;
 #if DEVELOPER
 	p->dev_builtin_plugins_unimportant = false;
 #endif /* DEVELOPER */
@@ -199,6 +200,7 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES,
 	p->used = 0;
 	p->subscriptions = NULL;
 	p->dynamic = false;
+	p->index = plugins->plugin_idx++;
 
 	p->log = new_log(p, plugins->log_book, NULL, "plugin-%s",
 			 path_basename(tmpctx, p->cmd));

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -50,6 +50,9 @@ struct plugin {
 
 	enum plugin_state plugin_state;
 
+	/* Our unique index, which is default hook ordering. */
+	u64 index;
+
 	/* If this plugin can be restarted without restarting lightningd */
 	bool dynamic;
 
@@ -112,6 +115,9 @@ struct plugins {
 
 	/* Whether we are shutting down (`plugins_free` is called) */
 	bool shutdown;
+
+	/* Index to show what order they were added in */
+	u64 plugin_idx;
 
 #if DEVELOPER
 	/* Whether builtin plugins should be overridden as unimportant.  */

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -168,4 +168,7 @@ void plugin_hook_add_deps(struct plugin_hook *hook,
 			  const jsmntok_t *before,
 			  const jsmntok_t *after);
 
+/* Returns NULL on success, error string allocated off ctx on failure. */
+char *plugin_hook_make_ordered(const tal_t *ctx, struct plugin_hook *hook);
+
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_HOOK_H */

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -168,7 +168,7 @@ void plugin_hook_add_deps(struct plugin_hook *hook,
 			  const jsmntok_t *before,
 			  const jsmntok_t *after);
 
-/* Returns NULL on success, error string allocated off ctx on failure. */
-char *plugin_hook_make_ordered(const tal_t *ctx, struct plugin_hook *hook);
+/* Returns array of plugins which cannot be ordered (empty on success) */
+struct plugin **plugin_hooks_make_ordered(const tal_t *ctx);
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_HOOK_H */

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -77,7 +77,7 @@ struct plugin_hook {
 
 	/* Which plugins have registered this hook? This is a `tal_arr`
 	 * initialized at creation. */
-	struct plugin **plugins;
+	struct hook_instance **hooks;
 };
 AUTODATA_TYPE(hooks, struct plugin_hook);
 
@@ -155,15 +155,17 @@ bool plugin_hook_continue(void *arg, const char *buffer, const jsmntok_t *toks);
 	AUTODATA(hooks, &name##_hook_gen);                                     \
 	PLUGIN_HOOK_CALL_DEF(name, cb_arg_type)
 
-bool plugin_hook_register(struct plugin *plugin, const char *method);
-
-/* Unregister a hook a plugin has registered for */
-bool plugin_hook_unregister(struct plugin *plugin, const char *method);
-
-/* Unregister all hooks a plugin has registered for */
-void plugin_hook_unregister_all(struct plugin *plugin);
+struct plugin_hook *plugin_hook_register(struct plugin *plugin,
+					 const char *method);
 
 /* Special sync plugin hook for db. */
 void plugin_hook_db_sync(struct db *db);
+
+/* Add dependencies for this hook. */
+void plugin_hook_add_deps(struct plugin_hook *hook,
+			  struct plugin *plugin,
+			  const char *buffer,
+			  const jsmntok_t *before,
+			  const jsmntok_t *after);
 
 #endif /* LIGHTNING_LIGHTNINGD_PLUGIN_HOOK_H */

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -628,8 +628,25 @@ handle_getmanifest(struct command *getmanifest_cmd,
 	json_array_end(params);
 
 	json_array_start(params, "hooks");
-	for (size_t i = 0; i < p->num_hook_subs; i++)
-		json_add_string(params, NULL, p->hook_subs[i].name);
+	for (size_t i = 0; i < p->num_hook_subs; i++) {
+		json_object_start(params, NULL);
+		json_add_string(params, "name", p->hook_subs[i].name);
+		if (p->hook_subs[i].before) {
+			json_array_start(params, "before");
+			for (size_t j = 0; p->hook_subs[i].before[j]; j++)
+				json_add_string(params, NULL,
+						p->hook_subs[i].before[j]);
+			json_array_end(params);
+		}
+		if (p->hook_subs[i].after) {
+			json_array_start(params, "after");
+			for (size_t j = 0; p->hook_subs[i].after[j]; j++)
+				json_add_string(params, NULL,
+						p->hook_subs[i].after[j]);
+			json_array_end(params);
+		}
+		json_object_end(params);
+	}
 	json_array_end(params);
 
 	if (p->our_features != NULL) {

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -93,6 +93,8 @@ struct plugin_hook {
 	struct command_result *(*handle)(struct command *cmd,
 	                                 const char *buf,
 	                                 const jsmntok_t *params);
+	/* If non-NULL, these are NULL-terminated arrays of deps */
+	const char **before, **after;
 };
 
 /* Return the feature set of the current lightning node */

--- a/tests/plugins/dep_a.py
+++ b/tests/plugins/dep_a.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+"""A simple plugin that must come before dep_b.
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted', before=['dep_b.py'])
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    print("htlc_accepted called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/dep_b.py
+++ b/tests/plugins/dep_b.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+"""A simple plugin that must come after dep_a, before dep_c.
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted', before=['dep_c.py'], after=['dep_a.py'])
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    print("htlc_accepted called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/dep_c.py
+++ b/tests/plugins/dep_c.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+"""A simple plugin that must come before dep_a.
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted', before=['dep_a.py'])
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    print("htlc_accepted called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/dep_d.py
+++ b/tests/plugins/dep_d.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+"""A simple plugin that must come before dep_e.
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted', before=['dep_e.py'])
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    print("htlc_accepted called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/dep_e.py
+++ b/tests/plugins/dep_e.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+"""A simple plugin that registers an htlc_accepted hook..
+"""
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(htlc, plugin, **kwargs):
+    print("htlc_accepted called")
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/test_libplugin.c
+++ b/tests/plugins/test_libplugin.c
@@ -118,9 +118,14 @@ static const struct plugin_command commands[] = { {
 	}
 };
 
+static const char *before[] = { "dummy", NULL };
+static const char *after[] = { "dummy", NULL };
+
 static const struct plugin_hook hooks[] = { {
 		"peer_connected",
 		json_peer_connected,
+		before,
+		after
 	}
 };
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1992,7 +1992,6 @@ def test_htlc_accepted_hook_failcodes(node_factory):
             l1.rpc.pay(inv)
 
 
-@pytest.mark.xfail(strict=True)
 def test_hook_dep(node_factory):
     dep_a = os.path.join(os.path.dirname(__file__), 'plugins/dep_a.py')
     dep_b = os.path.join(os.path.dirname(__file__), 'plugins/dep_b.py')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2033,7 +2033,6 @@ def test_hook_dep(node_factory):
     assert not l1.daemon.is_in_log("unknown plugin (?!dep_a.py)")
 
 
-@pytest.mark.xfail(strict=True)
 def test_hook_dep_stable(node_factory):
     # Load in order A, D, E, B.
     # A says it has to be before B, D says it has to be before E.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1992,8 +1992,10 @@ def test_hook_dep(node_factory):
                                                   {'plugin': [dep_a, dep_b]}])
 
     # l2 complains about the two unknown plugins, only.
-    assert l2.daemon.is_in_log("unknown plugin dep_a.py")
-    assert l2.daemon.is_in_log("unknown plugin dep_c.py")
+    # (Could be already past)
+    l2.daemon.logsearch_start = 0
+    l2.daemon.wait_for_logs(["unknown plugin dep_a.py",
+                             "unknown plugin dep_c.py"])
     assert not l2.daemon.is_in_log("unknown plugin (?!dep_a.py|dep_c.py)")
     logstart = l2.daemon.logsearch_start
 
@@ -2037,7 +2039,9 @@ def test_hook_dep_stable(node_factory):
                                               {'plugin': [dep_a, dep_d, dep_e, dep_b]}])
 
     # dep_a mentions deb_c, but nothing else should be unknown.
-    assert l2.daemon.is_in_log("unknown plugin dep_c.py")
+    # (Could be already past)
+    l2.daemon.logsearch_start = 0
+    l2.daemon.wait_for_log("unknown plugin dep_c.py")
     assert not l2.daemon.is_in_log("unknown plugin (?!|dep_c.py)")
 
     l1.pay(l2, 100000)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1992,15 +1992,30 @@ def test_htlc_accepted_hook_failcodes(node_factory):
             l1.rpc.pay(inv)
 
 
+@pytest.mark.xfail(strict=True)
 def test_hook_dep(node_factory):
     dep_a = os.path.join(os.path.dirname(__file__), 'plugins/dep_a.py')
     dep_b = os.path.join(os.path.dirname(__file__), 'plugins/dep_b.py')
     dep_c = os.path.join(os.path.dirname(__file__), 'plugins/dep_c.py')
-    l1, l2 = node_factory.line_graph(2, opts=[{}, {'plugin': dep_b}])
+    l1, l2, l3 = node_factory.line_graph(3, opts=[{},
+                                                  {'plugin': dep_b},
+                                                  {'plugin': [dep_a, dep_b]}])
+
+    # l2 complains about the two unknown plugins, only.
+    assert l2.daemon.is_in_log("unknown plugin dep_a.py")
+    assert l2.daemon.is_in_log("unknown plugin dep_c.py")
+    assert not l2.daemon.is_in_log("unknown plugin (?!dep_a.py|dep_c.py)")
+    logstart = l2.daemon.logsearch_start
+
+    # l3 complains about the dep_c, only.
+    assert l3.daemon.is_in_log("unknown plugin dep_c.py")
+    assert not l3.daemon.is_in_log("unknown plugin (?!dep_c.py)")
 
     # A says it has to be before B.
     l2.rpc.plugin_start(plugin=dep_a)
     l2.daemon.wait_for_log(r"started.*dep_a.py")
+    # Still doesn't know about c.
+    assert l2.daemon.is_in_log("unknown plugin dep_c.py", logstart)
 
     l1.pay(l2, 100000)
     # They must be called in this order!
@@ -2008,8 +2023,12 @@ def test_hook_dep(node_factory):
     l2.daemon.wait_for_log(r"dep_b.py: htlc_accepted called")
 
     # But depc will not load, due to cyclical dep
-    with pytest.raises(RpcError, match=r'Cannot correctly order hook htlc_accepted'):
+    with pytest.raises(RpcError, match=r'Cannot meet required hook dependencies'):
         l2.rpc.plugin_start(plugin=dep_c)
 
     l1.rpc.plugin_start(plugin=dep_c)
     l1.daemon.wait_for_log(r"started.*dep_c.py")
+
+    # Complaints about unknown plugin a, but nothing else
+    assert l1.daemon.is_in_log("unknown plugin dep_a.py")
+    assert not l1.daemon.is_in_log("unknown plugin (?!dep_a.py)")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -612,18 +612,9 @@ def test_openchannel_hook_chaining(node_factory, bitcoind):
     with pytest.raises(RpcError, match=r'They sent error channel'):
         l1.rpc.fundchannel(l2.info['id'], 100005)
 
-    # Note: hook chain order is currently undefined, because hooks are registerd
-    #       as a result of the getmanifest call, which may take some random time.
-    #       We need to workaround that fact, so test can be stable
-    correct_order = l2.daemon.is_in_log(hook_msg + "reject for a reason")
-    if correct_order:
-        assert l2.daemon.wait_for_log(hook_msg + "reject for a reason")
-        # the other plugin must not be called
-        assert not l2.daemon.is_in_log("reject on principle")
-    else:
-        assert l2.daemon.wait_for_log(hook_msg + "reject on principle")
-        # the other plugin must not be called
-        assert not l2.daemon.is_in_log("reject for a reason")
+    assert l2.daemon.wait_for_log(hook_msg + "reject for a reason")
+    # the third plugin must now not be called anymore
+    assert not l2.daemon.is_in_log("reject on principle")
 
     # 100000sat is good for hook_accepter, so it should fail 'on principle'
     # at third hook openchannel_reject.py


### PR DESCRIPTION
This allows hooks to specify they must be before/after some other plugins.  Either by basename or full pathname.

As our plugin ecosystem grows and gets more sophisticated, such conflicts will inevitably occur where multiple plugins want to ensure they are called in certain order.  

We could implement a priority number system, but that's usually just window-dressing on what people really want (though, unlike this, would allow you to specify that you must be first, or last: we could add wildcards if we wanted to).

Getting this in now means that after a few releases, plugin authors will simply be able to assume its existence.

Fixes: #4005 (thanks @m-schmoock for pointing that out!)