### PR TITLE
wire: remove declaration of towire_tlvs since its implementation is already removed

### DIFF
--- a/wire/tlvstream.h
+++ b/wire/tlvstream.h
@@ -27,12 +27,6 @@ struct tlv_field {
 	u8 *value;
 };
 
-/* Append a stream of tlvs: types[] must be in increasing type order! */
-void towire_tlvs(u8 **pptr,
-		 const struct tlv_record_type types[],
-		 size_t num_types,
-		 const void *record);
-
 /* Given any tlvstream serialize the raw fields (untyped ones). */
 void towire_tlvstream_raw(u8 **pptr, const struct tlv_field *fields);
 


### PR DESCRIPTION
Implementation of towire_tlvs was removed from wire/tlvstream.c at db92c2ac5ec5cf46bad6023f7560a3e06c7a9e39

Signed-off-by: YOSHIDA Masanori <masanori.yoshida@gmail.com>
Changelog-None