### PR TITLE
Hsmtool: enable dumping output descriptors of onchain wallet

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -21,6 +21,7 @@ COMMON_SRC_NOGEN :=				\
 	common/daemon_conn.c			\
 	common/decode_array.c			\
 	common/derive_basepoints.c		\
+	common/descriptor_checksum.c		\
 	common/dev_disconnect.c			\
 	common/dijkstra.c			\
 	common/ecdh_hsmd.c			\

--- a/common/descriptor_checksum.c
+++ b/common/descriptor_checksum.c
@@ -1,0 +1,82 @@
+#include <ccan/short_types/short_types.h>
+#include <common/descriptor_checksum.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+static const char CHECKSUM_CHARSET[] = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static const char INPUT_CHARSET[] =
+	"0123456789()[],'/*abcdefgh@:$%{}"
+	"IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~"
+	"ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
+
+static inline int charset_find(char ch) {
+	for (size_t i = 0; i < sizeof(INPUT_CHARSET); i++) {
+		if (INPUT_CHARSET[i] == ch)
+			return i;
+	}
+	return -1;
+}
+
+static u64 polymod(u64 c, int val)
+{
+	u8 c0 = c >> 35;
+	c = ((c & 0x7ffffffff) << 5) ^ val;
+	if (c0 & 1) c ^= 0xf5dee51989;
+	if (c0 & 2) c ^= 0xa9fdca3312;
+	if (c0 & 4) c ^= 0x1bab10e32d;
+	if (c0 & 8) c ^= 0x3706b1677a;
+	if (c0 & 16) c ^= 0x644d626ffd;
+	return c;
+}
+
+
+bool descriptor_checksum(const char *descriptor, int desc_size,
+			 struct descriptor_checksum *checksum)
+{
+	checksum->csum[0] = 0;
+
+	int j;
+	u64 c = 1;
+	int cls = 0;
+	int clscount = 0;
+
+	for (int i = 0; i < desc_size; i++) {
+		char ch = descriptor[i];
+		int pos = charset_find(ch);
+		if (pos == -1) {
+			checksum->csum[0] = 0;
+			return false;
+		}
+		/* Emit a symbol for the position inside the group, for every
+		 * character. */
+		c = polymod(c, pos & 31);
+
+		/* Accumulate the group numbers */
+		cls = cls * 3 + (pos >> 5);
+
+		if (++clscount == 3) {
+			c = polymod(c, cls);
+			cls = 0;
+			clscount = 0;
+		}
+	}
+
+	if (clscount > 0)
+		c = polymod(c, cls);
+
+	/* Shift further to determine the checksum. */
+	for (j = 0; j < DESCRIPTOR_CHECKSUM_LENGTH; ++j)
+		c = polymod(c, 0);
+
+	/* Prevent appending zeroes from not affecting the checksum. */
+	c ^= 1;
+
+	for (j = 0; j < DESCRIPTOR_CHECKSUM_LENGTH; ++j)
+		checksum->csum[j] = CHECKSUM_CHARSET[(c >> (5 * (7 - j))) & 31];
+
+	checksum->csum[DESCRIPTOR_CHECKSUM_LENGTH] = 0;
+
+	return true;
+}

--- a/common/descriptor_checksum.h
+++ b/common/descriptor_checksum.h
@@ -1,0 +1,16 @@
+#ifndef LIGHTNING_COMMON_DESCRIPTOR_CHECKSUM_H
+#define LIGHTNING_COMMON_DESCRIPTOR_CHECKSUM_H
+#include "config.h"
+#include <stdbool.h>
+
+/* https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#reference */
+#define DESCRIPTOR_CHECKSUM_LENGTH 8
+
+struct descriptor_checksum {
+	char csum[DESCRIPTOR_CHECKSUM_LENGTH + 1];
+};
+
+bool descriptor_checksum(const char *descriptor, int desc_size,
+			 struct descriptor_checksum *checksum);
+
+#endif /* LIGHTNING_COMMON_DESCRIPTOR_CHECKSUM_H */

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -132,6 +132,14 @@ def bitcoind(directory, teardown_checks):
         raise ValueError("bitcoind is too old. At least version 16000 (v0.16.0)"
                          " is needed, current version is {}".format(info['version']))
 
+    # Make sure we have a wallet, starting with 0.21 there is no default wallet
+    # anymore.
+    # FIXME: if we update the testsuite to use the upcoming 0.21 release we
+    # could switch to descriptor wallets and speed bitcoind operations
+    # consequently.
+    if not bitcoind.rpc.listwallets():
+        bitcoind.rpc.createwallet("lightningd-tests")
+
     info = bitcoind.rpc.getblockchaininfo()
     # Make sure we have some spendable funds
     if info['blocks'] < 101:

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -108,7 +108,6 @@ C-lightning has an internal bitcoin wallet, which you can use to make "on-chain"
 transactions, (see [withdraw](https://lightning.readthedocs.io/lightning-withdraw.7.html).
 These on-chain funds are backed up via the HD wallet seed, stored in byte-form in `hsm_secret`.
 
-and which you can backup thanks to a seed stored in the `hsm_secret`.
 `lightningd` also stores information for funds locked in Lightning Network channels, which are stored
 in a database. This database is required for on-going channel updates as well as channel closure.
 There is no single-seed backup for funds locked in channels.

--- a/doc/lightning-hsmtool.8
+++ b/doc/lightning-hsmtool.8
@@ -55,6 +55,17 @@ Specify \fIpassword\fR if the \fBhsm_secret\fR is encrypted\.
 \fBgeneratehsm\fR \fIhsm_secret_path\fR
 Generates a new hsm_secret using BIP39\.
 
+
+ \fBdumponchaindescriptors\fR \fIhsm_secret\fR [\fIpassword\fR] [\fInetwork\fR]
+Dump output descriptors for our onchain wallet\.
+The descriptors can be used by external services to be able to generate
+addresses for our onchain wallet\. (for example on \fBbitcoind\fR using the
+\fBimportmulti\fR or \fBimportdescriptors\fR RPC calls)
+We need the path to the hsm_secret containing the wallet seed, and an optional
+(skip using \fB""\fR) password if it was encrypted\.
+To generate descriptors using testnet master keys, you may specify \fItestnet\fR as
+the last parameter\. By default, mainnet-encoded keys are generated\.
+
 .SH BUGS
 
 You should report bugs on our github issues page, and maybe submit a fix
@@ -80,4 +91,4 @@ Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:918981692d3840344e15c539b007b473d5ea0ad481145eccff092bf61ec6ddb0
+\" SHA256STAMP:3d847c486363271e0635336caca4fd14f5007a3ff463c223fb5bdb52dbf7b98e

--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -51,6 +51,16 @@ Specify *password* if the `hsm_secret` is encrypted.
 **generatehsm** *hsm\_secret\_path*
 Generates a new hsm_secret using BIP39.
 
+ **dumponchaindescriptors** *hsm_secret* \[*password*\] \[*network*\]
+Dump output descriptors for our onchain wallet.
+The descriptors can be used by external services to be able to generate
+addresses for our onchain wallet. (for example on `bitcoind` using the
+`importmulti` or `importdescriptors` RPC calls)
+We need the path to the hsm_secret containing the wallet seed, and an optional
+(skip using `""`) password if it was encrypted.
+To generate descriptors using testnet master keys, you may specify *testnet* as
+the last parameter. By default, mainnet-encoded keys are generated.
+
 BUGS
 ----
 

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -21,6 +21,7 @@ FUZZ_COMMON_OBJS := \
 	common/daemon.o					\
 	common/daemon_conn.o				\
 	common/derive_basepoints.o			\
+	common/descriptor_checksum.o			\
 	common/fee_states.o				\
 	common/htlc_state.o				\
 	common/permute_tx.o				\

--- a/tests/fuzz/fuzz-amount.c
+++ b/tests/fuzz/fuzz-amount.c
@@ -21,10 +21,7 @@ void run(const uint8_t *data, size_t size)
 
 	/* We should not crash when parsing any string. */
 
-	string = tal_arr(NULL, char, size);
-	for (size_t i = 0; i < size; i++)
-		string[i] = (char) data[i] % (CHAR_MAX + 1);
-
+	string = to_string(NULL, data, size);
 	parse_amount_msat(&msat, string, tal_count(string));
 	parse_amount_sat(&sat, string, tal_count(string));
 	tal_free(string);

--- a/tests/fuzz/fuzz-descriptor_checksum.c
+++ b/tests/fuzz/fuzz-descriptor_checksum.c
@@ -1,0 +1,20 @@
+#include <tests/fuzz/libfuzz.h>
+
+#include <ccan/tal/tal.h>
+#include <common/descriptor_checksum.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	char *string;
+	struct descriptor_checksum checksum;
+
+	/* We should not crash nor overflow the checksum buffer. */
+
+	string = to_string(NULL, data, size);
+	descriptor_checksum(string, tal_count(string), &checksum);
+	tal_free(string);
+}

--- a/tests/fuzz/libfuzz.c
+++ b/tests/fuzz/libfuzz.c
@@ -31,3 +31,13 @@ const uint8_t **get_chunks(const void *ctx, const uint8_t *data,
 
 	return chunks;
 }
+
+char *to_string(const tal_t *ctx, const u8 *data, size_t data_size)
+{
+	char *string = tal_arr(ctx, char, data_size);
+
+	for (size_t i = 0; i < data_size; i++)
+		string[i] = (char) data[i] % (CHAR_MAX + 1);
+
+	return string;
+}

--- a/tests/fuzz/libfuzz.h
+++ b/tests/fuzz/libfuzz.h
@@ -1,6 +1,8 @@
 #ifndef LIGHTNING_TESTS_FUZZ_LIBFUZZ_H
 #define LIGHTNING_TESTS_FUZZ_LIBFUZZ_H
 
+#include <ccan/ccan/short_types/short_types.h>
+#include <ccan/ccan/tal/tal.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -14,5 +16,8 @@ void run(const uint8_t *data, size_t size);
 /* Copy an array of chunks from data. */
 const uint8_t **get_chunks(const void *ctx, const uint8_t *data,
 			  size_t data_size, size_t chunk_size);
+
+/* Copy the data as a string. */
+char *to_string(const tal_t *ctx, const u8 *data, size_t data_size);
 
 #endif /* LIGHTNING_TESTS_FUZZ_LIBFUZZ_H */

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -17,7 +17,7 @@ tools/headerversions: FORCE tools/headerversions.o $(CCAN_OBJS)
 
 tools/check-bolt: tools/check-bolt.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS)
 
-tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bech32.o common/bigsize.o common/derive_basepoints.o common/node_id.o common/type_to_string.o wire/fromwire.o wire/towire.o
+tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bech32.o common/bigsize.o common/derive_basepoints.o common/descriptor_checksum.o common/node_id.o common/type_to_string.o wire/fromwire.o wire/towire.o
 
 tools/lightning-hsmtool: tools/hsmtool
 	cp $< $@


### PR DESCRIPTION
This adds a new `dumponchaindescriptors` command to `hsmtool` which can:
- Dump 2 `xpub`-based descriptors (one for each scriptPubKey type we create)
    - Useful for external service (see https://github.com/ElementsProject/lightning/issues/4110 for more details)
- ~~Possibly dump 2 `xpriv`-based descriptors (one for each scriptPubKey type we create)~~ Removed: footgun with anchor outputs (thanks niftynei!)
    - ~~Useful for backing up / restoring the onchain wallet easily~~

TODO:
- [x] A functional test restoring a descriptor on `bitcoind` asserting we retrieve all the funds
- [x] Manpage and an extended doc on how to restore the onchain wallet using `bitcoind`
- [x] Maybe add a network parameter finally ?.. ~~EDIT: maybe output both main and test extended keys ?..~~ EDIT 2: added a `testnet` parameter

Fixes https://github.com/ElementsProject/lightning/issues/4110
Ping @jb55 : finally got to https://github.com/jb55/clightning-dumpkeys/issues/2 :-)