### PR TITLE
chore: fixes a cppcheck false positive

### DIFF
--- a/common/test/run-features.c
+++ b/common/test/run-features.c
@@ -182,6 +182,8 @@ static void test_feature_set_or(void)
 static void test_feature_set_sub(void)
 {
 	struct feature_set *f1, *f2, *control;
+
+	/* cppcheck-suppress uninitvar - false positive on f1->bits */
 	for (size_t i = 0; i < ARRAY_SIZE(f1->bits); i++) {
 		f1 = talz(tmpctx, struct feature_set);
 		f2 = talz(tmpctx, struct feature_set);
@@ -214,6 +216,8 @@ static void test_feature_set_sub(void)
 static void test_feature_trim(void)
 {
 	struct feature_set *f;
+
+	/* cppcheck-suppress uninitvar - false positive on f->bits */
 	for (size_t i = 0; i < ARRAY_SIZE(f->bits); i++) {
 		f = talz(tmpctx, struct feature_set);
 


### PR DESCRIPTION
Just applied the same suppression as rusty in 6635fe12e4 

My cppcheck was complaining about the same issue in the following functions.
I wonder why travis does not care though, maybe its having another version.

Also, I must admit that I can't see why this is a 'false' positive :thinking: .
Update: Figured out myself :D 

Changelog-None