### PR TITLE
bitcoin/signature: wrap libwally call.

### DIFF
--- a/bitcoin/signature.c
+++ b/bitcoin/signature.c
@@ -127,6 +127,8 @@ void bitcoin_tx_hash_for_sig(const struct bitcoin_tx *tx, unsigned int in,
 	input_amt = psbt_input_get_amount(tx->psbt, in);
 	input_val_sats = input_amt.satoshis; /* Raw: type conversion */
 
+	/* Wally can allocate here, iff tx doesn't fit on stack */
+	tal_wally_start();
 	if (is_elements(chainparams)) {
 		ret = wally_tx_confidential_value_from_satoshi(input_val_sats, value, sizeof(value));
 		assert(ret == WALLY_OK);
@@ -141,6 +143,7 @@ void bitcoin_tx_hash_for_sig(const struct bitcoin_tx *tx, unsigned int in,
 		    sighash_type, flags, dest->sha.u.u8, sizeof(*dest));
 		assert(ret == WALLY_OK);
 	}
+	tal_wally_end(tx->wtx);
 }
 
 void sign_tx_input(const struct bitcoin_tx *tx,


### PR DESCRIPTION
If a tx is larger than 2k, libwally will do an alloc:

```
lightning_hsmd: common/setup.c:11: wally_tal: Assertion `wally_tal_ctx' failed.
0x11c283 wally_tal
	common/setup.c:11
0x15ebd1 wally_malloc
	../../../libwally-core/src/internal.c:233
0x171e9e tx_to_bip143_bytes
	../../../libwally-core/src/transaction.c:1918
0x172cda tx_to_bytes
	../../../libwally-core/src/transaction.c:2086
0x1759df tx_get_signature_hash
	../../../libwally-core/src/transaction.c:2776
0x175afd wally_tx_get_signature_hash
	../../../libwally-core/src/transaction.c:2800
0x175b62 wally_tx_get_btc_signature_hash
	../../../libwally-core/src/transaction.c:2810
0x1297d9 bitcoin_tx_hash_for_sig
	bitcoin/signature.c:139
0x1298ca sign_tx_input
	bitcoin/signature.c:161
0x10e701 handle_sign_remote_commitment_tx
	hsmd/hsmd.c:1011
0x110f7f handle_client
	hsmd/hsmd.c:1968
0x147a71 next_plan
	ccan/ccan/io/io.c:59
0x1485ee do_plan
	ccan/ccan/io/io.c:407
0x14862c io_ready
	ccan/ccan/io/io.c:417
0x14a7f2 io_loop
	ccan/ccan/io/poll.c:445
0x111125 main
	hsmd/hsmd.c:2040
```

I reduced that constant in libwally to 200, and ran the entire
test suite, and found no other places.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None