### PR TITLE
pyln-testing: require bitcoin v0.20.1 for PSBT handling, and create wallet for v0.21

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -127,9 +127,15 @@ def bitcoind(directory, teardown_checks):
 
     info = bitcoind.rpc.getnetworkinfo()
 
-    if info['version'] < 160000:
+    # FIXME: include liquid-regtest in this check after elementsd has been
+    # updated
+    if info['version'] < 200100 and env('TEST_NETWORK') != 'liquid-regtest':
         bitcoind.rpc.stop()
-        raise ValueError("bitcoind is too old. At least version 16000 (v0.16.0)"
+        raise ValueError("bitcoind is too old. At least version 20100 (v0.20.1)"
+                         " is needed, current version is {}".format(info['version']))
+    elif info['version'] < 160000:
+        bitcoind.rpc.stop()
+        raise ValueError("elementsd is too old. At least version 160000 (v0.16.0)"
                          " is needed, current version is {}".format(info['version']))
 
     info = bitcoind.rpc.getblockchaininfo()


### PR DESCRIPTION

With older bitcoind, PSBTs fail:

```
    def test_utxopsbt(node_factory, bitcoind, chainparams):
...
>       psbt = bitcoind.rpc.decodepsbt(funding['psbt'])

tests/test_wallet.py:561: 
...
self = <bitcoin.rpc.RawProxy object at 0x7f4ec602e100>, service_name = 'decodepsbt'
args = ('cHNidP8BADMCAAAAAaoMihSVXlpdBHGcJePiroqtwq/b1zu09j8IkTG4OKs7AQAAAAD9////AGYAAAAAAQDeAgAAAAABAefqB6BkZE1/AqXaf36T02a7.../7Stf971PEgvUXgvASECXPTIO6tIVxDih6tfKy6suj6WJhhjycwoaTeuso/AQ8llAAAAAQEfQEIPAAAAAAAWABQB+tkKvNZml+JZIWRyLeSpXr7hZQA=',)
postdata = '{"version": "1.1", "method": "decodepsbt", "params": ["cHNidP8BADMCAAAAAaoMihSVXlpdBHGcJePiroqtwq/b1zu09j8IkTG4OKs7AQ...gvUXgvASECXPTIO6tIVxDih6tfKy6suj6WJhhjycwoaTeuso/AQ8llAAAAAQEfQEIPAAAAAAAWABQB+tkKvNZml+JZIWRyLeSpXr7hZQA="], "id": 1}'
headers = {'Authorization': b'Basic cnBjdXNlcjpycGNwYXNz', 'Content-type': 'application/json', 'Host': 'localhost', 'User-Agent': 'AuthServiceProxy/0.1'}
response = {'error': {'code': -22, 'message': 'TX decode failed PSBT is not sane.: iostream error'}, 'id': 1, 'result': None}
```

But with bitcoind v0.21 (or at least, current master), we fail every test with:

```
    @pytest.fixture
    def bitcoind(directory, teardown_checks):
        chaind = network_daemons[env('TEST_NETWORK', 'regtest')]
        bitcoind = chaind(bitcoin_dir=directory)
    
        try:
            bitcoind.start()
        except Exception:
            bitcoind.stop()
            raise
    
        info = bitcoind.rpc.getnetworkinfo()
    
        if info['version'] < 160000:
            bitcoind.rpc.stop()
            raise ValueError("bitcoind is too old. At least version 16000 (v0.16.0)"
                             " is needed, current version is {}".format(info['version']))
    
        info = bitcoind.rpc.getblockchaininfo()
        # Make sure we have some spendable funds
        if info['blocks'] < 101:
>           bitcoind.generate_block(101 - info['blocks'])

contrib/pyln-testing/pyln/testing/fixtures.py:138: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
contrib/pyln-testing/pyln/testing/utils.py:397: in generate_block
    return self.rpc.generatetoaddress(numblocks, self.rpc.getnewaddress())
contrib/pyln-testing/pyln/testing/utils.py:320: in f
    return proxy._call(name, *args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <bitcoin.rpc.RawProxy object at 0x7f59352554f0>, service_name = 'getnewaddress', args = (), postdata = '{"version": "1.1", "method": "getnewaddress", "params": [], "id": 1}'
headers = {'Authorization': b'Basic cnBjdXNlcjpycGNwYXNz', 'Content-type': 'application/json', 'Host': 'localhost', 'User-Agent': 'AuthServiceProxy/0.1'}
response = {'error': {'code': -18, 'message': 'No wallet is loaded. Load a wallet using loadwallet or create a new one with createwallet. (Note: A default wallet is no longer automatically created)'}, 'id': 1, 'result': None}
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Changed: *** Requires bitcoind v0.20 or above ***