### PR TITLE
lightningd: fix crash if we abort after enabling notifications.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1347,7 +1347,9 @@ static struct command_result *json_notifications(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
-	cmd->jcon->notifications_enabled = *enable;
+	/* Catch the case where they sent this command then hung up. */
+	if (cmd->jcon)
+		cmd->jcon->notifications_enabled = *enable;
 	return command_success(cmd, json_stream_success(cmd));
 }
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1021,12 +1021,13 @@ int main(int argc, char *argv[])
 	assert(io_loop_ret == ld);
 	ld->state = LD_STATE_SHUTDOWN;
 
+	stop_fd = -1;
+	stop_response = NULL;
+
 	/* Were we exited via `lightningd_exit`?  */
 	if (ld->exit_code) {
 		exit_code = *ld->exit_code;
-		stop_fd = -1;
-		stop_response = NULL;
-	} else {
+	} else if (ld->stop_conn) {
 		/* Keep this fd around, to write final response at the end. */
 		stop_fd = io_conn_fd(ld->stop_conn);
 		io_close_taken_fd(ld->stop_conn);


### PR DESCRIPTION
The rpc_command hook means that we have a delay between receiving
a JSON command and actually calling the handler.  In this case, the
caller can go away:

```
==1348== Invalid write of size 1
==1348==    at 0x130EA6: json_notifications (jsonrpc.c:1350)
==1348==    by 0x12EE9E: command_exec (jsonrpc.c:636)
==1348==    by 0x12F3C6: rpc_command_hook_callback (jsonrpc.c:752)
==1348==    by 0x15AA08: plugin_hook_callback (plugin_hook.c:210)
==1348==    by 0x155C9D: plugin_response_handle (plugin.c:398)
==1348==    by 0x155E84: plugin_read_json_one (plugin.c:504)
==1348==    by 0x15603D: plugin_read_json (plugin.c:548)
==1348==    by 0x1D4AB3: next_plan (io.c:59)
==1348==    by 0x1D5630: do_plan (io.c:407)
==1348==    by 0x1D566E: io_ready (io.c:417)
==1348==    by 0x1D7834: io_loop (poll.c:445)
==1348==    by 0x12CFAC: io_loop_with_timers (io_loop_with_timers.c:24)
==1348==  Address 0x58 is not stack'd, malloc'd or (recently) free'd
==1348==
lightningd: FATAL SIGNAL 11 (version v0.9.1-266-ga4df315)
0x180f7e send_backtrace
	common/daemon.c:38
0x181024 crashdump
	common/daemon.c:51
0x5bd7fcf ???
	???:0
0x130ea6 json_notifications
	lightningd/jsonrpc.c:1350
0x12ee9e command_exec
	lightningd/jsonrpc.c:636
0x12f3c6 rpc_command_hook_callback
	lightningd/jsonrpc.c:752
0x15aa08 plugin_hook_callback
	lightningd/plugin_hook.c:210
0x155c9d plugin_response_handle
	lightningd/plugin.c:398
0x155e84 plugin_read_json_one
	lightningd/plugin.c:504
0x15603d plugin_read_json
	lightningd/plugin.c:548
0x1d4ab3 next_plan
	ccan/ccan/io/io.c:59
0x1d5630 do_plan
	ccan/ccan/io/io.c:407
0x1d566e io_ready
	ccan/ccan/io/io.c:417
0x1d7834 io_loop
	ccan/ccan/io/poll.c:445
0x12cfac io_loop_with_timers
	lightningd/io_loop_with_timers.c:24
0x132825 main
	lightningd/lightningd.c:1016
0x5bbab96 ???
	???:0
0x1159e9 ???
	???:0
0xffffffffffffffff ???
	???:0
Log dumped in crash.log.20201106001723
```

Changelog-None: introduced in this release.

-----

Edit by ZmnSCPxj:

Fixes: #4183 