### PR TITLE
Remove lnd gossip workaround, clean up for modern spec

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -606,7 +606,7 @@ static struct io_plan *connectd_new_peer(struct io_conn *conn,
 	peer->scid_query_nodes = NULL;
 	peer->scid_query_nodes_idx = 0;
 	peer->scid_query_outstanding = false;
-	peer->query_channel_blocks = NULL;
+	peer->query_channel_scids = NULL;
 	peer->query_channel_range_cb = NULL;
 	peer->num_pings_outstanding = 0;
 

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -64,7 +64,6 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <wire/peer_wire.h>
 #include <wire/wire_io.h>
 #include <wire/wire_sync.h>
 
@@ -606,7 +605,7 @@ static struct io_plan *connectd_new_peer(struct io_conn *conn,
 	peer->scid_query_nodes = NULL;
 	peer->scid_query_nodes_idx = 0;
 	peer->scid_query_outstanding = false;
-	peer->query_channel_scids = NULL;
+	peer->range_replies = NULL;
 	peer->query_channel_range_cb = NULL;
 	peer->num_pings_outstanding = 0;
 

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -7,6 +7,7 @@
 #include <ccan/timer/timer.h>
 #include <common/bigsize.h>
 #include <common/node_id.h>
+#include <wire/peer_wire.h>
 
 /* We talk to `hsmd` to sign our gossip messages with the node key */
 #define HSM_FD 3
@@ -61,6 +62,11 @@ struct daemon {
 	struct feature_set *our_features;
 };
 
+struct range_query_reply {
+	struct short_channel_id scid;
+	struct channel_update_timestamps ts;
+};
+
 /* This represents each peer we're gossiping with */
 struct peer {
 	/* daemon->peers */
@@ -97,12 +103,10 @@ struct peer {
 	/* What we're querying: [range_first_blocknum, range_end_blocknum) */
 	u32 range_first_blocknum, range_end_blocknum;
 	u32 range_prev_end_blocknum;
-	struct short_channel_id *query_channel_scids;
-	struct channel_update_timestamps *query_channel_timestamps;
+	struct range_query_reply *range_replies;
 	void (*query_channel_range_cb)(struct peer *peer,
 				       u32 first_blocknum, u32 number_of_blocks,
-				       const struct short_channel_id *scids,
-				       const struct channel_update_timestamps *,
+				       const struct range_query_reply *replies,
 				       bool complete);
 
 	/* The daemon_conn used to queue messages to/from the peer. */

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -2,7 +2,6 @@
 #define LIGHTNING_GOSSIPD_GOSSIPD_H
 #include "config.h"
 #include <bitcoin/block.h>
-#include <ccan/bitmap/bitmap.h>
 #include <ccan/list/list.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/timer/timer.h>
@@ -95,11 +94,9 @@ struct peer {
 	/* How many pongs are we expecting? */
 	size_t num_pings_outstanding;
 
-	/* Map of outstanding channel_range requests. */
-	bitmap *query_channel_blocks;
 	/* What we're querying: [range_first_blocknum, range_end_blocknum) */
 	u32 range_first_blocknum, range_end_blocknum;
-	u32 range_blocks_remaining;
+	u32 range_prev_end_blocknum;
 	struct short_channel_id *query_channel_scids;
 	struct channel_update_timestamps *query_channel_timestamps;
 	void (*query_channel_range_cb)(struct peer *peer,

--- a/gossipd/queries.c
+++ b/gossipd/queries.c
@@ -693,12 +693,15 @@ static u8 *append_range_reply(struct peer *peer,
 	u16 i, old_num, added;
 	const struct channel_update_timestamps *ts;
 	/* Zero means "no timestamp" */
-	const static struct channel_update_timestamps zero_ts;
+	const static struct channel_update_timestamps zero_ts = { 0, 0 };
 
 	if (timestamps_tlv) {
 		ts = decode_channel_update_timestamps(tmpctx,
 						      timestamps_tlv);
-		if (!ts || tal_count(ts) != tal_count(scids)) {
+		if (!ts)
+			return towire_errorfmt(peer, NULL,
+					       "reply_channel_range can't decode timestamps.");
+		if (tal_count(ts) != tal_count(scids)) {
 			return towire_errorfmt(peer, NULL,
 					       "reply_channel_range %zu timestamps when %zu scids?",
 					       tal_count(ts),

--- a/gossipd/queries.h
+++ b/gossipd/queries.h
@@ -42,8 +42,7 @@ bool query_channel_range(struct daemon *daemon,
 			 enum query_option_flags qflags,
 			 void (*cb)(struct peer *peer,
 				    u32 first_blocknum, u32 number_of_blocks,
-				    const struct short_channel_id *scids,
-				    const struct channel_update_timestamps *,
+				    const struct range_query_reply *replies,
 				    bool complete));
 
 /* Ask this peer for info about an array of scids, with optional query_flags */

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -296,7 +296,7 @@ static bool peer_has_gossip_queries(const struct peer *peer)
 static bool peer_can_take_range_query(const struct peer *peer)
 {
 	return peer->gossip_queries_feature
-		&& !peer->query_channel_blocks;
+		&& !peer->query_channel_scids;
 }
 
 static bool peer_can_take_scid_query(const struct peer *peer)

--- a/gossipd/test/run-next_block_range.c
+++ b/gossipd/test/run-next_block_range.c
@@ -39,8 +39,7 @@ bool query_channel_range(struct daemon *daemon UNNEEDED,
 			 enum query_option_flags qflags UNNEEDED,
 			 void (*cb)(struct peer *peer UNNEEDED,
 				    u32 first_blocknum UNNEEDED, u32 number_of_blocks UNNEEDED,
-				    const struct short_channel_id *scids UNNEEDED,
-				    const struct channel_update_timestamps * UNNEEDED,
+				    const struct range_query_reply *replies UNNEEDED,
 				    bool complete))
 { fprintf(stderr, "query_channel_range called!\n"); abort(); }
 /* Generated stub for query_short_channel_ids */

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -700,8 +700,8 @@ def test_gossip_query_channel_range(node_factory, bitcoind, chainparams):
                            0, 1000000,
                            filters=['0109'])
     # It should definitely have split
-    l2.daemon.wait_for_log('queue_channel_ranges full: splitting')
-    # Turns out it sends: 0+53, 53+26, 79+13, 92+7, 99+3, 102+2, 104+1, 105+999895
+    l2.daemon.wait_for_log('reply_channel_range: splitting 0-1 of 2')
+
     start = 0
     scids = '00'
     for m in msgs:
@@ -719,12 +719,12 @@ def test_gossip_query_channel_range(node_factory, bitcoind, chainparams):
                              stdout=subprocess.PIPE).stdout.strip().decode()
     assert scids == encoded
 
-    # Test overflow case doesn't split forever; should still only get 8 for this
+    # Test overflow case doesn't split forever; should still only get 2 for this
     msgs = l2.query_gossip('query_channel_range',
                            genesis_blockhash,
                            1, 429496000,
                            filters=['0109'])
-    assert len(msgs) == 8
+    assert len(msgs) == 2
 
     # This should actually be large enough for zlib to kick in!
     scid34, _ = l3.fundchannel(l4, 10**5)


### PR DESCRIPTION
We can use a counter not a bitmap since the spec insists replies be in order.

We remove an old LND workaround, and add another.

Then we make our code more efficient for the "query every single channel!" case.


