### PR TITLE
optional "failure_onion" in reply to htlc_accepted hook.

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1053,7 +1053,25 @@ onion fields which a plugin doesn't want lightningd to consider.
 ```
 
 `fail` will tell `lightningd` to fail the HTLC with a given hex-encoded
-`failure_message` (please refer to the [spec][bolt4-failure-messages] for details: `incorrect_or_unknown_payment_details` is the most common).
+`failure_message` (please refer to the [spec][bolt4-failure-messages] for
+details: `incorrect_or_unknown_payment_details` is the most common).
+
+
+```json
+{
+  "result": "fail",
+  "failure_onion": "[serialized error packet]"
+}
+```
+
+Instead of `failure_message` the response can contain a hex-encoded
+`failure_onion` that will be used instead (please refer to the
+[spec][bolt4-failure-onion] for details). This can be used, for example,
+if you're writing a bridge between two Lightning Networks. Note that
+`lightningd` will apply the obfuscation step to the value returned here
+with its own shared secret (and key type `ammag`) before returning it to
+the previous hop.
+
 
 ```json
 {
@@ -1263,6 +1281,7 @@ The plugin must broadcast it and respond with the following fields:
 [jsonrpc-notification-spec]: https://www.jsonrpc.org/specification#notification
 [bolt4]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md
 [bolt4-failure-messages]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#failure-messages
+[bolt4-failure-onion]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#returning-errors
 [bolt2-open-channel]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-open_channel-message
 [sendcustommsg]: lightning-dev-sendcustommsg.7.html
 [oddok]: https://github.com/lightningnetwork/lightning-rfc/blob/master/00-introduction.md#its-ok-to-be-odd

--- a/tests/plugins/htlc_accepted-failonion.py
+++ b/tests/plugins/htlc_accepted-failonion.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""A simply plugin that fails HTLCs with a meaningless onion.
+
+"""
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.hook("htlc_accepted")
+def on_htlc_accepted(htlc, onion, plugin, **kwargs):
+    print('returning failonion', plugin.failonion)
+    return {"result": "fail", "failure_onion": plugin.failonion}
+
+
+@plugin.method("setfailonion")
+def setfailonion(plugin, onion):
+    """Sets the failure_onion to return when receiving an incoming HTLC.
+    """
+    plugin.failonion = onion
+
+
+@plugin.init()
+def on_init(**kwargs):
+    plugin.failonion = None
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2135,3 +2135,14 @@ def test_hook_dep_stable(node_factory):
     l2.daemon.wait_for_log(r"dep_d.py: htlc_accepted called")
     l2.daemon.wait_for_log(r"dep_e.py: htlc_accepted called")
     l2.daemon.wait_for_log(r"dep_b.py: htlc_accepted called")
+
+
+def test_htlc_accepted_hook_failonion(node_factory):
+    plugin = os.path.join(os.path.dirname(__file__), 'plugins/htlc_accepted-failonion.py')
+    l1, l2 = node_factory.line_graph(2, opts=[{}, {'plugin': plugin}])
+
+    # an invalid onion
+    l2.rpc.setfailonion('0' * (292 * 2))
+    inv = l2.rpc.invoice(42, 'failonion000', '')['bolt11']
+    with pytest.raises(RpcError):
+        l1.rpc.pay(inv)


### PR DESCRIPTION
I need this feature to be able to use "shadow" last hops with fake nodes on [@lntxbot](https://t.me/lntxbot) and [Etleneum](https://etleneum.com) and return proper `incorrect_or_unknown_payment_details` for the pre-pay probes with the wrong `payment_hash` that Zap, Strike and BoS wallets send. These wallets will not attempt the actual payment if the pre-pay probe fail with any other error -- and it must come from the final destination, which means that in my case I must parse `onion.next_onion` and extract the ephemeral key, compute the shared secret then encode the onion and return it in the special field `"failure_onion"` this PR introduces.

The above paragraph is just for the context.

In reality a feature like this is also necessary if we are to write plugins that interface between two different Lightning Networks or similar networks, since a bridge node must be able to forward a failure onion from one network to the other and this PR (hopefully, maybe) enables that kind of thing.

Disclaimer: I have no idea of what I'm doing, but it works and is live on [@lntxbot](https://t.me/lntxbot). So maybe someone who knows what they're doing can think of a better way to implement this.