### PR TITLE
chore: protocol error on htlc_minimum_msat check

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1775,7 +1775,8 @@ static bool channel_added_their_htlc(struct channel *channel,
 	 */
 	if (amount_msat_eq(added->amount, AMOUNT_MSAT(0))
 	    || amount_msat_less(added->amount, channel->our_config.htlc_minimum)) {
-		channel_internal_error(channel,
+		channel_fail_permanent(channel,
+				       REASON_PROTOCOL,
 				       "trying to add HTLC amount %s"
 				       " but minimum is %s",
 				       type_to_string(tmpctx,


### PR DESCRIPTION
`lightningd/peer_htlcs.c` `channel_added_their_htlc()`
```
	/* BOLT #2:
	 *
	 *  - receiving an `amount_msat` equal to 0, OR less than its own `htlc_minimum_msat`:
	 *    - SHOULD fail the channel.
	 */
```
By using `channel_fail_permanent()` here instead of `channel_internal_error()
we can pass the reason argument and set it to 'protocol'. Since this a
pure BOLTSPEC protocol error, I think the wrong function was called here.

Because of that I switched instead of adding a `reason` to internal
errors. They can still always reolve to `local` resons for now.

Changelog-None