### PR TITLE
pytest: silence pytest warnings about unregistered 'slow_test' marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,8 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+                            "slow_test: slow tests aren't run under Valgrind")


### PR DESCRIPTION
Silence pytest warning about unknown mark.

Changelog-None.