### PR TITLE
connectd: Update connection list with new address

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1457,8 +1457,17 @@ static void try_connect_peer(struct daemon *daemon,
 		return;
 
 	/* If we're trying to connect it right now, that's OK. */
-	if (find_connecting(daemon, id))
+	if ((connect = find_connecting(daemon, id))) {
+		/* If we've been passed in new connection details
+		 * for this connection, update our addrhint + add
+		 * to addresses to check */
+		if (addrhint) {
+			connect->addrhint = tal_steal(connect, addrhint);
+			tal_arr_expand(&connect->addrs, *addrhint);
+		}
+
 		return;
+	}
 
 	/* Start an array of addresses to try. */
 	addrs = tal_arr(tmpctx, struct wireaddr_internal, 0);

--- a/tests/plugins/slow_start.py
+++ b/tests/plugins/slow_start.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""This plugin is used to check that updated connection hints work properly.
+
+"""
+from pyln.client import Plugin
+
+import socket
+import time
+
+plugin = Plugin()
+
+
+@plugin.async_method('waitconn')
+def wait_connection(request, plugin):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('localhost', 0))
+    sock.listen(1)
+    print("listening for connections on port {}".format(sock.getsockname()[1]))
+
+    # We are a one and done socket connection!
+    conn, client_addr = sock.accept()
+    try:
+        print("connection from {}".format(client_addr))
+        time.sleep(3)
+
+    finally:
+        conn.close()
+
+    print("closing socket")
+    sock.close()
+
+
+plugin.run()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -453,7 +453,7 @@ def test_connect_stresstest(node_factory, executor):
     # We fire off random connect/disconnect commands.
     actions = [
         (l2.rpc.connect, l1.info['id'], 'localhost', l1.port),
-        (l3.rpc.connect, l1.info['id'], 'localhost', l3.port),
+        (l3.rpc.connect, l1.info['id'], 'localhost', l1.port),
         (l1.rpc.connect, l2.info['id'], 'localhost', l2.port),
         (l1.rpc.connect, l3.info['id'], 'localhost', l3.port),
         (l1.rpc.disconnect, l2.info['id'])


### PR DESCRIPTION
If we're already attempting to connect to a peer, we would ignore
new connection requests. This is problematic if your node has bad
connection details for the node -- you can't update it while inflight.

This patch appends new connection suggestions to the list of connections
to try.

Fixes #4154

Changelog-None