### PR TITLE
fix: hangup in plugin rescan

### DIFF
--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -141,6 +141,7 @@ plugin_dynamic_rescan_plugins(struct command *cmd)
 	if (res)
 		return res;
 
+	plugins_send_getmanifest(cmd->ld->plugins);
 	return command_still_pending(cmd);
 }
 


### PR DESCRIPTION
This adds a missing `plugins_send_getmanifest()` call in the rescan function
that lead to a RPC hangup. Not sure though if this is the proper fix.

Addresses https://github.com/ElementsProject/lightning/issues/4176

Changelog-None