### PR TITLE
pay: Avoid clobbering the channel_hints at all costs

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1364,8 +1364,6 @@ static struct command_result *payment_createonion_success(struct command *cmd,
 	struct route_hop *first = &p->route[0];
 	struct secret *secrets;
 
-	payment_chanhints_apply_route(p, false);
-
 	p->createonion_response = json_to_createonion_response(p, buffer, toks);
 
 	req = jsonrpc_request_start(p->plugin, NULL, "sendonion",
@@ -1485,6 +1483,8 @@ static void payment_compute_onion_payloads(struct payment *p)
 
 	p->step = PAYMENT_STEP_ONION_PAYLOAD;
 	hopcount = tal_count(p->route);
+
+	payment_chanhints_apply_route(p, false);
 
 	/* Now compute the payload we're about to pass to `createonion` */
 	cr = p->createonion_request = tal(p, struct createonion_request);

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -94,6 +94,11 @@ enum payment_step {
 	 * to amend the route. */
 	PAYMENT_STEP_GOT_ROUTE = 2,
 
+	/* Something went wrong with the route returned by the
+	previous step, so retry, but do not rerun the INITIALIZED
+	modifiers. */
+	PAYMENT_STEP_RETRY_GETROUTE = 3,
+
 	/* We just computed the onion payload, allow modifiers to amend,
 	 * before constructing the onion packet. */
 	PAYMENT_STEP_ONION_PAYLOAD = 4,


### PR DESCRIPTION
Due to the asynchronous `getroute` and `createonion` calls we were issuing multiple concurrent `getroute` calls for multi-part payments. This is particularly painful with the `presplit` modifier which causes all of the initial parts to be scheduled at the same time, competing for a route.

Since #4093 we no longer have an asynchronous call to `getroute` which alleviates the problem, but doesn't resolve it: `createonion` is still asynchronous and we were only updating the channel_hints after it was called. In addition plugins can yield control of the `io_loop` if they perform any asynchronous RPC call, resulting in the same issue again.

This PR moves the application of the route to the channel_hints up to just before the `createonion` call, which makes the route creation and postprocessing synchronous unless a plugin performs an RPC call.

In order to address the final venue for colliding route computations we introduce a new state, that serves only to repeat the getroute call, but nothing else (theoretically a plugin could hook into it as well, but that's unlikely to be of use).