### PR TITLE
fix: channel closer on unilateral to remote

### DIFF
--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -434,9 +434,10 @@ void channel_set_state(struct channel *channel,
 
 	/* set closer, if known */
 	if (state > CHANNELD_NORMAL && channel->closer == NUM_SIDES) {
-		if (reason == REASON_LOCAL)  channel->closer = LOCAL;
-		if (reason == REASON_USER)   channel->closer = LOCAL;
-		if (reason == REASON_REMOTE) channel->closer = REMOTE;
+		if (reason == REASON_LOCAL)   channel->closer = LOCAL;
+		if (reason == REASON_USER)    channel->closer = LOCAL;
+		if (reason == REASON_REMOTE)  channel->closer = REMOTE;
+		if (reason == REASON_ONCHAIN) channel->closer = REMOTE;
 	}
 
 	/* use or update state_change_cause, if known */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2757,6 +2757,10 @@ def test_channel_opener(node_factory):
 
     # close and check for 'closer'
     l1.rpc.close(l2.rpc.getinfo()["id"])
+    l1.daemon.wait_for_log("State changed from CHANNELD_NORMAL to")
+    l2.daemon.wait_for_log("State changed from CHANNELD_NORMAL to")
+
+    # 'closer' should now be set accordingly
     assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'local')
     assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'remote')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2744,27 +2744,6 @@ def test_htlc_retransmit_order(node_factory, executor):
     # If order was wrong, we'll get a LOG_BROKEN and fixtures will complain.
 
 
-def test_channel_opener(node_factory):
-    """ Simply checks for 'opener' and 'closer' attributes on `listpeers` channels """
-    l1, l2 = node_factory.line_graph(2)
-
-    assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['opener'] == 'local')
-    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['opener'] == 'remote')
-
-    # 'closer' should be null initially
-    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] is None)
-    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] is None)
-
-    # close and check for 'closer'
-    l1.rpc.close(l2.rpc.getinfo()["id"])
-    l1.daemon.wait_for_log("State changed from CHANNELD_NORMAL to")
-    l2.daemon.wait_for_log("State changed from CHANNELD_NORMAL to")
-
-    # 'closer' should now be set accordingly
-    assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'local')
-    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'remote')
-
-
 def test_fundchannel_start_alternate(node_factory, executor):
     ''' Test to see what happens if two nodes start channeling to
     each other alternately.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -643,6 +643,13 @@ def test_channel_state_changed_bilateral(node_factory, bitcoind):
         event = ast.literal_eval(re.findall(".*({.*}).*", msg)[0])
         return event
 
+    # check channel 'opener' and 'closer' within this testcase ...
+    assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['opener'] == 'local')
+    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['opener'] == 'remote')
+    # the 'closer' should be null initially
+    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] is None)
+    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] is None)
+
     event1 = wait_for_event(l1)
     assert(event1['peer_id'] == l2_id)  # we only test these IDs the first time
     assert(event1['channel_id'] == cid)
@@ -677,6 +684,10 @@ def test_channel_state_changed_bilateral(node_factory, bitcoind):
     assert(event2['new_state'] == "CHANNELD_SHUTTING_DOWN")
     assert(event2['cause'] == "remote")
     assert(event2['message'] == "Peer closes channel")
+
+    # 'closer' should now be set accordingly ...
+    assert(l1.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'local')
+    assert(l2.rpc.listpeers()['peers'][0]['channels'][0]['closer'] == 'remote')
 
     event1 = wait_for_event(l1)
     assert(event1['old_state'] == "CHANNELD_SHUTTING_DOWN")


### PR DESCRIPTION
Currently we set the `lightning-cli listpeers` channel `closer` to `null` if we have been offline and detected a force closed channel on us. This was because in theory it could have been ourself that used some scratching/recovery script for our private keys. Since this is topmost unlikely scenario, especially since someone doing this would certainly not fire up the daemon again and expect it to do something useful, we are better of to set the `closer` to `remote` as it should be.