### PR TITLE
pytest: use the 'contrib' plugin set, not the 'test' set

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -267,7 +267,7 @@ def test_plugin_command(node_factory):
 
     # Test that we can add a directory with more than one new plugin in it.
     try:
-        n.rpc.plugin_startdir(os.path.join(os.getcwd(), "tests/plugins"))
+        n.rpc.plugin_startdir(os.path.join(os.getcwd(), "contrib/plugins"))
     except RpcError:
         pass
 


### PR DESCRIPTION
It seems like all we're really trying to do is test that we load more than one plugin from a directory. Using the `test/plugins` directory is a miserable idea, as new additions tend to clobber each other (and some only get loaded if experimental is turned on). Instead, we use the more mundane `contrib/plugins` folder.

Alternately, we can probably remove this test entirely, as the first load tests the exact thing (and actually verifies they're used).

Changelog-None.