### PR TITLE
plugins: undeprecate old form of hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ This release named by Sergi Delgado Segura.
 
 Note: You should always set `allow-deprecated-apis=false` to test for changes.
 
- - Plugins: hooks should now be specified using objects, not raw names. ([4168](https://github.com/ElementsProject/lightning/pull/4168))
  - cli: scripts should filter out '^# ' or use `-N none`, as commands will start returning notifications soon ([4046](https://github.com/ElementsProject/lightning/pull/4046))
 
 ### Removed

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1108,12 +1108,10 @@ static const char *plugin_hooks_add(struct plugin *plugin, const char *buffer,
 			name = json_strdup(tmpctx, buffer, nametok);
 			beforetok = json_get_member(buffer, t, "before");
 			aftertok = json_get_member(buffer, t, "after");
-		} else if (deprecated_apis) {
+		} else {
+			/* FIXME: deprecate in 3 releases after v0.9.2! */
 			name = json_strdup(tmpctx, plugin->buffer, t);
 			beforetok = aftertok = NULL;
-		} else {
-			return tal_fmt(plugin,
-				    "hooks must be an array of objects");
 		}
 
 		hook = plugin_hook_register(plugin, name);


### PR DESCRIPTION
This effectively reverts ac93b780d5a457f8f304d658e80b4d531fb3b0e4.

Christian points out that plugins need time before we deprecate
the old options (probably 6 months) as they need to work with
both old and new.

Changelog-Deprecated: **UNDO** plugins: hooks should now be specified using objects, not raw names.
Suggested-by: @cdecker
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>