### PR TITLE
min_witness_weight param for fundpsbt/utxopsbt

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -841,13 +841,13 @@ size_t bitcoin_tx_input_sig_weight(void)
 	return 1 + 71;
 }
 
-/* We only do segwit inputs, and we assume witness is sig + key  */
-size_t bitcoin_tx_simple_input_weight(bool p2sh)
+/* Input weight */
+size_t bitcoin_tx_input_weight(bool p2sh, size_t witness_weight)
 {
-	size_t weight;
+	size_t weight = witness_weight;
 
 	/* Input weight: txid + index + sequence */
-	weight = (32 + 4 + 4) * 4;
+	weight += (32 + 4 + 4) * 4;
 
 	/* We always encode the length of the script, even if empty */
 	weight += 1 * 4;
@@ -856,14 +856,24 @@ size_t bitcoin_tx_simple_input_weight(bool p2sh)
 	if (p2sh)
 		weight += 23 * 4;
 
-	/* Account for witness (1 byte count + sig + key) */
-	weight += 1 + (bitcoin_tx_input_sig_weight() + 1 + 33);
-
 	/* Elements inputs have 6 bytes of blank proofs attached. */
 	if (chainparams->is_elements)
 		weight += 6;
 
 	return weight;
+}
+
+size_t bitcoin_tx_simple_input_witness_weight(void)
+{
+	/* Account for witness (1 byte count + sig + key) */
+	return 1 + (bitcoin_tx_input_sig_weight() + 1 + 33);
+}
+
+/* We only do segwit inputs, and we assume witness is sig + key  */
+size_t bitcoin_tx_simple_input_weight(bool p2sh)
+{
+	return bitcoin_tx_input_weight(p2sh,
+				       bitcoin_tx_simple_input_witness_weight());
 }
 
 struct amount_sat change_amount(struct amount_sat excess, u32 feerate_perkw)

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -255,6 +255,12 @@ size_t bitcoin_tx_output_weight(size_t outscript_len);
 /* Weight to push sig on stack. */
 size_t bitcoin_tx_input_sig_weight(void);
 
+/* Segwit input, but with parameter for witness weight (size) */
+size_t bitcoin_tx_input_weight(bool p2sh, size_t witness_weight);
+
+/* The witness weight for a simple (sig + key) input */
+size_t bitcoin_tx_simple_input_witness_weight(void);
+
 /* We only do segwit inputs, and we assume witness is sig + key  */
 size_t bitcoin_tx_simple_input_weight(bool p2sh);
 

--- a/common/utxo.c
+++ b/common/utxo.c
@@ -64,7 +64,14 @@ struct utxo *fromwire_utxo(const tal_t *ctx, const u8 **ptr, size_t *max)
 	return utxo;
 }
 
-size_t utxo_spend_weight(const struct utxo *utxo)
+size_t utxo_spend_weight(const struct utxo *utxo, size_t min_witness_weight)
 {
-	return bitcoin_tx_simple_input_weight(utxo->is_p2sh);
+	size_t wit_weight = bitcoin_tx_simple_input_witness_weight();
+	/* If the min is less than what we'd use for a 'normal' tx,
+	 * we return the value with the greater added/calculated */
+	if (wit_weight < min_witness_weight)
+		return bitcoin_tx_input_weight(utxo->is_p2sh,
+					       min_witness_weight);
+
+	return bitcoin_tx_input_weight(utxo->is_p2sh, wit_weight);
 }

--- a/common/utxo.h
+++ b/common/utxo.h
@@ -74,5 +74,5 @@ void towire_utxo(u8 **pptr, const struct utxo *utxo);
 struct utxo *fromwire_utxo(const tal_t *ctx, const u8 **ptr, size_t *max);
 
 /* Estimate of (signed) UTXO weight in transaction */
-size_t utxo_spend_weight(const struct utxo *utxo);
+size_t utxo_spend_weight(const struct utxo *utxo, size_t min_witness_weight);
 #endif /* LIGHTNING_COMMON_UTXO_H */

--- a/doc/lightning-fundpsbt.7
+++ b/doc/lightning-fundpsbt.7
@@ -3,7 +3,7 @@
 lightning-fundpsbt - Command to populate PSBT inputs from the wallet
 .SH SYNOPSIS
 
-\fBfundpsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR [\fIminconf\fR] [\fIreserve\fR] [\fIlocktime\fR]
+\fBfundpsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR [\fIminconf\fR] [\fIreserve\fR] [\fIlocktime\fR] [\fImin_witness_weight\fR]
 
 .SH DESCRIPTION
 
@@ -42,6 +42,11 @@ called (successfully, with \fIexclusive\fR true) on the returned PSBT\.
 
 \fIlocktime\fR is an optional locktime: if not set, it is set to a recent
 block height\.
+
+
+\fImin_witness_weight\fR is an optional minimum weight to use for a UTXO's
+witness\. If the actual witness weight is greater than the provided minimum,
+the actual witness weight will be used\.
 
 .SH EXAMPLE USAGE
 
@@ -104,4 +109,4 @@ Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:8eb6970e2d625198db9b8e5ab7f90f9fb141744a837f58ee68ef54d28c7066b0
+\" SHA256STAMP:a8b9705274638127c2f5ec4e97ed94e6d7f6b6b10a76c2248e8bc8b36dd804ff

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -4,7 +4,7 @@ lightning-fundpsbt -- Command to populate PSBT inputs from the wallet
 SYNOPSIS
 --------
 
-**fundpsbt** *satoshi* *feerate* *startweight* \[*minconf*\] \[*reserve*\] \[*locktime*\]
+**fundpsbt** *satoshi* *feerate* *startweight* \[*minconf*\] \[*reserve*\] \[*locktime*\] \[*min_witness_weight*\]
 
 DESCRIPTION
 -----------
@@ -38,6 +38,10 @@ called (successfully, with *exclusive* true) on the returned PSBT.
 
 *locktime* is an optional locktime: if not set, it is set to a recent
 block height.
+
+*min_witness_weight* is an optional minimum weight to use for a UTXO's
+witness. If the actual witness weight is greater than the provided minimum,
+the actual witness weight will be used.
 
 EXAMPLE USAGE
 -------------

--- a/doc/lightning-utxopsbt.7
+++ b/doc/lightning-utxopsbt.7
@@ -3,7 +3,7 @@
 lightning-utxopsbt - Command to populate PSBT inputs from given UTXOs
 .SH SYNOPSIS
 
-\fButxopsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR \fIutxos\fR [\fIreserve\fR] [\fIreservedok\fR] [\fIlocktime\fR]
+\fButxopsbt\fR \fIsatoshi\fR \fIfeerate\fR \fIstartweight\fR \fIutxos\fR [\fIreserve\fR] [\fIreservedok\fR] [\fIlocktime\fR] [\fImin_witness_weight\fR]
 
 .SH DESCRIPTION
 
@@ -30,6 +30,11 @@ if any of the \fIutxos\fR are already reserved\.
 
 \fIlocktime\fR is an optional locktime: if not set, it is set to a recent
 block height\.
+
+
+\fImin_witness_weight\fR is an optional minimum weight to use for a UTXO's
+witness\. If the actual witness weight is greater than the provided minimum,
+the actual witness weight will be used\.
 
 .SH RETURN VALUE
 
@@ -70,4 +75,4 @@ Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:e47331be08a0911c74e142f2255bf62a83b70b818c1cf39a9314aab8c17a6e47
+\" SHA256STAMP:777710bb963f435193e92a55344c740c123d7aa4d54bf573c99a616f59eeee54

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -4,7 +4,7 @@ lightning-utxopsbt -- Command to populate PSBT inputs from given UTXOs
 SYNOPSIS
 --------
 
-**utxopsbt** *satoshi* *feerate* *startweight* *utxos* \[*reserve*\] \[*reservedok*\] \[*locktime*\]
+**utxopsbt** *satoshi* *feerate* *startweight* *utxos* \[*reserve*\] \[*reservedok*\] \[*locktime*\] \[*min_witness_weight*\]
 
 DESCRIPTION
 -----------
@@ -28,6 +28,10 @@ if any of the *utxos* are already reserved.
 
 *locktime* is an optional locktime: if not set, it is set to a recent
 block height.
+
+*min_witness_weight* is an optional minimum weight to use for a UTXO's
+witness. If the actual witness weight is greater than the provided minimum,
+the actual witness weight will be used.
 
 RETURN VALUE
 ------------

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -386,7 +386,7 @@ static struct command_result *json_fundpsbt(struct command *cmd,
 {
 	struct utxo **utxos;
 	u32 *feerate_per_kw;
-	u32 *minconf, *weight;
+	u32 *minconf, *weight, *min_witness_weight;
 	struct amount_sat *amount, input, diff;
 	bool all, *reserve;
 	u32 *locktime, maxheight;
@@ -398,6 +398,8 @@ static struct command_result *json_fundpsbt(struct command *cmd,
 		   p_opt_def("minconf", param_number, &minconf, 1),
 		   p_opt_def("reserve", param_bool, &reserve, true),
 		   p_opt("locktime", param_number, &locktime),
+		   p_opt_def("min_witness_weight", param_number,
+			     &min_witness_weight, 0),
 		   NULL))
 		return command_param_failed();
 
@@ -427,7 +429,7 @@ static struct command_result *json_fundpsbt(struct command *cmd,
 						    "impossible UTXO value");
 
 			/* But also adds weight */
-			*weight += utxo_spend_weight(utxo);
+			*weight += utxo_spend_weight(utxo, *min_witness_weight);
 			continue;
 		}
 
@@ -555,7 +557,7 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 					    const jsmntok_t *params)
 {
 	struct utxo **utxos;
-	u32 *feerate_per_kw, *weight;
+	u32 *feerate_per_kw, *weight, *min_witness_weight;
 	bool all, *reserve, *reserved_ok;
 	struct amount_sat *amount, input, excess;
 	u32 current_height, *locktime;
@@ -568,6 +570,8 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 		   p_opt_def("reserve", param_bool, &reserve, true),
 		   p_opt_def("reservedok", param_bool, &reserved_ok, false),
 		   p_opt("locktime", param_number, &locktime),
+		   p_opt_def("min_witness_weight", param_number,
+			     &min_witness_weight, 0),
 		   NULL))
 		return command_param_failed();
 
@@ -592,7 +596,7 @@ static struct command_result *json_utxopsbt(struct command *cmd,
 					    "impossible UTXO value");
 
 		/* But also adds weight */
-		*weight += utxo_spend_weight(utxo);
+		*weight += utxo_spend_weight(utxo, *min_witness_weight);
 	}
 
 	/* For all, anything above 0 is "excess" */


### PR DESCRIPTION
Add a `min_witness_weight` param to our 'fund-/utxo-psbt' methods. This is to support the dual funding spec, which requires a floor of witness fees to be paid at 110 weight.

In theory, if we ever get more complicated UTXOs, we'll want to update the witness weight calculation to encompass the correct weight for these, also.