### PR TITLE
lightningd: remove unused pid_fd member in struct lightningd

### DIFF
--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -83,8 +83,6 @@ struct lightningd {
 	 * -1. */
 	int daemon_parent_fd;
 
-	int pid_fd;
-
 	/* Our config basedir, network directory, and rpc file */
 	char *config_basedir, *config_netdir;
 


### PR DESCRIPTION
Remove `pid_fd` from `struct lightningd` since `pid_fd` is not used anywhere.