### PR TITLE
Added build for oss-fuzz [Draft]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,7 +533,7 @@ $(ALL_PROGRAMS) $(ALL_TEST_PROGRAMS):
 
 # We special case the fuzzing target binaries, as they need to link against libfuzzer,
 # which brings its own main().
-ifneq($(OSS_FUZZ),0)
+ifneq ($(OSS_FUZZ),0)
 FUZZ_LDFLAGS = ${LIB_FUZZING_ENGINE}
 else
 FUZZ_LDFLAGS = -fsanitize=fuzzer

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+export FUZZING_CFLAGS=$CFLAGS
+FUZZING=1 OSS_FUZZ=1 CC="${CC}" ./configure && make
+mv $SRC/lightning/tests/fuzz/* $OUT/


### PR DESCRIPTION
I have been working on making Lightnings fuzzers run on OSS-fuzz's infrastructure, and I am hereby committing the build that allows for that.

If there is interest in integrating with oss-fuzz, I will be happy to setup the integrationg on the oss-fuzz side, as I have all the build files for the part ready.

Integration will allow Google to run the fuzzers continuously and notify maintainers when bugs are found. It is offered free of charge  for open source projects with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Lightning are put to good use.

To integrate, at least one maintainer email is needed for bug reports. This can be shared here or when the integration application is set up.