### PR TITLE
libwally: update to latest which uses libsecp-zkp submodule

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -67,14 +67,10 @@ $(TARGET_DIR)/libsecp256k1.% $(TARGET_DIR)/libwallycore.%: $(TARGET_DIR)/libwall
 	$(MAKE) -C $(TARGET_DIR)/libwally-core-build DESTDIR=$$(pwd)/$(TARGET_DIR) install-exec
 
 # Build libwally-core.
-#
-# PYTHON_VERSION is required to prevent configure from complaining about
-# missing python2 binaries. These have been removed in newer distros and we
-# shouldn't require them to be present either.
 $(TARGET_DIR)/libwally-core-build/src/libwallycore.% $(TARGET_DIR)/libwally-core-build/src/secp256k1/libsecp256k1.%: $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS)
-	cd external/libwally-core && ./tools/autogen.sh
+	cd external/libwally-core && git submodule init && git submodule update && ./tools/autogen.sh
 	mkdir -p ${TARGET_DIR}/libwally-core-build
-	cd ${TARGET_DIR}/libwally-core-build && PYTHON_VERSION=3 CFLAGS=-std=c99 ${TOP}/libwally-core/configure CC="$(CC)" --enable-static=yes $(CROSSCOMPILE_OPTS) --enable-module-recovery --enable-elements --enable-shared=no --prefix=/ --libdir=/ --enable-debug && $(MAKE)
+	cd ${TARGET_DIR}/libwally-core-build && CFLAGS=-std=c99 ${TOP}/libwally-core/configure CC="$(CC)" --enable-static=yes $(CROSSCOMPILE_OPTS) --enable-module-recovery --enable-elements --enable-shared=no --prefix=/ --libdir=/ --enable-debug && $(MAKE)
 
 # If we tell Make that the above builds both, it runs it twice in
 # parallel.  So we lie :(


### PR DESCRIPTION
And get rid of the now-obsolete PYTHON_VERSION hack.

Changelog-None.