### PR TITLE
tx: Remove wally workaround that is no longer needed

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -4,7 +4,6 @@
 #include <bitcoin/pubkey.h>
 #include <bitcoin/script.h>
 #include <bitcoin/signature.h>
-#include <ccan/cast/cast.h>
 #include <ccan/ccan/array_size/array_size.h>
 #include <ccan/ccan/mem/mem.h>
 #include <ccan/tal/str/str.h>
@@ -519,16 +518,14 @@ static bool wally_map_set_unknown(const tal_t *ctx,
 	struct wally_map_item *item;
 
 	assert(value_len != 0);
-	if (wally_map_find(map,
-			   cast_const(unsigned char *, key), tal_bytelen(key),
-			   &exists_at) != WALLY_OK)
+	if (wally_map_find(map, key, tal_bytelen(key), &exists_at) != WALLY_OK)
 		return false;
 
 	/* If not exists, add */
 	if (exists_at == 0) {
 		bool ok;
 		tal_wally_start();
-		ok = wally_map_add(map, cast_const(unsigned char *, key), tal_bytelen(key),
+		ok = wally_map_add(map, key, tal_bytelen(key),
 			      (unsigned char *) memcheck(value, value_len), value_len)
 			== WALLY_OK;
 		tal_wally_end(ctx);

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -4,7 +4,6 @@
 #include <bitcoin/psbt.h>
 #include <bitcoin/script.h>
 #include <bitcoin/tx.h>
-#include <ccan/cast/cast.h>
 #include <ccan/crypto/sha256/sha256.h>
 #include <ccan/endian/endian.h>
 #include <ccan/mem/mem.h>

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -353,18 +353,9 @@ void bitcoin_tx_input_set_witness(struct bitcoin_tx *tx, int innum,
 	tal_wally_end(tx->wtx);
 
 	/* Also add to the psbt */
-	if (stack) {
-		tal_wally_start();
-		wally_psbt_input_set_final_witness(&tx->psbt->inputs[innum], stack);
-		tal_wally_end(tx->psbt);
-	} else {
-		/* FIXME: libwally-psbt doesn't allow 'unsetting' of witness via
-		 * the set method at the moment, so we do it manually*/
-		struct wally_psbt_input *in = &tx->psbt->inputs[innum];
-		if (in->final_witness)
-			wally_tx_witness_stack_free(in->final_witness);
-		in->final_witness = NULL;
-	}
+	tal_wally_start();
+	wally_psbt_input_set_final_witness(&tx->psbt->inputs[innum], stack);
+	tal_wally_end(tx->psbt);
 
 	if (taken(witness))
 		tal_free(witness);


### PR DESCRIPTION
Just a minor nit now that wally supports clearing structs on PSBT members.

Changelog-None.