### PR TITLE
external/Makefile: fix parallel build with missing secp headers.

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -49,6 +49,7 @@ EXTERNAL_LDLIBS := -L${TARGET_DIR} $(patsubst lib%.a,-l%,$(notdir $(EXTERNAL_LIB
 
 submodcheck: FORCE
 	@tools/refresh-submodules.sh $(SUBMODULES)
+	@cd external/libwally-core && ../../tools/refresh-submodules.sh src/secp256k1
 
 $(EXTERNAL_HEADERS): submodcheck
 
@@ -68,7 +69,7 @@ $(TARGET_DIR)/libsecp256k1.% $(TARGET_DIR)/libwallycore.%: $(TARGET_DIR)/libwall
 
 # Build libwally-core.
 $(TARGET_DIR)/libwally-core-build/src/libwallycore.% $(TARGET_DIR)/libwally-core-build/src/secp256k1/libsecp256k1.%: $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS)
-	cd external/libwally-core && git submodule init && git submodule update && ./tools/autogen.sh
+	cd external/libwally-core && ./tools/autogen.sh
 	mkdir -p ${TARGET_DIR}/libwally-core-build
 	cd ${TARGET_DIR}/libwally-core-build && CFLAGS=-std=c99 ${TOP}/libwally-core/configure CC="$(CC)" --enable-static=yes $(CROSSCOMPILE_OPTS) --enable-module-recovery --enable-elements --enable-shared=no --prefix=/ --libdir=/ --enable-debug && $(MAKE)
 

--- a/tools/refresh-submodules.sh
+++ b/tools/refresh-submodules.sh
@@ -5,8 +5,8 @@ if [ $# = 0 ]; then
     exit 1
 fi
 
-# If no git dir, forget it.
-[ -d .git ] || exit 0
+# If no git dir (or, if we're a submodule, git file), forget it.
+[ -e .git ] || exit 0
 
 # git submodule can't run in parallel.  Really.
 # Wait for it to finish if in parallel.


### PR DESCRIPTION
Fixes: #4229
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None