### PR TITLE
Check whether the recipient supports keysend

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3373,7 +3373,7 @@ def test_listpay_result_with_paymod(node_factory, bitcoind):
 
     amount_sat = 10 ** 6
 
-    l1, l2, l3 = node_factory.line_graph(3)
+    l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True)
 
     invl2 = l2.rpc.invoice(amount_sat * 2, "inv_l2", "inv_l2")
     l1.rpc.pay(invl2['bolt11'])


### PR DESCRIPTION
We weren't checking whether the recipient supports `keysend` or not before trying to pay. This could lead to rather unhelpful 16399 errors, because the recipient simply doesn't understand what we're trying to do.

This might be the cause for https://github.com/ElementsProject/lightning/issues/3968, but I can't verify that that's the case.

Fixes #3968