### PR TITLE
pyln: failing test msat from float str

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -49,19 +49,19 @@ class Millisatoshi:
         """
         if isinstance(v, str):
             if v.endswith("msat"):
-                self.millisatoshis = int(v[0:-4])
+                parsed = Decimal(v[0:-4])
             elif v.endswith("sat"):
-                self.millisatoshis = int(v[0:-3]) * 1000
+                parsed = Decimal(v[0:-3]) * 1000
             elif v.endswith("btc"):
-                self.millisatoshis = int(v[0:-3]) * 1000 * 10**8
+                parsed = Decimal(v[0:-3]) * 1000 * 10**8
             else:
                 raise TypeError(
                     "Millisatoshi must be string with msat/sat/btc suffix or"
                     " int"
                 )
-            if self.millisatoshis != int(self.millisatoshis):
+            if parsed != int(parsed):
                 raise ValueError("Millisatoshi must be a whole number")
-            self.millisatoshis = int(self.millisatoshis)
+            self.millisatoshis = int(parsed)
 
         elif isinstance(v, Millisatoshi):
             self.millisatoshis = v.millisatoshis

--- a/contrib/pyln-client/tests/test_units.py
+++ b/contrib/pyln-client/tests/test_units.py
@@ -1,4 +1,5 @@
 from pyln.client import Millisatoshi
+import pytest  # type: ignore
 
 
 def test_to_approx_str():
@@ -34,3 +35,29 @@ def test_to_approx_str():
     assert amount.to_approx_str() == "12btc"
     amount = Millisatoshi('1200000000sat')
     assert amount.to_approx_str(1) == "12btc"  # note: no rounding
+
+
+def test_floats():
+    # test parsing amounts from floating number strings
+    amount = Millisatoshi("0.01btc")
+    assert amount.to_satoshi() == 10**6
+    amount = Millisatoshi("1.01btc")
+    assert amount.to_satoshi() == 10**8 + 10**6
+    amount = Millisatoshi("0.1sat")
+    assert int(amount) == 100
+    amount = Millisatoshi("0.01sat")
+    assert int(amount) == 10
+    amount = Millisatoshi("1.1sat")
+    assert int(amount) == 1100
+
+    # test floating point arithmetic
+    amount = Millisatoshi("1000msat") * 0.1
+    assert int(amount) == 100
+
+    # sub millisatoshi are not a concept yet
+    with pytest.raises(ValueError, match='Millisatoshi must be a whole number'):
+        amount = Millisatoshi("0.000000000001btc")
+    with pytest.raises(ValueError, match='Millisatoshi must be a whole number'):
+        amount = Millisatoshi("0.0001sat")
+    with pytest.raises(ValueError, match='Millisatoshi must be a whole number'):
+        amount = Millisatoshi("0.1msat")


### PR DESCRIPTION
Currently we are not able to create pyln Millisatoshi from floats, e.g.:
 - "0.01btc"
 - "0.1sat"
 - ...

This adds a test that is currently expected to fail because of this bug.

Changelog-None