### PR TITLE
feat: fees on listpeers rpc output

### DIFF
--- a/doc/lightning-listpeers.7
+++ b/doc/lightning-listpeers.7
@@ -138,6 +138,12 @@ a number followed by a string unit\.
 \fItotal_msat\fR: A string describing the total capacity of the channel;
 a number followed by a string unit\.
 .IP \[bu]
+\fIfee_base_msat\fR: The fixed routing fee we charge for forwards going out over
+this channel, regardless of payment size\.
+.IP \[bu]
+\fIfee_proportional_millionths\fR: The proportional routing fees in ppm (parts-
+per-millionths) we charge for forwards going out over this channel\.
+.IP \[bu]
 \fIfeatures\fR: An array of feature names supported by this channel\.
 
 .RE
@@ -319,7 +325,8 @@ Michael Hawkins \fI<michael.hawkins@protonmail.com\fR>\.
 
 .SH SEE ALSO
 
-\fBlightning-connect\fR(7), lightning-fundchannel_\fBstart\fR(7)
+\fBlightning-connect\fR(7), lightning-fundchannel_\fBstart\fR(7),
+\fBlightning-setchannelfee\fR(7)
 
 .SH RESOURCES
 
@@ -327,4 +334,4 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR Lightning
 RFC site (BOLT #9):
 \fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md\fR
 
-\" SHA256STAMP:8f6fbdc92e59d5efb2e9e8fa113651badb8aacddaea29d81798ecb598fbaad01
+\" SHA256STAMP:9e2ed8ce1612c02a6251db7da1d62e2d12f8e0648a54888687f177f0784ef2e6

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -100,6 +100,10 @@ The objects in the *channels* array will have at least these fields:
   a number followed by a string unit.
 * *total\_msat*: A string describing the total capacity of the channel;
   a number followed by a string unit.
+* *fee_base_msat*: The fixed routing fee we charge for forwards going out over
+  this channel, regardless of payment size.
+* *fee_proportional_millionths*: The proportional routing fees in ppm (parts-
+  per-millionths) we charge for forwards going out over this channel.
 * *features*: An array of feature names supported by this channel.
 
 These fields may exist if the channel has gotten beyond the `"OPENINGD"`
@@ -238,7 +242,8 @@ Michael Hawkins <<michael.hawkins@protonmail.com>>.
 SEE ALSO
 --------
 
-lightning-connect(7), lightning-fundchannel\_start(7)
+lightning-connect(7), lightning-fundchannel\_start(7),
+lightning-setchannelfee(7)
 
 RESOURCES
 ---------

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -877,6 +877,12 @@ static void json_add_channel(struct lightningd *ld,
 	json_add_amount_msat_compat(response, funding_msat,
 				    "msatoshi_total", "total_msat");
 
+	/* routing fees */
+	json_add_amount_msat_only(response, "fee_base_msat",
+				  amount_msat(channel->feerate_base));
+	json_add_u32(response, "fee_proportional_millionths",
+		     channel->feerate_ppm);
+
 	/* channel config */
 	json_add_amount_sat_compat(response,
 				   channel->our_config.dust_limit,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -224,6 +224,12 @@ void json_add_amount_msat_compat(struct json_stream *result UNNEEDED,
 				 const char *msatfieldname)
 
 { fprintf(stderr, "json_add_amount_msat_compat called!\n"); abort(); }
+/* Generated stub for json_add_amount_msat_only */
+void json_add_amount_msat_only(struct json_stream *result UNNEEDED,
+			  const char *msatfieldname UNNEEDED,
+			  struct amount_msat msat)
+
+{ fprintf(stderr, "json_add_amount_msat_only called!\n"); abort(); }
 /* Generated stub for json_add_amount_sat_compat */
 void json_add_amount_sat_compat(struct json_stream *result UNNEEDED,
 				struct amount_sat sat UNNEEDED,


### PR DESCRIPTION
As mentioned in the last developer meeting and additional to #4221 we want to have the local half-channel fees (the ones that are applied when a payment is routed though our node) as part of the `listpeers` output. Motivation is that this data is non-gossip and currently only available via gossip `listchannels`.

Example
```
{
    ...
    "fee_base_msat" : "100msat",
    "fee_proportinal_millionths" : 1000,
    ...
}
```

This PR adds feature, test and doc.