### PR TITLE
channeld: fix gcc warning on gcc 8.3.0 (Debian 8.3.0-6)

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -195,7 +195,8 @@ static void start_commit_timer(struct peer *peer);
 
 static void billboard_update(const struct peer *peer)
 {
-	const char *funding_status, *announce_status, *shutdown_status;
+	const char *funding_status, *announce_status,
+		*shutdown_status COMPILER_WANTS_INIT("gcc 8.3.0");
 
 	if (peer->funding_locked[LOCAL] && peer->funding_locked[REMOTE])
 		funding_status = "Funding transaction locked.";


### PR DESCRIPTION
```
channeld/channeld.c:237:2: error: ‘shutdown_status’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
```

Reported-by: az0re on IRC
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>

Changelog-None