### PR TITLE
pytest: recreate wallet on bitcoind restart (for master branch of bitcoind)

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -138,14 +138,6 @@ def bitcoind(directory, teardown_checks):
         raise ValueError("elementsd is too old. At least version 160000 (v0.16.0)"
                          " is needed, current version is {}".format(info['version']))
 
-    # Make sure we have a wallet, starting with 0.21 there is no default wallet
-    # anymore.
-    # FIXME: if we update the testsuite to use the upcoming 0.21 release we
-    # could switch to descriptor wallets and speed bitcoind operations
-    # consequently.
-    if not bitcoind.rpc.listwallets():
-        bitcoind.rpc.createwallet("lightningd-tests")
-
     info = bitcoind.rpc.getblockchaininfo()
     # Make sure we have some spendable funds
     if info['blocks'] < 101:

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1,5 +1,6 @@
 from bitcoin.core import COIN  # type: ignore
 from bitcoin.rpc import RawProxy as BitcoinProxy  # type: ignore
+from bitcoin.rpc import JSONRPCError
 from pyln.client import RpcError
 from pyln.testing.btcproxy import BitcoinRpcProxy
 from collections import OrderedDict
@@ -351,7 +352,7 @@ class BitcoinD(TailableProc):
             '-logtimestamps',
             '-nolisten',
             '-txindex',
-            '-wallet="test"',
+            '-nowallet',
             '-addresstype=bech32'
         ]
         # For up to and including 0.16.1, this needs to be in main section.
@@ -369,6 +370,10 @@ class BitcoinD(TailableProc):
         self.wait_for_log("Done loading", timeout=TIMEOUT)
 
         logging.info("BitcoinD started")
+        try:
+            self.rpc.createwallet("lightningd-tests")
+        except JSONRPCError:
+            self.rpc.loadwallet("lightningd-tests")
 
     def stop(self):
         for p in self.proxies:
@@ -461,6 +466,7 @@ class ElementsD(BitcoinD):
             '-server',
             '-logtimestamps',
             '-nolisten',
+            '-nowallet',
             '-validatepegin=0',
             '-con_blocksubsidy=5000000000',
         ]

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -324,6 +324,9 @@ static void fail_out_htlc(struct htlc_out *hout,
 							      hout->failmsg);
 			fail_in_htlc(hout->in, failonion);
 		}
+	} else {
+		if (taken(failmsg_needs_update))
+			tal_free(failmsg_needs_update);
 	}
 }
 


### PR DESCRIPTION
Upgraded builder, and it doesn't work any more.  Suggested by @achow101 that we make older versions behave like new ones, with `-nowallet`.

Also found an unrelated taken() leak while testing.

Changelog-None