### PR TITLE
Add txprepare to plugins/.gitignore

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -3,3 +3,4 @@ bcli
 pay
 spenderp
 multifundchannel
+txprepare


### PR DESCRIPTION
A binary is missing in plugins/.gitignore: txprepare. This means that when someone tries to modify the project with the compiled binaries, txprepare binary is added to their commit.