### PR TITLE
Improve validation of `txprepare` arguments

### DIFF
--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -21,6 +21,12 @@ struct wally_psbt;
 struct bitcoin_txid {
 	struct sha256_double shad;
 };
+
+struct bitcoin_outpoint {
+	struct bitcoin_txid txid;
+	u16 n;
+};
+
 /* Define bitcoin_txid_eq */
 STRUCTEQ_DEF(bitcoin_txid, 0, shad.sha.u);
 

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -24,7 +24,7 @@ struct bitcoin_txid {
 
 struct bitcoin_outpoint {
 	struct bitcoin_txid txid;
-	u16 n;
+	u32 n;
 };
 
 /* Define bitcoin_txid_eq */

--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -823,8 +823,9 @@ int main(int argc, char *argv[])
 		     "Missing 'id' in response '%s'", resp);
 	if (!json_tok_streq(resp, id, idstr))
 		errx(ERROR_TALKING_TO_LIGHTNINGD,
-		     "Incorrect 'id' in response: %.*s",
-		     json_tok_full_len(id), json_tok_full(resp, id));
+		     "Incorrect 'id' (%.*s) in response: %.*s",
+		     json_tok_full_len(id), json_tok_full(resp, id),
+		     json_tok_full_len(toks), json_tok_full(resp, toks));
 
 	if (!error || json_tok_is_null(resp, error)) {
 		switch (format) {

--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -740,6 +740,14 @@ int main(int argc, char *argv[])
 		tal_append_fmt(&cmd, "] }");
 	}
 
+	toks = json_parse_simple(ctx, cmd, strlen(cmd));
+	if (toks == NULL)
+		errx(ERROR_USAGE,
+		     "Some parameters are malformed, cannot create a valid "
+		     "JSON-RPC request: %s",
+		     cmd);
+	tal_free(toks);
+
 	if (!write_all(fd, cmd, strlen(cmd)))
 		err(ERROR_TALKING_TO_LIGHTNINGD, "Writing command");
 

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -96,26 +96,13 @@ bool json_to_txid(const char *buffer, const jsmntok_t *tok,
 bool json_to_outpoint(const char *buffer, const jsmntok_t *tok,
 		      struct bitcoin_outpoint *op)
 {
-	size_t len = tok->end - tok->start;
-	char str[len + 1];
+	jsmntok_t t1, t2;
 
-	if (len < 66)
-		return NULL;
-
-	memcpy(str, buffer+tok->start, len);
-	str[len] = 0x00;
-
-	if (str[64] != ':')
-		return NULL;
-
-	if (!bitcoin_txid_from_hex(str, 64, &op->txid))
+	if (!split_tok(buffer, tok, ':', &t1, &t2))
 		return false;
 
-	op->n = atoi(str + 65);
-	if (op->n < 0)
-		return false;
-
-	return true;
+	return json_to_txid(buffer, &t1, &op->txid)
+		&& json_to_u32(buffer, &t2, &op->n);
 }
 
 bool json_to_channel_id(const char *buffer, const jsmntok_t *tok,

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -93,6 +93,31 @@ bool json_to_txid(const char *buffer, const jsmntok_t *tok,
 				     tok->end - tok->start, txid);
 }
 
+bool json_to_outpoint(const char *buffer, const jsmntok_t *tok,
+		      struct bitcoin_outpoint *op)
+{
+	size_t len = tok->end - tok->start;
+	char str[len + 1];
+
+	if (len < 66)
+		return NULL;
+
+	memcpy(str, buffer+tok->start, len);
+	str[len] = 0x00;
+
+	if (str[64] != ':')
+		return NULL;
+
+	if (!bitcoin_txid_from_hex(str, 64, &op->txid))
+		return false;
+
+	op->n = atoi(str + 65);
+	if (op->n < 0)
+		return false;
+
+	return true;
+}
+
 bool json_to_channel_id(const char *buffer, const jsmntok_t *tok,
 			struct channel_id *cid)
 {

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -193,6 +193,14 @@ void json_add_txid(struct json_stream *result, const char *fieldname,
 	json_add_string(result, fieldname, hex);
 }
 
+void json_add_outpoint(struct json_stream *result, const char *fieldname,
+		       const struct bitcoin_outpoint *out)
+{
+	char hex[hex_str_size(sizeof(out->txid))];
+	bitcoin_txid_to_hex(&out->txid, hex, sizeof(hex));
+	json_add_member(result, fieldname, true, "%s:%d", hex, out->n);
+}
+
 void json_add_short_channel_id(struct json_stream *response,
 			       const char *fieldname,
 			       const struct short_channel_id *scid)

--- a/common/json_helpers.h
+++ b/common/json_helpers.h
@@ -62,6 +62,10 @@ bool json_to_msat(const char *buffer, const jsmntok_t *tok,
 bool json_to_txid(const char *buffer, const jsmntok_t *tok,
 		  struct bitcoin_txid *txid);
 
+/* Extract a bitcoin outpoint from this */
+bool json_to_outpoint(const char *buffer, const jsmntok_t *tok,
+		      struct bitcoin_outpoint *op);
+
 /* Extract a channel id from this */
 bool json_to_channel_id(const char *buffer, const jsmntok_t *tok,
 			struct channel_id *cid);

--- a/common/json_helpers.h
+++ b/common/json_helpers.h
@@ -102,6 +102,10 @@ void json_add_channel_id(struct json_stream *response,
 void json_add_txid(struct json_stream *result, const char *fieldname,
 		   const struct bitcoin_txid *txid);
 
+/* '"fieldname" : "txid:n" */
+void json_add_outpoint(struct json_stream *result, const char *fieldname,
+		       const struct bitcoin_outpoint *out);
+
 /* '"fieldname" : "1234:5:6"' */
 void json_add_short_channel_id(struct json_stream *response,
 			       const char *fieldname,

--- a/common/json_tok.c
+++ b/common/json_tok.c
@@ -520,13 +520,11 @@ struct command_result *param_outpoint_arr(struct command *cmd,
 	*outpoints = tal_arr(cmd, struct bitcoin_outpoint, tok->size);
 
 	json_for_each_arr(i, curr, tok) {
-		struct bitcoin_outpoint op;
-		if (!json_to_outpoint(buffer, curr, &op))
+		if (!json_to_outpoint(buffer, curr, &(*outpoints)[i]))
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Could not decode outpoint \"%.*s\", "
 					    "expected format: txid:output",
 					    json_tok_full_len(curr), json_tok_full(buffer, curr));
-		(*outpoints)[i] = op;
 	}
 	return NULL;
 }

--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -11,6 +11,7 @@
 struct amount_msat;
 struct amount_sat;
 struct bitcoin_txid;
+struct bitcoin_outpoint;
 struct channel_id;
 struct command;
 struct command_result;
@@ -172,4 +173,13 @@ struct command_result *param_psbt(struct command *cmd,
 				  const char *buffer,
 				  const jsmntok_t *tok,
 				  struct wally_psbt **psbt);
+
+/**
+ * Parse a list of `txid:output` outpoints.
+ */
+struct command_result *param_outpoint_arr(struct command *cmd,
+					  const char *name,
+					  const char *buffer,
+					  const jsmntok_t *tok,
+					  struct bitcoin_outpoint **outpoints);
 #endif /* LIGHTNING_COMMON_JSON_TOK_H */

--- a/common/param.c
+++ b/common/param.c
@@ -262,8 +262,6 @@ static struct command_result *param_arr(struct command *cmd, const char *buffer,
 			    "Expected array or object for params");
 }
 
-#include <stdio.h>
-
 const char *param_subcommand(struct command *cmd, const char *buffer,
 			     const jsmntok_t tokens[],
 			     const char *name, ...)

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -52,6 +52,10 @@ bool json_to_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEED
 bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			       struct node_id *id UNNEEDED)
 { fprintf(stderr, "json_to_node_id called!\n"); abort(); }
+/* Generated stub for json_to_outpoint */
+bool json_to_outpoint(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		      struct bitcoin_outpoint *op UNNEEDED)
+{ fprintf(stderr, "json_to_outpoint called!\n"); abort(); }
 /* Generated stub for json_to_pubkey */
 bool json_to_pubkey(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 		    struct pubkey *pubkey UNNEEDED)

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -8,6 +8,7 @@
 #include <common/setup.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <wire/wire.h>
 

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1172,19 +1172,7 @@ class LightningRpc(UnixDomainSocketRpc):
 
         return self.call("withdraw", payload)
 
-    def _deprecated_txprepare(self, destination, satoshi, feerate=None, minconf=None):
-        warnings.warn("txprepare now takes output arg: expect removal"
-                      " in Mid-2020",
-                      DeprecationWarning)
-        payload = {
-            "destination": destination,
-            "satoshi": satoshi,
-            "feerate": feerate,
-            "minconf": minconf,
-        }
-        return self.call("txprepare", payload)
-
-    def txprepare(self, *args, **kwargs):
+    def txprepare(self, outputs, feerate=None, minconf=None, utxos=None):
         """
         Prepare a Bitcoin transaction which sends to [outputs].
         The format of output is like [{address1: amount1},
@@ -1194,22 +1182,13 @@ class LightningRpc(UnixDomainSocketRpc):
         Outputs will be reserved until you call txdiscard or txsend, or
         lightningd restarts.
         """
-        if 'destination' in kwargs or 'satoshi' in kwargs:
-            return self._deprecated_txprepare(*args, **kwargs)
-
-        if len(args) and not isinstance(args[0], list):
-            return self._deprecated_txprepare(*args, **kwargs)
-
-        def _txprepare(outputs, feerate=None, minconf=None, utxos=None):
-            payload = {
-                "outputs": outputs,
-                "feerate": feerate,
-                "minconf": minconf,
-                "utxos": utxos,
-            }
-            return self.call("txprepare", payload)
-
-        return _txprepare(*args, **kwargs)
+        payload = {
+            "outputs": outputs,
+            "feerate": feerate,
+            "minconf": minconf,
+            "utxos": utxos,
+        }
+        return self.call("txprepare", payload)
 
     def txdiscard(self, txid):
         """

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -956,8 +956,10 @@ static struct io_plan *read_json(struct io_conn *conn,
 	if (!json_parse_input(&jcon->input_parser, &jcon->input_toks,
 			      jcon->buffer, jcon->used,
 			      &complete)) {
-		json_command_malformed(jcon, "null",
-				       "Invalid token in json input");
+		json_command_malformed(
+		    jcon, "null",
+		    tal_fmt(tmpctx, "Invalid token in json input: '%s'",
+			    tal_strndup(tmpctx, jcon->buffer, jcon->used)));
 		return io_halfclose(conn);
 	}
 

--- a/plugins/txprepare.c
+++ b/plugins/txprepare.c
@@ -67,6 +67,13 @@ static struct command_result *param_outputs(struct command *cmd,
 	size_t i;
 	const jsmntok_t *t;
 
+	if (tok->type != JSMN_ARRAY) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Expected an array of outputs in the "
+				    "format '[{\"txid\":0}, ...]', got \"%s\"",
+				    json_strdup(tmpctx, buffer, tok));
+	}
+
 	txp->outputs = tal_arr(txp, struct tx_output, tok->size);
 	txp->output_total = AMOUNT_SAT(0);
 	txp->all_output_idx = -1;


### PR DESCRIPTION
There are two issues we address in this PR:
 - Broken JSON strings when forwarding params as raw strings to further JSON-RPC calls, causing the infamous `id is null` error because the side receiving the mangled request cannot extract the `id` and returns a generic error instead, which doesn't match up with our expectations.
 - Interpreting a string param as an array, resulting in an empty array, and thus only adding the change output to a prepared tx.

In a couple of places we accept arrays of strings and don't validate
them. If we forward them, e.g., call a JSON-RPC method from the
plugin, we end up embedding the unverified string in the JSON-RPC
call without escaping, which then leads to invalid JSON being passed
on.

We were not checking that outputs is indeed an array, and just going
ahead creating the array of outputs. Since `tok->size` for a string is
0 we ended up ignoring the argument altogether and thus the created
transaction would end up only with a single change output.

Since I was looking at the cli params already I also added some more feedback
to `lightning-cli`. It now parses the request before sending it to `lightningd`, so if
a malformed param results in a malformed request we catch it early and tell the
user to check the formatting of the params.

Fixes #4238 
Fixes #4258