### PR TITLE
peer_control: Implement `listchannelfee` command

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -1093,6 +1093,18 @@ class LightningRpc(UnixDomainSocketRpc):
 
         return _sendpay(route, payment_hash, *args, **kwargs)
 
+    def listchannelfee(self, id=None):
+        """
+        Get local routing fees for a channel/peer {id} (or all channels if {id} is not specified).
+        """
+        if id is not None:
+            payload = {
+                "id": id
+            }
+            return self.call("listchannelfee", payload)
+        else:
+            return self.call("listchannelfee")
+
     def setchannelfee(self, id, base=None, ppm=None):
         """
         Set routing fees for a channel/peer {id} (or 'all'). {base} is a value in millisatoshi


### PR DESCRIPTION
This PR implements a `listchannelfee` command to complement `setchannelfee`.  Code is mostly cribbed from surrounding functions.

Fixes #4221.

Does not yet implement any test or documentation, so it is a draft PR for now.  Also I have not at all tried the pyln changes so careful review there would be good.