### PR TITLE
channeld: Fix the shutdown_sent billboard direction

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -220,9 +220,9 @@ static void billboard_update(const struct peer *peer)
 
 	if (!peer->shutdown_sent[LOCAL] && !peer->shutdown_sent[REMOTE])
 		shutdown_status = "";
-	else if (!peer->shutdown_sent[LOCAL] && peer->shutdown_sent[REMOTE])
-		shutdown_status = " We've send shutdown, waiting for theirs";
 	else if (peer->shutdown_sent[LOCAL] && !peer->shutdown_sent[REMOTE])
+		shutdown_status = " We've send shutdown, waiting for theirs";
+	else if (!peer->shutdown_sent[LOCAL] && peer->shutdown_sent[REMOTE])
 		shutdown_status = " They've sent shutdown, waiting for ours";
 	else if (peer->shutdown_sent[LOCAL] && peer->shutdown_sent[REMOTE]) {
 		size_t num_htlcs = num_channel_htlcs(peer->channel);


### PR DESCRIPTION
While debugging a hanging channel with a user I noticed that they
called `close` on a channel, resulting in the channel showing
`CHANNELD_SHUTTING_DOWN`, but the billboard seemed to show the
information the wrong way around:

```json
{
   "peers": [
      {
         "connected": true,
	 // ...
         "channels": [
            {
               "state": "CHANNELD_SHUTTING_DOWN",
	       // ...
               "status": [
                  "CHANNELD_SHUTTING_DOWN:Reconnected, and reestablished.",
                  "CHANNELD_SHUTTING_DOWN:Funding transaction locked. They need our announcement signatures. They've sent shutdown, waiting for ours"
               ],
	       // ...
            }
         ]
      }
   ]
}
```

Aside from the hung channel, the switch in direction of the status
seemed weird. Checking the billboard code seems to have the status
switched as well:

https://github.com/ElementsProject/lightning/blob/ff8830876dc2ead010dc4a6453abb7e30ec637ce/channeld/channeld.c#L223-L226

We set `shutdown_sent[LOCAL]` when we send the shutdown:

https://github.com/ElementsProject/lightning/blob/ff8830876dc2ead010dc4a6453abb7e30ec637ce/channeld/channeld.c#L823-L839

And we set `shutdown_sent[REMOTE]` when we receive the shutdown:

https://github.com/ElementsProject/lightning/blob/ff8830876dc2ead010dc4a6453abb7e30ec637ce/channeld/channeld.c#L1730-L1781

So I think the billboard code just needs to be switched around.

Changelog-Fixed: JSON-RPC: The status of the shutdown meesages being exchanged is now displayed correctly.