### PR TITLE
pyln: Add TOR and SOCKS5 support in pyln.proto.wire.connect

### DIFF
--- a/contrib/pyln-proto/requirements.txt
+++ b/contrib/pyln-proto/requirements.txt
@@ -3,3 +3,4 @@ cryptography==3.2
 coincurve==13.0.0
 base58==1.0.2
 mypy
+pysocks==1.7.*


### PR DESCRIPTION
I wanted to talk to TOR-based nodes, so here comes TOR support :-)

Changelog-None