### PR TITLE
pytest: Disable flaky test_fundchannel_start_alternate

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2841,6 +2841,7 @@ def test_htlc_retransmit_order(node_factory, executor):
     # If order was wrong, we'll get a LOG_BROKEN and fixtures will complain.
 
 
+@unittest.skipIf(True, "Currently failing, see tracking issue #4265")
 def test_fundchannel_start_alternate(node_factory, executor):
     ''' Test to see what happens if two nodes start channeling to
     each other alternately.


### PR DESCRIPTION
This test has been causing most CI runs to fail. See tracking issue #4265
for discussion on fixing and re-enabling it.