### PR TITLE
wallet: remove debugging fprintf.

### DIFF
--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -429,8 +429,6 @@ static struct command_result *json_fundpsbt(struct command *cmd,
 						    "impossible UTXO value");
 
 			/* But also adds weight */
-			fprintf(stderr, "min_witness_weight is %u\n",
-					*min_witness_weight);
 			*weight += utxo_spend_weight(utxo, *min_witness_weight);
 			continue;
 		}


### PR DESCRIPTION
Left over from e81d78ec4cad288f1ae42aff935e59e149fb4b9e.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None