### PR TITLE
pyln: fix div with Millisatoshi itself

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -176,13 +176,19 @@ class Millisatoshi:
     def __sub__(self, other: 'Millisatoshi') -> 'Millisatoshi':
         return Millisatoshi(int(self) - int(other))
 
-    def __mul__(self, other: int) -> 'Millisatoshi':
+    def __mul__(self, other: Union[int, float]) -> 'Millisatoshi':
+        if isinstance(other, Millisatoshi):
+            raise TypeError("Resulting unit msat^2 is not supported")
         return Millisatoshi(floor(self.millisatoshis * other))
 
-    def __truediv__(self, other: Union[int, float]) -> 'Millisatoshi':
+    def __truediv__(self, other: Union[int, float, 'Millisatoshi']) -> Union['Millisatoshi', float]:
+        if isinstance(other, Millisatoshi):
+            return self.millisatoshis / other.millisatoshis
         return Millisatoshi(floor(self.millisatoshis / other))
 
-    def __floordiv__(self, other: Union[int, float]) -> 'Millisatoshi':
+    def __floordiv__(self, other: Union[int, float, 'Millisatoshi']) -> Union['Millisatoshi', int]:
+        if isinstance(other, Millisatoshi):
+            return self.millisatoshis // other.millisatoshis
         return Millisatoshi(floor(self.millisatoshis // float(other)))
 
     def __mod__(self, other: Union[float, int]) -> 'Millisatoshi':

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -68,6 +68,10 @@ class Millisatoshi:
 
         elif int(v) == v:
             self.millisatoshis = int(v)
+
+        elif isinstance(v, float):
+            raise TypeError("Millisatoshi by float is currently not supported")
+
         else:
             raise TypeError(
                 "Millisatoshi must be string with msat/sat/btc suffix or int"

--- a/contrib/pyln-client/tests/test_units.py
+++ b/contrib/pyln-client/tests/test_units.py
@@ -312,3 +312,26 @@ def test_div():
     assert amount == 14
     amount = Millisatoshi(42) // Millisatoshi(4)
     assert amount == 10
+
+
+def test_init():
+    # Note: Ongoing Discussion, hence the `with pytest.raises`.
+    # https://github.com/ElementsProject/lightning/pull/4273#discussion_r540369093
+    #
+    # Initialization with a float should be possible:
+    # Millisatoshi(5) / 2 currently works, and removes the half msat.
+    # So Millisatoshi(5 / 2) should be the same.
+    amount = Millisatoshi(5) / 2
+    assert amount == Millisatoshi(2)
+    with pytest.raises(TypeError, match="Millisatoshi by float is currently not supported"):
+        assert amount == Millisatoshi(5 / 2)
+
+    ratio = Millisatoshi(8) / Millisatoshi(5)
+    assert isinstance(ratio, float)
+    with pytest.raises(TypeError, match="Millisatoshi by float is currently not supported"):
+        assert Millisatoshi(ratio) == Millisatoshi(8 / 5)
+
+    # Check that init by a round float is allowed.
+    # Required by some existing tests: tests/test_wallet.py::test_txprepare
+    amount = Millisatoshi(42.0)
+    assert amount == 42

--- a/contrib/pyln-client/tests/test_units.py
+++ b/contrib/pyln-client/tests/test_units.py
@@ -269,3 +269,46 @@ def test_nonegative():
         Millisatoshi("1sat") // -1
     with pytest.raises(ValueError, match='Millisatoshi must be >= 0'):
         Millisatoshi("1btc") // -1
+
+
+def test_mul():
+    # msat * num := msat
+    amount = Millisatoshi(21) * 2
+    assert isinstance(amount, Millisatoshi)
+    assert amount == Millisatoshi(42)
+    amount = Millisatoshi(21) * 2.5
+    assert amount == Millisatoshi(52)
+
+    # msat * msat := msat^2  (which is not supported)
+    with pytest.raises(TypeError, match="not supported"):
+        Millisatoshi(21) * Millisatoshi(2)
+
+
+def test_div():
+    # msat / num := msat
+    amount = Millisatoshi(42) / 2
+    assert isinstance(amount, Millisatoshi)
+    assert amount == Millisatoshi(21)
+    amount = Millisatoshi(42) / 2.6
+    assert amount == Millisatoshi(16)
+
+    # msat / msat := num   (float ratio)
+    amount = Millisatoshi(42) / Millisatoshi(2)
+    assert isinstance(amount, float)
+    assert amount == 21.0
+    amount = Millisatoshi(8) / Millisatoshi(5)
+    assert amount == 1.6
+
+    # msat // num := msat
+    amount = Millisatoshi(42) // 2
+    assert isinstance(amount, Millisatoshi)
+    assert amount == Millisatoshi(21)
+
+    # msat // msat := num
+    amount = Millisatoshi(42) // Millisatoshi(3)
+    assert isinstance(amount, int)
+    assert amount == 14
+    amount = Millisatoshi(42) // Millisatoshi(3)
+    assert amount == 14
+    amount = Millisatoshi(42) // Millisatoshi(4)
+    assert amount == 10


### PR DESCRIPTION
Current implementation does not allow dividing two msat's to get the ratio between them.
It fails with `unsupported operand type(s)`:
```python
from pyln.client import Millisatoshi
foo = Millisatoshi(42) / Millisatoshi(2)
```

- This PR changes this to return the `float` ratio between the two `msat's` for `__truediv__` and an `int` for `__floordiv__`. 
- Also adds an exception and a check that `Millisatoshi(float)` initialization is currently not allowed, except for whole float numbers, e.g. `42.0` this is currently required by some existing testcases: e.g. `tests/test_wallet.py::test_txprepare`
See https://github.com/ElementsProject/lightning/pull/4273#discussion_r540369093).