### PR TITLE
tests: Update mocks after breaking them via interleaved merges

### DIFF
--- a/common/test/run-sphinx-xor_cipher_stream.c
+++ b/common/test/run-sphinx-xor_cipher_stream.c
@@ -74,6 +74,9 @@ u64 fromwire_u64(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_u8 */
 u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 { fprintf(stderr, "fromwire_u8 called!\n"); abort(); }
+/* Generated stub for fromwire_u8_array */
+void fromwire_u8_array(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, u8 *arr UNNEEDED, size_t num UNNEEDED)
+{ fprintf(stderr, "fromwire_u8_array called!\n"); abort(); }
 /* Generated stub for hmac_done */
 void hmac_done(crypto_auth_hmacsha256_state *state UNNEEDED,
 	       struct hmac *hmac UNNEEDED)


### PR DESCRIPTION
Seems that I broke the mocks by merging two PRs that both modified the tests, thus overwriting each others set of mocks.

Changelog-None