### PR TITLE
pyln: add RPCException for finer method failure control.

### DIFF
--- a/contrib/pyln-client/README.md
+++ b/contrib/pyln-client/README.md
@@ -78,6 +78,9 @@ def hello(plugin, name="world"):
     It gets reported as the description when registering the function
     as a method with `lightningd`.
 
+    If this returns (a dict), that's the JSON "result" returned.  If
+    it raises an exception, that causes a JSON "error" return (raising
+    pyln.client.RpcException allows finer control over the return).
     """
     greeting = plugin.get_option('greeting')
     s = '{} {}'.format(greeting, name)

--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -1,5 +1,5 @@
 from .lightning import LightningRpc, RpcError, Millisatoshi
-from .plugin import Plugin, monkey_patch
+from .plugin import Plugin, monkey_patch, RpcException
 
 
 __version__ = "0.8.0"
@@ -9,6 +9,7 @@ __all__ = [
     "LightningRpc",
     "Plugin",
     "RpcError",
+    "RpcException",
     "Millisatoshi",
     "__version__",
     "monkey_patch"


### PR DESCRIPTION
Allows caller to set code and exact message to be returned.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Added: pyln-client: plugins can now return RPCException for finer control over error returns.

THE BIG QUESTION: RPCException or RpcException?!? :scream: 