### PR TITLE
setchannelfee: fix crash when channel is not in valid state.

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2027,6 +2027,12 @@ static struct command_result *json_setchannelfee(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
+	if (channel
+	    && channel->state != CHANNELD_NORMAL
+	    && channel->state != CHANNELD_AWAITING_LOCKIN)
+		return command_fail(cmd, LIGHTNINGD,
+				    "Channel is in state %s", channel_state_name(channel));
+
 	/* Open JSON response object for later iteration */
 	response = json_stream_success(cmd);
 	json_add_num(response, "base", *base);
@@ -2047,10 +2053,6 @@ static struct command_result *json_setchannelfee(struct command *cmd,
 
 	/* single channel should be updated */
 	} else {
-		if (channel->state != CHANNELD_NORMAL &&
-			channel->state != CHANNELD_AWAITING_LOCKIN)
-			return command_fail(cmd, LIGHTNINGD,
-					"Channel is in state %s", channel_state_name(channel));
 		set_channel_fees(cmd, channel, *base, *ppm, response);
 	}
 


### PR DESCRIPTION
You can't fail a cmd when you've already started streaming
a successful response:

lightningd: ccan/ccan/json_out/json_out.c:343: json_out_finished: Assertion `tal_count(jout->wrapping) == 0' failed.
lightningd: FATAL SIGNAL 6 (version v0.9.2-119-gf7cdf1d)
0x1847d1 send_backtrace
	common/daemon.c:38
0x184877 crashdump
	common/daemon.c:51
0x5bda03f ???
	???:0
0x5bd9fb7 ???
	???:0
0x5bdb920 ???
	???:0
0x5bcb489 ???
	???:0
0x5bcb501 ???
	???:0
0x1e07a8 json_out_finished
	ccan/ccan/json_out/json_out.c:343
0x18db0a json_stream_double_cr
	common/json_stream.c:95
0x18dbf3 json_stream_close
	common/json_stream.c:117
0x12fd98 command_raw_complete
	lightningd/jsonrpc.c:459
0x12fec9 command_failed
	lightningd/jsonrpc.c:488
0x12ffb9 command_fail
	lightningd/jsonrpc.c:503
0x14dc20 json_setchannelfee
	lightningd/peer_control.c:2052

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Fixed: JSONRPC: `setchannelfee` would fail an assertion if channel wasn't in normal state.