### PR TITLE
Bcli tweaks

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -594,7 +594,7 @@ static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcl
 	struct json_stream *response;
 
 	/* This is useful for functional tests. */
-	if (*bcli->exitstatus == 0)
+	if (bcli->exitstatus)
 		plugin_log(bcli->cmd->plugin, LOG_DBG, "sendrawtx exit %i (%s)",
 			   *bcli->exitstatus, bcli_args(bcli));
 

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -601,8 +601,10 @@ static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcl
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_bool(response, "success", *bcli->exitstatus == 0);
 	json_add_string(response, "errmsg",
-			bcli->exitstatus ? tal_strndup(bcli->cmd, bcli->output,
-						       bcli->output_bytes-1) : "");
+			*bcli->exitstatus ?
+			tal_strndup(bcli->cmd,
+				    bcli->output, bcli->output_bytes-1)
+			: "");
 
 	return command_finished(bcli->cmd, response);
 }

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -601,7 +601,7 @@ static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcl
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_bool(response, "success", *bcli->exitstatus == 0);
 	json_add_string(response, "errmsg",
-			bcli->exitstatus ? tal_strndup(bcli, bcli->output,
+			bcli->exitstatus ? tal_strndup(bcli->cmd, bcli->output,
 						       bcli->output_bytes-1) : "");
 
 	return command_finished(bcli->cmd, response);

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -595,8 +595,12 @@ static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcl
 
 	/* This is useful for functional tests. */
 	if (bcli->exitstatus)
-		plugin_log(bcli->cmd->plugin, LOG_DBG, "sendrawtx exit %i (%s)",
-			   *bcli->exitstatus, bcli_args(bcli));
+		plugin_log(bcli->cmd->plugin, LOG_DBG,
+			   "sendrawtx exit %i (%s) %.*s",
+			   *bcli->exitstatus, bcli_args(bcli),
+			   *bcli->exitstatus ?
+				(u32)bcli->output_bytes-1 : 0,
+				bcli->output);
 
 	response = jsonrpc_stream_success(bcli->cmd);
 	json_add_bool(response, "success", *bcli->exitstatus == 0);


### PR DESCRIPTION
Really minor tweaks to how bcli handles responses to bitcoind `sendrawtransaction`. Printing the error code is useful for failures in tests; the others changes are nice but not have to haves.

Changelog-None.