### PR TITLE
Added spent option to listfunds

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -851,11 +851,16 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("listforwards")
 
-    def listfunds(self):
+    def listfunds(self, spent=False):
         """
-        Show funds available for opening channels.
+        Show funds available for opening channels
+        or both unspent and spent funds if {spent} is True.
         """
-        return self.call("listfunds")
+
+        payload = {
+            "spent": spent
+        }
+        return self.call("listfunds", payload)
 
     def listtransactions(self):
         """

--- a/doc/lightning-listfunds.7
+++ b/doc/lightning-listfunds.7
@@ -3,13 +3,17 @@
 lightning-listfunds - Command showing all funds currently managed by the c-lightning node
 .SH SYNOPSIS
 
-\fBlistfunds\fR
+\fBlistfunds\fR [\fIspent\fR]
 
 .SH DESCRIPTION
 
 The \fBlistfunds\fR RPC command displays all funds available, either in
 unspent outputs (UTXOs) in the internal wallet or funds locked in
 currently open channels\.
+
+
+\fIspent\fR is a boolean: if true, then the \fIoutputs\fR will include spent outputs
+in addition to the unspent ones\. Default is false\.
 
 .SH RETURN VALUE
 
@@ -88,4 +92,4 @@ Felix \fI<fixone@gmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:d7b4a30a1ca19e772529fbe517fb73e8c0d5c07ec3c05969ab614a4abc1865a4
+\" SHA256STAMP:b59a2bed131c291e9650a6e330526b890f1e18182ccacd33aef60311f6ce2caa

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -4,7 +4,7 @@ lightning-listfunds -- Command showing all funds currently managed by the c-ligh
 SYNOPSIS
 --------
 
-**listfunds**
+**listfunds** \[*spent*\]
 
 DESCRIPTION
 -----------
@@ -12,6 +12,9 @@ DESCRIPTION
 The **listfunds** RPC command displays all funds available, either in
 unspent outputs (UTXOs) in the internal wallet or funds locked in
 currently open channels.
+
+*spent* is a boolean: if true, then the *outputs* will include spent outputs
+in addition to the unspent ones. Default is false.
 
 RETURN VALUE
 ------------

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2410,3 +2410,24 @@ def test_listtransactions(node_factory):
     # The txid of the transaction funding the channel is present, and
     # represented as little endian (like bitcoind and explorers).
     assert wallettxid in txids
+
+
+def test_listfunds(node_factory):
+    """Test listfunds command."""
+    l1, l2 = node_factory.get_nodes(2, opts=[{}, {}])
+
+    open_txid = l1.openchannel(l2, 10**5)["wallettxid"]
+
+    # unspent outputs
+    utxos = l1.rpc.listfunds()["outputs"]
+
+    # only 1 unspent output should be available
+    assert len(utxos) == 1
+
+    # both unspent and spent outputs
+    all_outputs = l1.rpc.listfunds(spent=True)["outputs"]
+    txids = [output['txid'] for output in all_outputs]
+
+    # 1 spent output (channel opening) and 1 unspent output
+    assert len(all_outputs) == 2
+    assert open_txid in txids


### PR DESCRIPTION
Added a `spent` option (a boolean) to `listfunds` which adds spent outputs to the `outputs` if set to true.

I didn't see any `test_listfunds` Python test so I thought I'd write one but then I couldn't figure out how to actually run these Python tests after reading `HACKING.md` :) 

* **blackbox tests** - These tests setup a mini-regtest environment and test
  lightningd as a whole.  They can be run individually:

  `PYTHONPATH=contrib/pylightning:contrib/pyln-client:contrib/pyln-testing:contrib/pyln-proto py.test -v tests/`

What's `py.test` ?

I checked `travis.yml` to see how it does that and it sets up bitcoind and elements and it's Linux specific but I'm using a Mac. If anyone knows how to run `tests/test_misc.py` on a Mac and could share this info with me I'd appreciate it.

Fixes #4291 
