### PR TITLE
pyln: log RPC binding error

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -550,7 +550,13 @@ class Plugin(object):
         elif 'request' in params:
             del params['request']
 
-        ba = sig.bind(**params)
+        try:
+            ba = sig.bind(**params)
+        except TypeError as e:
+            self.log((
+                "Error binding {}{}"
+            ).format(getattr(func, '__name__', 'unknown'), sig), level="error")
+            raise e
         self._coerce_arguments(func, ba)
         return ba
 


### PR DESCRIPTION
This adds a log error message with function name and params incase
a RPC method cannot be bound. This can help debugging plugins.

Changelog-None