### PR TITLE
Hsmtool (and hsm_secret encryption) refactorings

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -32,6 +32,7 @@ COMMON_SRC_NOGEN :=				\
 	common/gossip_store.c			\
 	common/hash_u5.c			\
 	common/hmac.c				\
+	common/hsm_encryption.c			\
 	common/htlc_state.c			\
 	common/htlc_trim.c			\
 	common/htlc_tx.c			\

--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -1,0 +1,38 @@
+#include <common/hsm_encryption.h>
+#include <sodium.h>
+#include <sodium/utils.h>
+
+
+char *hsm_secret_encryption_key(const char *pass, struct secret *key)
+{
+	u8 salt[16] = "c-lightning\0\0\0\0\0";
+
+	/* Don't swap the encryption key ! */
+	if (sodium_mlock(key->data, sizeof(key->data)) != 0)
+		return "Could not lock hsm_secret encryption key memory.";
+
+	/* Check bounds. */
+	if (strlen(pass) < crypto_pwhash_argon2id_PASSWD_MIN)
+		return "Password too short to be able to derive a key from it.";
+	if (strlen(pass) > crypto_pwhash_argon2id_PASSWD_MAX)
+		return "Password too long to be able to derive a key from it.";
+
+	/* Now derive the key. */
+	if (crypto_pwhash(key->data, sizeof(key->data), pass, strlen(pass), salt,
+			  /* INTERACTIVE needs 64 MiB of RAM, MODERATE needs 256,
+			   * and SENSITIVE needs 1024. */
+			  crypto_pwhash_argon2id_OPSLIMIT_MODERATE,
+			  crypto_pwhash_argon2id_MEMLIMIT_MODERATE,
+			  crypto_pwhash_ALG_ARGON2ID13) != 0)
+		return "Could not derive a key from the password.";
+
+	return NULL;
+}
+
+void discard_key(struct secret *key TAKES)
+{
+	/* sodium_munlock() also zeroes the memory. */
+	sodium_munlock(key->data, sizeof(key->data));
+	if (taken(key))
+		tal_free(key);
+}

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -19,4 +19,11 @@ char *hsm_secret_encryption_key(const char *pass, struct secret *encryption_key)
  */
 void discard_key(struct secret *key TAKES);
 
+/** Read hsm_secret encryption pass from stdin, disabling echoing.
+ * @reason: if NULL is returned, will point to the human-readable error.
+ *
+ * Caller must free the string as it does tal-reallocate getline's output.
+ */
+char *read_stdin_pass(char **reason);
+
 #endif /* LIGHTNING_COMMON_HSM_ENCRYPTION_H */

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -4,7 +4,20 @@
 #include <bitcoin/privkey.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
+#include <sodium.h>
 
+/* Length of the encrypted hsm secret header. */
+#define HS_HEADER_LEN crypto_secretstream_xchacha20poly1305_HEADERBYTES
+/* From libsodium: "The ciphertext length is guaranteed to always be message
+ * length + ABYTES" */
+#define HS_CIPHERTEXT_LEN \
+	(sizeof(struct secret) + crypto_secretstream_xchacha20poly1305_ABYTES)
+/* Total length of an encrypted hsm_secret */
+#define ENCRYPTED_HSM_SECRET_LEN (HS_HEADER_LEN + HS_CIPHERTEXT_LEN)
+
+struct encrypted_hsm_secret {
+	u8 data[ENCRYPTED_HSM_SECRET_LEN];
+};
 
 /** Derive the hsm_secret encryption key from a passphrase.
  * @pass: the passphrase string.
@@ -13,6 +26,17 @@
  * On success, NULL is returned. On error, a human-readable error is.
  */
 char *hsm_secret_encryption_key(const char *pass, struct secret *encryption_key);
+
+/** Encrypt the hsm_secret using a previously derived encryption key.
+ * @encryption_key: the key derived from the passphrase.
+ * @hsm_secret: the plaintext hsm_secret to encrypt.
+ * @output: the resulting encrypted hsm_secret.
+ *
+ * Return false on encryption failure.
+ */
+bool encrypt_hsm_secret(const struct secret *encryption_key,
+			const struct secret *hsm_secret,
+			struct encrypted_hsm_secret *output);
 
 /** Unlock and zeroize the encryption key memory after use.
  * @key: the encryption key. If taken, it will be tal_free'd

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -38,6 +38,17 @@ bool encrypt_hsm_secret(const struct secret *encryption_key,
 			const struct secret *hsm_secret,
 			struct encrypted_hsm_secret *output);
 
+/** Decrypt the hsm_secret using a previously derived encryption key.
+ * @encryption_key: the key derived from the passphrase.
+ * @cipher: the encrypted hsm_secret to decrypt.
+ * @output: the resulting hsm_secret.
+ *
+ * Return false on decryption failure.
+ */
+bool decrypt_hsm_secret(const struct secret *encryption_key,
+			const struct encrypted_hsm_secret *cipher,
+			struct secret *output);
+
 /** Unlock and zeroize the encryption key memory after use.
  * @key: the encryption key. If taken, it will be tal_free'd
  */

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -1,0 +1,22 @@
+#ifndef LIGHTNING_COMMON_HSM_ENCRYPTION_H
+#define LIGHTNING_COMMON_HSM_ENCRYPTION_H
+#include "config.h"
+#include <bitcoin/privkey.h>
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+
+
+/** Derive the hsm_secret encryption key from a passphrase.
+ * @pass: the passphrase string.
+ * @encryption_key: the output key derived from the passphrase.
+ *
+ * On success, NULL is returned. On error, a human-readable error is.
+ */
+char *hsm_secret_encryption_key(const char *pass, struct secret *encryption_key);
+
+/** Unlock and zeroize the encryption key memory after use.
+ * @key: the encryption key. If taken, it will be tal_free'd
+ */
+void discard_key(struct secret *key TAKES);
+
+#endif /* LIGHTNING_COMMON_HSM_ENCRYPTION_H */

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -26,6 +26,7 @@ HSMD_COMMON_OBJS :=				\
 	common/derive_basepoints.o		\
 	common/status_wiregen.o			\
 	common/hash_u5.o			\
+	common/hsm_encryption.o			\
 	common/key_derive.o			\
 	common/memleak.o			\
 	common/msg_queue.o			\

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -31,6 +31,7 @@
 #include <common/daemon_conn.h>
 #include <common/derive_basepoints.h>
 #include <common/hash_u5.h>
+#include <common/hsm_encryption.h>
 #include <common/key_derive.h>
 #include <common/memleak.h>
 #include <common/node_id.h>
@@ -779,12 +780,9 @@ static struct io_plan *init_hsm(struct io_conn *conn,
 	maybe_create_new_hsm(hsm_encryption_key, true);
 	load_hsm(hsm_encryption_key);
 
-	/*~ We don't need the hsm_secret encryption key anymore.
-	 * Note that sodium_munlock() also zeroes the memory. */
-	if (hsm_encryption_key) {
-		sodium_munlock(hsm_encryption_key, sizeof(*hsm_encryption_key));
-		tal_free(hsm_encryption_key);
-	}
+	/*~ We don't need the hsm_secret encryption key anymore. */
+	if (hsm_encryption_key)
+		discard_key(take(hsm_encryption_key));
 
 	/*~ We tell lightning our node id and (public) bip32 seed. */
 	node_key(NULL, &key);

--- a/lightningd/Makefile
+++ b/lightningd/Makefile
@@ -92,6 +92,7 @@ LIGHTNINGD_COMMON_OBJS :=			\
 	common/gossip_rcvd_filter.o		\
 	common/hash_u5.o			\
 	common/hmac.o				\
+	common/hsm_encryption.o			\
 	common/htlc_state.o			\
 	common/htlc_trim.o			\
 	common/htlc_wire.o			\

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -6,6 +6,7 @@
 #include <ccan/io/io.h>
 #include <ccan/take/take.h>
 #include <common/ecdh.h>
+#include <common/hsm_encryption.h>
 #include <common/json.h>
 #include <common/json_helpers.h>
 #include <common/jsonrpc_errors.h>
@@ -106,7 +107,8 @@ struct ext_key *hsm_init(struct lightningd *ld)
 	 * actual secret. */
 	if (!ld->config.keypass) {
 		struct stat st;
-		if (stat("hsm_secret", &st) == 0 && st.st_size > 32)
+		if (stat("hsm_secret", &st) == 0 &&
+			 st.st_size == ENCRYPTED_HSM_SECRET_LEN)
 			errx(1, "hsm_secret is encrypted, you need to pass the "
 			        "--encrypted-hsm startup option.");
 	}

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -59,6 +59,7 @@
 #include <common/daemon.h>
 #include <common/ecdh_hsmd.h>
 #include <common/features.h>
+#include <common/hsm_encryption.h>
 #include <common/memleak.h>
 #include <common/timeout.h>
 #include <common/utils.h>
@@ -878,7 +879,7 @@ int main(int argc, char *argv[])
 	/*~ If hsm_secret is encrypted, we don't need its encryption key
 	 * anymore. Note that sodium_munlock() also zeroes the memory.*/
 	if (ld->config.keypass)
-		sodium_munlock(ld->config.keypass->data, sizeof(ld->config.keypass->data));
+		discard_key(take(ld->config.keypass));
 
 	/*~ Our default color and alias are derived from our node id, so we
 	 * can only set those now (if not set by config options). */

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -50,6 +50,9 @@ s64 db_get_intvar(struct db *db UNNEEDED, char *varname UNNEEDED, s64 defval UNN
 /* Generated stub for db_in_transaction */
 bool db_in_transaction(struct db *db UNNEEDED)
 { fprintf(stderr, "db_in_transaction called!\n"); abort(); }
+/* Generated stub for discard_key */
+void discard_key(struct secret *key TAKES UNNEEDED)
+{ fprintf(stderr, "discard_key called!\n"); abort(); }
 /* Generated stub for ecdh_hsmd_setup */
 void ecdh_hsmd_setup(int hsm_fd UNNEEDED,
 		     void (*failed)(enum status_failreason UNNEEDED,

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -46,6 +46,7 @@ FUZZ_COMMON_OBJS := \
 	wire/onion_wiregen.o				\
 	wire/peer_wire.o				\
 	wire/peer_wiregen.o				\
+	wire/tlvstream.o				\
 	wire/towire.o					\
 	wire/wire_io.o					\
 	wire/wire_sync.o

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -23,6 +23,7 @@ FUZZ_COMMON_OBJS := \
 	common/derive_basepoints.o			\
 	common/descriptor_checksum.o			\
 	common/fee_states.o				\
+	common/hsm_encryption.o				\
 	common/htlc_state.o				\
 	common/permute_tx.o				\
 	common/initial_channel.o			\

--- a/tests/fuzz/fuzz-hsm_encryption.c
+++ b/tests/fuzz/fuzz-hsm_encryption.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <tests/fuzz/libfuzz.h>
+
+#include <bitcoin/privkey.h>
+#include <ccan/mem/mem.h>
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+#include <common/hsm_encryption.h>
+#include <common/utils.h>
+
+void init(int *argc, char ***argv)
+{
+}
+
+void run(const uint8_t *data, size_t size)
+{
+	/* 4294967295 is crypto_pwhash_argon2id_PASSWD_MAX. libfuzzer won't
+	 * generate inputs that large in practice, but hey. */
+	if (size > 32 && size < 4294967295) {
+		struct secret *hsm_secret, decrypted_hsm_secret, encryption_key;
+		char *passphrase;
+		struct encrypted_hsm_secret encrypted_secret;
+
+		/* Take the first 32 bytes as the plaintext hsm_secret seed,
+		 * and the remaining ones as the passphrase. */
+		hsm_secret = (struct secret *)tal_dup_arr(NULL, u8, data, 32, 0);
+		passphrase = to_string(NULL, data + 32, size - 32);
+
+		/* A valid seed, a valid passphrase. This should not fail. */
+		assert(!hsm_secret_encryption_key(passphrase, &encryption_key));
+		/* Roundtrip */
+		assert(encrypt_hsm_secret(&encryption_key, hsm_secret,
+					  &encrypted_secret));
+		assert(decrypt_hsm_secret(&encryption_key, &encrypted_secret,
+					  &decrypted_hsm_secret));
+		assert(memeq(hsm_secret->data, sizeof(hsm_secret->data),
+			     decrypted_hsm_secret.data,
+			     sizeof(decrypted_hsm_secret.data)));
+
+		tal_free(hsm_secret);
+		tal_free(passphrase);
+	}
+}

--- a/tests/fuzz/libfuzz.c
+++ b/tests/fuzz/libfuzz.c
@@ -34,10 +34,11 @@ const uint8_t **get_chunks(const void *ctx, const uint8_t *data,
 
 char *to_string(const tal_t *ctx, const u8 *data, size_t data_size)
 {
-	char *string = tal_arr(ctx, char, data_size);
+	char *string = tal_arr(ctx, char, data_size + 1);
 
 	for (size_t i = 0; i < data_size; i++)
 		string[i] = (char) data[i] % (CHAR_MAX + 1);
+	string[data_size] = '\0';
 
 	return string;
 }

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -956,8 +956,9 @@ def test_hsm_secret_encryption(node_factory):
     l1.stop()
     l1.daemon.opts.update({"encrypted-hsm": None})
     l1.daemon.start(stdin=slave_fd, wait_for_initialized=False)
-    l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
-
+    l1.daemon.wait_for_log(r'Enter hsm_secret password')
+    os.write(master_fd, password.encode("utf-8"))
+    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     os.write(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     id = l1.rpc.getinfo()["id"]
@@ -972,7 +973,9 @@ def test_hsm_secret_encryption(node_factory):
     l1.daemon.opts.update({"encrypted-hsm": None})
     l1.daemon.start(stdin=slave_fd, stderr=subprocess.STDOUT,
                     wait_for_initialized=False)
-    l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
+    l1.daemon.wait_for_log(r'Enter hsm_secret password')
+    os.write(master_fd, password[2:].encode("utf-8"))
+    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     os.write(master_fd, password[2:].encode("utf-8"))
     assert(l1.daemon.proc.wait() == 1)
     assert(l1.daemon.is_in_log("Wrong password for encrypted hsm_secret."))
@@ -980,6 +983,8 @@ def test_hsm_secret_encryption(node_factory):
     # Test we can restore the same wallet with the same password
     l1.daemon.start(stdin=slave_fd, wait_for_initialized=False)
     l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
+    os.write(master_fd, password.encode("utf-8"))
+    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     os.write(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     assert id == l1.rpc.getinfo()["id"]
@@ -1005,7 +1010,9 @@ def test_hsmtool_secret_decryption(node_factory):
     l1.stop()
     l1.daemon.opts.update({"encrypted-hsm": None})
     l1.daemon.start(stdin=slave_fd, wait_for_initialized=False)
-    l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
+    l1.daemon.wait_for_log(r'Enter hsm_secret password')
+    os.write(master_fd, password.encode("utf-8"))
+    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     os.write(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     node_id = l1.rpc.getinfo()["id"]
@@ -1038,6 +1045,8 @@ def test_hsmtool_secret_decryption(node_factory):
                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     hsmtool.wait_for_log(r"Enter hsm_secret password:")
     os.write(master_fd, password.encode("utf-8"))
+    hsmtool.wait_for_log(r"Confirm hsm_secret password:")
+    os.write(master_fd, password.encode("utf-8"))
     assert hsmtool.proc.wait(5) == 0
     # Now we need to pass the encrypted-hsm startup option
     l1.stop()
@@ -1050,6 +1059,8 @@ def test_hsmtool_secret_decryption(node_factory):
                     wait_for_initialized=False)
 
     l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
+    os.write(master_fd, password.encode("utf-8"))
+    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     os.write(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     print(node_id, l1.rpc.getinfo()["id"])

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -17,7 +17,7 @@ tools/headerversions: FORCE tools/headerversions.o $(CCAN_OBJS)
 
 tools/check-bolt: tools/check-bolt.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS)
 
-tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bech32.o common/bigsize.o common/configdir.o common/derive_basepoints.o common/descriptor_checksum.o common/node_id.o common/type_to_string.o common/version.o wire/fromwire.o wire/towire.o
+tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/bech32.o common/bigsize.o common/configdir.o common/derive_basepoints.o common/descriptor_checksum.o common/hsm_encryption.o common/node_id.o common/type_to_string.o common/version.o wire/fromwire.o wire/towire.o
 
 tools/lightning-hsmtool: tools/hsmtool
 	cp $< $@

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -145,14 +145,19 @@ static void get_channel_seed(struct secret *channel_seed, struct node_id *peer_i
 	            info, strlen(info));
 }
 
-/* We detect an encrypted hsm_secret as a hsm_secret which is larger than
- * the plaintext seed. */
+/* We detect an encrypted hsm_secret as a hsm_secret which is 73-bytes long. */
 static bool hsm_secret_is_encrypted(const char *hsm_secret_path)
 {
 	struct stat st;
+
 	if (stat(hsm_secret_path, &st) != 0)
 		errx(ERROR_HSM_FILE, "Could not stat hsm_secret");
-	return st.st_size > 32;
+
+	if (st.st_size != 32 && st.st_size != ENCRYPTED_HSM_SECRET_LEN)
+		errx(ERROR_HSM_FILE, "Invalid hsm_secret (neither plaintext "
+				     "nor encrypted).");
+
+	return st.st_size == ENCRYPTED_HSM_SECRET_LEN;
 }
 
 static int decrypt_hsm(const char *hsm_secret_path)

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -21,7 +21,6 @@
 #include <limits.h>
 #include <sodium.h>
 #include <sys/stat.h>
-#include <termios.h>
 #include <unistd.h>
 #include <wally_bip39.h>
 
@@ -168,46 +167,21 @@ static bool hsm_secret_is_encrypted(const char *hsm_secret_path)
 	return st.st_size > 32;
 }
 
-/* Read a pass from stdin, disabling echoing as done in lightning/options for the
- * --encrypted-hsm startup option.
- * Caller must free the returned string. */
-static char *read_stdin_pass(void)
-{
-	struct termios current_term, temp_term;
-	char *passwd = NULL;
-	size_t passwd_size = 0;
-
-	if (tcgetattr(fileno(stdin), &current_term) != 0)
-		errx(ERROR_TERM, "Could not get current terminal options.");
-	temp_term = current_term;
-	temp_term.c_lflag &= ~ECHO;
-	if (tcsetattr(fileno(stdin), TCSAFLUSH, &temp_term) != 0)
-		errx(ERROR_TERM, "Could not disable pass echoing.");
-	/* If we don't flush we might end up being buffered and we might seem
-	 * to hang while we wait for the password. */
-	fflush(stdout);
-	if (getline(&passwd, &passwd_size, stdin) < 0)
-		errx(ERROR_TERM, "Could not read pass from stdin.");
-	if (passwd[strlen(passwd) - 1] == '\n')
-		passwd[strlen(passwd) - 1] = '\0';
-	if (tcsetattr(fileno(stdin), TCSAFLUSH, &current_term) != 0)
-		errx(ERROR_TERM, "Could not restore terminal options.");
-
-	return passwd;
-}
-
 static int decrypt_hsm(const char *hsm_secret_path)
 {
 	int fd;
 	struct secret hsm_secret;
-	char *passwd;
+	char *passwd, *err;
 	const char *dir, *backup;
 
 	/* This checks the file existence, too. */
 	if (!hsm_secret_is_encrypted(hsm_secret_path))
 		errx(ERROR_USAGE, "hsm_secret is not encrypted");
 	printf("Enter hsm_secret password:\n");
-	passwd = read_stdin_pass();
+	fflush(stdout);
+	passwd = read_stdin_pass(&err);
+	if (!passwd)
+		errx(ERROR_TERM, "%s", err);
 
 	if (sodium_init() == -1)
 		errx(ERROR_LIBSODIUM,
@@ -265,9 +239,15 @@ static int encrypt_hsm(const char *hsm_secret_path)
 		errx(ERROR_USAGE, "hsm_secret is already encrypted");
 
 	printf("Enter hsm_secret password:\n");
-	passwd = read_stdin_pass();
+	fflush(stdout);
+	passwd = read_stdin_pass(&err);
+	if (!passwd)
+		errx(ERROR_TERM, "%s", err);
 	printf("Confirm hsm_secret password:\n");
-	passwd_confirmation = read_stdin_pass();
+	fflush(stdout);
+	passwd_confirmation = read_stdin_pass(&err);
+	if (!passwd_confirmation)
+		errx(ERROR_TERM, "%s", err);
 	if (!streq(passwd, passwd_confirmation))
 		errx(ERROR_USAGE, "Passwords confirmation mismatch.");
 	get_hsm_secret(&hsm_secret, hsm_secret_path);
@@ -295,10 +275,8 @@ static int encrypt_hsm(const char *hsm_secret_path)
 		errx(ERROR_LIBSODIUM, "Could not encrypt the seed.");
 
 	/* Once the encryption key derived, we don't need it anymore. */
-	if (passwd)
-		free(passwd);
-	if (passwd_confirmation)
-		free(passwd_confirmation);
+	free(passwd);
+	free(passwd_confirmation);
 
 	/* Create a backup file, "just in case". */
 	rename(hsm_secret_path, backup);
@@ -335,7 +313,7 @@ static int dump_commitments_infos(struct node_id *node_id, u64 channel_id,
 	struct sha256 shaseed;
 	struct secret hsm_secret, channel_seed, per_commitment_secret;
 	struct pubkey per_commitment_point;
-	char *passwd;
+	char *passwd, *err;
 
 	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
 	                                         | SECP256K1_CONTEXT_SIGN);
@@ -343,7 +321,10 @@ static int dump_commitments_infos(struct node_id *node_id, u64 channel_id,
 	/* This checks the file existence, too. */
 	if (hsm_secret_is_encrypted(hsm_secret_path)) {
 		printf("Enter hsm_secret password:\n");
-		passwd = read_stdin_pass();
+		fflush(stdout);
+		passwd = read_stdin_pass(&err);
+		if (!passwd)
+			errx(ERROR_TERM, "%s", err);
 		get_encrypted_hsm_secret(&hsm_secret, hsm_secret_path, passwd);
 		free(passwd);
 	} else
@@ -388,7 +369,7 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
                            u64 tries, char *hsm_secret_path)
 {
 	struct secret hsm_secret, channel_seed, basepoint_secret;
-	char *passwd;
+	char *passwd, *err;
 	struct pubkey basepoint;
 	struct ripemd160 pubkeyhash;
 	/* We only support P2WPKH, hence 20. */
@@ -410,7 +391,10 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 	/* This checks the file existence, too. */
 	if (hsm_secret_is_encrypted(hsm_secret_path)) {
 		printf("Enter hsm_secret password:\n");
-		passwd = read_stdin_pass();
+		fflush(stdout);
+		passwd = read_stdin_pass(&err);
+		if (!passwd)
+			errx(ERROR_TERM, "%s", err);
 		get_encrypted_hsm_secret(&hsm_secret, hsm_secret_path, passwd);
 		free(passwd);
 	} else
@@ -510,14 +494,17 @@ static void read_mnemonic(char *mnemonic) {
 static int generate_hsm(const char *hsm_secret_path)
 {
 	char mnemonic[BIP39_WORDLIST_LEN];
-	char *passphrase;
+	char *passphrase, *err;
 
 	read_mnemonic(mnemonic);
 	printf("Warning: remember that different passphrases yield different "
 	       "bitcoin wallets.\n");
 	printf("If left empty, no password is used (echo is disabled).\n");
 	printf("Enter your passphrase: \n");
-	passphrase = read_stdin_pass();
+	fflush(stdout);
+	passphrase = read_stdin_pass(&err);
+	if (!passphrase)
+		errx(ERROR_TERM, "%s", err);
 	if (strlen(passphrase) == 0) {
 		free(passphrase);
 		passphrase = NULL;
@@ -554,7 +541,7 @@ static int dumponchaindescriptors(const char *hsm_secret_path, const char *old_p
 				  const bool is_testnet)
 {
 	struct secret hsm_secret;
-	char *passwd;
+	char *passwd, *err;
 	u8 bip32_seed[BIP32_ENTROPY_LEN_256];
 	u32 salt = 0;
 	u32 version = is_testnet ?
@@ -566,7 +553,10 @@ static int dumponchaindescriptors(const char *hsm_secret_path, const char *old_p
 	/* This checks the file existence, too. */
 	if (hsm_secret_is_encrypted(hsm_secret_path)) {
 		printf("Enter hsm_secret password:\n");
-		passwd = read_stdin_pass();
+		fflush(stdout);
+		passwd = read_stdin_pass(&err);
+		if (!passwd)
+			errx(ERROR_TERM, "%s", err);
 		get_encrypted_hsm_secret(&hsm_secret, hsm_secret_path, passwd);
 		free(passwd);
 	} else


### PR DESCRIPTION
This is a bunch of cleanups on top of https://github.com/ElementsProject/lightning/pull/4303 .

Mainly, this makes the `hsm_encryption` contained into a common/ module, shared by `hsmd`, `lightningd` (options and hsm_control) and `hsmtool`. This then allows us to fuzz a roundtrip sanity check of our encryption.

Also:
- Cleanup errors in `hsmtool`
- Confirm password on `encrypt` in `hsmtool`
- Be stricter on `hsm_secret` validity (only accept 32-bytes (plaintext) and 73-bytes (encrypted) seeds)

There are still some cleanups left to be done (the channel seed derivation function is still duplicated, we could use `opt` for argument parsing).