### PR TITLE
pyln: Add command notifications support

### DIFF
--- a/tests/plugins/countdown.py
+++ b/tests/plugins/countdown.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from pyln.client import Plugin
+import time
+
+plugin = Plugin()
+
+
+@plugin.method("countdown")
+def countdown(count, plugin, request):
+    count = int(count)
+    for i in range(count):
+        time.sleep(0.1)
+        request.notify("{}/{}".format(i, count), "INFO")
+
+    return "Done"
+
+
+plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2027,15 +2027,18 @@ def test_notify(node_factory):
             assert out[2 + i].endswith("|\n")
         else:
             assert out[2 + i].endswith("|\r")
-    assert out[102] == '\r'
+
+    assert out[102] == '# Beginning stage 2\n'
+    assert out[103] == '\r'
+
     for i in range(10):
-        assert out[103 + i].startswith("# Stage 2/2 {:>2}/10 |".format(1 + i))
+        assert out[104 + i].startswith("# Stage 2/2 {:>2}/10 |".format(1 + i))
         if i == 9:
-            assert out[103 + i].endswith("|\n")
+            assert out[104 + i].endswith("|\n")
         else:
-            assert out[103 + i].endswith("|\r")
-    assert out[113] == '"This worked"\n'
-    assert len(out) == 114
+            assert out[104 + i].endswith("|\r")
+    assert out[114] == '"This worked"\n'
+    assert len(out) == 115
 
     # At debug level, we get the second prompt.
     out = subprocess.check_output(['cli/lightning-cli',


### PR DESCRIPTION
Adds command notification support to both the RPC client library as
well as the plugin library. This allows RPC clients to register a
notification callback that gets called for each notification, and
allows plugin methods to report status or progress using the
`Request.notify` method.