### PR TITLE
json-rpc: Add support for querying by hash or bolt11 to `listinvoices`

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -875,12 +875,17 @@ class LightningRpc(UnixDomainSocketRpc):
         """
         return self.call("listtransactions")
 
-    def listinvoices(self, label=None):
-        """
-        Show invoice {label} (or all, if no {label)).
+    def listinvoices(self, label=None, payment_hash=None, invstring=None):
+        """Query invoices
+
+        Show invoice matching {label} {payment_hash} or {invstring} (or
+        all, if no filters are present).
+
         """
         payload = {
-            "label": label
+            "label": label,
+            "payment_hash": payment_hash,
+            "invstring": invstring,
         }
         return self.call("listinvoices", payload)
 

--- a/doc/lightning-listinvoices.7
+++ b/doc/lightning-listinvoices.7
@@ -3,12 +3,18 @@
 lightning-listinvoices - Command for querying invoice status
 .SH SYNOPSIS
 
-\fBlistinvoices\fR [\fIlabel\fR]
+\fBlistinvoices\fR [\fIlabel\fR] [\fIinvstring\fR] [\fIpayment_hash\fR]
 
 .SH DESCRIPTION
 
 The \fBlistinvoices\fR RPC command gets the status of a specific invoice,
 if it exists, or the status of all invoices if given no argument\.
+
+
+A specific invoice can be queried by providing either the \fBlabel\fR
+provided when creating the invoice, the \fBinvstring\fR string representing
+the invoice, or the \fBpayment_hash\fR of the invoice\. Only one of the
+query parameters can be used at once\.
 
 .SH RETURN VALUE
 
@@ -35,4 +41,4 @@ Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:de5a19a60e141b582228650442680a6c966edbab2340894db3b532495c5f462c
+\" SHA256STAMP:24dc46a53eed1dd689d7fb371a3da52242f306126d54bba3d8c6ba5a75b6b795

--- a/doc/lightning-listinvoices.7.md
+++ b/doc/lightning-listinvoices.7.md
@@ -4,13 +4,18 @@ lightning-listinvoices -- Command for querying invoice status
 SYNOPSIS
 --------
 
-**listinvoices** \[*label*\]
+**listinvoices** \[*label*\] \[*invstring*\] \[*payment_hash*\]
 
 DESCRIPTION
 -----------
 
 The **listinvoices** RPC command gets the status of a specific invoice,
 if it exists, or the status of all invoices if given no argument.
+
+A specific invoice can be queried by providing either the `label`
+provided when creating the invoice, the `invstring` string representing
+the invoice, or the `payment_hash` of the invoice. Only one of the
+query parameters can be used at once.
 
 RETURN VALUE
 ------------

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -463,6 +463,11 @@ struct command_result *param_number(struct command *cmd UNNEEDED, const char *na
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				    unsigned int **num UNNEEDED)
 { fprintf(stderr, "param_number called!\n"); abort(); }
+/* Generated stub for param_sha256 */
+struct command_result *param_sha256(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				    struct sha256 **hash UNNEEDED)
+{ fprintf(stderr, "param_sha256 called!\n"); abort(); }
 /* Generated stub for param_short_channel_id */
 struct command_result *param_short_channel_id(struct command *cmd UNNEEDED,
 					      const char *name UNNEEDED,


### PR DESCRIPTION
A user reported that it is sometimes cumbersome to search an invoice
based on the payment hash or the bolt11 string in the full list, which
may be required when we don't have the label available.

This adds support for querying / filtering based on the `payment_hash`
or `bolt11` string.