### PR TITLE
channeld: stop taken() leak.

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -496,6 +496,18 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	htlc->amount = amount;
 	htlc->state = state;
 
+	htlc->rhash = *payment_hash;
+	if (blinding)
+		htlc->blinding = tal_dup(htlc, struct pubkey, blinding);
+	else {
+		/* Can be taken, even if NULL. */
+		taken(blinding);
+		htlc->blinding = NULL;
+	}
+	htlc->failed = NULL;
+	htlc->r = NULL;
+	htlc->routing = tal_dup_arr(htlc, u8, routing, TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE), 0);
+
 	/* FIXME: Change expiry to simple u32 */
 
 	/* BOLT #2:
@@ -509,15 +521,6 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	if (!blocks_to_abs_locktime(cltv_expiry, &htlc->expiry)) {
 		return CHANNEL_ERR_INVALID_EXPIRY;
 	}
-
-	htlc->rhash = *payment_hash;
-	if (blinding)
-		htlc->blinding = tal_dup(htlc, struct pubkey, blinding);
-	else
-		htlc->blinding = NULL;
-	htlc->failed = NULL;
-	htlc->r = NULL;
-	htlc->routing = tal_dup_arr(htlc, u8, routing, TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE), 0);
 
 	old = htlc_get(channel->htlcs, htlc->id, htlc_owner(htlc));
 	if (old) {


### PR DESCRIPTION
I saw this message:

```
lightning_channeld: outstanding taken(): channeld/channeld.c:3087:blinding
lightning_channeld: outstanding taken(): channeld/channeld.c:3087:blinding
lightning_channeld: outstanding taken(): channeld/channeld.c:3087:blinding
```

The caller does take(blinding), but blinding can be NULL.  We should
move the code around to do the take() earlier anyway.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None