### PR TITLE
pay: Fix a crash when waitblockheight times out

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -84,4 +84,7 @@ static const errcode_t OFFER_EXPIRED = 1002;
 static const errcode_t OFFER_ROUTE_NOT_FOUND = 1003;
 static const errcode_t OFFER_BAD_INVREQ_REPLY = 1004;
 
+/* Errors from wait* commands */
+static const errcode_t WAIT_TIMEOUT = 2000;
+
 #endif /* LIGHTNING_COMMON_JSONRPC_ERRORS_H */

--- a/doc/lightning-waitblockheight.7
+++ b/doc/lightning-waitblockheight.7
@@ -23,7 +23,7 @@ the block height at the time the command returns\.
 
 
 If \fItimeout\fR seconds is reached without the specified blockheight
-being reached, this command will fail\.
+being reached, this command will fail with a code of \fB2000\fR\.
 
 .SH AUTHOR
 
@@ -33,4 +33,4 @@ ZmnSCPxj \fI<ZmnSCPxj@protonmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:5714e6333e5ba57cc00de425e6dc411f2c30812bbc8d95d01d50c460ee002e29
+\" SHA256STAMP:ac3320b4b9e679d8c407e42c9663540e2fc2aca75143d192f58ce255ca9b3700

--- a/doc/lightning-waitblockheight.7.md
+++ b/doc/lightning-waitblockheight.7.md
@@ -24,7 +24,7 @@ an object with the single field *blockheight* is returned, which is
 the block height at the time the command returns.
 
 If *timeout* seconds is reached without the specified blockheight
-being reached, this command will fail.
+being reached, this command will fail with a code of `2000`.
 
 AUTHOR
 ------

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1850,7 +1850,7 @@ timeout_waitblockheight_waiter(struct waitblockheight_waiter *w)
 	list_del(&w->list);
 	w->removed = true;
 	tal_steal(tmpctx, w);
-	was_pending(command_fail(w->cmd, LIGHTNINGD,
+	was_pending(command_fail(w->cmd, WAIT_TIMEOUT,
 				 "Timed out."));
 }
 /* Called by lightningd at each new block.  */

--- a/tests/plugins/endlesswaitblockheight.py
+++ b/tests/plugins/endlesswaitblockheight.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Simple plugin to cause a waitblockheight that times out.
+
+We report an error with a future blockheight, which causes the sender
+to wait, and ultimately retry, excluding us because we misbehaved.
+
+"""
+
+
+from pyln.client import Plugin
+plugin = Plugin()
+
+
+@plugin.hook('htlc_accepted')
+def on_htlc_accepted(onion, htlc, **kwargs):
+    return {
+        'result': "fail",
+        "failure_message": "400f00000000000000007fffffff",  # Bogus error with INT32_MAX as blockheight
+    }
+
+
+plugin.run()

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3935,7 +3935,6 @@ def test_fetchinvoice(node_factory, bitcoind):
                                  'recurrence_label': 'test recurrence'})
 
 
-@pytest.mark.xfail(strict=True)
 def test_pay_waitblockheight_timeout(node_factory, bitcoind):
     plugin = os.path.join(os.path.dirname(__file__), 'plugins', 'endlesswaitblockheight.py')
     l1, l2 = node_factory.line_graph(2, opts=[{}, {'plugin': plugin}])


### PR DESCRIPTION
We would `plugin_err()` if the call to `waitblockheight` in the
corresponding modifier timed out, instead of returning after
successful sync. We now catch that and terminate the payment on
timeout. Since we only react to errors containing a blockheight from
the last node, not being in sync is fatal for that payment.

Fixes #4269
Fixes #4309
Changelog-Fixed: pay: Fixed an issue where waiting for the blockchain height to sync could time out.