### PR TITLE
wallet/db.c: Speed up deletion of single peers.

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -669,6 +669,11 @@ static struct migration dbmigrations[] = {
     /* A reference into our own offers table, if it was made from one */
     {SQL("ALTER TABLE payments ADD COLUMN local_offer_id BLOB DEFAULT NULL REFERENCES offers(offer_id);"), NULL},
     {SQL("ALTER TABLE channels ADD funding_tx_remote_sigs_received INTEGER DEFAULT 0;"), NULL},
+
+    /* Speeds up deletion of one peer from the database, measurements suggest
+     * it cuts down the time by 80%.  */
+    {SQL("CREATE INDEX forwarded_payments_out_htlc_id"
+	 " ON forwarded_payments (out_htlc_id);"), NULL},
 };
 
 /* Leak tracking. */

--- a/wallet/db_postgres_sqlgen.c
+++ b/wallet/db_postgres_sqlgen.c
@@ -873,6 +873,12 @@ struct db_query db_postgres_queries[] = {
          .readonly = false,
     },
     {
+         .name = "CREATE INDEX forwarded_payments_out_htlc_id ON forwarded_payments (out_htlc_id);",
+         .query = "CREATE INDEX forwarded_payments_out_htlc_id ON forwarded_payments (out_htlc_id);",
+         .placeholders = 0,
+         .readonly = false,
+    },
+    {
          .name = "UPDATE vars SET intval = intval + 1 WHERE name = 'data_version' AND intval = ?",
          .query = "UPDATE vars SET intval = intval + 1 WHERE name = 'data_version' AND intval = $1",
          .placeholders = 1,
@@ -1774,10 +1780,10 @@ struct db_query db_postgres_queries[] = {
     },
 };
 
-#define DB_POSTGRES_QUERY_COUNT 294
+#define DB_POSTGRES_QUERY_COUNT 295
 
 #endif /* HAVE_POSTGRES */
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_POSTGRES */
 
-// SHA256STAMP:ca47a99b5c64139f4556f3bf77a6d984cb9ab6b38bcd2851bc551c75c5cc240a
+// SHA256STAMP:910328b3c942486b746f7f5d2a91fad65ae9eb54032a5828705132bfa1b86eaf

--- a/wallet/db_sqlite3_sqlgen.c
+++ b/wallet/db_sqlite3_sqlgen.c
@@ -873,6 +873,12 @@ struct db_query db_sqlite3_queries[] = {
          .readonly = false,
     },
     {
+         .name = "CREATE INDEX forwarded_payments_out_htlc_id ON forwarded_payments (out_htlc_id);",
+         .query = "CREATE INDEX forwarded_payments_out_htlc_id ON forwarded_payments (out_htlc_id);",
+         .placeholders = 0,
+         .readonly = false,
+    },
+    {
          .name = "UPDATE vars SET intval = intval + 1 WHERE name = 'data_version' AND intval = ?",
          .query = "UPDATE vars SET intval = intval + 1 WHERE name = 'data_version' AND intval = ?",
          .placeholders = 1,
@@ -1774,10 +1780,10 @@ struct db_query db_sqlite3_queries[] = {
     },
 };
 
-#define DB_SQLITE3_QUERY_COUNT 294
+#define DB_SQLITE3_QUERY_COUNT 295
 
 #endif /* HAVE_SQLITE3 */
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_SQLITE3 */
 
-// SHA256STAMP:ca47a99b5c64139f4556f3bf77a6d984cb9ab6b38bcd2851bc551c75c5cc240a
+// SHA256STAMP:910328b3c942486b746f7f5d2a91fad65ae9eb54032a5828705132bfa1b86eaf

--- a/wallet/statements_gettextgen.po
+++ b/wallet/statements_gettextgen.po
@@ -574,67 +574,71 @@ msgstr ""
 msgid "ALTER TABLE channels ADD funding_tx_remote_sigs_received INTEGER DEFAULT 0;"
 msgstr ""
 
-#: wallet/db.c:898
+#: wallet/db.c:675
+msgid "CREATE INDEX forwarded_payments_out_htlc_id ON forwarded_payments (out_htlc_id);"
+msgstr ""
+
+#: wallet/db.c:903
 msgid "UPDATE vars SET intval = intval + 1 WHERE name = 'data_version' AND intval = ?"
 msgstr ""
 
-#: wallet/db.c:998
+#: wallet/db.c:1003
 msgid "SELECT version FROM version LIMIT 1"
 msgstr ""
 
-#: wallet/db.c:1056
+#: wallet/db.c:1061
 msgid "UPDATE version SET version=?;"
 msgstr ""
 
-#: wallet/db.c:1064
+#: wallet/db.c:1069
 msgid "INSERT INTO db_upgrades VALUES (?, ?);"
 msgstr ""
 
-#: wallet/db.c:1076
+#: wallet/db.c:1081
 msgid "SELECT intval FROM vars WHERE name = 'data_version'"
 msgstr ""
 
-#: wallet/db.c:1103
+#: wallet/db.c:1108
 msgid "SELECT intval FROM vars WHERE name= ? LIMIT 1"
 msgstr ""
 
-#: wallet/db.c:1119
+#: wallet/db.c:1124
 msgid "UPDATE vars SET intval=? WHERE name=?;"
 msgstr ""
 
-#: wallet/db.c:1128
+#: wallet/db.c:1133
 msgid "INSERT INTO vars (name, intval) VALUES (?, ?);"
 msgstr ""
 
-#: wallet/db.c:1142
+#: wallet/db.c:1147
 msgid "UPDATE channels SET feerate_base = ?, feerate_ppm = ?;"
 msgstr ""
 
-#: wallet/db.c:1163
+#: wallet/db.c:1168
 msgid "UPDATE channels SET our_funding_satoshi = funding_satoshi WHERE funder = 0;"
 msgstr ""
 
-#: wallet/db.c:1179
+#: wallet/db.c:1184
 msgid "SELECT type, keyindex, prev_out_tx, prev_out_index, channel_id, peer_id, commitment_point FROM outputs WHERE scriptpubkey IS NULL;"
 msgstr ""
 
-#: wallet/db.c:1241
+#: wallet/db.c:1246
 msgid "UPDATE outputs SET scriptpubkey = ? WHERE prev_out_tx = ?    AND prev_out_index = ?"
 msgstr ""
 
-#: wallet/db.c:1266
+#: wallet/db.c:1271
 msgid "SELECT id, funding_tx_id, funding_tx_outnum FROM channels;"
 msgstr ""
 
-#: wallet/db.c:1285
+#: wallet/db.c:1290
 msgid "UPDATE channels SET full_channel_id = ? WHERE id = ?;"
 msgstr ""
 
-#: wallet/db.c:1308
+#: wallet/db.c:1313
 msgid "SELECT   c.id, p.node_id, c.last_tx, c.funding_satoshi, c.fundingkey_remote, c.last_sig FROM channels c  LEFT OUTER JOIN peers p  ON p.id = c.peer_id;"
 msgstr ""
 
-#: wallet/db.c:1375
+#: wallet/db.c:1380
 msgid "UPDATE channels SET last_tx = ? WHERE id = ?;"
 msgstr ""
 
@@ -1173,4 +1177,4 @@ msgstr ""
 #: wallet/test/run-wallet.c:1390
 msgid "INSERT INTO channels (id) VALUES (1);"
 msgstr ""
-#  SHA256STAMP:e9a62e2d71753f9067c6853326ba6d9e486cd85947d46a228dfcc58b8de5004a
+#  SHA256STAMP:ca486a7af5f01c9cf68f53b5c4ea9d3baa3cffa8ea64b8b86c9b2295d974e312


### PR DESCRIPTION
Fixes #4325

I petition adding this to the 0.9.3 release candidate, as, it gives a massive speedup on peer deletion, does not change semantics of the database, just pure speedup, and the change is very small.