### PR TITLE
Weekly cleanups -- release edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ coverage
 ccan/config.h
 __pycache__
 config.vars
+monkeytype.sqlite3
 
 # Ignore some generated binaries
 */test/run-*
@@ -50,8 +51,11 @@ contrib/pylightning/pylightning.egg-info/
 contrib/pyln-*/build/
 contrib/pyln-*/dist/
 contrib/pyln-*/pyln_*.egg-info/
+plugins/fetchinvoice
+plugins/offers
 plugins/keysend
 release/
-
+tests/plugins/test_selfdisable_after_getmanifest
 devtools/route
 devtools/topology
+devtools/bolt12-cli

--- a/contrib/pyln-proto/requirements.txt
+++ b/contrib/pyln-proto/requirements.txt
@@ -2,5 +2,5 @@ bitstring==3.1.6
 cryptography==3.2
 coincurve==13.0.0
 base58==1.0.2
-mypy
+mypy==0.790
 pysocks==1.7.*

--- a/devtools/credit
+++ b/devtools/credit
@@ -48,11 +48,12 @@ while read LINE; do
 	fi
     fi
     if [ -n "$NOTES" ] || $VERBOSE; then
-	echo "$COUNT $NAME $EMAIL $NOTES"
+	echo " - $COUNT $NAME $EMAIL $NOTES"
     fi
 done < /tmp/authors.$$
 
 DAYS=$(( ( $(date +%s) - $(git log "$PREV_TAG" --format=%at | head -n1) ) / (3600*24) ))
 
-echo "$TOTAL commits in $DAYS days"
+AUTHORS=$(cat /tmp/authors.$$ | wc -l)
+echo "$TOTAL commits in $DAYS days by $AUTHORS authors"
 rm /tmp/authors.$$ /tmp/namers.$$ /tmp/prev-authors.$$

--- a/doc/MAKING-RELEASES.md
+++ b/doc/MAKING-RELEASES.md
@@ -27,7 +27,7 @@ Here's a checklist for the release process.
    `CHANGELOG.md`.  This does API queries to GitHub, which are severely
    ratelimited unless you use an API token: set the `GH_TOKEN` environment
    variable to a Personal Access Token from https://github.com/settings/tokens
-3. Create a new CHANGELOG.md heading to v<VERSION>-rc1, and create a link at
+3. Create a new CHANGELOG.md heading to `v<VERSION>rc1`, and create a link at
    the bottom. Note that you should exactly copy the date and name format from
    a previous release, as the `build-release.sh` script relies on this.
 4. Create a PR with the above.

--- a/doc/MAKING-RELEASES.md
+++ b/doc/MAKING-RELEASES.md
@@ -58,7 +58,11 @@ Here's a checklist for the release process.
 
 1. Update the CHANGELOG.md; remove -rcN in both places, update the date.
 2. Add a PR with that release.
-3. Merge the PR, then `git pull && git tag -s v<VERSION> && git push --tags`.
+3. Merge the PR, then:
+   - `export VERSION=0.9.3`
+   - `git pull`
+   - `git tag -a -s v${VERSION} -m v${VERSION}`
+   - `git push --tags`
 4. Run `tools/build-release.sh` to build the non-reprodicible images
    and reproducible zipfile.
 5. Use the zipfile to produce a [reproducible build](REPRODUCIBLE.md).

--- a/external/Makefile
+++ b/external/Makefile
@@ -71,7 +71,19 @@ $(TARGET_DIR)/libsecp256k1.% $(TARGET_DIR)/libwallycore.%: $(TARGET_DIR)/libwall
 $(TARGET_DIR)/libwally-core-build/src/libwallycore.% $(TARGET_DIR)/libwally-core-build/src/secp256k1/libsecp256k1.%: $(LIBWALLY_HEADERS) $(LIBSECP_HEADERS)
 	cd external/libwally-core && ./tools/autogen.sh
 	mkdir -p ${TARGET_DIR}/libwally-core-build
-	cd ${TARGET_DIR}/libwally-core-build && CFLAGS=-std=c99 ${TOP}/libwally-core/configure CC="$(CC)" --enable-static=yes $(CROSSCOMPILE_OPTS) --enable-module-recovery --enable-module-extrakeys --enable-module-schnorrsig --enable-elements --enable-shared=no --prefix=/ --libdir=/ --enable-debug && $(MAKE)
+	cd ${TARGET_DIR}/libwally-core-build \
+	&& PYTHON_VERSION=3 CFLAGS=-std=c99 ${TOP}/libwally-core/configure CC="$(CC)" \
+		--enable-static=yes \
+		$(CROSSCOMPILE_OPTS) \
+		--enable-module-recovery \
+		--enable-module-extrakeys \
+		--enable-module-schnorrsig \
+		--enable-elements \
+		--enable-shared=no \
+		--prefix=/ \
+		--libdir=/ \
+		--enable-debug \
+	&& $(MAKE)
 
 # If we tell Make that the above builds both, it runs it twice in
 # parallel.  So we lie :(

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -66,7 +66,7 @@ if [ "$VERSION" = "" ]; then
 fi
 
 # Skip 'v' here in $VERSION
-MTIME=${FORCE_MTIME:-$(sed -n "s/^## \\[${VERSION#v}\\] - \\([-0-9]*\\).*/\\1/p" < CHANGELOG.md)}
+MTIME=${FORCE_MTIME:-$(sed -n "s/^## \\[.*${VERSION#v}\\] - \\([-0-9]*\\).*/\\1/p" < CHANGELOG.md)}
 if [ -z "$MTIME" ]; then
     echo "No date found for $VERSION in CHANGELOG.md" >&2
     exit 1


### PR DESCRIPTION
Mostly some cosmetic changes to the release tools, but they address some pitfalls that caused my to restart the release process a couple of times (`0.9.3` vs `v0.9.3` in the changelog for example).

Changelog-None