### PR TITLE
lightningd: disallow --daemon without --log-file.

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -210,7 +210,8 @@ as well\.
 
 
  \fBdaemon\fR
-Run in the background, suppress stdout and stderr\.
+Run in the background, suppress stdout and stderr\.  Note that you need
+to specify \fBlog-file\fR for this case\.
 
 
  \fBconf\fR=\fIPATH\fR
@@ -607,4 +608,4 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 
-\" SHA256STAMP:e9f294f15d8873a2332b5748179be09c1496c9e81576dc0e4546c047474289fd
+\" SHA256STAMP:8e18374d48aff1d2574667c603e36cdac81c35e09a49397dc6982f1688dd454a

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -168,7 +168,8 @@ Set to 0660 to allow users with the same group to access the RPC
 as well.
 
  **daemon**
-Run in the background, suppress stdout and stderr.
+Run in the background, suppress stdout and stderr.  Note that you need
+to specify **log-file** for this case.
 
  **conf**=*PATH*
 Sets configuration file, and disable reading the normal general and network

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -726,6 +726,9 @@ static void check_config(struct lightningd *ld)
 
 	if (ld->use_proxy_always && !ld->proxyaddr)
 		fatal("--always-use-proxy needs --proxy");
+
+	if (ld->daemon_parent_fd != -1 && !ld->logfile)
+		fatal("--daemon needs --log-file");
 }
 
 static char *test_subdaemons_and_exit(struct lightningd *ld)


### PR DESCRIPTION
From #clightning:

     (11:24:10) andytoshi: hiya, i'm trying to set up a new lightningd node, and when i run lightningd --network=bitcoin --log-level=debug --daemon
     (11:24:17) andytoshi: i get errors of the form fetchinvoice: Malformed JSON reply '2021-01-25T00:51:16.655Z DEBUG   plugin-offers: disabled itself at init: offers not enabled in config
     (11:24:43) andytoshi: there are a couple variants of this, but always some form of "something: failed to parse <a log line> as json"

Indeed, we close stdout, and it ends up being reused for some plugin.
But the real problem is that we log to stdout by default, which doesn't
make sense.  If they really want to discard logs, they can use
--log-file=/dev/null.
