### PR TITLE
feat: chain hook custommsg

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1218,11 +1218,8 @@ ignored by nodes (see ["it's ok to be odd" in the specification][oddok] for
 details). The plugin must implement the parsing of the message, including the
 type prefix, since c-lightning does not know how to parse the message.
 
-The result for this hook is currently being discarded. For future uses of the
-result we suggest just returning `{'result': 'continue'}`.
-This will ensure backward
-compatibility should the semantics be changed in future.
-
+Because this is a chained hook, the daemon expects the result to be
+`{'result': 'continue'}`. It will fail if something else is returned.
 
 ### `onion_message` and `onion_message_blinded`
 

--- a/tests/plugins/custommsg.py
+++ b/tests/plugins/custommsg.py
@@ -10,6 +10,7 @@ def on_custommsg(peer_id, message, plugin, **kwargs):
         msg=message,
         peer_id=peer_id
     ))
+    return {'result': 'continue'}
 
 
 plugin.run()

--- a/tests/plugins/custommsg_a.py
+++ b/tests/plugins/custommsg_a.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('custommsg')
+def on_custommsg(peer_id, message, plugin, **kwargs):
+    plugin.log("Got custommessage_a {msg} from peer {peer_id}".format(
+        msg=message,
+        peer_id=peer_id
+    ))
+    return {'result': 'continue'}
+
+
+plugin.run()

--- a/tests/plugins/custommsg_b.py
+++ b/tests/plugins/custommsg_b.py
@@ -6,7 +6,7 @@ plugin = Plugin()
 
 @plugin.hook('custommsg')
 def on_custommsg(peer_id, message, plugin, **kwargs):
-    plugin.log("Got a custom message {msg} from peer {peer_id}".format(
+    plugin.log("Got custommessage_b {msg} from peer {peer_id}".format(
         msg=message,
         peer_id=peer_id
     ))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2239,8 +2239,10 @@ def test_sendcustommsg(node_factory):
     and we can't send to it.
 
     """
-    plugin = os.path.join(os.path.dirname(__file__), "plugins", "custommsg.py")
-    opts = {'log-level': 'io', 'plugin': plugin}
+    opts = {'log-level': 'io', 'plugin': [
+        os.path.join(os.path.dirname(__file__), "plugins", "custommsg_b.py"),
+        os.path.join(os.path.dirname(__file__), "plugins", "custommsg_a.py")
+    ]}
     l1, l2, l3, l4 = node_factory.get_nodes(4, opts=opts)
     node_factory.join_nodes([l1, l2, l3])
     l2.connect(l4)
@@ -2279,9 +2281,12 @@ def test_sendcustommsg(node_factory):
         )
     )
     l1.daemon.wait_for_log(r'\[IN\] {}'.format(serialized))
-    l1.daemon.wait_for_log(
-        r'Got a custom message {serialized} from peer {peer_id}'.format(
-            serialized=serialized, peer_id=l2.info['id']))
+    l1.daemon.wait_for_logs([
+        r'Got custommessage_a {serialized} from peer {peer_id}'.format(
+            serialized=serialized, peer_id=l2.info['id']),
+        r'Got custommessage_b {serialized} from peer {peer_id}'.format(
+            serialized=serialized, peer_id=l2.info['id'])
+    ])
 
     # This should work since the peer is currently owned by `openingd`
     l2.rpc.dev_sendcustommsg(l4.info['id'], msg)
@@ -2291,9 +2296,12 @@ def test_sendcustommsg(node_factory):
         )
     )
     l4.daemon.wait_for_log(r'\[IN\] {}'.format(serialized))
-    l4.daemon.wait_for_log(
-        r'Got a custom message {serialized} from peer {peer_id}'.format(
-            serialized=serialized, peer_id=l2.info['id']))
+    l4.daemon.wait_for_logs([
+        r'Got custommessage_a {serialized} from peer {peer_id}'.format(
+            serialized=serialized, peer_id=l2.info['id']),
+        r'Got custommessage_b {serialized} from peer {peer_id}'.format(
+            serialized=serialized, peer_id=l2.info['id']),
+    ])
 
 
 def test_sendonionmessage(node_factory):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -651,6 +651,8 @@ def test_openchannel_hook_chaining(node_factory, bitcoind):
         l1.rpc.fundchannel(l2.info['id'], 100005)
 
     assert l2.daemon.wait_for_log(hook_msg + "reject for a reason")
+    # first plugin in the chain was called
+    assert l2.daemon.is_in_log("accept on principle")
     # the third plugin must now not be called anymore
     assert not l2.daemon.is_in_log("reject on principle")
 


### PR DESCRIPTION
This PR will also make the `custommsg` hook chainable.

Adds: Feature, documentation and tests.

Note: I made the hooks response `{'result': 'continue'}` mandatory since this is cleaner for a chained hook.