### PR TITLE
chore: pyln testing improvements

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -84,13 +84,13 @@ TIMEOUT = int(env("TIMEOUT", 180 if SLOW_MACHINE else 60))
 def wait_for(success, timeout=TIMEOUT):
     start_time = time.time()
     interval = 0.25
-    while not success() and time.time() < start_time + timeout:
+    while not success():
+        if time.time() > start_time + timeout:
+            raise ValueError("Timeout while waiting for {}", success)
         time.sleep(interval)
         interval *= 2
         if interval > 5:
             interval = 5
-    if time.time() > start_time + timeout:
-        raise ValueError("Error waiting for {}", success)
 
 
 def write_config(filename, opts, regtest_opts=None, section_name='regtest'):

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -942,11 +942,14 @@ class LightningNode(object):
             raise ValueError("Error waiting for a route to destination {}".format(destination))
 
     # This helper waits for all HTLCs to settle
-    def wait_for_htlcs(self):
+    # `scids` can be a list of strings. If unset wait on all channels.
+    def wait_for_htlcs(self, scids=None):
         peers = self.rpc.listpeers()['peers']
         for p, peer in enumerate(peers):
             if 'channels' in peer:
                 for c, channel in enumerate(peer['channels']):
+                    if scids is not None and channel['short_channel_id'] not in scids:
+                        continue
                     if 'htlcs' in channel:
                         wait_for(lambda: len(self.rpc.listpeers()['peers'][p]['channels'][c]['htlcs']) == 0)
 


### PR DESCRIPTION
Tiny changes that can improve testing.

## About `wait_for` changes
When thinking about it, it does not make it potentially faster, but when timeout occurred, it does a final success() check to see if the last `time.sleep()` lead to a situation where `success()` became `True`. Before that, it did a `time.sleep()` and didn't re-check `success()`.

We could further improve this by checking that the final `sleep` will be finished right after timeout would occur so we are more precise on the final sleep and do not waste any time.