### PR TITLE
doc: Update the recommonmark extension for RTD compilation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.graphviz',
     'sphinx.ext.autodoc',
+    'recommonmark',
 ]
 
 source_parsers = {

--- a/wire/peer_printgen.c
+++ b/wire/peer_printgen.c
@@ -20,6 +20,10 @@ void printpeer_wire_message(const u8 *msg)
 			printf("WIRE_ERROR:\n");
 			printwire_error("error", msg);
 			return;
+		case WIRE_WARNING:
+			printf("WIRE_WARNING:\n");
+			printwire_warning("warning", msg);
+			return;
 		case WIRE_PING:
 			printf("WIRE_PING:\n");
 			printwire_ping("ping", msg);
@@ -513,6 +517,41 @@ void printwire_error(const char *fieldname, const u8 *cursor)
 
 	size_t plen = tal_count(cursor);
 	if (fromwire_u16(&cursor, &plen) != WIRE_ERROR) {
+		printf("WRONG TYPE?!\n");
+		return;
+	}
+
+	printf("channel_id=");
+	struct channel_id channel_id;
+	fromwire_channel_id(&cursor, &plen, &channel_id);
+
+	printwire_channel_id(tal_fmt(NULL, "%s.channel_id", fieldname), &channel_id);
+	if (!cursor) {
+		printf("**TRUNCATED**\n");
+		return;
+	}
+ 	u16 len = fromwire_u16(&cursor, &plen);
+	if (!cursor) {
+		printf("**TRUNCATED**\n");
+		return;
+	}
+ 	printf("data=");
+	printwire_u8_array(tal_fmt(NULL, "%s.data", fieldname), &cursor, &plen, len);
+
+	if (!cursor) {
+		printf("**TRUNCATED**\n");
+		return;
+	}
+
+
+	if (plen != 0)
+		printf("EXTRA: %s\n", tal_hexstr(NULL, cursor, plen));
+}
+void printwire_warning(const char *fieldname, const u8 *cursor)
+{
+
+	size_t plen = tal_count(cursor);
+	if (fromwire_u16(&cursor, &plen) != WIRE_WARNING) {
 		printf("WRONG TYPE?!\n");
 		return;
 	}
@@ -2091,4 +2130,4 @@ void printpeer_wire_tlv_message(const char *tlv_name, const u8 *msg) {
 		printwire_tlvs(tlv_name, &msg, &plen, print_tlvs_onion_message_tlvs, ARRAY_SIZE(print_tlvs_onion_message_tlvs));
 	}
 }
-// SHA256STAMP:9f70670271b0856273026df920106d9c2ef2b60a1fa7c9c687e83a38d7d85a00
+// SHA256STAMP:d0f5b313c478153542610f14d7c6b39c1121b6a6b08fb72f3d427a103243b990

--- a/wire/peer_printgen.h
+++ b/wire/peer_printgen.h
@@ -14,6 +14,8 @@ void printwire_init(const char *fieldname, const u8 *cursor);
 
 void printwire_error(const char *fieldname, const u8 *cursor);
 
+void printwire_warning(const char *fieldname, const u8 *cursor);
+
 void printwire_ping(const char *fieldname, const u8 *cursor);
 
 void printwire_pong(const char *fieldname, const u8 *cursor);
@@ -72,4 +74,4 @@ void printwire_onion_message(const char *fieldname, const u8 *cursor);
 void printwire_channel_update_checksums(const char *fieldname, const u8 **cursor, size_t *plen);
 void printwire_channel_update_timestamps(const char *fieldname, const u8 **cursor, size_t *plen);
 #endif /* LIGHTNING_WIRE_PEER_PRINTGEN_H */
-// SHA256STAMP:9f70670271b0856273026df920106d9c2ef2b60a1fa7c9c687e83a38d7d85a00
+// SHA256STAMP:d0f5b313c478153542610f14d7c6b39c1121b6a6b08fb72f3d427a103243b990

--- a/wire/peer_wiregen.h
+++ b/wire/peer_wiregen.h
@@ -19,6 +19,7 @@
 enum peer_wire {
         WIRE_INIT = 16,
         WIRE_ERROR = 17,
+        WIRE_WARNING = 1,
         WIRE_PING = 18,
         WIRE_PONG = 19,
         WIRE_OPEN_CHANNEL = 32,
@@ -531,6 +532,10 @@ bool fromwire_init(const tal_t *ctx, const void *p, u8 **globalfeatures, u8 **fe
 u8 *towire_error(const tal_t *ctx, const struct channel_id *channel_id, const u8 *data);
 bool fromwire_error(const tal_t *ctx, const void *p, struct channel_id *channel_id, u8 **data);
 
+/* WIRE: WARNING */
+u8 *towire_warning(const tal_t *ctx, const struct channel_id *channel_id, const u8 *data);
+bool fromwire_warning(const tal_t *ctx, const void *p, struct channel_id *channel_id, u8 **data);
+
 /* WIRE: PING */
 u8 *towire_ping(const tal_t *ctx, u16 num_pong_bytes, const u8 *ignored);
 bool fromwire_ping(const tal_t *ctx, const void *p, u16 *num_pong_bytes, u8 **ignored);
@@ -645,4 +650,4 @@ bool fromwire_channel_update_option_channel_htlc_max(const void *p, secp256k1_ec
 
 
 #endif /* LIGHTNING_WIRE_PEER_WIREGEN_H */
-// SHA256STAMP:9f70670271b0856273026df920106d9c2ef2b60a1fa7c9c687e83a38d7d85a00
+// SHA256STAMP:d0f5b313c478153542610f14d7c6b39c1121b6a6b08fb72f3d427a103243b990


### PR DESCRIPTION
Somewhere along the way ReadTheDocs upgraded to Sphinx 3.4.3 to build the docs and the recommonmark extension we used to render Markdown documents broke.

Testing locally this fixes that.

Changelog-None