### PR TITLE
Prevent pay from accepting a zero-length route (self-payments)

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -807,6 +807,12 @@ static struct command_result *payment_getroute(struct payment *p)
 	p->step = PAYMENT_STEP_GOT_ROUTE;
 	p->route = route_hops_from_route(p, p, r);
 
+	if (tal_count(p->route) == 0) {
+		payment_root(p)->abort = true;
+		payment_fail(p, "Empty route returned by getroute, are you "
+				"trying to pay yourself?");
+	}
+
 	fee = payment_route_fee(p);
 
 	/* Ensure that our fee and CLTV budgets are respected. */

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -2105,6 +2105,11 @@ static struct command_result *json_paymod(struct command *cmd,
 		p->amount = *msat;
 	}
 
+	if (node_id_eq(&my_id, p->destination))
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "This payment is destined for ourselves. "
+				    "Self-payments are not supported");
+
 	p->local_id = &my_id;
 	p->json_buffer = tal_steal(p, buf);
 	p->json_toks = params;

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4134,7 +4134,6 @@ def test_sendinvoice(node_factory, bitcoind):
                                 'label': 'test sendinvoice refund'})
 
 
-@pytest.mark.xfail(strict=True)
 def test_self_pay(node_factory):
     """Repro test for issue 4345: pay ourselves via the pay plugin.
 
@@ -4142,4 +4141,6 @@ def test_self_pay(node_factory):
     l1, l2 = node_factory.line_graph(2, wait_for_announce=True)
 
     inv = l1.rpc.invoice(10000, 'test', 'test')['bolt11']
-    l1.rpc.pay(inv)
+
+    with pytest.raises(RpcError):
+        l1.rpc.pay(inv)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4132,3 +4132,14 @@ def test_sendinvoice(node_factory, bitcoind):
 
     l1.rpc.call('sendinvoice', {'offer': refund,
                                 'label': 'test sendinvoice refund'})
+
+
+@pytest.mark.xfail(strict=True)
+def test_self_pay(node_factory):
+    """Repro test for issue 4345: pay ourselves via the pay plugin.
+
+    """
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=True)
+
+    inv = l1.rpc.invoice(10000, 'test', 'test')['bolt11']
+    l1.rpc.pay(inv)


### PR DESCRIPTION
As pointed out by #4345 we lost the check for zero-length routes in the `pay` plugin somewhere along the lines: `gossipd.getroute` refused to generate them, `gossmap` is happy to return an empty result, which is more correct, but also causes this regression, since we implicitly assumed that the route would never be empty and just access `p->route[0]` without checking.

While I'd like to make self-payments supported, there is currently no way of mapping a payment that doesn't result in HTLCs to a successful attempt, thus disabling self-payments and being verbose about it is the next best thing.

Note: the original issue arose during an attempt to rebalance using the `pay` plugin, which cannot possibly work, and the [rebalance plugin](https://github.com/lightningd/plugins/tree/master/rebalance) should be used instead.

Fixes #4345 