### PR TITLE
feat: chain hook rpc command

### DIFF
--- a/common/json_stream.c
+++ b/common/json_stream.c
@@ -194,8 +194,9 @@ void json_add_jsonstr(struct json_stream *js,
 	size_t len = strlen(jsonstr);
 
 	p = json_member_direct(js, fieldname, len);
-
-	memcpy(p, jsonstr, len);
+	/* Could be OOM! */
+	if (p)
+		memcpy(p, jsonstr, len);
 }
 
 /* This is where we read the json_stream and write it to conn */

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1198,6 +1198,9 @@ Return a custom error to the request sender:
 }
 ```
 
+Note: The `rpc_command` hook is chainable. If two or more plugins try to
+replace/result/error the same `method`, only the first plugin in the chain
+will be respected. Others will be ignored and a warning will be logged.
 
 ### `custommsg`
 

--- a/tests/plugins/rpc_command_1.py
+++ b/tests/plugins/rpc_command_1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This plugin is used to test the `rpc_command` hook.
+This plugin is used to test the chained `rpc_command` hook.
 """
 from pyln.client import Plugin
 
@@ -12,15 +12,11 @@ def on_rpc_command(plugin, rpc_command, **kwargs):
     request = rpc_command
     if request["method"] == "invoice":
         # Replace part of this command
-        request["params"]["description"] = "A plugin modified this description"
+        request["params"]["description"] = "rpc_command_1 modified this description"
         return {"replace": request}
     elif request["method"] == "listfunds":
         # Return a custom result to the command
-        return {"return": {"result": ["Custom result"]}}
-    elif request["method"] == "sendpay":
-        # Don't allow this command to be executed
-        return {"return": {"error": {"code": -1,
-                                     "message": "You cannot do this"}}}
+        return {"return": {"result": ["Custom rpc_command_1 result"]}}
     elif request["method"] == "help":
         request["method"] = "autocleaninvoice"
         return {"replace": request}

--- a/tests/plugins/rpc_command_2.py
+++ b/tests/plugins/rpc_command_2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+This plugin is used to test the chained `rpc_command` hook.
+"""
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook("rpc_command")
+def on_rpc_command(plugin, rpc_command, **kwargs):
+    request = rpc_command
+    if request["method"] == "invoice":
+        # Replace part of this command
+        request["params"]["description"] = "rpc_command_2 modified this description"
+        return {"replace": request}
+    elif request["method"] == "sendpay":
+        # Don't allow this command to be executed
+        return {"return": {"error": {"code": -1,
+                                     "message": "rpc_command_2 cannot do this"}}}
+    return {"result": "continue"}
+
+
+plugin.run()


### PR DESCRIPTION
This chains the last remaining single hook `rpc_command`

Adds: feature, doc and modified testcase.

This is in draft as there is an open issue that will crash the test that I don't fully understand yet.
It seems like `rpc_command_hook_payload *p` or at least `p->custom_result` is freed with `tal_free()` somewhere,
so that we cant read the JSON `p->custom_result` (via `command_raw_complete`) anymore and give it to the daemon.

If we modify the code so that `rpc_command_hook_final` is explicitly called in the `rpc_command_hook_callback`, we have a similar situation where it then wants to `tal_free()` the `rpc_command_hook_payload` which is already freed.
Ideally I want to call `rpc_command_hook_final` just implicitly (just like the current code does) in order to detect if two or multiple plugins try to handle the same `rpc_command`.

@cdecker @rustyrussell some advice could be helpful. 

```
--------------------------------------------------------- Captured stderr call ---------------------------------------------------------
lightningd: common/json_stream.c:99: json_stream_double_cr: Assertion `len >= 2' failed.
lightningd: FATAL SIGNAL 6 (version v0.9.3-107-g0bcc8ac-modded)
0x56017ae4e147 send_backtrace
	common/daemon.c:39
0x56017ae4e1ec crashdump
	common/daemon.c:52
0x7fe73bd6b69f ???
	???:0
0x7fe73bd6b615 ???
	???:0
0x7fe73bd54861 ???
	???:0
0x7fe73bd54746 ???
	???:0
0x7fe73bd63bf5 ???
	???:0
0x56017ae5842b json_stream_double_cr
	common/json_stream.c:99
0x56017ae584d1 json_stream_close
	common/json_stream.c:117
0x56017adf6d64 command_raw_complete
	lightningd/jsonrpc.c:459
0x56017adf7a2e rpc_command_hook_final
	lightningd/jsonrpc.c:751
0x56017ae24726 plugin_hook_callback
	lightningd/plugin_hook.c:216
0x56017ae1f1b0 plugin_response_handle
	lightningd/plugin.c:432
```