### PR TITLE
test utils: dont let memleak calls to dead/frozen nodes hang

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1380,7 +1380,8 @@ class NodeFactory(object):
             if not self.valgrind and DEVELOPER:
                 try:
                     # This also puts leaks in log.
-                    leaks = self.nodes[i].rpc.dev_memleak()['leaks']
+                    ex = self.executor.submit(self.nodes[i].rpc.dev_memleak)['leaks']
+                    leaks = ex.result(TIMEOUT)
                 except Exception:
                     pass
 


### PR DESCRIPTION
We time out if the memleak doesn't finish up?! 

I marked `test_multifunding_v2_exclusive` as `@pytest.mark.xfail` in #4397 for the duration of the refactoring job, but it started hanging weirdly on memleak. 

I say "weirdly" because it seems odd to me that the nodes would even get instantiatiated if the test is marked as `xfail`.

I don't know if this is a reasonable solution, but it fixes the problem.

Changelog-None.