### PR TITLE
`pay` optimizations round 1

### DIFF
--- a/common/bolt12.c
+++ b/common/bolt12.c
@@ -422,3 +422,24 @@ struct tlv_invoice *invoice_decode(const tal_t *ctx,
 	}
 	return invoice;
 }
+
+bool bolt12_has_invoice_prefix(const char *str)
+{
+	return strstarts(str, "lni1") || strstarts(str, "LNI1");
+}
+
+bool bolt12_has_request_prefix(const char *str)
+{
+	return strstarts(str, "lnr1") || strstarts(str, "LNR1");
+}
+
+bool bolt12_has_offer_prefix(const char *str)
+{
+	return strstarts(str, "lno1") || strstarts(str, "LNO1");
+}
+
+bool bolt12_has_prefix(const char *str)
+{
+	return bolt12_has_invoice_prefix(str) || bolt12_has_offer_prefix(str) ||
+	       bolt12_has_request_prefix(str);
+}

--- a/common/bolt12.h
+++ b/common/bolt12.h
@@ -122,4 +122,25 @@ void offer_period_paywindow(const struct tlv_offer_recurrence *recurrence,
 			    u64 basetime, u64 period_idx,
 			    u64 *period_start, u64 *period_end);
 
+
+/**
+ * Preliminary prefix check to see if the string might be a bolt12 invoice.
+ */
+bool bolt12_has_invoice_prefix(const char *str);
+
+/**
+ * Preliminary prefix check to see if the string might be a bolt12 request.
+ */
+bool bolt12_has_request_prefix(const char *str);
+
+/**
+ * Preliminary prefix check to see if the string might be a bolt12 offer.
+ */
+bool bolt12_has_offer_prefix(const char *str);
+
+/**
+ * Preliminary prefix check to see if the string might be a bolt12 string.
+ */
+bool bolt12_has_prefix(const char *str);
+
 #endif /* LIGHTNING_COMMON_BOLT12_H */

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -56,23 +56,15 @@ static struct keysend_data *keysend_init(struct payment *p)
 static void keysend_cb(struct keysend_data *d, struct payment *p) {
 	struct createonion_hop *last_payload;
 	size_t hopcount;
-	struct gossmap_node *node;
-	bool enabled;
-	const struct gossmap *gossmap = get_gossmap(p->plugin);
 
 	/* On the root payment we perform the featurebit check. */
 	if (p->parent == NULL && p->step == PAYMENT_STEP_INITIALIZED) {
-		node = gossmap_find_node(gossmap, p->destination);
-
-		enabled = gossmap_node_get_feature(gossmap, node,
-						   KEYSEND_FEATUREBIT) != -1;
-		if (!enabled)
+		if (!payment_root(p)->destination_has_tlv)
 			return payment_fail(
 			    p,
 			    "Recipient %s does not support keysend payments "
-			    "(feature bit %d missing in node announcement)",
-			    node_id_to_hexstr(tmpctx, p->destination),
-			    KEYSEND_FEATUREBIT);
+			    "(no TLV support)",
+			    node_id_to_hexstr(tmpctx, p->destination));
 	}
 
 	if (p->step != PAYMENT_STEP_ONION_PAYLOAD)

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2625,6 +2625,17 @@ static struct command_result *routehint_getroute_result(struct command *cmd,
 		/* FIXME: ***DO*** we need to add this extra routehint?
 		 * Once we run out of routehints the default system will
 		 * just attempt directly routing to the destination anyway.  */
+	} else if (tal_count(d->routehints) == 0) {
+		/* If we don't have any routehints and the destination
+		 * isn't reachable, then there is no point in
+		 * continuing. */
+
+		payment_abort(
+		    p,
+		    "Destination %s is not reachable directly and "
+		    "all routehints were unusable.",
+		    type_to_string(tmpctx, struct node_id, p->destination));
+		return command_still_pending(cmd);
 	}
 
 	routehint_pre_getroute(d, p);

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -292,6 +292,10 @@ struct payment {
 	 * and payment_lower_max_htlcs functions.
 	 */
 	u32 max_htlcs;
+
+	/* A human readable error message that is used as a top-level
+	 * explanation if a payment is aborted. */
+	char *aborterror;
 };
 
 struct payment_modifier {
@@ -435,6 +439,13 @@ void payment_set_step(struct payment *p, enum payment_step newstep);
 
 /* Fails a partial payment and continues with the core flow. */
 void payment_fail(struct payment *p, const char *fmt, ...) PRINTF_FMT(2,3);
+
+/* Fails a payment process by setting the root payment to
+ * aborted. This will cause all subpayments to terminate as soon as
+ * they can, and sets the root failreason so we have a sensible error
+ * message. The failreason is overwritten if it is already set, since
+ * we probably know better what happened in the modifier.. */
+void payment_abort(struct payment *p, const char *fmt, ...) PRINTF_FMT(2,3);
 
 struct payment *payment_root(struct payment *p);
 struct payment_tree_result payment_collect_result(struct payment *p);

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1521,6 +1521,11 @@ static void paystatus_add_payment(struct json_stream *s, const struct payment *p
 	/* TODO Add routehint. */
 	/* TODO Add route details */
 
+	if (p->step < PAYMENT_STEP_SPLIT)
+		json_add_string(s, "state", "pending");
+	else
+		json_add_string(s, "state", "completed");
+
 	if (p->step == PAYMENT_STEP_SPLIT) {
 		/* Don't add anything, this is neither a success nor a failure. */
 	} else if (p->result != NULL) {
@@ -1530,7 +1535,7 @@ static void paystatus_add_payment(struct json_stream *s, const struct payment *p
 			json_object_start(s, "failure");
 		json_add_sendpay_result(s, p->result);
 		json_object_end(s);
-	} else {
+	} else if (p->step >= PAYMENT_STEP_SPLIT) {
 		json_object_start(s, "failure");
 		json_add_num(s, "code", PAY_ROUTE_NOT_FOUND);
 		json_add_string(s, "message", "Call to getroute: Could not find a route");

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3049,7 +3049,7 @@ def test_keysend(node_factory):
 
     # And finally try to send a keysend payment to l4, which doesn't
     # support it. It MUST fail.
-    with pytest.raises(RpcError, match=r"Recipient [0-9a-f]{66} does not support keysend payments"):
+    with pytest.raises(RpcError, match=r"Recipient [0-9a-f]{66} reported an invalid payload"):
         l3.rpc.keysend(l4.info['id'], amt)
 
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4219,4 +4219,10 @@ def test_unreachable_routehint(node_factory, bitcoind):
     l2.connect(l3)
     wait_for(lambda: len(l1.rpc.listnodes(entrypoint)['nodes']) == 1)
 
-    # TODO(cdecker) investigate why dijkstra_distance tells us the entrypoint is reachable...
+    with pytest.raises(RpcError):
+        l1.rpc.pay(invoice)
+    assert(l1.daemon.is_in_log(
+        r"Removed routehint 0 because entrypoint {entrypoint} is unreachable.".format(
+            entrypoint=entrypoint
+        )
+    ))


### PR DESCRIPTION
This started out as a quick fix for #4299, but while debugging I
stumbled over a couple of easy optimizations:

 - Keysend no longer requires featurebit 55 to be signaled by the
   destination, instead requiring only TLV. This is because apparently
   keysend is not formally proposed to the spec, and the featurebit is
   not reserved. We now will report a more meaningful error message if
   the recipient returns an `INVALID_ONION_PAYLOAD` error.
 - We now filter routehints whose entrypoints we cannot reach, since
   there is no point in trying them if we can't even get to the
   entrypoint. This considers two different scenarios: entrypoint is
   unknown and entrypoint is unreachable.
 - Added `payment_abort` to set a top-level error message in the `pay`
   result, which should make it easier for modifiers to be helpful and
   give a human-readable error message.
   
I have some more improvements planned, but this seemed like a good
initial candidate set.