### PR TITLE
Regtest feerate setting

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -357,17 +357,6 @@ static void add_feerate_history(struct chain_topology *topo,
 	topo->feehistory[feerate][0] = val;
 }
 
-/* Did the the feerate change since we last estimated it ? */
-static bool feerate_changed(struct chain_topology *topo, u32 old_feerates[])
-{
-	for (int f = 0; f < NUM_FEERATES; f++) {
-		if (try_get_feerate(topo, f) != old_feerates[f])
-			return true;
-	}
-
-	return false;
-}
-
 /* We sanitize feerates if necessary to put them in descending order. */
 static void update_feerates(struct bitcoind *bitcoind,
 			    const u32 *satoshi_per_kw,
@@ -379,6 +368,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 	 * 2 minutes. The following will do that in a polling interval
 	 * independent manner. */
 	double alpha = 1 - pow(0.1,(double)topo->poll_seconds / 120);
+	bool feerate_changed = false;
 
 	for (size_t i = 0; i < NUM_FEERATES; i++) {
 		u32 feerate = satoshi_per_kw[i];
@@ -392,14 +382,18 @@ static void update_feerates(struct bitcoind *bitcoind,
 
 		/* Initial smoothed feerate is the polled feerate */
 		if (!old_feerates[i]) {
+			feerate_changed = true;
 			old_feerates[i] = feerate;
 			init_feerate_history(topo, i, feerate);
 
 			log_debug(topo->log,
 					  "Smoothed feerate estimate for %s initialized to polled estimate %u",
 					  feerate_name(i), feerate);
-		} else
+		} else {
+			if (feerate != old_feerates[i])
+				feerate_changed = true;
 			add_feerate_history(topo, i, feerate);
+		}
 
 		/* Smooth the feerate to avoid spikes. */
 		u32 feerate_smooth = feerate * alpha + old_feerates[i] * (1 - alpha);
@@ -435,7 +429,7 @@ static void update_feerates(struct bitcoind *bitcoind,
 		maybe_completed_init(topo);
 	}
 
-	if (feerate_changed(topo, old_feerates))
+	if (feerate_changed)
 		notify_feerate_change(bitcoind->ld);
 
 	next_updatefee_timer(topo);

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2282,7 +2282,7 @@ def test_fundee_forget_funding_tx_unconfirmed(node_factory, bitcoind):
 
 @unittest.skipIf(not DEVELOPER, "needs dev_fail")
 def test_no_fee_estimate(node_factory, bitcoind, executor):
-    l1 = node_factory.get_node(start=False)
+    l1 = node_factory.get_node(start=False, options={'dev-no-fake-fees': True})
 
     # Fail any fee estimation requests until we allow them further down
     l1.daemon.rpcproxy.mock_rpc('estimatesmartfee', {

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1438,7 +1438,8 @@ def test_ipv4_and_ipv6(node_factory):
     "FEERATE_FLOOR on testnets, and we test the new API."
 )
 def test_feerates(node_factory):
-    l1 = node_factory.get_node(options={'log-level': 'io'}, start=False)
+    l1 = node_factory.get_node(options={'log-level': 'io',
+                                        'dev-no-fake-fees': True}, start=False)
     l1.daemon.rpcproxy.mock_rpc('estimatesmartfee', {
         'error': {"errors": ["Insufficient data or no feerate found"], "blocks": 0}
     })


### PR DESCRIPTION
We have a dev knob to disable it for testing, but this is what everyone actually wants when using regtest, AFAICT.

During a recent demo I had one regtest peer send out an update_fee with a 0 rate.  To my consternation, I have been unable to reproduce this.  Is bitcoind giving wild fee estimates in some regtest setups?