### PR TITLE
added the default bitcoin path for macos to startup_regtest.sh

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -54,6 +54,8 @@ fi
 if [ -z "$PATH_TO_BITCOIN" ]; then
 	if [ -d "$HOME/.bitcoin" ]; then
 		PATH_TO_BITCOIN="$HOME/.bitcoin"
+	elif [ -d "$HOME/Library/Application Support/Bitcoin/" ]; then
+		PATH_TO_BITCOIN="$HOME/Library/Application Support/Bitcoin/"
 	else
 		echo "\$PATH_TO_BITCOIN not set to a .bitcoin dir?" >&2
 		return


### PR DESCRIPTION
The `contrib/startup_regtest.sh` script does not work out of the box on mac os as the default bitcoin dir in mac os is not `~/.bitcoin` but rather `~/Library/Application Support/Bitcoin/` so I added that