### PR TITLE
Weekly cleanups

### DIFF
--- a/configure
+++ b/configure
@@ -56,10 +56,17 @@ default_cwarnflags()
 
 default_pytest()
 {
-    PYTEST_BINS="pytest py.test pytest3 pytest-3"
+    # Since we just checked that we have python3 we give that one the
+    # most priority and then fall back to some common aliases.
+    PYTEST_BINS="python3 -m pytest,pytest,py.test,pytest3,pytest-3"
+    IFS=','
     for p in $PYTEST_BINS; do
-	if [ "$(which $p)" != "" ] ; then
-	    "$p" --version 2>&1 | grep -q "python3" || continue
+	# If it is a combined command such as `python3 -m pytest` we
+	# want to only call which on the executable
+	exe=$(echo "$p" | awk '{print $1}')
+	# shellcheck disable=SC2086
+	if [ "$(which $exe)" != "" ] ; then
+	    "$p" --version 2>&1 | grep -q "pytest" || continue
 	    echo "$p"
 	    return
 	fi

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -927,7 +927,7 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("listforwards", payload)
 
-    def listfunds(self, spent=False):
+    def listfunds(self, spent=None):
         """
         Show funds available for opening channels
         or both unspent and spent funds if {spent} is True.


### PR DESCRIPTION
- We improve the detection of pytest to prefer `python3 -m pytest`
   over the other executables since it is checked for just
   earlier. Also `pytest-3` must not be given special treatment since
   it refers to version 3 of pytest (ancient nowadays) not the python3
   version of pytest.
   
 - Found a regression in `pyln`: the `spent` parameter to the
   `listfunds` call would be always included, which would lead
   c-lightning versions 0.9.2 and older to complain about an unknown
   parameter. Always set these to `None` so pyln can remove them from
   the call, I didn't catch his in my review.