### PR TITLE
Add early abort in case of misconfigured plugins

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -907,6 +907,16 @@ int main(int argc, char *argv[])
 	 *  options registration). */
 	plugins_init(ld->plugins);
 
+	/*~ If the plugis are misconfigured we don't want to proceed. A
+	 * misconfiguration could for example be a plugin marked as important
+	 * not working correctly or a plugin squatting something an important
+	 * plugin needs to register, such as a method or CLI option. If we are
+	 * going to shut down immediately again, we shouldn't spend too much
+	 * effort in starting up.
+	 */
+	if (ld->exit_code)
+		fatal("Could not initialize the plugins, see above for details.");
+
 	/*~ Handle options and config. */
 	handle_opts(ld, argc, argv);
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1073,10 +1073,13 @@ static const char *plugin_rpcmethod_add(struct plugin *plugin,
 
 	cmd->dispatch = plugin_rpcmethod_dispatch;
 	if (!jsonrpc_command_add(plugin->plugins->ld->jsonrpc, cmd, usage)) {
-		return tal_fmt(plugin,
-			   "Could not register method \"%s\", a method with "
-			   "that name is already registered",
-			   cmd->name);
+		struct plugin *p =
+		    find_plugin_for_command(plugin->plugins->ld, cmd->name);
+		return tal_fmt(
+		    plugin,
+		    "Could not register method \"%s\", a method with "
+		    "that name is already registered by plugin %s",
+		    cmd->name, p->cmd);
 	}
 	tal_arr_expand(&plugin->methods, cmd->name);
 	return NULL;


### PR DESCRIPTION
There are ways to misconfigure plugins that will cause us to shut
down. These include having an important plugin fight for a method name
with another plugin, e.g., by loading the same plugin twice. Until now
we would happily continue with the startup sequence only to later
realize that we were supposed to shutdown, but by then we'd have
buried the error message in the logs.

This PR just adds a check for misconfigurations before we even start
the normal `io_loop`, avoiding expensive initializations and not
hiding the log entries about the cause. This works if we're just using
`--help` as well, and produces a much clearer picture of what is going
on.

I also added the name of the plugin that was clashing with RPC methods.

Fixes #4415
Reported-by: PsySc0rpi0n
Reported-by: Ján Sáreník <@jsarenik>
