### PR TITLE
contrib: add the dev- options to the config iff DEVELOPER=1 configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,24 @@ sudo apt-get install bitcoind lightningd
 
 ### Starting `lightningd`
 
+#### Regtest (local, fast-start) Option
 If you want to experiment with `lightningd`, there's a script to set
 up a `bitcoind` regtest test network of two local lightning nodes,
-which provides a convenient `start_ln` helper:
+which provides a convenient `start_ln` helper. See the notes at the top
+of the `startup_regtest.sh` file for details on how to use it.
 
 ```bash
 . contrib/startup_regtest.sh
 ```
 
+Note that your local nodeset will be much faster/more responsive if
+you've configured your node to expose the developer options, e.g.
+
+```bash
+./configure --enable-developer
+```
+
+#### Mainnet Option
 To test with real bitcoin,  you will need to have a local `bitcoind` node running:
 
 ```bash

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -86,9 +86,14 @@ start_nodes() {
 		log-level=debug
 		log-file=/tmp/l$i-$network/log
 		addr=localhost:$socket
-		dev-fast-gossip
-		dev-bitcoind-poll=5
 		EOF
+
+		# If we've configured to use developer, add dev options
+		if $LIGHTNINGD --help | grep -q dev-fast-gossip; then
+			echo "dev-fast-gossip" >> "/tmp/l$i-$network/config"
+			echo "dev-bitcoind-poll=5" >> "/tmp/l$i-$network/config"
+		fi
+
 
 		# Start the lightning nodes
 		test -f "/tmp/l$i-$network/lightningd-$network.pid" || \


### PR DESCRIPTION
We scan config.vars to figure out if you configured developer on or off.
If it's on, we add the dev-only options to the config.

Fixes: #4400
Reported-By: Jonathan Harvey-Buschel @jharveyb

Changelog-None