### PR TITLE
typo: information is an uncountable mass noun

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1422,7 +1422,7 @@ static void add_seed_addrs(struct wireaddr_internal **addrs,
 								 &a.u.wireaddr));
 				tal_arr_expand(addrs, a);
 			}
-			/* Other seeds will likely have the same informations. */
+			/* Other seeds will likely have the same information. */
 			return;
 		} else
 			status_peer_debug(id, "Could not resolve %s", hostnames[i]);

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -39,7 +39,7 @@ You can use the `listfunds` command and take a ratio of `our_amount_msat` over
 `amount_msat`. Note that this doesn't account for the [channel reserve](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#rationale).
 
 A better option is to use the [`summary` plugin](https://github.com/lightningd/plugins/tree/master/summary)
-which nicely displays channel balances, along with other useful channel informations.
+which nicely displays channel balances, along with other useful channel information.
 
 ### My channel is in state `STATE`, what does that mean ?
 

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -492,7 +492,7 @@ void bitcoind_getchaininfo_(struct bitcoind *bitcoind,
 
 /* `getutxout`
  *
- * Get informations about an UTXO. If the TXO is spent, the plugin will set
+ * Get information about an UTXO. If the TXO is spent, the plugin will set
  * all fields to `null`.
  * {
  *	"amount": <The output's amount in *sats*>,

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -932,7 +932,7 @@ static const struct plugin_command commands[] = {
 	{
 		"getutxout",
 		"bitcoin",
-		"Get informations about an output, identified by a {txid} an a {vout}",
+		"Get information about an output, identified by a {txid} an a {vout}",
 		"",
 		getutxout
 	},

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -60,7 +60,7 @@ struct plugin {
 	/* Synchronous RPC interaction */
 	struct rpc_conn *rpc_conn;
 
-	/* Plugin informations */
+	/* Plugin information details */
 	enum plugin_restartability restartability;
 	const struct plugin_command *commands;
 	size_t num_commands;


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Information

In libplugin.c also the word "details" was added (without removing
the 'information').

Changelog-None

Discussion welcome.

FYI: @darosior

Nice discussion of the topic is at [Englishforums](https://www.englishforums.com/English/InformationOrInformations/gzdmw/post.htm)