### PR TITLE
mfc: turn "UNKNOWN TYPE channel_id" logs into actually the channel id

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -95,6 +95,7 @@ PLUGIN_COMMON_OBJS :=				\
 	common/bech32_util.o			\
 	common/bigsize.o			\
 	common/bolt11.o				\
+	common/channel_id.o			\
 	common/daemon.o				\
 	common/features.o			\
 	common/hash_u5.o			\


### PR DESCRIPTION
Get rid of unuseful "UNKNOWN TYPE channel_id" prints in logs; only
affected usage for `type_to_string` of plugins/Makefile built things

```
lightningd-1: 2021-03-16T20:22:16.033Z DEBUG   plugin-spenderp: mfc 25, dest 0: `openchannel_signed` UNKNOWN TYPE channel_id psbt cHNidP8BAH0CAAAAAdDqv81NxTlsoSS7Glg4hxv9zc7mrgdxqCx7HHuOkcdpAQAAAAD9////AqCGAQAAAAAAIgAgW4zTuRTPZ83Y+mJzyTA1PdNkdnNPvZYhAsLfU7kIgM2yqQ0BAAAAABYA
FMLMqxccKlvp2rUuxBuCWGMCTFRmZgAAAAABAN4CAAAAAAEB0ZZNgU/XMipFydK/OaoZtNuh5nzl7rTGetG5/gETlrsAAAAAAP7///8CM6/2KAEAAAAWABQYE5O31J0/eswToHXSj8fiPjG6dEBCDwEAAAAAFgAUAfrZCrzWZpfiWSFkci3kqV6+4WUCRzBEAiBNLHSLQpGEiL3hVdg1FqjEJv+5TdNwtDOs/lDlY9oYZQIgSD00h264sETD6qelP767Q4PEkjpa5+74oV
GiL3rAsjIBIQJQpPejKThSde0+mBgOic2ZVZE1YZ+xVqTTf/x3ad4ghGUAAAABAR9AQg8BAAAAABYAFAH62Qq81maX4lkhZHIt5KlevuFlAQhrAkcwRAIgeHci3Hxaxttgx1WjTv/XSeii4pP3PVKMtg7o/bpgfDoCIC+86KPZdMa/7uxYgGiL7G1PlpjGSu3octWrxXb9D6bpASED10VEXJNiZl8i4NlunnZvJz8yYN6jnIp2v6Bd0mhN3M8M/AlsaWdodG5pbmcBCANF
ZcQhEOXqDPwJbGlnaHRuaW5nAgIAAQAM/AlsaWdodG5pbmcBCHtSnus2RFIYAAz8CWxpZ2h0bmluZwEI4c99cioMvCoA  
``` 

Changelog-None.