### PR TITLE
Various minor fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,8 @@ jobs:
           # The cross-compiled versions
           - {CFG: 21, ARCH: arm32v7, TARGET_HOST: arm-linux-gnueabihf}
           - {CFG: 22, ARCH: arm64v8, TARGET_HOST: aarch64-linux-gnu}
-          - {CFG: 23, EXPERIMENTAL_FEATURES: 1}
+          # Disabled for 0.10.0-rc1
+          # - {CFG: 23, EXPERIMENTAL_FEATURES: 1}
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -287,6 +287,9 @@ invoice_payment_hooks_done(struct invoice_payment_hook_payload *payload STEALS)
 		 type_to_string(tmpctx, struct amount_msat, &payload->msat),
 		 tal_count(payload->set->htlcs));
 	htlc_set_fulfill(payload->set, &payload->preimage);
+
+	notify_invoice_payment(ld, payload->msat, payload->preimage,
+			       payload->label);
 }
 
 static bool
@@ -430,8 +433,6 @@ void invoice_try_pay(struct lightningd *ld,
 	payload->preimage = details->r;
 	payload->set = set;
 	tal_add_destructor2(set, invoice_payload_remove_set, payload);
-
-	notify_invoice_payment(ld, payload->msat, payload->preimage, payload->label);
 
 	plugin_hook_call_invoice_payment(ld, payload);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -156,7 +156,7 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 
 	p = payment_new(cmd, cmd, NULL /* No parent */, pay_mods);
 	p->local_id = &my_id;
-	p->json_buffer = tal_steal(p, buf);
+	p->json_buffer = tal_dup_talarr(p, const char, buf);
 	p->json_toks = params;
 	p->destination = tal_steal(p, destination);
 	p->destination_has_tlv = true;

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -171,13 +171,19 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 	p->deadline = timeabs_add(time_now(), time_from_sec(*retryfor));
 	p->getroute->riskfactorppm = 10000000;
 
+	if (node_id_eq(&my_id, p->destination)) {
+		return command_fail(
+		    cmd, JSONRPC2_INVALID_PARAMS,
+		    "We are the destination. Keysend cannot be used to send funds to yourself");
+	}
+
 	if (!amount_msat_fee(&p->constraints.fee_budget, p->amount, 0,
 			     *maxfee_pct_millionths / 100)) {
-		tal_free(p);
 		return command_fail(
 		    cmd, JSONRPC2_INVALID_PARAMS,
 		    "Overflow when computing fee budget, fee rate too high.");
 	}
+
 	p->constraints.cltv_budget = *maxdelay;
 
 	payment_mod_exemptfee_get_data(p)->amount = *exemptfee;

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3030,6 +3030,10 @@ def test_keysend(node_factory):
     features = l1.rpc.listnodes(l4.info['id'])['nodes'][0]['features']
     assert(int(features, 16) >> 55 & 0x01 == 0)
 
+    # Self-sends are not allowed (see #4438)
+    with pytest.raises(RpcError, match=r'We are the destination.'):
+        l1.rpc.keysend(l1.info['id'], amt)
+
     # Send an indirect one from l1 to l3
     l1.rpc.keysend(l3.info['id'], amt)
     invs = l3.rpc.listinvoices()['invoices']


### PR DESCRIPTION
All of these are just single-commit fixes, so I didn't open a new PR for each:

 - We were stealing the plugin's read buffer in keysend and freeing it, causing a use-after-free on the next call.
 - Self-payments in `keysend` could result in a crash due to an empty route being returned.
 - The order in which the `invoice_payment` hook and notification were called was switched around (we were notifying about still to accept invoices being paid, when the hook could also reject it)

Fixes #4438 
Fixes #4434 