### PR TITLE
Minor post-rc1 fixes.

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2503-g56d5c41f
+CCAN version: init-2504-g48b4ffc3

--- a/common/htlc_wire.c
+++ b/common/htlc_wire.c
@@ -253,7 +253,7 @@ void fromwire_changed_htlc(const u8 **cursor, size_t *max,
 
 enum side fromwire_side(const u8 **cursor, size_t *max)
 {
-	enum side side = fromwire_u8(cursor, max);
+	u8 side = fromwire_u8(cursor, max);
 	if (side >= NUM_SIDES) {
 		side = NUM_SIDES;
 		fromwire_fail(cursor, max);


### PR DESCRIPTION
Handle time going backwards (a little) on OpenBSD 6.8 under Virtualbox, and fix a clang warning.