### PR TITLE
gossipd: fix rolling corruption.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -335,6 +335,11 @@ struct gossip_store *gossip_store_new(struct routing_state *rstate,
 		if (ftruncate(gs->fd, 0) != 0)
 			status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				      "Truncating store: %s", strerror(errno));
+		/* Subtle: we are at offset 1, move back to start! */
+		if (lseek(gs->fd, 0, SEEK_SET) != 0)
+			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+				      "Seeking to start of store: %s",
+				      strerror(errno));
 	}
 	/* Empty file, write version byte */
 	gs->version = GOSSIP_STORE_VERSION;


### PR DESCRIPTION
If gossip_store is an incorrect version, we will recreate it: with an incorrect
version!  This means we never get persistent gossip, *and* the pay plugin will
fail to map the gossip_store.  Everyone will be sad.

Debugged-by: Matt Whitlock
Fixes: #4376
Fixes: #4288
Typing-by: Rusty Russell <rusty@rustcorp.com.au>