### PR TITLE
dual-funding: introduce racy state

### DIFF
--- a/plugins/spender/multifundchannel.c
+++ b/plugins/spender/multifundchannel.c
@@ -122,6 +122,7 @@ has_commitments_secured(const struct multifundchannel_destination *dest)
 		return false;
 	case MULTIFUNDCHANNEL_COMPLETED:
 	case MULTIFUNDCHANNEL_SECURED:
+	case MULTIFUNDCHANNEL_SIGNED_NOT_SECURED:
 	case MULTIFUNDCHANNEL_SIGNED:
 	case MULTIFUNDCHANNEL_DONE:
 		return true;
@@ -311,6 +312,7 @@ mfc_cleanup_(struct multifundchannel_command *mfc,
 			continue;
 		case MULTIFUNDCHANNEL_SECURED:
 		case MULTIFUNDCHANNEL_SIGNED:
+		case MULTIFUNDCHANNEL_SIGNED_NOT_SECURED:
 			/* We don't actually *send* the
 			 * transaction until here,
 			 * but peer isnt going to forget. This

--- a/plugins/spender/multifundchannel.h
+++ b/plugins/spender/multifundchannel.h
@@ -38,6 +38,8 @@ enum multifundchannel_state {
 	MULTIFUNDCHANNEL_SECURED,
 	/* We've recieved the peer sigs for this destination */
 	MULTIFUNDCHANNEL_SIGNED,
+	/* We've gotten their sigs, but still waiting for their commit sigs */
+	MULTIFUNDCHANNEL_SIGNED_NOT_SECURED,
 
 	/* The transaction might now be broadcasted.  */
 	MULTIFUNDCHANNEL_DONE,


### PR DESCRIPTION
It's unlikely but possible that a race condition will result in us not
being at the 'secured' state yet here.

Crashlogs. All required msgs are received (in order)
from peers, but the crash suggests they weren't relayed/processed by the
spender plugin in the order received.

WIRE_TX_SIGNATURES is passed the the plugin via a notification;
WIRE_COMMITMENT_SIGNED is returned as the result of an RPC call.

```
021-03-25T12:12:33.5213247Z lightningd-1: 2021-03-25T11:50:13.351Z DEBUG   035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d-dualopend-chan#3: peer_in WIRE_COMMITMENT_SIGNED
2021-03-25T12:12:33.5221140Z lightningd-1: 2021-03-25T11:50:13.659Z DEBUG   022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-dualopend-chan#1: peer_in WIRE_COMMITMENT_SIGNED
2021-03-25T12:12:33.5228462Z lightningd-1: 2021-03-25T11:50:14.169Z DEBUG   035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d-dualopend-chan#3: peer_in WIRE_TX_SIGNATURES
2021-03-25T12:12:33.5230957Z lightningd-1: 2021-03-25T11:50:14.375Z DEBUG   plugin-spenderp: mfc 275, dest 1: openchannel_update 035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d returned.
2021-03-25T12:12:33.5233307Z lightningd-1: 2021-03-25T11:50:14.539Z DEBUG   022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-dualopend-chan#1: peer_in WIRE_TX_SIGNATURES
2021-03-25T12:12:33.5235120Z lightningd-1: 2021-03-25T11:50:17.240Z INFO    plugin-spenderp: Killing plugin: exited during normal operation
2021-03-25T12:12:33.5236707Z lightningd-1: 2021-03-25T11:50:17.260Z **BROKEN** plugin-spenderp: Plugin marked as important, shutting down lightningd!
```

Fixes #4455