### PR TITLE
channeld: don't ever send back-to-back feerate changes, fix feerate logic.

### DIFF
--- a/common/fee_states.c
+++ b/common/fee_states.c
@@ -73,6 +73,16 @@ u32 get_feerate(const struct fee_states *fee_states,
 	abort();
 }
 
+/* Are feerates all agreed by both sides? */
+bool feerate_changes_done(const struct fee_states *fee_states)
+{
+	size_t num_feerates = 0;
+	for (size_t i = 0; i < ARRAY_SIZE(fee_states->feerate); i++) {
+		num_feerates += (fee_states->feerate[i] != NULL);
+	}
+	return num_feerates == 1;
+}
+
 void start_fee_update(struct fee_states *fee_states,
 		      enum side opener,
 		      u32 feerate_per_kw)

--- a/common/fee_states.h
+++ b/common/fee_states.h
@@ -85,4 +85,8 @@ struct fee_states *fromwire_fee_states(const tal_t *ctx,
  * Is this fee_state struct valid for this side?
  */
 bool fee_states_valid(const struct fee_states *fee_states, enum side opener);
+
+/* Are therre no more fee changes in-flight? */
+bool feerate_changes_done(const struct fee_states *fee_states);
+
 #endif /* LIGHTNING_COMMON_FEE_STATES_H */


### PR DESCRIPTION
There are several reports of desynchronizaion with LND here; a simple
approach is to only have one feerate change in flight at any time.

But I also found that our fee state machine was a bit screwed (thanks to CI flake!), so that may also have caused this problem.

Fixes: #4152