### PR TITLE
HTLC test vector update

### DIFF
--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -52,8 +52,8 @@ static void add_offered_htlc_out(struct bitcoin_tx *tx, size_t n,
 				       option_anchor_outputs);
 	p2wsh = scriptpubkey_p2wsh(tx, wscript);
 	bitcoin_tx_add_output(tx, p2wsh, wscript, amount);
-	SUPERVERBOSE("# HTLC %" PRIu64 " offered %s wscript %s\n", htlc->id,
-		     type_to_string(tmpctx, struct amount_sat, &amount),
+	SUPERVERBOSE("# HTLC #%" PRIu64 " offered amount %"PRIu64" wscript %s\n", htlc->id,
+		     amount.satoshis, /* Raw: BOLT 3 output match */
 		     tal_hex(wscript, wscript));
 	tal_free(wscript);
 }
@@ -75,10 +75,9 @@ static void add_received_htlc_out(struct bitcoin_tx *tx, size_t n,
 
 	bitcoin_tx_add_output(tx, p2wsh, wscript, amount);
 
-	SUPERVERBOSE("# HTLC %"PRIu64" received %s wscript %s\n",
+	SUPERVERBOSE("# HTLC #%"PRIu64" received amount %"PRIu64" wscript %s\n",
 		     htlc->id,
-		     type_to_string(tmpctx, struct amount_sat,
-				    &amount),
+		     amount.satoshis, /* Raw: BOLT 3 output match */
 		     tal_hex(wscript, wscript));
 	tal_free(wscript);
 }
@@ -138,8 +137,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 	base_fee = commit_tx_base_fee(feerate_per_kw, untrimmed,
 				      option_anchor_outputs);
 
-	SUPERVERBOSE("# base commitment transaction fee = %s\n",
-		     type_to_string(tmpctx, struct amount_sat, &base_fee));
+	SUPERVERBOSE("# base commitment transaction fee = %"PRIu64"\n",
+		     base_fee.satoshis /* Raw: spec uses raw numbers */);
 
 	/* BOLT #3:
 	 * If `option_anchor_outputs` applies to the commitment
@@ -244,8 +243,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		(*htlcmap)[n] = direct_outputs ? dummy_to_local : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
-		SUPERVERBOSE("# to-local amount %s wscript %s\n",
-			     type_to_string(tmpctx, struct amount_sat, &amount),
+		SUPERVERBOSE("# to_local amount %"PRIu64" wscript %s\n",
+			     amount.satoshis, /* Raw: BOLT 3 output match */
 			     tal_hex(tmpctx, wscript));
 		n++;
 		to_local = true;
@@ -287,9 +286,8 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		(*htlcmap)[n] = direct_outputs ? dummy_to_remote : NULL;
 		/* We don't assign cltvs[n]: if we use it, order doesn't matter.
 		 * However, valgrind will warn us something wierd is happening */
-		SUPERVERBOSE("# to-remote amount %s key %s\n",
-			     type_to_string(tmpctx, struct amount_sat,
-					    &amount),
+		SUPERVERBOSE("# to_remote amount %"PRIu64" P2WPKH(%s)\n",
+			     amount.satoshis, /* Raw: BOLT 3 output match */
 			     type_to_string(tmpctx, struct pubkey,
 					    &keyset->other_payment_key));
 		n++;

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -168,9 +168,9 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 				  option_anchor_outputs, side))
 				ok &= amount_sat_add(&out, out, amount_msat_to_sat_round_down(htlcs[i]->amount));
 		}
-		if (amount_msat_greater_sat(self_pay, dust_limit))
+		if (amount_msat_greater_eq_sat(self_pay, dust_limit))
 			ok &= amount_sat_add(&out, out, amount_msat_to_sat_round_down(self_pay));
-		if (amount_msat_greater_sat(other_pay, dust_limit))
+		if (amount_msat_greater_eq_sat(other_pay, dust_limit))
 			ok &= amount_sat_add(&out, out, amount_msat_to_sat_round_down(other_pay));
 		assert(ok);
 		SUPERVERBOSE("# actual commitment transaction fee = %"PRIu64"\n",

--- a/channeld/test/run-commit_tx.c
+++ b/channeld/test/run-commit_tx.c
@@ -524,6 +524,11 @@ int main(int argc, const char *argv[])
 	struct amount_msat to_local, to_remote;
 	const struct htlc **htlcs, **htlc_map, **htlc_map2, **inv_htlcs;
 	bool option_anchor_outputs = false;
+	bool option_static_remotekey = false;
+
+	/* Allow us to check static-remotekey BOLT 3 vectors, too */
+	if (argv[1] && streq(argv[1], "--static-remotekey"))
+		option_static_remotekey = true;
 
 	chainparams = chainparams_for_network("bitcoin");
 
@@ -715,10 +720,14 @@ int main(int argc, const char *argv[])
 	printf("localkey: %s\n",
 	       type_to_string(tmpctx, struct pubkey, &localkey));
 
-	if (!derive_simple_key(&remote_payment_basepoint,
-			       &x_local_per_commitment_point,
-			       &remotekey))
-		abort();
+	if (option_static_remotekey)
+		remotekey = remote_payment_basepoint;
+	else {
+		if (!derive_simple_key(&remote_payment_basepoint,
+				       &x_local_per_commitment_point,
+				       &remotekey))
+			abort();
+	}
 	printf("remotekey: %s\n",
 	       type_to_string(tmpctx, struct pubkey, &remotekey));
 


### PR DESCRIPTION
This implements generation of test vectors to replicate https://github.com/lightningnetwork/lightning-rfc/pull/539 (merged) and does it in the cleaned-up format proposed in https://github.com/lightningnetwork/lightning-rfc/pull/852.  (When that is merged, we'll need to update some internal bolt quotes, but they're easy).

Changelog-None