### PR TITLE
plugin: Allow plugins to publish and subscribe to custom notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,11 @@ check-protos: $(ALL_PROGRAMS)
 ifeq ($(PYTEST),)
 	@echo "py.test is required to run the protocol tests, please install using 'pip3 install -r requirements.txt', and rerun 'configure'."; false
 else
+ifeq ($(DEVELOPER),1)
 	@(cd external/lnprototest && PYTHONPATH=$(PYTHONPATH) LIGHTNING_SRC=../.. $(PYTEST) --runner lnprototest.clightning.Runner $(PYTEST_OPTS))
+else
+	@echo "lnprototest target requires DEVELOPER=1, skipping"
+endif
 endif
 
 pytest: $(ALL_PROGRAMS)

--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -223,6 +223,7 @@ class Plugin(object):
         }
 
         self.options: Dict[str, Dict[str, Any]] = {}
+        self.notification_topics: List[str] = []
 
         def convert_featurebits(
                 bits: Optional[Union[int, str, bytes]]) -> Optional[str]:
@@ -419,6 +420,11 @@ class Plugin(object):
         """
         self.add_option(name, None, description, opt_type="flag",
                         deprecated=deprecated)
+
+    def add_notification_topic(self, topic: str):
+        """Announce that the plugin will emit notifications for the topic.
+        """
+        self.notification_topics.append(topic)
 
     def get_option(self, name: str) -> str:
         if name not in self.options:
@@ -898,6 +904,9 @@ class Plugin(object):
             'subscriptions': list(self.subscriptions.keys()),
             'hooks': hooks,
             'dynamic': self.dynamic,
+            'notifications': [
+                {"method": name} for name in self.notification_topics
+            ],
         }
 
         # Compact the features a bit, not important.

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -18,11 +18,18 @@ static struct notification *find_notification_by_topic(const char* topic)
 	return NULL;
 }
 
-bool notifications_have_topic(const char *topic)
+bool notifications_have_topic(const struct plugins *plugins, const char *topic)
 {
 	struct notification *noti = find_notification_by_topic(topic);
 	if (noti)
 		return true;
+
+	/* Some plugin at some point announced it'd be emitting
+	 * notifications to this topic. We don't care if it died, just
+	 * that it was a valid topic at some point in time. */
+	for (size_t i=0; i<tal_count(plugins->notification_topics); i++)
+		if (streq(plugins->notification_topics[i], topic))
+			return true;
 
 	return false;
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -26,15 +26,17 @@ bool notifications_topic_is_native(const char *topic)
 
 bool notifications_have_topic(const struct plugins *plugins, const char *topic)
 {
+	struct plugin *plugin;
 	if (notifications_topic_is_native(topic))
 		return true;
 
 	/* Some plugin at some point announced it'd be emitting
-	 * notifications to this topic. We don't care if it died, just
-	 * that it was a valid topic at some point in time. */
-	for (size_t i=0; i<tal_count(plugins->notification_topics); i++)
-		if (streq(plugins->notification_topics[i], topic))
-			return true;
+	 * notifications to this topic. */
+	list_for_each(&plugins->plugins, plugin, list) {
+		for (size_t i = 0; i < tal_count(plugin->notification_topics); i++)
+			if (streq(plugin->notification_topics[i], topic))
+				return true;
+	}
 
 	return false;
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -18,10 +18,15 @@ static struct notification *find_notification_by_topic(const char* topic)
 	return NULL;
 }
 
-bool notifications_have_topic(const struct plugins *plugins, const char *topic)
+bool notifications_topic_is_native(const char *topic)
 {
 	struct notification *noti = find_notification_by_topic(topic);
-	if (noti)
+	return noti != NULL;
+}
+
+bool notifications_have_topic(const struct plugins *plugins, const char *topic)
+{
+	if (notifications_topic_is_native(topic))
 		return true;
 
 	/* Some plugin at some point announced it'd be emitting

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -27,6 +27,10 @@ struct wally_psbt;
 
 bool notifications_have_topic(const struct plugins *plugins, const char *topic);
 
+/* Is the provided notification topic native, i.e., provided by
+ * lightningd itself? */
+bool notifications_topic_is_native(const char *topic);
+
 struct notification {
 	const char *topic;
 	/* the serialization interface */

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -25,7 +25,7 @@
 struct onionreply;
 struct wally_psbt;
 
-bool notifications_have_topic(const char *topic);
+bool notifications_have_topic(const struct plugins *plugins, const char *topic);
 
 struct notification {
 	const char *topic;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -76,7 +76,6 @@ struct plugins *plugins_new(const tal_t *ctx, struct log_book *log_book,
 	p->startup = true;
 	p->json_cmds = tal_arr(p, struct command *, 0);
 	p->blacklist = tal_arr(p, const char *, 0);
-	p->notification_topics = tal_arr(p, const char *, 0);
 	p->shutdown = false;
 	p->plugin_idx = 0;
 #if DEVELOPER
@@ -246,6 +245,7 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES,
 	p->plugin_state = UNCONFIGURED;
 	p->js_arr = tal_arr(p, struct json_stream *, 0);
 	p->used = 0;
+	p->notification_topics = tal_arr(p, const char *, 0);
 	p->subscriptions = NULL;
 	p->dynamic = false;
 	p->index = plugins->plugin_idx++;
@@ -1326,7 +1326,7 @@ static const char *plugin_notifications_add(const char *buffer,
 				       "missing or not a string.",
 				       i);
 
-		name = json_strdup(plugin->plugins, buffer, method);
+		name = json_strdup(plugin, buffer, method);
 
 		if (notifications_topic_is_native(name))
 			return tal_fmt(plugin,
@@ -1335,7 +1335,7 @@ static const char *plugin_notifications_add(const char *buffer,
 				       "however only be sent by lightningd",
 				       name);
 
-		tal_arr_expand(&plugin->plugins->notification_topics, name);
+		tal_arr_expand(&plugin->notification_topics, name);
 	}
 
 	return NULL;

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -240,6 +240,7 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES,
 	p = tal(plugins, struct plugin);
 	p->plugins = plugins;
 	p->cmd = tal_strdup(p, path);
+	p->shortname = path_basename(p, p->cmd);
 	p->start_cmd = start_cmd;
 
 	p->plugin_state = UNCONFIGURED;
@@ -250,8 +251,7 @@ struct plugin *plugin_register(struct plugins *plugins, const char* path TAKES,
 	p->dynamic = false;
 	p->index = plugins->plugin_idx++;
 
-	p->log = new_log(p, plugins->log_book, NULL, "plugin-%s",
-			 path_basename(tmpctx, p->cmd));
+	p->log = new_log(p, plugins->log_book, NULL, "plugin-%s", p->shortname);
 	p->methods = tal_arr(p, const char *, 0);
 	list_head_init(&p->plugin_opts);
 
@@ -1858,7 +1858,6 @@ void json_add_opt_plugins_array(struct json_stream *response,
 				bool important)
 {
 	struct plugin *p;
-	const char *plugin_name;
 	struct plugin_opt *opt;
 	const char *opt_name;
 
@@ -1873,9 +1872,7 @@ void json_add_opt_plugins_array(struct json_stream *response,
 		json_add_string(response, "path", p->cmd);
 
 		/* FIXME: use executables basename until plugins can define their names */
-		plugin_name = path_basename(NULL, p->cmd);
-		json_add_string(response, "name", plugin_name);
-		tal_free(plugin_name);
+		json_add_string(response, "name", p->shortname);
 
 		if (!list_empty(&p->plugin_opts)) {
 			json_object_start(response, "options");

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1327,6 +1327,14 @@ static const char *plugin_notifications_add(const char *buffer,
 				       i);
 
 		name = json_strdup(plugin->plugins, buffer, method);
+
+		if (notifications_topic_is_native(name))
+			return tal_fmt(plugin,
+				       "plugin attempted to register a native "
+				       "notification topic \"%s\", these may "
+				       "however only be sent by lightningd",
+				       name);
+
 		tal_arr_expand(&plugin->plugins->notification_topics, name);
 	}
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -93,6 +93,10 @@ struct plugin {
 	/* Parameters for dynamically-started plugins. */
 	const char *parambuf;
 	const jsmntok_t *params;
+
+	/* Notification topics that this plugin has registered with us
+	 * and that other plugins may subscribe to. */
+	const char **notification_topics;
 };
 
 /**
@@ -128,10 +132,6 @@ struct plugins {
 	/* Whether builtin plugins should be overridden as unimportant.  */
 	bool dev_builtin_plugins_unimportant;
 #endif /* DEVELOPER */
-
-	/* Notification topics that plugins have registered with us
-	 * and that other plugins may subscribe to. */
-	const char **notification_topics;
 };
 
 /* The value of a plugin option, which can have different types.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -128,6 +128,10 @@ struct plugins {
 	/* Whether builtin plugins should be overridden as unimportant.  */
 	bool dev_builtin_plugins_unimportant;
 #endif /* DEVELOPER */
+
+	/* Notification topics that plugins have registered with us
+	 * and that other plugins may subscribe to. */
+	const char **notification_topics;
 };
 
 /* The value of a plugin option, which can have different types.

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -39,7 +39,12 @@ enum plugin_state {
  * A plugin, exposed as a stub so we can pass it as an argument.
  */
 struct plugin {
+	/* Must be first element in the struct otherwise we get false
+	 * positives for leaks. */
 	struct list_node list;
+
+	/* The filename that can be used to refer to the plugin. */
+	const char *shortname;
 
 	pid_t pid;
 	char *cmd;

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 {
 	setup_locale();
 	plugin_main(argv, init, PLUGIN_STATIC, true, NULL, commands, ARRAY_SIZE(commands),
-	            NULL, 0, NULL, 0,
+	            NULL, 0, NULL, 0, NULL, 0,
 		    plugin_option("autocleaninvoice-cycle",
 				  "string",
 				  "Perform cleanup of expired invoices every"

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -972,7 +972,7 @@ int main(int argc, char *argv[])
 
 	plugin_main(argv, init, PLUGIN_STATIC, false /* Do not init RPC on startup*/,
 		    NULL, commands, ARRAY_SIZE(commands),
-		    NULL, 0, NULL, 0,
+		    NULL, 0, NULL, 0, NULL, 0,
 		    plugin_option("bitcoin-datadir",
 				  "string",
 				  "-datadir arg for bitcoin-cli",

--- a/plugins/fetchinvoice.c
+++ b/plugins/fetchinvoice.c
@@ -1389,6 +1389,7 @@ int main(int argc, char *argv[])
 		    /* No notifications */
 	            NULL, 0,
 		    hooks, ARRAY_SIZE(hooks),
+		    NULL, 0,
 		    /* No options */
 		    NULL);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -379,6 +379,7 @@ static const struct plugin_hook hooks[] = {
 
 static const char *notification_topics[] = {
 	"pay_success",
+	"pay_failure",
 };
 
 int main(int argc, char *argv[])

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -377,6 +377,10 @@ static const struct plugin_hook hooks[] = {
 	},
 };
 
+static const char *notification_topics[] = {
+	"pay_success",
+};
+
 int main(int argc, char *argv[])
 {
 	struct feature_set features;
@@ -388,5 +392,5 @@ int main(int argc, char *argv[])
 
 	plugin_main(argv, init, PLUGIN_STATIC, true, &features, commands,
 		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
-		    NULL, 0, NULL);
+		    notification_topics, ARRAY_SIZE(notification_topics), NULL);
 }

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -388,5 +388,5 @@ int main(int argc, char *argv[])
 
 	plugin_main(argv, init, PLUGIN_STATIC, true, &features, commands,
 		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
-		    NULL);
+		    NULL, 0, NULL);
 }

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1844,6 +1844,8 @@ static void payment_finished(struct payment *p)
 	struct json_stream *ret;
 	struct command *cmd = p->cmd;
 	const char *msg;
+	struct json_stream *n;
+	struct payment *root = payment_root(p);
 
 	/* Either none of the leaf attempts succeeded yet, or we have a
 	 * preimage. */
@@ -1884,6 +1886,12 @@ static void payment_finished(struct payment *p)
 			json_add_preimage(ret, "payment_preimage", result.preimage);
 
 			json_add_string(ret, "status", "complete");
+
+			n = plugin_notification_start(p->plugin, "pay_success");
+			json_add_sha256(n, "payment_hash", p->payment_hash);
+			if (root->invstring != NULL)
+				json_add_string(n, "bolt11", root->invstring);
+			plugin_notification_end(p->plugin, n);
 
 			if (command_finished(cmd, ret)) {/* Ignore result. */}
 			return;

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -670,6 +670,14 @@ handle_getmanifest(struct command *getmanifest_cmd,
 
 	json_add_bool(params, "dynamic", p->restartability == PLUGIN_RESTARTABLE);
 
+	json_array_start(params, "notifications");
+	for (size_t i = 0; p->notif_topics && i < p->num_notif_topics; i++) {
+		json_object_start(params, NULL);
+		json_add_string(params, "method", p->notif_topics[i]);
+		json_object_end(params);
+	}
+	json_array_end(params);
+
 	return command_finished(getmanifest_cmd, params);
 }
 

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -92,7 +92,8 @@ struct plugin {
 	 * initialization or need to recover from a disconnect. */
 	const char *rpc_location;
 
-	char **notification_topics;
+	const char **notif_topics;
+	size_t num_notif_topics;
 };
 
 /* command_result is mainly used as a compile-time check to encourage you
@@ -1314,6 +1315,8 @@ static struct plugin *new_plugin(const tal_t *ctx,
 				 size_t num_notif_subs,
 				 const struct plugin_hook *hook_subs,
 				 size_t num_hook_subs,
+				 const char **notif_topics,
+				 size_t num_notif_topics,
 				 va_list ap)
 {
 	const char *optname;
@@ -1351,6 +1354,8 @@ static struct plugin *new_plugin(const tal_t *ctx,
 
 	p->commands = commands;
 	p->num_commands = num_commands;
+	p->notif_topics = notif_topics;
+	p->num_notif_topics = num_notif_topics;
 	p->notif_subs = notif_subs;
 	p->num_notif_subs = num_notif_subs;
 	p->hook_subs = hook_subs;
@@ -1383,6 +1388,8 @@ void plugin_main(char *argv[],
 		 size_t num_notif_subs,
 		 const struct plugin_hook *hook_subs,
 		 size_t num_hook_subs,
+		 const char **notif_topics,
+		 size_t num_notif_topics,
 		 ...)
 {
 	struct plugin *plugin;
@@ -1395,10 +1402,10 @@ void plugin_main(char *argv[],
 	/* Note this already prints to stderr, which is enough for now */
 	daemon_setup(argv[0], NULL, NULL);
 
-	va_start(ap, num_hook_subs);
+	va_start(ap, num_notif_topics);
 	plugin = new_plugin(NULL, init, restartability, init_rpc, features, commands,
 			    num_commands, notif_subs, num_notif_subs, hook_subs,
-			    num_hook_subs, ap);
+			    num_hook_subs, notif_topics, num_notif_topics, ap);
 	va_end(ap);
 	setup_command_usage(plugin);
 

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -91,6 +91,8 @@ struct plugin {
 	/* Location of the RPC filename in case we need to defer RPC
 	 * initialization or need to recover from a disconnect. */
 	const char *rpc_location;
+
+	char **notification_topics;
 };
 
 /* command_result is mainly used as a compile-time check to encourage you

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1028,6 +1028,25 @@ static void plugin_logv(struct plugin *p, enum log_level l,
 	jsonrpc_finish_and_send(p, js);
 }
 
+struct json_stream *plugin_notification_start(struct plugin *plugin,
+					      const char *method)
+{
+	struct json_stream *js = new_json_stream(plugin, NULL, NULL);
+
+	json_object_start(js, NULL);
+	json_add_string(js, "jsonrpc", "2.0");
+	json_add_string(js, "method", method);
+
+	json_object_start(js, "params");
+	return js;
+}
+void plugin_notification_end(struct plugin *plugin,
+			     struct json_stream *stream)
+{
+	json_object_end(stream);
+	jsonrpc_finish_and_send(plugin, stream);
+}
+
 struct json_stream *plugin_notify_start(struct command *cmd, const char *method)
 {
 	struct json_stream *js = new_json_stream(cmd, NULL, NULL);

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -242,6 +242,13 @@ void plugin_log(struct plugin *p, enum log_level l, const char *fmt, ...) PRINTF
 struct json_stream *plugin_notify_start(struct command *cmd, const char *method);
 void plugin_notify_end(struct command *cmd, struct json_stream *js);
 
+/* Send a notification for a custom notification topic. These are sent
+ * to lightningd and distributed to subscribing plugins. */
+struct json_stream *plugin_notification_start(struct plugin *plugins,
+					      const char *method);
+void plugin_notification_end(struct plugin *plugin,
+			     struct json_stream *stream TAKES);
+
 /* Convenience wrapper for notify "message" */
 void plugin_notify_message(struct command *cmd,
 			   enum log_level level,

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -289,6 +289,8 @@ void NORETURN LAST_ARG_NULL plugin_main(char *argv[],
 					size_t num_notif_subs,
 					const struct plugin_hook *hook_subs,
 					size_t num_hook_subs,
+					const char **notif_topics,
+					size_t num_notif_topics,
 					...);
 
 struct listpeers_channel {

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -722,5 +722,5 @@ int main(int argc, char *argv[])
 	setenv("TZ", "", 1);
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands,
 		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
-		    NULL);
+		    NULL, 0, NULL);
 }

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -2193,12 +2193,17 @@ static const struct plugin_command commands[] = {
 	},
 };
 
+static const char *notification_topics[] = {
+	"pay_success",
+	"pay_failure",
+};
+
 int main(int argc, char *argv[])
 {
 	setup_locale();
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands,
 		    ARRAY_SIZE(commands), NULL, 0, NULL, 0,
-		    NULL, 0,
+		    notification_topics, ARRAY_SIZE(notification_topics),
 		    plugin_option("disable-mpp", "flag",
 				  "Disable multi-part payments.",
 				  flag_option, &disablempp),

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -2198,6 +2198,7 @@ int main(int argc, char *argv[])
 	setup_locale();
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands,
 		    ARRAY_SIZE(commands), NULL, 0, NULL, 0,
+		    NULL, 0,
 		    plugin_option("disable-mpp", "flag",
 				  "Disable multi-part payments.",
 				  flag_option, &disablempp),

--- a/plugins/spender/main.c
+++ b/plugins/spender/main.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv)
 		    commands, tal_count(commands),
 		    notifs, tal_count(notifs),
 		    NULL, 0,
+		    NULL, 0, /* Notification topics */
 		    NULL);
 
 	tal_free(owner);

--- a/plugins/txprepare.c
+++ b/plugins/txprepare.c
@@ -553,5 +553,5 @@ int main(int argc, char *argv[])
 {
 	setup_locale();
 	plugin_main(argv, NULL, PLUGIN_RESTARTABLE, true, NULL, commands,
-		    ARRAY_SIZE(commands), NULL, 0, NULL, 0, NULL);
+		    ARRAY_SIZE(commands), NULL, 0, NULL, 0, NULL, 0, NULL);
 }

--- a/tests/plugins/custom_notifications.py
+++ b/tests/plugins/custom_notifications.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+
+
+plugin = Plugin()
+
+
+@plugin.subscribe("custom")
+def on_custom_notification(val, plugin, **kwargs):
+    plugin.log("Got a custom notification {}".format(val))
+
+
+@plugin.method("emit")
+def emit(plugin):
+    """Emit a simple string notification to topic "custom"
+    """
+    plugin.notify("custom", "Hello world")
+
+
+plugin.add_notification_topic("custom")
+plugin.run()

--- a/tests/plugins/custom_notifications.py
+++ b/tests/plugins/custom_notifications.py
@@ -17,5 +17,19 @@ def emit(plugin):
     plugin.notify("custom", "Hello world")
 
 
+@plugin.method("faulty-emit")
+def faulty_emit(plugin):
+    """Emit a simple string notification to topic "custom"
+    """
+    plugin.notify("ididntannouncethis", "Hello world")
+
+
+@plugin.subscribe("ididntannouncethis")
+def on_faulty_emit(origin, payload, **kwargs):
+    """We should never receive this as it gets dropped.
+    """
+    plugin.log("Got the ididntannouncethis event")
+
+
 plugin.add_notification_topic("custom")
 plugin.run()

--- a/tests/plugins/custom_notifications.py
+++ b/tests/plugins/custom_notifications.py
@@ -24,6 +24,16 @@ def faulty_emit(plugin):
     plugin.notify("ididntannouncethis", "Hello world")
 
 
+@plugin.subscribe("pay_success")
+def on_pay_success(origin, payload, **kwargs):
+    plugin.log(
+        "Got a pay_success notification from plugin {} for payment_hash {}".format(
+            origin,
+            payload['payment_hash']
+        )
+    )
+
+
 @plugin.subscribe("ididntannouncethis")
 def on_faulty_emit(origin, payload, **kwargs):
     """We should never receive this as it gets dropped.

--- a/tests/plugins/custom_notifications.py
+++ b/tests/plugins/custom_notifications.py
@@ -6,8 +6,8 @@ plugin = Plugin()
 
 
 @plugin.subscribe("custom")
-def on_custom_notification(val, plugin, **kwargs):
-    plugin.log("Got a custom notification {}".format(val))
+def on_custom_notification(origin, payload, **kwargs):
+    plugin.log("Got a custom notification {} from plugin {}".format(payload, origin))
 
 
 @plugin.method("emit")

--- a/tests/plugins/test_libplugin.c
+++ b/tests/plugins/test_libplugin.c
@@ -146,6 +146,7 @@ int main(int argc, char *argv[])
 	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 	            notifs, ARRAY_SIZE(notifs), hooks, ARRAY_SIZE(hooks),
+		    NULL, 0,  /* Notification topics we publish */
 		    plugin_option("name",
 				  "string",
 				  "Who to say hello to.",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2402,3 +2402,13 @@ def test_self_disable(node_factory):
     # Also works with dynamic load attempts
     with pytest.raises(RpcError, match="Disabled via selfdisable option"):
         l1.rpc.plugin_start(p2, selfdisable=True)
+
+
+@pytest.mark.xfail(strict=True)
+def test_custom_notification_topics(node_factory):
+    plugin = os.path.join(
+        os.path.dirname(__file__), "plugins", "custom_notifications.py"
+    )
+    l1 = node_factory.get_node(options={'plugin': plugin})
+    l1.rpc.emit()
+    l1.daemon.wait_for_log(r'Got a custom notification Hello world')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2404,7 +2404,6 @@ def test_self_disable(node_factory):
         l1.rpc.plugin_start(p2, selfdisable=True)
 
 
-@pytest.mark.xfail(strict=True)
 def test_custom_notification_topics(node_factory):
     plugin = os.path.join(
         os.path.dirname(__file__), "plugins", "custom_notifications.py"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2408,9 +2408,14 @@ def test_custom_notification_topics(node_factory):
     plugin = os.path.join(
         os.path.dirname(__file__), "plugins", "custom_notifications.py"
     )
-    l1 = node_factory.get_node(options={'plugin': plugin})
+    l1, l2 = node_factory.line_graph(2, opts=[{'plugin': plugin}, {}])
     l1.rpc.emit()
     l1.daemon.wait_for_log(r'Got a custom notification Hello world')
+
+    inv = l2.rpc.invoice(42, "lbl", "desc")['bolt11']
+    l1.rpc.pay(inv)
+
+    l1.daemon.wait_for_log(r'Got a pay_success notification from plugin pay for payment_hash [0-9a-f]{64}')
 
     # And now make sure that we drop unannounced notifications
     l1.rpc.faulty_emit()


### PR DESCRIPTION
So far plugins could only subscribe to native notifications that originated in `lightningd` and which were limited to a few topics directly built into the daemon. With this PR we enable plugins to announce their intention to publish notifications to custom topics, and for other plugins to subscribe to those topics and receive the notifications.

Custom topics are required to be announced as part of the `getmanifest` call, allowing us to verify that subscriptions match the announced topics at startup, and print a warning message should a plugin subscribe to a topic that wasn't announced, and therefore will never receive a notification. Trying to send a notification with an unannounced topic will result in a warning being logged, and the message _not_ being delivered to subscribers.

To allow subscribers to identify the sender we wrap the notification payload in an outer object with the sender metadata alongside the payload. So the `sender` sending the first message below, will result in the second message being delivered to all subscribers:

```json
{
  "jsonrpc": "2.0",
  "method": "mycustomnotification",
  "params": {
    "key": "value",
	"message": "Hello fellow plugin!"
  }
}
```

is delivered as

```json
{
  "jsonrpc": "2.0",
  "method": "mycustomnotification",
  "params": {
    "origin": "sender",
    "payload": {
      "key": "value",
      "message": "Hello fellow plugin!"
    }
  }
}

```

Notification subscribers should be lenient in what they accept, given that multiple plugins may publish to the same topic, potentially with different payload structures. This in turn allows for both fanout and fanin communication patterns.

We also instrument the `pay` plugin, reporting a minimal `pay_success` or `pay_failure` notification, which includes the `payment_hash`, the `bolt11` string as well as the failure message for failures. The remaining fields may be added if required or can be looked up by querying `listpays`.