### PR TITLE
plugin notifications: minor cleanups.

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -109,9 +109,6 @@ void plugins_free(struct plugins *plugins)
 static void plugin_check_subscriptions(struct plugins *plugins,
 				       struct plugin *plugin)
 {
-	if (plugin->subscriptions == NULL)
-		return;
-
 	for (size_t i = 0; i < tal_count(plugin->subscriptions); i++) {
 		const char *topic = plugin->subscriptions[i];
 		if (!notifications_have_topic(plugins, topic))
@@ -1305,6 +1302,7 @@ static const char *plugin_notifications_add(const char *buffer,
 					    struct plugin *plugin)
 {
 	char *name;
+	size_t i;
 	const jsmntok_t *method, *obj;
 	const jsmntok_t *notifications =
 	    json_get_member(buffer, result, "notifications");
@@ -1316,8 +1314,7 @@ static const char *plugin_notifications_add(const char *buffer,
 		return tal_fmt(plugin,
 			       "\"result.notifications\" is not an array");
 
-	for (size_t i = 0; i < notifications->size; i++) {
-		obj = json_get_arr(notifications, i);
+	json_for_each_arr(i, obj, notifications) {
 		if (obj->type != JSMN_OBJECT)
 			return tal_fmt(
 			    plugin,

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1834,19 +1834,21 @@ static void payment_json_add_attempts(struct json_stream *s,
 	json_array_end(s);
 }
 
-static void payment_notify_failure(struct payment *p, const char *error_message) {
+static void payment_notify_failure(struct payment *p, const char *error_message)
+{
 	struct payment *root = payment_root(p);
 	struct json_stream *n;
-			n = plugin_notification_start(p->plugin, "pay_failure");
-			json_add_sha256(n, "payment_hash", p->payment_hash);
-			if (root->invstring != NULL)
-				json_add_string(n, "bolt11", root->invstring);
 
-			json_object_start(n, "error");
-			json_add_string(n, "message", error_message);
-			json_object_end(n); /* .error */
+	n = plugin_notification_start(p->plugin, "pay_failure");
+	json_add_sha256(n, "payment_hash", p->payment_hash);
+	if (root->invstring != NULL)
+		json_add_string(n, "bolt11", root->invstring);
 
-			plugin_notification_end(p->plugin, n);
+	json_object_start(n, "error");
+	json_add_string(n, "message", error_message);
+	json_object_end(n); /* .error */
+
+	plugin_notification_end(p->plugin, n);
 }
 
 /* This function is called whenever a payment ends up in a final state, or all


### PR DESCRIPTION
So minor I didn't want to hold up @cdecker's excellent PR from merging.

1. We don't need to check for NULL before tal_count(NULL).
2. Use of json_for_each_arr iterator is probably better.
3. Weird indent fixed.

Changelog-None