### PR TITLE
lightningd: implement --log-timestamps=false.

### DIFF
--- a/doc/lightningd-config.5
+++ b/doc/lightningd-config.5
@@ -197,6 +197,11 @@ Log to this file instead of stdout\. Sending \fBlightningd\fR(8) SIGHUP will
 cause it to reopen this file (useful for log rotation)\.
 
 
+ \fBlog-timetamps\fR=\fIBOOL\fR
+Set this to false to turn off timestamp prefixes (they will still appear
+in crash log files)\.
+
+
  \fBrpc-file\fR=\fIPATH\fR
 Set JSON-RPC socket (or /dev/tty), such as for \fBlightning-cli\fR(1)\.
 
@@ -627,4 +632,4 @@ Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license\.
 
-\" SHA256STAMP:cdddb53037da4e67505114769586ed56914827c584a073956387933bc09e7aa9
+\" SHA256STAMP:1cbbdff8f2b7ba54d6912c54a731357fcf37b87c053a528d546f3ffbfccd1216

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -157,6 +157,10 @@ with multiple daemons.
 Log to this file instead of stdout. Sending lightningd(8) SIGHUP will
 cause it to reopen this file (useful for log rotation).
 
+ **log-timetamps**=*BOOL*
+Set this to false to turn off timestamp prefixes (they will still appear
+in crash log files).
+
  **rpc-file**=*PATH*
 Set JSON-RPC socket (or /dev/tty), such as for lightning-cli(1).
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2529,3 +2529,10 @@ def test_version_reexec(node_factory, bitcoind):
     # Now "fix" it, it should restart.
     os.unlink(verfile)
     l1.daemon.wait_for_log("Server started with public key")
+
+
+def test_notimestamp_logging(node_factory):
+    l1 = node_factory.get_node(options={'log-timestamps': False})
+    assert l1.daemon.logs[0].startswith("DEBUG")
+
+    assert l1.rpc.listconfigs()['log-timestamps'] is False


### PR DESCRIPTION
Fixes: #4494
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Added: config: New option `log-timestamps` allow disabling of timestamp prefix in logs.