### PR TITLE
Update lnprototest with the last version of master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,5 @@
 	url = https://github.com/valyala/gheap
 [submodule "external/lnprototest"]
 	path = external/lnprototest
-	url = https://github.com/niftynei/lnprototest.git
-	branch = nifty/small-edits
-	ignore = dirty
+	url = https://github.com/rustyrussell/lnprototest.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,4 +17,3 @@
 [submodule "external/lnprototest"]
 	path = external/lnprototest
 	url = https://github.com/rustyrussell/lnprototest.git
-	branch = master


### PR DESCRIPTION
I followed the last update of lnprototest and I hope to avoid mistakes with this PR.
The actual version of lnprototest is a couple of comments back, and it missing the update with bitcoin 0.21.0 made by this PR https://github.com/rustyrussell/lnprototest/pull/10.

I made a double-check, and I think that the previous version of lnprototest is fully contained inside the master, with the following PR https://github.com/rustyrussell/lnprototest/pull/5.

Correct me if I'm wrong @niftynei 😄 

let see what GitHub action react to this change💺 

Closing #4516 

