### PR TITLE
`createonion` to accept an optional custom `onion_size`

### DIFF
--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -130,7 +130,7 @@ static struct route_step *decode_with_privkey(const tal_t *ctx, const u8 *onion,
 	if (!hex_decode(hexprivkey, strlen(hexprivkey), &seckey, sizeof(seckey)))
 		errx(1, "Invalid private key hex '%s'", hexprivkey);
 
-	packet = parse_onionpacket(tmpctx, onion, TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE), &why_bad);
+	packet = parse_onionpacket(tmpctx, onion, tal_bytelen(onion), &why_bad);
 
 	if (!packet)
 		errx(1, "Error parsing message: %s", onion_wire_name(why_bad));
@@ -147,7 +147,7 @@ static struct route_step *decode_with_privkey(const tal_t *ctx, const u8 *onion,
 static void do_decode(int argc, char **argv, const u8 *assocdata)
 {
 	const tal_t *ctx = talz(NULL, tal_t);
-	u8 serialized[TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE)];
+	u8 *serialized;
 	struct route_step *step;
 
 	if (argc != 4)
@@ -161,7 +161,8 @@ static void do_decode(int argc, char **argv, const u8 *assocdata)
 	while (isspace(hextemp[hexlen-1]))
 		hexlen--;
 
-	if (!hex_decode(hextemp, hexlen, serialized, sizeof(serialized))) {
+	serialized = tal_hexdata(hextemp, hextemp, hexlen);
+	if (!serialized) {
 		errx(1, "Invalid onion hex '%s'", hextemp);
 	}
 

--- a/doc/lightning-createonion.7
+++ b/doc/lightning-createonion.7
@@ -3,7 +3,7 @@
 lightning-createonion - Low-level command to create a custom onion
 .SH SYNOPSIS
 
-\fBcreateonion\fR \fIhops\fR \fIassocdata\fR [\fIsession_key\fR]
+\fBcreateonion\fR \fIhops\fR \fIassocdata\fR [\fIsession_key\fR] [\fIonion_size\fR]
 
 .SH DESCRIPTION
 
@@ -75,8 +75,8 @@ which the above \fIhops\fR parameter was generated:
 Notice that the payload in the \fIhops\fR parameter is the hex-encoded version
 of the parameters in the \fBgetroute\fR response\.
 .IP \[bu]
-The payloads are shifted left by one, i\.e\., payload 0 in \fBcreateonion\fR
-corresponds to payload 1 from \fBgetroute\fR\.
+Except for the pubkey, the values are shifted left by one, i\.e\., the 1st
+payload in \fBcreateonion\fR corresponds to the 2nd set of values from \fBgetroute\fR\.
 .IP \[bu]
 The final payload is a copy of the last payload sans \fBchannel\fR
 
@@ -96,6 +96,11 @@ used to generate the shared secrets used to encrypt the onion for each hop\. It
 should only be used for testing or if a specific shared secret is
 important\. If not specified it will be securely generated internally, and the
 shared secrets will be returned\.
+
+
+The optional \fIonion_size\fR parameter specifies a size different from the default
+payment onion (1300 bytes)\. May be used for custom protocols like trampoline
+routing\.
 
 .SH RETURN VALUE
 
@@ -132,4 +137,4 @@ Christian Decker \fI<decker.christian@gmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:287d404b94d0e85eedbc6138b8e7a204723df86ad6d5f984ccfcd03e718ec514
+\" SHA256STAMP:d32334049025248f8b6088afed4e3322be75815ea6b976f79a007c619518f98a

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -4,7 +4,7 @@ lightning-createonion -- Low-level command to create a custom onion
 SYNOPSIS
 --------
 
-**createonion** *hops* *assocdata* \[*session_key*\]
+**createonion** *hops* *assocdata* \[*session_key*\] \[*onion_size*\]
 
 DESCRIPTION
 -----------
@@ -68,10 +68,10 @@ which the above *hops* parameter was generated:
 
  - Notice that the payload in the *hops* parameter is the hex-encoded version
    of the parameters in the `getroute` response.
- - The payloads are shifted left by one, i.e., payload 0 in `createonion`
-   corresponds to payload 1 from `getroute`.
+ - Except for the pubkey, the values are shifted left by one, i.e., the 1st
+   payload in `createonion` corresponds to the 2nd set of values from `getroute`.
  - The final payload is a copy of the last payload sans `channel`
- 
+
 These rules are directly derived from the onion construction. Please refer
 [BOLT 04][bolt04] for details and rationale.
 
@@ -84,6 +84,10 @@ used to generate the shared secrets used to encrypt the onion for each hop. It
 should only be used for testing or if a specific shared secret is
 important. If not specified it will be securely generated internally, and the
 shared secrets will be returned.
+
+The optional *onion_size* parameter specifies a size different from the default
+payment onion (1300 bytes). May be used for custom protocols like trampoline
+routing.
 
 RETURN VALUE
 ------------
@@ -122,4 +126,3 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md
-


### PR DESCRIPTION
I'm trying to make a trampoline routing plugin and I'm hoping this very small change will be enough to allow me to make the custom trampoline onions to be built without me having to reimplement onion-making functions from scratch.