### PR TITLE
Improve documentation for calls that use psbt

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -164,3 +164,9 @@ Here is an example in Python checking if [one of the `option_static_remotekey` b
 >>> bool(0x02aaa2 & ((1 << 12) | (1 << 13)))
 True
 ```
+
+## Technical Questions
+
+### How do I get the `psbt` for RPC calls that need it?
+
+A `psbt` is created and returned by a call to [`utxopsbt` with `reservedok=true`](https://lightning.readthedocs.io/lightning-utxopsbt.7.html?highlight=psbt).

--- a/doc/lightning-utxopsbt.7
+++ b/doc/lightning-utxopsbt.7
@@ -42,11 +42,11 @@ for the excess sats\.
 
 .SH RETURN VALUE
 
-On success, returns the \fIpsbt\fR containing the inputs, \fIfeerate_per_kw\fR
-showing the exact numeric feerate it used, \fIestimated_final_weight\fR for
-the estimated weight of the transaction once fully signed, and
-\fIexcess_msat\fR containing the amount above \fIsatoshi\fR which is
-available\.  This could be zero, or dust\.  If \fIsatoshi\fR was "all",
+On success, returns the \fIpsbt\fR it created, containing the inputs,
+\fIfeerate_per_kw\fR showing the exact numeric feerate it used, 
+\fIestimated_final_weight\fR for the estimated weight of the transaction
+once fully signed, and \fIexcess_msat\fR containing the amount above \fIsatoshi\fR
+which is available\.  This could be zero, or dust\.  If \fIsatoshi\fR was "all",
 then \fIexcess_msat\fR is the entire amount once fees are subtracted
 for the weights of the inputs and \fIstartweight\fR\.
 
@@ -86,4 +86,4 @@ Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:a56057522ed576f232d7d96794f39cc67a5a1b1bb7b6f7912e42c3769555e007
+\" SHA256STAMP:f956240b56534af4f6e99e3e77bbb4f5bc707c390a935cde08be0178abbb9cbd

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -39,11 +39,11 @@ for the excess sats.
 RETURN VALUE
 ------------
 
-On success, returns the *psbt* containing the inputs, *feerate_per_kw*
-showing the exact numeric feerate it used, *estimated_final_weight* for
-the estimated weight of the transaction once fully signed, and
-*excess_msat* containing the amount above *satoshi* which is
-available.  This could be zero, or dust.  If *satoshi* was "all",
+On success, returns the *psbt* it created, containing the inputs,
+*feerate_per_kw* showing the exact numeric feerate it used, 
+*estimated_final_weight* for the estimated weight of the transaction
+once fully signed, and *excess_msat* containing the amount above *satoshi*
+which is available.  This could be zero, or dust.  If *satoshi* was "all",
 then *excess_msat* is the entire amount once fees are subtracted
 for the weights of the inputs and *startweight*.
 


### PR DESCRIPTION
Added FAQ on getting a PSBT.  Also when I read the RETURN VALUE for utxopsbt the first time, I didn't realize this command produces (or recreates) the psbt that I need.  The change I made makes that more obvious when it's presented as a hit by GH for a search for psbt.