### PR TITLE
df-bugs: rm duplicate call to channeld

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -47,10 +47,6 @@ static void channel_disconnect(struct channel *channel,
 			       bool reconnect,
 			       const char *desc)
 {
-	u8 *msg = towire_connectd_peer_disconnected(tmpctx,
-						    &channel->peer->id);
-	subd_send_msg(channel->peer->ld->connectd, msg);
-
 	log_(channel->log, level, NULL, false, "%s", desc);
 	channel_cleanup_commands(channel, desc);
 
@@ -67,6 +63,8 @@ static void channel_disconnect(struct channel *channel,
 	if (reconnect)
 		channel_fail_reconnect(channel, "%s: %s",
 				       channel->owner->name, desc);
+	else
+		channel_set_owner(channel, NULL);
 }
 
 void channel_close_conn(struct channel *channel, const char *why)


### PR DESCRIPTION
This gets called from channel_set_owner, which both `delete_channel` and
the `channel_fail_reconnect` pathways call.

Fixes crash
------------------------------------------------------ Captured stderr teardown -------------------------------------------------------
lightning_connectd: peer_disconnected unknown peer: 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 (version v0.10.0-144-gfaf98c9)
0x560e90d59d08 send_backtrace
        common/daemon.c:39
0x560e90d648a5 status_failed
        common/status.c:214
0x560e90d50e8f peer_disconnected
        connectd/connectd.c:1606
0x560e90d510d5 recv_req
        connectd/connectd.c:1662
0x560e90d5a266 handle_read
        common/daemon_conn.c:31
0x560e90d98ccb next_plan
        ccan/ccan/io/io.c:59
0x560e90d998b0 do_plan
        ccan/ccan/io/io.c:407
0x560e90d998f2 io_ready
        ccan/ccan/io/io.c:417
0x560e90d9bb8a io_loop
        ccan/ccan/io/poll.c:445
0x560e90d512c8 main
        connectd/connectd.c:1735
0x7fbdb828b0b2 ???
        ???:0
0x560e90d4a6dd ???
        ???:0
0xffffffffffffffff ???
        ???:0