### PR TITLE
Dual-funding, last of the CI tests

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1935,9 +1935,13 @@ json_openchannel_abort(struct command *cmd,
 		return command_fail(cmd, FUNDING_PEER_NOT_CONNECTED,
 				    "Peer not connected");
 
-	if (!channel->open_attempt)
+	if (!channel->open_attempt) {
+		if (list_empty(&channel->inflights))
+			return command_fail(cmd, FUNDING_STATE_INVALID,
+					    "Channel open not in progress");
 		return command_fail(cmd, FUNDING_STATE_INVALID,
-				    "Channel open not in progress");
+				    "Sigs already exchanged, can't cancel");
+	}
 
 	if (channel->open_attempt->cmd)
 		return command_fail(cmd, FUNDING_STATE_INVALID,


### PR DESCRIPTION
In 0f79b1bd805ba6b1d2aaf0cd0737f8aef830ffd9, we mark a bunch of tests as 'v1' only. Here we translate as many of those as possible/logical to have 'v2' counterparts.

Changelog-None