### PR TITLE
stop requiring channel and direction on `sendonion` since they're not used.

### DIFF
--- a/doc/lightning-sendonion.7
+++ b/doc/lightning-sendonion.7
@@ -39,7 +39,6 @@ to add an HTLC for 1002 millisatoshis and a delay of 21 blocks on top of the cur
 .RS
 {
   "id": "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59",
-  "direction": 1,
   "amount_msat": "1002msat",
   "delay": 21,
 }
@@ -121,4 +120,4 @@ Christian Decker \fI<decker.christian@gmail.com\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:19d7317d0c50409db6a09b1e4411fc9697976254be3555cbf3bcf2a28984529c
+\" SHA256STAMP:1d7ceae27ac4ac51597b92de50cf7bc917c59bdf59f3280efc06491ed4efaffc

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -37,7 +37,6 @@ to add an HTLC for 1002 millisatoshis and a delay of 21 blocks on top of the cur
 ```json
 {
   "id": "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59",
-  "direction": 1,
   "amount_msat": "1002msat",
   "delay": 21,
 }
@@ -112,4 +111,3 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md
-

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1007,7 +1007,7 @@ send_payment_core(struct lightningd *ld,
 					   "peer found");
 
 		json_add_routefail_info(data, 0, WIRE_UNKNOWN_NEXT_PEER,
-					&ld->id, channel->scid,
+					&ld->id, NULL,
 					node_id_idx(&ld->id,
 						    &first_hop->node_id),
 					NULL);

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1007,7 +1007,7 @@ send_payment_core(struct lightningd *ld,
 					   "peer found");
 
 		json_add_routefail_info(data, 0, WIRE_UNKNOWN_NEXT_PEER,
-					&ld->id, &first_hop->scid,
+					&ld->id, channel->scid,
 					node_id_idx(&ld->id,
 						    &first_hop->node_id),
 					NULL);
@@ -1021,7 +1021,7 @@ send_payment_core(struct lightningd *ld,
 	if (failmsg) {
 		fail = immediate_routing_failure(cmd, ld,
 						 fromwire_peektype(failmsg),
-						 &first_hop->scid,
+						 channel->scid,
 						 &channel->peer->id);
 
 		return sendpay_fail(

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1505,8 +1505,6 @@ static struct command_result *payment_createonion_success(struct command *cmd,
 	json_add_hex_talarr(req->js, "onion", p->createonion_response->onion);
 
 	json_object_start(req->js, "first_hop");
-	json_add_short_channel_id(req->js, "channel", &first->scid);
-	json_add_num(req->js, "direction", first->direction);
 	json_add_amount_msat_only(req->js, "amount_msat", first->amount);
 	json_add_num(req->js, "delay", first->delay);
 	json_add_node_id(req->js, "id", &first->node_id);


### PR DESCRIPTION
Does this make sense?

Untested, wanted to make sure it made sense first.