### PR TITLE
readme: fix ubuntu installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ For the impatient here's the gist of it for Ubuntu:
 
 ```bash
 sudo apt-get install -y software-properties-common
-sudo add-apt-repository -u ppa:bitcoin/bitcoin
 sudo add-apt-repository -u ppa:lightningnetwork/ppa
-sudo apt-get install bitcoind lightningd
+sudo apt-get install lightningd snapd
+sudo snap install bitcoin-core
+sudo ln -s /snap/bitcoin-core/current/bin/bitcoin{d,-cli} /usr/local/bin/
 ```
 
 ### Starting `lightningd`


### PR DESCRIPTION
I have verified that this results in working bitcoin core and c-lightning on fresh Ubuntu 20.04 server installation.

This is also consistent with instructions in doc/INSTALL.md

Fixes: #4539
Fixes:  #4538
Reported-By: @urza
Changelog-None: just readme