### PR TITLE
Make cltv_expiry for keysends slightly more conservative

### DIFF
--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -163,7 +163,8 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 	p->payment_secret = NULL;
 	p->amount = *msat;
 	p->routes = NULL;
-	p->min_final_cltv_expiry = DEFAULT_FINAL_CLTV_DELTA;
+	// 22 is the Rust-Lightning default and the highest minimum we know of.
+	p->min_final_cltv_expiry = 22;
 	p->features = NULL;
 	p->invstring = NULL;
 	p->why = "Initial attempt";


### PR DESCRIPTION
Hi all! I'm working on making Rust-Lightning compatible with CL's keysend.

Would you all be open to a change like this? Rust-Lightning is a bit more conservative than the default 18 for `min_final_cltv_expiry`, so I thought it might be reasonable to make CL use a bit more conservative value too. Let me know what you think.