### PR TITLE
Reject min channels

### DIFF
--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1640,3 +1640,12 @@ command_hook_success(struct command *cmd)
 	json_add_string(response, "result", "continue");
 	return command_finished(cmd, response);
 }
+
+struct command_result *WARN_UNUSED_RESULT
+command_hook_reject(struct command *cmd, const char *err)
+{
+	struct json_stream *response = jsonrpc_stream_success(cmd);
+	json_add_string(response, "result", "reject");
+	json_add_string(response, "error_message", err);
+	return command_finished(cmd, response);
+}

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -185,6 +185,12 @@ command_success(struct command *cmd, const struct json_out *result);
 struct command_result *WARN_UNUSED_RESULT
 command_hook_success(struct command *cmd);
 
+/* End a hook with a reject and message (with "result": "reject")
+ * Note that this isn't universal, only a select number of hooks
+ * support a 'reject' */
+struct command_result *WARN_UNUSED_RESULT
+command_hook_reject(struct command *cmd, const char *err);
+
 /* Synchronous helper to send command and extract fields from
  * response; can only be used in init callback. */
 void rpc_scan(struct plugin *plugin,


### PR DESCRIPTION
I realized after doing this that we have `min-capacity-sat` which lets us reject a channel open who's effective capacity will be below a certain limit.

This is less useful for v2 channels, since we're adding funds to it as well, but you can simply set `min-their-funding` to the same amount and achieve roughly the same thing.

Making this a draft since I don't think we should add it, but open to second opinions.