### PR TITLE
hsm_encryption: read from STDIN if not in a TTY

### DIFF
--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -3,7 +3,7 @@
 #include <sodium/utils.h>
 #include <termios.h>
 #include <unistd.h>
-#include <stdio.h>	
+#include <stdio.h>
 
 char *hsm_secret_encryption_key(const char *pass, struct secret *key)
 {

--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -1,9 +1,9 @@
 #include <ccan/tal/str/str.h>
 #include <common/hsm_encryption.h>
 #include <sodium/utils.h>
+#include <stdio.h>
 #include <termios.h>
 #include <unistd.h>
-#include <stdio.h>
 
 char *hsm_secret_encryption_key(const char *pass, struct secret *key)
 {

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -390,16 +390,8 @@ static char *opt_important_plugin(const char *arg, struct lightningd *ld)
  */
 static char *opt_set_hsm_password(struct lightningd *ld)
 {
-	struct termios current_term, temp_term;
 	char *passwd, *passwd_confirmation, *err;
 
-	/* Get the password from stdin, but don't echo it. */
-	if (tcgetattr(fileno(stdin), &current_term) != 0)
-		return "Could not get current terminal options.";
-	temp_term = current_term;
-	temp_term.c_lflag &= ~ECHO;
-	if (tcsetattr(fileno(stdin), TCSAFLUSH, &temp_term) != 0)
-		return "Could not disable password echoing.";
 	printf("The hsm_secret is encrypted with a password. In order to "
 	       "decrypt it and start the node you must provide the password.\n");
 	printf("Enter hsm_secret password:\n");


### PR DESCRIPTION
fixes: #4570 as discussed.

The temporary terminal with ECHO disabled is not created if the input is piped instead of typed in a terminal.

Passwords are still not visible when typed, but allows for automation.