### PR TITLE
Update libwally to v0.8.3

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -689,10 +689,6 @@ struct wally_psbt *psbt_from_b64(const tal_t *ctx,
 		psbt = NULL;
 	tal_wally_end(tal_steal(ctx, psbt));
 
-	/* FIXME: Patch for the empty-tx bug in libwally */
-	if (!psbt && strlen(str) == 28)
-		psbt = create_psbt(ctx, 0, 0, 0);
-
 	return psbt;
 }
 
@@ -743,10 +739,6 @@ struct wally_psbt *psbt_from_bytes(const tal_t *ctx, const u8 *bytes,
 	else
 		psbt = NULL;
 	tal_wally_end(tal_steal(ctx, psbt));
-
-	/* FIXME: Patch for the empty-tx bug in libwally */
-	if (!psbt && byte_len == 19)
-		psbt = create_psbt(ctx, 0, 0, 0);
 
 	return psbt;
 }

--- a/common/setup.c
+++ b/common/setup.c
@@ -19,6 +19,7 @@ static void wally_free(void *ptr)
 }
 
 static struct wally_operations wally_tal_ops = {
+	.struct_size = sizeof(struct wally_operations),
 	.malloc_fn = wally_tal,
 	.free_fn = wally_free,
 };

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 # Dependencies required to build and test c-lightning
-https://github.com/ElementsProject/libwally-core/releases/download/release_0.8.0/wallycore-0.8.0-cp36-cp36m-linux_x86_64.whl; 'linux' in sys_platform and python_version == '3.6'
-https://github.com/ElementsProject/libwally-core/releases/download/release_0.8.0/wallycore-0.8.0-cp37-cp37m-linux_x86_64.whl; 'linux' in sys_platform and python_version == '3.7'
-https://github.com/ElementsProject/libwally-core/releases/download/release_0.8.0/wallycore-0.8.0-cp37-cp37m-macosx_10_14_x86_64.whl; sys_platform == 'darwin' and python_version == '3.7'
 mrkd ~= 0.1.6
 Mako ~= 1.1.3
 flake8 ~= 3.7.8


### PR DESCRIPTION
Fixes the 'empty-psbt' problem etc. We also remove outdated/unnecessary wallycore python deps, as we no longer use it for integration tests.

Changelog-None