### PR TITLE
Revert "pytest: Skip hsm encryption test if we don't have a TTY"

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -12,7 +12,6 @@ from utils import (
 import os
 import pytest
 import subprocess
-import sys
 import unittest
 
 
@@ -992,7 +991,6 @@ def test_transaction_annotations(node_factory, bitcoind):
 
 
 @unittest.skipIf(VALGRIND, "It does not play well with prompt and key derivation.")
-@unittest.skipIf(not sys.stdout.isatty(), "Cannot")
 def test_hsm_secret_encryption(node_factory):
     l1 = node_factory.get_node(may_fail=True)  # May fail when started without key
     password = "reckful\n"


### PR DESCRIPTION
I don't see any reason for checking whether the stdout is a tty. In addition i'm pretty sure `pytest` captures `stdout` and that means this test was actually never run.

 I did a first dry-run on my fork's Github Action, and it doesn't need it either.