### PR TITLE
openingd: return more informative error message for v2 opens

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1177,6 +1177,15 @@ static struct command_result *json_fundchannel_start(struct command *cmd,
 	}
 
 	if (!peer->uncommitted_channel) {
+		if (feature_negotiated(cmd->ld->our_features,
+				       peer->their_features,
+				       OPT_DUAL_FUND))
+			return command_fail(cmd, FUNDING_STATE_INVALID,
+					    "Peer negotiated"
+					    " `option_dual_fund`,"
+					    " must use `openchannel_init` not"
+					    " `fundchannel_start`.");
+
 		return command_fail(cmd, FUNDING_PEER_NOT_CONNECTED,
 				    "Peer not connected");
 	}


### PR DESCRIPTION
Fixes #4562

New error message:

```
	zircon:lightning (nifty/fix-4562)$ l1-cli fundchannel_start 03fce775508719e4064b7f19d4e884ddaf51db23bbfc560286ce872f9ed106fee0 10000 253perkw
	{
	   "code": 312,
	   "message": "Peer negotiated `option_dual_fund`, must use `openchannel_init` not `fundchannel_start`."
	}
```

Changelog-None