### PR TITLE
wire/Makefile: always generate non-exp files.

### DIFF
--- a/wire/Makefile
+++ b/wire/Makefile
@@ -34,9 +34,22 @@ WIRE_OBJS := $(WIRE_SRC:.c=.o)
 WIRE_PRINT_OBJS := $(WIRE_PRINT_SRC:.c=.o)
 $(WIRE_OBJS) $(WIRE_PRINT_OBJS): $(WIRE_HEADERS)
 
-# Make sure these depend on everything.
-ALL_C_SOURCES += $(WIRE_SRC) $(WIRE_PRINT_SRC)
-ALL_C_HEADERS += $(WIRE_HEADERS)
+# Make sure these depend on everything: in case we're experimental,
+# include non-experimental ones here so they get rebuilt.
+WIRE_NONEXP_SRC := wire/bolt12_wiregen.c	\
+		wire/peer_wiregen.c		\
+		wire/onion_wiregen.c		\
+		wire/onion_printgen.c		\
+		wire/peer_printgen.c
+WIRE_NONEXP_HEADERS := wire/peer_wiregen.h	\
+		wire/onion_wiregen.h		\
+		wire/bolt12_wiregen.h		\
+		wire/peer_printgen.h		\
+		wire/onion_printgen.h
+
+ALL_C_SOURCES += $(WIRE_SRC) $(WIRE_PRINT_SRC) $(WIRE_NONEXP_SRC)
+
+ALL_C_HEADERS += $(WIRE_HEADERS) $(WIRE_NONEXP_HEADERS)
 
 # They may not have the bolts.
 BOLT_EXTRACT=$(LOCAL_BOLTDIR)/tools/extract-formats.py
@@ -123,7 +136,7 @@ wire/bolt12_exp_wiregen.c_args := $(wire/bolt12_wiregen.c_args)
 wire/peer_wiregen.h_args := --include='common/channel_id.h' --include='bitcoin/tx.h' --include='bitcoin/preimage.h' --include='bitcoin/short_channel_id.h' --include='common/node_id.h' --include='common/bigsize.h' --include='bitcoin/block.h' --include='bitcoin/privkey.h' -s --expose-tlv-type=n1 --expose-tlv-type=n2
 
 # All generated wire/ files depend on this Makefile
-$(filter %printgen.h %printgen.c %wiregen.h %wiregen.c, $(WIRE_SRC) $(WIRE_PRINT_SRC) $(WIRE_HEADERS)): wire/Makefile
+$(filter %printgen.h %printgen.c %wiregen.h %wiregen.c, $(WIRE_SRC) $(WIRE_PRINT_SRC) $(WIRE_NONEXP_SRC) $(WIRE_HEADERS) $(WIRE_NONEXP_HEADERS)): wire/Makefile
 
 maintainer-clean: wire-maintainer-clean
 

--- a/wire/bolt12_wiregen.c
+++ b/wire/bolt12_wiregen.c
@@ -1562,4 +1562,4 @@ bool invoice_error_is_valid(const struct tlv_invoice_error *record, size_t *err_
 	return tlv_fields_valid(record->fields, err_index);
 }
 
-// SHA256STAMP:85a22376bfbb4d4b5c1104ae7823b477443ac693db9b2ee53c16b777b74f7d2a
+// SHA256STAMP:73fe08a636a01319cb6996244159998c63cf6bc93a01e1f6562fbb27ff58d0cb

--- a/wire/bolt12_wiregen.h
+++ b/wire/bolt12_wiregen.h
@@ -316,4 +316,4 @@ struct fallback_address *fromwire_fallback_address(const tal_t *ctx, const u8 **
 
 
 #endif /* LIGHTNING_WIRE_BOLT12_WIREGEN_H */
-// SHA256STAMP:85a22376bfbb4d4b5c1104ae7823b477443ac693db9b2ee53c16b777b74f7d2a
+// SHA256STAMP:73fe08a636a01319cb6996244159998c63cf6bc93a01e1f6562fbb27ff58d0cb

--- a/wire/common_wiregen.c
+++ b/wire/common_wiregen.c
@@ -100,4 +100,4 @@ bool fromwire_custommsg_out(const tal_t *ctx, const void *p, u8 **msg)
 	fromwire_u8_array(&cursor, &plen, *msg, msg_len);
 	return cursor != NULL;
 }
-// SHA256STAMP:a747ee0bc8a91c00e719bae883b505d6e7c85b33165a9156a571a0aa171a7256
+// SHA256STAMP:195e43668e6a1d3cc539759de8706f07824d31d8cdac50cd7d46978b1541c479

--- a/wire/common_wiregen.h
+++ b/wire/common_wiregen.h
@@ -41,4 +41,4 @@ bool fromwire_custommsg_out(const tal_t *ctx, const void *p, u8 **msg);
 
 
 #endif /* LIGHTNING_WIRE_COMMON_WIREGEN_H */
-// SHA256STAMP:a747ee0bc8a91c00e719bae883b505d6e7c85b33165a9156a571a0aa171a7256
+// SHA256STAMP:195e43668e6a1d3cc539759de8706f07824d31d8cdac50cd7d46978b1541c479

--- a/wire/onion_printgen.c
+++ b/wire/onion_printgen.c
@@ -859,4 +859,4 @@ void printonion_wire_tlv_message(const char *tlv_name, const u8 *msg) {
 		printwire_tlvs(tlv_name, &msg, &plen, print_tlvs_encmsg_tlvs, ARRAY_SIZE(print_tlvs_encmsg_tlvs));
 	}
 }
-// SHA256STAMP:c3ff8c1573066a7cae73a1e5ce1c8c5b5dd7e241129393e600eaf2a4fd6b9f3e
+// SHA256STAMP:71be5e63440a00cd787385b25d9d802d14c6e8c71a7003a260fa6b21f5ecea23

--- a/wire/onion_printgen.h
+++ b/wire/onion_printgen.h
@@ -58,4 +58,4 @@ void printwire_mpp_timeout(const char *fieldname, const u8 *cursor);
 
 void printwire_onionmsg_path(const char *fieldname, const u8 **cursor, size_t *plen);
 #endif /* LIGHTNING_WIRE_ONION_PRINTGEN_H */
-// SHA256STAMP:c3ff8c1573066a7cae73a1e5ce1c8c5b5dd7e241129393e600eaf2a4fd6b9f3e
+// SHA256STAMP:71be5e63440a00cd787385b25d9d802d14c6e8c71a7003a260fa6b21f5ecea23

--- a/wire/onion_wiregen.c
+++ b/wire/onion_wiregen.c
@@ -1026,4 +1026,4 @@ bool fromwire_mpp_timeout(const void *p)
 		return false;
 	return cursor != NULL;
 }
-// SHA256STAMP:c3ff8c1573066a7cae73a1e5ce1c8c5b5dd7e241129393e600eaf2a4fd6b9f3e
+// SHA256STAMP:71be5e63440a00cd787385b25d9d802d14c6e8c71a7003a260fa6b21f5ecea23

--- a/wire/onion_wiregen.h
+++ b/wire/onion_wiregen.h
@@ -317,4 +317,4 @@ bool fromwire_mpp_timeout(const void *p);
 
 
 #endif /* LIGHTNING_WIRE_ONION_WIREGEN_H */
-// SHA256STAMP:c3ff8c1573066a7cae73a1e5ce1c8c5b5dd7e241129393e600eaf2a4fd6b9f3e
+// SHA256STAMP:71be5e63440a00cd787385b25d9d802d14c6e8c71a7003a260fa6b21f5ecea23

--- a/wire/peer_printgen.c
+++ b/wire/peer_printgen.c
@@ -2935,4 +2935,4 @@ void printpeer_wire_tlv_message(const char *tlv_name, const u8 *msg) {
 		printwire_tlvs(tlv_name, &msg, &plen, print_tlvs_onion_message_tlvs, ARRAY_SIZE(print_tlvs_onion_message_tlvs));
 	}
 }
-// SHA256STAMP:3ecafff6be37e4049f121dcd6816aada2818fc7c02099372d1358d1b5b9da1ca
+// SHA256STAMP:13b9d519f8dde4c4d6a6995a2961d9d6ef810cc9f81d3ab1bd054da4c383ffe0

--- a/wire/peer_printgen.h
+++ b/wire/peer_printgen.h
@@ -96,4 +96,4 @@ void printwire_channel_update_checksums(const char *fieldname, const u8 **cursor
 void printwire_channel_update_timestamps(const char *fieldname, const u8 **cursor, size_t *plen);
 void printwire_witness_stack(const char *fieldname, const u8 **cursor, size_t *plen);
 #endif /* LIGHTNING_WIRE_PEER_PRINTGEN_H */
-// SHA256STAMP:3ecafff6be37e4049f121dcd6816aada2818fc7c02099372d1358d1b5b9da1ca
+// SHA256STAMP:13b9d519f8dde4c4d6a6995a2961d9d6ef810cc9f81d3ab1bd054da4c383ffe0

--- a/wire/peer_wiregen.c
+++ b/wire/peer_wiregen.c
@@ -2330,4 +2330,4 @@ bool fromwire_channel_update_option_channel_htlc_max(const void *p, secp256k1_ec
  	*htlc_maximum_msat = fromwire_amount_msat(&cursor, &plen);
 	return cursor != NULL;
 }
-// SHA256STAMP:3ecafff6be37e4049f121dcd6816aada2818fc7c02099372d1358d1b5b9da1ca
+// SHA256STAMP:13b9d519f8dde4c4d6a6995a2961d9d6ef810cc9f81d3ab1bd054da4c383ffe0

--- a/wire/peer_wiregen.h
+++ b/wire/peer_wiregen.h
@@ -859,4 +859,4 @@ bool fromwire_channel_update_option_channel_htlc_max(const void *p, secp256k1_ec
 
 
 #endif /* LIGHTNING_WIRE_PEER_WIREGEN_H */
-// SHA256STAMP:3ecafff6be37e4049f121dcd6816aada2818fc7c02099372d1358d1b5b9da1ca
+// SHA256STAMP:13b9d519f8dde4c4d6a6995a2961d9d6ef810cc9f81d3ab1bd054da4c383ffe0

--- a/wire/test/Makefile
+++ b/wire/test/Makefile
@@ -17,7 +17,9 @@ WIRE_TEST_COMMON_OBJS :=		\
 # run-tlvstream.c needs to reach into bitcoin/pubkey for SUPERVERBOSE
 $(WIRE_TEST_PROGRAMS): $(WIRE_TEST_COMMON_OBJS) $(filter-out bitcoin/pubkey.o,$(BITCOIN_OBJS))
 
-$(WIRE_TEST_OBJS): $(WIRE_HEADERS) $(WIRE_SRC) $(WIRE_PRINT_SRC)
+# We put a dependency on non-exp sources here, so they get built even if
+# we're EXPERIMENTAL_FEATURES.
+$(WIRE_TEST_OBJS): $(WIRE_HEADERS) $(WIRE_SRC) $(WIRE_PRINT_SRC) $(WIRE_NONEXP_SRC)
 
 wire-tests: $(WIRE_TEST_PROGRAMS:%=unittest/%)
 


### PR DESCRIPTION
I wasn't regenerating these when I changed dependencies, because I was
configured with --enable-experimental-features.  Putting them in
ALL_C_HEADERS and ALL_C_SOURCES means they'll be regenerated, even
though nothing depends on them.

Changelog-None