### PR TITLE
lightning/pay: don't crash when trying to send payment down unconfirmed channel

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1000,7 +1000,7 @@ send_payment_core(struct lightningd *ld,
 		return offer_err;
 
 	channel = active_channel_by_id(ld, &first_hop->node_id, NULL);
-	if (!channel) {
+	if (!channel || !channel_can_add_htlc(channel)) {
 		struct json_stream *data
 			= json_stream_fail(cmd, PAY_TRY_OTHER_ROUTE,
 					   "No connection to first "


### PR DESCRIPTION
An "active" channel may still be CHANNELD_AWAITING_LOCKIN, so have ->scid NULL.

You can only trigger this by trying to sendpay to the node using a
manual route, since routing would never use such a channel.

```
lightningd: FATAL SIGNAL 11 (version v0.10.0-319-g81cbc20-modded)
0x55e79d194e17 send_backtrace
	common/daemon.c:39
0x55e79d194ec1 crashdump
	common/daemon.c:52
0x7fce2d79920f ???
	???:0
0x7fce2d8e16f7 ???
	???:0
0x55e79d2019eb tal_dup_
	ccan/ccan/tal/tal.c:801
0x55e79d14e1d9 immediate_routing_failure
	lightningd/pay.c:365
0x55e79d14fe91 send_payment_core
	lightningd/pay.c:1022
0x55e79d150995 send_payment
	lightningd/pay.c:1180
0x55e79d151975 json_sendpay
	lightningd/pay.c:1462
```

Changelog-None