### PR TITLE
plugins/bcli: fix uninitialized variable.

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -859,6 +859,8 @@ static const char *init(struct plugin *p, const char *buffer UNUSED,
 	/* Usually we fake up fees in regtest */
 	if (streq(chainparams->network_name, "regtest"))
 		bitcoind->fake_fees = IFDEV(!bitcoind->no_fake_fees, true);
+	else
+		bitcoind->fake_fees = false;
 
 	plugin_log(p, LOG_INFORM,
 		   "bitcoin-cli initialized and connected to bitcoind.");


### PR DESCRIPTION
We didn't set this to false on non-regtest!

Changelog-None

```
==198363== Conditional jump or move depends on uninitialised value(s)
==198363==    at 0x10EF88: estimatefees_parse_feerate (bcli.c:443)
==198363==    by 0x10F3BF: estimatefees_second_step (bcli.c:550)
==198363==    by 0x10E720: bcli_finished (bcli.c:258)
==198363==    by 0x1438A7: destroy_conn (poll.c:244)
==198363==    by 0x1438CB: destroy_conn_close_fd (poll.c:250)
==198363==    by 0x151A7A: notify (tal.c:240)
==198363==    by 0x151F91: del_tree (tal.c:402)
==198363==    by 0x15232D: tal_free (tal.c:486)
==198363==    by 0x141EB8: io_close (io.c:450)
==198363==    by 0x14400B: io_loop (poll.c:449)
==198363==    by 0x114BB0: plugin_main (libplugin.c:1414)
==198363==    by 0x1105C4: main (bcli.c:973)
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>