### PR TITLE
keysend: Add routehints argument to the keysend command

### DIFF
--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -3,6 +3,7 @@
 #define LIGHTNING_COMMON_JSON_TOK_H
 #include "config.h"
 #include <ccan/short_types/short_types.h>
+#include <common/bolt11.h>
 #include <common/json.h>
 #include <common/node_id.h>
 #include <common/sphinx.h>
@@ -194,4 +195,13 @@ struct command_result *param_extra_tlvs(struct command *cmd, const char *name,
 					const char *buffer,
 					const jsmntok_t *tok,
 					struct tlv_field **fields);
+
+struct command_result *param_routehint(struct command *cmd, const char *name,
+				       const char *buffer, const jsmntok_t *tok,
+				       struct route_info **ri);
+
+struct command_result *
+param_routehint_array(struct command *cmd, const char *name, const char *buffer,
+		      const jsmntok_t *tok, struct route_info ***ris);
+
 #endif /* LIGHTNING_COMMON_JSON_TOK_H */

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -49,6 +49,10 @@ bool fromwire_tlv(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
 bool json_to_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			struct channel_id *cid UNNEEDED)
 { fprintf(stderr, "json_to_channel_id called!\n"); abort(); }
+/* Generated stub for json_to_msat */
+bool json_to_msat(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+		  struct amount_msat *msat UNNEEDED)
+{ fprintf(stderr, "json_to_msat called!\n"); abort(); }
 /* Generated stub for json_to_node_id */
 bool json_to_node_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			       struct node_id *id UNNEEDED)

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1484,8 +1484,12 @@ static void add_config(struct lightningd *ld,
 			 * --plugin for each one, so ignore these */
 #if EXPERIMENTAL_FEATURES
 		} else if (opt->cb_arg == (void *)opt_set_accept_extra_tlv_types) {
-#endif
                         /* TODO Actually print the option */
+#endif
+#if DEVELOPER
+		} else if (strstarts(name, "dev-")) {
+			/* Ignore dev settings */
+#endif
 		} else {
 			/* Insert more decodes here! */
 			abort();

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -130,11 +130,12 @@ static const char *init(struct plugin *p, const char *buf UNUSED,
 	return NULL;
 }
 
-struct payment_modifier *pay_mods[8] = {
+struct payment_modifier *pay_mods[] = {
     &keysend_pay_mod,
     &local_channel_hints_pay_mod,
     &directpay_pay_mod,
     &shadowroute_pay_mod,
+    &routehints_pay_mod,
     &exemptfee_pay_mod,
     &waitblockheight_pay_mod,
     &retry_pay_mod,
@@ -151,6 +152,7 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 	u64 *maxfee_pct_millionths;
 	u32 *maxdelay;
 	unsigned int *retryfor;
+	struct route_info **hints;
 #if EXPERIMENTAL_FEATURES
 	struct tlv_field *extra_fields;
 #endif
@@ -171,6 +173,7 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 #if DEVELOPER
 		   p_opt_def("use_shadow", param_bool, &use_shadow, true),
 #endif
+		   p_opt("routehints", param_routehint_array, &hints),
 #if EXPERIMENTAL_FEATURES
 		   p_opt("extratlvs", param_extra_tlvs, &extra_fields),
 #endif
@@ -185,7 +188,7 @@ static struct command_result *json_keysend(struct command *cmd, const char *buf,
 	p->destination_has_tlv = true;
 	p->payment_secret = NULL;
 	p->amount = *msat;
-	p->routes = NULL;
+	p->routes = tal_steal(p, hints);
 	// 22 is the Rust-Lightning default and the highest minimum we know of.
 	p->min_final_cltv_expiry = 22;
 	p->features = NULL;

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3174,11 +3174,57 @@ def test_keysend_extra_tlvs(node_factory):
     assert(l2.daemon.is_in_log(r'plugin-sphinx-receiver.py.*extratlvs.*133773310.*feedc0de'))
 
     inv = invs[0]
-    print(inv)
     assert(inv['msatoshi_received'] >= amt)
 
     # Now try again with the TLV type in extra_tlvs as string:
     l1.rpc.keysend(l2.info['id'], amt, extratlvs={133773310: 'FEEDC0DE'})
+
+
+def test_keysend_routehint(node_factory):
+    """Test whether we can deliver a keysend by adding a routehint on the cli
+    """
+    amt = 10000
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=True)
+    l3 = node_factory.get_node()
+    l2.connect(l3)
+    l2.fundchannel(l3, announce_channel=False)
+
+    dest = l3.info['id']
+    routehints = [
+        [
+            {
+                'scid': l3.rpc.listpeers()['peers'][0]['channels'][0]['short_channel_id'],
+                'id': l2.info['id'],
+                'feebase': '1msat',
+                'feeprop': 10,
+                'expirydelta': 9,
+            }
+        ],
+        [  # Dummy
+            {
+                'scid': '1x2x3',
+                'id': '02' * 33,
+                'feebase': 1,
+                'feeprop': 1,
+                'expirydelta': 9,
+            },
+        ],
+    ]
+
+    # Without any hints we should fail:
+    with pytest.raises(RpcError):
+        l1.rpc.call("keysend", payload={'destination': dest, 'msatoshi': amt})
+
+    # We should also fail with only non-working hints:
+    with pytest.raises(RpcError):
+        l1.rpc.call("keysend", payload={'destination': dest, 'msatoshi': amt, 'routehints': routehints[1:]})
+
+    l1.rpc.call("keysend", payload={'destination': dest, 'msatoshi': amt, 'routehints': routehints})
+    invs = l3.rpc.listinvoices()['invoices']
+    assert(len(invs) == 1)
+
+    inv = invs[0]
+    assert(inv['msatoshi_received'] >= amt)
 
 
 def test_invalid_onion_channel_update(node_factory):


### PR DESCRIPTION
So far we could not reach non-publicly reachable nodes with the
keysend command since we couldn't compute a route to them. With this
change we can add some routehints that we may have gotten from an
address book or a previous invoice, and make it more likely that we
can reach the destination.

Builds on top of #4610 to avoid rebase conflicts, but I can separate them out if that's preferred. This PR consists only of the last 3 commits.