### PR TITLE
feat: listchannels filter by destination

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -844,13 +844,15 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("invoice", payload)
 
-    def listchannels(self, short_channel_id=None, source=None):
+    def listchannels(self, short_channel_id=None, source=None, destination=None):
         """
-        Show all known channels, accept optional {short_channel_id} or {source}.
+        Show all known channels or filter by optional
+        {short_channel_id}, {source} or {destination}.
         """
         payload = {
             "short_channel_id": short_channel_id,
-            "source": source
+            "source": source,
+            "destination": destination
         }
         return self.call("listchannels", payload)
 

--- a/doc/lightning-listchannels.7
+++ b/doc/lightning-listchannels.7
@@ -3,7 +3,7 @@
 lightning-listchannels - Command to query active lightning channels in the entire network
 .SH SYNOPSIS
 
-\fBlistchannels\fR [\fIshort_channel_id\fR] [\fIsource\fR]
+\fBlistchannels\fR [\fIshort_channel_id\fR] [\fIsource\fR] [\fIdestination\fR]
 
 .SH DESCRIPTION
 
@@ -20,7 +20,12 @@ If \fIsource\fR is a node id, then only channels leading from that node id
 are returned\.
 
 
-If neither is supplied, data on all lightning channels known to this
+If \fIdestination\fR is a node id, then only channels leading to that node id
+are returned\.
+
+
+Only one of \fIshort_channgel_id\fR, \fIsource\fR or \fIdestination\fR can be supplied\.
+If nothing is supplied, data on all lightning channels known to this
 node, are returned\. These can be local channels or public channels
 broadcast on the gossip network\.
 
@@ -60,8 +65,8 @@ On success, an object containing \fBchannels\fR is returned\.  It is an array of
 
 .RE
 
-If \fIshort_channel_id\fR or \fIsource\fR is supplied and no matching channels
-are found, a "channels" object with an empty list is returned\.
+If one of \fIshort_channel_id\fR, \fIsource\fR or \fIdestination\fR is supplied and no
+matching channels are found, a "channels" object with an empty list is returned\.
 
 
 On error the returned object will contain \fBcode\fR and \fBmessage\fR properties,
@@ -93,4 +98,4 @@ BOLT #7:
 \fIhttps://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md\fR
 
 .RE
-\" SHA256STAMP:e228d4a2553ac8fc052fd0c3acfac32cdce6f0cfd37f1bb238a87de2fa99e553
+\" SHA256STAMP:b53e67e29b3ac9efe5157e8656ea5af5b2e418559655cc6f39fa99875f52bdc0

--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -4,7 +4,7 @@ lightning-listchannels -- Command to query active lightning channels in the enti
 SYNOPSIS
 --------
 
-**listchannels** \[*short\_channel\_id*\] \[*source*\]
+**listchannels** \[*short\_channel\_id*\] \[*source*\] \[*destination*\]
 
 DESCRIPTION
 -----------
@@ -19,7 +19,11 @@ matching *short\_channel\_id* are returned.  Otherwise, it must be null.
 If *source* is a node id, then only channels leading from that node id
 are returned.
 
-If neither is supplied, data on all lightning channels known to this
+If *destination* is a node id, then only channels leading to that node id
+are returned.
+
+Only one of *short\_channgel\_id*, *source* or *destination* can be supplied.
+If nothing is supplied, data on all lightning channels known to this
 node, are returned. These can be local channels or public channels
 broadcast on the gossip network.
 
@@ -44,8 +48,8 @@ On success, an object containing **channels** is returned.  It is an array of ob
 - **htlc_maximum_msat** (msat, optional): The largest payment *source* will allow via this channel
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
-If *short\_channel\_id* or *source* is supplied and no matching channels
-are found, a "channels" object with an empty list is returned.
+If one of *short\_channel\_id*, *source* or *destination* is supplied and no
+matching channels are found, a "channels" object with an empty list is returned.
 
 On error the returned object will contain `code` and `message` properties,
 with `code` being one of the following:

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -281,7 +281,18 @@ def test_gossip_jsonrpc(node_factory):
     assert only_one(channels1)['destination'] == l2.info['id']
     assert channels1 == channels2
 
-    l2.rpc.listchannels()['channels']
+    # Test listchannels-by-destination
+    channels1 = l1.rpc.listchannels(destination=l1.info['id'])['channels']
+    channels2 = l2.rpc.listchannels(destination=l1.info['id'])['channels']
+    assert only_one(channels1)['destination'] == l1.info['id']
+    assert only_one(channels1)['source'] == l2.info['id']
+    assert channels1 == channels2
+
+    # Test only one of short_channel_id, source or destination can be supplied
+    with pytest.raises(RpcError, match=r"Can only specify one of.*"):
+        l1.rpc.listchannels(source=l1.info['id'], destination=l2.info['id'])
+    with pytest.raises(RpcError, match=r"Can only specify one of.*"):
+        l1.rpc.listchannels(short_channel_id="1x1x1", source=l2.info['id'])
 
     # Now proceed to funding-depth and do a full gossip round
     l1.bitcoin.generate_block(5)


### PR DESCRIPTION
When writing feeadjuster https://github.com/lightningd/plugins/pull/256 I figured there is a usecase for having `listchannels` be queried also by `destination`

Adds feature, doc and test.