### PR TITLE
plugins/bcli: don't try to parse stderr as JSON.

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -302,7 +302,7 @@ static void next_bcli(enum bitcoind_prio prio)
 	if (!bcli)
 		return;
 
-	bcli->pid = pipecmdarr(&in, &bcli->fd, &bcli->fd,
+	bcli->pid = pipecmdarr(&in, &bcli->fd, &pipecmd_preserve,
 			       cast_const2(char **, bcli->args));
 
 	if (bitcoind->rpcpass)


### PR DESCRIPTION
Just let it go through to the main stderr output.

Fixes: #4495
Changelog-Changed: plugins: bcli will not try to parse bitcoin-cli stderr.
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>