### PR TITLE
fix: remove spammy debug statements from getroute

### DIFF
--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -77,17 +77,11 @@ static bool can_carry(const struct gossmap *map,
 
 	/* First do generic check */
 	if (!route_can_carry(map, c, dir, amount, NULL)) {
-		plugin_log(plugin, LOG_DBG, "cannot carry %s across %p",
-			   type_to_string(tmpctx, struct amount_msat, &amount),
-			   c);
 		return false;
 	}
 
 	/* Now check exclusions.  Premature optimization: */
 	if (!tal_count(excludes)) {
-		plugin_log(plugin, LOG_DBG, "CAN carry %s across %p",
-			   type_to_string(tmpctx, struct amount_msat, &amount),
-			   c);
 		return true;
 	}
 


### PR DESCRIPTION
This simply removes the two spammy debug log statements introduced by e81e640
Turns out that these statements were slowing down `getroute` even on `log-level=info`.

Fixes https://github.com/ElementsProject/lightning/issues/4617

Changelog-None