### PR TITLE
keysend: Set a small final CLTV in the backfilled invoice

### DIFF
--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -399,6 +399,7 @@ static struct command_result *htlc_accepted_call(struct command *cmd,
 	json_add_string(req->js, "label", ki->label);
 	json_add_string(req->js, "description", "Spontaneous incoming payment through keysend");
 	json_add_preimage(req->js, "preimage", &ki->payment_preimage);
+	json_add_num(req->js, "cltv", 6);
 
 	return send_outreq(cmd->plugin, req);
 }

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3070,6 +3070,11 @@ def test_keysend(node_factory):
     print(inv)
     assert(inv['msatoshi_received'] >= amt)
 
+    # The invoice needs to have a low CLTV since otherwise we'd reject
+    # some keysends from older nodes.
+    details = l1.rpc.decode(inv['bolt11'])
+    assert(details['min_final_cltv_expiry'] == 6)
+
     # Now send a direct one instead from l1 to l2
     l1.rpc.keysend(l2.info['id'], amt)
     invs = l2.rpc.listinvoices()['invoices']


### PR DESCRIPTION
When backfilling an invoice in the DB to match the keysend we were not setting an expected final CLTV which could lead to some sender implementations to use a smaller CLTV for that hop, making the keysend as a whole fail. This was exacerbated by the recent bump in our default `min_final_cltv_delta` which made most keysends fail.

This explicitly sets a very low CLTV delta so we accept the payments again.

Changelog-None: The `min_final_cltv_delta` bump was not released publicly yet.