### PR TITLE
pytest: fix bad gossip flake.

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1657,13 +1657,18 @@ def test_onchain_middleman_their_unilateral_in(node_factory, bitcoind):
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
 
-    l2.fundchannel(l1, 10**6)
+    c12, _ = l2.fundchannel(l1, 10**6)
     c23, _ = l2.fundchannel(l3, 10**6)
     channel_id = first_channel_id(l1, l2)
 
     # Make sure routes finalized.
     bitcoind.generate_block(5)
     l1.wait_channel_active(c23)
+
+    # Make sure l3 sees gossip for channel now; it can get upset
+    # and give bad gossip msg if channel is closed before it sees
+    # node announcement.
+    wait_for(lambda: l3.rpc.listchannels(c12)['channels'] != [])
 
     # Give l1 some money to play with.
     l2.pay(l1, 2 * 10**8)


### PR DESCRIPTION
If l3 is too slow, it can get channel_announcement after channel
is closed, so it gets upset at the node_announcement which follows:

   022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-gossipd: Updated pending announce with update 103x1x1/1
   022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-gossipd: channel_announcement: no unspent txout 103x1x1
   022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-gossipd: Bad gossip order: WIRE_NODE_ANNOUNCEMENT before announcement 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>