### PR TITLE
funderupdate: add documentation, update some params

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,6 +28,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-fundchannel_start.7 \
 	doc/lightning-fundchannel_complete.7 \
 	doc/lightning-fundchannel_cancel.7 \
+	doc/lightning-funderupdate.7 \
 	doc/lightning-fundpsbt.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-getsharedsecret.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,6 +51,7 @@ c-lightning Documentation
    lightning-fundchannel_cancel <lightning-fundchannel_cancel.7.md>
    lightning-fundchannel_complete <lightning-fundchannel_complete.7.md>
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
+   lightning-funderupdate <lightning-funderupdate.7.md>
    lightning-fundpsbt <lightning-fundpsbt.7.md>
    lightning-getinfo <lightning-getinfo.7.md>
    lightning-getlog <lightning-getlog.7.md>

--- a/doc/lightning-funderupdate.7
+++ b/doc/lightning-funderupdate.7
@@ -1,0 +1,185 @@
+.TH "LIGHTNING-FUNDERUPDATE" "7" "" "" "lightning-funderupdate"
+.SH NAME
+lightning-funderupdate - Command for adjusting node funding v2 channels
+.SH SYNOPSIS
+
+\fBfunderupdate\fR [\fIpolicy\fR] [\fIpolicy_mod\fR] [\fIleases_only\fR] [\fImin_their_funding_msat\fR] [\fImax_their_funding_msat\fR] [\fIper_channel_min_msat\fR] [\fIper_channel_max_msat\fR] [\fIreserve_tank_msat\fR] [\fIfuzz_percent\fR] [\fIfund_probability\fR] [\fIlease_fee_base_msat\fR] [\fIlease_fee_basis\fR] [\fIfunding_weight\fR] [\fIchannel_fee_max_base_msat\fR] [\fIchannel_fee_max_proportional_thousandths\fR] [\fIcompact_lease\fR]
+
+
+NOTE: Must have --experimental-dual-fund enabled for these settings to take effect\.
+
+.SH DESCRIPTION
+
+For channel open requests using
+
+
+\fIpolicy\fR, \fIpolicy_mod\fR is the policy the funder plugin will use to decide
+how much capital to commit to a v2 open channel request\. There are three
+policy options, detailed below: \fBmatch\fR, \fBavailable\fR, and \fBfixed\fR\.
+The \fIpolicy_mod\fR is the number or 'modification' to apply to the policy\.
+Default is (fixed, 0sats)\.
+
+.RS
+.IP \[bu]
+\fBmatch\fR -- Contribute \fIpolicy_mod\fR percent of their requested funds\.
+ Valid \fIpolicy_mod\fR values are 0 to 200\. If this is a channel lease
+ request, we match based on their requested funds\. If it is not a
+ channel lease request (and \fIlease_only\fR is false), then we match
+ their funding amount\. Note: any lease match less than 100 will
+ likely fail, as clients will not accept a lease less than their request\.
+.IP \[bu]
+\fBavailable\fR -- Contribute \fIpolicy_mod\fR percent of our available
+ node wallet funds\. Valid \fIpolicy_mod\fR values are 0 to 100\.
+.IP \[bu]
+\fBfixed\fR -- Contributes a fixed  \fIpolicy_mod\fR sats to v2 channel open requests\.
+
+.RE
+
+Note: to maximize channel leases, best policy setting is (match, 100)\.
+
+
+\fIleases_only\fR will only contribute funds to \fBoption_will_fund\fR requests
+which pay to lease funds\. Defaults to false, will fund any v2 open request
+using \fIpolicy\fR even if it's they're not seeking to lease funds\. Note that
+\fBoption_will_fund\fR commits funds for 4032 blocks (~1mo)\. Must also set
+\fIlease_fee_base_msat\fR, \fIlease_fee_basis\fR, \fIfunding_weight\fR,
+\fIchannel_fee_max_base_msat\fR, and \fIchannel_fee_max_proportional_thousandths\fR
+to advertise available channel leases\.
+
+
+\fImin_their_funding_msat\fR is the minimum funding sats that we require in order
+to activate our contribution policy to the v2 open\.  Defaults to 10k sats\.
+
+
+\fImax_their_funding_msat\fR is the maximum funding sats that we will consider
+to activate our contribution policy to the v2 open\. Any channel open above this
+will not be funded\.  Defaults to no max (\fBUINT_MAX\fR)\.
+
+
+\fIper_channel_min_msat\fR is the minimum amount that we will contribute to a
+channel open\. Defaults to 10k sats\.
+
+
+\fIper_channel_max_msat\fR is the maximum amount that we will contribute to a
+channel open\. Defaults to no max (\fBUINT_MAX\fR)\.
+
+
+\fIreserve_tank_msat\fR is the amount of sats to leave available in the node wallet\.
+Defaults to zero sats\.
+
+
+\fIfuzz_percent\fR is a percentage to fuzz the resulting contribution amount by\.
+Valid values are 0 to 100\. Note that turning this on with (match, 100) policy
+will randomly fail \fBoption_will_fund\fR leases, as most clients
+expect an exact or greater match of their \fBrequested_funds\fR\.
+Defaults to 0% (no fuzz)\.
+
+
+\fIfund_probability\fR is the percent of v2 channel open requests to apply our
+policy to\. Valid values are integers from 0 (fund 0% of all open requests)
+to 100 (fund every request)\. Useful for randomizing opens that receive funds\.
+Defaults to 100\.
+
+
+Setting any of the next 5 options will activate channel leases for this node,
+and advertise these values via the lightning gossip network\. If any one is set,
+the other values will be the default\.
+
+
+\fIlease_fee_base_msat\fR is the flat fee for a channel lease\. Node will
+receive this much extra added to their channel balance, paid by the opening
+node\. Defaults to 2k sats\. Note that the minimum is 1sat\.
+
+
+\fIlease_fee_basis\fR is a basis fee that's calculated as 1/10k of the total
+requested funds the peer is asking for\. Node will receive the total of
+\fIlease_fee_basis\fR times requested funds / 10k satoshis added to their channel
+balance, paid by the opening node\.  Default is 0\.65% (65 basis points)
+
+
+\fIfunding_weight\fR is used to calculate the fee the peer will compensate your
+node for its contributing inputs to the funding transaction\. The total fee
+is calculated as the \fBopen_channel2\fR\.\fBfunding_feerate_perkw\fR times this
+\fIfunding_weight\fR divided by 1000\. Node will have this funding fee added
+to their channel balance, paid by the opening node\.  Default is
+2 inputs + 1 P2WPKH output\.
+
+
+\fIchannel_fee_max_base_msat\fR is a commitment to a maximum
+\fBchannel_fee_base_msat\fR that your node will charge for routing payments
+over this leased channel during the lease duration\.  Default is 5k sats\.
+
+
+\fIchannel_fee_max_proportional_thousandths\fR is a commitment to a maximum
+\fBchannel_fee_proportional_millionths\fR that your node will charge for
+routing payments over this leased channel during the lease duration\.
+Note that it's denominated in 'thousandths'\. A setting of \fB1\fR is equal
+to 1k ppm; \fB5\fR is 5k ppm, etc\.  Default is 100 (100k ppm)\.
+
+
+\fIcompact_lease\fR is a compact description of the channel lease params\. When
+opening a channel, passed in to \fBfundchannel\fR to indicate the terms we
+expect from the peer\.
+
+.SH RETURN VALUE
+
+On success, an object is returned, containing:
+
+.RS
+.IP \[bu]
+\fBsummary\fR (string): Summary of the current funding policy e\.g\. (match 100)
+.IP \[bu]
+\fBpolicy\fR (string): Policy funder plugin will use to decide how much captial to commit to a v2 open channel request (one of "match", "available", "fixed")
+.IP \[bu]
+\fBpolicy_mod\fR (u32): The \fIpolicy_mod\fR is the number or 'modification' to apply to the policy\.
+.IP \[bu]
+\fBleases_only\fR (boolean): Only contribute funds to \fBoption_will_fund\fR lease requests\.
+.IP \[bu]
+\fBmin_their_funding_msat\fR (msat): The minimum funding sats that we require from peer to activate our funding policy\.
+.IP \[bu]
+\fBmax_their_funding_msat\fR (msat): The maximum funding sats that we'll allow from peer to activate our funding policy\.
+.IP \[bu]
+\fBper_channel_min_msat\fR (msat): The minimum amount that we will fund a channel open with\.
+.IP \[bu]
+\fBper_channel_max_msat\fR (msat): The maximum amount that we will fund a channel open with\.
+.IP \[bu]
+\fBreserve_tank_msat\fR (msat): Amount of sats to leave available in the node wallet\.
+.IP \[bu]
+\fBfuzz_percent\fR (u32): Percentage to fuzz our funding amount by\.
+.IP \[bu]
+\fBfund_probability\fR (u32): Percent of opens to consider funding\. 100 means we'll consider funding every requested open channel request\.
+.IP \[bu]
+\fBlease_fee_base_msat\fR (msat, optional): Flat fee to charge for a channel lease\.
+.IP \[bu]
+\fBlease_fee_basis\fR (u32, optional): Proportional fee to charge for a channel lease, calculated as 1/10,000th of requested funds\.
+.IP \[bu]
+\fBfunding_weight\fR (u32, optional): Transaction weight the channel opener will pay us for a leased funding transaction\.
+.IP \[bu]
+\fBchannel_fee_max_base_msat\fR (msat, optional): Maximum channel_fee_base_msat we'll charge for routing funds leased on this channel\.
+.IP \[bu]
+\fBchannel_fee_max_proportional_thousandths\fR (u32, optional): Maximum channel_fee_proportional_millitionths we'll charge for routing funds leased on this channel, in thousandths\.
+.IP \[bu]
+\fBcompact_lease\fR (hex, optional): Compact description of the channel lease parameters\.
+
+.RE
+
+The following error code may occur:
+
+.RS
+.IP \[bu]
+-32602: If the given parameters are invalid\.
+
+.RE
+.SH AUTHOR
+
+@niftynei \fI<niftynei@gmail.com\fR> is mainly responsible\.
+
+.SH SEE ALSO
+
+\fBlightning-fundchannel\fR(7), \fBlightning-listfunds\fR(7)
+
+.SH RESOURCES
+
+Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
+
+\" SHA256STAMP:338d5b9547c47d3fa1ef7ed7a2985d190bba3f1bd911057cda8aa0d0f3ae0cea

--- a/doc/lightning-funderupdate.7.md
+++ b/doc/lightning-funderupdate.7.md
@@ -1,0 +1,148 @@
+lightning-funderupdate -- Command for adjusting node funding v2 channels
+========================================================================
+
+SYNOPSIS
+--------
+
+**funderupdate** \[*policy*\] \[*policy_mod*\] \[*leases_only*\] \[*min_their_funding_msat*\] \[*max_their_funding_msat*\] \[*per_channel_min_msat*\] \[*per_channel_max_msat*\] \[*reserve_tank_msat*\] \[*fuzz_percent*\] \[*fund_probability*\] \[*lease_fee_base_msat*\] \[*lease_fee_basis*\] \[*funding_weight*\] \[*channel_fee_max_base_msat*\] \[*channel_fee_max_proportional_thousandths*\] \[*compact_lease*\]
+
+NOTE: Must have --experimental-dual-fund enabled for these settings to take effect.
+
+DESCRIPTION
+-----------
+
+For channel open requests using
+
+
+*policy*, *policy_mod* is the policy the funder plugin will use to decide
+how much capital to commit to a v2 open channel request. There are three
+policy options, detailed below: `match`, `available`, and `fixed`.
+The *policy_mod* is the number or 'modification' to apply to the policy.
+Default is (fixed, 0sats).
+
+* `match` -- Contribute *policy_mod* percent of their requested funds.
+   Valid *policy_mod* values are 0 to 200. If this is a channel lease
+   request, we match based on their requested funds. If it is not a
+   channel lease request (and *lease_only* is false), then we match
+   their funding amount. Note: any lease match less than 100 will
+   likely fail, as clients will not accept a lease less than their request.
+* `available` -- Contribute *policy_mod* percent of our available
+   node wallet funds. Valid *policy_mod* values are 0 to 100.
+* `fixed` -- Contributes a fixed  *policy_mod* sats to v2 channel open requests.
+
+Note: to maximize channel leases, best policy setting is (match, 100).
+
+*leases_only* will only contribute funds to `option_will_fund` requests
+which pay to lease funds. Defaults to false, will fund any v2 open request
+using *policy* even if it's they're not seeking to lease funds. Note that
+`option_will_fund` commits funds for 4032 blocks (~1mo). Must also set
+*lease_fee_base_msat*, *lease_fee_basis*, *funding_weight*,
+*channel_fee_max_base_msat*, and *channel_fee_max_proportional_thousandths*
+to advertise available channel leases.
+
+*min_their_funding_msat* is the minimum funding sats that we require in order
+to activate our contribution policy to the v2 open.  Defaults to 10k sats.
+
+*max_their_funding_msat* is the maximum funding sats that we will consider
+to activate our contribution policy to the v2 open. Any channel open above this
+will not be funded.  Defaults to no max (`UINT_MAX`).
+
+*per_channel_min_msat* is the minimum amount that we will contribute to a
+channel open. Defaults to 10k sats.
+
+*per_channel_max_msat* is the maximum amount that we will contribute to a
+channel open. Defaults to no max (`UINT_MAX`).
+
+*reserve_tank_msat* is the amount of sats to leave available in the node wallet.
+Defaults to zero sats.
+
+*fuzz_percent* is a percentage to fuzz the resulting contribution amount by.
+Valid values are 0 to 100. Note that turning this on with (match, 100) policy
+will randomly fail `option_will_fund` leases, as most clients
+expect an exact or greater match of their `requested_funds`.
+Defaults to 0% (no fuzz).
+
+*fund_probability* is the percent of v2 channel open requests to apply our
+policy to. Valid values are integers from 0 (fund 0% of all open requests)
+to 100 (fund every request). Useful for randomizing opens that receive funds.
+Defaults to 100.
+
+Setting any of the next 5 options will activate channel leases for this node,
+and advertise these values via the lightning gossip network. If any one is set,
+the other values will be the default.
+
+*lease_fee_base_msat* is the flat fee for a channel lease. Node will
+receive this much extra added to their channel balance, paid by the opening
+node. Defaults to 2k sats. Note that the minimum is 1sat.
+
+*lease_fee_basis* is a basis fee that's calculated as 1/10k of the total
+requested funds the peer is asking for. Node will receive the total of
+*lease_fee_basis* times requested funds / 10k satoshis added to their channel
+balance, paid by the opening node.  Default is 0.65% (65 basis points)
+
+*funding_weight* is used to calculate the fee the peer will compensate your
+node for its contributing inputs to the funding transaction. The total fee
+is calculated as the `open_channel2`.`funding_feerate_perkw` times this
+*funding_weight* divided by 1000. Node will have this funding fee added
+to their channel balance, paid by the opening node.  Default is
+2 inputs + 1 P2WPKH output.
+
+*channel_fee_max_base_msat* is a commitment to a maximum
+`channel_fee_base_msat` that your node will charge for routing payments
+over this leased channel during the lease duration.  Default is 5k sats.
+
+*channel_fee_max_proportional_thousandths* is a commitment to a maximum
+`channel_fee_proportional_millionths` that your node will charge for
+routing payments over this leased channel during the lease duration.
+Note that it's denominated in 'thousandths'. A setting of `1` is equal
+to 1k ppm; `5` is 5k ppm, etc.  Default is 100 (100k ppm).
+
+*compact_lease* is a compact description of the channel lease params. When
+opening a channel, passed in to `fundchannel` to indicate the terms we
+expect from the peer.
+
+RETURN VALUE
+------------
+
+[comment]: # (GENERATE-FROM-SCHEMA-START)
+On success, an object is returned, containing:
+- **summary** (string): Summary of the current funding policy e.g. (match 100)
+- **policy** (string): Policy funder plugin will use to decide how much captial to commit to a v2 open channel request (one of "match", "available", "fixed")
+- **policy_mod** (u32): The *policy_mod* is the number or 'modification' to apply to the policy.
+- **leases_only** (boolean): Only contribute funds to `option_will_fund` lease requests.
+- **min_their_funding_msat** (msat): The minimum funding sats that we require from peer to activate our funding policy.
+- **max_their_funding_msat** (msat): The maximum funding sats that we'll allow from peer to activate our funding policy.
+- **per_channel_min_msat** (msat): The minimum amount that we will fund a channel open with.
+- **per_channel_max_msat** (msat): The maximum amount that we will fund a channel open with.
+- **reserve_tank_msat** (msat): Amount of sats to leave available in the node wallet.
+- **fuzz_percent** (u32): Percentage to fuzz our funding amount by.
+- **fund_probability** (u32): Percent of opens to consider funding. 100 means we'll consider funding every requested open channel request.
+- **lease_fee_base_msat** (msat, optional): Flat fee to charge for a channel lease.
+- **lease_fee_basis** (u32, optional): Proportional fee to charge for a channel lease, calculated as 1/10,000th of requested funds.
+- **funding_weight** (u32, optional): Transaction weight the channel opener will pay us for a leased funding transaction.
+- **channel_fee_max_base_msat** (msat, optional): Maximum channel_fee_base_msat we'll charge for routing funds leased on this channel.
+- **channel_fee_max_proportional_thousandths** (u32, optional): Maximum channel_fee_proportional_millitionths we'll charge for routing funds leased on this channel, in thousandths.
+- **compact_lease** (hex, optional): Compact description of the channel lease parameters.
+[comment]: # (GENERATE-FROM-SCHEMA-END)
+
+The following error code may occur:
+
+- -32602: If the given parameters are invalid.
+
+AUTHOR
+------
+
+@niftynei <<niftynei@gmail.com>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-fundchannel(7), lightning-listfunds(7)
+
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>
+
+[comment]: # ( SHA256STAMP:e09e7cd45085dbcbf9a5ea556a413f004812995506703f91973c1d2671780c5b)

--- a/doc/schemas/funderupdate.schema.json
+++ b/doc/schemas/funderupdate.schema.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["summary", "policy", "policy_mod", "leases_only", "min_their_funding_msat", "max_their_funding_msat", "per_channel_min_msat", "per_channel_max_msat", "reserve_tank_msat", "fuzz_percent", "fund_probability"],
+    "properties": {
+	"summary": {
+	   "type": "string",
+	   "description": "Summary of the current funding policy e.g. (match 100)"
+         },
+        "policy": {
+            "type": "string",
+            "enum": [ "match", "available", "fixed" ],
+            "description": "Policy funder plugin will use to decide how much captial to commit to a v2 open channel request"
+        },
+	"policy_mod": {
+	    "type": "u32",
+	    "description": "The *policy_mod* is the number or 'modification' to apply to the policy."
+	},
+	"leases_only": {
+	    "type": "boolean",
+	    "description": "Only contribute funds to `option_will_fund` lease requests."
+	},
+	"min_their_funding_msat": {
+	    "type": "msat",
+	    "description": "The minimum funding sats that we require from peer to activate our funding policy."
+	},
+	"max_their_funding_msat": {
+	    "type": "msat",
+	    "description": "The maximum funding sats that we'll allow from peer to activate our funding policy."
+	},
+	"per_channel_min_msat": {
+	    "type": "msat",
+	    "description": "The minimum amount that we will fund a channel open with."
+	},
+	"per_channel_max_msat": {
+	    "type": "msat",
+	    "description": "The maximum amount that we will fund a channel open with."
+	},
+	"reserve_tank_msat": {
+	    "type": "msat",
+	    "description": "Amount of sats to leave available in the node wallet."
+	},
+	"fuzz_percent": {
+	    "type": "u32",
+	    "description": "Percentage to fuzz our funding amount by."
+	},
+	"fund_probability": {
+	    "type": "u32",
+	    "description": "Percent of opens to consider funding. 100 means we'll consider funding every requested open channel request."
+	},
+	"lease_fee_base_msat": {
+	    "type": "msat",
+	    "description": "Flat fee to charge for a channel lease."
+	},
+	"lease_fee_basis": {
+	    "type": "u32",
+	    "description": "Proportional fee to charge for a channel lease, calculated as 1/10,000th of requested funds."
+	},
+	"funding_weight": {
+	    "type": "u32",
+	    "description": "Transaction weight the channel opener will pay us for a leased funding transaction."
+	},
+	"channel_fee_max_base_msat": {
+	    "type": "msat",
+	    "description": "Maximum channel_fee_base_msat we'll charge for routing funds leased on this channel."
+	},
+	"channel_fee_max_proportional_thousandths": {
+	    "type": "u32",
+	    "description": "Maximum channel_fee_proportional_millitionths we'll charge for routing funds leased on this channel, in thousandths."
+	},
+	"compact_lease": {
+	    "type": "hex",
+	    "description": "Compact description of the channel lease parameters."
+	}
+    }
+}

--- a/plugins/funder.c
+++ b/plugins/funder.c
@@ -762,15 +762,16 @@ static void json_add_policy(struct json_stream *stream,
 	json_add_string(stream, "policy",
 			funder_opt_name(policy->opt));
 	json_add_num(stream, "policy_mod", policy->mod);
-	json_add_amount_sat_only(stream, "min_their_funding",
+	json_add_bool(stream, "leases_only", policy->leases_only);
+	json_add_amount_sat_only(stream, "min_their_funding_msat",
 				 policy->min_their_funding);
-	json_add_amount_sat_only(stream, "max_their_funding",
+	json_add_amount_sat_only(stream, "max_their_funding_msat",
 				 policy->max_their_funding);
-	json_add_amount_sat_only(stream, "per_channel_min",
+	json_add_amount_sat_only(stream, "per_channel_min_msat",
 				 policy->per_channel_min);
-	json_add_amount_sat_only(stream, "per_channel_max",
+	json_add_amount_sat_only(stream, "per_channel_max_msat",
 				 policy->per_channel_max);
-	json_add_amount_sat_only(stream, "reserve_tank",
+	json_add_amount_sat_only(stream, "reserve_tank_msat",
 				 policy->reserve_tank);
 	json_add_num(stream, "fuzz_percent", policy->fuzz_factor);
 	json_add_num(stream, "fund_probability", policy->fund_probability);
@@ -921,19 +922,19 @@ json_funderupdate(struct command *cmd,
 			     current_policy->mod),
 		   p_opt_def("leases_only", param_bool, &leases_only,
 			     current_policy->leases_only),
-		   p_opt_def("min_their_funding", param_sat,
+		   p_opt_def("min_their_funding_msat", param_sat,
 			     &min_their_funding,
 			     current_policy->min_their_funding),
-		   p_opt_def("max_their_funding", param_sat,
+		   p_opt_def("max_their_funding_msat", param_sat,
 			     &max_their_funding,
 			     current_policy->max_their_funding),
-		   p_opt_def("per_channel_min", param_sat,
+		   p_opt_def("per_channel_min_msat", param_sat,
 			     &per_channel_min,
 			     current_policy->per_channel_min),
-		   p_opt_def("per_channel_max", param_sat,
+		   p_opt_def("per_channel_max_msat", param_sat,
 			     &per_channel_max,
 			     current_policy->per_channel_max),
-		   p_opt_def("reserve_tank", param_sat, &reserve_tank,
+		   p_opt_def("reserve_tank_msat", param_sat, &reserve_tank,
 			     current_policy->reserve_tank),
 		   p_opt_def("fuzz_percent", param_number,
 			     &fuzz_factor,

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1031,11 +1031,11 @@ def test_funder_options(node_factory, bitcoind):
 
     assert funder_opts['policy'] == 'fixed'
     assert funder_opts['policy_mod'] == 0
-    assert funder_opts['min_their_funding'] == '10000000msat'
-    assert funder_opts['max_their_funding'] == '4294967295000msat'
-    assert funder_opts['per_channel_min'] == '10000000msat'
-    assert funder_opts['per_channel_max'] == '4294967295000msat'
-    assert funder_opts['reserve_tank'] == '0msat'
+    assert funder_opts['min_their_funding_msat'] == Millisatoshi('10000000msat')
+    assert funder_opts['max_their_funding_msat'] == Millisatoshi('4294967295000msat')
+    assert funder_opts['per_channel_min_msat'] == Millisatoshi('10000000msat')
+    assert funder_opts['per_channel_max_msat'] == Millisatoshi('4294967295000msat')
+    assert funder_opts['reserve_tank_msat'] == Millisatoshi('0msat')
     assert funder_opts['fuzz_percent'] == 0
     assert funder_opts['fund_probability'] == 100
 
@@ -1051,21 +1051,21 @@ def test_funder_options(node_factory, bitcoind):
     funder_opts = l1.rpc.call('funderupdate',
                               {'policy': 'available',
                                'policy_mod': 100,
-                               'min_their_funding': '100000msat',
-                               'max_their_funding': '2000000000msat',
-                               'per_channel_min': '8000000msat',
-                               'per_channel_max': '10000000000msat',
-                               'reserve_tank': '3000000msat',
+                               'min_their_funding_msat': '100000msat',
+                               'max_their_funding_msat': '2000000000msat',
+                               'per_channel_min_msat': '8000000msat',
+                               'per_channel_max_msat': '10000000000msat',
+                               'reserve_tank_msat': '3000000msat',
                                'fund_probability': 99,
                                'fuzz_percent': 0})
 
     assert funder_opts['policy'] == 'available'
     assert funder_opts['policy_mod'] == 100
-    assert funder_opts['min_their_funding'] == '100000msat'
-    assert funder_opts['max_their_funding'] == '2000000000msat'
-    assert funder_opts['per_channel_min'] == '8000000msat'
-    assert funder_opts['per_channel_max'] == '10000000000msat'
-    assert funder_opts['reserve_tank'] == '3000000msat'
+    assert funder_opts['min_their_funding_msat'] == Millisatoshi('100000msat')
+    assert funder_opts['max_their_funding_msat'] == Millisatoshi('2000000000msat')
+    assert funder_opts['per_channel_min_msat'] == Millisatoshi('8000000msat')
+    assert funder_opts['per_channel_max_msat'] == Millisatoshi('10000000000msat')
+    assert funder_opts['reserve_tank_msat'] == Millisatoshi('3000000msat')
     assert funder_opts['fuzz_percent'] == 0
     assert funder_opts['fund_probability'] == 99
 
@@ -1114,8 +1114,8 @@ def test_funder_contribution_limits(node_factory, bitcoind):
     l2.rpc.call('funderupdate',
                 {'policy': 'available',
                  'policy_mod': 100,
-                 'min_their_funding': '1000msat',
-                 'per_channel_min': '1000000msat',
+                 'min_their_funding_msat': '1000msat',
+                 'per_channel_min_msat': '1000000msat',
                  'fund_probability': 100,
                  'fuzz_percent': 0})
 
@@ -1123,9 +1123,9 @@ def test_funder_contribution_limits(node_factory, bitcoind):
     l3.rpc.call('funderupdate',
                 {'policy': 'fixed',
                  'policy_mod': '50000sat',
-                 'min_their_funding': '1000msat',
-                 'per_channel_min': '1000sat',
-                 'per_channel_max': '500000sat',
+                 'min_their_funding_msat': '1000msat',
+                 'per_channel_min_msat': '1000sat',
+                 'per_channel_max_msat': '500000sat',
                  'fund_probability': 100,
                  'fuzz_percent': 0})
 


### PR DESCRIPTION
Documentation for the funderupdate command on the funder plugin.
Realized we were missing the "leases_only" in the output; also adds
'_msat' to msat denominated outputs so they're parsed correctly by our
python bindings (also matches our naming conventions)

Changelog-EXPERIMENTAL: funder: `funderupdate` command to view and update params for contributing our wallet funds to v2 channel openings. Provides params for enabling `option_will_fund`.