### PR TITLE
Fixed order parameter in the listforwards command

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2661,13 +2661,30 @@ static struct command_result *json_listforwards(struct command *cmd,
 	const char *status_str;
 	enum forward_status status = FORWARD_ANY;
 
+	// TODO: We will remove soon after the deprecated period.
+	if (params && deprecated_apis && params->type == JSMN_ARRAY) {
+		struct short_channel_id scid;
+		/* We need to catch [ null, null, "settled" ], and
+		 * [ "1x2x3" ] as old-style */
+	        if ((params->size > 0 && json_to_short_channel_id(buffer, params + 1, &scid)) ||
+		    (params->size == 3 && !json_to_short_channel_id(buffer, params + 3, &scid))) {
+			if (!param(cmd, buffer, params,
+				   p_opt("in_channel", param_short_channel_id, &chan_in),
+				   p_opt("out_channel", param_short_channel_id, &chan_out),
+				   p_opt("status", param_string, &status_str),
+				   NULL))
+				return command_param_failed();
+			goto parsed;
+		}
+	}
+
 	if (!param(cmd, buffer, params,
+		   p_opt("status", param_string, &status_str),
 		   p_opt("in_channel", param_short_channel_id, &chan_in),
 		   p_opt("out_channel", param_short_channel_id, &chan_out),
-		   p_opt("status", param_string, &status_str),
 		   NULL))
 		return command_param_failed();
-
+ parsed:
 	if (status_str && !string_to_forward_status(status_str, &status))
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Unrecognized status: %s", status_str);
 
@@ -2683,5 +2700,4 @@ static const struct json_command listforwards_command = {
 	json_listforwards,
 	"List all forwarded payments and their information optionally filtering by [in_channel] [out_channel] and [state]"
 };
-
 AUTODATA(json_command, &listforwards_command);

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1975,7 +1975,14 @@ def test_parms_listforwards(node_factory):
     it is simple and not useful, but it is good to have to avoid
     simile errors in the future.
     """
-    l1, _ = node_factory.line_graph(2)
+    l1, l2 = node_factory.line_graph(2)
 
-    forwards = l1.rpc.listforwards("settled")["forwards"]
-    assert len(forwards) == 0
+    l2.stop()
+    l2.daemon.opts['allow-deprecated-apis'] = True
+    l2.start()
+
+    forwards_new = l1.rpc.listforwards("settled")["forwards"]
+    forwards_dep = l2.rpc.call("listforwards", {"in_channel": "0x1x2", "out_channel": "0x2x3", "status": "settled"})["forwards"]
+
+    assert len(forwards_new) == 0
+    assert len(forwards_dep) == 0

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1964,3 +1964,18 @@ def test_addgossip(node_factory):
 
     with pytest.raises(RpcError, match='Bad signature'):
         l3.rpc.addgossip(badupdate)
+
+
+def test_parms_listforwards(node_factory):
+    """
+    Simple test to ensure that the order of the listforwards
+    is correct as describe in the documentation.
+
+    This test is written by a issue report in the IR channel,
+    it is simple and not useful, but it is good to have to avoid
+    simile errors in the future.
+    """
+    l1, _ = node_factory.line_graph(2)
+
+    forwards = l1.rpc.listforwards("settled")["forwards"]
+    assert len(forwards) == 0


### PR DESCRIPTION
From a report in IRC channel, I noted that the order of the parameters are wrong in the rpc command.

I assumed that the code take the wrong order because for us (programmers) write documentation is costly more than code :-)

In addition, I think is more natural to have as the first parameter the status, in my opinion, it is more frequently have a filter by the status instant of the filter by channel id.

In conclusion, I can revert the change and modify the docs, or if this change is good, I'm happy to know if the place where I wrote the test is a correct place (test_peers.py or test_rpc.py file is missed).
