### PR TITLE
increase timeout in the wait_for_log method in the test that fails

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3658,8 +3658,8 @@ def test_upgrade_statickey_fail(node_factory, executor, bitcoind):
     l1.rpc.disconnect(l2.info['id'], force=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    l1.daemon.wait_for_log('option_static_remotekey enabled at 2/2')
-    l2.daemon.wait_for_log('option_static_remotekey enabled at 2/2')
+    l1.daemon.wait_for_log('option_static_remotekey enabled at 2/2', timeout=360)
+    l2.daemon.wait_for_log('option_static_remotekey enabled at 2/2', timeout=360)
 
 
 @unittest.skipIf(not EXPERIMENTAL_FEATURES, "quiescence is experimental")


### PR DESCRIPTION
In several PR I noted that the wait_for_log creates a timeout error, and this PR tries to achieve a possible fixed point to find a solution.

The error that tries to resolve this PR is the following one https://github.com/ElementsProject/lightning/pull/4676/checks?check_run_id=3139499262

It is a good point or am I'm working on some random error and it is not a cause? If it is can be a solution, maybe we can increase the default timeout error?

