### PR TITLE
Moving the dependency to the minimum required

### DIFF
--- a/contrib/pyln-spec/requirements.txt
+++ b/contrib/pyln-spec/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto ~= 0.9.3
+pyln.proto >= 0.9.3


### PR DESCRIPTION
This PR increases the version of the `pyln-proto` in the `pyln-spec` package.

This help to fix the following error on `lnprototest`:

```
ERROR: pyln-bolt7 1.0.1.137 has requirement pyln.proto==0.8.4, but you'll have pyln-proto 0.10.0 which is incompatible.
ERROR: pyln-bolt4 1.0.1.137 has requirement pyln.proto==0.8.4, but you'll have pyln-proto 0.10.0 which is incompatible.
ERROR: pyln-bolt2 1.0.1.137 has requirement pyln.proto==0.8.4, but you'll have pyln-proto 0.10.0 which is incompatible.
ERROR: pyln-bolt1 1.0.1.137 has requirement pyln.proto==0.8.4, but you'll have pyln-proto 0.10.0 which is incompatible.

```