### PR TITLE
offers: make `decode` command available even without experimental-offers

### DIFF
--- a/doc/lightning-decode.7
+++ b/doc/lightning-decode.7
@@ -3,9 +3,6 @@
 lightning-decode - Command for decoding an invoice string (low-level)
 .SH SYNOPSIS
 
-\fB(WARNING: experimental-offers only)\fR
-
-
 \fBdecode\fR \fIstring\fR
 
 .SH DESCRIPTION
@@ -414,4 +411,4 @@ Rusty Russell \fI<rusty@rustcorp.com.au\fR> is mainly responsible\.
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:dda6e1cff3e58c38b637c5a11673b5a9f4837cbdf89ed3be52a8bfc874af87d4
+\" SHA256STAMP:a455b69caed56afb3bca4263a1cba9fbedbe16a5201b9397cfd0168fb297ea87

--- a/doc/lightning-decode.7.md
+++ b/doc/lightning-decode.7.md
@@ -4,8 +4,6 @@ lightning-decode -- Command for decoding an invoice string (low-level)
 SYNOPSIS
 --------
 
-**(WARNING: experimental-offers only)**
-
 **decode** *string*
 
 DESCRIPTION

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -17,6 +17,7 @@
 
 struct pubkey32 id;
 u32 cltv_final;
+bool offers_enabled;
 
 static struct command_result *finished(struct command *cmd,
 				       const char *buf,
@@ -85,6 +86,9 @@ static struct command_result *onion_message_call(struct command *cmd,
 						 const jsmntok_t *params)
 {
 	const jsmntok_t *om, *invreqtok, *invtok;
+
+	if (!offers_enabled)
+		return command_hook_success(cmd);
 
 	om = json_get_member(buf, params, "onion_message");
 
@@ -735,7 +739,6 @@ static const char *init(struct plugin *p,
 			const jsmntok_t *config UNUSED)
 {
 	struct pubkey k;
-	bool exp_offers;
 
 	rpc_scan(p, "getinfo",
 		 take(json_out_obj(NULL, NULL, NULL)),
@@ -748,10 +751,8 @@ static const char *init(struct plugin *p,
 		 take(json_out_obj(NULL, NULL, NULL)),
 		 "{cltv-final:%,experimental-offers:%}",
 		 JSON_SCAN(json_to_number, &cltv_final),
-		 JSON_SCAN(json_to_bool, &exp_offers));
+		 JSON_SCAN(json_to_bool, &offers_enabled));
 
-	if (!exp_offers)
-		return "offers not enabled in config";
 	return NULL;
 }
 

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -344,6 +344,10 @@ struct command_result *json_offer(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
+	if (!offers_enabled)
+		return command_fail(cmd, LIGHTNINGD,
+				    "experimental-offers not enabled");
+
 	/* BOLT-offers #12:
 	 * - MUST NOT set `quantity_min` or `quantity_max` less than 1.
 	 */
@@ -439,6 +443,10 @@ struct command_result *json_offerout(struct command *cmd,
 		   /* FIXME: hints support! */
 		   NULL))
 		return command_param_failed();
+
+	if (!offers_enabled)
+		return command_fail(cmd, LIGHTNINGD,
+				    "experimental-offers not enabled");
 
 	offer->send_invoice = tal(offer, struct tlv_offer_send_invoice);
 

--- a/plugins/offers_offer.h
+++ b/plugins/offers_offer.h
@@ -4,6 +4,7 @@
 #include <plugins/libplugin.h>
 
 extern struct pubkey32 id;
+extern bool offers_enabled;
 
 struct command_result *json_offer(struct command *cmd,
 				  const char *buffer,

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3917,10 +3917,16 @@ def test_mpp_overload_payee(node_factory, bitcoind):
 def test_offer_needs_option(node_factory):
     """Make sure we don't make offers without offer command"""
     l1 = node_factory.get_node()
-    with pytest.raises(RpcError, match='Unknown command'):
+    with pytest.raises(RpcError, match='experimental-offers not enabled'):
         l1.rpc.call('offer', {'amount': '1msat', 'description': 'test'})
+    with pytest.raises(RpcError, match='experimental-offers not enabled'):
+        l1.rpc.call('offerout', {'amount': '2msat',
+                                 'description': 'simple test'})
     with pytest.raises(RpcError, match='Unknown command'):
         l1.rpc.call('fetchinvoice', {'offer': 'aaaa'})
+
+    # Decode still works though
+    assert l1.rpc.decode('lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqyys5qq7ypnwgkvdr57yzh6h92zg3qctvrm7w38djg67kzcm4yeg8vc4cq633uzqaxlsxzxergsrav494jjrpuy9hcldjeglha57lxvz20fhha6hjwhv69nnzwzjsajntyf0c4z8h9e70dfdlfq8jdvc9rdht8vr955udtg')['valid']
 
 
 def test_offer(node_factory, bitcoind):


### PR DESCRIPTION
It subsumes `decodepay`, and it's nicer if people can just assume it's
available at all times.

Changelog-Added: JSON-RPC: `decode` now available without `experimental-offers`
