### PR TITLE
Default to lease-only for funder plugin

### DIFF
--- a/doc/lightning-openchannel_bump.7
+++ b/doc/lightning-openchannel_bump.7
@@ -32,6 +32,9 @@ is not met\.
 funding transaction\. Defaults to 1/64th greater than the last
 feerate used for this channel\.
 
+
+Warning: bumping a leased channel will lose the lease\.
+
 .SH RETURN VALUE
 
 On success, an object is returned, containing:
@@ -94,4 +97,4 @@ lightning-fundchannel_\fBstart\fR(7), lightning-fundchannel_\fBcomplete\fR(7),
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:357923fcd85b832cc52f77858c0744cae6c06d7612aaebb87e65f2ef0a42f367
+\" SHA256STAMP:dc25396dde0592afdcf44e62ef8c897649b43910d9afd4c63327033994f8b9fa

--- a/doc/lightning-openchannel_bump.7.md
+++ b/doc/lightning-openchannel_bump.7.md
@@ -30,6 +30,8 @@ is not met.
 funding transaction. Defaults to 1/64th greater than the last
 feerate used for this channel.
 
+Warning: bumping a leased channel will lose the lease.
+
 RETURN VALUE
 ------------
 

--- a/plugins/funder.c
+++ b/plugins/funder.c
@@ -288,6 +288,17 @@ struct open_info {
 	struct amount_sat requested_lease;
 };
 
+static struct open_info *new_open_info(const tal_t *ctx)
+{
+	struct open_info *info = tal(ctx, struct open_info);
+
+	info->requested_lease = AMOUNT_SAT(0);
+	info->lease_blockheight = 0;
+	info->node_blockheight = 0;
+
+	return info;
+}
+
 static struct command_result *
 psbt_funded(struct command *cmd,
 	    const char *buf,
@@ -641,7 +652,7 @@ json_rbf_channel_call(struct command *cmd,
 		      const char *buf,
 		      const jsmntok_t *params)
 {
-	struct open_info *info = tal(cmd, struct open_info);
+	struct open_info *info = new_open_info(cmd);
 	u64 feerate_our_max, feerate_our_min;
 	const char *err;
 	struct out_req *req;

--- a/plugins/funder_policy.c
+++ b/plugins/funder_policy.c
@@ -95,9 +95,7 @@ default_funder_policy(const tal_t *ctx,
 				 0, 		/* fuzz_factor */
 				 AMOUNT_SAT(0), /* reserve_tank */
 				 100,
-				 /* Defaults to true iif we're advertising
-				  * offers */
-				 false,
+				 true, /* Leases-only by default */
 				 NULL);
 }
 

--- a/plugins/test/run-funder_policy.c
+++ b/plugins/test/run-funder_policy.c
@@ -489,7 +489,7 @@ int main(int argc, const char *argv[])
 				    AMOUNT_SAT(50000),
 				    AMOUNT_SAT(50000),
 				    AMOUNT_SAT(100000),
-				    AMOUNT_SAT(0),
+				    AMOUNT_SAT(100000),
 				    &our_funds);
 	assert(amount_sat_eq(empty, our_funds));
 	assert(!err);

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -6,7 +6,7 @@ from pyln.testing.utils import SLOW_MACHINE
 from utils import (
     only_one, sync_blockheight, wait_for, TIMEOUT,
     account_balance, first_channel_id, closing_fee, TEST_NETWORK,
-    scriptpubkey_addr
+    scriptpubkey_addr, calc_lease_fee
 )
 
 import os
@@ -716,14 +716,6 @@ def test_penalty_outhtlc(node_factory, bitcoind, executor, chainparams):
     assert [o['status'] for o in outputs] == ['confirmed'] * 3
     assert set([o['txid'] for o in outputs]) == txids
     assert account_balance(l2, channel_id) == 0
-
-
-# check that the fee paid is correct
-def calc_lease_fee(amt, feerate, rates):
-    fee = rates['lease_fee_base_msat']
-    fee += amt * rates['lease_fee_basis'] // 10
-    fee += rates['funding_weight'] * feerate
-    return fee
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -857,7 +857,8 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
     l2-l3: l2 leases funds from l3; l3 goes to chain unilaterally
     '''
     opts = {'funder-policy': 'match', 'funder-policy-mod': 100,
-            'lease-fee-base-msat': '100sat', 'lease-fee-basis': 100}
+            'lease-fee-base-msat': '100sat', 'lease-fee-basis': 100,
+            'funder-lease-requests-only': False}
 
     l1, l2, l3 = node_factory.get_nodes(3, opts=opts)
     # Allow l2 some warnings

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -410,7 +410,8 @@ def test_disconnect_fundee_v2(node_factory):
     l2 = node_factory.get_node(disconnect=disconnects,
                                options={'funder-policy': 'match',
                                         'funder-policy-mod': 100,
-                                        'funder-fuzz-percent': 0})
+                                        'funder-fuzz-percent': 0,
+                                        'funder-lease-requests-only': False})
 
     l1.fundwallet(2000000)
     l2.fundwallet(2000000)
@@ -1689,10 +1690,12 @@ def test_multifunding_v2_exclusive(node_factory, bitcoind):
     options = [{},
                {'funder-policy': 'match',
                 'funder-policy-mod': 100,
-                'funder-fuzz-percent': 0},
+                'funder-fuzz-percent': 0,
+                'funder-lease-requests-only': False},
                {'funder-policy': 'match',
                 'funder-policy-mod': 100,
-                'funder-fuzz-percent': 0},
+                'funder-fuzz-percent': 0,
+                'funder-lease-requests-only': False},
                {}]
     l1, l2, l3, l4 = node_factory.get_nodes(4, opts=options)
 

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1038,6 +1038,7 @@ def test_funder_options(node_factory, bitcoind):
     assert funder_opts['reserve_tank_msat'] == Millisatoshi('0msat')
     assert funder_opts['fuzz_percent'] == 0
     assert funder_opts['fund_probability'] == 100
+    assert funder_opts['leases_only']
 
     # l2 funds a chanenl with us. We don't contribute
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
@@ -1057,7 +1058,8 @@ def test_funder_options(node_factory, bitcoind):
                                'per_channel_max_msat': '10000000000msat',
                                'reserve_tank_msat': '3000000msat',
                                'fund_probability': 99,
-                               'fuzz_percent': 0})
+                               'fuzz_percent': 0,
+                               'leases_only': False})
 
     assert funder_opts['policy'] == 'available'
     assert funder_opts['policy_mod'] == 100
@@ -1117,7 +1119,8 @@ def test_funder_contribution_limits(node_factory, bitcoind):
                  'min_their_funding_msat': '1000msat',
                  'per_channel_min_msat': '1000000msat',
                  'fund_probability': 100,
-                 'fuzz_percent': 0})
+                 'fuzz_percent': 0,
+                 'leases_only': False})
 
     # Set our contribution to 50k sat, should only use 7 of 12 available utxos
     l3.rpc.call('funderupdate',
@@ -1127,7 +1130,8 @@ def test_funder_contribution_limits(node_factory, bitcoind):
                  'per_channel_min_msat': '1000sat',
                  'per_channel_max_msat': '500000sat',
                  'fund_probability': 100,
-                 'fuzz_percent': 0})
+                 'fuzz_percent': 0,
+                 'leases_only': False})
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.fundchannel(l2, 10**7)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -336,6 +336,85 @@ def test_v2_rbf_single(node_factory, bitcoind, chainparams):
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
+def test_v2_rbf_liquidity_ad(node_factory, bitcoind, chainparams):
+
+    opts = {'funder-policy': 'match', 'funder-policy-mod': 100,
+            'lease-fee-base-msat': '100sat', 'lease-fee-basis': 100,
+            'may_reconnect': True}
+    l1, l2 = node_factory.get_nodes(2, opts=opts)
+
+    # what happens when we RBF?
+    feerate = 2000
+    amount = 500000
+    l1.fundwallet(20000000)
+    l2.fundwallet(20000000)
+
+    # l1 leases a channel from l2
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    rates = l1.rpc.dev_queryrates(l2.info['id'], amount, amount)
+    l1.daemon.wait_for_log('disconnect')
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    chan_id = l1.rpc.fundchannel(l2.info['id'], amount, request_amt=amount,
+                                 feerate='{}perkw'.format(feerate),
+                                 compact_lease=rates['compact_lease'])['channel_id']
+
+    vins = [x for x in l1.rpc.listfunds()['outputs'] if x['reserved']]
+    assert only_one(vins)
+    prev_utxos = ["{}:{}".format(vins[0]['txid'], vins[0]['output'])]
+
+    # Check that we're waiting for lockin
+    l1.daemon.wait_for_log(' to DUALOPEND_AWAITING_LOCKIN')
+
+    est_fees = calc_lease_fee(amount, feerate, rates)
+
+    # This should be the accepter's amount
+    fundings = only_one(only_one(l1.rpc.listpeers()['peers'])['channels'])['funding']
+    assert Millisatoshi(est_fees + amount * 1000) == Millisatoshi(fundings['remote_msat'])
+
+    # rbf the lease with a higher amount
+    rate = int(find_next_feerate(l1, l2)[:-5])
+    # We 4x the feerate to beat the min-relay fee
+    next_feerate = '{}perkw'.format(rate * 4)
+
+    # Initiate an RBF
+    startweight = 42 + 172  # base weight, funding output
+    initpsbt = l1.rpc.utxopsbt(amount, next_feerate, startweight,
+                               prev_utxos, reservedok=True,
+                               min_witness_weight=110,
+                               excess_as_change=True)['psbt']
+
+    # do the bump
+    bump = l1.rpc.openchannel_bump(chan_id, amount, initpsbt,
+                                   funding_feerate=next_feerate)
+    update = l1.rpc.openchannel_update(chan_id, bump['psbt'])
+    assert update['commitments_secured']
+    # Sign our inputs, and continue
+    signed_psbt = l1.rpc.signpsbt(update['psbt'])['signed_psbt']
+    l1.rpc.openchannel_signed(chan_id, signed_psbt)
+
+    # what happens when the channel opens?
+    bitcoind.generate_block(6)
+    l1.daemon.wait_for_log('to CHANNELD_NORMAL')
+
+    # This should be the accepter's amount
+    fundings = only_one(only_one(l1.rpc.listpeers()['peers'])['channels'])['funding']
+    # FIXME: The lease goes away :(
+    assert Millisatoshi(0) == Millisatoshi(fundings['remote_msat'])
+
+    wait_for(lambda: [c['active'] for c in l1.rpc.listchannels(l1.get_channel_scid(l2))['channels']] == [True, True])
+
+    # send some payments, mine a block or two
+    inv = l2.rpc.invoice(10**4, '1', 'no_1')
+    l1.rpc.pay(inv['bolt11'])
+
+    # l2 attempts to close a channel that it leased, should succeed
+    # (channel isnt leased)
+    l2.rpc.close(l1.get_channel_scid(l2))
+    l1.daemon.wait_for_log('State changed from CLOSINGD_SIGEXCHANGE to CLOSINGD_COMPLETE')
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+@pytest.mark.openchannel('v2')
 def test_v2_rbf_multi(node_factory, bitcoind, chainparams):
     l1, l2 = node_factory.get_nodes(2,
                                     opts={'may_reconnect': True,

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2,7 +2,7 @@ from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from pyln.client import RpcError, Millisatoshi
 from utils import (
-    only_one, wait_for, sync_blockheight, first_channel_id
+    only_one, wait_for, sync_blockheight, first_channel_id, calc_lease_fee
 )
 
 import pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,6 +74,13 @@ def move_matches(exp, mv):
     return True
 
 
+def calc_lease_fee(amt, feerate, rates):
+    fee = rates['lease_fee_base_msat']
+    fee += amt * rates['lease_fee_basis'] // 10
+    fee += rates['funding_weight'] * feerate
+    return fee
+
+
 def check_coin_moves(n, account_id, expected_moves, chainparams):
     moves = n.rpc.call('listcoinmoves_plugin')['coin_moves']
     node_id = n.info['id']


### PR DESCRIPTION
Quick patch to default to only 'lease-only' channel leases. Effectively shuts off putting money into channels on RBF attempts in the default case.