### PR TITLE
pytest: fix test_channel_lease_unilat_closes flake

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -932,8 +932,10 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
     # we *can* spend the 1csv lock one
     l2.rpc.withdraw(l2.rpc.newaddr()['bech32'], "all", utxos=[utxo3])
 
-    bitcoind.generate_block(4032)
-    sync_blockheight(bitcoind, [l2, l3])
+    # This can timeout, so do it in four easy stages.
+    for i in range(4):
+        bitcoind.generate_block(4032 // 4)
+        sync_blockheight(bitcoind, [l2, l3])
 
     l2.rpc.withdraw(l2.rpc.newaddr()['bech32'], "all", utxos=[utxo1])
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -910,7 +910,7 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
     l3.rpc.close(l2.info['id'], 1, force_lease_closed=True)
 
     # Wait til to_self_delay expires, l1 should claim to_local back
-    bitcoind.generate_block(10, wait_for_mempool=1)
+    bitcoind.generate_block(10, wait_for_mempool=2)
     l1.daemon.wait_for_log('Broadcasting OUR_DELAYED_RETURN_TO_WALLET')
     bitcoind.generate_block(1, wait_for_mempool=1)
     l1.daemon.wait_for_log('Resolved OUR_UNILATERAL/DELAYED_OUTPUT_TO_US by our proposal OUR_DELAYED_RETURN_TO_WALLET')


### PR DESCRIPTION
We fail waiting for 'Resolved OUR_UNILATERAL/DELAYED_OUTPUT_TO_US by our proposal OUR_DELAYED_RETURN_TO_WALLET'
because we close *two* channels, but only wait for one transaction before mining a block.
This means we might only have one, and we immediately mine the next wait_for_mempool=1,
so the OUR_DELAYED_RETURN_TO_WALLET isn't mined.

Changelog-None