### PR TITLE
Improve connectd to try non-tor connection first and filter duplicates

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -145,7 +145,7 @@ struct daemon {
 	struct addrinfo *proxyaddr;
 
 	/* They can tell us we must use proxy even for non-Tor addresses. */
-	bool use_proxy_always;
+	bool always_use_proxy;
 
 	/* There are DNS seeds we can use to look up node addresses as a last
 	 * resort, but doing so leaks our address so can be disabled. */
@@ -216,7 +216,7 @@ static bool broken_resolver(struct daemon *daemon)
 
 	/* If they told us to never do DNS queries, don't even do this one and
 	 * also not if we just say that we don't */
-	if (!daemon->use_dns || daemon->use_proxy_always) {
+	if (!daemon->use_dns || daemon->always_use_proxy) {
 		daemon->broken_resolver_response = NULL;
 		return false;
 	}
@@ -821,7 +821,7 @@ static struct io_plan *conn_proxy_init(struct io_conn *conn,
 static void try_connect_one_addr(struct connecting *connect)
 {
  	int fd, af;
-	bool use_proxy = connect->daemon->use_proxy_always;
+	bool use_proxy = connect->daemon->always_use_proxy;
 	const struct wireaddr_internal *addr = &connect->addrs[connect->addrnum];
 	struct io_conn *conn;
 
@@ -1312,7 +1312,7 @@ static struct io_plan *connect_init(struct io_conn *conn,
 		&daemon->id,
 		&proposed_wireaddr,
 		&proposed_listen_announce,
-		&proxyaddr, &daemon->use_proxy_always,
+		&proxyaddr, &daemon->always_use_proxy,
 		&daemon->dev_allow_localhost, &daemon->use_dns,
 		&tor_password,
 		&daemon->use_v3_autotor,
@@ -1528,7 +1528,7 @@ static void try_connect_peer(struct daemon *daemon,
 			     struct wireaddr_internal *addrhint)
 {
 	struct wireaddr_internal *addrs;
-	bool use_proxy = daemon->use_proxy_always;
+	bool use_proxy = daemon->always_use_proxy;
 	struct connecting *connect;
 
 	/* Already done?  May happen with timer. */

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -214,7 +214,8 @@ static bool broken_resolver(struct daemon *daemon)
 	const char *hostname = "nxdomain-test.doesntexist";
 	int err;
 
-	/* If they told us to never do DNS queries, don't even do this one and also not if we just say that we don't */
+	/* If they told us to never do DNS queries, don't even do this one and
+	 * also not if we just say that we don't */
 	if (!daemon->use_dns || daemon->use_proxy_always) {
 		daemon->broken_resolver_response = NULL;
 		return false;

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -302,7 +302,7 @@ simple JSON object containing the options:
         "port": 9050
     },
     "torv3-enabled": true,
-    "use_proxy_always": false
+    "always_use_proxy": false
   }
 }
 ```

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -165,7 +165,7 @@ static struct command_result *json_connect(struct command *cmd,
 		}
 		addr = tal(cmd, struct wireaddr_internal);
 		if (!parse_wireaddr_internal(name, addr, *port, false,
-					     !cmd->ld->use_proxy_always
+					     !cmd->ld->always_use_proxy
 					     && !cmd->ld->pure_tor_setup,
 					     true, deprecated_apis,
 					     &err_msg)) {
@@ -390,7 +390,7 @@ int connectd_init(struct lightningd *ld)
 	    &ld->id,
 	    wireaddrs,
 	    listen_announce,
-	    ld->proxyaddr, ld->use_proxy_always || ld->pure_tor_setup,
+	    ld->proxyaddr, ld->always_use_proxy || ld->pure_tor_setup,
 	    IFDEV(ld->dev_allow_localhost, false), ld->config.use_dns,
 	    ld->tor_service_password ? ld->tor_service_password : "",
 	    ld->config.use_v3_autotor,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -225,7 +225,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->topology = new_topology(ld, ld->log);
 	ld->daemon_parent_fd = -1;
 	ld->proxyaddr = NULL;
-	ld->use_proxy_always = false;
+	ld->always_use_proxy = false;
 	ld->pure_tor_setup = false;
 	ld->tor_service_password = NULL;
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -251,7 +251,7 @@ struct lightningd {
 
 	/* tor support */
 	struct wireaddr *proxyaddr;
-	bool use_proxy_always;
+	bool always_use_proxy;
 	char *tor_service_password;
 	bool pure_tor_setup;
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1821,7 +1821,10 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 	if (ld->proxyaddr) {
 		json_add_address(req->stream, "proxy", ld->proxyaddr);
 		json_add_bool(req->stream, "torv3-enabled", ld->config.use_v3_autotor);
-		json_add_bool(req->stream, "use_proxy_always", ld->use_proxy_always);
+		json_add_bool(req->stream, "always_use_proxy", ld->always_use_proxy);
+		if (deprecated_apis)
+			json_add_bool(req->stream, "use_proxy_always",
+				      ld->always_use_proxy);
 	}
 	json_object_start(req->stream, "feature_set");
 	for (enum feature_place fp = 0; fp < NUM_FEATURE_PLACE; fp++) {


### PR DESCRIPTION
This does:
- remove duplicate connection attempt if addr_hint was set and also added by gossip.
- try non-tor connections first as they are usually faster and more reliable.
- renames variable "use_proxy_always" to "always_use_proxy" to match config.