### PR TITLE
pytest: remove only_one() duplicate

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -520,10 +520,6 @@ def test_sendpay(node_factory):
         invoices = dst.rpc.listinvoices(label)['invoices']
         return len(invoices) == 1 and invoices[0]['status'] == 'unpaid'
 
-    def only_one(arr):
-        assert len(arr) == 1
-        return arr[0]
-
     routestep = {
         'msatoshi': amt,
         'id': l2.info['id'],


### PR DESCRIPTION
The function is already provided in contrib/pyln-testing/pyln/testing/utils.py (which is also imported in this module), so there is no need to define it a second time.