### PR TITLE
Move to minimum required mypy dependeces

### DIFF
--- a/contrib/pyln-client/Makefile
+++ b/contrib/pyln-client/Makefile
@@ -25,7 +25,7 @@ check-pytest:
 	pytest tests
 
 check-mypy:
-	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages tests pyln
+	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
 
 $(SDIST_FILE):
 	python3 setup.py sdist

--- a/contrib/pyln-proto/requirements.txt
+++ b/contrib/pyln-proto/requirements.txt
@@ -2,5 +2,5 @@ base58 ~= 2.0.1
 bitstring ~= 3.1.6
 coincurve ~= 13.0.0
 cryptography ~= 3.2
-mypy==0.790
+mypy>=0.790
 pysocks ~= 1.7.1

--- a/contrib/pyln-testing/Makefile
+++ b/contrib/pyln-testing/Makefile
@@ -25,7 +25,7 @@ check-pytest:
 	pytest tests
 
 check-mypy:
-	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages tests pyln
+	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
 
 $(SDIST_FILE):
 	python3 setup.py sdist

--- a/contrib/pyln-testing/pyln/testing/btcproxy.py
+++ b/contrib/pyln-testing/pyln/testing/btcproxy.py
@@ -1,13 +1,13 @@
 """ A bitcoind proxy that allows instrumentation and canned responses
 """
-from flask import Flask, request
+from flask import Flask, request  # type: ignore
 from bitcoin.rpc import JSONRPCError  # type: ignore
 from bitcoin.rpc import RawProxy as BitcoinProxy  # type: ignore
 from cheroot.wsgi import Server  # type: ignore
 from cheroot.wsgi import PathInfoDispatcher  # type: ignore
 
 import decimal
-import flask
+import flask  # type: ignore
 import json
 import logging
 import threading


### PR DESCRIPTION
Fixes the following error https://github.com/vincenzopalazzo/lnprototest/runs/3401023486?check_suite_focus=true#step:3:5839 on `lnprototest`, we can safely require the minimum version instead of a fixed oneversion.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>