### PR TITLE
pylightning: fix requirements to work with pyln-client

### DIFF
--- a/contrib/pylightning/requirements.txt
+++ b/contrib/pylightning/requirements.txt
@@ -1,1 +1,1 @@
-pyln-client ~= 0.9.3
+pyln-client >= 0.9.3


### PR DESCRIPTION
Without this, we cannot pip install pylightning and pyln-client in the
same environment anymore, as it tries to pull in an incompatible version
of pyln-client.

Changelog-None