### PR TITLE
Required jsonrpc string propriety inside the JSON rpc method request.

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -700,7 +700,7 @@ static void replace_command(struct rpc_command_hook_payload *p,
 			    const char *buffer,
 			    const jsmntok_t *replacetok)
 {
-	const jsmntok_t *method = NULL, *params = NULL, *jsonrpc = NULL;
+	const jsmntok_t *method = NULL, *params = NULL;
 	const char *bad;
 
 	/* Must contain "method", "params" and "id" */
@@ -732,10 +732,14 @@ static void replace_command(struct rpc_command_hook_payload *p,
 		goto fail;
 	}
 
-	jsonrpc = json_get_member(buffer, replacetok, "jsonrpc");
-	if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(buffer, jsonrpc, "2.0")) {
-		bad = "jsonrpc: \"2.0\" must be specified in the request";
-		goto fail;
+	// deprecated phase to give the possibility to all to migrate and stay safe
+	// from this more restrictive change.
+	if (!deprecated_apis) {
+		const jsmntok_t *jsonrpc = json_get_member(buffer, replacetok, "jsonrpc");
+		if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(buffer, jsonrpc, "2.0")) {
+			bad = "jsonrpc: \"2.0\" must be specified in the request";
+			goto fail;
+		}
 	}
 
 	was_pending(command_exec(p->cmd->jcon, p->cmd, buffer, replacetok,
@@ -870,7 +874,7 @@ REGISTER_PLUGIN_HOOK(rpc_command,
 static struct command_result *
 parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 {
-	const jsmntok_t *method, *id, *params, *jsonrpc;
+	const jsmntok_t *method, *id, *params;
 	struct command *c;
 	struct rpc_command_hook_payload *rpc_hook;
 	bool completed;
@@ -884,7 +888,6 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	method = json_get_member(jcon->buffer, tok, "method");
 	params = json_get_member(jcon->buffer, tok, "params");
 	id = json_get_member(jcon->buffer, tok, "id");
-	jsonrpc = json_get_member(jcon->buffer, tok, "jsonrpc");
 
 	if (!id) {
 		json_command_malformed(jcon, "null", "No id");
@@ -897,9 +900,15 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 		return NULL;
 	}
 
-        if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(jcon->buffer, jsonrpc, "2.0")) {
-		json_command_malformed(jcon, "null", "jsonrpc: \"2.0\" must be specified in the request");
-		return NULL;
+	// Adding a deprecated phase to make sure that all the c-lightning wrapper
+	// can migrate all the frameworks
+	if (!deprecated_apis) {
+		const jsmntok_t *jsonrpc = json_get_member(jcon->buffer, tok, "jsonrpc");
+
+		if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(jcon->buffer, jsonrpc, "2.0")) {
+			json_command_malformed(jcon, "null", "jsonrpc: \"2.0\" must be specified in the request");
+			return NULL;
+		}
 	}
 
 	/* Allocate the command off of the `jsonrpc` object and not

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -700,7 +700,7 @@ static void replace_command(struct rpc_command_hook_payload *p,
 			    const char *buffer,
 			    const jsmntok_t *replacetok)
 {
-	const jsmntok_t *method = NULL, *params = NULL;
+	const jsmntok_t *method = NULL, *params = NULL, *jsonrpc = NULL;
 	const char *bad;
 
 	/* Must contain "method", "params" and "id" */
@@ -729,6 +729,12 @@ static void replace_command(struct rpc_command_hook_payload *p,
 		bad = tal_fmt(tmpctx, "redirected to unknown method '%.*s'",
 			      method->end - method->start,
 			      buffer + method->start);
+		goto fail;
+	}
+
+	jsonrpc = json_get_member(buffer, replacetok, "jsonrpc");
+	if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(buffer, jsonrpc, "2.0")) {
+		bad = "jsonrpc: \"2.0\" must be specified in the request";
 		goto fail;
 	}
 
@@ -864,7 +870,7 @@ REGISTER_PLUGIN_HOOK(rpc_command,
 static struct command_result *
 parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 {
-	const jsmntok_t *method, *id, *params;
+	const jsmntok_t *method, *id, *params, *jsonrpc;
 	struct command *c;
 	struct rpc_command_hook_payload *rpc_hook;
 	bool completed;
@@ -878,14 +884,21 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	method = json_get_member(jcon->buffer, tok, "method");
 	params = json_get_member(jcon->buffer, tok, "params");
 	id = json_get_member(jcon->buffer, tok, "id");
+	jsonrpc = json_get_member(jcon->buffer, tok, "jsonrpc");
 
 	if (!id) {
 		json_command_malformed(jcon, "null", "No id");
 		return NULL;
 	}
+
 	if (id->type != JSMN_STRING && id->type != JSMN_PRIMITIVE) {
 		json_command_malformed(jcon, "null",
 				       "Expected string/primitive for id");
+		return NULL;
+	}
+
+        if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(jcon->buffer, jsonrpc, "2.0")) {
+		json_command_malformed(jcon, "null", "jsonrpc: \"2.0\" must be specified in the request");
 		return NULL;
 	}
 


### PR DESCRIPTION
I discovered that my java RPC wrapper has some missing requirements with the jsonrpc 2.0 protocol, and the unusual thing is that it is accepted inside c-lightning a quest without `"jsonrpc":"2.0"` and as specified in [the specification protocol](https://www.jsonrpc.org/specification) the string must be present inside the request.

- [X] First run it is only for testing.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>