### PR TITLE
Give the possibility to delete all the inactive offers.

### DIFF
--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -528,3 +528,27 @@ static const struct json_command payersign_command = {
 	"Sign {messagename} {fieldname} {merkle} (a 32-byte hex string) using public {tweak}",
 };
 AUTODATA(json_command, &payersign_command);
+
+static struct command_result *json_delinactiveoffers(struct command *cmd,
+						     const char *buffer,
+						     const jsmntok_t *obj UNNEEDED,
+						     const jsmntok_t *params) {
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params, NULL))
+		return command_param_failed();
+
+	wallet_offer_delete_inactive(cmd->ld->wallet);
+
+	//TODO: it is better put in the response the list of deleted offers?
+	response = json_stream_success(cmd);
+	return command_success(cmd, response);
+}
+
+static const struct json_command delinactiveoffers_command = {
+	"delinactiveoffers",
+	"payment",
+	json_delinactiveoffers,
+	"TODO: adding a description of the command here",
+};
+AUTODATA(json_command, &delinactiveoffers_command);

--- a/wallet/db_postgres_sqlgen.c
+++ b/wallet/db_postgres_sqlgen.c
@@ -2043,6 +2043,12 @@ struct db_query db_postgres_queries[] = {
          .readonly = true,
     },
     {
+         .name = "DELETE from offers WHERE offer_id = ?;",
+         .query = "DELETE from offers WHERE offer_id = $1;",
+         .placeholders = 1,
+         .readonly = false,
+    },
+    {
          .name = "SELECT name FROM sqlite_master WHERE type='table';",
          .query = "SELECT name FROM sqlite_master WHERE type='table';",
          .placeholders = 0,
@@ -2068,10 +2074,10 @@ struct db_query db_postgres_queries[] = {
     },
 };
 
-#define DB_POSTGRES_QUERY_COUNT 343
+#define DB_POSTGRES_QUERY_COUNT 344
 
 #endif /* HAVE_POSTGRES */
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_POSTGRES */
 
-// SHA256STAMP:219fccaaf2391eeabadd4cc15b4a3431c7ecab9d17755582e6962a34c74982c5
+// SHA256STAMP:298bd92e32ad873078d9ee0ebf2a713d563e16dd181e3783bb1cef1b06444cdf

--- a/wallet/db_sqlite3_sqlgen.c
+++ b/wallet/db_sqlite3_sqlgen.c
@@ -2043,6 +2043,12 @@ struct db_query db_sqlite3_queries[] = {
          .readonly = true,
     },
     {
+         .name = "DELETE from offers WHERE offer_id = ?;",
+         .query = "DELETE from offers WHERE offer_id = ?;",
+         .placeholders = 1,
+         .readonly = false,
+    },
+    {
          .name = "SELECT name FROM sqlite_master WHERE type='table';",
          .query = "SELECT name FROM sqlite_master WHERE type='table';",
          .placeholders = 0,
@@ -2068,10 +2074,10 @@ struct db_query db_sqlite3_queries[] = {
     },
 };
 
-#define DB_SQLITE3_QUERY_COUNT 343
+#define DB_SQLITE3_QUERY_COUNT 344
 
 #endif /* HAVE_SQLITE3 */
 
 #endif /* LIGHTNINGD_WALLET_GEN_DB_SQLITE3 */
 
-// SHA256STAMP:219fccaaf2391eeabadd4cc15b4a3431c7ecab9d17755582e6962a34c74982c5
+// SHA256STAMP:298bd92e32ad873078d9ee0ebf2a713d563e16dd181e3783bb1cef1b06444cdf

--- a/wallet/statements_gettextgen.po
+++ b/wallet/statements_gettextgen.po
@@ -1354,6 +1354,10 @@ msgstr ""
 msgid "SELECT key, data, generation FROM datastore ORDER BY key;"
 msgstr ""
 
+#: wallet/wallet.c:4885
+msgid "DELETE from offers WHERE offer_id = ?;"
+msgstr ""
+
 #: wallet/test/run-db.c:126
 msgid "SELECT name FROM sqlite_master WHERE type='table';"
 msgstr ""
@@ -1369,4 +1373,4 @@ msgstr ""
 #: wallet/test/run-wallet.c:1753
 msgid "INSERT INTO channels (id) VALUES (1);"
 msgstr ""
-#  SHA256STAMP:d098fea63dcba84aefff5cf924cbc455caf9d2ec13cb28ad9ab929bb001a12e6
+#  SHA256STAMP:3d149e3f9e0706ea8e395c29c26a3f4c12a112b50338c39b5d26283301d04bf5

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1593,4 +1593,11 @@ struct db_stmt *wallet_datastore_next(const tal_t *ctx,
 				      const u8 **data,
 				      u64 *generation);
 
+
+/**
+ * Delete all the not active offers stored in the database
+ * @w: the wallet.
+ */
+void wallet_offer_delete_inactive(struct wallet *w)
+	NO_NULL_ARGS;
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
Fixes #4744

There is a better way to delete all the offers from the DB @rustyrussell, I fall in the enum trick and maybe I'm missing some things here?

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>