### PR TITLE
docs: Remove explicit markdown configuration for rtd

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,10 +41,6 @@ extensions = [
     'recommonmark',
 ]
 
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Turns out sphinx added native markdown support, so this config was now failing.

Changelog-None