### PR TITLE
Shellcheck cleanup

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -2,7 +2,7 @@
 set -e
 
 # When run inside docker (from below), we do build and drop result in /release
-if [ x"$1" = x"--inside-docker" ]; then
+if [ "$1" = "--inside-docker" ]; then
     VER="$2"
     git clone /src /build
     cd /build

--- a/tools/mockup.sh
+++ b/tools/mockup.sh
@@ -44,7 +44,7 @@ for SYMBOL; do
     # has notleak_ as a declaration, and then an inline).
     # Also, prefer local headers over generic ones.
     WHERE=$(shopt -s nullglob; grep -nH "^[a-zA-Z0-9_ (),]* [*]*$SYMBOL(" "$UPDIRNAME"/*.h ./*/*.h | head -n1)
-    if [ x"$WHERE" = x ]; then
+    if [ -z "$WHERE" ]; then
 	echo "/* Could not find declaration for $SYMBOL */"
 	continue
     fi


### PR DESCRIPTION
Updates from output of latest version of shellcheck as per SC2268

“Avoid x-prefix in comparisons as it no longer serves a purpose”
https://www.shellcheck.net/wiki/SC2268

Changelog-None