### PR TITLE
feat: add  channel_id and commitnum to  commitment_revocation hook

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -906,7 +906,9 @@ The payload consists of the following information:
 ```json
 {
 	"commitment_txid": "58eea2cf538cfed79f4d6b809b920b40bb6b35962c4bb4cc81f5550a7728ab05",
-	"penalty_tx": "02000000000101...ac00000000"
+	"penalty_tx": "02000000000101...ac00000000",
+	"channel_id": "fb16398de93e8690c665873715ef590c038dfac5dd6c49a9d4b61dccfcedc2fb",
+	"commitnum": 21
 }
 ```
 

--- a/tests/plugins/watchtower.py
+++ b/tests/plugins/watchtower.py
@@ -6,9 +6,9 @@ plugin = Plugin()
 
 
 @plugin.hook('commitment_revocation')
-def on_commitment_revocation(commitment_txid, penalty_tx, plugin, **kwargs):
+def on_commitment_revocation(commitment_txid, penalty_tx, channel_id, commitnum, plugin, **kwargs):
     with open('watchtower.csv', 'a') as f:
-        f.write("{}, {}\n".format(commitment_txid, penalty_tx))
+        f.write("{}, {}, {}, {}\n".format(commitment_txid, penalty_tx, channel_id, commitnum))
 
 
 plugin.run()


### PR DESCRIPTION
I thought having the `channel_id` and `commitnum` might be a useful addition to the  `commitment_revocation` hook