### PR TITLE
Use __COUNTER__ in addition to __LINE__ in autodata

### DIFF
--- a/ccan/ccan/autodata/autodata.h
+++ b/ccan/ccan/autodata/autodata.h
@@ -43,7 +43,7 @@
 #define AUTODATA(name, ptr) \
 	static const autodata_##name##_ *NEEDED		\
 	__attribute__((section("xautodata_" #name)))	\
-	AUTODATA_VAR_(name, __LINE__) = (ptr);
+	AUTODATA_VAR_(name, __LINE__, __COUNTER__) = (ptr);
 
 /**
  * autodata_get - get an autodata set
@@ -80,8 +80,8 @@
 void autodata_free(void *p);
 
 /* Internal functions. */
-#define AUTODATA_VAR__(name, line) autodata_##name##_##line
-#define AUTODATA_VAR_(name, line) AUTODATA_VAR__(name, line)
+#define AUTODATA_VAR__(name, line, counter) autodata_##name##_##line##_##counter
+#define AUTODATA_VAR_(name, line, counter) AUTODATA_VAR__(name, line, counter)
 
 #if HAVE_SECTION_START_STOP
 void *autodata_get_section(void *start, void *stop, size_t *nump);
@@ -91,13 +91,15 @@ void *autodata_get_section(void *start, void *stop, size_t *nump);
 	static const void *autodata_##name##_ex = &autodata_##name##_ex
 
 #define AUTODATA_MAGIC ((long)0xFEEDA10DA7AF00D5ULL)
-#define AUTODATA(name, ptr)						\
+#define AUTODATA_WITH_COUNTER(name, ptr, counter)			\
 	static const autodata_##name##_ *NEEDED				\
-	AUTODATA_VAR_(name, __LINE__)[4] =				\
+	AUTODATA_VAR_(name, __LINE__, counter)[4] =			\
 	{ (void *)AUTODATA_MAGIC,					\
-	  (void *)&AUTODATA_VAR_(name, __LINE__),			\
+	  (void *)&AUTODATA_VAR_(name, __LINE__, counter),		\
 	  (ptr),							\
 	  (void *)#name }
+#define AUTODATA(name, ptr)						\
+	AUTODATA_WITH_COUNTER(name, ptr, __COUNTER__)
 
 #define autodata_get(name, nump)					\
 	((autodata_##name##_ **)					\


### PR DESCRIPTION
The use of `__LINE__` runs the chance of collision, which occured in https://github.com/ElementsProject/lightning/pull/4756/checks?check_run_id=3529432371

Adding `__COUNTER__` reduces the chance of collision issue but requires AUTODATA(..) to be slighting restructured.

Collision details from build:

```
In file included from ./common/type_to_string.h:5,
                 from ./lightningd/log.h:9,
                 from wallet/test/run-wallet.c:1:
ccan/ccan/autodata/autodata.h:83:36: error: redefinition of ‘autodata_json_command_2577’
   83 | #define AUTODATA_VAR__(name, line) autodata_##name##_##line
      |                                    ^~~~~~~~~
ccan/ccan/autodata/autodata.h:84:35: note: in expansion of macro ‘AUTODATA_VAR__’
   84 | #define AUTODATA_VAR_(name, line) AUTODATA_VAR__(name, line)
      |                                   ^~~~~~~~~~~~~~
ccan/ccan/autodata/autodata.h:46:2: note: in expansion of macro ‘AUTODATA_VAR_’
   46 |  AUTODATA_VAR_(name, __LINE__) = (ptr);
      |  ^~~~~~~~~~~~~
./lightningd/peer_htlcs.c:2577:1: note: in expansion of macro ‘AUTODATA’
 2577 | AUTODATA(json_command, &dev_ignore_htlcs);
      | ^~~~~~~~
ccan/ccan/autodata/autodata.h:83:36: note: previous definition of ‘autodata_json_command_2577’ was here
   83 | #define AUTODATA_VAR__(name, line) autodata_##name##_##line
      |                                    ^~~~~~~~~
ccan/ccan/autodata/autodata.h:84:35: note: in expansion of macro ‘AUTODATA_VAR__’
   84 | #define AUTODATA_VAR_(name, line) AUTODATA_VAR__(name, line)
      |                                   ^~~~~~~~~~~~~~
ccan/ccan/autodata/autodata.h:46:2: note: in expansion of macro ‘AUTODATA_VAR_’
   46 |  AUTODATA_VAR_(name, __LINE__) = (ptr);
      |  ^~~~~~~~~~~~~
./lightningd/peer_control.c:2577:1: note: in expansion of macro ‘AUTODATA’
 2577 | AUTODATA(json_command, &dev_fail_command);
      | ^~~~~~~~
```