### PR TITLE
resolve() appears broken on Python 3.7+ on Mac

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1151,7 +1151,7 @@ def flock(directory: Path):
     # So now we have a position in the lock, let's check if we are the
     # next one to go:
     while True:
-        files = sorted([f.resolve() for f in d.iterdir() if f.is_file()])
+        files = sorted([f for f in d.iterdir() if f.is_file()])
         # We're queued, so it should at least have us.
         assert len(files) >= 1
         if files[0] == fname:


### PR DESCRIPTION
On my machine it should have produced:
/tmp/ltests-1p0v5z1j/.locks/lock-1631090663.1066182
but instead it produced:
/private/tmp/ltests-1p0v5z1j/.locks/lock-1631090663.105848

The mismatch resulted in a hang inside flock.

Path .resolve() seems to be causing problems for others as well. It appears the library was not meant to handle complex path situations and isn't maintained as such (see link reference).

Since we have already built a full path here anyway, the call to .resolve() appears redundant.

Tested on python 3.9.6 on my Mac OS X 11.4 (20F71), Xcode 12.5.1 (12E507)

Relevant discussion: https://discuss.python.org/t/pathlib-absolute-vs-resolve/2573

Changelog-None