### PR TITLE
lightningd: shutdown plugin in two steps, db_write hook registered plugins last

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -37,7 +37,7 @@ static void plugin_config_cb(const char *buffer,
 			     const jsmntok_t *idtok,
 			     struct plugin *plugin)
 {
-	plugin->plugin_state = INIT_COMPLETE;
+	plugin_set_state(plugin, INIT_COMPLETE);
 	io_break(plugin);
 }
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1159,6 +1159,18 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 	return true;
 }
 
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name)
+{
+	size_t count = tal_count(rpc->commands);
+	for (size_t j = 0; j < count; j++) {
+		if (streq(name, rpc->commands[j]->name)) {
+			tal_free(rpc->commands[j]);
+			return true;
+		}
+	}
+	return false;
+}
+
 static bool jsonrpc_command_add_perm(struct lightningd *ld,
 				     struct jsonrpc *rpc,
 				     struct json_command *command)

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -431,7 +431,7 @@ static void destroy_command(struct command *cmd)
 {
 	if (!cmd->jcon) {
 		log_debug(cmd->ld->log,
-			    "Command returned result after jcon close");
+			    "Command returned result after jcon close: %s", cmd->json_cmd->name);
 		return;
 	}
 	list_del_from(&cmd->jcon->commands, &cmd->list);

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -191,6 +191,9 @@ void jsonrpc_listen(struct jsonrpc *rpc, struct lightningd *ld);
 bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 			 const char *usage TAKES);
 
+/* Remove a command from the JSON-RPC interface */
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name);
+
 /**
  * Begin a JSON-RPC notification with the specified topic.
  *

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1186,10 +1186,10 @@ int main(int argc, char *argv[])
 
 	/* We're not going to collect our children. */
 	remove_sigchild_handler();
+	shutdown_subdaemons(ld);
 
 	/* Tell plugins we're shutting down, except db_write plugins */
 	shutdown_plugins(ld, true);
-	shutdown_subdaemons(ld);
 
 	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
 	 * it might actually be touching the DB in some destructors, e.g.,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1187,8 +1187,8 @@ int main(int argc, char *argv[])
 	/* We're not going to collect our children. */
 	remove_sigchild_handler();
 
-	/* Tell plugins we're shutting down. */
-	shutdown_plugins(ld);
+	/* Tell plugins we're shutting down, except db_write plugins */
+	shutdown_plugins(ld, true);
 	shutdown_subdaemons(ld);
 
 	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
@@ -1197,6 +1197,9 @@ int main(int argc, char *argv[])
 	db_begin_transaction(ld->wallet->db);
 	tal_free(ld->jsonrpc);
 	db_commit_transaction(ld->wallet->db);
+
+	/* Shutdown remaining plugins and close the db */
+	shutdown_plugins(ld, false);
 
 	/* Clean our our HTLC maps, since they use malloc. */
 	htlc_in_map_clear(&ld->htlcs_in);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2108,6 +2108,14 @@ void shutdown_plugins(struct lightningd *ld, bool first)
 			tal_free(p);
 	}
 
+	/* Somehow a separate io_loop is needed to service the notification !? */
+	struct oneshot *t1;
+	t1 = new_reltimer(ld->timers, ld,
+					 time_from_sec(1),
+					 plugin_shutdown_timeout, ld);
+	io_loop_with_timers(ld);
+	tal_free(t1);
+
 	if (plugins_any_in_state(ld->plugins, SHUTDOWN)) {
 		struct oneshot *t;
 		/* Give them 30 or 5 seconds to self-terminate, the last one in

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2092,8 +2092,7 @@ void shutdown_plugins(struct lightningd *ld, bool first)
 
 	/* Mark the set of plugins we want to shutdown in this call */
 	list_for_each_safe(&ld->plugins->plugins, p, next, list) {
-		/* FIXME: Make db_write plugin's important by default? */
-		if (first && (plugin_registered_db_write_hook(p) || p->important))
+		if (first && plugin_registered_db_write_hook(p))
 			continue;
 
 		/* don't complain about important plugins vanishing and stop sending

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2092,7 +2092,8 @@ void shutdown_plugins(struct lightningd *ld, bool first)
 
 	/* Mark the set of plugins we want to shutdown in this call */
 	list_for_each_safe(&ld->plugins->plugins, p, next, list) {
-		if (first && plugin_registered_db_write_hook(p))
+		/* FIXME: Make db_write plugin's important by default? */
+		if (first && (plugin_registered_db_write_hook(p) || p->important))
 			continue;
 
 		/* don't complain about important plugins vanishing and stop sending

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -235,13 +235,13 @@ void plugin_kill(struct plugin *plugin, enum log_level loglevel,
 		 const char *fmt, ...);
 
 /**
- * The @first=true call sends all subscribed plugins a shutdown notification and
- * gives those 30s to self-terminate, others are killed immediate. Plugins
- * that registered the db_write hook are kept alive, but their JSON RPC methods
- * are removed.
+ * In the @first=true call: subscribed (non-db_write) plugins get a shutdown
+ * notification and have 30s to self-terminate, others are killed right away.
+ * Plugins that registered the db_write hook are kept alive, but stripped from
+ * their JSON RPC methods.
  *
- * The 2nd (first=false) call repeats above for any remaining plugins, so
- * db_write plugins can be notified twice, gives them 5s to self-terminate.
+ * In the 2nd (@first=false) call: kill remaining plugins, subscribed ones are
+ * notified and have 5s to self-terminate, finally the db is closed.
  */
 void shutdown_plugins(struct lightningd *ld, bool first);
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -267,6 +267,11 @@ struct command_result *plugin_register_all_complete(struct lightningd *ld,
 void plugins_config(struct plugins *plugins);
 
 /**
+ * Set plugin's state to state, an attempt to decrement (outside shutdown) kills it
+ */
+void plugin_set_state(struct plugin *p, enum plugin_state state);
+
+/**
  * Are any plugins at this state still?
  */
 bool plugins_any_in_state(const struct plugins *plugins, enum plugin_state state);

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -291,6 +291,16 @@ struct db_write_hook_req {
 	size_t *num_hooks;
 };
 
+bool plugin_registered_db_write_hook(struct plugin *plugin) {
+	const struct plugin_hook *hook = &db_write_hook;
+
+	for (size_t i = 0; i < tal_count(hook->hooks); i++)
+		if (hook->hooks[i]->plugin == plugin)
+			return true;
+
+	return false;
+}
+
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,
 			     const jsmntok_t *idtok,
 			     struct db_write_hook_req *dwh_req)

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -54,7 +54,7 @@ static struct plugin_hook *plugin_hook_by_name(const char *name)
 	return NULL;
 }
 
-/* When we destroy a plugin, we remove its hooks */
+/* When we destroy an unimportant plugin, we remove its hooks */
 static void destroy_hook_instance(struct hook_instance *h,
 				  struct plugin_hook *hook)
 {
@@ -91,7 +91,10 @@ struct plugin_hook *plugin_hook_register(struct plugin *plugin, const char *meth
 	h->plugin = plugin;
 	h->before = tal_arr(h, const char *, 0);
 	h->after = tal_arr(h, const char *, 0);
-	tal_add_destructor2(h, destroy_hook_instance, hook);
+
+	/* Never unregister important hooks */
+	if (!plugin->important)
+		tal_add_destructor2(h, destroy_hook_instance, hook);
 
 	tal_arr_expand(&hook->hooks, h);
 	return hook;
@@ -162,12 +165,6 @@ static void plugin_hook_callback(const char *buffer, const jsmntok_t *toks,
 	assert(last != NULL);
 	tal_del_destructor(last, plugin_hook_killed);
 	tal_free(last);
-
-	if (r->ld->state == LD_STATE_SHUTDOWN) {
-		log_debug(r->ld->log,
-			  "Abandoning plugin hook call due to shutdown");
-		return;
-	}
 
 	log_debug(r->ld->log, "Plugin %s returned from %s hook call",
 		  r->plugin->shortname, r->hook->name);

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -108,6 +108,9 @@ bool plugin_hook_continue(void *arg, const char *buffer, const jsmntok_t *toks);
 struct plugin_hook *plugin_hook_register(struct plugin *plugin,
 					 const char *method);
 
+/* Helper to tell if plugin registered the db_write hook */
+bool plugin_registered_db_write_hook(struct plugin *plugin);
+
 /* Special sync plugin hook for db. */
 void plugin_hook_db_sync(struct db *db);
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -199,7 +199,7 @@ void setup_topology(struct chain_topology *topology UNNEEDED,
 		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)
 { fprintf(stderr, "setup_topology called!\n"); abort(); }
 /* Generated stub for shutdown_plugins */
-void shutdown_plugins(struct lightningd *ld UNNEEDED)
+void shutdown_plugins(struct lightningd *ld UNNEEDED, bool first UNNEEDED)
 { fprintf(stderr, "shutdown_plugins called!\n"); abort(); }
 /* Generated stub for stop_topology */
 void stop_topology(struct chain_topology *topo UNNEEDED)

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -20,9 +20,7 @@ def shutdown(plugin, **kwargs):
     global shutdown_notifications
     shutdown_notifications += 1
     plugin.log("received shutdown notification {}".format(shutdown_notifications))
-    if shutdown_notifications > 1:
-        sleep(4)    # we have 5s to exit before timeout
-        exit(0)
+    # don't exit to triggers the 5s timeout
 
 
 plugin.run()

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -4,7 +4,6 @@ that they have some control at shutdown.
 '''
 
 from pyln.client import Plugin
-from time import sleep
 
 plugin = Plugin()
 shutdown_notifications = 0

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -1,16 +1,28 @@
 #! /usr/bin/env python3
-'''This plugin is a do-nothing backup plugin which just checks that we
-can handle multiple backup plugins.
+'''This plugin is used to test we can handle multiple backup plugins and
+that they have some control at shutdown.
 '''
 
 from pyln.client import Plugin
+from time import sleep
 
 plugin = Plugin()
+shutdown_notifications = 0
 
 
 @plugin.hook('db_write')
 def db_write(plugin, **kwargs):
     return {'result': 'continue'}
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    global shutdown_notifications
+    shutdown_notifications += 1
+    plugin.log("received shutdown notification {}".format(shutdown_notifications))
+    if shutdown_notifications > 1:
+        sleep(4)    # we have 5s to exit before timeout
+        exit(0)
 
 
 plugin.run()

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -4,6 +4,8 @@ that they have some control at shutdown.
 '''
 
 from pyln.client import Plugin
+from time import sleep
+import sys
 
 plugin = Plugin()
 shutdown_notifications = 0
@@ -16,10 +18,11 @@ def db_write(plugin, **kwargs):
 
 @plugin.subscribe("shutdown")
 def shutdown(plugin, **kwargs):
-    global shutdown_notifications
-    shutdown_notifications += 1
-    plugin.log("received shutdown notification {}".format(shutdown_notifications))
-    # don't exit to triggers the 5s timeout
+    plugin.log("received shutdown notification")
+    # plugins shutdown has timeout of 30s in first call and 5s in 2nd call
+    # so only in 2nd call we timeout
+    sleep(6)
+    sys.exit(0)
 
 
 plugin.run()

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
-'''This plugin is used to test we can handle multiple backup plugins and
-that they have some control at shutdown.
+'''This plugin is used to test we can handle multiple backup plugins, that it
+   has some control at shutdown and is correctly killed as last.
 '''
 
 from pyln.client import Plugin
@@ -22,6 +22,12 @@ def shutdown(plugin, **kwargs):
     # so only in 2nd call we timeout
     sleep(6)
     sys.exit(0)
+
+
+# dummy method, should've been removed before JSON RPC is closed
+@plugin.method("noop_method")
+def handle_dummy_method(plugin, **kwargs):
+    pass
 
 
 plugin.run()

--- a/tests/plugins/dbdummy.py
+++ b/tests/plugins/dbdummy.py
@@ -8,7 +8,6 @@ from time import sleep
 import sys
 
 plugin = Plugin()
-shutdown_notifications = 0
 
 
 @plugin.hook('db_write')

--- a/tests/plugins/delay_shutdown.py
+++ b/tests/plugins/delay_shutdown.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+'''This plugin is used to delay the plugin shutdown loop
+'''
+
+from pyln.client import Plugin
+from time import sleep
+import sys
+
+plugin = Plugin()
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    plugin.log("delaying shutdown with 10s")
+    sleep(8)
+    plugin.log("2s before exit")
+    sleep(2)
+    sys.exit(0)
+
+
+plugin.run()

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 """Plugin to be used to test miscellaneous notifications.
-
-Only used for 'channel_opened' for now.
 """
 
 from pyln.client import Plugin
-from time import sleep
 
 plugin = Plugin()
 
@@ -34,7 +31,6 @@ def shutdown(plugin, **kwargs):
     # should see the data before being shutdown and its hooks unregistered
     plugin.log("received shutdown notification")
     plugin.rpc.datastore(key='{}'.format(__file__), string="data written at shutdown")
-    sleep(5)
 
 
 plugin.run()

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -3,6 +3,7 @@
 """
 
 from pyln.client import Plugin
+import sys
 
 plugin = Plugin()
 
@@ -27,10 +28,10 @@ def channel_state_changed(plugin, channel_state_changed, **kwargs):
 
 @plugin.subscribe("shutdown")
 def shutdown(plugin, **kwargs):
-    # Trigger a db_write. If another plugin registered the db_write hook, it
-    # should see the data before being shutdown and its hooks unregistered
+    # Trigger a db_write during shutdown, db_write plugins should see it
     plugin.log("received shutdown notification")
-    plugin.rpc.datastore(key='{}'.format(__file__), string="data written at shutdown")
+    plugin.rpc.datastore(key='{}'.format(__file__), string="data written at shutdown", mode="create-or-replace")
+    sys.exit(0) # skip the 30s waiting
 
 
 plugin.run()

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -5,6 +5,7 @@ Only used for 'channel_opened' for now.
 """
 
 from pyln.client import Plugin
+from time import sleep
 
 plugin = Plugin()
 
@@ -25,6 +26,15 @@ def channel_opened(plugin, channel_opened, **kwargs):
 @plugin.subscribe("channel_state_changed")
 def channel_state_changed(plugin, channel_state_changed, **kwargs):
     plugin.log("channel_state_changed {}".format(channel_state_changed))
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    # Trigger a db_write. If another plugin registered the db_write hook, it
+    # should see the data before being shutdown and its hooks unregistered
+    plugin.log("received shutdown notification")
+    plugin.rpc.datastore(key='{}'.format(__file__), string="data written at shutdown")
+    sleep(5)
 
 
 plugin.run()

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -31,7 +31,7 @@ def shutdown(plugin, **kwargs):
     # Trigger a db_write during shutdown, db_write plugins should see it
     plugin.log("received shutdown notification")
     plugin.rpc.datastore(key='{}'.format(__file__), string="data written at shutdown", mode="create-or-replace")
-    sys.exit(0) # skip the 30s waiting
+    sys.exit(0)     # skip the 30s waiting
 
 
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -501,7 +501,8 @@ def test_db_hook(node_factory, executor):
 
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "Only sqlite3 implements the db_write_hook currently")
 def test_db_hook_multiple(node_factory, executor):
-    """This tests the db hook for multiple-plugin case and the 2-step shutdown of db_write plugins"""
+    """This tests the db hook for multiple-plugin case and the separate shutdown
+        timeout for db_write plugins that subscribed to it"""
     dbfile = os.path.join(node_factory.directory, "dblog.sqlite3")
     l1 = node_factory.get_node(options={'plugin': os.path.join(os.getcwd(), 'tests/plugins/dblog.py'),
                                         'important-plugin': os.path.join(os.getcwd(), 'tests/plugins/dbdummy.py'),
@@ -517,9 +518,8 @@ def test_db_hook_multiple(node_factory, executor):
     l1.daemon.wait_for_log("plugin-dblog.py: initialized.* 'startup': True")
 
     l1.stop()
-    # it registered db_write hook and receives 2 notifications, then times out
-    l1.daemon.wait_for_log("plugin-dbdummy.py: received shutdown notification 1")
-    l1.daemon.wait_for_log("plugin-dbdummy.py: received shutdown notification 2")
+    # it registered db_write hook and subscribed to shutdown and should timeout after 5s
+    l1.daemon.wait_for_log("plugin-dbdummy.py: received shutdown notification")
     l1.daemon.wait_for_log("lightningd: dbdummy.py: failed to self-terminate, killing.")
 
     # Databases should be identical.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -517,6 +517,10 @@ def test_db_hook_multiple(node_factory, executor):
     l1.daemon.wait_for_log("plugin-dblog.py: initialized.* 'startup': True")
 
     l1.stop()
+    # it registered db_write hook and receives 2 notifications, then self-terminates
+    l1.daemon.wait_for_log("plugin-dbdummy.py: received shutdown notification 1")
+    l1.daemon.wait_for_log("plugin-dbdummy.py: received shutdown notification 2")
+    l1.daemon.wait_for_log("plugin-dbdummy.py: Killing plugin: exited during shutdown")
 
     # Databases should be identical.
     db1 = sqlite3.connect(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'lightningd.sqlite3'))


### PR DESCRIPTION
Proof of concept, to fix #4785 

considerations:
- individual plugins can now be in state `SHUTDOWN` (when CL is shutting down), this overrides the `important_plugin` check
- plugins that register `db_write` hook are an exception, they MUST not make rpc calls, at least not during shutdown
- other plugins can do what they want within the 30s they get and are then killed

Todo: 
 - [x] the test can probably be weaved into an existing one
 - ~[ ] maybe reverse #1755? It seems redundant since #3867 but I am no expert.~
 - [x] make it nicer

First see if this passes test.