### PR TITLE
Clean up wire/channel_type_*gen* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ ccan/ccan/cdump/tools/cdump-enumstr
 gen_*.c
 gen_*.h
 wire/gen_*_csv
+wire/channel_type_printgen*
+wire/channel_type_wiregen*
 cli/lightning-cli
 coverage
 ccan/config.h

--- a/wire/Makefile
+++ b/wire/Makefile
@@ -155,6 +155,7 @@ clean: wire-clean
 
 wire-clean:
 	$(RM) wire/*.csv.*
+	$(RM) wire/channel_type_*gen*
 
 wire-maintainer-clean: wire-clean
 	$(RM) wire/gen_*_csv wire/extracted_*_experimental_csv


### PR DESCRIPTION
Files added to .gitignore and to wire-clean target
of wire/Makefile.