### PR TITLE
Fix build on Alpine Linux and OpenBSD

### DIFF
--- a/common/crypto_sync.c
+++ b/common/crypto_sync.c
@@ -9,6 +9,7 @@
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <wire/wire.h>
 
 void sync_crypto_write(struct per_peer_state *pps, const void *msg TAKES)

--- a/common/dev_disconnect.c
+++ b/common/dev_disconnect.c
@@ -4,6 +4,7 @@
 #include <common/status.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <wire/peer_wire.h>

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -69,7 +69,6 @@
 #include <lightningd/options.h>
 #include <lightningd/plugin.h>
 #include <sys/resource.h>
-#include <sys/stat.h>
 #include <wallet/txfilter.h>
 #include <wally_bip32.h>
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -3,6 +3,8 @@
 #include "config.h"
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
+#include <signal.h>
+#include <sys/stat.h>
 #include <wallet/wallet.h>
 
 /* Various adjustable things. */

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -9,6 +9,7 @@
 #include <common/type_to_string.h>
 #include <errno.h>
 #include <plugins/libplugin-pay.h>
+#include <sys/types.h>
 #include <wire/peer_wire.h>
 
 static struct gossmap *global_gossmap;


### PR DESCRIPTION
After recent header files clean-up it was not possible to
build c-lightning 7401b2682. This patch fixes it for me.