### PR TITLE
Add missing headers for compiling on FreeBSD 13

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -7,6 +7,7 @@
 #include <common/type_to_string.h>
 #include <common/wireaddr.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <wire/wire.h>
 
 bool wireaddr_eq(const struct wireaddr *a, const struct wireaddr *b)

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -34,6 +34,7 @@
 #include <connectd/tor_autoservice.h>
 #include <errno.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <sodium.h>
 #include <wire/wire_sync.h>
 

--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -14,6 +14,7 @@
 #else
 # define IF_SQLITE3(...)
 #endif
+#include <unistd.h>
 #include <zlib.h>
 
 static const char template[] =


### PR DESCRIPTION
- `netinet/in.h`: struct sockaddr_in, struct sockaddr_in6
- `unistd.h`: close()