### PR TITLE
Minor cleanups

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -159,11 +159,21 @@ Which is to say that channels created after block [598000](https://blockstream.i
 
 You can verify it using the `features` field from the [`listpeers` command](https://lightning.readthedocs.io/lightning-listpeers.7.html)'s result.
 
-Here is an example in Python checking if [one of the `option_static_remotekey` bits](https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md) is set in the negotiated features corresponding to `0x02aaa2`:
+Here is an example in Python checking if [one of the `option_static_remotekey` bits][spec-features] is set in the negotiated features corresponding to `0x02aaa2`:
 ```python
 >>> bool(0x02aaa2 & ((1 << 12) | (1 << 13)))
 True
 ```
+
+If `option_static_remotekey` is enabled you can attempt to recover the
+funds in a channel following [this tutorial][mandelbit-recovery] on
+how to extract the necessary information from the network topology. If
+successful, result will be a private key matching a unilaterally
+closed channel, that you can import into any wallet, recovering the
+funds into that wallet.
+
+[spec-features]: https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md
+[mandelbit-recovery]: https://github.com/mandelbit/bitcoin-tutorials/blob/master/CLightningRecoverFunds.md
 
 ## Technical Questions
 

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -617,8 +617,6 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 {
 	enum hsmd_wire t = fromwire_peektype(c->msg_in);
 
-	status_debug("Client: Received message %d from client", t);
-
 	/* Before we do anything else, is this client allowed to do
 	 * what he asks for? */
 	if (!hsmd_check_client_capabilities(c->hsmd_client, t))

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -1163,7 +1163,7 @@ static struct command_result *json_invoice(struct command *cmd,
 				    INVOICE_MAX_LABEL_LEN);
 	}
 
-	if (strlen(desc_val) >= BOLT11_FIELD_BYTE_LIMIT) {
+	if (strlen(desc_val) > BOLT11_FIELD_BYTE_LIMIT) {
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				    "Descriptions greater than %d bytes "
 				    "not yet supported "

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -16,6 +16,7 @@
  * This is how many request for each priority level we have.
  */
 #define BITCOIND_MAX_PARALLEL 4
+#define RPC_TRANSACTION_ALREADY_IN_CHAIN -27
 
 enum bitcoind_prio {
 	BITCOIND_LOW_PRIO,
@@ -489,7 +490,10 @@ static struct command_result *process_sendrawtransaction(struct bitcoin_cli *bcl
 				bcli->output);
 
 	response = jsonrpc_stream_success(bcli->cmd);
-	json_add_bool(response, "success", *bcli->exitstatus == 0);
+	json_add_bool(response, "success",
+		      *bcli->exitstatus == 0 ||
+			  *bcli->exitstatus ==
+			      RPC_TRANSACTION_ALREADY_IN_CHAIN);
 	json_add_string(response, "errmsg",
 			*bcli->exitstatus ?
 			tal_strndup(bcli->cmd,

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -1949,7 +1949,7 @@ static void payment_finished(struct payment *p)
 				 * success. */
 				json_add_string(ret, "status", "complete");
 
-			} else if (result.leafstates & ~PAYMENT_FAILED) {
+			} else if (result.leafstates & ~PAYMENT_STEP_FAILED) {
 				/* If there are non-failed leafs we are still trying. */
 				json_add_string(ret, "status", "pending");
 

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -30,9 +30,9 @@ struct createonion_request {
 
 /* States returned by listsendpays, waitsendpay, etc. */
 enum payment_result_state {
-	PAYMENT_PENDING,
-	PAYMENT_COMPLETE,
-	PAYMENT_FAILED,
+	PAYMENT_PENDING = 1,
+	PAYMENT_COMPLETE = 2,
+	PAYMENT_FAILED = 4,
 };
 
 /* A parsed version of the possible outcomes that a sendpay / payment may


### PR DESCRIPTION
Had these laying around for some time, and finally bundled them up.

 - Using wrong enum for pay status
 - Simplify the state aggregation by using orthogonal enum values
 - Silently drop the -27 already in chain failure in `bcli`
 - Error message not matching the verification

Especially the silencing of -27 should finally stabilize the lnprototests, but I'd like to have either @niftynei or @rusty check that it's actually ok to do.