### PR TITLE
pytest: fix flake in test_gossip.py::test_addgossip

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1933,9 +1933,8 @@ def test_addgossip(node_factory):
     # 0x0100 = channel_announcement
     # 0x0102 = channel_update
     # 0x0101 = node_announcement
-    ann = l1.daemon.is_in_log(r"\[OUT\] 0100.*")
-    if ann is None:
-        ann = l2.daemon.is_in_log(r"\[OUT\] 0100.*")
+    l1.daemon.logsearch_start = 0
+    ann = l1.daemon.wait_for_log(r"\[OUT\] 0100.*")
 
     upd1 = l1.daemon.is_in_log(r"\[OUT\] 0102.*")
     upd2 = l2.daemon.is_in_log(r"\[OUT\] 0102.*")


### PR DESCRIPTION
We can miss it in both logs, so wait for it instead:

```
2021-09-22T07:25:59.1582950Z >       l3.rpc.addgossip(ann.split()[3])
2021-09-22T07:25:59.1583911Z E       AttributeError: 'NoneType' object has no attribute 'split'
```

Changelog-None