### PR TITLE
gci: Add macOS configuration to test compatibility

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,94 @@
+---
+name: Mac OS pytest
+on: [push, pull_request]
+jobs:
+  smoke-test:
+    name: Smoke Test macOS
+    runs-on: macos-latest
+    env:
+      DEVELOPER: 1
+      VALGRIND: 0
+      EXPERIMENTAL_FEATURES: 1
+      COMPAT: 0
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Install dependencies
+        run: |
+          export BITCOIN_VERSION=0.20.1
+          brew install wget python autoconf automake libtool python3 gmp gnu-sed gettext libsodium
+
+          (
+            cd /tmp/
+            wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-osx64.tar.gz -O bitcoin.tar.gz
+            tar -xvzf bitcoin.tar.gz
+            sudo mv bitcoin-$BITCOIN_VERSION/bin/* /usr/local/bin
+          )
+          
+          pip install --upgrade mako pip
+          ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
+          export PATH="/usr/local/opt:$PATH"
+
+      - name: Build
+        env:
+          VALGRIND: ${{ matrix.VALGRIND }}
+          DEVELOPER: ${{ matrix.DEVELOPER }}
+          EXPERIMENTAL_FEATURES: ${{ matrix.EXPERIMENTAL_FEATURES }}
+          COMPILER: ${{ matrix.COMPILER }}
+          COMPAT: ${{ matrix.COMPAT }}
+          PYTEST_PAR: ${{ matrix.PYTEST_PAR }}
+          PYTEST_OPTS: ${{ matrix.PYTEST_OPTS }}
+          NO_PYTHON: ${{ matrix.NO_PYTHON }}
+          COPTFLAGS: ${{ matrix.COPTFLAGS }}
+          NETWORK: ${{ matrix.NETWORK }}
+          TEST_CMD: ${{ matrix.TEST_CMD }}
+          TEST_GROUP_COUNT: ${{ matrix.TEST_GROUP_COUNT }}
+          TEST_GROUP: ${{ matrix.TEST_GROUP }}
+        run: |
+          export PATH="/usr/local/opt:$PATH"
+          export LDFLAGS="-L/usr/local/opt/sqlite/lib"
+          export CPPFLAGS="-I/usr/local/opt/sqlite/include"
+
+          pip3 install -U \
+            -r requirements.txt \
+            -r contrib/pyln-client/requirements.txt \
+            -r contrib/pyln-proto/requirements.txt \
+            -r contrib/pyln-testing/requirements.txt
+
+            # Install utilities that aren't dependencies, but make
+            # running tests easier/feasible on CI (and pytest which
+            # keeps breaking the rerunfailures plugin).
+          pip3 install -U \
+            flaky \
+            blinker \
+            pytest-sentry \
+            pytest-test-groups==1.0.3 \
+            pytest-custom-exit-code==0.3.0 \
+            pytest-json-report \
+            mypy==0.790
+
+          cat << EOF > pytest.ini
+          [pytest]
+          addopts=-p no:logging --color=yes --timeout=600 --timeout-method=thread --test-group-random-seed=42 --force-flaky --no-success-flaky-report --max-runs=3 --junitxml=report.xml --json-report --json-report-file=report.json --json-report-indent=2
+          markers =
+              slow_test: marks tests as slow (deselect with '-m "not slow_test"')
+          EOF
+
+          ./configure
+          make
+
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Junit Report ${{ github.run_number }}.${{ matrix.cfg }}
+          path: report.*
+          if-no-files-found: ignore


### PR DESCRIPTION
First part of https://github.com/ElementsProject/lightning/issues/4708, building Mac OS on every push and pull request, to make sure we don't break it accidentally.

We don't test since `make pytest` on Github Actions + Mac OS is very flaky, I'll continue working on enabling testing, but that might take a while.

Changelog-None