### PR TITLE
pytest: Stabilize `test_addgossip`

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1934,7 +1934,7 @@ def test_addgossip(node_factory):
     # 0x0102 = channel_update
     # 0x0101 = node_announcement
     l1.daemon.logsearch_start = 0
-    ann = l1.daemon.wait_for_log(r"\[OUT\] 0100.*")
+    ann = l1.daemon.wait_for_log(r"\[(OUT|IN)\] 0100.*")  # Either direction will suppress the other.
 
     upd1 = l1.daemon.is_in_log(r"\[OUT\] 0102.*")
     upd2 = l2.daemon.is_in_log(r"\[OUT\] 0102.*")


### PR DESCRIPTION
It was incredibly flaky due to the potential for l2 announcing the
channel before l1 could get to it, thus suppressing the outgoing
announcement which we were looking for. This now checks either
direction.

Before this fix the failure rate was 24% (out of 100 runs), afterwards
it's 0%.

Changelog-None
