### PR TITLE
bolt7: dns support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ contrib/pyln-*/.eggs/
 contrib/pyln-*/pyln/*/__version__.py
 release/
 tests/plugins/test_selfdisable_after_getmanifest
-.DS_Store
 
 # Ignore generated files
 devtools/features
@@ -60,3 +59,7 @@ doc/lightning*.[1578]
 *_wiregen.[ch]
 *_printgen.[ch]
 *_gettextgen.po
+
+# Ignore unrelated stuff
+.DS_Store
+.gdb_history

--- a/common/json_helpers.c
+++ b/common/json_helpers.c
@@ -281,6 +281,10 @@ void json_add_address(struct json_stream *response, const char *fieldname,
 		json_add_string(response, "type", "torv3");
 		json_add_string(response, "address", fmt_wireaddr_without_port(tmpctx, addr));
 		json_add_num(response, "port", addr->port);
+	} else if (addr->type == ADDR_TYPE_DNS) {
+		json_add_string(response, "type", "dns");
+		json_add_string(response, "address", fmt_wireaddr_without_port(tmpctx, addr));
+		json_add_num(response, "port", addr->port);
 	} else if (addr->type == ADDR_TYPE_WEBSOCKET) {
 		json_add_string(response, "type", "websocket");
 		json_add_num(response, "port", addr->port);

--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -117,6 +117,26 @@ int main(int argc, char *argv[])
 
 	common_setup(argv[0]);
 
+	/* Check IP/TOR/DNS parser */
+	assert(is_ipaddr("192.168.1.2"));
+	assert(!is_ipaddr("foo.bar.1.2"));
+	assert(is_toraddr("qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion"));
+	assert(is_toraddr("qubesos4rrrrz6n4.onion"));
+	assert(!is_toraddr("QUBESOSfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion"));
+	assert(!is_toraddr("QUBESOS4rrrrz6n4.onion"));
+	assert(!is_toraddr("qubesos-asa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion"));
+	assert(is_dnsaddr("example.com"));
+	assert(is_dnsaddr("example.digits123.com"));
+	assert(is_dnsaddr("example-hyphen.com"));
+	assert(is_dnsaddr("123example.com"));
+	assert(is_dnsaddr("example123.com"));
+	assert(is_dnsaddr("is-valid.3hostname123.com"));
+	assert(!is_dnsaddr("UPPERCASE.invalid.com"));
+	assert(!is_dnsaddr("-.invalid.com"));
+	assert(!is_dnsaddr("invalid.-example.com"));
+	assert(!is_dnsaddr("invalid.example-.com"));
+	assert(!is_dnsaddr("invalid..example.com"));
+
 	/* Grossly invalid. */
 	assert(!separate_address_and_port(tmpctx, "[", &ip, &port));
 	assert(!separate_address_and_port(tmpctx, "[123", &ip, &port));
@@ -147,6 +167,19 @@ int main(int argc, char *argv[])
 	assert(separate_address_and_port(tmpctx, "192.168.2.255", &ip, &port));
 	assert(streq(ip, "192.168.2.255"));
 	assert(port == 0);
+
+	/* DNS types */
+	assert(separate_address_and_port(tmpctx, "example.com:42", &ip, &port));
+	assert(streq(ip, "example.com"));
+	assert(port == 42);
+	assert(separate_address_and_port(tmpctx, "sub.example.com:21", &ip, &port));
+	assert(streq(ip, "sub.example.com"));
+	assert(port == 21);
+	port = 123;
+	assert(separate_address_and_port(tmpctx, "sub.example.com", &ip, &port));
+	assert(streq(ip, "sub.example.com"));
+	assert(port == 123);
+	port = 0;
 
 	// unusual but possibly valid case
 	assert(separate_address_and_port(tmpctx, "[::1]", &ip, &port));

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -37,13 +37,18 @@ struct sockaddr_un;
  *             where `checksum = sha3(".onion checksum" | pubkey || version)[:2]`
  */
 
+/* BOLT-hostnames #7:
+ *   * `5`: DNS hostname; data = `[byte:len][len*byte:hostname][u16:port]` (length up to 258)
+ */
+
 /* BOLT-websockets #7:
  *    * `6`: WebSocket port; data = `[2:port]` (length 2)
  */
 
 #define	TOR_V2_ADDRLEN 10
 #define	TOR_V3_ADDRLEN 35
-#define	LARGEST_ADDRLEN TOR_V3_ADDRLEN
+#define	DNS_ADDRLEN 255
+#define	LARGEST_ADDRLEN DNS_ADDRLEN
 #define	TOR_V3_BLOBLEN 64
 #define	STATIC_TOR_MAGIC_STRING "gen-default-toraddress"
 
@@ -52,10 +57,10 @@ enum wire_addr_type {
 	ADDR_TYPE_IPV6 = 2,
 	ADDR_TYPE_TOR_V2_REMOVED = 3,
 	ADDR_TYPE_TOR_V3 = 4,
-	ADDR_TYPE_WEBSOCKET = 6,
+	ADDR_TYPE_DNS = 5,
+	ADDR_TYPE_WEBSOCKET = 6
 };
 
-/* Structure now fit for tor support */
 struct wireaddr {
 	enum wire_addr_type type;
 	u8 addrlen;

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -149,6 +149,16 @@ struct wireaddr_internal {
 
 bool wireaddr_internal_eq(const struct wireaddr_internal *a,
 			  const struct wireaddr_internal *b);
+
+bool separate_address_and_port(const tal_t *ctx, const char *arg,
+			       char **addr, u16 *port);
+
+bool is_ipaddr(const char *arg);
+
+bool is_toraddr(const char *arg);
+
+bool is_dnsaddr(const char *arg);
+
 bool parse_wireaddr_internal(const char *arg, struct wireaddr_internal *addr,
 			     u16 port, bool wildcard_ok, bool dns_ok,
 			     bool unresolved_ok, bool allow_deprecated,

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -928,12 +928,14 @@ static void try_connect_one_addr(struct connecting *connect)
 	bool use_proxy = connect->daemon->always_use_proxy;
 	const struct wireaddr_internal *addr = &connect->addrs[connect->addrnum];
 	struct io_conn *conn;
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	bool use_dns = connect->daemon->use_dns;
 	struct addrinfo hints, *ais, *aii;
 	struct wireaddr_internal addrhint;
 	int gai_err;
 	struct sockaddr_in *sa4;
 	struct sockaddr_in6 *sa6;
+#endif
 
 	/* In case we fail without a connection, make destroy_io_conn happy */
 	connect->conn = NULL;
@@ -984,6 +986,7 @@ static void try_connect_one_addr(struct connecting *connect)
 			af = AF_INET6;
 			break;
 		case ADDR_TYPE_DNS:
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 			if (use_proxy) /* hand it to the proxy */
 				break;
 			if (!use_dns)  /* ignore DNS when we can't use it */
@@ -1025,6 +1028,7 @@ static void try_connect_one_addr(struct connecting *connect)
 				addr = &connect->addrs[connect->addrnum];
 			}
 			freeaddrinfo(ais);
+#endif
 			goto next;
 		case ADDR_TYPE_WEBSOCKET:
 			af = -1;
@@ -1666,8 +1670,10 @@ static void add_seed_addrs(struct wireaddr_internal **addrs,
 		                                   NULL, broken_reply, NULL);
 		if (new_addrs) {
 			for (size_t j = 0; j < tal_count(new_addrs); j++) {
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 				if (new_addrs[j].type == ADDR_TYPE_DNS)
 					continue;
+#endif
 				struct wireaddr_internal a;
 				a.itype = ADDR_INTERNAL_WIREADDR;
 				a.u.wireaddr = new_addrs[j];

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -975,6 +975,9 @@ static void try_connect_one_addr(struct connecting *connect)
 		case ADDR_TYPE_IPV6:
 			af = AF_INET6;
 			break;
+		case ADDR_TYPE_DNS:
+			// TODO: resolve with getaddrinfo and set af
+			break;
 		case ADDR_TYPE_WEBSOCKET:
 			af = -1;
 			break;
@@ -1159,6 +1162,7 @@ static bool handle_wireaddr_listen(struct daemon *daemon,
 	case ADDR_TYPE_WEBSOCKET:
 	case ADDR_TYPE_TOR_V2_REMOVED:
 	case ADDR_TYPE_TOR_V3:
+	case ADDR_TYPE_DNS:
 		break;
 	}
 	status_failed(STATUS_FAIL_INTERNAL_ERROR,
@@ -1614,6 +1618,8 @@ static void add_seed_addrs(struct wireaddr_internal **addrs,
 		                                   NULL, broken_reply, NULL);
 		if (new_addrs) {
 			for (size_t j = 0; j < tal_count(new_addrs); j++) {
+				if (new_addrs[j].type == ADDR_TYPE_DNS)
+					continue;
 				struct wireaddr_internal a;
 				a.itype = ADDR_INTERNAL_WIREADDR;
 				a.u.wireaddr = new_addrs[j];

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -875,6 +875,7 @@ static struct io_plan *conn_init(struct io_conn *conn,
 		break;
 	case ADDR_INTERNAL_WIREADDR:
 		/* If it was a Tor address, we wouldn't be here. */
+		assert(!is_toraddr((char*)addr->u.wireaddr.addr));
 		ai = wireaddr_to_addrinfo(tmpctx, &addr->u.wireaddr);
 		break;
 	}

--- a/connectd/netaddress.c
+++ b/connectd/netaddress.c
@@ -258,6 +258,7 @@ bool guess_address(struct wireaddr *addr)
     }
     case ADDR_TYPE_TOR_V2_REMOVED:
     case ADDR_TYPE_TOR_V3:
+    case ADDR_TYPE_DNS:
     case ADDR_TYPE_WEBSOCKET:
         status_broken("Cannot guess address type %u", addr->type);
         break;

--- a/devtools/gossipwith.c
+++ b/devtools/gossipwith.c
@@ -324,6 +324,9 @@ int main(int argc, char *argv[])
 		case ADDR_TYPE_WEBSOCKET:
 			opt_usage_exit_fail("Don't support websockets");
 			break;
+		case ADDR_TYPE_DNS:
+			opt_usage_exit_fail("Don't support DNS");
+			break;
 		case ADDR_TYPE_IPV4:
 			af = AF_INET;
 			break;

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -40,10 +40,10 @@ On success, an object is returned, containing:
 - **network** (string): represents the type of network on the node are working (e.g: `bitcoin`, `testnet`, or `regtest`)
 - **fees_collected_msat** (msat): Total routing fees collected by this node
 - **address** (array of objects, optional): The addresses we announce to the world:
-  - **type** (string): Type of connection (one of "ipv4", "ipv6", "torv2", "torv3", "websocket")
+  - **type** (string): Type of connection (one of "dns", "ipv4", "ipv6", "torv2", "torv3", "websocket")
   - **port** (u16): port number
 
-  If **type** is "ipv4", "ipv6", "torv2" or "torv3":
+  If **type** is "dns", "ipv4", "ipv6", "torv2" or "torv3":
     - **address** (string): address in expected format for **type**
 - **binding** (array of objects, optional): The addresses we are listening on:
   - **type** (string): Type of connection (one of "local socket", "ipv4", "ipv6", "torv2", "torv3")
@@ -117,4 +117,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:8374064ca0f95ab0c20d3edaf7f3742316af98f4d1e0e8de88922524f1ea3ce5)
+[comment]: # ( SHA256STAMP:90a3bacb6cb4456119afee8e60677c29bf5f46c4cd950e660a9f9c8e0433b473)

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -36,10 +36,10 @@ If **last_timestamp** is present:
   - **color** (hex): The favorite RGB color this node advertized (always 6 characters)
   - **features** (hex): BOLT #9 features bitmap this node advertized
   - **addresses** (array of objects): The addresses this node advertized:
-    - **type** (string): Type of connection (one of "ipv4", "ipv6", "torv2", "torv3", "websocket")
+    - **type** (string): Type of connection (one of "dns", "ipv4", "ipv6", "torv2", "torv3", "websocket")
     - **port** (u16): port number
 
-    If **type** is "ipv4", "ipv6", "torv2" or "torv3":
+    If **type** is "dns", "ipv4", "ipv6", "torv2" or "torv3":
       - **address** (string): address in expected format for **type**
 
 If **option_will_fund** is present:
@@ -52,9 +52,9 @@ If **option_will_fund** is present:
     - **compact_lease** (hex): the lease as represented in the node_announcement
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
-  
+
 On failure, one of the following error codes may be returned:
- 
+
 - -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE
@@ -89,10 +89,10 @@ Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version o
 SEE ALSO
 --------
 
-FIXME: 
+FIXME:
 
 RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:4a5cfb1cf3d7fd77e49d6e7e369a9a6d374345b011d7db2fa9b4062156869ca4)
+[comment]: # ( SHA256STAMP:85400c9c1741943e2e02935b4f14fd187a7db6056410e42adec07ef3c6772f5f)

--- a/doc/schemas/getinfo.schema.json
+++ b/doc/schemas/getinfo.schema.json
@@ -86,6 +86,7 @@
           "type": {
             "type": "string",
             "enum": [
+              "dns",
               "ipv4",
               "ipv6",
               "torv2",
@@ -104,6 +105,7 @@
             "type": {
               "type": "string",
               "enum": [
+                "dns",
                 "ipv4",
                 "ipv6",
                 "torv2",

--- a/doc/schemas/listnodes.schema.json
+++ b/doc/schemas/listnodes.schema.json
@@ -74,6 +74,7 @@
                       "type": {
                         "type": "string",
                         "enum": [
+                          "dns",
                           "ipv4",
                           "ipv6",
                           "torv2",
@@ -92,6 +93,7 @@
                         "type": {
                           "type": "string",
                           "enum": [
+                            "dns",
                             "ipv4",
                             "ipv6",
                             "torv2",

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1050,8 +1050,8 @@ static void register_opts(struct lightningd *ld)
 			 "Comma separated list of extra TLV types to accept.");
 #endif
 
-	opt_register_noarg("--disable-dns", opt_set_invbool, &ld->config.use_dns,
-			   "Disable DNS lookups of peers");
+	opt_register_early_noarg("--disable-dns", opt_set_invbool, &ld->config.use_dns,
+				 "Disable DNS lookups of peers");
 
 	if (deprecated_apis)
 		opt_register_noarg("--enable-autotor-v2-mode", opt_set_invbool, &ld->config.use_v3_autotor,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -191,7 +191,6 @@ static char *opt_add_addr_withtype(const char *arg,
 
 	assert(arg != NULL);
 
-	tal_arr_expand(&ld->proposed_listen_announce, ala);
 	if (!parse_wireaddr_internal(arg, &wi,
 				     ld->portnum,
 				     wildcard_ok, !ld->always_use_proxy, false,
@@ -210,6 +209,8 @@ static char *opt_add_addr_withtype(const char *arg,
 				       ala & ADDR_ANNOUNCE ? "announce" : "listen",
 				       type_to_string(tmpctx, struct wireaddr_internal, &wi));
 	}
+
+	tal_arr_expand(&ld->proposed_listen_announce, ala);
 	tal_arr_expand(&ld->proposed_wireaddr, wi);
 	return NULL;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -188,12 +188,14 @@ static char *opt_add_addr_withtype(const char *arg,
 {
 	char const *err_msg;
 	struct wireaddr_internal wi;
+	bool dns_ok;
 
 	assert(arg != NULL);
+	dns_ok = !ld->always_use_proxy && ld->config.use_dns;
 
 	if (!parse_wireaddr_internal(arg, &wi,
 				     ld->portnum,
-				     wildcard_ok, !ld->always_use_proxy, false,
+				     wildcard_ok, dns_ok, false,
 				     deprecated_apis, &err_msg)) {
 		return tal_fmt(NULL, "Unable to parse address '%s': %s", arg, err_msg);
 	}

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -221,6 +221,7 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
 
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	/* Add ADDR_TYPE_DNS to announce DNS hostnames */
 	if (is_dnsaddr(address) && ala & ADDR_ANNOUNCE) {
 		memset(&wi, 0, sizeof(wi));
@@ -234,6 +235,7 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_listen_announce, ADDR_ANNOUNCE);
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
+#endif
 
 	return NULL;
 


### PR DESCRIPTION
This implements RFC https://github.com/lightningnetwork/lightning-rfc/pull/911 to allow annoucements of DNS hostnames.
The feature can only be used with `EXPERIMENTAL`.
The bold quotes are disabled in the topmost commit to please CI.

Adds:
 - related fixes and changes (i.e. announce up to two addresses of the same type)
 - feature itself
 - and tests