### PR TITLE
common/json.c: Have `json_add_literal` *use* `len` argument.

### DIFF
--- a/common/json.c
+++ b/common/json.c
@@ -1077,9 +1077,9 @@ void json_add_literal(struct json_stream *result, const char *fieldname,
 		      const char *literal, int len)
 {
 	/* Literal may contain quotes, so bypass normal checks */
-	char *dest = json_member_direct(result, fieldname, strlen(literal));
+	char *dest = json_member_direct(result, fieldname, len);
 	if (dest)
-		memcpy(dest, literal, strlen(literal));
+		memcpy(dest, literal, len);
 }
 
 void json_add_stringn(struct json_stream *result, const char *fieldname,


### PR DESCRIPTION
The current `json_add_literal` does not use its `len` argument, at all:

https://github.com/ElementsProject/lightning/blob/09c2fef4a409d70f4be150e8b4c8900d5c1c5d88/common/json.c#L1076-L1083

Which is something of a WTF, why even require the `len` argument if it
is not even used in the function?
This would have been acceptable if it were a callback and the
callback-requiring function passed it in always, but this function is
not intended to be a callback but instead to be called directly.

Existing callers always pass in `strlen(literal)`, so this bug was not
noticed before:

https://github.com/ElementsProject/lightning/blob/09c2fef4a409d70f4be150e8b4c8900d5c1c5d88/lightningd/jsonrpc.c#L511
https://github.com/ElementsProject/lightning/blob/09c2fef4a409d70f4be150e8b4c8900d5c1c5d88/lightningd/jsonrpc.c#L583
https://github.com/ElementsProject/lightning/blob/09c2fef4a409d70f4be150e8b4c8900d5c1c5d88/lightningd/options.c#L1408-L1409