### PR TITLE
Small Mac OS X python test fixes

### DIFF
--- a/common/daemon.c
+++ b/common/daemon.c
@@ -176,6 +176,7 @@ void daemon_maybe_debug(char *argv[])
 		 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425 */
 		if (system(cmd))
 			;
+		tal_free(cmd);
 		/* Continue in the debugger. */
 		kill(getpid(), SIGSTOP);
 	}

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -96,7 +96,7 @@ def test_reconnect_channel_peers(node_factory, executor):
     wait_for(lambda: not only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'])
 
     # Now should fail.
-    with pytest.raises(RpcError, match=r'Connection refused'):
+    with pytest.raises(RpcError, match=r'(Connection refused|Bad file descriptor)'):
         l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
     # Wait for exponential backoff to give us a 2 second window.
@@ -2040,7 +2040,7 @@ def test_multifunding_best_effort(node_factory, bitcoind):
     # With 2 down, it will fail to fund channel
     l2.stop()
     l3.stop()
-    with pytest.raises(RpcError, match=r'Connection refused'):
+    with pytest.raises(RpcError, match=r'(Connection refused|Bad file descriptor)'):
         l1.rpc.multifundchannel(destinations, minchannels=2)
 
     # This works though.

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -129,7 +129,7 @@ def test_multifunding_v2_best_effort(node_factory, bitcoind):
     # With 2 down, it will fail to fund channel
     l2.stop()
     l3.stop()
-    with pytest.raises(RpcError, match=r'Connection refused'):
+    with pytest.raises(RpcError, match=r'(Connection refused|Bad file descriptor)'):
         l1.rpc.multifundchannel(destinations, minchannels=2)
 
     # This works though.


### PR DESCRIPTION
* A memory leak detected (in debug mode only)
* Fix raised error testing regex to work on Mac OS X in a few places