### PR TITLE
Fixes msat and sat convention in the error message.

### DIFF
--- a/openingd/common.c
+++ b/openingd/common.c
@@ -133,6 +133,9 @@ bool check_config_bounds(const tal_t *ctx,
 	 * set by lightningd, don't bother opening it. */
 	if (amount_msat_greater_sat(min_effective_htlc_capacity,
 				    capacity)) {
+		struct amount_sat min_effective_htlc_capacity_sat =
+			amount_msat_to_sat_round_down(min_effective_htlc_capacity);
+
 		*err_reason = tal_fmt(ctx,
 				      "channel capacity with funding %s,"
 				      " reserves %s/%s,"
@@ -148,8 +151,8 @@ bool check_config_bounds(const tal_t *ctx,
 						     &remoteconf->max_htlc_value_in_flight),
 				      type_to_string(ctx, struct amount_sat,
 						     &capacity),
-				      type_to_string(ctx, struct amount_msat,
-						     &min_effective_htlc_capacity));
+				      type_to_string(ctx, struct amount_sat,
+						     &min_effective_htlc_capacity_sat));
 		return false;
 	}
 

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -31,8 +31,10 @@ static struct command_result *sendonionmessage_error(struct command *cmd,
 						     const jsmntok_t *err,
 						     void *unused)
 {
-	plugin_log(cmd->plugin, LOG_BROKEN,
-		   "sendoniomessage gave JSON error: %.*s",
+	/* This can happen if the peer goes offline or wasn't directly
+	 * connected: "Unknown first peer" */
+	plugin_log(cmd->plugin, LOG_DBG,
+		   "sendonionmessage gave JSON error: %.*s",
 		   json_tok_full_len(err),
 		   json_tok_full(buf, err));
 	return command_hook_success(cmd);

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -213,17 +213,17 @@ def test_opening_tiny_channel(node_factory):
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*msat'):
+    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l2, l2_min_capacity + overhead - 1)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.fundchannel(l2, l2_min_capacity + overhead)
 
-    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*msat'):
+    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l3, l3_min_capacity + overhead - 1)
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.fundchannel(l3, l3_min_capacity + overhead)
 
-    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*msat'):
+    with pytest.raises(RpcError, match=r'They sent [error|warning].*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l4, l4_min_capacity + overhead - 1)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
     l1.fundchannel(l4, l4_min_capacity + overhead)
@@ -231,7 +231,7 @@ def test_opening_tiny_channel(node_factory):
     # Note that this check applies locally too, so you can't open it if
     # you would reject it.
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    with pytest.raises(RpcError, match=r"channel capacity is .*, which is below .*msat"):
+    with pytest.raises(RpcError, match=r"channel capacity is .*, which is below .*sat"):
         l3.fundchannel(l2, l3_min_capacity + overhead - 1)
     l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l3.fundchannel(l2, l3_min_capacity + overhead)


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/4827

Preferring to round from `msat to sat,` instant to fail from `sat to msat`

Changelog-None: Avoid mixing different currency conventions in a generic error message.