### PR TITLE
closingd: ignore spurious pong messages.

### DIFF
--- a/closingd/closingd.c
+++ b/closingd/closingd.c
@@ -284,6 +284,9 @@ receive_offer(struct per_peer_state *pps,
 		 */
 		else if (fromwire_peektype(msg) == WIRE_SHUTDOWN)
 			msg = tal_free(msg);
+		/* channeld may have sent ping: ignore pong! */
+		else if (fromwire_peektype(msg) == WIRE_PONG)
+			msg = tal_free(msg);
 	} while (!msg);
 
 	their_sig.sighash_type = SIGHASH_ALL;


### PR DESCRIPTION
channeld may have sent a ping before shutdown, now closingd sees it.

```
lightningd-2: 2021-10-11T20:55:18.892Z DEBUG   0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-closingd-chan#1: peer_out WIRE_WARNING
lightningd-2: 2021-10-11T20:55:18.949Z DEBUG   0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-closingd-chan#1: billboard perm: Expected closing_signed: 0013000166
lightningd-2: 2021-10-11T20:55:18.983Z INFO    0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-chan#1: Peer transient failure in CLOSINGD_SIGEXCHANGE: closingd WARNING: Expected closing_signed: 0013000166
```
Changelog-None