### PR TITLE
Move log level from warning to info when create a new ln directory

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1211,7 +1211,7 @@ void handle_early_opts(struct lightningd *ld, int argc, char *argv[])
 	/*~ Move into config dir: this eases path manipulation and also
 	 * gives plugins a good place to store their stuff. */
 	if (chdir(ld->config_netdir) != 0) {
-		log_unusual(ld->log, "Creating configuration directory %s",
+		log_info(ld->log, "Creating configuration directory %s",
 			    ld->config_netdir);
 		/* We assume home dir exists, so only create two. */
 		if (mkdir(ld->config_basedir, 0700) != 0 && errno != EEXIST)


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/4869.

I agree with the idea that we need to give the possibility to run a log in a quiet way.

Changelog-None: Move log level from warning to info when creating a new ln directory.
