### PR TITLE
Fix typo in the fund channel error message

### DIFF
--- a/plugins/spender/fundchannel.c
+++ b/plugins/spender/fundchannel.c
@@ -132,7 +132,7 @@ fundchannel_get_result(struct command *cmd,
 
 	if (!ok)
 		plugin_err(cmd->plugin,
-			   "Unexpected result from nultifundchannel: %.*s",
+			   "Unexpected result from multifundchannel: %.*s",
 			   json_tok_full_len(result),
 			   json_tok_full(buf, result));
 


### PR DESCRIPTION
During my walk throw the code, I found this typo in the error message.

Changelog-None: Fix typo in the fund channel error message

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>