### PR TITLE
Guess to remote: support anchor channel commitments

### DIFF
--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -15,6 +15,7 @@ struct amount_sat;
 struct bitcoin_outpoint;
 struct bitcoin_signature;
 struct bitcoin_txid;
+struct sha256_double;
 struct pubkey;
 
 /** psbt_destroy - Destroy a PSBT that is not tal-allocated
@@ -228,6 +229,14 @@ void psbt_output_set_unknown(const tal_t *ctx,
 			     struct wally_psbt_output *out,
 			     const u8 *key, const void *value,
 			     size_t value_len);
+
+/* psbt_input_hash_for_sig - Produce (SegWit) signing hash for PSBT's input
+ *
+ * @psbt - psbt with input to produce hash of
+ * @in   - input to produce hash for
+ * @dest - hash result */
+void psbt_input_hash_for_sig(struct wally_psbt *psbt, size_t in,
+			     struct sha256_double *dest);
 
 /* psbt_input_get_amount - Returns the value of this input
  *

--- a/doc/RECOVER_ANCHOR.md
+++ b/doc/RECOVER_ANCHOR.md
@@ -1,0 +1,70 @@
+# Recovering (Very Lost) Anchor Outputs
+
+So the worst has happened and you've suffered a terrible dataloss. You've tried reconnecting to your peers, and they've sent all of your channels to chain.
+
+Now you're attempting to recover your lost funds by reclaiming all of the
+funds from on-chain outputs.
+
+There are *two* types of on-chain outputs that you might encounter:
+	- P2WPKH, which just need a private key to spend
+	- P2WSH, which need a script and some special handling to spend
+
+If the channel was using anchor outputs, then the output will be P2WSH.
+
+Never fear, we'll walk you through how to get your funds back for both of these.
+
+## guesstoremote
+
+The first thing you'll need is the peer's public id and the on-chain address that they paid your funds to when they unilaterally closed on you. You'll also need your `hsm_secret` file. We'll pass all of this through the `guesstoremote` recovery option.
+
+Required inputs:
+	- `hsm_secret` file
+	- the public id of the node you were a peer with
+	- the onchain address of the funds you're trying to recover
+
+
+Once you have these things for a channel, run them through `guesstoremote`.
+
+	$ ./tools/guesstoremote <onchain address> <node_id> 1000 <path to hsm_secret file>
+
+If the result you get lists a wif and privkey, then this is a P2WPKH output. You just need to import the WIF into bitcoind to be able to spend this address.
+
+	: bech32      :
+	: pubkey hash :
+	: pubkey      :
+	: privkey     :
+	: wif         :
+
+If the result you get lists a  'csv' and 'script hash', this is a P2WSH and you'll need to use the `recover_anchor` tool to get a signature for it.
+
+	: bech32      :
+	: script hash :
+	: script      :
+	: csv         :
+	: pubkey      :
+	: privkey     :
+
+## `recover_anchor`
+
+To spend an output that's a P2WSH, you'll first need to make a PSBT that spends that output. You can do this using bitcoin-cli's `createpsbt`. Make sure that you add the correct change output etc.
+
+Here's an example. Note that you'll need to get your own address for the output and figure out what the amount should be yourself. There may be other tools that are easier to use for this.
+
+The `txid` input in this case is the output we want to recover. You'll also need to know the exact amount, in satoshis, that you're trying to recover.
+
+	$ bitcoin-cli createpsbt '[{"txid": "f4b9ba88f98d2540573a0abecae247059c9c86749c4a03d71b894fabe96fc9ed", "vout":1, "sequence":0}]' '[{"tb1qcsrpjt06gsrzxkr4cyt933r9nguzmc0hlh5x6s":0.00001000}]'
+
+Once you have a PSBT, we'll pass the PSBT and the data output from `guesstoremote` to the `./tools/recover_anchor` tool.
+
+	$ ./tools/recover_anchor \
+		<psbt> 		 \ # psbt
+		0		 \ # index on the psbt to sign
+		643221sat	 \ # amount of the output we're saving
+		<script> 	 \ # script from guesstoremote
+		4019		 \ # csv from guesstoremote
+		<privkey>	   # privkey from guesstoremote
+
+This will return a PSBT with a signature for the indicated output. You can then finalize and broadcast this transaction.
+
+	$ bitcoin-cli finalizepsbt <psbt with signed output>
+	$ bitcoin-cli sendrawtransaction <hex>

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -2781,8 +2781,6 @@ static void handle_our_unilateral(const struct tx_parts *tx,
 		     to_self_delay[LOCAL],
 		     tal_hex(tmpctx, script[LOCAL]),
 		     tal_hex(tmpctx, local_wscript));
-	status_debug("Script to-them: %s",
-		     tal_hex(tmpctx, script[REMOTE]));
 
 	for (i = 0; i < tal_count(tx->outputs); i++) {
 		if (tx->outputs[i]->script == NULL)
@@ -2836,6 +2834,8 @@ static void handle_our_unilateral(const struct tx_parts *tx,
 		if (script[REMOTE]
 		    && wally_tx_output_scripteq(tx->outputs[i],
 						script[REMOTE])) {
+			status_debug("Script to-them: %s",
+				     tal_hex(tmpctx, script[REMOTE]));
 			/* BOLT #5:
 			 *
 			 *     - MAY ignore the `to_remote` output.
@@ -2936,6 +2936,8 @@ static void handle_our_unilateral(const struct tx_parts *tx,
 					if (!wally_tx_output_scripteq(tx->outputs[i], script[REMOTE]))
 						continue;
 
+					status_debug("Script to-them: %s",
+						     tal_hex(tmpctx, script[REMOTE]));
 					/* BOLT #5:
 					 *
 					 *     - MAY ignore the `to_remote` output.

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1195,6 +1195,43 @@ def test_hsmtool_dump_descriptors(node_factory, bitcoind):
     assert len(bitcoind.rpc.listunspent(1, 1, [addr])) == 1
 
 
+@pytest.mark.openchannel('v1')
+def test_hsmtool_guess_to_remote_non_anchor(node_factory, bitcoind):
+    l1, l2 = node_factory.get_nodes(2)
+    # Allow l2 some warnings
+    l2.allow_warning = True
+    amount = 500000
+    l1.fundwallet(20000000)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.fundchannel(l2.info['id'], amount)
+    bitcoind.generate_block(6)
+    l1.daemon.wait_for_log('to CHANNELD_NORMAL')
+    wait_for(lambda: [c['active'] for c in l1.rpc.listchannels(l1.get_channel_scid(l2))['channels']] == [True, True])
+
+    # unilateral close channels l1<->l2
+    l1.stop()
+    l2.rpc.close(l1.info['id'], 1)
+
+    # Wait til to_self_delay expires, l1 should claim to_local back
+    bitcoind.generate_block(10, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l2])
+    log = l2.daemon.wait_for_log(r'Script to-them: ')
+    m = re.search(r'Script to-them: ([a-f0-9]{44})', log)
+    onchain_addr = bitcoind.rpc.decodescript(m.group(1))['address']
+
+    # Now try using the hsmtool to find the thing
+    hsm_path = os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, "hsm_secret")
+    hsmtool = HsmTool("guesstoremote", onchain_addr,
+                      l2.info['id'], str(100), hsm_path)
+    master_fd, slave_fd = os.openpty()
+    hsmtool.start(stdin=slave_fd,
+                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    hsmtool.wait_for_log(r"bech32")
+    hsmtool.wait_for_log(r"pubkey hash")
+    hsmtool.wait_for_log(r"wif")
+
+
 @unittest.skipIf(TEST_NETWORK == 'liquid-regtest', 'v2 channels not available')
 @pytest.mark.openchannel('v2')
 @pytest.mark.developer("requres 'dev-queryrates'")

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -2,3 +2,4 @@ headerversions
 check-bolt
 hsmtool
 lightning-hsmtool
+recover_anchor

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
 #! /usr/bin/make
-TOOLS := tools/hsmtool tools/check-bolt
+TOOLS := tools/hsmtool tools/check-bolt tools/recover_anchor
 TOOLS_SRC := $(TOOLS:=.c)
 TOOLS_OBJ := $(TOOLS_SRC:.c=.o)
 
@@ -18,6 +18,18 @@ tools/headerversions: $(FORCE) tools/headerversions.o $(CCAN_OBJS)
 tools/check-bolt: tools/check-bolt.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS)
 
 tools/hsmtool: tools/hsmtool.o $(CCAN_OBJS) $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/autodata.o common/bech32.o common/bigsize.o common/configdir.o common/derive_basepoints.o common/descriptor_checksum.o common/hsm_encryption.o common/node_id.o common/type_to_string.o common/version.o wire/fromwire.o wire/towire.o
+
+tools/recover_anchor:					\
+	tools/recover_anchor.o 				\
+	$(BITCOIN_OBJS) 				\
+	$(CCAN_OBJS) 					\
+	$(TOOLS_COMMON_OBJS) 				\
+	common/amount.o 				\
+	common/autodata.o 				\
+	common/setup.o 					\
+	common/version.o 				\
+	wire/fromwire.o 				\
+	wire/towire.o
 
 tools/lightning-hsmtool: tools/hsmtool
 	cp $< $@

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -19,6 +19,7 @@
 #include <inttypes.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <wally_address.h>
 #include <wally_bip32.h>
 #include <wally_bip39.h>
 
@@ -396,6 +397,8 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 		/* Try it first as P2WPKH, non-anchor outputs */
 		pubkey_to_hash160(&basepoint, &pubkeyhash);
 		if (memcmp(pubkeyhash.u.u8, goal_hash, 20) == 0) {
+			char *wif;
+
 			printf("bech32      : %s\n", address);
 			printf("pubkey hash : %s\n",
 			       tal_hexstr(tmpctx, pubkeyhash.u.u8, 20));
@@ -403,6 +406,16 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 			       type_to_string(tmpctx, struct pubkey, &basepoint));
 			printf("privkey     : %s \n",
 			       type_to_string(tmpctx, struct secret, &basepoint_secret));
+
+			/* As a convenience, we also print the WIF */
+			wally_wif_from_bytes(basepoint_secret.data,
+					     sizeof(basepoint_secret.data),
+					     0x80, /* we assume mainnet */
+					     WALLY_WIF_FLAG_COMPRESSED,
+					     &wif);
+
+			printf("wif         : %s \n", wif);
+
 			return 0;
 		}
 

--- a/tools/recover_anchor.c
+++ b/tools/recover_anchor.c
@@ -1,0 +1,117 @@
+/* Code to produce a tx that spends a to-remote anchor output.
+ *
+ * Use "guesstoremote" to get the script, csv, and privkey needed for this.
+ *
+ * lightningd/tools/recover_anchor
+ * 	<psbt to sign>
+ * 	<index of input on psbt to sign>
+ * 	<amount that the input is worth>
+ * 	<script>
+ * 	<csv>
+ * 	<privkey>
+ */
+#include "config.h"
+#include <bitcoin/chainparams.h>
+#include <bitcoin/privkey.h>
+#include <bitcoin/psbt.h>
+#include <bitcoin/script.h>
+#include <bitcoin/shadouble.h>
+#include <bitcoin/signature.h>
+#include <ccan/ccan/err/err.h>
+#include <ccan/ccan/str/hex/hex.h>
+#include <ccan/crypto/hkdf_sha256/hkdf_sha256.h>
+#include <common/bech32.h>
+#include <common/setup.h>
+#include <common/utils.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <wally_psbt.h>
+
+extern const struct chainparams *chainparams;
+
+int main(int argc, char *argv[])
+{
+	int argnum, sequence, psbt_input;
+	struct wally_psbt *psbt;
+	struct bitcoin_signature sig;
+	struct privkey privkey;
+	struct sha256_double hash;
+	struct wally_tx_witness_stack *stack;
+	struct amount_sat output_amt;
+	u8 *witness_script, *scriptpub;
+	u8 der[73];
+	size_t siglen;
+
+	common_setup(argv[0]);
+
+	chainparams = chainparams_for_network("regtest");
+
+	if (argc != 7)
+		errx(1, "<psbt> <input to sign> <amount> <script> <csv> <privkey>\n\tHint: Use ./tools/hsmtool guesstoremote to find the script, csv, and privkey");
+
+	/* pull out the psbt */
+	argnum = 1;
+	psbt = psbt_from_b64(tmpctx, argv[argnum], strlen(argv[argnum]));
+	if (!psbt)
+		errx(1, "Bad PSBT %s", argv[argnum]);
+	argnum++;
+
+	psbt_input = atol(argv[argnum++]);
+	if (psbt_input >= psbt->num_inputs)
+		errx(1, "Provided PSBT doesn't have a %d input\n", psbt_input);
+
+	/* What's the amount of this output? */
+	if (!parse_amount_sat(&output_amt, argv[argnum], strlen(argv[argnum])))
+		errx(1, "Provided amount does not parse\n");
+
+	argnum++;
+	/* What's the witness script? */
+	witness_script = tal_hexdata(tmpctx, argv[argnum],
+				     strlen(argv[argnum]));
+
+	/* What should we set the sequence number to? */
+	argnum++;
+	sequence = atol(argv[argnum++]);
+
+	/* What's the private key to sign with? */
+	if (!hex_decode(argv[argnum], strlen(argv[argnum]),
+			&privkey, sizeof(privkey)))
+		errx(1, "Bad privkey");
+
+	/* Put the script and amount onto the psbt, so we can sign it */
+	scriptpub = scriptpubkey_p2wsh(tmpctx, witness_script);
+	psbt_input_set_wit_utxo(psbt, psbt_input, scriptpub, output_amt);
+	sig.sighash_type = SIGHASH_ALL;
+
+	tal_wally_start();
+	wally_psbt_input_set_sighash(&psbt->inputs[psbt_input],
+				     sig.sighash_type);
+	tal_wally_end(psbt);
+
+	/* Sign the input */
+	psbt_input_hash_for_sig(psbt, psbt_input, &hash);
+	sign_hash(&privkey, &hash, &sig.s);
+
+	tal_wally_start();
+	wally_tx_witness_stack_init_alloc(2, &stack);
+
+	siglen = signature_to_der(der, &sig);
+	wally_tx_witness_stack_add(stack, der, siglen);
+	wally_tx_witness_stack_add(stack, witness_script,
+				   tal_bytelen(witness_script));
+
+	wally_psbt_input_set_final_witness(&psbt->inputs[psbt_input], stack);
+	tal_wally_end(psbt);
+	/* Calls tal_wally internally */
+	psbt_input_set_witscript(psbt, psbt_input, witness_script);
+
+	/* Set the sequence number to match the csv */
+	psbt->tx->inputs[psbt_input].sequence = sequence;
+
+	/* Print out the updated/signed PSBT now */
+	printf("psbt with signed output: \n");
+	printf("%s\n", psbt_to_b64(tmpctx, psbt));
+
+	exit(0);
+}


### PR DESCRIPTION
A user recently had a catastrophic loss of their backups and in the process of working through recovery of funds discovered that they were unable to recover funds from 'dual-funded channels'.

This is ultimately because we use a different to-remote script, as these are anchored by default.