### PR TITLE
Fix out-of-sync sequence for psql and wrap destructor in optional DB transaction

### DIFF
--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -35,6 +35,10 @@ class Rewriter(object):
 
 class Sqlite3Rewriter(Rewriter):
     def rewrite_single(self, query):
+        # Replace DB specific queries with a no-op
+        if "/*PSQL*/" in query:
+            return "UPDATE vars SET intval=1 WHERE name='doesnotexist'"  # Return a no-op
+
         typemapping = {
             r'BIGINT': 'INTEGER',
             r'BIGINTEGER': 'INTEGER',
@@ -51,6 +55,10 @@ class Sqlite3Rewriter(Rewriter):
 
 class PostgresRewriter(Rewriter):
     def rewrite_single(self, q):
+        # Replace DB specific queries with a no-op
+        if "/*SQLITE*/" in q:
+            return "UPDATE vars SET intval=1 WHERE name='doesnotexist'"  # Return a no-op
+
         # Let's start by replacing any eventual '?' placeholders
         q2 = ""
         count = 1

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -855,6 +855,9 @@ static struct migration dbmigrations[] = {
     /* We default to 50k sats */
     {SQL("ALTER TABLE channel_configs ADD max_dust_htlc_exposure_msat BIGINT DEFAULT 50000000"), NULL},
     {SQL("ALTER TABLE channel_htlcs ADD fail_immediate INTEGER DEFAULT 0"), NULL},
+
+    /* Issue #4887: reset the payments.id sequence after the migration above. Since this is a SELECT statement that would otherwise fail, make it an INSERT into the `vars` table.*/
+    {SQL("/*PSQL*/INSERT INTO vars (name, intval) VALUES ('payment_id_reset', setval(pg_get_serial_sequence('payments', 'id'), COALESCE((SELECT MAX(id)+1 FROM payments), 1)))"), NULL},
 };
 
 /* Leak tracking. */


### PR DESCRIPTION
Fixes #4887
Fixes #4879 
Fixes #4891 