### PR TITLE
Intra-release candidates fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Fetch tags for auto versioning
-        run: git fetch --prune --unshallow --tags
+        run: git fetch --prune --unshallow --tags -f
 
       - name: Set up Python 3.6
         uses: actions/setup-python@v2

--- a/doc/lightning-check.7.md
+++ b/doc/lightning-check.7.md
@@ -9,12 +9,12 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **check** RPC command verifies another command’s parameters without
+The **check** RPC command verifies another command's parameters without
 running it.
 
 The *command\_to\_check* is the name of the relevant command.
 
-*parameters* is the command’s parameters.
+*parameters* is the command's parameters.
 
 This does not guarantee successful execution of the command in all
 cases. For example, a call to lightning-getroute(7) may still fail to

--- a/doc/lightning-cli.1.md
+++ b/doc/lightning-cli.1.md
@@ -4,7 +4,7 @@ lightning-cli -- Control lightning daemon
 SYNOPSIS
 --------
 
-**lightning-cli** \[*OPTIONS*\] *command*…
+**lightning-cli** \[*OPTIONS*\] *command*
 
 DESCRIPTION
 -----------
@@ -15,7 +15,7 @@ OPTIONS
 -------
 
  **--lightning-dir**=*DIR*
-Set the directory for the lightning daemon we’re talking to; defaults to
+Set the directory for the lightning daemon we're talking to; defaults to
 *$HOME/.lightning*.
 
  **--conf**=*PATH*
@@ -69,7 +69,7 @@ Print version number to standard output and exit.
 
  **allow-deprecated-apis**=*BOOL*
 Enable deprecated options. It defaults to *true*, but you should set
-it to *false* when testing to ensure that an upgrade won’t break your
+it to *false* when testing to ensure that an upgrade won't break your
 configuration.
 
 COMMANDS
@@ -109,7 +109,7 @@ BUGS
 ----
 
 This manpage documents how it should work, not how it does work. The
-pretty printing of results isn’t pretty.
+pretty printing of results isn't pretty.
 
 AUTHOR
 ------

--- a/doc/lightning-close.7.md
+++ b/doc/lightning-close.7.md
@@ -70,7 +70,7 @@ the defaults.
 
 Rates are one of the strings *urgent* (aim for next block), *normal*
 (next 4 blocks or so) or *slow* (next 100 blocks or so) to use
-lightningd’s internal estimates, or one of the names from
+lightningd's internal estimates, or one of the names from
 lightning-feerates(7).  Otherwise, they can be numbers with
 an optional suffix: *perkw* means the number is interpreted as
 satoshi-per-kilosipa (weight), and *perkb* means it is interpreted

--- a/doc/lightning-connect.7.md
+++ b/doc/lightning-connect.7.md
@@ -12,11 +12,11 @@ DESCRIPTION
 The **connect** RPC command establishes a new connection with another
 node in the Lightning Network.
 
-*id* represents the target node’s public key. As a convenience, *id* may
+*id* represents the target node's public key. As a convenience, *id* may
 be of the form *id@host* or *id@host:port*. In this case, the *host* and
 *port* parameters must be omitted.
 
-*host* is the peer’s hostname or IP address.
+*host* is the peer's hostname or IP address.
 
 If not specified, the *port* defaults to 9735.
 

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -108,7 +108,7 @@ above hops parameter:
 
 ```json
 {
-	"onion": "0003f3f80d2142b953319336d2fe4097[...✂...]6af33fcf4fb113bce01f56dd62248a9e5fcbbfba35c",
+	"onion": "0003f3f80d2142b953319336d2fe4097[...]6af33fcf4fb113bce01f56dd62248a9e5fcbbfba35c",
 	"shared_secrets": [
 		"88ce98c73e4d9293ab1797b0a913fe9bca0213a566252047d01b8af6da871f3e",
 		"4474d296810e57bd460ef8b83d2e7d288321f8a99ff7686f87384699747bcfc4",

--- a/doc/lightning-disconnect.7.md
+++ b/doc/lightning-disconnect.7.md
@@ -10,7 +10,7 @@ DESCRIPTION
 -----------
 
 The disconnect RPC command closes an existing connection to a peer,
-identified by *id*, in the Lightning Network, as long as it doesn’t have
+identified by *id*, in the Lightning Network, as long as it doesn't have
 an active channel. If *force* is set then it will disconnect even with
 an active channel.
 

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -37,7 +37,7 @@ channels were negotiated with the peer).
 *feerate* is an optional feerate used for the opening transaction and as
 initial feerate for commitment and HTLC transactions. It can be one of
 the strings *urgent* (aim for next block), *normal* (next 4 blocks or
-so) or *slow* (next 100 blocks or so) to use lightningd’s internal
+so) or *slow* (next 100 blocks or so) to use lightningd's internal
 estimates: *normal* is the default.
 
 Otherwise, *feerate* is a number, with an optional suffix: *perkw* means

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -20,7 +20,7 @@ ending in *000msat*, or a number with 1 to 8 decimal places ending in
 
 *feerate* can be one of the feerates listed in lightning-feerates(7),
 or one of the strings *urgent* (aim for next block), *normal* (next 4
-blocks or so) or *slow* (next 100 blocks or so) to use lightningd’s
+blocks or so) or *slow* (next 100 blocks or so) to use lightningd's
 internal estimates.  It can also be a *feerate* is a number, with an
 optional suffix: *perkw* means the number is interpreted as
 satoshi-per-kilosipa (weight), and *perkb* means it is interpreted

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -28,7 +28,7 @@ your funds being stuck (as a percentage).
 For example, if you thought the convenience of keeping your funds liquid
 (not stuck) was worth 20% per annum interest, *riskfactor* would be 20.
 
-If you didn’t care about risk, *riskfactor* would be zero.
+If you didn't care about risk, *riskfactor* would be zero.
 
 *fromid* is the node to start the route from: default is this node.
 

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -59,7 +59,7 @@ as a route hint candidate; if *false*, never.  If it is a short channel id
 will be considered candidates, even if they are public or dead-ends.
 
 The route hint is selected from the set of incoming channels of which:
-peer’s balance minus their reserves is at least *msatoshi*, state is
+peer's balance minus their reserves is at least *msatoshi*, state is
 normal, the peer is connected and not a dead end (i.e. has at least one
 other public channel). The selection uses some randomness to prevent
 probing, but favors channels that become more balanced after the

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -37,7 +37,7 @@ On success, an object is returned, containing:
     - **reserved_to_block** (u32): Block height where reservation will expire
 - **channels** (array of objects):
   - **peer_id** (pubkey): the peer with which the channel is opened
-  - **our_amount_msat** (msat): available satoshis on our node’s end of the channel
+  - **our_amount_msat** (msat): available satoshis on our node's end of the channel
   - **amount_msat** (msat): total channel value
   - **funding_txid** (txid): funding transaction id
   - **funding_output** (u32): the 0-based index of the output in the funding transaction

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -65,7 +65,7 @@ it cannot be an empty array.
 *commitment_feerate* is not set, as the initial feerate for
 commitment and HTLC transactions. It can be one of
 the strings *urgent* (aim for next block), *normal* (next 4 blocks or
-so) or *slow* (next 100 blocks or so) to use lightningd’s internal
+so) or *slow* (next 100 blocks or so) to use lightningd's internal
 estimates: *normal* is the default.
 
 Otherwise, *feerate* is a number, with an optional suffix: *perkw* means

--- a/doc/lightning-multiwithdraw.7.md
+++ b/doc/lightning-multiwithdraw.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **multiwithdraw** RPC command sends funds from c-lightning’s internal
+The **multiwithdraw** RPC command sends funds from c-lightning's internal
 wallet to the addresses specified in *outputs*,
 which is an array containing objects of the form `{address: amount}`.
 The `amount` may be the string *"all"*, indicating that all onchain funds
@@ -23,7 +23,7 @@ or a number with 1 to 8 decimal places ending in *btc*.
 
 *feerate* is an optional feerate to use. It can be one of the strings
 *urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
-(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
+(next 100 blocks or so) to use lightningd's internal estimates: *normal*
 is the default.
 
 Otherwise, *feerate* is a number, with an optional suffix: *perkw* means

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -10,7 +10,7 @@ DESCRIPTION
 -----------
 
 The **txprepare** RPC command creates an unsigned transaction which
-spends funds from c-lightning’s internal wallet to the outputs specified
+spends funds from c-lightning's internal wallet to the outputs specified
 in *outputs*.
 
 The *outputs* is the array of output that include *destination*
@@ -31,7 +31,7 @@ or a number with 1 to 8 decimal places ending in *btc*.
 
 *feerate* is an optional feerate to use. It can be one of the strings
 *urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
-(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
+(next 100 blocks or so) to use lightningd's internal estimates: *normal*
 is the default.
 
 Otherwise, *feerate* is a number, with an optional suffix: *perkw* means

--- a/doc/lightning-withdraw.7.md
+++ b/doc/lightning-withdraw.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **withdraw** RPC command sends funds from c-lightning’s internal
+The **withdraw** RPC command sends funds from c-lightning's internal
 wallet to the address specified in *destination*.
 
 The address can be of any Bitcoin accepted type, including bech32.
@@ -23,7 +23,7 @@ decimal places ending in *btc*.
 
 *feerate* is an optional feerate to use. It can be one of the strings
 *urgent* (aim for next block), *normal* (next 4 blocks or so) or *slow*
-(next 100 blocks or so) to use lightningd’s internal estimates: *normal*
+(next 100 blocks or so) to use lightningd's internal estimates: *normal*
 is the default.
 
 Otherwise, *feerate* is a number, with an optional suffix: *perkw* means

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -46,15 +46,15 @@ OPTIONS
  **allow-deprecated-apis**=*BOOL*
 Enable deprecated options, JSONRPC commands, fields, etc. It defaults to
 *true*, but you should set it to *false* when testing to ensure that an
-upgrade won’t break your configuration.
+upgrade won't break your configuration.
 
  **help**
 Print help and exit. Not very useful inside a configuration file, but
-fun to put in other’s config files while their computer is unattended.
+fun to put in other's config files while their computer is unattended.
 
  **version**
 Print version and exit. Also useless inside a configuration file, but
-putting this in someone’s config file may convince them to read this man
+putting this in someone's config file may convince them to read this man
 page.
 
 Bitcoin control options:
@@ -232,7 +232,7 @@ lightning-setchannelfee(7).
 
  **fee-per-satoshi**=*MILLIONTHS*
 Default: 10 (0.001%). This is the proportional fee to charge for every
-payment which passes through. As percentages are too coarse, it’s in
+payment which passes through. As percentages are too coarse, it's in
 millionths, so 10000 is 1%, 1000 is 0.1%. Changing this value will only
 affect new channels and not existing ones. If you want to change fees
 for existing channels, use the RPC call lightning-setchannelfee(7).
@@ -281,14 +281,14 @@ is spelled **large-channels** but it's pronounced **wumbo**.
 
  **watchtime-blocks**=*BLOCKS*
 How long we need to spot an outdated close attempt: on opening a channel
-we tell our peer that this is how long they’ll have to wait if they
+we tell our peer that this is how long they'll have to wait if they
 perform a unilateral close.
 
  **max-locktime-blocks**=*BLOCKS*
 The longest our funds can be delayed (ie. the longest
 **watchtime-blocks** our peer can ask for, and also the longest HTLC
-timeout we will accept). If our peer asks for longer, we’ll refuse to
-create a channel, and if an HTLC asks for longer, we’ll refuse it.
+timeout we will accept). If our peer asks for longer, we'll refuse to
+create a channel, and if an HTLC asks for longer, we'll refuse it.
 
  **funding-confirms**=*BLOCKS*
 Confirmations required for the funding transaction when the other side

--- a/doc/lightningd.8.md
+++ b/doc/lightningd.8.md
@@ -4,7 +4,7 @@ lightningd -- Daemon for running a Lightning Network node
 SYNOPSIS
 --------
 ```bash
-lightningd [--conf=<config-file>] [OPTIONS]…
+lightningd [--conf=<config-file>] [OPTIONS]
 ```
 
 DESCRIPTION


### PR DESCRIPTION
Testing the reproducible build with rc1 showed a couple of issues:

 - `mrkd` on ubuntu:18.04 doesn't like non-ASCII characters
 - Fetching tags and branches can cause conflicts on CI
 - Missing `websocketd` ignore