### PR TITLE
Add LIGHTNINGD_NETWORK env variable to Dockerfile for ARM

### DIFF
--- a/contrib/linuxarm32v7.Dockerfile
+++ b/contrib/linuxarm32v7.Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-t
 ENV LIGHTNINGD_DATA=/root/.lightning
 ENV LIGHTNINGD_RPC_PORT=9835
 ENV LIGHTNINGD_PORT=9735
+ENV LIGHTNINGD_NETWORK=bitcoin
 
 RUN mkdir $LIGHTNINGD_DATA && \
     touch $LIGHTNINGD_DATA/config

--- a/contrib/linuxarm64v8.Dockerfile
+++ b/contrib/linuxarm64v8.Dockerfile
@@ -103,6 +103,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-t
 ENV LIGHTNINGD_DATA=/root/.lightning
 ENV LIGHTNINGD_RPC_PORT=9835
 ENV LIGHTNINGD_PORT=9735
+ENV LIGHTNINGD_NETWORK=bitcoin
 
 RUN mkdir $LIGHTNINGD_DATA && \
     touch $LIGHTNINGD_DATA/config


### PR DESCRIPTION
As the `LIGHTNINGD_NETWORK` env variable was added to the Dockerfile in #3813, I added it to the Dockerfile for ARM.