### PR TITLE
lightningd: make shutdown smoother and safer

### DIFF
--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -103,7 +103,7 @@ char *read_stdin_pass(char **reason)
 		}
 		temp_term = current_term;
 		temp_term.c_lflag &= ~ECHO;
-		if (tcsetattr(fileno(stdin), TCSAFLUSH, &temp_term) != 0) {
+		if (tcsetattr(fileno(stdin), TCSANOW, &temp_term) != 0) {
 			*reason = "Could not disable pass echoing.";
 			return NULL;
 		}
@@ -114,7 +114,7 @@ char *read_stdin_pass(char **reason)
 		}
 
 		/* Restore the original terminal */
-		if (tcsetattr(fileno(stdin), TCSAFLUSH, &current_term) != 0) {
+		if (tcsetattr(fileno(stdin), TCSANOW, &current_term) != 0) {
 			*reason = "Could not restore terminal options.";
 			free(passwd);
 			return NULL;

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -28,6 +28,9 @@ static const errcode_t PLUGIN_ERROR = -3;
 /* Plugin terminated while handling a request. */
 static const errcode_t PLUGIN_TERMINATED = -4;
 
+/* Lightningd is shutting down while handling a request. */
+static const errcode_t LIGHTNINGD_SHUTDOWN = -5;
+
 /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
 static const errcode_t PAY_IN_PROGRESS = 200;
 static const errcode_t PAY_RHASH_ALREADY_USED = 201;

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -793,12 +793,14 @@ here, with the peer's signatures attached.
 
 ### `shutdown`
 
-Called when lightningd is shutting down, or this plugin has been
-shutdown by the plugin stop command.  The plugin has 30 seconds to
-exit itself, otherwise it's killed.
+Send in two situations: lightningd is (almost completely) shutdown, or the plugin
+`stop` command has been called for this plugin. In both cases the plugin has 30
+seconds to exit itself, otherwise it's killed.
 
-Because lightningd can crash or be killed, a plugin cannot rely on
-this function always called.
+In the shutdown case, plugins should not interact with lightnind except via (id-less)
+logging or notifications. New rpc calls will fail with error code -5 and (plugin's)
+responses will be ignored. Because lightningd can crash or be killed, a plugin cannot
+rely on the shutdown notification always been send.
 
 
 ## Hooks

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -933,6 +933,11 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 				    json_tok_full(jcon->buffer, method));
 	}
 
+	if (jcon->ld->state == LD_STATE_SHUTDOWN) {
+		return command_fail(c, LIGHTNINGD_SHUTDOWN,
+				    "lightningd is shutting down");
+	}
+
 	rpc_hook = tal(c, struct rpc_command_hook_payload);
 	rpc_hook->cmd = c;
 	/* Duplicate since we might outlive the connection */

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -972,7 +972,7 @@ static struct io_plan *start_json_stream(struct io_conn *conn,
 	io_wake(conn);
 
 	/* Once the stop_conn conn is drained, we can shut down. */
-	if (jcon->ld->stop_conn == conn) {
+	if (jcon->ld->stop_conn == conn && jcon->ld->state == LD_STATE_RUNNING) {
 		/* Return us to toplevel lightningd.c */
 		io_break(jcon->ld);
 		/* We never come back. */

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -22,7 +22,7 @@ enum command_mode {
 /* Context for a command (from JSON, but might outlive the connection!). */
 /* FIXME: move definition into jsonrpc.c */
 struct command {
-	/* Off json_cmd->commands */
+	/* Off list jcon->commands */
 	struct list_node list;
 	/* The global state */
 	struct lightningd *ld;

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1168,6 +1168,8 @@ int main(int argc, char *argv[])
 	 *  shut down.
 	 */
 	assert(io_loop_ret == ld);
+
+	/* Fail JSON RPC requests and ignore plugin's responses */
 	ld->state = LD_STATE_SHUTDOWN;
 
 	stop_fd = -1;

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1193,12 +1193,8 @@ int main(int argc, char *argv[])
 	/* Tell plugins we're shutting down, closes the db for write access. */
 	shutdown_plugins(ld);
 
-	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
-	 * it might actually be touching the DB in some destructors, e.g.,
-	 * unreserving UTXOs (see #1737) */
-	db_begin_transaction(ld->wallet->db);
+	/* Cleanup JSON RPC separately: destructors assume some list_head * in ld */
 	tal_free(ld->jsonrpc);
-	db_commit_transaction(ld->wallet->db);
 
 	/* Clean our our HTLC maps, since they use malloc. */
 	htlc_in_map_clear(&ld->htlcs_in);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -242,6 +242,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 */
 	ld->plugins = plugins_new(ld, ld->log_book, ld);
 	ld->plugins->startup = true;
+	ld->plugins->shutdown = false;
 
 	/*~ This is set when a JSON RPC command comes in to shut us down. */
 	ld->stop_conn = NULL;
@@ -1187,10 +1188,10 @@ int main(int argc, char *argv[])
 
 	/* We're not going to collect our children. */
 	remove_sigchild_handler();
-
-	/* Tell plugins we're shutting down. */
-	shutdown_plugins(ld);
 	shutdown_subdaemons(ld);
+
+	/* Tell plugins we're shutting down, closes the db for write access. */
+	shutdown_plugins(ld);
 
 	/* Clean up the JSON-RPC. This needs to happen in a DB transaction since
 	 * it might actually be touching the DB in some destructors, e.g.,

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -520,6 +520,11 @@ static const char *plugin_response_handle(struct plugin *plugin,
 			"Received a JSON-RPC response for non-existent request");
 	}
 
+	/* Ignore responses when shutting down */
+	if (plugin->plugins->ld->state == LD_STATE_SHUTDOWN) {
+		return NULL;
+	}
+
 	/* We expect the request->cb to copy if needed */
 	pd = plugin_detect_destruction(plugin);
 	request->response_cb(plugin->buffer, toks, idtok, request->response_cb_arg);

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -113,7 +113,7 @@ struct plugins {
 	/* Blacklist of plugins from --disable-plugin */
 	const char **blacklist;
 
-	/* Whether we are shutting down (`plugins_free` is called) */
+	/* Whether we are shutting down, blocks db write's */
 	bool shutdown;
 
 	/* Index to show what order they were added in */

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -337,6 +337,7 @@ void plugin_hook_db_sync(struct db *db)
 	size_t i;
 	size_t num_hooks;
 
+	db_check_plugins_not_shutdown(db);
 	const char **changes = db_changes(db);
 	num_hooks = tal_count(hook->hooks);
 	if (num_hooks == 0)

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -3231,7 +3231,7 @@ static struct command_result *direct_pay_listpeers(struct command *cmd,
 	    json_to_listpeers_result(tmpctx, buffer, toks);
 	struct direct_pay_data *d = payment_mod_directpay_get_data(p);
 
-	if (tal_count(r->peers) == 1) {
+	if (r && tal_count(r->peers) == 1) {
 		struct listpeers_peer *peer = r->peers[0];
 		if (!peer->connected)
 			goto cont;

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Plugin to be used to test miscellaneous notifications.
-
-Only used for 'channel_opened' for now.
 """
 
 from pyln.client import Plugin
+from time import sleep
+import sys
 
 plugin = Plugin()
 
@@ -25,6 +25,13 @@ def channel_opened(plugin, channel_opened, **kwargs):
 @plugin.subscribe("channel_state_changed")
 def channel_state_changed(plugin, channel_state_changed, **kwargs):
     plugin.log("channel_state_changed {}".format(channel_state_changed))
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    plugin.log("delaying shutdown with 5s")
+    sleep(5)
+    sys.exit(0)
 
 
 plugin.run()

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3099,7 +3099,7 @@ def test_closing_higherfee(node_factory, bitcoind, executor):
     l1.daemon.wait_for_log(r'deriving max fee from rate 30000 -> 16440sat \(not 1000000sat\)')
 
     # This will fail because l1 restarted!
-    with pytest.raises(RpcError, match=r'Connection to RPC server lost.'):
+    with pytest.raises(RpcError, match=r'Channel forgotten before proper close.'):
         fut.result(TIMEOUT)
 
     # But we still complete negotiation!

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3541,6 +3541,9 @@ def test_upgrade_statickey_onchaind(node_factory, executor, bitcoind):
     l1.daemon.wait_for_log('option_static_remotekey enabled at 1/1')
 
     # Pre-statickey penalty works.
+    # FIXME: Without this sleep, l1 will broadcasts one tx more compared to good
+    # case, causing `wait_for_onchaind_broadcast` to timeout.
+    time.sleep(5)
     bitcoind.rpc.sendrawtransaction(tx)
     bitcoind.generate_block(1)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -27,33 +27,6 @@ import time
 import unittest
 
 
-@pytest.mark.developer("needs --dev-disconnect")
-@pytest.mark.openchannel('v1')
-def test_stop_pending_fundchannel(node_factory, executor):
-    """Stop the daemon while waiting for an accept_channel
-
-    This used to crash the node, since we were calling unreserve_utxo while
-    freeing the daemon, but that needs a DB transaction to be open.
-
-    """
-    l1, l2 = node_factory.get_nodes(2)
-
-    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-
-    # We want l2 to stop replying altogether, not disconnect
-    os.kill(l2.daemon.proc.pid, signal.SIGSTOP)
-
-    # The fundchannel call will not terminate so run it in a future
-    executor.submit(l1.fundchannel, l2, 10**6)
-    l1.daemon.wait_for_log('peer_out WIRE_OPEN_CHANNEL')
-
-    l1.rpc.stop()
-
-    # Now allow l2 a clean shutdown
-    os.kill(l2.daemon.proc.pid, signal.SIGCONT)
-    l2.rpc.stop()
-
-
 def test_names(node_factory):
     # Note:
     # private keys:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1079,6 +1079,32 @@ def test_htlc_accepted_hook_direct_restart(node_factory, executor):
     f1.result()
 
 
+def test_htlc_accepted_hook_shutdown(node_factory, executor):
+    """Hooks of important-plugins are never removed and these plugins are kept
+       alive until after subdaemons are shutdown.
+    """
+    l1, l2 = node_factory.line_graph(2, opts=[
+        {'may_reconnect': True, 'log-level': 'info'},
+        {'may_reconnect': True, 'log-level': 'debug',
+         'plugin': [os.path.join(os.getcwd(), 'tests/plugins/misc_notifications.py')],
+         'important-plugin': [os.path.join(os.getcwd(), 'tests/plugins/fail_htlcs.py')]}
+    ])
+
+    i1 = l2.rpc.invoice(msatoshi=1000, label="inv1", description="desc")['bolt11']
+
+    # fail_htlcs.py makes payment fail
+    with pytest.raises(RpcError):
+        l1.rpc.pay(i1)
+
+    f_stop = executor.submit(l2.rpc.stop)
+    l2.daemon.wait_for_log(r'plugin-misc_notifications.py: delaying shutdown with 5s')
+
+    # Should still fail htlc while shutting down
+    with pytest.raises(RpcError):
+        l1.rpc.pay(i1)
+    f_stop.result()
+
+
 @pytest.mark.developer("without DEVELOPER=1, gossip v slow")
 def test_htlc_accepted_hook_forward_restart(node_factory, executor):
     """l2 restarts while it is pondering what to do with an HTLC.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1081,7 +1081,7 @@ def test_htlc_accepted_hook_direct_restart(node_factory, executor):
 
 def test_htlc_accepted_hook_shutdown(node_factory, executor):
     """Hooks of important-plugins are never removed and these plugins are kept
-       alive until after subdaemons are shutdown.
+       alive until after subdaemons are shutdown. Also tests shutdown notification.
     """
     l1, l2 = node_factory.line_graph(2, opts=[
         {'may_reconnect': True, 'log-level': 'info'},
@@ -1089,6 +1089,10 @@ def test_htlc_accepted_hook_shutdown(node_factory, executor):
          'plugin': [os.path.join(os.getcwd(), 'tests/plugins/misc_notifications.py')],
          'important-plugin': [os.path.join(os.getcwd(), 'tests/plugins/fail_htlcs.py')]}
     ])
+
+    l2.rpc.plugin_stop(os.path.join(os.getcwd(), 'tests/plugins/misc_notifications.py'))
+    l2.daemon.wait_for_log(r'datastore success')
+    l2.rpc.plugin_start(os.path.join(os.getcwd(), 'tests/plugins/misc_notifications.py'))
 
     i1 = l2.rpc.invoice(msatoshi=1000, label="inv1", description="desc")['bolt11']
 
@@ -1102,6 +1106,8 @@ def test_htlc_accepted_hook_shutdown(node_factory, executor):
     # Should still fail htlc while shutting down
     with pytest.raises(RpcError):
         l1.rpc.pay(i1)
+
+    l2.daemon.wait_for_log(r'datastore failed')
     f_stop.result()
 
 

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1266,6 +1266,7 @@ struct db *db_setup(const tal_t *ctx, struct lightningd *ld,
 	struct db *db = db_open(ctx, ld->wallet_dsn);
 	bool migrated;
 	db->log = new_log(db, ld->log_book, NULL, "database");
+	db->plugins_shutdown = &ld->plugins->shutdown;
 
 	db_begin_transaction(db);
 
@@ -2338,6 +2339,11 @@ void db_changes_add(struct db_stmt *stmt, const char * expanded)
 	}
 
 	tal_arr_expand(&db->changes, tal_strdup(db->changes, expanded));
+}
+
+void db_check_plugins_not_shutdown(struct db *db)
+{
+	assert(!*db->plugins_shutdown);
 }
 
 const char **db_changes(struct db *db)

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -249,6 +249,9 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
 #define db_prepare_v2(db,query)						\
 	db_prepare_v2_(__FILE__ ":" stringify(__LINE__), db, query)
 
+/* Check that plugins are not shutting down when calling db_write hook */
+void db_check_plugins_not_shutdown(struct db *db);
+
 /**
  * Access pending changes that have been added to the current transaction.
  */

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -34,6 +34,9 @@ struct db {
 	 * Used to bump the data_version in the DB.*/
 	bool dirty;
 
+	/* Only needed to check shutdown state of plugins */
+	const bool *plugins_shutdown;
+
 	/* The current DB version we expect to update if changes are
 	 * committed. */
 	u32 data_version;

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -401,35 +401,8 @@ bool wallet_unreserve_output(struct wallet *w,
 					   OUTPUT_STATE_AVAILABLE);
 }
 
-/**
- * unreserve_utxo - Mark a reserved UTXO as available again
- */
-static void unreserve_utxo(struct wallet *w, const struct utxo *unres)
-{
-	if (!wallet_update_output_status(w, &unres->outpoint,
-					 OUTPUT_STATE_RESERVED,
-					 OUTPUT_STATE_AVAILABLE)) {
-		fatal("Unable to unreserve output");
-	}
-}
-
-/**
- * destroy_utxos - Destructor for an array of pointers to utxo
- */
-static void destroy_utxos(const struct utxo **utxos, struct wallet *w)
-{
-	for (size_t i = 0; i < tal_count(utxos); i++)
-		unreserve_utxo(w, utxos[i]);
-}
-
-void wallet_persist_utxo_reservation(struct wallet *w, const struct utxo **utxos)
-{
-	tal_del_destructor2(utxos, destroy_utxos, w);
-}
-
 void wallet_confirm_utxos(struct wallet *w, const struct utxo **utxos)
 {
-	tal_del_destructor2(utxos, destroy_utxos, w);
 	for (size_t i = 0; i < tal_count(utxos); i++) {
 		if (!wallet_update_output_status(
 			w, &utxos[i]->outpoint,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1411,13 +1411,6 @@ void add_unreleased_tx(struct wallet *w, struct unreleased_tx *utx);
 /* These will touch the db, so need to be explicitly freed. */
 void free_unreleased_txs(struct wallet *w);
 
-/* wallet_persist_utxo_reservation - Removes destructor
- *
- * Persists the reservation in the database (until a restart)
- * instead of clearing the reservation when the utxo object
- * is destroyed */
-void wallet_persist_utxo_reservation(struct wallet *w, const struct utxo **utxos);
-
 /* wallet_unreserve_output - Unreserve a utxo
  *
  * We unreserve utxos so that they can be spent elsewhere.


### PR DESCRIPTION
Another proof of concept (should I make this a draft PR?), to address issues raised in #4785 #4790 and  #4883 

The point of shutdown is to break-down or reduce activity. Starting a new `io_loop` in order to write `shutdown` notifications to plugins and wait for them to terminate, should not trigger new activity other then logging and (maybe?) notifications.

So before restarting this `io_loop` we shutdown subdaemons and disable handling of all JSON RPC requests and responses with an "id" field in it. Hook callback's will abandon already and without subdaemons or JSON RPC no new hooks can be called. All of that should prevent any `db_write`'s and we can safely start the `io_loop` and shutdown all plugins.

Also cleans up some dead code related to unused `destroy_utxos` destructor.

TODO:
- [x] documentation