### PR TITLE
Add exclude option to pay

### DIFF
--- a/common/json_tok.h
+++ b/common/json_tok.h
@@ -18,6 +18,7 @@ struct channel_id;
 struct command;
 struct command_result;
 struct json_escape;
+struct route_exclusion;
 struct sha256;
 struct wally_psbt;
 
@@ -204,6 +205,15 @@ struct command_result *param_routehint(struct command *cmd, const char *name,
 struct command_result *
 param_routehint_array(struct command *cmd, const char *name, const char *buffer,
 		      const jsmntok_t *tok, struct route_info ***ris);
+
+struct command_result *param_route_exclusion(struct command *cmd,
+					const char *name, const char *buffer, const jsmntok_t *tok,
+					struct route_exclusion **re);
+
+struct command_result *
+param_route_exclusion_array(struct command *cmd, const char *name,
+					const char *buffer, const jsmntok_t *tok,
+					struct route_exclusion ***res);
 
 /**
  * Parse a 'compact-lease' (serialized lease_rates) back into lease_rates

--- a/common/route.h
+++ b/common/route.h
@@ -74,4 +74,22 @@ struct route_hop *route_from_dijkstra(const tal_t *ctx,
 				      const struct gossmap_node *src,
 				      struct amount_msat final_amount,
 				      u32 final_cltv);
+
+/*
+ * Manually exlude nodes or channels from a route.
+ * Used with `getroute` and `pay` commands
+ */
+enum route_exclusion_type {
+	EXCLUDE_CHANNEL = 1,
+	EXCLUDE_NODE = 2
+};
+
+struct route_exclusion {
+	enum route_exclusion_type type;
+	union {
+		struct short_channel_id_dir chan_id;
+		struct node_id node_id;
+	} u;
+};
+
 #endif /* LIGHTNING_COMMON_ROUTE_H */

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -616,7 +616,7 @@ class LightningRpc(UnixDomainSocketRpc):
 
     def dev_pay(self, bolt11, msatoshi=None, label=None, riskfactor=None,
                 maxfeepercent=None, retry_for=None,
-                maxdelay=None, exemptfee=None, use_shadow=True):
+                maxdelay=None, exemptfee=None, use_shadow=True, exclude=[]):
         """
         A developer version of `pay`, with the possibility to deactivate
         shadow routing (used for testing).
@@ -631,6 +631,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "maxdelay": maxdelay,
             "exemptfee": exemptfee,
             "use_shadow": use_shadow,
+            "exclude": exclude,
         }
         return self.call("pay", payload)
 
@@ -989,7 +990,7 @@ class LightningRpc(UnixDomainSocketRpc):
 
     def pay(self, bolt11, msatoshi=None, label=None, riskfactor=None,
             maxfeepercent=None, retry_for=None,
-            maxdelay=None, exemptfee=None):
+            maxdelay=None, exemptfee=None, exclude=[]):
         """
         Send payment specified by {bolt11} with {msatoshi}
         (ignored if {bolt11} has an amount), optional {label}
@@ -1004,6 +1005,7 @@ class LightningRpc(UnixDomainSocketRpc):
             "retry_for": retry_for,
             "maxdelay": maxdelay,
             "exemptfee": exemptfee,
+            "exclude": exclude,
         }
         return self.call("pay", payload)
 

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -6,6 +6,7 @@ SYNOPSIS
 
 **pay** *bolt11* \[*msatoshi*\] \[*label*\] \[*riskfactor*\]
 \[*maxfeepercent*\] \[*retry\_for*\] \[*maxdelay*\] \[*exemptfee*\]
+\[*exclude*\]
 
 DESCRIPTION
 -----------
@@ -39,6 +40,11 @@ Until *retry\_for* seconds passes (default: 60), the command will keep
 finding routes and retrying the payment. However, a payment may be
 delayed for up to `maxdelay` blocks by another node; clients should be
 prepared for this worst case.
+
+*exclude* is a JSON array of short-channel-id/direction (e.g. \[
+"564334x877x1/0", "564195x1292x0/1" \]) or node-id which should be excluded
+from consideration for routing. The default is not to exclude any channels
+or nodes.
 
 When using *lightning-cli*, you may skip optional parameters by using
 *null*. Alternatively, use **-k** option to provide parameters by name.

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -406,6 +406,10 @@ struct adaptive_split_mod_data {
 	u32 htlc_budget;
 };
 
+struct route_exclusions_data {
+	struct route_exclusion **exclusions;
+};
+
 /* List of globally available payment modifiers. */
 REGISTER_PAYMENT_MODIFIER_HEADER(retry, struct retry_mod_data);
 REGISTER_PAYMENT_MODIFIER_HEADER(routehints, struct routehints_data);
@@ -426,6 +430,8 @@ REGISTER_PAYMENT_MODIFIER_HEADER(local_channel_hints, void);
  * we detect the payee to have, in order to not exhaust the number of HTLCs
  * each of those channels can bear.  */
 REGISTER_PAYMENT_MODIFIER_HEADER(payee_incoming_limit, void);
+REGISTER_PAYMENT_MODIFIER_HEADER(route_exclusions, struct route_exclusions_data);
+
 
 struct payment *payment_new(tal_t *ctx, struct command *cmd,
 			    struct payment *parent,

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5000,3 +5000,30 @@ def test_sendpay_grouping(node_factory, bitcoind):
     pays = l1.rpc.listpays()['pays']
     assert(len(pays) == 3)
     assert([p['status'] for p in pays] == ['failed', 'failed', 'complete'])
+
+
+def test_pay_manual_exclude(node_factory, bitcoind):
+    l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True)
+    l1_id = l1.rpc.getinfo()['id']
+    l2_id = l2.rpc.getinfo()['id']
+    l3_id = l3.rpc.getinfo()['id']
+    chan12 = l1.rpc.listpeers(l2_id)['peers'][0]['channels'][0]
+    chan23 = l2.rpc.listpeers(l3_id)['peers'][0]['channels'][0]
+    scid12 = chan12['short_channel_id'] + '/' + str(chan12['direction'])
+    scid23 = chan23['short_channel_id'] + '/' + str(chan23['direction'])
+    inv = l3.rpc.invoice(msatoshi='123000', label='label1', description='desc')['bolt11']
+    # Exclude the payer node id
+    with pytest.raises(RpcError, match=r'Payer is manually excluded'):
+        l1.rpc.pay(inv, exclude=[l1_id])
+    # Exclude the direct payee node id
+    with pytest.raises(RpcError, match=r'Payee is manually excluded'):
+        l2.rpc.pay(inv, exclude=[l3_id])
+    # Exclude intermediate node id
+    with pytest.raises(RpcError, match=r'is not reachable directly and all routehints were unusable.'):
+        l1.rpc.pay(inv, exclude=[l2_id])
+    # Exclude intermediate channel id
+    with pytest.raises(RpcError, match=r'is not reachable directly and all routehints were unusable.'):
+        l1.rpc.pay(inv, exclude=[scid12])
+    # Exclude direct channel id
+    with pytest.raises(RpcError, match=r'is not reachable directly and all routehints were unusable.'):
+        l2.rpc.pay(inv, exclude=[scid23])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -392,7 +392,7 @@ def test_pay_plugin(node_factory):
 
     # Make sure usage messages are present.
     msg = 'pay bolt11 [msatoshi] [label] [riskfactor] [maxfeepercent] '\
-          '[retry_for] [maxdelay] [exemptfee] [localofferid]'
+          '[retry_for] [maxdelay] [exemptfee] [localofferid] [exclude]'
     if DEVELOPER:
         msg += ' [use_shadow]'
     assert only_one(l1.rpc.help('pay')['help'])['command'] == msg


### PR DESCRIPTION
This adds an `exclude` option to the `pay` command, similar to the `exclude` option of the `getroute` command. This is motivated by https://github.com/ElementsProject/lightning/issues/2529, and can be closed via plugin after this is merged.