### PR TITLE
Update install docs and add some files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ contrib/pylightning/pylightning.egg-info/
 contrib/pyln-*/build/
 contrib/pyln-*/dist/
 contrib/pyln-*/pyln_*.egg-info/
+contrib/pyln-*/.eggs/
+contrib/pyln-*/pyln/*/__version__.py
 release/
 tests/plugins/test_selfdisable_after_getmanifest
 .DS_Store

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -163,12 +163,10 @@ Build and Development
 Install `valgrind` and the python dependencies for best results:
 
 ```
-sudo apt install valgrind cppcheck shellcheck libsecp256k1-dev
-pip3 install --user \
-         -r requirements.txt \
-         -r contrib/pyln-client/requirements.txt \
-         -r contrib/pyln-proto/requirements.txt \
-         -r contrib/pyln-testing/requirements.txt
+sudo apt update
+sudo apt install valgrind cppcheck shellcheck libsecp256k1-dev libpq-dev
+pip3 install --upgrade pip
+pip3 install --user -r requirements.txt
 ```
 
 Re-run `configure` for the python dependencies and build using `make`.

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -37,9 +37,10 @@ Get dependencies:
 
     sudo apt-get update
     sudo apt-get install -y \
-      autoconf automake build-essential git libtool libgmp-dev \
-      libsqlite3-dev python3 python3-mako net-tools zlib1g-dev libsodium-dev \
+      autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev \
+      python3 python3-mako python3-pip net-tools zlib1g-dev libsodium-dev \
       gettext
+    pip3 install --user mrkd
 
 If you don't have Bitcoin installed locally you'll need to install that
 as well. It's now available via [snapd](https://snapcraft.io/bitcoin-core).
@@ -57,8 +58,10 @@ Clone lightning:
     
 For development or running tests, get additional dependencies:
 
-    sudo apt-get install -y valgrind python3-pip libpq-dev
-    sudo pip3 install -r requirements.txt --use-feature=in-tree-build
+    sudo apt-get install -y valgrind libpq-dev shellcheck cppcheck \
+      libsecp256k1-dev
+    pip3 install --upgrade pip
+    pip3 install --user -r requirements.txt
 
 Build lightning:
 


### PR DESCRIPTION
In my quest to get `make -j12 full-check PYTEST_PAR=24 DEVELOPER=1 VALGRIND=0` to work on Ubuntu from [HACKING.md](https://github.com/ElementsProject/lightning/blob/master/doc/HACKING.md#testing), I came across some directories not ignored and had to install some dependencies. Updated the deps install docs and added some dirs to gitignore.
