### PR TITLE
pyln-bolt7: fix requirements.txt

### DIFF
--- a/contrib/pyln-spec/bolt1/requirements.txt
+++ b/contrib/pyln-spec/bolt1/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto >= 0.9.3
+pyln-proto >= 0.9.3

--- a/contrib/pyln-spec/bolt2/requirements.txt
+++ b/contrib/pyln-spec/bolt2/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto >= 0.9.3
+pyln-proto >= 0.9.3

--- a/contrib/pyln-spec/bolt4/requirements.txt
+++ b/contrib/pyln-spec/bolt4/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto >= 0.9.3
+pyln-proto >= 0.9.3

--- a/contrib/pyln-spec/bolt7/requirements.txt
+++ b/contrib/pyln-spec/bolt7/requirements.txt
@@ -1,1 +1,1 @@
-pyln.proto
+pyln-proto


### PR DESCRIPTION
The correct package name is [pyln-proto](https://github.com/ElementsProject/lightning/blob/12689674c7546a6b6ee70839e3867e04dcd33a2f/contrib/pyln-proto/setup.py#L22). H/T @erikarvstedt