### PR TITLE
paystatus: remove doubled amount_msat.

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1598,9 +1598,6 @@ static struct command_result *json_paystatus(struct command *cmd,
 		if (p->invstring)
 			json_add_invstring(ret, p->invstring);
 		json_add_amount_msat_only(ret, "amount_msat", p->amount);
-		json_add_string(
-		    ret, "amount_msat",
-		    type_to_string(tmpctx, struct amount_msat, &p->amount));
 
 		json_add_node_id(ret, "destination", p->destination);
 


### PR DESCRIPTION
It's always been there:

```
{
   "pay": [
      {
         "bolt11": "...",
         "amount_msat": "1000msat",
         "amount_msat": "1000msat",
         "destination": "03...",
         "attempts": [
            {
               "strategy": "Initial attempt",
               "start_time": "2021-11-06T04:20:20.135Z",
               "age_in_seconds": 229032,
               "end_time": "2021-11-06T04:20:27.792Z",
               "state": "completed",
               "success": {
                  "id": 31994,
                  "payment_preimage": "..."
               }
            }
         ]
      }
   ]
}
```

Reported-by: denis2342 on IRC
Changelog-Fixed: JSON-RPC: `paystatus` entries no longer have two identical `amount_msat` entries.
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>