### PR TITLE
lightningd: fix compilation error on OpenBSD

### DIFF
--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -213,7 +213,7 @@ static int subd(const char *path, const char *name,
 		size_t num_args;
 		char *args[] = { NULL, NULL, NULL, NULL, NULL };
 		int **fds = tal_arr(tmpctx, int *, 3);
-		int stdout = STDOUT_FILENO, stderr = STDERR_FILENO;
+		int stdoutfd = STDOUT_FILENO, stderrfd = STDERR_FILENO;
 
 		close(childmsg[0]);
 		close(execfail[0]);
@@ -221,8 +221,8 @@ static int subd(const char *path, const char *name,
 		/* msg = STDIN (0) */
 		fds[0] = &childmsg[1];
 		/* These are untouched */
-		fds[1] = &stdout;
-		fds[2] = &stderr;
+		fds[1] = &stdoutfd;
+		fds[2] = &stderrfd;
 
 		while ((fd = va_arg(*ap, int *)) != NULL) {
 			assert(*fd != -1);


### PR DESCRIPTION
```

cc lightningd/subd.c
lightningd/subd.c:216:7: error: expected identifier or '('
                int stdout = STDOUT_FILENO, stderr = STDERR_FILENO;
                    ^
/usr/include/stdio.h:198:17: note: expanded from macro 'stdout'
                 ^
lightningd/subd.c:216:7: error: expected ')'
/usr/include/stdio.h:198:17: note: expanded from macro 'stdout'
                 ^
lightningd/subd.c:216:7: note: to match this '('
/usr/include/stdio.h:198:16: note: expanded from macro 'stdout'
                ^
lightningd/subd.c:224:12: error: cannot take the address of an rvalue of type 'FILE *' (aka 'struct __sFILE *')
                fds[1] = &stdout;
                         ^~~~~~~
lightningd/subd.c:225:12: error: cannot take the address of an rvalue of type 'FILE *' (aka 'struct __sFILE *')
                fds[2] = &stderr;
                         ^~~~~~~
4 errors generated.
gmake: *** [Makefile:279: lightningd/subd.o] Error 1
```

Changelog-None: introduced since last release.
Fixes: #4914
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au> ```