### PR TITLE
doc/PLUGINS.md: Clarify that `db_write` hook only works on SQLITE3.

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -939,7 +939,11 @@ hook subscribers would not get called.
 
 ### `db_write`
 
-This hook is called whenever a change is about to be committed to the database.
+This hook is called whenever a change is about to be committed to the database,
+if you are using a SQLITE3 database (the default).
+This hook will be useless (the `"writes"` field will always be empty) if you are
+using a PostgreSQL database.
+
 It is currently extremely restricted:
 
 1. a plugin registering for this hook should not perform anything that may cause


### PR DESCRIPTION
I noticed that `wallet/db_postgres.c` never actually calls `db_changes_add`.

PostgreSQL arguably has a better replication system (a PostgreSQL cluster)
than what `db_write` hook can offer, so rather than make `db_write` work on
PostgreSQL, just document that it does not actually work there.

ChangeLog-none