### PR TITLE
bitcoin/chainparams.c: Change `signet` BIP173 name to `tbs`.

### DIFF
--- a/bitcoin/chainparams.c
+++ b/bitcoin/chainparams.c
@@ -79,7 +79,7 @@ const struct chainparams networks[] = {
 			   .bip32_privkey_version = BIP32_VER_TEST_PRIVATE},
      .is_elements = false},
     {.network_name = "signet",
-     .bip173_name = "tb",
+     .bip173_name = "tbs",
      .bip70_name = "signet",
      // 00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6
      .genesis_blockhash = {{{.u.u8 = {0xf6, 0x1e, 0xee, 0x3b, 0x63, 0xa3, 0x80,


### PR DESCRIPTION
Fixes: #4924

ChangeLog-Changed: `signet` addresses and invoices now use `tbs` instead of `tb`.