### PR TITLE
Reduce mem usage for CI with valgrind

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -282,6 +282,7 @@ def test_plugin_disable(node_factory):
     with pytest.raises(RpcError):
         n.rpc.hello(name='Sun')
     assert n.daemon.is_in_log('helloworld.py: disabled via disable-plugin')
+    n.stop()
 
     # Also works by basename.
     n = node_factory.get_node(options=OrderedDict([('plugin-dir', plugin_dir),
@@ -290,6 +291,7 @@ def test_plugin_disable(node_factory):
     with pytest.raises(RpcError):
         n.rpc.hello(name='Sun')
     assert n.daemon.is_in_log('helloworld.py: disabled via disable-plugin')
+    n.stop()
 
     # Other order also works!
     n = node_factory.get_node(options=OrderedDict([('disable-plugin',
@@ -298,6 +300,7 @@ def test_plugin_disable(node_factory):
     with pytest.raises(RpcError):
         n.rpc.hello(name='Sun')
     assert n.daemon.is_in_log('helloworld.py: disabled via disable-plugin')
+    n.stop()
 
     # Both orders of explicit specification work.
     n = node_factory.get_node(options=OrderedDict([('disable-plugin',
@@ -308,6 +311,7 @@ def test_plugin_disable(node_factory):
     with pytest.raises(RpcError):
         n.rpc.hello(name='Sun')
     assert n.daemon.is_in_log('helloworld.py: disabled via disable-plugin')
+    n.stop()
 
     # Both orders of explicit specification work.
     n = node_factory.get_node(options=OrderedDict([('plugin',
@@ -322,6 +326,7 @@ def test_plugin_disable(node_factory):
     # Still disabled if we load directory.
     n.rpc.plugin_startdir(directory=os.path.join(os.getcwd(), "contrib/plugins"))
     n.daemon.wait_for_log('helloworld.py: disabled via disable-plugin')
+    n.stop()
 
     # Check that list works
     n = node_factory.get_node(options={'disable-plugin':


### PR DESCRIPTION
This should reduce the flakes we're getting due to kill -9, which I suspect is OOM killer.

I printed out the total %mem, mem and vsz every 5 seconds and ran the full testsuite with VALGRIND=1 SLOW_MACHINE=1 (non-parallel).  The largest mem users were those creating many nodes (of course), and this should help with that.

Changelog-None