### PR TITLE
pytest: fix flake in testing.

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3540,10 +3540,10 @@ def test_upgrade_statickey_onchaind(node_factory, executor, bitcoind):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.daemon.wait_for_log('option_static_remotekey enabled at 1/1')
 
+    # Make sure l2 gets REVOKE_AND_ACK from previous.
+    l2.daemon.wait_for_log('peer_out WIRE_REVOKE_AND_ACK')
+
     # Pre-statickey penalty works.
-    # FIXME: Without this sleep, l1 will broadcasts one tx more compared to good
-    # case, causing `wait_for_onchaind_broadcast` to timeout.
-    time.sleep(5)
     bitcoind.rpc.sendrawtransaction(tx)
     bitcoind.generate_block(1)
 


### PR DESCRIPTION
As noted in https://github.com/ElementsProject/lightning/pull/4897/commits/0a406230d051a83f9f029054efe2dd24e87887a8#diff-5871d4c569454db5e625383975462132da0bd03d32df145d8d72d8fafd86d952R3544-R3546

Turns out we sometimes hang up before l2 sees the previous tx revoked,
so we get a normal unilateral close, not a cheat.

Reported-by: Simon Vrouwe
Changelog-None