### PR TITLE
make: remove generated files when running clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,6 @@ distclean: clean
 maintainer-clean: distclean
 	@echo 'This command is intended for maintainers to use; it'
 	@echo 'deletes files that may need special tools to rebuild.'
-	$(RM) $(ALL_GEN_HEADERS) $(ALL_GEN_SOURCES)
 
 # We used to have gen_ files, now we have _gen files.
 obsclean:
@@ -618,6 +617,7 @@ obsclean:
 
 clean: obsclean
 	$(RM) $(CCAN_OBJS) $(CDUMP_OBJS) $(ALL_OBJS)
+	$(RM) $(ALL_GEN_HEADERS) $(ALL_GEN_SOURCES)
 	$(RM) $(ALL_PROGRAMS)
 	$(RM) $(ALL_TEST_PROGRAMS)
 	$(RM) $(ALL_FUZZ_TARGETS)

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -46,7 +46,8 @@ wallet/db_%_sqlgen.c: wallet/statements_gettextgen.po devtools/sql-rewrite.py $(
 		$(call VERBOSE,"sql-rewrite $@",devtools/sql-rewrite.py wallet/statements_gettextgen.po $* > $@ && $(call SHA256STAMP,//,)); \
 	fi
 
-maintainer-clean: wallet-maintainer-clean
+maintainer-clean: clean
+clean: wallet-maintainer-clean
 wallet-maintainer-clean:
 	$(RM) wallet/statements.po
 	$(RM) wallet/statements_gettextgen.po


### PR DESCRIPTION
This updates `make clean` to also remove all generated source and header files. This would have resolved https://github.com/ElementsProject/lightning/issues/4939 with a `make clean`, but instead the user ended up nuking the repo and cloning again.

There is a comment about only removing generated files with `make maintainer-clean`:
> This command is intended for maintainers to use; it deletes files that may need special tools to rebuild.

I checked and all generated files are not checked in source control, so anything that succeeds in building already has all available tools. Not sure if that comment is out of date or if there is some history behind it that I'm not aware of, but it seems that it is safe to remove these generated source and header files on `make clean`.
