### PR TITLE
lightningd: make shutdown smoother and safer, PART II

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -4076,7 +4076,7 @@ int main(int argc, char *argv[])
 
 		expired = timers_expire(&peer->timers, now);
 		if (expired) {
-			timer_expired(peer, expired);
+			timer_expired(expired);
 			continue;
 		}
 

--- a/common/timeout.c
+++ b/common/timeout.c
@@ -35,7 +35,7 @@ void *reltimer_arg(struct oneshot *t)
 	return t->arg;
 }
 
-void timer_expired(tal_t *ctx, struct timer *timer)
+void timer_expired(struct timer *timer)
 {
 	struct oneshot *t = container_of(timer, struct oneshot, timer);
 

--- a/common/timeout.h
+++ b/common/timeout.h
@@ -18,6 +18,6 @@ struct oneshot *new_reltimer_(struct timers *timers,
 /* Get timer arg. */
 void *reltimer_arg(struct oneshot *t);
 
-void timer_expired(tal_t *ctx, struct timer *timer);
+void timer_expired(struct timer *timer);
 
 #endif /* LIGHTNING_COMMON_TIMEOUT_H */

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -2069,7 +2069,7 @@ int main(int argc, char *argv[])
 	for (;;) {
 		struct timer *expired;
 		io_loop(&daemon->timers, &expired);
-		timer_expired(daemon, expired);
+		timer_expired(expired);
 	}
 }
 

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1660,7 +1660,7 @@ int main(int argc, char *argv[])
 		struct timer *expired = NULL;
 		io_loop(&daemon->timers, &expired);
 
-		timer_expired(daemon, expired);
+		timer_expired(expired);
 	}
 }
 

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 	t = timers_expire(&timers, timemono_add(time_mono(),
 						time_from_sec(3601)));
 	assert(t);
-	timer_expired(NULL, t);
+	timer_expired(t);
 
 	/* Still there, just old.  Refresh scid1 */
 	assert(rstate->num_txout_failures == 0);
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
 	t = timers_expire(&timers, timemono_add(time_mono(),
 						time_from_sec(3601)));
 	assert(t);
-	timer_expired(NULL, t);
+	timer_expired(t);
 
 	assert(rstate->num_txout_failures == 0);
 	assert(in_txout_failures(rstate, &scid1));

--- a/lightningd/io_loop_with_timers.c
+++ b/lightningd/io_loop_with_timers.c
@@ -26,7 +26,7 @@ void *io_loop_with_timers(struct lightningd *ld)
 			/* This routine is legal in early startup, too. */
 			if (ld->wallet)
 				db_begin_transaction(ld->wallet->db);
-			timer_expired(ld, expired);
+			timer_expired(expired);
 			if (ld->wallet)
 				db_commit_transaction(ld->wallet->db);
 		}

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1192,7 +1192,7 @@ int main(int argc, char *argv[])
 	remove_sigchild_handler(sigchld_conn);
 	shutdown_subdaemons(ld);
 
-	/* Tell plugins we're shutting down, closes the db for write access. */
+	/* Tell plugins we're shutting down, closes the db. */
 	shutdown_plugins(ld);
 
 	/* Cleanup JSON RPC separately: destructors assume some list_head * in ld */

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -337,7 +337,6 @@ void plugin_hook_db_sync(struct db *db)
 	size_t i;
 	size_t num_hooks;
 
-	db_check_plugins_not_shutdown(db);
 	const char **changes = db_changes(db);
 	num_hooks = tal_count(hook->hooks);
 	if (num_hooks == 0)

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -206,7 +206,7 @@ void shutdown_plugins(struct lightningd *ld UNNEEDED)
 void stop_topology(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "stop_topology called!\n"); abort(); }
 /* Generated stub for timer_expired */
-void timer_expired(tal_t *ctx UNNEEDED, struct timer *timer UNNEEDED)
+void timer_expired(struct timer *timer UNNEEDED)
 { fprintf(stderr, "timer_expired called!\n"); abort(); }
 /* Generated stub for towire_bigsize */
 void towire_bigsize(u8 **pptr UNNEEDED, const bigsize_t val UNNEEDED)

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1266,7 +1266,6 @@ struct db *db_setup(const tal_t *ctx, struct lightningd *ld,
 	struct db *db = db_open(ctx, ld->wallet_dsn);
 	bool migrated;
 	db->log = new_log(db, ld->log_book, NULL, "database");
-	db->plugins_shutdown = &ld->plugins->shutdown;
 
 	db_begin_transaction(db);
 
@@ -2339,11 +2338,6 @@ void db_changes_add(struct db_stmt *stmt, const char * expanded)
 	}
 
 	tal_arr_expand(&db->changes, tal_strdup(db->changes, expanded));
-}
-
-void db_check_plugins_not_shutdown(struct db *db)
-{
-	assert(!*db->plugins_shutdown);
 }
 
 const char **db_changes(struct db *db)

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -249,9 +249,6 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
 #define db_prepare_v2(db,query)						\
 	db_prepare_v2_(__FILE__ ":" stringify(__LINE__), db, query)
 
-/* Check that plugins are not shutting down when calling db_write hook */
-void db_check_plugins_not_shutdown(struct db *db);
-
 /**
  * Access pending changes that have been added to the current transaction.
  */

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -34,9 +34,6 @@ struct db {
 	 * Used to bump the data_version in the DB.*/
 	bool dirty;
 
-	/* Only needed to check shutdown state of plugins */
-	const bool *plugins_shutdown;
-
 	/* The current DB version we expect to update if changes are
 	 * committed. */
 	u32 data_version;


### PR DESCRIPTION
Follow up of  #4897
Fixes issues raised  by @rustyrussell

- Simply close the `db` in the `shutdown_plugins`, is cleaner: no need to touch `db.c` with asserts etc.
- Use a simpler `io_loop`.

Some cleanup. BTW I found below comment confusing:
https://github.com/ElementsProject/lightning/blob/5a5cf8c69678fa73f211f391a9e938a0b991bb95/ccan/ccan/io/poll.c#L402-L403
Maybe more descriptive would be: `/* Check for expired timers. */`