### PR TITLE
status: do not log ping and pong packets

### DIFF
--- a/common/status.c
+++ b/common/status.c
@@ -98,13 +98,25 @@ static void status_io_full(enum log_level iodir,
 	status_send(take(towire_status_io(NULL, iodir, peer, who, p)));
 }
 
+static bool status_peer_io_filter_packettype(const u8 *p)
+{
+	int msg_type = fromwire_peektype(p);
+	switch (msg_type) {
+	case WIRE_PING:
+	case WIRE_PONG:
+		return true;
+	}
+	return false;
+}
+
 static void status_peer_io_short(enum log_level iodir,
 				 const struct node_id *peer,
 				 const u8 *p)
 {
-	status_peer_debug(peer, "%s %s",
-			  iodir == LOG_IO_OUT ? "peer_out" : "peer_in",
-			  peer_wire_name(fromwire_peektype(p)));
+	if (!status_peer_io_filter_packettype(p))
+		status_peer_debug(peer, "%s %s",
+				  iodir == LOG_IO_OUT ? "peer_out" : "peer_in",
+				  peer_wire_name(fromwire_peektype(p)));
 }
 
 void status_peer_io(enum log_level iodir,


### PR DESCRIPTION
Debug logging of ping and pong packets turned out to be
too excessive since this is now done on all channels
and without config option.

Changelog-None