### PR TITLE
hsmd: Add hsmd_new_channel and hsmd_ready_channel messages for validating signers

### DIFF
--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -640,6 +640,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 	case WIRE_HSMD_DEV_MEMLEAK:
 #endif /* DEVELOPER */
 
+	case WIRE_HSMD_NEW_CHANNEL:
 	case WIRE_HSMD_SIGN_COMMITMENT_TX:
 	case WIRE_HSMD_SIGN_PENALTY_TO_US:
 	case WIRE_HSMD_SIGN_REMOTE_COMMITMENT_TX:
@@ -670,6 +671,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 	case WIRE_HSMD_CANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
+	case WIRE_HSMD_NEW_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -641,6 +641,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 #endif /* DEVELOPER */
 
 	case WIRE_HSMD_NEW_CHANNEL:
+	case WIRE_HSMD_READY_CHANNEL:
 	case WIRE_HSMD_SIGN_COMMITMENT_TX:
 	case WIRE_HSMD_SIGN_PENALTY_TO_US:
 	case WIRE_HSMD_SIGN_REMOTE_COMMITMENT_TX:
@@ -672,6 +673,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
+	case WIRE_HSMD_READY_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -52,6 +52,28 @@ msgtype,hsmd_get_channel_basepoints_reply,110
 msgdata,hsmd_get_channel_basepoints_reply,basepoints,basepoints,
 msgdata,hsmd_get_channel_basepoints_reply,funding_pubkey,pubkey,
 
+#include <common/channel_type.h>
+# Provide channel parameters.
+msgtype,hsmd_ready_channel,31
+msgdata,hsmd_ready_channel,is_outbound,bool,
+msgdata,hsmd_ready_channel,channel_value,amount_sat,
+msgdata,hsmd_ready_channel,push_value,amount_msat,
+msgdata,hsmd_ready_channel,funding_txid,bitcoin_txid,
+msgdata,hsmd_ready_channel,funding_txout,u16,
+msgdata,hsmd_ready_channel,local_to_self_delay,u16,
+msgdata,hsmd_ready_channel,local_shutdown_script_len,u16,
+msgdata,hsmd_ready_channel,local_shutdown_script,u8,local_shutdown_script_len
+msgdata,hsmd_ready_channel,local_shutdown_wallet_index,?u32,
+msgdata,hsmd_ready_channel,remote_basepoints,basepoints,
+msgdata,hsmd_ready_channel,remote_funding_pubkey,pubkey,
+msgdata,hsmd_ready_channel,remote_to_self_delay,u16,
+msgdata,hsmd_ready_channel,remote_shutdown_script_len,u16,
+msgdata,hsmd_ready_channel,remote_shutdown_script,u8,remote_shutdown_script_len
+msgdata,hsmd_ready_channel,channel_type,channel_type,
+
+# No value returned.
+msgtype,hsmd_ready_channel_reply,131
+
 # Return signature for a funding tx.
 #include <common/utxo.h>
 

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -23,6 +23,14 @@ msgdata,hsmd_init_reply,bip32,ext_key,
 msgdata,hsmd_init_reply,bolt12,point32,
 msgdata,hsmd_init_reply,onion_reply_secret,secret,
 
+# Declare a new channel.
+msgtype,hsmd_new_channel,30
+msgdata,hsmd_new_channel,id,node_id,
+msgdata,hsmd_new_channel,dbid,u64,
+
+# No value returned.
+msgtype,hsmd_new_channel_reply,130
+
 # Get a new HSM FD, with the specified capabilities
 msgtype,hsmd_client_hsmfd,9
 # Which identity to use for requests

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -91,6 +91,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 
 	case WIRE_HSMD_GET_PER_COMMITMENT_POINT:
 	case WIRE_HSMD_CHECK_FUTURE_SECRET:
+	case WIRE_HSMD_READY_CHANNEL:
 		return (client->capabilities & HSM_CAP_COMMITMENT_POINT) != 0;
 
 	case WIRE_HSMD_SIGN_REMOTE_COMMITMENT_TX:
@@ -124,6 +125,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
+	case WIRE_HSMD_READY_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:
@@ -292,6 +294,59 @@ static u8 *handle_new_channel(struct hsmd_client *c, const u8 *msg_in)
 	/* Stub implementation */
 
 	return towire_hsmd_new_channel_reply(NULL);
+}
+
+static bool mem_is_zero(const void *mem, size_t len)
+{
+	size_t i;
+	for (i = 0; i < len; ++i)
+		if (((const unsigned char *)mem)[i])
+			return false;
+	return true;
+}
+
+/* ~This stub implementation is overriden by fully validating signers
+ * that need the unchanging channel parameters. */
+static u8 *handle_ready_channel(struct hsmd_client *c, const u8 *msg_in)
+{
+	bool is_outbound;
+	struct amount_sat channel_value;
+	struct amount_msat push_value;
+	struct bitcoin_txid funding_txid;
+	u16 funding_txout;
+	u16 local_to_self_delay;
+	u8 *local_shutdown_script;
+	u32 *local_shutdown_wallet_index;
+	struct basepoints remote_basepoints;
+	struct pubkey remote_funding_pubkey;
+	u16 remote_to_self_delay;
+	u8 *remote_shutdown_script;
+	struct amount_msat value_msat;
+	struct channel_type *channel_type;
+
+	if (!fromwire_hsmd_ready_channel(tmpctx, msg_in, &is_outbound,
+					&channel_value, &push_value, &funding_txid,
+					&funding_txout, &local_to_self_delay,
+					&local_shutdown_script,
+					&local_shutdown_wallet_index,
+					&remote_basepoints,
+					&remote_funding_pubkey,
+					&remote_to_self_delay,
+					&remote_shutdown_script,
+					&channel_type))
+		return hsmd_status_malformed_request(c, msg_in);
+
+	/* Stub implementation */
+
+	/* Fail fast if any values are uninitialized or obviously wrong. */
+	assert(amount_sat_greater(channel_value, AMOUNT_SAT(0)));
+	assert(amount_sat_to_msat(&value_msat, channel_value));
+	assert(amount_msat_less_eq(push_value, value_msat));
+	assert(!mem_is_zero(&funding_txid, sizeof(funding_txid)));
+	assert(local_to_self_delay > 0);
+	assert(remote_to_self_delay > 0);
+
+	return towire_hsmd_ready_channel_reply(NULL);
 }
 
 /*~ For almost every wallet tx we use the BIP32 seed, but not for onchain
@@ -1412,6 +1467,8 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 
 	case WIRE_HSMD_NEW_CHANNEL:
 		return handle_new_channel(client, msg);
+	case WIRE_HSMD_READY_CHANNEL:
+		return handle_ready_channel(client, msg);
 	case WIRE_HSMD_GET_OUTPUT_SCRIPTPUBKEY:
 		return handle_get_output_scriptpubkey(client, msg);
 	case WIRE_HSMD_CHECK_FUTURE_SECRET:
@@ -1461,6 +1518,7 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
+	case WIRE_HSMD_READY_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -104,6 +104,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 		return (client->capabilities & HSM_CAP_SIGN_WILL_FUND_OFFER) != 0;
 
 	case WIRE_HSMD_INIT:
+	case WIRE_HSMD_NEW_CHANNEL:
 	case WIRE_HSMD_CLIENT_HSMFD:
 	case WIRE_HSMD_SIGN_WITHDRAWAL:
 	case WIRE_HSMD_SIGN_INVOICE:
@@ -122,6 +123,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 	case WIRE_HSMD_CANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
+	case WIRE_HSMD_NEW_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:
@@ -275,6 +277,21 @@ static void get_channel_seed(const struct node_id *peer_id, u64 dbid,
 		    input, sizeof(input),
 		    &channel_base, sizeof(channel_base),
 		    info, strlen(info));
+}
+
+/* ~This stub implementation is overriden by fully validating signers
+ * that need to manage per-channel state. */
+static u8 *handle_new_channel(struct hsmd_client *c, const u8 *msg_in)
+{
+	struct node_id peer_id;
+	u64 dbid;
+
+	if (!fromwire_hsmd_new_channel(msg_in, &peer_id, &dbid))
+		return hsmd_status_malformed_request(c, msg_in);
+
+	/* Stub implementation */
+
+	return towire_hsmd_new_channel_reply(NULL);
 }
 
 /*~ For almost every wallet tx we use the BIP32 seed, but not for onchain
@@ -1393,6 +1410,8 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 		    "libhsmd",
 		    hsmd_wire_name(t));
 
+	case WIRE_HSMD_NEW_CHANNEL:
+		return handle_new_channel(client, msg);
 	case WIRE_HSMD_GET_OUTPUT_SCRIPTPUBKEY:
 		return handle_get_output_scriptpubkey(client, msg);
 	case WIRE_HSMD_CHECK_FUTURE_SECRET:
@@ -1441,6 +1460,7 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 	case WIRE_HSMD_CANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
+	case WIRE_HSMD_NEW_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -61,6 +61,7 @@ msgdata,dualopend_reinit,local_shutdown_len,u16,
 msgdata,dualopend_reinit,local_shutdown_scriptpubkey,u8,local_shutdown_len
 msgdata,dualopend_reinit,remote_shutdown_len,u16,
 msgdata,dualopend_reinit,remote_shutdown_scriptpubkey,u8,remote_shutdown_len
+msgdata,dualopend_reinit,local_shutdown_wallet_index,?u32,
 msgdata,dualopend_reinit,remote_funding_sigs_received,bool,
 msgdata,dualopend_reinit,fee_states,fee_states,
 msgdata,dualopend_reinit,channel_flags,u8,
@@ -94,6 +95,7 @@ msgdata,dualopend_got_offer_reply,accepter_funding,amount_sat,
 msgdata,dualopend_got_offer_reply,psbt,wally_psbt,
 msgdata,dualopend_got_offer_reply,shutdown_len,u16,
 msgdata,dualopend_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
+msgdata,dualopend_got_offer_reply,our_shutdown_wallet_index,?u32,
 # must go last because of embedded tu32
 msgdata,dualopend_got_offer_reply,lease_rates,?lease_rates,
 
@@ -172,6 +174,7 @@ msgdata,dualopend_opener_init,psbt,wally_psbt,
 msgdata,dualopend_opener_init,funding_amount,amount_sat,
 msgdata,dualopend_opener_init,local_shutdown_len,u16,
 msgdata,dualopend_opener_init,local_shutdown_scriptpubkey,u8,local_shutdown_len
+msgdata,dualopend_opener_init,local_shutdown_wallet_index,?u32,
 msgdata,dualopend_opener_init,feerate_per_kw,u32,
 msgdata,dualopend_opener_init,feerate_per_kw_funding,u32,
 msgdata,dualopend_opener_init,channel_flags,u8,

--- a/openingd/openingd_wire.csv
+++ b/openingd/openingd_wire.csv
@@ -55,6 +55,7 @@ msgtype,openingd_got_offer_reply,6105
 msgdata,openingd_got_offer_reply,rejection,?wirestring,
 msgdata,openingd_got_offer_reply,shutdown_len,u16,
 msgdata,openingd_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
+msgdata,openingd_got_offer_reply,our_shutdown_wallet_index,?u32,
 
 #include <common/penalty_base.h>
 # Openingd->master: we've successfully offered channel.
@@ -85,6 +86,7 @@ msgdata,openingd_funder_start,funding_satoshis,amount_sat,
 msgdata,openingd_funder_start,push_msat,amount_msat,
 msgdata,openingd_funder_start,len_upfront,u16,
 msgdata,openingd_funder_start,upfront_shutdown_script,u8,len_upfront
+msgdata,openingd_funder_start,upfront_shutdown_wallet_index,?u32,
 msgdata,openingd_funder_start,feerate_per_kw,u32,
 msgdata,openingd_funder_start,channel_flags,u8,
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -138,6 +138,10 @@ bool fromwire_custommsg_in(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8
 /* Generated stub for fromwire_gossipd_get_stripped_cupdate_reply */
 bool fromwire_gossipd_get_stripped_cupdate_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **stripped_update UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_get_stripped_cupdate_reply called!\n"); abort(); }
+u8 *towire_hsmd_new_channel(const tal_t *ctx UNNEEDED, const struct node_id *id UNNEEDED, u64 dbid UNNEEDED)
+{ fprintf(stderr, "towire_hsmd_new_channel called!\n"); abort(); }
+bool fromwire_hsmd_new_channel_reply(const void *p UNNEEDED)
+{ fprintf(stderr, "fromwire_hsmd_new_channel_reply called!\n"); abort(); }
 /* Generated stub for fromwire_hsmd_get_output_scriptpubkey_reply */
 bool fromwire_hsmd_get_output_scriptpubkey_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **script UNNEEDED)
 { fprintf(stderr, "fromwire_hsmd_get_output_scriptpubkey_reply called!\n"); abort(); }

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -615,8 +615,8 @@ bool wallet_add_onchaind_utxo(struct wallet *w,
 	return true;
 }
 
-static bool wallet_can_spend(struct wallet *w, const u8 *script,
-			     u32 *index, bool *output_is_p2sh)
+bool wallet_can_spend(struct wallet *w, const u8 *script,
+		      u32 *index, bool *output_is_p2sh)
 {
 	struct ext_key ext;
 	u64 bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -491,6 +491,19 @@ struct utxo *wallet_utxo_get(const tal_t *ctx, struct wallet *w,
 			     const struct bitcoin_outpoint *outpoint);
 
 /**
+ * wallet_can_spend - Do we have the private key matching this scriptpubkey?
+ *
+ * FIXME: This is very slow with lots of inputs!
+ *
+ * @w: (in) wallet holding the pubkeys to check against (privkeys are on HSM)
+ * @script: (in) the script to check
+ * @index: (out) the bip32 derivation index that matched the script
+ * @output_is_p2sh: (out) whether the script is a p2sh, or p2wpkh
+ */
+bool wallet_can_spend(struct wallet *w, const u8 *script,
+		      u32 *index, bool *output_is_p2sh);
+
+/**
  * wallet_get_newindex - get a new index from the wallet.
  * @ld: (in) lightning daemon
  *


### PR DESCRIPTION
This PR adds two messages (& replies) to `hsmd_wire.csv`. 

Summary of changes needed to support fully validating signers here:
https://gitlab.com/-/snippets/2179274
