### PR TITLE
lightningd: make shutdown smoother and safer, PART II (again)

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -4077,7 +4077,7 @@ int main(int argc, char *argv[])
 
 		expired = timers_expire(&peer->timers, now);
 		if (expired) {
-			timer_expired(peer, expired);
+			timer_expired(expired);
 			continue;
 		}
 

--- a/common/timeout.c
+++ b/common/timeout.c
@@ -36,7 +36,7 @@ void *reltimer_arg(struct oneshot *t)
 	return t->arg;
 }
 
-void timer_expired(tal_t *ctx, struct timer *timer)
+void timer_expired(struct timer *timer)
 {
 	struct oneshot *t = container_of(timer, struct oneshot, timer);
 

--- a/common/timeout.h
+++ b/common/timeout.h
@@ -18,6 +18,6 @@ struct oneshot *new_reltimer_(struct timers *timers,
 /* Get timer arg. */
 void *reltimer_arg(struct oneshot *t);
 
-void timer_expired(tal_t *ctx, struct timer *timer);
+void timer_expired(struct timer *timer);
 
 #endif /* LIGHTNING_COMMON_TIMEOUT_H */

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -2075,7 +2075,7 @@ int main(int argc, char *argv[])
 	for (;;) {
 		struct timer *expired;
 		io_loop(&daemon->timers, &expired);
-		timer_expired(daemon, expired);
+		timer_expired(expired);
 	}
 }
 

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1548,7 +1548,7 @@ int main(int argc, char *argv[])
 		struct timer *expired = NULL;
 		io_loop(&daemon->timers, &expired);
 
-		timer_expired(daemon, expired);
+		timer_expired(expired);
 	}
 }
 

--- a/gossipd/test/run-onion_message.c
+++ b/gossipd/test/run-onion_message.c
@@ -302,7 +302,7 @@ void status_setup_async(struct daemon_conn *master UNNEEDED)
 void subdaemon_setup(int argc UNNEEDED, char *argv[])
 { fprintf(stderr, "subdaemon_setup called!\n"); abort(); }
 /* Generated stub for timer_expired */
-void timer_expired(tal_t *ctx UNNEEDED, struct timer *timer UNNEEDED)
+void timer_expired(struct timer *timer UNNEEDED)
 { fprintf(stderr, "timer_expired called!\n"); abort(); }
 /* Generated stub for towire_gossipd_addgossip_reply */
 u8 *towire_gossipd_addgossip_reply(const tal_t *ctx UNNEEDED, const wirestring *err UNNEEDED)

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 	t = timers_expire(&timers, timemono_add(time_mono(),
 						time_from_sec(3601)));
 	assert(t);
-	timer_expired(NULL, t);
+	timer_expired(t);
 
 	/* Still there, just old.  Refresh scid1 */
 	assert(rstate->num_txout_failures == 0);
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
 	t = timers_expire(&timers, timemono_add(time_mono(),
 						time_from_sec(3601)));
 	assert(t);
-	timer_expired(NULL, t);
+	timer_expired(t);
 
 	assert(rstate->num_txout_failures == 0);
 	assert(in_txout_failures(rstate, &scid1));

--- a/lightningd/io_loop_with_timers.c
+++ b/lightningd/io_loop_with_timers.c
@@ -26,7 +26,7 @@ void *io_loop_with_timers(struct lightningd *ld)
 			/* This routine is legal in early startup, too. */
 			if (ld->wallet)
 				db_begin_transaction(ld->wallet->db);
-			timer_expired(ld, expired);
+			timer_expired(expired);
 			if (ld->wallet)
 				db_commit_transaction(ld->wallet->db);
 		}

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1197,7 +1197,7 @@ int main(int argc, char *argv[])
 	remove_sigchild_handler(sigchld_conn);
 	shutdown_subdaemons(ld);
 
-	/* Tell plugins we're shutting down, closes the db for write access. */
+	/* Tell plugins we're shutting down, closes the db. */
 	shutdown_plugins(ld);
 
 	/* Cleanup JSON RPC separately: destructors assume some list_head * in ld */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -243,7 +243,6 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 */
 	ld->plugins = plugins_new(ld, ld->log_book, ld);
 	ld->plugins->startup = true;
-	ld->plugins->shutdown = false;
 
 	/*~ This is set when a JSON RPC command comes in to shut us down. */
 	ld->stop_conn = NULL;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -113,9 +113,6 @@ struct plugins {
 	/* Blacklist of plugins from --disable-plugin */
 	const char **blacklist;
 
-	/* Whether we are shutting down, blocks db write's */
-	bool shutdown;
-
 	/* Index to show what order they were added in */
 	u64 plugin_idx;
 

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -338,7 +338,6 @@ void plugin_hook_db_sync(struct db *db)
 	size_t i;
 	size_t num_hooks;
 
-	db_check_plugins_not_shutdown(db);
 	const char **changes = db_changes(db);
 	num_hooks = tal_count(hook->hooks);
 	if (num_hooks == 0)

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -207,7 +207,7 @@ void shutdown_plugins(struct lightningd *ld UNNEEDED)
 void stop_topology(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "stop_topology called!\n"); abort(); }
 /* Generated stub for timer_expired */
-void timer_expired(tal_t *ctx UNNEEDED, struct timer *timer UNNEEDED)
+void timer_expired(struct timer *timer UNNEEDED)
 { fprintf(stderr, "timer_expired called!\n"); abort(); }
 /* Generated stub for towire_bigsize */
 void towire_bigsize(u8 **pptr UNNEEDED, const bigsize_t val UNNEEDED)

--- a/tests/plugins/misc_notifications.py
+++ b/tests/plugins/misc_notifications.py
@@ -3,7 +3,6 @@
 """
 
 from pyln.client import Plugin, RpcError
-from time import sleep
 import sys
 import pytest
 
@@ -30,25 +29,22 @@ def channel_state_changed(plugin, channel_state_changed, **kwargs):
 
 @plugin.subscribe("shutdown")
 def shutdown(plugin, **kwargs):
-    plugin.log("received shutdown notification")
 
     # 'shutdown' notification can be called in two ways, from `plugin stop` or from
     # lightningd's shutdown loop, we test which one by making `getinfo` call
     try:
         plugin.rpc.getinfo()
         plugin.rpc.datastore(key='test', string='Allowed', mode="create-or-append")
-        plugin.log("datastore success")
+        plugin.log("via plugin stop, datastore success")
     except RpcError as e:
         if e.error == {'code': -5, 'message': 'lightningd is shutting down'}:
             # JSON RPC is disabled by now, but can do logging
             with pytest.raises(RpcError, match=r'-5.*lightningd is shutting down'):
                 plugin.rpc.datastore(key='test', string='Not allowed', mode="create-or-append")
-            plugin.log("datastore failed")
+            plugin.log("via lightningd shutdown, datastore failed")
         else:
             raise
 
-    plugin.log("delaying shutdown with 5s")
-    sleep(5)
     sys.exit(0)
 
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4352,6 +4352,10 @@ def test_fetchinvoice_3hop(node_factory, bitcoind):
 
     l1.rpc.call('fetchinvoice', {'offer': offer1['bolt12']})
 
+    # Make sure l4 handled both onions before shutting down
+    l1.daemon.wait_for_log(r'plugin-fetchinvoice: Received modern onion .*obs2\\":false')
+    l1.daemon.wait_for_log(r'plugin-fetchinvoice: No match for modern onion.*obs2\\":true')
+
     # Test with obsolete onion.
     l4.stop()
     l4.daemon.opts['dev-no-modern-onion'] = None

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1276,7 +1276,6 @@ struct db *db_setup(const tal_t *ctx, struct lightningd *ld,
 	struct db *db = db_open(ctx, ld->wallet_dsn);
 	bool migrated;
 	db->log = new_log(db, ld->log_book, NULL, "database");
-	db->plugins_shutdown = &ld->plugins->shutdown;
 
 	db_begin_transaction(db);
 
@@ -2349,11 +2348,6 @@ void db_changes_add(struct db_stmt *stmt, const char * expanded)
 	}
 
 	tal_arr_expand(&db->changes, tal_strdup(db->changes, expanded));
-}
-
-void db_check_plugins_not_shutdown(struct db *db)
-{
-	assert(!*db->plugins_shutdown);
 }
 
 const char **db_changes(struct db *db)

--- a/wallet/db.h
+++ b/wallet/db.h
@@ -249,9 +249,6 @@ struct db_stmt *db_prepare_v2_(const char *location, struct db *db,
 #define db_prepare_v2(db,query)						\
 	db_prepare_v2_(__FILE__ ":" stringify(__LINE__), db, query)
 
-/* Check that plugins are not shutting down when calling db_write hook */
-void db_check_plugins_not_shutdown(struct db *db);
-
 /**
  * Access pending changes that have been added to the current transaction.
  */

--- a/wallet/db_common.h
+++ b/wallet/db_common.h
@@ -34,9 +34,6 @@ struct db {
 	 * Used to bump the data_version in the DB.*/
 	bool dirty;
 
-	/* Only needed to check shutdown state of plugins */
-	const bool *plugins_shutdown;
-
 	/* The current DB version we expect to update if changes are
 	 * committed. */
 	u32 data_version;


### PR DESCRIPTION
Follow up of #4897, fixes the issues raised in that PR. (similar to #4947, but could not reopen it after force push)

- Simply close the `db` in the `shutdown_plugins`, this partially reverts 5f69674faaf4763e4457431e27c35147e0d52bc5 (the part that touched  `wallet` code).
- Use a simpler `io_loop` in `shutdown_plugins`
- Removed `test_htlc_accepted_hook_shutdown`, moved relevant parts into `test_plugin_shutdown`

Some cleanup: `timer_expired()` had an obsolete parameter.

BTW I found below comment inside `io_loop` confusing:
https://github.com/ElementsProject/lightning/blob/5a5cf8c69678fa73f211f391a9e938a0b991bb95/ccan/ccan/io/poll.c#L402-L403
Maybe more descriptive would be: `/* Look for expired timers. */`