### PR TITLE
connectd: fix empty error message

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -232,7 +232,7 @@ def test_announce_and_connect_via_dns(node_factory, bitcoind):
 
     # l4 however must not be able to connect because he used '--disable-dns'
     # This raises RpcError code 401, currently with an empty error message.
-    with pytest.raises(RpcError, match=r"401"):
+    with pytest.raises(RpcError, match=r"401.*dns disabled"):
         l4.rpc.connect(l1.info['id'])
 
 


### PR DESCRIPTION
1. Adds the missing DNS error massages so they can be handled by
   connect_control.
2. Prepends a 'All addresses failed' to code 401 message, so we
   always have at least some error message to the user.

Changelog-None