### PR TITLE
doc: force mistune==0.8.4 during pip package resolution.

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -40,7 +40,7 @@ Get dependencies:
       autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev \
       python3 python3-mako python3-pip net-tools zlib1g-dev libsodium-dev \
       gettext
-    pip3 install --user mrkd
+    pip3 install --user mrkd mistune==0.8.4
 
 If you don't have Bitcoin installed locally you'll need to install that
 as well. It's now available via [snapd](https://snapcraft.io/bitcoin-core).


### PR DESCRIPTION
This PR will add tips in the docs because on IRC there are some reports on bad resolution versions caused by this bug of `mrkd` https://github.com/refi64/mrkd/pull/6#issue-1073838481

Basically, the package has no fixed version and this gives them the power to pip to pull the last version of the `mistune` dependence, which will break the `mrkd` package.

P.S: The change should be forwarded also to all the docker files, but we hope that release the new version of the package takes only a few days

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
Changelog-None: doc: force mistune==0.8.4 during pip package resolution.