### PR TITLE
Removed FIXME to match bolts PR 918

### DIFF
--- a/common/ping.c
+++ b/common/ping.c
@@ -13,14 +13,6 @@ bool check_ping_make_pong(const tal_t *ctx, const u8 *ping, u8 **pong)
 		return false;
 	tal_free(ignored);
 
-	/* FIXME: */
-	/* BOLT #1:
-	 *
-	 * A node receiving a `ping` message:
-	 *  - SHOULD fail the channels if it has received significantly in
-	 *    excess of one `ping` per 30 seconds.
-	 */
-
 	/* BOLT #1:
 	 *
 	 * A node receiving a `ping` message:


### PR DESCRIPTION
It seems as if  [PR 918](https://github.com/lightning/bolts/pull/918) will be merged to the bolts so this requirement will be dropped from the spec and we do not need to have a FIXME in the code base.

Yes I know that this is a somewhat silly PR.