### PR TITLE
Update .gitignore for tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dSYM
 *.rej
 *.pyc
+*.tmp
 .cppcheck-suppress
 .mypy_cache
 TAGS


### PR DESCRIPTION
`.tmp` files are generated from compiling the docs, these should be ignored by git