### PR TITLE
Fix comment to reflect the code

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -170,7 +170,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 * in limbo until we get all the parts, or we time them out. */
 	htlc_set_map_init(&ld->htlc_sets);
 
-	/*~ We have a multi-entry log-book infrastructure: we define a 100MB log
+	/*~ We have a multi-entry log-book infrastructure: we define a 10MB log
 	 * book to hold all the entries (and trims as necessary), and multiple
 	 * log objects which each can write into it, each with a unique
 	 * prefix. */


### PR DESCRIPTION
The comment mentions a 100MB log book, but the code was modified 15 months ago to allocate a 10MB log book to preserve memory.