### PR TITLE
hsmd: Add fields to hsmd_sign_commitment_tx and hsmd_sign_remote_commitment_tx

### DIFF
--- a/common/htlc_wire.c
+++ b/common/htlc_wire.c
@@ -24,6 +24,20 @@ static struct failed_htlc *failed_htlc_dup(const tal_t *ctx,
 	return newf;
 }
 
+struct simple_htlc *new_simple_htlc(const tal_t *ctx,
+				    enum side side,
+				    struct amount_msat amount,
+				    const struct sha256 *payment_hash,
+				    u32 cltv_expiry)
+{
+	struct simple_htlc *simple = tal(ctx, struct simple_htlc);
+	simple->side = side;
+	simple->amount = amount;
+	simple->payment_hash = *payment_hash;
+	simple->cltv_expiry = cltv_expiry;
+	return simple;
+}
+
 struct existing_htlc *new_existing_htlc(const tal_t *ctx,
 					u64 id,
 					enum htlc_state state,
@@ -98,6 +112,14 @@ void towire_existing_htlc(u8 **pptr, const struct existing_htlc *existing)
 		towire_pubkey(pptr, existing->blinding);
 	} else
 		towire_bool(pptr, false);
+}
+
+void towire_simple_htlc(u8 **pptr, const struct simple_htlc *simple)
+{
+	towire_side(pptr, simple->side);
+	towire_amount_msat(pptr, simple->amount);
+	towire_sha256(pptr, &simple->payment_hash);
+	towire_u32(pptr, simple->cltv_expiry);
 }
 
 void towire_fulfilled_htlc(u8 **pptr, const struct fulfilled_htlc *fulfilled)
@@ -195,6 +217,18 @@ struct existing_htlc *fromwire_existing_htlc(const tal_t *ctx,
 	} else
 		existing->blinding = NULL;
 	return existing;
+}
+
+struct simple_htlc *fromwire_simple_htlc(const tal_t *ctx,
+					 const u8 **cursor, size_t *max)
+{
+	struct simple_htlc *simple = tal(ctx, struct simple_htlc);
+
+	simple->side = fromwire_side(cursor, max);
+	simple->amount = fromwire_amount_msat(cursor, max);
+	fromwire_sha256(cursor, max, &simple->payment_hash);
+	simple->cltv_expiry = fromwire_u32(cursor, max);
+	return simple;
 }
 
 void fromwire_fulfilled_htlc(const u8 **cursor, size_t *max,

--- a/common/htlc_wire.h
+++ b/common/htlc_wire.h
@@ -63,6 +63,14 @@ struct changed_htlc {
 	u64 id;
 };
 
+/* For signing interfaces */
+struct simple_htlc {
+	enum side side;
+	struct amount_msat amount;
+	struct sha256 payment_hash;
+	u32 cltv_expiry;
+};
+
 struct existing_htlc *new_existing_htlc(const tal_t *ctx,
 					u64 id,
 					enum htlc_state state,
@@ -74,8 +82,15 @@ struct existing_htlc *new_existing_htlc(const tal_t *ctx,
 					const struct preimage *preimage TAKES,
 					const struct failed_htlc *failed TAKES);
 
+struct simple_htlc *new_simple_htlc(const tal_t *ctx,
+				    enum side side,
+				    struct amount_msat amount,
+				    const struct sha256 *payment_hash,
+				    u32 cltv_expiry);
+
 void towire_added_htlc(u8 **pptr, const struct added_htlc *added);
 void towire_existing_htlc(u8 **pptr, const struct existing_htlc *existing);
+void towire_simple_htlc(u8 **pptr, const struct simple_htlc *simple);
 void towire_fulfilled_htlc(u8 **pptr, const struct fulfilled_htlc *fulfilled);
 void towire_failed_htlc(u8 **pptr, const struct failed_htlc *failed);
 void towire_changed_htlc(u8 **pptr, const struct changed_htlc *changed);
@@ -86,6 +101,8 @@ void fromwire_added_htlc(const u8 **cursor, size_t *max,
 			 struct added_htlc *added);
 struct existing_htlc *fromwire_existing_htlc(const tal_t *ctx,
 					     const u8 **cursor, size_t *max);
+struct simple_htlc *fromwire_simple_htlc(const tal_t *ctx,
+					 const u8 **cursor, size_t *max);
 void fromwire_fulfilled_htlc(const u8 **cursor, size_t *max,
 			     struct fulfilled_htlc *fulfilled);
 struct failed_htlc *fromwire_failed_htlc(const tal_t *ctx, const u8 **cursor,

--- a/gossipd/Makefile
+++ b/gossipd/Makefile
@@ -50,6 +50,7 @@ GOSSIPD_COMMON_OBJS :=				\
 	common/memleak.o			\
 	common/msg_queue.o			\
 	common/node_id.o			\
+	common/onionreply.o			\
 	common/per_peer_state.o			\
 	common/ping.o				\
 	common/psbt_open.o			\

--- a/hsmd/Makefile
+++ b/hsmd/Makefile
@@ -10,7 +10,9 @@ HSMD_OBJS := $(HSMD_SRC:.c=.o)
 $(HSMD_OBJS): $(HSMD_HEADERS)
 
 # Other programs which use the hsm need this.
-HSMD_CLIENT_OBJS := hsmd/hsmd_wiregen.o
+HSMD_CLIENT_OBJS := \
+	hsmd/hsmd_wiregen.o			\
+	common/htlc_wire.o
 
 # Make sure these depend on everything.
 ALL_C_SOURCES += $(HSMD_SRC)
@@ -32,11 +34,13 @@ HSMD_COMMON_OBJS :=				\
 	common/status_wiregen.o			\
 	common/hash_u5.o			\
 	common/hsm_encryption.o			\
+	common/htlc_wire.o			\
 	common/key_derive.o			\
 	common/lease_rates.o			\
 	common/memleak.o			\
 	common/msg_queue.o			\
 	common/node_id.o			\
+	common/onionreply.o			\
 	common/permute_tx.o			\
 	common/psbt_open.o			\
 	common/pseudorand.o			\

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -133,6 +133,7 @@ msgdata,hsmd_sign_commitment_tx,peer_id,node_id,
 msgdata,hsmd_sign_commitment_tx,channel_dbid,u64,
 msgdata,hsmd_sign_commitment_tx,tx,bitcoin_tx,
 msgdata,hsmd_sign_commitment_tx,remote_funding_key,pubkey,
+msgdata,hsmd_sign_commitment_tx,commit_num,u64,
 
 msgtype,hsmd_sign_commitment_tx_reply,105
 msgdata,hsmd_sign_commitment_tx_reply,sig,bitcoin_signature,
@@ -176,11 +177,16 @@ msgdata,hsmd_sign_local_htlc_tx,wscript,u8,wscript_len
 msgdata,hsmd_sign_local_htlc_tx,option_anchor_outputs,bool,
 
 # Openingd/channeld asks HSM to sign the other sides' commitment tx.
+#include <common/htlc_wire.h>
 msgtype,hsmd_sign_remote_commitment_tx,19
 msgdata,hsmd_sign_remote_commitment_tx,tx,bitcoin_tx,
 msgdata,hsmd_sign_remote_commitment_tx,remote_funding_key,pubkey,
 msgdata,hsmd_sign_remote_commitment_tx,remote_per_commit,pubkey,
 msgdata,hsmd_sign_remote_commitment_tx,option_static_remotekey,bool,
+msgdata,hsmd_sign_remote_commitment_tx,commit_num,u64,
+msgdata,hsmd_sign_remote_commitment_tx,num_htlcs,u16,
+msgdata,hsmd_sign_remote_commitment_tx,htlcs,simple_htlc,num_htlcs
+msgdata,hsmd_sign_remote_commitment_tx,feerate,u32,
 
 # channeld asks HSM to sign remote HTLC tx.
 msgtype,hsmd_sign_remote_htlc_tx,20

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -1203,12 +1203,17 @@ static u8 *handle_sign_remote_commitment_tx(struct hsmd_client *c, const u8 *msg
 	const u8 *funding_wscript;
 	struct pubkey remote_per_commit;
 	bool option_static_remotekey;
+	u64 commit_num;
+	struct simple_htlc **htlc;
+	u32 feerate;
 
 	if (!fromwire_hsmd_sign_remote_commitment_tx(tmpctx, msg_in,
 						    &tx,
 						    &remote_funding_pubkey,
 						    &remote_per_commit,
-						    &option_static_remotekey))
+						    &option_static_remotekey,
+						    &commit_num,
+						    &htlc, &feerate))
 		return hsmd_status_malformed_request(c, msg_in);
 	tx->chainparams = c->chainparams;
 
@@ -1293,13 +1298,15 @@ static u8 *handle_sign_commitment_tx(struct hsmd_client *c, const u8 *msg_in)
 	struct secret channel_seed;
 	struct bitcoin_tx *tx;
 	struct bitcoin_signature sig;
+	u64 commit_num;
 	struct secrets secrets;
 	const u8 *funding_wscript;
 
 	if (!fromwire_hsmd_sign_commitment_tx(tmpctx, msg_in,
 					     &peer_id, &dbid,
 					     &tx,
-					     &remote_funding_pubkey))
+					     &remote_funding_pubkey,
+					     &commit_num))
 		return hsmd_status_malformed_request(c, msg_in);
 
 	tx->chainparams = c->chainparams;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -185,13 +185,16 @@ static void sign_last_tx(struct channel *channel,
 	struct bitcoin_signature sig;
 	u8 *msg, **witness;
 
+	u64 commit_index = channel->next_index[LOCAL] - 1;
+
 	assert(!last_tx->wtx->inputs[0].witness);
 	msg = towire_hsmd_sign_commitment_tx(tmpctx,
 					     &channel->peer->id,
 					     channel->dbid,
 					     last_tx,
 					     &channel->channel_info
-					     .remote_fundingkey);
+					     .remote_fundingkey,
+					     commit_index);
 
 	if (!wire_sync_write(ld->hsm_fd, take(msg)))
 		fatal("Could not write to HSM: %s", strerror(errno));

--- a/lightningd/test/Makefile
+++ b/lightningd/test/Makefile
@@ -14,12 +14,14 @@ LIGHTNINGD_TEST_COMMON_OBJS :=			\
 	common/bech32.o				\
 	common/daemon_conn.o			\
 	common/htlc_state.o			\
+	common/htlc_wire.o			\
 	common/json.o				\
 	common/key_derive.o			\
 	common/pseudorand.o			\
 	common/random_select.o			\
 	common/memleak.o			\
 	common/msg_queue.o			\
+	common/onionreply.o			\
 	common/setup.o				\
 	common/utils.o				\
 	common/utxo.o				\

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -649,7 +649,7 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 u8 *towire_hsmd_sign_bolt12(const tal_t *ctx UNNEEDED, const wirestring *messagename UNNEEDED, const wirestring *fieldname UNNEEDED, const struct sha256 *merkleroot UNNEEDED, const u8 *publictweak UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_bolt12 called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_commitment_tx */
-u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED)
+u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_commitment_tx called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_invoice */
 u8 *towire_hsmd_sign_invoice(const tal_t *ctx UNNEEDED, const u8 *u5bytes UNNEEDED, const u8 *hrp UNNEEDED)

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -1901,11 +1901,17 @@ static u8 *accepter_commits(struct state *state,
 	}
 
 	/* Make HSM sign it */
+	struct simple_htlc **htlcs = tal_arr(tmpctx, struct simple_htlc *, 0);
+	u32 feerate = 0; // unused since there are no htlcs
+	u64 commit_num = 0;
 	msg = towire_hsmd_sign_remote_commitment_tx(NULL,
 						    remote_commit,
 						    &state->channel->funding_pubkey[REMOTE],
 						    &state->first_per_commitment_point[REMOTE],
-						    true);
+						    true,
+						    commit_num,
+						    (const struct simple_htlc **) htlcs,
+						    feerate);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
 	if (!fromwire_hsmd_sign_tx_reply(msg, &local_sig))
@@ -2494,11 +2500,17 @@ static u8 *opener_commits(struct state *state,
 	 * witness script.  It also needs the amount of the funding output,
 	 * as segwit signatures commit to that as well, even though it doesn't
 	 * explicitly appear in the transaction itself. */
+	struct simple_htlc **htlcs = tal_arr(tmpctx, struct simple_htlc *, 0);
+	u32 feerate = 0; // unused since there are no htlcs
+	u64 commit_num = 0;
 	msg = towire_hsmd_sign_remote_commitment_tx(NULL,
 						   remote_commit,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
-						   true);
+						    true,
+						    commit_num,
+						    (const struct simple_htlc **) htlcs,
+						    feerate);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
 	if (!fromwire_hsmd_sign_tx_reply(msg, &local_sig))

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -594,12 +594,18 @@ static bool funder_finalize_channel_setup(struct state *state,
 	 * witness script.  It also needs the amount of the funding output,
 	 * as segwit signatures commit to that as well, even though it doesn't
 	 * explicitly appear in the transaction itself. */
+	struct simple_htlc **htlcs = tal_arr(tmpctx, struct simple_htlc *, 0);
+	u32 feerate = 0; // unused since there are no htlcs
+	u64 commit_num = 0;
 	msg = towire_hsmd_sign_remote_commitment_tx(NULL,
 						   *tx,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
 						    channel_has(state->channel,
-								OPT_STATIC_REMOTEKEY));
+								OPT_STATIC_REMOTEKEY),
+						    commit_num,
+						    (const struct simple_htlc **) htlcs,
+						    feerate);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
@@ -1185,12 +1191,18 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	}
 
 	/* Make HSM sign it */
+	struct simple_htlc **htlcs = tal_arr(tmpctx, struct simple_htlc *, 0);
+	u32 feerate = 0; // unused since there are no htlcs
+	u64 commit_num = 0;
 	msg = towire_hsmd_sign_remote_commitment_tx(NULL,
 						   remote_commit,
 						   &state->channel->funding_pubkey[REMOTE],
 						   &state->first_per_commitment_point[REMOTE],
 						    channel_has(state->channel,
-								OPT_STATIC_REMOTEKEY));
+								OPT_STATIC_REMOTEKEY),
+						   commit_num,
+						   (const struct simple_htlc **) htlcs,
+						   feerate);
 
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -228,6 +228,7 @@ class Type(FieldSet):
         'gossip_getchannels_entry',
         'failed_htlc',
         'existing_htlc',
+        'simple_htlc',
         'utxo',
         'bitcoin_tx',
         'wirestring',

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -756,7 +756,7 @@ u8 *towire_hsmd_get_output_scriptpubkey(const tal_t *ctx UNNEEDED, u64 channel_i
 u8 *towire_hsmd_new_channel(const tal_t *ctx UNNEEDED, const struct node_id *id UNNEEDED, u64 dbid UNNEEDED)
 { fprintf(stderr, "towire_hsmd_new_channel called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_commitment_tx */
-u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED)
+u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_id *peer_id UNNEEDED, u64 channel_dbid UNNEEDED, const struct bitcoin_tx *tx UNNEEDED, const struct pubkey *remote_funding_key UNNEEDED, u64 commit_num UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_commitment_tx called!\n"); abort(); }
 /* Generated stub for towire_incorrect_cltv_expiry */
 u8 *towire_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expiry UNNEEDED, const u8 *channel_update UNNEEDED)


### PR DESCRIPTION
Add to hsmd_sign_remote_commitment_tx:
- commitment_number
- feerate
- htlcs

Add to hsmd_sign_commitment_tx:
- commitment_number

These fields are needed for validating signers.

[Summary of all changes for validating signers](https://gitlab.com/lightning-signer/docs/-/wikis/C-Lightning-Modifications)

