### PR TITLE
make: Add macos M1 support

### DIFF
--- a/configure
+++ b/configure
@@ -8,6 +8,18 @@ CONFIG_VAR_FILE=config.vars
 CONFIG_HEADER=ccan/config.h
 BASE_WARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror"
 
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [ "$OS-$ARCH" = "Darwin-arm64" ]; then
+CPATH=/opt/homebrew/include
+LIBRARY_PATH=/opt/homebrew/lib
+export PKG_CONFIG_PATH=/opt/homebrew/opt/sqlite/lib/pkgconfig
+else
+CPATH=/usr/local/lib
+LIBRARY_PATH=/usr/local/lib
+export PKG_CONFIG_PATH=/usr/local/opt/sqlite/lib/pkgconfig
+fi
+
 : ${PKG_CONFIG=pkg-config}
 
 # You can set PG_CONFIG in the environment to direct configure to call

--- a/configure
+++ b/configure
@@ -301,7 +301,7 @@ fi
 # Clean up on exit.
 trap "rm -f $CONFIG_VAR_FILE.$$" 0
 
-$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER.$$ --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I/usr/local/include -L/usr/local/lib $SQLITE3_CFLAGS $POSTGRES_INCLUDE <<EOF
+$CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER.$$ --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS -I$CPATH -L$LIBRARY_PATH $SQLITE3_CFLAGS $POSTGRES_INCLUDE <<EOF
 
 var=HAVE_GOOD_LIBSODIUM
 desc=libsodium with IETF chacha20 variants

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -2,6 +2,7 @@ x86_64-linux-gnu
 aarch64-linux-gnu
 arm-linux-gnueabihf
 x86_64-pc-linux-gnu
+arm64-apple-darwin*
 
 libbacktrace-build/
 libbacktrace.a


### PR DESCRIPTION
The M1 Macs support both x86_64 and arm64 architectures, which forced
homebrew to use a different path for its storage (`/opt/homebrew/`
instead of `/usr/local`). If we don't adjust the path we'd mix x86_64
and arm64 libraries which can lead to weird compiler and linker
errors.

This patch just introduces `CPATH` and `LIBRARY_PATH` as suggested by
the homebrew team, and detects the current architecture automatically.

Changelog-Added: macos: Added m1 architecture support for macos