### PR TITLE
dns: only allow one dns

### DIFF
--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -21,6 +21,7 @@ struct io_plan *peer_connected(struct io_conn *conn,
 			       struct daemon *daemon,
 			       const struct node_id *id,
 			       const struct wireaddr_internal *addr,
+			       const struct wireaddr_internal *remote_addr,
 			       struct crypto_state *cs,
 			       const u8 *their_features TAKES,
 			       bool incoming);

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -59,6 +59,7 @@ msgdata,connectd_connect_failed,addrhint,?wireaddr_internal,
 msgtype,connectd_peer_connected,2002
 msgdata,connectd_peer_connected,id,node_id,
 msgdata,connectd_peer_connected,addr,wireaddr_internal,
+msgdata,connectd_peer_connected,remote_addr,wireaddr_internal,
 msgdata,connectd_peer_connected,incoming,bool,
 msgdata,connectd_peer_connected,pps,per_peer_state,
 msgdata,connectd_peer_connected,flen,u16,

--- a/contrib/pyln-spec/bolt1/pyln/spec/bolt1/csv.py
+++ b/contrib/pyln-spec/bolt1/pyln/spec/bolt1/csv.py
@@ -7,6 +7,8 @@ csv = [
     "msgdata,init,tlvs,init_tlvs,",
     "tlvtype,init_tlvs,networks,1",
     "tlvdata,init_tlvs,networks,chains,chain_hash,...",
+    "tlvtype,init_tlvs,remote_addr,3",
+    "tlvdata,init_tlvs,remote_addr,data,byte,...",
     "msgtype,error,17",
     "msgdata,error,channel_id,channel_id,",
     "msgdata,error,len,u16,",

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -196,6 +196,23 @@ static char *opt_set_accept_extra_tlv_types(const char *arg,
 }
 #endif
 
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
+/* Returns the number of wireaddr types already announced */
+static size_t num_announced_types(enum wire_addr_type type, struct lightningd *ld)
+{
+	size_t num = 0;
+	for (size_t i = 0; i < tal_count(ld->proposed_wireaddr); i++) {
+		if (ld->proposed_wireaddr[i].itype != ADDR_INTERNAL_WIREADDR)
+			continue;
+		if (ld->proposed_wireaddr[i].u.wireaddr.type != type)
+			continue;
+		if (ld->proposed_listen_announce[i] & ADDR_ANNOUNCE)
+			num++;
+	}
+	return num;
+}
+#endif
+
 static char *opt_add_addr_withtype(const char *arg,
 				   struct lightningd *ld,
 				   enum addr_listen_announce ala,
@@ -242,6 +259,9 @@ static char *opt_add_addr_withtype(const char *arg,
 #if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	/* Add ADDR_TYPE_DNS to announce DNS hostnames */
 	if (is_dnsaddr(address) && ala & ADDR_ANNOUNCE) {
+		if (num_announced_types(ADDR_TYPE_DNS, ld) > 0) {
+			return tal_fmt(NULL, "Only one DNS can be announced");
+		}
 		memset(&wi, 0, sizeof(wi));
 		wi.itype = ADDR_INTERNAL_WIREADDR;
 		wi.u.wireaddr.type = ADDR_TYPE_DNS;

--- a/lightningd/test/Makefile
+++ b/lightningd/test/Makefile
@@ -10,6 +10,7 @@ ALL_TEST_PROGRAMS += $(LIGHTNINGD_TEST_PROGRAMS)
 LIGHTNINGD_TEST_COMMON_OBJS :=			\
 	common/amount.o				\
 	common/autodata.o			\
+	common/base32.o				\
 	common/bech32.o				\
 	common/daemon_conn.o			\
 	common/htlc_state.o			\
@@ -23,7 +24,8 @@ LIGHTNINGD_TEST_COMMON_OBJS :=			\
 	common/utils.o				\
 	common/utxo.o				\
 	common/type_to_string.o			\
-	common/permute_tx.o
+	common/permute_tx.o			\
+	common/wireaddr.o			\
 
 $(LIGHTNINGD_TEST_PROGRAMS): $(CCAN_OBJS) $(BITCOIN_OBJS) $(WIRE_OBJS) $(LIGHTNINGD_TEST_COMMON_OBJS)
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -1,8 +1,6 @@
 #include "config.h"
 #define main unused_main
 int unused_main(int argc, char *argv[]);
-#include "../../common/base32.c"
-#include "../../common/wireaddr.c"
 #include "../io_loop_with_timers.c"
 #include "../lightningd.c"
 #include "../subd.c"

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -210,7 +210,7 @@ bool fromwire_channel_id(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
 bool fromwire_channeld_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEEDED)
 { fprintf(stderr, "fromwire_channeld_dev_memleak_reply called!\n"); abort(); }
 /* Generated stub for fromwire_connectd_peer_connected */
-bool fromwire_connectd_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, bool *incoming UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)
+bool fromwire_connectd_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct wireaddr_internal *remote_addr UNNEEDED, bool *incoming UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)
 { fprintf(stderr, "fromwire_connectd_peer_connected called!\n"); abort(); }
 /* Generated stub for fromwire_hsmd_sign_bolt12_reply */
 bool fromwire_hsmd_sign_bolt12_reply(const void *p UNNEEDED, struct bip340sig *sig UNNEEDED)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -48,6 +48,8 @@ def test_connect(node_factory):
     assert len(l1.rpc.listpeers()) == 1
     assert len(l2.rpc.listpeers()) == 1
 
+    l1.daemon.wait_for_log("Peer reports remote_addr: 127.0.0.1")
+
     # Should get reasonable error if unknown addr for peer.
     with pytest.raises(RpcError, match=r'Unable to connect, no address known'):
         l1.rpc.connect('032cf15d1ad9c4a08d26eab1918f732d8ef8fdc6abb9640bf3db174372c491304e')

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -16,6 +16,9 @@
 # Subtypes:
 #   subtype,<subtypename>
 #   subtypedata,<subtypename>,<fieldname>,<typename>,[<count>]
+#
+# Note: <count> can be a fixed value, a named value read before,
+#       or '...' to read until the end of the current structure.
 
 from argparse import ArgumentParser, REMAINDER
 from collections import OrderedDict

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -130,7 +130,7 @@ bool fromwire_channeld_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p
 bool fromwire_channeld_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct penalty_base **pbase UNNEEDED, struct fee_states **fee_states UNNEEDED, struct height_states **blockheight_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, struct bitcoin_signature **htlc_sigs UNNEEDED)
 { fprintf(stderr, "fromwire_channeld_sending_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_connectd_peer_connected */
-bool fromwire_connectd_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, bool *incoming UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)
+bool fromwire_connectd_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct wireaddr_internal *remote_addr UNNEEDED, bool *incoming UNNEEDED, struct per_peer_state **pps UNNEEDED, u8 **features UNNEEDED)
 { fprintf(stderr, "fromwire_connectd_peer_connected called!\n"); abort(); }
 /* Generated stub for fromwire_custommsg_in */
 bool fromwire_custommsg_in(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u8 **msg UNNEEDED)

--- a/wire/peer_wire.csv
+++ b/wire/peer_wire.csv
@@ -6,6 +6,8 @@ msgdata,init,features,byte,flen
 msgdata,init,tlvs,init_tlvs,
 tlvtype,init_tlvs,networks,1
 tlvdata,init_tlvs,networks,chains,chain_hash,...
+tlvtype,init_tlvs,remote_addr,3
+tlvdata,init_tlvs,remote_addr,data,byte,...
 msgtype,error,17
 msgdata,error,channel_id,channel_id,
 msgdata,error,len,u16,


### PR DESCRIPTION
Since https://github.com/lightning/bolts/pull/911 will contain `- MUST NOT announce more than one "type 5" DNS hostname.` we need to add this.