### PR TITLE
LightningRpc should accept pathlib Path

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -223,7 +223,7 @@ class UnixSocket(object):
     """
 
     def __init__(self, path: str):
-        self.path = path
+        self.path = str(path) if 'pathlib' in str(type(path)) else path
         self.sock: Optional[socket.SocketType] = None
         self.connect()
 

--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -223,14 +223,14 @@ class UnixSocket(object):
     """
 
     def __init__(self, path: str):
-        self.path = str(path) if 'pathlib' in str(type(path)) else path
+        self.path = path
         self.sock: Optional[socket.SocketType] = None
         self.connect()
 
     def connect(self) -> None:
         try:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.sock.connect(self.path)
+            self.sock.connect(str(self.path))
         except OSError as e:
             self.close()
 


### PR DESCRIPTION
Not sure why socket does not accept pathlib, but just added some code to transform the path to string.
It is not the most pretty code, but better than these:
https://stackoverflow.com/questions/58647584/how-to-test-if-object-is-a-pathlib-path