### PR TITLE
cli: change the redefine logic to read from the stdin

### DIFF
--- a/cli/config_cli.h
+++ b/cli/config_cli.h
@@ -1,0 +1,15 @@
+#ifndef LIGHTNING_CLI_CONFIG_CLI_H
+#define LIGHTNING_CLI_CONFIG_CLI_H
+
+#include "config.h"
+#include <stdio.h>
+
+#ifndef CLN_TEST
+/* Redefinition procedure is a very cool feature, but
+   if we try to redefine a procedure that is already
+   redefined somewhere (like read in alpine) we can have
+   tricky compilation error */
+#define cli_read read
+#endif
+
+#endif /* LIGHTNING_CLI_CONFIG_CLI_H */

--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -2,6 +2,7 @@
  * Helper to submit via JSON-RPC and get back response.
  */
 #include "config.h"
+#include "config_cli.h"
 #include <ccan/asort/asort.h>
 #include <ccan/err/err.h>
 #include <ccan/json_escape/json_escape.h>
@@ -15,7 +16,6 @@
 #include <common/utils.h>
 #include <common/version.h>
 #include <libgen.h>
-#include <stdio.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>
@@ -386,7 +386,7 @@ static size_t read_nofail(int fd, void *buf, size_t len)
 	ssize_t i;
 	assert(len > 0);
 
-	i = read(fd, buf, len);
+	i = cli_read(fd, buf, len);
 	if (i == 0)
 		errx(ERROR_TALKING_TO_LIGHTNINGD,
 		     "reading response: socket closed");
@@ -572,7 +572,7 @@ static void enable_notifications(int fd)
 	memset(rbuf, 0, sizeof(rbuf));
 	while (!strends(rbuf, "\n\n")) {
 		size_t len = strlen(rbuf);
-		if (read(fd, rbuf + len, sizeof(rbuf) - len) < 0)
+		if (cli_read(fd, rbuf + len, sizeof(rbuf) - len) < 0)
 			err(ERROR_TALKING_TO_LIGHTNINGD,
 			    "Reading enable response");
 	}
@@ -756,7 +756,7 @@ int main(int argc, char *argv[])
 	while (parserr <= 0) {
 		/* Read more if parser says, or we have 0 tokens. */
 		if (parserr == 0 || parserr == JSMN_ERROR_PART) {
-			ssize_t i = read(fd, resp + off, tal_bytelen(resp) - 1 - off);
+			ssize_t i = cli_read(fd, resp + off, tal_bytelen(resp) - 1 - off);
 			if (i == 0)
 				errx(ERROR_TALKING_TO_LIGHTNINGD,
 				     "reading response: socket closed");

--- a/cli/test/config_test.h
+++ b/cli/test/config_test.h
@@ -1,0 +1,8 @@
+#ifndef LIGHTNING_CLI_TEST_CONFIG_TEST_H
+#define LIGHTNING_CLI_TEST_CONFIG_TEST_H
+
+#include "config.h"
+
+#define CLN_TEST 1
+
+#endif /* LIGHTNING_CLI_TEST_CONFIG_TEST_H */

--- a/cli/test/run-human-mode.c
+++ b/cli/test/run-human-mode.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "config_test.h"
 #include <common/amount.h>
 #include <common/bigsize.h>
 #include <common/channel_id.h>
@@ -18,7 +19,7 @@ int test_printf(const char *format, ...);
 int test_chdir(const char *path);
 
 #define main test_main
-#define read test_read
+#define cli_read test_read
 #define socket test_socket
 #define connect test_connect
 #define getpid test_getpid
@@ -174,4 +175,3 @@ int main(int argc UNUSED, char *argv[])
 	common_shutdown();
 	return 0;
 }
-

--- a/cli/test/run-large-input.c
+++ b/cli/test/run-large-input.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "config_test.h"
 #include <common/amount.h>
 #include <common/bigsize.h>
 #include <common/channel_id.h>
@@ -18,7 +19,7 @@ int test_printf(const char *format, ...);
 int test_chdir(const char *path);
 
 #define main test_main
-#define read test_read
+#define cli_read test_read
 #define socket test_socket
 #define connect test_connect
 #define getpid test_getpid

--- a/cli/test/run-remove-hint.c
+++ b/cli/test/run-remove-hint.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "config_test.h"
 #include <common/amount.h>
 #include <common/bigsize.h>
 #include <common/channel_id.h>
@@ -20,7 +21,7 @@ int test_fputc(int c, FILE *stream);
 int test_chdir(const char *path);
 
 #define main test_main
-#define read test_read
+#define cli_read test_read
 #define socket test_socket
 #define connect test_connect
 #define getpid test_getpid


### PR DESCRIPTION
Procedure redefinition is a very cool feature but when other libraries redefine the same function can be very tricky to avoid compilation errors.

This PR proposed a change of logic and use a customization function definition to read from the stdin, so we can avoid future errors at compile time.

However, we could be check also the os or compiler that cause the error and redefine the missing function.

Compilation success on alpine is reported here https://github.com/vincenzopalazzo/lightning/runs/4795110552?check_suite_focus=true

If this PR will be merged the #4987 should be compiled on alpine to each new changes

Fixes https://github.com/ElementsProject/lightning/issues/4918 (really fixes)

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>