### PR TITLE
cln-plugin: Write your plugins in rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
   "cln-rpc",
   "cln-grpc",
+  "plugins",
 ]

--- a/cln-rpc/examples/getinfo.rs
+++ b/cln-rpc/examples/getinfo.rs
@@ -13,6 +13,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut rpc = ClnRpc::new(p).await?;
     let response = rpc.call(Request::Getinfo(GetinfoRequest {})).await?;
-    info!("{}", serde_json::to_string_pretty(&response)?);
+    println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -242,6 +242,37 @@ TEST_DB_PROVIDER=[sqlite3|postgres] - Selects the database to use when running
 EXPERIMENTAL_DUAL_FUND=[0|1]	    - Enable dual-funding tests.
 ```
 
+#### Troubleshooting
+
+##### Valgrind complains about code we don't control
+
+Sometimes `valgrind` will complain about code we do not control
+ourselves, either because it's in a library we use or it's a false
+positive. There are generally three ways to address these issues
+(in descending order of preference):
+
+ 1. Add a suppression for the one specific call that is causing the
+    issue. Upon finding an issue `valgrind` is instructed in the
+    testing framework to print filters that'd match the issue. These
+    can be added to the suppressions file under
+    `tests/valgrind-suppressions.txt` in order to explicitly skip
+    reporting these in future. This is preferred over the other
+    solutions since it only disables reporting selectively for things
+    that were manually checked. See the [valgrind docs][vg-supp] for
+    details.
+ 2. Add the process that `valgrind` is complaining about to the
+    `--trace-children-skip` argument in `pyln-testing`. This is used
+    in cases of full binaries not being under our control, such as the
+    `python3` interpreter used in tests that run plugins. Do not use
+    this for binaries that are compiled from our code, as it tends to
+    mask real issues.
+ 3. Mark the test as skipped if running under `valgrind`. It's mostly
+    used to skip tests that otherwise would take considerably too long
+    to test on CI. We discourage this for suppressions, since it is a
+    very blunt tool.
+
+[vg-supp]: https://valgrind.org/docs/manual/manual-core.html#manual-core.suppress
+
 Making BOLT Modifications
 -------------------------
 

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "cln-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[[example]]
+name = "cln-plugin-startup"
+path = "examples/cln-plugin-startup.rs"
+
+[dependencies]
+anyhow = "1.0.51"
+bytes = "1.1.0"
+log = "0.4.14"
+serde = { version = "1.0.131", features = ["derive"] }
+serde_json = "1.0.72"
+tokio-util = { version = "0.6.9", features = ["codec"] }
+tokio = { version="1", features = ['io-std', 'rt'] }
+tokio-stream = "*"
+futures = "0.3"
+cln-rpc = { path = "../cln-rpc" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", ] }
+env_logger = "*"
+cln-grpc = { path = "../cln-grpc" }

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -10,11 +10,11 @@ path = "examples/cln-plugin-startup.rs"
 [dependencies]
 anyhow = "1.0.51"
 bytes = "1.1.0"
-log = "0.4.14"
+log = { version = "0.4.14", features = ['std'] }
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.72"
 tokio-util = { version = "0.6.9", features = ["codec"] }
-tokio = { version="1", features = ['io-std', 'rt'] }
+tokio = { version="1", features = ['io-std', 'rt', 'sync'] }
 tokio-stream = "*"
 futures = "0.3"
 cln-rpc = { path = "../cln-rpc" }

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -173,4 +173,14 @@ ALL_C_HEADERS += plugins/list_of_builtin_plugins_gen.h
 plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile
 	@$(call VERBOSE,GEN $@,echo "static const char *list_of_builtin_plugins[] = { $(foreach d,$(notdir $(PLUGINS)),\"$d\",) NULL };" > $@)
 
+CLN_PLUGIN_EXAMPLES := target/${RUST_PROFILE}/examples/cln-plugin-startup
+CLN_PLUGIN_SRC = $(shell find plugins/src -name "*.rs")
+
+${CLN_PLUGIN_EXAMPLES}: ${CLN_PLUGIN_SRC}
+	(cd plugins; cargo build ${CARGO_OPTS} --examples)
+
+ifneq ($(RUST),0)
+DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES)
+endif
+
 include plugins/test/Makefile

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -6,9 +6,10 @@ use tokio;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    env_logger::init();
-
     let (plugin, stdin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout()).build();
-    plugin.run(stdin).await;
-    Ok(())
+    tokio::spawn(async {
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        log::info!("Hello world");
+    });
+    plugin.run(stdin).await
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -1,12 +1,19 @@
 //! This is a test plugin used to verify that we can compile and run
 //! plugins using the Rust API against c-lightning.
 
-use cln_plugin::Builder;
+use cln_plugin::{options, Builder};
 use tokio;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let (plugin, stdin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout()).build();
+    let (plugin, stdin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
+        .option(options::ConfigOption::new(
+            "test-option",
+            options::Value::Integer(42),
+            "a test-option with default 42",
+        ))
+        .build();
+
     tokio::spawn(async {
         tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
         log::info!("Hello world");

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -6,17 +6,13 @@ use tokio;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let (plugin, stdin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
+    let plugin = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
         .option(options::ConfigOption::new(
             "test-option",
             options::Value::Integer(42),
             "a test-option with default 42",
         ))
-        .build();
-
-    tokio::spawn(async {
-        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-        log::info!("Hello world");
-    });
-    plugin.run(stdin).await
+        .start()
+        .await?;
+    plugin.join().await
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -1,0 +1,14 @@
+//! This is a test plugin used to verify that we can compile and run
+//! plugins using the Rust API against c-lightning.
+
+use cln_plugin::Builder;
+use tokio;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    env_logger::init();
+
+    let (plugin, stdin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout()).build();
+    plugin.run(stdin).await;
+    Ok(())
+}

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -14,6 +14,8 @@ async fn main() -> Result<(), anyhow::Error> {
             "a test-option with default 42",
         ))
         .rpcmethod("testmethod", "This is a test", Box::new(testmethod))
+        .subscribe("connect", Box::new(connect_handler))
+        .hook("peer_connected", Box::new(peer_connected_handler))
         .start()
         .await?;
     plugin.join().await
@@ -21,4 +23,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
 fn testmethod(_p: Plugin<()>, _v: &serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
+}
+
+fn connect_handler(_p: Plugin<()>, v: &serde_json::Value) -> Result<(), Error> {
+    log::info!("Got a connect notification: {}", v);
+    Ok(())
+}
+
+fn peer_connected_handler(_p: Plugin<()>, v: &serde_json::Value) -> Result<serde_json::Value, Error> {
+    log::info!("Got a connect hook call: {}", v);
+    Ok(json!({"result": "continue"}))
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -1,9 +1,10 @@
 //! This is a test plugin used to verify that we can compile and run
 //! plugins using the Rust API against c-lightning.
-
-use cln_plugin::{options, Builder};
+#[macro_use]
+extern crate serde_json;
+use cln_plugin::{options, Builder, Error, Plugin};
+use std::pin::Pin;
 use tokio;
-
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let plugin = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
@@ -12,7 +13,12 @@ async fn main() -> Result<(), anyhow::Error> {
             options::Value::Integer(42),
             "a test-option with default 42",
         ))
+        .rpcmethod("testmethod", "This is a test", Box::new(testmethod))
         .start()
         .await?;
     plugin.join().await
+}
+
+fn testmethod(_p: Plugin<()>, _v: &serde_json::Value) -> Result<serde_json::Value, Error> {
+    Ok(json!("Hello"))
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), anyhow::Error> {
         ))
         .rpcmethod("testmethod", "This is a test", testmethod)
         .subscribe("connect", Box::new(connect_handler))
-        //.hook("peer_connected", Box::new(peer_connected_handler))
+        .hook("peer_connected", peer_connected_handler)
         .start()
         .await?;
     plugin.join().await
@@ -30,7 +30,7 @@ fn connect_handler(_p: Plugin<()>, v: &serde_json::Value) -> Result<(), Error> {
     Ok(())
 }
 
-fn peer_connected_handler(_p: Plugin<()>, v: &serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn peer_connected_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
     log::info!("Got a connect hook call: {}", v);
     Ok(json!({"result": "continue"}))
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -13,15 +13,15 @@ async fn main() -> Result<(), anyhow::Error> {
             options::Value::Integer(42),
             "a test-option with default 42",
         ))
-        .rpcmethod("testmethod", "This is a test", Box::new(testmethod))
+        .rpcmethod("testmethod", "This is a test", testmethod)
         .subscribe("connect", Box::new(connect_handler))
-        .hook("peer_connected", Box::new(peer_connected_handler))
+        //.hook("peer_connected", Box::new(peer_connected_handler))
         .start()
         .await?;
     plugin.join().await
 }
 
-fn testmethod(_p: Plugin<()>, _v: &serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
 }
 

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -3,7 +3,6 @@
 #[macro_use]
 extern crate serde_json;
 use cln_plugin::{options, Builder, Error, Plugin};
-use std::pin::Pin;
 use tokio;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -14,7 +13,7 @@ async fn main() -> Result<(), anyhow::Error> {
             "a test-option with default 42",
         ))
         .rpcmethod("testmethod", "This is a test", testmethod)
-        .subscribe("connect", Box::new(connect_handler))
+        .subscribe("connect", connect_handler)
         .hook("peer_connected", peer_connected_handler)
         .start()
         .await?;
@@ -25,7 +24,7 @@ async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json:
     Ok(json!("Hello"))
 }
 
-fn connect_handler(_p: Plugin<()>, v: &serde_json::Value) -> Result<(), Error> {
+async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
     log::info!("Got a connect notification: {}", v);
     Ok(())
 }

--- a/plugins/src/codec.rs
+++ b/plugins/src/codec.rs
@@ -1,0 +1,207 @@
+/// The codec is used to encode and decode messages received from and
+/// sent to the main daemon. The protocol uses `stdout` and `stdin` to
+/// exchange JSON formatted messages. Each message is separated by an
+/// empty line and we're guaranteed that no other empty line is
+/// present in the messages.
+use crate::Error;
+use anyhow::anyhow;
+use bytes::{BufMut, BytesMut};
+use serde_json::value::Value;
+use std::str::FromStr;
+use std::{io, str};
+use tokio_util::codec::{Decoder, Encoder};
+
+use crate::messages::{Notification, Request};
+pub use crate::messages::JsonRpc;
+
+/// A simple codec that parses messages separated by two successive
+/// `\n` newlines.
+#[derive(Default)]
+pub struct MultiLineCodec {}
+
+/// Find two consecutive newlines, i.e., an empty line, signalling the
+/// end of one message and the start of the next message.
+fn find_separator(buf: &mut BytesMut) -> Option<usize> {
+    buf.iter()
+        .zip(buf.iter().skip(1))
+        .position(|b| *b.0 == b'\n' && *b.1 == b'\n')
+}
+
+fn utf8(buf: &[u8]) -> Result<&str, io::Error> {
+    str::from_utf8(buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Unable to decode input as UTF8"))
+}
+
+impl Decoder for MultiLineCodec {
+    type Item = String;
+    type Error = Error;
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Error> {
+        if let Some(newline_offset) = find_separator(buf) {
+            let line = buf.split_to(newline_offset + 2);
+            let line = &line[..line.len() - 2];
+            let line = utf8(line)?;
+            Ok(Some(line.to_string()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<T> Encoder<T> for MultiLineCodec
+where
+    T: AsRef<str>,
+{
+    type Error = Error;
+    fn encode(&mut self, line: T, buf: &mut BytesMut) -> Result<(), Self::Error> {
+        let line = line.as_ref();
+        buf.reserve(line.len() + 2);
+        buf.put(line.as_bytes());
+        buf.put_u8(b'\n');
+        buf.put_u8(b'\n');
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct JsonCodec {
+    /// Sub-codec used to split the input into chunks that can then be
+    /// parsed by the JSON parser.
+    inner: MultiLineCodec,
+}
+
+impl<T> Encoder<T> for JsonCodec
+where
+    T: Into<Value>,
+{
+    type Error = Error;
+    fn encode(&mut self, msg: T, buf: &mut BytesMut) -> Result<(), Self::Error> {
+        let s = msg.into().to_string();
+        self.inner.encode(s, buf)
+    }
+}
+
+impl Decoder for JsonCodec {
+    type Item = Value;
+    type Error = Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Error> {
+        match self.inner.decode(buf) {
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+            Ok(Some(s)) => {
+                if let Ok(v) = Value::from_str(&s) {
+                    Ok(Some(v))
+                } else {
+                    Err(anyhow!("failed to parse JSON"))
+                }
+            }
+        }
+    }
+}
+
+/// A codec that reads fully formed [crate::messages::JsonRpc]
+/// messages. Internally it uses the [JsonCodec] which itself is built
+/// on the [MultiLineCodec].
+#[derive(Default)]
+pub(crate) struct JsonRpcCodec {
+    inner: JsonCodec,
+}
+
+impl Decoder for JsonRpcCodec {
+    type Item = JsonRpc<Notification, Request>;
+    type Error = Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Error> {
+        match self.inner.decode(buf) {
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+            Ok(Some(s)) => {
+                let req: Self::Item = serde_json::from_value(s)?;
+                Ok(Some(req))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{find_separator, JsonCodec, MultiLineCodec};
+    use bytes::{BufMut, BytesMut};
+    use serde_json::json;
+    use tokio_util::codec::{Decoder, Encoder};
+
+    #[test]
+    fn test_separator() {
+        struct Test(String, Option<usize>);
+        let tests = vec![
+            Test("".to_string(), None),
+            Test("}\n\n".to_string(), Some(1)),
+            Test("\"hello\"},\n\"world\"}\n\n".to_string(), Some(18)),
+        ];
+
+        for t in tests.iter() {
+            let mut buf = BytesMut::new();
+            buf.put_slice(t.0.as_bytes());
+            assert_eq!(find_separator(&mut buf), t.1);
+        }
+    }
+
+    #[test]
+    fn test_ml_decoder() {
+        struct Test(String, Option<String>, String);
+        let tests = vec![
+            Test("".to_string(), None, "".to_string()),
+            Test(
+                "{\"hello\":\"world\"}\n\nremainder".to_string(),
+                Some("{\"hello\":\"world\"}".to_string()),
+                "remainder".to_string(),
+            ),
+            Test(
+                "{\"hello\":\"world\"}\n\n{}\n\nremainder".to_string(),
+                Some("{\"hello\":\"world\"}".to_string()),
+                "{}\n\nremainder".to_string(),
+            ),
+        ];
+
+        for t in tests.iter() {
+            let mut buf = BytesMut::new();
+            buf.put_slice(t.0.as_bytes());
+
+            let mut codec = MultiLineCodec::default();
+            let mut remainder = BytesMut::new();
+            remainder.put_slice(t.2.as_bytes());
+
+            assert_eq!(codec.decode(&mut buf).unwrap(), t.1);
+            assert_eq!(buf, remainder);
+        }
+    }
+
+    #[test]
+    fn test_ml_encoder() {
+        let tests = vec!["test"];
+
+        for t in tests.iter() {
+            let mut buf = BytesMut::new();
+            let mut codec = MultiLineCodec::default();
+            let mut expected = BytesMut::new();
+            expected.put_slice(t.as_bytes());
+            expected.put_u8(b'\n');
+            expected.put_u8(b'\n');
+            codec.encode(t, &mut buf).unwrap();
+            assert_eq!(buf, expected);
+        }
+    }
+
+    #[test]
+    fn test_json_codec() {
+        let tests = vec![json!({"hello": "world"})];
+
+        for t in tests.iter() {
+            let mut codec = JsonCodec::default();
+            let mut buf = BytesMut::new();
+            codec.encode(t.clone(), &mut buf).unwrap();
+            let decoded = codec.decode(&mut buf).unwrap().unwrap();
+            assert_eq!(&decoded, t);
+        }
+    }
+}

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,0 +1,191 @@
+use crate::codec::{JsonCodec, JsonRpcCodec};
+use futures::sink::SinkExt;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_util::codec::FramedWrite;
+pub mod codec;
+mod messages;
+pub use anyhow::Error;
+use log::{trace, warn};
+use std::marker::PhantomData;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_stream::StreamExt;
+use tokio_util::codec::FramedRead;
+
+#[macro_use]
+extern crate serde_json;
+
+/// Builder for a new plugin.
+pub struct Builder<S, I, O>
+where
+    S: Clone + Send,
+    I: AsyncRead + Unpin,
+    O: Send + AsyncWrite + Unpin,
+{
+    state: S,
+
+    input: I,
+    output: O,
+
+    #[allow(dead_code)]
+    hooks: Hooks,
+
+    #[allow(dead_code)]
+    subscriptions: Subscriptions,
+}
+
+impl<S, I, O> Builder<S, I, O>
+where
+    O: Send + AsyncWrite + Unpin + 'static,
+    S: Clone + Send + 'static,
+    I: AsyncRead + Send + Unpin + 'static,
+{
+    pub fn new(state: S, input: I, output: O) -> Self {
+        Self {
+            state,
+            input,
+            output,
+            hooks: Hooks::default(),
+            subscriptions: Subscriptions::default(),
+        }
+    }
+
+    pub async fn run(self) -> Result<(), Error> {
+        let (plugin, input) = self.build();
+        plugin.run(input).await
+    }
+
+    pub fn build(self) -> (Plugin<S, I, O>, I) {
+        (
+            Plugin {
+                state: Arc::new(Mutex::new(self.state)),
+                output: Arc::new(Mutex::new(FramedWrite::new(
+                    self.output,
+                    JsonCodec::default(),
+                ))),
+                input_type: PhantomData,
+            },
+            self.input,
+        )
+    }
+}
+
+pub struct Plugin<S, I, O>
+where
+    S: Clone + Send,
+    I: AsyncRead,
+    O: Send + AsyncWrite,
+{
+    //input: FramedRead<Stdin, JsonCodec>,
+    output: Arc<Mutex<FramedWrite<O, JsonCodec>>>,
+
+    /// The state gets cloned for each request
+    state: Arc<Mutex<S>>,
+    input_type: PhantomData<I>,
+}
+impl<S, I, O> Plugin<S, I, O>
+where
+    S: Clone + Send,
+    I: AsyncRead + Send + Unpin,
+    O: Send + AsyncWrite + Unpin,
+{
+    /// Read incoming requests from `c-lightning and dispatch their handling.
+    #[allow(unused_mut)]
+    pub async fn run(mut self, input: I) -> Result<(), Error> {
+        let mut input = FramedRead::new(input, JsonRpcCodec::default());
+        loop {
+            match input.next().await {
+                Some(Ok(msg)) => {
+                    trace!("Received a message: {:?}", msg);
+                    match msg {
+                        messages::JsonRpc::Request(id, p) => {
+                            self.dispatch_request(id, p).await?
+                            // Use a match to detect Ok / Error and return an error if we failed.
+                        }
+                        messages::JsonRpc::Notification(n) => self.dispatch_notification(n).await?,
+                    }
+                }
+                Some(Err(e)) => {
+                    warn!("Error reading command: {}", e);
+                    break;
+                }
+                None => break,
+            }
+        }
+        Ok(())
+    }
+
+    async fn dispatch_request(
+        &mut self,
+        id: usize,
+        request: messages::Request,
+    ) -> Result<(), Error> {
+        trace!("Dispatching request {:?}", request);
+        let state = self.state.clone();
+        let res: serde_json::Value = match request {
+            messages::Request::Getmanifest(c) => {
+                serde_json::to_value(Plugin::<S, I, O>::handle_get_manifest(c, state).await?)
+                    .unwrap()
+            }
+            messages::Request::Init(c) => {
+                serde_json::to_value(Plugin::<S, I, O>::handle_init(c, state).await?).unwrap()
+            }
+            o => panic!("Request {:?} is currently unhandled", o),
+        };
+        trace!("Sending respone {:?}", res);
+
+        let mut out = self.output.lock().await;
+        out.send(json!({
+            "jsonrpc": "2.0",
+            "result": res,
+            "id": id,
+        }))
+        .await
+        .unwrap();
+        Ok(())
+    }
+
+    async fn dispatch_notification(
+        &mut self,
+        notification: messages::Notification,
+    ) -> Result<(), Error> {
+        trace!("Dispatching notification {:?}", notification);
+        unimplemented!()
+    }
+
+    async fn handle_get_manifest(
+        _call: messages::GetManifestCall,
+        _state: Arc<Mutex<S>>,
+    ) -> Result<messages::GetManifestResponse, Error> {
+        Ok(messages::GetManifestResponse::default())
+    }
+
+    async fn handle_init(
+        _call: messages::InitCall,
+        _state: Arc<Mutex<S>>,
+    ) -> Result<messages::InitResponse, Error> {
+        Ok(messages::InitResponse::default())
+    }
+}
+
+/// A container for all the configure hooks. It is just a collection
+/// of callbacks that can be registered by the users of the
+/// library. Based on this configuration we can then generate the
+/// [`messages::GetManifestResponse`] from, populating our subscriptions
+#[derive(Debug, Default)]
+struct Hooks {}
+
+/// A container for all the configured notifications.
+#[derive(Debug, Default)]
+struct Subscriptions {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn init() {
+        let builder = Builder::new((), tokio::io::stdin(), tokio::io::stdout());
+        let plugin = builder.build();
+    }
+}

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,9 +1,8 @@
 use crate::codec::{JsonCodec, JsonRpcCodec};
-pub use anyhow::Error;
+pub use anyhow::{anyhow, Context, Error};
 use futures::sink::SinkExt;
 extern crate log;
-use log::{trace, warn};
-use std::marker::PhantomData;
+use log::trace;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
@@ -25,14 +24,13 @@ use options::ConfigOption;
 /// Builder for a new plugin.
 pub struct Builder<S, I, O>
 where
-    S: Clone + Send,
     I: AsyncRead + Unpin,
     O: Send + AsyncWrite + Unpin,
 {
     state: S,
 
-    input: I,
-    output: O,
+    input: Option<I>,
+    output: Option<O>,
 
     #[allow(dead_code)]
     hooks: Hooks,
@@ -46,14 +44,14 @@ where
 impl<S, I, O> Builder<S, I, O>
 where
     O: Send + AsyncWrite + Unpin + 'static,
-    S: Clone + Send + 'static,
+    S: Clone + Sync + Send + Clone + 'static,
     I: AsyncRead + Send + Unpin + 'static,
 {
     pub fn new(state: S, input: I, output: O) -> Self {
         Self {
             state,
-            input,
-            output,
+            input: Some(input),
+            output: Some(output),
             hooks: Hooks::default(),
             subscriptions: Subscriptions::default(),
             options: vec![],
@@ -65,147 +63,96 @@ where
         self
     }
 
-    pub fn build(self) -> (Plugin<S, I, O>, I) {
+    /// Build and start the plugin loop. This performs the handshake
+    /// and spawns a new task that accepts incoming messages from
+    /// c-lightning and dispatches them to the handlers. It only
+    /// returns after completing the handshake to ensure that the
+    /// configuration and initialization was successfull.
+    pub async fn start(mut self) -> Result<Plugin<S>, anyhow::Error> {
+        let mut input = FramedRead::new(self.input.take().unwrap(), JsonRpcCodec::default());
+
+        // Sadly we need to wrap the output in a mutex in order to
+        // enable early logging, i.e., logging that is done before the
+        // PluginDriver is processing events during the
+        // handshake. Otherwise we could just write the log events to
+        // the event queue and have the PluginDriver be the sole owner
+        // of `Stdout`.
         let output = Arc::new(Mutex::new(FramedWrite::new(
-            self.output,
+            self.output.take().unwrap(),
             JsonCodec::default(),
         )));
 
         // Now configure the logging, so any `log` call is wrapped
         // in a JSON-RPC notification and sent to c-lightning
-        tokio::spawn(async move {});
-        (
-            Plugin {
-                state: Arc::new(Mutex::new(self.state)),
-                output,
-                input_type: PhantomData,
-                options: self.options,
-            },
-            self.input,
-        )
-    }
-}
-
-pub struct Plugin<S, I, O>
-where
-    S: Clone + Send,
-    I: AsyncRead,
-    O: Send + AsyncWrite + 'static,
-{
-    //input: FramedRead<Stdin, JsonCodec>,
-    output: Arc<Mutex<FramedWrite<O, JsonCodec>>>,
-
-    /// The state gets cloned for each request
-    state: Arc<Mutex<S>>,
-    input_type: PhantomData<I>,
-    options: Vec<ConfigOption>,
-}
-
-impl<S, I, O> Plugin<S, I, O>
-where
-    S: Clone + Send,
-    I: AsyncRead + Send + Unpin,
-    O: Send + AsyncWrite + Unpin,
-{
-    pub fn options(&self) -> Vec<ConfigOption> {
-        self.options.clone()
-    }
-}
-
-impl<S, I, O> Plugin<S, I, O>
-where
-    S: Clone + Send,
-    I: AsyncRead + Send + Unpin,
-    O: Send + AsyncWrite + Unpin + 'static,
-{
-    /// Read incoming requests from `c-lightning and dispatch their handling.
-    #[allow(unused_mut)]
-    pub async fn run(mut self, input: I) -> Result<(), Error> {
-        crate::logging::init(self.output.clone()).await?;
+        crate::logging::init(output.clone()).await?;
         trace!("Plugin logging initialized");
 
-        let mut input = FramedRead::new(input, JsonRpcCodec::default());
-        loop {
-            match input.next().await {
-                Some(Ok(msg)) => {
-                    trace!("Received a message: {:?}", msg);
-                    match msg {
-                        messages::JsonRpc::Request(id, p) => {
-                            self.dispatch_request(id, p).await?
-                            // Use a match to detect Ok / Error and return an error if we failed.
-                        }
-                        messages::JsonRpc::Notification(n) => self.dispatch_notification(n).await?,
-                    }
-                }
-                Some(Err(e)) => {
-                    warn!("Error reading command: {}", e);
-                    break;
-                }
-                None => break,
+        // Read the `getmanifest` message:
+        match input.next().await {
+            Some(Ok(messages::JsonRpc::Request(id, messages::Request::Getmanifest(m)))) => {
+                output
+                    .lock()
+                    .await
+                    .send(json!({
+                        "jsonrpc": "2.0",
+                        "result": self.handle_get_manifest(m),
+                        "id": id,
+                    }))
+                    .await?
             }
-        }
-        Ok(())
-    }
-
-    async fn dispatch_request(
-        &mut self,
-        id: usize,
-        request: messages::Request,
-    ) -> Result<(), Error> {
-        trace!("Dispatching request {:?}", request);
-        let state = self.state.clone();
-        let res: serde_json::Value = match request {
-            messages::Request::Getmanifest(c) => {
-                serde_json::to_value(self.handle_get_manifest(c, state).await?).unwrap()
-            }
-            messages::Request::Init(c) => {
-                serde_json::to_value(self.handle_init(c, state).await?).unwrap()
-            }
-            o => panic!("Request {:?} is currently unhandled", o),
+            o => return Err(anyhow!("Got unexpected message {:?} from lightningd", o)),
         };
-        trace!("Sending respone {:?}", res);
 
-        let mut out = self.output.lock().await;
-        out.send(json!({
-            "jsonrpc": "2.0",
-            "result": res,
-            "id": id,
-        }))
-        .await
-        .unwrap();
-        Ok(())
+        match input.next().await {
+            Some(Ok(messages::JsonRpc::Request(id, messages::Request::Init(m)))) => {
+                output
+                    .lock()
+                    .await
+                    .send(json!({
+                        "jsonrpc": "2.0",
+                        "result": self.handle_init(m)?,
+                        "id": id,
+                    }))
+                    .await?
+            }
+
+            o => return Err(anyhow!("Got unexpected message {:?} from lightningd", o)),
+        };
+
+        let (tx, _) = tokio::sync::broadcast::channel(1);
+        let plugin = Plugin {
+            state: self.state,
+            options: self.options,
+            wait_handle: tx,
+        };
+
+        // Start the PluginDriver to handle plugin IO
+        tokio::spawn(
+            PluginDriver {
+                plugin: plugin.clone(),
+            }
+            .run(input, output),
+        );
+
+        Ok(plugin)
     }
 
-    async fn dispatch_notification(
-        &mut self,
-        notification: messages::Notification,
-    ) -> Result<(), Error> {
-        trace!("Dispatching notification {:?}", notification);
-        unimplemented!()
-    }
-
-    async fn handle_get_manifest(
+    fn handle_get_manifest(
         &mut self,
         _call: messages::GetManifestCall,
-        _state: Arc<Mutex<S>>,
-    ) -> Result<messages::GetManifestResponse, Error> {
-        Ok(messages::GetManifestResponse {
+    ) -> messages::GetManifestResponse {
+        messages::GetManifestResponse {
             options: self.options.clone(),
             rpcmethods: vec![],
-        })
+        }
     }
 
-    async fn handle_init(
-        &mut self,
-        call: messages::InitCall,
-        _state: Arc<Mutex<S>>,
-    ) -> Result<messages::InitResponse, Error> {
+    fn handle_init(&mut self, call: messages::InitCall) -> Result<messages::InitResponse, Error> {
         use options::Value as OValue;
         use serde_json::Value as JValue;
 
         // Match up the ConfigOptions and fill in their values if we
         // have a matching entry.
-
         for opt in self.options.iter_mut() {
             if let Some(val) = call.options.get(opt.name()) {
                 opt.value = Some(match (opt.default(), &val) {
@@ -224,6 +171,125 @@ where
     }
 }
 
+#[derive(Clone)]
+pub struct Plugin<S>
+where
+    S: Clone + Send,
+{
+    /// The state gets cloned for each request
+    state: S,
+    options: Vec<ConfigOption>,
+
+    /// A signal that allows us to wait on the plugin's shutdown.
+    wait_handle: tokio::sync::broadcast::Sender<()>,
+}
+
+/// The [PluginDriver] is used to run the IO loop, reading messages
+/// from the Lightning daemon, dispatching calls and notifications to
+/// the plugin, and returning responses to the the daemon. We also use
+/// it to handle spontaneous messages like Notifications and logging
+/// events.
+struct PluginDriver<S>
+where
+    S: Send + Clone,
+{
+    #[allow(dead_code)]
+    plugin: Plugin<S>,
+}
+
+use tokio::io::AsyncReadExt;
+impl<S> PluginDriver<S>
+where
+    S: Send + Clone,
+{
+    /// Run the plugin until we get a shutdown command.
+    async fn run<I, O>(
+        self,
+        mut input: FramedRead<I, JsonRpcCodec>,
+        _output: Arc<Mutex<FramedWrite<O, JsonCodec>>>,
+    ) -> Result<(), Error>
+    where
+        I: Send + AsyncReadExt + Unpin,
+        O: Send,
+    {
+        loop {
+            tokio::select! {
+                _ = PluginDriver::dispatch_one(&mut input, &self.plugin) => {},
+            }
+        }
+    }
+
+    /// Dispatch one server-side event and then return. Just so we
+    /// have a nicer looking `select` statement in `run` :-)
+    async fn dispatch_one<I>(
+        input: &mut FramedRead<I, JsonRpcCodec>,
+        plugin: &Plugin<S>,
+    ) -> Result<(), Error>
+    where
+        I: Send + AsyncReadExt + Unpin,
+    {
+        match input.next().await {
+            Some(Ok(msg)) => {
+                trace!("Received a message: {:?}", msg);
+                match msg {
+                    messages::JsonRpc::Request(id, p) => {
+                        PluginDriver::<S>::dispatch_request(id, p, plugin).await
+                    }
+                    messages::JsonRpc::Notification(n) => {
+                        PluginDriver::<S>::dispatch_notification(n, plugin).await
+                    }
+                }
+            }
+            Some(Err(e)) => Err(anyhow!("Error reading command: {}", e)),
+            None => Ok(()),
+        }
+    }
+
+    async fn dispatch_request(
+        id: usize,
+        request: messages::Request,
+        _plugin: &Plugin<S>,
+    ) -> Result<(), Error> {
+        panic!("Unexpected request {:?} with id {}", request, id);
+    }
+
+    async fn dispatch_notification(
+        notification: messages::Notification,
+        _plugin: &Plugin<S>,
+    ) -> Result<(), Error>
+    where
+        S: Send + Clone,
+    {
+        trace!("Dispatching notification {:?}", notification);
+        unimplemented!()
+    }
+}
+
+impl<S> Plugin<S>
+where
+    S: Clone + Send,
+{
+    pub fn options(&self) -> Vec<ConfigOption> {
+        self.options.clone()
+    }
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+}
+
+impl<S> Plugin<S>
+where
+    S: Send + Clone,
+{
+    pub async fn join(&self) -> Result<(), Error> {
+        self.wait_handle
+            .subscribe()
+            .recv()
+            .await
+            .context("error waiting for shutdown")
+    }
+}
+
 /// A container for all the configure hooks. It is just a collection
 /// of callbacks that can be registered by the users of the
 /// library. Based on this configuration we can then generate the
@@ -239,9 +305,9 @@ struct Subscriptions {}
 mod test {
     use super::*;
 
-    #[test]
-    fn init() {
+    #[tokio::test]
+    async fn init() {
         let builder = Builder::new((), tokio::io::stdin(), tokio::io::stdout());
-        builder.build();
+        let _ = builder.start();
     }
 }

--- a/plugins/src/logging.rs
+++ b/plugins/src/logging.rs
@@ -1,0 +1,92 @@
+use crate::codec::JsonCodec;
+use futures::SinkExt;
+use log::{Level, Metadata, Record};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::io::AsyncWrite;
+use tokio::sync::Mutex;
+use tokio_util::codec::FramedWrite;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+struct LogEntry {
+    level: LogLevel,
+    message: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(lvl: log::Level) -> Self {
+        match lvl {
+            log::Level::Error => LogLevel::Error,
+            log::Level::Warn => LogLevel::Warn,
+            log::Level::Info => LogLevel::Info,
+            log::Level::Debug | log::Level::Trace => LogLevel::Debug,
+        }
+    }
+}
+
+/// A simple logger that just wraps log entries in a JSON-RPC
+/// notification and delivers it to `lightningd`.
+struct PluginLogger {
+    // An unbounded mpsc channel we can use to talk to the
+    // flusher. This avoids having circular locking dependencies if we
+    // happen to emit a log record while holding the lock on the
+    // plugin connection.
+    sender: tokio::sync::mpsc::UnboundedSender<LogEntry>,
+}
+
+/// Initialize the logger starting a flusher to the passed in sink.
+pub async fn init<O>(out: Arc<Mutex<FramedWrite<O, JsonCodec>>>) -> Result<(), log::SetLoggerError>
+where
+    O: AsyncWrite + Send + Unpin + 'static,
+{
+    let out = out.clone();
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<LogEntry>();
+    tokio::spawn(async move {
+        while let Some(i) = receiver.recv().await {
+            // We continue draining the queue, even if we get some
+            // errors when forwarding. Forwarding could break due to
+            // an interrupted connection or stdout being closed, but
+            // keeping the messages in the queue is a memory leak.
+            let _ = out
+                .lock()
+                .await
+                .send(json!({
+                    "jsonrpc": "2.0",
+                    "method": "log",
+                    "params": i
+                }))
+                .await;
+        }
+    });
+    log::set_boxed_logger(Box::new(PluginLogger { sender }))
+        .map(|()| log::set_max_level(log::LevelFilter::Debug))
+}
+
+impl log::Log for PluginLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Debug
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            self.sender
+                .send(LogEntry {
+                    level: record.level().into(),
+                    message: record.args().to_string(),
+                })
+                .unwrap();
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,3 +1,4 @@
+use crate::options::ConfigOption;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -149,9 +150,9 @@ where
 }
 
 #[derive(Serialize, Default, Debug)]
-pub struct GetManifestResponse {
-    options: Vec<()>,
-    rpcmethods: Vec<()>,
+pub(crate) struct GetManifestResponse {
+    pub(crate) options: Vec<ConfigOption>,
+    pub(crate) rpcmethods: Vec<()>,
 }
 
 #[derive(Serialize, Default, Debug)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -62,9 +62,8 @@ pub(crate) enum Notification {
 pub struct GetManifestCall {}
 
 #[derive(Deserialize, Debug)]
-pub struct InitCall {
-    pub options: Value,
-    pub configuration: HashMap<String, Value>,
+pub(crate) struct InitCall {
+    pub(crate) options: HashMap<String, Value>,
 }
 
 #[derive(Debug)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -12,50 +12,49 @@ pub(crate) enum Request {
     // Builtin
     Getmanifest(GetManifestCall),
     Init(InitCall),
-
     // Hooks
-    PeerConnected,
-    CommitmentRevocation,
-    DbWrite,
-    InvoicePayment,
-    Openchannel,
-    Openchannel2,
-    Openchannel2Changed,
-    Openchannel2Sign,
-    RbfChannel,
-    HtlcAccepted,
-    RpcCommand,
-    Custommsg,
-    OnionMessage,
-    OnionMessageBlinded,
-    OnionMessageOurpath,
+    //     PeerConnected,
+    //     CommitmentRevocation,
+    //     DbWrite,
+    //     InvoicePayment,
+    //     Openchannel,
+    //     Openchannel2,
+    //     Openchannel2Changed,
+    //     Openchannel2Sign,
+    //     RbfChannel,
+    //     HtlcAccepted,
+    //     RpcCommand,
+    //     Custommsg,
+    //     OnionMessage,
+    //     OnionMessageBlinded,
+    //     OnionMessageOurpath,
 
     // Bitcoin backend
-    Getchaininfo,
-    Estimatefees,
-    Getrawblockbyheight,
-    Getutxout,
-    Sendrawtransaction,
+    //     Getchaininfo,
+    //     Estimatefees,
+    //     Getrawblockbyheight,
+    //     Getutxout,
+    //     Sendrawtransaction,
 }
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "method", content = "params")]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Notification {
-    ChannelOpened,
-    ChannelOpenFailed,
-    ChannelStateChanged,
-    Connect,
-    Disconnect,
-    InvoicePayment,
-    InvoiceCreation,
-    Warning,
-    ForwardEvent,
-    SendpaySuccess,
-    SendpayFailure,
-    CoinMovement,
-    OpenchannelPeerSigs,
-    Shutdown,
+//     ChannelOpened,
+//     ChannelOpenFailed,
+//     ChannelStateChanged,
+//     Connect,
+//     Disconnect,
+//     InvoicePayment,
+//     InvoiceCreation,
+//     Warning,
+//     ForwardEvent,
+//     SendpaySuccess,
+//     SendpayFailure,
+//     CoinMovement,
+//     OpenchannelPeerSigs,
+//     Shutdown,
 }
 
 #[derive(Deserialize, Debug)]
@@ -128,6 +127,8 @@ pub(crate) struct RpcMethod {
 pub(crate) struct GetManifestResponse {
     pub(crate) options: Vec<ConfigOption>,
     pub(crate) rpcmethods: Vec<RpcMethod>,
+    pub(crate) subscriptions: Vec<String>,
+    pub(crate) hooks: Vec<String>,
 }
 
 #[derive(Serialize, Default, Debug)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,0 +1,160 @@
+use serde::de::{self, Deserializer};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "method", content = "params")]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Request {
+    // Builtin
+    Getmanifest(GetManifestCall),
+    Init(InitCall),
+
+    // Hooks
+    PeerConnected,
+    CommitmentRevocation,
+    DbWrite,
+    InvoicePayment,
+    Openchannel,
+    Openchannel2,
+    Openchannel2Changed,
+    Openchannel2Sign,
+    RbfChannel,
+    HtlcAccepted,
+    RpcCommand,
+    Custommsg,
+    OnionMessage,
+    OnionMessageBlinded,
+    OnionMessageOurpath,
+
+    // Bitcoin backend
+    Getchaininfo,
+    Estimatefees,
+    Getrawblockbyheight,
+    Getutxout,
+    Sendrawtransaction,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "method", content = "params")]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Notification {
+    ChannelOpened,
+    ChannelOpenFailed,
+    ChannelStateChanged,
+    Connect,
+    Disconnect,
+    InvoicePayment,
+    InvoiceCreation,
+    Warning,
+    ForwardEvent,
+    SendpaySuccess,
+    SendpayFailure,
+    CoinMovement,
+    OpenchannelPeerSigs,
+    Shutdown,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct GetManifestCall {}
+
+#[derive(Deserialize, Debug)]
+pub struct InitCall {
+    pub options: Value,
+    pub configuration: HashMap<String, Value>,
+}
+
+#[derive(Debug)]
+pub enum JsonRpc<N, R> {
+    Request(usize, R),
+    Notification(N),
+}
+
+/// This function disentangles the various cases:
+///
+///   1) If we have an `id` then it is a request
+///
+///   2) Otherwise it's a notification that doesn't require a
+///   response.
+///
+/// Furthermore we distinguish between the built-in types and the
+/// custom user notifications/methods:
+///
+///   1) We either match a built-in type above,
+///
+///   2) Or it's a custom one, so we pass it around just as a
+///   `serde_json::Value`
+impl<'de, N, R> Deserialize<'de> for JsonRpc<N, R>
+where
+    N: Deserialize<'de> + Debug,
+    R: Deserialize<'de> + Debug,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Debug)]
+        struct IdHelper {
+            id: Option<usize>,
+        }
+
+        let v = Value::deserialize(deserializer)?;
+        let helper = IdHelper::deserialize(&v).map_err(de::Error::custom)?;
+        match helper.id {
+            Some(id) => {
+                let r = R::deserialize(v).map_err(de::Error::custom)?;
+                Ok(JsonRpc::Request(id, r))
+            }
+            None => {
+                let n = N::deserialize(v).map_err(de::Error::custom)?;
+                Ok(JsonRpc::Notification(n))
+            }
+        }
+    }
+}
+
+use serde::ser::{SerializeStruct, Serializer};
+
+impl<N, R> Serialize for JsonRpc<N, R>
+where
+    N: Serialize + Debug,
+    R: Serialize + Debug,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            JsonRpc::Notification(r) => {
+                let r = serde_json::to_value(r).unwrap();
+                let mut s = serializer.serialize_struct("Notification", 3)?;
+                s.serialize_field("jsonrpc", "2.0")?;
+                s.serialize_field("method", &r["method"])?;
+                s.serialize_field("params", &r["params"])?;
+                s.end()
+            }
+            JsonRpc::Request(id, r) => {
+                let r = serde_json::to_value(r).unwrap();
+                let mut s = serializer.serialize_struct("Request", 4)?;
+                s.serialize_field("jsonrpc", "2.0")?;
+                s.serialize_field("id", id)?;
+                s.serialize_field("method", &r["method"])?;
+                s.serialize_field("params", &r["params"])?;
+                s.end()
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Default, Debug)]
+pub struct GetManifestResponse {
+    options: Vec<()>,
+    rpcmethods: Vec<()>,
+}
+
+#[derive(Serialize, Default, Debug)]
+pub struct InitResponse {}
+
+pub trait Response: Serialize + Debug {}

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -104,14 +104,14 @@ mod test {
                     }),
             ),
             (
-                ConfigOption::new("name", Value::Boolean(true), "description"
+                ConfigOption::new("name", Value::Boolean(true), "description"),
                 json!({
                 "name": "name",
                         "description":"description",
                         "default": true,
                         "type": "booltes",
                     }),
-            )),
+            ),
         ];
 
         for (input, expected) in tests.iter() {

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -109,7 +109,7 @@ mod test {
                 "name": "name",
                         "description":"description",
                         "default": true,
-                        "type": "booltes",
+                        "type": "bool",
                     }),
             ),
         ];

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -1,0 +1,122 @@
+use serde::ser::{SerializeStruct, Serializer};
+use serde::{Serialize};
+
+#[derive(Clone, Debug)]
+pub enum Value {
+    String(String),
+    Integer(i64),
+    Boolean(bool),
+}
+
+/// An stringly typed option that is passed to
+#[derive(Clone, Debug)]
+pub struct ConfigOption {
+    name: String,
+    pub(crate) value: Option<Value>,
+    default: Value,
+    description: String,
+}
+
+impl ConfigOption {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn default(&self) -> &Value {
+        &self.default
+    }
+}
+
+// When we serialize we don't add the value. This is because we only
+// ever serialize when we pass the option back to lightningd during
+// the getmanifest call.
+impl Serialize for ConfigOption {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("ConfigOption", 4)?;
+        s.serialize_field("name", &self.name)?;
+        match &self.default {
+            Value::String(ss) => {
+                s.serialize_field("type", "string")?;
+                s.serialize_field("default", ss)?;
+            }
+            Value::Integer(i) => {
+                s.serialize_field("type", "int")?;
+                s.serialize_field("default", i)?;
+            }
+
+            Value::Boolean(b) => {
+                s.serialize_field("type", "bool")?;
+                s.serialize_field("default", b)?;
+            }
+        }
+
+        s.serialize_field("description", &self.description)?;
+        s.end()
+    }
+}
+impl ConfigOption {
+    pub fn new(name: &str, default: Value, description: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            default,
+            description: description.to_string(),
+            value: None,
+        }
+    }
+
+    pub fn value(&self) -> Value {
+        match &self.value {
+            None => self.default.clone(),
+            Some(v) => v.clone(),
+        }
+    }
+
+    pub fn description(&self) -> String {
+        self.description.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_option_serialize() {
+        let tests = vec![
+            (
+                ConfigOption::new("name", Value::String("default".to_string()), "description"),
+                json!({
+                "name": "name",
+                        "description":"description",
+                        "default": "default",
+                        "type": "string",
+                    }),
+            ),
+            (
+                ConfigOption::new("name", Value::Integer(42), "description"),
+                json!({
+                "name": "name",
+                        "description":"description",
+                        "default": 42,
+                        "type": "int",
+                    }),
+            ),
+            (
+                ConfigOption::new("name", Value::Boolean(true), "description"
+                json!({
+                "name": "name",
+                        "description":"description",
+                        "default": true,
+                        "type": "booltes",
+                    }),
+            )),
+        ];
+
+        for (input, expected) in tests.iter() {
+            let res = serde_json::to_value(input).unwrap();
+            assert_eq!(&res, expected);
+        }
+    }
+}

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -24,7 +24,7 @@ def test_plugin_start(node_factory):
     """Start a minimal plugin and ensure it is well-behaved
     """
     bin_path = Path.cwd() / "target" / "debug" / "examples" / "cln-plugin-startup"
-    l1 = node_factory.get_node(options={"plugin": str(bin_path)})
+    l1 = node_factory.get_node(options={"plugin": str(bin_path), 'test-option': 31337})
 
     cfg = l1.rpc.listconfigs()
     p = cfg['plugins'][0]
@@ -32,9 +32,8 @@ def test_plugin_start(node_factory):
     expected = {
         'name': 'cln-plugin-startup',
         'options': {
-            'test-option': 42
+            'test-option': 31337
         },
         'path': None
     }
     assert expected == p
-

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -37,3 +37,18 @@ def test_plugin_start(node_factory):
         'path': None
     }
     assert expected == p
+
+    # Now check that the `testmethod was registered ok
+    l1.rpc.help("testmethod") == {
+        'help': [
+            {
+                'command': 'testmethod ',
+                'category': 'plugin',
+                'description': 'This is a test',
+                'verbose': 'This is a test'
+            }
+        ],
+        'format-hint': 'simple'
+    }
+
+    assert l1.rpc.testmethod() == "Hello"

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -21,14 +21,20 @@ def test_rpc_client(node_factory):
 
 
 def test_plugin_start(node_factory):
-   """Start a minimal plugin and ensure it is well-behaved
-   """
-   bin_path = Path.cwd() / "target" / "debug" / "examples" / "cln-plugin-startup"
-   l1 = node_factory.get_node(options={"plugin": str(bin_path)})
+    """Start a minimal plugin and ensure it is well-behaved
+    """
+    bin_path = Path.cwd() / "target" / "debug" / "examples" / "cln-plugin-startup"
+    l1 = node_factory.get_node(options={"plugin": str(bin_path)})
 
-   # The plugin should be in the list of active plugins
-   plugins = l1.rpc.plugin('list')['plugins']
-   assert len([p for p in plugins if 'cln-plugin-startup' in p['name'] and p['active']]) == 1
+    cfg = l1.rpc.listconfigs()
+    p = cfg['plugins'][0]
+    p['path'] = None  # The path is host-specific, so blank it.
+    expected = {
+        'name': 'cln-plugin-startup',
+        'options': {
+            'test-option': 42
+        },
+        'path': None
+    }
+    assert expected == p
 
-   # Logging should also work through the log integration
-   l1.daemon.wait_for_log(r'Hello world')

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -5,19 +5,11 @@ import subprocess
 import pytest
 
 
-# Skip the entire module if we don't have Rust. The same is true for
-# VALGRIND, since it sometimes causes false positives in
-# `std::sync::Once`
-pytestmark = [
-    pytest.mark.skipif(
-        env('RUST') != '1',
-        reason='RUST is not enabled skipping rust-dependent tests'
-    ),
-    pytest.mark.skipif(
-        env('VALGRIND') == '1',
-        reason='VALGRIND is enabled skipping rust-dependent tests, as they may report false positives.'
-    ),
-]
+# Skip the entire module if we don't have Rust.
+pytestmark = pytest.mark.skipif(
+    env('RUST') != '1',
+    reason='RUST is not enabled skipping rust-dependent tests'
+)
 
 
 def test_rpc_client(node_factory):

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -5,11 +5,19 @@ import subprocess
 import pytest
 
 
-# Skip the entire module if we don't have Rust.
-pytestmark = pytest.mark.skipif(
-    env('RUST') != '1',
-    reason='RUST is not enabled, skipping rust-dependent tests'
-)
+# Skip the entire module if we don't have Rust. The same is true for
+# VALGRIND, since it sometimes causes false positives in
+# `std::sync::Once`
+pytestmark = [
+    pytest.mark.skipif(
+        env('RUST') != '1',
+        reason='RUST is not enabled skipping rust-dependent tests'
+    ),
+    pytest.mark.skipif(
+        env('VALGRIND') == '1',
+        reason='VALGRIND is enabled skipping rust-dependent tests, as they may report false positives.'
+    ),
+]
 
 
 def test_rpc_client(node_factory):

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -25,6 +25,7 @@ def test_plugin_start(node_factory):
     """
     bin_path = Path.cwd() / "target" / "debug" / "examples" / "cln-plugin-startup"
     l1 = node_factory.get_node(options={"plugin": str(bin_path), 'test-option': 31337})
+    l2 = node_factory.get_node()
 
     cfg = l1.rpc.listconfigs()
     p = cfg['plugins'][0]
@@ -52,3 +53,7 @@ def test_plugin_start(node_factory):
     }
 
     assert l1.rpc.testmethod() == "Hello"
+
+    l1.connect(l2)
+    l1.daemon.wait_for_log(r'Got a connect hook call')
+    l1.daemon.wait_for_log(r'Got a connect notification')

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -2,7 +2,6 @@ from fixtures import *  # noqa: F401,F403
 from pathlib import Path
 from pyln.testing.utils import env, TEST_NETWORK
 import subprocess
-import os
 import pytest
 
 
@@ -12,8 +11,6 @@ pytestmark = pytest.mark.skipif(
     reason='RUST is not enabled, skipping rust-dependent tests'
 )
 
-os.environ['RUST_LOG'] = "trace"
-
 
 def test_rpc_client(node_factory):
     l1 = node_factory.get_node()
@@ -21,3 +18,17 @@ def test_rpc_client(node_factory):
     rpc_path = Path(l1.daemon.lightning_dir) / TEST_NETWORK / "lightning-rpc"
     out = subprocess.check_output([bin_path, rpc_path], stderr=subprocess.STDOUT)
     assert(b'0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518' in out)
+
+
+def test_plugin_start(node_factory):
+   """Start a minimal plugin and ensure it is well-behaved
+   """
+   bin_path = Path.cwd() / "target" / "debug" / "examples" / "cln-plugin-startup"
+   l1 = node_factory.get_node(options={"plugin": str(bin_path)})
+
+   # The plugin should be in the list of active plugins
+   plugins = l1.rpc.plugin('list')['plugins']
+   assert len([p for p in plugins if 'cln-plugin-startup' in p['name'] and p['active']]) == 1
+
+   # Logging should also work through the log integration
+   l1.daemon.wait_for_log(r'Hello world')

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -55,5 +55,5 @@ def test_plugin_start(node_factory):
     assert l1.rpc.testmethod() == "Hello"
 
     l1.connect(l2)
-    l1.daemon.wait_for_log(r'Got a connect hook call')
+    #l1.daemon.wait_for_log(r'Got a connect hook call')
     l1.daemon.wait_for_log(r'Got a connect notification')

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -55,5 +55,5 @@ def test_plugin_start(node_factory):
     assert l1.rpc.testmethod() == "Hello"
 
     l1.connect(l2)
-    #l1.daemon.wait_for_log(r'Got a connect hook call')
+    l1.daemon.wait_for_log(r'Got a connect hook call')
     l1.daemon.wait_for_log(r'Got a connect notification')

--- a/tests/valgrind-suppressions.txt
+++ b/tests/valgrind-suppressions.txt
@@ -1,0 +1,14 @@
+{
+   rust__std_sync_once__try_statx_01
+   Memcheck:Param
+   statx(buf)
+   fun:statx
+   ...
+}
+{
+   rust__std_sync_once__try_statx_02
+   Memcheck:Param
+   statx(file_name)
+   fun:statx
+   ...
+}


### PR DESCRIPTION
This is likely the least mature crate of the cln-* series. It just implements the bare minimum of a plugin's lifetime such that it stays alive when run by `lightningd`. It doesn't yet have custom RPC methods support, nor config support, but I intend to build these out as we go. It is pretty much just the minimum to get us into a situation we can write the `grpc-plugin` plugin.