### PR TITLE
json_add_invoice: fix crash if missing invstring

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -39,7 +39,8 @@ static void json_add_invoice(struct json_stream *response,
 			     const struct invoice_details *inv)
 {
 	json_add_escaped_string(response, "label", inv->label);
-	json_add_invstring(response, inv->invstring);
+	if (inv->invstring)
+		json_add_invstring(response, inv->invstring);
 	json_add_sha256(response, "payment_hash", &inv->rhash);
 	if (inv->msat)
 		json_add_amount_msat_compat(response, *inv->msat,


### PR DESCRIPTION
If this field is missing for whatever reason (weird db state?)
clightning will crash when listing invoices.

This started happening when I pulled the latest master. I haven't bisected to see where it was introduced yet, if I even can anymore due to db upgrade.

Signed-off-by: William Casarin <jb55@jb55.com>

Changelog-Fixed: jsonrpc: Fixed a crash caused by a missing invoice string in `listinvoices`