### PR TITLE
`coin_movement` updates

### DIFF
--- a/common/coin_mvt.c
+++ b/common/coin_mvt.c
@@ -261,11 +261,9 @@ struct chain_coin_mvt *new_coin_external_deposit(const tal_t *ctx,
 						 struct amount_sat amount,
 						 enum mvt_tag tag)
 {
-	return new_chain_coin_mvt(ctx, EXTERNAL, NULL,
-				  outpoint, NULL,
-				  blockheight,
-				  take(new_tag_arr(NULL, tag)),
-				  AMOUNT_MSAT(0), true, amount);
+	return new_chain_coin_mvt_sat(ctx, EXTERNAL, NULL, outpoint, NULL,
+				      blockheight, take(new_tag_arr(NULL, tag)),
+				      amount, true);
 }
 
 bool chain_mvt_is_external(const struct chain_coin_mvt *mvt)

--- a/common/coin_mvt.h
+++ b/common/coin_mvt.h
@@ -83,6 +83,10 @@ struct chain_coin_mvt {
 
 	/* total value of output (useful for tracking external outs) */
 	struct amount_sat output_val;
+
+	/* When we pay to external accounts, it's useful
+	 * to track which internal account it originated from */
+	const char *originating_acct;
 };
 
 /* differs depending on type!? */
@@ -96,6 +100,9 @@ struct mvt_id {
 struct coin_mvt {
 	/* name of 'account': wallet, external, <channel_id> */
 	const char *account_id;
+
+	/* if account_id is external, the account this 'impacted' */
+	const char *originating_acct;
 
 	/* Chain name: BIP 173, except signet lightning-style: tbs not tb */
 	const char *hrp_name;
@@ -248,6 +255,9 @@ struct coin_mvt *finalize_channel_mvt(const tal_t *ctx,
 				      u32 timestamp,
 				      const struct node_id *node_id)
 	NON_NULL_ARGS(2, 3, 5);
+
+/* Is this an xternal account? */
+bool chain_mvt_is_external(const struct chain_coin_mvt *mvt);
 
 const char *mvt_type_str(enum mvt_type type);
 const char *mvt_tag_str(enum mvt_tag tag);

--- a/common/psbt_open.c
+++ b/common/psbt_open.c
@@ -491,6 +491,23 @@ bool psbt_has_our_input(const struct wally_psbt *psbt)
 	return false;
 }
 
+void psbt_output_mark_as_external(const tal_t *ctx,
+				  struct wally_psbt_output *output)
+{
+	u8 *key = psbt_make_key(tmpctx, PSBT_TYPE_OUTPUT_EXTERNAL, NULL);
+	beint16_t bev = cpu_to_be16(1);
+
+	psbt_output_set_unknown(ctx, output, key, &bev, sizeof(bev));
+}
+
+bool psbt_output_to_external(const struct wally_psbt_output *output)
+{
+	size_t unused;
+	void *result = psbt_get_lightning(&output->unknowns,
+					  PSBT_TYPE_OUTPUT_EXTERNAL, &unused);
+	return !(!result);
+}
+
 bool psbt_contribs_changed(struct wally_psbt *orig,
 			   struct wally_psbt *new)
 {

--- a/common/psbt_open.h
+++ b/common/psbt_open.h
@@ -37,6 +37,7 @@ struct psbt_changeset {
 
 #define PSBT_TYPE_SERIAL_ID 0x01
 #define PSBT_TYPE_INPUT_MARKER 0x02
+#define PSBT_TYPE_OUTPUT_EXTERNAL 0x04
 
 /* psbt_get_serial_id - Returns the serial_id from an unknowns map
  *
@@ -176,6 +177,17 @@ bool psbt_input_is_ours(const struct wally_psbt_input *input);
  * 			 any input that is ours
  */
 bool psbt_has_our_input(const struct wally_psbt *psbt);
+
+/* psbt_output_mark_external - Marks an output as a deposit to
+ * 			       an external address.
+ * 			       Used when withdrawing from internal
+ * 			       wallet */
+void psbt_output_mark_as_external(const tal_t *ctx,
+				  struct wally_psbt_output *output);
+
+/* psbt_output_to_external - Is this an output we're paying to an external
+ * 			     party? */
+bool psbt_output_to_external(const struct wally_psbt_output *output);
 
 /* psbt_contribs_changed - Returns true if the psbt's inputs/outputs
  *                         have changed.

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -701,6 +701,7 @@ i.e. only definitively resolved HTLCs or confirmed bitcoin transactions.
 		"node_id":"03a7103a2322b811f7369cbb27fb213d30bbc0b012082fed3cad7e4498da2dc56b",
 		"type":"chain_mvt",
 		"account_id":"wallet",
+		"originating_account": "wallet", // (`chain_mvt` only, optional)
 		"txid":"0159693d8f3876b4def468b208712c630309381e9d106a9836fa0a9571a28722", // (`chain_mvt` only, optional)
 		"utxo_txid":"0159693d8f3876b4def468b208712c630309381e9d106a9836fa0a9571a28722", // (`chain_mvt` only)
 		"vout":1, // (`chain_mvt` only)
@@ -730,6 +731,9 @@ notification adheres to.
 
 `account_id` is the name of this account. The node's wallet is named 'wallet',
 all channel funds' account are the channel id.
+
+`originating_account` is the account that this movement originated from.
+*Only* tagged on external events (deposits/withdrawals to an external party).
 
 `txid` is the transaction id of the bitcoin transaction that triggered this
 ledger event. `utxo_txid` and `vout` identify the bitcoin output which triggered

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -771,22 +771,22 @@ both the debit/credit contain fees. Technically routed debits are the
  - `invoice`: funds paid to or recieved from an invoice.
  - `routed`: funds routed through this node.
  - `pushed`: funds pushed to peer.
- -  channel_open : channel is opened, initial channel balance
- -  channel_close: channel is closed, final channel balance
- -  delayed_to_us : on-chain output to us, spent back into our wallet
- -  htlc_timeout : on-chain htlc timeout output
- - htlc_fulfill : on-chian htlc fulfill output
- - htlc_tx : on-chain htlc tx has happened
- - to_wallet : output being spent into our wallet
- - ignored : output is being ignored
- - anchor : an anchor output
- - to_them : output intended to peer's wallet
- - penalized : output we've 'lost' due to a penalty (failed cheat attempt)
- - stolen : output we've 'lost' due to peer's cheat
- - to_miner : output we've burned to miner (OP_RETURN)
- - opener : tags channel_open, we are the channel opener
- - lease_fee: amount paid as lease fee
- - leased: tags channel_open, channel contains leased funds
+ - `channel_open` : channel is opened, initial channel balance
+ - `channel_close`: channel is closed, final channel balance
+ - `delayed_to_us`: on-chain output to us, spent back into our wallet
+ - `htlc_timeout`: on-chain htlc timeout output
+ - `htlc_fulfill`: on-chian htlc fulfill output
+ - `htlc_tx`: on-chain htlc tx has happened
+ - `to_wallet`: output being spent into our wallet
+ - `ignored`: output is being ignored
+ - `anchor`: an anchor output
+ - `to_them`: output intended to peer's wallet
+ - `penalized`: output we've 'lost' due to a penalty (failed cheat attempt)
+ - `stolen`: output we've 'lost' due to peer's cheat
+ - `to_miner`: output we've burned to miner (OP_RETURN)
+ - `opener`: tags channel_open, we are the channel opener
+ - `lease_fee`: amount paid as lease fee
+ - `leased`: tags channel_open, channel contains leased funds
 
 `blockheight` is the block the txid is included in.
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -788,7 +788,9 @@ both the debit/credit contain fees. Technically routed debits are the
  - `lease_fee`: amount paid as lease fee
  - `leased`: tags channel_open, channel contains leased funds
 
-`blockheight` is the block the txid is included in.
+`blockheight` is the block the txid is included in. `channel_mvt`s will be null,
+so will the blockheight for withdrawals to external parties (we issue these events
+when we send the tx containing them, before they're included in the chain).
 
 The `timestamp` is seconds since Unix epoch of the node's machine time
 at the time lightningd broadcasts the notification.

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -470,6 +470,9 @@ static void coin_movement_notification_serialize(struct json_stream *stream,
 	json_add_node_id(stream, "node_id", mvt->node_id);
 	json_add_string(stream, "type", mvt_type_str(mvt->type));
 	json_add_string(stream, "account_id", mvt->account_id);
+	if (mvt->originating_acct)
+		json_add_string(stream, "originating_account",
+				mvt->originating_acct);
 	json_mvt_id(stream, mvt->type, &mvt->id);
 	json_add_amount_msat_only(stream, "credit", mvt->credit);
 	json_add_amount_msat_only(stream, "debit", mvt->debit);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -265,6 +265,9 @@ static void handle_onchain_log_coin_move(struct channel *channel, const u8 *msg)
 	if (!mvt->account_name)
 		mvt->account_name = type_to_string(mvt, struct channel_id,
 						   &channel->cid);
+	else if (chain_mvt_is_external(mvt))
+		mvt->originating_acct = type_to_string(mvt, struct channel_id,
+						       &channel->cid);
 	notify_chain_mvt(channel->peer->ld, mvt);
 	tal_free(mvt);
 }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,7 +10,7 @@ from pyln.testing.utils import (
     wait_for, TailableProc, env
 )
 from utils import (
-    account_balance, scriptpubkey_addr
+    account_balance, scriptpubkey_addr, check_coin_moves
 )
 from ephemeral_port_reserve import reserve
 from utils import EXPERIMENTAL_FEATURES
@@ -622,6 +622,16 @@ def test_withdraw_misc(node_factory, bitcoind, chainparams):
     bitcoind.generate_block(1)
     sync_blockheight(bitcoind, [l1])
     assert account_balance(l1, 'wallet') == 0
+
+    external_moves = [
+        {'type': 'chain_mvt', 'credit': 2000000000, 'debit': 0, 'tags': ['deposit']},
+        {'type': 'chain_mvt', 'credit': 2000000000, 'debit': 0, 'tags': ['deposit']},
+        {'type': 'chain_mvt', 'credit': 2000000000, 'debit': 0, 'tags': ['deposit']},
+        {'type': 'chain_mvt', 'credit': 2000000000, 'debit': 0, 'tags': ['deposit']},
+        {'type': 'chain_mvt', 'credit': 11957603000, 'debit': 0, 'tags': ['deposit']},
+    ]
+
+    check_coin_moves(l1, 'external', external_moves, chainparams)
 
 
 def test_io_logging(node_factory, executor):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -136,7 +136,7 @@ def check_coin_moves(n, account_id, expected_moves, chainparams):
         assert mv['timestamp'] > 0
         assert mv['coin_type'] == chainparams['bip173_prefix']
         # chain moves should have blockheights
-        if mv['type'] == 'chain_mvt':
+        if mv['type'] == 'chain_mvt' and mv['account_id'] != 'external':
             assert mv['blockheight'] is not None
 
     for num, m in enumerate(expected_moves):


### PR DESCRIPTION
While working on the accounting plugin, I ran into some problems/limitations of our current event emissions.

1) We weren't tracking withdrawals to external wallets (initiated via `withdraw`/`multiwithdraw`). This makes it really difficult to see where our funds are going, as well as confuses the onchain fee tracker that the accountant plugin has. Now, we emit a `coin_movement` for 

2) Funds sent to 'external' accounts don't say which account they originated from. While it's possible to figure this out from the utxo tracking, that's sometimes difficult to reconstruct. Instead, for every `external` deposit, we now record what internal account the payment originated from. For example, wallet payments to an external account will be tagged 'wallet'. Payments to the peer in a channel will 'originate' from the channel's account.