### PR TITLE
misc: Add build targets for the tarball and debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,24 @@ RUN mkdir /opt/litecoin && cd /opt/litecoin \
 FROM debian:buster-slim as builder
 
 ENV LIGHTNINGD_VERSION=master
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential git libtool python3 python3-pip python3-setuptools python3-mako wget gnupg dirmngr git gettext
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        dirmngr \
+        gettext \
+        git \
+        gnupg \
+        libtool \
+        python3 \
+        python3-mako \
+        python3-pip \
+        python3-setuptools \
+        wget
+
+RUN pip3 install -U setuptools mrkd mako
 
 RUN wget -q https://zlib.net/zlib-1.2.11.tar.gz \
 && tar xvf zlib-1.2.11.tar.gz \

--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ usage_with_default()
 default_coptflags()
 {
     if [ "$1" = 0 ]; then
-	echo "-Og"
+	echo ""
     fi
 }
 


### PR DESCRIPTION
The tarball needs to materialze all submodules, and git needs to be
removed as a build dependency. I thought @rustyrussell might find these
useful, so we can distribute the deb packages via the releases page. The
tarball is conforming to the debuild format, hence the extra work.

Changelog-None