### PR TITLE
fix UnicodeDecodeError in doc/lightning-listfunds.7.md

### DIFF
--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -37,7 +37,7 @@ On success, an object is returned, containing:
     - **reserved_to_block** (u32): Block height where reservation will expire
 - **channels** (array of objects):
   - **peer_id** (pubkey): the peer with which the channel is opened
-  - **our_amount_msat** (msat): available satoshis on our node’s end of the channel
+  - **our_amount_msat** (msat): available satoshis on our node's end of the channel
   - **amount_msat** (msat): total channel value
   - **funding_txid** (txid): funding transaction id
   - **funding_output** (u32): the 0-based index of the output in the funding transaction

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -67,4 +67,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7e2ee47b9e35c222ee8b671745990800feaba771cf60fbe8390c2afd040e878f)
+[comment]: # ( SHA256STAMP:959d54ed855f9f5d64148f5acf4a0bbb4bc1503e610ddae5ab4c04fd397af0b3)

--- a/doc/schemas/listfunds.schema.json
+++ b/doc/schemas/listfunds.schema.json
@@ -151,7 +151,7 @@
           },
           "our_amount_msat": {
             "type": "msat",
-            "description": "available satoshis on our node’s end of the channel"
+            "description": "available satoshis on our node's end of the channel"
           },
           "channel_sat": {
             "deprecated": true


### PR DESCRIPTION
I tried to build lightning following the steps here:
https://github.com/ElementsProject/lightning/blob/master/doc/INSTALL.md
On a box (via ssh) with LC_ALL=C and LANG=C.
I am aware this issue could probably be avoided by setting the locale.

However in my setup I received the following build error
```
$ make
...<snip>
mrkd doc/lightning-listfunds.7.md
Traceback (most recent call last):
  File "/home/user/.local/bin/mrkd", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/mrkd.py", line 254, in main
    plac.call(entry_point)
  File "/home/user/.local/lib/python3.6/site-packages/plac_core.py", line 436, in call
    cmd, result = parser.consume(arglist)
  File "/home/user/.local/lib/python3.6/site-packages/plac_core.py", line 287, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/mrkd.py", line 225, in entry_point
    result = mistune.markdown(fp.read(), inline=inline, renderer=renderer)
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1502: ordinal not in range(128)
doc/Makefile:115: recipe for target 'doc/lightning-listfunds.7' failed
make: *** [doc/lightning-listfunds.7] Error 1
```

This change fixes the ' character to ascii which fixed the build for me.
Changelog-None