### PR TITLE
db: enable SQLite extended result codes

### DIFF
--- a/wallet/db_sqlite3.c
+++ b/wallet/db_sqlite3.c
@@ -146,6 +146,12 @@ static bool db_sqlite3_setup(struct db *db)
 	}
 	wrapper->conn = sql;
 
+	err = sqlite3_extended_result_codes(wrapper->conn, 1);
+	if (err != SQLITE_OK) {
+		db_fatal("failed to enable extended result codes: %s",
+			 sqlite3_errstr(err));
+	}
+
 	if (!backup_filename)
 		wrapper->backup_conn = NULL;
 	else {


### PR DESCRIPTION
With this change, we get more fine-grained error messages if something goes wrong in the course of communicating with the SQLite database. To pick some random examples, the error codes SQLITE_IOERR_NOMEM, SQLITE_IOERR_CORRUPTFS or SQLITE_IOERR_FSYNC are way more specific than just a plain SQLITE_IOERR, and the corresponding error messages generated by sqlite3_errstr() will hence give a better hint to the user (or also to the developers, if an error report is sent) what the cause for a failure is.

See the SQLite documentation
      https://www.sqlite.org/c3ref/extended_result_codes.html
      https://www.sqlite.org/c3ref/c_abort_rollback.html

 > In its default configuration, SQLite API routines return one of 30 integer result codes. However, experience has shown that many of these result codes are too coarse-grained. They do not provide as much information about problems as programmers might like. In an effort to address this, newer versions of SQLite (version 3.3.8 2006-10-09 and later) include support for additional result codes that provide more detailed information about errors.

(Note that an almost identical PR has been opened and merged on Bitcoin Core some months ago: https://github.com/bitcoin/bitcoin/pull/23112)