### PR TITLE
doc: reintroduce the fmt command to fmt the schema

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -93,9 +93,13 @@ doc-all: $(MANPAGES) doc/index.rst
 
 SCHEMAS := $(wildcard doc/schemas/*.json)
 check-fmt-schemas: $(SCHEMAS:%=check-fmt-schema/%)
+fmt-schemas: $(SCHEMAS:%=fmt-schema/%)
 
 check-fmt-schema/%: %
 	@jq . < "$*" > "$*".fmt && diff -u "$*" "$*.fmt" && rm "$*.fmt"
+
+fmt-schema/%: %
+	@jq . < "$*" > "$*".fmt && cat "$*".fmt > "$*" && rm "$*.fmt"
 
 check-doc: check-config-docs check-manpages check-fmt-schemas
 


### PR DESCRIPTION
For some reason, there is no fmt schema command anymore, but just a check it.

So, this command now it is introduced by a helper command that needs to be expressed called by the human with `fmt-schemas`, and it help to format a very big JSON schema like the one introduced in this PR https://github.com/ElementsProject/lightning/pull/5022

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
Changelog-None