### PR TITLE
Add short_channel_id to listchannels.schema.json

### DIFF
--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -34,6 +34,7 @@ RETURN VALUE
 On success, an object containing **channels** is returned.  It is an array of objects, where each object contains:
 - **source** (pubkey): the source node
 - **destination** (pubkey): the destination node
+- **short_channel_id** (short_channel_id): short channel id of channel
 - **public** (boolean): true if this is announced (otherwise it must be our channel)
 - **amount_msat** (msat): the total capacity of this channel (always a whole number of satoshis)
 - **message_flags** (u8): as defined by BOLT #7
@@ -77,4 +78,4 @@ Lightning RFC site
 -   BOLT \#7:
     <https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md>
 
-[comment]: # ( SHA256STAMP:c2ebd6407a66ad5f67b5fd933552a468e306b1fed7868f92985c24e321861fae)
+[comment]: # ( SHA256STAMP:e27d51a95411739ee10b082beaca55e33de4b2177b0e39df2223700c3141bc02)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -377,4 +377,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:444080f602bbce7d86bc7c38a4a2b1186a31c63d6b747d92c5aa4711dd9118c1)
+[comment]: # ( SHA256STAMP:d45de73a968bcc3e7fb699f0acd7a27a4c70d9e9fded8af8c684a71fe012f1ce)

--- a/doc/schemas/listchannels.schema.json
+++ b/doc/schemas/listchannels.schema.json
@@ -36,6 +36,10 @@
             "type": "pubkey",
             "description": "the destination node"
           },
+          "short_channel_id": {
+            "type": "short_channel_id",
+            "description": "short channel id of channel"
+          },
           "public": {
             "type": "boolean",
             "description": "true if this is announced (otherwise it must be our channel)"

--- a/doc/schemas/listchannels.schema.json
+++ b/doc/schemas/listchannels.schema.json
@@ -10,7 +10,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "source",
           "destination",


### PR DESCRIPTION
This was previously marked as required, but not actually defined in properties.

I found this while working on [c-lightning.ts](https://github.com/runcitadel/c-lightning-client).

Changelog-None