### PR TITLE
bitcoin/tx: remove unused SEGREGATED_WITNESS_FLAG

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -9,8 +9,6 @@
 #include <wire/wire.h>
 #include <bitcoin/tx.h>
 
-#define SEGREGATED_WITNESS_FLAG 0x1
-
 struct bitcoin_tx_output *new_tx_output(const tal_t *ctx,
 					struct amount_sat amount,
 					const u8 *script)


### PR DESCRIPTION
This define is unused since commit 509bb2c7aee5887a96e8966869c39bb4d5aba766.