### PR TITLE
gossipd: don't send updates in error messages for unannounced channels.

### DIFF
--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -420,9 +420,13 @@ static u8 *sign_and_timestamp_update(const tal_t *ctx,
 		tal_free(unsigned_update);
 
 	/* Tell lightningd about this immediately (even if we're not actually
-	 * applying it now) */
-	msg = towire_gossipd_got_local_channel_update(NULL, &chan->scid, update);
-	daemon_conn_send(daemon->master, take(msg));
+	 * applying it now).  We choose not to send info about private
+	 * channels, even in errors. */
+	if (is_chan_public(chan)) {
+		msg = towire_gossipd_got_local_channel_update(NULL, &chan->scid,
+							      update);
+		daemon_conn_send(daemon->master, take(msg));
+	}
 
 	return update;
 }

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1746,9 +1746,7 @@ def test_pay_retry(node_factory, bitcoind, executor, chainparams):
 def test_pay_routeboost(node_factory, bitcoind, compat):
     """Make sure we can use routeboost information. """
     # l1->l2->l3--private-->l4
-    # Note: l1 gets upset because it extracts update for private channel.
-    l1, l2 = node_factory.line_graph(2, announce_channels=True, wait_for_announce=True,
-                                     opts=[{'allow_bad_gossip': True}, {}])
+    l1, l2 = node_factory.line_graph(2, announce_channels=True, wait_for_announce=True)
     l3, l4, l5 = node_factory.line_graph(3, announce_channels=False, wait_for_announce=False)
 
     # This should a "could not find a route" because that's true.


### PR DESCRIPTION
This restores the behaviour prior to `lightningd: use our cached
channel_update for errors instead of asking gossipd.`, where gossipd
would refuse to give us channel_updates for unannounced channels.

@t-bast pinged for opinions! 