### PR TITLE
bolt11: prevent duplicate min_final_cltv_expiry and expiry tags

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -224,7 +224,7 @@ static void decode_h(struct bolt11 *b11,
 static char *decode_x(struct bolt11 *b11,
 		      struct hash_u5 *hu5,
 		      u5 **data, size_t *data_len,
-		      size_t data_length, const bool *have_x)
+		      size_t data_length, bool *have_x)
 {
 	if (*have_x)
 		return unknown_field(b11, hu5, data, data_len, 'x',
@@ -234,6 +234,8 @@ static char *decode_x(struct bolt11 *b11,
 	if (!pull_uint(hu5, data, data_len, &b11->expiry, data_length * 5))
 		return tal_fmt(b11, "x: length %zu chars is excessive",
 			       *data_len);
+
+	*have_x = true;
 	return NULL;
 }
 

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -245,7 +245,7 @@ static char *decode_x(struct bolt11 *b11,
 static char *decode_c(struct bolt11 *b11,
 		      struct hash_u5 *hu5,
 		      u5 **data, size_t *data_len,
-		      size_t data_length, const bool *have_c)
+		      size_t data_length, bool *have_c)
 {
 	u64 c;
 	if (*have_c)
@@ -261,6 +261,7 @@ static char *decode_c(struct bolt11 *b11,
 	if (b11->min_final_cltv_expiry != c)
 		return tal_fmt(b11, "c: %"PRIu64" is too large", c);
 
+	*have_c = true;
 	return NULL;
 }
 


### PR DESCRIPTION
When decoding bolt11 tags, it looks like there are checks (`have_c`, `have_x`,
etc) which prevent duplicate tags. Unfortunately `decode_c` doesn't set
`have_c` unlike the other `decode_` methods. At the start of the function,
`decode_c` checks `have_c` to see if it's set, but it is never set. It seems
like this could allow for duplicate `c` tags, which is probably not intended.

It looks like there's the same issue with the `x` (expiry) tag as well.
