### PR TITLE
configure: restore -Og default on non-developer builds.

### DIFF
--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ usage_with_default()
 default_coptflags()
 {
     if [ "$1" = 0 ]; then
-	echo ""
+	echo "-Og"
     fi
 }
 


### PR DESCRIPTION
Reverts change in 1ef77504b1b8c00fe41e82b205177463924dea6c.
