### PR TITLE
connectd: be more graceful when an address is in use.

### DIFF
--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -165,7 +165,7 @@ struct daemon {
 	struct sockaddr *broken_resolver_response;
 
 	/* File descriptors to listen on once we're activated. */
-	struct listen_fd *listen_fds;
+	const struct listen_fd **listen_fds;
 
 	/* Allow to define the default behavior of tor services calls*/
 	bool use_v3_autotor;

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -40,6 +40,7 @@ msgdata,connectd_activate,listen,bool,
 
 # Connectd->master, I am ready.
 msgtype,connectd_activate_reply,2125
+msgdata,connectd_activate_reply,failmsg,?wirestring,
 
 # connectd->master: disconnect this peer please (due to reconnect).
 msgtype,connectd_reconnected,2112

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -31,6 +31,7 @@ msgdata,connectd_init_reply,num_bindings,u16,
 msgdata,connectd_init_reply,bindings,wireaddr_internal,num_bindings
 msgdata,connectd_init_reply,num_announcable,u16,
 msgdata,connectd_init_reply,announcable,wireaddr,num_announcable
+msgdata,connectd_init_reply,failmsg,?wirestring,
 
 # Activate the connect daemon, so others can connect.
 msgtype,connectd_activate,2025

--- a/connectd/tor_autoservice.c
+++ b/connectd/tor_autoservice.c
@@ -265,36 +265,18 @@ static void negotiate_auth(struct rbuf *rbuf, const char *tor_password)
 		      "Tor protocolinfo did not give auth");
 }
 
-/* We need to have a bound address we can tell Tor to connect to */
-const struct wireaddr *
-find_local_address(const struct wireaddr_internal *bindings)
-{
-	for (size_t i = 0; i < tal_count(bindings); i++) {
-		if (bindings[i].itype != ADDR_INTERNAL_WIREADDR)
-			continue;
-		if (bindings[i].u.wireaddr.type != ADDR_TYPE_IPV4
-		    && bindings[i].u.wireaddr.type != ADDR_TYPE_IPV6)
-			continue;
-		return &bindings[i].u.wireaddr;
-	}
-	status_failed(STATUS_FAIL_INTERNAL_ERROR,
-		      "No local address found to tell Tor to connect to");
-}
-
 struct wireaddr *tor_autoservice(const tal_t *ctx,
 				 const struct wireaddr_internal *tor_serviceaddr,
 				 const char *tor_password,
-				 const struct wireaddr_internal *bindings,
+				 const struct wireaddr *laddr,
 				 const bool use_v3_autotor)
 {
 	int fd;
-	const struct wireaddr *laddr;
 	struct wireaddr *onion;
 	struct addrinfo *ai_tor;
 	struct rbuf rbuf;
 	char *buffer;
 
-	laddr = find_local_address(bindings);
 	ai_tor = wireaddr_to_addrinfo(tmpctx, &tor_serviceaddr->u.torservice.address);
 
 	fd = socket(ai_tor->ai_family, SOCK_STREAM, 0);

--- a/connectd/tor_autoservice.h
+++ b/connectd/tor_autoservice.h
@@ -9,7 +9,7 @@
 struct wireaddr *tor_autoservice(const tal_t *ctx,
 				 const struct wireaddr_internal *tor_serviceaddr,
 				 const char *tor_password,
-				 const struct wireaddr_internal *bindings,
+				 const struct wireaddr *localaddr,
 				 const bool use_v3_autotor);
 
 struct wireaddr *tor_fixed_service(const tal_t *ctx,
@@ -18,9 +18,5 @@ struct wireaddr *tor_fixed_service(const tal_t *ctx,
 				 const char *blob,
 				 const struct wireaddr *bind,
 				 const u8 index);
-
-const struct wireaddr *
-find_local_address(const struct wireaddr_internal *bindings);
-
 
 #endif /* LIGHTNING_CONNECTD_TOR_AUTOSERVICE_H */

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -471,7 +471,7 @@ static void connect_init_done(struct subd *connectd,
 					  &ld->binding,
 					  &ld->announcable,
 					  &errmsg))
-		fatal("Bad connectd_activate_reply: %s",
+		fatal("Bad connectd_init_reply: %s",
 		      tal_hex(reply, reply));
 
 	/* connectd can fail in *informative* ways: don't use fatal() here and
@@ -549,10 +549,22 @@ int connectd_init(struct lightningd *ld)
 }
 
 static void connect_activate_done(struct subd *connectd,
-				  const u8 *reply UNUSED,
+				  const u8 *reply,
 				  const int *fds UNUSED,
 				  void *unused UNUSED)
 {
+	char *errmsg;
+	if (!fromwire_connectd_activate_reply(reply, reply, &errmsg))
+		fatal("Bad connectd_activate_reply: %s",
+		      tal_hex(reply, reply));
+
+	/* connectd can fail in *informative* ways: don't use fatal() here and
+	 * confuse things with a backtrace! */
+	if (errmsg) {
+		log_broken(connectd->log, "%s", errmsg);
+		exit(1);
+	}
+
 	/* Break out of loop, so we can begin */
 	io_break(connectd);
 }


### PR DESCRIPTION
Aditya had this issue due to a config line, and the result was hard to diagnose even for me.

It's now:

```
$ ./lightningd/lightningd --network=regtest --addr=:18444
2022-02-26T05:01:28.705Z **BROKEN** connectd: Failed to bind socket for 0.0.0.0:18444: Address already in use
```

Whereas before it doesn't even give the address it's trying to bind:

```
rusty@rusty-XPS-13-9370:~/devel/cvs/lightning (master)$ ./lightningd/lightningd --network=regtest --addr=:18444
lightning_connectd: Failed to bind on 2 socket: Address already in use (version v0.10.2-331-g86b83e4)
0x558a8b8d9a12 send_backtrace
	common/daemon.c:33
0x558a8b8e91e1 status_failed
	common/status.c:221
0x558a8b8c8e4f make_listen_fd
	connectd/connectd.c:1090
0x558a8b8c8f55 handle_wireaddr_listen
	connectd/connectd.c:1129
0x558a8b8c993d setup_listeners
	connectd/connectd.c:1312
0x558a8b8ca344 connect_init
	connectd/connectd.c:1517
0x558a8b8cbb57 recv_req
	connectd/connectd.c:1896
0x558a8b8d9f9f handle_read
	common/daemon_conn.c:31
0x558a8b9247c1 next_plan
	ccan/ccan/io/io.c:59
0x558a8b9253c9 do_plan
	ccan/ccan/io/io.c:407
0x558a8b92540b io_ready
	ccan/ccan/io/io.c:417
0x558a8b9276fe io_loop
	ccan/ccan/io/poll.c:453
0x558a8b8cbf36 main
	connectd/connectd.c:2033
0x7fe4d02940b2 ???
	???:0
0x558a8b8c285d ???
	???:0
0xffffffffffffffff ???
	???:0
2022-02-26T05:02:27.547Z **BROKEN** connectd: Failed to bind on 2 socket: Address already in use (version v0.10.2-331-g86b83e4)
2022-02-26T05:02:27.547Z **BROKEN** connectd: backtrace: common/daemon.c:38 (send_backtrace) 0x558a8b8d9a68
2022-02-26T05:02:27.547Z **BROKEN** connectd: backtrace: common/status.c:221 (status_failed) 0x558a8b8e91e1
2022-02-26T05:02:27.547Z **BROKEN** connectd: backtrace: connectd/connectd.c:1090 (make_listen_fd) 0x558a8b8c8e4f
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: connectd/connectd.c:1129 (handle_wireaddr_listen) 0x558a8b8c8f55
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: connectd/connectd.c:1312 (setup_listeners) 0x558a8b8c993d
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: connectd/connectd.c:1517 (connect_init) 0x558a8b8ca344
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: connectd/connectd.c:1896 (recv_req) 0x558a8b8cbb57
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: common/daemon_conn.c:31 (handle_read) 0x558a8b8d9f9f
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x558a8b9247c1
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: ccan/ccan/io/io.c:407 (do_plan) 0x558a8b9253c9
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: ccan/ccan/io/io.c:417 (io_ready) 0x558a8b92540b
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: ccan/ccan/io/poll.c:453 (io_loop) 0x558a8b9276fe
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: connectd/connectd.c:2033 (main) 0x558a8b8cbf36
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: (null):0 ((null)) 0x7fe4d02940b2
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: (null):0 ((null)) 0x558a8b8c285d
2022-02-26T05:02:27.548Z **BROKEN** connectd: backtrace: (null):0 ((null)) 0xffffffffffffffff
2022-02-26T05:02:27.548Z **BROKEN** connectd: STATUS_FAIL_INTERNAL_ERROR: Failed to bind on 2 socket: Address already in use
lightningd: connectd failed (exit status 242), exiting.
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>