### PR TITLE
test_close: sync l1 to the blockchain, so that the events are there

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -548,7 +548,7 @@ def test_penalty_inhtlc(node_factory, bitcoind, executor, chainparams):
 
     bitcoind.generate_block(100)
 
-    sync_blockheight(bitcoind, [l2])
+    sync_blockheight(bitcoind, [l1, l2])
     wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 0)
 
     # Do one last pass over the logs to extract the reactions l2 sent
@@ -677,7 +677,7 @@ def test_penalty_outhtlc(node_factory, bitcoind, executor, chainparams):
     # 100 blocks later, all resolved.
     bitcoind.generate_block(100)
 
-    sync_blockheight(bitcoind, [l2])
+    sync_blockheight(bitcoind, [l1, l2])
     wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 0)
 
     # Do one last pass over the logs to extract the reactions l2 sent


### PR DESCRIPTION
Flake on CI coming from `penalty_in/outhtlc` due to the fact that all
the events haven't arrived for the check.

If we wait to sync `l1` as well as `l2`, this should resolve the flake.

        # We use a subset of tags in expected_2 that are used in expected_1
>       tags = check_utxos_channel(l1, [channel_id], expected_1)

tests/test_closing.py:726:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/utils.py:321: in check_utxos_channel
    txid = matchup_events(u_set, evs, chans, tag_list)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

u_set = [[{'account_id': 'external', 'blockheight': 104, 'coin_type': 'bcrt', 'credit': '100000000msat', ...}, None]]
evs = [('external', ['penalty'], None, None), ('external', ['penalty'], None, None), ('external', ['penalty'], None, None)]
chans = ['2722a5fe49a8b5fa4004c19828f3e903632ac02712c6fe78ebea418daad2691f']
tag_list = {'0': '892c64c7d8c8f15d7bdcdcde34b615817d273d2e33d9d775cc9ff38e8e3deeb2', 'A': '1e69d2aa8d41eaeb78fec61227c02a6303e9f32898c10440fab5a849fea52227', 'B': '0e11e2ca01bf5f30b4c54522af172af055dcff8e3810f80a5069a2394cad74b5'}

    def matchup_events(u_set, evs, chans, tag_list):
>       assert len(u_set) == len(evs) and len(u_set) > 0
E       AssertionError

Changelog-None.