### PR TITLE
Gossip node_announcement more aggressively, allow 2 updates per day for gossip.

### DIFF
--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -214,13 +214,16 @@ static void sign_and_send_nannounce(struct daemon *daemon,
 
 /* Mutual recursion via timer */
 static void update_own_node_announcement_after_startup(struct daemon *daemon);
+static void setup_force_nannounce_regen_timer(struct daemon *daemon);
 
 /* This routine created a `node_announcement` for our node, and hands it to
  * the routing.c code like any other `node_announcement`.  Such announcements
  * are only accepted if there is an announced channel associated with that node
  * (to prevent spam), so we only call this once we've announced a channel. */
 /* Returns true if this sent one, or has arranged to send one in future. */
-static bool update_own_node_announcement(struct daemon *daemon, bool startup)
+static bool update_own_node_announcement(struct daemon *daemon,
+					 bool startup,
+					 bool always_refresh)
 {
 	u32 timestamp = gossip_time_now(daemon->rstate).ts.tv_sec;
 	u8 *nannounce;
@@ -247,6 +250,8 @@ static bool update_own_node_announcement(struct daemon *daemon, bool startup)
 
 		if (!nannounce_different(daemon->rstate->gs, self, nannounce,
 					 &only_missing_tlv)) {
+			if (always_refresh)
+				goto send;
 			return false;
 		}
 
@@ -288,7 +293,12 @@ static bool update_own_node_announcement(struct daemon *daemon, bool startup)
 		}
 	}
 
+send:
 	sign_and_send_nannounce(daemon, nannounce, timestamp);
+
+	/* Generate another one in 24 hours. */
+	setup_force_nannounce_regen_timer(daemon);
+
 	return true;
 }
 
@@ -303,9 +313,35 @@ static void force_self_nannounce_rexmit(struct daemon *daemon)
 static void update_own_node_announcement_after_startup(struct daemon *daemon)
 {
 	/* If that doesn't send one, arrange rexmit anyway */
-	if (!update_own_node_announcement(daemon, false))
+	if (!update_own_node_announcement(daemon, false, false))
 		force_self_nannounce_rexmit(daemon);
 }
+
+/* This creates and transmits a *new* node announcement */
+static void force_self_nannounce_regen(struct daemon *daemon)
+{
+	struct node *self = get_node(daemon->rstate, &daemon->id);
+
+	/* No channels left?  We'll restart timer once we have one. */
+	if (!self || !self->bcast.index)
+		return;
+
+	update_own_node_announcement(daemon, false, true);
+}
+
+/* Because node_announcement propagation is spotty, we rexmit this every
+ * 24 hours. */
+static void setup_force_nannounce_regen_timer(struct daemon *daemon)
+{
+	tal_free(daemon->node_announce_regen_timer);
+	daemon->node_announce_regen_timer
+		= new_reltimer(&daemon->timers,
+			       daemon,
+			       time_from_sec(24 * 3600),
+			       force_self_nannounce_regen,
+			       daemon);
+}
+
 
 /* Should we announce our own node?  Called at strategic places. */
 void maybe_send_own_node_announce(struct daemon *daemon, bool startup)
@@ -318,7 +354,7 @@ void maybe_send_own_node_announce(struct daemon *daemon, bool startup)
 		return;
 
 	/* If we didn't send one, arrange rexmit of existing at startup */
-	if (!update_own_node_announcement(daemon, startup)) {
+	if (!update_own_node_announcement(daemon, startup, false)) {
 		if (startup)
 			force_self_nannounce_rexmit(daemon);
 	}

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -1059,6 +1059,7 @@ int main(int argc, char *argv[])
 	list_head_init(&daemon->peers);
 	daemon->deferred_txouts = tal_arr(daemon, struct short_channel_id, 0);
 	daemon->node_announce_timer = NULL;
+	daemon->node_announce_regen_timer = NULL;
 	daemon->current_blockheight = 0; /* i.e. unknown */
 	daemon->rates = NULL;
 	list_head_init(&daemon->deferred_updates);

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -47,8 +47,11 @@ struct daemon {
 	/* What addresses we can actually announce. */
 	struct wireaddr *announcable;
 
-	/* Timer until we can send a new node_announcement */
+	/* Timer until we can send an updated node_announcement */
 	struct oneshot *node_announce_timer;
+
+	/* Timer until we should force a new new node_announcement */
+	struct oneshot *node_announce_regen_timer;
 
 	/* Channels we have an announce for, but aren't deep enough. */
 	struct short_channel_id *deferred_txouts;

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -33,10 +33,10 @@ struct pending_node_announce {
 	struct peer *peer_softref;
 };
 
-/* We consider a reasonable gossip rate to be 1 per day, with burst of
+/* We consider a reasonable gossip rate to be 2 per day, with burst of
  * 4 per day.  So we use a granularity of one hour. */
-#define TOKENS_PER_MSG 24
-#define TOKEN_MAX (24 * 4)
+#define TOKENS_PER_MSG 12
+#define TOKEN_MAX (12 * 4)
 
 static u8 update_tokens(const struct routing_state *rstate,
 			u8 tokens, u32 prev_timestamp, u32 new_timestamp)

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -406,4 +406,8 @@ void remove_all_gossip(struct routing_state *rstate);
 /* This scid is dead to us. */
 void add_to_txout_failures(struct routing_state *rstate,
 			   const struct short_channel_id *scid);
+
+/* Move this node's announcement to the tail of the gossip_store, to
+ * make everyone send it again. */
+void force_node_announce_rexmit(struct routing_state *rstate, struct node *node);
 #endif /* LIGHTNING_GOSSIPD_ROUTING_H */

--- a/gossipd/test/run-check_node_announcement.c
+++ b/gossipd/test/run-check_node_announcement.c
@@ -36,6 +36,9 @@ struct peer *find_peer(struct daemon *daemon UNNEEDED, const struct node_id *id 
 /* Generated stub for fmt_wireaddr_without_port */
 char *fmt_wireaddr_without_port(const tal_t *ctx UNNEEDED, const struct wireaddr *a UNNEEDED)
 { fprintf(stderr, "fmt_wireaddr_without_port called!\n"); abort(); }
+/* Generated stub for force_node_announce_rexmit */
+void force_node_announce_rexmit(struct routing_state *rstate UNNEEDED, struct node *node UNNEEDED)
+{ fprintf(stderr, "force_node_announce_rexmit called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_local_channel_update */
 bool fromwire_gossipd_local_channel_update(const void *p UNNEEDED, struct node_id *id UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, bool *disable UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, struct amount_msat *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED, struct amount_msat *htlc_maximum_msat UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_local_channel_update called!\n"); abort(); }

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -54,6 +54,9 @@ struct peer *find_peer(struct daemon *daemon UNNEEDED, const struct node_id *id 
 /* Generated stub for fmt_wireaddr_without_port */
 char *fmt_wireaddr_without_port(const tal_t *ctx UNNEEDED, const struct wireaddr *a UNNEEDED)
 { fprintf(stderr, "fmt_wireaddr_without_port called!\n"); abort(); }
+/* Generated stub for force_node_announce_rexmit */
+void force_node_announce_rexmit(struct routing_state *rstate UNNEEDED, struct node *node UNNEEDED)
+{ fprintf(stderr, "force_node_announce_rexmit called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_dev_set_max_scids_encode_size */
 bool fromwire_gossipd_dev_set_max_scids_encode_size(const void *p UNNEEDED, u32 *max UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_dev_set_max_scids_encode_size called!\n"); abort(); }


### PR DESCRIPTION
This should do something to mitigate the propagation issues seen in https://github.com/ElementsProject/lightning/issues/5037, as well as the problem reported that some LND nodes are scheduling daily downtime which causes 2 updates per day. 