### PR TITLE
cli: make the command line more user friendly.

### DIFF
--- a/common/errcode.h
+++ b/common/errcode.h
@@ -14,5 +14,6 @@ typedef s32 errcode_t;
 #define HSM_ERROR_IS_ENCRYPT 21
 #define HSM_BAD_PASSWORD 22
 #define HSM_PASSWORD_INPUT_ERR 23
+#define ERROR_HSM_FILE 24
 
 #endif /* LIGHTNING_COMMON_ERRCODE_H */

--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -1,6 +1,8 @@
 #include "config.h"
+#include <ccan/tal/str/str.h>
 #include <common/errcode.h>
 #include <common/hsm_encryption.h>
+#include <errno.h>
 #include <termios.h>
 #include <unistd.h>
 
@@ -77,6 +79,17 @@ bool decrypt_hsm_secret(const struct secret *encryption_key,
 		return false;
 
 	return true;
+}
+
+/* Returns -1 on error (and sets errno), 0 if not encrypted, 1 if it is */
+int is_hsm_secret_encrypted(const char *path)
+{
+	struct stat st;
+
+        if (stat(path, &st) != 0)
+		return -1;
+
+        return st.st_size == ENCRYPTED_HSM_SECRET_LEN;
 }
 
 void discard_key(struct secret *key TAKES)

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -4,6 +4,7 @@
 #include <bitcoin/privkey.h>
 #include <ccan/tal/tal.h>
 #include <sodium.h>
+#include <sys/stat.h>
 
 /* Length of the encrypted hsm secret header. */
 #define HS_HEADER_LEN crypto_secretstream_xchacha20poly1305_HEADERBYTES
@@ -63,4 +64,6 @@ void discard_key(struct secret *key TAKES);
  */
 char *read_stdin_pass_with_exit_code(char **reason, int *exit_code);
 
+/** Returns -1 on error (and sets errno), 0 if not encrypted, 1 if it is */
+int is_hsm_secret_encrypted(const char *path);
 #endif /* LIGHTNING_COMMON_HSM_ENCRYPTION_H */

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -96,11 +96,9 @@ struct ext_key *hsm_init(struct lightningd *ld)
 	 * not passed, don't let hsmd use the first 32 bytes of the cypher as the
 	 * actual secret. */
 	if (!ld->config.keypass) {
-		struct stat st;
-		if (stat("hsm_secret", &st) == 0 &&
-			 st.st_size == ENCRYPTED_HSM_SECRET_LEN)
+		if (is_hsm_secret_encrypted("hsm_secret") == 1)
 			errx(HSM_ERROR_IS_ENCRYPT, "hsm_secret is encrypted, you need to pass the "
-			        "--encrypted-hsm startup option.");
+			     "--encrypted-hsm startup option.");
 	}
 
 	ld->hsm_fd = fds[0];

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -518,6 +518,12 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	passwd_confirmation = read_stdin_pass_with_exit_code(&err_msg, &opt_exitcode);
 	if (!passwd_confirmation)
 		return err_msg;
+
+	if (!streq(passwd, passwd_confirmation)) {
+		opt_exitcode = HSM_BAD_PASSWORD;
+		return "Passwords confirmation mismatch.";
+	}
+
 	printf("\n");
 
 	ld->config.keypass = tal(NULL, struct secret);

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2064,7 +2064,6 @@ def test_setchannel_state(node_factory, bitcoind):
 
     # Disconnect and unilaterally close from l2 to l1
     l2.rpc.disconnect(l1.info['id'], force=True)
-    l1.rpc.disconnect(l2.info['id'], force=True)
     result = l2.rpc.close(scid, 1)
     assert result['type'] == 'unilateral'
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1039,8 +1039,6 @@ def test_hsm_secret_encryption(node_factory):
                     wait_for_initialized=False)
     l1.daemon.wait_for_log(r'Enter hsm_secret password')
     write_all(master_fd, password[2:].encode("utf-8"))
-    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
-    write_all(master_fd, password[2:].encode("utf-8"))
     assert(l1.daemon.proc.wait(WAIT_TIMEOUT) == HSM_BAD_PASSWORD)
     assert(l1.daemon.is_in_log("Wrong password for encrypted hsm_secret."))
 
@@ -1048,15 +1046,12 @@ def test_hsm_secret_encryption(node_factory):
     l1.daemon.start(stdin=slave_fd, wait_for_initialized=False)
     l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
     write_all(master_fd, password.encode("utf-8"))
-    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
-    write_all(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     assert id == l1.rpc.getinfo()["id"]
     l1.stop()
 
     # We can restore the same wallet with the same password provided through stdin
     l1.daemon.start(stdin=subprocess.PIPE, wait_for_initialized=False)
-    l1.daemon.proc.stdin.write(password.encode("utf-8"))
     l1.daemon.proc.stdin.write(password.encode("utf-8"))
     l1.daemon.proc.stdin.flush()
     l1.daemon.wait_for_log("Server started with public key")
@@ -1137,8 +1132,6 @@ def test_hsmtool_secret_decryption(node_factory):
                     wait_for_initialized=False)
 
     l1.daemon.wait_for_log(r'The hsm_secret is encrypted')
-    write_all(master_fd, password.encode("utf-8"))
-    l1.daemon.wait_for_log(r'Confirm hsm_secret password')
     write_all(master_fd, password.encode("utf-8"))
     l1.daemon.wait_for_log("Server started with public key")
     print(node_id, l1.rpc.getinfo()["id"])


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/5073
Fixes https://github.com/ElementsProject/lightning/issues/4623

This is one of my first attempts to improve the command line UX when we are asking a password to decrypt an `hsm_secret` already encrypted.

In addition, this introduces the check between the password and password confirmation in the cmd option when the password confirmation is provided