### PR TITLE
memleak: make sure we catch children which are also "notleak".

### DIFF
--- a/common/memleak.c
+++ b/common/memleak.c
@@ -267,21 +267,25 @@ static void call_memleak_helpers(struct htable *memtable, const tal_t *p)
 	for (i = tal_first(p); i; i = tal_next(i)) {
 		const char *name = tal_name(i);
 
-		if (name && strends(name, "struct memleak_helper")) {
-			const struct memleak_helper *mh = i;
-			mh->cb(memtable, p);
-		} else if (name && strends(name, " **NOTLEAK**")) {
-			pointer_referenced(memtable, i);
-			memleak_remove_region(memtable, i, tal_bytelen(i));
-		} else if (name && strends(name, " **NOTLEAK_IGNORE_CHILDREN**")) {
-			remove_with_children(memtable, i);
-			memleak_remove_region(memtable, i, tal_bytelen(i));
-		} else if (name && strends(name, "_notleak")) {
-			pointer_referenced(memtable, i);
-			call_memleak_helpers(memtable, i);
-		} else {
-			call_memleak_helpers(memtable, i);
+		if (name) {
+			if (strends(name, "struct memleak_helper")) {
+				const struct memleak_helper *mh = i;
+				mh->cb(memtable, p);
+			} else if (strends(name, " **NOTLEAK**")
+				   || strends(name, "_notleak")) {
+				pointer_referenced(memtable, i);
+				memleak_remove_region(memtable, i,
+						      tal_bytelen(i));
+			} else if (strends(name,
+					   " **NOTLEAK_IGNORE_CHILDREN**")) {
+				remove_with_children(memtable, i);
+				memleak_remove_region(memtable, i,
+						      tal_bytelen(i));
+			}
 		}
+
+		/* Recurse down looking for "notleak" children */
+		call_memleak_helpers(memtable, i);
 	}
 }
 


### PR DESCRIPTION
By not recursing into "notleak" children, we could miss other "notleak"
pointers:

```
2022-03-15T05:25:33.9759500Z lightningd-1: 2022-03-15T05:00:15.998Z **BROKEN** connectd: MEMLEAK: 0x55b29c3d0cc8
2022-03-15T05:25:33.9759901Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:   label=common/timeout.c:22:struct oneshot **NOTLEAK**
2022-03-15T05:25:33.9760195Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:   backtrace:
2022-03-15T05:25:33.9760555Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:     ccan/ccan/tal/tal.c:442 (tal_alloc_)
2022-03-15T05:25:33.9760905Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:     common/timeout.c:22 (new_reltimer_)
2022-03-15T05:25:33.9761272Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:     connectd/multiplex.c:558 (set_closing_timer)
2022-03-15T05:25:33.9761647Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:     connectd/multiplex.c:586 (write_to_peer)
2022-03-15T05:25:33.9761986Z lightningd-1: 2022-03-15T05:00:16.003Z **BROKEN** connectd:     ccan/ccan/io/io.c:59 (next_plan)
2022-03-15T05:25:33.9762335Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     ccan/ccan/io/io.c:435 (io_do_always)
2022-03-15T05:25:33.9762692Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     ccan/ccan/io/poll.c:304 (handle_always)
2022-03-15T05:25:33.9763035Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     ccan/ccan/io/poll.c:385 (io_loop)
2022-03-15T05:25:33.9763376Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     connectd/connectd.c:2131 (main)
2022-03-15T05:25:33.9763645Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:   parents:
2022-03-15T05:25:33.9764020Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     ccan/ccan/io/io.c:91:struct io_conn **NOTLEAK**
2022-03-15T05:25:33.9764471Z lightningd-1: 2022-03-15T05:00:16.004Z **BROKEN** connectd:     connectd/connectd.c:2104:struct daemon
```

Changelog-None