### PR TITLE
fix: Remove \ from help documentation

### DIFF
--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -4,7 +4,7 @@ lightning-help -- Command to return all information about RPC commands.
 SYNOPSIS
 --------
 
-**help** [*command\*]
+**help** [*command*]
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
This fixes one leftover backslash from #5018.