### PR TITLE
Add more warnings to fundchannel_start

### DIFF
--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -43,9 +43,12 @@ RETURN VALUE
 
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
-- **funding_address** (string): The address to send funding to for the channel
+- **funding_address** (string): The address to send funding to for the channel. DO NOT SEND COINS TO THIS ADDRESS YET.
 - **scriptpubkey** (hex): The raw scriptPubkey for the address
 - **close_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close_to* parameter was specified and peer supports `option_upfront_shutdown_script`
+
+The following warnings may also be returned:
+- **warning_usage**: A warning not to prematurely broadcast the funding transaction (always present!)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -79,4 +82,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:eab533b02f2bffecef27724078461ed25f3a9b729c2432b80bbdc35aea670ca2)
+[comment]: # ( SHA256STAMP:acbd9ffb07219bc10e06e8f8bc6772d12ec62650bd30b6ee1084a24f53da2ac2)

--- a/doc/schemas/fundchannel_start.schema.json
+++ b/doc/schemas/fundchannel_start.schema.json
@@ -4,12 +4,13 @@
   "additionalProperties": false,
   "required": [
     "funding_address",
-    "scriptpubkey"
+    "scriptpubkey",
+    "warning_usage"
   ],
   "properties": {
     "funding_address": {
       "type": "string",
-      "description": "The address to send funding to for the channel"
+      "description": "The address to send funding to for the channel. DO NOT SEND COINS TO THIS ADDRESS YET."
     },
     "scriptpubkey": {
       "type": "hex",
@@ -18,6 +19,10 @@
     "close_to": {
       "type": "hex",
       "description": "The raw scriptPubkey which mutual close will go to; only present if *close_to* parameter was specified and peer supports `option_upfront_shutdown_script`"
+    },
+    "warning_usage": {
+      "type": "string",
+      "description": "A warning not to prematurely broadcast the funding transaction (always present!)"
     }
   }
 }

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -283,6 +283,8 @@ static void funding_started_success(struct funding_channel *fc)
 				    fc->funding_scriptpubkey);
 		if (fc->our_upfront_shutdown_script)
 			json_add_hex_talarr(response, "close_to", fc->our_upfront_shutdown_script);
+		json_add_string(response, "warning_usage",
+				"The funding transaction MUST NOT be broadcast until after channel establishment has been successfully completed by running `fundchannel_complete`");
 	}
 
 	/* Clear this so cancel doesn't think it's still in progress */


### PR DESCRIPTION
"A friend" nearly shot himself in the foot by prematurely sending coins to the address returned by this. Apparently he managed to cancel the transaction with a double-spend just in time.

This PR adds some bigger warnings.

Changelog-None