### PR TITLE
lightningd: allow 'style' 'legacy' for clboss compat (with deprecated_apis)

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1358,7 +1358,6 @@ The payload of the hook call has the following format:
 {
   "onion": {
     "payload": "",
-    "type": "legacy",
     "short_channel_id": "1x2x3",
     "forward_amount": "42msat",
     "outgoing_cltv_value": 500014,
@@ -1379,7 +1378,6 @@ For detailed information about each field please refer to [BOLT 04 of the specif
  - `onion`:
    - `payload` contains the unparsed payload that was sent to us from the
    sender of the payment.
-   - `type` is `legacy` for realm 0 payments, `tlv` for realm > 1.
    - `short_channel_id` determines the channel that the sender is hinting
        should be used next.  Not present if we're the final destination.
    - `forward_amount` is the amount we should be forwarding to the next hop,

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -45,7 +45,6 @@ which the above *hops* parameter was generated:
 		"msatoshi": 1002,
 		"amount_msat": "1002msat",
 		"delay": 21,
-		"style": "legacy"
 	}, {
 		"id": "035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d",
 		"channel": "103x1x1",
@@ -53,7 +52,6 @@ which the above *hops* parameter was generated:
 		"msatoshi": 1001,
 		"amount_msat": "1001msat",
 		"delay": 15,
-		"style": "legacy"
 	}, {
 		"id": "0382ce59ebf18be7d84677c2e35f23294b9992ceca95491fcf8a56c6cb2d9de199",
 		"channel": "103x3x1",
@@ -61,7 +59,6 @@ which the above *hops* parameter was generated:
 		"msatoshi": 1000,
 		"amount_msat": "1000msat",
 		"delay": 9,
-		"style": "legacy"
 	}
 ]
 ```

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -284,7 +284,7 @@ On success, an object containing **route** is returned.  It is an array of objec
 - **direction** (u32): 0 if this channel is traversed from lesser to greater **id**, otherwise 1
 - **amount_msat** (msat): The amount expected by the node at the end of this hop
 - **delay** (u32): The total CLTV expected by the node at the end of this hop
-- **style** (string): The features understood by the destination node (one of "legacy", "tlv")
+- **style** (string): The features understood by the destination node (always "tlv")
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -309,4 +309,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0c1f92ff24ae0277fed3cf3fd41f2f45e4a57558a4b61fc51a1a698b4f3d8f01)
+[comment]: # ( SHA256STAMP:3494cb4003abfe32e8942ec5d92d0c464815d5e65edf29087cd2193eb414d694)

--- a/doc/schemas/getroute.schema.json
+++ b/doc/schemas/getroute.schema.json
@@ -48,7 +48,6 @@
             "type": "string",
             "description": "The features understood by the destination node",
             "enum": [
-              "legacy",
               "tlv"
             ]
           }

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1,6 +1,7 @@
 #include "config.h"
 #include <ccan/tal/str/str.h>
 #include <common/bolt12_merkle.h>
+#include <common/configdir.h>
 #include <common/json_command.h>
 #include <common/json_helpers.h>
 #include <common/json_tok.h>
@@ -1330,6 +1331,10 @@ static struct command_result *param_route_hop_style(struct command *cmd,
 	if (json_tok_streq(buffer, tok, "tlv")) {
 		return NULL;
 	}
+
+	/* We still let you *specify* this, but we ignore it! */
+	if (deprecated_apis && json_tok_streq(buffer, tok, "legacy"))
+		return NULL;
 
 	return command_fail_badparam(cmd, name, buffer, tok,
 			    "should be 'tlv' ('legacy' not supported)");

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -771,6 +771,9 @@ static struct command_result *sendrawtransaction(struct command *cmd,
 	} else
 		highfeesarg = NULL;
 
+	/* Keep memleak happy! */
+	tal_free(allowhighfees);
+
 	start_bitcoin_cli(NULL, cmd, process_sendrawtransaction, true,
 			  BITCOIND_HIGH_PRIO, NULL,
 			  "sendrawtransaction",


### PR DESCRIPTION
We keep the parameter around for future use (e.g. PTLC support?), but clboss
master still sets 'style' to "legacy".  Accept, but ignore it.

Reported-by: grubman on #c-lightning (IRC)
Changelog-None: change introduced this release