### PR TITLE
plugins/topology: don't get upset if we hit deleted channel.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -470,9 +470,9 @@ static bool update_channel(struct gossmap *map, size_t cupdate_off)
 
 	scid.u64 = map_be64(map, scid_off);
 	chan = gossmap_find_chan(map, &scid);
+	/* This can happen if channel gets deleted! */
 	if (!chan)
-		errx(1, "update for channel %s not found!",
-		     type_to_string(tmpctx, struct short_channel_id, &scid));
+		return false;
 
 	/* We round this *down*, since too-low min is more conservative */
 	hc.htlc_min = u64_to_fp16(map_be64(map, htlc_minimum_off), false);


### PR DESCRIPTION
There's a race under CI, where a channel is deleted then we see the
channel_update in the gossip store.  We assumed this wouldn't happen,
but it can!

```
[gw1] [ 95%] FAILED tests/test_connection.py::test_multichan
[gw1] [ 95%] ERROR tests/test_connection.py::test_multichan
...
>           raise ValueError(str(errors))
E           ValueError:
E           Node errors:
E            - lightningd-3: had BROKEN messages
E            - lightningd-3: Node exited with return code 1
E           Global errors:
...
lightningd-3: 2022-03-28T00:11:42.160Z DEBUG   wallet: Owning output 0 100000sat (SEGWIT) txid 30616903feba1839a3834e2b3b6123759ce1fe0d76414ca77e2dbc17414772e0 CONFIRMED
lightningd-3: 2022-03-28T00:11:42.392Z DEBUG   hsmd: Client: Received message 5 from client
lightningd-3: 2022-03-28T00:11:42.393Z DEBUG   hsmd: new_client: 2
lightningd-3: 2022-03-28T00:11:42.398Z INFO    plugin-topology: Killing plugin: exited during normal operation
lightningd-3: 2022-03-28T00:11:42.400Z **BROKEN** plugin-topology: Plugin marked as important, shutting down lightningd!
...
----------------------------- Captured stderr call -----------------------------
topology: update for channel 105x1x1 not found!
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>