### PR TITLE
subd: make channel/peer own the subd.

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -590,7 +590,7 @@ void peer_start_channeld(struct channel *channel,
 				  | HSM_CAP_SIGN_ONCHAIN_TX);
 
 	channel_set_owner(channel,
-			  new_channel_subd(ld,
+			  new_channel_subd(channel, ld,
 					   "lightning_channeld",
 					   channel,
 					   &channel->peer->id,

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -364,7 +364,7 @@ void peer_start_closingd(struct channel *channel, struct peer_fd *peer_fd)
 				  | HSM_CAP_COMMITMENT_POINT);
 
 	channel_set_owner(channel,
-			  new_channel_subd(ld,
+			  new_channel_subd(channel, ld,
 					   "lightning_closingd",
 					   channel, &channel->peer->id,
 					   channel->log, true,

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -3219,7 +3219,8 @@ bool peer_start_dualopend(struct peer *peer,
 				  | HSM_CAP_SIGN_REMOTE_TX
 				  | HSM_CAP_SIGN_WILL_FUND_OFFER);
 
-	channel->owner = new_channel_subd(peer->ld,
+	channel->owner = new_channel_subd(channel,
+					  peer->ld,
 					  "lightning_dualopend",
 					  channel,
 					  &peer->id,
@@ -3286,7 +3287,8 @@ void peer_restart_dualopend(struct peer *peer,
 				  | HSM_CAP_SIGN_WILL_FUND_OFFER);
 
 	channel_set_owner(channel,
-			  new_channel_subd(peer->ld, "lightning_dualopend",
+			  new_channel_subd(channel, peer->ld,
+					   "lightning_dualopend",
 					   channel,
 					   &peer->id,
 					   channel->log, true,

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -619,7 +619,7 @@ enum watch_result onchaind_funding_spent(struct channel *channel,
 				  HSM_CAP_SIGN_ONCHAIN_TX
 				  | HSM_CAP_COMMITMENT_POINT);
 
-	channel_set_owner(channel, new_channel_subd(ld,
+	channel_set_owner(channel, new_channel_subd(channel, ld,
 						    "lightning_onchaind",
 						    channel,
 						    &channel->peer->id,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -867,7 +867,7 @@ bool peer_start_openingd(struct peer *peer, struct peer_fd *peer_fd)
 				  HSM_CAP_COMMITMENT_POINT
 				  | HSM_CAP_SIGN_REMOTE_TX);
 
-	uc->open_daemon = new_channel_subd(peer->ld,
+	uc->open_daemon = new_channel_subd(peer, peer->ld,
 					"lightning_openingd",
 					uc, &peer->id, uc->log,
 					true, openingd_wire_name,

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -690,7 +690,8 @@ static struct io_plan *msg_setup(struct io_conn *conn, struct subd *sd)
 			 msg_send_next(conn, sd));
 }
 
-static struct subd *new_subd(struct lightningd *ld,
+static struct subd *new_subd(const tal_t *ctx,
+			     struct lightningd *ld,
 			     const char *name,
 			     void *channel,
 			     const struct node_id *node_id,
@@ -710,7 +711,7 @@ static struct subd *new_subd(struct lightningd *ld,
 						 const char *happenings),
 			     va_list *ap)
 {
-	struct subd *sd = tal(ld, struct subd);
+	struct subd *sd = tal(ctx, struct subd);
 	int msg_fd;
 	const char *debug_subd = NULL;
 	const char *shortname;
@@ -791,7 +792,7 @@ struct subd *new_global_subd(struct lightningd *ld,
 	struct subd *sd;
 
 	va_start(ap, msgcb);
-	sd = new_subd(ld, name, NULL, NULL, NULL, false,
+	sd = new_subd(ld, ld, name, NULL, NULL, NULL, false,
 		      msgname, msgcb, NULL, NULL, &ap);
 	va_end(ap);
 
@@ -799,7 +800,8 @@ struct subd *new_global_subd(struct lightningd *ld,
 	return sd;
 }
 
-struct subd *new_channel_subd_(struct lightningd *ld,
+struct subd *new_channel_subd_(const tal_t *ctx,
+			       struct lightningd *ld,
 			       const char *name,
 			       void *channel,
 			       const struct node_id *node_id,
@@ -822,7 +824,7 @@ struct subd *new_channel_subd_(struct lightningd *ld,
 	struct subd *sd;
 
 	va_start(ap, billboardcb);
-	sd = new_subd(ld, name, channel, node_id, base_log,
+	sd = new_subd(ctx, ld, name, channel, node_id, base_log,
 		      talks_to_peer, msgname, msgcb, errcb, billboardcb, &ap);
 	va_end(ap);
 	return sd;

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -104,6 +104,7 @@ struct subd *new_global_subd(struct lightningd *ld,
 
 /**
  * new_channel_subd - create a new subdaemon for a specific channel.
+ * @ctx: context to allocate from (usually peer or channel)
  * @ld: global state
  * @name: basename of daemon
  * @channel: channel to associate.
@@ -120,7 +121,8 @@ struct subd *new_global_subd(struct lightningd *ld,
  * that many @fds are received before calling again.  If it returns -1, the
  * subdaemon is shutdown.
  */
-struct subd *new_channel_subd_(struct lightningd *ld,
+struct subd *new_channel_subd_(const tal_t *ctx,
+			       struct lightningd *ld,
 			       const char *name,
 			       void *channel,
 			       const struct node_id *node_id,
@@ -139,10 +141,10 @@ struct subd *new_channel_subd_(struct lightningd *ld,
 						   const char *happenings),
 			       ...);
 
-#define new_channel_subd(ld, name, channel, node_id, log, 		\
+#define new_channel_subd(ctx, ld, name, channel, node_id, log, 		\
 			 talks_to_peer, msgname, msgcb, errcb, 		\
 			 billboardcb, ...)				\
-	new_channel_subd_((ld), (name), (channel), (node_id), 		\
+	new_channel_subd_((ctx), (ld), (name), (channel), (node_id),	\
 			  (log), (talks_to_peer),			\
 			  (msgname), (msgcb),				\
 			  typesafe_cb_postargs(void, void *, (errcb),	\


### PR DESCRIPTION
We get some memleak reports because ld owns the subd, but once
the peer/channel is freed, there's no reference for the brief time
until the subd exits.

This happens for both opening and closingd.  For openingd, the
peer owns it, for others (including dualopend) the channel owns it.