### PR TITLE
docs: use poetry in the osx installation process

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -241,6 +241,7 @@ If you need Python 3.x for mako (or get a mako build error):
     $ source ~/.bash_profile
     $ pyenv install 3.7.4
     $ pip install --upgrade pip
+    $ pip install poetry
 
 If you don't have bitcoind installed locally you'll need to install that
 as well:
@@ -257,16 +258,11 @@ Clone lightning:
     $ git clone https://github.com/ElementsProject/lightning.git
     $ cd lightning
 
-Configure Python 3.x & get mako:
-
-    $ pyenv local 3.7.4
-    $ pip install mako
-
 Build lightning:
 
-    $ pip install -r requirements.txt
+    $ poetry install
     $ ./configure
-    $ make
+    $ poetry run make
 
 Running lightning:
 


### PR DESCRIPTION
During some onboarding of summer of bitcoin guys, I noted that our installation process for osx was outdated

Fixes https://github.com/ElementsProject/lightning/issues/5156

Changelog-None: docs: use poetry in the osx installation process
