### PR TITLE
rpc-plugin: introduce the possibility to disable important plugins

### DIFF
--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -30,6 +30,7 @@ showing default values (\fBdev-\fR options are not shown)\.
 
 On success, an object is returned, containing:
 
+
 .RS
 .IP \[bu]
 \fB# version\fR (string, optional): Special field indicating the current version
@@ -93,6 +94,8 @@ On success, an object is returned, containing:
 \fBexperimental-shutdown-wrong-funding\fR (boolean, optional): \fBexperimental-shutdown-wrong-funding\fR field from config or cmdline, or default
 .IP \[bu]
 \fBexperimental-websocket-port\fR (u16, optional): \fBexperimental-websocket-port\fR field from config or cmdline, or default
+.IP \[bu]
+\fBgrpc-port\fR (u64, optional): \fBgrpc-port\fR field from config or cmdline, or default
 .IP \[bu]
 \fBrgb\fR (hex, optional): \fBrgb\fR field from config or cmdline, or default (always 6 characters)
 .IP \[bu]
@@ -169,6 +172,7 @@ On success, an object is returned, containing:
 .RE
 
 On failure, one of the following error codes may be returned:
+
 
 .RS
 .IP \[bu]
@@ -282,4 +286,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:8d8f73010f55f3af6e050c944cf7670109224b3cf3166cc754047f6e20beef20
+\" SHA256STAMP:ab721971acdc262075500c3f6b9cbe3d85f10bf50303f221ff1995e7f30986ef

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -57,6 +57,7 @@ On success, an object is returned, containing:
 - **experimental-offers** (boolean, optional): `experimental-offers` field from config or cmdline, or default
 - **experimental-shutdown-wrong-funding** (boolean, optional): `experimental-shutdown-wrong-funding` field from config or cmdline, or default
 - **experimental-websocket-port** (u16, optional): `experimental-websocket-port` field from config or cmdline, or default
+- **grpc-port** (u64, optional): `grpc-port` field from config or cmdline, or default
 - **rgb** (hex, optional): `rgb` field from config or cmdline, or default (always 6 characters)
 - **alias** (string, optional): `alias` field from config or cmdline, or default
 - **pid-file** (string, optional): `pid-file` field from config or cmdline, or default
@@ -211,4 +212,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:ebc37d1f9cb452d312285a8168d2bb6da2d1dba08db56bbb8d3d7f47b58d7fa4)
+[comment]: # ( SHA256STAMP:197e7e6f3a6aa9a7925d4a2b0463386a2efd26a9b8807bba8bed8a387223b035)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -465,12 +465,12 @@ all DNS lookups, to avoid leaking information.
 Disable the DNS bootstrapping mechanism to find a node by its node ID.
 
  **tor-service-password**=*PASSWORD*
-Set a Tor control password, which may be needed for *autotor:* to
+Set a Tor control password, which may be needed for *autotor:** to
 authenticate to the Tor control port.
 
-  **grpc-port**=*PORT*
-Set the port where the GRPC server will listen incoming request, if
-it is not specified, the GRPC server is disabled.
+ **grpc-port**=*PORT*
+Set the port where the GRPC server will listen incoming request, if it
+is not set no server is started.
 
 ### Lightning Plugins
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -468,6 +468,10 @@ Disable the DNS bootstrapping mechanism to find a node by its node ID.
 Set a Tor control password, which may be needed for *autotor:* to
 authenticate to the Tor control port.
 
+  **grpc-port**=*PORT*
+Set the port where the GRPC server will listen incoming request, if
+it is not specified, the GRPC server is disabled.
+
 ### Lightning Plugins
 
 lightningd(8) supports plugins, which offer additional configuration

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -129,6 +129,10 @@
       "type": "u16",
       "description": "`experimental-websocket-port` field from config or cmdline, or default"
     },
+    "grpc-port": {
+      "type": "u64",
+      "description": "`grpc-port` field from config or cmdline, or default"
+    },
     "rgb": {
       "type": "hex",
       "description": "`rgb` field from config or cmdline, or default",

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -30,7 +30,7 @@ PLUGIN_OFFERS_HEADER := $(PLUGIN_OFFERS_SRC:.c=.h)
 
 PLUGIN_FETCHINVOICE_SRC := plugins/fetchinvoice.c
 PLUGIN_FETCHINVOICE_OBJS := $(PLUGIN_FETCHINVOICE_SRC:.c=.o)
-PLUGIN_FETCHINVOICE_HEADER := 
+PLUGIN_FETCHINVOICE_HEADER :=
 
 PLUGIN_SPENDER_SRC :=				\
 	plugins/spender/fundchannel.c		\
@@ -168,16 +168,6 @@ plugins/fetchinvoice: bitcoin/chainparams.o $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN
 
 plugins/funder: bitcoin/chainparams.o bitcoin/psbt.o common/psbt_open.o $(PLUGIN_FUNDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
-ifneq ($(RUST),0)
-# Builtin plugins must be in this plugins dir to work when we're executed
-# *without* make install.
-plugins/cln-grpc: target/${RUST_PROFILE}/cln-grpc
-	@cp $< $@
-
-DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) plugins/cln-grpc
-PLUGINS += plugins/cln-grpc
-endif
-
 # Generated from PLUGINS definition in plugins/Makefile
 ALL_C_HEADERS += plugins/list_of_builtin_plugins_gen.h
 plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile
@@ -191,5 +181,15 @@ ${CLN_PLUGIN_EXAMPLES}: ${CLN_PLUGIN_SRC}
 
 target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC}
 	cargo build ${CARGO_OPTS} --bin cln-grpc
+
+ifneq ($(RUST),0)
+# Builtin plugins must be in this plugins dir to work when we're executed
+# *without* make install.
+plugins/cln-grpc: target/${RUST_PROFILE}/cln-grpc
+	@cp $< $@
+
+DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) plugins/cln-grpc
+PLUGINS += plugins/cln-grpc
+endif
 
 include plugins/test/Makefile

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -168,6 +168,11 @@ plugins/fetchinvoice: bitcoin/chainparams.o $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN
 
 plugins/funder: bitcoin/chainparams.o bitcoin/psbt.o common/psbt_open.o $(PLUGIN_FUNDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
+ifneq ($(RUST),0)
+DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) target/${RUST_PROFILE}/cln-grpc
+PLUGINS += target/${RUST_PROFILE}/cln-grpc
+endif
+
 # Generated from PLUGINS definition in plugins/Makefile
 ALL_C_HEADERS += plugins/list_of_builtin_plugins_gen.h
 plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile
@@ -181,9 +186,5 @@ ${CLN_PLUGIN_EXAMPLES}: ${CLN_PLUGIN_SRC}
 
 target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC}
 	cargo build ${CARGO_OPTS} --bin cln-grpc
-
-ifneq ($(RUST),0)
-DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) target/${RUST_PROFILE}/cln-grpc
-endif
 
 include plugins/test/Makefile

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -169,8 +169,13 @@ plugins/fetchinvoice: bitcoin/chainparams.o $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN
 plugins/funder: bitcoin/chainparams.o bitcoin/psbt.o common/psbt_open.o $(PLUGIN_FUNDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
 ifneq ($(RUST),0)
-DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) target/${RUST_PROFILE}/cln-grpc
-PLUGINS += target/${RUST_PROFILE}/cln-grpc
+# Builtin plugins must be in this plugins dir to work when we're executed
+# *without* make install.
+plugins/cln-grpc: target/${RUST_PROFILE}/cln-grpc
+	@cp $< $@
+
+DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) plugins/cln-grpc
+PLUGINS += plugins/cln-grpc
 endif
 
 # Generated from PLUGINS definition in plugins/Makefile

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -5,14 +5,9 @@ extern crate serde_json;
 use cln_plugin::{options, Builder, Error, Plugin};
 use tokio;
 
-#[derive(Clone, Debug)]
-struct PluginState;
-
-impl cln_plugin::PluginState for PluginState {}
-
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let plugin = Builder::new(PluginState{}, tokio::io::stdin(), tokio::io::stdout())
+    let plugin = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
         .option(options::ConfigOption::new(
             "test-option",
             options::Value::Integer(42),
@@ -26,16 +21,22 @@ async fn main() -> Result<(), anyhow::Error> {
     plugin.join().await
 }
 
-async fn testmethod(_p: Plugin<PluginState>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn testmethod(
+    _p: Plugin<()>,
+    _v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
 }
 
-async fn connect_handler(_p: Plugin<PluginState>, v: serde_json::Value) -> Result<(), Error> {
+async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
     log::info!("Got a connect notification: {}", v);
     Ok(())
 }
 
-async fn peer_connected_handler(_p: Plugin<PluginState>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn peer_connected_handler(
+    _p: Plugin<()>,
+    v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
     log::info!("Got a connect hook call: {}", v);
     Ok(json!({"result": "continue"}))
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -4,9 +4,15 @@
 extern crate serde_json;
 use cln_plugin::{options, Builder, Error, Plugin};
 use tokio;
+
+#[derive(Clone, Debug)]
+struct PluginState;
+
+impl cln_plugin::PluginState for PluginState {}
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let plugin = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
+    let plugin = Builder::new(PluginState{}, tokio::io::stdin(), tokio::io::stdout())
         .option(options::ConfigOption::new(
             "test-option",
             options::Value::Integer(42),
@@ -20,16 +26,16 @@ async fn main() -> Result<(), anyhow::Error> {
     plugin.join().await
 }
 
-async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn testmethod(_p: Plugin<PluginState>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
 }
 
-async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
+async fn connect_handler(_p: Plugin<PluginState>, v: serde_json::Value) -> Result<(), Error> {
     log::info!("Got a connect notification: {}", v);
     Ok(())
 }
 
-async fn peer_connected_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn peer_connected_handler(_p: Plugin<PluginState>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
     log::info!("Got a connect hook call: {}", v);
     Ok(json!({"result": "continue"}))
 }

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -21,10 +21,7 @@ async fn main() -> Result<(), anyhow::Error> {
     plugin.join().await
 }
 
-async fn testmethod(
-    _p: Plugin<()>,
-    _v: serde_json::Value,
-) -> Result<serde_json::Value, Error> {
+async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
 }
 

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -12,6 +12,8 @@ anyhow = "1.0"
 log = "0.4"
 prost = "0.8"
 rcgen = { version = "0.8", features = ["pem", "x509-parser"] }
+serde = { version = "1.0.131", features = ["derive"] }
+serde_json = "1.0.72"
 
 [dependencies.cln-grpc]
 path = "../../cln-grpc"

--- a/plugins/src/codec.rs
+++ b/plugins/src/codec.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use std::{io, str};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::messages::{Notification, Request};
 pub use crate::messages::JsonRpc;
+use crate::messages::{Notification, Request};
 
 /// A simple codec that parses messages separated by two successive
 /// `\n` newlines.

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -294,12 +294,14 @@ where
                 let resp = callback(self.state.clone(), serde_json::to_value(&call.options)?).await;
                 match resp {
                     Ok(result) => {
-                        let init_resp = serde_json::from_value::<messages::InitResponse>(result).unwrap();
-                        info!(
-                            "send custom init response {:?}",
-                            json!(&init_resp)
-                        );
-                        Ok(init_resp.clone())
+                        let init_resp = serde_json::from_value::<messages::InitResponse>(result);
+                        match init_resp {
+                            Ok(response) => {
+                                info!("send custom init response {:?}", response);
+                                Ok(response.clone())
+                            }
+                            Err(_) => Ok(messages::InitResponse::default()),
+                        }
                     }
                     Err(_) => Ok(messages::InitResponse::default()),
                 }

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -280,16 +280,10 @@ where
             }
         }
 
-        match self.state.disable_reason() {
-            Some(reason) => {
-                let init_resp = messages::InitResponse{
-                    disable: Some(reason),
-                };
-                Ok(init_resp)
-            },
-            None => Ok(messages::InitResponse::default()),
-        }
-
+        let init_resp = messages::InitResponse{
+            disable: self.state.disable_reason(),
+        };
+        Ok(init_resp)
     }
 }
 

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -132,6 +132,11 @@ pub(crate) struct GetManifestResponse {
 }
 
 #[derive(Serialize, Default, Debug)]
-pub struct InitResponse {}
+pub(crate) struct InitResponse {
+    /// enable the possibility to disable the plugins
+    /// when are marked as important.
+    #[serde(default)]
+    pub(crate) disable: Option<String>,
+}
 
 pub trait Response: Serialize + Debug {}

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -132,9 +132,9 @@ pub(crate) struct GetManifestResponse {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
-pub(crate) struct InitResponse{
+pub(crate) struct InitResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) disabled: Option<String>,
+    pub(crate) disable: Option<String>,
 }
 
 pub trait Response: Serialize + Debug {}

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -135,7 +135,7 @@ pub(crate) struct GetManifestResponse {
 pub(crate) struct InitResponse {
     /// enable the possibility to disable the plugins
     /// when are marked as important.
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) disable: Option<String>,
 }
 

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -41,7 +41,7 @@ pub(crate) enum Request {
 #[serde(tag = "method", content = "params")]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Notification {
-//     ChannelOpened,
+    //     ChannelOpened,
 //     ChannelOpenFailed,
 //     ChannelStateChanged,
 //     Connect,
@@ -131,12 +131,10 @@ pub(crate) struct GetManifestResponse {
     pub(crate) hooks: Vec<String>,
 }
 
-#[derive(Serialize, Default, Debug)]
-pub(crate) struct InitResponse {
-    /// enable the possibility to disable the plugins
-    /// when are marked as important.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub(crate) struct InitResponse{
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) disable: Option<String>,
+    pub(crate) disabled: Option<String>,
 }
 
 pub trait Response: Serialize + Debug {}

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -1,5 +1,5 @@
 use serde::ser::{SerializeStruct, Serializer};
-use serde::{Serialize};
+use serde::Serialize;
 
 #[derive(Clone, Debug)]
 pub enum Value {

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -177,7 +177,7 @@ def test_grpc_no_auto_start(node_factory):
     })
 
     wait_for(lambda: [p for p in l1.rpc.plugin('list')['plugins'] if 'cln-grpc' in p['name']] == [])
-    assert l1.daemon.is_in_log(r'plugin-cln-grpc: Killing plugin: exited during normal operation')
+    assert l1.daemon.is_in_log(r'plugin-cln-grpc: Killing plugin: disabled itself at init')
 
 
 def test_grpc_wrong_auth(node_factory):


### PR DESCRIPTION
Build on top of https://github.com/ElementsProject/lightning/pull/5166

This required some work to do, but I think this should be one of the general idea.

Another one that can be an alternative is keep the plugin active and maintains add two rpc method like `start_grpc` and `stop_grpc` but for now, I choose the simple think