### PR TITLE
Disable grpc plugin if `grpc-port` is not set

### DIFF
--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -40,19 +40,22 @@ async fn main() -> Result<()> {
     let bind_port = match plugin.option("grpc-port") {
         Some(options::Value::Integer(-1)) => {
             log::info!("`grpc-port` option is not configured, exiting.");
-            return Ok(());
+            None
         }
-        Some(options::Value::Integer(i)) => i,
+        Some(options::Value::Integer(i)) => Some(i),
         None => return Err(anyhow!("Missing 'grpc-port' option")),
         Some(o) => return Err(anyhow!("grpc-port is not a valid integer: {:?}", o)),
     };
-    let bind_addr: SocketAddr = format!("0.0.0.0:{}", bind_port).parse().unwrap();
 
-    tokio::spawn(async move {
-        if let Err(e) = run_interface(bind_addr, state).await {
-            warn!("Error running the grpc interface: {}", e);
-        }
-    });
+    if let Some(bind_port) = bind_port {
+        let bind_addr: SocketAddr = format!("0.0.0.0:{}", bind_port).parse().unwrap();
+
+        tokio::spawn(async move {
+            if let Err(e) = run_interface(bind_addr, state).await {
+                warn!("Error running the grpc interface: {}", e);
+            }
+        });
+    }
 
     plugin.join().await
 }

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -132,6 +132,9 @@ pub(crate) struct GetManifestResponse {
 }
 
 #[derive(Serialize, Default, Debug)]
-pub struct InitResponse {}
+pub struct InitResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable: Option<String>,
+}
 
 pub trait Response: Serialize + Debug {}

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -176,8 +176,8 @@ def test_grpc_no_auto_start(node_factory):
         "plugin": str(bin_path),
     })
 
-    l1.daemon.logsearch_start = 0
-    assert l1.daemon.is_in_log(r'plugin-cln-grpc: Killing plugin: exited during normal operation')
+    wait_for(lambda: [p for p in l1.rpc.plugin('list')['plugins'] if 'cln-grpc' in p['name']] == [])
+    assert l1.daemon.is_in_log(r'plugin-cln-grpc: Killing plugin: disabled itself at init')
 
 
 def test_grpc_wrong_auth(node_factory):

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -176,7 +176,7 @@ def test_grpc_no_auto_start(node_factory):
         "plugin": str(bin_path),
     })
 
-    wait_for(lambda: [p for p in l1.rpc.plugin('list')['plugins'] if 'cln-grpc' in p['name']] == [])
+    l1.daemon.logsearch_start = 0
     assert l1.daemon.is_in_log(r'plugin-cln-grpc: Killing plugin: exited during normal operation')
 
 


### PR DESCRIPTION
Alternative to #5173. This is relatively simple, and just disables listening, but doesn't exit if `grpc-port` isn't set, so we don't need to disable the plugin itself.
This is a quick fix, until we find a good way of doing `init` callbacks that are clean.