### PR TITLE
use full path to reference `lightningd.c`

### DIFF
--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -18,7 +18,7 @@ It's in C, to encourage alternate implementations.  Patches are welcome!
 You should read our [Style Guide](STYLE.md).
 
 To read the code, you should start from
-[lightningd.c](../lightningd/lightningd.c) and hop your way through
+[lightningd.c](https://github.com/ElementsProject/lightning/blob/master/lightningd/lightningd.c) and hop your way through
 the '~' comments at the head of each daemon in the suggested
 order.
 


### PR DESCRIPTION
The relative path makes for a difficult experience when people are reading on `https://lightning.readthedocs.io/`. Directly linking saves the reader a few clicks hunting down the correct location :)

Current experience:
<img width="1104" alt="image" src="https://user-images.githubusercontent.com/13646076/162593906-5cd7234b-6d69-4963-90b3-59d04fe83556.png">
<img width="824" alt="image" src="https://user-images.githubusercontent.com/13646076/162593952-452c3ae8-8b75-451e-9cc5-87407665a065.png">