### PR TITLE
dualopend: handle dev_memleak during RBF.

### DIFF
--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -3061,6 +3061,13 @@ static void rbf_wrap_up(struct state *state,
 	wire_sync_write(REQ_FD, take(msg));
 	msg = wire_sync_read(tmpctx, REQ_FD);
 
+#if DEVELOPER
+	while (fromwire_dualopend_dev_memleak(msg)) {
+		handle_dev_memleak(state, msg);
+		msg = wire_sync_read(tmpctx, REQ_FD);
+	}
+#endif
+
 	if ((msg_type = fromwire_peektype(msg)) == WIRE_DUALOPEND_FAIL) {
 		if (!fromwire_dualopend_fail(msg, msg, &err_reason))
 			master_badmsg(msg_type, msg);


### PR DESCRIPTION
Happens in CI:

```
lightningd-2: 2022-04-10T15:30:40.788Z **BROKEN** 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-dualopend-chan#1: STATUS_FAIL_MASTER_IO: Error parsing 7507: 1b79
```

Changelog-None