### PR TITLE
Changed external/libwally-core to 0.8.5 release

### DIFF
--- a/common/blinding.c
+++ b/common/blinding.c
@@ -35,6 +35,6 @@ bool blinding_next_privkey(const struct privkey *e,
 			   struct privkey *next)
 {
 	*next = *e;
-	return secp256k1_ec_privkey_tweak_mul(secp256k1_ctx, next->secret.data,
+	return secp256k1_ec_seckey_tweak_mul(secp256k1_ctx, next->secret.data,
 					      h->u.u8) == 1;
 }

--- a/common/bolt12.c
+++ b/common/bolt12.c
@@ -83,6 +83,7 @@ bool bolt12_check_signature(const struct tlv_field *fields,
 	return secp256k1_schnorrsig_verify(secp256k1_ctx,
 					   sig->u8,
 					   shash.u.u8,
+					   sizeof(shash.u.u8),
 					   &key->pubkey) == 1;
 }
 

--- a/common/key_derive.c
+++ b/common/key_derive.c
@@ -84,7 +84,7 @@ bool derive_simple_privkey(const struct secret *base_secret,
 #endif
 
 	key->secret = *base_secret;
-	if (secp256k1_ec_privkey_tweak_add(secp256k1_ctx, key->secret.data,
+	if (secp256k1_ec_seckey_tweak_add(secp256k1_ctx, key->secret.data,
 					   sha.u.u8) != 1)
 		return false;
 #ifdef SUPERVERBOSE
@@ -207,7 +207,7 @@ bool derive_revocation_privkey(const struct secret *base_secret,
 #endif
 
 	key->secret = *base_secret;
-	if (secp256k1_ec_privkey_tweak_mul(secp256k1_ctx, key->secret.data,
+	if (secp256k1_ec_seckey_tweak_mul(secp256k1_ctx, key->secret.data,
 					   sha.u.u8)
 	    != 1)
 		return false;
@@ -229,7 +229,7 @@ bool derive_revocation_privkey(const struct secret *base_secret,
 #endif
 
 	part2 = *per_commitment_secret;
-	if (secp256k1_ec_privkey_tweak_mul(secp256k1_ctx, part2.data,
+	if (secp256k1_ec_seckey_tweak_mul(secp256k1_ctx, part2.data,
 					   sha.u.u8) != 1)
 		return false;
 #ifdef SUPERVERBOSE
@@ -239,7 +239,7 @@ bool derive_revocation_privkey(const struct secret *base_secret,
 		printf("# = 0x%s\n", tal_hexstr(tmpctx, &part2, sizeof(part2)));
 #endif
 
-	if (secp256k1_ec_privkey_tweak_add(secp256k1_ctx, key->secret.data,
+	if (secp256k1_ec_seckey_tweak_add(secp256k1_ctx, key->secret.data,
 					   part2.data) != 1)
 		return false;
 

--- a/devtools/bolt12-cli.c
+++ b/devtools/bolt12-cli.c
@@ -321,6 +321,7 @@ static bool print_signature(const char *messagename,
 	if (secp256k1_schnorrsig_verify(secp256k1_ctx,
 					sig->u8,
 					shash.u.u8,
+					sizeof(shash.u.u8),
 					&node_id->pubkey) != 1) {
 		fprintf(stderr, "%s: INVALID\n", fieldname);
 		return false;

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -635,10 +635,10 @@ static u8 *handle_sign_bolt12(struct hsmd_client *c, const u8 *msg_in)
 		}
 	}
 
-	if (!secp256k1_schnorrsig_sign(secp256k1_ctx, sig.u8,
+	if (!secp256k1_schnorrsig_sign32(secp256k1_ctx, sig.u8,
 				       sha.u.u8,
 				       &kp,
-				       NULL, NULL)) {
+				       NULL)) {
 		return hsmd_status_bad_request_fmt(c, msg_in,
 						   "Failed to sign bolt12");
 	}

--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -77,7 +77,7 @@ static void hsm_sign_b12(struct lightningd *ld,
 	/* Now we sanity-check! */
 	sighash_from_merkle(messagename, fieldname, merkle, &sighash);
 	if (secp256k1_schnorrsig_verify(secp256k1_ctx, sig->u8,
-					sighash.u.u8, &key->pubkey) != 1)
+					sighash.u.u8, sizeof(sighash.u.u8), &key->pubkey) != 1)
 		fatal("HSM gave bad signature %s for pubkey %s",
 		      type_to_string(tmpctx, struct bip340sig, sig),
 		      type_to_string(tmpctx, struct point32, key));

--- a/plugins/fetchinvoice.c
+++ b/plugins/fetchinvoice.c
@@ -218,7 +218,7 @@ static struct command_result *handle_invreq_response(struct command *cmd,
 
 	if (!inv->signature
 	    || secp256k1_schnorrsig_verify(secp256k1_ctx, inv->signature->u8,
-					   sighash.u.u8, &inv->node_id->pubkey) != 1) {
+					   sighash.u.u8, sizeof(sighash.u.u8), &inv->node_id->pubkey) != 1) {
 		badfield = "signature";
 		goto badinv;
 	}
@@ -1198,11 +1198,11 @@ force_payer_secret(struct command *cmd,
 		sighash_from_merkle("invoice_request", "signature", &merkle, &sha);
 
 	sent->invreq->signature = tal(invreq, struct bip340sig);
-	if (!secp256k1_schnorrsig_sign(secp256k1_ctx,
+	if (!secp256k1_schnorrsig_sign32(secp256k1_ctx,
 				       sent->invreq->signature->u8,
 				       sha.u.u8,
 				       &kp,
-				       NULL, NULL)) {
+				       NULL)) {
 		return command_fail(cmd, LIGHTNINGD,
 				    "Failed to sign with payer_secret");
 	}

--- a/plugins/offers_inv_hook.c
+++ b/plugins/offers_inv_hook.c
@@ -387,6 +387,7 @@ struct command_result *handle_invoice(struct command *cmd,
 	if (secp256k1_schnorrsig_verify(secp256k1_ctx,
 					inv->inv->signature->u8,
 					shash.u.u8,
+					sizeof(shash.u.u8),
 					&inv->inv->node_id->pubkey) != 1) {
 		return fail_inv(cmd, inv, "Bad signature");
 	}

--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -433,7 +433,7 @@ static bool check_payer_sig(struct command *cmd,
 
 	if (secp256k1_schnorrsig_verify(secp256k1_ctx,
 					sig->u8,
-					sighash.u.u8, &payer_key->pubkey) == 1)
+					sighash.u.u8, sizeof(sighash.u.u8), &payer_key->pubkey) == 1)
 		return true;
 
 	if (!deprecated_apis)
@@ -447,7 +447,7 @@ static bool check_payer_sig(struct command *cmd,
 
 	return secp256k1_schnorrsig_verify(secp256k1_ctx,
 					   sig->u8,
-					   sighash.u.u8, &payer_key->pubkey) == 1;
+					   sighash.u.u8, sizeof(sighash.u.u8), &payer_key->pubkey) == 1;
 }
 
 static struct command_result *invreq_amount_by_quantity(struct command *cmd,


### PR DESCRIPTION
Combined with the following commit which is required to
update against changed libsecp256k1 APIs:

Updated deprecated function calls

This is #5172 squished into a single commit (so it doesn't break bisect!) and removing the extraneous commit.
Changelog-None