### PR TITLE
connectd: avoid use-after-free on reconnect with remote_addr.

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -269,7 +269,7 @@ static struct io_plan *peer_reconnected(struct io_conn *conn,
 	pr->id = *id;
 	pr->cs = *cs;
 	pr->addr = *addr;
-	pr->remote_addr = remote_addr;
+	pr->remote_addr = tal_dup_or_null(pr, struct wireaddr, remote_addr);
 	pr->incoming = incoming;
 
 	/*~ Note that tal_dup_talarr() will do handle the take() of features


### PR DESCRIPTION
I was seeing a strange crash:
	Connectd gave bad CONNECT_PEER_CONNECTED message

The message is indeed mangled, around the remote_addr!
A quick review of the code revealed that we were not making a copy
when it was a reconnect, and so the remote_addr pointer was pointing
to memory which was freed.

Changelog-None