### PR TITLE
remove shell git from make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #! /usr/bin/make
 
 # Extract version from git, or if we're from a zipfile, use dirname
-VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc\-]*\)$$|\1|gp')
+VERSION=$(git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc\-]*\)$$|\1|gp')
 
 ifeq ($(VERSION),)
 $(error "ERROR: git is required for generating version information")
@@ -494,7 +494,7 @@ check-markdown:
 check-spelling:
 	@tools/check-spelling.sh
 
-PYSRC=$(shell git ls-files "*.py" | grep -v /text.py) contrib/pylightning/lightning-pay
+PYSRC=$(git ls-files "*.py" | grep -v /text.py) contrib/pylightning/lightning-pay
 
 # Some tests in pyln will need to find lightningd to run, so have a PATH that
 # allows it to find that


### PR DESCRIPTION
on arch Linux I can reproduce the issue https://github.com/ElementsProject/lightning/issues/5189 and this solve the error by removing the shell prefix.

More os info

```
➜  lightning git:(macros/make_file) ✗ make --version 
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
➜  lightning git:(macros/make_file) ✗ git --version     
git version 2.36.0
➜  lightning git:(macros/make_file) ✗
```

Shell `zsh`

Fixes https://github.com/ElementsProject/lightning/issues/5189