### PR TITLE
cln-grpc: Fix minor bug in rust client generator.

### DIFF
--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -277,6 +277,7 @@ pub mod requests {
 	    pub string: Option<String>,
 	    #[serde(alias = "hex", skip_serializing_if = "Option::is_none")]
 	    pub hex: Option<String>,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mode: Option<DatastoreMode>,
 	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
@@ -449,6 +450,7 @@ pub mod requests {
 	    pub bolt11: Option<String>,
 	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<Sha256>,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListsendpaysStatus>,
 	}
 
@@ -539,6 +541,7 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct NewaddrRequest {
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub addresstype: Option<NewaddrAddresstype>,
 	}
 
@@ -741,6 +744,7 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListforwardsRequest {
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListforwardsStatus>,
 	    #[serde(alias = "in_channel", skip_serializing_if = "Option::is_none")]
 	    pub in_channel: Option<ShortChannelId>,
@@ -775,6 +779,7 @@ pub mod requests {
 	    pub bolt11: Option<String>,
 	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<Sha256>,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListpaysStatus>,
 	}
 
@@ -1934,6 +1939,7 @@ pub mod responses {
 	    pub index: u32,
 	    #[serde(alias = "sequence")]
 	    pub sequence: u32,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub item_type: Option<ListtransactionsTransactionsInputsType>,
 	    #[serde(alias = "channel", skip_serializing_if = "Option::is_none")]
 	    pub channel: Option<ShortChannelId>,
@@ -1993,6 +1999,7 @@ pub mod responses {
 	    pub msat: Amount,
 	    #[serde(alias = "scriptPubKey")]
 	    pub script_pub_key: String,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub item_type: Option<ListtransactionsTransactionsOutputsType>,
 	    #[serde(alias = "channel", skip_serializing_if = "Option::is_none")]
 	    pub channel: Option<ShortChannelId>,
@@ -2599,6 +2606,7 @@ pub mod responses {
 	    pub out_channel: Option<ShortChannelId>,
 	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<String>,
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub style: Option<ListforwardsForwardsStyle>,
 	    #[serde(alias = "fee_msat", skip_serializing_if = "Option::is_none")]
 	    pub fee_msat: Option<Amount>,

--- a/contrib/msggen/msggen/rust.py
+++ b/contrib/msggen/msggen/rust.py
@@ -133,7 +133,7 @@ def gen_enum(e):
         defi = f"    // Path `{e.path}`\n    #[serde(rename = \"{e.name}\")]\n    pub {e.name.normalized()}: {typename},\n"
     else:
         defi = f'    #[serde(skip_serializing_if = "Option::is_none")]\n'
-        defi = f"    pub {e.name.normalized()}: Option<{typename}>,\n"
+        defi += f"    pub {e.name.normalized()}: Option<{typename}>,\n"
 
     return defi, decl
 


### PR DESCRIPTION
This commit fixes a bug in a function `gen_enum`, which
is not caught because so far we have no non-required field in enums
defined in json schema.

Changelog-None