### PR TITLE
update bolt spec regeneration text

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -2,7 +2,7 @@
 
 echo "Running in $(pwd)"
 export ARCH=${ARCH:-64}
-export BOLTDIR=lightning-rfc
+export BOLTDIR=bolts
 export CC=${COMPILER:-gcc}
 export COMPAT=${COMPAT:-1}
 export TEST_CHECK_DBSTMTS=${TEST_CHECK_DBSTMTS:-0}
@@ -25,7 +25,7 @@ pip3 install --user poetry
 poetry config virtualenvs.create false --local
 poetry install
 
-git clone https://github.com/lightningnetwork/lightning-rfc.git ../lightning-rfc
+git clone https://github.com/lightning/bolts.git ../${BOLTDIR}
 git submodule update --init --recursive
 
 ./configure CC="$CC"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PKGNAME = c-lightning
 CCANDIR := ccan
 
 # Where we keep the BOLT RFCs
-BOLTDIR := ../lightning-rfc/
+BOLTDIR := ../bolts/
 DEFAULT_BOLTVERSION := e60d594abf436e768116684080997a8d4f960263
 # Can be overridden on cmdline.
 BOLTVERSION := $(DEFAULT_BOLTVERSION)

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -314,10 +314,13 @@ Protocol Modifications
 
 The source tree contains CSV files extracted from the v1.0 BOLT
 specifications (wire/extracted_peer_wire_csv and
-wire/extracted_onion_wire_csv).  You can regenerate these by setting
-`BOLTDIR` and `BOLTVERSION` appropriately, and running `make
-extract-bolt-csv`.
+wire/extracted_onion_wire_csv).  You can regenerate these by
+first deleting the local copy(if any) at directory .tmp.lightning-rfc,
+setting `BOLTDIR` and `BOLTVERSION` appropriately, and finally running `make
+extract-bolt-csv`. By default the bolts will be retrieved from the
+directory `../lightning-rfc` and a recent git version.
 
+e.g., `make extract-bolt-csv BOLTDIR=../bolts BOLTVERSION=ee76043271f79f45b3392e629fd35e47f1268dc8`
 
 Further Information
 -------------------

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -318,7 +318,7 @@ wire/extracted_onion_wire_csv).  You can regenerate these by
 first deleting the local copy(if any) at directory .tmp.lightning-rfc,
 setting `BOLTDIR` and `BOLTVERSION` appropriately, and finally running `make
 extract-bolt-csv`. By default the bolts will be retrieved from the
-directory `../lightning-rfc` and a recent git version.
+directory `../bolts` and a recent git version.
 
 e.g., `make extract-bolt-csv BOLTDIR=../bolts BOLTVERSION=ee76043271f79f45b3392e629fd35e47f1268dc8`
 


### PR DESCRIPTION
Wasn't clear to me where things were being searched for, or how to re-do regeneration from the text there.

Second commit probably breaks something in github actions, but I felt by default picking the name most new checkouts would use is best? Could be dropped.