### PR TITLE
makefile: improve error messages if git version failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 VERSION=$(shell git describe --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc\-]*\)$$|\1|gp')
 
 ifeq ($(VERSION),)
-$(error "ERROR: git is required for generating version information")
+$(error "ERROR: git is required for generating version information. If you have git installed, try to run the following command: git config --system --add safe.directory `pwd`'/*'")
 endif
 
 # --quiet / -s means quiet, dammit!


### PR DESCRIPTION
Fixes following error

`Makefile:7: *** "ERROR: git is required for generating version information". Stop.`

that generate

`fatal: unsafe repository ('/Users/runner/work/lightning/lightning' is owned by someone else)`

Some of users reported that also with `--global` doesn't work, because with `sudo make install`, will take the system conf. 

This PR include a better error message that set the safe directory at global level, but not sure if it is the right think to do!

Fixes https://github.com/ElementsProject/lightning/issues/5189

