### PR TITLE
lightning-cli plugin start - Assume default relative path

### DIFF
--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -16,9 +16,11 @@ optionally one or two parameters which describes the plugin on which the
 action has to be taken.
 
 The *start* command takes a path as the first parameter and will load
-the plugin available from this path.  Any additional parameters are
-passed to the plugin. It will wait for the plugin to complete the
-handshake with `lightningd` for 20 seconds at the most.
+the plugin available from this path. The path can be a full path to a
+plugin or a relative path to a plugin that is located in or below the
+default plugins directory. Any additional parameters are passed to the
+plugin. It will wait for the plugin to complete the handshake with
+`lightningd` for 20 seconds at the most.
 
 The *stop* command takes a plugin name as parameter. It will kill and
 unload the specified plugin.

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -259,8 +259,7 @@ static struct command_result *json_plugin_control(struct command *cmd,
 		}
 		if (access(plugin_path, X_OK) != 0)
 			plugin_path = path_join(cmd,
-					path_join(cmd, cmd->ld->config_basedir, "plugins/"),
-					plugin_path);
+					cmd->ld->plugins->default_dir, plugin_path);
 		if (access(plugin_path, X_OK) == 0)
 			return plugin_dynamic_start(pcmd, plugin_path,
 						    buffer, mod_params);

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
 #include <common/json_command.h>
 #include <common/json_tok.h>
@@ -256,6 +257,10 @@ static struct command_result *json_plugin_control(struct command *cmd,
 					json_get_member(buffer, mod_params,
 							"plugin") - 1, 1);
 		}
+		if (access(plugin_path, X_OK) != 0)
+			plugin_path = path_join(cmd,
+					path_join(cmd, cmd->ld->config_basedir, "plugins/"),
+					plugin_path);
 		if (access(plugin_path, X_OK) == 0)
 			return plugin_dynamic_start(pcmd, plugin_path,
 						    buffer, mod_params);


### PR DESCRIPTION
When starting a plugin, if the plugin path cannot be found in
absolute context, assume it is a relative path to the default
plugins dir. As a result, the following now works when my_plugin.py
is installed in the default plugins dir:

lightning-cli plugin start my_plugin.py

Changelog-Added: plugin start RPC subcommand now assumes relative path to default plugins dir if the path is not found in absolute context. i.e. lightning-cli plugin start my_plugin.py

	modified:   plugin_control.c