### PR TITLE
Slight problem with `./configure help`

### DIFF
--- a/configure
+++ b/configure
@@ -177,7 +177,7 @@ usage()
     usage_with_default "--enable/disable-ub-sanitizer" "$UBSAN" "enable" "disable"
     echo "    Compile with undefined behaviour sanitizer"
     usage_with_default "--enable/disable-fuzzing" "$FUZZING" "enable" "disable"
-    echo "    ***something about fuzzing***"
+    echo "    Compile with fuzzing"
     usage_with_default "--enable/disable-rust" "$RUST" "enable" "disable"
     echo "    Compile with Rust support"
     exit 1

--- a/configure
+++ b/configure
@@ -177,8 +177,9 @@ usage()
     usage_with_default "--enable/disable-ub-sanitizer" "$UBSAN" "enable" "disable"
     echo "    Compile with undefined behaviour sanitizer"
     usage_with_default "--enable/disable-fuzzing" "$FUZZING" "enable" "disable"
-    echo "    Compile with Rust support"
+    echo "    ***something about fuzzing***"
     usage_with_default "--enable/disable-rust" "$RUST" "enable" "disable"
+    echo "    Compile with Rust support"
     exit 1
 }
 


### PR DESCRIPTION
I noticed that the help for each configure option was a little out of sync at the bottom and there was no help text for `--enable/disable-fuzzing`. Not sure on the exact language I should use, because I don't know what fuzzing is in this context.

Changelog-None