### PR TITLE
pyln: Update the makefile to use poetry for publishing

### DIFF
--- a/contrib/pyln-client/.gitignore
+++ b/contrib/pyln-client/.gitignore
@@ -1,1 +1,3 @@
 poetry.lock
+requirements.txt
+

--- a/contrib/pyln-client/Makefile
+++ b/contrib/pyln-client/Makefile
@@ -19,30 +19,35 @@ check: check-source check-pytest
 check-source: check-flake8 check-mypy
 
 check-flake8:
-	flake8 --ignore=E501,E731,W503,E741
+	flake8 --ignore=E501,E731,W503,E741 pyln tests
 
 check-pytest:
 	pytest tests
 
 check-mypy:
-	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
+#	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
 
-$(SDIST_FILE):
-	python3 setup.py sdist
+pyproject.toml: pyln/${PKG}/__init__.py
+	poetry version ${VERSION}
 
-$(BDIST_FILE):
-	python3 setup.py bdist_wheel
+$(SDIST_FILE) $(BDIST_FILE): pyproject.toml
+	poetry build
 
-test-release: check $(ARTEFACTS)
-	python3 -m twine upload --repository testpypi --skip-existing $(ARTEFACTS)
+test-release: check $(ARTEFACTS) pyproject.toml
+	# No way of saying "it's ok if files exist" yet
+	poetry publish --repository testpypi || /bin/true
+	echo Sleeping for PyPI index to update
+	sleep 10
+
+	# Generate a requirements.txt file, needed for us to download requirements from the prod pypi instead of the test pypi, since some packages are not published to test pypi.
+	poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 	# Create a test virtualenv, install from the testpypi and run the
 	# tests against it (make sure not to use any virtualenv that may have
 	# pyln-${PKG} already installed).
 	virtualenv testpypi --python=/usr/bin/python3 --download --always-copy --clear
-	# Install the requirements from the prod repo, they are not being kept up to date on the test repo
 	testpypi/bin/python3 -m pip install -r requirements.txt flaky pytest-timeout
-	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}
+	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}==${VERSION}
 	testpypi/bin/python3 -c "from pyln import ${PKG};assert(${PKG}.__version__ == '$(VERSION)')"
 	testpypi/bin/pytest tests
 	rm -rf testpypi

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "0.10.2.post1"
+version = "0.11.0"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyln-bolt7 = "^1.0.186"
+pyln-bolt7 = "^1.0"
 pyln-proto = "^0.10.2"
 
 [tool.poetry.dev-dependencies]

--- a/contrib/pyln-proto/.gitignore
+++ b/contrib/pyln-proto/.gitignore
@@ -1,1 +1,2 @@
 poetry.lock
+requirements.txt

--- a/contrib/pyln-proto/Makefile
+++ b/contrib/pyln-proto/Makefile
@@ -19,31 +19,35 @@ check: check-source check-pytest
 check-source: check-flake8 check-mypy
 
 check-flake8:
-	flake8 --ignore=E501,E731,W503,E741
+	flake8 --ignore=E501,E731,W503,E741 pyln tests
 
 check-pytest:
 	pytest tests
 
 check-mypy:
-	#mypy --namespace-packages tests pyln
-	echo mypy disabled for pyln-proto
+#	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
 
-$(SDIST_FILE):
-	python3 setup.py sdist
+pyproject.toml: pyln/${PKG}/__init__.py
+	poetry version ${VERSION}
 
-$(BDIST_FILE):
-	python3 setup.py bdist_wheel
+$(SDIST_FILE) $(BDIST_FILE): pyproject.toml
+	poetry build
 
-test-release: check $(ARTEFACTS)
-	python3 -m twine upload --repository testpypi --skip-existing $(ARTEFACTS)
+test-release: check $(ARTEFACTS) pyproject.toml
+	# No way of saying "it's ok if files exist" yet
+	poetry publish --repository testpypi || /bin/true
+	echo Sleeping for PyPI index to update
+	sleep 10
+
+	# Generate a requirements.txt file, needed for us to download requirements from the prod pypi instead of the test pypi, since some packages are not published to test pypi.
+	poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 	# Create a test virtualenv, install from the testpypi and run the
 	# tests against it (make sure not to use any virtualenv that may have
 	# pyln-${PKG} already installed).
 	virtualenv testpypi --python=/usr/bin/python3 --download --always-copy --clear
-	# Install the requirements from the prod repo, they are not being kept up to date on the test repo
 	testpypi/bin/python3 -m pip install -r requirements.txt flaky pytest-timeout
-	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}
+	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}==${VERSION}
 	testpypi/bin/python3 -c "from pyln import ${PKG};assert(${PKG}.__version__ == '$(VERSION)')"
 	testpypi/bin/pytest tests
 	rm -rf testpypi

--- a/contrib/pyln-proto/pyproject.toml
+++ b/contrib/pyln-proto/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-proto"
-version = "0.10.2.post1"
+version = "0.11.0"
 description = "This package implements some of the Lightning Network protocol in pure python. It is intended for protocol testing and some minor tooling only. It is not deemed secure enough to handle any amount of real funds (you have been warned!)."
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-testing/.gitignore
+++ b/contrib/pyln-testing/.gitignore
@@ -1,1 +1,2 @@
 poetry.lock
+requirements.txt

--- a/contrib/pyln-testing/Makefile
+++ b/contrib/pyln-testing/Makefile
@@ -19,30 +19,35 @@ check: check-source check-pytest
 check-source: check-flake8 check-mypy
 
 check-flake8:
-	flake8 --ignore=E501,E731,W503,E741
+	flake8 --ignore=E501,E731,W503,E741 pyln tests
 
 check-pytest:
 	pytest tests
 
 check-mypy:
-	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
+#	MYPYPATH=$(PYTHONPATH) mypy --namespace-packages --follow-imports=skip tests pyln
 
-$(SDIST_FILE):
-	python3 setup.py sdist
+pyproject.toml: pyln/${PKG}/__init__.py
+	poetry version ${VERSION}
 
-$(BDIST_FILE):
-	python3 setup.py bdist_wheel
+$(SDIST_FILE) $(BDIST_FILE): pyproject.toml
+	poetry build
 
-test-release: check $(ARTEFACTS)
-	python3 -m twine upload --repository testpypi --skip-existing $(ARTEFACTS)
+test-release: check $(ARTEFACTS) pyproject.toml
+	# No way of saying "it's ok if files exist" yet
+	poetry publish --repository testpypi || /bin/true
+	echo Sleeping for PyPI index to update
+	sleep 10
+
+	# Generate a requirements.txt file, needed for us to download requirements from the prod pypi instead of the test pypi, since some packages are not published to test pypi.
+	poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 	# Create a test virtualenv, install from the testpypi and run the
 	# tests against it (make sure not to use any virtualenv that may have
 	# pyln-${PKG} already installed).
 	virtualenv testpypi --python=/usr/bin/python3 --download --always-copy --clear
-	# Install the requirements from the prod repo, they are not being kept up to date on the test repo
 	testpypi/bin/python3 -m pip install -r requirements.txt flaky pytest-timeout
-	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}
+	testpypi/bin/python3 -m pip install -I --index-url https://test.pypi.org/simple/ --no-deps pyln-${PKG}==${VERSION}
 	testpypi/bin/python3 -c "from pyln import ${PKG};assert(${PKG}.__version__ == '$(VERSION)')"
 	testpypi/bin/pytest tests
 	rm -rf testpypi

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-testing"
-version = "0.10.2"
+version = "0.11.0"
 description = "Test your Core Lightning integration, plugins or whatever you want"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"


### PR DESCRIPTION
`poetry` does handle a couple of things better, but we needed to adjust the makefile targets to use it too.

Changelog-None