### PR TITLE
Reproducibility fixes for v0.11.0

### DIFF
--- a/contrib/reprobuild/Dockerfile.bionic
+++ b/contrib/reprobuild/Dockerfile.bionic
@@ -7,36 +7,52 @@ RUN sed -i '/updates/d' /etc/apt/sources.list && \
     sed -i '/security/d' /etc/apt/sources.list
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
       ca-certificates \
-	sudo \
-	build-essential \
-	libsodium23 \
-	python3-setuptools \
-	libpq-dev \
-	git \
-	file \
-	autoconf \
-	debianutils \
-	gettext \
-	zip \
-	unzip \
-	wget
+      sudo \
+      build-essential \
+      libsodium23 \
+      libpq-dev \
+      git \
+      file \
+      autoconf \
+      debianutils \
+      gettext \
+      zip \
+      unzip \
+      wget
+
+# Need to fetch a python version that is >= 3.7 since that's the
+# lowest version supported by pyln. This is just temporary until we
+# drop support for ubuntu 18.04
+ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:$PATH
+RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv \
+    && apt-get install -y --no-install-recommends \
+      libbz2-dev \
+      libffi-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      zlib1g-dev \
+    && pyenv install 3.7.0 \
+    && pyenv global 3.7.0
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
 	&& rm /tmp/get-pip.py \
-	&& pip install mrkd mako
+	&& pip install poetry
 
 RUN mkdir /build
 WORKDIR /build
 
 CMD git clone /repo /build \
-	&& tools/build-release.sh zipfile \
-	&& mkdir -p /repro \
-	&& cd /repro \
-	&& unzip /build/release/*.zip \
-	&& cd clightning* \
-	&& tools/repro-build.sh \
-	&& cp *.xz /build/release/* /repo/release/ \
-	&& cd /repo/release \
-	&& sha256sum *
+    && poetry export -o requirements.txt --without-hashes \
+    && pip install -r requirements.txt\
+    && tools/build-release.sh zipfile \
+    && mkdir -p /repro \
+    && cd /repro \
+    && unzip /build/release/*.zip \
+    && cd clightning* \
+    && tools/repro-build.sh \
+    && cp *.xz /build/release/* /repo/release/ \
+    && cd /repo/release \
+    && sha256sum *

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -1,4 +1,4 @@
-FROM focal
+FROM jammy
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/doc/REPRODUCIBLE.md
+++ b/doc/REPRODUCIBLE.md
@@ -66,30 +66,26 @@ latter means that if we disable the `updates` and `security` repositories for
 packages (wrongly updated packages depending on the versions not available in
 the non-updated repos).
 
-The following will create that base image:
-
-```bash
-sudo debootstrap bionic bionic
-sudo tar -C bionic -c . | sudo docker import - bionic
-```
-
-`bionic` in this case is the codename for Ubuntu 18.04 LTS. The following
-table lists the codenames of distributions that we currently support:
+The following table lists the codenames of distributions that we
+currently support:
 
 | Distribution Version | Codename |
 |----------------------|----------|
 | Ubuntu 18.04         | bionic   |
 | Ubuntu 20.04         | focal    |
+| Ubuntu 22.04         | jammy    |
 
-Notice that you migh not have `debootstrap` manifests for versions newer than
-your host OS. If one of the `debootstrap` command above complains about a
-script not existing you might need to run `debootstrap` in a docker container
-itself:
+Depending on your host OS release you migh not have `debootstrap`
+manifests for versions newer than your host OS. Due to this we run the
+`debootstrap` commands in a container of the latest version itself:
 
 ```bash
-sudo docker run --rm -v $(pwd):/build ubuntu:20.04 \
-	bash -c "apt update && apt-get install -y debootstrap && debootstrap focal /build/focal"
-sudo tar -C focal -c . | sudo docker import - focal
+for v in bionic focal jammy; do
+  echo "Building base image for $v"
+  sudo docker run --rm -v $(pwd):/build ubuntu:22.04 \
+	bash -c "apt-get update && apt-get install -y debootstrap && debootstrap $v /build/$v"
+  sudo tar -C $v -c . | sudo docker import - $v
+done
 ```
 
 Verify that the image corresponds to our expectation and is runnable:

--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -135,6 +135,34 @@ a7d59420134a8307eb11ef79b68e2b35cadc794a60f82c87f4583e37c763fd01  /var/cache/apt
 9cd69c847d7b12bd9cb2c58afe8bd17fb3973361716af71eb45c0f2b6d7e6884  /var/cache/apt/archives/zlib1g-dev_1%3a1.2.11.dfsg-2ubuntu1_amd64.deb
 EOF
 	;;
+    Ubuntu-22.04)
+	if grep ^deb /etc/apt/sources.list | grep -- '-\(updates\|security\)'; then
+	    echo Please disable security and updates in /etc/apt/sources.list >&2
+	    exit 1
+	fi
+	DOWNLOAD='sudo apt -y --no-install-recommends --reinstall -d install'
+	PKGS='autoconf automake libtool make gcc libgmp-dev libsqlite3-dev zlib1g-dev libsodium-dev'
+	INST='sudo dpkg -i'
+	cat > /tmp/SHASUMS <<EOF
+96b528889794c4134015a63c75050f93d8aecdf5e3f2a20993c1433f4c61b80e  /var/cache/apt/archives/autoconf_2.71-2_all.deb
+db854b9af0f94eded5039830177f57a5b2d529f76e2b5b0de8ec0b26f7aedc83  /var/cache/apt/archives/gcc-11-base_11.2.0-19ubuntu1_amd64.deb
+0320b98a2d4664b10f6de2ec3f3e2409cb8c3dbec8c32d938a6beaa78e1fed76  /var/cache/apt/archives/gcc-11_11.2.0-19ubuntu1_amd64.deb
+0fbbb920bb9b3b24c357cca9035671fcfee5f9ed49175f6145db979406dbc532  /var/cache/apt/archives/libc-bin_2.35-0ubuntu3_amd64.deb
+cc37cab5c60bcfe4bbf289a8002f369949a41ed46e8b51a0503a001099370c56  /var/cache/apt/archives/libc6-dev_2.35-0ubuntu3_amd64.deb
+2f52cdc0aca888bb3995d871a65282107dc7c2a0a4d78f60680f709bdc0875aa  /var/cache/apt/archives/libcc1-0_12-20220319-1ubuntu1_amd64.deb
+a79be2f6e45823dcc09e04d5e98c88ec88d07d5b8895d05b875a8ade8b345efa  /var/cache/apt/archives/libcrypt-dev_1%3a4.4.27-1_amd64.deb
+adae5a301c7899c1bce8ae26b5423716a47e516df25c09d6d536607bc34853bc  /var/cache/apt/archives/libgcc-11-dev_11.2.0-19ubuntu1_amd64.deb
+e4ce547c5c5e4efd98854d06559349b3a03272eb343f1bd8e4ccac7b783229a3  /var/cache/apt/archives/libgmp-dev_2%3a6.2.1+dfsg-3ubuntu1_amd64.deb
+d8b8653388e676a3ae2fcf565c2b1a42a01a1104062317f641e8d24f0eaff9c3  /var/cache/apt/archives/libpq-dev_14.2-1ubuntu1_amd64.deb
+542dcee1409c74d03ecdd4ca4a0cfd467e5d2804d9985b58e39d3c5889a409e3  /var/cache/apt/archives/libpq5_14.2-1ubuntu1_amd64.deb
+885ee09c37d0e37ef6042e8cb4a22ccbab92101f21ab0c8f51ae961e4484407c  /var/cache/apt/archives/libsodium23_1.0.18-1build2_amd64.deb
+000a1d5c0df0373c75fadbfea604afb6b1325bf866a3ce637ae0138abe6d556d  /var/cache/apt/archives/libsqlite3-0_3.37.2-2_amd64.deb
+1b2a93020593c9e94a25f750ce442da5a6e8ff48a20f52cec92dfc3fa35336d8  /var/cache/apt/archives/linux-libc-dev_5.15.0-25.25_amd64.deb
+572a544d2c18bf49d25c465720c570cd8e6e38731386ac9c0a7f29bed2486f3e  /var/cache/apt/archives/m4_1.4.18-5ubuntu2_amd64.deb
+080b79a1a1623a2e6c6eead37d62b15fdf2c3dbfeafe8ecf5e31c54eb09eadcc  /var/cache/apt/archives/make_4.3-4.1build1_amd64.deb
+52449467942cc943d651fd16867014e9339f3657935fc09b75b3347aa5a78066  /var/cache/apt/archives/zlib1g_1%3a1.2.11.dfsg-2ubuntu9_amd64.deb
+EOF
+	;;
     *)
 	echo Unsupported platform "$PLATFORM" >&2
 	exit 1


### PR DESCRIPTION
This should fix the reprobuilds for v0.11.0.1. Due to us not being able to move the tag, we need to use the new reprobuild images with the tag checked out:

 - Check out this PR's head
 - Follow the instructions in `doc/REPRODUCIBLE.md` to create the base and builder images, but stop before the section `Building using the builder image`
 - Check out tag `v0.11.0.1`
 - Now call the two repro builds: `sudo docker run --rm -v $(pwd):/repo -ti cl-repro-bionic` and `sudo docker run --rm -v $(pwd):/repo -ti cl-repro-focal` (the config for `jammy` was added in this PR, but is not available in the tarball yet, so attempting to build it will yield an `Unsupported OS` error)

My hashes are these:

```
9dbc98c20df37eee6d7ae6ea8b5feedb51d69b3a62028a309ddd3c67aa70d476  clightning-v0.11.0.1-Ubuntu-18.04.tar.xz
798f7e595c4a77492cd71fdfdaa146a87bae39a311a250d9bdeba62fd4f0d933  clightning-v0.11.0.1-Ubuntu-20.04.tar.xz
e2ad6eead19a0cd8869e291c27d318cf553bb015339c1f0e8d8b30e7bc0910d8  clightning-v0.11.0.1.zip
```