### PR TITLE
Add psbt routine for finalizing multisig sigs

### DIFF
--- a/common/psbt_internal.h
+++ b/common/psbt_internal.h
@@ -20,6 +20,24 @@ struct witness_element;
 void psbt_finalize_input(const tal_t *ctx,
 			 struct wally_psbt_input *in,
 			 const struct witness_element **elements);
+/* psbt_finalize_multisig_signatures - Takes signatures from the
+ * "partial signatures" section and adds them to the witness stack
+ * in the order their corresponding public keys appear in the witness
+ * script. If the signature is already present, it is not added.
+ *
+ * If the stack is empty, the witness_script is appended and a zero
+ * size signature is prepended.
+ *
+ * The signatures are DER encoded if not already.
+ *
+ * @ctx - the context to allocate onto
+ * @in - input to set final_witness for
+ *
+ * Returns the number of signatures that were recognized as correct
+ * for the witness script (whether they were already present or not).
+ */
+int psbt_finalize_multisig_signatures(const tal_t *ctx,
+				       struct wally_psbt_input *in);
 /* psbt_to_witness_stacks - Take all sigs on a PSBT and copy to a
  * 			    witness_stack
  *


### PR DESCRIPTION
Takes partial signatures from a PSBT and builds a witness stack for a multisig & finalizes things.

This is needed for splicing so we can sign the old channel tx over to the new one as part of the splice.