### PR TITLE
external/Makefile: fix `submodcheck` for sudo make install and modern git

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -49,8 +49,10 @@ endif
 EXTERNAL_LDLIBS := -L${TARGET_DIR} $(patsubst lib%.a,-l%,$(notdir $(EXTERNAL_LIBS)))
 
 submodcheck: $(FORCE)
+ifneq ($(VERSION),)
 	@tools/refresh-submodules.sh $(SUBMODULES)
 	@cd external/libwally-core && ../../tools/refresh-submodules.sh src/secp256k1
+endif
 
 $(EXTERNAL_HEADERS): submodcheck
 


### PR DESCRIPTION
Really fixes https://github.com/ElementsProject/lightning/pull/5225

We can't run refresh-submodules without a working git, either:

```
$ sudo make install
mkdir -p /usr/local/bin
mkdir -p /usr/local/libexec/c-lightning
mkdir -p /usr/local/libexec/c-lightning/plugins
mkdir -p /usr/local/share/man/man1
mkdir -p /usr/local/share/man/man5
mkdir -p /usr/local/share/man/man7
mkdir -p /usr/local/share/man/man8
mkdir -p /usr/local/share/doc/c-lightning
fatal: unsafe repository ('/home/rusty/lightning' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /home/rusty/lightning
Reinitializing submodules external/libsodium external/libwally-core external/gheap external/jsmn external/libbacktrace external/lnprototest ...
fatal: unsafe repository ('/home/rusty/lightning' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /home/rusty/lightning
fatal: unsafe repository ('/home/rusty/lightning' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /home/rusty/lightning
make: *** [external/Makefile:52: submodcheck] Error 128
```

Changelog-None