### PR TITLE
Fix broken length on show_log_prefix

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -601,7 +601,8 @@ static void show_log_level(char buf[OPT_SHOW_LEN], const struct log *log)
 		l = *log->lr->default_print_level;
 	else
 		l = DEFAULT_LOGLEVEL;
-	strncpy(buf, log_level_name(l), OPT_SHOW_LEN-1);
+	strncpy(buf, log_level_name(l), OPT_SHOW_LEN - 1);
+	buf[OPT_SHOW_LEN - 1] = '\0';
 }
 
 static char *arg_log_prefix(const char *arg, struct log *log)

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -614,7 +614,8 @@ static char *arg_log_prefix(const char *arg, struct log *log)
 
 static void show_log_prefix(char buf[OPT_SHOW_LEN], const struct log *log)
 {
-	strncpy(buf, log->prefix->prefix, OPT_SHOW_LEN);
+	strncpy(buf, log->prefix->prefix, OPT_SHOW_LEN - 1);
+	buf[OPT_SHOW_LEN - 1] = '\0';
 }
 
 static int signalfds[2];

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1537,8 +1537,8 @@ static void add_config(struct lightningd *ld,
 		if (opt->desc == opt_hidden) {
 			/* Ignore hidden options (deprecated) */
 		} else if (opt->show) {
-			strcpy(buf + OPT_SHOW_LEN, "...");
 			opt->show(buf, opt->u.carg);
+			strcpy(buf + OPT_SHOW_LEN - 1, "...");
 
 			if (streq(buf, "true") || streq(buf, "false")
 			    || strspn(buf, "0123456789.") == strlen(buf)) {

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -737,7 +737,7 @@ def test_listconfigs(node_factory, bitcoind, chainparams):
     assert configs['network'] == chainparams['name']
     assert configs['ignore-fee-limits'] is False
     assert configs['ignore-fee-limits'] is False
-    assert configs['log-prefix'] == 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...'
+    assert configs['log-prefix'] == 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...'
 
     # These are aliases, but we don't print the (unofficial!) wumbo.
     assert 'wumbo' not in configs


### PR DESCRIPTION
This PR solves an issue that appears when building cln as a nix derivation with the "--enable-developer" config flag set. In this case the build crashes with the following error:
```
In file included from /nix/store/bd9k3zwm0b3p8k3qw0nlk71vzfa5hn8n-glibc-2.34-115-dev/include/string.h:519,
                 from ccan/ccan/str/str.h:5,
                 from ccan/ccan/tal/tal.h:8,
                 from ccan/ccan/io/io.h:4,
                 from lightningd/log.c:3:
In function 'strncpy',
    inlined from 'show_log_prefix' at lightningd/log.c:617:2:
/nix/store/bd9k3zwm0b3p8k3qw0nlk71vzfa5hn8n-glibc-2.34-115-dev/include/bits/string_fortified.h:95:10: error: '__builtin_strncpy' specified bound 80 equals destination size [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation-Werror=stringop-truncation8;;]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:286: lightningd/log.o] Error 1
```

Lowering the max number of chars copied by `strncpy` by 1 (as it is also done by `show_log_level` in line 604) fixes this.