### PR TITLE
gh: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,20 @@
 # also can optionally require approval from a code owner before the
 # author can merge a pull request in the repository.
 
-wallet/                 @cdecker
-*.py                    @cdecker
+cln-grpc/               @cdecker
+cln-rpc/                @cdecker
+plugins/src/            @cdecker
+plugins/grpc-plugin/    @cdecker
+contrib/reprobuild/     @cdecker
+contrib/msggen/         @cdecker
+contrib/pyln-client/    @cdecker
+contrib/pyln-testing/   @cdecker
+# Needed to ensure hsmd wire compatibility between releases
+hsmd/hsmd_wire.csv      @cdecker
 
-wallet/invoices.*       @ZmnSCPxj
+wallet/invoices.*          @ZmnSCPxj
 plugins/multifundchannel.c @ZmnSCPxj
-doc/BACKUP.md           @ZmnSCPxj @cdecker
+doc/BACKUP.md              @ZmnSCPxj
 
 # See https://help.github.com/articles/about-codeowners/ for more
 # information

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,5 @@ wallet/invoices.*       @ZmnSCPxj
 plugins/multifundchannel.c @ZmnSCPxj
 doc/BACKUP.md           @ZmnSCPxj @cdecker
 
-common/param.*          @wythe
-common/json.*           @wythe
-common/json_tok.*       @wythe
-common/wallet_tx.*      @wythe
-
 # See https://help.github.com/articles/about-codeowners/ for more
 # information


### PR DESCRIPTION
Github was complaining about the CODEOWNERS file, since it seems @wythe is no longer active, or able to see the repository? I took the opportunity of refining my own ownership, which means I should get added as an automatic reviewer for the paths that I am responsible for.