### PR TITLE
Polish feature remote_addr  

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -899,3 +899,12 @@ int wireaddr_cmp_type(const struct wireaddr *a,
 		return tal_bytelen(a_wire) - tal_bytelen(b_wire);
 	return cmp;
 }
+
+bool wireaddr_arr_contains(const struct wireaddr *was,
+			   const struct wireaddr *wa)
+{
+	for (size_t i = 0; i < tal_count(was); i++)
+		if (wireaddr_eq(&was[i], wa))
+			return true;
+	return false;
+}

--- a/common/wireaddr.h
+++ b/common/wireaddr.h
@@ -197,4 +197,7 @@ struct wireaddr *fromwire_wireaddr_array(const tal_t *ctx, const u8 *ser);
 int wireaddr_cmp_type(const struct wireaddr *a,
 		      const struct wireaddr *b, void *unused);
 
+bool wireaddr_arr_contains(const struct wireaddr *was,
+			   const struct wireaddr *wa);
+
 #endif /* LIGHTNING_COMMON_WIREADDR_H */

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1739,7 +1739,36 @@ static bool wireaddr_int_equals_wireaddr(const struct wireaddr_internal *addr_a,
 	return wireaddr_eq(&addr_a->u.wireaddr, addr_b);
 }
 
-/*~ Orders the addresses which lightningd gave us. */
+/*~ Adds just one address type.
+ *
+ * Ignores deprecated and the `addrhint`. */
+static void add_gossip_addrs_bytype(struct wireaddr_internal **addrs,
+				    const struct wireaddr *normal_addrs,
+				    const struct wireaddr_internal *addrhint,
+				    const enum wire_addr_type type)
+{
+	for (size_t i = 0; i < tal_count(normal_addrs); i++) {
+		if (normal_addrs[i].type == ADDR_TYPE_TOR_V2_REMOVED)
+			continue;
+		if (wireaddr_int_equals_wireaddr(addrhint, &normal_addrs[i]))
+			continue;
+		if (normal_addrs[i].type != type)
+			continue;
+		struct wireaddr_internal addr;
+		addr.itype = ADDR_INTERNAL_WIREADDR;
+		addr.u.wireaddr = normal_addrs[i];
+		tal_arr_expand(addrs, addr);
+	}
+
+}
+
+
+/*~ Orders the addresses which lightningd gave us.
+ *
+ * Ignores deprecated protocols and the `addrhint` that is assumed to be
+ * already added first. Adds all IPv6 addresses, followed by IPv4 and then TOR.
+ * This ensures we are modern and use IPv6 when possible, falling back to
+ * direct (faster) IPv4 and finally (less stable) TOR connections. */
 static void add_gossip_addrs(struct wireaddr_internal **addrs,
 			     const struct wireaddr *normal_addrs,
 			     const struct wireaddr_internal *addrhint)
@@ -1749,28 +1778,22 @@ static void add_gossip_addrs(struct wireaddr_internal **addrs,
 		/* This is not supported, ignore. */
 		if (normal_addrs[i].type == ADDR_TYPE_TOR_V2_REMOVED)
 			continue;
-
-		/* add TOR addresses in a second loop */
+		/* The hint was already added earlier */
+		if (wireaddr_int_equals_wireaddr(addrhint, &normal_addrs[i]))
+			continue;
+		/* We add IPv4 and TOR in separate loops to prefer IPv6 */
+		if (normal_addrs[i].type == ADDR_TYPE_IPV4)
+			continue;
 		if (normal_addrs[i].type == ADDR_TYPE_TOR_V3)
 			continue;
-		if (wireaddr_int_equals_wireaddr(addrhint, &normal_addrs[i]))
-			continue;
 		struct wireaddr_internal addr;
 		addr.itype = ADDR_INTERNAL_WIREADDR;
 		addr.u.wireaddr = normal_addrs[i];
 		tal_arr_expand(addrs, addr);
 	}
-	/* so connectd prefers direct connections if possible. */
-	for (size_t i = 0; i < tal_count(normal_addrs); i++) {
-		if (normal_addrs[i].type != ADDR_TYPE_TOR_V3)
-			continue;
-		if (wireaddr_int_equals_wireaddr(addrhint, &normal_addrs[i]))
-			continue;
-		struct wireaddr_internal addr;
-		addr.itype = ADDR_INTERNAL_WIREADDR;
-		addr.u.wireaddr = normal_addrs[i];
-		tal_arr_expand(addrs, addr);
-	}
+	/* Do the loop for skipped protocols in preferred order. */
+	add_gossip_addrs_bytype(addrs, normal_addrs, addrhint, ADDR_TYPE_IPV4);
+	add_gossip_addrs_bytype(addrs, normal_addrs, addrhint, ADDR_TYPE_TOR_V3);
 }
 
 /*~ Consumes addrhint if not NULL.

--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -105,11 +105,10 @@ static struct io_plan *peer_init_received(struct io_conn *conn,
 			switch (remote_addr->type) {
 			case ADDR_TYPE_IPV4:
 			case ADDR_TYPE_IPV6:
-#if DEVELOPER		/* ignore private addresses (non-DEVELOPER builds) */
-				if (!address_routable(remote_addr, true))
-#else
-				if (!address_routable(remote_addr, false))
-#endif /* DEVELOPER */
+				/* Drop non-public addresses when not testing */
+				if (!address_routable(remote_addr,
+						      IFDEV(peer->daemon->dev_allow_localhost,
+						      false)))
 					remote_addr = tal_free(remote_addr);
 				break;
 			/* We are only interested in IP addresses */

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -159,6 +159,7 @@ If **connected** is *true*:
   - **netaddr** (array of strings): A single entry array:
     - address, e.g. 1.2.3.4:1234
   - **features** (hex): bitmap of BOLT #9 features from peer's INIT message
+  - **remote_addr** (string, optional): The public IPv4/6 address the peer sees us from, e.g. 1.2.3.4:1234
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -380,4 +381,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:4f76b5ac19d3dfdaf3d04f5dd5de2312a2ab0ccffe779508c416aaf6e644612a)
+[comment]: # ( SHA256STAMP:e6829e8ced923131b95bcfa4f366dd04286fe85485039e9ebc89e79899937df6)

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -1114,6 +1114,10 @@
                     "description": "address, e.g. 1.2.3.4:1234"
                   }
                 },
+                "remote_addr": {
+                  "type": "string",
+                  "description": "The public IPv4/6 address the peer sees us from, e.g. 1.2.3.4:1234"
+                },
                 "features": {
                   "type": "hex",
                   "description": "bitmap of BOLT #9 features from peer's INIT message"

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -20,15 +20,6 @@
 #include <hsmd/hsmd_wiregen.h>
 #include <wire/wire_sync.h>
 
-static bool wireaddr_arr_contains(const struct wireaddr *was,
-				  const struct wireaddr *wa)
-{
-	for (size_t i = 0; i < tal_count(was); i++)
-		if (wireaddr_eq(&was[i], wa))
-			return true;
-	return false;
-}
-
 /* Create a node_announcement with the given signature. It may be NULL in the
  * case we need to create a provisional announcement for the HSM to sign.
  * This is called twice: once with the dummy signature to get it signed and a

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -97,6 +97,7 @@ struct peer *new_peer(struct lightningd *ld, u64 dbid,
 	peer->uncommitted_channel = NULL;
 	peer->addr = *addr;
 	peer->connected_incoming = connected_incoming;
+	peer->remote_addr = NULL;
 	peer->their_features = NULL;
 	list_head_init(&peer->channels);
 	peer->direction = node_id_idx(&peer->ld->id, &peer->id);
@@ -1154,6 +1155,9 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 	/* Update peer address and direction */
 	peer->addr = hook_payload->addr;
 	peer->connected_incoming = hook_payload->incoming;
+	if (peer->remote_addr)
+		tal_free(peer->remote_addr);
+	peer->remote_addr = NULL;
 	peer_update_features(peer, their_features);
 
 	tal_steal(peer, hook_payload);
@@ -1172,6 +1176,8 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 	if (hook_payload->remote_addr) {
 		log_peer_info(ld->log, &id, "Peer says it sees our address as: %s",
 			      fmt_wireaddr(tmpctx, hook_payload->remote_addr));
+		peer->remote_addr = tal_dup(peer, struct wireaddr,
+					    hook_payload->remote_addr);
 		/* Currently only from peers we have a channel with, until we
 		 * do stuff like probing for remote_addr to a random node. */
 		if (!list_empty(&peer->channels))
@@ -1671,6 +1677,10 @@ static void json_add_peer(struct lightningd *ld,
 					       struct wireaddr_internal,
 					       &p->addr));
 		json_array_end(response);
+		/* If peer reports our IP remote_addr, add that here */
+		if (p->remote_addr)
+			json_add_string(response, "remote_addr",
+					fmt_wireaddr(response, p->remote_addr));
 		json_add_hex_talarr(response, "features", p->their_features);
 	}
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1170,8 +1170,8 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 
 	/* Log and update remote_addr for Nat/IP discovery. */
 	if (hook_payload->remote_addr) {
-		log_info(ld->log, "Peer says it sees our address as: %s",
-			 fmt_wireaddr(tmpctx, hook_payload->remote_addr));
+		log_peer_info(ld->log, &id, "Peer says it sees our address as: %s",
+			      fmt_wireaddr(tmpctx, hook_payload->remote_addr));
 		/* Currently only from peers we have a channel with, until we
 		 * do stuff like probing for remote_addr to a random node. */
 		if (!list_empty(&peer->channels))

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2014,6 +2014,12 @@ static struct command_result *json_getinfo(struct command *cmd,
         json_array_start(response, "address");
         for (size_t i = 0; i < tal_count(cmd->ld->announceable); i++)
             json_add_address(response, NULL, cmd->ld->announceable+i);
+	if (cmd->ld->remote_addr_v4 != NULL &&
+	    !wireaddr_arr_contains(cmd->ld->announceable, cmd->ld->remote_addr_v4))
+		json_add_address(response, NULL, cmd->ld->remote_addr_v4);
+	if (cmd->ld->remote_addr_v6 != NULL &&
+	    !wireaddr_arr_contains(cmd->ld->announceable, cmd->ld->remote_addr_v6))
+		json_add_address(response, NULL, cmd->ld->remote_addr_v6);
         json_array_end(response);
 
         /* This is what we're actually bound to. */

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -40,6 +40,9 @@ struct peer {
 	struct wireaddr_internal addr;
 	bool connected_incoming;
 
+	/* They send what they see as our address as remote_addr */
+	struct wireaddr *remote_addr;
+
 	/* We keep a copy of their feature bits */
 	const u8 *their_features;
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -86,7 +86,9 @@ def test_remote_addr(node_factory, bitcoind):
     l2.start()
 
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
+    logmsg = l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
+    # check 'listpeers' contains the 'remote_addr' as logged
+    assert logmsg.endswith(l2.rpc.listpeers()['peers'][0]['remote_addr'])
 
     # Fund first channel so initial node_announcement is send
     # and also check no addresses have been announced yet

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -458,7 +458,10 @@ def test_peer_connected_remote_addr(node_factory):
 
     The optional tlv `remote_addr` should only be visible to the initiator l1.
     """
-    l1, l2 = node_factory.get_nodes(2, opts={'plugin': os.path.join(os.getcwd(), 'tests/plugins/peer_connected_logger_a.py')})
+    pluginpath = os.path.join(os.getcwd(), 'tests/plugins/peer_connected_logger_a.py')
+    l1, l2 = node_factory.get_nodes(2, opts={
+        'plugin': pluginpath,
+        'dev-allow-localhost': None})
     l1id = l1.info['id']
     l2id = l2.info['id']
 


### PR DESCRIPTION
Now that the feature is out in the wild, I see several improvements that can be made:

- [x] Address https://github.com/ElementsProject/lightning/issues/5234
- [x] Add detected addresses to `getinfo` RPC. This was missed in prior PR.
- [x] Add nodeid to log message ...'Peer says it sees our address as xyz'. This is a lot more useful
- [x] Prefer IPv6 when making a connection.
- [ ] Maybe filter out `remote_addr` from peers that cannot be confirmed other peers (see https://github.com/ACINQ/eclair/issues/2256 ). Note: This currently does not produce false positives, but 'interrupts' the detection of the correct address.
- [x] Maybe add `remote_addr` field to `listpeers` RPC.
- [ ] Maybe add method to set announced addresses via RPC call