### PR TITLE
ignore generic binary from github tree

### DIFF
--- a/devtools/.gitignore
+++ b/devtools/.gitignore
@@ -17,3 +17,4 @@ mkquery
 onion
 route
 topology
+fp16


### PR DESCRIPTION
I start to noded this binary generated during the build process and maybe this can be excluded!

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>