### PR TITLE
rpc: checkmessage return an error is the pubkey is not found in the graph

### DIFF
--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -388,7 +388,7 @@ message CheckmessageRequest {
 
 message CheckmessageResponse {
 	bool verified = 1;
-	optional bytes pubkey = 2;
+	bytes pubkey = 2;
 }
 
 message CloseRequest {

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -299,7 +299,7 @@ impl From<&responses::CheckmessageResponse> for pb::CheckmessageResponse {
     fn from(c: &responses::CheckmessageResponse) -> Self {
         Self {
             verified: c.verified.clone(), // Rule #2 for type boolean
-            pubkey: c.pubkey.as_ref().map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            pubkey: c.pubkey.to_vec(), // Rule #2 for type pubkey
         }
     }
 }

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1441,8 +1441,8 @@ pub mod responses {
 	pub struct CheckmessageResponse {
 	    #[serde(alias = "verified")]
 	    pub verified: bool,
-	    #[serde(alias = "pubkey", skip_serializing_if = "Option::is_none")]
-	    pub pubkey: Option<Pubkey>,
+	    #[serde(alias = "pubkey")]
+	    pub pubkey: Pubkey,
 	}
 
 	/// Whether we successfully negotiated a mutual close, closed without them, or discarded not-yet-opened channel

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -99,6 +99,9 @@ static const errcode_t DATASTORE_UPDATE_WRONG_GENERATION = 1204;
 static const errcode_t DATASTORE_UPDATE_HAS_CHILDREN = 1205;
 static const errcode_t DATASTORE_UPDATE_NO_CHILDREN = 1206;
 
+/* Errors from signmessage command */
+static const errcode_t SIGNMESSAGE_PUBKEY_NOT_FOUND = 1301;
+
 /* Errors from wait* commands */
 static const errcode_t WAIT_TIMEOUT = 2000;
 

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -29,13 +29,8 @@ RETURN VALUE
 
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
-- **verified** (boolean): Whether the signature was valid
-
-If **verified** is *true*:
-  - **pubkey** (pubkey): the *pubkey* parameter, or the pubkey found by looking for known nodes
-
-If **verified** is *false*:
-  - **pubkey** (pubkey): the *pubkey* (if any) which could have signed this; this is usually not useful!
+- **verified** (boolean): whether the signature was valid (always *true*)
+- **pubkey** (pubkey): the *pubkey* parameter, or the pubkey found by looking for known nodes
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -54,4 +49,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7dcca1fd1708d93b4a0c9b83955630fc4f551c4ffd452fb866c624c72aeaa44d)
+[comment]: # ( SHA256STAMP:af2feeb4eddafc509dff150ec4b11225618f1cbbea06ef81f6d97a1bece3e94c)

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -49,4 +49,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:af2feeb4eddafc509dff150ec4b11225618f1cbbea06ef81f6d97a1bece3e94c)
+[comment]: # ( SHA256STAMP:733247e44d555f9c480a684ceb30440f4f33daf5755253249b5c7b9269c96e49)

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -20,6 +20,10 @@ known node key (as per *listnodes*), and verification succeeds if it
 matches for any one of them.  Note: this is implemented far more
 efficiently than trying each one, so performance is not a concern.
 
+On failure, an error is returned and core lightning exit with the following error code:
+- -32602: Parameter missed or malformed;
+- 1301: *pubkey* not found in the graph.
+
 RETURN VALUE
 ------------
 

--- a/doc/schemas/checkmessage.schema.json
+++ b/doc/schemas/checkmessage.schema.json
@@ -2,65 +2,21 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
-    "verified"
+    "verified",
+    "pubkey"
   ],
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "verified": {
       "type": "boolean",
-      "description": "Whether the signature was valid"
-    }
-  },
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "verified": {
-            "type": "boolean",
-            "enum": [
-              true
-            ]
-          }
-        }
-      },
-      "then": {
-        "additionalProperties": false,
-        "required": [
-          "pubkey"
-        ],
-        "properties": {
-          "verified": {},
-          "pubkey": {
-            "type": "pubkey",
-            "description": "the *pubkey* parameter, or the pubkey found by looking for known nodes"
-          }
-        }
-      }
+      "enum": [
+        true
+      ],
+      "description": "whether the signature was valid"
     },
-    {
-      "if": {
-        "properties": {
-          "verified": {
-            "type": "boolean",
-            "enum": [
-              false
-            ]
-          }
-        }
-      },
-      "then": {
-        "additionalProperties": false,
-        "required": [
-          "pubkey"
-        ],
-        "properties": {
-          "verified": {},
-          "pubkey": {
-            "type": "pubkey",
-            "description": "the *pubkey* (if any) which could have signed this; this is usually not useful!"
-          }
-        }
-      }
+    "pubkey": {
+      "type": "pubkey",
+      "description": "the *pubkey* parameter, or the pubkey found by looking for known nodes"
     }
-  ]
+  }
 }

--- a/lightningd/signmessage.c
+++ b/lightningd/signmessage.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <common/bech32.h>
+#include <common/configdir.h>
 #include <common/json_command.h>
 #include <common/json_param.h>
 #include <errno.h>
@@ -133,6 +134,12 @@ static void listnodes_done(const char *buffer,
 	if (t)
 		t = json_get_member(buffer, t, "nodes");
 
+	if (!deprecated_apis && (!t || t->size == 0)) {
+		was_pending(command_fail(can->cmd, SIGNMESSAGE_PUBKEY_NOT_FOUND,
+					 "pub key not found in the graph, expected pubkey is %s",
+					 node_id_to_hexstr(tmpctx, &can->id)));
+		return;
+	}
 	response = json_stream_success(can->cmd);
 	json_add_node_id(response, "pubkey", &can->id);
 	json_add_bool(response, "verified", t && t->size == 1);

--- a/lightningd/signmessage.c
+++ b/lightningd/signmessage.c
@@ -135,9 +135,12 @@ static void listnodes_done(const char *buffer,
 		t = json_get_member(buffer, t, "nodes");
 
 	if (!deprecated_apis && (!t || t->size == 0)) {
-		was_pending(command_fail(can->cmd, SIGNMESSAGE_PUBKEY_NOT_FOUND,
-					 "pub key not found in the graph, expected pubkey is %s",
-					 node_id_to_hexstr(tmpctx, &can->id)));
+		struct json_stream *response;
+		response = json_stream_fail(can->cmd, SIGNMESSAGE_PUBKEY_NOT_FOUND,
+							"pubkey not found in the graph");
+		json_add_node_id(response, "claimed_key", &can->id);
+		json_object_end(response);
+		was_pending(command_failed(can->cmd, response));
 		return;
 	}
 	response = json_stream_success(can->cmd);

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2717,8 +2717,11 @@ def test_checkmessage_pubkey_not_found(node_factory):
     pubkey = "03be3b0e9992153b1d5a6e1623670b6c3663f72ce6cf2e0dd39c0a373a7de5a3b7"
     zbase = "d66bqz3qsku5fxtqsi37j11pci47ydxa95iusphutggz9ezaxt56neh77kxe5hyr41kwgkncgiu94p9ecxiexgpgsz8daoq4tw8kj8yx"
 
-    with pytest.raises(RpcError, match="not found in the graph, expected pubkey is {}".format(pubkey)):
+    with pytest.raises(RpcError) as exception:
         l1.rpc.checkmessage(msg, zbase)
+    err = exception.value
+    assert err.error['message'] == "pubkey not found in the graph"
+    assert err.error['data']['claimed_key'] == pubkey
 
     check_result = l1.rpc.checkmessage(msg, zbase, pubkey=pubkey)
     assert check_result["pubkey"] == pubkey

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1847,6 +1847,7 @@ def test_relative_config_dir(node_factory):
 def test_signmessage(node_factory):
     l1, l2 = node_factory.line_graph(2, wait_for_announce=True,
                                      opts={'allow-deprecated-apis': True})
+    l1.rpc.jsonschemas = {}
 
     corpus = [[None,
                "this is a test!",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1845,7 +1845,8 @@ def test_relative_config_dir(node_factory):
 
 
 def test_signmessage(node_factory):
-    l1, l2 = node_factory.line_graph(2, wait_for_announce=True)
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=True,
+                                     opts={'allow-deprecated-apis': True})
 
     corpus = [[None,
                "this is a test!",
@@ -2707,3 +2708,18 @@ def test_torv2_in_db(node_factory):
     l1.stop()
     l1.db_manip("UPDATE peers SET address='3fyb44wdhnd2ghhl.onion:1234';")
     l1.start()
+
+
+def test_checkmessage_pubkey_not_found(node_factory):
+    l1 = node_factory.get_node()
+
+    msg = "testcase to check new rpc error"
+    pubkey = "03be3b0e9992153b1d5a6e1623670b6c3663f72ce6cf2e0dd39c0a373a7de5a3b7"
+    zbase = "d66bqz3qsku5fxtqsi37j11pci47ydxa95iusphutggz9ezaxt56neh77kxe5hyr41kwgkncgiu94p9ecxiexgpgsz8daoq4tw8kj8yx"
+
+    with pytest.raises(RpcError, match="not found in the graph, expected pubkey is {}".format(pubkey)):
+        l1.rpc.checkmessage(msg, zbase)
+
+    check_result = l1.rpc.checkmessage(msg, zbase, pubkey=pubkey)
+    assert check_result["pubkey"] == pubkey
+    assert check_result["verified"] is True


### PR DESCRIPTION
Returning a warning message when the pub key is not specified and there is no node in the graph.

We try to help people that use core lightning as a signer and nothing else.

Fixes https://github.com/ElementsProject/lightning/issues/5247

Changelog-Added: rpc: checkmessage return an warning msg when no node is found in the graph and no pubkey is provided.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>