### PR TITLE
connectd: fix accidental handling of old reconnections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 TODO: Insert version codename, and username of the contributor that named the release.
 -->
 
+## [0.11.1] - 2022-05-13: Simon's Carefully Chosen Release Name II
+
+Single change which fixed a bug introduced in 0.11.0 which could cause
+unwanted unilateral closes (`bad reestablish revocation_number: 0 vs 3`)
+
+### Fixed
+
+ - connectd: make sure we don't keep stale reconnections around. ([#5256])
+ - connectd: fix assert which we could trigger. ([#5256])
+
+[#5256]: https://github.com/ElementsProject/lightning/pull/5256
+
 ## [0.11.0.1] - 2022-04-04: Simon's Carefully Chosen Release Name
 
 This release would have been named by Simon Vrouwe, had he responded to my emails!

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1900,7 +1900,6 @@ void peer_conn_closed(struct peer *peer)
 	struct connecting *connect = find_connecting(peer->daemon, &peer->id);
 
 	/* These should be closed already! */
-	assert(tal_count(peer->subds) == 0);
 	assert(!peer->to_peer);
 	assert(peer->ready_to_die || !peer->active);
 


### PR DESCRIPTION
We had multiple reports of channels being unilaterally closed because
it seemed like the peer was sending old revocation numbers.

Turns out, it was actually old reestablish messages!  When we have a
reconnection, we would put the new connection aside, and tell lightningd
to close the current connection: when it did, we would restart
processing of the initial reconnection.

However, we could end up with *multiple* "reconnecting" connections,
while waiting for an existing connection to close.  Though the
connections were long gone, there could still be messages queued
(particularly the channel_reestablish message, which comes early on).

Eventually, a normal reconnection would cause us to process one of
these reconnecting connections, and channeld would see the (perhaps
very old!) messages, and get confused.

(I have a test which triggers this, but it also hangs the connect
 command, due to other issues we will fix in the next release...)

Fixes: #5240
Fixes: #5235