### PR TITLE
cln-rpc: API improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitcoin_hashes"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +126,7 @@ name = "cln-grpc"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "bitcoin_hashes",
  "cln-rpc",
  "hex",
  "log",
@@ -164,6 +174,7 @@ name = "cln-rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitcoin_hashes",
  "bytes",
  "env_logger",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "async-stream"
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -89,15 +89,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -113,9 +113,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -166,7 +166,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -180,10 +180,11 @@ dependencies = [
  "futures-util",
  "hex",
  "log",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -218,15 +219,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -258,9 +259,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -273,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -283,15 +284,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -300,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -317,21 +318,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -347,20 +348,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -371,15 +372,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -407,9 +408,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -418,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -447,9 +448,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.18"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -483,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -502,24 +503,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -532,9 +533,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "log"
@@ -559,13 +560,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -636,24 +637,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -667,18 +668,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -705,11 +706,11 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -765,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -795,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -817,18 +818,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -837,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -889,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "sct"
@@ -904,19 +905,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.137"
+name = "secp256k1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+dependencies = [
+ "secp256k1-sys",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -925,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -936,15 +956,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -958,13 +981,13 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -992,18 +1015,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1012,10 +1035,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1040,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1073,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1087,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1123,7 +1147,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1145,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1157,7 +1181,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.4",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1171,15 +1195,15 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -1190,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1201,11 +1225,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1225,16 +1249,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
+name = "unicode-ident"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.3"
+name = "unicode-segmentation"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "untrusted"
@@ -1254,21 +1278,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1276,13 +1294,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1291,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1301,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1314,15 +1332,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1340,13 +1358,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -10,6 +10,7 @@ cln-rpc = { path="../cln-rpc" }
 tonic = { version = "^0.5", features = ["tls", "transport"] }
 prost = "0.8"
 hex = "0.4.3"
+bitcoin_hashes = { version = "0.10.0", features = [ "serde" ] }
 
 [dev-dependencies]
 serde_json = "1.0.72"

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-cln-rpc = { path="../cln-rpc" }
+cln-rpc = { path="../cln-rpc/" }
 tonic = { version = "^0.5", features = ["tls", "transport"] }
 prost = "0.8"
 hex = "0.4.3"

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -8,6 +8,8 @@ use std::convert::From;
 use cln_rpc::model::{responses,requests};
 use crate::pb;
 use std::str::FromStr;
+use bitcoin_hashes::sha256::Hash as Sha256;
+use bitcoin_hashes::Hash;
 
 #[allow(unused_variables)]
 impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
@@ -1020,7 +1022,7 @@ impl From<pb::SendpayRequest> for requests::SendpayRequest {
     fn from(c: pb::SendpayRequest) -> Self {
         Self {
             route: c.route.into_iter().map(|s| s.into()).collect(), // Rule #4
-            payment_hash: c.payment_hash.try_into().unwrap(), // Rule #1 for type hash
+            payment_hash: Sha256::from_slice(&c.payment_hash).unwrap(), // Rule #1 for type hash
             label: c.label, // Rule #1 for type string?
             amount_msat: c.amount_msat.map(|a| a.into()), // Rule #1 for type msat?
             bolt11: c.bolt11, // Rule #1 for type string?
@@ -1218,14 +1220,14 @@ impl From<pb::SendonionRequest> for requests::SendonionRequest {
     fn from(c: pb::SendonionRequest) -> Self {
         Self {
             onion: hex::encode(&c.onion), // Rule #1 for type hex
-            payment_hash: c.payment_hash.try_into().unwrap(), // Rule #1 for type hash
+            payment_hash: Sha256::from_slice(&c.payment_hash).unwrap(), // Rule #1 for type hash
             label: c.label, // Rule #1 for type string?
             shared_secrets: Some(c.shared_secrets.into_iter().map(|s| s.try_into().unwrap()).collect()), // Rule #4
             partid: c.partid.map(|v| v as u16), // Rule #1 for type u16?
             bolt11: c.bolt11, // Rule #1 for type string?
             amount_msat: c.amount_msat.map(|a| a.into()), // Rule #1 for type msat?
             destination: c.destination.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
-            localofferid: c.localofferid.map(|v| v.try_into().unwrap()), // Rule #1 for type hash?
+            localofferid: c.localofferid.map(|v| Sha256::from_slice(&v).unwrap()), // Rule #1 for type hash?
             groupid: c.groupid, // Rule #1 for type u64?
         }
     }
@@ -1236,7 +1238,7 @@ impl From<pb::ListsendpaysRequest> for requests::ListsendpaysRequest {
     fn from(c: pb::ListsendpaysRequest) -> Self {
         Self {
             bolt11: c.bolt11, // Rule #1 for type string?
-            payment_hash: c.payment_hash.map(|v| v.try_into().unwrap()), // Rule #1 for type hash?
+            payment_hash: c.payment_hash.map(|v| Sha256::from_slice(&v).unwrap()), // Rule #1 for type hash?
             status: c.status.map(|v| v.try_into().unwrap()),
         }
     }
@@ -1302,7 +1304,7 @@ impl From<pb::WaitinvoiceRequest> for requests::WaitinvoiceRequest {
 impl From<pb::WaitsendpayRequest> for requests::WaitsendpayRequest {
     fn from(c: pb::WaitsendpayRequest) -> Self {
         Self {
-            payment_hash: c.payment_hash.try_into().unwrap(), // Rule #1 for type hash
+            payment_hash: Sha256::from_slice(&c.payment_hash).unwrap(), // Rule #1 for type hash
             timeout: c.timeout, // Rule #1 for type u32?
             partid: c.partid, // Rule #1 for type u64?
             groupid: c.groupid, // Rule #1 for type u64?
@@ -1502,7 +1504,7 @@ impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
     fn from(c: pb::ListpaysRequest) -> Self {
         Self {
             bolt11: c.bolt11, // Rule #1 for type string?
-            payment_hash: c.payment_hash.map(|v| v.try_into().unwrap()), // Rule #1 for type hash?
+            payment_hash: c.payment_hash.map(|v| Sha256::from_slice(&v).unwrap()), // Rule #1 for type hash?
             status: c.status.map(|v| v.try_into().unwrap()),
         }
     }

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -10,6 +10,7 @@ use crate::pb;
 use std::str::FromStr;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash;
+use cln_rpc::primitives::PublicKey;
 
 #[allow(unused_variables)]
 impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
@@ -38,7 +39,7 @@ impl From<responses::GetinfoBinding> for pb::GetinfoBinding {
 impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
     fn from(c: responses::GetinfoResponse) -> Self {
         Self {
-            id: c.id.to_vec(), // Rule #2 for type pubkey
+            id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             alias: c.alias, // Rule #2 for type string
             color: hex::decode(&c.color).unwrap(), // Rule #2 for type hex
             num_peers: c.num_peers, // Rule #2 for type u32
@@ -67,7 +68,7 @@ impl From<responses::ListpeersPeersLog> for pb::ListpeersPeersLog {
             time: c.time, // Rule #2 for type string?
             source: c.source, // Rule #2 for type string?
             log: c.log, // Rule #2 for type string?
-            node_id: c.node_id.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            node_id: c.node_id.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             data: c.data.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
         }
     }
@@ -160,7 +161,7 @@ impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
 impl From<responses::ListpeersPeers> for pb::ListpeersPeers {
     fn from(c: responses::ListpeersPeers) -> Self {
         Self {
-            id: c.id.to_vec(), // Rule #2 for type pubkey
+            id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             connected: c.connected, // Rule #2 for type boolean
             log: c.log.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
             channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpeersPeersChannels 
@@ -201,7 +202,7 @@ impl From<responses::ListfundsOutputs> for pb::ListfundsOutputs {
 impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
     fn from(c: responses::ListfundsChannels) -> Self {
         Self {
-            peer_id: c.peer_id.to_vec(), // Rule #2 for type pubkey
+            peer_id: c.peer_id.serialize().to_vec(), // Rule #2 for type pubkey
             our_amount_msat: Some(c.our_amount_msat.into()), // Rule #2 for type msat
             amount_msat: Some(c.amount_msat.into()), // Rule #2 for type msat
             funding_txid: hex::decode(&c.funding_txid).unwrap(), // Rule #2 for type txid
@@ -232,7 +233,7 @@ impl From<responses::SendpayResponse> for pb::SendpayResponse {
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             status: c.status as i32,
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             created_at: c.created_at, // Rule #2 for type u64
             completed_at: c.completed_at, // Rule #2 for type u64?
             amount_sent_msat: Some(c.amount_sent_msat.into()), // Rule #2 for type msat
@@ -250,8 +251,8 @@ impl From<responses::SendpayResponse> for pb::SendpayResponse {
 impl From<responses::ListchannelsChannels> for pb::ListchannelsChannels {
     fn from(c: responses::ListchannelsChannels) -> Self {
         Self {
-            source: c.source.to_vec(), // Rule #2 for type pubkey
-            destination: c.destination.to_vec(), // Rule #2 for type pubkey
+            source: c.source.serialize().to_vec(), // Rule #2 for type pubkey
+            destination: c.destination.serialize().to_vec(), // Rule #2 for type pubkey
             short_channel_id: c.short_channel_id.to_string(), // Rule #2 for type short_channel_id
             public: c.public, // Rule #2 for type boolean
             amount_msat: Some(c.amount_msat.into()), // Rule #2 for type msat
@@ -302,7 +303,7 @@ impl From<responses::CheckmessageResponse> for pb::CheckmessageResponse {
     fn from(c: responses::CheckmessageResponse) -> Self {
         Self {
             verified: c.verified, // Rule #2 for type boolean
-            pubkey: c.pubkey.to_vec(), // Rule #2 for type pubkey
+            pubkey: c.pubkey.serialize().to_vec(), // Rule #2 for type pubkey
         }
     }
 }
@@ -322,7 +323,7 @@ impl From<responses::CloseResponse> for pb::CloseResponse {
 impl From<responses::ConnectResponse> for pb::ConnectResponse {
     fn from(c: responses::ConnectResponse) -> Self {
         Self {
-            id: c.id.to_vec(), // Rule #2 for type pubkey
+            id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             features: hex::decode(&c.features).unwrap(), // Rule #2 for type hex
             direction: c.direction as i32,
         }
@@ -488,7 +489,7 @@ impl From<responses::SendonionResponse> for pb::SendonionResponse {
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             status: c.status as i32,
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             created_at: c.created_at, // Rule #2 for type u64
             amount_sent_msat: Some(c.amount_sent_msat.into()), // Rule #2 for type msat
             label: c.label, // Rule #2 for type string?
@@ -510,7 +511,7 @@ impl From<responses::ListsendpaysPayments> for pb::ListsendpaysPayments {
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             status: c.status as i32,
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             created_at: c.created_at, // Rule #2 for type u64
             amount_sent_msat: Some(c.amount_sent_msat.into()), // Rule #2 for type msat
             label: c.label, // Rule #2 for type string?
@@ -589,7 +590,7 @@ impl From<responses::PayResponse> for pb::PayResponse {
     fn from(c: responses::PayResponse) -> Self {
         Self {
             payment_preimage: c.payment_preimage.to_vec(), // Rule #2 for type secret
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             created_at: c.created_at, // Rule #2 for type number
             parts: c.parts, // Rule #2 for type u32
@@ -616,7 +617,7 @@ impl From<responses::ListnodesNodesAddresses> for pb::ListnodesNodesAddresses {
 impl From<responses::ListnodesNodes> for pb::ListnodesNodes {
     fn from(c: responses::ListnodesNodes) -> Self {
         Self {
-            nodeid: c.nodeid.to_vec(), // Rule #2 for type pubkey
+            nodeid: c.nodeid.serialize().to_vec(), // Rule #2 for type pubkey
             last_timestamp: c.last_timestamp, // Rule #2 for type u32?
             alias: c.alias, // Rule #2 for type string?
             color: c.color.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
@@ -684,7 +685,7 @@ impl From<responses::WaitsendpayResponse> for pb::WaitsendpayResponse {
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             status: c.status as i32,
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             created_at: c.created_at, // Rule #2 for type u64
             completed_at: c.completed_at, // Rule #2 for type number?
             amount_sent_msat: Some(c.amount_sent_msat.into()), // Rule #2 for type msat
@@ -723,7 +724,7 @@ impl From<responses::KeysendResponse> for pb::KeysendResponse {
     fn from(c: responses::KeysendResponse) -> Self {
         Self {
             payment_preimage: c.payment_preimage.to_vec(), // Rule #2 for type secret
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             created_at: c.created_at, // Rule #2 for type number
             parts: c.parts, // Rule #2 for type u32
@@ -875,7 +876,7 @@ impl From<responses::FundchannelResponse> for pb::FundchannelResponse {
 impl From<responses::GetrouteRoute> for pb::GetrouteRoute {
     fn from(c: responses::GetrouteRoute) -> Self {
         Self {
-            id: c.id.to_vec(), // Rule #2 for type pubkey
+            id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             channel: c.channel.to_string(), // Rule #2 for type short_channel_id
             direction: c.direction, // Rule #2 for type u32
             amount_msat: Some(c.amount_msat.into()), // Rule #2 for type msat
@@ -927,7 +928,7 @@ impl From<responses::ListpaysPays> for pb::ListpaysPays {
         Self {
             payment_hash: hex::decode(&c.payment_hash).unwrap(), // Rule #2 for type hex
             status: c.status as i32,
-            destination: c.destination.map(|v| v.to_vec()), // Rule #2 for type pubkey?
+            destination: c.destination.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             created_at: c.created_at, // Rule #2 for type u64
             completed_at: c.completed_at, // Rule #2 for type u64?
             label: c.label, // Rule #2 for type string?
@@ -990,7 +991,7 @@ impl From<pb::GetinfoRequest> for requests::GetinfoRequest {
 impl From<pb::ListpeersRequest> for requests::ListpeersRequest {
     fn from(c: pb::ListpeersRequest) -> Self {
         Self {
-            id: c.id.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            id: c.id.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
             level: c.level, // Rule #1 for type string?
         }
     }
@@ -1010,7 +1011,7 @@ impl From<pb::SendpayRoute> for requests::SendpayRoute {
     fn from(c: pb::SendpayRoute) -> Self {
         Self {
             amount_msat: c.amount_msat.unwrap().into(), // Rule #1 for type msat
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
+            id: PublicKey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
             delay: c.delay as u16, // Rule #1 for type u16
             channel: cln_rpc::primitives::ShortChannelId::from_str(&c.channel).unwrap(), // Rule #1 for type short_channel_id
         }
@@ -1039,8 +1040,8 @@ impl From<pb::ListchannelsRequest> for requests::ListchannelsRequest {
     fn from(c: pb::ListchannelsRequest) -> Self {
         Self {
             short_channel_id: c.short_channel_id.map(|v| cln_rpc::primitives::ShortChannelId::from_str(&v).unwrap()), // Rule #1 for type short_channel_id?
-            source: c.source.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
-            destination: c.destination.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            source: c.source.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
+            destination: c.destination.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
         }
     }
 }
@@ -1070,7 +1071,7 @@ impl From<pb::CheckmessageRequest> for requests::CheckmessageRequest {
         Self {
             message: c.message, // Rule #1 for type string
             zbase: c.zbase, // Rule #1 for type string
-            pubkey: c.pubkey.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            pubkey: c.pubkey.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
         }
     }
 }
@@ -1129,7 +1130,7 @@ impl From<pb::DatastoreRequest> for requests::DatastoreRequest {
 impl From<pb::CreateonionHops> for requests::CreateonionHops {
     fn from(c: pb::CreateonionHops) -> Self {
         Self {
-            pubkey: cln_rpc::primitives::Pubkey::from_slice(&c.pubkey).unwrap(), // Rule #1 for type pubkey
+            pubkey: PublicKey::from_slice(&c.pubkey).unwrap(), // Rule #1 for type pubkey
             payload: hex::encode(&c.payload), // Rule #1 for type hex
         }
     }
@@ -1226,7 +1227,7 @@ impl From<pb::SendonionRequest> for requests::SendonionRequest {
             partid: c.partid.map(|v| v as u16), // Rule #1 for type u16?
             bolt11: c.bolt11, // Rule #1 for type string?
             amount_msat: c.amount_msat.map(|a| a.into()), // Rule #1 for type msat?
-            destination: c.destination.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            destination: c.destination.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
             localofferid: c.localofferid.map(|v| Sha256::from_slice(&v).unwrap()), // Rule #1 for type hash?
             groupid: c.groupid, // Rule #1 for type u64?
         }
@@ -1276,7 +1277,7 @@ impl From<pb::PayRequest> for requests::PayRequest {
 impl From<pb::ListnodesRequest> for requests::ListnodesRequest {
     fn from(c: pb::ListnodesRequest) -> Self {
         Self {
-            id: c.id.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            id: c.id.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
         }
     }
 }
@@ -1338,7 +1339,7 @@ impl From<pb::WithdrawRequest> for requests::WithdrawRequest {
 impl From<pb::KeysendRequest> for requests::KeysendRequest {
     fn from(c: pb::KeysendRequest) -> Self {
         Self {
-            destination: cln_rpc::primitives::Pubkey::from_slice(&c.destination).unwrap(), // Rule #1 for type pubkey
+            destination: PublicKey::from_slice(&c.destination).unwrap(), // Rule #1 for type pubkey
             amount_msat: c.amount_msat.unwrap().into(), // Rule #1 for type msat
             label: c.label, // Rule #1 for type string?
             maxfeepercent: c.maxfeepercent, // Rule #1 for type number?
@@ -1437,7 +1438,7 @@ impl From<pb::TxsendRequest> for requests::TxsendRequest {
 impl From<pb::DisconnectRequest> for requests::DisconnectRequest {
     fn from(c: pb::DisconnectRequest) -> Self {
         Self {
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
+            id: PublicKey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
             force: c.force, // Rule #1 for type boolean?
         }
     }
@@ -1456,7 +1457,7 @@ impl From<pb::FeeratesRequest> for requests::FeeratesRequest {
 impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
     fn from(c: pb::FundchannelRequest) -> Self {
         Self {
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
+            id: PublicKey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
             amount: c.amount.unwrap().into(), // Rule #1 for type msat_or_all
             feerate: c.feerate.map(|a| a.into()), // Rule #1 for type feerate?
             announce: c.announce, // Rule #1 for type boolean?
@@ -1476,11 +1477,11 @@ impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
 impl From<pb::GetrouteRequest> for requests::GetrouteRequest {
     fn from(c: pb::GetrouteRequest) -> Self {
         Self {
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
+            id: PublicKey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
             amount_msat: c.amount_msat.unwrap().into(), // Rule #1 for type msat
             riskfactor: c.riskfactor, // Rule #1 for type u64
             cltv: c.cltv, // Rule #1 for type number?
-            fromid: c.fromid.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap()), // Rule #1 for type pubkey?
+            fromid: c.fromid.map(|v| PublicKey::from_slice(&v).unwrap()), // Rule #1 for type pubkey?
             fuzzpercent: c.fuzzpercent, // Rule #1 for type u32?
             exclude: Some(c.exclude.into_iter().map(|s| s.into()).collect()), // Rule #4
             maxhops: c.maxhops, // Rule #1 for type u32?
@@ -1514,7 +1515,7 @@ impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
 impl From<pb::PingRequest> for requests::PingRequest {
     fn from(c: pb::PingRequest) -> Self {
         Self {
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
+            id: PublicKey::from_slice(&c.id).unwrap(), // Rule #1 for type pubkey
             len: c.len, // Rule #1 for type number?
             pongbytes: c.pongbytes, // Rule #1 for type number?
         }

--- a/cln-grpc/src/pb.rs
+++ b/cln-grpc/src/pb.rs
@@ -1,6 +1,6 @@
 tonic::include_proto!("cln");
-use std::str::FromStr;
 use bitcoin_hashes::Hash;
+use std::str::FromStr;
 
 use cln_rpc::primitives::{
     Amount as JAmount, AmountOrAll as JAmountOrAll, AmountOrAny as JAmountOrAny,
@@ -106,7 +106,7 @@ impl From<AmountOrAny> for JAmountOrAny {
 impl From<RouteHop> for cln_rpc::primitives::Routehop {
     fn from(c: RouteHop) -> Self {
         Self {
-            id: cln_rpc::primitives::Pubkey::from_slice(&c.id).unwrap(),
+            id: cln_rpc::primitives::PublicKey::from_slice(&c.id).unwrap(),
             scid: cln_rpc::primitives::ShortChannelId::from_str(&c.short_channel_id).unwrap(),
             feebase: c.feebase.unwrap().into(),
             feeprop: c.feeprop,

--- a/cln-grpc/src/pb.rs
+++ b/cln-grpc/src/pb.rs
@@ -1,5 +1,6 @@
 tonic::include_proto!("cln");
 use std::str::FromStr;
+use bitcoin_hashes::Hash;
 
 use cln_rpc::primitives::{
     Amount as JAmount, AmountOrAll as JAmountOrAll, AmountOrAny as JAmountOrAny,
@@ -21,7 +22,7 @@ impl From<Amount> for JAmount {
 impl From<JOutpoint> for Outpoint {
     fn from(a: JOutpoint) -> Self {
         Outpoint {
-            txid: a.txid,
+            txid: a.txid.to_vec(),
             outnum: a.outnum,
         }
     }
@@ -30,7 +31,7 @@ impl From<JOutpoint> for Outpoint {
 impl From<Outpoint> for JOutpoint {
     fn from(a: Outpoint) -> Self {
         JOutpoint {
-            txid: a.txid,
+            txid: bitcoin_hashes::sha256::Hash::from_slice(&a.txid).unwrap(),
             outnum: a.outnum,
         }
     }

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -9,6 +9,7 @@ path = "examples/getinfo.rs"
 
 [dependencies]
 anyhow = "1.0.51"
+bitcoin_hashes = { version = "0.10.0", features = [ "serde" ] }
 bytes = "1.1.0"
 log = "0.4.14"
 serde = { version = "1.0.131", features = ["derive"] }

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.51"
 bitcoin_hashes = { version = "0.10.0", features = [ "serde" ] }
 bytes = "1.1.0"
 log = "0.4.14"
+secp256k1 = { version = "0.22.1", features = [ "serde" ] }
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.72"
 tokio-util = { version = "0.6.9", features = ["codec"] }

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -148,7 +148,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersRequest {
 	    #[serde(alias = "id", skip_serializing_if = "Option::is_none")]
-	    pub id: Option<Pubkey>,
+	    pub id: Option<PublicKey>,
 	    #[serde(alias = "level", skip_serializing_if = "Option::is_none")]
 	    pub level: Option<String>,
 	}
@@ -184,7 +184,7 @@ pub mod requests {
 	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "delay")]
 	    pub delay: u16,
 	    #[serde(alias = "channel")]
@@ -228,9 +228,9 @@ pub mod requests {
 	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
 	    #[serde(alias = "source", skip_serializing_if = "Option::is_none")]
-	    pub source: Option<Pubkey>,
+	    pub source: Option<PublicKey>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	}
 
 	impl From<ListchannelsRequest> for Request {
@@ -284,7 +284,7 @@ pub mod requests {
 	    #[serde(alias = "zbase")]
 	    pub zbase: String,
 	    #[serde(alias = "pubkey", skip_serializing_if = "Option::is_none")]
-	    pub pubkey: Option<Pubkey>,
+	    pub pubkey: Option<PublicKey>,
 	}
 
 	impl From<CheckmessageRequest> for Request {
@@ -419,7 +419,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionHops {
 	    #[serde(alias = "pubkey")]
-	    pub pubkey: Pubkey,
+	    pub pubkey: PublicKey,
 	    #[serde(alias = "payload")]
 	    pub payload: String,
 	}
@@ -595,7 +595,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendonionFirst_hop {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
 	    #[serde(alias = "delay")]
@@ -619,7 +619,7 @@ pub mod requests {
 	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "localofferid", skip_serializing_if = "Option::is_none")]
 	    pub localofferid: Option<Sha256>,
 	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
@@ -732,7 +732,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesRequest {
 	    #[serde(alias = "id", skip_serializing_if = "Option::is_none")]
-	    pub id: Option<Pubkey>,
+	    pub id: Option<PublicKey>,
 	}
 
 	impl From<ListnodesRequest> for Request {
@@ -869,7 +869,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct KeysendRequest {
 	    #[serde(alias = "destination")]
-	    pub destination: Pubkey,
+	    pub destination: PublicKey,
 	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
 	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
@@ -1051,7 +1051,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DisconnectRequest {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "force", skip_serializing_if = "Option::is_none")]
 	    pub force: Option<bool>,
 	}
@@ -1104,7 +1104,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundchannelRequest {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "amount")]
 	    pub amount: AmountOrAll,
 	    #[serde(alias = "feerate", skip_serializing_if = "Option::is_none")]
@@ -1142,7 +1142,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRequest {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
 	    #[serde(alias = "riskfactor")]
@@ -1150,7 +1150,7 @@ pub mod requests {
 	    #[serde(alias = "cltv", skip_serializing_if = "Option::is_none")]
 	    pub cltv: Option<f64>,
 	    #[serde(alias = "fromid", skip_serializing_if = "Option::is_none")]
-	    pub fromid: Option<Pubkey>,
+	    pub fromid: Option<PublicKey>,
 	    #[serde(alias = "fuzzpercent", skip_serializing_if = "Option::is_none")]
 	    pub fuzzpercent: Option<u32>,
 	    #[serde(alias = "exclude", skip_serializing_if = "crate::is_none_or_empty")]
@@ -1257,7 +1257,7 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PingRequest {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "len", skip_serializing_if = "Option::is_none")]
 	    pub len: Option<f64>,
 	    #[serde(alias = "pongbytes", skip_serializing_if = "Option::is_none")]
@@ -1412,7 +1412,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoResponse {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "alias")]
 	    pub alias: String,
 	    #[serde(alias = "color")]
@@ -1453,7 +1453,7 @@ pub mod responses {
 	            Response::Getinfo(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -1503,7 +1503,7 @@ pub mod responses {
 	    #[serde(alias = "log", skip_serializing_if = "Option::is_none")]
 	    pub log: Option<String>,
 	    #[serde(alias = "node_id", skip_serializing_if = "Option::is_none")]
-	    pub node_id: Option<Pubkey>,
+	    pub node_id: Option<PublicKey>,
 	    #[serde(alias = "data", skip_serializing_if = "Option::is_none")]
 	    pub data: Option<String>,
 	}
@@ -1762,7 +1762,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeers {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "connected")]
 	    pub connected: bool,
 	    #[serde(alias = "log", skip_serializing_if = "crate::is_none_or_empty")]
@@ -1791,7 +1791,7 @@ pub mod responses {
 	            Response::ListPeers(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -1841,7 +1841,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsChannels {
 	    #[serde(alias = "peer_id")]
-	    pub peer_id: Pubkey,
+	    pub peer_id: PublicKey,
 	    #[serde(alias = "our_amount_msat")]
 	    pub our_amount_msat: Amount,
 	    #[serde(alias = "amount_msat")]
@@ -1875,7 +1875,7 @@ pub mod responses {
 	            Response::ListFunds(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of the payment (could be complete if already sent previously)
@@ -1911,7 +1911,7 @@ pub mod responses {
 	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
 	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
@@ -1940,15 +1940,15 @@ pub mod responses {
 	            Response::SendPay(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsChannels {
 	    #[serde(alias = "source")]
-	    pub source: Pubkey,
+	    pub source: PublicKey,
 	    #[serde(alias = "destination")]
-	    pub destination: Pubkey,
+	    pub destination: PublicKey,
 	    #[serde(alias = "short_channel_id")]
 	    pub short_channel_id: ShortChannelId,
 	    #[serde(alias = "public")]
@@ -1991,7 +1991,7 @@ pub mod responses {
 	            Response::ListChannels(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2006,7 +2006,7 @@ pub mod responses {
 	            Response::AddGossip(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2027,7 +2027,7 @@ pub mod responses {
 	            Response::AutoCleanInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2035,7 +2035,7 @@ pub mod responses {
 	    #[serde(alias = "verified")]
 	    pub verified: bool,
 	    #[serde(alias = "pubkey")]
-	    pub pubkey: Pubkey,
+	    pub pubkey: PublicKey,
 	}
 
 	impl TryFrom<Response> for CheckmessageResponse {
@@ -2046,7 +2046,7 @@ pub mod responses {
 	            Response::CheckMessage(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether we successfully negotiated a mutual close, closed without them, or discarded not-yet-opened channel
@@ -2090,7 +2090,7 @@ pub mod responses {
 	            Response::Close(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether they initiated connection or we did
@@ -2156,7 +2156,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ConnectResponse {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "features")]
 	    pub features: String,
 	    // Path `Connect.direction`
@@ -2172,7 +2172,7 @@ pub mod responses {
 	            Response::Connect(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether it has been paid, or can no longer be paid
@@ -2238,7 +2238,7 @@ pub mod responses {
 	            Response::CreateInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2261,7 +2261,7 @@ pub mod responses {
 	            Response::Datastore(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2280,7 +2280,7 @@ pub mod responses {
 	            Response::CreateOnion(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2303,7 +2303,7 @@ pub mod responses {
 	            Response::DelDatastore(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2318,7 +2318,7 @@ pub mod responses {
 	            Response::DelExpiredInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// State of invoice
@@ -2376,7 +2376,7 @@ pub mod responses {
 	            Response::DelInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2409,7 +2409,7 @@ pub mod responses {
 	            Response::Invoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2438,7 +2438,7 @@ pub mod responses {
 	            Response::ListDatastore(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether it's paid, unpaid or unpayable
@@ -2510,7 +2510,7 @@ pub mod responses {
 	            Response::ListInvoices(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of the payment (could be complete if already sent previously)
@@ -2544,7 +2544,7 @@ pub mod responses {
 	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
 	    #[serde(alias = "amount_sent_msat")]
@@ -2571,7 +2571,7 @@ pub mod responses {
 	            Response::SendOnion(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of the payment
@@ -2610,7 +2610,7 @@ pub mod responses {
 	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
 	    #[serde(alias = "amount_sent_msat")]
@@ -2643,7 +2643,7 @@ pub mod responses {
 	            Response::ListSendPays(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// the purpose of this input (*EXPERIMENTAL_FEATURES* only)
@@ -2802,7 +2802,7 @@ pub mod responses {
 	            Response::ListTransactions(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of payment
@@ -2832,7 +2832,7 @@ pub mod responses {
 	    #[serde(alias = "payment_preimage")]
 	    pub payment_preimage: Secret,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    #[serde(alias = "created_at")]
@@ -2858,7 +2858,7 @@ pub mod responses {
 	            Response::Pay(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Type of connection
@@ -2906,7 +2906,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesNodes {
 	    #[serde(alias = "nodeid")]
-	    pub nodeid: Pubkey,
+	    pub nodeid: PublicKey,
 	    #[serde(alias = "last_timestamp", skip_serializing_if = "Option::is_none")]
 	    pub last_timestamp: Option<u32>,
 	    #[serde(alias = "alias", skip_serializing_if = "Option::is_none")]
@@ -2933,7 +2933,7 @@ pub mod responses {
 	            Response::ListNodes(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether it's paid or expired
@@ -2992,7 +2992,7 @@ pub mod responses {
 	            Response::WaitAnyInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// Whether it's paid or expired
@@ -3051,7 +3051,7 @@ pub mod responses {
 	            Response::WaitInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of the payment
@@ -3084,7 +3084,7 @@ pub mod responses {
 	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
 	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
@@ -3111,7 +3111,7 @@ pub mod responses {
 	            Response::WaitSendPay(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3130,7 +3130,7 @@ pub mod responses {
 	            Response::NewAddr(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3151,7 +3151,7 @@ pub mod responses {
 	            Response::Withdraw(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of payment
@@ -3175,7 +3175,7 @@ pub mod responses {
 	    #[serde(alias = "payment_preimage")]
 	    pub payment_preimage: Secret,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    #[serde(alias = "created_at")]
@@ -3201,7 +3201,7 @@ pub mod responses {
 	            Response::KeySend(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3242,7 +3242,7 @@ pub mod responses {
 	            Response::FundPsbt(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3261,7 +3261,7 @@ pub mod responses {
 	            Response::SendPsbt(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3278,7 +3278,7 @@ pub mod responses {
 	            Response::SignPsbt(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3319,7 +3319,7 @@ pub mod responses {
 	            Response::UtxoPsbt(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3338,7 +3338,7 @@ pub mod responses {
 	            Response::TxDiscard(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3359,7 +3359,7 @@ pub mod responses {
 	            Response::TxPrepare(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3380,7 +3380,7 @@ pub mod responses {
 	            Response::TxSend(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3395,7 +3395,7 @@ pub mod responses {
 	            Response::Disconnect(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3466,7 +3466,7 @@ pub mod responses {
 	            Response::Feerates(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3493,7 +3493,7 @@ pub mod responses {
 	            Response::FundChannel(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// The features understood by the destination node
@@ -3515,7 +3515,7 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRoute {
 	    #[serde(alias = "id")]
-	    pub id: Pubkey,
+	    pub id: PublicKey,
 	    #[serde(alias = "channel")]
 	    pub channel: ShortChannelId,
 	    #[serde(alias = "direction")]
@@ -3543,7 +3543,7 @@ pub mod responses {
 	            Response::GetRoute(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// still ongoing, completed, failed locally, or failed after forwarding
@@ -3629,7 +3629,7 @@ pub mod responses {
 	            Response::ListForwards(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	/// status of the payment
@@ -3662,7 +3662,7 @@ pub mod responses {
 	    #[serde(rename = "status")]
 	    pub status: ListpaysPaysStatus,
 	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
-	    pub destination: Option<Pubkey>,
+	    pub destination: Option<PublicKey>,
 	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
 	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
@@ -3697,7 +3697,7 @@ pub mod responses {
 	            Response::ListPays(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3714,7 +3714,7 @@ pub mod responses {
 	            Response::Ping(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3735,7 +3735,7 @@ pub mod responses {
 	            Response::SignMessage(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3750,7 +3750,7 @@ pub mod responses {
 	            Response::Stop(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
-	    } 
+	    }
 	}
 
 }

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -116,14 +116,33 @@ pub enum Response {
 	Stop(responses::StopResponse),
 }
 
+
+pub trait IntoRequest: Into<Request> {
+    type Response: TryFrom<Response, Error = TryFromResponseError>;
+}
+
+#[derive(Debug)]
+pub struct TryFromResponseError;
+
 pub mod requests {
     #[allow(unused_imports)]
     use crate::primitives::*;
     #[allow(unused_imports)]
     use serde::{{Deserialize, Serialize}};
+    use super::{IntoRequest, Request};
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoRequest {
+	}
+
+	impl From<GetinfoRequest> for Request {
+	    fn from(r: GetinfoRequest) -> Self {
+	        Request::Getinfo(r)
+	    }
+	}
+
+	impl IntoRequest for GetinfoRequest {
+	    type Response = super::responses::GetinfoResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -134,10 +153,30 @@ pub mod requests {
 	    pub level: Option<String>,
 	}
 
+	impl From<ListpeersRequest> for Request {
+	    fn from(r: ListpeersRequest) -> Self {
+	        Request::ListPeers(r)
+	    }
+	}
+
+	impl IntoRequest for ListpeersRequest {
+	    type Response = super::responses::ListpeersResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsRequest {
 	    #[serde(alias = "spent", skip_serializing_if = "Option::is_none")]
 	    pub spent: Option<bool>,
+	}
+
+	impl From<ListfundsRequest> for Request {
+	    fn from(r: ListfundsRequest) -> Self {
+	        Request::ListFunds(r)
+	    }
+	}
+
+	impl IntoRequest for ListfundsRequest {
+	    type Response = super::responses::ListfundsResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -174,6 +213,16 @@ pub mod requests {
 	    pub groupid: Option<u64>,
 	}
 
+	impl From<SendpayRequest> for Request {
+	    fn from(r: SendpayRequest) -> Self {
+	        Request::SendPay(r)
+	    }
+	}
+
+	impl IntoRequest for SendpayRequest {
+	    type Response = super::responses::SendpayResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsRequest {
 	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
@@ -184,10 +233,30 @@ pub mod requests {
 	    pub destination: Option<Pubkey>,
 	}
 
+	impl From<ListchannelsRequest> for Request {
+	    fn from(r: ListchannelsRequest) -> Self {
+	        Request::ListChannels(r)
+	    }
+	}
+
+	impl IntoRequest for ListchannelsRequest {
+	    type Response = super::responses::ListchannelsResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct AddgossipRequest {
 	    #[serde(alias = "message")]
 	    pub message: String,
+	}
+
+	impl From<AddgossipRequest> for Request {
+	    fn from(r: AddgossipRequest) -> Self {
+	        Request::AddGossip(r)
+	    }
+	}
+
+	impl IntoRequest for AddgossipRequest {
+	    type Response = super::responses::AddgossipResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -198,6 +267,16 @@ pub mod requests {
 	    pub cycle_seconds: Option<u64>,
 	}
 
+	impl From<AutocleaninvoiceRequest> for Request {
+	    fn from(r: AutocleaninvoiceRequest) -> Self {
+	        Request::AutoCleanInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for AutocleaninvoiceRequest {
+	    type Response = super::responses::AutocleaninvoiceResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CheckmessageRequest {
 	    #[serde(alias = "message")]
@@ -206,6 +285,16 @@ pub mod requests {
 	    pub zbase: String,
 	    #[serde(alias = "pubkey", skip_serializing_if = "Option::is_none")]
 	    pub pubkey: Option<Pubkey>,
+	}
+
+	impl From<CheckmessageRequest> for Request {
+	    fn from(r: CheckmessageRequest) -> Self {
+	        Request::CheckMessage(r)
+	    }
+	}
+
+	impl IntoRequest for CheckmessageRequest {
+	    type Response = super::responses::CheckmessageResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -226,6 +315,16 @@ pub mod requests {
 	    pub feerange: Option<Vec<Feerate>>,
 	}
 
+	impl From<CloseRequest> for Request {
+	    fn from(r: CloseRequest) -> Self {
+	        Request::Close(r)
+	    }
+	}
+
+	impl IntoRequest for CloseRequest {
+	    type Response = super::responses::CloseResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ConnectRequest {
 	    #[serde(alias = "id")]
@@ -236,6 +335,16 @@ pub mod requests {
 	    pub port: Option<u16>,
 	}
 
+	impl From<ConnectRequest> for Request {
+	    fn from(r: ConnectRequest) -> Self {
+	        Request::Connect(r)
+	    }
+	}
+
+	impl IntoRequest for ConnectRequest {
+	    type Response = super::responses::ConnectResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateinvoiceRequest {
 	    #[serde(alias = "invstring")]
@@ -244,6 +353,16 @@ pub mod requests {
 	    pub label: String,
 	    #[serde(alias = "preimage")]
 	    pub preimage: String,
+	}
+
+	impl From<CreateinvoiceRequest> for Request {
+	    fn from(r: CreateinvoiceRequest) -> Self {
+	        Request::CreateInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for CreateinvoiceRequest {
+	    type Response = super::responses::CreateinvoiceResponse;
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -287,6 +406,16 @@ pub mod requests {
 	    pub generation: Option<u64>,
 	}
 
+	impl From<DatastoreRequest> for Request {
+	    fn from(r: DatastoreRequest) -> Self {
+	        Request::Datastore(r)
+	    }
+	}
+
+	impl IntoRequest for DatastoreRequest {
+	    type Response = super::responses::DatastoreResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionHops {
 	    #[serde(alias = "pubkey")]
@@ -307,6 +436,16 @@ pub mod requests {
 	    pub onion_size: Option<u16>,
 	}
 
+	impl From<CreateonionRequest> for Request {
+	    fn from(r: CreateonionRequest) -> Self {
+	        Request::CreateOnion(r)
+	    }
+	}
+
+	impl IntoRequest for CreateonionRequest {
+	    type Response = super::responses::CreateonionResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DeldatastoreRequest {
 	    #[serde(alias = "key")]
@@ -315,10 +454,30 @@ pub mod requests {
 	    pub generation: Option<u64>,
 	}
 
+	impl From<DeldatastoreRequest> for Request {
+	    fn from(r: DeldatastoreRequest) -> Self {
+	        Request::DelDatastore(r)
+	    }
+	}
+
+	impl IntoRequest for DeldatastoreRequest {
+	    type Response = super::responses::DeldatastoreResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelexpiredinvoiceRequest {
 	    #[serde(alias = "maxexpirytime", skip_serializing_if = "Option::is_none")]
 	    pub maxexpirytime: Option<u64>,
+	}
+
+	impl From<DelexpiredinvoiceRequest> for Request {
+	    fn from(r: DelexpiredinvoiceRequest) -> Self {
+	        Request::DelExpiredInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for DelexpiredinvoiceRequest {
+	    type Response = super::responses::DelexpiredinvoiceResponse;
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -353,6 +512,16 @@ pub mod requests {
 	    pub desconly: Option<bool>,
 	}
 
+	impl From<DelinvoiceRequest> for Request {
+	    fn from(r: DelinvoiceRequest) -> Self {
+	        Request::DelInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for DelinvoiceRequest {
+	    type Response = super::responses::DelinvoiceResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct InvoiceRequest {
 	    #[serde(alias = "amount_msat")]
@@ -375,10 +544,30 @@ pub mod requests {
 	    pub deschashonly: Option<bool>,
 	}
 
+	impl From<InvoiceRequest> for Request {
+	    fn from(r: InvoiceRequest) -> Self {
+	        Request::Invoice(r)
+	    }
+	}
+
+	impl IntoRequest for InvoiceRequest {
+	    type Response = super::responses::InvoiceResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListdatastoreRequest {
 	    #[serde(alias = "key", skip_serializing_if = "crate::is_none_or_empty")]
 	    pub key: Option<Vec<String>>,
+	}
+
+	impl From<ListdatastoreRequest> for Request {
+	    fn from(r: ListdatastoreRequest) -> Self {
+	        Request::ListDatastore(r)
+	    }
+	}
+
+	impl IntoRequest for ListdatastoreRequest {
+	    type Response = super::responses::ListdatastoreResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -391,6 +580,16 @@ pub mod requests {
 	    pub payment_hash: Option<String>,
 	    #[serde(alias = "offer_id", skip_serializing_if = "Option::is_none")]
 	    pub offer_id: Option<String>,
+	}
+
+	impl From<ListinvoicesRequest> for Request {
+	    fn from(r: ListinvoicesRequest) -> Self {
+	        Request::ListInvoices(r)
+	    }
+	}
+
+	impl IntoRequest for ListinvoicesRequest {
+	    type Response = super::responses::ListinvoicesResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -427,6 +626,16 @@ pub mod requests {
 	    pub groupid: Option<u64>,
 	}
 
+	impl From<SendonionRequest> for Request {
+	    fn from(r: SendonionRequest) -> Self {
+	        Request::SendOnion(r)
+	    }
+	}
+
+	impl IntoRequest for SendonionRequest {
+	    type Response = super::responses::SendonionResponse;
+	}
+
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum ListsendpaysStatus {
 	    #[serde(rename = "pending")]
@@ -458,8 +667,28 @@ pub mod requests {
 	    pub status: Option<ListsendpaysStatus>,
 	}
 
+	impl From<ListsendpaysRequest> for Request {
+	    fn from(r: ListsendpaysRequest) -> Self {
+	        Request::ListSendPays(r)
+	    }
+	}
+
+	impl IntoRequest for ListsendpaysRequest {
+	    type Response = super::responses::ListsendpaysResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListtransactionsRequest {
+	}
+
+	impl From<ListtransactionsRequest> for Request {
+	    fn from(r: ListtransactionsRequest) -> Self {
+	        Request::ListTransactions(r)
+	    }
+	}
+
+	impl IntoRequest for ListtransactionsRequest {
+	    type Response = super::responses::ListtransactionsResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -490,10 +719,30 @@ pub mod requests {
 	    pub description: Option<String>,
 	}
 
+	impl From<PayRequest> for Request {
+	    fn from(r: PayRequest) -> Self {
+	        Request::Pay(r)
+	    }
+	}
+
+	impl IntoRequest for PayRequest {
+	    type Response = super::responses::PayResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesRequest {
 	    #[serde(alias = "id", skip_serializing_if = "Option::is_none")]
 	    pub id: Option<Pubkey>,
+	}
+
+	impl From<ListnodesRequest> for Request {
+	    fn from(r: ListnodesRequest) -> Self {
+	        Request::ListNodes(r)
+	    }
+	}
+
+	impl IntoRequest for ListnodesRequest {
+	    type Response = super::responses::ListnodesResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -504,10 +753,30 @@ pub mod requests {
 	    pub timeout: Option<u64>,
 	}
 
+	impl From<WaitanyinvoiceRequest> for Request {
+	    fn from(r: WaitanyinvoiceRequest) -> Self {
+	        Request::WaitAnyInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for WaitanyinvoiceRequest {
+	    type Response = super::responses::WaitanyinvoiceResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitinvoiceRequest {
 	    #[serde(alias = "label")]
 	    pub label: String,
+	}
+
+	impl From<WaitinvoiceRequest> for Request {
+	    fn from(r: WaitinvoiceRequest) -> Self {
+	        Request::WaitInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for WaitinvoiceRequest {
+	    type Response = super::responses::WaitinvoiceResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -520,6 +789,16 @@ pub mod requests {
 	    pub partid: Option<u64>,
 	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
+	}
+
+	impl From<WaitsendpayRequest> for Request {
+	    fn from(r: WaitsendpayRequest) -> Self {
+	        Request::WaitSendPay(r)
+	    }
+	}
+
+	impl IntoRequest for WaitsendpayRequest {
+	    type Response = super::responses::WaitsendpayResponse;
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -549,6 +828,16 @@ pub mod requests {
 	    pub addresstype: Option<NewaddrAddresstype>,
 	}
 
+	impl From<NewaddrRequest> for Request {
+	    fn from(r: NewaddrRequest) -> Self {
+	        Request::NewAddr(r)
+	    }
+	}
+
+	impl IntoRequest for NewaddrRequest {
+	    type Response = super::responses::NewaddrResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WithdrawRequest {
 	    #[serde(alias = "destination")]
@@ -561,6 +850,16 @@ pub mod requests {
 	    pub minconf: Option<u16>,
 	    #[serde(alias = "utxos", skip_serializing_if = "crate::is_none_or_empty")]
 	    pub utxos: Option<Vec<Outpoint>>,
+	}
+
+	impl From<WithdrawRequest> for Request {
+	    fn from(r: WithdrawRequest) -> Self {
+	        Request::Withdraw(r)
+	    }
+	}
+
+	impl IntoRequest for WithdrawRequest {
+	    type Response = super::responses::WithdrawResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -587,6 +886,16 @@ pub mod requests {
 	    pub routehints: Option<RoutehintList>,
 	}
 
+	impl From<KeysendRequest> for Request {
+	    fn from(r: KeysendRequest) -> Self {
+	        Request::KeySend(r)
+	    }
+	}
+
+	impl IntoRequest for KeysendRequest {
+	    type Response = super::responses::KeysendResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundpsbtRequest {
 	    #[serde(alias = "satoshi")]
@@ -607,6 +916,16 @@ pub mod requests {
 	    pub excess_as_change: Option<bool>,
 	}
 
+	impl From<FundpsbtRequest> for Request {
+	    fn from(r: FundpsbtRequest) -> Self {
+	        Request::FundPsbt(r)
+	    }
+	}
+
+	impl IntoRequest for FundpsbtRequest {
+	    type Response = super::responses::FundpsbtResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpsbtRequest {
 	    #[serde(alias = "psbt")]
@@ -615,12 +934,32 @@ pub mod requests {
 	    pub reserve: Option<bool>,
 	}
 
+	impl From<SendpsbtRequest> for Request {
+	    fn from(r: SendpsbtRequest) -> Self {
+	        Request::SendPsbt(r)
+	    }
+	}
+
+	impl IntoRequest for SendpsbtRequest {
+	    type Response = super::responses::SendpsbtResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignpsbtRequest {
 	    #[serde(alias = "psbt")]
 	    pub psbt: String,
 	    #[serde(alias = "signonly", skip_serializing_if = "crate::is_none_or_empty")]
 	    pub signonly: Option<Vec<u32>>,
+	}
+
+	impl From<SignpsbtRequest> for Request {
+	    fn from(r: SignpsbtRequest) -> Self {
+	        Request::SignPsbt(r)
+	    }
+	}
+
+	impl IntoRequest for SignpsbtRequest {
+	    type Response = super::responses::SignpsbtResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -645,10 +984,30 @@ pub mod requests {
 	    pub excess_as_change: Option<bool>,
 	}
 
+	impl From<UtxopsbtRequest> for Request {
+	    fn from(r: UtxopsbtRequest) -> Self {
+	        Request::UtxoPsbt(r)
+	    }
+	}
+
+	impl IntoRequest for UtxopsbtRequest {
+	    type Response = super::responses::UtxopsbtResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxdiscardRequest {
 	    #[serde(alias = "txid")]
 	    pub txid: String,
+	}
+
+	impl From<TxdiscardRequest> for Request {
+	    fn from(r: TxdiscardRequest) -> Self {
+	        Request::TxDiscard(r)
+	    }
+	}
+
+	impl IntoRequest for TxdiscardRequest {
+	    type Response = super::responses::TxdiscardResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -663,10 +1022,30 @@ pub mod requests {
 	    pub utxos: Option<Vec<Outpoint>>,
 	}
 
+	impl From<TxprepareRequest> for Request {
+	    fn from(r: TxprepareRequest) -> Self {
+	        Request::TxPrepare(r)
+	    }
+	}
+
+	impl IntoRequest for TxprepareRequest {
+	    type Response = super::responses::TxprepareResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxsendRequest {
 	    #[serde(alias = "txid")]
 	    pub txid: String,
+	}
+
+	impl From<TxsendRequest> for Request {
+	    fn from(r: TxsendRequest) -> Self {
+	        Request::TxSend(r)
+	    }
+	}
+
+	impl IntoRequest for TxsendRequest {
+	    type Response = super::responses::TxsendResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -675,6 +1054,16 @@ pub mod requests {
 	    pub id: Pubkey,
 	    #[serde(alias = "force", skip_serializing_if = "Option::is_none")]
 	    pub force: Option<bool>,
+	}
+
+	impl From<DisconnectRequest> for Request {
+	    fn from(r: DisconnectRequest) -> Self {
+	        Request::Disconnect(r)
+	    }
+	}
+
+	impl IntoRequest for DisconnectRequest {
+	    type Response = super::responses::DisconnectResponse;
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -700,6 +1089,16 @@ pub mod requests {
 	    // Path `Feerates.style`
 	    #[serde(rename = "style")]
 	    pub style: FeeratesStyle,
+	}
+
+	impl From<FeeratesRequest> for Request {
+	    fn from(r: FeeratesRequest) -> Self {
+	        Request::Feerates(r)
+	    }
+	}
+
+	impl IntoRequest for FeeratesRequest {
+	    type Response = super::responses::FeeratesResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -730,6 +1129,16 @@ pub mod requests {
 	    pub reserve: Option<Amount>,
 	}
 
+	impl From<FundchannelRequest> for Request {
+	    fn from(r: FundchannelRequest) -> Self {
+	        Request::FundChannel(r)
+	    }
+	}
+
+	impl IntoRequest for FundchannelRequest {
+	    type Response = super::responses::FundchannelResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRequest {
 	    #[serde(alias = "id")]
@@ -748,6 +1157,16 @@ pub mod requests {
 	    pub exclude: Option<Vec<String>>,
 	    #[serde(alias = "maxhops", skip_serializing_if = "Option::is_none")]
 	    pub maxhops: Option<u32>,
+	}
+
+	impl From<GetrouteRequest> for Request {
+	    fn from(r: GetrouteRequest) -> Self {
+	        Request::GetRoute(r)
+	    }
+	}
+
+	impl IntoRequest for GetrouteRequest {
+	    type Response = super::responses::GetrouteResponse;
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -784,6 +1203,16 @@ pub mod requests {
 	    pub out_channel: Option<ShortChannelId>,
 	}
 
+	impl From<ListforwardsRequest> for Request {
+	    fn from(r: ListforwardsRequest) -> Self {
+	        Request::ListForwards(r)
+	    }
+	}
+
+	impl IntoRequest for ListforwardsRequest {
+	    type Response = super::responses::ListforwardsResponse;
+	}
+
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum ListpaysStatus {
 	    #[serde(rename = "pending")]
@@ -815,6 +1244,16 @@ pub mod requests {
 	    pub status: Option<ListpaysStatus>,
 	}
 
+	impl From<ListpaysRequest> for Request {
+	    fn from(r: ListpaysRequest) -> Self {
+	        Request::ListPays(r)
+	    }
+	}
+
+	impl IntoRequest for ListpaysRequest {
+	    type Response = super::responses::ListpaysResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PingRequest {
 	    #[serde(alias = "id")]
@@ -825,14 +1264,44 @@ pub mod requests {
 	    pub pongbytes: Option<f64>,
 	}
 
+	impl From<PingRequest> for Request {
+	    fn from(r: PingRequest) -> Self {
+	        Request::Ping(r)
+	    }
+	}
+
+	impl IntoRequest for PingRequest {
+	    type Response = super::responses::PingResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignmessageRequest {
 	    #[serde(alias = "message")]
 	    pub message: String,
 	}
 
+	impl From<SignmessageRequest> for Request {
+	    fn from(r: SignmessageRequest) -> Self {
+	        Request::SignMessage(r)
+	    }
+	}
+
+	impl IntoRequest for SignmessageRequest {
+	    type Response = super::responses::SignmessageResponse;
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct StopRequest {
+	}
+
+	impl From<StopRequest> for Request {
+	    fn from(r: StopRequest) -> Self {
+	        Request::Stop(r)
+	    }
+	}
+
+	impl IntoRequest for StopRequest {
+	    type Response = super::responses::StopResponse;
 	}
 
 }
@@ -843,6 +1312,7 @@ pub mod responses {
     use crate::primitives::*;
     #[allow(unused_imports)]
     use serde::{{Deserialize, Serialize}};
+    use super::{TryFromResponseError, Response};
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoOur_features {
@@ -973,6 +1443,17 @@ pub mod responses {
 	    pub warning_bitcoind_sync: Option<String>,
 	    #[serde(alias = "warning_lightningd_sync", skip_serializing_if = "Option::is_none")]
 	    pub warning_lightningd_sync: Option<String>,
+	}
+
+	impl TryFrom<Response> for GetinfoResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Getinfo(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -1302,6 +1783,17 @@ pub mod responses {
 	    pub peers: Vec<ListpeersPeers>,
 	}
 
+	impl TryFrom<Response> for ListpeersResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListPeers(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum ListfundsOutputsStatus {
 	    #[serde(rename = "unconfirmed")]
@@ -1375,6 +1867,17 @@ pub mod responses {
 	    pub channels: Vec<ListfundsChannels>,
 	}
 
+	impl TryFrom<Response> for ListfundsResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListFunds(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// status of the payment (could be complete if already sent previously)
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum SendpayStatus {
@@ -1429,6 +1932,17 @@ pub mod responses {
 	    pub message: Option<String>,
 	}
 
+	impl TryFrom<Response> for SendpayResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SendPay(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsChannels {
 	    #[serde(alias = "source")]
@@ -1469,8 +1983,30 @@ pub mod responses {
 	    pub channels: Vec<ListchannelsChannels>,
 	}
 
+	impl TryFrom<Response> for ListchannelsResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListChannels(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct AddgossipResponse {
+	}
+
+	impl TryFrom<Response> for AddgossipResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::AddGossip(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1483,12 +2019,34 @@ pub mod responses {
 	    pub cycle_seconds: Option<u64>,
 	}
 
+	impl TryFrom<Response> for AutocleaninvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::AutoCleanInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CheckmessageResponse {
 	    #[serde(alias = "verified")]
 	    pub verified: bool,
 	    #[serde(alias = "pubkey")]
 	    pub pubkey: Pubkey,
+	}
+
+	impl TryFrom<Response> for CheckmessageResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::CheckMessage(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// Whether we successfully negotiated a mutual close, closed without them, or discarded not-yet-opened channel
@@ -1522,6 +2080,17 @@ pub mod responses {
 	    pub tx: Option<String>,
 	    #[serde(alias = "txid", skip_serializing_if = "Option::is_none")]
 	    pub txid: Option<String>,
+	}
+
+	impl TryFrom<Response> for CloseResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Close(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// Whether they initiated connection or we did
@@ -1595,6 +2164,17 @@ pub mod responses {
 	    pub direction: ConnectDirection,
 	}
 
+	impl TryFrom<Response> for ConnectResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Connect(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// Whether it has been paid, or can no longer be paid
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum CreateinvoiceStatus {
@@ -1650,6 +2230,17 @@ pub mod responses {
 	    pub payer_note: Option<String>,
 	}
 
+	impl TryFrom<Response> for CreateinvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::CreateInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DatastoreResponse {
 	    #[serde(alias = "key")]
@@ -1662,12 +2253,34 @@ pub mod responses {
 	    pub string: Option<String>,
 	}
 
+	impl TryFrom<Response> for DatastoreResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Datastore(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionResponse {
 	    #[serde(alias = "onion")]
 	    pub onion: String,
 	    #[serde(alias = "shared_secrets")]
 	    pub shared_secrets: Vec<Secret>,
+	}
+
+	impl TryFrom<Response> for CreateonionResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::CreateOnion(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1682,8 +2295,30 @@ pub mod responses {
 	    pub string: Option<String>,
 	}
 
+	impl TryFrom<Response> for DeldatastoreResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::DelDatastore(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelexpiredinvoiceResponse {
+	}
+
+	impl TryFrom<Response> for DelexpiredinvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::DelExpiredInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// State of invoice
@@ -1733,6 +2368,17 @@ pub mod responses {
 	    pub payer_note: Option<String>,
 	}
 
+	impl TryFrom<Response> for DelinvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::DelInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct InvoiceResponse {
 	    #[serde(alias = "bolt11")]
@@ -1755,6 +2401,17 @@ pub mod responses {
 	    pub warning_mpp: Option<String>,
 	}
 
+	impl TryFrom<Response> for InvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Invoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListdatastoreDatastore {
 	    #[serde(alias = "key")]
@@ -1771,6 +2428,17 @@ pub mod responses {
 	pub struct ListdatastoreResponse {
 	    #[serde(alias = "datastore")]
 	    pub datastore: Vec<ListdatastoreDatastore>,
+	}
+
+	impl TryFrom<Response> for ListdatastoreResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListDatastore(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// Whether it's paid, unpaid or unpayable
@@ -1834,6 +2502,17 @@ pub mod responses {
 	    pub invoices: Vec<ListinvoicesInvoices>,
 	}
 
+	impl TryFrom<Response> for ListinvoicesResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListInvoices(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// status of the payment (could be complete if already sent previously)
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum SendonionStatus {
@@ -1882,6 +2561,17 @@ pub mod responses {
 	    pub payment_preimage: Option<Secret>,
 	    #[serde(alias = "message", skip_serializing_if = "Option::is_none")]
 	    pub message: Option<String>,
+	}
+
+	impl TryFrom<Response> for SendonionResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SendOnion(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// status of the payment
@@ -1943,6 +2633,17 @@ pub mod responses {
 	pub struct ListsendpaysResponse {
 	    #[serde(alias = "payments")]
 	    pub payments: Vec<ListsendpaysPayments>,
+	}
+
+	impl TryFrom<Response> for ListsendpaysResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListSendPays(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// the purpose of this input (*EXPERIMENTAL_FEATURES* only)
@@ -2093,6 +2794,17 @@ pub mod responses {
 	    pub transactions: Vec<ListtransactionsTransactions>,
 	}
 
+	impl TryFrom<Response> for ListtransactionsResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListTransactions(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// status of payment
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum PayStatus {
@@ -2136,6 +2848,17 @@ pub mod responses {
 	    // Path `Pay.status`
 	    #[serde(rename = "status")]
 	    pub status: PayStatus,
+	}
+
+	impl TryFrom<Response> for PayResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Pay(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// Type of connection
@@ -2202,6 +2925,17 @@ pub mod responses {
 	    pub nodes: Vec<ListnodesNodes>,
 	}
 
+	impl TryFrom<Response> for ListnodesResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListNodes(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// Whether it's paid or expired
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum WaitanyinvoiceStatus {
@@ -2250,6 +2984,17 @@ pub mod responses {
 	    pub payment_preimage: Option<Secret>,
 	}
 
+	impl TryFrom<Response> for WaitanyinvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::WaitAnyInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// Whether it's paid or expired
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum WaitinvoiceStatus {
@@ -2296,6 +3041,17 @@ pub mod responses {
 	    pub paid_at: Option<u64>,
 	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
+	}
+
+	impl TryFrom<Response> for WaitinvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::WaitInvoice(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// status of the payment
@@ -2347,12 +3103,34 @@ pub mod responses {
 	    pub payment_preimage: Option<Secret>,
 	}
 
+	impl TryFrom<Response> for WaitsendpayResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::WaitSendPay(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct NewaddrResponse {
 	    #[serde(alias = "bech32", skip_serializing_if = "Option::is_none")]
 	    pub bech32: Option<String>,
 	    #[serde(alias = "p2sh-segwit", skip_serializing_if = "Option::is_none")]
 	    pub p2sh_segwit: Option<String>,
+	}
+
+	impl TryFrom<Response> for NewaddrResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::NewAddr(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2363,6 +3141,17 @@ pub mod responses {
 	    pub txid: String,
 	    #[serde(alias = "psbt")]
 	    pub psbt: String,
+	}
+
+	impl TryFrom<Response> for WithdrawResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Withdraw(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// status of payment
@@ -2404,6 +3193,17 @@ pub mod responses {
 	    pub status: KeysendStatus,
 	}
 
+	impl TryFrom<Response> for KeysendResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::KeySend(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundpsbtReservations {
 	    #[serde(alias = "txid")]
@@ -2434,6 +3234,17 @@ pub mod responses {
 	    pub reservations: Option<Vec<FundpsbtReservations>>,
 	}
 
+	impl TryFrom<Response> for FundpsbtResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::FundPsbt(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpsbtResponse {
 	    #[serde(alias = "tx")]
@@ -2442,10 +3253,32 @@ pub mod responses {
 	    pub txid: String,
 	}
 
+	impl TryFrom<Response> for SendpsbtResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SendPsbt(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignpsbtResponse {
 	    #[serde(alias = "signed_psbt")]
 	    pub signed_psbt: String,
+	}
+
+	impl TryFrom<Response> for SignpsbtResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SignPsbt(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2478,12 +3311,34 @@ pub mod responses {
 	    pub reservations: Option<Vec<UtxopsbtReservations>>,
 	}
 
+	impl TryFrom<Response> for UtxopsbtResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::UtxoPsbt(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxdiscardResponse {
 	    #[serde(alias = "unsigned_tx")]
 	    pub unsigned_tx: String,
 	    #[serde(alias = "txid")]
 	    pub txid: String,
+	}
+
+	impl TryFrom<Response> for TxdiscardResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::TxDiscard(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2496,6 +3351,17 @@ pub mod responses {
 	    pub txid: String,
 	}
 
+	impl TryFrom<Response> for TxprepareResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::TxPrepare(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxsendResponse {
 	    #[serde(alias = "psbt")]
@@ -2506,8 +3372,30 @@ pub mod responses {
 	    pub txid: String,
 	}
 
+	impl TryFrom<Response> for TxsendResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::TxSend(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DisconnectResponse {
+	}
+
+	impl TryFrom<Response> for DisconnectResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Disconnect(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2570,6 +3458,17 @@ pub mod responses {
 	    pub warning_missing_feerates: Option<String>,
 	}
 
+	impl TryFrom<Response> for FeeratesResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Feerates(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundchannelResponse {
 	    #[serde(alias = "tx")]
@@ -2584,6 +3483,17 @@ pub mod responses {
 	    pub close_to: Option<String>,
 	    #[serde(alias = "mindepth", skip_serializing_if = "Option::is_none")]
 	    pub mindepth: Option<u32>,
+	}
+
+	impl TryFrom<Response> for FundchannelResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::FundChannel(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// The features understood by the destination node
@@ -2623,6 +3533,17 @@ pub mod responses {
 	pub struct GetrouteResponse {
 	    #[serde(alias = "route")]
 	    pub route: Vec<GetrouteRoute>,
+	}
+
+	impl TryFrom<Response> for GetrouteResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::GetRoute(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	/// still ongoing, completed, failed locally, or failed after forwarding
@@ -2700,6 +3621,17 @@ pub mod responses {
 	    pub forwards: Vec<ListforwardsForwards>,
 	}
 
+	impl TryFrom<Response> for ListforwardsResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListForwards(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	/// status of the payment
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum ListpaysPaysStatus {
@@ -2757,10 +3689,32 @@ pub mod responses {
 	    pub pays: Vec<ListpaysPays>,
 	}
 
+	impl TryFrom<Response> for ListpaysResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::ListPays(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PingResponse {
 	    #[serde(alias = "totlen")]
 	    pub totlen: u16,
+	}
+
+	impl TryFrom<Response> for PingResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Ping(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2773,8 +3727,30 @@ pub mod responses {
 	    pub zbase: String,
 	}
 
+	impl TryFrom<Response> for SignmessageResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SignMessage(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct StopResponse {
+	}
+
+	impl TryFrom<Response> for StopResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::Stop(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    } 
 	}
 
 }

--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -78,6 +78,26 @@ impl Amount {
     }
 }
 
+impl std::ops::Add for Amount {
+    type Output = Amount;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Amount {
+            msat: self.msat + rhs.msat
+        }
+    }
+}
+
+impl std::ops::Sub for Amount {
+    type Output = Amount;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Amount {
+            msat: self.msat - rhs.msat
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ShortChannelId(u64);
 

--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -78,7 +78,7 @@ impl Amount {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ShortChannelId(u64);
 
 impl Serialize for ShortChannelId {
@@ -134,7 +134,7 @@ impl ShortChannelId {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Secret([u8; 32]);
 
 impl TryFrom<Vec<u8>> for Secret {
@@ -177,7 +177,7 @@ impl Secret {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Outpoint {
     pub txid: Sha256,
     pub outnum: u32,

--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use anyhow::Context;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
@@ -671,3 +672,15 @@ pub struct RpcError {
     pub code: Option<i32>,
     pub message: String,
 }
+
+impl Display for RpcError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(code) = self.code {
+            write!(f, "Error code {}: {}", code, self.message)
+        } else {
+            write!(f, "Error: {}", self.message)
+        }
+    }
+}
+
+impl std::error::Error for RpcError {}

--- a/contrib/msggen/msggen/gen/grpc.py
+++ b/contrib/msggen/msggen/gen/grpc.py
@@ -302,8 +302,8 @@ class GrpcConverterGenerator(IGenerator):
                     'u16?': f'c.{name}.map(|v| v.into())',
                     'msat': f'Some(c.{name}.into())',
                     'msat?': f'c.{name}.map(|f| f.into())',
-                    'pubkey': f'c.{name}.to_vec()',
-                    'pubkey?': f'c.{name}.map(|v| v.to_vec())',
+                    'pubkey': f'c.{name}.serialize().to_vec()',
+                    'pubkey?': f'c.{name}.map(|v| v.serialize().to_vec())',
                     'hex': f'hex::decode(&c.{name}).unwrap()',
                     'hex?': f'c.{name}.map(|v| hex::decode(v).unwrap())',
                     'txid': f'hex::decode(&c.{name}).unwrap()',
@@ -351,6 +351,7 @@ class GrpcConverterGenerator(IGenerator):
         use std::str::FromStr;
         use bitcoin_hashes::sha256::Hash as Sha256;
         use bitcoin_hashes::Hash;
+        use cln_rpc::primitives::PublicKey;
 
         """)
 
@@ -420,8 +421,8 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
                     'hex': f'hex::encode(&c.{name})',
                     'hex?': f'c.{name}.map(|v| hex::encode(v))',
                     'txid?': f'c.{name}.map(|v| hex::encode(v))',
-                    'pubkey': f'cln_rpc::primitives::Pubkey::from_slice(&c.{name}).unwrap()',
-                    'pubkey?': f'c.{name}.map(|v| cln_rpc::primitives::Pubkey::from_slice(&v[..]).unwrap())',
+                    'pubkey': f'PublicKey::from_slice(&c.{name}).unwrap()',
+                    'pubkey?': f'c.{name}.map(|v| PublicKey::from_slice(&v).unwrap())',
                     'msat': f'c.{name}.unwrap().into()',
                     'msat?': f'c.{name}.map(|a| a.into())',
                     'msat_or_all': f'c.{name}.unwrap().into()',

--- a/contrib/msggen/msggen/gen/grpc.py
+++ b/contrib/msggen/msggen/gen/grpc.py
@@ -349,6 +349,8 @@ class GrpcConverterGenerator(IGenerator):
         use cln_rpc::model::{responses,requests};
         use crate::pb;
         use std::str::FromStr;
+        use bitcoin_hashes::sha256::Hash as Sha256;
+        use bitcoin_hashes::Hash;
 
         """)
 
@@ -434,8 +436,8 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
                     'short_channel_id?': f'c.{name}.map(|v| cln_rpc::primitives::ShortChannelId::from_str(&v).unwrap())',
                     'secret': f'c.{name}.try_into().unwrap()',
                     'secret?': f'c.{name}.map(|v| v.try_into().unwrap())',
-                    'hash': f'c.{name}.try_into().unwrap()',
-                    'hash?': f'c.{name}.map(|v| v.try_into().unwrap())',
+                    'hash': f'Sha256::from_slice(&c.{name}).unwrap()',
+                    'hash?': f'c.{name}.map(|v| Sha256::from_slice(&v).unwrap())',
                     'txid': f'hex::encode(&c.{name})',
                 }.get(
                     typ,

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -38,7 +38,7 @@ typemap = {
     'msat_or_all': 'AmountOrAll',
     'msat_or_any': 'AmountOrAny',
     'number': 'f64',
-    'pubkey': 'Pubkey',
+    'pubkey': 'PublicKey',
     'short_channel_id': 'ShortChannelId',
     'signature': 'String',
     'string': 'String',

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -6,7 +6,7 @@ import sys
 import re
 
 from msggen.model import (ArrayField, CompositeField, EnumField,
-                          PrimitiveField, Service)
+                          PrimitiveField, Service, Method)
 from msggen.gen.generator import IGenerator
 
 logger = logging.getLogger(__name__)
@@ -214,6 +214,7 @@ class RustGenerator(IGenerator):
             use crate::primitives::*;
             #[allow(unused_imports)]
             use serde::{{Deserialize, Serialize}};
+            use super::{IntoRequest, Request};
 
         """)
 
@@ -221,8 +222,23 @@ class RustGenerator(IGenerator):
             req = meth.request
             _, decl = gen_composite(req)
             self.write(decl, numindent=1)
+            self.generate_request_trait_impl(meth)
 
         self.write("}\n\n")
+
+    def generate_request_trait_impl(self, method: Method):
+        self.write(dedent(f"""\
+        impl From<{method.request.typename}> for Request {{
+            fn from(r: {method.request.typename}) -> Self {{
+                Request::{method.name}(r)
+            }}
+        }}
+
+        impl IntoRequest for {method.request.typename} {{
+            type Response = super::responses::{method.response.typename};
+        }}
+
+        """), numindent=1)
 
     def generate_responses(self, service: Service):
         self.write("""
@@ -231,6 +247,7 @@ class RustGenerator(IGenerator):
             use crate::primitives::*;
             #[allow(unused_imports)]
             use serde::{{Deserialize, Serialize}};
+            use super::{TryFromResponseError, Response};
 
         """)
 
@@ -238,8 +255,24 @@ class RustGenerator(IGenerator):
             res = meth.response
             _, decl = gen_composite(res)
             self.write(decl, numindent=1)
+            self.generate_response_trait_impl(meth)
 
         self.write("}\n\n")
+
+    def generate_response_trait_impl(self, method: Method):
+        self.write(dedent(f"""\
+        impl TryFrom<Response> for {method.response.typename} {{
+            type Error = super::TryFromResponseError;
+
+            fn try_from(response: Response) -> Result<Self, Self::Error> {{
+                match response {{
+                    Response::{method.name}(response) => Ok(response),
+                    _ => Err(TryFromResponseError)
+                }}
+            }}
+        }}
+
+        """), numindent=1)
 
     def generate_enums(self, service: Service):
         """The Request and Response enums serve as parsing primitives.
@@ -275,10 +308,23 @@ class RustGenerator(IGenerator):
 
         """)
 
+    def generate_request_trait(self):
+        self.write("""
+        pub trait IntoRequest: Into<Request> {
+            type Response: TryFrom<Response, Error = TryFromResponseError>;
+        }
+
+        #[derive(Debug)]
+        pub struct TryFromResponseError;
+
+        """)
+
     def generate(self, service: Service) -> None:
         self.write(header)
 
         self.generate_enums(service)
+
+        self.generate_request_trait()
 
         self.generate_requests(service)
         self.generate_responses(service)


### PR DESCRIPTION
While using the rust RPC library I noticed a few unidiomatic/unergonomic API details. This PR proposes fixes to some of them that I'd like to discuss. If you think certain changes should be merged and wish to split them up that should be easily possible.

Changes:
* Implement `Error` for `RpcError` so that `?` works with `anyhow`
* Implement a "typed" version of `call` that knows which return type it expects, so users don't need to match over the entire `Response` enum
* Use `bitcoin_hashes` and `secp256k1` instead of custom implementations (that are lacking a lot of convenience methods already present in these crates)
* Implement `Debug` for the client struct
* Make more types `Copy`
* Add arithmetic functions to the `Amount` type. I'm not sure what's the best way. Ideally we would implement overflow-checked versions, but there aren't traits for that in `std` and it's inconvenient to use. For convenience one would also like to have floating point division/multiplication but that's also a footgun. The scope this change should have is very unclear to me.

Changes I'm holding off on for now:
* Replacing `Outpoint` with `rust-bitcoin`'s implementation. This would require either pulling in the entirety of `rust-bitcoin` or splitting it into multiple crates (see rust-bitcoin/rust-bitcoin#550)

For now I haven't fixed any breakage in any of the sister crates, this will be the next step.