### PR TITLE
cln-plugin: Save "configuration" from "init" method

### DIFF
--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,4 +1,5 @@
 use crate::options::ConfigOption;
+use crate::Configuration;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -63,6 +64,7 @@ pub struct GetManifestCall {}
 #[derive(Deserialize, Debug)]
 pub(crate) struct InitCall {
     pub(crate) options: HashMap<String, Value>,
+    pub(crate) configuration: Configuration,
 }
 
 #[derive(Debug)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,5 +1,4 @@
 use crate::options::ConfigOption;
-use crate::Configuration;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -65,6 +64,29 @@ pub struct GetManifestCall {}
 pub(crate) struct InitCall {
     pub(crate) options: HashMap<String, Value>,
     pub(crate) configuration: Configuration,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Configuration {
+    #[serde(rename = "lightning-dir")]
+    pub lightning_dir: String,
+    #[serde(rename = "rpc-file")]
+    pub rpc_file: String,
+    pub startup: bool,
+    pub network: String,
+    pub feature_set: HashMap<String, String>,
+    pub proxy: ProxyInfo,
+    #[serde(rename = "torv3-enabled")]
+    pub torv3_enabled: bool,
+    pub always_use_proxy: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProxyInfo {
+    #[serde(alias = "type")]
+    pub typ: String,
+    pub address: String,
+    pub port: i64,
 }
 
 #[derive(Debug)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -75,10 +75,13 @@ pub struct Configuration {
     pub startup: bool,
     pub network: String,
     pub feature_set: HashMap<String, String>,
-    pub proxy: ProxyInfo,
+
+    // The proxy related options are only populated if a proxy was
+    // configured.
+    pub proxy: Option<ProxyInfo>,
     #[serde(rename = "torv3-enabled")]
-    pub torv3_enabled: bool,
-    pub always_use_proxy: bool,
+    pub torv3_enabled: Option<bool>,
+    pub always_use_proxy: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -140,3 +140,55 @@ pub struct InitResponse {
 }
 
 pub trait Response: Serialize + Debug {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::messages;
+    use serde_json::json;
+
+    #[test]
+    fn test_init_message_parsing() {
+        let value = json!({
+            "jsonrpc": "2.0",
+            "method": "init",
+            "params": {
+                "options": {
+                    "greeting": "World",
+                    "number": [0]
+                },
+                "configuration": {
+                    "lightning-dir": "/home/user/.lightning/testnet",
+                    "rpc-file": "lightning-rpc",
+                    "startup": true,
+                    "network": "testnet",
+                    "feature_set": {
+                        "init": "02aaa2",
+                        "node": "8000000002aaa2",
+                        "channel": "",
+                        "invoice": "028200"
+                    },
+                    "proxy": {
+                        "type": "ipv4",
+                        "address": "127.0.0.1",
+                        "port": 9050
+                    },
+                    "torv3-enabled": true,
+                    "always_use_proxy": false
+                }
+            },
+            "id": 10,
+        });
+        let req: JsonRpc<Notification, Request> = serde_json::from_value(value).unwrap();
+        match req {
+            messages::JsonRpc::Request(_, messages::Request::Init(init)) => {
+                assert_eq!(init.options["greeting"], "World");
+                assert_eq!(
+                    init.configuration.lightning_dir,
+                    String::from("/home/user/.lightning/testnet")
+                );
+            }
+            _ => panic!("Couldn't parse init message"),
+        }
+    }
+}


### PR DESCRIPTION
`cln-plugin` throws away the "configuration" field from the "init" message.