### PR TITLE
Fix two small topology issues

### DIFF
--- a/common/route.c
+++ b/common/route.c
@@ -25,7 +25,7 @@ bool route_can_carry(const struct gossmap *map,
 		       struct amount_msat amount,
 		       void *arg)
 {
-	if (!c->half[dir].enabled || !c->half[!dir].enabled)
+	if (!c->half[dir].enabled)
 		return false;
 	return route_can_carry_even_disabled(map, c, dir, amount, arg);
 }

--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -557,9 +557,9 @@ static struct amount_msat peer_capacity(const struct gossmap *gossmap,
 			continue;
 		if (!c->half[!dir].enabled)
 			continue;
-		if (!amount_msat_add(&capacity, capacity,
-				    amount_msat(fp16_to_u64(c->half[dir]
-							   .htlc_max))))
+		if (!amount_msat_add(
+			&capacity, capacity,
+			amount_msat(fp16_to_u64(c->half[!dir].htlc_max))))
 			continue;
 	}
 	return capacity;


### PR DESCRIPTION
I found these while working on `zeroconf` and took me a while to track down:

 - We were considering the maximum number of HTLCs on the wrong direction, i.e. we were trying to go from A->B but were considering B->A. This is usually not an issue as long as we have `channel_update`s from both endpoints, but if that's not the case we'd be unable to use either direction (if A->B is missing/disabled we'd discard the channel right away, if B->A is missing we'd consider the channel, but then read that the maximum number of HTLCs is 0, thus indirectly discarding it too)
 - We were requiring both directions to be enabled, likely as a shorthand for a node dying and only the peer disabling their direction. This is unnecessary as a dying node would get isolated by all of its peers, thus we couldn't enter that node, and we don't require a way to leave from that node (which is the direction that the failing node would have failed to disable). This is actually quite a common occurrence in zeroconf, since the channels have different aliases depending on who assigned it, and so we end up with two half channels, instead of one full channel.