### PR TITLE
signmessage: improve the UX of the rpc command when zbase is not a valid one

### DIFF
--- a/lightningd/signmessage.c
+++ b/lightningd/signmessage.c
@@ -56,8 +56,7 @@ static const u8 *from_zbase32(const tal_t *ctx, const char *msg)
 	if (!bech32_convert_bits(u8arr, &len, 8,
 				 u5arr, tal_bytelen(u5arr), 5, false))
 		return tal_free(u8arr);
-	assert(len == tal_bytelen(u8arr));
-	return u8arr;
+	return len == tal_bytelen(u8arr) ? u8arr : tal_free(u8arr);
 }
 
 static struct command_result *json_signmessage(struct command *cmd,
@@ -235,4 +234,3 @@ static const struct json_command json_checkmessage_cmd = {
 	"Verify a digital signature {zbase} of {message} signed with {pubkey}",
 };
 AUTODATA(json_command, &json_checkmessage_cmd);
-

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1867,6 +1867,9 @@ def test_signmessage(node_factory):
     checknokey = l2.rpc.checkmessage(message="message for you", zbase=zm)
     assert checknokey['pubkey'] == l1.info['id']
     assert checknokey['verified']
+    # check that checkmassage used with a wrong zbase format throws an RPC exception
+    with pytest.raises(RpcError, match="zbase is not valid zbase32"):
+        l2.rpc.checkmessage(message="wrong zbase format", zbase="wrong zbase format")
 
 
 def test_include(node_factory):


### PR DESCRIPTION
This PR improves the UX of the RPC command when `zbase` is not a valid one because we have a crash on bad `zbase`!

Fixes https://github.com/ElementsProject/lightning/issues/5293

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>