### PR TITLE
Expose htlc id to `htlc_accepted` hook

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1365,6 +1365,8 @@ The payload of the hook call has the following format:
     "next_onion": "[1365bytes of serialized onion]"
   },
   "htlc": {
+    "short_channel_id": "4x5x6",
+    "id": 27,
     "amount": "43msat",
     "cltv_expiry": 500028,
     "cltv_expiry_relative": 10,
@@ -1393,6 +1395,8 @@ For detailed information about each field please refer to [BOLT 04 of the specif
    - `shared_secret` is the shared secret we used to decrypt the incoming
      onion. It is shared with the sender that constructed the onion.
  - `htlc`:
+   - `short_channel_id` is the channel this payment is coming from.
+   - `id` is the low-level sequential HTLC id integer as sent by the channel peer.
    - `amount` is the amount that we received with the HTLC. This amount minus
      the `forward_amount` is the fee that will stay with us.
    - `cltv_expiry` determines when the HTLC reverts back to the

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1065,6 +1065,8 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	json_object_end(s);
 
 	json_object_start(s, "htlc");
+	json_add_short_channel_id(s, "short_channel_id", hin->key.channel->scid);
+	json_add_u64(s, "id", hin->key.id);
 	json_add_amount_msat_only(s, "amount", hin->msat);
 	json_add_u32(s, "cltv_expiry", expiry);
 	json_add_s32(s, "cltv_expiry_relative", expiry - blockheight);


### PR DESCRIPTION
I believe this is necessary for low-level stuff that deals with MPP, for example, although I am not entirely sure.