### PR TITLE
Adds option_will_fund info to the RPC listnodes output

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -623,12 +623,21 @@
             "ListNodes.nodes[].color": 4,
             "ListNodes.nodes[].features": 5,
             "ListNodes.nodes[].last_timestamp": 2,
-            "ListNodes.nodes[].nodeid": 1
+            "ListNodes.nodes[].nodeid": 1,
+            "ListNodes.nodes[].option_will_fund": 7
         },
         "ListnodesNodesAddresses": {
             "ListNodes.nodes[].addresses[].address": 3,
             "ListNodes.nodes[].addresses[].port": 2,
             "ListNodes.nodes[].addresses[].type": 1
+        },
+        "ListnodesNodesOption_will_fund": {
+            "ListNodes.nodes[].option_will_fund.channel_fee_max_base_msat": 4,
+            "ListNodes.nodes[].option_will_fund.channel_fee_max_proportional_thousandths": 5,
+            "ListNodes.nodes[].option_will_fund.compact_lease": 6,
+            "ListNodes.nodes[].option_will_fund.funding_weight": 3,
+            "ListNodes.nodes[].option_will_fund.lease_fee_base_msat": 1,
+            "ListNodes.nodes[].option_will_fund.lease_fee_basis": 2
         },
         "ListnodesRequest": {
             "ListNodes.id": 1

--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -823,6 +823,15 @@ message ListnodesNodes {
 	repeated ListnodesNodesAddresses addresses = 6;
 }
 
+message ListnodesNodesOption_will_fund {
+	Amount lease_fee_base_msat = 1;
+	uint32 lease_fee_basis = 2;
+	uint32 funding_weight = 3;
+	Amount channel_fee_max_base_msat = 4;
+	uint32 channel_fee_max_proportional_thousandths = 5;
+	bytes compact_lease = 6;
+}
+
 message ListnodesNodesAddresses {
 	// ListNodes.nodes[].addresses[].type
 	enum ListnodesNodesAddressesType {

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -618,6 +618,8 @@ impl From<&responses::ListnodesNodes> for pb::ListnodesNodes {
             color: c.color.as_ref().map(|v| hex::decode(&v).unwrap()), // Rule #2 for type hex?
             features: c.features.as_ref().map(|v| hex::decode(&v).unwrap()), // Rule #2 for type hex?
             addresses: c.addresses.as_ref().map(|arr| arr.iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            // Also need codegen'd
+            // option_will_fund: c.option_will_fund.<I'm not certain what goes here>
         }
     }
 }

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -2082,6 +2082,22 @@ pub mod responses {
 	    pub status: PayStatus,
 	}
 
+	#[derive(Clone, Debug, Deserialize, Serialize)]
+	pub struct ListnodesNodesOption_will_fund {
+	    #[serde(alias = "lease_fee_base_msat")]
+	    pub lease_fee_base_msat: Amount,
+	    #[serde(alias = "lease_fee_basis")]
+	    pub lease_fee_basis: u32,
+	    #[serde(alias = "funding_weight")]
+	    pub funding_weight: u32,
+	    #[serde(alias = "channel_fee_max_base_msat")]
+	    pub channel_fee_max_base_msat: Amount,
+	    #[serde(alias = "channel_fee_max_proportional_thousandths")]
+	    pub channel_fee_max_proportional_thousandths: u32,
+	    #[serde(alias = "compact_lease")]
+	    pub compact_lease: String,
+	}
+
 	/// Type of connection
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 	pub enum ListnodesNodesAddressesType {

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -2154,6 +2154,8 @@ pub mod responses {
 	    pub features: Option<String>,
 	    #[serde(alias = "addresses", skip_serializing_if = "Option::is_none")]
 	    pub addresses: Option<Vec<ListnodesNodesAddresses>>,
+		// This would need to get some codegen'd version of:
+		// pub option_will_fund: Option<ListnodesNodesOption_will_fund>
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2510,6 +2512,7 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesOnchain_fee_estimates {
+		// ^^ Similar naming/casing pattern
 	    #[serde(alias = "opening_channel_satoshis")]
 	    pub opening_channel_satoshis: u64,
 	    #[serde(alias = "mutual_close_satoshis")]

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -30,26 +30,24 @@ RETURN VALUE
 On success, an object containing **nodes** is returned.  It is an array of objects, where each object contains:
 - **nodeid** (pubkey): the public key of the node
 - **last_timestamp** (u32, optional): A node_announcement has been received for this node (UNIX timestamp)
+- **option_will_fund** (object, optional): A liquidity ad announcement has been received for this node:
+  - **lease_fee_base_msat** (msat): the fixed fee for a lease (whole number of satoshis)
+  - **lease_fee_basis** (u32): the proportional fee in basis points (parts per 10,000) for a lease
+  - **funding_weight** (u32): the onchain weight you'll have to pay for a lease
+  - **channel_fee_max_base_msat** (msat): the maximum base routing fee this node will charge during the lease
+  - **channel_fee_max_proportional_thousandths** (u32): the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel_update)
+  - **compact_lease** (hex): the lease as represented in the node_announcement
 
 If **last_timestamp** is present:
   - **alias** (string): The fun alias this node advertized (up to 32 characters)
   - **color** (hex): The favorite RGB color this node advertized (always 6 characters)
-  - **features** (hex): BOLT #9 features bitmap this node advertized in node_announcement message
+  - **features** (hex): BOLT #9 features bitmap this node advertized
   - **addresses** (array of objects): The addresses this node advertized:
     - **type** (string): Type of connection (one of "dns", "ipv4", "ipv6", "torv2", "torv3", "websocket")
     - **port** (u16): port number
 
     If **type** is "dns", "ipv4", "ipv6", "torv2" or "torv3":
       - **address** (string): address in expected format for **type**
-
-If **option_will_fund** is present:
-  - **option_will_fund** (object):
-    - **lease_fee_base_msat** (msat): the fixed fee for a lease (whole number of satoshis)
-    - **lease_fee_basis** (u32): the proportional fee in basis points (parts per 10,000) for a lease
-    - **funding_weight** (u32): the onchain weight you'll have to pay for a lease
-    - **channel_fee_max_base_msat** (msat): the maximum base routing fee this node will charge during the lease
-    - **channel_fee_max_proportional_thousandths** (u32): the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel_update)
-    - **compact_lease** (hex): the lease as represented in the node_announcement
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -95,4 +93,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:85400c9c1741943e2e02935b4f14fd187a7db6056410e42adec07ef3c6772f5f)
+[comment]: # ( SHA256STAMP:9b1f940088c35054205287fa3e539939054ab035947ae3c78fee195faa35a7d7)

--- a/doc/schemas/listnodes.schema.json
+++ b/doc/schemas/listnodes.schema.json
@@ -22,6 +22,45 @@
           "last_timestamp": {
             "type": "u32",
             "description": "A node_announcement has been received for this node (UNIX timestamp)"
+          },
+          "option_will_fund": {
+            "type": "object",
+            "description": "A liquidity ad announcement has been received for this node", 
+            "properties": {
+              "lease_fee_base_msat": {
+                "type": "msat",
+                "description": "the fixed fee for a lease (whole number of satoshis)"
+              },
+              "lease_fee_basis": {
+                "type": "u32",
+                "description": "the proportional fee in basis points (parts per 10,000) for a lease"
+              },
+              "funding_weight": {
+                "type": "u32",
+                "description": "the onchain weight you'll have to pay for a lease"
+              },
+              "channel_fee_max_base_msat": {
+                "type": "msat",
+                "description": "the maximum base routing fee this node will charge during the lease"
+              },
+              "channel_fee_max_proportional_thousandths": {
+                "type": "u32",
+                "description": "the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel_update)"
+              },
+              "compact_lease": {
+                "type": "hex",
+                "description": "the lease as represented in the node_announcement"
+              }
+          },
+          "additionalProperties": false,
+            "required": [
+              "lease_fee_base_msat",
+              "lease_fee_basis",
+              "funding_weight",
+              "channel_fee_max_base_msat",
+              "channel_fee_max_proportional_thousandths",
+              "compact_lease"
+            ]
           }
         },
         "allOf": [
@@ -32,7 +71,7 @@
               ]
             },
             "then": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "required": [
                 "nodeid",
                 "last_timestamp",
@@ -137,59 +176,6 @@
               "additionalProperties": false,
               "properties": {
                 "nodeid": {}
-              }
-            }
-          },
-          {
-            "if": {
-              "required": [
-                "option_will_fund"
-              ]
-            },
-            "then": {
-              "additionalProperties": true,
-              "required": [
-                "option_will_fund"
-              ],
-              "properties": {
-                "option_will_fund": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "lease_fee_base_msat",
-                    "lease_fee_basis",
-                    "funding_weight",
-                    "channel_fee_max_base_msat",
-                    "channel_fee_max_proportional_thousandths",
-                    "compact_lease"
-                  ],
-                  "properties": {
-                    "lease_fee_base_msat": {
-                      "type": "msat",
-                      "description": "the fixed fee for a lease (whole number of satoshis)"
-                    },
-                    "lease_fee_basis": {
-                      "type": "u32",
-                      "description": "the proportional fee in basis points (parts per 10,000) for a lease"
-                    },
-                    "funding_weight": {
-                      "type": "u32",
-                      "description": "the onchain weight you'll have to pay for a lease"
-                    },
-                    "channel_fee_max_base_msat": {
-                      "type": "msat",
-                      "description": "the maximum base routing fee this node will charge during the lease"
-                    },
-                    "channel_fee_max_proportional_thousandths": {
-                      "type": "u32",
-                      "description": "the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel_update)"
-                    },
-                    "compact_lease": {
-                      "type": "hex",
-                      "description": "the lease as represented in the node_announcement"
-                    }
-                  }
-                }
               }
             }
           }


### PR DESCRIPTION
I'm having a lot of trouble with this.  I *have* been able to get the code to run and return the values well, but I am unable to get the schema -> code-generation to create the files correctly.

From what I can tell, I should be able to make a change to the file changed:

doc/schemas/listnodes.schema.json

And that should bubble out first to `.msggen.json`.  That is working correctly.

Then the `contrib/msggen/msggen/__main__.py` loads that file and should output a correct:

- `cln-rpc/src/model.rs`
- `cln-grpc/proto/node.proto`
- `cln-grpc/src/server.rs`
- `cln-grpc/src/convert.rs`

The included changes create new definitions for the `ListnodesNodesOption_will_fund` objects, however, they do not attach that object into the `ListnodesNodes` object.  

I would appreciate any guidance here.