### PR TITLE
add 'perl' dependency for 'build on fedora'

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -90,6 +90,7 @@ $ sudo dnf update -y && \
                 'C Development Tools and Libraries' \
                 'Development Tools' && \
         sudo dnf install -y \
+	        perl \
                 clang \
                 gettext \
                 git \


### PR DESCRIPTION
Building on Fedora Linux 36 (Workstation Edition) x86_64 failed with an error pointing me to [this](https://github.com/openssl/openssl/issues/13761#issue-777412186). Installing perl fixed it for me 