### PR TITLE
doc: Tor needs CookieAuthFile set

### DIFF
--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -62,6 +62,7 @@ On most Linux distributions there will be commented-out settings below in the
 ```
 ControlPort 9051
 CookieAuthentication 1
+CookieAuthFile /var/lib/tor/control_auth_cookie
 CookieAuthFileGroupReadable 1
 ```
 


### PR DESCRIPTION
The message was

    [warn] CookieAuthFileGroupReadable is set, but will have no effect: you must specify an explicit CookieAuthFile to have it group-readable.

Changelog-None