### PR TITLE
common: downgrade "internal error" errors from lnd.

### DIFF
--- a/common/peer_failed.c
+++ b/common/peer_failed.c
@@ -84,6 +84,15 @@ void peer_failed_received_errmsg(struct per_peer_state *pps,
 {
 	u8 *msg;
 
+	/* LND sends "internal error" and we close the channel.  But
+	 * prior to 0.11 we would turn this into a warning, and they
+	 * would recover after a reconnect.  So we downgrade, but snark
+	 * about it in the logs. */
+	if (!warning && streq(desc, "internal error")) {
+		status_unusual("lnd sent 'internal error':"
+			       " let's give it some space");
+		warning = true;
+	}
 	msg = towire_status_peer_error(NULL, channel_id, desc, warning,
 				       NULL);
 	peer_billboard(true, "Received %s", desc);

--- a/common/peer_failed.c
+++ b/common/peer_failed.c
@@ -88,7 +88,7 @@ void peer_failed_received_errmsg(struct per_peer_state *pps,
 	 * prior to 0.11 we would turn this into a warning, and they
 	 * would recover after a reconnect.  So we downgrade, but snark
 	 * about it in the logs. */
-	if (!warning && streq(desc, "internal error")) {
+	if (!warning && strends(desc, "internal error")) {
 		status_unusual("lnd sent 'internal error':"
 			       " let's give it some space");
 		warning = true;


### PR DESCRIPTION
Prior to 0.11.0 we had cases where we would treat errors
as warnings: regretfully, this is still needed.  This message
in particular has been widely reported, and it now causes
channel force closes.

Downgrade and log.  I did insert some snarky log message earlier,
but hey, I'm sure CLN has done worse things to our peers!

Fixes: #5102 
Changelog-None: Changelog is updated in v0.11.2 branch, which will be merged after that is released.