### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.2] - 2022-06-20: Simon's Carefully Chosen Release Name III
+## [0.11.2] - 2022-06-24: Simon's Carefully Chosen Release Name III
 
 Regressions since 0.10.2 which could not wait for the 0.12 release,
 which especially hurt larger nodes.
@@ -13,6 +13,7 @@ which especially hurt larger nodes.
 
  - Protocol: treat LND "internal error" as warnings, not force close events (like v0.10) ([#5326])
  - connectd: no longer occasional crashes when peers reconnect. ([#5300])
+ - connectd: another crash fix on trying to reconnect to disconnecting peer. ([#5340])
  - topology: Under some circumstances we were considering the limits on the wrong direction for a channel ([#5286])
  - routing: Fixed an issue where we would exclude the entire channel if either direction was disabled, or we hadn't seen an update yet. ([#5286])
  - connectd: large memory usage with many peers fixed. ([#5312])
@@ -25,6 +26,8 @@ which especially hurt larger nodes.
 [#5326]: https://github.com/ElementsProject/lightning/pull/5326
 [#5328]: https://github.com/ElementsProject/lightning/pull/5328
 [#5331]: https://github.com/ElementsProject/lightning/pull/5331
+[#5340]: https://github.com/ElementsProject/lightning/pull/5340
+
 [0.11.2]: https://github.com/ElementsProject/lightning/releases/tag/v0.11.2
 
 ## [0.11.1] - 2022-05-13: Simon's Carefully Chosen Release Name II

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -756,6 +756,7 @@ static void destroy_io_conn(struct io_conn *conn, struct connecting *connect)
 				      &connect->addrs[connect->addrnum]),
 		       connect->connstate, errstr));
 	connect->addrnum++;
+	connect->conn = NULL;
 	try_connect_one_addr(connect);
 }
 
@@ -857,8 +858,7 @@ static void try_connect_one_addr(struct connecting *connect)
 	struct sockaddr_in6 *sa6;
 #endif
 
-	/* In case we fail without a connection, make destroy_io_conn happy */
-	connect->conn = NULL;
+	assert(!connect->conn);
 
 	/* Out of addresses? */
 	if (connect->addrnum == tal_count(connect->addrs)) {
@@ -1879,6 +1879,7 @@ static void try_connect_peer(struct daemon *daemon,
 	connect->seconds_waited = seconds_waited;
 	connect->addrhint = tal_steal(connect, addrhint);
 	connect->errors = tal_strdup(connect, "");
+	connect->conn = NULL;
 	list_add_tail(&daemon->connecting, &connect->list);
 	tal_add_destructor(connect, destroy_connecting);
 
@@ -1931,7 +1932,7 @@ void peer_conn_closed(struct peer *peer)
 	tal_free(peer);
 
 	/* If we wanted to connect to it, but found it was exiting, try again */
-	if (connect)
+	if (connect && !connect->conn)
 		try_connect_one_addr(connect);
 }
 


### PR DESCRIPTION
This is based on v0.11.1 (first three commits), and consists entirely of commits cherry-picked from master (and pending PRs), and will be committed to its own branch after review and testing.