### PR TITLE
listforwards localfail out_channel

### DIFF
--- a/doc/lightning-listforwards.7.md
+++ b/doc/lightning-listforwards.7.md
@@ -27,11 +27,11 @@ On success, an object containing **forwards** is returned.  It is an array of ob
 - **in_msat** (msat): the value of the incoming HTLC
 - **status** (string): still ongoing, completed, failed locally, or failed after forwarding (one of "offered", "settled", "local_failed", "failed")
 - **received_time** (number): the UNIX timestamp when this was received
-- **out_channel** (short_channel_id, optional): the channel that the HTLC was forwarded to
+- **out_channel** (short_channel_id, optional): the channel that the HTLC (trying to) forward to
 - **payment_hash** (hex, optional): payment hash sought by HTLC (always 64 characters)
 - **style** (string, optional): Either a legacy onion format or a modern tlv format (one of "legacy", "tlv")
 
-If **out_channel** is present:
+If **out_msat** is present:
   - **fee_msat** (msat): the amount this paid in fees
   - **out_msat** (msat): the amount we sent out the *out_channel*
 
@@ -59,4 +59,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:131410f052b8a1845c8d3c7eb2d48df0fc7638e7d26817f56863815be86d8f1e)
+[comment]: # ( SHA256STAMP:c8adfa0a6dcae939c5da919d7996261db8663a871210e33b426c3b40c30d7b29)

--- a/doc/schemas/listforwards.schema.json
+++ b/doc/schemas/listforwards.schema.json
@@ -45,7 +45,7 @@
           },
           "out_channel": {
             "type": "short_channel_id",
-            "description": "the channel that the HTLC was forwarded to"
+            "description": "the channel that the HTLC (trying to) forward to"
           },
           "payment_hash": {
             "type": "hex",
@@ -66,14 +66,15 @@
           {
             "if": {
               "required": [
-                "out_channel"
+                "out_msat"
               ]
             },
             "then": {
               "additionalProperties": false,
               "required": [
                 "fee_msat",
-                "out_msat"
+                "out_msat",
+                "out_channel"
               ],
               "properties": {
                 "in_channel": {},
@@ -116,7 +117,8 @@
                 "resolved_time": {},
                 "payment_hash": {},
                 "failcode": {},
-                "failreason": {}
+                "failreason": {},
+                "out_channel": {}
               }
             }
           },

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -538,11 +538,11 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds UNU
 			fail_in_htlc(hout->in, failonion);
 
 			/* here we haven't called connect_htlc_out(),
-			 * so set htlc field with NULL */
+			 * so set htlc field with NULL (db wants it to exist!) */
 			wallet_forwarded_payment_add(ld->wallet,
 					 hout->in,
 					 get_onion_style(hout->in),
-					 NULL, NULL,
+					 channel_scid_or_local_alias(hout->key.channel), NULL,
 					 FORWARD_LOCAL_FAILED,
 						     fromwire_peektype(hout->failmsg));
 		}

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -702,7 +702,7 @@ static void forward_htlc(struct htlc_in *hin,
 		local_fail_in_htlc(hin, take(towire_unknown_next_peer(NULL)));
 		wallet_forwarded_payment_add(hin->key.channel->peer->ld->wallet,
 					 hin, get_onion_style(hin),
-					 next ? next->scid : NULL, NULL,
+					 scid, NULL,
 					 FORWARD_LOCAL_FAILED,
 					 WIRE_UNKNOWN_NEXT_PEER);
 		return;
@@ -797,7 +797,7 @@ static void forward_htlc(struct htlc_in *hin,
 fail:
 	local_fail_in_htlc(hin, failmsg);
 	wallet_forwarded_payment_add(ld->wallet,
-				 hin, get_onion_style(hin), next->scid, hout,
+				 hin, get_onion_style(hin), scid, hout,
 				 FORWARD_LOCAL_FAILED,
 				 fromwire_peektype(failmsg));
 }
@@ -1337,7 +1337,7 @@ static void fulfill_our_htlc_out(struct channel *channel, struct htlc_out *hout,
 		fulfill_htlc(hout->in, preimage);
 		wallet_forwarded_payment_add(ld->wallet, hout->in,
 					     get_onion_style(hout->in),
-					     hout->key.channel->scid, hout,
+					     channel_scid_or_local_alias(hout->key.channel), hout,
 					     FORWARD_SETTLED, 0);
 	}
 }
@@ -1465,7 +1465,7 @@ static bool peer_failed_our_htlc(struct channel *channel,
 	if (hout->in)
 		wallet_forwarded_payment_add(ld->wallet, hout->in,
 					     get_onion_style(hout->in),
-					     channel->scid,
+					     channel_scid_or_local_alias(channel),
 					     hout, FORWARD_FAILED,
 					     hout->failmsg
 					     ? fromwire_peektype(hout->failmsg)
@@ -1628,7 +1628,7 @@ void onchain_failed_our_htlc(const struct channel *channel,
 				   take(towire_permanent_channel_failure(NULL)));
 		wallet_forwarded_payment_add(hout->key.channel->peer->ld->wallet,
 					 hout->in, get_onion_style(hout->in),
-					 channel->scid, hout,
+					 channel_scid_or_local_alias(channel), hout,
 					 FORWARD_LOCAL_FAILED,
 					 hout->failmsg
 					 ? fromwire_peektype(hout->failmsg)
@@ -1795,7 +1795,7 @@ static bool update_out_htlc(struct channel *channel,
 		if (hout->in) {
 			wallet_forwarded_payment_add(ld->wallet, hout->in,
 						     get_onion_style(hout->in),
-						     channel->scid, hout,
+						     channel_scid_or_local_alias(channel), hout,
 						     FORWARD_OFFERED, 0);
 		}
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2779,7 +2779,7 @@ void json_format_forwarding_object(struct json_stream *response,
 				    "in_msatoshi", "in_msat");
 
 	/* These can be unset (aka zero) if we failed before channel lookup */
-	if (cur->channel_out.u64 != 0) {
+	if (!amount_msat_eq(cur->msat_out, AMOUNT_MSAT(0))) {
 		json_add_amount_msat_compat(response,
 					    cur->msat_out,
 					    "out_msatoshi",  "out_msat");

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1383,6 +1383,7 @@ def test_forward_stats(node_factory, bitcoind):
     assert 'received_time' in stats['forwards'][2] and 'resolved_time' not in stats['forwards'][2]
 
 
+@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("too slow without --dev-fast-gossip")
 @pytest.mark.slow_test
 def test_forward_local_failed_stats(node_factory, bitcoind, executor):
@@ -1607,6 +1608,10 @@ def test_forward_local_failed_stats(node_factory, bitcoind, executor):
     assert 'received_time' in stats['forwards'][2] and 'resolved_time' not in stats['forwards'][2]
     assert 'received_time' in stats['forwards'][3] and 'resolved_time' not in stats['forwards'][3]
     assert 'received_time' in stats['forwards'][3] and 'resolved_time' not in stats['forwards'][4]
+
+    # Correct in and out channels
+    assert [s['in_channel'] for s in stats['forwards']] == [c12] * 5
+    assert [s.get('out_channel') for s in stats['forwards']] == [c23, c24, c25, None, c24]
 
 
 @pytest.mark.developer("too slow without --dev-fast-gossip")

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1383,7 +1383,6 @@ def test_forward_stats(node_factory, bitcoind):
     assert 'received_time' in stats['forwards'][2] and 'resolved_time' not in stats['forwards'][2]
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("too slow without --dev-fast-gossip")
 @pytest.mark.slow_test
 def test_forward_local_failed_stats(node_factory, bitcoind, executor):


### PR DESCRIPTION
There are more cases where we can populate out_channel; we definitely need to fix the case where we failed locally because the outgoing channel didn't have capacity, but we should also try anywhere that they gave us a channel to fwd to, even if it doesn't exist, for example.