### PR TITLE
Remove native-tls dependency from cln-rpc

### DIFF
--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.72"
 tokio-util = { version = "0.6.9", features = ["codec"] }
 tokio = { version = "1", features = ["net"]}
-native-tls = { version = "*", features = ["vendored"] }
 futures-util = { version = "*", features = [ "sink" ] }
 hex = "0.4.3"
 


### PR DESCRIPTION
`native-tls` is unused and in minimint we noticed that compiling its openssl-sys dependency is taking a long time

![image](https://user-images.githubusercontent.com/4335621/174932517-a978162a-f3aa-4b5f-aba6-2d031381d5aa.png)

