### PR TITLE
Add Arch Linux build instructions

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -297,9 +297,9 @@ $ cd lightning
 Build Core Lightning:
 
 ```
-~/.local/bin/poetry install
+python -m poetry install
 ./configure
-~/.local/bin/poetry run make
+python -m poetry run make
 ```
 
 Launch Core Lightning:

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -8,11 +8,12 @@ Install
 5. [OpenBSD](#to-build-on-openbsd)
 6. [NixOS](#to-build-on-nixos)
 7. [macOS](#to-build-on-macos)
-8. [Android](#to-cross-compile-for-android)
-9. [Raspberry Pi](#to-cross-compile-for-raspberry-pi)
-10. [Armbian](#to-compile-for-armbian)
-11. [Alpine](#to-compile-for-alpine)
-12. [Additional steps](#additional-steps)
+8. [Arch Linux](#to-build-on-arch-linux)
+9. [Android](#to-cross-compile-for-android)
+10. [Raspberry Pi](#to-cross-compile-for-raspberry-pi)
+11. [Armbian](#to-compile-for-armbian)
+12. [Alpine](#to-compile-for-alpine)
+13. [Additional steps](#additional-steps)
 
 Library Requirements
 --------------------
@@ -275,6 +276,36 @@ need to include `testnet=1`
     bitcoind &
     ./lightningd/lightningd &
     ./cli/lightning-cli help
+
+To Build on Arch Linux
+---------------------
+
+Install dependencies:
+
+```
+pacman --sync autoconf automake gcc git make python-pip
+pip install --user poetry
+```
+
+Clone Core Lightning:
+```
+$ git clone https://github.com/ElementsProject/lightning.git
+$ cd lightning
+```
+
+Build Core Lightning:
+
+```
+~/.local/bin/poetry install
+./configure
+~/.local/bin/poetry run make
+```
+
+Launch Core Lightning:
+
+```
+./lightningd/lightningd
+```
 
 To cross-compile for Android
 --------------------

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -288,6 +288,7 @@ pip install --user poetry
 ```
 
 Clone Core Lightning:
+
 ```
 $ git clone https://github.com/ElementsProject/lightning.git
 $ cd lightning

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -1,19 +1,19 @@
 Install
 =======
 
-1. [Library Requirements](#library-requirements)
-2. [Ubuntu](#to-build-on-ubuntu)
-3. [Fedora](#to-build-on-fedora)
-4. [FreeBSD](#to-build-on-freebsd)
-5. [OpenBSD](#to-build-on-openbsd)
-6. [NixOS](#to-build-on-nixos)
-7. [macOS](#to-build-on-macos)
-8. [Arch Linux](#to-build-on-arch-linux)
-9. [Android](#to-cross-compile-for-android)
-10. [Raspberry Pi](#to-cross-compile-for-raspberry-pi)
-11. [Armbian](#to-compile-for-armbian)
-12. [Alpine](#to-compile-for-alpine)
-13. [Additional steps](#additional-steps)
+- [Library Requirements](#library-requirements)
+- [Ubuntu](#to-build-on-ubuntu)
+- [Fedora](#to-build-on-fedora)
+- [FreeBSD](#to-build-on-freebsd)
+- [OpenBSD](#to-build-on-openbsd)
+- [NixOS](#to-build-on-nixos)
+- [macOS](#to-build-on-macos)
+- [Arch Linux](#to-build-on-arch-linux)
+- [Android](#to-cross-compile-for-android)
+- [Raspberry Pi](#to-cross-compile-for-raspberry-pi)
+- [Armbian](#to-compile-for-armbian)
+- [Alpine](#to-compile-for-alpine)
+- [Additional steps](#additional-steps)
 
 Library Requirements
 --------------------


### PR DESCRIPTION
The only caveat I'm aware of is the fact that `./configure` will misbehave [here](https://github.com/ElementsProject/lightning/blob/e6442d798ef24e1f868ca6003cad6e20a4d8dd5e/configure#L68) and [here](https://github.com/ElementsProject/lightning/blob/e6442d798ef24e1f868ca6003cad6e20a4d8dd5e/configure#L77) (it won't process those errors but it will conclude that `PYTEST not found` when it's in fact present). To address that, `which` can be added to the list of deps, or we can replace those `which` calls with `command -v`, which is safer since this approach is POSIX-compatible and it does exactly the same thing