### PR TITLE
pyln: Fix relative path dependencies when publishing to PyPI

### DIFF
--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "0.11.0"
+version = "0.11.1"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"
@@ -13,10 +13,12 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 pyln-bolt7 = "^1.0"
-pyln-proto = "^0.10.2"
+pyln-proto = "^0.11"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
+pyln-bolt7 = { path = "../pyln-spec/bolt7", develop = true }
+pyln-proto = { path = "../pyln-proto", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/contrib/pyln-proto/pyproject.toml
+++ b/contrib/pyln-proto/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-proto"
-version = "0.11.0"
+version = "0.11.1"
 description = "This package implements some of the Lightning Network protocol in pure python. It is intended for protocol testing and some minor tooling only. It is not deemed secure enough to handle any amount of real funds (you have been warned!)."
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-testing"
-version = "0.11.0"
+version = "0.11.1"
 description = "Test your Core Lightning integration, plugins or whatever you want"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"
@@ -17,11 +17,13 @@ ephemeral-port-reserve = "^1.1.4"
 psycopg2-binary = "^2.9.3"
 python-bitcoinlib = "^0.11.0"
 jsonschema = "^4.4.0"
-pyln-client = "^0.10.2"
+pyln-client = "^0.11"
 Flask = "^2.0.3"
 cheroot = "^8.6.0"
 psutil = "^5.9.0"
+
 [tool.poetry.dev-dependencies]
+pyln-client = { path = "../pyln-client", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
So this was quite a journey:

 - We want relative depdendencies (using the `path` argument) whenever
   developing locally. Otherwise we would have to install each
   dependency every time we change a single character, which
   undoubtedly would cause us to waste time trying to debug an issue
   just because we forgot to install.
 - When publishing however we want to rely on the version number,
   since the repo context gets lost upon publishing, and path
   dependencies cause failures.

The solution then it seems is to use `dev-dependencies` (not that
surprising once you find it) with relative paths, so that `poetry
install` uses these over the normal dependencies (no idea how they
dedup them) and use `dependencies` when publishing. The paths are
still in there when publishing, but `pip install` ignores them.

I checked that `poetry install` from an unrelated project doesn't
accidentally use the path dependencies, even when adding them as
dev-dependencies. This should hopefully also allow installing them
as a repo link, though I can't test that right now.

Fixes #5246