### PR TITLE
lightningd: remove overzealous assertion.

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1169,9 +1169,6 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 	if (!peer_subds_pending(peer))
 		connect_succeeded(ld, peer, hook_payload->incoming, &hook_payload->addr);
 
-	/* Can't be opening, since we wouldn't have sent peer_disconnected. */
-	assert(!peer->uncommitted_channel);
-
 	/* Log and update remote_addr for Nat/IP discovery. */
 	if (hook_payload->remote_addr) {
 		log_peer_info(ld->log, &id, "Peer says it sees our address as: %s",


### PR DESCRIPTION
This is being hit: it's possible if connectd and lightningd get desynchronized,
and we'll handle this later when peer is activated.

Fixes: #5337 
Changelog-None