### PR TITLE
plugins: unique command line options, small fixes and plugin documentation

### DIFF
--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -7,7 +7,10 @@ lightning-listconfigs - Command to list all configuration options\.
 
 .SH DESCRIPTION
 
-The \fBlistconfigs\fR RPC command to list all configuration options, or with \fIconfig\fR, just that one\.
+\fIconfig\fR (optional) is a configuration option name, or "plugin" to show plugin options
+
+
+The \fBlistconfigs\fR RPC command to list all configuration options, or with \fIconfig\fR only a selection\.
 
 
 The returned values reflect the current configuration, including
@@ -29,6 +32,7 @@ showing default values (\fBdev-\fR options are not shown)\.
 .SH RETURN VALUE
 
 On success, an object is returned, containing:
+
 
 .RS
 .IP \[bu]
@@ -170,6 +174,7 @@ On success, an object is returned, containing:
 
 On failure, one of the following error codes may be returned:
 
+
 .RS
 .IP \[bu]
 -32602: Error in given parameters or field with \fIconfig\fR name doesn't exist\.
@@ -281,4 +286,4 @@ Vincenzo Palazzo \fI<vincenzo.palazzo@protonmail.com\fR> wrote the initial versi
 
 Main web site: \fIhttps://github.com/ElementsProject/lightning\fR
 
-\" SHA256STAMP:c55d5a93c5917bbab0be1633f0f9f06196cfdde6b79434ef012e9dfc2fbbcca9
+\" SHA256STAMP:67e5f100671ed8ef0e490caa46d57dc73e7443caa86a85f32806a0e8183cd1b8

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -9,7 +9,9 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **listconfigs** RPC command to list all configuration options, or with *config*, just that one.
+*config* (optional) is a configuration option name, or "plugin" to show plugin options
+
+The **listconfigs** RPC command to list all configuration options, or with *config* only a selection.
 
 The returned values reflect the current configuration, including
 showing default values (`dev-` options are not shown).

--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -56,6 +56,7 @@ If **command** is "start", "startdir", "rescan" or "list":
   - **plugins** (array of objects):
     - **name** (string): full pathname of the plugin
     - **active** (boolean): status; plugin completed init and is operational, plugins are configured asynchronously.
+    - **dynamic** (boolean): plugin can be stopped or started without restarting lightningd
 
 If **command** is "stop":
   - **result** (string): A message saying it successfully stopped
@@ -80,4 +81,4 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [writing plugins]: PLUGINS.md
-[comment]: # ( SHA256STAMP:ee9c974be30d7870cb6a7785956548700b95d2d6b3fe4f18f7757afdfa015553)
+[comment]: # ( SHA256STAMP:5c3b25ecb137bfe7a81f80f0b4183a9e1282530ebfac3b1bc05fc5406f59cfc7)

--- a/doc/schemas/plugin.schema.json
+++ b/doc/schemas/plugin.schema.json
@@ -48,7 +48,8 @@
               "additionalProperties": false,
               "required": [
                 "name",
-                "active"
+                "active",
+                "dynamic"
               ],
               "properties": {
                 "name": {
@@ -58,6 +59,10 @@
                 "active": {
                   "type": "boolean",
                   "description": "status; plugin completed init and is operational, plugins are configured asynchronously."
+                },
+                "dynamic": {
+                  "type": "boolean",
+                  "description": "plugin can be stopped or started without restarting lightningd"
                 }
               }
             }

--- a/doc/schemas/plugin.schema.json
+++ b/doc/schemas/plugin.schema.json
@@ -57,7 +57,7 @@
                 },
                 "active": {
                   "type": "boolean",
-                  "description": "status; since plugins are configured asynchronously, a freshly started plugin may not appear immediately."
+                  "description": "status; plugin completed init and is operational, plugins are configured asynchronously."
                 }
               }
             }

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -458,11 +458,14 @@ static char *opt_add_proxy_addr(const char *arg, struct lightningd *ld)
 
 static char *opt_add_plugin(const char *arg, struct lightningd *ld)
 {
+	struct plugin *p;
 	if (plugin_blacklisted(ld->plugins, arg)) {
 		log_info(ld->log, "%s: disabled via disable-plugin", arg);
 		return NULL;
 	}
-	plugin_register(ld->plugins, arg, NULL, false, NULL, NULL);
+	p = plugin_register(ld->plugins, arg, NULL, false, NULL, NULL);
+	if (!p)
+		return tal_fmt(NULL, "Failed to register %s: %s", arg, strerror(errno));
 	return NULL;
 }
 
@@ -485,11 +488,14 @@ static char *opt_clear_plugins(struct lightningd *ld)
 
 static char *opt_important_plugin(const char *arg, struct lightningd *ld)
 {
+	struct plugin *p;
 	if (plugin_blacklisted(ld->plugins, arg)) {
 		log_info(ld->log, "%s: disabled via disable-plugin", arg);
 		return NULL;
 	}
-	plugin_register(ld->plugins, arg, NULL, true, NULL, NULL);
+	p = plugin_register(ld->plugins, arg, NULL, true, NULL, NULL);
+	if (!p)
+		return tal_fmt(NULL, "Failed to register %s: %s", arg, strerror(errno));
 	return NULL;
 }
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1521,7 +1521,8 @@ static const char *plugin_parse_getmanifest_response(const char *buffer,
 	if (!err)
 		err = plugin_add_params(plugin);
 
-	plugin->plugin_state = NEEDS_INIT;
+	if (!err)
+		plugin->plugin_state = NEEDS_INIT;
 	return err;
 }
 

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -34,6 +34,7 @@ static struct command_result *plugin_dynamic_list_plugins(struct plugin_command 
 		json_add_string(response, "name", p->cmd);
 		json_add_bool(response, "active",
 		              p->plugin_state == INIT_COMPLETE);
+		json_add_bool(response, "dynamic", p->dynamic);
 		json_object_end(response);
 	}
 	json_array_end(response);

--- a/lightningd/plugin_control.c
+++ b/lightningd/plugin_control.c
@@ -71,8 +71,8 @@ plugin_dynamic_start(struct plugin_command *pcmd, const char *plugin_path,
 
 	if (!p)
 		return command_fail(pcmd->cmd, JSONRPC2_INVALID_PARAMS,
-				    "%s: already registered",
-				    plugin_path);
+				    "%s: %s", plugin_path,
+					    errno ? strerror(errno) : "already registered");
 
 	/* This will come back via plugin_cmd_killed or plugin_cmd_succeeded */
 	err = plugin_send_getmanifest(p);

--- a/tests/plugins/options.py
+++ b/tests/plugins/options.py
@@ -22,4 +22,6 @@ plugin.add_flag_option('flag_opt', 'an example flag type option')
 plugin.add_option('str_optm', None, 'an example string option', multi=True)
 plugin.add_option('int_optm', 7, 'an example int type option', opt_type='int', multi=True)
 
+plugin.add_option('greeting', 7, 'option _names_ should be unique', opt_type='int', multi=True)
+
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2074,10 +2074,11 @@ def test_important_plugin(node_factory):
     n = node_factory.get_node(options={"important-plugin": os.path.join(pluginsdir, "nonexistent")},
                               may_fail=True, expect_fail=True,
                               allow_broken_log=True, start=False)
+
     n.daemon.start(wait_for_initialized=False)
     # Will exit with failure code.
     assert n.daemon.wait() == 1
-    assert n.daemon.is_in_stderr(r"error starting plugin '.*nonexistent'")
+    assert n.daemon.is_in_stderr(r"Failed to register .*nonexistent: No such file or directory")
 
     # Check we exit if the important plugin dies.
     n.daemon.opts['important-plugin'] = os.path.join(pluginsdir, "fail_by_itself.py")


### PR DESCRIPTION
Some issues I came across looking at #5294 (that discussion is ongoing, this PR adds some context)

Converts `plugin->cmd` to a full path immediately (couldn't find a reason not to), ensures only one instance can run.
Plugin command line options should have unique names (and no aliases).
Update plugin documentation.

**edit** ~Last 2~ [8be7693](https://github.com/ElementsProject/lightning/pull/5343/commits/8be769345a6b3b869022bcb7ae3cd107ffb162d5) and  [cf2dbbb](https://github.com/ElementsProject/lightning/pull/5343/commits/cf2dbbbe6a71b6a383f5126778e74bd915443641) ~commits is an idea for plugins that do configs internally, not fully worked out.~

**edit** Add "dynamic" field to `plugin list` result, some builtin plugins are dynamic !