### PR TITLE
plugin: add check on the type json object during the IO message handling

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -643,6 +643,11 @@ static const char *plugin_read_json_one(struct plugin *plugin,
 		return NULL;
 	}
 
+	if (plugin->toks->type != JSMN_OBJECT)
+		return tal_fmt(
+		    plugin,
+		    "JSON-RPC message is not a valid JSON object type");
+
 	jrtok = json_get_member(plugin->buffer, plugin->toks, "jsonrpc");
 	idtok = json_get_member(plugin->buffer, plugin->toks, "id");
 


### PR DESCRIPTION
During the debugging of a summer of the bitcoin project with @swaptr, core lightning lies in the error message when receiving a notification with an invalid JSON, it tells that the object did not contains the `jsonrpc` filed, but if I send a string with a valid json inside like `"{valid json rpc 2.0 notification}"` cln should tell us that we are sending somethings that it is not a json object

Having a better error message can speed up the debugging process, and from our point of view it is just an `if`

Still thinking about how to make a test for this, any suggestions?