### PR TITLE
connectd: don't insist on ping replies when other traffic is flowing.

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -310,6 +310,7 @@ static struct peer *new_peer(struct daemon *daemon,
 	peer->ready_to_die = false;
 	peer->active = false;
 	peer->peer_outq = msg_queue_new(peer, false);
+	peer->last_recv_time = time_now();
 
 #if DEVELOPER
 	peer->dev_writes_enabled = NULL;

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -87,6 +87,9 @@ struct peer {
 	/* Random ping timer, to detect dead connections. */
 	struct oneshot *ping_timer;
 
+	/* Last time we received traffic */
+	struct timeabs last_recv_time;
+
 #if DEVELOPER
 	bool dev_read_enabled;
 	/* If non-NULL, this counts down; 0 means disable */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3848,15 +3848,18 @@ def test_ping_timeout(node_factory):
 
     l1, l2 = node_factory.get_nodes(2, opts=[{'dev-no-reconnect': None,
                                               'disconnect': l1_disconnects},
-                                             {}])
+                                             {'dev-no-ping-timer': None}])
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
-    # Takes 15-45 seconds, then another to try second ping
-    # Because of ping timer randomness we don't know which side hangs up first
-    wait_for(lambda: l1.rpc.listpeers(l2.info['id'])['peers'] == [],
-             timeout=45 + 45 + 5)
-    wait_for(lambda: (l1.daemon.is_in_log('Last ping unreturned: hanging up')
-                      or l2.daemon.is_in_log('Last ping unreturned: hanging up')))
+    # This can take 10 seconds (dev-fast-gossip means timer fires every 5 seconds)
+    l1.daemon.wait_for_log('seeker: startup peer finished', timeout=15)
+    # Ping timers runs at 15-45 seconds, *but* only fires if also 60 seconds
+    # after previous traffic.
+    l1.daemon.wait_for_log('dev_disconnect: xWIRE_PING', timeout=60 + 45 + 5)
+
+    # Next pign will cause hangup
+    l1.daemon.wait_for_log('Last ping unreturned: hanging up', timeout=45 + 5)
+    wait_for(lambda: l1.rpc.listpeers(l2.info['id'])['peers'] == [])
 
 
 @pytest.mark.openchannel('v1')

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1281,8 +1281,7 @@ def test_node_reannounce(node_factory, bitcoind, chainparams):
                             filters=['0109', '0107', '0102', '0100', '0012'])
 
     # May send its own announcement *twice*, since it always spams us.
-    msgs2 = list(set(msgs2))
-    assert msgs == msgs2
+    assert set(msgs) == set(msgs2)
     # Won't have queued up another one, either.
     assert not l1.daemon.is_in_log('node_announcement: delaying')
 
@@ -1308,8 +1307,7 @@ def test_node_reannounce(node_factory, bitcoind, chainparams):
                             # channel_announcement and channel_updates.
                             # And pings.
                             filters=['0109', '0107', '0102', '0100', '0012'])
-    msgs2 = list(set(msgs2))
-    assert msgs != msgs2
+    assert set(msgs) != set(msgs2)
 
 
 def test_gossipwith(node_factory):


### PR DESCRIPTION
Got complaints about us hanging up on some nodes because they don't respond
to pings in a timely manner (e.g. ACINQ?).  This only matters to us if no
other traffic is flowing, so mitigate that.

This may solve the problem because we've previously seen implementations
badly prioritize gossip traffic, and thus important messages can get queued
behind gossip dumps!
