### PR TITLE
Peer storage feature

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -2300,6 +2300,8 @@ static void peer_in(struct peer *peer, const u8 *msg)
 	case WIRE_WARNING:
 	case WIRE_ERROR:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 		abort();
 	}
 

--- a/common/features.c
+++ b/common/features.c
@@ -136,12 +136,12 @@ static const struct feature_style feature_styles[] = {
 			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT,
 			  [BOLT11_FEATURE] = FEATURE_DONT_REPRESENT,
 			  [CHANNEL_FEATURE] = FEATURE_DONT_REPRESENT } },
-	{ PEER_STORAGE_FEATURE,
-	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL,
-			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL } },
-	{ YOUR_PEER_STORAGE_FEATURE,
-	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL,
-			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL } },
+	{ OPT_WANT_PEER_BACKUP_STORAGE,
+	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT,
+			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT } },
+	{ OPT_PROVIDE_PEER_BACKUP_STORAGE,
+	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT,
+			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT } },
 };
 
 struct dependency {
@@ -462,8 +462,8 @@ const char *feature_name(const tal_t *ctx, size_t f)
 		"option_quiesce", /* https://github.com/lightning/bolts/pull/869 */
 		NULL,
 		"option_onion_messages",  /* https://github.com/lightning/bolts/pull/759 */
-		"option_your_peer_storage", /* 40/41 */
-		"option_peer_storage",
+		"option_want_peer_backup_storage", /* 40/41 */ /* https://github.com/lightning/bolts/pull/881/files */
+		"option_provide_peer_backup_storage", /* https://github.com/lightning/bolts/pull/881/files */
 		"option_channel_type",
 		"option_scid_alias", /* https://github.com/lightning/bolts/pull/910 */
 		"option_payment_metadata",

--- a/common/features.c
+++ b/common/features.c
@@ -136,6 +136,12 @@ static const struct feature_style feature_styles[] = {
 			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT,
 			  [BOLT11_FEATURE] = FEATURE_DONT_REPRESENT,
 			  [CHANNEL_FEATURE] = FEATURE_DONT_REPRESENT } },
+	{ PEER_STORAGE_FEATURE,
+	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL,
+			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL } },
+	{ YOUR_PEER_STORAGE_FEATURE,
+	  .copy_style = { [INIT_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL,
+			  [NODE_ANNOUNCE_FEATURE] = FEATURE_REPRESENT_AS_OPTIONAL } },
 };
 
 struct dependency {
@@ -456,8 +462,8 @@ const char *feature_name(const tal_t *ctx, size_t f)
 		"option_quiesce", /* https://github.com/lightning/bolts/pull/869 */
 		NULL,
 		"option_onion_messages",  /* https://github.com/lightning/bolts/pull/759 */
-		"option_want_peer_backup", /* 40/41 */ /* https://github.com/lightning/bolts/pull/881 */
-		"option_provide_peer_backup", /* https://github.com/lightning/bolts/pull/881 */
+		"option_your_peer_storage", /* 40/41 */
+		"option_peer_storage",
 		"option_channel_type",
 		"option_scid_alias", /* https://github.com/lightning/bolts/pull/910 */
 		"option_payment_metadata",

--- a/common/features.h
+++ b/common/features.h
@@ -15,7 +15,8 @@ enum feature_place {
 	BOLT12_INVOICE_FEATURE,
 };
 #define NUM_FEATURE_PLACE (BOLT12_INVOICE_FEATURE+1)
-
+#define PEER_STORAGE_FEATURE 42
+#define YOUR_PEER_STORAGE_FEATURE 40
 extern const char *feature_place_names[NUM_FEATURE_PLACE];
 
 /* The complete set of features for all contexts */

--- a/common/features.h
+++ b/common/features.h
@@ -15,8 +15,6 @@ enum feature_place {
 	BOLT12_INVOICE_FEATURE,
 };
 #define NUM_FEATURE_PLACE (BOLT12_INVOICE_FEATURE+1)
-#define PEER_STORAGE_FEATURE 42
-#define YOUR_PEER_STORAGE_FEATURE 40
 extern const char *feature_place_names[NUM_FEATURE_PLACE];
 
 /* The complete set of features for all contexts */
@@ -165,5 +163,13 @@ struct feature_set *feature_set_dup(const tal_t *ctx,
 #define OPT_ONION_MESSAGES			38
 
 #define OPT_SHUTDOWN_WRONG_FUNDING		104
+
+/* BOLT-peer-storage #9:
+ *
+ * | 40/41 | `want_peer_backup_storage`        | Want to use other nodes to store encrypted backup data    | IN ...
+ * | 42/43 | `provide_peer_backup_storage`     | Can store other nodes' encrypted backup data              | IN ...
+ */
+#define OPT_WANT_PEER_BACKUP_STORAGE		40
+#define OPT_PROVIDE_PEER_BACKUP_STORAGE		42
 
 #endif /* LIGHTNING_COMMON_FEATURES_H */

--- a/connectd/gossip_rcvd_filter.c
+++ b/connectd/gossip_rcvd_filter.c
@@ -87,6 +87,8 @@ static bool is_msg_gossip_broadcast(const u8 *cursor)
 	case WIRE_TX_INIT_RBF:
 	case WIRE_TX_ACK_RBF:
 	case WIRE_TX_ABORT:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 	case WIRE_OPEN_CHANNEL2:
 	case WIRE_ACCEPT_CHANNEL2:
 #if EXPERIMENTAL_FEATURES

--- a/connectd/gossip_store.c
+++ b/connectd/gossip_store.c
@@ -92,6 +92,8 @@ static bool public_msg_type(enum peer_wire type)
 	case WIRE_REPLY_CHANNEL_RANGE:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 	case WIRE_STFU:
 #endif

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -723,7 +723,7 @@ static bool handle_custommsg(struct daemon *daemon,
 			     const u8 *msg)
 {
 	enum peer_wire type = fromwire_peektype(msg);
-	if (type % 2 == 1 && !peer_wire_is_defined(type)) {
+	if (type % 2 == 1 && !peer_wire_is_internal(type)) {
 		/* The message is not part of the messages we know how to
 		 * handle. Assuming this is a custommsg, we just forward it to the
 		 * master. */

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -385,6 +385,8 @@ static bool is_urgent(enum peer_wire type)
 	case WIRE_REPLY_CHANNEL_RANGE:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 	case WIRE_STFU:
 #endif

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -62,6 +62,7 @@ On success, an object is returned, containing:
 - **experimental-offers** (boolean, optional): `experimental-offers` field from config or cmdline, or default
 - **experimental-shutdown-wrong-funding** (boolean, optional): `experimental-shutdown-wrong-funding` field from config or cmdline, or default
 - **experimental-websocket-port** (u16, optional): `experimental-websocket-port` field from config or cmdline, or default
+- **experimental-peer-storage** (boolean, optional): `experimental-peer-storage` field from config or cmdline, or default *(added v23.02)*
 - **database-upgrade** (boolean, optional): `database-upgrade` field from config or cmdline
 - **rgb** (hex, optional): `rgb` field from config or cmdline, or default (always 6 characters)
 - **alias** (string, optional): `alias` field from config or cmdline, or default
@@ -223,4 +224,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:581225b26efd84bfa99dc98e7a91e6fae11ef0b11939031d3da07f751f6d8f87)
+[comment]: # ( SHA256STAMP:1088401b9aeae1e079dab550d3b035ef82195f0466ad471bc7373386182f37dc)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -714,6 +714,12 @@ connections on that port, on any IPv4 and IPv6 addresses you listen
 to ([bolt][bolt] #891).  The normal protocol is expected to be sent over WebSocket binary
 frames once the connection is upgraded.
 
+* **experimental-peer-storage**
+
+  Specifying this option means we will store up to 64k of encrypted
+data for our peers, and give them our (encrypted!) backup data to
+store as well, based on a protocol similar to [bolt][bolt] #881.
+
 BUGS
 ----
 

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -137,6 +137,11 @@
       "type": "u16",
       "description": "`experimental-websocket-port` field from config or cmdline, or default"
     },
+    "experimental-peer-storage": {
+      "type": "boolean",
+      "added": "v23.02",
+      "description": "`experimental-peer-storage` field from config or cmdline, or default"
+    },
     "database-upgrade": {
       "type": "boolean",
       "description": "`database-upgrade` field from config or cmdline"

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -569,6 +569,8 @@ static void handle_recv_gossip(struct daemon *daemon, const u8 *outermsg)
 	case WIRE_OPEN_CHANNEL2:
 	case WIRE_ACCEPT_CHANNEL2:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 	case WIRE_STFU:
 #endif

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -752,7 +752,9 @@ static struct command_result *json_sendcustommsg(struct command *cmd,
 		return command_param_failed();
 
 	type = fromwire_peektype(msg);
-	if (peer_wire_is_defined(type)) {
+
+	/* Allow peer_storage and your_peer_storage msgtypes */
+	if (peer_wire_is_internal(type)) {
 		return command_fail(
 		    cmd, JSONRPC2_INVALID_REQUEST,
 		    "Cannot send messages of type %d (%s). It is not possible "

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -779,11 +779,11 @@ static struct command_result *json_sendcustommsg(struct command *cmd,
 				    type_to_string(cmd, struct node_id, dest));
 	}
 
-	if (peer->connected != PEER_CONNECTED)
+	/* We allow messages from plugins responding to peer_connected hook,
+	 * so can be PEER_CONNECTING. */
+	if (peer->connected == PEER_DISCONNECTED)
 		return command_fail(cmd, JSONRPC2_INVALID_REQUEST,
-				    "Peer is %s",
-				    peer->connected == PEER_DISCONNECTED
-				    ? "not connected" : "still connecting");
+				    "Peer is not connected");
 
 	subd_send_msg(cmd->ld->connectd,
 		      take(towire_connectd_custommsg_out(cmd, dest, msg)));

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1078,6 +1078,15 @@ static char *opt_set_shutdown_wrong_funding(struct lightningd *ld)
 	return NULL;
 }
 
+static char *opt_set_peer_storage(struct lightningd *ld)
+{
+	feature_set_or(ld->our_features,
+		       take(feature_set_for_feature(NULL, OPT_PROVIDE_PEER_BACKUP_STORAGE)));
+	feature_set_or(ld->our_features,
+		       take(feature_set_for_feature(NULL, OPT_WANT_PEER_BACKUP_STORAGE)));
+	return NULL;
+}
+
 static char *opt_set_offers(struct lightningd *ld)
 {
 	ld->config.exp_offers = true;
@@ -1156,6 +1165,9 @@ static void register_opts(struct lightningd *ld)
 	opt_register_early_noarg("--experimental-shutdown-wrong-funding",
 				 opt_set_shutdown_wrong_funding, ld,
 				 "EXPERIMENTAL: allow shutdown with alternate txids");
+	opt_register_early_noarg("--experimental-peer-storage",
+				 opt_set_peer_storage, ld,
+				 "EXPERIMENTAL: enable peer backup storage and restore");
 	opt_register_early_arg("--announce-addr-dns",
 			       opt_set_bool_arg, opt_show_bool,
 			       &ld->announce_dns,
@@ -1641,6 +1653,11 @@ static void add_config(struct lightningd *ld,
 				      feature_offered(ld->our_features
 						      ->bits[INIT_FEATURE],
 						      OPT_SHUTDOWN_WRONG_FUNDING));
+		} else if (opt->cb == (void *)opt_set_peer_storage) {
+			json_add_bool(response, name0,
+				      feature_offered(ld->our_features
+						      ->bits[INIT_FEATURE],
+						      OPT_PROVIDE_PEER_BACKUP_STORAGE));
 		} else if (opt->cb == (void *)plugin_opt_flag_set) {
 			/* Noop, they will get added below along with the
 			 * OPT_HASARG options. */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1424,7 +1424,7 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 	if (peer->remote_addr)
 		tal_free(peer->remote_addr);
 	peer->remote_addr = NULL;
-	peer_update_features(peer, their_features);
+	peer_update_features(peer, take(their_features));
 
 	tal_steal(peer, hook_payload);
 	hook_payload->peer = peer;

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -1443,6 +1443,8 @@ static u8 *opening_negotiate_msg(const tal_t *ctx, struct state *state)
 		case WIRE_WARNING:
 		case WIRE_PING:
 		case WIRE_PONG:
+		case WIRE_PEER_STORAGE:
+		case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 		case WIRE_STFU:
 #endif
@@ -1817,6 +1819,8 @@ static bool run_tx_interactive(struct state *state,
 		case WIRE_REPLY_SHORT_CHANNEL_IDS_END:
 		case WIRE_PING:
 		case WIRE_PONG:
+		case WIRE_PEER_STORAGE:
+		case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 		case WIRE_STFU:
 #endif
@@ -4166,6 +4170,8 @@ static u8 *handle_peer_in(struct state *state)
 	case WIRE_WARNING:
 	case WIRE_PING:
 	case WIRE_PONG:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 	case WIRE_STFU:
 #endif

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -425,11 +425,10 @@ static struct command_result *after_listpeers(struct command *cmd,
 					      const jsmntok_t *params,
 					      void *cb_arg UNUSED)
 {
-	const jsmntok_t *peers, *peer, *nodeid;
+	const jsmntok_t *peers, *peer;
         struct out_req *req;
 	size_t i;
 	struct info *info = tal(cmd, struct info);
-	struct node_id *node_id = tal(cmd, struct node_id);
 	bool is_connected;
 
 	u8 *scb = get_file_data(cmd->plugin);
@@ -444,8 +443,11 @@ static struct command_result *after_listpeers(struct command *cmd,
 			     &is_connected);
 
 		if (is_connected) {
+			const jsmntok_t *nodeid;
+			struct node_id node_id;
+
 			nodeid = json_get_member(buf, peer, "id");
-			json_to_node_id(buf, nodeid, node_id);
+			json_to_node_id(buf, nodeid, &node_id);
 
 			req = jsonrpc_request_start(cmd->plugin,
 						    cmd,
@@ -454,7 +456,7 @@ static struct command_result *after_listpeers(struct command *cmd,
 						    after_send_scb_single_fail,
 						    info);
 
-			json_add_node_id(req->js, "node_id", node_id);
+			json_add_node_id(req->js, "node_id", &node_id);
 			json_add_hex(req->js, "msg", serialise_scb,
 				     tal_bytelen(serialise_scb));
 			info->idx++;

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -410,7 +410,7 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL,
+	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 	        notifs, ARRAY_SIZE(notifs), NULL, 0,
 		    NULL, 0,  /* Notification topics we publish */

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -21,6 +21,8 @@
 #define HEADER_LEN crypto_secretstream_xchacha20poly1305_HEADERBYTES
 #define ABYTES crypto_secretstream_xchacha20poly1305_ABYTES
 
+#define FILENAME "emergency.recover"
+
 /* VERSION is the current version of the data encrypted in the file */
 #define VERSION ((u64)1)
 
@@ -111,7 +113,7 @@ static void maybe_create_new_scb(struct plugin *p,
 
 	/* Note that this is opened for write-only, even though the permissions
 	 * are set to read-only.  That's perfectly valid! */
-	int fd = open("emergency.recover", O_CREAT|O_EXCL|O_WRONLY, 0400);
+	int fd = open(FILENAME, O_CREAT|O_EXCL|O_WRONLY, 0400);
 	if (fd < 0) {
 		/* Don't do anything if the file already exists. */
 		if (errno == EEXIST)
@@ -120,7 +122,7 @@ static void maybe_create_new_scb(struct plugin *p,
 	}
 
 	/* Comes here only if the file haven't existed before */
-	unlink_noerr("emergency.recover");
+	unlink_noerr(FILENAME);
 
 	/* This couldn't give EEXIST because we call unlink_noerr("scb.tmp")
 	 * in INIT */
@@ -161,7 +163,7 @@ static void maybe_create_new_scb(struct plugin *p,
 	close(fd);
 
 	/* This will update the scb file */
-	rename("scb.tmp", "emergency.recover");
+	rename("scb.tmp", FILENAME);
 }
 
 
@@ -169,9 +171,9 @@ static void maybe_create_new_scb(struct plugin *p,
 static u8 *decrypt_scb(struct plugin *p)
 {
 	struct stat st;
-	int fd = open("emergency.recover", O_RDONLY);
+	int fd = open(FILENAME, O_RDONLY);
 
-	if (stat("emergency.recover", &st) != 0)
+	if (stat(FILENAME, &st) != 0)
 		plugin_err(p, "SCB file is corrupted!: %s",
                           strerror(errno));
 
@@ -315,7 +317,7 @@ static void update_scb(struct plugin *p, struct scb_chan **channels)
 	close(fd);
 
 	/* This will atomically replace the main file */
-	rename("scb.tmp", "emergency.recover");
+	rename("scb.tmp", FILENAME);
 }
 
 static struct command_result *after_staticbackup(struct command *cmd,

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -7,6 +7,7 @@
 #include <ccan/read_write_all/read_write_all.h>
 #include <ccan/tal/str/str.h>
 #include <ccan/time/time.h>
+#include <common/features.h>
 #include <common/hsm_encryption.h>
 #include <common/json_param.h>
 #include <common/json_stream.h>
@@ -409,7 +410,12 @@ static const struct plugin_command commands[] = { {
 
 int main(int argc, char *argv[])
 {
-	setup_locale();
+        setup_locale();
+	struct feature_set *features = feature_set_for_feature(NULL, PEER_STORAGE_FEATURE);
+	feature_set_or(features,
+		       take(feature_set_for_feature(NULL,
+						    YOUR_PEER_STORAGE_FEATURE)));
+
 	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 	        notifs, ARRAY_SIZE(notifs), NULL, 0,

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -795,10 +795,10 @@ static const struct plugin_command commands[] = {
 int main(int argc, char *argv[])
 {
         setup_locale();
-	struct feature_set *features = feature_set_for_feature(NULL, PEER_STORAGE_FEATURE);
+	struct feature_set *features = feature_set_for_feature(NULL, OPT_WANT_PEER_BACKUP_STORAGE);
 	feature_set_or(features,
 		       take(feature_set_for_feature(NULL,
-						    YOUR_PEER_STORAGE_FEATURE)));
+						    OPT_PROVIDE_PEER_BACKUP_STORAGE)));
 
 	plugin_main(argv, init, PLUGIN_STATIC, true, features,
 		    commands, ARRAY_SIZE(commands),

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -338,14 +338,9 @@ static struct command_result *json_state_changed(struct command *cmd,
                                                     "channel_state_changed"),
 	*statetok = json_get_member(buf, notiftok, "new_state");
 
-	/* FIXME: I wanted to update the file on CHANNELD_AWAITING_LOCKIN,
-	 * But I don't get update for it, maybe because there is
-	 * no previous_state, also apparently `channel_opened` gets published
-	 * when *peer* funded a channel with us?
-	 * So, is their no way to get a notif on CHANNELD_AWAITING_LOCKIN? */
 	if (json_tok_streq(buf, statetok, "CLOSED") ||
-		json_tok_streq(buf, statetok, "CHANNELD_NORMAL")) {
-
+		json_tok_streq(buf, statetok, "CHANNELD_AWAITING_LOCKIN") ||
+		json_tok_streq(buf, statetok, "DUALOPENED_AWAITING_LOCKIN")) {
 		struct out_req *req;
 		req = jsonrpc_request_start(cmd->plugin,
                                             cmd,

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -33,8 +33,8 @@ static struct secret secret;
 
 /* Helper to fetch out SCB from the RPC call */
 static bool json_to_scb_chan(const char *buffer,
-                        const jsmntok_t *tok,
-		        struct scb_chan ***channels)
+			     const jsmntok_t *tok,
+			     struct scb_chan ***channels)
 {
 	size_t i;
 	const jsmntok_t *t;
@@ -74,10 +74,10 @@ static void write_scb(struct plugin *p,
 						      		  scb_chan_arr));
 
 	u8 *encrypted_scb = tal_arr(tmpctx,
-                            u8,
-                            tal_bytelen(decrypted_scb) +
-                            ABYTES +
-                            HEADER_LEN);
+				    u8,
+				    tal_bytelen(decrypted_scb) +
+				    ABYTES +
+				    HEADER_LEN);
 
 	crypto_secretstream_xchacha20poly1305_state crypto_state;
 
@@ -90,20 +90,20 @@ static void write_scb(struct plugin *p,
 	}
 
 	if (crypto_secretstream_xchacha20poly1305_push(&crypto_state,
-                                                encrypted_scb +
-                                                HEADER_LEN,
-                                                NULL, decrypted_scb,
-                                                tal_bytelen(decrypted_scb),
-                                                /* Additional data and tag */
-                                                NULL, 0, 0)) {
+						       encrypted_scb +
+						       HEADER_LEN,
+						       NULL, decrypted_scb,
+						       tal_bytelen(decrypted_scb),
+						       /* Additional data and tag */
+						       NULL, 0, 0)) {
 		plugin_err(p, "Can't encrypt the data!");
 		return;
 	}
 
 	if (!write_all(fd, encrypted_scb, tal_bytelen(encrypted_scb))) {
-			unlink_noerr("scb.tmp");
-			plugin_err(p, "Writing encrypted SCB: %s",
-                                  strerror(errno));
+		unlink_noerr("scb.tmp");
+		plugin_err(p, "Writing encrypted SCB: %s",
+			   strerror(errno));
 	}
 
 }
@@ -188,12 +188,12 @@ static u8 *decrypt_scb(struct plugin *p)
 	crypto_secretstream_xchacha20poly1305_state crypto_state;
 
 	if (tal_bytelen(filedata) < ABYTES +
-			 HEADER_LEN)
+	    HEADER_LEN)
 		plugin_err(p, "SCB file is corrupted!");
 
 	u8 *decrypt_scb = tal_arr(tmpctx, u8, tal_bytelen(filedata) -
-                          ABYTES -
-                          HEADER_LEN);
+				  ABYTES -
+				  HEADER_LEN);
 
 	/* The header part */
 	if (crypto_secretstream_xchacha20poly1305_init_pull(&crypto_state,
@@ -235,8 +235,8 @@ static struct command_result *after_recover_rpc(struct command *cmd,
 
 /* Recovers the channels by making RPC to `recoverchannel` */
 static struct command_result *json_emergencyrecover(struct command *cmd,
-				      const char *buf,
-                                      const jsmntok_t *params)
+						    const char *buf,
+						    const jsmntok_t *params)
 {
 	struct out_req *req;
 	u64 version;
@@ -262,8 +262,8 @@ static struct command_result *json_emergencyrecover(struct command *cmd,
 	}
 
 	req = jsonrpc_request_start(cmd->plugin, cmd, "recoverchannel",
-				after_recover_rpc,
-				&forward_error, NULL);
+				    after_recover_rpc,
+				    &forward_error, NULL);
 
 	json_array_start(req->js, "scb");
 	for (size_t i=0; i<tal_count(scb); i++) {
@@ -319,9 +319,9 @@ static void update_scb(struct plugin *p, struct scb_chan **channels)
 
 static struct command_result
 *peer_after_send_their_peer_strg(struct command *cmd,
-                            const char *buf,
-                            const jsmntok_t *params,
-                            void *cb_arg UNUSED)
+				 const char *buf,
+				 const jsmntok_t *params,
+				 void *cb_arg UNUSED)
 {
         plugin_log(cmd->plugin, LOG_DBG, "Sent their peer storage!");
 	return command_hook_success(cmd);
@@ -329,9 +329,9 @@ static struct command_result
 
 static struct command_result
 *peer_after_send_their_peer_strg_err(struct command *cmd,
-                            const char *buf,
-                            const jsmntok_t *params,
-                            void *cb_arg UNUSED)
+				     const char *buf,
+				     const jsmntok_t *params,
+				     void *cb_arg UNUSED)
 {
         plugin_log(cmd->plugin, LOG_DBG, "Unable to send Peer storage!");
 	return command_hook_success(cmd);
@@ -375,9 +375,9 @@ static struct command_result *peer_after_send_scb(struct command *cmd,
 				     	    cmd,
 				     	    tal_fmt(cmd,
 				     		    "chanbackup/peers/%s",
-					     	     type_to_string(tmpctx,
-							            struct node_id,
-							    	    nodeid)),
+						    type_to_string(tmpctx,
+								   struct node_id,
+								   nodeid)),
 				     	    peer_after_listdatastore,
 				     	    nodeid);
 }
@@ -397,9 +397,9 @@ struct info {
 };
 
 static struct command_result *after_send_scb_single(struct command *cmd,
-                                             const char *buf,
-                                             const jsmntok_t *params,
-                                             struct info *info)
+						    const char *buf,
+						    const jsmntok_t *params,
+						    struct info *info)
 {
         plugin_log(cmd->plugin, LOG_INFORM, "Peer storage sent!");
 	if (--info->idx != 0)
@@ -409,9 +409,9 @@ static struct command_result *after_send_scb_single(struct command *cmd,
 }
 
 static struct command_result *after_send_scb_single_fail(struct command *cmd,
-                                             const char *buf,
-                                             const jsmntok_t *params,
-                                             struct info *info)
+							 const char *buf,
+							 const jsmntok_t *params,
+							 struct info *info)
 {
         plugin_log(cmd->plugin, LOG_DBG, "Peer storage send failed!");
 	if (--info->idx != 0)
@@ -421,9 +421,9 @@ static struct command_result *after_send_scb_single_fail(struct command *cmd,
 }
 
 static struct command_result *after_listpeers(struct command *cmd,
-                                             const char *buf,
-                                             const jsmntok_t *params,
-                                             void *cb_arg UNUSED)
+					      const char *buf,
+					      const jsmntok_t *params,
+					      void *cb_arg UNUSED)
 {
 	const jsmntok_t *peers, *peer, *nodeid;
         struct out_req *req;
@@ -441,22 +441,22 @@ static struct command_result *after_listpeers(struct command *cmd,
 	info->idx = 0;
 	json_for_each_arr(i, peer, peers) {
 		json_to_bool(buf, json_get_member(buf, peer, "connected"),
-				&is_connected);
+			     &is_connected);
 
 		if (is_connected) {
 			nodeid = json_get_member(buf, peer, "id");
 			json_to_node_id(buf, nodeid, node_id);
 
 			req = jsonrpc_request_start(cmd->plugin,
-				cmd,
-				"sendcustommsg",
-				after_send_scb_single,
-				after_send_scb_single_fail,
-				info);
+						    cmd,
+						    "sendcustommsg",
+						    after_send_scb_single,
+						    after_send_scb_single_fail,
+						    info);
 
 			json_add_node_id(req->js, "node_id", node_id);
 			json_add_hex(req->js, "msg", serialise_scb,
-				tal_bytelen(serialise_scb));
+				     tal_bytelen(serialise_scb));
 			info->idx++;
 			send_outreq(cmd->plugin, req);
 		}
@@ -497,11 +497,11 @@ static struct command_result *json_state_changed(struct command *cmd,
 	const jsmntok_t *notiftok = json_get_member(buf,
                                                     params,
                                                     "channel_state_changed"),
-	*statetok = json_get_member(buf, notiftok, "new_state");
+		*statetok = json_get_member(buf, notiftok, "new_state");
 
 	if (json_tok_streq(buf, statetok, "CLOSED") ||
-		json_tok_streq(buf, statetok, "CHANNELD_AWAITING_LOCKIN") ||
-		json_tok_streq(buf, statetok, "DUALOPENED_AWAITING_LOCKIN")) {
+	    json_tok_streq(buf, statetok, "CHANNELD_AWAITING_LOCKIN") ||
+	    json_tok_streq(buf, statetok, "DUALOPENED_AWAITING_LOCKIN")) {
 		struct out_req *req;
 		req = jsonrpc_request_start(cmd->plugin,
                                             cmd,
@@ -583,8 +583,8 @@ static struct command_result *datastore_failed(struct command *cmd,
 }
 
 static struct command_result *handle_your_peer_storage(struct command *cmd,
-					         const char *buf,
-					         const jsmntok_t *params)
+						       const char *buf,
+						       const jsmntok_t *params)
 {
         struct node_id node_id;
         u8 *payload, *payload_deserialise;
@@ -622,14 +622,14 @@ static struct command_result *handle_your_peer_storage(struct command *cmd,
         	crypto_secretstream_xchacha20poly1305_state crypto_state;
 
                 if (tal_bytelen(payload_deserialise) < ABYTES +
-			                               HEADER_LEN)
+		    HEADER_LEN)
 		        return failed_peer_restore(cmd, &node_id,
 						   "Too short!");
 
                 u8 *decoded_bkp = tal_arr(tmpctx, u8,
-				        tal_bytelen(payload_deserialise) -
-                                	ABYTES -
-                                	HEADER_LEN);
+					  tal_bytelen(payload_deserialise) -
+					  ABYTES -
+					  HEADER_LEN);
 
                 /* The header part */
                 if (crypto_secretstream_xchacha20poly1305_init_pull(&crypto_state,
@@ -659,15 +659,15 @@ static struct command_result *handle_your_peer_storage(struct command *cmd,
 					     	    datastore_failed,
 						    "Saving latestscb");
 	} else {
-                        plugin_log(cmd->plugin, LOG_DBG,
-                                   "Peer sent bad custom message for chanbackup!");
-                        return command_hook_success(cmd);
+		plugin_log(cmd->plugin, LOG_DBG,
+			   "Peer sent bad custom message for chanbackup!");
+		return command_hook_success(cmd);
         }
 }
 
 static struct command_result *after_latestscb(struct command *cmd,
-					        const u8 *res,
-					        void *cb_arg UNUSED)
+					      const u8 *res,
+					      void *cb_arg UNUSED)
 {
         u64 version;
 	u32 timestamp;
@@ -697,8 +697,8 @@ static struct command_result *after_latestscb(struct command *cmd,
 	}
 
         req = jsonrpc_request_start(cmd->plugin, cmd, "recoverchannel",
-				after_recover_rpc,
-				&forward_error, NULL);
+				    after_recover_rpc,
+				    &forward_error, NULL);
 
 	json_array_start(req->js, "scb");
 	for (size_t i=0; i<tal_count(scb); i++) {
@@ -713,8 +713,8 @@ static struct command_result *after_latestscb(struct command *cmd,
 }
 
 static struct command_result *json_restorefrompeer(struct command *cmd,
-				      const char *buf,
-                                      const jsmntok_t *params)
+						   const char *buf,
+						   const jsmntok_t *params)
 {
 	if (!param(cmd, buf, params, NULL))
 		return command_param_failed();
@@ -773,22 +773,23 @@ static const struct plugin_hook hooks[] = {
 	},
 };
 
-static const struct plugin_command commands[] = { {
+static const struct plugin_command commands[] = {
+	{
 		"emergencyrecover",
 		"recovery",
 		"Populates the DB with stub channels",
 		"returns stub channel-id's on completion",
 		json_emergencyrecover,
 	},
-        {
-                "restorefrompeer",
-                "recovery",
-                "Checks if i have got a backup from a peer, and if so, will stub "
+	{
+		"restorefrompeer",
+		"recovery",
+		"Checks if i have got a backup from a peer, and if so, will stub "
 		"those channels in the database and if is successful, will return "
 		"list of channels that have been successfully stubbed",
-                "return channel-id's on completion",
-                json_restorefrompeer,
-        },
+		"return channel-id's on completion",
+		json_restorefrompeer,
+	},
 };
 
 int main(int argc, char *argv[])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2510,8 +2510,11 @@ def test_restorefrompeer(node_factory, bitcoind):
     """
     Test restorefrompeer
     """
-    l1, l2 = node_factory.get_nodes(2, opts=[{'allow_broken_log': True, 'may_reconnect': True},
-                                             {'may_reconnect': True}])
+    l1, l2 = node_factory.get_nodes(2, [{'allow_broken_log': True,
+                                         'experimental-peer-storage': None,
+                                         'may_reconnect': True},
+                                        {'experimental-peer-storage': None,
+                                         'may_reconnect': True}])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 

--- a/wire/extracted_peer_07_peer_storage.patch
+++ b/wire/extracted_peer_07_peer_storage.patch
@@ -1,0 +1,15 @@
+--- wire/peer_wire.csv	2022-07-18 13:49:29.079542016 +0530
++++ -	2022-07-18 13:58:17.706696582 +0530
+@@ -249,6 +249,12 @@
+ msgdata,channel_reestablish,next_revocation_number,u64,
+ msgdata,channel_reestablish,your_last_per_commitment_secret,byte,32
+ msgdata,channel_reestablish,my_current_per_commitment_point,point,
++msgtype,peer_storage,7
++msgdata,peer_storage,len,u16,
++msgdata,peer_storage,blob,byte,len
++msgtype,your_peer_storage,9
++msgdata,your_peer_storage,len,u16,
++msgdata,your_peer_storage,blob,byte,len
+ msgtype,announcement_signatures,259
+ msgdata,announcement_signatures,channel_id,channel_id,
+ msgdata,announcement_signatures,short_channel_id,short_channel_id,

--- a/wire/extracted_peer_exp_upgradable.patch
+++ b/wire/extracted_peer_exp_upgradable.patch
@@ -13,6 +13,6 @@
 +tlvdata,channel_reestablish_tlvs,current_channel_type,type,byte,...
 +tlvtype,channel_reestablish_tlvs,upgradable_channel_type,7
 +tlvdata,channel_reestablish_tlvs,upgradable_channel_type,type,byte,...
- msgtype,announcement_signatures,259
- msgdata,announcement_signatures,channel_id,channel_id,
- msgdata,announcement_signatures,short_channel_id,short_channel_id,
+ msgtype,peer_storage,7
+ msgdata,peer_storage,len,u16,
+ msgdata,peer_storage,blob,byte,len

--- a/wire/peer_wire.c
+++ b/wire/peer_wire.c
@@ -45,6 +45,8 @@ static bool unknown_type(enum peer_wire t)
 	case WIRE_TX_INIT_RBF:
 	case WIRE_TX_ACK_RBF:
 	case WIRE_TX_ABORT:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 	case WIRE_OPEN_CHANNEL2:
 	case WIRE_ACCEPT_CHANNEL2:
 #if EXPERIMENTAL_FEATURES
@@ -101,6 +103,8 @@ bool is_msg_for_gossipd(const u8 *cursor)
 	case WIRE_OPEN_CHANNEL2:
 	case WIRE_ACCEPT_CHANNEL2:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 #if EXPERIMENTAL_FEATURES
 	case WIRE_STFU:
 #endif
@@ -140,6 +144,8 @@ bool extract_channel_id(const u8 *in_pkt, struct channel_id *channel_id)
 	case WIRE_REPLY_CHANNEL_RANGE:
 	case WIRE_GOSSIP_TIMESTAMP_FILTER:
 	case WIRE_ONION_MESSAGE:
+	case WIRE_PEER_STORAGE:
+	case WIRE_YOUR_PEER_STORAGE:
 		return false;
 
 	/* Special cases: */

--- a/wire/peer_wire.c
+++ b/wire/peer_wire.c
@@ -120,6 +120,20 @@ bool is_unknown_msg_discardable(const u8 *cursor)
 	return unknown_type(t) && (t & 1);
 }
 
+/* Returns true if the message type should be handled by CLN's core */
+bool peer_wire_is_internal(enum peer_wire type)
+{
+	/* Unknown messages are not handled by CLN */
+	if (!peer_wire_is_defined(type))
+		return false;
+
+	/* handled by pluigns */
+	if (type == WIRE_PEER_STORAGE || type == WIRE_YOUR_PEER_STORAGE)
+		return false;
+
+	return true;
+}
+
 /* Extract channel_id from various packets, return true if possible. */
 bool extract_channel_id(const u8 *in_pkt, struct channel_id *channel_id)
 {

--- a/wire/peer_wire.csv
+++ b/wire/peer_wire.csv
@@ -262,6 +262,12 @@ msgdata,channel_reestablish,next_commitment_number,u64,
 msgdata,channel_reestablish,next_revocation_number,u64,
 msgdata,channel_reestablish,your_last_per_commitment_secret,byte,32
 msgdata,channel_reestablish,my_current_per_commitment_point,point,
+msgtype,peer_storage,7
+msgdata,peer_storage,len,u16,
+msgdata,peer_storage,blob,byte,len
+msgtype,your_peer_storage,9
+msgdata,your_peer_storage,len,u16,
+msgdata,your_peer_storage,blob,byte,len
 msgtype,announcement_signatures,259
 msgdata,announcement_signatures,channel_id,channel_id,
 msgdata,announcement_signatures,short_channel_id,short_channel_id,

--- a/wire/peer_wire.h
+++ b/wire/peer_wire.h
@@ -23,7 +23,8 @@
 bool is_unknown_msg_discardable(const u8 *cursor);
 /* Return true if it's a message for gossipd. */
 bool is_msg_for_gossipd(const u8 *cursor);
-
+/* Returns true if the message type should be treated as a custommsg */
+bool peer_wire_is_internal(enum peer_wire type);
 /* Extract channel_id from various packets, return true if possible. */
 bool extract_channel_id(const u8 *in_pkt, struct channel_id *channel_id);
 


### PR DESCRIPTION
# PEER STORAGE BACKUP

This PR implements `peer storage backup` which will enable nodes to exchange their respective SCBs (Static channel backup), This will be useful in case of complete data loss.

### WHY

One of the major features of lightning is that the transactions are off-chain and are stored in a local database, which makes this DB highly dynamic and complex to backup.
Peer storage backup will allow users to send their encrypted backup to their peers, which can be used to recover their funds in case of complete data loss.

### HOW

The strategy is that we'll store the data received in the [datastore](https://lightning.readthedocs.io/lightning-datastore.7.html).
So to implement this I've introduced 2 new messages i.e. `PEER_STORAGE` and `YOUR_PEER_STORAGE`, these will be used to exchange the data stored between the nodes. 
-`PEER_STORAGE` will be used to send our own encrypted backup to the peer.
-`YOUR_PEER_STORAGE` will be used to send the most recent backup of the peer.

The general flow of messages every time we `connect` is:

Alice -----------------------  :hearts: ------------------------------ Bob
-------------------------------------------------------------------------------------------------------
PEER_STORAGE :outbox_tray:-------------:incoming_envelope:-------------> :inbox_tray:
YOUR_PEER_STORAGE :outbox_tray:---------:incoming_envelope:------------> :inbox_tray:

:inbox_tray: <------------:incoming_envelope:--------------PEER_STORAGE :outbox_tray:
:inbox_tray: <-----------:incoming_envelope:------------YOUR_PEER_STORAGE :outbox_tray: 

-------------------------------------------------------------------------------------------------------

On receiving `YOUR_PEER_STORAGE` bob will verify if it's correct and Alice has not changed anything in his last sent backup.
On receiving `PEER_STORAGE` bob will update the backup he has stored for Alice in his own datastore.

Every time we open a new channel or close an old one we will send `PEER_STORAGE` to every peer we're connected to (Haven't figured out yet, maybe a new RPC (`sendcustommsgmulti`) which will enable plugins to send a single message to multiple users at once, because the interaction between lightningd and plugins is single-threaded)

They can choose to ignore the messages since they are odd (`It's okay to be odd`)

In case of complete data loss, the user will reconnect to their peers and hope that they get a YOUR_PEER_STORAGE message. Then they can directly use the RPC specified in the plugin to recover the channels.