### PR TITLE
valgrind: ignore plugin built with rust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - CFG: "make"
-            TEST_CMD: "make"
+          - CFG: "make and unit test w/ VALGRIND"
+            TEST_CMD: "make default check-source"
+            VALGRIND: 1
           - CFG: "make-O3-check"
             TEST_CMD: "make check-source check-units installcheck check-gen-updated"
             COPTFLAGS: "-O3"
@@ -28,10 +29,9 @@ jobs:
             ARCH: 32
             TEST_CMD: "make check-source check-units installcheck"
             DEVELOPER: 0
-          - CFG: "make-EXPERIMENTAL-check w/ VALGRIND"
+          - CFG: "make-EXPERIMENTAL-check"
             TEST_CMD: "make check-source check-units installcheck check-gen-updated"
             EXPERIMENTAL_FEATURES: 1
-	    VALGRIND: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -732,7 +732,7 @@ class LightningNode(object):
         if dsn is not None:
             self.daemon.opts['wallet'] = dsn
         if valgrind:
-            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*'
+            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*,*cln-grpc'
             if not valgrind_plugins:
                 trace_skip_pattern += ',*plugins*'
             self.daemon.cmd_prefix = [


### PR DESCRIPTION
Build on top of https://github.com/ElementsProject/lightning/pull/5359

Ok this should fixes the following stack trace


```
2022-06-29T14:19:41.183Z DEBUG   lightningd: Command returned result after jcon close
------------------------------- Valgrind errors --------------------------------
Valgrind error file: valgrind-errors.55581
==55581== Syscall param statx(file_name) points to unaddressable byte(s)
==55581==    at 0x4B0188E: statx (statx.c:29)
==55581==    by 0x1133481: std::sys::unix::fs::try_statx (weak.rs:178)
==55581==    by 0x11265E0: std::fs::buffer_capacity_required (fs.rs:851)
==55581==    by 0x112675B: <std::fs::File as std::io::Read>::read_to_string (fs.rs:644)
==55581==    by 0x10DACA8: num_cpus::linux::Cgroup::param (linux.rs:214)
==55581==    by 0x10DAB39: num_cpus::linux::Cgroup::quota_us (linux.rs:203)
==55581==    by 0x10DA9C2: num_cpus::linux::Cgroup::cpu_quota (linux.rs:188)
==55581==    by 0x10DA5A1: num_cpus::linux::load_cgroups (linux.rs:149)
==55581==    by 0x10DA23D: num_cpus::linux::init_cgroups (linux.rs:129)
==55581==    by 0x10DCDC8: core::ops::function::FnOnce::call_once (function.rs:227)
==55581==    by 0x10DC749: std::sync::once::Once::call_once::{{closure}} (once.rs:276)
==55581==    by 0x21EE89: std::sync::once::Once::call_inner (once.rs:434)
==55581==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==55581== 
==55581== Syscall param statx(buf) points to unaddressable byte(s)
==55581==    at 0x4B0188E: statx (statx.c:29)
==55581==    by 0x1133481: std::sys::unix::fs::try_statx (weak.rs:178)
==55581==    by 0x11265E0: std::fs::buffer_capacity_required (fs.rs:851)
==55581==    by 0x112675B: <std::fs::File as std::io::Read>::read_to_string (fs.rs:644)
==55581==    by 0x10DACA8: num_cpus::linux::Cgroup::param (linux.rs:214)
==55581==    by 0x10DAB39: num_cpus::linux::Cgroup::quota_us (linux.rs:203)
==55581==    by 0x10DA9C2: num_cpus::linux::Cgroup::cpu_quota (linux.rs:188)
==55581==    by 0x10DA5A1: num_cpus::linux::load_cgroups (linux.rs:149)
==55581==    by 0x10DA23D: num_cpus::linux::init_cgroups (linux.rs:129)
==55581==    by 0x10DCDC8: core::ops::function::FnOnce::call_once (function.rs:227)
==55581==    by 0x10DC749: std::sync::once::Once::call_once::{{closure}} (once.rs:276)
==55581==    by 0x21EE89: std::sync::once::Once::call_inner (once.rs:434)
==55581==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==55581==
--------------------------------------------------------------------------------
Leaving base_dir /tmp/ltests-hzt9ppqp intact, it still has test sub-directories with failure details: ['test_peers_1']
```

But today I made a little bit of more research, there is a issue related to rust https://github.com/rust-lang/rust/issues/68979 and it looks like that was a bug in Valgrind that was fixed in some of the new version https://sourceware.org/git/?p=valgrind.git;a=commit;h=2a7d3ae768f9e5b29acd5cb743c3fb13640a391c

Changelog-None