### PR TITLE
github workflow: Correct yaml syntax for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,16 +22,18 @@ jobs:
           - CFG: "make"
             TEST_CMD: "make"
           - CFG: "make-O3-check"
-            TEST_CMD: "make check-source check-units installcheck check-gen-updated"
+            TEST_CMD: "make check-source check-units installcheck
+              check-gen-updated"
             COPTFLAGS: "-O3"
           - CFG: "make-32-bit-nodev-check"
             ARCH: 32
             TEST_CMD: "make check-source check-units installcheck"
             DEVELOPER: 0
           - CFG: "make-EXPERIMENTAL-check w/ VALGRIND"
-            TEST_CMD: "make check-source check-units installcheck check-gen-updated"
+            TEST_CMD: "make check-source check-units installcheck
+              check-gen-updated"
             EXPERIMENTAL_FEATURES: 1
-	    VALGRIND: 1
+            VALGRIND: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0


### PR DESCRIPTION
Github refuses to run CI due to a parsing issue:

"Invalid workflow file: .github/workflows/ci.yaml#L33
You have an error in your yaml syntax on line 33"