### PR TITLE
notify: `channel_state_changed` now receives notice when channel opens

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -101,6 +101,7 @@ wallet_commit_channel(struct lightningd *ld,
 	u64 static_remotekey_start;
 	u32 lease_start_blockheight = 0; /* No leases on v1 */
 	struct short_channel_id *alias_local;
+	struct timeabs timestamp;
 
 	/* We cannot both be the fundee *and* have a `fundchannel_start`
 	 * command running!
@@ -224,6 +225,17 @@ wallet_commit_channel(struct lightningd *ld,
 
 	/* Now we finally put it in the database. */
 	wallet_channel_insert(ld->wallet, channel);
+
+	/* Notify that channel state changed (from non existant to existant) */
+	timestamp = time_now();
+	notify_channel_state_changed(ld, &channel->peer->id,
+				     &channel->cid,
+				     channel->scid, /* NULL */
+				     &timestamp,
+				     0, /* No prior state */
+				     channel->state,
+				     channel->state_change_cause,
+				     "new channel opened");
 
 	return channel;
 }


### PR DESCRIPTION
Previously we wouldn't notify when a channel moves into state
"CHANNELD_AWAITING_LOCKIN", as this is the original state (so there's
no movement btw states). This meant that it's impossible to track when a
channel's commitment txs have been exchanged and we're waiting for
onchain confirmation.

It's useful to have notice of this initialization though, all in one
place so that the `channel_state_changed` notification can successfully
track the entire lifecycle of a channel, from inception to close.

Note that for v2 "dual-funded" channels, we already notify at the same place, at
"DUALOPEND_AWAITING_LOCKIN" (the initial state for a dualopend channel
is "DUALOPEND_OPEN_INIT" -- this is the only state we don't get notified
at now...)

Changelog-Added: Plugins: `channel_state_changed` now triggers for a v1 channel's initial "CHANNELD_AWAITING_LOCKIN" state transition (from prior state "unknown")