### PR TITLE
lightningd: fire watches on blocks before telling lightningd.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -619,11 +619,11 @@ void topology_add_sync_waiter_(const tal_t *ctx,
 static void updates_complete(struct chain_topology *topo)
 {
 	if (!bitcoin_blkid_eq(&topo->tip->blkid, &topo->prev_tip)) {
-		/* Tell lightningd about new block. */
-		notify_new_block(topo->bitcoind->ld, topo->tip->height);
-
 		/* Tell watch code to re-evaluate all txs. */
 		watch_topology_changed(topo);
+
+		/* Tell lightningd about new block. */
+		notify_new_block(topo->bitcoind->ld, topo->tip->height);
 
 		/* Maybe need to rebroadcast. */
 		rebroadcast_txs(topo, NULL);


### PR DESCRIPTION
We noticed bogus behavior where (with 200 blocks added at once)
lightningd didn't see a DF channel open: this is because we told
lightningd about the new blocks (and it timed out channel) before
the watches for the transaction are fired.