### PR TITLE
doc: Fix generated `listconfigs` man-page

### DIFF
--- a/doc/lightning-listconfigs.7
+++ b/doc/lightning-listconfigs.7
@@ -30,6 +30,7 @@ showing default values (\fBdev-\fR options are not shown)\.
 
 On success, an object is returned, containing:
 
+
 .RS
 .IP \[bu]
 \fB# version\fR (string, optional): Special field indicating the current version
@@ -169,6 +170,7 @@ On success, an object is returned, containing:
 .RE
 
 On failure, one of the following error codes may be returned:
+
 
 .RS
 .IP \[bu]


### PR DESCRIPTION
This seems to have been missed by a recent PR.

Changelog-None