### PR TITLE
common: add missing .c file to src list

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -91,7 +91,7 @@ COMMON_SRC_NOGEN :=				\
 	common/wire_error.c
 
 
-COMMON_SRC_GEN := common/status_wiregen.c common/peer_status_wiregen.c
+COMMON_SRC_GEN := common/status_wiregen.c common/peer_status_wiregen.c common/scb_wiregen.c
 
 COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h)	\
 	common/closing_fee.h				\


### PR DESCRIPTION
`make check-common-files` fails on master; it's missing the common/scb_wiregen.c file in `common/Makefile`


Changelog-None.