### PR TITLE
lightningd: fix close of ancient all-dust channel.

### DIFF
--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -55,12 +55,13 @@ static void
 resolve_one_close_command(struct close_command *cc, bool cooperative)
 {
 	struct json_stream *result = json_stream_success(cc->cmd);
-	struct bitcoin_txid txid;
-
-	bitcoin_txid(cc->channel->last_tx, &txid);
 
 	json_add_tx(result, "tx", cc->channel->last_tx);
-	json_add_txid(result, "txid", &txid);
+	if (!invalid_last_tx(cc->channel->last_tx)) {
+		struct bitcoin_txid txid;
+		bitcoin_txid(cc->channel->last_tx, &txid);
+		json_add_txid(result, "txid", &txid);
+	}
 	if (cooperative)
 		json_add_string(result, "type", "mutual");
 	else

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -220,7 +220,7 @@ static void remove_sig(struct bitcoin_tx *signed_tx)
 	bitcoin_tx_input_set_witness(signed_tx, 0, NULL);
 }
 
-static bool invalid_last_tx(const struct bitcoin_tx *tx)
+bool invalid_last_tx(const struct bitcoin_tx *tx)
 {
 	/* This problem goes back further, but was discovered just before the
 	 * 0.7.1 release. */

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -121,4 +121,7 @@ command_find_channel(struct command *cmd,
 		     const char *buffer, const jsmntok_t *tok,
 		     struct channel **channel);
 
+/* Ancient (0.7.0 and before) releases could create invalid commitment txs! */
+bool invalid_last_tx(const struct bitcoin_tx *tx);
+
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */


### PR DESCRIPTION
libwally asserts() when trying to calculate the txid: we report it as
invalid elsewhere, but then crash:

```
May 19 20:37:03 c-lightning lightningd[26236]: 2022-05-19T20:37:03.689Z DEBUG   lightningd: close_command: timeout = 1
May 19 20:37:04 c-lightning lightningd[26236]: 2022-05-19T20:37:04.689Z UNUSUAL 037f32400c108f8385db94371bfcef08948bc0042069c1ef6f39086cdf23420ee5-chan#91: Peer permanent failure in CHANNELD_SHUTTING_DOWN: Forcibly closed by `close` command timeout
May 19 20:37:04 c-lightning lightningd[26236]: 2022-05-19T20:37:04.689Z **BROKEN** 037f32400c108f8385db94371bfcef08948bc0042069c1ef6f39086cdf23420ee5-chan#91: Cannot broadcast our commitment tx: it's invalid! (ancient channel?)
May 19 20:37:04 c-lightning lightningd[26236]: lightningd: bitcoin/tx.c:485: wally_txid: Assertion `len == written' failed.
May 19 20:37:04 c-lightning lightningd[26236]: lightningd: FATAL SIGNAL 6 (version v0.11.1)
May 19 20:37:04 c-lightning lightningd[26236]: 0x45bd01 send_backtrace
May 19 20:37:04 c-lightning lightningd[26236]:         common/daemon.c:33
May 19 20:37:04 c-lightning lightningd[26236]: 0x45bd8b crashdump
May 19 20:37:04 c-lightning lightningd[26236]:         common/daemon.c:46
May 19 20:37:04 c-lightning lightningd[26236]: 0x7f9f877604bf ???
May 19 20:37:04 c-lightning lightningd[26236]:         ???:0
May 19 20:37:04 c-lightning lightningd[26236]: 0x7f9f87760438 ???
May 19 20:37:04 c-lightning lightningd[26236]:         ???:0
May 19 20:37:04 c-lightning lightningd[26236]: 0x7f9f87762039 ???
May 19 20:37:04 c-lightning lightningd[26236]:         ???:0
May 19 20:37:04 c-lightning lightningd[26236]: 0x7f9f87758be6 ???
May 19 20:37:04 c-lightning lightningd[26236]:         ???:0
May 19 20:37:04 c-lightning lightningd[26236]: 0x7f9f87758c91 ???
May 19 20:37:04 c-lightning lightningd[26236]:         ???:0
May 19 20:37:04 c-lightning lightningd[26236]: 0x4751b7 wally_txid
May 19 20:37:04 c-lightning lightningd[26236]:         bitcoin/tx.c:485
May 19 20:37:04 c-lightning lightningd[26236]: 0x4751f4 bitcoin_txid
May 19 20:37:04 c-lightning lightningd[26236]:         bitcoin/tx.c:496
May 19 20:37:04 c-lightning lightningd[26236]: 0x40bad0 resolve_one_close_command
May 19 20:37:04 c-lightning lightningd[26236]:         lightningd/closing_control.c:60
May 19 20:37:04 c-lightning lightningd[26236]: 0x40cef3 resolve_close_command
May 19 20:37:04 c-lightning lightningd[26236]:         lightningd/closing_control.c:82
May 19 20:37:04 c-lightning lightningd[26236]: 0x430355 drop_to_chain
May 19 20:37:04 c-lightning lightningd[26236]:         lightningd/peer_control.c:286
```

Fixes: #5277
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>