### PR TITLE
Allow old "msatoshi" as well as "amount_msat" in sendpay route

### DIFF
--- a/common/param.h
+++ b/common/param.h
@@ -70,6 +70,7 @@ const char *param_subcommand(struct command *cmd, const char *buffer,
 
 enum param_style {
 	PARAM_REQUIRED,
+	PARAM_REQUIRED_ALLOW_DUPS,
 	PARAM_OPTIONAL,
 	PARAM_OPTIONAL_WITH_DEFAULT,
 };
@@ -95,6 +96,20 @@ enum param_style {
 #define p_opt(name, cbx, arg)                                   \
 	      name"",                                           \
 	      PARAM_OPTIONAL,                                   \
+	      (param_cbx)(cbx),                                 \
+	      ({ *arg = NULL;                                   \
+		 (arg) + 0*sizeof((cbx)((struct command *)NULL, \
+		                  (const char *)NULL,           \
+				  (const char *)NULL,           \
+				  (const jsmntok_t *)NULL,      \
+				  (arg)) == (struct command_result *)NULL); })
+
+/*
+ * Add an required parameter, like p_req, but ignore duplicates.
+ */
+#define p_req_dup_ok(name, cbx, arg)                            \
+	      name"",                                           \
+	      PARAM_REQUIRED_ALLOW_DUPS,                        \
 	      (param_cbx)(cbx),                                 \
 	      ({ *arg = NULL;                                   \
 		 (arg) + 0*sizeof((cbx)((struct command *)NULL, \

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1375,7 +1375,8 @@ static struct command_result *param_route_hops(struct command *cmd,
 		int *ignored;
 
 		if (!param(cmd, buffer, t,
-			   p_req("amount_msat|msatoshi", param_msat, &amount_msat),
+			   /* deprecated: getroute gives both, so we allow both! */
+			   p_req_dup_ok("amount_msat|msatoshi", param_msat, &amount_msat),
 			   p_req("id", param_node_id, &id),
 			   p_req("delay", param_number, &delay),
 			   p_req("channel", param_short_channel_id, &channel),

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5313,3 +5313,24 @@ def test_pay_middle_fail(node_factory, bitcoind, executor):
     # And that will fail upstream
     with pytest.raises(RpcError, match=r'WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS'):
         l1.rpc.waitsendpay('00' * 32)
+
+
+@pytest.mark.xfail(strict=True)
+def test_sendpay_dual_amounts(node_factory):
+    """Test that handing *both* msatoshi and amount_msat to sendpay works"""
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
+
+    route = [{'amount_msat': 1011,
+              'msatoshi': 1011,
+              'id': '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59',
+              'delay': 20,
+              'channel': '1x1x1'},
+             {'amount_msat': 1000,
+              'msatoshi': 1000,
+              'id': '035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d',
+              'delay': 10,
+              'channel': '2x2x2'}]
+    l1.rpc.check("sendpay", route=route, payment_hash="00" * 32)
+
+    with pytest.raises(RpcError, match=r'No connection to first peer found'):
+        l1.rpc.sendpay(route=route, payment_hash="00" * 32)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5315,7 +5315,6 @@ def test_pay_middle_fail(node_factory, bitcoind, executor):
         l1.rpc.waitsendpay('00' * 32)
 
 
-@pytest.mark.xfail(strict=True)
 def test_sendpay_dual_amounts(node_factory):
     """Test that handing *both* msatoshi and amount_msat to sendpay works"""
     l1 = node_factory.get_node(options={'allow-deprecated-apis': True})


### PR DESCRIPTION
Changelog-None: regression during this release cycle