### PR TITLE
pytest: fix test_gossip_no_empty_announcements flake.

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -622,10 +622,10 @@ def test_gossip_no_empty_announcements(node_factory, bitcoind, chainparams):
     # l2 sends CHANNEL_ANNOUNCEMENT to l1, then disconnects/
     l2.daemon.wait_for_log('dev_disconnect')
     l1.daemon.wait_for_log(r'\[IN\] 0100')
+    wait_for(lambda: l1.rpc.listchannels()['channels'] == [])
 
     # l1 won't relay it (make sure it has time to digest though)
     time.sleep(2)
-    assert l1.rpc.listchannels()['channels'] == []
     encoded = subprocess.run(['devtools/mkencoded', '--scids', '00'],
                              check=True,
                              timeout=TIMEOUT,

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1766,7 +1766,7 @@ def test_gossip_announce_unknown_block(node_factory, bitcoind):
     sync_blockheight(bitcoind, [l1])
 
 
-@unittest.skipIf(DEVELOPER, "Developer gossip too fast!")
+@pytest.mark.developer("gossip without DEVELOPER=1 is slow")
 def test_gossip_no_backtalk(node_factory):
     # l3 connects, gets gossip, but should *not* play it back.
     l1, l2, l3 = node_factory.get_nodes(3,
@@ -1779,8 +1779,8 @@ def test_gossip_no_backtalk(node_factory):
                              r'\[IN\] 0102', r'\[IN\] 0102',
                              r'\[IN\] 0101', r'\[IN\] 0101'])
 
-    # Will flush every 60 seconds, so definitely should by this time!
-    time.sleep(90)
+    # With DEVELOPER, this is long enough for gossip flush.
+    time.sleep(2)
     assert not l3.daemon.is_in_log(r'\[OUT\] 0100')
 
 


### PR DESCRIPTION
his is a side-effect of fixing aging: sometimes, we age our rcvd_filter cache too fast, and thus re-xmit.  This breaks our test, since it used dev-disconnect on the channel_announce, but that closes to l3, not l1!
    
```
    >       assert l1.rpc.listchannels()['channels'] == []
    E       AssertionError: assert [{'active': T...ags': 1, ...}] == []
    E         Left contains 2 more items, first extra item: {'active': True, 'amount_msat': 100000000msat, 'base_fee_millisatoshi': 1, 'channel_flags': 0, ...}
```

Fix this flushing properly, remove previous workaround in another test.    

Fixes: #5403
