### PR TITLE
gossipd: fix of gossip v10 channel removal handling

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -501,6 +501,8 @@ static void remove_chan_from_node(struct routing_state *rstate,
 		gossip_store_delete(rstate->gs,
 				    &node->bcast,
 				    WIRE_NODE_ANNOUNCEMENT);
+		node->rgraph.index = node->bcast.index = 0;
+		node->rgraph.timestamp = node->bcast.timestamp = 0;
 	} else if (node_announce_predates_channels(node)) {
 		/* node announcement predates all channel announcements?
 		 * Move to end (we could, in theory, move to just past next
@@ -1377,7 +1379,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 			} else if (hc->bcast.index != hc->rgraph.index){
 				status_broken("gossip_store rate-limited "
 					      "channel_update %u replaces %u!",
-					      index, hc->bcast.index);
+					      index, hc->rgraph.index);
 				return false;
 			}
 		}
@@ -1730,7 +1732,7 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 			} else if (node->bcast.index != node->rgraph.index){
 				status_broken("gossip_store rate-limited "
 					      "node_announcement %u replaces %u!",
-					      index, node->bcast.index);
+					      index, node->rgraph.index);
 				return false;
 			}
 		}


### PR DESCRIPTION
Node announcement indices reinitialized after deleting the referenced announcement.  Debugging output also corrected.

Fixes this crash in CI:
FAILED tests/test_closing.py::test_closing_specified_destination - Connection...
DEBUG   gossipd: Deleting channel 107x1x0 due to the funding outpoint being spent
**BROKEN** gossipd: gossip_store: get delete entry offset 4291/5445 (version ddf8fbd-modded)
**BROKEN** gossipd: backtrace: common/daemon.c:38 (send_backtrace) 0x56405b5da570
**BROKEN** gossipd: backtrace: common/status.c:221 (status_failed) 0x56405b5e5f9d
**BROKEN** gossipd: backtrace: gossipd/gossip_store.c:703 (gossip_store_get) 0x56405b5c857c
**BROKEN** gossipd: backtrace: gossipd/gossip_store.c:635 (delete_by_index) 0x56405b5c8285
**BROKEN** gossipd: backtrace: gossipd/gossip_store.c:665 (gossip_store_delete) 0x56405b5c8417
**BROKEN** gossipd: backtrace: gossipd/routing.c:482 (remove_chan_from_node) 0x56405b5cf850
**BROKEN** gossipd: backtrace: gossipd/routing.c:523 (free_chans_from_node) 0x56405b5cf991
**BROKEN** gossipd: backtrace: gossipd/routing.c:535 (free_chan) 0x56405b5cf9e2
**BROKEN** gossipd: backtrace: gossipd/gossipd.c:953 (handle_outpoint_spent) 0x56405b5c624c
**BROKEN** gossipd: backtrace: gossipd/gossipd.c:1006 (recv_req) 0x56405b5c6403
**BROKEN** gossipd: backtrace: common/daemon_conn.c:31 (handle_read) 0x56405b5daaa7
**BROKEN** gossipd: backtrace: ccan/ccan/io/io.c:59 (next_plan) 0x56405b61ffe8
**BROKEN** gossipd: backtrace: ccan/ccan/io/io.c:407 (do_plan) 0x56405b620bf0
**BROKEN** gossipd: backtrace: ccan/ccan/io/io.c:417 (io_ready) 0x56405b620c32
**BROKEN** gossipd: backtrace: ccan/ccan/io/poll.c:453 (io_loop) 0x56405b622f25
**BROKEN** gossipd: backtrace: gossipd/gossipd.c:1130 (main) 0x56405b5c6743
**BROKEN** gossipd: backtrace: ../csu/libc-start.c:308 (__libc_start_main) 0x7f1dd971f082
**BROKEN** gossipd: backtrace: (null):0 ((null)) 0x56405b5bff4d
**BROKEN** gossipd: backtrace: (null):0 ((null)) 0xffffffffffffffff
**BROKEN** gossipd: STATUS_FAIL_INTERNAL_ERROR: gossip_store: get delete entry offset 4291/5445

Changelog-None