### PR TITLE
plugin: autoclean fix crash + pyln-testing: print stderr from errlog

### DIFF
--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -47,12 +47,14 @@ static struct command_result *json_autocleaninvoice(struct command *cmd,
 	cycle_seconds = *cycle;
 	expired_by = *exby;
 
+	cleantimer = tal_free(cleantimer);
+
 	if (cycle_seconds == 0) {
 		response = jsonrpc_stream_success(cmd);
 		json_add_bool(response, "enabled", false);
 		return command_finished(cmd, response);
 	}
-	tal_free(cleantimer);
+
 	cleantimer = plugin_timer(cmd->plugin, time_from_sec(cycle_seconds),
 				  do_clean, cmd->plugin);
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -559,7 +559,6 @@ def test_waitanyinvoice_reversed(node_factory, executor):
     assert r['label'] == 'inv1'
 
 
-@pytest.mark.xfail(strict=True)
 def test_autocleaninvoice(node_factory):
     l1 = node_factory.get_node()
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -559,6 +559,7 @@ def test_waitanyinvoice_reversed(node_factory, executor):
     assert r['label'] == 'inv1'
 
 
+@pytest.mark.xfail(strict=True)
 def test_autocleaninvoice(node_factory):
     l1 = node_factory.get_node()
 
@@ -598,6 +599,13 @@ def test_autocleaninvoice(node_factory):
     # Everything deleted
     assert len(l1.rpc.listinvoices('inv1')['invoices']) == 0
     assert len(l1.rpc.listinvoices('inv2')['invoices']) == 0
+
+    # stress test
+    l1.rpc.autocleaninvoice(cycle_seconds=0)
+    l1.rpc.autocleaninvoice(cycle_seconds=1)
+    l1.rpc.autocleaninvoice(cycle_seconds=0)
+    time.sleep(1)
+    l1.rpc.autocleaninvoice(cycle_seconds=1, expired_by=1)
 
 
 def test_decode_unknown(node_factory):


### PR DESCRIPTION
Plugin `autoclean` crashes with below backtrace after disable and re-enable.
Strangely I mostly reproduces with the sequence disable-enable-disable-sleep-enable, see added test.

Also modifies `pyln-testing` to add stderr `errlog` (with backtrace etc.) to CI report after unexpected test failure.
 
I have the fix, but I am just curious if below backtrace shows up in the test results.
```
autoclean: FATAL SIGNAL 6 (version v0.11.0.1-240-gbd239d2)
0x55a26e53adf4 send_backtrace
        common/daemon.c:33
0x55a26e53ae9a crashdump
        common/daemon.c:46
0x7fed8b8d783f ???
        /build/glibc-fWwxX8/glibc-2.28/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
0x7fed8b8d77bb __GI_raise
        ../sysdeps/unix/sysv/linux/raise.c:51
0x7fed8b8c2534 __GI_abort
        /build/glibc-fWwxX8/glibc-2.28/stdlib/abort.c:79
0x55a26e57a98c call_error
        ccan/ccan/tal/tal.c:93
0x55a26e57ab54 check_bounds
        ccan/ccan/tal/tal.c:165
0x55a26e57abb2 to_tal_hdr
        ccan/ccan/tal/tal.c:176
0x55a26e57b53c tal_free
        ccan/ccan/tal/tal.c:479
0x55a26e5213b8 json_autocleaninvoice
        plugins/autoclean.c:55
0x55a26e5255d2 ld_command_handle
        plugins/libplugin.c:1307
0x55a26e525723 ld_read_json_one
        plugins/libplugin.c:1348
0x55a26e525855 ld_read_json
        plugins/libplugin.c:1368
0x55a26e5695d6 next_plan
        ccan/ccan/io/io.c:59
0x55a26e56a176 do_plan
        ccan/ccan/io/io.c:407
0x55a26e56a1b4 io_ready
        ccan/ccan/io/io.c:417
0x55a26e56c3d1 io_loop
        ccan/ccan/io/poll.c:453
0x55a26e5262e9 plugin_main
        plugins/libplugin.c:1565
0x55a26e5215de main
        plugins/autoclean.c:92
0x7fed8b8c409a __libc_start_main
        ../csu/libc-start.c:308
0x55a26e520de9 ???
        ???:0
0xffffffffffffffff ???
        ???:0
autoclean: FATAL SIGNAL 11 (version v0.11.0.1-240-gbd239d2)
0x55a26e53adf4 send_backtrace
        common/daemon.c:33
0x55a26e53ae9a crashdump
        common/daemon.c:46
0x7fed8b8d783f ???
        /build/glibc-fWwxX8/glibc-2.28/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
0x0 ???
        ???:0

```