### PR TITLE
Fix awaiting unilateral rexmit

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1153,6 +1153,12 @@ int main(int argc, char *argv[])
 			 "/dev/fd (if running in chroot) if you are "
 			 "approaching that many channels.");
 
+	/*~ If we have channels closing, make sure we re-xmit the last
+	 * transaction, in case bitcoind lost it. */
+	db_begin_transaction(ld->wallet->db);
+	resend_closing_transactions(ld);
+	db_commit_transaction(ld->wallet->db);
+
 	/*~ This is where we ask connectd to reconnect to any peers who have
 	 * live channels with us, and makes sure we're watching the funding
 	 * tx. */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -287,6 +287,21 @@ void drop_to_chain(struct lightningd *ld, struct channel *channel,
 	resolve_close_command(ld, channel, cooperative);
 }
 
+void resend_closing_transactions(struct lightningd *ld)
+{
+	struct peer *peer;
+	struct channel *channel;
+
+	list_for_each(&ld->peers, peer, list) {
+		list_for_each(&peer->channels, channel, list) {
+			if (channel->state == CLOSINGD_COMPLETE)
+				drop_to_chain(ld, channel, true);
+			else if (channel->state == AWAITING_UNILATERAL)
+				drop_to_chain(ld, channel, false);
+		}
+	}
+}
+
 void channel_errmsg(struct channel *channel,
 		    struct peer_fd *peer_fd,
 		    const struct channel_id *channel_id UNUSED,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -89,6 +89,9 @@ u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx);
 /* We've loaded peers from database, set them going. */
 void setup_peers(struct lightningd *ld);
 
+/* At startup, re-send any transactions we want bitcoind to have */
+void resend_closing_transactions(struct lightningd *ld);
+
 void drop_to_chain(struct lightningd *ld, struct channel *channel, bool cooperative);
 
 void channel_watch_funding(struct lightningd *ld, struct channel *channel);

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -185,6 +185,9 @@ struct plugins *plugins_new(const tal_t *ctx UNNEEDED, struct log_book *log_book
 void plugins_set_builtin_plugins_dir(struct plugins *plugins UNNEEDED,
 				     const char *dir UNNEEDED)
 { fprintf(stderr, "plugins_set_builtin_plugins_dir called!\n"); abort(); }
+/* Generated stub for resend_closing_transactions */
+void resend_closing_transactions(struct lightningd *ld UNNEEDED)
+{ fprintf(stderr, "resend_closing_transactions called!\n"); abort(); }
 /* Generated stub for setup_color_and_alias */
 void setup_color_and_alias(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "setup_color_and_alias called!\n"); abort(); }

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3697,7 +3697,6 @@ We send an HTLC, and peer unilaterally closes: do we close upstream?
         l1.rpc.waitsendpay(ph1, timeout=TIMEOUT)
 
 
-@pytest.mark.xfail(strict=True)
 def test_onchain_rexmit_tx(node_factory, bitcoind):
     """Make sure we re-xmit last tx if we restart and channel is AWAITING_UNILATERAL"""
     l1, l2 = node_factory.line_graph(2)


### PR DESCRIPTION
In diagnosing a users' issue, I noted we didn't try to rexmit transactions on startup.  Bitcoind is usually really good at keeping transactions around, but we should not count on it.