### PR TITLE
flake htlc_tx timeout

### DIFF
--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1727,12 +1727,12 @@ static void output_spent(struct tracked_output ***outs,
 			break;
 
 		case THEIR_HTLC:
-			record_external_deposit(out, out->tx_blockheight,
-						HTLC_TIMEOUT);
-			record_external_spend(&tx_parts->txid, out,
-					      tx_blockheight, HTLC_TIMEOUT);
-
 			if (out->tx_type == THEIR_REVOKED_UNILATERAL) {
+				record_external_deposit(out, out->tx_blockheight,
+							HTLC_TIMEOUT);
+				record_external_spend(&tx_parts->txid, out,
+						      tx_blockheight, HTLC_TIMEOUT);
+
 				/* we've actually got a 'new' output here */
 				steal_htlc_tx(out, outs, tx_parts,
 					      tx_blockheight,

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -2520,7 +2520,6 @@ def test_onchain_feechange(node_factory, bitcoind, executor):
     assert only_one(l2.rpc.listinvoices('onchain_timeout')['invoices'])['status'] == 'unpaid'
 
 
-@pytest.mark.skip("Lisa, please fix this!")
 @pytest.mark.developer("needs DEVELOPER=1 for dev-set-fees")
 def test_onchain_all_dust(node_factory, bitcoind, executor):
     """Onchain handling when we reduce output to all dust"""

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -2557,7 +2557,7 @@ def test_onchain_all_dust(node_factory, bitcoind, executor):
     l2.wait_for_channel_onchain(l1.info['id'])
 
     # Make l1's fees really high (and wait for it to exceed 50000)
-    l1.set_feerates((100000, 100000, 100000, 100000))
+    l1.set_feerates((1000000, 1000000, 1000000, 1000000))
     l1.daemon.wait_for_log('Feerate estimate for unilateral_close set to [56789][0-9]{4}')
 
     bitcoind.generate_block(1)


### PR DESCRIPTION
Fix flake fail from race on coin-movement reporting for htlc_timeout transactions (external)