### PR TITLE
lightningd: reduce log level for remote address reporting.

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1202,8 +1202,8 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 
 	/* Log and update remote_addr for Nat/IP discovery. */
 	if (hook_payload->remote_addr) {
-		log_peer_info(ld->log, &id, "Peer says it sees our address as: %s",
-			      fmt_wireaddr(tmpctx, hook_payload->remote_addr));
+		log_peer_debug(ld->log, &id, "Peer says it sees our address as: %s",
+			       fmt_wireaddr(tmpctx, hook_payload->remote_addr));
 		peer->remote_addr = tal_dup(peer, struct wireaddr,
 					    hook_payload->remote_addr);
 		/* Currently only from peers we have a channel with, until we


### PR DESCRIPTION
It's available in listpeers() if you want to see it, otherwise it's not
really something users want to see in the normal course of operation.

Changelog-None