### PR TITLE
Check if funds are getting recovered on reconnect…

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2312,7 +2312,9 @@ def test_emergencyrecover(node_factory, bitcoind):
     """
     Test emergencyrecover
     """
-    l1, l2 = node_factory.get_nodes(2, opts=[{}, {}])
+    l1, l2 = node_factory.get_nodes(2, opts=[{'allow_broken_log': True, 'may_reconnect': True},
+                                             {'may_reconnect': True}])
+
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     c12, _ = l1.fundchannel(l2, 10**5)
     stubs = l1.rpc.emergencyrecover()["stubs"]
@@ -2331,6 +2333,18 @@ def test_emergencyrecover(node_factory, bitcoind):
 
     listfunds = l1.rpc.listfunds()["channels"][0]
     assert listfunds["short_channel_id"] == "1x1x1"
+
+    l1.daemon.wait_for_log('peer_out WIRE_ERROR')
+    l2.daemon.wait_for_log('State changed from CHANNELD_NORMAL to AWAITING_UNILATERAL')
+
+    l2.bitcoin.generate_block(5)
+    sync_blockheight(bitcoind, [l1, l2])
+
+    l1.daemon.wait_for_log(r'All outputs resolved.*')
+    wait_for(lambda: l1.rpc.listfunds()["channels"][0]["state"] == "ONCHAIN")
+    # Check if funds are recovered.
+    assert l1.rpc.listfunds()["channels"][0]["state"] == "ONCHAIN"
+    assert l2.rpc.listfunds()["channels"][0]["state"] == "ONCHAIN"
 
 
 def test_commitfee_option(node_factory):


### PR DESCRIPTION
Increasing the scope of `test_emergencyrecover` to check if it recovers the funds successfully...