### PR TITLE
hsmtool: implement checkhsm.

### DIFF
--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -51,6 +51,9 @@ Specify *password* if the `hsm_secret` is encrypted.
 **generatehsm** *hsm\_secret\_path*
 Generates a new hsm_secret using BIP39.
 
+**checkhsm** *hsm\_secret\_path*
+Checks that hsm_secret matchs a BIP39 pass phrase.
+
  **dumponchaindescriptors** *hsm_secret* \[*password*\] \[*network*\]
 Dump output descriptors for our onchain wallet.
 The descriptors can be used by external services to be able to generate

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1218,7 +1218,6 @@ def test_hsmtool_dump_descriptors(node_factory, bitcoind):
     assert len(bitcoind.rpc.listunspent(1, 1, [addr])) == 1
 
 
-@unittest.skipIf(VALGRIND, "It does not play well with prompt and key derivation.")
 def test_hsmtool_generatehsm(node_factory):
     l1 = node_factory.get_node()
     l1.stop()
@@ -1243,8 +1242,47 @@ def test_hsmtool_generatehsm(node_factory):
               "cake have wedding\n".encode("utf-8"))
     hsmtool.wait_for_log(r"Enter your passphrase:")
     write_all(master_fd, "This is actually not a passphrase\n".encode("utf-8"))
-    hsmtool.proc.wait(WAIT_TIMEOUT)
+    assert hsmtool.proc.wait(WAIT_TIMEOUT) == 0
     hsmtool.is_in_log(r"New hsm_secret file created")
+
+    # Check should pass.
+    hsmtool = HsmTool(node_factory.directory, "checkhsm", hsm_path)
+    master_fd, slave_fd = os.openpty()
+    hsmtool.start(stdin=slave_fd)
+    hsmtool.wait_for_log(r"Enter your passphrase:")
+    write_all(master_fd, "This is actually not a passphrase\n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Select your language:")
+    write_all(master_fd, "0\n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Introduce your BIP39 word list")
+    write_all(master_fd, "ritual idle hat sunny universe pluck key alpha wing "
+              "cake have wedding\n".encode("utf-8"))
+    assert hsmtool.proc.wait(WAIT_TIMEOUT) == 0
+    hsmtool.is_in_log(r"OK")
+
+    # Wrong mnemonic will fail.
+    master_fd, slave_fd = os.openpty()
+    hsmtool.start(stdin=slave_fd)
+    hsmtool.wait_for_log(r"Enter your passphrase:")
+    write_all(master_fd, "This is actually not a passphrase\n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Select your language:")
+    write_all(master_fd, "0\n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Introduce your BIP39 word list")
+    write_all(master_fd, "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n".encode("utf-8"))
+    assert hsmtool.proc.wait(WAIT_TIMEOUT) == 5
+    hsmtool.is_in_log(r"resulting hsm_secret did not match")
+
+    # Wrong passphrase will fail.
+    master_fd, slave_fd = os.openpty()
+    hsmtool.start(stdin=slave_fd)
+    hsmtool.wait_for_log(r"Enter your passphrase:")
+    write_all(master_fd, "This is actually not a passphrase \n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Select your language:")
+    write_all(master_fd, "0\n".encode("utf-8"))
+    hsmtool.wait_for_log(r"Introduce your BIP39 word list")
+    write_all(master_fd, "ritual idle hat sunny universe pluck key alpha wing "
+              "cake have wedding\n".encode("utf-8"))
+    assert hsmtool.proc.wait(WAIT_TIMEOUT) == 5
+    hsmtool.is_in_log(r"resulting hsm_secret did not match")
 
     # We can start the node with this hsm_secret
     l1.start()


### PR DESCRIPTION
This gives a nice way to ensure your secret is the correct one.

Also, we don't need to suppress VALGRIND for this test, now the output
races are fixed.

Changelog-Added: `hsmtool`: new command `checkhsm` to check BIP39 passphrase against hsm_secret.
