### PR TITLE
libplugin: don't call callbacks if cmd completed before response, and fix another commando crash

### DIFF
--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -452,8 +452,11 @@ static void handle_incmd(struct node_id *peer,
 
 	incmd = find_commando(incoming_commands, peer, NULL);
 	/* Don't let them buffer multiple commands: discard old. */
-	if (incmd && incmd->id != idnum)
+	if (incmd && incmd->id != idnum) {
+		plugin_log(plugin, LOG_DBG, "New cmd from %s, replacing old",
+			   node_id_to_hexstr(tmpctx, peer));
 		incmd = tal_free(incmd);
+	}
 
 	if (!incmd) {
 		incmd = tal(plugin, struct commando);
@@ -705,6 +708,7 @@ static struct command_result *json_commando(struct command *cmd,
 	tal_free(peer);
 	tal_free(method);
 	tal_free(cparams);
+	tal_free(rune);
 
 	return send_more_cmd(cmd, NULL, NULL, outgoing);
 }

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -344,10 +344,11 @@ static const char *check_rune(const tal_t *ctx,
 	cinfo.params = params;
 	cinfo.usage = NULL;
 	strmap_init(&cinfo.cached_params);
-	err = rune_test(ctx, master_rune, rune, check_condition, &cinfo);
+	err = rune_test(tmpctx, master_rune, rune, check_condition, &cinfo);
 	/* Just in case they manage to make us speak non-JSON, escape! */
 	if (err)
-		err = json_escape(ctx, take(err))->s;
+		err = json_escape(ctx, err)->s;
+
 	strmap_clear(&cinfo.cached_params);
 
 	/* If it succeeded, *now* we increment any associated usage counter. */

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -463,6 +463,10 @@ static void handle_incmd(struct node_id *peer,
 		incmd->contents = tal_arr(incmd, u8, 0);
 		tal_arr_expand(&incoming_commands, incmd);
 		tal_add_destructor2(incmd, destroy_commando, &incoming_commands);
+
+		/* More than 16 partial commands at once?  Free oldest */
+		if (tal_count(incoming_commands) > 16)
+			tal_free(incoming_commands[0]);
 	}
 
 	/* 1MB should be enough for anybody! */

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -425,7 +425,7 @@ def test_db_sanity_checks(bitcoind, node_factory):
 
     # Provide the --wallet option and start with wrong db
     l1.daemon.opts['wallet'] = "sqlite3://" + l2.db.path
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_log(r'\*\*BROKEN\*\* wallet: Wallet node_id does not match HSM')
     # Will have exited with non-zero status.
     assert l1.daemon.proc.wait(TIMEOUT) != 0
@@ -435,7 +435,7 @@ def test_db_sanity_checks(bitcoind, node_factory):
     l1.daemon.opts['wallet'] = "sqlite3://" + l1.db.path
     l1.daemon.opts['network'] = "bitcoin"
 
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_log(r'\*\*BROKEN\*\* wallet: Wallet blockchain hash does not match network blockchain hash')
     # Will have exited with non-zero status.
     assert l1.daemon.proc.wait(TIMEOUT) != 0

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -241,8 +241,9 @@ def test_announce_and_connect_via_dns(node_factory, bitcoind):
 @unittest.skipIf(not EXPERIMENTAL_FEATURES, "BOLT7 DNS RFC #911")
 def test_only_announce_one_dns(node_factory, bitcoind):
     # and test that we can't announce more than one DNS address
-    l1 = node_factory.get_node(may_fail=True, expect_fail=True,
+    l1 = node_factory.get_node(expect_fail=True, start=False,
                                options={'announce-addr': ['localhost.localdomain:12345', 'example.com:12345']})
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     wait_for(lambda: l1.daemon.is_in_stderr("Only one DNS can be announced"))
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -109,7 +109,7 @@ def test_bitcoin_failure(node_factory, bitcoind):
     # Ignore BROKEN log message about blocksonly mode.
     l2 = node_factory.get_node(start=False, expect_fail=True,
                                allow_broken_log=True)
-    l2.daemon.start(wait_for_initialized=False)
+    l2.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert l2.daemon.wait() == 1
     assert l2.daemon.is_in_stderr(r".*deactivating transaction relay is not"
@@ -1212,7 +1212,7 @@ def test_rescan(node_factory, bitcoind):
     l1.daemon.opts['rescan'] = -500000
     l1.stop()
     bitcoind.generate_block(4)
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
     assert l1.daemon.is_in_stderr(r"bitcoind has gone backwards from 500000 to 105 blocks!")
@@ -1243,7 +1243,7 @@ def test_bitcoind_goes_backwards(node_factory, bitcoind):
     bitcoind.start()
 
     # Will simply refuse to start.
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
     assert l1.daemon.is_in_stderr('bitcoind has gone backwards')
@@ -1252,7 +1252,7 @@ def test_bitcoind_goes_backwards(node_factory, bitcoind):
     l1.daemon.opts['rescan'] = 3
 
     # Will simply refuse to start.
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
     assert l1.daemon.is_in_stderr('bitcoind has gone backwards')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -109,7 +109,7 @@ def test_option_types(node_factory):
     }, may_fail=True, start=False)
 
     # the node should fail after start, and we get a stderr msg
-    n.daemon.start(wait_for_initialized=False)
+    n.daemon.start(wait_for_initialized=False, stderr_redir=True)
     assert n.daemon.wait() == 1
     wait_for(lambda: n.daemon.is_in_stderr('bool_opt: ! does not parse as type bool'))
 
@@ -122,7 +122,7 @@ def test_option_types(node_factory):
     }, may_fail=True, start=False)
 
     # the node should fail after start, and we get a stderr msg
-    n.daemon.start(wait_for_initialized=False)
+    n.daemon.start(wait_for_initialized=False, stderr_redir=True)
     assert n.daemon.wait() == 1
     assert n.daemon.is_in_stderr('--int_opt: notok does not parse as type int')
 
@@ -136,7 +136,7 @@ def test_option_types(node_factory):
     }, may_fail=True, start=False)
 
     # the node should fail after start, and we get a stderr msg
-    n.daemon.start(wait_for_initialized=False)
+    n.daemon.start(wait_for_initialized=False, stderr_redir=True)
     assert n.daemon.wait() == 1
     assert n.daemon.is_in_stderr("--flag_opt: doesn't allow an argument")
 
@@ -1522,7 +1522,7 @@ def test_libplugin(node_factory):
     l1.stop()
     l1.daemon.opts["name-deprecated"] = "test_opt"
 
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
     assert l1.daemon.is_in_stderr(r"name-deprecated: deprecated option")
@@ -1669,7 +1669,7 @@ def test_bitcoin_backend(node_factory, bitcoind):
     # We don't start if we haven't all the required methods registered.
     plugin = os.path.join(os.getcwd(), "tests/plugins/bitcoin/part1.py")
     l1.daemon.opts["plugin"] = plugin
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_log("Missing a Bitcoin plugin command")
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
@@ -2094,7 +2094,7 @@ def test_important_plugin(node_factory):
                               may_fail=True, expect_fail=True,
                               allow_broken_log=True, start=False)
 
-    n.daemon.start(wait_for_initialized=False)
+    n.daemon.start(wait_for_initialized=False, stderr_redir=True)
     # Will exit with failure code.
     assert n.daemon.wait() == 1
     assert n.daemon.is_in_stderr(r"Failed to register .*nonexistent: No such file or directory")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2559,6 +2559,14 @@ def test_commando(node_factory, executor):
         fut.result(10)
 
     rune = l1.rpc.commando_rune()['rune']
+
+    # Bad rune fails
+    with pytest.raises(RpcError, match="Not authorized: Not derived from master"):
+        l2.rpc.call(method='commando',
+                    payload={'peer_id': l1.info['id'],
+                             'rune': 'VXY4AAkrPyH2vzSvOHnI7PDVfS6O04bRQLUCIUFJD5Y9NjQmbWV0aG9kPWludm9pY2UmcmF0ZT0yMZ==',
+                             'method': 'listpeers'})
+
     # This works
     res = l2.rpc.call(method='commando',
                       payload={'peer_id': l1.info['id'],

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1038,7 +1038,7 @@ def test_hsm_secret_encryption(node_factory):
 
     # Test we cannot restore the same wallet with another password
     l1.daemon.opts.update({"encrypted-hsm": None})
-    l1.daemon.start(stdin=slave_fd, wait_for_initialized=False)
+    l1.daemon.start(stdin=slave_fd, wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_log(r'Enter hsm_secret password')
     write_all(master_fd, password[2:].encode("utf-8"))
     assert(l1.daemon.proc.wait(WAIT_TIMEOUT) == HSM_BAD_PASSWORD)


### PR DESCRIPTION
The callbacks-after-command-completed can particularly happen with commando:

```
 commando: FATAL SIGNAL 11 (version 06b36d3)
0x55609e953d51 send_backtrace
	common/daemon.c:33
0x55609e953dfb crashdump
	common/daemon.c:46
0x7f665e3b908f ???
	/build/glibc-SzIz7B/glibc-2.31/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
0x55609e9387a3 send_more_cmd
	plugins/commando.c:632
0x55609e93b270 handle_rpc_reply
	plugins/libplugin.c:669
0x55609e93bd50 rpc_read_response_one
	plugins/libplugin.c:842
0x55609e93be86 rpc_conn_read_response
	plugins/libplugin.c:862
0x55609e9f4f68 next_plan
	ccan/ccan/io/io.c:59
0x55609e9f5b70 do_plan
	ccan/ccan/io/io.c:407
0x55609e9f5bb2 io_ready
	ccan/ccan/io/io.c:417
0x55609e9f7ea5 io_loop
	ccan/ccan/io/poll.c:453
0x55609e93eb20 plugin_main
	plugins/libplugin.c:1676
0x55609e9397ab main
	plugins/commando.c:922
0x7f665e39a082 __libc_start_main
	../csu/libc-start.c:308
0x55609e93677d ???
	???:0
0xffffffffffffffff ???
	???:0
```

Reported-by: @adi2011
Changelog-None