### PR TITLE
test-flake: dont let `l1` send their unilateral tx

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2269,6 +2269,12 @@ def test_channel_persistence(node_factory, bitcoind, executor):
     l1.restart()
     assert only_one(l1.rpc.listpeers()['peers'][0]['channels'])['to_us_msat'] == 99980000
 
+    # Keep l1 from sending its onchain tx
+    def censoring_sendrawtx(r):
+        return {'id': r['id'], 'result': {}}
+
+    l1.daemon.rpcproxy.mock_rpc('sendrawtransaction', censoring_sendrawtx)
+
     # Now make sure l1 is watching for unilateral closes
     l2.rpc.dev_fail(l1.info['id'])
     l2.daemon.wait_for_log('Failing due to dev-fail command')


### PR DESCRIPTION
`l1` got their tx in before `l2`, but we're waiting for `l2`'s
commitment tx. (l2 sends an error message to l1 when we call dev-fail,
l1 broadcasts their commitment tx when they get the error)

Instead, we let l1 send their commitment tx, except we blackhole it.

```
        l2.rpc.dev_fail(l1.info['id'])
        l2.daemon.wait_for_log('Failing due to dev-fail command')
>       l2.wait_for_channel_onchain(l1.info['id'])
tests/test_connection.py:2275:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
contrib/pyln-testing/pyln/testing/utils.py:1043: in wait_for_channel_onchain
    wait_for(lambda: txid inself.bitcoin.rpc.getrawmempool())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
success = <function LightningNode.wait_for_channel_onchain.<locals>.<lambda> at 0x7f0f5f7577a0>
timeout = 900
defwait_for(success, timeout=TIMEOUT):
        start_time = time.time()
        interval = 0.25
whilenot success():
            time_left = start_time + timeout - time.time()
if time_left <= 0:
>               raiseValueError("Timeout while waiting for {}", success)
E               ValueError: ('Timeout while waiting for {}', <function LightningNode.wait_for_channel_onchain.<locals>.<lambda> at 0x7f0f5f7577a0>)
contrib/pyln-testing/pyln/testing/utils.py:93: ValueError
```