### PR TITLE
msat string miss

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -84,6 +84,7 @@ start_nodes() {
 		log-level=debug
 		log-file=/tmp/l$i-$network/log
 		addr=localhost:$socket
+		allow-deprecated-apis=false
 		EOF
 
 		# If we've configured to use developer, add dev options
@@ -98,7 +99,7 @@ start_nodes() {
 			funder-min-their-funding=10000
 			funder-per-channel-max=100000
 			funder-fuzz-percent=0
-			lease-fee-base-msat=2sat
+			lease-fee-base-sat=2sat
 			lease-fee-basis=50
 			EOF
 		fi

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -399,11 +399,10 @@ static void add_new_entry(struct json_stream *ret,
 	/* This is only tallied for pending and successful payments, not
 	 * failures. */
 	if (pm->amount != NULL && pm->num_nonfailed_parts > 0)
-		json_add_string(ret, "amount_msat",
-				fmt_amount_msat(tmpctx, *pm->amount));
+		json_add_amount_msat_only(ret, "amount_msat", *pm->amount);
 
-	json_add_string(ret, "amount_sent_msat",
-			fmt_amount_msat(tmpctx, pm->amount_sent));
+	json_add_amount_msat_only(ret, "amount_sent_msat",
+				  pm->amount_sent);
 
 	if (pm->num_nonfailed_parts > 1)
 		json_add_u64(ret, "number_of_parts",

--- a/plugins/spender/multifundchannel.c
+++ b/plugins/spender/multifundchannel.c
@@ -1117,8 +1117,8 @@ fundchannel_start_dest(struct multifundchannel_destination *dest)
 		json_add_string(req->js, "feerate", mfc->feerate_str);
 
 	json_add_bool(req->js, "announce", dest->announce);
-	json_add_string(req->js, "push_msat",
-			fmt_amount_msat(tmpctx, dest->push_msat));
+	json_add_amount_msat_only(req->js, "push_msat", dest->push_msat);
+
 	if (dest->close_to_str)
 		json_add_string(req->js, "close_to", dest->close_to_str);
 


### PR DESCRIPTION
`listpays` was missing the updated "no strings in msat responses" cleanup, since we were using `json_add_str` there instead of an msat helper.

Also went ahead and updated the `startup_regtest` to turn off deprecated apis and updated a now deprecated option for the `funder` plugin that it loads for dev builds.

Changelog-None