### PR TITLE
test timing fixes/stderr redirect 

### DIFF
--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -364,8 +364,10 @@ static void connect_failed(struct lightningd *ld,
 		u32 delay;
 		if (seconds_to_delay)
 			delay = *seconds_to_delay;
+		else if (peer->delay_reconnect)
+			delay = DEV_FAST_RECONNECT(ld->dev_fast_reconnect, 3, 60);
 		else
-			delay = peer->delay_reconnect ? 60 : 1;
+			delay = 1;
 		log_peer_debug(ld->log, id, "Reconnecting in %u seconds", delay);
 		try_reconnect(peer, peer, delay, addrhint);
 	} else

--- a/lightningd/connect_control.h
+++ b/lightningd/connect_control.h
@@ -3,11 +3,16 @@
 #include "config.h"
 #include <ccan/short_types/short_types.h>
 #include <ccan/tal/tal.h>
+#include <common/utils.h>
 
 struct lightningd;
 struct peer;
 struct pubkey;
 struct wireaddr_internal;
+
+/* Speedy reconnect timeout! */
+#define DEV_FAST_RECONNECT(dev_fast_reconnect_flag, fast, normal)	\
+	IFDEV((dev_fast_reconnect_flag) ? (fast) : (normal), (normal))
 
 /* Returns fd for gossipd to talk to connectd */
 int connectd_init(struct lightningd *ld);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -125,6 +125,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_gossip_time = 0;
 	ld->dev_fast_gossip = false;
 	ld->dev_fast_gossip_prune = false;
+	ld->dev_fast_reconnect = false;
 	ld->dev_force_privkey = NULL;
 	ld->dev_force_bip32_seed = NULL;
 	ld->dev_force_channel_secrets = NULL;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -244,6 +244,9 @@ struct lightningd {
 	bool dev_fast_gossip;
 	bool dev_fast_gossip_prune;
 
+	/* Speedup reconnect delay, for testing. */
+	bool dev_fast_reconnect;
+
 	/* This is the forced private key for the node. */
 	struct privkey *dev_force_privkey;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -691,6 +691,10 @@ static void dev_register_opts(struct lightningd *ld)
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
 			   &ld->reconnect,
 			   "Disable automatic reconnect-attempts by this node, but accept incoming");
+	opt_register_noarg("--dev-fast-reconnect", opt_set_bool,
+			   &ld->dev_fast_reconnect,
+			   "Make default reconnect delay 3 (not 60) seconds");
+
 	opt_register_noarg("--dev-fail-on-subdaemon-fail", opt_set_bool,
 			   &ld->dev_subdaemon_fail, opt_hidden);
 	opt_register_arg("--dev-disconnect=<filename>", opt_subd_dev_disconnect,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1132,7 +1132,7 @@ def test_funding_reorg_private(node_factory, bitcoind):
     l2.daemon.wait_for_log(r'Deleting channel')
 
 
-@pytest.mark.developer("needs DEVELOPER=1")
+@pytest.mark.developer("needs DEVELOPER=1", "uses --dev-fast-reconnect")
 @pytest.mark.openchannel('v1')
 @pytest.mark.openchannel('v2')
 def test_funding_reorg_remote_lags(node_factory, bitcoind):
@@ -1140,7 +1140,7 @@ def test_funding_reorg_remote_lags(node_factory, bitcoind):
     """
     # may_reconnect so channeld will restart; bad gossip can happen due to reorg
     opts = {'funding-confirms': 1, 'may_reconnect': True, 'allow_bad_gossip': True,
-            'allow_warning': True}
+            'allow_warning': True, 'dev-fast-reconnect': None}
     l1, l2 = node_factory.line_graph(2, fundchannel=False, opts=opts)
     l1.fundwallet(10000000)
     sync_blockheight(bitcoind, [l1])                # height 102

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1716,9 +1716,11 @@ def test_bitcoind_fail_first(node_factory, bitcoind):
     """
     # Do not start the lightning node since we need to instrument bitcoind
     # first.
+    timeout = 5 if 5 < TIMEOUT // 3 else TIMEOUT // 3
     l1 = node_factory.get_node(start=False,
                                allow_broken_log=True,
-                               may_fail=True)
+                               may_fail=True,
+                               options={'bitcoin-retry-timeout': timeout})
 
     # Instrument bitcoind to fail some queries first.
     def mock_fail(*args):
@@ -1730,7 +1732,7 @@ def test_bitcoind_fail_first(node_factory, bitcoind):
     l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_logs([r'getblockhash [a-z0-9]* exited with status 1',
                              r'Unable to estimate opening fees',
-                             r'BROKEN.*we have been retrying command for --bitcoin-retry-timeout=60 seconds'])
+                             r'BROKEN.*we have been retrying command for --bitcoin-retry-timeout={} seconds'.format(timeout)])
     # Will exit with failure code.
     assert l1.daemon.wait() == 1
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1727,7 +1727,7 @@ def test_bitcoind_fail_first(node_factory, bitcoind):
     l1.daemon.rpcproxy.mock_rpc('getblockhash', mock_fail)
     l1.daemon.rpcproxy.mock_rpc('estimatesmartfee', mock_fail)
 
-    l1.daemon.start(wait_for_initialized=False)
+    l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     l1.daemon.wait_for_logs([r'getblockhash [a-z0-9]* exited with status 1',
                              r'Unable to estimate opening fees',
                              r'BROKEN.*we have been retrying command for --bitcoin-retry-timeout=60 seconds'])


### PR DESCRIPTION
I was getting consistent test failures for these when looking at the `bookkeeper` test fails; mostly these were timing bugs!