### PR TITLE
decode: fix crash when decoding invalid rune.

### DIFF
--- a/doc/lightning-decode.7.md
+++ b/doc/lightning-decode.7.md
@@ -163,7 +163,8 @@ If **type** is "bolt11 invoice", and **valid** is *true*:
     - **tag** (string): The bech32 letter which identifies this field (always 1 characters)
     - **data** (string): The bech32 data for this field
 
-If **type** is "rune":
+If **type** is "rune", and **valid** is *true*:
+  - **valid** (boolean) (always *true*)
   - **string** (string): the string encoding of the rune
   - **restrictions** (array of objects): restrictions built into the rune: all must pass:
     - **alternatives** (array of strings): each way restriction can be met: any can pass:
@@ -171,7 +172,12 @@ If **type** is "rune":
     - **summary** (string): human-readable summary of this restriction
   - **unique_id** (string, optional): unique id (always a numeric id on runes we create)
   - **version** (string, optional): rune version, not currently set on runes we create
-  - **valid** (boolean, optional) (always *true*)
+
+If **type** is "rune", and **valid** is *false*:
+  - **valid** (boolean) (always *false*)
+  - **hex** (hex, optional): the raw rune in hex
+  - the following warnings are possible:
+    - **warning_rune_invalid_utf8**: the rune contains invalid UTF-8 strings
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -195,4 +201,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:d1e1f044c2e67ec169728dbc551903c97f9a9daa1f42e9d2f1686fc692d25be8)
+[comment]: # ( SHA256STAMP:a3963c3e0061b0d42a1f9e2f2a9012df780fce0264c6785f0311909b01f78af2)

--- a/doc/schemas/decode.schema.json
+++ b/doc/schemas/decode.schema.json
@@ -919,13 +919,20 @@
             "enum": [
               "rune"
             ]
+          },
+          "valid": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           }
         }
       },
       "then": {
         "required": [
           "string",
-          "restrictions"
+          "restrictions",
+          "valid"
         ],
         "additionalProperties": false,
         "properties": {
@@ -973,6 +980,47 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "rune"
+            ]
+          },
+          "valid": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "valid"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "type": {},
+          "warning_rune_invalid_utf8": {
+            "type": "string",
+            "description": "the rune contains invalid UTF-8 strings"
+          },
+          "hex": {
+            "type": "hex",
+            "description": "the raw rune in hex"
           }
         }
       }


### PR DESCRIPTION
If rune contains invalid UTF-8, offers (which implements decode) would
produce JSON with invalid UTF-8, which causes lightningd to complain
and kill it, and then die because it's an important plugin.

So don't decode invalid UTF-8!

Reported-by: @jb55
Changelog-None: introduced in this release.