### PR TITLE
lightningd: fix fatal() log message in log.

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -840,14 +840,20 @@ void log_backtrace_exit(void)
 
 void fatal_vfmt(const char *fmt, va_list ap)
 {
+	va_list ap2;
+
+	/* You are not allowed to re-use va_lists, so make a copy. */
+	va_copy(ap2, ap);
 	vfprintf(stderr, fmt, ap);
 	fprintf(stderr, "\n");
 
 	if (!crashlog)
 		exit(1);
 
-	logv(crashlog, LOG_BROKEN, NULL, true, fmt, ap);
+	logv(crashlog, LOG_BROKEN, NULL, true, fmt, ap2);
 	abort();
+	/* va_copy() must be matched with va_end(), even if unreachable. */
+	va_end(ap2);
 }
 
 void fatal(const char *fmt, ...)


### PR DESCRIPTION
The one to stderr is fine, the log one gets corrupted, like so:

```
2022-07-24T07:20:08.6250702Z lightningd-2 2022-07-24T06:49:19.494Z **BROKEN** lightningd: Plugin '????UH??SH??8H?}?H?u?H?U?H?M?H?M?H?E?H?????' returned an invalid response to the db_write hook: (F???U
```

Changelog-None