### PR TITLE
Fix default args, fix flake

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -940,7 +940,7 @@ static const char *plugin_opt_add(struct plugin *plugin, const char *buffer,
 	if (strchr(popt->name, '|'))
 		return tal_fmt(plugin, "Option \"name\" may not contain '|'");
 
-	popt->description = NULL;
+	popt->description = json_strdup(popt, buffer, desctok);
 	if (deptok) {
 		if (!json_to_bool(buffer, deptok, &popt->deprecated))
 			return tal_fmt(plugin,
@@ -981,7 +981,7 @@ static const char *plugin_opt_add(struct plugin *plugin, const char *buffer,
 			       "Only \"string\", \"int\", \"bool\", and \"flag\" options are supported");
 	}
 
-	if (defaulttok) {
+	if (defaulttok && !json_tok_is_null(buffer, defaulttok)) {
 		popt->def = plugin_opt_value(popt, popt->type,
 					     json_strdup(tmpctx, buffer, defaulttok));
 		if (!popt->def)
@@ -991,8 +991,6 @@ static const char *plugin_opt_add(struct plugin *plugin, const char *buffer,
 				       popt->type);
 	}
 
-	if (!popt->description)
-		popt->description = json_strdup(popt, buffer, desctok);
 
 	list_add_tail(&plugin->plugin_opts, &popt->list);
 

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -485,6 +485,7 @@ static void handle_incmd(struct node_id *peer,
 	}
 
 	try_command(peer, idnum, incmd->contents, tal_bytelen(incmd->contents));
+	tal_free(incmd);
 }
 
 static struct command_result *handle_reply(struct node_id *peer,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,6 +40,7 @@ class LightningNode(utils.LightningNode):
             if not has_dblog:
                 # Add as an expanded option so we don't clobber other options.
                 self.daemon.opts['plugin={}'.format(dblog)] = None
+                self.daemon.opts['dblog-file'] = 'dblog.sqlite3'
 
         # Yes, we really want to test the local development version, not
         # something in out path.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2203,6 +2203,8 @@ def test_funding_while_offline(node_factory, bitcoind):
 @pytest.mark.developer
 @pytest.mark.openchannel('v1')
 @pytest.mark.openchannel('v2')
+@unittest.skipIf(os.environ.get("TEST_CHECK_DBSTMTS", None) == "1",
+                 "We kill l2, dblog plugin replay will be unreliable")
 def test_channel_persistence(node_factory, bitcoind, executor):
     # Start two nodes and open a channel (to remember). l2 will
     # mysteriously die while committing the first HTLC so we can

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2835,8 +2835,12 @@ def test_commando_stress(node_factory, executor):
             assert(e.error['message'] == "Invalid JSON")
             discards += 1
 
-    # Should have exactly one discard msg from each discard
-    nodes[0].daemon.wait_for_logs([r"New cmd from .*, replacing old"] * discards)
+    # Should have at least one discard msg from each failure (we can have
+    # more, if they kept replacing each other, as happens!)
+    if discards > 0:
+        nodes[0].daemon.wait_for_logs([r"New cmd from .*, replacing old"] * discards)
+    else:
+        assert not nodes[0].daemon.is_in_log(r"New cmd from .*, replacing old")
 
 
 def test_commando_badrune(node_factory):


### PR DESCRIPTION
Turns out python plugins saw the string "null" as their options if there was no default value.  Best to fix this in core, and ship in 0.12.

I appended two commando fixes which I found while testing this locally...