### PR TITLE
Test flakes?? (works for me)

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -337,6 +337,7 @@ bool separate_address_and_port(const tal_t *ctx, const char *arg,
 		*port = strtol(portcolon + 1, &endp, 10);
 		return *port != 0 && *endp == '\0';
 	}
+
 	return true;
 }
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -226,6 +226,8 @@ static char *opt_add_addr_withtype(const char *arg,
 	assert(arg != NULL);
 	dns_ok = !ld->always_use_proxy && ld->config.use_dns;
 
+	/* Will be overridden in next call iff has port */
+	port = 0;
 	if (!separate_address_and_port(tmpctx, arg, &address, &port))
 		return tal_fmt(NULL, "Unable to parse address:port '%s'", arg);
 

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -149,6 +149,8 @@ static void disable_request_cb(struct command *cmd, struct out_req *out)
 {
 	out->errcb = NULL;
 	out->cb = ignore_cb;
+	/* Called because cmd got free'd */
+	out->cmd = NULL;
 }
 
 /* FIXME: Move lightningd/jsonrpc to common/ ? */

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1084,7 +1084,7 @@ def chan_active(node, scid, is_active):
     return [c['active'] for c in chans] == [is_active, is_active]
 
 
-@pytest.mark.developer("needs DEVELOPER=1")
+@pytest.mark.developer("needs DEVELOPER=1", "uses dev-fast-reconnect")
 @pytest.mark.openchannel('v2')
 @pytest.mark.openchannel('v1')
 def test_funding_reorg_private(node_factory, bitcoind):
@@ -1096,7 +1096,8 @@ def test_funding_reorg_private(node_factory, bitcoind):
             'allow_bad_gossip': True,
             # gossipd send lightning update for original channel.
             'allow_broken_log': True,
-            'allow_warning': True}
+            'allow_warning': True,
+            'dev-fast-reconnect': None}
     l1, l2 = node_factory.line_graph(2, fundchannel=False, opts=opts)
     l1.fundwallet(10000000)
     sync_blockheight(bitcoind, [l1])                # height 102


### PR DESCRIPTION
Valgrind was choking on some things while running tests locally for the `bookkeeper`; this fixes those up.

Also speeds up a test's reconnect, which would flake locally when TIMEOUT is set low.