### PR TITLE
v2 opens and funder flakes

### DIFF
--- a/plugins/spender/openchannel.c
+++ b/plugins/spender/openchannel.c
@@ -621,10 +621,9 @@ funding_transaction_established(struct multifundchannel_command *mfc)
 
 	/* If all we've got is v2 destinations, we're just waiting
 	 * for all of our peers to send us their sigs.
-	 * That callback triggers separately, so we just return
-	 * a 'still pending' here */
+	 * Let's check if we've gotten them yet */
 	if (dest_count(mfc, FUND_CHANNEL) == 0)
-		return command_still_pending(mfc->cmd);
+		return check_sigs_ready(mfc);
 
 	/* For any v1 destination, we need to update the destination
 	 * outnum with the correct outnum on the now-known

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3358,12 +3358,11 @@ def test_wumbo_channels(node_factory, bitcoind):
 
     # Connect l3, get gossip.
     l3.rpc.connect(l1.info['id'], 'localhost', port=l1.port)
-    wait_for(lambda: len(l3.rpc.listnodes(l1.info['id'])['nodes']) == 1)
-    wait_for(lambda: 'features' in only_one(l3.rpc.listnodes(l1.info['id'])['nodes']))
 
-    # Make sure channel capacity is what we expected.
-    assert ([c['amount_msat'] for c in l3.rpc.listchannels()['channels']]
-            == [Millisatoshi(str(1 << 24) + "sat")] * 2)
+    # Make sure channel capacity is what we expected (might need to wait for
+    # both channel updates!
+    wait_for(lambda: [c['amount_msat'] for c in l3.rpc.listchannels()['channels']]
+             == [Millisatoshi(str(1 << 24) + "sat")] * 2)
 
     # Make sure channel features are right from channel_announcement
     assert ([c['features'] for c in l3.rpc.listchannels()['channels']]

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -170,10 +170,12 @@ def test_v2_open_sigs_restart(node_factory, bitcoind):
     assert log
     psbt = re.search("psbt (.*)", log).group(1)
 
-    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.daemon.wait_for_log('Peer has reconnected, state DUALOPEND_OPEN_INIT')
-    with pytest.raises(RpcError):
+    try:
+        # FIXME: why do we need to retry signed?
         l1.rpc.openchannel_signed(chan_id, psbt)
+    except RpcError:
+        pass
 
     l2.daemon.wait_for_log('Broadcasting funding tx')
     txid = l2.rpc.listpeers(l1.info['id'])['peers'][0]['channels'][0]['funding_txid']
@@ -219,10 +221,12 @@ def test_v2_open_sigs_restart_while_dead(node_factory, bitcoind):
     assert log
     psbt = re.search("psbt (.*)", log).group(1)
 
-    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     l1.daemon.wait_for_log('Peer has reconnected, state DUALOPEND_OPEN_INIT')
-    with pytest.raises(RpcError):
+    try:
+        # FIXME: why do we need to retry signed?
         l1.rpc.openchannel_signed(chan_id, psbt)
+    except RpcError:
+        pass
 
     l2.daemon.wait_for_log('Broadcasting funding tx')
     l2.daemon.wait_for_log('sendrawtx exit 0')


### PR DESCRIPTION
The `funder_contribution_limits` test hang is kind of interesting -- I was assuming that the RPC response to openchannel_update would always beat the notification of tx_signatures arriving since the spec says they MUST always arrive one after the other (and in fact the code doesn't work if they get called out of order). In rare cases however the notification arrives before the RPC response, which causes the hang we've been seeing.

Really easy to fix, but kind of interesting!


The other flake has to do with how fast the connection drops -- if it drops too fast we get an RPC error; otherwise the RPC returns correctly. We don't really care if the RPC works we just need to call it.

"needing to call this RPC no matter if it returns ok or not" has a bit of a smell; I'm planning to do some work on this flow next release. I'm punting on cleaning it up til then.  

Changelog-None