### PR TITLE
doc: fix bolt 12 link (it's not in master), update bolt 11 to new "bolts" repo

### DIFF
--- a/doc/lightning-decode.7.md
+++ b/doc/lightning-decode.7.md
@@ -191,9 +191,9 @@ SEE ALSO
 
 lightning-pay(7), lightning-offer(7), lightning-offerout(7), lightning-fetchinvoice(7), lightning-sendinvoice(7), lightning-commando-rune(7)
 
-[BOLT \#11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md).
+[BOLT #11](https://github.com/lightningnetwork/bolts/blob/master/11-payment-encoding.md).
 
-[BOLT \#12](https://github.com/lightningnetwork/lightning-rfc/blob/master/12-offer-encoding.md).
+[BOLT #12](https://github.com/rustyrussell/lightning-rfc/blob/guilt/offers/12-offer-encoding.md).
 
 
 RESOURCES


### PR DESCRIPTION
It's weird that readthedocs.io drops the ".md" suffix though;
let's see if this fixes it.

Changelog-None
Fixes: #5462