### PR TITLE
bkpr: avoid assert failure from subtracting an equal amount of sats

### DIFF
--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -640,7 +640,7 @@ static bool new_missed_channel_account(struct command *cmd,
 				push_credit = AMOUNT_MSAT(0);
 				push_debit = push_amt;
 			} else {
-				ok = amount_msat_sub(&amt, amt, push_amt);
+				ok = amount_msat_sub(&amt, remote_amt, push_amt);
 				push_credit = push_amt;
 				push_debit = AMOUNT_MSAT(0);
 			}


### PR DESCRIPTION
If the remote party opened the channel and pushed zero sats, then `amt` and `push_amt` are both zero.
This makes the subtraction `amount_msat_sub` fail, breaking on the next assert(ok).

```
2022-07-28T07:11:13.144Z INFO    plugin-bookkeeper: account 2cdeXXXf12 not found, adding along with new balance
bookkeeper: plugins/bkpr/bookkeeper.c:653: new_missed_channel_account: Assertion `ok' failed.
bookkeeper: FATAL SIGNAL 6 (version v0.11.0.1-498-g8c9fa45)
...
```
Tried to fix by first checking `amount_msat_greater` and conditionally setting `amt = AMOUNT_MSAT(0)` if `amt` is in fact equal or smaller. Not really the nicest, is there a better way to subtract two possibly equal amounts?

haven't had a change to test yet for unrelated reasons