### PR TITLE
commando-rune: show warning when creating runes with no restrictions

### DIFF
--- a/doc/lightning-commando-rune.7.md
+++ b/doc/lightning-commando-rune.7.md
@@ -193,6 +193,9 @@ On success, an object is returned, containing:
 - **rune** (string): the resulting rune
 - **unique_id** (string): the id of this rune: this is set at creation and cannot be changed (even as restrictions are added)
 
+The following warnings may also be returned:
+- **warning_unrestricted_rune**: A warning shown when runes are created with powers that could drain your node
+
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 AUTHOR
@@ -214,4 +217,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:598337212d2e8a6833698e931f838d8cb424c353af4d7adf6891803ff0ee604b)
+[comment]: # ( SHA256STAMP:34c6d5222fee79f4648be4a717041d32004b5bb3644364dc6569b87b16ed2ebe)

--- a/doc/schemas/commando-rune.schema.json
+++ b/doc/schemas/commando-rune.schema.json
@@ -14,6 +14,10 @@
     "unique_id": {
       "type": "string",
       "description": "the id of this rune: this is set at creation and cannot be changed (even as restrictions are added)"
+    },
+    "warning_unrestricted_rune": {
+      "type": "string",
+      "description": "A warning shown when runes are created with powers that could drain your node"
     }
   }
 }

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -804,6 +804,10 @@ static struct command_result *reply_with_rune(struct command *cmd,
 
 	json_add_string(js, "rune", rune_to_base64(tmpctx, rune));
 	json_add_string(js, "unique_id", rune->unique_id);
+
+	if (tal_count(rune->restrs) <= 1) {
+		json_add_string(js, "warning_unrestricted_rune", "WARNING: This rune has no restrictions! Anyone who has access to this rune could drain funds from your node. Be careful when giving this to apps that you don't trust. Consider using the restrictions parameter to only allow access to specific rpc methods.");
+	}
 	return command_finished(cmd, js);
 }
 


### PR DESCRIPTION
Changelog-Added: Show warning when creating runes with no restrictions
Signed-off-by: William Casarin <jb55@jb55.com>
