### PR TITLE
bkpr: track channel rebalances, display in listincome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ contrib/pyln-*/dist/
 contrib/pyln-*/pyln_*.egg-info/
 contrib/pyln-*/.eggs/
 contrib/pyln-*/pyln/*/__version__.py
-release/
 tests/plugins/test_selfdisable_after_getmanifest
 
 # Ignore generated files
@@ -75,3 +74,9 @@ tests/primitives_pb2_grpc.py
 # Rust targets
 target
 plugins/cln-grpc
+
+# Build directories
+bionic/
+focal/
+jammy/
+release/

--- a/doc/lightning-bkpr-listaccountevents.7.md
+++ b/doc/lightning-bkpr-listaccountevents.7.md
@@ -45,6 +45,7 @@ If **type** is "onchain_fee":
 
 If **type** is "channel":
   - **fees_msat** (msat, optional): Amount paid in fees
+  - **is_rebalance** (boolean, optional): Is this payment part of a rebalance
   - **payment_id** (hex, optional): lightning payment identifier. For an htlc, this will be the preimage.
   - **part_id** (u32, optional): Counter for multi-part payments
 
@@ -66,4 +67,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f8538b1d1e6cda7cd801690e5c09741c8a843b27cc922065598914516c16d2b3)
+[comment]: # ( SHA256STAMP:8568188808cb649d7182ffb628950b93b18406a0498b5b6768371bc94375e258)

--- a/doc/schemas/bkpr-listaccountevents.schema.json
+++ b/doc/schemas/bkpr-listaccountevents.schema.json
@@ -165,6 +165,10 @@
                   "type": "msat",
                   "description": "Amount paid in fees"
                 },
+                "is_rebalance": {
+                  "type": "boolean",
+                  "description": "Is this payment part of a rebalance"
+                },
                 "payment_id": {
                   "type": "hex",
                   "description": "lightning payment identifier. For an htlc, this will be the preimage."

--- a/plugins/bkpr/account_entry.c
+++ b/plugins/bkpr/account_entry.c
@@ -8,6 +8,7 @@ static const char *tags[] = {
 	"journal_entry",
 	"penalty_adj",
 	"invoice_fee",
+	"rebalance_fee",
 };
 
 const char *account_entry_tag_str(enum account_entry_tag tag)

--- a/plugins/bkpr/account_entry.h
+++ b/plugins/bkpr/account_entry.h
@@ -2,11 +2,12 @@
 #define LIGHTNING_PLUGINS_BKPR_ACCOUNT_ENTRY_H
 #include "config.h"
 
-#define NUM_ACCOUNT_ENTRY_TAGS (INVOICEFEE + 1)
+#define NUM_ACCOUNT_ENTRY_TAGS (REBALANCEFEE + 1)
 enum account_entry_tag {
 	JOURNAL_ENTRY = 0,
 	PENALTY_ADJ = 1,
 	INVOICEFEE = 2,
+	REBALANCEFEE= 3,
 };
 
 /* Convert an enum into a string */

--- a/plugins/bkpr/chain_event.h
+++ b/plugins/bkpr/chain_event.h
@@ -34,6 +34,9 @@ struct chain_event {
 	 * we'll need to watch it for longer */
 	bool stealable;
 
+	/* Is this a rebalance event? */
+	bool rebalance;
+
 	/* Amount we received in this event */
 	struct amount_msat credit;
 

--- a/plugins/bkpr/channel_event.c
+++ b/plugins/bkpr/channel_event.c
@@ -27,6 +27,7 @@ struct channel_event *new_channel_event(const tal_t *ctx,
 	ev->part_id = part_id;
 	ev->timestamp = timestamp;
 	ev->desc = NULL;
+	ev->rebalance_id = NULL;
 
 	return ev;
 }
@@ -50,5 +51,6 @@ void json_add_channel_event(struct json_stream *out,
 	json_add_u64(out, "timestamp", ev->timestamp);
 	if (ev->desc)
 		json_add_string(out, "description", ev->desc);
+	json_add_bool(out, "is_rebalance", ev->rebalance_id != NULL);
 	json_object_end(out);
 }

--- a/plugins/bkpr/channel_event.h
+++ b/plugins/bkpr/channel_event.h
@@ -46,6 +46,9 @@ struct channel_event {
 
 	/* Description, usually from invoice */
 	const char *desc;
+
+	/* ID of paired event, iff is a rebalance */
+	u64 *rebalance_id;
 };
 
 struct channel_event *new_channel_event(const tal_t *ctx,

--- a/plugins/bkpr/db.c
+++ b/plugins/bkpr/db.c
@@ -98,6 +98,7 @@ static struct migration db_migrations[] = {
 	{SQL("ALTER TABLE chain_events ADD stealable INTEGER;"), NULL},
 	{SQL("ALTER TABLE chain_events ADD ev_desc TEXT DEFAULT NULL;"), NULL},
 	{SQL("ALTER TABLE channel_events ADD ev_desc TEXT DEFAULT NULL;"), NULL},
+	{SQL("ALTER TABLE channel_events ADD rebalance_id BIGINT DEFAULT NULL;"), NULL},
 };
 
 static bool db_migrate(struct plugin *p, struct db *db, bool *created)

--- a/plugins/bkpr/recorder.h
+++ b/plugins/bkpr/recorder.h
@@ -41,6 +41,15 @@ struct txo_set {
 	struct txo_pair **pairs;
 };
 
+struct rebalance {
+	u64 in_ev_id;
+	u64 out_ev_id;
+	char *in_acct_name;
+	char *out_acct_name;
+	struct amount_msat rebal_msat;
+	struct amount_msat fee_msat;
+};
+
 /* Get all accounts */
 struct account **list_accounts(const tal_t *ctx, struct db *db);
 
@@ -199,6 +208,14 @@ void add_payment_hash_desc(struct db *db,
  * This method updates the blockheight on these events to the
  * height an input was spent into */
 void maybe_closeout_external_deposits(struct db *db, struct chain_event *ev);
+
+/* Keep track of rebalancing payments (payments paid to/from ourselves.
+ * Returns true if was rebalance */
+void maybe_record_rebalance(struct db *db,
+			    struct channel_event *out);
+
+/* List all rebalances */
+struct rebalance **list_rebalances(const tal_t *ctx, struct db *db);
 
 /* Log a channel event */
 void log_channel_event(struct db *db,

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -283,6 +283,9 @@ static bool channel_events_eq(struct channel_event *e1, struct channel_event *e2
 	CHECK(amount_msat_eq(e1->credit, e2->credit));
 	CHECK(amount_msat_eq(e1->debit, e2->debit));
 	CHECK(amount_msat_eq(e1->fees, e2->fees));
+	CHECK((e1->rebalance_id != NULL) == (e2->rebalance_id != NULL));
+	if (e1->rebalance_id)
+		CHECK(*e1->rebalance_id == *e2->rebalance_id);
 	CHECK(streq(e1->currency, e2->currency));
 	CHECK((e1->payment_id != NULL) == (e2->payment_id != NULL));
 	if (e1->payment_id)
@@ -311,6 +314,8 @@ static bool chain_events_eq(struct chain_event *e1, struct chain_event *e2)
 	CHECK(streq(e1->currency, e2->currency));
 	CHECK(e1->timestamp == e2->timestamp);
 	CHECK(e1->blockheight == e2->blockheight);
+	CHECK(e1->stealable == e2->stealable);
+	CHECK(e1->ignored == e2->ignored);
 	CHECK(bitcoin_outpoint_eq(&e1->outpoint, &e2->outpoint));
 
 	CHECK((e1->spending_txid != NULL) == (e2->spending_txid != NULL));
@@ -346,6 +351,7 @@ static struct channel_event *make_channel_event(const tal_t *ctx,
 	ev->part_id = 19;
 	ev->tag = tag;
 	ev->desc = tal_fmt(ev, "description");
+	ev->rebalance_id = NULL;
 	return ev;
 }
 
@@ -869,6 +875,92 @@ static bool test_onchain_fee_chan_open(const tal_t *ctx, struct plugin *p)
 	return true;
 }
 
+static bool test_channel_rebalances(const tal_t *ctx, struct plugin *p)
+{
+	bool created;
+	struct db *db = db_setup(ctx, p, tmp_dsn(ctx), &created);
+	struct channel_event *ev1, *ev2, *ev3, **chan_evs;
+	struct rebalance **rebals;
+	struct account *acct1, *acct2, *acct3;
+	struct node_id peer_id;
+
+	memset(&peer_id, 3, sizeof(struct node_id));
+	acct1 = new_account(ctx, tal_fmt(ctx, "one"), &peer_id);
+	acct2 = new_account(ctx, tal_fmt(ctx, "two"), &peer_id);
+	acct3 = new_account(ctx, tal_fmt(ctx, "three"), &peer_id);
+
+	db_begin_transaction(db);
+
+	account_add(db, acct1);
+	account_add(db, acct2);
+	account_add(db, acct3);
+
+	/* Simulate a rebalance of 100msats, w/ a 12msat fee */
+	ev1 = make_channel_event(ctx, "invoice",
+		           AMOUNT_MSAT(100),
+			   AMOUNT_MSAT(0),
+			   'A');
+	ev1->fees = AMOUNT_MSAT(0);
+	log_channel_event(db, acct1, ev1);
+
+	ev2 = make_channel_event(ctx, "invoice",
+				 AMOUNT_MSAT(0),
+				 AMOUNT_MSAT(112),
+				 'A');
+	ev2->fees = AMOUNT_MSAT(12);
+	log_channel_event(db, acct2, ev2);
+
+	/* Third event w/ same preimage but diff amounts */
+	ev3 = make_channel_event(ctx, "invoice",
+				 AMOUNT_MSAT(105),
+				 AMOUNT_MSAT(0),
+				 'A');
+	log_channel_event(db, acct3, ev3);
+	db_commit_transaction(db);
+	CHECK_MSG(!db_err, db_err);
+
+	db_begin_transaction(db);
+	chan_evs = account_get_channel_events(ctx, db, acct1);
+	CHECK(tal_count(chan_evs) == 1 && !chan_evs[0]->rebalance_id);
+
+	chan_evs = account_get_channel_events(ctx, db, acct2);
+	CHECK(tal_count(chan_evs) == 1 && !chan_evs[0]->rebalance_id);
+
+	chan_evs = account_get_channel_events(ctx, db, acct3);
+	CHECK(tal_count(chan_evs) == 1 && !chan_evs[0]->rebalance_id);
+
+	maybe_record_rebalance(db, ev2);
+	CHECK(ev2->rebalance_id != NULL);
+
+	/* Both events should be marked as rebalance */
+	chan_evs = account_get_channel_events(ctx, db, acct1);
+	CHECK(tal_count(chan_evs) == 1 && chan_evs[0]->rebalance_id);
+
+	chan_evs = account_get_channel_events(ctx, db, acct2);
+	CHECK(tal_count(chan_evs) == 1 && chan_evs[0]->rebalance_id);
+
+	/* Third event is not a rebalance though */
+	chan_evs = account_get_channel_events(ctx, db, acct3);
+	CHECK(tal_count(chan_evs) == 1 && !chan_evs[0]->rebalance_id);
+
+	/* Did we get an accurate rebalances entry? */
+	rebals = list_rebalances(ctx, db);
+
+	CHECK(tal_count(rebals) == 1);
+
+	CHECK(rebals[0]->in_ev_id == ev1->db_id);
+	CHECK(rebals[0]->out_ev_id == ev2->db_id);
+	CHECK(streq(rebals[0]->in_acct_name, "one"));
+	CHECK(streq(rebals[0]->out_acct_name, "two"));
+	CHECK(amount_msat_eq(rebals[0]->rebal_msat, AMOUNT_MSAT(100)));
+	CHECK(amount_msat_eq(rebals[0]->fee_msat, AMOUNT_MSAT(12)));
+
+	db_commit_transaction(db);
+	CHECK_MSG(!db_err, db_err);
+
+	return true;
+}
+
 static bool test_channel_event_crud(const tal_t *ctx, struct plugin *p)
 {
 	bool created;
@@ -897,6 +989,7 @@ static bool test_channel_event_crud(const tal_t *ctx, struct plugin *p)
 	ev1->timestamp = 11111;
 	ev1->part_id = 19;
 	ev1->desc = tal_strdup(ev1, "hello desc1");
+	ev1->rebalance_id = NULL;
 
 	/* Passing unknown tags in should be ok */
 	ev1->tag = "hello";
@@ -913,6 +1006,8 @@ static bool test_channel_event_crud(const tal_t *ctx, struct plugin *p)
 	ev2->part_id = 0;
 	ev2->tag = tal_fmt(ev2, "deposit");
 	ev2->desc = NULL;
+	ev2->rebalance_id = tal(ev2, u64);
+	*ev2->rebalance_id = 1;
 
 	ev3 = tal(ctx, struct channel_event);
 	ev3->payment_id = tal(ev3, struct sha256);
@@ -925,6 +1020,7 @@ static bool test_channel_event_crud(const tal_t *ctx, struct plugin *p)
 	ev3->part_id = 5;
 	ev3->tag = tal_fmt(ev3, "routed");
 	ev3->desc = NULL;
+	ev3->rebalance_id = NULL;
 
 	db_begin_transaction(db);
 	log_channel_event(db, acct, ev1);
@@ -1322,6 +1418,7 @@ int main(int argc, char *argv[])
 		ok &= test_account_balances(tmpctx, plugin);
 		ok &= test_onchain_fee_chan_close(tmpctx, plugin);
 		ok &= test_onchain_fee_chan_open(tmpctx, plugin);
+		ok &= test_channel_rebalances(tmpctx, plugin);
 		ok &= test_onchain_fee_wallet_spend(tmpctx, plugin);
 	}
 


### PR DESCRIPTION
Self-transfers should really be ignored for income reports. This change adds rebalance tracking,
which allows us to report the right thing for `listincome`.

Tracks rebalances, and report income events for them.

Previously `listincome` would report:
	- invoice event, debit, outgoing channel
	- invoice_fee event, debit, outgoing channel
	- invoice event, credit, inbound channel

Now reports:
	- rebalance_fee, debit, outgoing channel
	(same value as invoice_fee above)

Note: only applies on channel events; if a rebalance falls to chain
we'll use the older style of accounting.

Changelog-None