### PR TITLE
bkpr: make unit tests not fail if !HAVE_SQLITE3

### DIFF
--- a/plugins/bkpr/test/run-bkpr_db.c
+++ b/plugins/bkpr/test/run-bkpr_db.c
@@ -292,7 +292,9 @@ int main(int argc, char *argv[])
 
 	common_setup(argv[0]);
 
-	ok &= test_db_migrate(plugin);
+	if (HAVE_SQLITE3) {
+		ok &= test_db_migrate(plugin);
+	}
 
 	tal_free(plugin);
 	common_shutdown();

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -1315,13 +1315,15 @@ int main(int argc, char *argv[])
 
 	common_setup(argv[0]);
 
-	ok &= test_account_crud(tmpctx, plugin);
-	ok &= test_channel_event_crud(tmpctx, plugin);
-	ok &= test_chain_event_crud(tmpctx, plugin);
-	ok &= test_account_balances(tmpctx, plugin);
-	ok &= test_onchain_fee_chan_close(tmpctx, plugin);
-	ok &= test_onchain_fee_chan_open(tmpctx, plugin);
-	ok &= test_onchain_fee_wallet_spend(tmpctx, plugin);
+	if (HAVE_SQLITE3) {
+		ok &= test_account_crud(tmpctx, plugin);
+		ok &= test_channel_event_crud(tmpctx, plugin);
+		ok &= test_chain_event_crud(tmpctx, plugin);
+		ok &= test_account_balances(tmpctx, plugin);
+		ok &= test_onchain_fee_chan_close(tmpctx, plugin);
+		ok &= test_onchain_fee_chan_open(tmpctx, plugin);
+		ok &= test_onchain_fee_wallet_spend(tmpctx, plugin);
+	}
 
 	tal_free(plugin);
 	common_shutdown();


### PR DESCRIPTION
We rely on sqlite3 being present to run unit tests for some bookkeeper
tests; here we effectively disable these tests if not available

Fixes report in #4928
Reported-By: @whitslack