### PR TITLE
chore: remove EXPERIMENTAL for DNS Bolt7

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -766,14 +766,12 @@ static void try_connect_one_addr(struct connecting *connect)
 	bool use_proxy = connect->daemon->always_use_proxy;
 	const struct wireaddr_internal *addr = &connect->addrs[connect->addrnum];
 	struct io_conn *conn;
-#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	bool use_dns = connect->daemon->use_dns;
 	struct addrinfo hints, *ais, *aii;
 	struct wireaddr_internal addrhint;
 	int gai_err;
 	struct sockaddr_in *sa4;
 	struct sockaddr_in6 *sa6;
-#endif
 
 	assert(!connect->conn);
 
@@ -823,7 +821,6 @@ static void try_connect_one_addr(struct connecting *connect)
 			af = AF_INET6;
 			break;
 		case ADDR_TYPE_DNS:
-#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 			if (use_proxy) /* hand it to the proxy */
 				break;
 			if (!use_dns) {  /* ignore DNS when we can't use it */
@@ -875,12 +872,6 @@ static void try_connect_one_addr(struct connecting *connect)
 				addr = &connect->addrs[connect->addrnum];
 			}
 			freeaddrinfo(ais);
-#endif
-			tal_append_fmt(&connect->errors,
-				       "%s: EXPERIMENTAL_FEATURES needed. ",
-				       type_to_string(tmpctx,
-						      struct wireaddr_internal,
-						      addr));
 			goto next;
 		case ADDR_TYPE_WEBSOCKET:
 			af = -1;
@@ -1636,10 +1627,8 @@ static void add_seed_addrs(struct wireaddr_internal **addrs,
 		                                   NULL, broken_reply, NULL);
 		if (new_addrs) {
 			for (size_t j = 0; j < tal_count(new_addrs); j++) {
-#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 				if (new_addrs[j].type == ADDR_TYPE_DNS)
 					continue;
-#endif
 				struct wireaddr_internal a;
 				a.itype = ADDR_INTERNAL_WIREADDR;
 				a.u.wireaddr = new_addrs[j];

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -195,7 +195,6 @@ static char *opt_set_accept_extra_tlv_types(const char *arg,
 }
 #endif
 
-#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 /* Returns the number of wireaddr types already announced */
 static size_t num_announced_types(enum wire_addr_type type, struct lightningd *ld)
 {
@@ -210,7 +209,6 @@ static size_t num_announced_types(enum wire_addr_type type, struct lightningd *l
 	}
 	return num;
 }
-#endif
 
 static char *opt_add_addr_withtype(const char *arg,
 				   struct lightningd *ld,
@@ -257,7 +255,6 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
 
-#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	/* Add ADDR_TYPE_DNS to announce DNS hostnames */
 	if (is_dnsaddr(address) && ala & ADDR_ANNOUNCE) {
 		/* BOLT-hostnames #7:
@@ -282,7 +279,6 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_listen_announce, ADDR_ANNOUNCE);
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
-#endif
 
 	return NULL;
 


### PR DESCRIPTION
This has been merged https://github.com/lightning/bolts/pull/911
Should we remove EXPERIMENTAL?

Changelog-Changed: DNS annoucenent support is no longer EXPERIMENTAL