### PR TITLE
lightningd: fix funding_locked in channel_opened notification.

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1631,7 +1631,7 @@ static void handle_peer_tx_sigs_sent(struct subd *dualopend,
 					      &channel->peer->id,
 					      &channel->funding_sats,
 					      &channel->funding.txid,
-					      &channel->remote_funding_locked);
+					      channel->remote_funding_locked);
 
 		/* BOLT-f53ca2301232db780843e894f55d95d512f297f9 #2
 		 * The receiving node:  ...
@@ -1997,7 +1997,7 @@ static void handle_peer_tx_sigs_msg(struct subd *dualopend,
 					      &channel->peer->id,
 					      &channel->funding_sats,
 					      &channel->funding.txid,
-					      &channel->remote_funding_locked);
+					      channel->remote_funding_locked);
 
 		/* BOLT-f53ca2301232db780843e894f55d95d512f297f9 #2
 		 * The receiving node:  ...

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -201,7 +201,7 @@ static void channel_opened_notification_serialize(struct json_stream *stream,
 						  struct node_id *node_id,
 						  struct amount_sat *funding_sat,
 						  struct bitcoin_txid *funding_txid,
-						  bool *funding_locked)
+						  bool funding_locked)
 {
 	json_object_start(stream, "channel_opened");
 	json_add_node_id(stream, "id", node_id);
@@ -216,13 +216,13 @@ REGISTER_NOTIFICATION(channel_opened,
 
 void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
 			   struct amount_sat *funding_sat, struct bitcoin_txid *funding_txid,
-			   bool *funding_locked)
+			   bool funding_locked)
 {
 	void (*serialize)(struct json_stream *,
 			  struct node_id *,
 			  struct amount_sat *,
 			  struct bitcoin_txid *,
-			  bool *) = channel_opened_notification_gen.serialize;
+			  bool) = channel_opened_notification_gen.serialize;
 
 	struct jsonrpc_notification *n
 		= jsonrpc_notification_start(NULL, channel_opened_notification_gen.topic);

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -47,7 +47,7 @@ void notify_invoice_creation(struct lightningd *ld, struct amount_msat *amount,
 
 void notify_channel_opened(struct lightningd *ld, struct node_id *node_id,
 			   struct amount_sat *funding_sat, struct bitcoin_txid *funding_txid,
-			   bool *funding_locked);
+			   bool funding_locked);
 
 void notify_channel_state_changed(struct lightningd *ld,
 				  struct node_id *peer_id,

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -539,7 +539,7 @@ static void opening_fundee_finished(struct subd *openingd,
 
 	/* Tell plugins about the success */
 	notify_channel_opened(ld, &channel->peer->id, &channel->funding_sats,
-			      &channel->funding.txid, &channel->remote_funding_locked);
+			      &channel->funding.txid, channel->remote_funding_locked);
 
 	if (pbase)
 		wallet_penalty_base_add(ld->wallet, channel->dbid, pbase);


### PR DESCRIPTION
Previously, "funding_locked" was always "true"!

(It's actually been wrong since its introduction in v0.7.3!)

Changelog-Fixed: Plugins: `channel_opened` notification `funding_locked` field is now accurate: was always `true`.
