### PR TITLE
Prevent a crash in `pay` when calling it in close succession

### DIFF
--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -589,7 +589,12 @@ static void on_payment_success(struct payment *payment)
 		 * `payment_finished`. */
 		if (payment == p)
 			continue;
-		if (!sha256_eq(payment->payment_hash, p->payment_hash))
+
+		/* Both groupid and payment_hash must match. This is
+		 * because when we suspended the payment itself, we
+		 * set the groupid to match. */
+		if (!sha256_eq(payment->payment_hash, p->payment_hash) ||
+		    payment->groupid != p->groupid)
 			continue;
 		if (p->cmd == NULL)
 			continue;
@@ -675,7 +680,11 @@ static void on_payment_failure(struct payment *payment)
 		 * `payment_finished`. */
 		if (payment == p)
 			continue;
-		if (!sha256_eq(payment->payment_hash, p->payment_hash))
+
+		/* When we suspended we've set the groupid to match so
+		 * we'd know which calls were duplicates. */
+		if (!sha256_eq(payment->payment_hash, p->payment_hash) ||
+		    payment->groupid != p->groupid)
 			continue;
 		if (p->cmd == NULL)
 			continue;

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -574,7 +574,7 @@ static const char *init(struct plugin *p,
 
 static void on_payment_success(struct payment *payment)
 {
-	struct payment *p;
+	struct payment *p, *nxt;
 	struct payment_tree_result result = payment_collect_result(payment);
 	struct json_stream *ret;
 	struct command *cmd;
@@ -585,7 +585,7 @@ static void on_payment_success(struct payment *payment)
 	/* Iterate through any pending payments we suspended and
 	 * terminate them. */
 
-	list_for_each(&payments, p, list) {
+	list_for_each_safe(&payments, p, nxt, list) {
 		/* The result for the active payment is returned in
 		 * `payment_finished`. */
 		if (payment == p)
@@ -672,9 +672,9 @@ static void payment_json_add_attempts(struct json_stream *s,
 
 static void on_payment_failure(struct payment *payment)
 {
-	struct payment *p;
+	struct payment *p, *nxt;
 	struct payment_tree_result result = payment_collect_result(payment);
-	list_for_each(&payments, p, list)
+	list_for_each_safe(&payments, p, nxt, list)
 	{
 		struct json_stream *ret;
 		struct command *cmd;


### PR DESCRIPTION
We were completing unrelated `pay` calls due to:

 - Not identifying suspended calls correctly when completing the original `pay` call
 - Iterating over a list while modifying it at the same time

Also fixed a small use-after-free bug.

Thanks @rustyrussell for pointing out where this might go wrong.

Fixes #5443