### PR TITLE
pay: Fix a memory leak when retrying getroute

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -809,6 +809,10 @@ static struct command_result *payment_getroute(struct payment *p)
 	const char *errstr;
 	struct gossmap *gossmap;
 
+	/* If we retry the getroute call we might already have a route, so
+	 * free an eventual stale route. */
+	p->route = tal_free(p->route);
+
 	gossmap = get_gossmap(p->plugin);
 
 	dst = gossmap_find_node(gossmap, p->getroute->destination);


### PR DESCRIPTION
If we retry a getroute call we could end up losing track of a prior route. This could happen if we were unable to apply the channel hints due to insufficient balance or number of HTLCs.