### PR TITLE
bookkeeper: dont skip zero balance channels that are missing

### DIFF
--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -911,7 +911,6 @@ listpeers_multi_done(struct command *cmd,
 		if (err)
 			plugin_err(cmd->plugin, err);
 
-		plugin_log(cmd->plugin, LOG_DBG, "Snapshot balances updated");
 		log_journal_entry(info->acct,
 				  info->currency,
 				  info->timestamp - 1,

--- a/plugins/bkpr/incomestmt.c
+++ b/plugins/bkpr/incomestmt.c
@@ -225,6 +225,10 @@ static struct income_event *paid_invoice_fee(const tal_t *ctx,
 static struct income_event *maybe_channel_income(const tal_t *ctx,
 						 struct channel_event *ev)
 {
+	if (amount_msat_zero(ev->credit)
+	    && amount_msat_zero(ev->debit))
+		return NULL;
+
 	/* We record a +/- penalty adj, but we only count the credit */
 	if (streq(ev->tag, "penalty_adj")) {
 		if (!amount_msat_zero(ev->credit))

--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -766,7 +766,8 @@ char *account_get_balance(const tal_t *ctx,
 			  const char *acct_name,
 			  bool calc_sum,
 			  bool skip_ignored,
-			  struct acct_balance ***balances)
+			  struct acct_balance ***balances,
+			  bool *account_exists)
 {
 	struct db_stmt *stmt;
 
@@ -787,6 +788,8 @@ char *account_get_balance(const tal_t *ctx,
 	db_bind_int(stmt, 1, skip_ignored ? 1 : 2);
 	db_query_prepared(stmt);
 	*balances = tal_arr(ctx, struct acct_balance *, 0);
+	if (account_exists)
+		*account_exists = false;
 
 	while (db_step(stmt)) {
 		struct acct_balance *bal;
@@ -797,6 +800,9 @@ char *account_get_balance(const tal_t *ctx,
 		db_col_amount_msat(stmt, "credit", &bal->credit);
 		db_col_amount_msat(stmt, "debit", &bal->debit);
 		tal_arr_expand(balances, bal);
+
+		if (account_exists)
+			*account_exists = true;
 	}
 	tal_free(stmt);
 

--- a/plugins/bkpr/recorder.h
+++ b/plugins/bkpr/recorder.h
@@ -99,7 +99,8 @@ char *account_get_balance(const tal_t *ctx,
 			  const char *acct_name,
 			  bool calc_sum,
 			  bool skip_ignored,
-			  struct acct_balance ***balances);
+			  struct acct_balance ***balances,
+			  bool *account_exists);
 
 /* Get chain fees for account */
 struct onchain_fee **account_get_chain_fees(const tal_t *ctx, struct db *db,

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -539,15 +539,18 @@ def test_bookkeeping_onchaind_txs(node_factory, bitcoind):
     Test for a channel that's closed, but whose close tx
     re-appears in the rescan
     """
+    coin_mvt_plugin = Path(__file__).parent / "plugins" / "coin_movements.py"
     l1, l2 = node_factory.line_graph(2,
                                      wait_for_announce=True,
-                                     opts={'disable-plugin': 'bookkeeper'})
+                                     opts={'disable-plugin': 'bookkeeper',
+                                           'plugin': str(coin_mvt_plugin)})
 
     # Double check there's no bookkeeper plugin on
     assert l1.daemon.opts['disable-plugin'] == 'bookkeeper'
 
     # Send l2 funds via the channel
     l1.pay(l2, 11000000)
+    l1.daemon.wait_for_log(r'coin movement:.*\'invoice\'')
     bitcoind.generate_block(10)
 
     # Amicably close the channel, mine 101 blocks (channel forgotten)

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -473,6 +473,7 @@ def test_bookkeeping_missed_chans_pay_after(node_factory, bitcoind):
     """
     coin_mvt_plugin = Path(__file__).parent / "plugins" / "coin_movements.py"
     l1, l2 = node_factory.get_nodes(2, opts={'disable-plugin': 'bookkeeper',
+                                             'may_reconnect': True,
                                              'plugin': str(coin_mvt_plugin)})
 
     # Double check there's no bookkeeper plugin on

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -1331,9 +1331,14 @@ def test_forward_pad_fees_and_cltv(node_factory, bitcoind):
     wait_for(lambda: len(_income_tagset(l1, tags)) == 2)
     incomes = _income_tagset(l1, tags)
     # the balance on l3 should equal the invoice
-    bal = only_one(only_one(l3.rpc.bkpr_listbalances()['accounts'])['balances'])['balance_msat']
+    accts = l3.rpc.bkpr_listbalances()['accounts']
+    assert len(accts) == 2
+    wallet = accts[0]
+    chan_acct = accts[1]
+    assert wallet['account'] == 'wallet'
+    assert only_one(wallet['balances'])['balance_msat'] == Millisatoshi(0)
     assert incomes[0]['tag'] == 'invoice'
-    assert Millisatoshi(bal) == incomes[0]['debit_msat']
+    assert only_one(chan_acct['balances'])['balance_msat'] == incomes[0]['debit_msat']
     inve = only_one([e for e in l1.rpc.bkpr_listaccountevents()['events'] if e['tag'] == 'invoice'])
     assert inve['debit_msat'] == incomes[0]['debit_msat'] + incomes[1]['debit_msat']
 


### PR DESCRIPTION
We weren't adding zero balance channels during "catch up starts (accounting for things missing while bookkeeper wasn't running)", which resulted in a crash/restart when any payment got routed through these channels.

Also patches a flake (which really needs a nicer fix than this line/by line patch but yolo) and removes a duplicated log statement.

Changelog-None.