### PR TITLE
Don't crash if the PSBT is junk

### DIFF
--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -502,7 +502,8 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 			tal_wally_start();
 			if (wally_psbt_sign(psbt, privkey.secret.data,
 					    sizeof(privkey.secret.data),
-					    EC_FLAG_GRIND_R) != WALLY_OK)
+					    EC_FLAG_GRIND_R) != WALLY_OK) {
+				tal_wally_end(psbt);
 				hsmd_status_broken(
 				    "Received wally_err attempting to "
 				    "sign utxo with key %s. PSBT: %s",
@@ -510,6 +511,7 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 						   &pubkey),
 				    type_to_string(tmpctx, struct wally_psbt,
 						   psbt));
+			}
 			tal_wally_end(psbt);
 		}
 	}

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -789,8 +789,9 @@ static struct command_result *json_signpsbt(struct command *cmd,
 	msg = wire_sync_read(cmd, cmd->ld->hsm_fd);
 
 	if (!fromwire_hsmd_sign_withdrawal_reply(cmd, msg, &signed_psbt))
-		fatal("HSM gave bad sign_withdrawal_reply %s",
-		      tal_hex(tmpctx, msg));
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "HSM gave bad sign_withdrawal_reply %s",
+				    tal_hex(tmpctx, msg));
 
 	response = json_stream_success(cmd);
 	json_add_psbt(response, "signed_psbt", signed_psbt);


### PR DESCRIPTION
If you pass in a PSBT that's invalid (no inputs/outputs for example), lightningd blows up in the HSM.

Instead, let's catch bad PSBTs before we get that far.

Also uncovered a kinda fun "double entrance" into `tal_wally` code.

Waiting for confirmation from @fiatjaf 