### PR TITLE
use 'postgres' driver (not postgresql). Include plain url to guide, as link is broken on RTD.

### DIFF
--- a/doc/BACKUP.md
+++ b/doc/BACKUP.md
@@ -327,13 +327,15 @@ it just gains the option to use a PostgreSQL database as well.
 If you just want to use PostgreSQL without using a cluster (for
 example, as an initial test without risking any significant funds),
 then after setting up a PostgreSQL database, you just need to add
-`--wallet=postgresql://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}`
+`--wallet=postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}`
 to your `lightningd` config or invocation.
 
 To set up a cluster for a brand new node, follow this (external)
 [guide by @gabridome][gabridomeguide].
 
 [gabridomeguide]: https://github.com/gabridome/docs/blob/master/c-lightning_with_postgresql_reliability.md
+
+(plain url in case of broken link on RTD: https://github.com/gabridome/docs/blob/master/c-lightning_with_postgresql_reliability.md).
 
 The above guide assumes you are setting up a new node from scratch.
 It is also specific to PostgreSQL 12, and setting up for other versions


### PR DESCRIPTION
BACKUP.md has:

```
--wallet=postgresql://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}
```

Which should be:

```
--wallet=postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}
```

Currently this leads to the "Unable to find db driver for postgresql" issue.

Also, on readthedocs, the link to:

https://github.com/gabridome/docs/blob/master/c-lightning_with_postgresql_reliability.md

is broken. RTD seems to remove the .md extension, which compounds the confusion after running into the db driver not found error.

Creating a PR in the docs branch although it seems stale. Will also create this same PR in master.