### PR TITLE
Strip "NULLS FIRST" from sqlite3 queries

### DIFF
--- a/devtools/sql-rewrite.py
+++ b/devtools/sql-rewrite.py
@@ -51,6 +51,8 @@ class Sqlite3Rewriter(Rewriter):
             r'decode\((.*),\s*[\'\"]hex[\'\"]\)': 'x\\1',
             # GREATEST() of multiple columns is simple MAX in sqlite3.
             r'GREATEST\(([^)]*)\)': "MAX(\\1)",
+            # NULLS FIRST is default behavior on sqlite, make it disappear
+            r' NULLS FIRST': '',
         }
         return self.rewrite_types(query, typemapping)
 

--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -72,6 +72,8 @@ static struct chain_event **find_chain_events(const tal_t *ctx,
 	struct chain_event **results;
 
 	db_query_prepared(stmt);
+	if (stmt->error)
+		db_fatal("find_chain_events err: %s", stmt->error);
 	results = tal_arr(ctx, struct chain_event *, 0);
 	while (db_step(stmt)) {
 		struct chain_event *e = stmt2chain_event(results, stmt);

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -697,6 +697,7 @@ static bool test_onchain_fee_chan_close(const tal_t *ctx, struct plugin *p)
 	CHECK(acct->onchain_resolved_block == 0);
 	db_begin_transaction(db);
 	maybe_mark_account_onchain(db, acct);
+	CHECK_MSG(!db_err, db_err);
 	CHECK(acct->onchain_resolved_block == blockheight + 2);
 	err = update_channel_onchain_fees(ctx, db, acct);
 	CHECK_MSG(!err, err);


### PR DESCRIPTION
Keywords were added "recently" (2019) and were causing silent failures in updates on machines using older versions of sqlite3.

These patches strip the keywords out for sqlite3 (which is fine, nulls first *is* the default behavior on sqlite3, it was only problematic on postgres). 

Nicer fix would be to allow for versioning of queries depending on sqlite3 version but yolo?

Changelog-None