### PR TITLE
fix: Zeroconf in combination with multiple channels tries to log a non-existent scid

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -660,6 +660,7 @@ static void forward_htlc(struct htlc_in *hin,
 	struct lightningd *ld = hin->key.channel->peer->ld;
 	struct channel *next;
 	struct htlc_out *hout = NULL;
+	struct short_channel_id *altscid;
 
 	/* This is a shortcut for specifying next peer; doesn't mean
 	 * the actual channel! */
@@ -687,10 +688,14 @@ static void forward_htlc(struct htlc_in *hin,
 					     channel->channel_info.their_config.htlc_minimum))
 				continue;
 
+			altscid = channel->scid != NULL ? channel->scid
+							: channel->alias[LOCAL];
+
 			/* OK, it's better! */
 			log_debug(next->log, "Chose a better channel: %s",
-				  type_to_string(tmpctx, struct short_channel_id,
-						 channel->scid));
+				  type_to_string(tmpctx,
+						 struct short_channel_id,
+						 altscid));
 			next = channel;
 		}
 	}

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1577,7 +1577,6 @@ def test_scid_alias_private(node_factory, bitcoind):
     l1.rpc.waitsendpay(inv['payment_hash'])
 
 
-@pytest.mark.xfail("Reproducing a crash", strict=True)
 def test_zeroconf_multichan_forward(node_factory):
     """The freedom to choose the forward channel bytes us when it is 0conf
 


### PR DESCRIPTION
When forwarding an HTLC we're allowed to pick another channel than the one specified in the onion. We do so if using another channel is advantageous. In this case we'd have a confirmed channel and a zeroconf channel in parallel, and the latter would be picked because it is advantageous (more `spendable_msat`), and we'd try to log its `scid`. However the `scid` for a zeroconf channel is not set until it gets at least one confirmation, causing a NULL-access.