### PR TITLE
docs: use 'postgres' driver (not postgresql). Include plain url to guide

### DIFF
--- a/doc/BACKUP.md
+++ b/doc/BACKUP.md
@@ -394,13 +394,13 @@ it just gains the option to use a PostgreSQL database as well.
 If you just want to use PostgreSQL without using a cluster (for
 example, as an initial test without risking any significant funds),
 then after setting up a PostgreSQL database, you just need to add
-`--wallet=postgresql://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}`
+`--wallet=postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${DB}`
 to your `lightningd` config or invocation.
 
 To set up a cluster for a brand new node, follow this (external)
 [guide by @gabridome][gabridomeguide].
 
-[gabridomeguide]: https://github.com/gabridome/docs/blob/master/c-lightning_with_postgresql_reliability.md
+[gabridomeguide]: https://bit.ly/3KffmN3
 
 The above guide assumes you are setting up a new node from scratch.
 It is also specific to PostgreSQL 12, and setting up for other versions


### PR DESCRIPTION
Apologies @lightningorb, I have no idea what happened to #5521, so I'm reopening the PR with this amended changeset.