### PR TITLE
plugin: make the plugin aware of deprecated api flag

### DIFF
--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -337,7 +337,8 @@ simple JSON object containing the options:
         "port": 9050
     },
     "torv3-enabled": true,
-    "always_use_proxy": false
+    "always_use_proxy": false,
+    "deprecated-api-allowed": false,
   }
 }
 ```

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1882,6 +1882,7 @@ plugin_populate_init_request(struct plugin *plugin, struct jsonrpc_request *req)
 	json_add_string(req->stream, "rpc-file", ld->rpc_filename);
 	json_add_bool(req->stream, "startup", plugin->plugins->startup);
 	json_add_string(req->stream, "network", chainparams->network_name);
+	json_add_bool(req->stream, "deprecated-api-allowed", deprecated_apis);
 	if (ld->proxyaddr) {
 		json_add_address(req->stream, "proxy", ld->proxyaddr);
 		json_add_bool(req->stream, "torv3-enabled", true);


### PR DESCRIPTION
This PR put the deprecated apis flag inside the plugin init payload to give the possibility to a plugin to be aware of some deprecated API, and more important to adopt the same deprecated workflow of core lightning in case this plugin will proxy some cln command.

Use case covered:

- Give the plugin the possibility to use old API if available, or avoid to use it. eg: splitting listpeers in 2 different command.
- Be able to deprecated some field in the plugin and follow the same rules of cln.

Changelog-Added: plugin: add deprecated api flag in the plugin init method.

Release target > 0.12.0