### PR TITLE
doc: update usage of lightning-invoice.

### DIFF
--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -4,7 +4,7 @@ lightning-invoice -- Command for accepting payments
 SYNOPSIS
 --------
 
-**invoice** *msatoshi* *label* *description* [*expiry*]
+**invoice** *amount_msat* *label* *description* [*expiry*]
 [*fallbacks*] [*preimage*] [*exposeprivatechannels*] [*cltv*] [*deschashonly*]
 
 DESCRIPTION
@@ -16,7 +16,7 @@ lightning daemon can use to pay this invoice. This token includes a
 *route hint* description of an incoming channel with capacity to pay the
 invoice, if any exists.
 
-The *msatoshi* parameter can be the string "any", which creates an
+The *amount_msat* parameter can be the string "any", which creates an
 invoice that can be paid with any amount. Otherwise it is a positive value in
 millisatoshi precision; it can be a whole number, or a whole number
 ending in *msat* or *sat*, or a number with three decimal places ending


### PR DESCRIPTION
The new parameter name (this version) is amount_msat: msatoshi is
deprecated.   The doc/schemas/invoice.request.json has this correct
(but we don't generate teh *usage* line from that yet!)

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>