### PR TITLE
Skip over saved channels while recovering from emergencyrecover

### DIFF
--- a/doc/lightning-staticbackup.7.md
+++ b/doc/lightning-staticbackup.7.md
@@ -1,4 +1,4 @@
-lightning-staticbacup -- Command for deriving getting SCB of all the existing channels
+lightning-staticbackup -- Command for deriving getting SCB of all the existing channels
 ======================================================================================
 
 SYNOPSIS

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2312,6 +2312,8 @@ def test_emergencyrecover(node_factory, bitcoind):
     l1, l2 = node_factory.get_nodes(2, opts=[{}, {}])
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     c12, _ = l1.fundchannel(l2, 10**5)
+    stubs = l1.rpc.emergencyrecover()["stubs"]
+    assert l1.daemon.is_in_log('channel {} already exists!'.format(_['channel_id']))
 
     l1.stop()
 
@@ -2322,6 +2324,7 @@ def test_emergencyrecover(node_factory, bitcoind):
     stubs = l1.rpc.emergencyrecover()["stubs"]
     assert len(stubs) == 1
     assert stubs[0] == _["channel_id"]
+    assert l1.daemon.is_in_log('channel {} already exists!'.format(_['channel_id']))
 
     listfunds = l1.rpc.listfunds()["channels"][0]
     assert listfunds["short_channel_id"] == "1x1x1"


### PR DESCRIPTION
Currently, If a user uses `emergencyrecover` and they already have the channels stored in the Database, it throws a UNIQUE constraint error and the node goes down. Which is horrible UX. So now, we check for every channel and skip over those which are already stored.

This completely slipped out of my mind while developing, All thanks to @niftynei for being patient with me, and reminding me about this.