### PR TITLE
lightningd: refuse to upgrade db on non-released versions by default.

### DIFF
--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -62,6 +62,7 @@ On success, an object is returned, containing:
 - **experimental-offers** (boolean, optional): `experimental-offers` field from config or cmdline, or default
 - **experimental-shutdown-wrong-funding** (boolean, optional): `experimental-shutdown-wrong-funding` field from config or cmdline, or default
 - **experimental-websocket-port** (u16, optional): `experimental-websocket-port` field from config or cmdline, or default
+- **database-upgrade** (boolean, optional): `database-upgrade` field from config or cmdline
 - **rgb** (hex, optional): `rgb` field from config or cmdline, or default (always 6 characters)
 - **alias** (string, optional): `alias` field from config or cmdline, or default
 - **pid-file** (string, optional): `pid-file` field from config or cmdline, or default
@@ -215,4 +216,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:14fa07df1432e7104983afc4fba02cc462237bd1a154ba3f3750355d10ffdadb)
+[comment]: # ( SHA256STAMP:dcab86f29b946fed925de5e05cb79faa03cc4421cefeab3561a596ed5e64962d)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -60,7 +60,17 @@ fun to put in other's config files while their computer is unattended.
 putting this in someone's config file may convince them to read this man
 page.
 
+* **database-upgrade**=*BOOL*
+
+  Upgrades to Core Lightning often change the database: once this is done,
+downgrades are not generally possible.  By default, Core Lightning will
+exit with an error rather than upgrade, unless this is an official released
+version.  If you really want to upgrade to a non-release version, you can
+set this to *true* (or *false* to never allow a non-reversible upgrade!).
+
 ### Bitcoin control options:
+
+Bitcoin control options:
 
 * **network**=*NETWORK*
 

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -137,6 +137,10 @@
       "type": "u16",
       "description": "`experimental-websocket-port` field from config or cmdline, or default"
     },
+    "database-upgrade": {
+      "type": "boolean",
+      "description": "`database-upgrade` field from config or cmdline"
+    },
     "rgb": {
       "type": "hex",
       "description": "`rgb` field from config or cmdline, or default",

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -213,6 +213,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->autolisten = true;
 	ld->reconnect = true;
 	ld->try_reexec = false;
+	ld->db_upgrade_ok = NULL;
 
 	/*~ This is from ccan/timer: it is efficient for the case where timers
 	 * are deleted before expiry (as is common with timeouts) using an

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -221,6 +221,9 @@ struct lightningd {
 	 * FEERATE_PENALTY). */
 	u32 *force_feerates;
 
+	/* If they force db upgrade on or off this is set. */
+	bool *db_upgrade_ok;
+
 #if DEVELOPER
 	/* If we want to debug a subdaemon/plugin. */
 	const char *dev_debug_subprocess;

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -49,7 +49,7 @@ def test_names(node_factory):
 
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This migration is based on a sqlite3 snapshot")
 def test_db_upgrade(node_factory):
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={'database-upgrade': True})
     l1.stop()
 
     version = subprocess.check_output(['lightningd/lightningd',


### PR DESCRIPTION
This is a good sanity check that users understand that if they upgrade
to master mid-cycle they can't go back!

Suggested-by: @wtogami
Changelog-Added: Config: `--database-upgrade=true` required if a non-release version wants to (irrevocably!) upgrade the db.