### PR TITLE
test: add in `test_penalty_htlc_tx_fulfill` while running waitsendpay the part_id (by guessing)

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -12,6 +12,7 @@ from utils import (
 )
 
 import os
+import logging
 import queue
 import pytest
 import re
@@ -1192,8 +1193,9 @@ def test_penalty_htlc_tx_fulfill(node_factory, bitcoind, chainparams):
 
     # push some money so that 1 + 4 can both send htlcs
     inv = l2.rpc.invoice(10**9 // 2, '1', 'balancer')
-    l1.rpc.pay(inv['bolt11'])
-    l1.rpc.waitsendpay(inv['payment_hash'])
+    res = l1.rpc.pay(inv['bolt11'])
+    logging.info(f"Result pay command {res}")
+    l1.rpc.waitsendpay(inv['payment_hash'], partid=res["parts"])
 
     inv = l4.rpc.invoice(10**9 // 2, '1', 'balancer')
     l2.rpc.pay(inv['bolt11'])


### PR DESCRIPTION
While working on the `listpeers` splitting resurrection in https://github.com/vincenzopalazzo/lightning/tree/macros/listpeers_resurrection I fall in a test error where the `waitsendpay` fails because there is no `partid` 0

After some debugging and asking @cdecker what this failure means I make a monkey patch that works on my branch and make the test happy, but I think I'm hiding some bug in my branch, so making this PR to try to receive some feedback as a sanity check of my guess.

Original Error

```
Never attempted payment part 0 for 'e1512dfc39cab0ad6a2aa14e285f50579ea5c348fcf2608e78873d5b030197b7
```

Previous Pay command result

```
root:test_closing.py:1199 Result pay command {'destination': '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59', 'payment_hash': 'e1512dfc39cab0ad6a2aa14e285f50579ea5c348fcf2608e78873d5b030197b7', 'created_at': 1661443638.726, 'parts': 7, 'amount_msat': 500000000msat, 'amount_sent_msat': 500000000msat, 'payment_preimage': '4e544668a07d9f8919052a23a55ecf3a6f0c513e46c112340a76971bb1cf8272', 'status': 'complete'}
```