### PR TITLE
Fix mrkd

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -63,7 +63,7 @@ jobs:
             blinker \
             flake8 \
             mako \
-            mrkd \
+            mistune \
             pytest-sentry \
             pytest-test-groups==1.0.3 \
             pytest-custom-exit-code==0.3.0 \

--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -15,7 +15,7 @@ COPY . lightning
 RUN cd lightning && \
     git submodule update --init --recursive && \
     ./configure && \
-    pip3 install mrkd mistune==0.8.4 && \
+    pip3 install mistune && \
     make -j$(nproc) && \
     make install
 

--- a/contrib/docker/Dockerfile.builder
+++ b/contrib/docker/Dockerfile.builder
@@ -66,4 +66,4 @@ RUN pip3 install --upgrade pip && \
 	pytest-test-groups==1.0.3 \
 	flake8==3.5.0 \
 	pytest-rerunfailures==3.1 \
-	mrkd==0.1.6
+        mistune==2.0.4

--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -32,4 +32,4 @@ RUN wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_
     rm -rf bitcoin.tar.gz bitcoin-$BITCOIN_VERSION
 
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib==0.10.2 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 mrkd==0.1.6
+    python3 -m pip install python-bitcoinlib==0.10.2 pytest==3.0.5 setuptools==36.6.0 pytest-test-groups==1.0.3 flake8==3.5.0 pytest-rerunfailures==3.1 ephemeral-port-reserve==1.1.0 mistune==2.0.4

--- a/contrib/docker/linuxarm32v7.Dockerfile
+++ b/contrib/docker/linuxarm32v7.Dockerfile
@@ -92,7 +92,7 @@ RUN git clone --recursive /tmp/lightning . && \
 
 ARG DEVELOPER=0
 ENV PYTHON_VERSION=3
-RUN pip3 install mrkd
+RUN pip3 install mistune
 RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVELOPER=${DEVELOPER} && make install
 
 FROM arm32v7/debian:buster-slim as final

--- a/contrib/docker/linuxarm64v8.Dockerfile
+++ b/contrib/docker/linuxarm64v8.Dockerfile
@@ -91,7 +91,7 @@ RUN git clone --recursive /tmp/lightning . && \
 
 ARG DEVELOPER=0
 ENV PYTHON_VERSION=3
-RUN pip3 install mrkd
+RUN pip3 install mistune
 RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVELOPER=${DEVELOPER} && make install
 
 FROM arm64v8/debian:buster-slim as final

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -75,7 +75,7 @@ There are two ways to build core lightning, and this depends on how you want use
 To build cln to just install a tagged or master version you can use the following commands:
 
     pip3 install --upgrade pip
-    pip3 install mako mistune==0.8.4 mrkd
+    pip3 install mako mistune
     ./configure
     make
     sudo make install
@@ -174,7 +174,7 @@ fiddle with compile time options:
 
     # cd /usr/ports/net-p2p/c-lightning && make install
 
-mrkd is required to build man pages from markdown files (not done by the port):
+mistune is required to build man pages from markdown files (not done by the port):
 
     # cd /usr/ports/devel/py-pip && make install
     $ pip install --user poetry
@@ -209,7 +209,7 @@ pkg_add git python gmake py3-pip libtool gmp
 pkg_add automake # (select highest version, automake1.16.2 at time of writing)
 pkg_add autoconf # (select highest version, autoconf-2.69p2 at time of writing)
 ```
-Install `mako` and `mrkd` otherwise we run into build errors:
+Install `mako` and `mistune` otherwise we run into build errors:
 ```
 pip3.7 install --user poetry
 poetry install

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -125,10 +125,8 @@ RBRACKET=)
 $(MARKDOWN_WITH_SCHEMA): doc/lightning-%.7.md: doc/schemas/%.schema.json tools/fromschema.py
 	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE, "fromschema $@", tools/fromschema.py --markdownfile=$@ doc/schemas/$*.schema.json > $@.tmp && grep -v SHA256STAMP: $@.tmp > $@ && rm -f $@.tmp && $(call SHA256STAMP,[comment]: # $(LBRACKET),$(RBRACKET))); else touch $@; fi
 
-# mrkd doesn't format nested lists properly, so we fixup with sed (see doc/lightning-connect.7
-# and https://github.com/refi64/mrkd/issues/4
-$(MANPAGES): doc/%: doc/%.md
-	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE, "mrkd $<", mrkd $< $@.tmp && sed -e 's/\(.\)\.RS$$/\1\n.RS/' < $@.tmp > $@ && rm $@.tmp && $(call SHA256STAMP,\\\",)); else touch $@; fi
+$(MANPAGES): doc/%: doc/%.md tools/mrkd.py
+	@if $(call SHA256STAMP_CHANGED); then $(call VERBOSE, "tools/mrkd.py $<", tools/mrkd.py $< $@ && $(call SHA256STAMP,\\\",)); else touch $@; fi
 
 $(MANPAGES): $(FORCE)
 $(MARKDOWN_WITH_SCHEMA): $(FORCE)

--- a/doc/lightning-delpay.7.md
+++ b/doc/lightning-delpay.7.md
@@ -101,4 +101,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:ecdf9fe432142054328abb6aa3f76b726968dd28db1fc26875a81f291e10135a)

--- a/doc/lightning-disableoffer.7.md
+++ b/doc/lightning-disableoffer.7.md
@@ -74,4 +74,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:d91f424d5374fd26d4d85df10f9e5eb092e5b0e1bac8dae44b98d844a55b6e22)

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -106,7 +106,7 @@ channel parameters (funding limits, channel reserves, fees, etc.).
 SEE ALSO
 --------
 
-lightning-connect(7), lightning-listfunds(), lightning-listpeers(7),
+lightning-connect(7), lightning-listfunds(7), lightning-listpeers(7),
 lightning-feerates(7), lightning-multifundchannel(7)
 
 RESOURCES

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -128,4 +128,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:aedad2e6949f96d8d331e39c17effe5786816729562987b058d146b4b94286cb)

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -90,4 +90,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:46482f3cc6b332b284cae1b1e5477b19e227cb6c1cd1086452d28f0887433cb1)

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -67,4 +67,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:881f00fb7943bc1655c054488643a4da37742b6705924f0ba33366e8cf3f2b93)

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -214,4 +214,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:999502771ada48f32011ea4df2443a2a3385d27377d8e55ec82cf283f9acd0a6)

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -95,4 +95,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:df4e056ac91672041b38811329eb7555636c7b4d4985456894255a7b8e11bf54)

--- a/doc/lightning-listoffers.7.md
+++ b/doc/lightning-listoffers.7.md
@@ -80,4 +80,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:aad235e8255da495032f638a7066b05d651e2c99b668f7b3afffb21d908c788a)

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -104,4 +104,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:4d5d2f1cea0668b3e58e73a93fe6d217ac4a8c740bed09fcdce21c9e72daae99)

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -158,4 +158,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:49c7f69eb4b532802c465ac5d0421cdad176f6a28c4c8e4c1c3ee0a94faad5bf)

--- a/doc/lightning-multiwithdraw.7.md
+++ b/doc/lightning-multiwithdraw.7.md
@@ -71,4 +71,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:1fe5147036f714c8f9185dd482a1bfa3e3ac5c4d0b6603fba1bc2b78de591b8f)

--- a/doc/lightning-notifications.7.md
+++ b/doc/lightning-notifications.7.md
@@ -102,4 +102,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:c801b02463804504c2387387a36a6739351330a2c496aaa10de2b1f49c36ed32)

--- a/doc/lightning-openchannel_abort.7.md
+++ b/doc/lightning-openchannel_abort.7.md
@@ -54,4 +54,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:014c926a7202b951a2407b1a9996c90d4dd68aadfdbdb04311b280c016d538dc)

--- a/doc/lightning-openchannel_bump.7.md
+++ b/doc/lightning-openchannel_bump.7.md
@@ -80,4 +80,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:2846dc5350c8a1ac5d0e33fc52a37f5e535e6db5b4080ae2be9c3df428ccf122)

--- a/doc/lightning-openchannel_init.7.md
+++ b/doc/lightning-openchannel_init.7.md
@@ -102,4 +102,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:70ebfff5ce81962cf574b39cb3d95206b1f1541d24b8a3a0380b6f0b594d0ca4)

--- a/doc/lightning-openchannel_signed.7.md
+++ b/doc/lightning-openchannel_signed.7.md
@@ -66,4 +66,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:304d819b092e1d9ce7b4cd8ef08ecdd7952b454fed59e908ab1af02b50e9a0b0)

--- a/doc/lightning-openchannel_update.7.md
+++ b/doc/lightning-openchannel_update.7.md
@@ -71,4 +71,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:1a29b970038901773c6712c5e9267ae2c0ed3e9d4b11543d287c272a031003c1)

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -69,4 +69,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:59da52931ba9cb4c192ab81973efed2246baa9a97aded29e2c4cf280972c9a9a)

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -65,4 +65,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:1fe5147036f714c8f9185dd482a1bfa3e3ac5c4d0b6603fba1bc2b78de591b8f)

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -71,4 +71,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:a64f3742f0c66ddf203afa3f69859d4385c4156fe99c30f0931e41ce95d944b1)

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -42,4 +42,5 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
+
 [comment]: # ( SHA256STAMP:a83ac745b36e0e3d00ba11f036cec93973773f47e1265eb5c70a3d3298e58e4b)

--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1063,7 +1063,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 		    || !amount_msat_zero(debit_diff)) {
 			struct account *acct;
 			struct channel_event *ev;
-			u64 timestamp;
+			u64 timestamp_now;
 
 			/* This is *expected* on first run of bookkeeper! */
 			plugin_log(cmd->plugin,
@@ -1079,7 +1079,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 						  &credit_diff),
 				   acct_name);
 
-			timestamp = time_now().ts.tv_sec;
+			timestamp_now = time_now().ts.tv_sec;
 
 			/* Log a channel "journal entry" to get
 			 * the balances inline */
@@ -1103,7 +1103,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 					info = tal(new_accts, struct new_account_info);
 					info->acct = tal_steal(info, acct);
 					info->curr_bal = snap_balance;
-					info->timestamp = timestamp;
+					info->timestamp = timestamp_now;
 					info->currency =
 						tal_strdup(info, currency);
 

--- a/plugins/bkpr/db.c
+++ b/plugins/bkpr/db.c
@@ -126,8 +126,7 @@ static bool db_migrate(struct plugin *p, struct db *db, bool *created)
 	while (current < available) {
 		current++;
 		if (db_migrations[current].sql) {
-			struct db_stmt *stmt =
-				db_prepare_v2(db, db_migrations[current].sql);
+			stmt = db_prepare_v2(db, db_migrations[current].sql);
 			db_exec_prepared_v2(take(stmt));
 		}
 		if (db_migrations[current].func)

--- a/poetry.lock
+++ b/poetry.lock
@@ -341,8 +341,8 @@ python-versions = "*"
 
 [[package]]
 name = "mistune"
-version = "0.8.4"
-description = "The fastest markdown parser in pure Python"
+version = "2.0.4"
+description = "A sane Markdown parser with useful plugins and renderers"
 category = "main"
 optional = false
 python-versions = "*"
@@ -354,26 +354,6 @@ description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
 python-versions = ">=3.5"
-
-[[package]]
-name = "mrkd"
-version = "0.2.0"
-description = ""
-category = "main"
-optional = false
-python-versions = "*"
-develop = false
-
-[package.dependencies]
-Jinja2 = "*"
-mistune = "0.8.4"
-pygments = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/refi64/mrkd.git"
-reference = "781f05eb9898ca652f18eed29b3c956389e6a2a7"
-resolved_reference = "781f05eb9898ca652f18eed29b3c956389e6a2a7"
 
 [[package]]
 name = "mypy"
@@ -485,14 +465,6 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pygments"
-version = "2.12.0"
-description = "Pygments is a syntax highlighting package written in Python."
-category = "main"
-optional = false
-python-versions = ">=3.6"
 
 [[package]]
 name = "pyln-bolt7"
@@ -1007,7 +979,6 @@ more-itertools = [
     {file = "more-itertools-8.13.0.tar.gz", hash = "sha256:a42901a0a5b169d925f6f217cd5a190e32ef54360905b9c39ee7db5313bfec0f"},
     {file = "more_itertools-8.13.0-py3-none-any.whl", hash = "sha256:c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb"},
 ]
-mrkd = []
 mypy = [
     {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
     {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,17 +16,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "base58"
@@ -168,7 +168,7 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "flask"
-version = "2.1.2"
+version = "2.2.2"
 description = "A simple framework for building complex web applications."
 category = "dev"
 optional = false
@@ -179,11 +179,11 @@ click = ">=8.0"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.0"
 Jinja2 = ">=3.0"
-Werkzeug = ">=2.0"
+Werkzeug = ">=2.2.2"
 
 [package.extras]
-async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
+async = ["asgiref (>=3.2)"]
 
 [[package]]
 name = "grpcio"
@@ -229,7 +229,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "importlib-resources"
-version = "5.8.0"
+version = "5.9.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -239,8 +239,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -260,7 +260,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "jaraco.functools"
-version = "3.5.0"
+version = "3.5.1"
 description = "Functools like those found in stdlib"
 category = "dev"
 optional = false
@@ -270,14 +270,14 @@ python-versions = ">=3.7"
 more-itertools = "*"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.classes", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.classes", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -289,7 +289,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.7.2"
+version = "4.14.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -299,6 +299,7 @@ python-versions = ">=3.7"
 attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
@@ -308,7 +309,7 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "mako"
-version = "1.2.1"
+version = "1.2.2"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 category = "main"
 optional = false
@@ -349,7 +350,7 @@ python-versions = "*"
 
 [[package]]
 name = "more-itertools"
-version = "8.13.0"
+version = "8.14.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
@@ -391,6 +392,14 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pkgutil-resolve-name"
+version = "1.3.10"
+description = "Resolve a name to an object."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "pluggy"
@@ -649,7 +658,7 @@ testing = ["filelock"]
 
 [[package]]
 name = "python-bitcoinlib"
-version = "0.11.0"
+version = "0.11.2"
 description = "The Swiss Army Knife of the Bitcoin protocol."
 category = "dev"
 optional = false
@@ -689,24 +698,27 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "websocket-client"
-version = "1.3.3"
+version = "1.4.0"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
-optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
+optional = ["wsaccel", "python-socks"]
+docs = ["sphinx-rtd-theme (>=0.5)", "Sphinx (>=3.4)"]
 
 [[package]]
 name = "werkzeug"
-version = "2.1.2"
+version = "2.2.2"
 description = "The comprehensive WSGI web application library."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog"]
@@ -726,17 +738,19 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6c86f252c45a49ebb8dae1df12623ae1ff80040e7434a8050729df72503502bc"
+content-hash = "5682679240c1dac9ec8bb2e37ffb024250b08aaf889af6e6b2a36948a912924a"
 
 [metadata.files]
 asn1crypto = [
     {file = "asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67"},
     {file = "asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"},
 ]
-atomicwrites = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
 attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 base58 = [
     {file = "base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2"},
@@ -861,7 +875,75 @@ colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
-crc32c = []
+crc32c = [
+    {file = "crc32c-2.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:82942ed343e5c884b5c0c9aa6bb5bb47de0247df95ce5d154cc48744d5c2ffd4"},
+    {file = "crc32c-2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f641a9bd24a309637cca6c119b8aabdfe6d41bab5ea630124ee9be7891e36ba1"},
+    {file = "crc32c-2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:374d288cc1735932276bc65670db329dd9fe2af4ec323599dc40e1212b13985e"},
+    {file = "crc32c-2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b7c71a3ae1511c42b7919e6116560c08ba89479ea249f281c5bfba2b619411d"},
+    {file = "crc32c-2.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f524fd202472d041b9bddb4a51b5fff28767a9c69953dbcdeecc67ef65707c07"},
+    {file = "crc32c-2.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a070dbe10dac29c2f591a59300c37448e3c7a747b6ea18d4826b7c94a956bd"},
+    {file = "crc32c-2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8ab9df0bd9bf10f3d5bd346321d48da8a28392b1f48f7a6fa3234acebe6ee448"},
+    {file = "crc32c-2.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8948a9262d36e2aad3be74aac3ce7a1b090ab2361f7619b3f23418fa536f1b25"},
+    {file = "crc32c-2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:865bf66d86809971d4856e38085a4a15a7251b8e780f22ad52e12b50784dac25"},
+    {file = "crc32c-2.3-cp310-cp310-win32.whl", hash = "sha256:e14f4d57e004fa5a6100ea3aeb9574bee6f95965a96a382154fa40aee1fdeb5e"},
+    {file = "crc32c-2.3-cp310-cp310-win_amd64.whl", hash = "sha256:ca03d8d5b35a26e0d3eb8c7121de3e37a59042735029eabcf1c4b15343f82cdd"},
+    {file = "crc32c-2.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5612be1606eec55511ade38deec40c9f1c7647ec0407a4031e0a2e6e6a635f27"},
+    {file = "crc32c-2.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ab21f02c13dc5a0411838d0709cb4d24bcb865ea28b683b7403826c08d14e27"},
+    {file = "crc32c-2.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c1f3e28b8aec8a0f7727337fafa31f0ace38e59e054c51fecb923535c6dc6e6"},
+    {file = "crc32c-2.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed14214fcc1416e0dc63be4c88aad7f58e0f0cb2c22d578b861e8fc19d1b2d2f"},
+    {file = "crc32c-2.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:1d334d51d395f78fb649e8442341da782e63d3f9552fcfbc040995d24d4b794d"},
+    {file = "crc32c-2.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5ddf91756d6275f497d0895b8875d1f1fdac6be08a5900f4123ede2c91cd1422"},
+    {file = "crc32c-2.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:5aa6383c0a13a542c3f1eb82a02e29c1141e0a2bc63faedd0062d1c41649989f"},
+    {file = "crc32c-2.3-cp36-cp36m-win32.whl", hash = "sha256:ef1165f7f36edaae03fcf03f1ca3bdbf196a5255d656bfb17959ba0405a2c8ee"},
+    {file = "crc32c-2.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f1679f7f700f2aec3dbee4e357a2fdde53e2ec151dde4e0b52a9205fac273a90"},
+    {file = "crc32c-2.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c04a27ba3cbc7a9e34c77f402bd3a83442a2c7acd3897d2539b1a3321ed28a6a"},
+    {file = "crc32c-2.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a51ac079c44297bbf624a598cffe6f85bd0a5faf780fd75d2d5e531d42d427ef"},
+    {file = "crc32c-2.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb1fea3d9ec71f353a6c38648d074e722fff1f43c1998ae6088dbee324a1ca6"},
+    {file = "crc32c-2.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b917b73d810bcdbcd1461978ba55038dcf2bbc3b56704b0082d2f9b0d5edc7ad"},
+    {file = "crc32c-2.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0369e637d13db5c06e45a34b069ff2ba292ac881e8a44a8658ccf3edaa9c392f"},
+    {file = "crc32c-2.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:47088e524a9ec2887ae0ec519d75df40f005debf9d52f10e688f27e7cc0d339c"},
+    {file = "crc32c-2.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:fddf16ed92dcb8ee34a12bd0757d5719d3c750a9dc813d82972477885b114339"},
+    {file = "crc32c-2.3-cp37-cp37m-win32.whl", hash = "sha256:3f372a53e9cf2464421b82b41fb66d98f654284c8fc4363f51bb0f5485fdc2b4"},
+    {file = "crc32c-2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4d223e844ee61ac492f0197b62ccc2a9c23db15e4d2938e698fec6eded0daf15"},
+    {file = "crc32c-2.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4323f56908b7e5cea039122aad039fcf750974b09e4f993244d4dddb24cab561"},
+    {file = "crc32c-2.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fac1b4248625acd65985378f6b34a00b73cfc9db5b8ccc73101744de2e3dfa66"},
+    {file = "crc32c-2.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9ce72a40c17636af97e37bad2f2c11a2e740f57d4051ef586c04d1aa83db8b38"},
+    {file = "crc32c-2.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd9bc7e5599f5970fff1f9aa551639336a76d1bb1fb00f0b87704049df8ba035"},
+    {file = "crc32c-2.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:682974e2cfb199ebc4adc5eb4d493dbcf83812a031a8ecccae5a7b5bcade5d9f"},
+    {file = "crc32c-2.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:255e35719c252ce7609cb3f1c5a045783a6e0d6d7b035d507ddd82d5194c236a"},
+    {file = "crc32c-2.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:df19ab6ab3884a237388c7720b1fe617dd4893305f62383d0f96fc7980dfdf7c"},
+    {file = "crc32c-2.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:61479a60d5a2b3160a4ae17b37df119963a741fd61ca71d4792670cdf7d7ea41"},
+    {file = "crc32c-2.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e6e16d57b8103fee9fdecb38e908d9ceb70d2196bb932dba64bf7b570f44c0b9"},
+    {file = "crc32c-2.3-cp38-cp38-win32.whl", hash = "sha256:ad83e4c78379cc3e22b760e9874bc57f91a9cfb85107ccba1c6442bc1a2e2a1c"},
+    {file = "crc32c-2.3-cp38-cp38-win_amd64.whl", hash = "sha256:32c573dd861933e2390932cc10e1b78d71ee7827ee4dfcec96e23cf007a1a6d3"},
+    {file = "crc32c-2.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ad57917650af59c989b62184fc4604d6c5066fc030ced4c6e07a596000f1ab86"},
+    {file = "crc32c-2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5e076ae46ac0e4e28eb43932c5c0b8e1b8751bb7d1b0d239f18230aed7cca3bf"},
+    {file = "crc32c-2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:896bda76db13f229c1126d5e384673f78e06685e70d76fff4c5a3f65b4068b4d"},
+    {file = "crc32c-2.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:554bc2a9ccfa7c02bb8a5346fd546b65ed265965e7fea768c7f2681f2b68d6a0"},
+    {file = "crc32c-2.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6872d8728f30f2a13f95762801428cf92a7ee6f170c872be81a17b1549b69131"},
+    {file = "crc32c-2.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:327e44184826cd1c72bcd4a9b2c4badfd29501333e158460c7d3ad8b7f066588"},
+    {file = "crc32c-2.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:866d1cbe646bdef67fc225371da265f081809bcf238bf562d6874c97e7fcb0d6"},
+    {file = "crc32c-2.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c59c6ea67ab927b2ab958c7b01a6b17c9cad882e7a1da51b9c35fbc9874ff46a"},
+    {file = "crc32c-2.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d27116037f97a02f1a123ca82008ee993c28afe8590e047a6cd86aca33653cca"},
+    {file = "crc32c-2.3-cp39-cp39-win32.whl", hash = "sha256:90c46644225dc7f71b4dd499ed71ada59d061fd60aa55233270d088ee8cfcd13"},
+    {file = "crc32c-2.3-cp39-cp39-win_amd64.whl", hash = "sha256:a2427a9196c2b8b1c27d7e31cc5c9fff13af0b1411ff1565459f65554990f055"},
+    {file = "crc32c-2.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5a13d41a29d3feea5ba87def9d4dccc3362139345a24997de33fad00b656622b"},
+    {file = "crc32c-2.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8363b553b33719b37fff46378a6e96106fd9232d2e043eebb6c6da46925c7663"},
+    {file = "crc32c-2.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ec3d9257d0624fb74335f67592b6a30de5e0cfb60322ed8682e35820decac8f"},
+    {file = "crc32c-2.3-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d82fa5bb0661a7a508e62730d4d9045f53d4ab6a9211b560a014f1d58a8337cb"},
+    {file = "crc32c-2.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:5f347244590f294eaea2e92546100bd56db926305e0603a0d57a88e59f86b308"},
+    {file = "crc32c-2.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:dce1deda03c6dbe0f5ae6e3e0f8671caead64075fd19a61b1700d42a88af97c8"},
+    {file = "crc32c-2.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7d568eb07473d9bc6fb413a4d3248265212c537b80d494ab884cc5316589110"},
+    {file = "crc32c-2.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5560faa3f673183eb1e2fc2c1361cc9ab86865a1d5774baf61fec9ca6c1a696"},
+    {file = "crc32c-2.3-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8067ce072908626869b583700da6b4bfc9a538975d77232ae68a31d8af5f1ff6"},
+    {file = "crc32c-2.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:250af144edce7850a35c618b4dd1bf56436e031560228c17a7c78bf29239ceb0"},
+    {file = "crc32c-2.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4ac8738e9cd28948e40fb3a3c89a44660e4ad266f7726964200224e101f5c8ef"},
+    {file = "crc32c-2.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c74d81a00972cbe65e27e99838b44ed5e04bced971e5bfa01c27a4bd17138442"},
+    {file = "crc32c-2.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a423c098ceffbd70544d1de3e00eeb45ec4b8463ab5d8005389fbbf3243314d1"},
+    {file = "crc32c-2.3-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b04c44ad7cde9c21ad426bdfa675ba7039db82a6961c99690f9d2ff2f034c892"},
+    {file = "crc32c-2.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cea0fe7053e36a4809e5bf95989552f52c98bbc94dca9062fb5b8c976daa0f32"},
+    {file = "crc32c-2.3.tar.gz", hash = "sha256:17ce6c596ad0d53df52dcd72defb66984aeabd98fbefea7ba848a6b6bdece36a"},
+]
 cryptography = [
     {file = "cryptography-36.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:4e2dddd38a5ba733be6a025a1475a9f45e4e41139d1321f412c6b360b19070b6"},
     {file = "cryptography-36.0.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:4881d09298cd0b669bb15b9cfe6166f16fc1277b4ed0d04a22f3d6430cb30f1d"},
@@ -892,20 +974,111 @@ execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
 ]
-flake8 = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
-]
+flake8 = []
 flask = [
-    {file = "Flask-2.1.2-py3-none-any.whl", hash = "sha256:fad5b446feb0d6db6aec0c3184d16a8c1f6c3e464b511649c8918a9be100b4fe"},
-    {file = "Flask-2.1.2.tar.gz", hash = "sha256:315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477"},
+    {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
+    {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
 ]
-grpcio = []
-grpcio-tools = []
+grpcio = [
+    {file = "grpcio-1.47.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:544da3458d1d249bb8aed5504adf3e194a931e212017934bf7bfa774dad37fb3"},
+    {file = "grpcio-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:b88bec3f94a16411a1e0336eb69f335f58229e45d4082b12d8e554cedea97586"},
+    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:06c0739dff9e723bca28ec22301f3711d85c2e652d1c8ae938aa0f7ad632ef9a"},
+    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4508e8abd67ebcccd0fbde6e2b1917ba5d153f3f20c1de385abd8722545e05f"},
+    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9723784cf264697024778dcf4b7542c851fe14b14681d6268fb984a53f76df1"},
+    {file = "grpcio-1.47.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1bb9afa85e797a646bfcd785309e869e80a375c959b11a17c9680abebacc0cb0"},
+    {file = "grpcio-1.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4d9ad7122f60157454f74a850d1337ba135146cef6fb7956d78c7194d52db0fe"},
+    {file = "grpcio-1.47.0-cp310-cp310-win32.whl", hash = "sha256:0425b5577be202d0a4024536bbccb1b052c47e0766096e6c3a5789ddfd5f400d"},
+    {file = "grpcio-1.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:d0d481ff55ea6cc49dab2c8276597bd4f1a84a8745fedb4bc23e12e9fb9d0e45"},
+    {file = "grpcio-1.47.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:5f57b9b61c22537623a5577bf5f2f970dc4e50fac5391090114c6eb3ab5a129f"},
+    {file = "grpcio-1.47.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:14d2bc74218986e5edf5527e870b0969d63601911994ebf0dce96288548cf0ef"},
+    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:c79996ae64dc4d8730782dff0d1daacc8ce7d4c2ba9cef83b6f469f73c0655ce"},
+    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a24b50810aae90c74bbd901c3f175b9645802d2fbf03eadaf418ddee4c26668"},
+    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55782a31ec539f15b34ee56f19131fe1430f38a4be022eb30c85e0b0dcf57f11"},
+    {file = "grpcio-1.47.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:35dfd981b03a3ec842671d1694fe437ee9f7b9e6a02792157a2793b0eba4f478"},
+    {file = "grpcio-1.47.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:664a270d3eac68183ad049665b0f4d0262ec387d5c08c0108dbcfe5b351a8b4d"},
+    {file = "grpcio-1.47.0-cp36-cp36m-win32.whl", hash = "sha256:9298d6f2a81f132f72a7e79cbc90a511fffacc75045c2b10050bb87b86c8353d"},
+    {file = "grpcio-1.47.0-cp36-cp36m-win_amd64.whl", hash = "sha256:815089435d0f113719eabf105832e4c4fa1726b39ae3fb2ca7861752b0f70570"},
+    {file = "grpcio-1.47.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:7191ffc8bcf8a630c547287ab103e1fdf72b2e0c119e634d8a36055c1d988ad0"},
+    {file = "grpcio-1.47.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:1ec63bbd09586e5cda1bdc832ae6975d2526d04433a764a1cc866caa399e50d4"},
+    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:08307dc5a6ac4da03146d6c00f62319e0665b01c6ffe805cfcaa955c17253f9c"},
+    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:668350ea02af018ca945bd629754d47126b366d981ab88e0369b53bc781ffb14"},
+    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64e097dd08bb408afeeaee9a56f75311c9ca5b27b8b0278279dc8eef85fa1051"},
+    {file = "grpcio-1.47.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0d8a7f3eb6f290189f48223a5f4464c99619a9de34200ce80d5092fb268323d2"},
+    {file = "grpcio-1.47.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f89de64d9eb3478b188859214752db50c91a749479011abd99e248550371375f"},
+    {file = "grpcio-1.47.0-cp37-cp37m-win32.whl", hash = "sha256:67cd275a651532d28620eef677b97164a5438c5afcfd44b15e8992afa9eb598c"},
+    {file = "grpcio-1.47.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f515782b168a4ec6ea241add845ccfebe187fc7b09adf892b3ad9e2592c60af1"},
+    {file = "grpcio-1.47.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:91cd292373e85a52c897fa5b4768c895e20a7dc3423449c64f0f96388dd1812e"},
+    {file = "grpcio-1.47.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:a278d02272214ec33f046864a24b5f5aab7f60f855de38c525e5b4ef61ec5b48"},
+    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:bfdb8af4801d1c31a18d54b37f4e49bb268d1f485ecf47f70e78d56e04ff37a7"},
+    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e63e0619a5627edb7a5eb3e9568b9f97e604856ba228cc1d8a9f83ce3d0466e"},
+    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc34d182c4fd64b6ff8304a606b95e814e4f8ed4b245b6d6cc9607690e3ef201"},
+    {file = "grpcio-1.47.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a6b2432ac2353c80a56d9015dfc5c4af60245c719628d4193ecd75ddf9cd248c"},
+    {file = "grpcio-1.47.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fcd5d932842df503eb0bf60f9cc35e6fe732b51f499e78b45234e0be41b0018d"},
+    {file = "grpcio-1.47.0-cp38-cp38-win32.whl", hash = "sha256:43857d06b2473b640467467f8f553319b5e819e54be14c86324dad83a0547818"},
+    {file = "grpcio-1.47.0-cp38-cp38-win_amd64.whl", hash = "sha256:96cff5a2081db82fb710db6a19dd8f904bdebb927727aaf4d9c427984b79a4c1"},
+    {file = "grpcio-1.47.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:68b5e47fcca8481f36ef444842801928e60e30a5b3852c9f4a95f2582d10dcb2"},
+    {file = "grpcio-1.47.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0cd44d78f302ff67f11a8c49b786c7ccbed2cfef6f4fd7bb0c3dc9255415f8f7"},
+    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:4706c78b0c183dca815bbb4ef3e8dd2136ccc8d1699f62c585e75e211ad388f6"},
+    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:324e363bad4d89a8ec7124013371f268d43afd0ac0fdeec1b21c1a101eb7dafb"},
+    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b821403907e865e8377af3eee62f0cb233ea2369ba0fcdce9505ca5bfaf4eeb3"},
+    {file = "grpcio-1.47.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2061dbe41e43b0a5e1fd423e8a7fb3a0cf11d69ce22d0fac21f1a8c704640b12"},
+    {file = "grpcio-1.47.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8dbef03853a0dbe457417c5469cb0f9d5bf47401b49d50c7dad3c495663b699b"},
+    {file = "grpcio-1.47.0-cp39-cp39-win32.whl", hash = "sha256:090dfa19f41efcbe760ae59b34da4304d4be9a59960c9682b7eab7e0b6748a79"},
+    {file = "grpcio-1.47.0-cp39-cp39-win_amd64.whl", hash = "sha256:55cd8b13c5ef22003889f599b8f2930836c6f71cd7cf3fc0196633813dc4f928"},
+    {file = "grpcio-1.47.0.tar.gz", hash = "sha256:5dbba95fab9b35957b4977b8904fc1fa56b302f9051eff4d7716ebb0c087f801"},
+]
+grpcio-tools = [
+    {file = "grpcio-tools-1.47.0.tar.gz", hash = "sha256:f64b5378484be1d6ce59311f86174be29c8ff98d8d90f589e1c56d5acae67d3c"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:3edb04d102e0d6f0149d93fe8cf69a38c20a2259a913701a4c35c119049c8404"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:dd5d330230038374e64fc652fc4c1b25d457a8b67b9069bfce83a17ab675650b"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:498c0bae4975683a5a33b72cf1bd64703b34c826871fd3ee8d295407cd5211ec"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1de1f139f05ab6bbdabc58b06f6ebb5940a92214bbc7246270299387d0af2ae"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fccc282ee97211a33652419dcdfd24a9a60bbd2d56f5c5dd50c7186a0f4d978"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:441a0a378117447c089b944f325f11039329d8aa961ecdb8226c5dd84af6f003"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0eced69e159b3fdd7597d85950f56990e0aa81c11a20a7785fb66f0e47c46b57"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-win32.whl", hash = "sha256:2c5c50886e6e79af5387c6514eb19f1f6b1a0b4eb787f1b7a8f21a74e2444102"},
+    {file = "grpcio_tools-1.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:156b5f6654fea51983fd9257d47f1ad7bfb2a1d09ed471e610a7b34b97d40802"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:94114e01c4508d904825bd984e3d2752c0b0e6eb714ac08b99f73421691cf931"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:51352070f13ea3346b5f5ca825f2203528b8218fffc6ac6d951216f812272d8b"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:53c47b08ee2f59a89e8df5f3c09850d7fac264754cbaeabae65f6fbf78d80536"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:818fca1c7dd4ad1c9c01f91ba37006964f4c57c93856fa4ebd7d5589132844d6"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2364ac3bd7266752c9971dbef3f79d21cd958777823512faa93473cbd973b8f1"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:9dd6e26e3e0555deadcb52b087c6064e4fd02c09180b42e96c66260137d26b50"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a93263955da8d6e449d7ceb84af4e84b82fa760fd661b4ef4549929d9670ab8e"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-win32.whl", hash = "sha256:6804cbd92b9069ae9189d65300e456bcc3945f6ae196d2af254e9635b9c3ef0d"},
+    {file = "grpcio_tools-1.47.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7589d6f56e633378047274223f0a75534b2cd7c598f9f2894cb4854378b8b00b"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:6d41ec06f2ccc8adcd400a63508ea8e008fb03f270e0031ff2de047def2ada9d"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:74f607b9084b5325a997d9ae57c0814955e19311111568d029b2a6a66f4869ec"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:7fd10683f4f03400536e7a026de9929430ee198c2cbdf2c584edfa909ccc8993"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7be45d69f0eed912df2e92d94958d1a3e72617469ec58ffcac3e2eb153a7057e"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca548afcfa0ffc47c3cf9eeede81adde15c321bfe897085e90ce8913615584ae"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f19191460435f8bc72450cf26ac0559726f98c49ad9b0969db3db8ba51be98c8"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b2fa3c545c8aa1e8c33ca04b1424be3ff77da631faf37db3350d7459c3bdedde"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-win32.whl", hash = "sha256:0b32002ff4ae860c85feb2aca1b752eb4518e7781c5770b869e7b2dfa9d92cbe"},
+    {file = "grpcio_tools-1.47.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5c8ab9b541a869d3b4ef34c291fbfb6ec78ad728e04737fddd91eac3c2193459"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:05b495ed997a9afc9016c696ed7fcd35678a7276fe0bd8b95743a382363ad2b4"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:6c66094fd79ee98bcb504e9f1a3fa6e7ebfd246b4e3d8132227e5020b5633988"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:84e38f46af513a6f62a3d482160fcb94063dbc9fdd1452d09f8010422f144de1"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:058060fbc5a60a1c6cc2cbb3d99f730825ba249917978d48b7d0fd8f2caf01da"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc6567d652c6b70d8c03f4e450a694e62b4d69a400752f8b9c3c8b659dd6b06a"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9ab78cd16b4ac7c6b79c8be194c67e03238f6378694133ce3ce9b123caf24ed5"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ccc8ce33bd31bf12649541b5857fabfee7dd84b04138336a27bf46a28d150c11"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-win32.whl", hash = "sha256:4eced9e0674bfb5c528a3bf2ea2b8596da133148b3e0718915792074204ea226"},
+    {file = "grpcio_tools-1.47.0-cp38-cp38-win_amd64.whl", hash = "sha256:45ceb73a97e2d7ff719fc12c02f1ef13014c47bad60a864313da88ccd90cdf36"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:ac5c6aef72618ebc5ee9ad725dd53e1c145ef420b79d21a7c43ca80658d3d8d4"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:c2c280197d68d5a28f5b90adf755bd9e28c99f3e47ad4edcfe20497cf3456e1d"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:93d08c02bd82e423353399582f22493a191db459c3f34031b583f13bcf42b95e"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18548f35b0657422d5d40e6fa89994469f4bb77df09f8133ecdccec0e31fc72c"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb44ae747fd299b6513420cb6ead50491dc3691d17da48f28fcc5ebf07f47741"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ae53ae35a9761ceea50a502addb7186c5188969d63ad21cf12e00d939db5b967"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2a6a6e5e08866d643b84c89140bbe504f864f11b87bfff7a5f2af94c5a2be18d"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-win32.whl", hash = "sha256:759064fc8439bbfe5402b2fd3b0685f4ffe07d7cc6a64908c2f88a7c80449ce4"},
+    {file = "grpcio_tools-1.47.0-cp39-cp39-win_amd64.whl", hash = "sha256:1a0a91941f6f2a4d97e843a5d9ad7ccccf702af2d9455932f18cf922e65af95e"},
+]
 importlib-metadata = []
 importlib-resources = [
-    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
-    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
+    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
+    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -916,15 +1089,21 @@ itsdangerous = [
     {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
 ]
 "jaraco.functools" = [
-    {file = "jaraco.functools-3.5.0-py3-none-any.whl", hash = "sha256:141f95c490a18eb8aab86caf7a2728f02f604988a26dc36652e3d9fa9e4c49fa"},
-    {file = "jaraco.functools-3.5.0.tar.gz", hash = "sha256:31e0e93d1027592b7b0bec6ad468db850338981ebee76ba5e212e235f4c7dda0"},
+    {file = "jaraco.functools-3.5.1-py3-none-any.whl", hash = "sha256:c8774f73323de42250a659934215da1d899b02c66a6133f1cb79f02a5aff4f38"},
+    {file = "jaraco.functools-3.5.1.tar.gz", hash = "sha256:d0adcf91710a0853efe9f23a78fad586bf67df572f0d6d8e0fa36d289ae1c1d9"},
 ]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
-jsonschema = []
-mako = []
+jsonschema = [
+    {file = "jsonschema-4.14.0-py3-none-any.whl", hash = "sha256:9892b8d630a82990521a9ca630d3446bd316b5ad54dbe981338802787f3e0d2d"},
+    {file = "jsonschema-4.14.0.tar.gz", hash = "sha256:15062f4cc6f591400cd528d2c355f2cfa6a57e44c820dc783aee5e23d36a831f"},
+]
+mako = [
+    {file = "Mako-1.2.2-py3-none-any.whl", hash = "sha256:8efcb8004681b5f71d09c983ad5a9e6f5c40601a6ec469148753292abc0da534"},
+    {file = "Mako-1.2.2.tar.gz", hash = "sha256:3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"},
+]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
@@ -967,40 +1146,16 @@ markupsafe = [
     {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
-mccabe = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
+mccabe = []
 mistune = [
-    {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
-    {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
+    {file = "mistune-2.0.4-py2.py3-none-any.whl", hash = "sha256:182cc5ee6f8ed1b807de6b7bb50155df7b66495412836b9a74c8fbdfc75fe36d"},
+    {file = "mistune-2.0.4.tar.gz", hash = "sha256:9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.13.0.tar.gz", hash = "sha256:a42901a0a5b169d925f6f217cd5a190e32ef54360905b9c39ee7db5313bfec0f"},
-    {file = "more_itertools-8.13.0-py3-none-any.whl", hash = "sha256:c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb"},
+    {file = "more-itertools-8.14.0.tar.gz", hash = "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"},
+    {file = "more_itertools-8.14.0-py3-none-any.whl", hash = "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"},
 ]
-mypy = [
-    {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
-    {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
-    {file = "mypy-0.931-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714"},
-    {file = "mypy-0.931-cp310-cp310-win_amd64.whl", hash = "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc"},
-    {file = "mypy-0.931-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d"},
-    {file = "mypy-0.931-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d"},
-    {file = "mypy-0.931-cp36-cp36m-win_amd64.whl", hash = "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c"},
-    {file = "mypy-0.931-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0"},
-    {file = "mypy-0.931-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05"},
-    {file = "mypy-0.931-cp37-cp37m-win_amd64.whl", hash = "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7"},
-    {file = "mypy-0.931-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0"},
-    {file = "mypy-0.931-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069"},
-    {file = "mypy-0.931-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799"},
-    {file = "mypy-0.931-cp38-cp38-win_amd64.whl", hash = "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a"},
-    {file = "mypy-0.931-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"},
-    {file = "mypy-0.931-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266"},
-    {file = "mypy-0.931-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd"},
-    {file = "mypy-0.931-cp39-cp39-win_amd64.whl", hash = "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697"},
-    {file = "mypy-0.931-py3-none-any.whl", hash = "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d"},
-    {file = "mypy-0.931.tar.gz", hash = "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce"},
-]
+mypy = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1008,6 +1163,10 @@ mypy-extensions = [
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pkgutil-resolve-name = [
+    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
+    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1141,10 +1300,6 @@ pycparser = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pyflakes = []
-pygments = [
-    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
-    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
-]
 pyln-bolt7 = [
     {file = "pyln-bolt7-1.0.186.post0.tar.gz", hash = "sha256:950f788869df138599abea7643b752c16ae8ddfa91c3a31b64647c45d08c0407"},
     {file = "pyln_bolt7-1.0.186.post0-py3-none-any.whl", hash = "sha256:9b65cbaa4fd9db19f30ead7bb5eb61793d2157038237430ff9759e3abc84d739"},
@@ -1188,17 +1343,12 @@ pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
     {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
 ]
-pytest-custom-exit-code = [
-    {file = "pytest-custom_exit_code-0.3.0.tar.gz", hash = "sha256:51ffff0ee2c1ddcc1242e2ddb2a5fd02482717e33a2326ef330e3aa430244635"},
-    {file = "pytest_custom_exit_code-0.3.0-py3-none-any.whl", hash = "sha256:6e0ce6e57ce3a583cb7e5023f7d1021e19dfec22be41d9ad345bae2fc61caf3b"},
-]
+pytest-custom-exit-code = []
 pytest-forked = [
     {file = "pytest-forked-1.4.0.tar.gz", hash = "sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e"},
     {file = "pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
 ]
-pytest-test-groups = [
-    {file = "pytest-test-groups-1.0.3.tar.gz", hash = "sha256:a93ee8ae8605ad290965508d13efc975de64f80429465837af5f3dd5bc93fd96"},
-]
+pytest-test-groups = []
 pytest-timeout = [
     {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
     {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
@@ -1208,8 +1358,8 @@ pytest-xdist = [
     {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
 ]
 python-bitcoinlib = [
-    {file = "python-bitcoinlib-0.11.0.tar.gz", hash = "sha256:3daafd63cb755f6e2067b7c9c514053856034c9f9363c80c37007744d54a2e06"},
-    {file = "python_bitcoinlib-0.11.0-py3-none-any.whl", hash = "sha256:6e7982734637135599e2136d3c88d622f147e3b29201636665f799365784cd9e"},
+    {file = "python-bitcoinlib-0.11.2.tar.gz", hash = "sha256:61ba514e0d232cc84741e49862dcedaf37199b40bba252a17edc654f63d13f39"},
+    {file = "python_bitcoinlib-0.11.2-py3-none-any.whl", hash = "sha256:78bd4ee717fe805cd760dfdd08765e77b7c7dbef4627f8596285e84953756508"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1219,17 +1369,45 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-typed-ast = []
+typed-ast = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.3.3.tar.gz", hash = "sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1"},
-    {file = "websocket_client-1.3.3-py3-none-any.whl", hash = "sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877"},
+    {file = "websocket-client-1.4.0.tar.gz", hash = "sha256:79d730c9776f4f112f33b10b78c8d209f23b5806d9a783e296b3813fc5add2f1"},
+    {file = "websocket_client-1.4.0-py3-none-any.whl", hash = "sha256:33ad3cf0aef4270b95d10a5a66b670a66be1f5ccf10ce390b3644f9eddfdca9d"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.1.2-py3-none-any.whl", hash = "sha256:72a4b735692dd3135217911cbeaa1be5fa3f62bffb8745c5215420a03dc55255"},
-    {file = "Werkzeug-2.1.2.tar.gz", hash = "sha256:1ce08e8093ed67d638d63879fd1ba3735817f7a80de3674d293f5984f25fb6e6"},
+    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
+    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
 ]
-zipp = []
+zipp = [
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.7"
 pyln-client = { path = "./contrib/pyln-client", develop = true }
 pyln-proto = { path = "./contrib/pyln-proto", develop = true }
 Mako = "^1.1.6"
-mrkd = { git = "https://github.com/refi64/mrkd.git", rev = "781f05eb9898ca652f18eed29b3c956389e6a2a7" }
+mistune = "^2.0.4"
 websocket-client = "^1.2.3"
 grpcio-tools = "^1.44.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ pyln-proto = { path = "./contrib/pyln-proto", develop = true }
 Mako = "^1.1.6"
 mistune = "^2.0.4"
 websocket-client = "^1.2.3"
-grpcio-tools = "^1.44.0"
+grpcio-tools = "1.47.0"
+grpcio = "1.47.0"
 
 [tool.poetry.dev-dependencies]
 # Test dependencies and inherited dependencies belong here

--- a/tools/mrkd.py
+++ b/tools/mrkd.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import io
+import mistune
+import os
+import re
+import sys
+
+lines = lambda *a: '\n'.join(a) + '\n'
+
+
+REF_PATTERN = (r'([A-Za-z-_.]+)\((\d+)\)')
+
+
+def parse_ref(inline, m, state):
+    return 'reference', m.group(1), m.group(2)
+
+
+def plugin_reference(md):
+    md.inline.register_rule('reference', REF_PATTERN, parse_ref)
+    md.inline.rules.append('reference')
+    md.renderer.register('reference', md.renderer.reference)
+
+
+class RoffRenderer(mistune.HTMLRenderer):
+    def __init__(self, name, sect, index):
+        super(RoffRenderer, self).__init__()
+        self.name = name
+        self.sect = sect
+        self.index = index
+
+    # Used above in parse_ref
+    def reference(self, text, section):
+        return f'{self.strong(text)}({section})'
+
+    # Inline level.
+    def text(self, text):
+        return text.replace('\\', '\\\\').replace('.', '\\.')
+
+    def link(self, link, title=None, children=None):
+        if 'mailto:' in link or link == title:
+            return f'{self.emphasis(title)}'
+
+        if link and title:
+            return f'{self.strong(title)} ({self.emphasis(link)})'
+
+        return f'{self.emphasis(link)}'
+
+    def image(self, src, alt="", title=None):
+        assert 0
+
+    def emphasis(self, text):
+        return f'\\fI{text}\\fR'
+
+    def strong(self, text):
+        return f'\\fB{text}\\fR'
+
+    def codespan(self, text):
+        return self.strong(text)
+
+    def linebreak(self):
+        assert 0
+
+    def newline(self):
+        return ''
+
+    def inline_html(self, text):
+        return ''
+
+    # Block level.
+    def paragraph(self, text):
+        return lines('', text, '')
+
+    def heading(self, text, level):
+        if level == 1:
+            if '--' not in text:
+                sys.exit(f'Invalid header: {text}')
+            self.description = text.split('--', 1)[1].strip()
+            return lines(
+                f'.TH "{self.name.upper()}" "{self.sect}" "" "" "{self.name}"',
+                '.SH NAME',
+                f'{text.replace("--", "-")}',
+            )
+        else:
+            return lines(f'.SH {text}')
+
+    def thematic_break(self):
+        return lines('.HL')
+
+    def block_text(self, text):
+        return self.paragraph(text)
+
+    def block_code(self, code, info=None):
+        return lines(
+            '.nf',
+            self.block_quote(code.replace('\\', '\\\\')),
+            '.fi',
+        )
+
+    def block_quote(self, text):
+        return lines(
+            '.RS',
+            text,
+            '.RE',
+        )
+
+    def block_html(self, html):
+        return '\n'
+
+    def block_error(self, html):
+        assert 0
+
+    def list(self, text, ordered, level, start=None):
+        if ordered:
+            count = 1
+            buf = io.StringIO()
+
+            assert text[0] == '\0'
+            for chunk in text.split('\0')[1:]:
+                buf.write(f'.IP {count}\\.')
+                buf.write(chunk)
+                count += 1
+
+            contents = buf.getvalue()
+        else:
+            contents = text.replace('\0', '.IP \\[bu]')
+
+        return lines(
+            '.RS',
+            contents,
+            '.RE',
+        )
+
+    def list_item(self, text, level):
+        return '\0' + text
+
+    def finalize(self, data):
+        return ''.join(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='mrkd', allow_abbrev=True)
+    parser.add_argument('source', help='The source man page')
+    parser.add_argument('output', help='The output file')
+    parser.add_argument('-name', help='The name to use for the man page')
+    parser.add_argument('-section', help='The section to use for the man page')
+    parser.add_argument('-template', help='The HTML template file to use')
+    parser.add_argument('-index', help='An index file to use for HTML links')
+    parser.add_argument('-format',
+                        help='The output format',
+                        choices=['roff'],
+                        default='roff')
+
+    args = parser.parse_args()
+
+    name = args.name
+    section = args.section
+
+    m = re.match(r'(.*).(\d).[^.]+$', os.path.basename(args.source))
+    if m is None:
+        if name is None or section is None:
+            sys.exit('Both -name and -section must be passed for invalid filenames.')
+    else:
+        if name is None:
+            name = m.group(1)
+        if section is None:
+            section = m.group(2)
+
+    if args.index is not None:
+        index_config = configparser.ConfigParser()
+        with open(args.index) as fp:
+            index_config.read_file(fp)
+
+        try:
+            index_data = index_config['Index']
+        except KeyError:
+            sys.exit('Index file must contain an [Index] section.')
+    else:
+        index_data = {}
+
+    renderer = RoffRenderer(name, section, index_data)
+
+    with open(args.source) as fp:
+        markdown = mistune.create_markdown(renderer=renderer, plugins=[plugin_reference])
+        result = markdown(fp.read())
+
+    if args.output == '-':
+        print(result)
+    else:
+        with open(args.output, 'w') as fp:
+            fp.write(result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Alternate proposal to #5445.

What if instead of removing it, we bring `mrkd` "in-house" and update it to use the newest/latest and greatest version of `mistune`?

Not really sure what the policy is on updating the `poetry.lock` so did it in two chunks.

Seems to work for almost everything, with the exception that I had to update my local `mistune` install to use 2.0.4; the reproducible builds are getting stuck in the libwally autoconfigure step. Need to debug those.