### PR TITLE
build, shadows: fix broken build (no shadows)

### DIFF
--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1063,7 +1063,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 		    || !amount_msat_zero(debit_diff)) {
 			struct account *acct;
 			struct channel_event *ev;
-			u64 timestamp;
+			u64 timestamp_now;
 
 			/* This is *expected* on first run of bookkeeper! */
 			plugin_log(cmd->plugin,
@@ -1079,7 +1079,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 						  &credit_diff),
 				   acct_name);
 
-			timestamp = time_now().ts.tv_sec;
+			timestamp_now = time_now().ts.tv_sec;
 
 			/* Log a channel "journal entry" to get
 			 * the balances inline */
@@ -1103,7 +1103,7 @@ static struct command_result *json_balance_snapshot(struct command *cmd,
 					info = tal(new_accts, struct new_account_info);
 					info->acct = tal_steal(info, acct);
 					info->curr_bal = snap_balance;
-					info->timestamp = timestamp;
+					info->timestamp = timestamp_now;
 					info->currency =
 						tal_strdup(info, currency);
 

--- a/plugins/bkpr/db.c
+++ b/plugins/bkpr/db.c
@@ -126,8 +126,7 @@ static bool db_migrate(struct plugin *p, struct db *db, bool *created)
 	while (current < available) {
 		current++;
 		if (db_migrations[current].sql) {
-			struct db_stmt *stmt =
-				db_prepare_v2(db, db_migrations[current].sql);
+			stmt = db_prepare_v2(db, db_migrations[current].sql);
 			db_exec_prepared_v2(take(stmt));
 		}
 		if (db_migrations[current].func)


### PR DESCRIPTION
Merged a commit that broke everything with shadows, which turned out to
be the bookkeeper code.