### PR TITLE
pyln-client: allow 'msat' fields to be 'null'

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -455,6 +455,11 @@ class LightningRpc(UnixDomainSocketRpc):
                     if k.endswith('msat'):
                         if isinstance(v, list):
                             obj[k] = [Millisatoshi(e) for e in v]
+                        # FIXME: Deprecated "listconfigs" gives two 'null' fields:
+                        #            "lease-fee-base-msat": null,
+                        #            "channel-fee-max-base-msat": null,
+                        elif v is None:
+                            obj[k] = None
                         else:
                             obj[k] = Millisatoshi(v)
                     else:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -725,29 +725,29 @@ def test_address(node_factory):
     l2.rpc.connect(l1.info['id'], l1.daemon.opts['addr'])
 
 
-@unittest.skipIf(DEPRECATED_APIS, "Tests the --allow-deprecated-apis config")
 def test_listconfigs(node_factory, bitcoind, chainparams):
     # Make extremely long entry, check it works
-    l1 = node_factory.get_node(options={'log-prefix': 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'})
+    for deprecated in (True, False):
+        l1 = node_factory.get_node(options={'log-prefix': 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                                            'allow-deprecated-apis': deprecated})
 
-    configs = l1.rpc.listconfigs()
-    # See utils.py
-    assert configs['allow-deprecated-apis'] is False
-    assert configs['network'] == chainparams['name']
-    assert configs['ignore-fee-limits'] is False
-    assert configs['ignore-fee-limits'] is False
-    assert configs['log-prefix'] == 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...'
+        configs = l1.rpc.listconfigs()
+        # See utils.py
+        assert configs['allow-deprecated-apis'] == deprecated
+        assert configs['network'] == chainparams['name']
+        assert configs['ignore-fee-limits'] is False
+        assert configs['log-prefix'] == 'lightning1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...'
 
-    # These are aliases, but we don't print the (unofficial!) wumbo.
-    assert 'wumbo' not in configs
-    assert configs['large-channels'] is False
+        # These are aliases, but we don't print the (unofficial!) wumbo.
+        assert 'wumbo' not in configs
+        assert configs['large-channels'] is False
 
-    # Test one at a time.
-    for c in configs.keys():
-        if c.startswith('#') or c.startswith('plugins') or c == 'important-plugins':
-            continue
-        oneconfig = l1.rpc.listconfigs(config=c)
-        assert(oneconfig[c] == configs[c])
+        # Test one at a time.
+        for c in configs.keys():
+            if c.startswith('#') or c.startswith('plugins') or c == 'important-plugins':
+                continue
+            oneconfig = l1.rpc.listconfigs(config=c)
+            assert(oneconfig[c] == configs[c])
 
 
 def test_listconfigs_plugins(node_factory, bitcoind, chainparams):


### PR DESCRIPTION
This happens with deprecated-apis and listconfigs, breaking some
python plugins!

Fixes: #5546
Fixes: #5563