### PR TITLE
fix: peer_control getinfo to show correct port on discovered IPs

### DIFF
--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -43,18 +43,18 @@ static u8 *create_node_announcement(const tal_t *ctx, struct daemon *daemon,
 	for (i = 0; i < count_announceable; i++)
 		tal_arr_expand(&was, daemon->announceable[i]);
 
-	/* Add IP discovery `remote_addr` v4 and v6 of our self. */
+	/* Add discovered IPs v4/v6 verified by peer `remote_addr` feature. */
 	/* Only do that if we don't have addresses announced. */
 	if (count_announceable == 0) {
-		if (daemon->remote_addr_v4 != NULL &&
-		    !wireaddr_arr_contains(was, daemon->remote_addr_v4))
-			tal_arr_expand(&was, *daemon->remote_addr_v4);
-		if (daemon->remote_addr_v6 != NULL &&
-		    !wireaddr_arr_contains(was, daemon->remote_addr_v6))
-			tal_arr_expand(&was, *daemon->remote_addr_v6);
+		if (daemon->discovered_ip_v4 != NULL &&
+		    !wireaddr_arr_contains(was, daemon->discovered_ip_v4))
+			tal_arr_expand(&was, *daemon->discovered_ip_v4);
+		if (daemon->discovered_ip_v6 != NULL &&
+		    !wireaddr_arr_contains(was, daemon->discovered_ip_v6))
+			tal_arr_expand(&was, *daemon->discovered_ip_v6);
 	}
 
-	/* Sort by address type again, as we added dynamic remote_addr v4/v6. */
+	/* Sort by address type again, as we added dynamic discovered_ip v4/v6. */
 	/* BOLT #7:
 	 *
 	 * The origin node:

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -350,9 +350,6 @@ static void handle_remote_addr(struct daemon *daemon, const u8 *msg)
 	if (!fromwire_gossipd_remote_addr(msg, &remote_addr))
 		master_badmsg(WIRE_GOSSIPD_REMOTE_ADDR, msg);
 
-	/* Best guess is that we use default port for the selected network */
-	remote_addr.port = chainparams_get_ln_port(chainparams);
-
 	switch (remote_addr.type) {
 	case ADDR_TYPE_IPV4:
 		if (daemon->remote_addr_v4 != NULL &&

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -48,8 +48,8 @@ struct daemon {
 	struct wireaddr *announceable;
 
 	/* verified remote_addr as reported by recent peers */
-	struct wireaddr *remote_addr_v4;
-	struct wireaddr *remote_addr_v6;
+	struct wireaddr *discovered_ip_v4;
+	struct wireaddr *discovered_ip_v6;
 
 	/* Timer until we can send an updated node_announcement */
 	struct oneshot *node_announce_timer;

--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -123,6 +123,6 @@ msgdata,gossipd_local_private_channel,features,u8,len
 msgtype,gossipd_used_local_channel_update,3052
 msgdata,gossipd_used_local_channel_update,scid,short_channel_id,
 
-# Tell gossipd we have discovered a new remote_addr
-msgtype,gossipd_remote_addr,3009
-msgdata,gossipd_remote_addr,remote_addr,wireaddr,
+# Tell gossipd we have verified a new public IP by the remote_addr feature
+msgtype,gossipd_discovered_ip,3009
+msgdata,gossipd_discovered_ip,discovered_ip,wireaddr,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -174,7 +174,7 @@ static unsigned gossip_msg(struct subd *gossip, const u8 *msg, const int *fds)
 	case WIRE_GOSSIPD_ADDGOSSIP_REPLY:
 	case WIRE_GOSSIPD_NEW_BLOCKHEIGHT_REPLY:
 	case WIRE_GOSSIPD_GET_ADDRS_REPLY:
-	case WIRE_GOSSIPD_REMOTE_ADDR:
+	case WIRE_GOSSIPD_DISCOVERED_IP:
 		break;
 
 	case WIRE_GOSSIPD_GET_TXOUT:

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -209,6 +209,8 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 
 	ld->remote_addr_v4 = NULL;
 	ld->remote_addr_v6 = NULL;
+	ld->discovered_ip_v4 = NULL;
+	ld->discovered_ip_v6 = NULL;
 	ld->listen = true;
 	ld->autolisten = true;
 	ld->reconnect = true;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -158,6 +158,10 @@ struct lightningd {
 	struct node_id remote_addr_v4_peer;
 	struct node_id remote_addr_v6_peer;
 
+	/* verified discovered IPs to be used for anouncement */
+	struct wireaddr *discovered_ip_v4;
+	struct wireaddr *discovered_ip_v6;
+
 	/* Bearer of all my secrets. */
 	int hsm_fd;
 	struct subd *hsm;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1303,7 +1303,7 @@ static void update_remote_addr(struct lightningd *ld,
 			ld->discovered_ip_v4 = tal_dup(ld, struct wireaddr,
 						       ld->remote_addr_v4);
 			ld->discovered_ip_v4->port = public_port;
-			subd_send_msg(ld->gossip, towire_gossipd_remote_addr(
+			subd_send_msg(ld->gossip, towire_gossipd_discovered_ip(
 							  tmpctx,
 							  ld->discovered_ip_v4));
 		}
@@ -1326,7 +1326,7 @@ static void update_remote_addr(struct lightningd *ld,
 			ld->discovered_ip_v6 = tal_dup(ld, struct wireaddr,
 						       ld->remote_addr_v6);
 			ld->discovered_ip_v6->port = public_port;
-			subd_send_msg(ld->gossip, towire_gossipd_remote_addr(
+			subd_send_msg(ld->gossip, towire_gossipd_discovered_ip(
 							  tmpctx,
 							  ld->discovered_ip_v6));
 		}

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -733,9 +733,9 @@ u8 *towire_errorfmt(const tal_t *ctx UNNEEDED,
 		    const struct channel_id *channel UNNEEDED,
 		    const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "towire_errorfmt called!\n"); abort(); }
-/* Generated stub for towire_gossipd_remote_addr */
-u8 *towire_gossipd_remote_addr(const tal_t *ctx UNNEEDED, const struct wireaddr *remote_addr UNNEEDED)
-{ fprintf(stderr, "towire_gossipd_remote_addr called!\n"); abort(); }
+/* Generated stub for towire_gossipd_discovered_ip */
+u8 *towire_gossipd_discovered_ip(const tal_t *ctx UNNEEDED, const struct wireaddr *discovered_ip UNNEEDED)
+{ fprintf(stderr, "towire_gossipd_discovered_ip called!\n"); abort(); }
 /* Generated stub for towire_hsmd_sign_bolt12 */
 u8 *towire_hsmd_sign_bolt12(const tal_t *ctx UNNEEDED, const wirestring *messagename UNNEEDED, const wirestring *fieldname UNNEEDED, const struct sha256 *merkleroot UNNEEDED, const u8 *publictweak UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_bolt12 called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -611,11 +611,6 @@ struct command_result *param_short_channel_id(struct command *cmd UNNEEDED,
 					      const jsmntok_t *tok UNNEEDED,
 					      struct short_channel_id **scid UNNEEDED)
 { fprintf(stderr, "param_short_channel_id called!\n"); abort(); }
-/* Generated stub for param_string */
-struct command_result *param_string(struct command *cmd UNNEEDED, const char *name UNNEEDED,
-				    const char * buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
-				    const char **str UNNEEDED)
-{ fprintf(stderr, "param_string called!\n"); abort(); }
 /* Generated stub for parse_onionpacket */
 struct onionpacket *parse_onionpacket(const tal_t *ctx UNNEEDED,
 				      const u8 *src UNNEEDED,
@@ -774,9 +769,9 @@ u8 *towire_final_incorrect_cltv_expiry(const tal_t *ctx UNNEEDED, u32 cltv_expir
 /* Generated stub for towire_final_incorrect_htlc_amount */
 u8 *towire_final_incorrect_htlc_amount(const tal_t *ctx UNNEEDED, struct amount_msat incoming_htlc_amt UNNEEDED)
 { fprintf(stderr, "towire_final_incorrect_htlc_amount called!\n"); abort(); }
-/* Generated stub for towire_gossipd_remote_addr */
-u8 *towire_gossipd_remote_addr(const tal_t *ctx UNNEEDED, const struct wireaddr *remote_addr UNNEEDED)
-{ fprintf(stderr, "towire_gossipd_remote_addr called!\n"); abort(); }
+/* Generated stub for towire_gossipd_discovered_ip */
+u8 *towire_gossipd_discovered_ip(const tal_t *ctx UNNEEDED, const struct wireaddr *discovered_ip UNNEEDED)
+{ fprintf(stderr, "towire_gossipd_discovered_ip called!\n"); abort(); }
 /* Generated stub for towire_hsmd_get_output_scriptpubkey */
 u8 *towire_hsmd_get_output_scriptpubkey(const tal_t *ctx UNNEEDED, u64 channel_id UNNEEDED, const struct node_id *peer_id UNNEEDED, const struct pubkey *commitment_point UNNEEDED)
 { fprintf(stderr, "towire_hsmd_get_output_scriptpubkey called!\n"); abort(); }


### PR DESCRIPTION
Before this patch, getinfo shows incorrect ports on `getinfo` auto discovered IP addresses.
It also just showed (not announced) unconfirmed addresses.

Addresses #5553

Changelog-Fixed: peer_control: getinfo shows the correct port on discovered IPs