### PR TITLE
Fix for #5572 and #5565

### DIFF
--- a/common/gossip_store.c
+++ b/common/gossip_store.c
@@ -199,8 +199,8 @@ size_t find_gossip_store_end(int gossip_store_fd, size_t off)
 	} buf;
 	int r;
 
-	while ((r = read(gossip_store_fd, &buf,
-			 sizeof(buf.hdr) + sizeof(buf.type)))
+	while ((r = pread(gossip_store_fd, &buf,
+			 sizeof(buf.hdr) + sizeof(buf.type), off))
 	       == sizeof(buf.hdr) + sizeof(buf.type)) {
 		u32 msglen = be32_to_cpu(buf.hdr.len) & GOSSIP_STORE_LEN_MASK;
 
@@ -209,7 +209,6 @@ size_t find_gossip_store_end(int gossip_store_fd, size_t off)
 			break;
 
 		off += sizeof(buf.hdr) + msglen;
-		lseek(gossip_store_fd, off, SEEK_SET);
 	}
 	return off;
 }


### PR DESCRIPTION
This took more effort to debug than it appears, but I believe this is ultimately the source of the gossip_store offset error!  Some of the previously reported node announcement propagation issues may have originated here as well.  Accounting for the gossip_store's leading version byte is a simple fix. 