### PR TITLE
gossmap: don't crash if we see a duplicate channel_announce.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -414,11 +414,8 @@ static struct gossmap_chan *add_channel(struct gossmap *map,
 	 * that's the only time we get duplicates */
 	scid.u64 = map_be64(map, cannounce_off + plus_scid_off);
 	chan = gossmap_find_chan(map, &scid);
-	if (chan) {
-		assert(chan->private);
-		assert(!private);
+	if (chan)
 		gossmap_remove_chan(map, chan);
-	}
 
 	/* We carefully map pointers to indexes, since new_node can move them! */
 	n[0] = gossmap_find_node(map, &node_id[0]);


### PR DESCRIPTION
Apparently we had two private channel announcements (the !private assert failed).  While this shouldn't happen, don't crash because of it.

Fixes: #5578
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Fixed: Plugins: topology plugin could crash when it sees duplicate private channel announcements.