### PR TITLE
gci: Use stable rust instead of nightly

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -3,7 +3,7 @@
 export DEBIAN_FRONTEND=noninteractive
 export BITCOIN_VERSION=0.20.1
 export ELEMENTS_VERSION=0.18.1.8
-export RUST_VERSION=nightly
+export RUST_VERSION=stable
 
 sudo useradd -ms /bin/bash tester
 sudo apt-get update -qq


### PR DESCRIPTION
Nightly occasionally breaks, so use stable instead.

Changelog-None