### PR TITLE
pyln: Add grpcio and protobuf dependencies to pyln-testing

### DIFF
--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -21,6 +21,8 @@ pyln-client = "^0.11"
 Flask = "^2.0.3"
 cheroot = "^8.6.0"
 psutil = "^5.9.0"
+grpcio = "^1.49.0"
+protobuf = "^4.21.6"
 
 [tool.poetry.dev-dependencies]
 pyln-client = { path = "../pyln-client", develop = true}


### PR DESCRIPTION
While testing plugins in the community repo I found that these two are missing.

Changelog-None