### PR TITLE
connectd+: Flake/race fix for new channels

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -955,6 +955,10 @@ static void send_shutdown_complete(struct peer *peer)
 	wire_sync_write(MASTER_FD,
 			take(towire_channeld_shutdown_complete(NULL)));
 	per_peer_state_fdpass_send(MASTER_FD, peer->pps);
+
+	/* Give master a chance to pass the fd along */
+	sleep(1);
+
 	close(MASTER_FD);
 }
 

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -303,6 +303,9 @@ static void dualopen_shutdown(struct state *state)
 	status_debug("Sent %s with fds",
 		     dualopend_wire_name(fromwire_peektype(msg)));
 
+	/* Give master a chance to pass the fd along */
+	sleep(1);
+
 	/* This frees the entire tal tree. */
 	tal_free(state);
 	daemon_shutdown();
@@ -3988,6 +3991,9 @@ int main(int argc, char *argv[])
 	status_debug("Sent %s with fds",
 		     dualopend_wire_name(fromwire_peektype(msg)));
 	tal_free(msg);
+
+	/* Give master a chance to pass the fd along */
+	sleep(1);
 
 	/* This frees the entire tal tree. */
 	tal_free(state);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1485,6 +1485,9 @@ int main(int argc, char *argv[])
 	status_debug("Sent %s with fd",
 		     openingd_wire_name(fromwire_peektype(msg)));
 
+	/* Give master a chance to pass the fd along */
+	sleep(1);
+
 	/* This frees the entire tal tree. */
 	tal_free(state);
 


### PR DESCRIPTION
1) dualopen has fd to connectd
2) channeld needs to take over
3) dualopen passes fd that leads to a connectd over for channeld to use
4) lightningd must receive the fd transfer request and process it
5) dualopen shuts down and closes everything it owns

4 & 5 end up in a race. If 5 happens before 4, channeld ends up with an invalid fd for connectd — leaving it in a position to not receive messages.

Lingering for a second makes 4 win the race. Since the daemon is closing anyway, waiting for a second should be alright.