### PR TITLE
devtools: Make fund_nodes compatible w/zsh

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -206,7 +206,7 @@ fund_nodes() {
 
 	last_node=""
 
-	for i in $NODES; do
+	echo "$NODES" | while read -r i; do
 
 		if [ -z "$last_node" ]; then
 			last_node=$i
@@ -253,6 +253,7 @@ fund_nodes() {
 		done
 
 		echo "done."
+
 	done
 }
 


### PR DESCRIPTION
Mac is updating to using zsh in general.

The “for i in” reads strings with spaces as a single entry instead of multiple entries as sh did.

Using “while read” … “<<< $var” makes it treat each space as a new entry.

Changelog-None