### PR TITLE
pyln-client: use f strings to concatenate JSON ids, handle older integer ids

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -335,7 +335,7 @@ class UnixDomainSocketRpc(object):
         if cmdprefix is None:
             cmdprefix = self.cmdprefix
         if cmdprefix:
-            this_id = cmdprefix + '/' + this_id
+            this_id = f'{cmdprefix}/{this_id}'
         return this_id
 
     def call(self, method, payload=None, cmdprefix=None):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2215,7 +2215,7 @@ def test_sendcustommsg(node_factory):
         l1.rpc.sendcustommsg(node_id, msg)
 
     # `l3` is disconnected and we can't send messages to it
-    assert(not l2.rpc.listpeers(l3.info['id'])['peers'][0]['connected'])
+    wait_for(lambda: l2.rpc.listpeers(l3.info['id'])['peers'][0]['connected'] is False)
     with pytest.raises(RpcError, match=r'Peer is not connected'):
         l2.rpc.sendcustommsg(l3.info['id'], msg)
 


### PR DESCRIPTION
We don't really support using pyln-client with older Core Lightning versions, but this is neater anyway.  I checked: f-strings go back to python 3.6, so we can use them (I think this may be the first!).

Suggested-by: @MiWCryptAnalytics
Fixes: #5609
Changelog-None: introduced since 0.12 with chained ids