### PR TITLE
pyln: Publish 0.12.0.post1 to address non-integer ID error

### DIFF
--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -2,7 +2,7 @@ from .lightning import LightningRpc, RpcError, Millisatoshi
 from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapNodeId
 
-__version__ = "0.12.0"
+__version__ = "0.12.0.post1"
 
 __all__ = [
     "LightningRpc",

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "0.11.1"
+version = "0.12.0.post1"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -17,7 +17,7 @@ ephemeral-port-reserve = "^1.1.4"
 psycopg2-binary = "^2.9.3"
 python-bitcoinlib = "^0.11.0"
 jsonschema = "^4.4.0"
-pyln-client = "^0.11"
+pyln-client = ">=0.12.0.post1"  # Need at least the json_id patch
 Flask = "^2.0.3"
 cheroot = "^8.6.0"
 psutil = "^5.9.0"


### PR DESCRIPTION
The non-numeric JSON-RPC request IDs are throwing off the plugins based on pyln-client, let's fix that.

Changelog-None