### PR TITLE
build-release: configure before submodcheck

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -72,6 +72,8 @@ if [ -z "$MTIME" ]; then
     exit 1
 fi
 
+# submodcheck needs to know if we have lowdown
+./configure --reconfigure
 # If it's a completely clean directory, we need submodules!
 make submodcheck
 mkdir -p release


### PR DESCRIPTION
We added a submod dep (lowdown) that requires config to run first.

Changelog-None