### PR TITLE
pyln: Bump versions to v0.12.1

### DIFF
--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -2,7 +2,7 @@ from .lightning import LightningRpc, RpcError, Millisatoshi
 from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapNodeId
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "LightningRpc",

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "0.12.0"
+version = "0.12.1"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"
@@ -12,8 +12,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyln-bolt7 = "^1.0"
 pyln-proto = ">=0.12"
+pyln-bolt7 = ">=1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"

--- a/contrib/pyln-proto/pyproject.toml
+++ b/contrib/pyln-proto/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-proto"
-version = "0.12.0"
+version = "0.12.1"
 description = "This package implements some of the Lightning Network protocol in pure python. It is intended for protocol testing and some minor tooling only. It is not deemed secure enough to handle any amount of real funds (you have been warned!)."
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-testing/pyln/testing/__init__.py
+++ b/contrib/pyln-testing/pyln/testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.0.post1"
+__version__ = "0.12.1"
 
 __all__ = [
     "__version__",

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-testing"
-version = "0.12.0.post1"
+version = "0.12.1"
 description = "Test your Core Lightning integration, plugins or whatever you want"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"
@@ -17,7 +17,7 @@ ephemeral-port-reserve = "^1.1.4"
 psycopg2-binary = "^2.9.3"
 python-bitcoinlib = "^0.11.0"
 jsonschema = "^4.4.0"
-pyln-client = "^0.12"
+pyln-client = ">=0.12.1"
 Flask = "^2.0.3"
 cheroot = "^8.6.0"
 psutil = "^5.9.0"


### PR DESCRIPTION
This is just before the introduction of `get_json_id`, but has the correct dependency constraints such that all packages can be updated to >=v0.12 and we don't mix minor versions.

This addresses a couple of issues:

 - The `pyln-client=^0.11` constraint would end up picking an older version
 - The `PrettyPrintingLightningRpc` published in `pyln-testing` already uses `get_json_id` which is not defined in `LightningRpc`, but intercepted via `__getattr__` call, and interpreted as a JSON-RPC call, which caused a recursive call.

This fixes both of them by publishing an earlier `pyln-testing` and fixing the constraints in `pyln-testing`.

Changelog-None