### PR TITLE
pytest: fix flakes in test_zeroconf_forward, test_gossip_persistence

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -526,9 +526,9 @@ def test_gossip_persistence(node_factory, bitcoind):
     scid12, _ = l1.fundchannel(l2, 10**6)
     scid23, _ = l2.fundchannel(l3, 10**6)
 
-    # Make channels public, except for l3 -> l4, which is kept local-only for now
+    # Make channels public, except for l3 -> l4, which is kept local-only
     mine_funding_to_announce(bitcoind, [l1, l2, l3, l4])
-    scid34, _ = l3.fundchannel(l4, 10**6)
+    scid34, _ = l3.fundchannel(l4, 10**6, announce_channel=False)
     bitcoind.generate_block(1)
 
     def active(node):

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1490,6 +1490,10 @@ def test_zeroconf_forward(node_factory, bitcoind):
     # And now try the other way around: zeroconf channel first
     # followed by a public one.
     wait_for(lambda: len(l3.rpc.listchannels()['channels']) == 4)
+
+    # Make sure all htlcs completely settled!
+    wait_for(lambda: all(only_one(p['channels'])['htlcs'] == [] for p in l2.rpc.listpeers()['peers']))
+
     inv = l1.rpc.invoice(42, 'back1', 'desc')['bolt11']
     l3.rpc.pay(inv)
 


### PR DESCRIPTION
Second pay can fail if first is not completely settled:

```
    def test_zeroconf_forward(node_factory, bitcoind):
        """Ensure that we can use zeroconf channels in forwards.

...
        # Make sure (esp in non-dev-mode) blockheights agree so we don't WIRE_EXPIRY_TOO_SOON...
        sync_blockheight(bitcoind, [l1, l2, l3])
        inv = l3.rpc.invoice(42 * 10**6, 'inv1', 'desc')['bolt11']
        l1.rpc.pay(inv)

        # And now try the other way around: zeroconf channel first
        # followed by a public one.
        wait_for(lambda: len(l3.rpc.listchannels()['channels']) == 4)
        inv = l1.rpc.invoice(42, 'back1', 'desc')['bolt11']
>       l3.rpc.pay(inv)

...
>           raise RpcError(method, payload, resp['error'])
E           pyln.client.lightning.RpcError: RPC call failed: method: pay, payload: {'bolt11': 'lnbcrt420p1p3junrssp588gtjzmlrr4pfj7ssmdlulzhhushrpq3rdqxjuz2m33scsvzdjlspp5fk5yhu6netc0d0sgp8es52vjk6akhd3uayr08u8max4d8rwzpjuqdq8v3jhxccxqyjw5qcqp99qyysgqcpyyugejv4nya97v6gw8fhtr0ru3vq87jjlltav99wlat436a95n0z8yzdp699p9md0zz9tmnsjpvfj622n9g9fh7r6ldhpgh9wmr4qpcru3rk'}, error: {'code': 210, 'message': 'Destination 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 is not reachable directly and all routehints were unusable.', 'attempts': [{'status': 'failed', 'failreason': 'Destination 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 is not reachable directly and all routehints were unusable.', 'partid': 0, 'amount_msat': 42msat}]}
```

Bonus fix:

We used to ensure the l3<->l4 channel was private by
simply not mining enough blocks to announce.  Then
we started mining 13 blocks to close the channel, and
it will get announced, causing a failure:

```
        assert non_public(l2) == []
>       wait_for(lambda: non_public(l3) == [scid34, scid34])
...
>               raise ValueError("Timeout while waiting for {}", success)
E               ValueError: ('Timeout while waiting for {}', <function test_gossip_persistence.<locals>.<lambda> at 0x7f6cc69b4170>)
```

Changelog-None