### PR TITLE
channeld: do not enforce max_accepted_htlcs on LOCAL in channel reinit

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -629,7 +629,7 @@ static enum channel_add_err add_htlc(struct channel *channel,
 	 * the channel to pay unnecessary onchain fees during a fee
 	 * spike with large commitment transactions.
 	 */
-	if (sender == LOCAL
+	if (enforce_aggregate_limits && sender == LOCAL
 	    && htlc_count + 1 > channel->config[LOCAL].max_accepted_htlcs) {
 		return CHANNEL_ERR_TOO_MANY_HTLCS;
 	}


### PR DESCRIPTION
If a channel goes offline while the count of outstanding outgoing HTLCs exceeds the limit that we enforce against the peer, then the channel could never be brought online again because `add_htlc` called by `channel_force_htlcs` in `channeld/full_channel.c` would return `CHANNEL_ERR_TOO_MANY_HTLCS`. The protocol specification actually does allow us to exceed the limits that we are enforcing against the peer; we are only prohibited from exceeding the limits that the peer is enforcing against us. `add_htlc` takes an `enforce_aggregate_limits` parameter that appears to have been intended for `channel_force_htlcs` to exempt the local node from obeying the limits that it is enforcing against the peer, but this parameter was only being respected for the total HTLC value-in-flight check but not for the HTLC count check. This commit respects the parameter for the HTLC count check as well and resolves the problem of "Could not restore HTLCs".

Fixes: #5636
Changelog-Fixed: channeld: Channel reinitialization no longer fails when the number of outstanding outgoing HTLCs exceeds `max_accepted_htlcs`.