### PR TITLE
cln-rpc: implement from Secret to slice conversion

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -197,6 +197,12 @@ impl Secret {
     }
 }
 
+impl From<Secret> for [u8; 32] {
+    fn from(s: Secret) -> [u8; 32] {
+        s.0
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Outpoint {
     pub txid: Sha256,


### PR DESCRIPTION
Support direct value-to-value conversion between payment `Secret` and a `[u8;32]`. Helps the rpc user skip a heap allocation.

Enables:
```
struct Preimage([u8; 32]);
let response = cln_rpc.lock().await.call({}).await?;

let preimage = Preimage(response.payment_preimage.into());
```
Where we would require:
```
...
let slice: [u8; 32] = response
                    .payment_preimage
                    .to_vec()
                    .try_into()
                    .expect("invalid payment preimage");
let preimage = Preimage(slice);
```

Changelog-None