### PR TITLE
Reckless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,8 @@ ALL_NONGEN_SRCFILES := $(ALL_NONGEN_HEADERS) $(ALL_NONGEN_SOURCES)
 BIN_PROGRAMS = \
 	       cli/lightning-cli \
 	       lightningd/lightningd \
-	       tools/lightning-hsmtool
+	       tools/lightning-hsmtool\
+	       tools/reckless
 PKGLIBEXEC_PROGRAMS = \
 	       lightningd/lightning_channeld \
 	       lightningd/lightning_closingd \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -102,7 +102,8 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-listnodes.7 \
 	doc/lightning-listconfigs.7 \
 	doc/lightning-help.7 \
-	doc/lightning-getlog.7
+	doc/lightning-getlog.7 \
+	doc/reckless.7
 
 doc-all: $(MANPAGES) doc/index.rst
 

--- a/doc/reckless.7.md
+++ b/doc/reckless.7.md
@@ -1,0 +1,142 @@
+reckless - install and activate a CLN plugin by name
+====================================================
+
+SYNOPSIS
+--------
+
+**reckless** [*options*] **install/uninstall/enable/disable/source** *target*
+
+DESCRIPTION
+-----------
+
+Reckless is a plugin manager for Core-Lightning. Typical plugin
+installation involves: finding the source plugin, copying,
+installing dependencies, testing, activating, and updating the
+lightningd config file. Reckless does all of these by invoking:
+
+**reckless** **install** *plugin_name*
+
+reckless will exit early in the event that:
+- the plugin is not found in any available source repositories
+- dependencies are not sucessfully installed
+- the plugin fails to execute
+
+Reckless-installed plugins reside in the 'reckless' subdirectory
+of the user's `.lightning` folder.  By default, plugins are activated
+on the `bitcoin` network (and use lightningd's bitcoin network
+config), but regtest may also be used.
+
+Other commands include:
+
+**reckless** **uninstall** *plugin_name*
+	disables the plugin, removes the directory.
+
+**reckless** **search** *plugin_name*
+	looks through all available sources for a plugin matching
+	this name.
+
+**reckless** **enable** *plugin_name*
+	dynamically enables the reckless-installed plugin and updates
+	the config to match.
+
+**reckless** **disable** *plugin_name*
+	dynamically disables the reckless-installed plugin and updates
+	the config to match.
+
+**reckless** **source** **list**
+	list available plugin repositories.
+
+**reckless** **source** **add** *repo_url*
+	add another plugin repo for reckless to search.
+
+**reckless** **source** **rm** *repo_url*
+	remove a plugin repo for reckless to search.
+
+OPTIONS
+-------
+
+Available option flags:
+
+**-d**, **--reckless-dir** *reckless_dir*
+	specify an alternative data directory for reckless to use.
+	Useful if your .lightning is protected from execution.
+
+**-l**, **--lightning** *lightning_data_dir*
+	lightning data directory (defaults to $USER/.lightning)
+
+**-c**, **--conf** *lightning_config*
+	pass the config used by lightningd
+
+**-r**, **--regtest**
+	use the regtest network and config instead of bitcoin mainnet
+
+**-v**, **--verbose**
+	request additional debug output
+
+NOTES
+-----
+
+Reckless currently supports python plugins only. Additional language
+support will be provided in future releases.
+
+Running the first time will prompt the user that their lightningd's
+bitcoin config will be appended (or created) to inherit the reckless
+config file (this config is specific to bitcoin by default.)
+Management of plugins will subsequently modify this file.
+
+
+Troubleshooting tips:
+
+Plugins must be executable. For python plugins, the shebang is
+invoked, so **python3** should be available in your environment. This
+can be verified with **which Python3**. The default reckless directory
+is $USER/.lightning/reckless and it should be possible for the
+lightningd user to execute files located here.  If this is a problem,
+the option flag **reckless -d=<my_alternate_dir>** may be used to
+relocate the reckless directory from its default. Consider creating a
+permanent alias in this case.
+
+For Plugin Developers:
+
+To make your plugin compatible with reckless install:
+- Choose a unique plugin name.
+- The plugin entrypoint is inferred.  Naming your plugin executable
+    the same as your plugin name will allow reckless to identify it
+    correctly (file extensions are okay.)
+- For python plugins, a requirements.txt is the preferred medium for
+    python dependencies. A pyproject.toml will be used as a fallback,
+    but test installation via `pip install -e .` - Poetry looks for
+    additional files in the working directory, whereas with pip, any
+    references to these will require something like
+    `packages = [{ include = "*.py" }]` under the `[tool.poetry]`
+    section.
+- Additional repository sources may be added with
+    `reckless source add https://my.repo.url/here` however,
+    https://github.com/lightningd/plugins is included by default.
+    Consider adding your plugin lightningd/plugins to make
+    installation simpler.
+- If your plugin is located in a subdirectory of your repo with a
+    different name than your plugin, it will likely be overlooked.
+
+AUTHOR
+------
+
+Antoine Poinsot wrote the original reckless plugin on which this is
+based.
+
+Rusty Russell wrote the outline for the reckless utility's function
+
+Alex Myers <<alex@endothermic.dev>> is mostly responsible for the
+reckless code and this man page, with thanks to Christian Decker for
+extensive review.
+
+SEE ALSO
+--------
+
+Core-Lightning plugins repo: <https://github.com/lightningd/plugins>
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>
+

--- a/tools/reckless
+++ b/tools/reckless
@@ -105,7 +105,7 @@ def remove_dir(target):
 
 class Config():
     """A generic class for procuring, reading and editing config files"""
-    def obtain_config(self, config_path, default_text):
+    def obtain_config(self, config_path, default_text, warn=False):
         """Return a config file from the desired location. Create one with
         default_text if it cannot be found."""
         if isinstance(config_path, type(None)):
@@ -117,8 +117,11 @@ class Config():
                 config_content = f.readlines()
             return config_content
         print(f'config file not found: {config_path}')
-        confirm = input('press [Y] to create one now.\n')
-        if confirm.upper() != 'Y':
+        if warn:
+            confirm = input('press [Y] to create one now.\n').upper() == 'Y'
+        else:
+            confirm = True
+        if not confirm:
             sys.exit(1)
         parent_path = os.path.split(config_path)[0]
         # Create up to one parent in the directory tree.
@@ -161,11 +164,12 @@ class Config():
                 if not line_exists:
                     conf_write.write(f'\n{addline}')
 
-    def __init__(self, path=None, default_text=None):
+    def __init__(self, path=None, default_text=None, warn=False):
         assert path is not None
         assert default_text is not None
         self.conf_fp = path
-        self.content = self.obtain_config(self.conf_fp, default_text)
+        self.content = self.obtain_config(self.conf_fp, default_text,
+                                          warn=warn)
 
 
 class RecklessConfig(Config):
@@ -199,13 +203,13 @@ class LightningBitcoinConfig(Config):
     """lightningd config specific to the bitcoin network. This is inherited by
     the main lightningd config and in turn, inherits bitcoin-reckless.conf."""
 
-    def __init__(self, path=None, default_text=None):
+    def __init__(self, path=None, default_text=None, warn=True):
         if path is None:
             path = os.path.join(LIGHTNING_DIR, 'bitcoin', 'config')
         if default_text is None:
             default_text = "# This config was autopopulated by reckless\n\n"
         Config.__init__(self, path=str(path),
-                        default_text=default_text)
+                        default_text=default_text, warn=warn)
 
 
 class InferInstall():

--- a/tools/reckless
+++ b/tools/reckless
@@ -232,12 +232,12 @@ class InferInstall():
         raise Exception(f'plugin entrypoint not found in {self.dir}')
 
 
-def help(target):
-    if len(target) > 0:
-        if target[0] in globals() and hasattr(globals()[target[0]], '__doc__'):
-            print(globals()[target[0]].__doc__)
-    else:
+def help_alias(target):
+    if len(target) == 0:
         parser.print_help(sys.stdout)
+    else:
+        print('try "reckless {} -h"'.format(' '.join(target)))
+        sys.exit(1)
 
 
 def verbose(*args):
@@ -697,9 +697,10 @@ if __name__ == '__main__':
     source_rem.add_argument('targets', type=str, nargs='*')
     source_rem.set_defaults(func=remove_source)
 
-    help_cmd = cmd1.add_parser('help', help='display this message')
+    help_cmd = cmd1.add_parser('help', help='for contextual help, use '
+                               '"reckless <cmd> -h"')
     help_cmd.add_argument('targets', type=str, nargs='*')
-    help_cmd.set_defaults(func=help)
+    help_cmd.set_defaults(func=help_alias)
 
     args = parser.parse_args()
 

--- a/tools/reckless
+++ b/tools/reckless
@@ -82,14 +82,14 @@ class InstInfo:
 
 def create_dir(r: int, directory: str) -> bool:
     """Creation of a directory at path `d` with a maximum new dir depth `r`"""
-    if os.path.exists(directory):
+    if Path(directory).exists():
         return True
     elif r <= 0:
         return False
-    elif create_dir(r-1, os.path.split(directory)[0]):
+    elif create_dir(r-1, Path(directory).parent):
         os.mkdir(directory, 0o777)
         print(f'created directory {directory}')
-        assert os.path.exists(directory)
+        assert Path(directory).exists()
         return True
 
 
@@ -116,7 +116,7 @@ class Config():
             raise Exception("Generic config must be passed a config_path.")
         assert isinstance(config_path, str)
         # FIXME: warn if reckless dir exists, but conf not found
-        if os.path.exists(config_path):
+        if Path(config_path).exists():
             with open(config_path, 'r+') as f:
                 config_content = f.readlines()
             return config_content
@@ -127,7 +127,7 @@ class Config():
             confirm = True
         if not confirm:
             sys.exit(1)
-        parent_path = os.path.split(config_path)[0]
+        parent_path = Path(config_path).parent
         # Create up to one parent in the directory tree.
         if create_dir(1, parent_path):
             with open(self.conf_fp, 'w') as f:
@@ -196,14 +196,14 @@ class RecklessConfig(Config):
     def __init__(self, path: Union[str, None] = None,
                  default_text: Union[str, None] = None):
         if path is None:
-            path = os.path.join(LIGHTNING_DIR, 'reckless',
-                                'bitcoin-reckless.conf')
+            path = Path(LIGHTNING_DIR).joinpath('reckless',
+                                                'bitcoin-reckless.conf')
         if default_text is None:
             default_text = '# This configuration file is managed by reckles' +\
                            's to activate and disable\n# reckless-installed' +\
                            ' plugins\n\n'
         Config.__init__(self, path=str(path), default_text=default_text)
-        self.reckless_dir = os.path.split(path)[0]
+        self.reckless_dir = Path(path).parent
 
 
 class LightningBitcoinConfig(Config):
@@ -214,7 +214,7 @@ class LightningBitcoinConfig(Config):
                  default_text: Union[str, None] = None,
                  warn: bool = True):
         if path is None:
-            path = os.path.join(LIGHTNING_DIR, 'bitcoin', 'config')
+            path = Path(LIGHTNING_DIR).joinpath('bitcoin', 'config')
         if default_text is None:
             default_text = "# This config was autopopulated by reckless\n\n"
         Config.__init__(self, path=str(path),
@@ -228,16 +228,16 @@ class InferInstall():
         if name[-3:] == '.py':
             name = name[:-3]
         if name in reck_contents:
-            self.dir = os.path.join(RECKLESS_CONFIG.reckless_dir, name)
+            self.dir = Path(RECKLESS_CONFIG.reckless_dir).joinpath(name)
         else:
             raise Exception(f"Could not find a reckless directory for {name}")
-        plug_contents = os.listdir(os.path.join(RECKLESS_CONFIG.reckless_dir,
-                                                name))
-        for n in py_entry_guesses(name):
-            if n in plug_contents:
-                self.entry = os.path.join(self.dir, n)
-                self.name = n
-                return
+        plug_dir = Path(RECKLESS_CONFIG.reckless_dir).joinpath(name)
+        for guess in py_entry_guesses(name):
+            for content in plug_dir.iterdir():
+                if content.name == guess:
+                    self.entry = str(content)
+                    self.name = guess
+                    return
         raise Exception(f'plugin entrypoint not found in {self.dir}')
 
 
@@ -325,10 +325,9 @@ def _install_plugin(src: InstInfo) -> bool:
         sys.exit(1)
     # Use a unique directory for each cloned repo.
     clone_path = 'reckless-{}'.format(str(hash(os.times()))[-9:])
-    clone_path = os.path.join(tempfile.gettempdir(), clone_path)
-    inst_path = os.path.join(RECKLESS_CONFIG.reckless_dir,
-                             src.name)
-    if os.path.exists(clone_path):
+    clone_path = Path(tempfile.gettempdir()).joinpath(clone_path)
+    inst_path = Path(RECKLESS_CONFIG.reckless_dir).joinpath(src.name)
+    if Path(clone_path).exists():
         verbose(f'{clone_path} already exists - deleting')
         shutil.rmtree(clone_path)
     # clone git repository to /tmp/reckless-...
@@ -344,13 +343,13 @@ def _install_plugin(src: InstInfo) -> bool:
         if git.returncode != 0:
             if git.stderr:
                 print(git.stderr.read().decode())
-            if os.path.exists(clone_path):
+            if Path(clone_path).exists():
                 remove_dir(clone_path)
             print('Error: Failed to clone repo')
             return False
     plugin_path = clone_path
     if src.subdir is not None:
-        plugin_path = os.path.join(clone_path, src.subdir)
+        plugin_path = Path(clone_path).joinpath(src.subdir)
     os.chdir(plugin_path)
     if src.commit:
         verbose(f"Checking out commit {src.commit}")
@@ -381,7 +380,7 @@ def _install_plugin(src: InstInfo) -> bool:
             print('error encountered installing dependencies')
             verbose(pip.stdout.read())
             return False
-    test = Popen([os.path.join(plugin_path, src.entry)],
+    test = Popen([Path(plugin_path).joinpath(src.entry)],
                  stdout=PIPE, stderr=PIPE, universal_newlines=True)
     test_log = []
     with test.stderr:
@@ -412,9 +411,8 @@ def install(plugin_name: str):
         if not _install_plugin(src):
             print('installation aborted')
             sys.exit(1)
-        inst_path = os.path.join(RECKLESS_CONFIG.reckless_dir,
-                                 src.name,
-                                 src.entry)
+        inst_path = Path(RECKLESS_CONFIG.reckless_dir).joinpath(src.name,
+                                                                src.entry)
         RECKLESS_CONFIG.enable_plugin(inst_path)
         enable(plugin_name)
 
@@ -424,7 +422,7 @@ def uninstall(plugin_name: str):
     assert isinstance(plugin_name, str)
     print(f'Uninstalling plugin {plugin_name}')
     disable(plugin_name)
-    plugin_dir = os.path.join(RECKLESS_CONFIG.reckless_dir, plugin_name)
+    plugin_dir = Path(RECKLESS_CONFIG.reckless_dir).joinpath(plugin_name)
     verbose(f'looking for {plugin_dir}')
     if remove_dir(plugin_dir):
         print(f"{plugin_name} uninstalled successfully.")
@@ -464,7 +462,7 @@ def enable(plugin_name: str):
     assert isinstance(plugin_name, str)
     inst = InferInstall(plugin_name)
     path = inst.entry
-    if not os.path.exists(path):
+    if not Path(path).exists():
         print('cannot find installed plugin at expected path {}'
               .format(path))
         sys.exit(1)
@@ -500,7 +498,7 @@ def disable(plugin_name: str):
     assert isinstance(plugin_name, str)
     inst = InferInstall(plugin_name)
     path = inst.entry
-    if not os.path.exists(path):
+    if not Path(path).exists():
         sys.stderr.write(f'Could not find plugin at {path}\n')
         sys.exit(1)
     if not lightning_cli_available():
@@ -539,19 +537,19 @@ def load_config(reckless_dir: Union[str, None] = None,
             if 'conf' in output:
                 net_conf = LightningBitcoinConfig(path=output['conf'])
     if reckless_dir is None:
-        reckless_dir = str(os.path.join(LIGHTNING_DIR, 'reckless'))
+        reckless_dir = Path(LIGHTNING_DIR).joinpath('reckless')
     else:
         if not os.path.isabs(reckless_dir):
-            reckless_dir = os.path.join(os.getcwd(), reckless_dir)
+            reckless_dir = Path.cwd().joinpath(reckless_dir)
     # Reckless applies to the bitcoin network configuration by default.
     if network == 'bitcoin':
-        reck_conf_path = os.path.join(reckless_dir, 'bitcoin-reckless.conf')
+        reck_conf_path = Path(reckless_dir).joinpath('bitcoin-reckless.conf')
         if not net_conf:
             # This config file inherits the RecklessConfig.
             net_conf = LightningBitcoinConfig()
     elif network == 'regtest':
-        reck_conf_path = os.path.join(reckless_dir, 'regtest-reckless.conf')
-        regtest_path = os.path.join(LIGHTNING_DIR, 'regtest', 'config')
+        reck_conf_path = Path(reckless_dir).joinpath('regtest-reckless.conf')
+        regtest_path = Path(LIGHTNING_DIR).joinpath('regtest', 'config')
         if not net_conf:
             # Actually the regtest network config
             net_conf = LightningBitcoinConfig(path=regtest_path)
@@ -571,7 +569,7 @@ def load_config(reckless_dir: Union[str, None] = None,
 
 
 def get_sources_file() -> str:
-    return os.path.join(RECKLESS_DIR, '.sources')
+    return Path(RECKLESS_DIR).joinpath('.sources')
 
 
 def sources_from_file() -> list:
@@ -589,7 +587,7 @@ def loadSources() -> list:
     """Look for the repo sources file."""
     sources_file = get_sources_file()
     # This would have been created if possible
-    if not os.path.exists(sources_file):
+    if not Path(sources_file).exists():
         print('Warning: Reckless requires write access')
         Config(path=sources_file,
                default_text='https://github.com/lightningd/plugins')
@@ -602,7 +600,7 @@ def add_source(src: str):
     assert isinstance(src, str)
     # Is it a file?
     maybe_path = os.path.realpath(src)
-    if os.path.exists(maybe_path):
+    if Path(maybe_path).exists():
         # FIXME: This should handle either a directory or a git repo
         if os.path.isdir(maybe_path):
             print(f'Plugin source directory found: {maybe_path}')
@@ -700,7 +698,7 @@ if __name__ == '__main__':
     if args.reckless_dir:
         RECKLESS_DIR = args.reckless_dir
     else:
-        RECKLESS_DIR = os.path.join(LIGHTNING_DIR, 'reckless')
+        RECKLESS_DIR = Path(LIGHTNING_DIR).joinpath('reckless')
     RECKLESS_CONFIG = load_config(reckless_dir=RECKLESS_DIR,
                                   network=NETWORK)
     RECKLESS_SOURCES = loadSources()

--- a/tools/reckless
+++ b/tools/reckless
@@ -34,9 +34,8 @@ class InstInfo:
         self.commit = None
 
     def __repr__(self):
-        return f'<InstInfo object>\n'\
-               f'name: {self.name}\nrepo: {self.repo}\ngit: {self.git_url}'\
-               f'\nentry:{self.entry}\ndepency source:{self.deps}'
+        return (f'InstInfo({self.name}, {self.repo}, {self.git_url}'
+                f'{self.entry}, {self.deps})')
 
     def get_inst_details(self):
         """
@@ -199,9 +198,10 @@ class RecklessConfig(Config):
             path = Path(LIGHTNING_DIR).joinpath('reckless',
                                                 'bitcoin-reckless.conf')
         if default_text is None:
-            default_text = '# This configuration file is managed by reckles' +\
-                           's to activate and disable\n# reckless-installed' +\
-                           ' plugins\n\n'
+            default_text = (
+                '# This configuration file is managed by reckless to activate '
+                'and disable\n# reckless-installed plugins\n\n'
+            )
         Config.__init__(self, path=str(path), default_text=default_text)
         self.reckless_dir = Path(path).parent
 
@@ -579,7 +579,6 @@ def sources_from_file() -> list:
         for src in f.readlines():
             if len(src.strip()) > 0:
                 read_sources.append(src.strip())
-        # print('loaded sources:', repos)
         return read_sources
 
 

--- a/tools/reckless
+++ b/tools/reckless
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen, PIPE
+import sys
+import json
+import os
+import argparse
+from pathlib import Path
+import shutil
+import tempfile
+import requests
+
+
+repos = ['https://github.com/lightningd/plugins']
+
+
+def py_entry_guesses(name):
+    return [name, f'{name}.py', '__init__.py']
+
+
+def unsupported_entry(name):
+    return [f'{name}.go', f'{name}.sh']
+
+
+class InstInfo:
+    def __init__(self, name, url, git_url):
+        self.name = name
+        self.repo = url         # Used for 'git clone'
+        self.git_url = git_url  # API access for github repos
+        self.entry = None
+        self.deps = None
+        self.subdir = None
+        self.commit = None
+
+    def __repr__(self):
+        return f'<InstInfo object>\n'\
+               f'name: {self.name}\nrepo: {self.repo}\ngit: {self.git_url}'\
+               f'\nentry:{self.entry}\ndepency source:{self.deps}'
+
+    def get_inst_details(self):
+        """
+        Populate installation details from a github repo url.
+        Return True if all data is found.
+        """
+        r = requests.get(self.git_url)
+        if r.status_code != 200:
+            return False
+        if 'git/tree' in self.git_url:
+            tree = r.json()['tree']
+        else:
+            tree = r.json()
+        entry_guesses = py_entry_guesses(self.name)
+        for g in entry_guesses:
+            for f in tree:
+                if f['path'] == g:
+                    self.entry = g
+                    break
+            if self.entry is not None:
+                break
+        if self.entry is None:
+            for g in unsupported_entry(self.name):
+                for f in tree:
+                    if f['path'] == g:
+                        # FIXME: This should be easier to implement
+                        print(f'entrypoint {g} is not yet supported')
+                        return False
+        dependency_info = ['requirements.txt', 'pyproject.toml']
+        for d in dependency_info:
+            for f in tree:
+                if f['path'] == d:
+                    self.deps = d
+                    break
+            if self.deps is not None:
+                break
+        if not self.entry:
+            return False
+        if not self.deps:
+            return False
+        return True
+
+
+def create_dir(r, directory):
+    """Creation of a directory at path `d` with a maximum new dir depth `r`"""
+    if os.path.exists(directory):
+        return True
+    elif r <= 0:
+        return False
+    elif create_dir(r-1, os.path.split(directory)[0]):
+        os.mkdir(directory, 0o777)
+        print(f'created directory {directory}')
+        if os.path.exists(directory):
+            return True
+
+
+def remove_dir(target):
+    try:
+        shutil.rmtree(target)
+        return True
+    except NotADirectoryError:
+        print(f"Tried to remove directory {target} that does not exist.")
+    except PermissionError:
+        print(f"Permission denied removing dir: {target}")
+    return False
+
+
+class Config():
+    """A generic class for procuring, reading and editing config files"""
+    def obtain_config(self, config_path, default_text):
+        """Return a config file from the desired location. Create one with
+        default_text if it cannot be found."""
+        if isinstance(config_path, type(None)):
+            raise Exception("Generic config must be passed a config_path.")
+        assert isinstance(config_path, str)
+        # FIXME: warn if reckless dir exists, but conf not found
+        if os.path.exists(config_path):
+            with open(config_path, 'r+') as f:
+                config_content = f.readlines()
+            return config_content
+        print(f'config file not found: {config_path}')
+        confirm = input('press [Y] to create one now.\n')
+        if confirm.upper() != 'Y':
+            sys.exit(1)
+        parent_path = os.path.split(config_path)[0]
+        # Create up to one parent in the directory tree.
+        if create_dir(1, parent_path):
+            with open(self.conf_fp, 'w') as f:
+                f.write(default_text)
+                # FIXME: Handle write failure
+                return default_text
+        else:
+            print('could not create the parent directory')
+            return None
+
+    def editConfigFile(self, addline, removeline):
+        remove_these_lines = []
+        with open(self.conf_fp, 'r') as reckless_conf:
+            original = reckless_conf.readlines()
+            empty_lines = []
+            for n, l in enumerate(original):
+                if l.strip() == removeline:
+                    remove_these_lines.append(n)
+                    continue
+                if l.strip() == '':
+                    empty_lines.append(n)
+                    if n-1 in empty_lines:
+                        # The white space is getting excessive.
+                        remove_these_lines.append(n)
+                        continue
+            with open(self.conf_fp, 'w') as conf_write:
+                # no need to write if passed 'None'
+                line_exists = not bool(addline)
+                for n, l in enumerate(original):
+                    if n not in remove_these_lines:
+                        if n > 0:
+                            conf_write.write(f'\n{l.strip()}')
+                        else:
+                            conf_write.write(l.strip())
+                        if addline == l:
+                            # addline is idempotent
+                            line_exists = True
+                if not line_exists:
+                    conf_write.write(f'\n{addline}')
+
+    def __init__(self, path=None, default_text=None):
+        assert path is not None
+        assert default_text is not None
+        self.conf_fp = path
+        self.content = self.obtain_config(self.conf_fp, default_text)
+
+
+class RecklessConfig(Config):
+    """Reckless config (by default, specific to the bitcoin network only.)
+    This is inherited by the lightningd config and contains all reckless
+    maintained plugins."""
+
+    def enable_plugin(self, plugin_path):
+        """Handle persistent plugin loading via config"""
+        self.editConfigFile(f'plugin={plugin_path}',
+                            f'disable-plugin={plugin_path}')
+
+    def disable_plugin(self, plugin_path):
+        """Handle persistent plugin disabling via config"""
+        self.editConfigFile(f'disable-plugin={plugin_path}',
+                            f'plugin={plugin_path}')
+
+    def __init__(self, path=None, default_text=None):
+        if path is None:
+            path = os.path.join(LIGHTNING_DIR, 'reckless',
+                                'bitcoin-reckless.conf')
+        if default_text is None:
+            default_text = '# This configuration file is managed by reckles' +\
+                           's to activate and disable\n# reckless-installed' +\
+                           ' plugins\n\n'
+        Config.__init__(self, path=str(path), default_text=default_text)
+        self.reckless_dir = os.path.split(path)[0]
+
+
+class LightningBitcoinConfig(Config):
+    """lightningd config specific to the bitcoin network. This is inherited by
+    the main lightningd config and in turn, inherits bitcoin-reckless.conf."""
+
+    def __init__(self, path=None, default_text=None):
+        if path is None:
+            path = os.path.join(LIGHTNING_DIR, 'bitcoin', 'config')
+        if default_text is None:
+            default_text = "# This config was autopopulated by reckless\n\n"
+        Config.__init__(self, path=str(path),
+                        default_text=default_text)
+
+
+class InferInstall():
+    """Once a plugin is installed, we may need its directory and entrypoint"""
+    def __init__(self, name):
+        reck_contents = os.listdir(RECKLESS_CONFIG.reckless_dir)
+        if name[-3:] == '.py':
+            name = name[:-3]
+        if name in reck_contents:
+            self.dir = os.path.join(RECKLESS_CONFIG.reckless_dir, name)
+        else:
+            raise Exception(f"Could not find a reckless directory for {name}")
+        plug_contents = os.listdir(os.path.join(RECKLESS_CONFIG.reckless_dir,
+                                                name))
+        for n in py_entry_guesses(name):
+            if n in plug_contents:
+                self.entry = os.path.join(self.dir, n)
+                self.name = n
+                return
+        raise Exception(f'plugin entrypoint not found in {self.dir}')
+
+
+def help(target):
+    if len(target) > 0:
+        print(globals()[target[0]].__doc__)
+    else:
+        parser.print_help(sys.stdout)
+
+
+def verbose(*args):
+    if not IS_VERBOSE:
+        return
+    print(*args)
+
+
+def _search_repo(name, url):
+    """look in given repo and, if found, populate InstInfo"""
+    # Remove api subdomain, subdirectories, etc.
+    repo = url.split('/')
+    while '' in repo:
+        repo.remove('')
+    repo_name = None
+    for i in range(len(repo)):
+        if 'github.com' in repo[i]:
+            # Extract user and repo name
+            start = i + 1
+            if repo[start] == 'repo':
+                # Maybe we were passed an api.github.com/repo/<user> url
+                start = start + 1
+            repo_user = repo[start]
+            repo_name = repo[start+1]
+            break
+    # FIXME: Handle non-github repos.
+    # Get details from the github API.
+    if repo_name is not None:
+        api_url = f'https://api.github.com/repos/{repo_user}/' + \
+                  f'{repo_name}/contents/'
+    plugins_cont = api_url
+    r = requests.get(plugins_cont, timeout=5)
+    if r.status_code != 200:
+        print("Plugin repository unavailable")
+        return False
+    # Repo is for this plugin
+    if repo_name == name:
+        MyPlugin = InstInfo(name, f'https://github.com/{repo_user}/'
+                            f'{repo_name}', api_url)
+        if not MyPlugin.get_inst_details():
+            return False
+        return MyPlugin
+    # Repo contains multiple plugins?
+    for x in r.json():
+        if x["name"] == name:
+            # Look for the rest of the install details
+            # These are in lightningd/plugins directly
+            if 'lightningd/plugins/' in x['html_url']:
+                MyPlugin = InstInfo(name,
+                                    'https://github.com/lightningd/plugins',
+                                    x['git_url'])
+                MyPlugin.subdir = x['name']
+            # submodules from another github repo
+            else:
+                MyPlugin = InstInfo(name, x['html_url'], x['git_url'])
+                # Submodule URLs are appended with /tree/<commit hash>
+                if MyPlugin.repo.split('/')[-2] == 'tree':
+                    MyPlugin.commit = MyPlugin.repo.split('/')[-1]
+                    MyPlugin.repo = MyPlugin.repo.split('/tree/')[0]
+                    verbose(f'repo using commit: {MyPlugin.commit}')
+            if not MyPlugin.get_inst_details():
+                return False
+            return MyPlugin
+    return False
+
+
+def _install_plugin(src):
+    """make sure the repo exists and clone it."""
+    verbose(f'Install requested from {src}.')
+    if RECKLESS_CONFIG is None:
+        print('error: reckless install directory unavailable')
+        sys.exit(2)
+    req = requests.get(src.repo, timeout=20)
+    if not req.status_code == 200:
+        print('plugin source repository unavailable')
+        sys.exit(1)
+    # Use a unique directory for each cloned repo.
+    clone_path = 'reckless-{}'.format(str(hash(os.times()))[-9:])
+    clone_path = os.path.join(tempfile.gettempdir(), clone_path)
+    inst_path = os.path.join(RECKLESS_CONFIG.reckless_dir,
+                             src.name)
+    if os.path.exists(clone_path):
+        verbose(f'{clone_path} already exists - deleting')
+        shutil.rmtree(clone_path)
+    # clone git repository to /tmp/reckless-...
+    if ('http' in src.repo[:4]) or ('github.com' in src.repo):
+        # Ugly, but interactively handling stderr gets hairy.
+        if IS_VERBOSE:
+            git = Popen(['git', 'clone',  src.repo, clone_path],
+                        stdout=PIPE)
+        else:
+            git = Popen(['git', 'clone',  src.repo, clone_path],
+                        stdout=PIPE, stderr=PIPE)
+        git.wait()
+        if git.returncode != 0:
+            if git.stderr:
+                print(git.stderr.read().decode())
+            if os.path.exists(clone_path):
+                remove_dir(clone_path)
+            print('Error: Failed to clone repo')
+            return False
+    plugin_path = clone_path
+    if src.subdir is not None:
+        plugin_path = os.path.join(clone_path, src.subdir)
+    os.chdir(plugin_path)
+    if src.commit:
+        verbose(f"Checking out commit {src.commit}")
+        checkout = Popen(['git', 'checkout', src.commit],
+                         stdout=PIPE, stderr=PIPE)
+        checkout.wait()
+        if checkout.returncode != 0:
+            print(f'failed to checkout referenced commit {src.commit}')
+            return False
+    # Install dependencies via requirements.txt
+    install_methods = {
+        'requirements.txt': ['pip', 'install', '-r', 'requirements.txt'],
+        'pyproject.toml': ['pip', 'install', '-e', '.']
+    }
+
+    if src.deps is not None:
+        verbose(f'installing dependencies using {src.deps}')
+        procedure = install_methods[src.deps]
+        pip = Popen(procedure, stdout=PIPE)
+        pip.wait()
+        if pip.returncode == 0:
+            print('dependencies installed successfully')
+        else:
+            print('error encountered installing dependencies')
+            verbose(pip.stdout.read())
+            return False
+    test = Popen([os.path.join(plugin_path, src.entry)],
+                 stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    test_log = []
+    with test.stderr:
+        for line in test.stderr:
+            test_log.append(line.strip('\n'))
+    test.wait()
+    # FIXME: add noexec test/warning. Maybe try chmod entrypoint.
+    if test.returncode != 0:
+        verbose("plugin testing error:")
+        for line in test_log:
+            verbose(f'  {line}')
+        print('plugin testing failed')
+        return False
+
+    # Find this cute little plugin a forever home
+    shutil.copytree(plugin_path, inst_path)
+    print(f'plugin installed: {inst_path}')
+    remove_dir(clone_path)
+    return True
+
+
+def install(plugin_name):
+    """reckless install <plugin>
+    downloads plugin from source repos, installs and activates plugin"""
+    assert isinstance(plugin_name, list)
+    plugin_name = plugin_name[0]
+    if plugin_name is None:
+        print('missing argument: plugin_name')
+
+    src = search([plugin_name])
+
+    if src:
+        verbose(f'Retrieving {plugin_name} from {src.repo}')
+        if not _install_plugin(src):
+            print('installation aborted')
+            sys.exit(1)
+        inst_path = os.path.join(RECKLESS_CONFIG.reckless_dir,
+                                 src.name,
+                                 src.entry)
+        RECKLESS_CONFIG.enable_plugin(inst_path)
+        enable([plugin_name])
+
+
+def uninstall(plugin_name):
+    """reckless uninstall <plugin>
+    disables plugin and deletes the plugin's reckless dir"""
+    assert isinstance(plugin_name, list)
+    plugin_name = plugin_name[0]
+    if plugin_name is not None:
+        # FIXME: Do something here.
+        print('Uninstalling plugin {}'.format(plugin_name))
+        disable([plugin_name])
+        plugin_dir = os.path.join(RECKLESS_CONFIG.reckless_dir, plugin_name)
+        verbose("looking for {}".format(plugin_dir))
+        if remove_dir(plugin_dir):
+            print(f"{plugin_name} uninstalled successfully.")
+
+
+def search(plugin_name):
+    """reckless search <plugin>
+    searches plugin index for plugin"""
+    plugin_name = plugin_name[0]
+    if plugin_name is None:
+        print('plugin name required')
+        return None
+    ordered_repos = RECKLESS_SOURCES
+    for r in RECKLESS_SOURCES:
+        if r.split('/')[-1].lower() == plugin_name.lower():
+            ordered_repos.remove(r)
+            ordered_repos.insert(0, r)
+    for r in ordered_repos:
+        p = _search_repo(plugin_name, r)
+        if p:
+            print(f"found {p.name} in repo: {p.repo}")
+            verbose(f"entry: {p.entry}")
+            if p.subdir:
+                verbose(f'sub-directory: {p.subdir}')
+            return p
+    print(f'Unable to locate source for plugin {plugin_name}')
+
+
+def lightning_cli_available():
+    clncli = Popen(['lightning-cli'], stdout=PIPE, stderr=PIPE)
+    clncli.wait(timeout=1)
+    if clncli.returncode == 0:
+        return True
+    else:
+        return False
+
+
+def enable(plugin_name):
+    """reckless enable <plugin>
+    dynamically activates plugin and adds to config (persistent)"""
+    assert isinstance(plugin_name, list)
+    plugin_name = plugin_name[0]
+    if plugin_name is None:
+        sys.stderr.write('Plugin name required.')
+        sys.exit(1)
+    inst = InferInstall(plugin_name)
+    path = inst.entry
+    if not os.path.exists(path):
+        print('cannot find installed plugin at expected path {}'
+              .format(path))
+        sys.exit(1)
+    verbose('activating {}'.format(plugin_name))
+
+    if not lightning_cli_available():
+        # Config update should not be dependent upon lightningd running
+        RECKLESS_CONFIG.enable_plugin(path)
+        return
+
+    clncli = Popen(['lightning-cli', 'plugin', 'start', path], stdout=PIPE)
+    clncli.wait(timeout=3)
+    if clncli.returncode == 0:
+        RECKLESS_CONFIG.enable_plugin(path)
+        print('{} enabled'.format(plugin_name))
+    else:
+        err = eval(clncli.stdout.read().decode().replace('\n', ''))['message']
+        if ': already registered' in err:
+            RECKLESS_CONFIG.enable_plugin(path)
+            verbose(f'{inst.name} already registered with lightningd')
+            print('{} enabled'.format(plugin_name))
+        else:
+            print(f'reckless: {inst.name} failed to start!')
+            print(err)
+    sys.exit(clncli.returncode)
+
+
+def disable(plugin_name):
+    """reckless disable <plugin>
+    deactivates an installed plugin"""
+    assert isinstance(plugin_name, list)
+    plugin_name = plugin_name[0]
+    if plugin_name is None:
+        sys.stderr.write('Plugin name required.')
+        sys.exit(1)
+    inst = InferInstall(plugin_name)
+    path = inst.entry
+    if not os.path.exists(path):
+        sys.stderr.write(f'Could not find plugin at {path}\n')
+        sys.exit(1)
+    if not lightning_cli_available():
+        RECKLESS_CONFIG.disable_plugin(path)
+        print(f'{plugin_name} disabled')
+        return
+    clncli = Popen(['lightning-cli', 'plugin', 'stop', path],
+                   stdout=PIPE, stderr=PIPE)
+    clncli.wait(timeout=3)
+    output = json.loads(clncli.stdout.read().decode()
+                        .replace('\n', '').replace('   ', ''))
+    # print(output)
+    if ('code' in output.keys() and output['code'] == -32602):
+        print('plugin not currently running')
+    elif clncli.returncode != 0:
+        print('lightning-cli plugin stop failed')
+        sys.stderr.write(clncli.stderr.read().decode())
+        sys.exit(clncli.returncode)
+    RECKLESS_CONFIG.disable_plugin(path)
+    print(f'{plugin_name} disabled')
+
+
+def load_config(reckless_dir=None, network='bitcoin'):
+    """Initial directory discovery and config file creation."""
+    if reckless_dir is None:
+        reckless_dir = str(os.path.join(LIGHTNING_DIR, 'reckless'))
+    else:
+        if not os.path.isabs(reckless_dir):
+            reckless_dir = os.path.join(os.getcwd(), reckless_dir)
+    # Reckless applies to the bitcoin network configuration by default.
+    if network == 'bitcoin':
+        reck_conf_path = os.path.join(reckless_dir, 'bitcoin-reckless.conf')
+        # This config file inherits the RecklessConfig.
+        net_conf = LightningBitcoinConfig()
+    elif network == 'regtest':
+        reck_conf_path = os.path.join(reckless_dir, 'regtest-reckless.conf')
+        regtest_path = os.path.join(LIGHTNING_DIR, 'regtest', 'config')
+        # Actually the regtest network config
+        net_conf = LightningBitcoinConfig(path=regtest_path)
+    # Reckless manages plugins here.
+    reckless_conf = RecklessConfig(path=reck_conf_path)
+    if not reckless_conf:
+        print('Error: reckless config file could not be written')
+        sys.exit(1)
+    if not net_conf:
+        print('Error: could not load or create the network specific lightningd'
+              ' config (default .lightning/bitcoin)')
+        sys.exit(1)
+    net_conf.editConfigFile(f'include {reckless_conf.conf_fp}', None)
+    return reckless_conf
+
+
+def get_sources_file():
+    return os.path.join(RECKLESS_DIR, '.sources')
+
+
+def sources_from_file():
+    sources_file = get_sources_file()
+    read_sources = []
+    with open(sources_file, 'r') as f:
+        for src in f.readlines():
+            if len(src.strip()) > 0:
+                read_sources.append(src.strip())
+        # print('loaded sources:', repos)
+        return read_sources
+
+
+def loadSources():
+    """Look for the repo sources file"""
+    sources_file = get_sources_file()
+    # This would have been created if possible
+    if not os.path.exists(sources_file):
+        print('Warning: Reckless requires write access')
+        Config(path=sources_file,
+               default_text='https://github.com/lightningd/plugins')
+        return ['https://github.com/lightningd/plugins']
+    return sources_from_file()
+
+
+def add_source(src):
+    """Additional git repositories, directories, etc. are passed here
+    singly."""
+    # Is it a file?
+    assert isinstance(src, str)
+    maybe_path = os.path.realpath(src)
+    if os.path.exists(maybe_path):
+        # FIXME: This should handle either a directory or a git repo
+        if os.path.isdir(maybe_path):
+            print(f'Plugin source directory found: {maybe_path}')
+    elif 'github.com' in src:
+        my_file = Config(path=str(get_sources_file()),
+                         default_text='https://github.com/lightningd/plugins')
+        my_file.editConfigFile(src, None)
+
+
+def remove_source(src):
+    assert isinstance(src, str)
+    if src in sources_from_file():
+        my_file = Config(path=get_sources_file(),
+                         default_text='https://github.com/lightningd/plugins')
+        my_file.editConfigFile(None, src)
+        print('plugin source removed')
+    else:
+        print(f'source not found: {src}')
+
+
+def list_source():
+    for src in sources_from_file():
+        print(src)
+
+
+def source(cmd):
+    """reckless source <add/remove/list>
+    reckless source add <github repository url>      adds a source to search
+    reckless source remove <github repository url>   removes a source
+    reckless source list                             lists all sources
+    """
+    assert isinstance(cmd, list)
+    if cmd[0] == 'add':
+        for src in cmd[1:]:
+            add_source(src)
+    elif cmd[0] == 'remove' or cmd[0] == 'rem' or cmd[0] == 'rm':
+        for src in cmd[1:]:
+            remove_source(src)
+    elif cmd[0] == 'list':
+        list_source()
+    else:
+        print('unrecognized argument to reckless source: {cmd[0]}')
+        sys.exit(1)
+
+
+def sources(cmd):
+    # alias to improve ux
+    source(cmd)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(dest='command', help='install/uninstall/search/enable'
+                        '/disable/source/help',
+                        type=str)
+    # Here we pass a list of argument in as target. This is useful for
+    # subcommands (i.e., reckless source add <repo>) as well as for passing
+    # lists of plugins to handle in sequence (to be implemented.)
+    parser.add_argument(dest='target', nargs='*', default=None, help='target',
+                        type=str)
+    # This default depends on the .lightning directory
+    parser.add_argument('-d', '--reckless-dir',
+                        help='specify a data directory for reckless to use',
+                        type=str, default=None)
+    parser.add_argument('-l', '--lightning',
+                        help='lightning data directory (default:~/.lightning)',
+                        type=str,
+                        default=Path.home().joinpath('.lightning'))
+    parser.add_argument('-r', '--regtest', action='store_true')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+
+    if hasattr(args, 'command'):
+        if args.command in ['install', 'uninstall', 'search', 'enable',
+                            'disable', 'help', 'source', 'sources']:
+            NETWORK = 'regtest' if args.regtest else 'bitcoin'
+            LIGHTNING_DIR = Path(args.lightning)
+            if args.reckless_dir:
+                RECKLESS_DIR = args.reckless_dir
+            else:
+                RECKLESS_DIR = os.path.join(LIGHTNING_DIR, 'reckless')
+            RECKLESS_CONFIG = load_config(reckless_dir=RECKLESS_DIR,
+                                          network=NETWORK)
+            RECKLESS_SOURCES = loadSources()
+            IS_VERBOSE = bool(args.verbose)
+            globals()[args.command](args.target)
+            sys.exit(0)
+        else:
+            print(f'{args.command}: command unrecognized')

--- a/tools/reckless
+++ b/tools/reckless
@@ -350,10 +350,14 @@ def _install_plugin(src):
         if checkout.returncode != 0:
             print(f'failed to checkout referenced commit {src.commit}')
             return False
-    # Install dependencies via requirements.txt
+
+    # Install dependencies via requirements.txt or pyproject.toml
+    mypip = 'pip3' if shutil.which('pip3') else 'pip'
+    if not shutil.which(mypip):
+        raise Exception(f'{mypip} not found in PATH')
     install_methods = {
-        'requirements.txt': ['pip', 'install', '-r', 'requirements.txt'],
-        'pyproject.toml': ['pip', 'install', '-e', '.']
+        'requirements.txt': [mypip, 'install', '-r', 'requirements.txt'],
+        'pyproject.toml': [mypip, 'install', '-e', '.']
     }
 
     if src.deps is not None:

--- a/tools/reckless
+++ b/tools/reckless
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import requests
 from typing import Union
+from urllib.parse import urlparse
 
 
 repos = ['https://github.com/lightningd/plugins']
@@ -262,21 +263,21 @@ def _search_repo(name: str, url: str) -> InstInfo:
     while '' in repo:
         repo.remove('')
     repo_name = None
-    for i in range(len(repo)):
-        if 'github.com' in repo[i]:
-            # Extract user and repo name
-            start = i + 1
-            if repo[start] == 'repo':
-                # Maybe we were passed an api.github.com/repo/<user> url
-                start = start + 1
-            repo_user = repo[start]
-            repo_name = repo[start+1]
-            break
-    # FIXME: Handle non-github repos.
+    parsed_url = urlparse(url)
+    if 'github.com' not in parsed_url.netloc:
+        # FIXME: Handle non-github repos.
+        return False
+    if len(parsed_url.path.split('/')) < 2:
+        return False
+    start = 1
+    # Maybe we were passed an api.github.com/repo/<user> url
+    if 'api' in parsed_url.netloc:
+        start += 1
+    repo_user = parsed_url.path.split('/')[start]
+    repo_name = parsed_url.path.split('/')[start + 1]
+
     # Get details from the github API.
-    if repo_name is not None:
-        api_url = f'https://api.github.com/repos/{repo_user}/' + \
-                  f'{repo_name}/contents/'
+    api_url = f'https://api.github.com/repos/{repo_user}/{repo_name}/contents/'
     plugins_cont = api_url
     r = requests.get(plugins_cont, timeout=5)
     if r.status_code != 200:
@@ -284,8 +285,9 @@ def _search_repo(name: str, url: str) -> InstInfo:
         return False
     # Repo is for this plugin
     if repo_name == name:
-        MyPlugin = InstInfo(name, f'https://github.com/{repo_user}/'
-                            f'{repo_name}', api_url)
+        MyPlugin = InstInfo(name,
+                            f'https://github.com/{repo_user}/{repo_name}',
+                            api_url)
         if not MyPlugin.get_inst_details():
             return False
         return MyPlugin

--- a/tools/reckless
+++ b/tools/reckless
@@ -234,7 +234,8 @@ class InferInstall():
 
 def help(target):
     if len(target) > 0:
-        print(globals()[target[0]].__doc__)
+        if target[0] in globals() and hasattr(globals()[target[0]], '__doc__'):
+            print(globals()[target[0]].__doc__)
     else:
         parser.print_help(sys.stdout)
 
@@ -607,9 +608,11 @@ def loadSources():
     return sources_from_file()
 
 
-def add_source(src):
+def add_source(sources):
     """Additional git repositories, directories, etc. are passed here
-    singly."""
+    as a list."""
+    assert isinstance(sources, list)
+    src = sources[0]
     # Is it a file?
     assert isinstance(src, str)
     maybe_path = os.path.realpath(src)
@@ -623,7 +626,9 @@ def add_source(src):
         my_file.editConfigFile(src, None)
 
 
-def remove_source(src):
+def remove_source(sources):
+    assert isinstance(sources, list)
+    src = sources[0]
     assert isinstance(src, str)
     if src in sources_from_file():
         my_file = Config(path=get_sources_file(),
@@ -639,41 +644,8 @@ def list_source():
         print(src)
 
 
-def source(cmd):
-    """reckless source <add/remove/list>
-    reckless source add <github repository url>      adds a source to search
-    reckless source remove <github repository url>   removes a source
-    reckless source list                             lists all sources
-    """
-    assert isinstance(cmd, list)
-    if cmd[0] == 'add':
-        for src in cmd[1:]:
-            add_source(src)
-    elif cmd[0] == 'remove' or cmd[0] == 'rem' or cmd[0] == 'rm':
-        for src in cmd[1:]:
-            remove_source(src)
-    elif cmd[0] == 'list':
-        list_source()
-    else:
-        print('unrecognized argument to reckless source: {cmd[0]}')
-        sys.exit(1)
-
-
-def sources(cmd):
-    # alias to improve ux
-    source(cmd)
-
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument(dest='command', help='install/uninstall/search/enable'
-                        '/disable/source/help',
-                        type=str)
-    # Here we pass a list of argument in as target. This is useful for
-    # subcommands (i.e., reckless source add <repo>) as well as for passing
-    # lists of plugins to handle in sequence (to be implemented.)
-    parser.add_argument(dest='target', nargs='*', default=None, help='target',
-                        type=str)
     # This default depends on the .lightning directory
     parser.add_argument('-d', '--reckless-dir',
                         help='specify a data directory for reckless to use',
@@ -684,27 +656,70 @@ if __name__ == '__main__':
                         default=Path.home().joinpath('.lightning'))
     parser.add_argument('-r', '--regtest', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
+    cmd1 = parser.add_subparsers(dest='cmd1', help='command',
+                                 required=True)
+
+    install_cmd = cmd1.add_parser('install', help='search for and install a '
+                                  'plugin, then test and activate')
+    install_cmd.add_argument('targets', type=str, nargs='*')
+    install_cmd.set_defaults(func=install)
+
+    uninstall_cmd = cmd1.add_parser('uninstall', help='deactivate a plugin '
+                                    'and remove it from the directory')
+    uninstall_cmd.add_argument('targets', type=str, nargs='*')
+    uninstall_cmd.set_defaults(func=uninstall)
+
+    search_cmd = cmd1.add_parser('search', help='search for a plugin from '
+                                 'the available source repositories')
+    search_cmd.add_argument('targets', type=str, nargs='*')
+    search_cmd.set_defaults(func=search)
+
+    enable_cmd = cmd1.add_parser('enable', help='dynamically enable a plugin '
+                                 'and update config')
+    enable_cmd.add_argument('targets', type=str, nargs='*')
+    enable_cmd.set_defaults(func=enable)
+    disable_cmd = cmd1.add_parser('disable', help='disable a plugin')
+    disable_cmd.add_argument('targets', type=str, nargs='*')
+    disable_cmd.set_defaults(func=disable)
+    source_parser = cmd1.add_parser('source', help='manage plugin search '
+                                    'sources')
+    source_subs = source_parser.add_subparsers(dest='source_subs',
+                                               required=True)
+    list_parse = source_subs.add_parser('list', help='list available plugin '
+                                        'sources (repositories)')
+    list_parse.set_defaults(func=list_source)
+    source_add = source_subs.add_parser('add', help='add a source repository')
+    source_add.add_argument('targets', type=str, nargs='*')
+    source_add.set_defaults(func=add_source)
+    source_rem = source_subs.add_parser('remove', aliases=['rem', 'rm'],
+                                        help='remove a plugin source '
+                                        'repository')
+    source_rem.add_argument('targets', type=str, nargs='*')
+    source_rem.set_defaults(func=remove_source)
+
+    help_cmd = cmd1.add_parser('help', help='display this message')
+    help_cmd.add_argument('targets', type=str, nargs='*')
+    help_cmd.set_defaults(func=help)
+
     args = parser.parse_args()
 
-    if hasattr(args, 'command'):
-        if args.command in ['install', 'uninstall', 'search', 'enable',
-                            'disable', 'help', 'source', 'sources']:
-            NETWORK = 'regtest' if args.regtest else 'bitcoin'
-            LIGHTNING_DIR = Path(args.lightning)
-            LIGHTNING_CLI_CALL = ['lightning-cli']
-            if NETWORK != 'bitcoin':
-                LIGHTNING_CLI_CALL.append(f'--network={NETWORK}')
-            if LIGHTNING_DIR != Path.home().joinpath('.lightning'):
-                LIGHTNING_CLI_CALL.append(f'--lightning-dir={LIGHTNING_DIR}')
-            if args.reckless_dir:
-                RECKLESS_DIR = args.reckless_dir
-            else:
-                RECKLESS_DIR = os.path.join(LIGHTNING_DIR, 'reckless')
-            RECKLESS_CONFIG = load_config(reckless_dir=RECKLESS_DIR,
-                                          network=NETWORK)
-            RECKLESS_SOURCES = loadSources()
-            IS_VERBOSE = bool(args.verbose)
-            globals()[args.command](args.target)
-            sys.exit(0)
-        else:
-            print(f'{args.command}: command unrecognized')
+    NETWORK = 'regtest' if args.regtest else 'bitcoin'
+    LIGHTNING_DIR = Path(args.lightning)
+    LIGHTNING_CLI_CALL = ['lightning-cli']
+    if NETWORK != 'bitcoin':
+        LIGHTNING_CLI_CALL.append(f'--network={NETWORK}')
+    if LIGHTNING_DIR != Path.home().joinpath('.lightning'):
+        LIGHTNING_CLI_CALL.append(f'--lightning-dir={LIGHTNING_DIR}')
+    if args.reckless_dir:
+        RECKLESS_DIR = args.reckless_dir
+    else:
+        RECKLESS_DIR = os.path.join(LIGHTNING_DIR, 'reckless')
+    RECKLESS_CONFIG = load_config(reckless_dir=RECKLESS_DIR,
+                                  network=NETWORK)
+    RECKLESS_SOURCES = loadSources()
+    IS_VERBOSE = bool(args.verbose)
+
+    if 'targets' in args:
+        args.func(args.targets)
+    else:
+        args.func()

--- a/tools/reckless
+++ b/tools/reckless
@@ -447,14 +447,48 @@ def search(plugin_name: str) -> InstInfo:
     print(f'Unable to locate source for plugin {plugin_name}')
 
 
-def lightning_cli_available() -> bool:
-    """returns True if lightning-cli rpc available with current config"""
-    clncli = Popen(LIGHTNING_CLI_CALL, stdout=PIPE, stderr=PIPE)
-    clncli.wait(timeout=1)
-    if clncli.returncode == 0:
-        return True
+class RPCError(Exception):
+    """lightning-cli fails to connect to lightningd RPC"""
+    def __init__(self, err):
+        self.err = err
+
+    def __str__(self):
+        return 'RPCError({self.err})'
+
+
+class CLIError(Exception):
+    """lightningd error response"""
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return f'CLIError({self.code} {self.message})'
+
+
+def lightning_cli(*args, timeout=15) -> dict:
+    # CLI commands will be added to any necessary options
+    cmd = LIGHTNING_CLI_CALL.copy()
+    cmd.extend(args)
+    clncli = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    clncli.wait(timeout=timeout)
+    out = clncli.stdout.read().decode()
+    if len(out) > 0 and out[0] == '{':
+        # If all goes well, a json object is typically returned
+        out = json.loads(out.replace('\n', ''))
     else:
-        return False
+        # help, -V, etc. may not return json, so stash it here.
+        out = {'content': out}
+    if clncli.returncode == 0:
+        return out
+    if clncli.returncode == 1:
+        # RPC doesn't like our input
+        # output contains 'code' and 'message'
+        raise CLIError(out['code'], out['message'])
+    if clncli.returncode == 2:
+        # RPC not available - lightningd not running or using alternate config
+        err = clncli.stderr.read().decode()
+        raise RPCError(err)
 
 
 def enable(plugin_name: str):
@@ -463,33 +497,21 @@ def enable(plugin_name: str):
     inst = InferInstall(plugin_name)
     path = inst.entry
     if not Path(path).exists():
-        print('cannot find installed plugin at expected path {}'
-              .format(path))
+        print(f'cannot find installed plugin at expected path {path}')
         sys.exit(1)
-    verbose('activating {}'.format(plugin_name))
-
-    if not lightning_cli_available():
-        # Config update should not be dependent upon lightningd running
-        RECKLESS_CONFIG.enable_plugin(path)
-        return
-
-    cmd = LIGHTNING_CLI_CALL.copy()
-    cmd.extend(['plugin', 'start', path])
-    clncli = Popen(cmd, stdout=PIPE)
-    clncli.wait(timeout=3)
-    if clncli.returncode == 0:
-        RECKLESS_CONFIG.enable_plugin(path)
-        print('{} enabled'.format(plugin_name))
-    else:
-        err = eval(clncli.stdout.read().decode().replace('\n', ''))['message']
-        if ': already registered' in err:
-            RECKLESS_CONFIG.enable_plugin(path)
-            verbose(f'{inst.name} already registered with lightningd')
-            print('{} enabled'.format(plugin_name))
+    verbose(f'activating {plugin_name}')
+    try:
+        lightning_cli('plugin', 'start', path)
+    except CLIError as err:
+        if 'already registered' in err.message:
+            verbose(f'{inst.name} is already running')
         else:
             print(f'reckless: {inst.name} failed to start!')
-            print(err)
-        sys.exit(clncli.returncode)
+            raise err
+    except RPCError:
+        verbose('lightningd rpc unavailable. Skipping dynamic activation.')
+    RECKLESS_CONFIG.enable_plugin(path)
+    print(f'{plugin_name} enabled')
 
 
 def disable(plugin_name: str):
@@ -501,22 +523,17 @@ def disable(plugin_name: str):
     if not Path(path).exists():
         sys.stderr.write(f'Could not find plugin at {path}\n')
         sys.exit(1)
-    if not lightning_cli_available():
-        RECKLESS_CONFIG.disable_plugin(path)
-        print(f'{plugin_name} disabled')
-        return
-    cmd = LIGHTNING_CLI_CALL.copy()
-    cmd.extend(['plugin', 'stop', path])
-    clncli = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    clncli.wait(timeout=3)
-    output = json.loads(clncli.stdout.read().decode()
-                        .replace('\n', '').replace('   ', ''))
-    if ('code' in output.keys() and output['code'] == -32602):
-        print('plugin not currently running')
-    elif clncli.returncode != 0:
-        print('lightning-cli plugin stop failed')
-        sys.stderr.write(clncli.stderr.read().decode())
-        sys.exit(clncli.returncode)
+    verbose(f'deactivating {plugin_name}')
+    try:
+        lightning_cli('plugin', 'stop', path)
+    except CLIError as err:
+        if err.code == -32602:
+            verbose('plugin not currently running')
+        else:
+            print('lightning-cli plugin stop failed')
+            raise err
+    except RPCError:
+        verbose('lightningd rpc unavailable. Skipping dynamic deactivation.')
     RECKLESS_CONFIG.disable_plugin(path)
     print(f'{plugin_name} disabled')
 
@@ -526,16 +543,12 @@ def load_config(reckless_dir: Union[str, None] = None,
     """Initial directory discovery and config file creation."""
     # Does the lightning-cli already reference an explicit config?
     net_conf = None
-    if lightning_cli_available():
-        cmd = LIGHTNING_CLI_CALL
-        cmd.extend(['listconfigs'])
-        clncli = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        clncli.wait(timeout=3)
-        if clncli.returncode == 0:
-            output = json.loads(clncli.stdout.read().decode()
-                                .replace('\n', '').replace('   ', ''))
-            if 'conf' in output:
-                net_conf = LightningBitcoinConfig(path=output['conf'])
+    try:
+        active_config = lightning_cli('listconfigs', timeout=3)
+        if 'conf' in active_config:
+            net_conf = LightningBitcoinConfig(path=active_config['conf'])
+    except RPCError:
+        pass
     if reckless_dir is None:
         reckless_dir = Path(LIGHTNING_DIR).joinpath('reckless')
     else:

--- a/tools/reckless
+++ b/tools/reckless
@@ -450,7 +450,7 @@ def search(plugin_name):
 
 
 def lightning_cli_available():
-    clncli = Popen(['lightning-cli'], stdout=PIPE, stderr=PIPE)
+    clncli = Popen(LIGHTNING_CLI_CALL, stdout=PIPE, stderr=PIPE)
     clncli.wait(timeout=1)
     if clncli.returncode == 0:
         return True
@@ -479,7 +479,9 @@ def enable(plugin_name):
         RECKLESS_CONFIG.enable_plugin(path)
         return
 
-    clncli = Popen(['lightning-cli', 'plugin', 'start', path], stdout=PIPE)
+    cmd = LIGHTNING_CLI_CALL.copy()
+    cmd.extend(['plugin', 'start', path])
+    clncli = Popen(cmd, stdout=PIPE)
     clncli.wait(timeout=3)
     if clncli.returncode == 0:
         RECKLESS_CONFIG.enable_plugin(path)
@@ -513,8 +515,9 @@ def disable(plugin_name):
         RECKLESS_CONFIG.disable_plugin(path)
         print(f'{plugin_name} disabled')
         return
-    clncli = Popen(['lightning-cli', 'plugin', 'stop', path],
-                   stdout=PIPE, stderr=PIPE)
+    cmd = LIGHTNING_CLI_CALL.copy()
+    cmd.extend(['plugin', 'stop', path])
+    clncli = Popen(cmd, stdout=PIPE, stderr=PIPE)
     clncli.wait(timeout=3)
     output = json.loads(clncli.stdout.read().decode()
                         .replace('\n', '').replace('   ', ''))
@@ -670,6 +673,11 @@ if __name__ == '__main__':
                             'disable', 'help', 'source', 'sources']:
             NETWORK = 'regtest' if args.regtest else 'bitcoin'
             LIGHTNING_DIR = Path(args.lightning)
+            LIGHTNING_CLI_CALL = ['lightning-cli']
+            if NETWORK != 'bitcoin':
+                LIGHTNING_CLI_CALL.append(f'--network={NETWORK}')
+            if LIGHTNING_DIR != Path.home().joinpath('.lightning'):
+                LIGHTNING_CLI_CALL.append(f'--lightning-dir={LIGHTNING_DIR}')
             if args.reckless_dir:
                 RECKLESS_DIR = args.reckless_dir
             else:

--- a/tools/reckless
+++ b/tools/reckless
@@ -538,6 +538,18 @@ def disable(plugin_name):
 
 def load_config(reckless_dir=None, network='bitcoin'):
     """Initial directory discovery and config file creation."""
+    # Does the lightning-cli already reference an explicit config?
+    net_conf = None
+    if lightning_cli_available():
+        cmd = LIGHTNING_CLI_CALL
+        cmd.extend(['listconfigs'])
+        clncli = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        clncli.wait(timeout=3)
+        if clncli.returncode == 0:
+            output = json.loads(clncli.stdout.read().decode()
+                                .replace('\n', '').replace('   ', ''))
+            if 'conf' in output:
+                net_conf = LightningBitcoinConfig(path=output['conf'])
     if reckless_dir is None:
         reckless_dir = str(os.path.join(LIGHTNING_DIR, 'reckless'))
     else:
@@ -546,13 +558,15 @@ def load_config(reckless_dir=None, network='bitcoin'):
     # Reckless applies to the bitcoin network configuration by default.
     if network == 'bitcoin':
         reck_conf_path = os.path.join(reckless_dir, 'bitcoin-reckless.conf')
-        # This config file inherits the RecklessConfig.
-        net_conf = LightningBitcoinConfig()
+        if not net_conf:
+            # This config file inherits the RecklessConfig.
+            net_conf = LightningBitcoinConfig()
     elif network == 'regtest':
         reck_conf_path = os.path.join(reckless_dir, 'regtest-reckless.conf')
         regtest_path = os.path.join(LIGHTNING_DIR, 'regtest', 'config')
-        # Actually the regtest network config
-        net_conf = LightningBitcoinConfig(path=regtest_path)
+        if not net_conf:
+            # Actually the regtest network config
+            net_conf = LightningBitcoinConfig(path=regtest_path)
     # Reckless manages plugins here.
     reckless_conf = RecklessConfig(path=reck_conf_path)
     if not reckless_conf:

--- a/tools/reckless
+++ b/tools/reckless
@@ -131,8 +131,8 @@ class Config():
                 # FIXME: Handle write failure
                 return default_text
         else:
-            print('could not create the parent directory')
-            return None
+            verbose(f'could not create the parent directory {parent_path}')
+            raise FileNotFoundError('invalid parent directory')
 
     def editConfigFile(self, addline, removeline):
         remove_these_lines = []
@@ -436,8 +436,8 @@ def search(plugin_name):
     searches plugin index for plugin"""
     plugin_name = plugin_name[0]
     if plugin_name is None:
-        print('plugin name required')
-        return None
+        sys.stderr.write('plugin name required')
+        sys.exit(1)
     ordered_repos = RECKLESS_SOURCES
     for r in RECKLESS_SOURCES:
         if r.split('/')[-1].lower() == plugin_name.lower():
@@ -569,9 +569,11 @@ def load_config(reckless_dir=None, network='bitcoin'):
             # Actually the regtest network config
             net_conf = LightningBitcoinConfig(path=regtest_path)
     # Reckless manages plugins here.
-    reckless_conf = RecklessConfig(path=reck_conf_path)
-    if not reckless_conf:
-        print('Error: reckless config file could not be written')
+    try:
+        reckless_conf = RecklessConfig(path=reck_conf_path)
+    except FileNotFoundError:
+        print('Error: reckless config file could not be written: ',
+              str(reck_conf_path))
         sys.exit(1)
     if not net_conf:
         print('Error: could not load or create the network specific lightningd'

--- a/tools/reckless
+++ b/tools/reckless
@@ -9,6 +9,7 @@ from pathlib import Path
 import shutil
 import tempfile
 import requests
+from typing import Union
 
 
 repos = ['https://github.com/lightningd/plugins']
@@ -79,7 +80,7 @@ class InstInfo:
         return True
 
 
-def create_dir(r, directory):
+def create_dir(r: int, directory: str) -> bool:
     """Creation of a directory at path `d` with a maximum new dir depth `r`"""
     if os.path.exists(directory):
         return True
@@ -88,11 +89,11 @@ def create_dir(r, directory):
     elif create_dir(r-1, os.path.split(directory)[0]):
         os.mkdir(directory, 0o777)
         print(f'created directory {directory}')
-        if os.path.exists(directory):
-            return True
+        assert os.path.exists(directory)
+        return True
 
 
-def remove_dir(target):
+def remove_dir(target: str) -> bool:
     try:
         shutil.rmtree(target)
         return True
@@ -105,7 +106,10 @@ def remove_dir(target):
 
 class Config():
     """A generic class for procuring, reading and editing config files"""
-    def obtain_config(self, config_path, default_text, warn=False):
+    def obtain_config(self,
+                      config_path: str,
+                      default_text: str,
+                      warn: bool = False) -> str:
         """Return a config file from the desired location. Create one with
         default_text if it cannot be found."""
         if isinstance(config_path, type(None)):
@@ -134,7 +138,7 @@ class Config():
             verbose(f'could not create the parent directory {parent_path}')
             raise FileNotFoundError('invalid parent directory')
 
-    def editConfigFile(self, addline, removeline):
+    def editConfigFile(self, addline: str, removeline: str):
         remove_these_lines = []
         with open(self.conf_fp, 'r') as reckless_conf:
             original = reckless_conf.readlines()
@@ -164,7 +168,9 @@ class Config():
                 if not line_exists:
                     conf_write.write(f'\n{addline}')
 
-    def __init__(self, path=None, default_text=None, warn=False):
+    def __init__(self, path: Union[str, None] = None,
+                 default_text: Union[str, None] = None,
+                 warn: bool = False):
         assert path is not None
         assert default_text is not None
         self.conf_fp = path
@@ -177,17 +183,18 @@ class RecklessConfig(Config):
     This is inherited by the lightningd config and contains all reckless
     maintained plugins."""
 
-    def enable_plugin(self, plugin_path):
+    def enable_plugin(self, plugin_path: str):
         """Handle persistent plugin loading via config"""
         self.editConfigFile(f'plugin={plugin_path}',
                             f'disable-plugin={plugin_path}')
 
-    def disable_plugin(self, plugin_path):
+    def disable_plugin(self, plugin_path: str):
         """Handle persistent plugin disabling via config"""
         self.editConfigFile(f'disable-plugin={plugin_path}',
                             f'plugin={plugin_path}')
 
-    def __init__(self, path=None, default_text=None):
+    def __init__(self, path: Union[str, None] = None,
+                 default_text: Union[str, None] = None):
         if path is None:
             path = os.path.join(LIGHTNING_DIR, 'reckless',
                                 'bitcoin-reckless.conf')
@@ -203,7 +210,9 @@ class LightningBitcoinConfig(Config):
     """lightningd config specific to the bitcoin network. This is inherited by
     the main lightningd config and in turn, inherits bitcoin-reckless.conf."""
 
-    def __init__(self, path=None, default_text=None, warn=True):
+    def __init__(self, path: Union[str, None] = None,
+                 default_text: Union[str, None] = None,
+                 warn: bool = True):
         if path is None:
             path = os.path.join(LIGHTNING_DIR, 'bitcoin', 'config')
         if default_text is None:
@@ -214,7 +223,7 @@ class LightningBitcoinConfig(Config):
 
 class InferInstall():
     """Once a plugin is installed, we may need its directory and entrypoint"""
-    def __init__(self, name):
+    def __init__(self, name: str):
         reck_contents = os.listdir(RECKLESS_CONFIG.reckless_dir)
         if name[-3:] == '.py':
             name = name[:-3]
@@ -232,11 +241,11 @@ class InferInstall():
         raise Exception(f'plugin entrypoint not found in {self.dir}')
 
 
-def help_alias(target):
-    if len(target) == 0:
+def help_alias(targets: list):
+    if len(targets) == 0:
         parser.print_help(sys.stdout)
     else:
-        print('try "reckless {} -h"'.format(' '.join(target)))
+        print('try "reckless {} -h"'.format(' '.join(targets)))
         sys.exit(1)
 
 
@@ -246,7 +255,7 @@ def verbose(*args):
     print(*args)
 
 
-def _search_repo(name, url):
+def _search_repo(name: str, url: str) -> InstInfo:
     """look in given repo and, if found, populate InstInfo"""
     # Remove api subdomain, subdirectories, etc.
     repo = url.split('/')
@@ -304,7 +313,7 @@ def _search_repo(name, url):
     return False
 
 
-def _install_plugin(src):
+def _install_plugin(src: InstInfo) -> bool:
     """make sure the repo exists and clone it."""
     verbose(f'Install requested from {src}.')
     if RECKLESS_CONFIG is None:
@@ -394,7 +403,7 @@ def _install_plugin(src):
     return True
 
 
-def install(plugin_name):
+def install(plugin_name: list):
     """reckless install <plugin>
     downloads plugin from source repos, installs and activates plugin"""
     assert isinstance(plugin_name, list)
@@ -416,7 +425,7 @@ def install(plugin_name):
         enable([plugin_name])
 
 
-def uninstall(plugin_name):
+def uninstall(plugin_name: list):
     """reckless uninstall <plugin>
     disables plugin and deletes the plugin's reckless dir"""
     assert isinstance(plugin_name, list)
@@ -431,7 +440,7 @@ def uninstall(plugin_name):
             print(f"{plugin_name} uninstalled successfully.")
 
 
-def search(plugin_name):
+def search(plugin_name: list) -> InstInfo:
     """reckless search <plugin>
     searches plugin index for plugin"""
     plugin_name = plugin_name[0]
@@ -454,7 +463,7 @@ def search(plugin_name):
     print(f'Unable to locate source for plugin {plugin_name}')
 
 
-def lightning_cli_available():
+def lightning_cli_available() -> bool:
     clncli = Popen(LIGHTNING_CLI_CALL, stdout=PIPE, stderr=PIPE)
     clncli.wait(timeout=1)
     if clncli.returncode == 0:
@@ -463,7 +472,7 @@ def lightning_cli_available():
         return False
 
 
-def enable(plugin_name):
+def enable(plugin_name: list):
     """reckless enable <plugin>
     dynamically activates plugin and adds to config (persistent)"""
     assert isinstance(plugin_name, list)
@@ -503,7 +512,7 @@ def enable(plugin_name):
     sys.exit(clncli.returncode)
 
 
-def disable(plugin_name):
+def disable(plugin_name: list):
     """reckless disable <plugin>
     deactivates an installed plugin"""
     assert isinstance(plugin_name, list)
@@ -537,7 +546,8 @@ def disable(plugin_name):
     print(f'{plugin_name} disabled')
 
 
-def load_config(reckless_dir=None, network='bitcoin'):
+def load_config(reckless_dir: Union[str, None] = None,
+                network: str = 'bitcoin') -> Config:
     """Initial directory discovery and config file creation."""
     # Does the lightning-cli already reference an explicit config?
     net_conf = None
@@ -583,11 +593,11 @@ def load_config(reckless_dir=None, network='bitcoin'):
     return reckless_conf
 
 
-def get_sources_file():
+def get_sources_file() -> str:
     return os.path.join(RECKLESS_DIR, '.sources')
 
 
-def sources_from_file():
+def sources_from_file() -> list:
     sources_file = get_sources_file()
     read_sources = []
     with open(sources_file, 'r') as f:
@@ -598,7 +608,7 @@ def sources_from_file():
         return read_sources
 
 
-def loadSources():
+def loadSources() -> list:
     """Look for the repo sources file"""
     sources_file = get_sources_file()
     # This would have been created if possible
@@ -610,7 +620,7 @@ def loadSources():
     return sources_from_file()
 
 
-def add_source(sources):
+def add_source(sources: list):
     """Additional git repositories, directories, etc. are passed here
     as a list."""
     assert isinstance(sources, list)
@@ -628,7 +638,7 @@ def add_source(sources):
         my_file.editConfigFile(src, None)
 
 
-def remove_source(sources):
+def remove_source(sources: list):
     assert isinstance(sources, list)
     src = sources[0]
     assert isinstance(src, str)

--- a/tools/reckless
+++ b/tools/reckless
@@ -541,8 +541,8 @@ def disable(plugin_name: str):
 def load_config(reckless_dir: Union[str, None] = None,
                 network: str = 'bitcoin') -> Config:
     """Initial directory discovery and config file creation."""
-    # Does the lightning-cli already reference an explicit config?
     net_conf = None
+    # Does the lightning-cli already reference an explicit config?
     try:
         active_config = lightning_cli('listconfigs', timeout=3)
         if 'conf' in active_config:
@@ -554,18 +554,20 @@ def load_config(reckless_dir: Union[str, None] = None,
     else:
         if not os.path.isabs(reckless_dir):
             reckless_dir = Path.cwd().joinpath(reckless_dir)
-    # Reckless applies to the bitcoin network configuration by default.
-    if network == 'bitcoin':
-        reck_conf_path = Path(reckless_dir).joinpath('bitcoin-reckless.conf')
-        if not net_conf:
-            # This config file inherits the RecklessConfig.
-            net_conf = LightningBitcoinConfig()
-    elif network == 'regtest':
-        reck_conf_path = Path(reckless_dir).joinpath('regtest-reckless.conf')
-        regtest_path = Path(LIGHTNING_DIR).joinpath('regtest', 'config')
-        if not net_conf:
-            # Actually the regtest network config
-            net_conf = LightningBitcoinConfig(path=regtest_path)
+    if LIGHTNING_CONFIG:
+        network_path = LIGHTNING_CONFIG
+    else:
+        network_path = Path(LIGHTNING_DIR).joinpath(network, 'config')
+    reck_conf_path = Path(reckless_dir).joinpath(f'{network}-reckless.conf')
+    if net_conf:
+        if str(network_path) != net_conf.conf_fp:
+            print('error: reckless configuration does not match lightningd:\n'
+                  f'reckless network config path: {network_path}\n'
+                  f'lightningd active config: {net_conf.conf_fp}')
+            sys.exit(1)
+    else:
+        # The network-specific config file (bitcoin by default)
+        net_conf = LightningBitcoinConfig(path=network_path)
     # Reckless manages plugins here.
     try:
         reckless_conf = RecklessConfig(path=reck_conf_path)
@@ -650,6 +652,10 @@ if __name__ == '__main__':
                         help='lightning data directory (default:~/.lightning)',
                         type=str,
                         default=Path.home().joinpath('.lightning'))
+    parser.add_argument('-c', '--conf',
+                        help=' config file used by lightningd',
+                        type=str,
+                        default=None)
     parser.add_argument('-r', '--regtest', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
     cmd1 = parser.add_subparsers(dest='cmd1', help='command',
@@ -711,6 +717,7 @@ if __name__ == '__main__':
         RECKLESS_DIR = args.reckless_dir
     else:
         RECKLESS_DIR = Path(LIGHTNING_DIR).joinpath('reckless')
+    LIGHTNING_CONFIG = args.conf
     RECKLESS_CONFIG = load_config(reckless_dir=RECKLESS_DIR,
                                   network=NETWORK)
     RECKLESS_SOURCES = loadSources()

--- a/tools/reckless
+++ b/tools/reckless
@@ -403,16 +403,10 @@ def _install_plugin(src: InstInfo) -> bool:
     return True
 
 
-def install(plugin_name: list):
-    """reckless install <plugin>
-    downloads plugin from source repos, installs and activates plugin"""
-    assert isinstance(plugin_name, list)
-    plugin_name = plugin_name[0]
-    if plugin_name is None:
-        print('missing argument: plugin_name')
-
-    src = search([plugin_name])
-
+def install(plugin_name: str):
+    """downloads plugin from source repos, installs and activates plugin"""
+    assert isinstance(plugin_name, str)
+    src = search(plugin_name)
     if src:
         verbose(f'Retrieving {plugin_name} from {src.repo}')
         if not _install_plugin(src):
@@ -422,33 +416,25 @@ def install(plugin_name: list):
                                  src.name,
                                  src.entry)
         RECKLESS_CONFIG.enable_plugin(inst_path)
-        enable([plugin_name])
+        enable(plugin_name)
 
 
-def uninstall(plugin_name: list):
-    """reckless uninstall <plugin>
-    disables plugin and deletes the plugin's reckless dir"""
-    assert isinstance(plugin_name, list)
-    plugin_name = plugin_name[0]
-    if plugin_name is not None:
-        # FIXME: Do something here.
-        print('Uninstalling plugin {}'.format(plugin_name))
-        disable([plugin_name])
-        plugin_dir = os.path.join(RECKLESS_CONFIG.reckless_dir, plugin_name)
-        verbose("looking for {}".format(plugin_dir))
-        if remove_dir(plugin_dir):
-            print(f"{plugin_name} uninstalled successfully.")
+def uninstall(plugin_name: str):
+    """disables plugin and deletes the plugin's reckless dir"""
+    assert isinstance(plugin_name, str)
+    print(f'Uninstalling plugin {plugin_name}')
+    disable(plugin_name)
+    plugin_dir = os.path.join(RECKLESS_CONFIG.reckless_dir, plugin_name)
+    verbose(f'looking for {plugin_dir}')
+    if remove_dir(plugin_dir):
+        print(f"{plugin_name} uninstalled successfully.")
 
 
-def search(plugin_name: list) -> InstInfo:
-    """reckless search <plugin>
-    searches plugin index for plugin"""
-    plugin_name = plugin_name[0]
-    if plugin_name is None:
-        sys.stderr.write('plugin name required')
-        sys.exit(1)
+def search(plugin_name: str) -> InstInfo:
+    """searches plugin index for plugin"""
     ordered_repos = RECKLESS_SOURCES
     for r in RECKLESS_SOURCES:
+        # Search repos named after the plugin first
         if r.split('/')[-1].lower() == plugin_name.lower():
             ordered_repos.remove(r)
             ordered_repos.insert(0, r)
@@ -464,6 +450,7 @@ def search(plugin_name: list) -> InstInfo:
 
 
 def lightning_cli_available() -> bool:
+    """returns True if lightning-cli rpc available with current config"""
     clncli = Popen(LIGHTNING_CLI_CALL, stdout=PIPE, stderr=PIPE)
     clncli.wait(timeout=1)
     if clncli.returncode == 0:
@@ -472,14 +459,9 @@ def lightning_cli_available() -> bool:
         return False
 
 
-def enable(plugin_name: list):
-    """reckless enable <plugin>
-    dynamically activates plugin and adds to config (persistent)"""
-    assert isinstance(plugin_name, list)
-    plugin_name = plugin_name[0]
-    if plugin_name is None:
-        sys.stderr.write('Plugin name required.')
-        sys.exit(1)
+def enable(plugin_name: str):
+    """dynamically activates plugin and adds to config (persistent)"""
+    assert isinstance(plugin_name, str)
     inst = InferInstall(plugin_name)
     path = inst.entry
     if not os.path.exists(path):
@@ -509,17 +491,13 @@ def enable(plugin_name: list):
         else:
             print(f'reckless: {inst.name} failed to start!')
             print(err)
-    sys.exit(clncli.returncode)
+        sys.exit(clncli.returncode)
 
 
-def disable(plugin_name: list):
+def disable(plugin_name: str):
     """reckless disable <plugin>
     deactivates an installed plugin"""
-    assert isinstance(plugin_name, list)
-    plugin_name = plugin_name[0]
-    if plugin_name is None:
-        sys.stderr.write('Plugin name required.')
-        sys.exit(1)
+    assert isinstance(plugin_name, str)
     inst = InferInstall(plugin_name)
     path = inst.entry
     if not os.path.exists(path):
@@ -535,7 +513,6 @@ def disable(plugin_name: list):
     clncli.wait(timeout=3)
     output = json.loads(clncli.stdout.read().decode()
                         .replace('\n', '').replace('   ', ''))
-    # print(output)
     if ('code' in output.keys() and output['code'] == -32602):
         print('plugin not currently running')
     elif clncli.returncode != 0:
@@ -609,7 +586,7 @@ def sources_from_file() -> list:
 
 
 def loadSources() -> list:
-    """Look for the repo sources file"""
+    """Look for the repo sources file."""
     sources_file = get_sources_file()
     # This would have been created if possible
     if not os.path.exists(sources_file):
@@ -620,13 +597,10 @@ def loadSources() -> list:
     return sources_from_file()
 
 
-def add_source(sources: list):
-    """Additional git repositories, directories, etc. are passed here
-    as a list."""
-    assert isinstance(sources, list)
-    src = sources[0]
-    # Is it a file?
+def add_source(src: str):
+    """Additional git repositories, directories, etc. are passed here."""
     assert isinstance(src, str)
+    # Is it a file?
     maybe_path = os.path.realpath(src)
     if os.path.exists(maybe_path):
         # FIXME: This should handle either a directory or a git repo
@@ -638,9 +612,8 @@ def add_source(sources: list):
         my_file.editConfigFile(src, None)
 
 
-def remove_source(sources: list):
-    assert isinstance(sources, list)
-    src = sources[0]
+def remove_source(src: str):
+    """Remove a source from the sources file."""
     assert isinstance(src, str)
     if src in sources_from_file():
         my_file = Config(path=get_sources_file(),
@@ -652,6 +625,7 @@ def remove_source(sources: list):
 
 
 def list_source():
+    """Provide the user with all stored source repositories."""
     for src in sources_from_file():
         print(src)
 
@@ -733,6 +707,11 @@ if __name__ == '__main__':
     IS_VERBOSE = bool(args.verbose)
 
     if 'targets' in args:
-        args.func(args.targets)
+        # FIXME: Catch missing argument
+        if args.func.__name__ == 'help_alias':
+            args.func(args.targets)
+            sys.exit(0)
+        for target in args.targets:
+            args.func(target)
     else:
         args.func()

--- a/tools/reckless
+++ b/tools/reckless
@@ -336,10 +336,10 @@ def _install_plugin(src: InstInfo) -> bool:
     if ('http' in src.repo[:4]) or ('github.com' in src.repo):
         # Ugly, but interactively handling stderr gets hairy.
         if IS_VERBOSE:
-            git = Popen(['git', 'clone',  src.repo, clone_path],
+            git = Popen(['git', 'clone',  src.repo, str(clone_path)],
                         stdout=PIPE)
         else:
-            git = Popen(['git', 'clone',  src.repo, clone_path],
+            git = Popen(['git', 'clone',  src.repo, str(clone_path)],
                         stdout=PIPE, stderr=PIPE)
         git.wait()
         if git.returncode != 0:
@@ -353,6 +353,7 @@ def _install_plugin(src: InstInfo) -> bool:
     if src.subdir is not None:
         plugin_path = Path(clone_path).joinpath(src.subdir)
     os.chdir(plugin_path)
+    assert os.getcwd() == str(plugin_path)
     if src.commit:
         verbose(f"Checking out commit {src.commit}")
         checkout = Popen(['git', 'checkout', src.commit],
@@ -400,6 +401,7 @@ def _install_plugin(src: InstInfo) -> bool:
     # Find this cute little plugin a forever home
     shutil.copytree(plugin_path, inst_path)
     print(f'plugin installed: {inst_path}')
+    os.chdir(RECKLESS_CONFIG.reckless_dir)
     remove_dir(clone_path)
     return True
 
@@ -422,7 +424,7 @@ def install(plugin_name: str):
 def uninstall(plugin_name: str):
     """disables plugin and deletes the plugin's reckless dir"""
     assert isinstance(plugin_name, str)
-    print(f'Uninstalling plugin {plugin_name}')
+    verbose(f'Uninstalling plugin {plugin_name}')
     disable(plugin_name)
     plugin_dir = Path(RECKLESS_CONFIG.reckless_dir).joinpath(plugin_name)
     verbose(f'looking for {plugin_dir}')
@@ -604,8 +606,8 @@ def loadSources() -> list:
     sources_file = get_sources_file()
     # This would have been created if possible
     if not Path(sources_file).exists():
-        print('Warning: Reckless requires write access')
-        Config(path=sources_file,
+        verbose('Warning: Reckless requires write access')
+        Config(path=str(sources_file),
                default_text='https://github.com/lightningd/plugins')
         return ['https://github.com/lightningd/plugins']
     return sources_from_file()


### PR DESCRIPTION
# reckless

A Core-Lightning plugin manager


## Features

Love Core-Lightning? Want to install and test a CLN plugin with only three words and a command line? Reckless has you covered!

- Install a plugin from the lightningd/plugins repository
- Add additional source repos to search/install
- Automatically install dependencies and verify installation
- Dynamically enable/disable reckless-managed plugins
- Persists plugin state by managing a config file inherited by lightningd


## Commands

`reckless install <plugin>` searches available repositories, if one matches, clones it, installs dependencies, and tests that the plugin executes and exits normally.  If so, the plugin is permanently installed, added to the CLN config, and dynamically activated.

`reckless uninstall <plugin>` disables the plugin, removes the directory.

`reckless search <plugin>` looks through all available sources for a plugin matching this name.

`reckless enable <plugin>`/`reckless disable <plugin>` dynamically enables/disables the reckless-installed plugin and updates the config to match.

`reckless source list` list all plugin repositories.

`reckless source add <repo url>` add another plugin repository for reckless to search or install from.


## Let's Get Reckless!

Running the first time will prompt the user that their lightningd's bitcoin config will be appended (or created) to inherit the reckless config file (this config is specific to bitcoin by default.) Management of plugins will subsequently modify this file.

Start with a simple installation such as `reckless install summary`


## Troubleshooting tips

Plugins must be executable. For python plugins, the shebang is invoked, so `python3` should be available in your environment. This can be verified with `which Python3`. The default reckless directory is /home/<user>/.lightning/reckless and it should be possible for the lightningd user to execute files located here.  If this is a problem, the option flag `reckless -d=<my_alternate_dir>` may be used to relocate the reckless directory from its default. Consider creating a permanent alias in this case.


## For Developers

Tips for making your plugin compatible with reckless install:
- Choose a unique plugin name.
- The plugin entrypoint is inferred.  Naming your plugin executable the same as your plugin name will allow reckless to identify it correctly (file extensions are okay.)
- For python plugins, a requirements.txt is the preferred medium for python dependencies. A pyproject.toml will be used as a fallback, but test installation via `pip install -e .` - Poetry looks for additional files in the working directory, whereas with pip, any references to these will require something like `packages = [{ include = "*.py" }]` under the `[tool.poetry]` section.
- Additional repository sources may be added with `reckless source add https://my.repo.url/here` however, https://github.com/lightningd/plugins is included by default. Consider adding your plugin lightningd/plugins to make installation simpler.
- If your plugin is located in a subdirectory of your repo with a different name than your plugin, it will likely be overlooked.


## To Do

This is the minimum viable product of the utility [outlined by Rusty](https://gist.github.com/rustyrussell/762297e84dc5239fe408c45e6811e1a9).

Still to come:
- Man page
- Support for non-python plugins.
- Install by specifying url/dir directly.
- Possibly support installing a virtual environments for python plugins.

