### PR TITLE
Fix undeleted private channel update gossip_store entry

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1423,6 +1423,9 @@ bool routing_add_channel_update(struct routing_state *rstate,
 					    is_chan_public(chan)
 					    ? WIRE_CHANNEL_UPDATE
 					    : WIRE_GOSSIP_STORE_PRIVATE_UPDATE);
+		} else if (!is_chan_public(chan)){
+			gossip_store_delete(rstate->gs, &hc->rgraph,
+					    WIRE_GOSSIP_STORE_PRIVATE_UPDATE);
 		}
 	} else {
 		/* Safe to broadcast */


### PR DESCRIPTION
gossipd: ensure old private channel updates are properly deleted

When private channel updates exceed the gossip ratelimit, the previous gossip store entry was not deleted even though all private channel updates are stored. This caused gossip store corruption due to duplicate entries for the same channel.
Fixes: #5656

Changelog-Fixed: Fixed gossip_store corruption from duplicate private channel update