### PR TITLE
onchaind: Adjust the witness weight estimation to be a bit more conservative

### DIFF
--- a/bitcoin/test/run-tx-bitcoin_tx_2of2_input_witness_weight.c
+++ b/bitcoin/test/run-tx-bitcoin_tx_2of2_input_witness_weight.c
@@ -145,6 +145,14 @@ int main(int argc, const char *argv[])
 
 	/* 1 byte for num witnesses, one per witness element */
 	weight = 1;
+
+	/* Two signatures, slightly overestimated to be 73 bytes each,
+	 * while the actual witness will often be smaller.*/
+        /* BOLT #03:
+         * Signatures are 73 bytes long (the maximum length).
+         */
+	weight += 2 + 2;
+
 	for (size_t i = 0; i < tal_count(wit); i++)
 		weight += 1 + tal_bytelen(wit[i]);
 	assert(bitcoin_tx_2of2_input_witness_weight() == weight);

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -886,13 +886,16 @@ size_t bitcoin_tx_simple_input_weight(bool p2sh)
 
 size_t bitcoin_tx_2of2_input_witness_weight(void)
 {
+        /* BOLT #03:
+         * Signatures are 73 bytes long (the maximum length).
+         */
 	return 1 + /* Prefix: 4 elements to push on stack */
 		(1 + 0) + /* [0]: witness-marker-and-flag */
-		(1 + 72) + /* [1] Party A signature and length prefix */
-		(1 + 72) + /* [2] Party B signature and length prefix */
+		(1 + 73) + /* [1] Party A signature and length prefix */
+		(1 + 73) + /* [2] Party B signature and length prefix */
 		(1 + 1 + /* [3] length prefix and numpushes (2) */
-		 33 + /* pubkey A (missing prefix) */
-		 33 + /* pubkey B (missing prefix) */
+		 1 + 33 + /* pubkey A (with prefix) */
+		 1 + 33 + /* pubkey B (with prefix) */
 		 1 + 1 /* num sigs required and checkmultisig */
 		);
 }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -427,7 +427,7 @@ def basic_fee(feerate):
 
 def closing_fee(feerate, num_outputs):
     assert num_outputs == 1 or num_outputs == 2
-    weight = 424 + 124 * num_outputs
+    weight = 428 + 124 * num_outputs
     return (weight * feerate) // 1000
 
 


### PR DESCRIPTION
This came up while debugging the VLS signer for Greenlight. In case of the feerate hitting the floor it is important we agree on the size of the transaction, and in particular the witness weight which is estimated, not measured. If the estimation of VLS is larger than the one in CLN we end up with too small a fee according to VLS, and it'll refuse to sign.

The differences we found were due to a) a missing `OP_PUSH33` for the pubkeys, and b) the lower expected signature weight of 72 instead of the spec suggestion of 73.