### PR TITLE
fd_send: Add explicit ack packet

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -958,9 +958,6 @@ static void send_shutdown_complete(struct peer *peer)
 			take(towire_channeld_shutdown_complete(NULL)));
 	per_peer_state_fdpass_send(MASTER_FD, peer->pps);
 
-	/* Give master a chance to pass the fd along */
-	sleep(1);
-
 	close(MASTER_FD);
 }
 

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -307,9 +307,6 @@ static void dualopen_shutdown(struct state *state)
 	status_debug("Sent %s with fds",
 		     dualopend_wire_name(fromwire_peektype(msg)));
 
-	/* Give master a chance to pass the fd along */
-	sleep(1);
-
 	/* This frees the entire tal tree. */
 	tal_free(state);
 	daemon_shutdown();
@@ -4015,9 +4012,6 @@ int main(int argc, char *argv[])
 	status_debug("Sent %s with fds",
 		     dualopend_wire_name(fromwire_peektype(msg)));
 	tal_free(msg);
-
-	/* Give master a chance to pass the fd along */
-	sleep(1);
 
 	/* This frees the entire tal tree. */
 	tal_free(state);

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1553,9 +1553,6 @@ int main(int argc, char *argv[])
 	status_debug("Sent %s with fd",
 		     openingd_wire_name(fromwire_peektype(msg)));
 
-	/* Give master a chance to pass the fd along */
-	sleep(1);
-
 	/* This frees the entire tal tree. */
 	tal_free(state);
 


### PR DESCRIPTION
* Adding an explicit ACK 1 byte packet of the fd_send
* This should hopefully allows us to remove the sleep trick
* And doesn’t appear to bring back the flack’ness issue (at least on my machine)

Would be great to get additional testing from anyone else who’s environment has experience this particular flake.