### PR TITLE
cln-grpc notification support

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -512,6 +512,11 @@
             "Invoice.warning_offline": 6,
             "Invoice.warning_private_unused": 8
         },
+        "InvoicecreationnotificationResponse": {
+            "InvoiceCreationNotification.amount_msat": 3,
+            "InvoiceCreationNotification.label": 1,
+            "InvoiceCreationNotification.preimage": 2
+        },
         "KeysendRequest": {
             "KeySend.amount_msat": 10,
             "KeySend.destination": 1,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,10 +128,14 @@ dependencies = [
  "anyhow",
  "bitcoin_hashes",
  "cln-rpc",
+ "futures",
+ "futures-core",
  "hex",
  "log",
  "prost",
  "serde_json",
+ "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
 ]
@@ -147,6 +151,7 @@ dependencies = [
  "log",
  "prost",
  "rcgen",
+ "serde_json",
  "tokio",
  "tonic",
 ]
@@ -184,6 +189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.6.10",
 ]
 
@@ -259,9 +265,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -274,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -284,15 +290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -301,15 +307,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -318,21 +324,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -945,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -1086,13 +1092,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.7.4",
 ]
 
 [[package]]

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 anyhow = "1.0"
 log = "0.4"
 cln-rpc = { path="../cln-rpc/" }
+futures = "0.3.25"
+futures-core = "0.3.25"
+serde_json = "1.0.72"
+tokio = "1"
+tokio-stream = { version = "0.1.11", features = [ "sync" ] }
 tonic = { version = "^0.5", features = ["tls", "transport"] }
 prost = "0.8"
 hex = "0.4.3"

--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -55,6 +55,7 @@ service Node {
 	rpc SetChannel(SetchannelRequest) returns (SetchannelResponse) {}
 	rpc SignMessage(SignmessageRequest) returns (SignmessageResponse) {}
 	rpc Stop(StopRequest) returns (StopResponse) {}
+       rpc InvoiceCreationNotification(InvoicecreationnotificationRequest) returns (stream InvoicecreationnotificationResponse) {}
 }
 
 message GetinfoRequest {
@@ -1329,4 +1330,13 @@ message StopRequest {
 }
 
 message StopResponse {
+}
+
+message InvoicecreationnotificationRequest {
+}
+
+message InvoicecreationnotificationResponse {
+	string label = 1;
+	optional bytes preimage = 2;
+	Amount amount_msat = 3;
 }

--- a/cln-grpc/src/lib.rs
+++ b/cln-grpc/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod convert;
 pub mod pb;
+mod serde_convert;
 mod server;
 
 pub use crate::server::Server;

--- a/cln-grpc/src/serde_convert.rs
+++ b/cln-grpc/src/serde_convert.rs
@@ -1,0 +1,22 @@
+use crate::pb;
+use std::convert::From;
+use std::num::ParseIntError;
+
+#[allow(unused_variables)]
+impl From<serde_json::Value> for pb::InvoicecreationnotificationResponse {
+    fn from(c: serde_json::Value) -> Self {
+        let obj = c["invoice_creation"].as_object().unwrap();
+        let parsed_msat = parse_int(&obj["msat"].as_str().unwrap()).unwrap();
+
+        Self {
+            label: String::from(obj["label"].as_str().unwrap()),
+            preimage: serde_json::to_vec(&obj["preimage"]).ok(),
+            amount_msat: Some(pb::Amount { msat: parsed_msat }),
+        }
+    }
+}
+
+fn parse_int(val: &str) -> Result<u64, ParseIntError> {
+    let msat_pos = val.find("m").unwrap_or(val.len());
+    val[..msat_pos].parse()
+}

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.72"
 tokio-util = { version = "0.6.9", features = ["codec"] }
 tokio = { version = "1", features = ["net"]}
+tokio-stream = "0.1"
 futures-util = { version = "*", features = [ "sink" ] }
 hex = "0.4.3"
 

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -118,7 +118,6 @@ pub enum Response {
 	Stop(responses::StopResponse),
 }
 
-
 pub trait IntoRequest: Into<Request> {
     type Response: TryFrom<Response, Error = TryFromResponseError>;
 }

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -226,10 +226,11 @@ class RustGenerator(IGenerator):
         """)
 
         for meth in service.methods:
-            req = meth.request
-            _, decl = gen_composite(req)
-            self.write(decl, numindent=1)
-            self.generate_request_trait_impl(meth)
+            if not meth.notification:
+                req = meth.request
+                _, decl = gen_composite(req)
+                self.write(decl, numindent=1)
+                self.generate_request_trait_impl(meth)
 
         self.write("}\n\n")
 
@@ -259,10 +260,11 @@ class RustGenerator(IGenerator):
         """)
 
         for meth in service.methods:
-            res = meth.response
-            _, decl = gen_composite(res)
-            self.write(decl, numindent=1)
-            self.generate_response_trait_impl(meth)
+            if not meth.notification:
+                res = meth.response
+                _, decl = gen_composite(res)
+                self.write(decl, numindent=1)
+                self.generate_response_trait_impl(meth)
 
         self.write("}\n\n")
 
@@ -296,7 +298,8 @@ class RustGenerator(IGenerator):
         """)
 
         for method in service.methods:
-            self.write(f"{method.name}(requests::{method.request.typename}),\n", numindent=1)
+            if not method.notification:
+                self.write(f"{method.name}(requests::{method.request.typename}),\n", numindent=1)
 
         self.write(f"""\
         }}
@@ -308,11 +311,11 @@ class RustGenerator(IGenerator):
         """)
 
         for method in service.methods:
-            self.write(f"{method.name}(responses::{method.response.typename}),\n", numindent=1)
+            if not method.notification:
+                self.write(f"{method.name}(responses::{method.response.typename}),\n", numindent=1)
 
         self.write(f"""\
         }}
-
         """)
 
     def generate_request_trait(self):

--- a/contrib/msggen/msggen/model.py
+++ b/contrib/msggen/msggen/model.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 def path2type(path):
     typename = "".join([s.capitalize() for s in path.replace("[]", "").split(".")])
+
     return typename
 
 
@@ -85,10 +86,11 @@ class Service:
 
 
 class Method:
-    def __init__(self, name: str, request: Field, response: Field):
+    def __init__(self, name: str, request: Field, response: Field, notification: bool):
         self.name = name
         self.request = request
         self.response = response
+        self.notification = notification
 
 
 class CompositeField(Field):

--- a/contrib/msggen/msggen/utils/utils.py
+++ b/contrib/msggen/msggen/utils/utils.py
@@ -122,6 +122,7 @@ def load_jsonrpc_service(schema_dir: str = None):
         "Stop",
         # "notifications",  # No point in mapping this
         # "help",
+        "InvoiceCreationNotification",
     ]
     methods = [load_jsonrpc_method(name, schema_dir=schema_dir) for name in method_names]
     service = Service(name="Node", methods=methods)

--- a/contrib/msggen/msggen/utils/utils.py
+++ b/contrib/msggen/msggen/utils/utils.py
@@ -17,10 +17,15 @@ def load_jsonrpc_method(name, schema_dir: str = None):
         base_path = (repo_root() / "doc" / "schemas").resolve()
     else:
         base_path = schema_dir
+
     req_file = base_path / f"{name.lower()}.request.json"
     resp_file = base_path / f"{name.lower()}.schema.json"
     request = CompositeField.from_js(json.load(open(req_file)), path=name)
     response = CompositeField.from_js(json.load(open(resp_file)), path=name)
+
+    notification = False
+    if name.endswith("Notification"):
+         notification = True
 
     # Normalize the method request and response typename so they no
     # longer conflict.
@@ -31,6 +36,7 @@ def load_jsonrpc_method(name, schema_dir: str = None):
         name,
         request=request,
         response=response,
+        notification=notification,
     )
 
 

--- a/contrib/pyln-testing/pyln/testing/grpc2py.py
+++ b/contrib/pyln-testing/pyln/testing/grpc2py.py
@@ -882,3 +882,11 @@ def signmessage2py(m):
 def stop2py(m):
     return remove_default({
     })
+
+
+def invoicecreationnotification2py(m):
+    return remove_default({
+        "label": m.label,  # PrimitiveField in generate_composite
+        "preimage": hexlify(m.preimage),  # PrimitiveField in generate_composite
+        "amount_msat": amount2msat(m.amount_msat),  # PrimitiveField in generate_composite
+    })

--- a/doc/schemas/invoicecreationnotification.request.json
+++ b/doc/schemas/invoicecreationnotification.request.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [],
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/doc/schemas/invoicecreationnotification.schema.json
+++ b/doc/schemas/invoicecreationnotification.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "label",
+    "payment_hash",
+    "amount_msat"
+  ],
+  "properties": {
+    "label": {
+      "type": "string",
+      "description": "unique label supplied at invoice creation"
+    },
+    "preimage": {
+      "type": "secret",
+      "description": "proof of payment",
+      "maxLength": 64,
+      "minLength": 64
+    },
+    "amount_msat": {
+      "type": "msat",
+      "description": "the amount required to pay this invoice"
+    }
+  }
+}
+

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 log = "0.4"
 prost = "0.8"
 rcgen = { version = "0.8", features = ["pem", "x509-parser"] }
+serde_json = "1.0.87"
 
 [dependencies.cln-grpc]
 path = "../../cln-grpc"

--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -1,9 +1,11 @@
 use anyhow::{anyhow, Context, Result};
+use cln_grpc::pb;
 use cln_grpc::pb::node_server::NodeServer;
-use cln_plugin::{options, Builder};
+use cln_plugin::{options, Builder, Error, Plugin};
 use log::{debug, warn};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use tokio::sync::broadcast;
 
 mod tls;
 
@@ -12,6 +14,7 @@ struct PluginState {
     rpc_path: PathBuf,
     identity: tls::Identity,
     ca_cert: Vec<u8>,
+    event_channel: broadcast::Sender<pb::InvoicecreationnotificationResponse>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -22,12 +25,15 @@ async fn main() -> Result<()> {
     let directory = std::env::current_dir()?;
     let (identity, ca_cert) = tls::init(&directory)?;
 
+    let (tx, _) = broadcast::channel(16);
+
     let plugin = match Builder::new(tokio::io::stdin(), tokio::io::stdout())
         .option(options::ConfigOption::new(
             "grpc-port",
             options::Value::Integer(-1),
             "Which port should the grpc plugin listen for incoming connections?",
         ))
+        .subscribe("invoice_creation", invoice_handler)
         .configure()
         .await?
     {
@@ -52,6 +58,7 @@ async fn main() -> Result<()> {
         rpc_path: path.into(),
         identity,
         ca_cert,
+        event_channel: tx.clone(),
     };
 
     let plugin = plugin.start(state.clone()).await?;
@@ -60,15 +67,16 @@ async fn main() -> Result<()> {
 
     tokio::select! {
         _ = plugin.join() => {
-	    // This will likely never be shown, if we got here our
-	    // parent process is exiting and not processing out log
-	    // messages anymore.
+        // This will likely never be shown, if we got here our
+        // parent process is exiting and not processing out log
+        // messages anymore.
             debug!("Plugin loop terminated")
         }
         e = run_interface(bind_addr, state) => {
             warn!("Error running grpc interface: {:?}", e)
         }
     }
+
     Ok(())
 }
 
@@ -84,7 +92,7 @@ async fn run_interface(bind_addr: SocketAddr, state: PluginState) -> Result<()> 
         .tls_config(tls)
         .context("configuring tls")?
         .add_service(NodeServer::new(
-            cln_grpc::Server::new(&state.rpc_path)
+            cln_grpc::Server::new(&state.rpc_path, state.event_channel.clone())
                 .await
                 .context("creating NodeServer instance")?,
         ))
@@ -96,6 +104,16 @@ async fn run_interface(bind_addr: SocketAddr, state: PluginState) -> Result<()> 
     );
 
     server.await.context("serving requests")?;
+
+    Ok(())
+}
+
+async fn invoice_handler(p: Plugin<PluginState>, v: serde_json::Value) -> Result<(), Error> {
+    log::info!("Got an invoice notification: {}", v);
+
+    p.state()
+        .event_channel
+        .send(pb::InvoicecreationnotificationResponse::from(v));
 
     Ok(())
 }


### PR DESCRIPTION
This pr does two things:
- It adds support for notifications in msggen so we can generate notification data structures in grpc and rust.
- Adds a rpc for streaming invoicecreation notifications with the grpc rust api. Should be easy to add other notifications later on, but figured it be good to square away an initial one first