### PR TITLE
lightningd: Add `signinvoice` to sign a BOLT11 invoice. 

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -1006,6 +1006,12 @@
         "SetchannelResponse": {
             "SetChannel.channels[]": 1
         },
+        "SigninvoiceRequest": {
+            "SignInvoice.invstring": 1
+        },
+        "SigninvoiceResponse": {
+            "SignInvoice.bolt11": 1
+        },
         "SignmessageRequest": {
             "SignMessage.message": 1
         },

--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -53,6 +53,7 @@ service Node {
 	rpc ListPays(ListpaysRequest) returns (ListpaysResponse) {}
 	rpc Ping(PingRequest) returns (PingResponse) {}
 	rpc SetChannel(SetchannelRequest) returns (SetchannelResponse) {}
+	rpc SignInvoice(SigninvoiceRequest) returns (SigninvoiceResponse) {}
 	rpc SignMessage(SignmessageRequest) returns (SignmessageResponse) {}
 	rpc Stop(StopRequest) returns (StopResponse) {}
 }
@@ -1321,6 +1322,14 @@ message SetchannelChannels {
 	optional string warning_htlcmin_too_low = 7;
 	Amount maximum_htlc_out_msat = 8;
 	optional string warning_htlcmax_too_high = 9;
+}
+
+message SigninvoiceRequest {
+	string invstring = 1;
+}
+
+message SigninvoiceResponse {
+	string bolt11 = 1;
 }
 
 message SignmessageRequest {

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -1102,6 +1102,15 @@ impl From<responses::SetchannelResponse> for pb::SetchannelResponse {
 }
 
 #[allow(unused_variables)]
+impl From<responses::SigninvoiceResponse> for pb::SigninvoiceResponse {
+    fn from(c: responses::SigninvoiceResponse) -> Self {
+        Self {
+            bolt11: c.bolt11, // Rule #2 for type string
+        }
+    }
+}
+
+#[allow(unused_variables)]
 impl From<responses::SignmessageResponse> for pb::SignmessageResponse {
     fn from(c: responses::SignmessageResponse) -> Self {
         Self {
@@ -1686,6 +1695,15 @@ impl From<pb::SetchannelRequest> for requests::SetchannelRequest {
             htlcmin: c.htlcmin.map(|a| a.into()), // Rule #1 for type msat?
             htlcmax: c.htlcmax.map(|a| a.into()), // Rule #1 for type msat?
             enforcedelay: c.enforcedelay, // Rule #1 for type u32?
+        }
+    }
+}
+
+#[allow(unused_variables)]
+impl From<pb::SigninvoiceRequest> for requests::SigninvoiceRequest {
+    fn from(c: pb::SigninvoiceRequest) -> Self {
+        Self {
+            invstring: c.invstring, // Rule #1 for type string
         }
     }
 }

--- a/cln-grpc/src/server.rs
+++ b/cln-grpc/src/server.rs
@@ -1466,6 +1466,38 @@ async fn set_channel(
 
 }
 
+async fn sign_invoice(
+    &self,
+    request: tonic::Request<pb::SigninvoiceRequest>,
+) -> Result<tonic::Response<pb::SigninvoiceResponse>, tonic::Status> {
+    let req = request.into_inner();
+    let req: requests::SigninvoiceRequest = req.into();
+    debug!("Client asked for sign_invoice");
+    trace!("sign_invoice request: {:?}", req);
+    let mut rpc = ClnRpc::new(&self.rpc_path)
+        .await
+        .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+    let result = rpc.call(Request::SignInvoice(req))
+        .await
+        .map_err(|e| Status::new(
+           Code::Unknown,
+           format!("Error calling method SignInvoice: {:?}", e)))?;
+    match result {
+        Response::SignInvoice(r) => {
+           trace!("sign_invoice response: {:?}", r);
+           Ok(tonic::Response::new(r.into()))
+        },
+        r => Err(Status::new(
+            Code::Internal,
+            format!(
+                "Unexpected result {:?} to method call SignInvoice",
+                r
+            )
+        )),
+    }
+
+}
+
 async fn sign_message(
     &self,
     request: tonic::Request<pb::SignmessageRequest>,

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -61,6 +61,7 @@ pub enum Request {
 	ListPays(requests::ListpaysRequest),
 	Ping(requests::PingRequest),
 	SetChannel(requests::SetchannelRequest),
+	SignInvoice(requests::SigninvoiceRequest),
 	SignMessage(requests::SignmessageRequest),
 	Stop(requests::StopRequest),
 }
@@ -114,6 +115,7 @@ pub enum Response {
 	ListPays(responses::ListpaysResponse),
 	Ping(responses::PingResponse),
 	SetChannel(responses::SetchannelResponse),
+	SignInvoice(responses::SigninvoiceResponse),
 	SignMessage(responses::SignmessageResponse),
 	Stop(responses::StopResponse),
 }
@@ -1239,6 +1241,21 @@ pub mod requests {
 
 	impl IntoRequest for SetchannelRequest {
 	    type Response = super::responses::SetchannelResponse;
+	}
+
+	#[derive(Clone, Debug, Deserialize, Serialize)]
+	pub struct SigninvoiceRequest {
+	    pub invstring: String,
+	}
+
+	impl From<SigninvoiceRequest> for Request {
+	    fn from(r: SigninvoiceRequest) -> Self {
+	        Request::SignInvoice(r)
+	    }
+	}
+
+	impl IntoRequest for SigninvoiceRequest {
+	    type Response = super::responses::SigninvoiceResponse;
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
@@ -3512,6 +3529,22 @@ pub mod responses {
 	    fn try_from(response: Response) -> Result<Self, Self::Error> {
 	        match response {
 	            Response::SetChannel(response) => Ok(response),
+	            _ => Err(TryFromResponseError)
+	        }
+	    }
+	}
+
+	#[derive(Clone, Debug, Deserialize, Serialize)]
+	pub struct SigninvoiceResponse {
+	    pub bolt11: String,
+	}
+
+	impl TryFrom<Response> for SigninvoiceResponse {
+	    type Error = super::TryFromResponseError;
+
+	    fn try_from(response: Response) -> Result<Self, Self::Error> {
+	        match response {
+	            Response::SignInvoice(response) => Ok(response),
 	            _ => Err(TryFromResponseError)
 	        }
 	    }

--- a/contrib/msggen/msggen/utils/utils.py
+++ b/contrib/msggen/msggen/utils/utils.py
@@ -97,6 +97,7 @@ def load_jsonrpc_service(schema_dir: str):
         # "sendinvoice",
         # "sendonionmessage",
         "SetChannel",
+        "SignInvoice",
         "SignMessage",
         # "unreserveinputs",
         # "waitblockheight",

--- a/contrib/pyln-testing/pyln/testing/grpc2py.py
+++ b/contrib/pyln-testing/pyln/testing/grpc2py.py
@@ -871,6 +871,12 @@ def setchannel2py(m):
     })
 
 
+def signinvoice2py(m):
+    return remove_default({
+        "bolt11": m.bolt11,  # PrimitiveField in generate_composite
+    })
+
+
 def signmessage2py(m):
     return remove_default({
         "signature": hexlify(m.signature),  # PrimitiveField in generate_composite

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -84,6 +84,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-sendpay.7 \
 	doc/lightning-setchannel.7 \
 	doc/lightning-sendcustommsg.7 \
+	doc/lightning-signinvoice.7 \
 	doc/lightning-signmessage.7 \
 	doc/lightning-staticbackup.7 \
 	doc/lightning-txprepare.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -116,6 +116,7 @@ Core Lightning Documentation
    lightning-sendpay <lightning-sendpay.7.md>
    lightning-sendpsbt <lightning-sendpsbt.7.md>
    lightning-setchannel <lightning-setchannel.7.md>
+   lightning-signinvoice <lightning-signinvoice.7.md>
    lightning-signmessage <lightning-signmessage.7.md>
    lightning-signpsbt <lightning-signpsbt.7.md>
    lightning-sql <lightning-sql.7.md>

--- a/doc/lightning-createinvoice.7.md
+++ b/doc/lightning-createinvoice.7.md
@@ -12,8 +12,8 @@ DESCRIPTION
 The **createinvoice** RPC command signs and saves an invoice into the
 database.
 
-The *invstring* parameter is of bolt11 form, but without the final
-signature appended.  Minimal sanity checks are done.  (Note: if
+The *invstring* parameter is of bolt11 form, but the final signature
+is ignored.  Minimal sanity checks are done.  (Note: if
 **experimental-offers** is enabled, *invstring* can actually be an
 unsigned bolt12 invoice).
 

--- a/doc/lightning-signinvoice.7.md
+++ b/doc/lightning-signinvoice.7.md
@@ -1,0 +1,51 @@
+lightning-signinvoice -- Low-level invoice signing
+=====================================================
+
+SYNOPSIS
+--------
+
+**signinvoice** *invstring*
+
+DESCRIPTION
+-----------
+
+The **signinvoice** RPC command signs an invoice.  Unlike
+**createinvoice** it does not save the invoice into the database and
+thus does not require the preimage.
+
+The *invstring* parameter is of bolt11 form, but the final signature
+is ignored.  Minimal sanity checks are done.
+
+RETURN VALUE
+------------
+
+[comment]: # (GENERATE-FROM-SCHEMA-START)
+On success, an object is returned, containing:
+
+- **bolt11** (string): the bolt11 string
+
+[comment]: # (GENERATE-FROM-SCHEMA-END)
+
+On failure, an error is returned.
+
+The following error codes may occur:
+- -1: Catchall nonspecific error.
+
+AUTHOR
+------
+
+Carl Dong <<contact@carldong.me>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-createinvoice(7), lightning-invoice(7), lightning-listinvoices(7),
+lightning-delinvoice(7), lightning-getroute(7), lightning-sendpay(7),
+lightning-offer(7).
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>
+
+[comment]: # ( SHA256STAMP:9348784bd3daaed1cd35b29b2e5c91ea17bc8e11bf5bb6e1de9a098241cb74d6)

--- a/doc/schemas/signinvoice.request.json
+++ b/doc/schemas/signinvoice.request.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "added": "v23.02",
+  "required": [
+    "invstring"
+  ],
+  "properties": {
+    "invstring": {
+      "type": "string",
+      "description": ""
+    }
+  }
+}

--- a/doc/schemas/signinvoice.schema.json
+++ b/doc/schemas/signinvoice.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bolt11"
+  ],
+  "properties": {
+    "bolt11": {
+      "type": "string",
+      "description": "the bolt11 string"
+    }
+  }
+}

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -533,6 +533,19 @@ def test_waitanyinvoice(node_factory, executor):
         l2.rpc.waitanyinvoice('non-number')
 
 
+def test_signinvoice(node_factory, executor):
+    # Setup
+    l1, l2 = node_factory.line_graph(2)
+
+    # Create an invoice for l1
+    inv1 = l1.rpc.invoice(1000, 'inv1', 'inv1')['bolt11']
+    assert l1.rpc.decodepay(inv1)['payee'] == l1.info['id']
+
+    # Have l2 re-sign the invoice
+    inv2 = l2.rpc.signinvoice(inv1)['bolt11']
+    assert l1.rpc.decodepay(inv2)['payee'] == l2.info['id']
+
+
 def test_waitanyinvoice_reversed(node_factory, executor):
     """Test waiting for invoices, where they are paid in reverse order
     to when they are created.


### PR DESCRIPTION
```
Though there's already a `createinvoice` command, there are usecases where a
user may want to sign an invoice that they don't yet have the preimage to. For
example, they may have an htlc_accepted plugin that pays to obtain the preimage
from someone else and returns a `{ "result": "resolve", ... }`.

This RPC command addresses this usecase without overly complicating the
semantics of the existing `createinvoice` command.

Changlog-Added: JSON-RPC: `signinvoice` new command to sign BOLT11
invoices.
```

Also adds a commit to correct `createinvoice`'s `invstring` description. (See the commit message for more details)

One main question for reviewers is whether this PR is acceptable without support for BOLT12 invoices. I'm not familiar enough with them to write code for them. Perhaps it can be left for a followup PR? If so, do we need to make the `bolt11` field in `doc/schemas/signinvoice.schema.json` non-required?

CC: @cdecker 