### PR TITLE
Handle non-standard onion reply size

### DIFF
--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -679,12 +679,19 @@ struct route_step *process_onionpacket(
 	return step;
 }
 
+#if DEVELOPER
+unsigned dev_onion_reply_length = ONION_REPLY_SIZE;
+#define OUR_ONION_REPLY_SIZE	dev_onion_reply_length
+#else
+#define OUR_ONION_REPLY_SIZE	ONION_REPLY_SIZE
+#endif
+
 struct onionreply *create_onionreply(const tal_t *ctx,
 				     const struct secret *shared_secret,
 				     const u8 *failure_msg)
 {
 	size_t msglen = tal_count(failure_msg);
-	size_t padlen = ONION_REPLY_SIZE - msglen;
+	size_t padlen = OUR_ONION_REPLY_SIZE - msglen;
 	struct onionreply *reply = tal(ctx, struct onionreply);
 	u8 *payload = tal_arr(ctx, u8, 0);
 	struct secret key;
@@ -716,7 +723,7 @@ struct onionreply *create_onionreply(const tal_t *ctx,
 	 *     - Note: this value is 118 bytes longer than the longest
 	 *       currently-defined message.
 	 */
-	assert(tal_count(payload) == ONION_REPLY_SIZE + 4);
+	assert(tal_count(payload) == OUR_ONION_REPLY_SIZE + 4);
 
 	/* BOLT #4:
 	 *

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -267,6 +267,9 @@ sphinx_compressed_onion_deserialize(const tal_t *ctx, const u8 *src);
 #if DEVELOPER
 /* Override to force us to reject valid onion packets */
 extern bool dev_fail_process_onionpacket;
+
+/* Override to set custom onion error lengths. */
+extern unsigned dev_onion_reply_length;
 #endif
 
 #endif /* LIGHTNING_COMMON_SPHINX_H */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -752,6 +752,11 @@ static void dev_register_opts(struct lightningd *ld)
 	opt_register_noarg("--dev-no-ping-timer", opt_set_bool,
 			   &ld->dev_no_ping_timer,
 			   "Don't hang up if we don't get a ping response");
+	opt_register_arg("--dev-onion-reply-length",
+			 opt_set_uintval,
+			 opt_show_uintval,
+			 &dev_onion_reply_length,
+			 "Send onion errors of custom length");
 }
 #endif /* DEVELOPER */
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1042,7 +1042,8 @@ def test_channel_state_change_history(node_factory, bitcoind):
         assert(history[3]['message'] == "Closing complete")
 
 
-@pytest.mark.developer("without DEVELOPER=1, gossip v slow")
+@pytest.mark.xfail(strict=True)
+@pytest.mark.developer("Gossip slow, and we test --dev-onion-reply-length")
 def test_htlc_accepted_hook_fail(node_factory):
     """Send payments from l1 to l2, but l2 just declines everything.
 
@@ -1053,7 +1054,8 @@ def test_htlc_accepted_hook_fail(node_factory):
     """
     l1, l2, l3 = node_factory.line_graph(3, opts=[
         {},
-        {'plugin': os.path.join(os.getcwd(), 'tests/plugins/fail_htlcs.py')},
+        {'dev-onion-reply-length': 1111,
+         'plugin': os.path.join(os.getcwd(), 'tests/plugins/fail_htlcs.py')},
         {}
     ], wait_for_announce=True)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1042,7 +1042,6 @@ def test_channel_state_change_history(node_factory, bitcoind):
         assert(history[3]['message'] == "Closing complete")
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("Gossip slow, and we test --dev-onion-reply-length")
 def test_htlc_accepted_hook_fail(node_factory):
     """Send payments from l1 to l2, but l2 just declines everything.

--- a/wire/fromwire.c
+++ b/wire/fromwire.c
@@ -223,6 +223,8 @@ u8 *fromwire_tal_arrn(const tal_t *ctx,
 
 	arr = tal_arr(ctx, u8, num);
 	fromwire_u8_array(cursor, max, arr, num);
+	if (!*cursor)
+		return tal_free(arr);
 	return arr;
 }
 


### PR DESCRIPTION
Turns out we *didn't* handle this correctly, sorry Joost!

See https://github.com/lightning/bolts/pull/1021