### PR TITLE
fix: Raise Error for long TEST_DIR

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -25,6 +25,8 @@ __attempts: Dict[str, int] = {}
 @pytest.fixture(scope="session")
 def test_base_dir():
     d = os.getenv("TEST_DIR", "/tmp")
+    if len(d) > 12:
+        raise ValueError("TEST_DIR length is too long please create one with less than x characters")
 
     directory = tempfile.mkdtemp(prefix='ltests-', dir=d)
     print("Running tests in {}".format(directory))


### PR DESCRIPTION
I added an if statment after we define our test dir path to check if it is larger than 12 characters because otherwise it was throwing an error

this closes: https://github.com/ElementsProject/lightning/issues/5576