### PR TITLE
doc: Escape non-formatting underscores in Markdown for man pages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -184,6 +184,7 @@ check: check-manpages
 check-manpages: all-programs check-config-docs default-targets
 	@tools/check-manpage.sh cli/lightning-cli doc/lightning-cli.1.md
 	@tools/check-manpage.sh "lightningd/lightningd --lightning-dir=/tmp/" doc/lightningd-config.5.md
+	@awk '/^$$/ { do { getline } while ($$0 ~ /^( {4,}|\t)/) } /^\s*```/ { do { getline } while ($$0 !~ /^\s*```/) } /^([^`_\\]|`([^`\\]|\\.)*`|\b_|_\b|\\.)*\B_\B/ { print "" ; print "Unescaped underscore at " FILENAME ":" NR ":" ; print ; ret = 1 } ENDFILE { NR = 0 } END { exit ret }' doc/*.[0-9].md
 
 # Makes sure that fields mentioned in schema are in man page, and vice versa.
 check-config-docs:

--- a/doc/lightning-addgossip.7.md
+++ b/doc/lightning-addgossip.7.md
@@ -16,7 +16,7 @@ update its internal state using the gossip message.
 Note that currently some paths will still silently reject the gossip: it
 is best effort.
 
-This is particularly used by plugins which may receive channel_update
+This is particularly used by plugins which may receive channel\_update
 messages within error replies.
 
 RETURN VALUE

--- a/doc/lightning-addgossip.7.md
+++ b/doc/lightning-addgossip.7.md
@@ -42,4 +42,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:326e5801f65998e13e909d8b682e9fbc9824f3a43aa7da1d76b871882e52f293)
+[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)

--- a/doc/lightning-autoclean-once.7.md
+++ b/doc/lightning-autoclean-once.7.md
@@ -67,4 +67,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:eebeb7600540caf66857b98c384ae7ee9a2a651398a7aec005703e71e72a6d62)
+[comment]: # ( SHA256STAMP:9853f639595b1fd8d04e41cf7fe8de9bb90d1cb132c70dd4f8db8a7cf6f1233b)

--- a/doc/lightning-autoclean-status.7.md
+++ b/doc/lightning-autoclean-status.7.md
@@ -91,4 +91,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:9431024693a7c26f9519ef24bdfb8b5c26902bdc0631d427f89c9e49ecd88e13)
+[comment]: # ( SHA256STAMP:151fc6cdfd277cac7e6f18e98384b40a6cc1c2a3eb2d0f1e3c26442aa0e9e8d4)

--- a/doc/lightning-batching.7.md
+++ b/doc/lightning-batching.7.md
@@ -52,4 +52,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:326e5801f65998e13e909d8b682e9fbc9824f3a43aa7da1d76b871882e52f293)
+[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)

--- a/doc/lightning-bkpr-channelsapy.7.md
+++ b/doc/lightning-bkpr-channelsapy.7.md
@@ -4,7 +4,7 @@ lightning-bkpr-channelsapy -- Command to list stats on channel earnings
 SYNOPSIS
 --------
 
-**bkpr-channelsapy** \[*start_time*\] \[*end_time*\]
+**bkpr-channelsapy** \[*start\_time*\] \[*end\_time*\]
 
 DESCRIPTION
 -----------
@@ -12,9 +12,9 @@ DESCRIPTION
 The **bkpr-channelsapy** RPC command lists stats on routing income, leasing income,
 and various calculated APYs for channel routed funds.
 
-The **start_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
+The **start\_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
 
-The **end_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
+The **end\_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
 
 
 RETURN VALUE

--- a/doc/lightning-bkpr-channelsapy.7.md
+++ b/doc/lightning-bkpr-channelsapy.7.md
@@ -23,14 +23,14 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **channels\_apy** is returned.  It is an array of objects, where each object contains:
 
-- **account** (string): The account name. If the account is a channel, the channel_id. The 'net' entry is the rollup of all channel accounts
+- **account** (string): The account name. If the account is a channel, the channel\_id. The 'net' entry is the rollup of all channel accounts
 - **routed\_out\_msat** (msat): Sats routed (outbound)
 - **routed\_in\_msat** (msat): Sats routed (inbound)
 - **lease\_fee\_paid\_msat** (msat): Sats paid for leasing inbound (liquidity ads)
 - **lease\_fee\_earned\_msat** (msat): Sats earned for leasing outbound (liquidity ads)
 - **pushed\_out\_msat** (msat): Sats pushed to peer at open
 - **pushed\_in\_msat** (msat): Sats pushed in from peer at open
-- **our\_start\_balance\_msat** (msat): Starting balance in channel at funding. Note that if our start ballance is zero, any _initial field will be omitted (can't divide by zero)
+- **our\_start\_balance\_msat** (msat): Starting balance in channel at funding. Note that if our start ballance is zero, any \_initial field will be omitted (can't divide by zero)
 - **channel\_start\_balance\_msat** (msat): Total starting balance at funding
 - **fees\_out\_msat** (msat): Fees earned on routed outbound
 - **utilization\_out** (string): Sats routed outbound / total start balance
@@ -65,4 +65,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:8ec833f8261ab8b559f0d645d6da45322b388905413ef262d95f5039d533fdc8)
+[comment]: # ( SHA256STAMP:97fb832389b1084e25015a7a46b5d84b37e8e08f7c9e9eb678beb0d026f161dd)

--- a/doc/lightning-bkpr-channelsapy.7.md
+++ b/doc/lightning-bkpr-channelsapy.7.md
@@ -30,7 +30,7 @@ On success, an object containing **channels\_apy** is returned.  It is an array 
 - **lease\_fee\_earned\_msat** (msat): Sats earned for leasing outbound (liquidity ads)
 - **pushed\_out\_msat** (msat): Sats pushed to peer at open
 - **pushed\_in\_msat** (msat): Sats pushed in from peer at open
-- **our\_start\_balance\_msat** (msat): Starting balance in channel at funding. Note that if our start ballance is zero, any \_initial field will be omitted (can't divide by zero)
+- **our\_start\_balance\_msat** (msat): Starting balance in channel at funding. Note that if our start balance is zero, any \_initial field will be omitted (can't divide by zero)
 - **channel\_start\_balance\_msat** (msat): Total starting balance at funding
 - **fees\_out\_msat** (msat): Fees earned on routed outbound
 - **utilization\_out** (string): Sats routed outbound / total start balance
@@ -65,4 +65,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:97fb832389b1084e25015a7a46b5d84b37e8e08f7c9e9eb678beb0d026f161dd)
+[comment]: # ( SHA256STAMP:05c9260f9ba49e3c3333ec7d4b0e671f81b8f8cd32cde87ea46c532b54ae7e54)

--- a/doc/lightning-bkpr-dumpincomecsv.7.md
+++ b/doc/lightning-bkpr-dumpincomecsv.7.md
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1375c000d025b6cb72daa3b2ea64ec3212ae1aa5552c0d87918fd869d2fc5a0b)
+[comment]: # ( SHA256STAMP:8c27ebf6e36fb26051ec724d44497d765454cac071d287586d2b0490e690c01c)

--- a/doc/lightning-bkpr-dumpincomecsv.7.md
+++ b/doc/lightning-bkpr-dumpincomecsv.7.md
@@ -4,19 +4,19 @@ lightning-bkpr-dumpincomecsv -- Command to emit a CSV of income events
 SYNOPSIS
 --------
 
-**bkpr-dumpincomecsv** *csv_format* \[*csv_file*\] \[*consolidate_fees*\] \[*start_time*\] \[*end_time*\]
+**bkpr-dumpincomecsv** *csv\_format* \[*csv\_file*\] \[*consolidate\_fees*\] \[*start\_time*\] \[*end\_time*\]
 
 DESCRIPTION
 -----------
 
-The **bkpr-dumpincomcsv** RPC command writes a CSV file to disk at *csv_file*
+The **bkpr-dumpincomcsv** RPC command writes a CSV file to disk at *csv\_file*
 location. This is a formatted output of the **listincome** RPC command.
 
-**csv_format** is which CSV format to use. See RETURN VALUE for options.
+**csv\_format** is which CSV format to use. See RETURN VALUE for options.
 
-**csv_file** is the on-disk destination of the generated CSV file.
+**csv\_file** is the on-disk destination of the generated CSV file.
 
-If **consolidate_fees** is true, we emit a single, consolidated event for
+If **consolidate\_fees** is true, we emit a single, consolidated event for
 any onchain-fees for a txid and account. Otherwise, events for every update to
 the onchain fee calculation for this account and txid will be printed.
 Defaults to true. Note that this means that the events emitted are
@@ -24,9 +24,9 @@ non-stable, i.e.  calling **dumpincomecsv** twice may result in different
 onchain fee events being emitted, depending on how much information we've
 logged for that transaction.
 
-The **start_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
+The **start\_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
 
-The **end_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
+The **end\_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
 
 
 RETURN VALUE

--- a/doc/lightning-bkpr-inspect.7.md
+++ b/doc/lightning-bkpr-inspect.7.md
@@ -52,4 +52,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ea50ea813e46669b522ebd466619ac6f7a4be5ae38b4f976a7db70a3c01b7fae)
+[comment]: # ( SHA256STAMP:1fc6c84962d2c670b3555dbdb7ffdddf33c4f5c445f3cfbab474a6c017ead06b)

--- a/doc/lightning-bkpr-listaccountevents.7.md
+++ b/doc/lightning-bkpr-listaccountevents.7.md
@@ -25,13 +25,13 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **events** is returned.  It is an array of objects, where each object contains:
 
-- **account** (string): The account name. If the account is a channel, the channel_id
-- **type** (string): Coin movement type (one of "onchain_fee", "chain", "channel")
+- **account** (string): The account name. If the account is a channel, the channel\_id
+- **type** (string): Coin movement type (one of "onchain\_fee", "chain", "channel")
 - **tag** (string): Description of movement
 - **credit\_msat** (msat): Amount credited
 - **debit\_msat** (msat): Amount debited
 - **currency** (string): human-readable bech32 part for this coin type
-- **timestamp** (u32): Timestamp this event was recorded by the node. For consolidated events such as onchain_fees, the most recent timestamp
+- **timestamp** (u32): Timestamp this event was recorded by the node. For consolidated events such as onchain\_fees, the most recent timestamp
 
 If **type** is "chain":
 
@@ -42,7 +42,7 @@ If **type** is "chain":
   - **txid** (txid, optional): The txid of the transaction that created this event
   - **description** (string, optional): The description of this event
 
-If **type** is "onchain_fee":
+If **type** is "onchain\_fee":
 
   - **txid** (txid): The txid of the transaction that created this event
 
@@ -71,4 +71,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1ac0919bf29ebc37a92283d15a9ffa06f0f46be5fb55920b335d0c43e02a6ee4)
+[comment]: # ( SHA256STAMP:2326473627193f2e7d2a1688d046106996a43602ccad64df16913e89bf67b3e8)

--- a/doc/lightning-bkpr-listaccountevents.7.md
+++ b/doc/lightning-bkpr-listaccountevents.7.md
@@ -14,7 +14,7 @@ The **bkpr-listaccountevents** RPC command is a list of all bookkeeping events t
 If the optional parameter **account** is set, we only emit events for the
 specified account, if exists.
 
-Note that the type **onchain_fees** that are emitted are of opposite credit/debit than as they appear in **listincome**, as **listincome** shows all events from the perspective of the node, whereas **listaccountevents** just dumps the event data as we've got it. Onchain fees are updated/recorded as we get more information about input and output spends -- the total onchain fees that were recorded for a transaction for an account can be found by summing all onchain fee events and taking the difference between the **credit_msat** and **debit_msat** for these events. We do this so that successive calls to **listaccountevents** always
+Note that the type **onchain\_fees** that are emitted are of opposite credit/debit than as they appear in **listincome**, as **listincome** shows all events from the perspective of the node, whereas **listaccountevents** just dumps the event data as we've got it. Onchain fees are updated/recorded as we get more information about input and output spends -- the total onchain fees that were recorded for a transaction for an account can be found by summing all onchain fee events and taking the difference between the **credit\_msat** and **debit\_msat** for these events. We do this so that successive calls to **listaccountevents** always
 produce the same list of events -- no previously emitted event will be
 subsequently updated, rather we add a new event to the list.
 

--- a/doc/lightning-bkpr-listbalances.7.md
+++ b/doc/lightning-bkpr-listbalances.7.md
@@ -21,7 +21,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **accounts** is returned.  It is an array of objects, where each object contains:
 
-- **account** (string): The account name. If the account is a channel, the channel_id
+- **account** (string): The account name. If the account is a channel, the channel\_id
 - **balances** (array of objects):
   - **balance\_msat** (msat): Current account balance
   - **coin\_type** (string): coin type, same as HRP for bech32
@@ -53,4 +53,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2801e5f237043c6f85d35e2f4a5f69aab5d1cb6a9fcbea9ead1da2daa93265c8)
+[comment]: # ( SHA256STAMP:ece6c722354576bd5de4d116547546129cdb22e950ce5e9fde3c4d7466bd255c)

--- a/doc/lightning-bkpr-listincome.7.md
+++ b/doc/lightning-bkpr-listincome.7.md
@@ -28,12 +28,12 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **income\_events** is returned.  It is an array of objects, where each object contains:
 
-- **account** (string): The account name. If the account is a channel, the channel_id
+- **account** (string): The account name. If the account is a channel, the channel\_id
 - **tag** (string): Type of income event
 - **credit\_msat** (msat): Amount earned (income)
 - **debit\_msat** (msat): Amount spent (expenses)
 - **currency** (string): human-readable bech32 part for this coin type
-- **timestamp** (u32): Timestamp this event was recorded by the node. For consolidated events such as onchain_fees, the most recent timestamp
+- **timestamp** (u32): Timestamp this event was recorded by the node. For consolidated events such as onchain\_fees, the most recent timestamp
 - **description** (string, optional): More information about this event. If a `invoice` type, typically the bolt11/bolt12 description
 - **outpoint** (string, optional): The txid:outnum for this event, if applicable
 - **txid** (txid, optional): The txid of the transaction that created this event, if applicable
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:24a4784f87f26283e8849e525d51b376d3e69ae20c0941cfd745a7d07af8032a)
+[comment]: # ( SHA256STAMP:8d35ccd4a389f70dc69bda4b66bd834bd48198191565fe37d4af8caa165a8108)

--- a/doc/lightning-bkpr-listincome.7.md
+++ b/doc/lightning-bkpr-listincome.7.md
@@ -4,23 +4,23 @@ lightning-bkpr-listincome -- Command for listing all income impacting events
 SYNOPSIS
 --------
 
-**bkpr-listincome** \[*consolidate_fees*\] \[*start_time*\] \[*end_time*\]
+**bkpr-listincome** \[*consolidate\_fees*\] \[*start\_time*\] \[*end\_time*\]
 
 DESCRIPTION
 -----------
 
 The **bkpr-listincome** RPC command is a list of all income impacting events that the bookkeeper plugin has recorded for this node.
 
-If **consolidate_fees** is true, we emit a single, consolidated event for
+If **consolidate\_fees** is true, we emit a single, consolidated event for
 any onchain-fees for a txid and account. Otherwise, events for every update to
 the onchain fee calculation for this account and txid will be printed. Defaults to true. Note that this means that the events emitted are non-stable,
 i.e. calling **listincome** twice may result in different onchain fee events
 being emitted, depending on how much information we've logged for that
 transaction.
 
-The **start_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
+The **start\_time** is a UNIX timestamp (in seconds) that filters events after the provided timestamp. Defaults to zero.
 
-The **end_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
+The **end\_time** is a UNIX timestamp (in seconds) that filters events up to and at the provided timestamp. Defaults to max-int.
 
 RETURN VALUE
 ------------

--- a/doc/lightning-check.7.md
+++ b/doc/lightning-check.7.md
@@ -26,7 +26,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **command\_to\_check** (string): the *command_to_check* argument
+- **command\_to\_check** (string): the *command\_to\_check* argument
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -41,4 +41,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:22c1ad9baf37cb8c7c4b587047d40ef23f0af3d821feaf1aab6d365d724b08fe)
+[comment]: # ( SHA256STAMP:0a799d16e3f191b6c5dbea039ba32c6824718b326a1178b1f4948461c8ba6a0b)

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -50,4 +50,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:28b7c05443a785461a0134e3c2761a2e2d698cb71044f4d895d15ac7f2ee4316)
+[comment]: # ( SHA256STAMP:7a8b174b98e2e339e0001de740d19ac83042617eaad9b160fa5a8a3525ce7bc4)

--- a/doc/lightning-close.7.md
+++ b/doc/lightning-close.7.md
@@ -4,7 +4,7 @@ lightning-close -- Command for closing channels with direct peers
 SYNOPSIS
 --------
 
-**close** *id* [*unilateraltimeout*] [*destination*] [*fee_negotiation_step*] [*wrong_funding*] [*force_lease_closed*] [\*feerange\*]
+**close** *id* [*unilateraltimeout*] [*destination*] [*fee\_negotiation\_step*] [*wrong\_funding*] [*force\_lease\_closed*] [\*feerange\*]
 
 DESCRIPTION
 -----------
@@ -31,7 +31,7 @@ the peer hasn't offered the `option_shutdown_anysegwit` feature, then
 taproot addresses (or other v1+ segwit) are not allowed.  Tell your
 friends to upgrade!
 
-The *fee_negotiation_step* parameter controls how closing fee
+The *fee\_negotiation\_step* parameter controls how closing fee
 negotiation is performed assuming the peer proposes a fee that is
 different than our estimate.  (Note that modern peers use the quick-close protocol which does not allow negotiation: see *feerange* instead).
 
@@ -50,8 +50,8 @@ we quickly accept the peer's proposal.
  
 The default is "50%".
 
-*wrong_funding* can only be specified if both sides have offered
-the "shutdown_wrong_funding" feature (enabled by the
+*wrong\_funding* can only be specified if both sides have offered
+the "shutdown\_wrong\_funding" feature (enabled by the
 **experimental-shutdown-wrong-funding** option): it must be a
 transaction id followed by a colon then the output number.  Instead of
 negotiating a shutdown to spend the expected funding transaction, the
@@ -59,13 +59,13 @@ shutdown transaction will spend this output instead.  This is only
 allowed if this peer opened the channel and the channel is unused: it
 can rescue openings which have been manually miscreated.
 
-*force_lease_closed* if the channel has funds leased to the peer
-(option_will_fund), we prevent initiation of a mutual close
+*force\_lease\_closed* if the channel has funds leased to the peer
+(option\_will\_fund), we prevent initiation of a mutual close
 unless this flag is passed in. Defaults to false.
 
 *feerange* is an optional array [ *min*, *max* ], indicating the
 minimum and maximum feerates to offer: the peer will obey these if it
-supports the quick-close protocol.  *slow* and *unilateral_close* are
+supports the quick-close protocol.  *slow* and *unilateral\_close* are
 the defaults.
 
 Rates are one of the strings *urgent* (aim for next block), *normal*

--- a/doc/lightning-close.7.md
+++ b/doc/lightning-close.7.md
@@ -135,4 +135,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6a438338ae697732f0100f9e1566b9b8d189778cdb05681305e060487d68663e)
+[comment]: # ( SHA256STAMP:f323b7998a41c28a6c398b8e4ebbefcd227b7624dcf7c03373b518bc55211dd6)

--- a/doc/lightning-commando-rune.7.md
+++ b/doc/lightning-commando-rune.7.md
@@ -30,7 +30,7 @@ is listpeers", or "method is listpeers OR time is before 2023".  Alternatives us
 being run:
 
 * time: the current UNIX time, e.g. "time<1656759180".
-* id: the node_id of the peer, e.g. "id=024b9a1fa8e006f1e3937f65f66c408e6da8e1ca728ea43222a7381df1cc449605".
+* id: the node\_id of the peer, e.g. "id=024b9a1fa8e006f1e3937f65f66c408e6da8e1ca728ea43222a7381df1cc449605".
 * method: the command being run, e.g. "method=withdraw".
 * rate: the rate limit, per minute, e.g. "rate=60".
 * pnum: the number of parameters. e.g. "pnum<2".

--- a/doc/lightning-commando-rune.7.md
+++ b/doc/lightning-commando-rune.7.md
@@ -218,4 +218,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:08ded3c93fea629f414a96f12ac02de1000743a487ec8989ba1510a59861ccc1)
+[comment]: # ( SHA256STAMP:5f4371a060861ca04019948242803f8b6254627f9993a866ec6e119d8a14cef6)

--- a/doc/lightning-commando.7.md
+++ b/doc/lightning-commando.7.md
@@ -4,13 +4,13 @@ lightning-commando -- Command to Send a Command to a Remote Peer
 SYNOPSIS
 --------
 
-**commando** *peer_id* *method* [*params*] [*rune*]
+**commando** *peer\_id* *method* [*params*] [*rune*]
 
 DESCRIPTION
 -----------
 
 The **commando** RPC command is a homage to bad 80s movies.  It also
-sends a directly-connected *peer_id* a custom message, containing a
+sends a directly-connected *peer\_id* a custom message, containing a
 request to run *method* (with an optional dictionary of *params*);
 generally the peer will only allow you to run a command if it has
 provided you with a *rune* which allows it.

--- a/doc/lightning-connect.7.md
+++ b/doc/lightning-connect.7.md
@@ -104,4 +104,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:581c6243302c8fa5c9234de97e1f6af842bbfee544850c55281924721b46432f)
+[comment]: # ( SHA256STAMP:b9f59ec875e50da2251c3e9e6166e62cfc473a46e29eece96705f34c27841782)

--- a/doc/lightning-createinvoice.7.md
+++ b/doc/lightning-createinvoice.7.md
@@ -34,7 +34,7 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **label** (string): the label for the invoice
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): Whether it has been paid, or can no longer be paid (one of "paid", "expired", "unpaid")
 - **description** (string): Description extracted from **bolt11** or **bolt12**
 - **expires\_at** (u64): UNIX timestamp of when invoice expires (or expired)
@@ -44,9 +44,9 @@ On success, an object is returned, containing:
 - **pay\_index** (u64, optional): Incrementing id for when this was paid (**status** *paid* only)
 - **amount\_received\_msat** (msat, optional): Amount actually received (**status** *paid* only)
 - **paid\_at** (u64, optional): UNIX timestamp of when invoice was paid (**status** *paid* only)
-- **payment\_preimage** (secret, optional): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
+- **payment\_preimage** (secret, optional): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
 - **local\_offer\_id** (hex, optional): the *id* of our offer which created this invoice (**experimental-offers** only). (always 64 characters)
-- **invreq\_payer\_note** (string, optional): the optional *invreq_payer_note* from invoice_request which created this invoice (**experimental-offers** only).
+- **invreq\_payer\_note** (string, optional): the optional *invreq\_payer\_note* from invoice\_request which created this invoice (**experimental-offers** only).
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -75,4 +75,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:3acf2924a8670605f70a7976cf4909b60addf4b1aeebc9b9a104151cffa2c984)
+[comment]: # ( SHA256STAMP:8f1ca1ec7fafd96f38d6ffaa0b9b1d0ac0a5ec5d535c45b8b4cb08257468a6b2)

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -4,7 +4,7 @@ lightning-createonion -- Low-level command to create a custom onion
 SYNOPSIS
 --------
 
-**createonion** *hops* *assocdata* [*session_key*] [*onion_size*]
+**createonion** *hops* *assocdata* [*session\_key*] [*onion\_size*]
 
 DESCRIPTION
 -----------
@@ -75,13 +75,13 @@ The *assocdata* parameter specifies the associated data that the onion should
 commit to. If the onion is to be used to send a payment later it MUST match
 the `payment_hash` of the payment in order to be valid.
 
-The optional *session_key* parameter can be used to specify a secret that is
+The optional *session\_key* parameter can be used to specify a secret that is
 used to generate the shared secrets used to encrypt the onion for each hop. It
 should only be used for testing or if a specific shared secret is
 important. If not specified it will be securely generated internally, and the
 shared secrets will be returned.
 
-The optional *onion_size* parameter specifies a size different from the default
+The optional *onion\_size* parameter specifies a size different from the default
 payment onion (1300 bytes). May be used for custom protocols like trampoline
 routing.
 

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -91,7 +91,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **onion** (hex): the onion packet (*onion_size* bytes)
+- **onion** (hex): the onion packet (*onion\_size* bytes)
 - **shared\_secrets** (array of secrets): one shared secret for each node in the *hops* parameter:
   - the shared secret with this hop (always 64 characters)
 
@@ -132,4 +132,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c8bd0abd35904cb009b95a7d345be4cc254cff2a427dcf04679a64a6e62dce1e)
+[comment]: # ( SHA256STAMP:da11700fff0b97851d2c649b3717a3b51c606a930b84dbdd24fb3367dd7de8cb)

--- a/doc/lightning-datastore.7.md
+++ b/doc/lightning-datastore.7.md
@@ -66,4 +66,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:cb5bccd7efd8438c61b909bda419e0300993b2b2267cb335c1f91d12bd402b3e)
+[comment]: # ( SHA256STAMP:65c6c1cb555e5042c3d5d7ad4f9577ec75838d497349c8caee7e186486e09d04)

--- a/doc/lightning-decode.7.md
+++ b/doc/lightning-decode.7.md
@@ -24,7 +24,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **type** (string): what kind of object it decoded to (one of "bolt12 offer", "bolt12 invoice", "bolt12 invoice_request", "bolt11 invoice", "rune")
+- **type** (string): what kind of object it decoded to (one of "bolt12 offer", "bolt12 invoice", "bolt12 invoice\_request", "bolt11 invoice", "rune")
 - **valid** (boolean): if this is false, you *MUST* not use the result except for diagnostics!
 
 If **type** is "bolt12 offer", and **valid** is *true*:
@@ -47,7 +47,7 @@ If **type** is "bolt12 offer", and **valid** is *true*:
     - **first\_node\_id** (pubkey): the (presumably well-known) public key of the start of the path
     - **blinding** (pubkey): blinding factor for this path
     - **path** (array of objects): an individual path:
-      - **blinded\_node\_id** (pubkey): node_id of the hop
+      - **blinded\_node\_id** (pubkey): node\_id of the hop
       - **encrypted\_recipient\_data** (hex): encrypted TLV entry for this hop
   - **offer\_recurrence** (object, optional): how often to this offer should be used:
     - **time\_unit** (u32): the BOLT12 time unit
@@ -76,13 +76,13 @@ If **type** is "bolt12 offer", and **valid** is *false*:
     - **warning\_invalid\_offer\_currency**: `offer_currency_code` is not valid UTF8
     - **warning\_invalid\_offer\_issuer**: `offer_issuer` is not valid UTF8
 
-If **type** is "bolt12 invoice_request", and **valid** is *true*:
+If **type** is "bolt12 invoice\_request", and **valid** is *true*:
 
   - **offer\_description** (string): the description of the purpose of the offer
   - **offer\_node\_id** (pubkey): public key of the offering node
-  - **invreq\_metadata** (hex): the payer-provided blob to derive invreq_payer_id
+  - **invreq\_metadata** (hex): the payer-provided blob to derive invreq\_payer\_id
   - **invreq\_payer\_id** (hex): the payer-provided key
-  - **signature** (bip340sig): BIP-340 signature of the `invreq_payer_id` on this invoice_request
+  - **signature** (bip340sig): BIP-340 signature of the `invreq_payer_id` on this invoice\_request
   - **offer\_id** (hex, optional): the id we use to identify this offer (always 64 characters)
   - **offer\_chains** (array of hexs, optional): which blockchains this offer is for (missing implies bitcoin mainnet only):
     - the genesis blockhash (always 64 characters)
@@ -99,7 +99,7 @@ If **type** is "bolt12 invoice_request", and **valid** is *true*:
     - **first\_node\_id** (pubkey): the (presumably well-known) public key of the start of the path
     - **blinding** (pubkey): blinding factor for this path
     - **path** (array of objects): an individual path:
-      - **blinded\_node\_id** (pubkey): node_id of the hop
+      - **blinded\_node\_id** (pubkey): node\_id of the hop
       - **encrypted\_recipient\_data** (hex): encrypted TLV entry for this hop
   - **offer\_recurrence** (object, optional): how often to this offer should be used:
     - **time\_unit** (u32): the BOLT12 time unit
@@ -114,7 +114,7 @@ If **type** is "bolt12 invoice_request", and **valid** is *true*:
       - **proportional\_amount** (boolean, optional): amount should be scaled if payed after period start (always *true*)
   - **invreq\_chain** (hex, optional): which blockchain this offer is for (missing implies bitcoin mainnet only) (always 64 characters)
   - **invreq\_amount\_msat** (msat, optional): the amount the invoice should be for
-  - **invreq\_features** (hex, optional): the feature bits of the invoice_request
+  - **invreq\_features** (hex, optional): the feature bits of the invoice\_request
   - **invreq\_quantity** (u64, optional): the number of items to invoice for
   - **invreq\_payer\_note** (string, optional): a note attached by the payer
   - **invreq\_recurrence\_counter** (u32, optional): which number request this is for the same invoice
@@ -126,7 +126,7 @@ If **type** is "bolt12 invoice_request", and **valid** is *true*:
   - the following warnings are possible:
     - **warning\_unknown\_offer\_currency**: The currency code is unknown (so no `currency_minor_unit`)
 
-If **type** is "bolt12 invoice_request", and **valid** is *false*:
+If **type** is "bolt12 invoice\_request", and **valid** is *false*:
 
   - the following warnings are possible:
     - **warning\_invalid\_offer\_description**: `offer_description` is not valid UTF8
@@ -143,20 +143,20 @@ If **type** is "bolt12 invoice", and **valid** is *true*:
 
   - **offer\_description** (string): the description of the purpose of the offer
   - **offer\_node\_id** (pubkey): public key of the offering node
-  - **invreq\_metadata** (hex): the payer-provided blob to derive invreq_payer_id
+  - **invreq\_metadata** (hex): the payer-provided blob to derive invreq\_payer\_id
   - **invreq\_payer\_id** (hex): the payer-provided key
   - **invoice\_paths** (array of objects): Paths to pay the destination:
     - **first\_node\_id** (pubkey): the (presumably well-known) public key of the start of the path
     - **blinding** (pubkey): blinding factor for this path
     - **path** (array of objects): an individual path:
-      - **blinded\_node\_id** (pubkey): node_id of the hop
+      - **blinded\_node\_id** (pubkey): node\_id of the hop
       - **encrypted\_recipient\_data** (hex): encrypted TLV entry for this hop
       - **fee\_base\_msat** (msat, optional): basefee for path
       - **fee\_proportional\_millionths** (u32, optional): proportional fee for path
       - **cltv\_expiry\_delta** (u32, optional): CLTV delta for path
       - **features** (hex, optional): features allowed for path
   - **invoice\_created\_at** (u64): the UNIX timestamp of invoice creation
-  - **invoice\_payment\_hash** (hex): the hash of the *payment_preimage* (always 64 characters)
+  - **invoice\_payment\_hash** (hex): the hash of the *payment\_preimage* (always 64 characters)
   - **invoice\_amount\_msat** (msat): the amount required to fulfill invoice
   - **signature** (bip340sig): BIP-340 signature of the `offer_node_id` on this invoice
   - **offer\_id** (hex, optional): the id we use to identify this offer (always 64 characters)
@@ -175,7 +175,7 @@ If **type** is "bolt12 invoice", and **valid** is *true*:
     - **first\_node\_id** (pubkey): the (presumably well-known) public key of the start of the path
     - **blinding** (pubkey): blinding factor for this path
     - **path** (array of objects): an individual path:
-      - **blinded\_node\_id** (pubkey): node_id of the hop
+      - **blinded\_node\_id** (pubkey): node\_id of the hop
       - **encrypted\_recipient\_data** (hex): encrypted TLV entry for this hop
   - **offer\_recurrence** (object, optional): how often to this offer should be used:
     - **time\_unit** (u32): the BOLT12 time unit
@@ -190,18 +190,18 @@ If **type** is "bolt12 invoice", and **valid** is *true*:
       - **proportional\_amount** (boolean, optional): amount should be scaled if payed after period start (always *true*)
   - **invreq\_chain** (hex, optional): which blockchain this offer is for (missing implies bitcoin mainnet only) (always 64 characters)
   - **invreq\_amount\_msat** (msat, optional): the amount the invoice should be for
-  - **invreq\_features** (hex, optional): the feature bits of the invoice_request
+  - **invreq\_features** (hex, optional): the feature bits of the invoice\_request
   - **invreq\_quantity** (u64, optional): the number of items to invoice for
   - **invreq\_payer\_note** (string, optional): a note attached by the payer
   - **invreq\_recurrence\_counter** (u32, optional): which number request this is for the same invoice
   - **invreq\_recurrence\_start** (u32, optional): when we're requesting to start an invoice at a non-zero period
-  - **invoice\_relative\_expiry** (u32, optional): the number of seconds after *invoice_created_at* when this expires
+  - **invoice\_relative\_expiry** (u32, optional): the number of seconds after *invoice\_created\_at* when this expires
   - **invoice\_fallbacks** (array of objects, optional): onchain addresses:
     - **version** (u8): Segwit address version
     - **hex** (hex): Raw encoded segwit address
     - **address** (string, optional): bech32 segwit address
   - **invoice\_features** (hex, optional): the feature bits of the invoice
-  - **invoice\_node\_id** (pubkey, optional): the id to pay (usually the same as offer_node_id)
+  - **invoice\_node\_id** (pubkey, optional): the id to pay (usually the same as offer\_node\_id)
   - **invoice\_recurrence\_basetime** (u64, optional): the UNIX timestamp to base the invoice periods on
   - **unknown\_invoice\_tlvs** (array of objects, optional): Any extra fields we didn't know how to parse:
     - **type** (u64): The type
@@ -238,7 +238,7 @@ If **type** is "bolt11 invoice", and **valid** is *true*:
   - **created\_at** (u64): the UNIX-style timestamp of the invoice
   - **expiry** (u64): the number of seconds this is valid after `created_at`
   - **payee** (pubkey): the public key of the recipient
-  - **payment\_hash** (hex): the hash of the *payment_preimage* (always 64 characters)
+  - **payment\_hash** (hex): the hash of the *payment\_preimage* (always 64 characters)
   - **signature** (signature): signature of the *payee* on this invoice
   - **min\_final\_cltv\_expiry** (u32): the minimum CLTV delay for the final node
   - **amount\_msat** (msat, optional): Amount the invoice asked for
@@ -246,7 +246,7 @@ If **type** is "bolt11 invoice", and **valid** is *true*:
   - **description\_hash** (hex, optional): the hash of the description, in place of *description* (always 64 characters)
   - **payment\_secret** (hex, optional): the secret to hand to the payee node (always 64 characters)
   - **features** (hex, optional): the features bitmap for this invoice
-  - **payment\_metadata** (hex, optional): the payment_metadata to put in the payment
+  - **payment\_metadata** (hex, optional): the payment\_metadata to put in the payment
   - **fallbacks** (array of objects, optional): onchain addresses:
     - **type** (string): the address type (if known) (one of "P2PKH", "P2SH", "P2WPKH", "P2WSH")
     - **hex** (hex): Raw encoded address
@@ -302,4 +302,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1d13c0e0619d05d8c49cf9fbed90f0baf260d59fd8c16bd283d3b211e8be9878)
+[comment]: # ( SHA256STAMP:7920e365fe0f41fc2aa99c9e99af7c0666da229310ce50c2c2728c973069b2a7)

--- a/doc/lightning-decodepay.7.md
+++ b/doc/lightning-decodepay.7.md
@@ -22,7 +22,7 @@ On success, an object is returned, containing:
 - **created\_at** (u64): the UNIX-style timestamp of the invoice
 - **expiry** (u64): the number of seconds this is valid after *timestamp*
 - **payee** (pubkey): the public key of the recipient
-- **payment\_hash** (hex): the hash of the *payment_preimage* (always 64 characters)
+- **payment\_hash** (hex): the hash of the *payment\_preimage* (always 64 characters)
 - **signature** (signature): signature of the *payee* on this invoice
 - **min\_final\_cltv\_expiry** (u32): the minimum CLTV delay for the final node
 - **amount\_msat** (msat, optional): Amount the invoice asked for
@@ -30,7 +30,7 @@ On success, an object is returned, containing:
 - **description\_hash** (hex, optional): the hash of the description, in place of *description* (always 64 characters)
 - **payment\_secret** (hex, optional): the secret to hand to the payee node (always 64 characters)
 - **features** (hex, optional): the features bitmap for this invoice
-- **payment\_metadata** (hex, optional): the payment_metadata to put in the payment
+- **payment\_metadata** (hex, optional): the payment\_metadata to put in the payment
 - **fallbacks** (array of objects, optional): onchain addresses:
   - **type** (string): the address type (if known) (one of "P2PKH", "P2SH", "P2WPKH", "P2WSH")
   - **hex** (hex): Raw encoded address
@@ -71,4 +71,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c98fd8cac46b5446ff2d01ede6b082f64a83d4b5745d06e410af3e1dd91be8e2)
+[comment]: # ( SHA256STAMP:a1163f7535526b8f9bcea137c6cd5d270e0730d2d58f8c8487794415273dd489)

--- a/doc/lightning-deldatastore.7.md
+++ b/doc/lightning-deldatastore.7.md
@@ -49,4 +49,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:262227d8b4aaee5cad954afa4335b29bceabd787f346d1e5a990614edac7f5e7)
+[comment]: # ( SHA256STAMP:0d9d6e4336f6317ca85628b76f2aa40a5172b54333a1a3931e1284d9a803f61b)

--- a/doc/lightning-delexpiredinvoice.7.md
+++ b/doc/lightning-delexpiredinvoice.7.md
@@ -38,4 +38,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:01526643e128e75057c668cd5dd36e79f075ca847bc692629e1c773b6c940ae6)
+[comment]: # ( SHA256STAMP:aa572f59f54ad8ca0d2c43d41574e9068c7d5dc371927638b7c8a0c1c3b6e496)

--- a/doc/lightning-delforward.7.md
+++ b/doc/lightning-delforward.7.md
@@ -4,13 +4,13 @@ lightning-delforward -- Command for removing a forwarding entry
 SYNOPSIS
 --------
 
-**delforward** *in_channel* *in_htlc_id* *status*
+**delforward** *in\_channel* *in\_htlc\_id* *status*
 
 DESCRIPTION
 -----------
 
 The **delforward** RPC command removes a single forward from **listforwards**,
-using the uniquely-identifying *in_channel* and *in_htlc_id* (and, as a sanity
+using the uniquely-identifying *in\_channel* and *in\_htlc\_id* (and, as a sanity
 check, the *status*) given by that command.
 
 This command is mainly used by the *autoclean* plugin (see lightningd-config(7)),
@@ -20,10 +20,10 @@ has no effect on the running of your node.
 You cannot delete forwards which have status *offered* (i.e. are
 currently active).
 
-Note: for **listforwards** entries without an *in_htlc_id* entry (no
+Note: for **listforwards** entries without an *in\_htlc\_id* entry (no
 longer created in v22.11, but can exist from older versions), a value
 of 18446744073709551615 can be used, but then it will delete *all*
-entries without *in_htlc_id* for this *in_channel* and *status*.
+entries without *in\_htlc\_id* for this *in\_channel* and *status*.
 
 RETURN VALUE
 ------------

--- a/doc/lightning-delforward.7.md
+++ b/doc/lightning-delforward.7.md
@@ -55,4 +55,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:200de829c6635242cb2dd8ec0650c2fa8f5fcbf413f4a704884516df80492fcb)
+[comment]: # ( SHA256STAMP:4aff9673290966c7b09e65672da5dc8ef4d2601d3d1681009b329a4f8ceb9af6)

--- a/doc/lightning-delinvoice.7.md
+++ b/doc/lightning-delinvoice.7.md
@@ -28,7 +28,7 @@ Note: The return is the same as an object from lightning-listinvoice(7).
 On success, an object is returned, containing:
 
 - **label** (string): Unique label given at creation time
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): State of invoice (one of "paid", "expired", "unpaid")
 - **expires\_at** (u64): UNIX timestamp when invoice expires (or expired)
 - **bolt11** (string, optional): BOLT11 string
@@ -39,14 +39,14 @@ On success, an object is returned, containing:
 If **bolt12** is present:
 
   - **local\_offer\_id** (hex, optional): offer for which this invoice was created
-  - **invreq\_payer\_note** (string, optional): the optional *invreq_payer_note* from invoice_request which created this invoice
+  - **invreq\_payer\_note** (string, optional): the optional *invreq\_payer\_note* from invoice\_request which created this invoice
 
 If **status** is "paid":
 
   - **pay\_index** (u64): unique index for this invoice payment
   - **amount\_received\_msat** (msat): how much was actually received
   - **paid\_at** (u64): UNIX timestamp of when payment was received
-  - **payment\_preimage** (secret): SHA256 of this is the *payment_hash* offered in the invoice (always 64 characters)
+  - **payment\_preimage** (secret): SHA256 of this is the *payment\_hash* offered in the invoice (always 64 characters)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -81,4 +81,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:961571f6b2155f0452ac376bdf957474dd20e97e05a89efdf590f6e4da310f4f)
+[comment]: # ( SHA256STAMP:c21dd851c40769c1b79489ccaf364c4647a67bf6cd1a34dd96a8574016d66d96)

--- a/doc/lightning-delinvoice.7.md
+++ b/doc/lightning-delinvoice.7.md
@@ -59,7 +59,7 @@ The following errors may be reported:
 - 905:  An invoice with that label does not exist.
 - 906:  The invoice *status* does not match the parameter.
   An error object will be returned as error *data*, containing
-  *current_status* and *expected_status* fields.
+  *current\_status* and *expected\_status* fields.
   This is most likely due to the *status* of the invoice
   changing just before this command is invoked.
 - 908: The invoice already has no description, and *desconly* was set.

--- a/doc/lightning-delpay.7.md
+++ b/doc/lightning-delpay.7.md
@@ -42,7 +42,7 @@ payments will be returned -- one payment object for each partid.
 On success, an object containing **payments** is returned.  It is an array of objects, where each object contains:
 
 - **id** (u64): unique ID for this payment attempt
-- **payment\_hash** (hex): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hex): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (one of "pending", "failed", "complete")
 - **amount\_sent\_msat** (msat): the amount we actually sent, including fees
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
@@ -50,7 +50,7 @@ On success, an object containing **payments** is returned.  It is an array of ob
 - **destination** (pubkey, optional): the final destination of the payment if known
 - **amount\_msat** (msat, optional): the amount the destination received, if known
 - **completed\_at** (u64, optional): the UNIX timestamp showing when this payment was completed
-- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment_hash
+- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment\_hash
 - **payment\_preimage** (hex, optional): proof of payment (always 64 characters)
 - **label** (string, optional): the label, if given to sendpay
 - **bolt11** (string, optional): the bolt11 string (if pay supplied one)
@@ -106,4 +106,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:1ce2241eeae759ed5566342fb7810e62fa2c618f2465314f17376ebe9b6d24f8)
+[comment]: # ( SHA256STAMP:6f1e5f66278e49d10d5556abfabbab6a178f0dbd518b669ce93a32e6763dd458)

--- a/doc/lightning-disableoffer.7.md
+++ b/doc/lightning-disableoffer.7.md
@@ -74,4 +74,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:b471374a7c160373b328c2171953225b7fa27d26314a270e95320c1b6ef57307)
+[comment]: # ( SHA256STAMP:f6896438745837d5f1f5999553b397660eded7b22e5d0765ce5feaa3fc14e48e)

--- a/doc/lightning-disconnect.7.md
+++ b/doc/lightning-disconnect.7.md
@@ -59,4 +59,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:326e5801f65998e13e909d8b682e9fbc9824f3a43aa7da1d76b871882e52f293)
+[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)

--- a/doc/lightning-feerates.7.md
+++ b/doc/lightning-feerates.7.md
@@ -114,7 +114,7 @@ SEE ALSO
 --------
 
 lightning-parsefeerate(7), lightning-fundchannel(7), lightning-withdraw(7),
-lightning-txprepare(7), lightning-fundchannel_start(7).
+lightning-txprepare(7), lightning-fundchannel\_start(7).
 
 RESOURCES
 ---------

--- a/doc/lightning-feerates.7.md
+++ b/doc/lightning-feerates.7.md
@@ -52,7 +52,7 @@ On success, an object is returned, containing:
   - **max\_acceptable** (u32): The largest feerate we will accept from remote negotiations.  If a peer attempts to set the feerate higher than this we will unilaterally close the channel (or simply forget it if it's not open yet).
   - **opening** (u32, optional): Default feerate for lightning-fundchannel(7) and lightning-withdraw(7)
   - **mutual\_close** (u32, optional): Feerate to aim for in cooperative shutdown.  Note that since mutual close is a **negotiation**, the actual feerate used in mutual close will be somewhere between this and the corresponding mutual close feerate of the peer.
-  - **unilateral\_close** (u32, optional): Feerate for commitment_transaction in a live channel which we originally funded
+  - **unilateral\_close** (u32, optional): Feerate for commitment\_transaction in a live channel which we originally funded
   - **delayed\_to\_us** (u32, optional): Feerate for returning unilateral close funds to our wallet
   - **htlc\_resolution** (u32, optional): Feerate for returning unilateral close HTLC outputs to our wallet
   - **penalty** (u32, optional): Feerate to start at when penalizing a cheat attempt
@@ -61,7 +61,7 @@ On success, an object is returned, containing:
   - **max\_acceptable** (u32): The largest feerate we will accept from remote negotiations.  If a peer attempts to set the feerate higher than this we will unilaterally close the channel (or simply forget it if it's not open yet).
   - **opening** (u32, optional): Default feerate for lightning-fundchannel(7) and lightning-withdraw(7)
   - **mutual\_close** (u32, optional): Feerate to aim for in cooperative shutdown.  Note that since mutual close is a **negotiation**, the actual feerate used in mutual close will be somewhere between this and the corresponding mutual close feerate of the peer.
-  - **unilateral\_close** (u32, optional): Feerate for commitment_transaction in a live channel which we originally funded
+  - **unilateral\_close** (u32, optional): Feerate for commitment\_transaction in a live channel which we originally funded
   - **delayed\_to\_us** (u32, optional): Feerate for returning unilateral close funds to our wallet
   - **htlc\_resolution** (u32, optional): Feerate for returning unilateral close HTLC outputs to our wallet
   - **penalty** (u32, optional): Feerate to start at when penalizing a cheat attempt
@@ -121,4 +121,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:d448abe4c00efb8cb68edf6f8316f130ed45a26223b151ac0647bf5b69aec4fd)
+[comment]: # ( SHA256STAMP:c4fbacd9a36de4ed8307deae74f49e40a158435d726aee02f5c37f7a31a71400)

--- a/doc/lightning-fetchinvoice.7.md
+++ b/doc/lightning-fetchinvoice.7.md
@@ -58,7 +58,7 @@ On success, an object is returned, containing:
   - **vendor\_removed** (string, optional): The *vendor* from the offer, which is missing in the invoice
   - **vendor** (string, optional): a completely replaced *vendor* field
   - **amount\_msat** (msat, optional): the amount, if different from the offer amount multiplied by any *quantity* (or the offer had no amount, or was not in BTC).
-- **next\_period** (object, optional): Only for recurring invoices if the next period is under the *recurrence_limit*:
+- **next\_period** (object, optional): Only for recurring invoices if the next period is under the *recurrence\_limit*:
   - **counter** (u64): the index of the next period to fetchinvoice
   - **starttime** (u64): UNIX timestamp that the next period starts
   - **endtime** (u64): UNIX timestamp that the next period ends
@@ -89,4 +89,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:18164ef676c71c8d3abde89d974b3c74bd7fdb43356a737f937b2fb060795a47)
+[comment]: # ( SHA256STAMP:59b33634070b62e711cae7457bfb08874851e4e001512feaefc5ddac1a5b3b5b)

--- a/doc/lightning-fetchinvoice.7.md
+++ b/doc/lightning-fetchinvoice.7.md
@@ -6,7 +6,7 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**fetchinvoice** *offer* [*msatoshi*] [*quantity*] [*recurrence_counter*] [*recurrence_start*] [*recurrence_label*] [*timeout*] [*payer_note*]
+**fetchinvoice** *offer* [*msatoshi*] [*quantity*] [*recurrence\_counter*] [*recurrence\_start*] [*recurrence\_label*] [*timeout*] [*payer\_note*]
 
 DESCRIPTION
 -----------
@@ -19,31 +19,31 @@ If **fetchinvoice-noconnect** is not specified in the configuation, it
 will connect to the destination in the (currently common!) case where it
 cannot find a route which supports `option_onion_messages`.
 
-The offer must not contain *send_invoice*; see lightning-sendinvoice(7).
+The offer must not contain *send\_invoice*; see lightning-sendinvoice(7).
 
 *msatoshi* is required if the *offer* does not specify
 an amount at all, otherwise it is not allowed.
 
 *quantity* is is required if the *offer* specifies
-*quantity_min* or *quantity_max*, otherwise it is not allowed.
+*quantity\_min* or *quantity\_max*, otherwise it is not allowed.
 
-*recurrence_counter* is required if the *offer*
+*recurrence\_counter* is required if the *offer*
 specifies *recurrence*, otherwise it is not allowed.
-*recurrence_counter* should first be set to 0, and incremented for
+*recurrence\_counter* should first be set to 0, and incremented for
 each successive invoice in a given series.
 
-*recurrence_start* is required if the *offer*
-specifies *recurrence_base* with *start_any_period* set, otherwise it
+*recurrence\_start* is required if the *offer*
+specifies *recurrence\_base* with *start\_any\_period* set, otherwise it
 is not allowed.  It indicates what period number to start at.
 
-*recurrence_label* is required if *recurrence_counter* is set, and
+*recurrence\_label* is required if *recurrence\_counter* is set, and
 otherwise is not allowed.  It must be the same as prior fetchinvoice
 calls for the same recurrence, as it is used to link them together.
 
 *timeout* is an optional timeout; if we don't get a reply before this
 we fail (default, 60 seconds).
 
-*payer_note* is an optional payer note to include in the fetched invoice.
+*payer\_note* is an optional payer note to include in the fetched invoice.
 
 RETURN VALUE
 ------------

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -5,7 +5,7 @@ SYNOPSIS
 --------
 
 **fundchannel** *id* *amount* [*feerate*] [*announce*] [*minconf*]
-[*utxos*] [*push_msat*] [*close_to*] [*request_amt*] [*compact_lease*]
+[*utxos*] [*push\_msat*] [*close\_to*] [*request\_amt*] [*compact\_lease*]
 
 DESCRIPTION
 -----------
@@ -55,20 +55,20 @@ outputs should have. Default is 1.
 *utxos* specifies the utxos to be used to fund the channel, as an array
 of "txid:vout".
 
-*push_msat* is the amount of millisatoshis to push to the channel peer at
+*push\_msat* is the amount of millisatoshis to push to the channel peer at
 open. Note that this is a gift to the peer -- these satoshis are
 added to the initial balance of the peer at channel start and are largely
 unrecoverable once pushed.
 
-*close_to* is a Bitcoin address to which the channel funds should be sent to
+*close\_to* is a Bitcoin address to which the channel funds should be sent to
 on close. Only valid if both peers have negotiated `option_upfront_shutdown_script`.
 Returns `close_to` set to closing script iff is negotiated.
 
-*request_amt* is an amount of liquidity you'd like to lease from the peer.
+*request\_amt* is an amount of liquidity you'd like to lease from the peer.
 If peer supports `option_will_fund`, indicates to them to include this
-much liquidity into the channel. Must also pass in *compact_lease*.
+much liquidity into the channel. Must also pass in *compact\_lease*.
 
-*compact_lease* is a compact represenation of the peer's expected
+*compact\_lease* is a compact represenation of the peer's expected
 channel lease terms. If the peer's terms don't match this set, we will
 fail to open the channel.
 

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -88,8 +88,8 @@ On success, an object is returned, containing:
 - **tx** (hex): The raw transaction which funded the channel
 - **txid** (txid): The txid of the transaction which funded the channel
 - **outnum** (u32): The 0-based output index showing which output funded the channel
-- **channel\_id** (hex): The channel_id of the resulting channel (always 64 characters)
-- **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close_to* parameter was specified and peer supports `option_upfront_shutdown_script`
+- **channel\_id** (hex): The channel\_id of the resulting channel (always 64 characters)
+- **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close\_to* parameter was specified and peer supports `option_upfront_shutdown_script`
 - **mindepth** (u32, optional): Number of confirmations before we consider the channel active.
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
@@ -115,4 +115,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:bca36e910b93b86fc42c2d047e703e9760250757cbf09d8cacdf4e3fe1a1f605)
+[comment]: # ( SHA256STAMP:ed7d5aa730bf6b87b3f7072272b984539ca991670c13f85a0da8d4d1333549ae)

--- a/doc/lightning-fundchannel_cancel.7.md
+++ b/doc/lightning-fundchannel_cancel.7.md
@@ -60,4 +60,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:a6b67ae1ecd3bfe5c41e17710342ce32e93675775653bfcffc5b7413c6a15726)
+[comment]: # ( SHA256STAMP:d8a18db4d75c051ec89cd2a52add52aea04e78608c625270238c992b977ec173)

--- a/doc/lightning-fundchannel_complete.7.md
+++ b/doc/lightning-fundchannel_complete.7.md
@@ -29,7 +29,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **channel\_id** (hex): The channel_id of the resulting channel (always 64 characters)
+- **channel\_id** (hex): The channel\_id of the resulting channel (always 64 characters)
 - **commitments\_secured** (boolean): Indication that channel is safe to use (always *true*)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
@@ -62,4 +62,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6852cb54595920fa692b6c0a816b44efa7623a3fd12af90602a137f7de0fc57c)
+[comment]: # ( SHA256STAMP:a1853aa4288c0ee50956328f02e86b580de0dffc8b73e204c8f5daaa79c51a0c)

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -46,7 +46,7 @@ On success, an object is returned, containing:
 
 - **funding\_address** (string): The address to send funding to for the channel. DO NOT SEND COINS TO THIS ADDRESS YET.
 - **scriptpubkey** (hex): The raw scriptPubkey for the address
-- **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close_to* parameter was specified and peer supports `option_upfront_shutdown_script`
+- **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close\_to* parameter was specified and peer supports `option_upfront_shutdown_script`
 - **mindepth** (u32, optional): Number of confirmations before we consider the channel active.
 
 The following warnings may also be returned:
@@ -85,4 +85,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:b054bc55f69cc1f23f78f342974a8476eab84146bbcf57ab30095e8eba3ed849)
+[comment]: # ( SHA256STAMP:ca4ad15c25dc588980dea11be9d3f73c9da3688a5e81bfc13660eabe93cbec13)

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -4,7 +4,7 @@ lightning-fundchannel\_start -- Command for initiating channel establishment for
 SYNOPSIS
 --------
 
-**fundchannel\_start** *id* *amount* [*feerate* *announce* *close_to* *push_msat*]
+**fundchannel\_start** *id* *amount* [*feerate* *announce* *close\_to* *push\_msat*]
 
 DESCRIPTION
 -----------
@@ -23,11 +23,11 @@ commitment transactions: see **fundchannel**.
 
 *announce* whether or not to announce this channel.
 
-*close_to* is a Bitcoin address to which the channel funds should be sent to
+*close\_to* is a Bitcoin address to which the channel funds should be sent to
 on close. Only valid if both peers have negotiated `option_upfront_shutdown_script`.
 Returns `close_to` set to closing script iff is negotiated.
 
-*push_msat* is the amount of millisatoshis to push to the channel peer at
+*push\_msat* is the amount of millisatoshis to push to the channel peer at
 open. Note that this is a gift to the peer -- these satoshis are
 added to the initial balance of the peer at channel start and are largely
 unrecoverable once pushed.

--- a/doc/lightning-funderupdate.7.md
+++ b/doc/lightning-funderupdate.7.md
@@ -109,7 +109,7 @@ On success, an object is returned, containing:
 
 - **summary** (string): Summary of the current funding policy e.g. (match 100)
 - **policy** (string): Policy funder plugin will use to decide how much captial to commit to a v2 open channel request (one of "match", "available", "fixed")
-- **policy\_mod** (u32): The *policy_mod* is the number or 'modification' to apply to the policy.
+- **policy\_mod** (u32): The *policy\_mod* is the number or 'modification' to apply to the policy.
 - **leases\_only** (boolean): Only contribute funds to `option_will_fund` lease requests.
 - **min\_their\_funding\_msat** (msat): The minimum funding sats that we require from peer to activate our funding policy.
 - **max\_their\_funding\_msat** (msat): The maximum funding sats that we'll allow from peer to activate our funding policy.
@@ -121,8 +121,8 @@ On success, an object is returned, containing:
 - **lease\_fee\_base\_msat** (msat, optional): Flat fee to charge for a channel lease.
 - **lease\_fee\_basis** (u32, optional): Proportional fee to charge for a channel lease, calculated as 1/10,000th of requested funds.
 - **funding\_weight** (u32, optional): Transaction weight the channel opener will pay us for a leased funding transaction.
-- **channel\_fee\_max\_base\_msat** (msat, optional): Maximum channel_fee_base_msat we'll charge for routing funds leased on this channel.
-- **channel\_fee\_max\_proportional\_thousandths** (u32, optional): Maximum channel_fee_proportional_millitionths we'll charge for routing funds leased on this channel, in thousandths.
+- **channel\_fee\_max\_base\_msat** (msat, optional): Maximum channel\_fee\_base\_msat we'll charge for routing funds leased on this channel.
+- **channel\_fee\_max\_proportional\_thousandths** (u32, optional): Maximum channel\_fee\_proportional\_millitionths we'll charge for routing funds leased on this channel, in thousandths.
 - **compact\_lease** (hex, optional): Compact description of the channel lease parameters.
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
@@ -147,4 +147,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:03b74bb9d03466181e3f643f718a07388e722e4a6ea1fbb30350e22a7fc491c3)
+[comment]: # ( SHA256STAMP:13eef3ba929ea98506f6ed3d042072be6f70fd01d503ca5f7b49480dea7af627)

--- a/doc/lightning-funderupdate.7.md
+++ b/doc/lightning-funderupdate.7.md
@@ -4,7 +4,7 @@ lightning-funderupdate -- Command for adjusting node funding v2 channels
 SYNOPSIS
 --------
 
-**funderupdate** [*policy*] [*policy_mod*] [*leases_only*] [*min_their_funding_msat*] [*max_their_funding_msat*] [*per_channel_min_msat*] [*per_channel_max_msat*] [*reserve_tank_msat*] [*fuzz_percent*] [*fund_probability*] [*lease_fee_base_msat*] [*lease_fee_basis*] [*funding_weight*] [*channel_fee_max_base_msat*] [*channel_fee_max_proportional_thousandths*] [*compact_lease*]
+**funderupdate** [*policy*] [*policy\_mod*] [*leases\_only*] [*min\_their\_funding\_msat*] [*max\_their\_funding\_msat*] [*per\_channel\_min\_msat*] [*per\_channel\_max\_msat*] [*reserve\_tank\_msat*] [*fuzz\_percent*] [*fund\_probability*] [*lease\_fee\_base\_msat*] [*lease\_fee\_basis*] [*funding\_weight*] [*channel\_fee\_max\_base\_msat*] [*channel\_fee\_max\_proportional\_thousandths*] [*compact\_lease*]
 
 NOTE: Must have --experimental-dual-fund enabled for these settings to take effect.
 
@@ -14,55 +14,55 @@ DESCRIPTION
 For channel open requests using
 
 
-*policy*, *policy_mod* is the policy the funder plugin will use to decide
+*policy*, *policy\_mod* is the policy the funder plugin will use to decide
 how much capital to commit to a v2 open channel request. There are three
 policy options, detailed below: `match`, `available`, and `fixed`.
-The *policy_mod* is the number or 'modification' to apply to the policy.
+The *policy\_mod* is the number or 'modification' to apply to the policy.
 Default is (fixed, 0sats).
 
-* `match` -- Contribute *policy_mod* percent of their requested funds.
-   Valid *policy_mod* values are 0 to 200. If this is a channel lease
+* `match` -- Contribute *policy\_mod* percent of their requested funds.
+   Valid *policy\_mod* values are 0 to 200. If this is a channel lease
    request, we match based on their requested funds. If it is not a
-   channel lease request (and *lease_only* is false), then we match
+   channel lease request (and *lease\_only* is false), then we match
    their funding amount. Note: any lease match less than 100 will
    likely fail, as clients will not accept a lease less than their request.
-* `available` -- Contribute *policy_mod* percent of our available
-   node wallet funds. Valid *policy_mod* values are 0 to 100.
-* `fixed` -- Contributes a fixed  *policy_mod* sats to v2 channel open requests.
+* `available` -- Contribute *policy\_mod* percent of our available
+   node wallet funds. Valid *policy\_mod* values are 0 to 100.
+* `fixed` -- Contributes a fixed  *policy\_mod* sats to v2 channel open requests.
 
 Note: to maximize channel leases, best policy setting is (match, 100).
 
-*leases_only* will only contribute funds to `option_will_fund` requests
+*leases\_only* will only contribute funds to `option_will_fund` requests
 which pay to lease funds. Defaults to false, will fund any v2 open request
 using *policy* even if it's they're not seeking to lease funds. Note that
 `option_will_fund` commits funds for 4032 blocks (~1mo). Must also set
-*lease_fee_base_msat*, *lease_fee_basis*, *funding_weight*,
-*channel_fee_max_base_msat*, and *channel_fee_max_proportional_thousandths*
+*lease\_fee\_base\_msat*, *lease\_fee\_basis*, *funding\_weight*,
+*channel\_fee\_max\_base\_msat*, and *channel\_fee\_max\_proportional\_thousandths*
 to advertise available channel leases.
 
-*min_their_funding_msat* is the minimum funding sats that we require in order
+*min\_their\_funding\_msat* is the minimum funding sats that we require in order
 to activate our contribution policy to the v2 open.  Defaults to 10k sats.
 
-*max_their_funding_msat* is the maximum funding sats that we will consider
+*max\_their\_funding\_msat* is the maximum funding sats that we will consider
 to activate our contribution policy to the v2 open. Any channel open above this
 will not be funded.  Defaults to no max (`UINT_MAX`).
 
-*per_channel_min_msat* is the minimum amount that we will contribute to a
+*per\_channel\_min\_msat* is the minimum amount that we will contribute to a
 channel open. Defaults to 10k sats.
 
-*per_channel_max_msat* is the maximum amount that we will contribute to a
+*per\_channel\_max\_msat* is the maximum amount that we will contribute to a
 channel open. Defaults to no max (`UINT_MAX`).
 
-*reserve_tank_msat* is the amount of sats to leave available in the node wallet.
+*reserve\_tank\_msat* is the amount of sats to leave available in the node wallet.
 Defaults to zero sats.
 
-*fuzz_percent* is a percentage to fuzz the resulting contribution amount by.
+*fuzz\_percent* is a percentage to fuzz the resulting contribution amount by.
 Valid values are 0 to 100. Note that turning this on with (match, 100) policy
 will randomly fail `option_will_fund` leases, as most clients
 expect an exact or greater match of their `requested_funds`.
 Defaults to 0% (no fuzz).
 
-*fund_probability* is the percent of v2 channel open requests to apply our
+*fund\_probability* is the percent of v2 channel open requests to apply our
 policy to. Valid values are integers from 0 (fund 0% of all open requests)
 to 100 (fund every request). Useful for randomizing opens that receive funds.
 Defaults to 100.
@@ -71,33 +71,33 @@ Setting any of the next 5 options will activate channel leases for this node,
 and advertise these values via the lightning gossip network. If any one is set,
 the other values will be the default.
 
-*lease_fee_base_msat* is the flat fee for a channel lease. Node will
+*lease\_fee\_base\_msat* is the flat fee for a channel lease. Node will
 receive this much extra added to their channel balance, paid by the opening
 node. Defaults to 2k sats. Note that the minimum is 1sat.
 
-*lease_fee_basis* is a basis fee that's calculated as 1/10k of the total
+*lease\_fee\_basis* is a basis fee that's calculated as 1/10k of the total
 requested funds the peer is asking for. Node will receive the total of
-*lease_fee_basis* times requested funds / 10k satoshis added to their channel
+*lease\_fee\_basis* times requested funds / 10k satoshis added to their channel
 balance, paid by the opening node.  Default is 0.65% (65 basis points)
 
-*funding_weight* is used to calculate the fee the peer will compensate your
+*funding\_weight* is used to calculate the fee the peer will compensate your
 node for its contributing inputs to the funding transaction. The total fee
 is calculated as the `open_channel2`.`funding_feerate_perkw` times this
-*funding_weight* divided by 1000. Node will have this funding fee added
+*funding\_weight* divided by 1000. Node will have this funding fee added
 to their channel balance, paid by the opening node.  Default is
 2 inputs + 1 P2WPKH output.
 
-*channel_fee_max_base_msat* is a commitment to a maximum
+*channel\_fee\_max\_base\_msat* is a commitment to a maximum
 `channel_fee_base_msat` that your node will charge for routing payments
 over this leased channel during the lease duration.  Default is 5k sats.
 
-*channel_fee_max_proportional_thousandths* is a commitment to a maximum
+*channel\_fee\_max\_proportional\_thousandths* is a commitment to a maximum
 `channel_fee_proportional_millionths` that your node will charge for
 routing payments over this leased channel during the lease duration.
 Note that it's denominated in 'thousandths'. A setting of `1` is equal
 to 1k ppm; `5` is 5k ppm, etc.  Default is 100 (100k ppm).
 
-*compact_lease* is a compact description of the channel lease params. When
+*compact\_lease* is a compact description of the channel lease params. When
 opening a channel, passed in to `fundchannel` to indicate the terms we
 expect from the peer.
 

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -4,7 +4,7 @@ lightning-fundpsbt -- Command to populate PSBT inputs from the wallet
 SYNOPSIS
 --------
 
-**fundpsbt** *satoshi* *feerate* *startweight* [*minconf*] [*reserve*] [*locktime*] [*min_witness_weight*] [*excess_as_change*]
+**fundpsbt** *satoshi* *feerate* *startweight* [*minconf*] [*reserve*] [*locktime*] [*min\_witness\_weight*] [*excess\_as\_change*]
 
 DESCRIPTION
 -----------
@@ -40,11 +40,11 @@ If *reserve* if not zero, then *reserveinputs* is called (successfully, with
 *locktime* is an optional locktime: if not set, it is set to a recent
 block height.
 
-*min_witness_weight* is an optional minimum weight to use for a UTXO's
+*min\_witness\_weight* is an optional minimum weight to use for a UTXO's
 witness. If the actual witness weight is greater than the provided minimum,
 the actual witness weight will be used.
 
-*excess_as_change* is an optional boolean to flag to add a change output
+*excess\_as\_change* is an optional boolean to flag to add a change output
 for the excess sats.
 
 EXAMPLE USAGE
@@ -57,15 +57,15 @@ known outputs of the transaction (typically (9 + scriptlen) * 4).  For
 a simple P2WPKH it's a 22 byte scriptpubkey, so that's 124 weight.
 
 It calls "*fundpsbt* 100000sat slow 166", which succeeds, and returns
-the *psbt* and *feerate_per_kw* it used, the *estimated_final_weight*
-and any *excess_msat*.
+the *psbt* and *feerate\_per\_kw* it used, the *estimated\_final\_weight*
+and any *excess\_msat*.
 
-If *excess_msat* is greater than the cost of adding a change output,
+If *excess\_msat* is greater than the cost of adding a change output,
 the caller adds a change output randomly to position 0 or 1 in the
-PSBT.  Say *feerate_per_kw* is 253, and the change output is a P2WPKH
+PSBT.  Say *feerate\_per\_kw* is 253, and the change output is a P2WPKH
 (weight 124), the cost is around 31 sats.  With the dust limit disallowing
 payments below 546 satoshis, we would only create a change output
-if *excess_msat* was greater or equal to 31 + 546.
+if *excess\_msat* was greater or equal to 31 + 546.
 
 RETURN VALUE
 ------------
@@ -87,10 +87,10 @@ On success, an object is returned, containing:
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
-If *excess_as_change* is true and the excess is enough to cover
+If *excess\_as\_change* is true and the excess is enough to cover
 an additional output above the `dust_limit`, then an output is
-added to the PSBT for the excess amount. The *excess_msat* will
-be zero. A *change_outnum* will be returned with the index of
+added to the PSBT for the excess amount. The *excess\_msat* will
+be zero. A *change\_outnum* will be returned with the index of
 the change output.
 
 On error the returned object will contain `code` and `message` properties,

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -76,8 +76,8 @@ On success, an object is returned, containing:
 - **psbt** (string): Unsigned PSBT which fulfills the parameters given
 - **feerate\_per\_kw** (u32): The feerate used to create the PSBT, in satoshis-per-kiloweight
 - **estimated\_final\_weight** (u32): The estimated weight of the transaction once fully signed
-- **excess\_msat** (msat): The amount above *satoshi* which is available.  This could be zero, or dust; it will be zero if *change_outnum* is also returned
-- **change\_outnum** (u32, optional): The 0-based output number where change was placed (only if parameter *excess_as_change* was true and there was sufficient funds)
+- **excess\_msat** (msat): The amount above *satoshi* which is available.  This could be zero, or dust; it will be zero if *change\_outnum* is also returned
+- **change\_outnum** (u32, optional): The 0-based output number where change was placed (only if parameter *excess\_as\_change* was true and there was sufficient funds)
 - **reservations** (array of objects, optional): If *reserve* was true or a non-zero number, just as per lightning-reserveinputs(7):
   - **txid** (txid): The txid of the transaction
   - **vout** (u32): The 0-based output number
@@ -115,4 +115,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0f290582f49c6103258b7f781a9e7fa4075ec6c05335a459a91da0b6fd58c68d)
+[comment]: # ( SHA256STAMP:35947e2b2c402a87c4bad3a5a90443bfe5db44d71cb515541074abfc4dc3f24d)

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -41,9 +41,9 @@ On success, an object is returned, containing:
 - **network** (string): represents the type of network on the node are working (e.g: `bitcoin`, `testnet`, or `regtest`)
 - **fees\_collected\_msat** (msat): Total routing fees collected by this node
 - **our\_features** (object, optional): Our BOLT #9 feature bits (as hexstring) for various contexts:
-  - **init** (hex): features (incl. globalfeatures) in our init message, these also restrict what we offer in open_channel or accept in accept_channel
-  - **node** (hex): features in our node_announcement message
-  - **channel** (hex): negotiated channel features we (as channel initiator) publish in the channel_announcement message
+  - **init** (hex): features (incl. globalfeatures) in our init message, these also restrict what we offer in open\_channel or accept in accept\_channel
+  - **node** (hex): features in our node\_announcement message
+  - **channel** (hex): negotiated channel features we (as channel initiator) publish in the channel\_announcement message
   - **invoice** (hex): features in our BOLT11 invoices
 - **address** (array of objects, optional): The addresses we announce to the world:
   - **type** (string): Type of connection (one of "dns", "ipv4", "ipv6", "torv2", "torv3", "websocket")
@@ -131,4 +131,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:0e54af449933b833f2e74bab9fde46096a79d69b4d958a548c7c0b7cc5654e99)
+[comment]: # ( SHA256STAMP:ce2b96e2e97cf6bc1e311d6125253dfbed900f13c001f518e9a0b4f202a0e1d6)

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -33,9 +33,9 @@ On success, an object is returned, containing:
 
 - **created\_at** (string): UNIX timestamp with 9 decimal places, when logging was initialized
 - **bytes\_used** (u32): The number of bytes used by logging records
-- **bytes\_max** (u32): The bytes_used values at which records will be trimmed 
+- **bytes\_max** (u32): The bytes\_used values at which records will be trimmed 
 - **log** (array of objects):
-  - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO_IN", "IO_OUT")
+  - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO\_IN", "IO\_OUT")
 
   If **type** is "SKIPPED":
 
@@ -43,14 +43,14 @@ On success, an object is returned, containing:
 
   If **type** is "BROKEN", "UNUSUAL", "INFO" or "DEBUG":
 
-    - **time** (string): UNIX timestamp with 9 decimal places after **created_at**
+    - **time** (string): UNIX timestamp with 9 decimal places after **created\_at**
     - **source** (string): The particular logbook this was found in
     - **log** (string): The actual log message
     - **node\_id** (pubkey, optional): The peer this is associated with
 
-  If **type** is "IO_IN" or "IO_OUT":
+  If **type** is "IO\_IN" or "IO\_OUT":
 
-    - **time** (string): Seconds after **created_at**, with 9 decimal places
+    - **time** (string): Seconds after **created\_at**, with 9 decimal places
     - **source** (string): The particular logbook this was found in
     - **log** (string): The associated log message
     - **data** (hex): The IO which occurred
@@ -94,4 +94,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:0f6e346c57e59aa8ebe0aee9bcb7ded6f66776752e55c4c125f4a80d98cf90fd)
+[comment]: # ( SHA256STAMP:6b925456a06076ba98a04df3ff6931d2cd5d09ccec82829301428493ff824e34)

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -310,4 +310,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:e592a238b3701399c1e8de45cb7186b9714742daefa2f33287019f860c1cc24d)
+[comment]: # ( SHA256STAMP:7456e80dc70830703bd8fd05d4047f721592bc3c1b2c51fbcb54ce0d87167380)

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -68,4 +68,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:48f9ef4d1d73aa13ebd1ffa37107111c35c1a197bbcf00f52c5149847ca57ac1)
+[comment]: # ( SHA256STAMP:64c5aa03469d6cb3e00e46141a5f11e499a0cc74a13b5600b26aa6dd1539346f)

--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -53,17 +53,17 @@ ever had.
 Specify *password* if the `hsm_secret` is encrypted.
 
 **generatehsm** *hsm\_secret\_path*
-  Generates a new hsm_secret using BIP39.
+  Generates a new hsm\_secret using BIP39.
 
 **checkhsm** *hsm\_secret\_path*
-  Checks that hsm_secret matchs a BIP39 pass phrase.
+  Checks that hsm\_secret matchs a BIP39 pass phrase.
 
-**dumponchaindescriptors** *hsm_secret* \[*password*\] \[*network*\]
+**dumponchaindescriptors** *hsm\_secret* \[*password*\] \[*network*\]
   Dump output descriptors for our onchain wallet.
 The descriptors can be used by external services to be able to generate
 addresses for our onchain wallet. (for example on `bitcoind` using the
 `importmulti` or `importdescriptors` RPC calls)
-We need the path to the hsm_secret containing the wallet seed, and an optional
+We need the path to the hsm\_secret containing the wallet seed, and an optional
 (skip using `""`) password if it was encrypted.
 To generate descriptors using testnet master keys, you may specify *testnet* as
 the last parameter. By default, mainnet-encoded keys are generated.

--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -56,7 +56,7 @@ Specify *password* if the `hsm_secret` is encrypted.
   Generates a new hsm\_secret using BIP39.
 
 **checkhsm** *hsm\_secret\_path*
-  Checks that hsm\_secret matchs a BIP39 pass phrase.
+  Checks that hsm\_secret matches a BIP39 passphrase.
 
 **dumponchaindescriptors** *hsm\_secret* \[*password*\] \[*network*\]
   Dump output descriptors for our onchain wallet.

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -79,8 +79,8 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **bolt11** (string): the bolt11 string
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
-- **payment\_secret** (secret): the *payment_secret* to place in the onion (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
+- **payment\_secret** (secret): the *payment\_secret* to place in the onion (always 64 characters)
 - **expires\_at** (u64): UNIX timestamp of when invoice expires
 
 The following warnings may also be returned:
@@ -119,4 +119,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4dd2b9d74116f77ad09ad4162ba8438db79e79d1aa99b23e2c993d754327649d)
+[comment]: # ( SHA256STAMP:e3b07ce2a4cbe9198d5a65df1e49b628a8a7e857770e004a1d84c41c67601712)

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -4,7 +4,7 @@ lightning-invoice -- Command for accepting payments
 SYNOPSIS
 --------
 
-**invoice** *amount_msat* *label* *description* [*expiry*]
+**invoice** *amount\_msat* *label* *description* [*expiry*]
 [*fallbacks*] [*preimage*] [*exposeprivatechannels*] [*cltv*] [*deschashonly*]
 
 DESCRIPTION
@@ -16,7 +16,7 @@ lightning daemon can use to pay this invoice. This token includes a
 *route hint* description of an incoming channel with capacity to pay the
 invoice, if any exists.
 
-The *amount_msat* parameter can be the string "any", which creates an
+The *amount\_msat* parameter can be the string "any", which creates an
 invoice that can be paid with any amount. Otherwise it is a positive value in
 millisatoshi precision; it can be a whole number, or a whole number
 ending in *msat* or *sat*, or a number with three decimal places ending
@@ -64,7 +64,7 @@ other public channel). The selection uses some randomness to prevent
 probing, but favors channels that become more balanced after the
 payment.
 
-If specified, *cltv* sets the *min_final_cltv_expiry* for the invoice.
+If specified, *cltv* sets the *min\_final\_cltv\_expiry* for the invoice.
 Otherwise, it's set to the parameter **cltv-final**.
 
 If *deschashonly* is true (default false), then the bolt11 returned

--- a/doc/lightning-keysend.7.md
+++ b/doc/lightning-keysend.7.md
@@ -70,8 +70,8 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **created\_at** (number): the UNIX timestamp showing when this payment was initiated
 - **parts** (u32): how many attempts this took
 - **amount\_msat** (msat): Amount the recipient received
@@ -118,4 +118,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:d208bd6f3e78b039a4790b8de599ffd819aa169c59430ac487fd7030cd3fe640)
+[comment]: # ( SHA256STAMP:b6a047c09d40be10ed9027ca0f38332a57bfe7a232fa66fa5a669cf76e2731cd)

--- a/doc/lightning-keysend.7.md
+++ b/doc/lightning-keysend.7.md
@@ -33,7 +33,7 @@ Setting `exemptfee` allows the `maxfeepercent` check to be skipped on fees that 
 The response will occur when the payment fails or succeeds.
 Unlike lightning-pay(7), issuing the same `keysend` commands multiple times will result in multiple payments being sent.
 
-Until *retry_for* seconds passes (default: 60), the command will keep finding routes and retrying the payment.
+Until *retry\_for* seconds passes (default: 60), the command will keep finding routes and retrying the payment.
 However, a payment may be delayed for up to `maxdelay` blocks by another node; clients should be prepared for this worst case.
 
 *extratlvs* is an optional dictionary of additional fields to insert into the final tlv.  The format is 'fieldnumber': 'hexstring'.
@@ -99,7 +99,7 @@ A routing failure object has the fields below:
 - `erring_node`: The hex string of the pubkey id of the node that reported the error.
 - `erring_channel`: The short channel ID of the channel that has the error, or *0:0:0* if the destination node raised the error.
 - `failcode`: The failure code, as per BOLT \#4.
-- `channel_update`. The hex string of the *channel_update* message received from the remote node. Only present if error is from the remote node and the *failcode* has the `UPDATE` bit set, as per BOLT \#4.
+- `channel_update`. The hex string of the *channel\_update* message received from the remote node. Only present if error is from the remote node and the *failcode* has the `UPDATE` bit set, as per BOLT \#4.
 
 
 AUTHOR

--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -41,7 +41,7 @@ On success, an object containing **channels** is returned.  It is an array of ob
 - **message\_flags** (u8): as defined by BOLT #7
 - **channel\_flags** (u8): as defined by BOLT #7
 - **active** (boolean): true unless source has disabled it, or it's a local channel and the peer is disconnected or it's still opening or closing
-- **last\_update** (u32): UNIX timestamp on the last channel_update from *source*
+- **last\_update** (u32): UNIX timestamp on the last channel\_update from *source*
 - **base\_fee\_millisatoshi** (u32): Base fee changed by *source* to use this channel
 - **fee\_per\_millionth** (u32): Proportional fee changed by *source* to use this channel, in parts-per-million
 - **delay** (u32): The number of blocks delay required by *source* to use this channel
@@ -79,4 +79,4 @@ Lightning RFC site
 -   BOLT \#7:
     <https://github.com/lightning/bolts/blob/master/07-routing-gossip.md>
 
-[comment]: # ( SHA256STAMP:baf45b77bd2ba22e245e007b57d8e5f70d06cbf9cebf7ed1431da6a0cf6f367a)
+[comment]: # ( SHA256STAMP:693b8297d390522cd68a27b607194567cebb7bf021f769c82d430afced9d0029)

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -101,7 +101,7 @@ On success, an object is returned, containing:
 - **accept-htlc-tlv-types** (string, optional): `accept-extra-tlvs-type` fields from config or cmdline, or not present
 - **tor-service-password** (string, optional): `tor-service-password` field from config or cmdline, if any
 - **dev-allowdustreserve** (boolean, optional): Whether we allow setting dust reserves
-- **announce-addr-dns** (boolean, optional): Whether we put DNS entries into node_announcement
+- **announce-addr-dns** (boolean, optional): Whether we put DNS entries into node\_announcement
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -219,4 +219,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:745268f7f4e4eb19d04ec1a221fbb734d89b4a266049cde3adc3131d86423294)
+[comment]: # ( SHA256STAMP:862a1d319a30cb4a0e851d0d57b62eef78d7b7e35f76c70c6bc71d4d2f270a94)

--- a/doc/lightning-listdatastore.7.md
+++ b/doc/lightning-listdatastore.7.md
@@ -47,4 +47,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:699f7121a6f1aac9ea8afe39f4bac0e696e97754579d544a141fe2a0e404305f)
+[comment]: # ( SHA256STAMP:ccb9085c7ad0757e324e4e74d5a22009153f2a9f40f4e926c15fc918ab2bab4f)

--- a/doc/lightning-listforwards.7.md
+++ b/doc/lightning-listforwards.7.md
@@ -4,7 +4,7 @@ lightning-listforwards -- Command showing all htlcs and their information
 SYNOPSIS
 --------
 
-**listforwards** [*status*] [*in_channel*] [*out_channel*]
+**listforwards** [*status*] [*in\_channel*] [*out\_channel*]
 
 DESCRIPTION
 -----------
@@ -13,9 +13,9 @@ The **listforwards** RPC command displays all htlcs that have been
 attempted to be forwarded by the Core Lightning node.
 
 If *status* is specified, then only the forwards with the given status are returned.
-*status* can be either *offered* or *settled* or *failed* or *local_failed*
+*status* can be either *offered* or *settled* or *failed* or *local\_failed*
 
-If *in_channel* or *out_channel* is specified, then only the matching forwards
+If *in\_channel* or *out\_channel* is specified, then only the matching forwards
 on the given in/out channel are returned.
 
 RETURN VALUE

--- a/doc/lightning-listforwards.7.md
+++ b/doc/lightning-listforwards.7.md
@@ -26,23 +26,23 @@ On success, an object containing **forwards** is returned.  It is an array of ob
 
 - **in\_channel** (short\_channel\_id): the channel that received the HTLC
 - **in\_msat** (msat): the value of the incoming HTLC
-- **status** (string): still ongoing, completed, failed locally, or failed after forwarding (one of "offered", "settled", "local_failed", "failed")
+- **status** (string): still ongoing, completed, failed locally, or failed after forwarding (one of "offered", "settled", "local\_failed", "failed")
 - **received\_time** (number): the UNIX timestamp when this was received
 - **in\_htlc\_id** (u64, optional): the unique HTLC id the sender gave this (not present if incoming channel was closed before ugprade to v22.11)
 - **out\_channel** (short\_channel\_id, optional): the channel that the HTLC (trying to) forward to
-- **out\_htlc\_id** (u64, optional): the unique HTLC id we gave this when sending (may be missing even if out_channel is present, for old forwards before v22.11)
+- **out\_htlc\_id** (u64, optional): the unique HTLC id we gave this when sending (may be missing even if out\_channel is present, for old forwards before v22.11)
 - **style** (string, optional): Either a legacy onion format or a modern tlv format (one of "legacy", "tlv")
 
 If **out\_msat** is present:
 
   - **fee\_msat** (msat): the amount this paid in fees
-  - **out\_msat** (msat): the amount we sent out the *out_channel*
+  - **out\_msat** (msat): the amount we sent out the *out\_channel*
 
 If **status** is "settled" or "failed":
 
   - **resolved\_time** (number): the UNIX timestamp when this was resolved
 
-If **status** is "local_failed" or "failed":
+If **status** is "local\_failed" or "failed":
 
   - **failcode** (u32, optional): the numeric onion code returned
   - **failreason** (string, optional): the name of the onion code returned
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:15bf997ae8e93ab28b0084d9cc45fc80fb18b2bcf705f690f77617f0b66b069d)
+[comment]: # ( SHA256STAMP:2627ce6a1e4877810e690a40fda2145292ce15f0b1393d3b35b4c54b599b044e)

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -46,13 +46,13 @@ On success, an object is returned, containing:
   - **funding\_txid** (txid): funding transaction id
   - **funding\_output** (u32): the 0-based index of the output in the funding transaction
   - **connected** (boolean): whether the channel peer is connected
-  - **state** (string): the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD_AWAITING_LOCKIN", "CHANNELD_NORMAL", "CHANNELD_SHUTTING_DOWN", "CLOSINGD_SIGEXCHANGE", "CLOSINGD_COMPLETE", "AWAITING_UNILATERAL", "FUNDING_SPEND_SEEN", "ONCHAIN", "DUALOPEND_OPEN_INIT", "DUALOPEND_AWAITING_LOCKIN")
+  - **state** (string): the channel state, in particular "CHANNELD\_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
 
-  If **state** is "CHANNELD_NORMAL":
+  If **state** is "CHANNELD\_NORMAL":
 
     - **short\_channel\_id** (short\_channel\_id): short channel id of channel
 
-  If **state** is "CHANNELD_SHUTTING_DOWN", "CLOSINGD_SIGEXCHANGE", "CLOSINGD_COMPLETE", "AWAITING_UNILATERAL", "FUNDING_SPEND_SEEN" or "ONCHAIN":
+  If **state** is "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN" or "ONCHAIN":
 
     - **short\_channel\_id** (short\_channel\_id, optional): short channel id of channel (only if funding reached lockin depth before closing)
 
@@ -73,4 +73,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:62a8754ad2a24dfb5bb4e412a2e710748bd54ef0cffaaeb7ce352f6273742431)
+[comment]: # ( SHA256STAMP:5c118dc7780049bcd320aa16d301bf778552fe6ae42c9d598a3926ab0c14694d)

--- a/doc/lightning-listhtlcs.7.md
+++ b/doc/lightning-listhtlcs.7.md
@@ -27,7 +27,7 @@ On success, an object containing **htlcs** is returned.  It is an array of objec
 - **amount\_msat** (msat): the value of the HTLC
 - **direction** (string): out if we offered this to the peer, in if they offered it (one of "out", "in")
 - **payment\_hash** (hex): payment hash sought by HTLC (always 64 characters)
-- **state** (string): The first 10 states are for `in`, the next 10 are for `out`. (one of "SENT_ADD_HTLC", "SENT_ADD_COMMIT", "RCVD_ADD_REVOCATION", "RCVD_ADD_ACK_COMMIT", "SENT_ADD_ACK_REVOCATION", "RCVD_REMOVE_HTLC", "RCVD_REMOVE_COMMIT", "SENT_REMOVE_REVOCATION", "SENT_REMOVE_ACK_COMMIT", "RCVD_REMOVE_ACK_REVOCATION", "RCVD_ADD_HTLC", "RCVD_ADD_COMMIT", "SENT_ADD_REVOCATION", "SENT_ADD_ACK_COMMIT", "RCVD_ADD_ACK_REVOCATION", "SENT_REMOVE_HTLC", "SENT_REMOVE_COMMIT", "RCVD_REMOVE_REVOCATION", "RCVD_REMOVE_ACK_COMMIT", "SENT_REMOVE_ACK_REVOCATION")
+- **state** (string): The first 10 states are for `in`, the next 10 are for `out`. (one of "SENT\_ADD\_HTLC", "SENT\_ADD\_COMMIT", "RCVD\_ADD\_REVOCATION", "RCVD\_ADD\_ACK\_COMMIT", "SENT\_ADD\_ACK\_REVOCATION", "RCVD\_REMOVE\_HTLC", "RCVD\_REMOVE\_COMMIT", "SENT\_REMOVE\_REVOCATION", "SENT\_REMOVE\_ACK\_COMMIT", "RCVD\_REMOVE\_ACK\_REVOCATION", "RCVD\_ADD\_HTLC", "RCVD\_ADD\_COMMIT", "SENT\_ADD\_REVOCATION", "SENT\_ADD\_ACK\_COMMIT", "RCVD\_ADD\_ACK\_REVOCATION", "SENT\_REMOVE\_HTLC", "SENT\_REMOVE\_COMMIT", "RCVD\_REMOVE\_REVOCATION", "RCVD\_REMOVE\_ACK\_COMMIT", "SENT\_REMOVE\_ACK\_REVOCATION")
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -46,4 +46,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ef16f6e1f54522435130d99f224ca41a38fb3c5bc26886ccdaddc69f1abb946)
+[comment]: # ( SHA256STAMP:444e5aefafe607226d36b80adfebef7bf0b9173dbb28bbfcc7f78aaed0eac682)

--- a/doc/lightning-listinvoices.7.md
+++ b/doc/lightning-listinvoices.7.md
@@ -24,7 +24,7 @@ RETURN VALUE
 On success, an object containing **invoices** is returned.  It is an array of objects, where each object contains:
 
 - **label** (string): unique label supplied at invoice creation
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): Whether it's paid, unpaid or unpayable (one of "unpaid", "paid", "expired")
 - **expires\_at** (u64): UNIX timestamp of when it will become / became unpayable
 - **description** (string, optional): description used in the invoice
@@ -32,12 +32,12 @@ On success, an object containing **invoices** is returned.  It is an array of ob
 - **bolt11** (string, optional): the BOLT11 string (always present unless *bolt12* is)
 - **bolt12** (string, optional): the BOLT12 string (always present unless *bolt11* is)
 - **local\_offer\_id** (hex, optional): the *id* of our offer which created this invoice (**experimental-offers** only). (always 64 characters)
-- **invreq\_payer\_note** (string, optional): the optional *invreq_payer_note* from invoice_request which created this invoice (**experimental-offers** only).
+- **invreq\_payer\_note** (string, optional): the optional *invreq\_payer\_note* from invoice\_request which created this invoice (**experimental-offers** only).
 
 If **status** is "paid":
 
   - **pay\_index** (u64): Unique incrementing index for this payment
-  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount_msat*, since clients may overpay)
+  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount\_msat*, since clients may overpay)
   - **paid\_at** (u64): UNIX timestamp of when it was paid
   - **payment\_preimage** (secret): proof of payment (always 64 characters)
 
@@ -58,4 +58,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:5c64a05bbf7485840010b16005c6f5d57725e4b0bf0a2a2106febe91ff0d4eb8)
+[comment]: # ( SHA256STAMP:67af32ecf6319aec4376074b0f0a1b42cf111cbb3acec0108d7f3607dc441252)

--- a/doc/lightning-listinvoices.7.md
+++ b/doc/lightning-listinvoices.7.md
@@ -4,7 +4,7 @@ lightning-listinvoices -- Command for querying invoice status
 SYNOPSIS
 --------
 
-**listinvoices** [*label*] [*invstring*] [*payment_hash*] [*offer_id*]
+**listinvoices** [*label*] [*invstring*] [*payment\_hash*] [*offer\_id*]
 
 DESCRIPTION
 -----------

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -30,7 +30,7 @@ RETURN VALUE
 On success, an object containing **nodes** is returned.  It is an array of objects, where each object contains:
 
 - **nodeid** (pubkey): the public key of the node
-- **last\_timestamp** (u32, optional): A node_announcement has been received for this node (UNIX timestamp)
+- **last\_timestamp** (u32, optional): A node\_announcement has been received for this node (UNIX timestamp)
 
 If **last\_timestamp** is present:
 
@@ -52,8 +52,8 @@ If **option\_will\_fund** is present:
     - **lease\_fee\_basis** (u32): the proportional fee in basis points (parts per 10,000) for a lease
     - **funding\_weight** (u32): the onchain weight you'll have to pay for a lease
     - **channel\_fee\_max\_base\_msat** (msat): the maximum base routing fee this node will charge during the lease
-    - **channel\_fee\_max\_proportional\_thousandths** (u32): the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel_update)
-    - **compact\_lease** (hex): the lease as represented in the node_announcement
+    - **channel\_fee\_max\_proportional\_thousandths** (u32): the maximum proportional routing fee this node will charge during the lease (in thousandths, not millionths like channel\_update)
+    - **compact\_lease** (hex): the lease as represented in the node\_announcement
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -99,4 +99,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:7f1378c1376ade1c9912c8eef3ebc77b13cbc5194ee813f8f1b4e0061338e0bb)
+[comment]: # ( SHA256STAMP:030d48d2a5fc02cb26fc2a35125116085eb67d0afc39066259adacc433a3d38b)

--- a/doc/lightning-listoffers.7.md
+++ b/doc/lightning-listoffers.7.md
@@ -80,4 +80,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:985a6bae4b0a1702cd02998859c8072eee44b219c15294af4f4078465531c8c9)
+[comment]: # ( SHA256STAMP:088d6fef8790bc9151b07f9b974568ce612c7fea8f52fdcaaf52b32e4ef8d5f2)

--- a/doc/lightning-listoffers.7.md
+++ b/doc/lightning-listoffers.7.md
@@ -5,13 +5,13 @@ SYNOPSIS
 --------
 **(WARNING: experimental-offers only)**
 
-**listoffers** [*offer_id*] [*active_only*]
+**listoffers** [*offer\_id*] [*active\_only*]
 
 DESCRIPTION
 -----------
 
 The **listoffers** RPC command list all offers, or with `offer_id`,
-only the offer with that offer_id (if it exists).  If `active_only` is
+only the offer with that offer\_id (if it exists).  If `active_only` is
 set and is true, only offers with `active` true are returned.
 
 EXAMPLE JSON REQUEST

--- a/doc/lightning-listpays.7.md
+++ b/doc/lightning-listpays.7.md
@@ -19,7 +19,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **pays** is returned.  It is an array of objects, where each object contains:
 
-- **payment\_hash** (hex): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hex): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (one of "pending", "failed", "complete")
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
 - **destination** (pubkey, optional): the final destination of the payment if known
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1175415c0f9398e1087d68dd75266bf894249053a4e57f16b8ee16cf5ffa414f)
+[comment]: # ( SHA256STAMP:ee5242e7cf0a7c1385ab26885436b723b916f0d4e17080323876781e8c2aee76)

--- a/doc/lightning-listpays.7.md
+++ b/doc/lightning-listpays.7.md
@@ -4,13 +4,13 @@ lightning-listpays -- Command for querying payment status
 SYNOPSIS
 --------
 
-**listpays** [*bolt11*] [*payment_hash*] [*status*]
+**listpays** [*bolt11*] [*payment\_hash*] [*status*]
 
 DESCRIPTION
 -----------
 
 The **listpay** RPC command gets the status of all *pay* commands, or a
-single one if either *bolt11* or *payment_hash* was specified.
+single one if either *bolt11* or *payment\_hash* was specified.
 It is possible filter the payments also by *status*.
 
 RETURN VALUE
@@ -40,7 +40,7 @@ If **status** is "failed":
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
-The returned array is ordered by increasing **created_at** fields.
+The returned array is ordered by increasing **created\_at** fields.
 
 AUTHOR
 ------

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -227,7 +227,7 @@ The objects in the *channels* array will have at least these fields:
     peer, or a theft attempt).
   * `"CLOSED"`: The channel closure has been confirmed deeply.
     The channel will eventually be removed from this array.
-* *state_changes*: An array of objects describing prior state change events.
+* *state\_changes*: An array of objects describing prior state change events.
 * *opener*: A string `"local"` or `"remote`" describing which side opened this
   channel.
 * *closer*: A string `"local"` or `"remote`" describing which side
@@ -243,9 +243,9 @@ The objects in the *channels* array will have at least these fields:
   a number followed by a string unit.
 * *total\_msat*: A string describing the total capacity of the channel;
   a number followed by a string unit.
-* *fee_base_msat*: The fixed routing fee we charge for forwards going out over
+* *fee\_base\_msat*: The fixed routing fee we charge for forwards going out over
   this channel, regardless of payment size.
-* *fee_proportional_millionths*: The proportional routing fees in ppm (parts-
+* *fee\_proportional\_millionths*: The proportional routing fees in ppm (parts-
   per-millionths) we charge for forwards going out over this channel.
 * *features*: An array of feature names supported by this channel.
 
@@ -325,7 +325,7 @@ state, or in various circumstances:
   your funds, if you close unilaterally.
 * *max\_accepted\_htlcs*: The maximum number of HTLCs you will accept on
   this channel.
-* *in\_payments_offered*: The number of incoming HTLCs offered over this
+* *in\_payments\_offered*: The number of incoming HTLCs offered over this
   channel.
 * *in\_offered\_msat*: A string describing the total amount of all incoming
   HTLCs offered over this channel;
@@ -345,9 +345,9 @@ state, or in various circumstances:
 * *out\_fulfilled\_msat*: A string describing the total amount of all
   outgoing HTLCs offered *and successfully claimed* over this channel;
   a number followed by a string unit.
-* *scratch_txid*: The txid of the latest transaction (what we would sign and
+* *scratch\_txid*: The txid of the latest transaction (what we would sign and
   send to chain if the channel were to fail now).
-* *last_tx_fee*: The fee on that latest transaction.
+* *last\_tx\_fee*: The fee on that latest transaction.
 * *feerate*: An object containing the latest feerate as both *perkw* and *perkb*.
 * *htlcs*: An array of objects describing the HTLCs currently in-flight
   in the channel.

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -44,17 +44,17 @@ On success, an object containing **peers** is returned.  It is an array of objec
 - **id** (pubkey): the public key of the peer
 - **connected** (boolean): True if the peer is currently connected
 - **channels** (array of objects):
-  - **state** (string): the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD_AWAITING_LOCKIN", "CHANNELD_NORMAL", "CHANNELD_SHUTTING_DOWN", "CLOSINGD_SIGEXCHANGE", "CLOSINGD_COMPLETE", "AWAITING_UNILATERAL", "FUNDING_SPEND_SEEN", "ONCHAIN", "DUALOPEND_OPEN_INIT", "DUALOPEND_AWAITING_LOCKIN")
+  - **state** (string): the channel state, in particular "CHANNELD\_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
   - **opener** (string): Who initiated the channel (one of "local", "remote")
   - **features** (array of strings):
-    - BOLT #9 features which apply to this channel (one of "option_static_remotekey", "option_anchor_outputs", "option_zeroconf")
+    - BOLT #9 features which apply to this channel (one of "option\_static\_remotekey", "option\_anchor\_outputs", "option\_zeroconf")
   - **scratch\_txid** (txid, optional): The txid we would use if we went onchain now
   - **feerate** (object, optional): Feerates for the current tx:
     - **perkw** (u32): Feerate per 1000 weight (i.e kSipa)
     - **perkb** (u32): Feerate per 1000 virtual bytes
   - **owner** (string, optional): The current subdaemon controlling this connection
-  - **short\_channel\_id** (short\_channel\_id, optional): The short_channel_id (once locked in)
-  - **channel\_id** (hash, optional): The full channel_id (always 64 characters)
+  - **short\_channel\_id** (short\_channel\_id, optional): The short\_channel\_id (once locked in)
+  - **channel\_id** (hash, optional): The full channel\_id (always 64 characters)
   - **funding\_txid** (txid, optional): ID of the funding transaction
   - **funding\_outnum** (u32, optional): The 0-based output number of the funding transaction which opens the channel
   - **initial\_feerate** (string, optional): For inflight opens, the first feerate used to initiate the channel open
@@ -102,8 +102,8 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **remote** (short\_channel\_id, optional): An alias assigned by the remote node to this channel, usable in routehints and invoices
   - **state\_changes** (array of objects, optional): Prior state changes:
     - **timestamp** (string): UTC timestamp of form YYYY-mm-ddTHH:MM:SS.%03dZ
-    - **old\_state** (string): Previous state (one of "OPENINGD", "CHANNELD_AWAITING_LOCKIN", "CHANNELD_NORMAL", "CHANNELD_SHUTTING_DOWN", "CLOSINGD_SIGEXCHANGE", "CLOSINGD_COMPLETE", "AWAITING_UNILATERAL", "FUNDING_SPEND_SEEN", "ONCHAIN", "DUALOPEND_OPEN_INIT", "DUALOPEND_AWAITING_LOCKIN")
-    - **new\_state** (string): New state (one of "OPENINGD", "CHANNELD_AWAITING_LOCKIN", "CHANNELD_NORMAL", "CHANNELD_SHUTTING_DOWN", "CLOSINGD_SIGEXCHANGE", "CLOSINGD_COMPLETE", "AWAITING_UNILATERAL", "FUNDING_SPEND_SEEN", "ONCHAIN", "DUALOPEND_OPEN_INIT", "DUALOPEND_AWAITING_LOCKIN")
+    - **old\_state** (string): Previous state (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
+    - **new\_state** (string): New state (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
     - **cause** (string): What caused the change (one of "unknown", "local", "user", "remote", "protocol", "onchain")
     - **message** (string): Human-readable explanation
   - **status** (array of strings, optional):
@@ -121,17 +121,17 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **id** (u64): Unique ID for this htlc on this channel in this direction
     - **amount\_msat** (msat): Amount send/received for this HTLC
     - **expiry** (u32): Block this HTLC expires at
-    - **payment\_hash** (hash): the hash of the payment_preimage which will prove payment (always 64 characters)
+    - **payment\_hash** (hash): the hash of the payment\_preimage which will prove payment (always 64 characters)
     - **local\_trimmed** (boolean, optional): if this is too small to enforce onchain (always *true*)
     - **status** (string, optional): set if this HTLC is currently waiting on a hook (and shows what plugin)
 
     If **direction** is "out":
 
-      - **state** (string): Status of the HTLC (one of "SENT_ADD_HTLC", "SENT_ADD_COMMIT", "RCVD_ADD_REVOCATION", "RCVD_ADD_ACK_COMMIT", "SENT_ADD_ACK_REVOCATION", "RCVD_REMOVE_HTLC", "RCVD_REMOVE_COMMIT", "SENT_REMOVE_REVOCATION", "SENT_REMOVE_ACK_COMMIT", "RCVD_REMOVE_ACK_REVOCATION")
+      - **state** (string): Status of the HTLC (one of "SENT\_ADD\_HTLC", "SENT\_ADD\_COMMIT", "RCVD\_ADD\_REVOCATION", "RCVD\_ADD\_ACK\_COMMIT", "SENT\_ADD\_ACK\_REVOCATION", "RCVD\_REMOVE\_HTLC", "RCVD\_REMOVE\_COMMIT", "SENT\_REMOVE\_REVOCATION", "SENT\_REMOVE\_ACK\_COMMIT", "RCVD\_REMOVE\_ACK\_REVOCATION")
 
     If **direction** is "in":
 
-      - **state** (string): Status of the HTLC (one of "RCVD_ADD_HTLC", "RCVD_ADD_COMMIT", "SENT_ADD_REVOCATION", "SENT_ADD_ACK_COMMIT", "RCVD_ADD_ACK_REVOCATION", "SENT_REMOVE_HTLC", "SENT_REMOVE_COMMIT", "RCVD_REMOVE_REVOCATION", "RCVD_REMOVE_ACK_COMMIT", "SENT_REMOVE_ACK_REVOCATION")
+      - **state** (string): Status of the HTLC (one of "RCVD\_ADD\_HTLC", "RCVD\_ADD\_COMMIT", "SENT\_ADD\_REVOCATION", "SENT\_ADD\_ACK\_COMMIT", "RCVD\_ADD\_ACK\_REVOCATION", "SENT\_REMOVE\_HTLC", "SENT\_REMOVE\_COMMIT", "RCVD\_REMOVE\_REVOCATION", "RCVD\_REMOVE\_ACK\_COMMIT", "SENT\_REMOVE\_ACK\_REVOCATION")
 
   If **close\_to** is present:
 
@@ -143,7 +143,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
 
   If **short\_channel\_id** is present:
 
-    - **direction** (u32): 0 if we're the lesser node_id, 1 if we're the greater
+    - **direction** (u32): 0 if we're the lesser node\_id, 1 if we're the greater
 
   If **inflight** is present:
 
@@ -151,7 +151,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **last\_feerate** (string): The feerate for the latest funding transaction in per-1000-weight, with "kpw" appended
     - **next\_feerate** (string): The minimum feerate for the next funding transaction in per-1000-weight, with "kpw" appended
 - **log** (array of objects, optional): if *level* is specified, logs for this peer:
-  - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO_IN", "IO_OUT")
+  - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO\_IN", "IO\_OUT")
 
   If **type** is "SKIPPED":
 
@@ -164,7 +164,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **log** (string): The actual log message
     - **node\_id** (pubkey): The peer this is associated with
 
-  If **type** is "IO_IN" or "IO_OUT":
+  If **type** is "IO\_IN" or "IO\_OUT":
 
     - **time** (string): UNIX timestamp with 9 decimal places
     - **source** (string): The particular logbook this was found in
@@ -399,4 +399,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:108f43815e3475b88fd9b6a4a8f868e9d729c5d7616e0b0cc2c14f8922f54955)
+[comment]: # ( SHA256STAMP:faff728119e12d98202be265991e8b2c17dfa1a611bc52586c662fe8bfdccf53)

--- a/doc/lightning-listsendpays.7.md
+++ b/doc/lightning-listsendpays.7.md
@@ -26,8 +26,8 @@ Note that the returned array is ordered by increasing *id*.
 On success, an object containing **payments** is returned.  It is an array of objects, where each object contains:
 
 - **id** (u64): unique ID for this payment attempt
-- **groupid** (u64): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment_hash
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **groupid** (u64): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment\_hash
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (one of "pending", "failed", "complete")
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
 - **amount\_sent\_msat** (msat): The amount sent
@@ -40,7 +40,7 @@ On success, an object containing **payments** is returned.  It is an array of ob
 
 If **status** is "complete":
 
-  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
+  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
 
 If **status** is "failed":
 
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:eddbf227775b367fbea5d90dfc1d06bc87b9301e4b862b0d755592432ef58f89)
+[comment]: # ( SHA256STAMP:bd2975d79d2000a8f390da4744c79a924b4fba8268830d086d5024defe8ac274)

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -37,17 +37,17 @@ On success, an object containing **transactions** is returned.  It is an array o
   - **txid** (txid): the transaction id spent
   - **index** (u32): the output spent
   - **sequence** (u32): the nSequence value
-  - **type** (string, optional): the purpose of this input (*EXPERIMENTAL_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel_funding", "channel_mutual_close", "channel_unilateral_close", "channel_sweep", "channel_htlc_success", "channel_htlc_timeout", "channel_penalty", "channel_unilateral_cheat")
-  - **channel** (short\_channel\_id, optional): the channel this input is associated with (*EXPERIMENTAL_FEATURES* only)
+  - **type** (string, optional): the purpose of this input (*EXPERIMENTAL\_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel\_funding", "channel\_mutual\_close", "channel\_unilateral\_close", "channel\_sweep", "channel\_htlc\_success", "channel\_htlc\_timeout", "channel\_penalty", "channel\_unilateral\_cheat")
+  - **channel** (short\_channel\_id, optional): the channel this input is associated with (*EXPERIMENTAL\_FEATURES* only)
 - **outputs** (array of objects): Each output, in order:
   - **index** (u32): the 0-based output number
   - **amount\_msat** (msat): the amount of the output
   - **scriptPubKey** (hex): the scriptPubKey
-  - **type** (string, optional): the purpose of this output (*EXPERIMENTAL_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel_funding", "channel_mutual_close", "channel_unilateral_close", "channel_sweep", "channel_htlc_success", "channel_htlc_timeout", "channel_penalty", "channel_unilateral_cheat")
-  - **channel** (short\_channel\_id, optional): the channel this output is associated with (*EXPERIMENTAL_FEATURES* only)
+  - **type** (string, optional): the purpose of this output (*EXPERIMENTAL\_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel\_funding", "channel\_mutual\_close", "channel\_unilateral\_close", "channel\_sweep", "channel\_htlc\_success", "channel\_htlc\_timeout", "channel\_penalty", "channel\_unilateral\_cheat")
+  - **channel** (short\_channel\_id, optional): the channel this output is associated with (*EXPERIMENTAL\_FEATURES* only)
 - **type** (array of strings, optional):
-  - Reason we care about this transaction (*EXPERIMENTAL_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel_funding", "channel_mutual_close", "channel_unilateral_close", "channel_sweep", "channel_htlc_success", "channel_htlc_timeout", "channel_penalty", "channel_unilateral_cheat")
-- **channel** (short\_channel\_id, optional): the channel this transaction is associated with (*EXPERIMENTAL_FEATURES* only)
+  - Reason we care about this transaction (*EXPERIMENTAL\_FEATURES* only) (one of "theirs", "deposit", "withdraw", "channel\_funding", "channel\_mutual\_close", "channel\_unilateral\_close", "channel\_sweep", "channel\_htlc\_success", "channel\_htlc\_timeout", "channel\_penalty", "channel\_unilateral\_cheat")
+- **channel** (short\_channel\_id, optional): the channel this transaction is associated with (*EXPERIMENTAL\_FEATURES* only)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
   
@@ -105,4 +105,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:f7c39908eaa1a2561597c8f97658b873953daab0a68ed2e9b68e434a55d55efe)
+[comment]: # ( SHA256STAMP:1a1afbcbcdbd19df28020d48c581dfff6ed4f5beaf557e1423edb6828eb78a07)

--- a/doc/lightning-makesecret.7.md
+++ b/doc/lightning-makesecret.7.md
@@ -20,7 +20,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **secret** (secret): the pseudorandom key derived from HSM_secret (always 64 characters)
+- **secret** (secret): the pseudorandom key derived from HSM\_secret (always 64 characters)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -38,4 +38,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0ef7c3e2172219fa647d1c447cb82daa7857c6c53a27fd191bff83f59ce6b9f7)
+[comment]: # ( SHA256STAMP:5560433bde5292bad74eab0b688d8e6baa0a51562670a4f486d41b4eb2103ca8)

--- a/doc/lightning-makesecret.7.md
+++ b/doc/lightning-makesecret.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **makesecret** RPC command derives a secret key from the HSM_secret.
+The **makesecret** RPC command derives a secret key from the HSM\_secret.
 
 One of *hex* or *string* must be specified: *hex* can be any hex data,
 *string* is a UTF-8 string interpreted literally.

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -4,7 +4,7 @@ lightning-multifundchannel -- Command for establishing many lightning channels
 SYNOPSIS
 --------
 
-**multifundchannel** *destinations* [*feerate*] [*minconf*] [*utxos*] [*minchannels*] [*commitment_feerate*]
+**multifundchannel** *destinations* [*feerate*] [*minconf*] [*utxos*] [*minchannels*] [*commitment\_feerate*]
 
 DESCRIPTION
 -----------
@@ -47,14 +47,14 @@ Readiness is indicated by **listpeers** reporting a *state* of
   node.
   This is a gift to the peer, and you do not get a proof-of-payment
   out of this.
-* *close_to* is a Bitcoin address to which the channel funds should be sent to
+* *close\_to* is a Bitcoin address to which the channel funds should be sent to
   on close. Only valid if both peers have negotiated
   `option_upfront_shutdown_script`.  Returns `close_to` set to
   closing script iff is negotiated.
-* *request_amt* is the amount of liquidity you'd like to lease from peer.
+* *request\_amt* is the amount of liquidity you'd like to lease from peer.
   If peer supports `option_will_fund`, indicates to them to include this
-  much liquidity into the channel. Must also pass in *compact_lease*.
-* *compact_lease* is a compact represenation of the peer's expected
+  much liquidity into the channel. Must also pass in *compact\_lease*.
+* *compact\_lease* is a compact represenation of the peer's expected
   channel lease terms. If the peer's terms don't match this set, we will
   fail to open the channel to this destination.
 
@@ -62,7 +62,7 @@ There must be at least one entry in *destinations*;
 it cannot be an empty array.
 
 *feerate* is an optional feerate used for the opening transaction and, if
-*commitment_feerate* is not set, as the initial feerate for
+*commitment\_feerate* is not set, as the initial feerate for
 commitment and HTLC transactions. It can be one of
 the strings *urgent* (aim for next block), *normal* (next 4 blocks or
 so) or *slow* (next 100 blocks or so) to use lightningd's internal
@@ -84,7 +84,7 @@ this many peers remain (must not be zero).
 The **multifundchannel** command will only fail if too many peers fail
 the funding process.
 
-*commitment_feerate* is the initial feerate for commitment and HTLC
+*commitment\_feerate* is the initial feerate for commitment and HTLC
 transactions. See *feerate* for valid values.
 
 RETURN VALUE

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -105,11 +105,11 @@ On success, an object is returned, containing:
 - **channel\_ids** (array of objects):
   - **id** (pubkey): The peer we opened the channel with
   - **outnum** (u32): The 0-based output index showing which output funded the channel
-  - **channel\_id** (hex): The channel_id of the resulting channel (always 64 characters)
-  - **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close_to* parameter was specified and peer supports `option_upfront_shutdown_script`
+  - **channel\_id** (hex): The channel\_id of the resulting channel (always 64 characters)
+  - **close\_to** (hex, optional): The raw scriptPubkey which mutual close will go to; only present if *close\_to* parameter was specified and peer supports `option_upfront_shutdown_script`
 - **failed** (array of objects, optional): any peers we failed to open with (if *minchannels* was specified less than the number of destinations):
   - **id** (pubkey): The peer we failed to open the channel with
-  - **method** (string): What stage we failed at (one of "connect", "openchannel_init", "fundchannel_start", "fundchannel_complete")
+  - **method** (string): What stage we failed at (one of "connect", "openchannel\_init", "fundchannel\_start", "fundchannel\_complete")
   - **error** (object):
     - **code** (integer): JSON error code from failing stage
     - **message** (string): Message from stage
@@ -159,4 +159,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:a507d57bbf36455924497c8354f41e225bc16f63f12fe01b4f7c4af37f0c6960)
+[comment]: # ( SHA256STAMP:0dc2b563ed6995f65388a52b01e8882a167ead3c1d3b3dc985486cd8b4dfe157)

--- a/doc/lightning-multiwithdraw.7.md
+++ b/doc/lightning-multiwithdraw.7.md
@@ -72,4 +72,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:6c0054088c17481dedbedb6a5ed4be7f09ce8783780707432907508ebf4bbd7a)
+[comment]: # ( SHA256STAMP:632868a585b9150a80ccc4ba173d90a8beebab8e604c06f1ccdc4493604152e3)

--- a/doc/lightning-newaddr.7.md
+++ b/doc/lightning-newaddr.7.md
@@ -58,4 +58,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:e9650b5f1f4374007c8fde63dae2ac9981c952ed8074aabade39fcc0ebe21333)
+[comment]: # ( SHA256STAMP:2178e43f4b90a07f1d31679f86e7e5b1bc5239333ba64652614f03847c869fd4)

--- a/doc/lightning-notifications.7.md
+++ b/doc/lightning-notifications.7.md
@@ -102,4 +102,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:326e5801f65998e13e909d8b682e9fbc9824f3a43aa7da1d76b871882e52f293)
+[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)

--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -100,7 +100,7 @@ On success, an object is returned, containing:
 
 - **offer\_id** (hex): the id of this offer (merkle hash of non-signature fields) (always 64 characters)
 - **active** (boolean): whether this can still be used (always *true*)
-- **single\_use** (boolean): whether this expires as soon as it's paid (reflects the *single_use* parameter)
+- **single\_use** (boolean): whether this expires as soon as it's paid (reflects the *single\_use* parameter)
 - **bolt12** (string): the bolt12 encoding of the offer
 - **used** (boolean): True if an associated invoice has been paid
 - **created** (boolean): false if the offer already existed
@@ -135,4 +135,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:217af2aae777229992e2ee07c6f8040d4ca5b75ee2064590584de13162974fe2)
+[comment]: # ( SHA256STAMP:a9cd6cc9f41fefc87c060ee979599f55154a11fc3a9b5dca046cea3e9c2385c2)

--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -6,14 +6,14 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**offer** *amount* *description* [*issuer*] [*label*] [*quantity_max*] [*absolute_expiry*] [*recurrence*] [*recurrence_base*] [*recurrence_paywindow*] [*recurrence_limit*] [*single_use*]
+**offer** *amount* *description* [*issuer*] [*label*] [*quantity\_max*] [*absolute\_expiry*] [*recurrence*] [*recurrence\_base*] [*recurrence\_paywindow*] [*recurrence\_limit*] [*single\_use*]
 
 DESCRIPTION
 -----------
 
 The **offer** RPC command creates an offer (or returns an existing
 one), which is a precursor to creating one or more invoices.  It
-automatically enables the processing of an incoming invoice_request,
+automatically enables the processing of an incoming invoice\_request,
 and issuing of invoices.
 
 Note that it creates two variants of the offer: a signed and an
@@ -43,13 +43,13 @@ reflects who is issuing this offer (i.e. you) if appropriate.
 The *label* field is an internal-use name for the offer, which can
 be any UTF-8 string.
 
-The presence of *quantity_max* indicates that the
+The presence of *quantity\_max* indicates that the
 invoice can specify more than one of the items up (and including)
 this maximum: 0 is a special value meaning "no maximuim".
 The *amount* for the invoice will need to be multiplied
 accordingly.  This is encoded in the offer.
 
-The *absolute_expiry* is optionally the time the offer is valid until,
+The *absolute\_expiry* is optionally the time the offer is valid until,
 in seconds since the first day of 1970 UTC.  If not set, the offer
 remains valid (though it can be deactivated by the issuer of course).
 This is encoded in the offer.
@@ -61,7 +61,7 @@ without the trailing "s" are also permitted).  This is encoded in the
 offer.  The semantics of recurrence is fairly predictable, but fully
 documented in BOLT 12.  e.g. "4weeks".
 
-*recurrence_base* is an optional time in seconds since the first day
+*recurrence\_base* is an optional time in seconds since the first day
 of 1970 UTC, optionally with a "@" prefix.  This indicates when the
 first period begins; without this, the recurrence periods start from
 the first invoice.  The "@" prefix means that the invoice must start
@@ -69,7 +69,7 @@ by paying the first period; otherwise it is permitted to start at any
 period.  This is encoded in the offer.  e.g. "@1609459200" indicates
 you must start paying on the 1st January 2021.
 
-*recurrence_paywindow* is an optional argument of form
+*recurrence\_paywindow* is an optional argument of form
 '-time+time[%]'.  The first time is the number of seconds before the
 start of a period in which an invoice and payment is valid, the second
 time is the number of seconds after the start of the period.  For
@@ -80,15 +80,15 @@ by the time remaining in the period.  If this is not specified, the
 default is that payment is allowed during the current and previous
 periods.  This is encoded in the offer.
 
-*recurrence_limit* is an optional argument to indicate the maximum
+*recurrence\_limit* is an optional argument to indicate the maximum
 period which exists.  eg. "12" means there are 13 periods, from 0 to
 12 inclusive.  This is encoded in the offer.
 
-*refund_for* is the payment_preimage of a previous (paid) invoice.
-This implies *send_invoice* and *single_use*.  This is encoded in the
+*refund\_for* is the payment\_preimage of a previous (paid) invoice.
+This implies *send\_invoice* and *single\_use*.  This is encoded in the
 offer.
 
-*single_use* (default false) indicates that the offer is only valid
+*single\_use* (default false) indicates that the offer is only valid
 once; we may issue multiple invoices, but as soon as one is paid all other
 invoices will be expired (i.e. only one person can pay this offer).
 
@@ -118,7 +118,7 @@ if it's not active then this call fails.
 
 The following error codes may occur:
 - -1: Catchall nonspecific error.
-- 1000: Offer with this offer_id already exists (but is not active).
+- 1000: Offer with this offer\_id already exists (but is not active).
 
 AUTHOR
 ------

--- a/doc/lightning-offerout.7.md
+++ b/doc/lightning-offerout.7.md
@@ -7,7 +7,7 @@ SYNOPSIS
 **(WARNING: experimental-offers only)**
 
 
-**offerout** *amount* *description* [*issuer*] [*label*] [*absolute_expiry*] [*refund_for*]
+**offerout** *amount* *description* [*issuer*] [*label*] [*absolute\_expiry*] [*refund\_for*]
 
 DESCRIPTION
 -----------
@@ -40,13 +40,13 @@ reflects who is issuing this offer (i.e. you) if appropriate.
 The *label* field is an internal-use name for the offer, which can
 be any UTF-8 string.
 
-The *absolute_expiry* is optionally the time the offer is valid until,
+The *absolute\_expiry* is optionally the time the offer is valid until,
 in seconds since the first day of 1970 UTC.  If not set, the offer
 remains valid (though it can be deactivated by the issuer of course).
 This is encoded in the offer.
 
-*refund_for* is a previous (paid) invoice of ours.  The
-payment_preimage of this is encoded in the offer, and redemption
+*refund\_for* is a previous (paid) invoice of ours.  The
+payment\_preimage of this is encoded in the offer, and redemption
 requires that the invoice we receive contains a valid signature using
 that previous `payer_key`.
 
@@ -73,7 +73,7 @@ not.
 
 The following error codes may occur:
 - -1: Catchall nonspecific error.
-- 1000: Offer with this offer_id already exists.
+- 1000: Offer with this offer\_id already exists.
 
 NOTES
 -----

--- a/doc/lightning-offerout.7.md
+++ b/doc/lightning-offerout.7.md
@@ -99,4 +99,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:903e40a51c806613da956ce1b4021e9aac964c11d0d0c2714aeb68a12f083265)
+[comment]: # ( SHA256STAMP:4f780ca32d486bd715eed86a130b87ff1515fce6f9e225cb13219267b82b33bb)

--- a/doc/lightning-openchannel_abort.7.md
+++ b/doc/lightning-openchannel_abort.7.md
@@ -55,4 +55,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:ed449af5b443c981faaff360cb2276816bbc7cd80f85fdb4403987c29d65baed)
+[comment]: # ( SHA256STAMP:f80423882383e5cb39b86543eb8cfbc0d9b6731ea85af3b3e1fb8973b9355781)

--- a/doc/lightning-openchannel_abort.7.md
+++ b/doc/lightning-openchannel_abort.7.md
@@ -4,7 +4,7 @@ lightning-openchannel\_abort -- Command to abort a channel to a peer
 SYNOPSIS
 --------
 
-**openchannel_abort** *channel_id*
+**openchannel\_abort** *channel\_id*
 
 DESCRIPTION
 -----------
@@ -13,7 +13,7 @@ DESCRIPTION
 open with a specified peer. It uses the openchannel protocol
 which allows for interactive transaction construction.
 
-*channel_id* is id of this channel.
+*channel\_id* is id of this channel.
 
 
 RETURN VALUE

--- a/doc/lightning-openchannel_bump.7.md
+++ b/doc/lightning-openchannel_bump.7.md
@@ -41,7 +41,7 @@ On success, an object is returned, containing:
 - **channel\_id** (hex): the channel id of the channel (always 64 characters)
 - **psbt** (string): the (incomplete) PSBT of the RBF transaction
 - **commitments\_secured** (boolean): whether the *psbt* is complete (always *false*)
-- **funding\_serial** (u64): the serial_id of the funding output in the *psbt*
+- **funding\_serial** (u64): the serial\_id of the funding output in the *psbt*
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -81,4 +81,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:3cba5d1c16925322754eae979e956132e8b94e40da0dee6925037a8854d9b791)
+[comment]: # ( SHA256STAMP:fe2bf77f2cb693ee91ab1977d05ba8431b0a8bed67aa1bbda6992bf64604081b)

--- a/doc/lightning-openchannel_bump.7.md
+++ b/doc/lightning-openchannel_bump.7.md
@@ -4,7 +4,7 @@ lightning-openchannel\_bump -- Command to initiate a channel RBF
 SYNOPSIS
 --------
 
-**openchannel_bump** *channel_id* *amount* *initalpsbt* [*funding_feerate*]
+**openchannel\_bump** *channel\_id* *amount* *initalpsbt* [*funding\_feerate*]
 
 DESCRIPTION
 -----------
@@ -26,7 +26,7 @@ Must have the Non-Witness UTXO (PSBT\_IN\_NON\_WITNESS\_UTXO) set for
 every input. An error (code 309) will be returned if this requirement
 is not met.
 
-*funding_feerate* is an optional field. Sets the feerate for the
+*funding\_feerate* is an optional field. Sets the feerate for the
 funding transaction. Defaults to 1/64th greater than the last
 feerate used for this channel.
 

--- a/doc/lightning-openchannel_init.7.md
+++ b/doc/lightning-openchannel_init.7.md
@@ -4,7 +4,7 @@ lightning-openchannel\_init -- Command to initiate a channel to a peer
 SYNOPSIS
 --------
 
-**openchannel_init** *id* *amount* *initalpsbt* [*commitment_feerate*] [*funding_feerate*] [*announce*] [*close_to*] [*request_amt*] [*compact_lease*]
+**openchannel\_init** *id* *amount* *initalpsbt* [*commitment\_feerate*] [*funding\_feerate*] [*announce*] [*close\_to*] [*request\_amt*] [*compact\_lease*]
 
 DESCRIPTION
 -----------
@@ -26,23 +26,23 @@ Must have the Non-Witness UTXO (PSBT\_IN\_NON\_WITNESS\_UTXO) set for
 every input. An error (code 309) will be returned if this requirement
 is not met.
 
-*commitment_feerate* is an optional field. Sets the feerate for
+*commitment\_feerate* is an optional field. Sets the feerate for
 commitment transactions: see **fundchannel**.
 
-*funding_feerate* is an optional field. Sets the feerate for the
+*funding\_feerate* is an optional field. Sets the feerate for the
 funding transaction. Defaults to 'opening' feerate.
 
 *announce* is an optional field. Whether or not to announce this channel.
 
-*close_to* is a Bitcoin address to which the channel funds should be
+*close\_to* is a Bitcoin address to which the channel funds should be
 sent on close. Only valid if both peers have negotiated
 `option_upfront_shutdown_script`.
 
-*request_amt* is an amount of liquidity you'd like to lease from the peer.
+*request\_amt* is an amount of liquidity you'd like to lease from the peer.
 If peer supports `option_will_fund`, indicates to them to include this
-much liquidity into the channel. Must also pass in *compact_lease*.
+much liquidity into the channel. Must also pass in *compact\_lease*.
 
-*compact_lease* is a compact represenation of the peer's expected
+*compact\_lease* is a compact represenation of the peer's expected
 channel lease terms. If the peer's terms don't match this set, we will
 fail to open the channel.
 
@@ -63,12 +63,12 @@ On success, an object is returned, containing:
 If the peer does not support `option_dual_fund`, this command
 will return an error.
 
-If you sent a *request_amt* and the peer supports `option_will_fund` and is
+If you sent a *request\_amt* and the peer supports `option_will_fund` and is
 interested in leasing you liquidity in this channel, returns their updated
-channel fee max (*channel_fee_proportional_basis*, *channel_fee_base_msat*),
-updated rate card for the lease fee (*lease_fee_proportional_basis*,
-*lease_fee_base_sat*) and their on-chain weight *weight_charge*, which will
-be added to the lease fee at a rate of *funding_feerate* * *weight_charge*
+channel fee max (*channel\_fee\_proportional\_basis*, *channel\_fee\_base\_msat*),
+updated rate card for the lease fee (*lease\_fee\_proportional\_basis*,
+*lease\_fee\_base\_sat*) and their on-chain weight *weight\_charge*, which will
+be added to the lease fee at a rate of *funding\_feerate* * *weight\_charge*
 / 1000.
 
 On error the returned object will contain `code` and `message` properties,

--- a/doc/lightning-openchannel_init.7.md
+++ b/doc/lightning-openchannel_init.7.md
@@ -56,7 +56,7 @@ On success, an object is returned, containing:
 - **channel\_id** (hex): the channel id of the channel (always 64 characters)
 - **psbt** (string): the (incomplete) PSBT of the funding transaction
 - **commitments\_secured** (boolean): whether the *psbt* is complete (always *false*)
-- **funding\_serial** (u64): the serial_id of the funding output in the *psbt*
+- **funding\_serial** (u64): the serial\_id of the funding output in the *psbt*
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -103,4 +103,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:18421f03dece31aafe32cb1a9b520dd6b898e018cb187de6d666e391232fab4e)
+[comment]: # ( SHA256STAMP:ca7708f0c64afc898cb336eafb26ee384895f83b2026aecab75596372d33e46e)

--- a/doc/lightning-openchannel_signed.7.md
+++ b/doc/lightning-openchannel_signed.7.md
@@ -4,7 +4,7 @@ lightning-openchannel\_signed -- Command to conclude a channel open
 SYNOPSIS
 --------
 
-**openchannel_signed** *channel_id* *signed_psbt*
+**openchannel\_signed** *channel\_id* *signed\_psbt*
 
 DESCRIPTION
 -----------
@@ -14,15 +14,15 @@ open with the specified peer. It uses the v2 openchannel protocol, which
 allows for interactive transaction construction.
 
 This command should be called after `openchannel_update` returns
-*commitments_secured* `true`.
+*commitments\_secured* `true`.
 
 This command will broadcast the finalized funding transaction,
 if we receive valid signatures from the peer.
 
-*channel_id* is the id of the channel.
+*channel\_id* is the id of the channel.
 
-*signed_psbt* is the PSBT returned from `openchannel_update` (where
-*commitments_secured* was true) with partial signatures or finalized
+*signed\_psbt* is the PSBT returned from `openchannel_update` (where
+*commitments\_secured* was true) with partial signatures or finalized
 witness stacks included for every input that we contributed to the
 PSBT.
 

--- a/doc/lightning-openchannel_signed.7.md
+++ b/doc/lightning-openchannel_signed.7.md
@@ -67,4 +67,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:41e2a4aed1aaac01675f99e91326197afa370a05e32b2ef20cbbb8247de57289)
+[comment]: # ( SHA256STAMP:2ee447b0f9d13ebe8898addc99f52a9024f0e80f67fa505dcc35a3256c3e4c55)

--- a/doc/lightning-openchannel_update.7.md
+++ b/doc/lightning-openchannel_update.7.md
@@ -4,23 +4,23 @@ lightning-openchannel\_update -- Command to update a collab channel open
 SYNOPSIS
 --------
 
-**openchannel_update** *channel_id* *psbt*
+**openchannel\_update** *channel\_id* *psbt*
 
 DESCRIPTION
 -----------
 
 `openchannel_update` is a low level RPC command which continues an open
-channel, as specified by *channel_id*. An updated  *psbt* is passed in; any
+channel, as specified by *channel\_id*. An updated  *psbt* is passed in; any
 changes from the PSBT last returned (either from `openchannel_init` or
 a previous call to `openchannel_update`) will be communicated to the peer.
 
 Must be called after `openchannel_init` and before `openchannel_signed`.
 
-Must be called until *commitments_secured* is returned as true, at which point
+Must be called until *commitments\_secured* is returned as true, at which point
 `openchannel_signed` should be called with a signed version of the PSBT
 returned by the last call to `openchannel_update`.
 
-*channel_id* is the id of the channel.
+*channel\_id* is the id of the channel.
 
 *psbt* is the updated PSBT to be sent to the peer. May be identical to
 the PSBT last returned by either `openchannel_init` or `openchannel_update`.
@@ -39,11 +39,11 @@ On success, an object is returned, containing:
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
-If *commitments_secured* is true, will also return:
-- The derived *channel_id*.
-- A *close_to* script, iff a `close_to` address was provided to
+If *commitments\_secured* is true, will also return:
+- The derived *channel\_id*.
+- A *close\_to* script, iff a `close_to` address was provided to
   `openchannel_init` and the peer supports `option_upfront_shutdownscript`.
-- The *funding_outnum*, the index of the funding output for this channel
+- The *funding\_outnum*, the index of the funding output for this channel
   in the funding transaction.
 
 

--- a/doc/lightning-openchannel_update.7.md
+++ b/doc/lightning-openchannel_update.7.md
@@ -72,4 +72,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:14632f65d4c44b34762d3fa7e0f5b823a519d3dc5fc7a2a69f677000efd937fb)
+[comment]: # ( SHA256STAMP:223ec3a444341e4c269eab3c3fbe80f13df9258b5f7a548d9e32698a5d4d6790)

--- a/doc/lightning-parsefeerate.7.md
+++ b/doc/lightning-parsefeerate.7.md
@@ -19,7 +19,7 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **perkw** (u32, optional): Value of *feerate_str* in kilosipa
+- **perkw** (u32, optional): Value of *feerate\_str* in kilosipa
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -44,4 +44,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:62a45d5091e5bdb4581a2986a66681616315999b8497038864ece8e3308c3f50)
+[comment]: # ( SHA256STAMP:e61c7a3d05b16533716be2052d7235829c1fb69896d38e6ad31baf12a3f4cb02)

--- a/doc/lightning-parsefeerate.7.md
+++ b/doc/lightning-parsefeerate.7.md
@@ -4,13 +4,13 @@ lightning-parsefeerate -- Command for parsing a feerate string to a feerate
 SYNOPSIS
 --------
 
-**parsefeerate** *feerate_str*
+**parsefeerate** *feerate\_str*
 
 DESCRIPTION
 -----------
 
 The **parsefeerate** command returns the current feerate for any valid
-*feerate_str*. This is useful for finding the current feerate that a
+*feerate\_str*. This is useful for finding the current feerate that a
 **fundpsbt** or **utxopsbt** command might use.
 
 RETURN VALUE
@@ -26,7 +26,7 @@ On success, an object is returned, containing:
 ERRORS
 ------
 
-The **parsefeerate** command will error if the *feerate_str* format is
+The **parsefeerate** command will error if the *feerate\_str* format is
 not recognized.
 
 - -32602: If the given parameters are wrong.

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -5,7 +5,7 @@ SYNOPSIS
 --------
 
 **pay** *bolt11* [*msatoshi*] [*label*] [*riskfactor*]
-[*maxfeepercent*] [*retry_for*] [*maxdelay*] [*exemptfee*]
+[*maxfeepercent*] [*retry\_for*] [*maxdelay*] [*exemptfee*]
 [*localinvreqid*] [*exclude*] [*maxfee*] [*description*]
 
 DESCRIPTION

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -95,8 +95,8 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **created\_at** (number): the UNIX timestamp showing when this payment was initiated
 - **parts** (u32): how many attempts this took
 - **amount\_msat** (msat): Amount the recipient received
@@ -167,4 +167,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6f7640af4859e4605f4369a4e17fcfbaead1be53928ad8101cc44fde6f441a97)
+[comment]: # ( SHA256STAMP:735dd61146b04745f1e884037ead662a386fec2c41e2de1a8698d6bb03f63540)

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -70,4 +70,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:f33aa4d93ca623ff7cd5e4062e0533f617b00372797f8ee0d2498479d2fe08a9)
+[comment]: # ( SHA256STAMP:fe8760ada0a86222a74dc1c78ff111325a2247d5ca90683347b8e8f5dee8a867)

--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -84,4 +84,4 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [writing plugins]: PLUGINS.md
-[comment]: # ( SHA256STAMP:3d7e6647d7fb3eab2a8c6361bb0cbe60efbd822f30f31e08cce68e2aa41ba532)
+[comment]: # ( SHA256STAMP:5e067df44c38f3ee529cc30ac66050830244d0d9b91d7ad386e3c50aa841b0e9)

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -40,9 +40,9 @@ which was reserved:
 
 - *txid* is the input transaction id.
 - *vout* is the input index.
-- *was_reserved* indicates whether the input was already reserved.
+- *was\_reserved* indicates whether the input was already reserved.
 - *reserved* indicates that the input is now reserved (i.e. true).
-- *reserved_to_block* indicates what blockheight the reservation will expire.
+- *reserved\_to\_block* indicates what blockheight the reservation will expire.
 
 On failure, an error is reported and no UTXOs are reserved.
 

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7fd7e24084f7e7da57bccd98cbcf511be56e44e282813c964bdd69d0785dfd22)
+[comment]: # ( SHA256STAMP:c3bb624daff32be6701e54505432ee6d33aab6491e3286791331d0b680fee737)

--- a/doc/lightning-sendcustommsg.7.md
+++ b/doc/lightning-sendcustommsg.7.md
@@ -4,7 +4,7 @@ lightning-sendcustommsg -- Low-level interface to send protocol messages to peer
 SYNOPSIS
 --------
 
-**sendcustommsg** *node_id* *msg*
+**sendcustommsg** *node\_id* *msg*
 
 DESCRIPTION
 -----------

--- a/doc/lightning-sendcustommsg.7.md
+++ b/doc/lightning-sendcustommsg.7.md
@@ -69,4 +69,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:fded86dbe217eacf0c170db87140fd5f10f23c22760ac08b7aa4d2faa4764b3a)
+[comment]: # ( SHA256STAMP:2427c75c952bbbd5a3ccf69a217516a73079a014bb656aff3de7038a26cd301b)

--- a/doc/lightning-sendinvoice.7.md
+++ b/doc/lightning-sendinvoice.7.md
@@ -43,7 +43,7 @@ On success, an object is returned, containing:
 
 - **label** (string): unique label supplied at invoice creation
 - **description** (string): description used in the invoice
-- **payment\_hash** (hex): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hex): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): Whether it's paid, unpaid or unpayable (one of "unpaid", "paid", "expired")
 - **expires\_at** (u64): UNIX timestamp of when it will become / became unpayable
 - **amount\_msat** (msat, optional): the amount required to pay this invoice
@@ -52,7 +52,7 @@ On success, an object is returned, containing:
 If **status** is "paid":
 
   - **pay\_index** (u64): Unique incrementing index for this payment
-  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount_msat*, since clients may overpay)
+  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount\_msat*, since clients may overpay)
   - **paid\_at** (u64): UNIX timestamp of when it was paid
   - **payment\_preimage** (hex): proof of payment (always 64 characters)
 
@@ -80,4 +80,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:23d06329b3d5d2d21639ecc152b541788bb204188c24a0294f97582401b2b3dc)
+[comment]: # ( SHA256STAMP:32b4918787ebd97b7a64cca0fe7d26f259688cbbad93ce89a4dd3e9201d66b78)

--- a/doc/lightning-sendinvoice.7.md
+++ b/doc/lightning-sendinvoice.7.md
@@ -13,7 +13,7 @@ DESCRIPTION
 
 The **sendinvoice** RPC command creates and sends an invoice to the
 issuer of an *offer* for it to pay: the offer must contain
-*send_invoice*; see lightning-fetchinvoice(7).
+*send\_invoice*; see lightning-fetchinvoice(7).
 
 If **fetchinvoice-noconnect** is not specified in the configuation, it
 will connect to the destination in the (currently common!) case where it
@@ -33,7 +33,7 @@ invoice or return an error, default 90 seconds.  This will also be the
 timeout on the invoice that is sent.
 
 *quantity* is optional: it is required if the *offer* specifies
-*quantity_min* or *quantity_max*, otherwise it is not allowed.
+*quantity\_min* or *quantity\_max*, otherwise it is not allowed.
 
 RETURN VALUE
 ------------

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -94,7 +94,7 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **id** (u64): unique ID for this payment attempt
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (could be complete if already sent previously) (one of "pending", "complete")
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
 - **amount\_sent\_msat** (msat): The amount sent
@@ -107,7 +107,7 @@ On success, an object is returned, containing:
 
 If **status** is "complete":
 
-  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
+  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
 
 If **status** is "pending":
 
@@ -135,4 +135,4 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md
-[comment]: # ( SHA256STAMP:84283d16d289b6f72ffac0fdca6791bb49ac9ec1ef2bbb06028c18453bb15f02)
+[comment]: # ( SHA256STAMP:d01679d11406d49930e69a7492550a36118950b0d93acca5c26b299fc91680a4)

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -4,7 +4,7 @@ lightning-sendonion -- Send a payment with a custom onion packet
 SYNOPSIS
 --------
 
-**sendonion** *onion* *first_hop* *payment_hash* [*label*] [*shared_secrets*] [*partid*] [*bolt11*]
+**sendonion** *onion* *first\_hop* *payment\_hash* [*label*] [*shared\_secrets*] [*partid*] [*bolt11*]
 [*msatoshi*] [*destination*]
 
 DESCRIPTION
@@ -18,7 +18,7 @@ of the payment for the final hop. However, it is possible to add arbitrary
 information for hops in the custom onion, allowing for custom extensions that
 are not directly supported by Core Lightning.
 
-The onion is specific to the route that is being used and the *payment_hash*
+The onion is specific to the route that is being used and the *payment\_hash*
 used to construct, and therefore cannot be reused for other payments or to
 attempt a separate route. The custom onion can generally be created using the
 `devtools/onion` CLI tool, or the **createonion** RPC command.
@@ -28,7 +28,7 @@ by either of the tools that can generate onions. It contains the payloads
 destined for each hop and some metadata. Please refer to [BOLT 04][bolt04] for
 further details.
 
-The *first_hop* parameter instructs Core Lightning which peer to send the onion
+The *first\_hop* parameter instructs Core Lightning which peer to send the onion
 to. It is a JSON dictionary that corresponds to the first element of the route
 array returned by *getroute*. The following is a minimal example telling
 Core Lightning to use any available channel to `022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59`
@@ -46,18 +46,18 @@ If the first element of *route* does not have "channel" set, a
 suitable channel (if any) will be chosen, otherwise that specific
 short-channel-id is used.
 
-The *payment_hash* parameter specifies the 32 byte hex-encoded hash to use as
+The *payment\_hash* parameter specifies the 32 byte hex-encoded hash to use as
 a challenge to the HTLC that we are sending. It is specific to the onion and
 has to match the one the onion was created with.
 
 The *label* parameter can be used to provide a human readable reference to
 retrieve the payment at a later time.
 
-The *shared_secrets* parameter is a JSON list of 32 byte hex-encoded secrets
+The *shared\_secrets* parameter is a JSON list of 32 byte hex-encoded secrets
 that were used when creating the onion. Core Lightning can send a payment with a
 custom onion without the knowledge of these secrets, however it will not be
 able to parse an eventual error message since that is encrypted with the
-shared secrets used in the onion. If *shared_secrets* is provided Core Lightning
+shared secrets used in the onion. If *shared\_secrets* is provided Core Lightning
 will decrypt the error, act accordingly, e.g., add a `channel_update` included
 in the error to its network view, and set the details in *listsendpays*
 correctly. If it is not provided Core Lightning will store the encrypted onion,
@@ -72,12 +72,12 @@ externally. The following is an example of a 3 hop onion:
 ]
 ```
 
-If *shared_secrets* is not provided the Core Lightning node does not know how
+If *shared\_secrets* is not provided the Core Lightning node does not know how
 long the route is, which channels or nodes are involved, and what an eventual
 error could have been. It can therefore be used for oblivious payments.
 
 The *partid* value, if provided and non-zero, allows for multiple parallel
-partial payments with the same *payment_hash*.
+partial payments with the same *payment\_hash*.
 
 The *bolt11* parameter, if provided, will be returned in
 *waitsendpay* and *listsendpays* results.
@@ -115,7 +115,7 @@ If **status** is "pending":
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
-If *shared_secrets* was provided and an error was returned by one of the
+If *shared\_secrets* was provided and an error was returned by one of the
 intermediate nodes the error details are decrypted and presented
 here. Otherwise the error code is 202 for an unparseable onion.
 

--- a/doc/lightning-sendonionmessage.7.md
+++ b/doc/lightning-sendonionmessage.7.md
@@ -6,7 +6,7 @@ SYNOPSIS
 
 **(WARNING: experimental-onion-messages only)**
 
-**sendonionmessage** *first_id* *blinding* *hops*
+**sendonionmessage** *first\_id* *blinding* *hops*
 
 DESCRIPTION
 -----------

--- a/doc/lightning-sendonionmessage.7.md
+++ b/doc/lightning-sendonionmessage.7.md
@@ -43,4 +43,4 @@ Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md
 
-[comment]: # ( SHA256STAMP:200de829c6635242cb2dd8ec0650c2fa8f5fcbf413f4a704884516df80492fcb)
+[comment]: # ( SHA256STAMP:4aff9673290966c7b09e65672da5dc8ef4d2601d3d1681009b329a4f8ceb9af6)

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -69,11 +69,11 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **id** (u64): unique ID for this payment attempt
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (could be complete if already sent previously) (one of "pending", "complete")
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
 - **amount\_sent\_msat** (msat): The amount sent
-- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment_hash
+- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment\_hash
 - **amount\_msat** (msat, optional): The amount delivered to destination (if known)
 - **destination** (pubkey, optional): the final destination of the payment if known
 - **completed\_at** (u64, optional): the UNIX timestamp showing when this payment was completed
@@ -84,7 +84,7 @@ On success, an object is returned, containing:
 
 If **status** is "complete":
 
-  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
+  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
 
 If **status** is "pending":
 
@@ -143,4 +143,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c129f537b1af8a5dc767a25a72be419634cb21ebc26a9e6b9bb091db8db7e6ca)
+[comment]: # ( SHA256STAMP:b7f1a5efd80156722e5f9cca6f291306fcd22ab7b9b2754beac880f2ae5a7418)

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -5,8 +5,8 @@ SYNOPSIS
 --------
 
 **sendpay** *route* *payment\_hash* [*label*] [*msatoshi*]
-[*bolt11*] [*payment_secret*] [*partid*] [*localinvreqid*] [*groupid*]
-[*payment_metadata*] [*description*]
+[*bolt11*] [*payment\_secret*] [*partid*] [*localinvreqid*] [*groupid*]
+[*payment\_metadata*] [*description*]
 
 DESCRIPTION
 -----------
@@ -34,26 +34,26 @@ amount to the destination. By default it is in millisatoshi precision; it can be
 ending in *msat* or *sat*, or a number with three decimal places ending
 in *sat*, or a number with 1 to 11 decimal places ending in *btc*.
 
-The *payment_secret* is the value that the final recipient requires to
+The *payment\_secret* is the value that the final recipient requires to
 accept the payment, as defined by the `payment_data` field in BOLT 4
 and the `s` field in the BOLT 11 invoice format.  It is required if
 *partid* is non-zero.
 
 The *partid* value, if provided and non-zero, allows for multiple parallel
-partial payments with the same *payment_hash*.  The *msatoshi* amount
+partial payments with the same *payment\_hash*.  The *msatoshi* amount
 (which must be provided) for each **sendpay** with matching
-*payment_hash* must be equal, and **sendpay** will fail if there are
+*payment\_hash* must be equal, and **sendpay** will fail if there are
 already *msatoshi* worth of payments pending.
 
 The *localinvreqid* value indicates that this payment is being made for a local
-invoice_request: this ensures that we only send a payment for a single-use
-invoice_request once.
+invoice\_request: this ensures that we only send a payment for a single-use
+invoice\_request once.
 
 *groupid* allows you to attach a number which appears in **listsendpays** so
 payments can be identified as part of a logical group.  The *pay* plugin uses
 this to identify one attempt at a MPP payment, for example.
 
-*payment_metadata* is placed in the final onion hop TLV.
+*payment\_metadata* is placed in the final onion hop TLV.
 
 Once a payment has succeeded, calls to **sendpay** with the same
 *payment\_hash* but a different *msatoshi* or destination will fail;
@@ -109,7 +109,7 @@ The following error codes may occur:
     will be routing failure object.
 -   204: Failure along route; retry a different route. The *data* field
     of the error will be routing failure object.
--   212: *localinvreqid* refers to an invalid, or used, local invoice_request.
+-   212: *localinvreqid* refers to an invalid, or used, local invoice\_request.
 
 A routing failure object has the fields below:
 -   *erring\_index*. The index of the node along the route that reported

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -66,4 +66,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:6c0054088c17481dedbedb6a5ed4be7f09ce8783780707432907508ebf4bbd7a)
+[comment]: # ( SHA256STAMP:632868a585b9150a80ccc4ba173d90a8beebab8e604c06f1ccdc4493604152e3)

--- a/doc/lightning-setchannel.7.md
+++ b/doc/lightning-setchannel.7.md
@@ -68,13 +68,13 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object containing **channels** is returned.  It is an array of objects, where each object contains:
 
-- **peer\_id** (pubkey): The node_id of the peer
-- **channel\_id** (hex): The channel_id of the channel (always 64 characters)
+- **peer\_id** (pubkey): The node\_id of the peer
+- **channel\_id** (hex): The channel\_id of the channel (always 64 characters)
 - **fee\_base\_msat** (msat): The resulting feebase (this is the BOLT #7 name)
 - **fee\_proportional\_millionths** (u32): The resulting feeppm (this is the BOLT #7 name)
-- **minimum\_htlc\_out\_msat** (msat): The resulting htlcmin we will advertize (the BOLT #7 name is htlc_minimum_msat)
-- **maximum\_htlc\_out\_msat** (msat): The resulting htlcmax we will advertize (the BOLT #7 name is htlc_maximum_msat)
-- **short\_channel\_id** (short\_channel\_id, optional): the short_channel_id (if locked in)
+- **minimum\_htlc\_out\_msat** (msat): The resulting htlcmin we will advertize (the BOLT #7 name is htlc\_minimum\_msat)
+- **maximum\_htlc\_out\_msat** (msat): The resulting htlcmax we will advertize (the BOLT #7 name is htlc\_maximum\_msat)
+- **short\_channel\_id** (short\_channel\_id, optional): the short\_channel\_id (if locked in)
 - the following warnings are possible:
   - **warning\_htlcmin\_too\_low**: The requested htlcmin was too low for this peer, so we set it to the minimum they will allow
   - **warning\_htlcmax\_too\_high**: The requested htlcmax was greater than the channel capacity, so we set it to the channel capacity
@@ -107,4 +107,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0f7cd751f329360a8cd957dfc8ea0b7d579aa05f4de4f8577039e50266a04f30)
+[comment]: # ( SHA256STAMP:31300838ff4b12d9bf43879c91a5d51af76f70ebe8527a35ba476801424c3e65)

--- a/doc/lightning-setchannel.7.md
+++ b/doc/lightning-setchannel.7.md
@@ -22,7 +22,7 @@ will accept: we allow 2 a day, with a few extra occasionally).
 *id* is required and should contain a scid (short channel ID), channel
 id or peerid (pubkey) of the channel to be modified. If *id* is set to
 "all", the updates are applied to all channels in states
-CHANNELD\_NORMAL CHANNELD\_AWAITING\_LOCKIN or DUALOPEND_AWAITING_LOCKIN.
+CHANNELD\_NORMAL CHANNELD\_AWAITING\_LOCKIN or DUALOPEND\_AWAITING\_LOCKIN.
 If *id* is a peerid, all channels with the +peer in those states are
 changed.
 

--- a/doc/lightning-setchannelfee.7.md
+++ b/doc/lightning-setchannelfee.7.md
@@ -49,12 +49,12 @@ RETURN VALUE
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, an object is returned, containing:
 
-- **base** (u32): The fee_base_msat value
-- **ppm** (u32): The fee_proportional_millionths value
+- **base** (u32): The fee\_base\_msat value
+- **ppm** (u32): The fee\_proportional\_millionths value
 - **channels** (array of objects): channel(s) whose rate is now set:
-  - **peer\_id** (pubkey): The node_id of the peer
-  - **channel\_id** (hex): The channel_id of the channel (always 64 characters)
-  - **short\_channel\_id** (short\_channel\_id, optional): the short_channel_id (if locked in)
+  - **peer\_id** (pubkey): The node\_id of the peer
+  - **channel\_id** (hex): The channel\_id of the channel (always 64 characters)
+  - **short\_channel\_id** (short\_channel\_id, optional): the short\_channel\_id (if locked in)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -83,4 +83,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:a7f079e9a25ee5f4c3d8bf3ed2c61d2f807eae99e6bfe02b0737a9692aca503b)
+[comment]: # ( SHA256STAMP:f4de7a0b01820a22b9b8f20e2cce249d3b0d2be10346e745e1066b101a37df3d)

--- a/doc/lightning-setchannelfee.7.md
+++ b/doc/lightning-setchannelfee.7.md
@@ -12,13 +12,13 @@ DESCRIPTION
 The **setchannelfee** RPC command sets channel specific routing fees as
 defined in BOLT \#7. The channel has to be in normal or awaiting state.
 This can be checked by **listpeers** reporting a *state* of
-CHANNELD\_NORMAL, CHANNELD\_AWAITING\_LOCKIN or DUALOPEND_AWAITING_LOCKIN for the channel.
+CHANNELD\_NORMAL, CHANNELD\_AWAITING\_LOCKIN or DUALOPEND\_AWAITING\_LOCKIN for the channel.
 
 *id* is required and should contain a scid (short channel ID), channel
 id or peerid (pubkey) of the channel to be modified. If *id* is set to
 "all", the fees for all channels are updated that are in state
 CHANNELD\_NORMAL, CHANNELD\_AWAITING\_LOCKIN or
-DUALOPEND_AWAITING_LOCKIN.  If *id* is a peerid, all channels with the
+DUALOPEND\_AWAITING\_LOCKIN.  If *id* is a peerid, all channels with the
 peer in those states are changed.
 
 *base* is an optional value in millisatoshi that is added as base fee to

--- a/doc/lightning-signmessage.7.md
+++ b/doc/lightning-signmessage.7.md
@@ -42,4 +42,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ff35aee05f86de2c44be50a156afc1e325183d8c9333bff68114c8d846a75e6)
+[comment]: # ( SHA256STAMP:ac618ebda6ab3acac85729f7b3e5607ccdcc78c75e40129ced84ae02e321f5c3)

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -72,4 +72,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:0daef100b12490126849fcb93a9e861554807d1a5acf68bc17de92a30505e18a)
+[comment]: # ( SHA256STAMP:655ef649bd68e29da6026cacf3d6f7399c5d9b2ac153c53e66cda9ece3fd761f)

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -42,4 +42,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:2103952683449a5aa313eefa9c850dc0ae1cf4aa65edeb7897a8748a010a9349)
+[comment]: # ( SHA256STAMP:3ad64970d67b1084b6f33bb690ba1dd3744292a60b3efe8a845f88a0ebc61450)

--- a/doc/lightning-txdiscard.7.md
+++ b/doc/lightning-txdiscard.7.md
@@ -19,7 +19,7 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **unsigned\_tx** (hex): the unsigned transaction
-- **txid** (txid): the transaction id of *unsigned_tx*
+- **txid** (txid): the transaction id of *unsigned\_tx*
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -45,4 +45,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f52ad03cccaea672deefada22f0a11acff9d0c4f98ccfedca12759eaa6bac057)
+[comment]: # ( SHA256STAMP:3b3b5c8e6bc2f30080053f93cc7db3dfc39bef118354ebfc2ed62e621329afc4)

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -57,7 +57,7 @@ On success, an object is returned, containing:
 
 - **psbt** (string): the PSBT representing the unsigned transaction
 - **unsigned\_tx** (hex): the unsigned transaction
-- **txid** (txid): the transaction id of *unsigned_tx*; you hand this to lightning-txsend(7) or lightning-txdiscard(7), as the inputs of this transaction are reserved.
+- **txid** (txid): the transaction id of *unsigned\_tx*; you hand this to lightning-txsend(7) or lightning-txdiscard(7), as the inputs of this transaction are reserved.
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -85,4 +85,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c13561bf71189143811cd4bd49db69c163b8443f1660931671eb1e95e0a7e3ff)
+[comment]: # ( SHA256STAMP:200dbb8ac175dbb5321e699cfa78dd319a96ceef0d61a7569415544503562d52)

--- a/doc/lightning-txsend.7.md
+++ b/doc/lightning-txsend.7.md
@@ -45,4 +45,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:dcb4d5f03b44bf3bc6852f97f56c0ac7d34505df71f042ed86a0daf4927dcaff)
+[comment]: # ( SHA256STAMP:db5c1f15e439f7784dcb759d444cf4f0844aa8093c6af2252e5989e1b75f0523)

--- a/doc/lightning-unreserveinputs.7.md
+++ b/doc/lightning-unreserveinputs.7.md
@@ -55,4 +55,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:41e0fba4aea57e12d91366a55663e7331e952b223eeb8fc9f83deb5a948f63b4)
+[comment]: # ( SHA256STAMP:4560823ed1adae2127b71b599cdaae1539bd5c87c03ecf593beed5813bb68511)

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -4,7 +4,7 @@ lightning-utxopsbt -- Command to populate PSBT inputs from given UTXOs
 SYNOPSIS
 --------
 
-**utxopsbt** *satoshi* *feerate* *startweight* *utxos* [*reserve*] [*reservedok*] [*locktime*] [*min_witness_weight*] [*excess_as_change*]
+**utxopsbt** *satoshi* *feerate* *startweight* *utxos* [*reserve*] [*reservedok*] [*locktime*] [*min\_witness\_weight*] [*excess\_as\_change*]
 
 DESCRIPTION
 -----------
@@ -33,11 +33,11 @@ if any of the *utxos* are already reserved.
 *locktime* is an optional locktime: if not set, it is set to a recent
 block height.
 
-*min_witness_weight* is an optional minimum weight to use for a UTXO's
+*min\_witness\_weight* is an optional minimum weight to use for a UTXO's
 witness. If the actual witness weight is greater than the provided minimum,
 the actual witness weight will be used.
 
-*excess_as_change* is an optional boolean to flag to add a change output
+*excess\_as\_change* is an optional boolean to flag to add a change output
 for the excess sats.
 
 RETURN VALUE
@@ -62,20 +62,20 @@ On success, an object is returned, containing:
 
 
 On success, returns the *psbt* it created, containing the inputs,
-*feerate_per_kw* showing the exact numeric feerate it used, 
-*estimated_final_weight* for the estimated weight of the transaction
-once fully signed, and *excess_msat* containing the amount above *satoshi*
+*feerate\_per\_kw* showing the exact numeric feerate it used, 
+*estimated\_final\_weight* for the estimated weight of the transaction
+once fully signed, and *excess\_msat* containing the amount above *satoshi*
 which is available.  This could be zero, or dust.  If *satoshi* was "all",
-then *excess_msat* is the entire amount once fees are subtracted
+then *excess\_msat* is the entire amount once fees are subtracted
 for the weights of the inputs and *startweight*.
 
 If *reserve* was *true* or a non-zero number, then a *reservations*
 array is returned, exactly like *reserveinputs*.
 
-If *excess_as_change* is true and the excess is enough to cover
+If *excess\_as\_change* is true and the excess is enough to cover
 an additional output above the `dust_limit`, then an output is
-added to the PSBT for the excess amount. The *excess_msat* will
-be zero. A *change_outnum* will be returned with the index of
+added to the PSBT for the excess amount. The *excess\_msat* will
+be zero. A *change\_outnum* will be returned with the index of
 the change output.
 
 On error the returned object will contain `code` and `message` properties,

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -49,8 +49,8 @@ On success, an object is returned, containing:
 - **psbt** (string): Unsigned PSBT which fulfills the parameters given
 - **feerate\_per\_kw** (u32): The feerate used to create the PSBT, in satoshis-per-kiloweight
 - **estimated\_final\_weight** (u32): The estimated weight of the transaction once fully signed
-- **excess\_msat** (msat): The amount above *satoshi* which is available.  This could be zero, or dust; it will be zero if *change_outnum* is also returned
-- **change\_outnum** (u32, optional): The 0-based output number where change was placed (only if parameter *excess_as_change* was true and there was sufficient funds)
+- **excess\_msat** (msat): The amount above *satoshi* which is available.  This could be zero, or dust; it will be zero if *change\_outnum* is also returned
+- **change\_outnum** (u32, optional): The 0-based output number where change was placed (only if parameter *excess\_as\_change* was true and there was sufficient funds)
 - **reservations** (array of objects, optional): If *reserve* was true or a non-zero number, just as per lightning-reserveinputs(7):
   - **txid** (txid): The txid of the transaction
   - **vout** (u32): The 0-based output number
@@ -100,4 +100,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c2c513b40099c9cd2ef7bda1c430fdff055499b67ef2ff9edf7772ea4d87fb2d)
+[comment]: # ( SHA256STAMP:237c832f7a7c1ea2567192b7432f4ea7fe79e553c9c531acf5be733b92095464)

--- a/doc/lightning-waitanyinvoice.7.md
+++ b/doc/lightning-waitanyinvoice.7.md
@@ -38,7 +38,7 @@ On success, an object is returned, containing:
 
 - **label** (string): unique label supplied at invoice creation
 - **description** (string): description used in the invoice
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): Whether it's paid or expired (one of "paid", "expired")
 - **expires\_at** (u64): UNIX timestamp of when it will become / became unpayable
 - **amount\_msat** (msat, optional): the amount required to pay this invoice
@@ -48,7 +48,7 @@ On success, an object is returned, containing:
 If **status** is "paid":
 
   - **pay\_index** (u64): Unique incrementing index for this payment
-  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount_msat*, since clients may overpay)
+  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount\_msat*, since clients may overpay)
   - **paid\_at** (u64): UNIX timestamp of when it was paid
   - **payment\_preimage** (secret): proof of payment (always 64 characters)
 
@@ -75,4 +75,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2b0c9e70bb03f5cf9999731fdf5b8bcd761ea70ef6fc04575a1c2451174ea769)
+[comment]: # ( SHA256STAMP:bd853f0a27258e0e3780c0dd6cdd8fca7ba8d95a00d247704ed3f3f55c2f086e)

--- a/doc/lightning-waitblockheight.7.md
+++ b/doc/lightning-waitblockheight.7.md
@@ -39,4 +39,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:e84e2ddf33c5abafe434ad0dcd76a3c1e6e2a2bdbba5dcf786f2a2ed80e61061)
+[comment]: # ( SHA256STAMP:b7986f9829dd7616ac4236c175b9d7011c27de19dd4fb50138b5957c59678177)

--- a/doc/lightning-waitinvoice.7.md
+++ b/doc/lightning-waitinvoice.7.md
@@ -20,7 +20,7 @@ On success, an object is returned, containing:
 
 - **label** (string): unique label supplied at invoice creation
 - **description** (string): description used in the invoice
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): Whether it's paid or expired (one of "paid", "expired")
 - **expires\_at** (u64): UNIX timestamp of when it will become / became unpayable
 - **amount\_msat** (msat, optional): the amount required to pay this invoice
@@ -30,7 +30,7 @@ On success, an object is returned, containing:
 If **status** is "paid":
 
   - **pay\_index** (u64): Unique incrementing index for this payment
-  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount_msat*, since clients may overpay)
+  - **amount\_received\_msat** (msat): the amount actually received (could be slightly greater than *amount\_msat*, since clients may overpay)
   - **paid\_at** (u64): UNIX timestamp of when it was paid
   - **payment\_preimage** (secret): proof of payment (always 64 characters)
 
@@ -60,4 +60,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2b0c9e70bb03f5cf9999731fdf5b8bcd761ea70ef6fc04575a1c2451174ea769)
+[comment]: # ( SHA256STAMP:bd853f0a27258e0e3780c0dd6cdd8fca7ba8d95a00d247704ed3f3f55c2f086e)

--- a/doc/lightning-waitsendpay.7.md
+++ b/doc/lightning-waitsendpay.7.md
@@ -36,11 +36,11 @@ RETURN VALUE
 On success, an object is returned, containing:
 
 - **id** (u64): unique ID for this payment attempt
-- **payment\_hash** (hash): the hash of the *payment_preimage* which will prove payment (always 64 characters)
+- **payment\_hash** (hash): the hash of the *payment\_preimage* which will prove payment (always 64 characters)
 - **status** (string): status of the payment (always "complete")
 - **created\_at** (u64): the UNIX timestamp showing when this payment was initiated
 - **amount\_sent\_msat** (msat): The amount sent
-- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment_hash
+- **groupid** (u64, optional): Grouping key to disambiguate multiple attempts to pay an invoice or the same payment\_hash
 - **amount\_msat** (msat, optional): The amount delivered to destination (if known)
 - **destination** (pubkey, optional): the final destination of the payment if known
 - **completed\_at** (number, optional): the UNIX timestamp showing when this payment was completed
@@ -51,7 +51,7 @@ On success, an object is returned, containing:
 
 If **status** is "complete":
 
-  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment_hash** (always 64 characters)
+  - **payment\_preimage** (secret): the proof of payment: SHA256 of this **payment\_hash** (always 64 characters)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -104,4 +104,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f4dbe3ecc88a294f7bb983a2f2b8e9613e440e4564580e51dd30fc83ba218a91)
+[comment]: # ( SHA256STAMP:5c783babcd7a98ef4f1bd676f7aa36c3441d52414dcd1038183d9c4445ddcf7d)

--- a/doc/lightning-withdraw.7.md
+++ b/doc/lightning-withdraw.7.md
@@ -74,4 +74,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:fcfd3c91a3cee9bbd36e86edccb5d6407b19c2beda7de1f51ebba5fbd1c2340a)
+[comment]: # ( SHA256STAMP:7ec01e1903d75e2a8694c50d051c40fcbdb8a8001943c79748ca8fd41d5d59b1)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -141,8 +141,8 @@ Current subdaemons are *channeld*, *closingd*,
 If the supplied path is relative the subdaemon binary is found in the
 working directory. This option may be specified multiple times.
 
-  So, **subdaemon=hsmd:remote_signer** would use a
-hypothetical remote signing proxy instead of the standard *lightning_hsmd*
+  So, **subdaemon=hsmd:remote\_signer** would use a
+hypothetical remote signing proxy instead of the standard *lightning\_hsmd*
 binary.
 
 * **pid-file**=*PATH*
@@ -343,8 +343,8 @@ This allows override of one or more of our standard feerates (see
 lightning-feerates(7)).  Up to 5 values, separated by '/' can be
 provided: if fewer are provided, then the final value is used for the
 remainder.  The values are in per-kw (roughly 1/4 of bitcoind's per-kb
-values), and the order is "opening", "mutual_close", "unilateral_close",
-"delayed_to_us", "htlc_resolution", and "penalty".
+values), and the order is "opening", "mutual\_close", "unilateral\_close",
+"delayed\_to\_us", "htlc\_resolution", and "penalty".
 
   You would usually put this option in the per-chain config file, to avoid
 setting it on Bitcoin mainnet!  e.g. `~rusty/.lightning/regtest/config`.

--- a/doc/lightningd-rpc.7.md
+++ b/doc/lightningd-rpc.7.md
@@ -84,8 +84,8 @@ Any field name which starts with "warning" is a specific warning, and
 should be documented in the commands' manual page.  Each warning field
 has an associated human-readable string, but it's redudant, as each
 separate warning should have a distinct field name
-(e.g. **warning_offer_unknown_currency** and
-**warning_offer_missing_description**).
+(e.g. **warning\_offer\_unknown\_currency** and
+**warning\_offer\_missing\_description**).
 
 JSON TYPES
 ----------

--- a/doc/lightningd.8.md
+++ b/doc/lightningd.8.md
@@ -142,11 +142,11 @@ and look at the *state* of the channel:
     $ lightning-cli listpeers $PUBLICKEY
 
 The channel will initially start with a *state* of
-*CHANNELD\_AWAITING_LOCKIN*. You need to wait for the channel *state*
-to become *CHANNELD_NORMAL*, meaning the funding transaction has been
+*CHANNELD\_AWAITING\_LOCKIN*. You need to wait for the channel *state*
+to become *CHANNELD\_NORMAL*, meaning the funding transaction has been
 confirmed deeply.
 
-Once the channel *state* is *CHANNELD_NORMAL*, you can start paying
+Once the channel *state* is *CHANNELD\_NORMAL*, you can start paying
 merchants over Lightning. Acquire a Lightning invoice from your favorite
 merchant, and use lightning-pay(7) to pay it:
 

--- a/doc/reckless.7.md
+++ b/doc/reckless.7.md
@@ -14,7 +14,7 @@ installation involves: finding the source plugin, copying,
 installing dependencies, testing, activating, and updating the
 lightningd config file. Reckless does all of these by invoking:
 
-**reckless** **install** *plugin_name*
+**reckless** **install** *plugin\_name*
 
 reckless will exit early in the event that:
 - the plugin is not found in any available source repositories
@@ -28,28 +28,28 @@ config), but regtest may also be used.
 
 Other commands include:
 
-**reckless** **uninstall** *plugin_name*
+**reckless** **uninstall** *plugin\_name*
 	disables the plugin, removes the directory.
 
-**reckless** **search** *plugin_name*
+**reckless** **search** *plugin\_name*
 	looks through all available sources for a plugin matching
 	this name.
 
-**reckless** **enable** *plugin_name*
+**reckless** **enable** *plugin\_name*
 	dynamically enables the reckless-installed plugin and updates
 	the config to match.
 
-**reckless** **disable** *plugin_name*
+**reckless** **disable** *plugin\_name*
 	dynamically disables the reckless-installed plugin and updates
 	the config to match.
 
 **reckless** **source** **list**
 	list available plugin repositories.
 
-**reckless** **source** **add** *repo_url*
+**reckless** **source** **add** *repo\_url*
 	add another plugin repo for reckless to search.
 
-**reckless** **source** **rm** *repo_url*
+**reckless** **source** **rm** *repo\_url*
 	remove a plugin repo for reckless to search.
 
 OPTIONS
@@ -57,14 +57,14 @@ OPTIONS
 
 Available option flags:
 
-**-d**, **--reckless-dir** *reckless_dir*
+**-d**, **--reckless-dir** *reckless\_dir*
 	specify an alternative data directory for reckless to use.
 	Useful if your .lightning is protected from execution.
 
-**-l**, **--lightning** *lightning_data_dir*
+**-l**, **--lightning** *lightning\_data\_dir*
 	lightning data directory (defaults to $USER/.lightning)
 
-**-c**, **--conf** *lightning_config*
+**-c**, **--conf** *lightning\_config*
 	pass the config used by lightningd
 
 **-r**, **--regtest**
@@ -92,7 +92,7 @@ invoked, so **python3** should be available in your environment. This
 can be verified with **which Python3**. The default reckless directory
 is $USER/.lightning/reckless and it should be possible for the
 lightningd user to execute files located here.  If this is a problem,
-the option flag **reckless -d=<my_alternate_dir>** may be used to
+the option flag **reckless -d=<my\_alternate\_dir>** may be used to
 relocate the reckless directory from its default. Consider creating a
 permanent alias in this case.
 

--- a/doc/schemas/bkpr-channelsapy.schema.json
+++ b/doc/schemas/bkpr-channelsapy.schema.json
@@ -59,7 +59,7 @@
           },
           "our_start_balance_msat": {
             "type": "msat",
-            "description": "Starting balance in channel at funding. Note that if our start ballance is zero, any _initial field will be omitted (can't divide by zero)"
+            "description": "Starting balance in channel at funding. Note that if our start balance is zero, any _initial field will be omitted (can't divide by zero)"
           },
           "channel_start_balance_msat": {
             "type": "msat",


### PR DESCRIPTION
The only time underscores aren't special in Markdown is when they appear in preformatted text. We have gotten away with not escaping underscores where an asterisk-enclosed span or the paragraph ends before the next underscore appears, but this is fragile and bad practice. Conversely, there are many places where we have not escaped underscores but needed to.
    
Escape all underscores that do not appear in preformatted blocks or preformatted spans and are not themselves delineating emphasized spans.

Also, add a check in `check-manpages` to help prevent more naughty underscores from creeping in in the future.