### PR TITLE
docs: remove the table inside the reprobuild docs 

### DIFF
--- a/doc/REPRODUCIBLE.md
+++ b/doc/REPRODUCIBLE.md
@@ -79,7 +79,7 @@ currently support:
   - Distribution Version: 22.04
   - Codename: jammy
 
-Depending on your host OS release you migh not have `debootstrap`
+Depending on your host OS release you might not have `debootstrap`
 manifests for versions newer than your host OS. Due to this we run the
 `debootstrap` commands in a container of the latest version itself:
 

--- a/doc/REPRODUCIBLE.md
+++ b/doc/REPRODUCIBLE.md
@@ -69,11 +69,15 @@ the non-updated repos).
 The following table lists the codenames of distributions that we
 currently support:
 
-| Distribution Version | Codename |
-|:---------------------|:---------|
-| Ubuntu 18.04         | bionic   |
-| Ubuntu 20.04         | focal    |
-| Ubuntu 22.04         | jammy    |
+- Ubuntu 18.06:
+  - Distribution Version: 18.04
+  - Codename: bionic
+- Ubuntu 20.04:
+  - Distribution Version: 20.04
+  - Codename: focal
+- Ubuntu 22.04:
+  - Distribution Version: 22.04
+  - Codename: jammy
 
 Depending on your host OS release you migh not have `debootstrap`
 manifests for versions newer than your host OS. Due to this we run the


### PR DESCRIPTION
This is a bit of a rabbit hole but the table looks like not supported in the docs site https://lightning.readthedocs.io/REPRODUCIBLE.html we should add additional dependencies, but I find the table is not accessible at all so I'm proposing a new list format.

In addition, other small commits to introduce the manpage for reckless and fix a small typo found in my emacs spellchecker