### PR TITLE
ld: Use `htable` to detect own transactions

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -208,6 +208,13 @@ static void broadcast_done(struct bitcoind *bitcoind,
 	if (otx->failed_or_success) {
 		otx->failed_or_success(otx->channel, success, msg);
 		tal_free(otx);
+	} else if (we_broadcast(bitcoind->ld->topology, &otx->txid)) {
+		log_debug(
+		    bitcoind->ld->topology->log,
+		    "Not adding %s to list of outgoing transactions, already "
+		    "present",
+		    type_to_string(tmpctx, struct bitcoin_txid, &otx->txid));
+		tal_free(otx);
 	} else {
 		/* For continual rebroadcasting, until channel freed. */
 		tal_steal(otx->channel, otx);

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -18,7 +18,6 @@ struct txwatch;
 
 /* Off topology->outgoing_txs */
 struct outgoing_tx {
-	struct list_node list;
 	struct channel *channel;
 	const char *hextx;
 	struct bitcoin_txid txid;
@@ -117,7 +116,7 @@ struct chain_topology {
 	struct oneshot *extend_timer, *updatefee_timer;
 
 	/* Bitcoin transactions we're broadcasting */
-	struct list_head outgoing_txs;
+	struct outgoing_tx_map outgoing_txs;
 
 	/* Transactions/txos we are watching. */
 	struct txwatch_hash txwatches;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -66,6 +66,26 @@ static inline bool block_eq(const struct block *b, const struct bitcoin_blkid *k
 }
 HTABLE_DEFINE_TYPE(struct block, keyof_block_map, hash_sha, block_eq, block_map);
 
+/* Hash blocks by sha */
+static inline const struct bitcoin_txid *keyof_outgoing_tx_map(const struct outgoing_tx *t)
+{
+	return &t->txid;
+}
+
+static inline size_t outgoing_tx_hash_sha(const struct bitcoin_txid *key)
+{
+	size_t ret;
+	memcpy(&ret, key, sizeof(ret));
+	return ret;
+}
+
+static inline bool outgoing_tx_eq(const struct outgoing_tx *b, const struct bitcoin_txid *key)
+{
+	return bitcoin_txid_eq(&b->txid, key);
+}
+HTABLE_DEFINE_TYPE(struct outgoing_tx, keyof_outgoing_tx_map,
+		   outgoing_tx_hash_sha, outgoing_tx_eq, outgoing_tx_map);
+
 struct chain_topology {
 	struct lightningd *ld;
 	struct block *root;


### PR DESCRIPTION
@whitslack did an in-depth analysis of the issue at hand, and it turns out we were doing quadratic lookups on an ever increasing list of transactions we broadcast, with ever rebroadcast doubling the size of the rebroadcast list.

The first commit avoids adding the same TX multiple times, while the following two commit replace the entire list with an `htable` instead, reducing complexity to linear.

Fixes #5682