### PR TITLE
cln-plugin: Make the configuration in `init` public

### DIFF
--- a/plugins/src/codec.rs
+++ b/plugins/src/codec.rs
@@ -12,7 +12,7 @@ use std::{io, str};
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::messages::{Notification, Request};
-pub use crate::messages::JsonRpc;
+use crate::messages::JsonRpc;
 
 /// A simple codec that parses messages separated by two successive
 /// `\n` newlines.

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::codec::{JsonCodec, JsonRpcCodec};
-pub use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context};
 use futures::sink::SinkExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 extern crate log;
@@ -16,9 +16,9 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::FramedWrite;
 
-pub mod codec;
-pub mod logging;
-mod messages;
+mod codec;
+mod logging;
+pub mod messages;
 
 #[macro_use]
 extern crate serde_json;

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -58,7 +58,7 @@ pub(crate) enum Notification {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct GetManifestCall {}
+pub(crate) struct GetManifestCall {}
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct InitCall {
@@ -93,7 +93,7 @@ pub struct ProxyInfo {
 }
 
 #[derive(Debug)]
-pub enum JsonRpc<N, R> {
+pub(crate) enum JsonRpc<N, R> {
     Request(serde_json::Value, R),
     Notification(N),
     CustomRequest(serde_json::Value, Value),

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -63,7 +63,7 @@ pub struct GetManifestCall {}
 #[derive(Deserialize, Debug)]
 pub(crate) struct InitCall {
     pub(crate) options: HashMap<String, Value>,
-    pub(crate) configuration: Configuration,
+    pub configuration: Configuration,
 }
 
 #[derive(Clone, Deserialize, Debug)]


### PR DESCRIPTION
It was set to crate level visibility for some reason, not all that helpful :-)

Suggested-by: Sergi Delgado Segura <@sr-gi>