### PR TITLE
lightningd: do not abort while parsing hsm pwd

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -516,9 +516,15 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 	int is_encrypted;
 
         is_encrypted = is_hsm_secret_encrypted("hsm_secret");
+	/* While lightningd is performing the first initialization
+	 * this check is always true because the file does not exist.
+	 *
+	 * Maybe the is_hsm_secret_encrypted is performing a not useful
+	 * check at this stage, but the hsm is a delicate part,
+	 * so it is a good information to have inside the log. */
 	if (is_encrypted == -1)
-		return tal_fmt(NULL, "Could not access 'hsm_secret': %s",
-			       strerror(errno));
+		log_info(ld->log, "'hsm_secret' does not exist (%s)",
+			 strerror(errno));
 
 	prompt(ld, "The hsm_secret is encrypted with a password. In order to "
 	       "decrypt it and start the node you must provide the password.");


### PR DESCRIPTION
This is a mistake that I introduced while I implemented the lightningd custom error for hsmd.

In particular, when the command line parser check
if the file is encrypted make an additional check regarding the existence of the file.

This can be a not useful check, but due to the delicate nature of the hsm file, it is better to check if exist and if it doesn't exist an informative line inside the log is emitted that notifies the user that the file does not exist.

This log may return useful while debugging disaster
(that can happen) to understand that there is something strange (eg. the user moves the hsm file somewhere else).

Fixes https://github.com/ElementsProject/lightning/issues/5719

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>