### PR TITLE
Make modern string-based JSON ids opt in, deprecate numeric ones

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -917,6 +917,7 @@ class Plugin(object):
             'subscriptions': list(self.subscriptions.keys()),
             'hooks': hooks,
             'dynamic': self.dynamic,
+            'nonnumericids': True,
             'notifications': [
                 {"method": name} for name in self.notification_topics
             ],

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -136,6 +136,7 @@ example:
 	  "method": "mycustomnotification"
 	}
   ],
+  "nonnumericids": true,
   "dynamic": true
 }
 ```
@@ -157,6 +158,13 @@ parameter names in `[]`.
 you plan on removing them: this will disable them if the user sets
 `allow-deprecated-apis` to false (which every developer should do,
 right?).
+
+The `nonnumericids` indicates that the plugin can handle
+string JSON request `id` fields: prior to v22.11 lightningd used numbers 
+for these, and the change to strings broke some plugins.  If not set,
+then strings will be used once this feature is removed after v23.05.
+See [the lightning-rpc documentation][lightning-rpc.7.md] for how to handle
+JSON `id` fields!
 
 The `dynamic` indicates if the plugin can be managed after `lightningd`
 has been started using the [plugin][lightning-plugin] JSON-RPC command. Critical plugins that should not be stopped should set it
@@ -1781,3 +1789,4 @@ The plugin must broadcast it and respond with the following fields:
 [bolt9]: https://github.com/lightning/bolts/blob/master/09-features.md
 [lightning-plugin]: lightning-plugin.7.md
 [pyln-client]: ../contrib/pyln-client
+[lightning-rpc.7.md]: lightning-rpc.7.md

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -49,7 +49,8 @@ static void config_plugin(struct plugin *plugin)
 	struct jsonrpc_request *req;
 	void *ret;
 
-	req = jsonrpc_request_start(plugin, "init", NULL, plugin->log,
+	req = jsonrpc_request_start(plugin, "init", NULL,
+				    plugin->non_numeric_ids, plugin->log,
 	                            NULL, plugin_config_cb, plugin);
 	plugin_populate_init_request(plugin, req);
 	jsonrpc_request_end(req);
@@ -237,7 +238,7 @@ void bitcoind_estimate_fees_(struct bitcoind *bitcoind,
 	call->cb = cb;
 	call->arg = arg;
 
-	req = jsonrpc_request_start(bitcoind, "estimatefees", NULL,
+	req = jsonrpc_request_start(bitcoind, "estimatefees", NULL, true,
 				    bitcoind->log,
 				    NULL, estimatefees_callback, call);
 	jsonrpc_request_end(req);
@@ -314,7 +315,8 @@ void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
 	call->cb_arg = cb_arg;
 	log_debug(bitcoind->log, "sendrawtransaction: %s", hextx);
 
-	req = jsonrpc_request_start(bitcoind, "sendrawtransaction", id_prefix,
+	req = jsonrpc_request_start(bitcoind, "sendrawtransaction",
+				    id_prefix, true,
 				    bitcoind->log,
 				    NULL, sendrawtx_callback,
 				    call);
@@ -401,7 +403,7 @@ void bitcoind_getrawblockbyheight_(struct bitcoind *bitcoind,
 	call->cb = cb;
 	call->cb_arg = cb_arg;
 
-	req = jsonrpc_request_start(bitcoind, "getrawblockbyheight", NULL,
+	req = jsonrpc_request_start(bitcoind, "getrawblockbyheight", NULL, true,
 				    bitcoind->log,
 				    NULL,  getrawblockbyheight_callback,
 				    call);
@@ -482,7 +484,7 @@ void bitcoind_getchaininfo_(struct bitcoind *bitcoind,
 	call->cb_arg = cb_arg;
 	call->first_call = first_call;
 
-	req = jsonrpc_request_start(bitcoind, "getchaininfo", NULL,
+	req = jsonrpc_request_start(bitcoind, "getchaininfo", NULL, true,
 				    bitcoind->log,
 				    NULL, getchaininfo_callback, call);
 	jsonrpc_request_end(req);
@@ -555,7 +557,8 @@ void bitcoind_getutxout_(struct bitcoind *bitcoind,
 	call->cb = cb;
 	call->cb_arg = cb_arg;
 
-	req = jsonrpc_request_start(bitcoind, "getutxout", NULL, bitcoind->log,
+	req = jsonrpc_request_start(bitcoind, "getutxout", NULL, true,
+				    bitcoind->log,
 				    NULL, getutxout_callback, call);
 	json_add_txid(req->stream, "txid", &outpoint->txid);
 	json_add_num(req->stream, "vout", outpoint->n);

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -73,6 +73,7 @@ struct jsonrpc_notification {
 
 struct jsonrpc_request {
 	const char *id;
+	bool id_is_string;
 	const char *method;
 	struct json_stream *stream;
 	void (*notify_cb)(const char *buffer,
@@ -226,9 +227,9 @@ void jsonrpc_notification_end(struct jsonrpc_notification *n);
  * start a JSONRPC request; id_prefix is non-NULL if this was triggered by
  * another JSONRPC request.
  */
-#define jsonrpc_request_start(ctx, method, id_prefix, log, notify_cb, response_cb, response_cb_arg) \
+#define jsonrpc_request_start(ctx, method, id_prefix, id_as_string, log, notify_cb, response_cb, response_cb_arg) \
 	jsonrpc_request_start_(					\
-	    (ctx), (method), (id_prefix), (log), true,		\
+	    (ctx), (method), (id_prefix), (id_as_string), (log), true, \
 	    typesafe_cb_preargs(void, void *, (notify_cb), (response_cb_arg),	\
 				const char *buffer,		\
 				const jsmntok_t *idtok,		\
@@ -240,9 +241,9 @@ void jsonrpc_notification_end(struct jsonrpc_notification *n);
 				const jsmntok_t *idtok),	\
 	    (response_cb_arg))
 
-#define jsonrpc_request_start_raw(ctx, method, id_prefix, log, notify_cb, response_cb, response_cb_arg) \
+#define jsonrpc_request_start_raw(ctx, method, id_prefix, id_as_string,log, notify_cb, response_cb, response_cb_arg) \
 	jsonrpc_request_start_(						\
-		(ctx), (method), (id_prefix), (log), false,		\
+		(ctx), (method), (id_prefix), (id_as_string), (log), false, \
 	    typesafe_cb_preargs(void, void *, (notify_cb), (response_cb_arg), \
 				const char *buffer,			\
 				const jsmntok_t *idtok,			\
@@ -256,7 +257,9 @@ void jsonrpc_notification_end(struct jsonrpc_notification *n);
 
 struct jsonrpc_request *jsonrpc_request_start_(
     const tal_t *ctx, const char *method,
-    const char *id_prefix TAKES, struct log *log, bool add_header,
+    const char *id_prefix TAKES,
+    bool id_as_string,
+    struct log *log, bool add_header,
     void (*notify_cb)(const char *buffer,
 		      const jsmntok_t *idtok,
 		      const jsmntok_t *methodtok,

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -81,6 +81,9 @@ struct plugin {
 	 * C-lightning should terminate as well.  */
 	bool important;
 
+	/* Can this handle non-numeric JSON ids? */
+	bool non_numeric_ids;
+
 	/* Parameters for dynamically-started plugins. */
 	const char *parambuf;
 	const jsmntok_t *params;

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -235,6 +235,7 @@ static void plugin_hook_call_next(struct plugin_hook_request *ph_req)
 	log_debug(ph_req->ld->log, "Calling %s hook of plugin %s",
 		  ph_req->hook->name, ph_req->plugin->shortname);
 	req = jsonrpc_request_start(NULL, hook->name, ph_req->cmd_id,
+				    ph_req->plugin->non_numeric_ids,
 				    plugin_get_log(ph_req->plugin),
 				    NULL,
 				    plugin_hook_callback, ph_req);
@@ -380,7 +381,9 @@ void plugin_hook_db_sync(struct db *db)
 
 		/* FIXME: id_prefix from caller? */
 		/* FIXME: do IO logging for this! */
-		req = jsonrpc_request_start(NULL, hook->name, NULL, NULL, NULL,
+		req = jsonrpc_request_start(NULL, hook->name, NULL,
+					    dwh_req->plugin->non_numeric_ids,
+					    NULL, NULL,
 					    db_hook_response,
 					    dwh_req);
 

--- a/lightningd/signmessage.c
+++ b/lightningd/signmessage.c
@@ -211,17 +211,18 @@ static struct command_result *json_checkmessage(struct command *cmd,
 
 		node_id_from_pubkey(&can->id, &reckey);
 		can->cmd = cmd;
-		req = jsonrpc_request_start(cmd, "listnodes",
-					    cmd->id,
-					    command_log(cmd),
-					    NULL, listnodes_done,
-					    can);
-		json_add_node_id(req->stream, "id", &can->id);
-		jsonrpc_request_end(req);
 
 		/* Only works if we have listnodes! */
 		plugin = find_plugin_for_command(cmd->ld, "listnodes");
 		if (plugin) {
+			req = jsonrpc_request_start(cmd, "listnodes",
+						    cmd->id,
+						    plugin->non_numeric_ids,
+						    command_log(cmd),
+						    NULL, listnodes_done,
+						    can);
+			json_add_node_id(req->stream, "id", &can->id);
+			jsonrpc_request_end(req);
 			plugin_request_send(plugin, req);
 			return command_still_pending(cmd);
 		}

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -517,7 +517,9 @@ void jsonrpc_request_end(struct jsonrpc_request *request UNNEEDED)
 /* Generated stub for jsonrpc_request_start_ */
 struct jsonrpc_request *jsonrpc_request_start_(
     const tal_t *ctx UNNEEDED, const char *method UNNEEDED,
-    const char *id_prefix TAKES UNNEEDED, struct log *log UNNEEDED, bool add_header UNNEEDED,
+    const char *id_prefix TAKES UNNEEDED,
+    bool id_as_string UNNEEDED,
+    struct log *log UNNEEDED, bool add_header UNNEEDED,
     void (*notify_cb)(const char *buffer UNNEEDED,
 		      const jsmntok_t *idtok UNNEEDED,
 		      const jsmntok_t *methodtok UNNEEDED,

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -888,6 +888,7 @@ handle_getmanifest(struct command *getmanifest_cmd,
 	}
 
 	json_add_bool(params, "dynamic", p->restartability == PLUGIN_RESTARTABLE);
+	json_add_bool(params, "nonnumericids", true);
 
 	json_array_start(params, "notifications");
 	for (size_t i = 0; p->notif_topics && i < p->num_notif_topics; i++) {

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -46,6 +46,7 @@ where
     rpcmethods: HashMap<String, RpcMethod<S>>,
     subscriptions: HashMap<String, Subscription<S>>,
     dynamic: bool,
+    nonnumericids: bool,
 }
 
 /// A plugin that has registered with the lightning daemon, and gotten
@@ -115,6 +116,7 @@ where
             options: vec![],
             rpcmethods: HashMap::new(),
             dynamic: false,
+            nonnumericids: true,
         }
     }
 
@@ -318,6 +320,7 @@ where
             hooks: self.hooks.keys().map(|s| s.clone()).collect(),
             rpcmethods,
             dynamic: self.dynamic,
+	    nonnumericids: true,
         }
     }
 

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -157,6 +157,7 @@ pub(crate) struct GetManifestResponse {
     pub(crate) subscriptions: Vec<String>,
     pub(crate) hooks: Vec<String>,
     pub(crate) dynamic: bool,
+    pub(crate) nonnumericids: bool,
 }
 
 #[derive(Serialize, Default, Debug)]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3238,18 +3238,3 @@ def test_block_added_notifications(node_factory, bitcoind):
     sync_blockheight(bitcoind, [l2])
     ret = l2.rpc.call("blockscatched")
     assert len(ret) == 3 and ret[1] == next_l2_base + 1 and ret[2] == next_l2_base + 2
-
-
-def test_numeric_json_ids(node_factory):
-    """Test that we use numeric json IDs when in deprecated mode (unless
-plugin says otherwise!)"""
-    l1 = node_factory.get_node(options={'allow-deprecated-apis': True,
-                                        'log-level': 'io'})
-
-    # getmanifest and init
-    l1.daemon.logsearch_start = 0
-    l1.daemon.wait_for_logs([r"plugin-commando: [0-9]*\[OUT\]"] * 2)
-
-    # This is in a plugin.
-    l1.rpc.commando_rune()
-    l1.daemon.wait_for_log(r"plugin-commando: [0-9]*\[OUT\]")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1501,8 +1501,9 @@ def test_libplugin(node_factory):
 
     myname = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
-    # Side note: getmanifest will trace back to plugin_start
-    l1.daemon.wait_for_log(r": {}:plugin#[0-9]*/cln:getmanifest#[0-9]*\[OUT\]".format(myname))
+    # Note: getmanifest always uses numeric ids, since it doesn't know
+    # yet whether strings are allowed:
+    l1.daemon.wait_for_log(r"test_libplugin: [0-9]*\[OUT\]")
 
     # Test commands
     assert l1.rpc.call("helloworld") == {"hello": "world"}
@@ -3237,3 +3238,18 @@ def test_block_added_notifications(node_factory, bitcoind):
     sync_blockheight(bitcoind, [l2])
     ret = l2.rpc.call("blockscatched")
     assert len(ret) == 3 and ret[1] == next_l2_base + 1 and ret[2] == next_l2_base + 2
+
+
+def test_numeric_json_ids(node_factory):
+    """Test that we use numeric json IDs when in deprecated mode (unless
+plugin says otherwise!)"""
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True,
+                                        'log-level': 'io'})
+
+    # getmanifest and init
+    l1.daemon.logsearch_start = 0
+    l1.daemon.wait_for_logs([r"plugin-commando: [0-9]*\[OUT\]"] * 2)
+
+    # This is in a plugin.
+    l1.rpc.commando_rune()
+    l1.daemon.wait_for_log(r"plugin-commando: [0-9]*\[OUT\]")


### PR DESCRIPTION
This is not actually as bad as you'd think; we already handle arbitrary ids, it's just that we need to remember if this request id is a string or not.  Most of the code is plumbing, to only set the flag when the plugin says we can.

This fixes clboss!

I get a new rust warning, though, suspect my monkey coding there is wrong:

```
warning: field is never read: `nonnumericids`
  --> plugins/src/lib.rs:49:5
   |
49 |     nonnumericids: bool,
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

```
