### PR TITLE
lightningd: don't timeout plugins if init is slow!

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1942,6 +1942,8 @@ def test_plugin_fail(node_factory):
     time.sleep(2)
     # It should clean up!
     assert 'failcmd' not in [h['command'] for h in l1.rpc.help()['help']]
+    # Can happen *before* the 'Server started with public key'
+    l1.daemon.logsearch_start = 0
     l1.daemon.wait_for_log(r': exited during normal operation')
 
     l1.rpc.plugin_start(plugin)


### PR DESCRIPTION
This is a minimal fix: we wait until all plugins reply from init before continuing.  Really large or busy nodes can have other things monopolize lightningd, then the timer goes off and we blame the plugin (which has responded, we just haven't read it yet!).

The real answer is to have some timeouts only advance when we're idle, or have them low-priority so we only activate them when we're idle (this doesn't apply to all timers: some are probably important!).  But this is a minimal fix for -rc3.

Fixes: https://github.com/ElementsProject/lightning/issues/5736