### PR TITLE
submod: Switch lnprototest to clone from github.com/rustyrussell/lnprototest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	url = https://github.com/valyala/gheap
 [submodule "external/lnprototest"]
 	path = external/lnprototest
-	url = https://github.com/niftynei/lnprototest.git
+	url = https://github.com/rustyrussell/lnprototest.git
 	branch = nifty/ripemd160-fallback
 [submodule "external/lowdown"]
 	path = external/lowdown


### PR DESCRIPTION
This is the official root repository, and some tools (pip for example) doesn't like pointing to repos that don't actually contain the commit that we point to. Funny that Github actually shows non-existent commits in clones (bitcoin/bitcoin has been impersonated before too).

Changelog-None