### PR TITLE
lightningd: correctly exit when an important-plugin fails to start.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -968,6 +968,7 @@ struct chain_topology *new_topology(struct lightningd *ld, struct log *log)
 	topo->feerate_uninitialized = true;
 	topo->root = NULL;
 	topo->sync_waiters = tal(topo, struct list_head);
+	topo->extend_timer = NULL;
 	topo->stopping = false;
 	list_head_init(topo->sync_waiters);
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -876,7 +876,7 @@ int main(int argc, char *argv[])
 	struct htlc_in_map *unconnected_htlcs_in;
 	struct ext_key *bip32_base;
 	int sigchld_rfd;
-	struct io_conn *sigchld_conn;
+	struct io_conn *sigchld_conn = NULL;
 	int exit_code = 0;
 	char **orig_argv;
 	bool try_reexec;
@@ -1104,7 +1104,8 @@ int main(int argc, char *argv[])
 
 	/*~ Now that the rpc path exists, we can start the plugins and they
 	 * can start talking to us. */
-	plugins_config(ld->plugins);
+	if (!plugins_config(ld->plugins))
+		goto stop;
 
 	/*~ Process any HTLCs we were in the middle of when we exited, now
 	 * that plugins (who might want to know via htlc_accepted hook) are
@@ -1201,6 +1202,7 @@ int main(int argc, char *argv[])
 	assert(io_loop_ret == ld);
 	log_debug(ld->log, "io_loop_with_timers: %s", __func__);
 
+stop:
 	/* Stop *new* JSON RPC requests. */
 	jsonrpc_stop_listening(ld->jsonrpc);
 

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -265,8 +265,11 @@ struct command_result *plugin_register_all_complete(struct lightningd *ld,
  * and send them over to the plugin. This finalizes the initialization
  * of the plugins and signals that lightningd is now ready to process
  * incoming JSON-RPC calls and messages.
+ *
+ * It waits for plugins to be initialized, but returns false if we
+ * should exit (an important plugin failed, or we got a shutdown command).
  */
-void plugins_config(struct plugins *plugins);
+bool plugins_config(struct plugins *plugins);
 
 /**
  * This populates the jsonrpc request with the plugin/lightningd specifications

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -168,7 +168,7 @@ struct chain_topology *new_topology(struct lightningd *ld UNNEEDED, struct log *
 void onchaind_replay_channels(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "onchaind_replay_channels called!\n"); abort(); }
 /* Generated stub for plugins_config */
-void plugins_config(struct plugins *plugins UNNEEDED)
+bool plugins_config(struct plugins *plugins UNNEEDED)
 { fprintf(stderr, "plugins_config called!\n"); abort(); }
 /* Generated stub for plugins_init */
 void plugins_init(struct plugins *plugins UNNEEDED)


### PR DESCRIPTION
This was found by tests/test_plugin.py::test_important_plugin and was NOT a flake!

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-None: only just committed
See: https://github.com/ElementsProject/lightning/pull/5741