### PR TITLE
Re-experimentalize DNS Bolt7 #911 ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ TODO: Insert version codename, and username of the contributor that named the re
 ### Changed
 
  - Protocol: We now require all channel_update messages include htlc_maximum_msat (as per latest BOLTs) ([#5592])
- - Protocol: Bolt7 #911 DNS annoucenent support is no longer EXPERIMENTAL ([#5487])
  - JSON-RPC: `listfunds` now lists coinbase outputs as 'immature' until they're spendable ([#5664])
  - JSON-RPC: UTXOs aren't spendable while immature ([#5664])
  - Plugins: `openchannel2` now always includes the `channel_max_msat` ([#5650])

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -766,12 +766,14 @@ static void try_connect_one_addr(struct connecting *connect)
 	bool use_proxy = connect->daemon->always_use_proxy;
 	const struct wireaddr_internal *addr = &connect->addrs[connect->addrnum];
 	struct io_conn *conn;
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	bool use_dns = connect->daemon->use_dns;
 	struct addrinfo hints, *ais, *aii;
 	struct wireaddr_internal addrhint;
 	int gai_err;
 	struct sockaddr_in *sa4;
 	struct sockaddr_in6 *sa6;
+#endif
 
 	assert(!connect->conn);
 
@@ -821,6 +823,7 @@ static void try_connect_one_addr(struct connecting *connect)
 			af = AF_INET6;
 			break;
 		case ADDR_TYPE_DNS:
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 			if (use_proxy) /* hand it to the proxy */
 				break;
 			if (!use_dns) {  /* ignore DNS when we can't use it */
@@ -872,6 +875,12 @@ static void try_connect_one_addr(struct connecting *connect)
 				addr = &connect->addrs[connect->addrnum];
 			}
 			freeaddrinfo(ais);
+#endif
+			tal_append_fmt(&connect->errors,
+				       "%s: EXPERIMENTAL_FEATURES needed. ",
+				       type_to_string(tmpctx,
+						      struct wireaddr_internal,
+						      addr));
 			goto next;
 		case ADDR_TYPE_WEBSOCKET:
 			af = -1;
@@ -1627,8 +1636,10 @@ static void add_seed_addrs(struct wireaddr_internal **addrs,
 		                                   NULL, broken_reply, NULL);
 		if (new_addrs) {
 			for (size_t j = 0; j < tal_count(new_addrs); j++) {
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 				if (new_addrs[j].type == ADDR_TYPE_DNS)
 					continue;
+#endif
 				struct wireaddr_internal a;
 				a.itype = ADDR_INTERNAL_WIREADDR;
 				a.u.wireaddr = new_addrs[j];

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -193,6 +193,7 @@ static char *opt_set_accept_extra_tlv_types(const char *arg,
 	return NULL;
 }
 
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 /* Returns the number of wireaddr types already announced */
 static size_t num_announced_types(enum wire_addr_type type, struct lightningd *ld)
 {
@@ -207,6 +208,7 @@ static size_t num_announced_types(enum wire_addr_type type, struct lightningd *l
 	}
 	return num;
 }
+#endif
 
 static char *opt_add_addr_withtype(const char *arg,
 				   struct lightningd *ld,
@@ -253,6 +255,7 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
 
+#if EXPERIMENTAL_FEATURES /* BOLT7 DNS RFC #911 */
 	/* Add ADDR_TYPE_DNS to announce DNS hostnames */
 	if (is_dnsaddr(address) && ala & ADDR_ANNOUNCE) {
 		/* BOLT-hostnames #7:
@@ -277,6 +280,7 @@ static char *opt_add_addr_withtype(const char *arg,
 		tal_arr_expand(&ld->proposed_listen_announce, ADDR_ANNOUNCE);
 		tal_arr_expand(&ld->proposed_wireaddr, wi);
 	}
+#endif
 
 	return NULL;
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -5,7 +5,7 @@ from fixtures import TEST_NETWORK
 from pyln.client import RpcError, Millisatoshi
 from utils import (
     DEVELOPER, wait_for, TIMEOUT, only_one, sync_blockheight,
-    expected_node_features,
+    expected_node_features, COMPAT, EXPERIMENTAL_FEATURES,
     mine_funding_to_announce, default_ln_port
 )
 
@@ -124,6 +124,13 @@ def test_announce_address(node_factory, bitcoind):
              '::'],
             'log-level': 'io',
             'dev-allow-localhost': None}
+    if not EXPERIMENTAL_FEATURES:  # BOLT7 DNS RFC #911
+        opts = {'disable-dns': None, 'announce-addr':
+                ['4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsnzjpbi7utijcltosqemad.onion',
+                 '1.2.3.4:1234',
+                 '::'],
+                'log-level': 'io',
+                'dev-allow-localhost': None}
     l1, l2 = node_factory.get_nodes(2, opts=[opts, {}])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
@@ -132,6 +139,14 @@ def test_announce_address(node_factory, bitcoind):
 
     l1.wait_channel_active(scid)
     l2.wait_channel_active(scid)
+
+    if not EXPERIMENTAL_FEATURES:  # BOLT7 DNS RFC #911
+        l1.daemon.wait_for_log(r"\[OUT\] 0101.*47"
+                               "010102030404d2"
+                               "017f000001...."
+                               "0200000000000000000000000000000000...."
+                               "04e00533f3e8f2aedaa8969b3d0fa03a96e857bbb28064dca5e147e934244b9ba5023003....")
+        return
 
     # We should see it send node announce with all addresses (257 = 0x0101)
     # Note: local ephemeral port is masked out.
@@ -158,6 +173,7 @@ def test_announce_address(node_factory, bitcoind):
     assert addresses_dns[0]['port'] == 1236
 
 
+@unittest.skipIf(not EXPERIMENTAL_FEATURES, "BOLT7 DNS RFC #911")
 @pytest.mark.developer("gossip without DEVELOPER=1 is slow")
 def test_announce_and_connect_via_dns(node_factory, bitcoind):
     """ Test that DNS annoucements propagate and can be used when connecting.
@@ -222,6 +238,7 @@ def test_announce_and_connect_via_dns(node_factory, bitcoind):
         l4.rpc.connect(l1.info['id'])
 
 
+@unittest.skipIf(not EXPERIMENTAL_FEATURES, "BOLT7 DNS RFC #911")
 def test_only_announce_one_dns(node_factory, bitcoind):
     # and test that we can't announce more than one DNS address
     l1 = node_factory.get_node(expect_fail=True, start=False,
@@ -230,6 +247,7 @@ def test_only_announce_one_dns(node_factory, bitcoind):
     wait_for(lambda: l1.daemon.is_in_stderr("Only one DNS can be announced"))
 
 
+@unittest.skipIf(not EXPERIMENTAL_FEATURES, "BOLT7 DNS RFC #911")
 def test_announce_dns_without_port(node_factory, bitcoind):
     """ Checks that the port of a DNS announcement is set to the corresponding
         network port. In this case regtest 19846


### PR DESCRIPTION
Most mainnet implementations are still broken when it comes to propagate `node_announcent` that have IP/Tor and also DNS names in them.

They should propagate entries they do not understand, but instead they drop it.
Having this feature live would make nodes inaccessible that try to use DNS.
We need to re-evaluate this in a couple of month.

Alternatives:
 - keep it as is in order to gently push the other implementations. I think the blame will be on us anyway.
 - disable DNS announcements but add static old style IP entries if DNS is used by config
 
 This PR is just to have a brief discussion about this issue before release...
