### PR TITLE
docs: Add the `reckless` manpage to the readthedocs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ tests/plugins/test_selfdisable_after_getmanifest
 # Ignore generated files
 devtools/features
 doc/lightning*.[1578]
+doc/reckless*.[1578]
 *_sqlgen.[ch]
 *_wiregen.[ch]
 *_printgen.[ch]

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -196,4 +196,4 @@ doc-clean:
 	$(RM) doc/deployable-lightning.{aux,bbl,blg,dvi,log,out,tex}
 
 doc/index.rst: $(MANPAGES:=.md)
-	@$(call VERBOSE, "genidx $@",(grep -v "^   lightning.*\.[0-9]\.md>$$" $@; for m in $$(cd doc && ls lightningd*.[0-9].md lightning-*.[0-9].md); do echo "   $${m%.[0-9].md} <$$m>"; done |$(SORT)) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@)
+	@$(call VERBOSE, "genidx $@",(grep -v "^   (reckless|lightning).*\.[0-9]\.md>$$" $@; for m in $$(cd doc && ls reckless.7.md lightningd*.[0-9].md lightning-*.[0-9].md); do echo "   $${m%.[0-9].md} <$$m>"; done |$(SORT)) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -129,3 +129,4 @@ Core Lightning Documentation
    lightningd <lightningd.8.md>
    lightningd-config <lightningd-config.5.md>
    lightningd-rpc <lightningd-rpc.7.md>
+   reckless <reckless.7.md>


### PR DESCRIPTION
Changelog-None