### PR TITLE
wireaddr: extend is_dnsaddr testcase a bit

### DIFF
--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -126,11 +126,13 @@ int main(int argc, char *argv[])
 	assert(is_dnsaddr("123example.com"));
 	assert(is_dnsaddr("example123.com"));
 	assert(is_dnsaddr("is-valid.3hostname123.com"));
+	assert(is_dnsaddr("just-a-hostname-with-dashes"));
 	assert(!is_dnsaddr("UPPERCASE.invalid.com"));
 	assert(!is_dnsaddr("-.invalid.com"));
 	assert(!is_dnsaddr("invalid.-example.com"));
 	assert(!is_dnsaddr("invalid.example-.com"));
 	assert(!is_dnsaddr("invalid..example.com"));
+	assert(!is_dnsaddr("lightningd_dest.issue-5657.underscores.not.allowed"));
 
 	/* Grossly invalid. */
 	assert(!separate_address_and_port(tmpctx, "[", &ip, &port));

--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -380,7 +380,7 @@ bool is_wildcardaddr(const char *arg)
  * - not longer than 255
  * - segments are separated with . dot
  * - segments do not start or end with - hyphen
- * - segments must be longer thant zero
+ * - segments must be longer than zero
  * - lowercase a-z and digits 0-9 and - hyphen
  */
 bool is_dnsaddr(const char *arg)


### PR DESCRIPTION
My little nothing patch :)
This extends the testcase for is_dnsaddr for a case that came up in issue https://github.com/ElementsProject/lightning/issues/5657

Also fixes a typo in a comment.

Changelog-None