### PR TITLE
doc/Makefile: fix genidx (add -E, for regexp)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -196,4 +196,4 @@ doc-clean:
 	$(RM) doc/deployable-lightning.{aux,bbl,blg,dvi,log,out,tex}
 
 doc/index.rst: $(MANPAGES:=.md)
-	@$(call VERBOSE, "genidx $@",(grep -v "^   (reckless|lightning).*\.[0-9]\.md>$$" $@; for m in $$(cd doc && ls reckless.7.md lightningd*.[0-9].md lightning-*.[0-9].md); do echo "   $${m%.[0-9].md} <$$m>"; done |$(SORT)) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@)
+	@$(call VERBOSE, "genidx $@",(grep -Ev "^   (reckless|lightning).*\.[0-9]\.md>$$" $@; for m in $$(cd doc && ls reckless.7.md lightningd*.[0-9].md lightning-*.[0-9].md); do echo "   $${m%.[0-9].md} <$$m>"; done |$(SORT)) > $@.tmp.$$$$ && mv $@.tmp.$$$$ $@)


### PR DESCRIPTION
From manual page grep(1):

    -E, --extended-regexp
           Interpret PATTERNS as extended regular  expressions  (EREs,  see
           below).

There are brackets in the expression and they are not quoted.
So without -E it would be grep -v "^   \(reckless\|lightning\) ...
but as it is written now, only -E needs to be added to make it
generally valid for UNIX grep and compatibles (GNU, busybox, etc.).