### PR TITLE
Revert "lightningd: always require "jsonrpc": "2.0"  in request."

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -711,7 +711,7 @@ static void replace_command(struct rpc_command_hook_payload *p,
 			    const char *buffer,
 			    const jsmntok_t *replacetok)
 {
-	const jsmntok_t *method = NULL, *params = NULL, *jsonrpc;
+	const jsmntok_t *method = NULL, *params = NULL;
 	const char *bad;
 
 	/* Must contain "method", "params" and "id" */
@@ -743,10 +743,14 @@ static void replace_command(struct rpc_command_hook_payload *p,
 		goto fail;
 	}
 
-	jsonrpc = json_get_member(buffer, replacetok, "jsonrpc");
-	if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(buffer, jsonrpc, "2.0")) {
-		bad = "jsonrpc: \"2.0\" must be specified in the request";
-		goto fail;
+	// deprecated phase to give the possibility to all to migrate and stay safe
+	// from this more restrictive change.
+	if (!deprecated_apis) {
+		const jsmntok_t *jsonrpc = json_get_member(buffer, replacetok, "jsonrpc");
+		if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(buffer, jsonrpc, "2.0")) {
+			bad = "jsonrpc: \"2.0\" must be specified in the request";
+			goto fail;
+		}
 	}
 
 	was_pending(command_exec(p->cmd->jcon, p->cmd, buffer, replacetok,
@@ -883,7 +887,7 @@ REGISTER_PLUGIN_HOOK(rpc_command,
 static struct command_result *
 parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 {
-	const jsmntok_t *method, *id, *params, *filter, *jsonrpc;
+	const jsmntok_t *method, *id, *params, *filter;
 	struct command *c;
 	struct rpc_command_hook_payload *rpc_hook;
 	bool completed;
@@ -912,11 +916,13 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 
 	// Adding a deprecated phase to make sure that all the Core Lightning wrapper
 	// can migrate all the frameworks
-	jsonrpc = json_get_member(jcon->buffer, tok, "jsonrpc");
+	if (!deprecated_apis) {
+		const jsmntok_t *jsonrpc = json_get_member(jcon->buffer, tok, "jsonrpc");
 
-	if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(jcon->buffer, jsonrpc, "2.0")) {
-		json_command_malformed(jcon, "null", "jsonrpc: \"2.0\" must be specified in the request");
-		return NULL;
+		if (!jsonrpc || jsonrpc->type != JSMN_STRING || !json_tok_streq(jcon->buffer, jsonrpc, "2.0")) {
+			json_command_malformed(jcon, "null", "jsonrpc: \"2.0\" must be specified in the request");
+			return NULL;
+		}
 	}
 
 	/* Allocate the command off of the `jsonrpc` object and not


### PR DESCRIPTION
This reverts commit 43b037ab0b372397cecc477a50fef201b0b313ed.

@NicholasDorier says BTC Payserver still wants this for another year or so.

Changelog-Added: JSON-RPC: reverts requirement for "jsonrpc" "2.0" inside requests (still deprecated though, just for a while longer!)
Fixes: #5782 