### PR TITLE
common: fix arm32 compile breakage.

### DIFF
--- a/common/bolt12.c
+++ b/common/bolt12.c
@@ -432,7 +432,7 @@ bool bolt12_has_prefix(const char *str)
 }
 
 /* Inclusive span of tlv range >= minfield and <= maxfield */
-size_t tlv_span(const u8 *tlvstream, size_t minfield, size_t maxfield,
+size_t tlv_span(const u8 *tlvstream, u64 minfield, u64 maxfield,
 		size_t *startp)
 {
 	const u8 *cursor = tlvstream;

--- a/common/bolt12.h
+++ b/common/bolt12.h
@@ -135,7 +135,7 @@ bool bolt12_has_prefix(const char *str);
  *
  * Returns length, so 0 means nothing found.
 */
-size_t tlv_span(const u8 *tlvstream, size_t minfield, size_t maxfield,
+size_t tlv_span(const u8 *tlvstream, u64 minfield, u64 maxfield,
 		size_t *start);
 
 /* Get offer_id referred to by various structures. */


### PR DESCRIPTION
It's obviously the incorrect type, while our CI didn't catch it, Nicholas did:

```
plugins/fetchinvoice.c:1362:30: error: conversion from 'long long unsigned int' to 'size_t' {aka 'unsigned int'} changes value from '18446744073709551615' to '4294967295' [-Werror=overflow]
 1362 |      || tlv_span(wire, 1001, UINT64_MAX, NULL) != 0) {
```

Reported-by: @NicholasDorier
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>
Changelog-Fixed: Build: arm32 compiler error in fetchinvoice, due to bad types on 32-bit platforms.
Fixes: #5776