### PR TITLE
wireaddr: relax is_dnsaddr to allow for underscore in hostname

### DIFF
--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -126,11 +126,14 @@ int main(int argc, char *argv[])
 	assert(is_dnsaddr("123example.com"));
 	assert(is_dnsaddr("example123.com"));
 	assert(is_dnsaddr("is-valid.3hostname123.com"));
+	assert(is_dnsaddr("just-a-hostname-with-dashes"));
+	assert(is_dnsaddr("lightningd_dest.underscore.allowed.in.hostname.part.com"));
 	assert(!is_dnsaddr("UPPERCASE.invalid.com"));
 	assert(!is_dnsaddr("-.invalid.com"));
 	assert(!is_dnsaddr("invalid.-example.com"));
 	assert(!is_dnsaddr("invalid.example-.com"));
 	assert(!is_dnsaddr("invalid..example.com"));
+	assert(!is_dnsaddr("underscore.not.allowed.in.domain_name.com"));
 
 	/* Grossly invalid. */
 	assert(!separate_address_and_port(tmpctx, "[", &ip, &port));

--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -375,18 +375,24 @@ bool is_wildcardaddr(const char *arg)
 	return streq(arg, "");
 }
 
-/* Rules:
+/* The rules to check for DNS FQDNs, see `man 7 hostname`
  *
  * - not longer than 255
  * - segments are separated with . dot
  * - segments do not start or end with - hyphen
- * - segments must be longer thant zero
- * - lowercase a-z and digits 0-9 and - hyphen
+ * - segments must be longer than zero
+ * - allow lowercase a-z and digits 0-9 and - hyphen
+ * - additionall we allow for an '_' underscore in the hostname part.
+ *
+ * See issue #5657
+ * https://github.com/ElementsProject/lightning/issues/5657
+ * https://en.wikipedia.org/wiki/Hostname
  */
 bool is_dnsaddr(const char *arg)
 {
 	size_t i, arglen;
 	int lastdot;
+	int numdot;
 
 	if (is_ipaddr(arg) || is_toraddr(arg) || is_wildcardaddr(arg))
 		return false;
@@ -396,8 +402,10 @@ bool is_dnsaddr(const char *arg)
 	if (arglen > 255)
 		return false;
 	lastdot = -1;
+	numdot = 0;
 	for (i = 0; i < arglen; i++) {
 		if (arg[i] == '.') {
+			numdot++;
 			/* segment must be longer than zero */
 			if (i - lastdot == 1)
 				return false;
@@ -415,6 +423,9 @@ bool is_dnsaddr(const char *arg)
 		if (arg[i] >= '0' && arg[i] <= '9')
 			continue;
 		if (arg[i] == '-')
+			continue;
+		/* allow for _ underscores in the first hostname part */
+		if (arg[i] == '_' && numdot == 0)
 			continue;
 		return false;
 	}


### PR DESCRIPTION
The hostname part of a DNS FQDN can allow for additional characters other than specified in `man 7 hostname`.
This extends is_dnsaddr and the test for issue #5657.
Also fixes a typo in a comment.

Changelog-Fixed: wireaddr: #5657 allow '_' underscore in hostname part of DNS FQDN