### PR TITLE
wireaddr: allow for UpperCase DNS names

### DIFF
--- a/common/test/run-ip_port_parsing.c
+++ b/common/test/run-ip_port_parsing.c
@@ -128,8 +128,9 @@ int main(int argc, char *argv[])
 	assert(is_dnsaddr("is-valid.3hostname123.com"));
 	assert(is_dnsaddr("just-a-hostname-with-dashes"));
 	assert(is_dnsaddr("lightningd_dest.underscore.allowed.in.hostname.part.com"));
+	assert(is_dnsaddr("UpperCase.valiD.COM"));
 	assert(is_dnsaddr("punycode.xn--bcher-kva.valid.com"));
-	assert(!is_dnsaddr("UPPERCASE.invalid.com"));
+	assert(!is_dnsaddr("nonpunycode.bücher.invalid.com"));
 	assert(!is_dnsaddr("-.invalid.com"));
 	assert(!is_dnsaddr("invalid.-example.com"));
 	assert(!is_dnsaddr("invalid.example-.com"));


### PR DESCRIPTION
This further relaxes the DNS hostname checks to allow for uppercase input.

Changelog-None