### PR TITLE
add reserve to the fundchannel docs

### DIFF
--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -6,6 +6,7 @@ SYNOPSIS
 
 **fundchannel** *id* *amount* [*feerate*] [*announce*] [*minconf*]
 [*utxos*] [*push\_msat*] [*close\_to*] [*request\_amt*] [*compact\_lease*]
+[*reserve*]
 
 DESCRIPTION
 -----------
@@ -71,6 +72,11 @@ much liquidity into the channel. Must also pass in *compact\_lease*.
 *compact\_lease* is a compact represenation of the peer's expected
 channel lease terms. If the peer's terms don't match this set, we will
 fail to open the channel.
+
+*reserve* is the amount we want the peer to maintain on its side of the channel.
+Default is 1% of the funding amount. It can be a whole number, a whole number
+ending in *sat*, a whole number ending in *000msat*, or a number with 1 to 8
+decimal places ending in *btc*.
 
 
 

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -57,6 +57,10 @@ Readiness is indicated by **listpeers** reporting a *state* of
 * *compact\_lease* is a compact represenation of the peer's expected
   channel lease terms. If the peer's terms don't match this set, we will
   fail to open the channel to this destination.
+* *reserve* is the amount we want the peer to maintain on its side of the
+  channel. Default is 1% of the funding amount. It can be a whole number, a
+  whole number ending in *sat*, a whole number ending in *000msat*, or a number
+  with 1 to 8 decimal places ending in *btc*.
 
 There must be at least one entry in *destinations*;
 it cannot be an empty array.


### PR DESCRIPTION
The reserve parameter was missing from the docs. Added the parameter to FundChannel and MultiFundChannel.

I'm not sure whether I used the right format or not, please check.

The reserve parameter was added in this PR: https://github.com/ElementsProject/lightning/pull/5315

Changelog-None: doc only.