### PR TITLE
pyln: check if msat replacement works on events

### DIFF
--- a/tests/plugins/forward_payment_status.py
+++ b/tests/plugins/forward_payment_status.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """This plugin is used to check that forward_event calls are working correctly.
 """
-from pyln.client import Plugin
+from pyln.client import Millisatoshi, Plugin
 
-plugin = Plugin()
+plugin = Plugin(notification_parse_msat=True)
 
 
 @plugin.init()
@@ -13,6 +13,10 @@ def init(configuration, options, plugin):
 
 @plugin.subscribe("forward_event")
 def notify_warning(plugin, forward_event):
+    # check if pyln-client '_msat' field Millisatoshi replacement works on events
+    if type(forward_event['in_msat']) is not Millisatoshi:
+        plugin.log(f"pyln-client has not replaced _msat field as it should: {forward_event}")
+
     # One forward payment may have many notification records for different status,
     # but one forward payment has only one record in 'listforwards' eventrually.
     plugin.log("receive a forward recored, status: {}, payment_hash: {}".format(forward_event['status'], forward_event['payment_hash']))

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1341,6 +1341,9 @@ def test_forward_event_notification(node_factory, bitcoind, executor):
     bitcoind.generate_block(100)
     sync_blockheight(bitcoind, [l2])
 
+    # check if pyln-client '_msat' field Millisatoshi replacement works on events
+    assert not l2.daemon.is_in_log("pyln-client has not replaced _msat field as it should")
+
     stats = l2.rpc.listforwards()['forwards']
     assert len(stats) == 3
     plugin_stats = l2.rpc.call('listforwards_plugin')['forwards']


### PR DESCRIPTION
Modifies `Plugin()` constructor to tell it that it also should replace msat fields on notifications.