### PR TITLE
doc: replace deprecated param keyword "msatoshi" with "amount_msat"

### DIFF
--- a/doc/lightning-fetchinvoice.7.md
+++ b/doc/lightning-fetchinvoice.7.md
@@ -6,7 +6,7 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**fetchinvoice** *offer* [*msatoshi*] [*quantity*] [*recurrence\_counter*] [*recurrence\_start*] [*recurrence\_label*] [*timeout*] [*payer\_note*]
+**fetchinvoice** *offer* [*amount\_msat*] [*quantity*] [*recurrence\_counter*] [*recurrence\_start*] [*recurrence\_label*] [*timeout*] [*payer\_note*]
 
 DESCRIPTION
 -----------
@@ -21,7 +21,7 @@ cannot find a route which supports `option_onion_messages`.
 
 The offer must not contain *send\_invoice*; see lightning-sendinvoice(7).
 
-*msatoshi* is required if the *offer* does not specify
+*amount\_msat* is required if the *offer* does not specify
 an amount at all, otherwise it is not allowed.
 
 *quantity* is is required if the *offer* specifies

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -4,17 +4,17 @@ lightning-getroute -- Command for routing a payment (low-level)
 SYNOPSIS
 --------
 
-**getroute** *id* *msatoshi* *riskfactor* [*cltv*] [*fromid*]
+**getroute** *id* *amount\_msat* *riskfactor* [*cltv*] [*fromid*]
 [*fuzzpercent*] [*exclude*] [*maxhops*]
 
 DESCRIPTION
 -----------
 
 The **getroute** RPC command attempts to find the best route for the
-payment of *msatoshi* to lightning node *id*, such that the payment will
+payment of *amount\_msat* to lightning node *id*, such that the payment will
 arrive at *id* with *cltv*-blocks to spare (default 9).
 
-*msatoshi* is in millisatoshi precision; it can be a whole number, or a
+*amount\_msat* is in millisatoshi precision; it can be a whole number, or a
 whole number ending in *msat* or *sat*, or a number with three decimal
 places ending in *sat*, or a number with 1 to 11 decimal places ending
 in *btc*.
@@ -290,7 +290,7 @@ On success, an object containing **route** is returned.  It is an array of objec
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The final *id* will be the destination *id* given in the input. The
-difference between the first *msatoshi* minus the *msatoshi* given in
+difference between the first *amount\_msat* minus the *amount\_msat* given in
 the input is the fee (assuming the first hop is free). The first
 *delay* is the very worst case timeout for the payment failure, in
 blocks.

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -58,7 +58,7 @@ as a route hint candidate; if *false*, never.  If it is a short channel id
 will be considered candidates, even if they are public or dead-ends.
 
 The route hint is selected from the set of incoming channels of which:
-peer's balance minus their reserves is at least *msatoshi*, state is
+peer's balance minus their reserves is at least *amount\_msat*, state is
 normal, the peer is connected and not a dead end (i.e. has at least one
 other public channel). The selection uses some randomness to prevent
 probing, but favors channels that become more balanced after the

--- a/doc/lightning-keysend.7.md
+++ b/doc/lightning-keysend.7.md
@@ -4,7 +4,7 @@ lightning-keysend -- Send funds to a node without an invoice
 SYNOPSIS
 --------
 
-**keysend** *destination* *msatoshi* [*label*] [*maxfeepercent*] [*retry\_for*] [*maxdelay*] [*exemptfee*] [*extratlvs*]
+**keysend** *destination* *amount\_msat* [*label*] [*maxfeepercent*] [*retry\_for*] [*maxdelay*] [*exemptfee*] [*extratlvs*]
 
 DESCRIPTION
 -----------
@@ -23,7 +23,7 @@ sending a payment. Please ensure that this matches your use-case when using
 `keysend`.
 
 `destination` is the 33 byte, hex-encoded, node ID of the node that the payment should go to.
-`msatoshi` is in millisatoshi precision; it can be a whole number, or a whole number with suffix `msat` or `sat`, or a three decimal point number with suffix `sat`, or an 1 to 11 decimal point number suffixed by `btc`.
+`amount\_msat` is in millisatoshi precision; it can be a whole number, or a whole number with suffix `msat` or `sat`, or a three decimal point number with suffix `sat`, or an 1 to 11 decimal point number suffixed by `btc`.
 
 The `label` field is used to attach a label to payments, and is returned in lightning-listpays(7) and lightning-listsendpays(7).
 The `maxfeepercent` limits the money paid in fees as percentage of the total amount that is to be transferred, and defaults to *0.5*.

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -4,7 +4,7 @@ lightning-pay -- Command for sending a payment to a BOLT11 invoice
 SYNOPSIS
 --------
 
-**pay** *bolt11* [*msatoshi*] [*label*] [*riskfactor*]
+**pay** *bolt11* [*amount\_msat*] [*label*] [*riskfactor*]
 [*maxfeepercent*] [*retry\_for*] [*maxdelay*] [*exemptfee*]
 [*localinvreqid*] [*exclude*] [*maxfee*] [*description*]
 
@@ -13,8 +13,8 @@ DESCRIPTION
 
 The **pay** RPC command attempts to find a route to the given
 destination, and send the funds it asks for. If the *bolt11* does not
-contain an amount, *msatoshi* is required, otherwise if it is specified
-it must be *null*. *msatoshi* is in millisatoshi precision; it can be a
+contain an amount, *amount\_msat* is required, otherwise if it is specified
+it must be *null*. *amount\_msat* is in millisatoshi precision; it can be a
 whole number, or a whole number with suffix *msat* or *sat*, or a three
 decimal point number with suffix *sat*, or an 1 to 11 decimal point
 number suffixed by *btc*.

--- a/doc/lightning-sendinvoice.7.md
+++ b/doc/lightning-sendinvoice.7.md
@@ -6,7 +6,7 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**sendinvoice** *offer* *label* [*msatoshi*] [*timeout*] [*quantity*]
+**sendinvoice** *offer* *label* [*amount\_msat*] [*timeout*] [*quantity*]
 
 DESCRIPTION
 -----------
@@ -23,7 +23,7 @@ cannot find a route which supports `option_onion_messages`.
 
 *label* is the unique label to use for this invoice.
 
-*msatoshi* is optional: it is required if the *offer* does not specify
+*amount\_msat* is optional: it is required if the *offer* does not specify
 an amount at all, or specifies it in a different currency.  Otherwise
 you may set it (e.g. to provide a tip), and if not it defaults to the
 amount contained in the offer (multiplied by *quantity* if any).

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -5,7 +5,7 @@ SYNOPSIS
 --------
 
 **sendonion** *onion* *first\_hop* *payment\_hash* [*label*] [*shared\_secrets*] [*partid*] [*bolt11*]
-[*msatoshi*] [*destination*]
+[*amount\_msat*] [*destination*]
 
 DESCRIPTION
 -----------
@@ -84,7 +84,7 @@ The *bolt11* parameter, if provided, will be returned in
 
 The *destination* parameter, if provided, will be returned in **listpays** result.
 
-The *msatoshi* parameter is used to annotate the payment, and is returned by
+The *amount\_msat* parameter is used to annotate the payment, and is returned by
 *waitsendpay* and *listsendpays*.
 
 RETURN VALUE

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -4,7 +4,7 @@ lightning-sendpay -- Low-level command for sending a payment via a route
 SYNOPSIS
 --------
 
-**sendpay** *route* *payment\_hash* [*label*] [*msatoshi*]
+**sendpay** *route* *payment\_hash* [*label*] [*amount\_msat*]
 [*bolt11*] [*payment\_secret*] [*partid*] [*localinvreqid*] [*groupid*]
 [*payment\_metadata*] [*description*]
 
@@ -28,7 +28,7 @@ definite failure.
 The *label* and *bolt11* parameters, if provided, will be returned in
 *waitsendpay* and *listsendpays* results.
 
-The *msatoshi* amount must be provided if *partid* is non-zero, otherwise
+The *amount\_msat* amount must be provided if *partid* is non-zero, otherwise
 it must be equal to the final
 amount to the destination. By default it is in millisatoshi precision; it can be a whole number, or a whole number
 ending in *msat* or *sat*, or a number with three decimal places ending
@@ -40,10 +40,9 @@ and the `s` field in the BOLT 11 invoice format.  It is required if
 *partid* is non-zero.
 
 The *partid* value, if provided and non-zero, allows for multiple parallel
-partial payments with the same *payment\_hash*.  The *msatoshi* amount
+partial payments with the same *payment\_hash*.  The *amount\_msat* amount
 (which must be provided) for each **sendpay** with matching
 *payment\_hash* must be equal, and **sendpay** will fail if there are
-already *msatoshi* worth of payments pending.
 
 The *localinvreqid* value indicates that this payment is being made for a local
 invoice\_request: this ensures that we only send a payment for a single-use
@@ -56,9 +55,9 @@ this to identify one attempt at a MPP payment, for example.
 *payment\_metadata* is placed in the final onion hop TLV.
 
 Once a payment has succeeded, calls to **sendpay** with the same
-*payment\_hash* but a different *msatoshi* or destination will fail;
+*payment\_hash* but a different *amount\_msat* or destination will fail;
 this prevents accidental multiple payments. Calls to **sendpay** with
-the same *payment\_hash*, *msatoshi*, and destination as a previous
+the same *payment\_hash*, *amount\_msat*, and destination as a previous
 successful payment (even if a different route or *partid*) will return immediately
 with success.
 


### PR DESCRIPTION
To encourage developers to not use deprecated API's and not scare them away with faulty documentation.

I used ripgrep to see where "msatoshi" is used in doc
```
rg -Pg '*.md' -e 'msatoshi' doc/
```
and checked
```
rg -Pg '*.{c,h}' -e 'p_.*\(".*msatoshi"'
```
to see where it is used as jsonrpc input parameter, or as alias for "amount_msat"

BTW `json_sendinvoice` has no "msatoshi" alias, I guess because that command is too new.