### PR TITLE
Use `.format` method instead `f-strings` for better compatibility 

### DIFF
--- a/devtools/blockreplace.py
+++ b/devtools/blockreplace.py
@@ -38,7 +38,7 @@ comment_style = {
 def replace(filename, blockname, language, content):
     start, stop = comment_style[language]
 
-    tempfile = f"{filename}.tmp"
+    tempfile = "{}.tmp".format(filename)
 
     with open(filename, 'r') as i, open(tempfile, 'w') as o:
         lines = i.readlines()


### PR DESCRIPTION
v22.11.1 compilation failed with Python versions not support `f-strings` (< 3.6):
```
 genidx doc/index.rst
  File "devtools/blockreplace.py", line 41
    tempfile = f"{filename}.tmp"
                               ^
SyntaxError: invalid syntax
doc/Makefile:200: recipe for target 'doc/index.rst' failed
make: *** [doc/index.rst] Error 1
```

So it's better use `.format` method instead for better compatibility.