### PR TITLE
devtools: allow just to compile in old os with old python version 

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { OS: alpine }
+        OS: [alpine, ubuntu1604]
     steps:
       - uses: actions/checkout@v2
       - name: Integration testing

--- a/contrib/docker/Dockerfile.ubuntu1604
+++ b/contrib/docker/Dockerfile.ubuntu1604
@@ -1,0 +1,35 @@
+FROM ubuntu:16.04
+LABEL mantainer="Vincenzo Palazzo vincenzopalazzodev@gmail.com"
+
+WORKDIR /work
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV TZ="Europe/London"
+
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+    sudo \
+    locales \
+    tzdata
+
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY . .
+
+# install package for python cryptography lib
+# https://cryptography.io/en/latest/installation/#debian-ubuntu
+
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
+    build-essential libssl-dev libffi-dev \
+    python3-dev cargo
+
+# move the script in the root of the directory
+RUN cp contrib/docker/scripts/build.sh .
+
+CMD ["./contrib/docker/scripts/build.sh"]

--- a/devtools/blockreplace.py
+++ b/devtools/blockreplace.py
@@ -38,7 +38,7 @@ comment_style = {
 def replace(filename, blockname, language, content):
     start, stop = comment_style[language]
 
-    tempfile = f"{filename}.tmp"
+    tempfile = "{}.tmp".format(filename)
 
     with open(filename, 'r') as i, open(tempfile, 'w') as o:
         lines = i.readlines()

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -32,7 +32,7 @@ You will also need a version of bitcoind with segregated witness and `estimatesm
 To Build on Ubuntu
 ---------------------
 
-OS version: Ubuntu 15.04 or above
+OS version: Ubuntu 16.04 or above
 
 Get dependencies:
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -32,7 +32,7 @@ You will also need a version of bitcoind with segregated witness and `estimatesm
 To Build on Ubuntu
 ---------------------
 
-OS version: Ubuntu 15.10 or above
+OS version: Ubuntu 15.04 or above
 
 Get dependencies:
 


### PR DESCRIPTION
This is a PR that supports the one closed https://github.com/ElementsProject/lightning/pull/5806 
but introduce a little bit of reasoning that the author 
of a PR should (and must) do while is proposing 
a not easily reproducible change.

## Reasoning

This commit allows working around some old python version
with some historical OS like Ubuntu 16.04 that still
has a security patch (not really if they allow only running
python 3.5, but anyway).

There is no reason to support the python version, but
I do not see also any reason to stop compile
core lightning due to dev dependencies.

So, this allows the user that just wants to compile the
core lightning and nothing else. We should allow this
till the change will not make life harder for
the developers, and this is just one line of code.

If this is the only change that Ubuntu 16.04 required to
compile the core lightning, I think we can support it because
there is no extra work from our point of view.

There are open questions like, how this OS can handle python plugins
but I think this is not our problem, till we do not require to run 
a python plugin with the default core lightning.

The PR https://github.com/ElementsProject/lightning/pull/5806  
contains all the good reasons to not support python 3.5 or 
older in developer mode, but from the feedback through 
github messages I think the author of the PR want 
just compile and nothing else.

However, this is my own interpretation and also I do not test if this is the only 
change required to compile, because I did not test it with ubuntu 16.04