### PR TITLE
common/test: fix typo in bolt12 test vector generation.

### DIFF
--- a/common/test/run-bolt12_merkle.c
+++ b/common/test/run-bolt12_merkle.c
@@ -421,7 +421,7 @@ int main(int argc, char *argv[])
 	json_out("],");
 	json_out("\"merkle\": \"%s\",",
 		 type_to_string(tmpctx, struct sha256, m));
-	json_out("\"signature_tag\": \"lightninginvoicerequestsignature\",");
+	json_out("\"signature_tag\": \"lightninginvoice_requestsignature\",");
 	json_out("\"H(signature_tag,merkle)\": \"%s\",", type_to_string(tmpctx, struct sha256, &sha));
 	json_out("\"signature\": \"%s\"", type_to_string(tmpctx, struct bip340sig, invreq->signature));
 	json_out("}]");


### PR DESCRIPTION
Reported-by: @jkczyz
Changelog-None

See: https://github.com/lightning/bolts/pull/798#discussion_r1033660687