### PR TITLE
connectd: don't ask DNS seeds for addresses on every reconnect.

### DIFF
--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -50,6 +50,7 @@ msgdata,connectd_connect_to_peer,id,node_id,
 msgdata,connectd_connect_to_peer,len,u32,
 msgdata,connectd_connect_to_peer,addrs,wireaddr,len
 msgdata,connectd_connect_to_peer,addrhint,?wireaddr_internal,
+msgdata,connectd_connect_to_peer,dns_fallback,bool,
 
 # Connectd->master: connect failed.
 msgtype,connectd_connect_failed,2020


### PR DESCRIPTION
We were stressing the servers if node cannot be found.  Only do lookup on manual connect commands.