### PR TITLE
Keep channel announcements when pruning channels

### DIFF
--- a/common/gossip_store.h
+++ b/common/gossip_store.h
@@ -40,6 +40,11 @@ struct gossip_rcvd_filter;
 #define GOSSIP_STORE_LEN_RATELIMIT_BIT 0x20000000U
 
 /**
+ * Bit used to mark a channel announcement as inactive (needs channel updates.)
+ */
+#define GOSSIP_STORE_LEN_ZOMBIE_BIT 0x10000000U
+
+/**
  * Full flags mask
  */
 #define GOSSIP_STORE_FLAGS_MASK 0xFFFF0000U

--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -620,6 +620,9 @@ static bool map_catchup(struct gossmap *map, size_t *num_rejected)
 		if (be32_to_cpu(ghdr.len) & GOSSIP_STORE_LEN_DELETED_BIT)
 			continue;
 
+		if (be32_to_cpu(ghdr.len) & GOSSIP_STORE_LEN_ZOMBIE_BIT)
+			continue;
+
 		/* Partial write, this can happen. */
 		if (map->map_end + reclen > map->map_size)
 			break;

--- a/devtools/dump-gossipstore.c
+++ b/devtools/dump-gossipstore.c
@@ -12,7 +12,7 @@
 
 /* Current versions we support */
 #define GSTORE_MAJOR 0
-#define GSTORE_MINOR 10
+#define GSTORE_MINOR 12
 
 int main(int argc, char *argv[])
 {
@@ -67,12 +67,13 @@ int main(int argc, char *argv[])
 		struct short_channel_id scid;
 		u32 msglen = be32_to_cpu(hdr.len);
 		u8 *msg, *inner;
-		bool deleted, push, ratelimit;
+		bool deleted, push, ratelimit, zombie;
 		u32 blockheight;
 
 		deleted = (msglen & GOSSIP_STORE_LEN_DELETED_BIT);
 		push = (msglen & GOSSIP_STORE_LEN_PUSH_BIT);
 		ratelimit = (msglen & GOSSIP_STORE_LEN_RATELIMIT_BIT);
+		zombie = (msglen & GOSSIP_STORE_LEN_ZOMBIE_BIT);
 
 		msglen &= GOSSIP_STORE_LEN_MASK;
 		msg = tal_arr(NULL, u8, msglen);
@@ -83,10 +84,11 @@ int main(int argc, char *argv[])
 		    != crc32c(be32_to_cpu(hdr.timestamp), msg, msglen))
 			warnx("Checksum verification failed");
 
-		printf("%zu: %s%s%s", off,
+		printf("%zu: %s%s%s%s", off,
 		       deleted ? "DELETED " : "",
 		       push ? "PUSH " : "",
-		       ratelimit ? "RATE-LIMITED " : "");
+		       ratelimit ? "RATE-LIMITED " : "",
+		       zombie ? "ZOMBIE " : "");
 		if (print_timestamp)
 			printf("T=%u ", be32_to_cpu(hdr.timestamp));
 		if (deleted && !print_deleted) {

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -339,7 +339,8 @@ static void update_own_node_announcement_after_startup(struct daemon *daemon)
 static void force_self_nannounce_regen(struct daemon *daemon)
 {
 	struct node *self = get_node(daemon->rstate, &daemon->id);
-
+	/* Clear timer pointer now. */
+	daemon->node_announce_regen_timer = NULL;
 	/* No channels left?  We'll restart timer once we have one. */
 	if (!self || !self->bcast.index)
 		return;

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -66,6 +66,20 @@ void gossip_store_delete(struct gossip_store *gs,
 void gossip_store_mark_channel_deleted(struct gossip_store *gs,
 				       const struct short_channel_id *scid);
 
+/*
+ * Marks the length field of a channel announcement with a zombie flag bit.
+ * This allows the channel_announcement to be retained in the store while
+ * waiting for channel updates to reactivate it.
+ */
+void gossip_store_mark_channel_zombie(struct gossip_store *gs,
+				      struct broadcastable *bcast);
+
+void gossip_store_mark_cupdate_zombie(struct gossip_store *gs,
+				      struct broadcastable *bcast);
+
+void gossip_store_mark_nannounce_zombie(struct gossip_store *gs,
+					struct broadcastable *bcast);
+
 /**
  * Direct store accessor: loads gossip msg back from store.
  *

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -41,11 +41,13 @@ u64 gossip_store_add_private_update(struct gossip_store *gs, const u8 *update);
  * @timestamp: the timestamp for filtering of this messsage.
  * @push: true if this should be sent to peers despite any timestamp filters.
  * @spam: true if this message is rate-limited and squelched to peers.
+ * @zombie: true if this channel is missing a current channel_update.
  * @addendum: another message to append immediately after this
  *            (for appending amounts to channel_announcements for internal use).
  */
 u64 gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg,
-		     u32 timestamp, bool push, bool spam, const u8 *addendum);
+		     u32 timestamp, bool push, bool zombie, bool spam,
+		     const u8 *addendum);
 
 
 /**

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -322,17 +322,30 @@ static void handle_local_private_channel(struct daemon *daemon, const u8 *msg)
 	u8 *features;
 	struct short_channel_id scid;
 	const u8 *cannounce;
+	struct chan *zombie;
 
 	if (!fromwire_gossipd_local_private_channel(msg, msg,
 						    &id, &capacity, &scid,
 						    &features))
 		master_badmsg(WIRE_GOSSIPD_LOCAL_PRIVATE_CHANNEL, msg);
 
+	status_debug("received private channel announcement from channeld for %s",
+		     type_to_string(tmpctx, struct short_channel_id, &scid));
 	cannounce = private_channel_announcement(tmpctx,
 						 &scid,
 						 &daemon->id,
 						 &id,
 						 features);
+	/* If there is already a zombie announcement for this channel in the
+	 * store we can disregard this one. */
+	zombie = get_channel(daemon->rstate, &scid);
+	if (zombie && (zombie->half[0].zombie || zombie->half[1].zombie)){
+		status_debug("received channel announcement for %s,"
+			     " but it is a zombie; discarding",
+			     type_to_string(tmpctx, struct short_channel_id,
+				            &scid));
+		return;
+	}
 
 	if (!routing_add_private_channel(daemon->rstate, &id, capacity,
 					 cannounce, 0)) {

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -3,6 +3,7 @@
 #include <bitcoin/script.h>
 #include <ccan/array_size/array_size.h>
 #include <ccan/tal/str/str.h>
+#include <common/gossip_store.h>
 #include <common/memleak.h>
 #include <common/pseudorand.h>
 #include <common/status.h>
@@ -394,6 +395,25 @@ static bool node_has_public_channels(struct node *node)
 	return false;
 }
 
+static bool is_chan_zombie(struct chan *chan)
+{
+	if (chan->half[0].zombie || chan->half[1].zombie)
+		return true;
+	return false;
+}
+
+static bool is_node_zombie(struct node* node)
+{
+	struct chan_map_iter i;
+	struct chan *c;
+
+	for (c = first_chan(node, &i); c; c = next_chan(node, &i)) {
+		if (!is_chan_zombie(c))
+			return false;
+	}
+	return true;
+}
+
 /* We can *send* a channel_announce for a channel attached to this node:
  * we only send once we have a channel_update. */
 static bool node_has_broadcastable_channels(struct node *node)
@@ -404,8 +424,8 @@ static bool node_has_broadcastable_channels(struct node *node)
 	for (c = first_chan(node, &i); c; c = next_chan(node, &i)) {
 		if (!is_chan_public(c))
 			continue;
-		if (is_halfchan_defined(&c->half[0])
-		    || is_halfchan_defined(&c->half[1]))
+		if ((is_halfchan_defined(&c->half[0])
+		    || is_halfchan_defined(&c->half[1])) && !is_chan_zombie(c))
 			return true;
 	}
 	return false;
@@ -444,6 +464,7 @@ static void force_node_announce_rexmit(struct routing_state *rstate,
 					     node->bcast.timestamp,
 					     is_local,
 					     false,
+					     false,
 					     NULL);
 	if (node->rgraph.index == initial_bcast_index){
 		node->rgraph.index = node->bcast.index;
@@ -456,6 +477,7 @@ static void force_node_announce_rexmit(struct routing_state *rstate,
 						      announce,
 						      node->rgraph.timestamp,
 						      is_local,
+						      false,
 						      false,
 						      NULL);
 	}
@@ -553,6 +575,7 @@ static void init_half_chan(struct routing_state *rstate,
 	broadcastable_init(&c->bcast);
 	broadcastable_init(&c->rgraph);
 	c->tokens = TOKEN_MAX;
+	c->zombie = false;
 }
 
 static void bad_gossip_order(const u8 *msg,
@@ -824,6 +847,7 @@ static void add_channel_announce_to_broadcast(struct routing_state *rstate,
 						     chan->bcast.timestamp,
 						     is_local,
 						     false,
+						     false,
 						     addendum);
 	rstate->local_channel_announced |= is_local;
 }
@@ -859,8 +883,9 @@ static void delete_chan_messages_from_store(struct routing_state *rstate,
 static void remove_channel_from_store(struct routing_state *rstate,
 				      struct chan *chan)
 {
-	/* Put in tombstone marker */
-	gossip_store_mark_channel_deleted(rstate->gs, &chan->scid);
+	/* Put in tombstone marker. Zombie channels will have one already. */
+	if (!is_chan_zombie(chan))
+		gossip_store_mark_channel_deleted(rstate->gs, &chan->scid);
 
 	/* Now delete old entries. */
 	delete_chan_messages_from_store(rstate, chan);
@@ -1290,6 +1315,31 @@ static void delete_spam_update(struct routing_state *rstate,
 	hc->rgraph.timestamp = hc->bcast.timestamp;
 }
 
+static void resurrect_nannouncements(struct routing_state *rstate,
+				     struct chan *chan)
+{
+	const u8 *zombie_nann = NULL;
+	for (int i = 0; i < 2; i++) {
+		struct node *node = chan->nodes[i];
+		/* Use the most recent announcement (could be spam.) */
+		zombie_nann = gossip_store_get(tmpctx, rstate->gs,
+					       node->rgraph.index);
+		/* If there was a spam entry, delete them both. */
+		if (node->bcast.index != node->rgraph.index)
+			gossip_store_delete(rstate->gs, &node->bcast,
+					    WIRE_NODE_ANNOUNCEMENT);
+		gossip_store_delete(rstate->gs, &node->rgraph,
+				    WIRE_NODE_ANNOUNCEMENT);
+		node->bcast.index = gossip_store_add(rstate->gs, zombie_nann,
+						     node->rgraph.timestamp,
+						     local_direction(rstate,
+								     chan, NULL),
+						     false, false, NULL);
+		node->bcast.timestamp = node->rgraph.timestamp;
+		node->rgraph.index = node->bcast.index;
+	}
+}
+
 bool routing_add_channel_update(struct routing_state *rstate,
 				const u8 *update TAKES,
 				u32 index,
@@ -1312,6 +1362,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 	u8 direction;
 	struct amount_sat sat;
 	bool spam;
+	bool zombie;
 
 	/* Make sure we own msg, even if we don't save it. */
 	if (taken(update))
@@ -1332,6 +1383,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 	if (chan) {
 		uc = NULL;
 		sat = chan->sat;
+		zombie = is_chan_zombie(chan);
 	} else {
 		/* Maybe announcement was waiting for this update? */
 		uc = get_unupdated_channel(rstate, &short_channel_id);
@@ -1339,6 +1391,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 			return false;
 		}
 		sat = uc->sat;
+		zombie = false;
 	}
 
 	/* Reject update if the `htlc_maximum_msat` is greater
@@ -1468,6 +1521,75 @@ bool routing_add_channel_update(struct routing_state *rstate,
 		return true;
 	}
 
+	/* Handle resurrection of zombie channels if the other side of the
+	 * zombie channel has a recent timestamp. */
+	if (zombie && timestamp_reasonable(rstate,
+		chan->half[!direction].bcast.timestamp)) {
+		status_peer_debug(peer ? &peer->id : NULL,
+				  "Resurrecting zombie channel %s.",
+				  type_to_string(tmpctx,
+						 struct short_channel_id,
+						 &chan->scid));
+		const u8 *zombie_announcement = NULL;
+		const u8 *zombie_addendum = NULL;
+		const u8 *zombie_update[2] = {NULL, NULL};
+		/* Resurrection is a careful process. First delete the zombie-
+		 * flagged channel_announcement which has already been
+		 * tombstoned, and re-add to the store without zombie flag. */
+		zombie_announcement = gossip_store_get(tmpctx, rstate->gs,
+						       chan->bcast.index);
+		u32 offset = tal_count(zombie_announcement) +
+			sizeof(struct gossip_hdr);
+		/* The channel_announcement addendum reminds us of its size. */
+		zombie_addendum = gossip_store_get(tmpctx, rstate->gs,
+						   chan->bcast.index + offset);
+		gossip_store_delete(rstate->gs, &chan->bcast,
+				    is_chan_public(chan)
+				    ? WIRE_CHANNEL_ANNOUNCEMENT
+				    : WIRE_GOSSIP_STORE_PRIVATE_CHANNEL);
+		chan->bcast.index =
+			gossip_store_add(rstate->gs, zombie_announcement,
+					 chan->bcast.timestamp,
+					 local_direction(rstate, chan, NULL),
+					 false, false, zombie_addendum);
+		/* Deletion of the old addendum is optional. */
+		/* This opposing channel_update has been stashed away.  Now that
+		 * there are two valid updates, this one gets restored. */
+		/* FIXME: Handle spam case probably needs a helper f'n */
+		zombie_update[0] = gossip_store_get(tmpctx, rstate->gs,
+			chan->half[!direction].bcast.index);
+		if (chan->half[!direction].bcast.index != chan->half[!direction].rgraph.index)
+			/* Don't forget the spam channel_update */
+			zombie_update[1] = gossip_store_get(tmpctx, rstate->gs,
+				chan->half[!direction].rgraph.index);
+		gossip_store_delete(rstate->gs, &chan->half[!direction].bcast,
+				    is_chan_public(chan)
+				    ? WIRE_CHANNEL_UPDATE
+				    : WIRE_GOSSIP_STORE_PRIVATE_UPDATE);
+		chan->half[!direction].bcast.index =
+			gossip_store_add(rstate->gs, zombie_update[0],
+					 chan->half[!direction].bcast.timestamp,
+					 local_direction(rstate, chan, NULL),
+					 false, false, NULL);
+		if (zombie_update[1])
+			chan->half[!direction].rgraph.index =
+				gossip_store_add(rstate->gs, zombie_update[1],
+						 chan->half[!direction].rgraph.timestamp,
+						 local_direction(rstate, chan, NULL),
+						 false, true, NULL);
+		else
+			chan->half[!direction].rgraph.index = chan->half[!direction].bcast.index;
+
+		/* If we caught any node_announcements for fully zombie nodes
+		 * (no remaining active channels) handle those as well. */
+		resurrect_nannouncements(rstate, chan);
+
+		/* It's a miracle! */
+		chan->half[0].zombie = false;
+		chan->half[1].zombie = false;
+		zombie = false;
+	}
+
 	/* If we're loading from store, this means we don't re-add to store. */
 	if (index) {
 		if (!spam)
@@ -1477,7 +1599,7 @@ bool routing_add_channel_update(struct routing_state *rstate,
 		hc->rgraph.index
 			= gossip_store_add(rstate->gs, update, timestamp,
 					   local_direction(rstate, chan, NULL),
-					   spam, NULL);
+					   zombie, spam, NULL);
 		if (hc->bcast.timestamp > rstate->last_timestamp
 		    && hc->bcast.timestamp < time_now().ts.tv_sec)
 			rstate->last_timestamp = hc->bcast.timestamp;
@@ -1673,7 +1795,8 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 
 	node = get_node(rstate, &node_id);
 
-	if (node == NULL || !node_has_broadcastable_channels(node)) {
+	if (node == NULL || (!node_has_broadcastable_channels(node) &&
+	    !is_node_zombie(node))) {
 		struct pending_node_announce *pna;
 		/* BOLT #7:
 		 *
@@ -1797,7 +1920,7 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 			= gossip_store_add(rstate->gs, msg, timestamp,
 					   node_id_eq(&node_id,
 						      &rstate->local_id),
-					   false, spam, NULL);
+					   is_node_zombie(node), spam, NULL);
 		if (node->bcast.timestamp > rstate->last_timestamp
 		    && node->bcast.timestamp < time_now().ts.tv_sec)
 			rstate->last_timestamp = node->bcast.timestamp;
@@ -1901,6 +2024,43 @@ u8 *handle_node_announcement(struct routing_state *rstate, const u8 *node_ann,
 	return NULL;
 }
 
+/* Set zombie flags in gossip_store and tombstone the channel for any
+ * gossip_store consumers. Remove any orphaned node_announcements. */
+static void zombify_channel(struct gossip_store *gs, struct chan *channel)
+{
+	struct half_chan *half;
+	assert(!is_chan_zombie(channel));
+	gossip_store_mark_channel_zombie(gs, &channel->bcast);
+	gossip_store_mark_channel_deleted(gs, &channel->scid);
+	for (int i = 0; i < 2; i++) {
+		half = &channel->half[i];
+		half->zombie = true;
+		if (half->bcast.index) {
+			gossip_store_mark_cupdate_zombie(gs, &half->bcast);
+			/* Channel may also have a spam entry */
+			if (half->bcast.index != half->rgraph.index)
+				gossip_store_mark_cupdate_zombie(gs, &half->rgraph);
+		}
+	}
+	status_debug("Channel %s zombified",
+		     type_to_string(tmpctx, struct short_channel_id,
+				    &channel->scid));
+
+	/* If one of the nodes has no remaining active channels, the
+	 * node_announcement should also be stashed. */
+	for (int i = 0; i < 2; i++) {
+		struct node *node = channel->nodes[i];
+		if (!is_node_zombie(node) || !node->bcast.index)
+			continue;
+		if (node->rgraph.index != node->bcast.index)
+			gossip_store_mark_nannounce_zombie(gs, &node->rgraph);
+		gossip_store_mark_nannounce_zombie(gs, &node->bcast);
+		status_debug("Node %s zombified",
+			     type_to_string(tmpctx, struct node_id,
+					    &node->id));
+	}
+}
+
 void route_prune(struct routing_state *rstate)
 {
 	u64 now = gossip_time_now(rstate).ts.tv_sec;
@@ -1915,6 +2075,9 @@ void route_prune(struct routing_state *rstate)
 	     chan = uintmap_after(&rstate->chanmap, &idx)) {
 		/* Local-only?  Don't prune. */
 		if (!is_chan_public(chan))
+			continue;
+		/* These have been pruned already */
+		if (is_chan_zombie(chan))
 			continue;
 
 		/* BOLT #7:
@@ -1951,10 +2114,12 @@ void route_prune(struct routing_state *rstate)
 		}
 	}
 
-	/* Now free all the chans and maybe even nodes. */
+	/* Any channels missing an update are now considered zombies. They may
+	 * come back later, in which case the channel_announcement needs to be
+	 * stashed away for later use. If all remaining channels for a node are
+	 * zombies, the node is zombified too. */
 	for (size_t i = 0; i < tal_count(pruned); i++) {
-		remove_channel_from_store(rstate, pruned[i]);
-		free_chan(rstate, pruned[i]);
+		zombify_channel(rstate->gs, pruned[i]);
 	}
 }
 

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1797,7 +1797,7 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 			= gossip_store_add(rstate->gs, msg, timestamp,
 					   node_id_eq(&node_id,
 						      &rstate->local_id),
-					   spam, NULL);
+					   false, spam, NULL);
 		if (node->bcast.timestamp > rstate->last_timestamp
 		    && node->bcast.timestamp < time_now().ts.tv_sec)
 			rstate->last_timestamp = node->bcast.timestamp;
@@ -2023,7 +2023,8 @@ bool routing_add_private_channel(struct routing_state *rstate,
 		u8 *msg = towire_gossip_store_private_channel(tmpctx,
 							      capacity,
 							      chan_ann);
-		index = gossip_store_add(rstate->gs, msg, 0, false, false, NULL);
+		index = gossip_store_add(rstate->gs, msg, 0, false, false,
+					 false, NULL);
 	}
 	chan->bcast.index = index;
 	return true;
@@ -2168,7 +2169,7 @@ void routing_channel_spent(struct routing_state *rstate,
 
 	/* Save to gossip_store in case we restart */
 	msg = towire_gossip_store_chan_dying(tmpctx, &chan->scid, deadline);
-	index = gossip_store_add(rstate->gs, msg, 0, false, false, NULL);
+	index = gossip_store_add(rstate->gs, msg, 0, false, false, false, NULL);
 
 	/* Remember locally so we can kill it in 12 blocks */
 	status_debug("channel %s closing soon due"

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -29,6 +29,9 @@ struct half_chan {
 
 	/* Token bucket */
 	u8 tokens;
+
+	/* Disabled channel waiting for a channel_update from both sides. */
+	bool zombie;
 };
 
 struct chan {

--- a/gossipd/test/run-check_channel_announcement.c
+++ b/gossipd/test/run-check_channel_announcement.c
@@ -86,6 +86,18 @@ const u8 *gossip_store_get_private_update(const tal_t *ctx UNNEEDED,
 void gossip_store_mark_channel_deleted(struct gossip_store *gs UNNEEDED,
 				       const struct short_channel_id *scid UNNEEDED)
 { fprintf(stderr, "gossip_store_mark_channel_deleted called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_channel_zombie */
+void gossip_store_mark_channel_zombie(struct gossip_store *gs UNNEEDED,
+				      struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_channel_zombie called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_cupdate_zombie */
+void gossip_store_mark_cupdate_zombie(struct gossip_store *gs UNNEEDED,
+				      struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_cupdate_zombie called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_nannounce_zombie */
+void gossip_store_mark_nannounce_zombie(struct gossip_store *gs UNNEEDED,
+					struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_nannounce_zombie called!\n"); abort(); }
 /* Generated stub for gossip_store_new */
 struct gossip_store *gossip_store_new(struct routing_state *rstate UNNEEDED,
 				      struct list_head *peers UNNEEDED)

--- a/gossipd/test/run-check_channel_announcement.c
+++ b/gossipd/test/run-check_channel_announcement.c
@@ -61,7 +61,8 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool spam UNNEEDED, const u8 *addendum UNNEEDED)
+		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */
 u64 gossip_store_add_private_update(struct gossip_store *gs UNNEEDED, const u8 *update UNNEEDED)

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -32,7 +32,8 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool spam UNNEEDED, const u8 *addendum UNNEEDED)
+		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */
 u64 gossip_store_add_private_update(struct gossip_store *gs UNNEEDED, const u8 *update UNNEEDED)

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -57,6 +57,18 @@ const u8 *gossip_store_get_private_update(const tal_t *ctx UNNEEDED,
 void gossip_store_mark_channel_deleted(struct gossip_store *gs UNNEEDED,
 				       const struct short_channel_id *scid UNNEEDED)
 { fprintf(stderr, "gossip_store_mark_channel_deleted called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_channel_zombie */
+void gossip_store_mark_channel_zombie(struct gossip_store *gs UNNEEDED,
+				      struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_channel_zombie called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_cupdate_zombie */
+void gossip_store_mark_cupdate_zombie(struct gossip_store *gs UNNEEDED,
+				      struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_cupdate_zombie called!\n"); abort(); }
+/* Generated stub for gossip_store_mark_nannounce_zombie */
+void gossip_store_mark_nannounce_zombie(struct gossip_store *gs UNNEEDED,
+					struct broadcastable *bcast UNNEEDED)
+{ fprintf(stderr, "gossip_store_mark_nannounce_zombie called!\n"); abort(); }
 /* Generated stub for memleak_add_helper_ */
 void memleak_add_helper_(const tal_t *p UNNEEDED, void (*cb)(struct htable *memtable UNNEEDED,
 						    const tal_t *)){ }

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1159,7 +1159,7 @@ def test_gossip_store_load(node_factory):
     """Make sure we can read canned gossip store"""
     l1 = node_factory.get_node(start=False)
     with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'), 'wb') as f:
-        f.write(bytearray.fromhex("0a"        # GOSSIP_STORE_VERSION
+        f.write(bytearray.fromhex("0c"        # GOSSIP_STORE_VERSION
                                   "000001b0"  # len
                                   "fea676e8"  # csum
                                   "5b8d9b44"  # timestamp
@@ -1217,7 +1217,7 @@ def test_gossip_store_load_announce_before_update(node_factory):
     """Make sure we can read canned gossip store with node_announce before update.  This happens when a channel_update gets replaced, leaving node_announce before it"""
     l1 = node_factory.get_node(start=False)
     with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'), 'wb') as f:
-        f.write(bytearray.fromhex("0a"        # GOSSIP_STORE_VERSION
+        f.write(bytearray.fromhex("0c"        # GOSSIP_STORE_VERSION
                                   "000001b0"  # len
                                   "fea676e8"  # csum
                                   "5b8d9b44"  # timestamp
@@ -1262,7 +1262,7 @@ def test_gossip_store_load_amount_truncated(node_factory):
     """Make sure we can read canned gossip store with truncated amount"""
     l1 = node_factory.get_node(start=False, allow_broken_log=True)
     with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'), 'wb') as f:
-        f.write(bytearray.fromhex("0a"        # GOSSIP_STORE_VERSION
+        f.write(bytearray.fromhex("0c"        # GOSSIP_STORE_VERSION
                                   "000001b0"  # len
                                   "fea676e8"  # csum
                                   "5b8d9b44"  # timestamp
@@ -1727,7 +1727,7 @@ def test_gossip_store_load_no_channel_update(node_factory):
 
     # A channel announcement with no channel_update.
     with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'), 'wb') as f:
-        f.write(bytearray.fromhex("0b"        # GOSSIP_STORE_VERSION
+        f.write(bytearray.fromhex("0c"        # GOSSIP_STORE_VERSION
                                   "000001b0"  # len
                                   "fea676e8"  # csum
                                   "5b8d9b44"  # timestamp
@@ -1754,7 +1754,7 @@ def test_gossip_store_load_no_channel_update(node_factory):
     l1.rpc.call('dev-compact-gossip-store')
 
     with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'), "rb") as f:
-        assert bytearray(f.read()) == bytearray.fromhex("0b")
+        assert bytearray(f.read()) == bytearray.fromhex("0c")
 
 
 @pytest.mark.developer("gossip without DEVELOPER=1 is slow")

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2226,7 +2226,6 @@ def test_gossip_private_updates(node_factory, bitcoind):
 
 
 @pytest.mark.developer("Needs --dev-fast-gossip, --dev-fast-gossip-prune")
-@pytest.mark.xfail(strict=True)
 def test_channel_resurrection(node_factory, bitcoind):
     """When a node goes offline long enough to prune a channel, the
     channel_announcement should be retained in case the node comes back online.


### PR DESCRIPTION
BOLT 7 allows pruning channels when one side's `channel_update` expires.  This results in the `channel_announcement` being deleted.  When the offline node sends a new `channel_update`, the `channel_announcement` will be unavailable and the channel is not reestablished.

Here instead of being deleted entirely, the channel is zombified: the `channel_announcement` is maintained along with the still relevant `channel_update` in case the expired `channel_update` is ever refreshed.  These are marked with a zombie bit in the gossip store so that they are available to gossipd, but ignored by gossmap and other consumers.  In the case that all channels of a node become zombies, the node_announcement is tagged as well.

Two valid `channel_update`s will resurrect a channel (and possibly a node), deleting the zombie tagged gossip entries and replacing them with fresh entries.

Changelog-Fixed: Pruned channels are more reliably restored.