### PR TITLE
ipdiscovery on/off/auto bool switch

### DIFF
--- a/ccan/ccan/opt/helpers.c
+++ b/ccan/ccan/opt/helpers.c
@@ -49,6 +49,30 @@ char *opt_set_bool_arg(const char *arg, bool *b)
 	return opt_invalid_argument(arg);
 }
 
+char *opt_set_autobool_arg(const char *arg, enum opt_autobool *b)
+{
+	if (!strcasecmp(arg, "yes") ||
+	    !strcasecmp(arg, "true") ||
+	    !strcasecmp(arg, "on") ||
+	    !strcasecmp(arg, "1")) {
+		*b = OPT_AUTOBOOL_ON;
+		return NULL;
+	}
+	if (!strcasecmp(arg, "no") ||
+	    !strcasecmp(arg, "false") ||
+	    !strcasecmp(arg, "off") ||
+	    !strcasecmp(arg, "0")) {
+		*b = OPT_AUTOBOOL_OFF;
+		return NULL;
+	}
+	if (!strcasecmp(arg, "auto") ||
+	    !strcasecmp(arg, "default")) {
+		*b = OPT_AUTOBOOL_AUTO;
+		return NULL;
+	}
+	return opt_invalid_argument(arg);
+}
+
 char *opt_set_invbool_arg(const char *arg, bool *b)
 {
 	char *err = opt_set_bool_arg(arg, b);
@@ -210,6 +234,21 @@ void opt_show_bool(char buf[OPT_SHOW_LEN], const bool *b)
 void opt_show_invbool(char buf[OPT_SHOW_LEN], const bool *b)
 {
 	strncpy(buf, *b ? "false" : "true", OPT_SHOW_LEN);
+}
+
+void opt_show_autobool(char buf[OPT_SHOW_LEN], const enum opt_autobool *b)
+{
+	switch (*b) {
+	case OPT_AUTOBOOL_ON:
+		strncpy(buf, "true", OPT_SHOW_LEN);
+		break;
+	case OPT_AUTOBOOL_OFF:
+		strncpy(buf, "false", OPT_SHOW_LEN);
+		break;
+	case OPT_AUTOBOOL_AUTO:
+	default:
+		strncpy(buf, "auto", OPT_SHOW_LEN);
+	}
 }
 
 void opt_show_charp(char buf[OPT_SHOW_LEN], char *const *p)

--- a/ccan/ccan/opt/helpers.c
+++ b/ccan/ccan/opt/helpers.c
@@ -35,9 +35,15 @@ char *opt_set_invbool(bool *b)
 
 char *opt_set_bool_arg(const char *arg, bool *b)
 {
-	if (!strcasecmp(arg, "yes") || !strcasecmp(arg, "true"))
+	if (!strcasecmp(arg, "yes") ||
+	    !strcasecmp(arg, "true") ||
+	    !strcasecmp(arg, "on") ||
+	    !strcasecmp(arg, "1"))
 		return opt_set_bool(b);
-	if (!strcasecmp(arg, "no") || !strcasecmp(arg, "false"))
+	if (!strcasecmp(arg, "no") ||
+	    !strcasecmp(arg, "false") ||
+	    !strcasecmp(arg, "off") ||
+	    !strcasecmp(arg, "0"))
 		return opt_set_invbool(b);
 
 	return opt_invalid_argument(arg);

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -441,7 +441,7 @@ void opt_show_bool(char buf[OPT_SHOW_LEN], const bool *b);
 /* The inverse */
 char *opt_set_invbool(bool *b);
 void opt_show_invbool(char buf[OPT_SHOW_LEN], const bool *b);
-/* Sets @b based on !arg: (yes/no/true/false). */
+/* Sets @b based on !arg: (yes/no/true/false/on/off/1/0). */
 char *opt_set_invbool_arg(const char *arg, bool *b);
 
 /* Set a char *. */

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -444,6 +444,14 @@ void opt_show_invbool(char buf[OPT_SHOW_LEN], const bool *b);
 /* Sets @b based on !arg: (yes/no/true/false/on/off/1/0). */
 char *opt_set_invbool_arg(const char *arg, bool *b);
 
+enum opt_autobool {
+	OPT_AUTOBOOL_OFF = 0,
+	OPT_AUTOBOOL_ON = 1,
+	OPT_AUTOBOOL_AUTO = 2,
+};
+char *opt_set_autobool_arg(const char *arg, enum opt_autobool *b);
+void opt_show_autobool(char buf[OPT_SHOW_LEN], const enum opt_autobool *b);
+
 /* Set a char *. */
 char *opt_set_charp(const char *arg, char **p);
 void opt_show_charp(char buf[OPT_SHOW_LEN], char *const *p);

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -375,7 +375,7 @@ use the RPC call lightning-setchannel(7).
 the discovered IP with TCP port 9735 as announced address. If unset and you
 open TCP port 9735 on your router towords your node, your node will remain
 connectable on changing IP addresses.  Note: Will always be disabled if you use
-'always-use-proxy'.
+'always-use-proxy'. (DEPRECATED)
 
 ### Lightning channel and HTLC options
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -361,6 +361,14 @@ RPC call lightning-setchannel(7).
 channels. If you want to change the `htlc_maximum_msat` for existing channels,
 use the RPC call lightning-setchannel(7).
 
+* **ip-discovery**=*BOOL*
+
+  Explicitly turn 'on' or 'off' public IP discovery to send `node_announcement`
+  updates that contain the discovered IP with TCP port 9735 as announced address.
+  Default: 'auto' - Only if we don't have anything else to announce.
+  Note: You also need to open TCP port 9735 on your router towords your node.
+  Note: Will always be disabled if you use 'always-use-proxy'.
+
 * **disable-ip-discovery**
 
   Turn off public IP discovery to send `node_announcement` updates that contain

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -44,8 +44,9 @@ static u8 *create_node_announcement(const tal_t *ctx, struct daemon *daemon,
 		tal_arr_expand(&was, daemon->announceable[i]);
 
 	/* Add discovered IPs v4/v6 verified by peer `remote_addr` feature. */
-	/* Only do that if we don't have addresses announced. */
-	if (count_announceable == 0) {
+	/* Only do that if we don't have any addresses announced or
+	 * `config.ip_discovery` is explicitly enabled. */
+	if (count_announceable == 0 || daemon->ip_discovery) {
 		if (daemon->discovered_ip_v4 != NULL &&
 		    !wireaddr_arr_contains(was, daemon->discovered_ip_v4))
 			tal_arr_expand(&was, *daemon->discovered_ip_v4);

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -380,8 +380,9 @@ static void handle_discovered_ip(struct daemon *daemon, const u8 *msg)
 	return;
 
 update_node_annoucement:
-	status_debug("Update our node_announcement for discovered address: %s",
-		     fmt_wireaddr(tmpctx, &discovered_ip));
+	if (daemon->ip_discovery)
+		status_debug("Update our node_announcement for discovered address: %s",
+			     fmt_wireaddr(tmpctx, &discovered_ip));
 	maybe_send_own_node_announce(daemon, false);
 }
 
@@ -727,7 +728,8 @@ static void gossip_init(struct daemon *daemon, const u8 *msg)
 				     &daemon->announceable,
 				     &dev_gossip_time,
 				     &dev_fast_gossip,
-				     &dev_fast_gossip_prune)) {
+				     &dev_fast_gossip_prune,
+				     &daemon->ip_discovery)) {
 		master_badmsg(WIRE_GOSSIPD_INIT, msg);
 	}
 
@@ -1096,6 +1098,7 @@ int main(int argc, char *argv[])
 	daemon->rates = NULL;
 	daemon->discovered_ip_v4 = NULL;
 	daemon->discovered_ip_v6 = NULL;
+	daemon->ip_discovery = false;
 	list_head_init(&daemon->deferred_updates);
 
 	/* Tell the ecdh() function how to talk to hsmd */

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -51,6 +51,7 @@ struct daemon {
 	/* verified remote_addr as reported by recent peers */
 	struct wireaddr *discovered_ip_v4;
 	struct wireaddr *discovered_ip_v6;
+	bool ip_discovery;
 
 	/* Timer until we can send an updated node_announcement */
 	struct oneshot *node_announce_timer;

--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -16,6 +16,7 @@ msgdata,gossipd_init,announceable,wireaddr,num_announceable
 msgdata,gossipd_init,dev_gossip_time,?u32,
 msgdata,gossipd_init,dev_fast_gossip,bool,
 msgdata,gossipd_init,dev_fast_gossip_prune,bool,
+msgdata,gossipd_init,ip_discovery,bool,
 
 msgtype,gossipd_init_reply,3100
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -262,7 +262,8 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    ld->announceable,
 	    IFDEV(ld->dev_gossip_time ? &ld->dev_gossip_time: NULL, NULL),
 	    IFDEV(ld->dev_fast_gossip, false),
-	    IFDEV(ld->dev_fast_gossip_prune, false));
+	    IFDEV(ld->dev_fast_gossip_prune, false),
+	    ld->config.ip_discovery);
 
 	subd_req(ld->gossip, ld->gossip, take(msg), -1, 0,
 		 gossipd_init_done, NULL);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -60,6 +60,7 @@ struct config {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	enum opt_autobool ip_discovery;
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	bool disable_ip_discovery;
 
 	/* Minimal amount of effective funding_satoshis for accepting channels */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #define LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #include "config.h"
+#include <ccan/ccan/opt/opt.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
 #include <signal.h>
@@ -56,6 +57,8 @@ struct config {
 	/* Are we allowed to use DNS lookup for peers. */
 	bool use_dns;
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	enum opt_autobool ip_discovery;
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	bool disable_ip_discovery;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -811,6 +811,7 @@ static const struct config testnet_config = {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
@@ -879,6 +880,7 @@ static const struct config mainnet_config = {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
@@ -1049,6 +1051,14 @@ static char *opt_set_db_upgrade(const char *arg, struct lightningd *ld)
 	return opt_set_bool_arg(arg, ld->db_upgrade_ok);
 }
 
+static char *opt_disable_ip_discovery(struct lightningd *ld)
+{
+	log_broken(ld->log, "--disable-ip-discovery has been deprecated, use --ip-discovery");
+	if (!deprecated_apis)
+		return "--disable-ip-discovery has been deprecated, use --ip-discovery";
+	return opt_set_bool(&ld->config.disable_ip_discovery);
+}
+
 static void register_opts(struct lightningd *ld)
 {
 	/* This happens before plugins started */
@@ -1181,9 +1191,8 @@ static void register_opts(struct lightningd *ld)
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
 
-	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
-			 &ld->config.disable_ip_discovery,
-			 "Turn off announcement of discovered public IPs");
+	opt_register_noarg("--disable-ip-discovery", opt_disable_ip_discovery, ld,
+			 "Turn off announcement of discovered public IPs. (DEPRECATED)");
 	opt_register_arg("--ip-discovery", opt_set_autobool_arg, opt_show_autobool,
 			 &ld->config.ip_discovery,
 			 "Explicitly turns IP discovery 'on' or 'off'.");

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -808,6 +808,8 @@ static const struct config testnet_config = {
 
 	.use_dns = true,
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -874,6 +876,8 @@ static const struct config mainnet_config = {
 
 	.use_dns = true,
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -1176,9 +1180,13 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--announce-addr", opt_add_announce_addr, NULL,
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
+
 	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
 			 &ld->config.disable_ip_discovery,
 			 "Turn off announcement of discovered public IPs");
+	opt_register_arg("--ip-discovery", opt_set_autobool_arg, opt_show_autobool,
+			 &ld->config.ip_discovery,
+			 "Explicitly turns IP discovery 'on' or 'off'.");
 
 	opt_register_noarg("--offline", opt_set_offline, ld,
 			   "Start in offline-mode (do not automatically reconnect and do not accept incoming connections)");


### PR DESCRIPTION
This adds a `--ip-discovery` 'autobool' switch which is a bool with a default value.
Can be used to explicitly turn on ip discovery.
Useful for example when a user has TOR only as fallback and wants IP discovery
to have a more effective way of connecting.

Currently without this patch, when having at least one usable address (the TOR one) IP discovery is disabled.