### PR TITLE
ipdiscovery: adds autobool config switch

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -72,9 +72,13 @@ Note that if you already have a channel open to them, you'll need to close it be
 There is no risk to your channels if your IP address changes.
 Other nodes might not be able to connect to you, but your node can still connect to them.
 But Core Lightning also has an integrated IPv4/6 address discovery mechanism.
-If your node detects an new public address, it will update its announcement.
+If your node detects an new public address, it can update its announcement.
 For this to work binhind a NAT router you need to forward the default TCP port 9735 to your node.
-IP discovery is only active if no other addresses are announced.
+
+Note: Per default and for privacy reasons IP discovery will only be active
+if no other addresses would be announced (as kind of a fallback).
+You can set `--announce-addr-discovered=true` to explicitly activate it.
+Your node will then update discovered IP addresses even if it also announces e.g. a TOR address.
 
 Alternatively, you can [setup a TOR hidden service](TOR.md) for your node that
 will also work well behind NAT firewalls.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -206,14 +206,19 @@ doc/index.rst: $(MANPAGES:=.md)
 	)
 
 # For CI to (very roughly!) check that we only deprecated fields, or labelled added ones
-
-# So GitHub renamed master to main.  This is painful.
+# When running on GitHub (CI=true), we need to fetch origin/master
 schema-added-check:
-	@if ! git describe master >/dev/null 2>&1; then MASTER=main; else MASTER=master; fi; if git diff $$MASTER doc/schemas | grep -q '^+.*{' && ! git diff master doc/schemas | grep -q '^+.*"added"'; then echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; fi
-
-# So GitHub renamed master to main.  This is painful.
+	@if ! test -z $$CI; then git fetch origin master; fi; \
+	if git diff origin/master -- doc/schemas | grep -q '^+.*{' && ! git diff origin/master -- doc/schemas | grep -q '^+.*"added"'; then \
+		git diff origin/master -- doc/schemas; \
+		echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; \
+	fi
 schema-removed-check:
-	@if ! git describe master >/dev/null 2>&1; then MASTER=main; else MASTER=master; fi; if git diff $$MASTER doc/schemas | grep -q '^-.*{' && ! git diff master doc/schemas | grep -q '^-.*"deprecated": "'; then echo 'Schema fields must be deprecated, with version, not removed' >&2; exit 1; fi
+	@if ! test -z $$CI; then git fetch origin master; fi; \
+	if git diff origin/master -- doc/schemas | grep -q '^-.*{' && ! git diff origin/master -- doc/schemas | grep -q '^-.*"deprecated"'; then \
+		git diff origin/master -- doc/schemas ; \
+		echo 'Schema fields must be "deprecated", with version, not removed' >&2; exit 1; \
+	fi
 
 schema-diff-check: schema-added-check schema-removed-check
 

--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -48,9 +48,14 @@ network between you and the Internet, as long as you can use Tor you can
 be connected to.
 
 Note: Core Lightning also support IPv4/6 address discovery behind NAT routers.
-For this to work you need to forward the default TCP port 9735 to your node.
+If your node detects an new public address, it can update its announcement.
+For this to work you need to forward the TCP port 9735 on your NAT router to your node.
 In this case you don't need TOR to punch through your firewall.
-IP discovery is only active if no other addresses are announced.
+
+Note: Per default and for privacy reasons IP discovery will only be active
+if no other addresses would be announced (as kind of a fallback).
+You can set `--announce-addr-discovered=true` to explicitly activate it.
+Your node will then update discovered IP addresses even if it also announces e.g. a TOR address.
 This usually has the benefit of quicker and more stable connections but does not
 offer additional privacy.
 

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -88,7 +88,8 @@ On success, an object is returned, containing:
 - **autolisten** (boolean, optional): `autolisten` field from config or cmdline, or default
 - **proxy** (string, optional): `proxy` field from config or cmdline, or default
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
-- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline
+- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline (DEPRECATED)
+- **ip-discovery** (string, optional): `true` if `ip-discovery` was set in config or cmdline
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
 - **log-level** (string, optional): `log-level` field from config or cmdline, or default

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -89,7 +89,7 @@ On success, an object is returned, containing:
 - **proxy** (string, optional): `proxy` field from config or cmdline, or default
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
 - **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline (DEPRECATED)
-- **ip-discovery** (string, optional): `true` if `ip-discovery` was set in config or cmdline
+- **announce-addr-discovered** (string, optional): `true`/`false`/`auto` depending on how `announce-addr-discovered` was set in config or cmdline *(added v23.02)*
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
 - **log-level** (string, optional): `log-level` field from config or cmdline, or default
@@ -221,4 +221,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:bc7c3374ba6609553f431deae62c1e5525e136086b39fffb6c674a58365c0740)
+[comment]: # ( SHA256STAMP:fcf5e537989d9df2cf2031ff6b7589cc1d6acc30a81806e7ecedb3265b8c9b3b)

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -88,7 +88,7 @@ On success, an object is returned, containing:
 - **autolisten** (boolean, optional): `autolisten` field from config or cmdline, or default
 - **proxy** (string, optional): `proxy` field from config or cmdline, or default
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
-- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline (DEPRECATED)
+- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline **deprecated, removal in v23.11**
 - **announce-addr-discovered** (string, optional): `true`/`false`/`auto` depending on how `announce-addr-discovered` was set in config or cmdline *(added v23.02)*
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
@@ -221,4 +221,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:fcf5e537989d9df2cf2031ff6b7589cc1d6acc30a81806e7ecedb3265b8c9b3b)
+[comment]: # ( SHA256STAMP:9953b3545acb82bed816b86a65ba51ff4b043d3848c4a3ae460aa68db1a4b542)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -368,14 +368,6 @@ use the RPC call lightning-setchannel(7).
   Note: You also need to open TCP port 9735 on your router towords your node.
   Note: Will always be disabled if you use 'always-use-proxy'.
 
-* **disable-ip-discovery**
-
-  Turn off public IP discovery to send `node_announcement` updates that contain
-the discovered IP with TCP port 9735 as announced address. If unset and you
-open TCP port 9735 on your router towords your node, your node will remain
-connectable on changing IP addresses.  Note: Will always be disabled if you use
-'always-use-proxy'.
-
 ### Lightning channel and HTLC options
 
 * **large-channels**

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -361,6 +361,13 @@ RPC call lightning-setchannel(7).
 channels. If you want to change the `htlc_maximum_msat` for existing channels,
 use the RPC call lightning-setchannel(7).
 
+* **announce-addr-discovered**=*BOOL*
+
+  Explicitly control the usage of discovered public IPs in `node_announcement` updates.
+  Default: 'auto' - Only if we don't have anything else to announce.
+  Note: You also need to open TCP port 9735 on your router towords your node.
+  Note: Will always be disabled if you use 'always-use-proxy'.
+
 * **disable-ip-discovery**
 
   Turn off public IP discovery to send `node_announcement` updates that contain

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -245,7 +245,8 @@
     },
     "disable-ip-discovery": {
       "type": "boolean",
-      "description": "`true` if `disable-ip-discovery` was set in config or cmdline"
+      "description": "`true` if `disable-ip-discovery` was set in config or cmdline",
+      "deprecated": "v23.02"
     },
     "announce-addr-discovered": {
       "type": "string",

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -247,6 +247,11 @@
       "type": "boolean",
       "description": "`true` if `disable-ip-discovery` was set in config or cmdline"
     },
+    "announce-addr-discovered": {
+      "type": "string",
+      "description": "`true`/`false`/`auto` depending on how `announce-addr-discovered` was set in config or cmdline",
+      "added": "v23.02"
+    },
     "encrypted-hsm": {
       "type": "boolean",
       "description": "`true` if `encrypted-hsm` was set in config or cmdline"

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <ccan/asort/asort.h>
 #include <ccan/cast/cast.h>
+#include <ccan/ccan/opt/opt.h>
 #include <ccan/mem/mem.h>
 #include <common/daemon_conn.h>
 #include <common/features.h>
@@ -44,8 +45,10 @@ static u8 *create_node_announcement(const tal_t *ctx, struct daemon *daemon,
 		tal_arr_expand(&was, daemon->announceable[i]);
 
 	/* Add discovered IPs v4/v6 verified by peer `remote_addr` feature. */
-	/* Only do that if we don't have addresses announced. */
-	if (count_announceable == 0) {
+	/* Only do that if we don't have any addresses announced or
+	 * `config.ip_discovery` is explicitly enabled. */
+	if ((daemon->ip_discovery == OPT_AUTOBOOL_AUTO && count_announceable == 0) ||
+	     daemon->ip_discovery == OPT_AUTOBOOL_TRUE) {
 		if (daemon->discovered_ip_v4 != NULL &&
 		    !wireaddr_arr_contains(was, daemon->discovered_ip_v4))
 			tal_arr_expand(&was, *daemon->discovered_ip_v4);

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_GOSSIPD_GOSSIPD_H
 #define LIGHTNING_GOSSIPD_GOSSIPD_H
 #include "config.h"
+#include <ccan/ccan/opt/opt.h>
 #include <ccan/timer/timer.h>
 #include <common/node_id.h>
 #include <lightningd/options.h>
@@ -52,6 +53,7 @@ struct daemon {
 	/* verified remote_addr as reported by recent peers */
 	struct wireaddr *discovered_ip_v4;
 	struct wireaddr *discovered_ip_v6;
+	enum opt_autobool ip_discovery;
 
 	/* Timer until we can send an updated node_announcement */
 	struct oneshot *node_announce_timer;

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <ccan/timer/timer.h>
 #include <common/node_id.h>
+#include <lightningd/options.h>
 #include <wire/peer_wire.h>
 
 /* We talk to `hsmd` to sign our gossip messages with the node key */

--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -16,6 +16,7 @@ msgdata,gossipd_init,announceable,wireaddr,num_announceable
 msgdata,gossipd_init,dev_gossip_time,?u32,
 msgdata,gossipd_init,dev_fast_gossip,bool,
 msgdata,gossipd_init,dev_fast_gossip_prune,bool,
+msgdata,gossipd_init,ip_discovery,u32,
 
 msgtype,gossipd_init_reply,3100
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -262,7 +262,8 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    ld->announceable,
 	    IFDEV(ld->dev_gossip_time ? &ld->dev_gossip_time: NULL, NULL),
 	    IFDEV(ld->dev_fast_gossip, false),
-	    IFDEV(ld->dev_fast_gossip_prune, false));
+	    IFDEV(ld->dev_fast_gossip_prune, false),
+	    ld->config.ip_discovery);
 
 	subd_req(ld->gossip, ld->gossip, take(msg), -1, 0,
 		 gossipd_init_done, NULL);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -69,7 +69,6 @@
 #include <lightningd/io_loop_with_timers.h>
 #include <lightningd/lightningd.h>
 #include <lightningd/onchain_control.h>
-#include <lightningd/options.h>
 #include <lightningd/plugin.h>
 #include <lightningd/subd.h>
 #include <sys/resource.h>

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #define LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #include "config.h"
+#include <ccan/ccan/opt/opt.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
 #include <lightningd/options.h>
@@ -58,6 +59,8 @@ struct config {
 	/* Are we allowed to use DNS lookup for peers. */
 	bool use_dns;
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	enum opt_autobool ip_discovery;
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	bool disable_ip_discovery;
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
+#include <lightningd/options.h>
 #include <lightningd/peer_control.h>
 #include <signal.h>
 #include <sys/stat.h>

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -61,8 +61,6 @@ struct config {
 
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	enum opt_autobool ip_discovery;
-	/* Turn off IP address announcement discovered via peer `remote_addr` */
-	bool disable_ip_discovery;
 
 	/* Minimal amount of effective funding_satoshis for accepting channels */
 	u64 min_capacity_sat;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -843,6 +843,8 @@ static const struct config testnet_config = {
 
 	.use_dns = true,
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -909,6 +911,8 @@ static const struct config mainnet_config = {
 
 	.use_dns = true,
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	.ip_discovery = OPT_AUTOBOOL_AUTO,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -1211,9 +1215,13 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--announce-addr", opt_add_announce_addr, NULL,
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
+
 	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
 			 &ld->config.disable_ip_discovery,
 			 "Turn off announcement of discovered public IPs");
+	opt_register_arg("--announce-addr-discovered", opt_set_autobool_arg, opt_show_autobool,
+			 &ld->config.ip_discovery,
+			 "Explicitly turns IP discovery 'on' or 'off'.");
 
 	opt_register_noarg("--offline", opt_set_offline, ld,
 			   "Start in offline-mode (do not automatically reconnect and do not accept incoming connections)");

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -102,6 +102,41 @@ static char *opt_set_s32(const char *arg, s32 *u)
 	return NULL;
 }
 
+char *opt_set_autobool_arg(const char *arg, enum opt_autobool *b)
+{
+	if (!strcasecmp(arg, "yes") ||
+	    !strcasecmp(arg, "true")) {
+		*b = OPT_AUTOBOOL_TRUE;
+		return NULL;
+	}
+	if (!strcasecmp(arg, "no") ||
+	    !strcasecmp(arg, "false")) {
+		*b = OPT_AUTOBOOL_FALSE;
+		return NULL;
+	}
+	if (!strcasecmp(arg, "auto") ||
+	    !strcasecmp(arg, "default")) {
+		*b = OPT_AUTOBOOL_AUTO;
+		return NULL;
+	}
+	return opt_invalid_argument(arg);
+}
+
+void opt_show_autobool(char buf[OPT_SHOW_LEN], const enum opt_autobool *b)
+{
+	switch (*b) {
+	case OPT_AUTOBOOL_TRUE:
+		strncpy(buf, "true", OPT_SHOW_LEN);
+		break;
+	case OPT_AUTOBOOL_FALSE:
+		strncpy(buf, "false", OPT_SHOW_LEN);
+		break;
+	case OPT_AUTOBOOL_AUTO:
+	default:
+		strncpy(buf, "auto", OPT_SHOW_LEN);
+	}
+}
+
 static char *opt_set_mode(const char *arg, mode_t *m)
 {
 	char *endp;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -845,8 +845,6 @@ static const struct config testnet_config = {
 
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
-	/* Turn off IP address announcement discovered via peer `remote_addr` */
-	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
@@ -913,8 +911,6 @@ static const struct config mainnet_config = {
 
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
-	/* Turn off IP address announcement discovered via peer `remote_addr` */
-	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
@@ -1084,6 +1080,13 @@ static char *opt_set_db_upgrade(const char *arg, struct lightningd *ld)
 	return opt_set_bool_arg(arg, ld->db_upgrade_ok);
 }
 
+static char *opt_disable_ip_discovery(struct lightningd *ld)
+{
+	log_broken(ld->log, "--disable-ip-discovery has been deprecated, use --announce-addr-discovered=false");
+	ld->config.ip_discovery = OPT_AUTOBOOL_FALSE;
+	return NULL;
+}
+
 static void register_opts(struct lightningd *ld)
 {
 	/* This happens before plugins started */
@@ -1216,9 +1219,7 @@ static void register_opts(struct lightningd *ld)
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
 
-	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
-			 &ld->config.disable_ip_discovery,
-			 "Turn off announcement of discovered public IPs");
+	opt_register_noarg("--disable-ip-discovery", opt_disable_ip_discovery, ld, opt_hidden);
 	opt_register_arg("--announce-addr-discovered", opt_set_autobool_arg, opt_show_autobool,
 			 &ld->config.ip_discovery,
 			 "Explicitly turns IP discovery 'on' or 'off'.");

--- a/lightningd/options.h
+++ b/lightningd/options.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_OPTIONS_H
 #define LIGHTNING_LIGHTNINGD_OPTIONS_H
 #include "config.h"
+#include <ccan/ccan/opt/opt.h>
 
 struct lightningd;
 
@@ -12,5 +13,13 @@ void handle_opts(struct lightningd *ld, int argc, char *argv[]);
 
 /* Derive default color and alias from the pubkey. */
 void setup_color_and_alias(struct lightningd *ld);
+
+enum opt_autobool {
+	OPT_AUTOBOOL_FALSE = 0,
+	OPT_AUTOBOOL_TRUE = 1,
+	OPT_AUTOBOOL_AUTO = 2,
+};
+char *opt_set_autobool_arg(const char *arg, enum opt_autobool *b);
+void opt_show_autobool(char buf[OPT_SHOW_LEN], const enum opt_autobool *b);
 
 #endif /* LIGHTNING_LIGHTNINGD_OPTIONS_H */

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1308,7 +1308,8 @@ static void update_remote_addr(struct lightningd *ld,
 	u16 public_port;
 
 	/* failsafe to prevent privacy leakage. */
-	if (ld->always_use_proxy || ld->config.disable_ip_discovery)
+	if (ld->always_use_proxy ||
+	    ld->config.ip_discovery == OPT_AUTOBOOL_FALSE)
 		return;
 
 	/* Peers will have likey reported our dynamic outbound TCP port.

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2383,10 +2383,10 @@ static struct command_result *json_getinfo(struct command *cmd,
 		for (size_t i = 0; i < count_announceable; i++)
 			json_add_address(response, NULL, cmd->ld->announceable+i);
 
-		/* Currently, IP discovery will only be announced by gossipd,
-		 * if we don't already have usable addresses.
-		 * See `create_node_announcement` in `gossip_generation.c`. */
-		if (count_announceable == 0) {
+		/* Add discovered IPs if we announce them.
+		 * Also see `create_node_announcement` in `gossip_generation.c`. */
+		if ((cmd->ld->config.ip_discovery == OPT_AUTOBOOL_AUTO && count_announceable == 0) ||
+		     cmd->ld->config.ip_discovery == OPT_AUTOBOOL_TRUE) {
 			if (cmd->ld->discovered_ip_v4 != NULL &&
 					!wireaddr_arr_contains(
 						cmd->ld->announceable,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -74,7 +74,7 @@ def test_remote_addr(node_factory, bitcoind):
     opts = {'may_reconnect': True,
             'dev-allow-localhost': None,
             'dev-no-reconnect': None,
-            'ip-discovery': True}
+            'announce-addr-discovered': True}
     l1, l2, l3 = node_factory.get_nodes(3, opts)
 
     # Disable announcing local autobind addresses with dev-allow-localhost.
@@ -156,7 +156,7 @@ def test_remote_addr_disabled(node_factory, bitcoind):
         l1 --> [l2] <-- l3
     """
     opts = {'dev-allow-localhost': None,
-            'disable-ip-discovery': None,
+            'announce-addr-discovered': False,
             'may_reconnect': True,
             'dev-no-reconnect': None}
     l1, l2, l3 = node_factory.get_nodes(3, opts=[opts, opts, opts])
@@ -165,24 +165,26 @@ def test_remote_addr_disabled(node_factory, bitcoind):
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
     l1.fundchannel(l2)
-    bitcoind.generate_block(5)
+    bitcoind.generate_block(6)
     l1.daemon.wait_for_log(f"Received node_announcement for node {l2.info['id']}")
     # l2->l3
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
     l2.fundchannel(l3)
-    bitcoind.generate_block(5)
+    bitcoind.generate_block(6)
+    l3.daemon.wait_for_log(f"Received node_announcement for node {l2.info['id']}")
 
     # restart both and wait for channels to be ready
     l1.restart()
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.daemon.wait_for_log("Already have funding locked in")
+    l2.daemon.wait_for_log(f"{l1.info['id']}.*Already have funding locked in")
     l3.restart()
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.daemon.wait_for_log("Already have funding locked in")
+    l2.daemon.wait_for_log(f"{l3.info['id']}.*Already have funding locked in")
 
     # if ip discovery would have been enabled, we would have send an updated
     # node_annoucement by now. Check we didn't...
+    bitcoind.generate_block(6)  # ugly, but we need to wait for gossip...
     assert not l2.daemon.is_in_log("Update our node_announcement for discovered address")
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -73,7 +73,8 @@ def test_remote_addr(node_factory, bitcoind):
     # don't announce anything per se
     opts = {'may_reconnect': True,
             'dev-allow-localhost': None,
-            'dev-no-reconnect': None}
+            'dev-no-reconnect': None,
+            'ip-discovery': True}
     l1, l2, l3 = node_factory.get_nodes(3, opts)
 
     # Disable announcing local autobind addresses with dev-allow-localhost.


### PR DESCRIPTION
This adds an 'AUTOBOOL' config switch that explicitly enables the IP discovery feature by `announce-addr-discovered`, as users may also want to have IP discovery plus TOR just as fallback to increase overall connectivity.

Currently its still a bit tricky to use IP discovery as one need to disable any usable addresses i.e. by binding just to a specific interface and configure without TOR. This will enable 'default' behavior: when there are no usable addresses try ip discovery. Without this trick, when a node finds just a single (a likely changing IP address), it will announce this forever and IP discovery is disabled and never rechecks addresses bound to initially.

If unset, the default/auto behavior stays the same, meaning only do IP discovery when there are no usable addresses.

**NOTE: there is a simpler version of this PR in #5843 that does the same but without the `autobool`, thus defaulting to disabled IP discovery.**