### PR TITLE
ipdiscovery: adds custom port parameter

### DIFF
--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -90,6 +90,7 @@ On success, an object is returned, containing:
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
 - **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline **deprecated, removal in v23.11**
 - **announce-addr-discovered** (string, optional): `true`/`false`/`auto` depending on how `announce-addr-discovered` was set in config or cmdline *(added v23.02)*
+- **announce-addr-discovered-port** (integer, optional): Sets the announced TCP port for dynamically discovered IPs. *(added v23.02)*
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
 - **log-level** (string, optional): `log-level` field from config or cmdline, or default
@@ -221,4 +222,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:9953b3545acb82bed816b86a65ba51ff4b043d3848c4a3ae460aa68db1a4b542)
+[comment]: # ( SHA256STAMP:2f325aa6ef0506dc627409e3253c8627c49a7d1749ea9dbf24a5baa0fc8c307c)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -368,6 +368,11 @@ use the RPC call lightning-setchannel(7).
   Note: You also need to open TCP port 9735 on your router towords your node.
   Note: Will always be disabled if you use 'always-use-proxy'.
 
+* **announce-addr-discovered-port**
+  Sets the public TCP port to use for announcing dynamically discovered IPs.
+  If unset, this defaults to the selected networks lightning port,
+  which is 9735 on mainnet.
+
 ### Lightning channel and HTLC options
 
 * **large-channels**

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -253,6 +253,11 @@
       "description": "`true`/`false`/`auto` depending on how `announce-addr-discovered` was set in config or cmdline",
       "added": "v23.02"
     },
+    "announce-addr-discovered-port": {
+      "type": "integer",
+      "description": "Sets the announced TCP port for dynamically discovered IPs.",
+      "added": "v23.02"
+    },
     "encrypted-hsm": {
       "type": "boolean",
       "description": "`true` if `encrypted-hsm` was set in config or cmdline"

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -62,6 +62,9 @@ struct config {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	enum opt_autobool ip_discovery;
 
+	/* Public TCP port assumed for IP discovery. Defaults to chainparams. */
+	u32 ip_discovery_port;
+
 	/* Minimal amount of effective funding_satoshis for accepting channels */
 	u64 min_capacity_sat;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -846,6 +846,9 @@ static const struct config testnet_config = {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
 
+	/* Public TCP port assumed for IP discovery. Defaults to chainparams. */
+	.ip_discovery_port = 0,
+
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
 
@@ -911,6 +914,9 @@ static const struct config mainnet_config = {
 
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	.ip_discovery = OPT_AUTOBOOL_AUTO,
+
+	/* Public TCP port assumed for IP discovery. Defaults to chainparams. */
+	.ip_discovery_port = 0,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
 	.min_capacity_sat = 10000,
@@ -1223,6 +1229,9 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--announce-addr-discovered", opt_set_autobool_arg, opt_show_autobool,
 			 &ld->config.ip_discovery,
 			 "Explicitly turns IP discovery 'on' or 'off'.");
+	opt_register_arg("--announce-addr-discovered-port", opt_set_uintval,
+			 opt_show_uintval, &ld->config.ip_discovery_port,
+			 "Sets the public TCP port to use for announcing discovered IPs.");
 
 	opt_register_noarg("--offline", opt_set_offline, ld,
 			   "Start in offline-mode (do not automatically reconnect and do not accept incoming connections)");
@@ -1426,6 +1435,9 @@ void handle_early_opts(struct lightningd *ld, int argc, char *argv[])
 		ld->config = testnet_config;
 	else
 		ld->config = mainnet_config;
+
+	/* Set the ln_port given from chainparams */
+	ld->config.ip_discovery_port = chainparams->ln_port;
 
 	/* Now we can initialize wallet_dsn */
 	ld->wallet_dsn = tal_fmt(ld, "sqlite3://%s/lightningd.sqlite3",

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1305,17 +1305,10 @@ static void update_remote_addr(struct lightningd *ld,
 			       const struct wireaddr *remote_addr,
 			       const struct node_id peer_id)
 {
-	u16 public_port;
-
 	/* failsafe to prevent privacy leakage. */
 	if (ld->always_use_proxy ||
 	    ld->config.ip_discovery == OPT_AUTOBOOL_FALSE)
 		return;
-
-	/* Peers will have likey reported our dynamic outbound TCP port.
-	 * Best guess is that we use default port for the selected network,
-	 * until we add a commandline switch to override this. */
-	public_port = chainparams_get_ln_port(chainparams);
 
 	switch (remote_addr->type) {
 	case ADDR_TYPE_IPV4:
@@ -1334,7 +1327,7 @@ static void update_remote_addr(struct lightningd *ld,
 		if (wireaddr_eq_without_port(ld->remote_addr_v4, remote_addr)) {
 			ld->discovered_ip_v4 = tal_dup(ld, struct wireaddr,
 						       ld->remote_addr_v4);
-			ld->discovered_ip_v4->port = public_port;
+			ld->discovered_ip_v4->port = ld->config.ip_discovery_port;
 			subd_send_msg(ld->gossip, towire_gossipd_discovered_ip(
 							  tmpctx,
 							  ld->discovered_ip_v4));
@@ -1357,7 +1350,7 @@ static void update_remote_addr(struct lightningd *ld,
 		if (wireaddr_eq_without_port(ld->remote_addr_v6, remote_addr)) {
 			ld->discovered_ip_v6 = tal_dup(ld, struct wireaddr,
 						       ld->remote_addr_v6);
-			ld->discovered_ip_v6->port = public_port;
+			ld->discovered_ip_v6->port = ld->config.ip_discovery_port;
 			subd_send_msg(ld->gossip, towire_gossipd_discovered_ip(
 							  tmpctx,
 							  ld->discovered_ip_v6));


### PR DESCRIPTION
This adds a config option `--announce-addr-discovered-port` that can set a non default port when using IP discovery on `node_announcement` updates. Currently and without this only the selected networks default port will be used.