### PR TITLE
ipdiscovery: adds bool config switch

### DIFF
--- a/ccan/ccan/opt/helpers.c
+++ b/ccan/ccan/opt/helpers.c
@@ -35,9 +35,15 @@ char *opt_set_invbool(bool *b)
 
 char *opt_set_bool_arg(const char *arg, bool *b)
 {
-	if (!strcasecmp(arg, "yes") || !strcasecmp(arg, "true"))
+	if (!strcasecmp(arg, "yes") ||
+	    !strcasecmp(arg, "true") ||
+	    !strcasecmp(arg, "on") ||
+	    !strcasecmp(arg, "1"))
 		return opt_set_bool(b);
-	if (!strcasecmp(arg, "no") || !strcasecmp(arg, "false"))
+	if (!strcasecmp(arg, "no") ||
+	    !strcasecmp(arg, "false") ||
+	    !strcasecmp(arg, "off") ||
+	    !strcasecmp(arg, "0"))
 		return opt_set_invbool(b);
 
 	return opt_invalid_argument(arg);

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -435,13 +435,13 @@ extern const char opt_hidden[];
 /* Standard helpers.  You can write your own: */
 /* Sets the @b to true. */
 char *opt_set_bool(bool *b);
-/* Sets @b based on arg: (yes/no/true/false). */
+/* Sets @b based on arg: (yes/no/true/false/on/off/1/0). */
 char *opt_set_bool_arg(const char *arg, bool *b);
 void opt_show_bool(char buf[OPT_SHOW_LEN], const bool *b);
 /* The inverse */
 char *opt_set_invbool(bool *b);
 void opt_show_invbool(char buf[OPT_SHOW_LEN], const bool *b);
-/* Sets @b based on !arg: (yes/no/true/false). */
+/* Sets @b based on !arg: (yes/no/true/false/on/off/1/0). */
 char *opt_set_invbool_arg(const char *arg, bool *b);
 
 /* Set a char *. */

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -72,9 +72,10 @@ Note that if you already have a channel open to them, you'll need to close it be
 There is no risk to your channels if your IP address changes.
 Other nodes might not be able to connect to you, but your node can still connect to them.
 But Core Lightning also has an integrated IPv4/6 address discovery mechanism.
-If your node detects an new public address, it will update its announcement.
-For this to work binhind a NAT router you need to forward the default TCP port 9735 to your node.
-IP discovery is only active if no other addresses are announced.
+If your node detects an new public address, it can update its announcement.
+
+Note: IP discovery needs to be activated using the `--ip-discovery=true` switch.
+You also need to forward the TCP port 9735 on your NAT router to your node.
 
 Alternatively, you can [setup a TOR hidden service](TOR.md) for your node that
 will also work well behind NAT firewalls.

--- a/doc/TOR.md
+++ b/doc/TOR.md
@@ -48,9 +48,10 @@ network between you and the Internet, as long as you can use Tor you can
 be connected to.
 
 Note: Core Lightning also support IPv4/6 address discovery behind NAT routers.
-For this to work you need to forward the default TCP port 9735 to your node.
+If your node detects an new public address, it can update its announcement.
+IP discovery needs to be activated using the `--ip-discovery=true` switch.
+You also need to forward the default TCP port 9735 on your NAT router to your node.
 In this case you don't need TOR to punch through your firewall.
-IP discovery is only active if no other addresses are announced.
 This usually has the benefit of quicker and more stable connections but does not
 offer additional privacy.
 

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -89,6 +89,7 @@ On success, an object is returned, containing:
 - **proxy** (string, optional): `proxy` field from config or cmdline, or default
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
 - **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline
+- **ip-discovery** (boolean, optional): `true` if `ip-discovery` was set in config or cmdline
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
 - **log-level** (string, optional): `log-level` field from config or cmdline, or default

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -88,7 +88,7 @@ On success, an object is returned, containing:
 - **autolisten** (boolean, optional): `autolisten` field from config or cmdline, or default
 - **proxy** (string, optional): `proxy` field from config or cmdline, or default
 - **disable-dns** (boolean, optional): `true` if `disable-dns` was set in config or cmdline
-- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline
+- **disable-ip-discovery** (boolean, optional): `true` if `disable-ip-discovery` was set in config or cmdline (DEPRECATED)
 - **ip-discovery** (boolean, optional): `true` if `ip-discovery` was set in config or cmdline
 - **encrypted-hsm** (boolean, optional): `true` if `encrypted-hsm` was set in config or cmdline
 - **rpc-file-mode** (string, optional): `rpc-file-mode` field from config or cmdline, or default
@@ -221,4 +221,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4a72e74f8551a9ded7ad9a23044198c985530b72d9a8974bb4ef68b3ee37b8da)
+[comment]: # ( SHA256STAMP:a1bd52e28e61dc343d76aa9b61c9530f6146bd3d12887717b2e36fa4cec7c6f4)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -361,6 +361,14 @@ RPC call lightning-setchannel(7).
 channels. If you want to change the `htlc_maximum_msat` for existing channels,
 use the RPC call lightning-setchannel(7).
 
+* **ip-discovery**=*BOOL*
+
+  Explicitly turn 'on' or 'off' public IP discovery to send `node_announcement`
+  updates that contain the discovered IP with TCP port 9735 as announced address.
+  Default: turned off .
+  Note: You also need to open TCP port 9735 on your router towords your node.
+  Note: Will always be disabled if you use 'always-use-proxy'.
+
 * **disable-ip-discovery**
 
   Turn off public IP discovery to send `node_announcement` updates that contain

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -369,14 +369,6 @@ use the RPC call lightning-setchannel(7).
   Note: You also need to open TCP port 9735 on your router towords your node.
   Note: Will always be disabled if you use 'always-use-proxy'.
 
-* **disable-ip-discovery**
-
-  Turn off public IP discovery to send `node_announcement` updates that contain
-the discovered IP with TCP port 9735 as announced address. If unset and you
-open TCP port 9735 on your router towords your node, your node will remain
-connectable on changing IP addresses.  Note: Will always be disabled if you use
-'always-use-proxy'.
-
 ### Lightning channel and HTLC options
 
 * **large-channels**

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -247,6 +247,10 @@
       "type": "boolean",
       "description": "`true` if `disable-ip-discovery` was set in config or cmdline"
     },
+    "ip-discovery": {
+      "type": "boolean",
+      "description": "`true` if `ip-discovery` was set in config or cmdline"
+    },
     "encrypted-hsm": {
       "type": "boolean",
       "description": "`true` if `encrypted-hsm` was set in config or cmdline"

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -245,7 +245,7 @@
     },
     "disable-ip-discovery": {
       "type": "boolean",
-      "description": "`true` if `disable-ip-discovery` was set in config or cmdline"
+      "description": "`true` if `disable-ip-discovery` was set in config or cmdline (DEPRECATED)"
     },
     "ip-discovery": {
       "type": "boolean",

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -44,8 +44,8 @@ static u8 *create_node_announcement(const tal_t *ctx, struct daemon *daemon,
 		tal_arr_expand(&was, daemon->announceable[i]);
 
 	/* Add discovered IPs v4/v6 verified by peer `remote_addr` feature. */
-	/* Only do that if we don't have addresses announced. */
-	if (count_announceable == 0) {
+	/* Only do that if `config.ip_discovery` is explicitly enabled. */
+	if (daemon->ip_discovery) {
 		if (daemon->discovered_ip_v4 != NULL &&
 		    !wireaddr_arr_contains(was, daemon->discovered_ip_v4))
 			tal_arr_expand(&was, *daemon->discovered_ip_v4);

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -380,8 +380,9 @@ static void handle_discovered_ip(struct daemon *daemon, const u8 *msg)
 	return;
 
 update_node_annoucement:
-	status_debug("Update our node_announcement for discovered address: %s",
-		     fmt_wireaddr(tmpctx, &discovered_ip));
+	if (daemon->ip_discovery)
+		status_debug("Update our node_announcement for discovered address: %s",
+			     fmt_wireaddr(tmpctx, &discovered_ip));
 	maybe_send_own_node_announce(daemon, false);
 }
 
@@ -727,7 +728,8 @@ static void gossip_init(struct daemon *daemon, const u8 *msg)
 				     &daemon->announceable,
 				     &dev_gossip_time,
 				     &dev_fast_gossip,
-				     &dev_fast_gossip_prune)) {
+				     &dev_fast_gossip_prune,
+				     &daemon->ip_discovery)) {
 		master_badmsg(WIRE_GOSSIPD_INIT, msg);
 	}
 
@@ -1096,6 +1098,7 @@ int main(int argc, char *argv[])
 	daemon->rates = NULL;
 	daemon->discovered_ip_v4 = NULL;
 	daemon->discovered_ip_v6 = NULL;
+	daemon->ip_discovery = false;
 	list_head_init(&daemon->deferred_updates);
 
 	/* Tell the ecdh() function how to talk to hsmd */

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -51,6 +51,7 @@ struct daemon {
 	/* verified remote_addr as reported by recent peers */
 	struct wireaddr *discovered_ip_v4;
 	struct wireaddr *discovered_ip_v6;
+	bool ip_discovery;
 
 	/* Timer until we can send an updated node_announcement */
 	struct oneshot *node_announce_timer;

--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -16,6 +16,7 @@ msgdata,gossipd_init,announceable,wireaddr,num_announceable
 msgdata,gossipd_init,dev_gossip_time,?u32,
 msgdata,gossipd_init,dev_fast_gossip,bool,
 msgdata,gossipd_init,dev_fast_gossip_prune,bool,
+msgdata,gossipd_init,ip_discovery,bool,
 
 msgtype,gossipd_init_reply,3100
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -262,7 +262,8 @@ void gossip_init(struct lightningd *ld, int connectd_fd)
 	    ld->announceable,
 	    IFDEV(ld->dev_gossip_time ? &ld->dev_gossip_time: NULL, NULL),
 	    IFDEV(ld->dev_fast_gossip, false),
-	    IFDEV(ld->dev_fast_gossip_prune, false));
+	    IFDEV(ld->dev_fast_gossip_prune, false),
+	    ld->config.ip_discovery);
 
 	subd_req(ld->gossip, ld->gossip, take(msg), -1, 0,
 		 gossipd_init_done, NULL);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #define LIGHTNING_LIGHTNINGD_LIGHTNINGD_H
 #include "config.h"
+#include <ccan/ccan/opt/opt.h>
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
 #include <signal.h>
@@ -56,6 +57,8 @@ struct config {
 	/* Are we allowed to use DNS lookup for peers. */
 	bool use_dns;
 
+	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
+	bool ip_discovery;
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	bool disable_ip_discovery;
 

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -60,6 +60,7 @@ struct config {
 	/* Excplicitly turns 'on' or 'off' IP discovery feature. */
 	bool ip_discovery;
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	bool disable_ip_discovery;
 
 	/* Minimal amount of effective funding_satoshis for accepting channels */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -808,6 +808,8 @@ static const struct config testnet_config = {
 
 	.use_dns = true,
 
+	/* If true, announce discovered IPs */
+	.ip_discovery = false,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -874,6 +876,8 @@ static const struct config mainnet_config = {
 
 	.use_dns = true,
 
+	/* If true, announce discovered IPs */
+	.ip_discovery = false,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
 	.disable_ip_discovery = false,
 
@@ -1176,9 +1180,13 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--announce-addr", opt_add_announce_addr, NULL,
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
+
 	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
 			 &ld->config.disable_ip_discovery,
 			 "Turn off announcement of discovered public IPs");
+	opt_register_arg("--ip-discovery", opt_set_bool_arg, opt_show_bool,
+			 &ld->config.ip_discovery,
+			 "If true, announce discovered IPs");
 
 	opt_register_noarg("--offline", opt_set_offline, ld,
 			   "Start in offline-mode (do not automatically reconnect and do not accept incoming connections)");

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -811,6 +811,7 @@ static const struct config testnet_config = {
 	/* If true, announce discovered IPs */
 	.ip_discovery = false,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
@@ -879,6 +880,7 @@ static const struct config mainnet_config = {
 	/* If true, announce discovered IPs */
 	.ip_discovery = false,
 	/* Turn off IP address announcement discovered via peer `remote_addr` */
+	/* DEPRECATED does not do anything usefuly by current implementation */
 	.disable_ip_discovery = false,
 
 	/* Sets min_effective_htlc_capacity - at 1000$/BTC this is 10ct */
@@ -1049,6 +1051,14 @@ static char *opt_set_db_upgrade(const char *arg, struct lightningd *ld)
 	return opt_set_bool_arg(arg, ld->db_upgrade_ok);
 }
 
+static char *opt_disable_ip_discovery(struct lightningd *ld)
+{
+	log_broken(ld->log, "--disable-ip-discovery has been deprecated, use --ip-discovery");
+	if (!deprecated_apis)
+		return "--disable-ip-discovery has been deprecated, use --ip-discovery";
+	return opt_set_bool(&ld->config.disable_ip_discovery);
+}
+
 static void register_opts(struct lightningd *ld)
 {
 	/* This happens before plugins started */
@@ -1181,9 +1191,7 @@ static void register_opts(struct lightningd *ld)
 			 ld,
 			 "Set an IP address (v4 or v6) or .onion v3 to announce, but not listen on");
 
-	opt_register_noarg("--disable-ip-discovery", opt_set_bool,
-			 &ld->config.disable_ip_discovery,
-			 "Turn off announcement of discovered public IPs");
+	opt_register_noarg("--disable-ip-discovery", opt_disable_ip_discovery, ld, opt_hidden);
 	opt_register_arg("--ip-discovery", opt_set_bool_arg, opt_show_bool,
 			 &ld->config.ip_discovery,
 			 "If true, announce discovered IPs");

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2286,10 +2286,9 @@ static struct command_result *json_getinfo(struct command *cmd,
 		for (size_t i = 0; i < count_announceable; i++)
 			json_add_address(response, NULL, cmd->ld->announceable+i);
 
-		/* Currently, IP discovery will only be announced by gossipd,
-		 * if we don't already have usable addresses.
-		 * See `create_node_announcement` in `gossip_generation.c`. */
-		if (count_announceable == 0) {
+		/* Add discovered IPs if we announce them.
+		 * Also see `create_node_announcement` in `gossip_generation.c`. */
+		if (cmd->ld->config.ip_discovery) {
 			if (cmd->ld->discovered_ip_v4 != NULL &&
 					!wireaddr_arr_contains(
 						cmd->ld->announceable,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -73,7 +73,8 @@ def test_remote_addr(node_factory, bitcoind):
     # don't announce anything per se
     opts = {'may_reconnect': True,
             'dev-allow-localhost': None,
-            'dev-no-reconnect': None}
+            'dev-no-reconnect': None,
+            'ip-discovery': True}
     l1, l2, l3 = node_factory.get_nodes(3, opts)
 
     # Disable announcing local autobind addresses with dev-allow-localhost.
@@ -149,13 +150,12 @@ def test_remote_addr(node_factory, bitcoind):
 
 @pytest.mark.developer("needs DEVELOPER=1 for fast gossip and --dev-allow-localhost for local remote_addr")
 def test_remote_addr_disabled(node_factory, bitcoind):
-    """Simply tests that IP address discovery annoucements can be turned off
+    """Simply tests that IP address discovery is turned off by default
 
        We perform logic tests on L2, setup:
         l1 --> [l2] <-- l3
     """
     opts = {'dev-allow-localhost': None,
-            'disable-ip-discovery': None,
             'may_reconnect': True,
             'dev-no-reconnect': None}
     l1, l2, l3 = node_factory.get_nodes(3, opts=[opts, opts, opts])
@@ -164,24 +164,26 @@ def test_remote_addr_disabled(node_factory, bitcoind):
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
     l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
     l1.fundchannel(l2)
-    bitcoind.generate_block(5)
+    bitcoind.generate_block(6)
     l1.daemon.wait_for_log(f"Received node_announcement for node {l2.info['id']}")
     # l2->l3
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l2.daemon.wait_for_log("Peer says it sees our address as: 127.0.0.1:[0-9]{5}")
     l2.fundchannel(l3)
-    bitcoind.generate_block(5)
+    bitcoind.generate_block(6)
+    l3.daemon.wait_for_log(f"Received node_announcement for node {l2.info['id']}")
 
     # restart both and wait for channels to be ready
     l1.restart()
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.daemon.wait_for_log("Already have funding locked in")
+    l2.daemon.wait_for_log(f"{l1.info['id']}.*Already have funding locked in")
     l3.restart()
     l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
-    l2.daemon.wait_for_log("Already have funding locked in")
+    l2.daemon.wait_for_log(f"{l3.info['id']}.*Already have funding locked in")
 
     # if ip discovery would have been enabled, we would have send an updated
     # node_annoucement by now. Check we didn't...
+    bitcoind.generate_block(6)  # ugly, but we need to wait for gossip...
     assert not l2.daemon.is_in_log("Update our node_announcement for discovered address")
 
 


### PR DESCRIPTION
This adds an bool config switch that explicitly enables the IP discovery feature, as users may want to have IP discovery plus TOR just as fallback to increase overall connectivity.

**NOTE: This PR is a simpler alternative to the 'autobool' PR #5841**

Currently its still a bit tricky to use IP discovery: One needs to disable any usable addresses i.e. by binding just to a specific interface and configure without TOR. This will enable the current 'default' behavior: when there are no usable addresses try ip discovery. Without this trick, when a node has or finds just a single (a likely changing IP address), it will announce this forever and IP discovery is disabled and never rechecks addresses bound to initially.

If unset, the default behavior changes to not to do IP discovery. This is a change, but this PR is simpler than #5841 that takes this into account and uses a complex `autobool` to have a 'on/off/auto' setting.