### PR TITLE
doc: note that grpc needs the protobuf-compiler

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -70,7 +70,7 @@ If you can't install `lowdown`, a version will be built in-tree.
 
 If you want to build the Rust plugins (currently, cln-grpc):
 
-	sudo apt-get install -y cargo rustfmt
+	sudo apt-get install -y cargo rustfmt protobuf-compiler
 
 There are two ways to build core lightning, and this depends on how you want use it.
 


### PR DESCRIPTION
```
error: failed to run custom build command for `cln-grpc v0.1.2 (/home/rusty/devel/cvs/lightning/cln-grpc)`

Caused by:
  process didn't exit successfully: `/home/rusty/devel/cvs/lightning/target/debug/build/cln-grpc-933c4bf5006f522c/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=proto/node.proto
  cargo:rerun-if-changed=proto

  --- stderr
  thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /home/rusty/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.4/src/lib.rs:1296:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [plugins/Makefile:211: target/debug/examples/cln-plugin-startup] Error 101
```

Changelog-None: doc only