### PR TITLE
100k peers project

### DIFF
--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -100,16 +100,8 @@ static const struct node_id *peer_keyof(const struct peer *peer)
 	return &peer->id;
 }
 
-/*~ We also need to define a hashing function. siphash24 is a fast yet
- * cryptographic hash in ccan/crypto/siphash24; we might be able to get away
- * with a slightly faster hash with fewer guarantees, but it's good hygiene to
- * use this unless it's a proven bottleneck.  siphash_seed() is a function in
- * common/pseudorand which sets up a seed for our hashing; it's different
- * every time the program is run. */
-static size_t node_id_hash(const struct node_id *id)
-{
-	return siphash24(siphash_seed(), id->k, sizeof(id->k));
-}
+/*~ We reuse node_id_hash from common/node_id.h, which uses siphash
+ * and a per-run seed. */
 
 /*~ We also define an equality function: is this element equal to this key? */
 static bool peer_eq_node_id(const struct peer *peer,

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -607,7 +607,12 @@ struct channel *any_channel_by_scid(struct lightningd *ld,
 {
 	struct peer *p;
 	struct channel *chan;
-	list_for_each(&ld->peers, p, list) {
+	struct peer_node_id_map_iter it;
+
+	/* FIXME: Support lookup by scid directly! */
+	for (p = peer_node_id_map_first(ld->peers, &it);
+	     p;
+	     p = peer_node_id_map_next(ld->peers, &it)) {
 		list_for_each(&p->channels, chan, list) {
 			/* BOLT-channel-type #2:
 			 * - MUST always recognize the `alias` as a
@@ -640,7 +645,12 @@ struct channel *channel_by_dbid(struct lightningd *ld, const u64 dbid)
 {
 	struct peer *p;
 	struct channel *chan;
-	list_for_each(&ld->peers, p, list) {
+	struct peer_node_id_map_iter it;
+
+	/* FIXME: Support lookup by id directly! */
+	for (p = peer_node_id_map_first(ld->peers, &it);
+	     p;
+	     p = peer_node_id_map_next(ld->peers, &it)) {
 		list_for_each(&p->channels, chan, list) {
 			if (chan->dbid == dbid)
 				return chan;
@@ -654,8 +664,12 @@ struct channel *channel_by_cid(struct lightningd *ld,
 {
 	struct peer *p;
 	struct channel *channel;
+	struct peer_node_id_map_iter it;
 
-	list_for_each(&ld->peers, p, list) {
+	/* FIXME: Support lookup by cid directly! */
+	for (p = peer_node_id_map_first(ld->peers, &it);
+	     p;
+	     p = peer_node_id_map_next(ld->peers, &it)) {
 		if (p->uncommitted_channel) {
 			/* We can't use this method for old, uncommitted
 			 * channels; there's no "channel" struct here! */

--- a/lightningd/coin_mvts.c
+++ b/lightningd/coin_mvts.c
@@ -94,6 +94,7 @@ void send_account_balance_snapshot(struct lightningd *ld, u32 blockheight)
 	struct utxo **utxos;
 	struct channel *chan;
 	struct peer *p;
+	struct peer_node_id_map_iter it;
 	/* Available + reserved utxos are A+, as reserved things have not yet
 	 * been spent */
 	enum output_status utxo_states[] = {OUTPUT_STATE_AVAILABLE,
@@ -125,7 +126,9 @@ void send_account_balance_snapshot(struct lightningd *ld, u32 blockheight)
 	snap->accts[0] = bal;
 
 	/* Add channel balances */
-	list_for_each(&ld->peers, p, list) {
+	for (p = peer_node_id_map_first(ld->peers, &it);
+	     p;
+	     p = peer_node_id_map_next(ld->peers, &it)) {
 		list_for_each(&p->channels, chan, list) {
 			if (report_chan_balance(chan)) {
 				bal = tal(snap, struct account_balance);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -181,6 +181,9 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 *  linked-list as part of the 100k-peers project! */
 	ld->peers = tal(ld, struct peer_node_id_map);
 	peer_node_id_map_init(ld->peers);
+	/*~ And this was done at the same time, for db lookups at startup */
+	ld->peers_by_dbid = tal(ld, struct peer_dbid_map);
+	peer_dbid_map_init(ld->peers_by_dbid);
 
 	/*~ For multi-part payments, we need to keep some incoming payments
 	 * in limbo until we get all the parts, or we time them out. */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <lightningd/htlc_end.h>
 #include <lightningd/htlc_set.h>
+#include <lightningd/peer_control.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <wallet/wallet.h>
@@ -178,8 +179,8 @@ struct lightningd {
 	/* Daemon looking after peers during init / before channel. */
 	struct subd *connectd;
 
-	/* All peers we're tracking. */
-	struct list_head peers;
+	/* All peers we're tracking (by node_id) */
+	struct peer_node_id_map *peers;
 
 	/* Outstanding connect commands. */
 	struct list_head connects;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -181,6 +181,8 @@ struct lightningd {
 
 	/* All peers we're tracking (by node_id) */
 	struct peer_node_id_map *peers;
+	/* And those in database by dbid */
+	struct peer_dbid_map *peers_by_dbid;
 
 	/* Outstanding connect commands. */
 	struct list_head connects;

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -98,11 +98,6 @@ static const struct node_id *node_cache_id(const struct node_id_cache *nc)
 	return &nc->node_id;
 }
 
-static size_t node_id_hash(const struct node_id *id)
-{
-	return siphash24(siphash_seed(), id->k, sizeof(id->k));
-}
-
 static bool node_id_cache_eq(const struct node_id_cache *nc,
 			     const struct node_id *node_id)
 {

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -155,6 +155,7 @@ static void finish_report(const struct leak_detect *leaks)
 	memleak_scan_htable(memtable, &ld->htlcs_in->raw);
 	memleak_scan_htable(memtable, &ld->htlcs_out->raw);
 	memleak_scan_htable(memtable, &ld->htlc_sets->raw);
+	memleak_scan_htable(memtable, &ld->peers->raw);
 
 	/* Now delete ld and those which it has pointers to. */
 	memleak_scan_obj(memtable, ld);

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -156,6 +156,7 @@ static void finish_report(const struct leak_detect *leaks)
 	memleak_scan_htable(memtable, &ld->htlcs_out->raw);
 	memleak_scan_htable(memtable, &ld->htlc_sets->raw);
 	memleak_scan_htable(memtable, &ld->peers->raw);
+	memleak_scan_htable(memtable, &ld->peers_by_dbid->raw);
 
 	/* Now delete ld and those which it has pointers to. */
 	memleak_scan_obj(memtable, ld);

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -15,10 +15,7 @@ struct peer_fd;
 struct wally_psbt;
 
 struct peer {
-	/* Inside ld->peers. */
-	struct list_node list;
-
-	/* Master context */
+	/* Master context (we're in the hashtable ld->peers) */
 	struct lightningd *ld;
 
 	/* Database ID of the peer */
@@ -142,5 +139,21 @@ command_find_channel(struct command *cmd,
 
 /* Ancient (0.7.0 and before) releases could create invalid commitment txs! */
 bool invalid_last_tx(const struct bitcoin_tx *tx);
+
+static const struct node_id *peer_node_id(const struct peer *peer)
+{
+	return &peer->id;
+}
+
+static bool peer_node_id_eq(const struct peer *peer,
+			    const struct node_id *node_id)
+{
+	return node_id_eq(&peer->id, node_id);
+}
+
+/* Defines struct peer_node_id_map */
+HTABLE_DEFINE_TYPE(struct peer,
+		   peer_node_id, node_id_hash, peer_node_id_eq,
+		   peer_node_id_map);
 
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -102,6 +102,9 @@ u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx);
 /* We've loaded peers from database, set them going. */
 void setup_peers(struct lightningd *ld);
 
+/* When database first writes peer into db, it sets the dbid */
+void peer_set_dbid(struct peer *peer, u64 dbid);
+
 /* At startup, re-send any transactions we want bitcoind to have */
 void resend_closing_transactions(struct lightningd *ld);
 
@@ -155,5 +158,25 @@ static bool peer_node_id_eq(const struct peer *peer,
 HTABLE_DEFINE_TYPE(struct peer,
 		   peer_node_id, node_id_hash, peer_node_id_eq,
 		   peer_node_id_map);
+
+static inline size_t dbid_hash(u64 dbid)
+{
+	return siphash24(siphash_seed(), &dbid, sizeof(dbid));
+}
+
+static u64 peer_dbid(const struct peer *peer)
+{
+	assert(peer->dbid);
+	return peer->dbid;
+}
+
+static bool peer_dbid_eq(const struct peer *peer, u64 dbid)
+{
+	return peer->dbid == dbid;
+}
+/* Defines struct peer_dbid_map */
+HTABLE_DEFINE_TYPE(struct peer,
+		   peer_dbid, dbid_hash, peer_dbid_eq,
+		   peer_dbid_map);
 
 #endif /* LIGHTNING_LIGHTNINGD_PEER_CONTROL_H */

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -999,7 +999,7 @@ static struct channel *add_peer(struct lightningd *ld, int n,
 
 	memset(&peer->id, n, sizeof(peer->id));
 	list_head_init(&peer->channels);
-	list_add_tail(&ld->peers, &peer->list);
+	peer_node_id_map_add(ld->peers, peer);
 	peer->ld = ld;
 
 	c->state = state;
@@ -1036,7 +1036,8 @@ int main(int argc, char *argv[])
 	common_setup(argv[0]);
 	ld = tal(tmpctx, struct lightningd);
 
-	list_head_init(&ld->peers);
+	ld->peers = tal(ld, struct peer_node_id_map);
+	peer_node_id_map_init(ld->peers);
 	ld->htlcs_in = tal(ld, struct htlc_in_map);
 	htlc_in_map_init(ld->htlcs_in);
 	chainparams = chainparams_for_network("regtest");

--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -192,17 +192,6 @@ static struct command_result *json_getroute(struct command *cmd,
 	return command_finished(cmd, js);
 }
 
-static const struct node_id *node_id_keyof(const struct node_id *id)
-{
-	return id;
-}
-
-static size_t node_id_hash(const struct node_id *id)
-{
-	return siphash24(siphash_seed(), id->k, sizeof(id->k));
-}
-
-
 HTABLE_DEFINE_TYPE(struct node_id, node_id_keyof, node_id_hash, node_id_eq,
 		   node_map);
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2413,7 +2413,10 @@ def test_setchannel_all(node_factory, bitcoind):
     wait_for(lambda: [c['base_fee_millisatoshi'] for c in l1.rpc.listchannels(scid3)['channels']] == [0xDEAD, DEF_BASE])
     wait_for(lambda: [c['fee_per_millionth'] for c in l1.rpc.listchannels(scid3)['channels']] == [0xBEEF, DEF_PPM])
 
+    # Don't assume order!
     assert len(result['channels']) == 2
+    if result['channels'][0]['peer_id'] == l3.info['id']:
+        result['channels'] = [result['channels'][1], result['channels'][0]]
     assert result['channels'][0]['peer_id'] == l2.info['id']
     assert result['channels'][0]['short_channel_id'] == scid2
     assert result['channels'][0]['fee_base_msat'] == 0xDEAD

--- a/wallet/Makefile
+++ b/wallet/Makefile
@@ -19,6 +19,9 @@ WALLET_HDRS := $(WALLET_LIB_SRC:.c=.h)
 
 WALLET_OBJS := $(WALLET_SRC:.c=.o)
 
+# This really should be a subdir of lightningd/.  We depend on their headers!
+$(WALLET_OBJS): $(LIGHTNINGD_SRC:.c=.h)
+
 # Make sure these depend on everything.
 ALL_C_SOURCES += $(WALLET_SRC) $(WALLET_DB_QUERIES)
 ALL_C_HEADERS += $(WALLET_HDRS)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1934,6 +1934,8 @@ int main(int argc, const char *argv[])
 	/* Only elements in ld we should access */
 	ld->peers = tal(ld, struct peer_node_id_map);
 	peer_node_id_map_init(ld->peers);
+	ld->peers_by_dbid = tal(ld, struct peer_dbid_map);
+	peer_dbid_map_init(ld->peers_by_dbid);
 	ld->rr_counter = 0;
 	node_id_from_hexstr("02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66, &ld->id);
 	/* Accessed in peer destructor sanity check */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1370,11 +1370,12 @@ static struct channel *wallet_channel_load(struct wallet *w, const u64 dbid)
 {
 	struct peer *peer;
 	struct channel *channel;
+	struct peer_node_id_map_iter it;
 
 	/* We expect only one peer, but reuse same code */
 	if (!wallet_init_channels(w))
 		return NULL;
-	peer = list_top(&w->ld->peers, struct peer, list);
+	peer = peer_node_id_map_first(w->ld->peers, &it);
 	CHECK(peer);
 
 	/* We load lots of identical dbid channels: use last one */
@@ -1931,7 +1932,8 @@ int main(int argc, const char *argv[])
 	ld->config = test_config;
 
 	/* Only elements in ld we should access */
-	list_head_init(&ld->peers);
+	ld->peers = tal(ld, struct peer_node_id_map);
+	peer_node_id_map_init(ld->peers);
 	ld->rr_counter = 0;
 	node_id_from_hexstr("02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66, &ld->id);
 	/* Accessed in peer destructor sanity check */

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2155,7 +2155,7 @@ static void wallet_peer_save(struct wallet *w, struct peer *peer)
 
 	if (db_step(stmt)) {
 		/* So we already knew this peer, just return its dbid */
-		peer->dbid = db_col_u64(stmt, "id");
+		peer_set_dbid(peer, db_col_u64(stmt, "id"));
 		tal_free(stmt);
 
 		/* Since we're at it update the wireaddr */
@@ -2174,7 +2174,7 @@ static void wallet_peer_save(struct wallet *w, struct peer *peer)
 		db_bind_node_id(stmt, 0, &peer->id);
 		db_bind_text(stmt, 1,addr);
 		db_exec_prepared_v2(stmt);
-		peer->dbid = db_last_insert_id_v2(take(stmt));
+		peer_set_dbid(peer, db_last_insert_id_v2(take(stmt)));
 	}
 }
 

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -313,6 +313,7 @@ static struct command_result *json_listfunds(struct command *cmd,
 {
 	struct json_stream *response;
 	struct peer *p;
+	struct peer_node_id_map_iter it;
 	struct utxo **utxos, **reserved_utxos, **spent_utxos;
 	bool *spent;
 
@@ -339,7 +340,9 @@ static struct command_result *json_listfunds(struct command *cmd,
 
 	/* Add funds that are allocated to channels */
 	json_array_start(response, "channels");
-	list_for_each(&cmd->ld->peers, p, list) {
+	for (p = peer_node_id_map_first(cmd->ld->peers, &it);
+	     p;
+	     p = peer_node_id_map_next(cmd->ld->peers, &it)) {
 		struct channel *c;
 		list_for_each(&p->channels, c, list) {
 			/* We don't print out uncommitted channels */


### PR DESCRIPTION
(Based on #5868 which changes htables to need to be tal'ocated, simply to avoid merge hell!)

I hacked the code to ignore signatures so I could quickly open 100k peers with one channel each, and looked at how the node responded.  Two simple fixes (linked lists were the culprit) and such a node is manageable (though not exactly speedy!).

Before this, reconnecting to all the peers took longer and longer (noticeable before we even had 10k peers).   And startup was extremely slow (not sure how bad it was, I gave up!).

It still takes 9 seconds to listpeers, and almost a minute to startup, and database is about 185MB.

Changelog-None Not user visible.