### PR TITLE
Change the zlib download url

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -54,14 +54,14 @@ then
     export STRIP="$TARGET_HOST"-strip
     export CONFIGURATION_WRAPPER=qemu-"${TARGET_HOST%%-*}"-static
 
-    wget -q https://zlib.net/fossils/zlib-1.2.12.tar.gz
-    tar xf zlib-1.2.12.tar.gz
-    cd zlib-1.2.12 || exit 1
+    wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz
+    tar xf zlib-1.2.13.tar.gz
+    cd zlib-1.2.13 || exit 1
     ./configure --prefix="$QEMU_LD_PREFIX"
     make
     sudo make install
     cd .. || exit 1
-    rm zlib-1.2.12.tar.gz && rm -rf zlib-1.2.12
+    rm zlib-1.2.13.tar.gz && rm -rf zlib-1.2.13
 
     wget -q https://www.sqlite.org/2018/sqlite-src-3260000.zip
     unzip -q sqlite-src-3260000.zip

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -54,7 +54,7 @@ then
     export STRIP="$TARGET_HOST"-strip
     export CONFIGURATION_WRAPPER=qemu-"${TARGET_HOST%%-*}"-static
 
-    wget -q https://zlib.net/zlib-1.2.12.tar.gz
+    wget -q https://zlib.net/fossils/zlib-1.2.12.tar.gz
     tar xf zlib-1.2.12.tar.gz
     cd zlib-1.2.12 || exit 1
     ./configure --prefix="$QEMU_LD_PREFIX"

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update -qq && \
         python3-setuptools \
         wget
 
-RUN wget -q https://zlib.net/zlib-1.2.13.tar.gz \
+RUN wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz \
     && tar xvf zlib-1.2.13.tar.gz \
     && cd zlib-1.2.13 \
     && ./configure \

--- a/contrib/docker/linuxarm32v7.Dockerfile
+++ b/contrib/docker/linuxarm32v7.Dockerfile
@@ -86,7 +86,7 @@ STRIP=${target_host}-strip \
 QEMU_LD_PREFIX=/usr/${target_host} \
 HOST=${target_host}
 
-RUN wget -q https://zlib.net/zlib-1.2.13.tar.gz \
+RUN wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz \
 && tar xvf zlib-1.2.13.tar.gz \
 && cd zlib-1.2.13 \
 && ./configure --prefix=$QEMU_LD_PREFIX \

--- a/contrib/docker/linuxarm64v8.Dockerfile
+++ b/contrib/docker/linuxarm64v8.Dockerfile
@@ -87,7 +87,7 @@ STRIP=${target_host}-strip \
 QEMU_LD_PREFIX=/usr/${target_host} \
 HOST=${target_host}
 
-RUN wget -q https://zlib.net/zlib-1.2.13.tar.gz \
+RUN wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz \
 && tar xvf zlib-1.2.13.tar.gz \
 && cd zlib-1.2.13 \
 && ./configure --prefix=$QEMU_LD_PREFIX \

--- a/contrib/docker/scripts/build.sh
+++ b/contrib/docker/scripts/build.sh
@@ -52,14 +52,14 @@ then
     export STRIP="$TARGET_HOST"-strip
     export CONFIGURATION_WRAPPER=qemu-"${TARGET_HOST%%-*}"-static
 
-    wget -q https://zlib.net/fossils/zlib-1.2.12.tar.gz
-    tar xf zlib-1.2.12.tar.gz
-    cd zlib-1.2.12 || exit 1
+    wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz
+    tar xf zlib-1.2.13.tar.gz
+    cd zlib-1.2.13 || exit 1
     ./configure --prefix="$QEMU_LD_PREFIX"
     make
     sudo make install
     cd .. || exit 1
-    rm zlib-1.2.12.tar.gz && rm -rf zlib-1.2.12
+    rm zlib-1.2.13.tar.gz && rm -rf zlib-1.2.13
 
     wget -q https://www.sqlite.org/2018/sqlite-src-3260000.zip
     unzip -q sqlite-src-3260000.zip

--- a/contrib/docker/scripts/build.sh
+++ b/contrib/docker/scripts/build.sh
@@ -52,7 +52,7 @@ then
     export STRIP="$TARGET_HOST"-strip
     export CONFIGURATION_WRAPPER=qemu-"${TARGET_HOST%%-*}"-static
 
-    wget -q https://zlib.net/zlib-1.2.12.tar.gz
+    wget -q https://zlib.net/fossils/zlib-1.2.12.tar.gz
     tar xf zlib-1.2.12.tar.gz
     cd zlib-1.2.12 || exit 1
     ./configure --prefix="$QEMU_LD_PREFIX"

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -411,7 +411,7 @@ Obtain and install cross-compiled versions of sqlite3, gmp and zlib:
 
 Download and build zlib:
 
-    wget https://zlib.net/zlib-1.2.12.tar.gz
+    wget https://zlib.net/fossils/zlib-1.2.12.tar.gz
     tar xvf zlib-1.2.12.tar.gz
     cd zlib-1.2.12
     ./configure --prefix=$QEMU_LD_PREFIX

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -411,9 +411,9 @@ Obtain and install cross-compiled versions of sqlite3, gmp and zlib:
 
 Download and build zlib:
 
-    wget https://zlib.net/fossils/zlib-1.2.12.tar.gz
-    tar xvf zlib-1.2.12.tar.gz
-    cd zlib-1.2.12
+    wget https://zlib.net/fossils/zlib-1.2.13.tar.gz
+    tar xvf zlib-1.2.13.tar.gz
+    cd zlib-1.2.13
     ./configure --prefix=$QEMU_LD_PREFIX
     make
     make install


### PR DESCRIPTION
1. The https://zlib.net/zlib-1.2.12.tar.gz change to https://zlib.net/fossils/zlib-1.2.12.tar.gz after zlib 1.2.13 released.
2.  To avoid simlar issue in future ,change https://zlib.net/zlib-1.2.13.tar.gz to https://zlib.net/fossils/zlib-1.2.13.tar.gz
3.  Unified the zlib version in doc and build script files.

Changelog-None