### PR TITLE
Fix link to github.com/lightningd/plugins not clickable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ Once you've started for the first time, there's a script called
 the lightning network.
 
 There are also numerous plugins available for Core Lightning which add
-capabilities: in particular there's a collection at:
-
-	https://github.com/lightningd/plugins
+capabilities: in particular there's a collection at: https://github.com/lightningd/plugins
 
 Including [helpme][helpme-github] which guides you through setting up
 your first channels and customizing your node.


### PR DESCRIPTION
Alright, I know this is just a nitpick but I am not sure if that was done on purpose.

The link to github.com/lightningd/plugins is not clickable in the README. One has to copy it and paste it themselves:

![2022-12-28-082733_446x157_scrot](https://user-images.githubusercontent.com/27162016/209775553-1ffa2436-1be0-4c02-8d4a-96dc399f40ee.png)

Github provides a copy button, but still, I am not sure if that is rendering as intended (instead of just indented).

Looking at the code, I think that this is just unfortunately rendered as a code block which makes the link not clickable since it was only indented (and not explicitly marked as a code block using ```).

Consider this PR as a discussion about this. Didn't want to create a ticket about such a minor issue first, haha