### PR TITLE
pyln-client: make Millisatoshi comparable to int

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -163,9 +163,13 @@ class Millisatoshi:
         return self.millisatoshis
 
     def __lt__(self, other: 'Millisatoshi') -> bool:
+        if isinstance(other, int):
+            return self.millisatoshis < other
         return self.millisatoshis < other.millisatoshis
 
     def __le__(self, other: 'Millisatoshi') -> bool:
+        if isinstance(other, int):
+            return self.millisatoshis <= other
         return self.millisatoshis <= other.millisatoshis
 
     def __eq__(self, other: object) -> bool:
@@ -177,9 +181,13 @@ class Millisatoshi:
             return False
 
     def __gt__(self, other: 'Millisatoshi') -> bool:
+        if isinstance(other, int):
+            return self.millisatoshis > other
         return self.millisatoshis > other.millisatoshis
 
     def __ge__(self, other: 'Millisatoshi') -> bool:
+        if isinstance(other, int):
+            return self.millisatoshis >= other
         return self.millisatoshis >= other.millisatoshis
 
     def __add__(self, other: 'Millisatoshi') -> 'Millisatoshi':


### PR DESCRIPTION
This often helps the msat purge, pyln msat replacement and deprecated-apis mischmasch issues. I changed it in a way that the `AttributeError: 'int' object has no attribute 'millisatoshis'` Error will still be raised whever a `Millisatoshi` is compared to something else then a `Millisatoshi` or `int`.

Also, since we already allow compare equal on `Millisatoshi` and `int`, we should do the same for lower/greater comparison.

Changelog-None