### PR TITLE
db: Fix the ordering of `channel_htlcs` in postgres

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -5460,7 +5460,8 @@ struct wallet_htlc_iter *wallet_htlcs_first(const tal_t *ctx,
 					    ", h.payment_hash"
 					    ", h.hstate"
 					    " FROM channel_htlcs h"
-					    " WHERE channel_id = ?"));
+					    " WHERE channel_id = ?"
+					    " ORDER BY id ASC"));
 		db_bind_u64(i->stmt, 0, chan->dbid);
 	} else {
 		i->scid.u64 = 0;
@@ -5474,7 +5475,8 @@ struct wallet_htlc_iter *wallet_htlcs_first(const tal_t *ctx,
 					    ", h.payment_hash"
 					    ", h.hstate"
 					    " FROM channel_htlcs h"
-					    " JOIN channels ON channels.id = h.channel_id"));
+					    " JOIN channels ON channels.id = h.channel_id"
+					    " ORDER BY h.id ASC"));
 	}
 	/* FIXME: db_prepare should take ctx! */
 	tal_steal(i, i->stmt);


### PR DESCRIPTION
I discovered this while reworking the CI workflow, and it seems like the HTLC queries do not order, while the tests assume a specific order. This matches sqlite3 which without an explicit ORDER clause will use insertion order, while postgres does not keep things in insertion order, thus breaking the assumption. Ordering by `id` re-establishes that implicit assumption

Changelog-Changed: postgres: Ordering of HTLCs in `listhtlcs` are now ordered by time of creation