### PR TITLE
topology: fix memleak in listchannels

### DIFF
--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -392,6 +392,7 @@ static struct node_map *local_connected(const tal_t *ctx,
 	struct node_map *connected = tal(ctx, struct node_map);
 
 	node_map_init(connected);
+	tal_add_destructor(connected, node_map_clear);
 
 	json_for_each_arr(i, t, peers) {
 		const jsmntok_t *chans, *c;


### PR DESCRIPTION
`local_connected` allocates a `struct node_map` off of the `struct listchannels_opts` but fails to ever release the internal table, so those table allocations hang around forever. Add `node_map_clear` as a destructor for the `struct node_map` to ensure that the internal table is freed when the enclosing struct is freed.