### PR TITLE
Commando enhancements and integrated cli support

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -601,6 +601,18 @@ static void opt_show_level(char buf[OPT_SHOW_LEN], const enum log_level *level)
 		strncpy(buf, log_level_name(*level), OPT_SHOW_LEN-1);
 }
 
+/* The standard opt_log_stderr_exit exits with status 1 */
+static void opt_log_stderr_exit_usage(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, "\n");
+	va_end(ap);
+	exit(ERROR_USAGE);
+}
+
 int main(int argc, char *argv[])
 {
 	setup_locale();
@@ -656,8 +668,8 @@ int main(int argc, char *argv[])
 
 	opt_register_version();
 
-	opt_early_parse(argc, argv, opt_log_stderr_exit);
-	opt_parse(&argc, argv, opt_log_stderr_exit);
+	opt_early_parse(argc, argv, opt_log_stderr_exit_usage);
+	opt_parse(&argc, argv, opt_log_stderr_exit_usage);
 
 	method = argv[1];
 	if (!method) {
@@ -872,7 +884,7 @@ int main(int argc, char *argv[])
 		}
 		tal_free(ctx);
 		opt_free_table();
-		return 0;
+		return NO_ERROR;
 	}
 
 	if (format == RAW)
@@ -884,5 +896,5 @@ int main(int argc, char *argv[])
 	}
 	tal_free(ctx);
 	opt_free_table();
-	return 1;
+	return ERROR_FROM_LIGHTNINGD;
 }

--- a/common/json_parse_simple.c
+++ b/common/json_parse_simple.c
@@ -206,7 +206,9 @@ const char *json_get_id(const tal_t *ctx,
 	const jsmntok_t *idtok = json_get_member(buffer, obj, "id");
 	if (!idtok)
 		return NULL;
-	return json_strdup(ctx, buffer, idtok);
+	return tal_strndup(ctx,
+			   json_tok_full(buffer, idtok),
+			   json_tok_full_len(idtok));
 }
 
 /*-----------------------------------------------------------------------------

--- a/common/json_parse_simple.h
+++ b/common/json_parse_simple.h
@@ -66,7 +66,7 @@ const jsmntok_t *json_get_member(const char *buffer, const jsmntok_t tok[],
 /* Get index'th array member. */
 const jsmntok_t *json_get_arr(const jsmntok_t tok[], size_t index);
 
-/* Helper to get "id" field from object. */
+/* Helper to get "id" field from object (including any quotes!). */
 const char *json_get_id(const tal_t *ctx,
 			const char *buffer, const jsmntok_t *obj);
 

--- a/common/json_stream.c
+++ b/common/json_stream.c
@@ -239,9 +239,6 @@ void json_add_jsonstr(struct json_stream *js,
 {
 	char *p;
 
-	if (!json_filter_ok(js->filter, fieldname))
-		return;
-
 	/* NOTE: Filtering doesn't really work here! */
 	if (!json_filter_ok(js->filter, fieldname))
 		return;
@@ -690,3 +687,11 @@ void json_add_lease_rates(struct json_stream *result,
 		     rates->channel_fee_max_proportional_thousandths);
 }
 
+void json_add_id(struct json_stream *result, const char *id)
+{
+	char *p;
+
+	/* Bypass escape-required assertion in json_out_add */
+	p = json_member_direct(result, "id", strlen(id));
+	memcpy(p, id, strlen(id));
+}

--- a/common/json_stream.h
+++ b/common/json_stream.h
@@ -390,4 +390,7 @@ void json_add_psbt(struct json_stream *stream,
  * Note that field names are set */
 void json_add_lease_rates(struct json_stream *result,
 			  const struct lease_rates *rates);
+
+/* Add an id field literally (i.e. it's already a JSON primitive or string!) */
+void json_add_id(struct json_stream *result, const char *id);
 #endif /* LIGHTNING_COMMON_JSON_STREAM_H */

--- a/doc/lightning-cli.1.md
+++ b/doc/lightning-cli.1.md
@@ -69,7 +69,7 @@ field without parsing JSON.
   If *LEVEL* is 'none', then never print out notifications.  Otherwise,
 print out notifications of *LEVEL* or above (one of `io`, `debug`,
 `info` (the default), `unusual` or `broken`: they are prefixed with `#
-`.
+`.  (Note: currently not supported with `--commando`).
 
 * **--filter**/**-l**=*JSON*
 
@@ -84,11 +84,20 @@ be changed using `-F`, `-R`, `-J`, `-H` etc.
 
   Print version number to standard output and exit.
 
-* **allow-deprecated-apis**=*BOOL*
+* **--allow-deprecated-apis**=*BOOL*
 
   Enable deprecated options. It defaults to *true*, but you should set
 it to *false* when testing to ensure that an upgrade won't break your
 configuration.
+
+* **--commando**/**-c**=**peerid**:**rune**
+
+  Convenience option to indicate that this command should be wrapped
+in a `commando` command to be sent to the connected peer with id
+`peerid`, using rune `rune`.  This also means that any `--filter` is
+handed via commando to the remote peer to reduce its output (which it
+will do it it is v23.02 or newer), rather than trying to do so
+locally.  Note that currently `-N` is not supported by commando.
 
 COMMANDS
 --------

--- a/doc/lightning-cli.1.md
+++ b/doc/lightning-cli.1.md
@@ -130,6 +130,15 @@ BUGS
 This manpage documents how it should work, not how it does work. The
 pretty printing of results isn't pretty.
 
+EXIT STATUS
+-----------
+
+If the command succeeds, the exit status is 0.  Otherwise:
+
+* `1`: lightningd(7) returned an error reply (which is printed).
+* `2`: we could not talk to lightningd.
+* `3`: usage error, such as bad arguments or malformed JSON in the parameters.
+
 AUTHOR
 ------
 

--- a/doc/schemas/commando.request.json
+++ b/doc/schemas/commando.request.json
@@ -30,6 +30,11 @@
     "rune": {
       "type": "string",
       "description": "rune to authorize the command"
+    },
+    "filter": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "filter to peer to apply to any successful result"
     }
   }
 }

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -203,7 +203,9 @@ static struct command_result *json_stop(struct command *cmd,
 	jout = json_out_new(tmpctx);
 	json_out_start(jout, NULL, '{');
 	json_out_addstr(jout, "jsonrpc", "2.0");
-	json_out_add(jout, "id", cmd->id_is_string, "%s", cmd->id);
+	/* Copy input id token exactly */
+	memcpy(json_out_member_direct(jout, "id", strlen(cmd->id)),
+	       cmd->id, strlen(cmd->id));
 	json_out_addstr(jout, "result", "Shutdown complete");
 	json_out_end(jout, '}');
 	json_out_finished(jout);
@@ -557,10 +559,7 @@ void json_notify_fmt(struct command *cmd,
 	json_add_string(js, "jsonrpc", "2.0");
 	json_add_string(js, "method", "message");
 	json_object_start(js, "params");
-	if (cmd->id_is_string)
-		json_add_string(js, "id", cmd->id);
-	else
-		json_add_jsonstr(js, "id", cmd->id, strlen(cmd->id));
+	json_add_id(js, cmd->id);
 	json_add_string(js, "level", log_level_name(level));
 	json_add_string(js, "message", tal_vfmt(tmpctx, fmt, ap));
 	json_object_end(js);
@@ -605,10 +604,7 @@ static struct json_stream *json_start(struct command *cmd)
 
 	json_object_start(js, NULL);
 	json_add_string(js, "jsonrpc", "2.0");
-	if (cmd->id_is_string)
-		json_add_string(js, "id", cmd->id);
-	else
-		json_add_jsonstr(js, "id", cmd->id, strlen(cmd->id));
+	json_add_id(js, cmd->id);
 	return js;
 }
 
@@ -934,7 +930,10 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 	c->pending = false;
 	c->json_stream = NULL;
 	c->id_is_string = (id->type == JSMN_STRING);
-	c->id = json_strdup(c, jcon->buffer, id);
+	/* Include "" around string */
+	c->id = tal_strndup(c,
+			    json_tok_full(jcon->buffer, id),
+			    json_tok_full_len(id));
 	c->mode = CMD_NORMAL;
 	c->filter = NULL;
 	list_add_tail(&jcon->commands, &c->list);
@@ -1068,7 +1067,7 @@ again:
 		json_command_malformed(
 		    jcon, "null",
 		    tal_fmt(tmpctx, "Invalid token in json input: '%s'",
-			    tal_strndup(tmpctx, jcon->buffer, jcon->used)));
+			    tal_hexstr(tmpctx, jcon->buffer, jcon->used)));
 		if (in_transaction)
 			db_commit_transaction(jcon->ld->wallet->db);
 		return io_halfclose(conn);
@@ -1400,11 +1399,23 @@ struct jsonrpc_request *jsonrpc_request_start_(
 
 	r->id_is_string = id_as_string;
 	if (r->id_is_string) {
-		if (id_prefix)
-			r->id = tal_fmt(r, "%s/cln:%s#%"PRIu64,
+		if (id_prefix) {
+			/* Strip "" and otherwise sanity-check */
+			if (strstarts(id_prefix, "\"")
+			    && strlen(id_prefix) > 1
+			    && strends(id_prefix, "\"")) {
+				id_prefix = tal_strndup(tmpctx, id_prefix + 1,
+							strlen(id_prefix) - 2);
+			}
+			/* We could try escaping, but TBH they're
+			 * messing with us at this point! */
+			if (json_escape_needed(id_prefix, strlen(id_prefix)))
+				id_prefix = "weird-id";
+
+			r->id = tal_fmt(r, "\"%s/cln:%s#%"PRIu64"\"",
 					id_prefix, method, next_request_id);
-		else
-			r->id = tal_fmt(r, "cln:%s#%"PRIu64, method, next_request_id);
+		} else
+			r->id = tal_fmt(r, "\"cln:%s#%"PRIu64"\"", method, next_request_id);
 	} else {
 		r->id = tal_fmt(r, "%"PRIu64, next_request_id);
 	}
@@ -1423,10 +1434,7 @@ struct jsonrpc_request *jsonrpc_request_start_(
 	if (add_header) {
 		json_object_start(r->stream, NULL);
 		json_add_string(r->stream, "jsonrpc", "2.0");
-		if (r->id_is_string)
-			json_add_string(r->stream, "id", r->id);
-		else
-			json_add_primitive(r->stream, "id", r->id);
+		json_add_id(r->stream, r->id);
 		json_add_string(r->stream, "method", method);
 		json_object_start(r->stream, "params");
 	}

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -362,7 +362,7 @@ static void try_command(struct node_id *peer,
 			const u8 *msg, size_t msglen)
 {
 	struct commando *incoming = tal(plugin, struct commando);
-	const jsmntok_t *toks, *method, *params, *rune;
+	const jsmntok_t *toks, *method, *params, *rune, *id;
 	const char *buf = (const char *)msg, *failmsg;
 	struct out_req *req;
 
@@ -394,6 +394,12 @@ static void try_command(struct node_id *peer,
 		return;
 	}
 	rune = json_get_member(buf, toks, "rune");
+	id = json_get_member(buf, toks, "id");
+	if (!id && !deprecated_apis) {
+		commando_error(incoming, COMMANDO_ERROR_REMOTE,
+			       "missing id field");
+		return;
+	}
 
 	failmsg = check_rune(tmpctx, incoming, peer, buf, method, params, rune);
 	if (failmsg) {

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -679,9 +679,10 @@ static struct command_result *json_commando(struct command *cmd,
 	tal_arr_expand(&outgoing_commands, ocmd);
 	tal_add_destructor2(ocmd, destroy_commando, &outgoing_commands);
 
+	/* We pass through their JSON id untouched. */
 	json = tal_fmt(tmpctx,
-		       "{\"method\":\"%s\",\"params\":%s", method,
-		       cparams ? cparams : "{}");
+		       "{\"method\":\"%s\",\"id\":%s,\"params\":%s", method,
+		       cmd->id, cparams ? cparams : "{}");
 	if (rune)
 		tal_append_fmt(&json, ",\"rune\":\"%s\"", rune);
 	tal_append_fmt(&json, "}");

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -177,14 +177,22 @@ static const char *get_json_id(const tal_t *ctx,
 			       const char *cmd_id,
 			       const char *method)
 {
-	if (cmd_id)
-		return tal_fmt(ctx, "%s/%s:%s#%"PRIu64,
-			       cmd_id,
-			       plugin->id, method,
-			       plugin->next_outreq_id++);
-	return tal_fmt(ctx, "%s:%s#%"PRIu64,
-		       plugin->id, method,
-		       plugin->next_outreq_id++);
+	const char *prefix;
+
+	if (cmd_id) {
+		/* Strip quotes! */
+		if (strstarts(cmd_id, "\"")) {
+			assert(strlen(cmd_id) >= 2);
+			assert(strends(cmd_id, "\""));
+			prefix = tal_fmt(tmpctx, "%.*s/",
+					 (int)strlen(cmd_id) - 2, cmd_id + 1);
+		} else
+			prefix = tal_fmt(tmpctx, "%s/", cmd_id);
+	} else
+		prefix = "";
+
+	return tal_fmt(ctx, "\"%s%s:%s#%"PRIu64"\"",
+		       prefix, plugin->id, method, plugin->next_outreq_id++);
 }
 
 static void destroy_out_req(struct out_req *out_req, struct plugin *plugin)
@@ -225,7 +233,7 @@ jsonrpc_request_start_(struct plugin *plugin, struct command *cmd,
 	out->js = new_json_stream(NULL, cmd, NULL);
 	json_object_start(out->js, NULL);
 	json_add_string(out->js, "jsonrpc", "2.0");
-	json_add_string(out->js, "id", out->id);
+	json_add_id(out->js, out->id);
 	json_add_string(out->js, "method", method);
 	if (out->errcb)
 		json_object_start(out->js, "params");
@@ -251,7 +259,7 @@ static struct json_stream *jsonrpc_stream_start(struct command *cmd)
 
 	json_object_start(js, NULL);
 	json_add_string(js, "jsonrpc", "2.0");
-	json_add_string(js, "id", cmd->id);
+	json_add_id(js, cmd->id);
 
 	return js;
 }
@@ -548,10 +556,12 @@ static const jsmntok_t *sync_req(const tal_t *ctx,
 	const jsmntok_t *contents;
 	int reqlen;
 	struct json_out *jout = json_out_new(tmpctx);
+	const char *id = get_json_id(tmpctx, plugin, "init", method);
 
 	json_out_start(jout, NULL, '{');
 	json_out_addstr(jout, "jsonrpc", "2.0");
-	json_out_addstr(jout, "id", get_json_id(tmpctx, plugin, "init", method));
+	/* Copy in id *literally* */
+	memcpy(json_out_member_direct(jout, "id", strlen(id)), id, strlen(id));
 	json_out_addstr(jout, "method", method);
 	json_out_add_splice(jout, "params", params);
 	if (taken(params))
@@ -810,8 +820,8 @@ static void handle_rpc_reply(struct plugin *plugin, const jsmntok_t *toks)
 		return;
 
 	out = strmap_getn(&plugin->out_reqs,
-			  buf + idtok->start,
-			  idtok->end - idtok->start);
+			  json_tok_full(buf, idtok),
+			  json_tok_full_len(idtok));
 	if (!out) {
 		/* This can actually happen, if they free req! */
 		plugin_log(plugin, LOG_DBG, "JSON reply with unknown id '%.*s'",
@@ -1376,7 +1386,7 @@ struct json_stream *plugin_notify_start(struct command *cmd, const char *method)
 	json_add_string(js, "method", method);
 
 	json_object_start(js, "params");
-	json_add_string(js, "id", cmd->id);
+	json_add_id(js, cmd->id);
 
 	return js;
 }

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -110,6 +110,7 @@ const struct feature_set *plugin_feature_set(const struct plugin *p);
 struct out_req *jsonrpc_request_start_(struct plugin *plugin,
 				       struct command *cmd,
 				       const char *method,
+				       const char *id_prefix,
 				       struct command_result *(*cb)(struct command *command,
 								    const char *buf,
 								    const jsmntok_t *result,
@@ -124,6 +125,7 @@ struct out_req *jsonrpc_request_start_(struct plugin *plugin,
  * "error" members. */
 #define jsonrpc_request_start(plugin, cmd, method, cb, errcb, arg)	\
 	jsonrpc_request_start_((plugin), (cmd), (method),		\
+		     json_id_prefix(tmpctx, (cmd)),			\
 		     typesafe_cb_preargs(struct command_result *, void *, \
 					 (cb), (arg),			\
 					 struct command *command,	\
@@ -139,8 +141,8 @@ struct out_req *jsonrpc_request_start_(struct plugin *plugin,
 
 /* This variant has callbacks received whole obj, not "result" or
  * "error" members.  It also doesn't start params{}. */
-#define jsonrpc_request_whole_object_start(plugin, cmd, method, cb, arg) \
-	jsonrpc_request_start_((plugin), (cmd), (method),		\
+#define jsonrpc_request_whole_object_start(plugin, cmd, method, id_prefix, cb, arg) \
+	jsonrpc_request_start_((plugin), (cmd), (method), (id_prefix),	\
 			       typesafe_cb_preargs(struct command_result *, void *, \
 						   (cb), (arg),		\
 						   struct command *command, \
@@ -469,6 +471,9 @@ struct createonion_response *json_to_createonion_response(const tal_t *ctx,
 
 struct route_hop *json_to_route(const tal_t *ctx, const char *buffer,
 				const jsmntok_t *toks);
+
+/* Create a prefix (ending in /) for this cmd_id, if any. */
+const char *json_id_prefix(const tal_t *ctx, const struct command *cmd);
 
 #if DEVELOPER
 struct htable;

--- a/plugins/test/run-route-overlong.c
+++ b/plugins/test/run-route-overlong.c
@@ -107,6 +107,9 @@ void json_array_start(struct json_stream *js UNNEEDED, const char *fieldname UNN
 const jsmntok_t *json_get_member(const char *buffer UNNEEDED, const jsmntok_t tok[] UNNEEDED,
 				 const char *label UNNEEDED)
 { fprintf(stderr, "json_get_member called!\n"); abort(); }
+/* Generated stub for json_id_prefix */
+const char *json_id_prefix(const tal_t *ctx UNNEEDED, const struct command *cmd UNNEEDED)
+{ fprintf(stderr, "json_id_prefix called!\n"); abort(); }
 /* Generated stub for json_next */
 const jsmntok_t *json_next(const jsmntok_t *tok UNNEEDED)
 { fprintf(stderr, "json_next called!\n"); abort(); }
@@ -184,6 +187,7 @@ bool json_tok_streq(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, 
 struct out_req *jsonrpc_request_start_(struct plugin *plugin UNNEEDED,
 				       struct command *cmd UNNEEDED,
 				       const char *method UNNEEDED,
+				       const char *id_prefix UNNEEDED,
 				       struct command_result *(*cb)(struct command *command UNNEEDED,
 								    const char *buf UNNEEDED,
 								    const jsmntok_t *result UNNEEDED,

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -21,7 +21,7 @@ def test_invoice(node_factory, chainparams):
 
     # Side note: invoice calls out to listincoming, so check JSON id is as expected
     myname = os.path.splitext(os.path.basename(sys.argv[0]))[0]
-    l1.daemon.wait_for_log(r": {}:invoice#[0-9]*/cln:listincoming#[0-9]*\[OUT\]".format(myname))
+    l1.daemon.wait_for_log(r': "{}:invoice#[0-9]*/cln:listincoming#[0-9]*"\[OUT\]'.format(myname))
 
     after = int(time.time())
     b11 = l1.rpc.decodepay(inv['bolt11'])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -937,6 +937,39 @@ def test_cli(node_factory):
     j, _ = json.JSONDecoder().raw_decode(out)
     assert j == {'help': [{'command': 'help [command]'}]}
 
+    # lightningd errors should exit with status 1.
+    ret = subprocess.run(['cli/lightning-cli',
+                          '--network={}'.format(TEST_NETWORK),
+                          '--lightning-dir={}'
+                          .format(l1.daemon.lightning_dir),
+                          'unknown-command'])
+    assert ret.returncode == 1
+
+    # Can't contact will exit with status code 2.
+    ret = subprocess.run(['cli/lightning-cli',
+                          '--network={}'.format(TEST_NETWORK),
+                          '--lightning-dir=xxx',
+                          'help'])
+    assert ret.returncode == 2
+
+    # Malformed parameter (invalid json) will exit with status code 3.
+    ret = subprocess.run(['cli/lightning-cli',
+                          '--network={}'.format(TEST_NETWORK),
+                          '--lightning-dir={}'
+                          .format(l1.daemon.lightning_dir),
+                          'listpeers',
+                          '[xxx]'])
+    assert ret.returncode == 3
+
+    # Bad usage should exit with status 3.
+    ret = subprocess.run(['cli/lightning-cli',
+                          '--bad-param',
+                          '--network={}'.format(TEST_NETWORK),
+                          '--lightning-dir={}'
+                          .format(l1.daemon.lightning_dir),
+                          'help'])
+    assert ret.returncode == 3
+
     # Test missing parameters.
     try:
         # This will error due to missing parameters.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -874,7 +874,7 @@ def test_cli(node_factory):
     assert 'help [command]\n    List available commands, or give verbose help on one {command}' in out
 
     # Check JSON id is as expected
-    l1.daemon.wait_for_log(r"jsonrpc#[0-9]*: cli:help#[0-9]*\[IN\]")
+    l1.daemon.wait_for_log(r'jsonrpc#[0-9]*: "cli:help#[0-9]*"\[IN\]')
 
     # Test JSON output.
     out = subprocess.check_output(['cli/lightning-cli',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2608,7 +2608,7 @@ def test_plugin_shutdown(node_factory):
 
 
 def test_commando(node_factory, executor):
-    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'allow-deprecated-apis': True})
+    l1, l2 = node_factory.line_graph(2, fundchannel=False)
 
     # Nothing works until we've issued a rune.
     fut = executor.submit(l2.rpc.call, method='commando',
@@ -2698,7 +2698,7 @@ def test_commando(node_factory, executor):
 
 
 def test_commando_rune(node_factory):
-    l1, l2 = node_factory.get_nodes(2, opts={'allow-deprecated-apis': True})
+    l1, l2 = node_factory.get_nodes(2)
 
     # Force l1's commando secret
     l1.rpc.datastore(key=['commando', 'secret'], hex='1241faef85297127c2ac9bde95421b2c51e5218498ae4901dc670c974af4284b')
@@ -2933,7 +2933,7 @@ def test_commando_rune(node_factory):
 
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
-    nodes = node_factory.get_nodes(5, opts={'allow-deprecated-apis': True})
+    nodes = node_factory.get_nodes(5)
 
     rune = nodes[0].rpc.commando_rune()['rune']
     for n in nodes[1:]:
@@ -2969,7 +2969,7 @@ def test_commando_stress(node_factory, executor):
 
 def test_commando_badrune(node_factory):
     """Test invalid UTF-8 encodings in rune: used to make us kill the offers plugin which implements decode, as it gave bad utf8!"""
-    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
+    l1 = node_factory.get_node()
     l1.rpc.decode('5zi6-ugA6hC4_XZ0R7snl5IuiQX4ugL4gm9BQKYaKUU9gCZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5Jm1ldGhvZC9saXN0ZGF0YXN0b3Jl')
     rune = l1.rpc.commando_rune(restrictions="readonly")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2648,6 +2648,14 @@ def test_commando(node_factory, executor):
     assert len(res['peers']) == 1
     assert res['peers'][0]['id'] == l2.info['id']
 
+    # Filter test
+    res = l2.rpc.call(method='commando',
+                      payload={'peer_id': l1.info['id'],
+                               'rune': rune,
+                               'method': 'listpeers',
+                               'filter': {'peers': [{'id': True}]}})
+    assert res == {'peers': [{'id': l2.info['id']}]}
+
     with pytest.raises(RpcError, match='missing required parameter'):
         l2.rpc.call(method='commando',
                     payload={'peer_id': l1.info['id'],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2608,7 +2608,7 @@ def test_plugin_shutdown(node_factory):
 
 
 def test_commando(node_factory, executor):
-    l1, l2 = node_factory.line_graph(2, fundchannel=False)
+    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={'allow-deprecated-apis': True})
 
     # Nothing works until we've issued a rune.
     fut = executor.submit(l2.rpc.call, method='commando',
@@ -2698,7 +2698,7 @@ def test_commando(node_factory, executor):
 
 
 def test_commando_rune(node_factory):
-    l1, l2 = node_factory.get_nodes(2)
+    l1, l2 = node_factory.get_nodes(2, opts={'allow-deprecated-apis': True})
 
     # Force l1's commando secret
     l1.rpc.datastore(key=['commando', 'secret'], hex='1241faef85297127c2ac9bde95421b2c51e5218498ae4901dc670c974af4284b')
@@ -2933,7 +2933,7 @@ def test_commando_rune(node_factory):
 
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
-    nodes = node_factory.get_nodes(5)
+    nodes = node_factory.get_nodes(5, opts={'allow-deprecated-apis': True})
 
     rune = nodes[0].rpc.commando_rune()['rune']
     for n in nodes[1:]:
@@ -2969,7 +2969,7 @@ def test_commando_stress(node_factory, executor):
 
 def test_commando_badrune(node_factory):
     """Test invalid UTF-8 encodings in rune: used to make us kill the offers plugin which implements decode, as it gave bad utf8!"""
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={'allow-deprecated-apis': True})
     l1.rpc.decode('5zi6-ugA6hC4_XZ0R7snl5IuiQX4ugL4gm9BQKYaKUU9gCZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5Jm1ldGhvZC9saXN0ZGF0YXN0b3Jl')
     rune = l1.rpc.commando_rune(restrictions="readonly")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2609,7 +2609,9 @@ def test_plugin_shutdown(node_factory):
 
 def test_commando(node_factory, executor):
     l1, l2 = node_factory.line_graph(2, fundchannel=False,
-                                     opts={'log-level': 'io'})
+                                     opts={'log-level': 'io',
+                                           # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
+                                           'allow_broken_log': True})
 
     # Nothing works until we've issued a rune.
     fut = executor.submit(l2.rpc.call, method='commando',
@@ -2704,7 +2706,8 @@ def test_commando(node_factory, executor):
 
 
 def test_commando_rune(node_factory):
-    l1, l2 = node_factory.get_nodes(2)
+    # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
+    l1, l2 = node_factory.get_nodes(2, opts={'allow_broken_log': True})
 
     # Force l1's commando secret
     l1.rpc.datastore(key=['commando', 'secret'], hex='1241faef85297127c2ac9bde95421b2c51e5218498ae4901dc670c974af4284b')
@@ -2939,7 +2942,8 @@ def test_commando_rune(node_factory):
 
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
-    nodes = node_factory.get_nodes(5)
+    # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
+    nodes = node_factory.get_nodes(5, opts={'allow_broken_log': True})
 
     rune = nodes[0].rpc.commando_rune()['rune']
     for n in nodes[1:]:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2608,7 +2608,8 @@ def test_plugin_shutdown(node_factory):
 
 
 def test_commando(node_factory, executor):
-    l1, l2 = node_factory.line_graph(2, fundchannel=False)
+    l1, l2 = node_factory.line_graph(2, fundchannel=False,
+                                     opts={'log-level': 'io'})
 
     # Nothing works until we've issued a rune.
     fut = executor.submit(l2.rpc.call, method='commando',
@@ -2633,6 +2634,11 @@ def test_commando(node_factory, executor):
                                'method': 'listpeers'})
     assert len(res['peers']) == 1
     assert res['peers'][0]['id'] == l2.info['id']
+
+    # Check JSON id is as expected (unfortunately pytest does not use a reliable name
+    # for itself: with -k it calls itself `-c` here, instead of `pytest`).
+    l2.daemon.wait_for_log(r'plugin-commando: "[^:/]*:commando#[0-9]*/cln:commando#[0-9]*"\[OUT\]')
+    l1.daemon.wait_for_log(r'jsonrpc#[0-9]*: "[^:/]*:commando#[0-9]*/cln:commando#[0-9]*/commando:listpeers#[0-9]*"\[IN\]')
 
     res = l2.rpc.call(method='commando',
                       payload={'peer_id': l1.info['id'],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1539,7 +1539,7 @@ def test_libplugin(node_factory):
     # Test hooks and notifications (add plugin, so we can test hook id)
     l2 = node_factory.get_node(options={"plugin": plugin, 'log-level': 'io'})
     l2.connect(l1)
-    l2.daemon.wait_for_log(r": {}:connect#[0-9]*/cln:peer_connected#[0-9]*\[OUT\]".format(myname))
+    l2.daemon.wait_for_log(r': "{}:connect#[0-9]*/cln:peer_connected#[0-9]*"\[OUT\]'.format(myname))
 
     l1.daemon.wait_for_log("{} peer_connected".format(l2.info["id"]))
     l1.daemon.wait_for_log("{} connected".format(l2.info["id"]))

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2609,9 +2609,7 @@ def test_plugin_shutdown(node_factory):
 
 def test_commando(node_factory, executor):
     l1, l2 = node_factory.line_graph(2, fundchannel=False,
-                                     opts={'log-level': 'io',
-                                           # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
-                                           'allow_broken_log': True})
+                                     opts={'log-level': 'io'})
 
     # Nothing works until we've issued a rune.
     fut = executor.submit(l2.rpc.call, method='commando',
@@ -2706,8 +2704,7 @@ def test_commando(node_factory, executor):
 
 
 def test_commando_rune(node_factory):
-    # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
-    l1, l2 = node_factory.get_nodes(2, opts={'allow_broken_log': True})
+    l1, l2 = node_factory.get_nodes(2)
 
     # Force l1's commando secret
     l1.rpc.datastore(key=['commando', 'secret'], hex='1241faef85297127c2ac9bde95421b2c51e5218498ae4901dc670c974af4284b')
@@ -2942,8 +2939,7 @@ def test_commando_rune(node_factory):
 
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
-    # FIXME: Currently, our JSON ids in replies are wrong, hence BROKEN!
-    nodes = node_factory.get_nodes(5, opts={'allow_broken_log': True})
+    nodes = node_factory.get_nodes(5)
 
     rune = nodes[0].rpc.commando_rune()['rune']
     for n in nodes[1:]:

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -62,7 +62,7 @@ def test_withdraw(node_factory, bitcoind):
 
     # Side note: sendrawtransaction will trace back to withdrawl
     myname = os.path.splitext(os.path.basename(sys.argv[0]))[0]
-    l1.daemon.wait_for_log(r": {}:withdraw#[0-9]*/cln:withdraw#[0-9]*/txprepare:sendpsbt#[0-9]*/cln:sendrawtransaction#[0-9]*\[OUT\]".format(myname))
+    l1.daemon.wait_for_log(r': "{}:withdraw#[0-9]*/cln:withdraw#[0-9]*/txprepare:sendpsbt#[0-9]*/cln:sendrawtransaction#[0-9]*"\[OUT\]'.format(myname))
 
     # Make sure bitcoind received the withdrawal
     unspent = l1.bitcoin.rpc.listunspent(0)


### PR DESCRIPTION
- Clean up our JSON id handling generally.
- Clean up JSON ids in commando commands specifically.
- Support filtering on server-side via `filter` parameter for `commando` cmd.
- Add `--commando=peerid/rune` convenience wrapper for `lightning-cli`.