### PR TITLE
Add deprecation / addition information to schemas

### DIFF
--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1613,8 +1613,10 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsFunding {
+	    #[deprecated]
 	    #[serde(alias = "local_msat", skip_serializing_if = "Option::is_none")]
 	    pub local_msat: Option<Amount>,
+	    #[deprecated]
 	    #[serde(alias = "remote_msat", skip_serializing_if = "Option::is_none")]
 	    pub remote_msat: Option<Amount>,
 	    #[serde(alias = "pushed_msat", skip_serializing_if = "Option::is_none")]

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -203,3 +203,14 @@ doc/index.rst: $(MANPAGES:=.md)
 	  sed 's/\(.*\)\.\(.*\).*\.md/\1 <\1.\2.md>/' | \
 	  python3 devtools/blockreplace.py doc/index.rst manpages --language=rst --indent "   " \
 	)
+
+# For CI to (very roughly!) check that we only deprecated fields, or labelled added ones
+schema-added-check:
+	@if git diff master doc/schemas | grep -q '^+.*{' && ! git diff master doc/schemas | grep -q '^+.*"added"'; then echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; fi
+
+schema-removed-check:
+	@if git diff master doc/schemas | grep -q '^-.*{' && ! git diff master doc/schemas | grep -q '^-.*"deprecated": "'; then echo 'Schema fields must be deprecated, with version, not removed' >&2; exit 1; fi
+
+schema-diff-check: schema-added-check schema-removed-check
+
+check-source: schema-diff-check

--- a/doc/lightning-addgossip.7.md
+++ b/doc/lightning-addgossip.7.md
@@ -42,4 +42,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)
+[comment]: # ( SHA256STAMP:ec98523e094209b75eeeb620d8f2a64409dafe6ba21baf3a89ade514b285d202)

--- a/doc/lightning-autoclean-once.7.md
+++ b/doc/lightning-autoclean-once.7.md
@@ -67,4 +67,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:9853f639595b1fd8d04e41cf7fe8de9bb90d1cb132c70dd4f8db8a7cf6f1233b)
+[comment]: # ( SHA256STAMP:98305a03bfeabffa053acbec0ed7d85ad9c0e342aad2b90aec260a51f0842e42)

--- a/doc/lightning-autoclean-status.7.md
+++ b/doc/lightning-autoclean-status.7.md
@@ -91,4 +91,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:151fc6cdfd277cac7e6f18e98384b40a6cc1c2a3eb2d0f1e3c26442aa0e9e8d4)
+[comment]: # ( SHA256STAMP:32dcce7526a1ebb45e7018df70434cdbe2fe3a78ac64c1d257a85e49d7cfa755)

--- a/doc/lightning-batching.7.md
+++ b/doc/lightning-batching.7.md
@@ -53,4 +53,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)
+[comment]: # ( SHA256STAMP:ec98523e094209b75eeeb620d8f2a64409dafe6ba21baf3a89ade514b285d202)

--- a/doc/lightning-bkpr-channelsapy.7.md
+++ b/doc/lightning-bkpr-channelsapy.7.md
@@ -65,4 +65,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:05c9260f9ba49e3c3333ec7d4b0e671f81b8f8cd32cde87ea46c532b54ae7e54)
+[comment]: # ( SHA256STAMP:c4521fe6da034f419cc94e1e0e969e7c230e8342412ea91c929ba30812175451)

--- a/doc/lightning-bkpr-dumpincomecsv.7.md
+++ b/doc/lightning-bkpr-dumpincomecsv.7.md
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:8c27ebf6e36fb26051ec724d44497d765454cac071d287586d2b0490e690c01c)
+[comment]: # ( SHA256STAMP:23c9bdc615f0fc8475b16a5a79607b8da528c9a218c32c8f2ccab835fe0b9078)

--- a/doc/lightning-bkpr-inspect.7.md
+++ b/doc/lightning-bkpr-inspect.7.md
@@ -52,4 +52,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1fc6c84962d2c670b3555dbdb7ffdddf33c4f5c445f3cfbab474a6c017ead06b)
+[comment]: # ( SHA256STAMP:6b3c960fb6d159ba5df5bd85960a8145e6dec7487ac84837127f9d461c1e8103)

--- a/doc/lightning-bkpr-listaccountevents.7.md
+++ b/doc/lightning-bkpr-listaccountevents.7.md
@@ -71,4 +71,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2326473627193f2e7d2a1688d046106996a43602ccad64df16913e89bf67b3e8)
+[comment]: # ( SHA256STAMP:b075f8f54879e8b2f1d9d1b93f08f0fb7a2be6fc7c5bff051b3c1d575596da81)

--- a/doc/lightning-bkpr-listbalances.7.md
+++ b/doc/lightning-bkpr-listbalances.7.md
@@ -53,4 +53,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ece6c722354576bd5de4d116547546129cdb22e950ce5e9fde3c4d7466bd255c)
+[comment]: # ( SHA256STAMP:d274d8cde5ec727630d6529664f0a1e287968e7071d3e2d7ca041bd5ee681d73)

--- a/doc/lightning-bkpr-listincome.7.md
+++ b/doc/lightning-bkpr-listincome.7.md
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:8d35ccd4a389f70dc69bda4b66bd834bd48198191565fe37d4af8caa165a8108)
+[comment]: # ( SHA256STAMP:3af2f2f05de9f698154d9fb90d7722bc7b47b8c220af58e90034636219198c87)

--- a/doc/lightning-check.7.md
+++ b/doc/lightning-check.7.md
@@ -41,4 +41,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0a799d16e3f191b6c5dbea039ba32c6824718b326a1178b1f4948461c8ba6a0b)
+[comment]: # ( SHA256STAMP:632a4a2cdaac10cdde1719f70bea672f3dc7c292e25395c6235255b1e2a11b28)

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -50,4 +50,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7a8b174b98e2e339e0001de740d19ac83042617eaad9b160fa5a8a3525ce7bc4)
+[comment]: # ( SHA256STAMP:ad6f3db0c6da357d6849aae546d50439e30cc43329150f02c1801a74e8c1c338)

--- a/doc/lightning-close.7.md
+++ b/doc/lightning-close.7.md
@@ -135,4 +135,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f323b7998a41c28a6c398b8e4ebbefcd227b7624dcf7c03373b518bc55211dd6)
+[comment]: # ( SHA256STAMP:d226164144e972628ff14d72e80a86b0016902851fde8f696f869abce697ff82)

--- a/doc/lightning-commando-rune.7.md
+++ b/doc/lightning-commando-rune.7.md
@@ -218,4 +218,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:5f4371a060861ca04019948242803f8b6254627f9993a866ec6e119d8a14cef6)
+[comment]: # ( SHA256STAMP:edf7087118018f9cc94b37aa3bb5bf976364d095d3d6bd1472cea171d9605183)

--- a/doc/lightning-connect.7.md
+++ b/doc/lightning-connect.7.md
@@ -104,4 +104,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:b9f59ec875e50da2251c3e9e6166e62cfc473a46e29eece96705f34c27841782)
+[comment]: # ( SHA256STAMP:c1361f5a2b1cff63b7ca5367c2d8b04c30f617c8a5943160afff620d5a099faa)

--- a/doc/lightning-createinvoice.7.md
+++ b/doc/lightning-createinvoice.7.md
@@ -75,4 +75,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:8f1ca1ec7fafd96f38d6ffaa0b9b1d0ac0a5ec5d535c45b8b4cb08257468a6b2)
+[comment]: # ( SHA256STAMP:e770524d66bd9c0eed2ebba2a9b73aab9cc6be10e2e1500f13506624b1703bf1)

--- a/doc/lightning-createonion.7.md
+++ b/doc/lightning-createonion.7.md
@@ -132,4 +132,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:da11700fff0b97851d2c649b3717a3b51c606a930b84dbdd24fb3367dd7de8cb)
+[comment]: # ( SHA256STAMP:9cb9d5ecae6a2480ba26ae9a6b3d894c81c4f7dbdcfbcc2132e7df5958886616)

--- a/doc/lightning-datastore.7.md
+++ b/doc/lightning-datastore.7.md
@@ -66,4 +66,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:65c6c1cb555e5042c3d5d7ad4f9577ec75838d497349c8caee7e186486e09d04)
+[comment]: # ( SHA256STAMP:6f79d42d7c47fb7fde8debdadde78a658c3502299dfbbf7422cf19fc482f4019)

--- a/doc/lightning-decode.7.md
+++ b/doc/lightning-decode.7.md
@@ -302,4 +302,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7920e365fe0f41fc2aa99c9e99af7c0666da229310ce50c2c2728c973069b2a7)
+[comment]: # ( SHA256STAMP:eadd9b06e6cb495a794568f3a9e2371c09718311c0b61ad05b0fca3014c429d3)

--- a/doc/lightning-decodepay.7.md
+++ b/doc/lightning-decodepay.7.md
@@ -71,4 +71,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:a1163f7535526b8f9bcea137c6cd5d270e0730d2d58f8c8487794415273dd489)
+[comment]: # ( SHA256STAMP:2b48a4c96cbb86a667fb920bbcf477b2971795eaf394f72b436351d6063441f2)

--- a/doc/lightning-deldatastore.7.md
+++ b/doc/lightning-deldatastore.7.md
@@ -49,4 +49,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0d9d6e4336f6317ca85628b76f2aa40a5172b54333a1a3931e1284d9a803f61b)
+[comment]: # ( SHA256STAMP:67036bda933bda35532ea55be1b6140785132d8d747094aba09d47fed40ec5ea)

--- a/doc/lightning-delexpiredinvoice.7.md
+++ b/doc/lightning-delexpiredinvoice.7.md
@@ -38,4 +38,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:aa572f59f54ad8ca0d2c43d41574e9068c7d5dc371927638b7c8a0c1c3b6e496)
+[comment]: # ( SHA256STAMP:6c100f08fe4cb4aa4f1b78243bfeb4414db2ff9bb5145fdb9eca7c9a4037d0e3)

--- a/doc/lightning-delforward.7.md
+++ b/doc/lightning-delforward.7.md
@@ -55,4 +55,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4aff9673290966c7b09e65672da5dc8ef4d2601d3d1681009b329a4f8ceb9af6)
+[comment]: # ( SHA256STAMP:a2b84b83e10b81fd82a2bed20874f707de6002c076a4276d4f6ff30772ad3e88)

--- a/doc/lightning-delinvoice.7.md
+++ b/doc/lightning-delinvoice.7.md
@@ -81,4 +81,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c21dd851c40769c1b79489ccaf364c4647a67bf6cd1a34dd96a8574016d66d96)
+[comment]: # ( SHA256STAMP:8748474d2323baf828d343de470f0f890e92d59240cd0f56bc6f0a3a802b7c70)

--- a/doc/lightning-delpay.7.md
+++ b/doc/lightning-delpay.7.md
@@ -107,4 +107,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6f1e5f66278e49d10d5556abfabbab6a178f0dbd518b669ce93a32e6763dd458)
+[comment]: # ( SHA256STAMP:996cdabe39a1c684f92ffee47334da2ef921ecb1bb411b063c8a748e172c3f20)

--- a/doc/lightning-disableoffer.7.md
+++ b/doc/lightning-disableoffer.7.md
@@ -75,4 +75,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f6896438745837d5f1f5999553b397660eded7b22e5d0765ce5feaa3fc14e48e)
+[comment]: # ( SHA256STAMP:7a813b5ae0c4ae2a9a77063d710ee7d4ef621d828e6a4a57c59d62d3f2091c89)

--- a/doc/lightning-disconnect.7.md
+++ b/doc/lightning-disconnect.7.md
@@ -59,4 +59,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)
+[comment]: # ( SHA256STAMP:ec98523e094209b75eeeb620d8f2a64409dafe6ba21baf3a89ade514b285d202)

--- a/doc/lightning-feerates.7.md
+++ b/doc/lightning-feerates.7.md
@@ -121,4 +121,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c4fbacd9a36de4ed8307deae74f49e40a158435d726aee02f5c37f7a31a71400)
+[comment]: # ( SHA256STAMP:4b1fa6f6ac4a6f9218486d9b42c8bc684fd48ad615b5644a0cd6650719d32a78)

--- a/doc/lightning-fetchinvoice.7.md
+++ b/doc/lightning-fetchinvoice.7.md
@@ -89,4 +89,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:59b33634070b62e711cae7457bfb08874851e4e001512feaefc5ddac1a5b3b5b)
+[comment]: # ( SHA256STAMP:8946b80c01151cfbb8c363a6c95e57e17cae39ad0fc9fa79646cd74af3548a5d)

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -121,4 +121,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ed7d5aa730bf6b87b3f7072272b984539ca991670c13f85a0da8d4d1333549ae)
+[comment]: # ( SHA256STAMP:4c393a5fb6bd920dfbe2bbf79120f5d11bc9f5b18d71a70a519d245b0c366ee6)

--- a/doc/lightning-fundchannel_cancel.7.md
+++ b/doc/lightning-fundchannel_cancel.7.md
@@ -60,4 +60,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:d8a18db4d75c051ec89cd2a52add52aea04e78608c625270238c992b977ec173)
+[comment]: # ( SHA256STAMP:ac584f54804ac2b3d28ab4ddb9cd6ebb9deb36d49a431e25b1d63cfb3a0480d3)

--- a/doc/lightning-fundchannel_complete.7.md
+++ b/doc/lightning-fundchannel_complete.7.md
@@ -62,4 +62,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:a1853aa4288c0ee50956328f02e86b580de0dffc8b73e204c8f5daaa79c51a0c)
+[comment]: # ( SHA256STAMP:c7c616115c90f39b896ac5cfba7d7bbdb9ec9e762e3de9527e8222d1a3a78e44)

--- a/doc/lightning-fundchannel_start.7.md
+++ b/doc/lightning-fundchannel_start.7.md
@@ -85,4 +85,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ca4ad15c25dc588980dea11be9d3f73c9da3688a5e81bfc13660eabe93cbec13)
+[comment]: # ( SHA256STAMP:f19bf6fedcc7c62a4422ef06abe1eb5b5d10aa4345b6a39ae5fce7408448ae0a)

--- a/doc/lightning-funderupdate.7.md
+++ b/doc/lightning-funderupdate.7.md
@@ -147,4 +147,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:13eef3ba929ea98506f6ed3d042072be6f70fd01d503ca5f7b49480dea7af627)
+[comment]: # ( SHA256STAMP:3ff71c0a62f350d099dbe5b3e5c4e20b486214a23333fcf5bcd6e7b062175ff9)

--- a/doc/lightning-fundpsbt.7.md
+++ b/doc/lightning-fundpsbt.7.md
@@ -115,4 +115,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:35947e2b2c402a87c4bad3a5a90443bfe5db44d71cb515541074abfc4dc3f24d)
+[comment]: # ( SHA256STAMP:90e5335b405a3ca2f0a84f3a13044f7f990ae74c29155330f9ba10f4e102f43d)

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -132,4 +132,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ce2b96e2e97cf6bc1e311d6125253dfbed900f13c001f518e9a0b4f202a0e1d6)
+[comment]: # ( SHA256STAMP:d458c44f03d1c242c484627d514b373bf14eca600a0a8390787d370a2ffd2559)

--- a/doc/lightning-getlog.7.md
+++ b/doc/lightning-getlog.7.md
@@ -33,7 +33,7 @@ On success, an object is returned, containing:
 
 - **created\_at** (string): UNIX timestamp with 9 decimal places, when logging was initialized
 - **bytes\_used** (u32): The number of bytes used by logging records
-- **bytes\_max** (u32): The bytes\_used values at which records will be trimmed
+- **bytes\_max** (u32): The bytes\_used values at which records will be trimmed 
 - **log** (array of objects):
   - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO\_IN", "IO\_OUT")
 
@@ -95,4 +95,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6b925456a06076ba98a04df3ff6931d2cd5d09ccec82829301428493ff824e34)
+[comment]: # ( SHA256STAMP:398c4068ebf1e340224f86d4eee0d3c7ed326e4b9abbb8f587c0177482f34cf0)

--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -310,4 +310,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7456e80dc70830703bd8fd05d4047f721592bc3c1b2c51fbcb54ce0d87167380)
+[comment]: # ( SHA256STAMP:baddf8e1a08e80c52b89d7a4d03c671d4a34a79eae3ae9c53b8ea6cea8ae5e4d)

--- a/doc/lightning-help.7.md
+++ b/doc/lightning-help.7.md
@@ -69,4 +69,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:64c5aa03469d6cb3e00e46141a5f11e499a0cc74a13b5600b26aa6dd1539346f)
+[comment]: # ( SHA256STAMP:bcf64b5073bc6aff09781631cdd9c72c57df5ba84244e59a2b7841f4eb43ab1c)

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -119,4 +119,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:e3b07ce2a4cbe9198d5a65df1e49b628a8a7e857770e004a1d84c41c67601712)
+[comment]: # ( SHA256STAMP:cb98bfe9144b9b0589beaf051da3e3a282103b901771a93c28e76a8e92a43ad5)

--- a/doc/lightning-keysend.7.md
+++ b/doc/lightning-keysend.7.md
@@ -118,4 +118,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:b6a047c09d40be10ed9027ca0f38332a57bfe7a232fa66fa5a669cf76e2731cd)
+[comment]: # ( SHA256STAMP:0fa28491cf3a3d33ced217e89bd3bdcaa8f0e1b7a547312d19aa8dc3a780161a)

--- a/doc/lightning-listchannels.7.md
+++ b/doc/lightning-listchannels.7.md
@@ -79,4 +79,4 @@ Lightning RFC site
 -   BOLT \#7:
     <https://github.com/lightning/bolts/blob/master/07-routing-gossip.md>
 
-[comment]: # ( SHA256STAMP:693b8297d390522cd68a27b607194567cebb7bf021f769c82d430afced9d0029)
+[comment]: # ( SHA256STAMP:d8d52272963a9ec4708fd3ae41585ddd8120bb5444c03219a7b728f0b2e09ec3)

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -220,4 +220,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4a72e74f8551a9ded7ad9a23044198c985530b72d9a8974bb4ef68b3ee37b8da)
+[comment]: # ( SHA256STAMP:8e668233f6814cd1e64c735fba57d7fb6449636a17c48ed881b3eb1e66c19e7a)

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -101,7 +101,7 @@ On success, an object is returned, containing:
 - **accept-htlc-tlv-types** (string, optional): `accept-htlc-tlv-types` fields from config or cmdline, or not present
 - **tor-service-password** (string, optional): `tor-service-password` field from config or cmdline, if any
 - **dev-allowdustreserve** (boolean, optional): Whether we allow setting dust reserves
-- **announce-addr-dns** (boolean, optional): Whether we put DNS entries into node\_announcement
+- **announce-addr-dns** (boolean, optional): Whether we put DNS entries into node\_announcement *(added v22.11.1)*
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -220,4 +220,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:8e668233f6814cd1e64c735fba57d7fb6449636a17c48ed881b3eb1e66c19e7a)
+[comment]: # ( SHA256STAMP:bc7c3374ba6609553f431deae62c1e5525e136086b39fffb6c674a58365c0740)

--- a/doc/lightning-listdatastore.7.md
+++ b/doc/lightning-listdatastore.7.md
@@ -47,4 +47,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ccb9085c7ad0757e324e4e74d5a22009153f2a9f40f4e926c15fc918ab2bab4f)
+[comment]: # ( SHA256STAMP:624530c12b1e247c79ee966090bf021f2c8570a8ae73da09cf14302d6784f981)

--- a/doc/lightning-listforwards.7.md
+++ b/doc/lightning-listforwards.7.md
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2627ce6a1e4877810e690a40fda2145292ce15f0b1393d3b35b4c54b599b044e)
+[comment]: # ( SHA256STAMP:68d847297711c3881fc9118de8e0e3994b7f4fb2a831b62dca1bb33d490d8416)

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -73,4 +73,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:5c118dc7780049bcd320aa16d301bf778552fe6ae42c9d598a3926ab0c14694d)
+[comment]: # ( SHA256STAMP:a9a29cb20e610f7c62f61bba5826d76f4f6be72b1e8f0fecfb8207c1b90712a1)

--- a/doc/lightning-listhtlcs.7.md
+++ b/doc/lightning-listhtlcs.7.md
@@ -46,4 +46,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:444e5aefafe607226d36b80adfebef7bf0b9173dbb28bbfcc7f78aaed0eac682)
+[comment]: # ( SHA256STAMP:2f658fb394c49408c60c03b396bbc5afe7465fd33f48d8043233f2fe2b76f25e)

--- a/doc/lightning-listinvoices.7.md
+++ b/doc/lightning-listinvoices.7.md
@@ -58,4 +58,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:67af32ecf6319aec4376074b0f0a1b42cf111cbb3acec0108d7f3607dc441252)
+[comment]: # ( SHA256STAMP:0dd6207e711b96094310c9d6b56575eb7e475a4a5bf728cd2b6e8d408ed3abbe)

--- a/doc/lightning-listnodes.7.md
+++ b/doc/lightning-listnodes.7.md
@@ -100,4 +100,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:030d48d2a5fc02cb26fc2a35125116085eb67d0afc39066259adacc433a3d38b)
+[comment]: # ( SHA256STAMP:938937f92ed57a3ff70ae5613ccc1709d500ea91c77ca261cb82f9f40c30579e)

--- a/doc/lightning-listoffers.7.md
+++ b/doc/lightning-listoffers.7.md
@@ -81,4 +81,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:088d6fef8790bc9151b07f9b974568ce612c7fea8f52fdcaaf52b32e4ef8d5f2)
+[comment]: # ( SHA256STAMP:e3e1446c2c1bf74852663c1d417bb386908c47898b05e958f153f806e73a9b4c)

--- a/doc/lightning-listpays.7.md
+++ b/doc/lightning-listpays.7.md
@@ -57,4 +57,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ee5242e7cf0a7c1385ab26885436b723b916f0d4e17080323876781e8c2aee76)
+[comment]: # ( SHA256STAMP:ebdcb353fc2b11f6d83610c538206ef348a24b77af4cb2dcd535235f50ee5c39)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -399,4 +399,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:faff728119e12d98202be265991e8b2c17dfa1a611bc52586c662fe8bfdccf53)
+[comment]: # ( SHA256STAMP:6d080ab1b7a6c3577fb535a05539a91fbf7927518cbefaece4565212ea5b586e)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -74,8 +74,8 @@ On success, an object containing **peers** is returned.  It is an array of objec
   - **funding** (object, optional):
     - **local\_funds\_msat** (msat): Amount of channel we funded
     - **remote\_funds\_msat** (msat): Amount of channel they funded
-    - **local\_msat** (msat, optional): Amount of channel we funded (deprecated)
-    - **remote\_msat** (msat, optional): Amount of channel they funded (deprecated)
+    - **local\_msat** (msat, optional): Amount of channel we funded **deprecated, removal in v23.05**
+    - **remote\_msat** (msat, optional): Amount of channel they funded **deprecated, removal in v23.05**
     - **pushed\_msat** (msat, optional): Amount pushed from opener to peer
     - **fee\_paid\_msat** (msat, optional): Amount we paid peer at open
     - **fee\_rcvd\_msat** (msat, optional): Amount we were paid by peer at open
@@ -399,4 +399,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:6d080ab1b7a6c3577fb535a05539a91fbf7927518cbefaece4565212ea5b586e)
+[comment]: # ( SHA256STAMP:c84136fcca3d0295cd1612873a54a074f3e8b6ae9cc643489cab6fb7376d66f6)

--- a/doc/lightning-listsendpays.7.md
+++ b/doc/lightning-listsendpays.7.md
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:bd2975d79d2000a8f390da4744c79a924b4fba8268830d086d5024defe8ac274)
+[comment]: # ( SHA256STAMP:c7a067147e3275afa7f0cad68a6e1d9c0a10fad038a7b95b9c173edf523aee23)

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -106,4 +106,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:1a1afbcbcdbd19df28020d48c581dfff6ed4f5beaf557e1423edb6828eb78a07)
+[comment]: # ( SHA256STAMP:450383460036860bfeb65fac98582b4c075d9b6c8df326f22ee1aabde7980d74)

--- a/doc/lightning-makesecret.7.md
+++ b/doc/lightning-makesecret.7.md
@@ -38,4 +38,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:5560433bde5292bad74eab0b688d8e6baa0a51562670a4f486d41b4eb2103ca8)
+[comment]: # ( SHA256STAMP:3a09136243f716a657368f4483d4211ac37853eb69f26b8b30f1270ed2c6e993)

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -164,4 +164,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:0dc2b563ed6995f65388a52b01e8882a167ead3c1d3b3dc985486cd8b4dfe157)
+[comment]: # ( SHA256STAMP:604a53a621512eebeeccdd2ec677f08577b3cd3c41d10439a7eb00ae1fe11121)

--- a/doc/lightning-multiwithdraw.7.md
+++ b/doc/lightning-multiwithdraw.7.md
@@ -73,4 +73,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:632868a585b9150a80ccc4ba173d90a8beebab8e604c06f1ccdc4493604152e3)
+[comment]: # ( SHA256STAMP:715042b3e709227dcb00068190a8566a1fe678840aa56e566fd4af27971150c8)

--- a/doc/lightning-newaddr.7.md
+++ b/doc/lightning-newaddr.7.md
@@ -58,4 +58,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2178e43f4b90a07f1d31679f86e7e5b1bc5239333ba64652614f03847c869fd4)
+[comment]: # ( SHA256STAMP:8ed49212ffddf29077007efe38a6b6446cc9c351cb24a1454030526c89407175)

--- a/doc/lightning-notifications.7.md
+++ b/doc/lightning-notifications.7.md
@@ -103,4 +103,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:6ab8038cbad395e5a65a52fe66948740ad360c123e42c28d5879f5f03369b744)
+[comment]: # ( SHA256STAMP:ec98523e094209b75eeeb620d8f2a64409dafe6ba21baf3a89ade514b285d202)

--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -135,4 +135,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:a9cd6cc9f41fefc87c060ee979599f55154a11fc3a9b5dca046cea3e9c2385c2)
+[comment]: # ( SHA256STAMP:ea0d06ff5697d92e37b9c737324ed0c10417b5fc2374cde2590c59c48821bc88)

--- a/doc/lightning-offerout.7.md
+++ b/doc/lightning-offerout.7.md
@@ -99,4 +99,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4f780ca32d486bd715eed86a130b87ff1515fce6f9e225cb13219267b82b33bb)
+[comment]: # ( SHA256STAMP:e28527bc56d2b54a77b222376c9280a612f7337c908ee0edcfa56d4d0ca2ac6c)

--- a/doc/lightning-openchannel_abort.7.md
+++ b/doc/lightning-openchannel_abort.7.md
@@ -56,4 +56,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:f80423882383e5cb39b86543eb8cfbc0d9b6731ea85af3b3e1fb8973b9355781)
+[comment]: # ( SHA256STAMP:c6f95d7c5638e19315ae917ea64adce77cfa492c12be843813a93e03027c82f1)

--- a/doc/lightning-openchannel_bump.7.md
+++ b/doc/lightning-openchannel_bump.7.md
@@ -82,4 +82,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:fe2bf77f2cb693ee91ab1977d05ba8431b0a8bed67aa1bbda6992bf64604081b)
+[comment]: # ( SHA256STAMP:346ffc931abfac76cb31643ee032fc8fbdc0ab164bf2862d51a8e33944bbfa86)

--- a/doc/lightning-openchannel_init.7.md
+++ b/doc/lightning-openchannel_init.7.md
@@ -104,4 +104,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ca7708f0c64afc898cb336eafb26ee384895f83b2026aecab75596372d33e46e)
+[comment]: # ( SHA256STAMP:d8d6bf454bb96dbb679e37ca7d1f13789a78653dced75c840433091b6cc6ffed)

--- a/doc/lightning-openchannel_signed.7.md
+++ b/doc/lightning-openchannel_signed.7.md
@@ -68,4 +68,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2ee447b0f9d13ebe8898addc99f52a9024f0e80f67fa505dcc35a3256c3e4c55)
+[comment]: # ( SHA256STAMP:61131b40f71d7c11a7a4d1633cf57a4a14bd60ff6b8867f06183bee60569ef67)

--- a/doc/lightning-openchannel_update.7.md
+++ b/doc/lightning-openchannel_update.7.md
@@ -73,4 +73,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:223ec3a444341e4c269eab3c3fbe80f13df9258b5f7a548d9e32698a5d4d6790)
+[comment]: # ( SHA256STAMP:0790e67080591d43ff7dcb033bef7e96d04be6719aa22deec69f2e019634c48d)

--- a/doc/lightning-parsefeerate.7.md
+++ b/doc/lightning-parsefeerate.7.md
@@ -44,4 +44,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:e61c7a3d05b16533716be2052d7235829c1fb69896d38e6ad31baf12a3f4cb02)
+[comment]: # ( SHA256STAMP:d192483fc5442582e9765fcb0657f3470083a1acfffdcbf72b9e414581a7f0e3)

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -168,4 +168,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:735dd61146b04745f1e884037ead662a386fec2c41e2de1a8698d6bb03f63540)
+[comment]: # ( SHA256STAMP:772f97fc664c5c6ca4cc24eade35b82d55681732518351e6343caed25bd7c2b5)

--- a/doc/lightning-ping.7.md
+++ b/doc/lightning-ping.7.md
@@ -71,4 +71,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:fe8760ada0a86222a74dc1c78ff111325a2247d5ca90683347b8e8f5dee8a867)
+[comment]: # ( SHA256STAMP:81b2e86262fb39f609f2ea93ffa2b3236758759d51612d331bbcc87406a15637)

--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -84,4 +84,4 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [writing plugins]: PLUGINS.md
-[comment]: # ( SHA256STAMP:5e067df44c38f3ee529cc30ac66050830244d0d9b91d7ad386e3c50aa841b0e9)
+[comment]: # ( SHA256STAMP:243a25cee50c6f04262551bc170f2c6b1d123ba9e85d574a2facaa2aabed5dc9)

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -64,4 +64,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:c3bb624daff32be6701e54505432ee6d33aab6491e3286791331d0b680fee737)
+[comment]: # ( SHA256STAMP:ab791403170230278c7b17a81af79d7b5332188a4f23c83c81dfa97638584e5e)

--- a/doc/lightning-sendcustommsg.7.md
+++ b/doc/lightning-sendcustommsg.7.md
@@ -69,4 +69,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:2427c75c952bbbd5a3ccf69a217516a73079a014bb656aff3de7038a26cd301b)
+[comment]: # ( SHA256STAMP:66216a842041c93d3527d7130dbb57fd4b34e6b5426fdc1bfd368302f6f8c611)

--- a/doc/lightning-sendinvoice.7.md
+++ b/doc/lightning-sendinvoice.7.md
@@ -80,4 +80,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:32b4918787ebd97b7a64cca0fe7d26f259688cbbad93ce89a4dd3e9201d66b78)
+[comment]: # ( SHA256STAMP:9e35052033fbb78416b024c22d8ecca256eaaf45b16b3b23b09a14920c155133)

--- a/doc/lightning-sendonion.7.md
+++ b/doc/lightning-sendonion.7.md
@@ -135,4 +135,4 @@ RESOURCES
 Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md
-[comment]: # ( SHA256STAMP:d01679d11406d49930e69a7492550a36118950b0d93acca5c26b299fc91680a4)
+[comment]: # ( SHA256STAMP:dab3d2111fac44ea7d0183485e6f67566d2c577f9dafde8a897f438fab04e7e6)

--- a/doc/lightning-sendonionmessage.7.md
+++ b/doc/lightning-sendonionmessage.7.md
@@ -43,4 +43,4 @@ Main web site: <https://github.com/ElementsProject/lightning>
 
 [bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md
 
-[comment]: # ( SHA256STAMP:4aff9673290966c7b09e65672da5dc8ef4d2601d3d1681009b329a4f8ceb9af6)
+[comment]: # ( SHA256STAMP:a2b84b83e10b81fd82a2bed20874f707de6002c076a4276d4f6ff30772ad3e88)

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -142,4 +142,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:b7f1a5efd80156722e5f9cca6f291306fcd22ab7b9b2754beac880f2ae5a7418)
+[comment]: # ( SHA256STAMP:d5df663428080fdd470950ec3c0c6630511f0936e7acd3ed860313ed95f33579)

--- a/doc/lightning-sendpsbt.7.md
+++ b/doc/lightning-sendpsbt.7.md
@@ -67,4 +67,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:632868a585b9150a80ccc4ba173d90a8beebab8e604c06f1ccdc4493604152e3)
+[comment]: # ( SHA256STAMP:715042b3e709227dcb00068190a8566a1fe678840aa56e566fd4af27971150c8)

--- a/doc/lightning-setchannel.7.md
+++ b/doc/lightning-setchannel.7.md
@@ -107,4 +107,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:31300838ff4b12d9bf43879c91a5d51af76f70ebe8527a35ba476801424c3e65)
+[comment]: # ( SHA256STAMP:3c0f2eb8fc8cfcebea463eaefab17eb96310b24ce6566f5c5a8f95bebf81fcb4)

--- a/doc/lightning-signmessage.7.md
+++ b/doc/lightning-signmessage.7.md
@@ -23,7 +23,7 @@ On success, an object is returned, containing:
 
 - **signature** (hex): The signature (always 128 characters)
 - **recid** (hex): The recovery id (0, 1, 2 or 3) (always 2 characters)
-- **zbase** (string): *signature* and *recid* encoded in a style compatible with **lnd**'s [SignMessageRequest](https://api.lightning.community/#signmessage-2)
+- **zbase** (string): *signature* and *recid* encoded in a style compatible with **lnd**'s [SignMessageRequest](https://api.lightning.community/#grpc-request-signmessagerequest)
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -42,4 +42,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:ac618ebda6ab3acac85729f7b3e5607ccdcc78c75e40129ced84ae02e321f5c3)
+[comment]: # ( SHA256STAMP:7b56f693aa33a88cf38459ff1581dd0fc09c1280b1068530e607f73ee62d4266)

--- a/doc/lightning-signpsbt.7.md
+++ b/doc/lightning-signpsbt.7.md
@@ -73,4 +73,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:655ef649bd68e29da6026cacf3d6f7399c5d9b2ac153c53e66cda9ece3fd761f)
+[comment]: # ( SHA256STAMP:83b5bc1c0d33cdf5bae731ab6ead5aef3aff32c09a13902ebb9b96429d02dca5)

--- a/doc/lightning-stop.7.md
+++ b/doc/lightning-stop.7.md
@@ -26,7 +26,6 @@ RETURN VALUE
 
 [comment]: # (GENERATE-FROM-SCHEMA-START)
 On success, returns a single element (string) (always "Shutdown complete")
-
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 Once it has returned, the daemon has cleaned up completely, and if
@@ -44,4 +43,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:3ad64970d67b1084b6f33bb690ba1dd3744292a60b3efe8a845f88a0ebc61450)
+[comment]: # ( SHA256STAMP:e119fe5893a4efe640aba23062bf2a37797ea8071293179c40398b824b1446cd)

--- a/doc/lightning-txdiscard.7.md
+++ b/doc/lightning-txdiscard.7.md
@@ -45,4 +45,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:3b3b5c8e6bc2f30080053f93cc7db3dfc39bef118354ebfc2ed62e621329afc4)
+[comment]: # ( SHA256STAMP:adcbdf53ef9b0ed3c60098e70555e51e94f26c6128cbc9a54307ef75a9eabd2a)

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -85,4 +85,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:200dbb8ac175dbb5321e699cfa78dd319a96ceef0d61a7569415544503562d52)
+[comment]: # ( SHA256STAMP:376f1c7c33637cccb1c65304063251a792059914d2059e376fcf3d52a2e5c469)

--- a/doc/lightning-txsend.7.md
+++ b/doc/lightning-txsend.7.md
@@ -45,4 +45,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:db5c1f15e439f7784dcb759d444cf4f0844aa8093c6af2252e5989e1b75f0523)
+[comment]: # ( SHA256STAMP:dd7fb4170a0507e6097ef8ba78fb937902604d5814b3fb8ce15c5f579d3e15e8)

--- a/doc/lightning-unreserveinputs.7.md
+++ b/doc/lightning-unreserveinputs.7.md
@@ -55,4 +55,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:4560823ed1adae2127b71b599cdaae1539bd5c87c03ecf593beed5813bb68511)
+[comment]: # ( SHA256STAMP:9f00af2719fcbddbffd40d57d0cddc4d8f8c4ba3855aee63f7ee796f1828e9b9)

--- a/doc/lightning-utxopsbt.7.md
+++ b/doc/lightning-utxopsbt.7.md
@@ -100,4 +100,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:237c832f7a7c1ea2567192b7432f4ea7fe79e553c9c531acf5be733b92095464)
+[comment]: # ( SHA256STAMP:12ae2b4f71606d6bb3972e3259ad27fc4369a72482cff3db28537ae9cdad4817)

--- a/doc/lightning-waitanyinvoice.7.md
+++ b/doc/lightning-waitanyinvoice.7.md
@@ -75,4 +75,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:bd853f0a27258e0e3780c0dd6cdd8fca7ba8d95a00d247704ed3f3f55c2f086e)
+[comment]: # ( SHA256STAMP:332f6ef658d50377b3e7b9ee2f5583dfbaf5034c7403d0b6ca8167295a9255e3)

--- a/doc/lightning-waitblockheight.7.md
+++ b/doc/lightning-waitblockheight.7.md
@@ -39,4 +39,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:b7986f9829dd7616ac4236c175b9d7011c27de19dd4fb50138b5957c59678177)
+[comment]: # ( SHA256STAMP:b8c8ba9b75da521171fcfa0c8dc4a1fdeb271e2c4dfacd445223aeda06910141)

--- a/doc/lightning-waitinvoice.7.md
+++ b/doc/lightning-waitinvoice.7.md
@@ -60,4 +60,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:bd853f0a27258e0e3780c0dd6cdd8fca7ba8d95a00d247704ed3f3f55c2f086e)
+[comment]: # ( SHA256STAMP:332f6ef658d50377b3e7b9ee2f5583dfbaf5034c7403d0b6ca8167295a9255e3)

--- a/doc/lightning-waitsendpay.7.md
+++ b/doc/lightning-waitsendpay.7.md
@@ -104,4 +104,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:5c783babcd7a98ef4f1bd676f7aa36c3441d52414dcd1038183d9c4445ddcf7d)
+[comment]: # ( SHA256STAMP:f7316b6ec1f7f0e4b652915baf3dba919a8c9f64f274b142429801809fbacf8a)

--- a/doc/lightning-withdraw.7.md
+++ b/doc/lightning-withdraw.7.md
@@ -74,4 +74,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:7ec01e1903d75e2a8694c50d051c40fcbdb8a8001943c79748ca8fd41d5d59b1)
+[comment]: # ( SHA256STAMP:57a5a6255500599f39425df668368601f24c95e09b7f0174662d7fba54f05374)

--- a/doc/schemas/WRITING_SCHEMAS.md
+++ b/doc/schemas/WRITING_SCHEMAS.md
@@ -10,6 +10,15 @@ use a subset of the full [JSON Schema Specification](https://json-schema.org/),
 but if you find that limiting it's probably a sign that you should simplify
 your JSON output.
 
+## Updating a Schema
+
+If you add a field, you should add it to the schema, and you must add
+"added": "VERSION" (where VERSION is the next release version!).
+
+Similarly, if you deprecate a field, add "deprecated": "VERSION" (where
+VERSION is the next release version).  They will be removed two versions
+later.
+
 ## How to Write a Schema
 
 Name the schema doc/schemas/`command`.schema.json: the testsuite should

--- a/doc/schemas/delinvoice.schema.json
+++ b/doc/schemas/delinvoice.schema.json
@@ -22,7 +22,7 @@
       "description": "BOLT12 string"
     },
     "msatoshi": {
-      "deprecated": "true"
+      "deprecated": true
     },
     "amount_msat": {
       "type": "msat",
@@ -147,7 +147,7 @@
             "description": "how much was actually received"
           },
           "msatoshi_received": {
-            "deprecated": "true"
+            "deprecated": true
           },
           "paid_at": {
             "type": "u64",

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -297,7 +297,8 @@
     },
     "announce-addr-dns": {
       "type": "boolean",
-      "description": "Whether we put DNS entries into node_announcement"
+      "description": "Whether we put DNS entries into node_announcement",
+      "added": "v22.11.1"
     }
   }
 }

--- a/doc/schemas/listinvoices.schema.json
+++ b/doc/schemas/listinvoices.schema.json
@@ -46,7 +46,7 @@
             "description": "UNIX timestamp of when it will become / became unpayable"
           },
           "msatoshi": {
-            "deprecated": "true"
+            "deprecated": true
           },
           "amount_msat": {
             "type": "msat",

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -343,11 +343,13 @@
                   "properties": {
                     "local_msat": {
                       "type": "msat",
-                      "description": "Amount of channel we funded (deprecated)"
+                      "deprecated": "v0.12.0",
+                      "description": "Amount of channel we funded"
                     },
                     "remote_msat": {
                       "type": "msat",
-                      "description": "Amount of channel they funded (deprecated)"
+                      "deprecated": "v0.12.0",
+                      "description": "Amount of channel they funded"
                     },
                     "pushed_msat": {
                       "type": "msat",

--- a/doc/schemas/sendinvoice.schema.json
+++ b/doc/schemas/sendinvoice.schema.json
@@ -38,7 +38,7 @@
       "description": "UNIX timestamp of when it will become / became unpayable"
     },
     "msatoshi": {
-      "deprecated": "true"
+      "deprecated": true
     },
     "amount_msat": {
       "type": "msat",

--- a/doc/schemas/sendpay.request.json
+++ b/doc/schemas/sendpay.request.json
@@ -22,7 +22,7 @@
             "type": "msat"
           },
           "msatoshi": {
-            "deprecated": "true"
+            "deprecated": true
           },
           "id": {
             "type": "pubkey"

--- a/doc/schemas/waitanyinvoice.schema.json
+++ b/doc/schemas/waitanyinvoice.schema.json
@@ -37,7 +37,7 @@
       "description": "UNIX timestamp of when it will become / became unpayable"
     },
     "msatoshi": {
-      "deprecated": "true"
+      "deprecated": true
     },
     "amount_msat": {
       "type": "msat",

--- a/doc/schemas/waitinvoice.schema.json
+++ b/doc/schemas/waitinvoice.schema.json
@@ -37,7 +37,7 @@
       "description": "UNIX timestamp of when it will become / became unpayable"
     },
     "msatoshi": {
-      "deprecated": "true"
+      "deprecated": true
     },
     "amount_msat": {
       "type": "msat",


### PR DESCRIPTION
This opens the door to far better documentation (we used to just not mention now-deprecated fields, and never noted what version a field was added!), but also lets the SQL plugin (#5679) handle deprecations more gracefully (it can ignore anything deprecated before it was released, for example).

Note that #5825 should be rebased onto this (as it currently removes deprecated fields from schema).