### PR TITLE
All hash tables should use tal

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -120,7 +120,6 @@ struct channel *new_full_channel(const tal_t *ctx,
 		channel->htlcs = tal(channel, struct htlc_map);
 		htlc_map_init(channel->htlcs);
 		memleak_add_helper(channel->htlcs, memleak_help_htlcmap);
-		tal_add_destructor(channel->htlcs, htlc_map_clear);
 	}
 	return channel;
 }

--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -699,8 +699,6 @@ static void destroy_map(struct gossmap *map)
 {
 	if (map->mmap)
 		munmap(map->mmap, map->map_size);
-	chanidx_htable_clear(map->channels);
-	nodeidx_htable_clear(map->nodes);
 
 	for (size_t i = 0; i < tal_count(map->node_arr); i++)
 		free(map->node_arr[i].chan_idxs);

--- a/common/memleak.c
+++ b/common/memleak.c
@@ -107,6 +107,10 @@ static void children_into_htable(struct htable *memtable, const tal_t *p)
 			if (streq(name, "tmpctx"))
 				continue;
 		}
+		/* Don't add (resizing!) memtable table! */
+		if (i == memtable->table)
+			continue;
+
 		htable_add(memtable, hash_ptr(i, NULL), i);
 		children_into_htable(memtable, i);
 	}

--- a/common/memleak.c
+++ b/common/memleak.c
@@ -319,7 +319,6 @@ struct htable *memleak_start(const tal_t *ctx)
 		call_memleak_helpers(memtable, NULL);
 	}
 
-	tal_add_destructor(memtable, htable_clear);
 	return memtable;
 }
 

--- a/common/setup.c
+++ b/common/setup.c
@@ -1,6 +1,7 @@
 #include "config.h"
 #include <assert.h>
 #include <ccan/ccan/err/err.h>
+#include <ccan/ccan/htable/htable.h>
 #include <common/autodata.h>
 #include <common/setup.h>
 #include <common/utils.h>
@@ -24,6 +25,15 @@ static struct wally_operations wally_tal_ops = {
 	.free_fn = wally_free,
 };
 
+static void *htable_tal(struct htable *ht, size_t len)
+{
+	return tal_arrz(ht, u8, len);
+}
+
+static void htable_tal_free(struct htable *ht, void *p)
+{
+	tal_free(p);
+}
 
 void common_setup(const char *argv0)
 {
@@ -46,6 +56,9 @@ void common_setup(const char *argv0)
 	if (wally_ret != WALLY_OK)
 		errx(1, "Error setting libwally operations: %i", wally_ret);
 	secp256k1_ctx = wally_get_secp_context();
+
+	/* Make htable* use tal for the tables themselves. */
+	htable_set_allocator(htable_tal, htable_tal_free);
 
 	setup_tmpctx();
 }

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -142,7 +142,7 @@ struct daemon {
 
 	/* Peers that we've handed to `lightningd`, which it hasn't told us
 	 * have disconnected. */
-	struct peer_htable peers;
+	struct peer_htable *peers;
 
 	/* Peers we are trying to reach */
 	struct list_head connecting;

--- a/connectd/gossip_rcvd_filter.c
+++ b/connectd/gossip_rcvd_filter.c
@@ -21,17 +21,11 @@ static size_t rehash(const void *key, void *unused)
 	return ptr2int(key);
 }
 
-static void destroy_msg_map(struct htable *ht)
-{
-	htable_clear(ht);
-}
-
 static struct htable *new_msg_map(const tal_t *ctx)
 {
 	struct htable *ht = tal(ctx, struct htable);
 
 	htable_init(ht, rehash, NULL);
-	tal_add_destructor(ht, destroy_msg_map);
 	return ht;
 }
 

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -592,7 +592,7 @@ void send_custommsg(struct daemon *daemon, const u8 *msg)
 		master_badmsg(WIRE_CONNECTD_CUSTOMMSG_OUT, msg);
 
 	/* Races can happen: this might be gone by now. */
-	peer = peer_htable_get(&daemon->peers, &id);
+	peer = peer_htable_get(daemon->peers, &id);
 	if (peer)
 		inject_peer_msg(peer, take(custommsg));
 }
@@ -1242,7 +1242,7 @@ void peer_connect_subd(struct daemon *daemon, const u8 *msg, int fd)
 		master_badmsg(WIRE_CONNECTD_PEER_CONNECT_SUBD, msg);
 
 	/* Races can happen: this might be gone by now (or reconnected!). */
-	peer = peer_htable_get(&daemon->peers, &id);
+	peer = peer_htable_get(daemon->peers, &id);
 	if (!peer || peer->counter != counter) {
 		close(fd);
 		return;
@@ -1276,7 +1276,7 @@ void send_manual_ping(struct daemon *daemon, const u8 *msg)
 	if (!fromwire_connectd_ping(msg, &id, &num_pong_bytes, &len))
 		master_badmsg(WIRE_CONNECTD_PING, msg);
 
-	peer = peer_htable_get(&daemon->peers, &id);
+	peer = peer_htable_get(daemon->peers, &id);
 	if (!peer) {
 		daemon_conn_send(daemon->master,
 				 take(towire_connectd_ping_reply(NULL,

--- a/connectd/onion_message.c
+++ b/connectd/onion_message.c
@@ -29,7 +29,7 @@ void onionmsg_req(struct daemon *daemon, const u8 *msg)
 
 	/* Even though lightningd checks for valid ids, there's a race
 	 * where it might vanish before we read this command. */
-	peer = peer_htable_get(&daemon->peers, &id);
+	peer = peer_htable_get(daemon->peers, &id);
 	if (peer) {
 		u8 *omsg = towire_onion_message(NULL, &blinding, onionmsg);
 		inject_peer_msg(peer, take(omsg));
@@ -86,7 +86,7 @@ void handle_onion_message(struct daemon *daemon,
 
 		/* FIXME: Handle short_channel_id! */
 		node_id_from_pubkey(&next_node_id, &next_node);
-		next_peer = peer_htable_get(&daemon->peers, &next_node_id);
+		next_peer = peer_htable_get(daemon->peers, &next_node_id);
 		if (!next_peer) {
 			status_peer_debug(&peer->id,
 					  "onion msg: unknown next peer %s",

--- a/connectd/test/run-gossip_rcvd_filter.c
+++ b/connectd/test/run-gossip_rcvd_filter.c
@@ -172,9 +172,14 @@ int main(int argc, char *argv[])
 	assert(htable_count(f->cur) == 0);
 	assert(htable_count(f->old) == 0);
 
-	/* They should have no children, and f should only have 2. */
-	assert(!tal_first(f->cur));
-	assert(!tal_first(f->old));
+	/* They should have no children (except htable contents for one!), and
+	 * f should only have 2. */
+	if (tal_first(f->cur) == NULL)
+		assert(tal_first(f->old) == f->old->table);
+	else {
+		assert(tal_first(f->cur) == f->cur->table);
+		assert(tal_first(f->old) == NULL);
+	}
 
 	assert((tal_first(f) == f->cur
 		&& tal_next(f->cur) == f->old

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -407,11 +407,6 @@ static void move_broadcast(struct offmap *offmap,
 	offmap_del(offmap, omap);
 }
 
-static void destroy_offmap(struct offmap *offmap)
-{
-	offmap_clear(offmap);
-}
-
 /**
  * Rewrite the on-disk gossip store, compacting it along the way
  *
@@ -453,7 +448,6 @@ bool gossip_store_compact(struct gossip_store *gs)
 	/* Walk old file, copy everything and remember new offsets. */
 	offmap = tal(tmpctx, struct offmap);
 	offmap_init_sized(offmap, gs->count);
-	tal_add_destructor(offmap, destroy_offmap);
 
 	/* Start by writing all channel announcements and updates. */
 	off = 1;

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -134,44 +134,43 @@ static struct node_map *new_node_map(const tal_t *ctx)
 /* We use a simple array (with NULL entries) until we have too many. */
 static bool node_uses_chan_map(const struct node *node)
 {
-	/* This is a layering violation: last entry in htable is the table ptr,
-	 * which is never NULL */
-	return node->chans.arr[NUM_IMMEDIATE_CHANS] != NULL;
+	return node->chan_map;
 }
 
 /* When simple array fills, use a htable. */
 static void convert_node_to_chan_map(struct node *node)
 {
-	struct chan *chans[NUM_IMMEDIATE_CHANS];
-
-	memcpy(chans, node->chans.arr, sizeof(chans));
-	chan_map_init_sized(&node->chans.map, NUM_IMMEDIATE_CHANS + 1);
+	assert(!node_uses_chan_map(node));
+	node->chan_map = tal(node, struct chan_map);
+	chan_map_init_sized(node->chan_map, ARRAY_SIZE(node->chan_arr) + 1);
 	assert(node_uses_chan_map(node));
-	for (size_t i = 0; i < ARRAY_SIZE(chans); i++)
-		chan_map_add(&node->chans.map, chans[i]);
+	for (size_t i = 0; i < ARRAY_SIZE(node->chan_arr); i++) {
+		chan_map_add(node->chan_map, node->chan_arr[i]);
+		node->chan_arr[i] = NULL;
+	}
 }
 
 static void add_chan(struct node *node, struct chan *chan)
 {
 	if (!node_uses_chan_map(node)) {
-		for (size_t i = 0; i < NUM_IMMEDIATE_CHANS; i++) {
-			if (node->chans.arr[i] == NULL) {
-				node->chans.arr[i] = chan;
+		for (size_t i = 0; i < ARRAY_SIZE(node->chan_arr); i++) {
+			if (node->chan_arr[i] == NULL) {
+				node->chan_arr[i] = chan;
 				return;
 			}
 		}
 		convert_node_to_chan_map(node);
 	}
 
-	chan_map_add(&node->chans.map, chan);
+	chan_map_add(node->chan_map, chan);
 }
 
 static struct chan *next_chan_arr(const struct node *node,
 				  struct chan_map_iter *i)
 {
-	while (i->i.off < NUM_IMMEDIATE_CHANS) {
-		if (node->chans.arr[i->i.off])
-			return node->chans.arr[i->i.off];
+	while (i->i.off < ARRAY_SIZE(node->chan_arr)) {
+		if (node->chan_arr[i->i.off])
+			return node->chan_arr[i->i.off];
 		i->i.off++;
 	}
 	return NULL;
@@ -184,7 +183,7 @@ struct chan *first_chan(const struct node *node, struct chan_map_iter *i)
 		return next_chan_arr(node, i);
 	}
 
-	return chan_map_first(&node->chans.map, i);
+	return chan_map_first(node->chan_map, i);
 }
 
 struct chan *next_chan(const struct node *node, struct chan_map_iter *i)
@@ -194,7 +193,7 @@ struct chan *next_chan(const struct node *node, struct chan_map_iter *i)
 		return next_chan_arr(node, i);
 	}
 
-	return chan_map_next(&node->chans.map, i);
+	return chan_map_next(node->chan_map, i);
 }
 
 static void destroy_routing_state(struct routing_state *rstate)
@@ -241,7 +240,7 @@ static void memleak_help_routing_tables(struct htable *memtable,
 	     n;
 	     n = node_map_next(rstate->nodes, &nit)) {
 		if (node_uses_chan_map(n))
-			memleak_scan_htable(memtable, &n->chans.map.raw);
+			memleak_scan_htable(memtable, &n->chan_map->raw);
 	}
 }
 #endif /* DEVELOPER */
@@ -360,7 +359,7 @@ static void destroy_node(struct node *node, struct routing_state *rstate)
 
 	/* Free htable if we need. */
 	if (node_uses_chan_map(node))
-		chan_map_clear(&node->chans.map);
+		chan_map_clear(node->chan_map);
 }
 
 struct node *get_node(struct routing_state *rstate,
@@ -378,7 +377,8 @@ static struct node *new_node(struct routing_state *rstate,
 
 	n = tal(rstate, struct node);
 	n->id = *id;
-	memset(n->chans.arr, 0, sizeof(n->chans.arr));
+	memset(n->chan_arr, 0, sizeof(n->chan_arr));
+	n->chan_map = NULL;
 	broadcastable_init(&n->bcast);
 	broadcastable_init(&n->rgraph);
 	n->tokens = TOKEN_MAX;
@@ -476,16 +476,16 @@ static void remove_chan_from_node(struct routing_state *rstate,
 
 	if (!node_uses_chan_map(node)) {
 		num_chans = 0;
-		for (size_t i = 0; i < NUM_IMMEDIATE_CHANS; i++) {
-			if (node->chans.arr[i] == chan)
-				node->chans.arr[i] = NULL;
-			else if (node->chans.arr[i] != NULL)
+		for (size_t i = 0; i < ARRAY_SIZE(node->chan_arr); i++) {
+			if (node->chan_arr[i] == chan)
+				node->chan_arr[i] = NULL;
+			else if (node->chan_arr[i] != NULL)
 				num_chans++;
 		}
 	} else {
-		if (!chan_map_del(&node->chans.map, chan))
+		if (!chan_map_del(node->chan_map, chan))
 			abort();
-		num_chans = chan_map_count(&node->chans.map);
+		num_chans = chan_map_count(node->chan_map);
 	}
 
 	/* Last channel?  Simply delete node (and associated announce) */
@@ -2078,7 +2078,7 @@ void remove_all_gossip(struct routing_state *rstate)
 	while ((n = node_map_first(rstate->nodes, &nit)) != NULL) {
 		tal_del_destructor2(n, destroy_node, rstate);
 		if (node_uses_chan_map(n))
-			chan_map_clear(&n->chans.map);
+			chan_map_clear(n->chan_map);
 		node_map_del(rstate->nodes, n);
 		tal_free(n);
 	}

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -203,7 +203,7 @@ struct routing_state {
 	struct pending_node_map *pending_node_map;
 
 	/* channel_announcement which are pending short_channel_id lookup */
-	struct pending_cannouncement_map pending_cannouncements;
+	struct pending_cannouncement_map *pending_cannouncements;
 
 	/* Gossip store */
 	struct gossip_store *gs;

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -90,7 +90,7 @@ struct chain_topology {
 	struct block *root;
 	struct block *tip;
 	struct bitcoin_blkid prev_tip;
-	struct block_map block_map;
+	struct block_map *block_map;
 	u32 feerate[NUM_FEERATES];
 	bool feerate_uninitialized;
 	u32 feehistory[NUM_FEERATES][FEE_HISTORY_NUM];
@@ -116,11 +116,11 @@ struct chain_topology {
 	struct oneshot *extend_timer, *updatefee_timer;
 
 	/* Bitcoin transactions we're broadcasting */
-	struct outgoing_tx_map outgoing_txs;
+	struct outgoing_tx_map *outgoing_txs;
 
 	/* Transactions/txos we are watching. */
-	struct txwatch_hash txwatches;
-	struct txowatch_hash txowatches;
+	struct txwatch_hash *txwatches;
+	struct txowatch_hash *txowatches;
 
 	/* The number of headers known to the bitcoin backend at startup. Not
 	 * updated after the initial check. */

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -35,9 +35,9 @@ struct htlc_out *channel_has_htlc_out(struct channel *channel)
 	struct htlc_out *hout;
 	struct lightningd *ld = channel->peer->ld;
 
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (hout->key.channel == channel)
 			return hout;
 	}
@@ -51,9 +51,9 @@ struct htlc_in *channel_has_htlc_in(struct channel *channel)
 	struct htlc_in *hin;
 	struct lightningd *ld = channel->peer->ld;
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (hin->key.channel == channel)
 			return hin;
 	}

--- a/lightningd/htlc_set.c
+++ b/lightningd/htlc_set.c
@@ -89,8 +89,8 @@ static struct htlc_set *new_htlc_set(struct lightningd *ld,
 	 */
 	set->timeout = new_reltimer(ld->timers, set, time_from_sec(70),
 				    timeout_htlc_set, set);
-	htlc_set_map_add(&ld->htlc_sets, set);
-	tal_add_destructor2(set, destroy_htlc_set, &ld->htlc_sets);
+	htlc_set_map_add(ld->htlc_sets, set);
+	tal_add_destructor2(set, destroy_htlc_set, ld->htlc_sets);
 	return set;
 }
 
@@ -131,7 +131,7 @@ void htlc_set_add(struct lightningd *ld,
 	 *  - otherwise, if it supports `basic_mpp`:
 	 *    - MUST add it to the HTLC set corresponding to that `payment_hash`.
 	 */
-	set = htlc_set_map_get(&ld->htlc_sets, &hin->payment_hash);
+	set = htlc_set_map_get(ld->htlc_sets, &hin->payment_hash);
 	if (!set)
 		set = new_htlc_set(ld, hin, total_msat);
 	else {

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1259,10 +1259,6 @@ stop:
 	/* Now close database */
 	ld->wallet->db = tal_free(ld->wallet->db);
 
-	/* Clean our our HTLC maps, since they use malloc. */
-	htlc_in_map_clear(ld->htlcs_in);
-	htlc_out_map_clear(ld->htlcs_out);
-
 	remove(ld->pidfile);
 
 	/* FIXME: pay can have children off tmpctx which unlink from

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -191,11 +191,11 @@ struct lightningd {
 	u32 blockheight;
 
 	/* HTLCs in flight. */
-	struct htlc_in_map htlcs_in;
-	struct htlc_out_map htlcs_out;
+	struct htlc_in_map *htlcs_in;
+	struct htlc_out_map *htlcs_out;
 
 	/* Sets of HTLCs we are holding onto for MPP. */
-	struct htlc_set_map htlc_sets;
+	struct htlc_set_map *htlc_sets;
 
 	struct wallet *wallet;
 

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -152,9 +152,9 @@ static void finish_report(const struct leak_detect *leaks)
 	/* First delete known false positives. */
 	memleak_scan_htable(memtable, &ld->topology->txwatches->raw);
 	memleak_scan_htable(memtable, &ld->topology->txowatches->raw);
-	memleak_scan_htable(memtable, &ld->htlcs_in.raw);
-	memleak_scan_htable(memtable, &ld->htlcs_out.raw);
-	memleak_scan_htable(memtable, &ld->htlc_sets.raw);
+	memleak_scan_htable(memtable, &ld->htlcs_in->raw);
+	memleak_scan_htable(memtable, &ld->htlcs_out->raw);
+	memleak_scan_htable(memtable, &ld->htlc_sets->raw);
 
 	/* Now delete ld and those which it has pointers to. */
 	memleak_scan_obj(memtable, ld);

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -150,8 +150,8 @@ static void finish_report(const struct leak_detect *leaks)
 	memleak_ignore_children(memtable, cmd);
 
 	/* First delete known false positives. */
-	memleak_scan_htable(memtable, &ld->topology->txwatches.raw);
-	memleak_scan_htable(memtable, &ld->topology->txowatches.raw);
+	memleak_scan_htable(memtable, &ld->topology->txwatches->raw);
+	memleak_scan_htable(memtable, &ld->topology->txowatches->raw);
 	memleak_scan_htable(memtable, &ld->htlcs_in.raw);
 	memleak_scan_htable(memtable, &ld->htlcs_out.raw);
 	memleak_scan_htable(memtable, &ld->htlc_sets.raw);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -27,9 +27,9 @@ static void onchaind_tell_fulfill(struct channel *channel)
 	u8 *msg;
 	struct lightningd *ld = channel->peer->ld;
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (hin->key.channel != channel)
 			continue;
 
@@ -76,7 +76,7 @@ static bool tell_if_missing(const struct channel *channel,
 		return false;
 
 	/* Might not be a current HTLC. */
-	hout = find_htlc_out(&channel->peer->ld->htlcs_out, channel, stub->id);
+	hout = find_htlc_out(channel->peer->ld->htlcs_out, channel, stub->id);
 	if (!hout)
 		return false;
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -440,9 +440,9 @@ static void json_add_htlcs(struct lightningd *ld,
 
 	/* FIXME: Add more fields. */
 	json_array_start(response, "htlcs");
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (hin->key.channel != channel)
 			continue;
 
@@ -464,9 +464,9 @@ static void json_add_htlcs(struct lightningd *ld,
 		json_object_end(response);
 	}
 
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (hout->key.channel != channel)
 			continue;
 
@@ -528,18 +528,18 @@ static struct amount_sat commit_txfee(const struct channel *channel,
 			     option_anchor_outputs))
 		num_untrimmed_htlcs++;
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (hin->key.channel != channel)
 			continue;
 		if (!htlc_is_trimmed(!side, hin->msat, feerate, dust_limit,
 				     side, option_anchor_outputs))
 			num_untrimmed_htlcs++;
 	}
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (hout->key.channel != channel)
 			continue;
 		if (!htlc_is_trimmed(side, hout->msat, feerate, dust_limit,
@@ -583,9 +583,9 @@ static void subtract_offered_htlcs(const struct channel *channel,
 	struct htlc_out_map_iter outi;
 	struct lightningd *ld = channel->peer->ld;
 
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (hout->key.channel != channel)
 			continue;
 		if (!amount_msat_sub(amount, *amount, hout->msat))
@@ -600,9 +600,9 @@ static void subtract_received_htlcs(const struct channel *channel,
 	struct htlc_in_map_iter ini;
 	struct lightningd *ld = channel->peer->ld;
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (hin->key.channel != channel)
 			continue;
 		if (!amount_msat_sub(amount, *amount, hin->msat))
@@ -2151,14 +2151,14 @@ struct htlc_in_map *load_channels_from_wallet(struct lightningd *ld)
 		list_for_each(&peer->channels, channel, list) {
 			if (!wallet_htlcs_load_in_for_channel(ld->wallet,
 							      channel,
-							      &ld->htlcs_in)) {
+							      ld->htlcs_in)) {
 				fatal("could not load htlcs for channel");
 			}
 		}
 	}
 
 	/* Make a copy of the htlc_map: entries removed as they're matched */
-	htlc_in_map_copy(unconnected_htlcs_in, &ld->htlcs_in);
+	htlc_in_map_copy(unconnected_htlcs_in, ld->htlcs_in);
 
 	/* Now we load the outgoing HTLCs, so we can connect them. */
 	list_for_each(&ld->peers, peer, list) {
@@ -2167,7 +2167,7 @@ struct htlc_in_map *load_channels_from_wallet(struct lightningd *ld)
 		list_for_each(&peer->channels, channel, list) {
 			if (!wallet_htlcs_load_out_for_channel(ld->wallet,
 							       channel,
-							       &ld->htlcs_out,
+							       ld->htlcs_out,
 							       unconnected_htlcs_in)) {
 				fatal("could not load outgoing htlcs for channel");
 			}

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2824,7 +2824,6 @@ void htlcs_resubmit(struct lightningd *ld,
 	}
 
 	/* Don't leak memory! */
-	htlc_in_map_clear(unconnected_htlcs_in);
 	tal_free(unconnected_htlcs_in);
 }
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -559,7 +559,7 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds UNU
 		return;
 	}
 
-	if (find_htlc_out(&subd->ld->htlcs_out, hout->key.channel, hout->key.id)
+	if (find_htlc_out(subd->ld->htlcs_out, hout->key.channel, hout->key.id)
 	    || hout->key.id == HTLC_INVALID_ID) {
 		channel_internal_error(subd->channel,
 				    "Bad offer_htlc_reply HTLC id %"PRIu64
@@ -570,7 +570,7 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds UNU
 	}
 
 	/* Add it to lookup table now we know id. */
-	connect_htlc_out(&subd->ld->htlcs_out, hout);
+	connect_htlc_out(subd->ld->htlcs_out, hout);
 
 	/* When channeld includes it in commitment, we'll make it persistent. */
 }
@@ -1284,7 +1284,7 @@ static bool peer_accepted_htlc(const tal_t *ctx,
 	*failmsg = NULL;
 	*badonion = 0;
 
-	hin = find_htlc_in(&ld->htlcs_in, channel, id);
+	hin = find_htlc_in(ld->htlcs_in, channel, id);
 	if (!hin) {
 		channel_internal_error(channel,
 				    "peer_got_revoke unknown htlc %"PRIu64, id);
@@ -1456,7 +1456,7 @@ static bool peer_fulfilled_our_htlc(struct channel *channel,
 	struct lightningd *ld = channel->peer->ld;
 	struct htlc_out *hout;
 
-	hout = find_htlc_out(&ld->htlcs_out, channel, fulfilled->id);
+	hout = find_htlc_out(ld->htlcs_out, channel, fulfilled->id);
 	if (!hout) {
 		channel_internal_error(channel,
 				    "fulfilled_our_htlc unknown htlc %"PRIu64,
@@ -1482,9 +1482,9 @@ void onchain_fulfilled_htlc(struct channel *channel,
 	sha256(&payment_hash, preimage, sizeof(*preimage));
 
 	/* FIXME: use db to look this up! */
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (hout->key.channel != channel)
 			continue;
 
@@ -1515,7 +1515,7 @@ static bool peer_failed_our_htlc(struct channel *channel,
 	struct htlc_out *hout;
 	struct lightningd *ld = channel->peer->ld;
 
-	hout = find_htlc_out(&ld->htlcs_out, channel, failed->id);
+	hout = find_htlc_out(ld->htlcs_out, channel, failed->id);
 	if (!hout) {
 		channel_internal_error(channel,
 				    "failed_our_htlc unknown htlc %"PRIu64,
@@ -1633,9 +1633,9 @@ static void fail_dangling_htlc_in(struct lightningd *ld,
 	struct htlc_in *hin;
 	struct htlc_in_map_iter ini;
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		if (!sha256_eq(&hin->payment_hash, payment_hash))
 			continue;
 		if (hin->badonion) {
@@ -1670,7 +1670,7 @@ void onchain_failed_our_htlc(const struct channel *channel,
 	struct htlc_out *hout;
 
 	log_debug(channel->log, "onchain_failed_our_htlc");
-	hout = find_htlc_out(&ld->htlcs_out, channel, htlc->id);
+	hout = find_htlc_out(ld->htlcs_out, channel, htlc->id);
 	if (!hout) {
 		/* For penalty transactions, tell onchaind about all possible
 		 * HTLCs: they may not all exist any more. */
@@ -1678,8 +1678,8 @@ void onchain_failed_our_htlc(const struct channel *channel,
 			log_broken(channel->log, "HTLC id %"PRIu64" not found!",
 				   htlc->id);
 		/* Immediate corruption sanity check if this happens */
-		htable_check(&ld->htlcs_out.raw, "onchain_failed_our_htlc out");
-		htable_check(&ld->htlcs_in.raw, "onchain_failed_our_htlc in");
+		htable_check(&ld->htlcs_out->raw, "onchain_failed_our_htlc out");
+		htable_check(&ld->htlcs_in->raw, "onchain_failed_our_htlc in");
 		return;
 	}
 
@@ -1746,8 +1746,8 @@ void onchain_failed_our_htlc(const struct channel *channel,
 			   htlc->id);
 
 		/* Immediate corruption sanity check if this happens */
-		htable_check(&ld->htlcs_out.raw, "onchain_failed_our_htlc out");
-		htable_check(&ld->htlcs_in.raw, "onchain_failed_our_htlc in");
+		htable_check(&ld->htlcs_out->raw, "onchain_failed_our_htlc out");
+		htable_check(&ld->htlcs_in->raw, "onchain_failed_our_htlc in");
 		fail_dangling_htlc_in(ld, &hout->payment_hash);
 	}
 }
@@ -1864,7 +1864,7 @@ static bool update_in_htlc(struct channel *channel,
 	struct htlc_in *hin;
 	struct lightningd *ld = channel->peer->ld;
 
-	hin = find_htlc_in(&ld->htlcs_in, channel, id);
+	hin = find_htlc_in(ld->htlcs_in, channel, id);
 	if (!hin) {
 		channel_internal_error(channel, "Can't find in HTLC %"PRIu64, id);
 		return false;
@@ -1887,7 +1887,7 @@ static bool update_out_htlc(struct channel *channel,
 	struct htlc_out *hout;
 	struct wallet_payment *payment;
 
-	hout = find_htlc_out(&ld->htlcs_out, channel, id);
+	hout = find_htlc_out(ld->htlcs_out, channel, id);
 	if (!hout) {
 		channel_internal_error(channel, "Can't find out HTLC %"PRIu64, id);
 		return false;
@@ -2150,7 +2150,7 @@ static bool channel_added_their_htlc(struct channel *channel,
 					     added->amount);
 
 	log_debug(channel->log, "Adding their HTLC %"PRIu64, added->id);
-	connect_htlc_in(&channel->peer->ld->htlcs_in, hin);
+	connect_htlc_in(channel->peer->ld->htlcs_in, hin);
 	return true;
 }
 
@@ -2472,11 +2472,11 @@ void peer_got_revoke(struct channel *channel, const u8 *msg)
 		struct htlc_in *hin;
 
 		if (badonions[i]) {
-			hin = find_htlc_in(&ld->htlcs_in, channel,
+			hin = find_htlc_in(ld->htlcs_in, channel,
 					   changed[i].id);
 			local_fail_in_htlc_badonion(hin, badonions[i]);
 		} else if (failmsgs[i]) {
-			hin = find_htlc_in(&ld->htlcs_in, channel,
+			hin = find_htlc_in(ld->htlcs_in, channel,
 					   changed[i].id);
 			local_fail_in_htlc(hin, failmsgs[i]);
 		} else
@@ -2518,9 +2518,9 @@ const struct existing_htlc **peer_htlcs(const tal_t *ctx,
 
 	htlcs = tal_arr(ctx, struct existing_htlc *, 0);
 
-	for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+	for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 	     hin;
-	     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+	     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 		struct failed_htlc *f;
 		struct existing_htlc *existing;
 
@@ -2544,9 +2544,9 @@ const struct existing_htlc **peer_htlcs(const tal_t *ctx,
 		tal_arr_expand(&htlcs, existing);
 	}
 
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		struct failed_htlc *f;
 		struct existing_htlc *existing;
 
@@ -2592,18 +2592,18 @@ void free_htlcs(struct lightningd *ld, const struct channel *channel)
 
 	do {
 		deleted = false;
-		for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+		for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 		     hout;
-		     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+		     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 			if (channel && hout->key.channel != channel)
 				continue;
 			tal_free(hout);
 			deleted = true;
 		}
 
-		for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+		for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 		     hin;
-		     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+		     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 			if (channel && hin->key.channel != channel)
 				continue;
 			tal_free(hin);
@@ -2657,9 +2657,9 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 
 		removed = false;
 
-		for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+		for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 		     hout;
-		     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+		     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 			/* Not timed out yet? */
 			if (height < htlc_out_deadline(hout))
 				continue;
@@ -2701,9 +2701,9 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 
 		removed = false;
 
-		for (hin = htlc_in_map_first(&ld->htlcs_in, &ini);
+		for (hin = htlc_in_map_first(ld->htlcs_in, &ini);
 		     hin;
-		     hin = htlc_in_map_next(&ld->htlcs_in, &ini)) {
+		     hin = htlc_in_map_next(ld->htlcs_in, &ini)) {
 			struct channel *channel = hin->key.channel;
 
 			/* Not fulfilled?  If overdue, that's their problem... */
@@ -2787,9 +2787,9 @@ void fixup_htlcs_out(struct lightningd *ld)
 	struct htlc_out_map_iter outi;
 	struct htlc_out *hout;
 
-	for (hout = htlc_out_map_first(&ld->htlcs_out, &outi);
+	for (hout = htlc_out_map_first(ld->htlcs_out, &outi);
 	     hout;
-	     hout = htlc_out_map_next(&ld->htlcs_out, &outi)) {
+	     hout = htlc_out_map_next(ld->htlcs_out, &outi)) {
 		if (!hout->am_origin)
 			fixup_hout(ld, hout);
 	}

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -546,7 +546,8 @@ static struct plugin **plugin_hook_make_ordered(const tal_t *ctx,
 	}
 
 	/* Success!  Copy ordered hooks back. */
-	memcpy(hook->hooks, done, tal_bytelen(hook->hooks));
+	if (hook->hooks)
+		memcpy(hook->hooks, done, tal_bytelen(hook->hooks));
 	return NULL;
 }
 

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -1033,7 +1033,8 @@ int main(int argc, char *argv[])
 	ld = tal(tmpctx, struct lightningd);
 
 	list_head_init(&ld->peers);
-	htlc_in_map_init(&ld->htlcs_in);
+	ld->htlcs_in = tal(ld, struct htlc_in_map);
+	htlc_in_map_init(ld->htlcs_in);
 	chainparams = chainparams_for_network("regtest");
 
 	candidates = tal_arr(tmpctx, struct routehint_candidate, 0);

--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -94,7 +94,7 @@ bool txowatch_eq(const struct txowatch *w, const struct bitcoin_outpoint *out)
 
 static void destroy_txowatch(struct txowatch *w)
 {
-	txowatch_hash_del(&w->topo->txowatches, w);
+	txowatch_hash_del(w->topo->txowatches, w);
 }
 
 const struct bitcoin_txid *txwatch_keyof(const struct txwatch *w)
@@ -115,7 +115,7 @@ bool txwatch_eq(const struct txwatch *w, const struct bitcoin_txid *txid)
 
 static void destroy_txwatch(struct txwatch *w)
 {
-	txwatch_hash_del(&w->topo->txwatches, w);
+	txwatch_hash_del(w->topo->txwatches, w);
 }
 
 struct txwatch *watch_txid(const tal_t *ctx,
@@ -138,7 +138,7 @@ struct txwatch *watch_txid(const tal_t *ctx,
 	w->channel = channel;
 	w->cb = cb;
 
-	txwatch_hash_add(&w->topo->txwatches, w);
+	txwatch_hash_add(w->topo->txwatches, w);
 	tal_add_destructor(w, destroy_txwatch);
 
 	return w;
@@ -153,9 +153,9 @@ struct txwatch *find_txwatch(struct chain_topology *topo,
 
 	/* We could have more than one channel watching same txid, though we
 	 * don't for onchaind. */
-	for (w = txwatch_hash_getfirst(&topo->txwatches, txid, &i);
+	for (w = txwatch_hash_getfirst(topo->txwatches, txid, &i);
 	     w;
-	     w = txwatch_hash_getnext(&topo->txwatches, txid, &i)) {
+	     w = txwatch_hash_getnext(topo->txwatches, txid, &i)) {
 		if (w->channel == channel)
 			break;
 	}
@@ -165,7 +165,7 @@ struct txwatch *find_txwatch(struct chain_topology *topo,
 bool watching_txid(const struct chain_topology *topo,
 		   const struct bitcoin_txid *txid)
 {
-	return txwatch_hash_get(&topo->txwatches, txid) != NULL;
+	return txwatch_hash_get(topo->txwatches, txid) != NULL;
 }
 
 struct txwatch *watch_tx(const tal_t *ctx,
@@ -201,7 +201,7 @@ struct txowatch *watch_txo(const tal_t *ctx,
 	w->channel = channel;
 	w->cb = cb;
 
-	txowatch_hash_add(&w->topo->txowatches, w);
+	txowatch_hash_add(w->topo->txowatches, w);
 	tal_add_destructor(w, destroy_txowatch);
 
 	return w;
@@ -247,7 +247,7 @@ void txwatch_fire(struct chain_topology *topo,
 {
 	struct txwatch *txw;
 
-	txw = txwatch_hash_get(&topo->txwatches, txid);
+	txw = txwatch_hash_get(topo->txwatches, txid);
 
 	if (txw)
 		txw_fire(txw, txid, depth);
@@ -287,9 +287,9 @@ void watch_topology_changed(struct chain_topology *topo)
 	do {
 		/* Iterating a htable during deletes is safe, but might skip entries. */
 		needs_rerun = false;
-		for (w = txwatch_hash_first(&topo->txwatches, &i);
+		for (w = txwatch_hash_first(topo->txwatches, &i);
 		     w;
-		     w = txwatch_hash_next(&topo->txwatches, &i)) {
+		     w = txwatch_hash_next(topo->txwatches, &i)) {
 			u32 depth;
 
 			depth = get_tx_depth(topo, &w->txid);
@@ -309,7 +309,7 @@ void txwatch_inform(const struct chain_topology *topo,
 {
 	struct txwatch *txw;
 
-	txw = txwatch_hash_get(&topo->txwatches, txid);
+	txw = txwatch_hash_get(topo->txwatches, txid);
 
 	if (txw && !txw->tx)
 		txw->tx = tal_steal(txw, tx_may_steal);

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -533,7 +533,6 @@ static struct command_result *listsendpays_done(struct command *cmd,
 		assert(pm != NULL);
 		add_new_entry(ret, buf, pm);
 	}
-	pay_map_clear(pay_map);
 	json_array_end(ret);
 	return command_finished(cmd, ret);
 }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1850,8 +1850,6 @@ static bool test_htlc_crud(struct lightningd *ld, const tal_t *ctx)
 	 * twisted */
 	tal_free(hin);
 	tal_free(hout);
-	htlc_in_map_clear(htlcs_in);
-	htlc_out_map_clear(htlcs_out);
 
 	return true;
 }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1933,8 +1933,10 @@ int main(int argc, const char *argv[])
 	ld->rr_counter = 0;
 	node_id_from_hexstr("02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc", 66, &ld->id);
 	/* Accessed in peer destructor sanity check */
-	htlc_in_map_init(&ld->htlcs_in);
-	htlc_out_map_init(&ld->htlcs_out);
+	ld->htlcs_in = tal(ld, struct htlc_in_map);
+	htlc_in_map_init(ld->htlcs_in);
+	ld->htlcs_out = tal(ld, struct htlc_out_map);
+	htlc_out_map_init(ld->htlcs_out);
 
 	/* We do a runtime test here, so we still check compile! */
 	if (HAVE_SQLITE3) {

--- a/wallet/txfilter.c
+++ b/wallet/txfilter.c
@@ -52,16 +52,10 @@ struct outpointfilter {
 	struct outpointset *set;
 };
 
-static void destroy_txfilter(struct txfilter *filter)
-{
-	scriptpubkeyset_clear(&filter->scriptpubkeyset);
-}
-
 struct txfilter *txfilter_new(const tal_t *ctx)
 {
 	struct txfilter *filter = tal(ctx, struct txfilter);
 	scriptpubkeyset_init(&filter->scriptpubkeyset);
-	tal_add_destructor(filter, destroy_txfilter);
 	return filter;
 }
 
@@ -123,16 +117,10 @@ void outpointfilter_remove(struct outpointfilter *of,
 	outpointset_del(of->set, outpoint);
 }
 
-static void destroy_outpointfilter(struct outpointfilter *opf)
-{
-	outpointset_clear(opf->set);
-}
-
 struct outpointfilter *outpointfilter_new(tal_t *ctx)
 {
 	struct outpointfilter *opf = tal(ctx, struct outpointfilter);
 	opf->set = tal(opf, struct outpointset);
 	outpointset_init(opf->set);
-	tal_add_destructor(opf, destroy_outpointfilter);
 	return opf;
 }


### PR DESCRIPTION
This would catch memory leaks like the one found by @whitslack in #5865 but requires us to allocate htable structs rather than embed them.

Changelog-None