### PR TITLE
lightningd: shutdown plugins in two steps, db_write plugins as last

### DIFF
--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1227,6 +1227,18 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 	return true;
 }
 
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name)
+{
+	size_t count = tal_count(rpc->commands);
+	for (size_t j = 0; j < count; j++) {
+		if (streq(name, rpc->commands[j]->name)) {
+			   tal_free(rpc->commands[j]);
+			   return true;
+		}
+	}
+	return false;
+}
+
 static bool jsonrpc_command_add_perm(struct lightningd *ld,
 				     struct jsonrpc *rpc,
 				     struct json_command *command)

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -210,6 +210,9 @@ void jsonrpc_stop_all(struct lightningd *ld);
 bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 			 const char *usage TAKES);
 
+/* Remove a command from the JSON-RPC interface */
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name);
+
 /**
  * Begin a JSON-RPC notification with the specified topic.
  *

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1244,8 +1244,8 @@ stop:
 	/* Get rid of per-channel subdaemons. */
 	subd_shutdown_nonglobals(ld);
 
-	/* Tell plugins we're shutting down, use force if necessary. */
-	shutdown_plugins(ld);
+	/* Tell normal plugins we're shutting down, use force if necessary. */
+	shutdown_plugins(ld, true);
 
 	/* Now kill any remaining connections */
 	jsonrpc_stop_all(ld);
@@ -1258,6 +1258,9 @@ stop:
 
 	/* Now close database */
 	ld->wallet->db = tal_free(ld->wallet->db);
+
+	/* As database is closed we can safely shutdown db_write plugins */
+	shutdown_plugins(ld, false);
 
 	remove(ld->pidfile);
 

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -65,6 +65,8 @@ static const char *state_desc(const struct plugin *plugin)
 		return "before replying to init";
 	case INIT_COMPLETE:
 		return "during normal operation";
+	case SHUTDOWN:
+		return "in state shutdown";
 	}
 	fatal("Invalid plugin state %i for %s",
 	      plugin->plugin_state, plugin->cmd);
@@ -216,8 +218,10 @@ static void destroy_plugin(struct plugin *p)
 
 	/* Daemon shutdown overrules plugin's importance; aborts init checks */
 	if (p->plugins->ld->state == LD_STATE_SHUTDOWN) {
-		/* But return if this was the last plugin! */
-		if (list_empty(&p->plugins->plugins)) {
+
+		/* But break io_loop if this was the last plugin we waited for */
+		if (p->plugin_state == SHUTDOWN &&
+				    !plugins_any_in_state(p->plugins, SHUTDOWN)) {
 			log_debug(p->plugins->ld->log, "io_break: %s", __func__);
 			io_break(destroy_plugin);
 		}
@@ -2140,37 +2144,88 @@ void plugins_set_builtin_plugins_dir(struct plugins *plugins,
 				NULL, NULL);
 }
 
-void shutdown_plugins(struct lightningd *ld)
+void shutdown_plugins(struct lightningd *ld, bool keep_db_write_plugins)
 {
 	struct plugin *p, *next;
+	bool need_io = false;
 
-	/* Tell them all to shutdown; if they care. */
 	list_for_each_safe(&ld->plugins->plugins, p, next, list) {
-		/* Kill immediately, deletes self from list. */
-		if (p->plugin_state != INIT_COMPLETE || !notify_plugin_shutdown(ld, p))
+
+		/* Simply kill uninitialized plugin, freeing removes it from list */
+		if (p->plugin_state < INIT_COMPLETE) {
 			tal_free(p);
+			continue;
+		}
+
+		/* First call: */
+		if (keep_db_write_plugins) {
+
+			/* Send shutdown notifications while jsonrpc still exists */
+			assert(ld->jsonrpc);
+			bool notify = notify_plugin_shutdown(ld, p);
+			need_io = need_io || notify;
+
+			if (plugin_registered_db_write_hook(p))
+				continue;
+
+			/* Mark the plugins we shall wait for, others are killed */
+			if (notify)
+				p->plugin_state = SHUTDOWN;
+			else
+				tal_free(p);
+
+		/* Second call: */
+		} else {
+			assert(!ld->wallet->db);
+
+			/* io_close sends EOF to plugin's stdin, which eventually breaks its
+			 * main io-loop (safely) after subroutines have returned. */
+			io_close(p->stdin_conn);
+			need_io = true;
+
+			/* But we still wait for them to self-terminate. */
+			p->plugin_state = SHUTDOWN;
+		}
 	}
 
-	/* If anyone was interested in shutdown, give them time. */
-	if (!list_empty(&ld->plugins->plugins)) {
+	/* io_loop sends the notifications, waits 30 seconds for marked plugins
+	 * to self-terminate, see also destroy_plugin */
+	if (need_io) {
 		struct timers *timer;
 		struct timer *expired;
 
-		/* 30 seconds should do it, use a clean timers struct */
+		/* But don't wait full 30s to just notify, also use a clean timers
+		 * struct to ignore any existing timers. */
+		int t = plugins_any_in_state(ld->plugins, SHUTDOWN) ? 30000 : 1;
 		timer = tal(NULL, struct timers);
 		timers_init(timer, time_mono());
-		new_reltimer(timer, timer, time_from_sec(30), NULL, NULL);
+		new_reltimer(timer, timer, time_from_msec(t), NULL, NULL);
 
 		void *ret = io_loop(timer, &expired);
 		assert(ret == NULL || ret == destroy_plugin);
 
-		/* Report and free remaining plugins. */
-		while (!list_empty(&ld->plugins->plugins)) {
-			p = list_pop(&ld->plugins->plugins, struct plugin, list);
+		/* Report and free plugins that didn't self-terminate in time */
+		list_for_each_safe(&ld->plugins->plugins, p, next, list) {
+			if (p->plugin_state != SHUTDOWN) {
+				continue;
+			}
+
+			list_del_from(&ld->plugins->plugins, &p->list);
 			log_debug(ld->log,
 				  "%s: failed to self-terminate in time, killing.",
 				  p->shortname);
 			tal_free(p);
 		}
 	}
+
+	if (keep_db_write_plugins)
+		/* Remove JSON-RPC methods of remaining db_write plugins, so we can
+		 * free jsonrpc. */
+		list_for_each(&ld->plugins->plugins, p, list) {
+			for (size_t i=0; i<tal_count(p->methods); i++) {
+				jsonrpc_command_del(ld->jsonrpc, p->methods[i]);
+			}
+		}
+	else
+		assert(list_empty(&ld->plugins->plugins));
 }

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -16,7 +16,9 @@ enum plugin_state {
 	/* We have to get `init` response */
 	AWAITING_INIT_RESPONSE,
 	/* We have `init` response. */
-	INIT_COMPLETE
+	INIT_COMPLETE,
+	/* Wait for it to self-terminate */
+	SHUTDOWN,
 };
 
 /**
@@ -238,9 +240,16 @@ void plugin_kill(struct plugin *plugin, enum log_level loglevel,
 		 const char *fmt, ...);
 
 /**
- * Tell all the plugins we're shutting down, and free them.
+ * Tell subscribed plugins we're shutting down, wait for them to self-terminate
+ * and free them.
+ *
+ * @keep_db_write_plugins=true: plugins that registered the db_write hook are
+ * kept alive, but still send them a "shutdown" notification when subscribed.
+ *
+ * @keep_db_write_plugins=false: shutdown remaining plugins: send EOF to their
+ * stdin, then wait for them to self-terminate.
  */
-void shutdown_plugins(struct lightningd *ld);
+void shutdown_plugins(struct lightningd *ld, bool keep_db_write_plugins);
 
 /**
  * Returns the plugin which registers the command with name {cmd_name}

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -304,6 +304,16 @@ struct db_write_hook_req {
 	size_t *num_hooks;
 };
 
+bool plugin_registered_db_write_hook(struct plugin *plugin) {
+	const struct plugin_hook *hook = &db_write_hook;
+
+	for (size_t i = 0; i < tal_count(hook->hooks); i++)
+		if (hook->hooks[i]->plugin == plugin)
+			return true;
+
+	return false;
+}
+
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,
 			     const jsmntok_t *idtok,
 			     struct db_write_hook_req *dwh_req)

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -110,6 +110,9 @@ bool plugin_hook_continue(void *arg, const char *buffer, const jsmntok_t *toks);
 struct plugin_hook *plugin_hook_register(struct plugin *plugin,
 					 const char *method);
 
+/* Helper to tell if plugin registered the db_write hook */
+bool plugin_registered_db_write_hook(struct plugin *plugin);
+
 /* Special sync plugin hook for db. */
 void plugin_hook_db_sync(struct db *db);
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -195,7 +195,7 @@ void setup_topology(struct chain_topology *topology UNNEEDED,
 		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)
 { fprintf(stderr, "setup_topology called!\n"); abort(); }
 /* Generated stub for shutdown_plugins */
-void shutdown_plugins(struct lightningd *ld UNNEEDED)
+void shutdown_plugins(struct lightningd *ld UNNEEDED, bool keep_db_write_plugins UNNEEDED)
 { fprintf(stderr, "shutdown_plugins called!\n"); abort(); }
 /* Generated stub for stop_topology */
 void stop_topology(struct chain_topology *topo UNNEEDED)

--- a/tests/plugins/dblog.py
+++ b/tests/plugins/dblog.py
@@ -50,5 +50,14 @@ def db_write(plugin, writes, **kwargs):
     return {"result": "continue"}
 
 
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    plugin.log("received shutdown notification")
+
+
 plugin.add_option('dblog-file', None, 'The db file to create.')
 plugin.run()
+
+# Because we subscribed 'db_write' hook, lightningd `stop` will wait for us in
+# the 2nd call of shutdown_plugins, after database has been closed!
+plugin.log('reached end of main')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2576,7 +2576,7 @@ plugin.run()
     n.stop()
 
 
-def test_plugin_shutdown(node_factory):
+def test_plugin_shutdown(node_factory, executor):
     """test 'shutdown' notifications, via `plugin stop` or via `stop`"""
 
     p = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")
@@ -2599,12 +2599,14 @@ def test_plugin_shutdown(node_factory):
     l1.daemon.wait_for_log(r"test_libplugin: shutdown called")
     l1.daemon.wait_for_log(r"test_libplugin: Timeout on shutdown: killing anyway")
 
-    # Now, should also shutdown or timeout on finish, RPC calls then fail with error code -5
+    # Now, should also shutdown or timeout on finish, RPC calls then fail
     l1.rpc.plugin_start(p, dont_shutdown=True)
-    l1.rpc.stop()
+    f_stop = executor.submit(l1.rpc.stop)
     l1.daemon.wait_for_logs(['test_libplugin: shutdown called',
                              'misc_notifications.py: .* Connection refused',
                              'test_libplugin: failed to self-terminate in time, killing.'])
+
+    f_stop.result()
 
 
 def test_commando(node_factory, executor):


### PR DESCRIPTION
Addresses issue #5859 to keep `db_write`-plugins alive when lightningd is shutting down, until _after_ the database is closed.

This revives an old idea (from #4790) to call `shutdown_plugins` twice:
- In the first call it sends "shutdown" notifications (jsonrpc still exist) and waits for all non-`db_write` plugins to terminate.
- In the second call, after database is closed, remaining `db_write` plugins can safely self-terminate when they see  an EOF event at their stdin.

~One `test_htlc_accepted_hook_shutdown` was added (currently skipped) to demonstrate a hang when L1 tries to pay an invoice while L2 is shutting down.~

Changed this into pull request after squashing, the unsquashed draft can be found [here](https://github.com/SimonVrouwe/lightning/tree/2023-01-12_draft_shutdown_issue_5859)

TODO:
- [ ] update documentation and add changelog