### PR TITLE
comm: make sure that our version check is reliable

### DIFF
--- a/common/test/Makefile
+++ b/common/test/Makefile
@@ -90,4 +90,11 @@ common/test/run-bolt12_merkle-json:			\
 	common/base32.o					\
 	common/wireaddr.o
 
+
+common/test/run-version:				\
+	common/amount.o                                 \
+	wire/fromwire.o					\
+	wire/towire.o
+
+
 check-units: $(COMMON_TEST_PROGRAMS:%=unittest/%)

--- a/common/test/run-version.c
+++ b/common/test/run-version.c
@@ -1,0 +1,16 @@
+#include "config.h"
+#include "../version.c"
+#include <common/setup.h>
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+	common_setup(argv[0]);
+
+	assert(cmp_release_version("v22.11"));
+	assert(cmp_release_version("v22.11.1"));
+	assert(cmp_release_version("v22.11.1-6-gdf29990-modded") == false);
+
+	common_shutdown();
+}

--- a/common/version.c
+++ b/common/version.c
@@ -3,6 +3,7 @@
 #include <common/version.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* Only common/version.c can safely include this.  */
 # include "version_gen.h"
@@ -19,4 +20,16 @@ char *version_and_exit(const void *unused UNUSED)
 		printf("Built with features: %s\n", BUILD_FEATURES);
 	}
 	exit(0);
+}
+
+static bool cmp_release_version(const char *version) {
+	if (version[0] != 'v')
+		return false;
+	return strspn(version+1, ".0123456789") == strlen(version+1);
+}
+
+/* Released versions are of form v[year].[month]?(.patch)* */
+bool is_released_version(void)
+{
+	return cmp_release_version(version());
 }

--- a/common/version.h
+++ b/common/version.h
@@ -1,9 +1,14 @@
 #ifndef LIGHTNING_COMMON_VERSION_H
 #define LIGHTNING_COMMON_VERSION_H
 #include "config.h"
+#include <stdbool.h>
 
 char *version_and_exit(const void *unused);
 const char *version(void);
+/* check if the current version is a release version.
+ *
+ * Released versions are of form v[year].[month]?(.patch)* */
+bool is_released_version(void);
 
 #define opt_register_version()						\
 	opt_register_early_noarg("--version|-V", version_and_exit, NULL, \

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -945,14 +945,6 @@ static struct migration dbmigrations[] = {
     /* FIXME: Remove payments local_offer_id column! */
 };
 
-/* Released versions are of form v{num}[.{num}]* */
-static bool is_released_version(void)
-{
-	if (version()[0] != 'v')
-		return false;
-	return strcspn(version()+1, ".0123456789") == strlen(version()+1);
-}
-
 /**
  * db_migrate - Apply all remaining migrations from the current version
  */


### PR DESCRIPTION
Rework the logic of the version check used in the
database migration, and make sure
that it is full functional to avoid confusion
at release time.

Fixes https://github.com/ElementsProject/lightning/issues/5870

Reported-by: @urza
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>