### PR TITLE
Bugfix: Fix 'extreme cases' logging of many commit timer failures

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1245,6 +1245,9 @@ static void send_commit(struct peer *peer)
 		peer->commit_timer = NULL;
 		start_commit_timer(peer);
 		return;
+	} else {
+		/* We can advance; wipe attempts */
+		peer->commit_timer_attempts = 0;
 	}
 
 	/* BOLT #2:
@@ -1399,7 +1402,6 @@ static void start_commit_timer(struct peer *peer)
 	if (peer->commit_timer)
 		return;
 
-	peer->commit_timer_attempts = 0;
 	peer->commit_timer = new_reltimer(&peer->timers, peer,
 					  time_from_msec(peer->commit_msec),
 					  send_commit, peer);
@@ -3984,6 +3986,7 @@ int main(int argc, char *argv[])
 	peer->shutdown_wrong_funding = NULL;
 	peer->last_update_timestamp = 0;
 	peer->last_empty_commitment = 0;
+	peer->commit_timer_attempts = 0;
 #if EXPERIMENTAL_FEATURES
 	peer->stfu = false;
 	peer->stfu_sent[LOCAL] = peer->stfu_sent[REMOTE] = false;


### PR DESCRIPTION
Currently it is impossible for the log line to be hit since the value is set to 1, then reset immediately after to 0. Makes it hard to see if this is happening in a degenerate way. 

Changelog-None