### PR TITLE
Compare balance entries by account_id, not assumed order

### DIFF
--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -536,6 +536,7 @@ def test_bookkeeping_missed_chans_pay_after(node_factory, bitcoind):
 
 
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "turns off bookkeeper at start")
+@pytest.mark.developer("wait for announce times out otherwise")
 def test_bookkeeping_onchaind_txs(node_factory, bitcoind):
     """
     Test for a channel that's closed, but whose close tx

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1301,12 +1301,15 @@ def test_penalty_htlc_tx_fulfill(node_factory, bitcoind, chainparams):
     if not chainparams['elements']:
         # Also check snapshots
         expected_bals_2 = [
-            {'blockheight': 101, 'accounts': [{'balance_msat': '0msat'}]},
-            {'blockheight': 108, 'accounts': [{'balance_msat': '995433000msat'}, {'balance_msat': '500000000msat'}, {'balance_msat': '499994999msat'}]},
-            # There's a duplicate because we stop and restart l2 twice
-            # (both times at block 108)
-            {'blockheight': 108, 'accounts': [{'balance_msat': '995433000msat'}, {'balance_msat': '500000000msat'}, {'balance_msat': '499994999msat'}]},
-        ]
+            {'blockheight': 101, 'accounts': [
+                {'balance_msat': '0msat', 'account_id': 'wallet'}
+            ]}
+        ] + [
+            {'blockheight': 108, 'accounts': [
+                {'balance_msat': '995433000msat', 'account_id': 'wallet'},
+                {'balance_msat': '500000000msat', 'account_id': first_channel_id(l1, l2)},
+                {'balance_msat': '499994999msat', 'account_id': channel_id}]}
+        ] * 2  # duplicated; we stop and restart l2 twice (both at block 108)
         check_balance_snaps(l2, expected_bals_2)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,14 +109,15 @@ def calc_lease_fee(amt, feerate, rates):
     return fee
 
 
+def _dictify(balances):
+    return {b['account_id']: Millisatoshi(b['balance_msat']) for b in balances['accounts']}
+
+
 def check_balance_snaps(n, expected_bals):
     snaps = n.rpc.listsnapshots()['balance_snapshots']
     for snap, exp in zip(snaps, expected_bals):
         assert snap['blockheight'] == exp['blockheight']
-        for acct, exp_acct in zip(snap['accounts'], exp['accounts']):
-            # FIXME: also check 'account_id's (these change every run)
-            for item in ['balance_msat']:
-                assert Millisatoshi(acct[item]) == Millisatoshi(exp_acct[item])
+        assert _dictify(snap) == _dictify(exp)
 
 
 def check_coin_moves(n, account_id, expected_moves, chainparams):


### PR DESCRIPTION
#5849 moves to hashmaps, not linked lists. This removes ordering of RPC call output, which the test assertion utility `check_balance_snaps` relied on.

Changelog-None