### PR TITLE
cln-grpc: update listpeers json fixing tests

### DIFF
--- a/cln-grpc/src/pb.rs
+++ b/cln-grpc/src/pb.rs
@@ -190,7 +190,9 @@ mod test {
                   "funding": {
                     "local_msat": "0msat",
                     "remote_msat": "1000000000msat",
-                    "pushed_msat": "0msat"
+                    "pushed_msat": "0msat",
+                    "local_funds_msat": "0msat",
+                    "remote_funds_msat": "0msat"
                   },
                   "msatoshi_to_us": 0,
                   "to_us_msat": "0msat",
@@ -289,7 +291,9 @@ mod test {
                   "funding": {
                     "local_msat": "1000000000msat",
                     "remote_msat": "0msat",
-                    "pushed_msat": "0msat"
+                    "pushed_msat": "0msat",
+                    "local_funds_msat": "0msat",
+                    "remote_funds_msat": "0msat"
                   },
                   "msatoshi_to_us": 1000000000,
                   "to_us_msat": "1000000000msat",

--- a/cln-grpc/src/test.rs
+++ b/cln-grpc/src/test.rs
@@ -38,7 +38,9 @@ fn test_listpeers() {
               "funding": {
                 "local_msat": "0msat",
                 "remote_msat": "1000000000msat",
-                "pushed_msat": "0msat"
+                "pushed_msat": "0msat",
+                "local_funds_msat": "0msat",
+                "remote_funds_msat": "0msat"
               },
               "msatoshi_to_us": 0,
               "to_us_msat": "0msat",
@@ -137,7 +139,9 @@ fn test_listpeers() {
               "funding": {
                 "local_msat": "1000000000msat",
                 "remote_msat": "0msat",
-                "pushed_msat": "0msat"
+                "pushed_msat": "0msat",
+                "local_funds_msat": "0msat",
+                "remote_funds_msat": "0msat"
               },
               "msatoshi_to_us": 1000000000,
               "to_us_msat": "1000000000msat",
@@ -278,7 +282,7 @@ fn test_keysend() {
                 }],
                 }],
             }),
-	    extratlvs: None,
+            extratlvs: None,
         };
 
     let u: cln_rpc::model::KeysendRequest = g.into();


### PR DESCRIPTION
`cargo test` is failing under `/cln-grpc` because a coupe of static json (result from listpeers) have not been updated with new fields as the model.

Fixes https://github.com/ElementsProject/lightning/issues/5899