### PR TITLE
ccan: update to fix recent gcc "comparison will always evaluate as 'false'" warning

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2548-gab87e56b
+CCAN version: init-2549-gba79e21b

--- a/ccan/ccan/tcon/tcon.h
+++ b/ccan/ccan/tcon/tcon.h
@@ -147,8 +147,7 @@
  * It evaluates to @x so you can chain it.
  */
 #define tcon_check_ptr(x, canary, expr)				\
-	(sizeof(&(x)->_tcon[0].canary == (expr)) ? (x) : (x))
-
+	(sizeof((expr) ? (expr) : &(x)->_tcon[0].canary) ? (x) : (x))
 
 /**
  * tcon_type - the type within a container (or void *)

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1117,8 +1117,11 @@ int main(int argc, char *argv[])
 
 	/*~ Now that the rpc path exists, we can start the plugins and they
 	 * can start talking to us. */
-	if (!plugins_config(ld->plugins))
+	if (!plugins_config(ld->plugins)) {
+		/* Valgrind can complain about this leak! */
+		tal_free(unconnected_htlcs_in);
 		goto stop;
+	}
 
 	/*~ Process any HTLCs we were in the middle of when we exited, now
 	 * that plugins (who might want to know via htlc_accepted hook) are

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2797,7 +2797,7 @@ void fixup_htlcs_out(struct lightningd *ld)
 #endif /* COMPAT_V061 */
 
 void htlcs_resubmit(struct lightningd *ld,
-		    struct htlc_in_map *unconnected_htlcs_in)
+		    struct htlc_in_map *unconnected_htlcs_in STEALS)
 {
 	struct htlc_in *hin;
 	struct htlc_in_map_iter ini;

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -65,7 +65,7 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height);
 void fixup_htlcs_out(struct lightningd *ld);
 
 void htlcs_resubmit(struct lightningd *ld,
-		    struct htlc_in_map *unconnected_htlcs_in);
+		    struct htlc_in_map *unconnected_htlcs_in STEALS);
 
 /* For HTLCs which terminate here, invoice payment calls one of these. */
 void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage);


### PR DESCRIPTION
(Breaking my build machine, so extracted as standalone from #5892 )

```
lightningd/jsonrpc.c: In function ‘destroy_json_command’:
lightningd/jsonrpc.c:1180:63: error: the comparison will always evaluate as ‘false’ for the address of ‘canary’ will never be NULL [-Werror=address]
lightningd/jsonrpc.c:108:53: note: ‘canary’ declared here
```

Changelog-None