### PR TITLE
doc-schema: make address field in getinfo response required

### DIFF
--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -65,7 +65,7 @@ impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
             network: c.network, // Rule #2 for type string
             msatoshi_fees_collected: c.msatoshi_fees_collected, // Rule #2 for type u64?
             fees_collected_msat: Some(c.fees_collected_msat.into()), // Rule #2 for type msat
-            address: c.address.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            address: c.address.into_iter().map(|i| i.into()).collect(), // Rule #3 for type GetinfoAddress 
             binding: c.binding.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
             warning_bitcoind_sync: c.warning_bitcoind_sync, // Rule #2 for type string?
             warning_lightningd_sync: c.warning_lightningd_sync, // Rule #2 for type string?

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1390,8 +1390,7 @@ pub mod responses {
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub msatoshi_fees_collected: Option<u64>,
 	    pub fees_collected_msat: Amount,
-	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
-	    pub address: Option<Vec<GetinfoAddress>>,
+	    pub address: Vec<GetinfoAddress>,
 	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub binding: Option<Vec<GetinfoBinding>>,
 	    #[serde(skip_serializing_if = "Option::is_none")]

--- a/doc/lightning-getinfo.7.md
+++ b/doc/lightning-getinfo.7.md
@@ -40,19 +40,19 @@ On success, an object is returned, containing:
 - **blockheight** (u32): The highest block height we've learned
 - **network** (string): represents the type of network on the node are working (e.g: `bitcoin`, `testnet`, or `regtest`)
 - **fees\_collected\_msat** (msat): Total routing fees collected by this node
-- **our\_features** (object, optional): Our BOLT #9 feature bits (as hexstring) for various contexts:
-  - **init** (hex): features (incl. globalfeatures) in our init message, these also restrict what we offer in open\_channel or accept in accept\_channel
-  - **node** (hex): features in our node\_announcement message
-  - **channel** (hex): negotiated channel features we (as channel initiator) publish in the channel\_announcement message
-  - **invoice** (hex): features in our BOLT11 invoices
-- **msatoshi\_fees\_collected** (u64, optional) **deprecated, removal in v23.05**
-- **address** (array of objects, optional): The addresses we announce to the world:
+- **address** (array of objects): The addresses we announce to the world:
   - **type** (string): Type of connection (one of "dns", "ipv4", "ipv6", "torv2", "torv3", "websocket")
   - **port** (u16): port number
 
   If **type** is "dns", "ipv4", "ipv6", "torv2" or "torv3":
 
     - **address** (string): address in expected format for **type**
+- **our\_features** (object, optional): Our BOLT #9 feature bits (as hexstring) for various contexts:
+  - **init** (hex): features (incl. globalfeatures) in our init message, these also restrict what we offer in open\_channel or accept in accept\_channel
+  - **node** (hex): features in our node\_announcement message
+  - **channel** (hex): negotiated channel features we (as channel initiator) publish in the channel\_announcement message
+  - **invoice** (hex): features in our BOLT11 invoices
+- **msatoshi\_fees\_collected** (u64, optional) **deprecated, removal in v23.05**
 - **binding** (array of objects, optional): The addresses we are listening on:
   - **type** (string): Type of connection (one of "local socket", "ipv4", "ipv6", "torv2", "torv3")
   - **address** (string, optional): address in expected format for **type**
@@ -133,4 +133,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:cd659304258fa31d104fa4bd41855a699a62777e6b57998fdbc064ffe02a293a)
+[comment]: # ( SHA256STAMP:5c7c4d6279279b6c92cd3b039dcb24429214b2460a6ad82bed384796389a9b5c)

--- a/doc/schemas/getinfo.schema.json
+++ b/doc/schemas/getinfo.schema.json
@@ -14,7 +14,8 @@
     "blockheight",
     "network",
     "fees_collected_msat",
-    "lightning-dir"
+    "lightning-dir",
+    "address"
   ],
   "properties": {
     "id": {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2365,10 +2365,10 @@ static struct command_result *json_getinfo(struct command *cmd,
 	json_add_num(response, "num_inactive_channels", inactive_channels);
 
 	/* Add network info */
+	json_array_start(response, "address");
 	if (cmd->ld->listen) {
 		/* These are the addresses we're announcing */
 		count_announceable = tal_count(cmd->ld->announceable);
-		json_array_start(response, "address");
 		for (size_t i = 0; i < count_announceable; i++)
 			json_add_address(response, NULL, cmd->ld->announceable+i);
 
@@ -2396,8 +2396,9 @@ static struct command_result *json_getinfo(struct command *cmd,
 		for (size_t i = 0; i < tal_count(cmd->ld->binding); i++)
 			json_add_address_internal(response, NULL,
 					cmd->ld->binding+i);
-		json_array_end(response);
 	}
+	json_array_end(response);
+
 	json_add_string(response, "version", version());
 	json_add_num(response, "blockheight", cmd->ld->blockheight);
 	json_add_string(response, "network", chainparams->network_name);


### PR DESCRIPTION
~~Since it is always returned even if empty~~ this was false, see https://github.com/ElementsProject/lightning/pull/5904#issuecomment-1386475617 , there are cases where address field is not returned, but since there are also cases where is returned empty the issue remains. 

alternative to #5902 
Closes #5902 
Changelog-None