### PR TITLE
add PartialEq to ShortChannelId

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -100,7 +100,7 @@ impl std::ops::Sub for Amount {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ShortChannelId(u64);
 
 impl Serialize for ShortChannelId {


### PR DESCRIPTION
PartialEq makes it possible to compare 2 ShortChannelIds for equality which i found often helpful