### PR TITLE
cln-rpc: use serde rename instead of alias

### DIFF
--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -149,9 +149,9 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersRequest {
-	    #[serde(alias = "id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub id: Option<PublicKey>,
-	    #[serde(alias = "level", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub level: Option<String>,
 	}
 
@@ -167,7 +167,7 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsRequest {
-	    #[serde(alias = "spent", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub spent: Option<bool>,
 	}
 
@@ -183,35 +183,29 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpayRoute {
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "delay")]
 	    pub delay: u16,
-	    #[serde(alias = "channel")]
 	    pub channel: ShortChannelId,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpayRequest {
-	    #[serde(alias = "route")]
 	    pub route: Vec<SendpayRoute>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "payment_secret", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_secret: Option<Secret>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u16>,
-	    #[serde(alias = "localinvreqid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub localinvreqid: Option<String>,
-	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
 	}
 
@@ -227,11 +221,11 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsRequest {
-	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
-	    #[serde(alias = "source", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub source: Option<PublicKey>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
 	}
 
@@ -247,7 +241,6 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct AddgossipRequest {
-	    #[serde(alias = "message")]
 	    pub message: String,
 	}
 
@@ -263,9 +256,9 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct AutocleaninvoiceRequest {
-	    #[serde(alias = "expired_by", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub expired_by: Option<u64>,
-	    #[serde(alias = "cycle_seconds", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub cycle_seconds: Option<u64>,
 	}
 
@@ -281,11 +274,9 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CheckmessageRequest {
-	    #[serde(alias = "message")]
 	    pub message: String,
-	    #[serde(alias = "zbase")]
 	    pub zbase: String,
-	    #[serde(alias = "pubkey", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pubkey: Option<PublicKey>,
 	}
 
@@ -301,19 +292,18 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CloseRequest {
-	    #[serde(alias = "id")]
 	    pub id: String,
-	    #[serde(alias = "unilateraltimeout", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub unilateraltimeout: Option<u32>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<String>,
-	    #[serde(alias = "fee_negotiation_step", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_negotiation_step: Option<String>,
-	    #[serde(alias = "wrong_funding", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub wrong_funding: Option<Outpoint>,
-	    #[serde(alias = "force_lease_closed", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub force_lease_closed: Option<bool>,
-	    #[serde(alias = "feerange", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub feerange: Option<Vec<Feerate>>,
 	}
 
@@ -329,11 +319,10 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ConnectRequest {
-	    #[serde(alias = "id")]
 	    pub id: String,
-	    #[serde(alias = "host", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub host: Option<String>,
-	    #[serde(alias = "port", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub port: Option<u16>,
 	}
 
@@ -349,11 +338,8 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateinvoiceRequest {
-	    #[serde(alias = "invstring")]
 	    pub invstring: String,
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "preimage")]
 	    pub preimage: String,
 	}
 
@@ -396,15 +382,14 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DatastoreRequest {
-	    #[serde(alias = "key")]
 	    pub key: Vec<String>,
-	    #[serde(alias = "string", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub string: Option<String>,
-	    #[serde(alias = "hex", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub hex: Option<String>,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mode: Option<DatastoreMode>,
-	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
 	}
 
@@ -420,21 +405,17 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionHops {
-	    #[serde(alias = "pubkey")]
 	    pub pubkey: PublicKey,
-	    #[serde(alias = "payload")]
 	    pub payload: String,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionRequest {
-	    #[serde(alias = "hops")]
 	    pub hops: Vec<CreateonionHops>,
-	    #[serde(alias = "assocdata")]
 	    pub assocdata: String,
-	    #[serde(alias = "session_key", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub session_key: Option<Secret>,
-	    #[serde(alias = "onion_size", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub onion_size: Option<u16>,
 	}
 
@@ -450,9 +431,8 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DeldatastoreRequest {
-	    #[serde(alias = "key")]
 	    pub key: Vec<String>,
-	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
 	}
 
@@ -468,7 +448,7 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelexpiredinvoiceRequest {
-	    #[serde(alias = "maxexpirytime", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxexpirytime: Option<u64>,
 	}
 
@@ -505,12 +485,10 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelinvoiceRequest {
-	    #[serde(alias = "label")]
 	    pub label: String,
 	    // Path `DelInvoice.status`
-	    #[serde(rename = "status")]
 	    pub status: DelinvoiceStatus,
-	    #[serde(alias = "desconly", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub desconly: Option<bool>,
 	}
 
@@ -526,23 +504,20 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct InvoiceRequest {
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: AmountOrAny,
-	    #[serde(alias = "description")]
 	    pub description: String,
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "expiry", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub expiry: Option<u64>,
-	    #[serde(alias = "fallbacks", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub fallbacks: Option<Vec<String>>,
-	    #[serde(alias = "preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub preimage: Option<String>,
-	    #[serde(alias = "exposeprivatechannels", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub exposeprivatechannels: Option<bool>,
-	    #[serde(alias = "cltv", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub cltv: Option<u32>,
-	    #[serde(alias = "deschashonly", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub deschashonly: Option<bool>,
 	}
 
@@ -558,7 +533,7 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListdatastoreRequest {
-	    #[serde(alias = "key", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub key: Option<Vec<String>>,
 	}
 
@@ -574,13 +549,13 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListinvoicesRequest {
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "invstring", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub invstring: Option<String>,
-	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<String>,
-	    #[serde(alias = "offer_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub offer_id: Option<String>,
 	}
 
@@ -596,37 +571,31 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendonionFirst_hop {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "delay")]
 	    pub delay: u16,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendonionRequest {
-	    #[serde(alias = "onion")]
 	    pub onion: String,
-	    #[serde(alias = "first_hop")]
 	    pub first_hop: SendonionFirst_hop,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "shared_secrets", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub shared_secrets: Option<Vec<Secret>>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u16>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "localinvreqid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub localinvreqid: Option<Sha256>,
-	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
 	}
 
@@ -663,9 +632,9 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListsendpaysRequest {
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<Sha256>,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListsendpaysStatus>,
@@ -697,29 +666,28 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PayRequest {
-	    #[serde(alias = "bolt11")]
 	    pub bolt11: String,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "riskfactor", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub riskfactor: Option<f64>,
-	    #[serde(alias = "maxfeepercent", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxfeepercent: Option<f64>,
-	    #[serde(alias = "retry_for", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub retry_for: Option<u16>,
-	    #[serde(alias = "maxdelay", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxdelay: Option<u16>,
-	    #[serde(alias = "exemptfee", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub exemptfee: Option<Amount>,
-	    #[serde(alias = "localinvreqid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub localinvreqid: Option<String>,
-	    #[serde(alias = "exclude", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub exclude: Option<Vec<String>>,
-	    #[serde(alias = "maxfee", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxfee: Option<Amount>,
-	    #[serde(alias = "description", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub description: Option<String>,
 	}
 
@@ -735,7 +703,7 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesRequest {
-	    #[serde(alias = "id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub id: Option<PublicKey>,
 	}
 
@@ -751,9 +719,9 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitanyinvoiceRequest {
-	    #[serde(alias = "lastpay_index", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub lastpay_index: Option<u64>,
-	    #[serde(alias = "timeout", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub timeout: Option<u64>,
 	}
 
@@ -769,7 +737,6 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitinvoiceRequest {
-	    #[serde(alias = "label")]
 	    pub label: String,
 	}
 
@@ -785,13 +752,12 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitsendpayRequest {
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "timeout", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub timeout: Option<u32>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u64>,
-	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
 	}
 
@@ -841,15 +807,14 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WithdrawRequest {
-	    #[serde(alias = "destination")]
 	    pub destination: String,
-	    #[serde(alias = "satoshi", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub satoshi: Option<AmountOrAll>,
-	    #[serde(alias = "feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feerate: Option<Feerate>,
-	    #[serde(alias = "minconf", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minconf: Option<u16>,
-	    #[serde(alias = "utxos", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub utxos: Option<Vec<Outpoint>>,
 	}
 
@@ -865,23 +830,21 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct KeysendRequest {
-	    #[serde(alias = "destination")]
 	    pub destination: PublicKey,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "maxfeepercent", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxfeepercent: Option<f64>,
-	    #[serde(alias = "retry_for", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub retry_for: Option<u32>,
-	    #[serde(alias = "maxdelay", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxdelay: Option<u32>,
-	    #[serde(alias = "exemptfee", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub exemptfee: Option<Amount>,
-	    #[serde(alias = "routehints", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub routehints: Option<RoutehintList>,
-	    #[serde(alias = "extratlvs", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub extratlvs: Option<TlvStream>,
 	}
 
@@ -897,21 +860,18 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundpsbtRequest {
-	    #[serde(alias = "satoshi")]
 	    pub satoshi: AmountOrAll,
-	    #[serde(alias = "feerate")]
 	    pub feerate: Feerate,
-	    #[serde(alias = "startweight")]
 	    pub startweight: u32,
-	    #[serde(alias = "minconf", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minconf: Option<u32>,
-	    #[serde(alias = "reserve", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub reserve: Option<u32>,
-	    #[serde(alias = "locktime", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub locktime: Option<u32>,
-	    #[serde(alias = "min_witness_weight", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub min_witness_weight: Option<u32>,
-	    #[serde(alias = "excess_as_change", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub excess_as_change: Option<bool>,
 	}
 
@@ -927,9 +887,8 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpsbtRequest {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "reserve", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub reserve: Option<bool>,
 	}
 
@@ -945,9 +904,8 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignpsbtRequest {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "signonly", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub signonly: Option<Vec<u32>>,
 	}
 
@@ -963,23 +921,19 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct UtxopsbtRequest {
-	    #[serde(alias = "satoshi")]
 	    pub satoshi: Amount,
-	    #[serde(alias = "feerate")]
 	    pub feerate: Feerate,
-	    #[serde(alias = "startweight")]
 	    pub startweight: u32,
-	    #[serde(alias = "utxos")]
 	    pub utxos: Vec<Outpoint>,
-	    #[serde(alias = "reserve", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub reserve: Option<u32>,
-	    #[serde(alias = "reservedok", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub reservedok: Option<bool>,
-	    #[serde(alias = "locktime", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub locktime: Option<u32>,
-	    #[serde(alias = "min_witness_weight", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub min_witness_weight: Option<u32>,
-	    #[serde(alias = "excess_as_change", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub excess_as_change: Option<bool>,
 	}
 
@@ -995,7 +949,6 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxdiscardRequest {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -1011,13 +964,12 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxprepareRequest {
-	    #[serde(alias = "outputs")]
 	    pub outputs: Vec<OutputDesc>,
-	    #[serde(alias = "feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feerate: Option<Feerate>,
-	    #[serde(alias = "minconf", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minconf: Option<u32>,
-	    #[serde(alias = "utxos", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub utxos: Option<Vec<Outpoint>>,
 	}
 
@@ -1033,7 +985,6 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxsendRequest {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -1049,9 +1000,8 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DisconnectRequest {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "force", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub force: Option<bool>,
 	}
 
@@ -1086,7 +1036,6 @@ pub mod requests {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesRequest {
 	    // Path `Feerates.style`
-	    #[serde(rename = "style")]
 	    pub style: FeeratesStyle,
 	}
 
@@ -1102,29 +1051,27 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundchannelRequest {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "amount")]
 	    pub amount: AmountOrAll,
-	    #[serde(alias = "feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feerate: Option<Feerate>,
-	    #[serde(alias = "announce", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub announce: Option<bool>,
-	    #[serde(alias = "minconf", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minconf: Option<u32>,
-	    #[serde(alias = "push_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub push_msat: Option<Amount>,
-	    #[serde(alias = "close_to", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub close_to: Option<String>,
-	    #[serde(alias = "request_amt", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub request_amt: Option<Amount>,
-	    #[serde(alias = "compact_lease", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub compact_lease: Option<String>,
-	    #[serde(alias = "utxos", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub utxos: Option<Vec<Outpoint>>,
-	    #[serde(alias = "mindepth", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mindepth: Option<u32>,
-	    #[serde(alias = "reserve", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub reserve: Option<Amount>,
 	}
 
@@ -1140,21 +1087,18 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRequest {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "riskfactor")]
 	    pub riskfactor: u64,
-	    #[serde(alias = "cltv", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub cltv: Option<f64>,
-	    #[serde(alias = "fromid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fromid: Option<PublicKey>,
-	    #[serde(alias = "fuzzpercent", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fuzzpercent: Option<u32>,
-	    #[serde(alias = "exclude", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub exclude: Option<Vec<String>>,
-	    #[serde(alias = "maxhops", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maxhops: Option<u32>,
 	}
 
@@ -1196,9 +1140,9 @@ pub mod requests {
 	pub struct ListforwardsRequest {
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListforwardsStatus>,
-	    #[serde(alias = "in_channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_channel: Option<ShortChannelId>,
-	    #[serde(alias = "out_channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_channel: Option<ShortChannelId>,
 	}
 
@@ -1235,9 +1179,9 @@ pub mod requests {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpaysRequest {
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "payment_hash", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_hash: Option<Sha256>,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<ListpaysStatus>,
@@ -1255,11 +1199,10 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PingRequest {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "len", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub len: Option<u16>,
-	    #[serde(alias = "pongbytes", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pongbytes: Option<u16>,
 	}
 
@@ -1275,17 +1218,16 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SetchannelRequest {
-	    #[serde(alias = "id")]
 	    pub id: String,
-	    #[serde(alias = "feebase", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feebase: Option<Amount>,
-	    #[serde(alias = "feeppm", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feeppm: Option<u32>,
-	    #[serde(alias = "htlcmin", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub htlcmin: Option<Amount>,
-	    #[serde(alias = "htlcmax", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub htlcmax: Option<Amount>,
-	    #[serde(alias = "enforcedelay", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub enforcedelay: Option<u32>,
 	}
 
@@ -1301,7 +1243,6 @@ pub mod requests {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignmessageRequest {
-	    #[serde(alias = "message")]
 	    pub message: String,
 	}
 
@@ -1341,13 +1282,9 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoOur_features {
-	    #[serde(alias = "init")]
 	    pub init: String,
-	    #[serde(alias = "node")]
 	    pub node: String,
-	    #[serde(alias = "channel")]
 	    pub channel: String,
-	    #[serde(alias = "invoice")]
 	    pub invoice: String,
 	}
 
@@ -1387,9 +1324,8 @@ pub mod responses {
 	    // Path `Getinfo.address[].type`
 	    #[serde(rename = "type")]
 	    pub item_type: GetinfoAddressType,
-	    #[serde(alias = "port")]
 	    pub port: u16,
-	    #[serde(alias = "address", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub address: Option<String>,
 	}
 
@@ -1426,52 +1362,41 @@ pub mod responses {
 	    // Path `Getinfo.binding[].type`
 	    #[serde(rename = "type")]
 	    pub item_type: GetinfoBindingType,
-	    #[serde(alias = "address", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub address: Option<String>,
-	    #[serde(alias = "port", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub port: Option<u16>,
-	    #[serde(alias = "socket", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub socket: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoResponse {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "alias")]
 	    pub alias: String,
-	    #[serde(alias = "color")]
 	    pub color: String,
-	    #[serde(alias = "num_peers")]
 	    pub num_peers: u32,
-	    #[serde(alias = "num_pending_channels")]
 	    pub num_pending_channels: u32,
-	    #[serde(alias = "num_active_channels")]
 	    pub num_active_channels: u32,
-	    #[serde(alias = "num_inactive_channels")]
 	    pub num_inactive_channels: u32,
-	    #[serde(alias = "version")]
 	    pub version: String,
-	    #[serde(alias = "lightning-dir")]
+	    #[serde(rename = "lightning-dir")]
 	    pub lightning_dir: String,
-	    #[serde(alias = "our_features", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub our_features: Option<GetinfoOur_features>,
-	    #[serde(alias = "blockheight")]
 	    pub blockheight: u32,
-	    #[serde(alias = "network")]
 	    pub network: String,
 	    #[deprecated]
-	    #[serde(alias = "msatoshi_fees_collected", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub msatoshi_fees_collected: Option<u64>,
-	    #[serde(alias = "fees_collected_msat")]
 	    pub fees_collected_msat: Amount,
-	    #[serde(alias = "address", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub address: Option<Vec<GetinfoAddress>>,
-	    #[serde(alias = "binding", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub binding: Option<Vec<GetinfoBinding>>,
-	    #[serde(alias = "warning_bitcoind_sync", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_bitcoind_sync: Option<String>,
-	    #[serde(alias = "warning_lightningd_sync", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_lightningd_sync: Option<String>,
 	}
 
@@ -1524,17 +1449,17 @@ pub mod responses {
 	    // Path `ListPeers.peers[].log[].type`
 	    #[serde(rename = "type")]
 	    pub item_type: ListpeersPeersLogType,
-	    #[serde(alias = "num_skipped", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub num_skipped: Option<u32>,
-	    #[serde(alias = "time", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub time: Option<String>,
-	    #[serde(alias = "source", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub source: Option<String>,
-	    #[serde(alias = "log", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub log: Option<String>,
-	    #[serde(alias = "node_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub node_id: Option<PublicKey>,
-	    #[serde(alias = "data", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub data: Option<String>,
 	}
 
@@ -1586,70 +1511,55 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsFeerate {
-	    #[serde(alias = "perkw")]
 	    pub perkw: u32,
-	    #[serde(alias = "perkb")]
 	    pub perkb: u32,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsInflight {
-	    #[serde(alias = "funding_txid")]
 	    pub funding_txid: String,
-	    #[serde(alias = "funding_outnum")]
 	    pub funding_outnum: u32,
-	    #[serde(alias = "feerate")]
 	    pub feerate: String,
-	    #[serde(alias = "total_funding_msat")]
 	    pub total_funding_msat: Amount,
-	    #[serde(alias = "our_funding_msat")]
 	    pub our_funding_msat: Amount,
-	    #[serde(alias = "scratch_txid")]
 	    pub scratch_txid: String,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsFunding {
 	    #[deprecated]
-	    #[serde(alias = "local_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local_msat: Option<Amount>,
 	    #[deprecated]
-	    #[serde(alias = "remote_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub remote_msat: Option<Amount>,
-	    #[serde(alias = "pushed_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pushed_msat: Option<Amount>,
-	    #[serde(alias = "local_funds_msat")]
 	    pub local_funds_msat: Amount,
-	    #[serde(alias = "remote_funds_msat")]
 	    pub remote_funds_msat: Amount,
-	    #[serde(alias = "fee_paid_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_paid_msat: Option<Amount>,
-	    #[serde(alias = "fee_rcvd_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_rcvd_msat: Option<Amount>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsAlias {
-	    #[serde(alias = "local", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local: Option<ShortChannelId>,
-	    #[serde(alias = "remote", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub remote: Option<ShortChannelId>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsState_changes {
-	    #[serde(alias = "timestamp")]
 	    pub timestamp: String,
 	    // Path `ListPeers.peers[].channels[].state_changes[].old_state`
-	    #[serde(rename = "old_state")]
 	    pub old_state: ChannelState,
 	    // Path `ListPeers.peers[].channels[].state_changes[].new_state`
-	    #[serde(rename = "new_state")]
 	    pub new_state: ChannelState,
 	    // Path `ListPeers.peers[].channels[].state_changes[].cause`
-	    #[serde(rename = "cause")]
 	    pub cause: ChannelStateChangeCause,
-	    #[serde(alias = "message")]
 	    pub message: String,
 	}
 
@@ -1675,150 +1585,139 @@ pub mod responses {
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsHtlcs {
 	    // Path `ListPeers.peers[].channels[].htlcs[].direction`
-	    #[serde(rename = "direction")]
 	    pub direction: ListpeersPeersChannelsHtlcsDirection,
-	    #[serde(alias = "id")]
 	    pub id: u64,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "expiry")]
 	    pub expiry: u32,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "local_trimmed", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local_trimmed: Option<bool>,
-	    #[serde(alias = "status", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub status: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannels {
 	    // Path `ListPeers.peers[].channels[].state`
-	    #[serde(rename = "state")]
 	    pub state: ListpeersPeersChannelsState,
-	    #[serde(alias = "scratch_txid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub scratch_txid: Option<String>,
-	    #[serde(alias = "feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub feerate: Option<ListpeersPeersChannelsFeerate>,
-	    #[serde(alias = "owner", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub owner: Option<String>,
-	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
-	    #[serde(alias = "channel_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub channel_id: Option<Sha256>,
-	    #[serde(alias = "funding_txid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub funding_txid: Option<String>,
-	    #[serde(alias = "funding_outnum", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub funding_outnum: Option<u32>,
-	    #[serde(alias = "initial_feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub initial_feerate: Option<String>,
-	    #[serde(alias = "last_feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub last_feerate: Option<String>,
-	    #[serde(alias = "next_feerate", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub next_feerate: Option<String>,
-	    #[serde(alias = "next_fee_step", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub next_fee_step: Option<u32>,
-	    #[serde(alias = "inflight", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub inflight: Option<Vec<ListpeersPeersChannelsInflight>>,
-	    #[serde(alias = "close_to", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub close_to: Option<String>,
-	    #[serde(alias = "private", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub private: Option<bool>,
 	    // Path `ListPeers.peers[].channels[].opener`
-	    #[serde(rename = "opener")]
 	    pub opener: ChannelSide,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub closer: Option<ChannelSide>,
-	    #[serde(alias = "features")]
 	    pub features: Vec<String>,
-	    #[serde(alias = "funding", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub funding: Option<ListpeersPeersChannelsFunding>,
-	    #[serde(alias = "to_us_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub to_us_msat: Option<Amount>,
-	    #[serde(alias = "min_to_us_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub min_to_us_msat: Option<Amount>,
-	    #[serde(alias = "max_to_us_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub max_to_us_msat: Option<Amount>,
-	    #[serde(alias = "total_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub total_msat: Option<Amount>,
-	    #[serde(alias = "fee_base_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_base_msat: Option<Amount>,
-	    #[serde(alias = "fee_proportional_millionths", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_proportional_millionths: Option<u32>,
-	    #[serde(alias = "dust_limit_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub dust_limit_msat: Option<Amount>,
-	    #[serde(alias = "max_total_htlc_in_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub max_total_htlc_in_msat: Option<Amount>,
-	    #[serde(alias = "their_reserve_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub their_reserve_msat: Option<Amount>,
-	    #[serde(alias = "our_reserve_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub our_reserve_msat: Option<Amount>,
-	    #[serde(alias = "spendable_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub spendable_msat: Option<Amount>,
-	    #[serde(alias = "receivable_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub receivable_msat: Option<Amount>,
-	    #[serde(alias = "minimum_htlc_in_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minimum_htlc_in_msat: Option<Amount>,
-	    #[serde(alias = "minimum_htlc_out_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub minimum_htlc_out_msat: Option<Amount>,
-	    #[serde(alias = "maximum_htlc_out_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub maximum_htlc_out_msat: Option<Amount>,
-	    #[serde(alias = "their_to_self_delay", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub their_to_self_delay: Option<u32>,
-	    #[serde(alias = "our_to_self_delay", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub our_to_self_delay: Option<u32>,
-	    #[serde(alias = "max_accepted_htlcs", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub max_accepted_htlcs: Option<u32>,
-	    #[serde(alias = "alias", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub alias: Option<ListpeersPeersChannelsAlias>,
-	    #[serde(alias = "state_changes", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub state_changes: Option<Vec<ListpeersPeersChannelsState_changes>>,
-	    #[serde(alias = "status", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub status: Option<Vec<String>>,
-	    #[serde(alias = "in_payments_offered", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_payments_offered: Option<u64>,
-	    #[serde(alias = "in_offered_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_offered_msat: Option<Amount>,
-	    #[serde(alias = "in_payments_fulfilled", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_payments_fulfilled: Option<u64>,
-	    #[serde(alias = "in_fulfilled_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_fulfilled_msat: Option<Amount>,
-	    #[serde(alias = "out_payments_offered", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_payments_offered: Option<u64>,
-	    #[serde(alias = "out_offered_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_offered_msat: Option<Amount>,
-	    #[serde(alias = "out_payments_fulfilled", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_payments_fulfilled: Option<u64>,
-	    #[serde(alias = "out_fulfilled_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_fulfilled_msat: Option<Amount>,
-	    #[serde(alias = "htlcs", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub htlcs: Option<Vec<ListpeersPeersChannelsHtlcs>>,
-	    #[serde(alias = "close_to_addr", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub close_to_addr: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeers {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "connected")]
 	    pub connected: bool,
-	    #[serde(alias = "log", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub log: Option<Vec<ListpeersPeersLog>>,
 	    #[deprecated]
-	    #[serde(alias = "channels", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub channels: Option<Vec<ListpeersPeersChannels>>,
-	    #[serde(alias = "netaddr", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub netaddr: Option<Vec<String>>,
-	    #[serde(alias = "remote_addr", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub remote_addr: Option<String>,
-	    #[serde(alias = "features", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub features: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersResponse {
-	    #[serde(alias = "peers")]
 	    pub peers: Vec<ListpeersPeers>,
 	}
 
@@ -1859,53 +1758,38 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsOutputs {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "output")]
 	    pub output: u32,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "scriptpubkey")]
 	    pub scriptpubkey: String,
-	    #[serde(alias = "address", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub address: Option<String>,
-	    #[serde(alias = "redeemscript", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub redeemscript: Option<String>,
 	    // Path `ListFunds.outputs[].status`
-	    #[serde(rename = "status")]
 	    pub status: ListfundsOutputsStatus,
-	    #[serde(alias = "reserved")]
 	    pub reserved: bool,
-	    #[serde(alias = "blockheight", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub blockheight: Option<u32>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsChannels {
-	    #[serde(alias = "peer_id")]
 	    pub peer_id: PublicKey,
-	    #[serde(alias = "our_amount_msat")]
 	    pub our_amount_msat: Amount,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "funding_txid")]
 	    pub funding_txid: String,
-	    #[serde(alias = "funding_output")]
 	    pub funding_output: u32,
-	    #[serde(alias = "connected")]
 	    pub connected: bool,
 	    // Path `ListFunds.channels[].state`
-	    #[serde(rename = "state")]
 	    pub state: ChannelState,
-	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsResponse {
-	    #[serde(alias = "outputs")]
 	    pub outputs: Vec<ListfundsOutputs>,
-	    #[serde(alias = "channels")]
 	    pub channels: Vec<ListfundsChannels>,
 	}
 
@@ -1941,36 +1825,31 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpayResponse {
-	    #[serde(alias = "id")]
 	    pub id: u64,
-	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `SendPay.status`
-	    #[serde(rename = "status")]
 	    pub status: SendpayStatus,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
-	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub completed_at: Option<u64>,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u64>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
-	    #[serde(alias = "message", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub message: Option<String>,
 	}
 
@@ -1987,41 +1866,26 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsChannels {
-	    #[serde(alias = "source")]
 	    pub source: PublicKey,
-	    #[serde(alias = "destination")]
 	    pub destination: PublicKey,
-	    #[serde(alias = "short_channel_id")]
 	    pub short_channel_id: ShortChannelId,
-	    #[serde(alias = "public")]
 	    pub public: bool,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "message_flags")]
 	    pub message_flags: u8,
-	    #[serde(alias = "channel_flags")]
 	    pub channel_flags: u8,
-	    #[serde(alias = "active")]
 	    pub active: bool,
-	    #[serde(alias = "last_update")]
 	    pub last_update: u32,
-	    #[serde(alias = "base_fee_millisatoshi")]
 	    pub base_fee_millisatoshi: u32,
-	    #[serde(alias = "fee_per_millionth")]
 	    pub fee_per_millionth: u32,
-	    #[serde(alias = "delay")]
 	    pub delay: u32,
-	    #[serde(alias = "htlc_minimum_msat")]
 	    pub htlc_minimum_msat: Amount,
-	    #[serde(alias = "htlc_maximum_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub htlc_maximum_msat: Option<Amount>,
-	    #[serde(alias = "features")]
 	    pub features: String,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListchannelsResponse {
-	    #[serde(alias = "channels")]
 	    pub channels: Vec<ListchannelsChannels>,
 	}
 
@@ -2053,11 +1917,10 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct AutocleaninvoiceResponse {
-	    #[serde(alias = "enabled")]
 	    pub enabled: bool,
-	    #[serde(alias = "expired_by", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub expired_by: Option<u64>,
-	    #[serde(alias = "cycle_seconds", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub cycle_seconds: Option<u64>,
 	}
 
@@ -2074,9 +1937,7 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CheckmessageResponse {
-	    #[serde(alias = "verified")]
 	    pub verified: bool,
-	    #[serde(alias = "pubkey")]
 	    pub pubkey: PublicKey,
 	}
 
@@ -2118,9 +1979,9 @@ pub mod responses {
 	    // Path `Close.type`
 	    #[serde(rename = "type")]
 	    pub item_type: CloseType,
-	    #[serde(alias = "tx", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub tx: Option<String>,
-	    #[serde(alias = "txid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub txid: Option<String>,
 	}
 
@@ -2187,24 +2048,20 @@ pub mod responses {
 	    // Path `Connect.address.type`
 	    #[serde(rename = "type")]
 	    pub item_type: ConnectAddressType,
-	    #[serde(alias = "socket", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub socket: Option<String>,
-	    #[serde(alias = "address", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub address: Option<String>,
-	    #[serde(alias = "port", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub port: Option<u16>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ConnectResponse {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "features")]
 	    pub features: String,
 	    // Path `Connect.direction`
-	    #[serde(rename = "direction")]
 	    pub direction: ConnectDirection,
-	    #[serde(alias = "address")]
 	    pub address: ConnectAddress,
 	}
 
@@ -2243,34 +2100,29 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateinvoiceResponse {
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
 	    // Path `CreateInvoice.status`
-	    #[serde(rename = "status")]
 	    pub status: CreateinvoiceStatus,
-	    #[serde(alias = "description")]
 	    pub description: String,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "pay_index", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pay_index: Option<u64>,
-	    #[serde(alias = "amount_received_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_received_msat: Option<Amount>,
-	    #[serde(alias = "paid_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub paid_at: Option<u64>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
-	    #[serde(alias = "local_offer_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local_offer_id: Option<String>,
-	    #[serde(alias = "invreq_payer_note", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub invreq_payer_note: Option<String>,
 	}
 
@@ -2287,13 +2139,12 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DatastoreResponse {
-	    #[serde(alias = "key")]
 	    pub key: Vec<String>,
-	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
-	    #[serde(alias = "hex", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub hex: Option<String>,
-	    #[serde(alias = "string", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub string: Option<String>,
 	}
 
@@ -2310,9 +2161,7 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateonionResponse {
-	    #[serde(alias = "onion")]
 	    pub onion: String,
-	    #[serde(alias = "shared_secrets")]
 	    pub shared_secrets: Vec<Secret>,
 	}
 
@@ -2329,13 +2178,12 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DeldatastoreResponse {
-	    #[serde(alias = "key")]
 	    pub key: Vec<String>,
-	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
-	    #[serde(alias = "hex", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub hex: Option<String>,
-	    #[serde(alias = "string", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub string: Option<String>,
 	}
 
@@ -2389,26 +2237,22 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelinvoiceResponse {
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "description", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub description: Option<String>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `DelInvoice.status`
-	    #[serde(rename = "status")]
 	    pub status: DelinvoiceStatus,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "local_offer_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local_offer_id: Option<String>,
-	    #[serde(alias = "invreq_payer_note", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub invreq_payer_note: Option<String>,
 	}
 
@@ -2425,23 +2269,19 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct InvoiceResponse {
-	    #[serde(alias = "bolt11")]
 	    pub bolt11: String,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "payment_secret")]
 	    pub payment_secret: Secret,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "warning_capacity", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_capacity: Option<String>,
-	    #[serde(alias = "warning_offline", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_offline: Option<String>,
-	    #[serde(alias = "warning_deadends", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_deadends: Option<String>,
-	    #[serde(alias = "warning_private_unused", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_private_unused: Option<String>,
-	    #[serde(alias = "warning_mpp", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_mpp: Option<String>,
 	}
 
@@ -2458,19 +2298,17 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListdatastoreDatastore {
-	    #[serde(alias = "key")]
 	    pub key: Vec<String>,
-	    #[serde(alias = "generation", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub generation: Option<u64>,
-	    #[serde(alias = "hex", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub hex: Option<String>,
-	    #[serde(alias = "string", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub string: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListdatastoreResponse {
-	    #[serde(alias = "datastore")]
 	    pub datastore: Vec<ListdatastoreDatastore>,
 	}
 
@@ -2509,40 +2347,35 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListinvoicesInvoices {
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "description", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub description: Option<String>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `ListInvoices.invoices[].status`
-	    #[serde(rename = "status")]
 	    pub status: ListinvoicesInvoicesStatus,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "local_offer_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub local_offer_id: Option<String>,
-	    #[serde(alias = "invreq_payer_note", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub invreq_payer_note: Option<String>,
-	    #[serde(alias = "pay_index", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pay_index: Option<u64>,
-	    #[serde(alias = "amount_received_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_received_msat: Option<Amount>,
-	    #[serde(alias = "paid_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub paid_at: Option<u64>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListinvoicesResponse {
-	    #[serde(alias = "invoices")]
 	    pub invoices: Vec<ListinvoicesInvoices>,
 	}
 
@@ -2578,32 +2411,27 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendonionResponse {
-	    #[serde(alias = "id")]
 	    pub id: u64,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `SendOnion.status`
-	    #[serde(rename = "status")]
 	    pub status: SendonionStatus,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u64>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
-	    #[serde(alias = "message", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub message: Option<String>,
 	}
 
@@ -2642,40 +2470,33 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListsendpaysPayments {
-	    #[serde(alias = "id")]
 	    pub id: u64,
-	    #[serde(alias = "groupid")]
 	    pub groupid: u64,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `ListSendPays.payments[].status`
-	    #[serde(rename = "status")]
 	    pub status: ListsendpaysPaymentsStatus,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "description", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub description: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
-	    #[serde(alias = "erroronion", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub erroronion: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListsendpaysResponse {
-	    #[serde(alias = "payments")]
 	    pub payments: Vec<ListsendpaysPayments>,
 	}
 
@@ -2738,15 +2559,12 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListtransactionsTransactionsInputs {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "index")]
 	    pub index: u32,
-	    #[serde(alias = "sequence")]
 	    pub sequence: u32,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub item_type: Option<ListtransactionsTransactionsInputsType>,
-	    #[serde(alias = "channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub channel: Option<ShortChannelId>,
 	}
 
@@ -2798,43 +2616,32 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListtransactionsTransactionsOutputs {
-	    #[serde(alias = "index")]
 	    pub index: u32,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "scriptPubKey")]
+	    #[serde(rename = "scriptPubKey")]
 	    pub script_pub_key: String,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub item_type: Option<ListtransactionsTransactionsOutputsType>,
-	    #[serde(alias = "channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub channel: Option<ShortChannelId>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListtransactionsTransactions {
-	    #[serde(alias = "hash")]
 	    pub hash: String,
-	    #[serde(alias = "rawtx")]
 	    pub rawtx: String,
-	    #[serde(alias = "blockheight")]
 	    pub blockheight: u32,
-	    #[serde(alias = "txindex")]
 	    pub txindex: u32,
-	    #[serde(alias = "channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub channel: Option<ShortChannelId>,
-	    #[serde(alias = "locktime")]
 	    pub locktime: u32,
-	    #[serde(alias = "version")]
 	    pub version: u32,
-	    #[serde(alias = "inputs")]
 	    pub inputs: Vec<ListtransactionsTransactionsInputs>,
-	    #[serde(alias = "outputs")]
 	    pub outputs: Vec<ListtransactionsTransactionsOutputs>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListtransactionsResponse {
-	    #[serde(alias = "transactions")]
 	    pub transactions: Vec<ListtransactionsTransactions>,
 	}
 
@@ -2873,24 +2680,17 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PayResponse {
-	    #[serde(alias = "payment_preimage")]
 	    pub payment_preimage: Secret,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "created_at")]
 	    pub created_at: f64,
-	    #[serde(alias = "parts")]
 	    pub parts: u32,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "warning_partial_completion", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_partial_completion: Option<String>,
 	    // Path `Pay.status`
-	    #[serde(rename = "status")]
 	    pub status: PayStatus,
 	}
 
@@ -2941,31 +2741,28 @@ pub mod responses {
 	    // Path `ListNodes.nodes[].addresses[].type`
 	    #[serde(rename = "type")]
 	    pub item_type: ListnodesNodesAddressesType,
-	    #[serde(alias = "port")]
 	    pub port: u16,
-	    #[serde(alias = "address", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub address: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesNodes {
-	    #[serde(alias = "nodeid")]
 	    pub nodeid: PublicKey,
-	    #[serde(alias = "last_timestamp", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub last_timestamp: Option<u32>,
-	    #[serde(alias = "alias", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub alias: Option<String>,
-	    #[serde(alias = "color", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub color: Option<String>,
-	    #[serde(alias = "features", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub features: Option<String>,
-	    #[serde(alias = "addresses", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub addresses: Option<Vec<ListnodesNodesAddresses>>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesResponse {
-	    #[serde(alias = "nodes")]
 	    pub nodes: Vec<ListnodesNodes>,
 	}
 
@@ -3001,30 +2798,25 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitanyinvoiceResponse {
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "description")]
 	    pub description: String,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `WaitAnyInvoice.status`
-	    #[serde(rename = "status")]
 	    pub status: WaitanyinvoiceStatus,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "pay_index", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pay_index: Option<u64>,
-	    #[serde(alias = "amount_received_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_received_msat: Option<Amount>,
-	    #[serde(alias = "paid_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub paid_at: Option<u64>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
 	}
 
@@ -3060,30 +2852,25 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitinvoiceResponse {
-	    #[serde(alias = "label")]
 	    pub label: String,
-	    #[serde(alias = "description")]
 	    pub description: String,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `WaitInvoice.status`
-	    #[serde(rename = "status")]
 	    pub status: WaitinvoiceStatus,
-	    #[serde(alias = "expires_at")]
 	    pub expires_at: u64,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "pay_index", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub pay_index: Option<u64>,
-	    #[serde(alias = "amount_received_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_received_msat: Option<Amount>,
-	    #[serde(alias = "paid_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub paid_at: Option<u64>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
 	}
 
@@ -3116,34 +2903,29 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitsendpayResponse {
-	    #[serde(alias = "id")]
 	    pub id: u64,
-	    #[serde(alias = "groupid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub groupid: Option<u64>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
 	    // Path `WaitSendPay.status`
-	    #[serde(rename = "status")]
 	    pub status: WaitsendpayStatus,
-	    #[serde(alias = "amount_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub amount_msat: Option<Amount>,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
-	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub completed_at: Option<f64>,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "partid", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub partid: Option<u64>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "payment_preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub payment_preimage: Option<Secret>,
 	}
 
@@ -3160,10 +2942,11 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct NewaddrResponse {
-	    #[serde(alias = "bech32", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bech32: Option<String>,
 	    #[deprecated]
-	    #[serde(alias = "p2sh-segwit", skip_serializing_if = "Option::is_none")]
+	    #[serde(rename = "p2sh-segwit")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub p2sh_segwit: Option<String>,
 	}
 
@@ -3180,11 +2963,8 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WithdrawResponse {
-	    #[serde(alias = "tx")]
 	    pub tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
 	}
 
@@ -3217,24 +2997,17 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct KeysendResponse {
-	    #[serde(alias = "payment_preimage")]
 	    pub payment_preimage: Secret,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: Sha256,
-	    #[serde(alias = "created_at")]
 	    pub created_at: f64,
-	    #[serde(alias = "parts")]
 	    pub parts: u32,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "amount_sent_msat")]
 	    pub amount_sent_msat: Amount,
-	    #[serde(alias = "warning_partial_completion", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_partial_completion: Option<String>,
 	    // Path `KeySend.status`
-	    #[serde(rename = "status")]
 	    pub status: KeysendStatus,
 	}
 
@@ -3251,31 +3024,22 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundpsbtReservations {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "vout")]
 	    pub vout: u32,
-	    #[serde(alias = "was_reserved")]
 	    pub was_reserved: bool,
-	    #[serde(alias = "reserved")]
 	    pub reserved: bool,
-	    #[serde(alias = "reserved_to_block")]
 	    pub reserved_to_block: u32,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundpsbtResponse {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "feerate_per_kw")]
 	    pub feerate_per_kw: u32,
-	    #[serde(alias = "estimated_final_weight")]
 	    pub estimated_final_weight: u32,
-	    #[serde(alias = "excess_msat")]
 	    pub excess_msat: Amount,
-	    #[serde(alias = "change_outnum", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub change_outnum: Option<u32>,
-	    #[serde(alias = "reservations", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub reservations: Option<Vec<FundpsbtReservations>>,
 	}
 
@@ -3292,9 +3056,7 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpsbtResponse {
-	    #[serde(alias = "tx")]
 	    pub tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -3311,7 +3073,6 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignpsbtResponse {
-	    #[serde(alias = "signed_psbt")]
 	    pub signed_psbt: String,
 	}
 
@@ -3328,31 +3089,22 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct UtxopsbtReservations {
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "vout")]
 	    pub vout: u32,
-	    #[serde(alias = "was_reserved")]
 	    pub was_reserved: bool,
-	    #[serde(alias = "reserved")]
 	    pub reserved: bool,
-	    #[serde(alias = "reserved_to_block")]
 	    pub reserved_to_block: u32,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct UtxopsbtResponse {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "feerate_per_kw")]
 	    pub feerate_per_kw: u32,
-	    #[serde(alias = "estimated_final_weight")]
 	    pub estimated_final_weight: u32,
-	    #[serde(alias = "excess_msat")]
 	    pub excess_msat: Amount,
-	    #[serde(alias = "change_outnum", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub change_outnum: Option<u32>,
-	    #[serde(alias = "reservations", skip_serializing_if = "crate::is_none_or_empty")]
+	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub reservations: Option<Vec<UtxopsbtReservations>>,
 	}
 
@@ -3369,9 +3121,7 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxdiscardResponse {
-	    #[serde(alias = "unsigned_tx")]
 	    pub unsigned_tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -3388,11 +3138,8 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxprepareResponse {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "unsigned_tx")]
 	    pub unsigned_tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -3409,11 +3156,8 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct TxsendResponse {
-	    #[serde(alias = "psbt")]
 	    pub psbt: String,
-	    #[serde(alias = "tx")]
 	    pub tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
 	}
 
@@ -3445,67 +3189,58 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesPerkb {
-	    #[serde(alias = "min_acceptable")]
 	    pub min_acceptable: u32,
-	    #[serde(alias = "max_acceptable")]
 	    pub max_acceptable: u32,
-	    #[serde(alias = "opening", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub opening: Option<u32>,
-	    #[serde(alias = "mutual_close", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mutual_close: Option<u32>,
-	    #[serde(alias = "unilateral_close", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub unilateral_close: Option<u32>,
-	    #[serde(alias = "delayed_to_us", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub delayed_to_us: Option<u32>,
-	    #[serde(alias = "htlc_resolution", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub htlc_resolution: Option<u32>,
-	    #[serde(alias = "penalty", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub penalty: Option<u32>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesPerkw {
-	    #[serde(alias = "min_acceptable")]
 	    pub min_acceptable: u32,
-	    #[serde(alias = "max_acceptable")]
 	    pub max_acceptable: u32,
-	    #[serde(alias = "opening", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub opening: Option<u32>,
-	    #[serde(alias = "mutual_close", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mutual_close: Option<u32>,
-	    #[serde(alias = "unilateral_close", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub unilateral_close: Option<u32>,
-	    #[serde(alias = "delayed_to_us", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub delayed_to_us: Option<u32>,
-	    #[serde(alias = "htlc_resolution", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub htlc_resolution: Option<u32>,
-	    #[serde(alias = "penalty", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub penalty: Option<u32>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesOnchain_fee_estimates {
-	    #[serde(alias = "opening_channel_satoshis")]
 	    pub opening_channel_satoshis: u64,
-	    #[serde(alias = "mutual_close_satoshis")]
 	    pub mutual_close_satoshis: u64,
-	    #[serde(alias = "unilateral_close_satoshis")]
 	    pub unilateral_close_satoshis: u64,
-	    #[serde(alias = "htlc_timeout_satoshis")]
 	    pub htlc_timeout_satoshis: u64,
-	    #[serde(alias = "htlc_success_satoshis")]
 	    pub htlc_success_satoshis: u64,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesResponse {
-	    #[serde(alias = "warning_missing_feerates", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_missing_feerates: Option<String>,
-	    #[serde(alias = "perkb", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub perkb: Option<FeeratesPerkb>,
-	    #[serde(alias = "perkw", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub perkw: Option<FeeratesPerkw>,
-	    #[serde(alias = "onchain_fee_estimates", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub onchain_fee_estimates: Option<FeeratesOnchain_fee_estimates>,
 	}
 
@@ -3522,17 +3257,13 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FundchannelResponse {
-	    #[serde(alias = "tx")]
 	    pub tx: String,
-	    #[serde(alias = "txid")]
 	    pub txid: String,
-	    #[serde(alias = "outnum")]
 	    pub outnum: u32,
-	    #[serde(alias = "channel_id")]
 	    pub channel_id: String,
-	    #[serde(alias = "close_to", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub close_to: Option<String>,
-	    #[serde(alias = "mindepth", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub mindepth: Option<u32>,
 	}
 
@@ -3565,27 +3296,20 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRoute {
-	    #[serde(alias = "id")]
 	    pub id: PublicKey,
-	    #[serde(alias = "channel")]
 	    pub channel: ShortChannelId,
-	    #[serde(alias = "direction")]
 	    pub direction: u32,
 	    #[deprecated]
-	    #[serde(alias = "msatoshi", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub msatoshi: Option<u64>,
-	    #[serde(alias = "amount_msat")]
 	    pub amount_msat: Amount,
-	    #[serde(alias = "delay")]
 	    pub delay: u32,
 	    // Path `GetRoute.route[].style`
-	    #[serde(rename = "style")]
 	    pub style: GetrouteRouteStyle,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteResponse {
-	    #[serde(alias = "route")]
 	    pub route: Vec<GetrouteRoute>,
 	}
 
@@ -3646,32 +3370,27 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListforwardsForwards {
-	    #[serde(alias = "in_channel")]
 	    pub in_channel: ShortChannelId,
-	    #[serde(alias = "in_htlc_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub in_htlc_id: Option<u64>,
-	    #[serde(alias = "in_msat")]
 	    pub in_msat: Amount,
 	    // Path `ListForwards.forwards[].status`
-	    #[serde(rename = "status")]
 	    pub status: ListforwardsForwardsStatus,
-	    #[serde(alias = "received_time")]
 	    pub received_time: f64,
-	    #[serde(alias = "out_channel", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_channel: Option<ShortChannelId>,
-	    #[serde(alias = "out_htlc_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_htlc_id: Option<u64>,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub style: Option<ListforwardsForwardsStyle>,
-	    #[serde(alias = "fee_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub fee_msat: Option<Amount>,
-	    #[serde(alias = "out_msat", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub out_msat: Option<Amount>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListforwardsResponse {
-	    #[serde(alias = "forwards")]
 	    pub forwards: Vec<ListforwardsForwards>,
 	}
 
@@ -3710,36 +3429,32 @@ pub mod responses {
 	}
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpaysPays {
-	    #[serde(alias = "payment_hash")]
 	    pub payment_hash: String,
 	    // Path `ListPays.pays[].status`
-	    #[serde(rename = "status")]
 	    pub status: ListpaysPaysStatus,
-	    #[serde(alias = "destination", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub destination: Option<PublicKey>,
-	    #[serde(alias = "created_at")]
 	    pub created_at: u64,
-	    #[serde(alias = "completed_at", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub completed_at: Option<u64>,
-	    #[serde(alias = "label", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub label: Option<String>,
-	    #[serde(alias = "bolt11", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt11: Option<String>,
-	    #[serde(alias = "description", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub description: Option<String>,
-	    #[serde(alias = "bolt12", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub bolt12: Option<String>,
-	    #[serde(alias = "preimage", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub preimage: Option<String>,
-	    #[serde(alias = "number_of_parts", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub number_of_parts: Option<u64>,
-	    #[serde(alias = "erroronion", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub erroronion: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpaysResponse {
-	    #[serde(alias = "pays")]
 	    pub pays: Vec<ListpaysPays>,
 	}
 
@@ -3756,7 +3471,6 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PingResponse {
-	    #[serde(alias = "totlen")]
 	    pub totlen: u16,
 	}
 
@@ -3773,29 +3487,22 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SetchannelChannels {
-	    #[serde(alias = "peer_id")]
 	    pub peer_id: PublicKey,
-	    #[serde(alias = "channel_id")]
 	    pub channel_id: String,
-	    #[serde(alias = "short_channel_id", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
-	    #[serde(alias = "fee_base_msat")]
 	    pub fee_base_msat: Amount,
-	    #[serde(alias = "fee_proportional_millionths")]
 	    pub fee_proportional_millionths: u32,
-	    #[serde(alias = "minimum_htlc_out_msat")]
 	    pub minimum_htlc_out_msat: Amount,
-	    #[serde(alias = "warning_htlcmin_too_low", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_htlcmin_too_low: Option<String>,
-	    #[serde(alias = "maximum_htlc_out_msat")]
 	    pub maximum_htlc_out_msat: Amount,
-	    #[serde(alias = "warning_htlcmax_too_high", skip_serializing_if = "Option::is_none")]
+	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub warning_htlcmax_too_high: Option<String>,
 	}
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SetchannelResponse {
-	    #[serde(alias = "channels")]
 	    pub channels: Vec<SetchannelChannels>,
 	}
 
@@ -3812,11 +3519,8 @@ pub mod responses {
 
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SignmessageResponse {
-	    #[serde(alias = "signature")]
 	    pub signature: String,
-	    #[serde(alias = "recid")]
 	    pub recid: String,
-	    #[serde(alias = "zbase")]
 	    pub zbase: String,
 	}
 


### PR DESCRIPTION
rename is necessary to roundtrip, otherwise the rust name is used.

This also remove the rename if they are not necessary.

Note that:
```
 #[serde(rename="foo", skip_serializing_if=="bar")]
 pub field: bool,
```

is equivalent to:
```
 #[serde(rename="foo")]
 #[serde(skip_serializing_if=="bar")]
 pub field: bool,
```

and for simplicity of construction the latter is used