### PR TITLE
ci: fix schema checks

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -206,14 +206,19 @@ doc/index.rst: $(MANPAGES:=.md)
 	)
 
 # For CI to (very roughly!) check that we only deprecated fields, or labelled added ones
-
-# So GitHub renamed master to main.  This is painful.
+# When running on GitHub (CI=true), we need to fetch origin/master
 schema-added-check:
-	@if ! git describe master >/dev/null 2>&1; then MASTER=main; else MASTER=master; fi; if git diff $$MASTER doc/schemas | grep -q '^+.*{' && ! git diff master doc/schemas | grep -q '^+.*"added"'; then echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; fi
-
-# So GitHub renamed master to main.  This is painful.
+	@if ! test -z $$CI; then git fetch origin master; fi; \
+	if git diff origin/master -- doc/schemas | grep -q '^+.*{' && ! git diff origin/master -- doc/schemas | grep -q '^+.*"added"'; then \
+		git diff origin/master -- doc/schemas; \
+		echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; \
+	fi
 schema-removed-check:
-	@if ! git describe master >/dev/null 2>&1; then MASTER=main; else MASTER=master; fi; if git diff $$MASTER doc/schemas | grep -q '^-.*{' && ! git diff master doc/schemas | grep -q '^-.*"deprecated": "'; then echo 'Schema fields must be deprecated, with version, not removed' >&2; exit 1; fi
+	@if ! test -z $$CI; then git fetch origin master; fi; \
+	if git diff origin/master -- doc/schemas | grep -q '^-.*{' && ! git diff origin/master -- doc/schemas | grep -q '^-.*"deprecated"'; then \
+		git diff origin/master -- doc/schemas ; \
+		echo 'Schema fields must be "deprecated", with version, not removed' >&2; exit 1; \
+	fi
 
 schema-diff-check: schema-added-check schema-removed-check
 


### PR DESCRIPTION
This fixes the CI errors when doing `make check-source` steps 'schema-added-check' and 'schema-removed-check'. These errors prevented CI from performing these steps correctly:

```
fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

I changed it so that CI does a `git fetch origin` at first and do the `git diff` against 'origin/master' (which then exist). Also fixed a bug in the script that was missing $$master in the same line.

Also I added that the script shows the actual diff before failing, so the user quickly sees whats wrong.

**Note 1:** Without this fix, CI is not doing this schema checks correctly, but silently ignore it, as it continues after the warnings/errors.

**Note 2:** I tested this fix on CI and locally, it now performs correctly and aborts, telling the user that there are missing 'added'/'deprecated' annotations.
