### PR TITLE
Add check for empty key array on datastore commands.

### DIFF
--- a/lightningd/datastore.c
+++ b/lightningd/datastore.c
@@ -66,7 +66,11 @@ static struct command_result *param_list_or_string(struct command *cmd,
 						   const jsmntok_t *tok,
 						   const char ***str)
 {
-	if (tok->type == JSMN_ARRAY) {
+	if (tok->type == JSMN_ARRAY && tok->size <= 0) {
+		return command_fail_badparam(cmd, name,
+								buffer, tok,
+								"should not be empty");
+	} else if (tok->type == JSMN_ARRAY) {
 		size_t i;
 		const jsmntok_t *t;
 		*str = tal_arr(cmd, const char *, tok->size);

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2796,12 +2796,21 @@ def test_datastore(node_factory):
     assert l1.rpc.listdatastore() == {'datastore': []}
     assert l1.rpc.listdatastore('somekey') == {'datastore': []}
 
+    # Fail on empty array
+    with pytest.raises(RpcError, match='should not be empty'):
+        l1.rpc.listdatastore([])
+
     # Add entries.
     somedata = b'somedata'.hex()
     somedata_expect = {'key': ['somekey'],
                        'generation': 0,
                        'hex': somedata,
                        'string': 'somedata'}
+
+    # We should fail trying to insert into an empty array
+    with pytest.raises(RpcError, match='should not be empty'):
+        l1.rpc.datastore(key=[], hex=somedata)
+
     assert l1.rpc.datastore(key='somekey', hex=somedata) == somedata_expect
 
     assert l1.rpc.listdatastore() == {'datastore': [somedata_expect]}


### PR DESCRIPTION
We need to check if the key parameter is an empty array in `datastore` commands as we expect a `key` to be at least of len 1 in _wallet.c_.

Changelog-None