### PR TITLE
docker: Install protobuf-compiler for builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update -qq && \
         libpq-dev \
         libtool \
         libffi-dev \
+        protobuf-compiler \
         python3 \
         python3-dev \
         python3-mako \


### PR DESCRIPTION
I needed to install `protobuf-compiler` to the builder for it to work.

Otherwise I would receive this error message:
```
cargo build --profile=release --quiet --example cln-plugin-startup
error: failed to run custom build command for `cln-grpc v0.1.2 (/opt/lightningd/cln-grpc)`

Caused by:
  process didn't exit successfully: `/opt/lightningd/target/release/build/cln-grpc-eaabe37d9f29a125/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=proto/node.proto
  cargo:rerun-if-changed=proto

  --- stderr
  thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.5/src/lib.rs:1295:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [cln-rpc/Makefile:17: target/release/examples/cln-plugin-startup] Error 101
```

Changelog-None