### PR TITLE
rs: derive PartialEq for simple rust enums

### DIFF
--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -12,7 +12,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use cln_rpc::primitives::PublicKey;
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetinfoOur_features> for pb::GetinfoOurFeatures {
     fn from(c: responses::GetinfoOur_features) -> Self {
         Self {
@@ -24,7 +24,7 @@ impl From<responses::GetinfoOur_features> for pb::GetinfoOurFeatures {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
     fn from(c: responses::GetinfoAddress) -> Self {
         Self {
@@ -35,7 +35,7 @@ impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetinfoBinding> for pb::GetinfoBinding {
     fn from(c: responses::GetinfoBinding) -> Self {
         Self {
@@ -47,7 +47,7 @@ impl From<responses::GetinfoBinding> for pb::GetinfoBinding {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
     fn from(c: responses::GetinfoResponse) -> Self {
         Self {
@@ -74,7 +74,7 @@ impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersLog> for pb::ListpeersPeersLog {
     fn from(c: responses::ListpeersPeersLog) -> Self {
         Self {
@@ -89,7 +89,7 @@ impl From<responses::ListpeersPeersLog> for pb::ListpeersPeersLog {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannelsFeerate> for pb::ListpeersPeersChannelsFeerate {
     fn from(c: responses::ListpeersPeersChannelsFeerate) -> Self {
         Self {
@@ -99,7 +99,7 @@ impl From<responses::ListpeersPeersChannelsFeerate> for pb::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannelsInflight> for pb::ListpeersPeersChannelsInflight {
     fn from(c: responses::ListpeersPeersChannelsInflight) -> Self {
         Self {
@@ -113,7 +113,7 @@ impl From<responses::ListpeersPeersChannelsInflight> for pb::ListpeersPeersChann
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannelsFunding> for pb::ListpeersPeersChannelsFunding {
     fn from(c: responses::ListpeersPeersChannelsFunding) -> Self {
         Self {
@@ -126,7 +126,7 @@ impl From<responses::ListpeersPeersChannelsFunding> for pb::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannelsAlias> for pb::ListpeersPeersChannelsAlias {
     fn from(c: responses::ListpeersPeersChannelsAlias) -> Self {
         Self {
@@ -136,7 +136,7 @@ impl From<responses::ListpeersPeersChannelsAlias> for pb::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannelsHtlcs> for pb::ListpeersPeersChannelsHtlcs {
     fn from(c: responses::ListpeersPeersChannelsHtlcs) -> Self {
         Self {
@@ -152,7 +152,7 @@ impl From<responses::ListpeersPeersChannelsHtlcs> for pb::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
     fn from(c: responses::ListpeersPeersChannels) -> Self {
         Self {
@@ -232,7 +232,7 @@ impl From<responses::ListpeersPeers> for pb::ListpeersPeers {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeersResponse> for pb::ListpeersResponse {
     fn from(c: responses::ListpeersResponse) -> Self {
         Self {
@@ -242,7 +242,7 @@ impl From<responses::ListpeersResponse> for pb::ListpeersResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListfundsOutputs> for pb::ListfundsOutputs {
     fn from(c: responses::ListfundsOutputs) -> Self {
         Self {
@@ -259,7 +259,7 @@ impl From<responses::ListfundsOutputs> for pb::ListfundsOutputs {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
     fn from(c: responses::ListfundsChannels) -> Self {
         Self {
@@ -276,7 +276,7 @@ impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListfundsResponse> for pb::ListfundsResponse {
     fn from(c: responses::ListfundsResponse) -> Self {
         Self {
@@ -288,7 +288,7 @@ impl From<responses::ListfundsResponse> for pb::ListfundsResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SendpayResponse> for pb::SendpayResponse {
     fn from(c: responses::SendpayResponse) -> Self {
         Self {
@@ -311,7 +311,7 @@ impl From<responses::SendpayResponse> for pb::SendpayResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListchannelsChannels> for pb::ListchannelsChannels {
     fn from(c: responses::ListchannelsChannels) -> Self {
         Self {
@@ -335,7 +335,7 @@ impl From<responses::ListchannelsChannels> for pb::ListchannelsChannels {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListchannelsResponse> for pb::ListchannelsResponse {
     fn from(c: responses::ListchannelsResponse) -> Self {
         Self {
@@ -345,7 +345,7 @@ impl From<responses::ListchannelsResponse> for pb::ListchannelsResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::AddgossipResponse> for pb::AddgossipResponse {
     fn from(c: responses::AddgossipResponse) -> Self {
         Self {
@@ -353,7 +353,7 @@ impl From<responses::AddgossipResponse> for pb::AddgossipResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::AutocleaninvoiceResponse> for pb::AutocleaninvoiceResponse {
     fn from(c: responses::AutocleaninvoiceResponse) -> Self {
         Self {
@@ -364,7 +364,7 @@ impl From<responses::AutocleaninvoiceResponse> for pb::AutocleaninvoiceResponse 
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::CheckmessageResponse> for pb::CheckmessageResponse {
     fn from(c: responses::CheckmessageResponse) -> Self {
         Self {
@@ -374,7 +374,7 @@ impl From<responses::CheckmessageResponse> for pb::CheckmessageResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::CloseResponse> for pb::CloseResponse {
     fn from(c: responses::CloseResponse) -> Self {
         Self {
@@ -385,7 +385,7 @@ impl From<responses::CloseResponse> for pb::CloseResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ConnectAddress> for pb::ConnectAddress {
     fn from(c: responses::ConnectAddress) -> Self {
         Self {
@@ -397,7 +397,7 @@ impl From<responses::ConnectAddress> for pb::ConnectAddress {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ConnectResponse> for pb::ConnectResponse {
     fn from(c: responses::ConnectResponse) -> Self {
         Self {
@@ -409,7 +409,7 @@ impl From<responses::ConnectResponse> for pb::ConnectResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::CreateinvoiceResponse> for pb::CreateinvoiceResponse {
     fn from(c: responses::CreateinvoiceResponse) -> Self {
         Self {
@@ -431,7 +431,7 @@ impl From<responses::CreateinvoiceResponse> for pb::CreateinvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DatastoreResponse> for pb::DatastoreResponse {
     fn from(c: responses::DatastoreResponse) -> Self {
         Self {
@@ -444,7 +444,7 @@ impl From<responses::DatastoreResponse> for pb::DatastoreResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::CreateonionResponse> for pb::CreateonionResponse {
     fn from(c: responses::CreateonionResponse) -> Self {
         Self {
@@ -455,7 +455,7 @@ impl From<responses::CreateonionResponse> for pb::CreateonionResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DeldatastoreResponse> for pb::DeldatastoreResponse {
     fn from(c: responses::DeldatastoreResponse) -> Self {
         Self {
@@ -468,7 +468,7 @@ impl From<responses::DeldatastoreResponse> for pb::DeldatastoreResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DelexpiredinvoiceResponse> for pb::DelexpiredinvoiceResponse {
     fn from(c: responses::DelexpiredinvoiceResponse) -> Self {
         Self {
@@ -476,7 +476,7 @@ impl From<responses::DelexpiredinvoiceResponse> for pb::DelexpiredinvoiceRespons
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DelinvoiceResponse> for pb::DelinvoiceResponse {
     fn from(c: responses::DelinvoiceResponse) -> Self {
         Self {
@@ -494,7 +494,7 @@ impl From<responses::DelinvoiceResponse> for pb::DelinvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::InvoiceResponse> for pb::InvoiceResponse {
     fn from(c: responses::InvoiceResponse) -> Self {
         Self {
@@ -511,7 +511,7 @@ impl From<responses::InvoiceResponse> for pb::InvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListdatastoreDatastore> for pb::ListdatastoreDatastore {
     fn from(c: responses::ListdatastoreDatastore) -> Self {
         Self {
@@ -524,7 +524,7 @@ impl From<responses::ListdatastoreDatastore> for pb::ListdatastoreDatastore {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListdatastoreResponse> for pb::ListdatastoreResponse {
     fn from(c: responses::ListdatastoreResponse) -> Self {
         Self {
@@ -534,7 +534,7 @@ impl From<responses::ListdatastoreResponse> for pb::ListdatastoreResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListinvoicesInvoices> for pb::ListinvoicesInvoices {
     fn from(c: responses::ListinvoicesInvoices) -> Self {
         Self {
@@ -556,7 +556,7 @@ impl From<responses::ListinvoicesInvoices> for pb::ListinvoicesInvoices {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListinvoicesResponse> for pb::ListinvoicesResponse {
     fn from(c: responses::ListinvoicesResponse) -> Self {
         Self {
@@ -566,7 +566,7 @@ impl From<responses::ListinvoicesResponse> for pb::ListinvoicesResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SendonionResponse> for pb::SendonionResponse {
     fn from(c: responses::SendonionResponse) -> Self {
         Self {
@@ -587,7 +587,7 @@ impl From<responses::SendonionResponse> for pb::SendonionResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListsendpaysPayments> for pb::ListsendpaysPayments {
     fn from(c: responses::ListsendpaysPayments) -> Self {
         Self {
@@ -610,7 +610,7 @@ impl From<responses::ListsendpaysPayments> for pb::ListsendpaysPayments {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListsendpaysResponse> for pb::ListsendpaysResponse {
     fn from(c: responses::ListsendpaysResponse) -> Self {
         Self {
@@ -620,7 +620,7 @@ impl From<responses::ListsendpaysResponse> for pb::ListsendpaysResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListtransactionsTransactionsInputs> for pb::ListtransactionsTransactionsInputs {
     fn from(c: responses::ListtransactionsTransactionsInputs) -> Self {
         Self {
@@ -631,7 +631,7 @@ impl From<responses::ListtransactionsTransactionsInputs> for pb::Listtransaction
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListtransactionsTransactionsOutputs> for pb::ListtransactionsTransactionsOutputs {
     fn from(c: responses::ListtransactionsTransactionsOutputs) -> Self {
         Self {
@@ -642,7 +642,7 @@ impl From<responses::ListtransactionsTransactionsOutputs> for pb::Listtransactio
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListtransactionsTransactions> for pb::ListtransactionsTransactions {
     fn from(c: responses::ListtransactionsTransactions) -> Self {
         Self {
@@ -660,7 +660,7 @@ impl From<responses::ListtransactionsTransactions> for pb::ListtransactionsTrans
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListtransactionsResponse> for pb::ListtransactionsResponse {
     fn from(c: responses::ListtransactionsResponse) -> Self {
         Self {
@@ -670,7 +670,7 @@ impl From<responses::ListtransactionsResponse> for pb::ListtransactionsResponse 
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::PayResponse> for pb::PayResponse {
     fn from(c: responses::PayResponse) -> Self {
         Self {
@@ -687,7 +687,7 @@ impl From<responses::PayResponse> for pb::PayResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListnodesNodesAddresses> for pb::ListnodesNodesAddresses {
     fn from(c: responses::ListnodesNodesAddresses) -> Self {
         Self {
@@ -698,7 +698,7 @@ impl From<responses::ListnodesNodesAddresses> for pb::ListnodesNodesAddresses {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListnodesNodes> for pb::ListnodesNodes {
     fn from(c: responses::ListnodesNodes) -> Self {
         Self {
@@ -713,7 +713,7 @@ impl From<responses::ListnodesNodes> for pb::ListnodesNodes {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListnodesResponse> for pb::ListnodesResponse {
     fn from(c: responses::ListnodesResponse) -> Self {
         Self {
@@ -723,7 +723,7 @@ impl From<responses::ListnodesResponse> for pb::ListnodesResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::WaitanyinvoiceResponse> for pb::WaitanyinvoiceResponse {
     fn from(c: responses::WaitanyinvoiceResponse) -> Self {
         Self {
@@ -743,7 +743,7 @@ impl From<responses::WaitanyinvoiceResponse> for pb::WaitanyinvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::WaitinvoiceResponse> for pb::WaitinvoiceResponse {
     fn from(c: responses::WaitinvoiceResponse) -> Self {
         Self {
@@ -763,7 +763,7 @@ impl From<responses::WaitinvoiceResponse> for pb::WaitinvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::WaitsendpayResponse> for pb::WaitsendpayResponse {
     fn from(c: responses::WaitsendpayResponse) -> Self {
         Self {
@@ -796,7 +796,7 @@ impl From<responses::NewaddrResponse> for pb::NewaddrResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::WithdrawResponse> for pb::WithdrawResponse {
     fn from(c: responses::WithdrawResponse) -> Self {
         Self {
@@ -807,7 +807,7 @@ impl From<responses::WithdrawResponse> for pb::WithdrawResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::KeysendResponse> for pb::KeysendResponse {
     fn from(c: responses::KeysendResponse) -> Self {
         Self {
@@ -824,7 +824,7 @@ impl From<responses::KeysendResponse> for pb::KeysendResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FundpsbtReservations> for pb::FundpsbtReservations {
     fn from(c: responses::FundpsbtReservations) -> Self {
         Self {
@@ -837,7 +837,7 @@ impl From<responses::FundpsbtReservations> for pb::FundpsbtReservations {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FundpsbtResponse> for pb::FundpsbtResponse {
     fn from(c: responses::FundpsbtResponse) -> Self {
         Self {
@@ -852,7 +852,7 @@ impl From<responses::FundpsbtResponse> for pb::FundpsbtResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SendpsbtResponse> for pb::SendpsbtResponse {
     fn from(c: responses::SendpsbtResponse) -> Self {
         Self {
@@ -862,7 +862,7 @@ impl From<responses::SendpsbtResponse> for pb::SendpsbtResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SignpsbtResponse> for pb::SignpsbtResponse {
     fn from(c: responses::SignpsbtResponse) -> Self {
         Self {
@@ -871,7 +871,7 @@ impl From<responses::SignpsbtResponse> for pb::SignpsbtResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::UtxopsbtReservations> for pb::UtxopsbtReservations {
     fn from(c: responses::UtxopsbtReservations) -> Self {
         Self {
@@ -884,7 +884,7 @@ impl From<responses::UtxopsbtReservations> for pb::UtxopsbtReservations {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::UtxopsbtResponse> for pb::UtxopsbtResponse {
     fn from(c: responses::UtxopsbtResponse) -> Self {
         Self {
@@ -899,7 +899,7 @@ impl From<responses::UtxopsbtResponse> for pb::UtxopsbtResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::TxdiscardResponse> for pb::TxdiscardResponse {
     fn from(c: responses::TxdiscardResponse) -> Self {
         Self {
@@ -909,7 +909,7 @@ impl From<responses::TxdiscardResponse> for pb::TxdiscardResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::TxprepareResponse> for pb::TxprepareResponse {
     fn from(c: responses::TxprepareResponse) -> Self {
         Self {
@@ -920,7 +920,7 @@ impl From<responses::TxprepareResponse> for pb::TxprepareResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::TxsendResponse> for pb::TxsendResponse {
     fn from(c: responses::TxsendResponse) -> Self {
         Self {
@@ -931,7 +931,7 @@ impl From<responses::TxsendResponse> for pb::TxsendResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannelsFeerate> for pb::ListpeerchannelsChannelsFeerate {
     fn from(c: responses::ListpeerchannelsChannelsFeerate) -> Self {
         Self {
@@ -941,7 +941,7 @@ impl From<responses::ListpeerchannelsChannelsFeerate> for pb::ListpeerchannelsCh
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannelsInflight> for pb::ListpeerchannelsChannelsInflight {
     fn from(c: responses::ListpeerchannelsChannelsInflight) -> Self {
         Self {
@@ -955,7 +955,7 @@ impl From<responses::ListpeerchannelsChannelsInflight> for pb::ListpeerchannelsC
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannelsFunding> for pb::ListpeerchannelsChannelsFunding {
     fn from(c: responses::ListpeerchannelsChannelsFunding) -> Self {
         Self {
@@ -968,7 +968,7 @@ impl From<responses::ListpeerchannelsChannelsFunding> for pb::ListpeerchannelsCh
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannelsAlias> for pb::ListpeerchannelsChannelsAlias {
     fn from(c: responses::ListpeerchannelsChannelsAlias) -> Self {
         Self {
@@ -978,7 +978,7 @@ impl From<responses::ListpeerchannelsChannelsAlias> for pb::ListpeerchannelsChan
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannelsHtlcs> for pb::ListpeerchannelsChannelsHtlcs {
     fn from(c: responses::ListpeerchannelsChannelsHtlcs) -> Self {
         Self {
@@ -994,7 +994,7 @@ impl From<responses::ListpeerchannelsChannelsHtlcs> for pb::ListpeerchannelsChan
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsChannels> for pb::ListpeerchannelsChannels {
     fn from(c: responses::ListpeerchannelsChannels) -> Self {
         Self {
@@ -1055,7 +1055,7 @@ impl From<responses::ListpeerchannelsChannels> for pb::ListpeerchannelsChannels 
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpeerchannelsResponse> for pb::ListpeerchannelsResponse {
     fn from(c: responses::ListpeerchannelsResponse) -> Self {
         Self {
@@ -1065,7 +1065,7 @@ impl From<responses::ListpeerchannelsResponse> for pb::ListpeerchannelsResponse 
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListclosedchannelsClosedchannelsAlias> for pb::ListclosedchannelsClosedchannelsAlias {
     fn from(c: responses::ListclosedchannelsClosedchannelsAlias) -> Self {
         Self {
@@ -1075,7 +1075,7 @@ impl From<responses::ListclosedchannelsClosedchannelsAlias> for pb::Listclosedch
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListclosedchannelsClosedchannels> for pb::ListclosedchannelsClosedchannels {
     fn from(c: responses::ListclosedchannelsClosedchannels) -> Self {
         Self {
@@ -1106,7 +1106,7 @@ impl From<responses::ListclosedchannelsClosedchannels> for pb::Listclosedchannel
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListclosedchannelsResponse> for pb::ListclosedchannelsResponse {
     fn from(c: responses::ListclosedchannelsResponse) -> Self {
         Self {
@@ -1116,7 +1116,7 @@ impl From<responses::ListclosedchannelsResponse> for pb::ListclosedchannelsRespo
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodepayFallbacks> for pb::DecodepayFallbacks {
     fn from(c: responses::DecodepayFallbacks) -> Self {
         Self {
@@ -1127,7 +1127,7 @@ impl From<responses::DecodepayFallbacks> for pb::DecodepayFallbacks {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodepayExtra> for pb::DecodepayExtra {
     fn from(c: responses::DecodepayExtra) -> Self {
         Self {
@@ -1137,7 +1137,7 @@ impl From<responses::DecodepayExtra> for pb::DecodepayExtra {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodepayResponse> for pb::DecodepayResponse {
     fn from(c: responses::DecodepayResponse) -> Self {
         Self {
@@ -1162,7 +1162,7 @@ impl From<responses::DecodepayResponse> for pb::DecodepayResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeOffer_paths> for pb::DecodeOfferPaths {
     fn from(c: responses::DecodeOffer_paths) -> Self {
         Self {
@@ -1172,7 +1172,7 @@ impl From<responses::DecodeOffer_paths> for pb::DecodeOfferPaths {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeInvoice_fallbacks> for pb::DecodeInvoiceFallbacks {
     fn from(c: responses::DecodeInvoice_fallbacks) -> Self {
         Self {
@@ -1183,7 +1183,7 @@ impl From<responses::DecodeInvoice_fallbacks> for pb::DecodeInvoiceFallbacks {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeFallbacks> for pb::DecodeFallbacks {
     fn from(c: responses::DecodeFallbacks) -> Self {
         Self {
@@ -1192,7 +1192,7 @@ impl From<responses::DecodeFallbacks> for pb::DecodeFallbacks {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeExtra> for pb::DecodeExtra {
     fn from(c: responses::DecodeExtra) -> Self {
         Self {
@@ -1202,7 +1202,7 @@ impl From<responses::DecodeExtra> for pb::DecodeExtra {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeRestrictions> for pb::DecodeRestrictions {
     fn from(c: responses::DecodeRestrictions) -> Self {
         Self {
@@ -1213,7 +1213,7 @@ impl From<responses::DecodeRestrictions> for pb::DecodeRestrictions {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DecodeResponse> for pb::DecodeResponse {
     fn from(c: responses::DecodeResponse) -> Self {
         Self {
@@ -1296,7 +1296,7 @@ impl From<responses::DecodeResponse> for pb::DecodeResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::DisconnectResponse> for pb::DisconnectResponse {
     fn from(c: responses::DisconnectResponse) -> Self {
         Self {
@@ -1304,7 +1304,7 @@ impl From<responses::DisconnectResponse> for pb::DisconnectResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FeeratesPerkbEstimates> for pb::FeeratesPerkbEstimates {
     fn from(c: responses::FeeratesPerkbEstimates) -> Self {
         Self {
@@ -1337,7 +1337,7 @@ impl From<responses::FeeratesPerkb> for pb::FeeratesPerkb {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FeeratesPerkwEstimates> for pb::FeeratesPerkwEstimates {
     fn from(c: responses::FeeratesPerkwEstimates) -> Self {
         Self {
@@ -1370,7 +1370,7 @@ impl From<responses::FeeratesPerkw> for pb::FeeratesPerkw {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FeeratesOnchain_fee_estimates> for pb::FeeratesOnchainFeeEstimates {
     fn from(c: responses::FeeratesOnchain_fee_estimates) -> Self {
         Self {
@@ -1384,7 +1384,7 @@ impl From<responses::FeeratesOnchain_fee_estimates> for pb::FeeratesOnchainFeeEs
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FeeratesResponse> for pb::FeeratesResponse {
     fn from(c: responses::FeeratesResponse) -> Self {
         Self {
@@ -1396,7 +1396,7 @@ impl From<responses::FeeratesResponse> for pb::FeeratesResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::FundchannelResponse> for pb::FundchannelResponse {
     fn from(c: responses::FundchannelResponse) -> Self {
         Self {
@@ -1410,7 +1410,7 @@ impl From<responses::FundchannelResponse> for pb::FundchannelResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetrouteRoute> for pb::GetrouteRoute {
     fn from(c: responses::GetrouteRoute) -> Self {
         Self {
@@ -1424,7 +1424,7 @@ impl From<responses::GetrouteRoute> for pb::GetrouteRoute {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::GetrouteResponse> for pb::GetrouteResponse {
     fn from(c: responses::GetrouteResponse) -> Self {
         Self {
@@ -1434,7 +1434,7 @@ impl From<responses::GetrouteResponse> for pb::GetrouteResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListforwardsForwards> for pb::ListforwardsForwards {
     fn from(c: responses::ListforwardsForwards) -> Self {
         Self {
@@ -1452,7 +1452,7 @@ impl From<responses::ListforwardsForwards> for pb::ListforwardsForwards {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListforwardsResponse> for pb::ListforwardsResponse {
     fn from(c: responses::ListforwardsResponse) -> Self {
         Self {
@@ -1462,7 +1462,7 @@ impl From<responses::ListforwardsResponse> for pb::ListforwardsResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpaysPays> for pb::ListpaysPays {
     fn from(c: responses::ListpaysPays) -> Self {
         Self {
@@ -1482,7 +1482,7 @@ impl From<responses::ListpaysPays> for pb::ListpaysPays {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::ListpaysResponse> for pb::ListpaysResponse {
     fn from(c: responses::ListpaysResponse) -> Self {
         Self {
@@ -1492,7 +1492,7 @@ impl From<responses::ListpaysResponse> for pb::ListpaysResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::PingResponse> for pb::PingResponse {
     fn from(c: responses::PingResponse) -> Self {
         Self {
@@ -1501,7 +1501,7 @@ impl From<responses::PingResponse> for pb::PingResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SendcustommsgResponse> for pb::SendcustommsgResponse {
     fn from(c: responses::SendcustommsgResponse) -> Self {
         Self {
@@ -1510,7 +1510,7 @@ impl From<responses::SendcustommsgResponse> for pb::SendcustommsgResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SetchannelChannels> for pb::SetchannelChannels {
     fn from(c: responses::SetchannelChannels) -> Self {
         Self {
@@ -1527,7 +1527,7 @@ impl From<responses::SetchannelChannels> for pb::SetchannelChannels {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SetchannelResponse> for pb::SetchannelResponse {
     fn from(c: responses::SetchannelResponse) -> Self {
         Self {
@@ -1537,7 +1537,7 @@ impl From<responses::SetchannelResponse> for pb::SetchannelResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SigninvoiceResponse> for pb::SigninvoiceResponse {
     fn from(c: responses::SigninvoiceResponse) -> Self {
         Self {
@@ -1546,7 +1546,7 @@ impl From<responses::SigninvoiceResponse> for pb::SigninvoiceResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::SignmessageResponse> for pb::SignmessageResponse {
     fn from(c: responses::SignmessageResponse) -> Self {
         Self {
@@ -1557,7 +1557,7 @@ impl From<responses::SignmessageResponse> for pb::SignmessageResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::StopResponse> for pb::StopResponse {
     fn from(c: responses::StopResponse) -> Self {
         Self {
@@ -1565,7 +1565,7 @@ impl From<responses::StopResponse> for pb::StopResponse {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::PreapprovekeysendResponse> for pb::PreapprovekeysendResponse {
     fn from(c: responses::PreapprovekeysendResponse) -> Self {
         Self {
@@ -1573,7 +1573,7 @@ impl From<responses::PreapprovekeysendResponse> for pb::PreapprovekeysendRespons
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<responses::PreapproveinvoiceResponse> for pb::PreapproveinvoiceResponse {
     fn from(c: responses::PreapproveinvoiceResponse) -> Self {
         Self {
@@ -1581,7 +1581,7 @@ impl From<responses::PreapproveinvoiceResponse> for pb::PreapproveinvoiceRespons
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::GetinfoRequest> for pb::GetinfoRequest {
     fn from(c: requests::GetinfoRequest) -> Self {
         Self {
@@ -1589,7 +1589,7 @@ impl From<requests::GetinfoRequest> for pb::GetinfoRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListpeersRequest> for pb::ListpeersRequest {
     fn from(c: requests::ListpeersRequest) -> Self {
         Self {
@@ -1599,7 +1599,7 @@ impl From<requests::ListpeersRequest> for pb::ListpeersRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListfundsRequest> for pb::ListfundsRequest {
     fn from(c: requests::ListfundsRequest) -> Self {
         Self {
@@ -1608,7 +1608,7 @@ impl From<requests::ListfundsRequest> for pb::ListfundsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendpayRoute> for pb::SendpayRoute {
     fn from(c: requests::SendpayRoute) -> Self {
         Self {
@@ -1620,7 +1620,7 @@ impl From<requests::SendpayRoute> for pb::SendpayRoute {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendpayRequest> for pb::SendpayRequest {
     fn from(c: requests::SendpayRequest) -> Self {
         Self {
@@ -1638,7 +1638,7 @@ impl From<requests::SendpayRequest> for pb::SendpayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListchannelsRequest> for pb::ListchannelsRequest {
     fn from(c: requests::ListchannelsRequest) -> Self {
         Self {
@@ -1649,7 +1649,7 @@ impl From<requests::ListchannelsRequest> for pb::ListchannelsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::AddgossipRequest> for pb::AddgossipRequest {
     fn from(c: requests::AddgossipRequest) -> Self {
         Self {
@@ -1658,7 +1658,7 @@ impl From<requests::AddgossipRequest> for pb::AddgossipRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::AutocleaninvoiceRequest> for pb::AutocleaninvoiceRequest {
     fn from(c: requests::AutocleaninvoiceRequest) -> Self {
         Self {
@@ -1668,7 +1668,7 @@ impl From<requests::AutocleaninvoiceRequest> for pb::AutocleaninvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::CheckmessageRequest> for pb::CheckmessageRequest {
     fn from(c: requests::CheckmessageRequest) -> Self {
         Self {
@@ -1679,7 +1679,7 @@ impl From<requests::CheckmessageRequest> for pb::CheckmessageRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::CloseRequest> for pb::CloseRequest {
     fn from(c: requests::CloseRequest) -> Self {
         Self {
@@ -1695,7 +1695,7 @@ impl From<requests::CloseRequest> for pb::CloseRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ConnectRequest> for pb::ConnectRequest {
     fn from(c: requests::ConnectRequest) -> Self {
         Self {
@@ -1706,7 +1706,7 @@ impl From<requests::ConnectRequest> for pb::ConnectRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::CreateinvoiceRequest> for pb::CreateinvoiceRequest {
     fn from(c: requests::CreateinvoiceRequest) -> Self {
         Self {
@@ -1717,7 +1717,7 @@ impl From<requests::CreateinvoiceRequest> for pb::CreateinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DatastoreRequest> for pb::DatastoreRequest {
     fn from(c: requests::DatastoreRequest) -> Self {
         Self {
@@ -1731,7 +1731,7 @@ impl From<requests::DatastoreRequest> for pb::DatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::CreateonionHops> for pb::CreateonionHops {
     fn from(c: requests::CreateonionHops) -> Self {
         Self {
@@ -1741,7 +1741,7 @@ impl From<requests::CreateonionHops> for pb::CreateonionHops {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::CreateonionRequest> for pb::CreateonionRequest {
     fn from(c: requests::CreateonionRequest) -> Self {
         Self {
@@ -1754,7 +1754,7 @@ impl From<requests::CreateonionRequest> for pb::CreateonionRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DeldatastoreRequest> for pb::DeldatastoreRequest {
     fn from(c: requests::DeldatastoreRequest) -> Self {
         Self {
@@ -1765,7 +1765,7 @@ impl From<requests::DeldatastoreRequest> for pb::DeldatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DelexpiredinvoiceRequest> for pb::DelexpiredinvoiceRequest {
     fn from(c: requests::DelexpiredinvoiceRequest) -> Self {
         Self {
@@ -1774,7 +1774,7 @@ impl From<requests::DelexpiredinvoiceRequest> for pb::DelexpiredinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DelinvoiceRequest> for pb::DelinvoiceRequest {
     fn from(c: requests::DelinvoiceRequest) -> Self {
         Self {
@@ -1785,7 +1785,7 @@ impl From<requests::DelinvoiceRequest> for pb::DelinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::InvoiceRequest> for pb::InvoiceRequest {
     fn from(c: requests::InvoiceRequest) -> Self {
         Self {
@@ -1802,7 +1802,7 @@ impl From<requests::InvoiceRequest> for pb::InvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListdatastoreRequest> for pb::ListdatastoreRequest {
     fn from(c: requests::ListdatastoreRequest) -> Self {
         Self {
@@ -1812,7 +1812,7 @@ impl From<requests::ListdatastoreRequest> for pb::ListdatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListinvoicesRequest> for pb::ListinvoicesRequest {
     fn from(c: requests::ListinvoicesRequest) -> Self {
         Self {
@@ -1824,7 +1824,7 @@ impl From<requests::ListinvoicesRequest> for pb::ListinvoicesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendonionFirst_hop> for pb::SendonionFirstHop {
     fn from(c: requests::SendonionFirst_hop) -> Self {
         Self {
@@ -1835,7 +1835,7 @@ impl From<requests::SendonionFirst_hop> for pb::SendonionFirstHop {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendonionRequest> for pb::SendonionRequest {
     fn from(c: requests::SendonionRequest) -> Self {
         Self {
@@ -1855,7 +1855,7 @@ impl From<requests::SendonionRequest> for pb::SendonionRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListsendpaysRequest> for pb::ListsendpaysRequest {
     fn from(c: requests::ListsendpaysRequest) -> Self {
         Self {
@@ -1866,7 +1866,7 @@ impl From<requests::ListsendpaysRequest> for pb::ListsendpaysRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListtransactionsRequest> for pb::ListtransactionsRequest {
     fn from(c: requests::ListtransactionsRequest) -> Self {
         Self {
@@ -1874,7 +1874,7 @@ impl From<requests::ListtransactionsRequest> for pb::ListtransactionsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::PayRequest> for pb::PayRequest {
     fn from(c: requests::PayRequest) -> Self {
         Self {
@@ -1895,7 +1895,7 @@ impl From<requests::PayRequest> for pb::PayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListnodesRequest> for pb::ListnodesRequest {
     fn from(c: requests::ListnodesRequest) -> Self {
         Self {
@@ -1904,7 +1904,7 @@ impl From<requests::ListnodesRequest> for pb::ListnodesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::WaitanyinvoiceRequest> for pb::WaitanyinvoiceRequest {
     fn from(c: requests::WaitanyinvoiceRequest) -> Self {
         Self {
@@ -1914,7 +1914,7 @@ impl From<requests::WaitanyinvoiceRequest> for pb::WaitanyinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::WaitinvoiceRequest> for pb::WaitinvoiceRequest {
     fn from(c: requests::WaitinvoiceRequest) -> Self {
         Self {
@@ -1923,7 +1923,7 @@ impl From<requests::WaitinvoiceRequest> for pb::WaitinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::WaitsendpayRequest> for pb::WaitsendpayRequest {
     fn from(c: requests::WaitsendpayRequest) -> Self {
         Self {
@@ -1935,7 +1935,7 @@ impl From<requests::WaitsendpayRequest> for pb::WaitsendpayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::NewaddrRequest> for pb::NewaddrRequest {
     fn from(c: requests::NewaddrRequest) -> Self {
         Self {
@@ -1944,7 +1944,7 @@ impl From<requests::NewaddrRequest> for pb::NewaddrRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::WithdrawRequest> for pb::WithdrawRequest {
     fn from(c: requests::WithdrawRequest) -> Self {
         Self {
@@ -1958,7 +1958,7 @@ impl From<requests::WithdrawRequest> for pb::WithdrawRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::KeysendRequest> for pb::KeysendRequest {
     fn from(c: requests::KeysendRequest) -> Self {
         Self {
@@ -1975,7 +1975,7 @@ impl From<requests::KeysendRequest> for pb::KeysendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::FundpsbtRequest> for pb::FundpsbtRequest {
     fn from(c: requests::FundpsbtRequest) -> Self {
         Self {
@@ -1993,7 +1993,7 @@ impl From<requests::FundpsbtRequest> for pb::FundpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendpsbtRequest> for pb::SendpsbtRequest {
     fn from(c: requests::SendpsbtRequest) -> Self {
         Self {
@@ -2003,7 +2003,7 @@ impl From<requests::SendpsbtRequest> for pb::SendpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SignpsbtRequest> for pb::SignpsbtRequest {
     fn from(c: requests::SignpsbtRequest) -> Self {
         Self {
@@ -2014,7 +2014,7 @@ impl From<requests::SignpsbtRequest> for pb::SignpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::UtxopsbtRequest> for pb::UtxopsbtRequest {
     fn from(c: requests::UtxopsbtRequest) -> Self {
         Self {
@@ -2033,7 +2033,7 @@ impl From<requests::UtxopsbtRequest> for pb::UtxopsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::TxdiscardRequest> for pb::TxdiscardRequest {
     fn from(c: requests::TxdiscardRequest) -> Self {
         Self {
@@ -2042,7 +2042,7 @@ impl From<requests::TxdiscardRequest> for pb::TxdiscardRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::TxprepareRequest> for pb::TxprepareRequest {
     fn from(c: requests::TxprepareRequest) -> Self {
         Self {
@@ -2056,7 +2056,7 @@ impl From<requests::TxprepareRequest> for pb::TxprepareRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::TxsendRequest> for pb::TxsendRequest {
     fn from(c: requests::TxsendRequest) -> Self {
         Self {
@@ -2065,7 +2065,7 @@ impl From<requests::TxsendRequest> for pb::TxsendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListpeerchannelsRequest> for pb::ListpeerchannelsRequest {
     fn from(c: requests::ListpeerchannelsRequest) -> Self {
         Self {
@@ -2074,7 +2074,7 @@ impl From<requests::ListpeerchannelsRequest> for pb::ListpeerchannelsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListclosedchannelsRequest> for pb::ListclosedchannelsRequest {
     fn from(c: requests::ListclosedchannelsRequest) -> Self {
         Self {
@@ -2083,7 +2083,7 @@ impl From<requests::ListclosedchannelsRequest> for pb::ListclosedchannelsRequest
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DecodepayRequest> for pb::DecodepayRequest {
     fn from(c: requests::DecodepayRequest) -> Self {
         Self {
@@ -2093,7 +2093,7 @@ impl From<requests::DecodepayRequest> for pb::DecodepayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DecodeRequest> for pb::DecodeRequest {
     fn from(c: requests::DecodeRequest) -> Self {
         Self {
@@ -2102,7 +2102,7 @@ impl From<requests::DecodeRequest> for pb::DecodeRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::DisconnectRequest> for pb::DisconnectRequest {
     fn from(c: requests::DisconnectRequest) -> Self {
         Self {
@@ -2112,7 +2112,7 @@ impl From<requests::DisconnectRequest> for pb::DisconnectRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::FeeratesRequest> for pb::FeeratesRequest {
     fn from(c: requests::FeeratesRequest) -> Self {
         Self {
@@ -2121,7 +2121,7 @@ impl From<requests::FeeratesRequest> for pb::FeeratesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::FundchannelRequest> for pb::FundchannelRequest {
     fn from(c: requests::FundchannelRequest) -> Self {
         Self {
@@ -2142,7 +2142,7 @@ impl From<requests::FundchannelRequest> for pb::FundchannelRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::GetrouteRequest> for pb::GetrouteRequest {
     fn from(c: requests::GetrouteRequest) -> Self {
         Self {
@@ -2159,7 +2159,7 @@ impl From<requests::GetrouteRequest> for pb::GetrouteRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListforwardsRequest> for pb::ListforwardsRequest {
     fn from(c: requests::ListforwardsRequest) -> Self {
         Self {
@@ -2170,7 +2170,7 @@ impl From<requests::ListforwardsRequest> for pb::ListforwardsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::ListpaysRequest> for pb::ListpaysRequest {
     fn from(c: requests::ListpaysRequest) -> Self {
         Self {
@@ -2181,7 +2181,7 @@ impl From<requests::ListpaysRequest> for pb::ListpaysRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::PingRequest> for pb::PingRequest {
     fn from(c: requests::PingRequest) -> Self {
         Self {
@@ -2192,7 +2192,7 @@ impl From<requests::PingRequest> for pb::PingRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SendcustommsgRequest> for pb::SendcustommsgRequest {
     fn from(c: requests::SendcustommsgRequest) -> Self {
         Self {
@@ -2202,7 +2202,7 @@ impl From<requests::SendcustommsgRequest> for pb::SendcustommsgRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SetchannelRequest> for pb::SetchannelRequest {
     fn from(c: requests::SetchannelRequest) -> Self {
         Self {
@@ -2216,7 +2216,7 @@ impl From<requests::SetchannelRequest> for pb::SetchannelRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SigninvoiceRequest> for pb::SigninvoiceRequest {
     fn from(c: requests::SigninvoiceRequest) -> Self {
         Self {
@@ -2225,7 +2225,7 @@ impl From<requests::SigninvoiceRequest> for pb::SigninvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::SignmessageRequest> for pb::SignmessageRequest {
     fn from(c: requests::SignmessageRequest) -> Self {
         Self {
@@ -2234,7 +2234,7 @@ impl From<requests::SignmessageRequest> for pb::SignmessageRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::StopRequest> for pb::StopRequest {
     fn from(c: requests::StopRequest) -> Self {
         Self {
@@ -2242,7 +2242,7 @@ impl From<requests::StopRequest> for pb::StopRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::PreapprovekeysendRequest> for pb::PreapprovekeysendRequest {
     fn from(c: requests::PreapprovekeysendRequest) -> Self {
         Self {
@@ -2253,7 +2253,7 @@ impl From<requests::PreapprovekeysendRequest> for pb::PreapprovekeysendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<requests::PreapproveinvoiceRequest> for pb::PreapproveinvoiceRequest {
     fn from(c: requests::PreapproveinvoiceRequest) -> Self {
         Self {
@@ -2263,7 +2263,7 @@ impl From<requests::PreapproveinvoiceRequest> for pb::PreapproveinvoiceRequest {
 }
 
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::GetinfoRequest> for requests::GetinfoRequest {
     fn from(c: pb::GetinfoRequest) -> Self {
         Self {
@@ -2271,7 +2271,7 @@ impl From<pb::GetinfoRequest> for requests::GetinfoRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListpeersRequest> for requests::ListpeersRequest {
     fn from(c: pb::ListpeersRequest) -> Self {
         Self {
@@ -2281,7 +2281,7 @@ impl From<pb::ListpeersRequest> for requests::ListpeersRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListfundsRequest> for requests::ListfundsRequest {
     fn from(c: pb::ListfundsRequest) -> Self {
         Self {
@@ -2290,7 +2290,7 @@ impl From<pb::ListfundsRequest> for requests::ListfundsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendpayRoute> for requests::SendpayRoute {
     fn from(c: pb::SendpayRoute) -> Self {
         Self {
@@ -2302,7 +2302,7 @@ impl From<pb::SendpayRoute> for requests::SendpayRoute {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendpayRequest> for requests::SendpayRequest {
     fn from(c: pb::SendpayRequest) -> Self {
         Self {
@@ -2319,7 +2319,7 @@ impl From<pb::SendpayRequest> for requests::SendpayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListchannelsRequest> for requests::ListchannelsRequest {
     fn from(c: pb::ListchannelsRequest) -> Self {
         Self {
@@ -2330,7 +2330,7 @@ impl From<pb::ListchannelsRequest> for requests::ListchannelsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::AddgossipRequest> for requests::AddgossipRequest {
     fn from(c: pb::AddgossipRequest) -> Self {
         Self {
@@ -2339,7 +2339,7 @@ impl From<pb::AddgossipRequest> for requests::AddgossipRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::AutocleaninvoiceRequest> for requests::AutocleaninvoiceRequest {
     fn from(c: pb::AutocleaninvoiceRequest) -> Self {
         Self {
@@ -2349,7 +2349,7 @@ impl From<pb::AutocleaninvoiceRequest> for requests::AutocleaninvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::CheckmessageRequest> for requests::CheckmessageRequest {
     fn from(c: pb::CheckmessageRequest) -> Self {
         Self {
@@ -2360,7 +2360,7 @@ impl From<pb::CheckmessageRequest> for requests::CheckmessageRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::CloseRequest> for requests::CloseRequest {
     fn from(c: pb::CloseRequest) -> Self {
         Self {
@@ -2375,7 +2375,7 @@ impl From<pb::CloseRequest> for requests::CloseRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ConnectRequest> for requests::ConnectRequest {
     fn from(c: pb::ConnectRequest) -> Self {
         Self {
@@ -2386,7 +2386,7 @@ impl From<pb::ConnectRequest> for requests::ConnectRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::CreateinvoiceRequest> for requests::CreateinvoiceRequest {
     fn from(c: pb::CreateinvoiceRequest) -> Self {
         Self {
@@ -2397,7 +2397,7 @@ impl From<pb::CreateinvoiceRequest> for requests::CreateinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DatastoreRequest> for requests::DatastoreRequest {
     fn from(c: pb::DatastoreRequest) -> Self {
         Self {
@@ -2410,7 +2410,7 @@ impl From<pb::DatastoreRequest> for requests::DatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::CreateonionHops> for requests::CreateonionHops {
     fn from(c: pb::CreateonionHops) -> Self {
         Self {
@@ -2420,7 +2420,7 @@ impl From<pb::CreateonionHops> for requests::CreateonionHops {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::CreateonionRequest> for requests::CreateonionRequest {
     fn from(c: pb::CreateonionRequest) -> Self {
         Self {
@@ -2432,7 +2432,7 @@ impl From<pb::CreateonionRequest> for requests::CreateonionRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DeldatastoreRequest> for requests::DeldatastoreRequest {
     fn from(c: pb::DeldatastoreRequest) -> Self {
         Self {
@@ -2442,7 +2442,7 @@ impl From<pb::DeldatastoreRequest> for requests::DeldatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DelexpiredinvoiceRequest> for requests::DelexpiredinvoiceRequest {
     fn from(c: pb::DelexpiredinvoiceRequest) -> Self {
         Self {
@@ -2451,7 +2451,7 @@ impl From<pb::DelexpiredinvoiceRequest> for requests::DelexpiredinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DelinvoiceRequest> for requests::DelinvoiceRequest {
     fn from(c: pb::DelinvoiceRequest) -> Self {
         Self {
@@ -2462,7 +2462,7 @@ impl From<pb::DelinvoiceRequest> for requests::DelinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::InvoiceRequest> for requests::InvoiceRequest {
     fn from(c: pb::InvoiceRequest) -> Self {
         Self {
@@ -2478,7 +2478,7 @@ impl From<pb::InvoiceRequest> for requests::InvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListdatastoreRequest> for requests::ListdatastoreRequest {
     fn from(c: pb::ListdatastoreRequest) -> Self {
         Self {
@@ -2487,7 +2487,7 @@ impl From<pb::ListdatastoreRequest> for requests::ListdatastoreRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListinvoicesRequest> for requests::ListinvoicesRequest {
     fn from(c: pb::ListinvoicesRequest) -> Self {
         Self {
@@ -2499,7 +2499,7 @@ impl From<pb::ListinvoicesRequest> for requests::ListinvoicesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendonionFirstHop> for requests::SendonionFirst_hop {
     fn from(c: pb::SendonionFirstHop) -> Self {
         Self {
@@ -2510,7 +2510,7 @@ impl From<pb::SendonionFirstHop> for requests::SendonionFirst_hop {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendonionRequest> for requests::SendonionRequest {
     fn from(c: pb::SendonionRequest) -> Self {
         Self {
@@ -2529,7 +2529,7 @@ impl From<pb::SendonionRequest> for requests::SendonionRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListsendpaysRequest> for requests::ListsendpaysRequest {
     fn from(c: pb::ListsendpaysRequest) -> Self {
         Self {
@@ -2540,7 +2540,7 @@ impl From<pb::ListsendpaysRequest> for requests::ListsendpaysRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListtransactionsRequest> for requests::ListtransactionsRequest {
     fn from(c: pb::ListtransactionsRequest) -> Self {
         Self {
@@ -2548,7 +2548,7 @@ impl From<pb::ListtransactionsRequest> for requests::ListtransactionsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::PayRequest> for requests::PayRequest {
     fn from(c: pb::PayRequest) -> Self {
         Self {
@@ -2568,7 +2568,7 @@ impl From<pb::PayRequest> for requests::PayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListnodesRequest> for requests::ListnodesRequest {
     fn from(c: pb::ListnodesRequest) -> Self {
         Self {
@@ -2577,7 +2577,7 @@ impl From<pb::ListnodesRequest> for requests::ListnodesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::WaitanyinvoiceRequest> for requests::WaitanyinvoiceRequest {
     fn from(c: pb::WaitanyinvoiceRequest) -> Self {
         Self {
@@ -2587,7 +2587,7 @@ impl From<pb::WaitanyinvoiceRequest> for requests::WaitanyinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::WaitinvoiceRequest> for requests::WaitinvoiceRequest {
     fn from(c: pb::WaitinvoiceRequest) -> Self {
         Self {
@@ -2596,7 +2596,7 @@ impl From<pb::WaitinvoiceRequest> for requests::WaitinvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::WaitsendpayRequest> for requests::WaitsendpayRequest {
     fn from(c: pb::WaitsendpayRequest) -> Self {
         Self {
@@ -2608,7 +2608,7 @@ impl From<pb::WaitsendpayRequest> for requests::WaitsendpayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::NewaddrRequest> for requests::NewaddrRequest {
     fn from(c: pb::NewaddrRequest) -> Self {
         Self {
@@ -2617,7 +2617,7 @@ impl From<pb::NewaddrRequest> for requests::NewaddrRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::WithdrawRequest> for requests::WithdrawRequest {
     fn from(c: pb::WithdrawRequest) -> Self {
         Self {
@@ -2630,7 +2630,7 @@ impl From<pb::WithdrawRequest> for requests::WithdrawRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::KeysendRequest> for requests::KeysendRequest {
     fn from(c: pb::KeysendRequest) -> Self {
         Self {
@@ -2647,7 +2647,7 @@ impl From<pb::KeysendRequest> for requests::KeysendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::FundpsbtRequest> for requests::FundpsbtRequest {
     fn from(c: pb::FundpsbtRequest) -> Self {
         Self {
@@ -2665,7 +2665,7 @@ impl From<pb::FundpsbtRequest> for requests::FundpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendpsbtRequest> for requests::SendpsbtRequest {
     fn from(c: pb::SendpsbtRequest) -> Self {
         Self {
@@ -2675,7 +2675,7 @@ impl From<pb::SendpsbtRequest> for requests::SendpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SignpsbtRequest> for requests::SignpsbtRequest {
     fn from(c: pb::SignpsbtRequest) -> Self {
         Self {
@@ -2685,7 +2685,7 @@ impl From<pb::SignpsbtRequest> for requests::SignpsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::UtxopsbtRequest> for requests::UtxopsbtRequest {
     fn from(c: pb::UtxopsbtRequest) -> Self {
         Self {
@@ -2703,7 +2703,7 @@ impl From<pb::UtxopsbtRequest> for requests::UtxopsbtRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::TxdiscardRequest> for requests::TxdiscardRequest {
     fn from(c: pb::TxdiscardRequest) -> Self {
         Self {
@@ -2712,7 +2712,7 @@ impl From<pb::TxdiscardRequest> for requests::TxdiscardRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::TxprepareRequest> for requests::TxprepareRequest {
     fn from(c: pb::TxprepareRequest) -> Self {
         Self {
@@ -2724,7 +2724,7 @@ impl From<pb::TxprepareRequest> for requests::TxprepareRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::TxsendRequest> for requests::TxsendRequest {
     fn from(c: pb::TxsendRequest) -> Self {
         Self {
@@ -2733,7 +2733,7 @@ impl From<pb::TxsendRequest> for requests::TxsendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListpeerchannelsRequest> for requests::ListpeerchannelsRequest {
     fn from(c: pb::ListpeerchannelsRequest) -> Self {
         Self {
@@ -2742,7 +2742,7 @@ impl From<pb::ListpeerchannelsRequest> for requests::ListpeerchannelsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListclosedchannelsRequest> for requests::ListclosedchannelsRequest {
     fn from(c: pb::ListclosedchannelsRequest) -> Self {
         Self {
@@ -2751,7 +2751,7 @@ impl From<pb::ListclosedchannelsRequest> for requests::ListclosedchannelsRequest
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DecodepayRequest> for requests::DecodepayRequest {
     fn from(c: pb::DecodepayRequest) -> Self {
         Self {
@@ -2761,7 +2761,7 @@ impl From<pb::DecodepayRequest> for requests::DecodepayRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DecodeRequest> for requests::DecodeRequest {
     fn from(c: pb::DecodeRequest) -> Self {
         Self {
@@ -2770,7 +2770,7 @@ impl From<pb::DecodeRequest> for requests::DecodeRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::DisconnectRequest> for requests::DisconnectRequest {
     fn from(c: pb::DisconnectRequest) -> Self {
         Self {
@@ -2780,7 +2780,7 @@ impl From<pb::DisconnectRequest> for requests::DisconnectRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::FeeratesRequest> for requests::FeeratesRequest {
     fn from(c: pb::FeeratesRequest) -> Self {
         Self {
@@ -2789,7 +2789,7 @@ impl From<pb::FeeratesRequest> for requests::FeeratesRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
     fn from(c: pb::FundchannelRequest) -> Self {
         Self {
@@ -2809,7 +2809,7 @@ impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::GetrouteRequest> for requests::GetrouteRequest {
     fn from(c: pb::GetrouteRequest) -> Self {
         Self {
@@ -2825,7 +2825,7 @@ impl From<pb::GetrouteRequest> for requests::GetrouteRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListforwardsRequest> for requests::ListforwardsRequest {
     fn from(c: pb::ListforwardsRequest) -> Self {
         Self {
@@ -2836,7 +2836,7 @@ impl From<pb::ListforwardsRequest> for requests::ListforwardsRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
     fn from(c: pb::ListpaysRequest) -> Self {
         Self {
@@ -2847,7 +2847,7 @@ impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::PingRequest> for requests::PingRequest {
     fn from(c: pb::PingRequest) -> Self {
         Self {
@@ -2858,7 +2858,7 @@ impl From<pb::PingRequest> for requests::PingRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SendcustommsgRequest> for requests::SendcustommsgRequest {
     fn from(c: pb::SendcustommsgRequest) -> Self {
         Self {
@@ -2868,7 +2868,7 @@ impl From<pb::SendcustommsgRequest> for requests::SendcustommsgRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SetchannelRequest> for requests::SetchannelRequest {
     fn from(c: pb::SetchannelRequest) -> Self {
         Self {
@@ -2882,7 +2882,7 @@ impl From<pb::SetchannelRequest> for requests::SetchannelRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SigninvoiceRequest> for requests::SigninvoiceRequest {
     fn from(c: pb::SigninvoiceRequest) -> Self {
         Self {
@@ -2891,7 +2891,7 @@ impl From<pb::SigninvoiceRequest> for requests::SigninvoiceRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::SignmessageRequest> for requests::SignmessageRequest {
     fn from(c: pb::SignmessageRequest) -> Self {
         Self {
@@ -2900,7 +2900,7 @@ impl From<pb::SignmessageRequest> for requests::SignmessageRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::StopRequest> for requests::StopRequest {
     fn from(c: pb::StopRequest) -> Self {
         Self {
@@ -2908,7 +2908,7 @@ impl From<pb::StopRequest> for requests::StopRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::PreapprovekeysendRequest> for requests::PreapprovekeysendRequest {
     fn from(c: pb::PreapprovekeysendRequest) -> Self {
         Self {
@@ -2919,7 +2919,7 @@ impl From<pb::PreapprovekeysendRequest> for requests::PreapprovekeysendRequest {
     }
 }
 
-#[allow(unused_variables,deprecated)]
+#[allow(unused_variables)]
 impl From<pb::PreapproveinvoiceRequest> for requests::PreapproveinvoiceRequest {
     fn from(c: pb::PreapproveinvoiceRequest) -> Self {
         Self {

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -367,7 +367,7 @@ pub mod requests {
 	    type Response = super::responses::CreateinvoiceResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum DatastoreMode {
 	    #[serde(rename = "must-create")]
 	    MUST_CREATE,
@@ -476,7 +476,7 @@ pub mod requests {
 	    type Response = super::responses::DelexpiredinvoiceResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -621,7 +621,7 @@ pub mod requests {
 	    type Response = super::responses::SendonionResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListsendpaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -783,7 +783,7 @@ pub mod requests {
 	    type Response = super::responses::WaitsendpayResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum NewaddrAddresstype {
 	    #[serde(rename = "bech32")]
 	    BECH32,
@@ -1097,7 +1097,7 @@ pub mod requests {
 	    type Response = super::responses::DisconnectResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum FeeratesStyle {
 	    #[serde(rename = "perkb")]
 	    PERKB,
@@ -1194,7 +1194,7 @@ pub mod requests {
 	    type Response = super::responses::GetrouteResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListforwardsStatus {
 	    #[serde(rename = "offered")]
 	    OFFERED,
@@ -1238,7 +1238,7 @@ pub mod requests {
 	    type Response = super::responses::ListforwardsResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -1438,7 +1438,7 @@ pub mod responses {
 	}
 
 	/// Type of connection (until 23.08, `websocket` was also allowed)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum GetinfoAddressType {
 	    #[serde(rename = "dns")]
 	    DNS,
@@ -1476,7 +1476,7 @@ pub mod responses {
 	}
 
 	/// Type of connection
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum GetinfoBindingType {
 	    #[serde(rename = "local socket")]
 	    LOCAL_SOCKET,
@@ -1558,7 +1558,7 @@ pub mod responses {
 	    }
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpeersPeersLogType {
 	    #[serde(rename = "SKIPPED")]
 	    SKIPPED,
@@ -1611,7 +1611,7 @@ pub mod responses {
 	}
 
 	/// the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpeersPeersChannelsState {
 	    #[serde(rename = "OPENINGD")]
 	    OPENINGD,
@@ -1693,7 +1693,7 @@ pub mod responses {
 	}
 
 	/// Whether it came from peer, or is going to peer
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpeersPeersChannelsHtlcsDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -1863,7 +1863,7 @@ pub mod responses {
 	    }
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListfundsOutputsStatus {
 	    #[serde(rename = "unconfirmed")]
 	    UNCONFIRMED,
@@ -1938,7 +1938,7 @@ pub mod responses {
 	}
 
 	/// status of the payment (could be complete if already sent previously)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum SendpayStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2087,7 +2087,7 @@ pub mod responses {
 	}
 
 	/// Whether we successfully negotiated a mutual close, closed without them, or discarded not-yet-opened channel
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum CloseType {
 	    #[serde(rename = "mutual")]
 	    MUTUAL,
@@ -2131,7 +2131,7 @@ pub mod responses {
 	}
 
 	/// Whether they initiated connection or we did
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ConnectDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -2150,7 +2150,7 @@ pub mod responses {
 	    }
 	}
 	/// Type of connection (*torv2*/*torv3* only if **direction** is *out*)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ConnectAddressType {
 	    #[serde(rename = "local socket")]
 	    LOCAL_SOCKET,
@@ -2211,7 +2211,7 @@ pub mod responses {
 	}
 
 	/// Whether it has been paid, or can no longer be paid
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum CreateinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2348,7 +2348,7 @@ pub mod responses {
 	}
 
 	/// State of invoice
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2458,7 +2458,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid, unpaid or unpayable
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListinvoicesInvoicesStatus {
 	    #[serde(rename = "unpaid")]
 	    UNPAID,
@@ -2525,7 +2525,7 @@ pub mod responses {
 	}
 
 	/// status of the payment (could be complete if already sent previously)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum SendonionStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2581,7 +2581,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListsendpaysPaymentsStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2691,7 +2691,7 @@ pub mod responses {
 	}
 
 	/// status of payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum PayStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -2740,7 +2740,7 @@ pub mod responses {
 	}
 
 	/// Type of connection (until 23.08, `websocket` was also allowed)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListnodesNodesAddressesType {
 	    #[serde(rename = "dns")]
 	    DNS,
@@ -2809,7 +2809,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid or expired
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum WaitanyinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2863,7 +2863,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid or expired
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum WaitinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2917,7 +2917,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum WaitsendpayStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -3011,7 +3011,7 @@ pub mod responses {
 	}
 
 	/// status of payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum KeysendStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -3204,7 +3204,7 @@ pub mod responses {
 	}
 
 	/// the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpeerchannelsChannelsState {
 	    #[serde(rename = "OPENINGD")]
 	    OPENINGD,
@@ -3296,7 +3296,7 @@ pub mod responses {
 	}
 
 	/// Whether it came from peer, or is going to peer
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpeerchannelsChannelsHtlcsDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -3464,7 +3464,7 @@ pub mod responses {
 	}
 
 	/// What caused the channel to close
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListclosedchannelsClosedchannelsClose_cause {
 	    #[serde(rename = "unknown")]
 	    UNKNOWN,
@@ -3549,7 +3549,7 @@ pub mod responses {
 	}
 
 	/// the address type (if known)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum DecodepayFallbacksType {
 	    #[serde(rename = "P2PKH")]
 	    P2PKH,
@@ -3628,7 +3628,7 @@ pub mod responses {
 	}
 
 	/// what kind of object it decoded to
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum DecodeType {
 	    #[serde(rename = "bolt12 offer")]
 	    BOLT12_OFFER,
@@ -3985,7 +3985,7 @@ pub mod responses {
 	}
 
 	/// The features understood by the destination node
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum GetrouteRouteStyle {
 	    #[serde(rename = "tlv")]
 	    TLV,
@@ -4028,7 +4028,7 @@ pub mod responses {
 	}
 
 	/// still ongoing, completed, failed locally, or failed after forwarding
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListforwardsForwardsStatus {
 	    #[serde(rename = "offered")]
 	    OFFERED,
@@ -4053,7 +4053,7 @@ pub mod responses {
 	    }
 	}
 	/// Either a legacy onion format or a modern tlv format
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListforwardsForwardsStyle {
 	    #[serde(rename = "legacy")]
 	    LEGACY,
@@ -4109,7 +4109,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 	pub enum ListpaysPaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -367,7 +367,7 @@ pub mod requests {
 	    type Response = super::responses::CreateinvoiceResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DatastoreMode {
 	    #[serde(rename = "must-create")]
 	    MUST_CREATE,
@@ -476,7 +476,7 @@ pub mod requests {
 	    type Response = super::responses::DelexpiredinvoiceResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -621,7 +621,7 @@ pub mod requests {
 	    type Response = super::responses::SendonionResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListsendpaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -783,7 +783,7 @@ pub mod requests {
 	    type Response = super::responses::WaitsendpayResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum NewaddrAddresstype {
 	    #[serde(rename = "bech32")]
 	    BECH32,
@@ -1097,7 +1097,7 @@ pub mod requests {
 	    type Response = super::responses::DisconnectResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum FeeratesStyle {
 	    #[serde(rename = "perkb")]
 	    PERKB,
@@ -1194,7 +1194,7 @@ pub mod requests {
 	    type Response = super::responses::GetrouteResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsStatus {
 	    #[serde(rename = "offered")]
 	    OFFERED,
@@ -1238,7 +1238,7 @@ pub mod requests {
 	    type Response = super::responses::ListforwardsResponse;
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -1438,7 +1438,7 @@ pub mod responses {
 	}
 
 	/// Type of connection (until 23.08, `websocket` was also allowed)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetinfoAddressType {
 	    #[serde(rename = "dns")]
 	    DNS,
@@ -1476,7 +1476,7 @@ pub mod responses {
 	}
 
 	/// Type of connection
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetinfoBindingType {
 	    #[serde(rename = "local socket")]
 	    LOCAL_SOCKET,
@@ -1558,7 +1558,7 @@ pub mod responses {
 	    }
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeersPeersLogType {
 	    #[serde(rename = "SKIPPED")]
 	    SKIPPED,
@@ -1611,7 +1611,7 @@ pub mod responses {
 	}
 
 	/// the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeersPeersChannelsState {
 	    #[serde(rename = "OPENINGD")]
 	    OPENINGD,
@@ -1693,7 +1693,7 @@ pub mod responses {
 	}
 
 	/// Whether it came from peer, or is going to peer
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeersPeersChannelsHtlcsDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -1863,7 +1863,7 @@ pub mod responses {
 	    }
 	}
 
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListfundsOutputsStatus {
 	    #[serde(rename = "unconfirmed")]
 	    UNCONFIRMED,
@@ -1938,7 +1938,7 @@ pub mod responses {
 	}
 
 	/// status of the payment (could be complete if already sent previously)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum SendpayStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2087,7 +2087,7 @@ pub mod responses {
 	}
 
 	/// Whether we successfully negotiated a mutual close, closed without them, or discarded not-yet-opened channel
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum CloseType {
 	    #[serde(rename = "mutual")]
 	    MUTUAL,
@@ -2131,7 +2131,7 @@ pub mod responses {
 	}
 
 	/// Whether they initiated connection or we did
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ConnectDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -2150,7 +2150,7 @@ pub mod responses {
 	    }
 	}
 	/// Type of connection (*torv2*/*torv3* only if **direction** is *out*)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ConnectAddressType {
 	    #[serde(rename = "local socket")]
 	    LOCAL_SOCKET,
@@ -2211,7 +2211,7 @@ pub mod responses {
 	}
 
 	/// Whether it has been paid, or can no longer be paid
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum CreateinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2348,7 +2348,7 @@ pub mod responses {
 	}
 
 	/// State of invoice
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2458,7 +2458,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid, unpaid or unpayable
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListinvoicesInvoicesStatus {
 	    #[serde(rename = "unpaid")]
 	    UNPAID,
@@ -2525,7 +2525,7 @@ pub mod responses {
 	}
 
 	/// status of the payment (could be complete if already sent previously)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum SendonionStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2581,7 +2581,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListsendpaysPaymentsStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,
@@ -2691,7 +2691,7 @@ pub mod responses {
 	}
 
 	/// status of payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum PayStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -2740,7 +2740,7 @@ pub mod responses {
 	}
 
 	/// Type of connection (until 23.08, `websocket` was also allowed)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListnodesNodesAddressesType {
 	    #[serde(rename = "dns")]
 	    DNS,
@@ -2809,7 +2809,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid or expired
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitanyinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2863,7 +2863,7 @@ pub mod responses {
 	}
 
 	/// Whether it's paid or expired
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitinvoiceStatus {
 	    #[serde(rename = "paid")]
 	    PAID,
@@ -2917,7 +2917,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitsendpayStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -3011,7 +3011,7 @@ pub mod responses {
 	}
 
 	/// status of payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum KeysendStatus {
 	    #[serde(rename = "complete")]
 	    COMPLETE,
@@ -3204,7 +3204,7 @@ pub mod responses {
 	}
 
 	/// the channel state, in particular "CHANNELD_NORMAL" means the channel can be used normally
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeerchannelsChannelsState {
 	    #[serde(rename = "OPENINGD")]
 	    OPENINGD,
@@ -3296,7 +3296,7 @@ pub mod responses {
 	}
 
 	/// Whether it came from peer, or is going to peer
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeerchannelsChannelsHtlcsDirection {
 	    #[serde(rename = "in")]
 	    IN,
@@ -3464,7 +3464,7 @@ pub mod responses {
 	}
 
 	/// What caused the channel to close
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListclosedchannelsClosedchannelsClose_cause {
 	    #[serde(rename = "unknown")]
 	    UNKNOWN,
@@ -3549,7 +3549,7 @@ pub mod responses {
 	}
 
 	/// the address type (if known)
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DecodepayFallbacksType {
 	    #[serde(rename = "P2PKH")]
 	    P2PKH,
@@ -3628,7 +3628,7 @@ pub mod responses {
 	}
 
 	/// what kind of object it decoded to
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DecodeType {
 	    #[serde(rename = "bolt12 offer")]
 	    BOLT12_OFFER,
@@ -3985,7 +3985,7 @@ pub mod responses {
 	}
 
 	/// The features understood by the destination node
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetrouteRouteStyle {
 	    #[serde(rename = "tlv")]
 	    TLV,
@@ -4028,7 +4028,7 @@ pub mod responses {
 	}
 
 	/// still ongoing, completed, failed locally, or failed after forwarding
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsForwardsStatus {
 	    #[serde(rename = "offered")]
 	    OFFERED,
@@ -4053,7 +4053,7 @@ pub mod responses {
 	    }
 	}
 	/// Either a legacy onion format or a modern tlv format
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsForwardsStyle {
 	    #[serde(rename = "legacy")]
 	    LEGACY,
@@ -4109,7 +4109,7 @@ pub mod responses {
 	}
 
 	/// status of the payment
-	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpaysPaysStatus {
 	    #[serde(rename = "pending")]
 	    PENDING,

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -394,6 +394,19 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for DatastoreMode {
+	    fn to_string(&self) -> String {
+	        match self {
+	            DatastoreMode::MUST_CREATE => "MUST_CREATE",
+	            DatastoreMode::MUST_REPLACE => "MUST_REPLACE",
+	            DatastoreMode::CREATE_OR_REPLACE => "CREATE_OR_REPLACE",
+	            DatastoreMode::MUST_APPEND => "MUST_APPEND",
+	            DatastoreMode::CREATE_OR_APPEND => "CREATE_OR_APPEND",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DatastoreRequest {
 	    pub key: Vec<String>,
@@ -497,6 +510,17 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for DelinvoiceStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            DelinvoiceStatus::PAID => "PAID",
+	            DelinvoiceStatus::EXPIRED => "EXPIRED",
+	            DelinvoiceStatus::UNPAID => "UNPAID",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelinvoiceRequest {
 	    pub label: String,
@@ -642,6 +666,17 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for ListsendpaysStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListsendpaysStatus::PENDING => "PENDING",
+	            ListsendpaysStatus::COMPLETE => "COMPLETE",
+	            ListsendpaysStatus::FAILED => "FAILED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListsendpaysRequest {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -801,6 +836,16 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for NewaddrAddresstype {
+	    fn to_string(&self) -> String {
+	        match self {
+	            NewaddrAddresstype::BECH32 => "BECH32",
+	            NewaddrAddresstype::ALL => "ALL",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct NewaddrRequest {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -1115,6 +1160,16 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for FeeratesStyle {
+	    fn to_string(&self) -> String {
+	        match self {
+	            FeeratesStyle::PERKB => "PERKB",
+	            FeeratesStyle::PERKW => "PERKW",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct FeeratesRequest {
 	    // Path `Feerates.style`
@@ -1218,6 +1273,18 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for ListforwardsStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListforwardsStatus::OFFERED => "OFFERED",
+	            ListforwardsStatus::SETTLED => "SETTLED",
+	            ListforwardsStatus::LOCAL_FAILED => "LOCAL_FAILED",
+	            ListforwardsStatus::FAILED => "FAILED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListforwardsRequest {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -1259,6 +1326,17 @@ pub mod requests {
 	        }
 	    }
 	}
+
+	impl ToString for ListpaysStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpaysStatus::PENDING => "PENDING",
+	            ListpaysStatus::COMPLETE => "COMPLETE",
+	            ListpaysStatus::FAILED => "FAILED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpaysRequest {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -1465,6 +1543,19 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for GetinfoAddressType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            GetinfoAddressType::DNS => "DNS",
+	            GetinfoAddressType::IPV4 => "IPV4",
+	            GetinfoAddressType::IPV6 => "IPV6",
+	            GetinfoAddressType::TORV2 => "TORV2",
+	            GetinfoAddressType::TORV3 => "TORV3",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoAddress {
 	    // Path `Getinfo.address[].type`
@@ -1506,6 +1597,20 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for GetinfoBindingType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            GetinfoBindingType::LOCAL_SOCKET => "LOCAL_SOCKET",
+	            GetinfoBindingType::WEBSOCKET => "WEBSOCKET",
+	            GetinfoBindingType::IPV4 => "IPV4",
+	            GetinfoBindingType::IPV6 => "IPV6",
+	            GetinfoBindingType::TORV2 => "TORV2",
+	            GetinfoBindingType::TORV3 => "TORV3",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetinfoBinding {
 	    // Path `Getinfo.binding[].type`
@@ -1591,6 +1696,21 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpeersPeersLogType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpeersPeersLogType::SKIPPED => "SKIPPED",
+	            ListpeersPeersLogType::BROKEN => "BROKEN",
+	            ListpeersPeersLogType::UNUSUAL => "UNUSUAL",
+	            ListpeersPeersLogType::INFO => "INFO",
+	            ListpeersPeersLogType::DEBUG => "DEBUG",
+	            ListpeersPeersLogType::IO_IN => "IO_IN",
+	            ListpeersPeersLogType::IO_OUT => "IO_OUT",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersLog {
 	    // Path `ListPeers.peers[].log[].type`
@@ -1656,6 +1776,25 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpeersPeersChannelsState {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpeersPeersChannelsState::OPENINGD => "OPENINGD",
+	            ListpeersPeersChannelsState::CHANNELD_AWAITING_LOCKIN => "CHANNELD_AWAITING_LOCKIN",
+	            ListpeersPeersChannelsState::CHANNELD_NORMAL => "CHANNELD_NORMAL",
+	            ListpeersPeersChannelsState::CHANNELD_SHUTTING_DOWN => "CHANNELD_SHUTTING_DOWN",
+	            ListpeersPeersChannelsState::CLOSINGD_SIGEXCHANGE => "CLOSINGD_SIGEXCHANGE",
+	            ListpeersPeersChannelsState::CLOSINGD_COMPLETE => "CLOSINGD_COMPLETE",
+	            ListpeersPeersChannelsState::AWAITING_UNILATERAL => "AWAITING_UNILATERAL",
+	            ListpeersPeersChannelsState::FUNDING_SPEND_SEEN => "FUNDING_SPEND_SEEN",
+	            ListpeersPeersChannelsState::ONCHAIN => "ONCHAIN",
+	            ListpeersPeersChannelsState::DUALOPEND_OPEN_INIT => "DUALOPEND_OPEN_INIT",
+	            ListpeersPeersChannelsState::DUALOPEND_AWAITING_LOCKIN => "DUALOPEND_AWAITING_LOCKIN",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsFeerate {
 	    pub perkw: u32,
@@ -1711,6 +1850,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpeersPeersChannelsHtlcsDirection {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpeersPeersChannelsHtlcsDirection::IN => "IN",
+	            ListpeersPeersChannelsHtlcsDirection::OUT => "OUT",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeersPeersChannelsHtlcs {
 	    // Path `ListPeers.peers[].channels[].htlcs[].direction`
@@ -1887,6 +2036,18 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListfundsOutputsStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListfundsOutputsStatus::UNCONFIRMED => "UNCONFIRMED",
+	            ListfundsOutputsStatus::CONFIRMED => "CONFIRMED",
+	            ListfundsOutputsStatus::SPENT => "SPENT",
+	            ListfundsOutputsStatus::IMMATURE => "IMMATURE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListfundsOutputs {
 	    pub txid: String,
@@ -1956,6 +2117,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for SendpayStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            SendpayStatus::PENDING => "PENDING",
+	            SendpayStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendpayResponse {
 	    pub id: u64,
@@ -2108,6 +2279,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for CloseType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            CloseType::MUTUAL => "MUTUAL",
+	            CloseType::UNILATERAL => "UNILATERAL",
+	            CloseType::UNOPENED => "UNOPENED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CloseResponse {
 	    // Path `Close.type`
@@ -2149,6 +2331,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ConnectDirection {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ConnectDirection::IN => "IN",
+	            ConnectDirection::OUT => "OUT",
+	        }.to_string()
+	    }
+	}
+
 	/// Type of connection (*torv2*/*torv3* only if **direction** is *out*)
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ConnectAddressType {
@@ -2177,6 +2369,19 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ConnectAddressType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ConnectAddressType::LOCAL_SOCKET => "LOCAL_SOCKET",
+	            ConnectAddressType::IPV4 => "IPV4",
+	            ConnectAddressType::IPV6 => "IPV6",
+	            ConnectAddressType::TORV2 => "TORV2",
+	            ConnectAddressType::TORV3 => "TORV3",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ConnectAddress {
 	    // Path `Connect.address.type`
@@ -2232,6 +2437,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for CreateinvoiceStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            CreateinvoiceStatus::PAID => "PAID",
+	            CreateinvoiceStatus::EXPIRED => "EXPIRED",
+	            CreateinvoiceStatus::UNPAID => "UNPAID",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct CreateinvoiceResponse {
 	    pub label: String,
@@ -2369,6 +2585,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for DelinvoiceStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            DelinvoiceStatus::PAID => "PAID",
+	            DelinvoiceStatus::EXPIRED => "EXPIRED",
+	            DelinvoiceStatus::UNPAID => "UNPAID",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DelinvoiceResponse {
 	    pub label: String,
@@ -2479,6 +2706,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListinvoicesInvoicesStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListinvoicesInvoicesStatus::UNPAID => "UNPAID",
+	            ListinvoicesInvoicesStatus::PAID => "PAID",
+	            ListinvoicesInvoicesStatus::EXPIRED => "EXPIRED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListinvoicesInvoices {
 	    pub label: String,
@@ -2543,6 +2781,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for SendonionStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            SendonionStatus::PENDING => "PENDING",
+	            SendonionStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct SendonionResponse {
 	    pub id: u64,
@@ -2602,6 +2850,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListsendpaysPaymentsStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListsendpaysPaymentsStatus::PENDING => "PENDING",
+	            ListsendpaysPaymentsStatus::FAILED => "FAILED",
+	            ListsendpaysPaymentsStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListsendpaysPayments {
 	    pub id: u64,
@@ -2712,6 +2971,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for PayStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            PayStatus::COMPLETE => "COMPLETE",
+	            PayStatus::PENDING => "PENDING",
+	            PayStatus::FAILED => "FAILED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct PayResponse {
 	    pub payment_preimage: Secret,
@@ -2767,6 +3037,19 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListnodesNodesAddressesType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListnodesNodesAddressesType::DNS => "DNS",
+	            ListnodesNodesAddressesType::IPV4 => "IPV4",
+	            ListnodesNodesAddressesType::IPV6 => "IPV6",
+	            ListnodesNodesAddressesType::TORV2 => "TORV2",
+	            ListnodesNodesAddressesType::TORV3 => "TORV3",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListnodesNodesAddresses {
 	    // Path `ListNodes.nodes[].addresses[].type`
@@ -2827,6 +3110,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for WaitanyinvoiceStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            WaitanyinvoiceStatus::PAID => "PAID",
+	            WaitanyinvoiceStatus::EXPIRED => "EXPIRED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitanyinvoiceResponse {
 	    pub label: String,
@@ -2881,6 +3174,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for WaitinvoiceStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            WaitinvoiceStatus::PAID => "PAID",
+	            WaitinvoiceStatus::EXPIRED => "EXPIRED",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitinvoiceResponse {
 	    pub label: String,
@@ -2932,6 +3235,15 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for WaitsendpayStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            WaitsendpayStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct WaitsendpayResponse {
 	    pub id: u64,
@@ -3026,6 +3338,15 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for KeysendStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            KeysendStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct KeysendResponse {
 	    pub payment_preimage: Secret,
@@ -3249,6 +3570,25 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpeerchannelsChannelsState {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpeerchannelsChannelsState::OPENINGD => "OPENINGD",
+	            ListpeerchannelsChannelsState::CHANNELD_AWAITING_LOCKIN => "CHANNELD_AWAITING_LOCKIN",
+	            ListpeerchannelsChannelsState::CHANNELD_NORMAL => "CHANNELD_NORMAL",
+	            ListpeerchannelsChannelsState::CHANNELD_SHUTTING_DOWN => "CHANNELD_SHUTTING_DOWN",
+	            ListpeerchannelsChannelsState::CLOSINGD_SIGEXCHANGE => "CLOSINGD_SIGEXCHANGE",
+	            ListpeerchannelsChannelsState::CLOSINGD_COMPLETE => "CLOSINGD_COMPLETE",
+	            ListpeerchannelsChannelsState::AWAITING_UNILATERAL => "AWAITING_UNILATERAL",
+	            ListpeerchannelsChannelsState::FUNDING_SPEND_SEEN => "FUNDING_SPEND_SEEN",
+	            ListpeerchannelsChannelsState::ONCHAIN => "ONCHAIN",
+	            ListpeerchannelsChannelsState::DUALOPEND_OPEN_INIT => "DUALOPEND_OPEN_INIT",
+	            ListpeerchannelsChannelsState::DUALOPEND_AWAITING_LOCKIN => "DUALOPEND_AWAITING_LOCKIN",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeerchannelsChannelsFeerate {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -3314,6 +3654,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpeerchannelsChannelsHtlcsDirection {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpeerchannelsChannelsHtlcsDirection::IN => "IN",
+	            ListpeerchannelsChannelsHtlcsDirection::OUT => "OUT",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpeerchannelsChannelsHtlcs {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -3494,6 +3844,20 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListclosedchannelsClosedchannelsClose_cause {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListclosedchannelsClosedchannelsClose_cause::UNKNOWN => "UNKNOWN",
+	            ListclosedchannelsClosedchannelsClose_cause::LOCAL => "LOCAL",
+	            ListclosedchannelsClosedchannelsClose_cause::USER => "USER",
+	            ListclosedchannelsClosedchannelsClose_cause::REMOTE => "REMOTE",
+	            ListclosedchannelsClosedchannelsClose_cause::PROTOCOL => "PROTOCOL",
+	            ListclosedchannelsClosedchannelsClose_cause::ONCHAIN => "ONCHAIN",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListclosedchannelsClosedchannels {
 	    #[serde(skip_serializing_if = "Option::is_none")]
@@ -3573,6 +3937,18 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for DecodepayFallbacksType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            DecodepayFallbacksType::P2PKH => "P2PKH",
+	            DecodepayFallbacksType::P2SH => "P2SH",
+	            DecodepayFallbacksType::P2WPKH => "P2WPKH",
+	            DecodepayFallbacksType::P2WSH => "P2WSH",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DecodepayFallbacks {
 	    // Path `DecodePay.fallbacks[].type`
@@ -3655,6 +4031,19 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for DecodeType {
+	    fn to_string(&self) -> String {
+	        match self {
+	            DecodeType::BOLT12_OFFER => "BOLT12_OFFER",
+	            DecodeType::BOLT12_INVOICE => "BOLT12_INVOICE",
+	            DecodeType::BOLT12_INVOICE_REQUEST => "BOLT12_INVOICE_REQUEST",
+	            DecodeType::BOLT11_INVOICE => "BOLT11_INVOICE",
+	            DecodeType::RUNE => "RUNE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct DecodeOffer_paths {
 	    pub first_node_id: PublicKey,
@@ -4000,6 +4389,15 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for GetrouteRouteStyle {
+	    fn to_string(&self) -> String {
+	        match self {
+	            GetrouteRouteStyle::TLV => "TLV",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct GetrouteRoute {
 	    pub id: PublicKey,
@@ -4052,6 +4450,18 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListforwardsForwardsStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListforwardsForwardsStatus::OFFERED => "OFFERED",
+	            ListforwardsForwardsStatus::SETTLED => "SETTLED",
+	            ListforwardsForwardsStatus::LOCAL_FAILED => "LOCAL_FAILED",
+	            ListforwardsForwardsStatus::FAILED => "FAILED",
+	        }.to_string()
+	    }
+	}
+
 	/// Either a legacy onion format or a modern tlv format
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsForwardsStyle {
@@ -4071,6 +4481,16 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListforwardsForwardsStyle {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListforwardsForwardsStyle::LEGACY => "LEGACY",
+	            ListforwardsForwardsStyle::TLV => "TLV",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListforwardsForwards {
 	    pub in_channel: ShortChannelId,
@@ -4130,6 +4550,17 @@ pub mod responses {
 	        }
 	    }
 	}
+
+	impl ToString for ListpaysPaysStatus {
+	    fn to_string(&self) -> String {
+	        match self {
+	            ListpaysPaysStatus::PENDING => "PENDING",
+	            ListpaysPaysStatus::FAILED => "FAILED",
+	            ListpaysPaysStatus::COMPLETE => "COMPLETE",
+	        }.to_string()
+	    }
+	}
+
 	#[derive(Clone, Debug, Deserialize, Serialize)]
 	pub struct ListpaysPays {
 	    pub payment_hash: Sha256,

--- a/contrib/msggen/msggen/gen/grpc.py
+++ b/contrib/msggen/msggen/gen/grpc.py
@@ -247,9 +247,17 @@ class GrpcConverterGenerator(IGenerator):
                 self.generate_composite(prefix, f)
 
         pbname = self.to_camel_case(field.typename)
+
+        # If any of the field accesses would result in a deprecated
+        # warning we mark the construction here to allow deprecated
+        # fields being access.
+
+        has_deprecated = any([f.deprecated for f in field.fields])
+        deprecated = ",deprecated" if has_deprecated else ""
+
         # And now we can convert the current field:
         self.write(f"""\
-        #[allow(unused_variables,deprecated)]
+        #[allow(unused_variables{deprecated})]
         impl From<{prefix}::{field.typename}> for pb::{pbname} {{
             fn from(c: {prefix}::{field.typename}) -> Self {{
                 Self {{
@@ -406,10 +414,13 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
             elif isinstance(f, CompositeField):
                 self.generate_composite(prefix, f)
 
+        has_deprecated = any([f.deprecated for f in field.fields])
+        deprecated = ",deprecated" if has_deprecated else ""
+
         pbname = self.to_camel_case(field.typename)
         # And now we can convert the current field:
         self.write(f"""\
-        #[allow(unused_variables,deprecated)]
+        #[allow(unused_variables{deprecated})]
         impl From<pb::{pbname}> for {prefix}::{field.typename} {{
             fn from(c: pb::{pbname}) -> Self {{
                 Self {{

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -85,7 +85,7 @@ def gen_enum(e):
 
     if e.deprecated:
         decl += "#[deprecated]\n"
-    decl += f"#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]\npub enum {e.typename} {{\n"
+    decl += f"#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]\npub enum {e.typename} {{\n"
     for v in e.variants:
         if v is None:
             continue

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -111,6 +111,24 @@ def gen_enum(e):
             }}
         }}
     }}
+
+    """)
+
+    # Implement ToString for enums so we can print them nicely as they
+    # appear in the schemas.
+    decl += dedent(f"""\
+    impl ToString for {e.typename} {{
+        fn to_string(&self) -> String {{
+            match self {{
+    """)
+    for v in e.variants:
+        norm = v.normalized()
+        decl += f"            {e.typename}::{norm} => \"{norm}\",\n"
+    decl += dedent(f"""\
+            }}.to_string()
+        }}
+    }}
+
     """)
 
     typename = e.typename
@@ -124,7 +142,7 @@ def gen_enum(e):
         defi += rename_if_necessary(str(e.name), e.name.normalized())
         defi += f"    pub {e.name.normalized()}: {typename},\n"
     else:
-        defi = f'    #[serde(skip_serializing_if = "Option::is_none")]\n'
+        defi = f"    #[serde(skip_serializing_if = \"Option::is_none\")]\n"
         defi += f"    pub {e.name.normalized()}: Option<{typename}>,\n"
 
     return defi, decl

--- a/contrib/msggen/msggen/gen/rust.py
+++ b/contrib/msggen/msggen/gen/rust.py
@@ -85,7 +85,7 @@ def gen_enum(e):
 
     if e.deprecated:
         decl += "#[deprecated]\n"
-    decl += f"#[derive(Copy, Clone, Debug, Deserialize, Serialize)]\npub enum {e.typename} {{\n"
+    decl += f"#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]\npub enum {e.typename} {{\n"
     for v in e.variants:
         if v is None:
             continue

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -47,8 +47,6 @@ where
     rpcmethods: HashMap<String, RpcMethod<S>>,
     subscriptions: HashMap<String, Subscription<S>>,
     dynamic: bool,
-    #[allow(unused)]
-    nonnumericids: bool,
 }
 
 /// A plugin that has registered with the lightning daemon, and gotten
@@ -118,7 +116,6 @@ where
             options: vec![],
             rpcmethods: HashMap::new(),
             dynamic: false,
-            nonnumericids: true,
         }
     }
 


### PR DESCRIPTION
currently I'm doing something like this to compare two RPC enums:
```
format!("{:?}", sendpay_response.status) == format!("{:?}", SendpayStatus::COMPLETE)
```
(maybe there's a better hack I'm unaware of)

by adding PartialEq I can do `sendpay_response.status == SendpayStatus::COMPLETE`

I'm not super familiar with the whole logic of `rust.py` but I don't think this will land on any enums that can't derive PartialEq because `gen_enum` also derives TryFrom i32 for these same enums

Question: should this change include a bump to the cln-rpc version?