### PR TITLE
db: catch postgres error on uninitialized database

### DIFF
--- a/db/exec.c
+++ b/db/exec.c
@@ -44,7 +44,11 @@ u32 db_data_version_get(struct db *db)
 	struct db_stmt *stmt;
 	u32 version;
 	stmt = db_prepare_v2(db, SQL("SELECT intval FROM vars WHERE name = 'data_version'"));
-	db_query_prepared(stmt);
+	/* postgres will act upset if the table doesn't exist yet. */
+	if (!db_query_prepared(stmt)) {
+		tal_free(stmt);
+		return 0;
+	}
 	/* This fails on uninitialized db, so "0" */
 	if (db_step(stmt))
 		version = db_col_int(stmt, "intval");


### PR DESCRIPTION
Avoids the following when postgres returns no query result: ==63458== Conditional jump or move depends on uninitialised value(s)
==63458==    at 0x226A1F: db_postgres_step (db_postgres.c:156)
==63458==    by 0x22535B: db_step (utils.c:155)
==63458==    by 0x1E089A: db_data_version_get (exec.c:49)
==63458==    by 0x194F6F: db_setup (db.c:1029)
==63458==    by 0x199A2F: wallet_new (wallet.c:101)
==63458==    by 0x154B70: main (lightningd.c:1035)

Changelog-None