### PR TITLE
Some Updates to macOS Install Instructions

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -306,9 +306,9 @@ need to include `testnet=1`
     ./cli/lightning-cli help
 
 
-To install the built binaries into your system, you'll need to run `make install`:
+To install the built binaries into your system, you'll need to run `sudo make install`:
 
-    make install
+    sudo make install
 
 On an M1 mac you may need to use this command instead:
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -266,7 +266,7 @@ If you need Python 3.x for mako (or get a mako build error):
     $ brew install pyenv
     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
     $ source ~/.bash_profile
-    $ pyenv install 3.7.4
+    $ pyenv install 3.7.8
     $ pip install --upgrade pip
     $ pip install poetry
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -246,7 +246,7 @@ To Build on macOS
 
 Assuming you have Xcode and Homebrew installed. Install dependencies:
 
-    $ brew install autoconf automake libtool python3 gmp gnu-sed gettext libsodium
+    $ brew install autoconf automake libtool python3 gmp gnu-sed gettext libsodium protobuf
     $ ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
     $ export PATH="/usr/local/opt:$PATH"
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -267,8 +267,8 @@ If you need Python 3.x for mako (or get a mako build error):
     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
     $ source ~/.bash_profile
     $ pyenv install 3.7.8
-    $ pip install --upgrade pip
-    $ pip install poetry
+    $ pip3 install --upgrade pip
+    $ pip3 install poetry
 
 If you don't have bitcoind installed locally you'll need to install that
 as well:


### PR DESCRIPTION
#### This step in the install documentation: `pyenv install 3.7.4` doesn't work on macOS version 11+.

See GitHub Issue [here](https://github.com/pyenv/pyenv/issues/1737#issuecomment-794592631):

```
Python versions without https://github.com/python/cpython/pull/21113 and its backports are incompatible with MacOS 11 and cannot be built on it.
Releases with the fix are: 3.7.8+, 3.8.4+, 3.9.0+
Any earlier versions can't be built.
```

I'm making the assumption that there wasn't any specific reason that `3.7.4` was required vs `3.7.8`

#### Specify `pip3` vs `pip`

#### `brew install protobuf` was required for this step:
`cargo build --quiet --bin cln-grpc`

#### Use `sudo make install`