### PR TITLE
Flag false-positive memleak in lightningd

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1115,7 +1115,7 @@ int main(int argc, char *argv[])
 	/*~ Pull peers, channels and HTLCs from db. Needs to happen after the
 	 *  topology is initialized since some decisions rely on being able to
 	 *  know the blockheight. */
-	unconnected_htlcs_in = load_channels_from_wallet(ld);
+	unconnected_htlcs_in = notleak(load_channels_from_wallet(ld));
 	db_commit_transaction(ld->wallet->db);
 
  	/*~ The gossip daemon looks after the routing gossip;


### PR DESCRIPTION
I believe our memleak detection is limited in the context of lightningd's main(). This has not been an issue until recently when the 100k peers changes introduced just enough delay on the postgres CI test that `unconnected_htlcs_in` is unable to be freed before tests/test_misc.py::test_logging kills lightningd.

After investigating, it appears the memory is appropriately freed and reallocated during map_copy, so the only thing to do is flag this with `notleak` as is done with `sigchld_conn` and `orig_argv`.  Alternatively, adding `l2.stop()` to the end of the test in question allows allows time for the memory to be freed and results in no test errors.

The CI flake this addresses:
```
E           ValueError: 
E           Node errors:
E           Global errors:
E            - Node /tmp/ltests-2w0twvph/test_logging_1/lightning-2/ has memory leaks: [
E               {
E                   "backtrace": [
E                       "ccan/ccan/tal/tal.c:442 (tal_alloc_)",
E                       "lightningd/peer_control.c:2223 (load_channels_from_wallet)",
E                       "lightningd/lightningd.c:1118 (main)"
E                   ],
E                   "label": "lightningd/peer_control.c:2223:struct htlc_in_map",
E                   "parents": [
E                       "lightningd/lightningd.c:105:struct lightningd"
E                   ],
E                   "value": "0x556e064a1008"
E               }
E           ]
```