### PR TITLE
lightningd: make shutdown safe again

### DIFF
--- a/db/common.h
+++ b/db/common.h
@@ -46,6 +46,7 @@ struct db {
 	/* List of statements that have been created but not executed yet. */
 	struct list_head pending_statements;
 	char *error;
+	bool *shutdown;
 
 	/* Were there any modifying statements in the current transaction?
 	 * Used to bump the data_version in the DB.*/

--- a/db/utils.c
+++ b/db/utils.c
@@ -217,14 +217,16 @@ void db_report_changes(struct db *db, const char *final, size_t min)
 {
 	assert(db->changes);
 	assert(tal_count(db->changes) >= min);
-
 	/* Having changes implies that we have a dirty TX. The opposite is
 	 * currently not true, e.g., the postgres driver doesn't record
 	 * changes yet. */
 	assert(!tal_count(db->changes) || db->dirty);
 
-	if (tal_count(db->changes) > min && db->report_changes_fn)
+	if (tal_count(db->changes) > min && db->report_changes_fn) {
+		if (*db->shutdown)
+			db_fatal("sivr db_write during shutdown");
 		db->report_changes_fn(db);
+	}
 	db->changes = tal_free(db->changes);
 }
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -973,6 +973,10 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 				    json_tok_full(jcon->buffer, method));
 	}
 
+	if (c->ld->state == LD_STATE_SHUTDOWN)
+		return command_fail(c, LIGHTNINGD_SHUTDOWN,
+						   "lightningd is shutting down");
+
 	rpc_hook = tal(c, struct rpc_command_hook_payload);
 	rpc_hook->cmd = c;
 	/* Duplicate since we might outlive the connection */

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -973,9 +973,14 @@ parse_request(struct json_connection *jcon, const jsmntok_t tok[])
 				    json_tok_full(jcon->buffer, method));
 	}
 
-	if (c->ld->state == LD_STATE_SHUTDOWN)
+	if (c->ld->state == LD_STATE_SHUTDOWN) {
+		log_debug(jcon->ld->log, "sivr method=%s id=%s\n",
+						method ? json_strdup(tmpctx, jcon->buffer, method) : "",
+						id ? json_strdup(tmpctx, jcon->buffer, id) : "");
 		return command_fail(c, LIGHTNINGD_SHUTDOWN,
 						   "lightningd is shutting down");
+	}
+
 
 	rpc_hook = tal(c, struct rpc_command_hook_payload);
 	rpc_hook->cmd = c;

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1227,6 +1227,18 @@ bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 	return true;
 }
 
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name)
+{
+	size_t count = tal_count(rpc->commands);
+	for (size_t j = 0; j < count; j++) {
+		if (streq(name, rpc->commands[j]->name)) {
+			   tal_free(rpc->commands[j]);
+			   return true;
+		}
+	}
+	return false;
+}
+
 static bool jsonrpc_command_add_perm(struct lightningd *ld,
 				     struct jsonrpc *rpc,
 				     struct json_command *command)

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -210,6 +210,9 @@ void jsonrpc_stop_all(struct lightningd *ld);
 bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 			 const char *usage TAKES);
 
+/* Remove a command from the JSON-RPC interface */
+bool jsonrpc_command_del(struct jsonrpc *rpc, const char *name);
+
 /**
  * Begin a JSON-RPC notification with the specified topic.
  *

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1267,6 +1267,9 @@ stop:
 	/* Get rid of major subdaemons. */
 	shutdown_global_subdaemons(ld);
 
+	/* Tell plugins we're shutting down, use force if necessary. */
+	shutdown_plugins(ld);
+
 	/* Clean up internal peer/channel/htlc structures. */
 	free_all_channels(ld);
 
@@ -1275,9 +1278,6 @@ stop:
 	 * trigger any such customizable behavior. Ideally we would like to close
 	 * the database now so that we can safely stop db_write plugins. */
 	ld->wallet->db = tal_free(ld->wallet->db);
-
-	/* Tell plugins we're shutting down, use force if necessary. */
-	shutdown_plugins(ld);
 
 	/* Now kill any remaining connections */
 	jsonrpc_stop_all(ld);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -964,6 +964,9 @@ int main(int argc, char *argv[])
 
 	/*~ Every daemon calls this in some form: the hooks are for dumping
 	 * backtraces when we crash (if supported on this platform). */
+#if DEVELOPER
+	daemon_maybe_debug(argv);
+#endif
 	daemon_setup(argv[0], log_backtrace_print, log_backtrace_exit);
 
 	/*~ There's always a battle between what a constructor like this

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -977,6 +977,7 @@ int main(int argc, char *argv[])
 	 * variables. */
 	ld = new_lightningd(NULL);
 	ld->state = LD_STATE_RUNNING;
+	ld->shutdown = false;
 
 	/*~ We store an copy of our arguments before parsing mangles them, so
 	 * we can re-exec if versions of subdaemons change.  Note the use of
@@ -1240,7 +1241,8 @@ stop:
 	jsonrpc_stop_listening(ld->jsonrpc);
 
 	/* Give permission for things to get destroyed without getting upset.
-	 * Also ignore responses to JSON-RPC requests in upcoming main io_loop. */
+	 * Also ignore responses to JSON-RPC requests in upcoming main io_loop.*/
+	/* Fail JSON RPC requests and ignore plugin's responses */
 	ld->state = LD_STATE_SHUTDOWN;
 
 	stop_fd = -1;
@@ -1269,6 +1271,7 @@ stop:
 	shutdown_global_subdaemons(ld);
 
 	/* Tell normal plugins we're shutting down, use force if necessary. */
+	ld->shutdown = true;
 	shutdown_plugins(ld, true);
 
 	/* Clean up internal peer/channel/htlc structures. */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1239,7 +1239,8 @@ stop:
 	/* Stop *new* JSON RPC requests. */
 	jsonrpc_stop_listening(ld->jsonrpc);
 
-	/* Give permission for things to get destroyed without getting upset. */
+	/* Give permission for things to get destroyed without getting upset.
+	 * Also ignore responses to JSON-RPC requests in upcoming main io_loop. */
 	ld->state = LD_STATE_SHUTDOWN;
 
 	stop_fd = -1;
@@ -1267,9 +1268,6 @@ stop:
 	/* Get rid of major subdaemons. */
 	shutdown_global_subdaemons(ld);
 
-	/* Tell plugins we're shutting down, use force if necessary. */
-	shutdown_plugins(ld);
-
 	/* Clean up internal peer/channel/htlc structures. */
 	free_all_channels(ld);
 
@@ -1278,6 +1276,9 @@ stop:
 	 * trigger any such customizable behavior. Ideally we would like to close
 	 * the database now so that we can safely stop db_write plugins. */
 	ld->wallet->db = tal_free(ld->wallet->db);
+
+	/* Tell plugins we're shutting down, use force if necessary. */
+	shutdown_plugins(ld);
 
 	/* Now kill any remaining connections */
 	jsonrpc_stop_all(ld);

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -318,6 +318,7 @@ struct lightningd {
 	alt_subdaemon_map alt_subdaemons;
 
 	enum lightningd_state state;
+	bool shutdown;
 
 	/* Total number of coin moves we've seen, since
 	 * coin move tracking was cool */

--- a/lightningd/opening_common.c
+++ b/lightningd/opening_common.c
@@ -25,7 +25,7 @@ static void destroy_uncommitted_channel(struct uncommitted_channel *uc)
 		subd_release_channel(open_daemon, uc);
 	}
 
-	/* This is how shutdown_subdaemons tells us not to delete from db! */
+	/* This is how free_all_channels tells us not to delete from db! */
 	if (!uc->peer->uncommitted_channel)
 		return;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -678,6 +678,11 @@ static char *opt_force_featureset(const char *optarg,
 	return NULL;
 }
 
+static char *opt_null(void *unused UNNEEDED)
+{
+	return NULL;
+}
+
 static void dev_register_opts(struct lightningd *ld)
 {
 	/* We might want to debug plugins, which are started before normal
@@ -689,6 +694,8 @@ static void dev_register_opts(struct lightningd *ld)
 				 &ld->dev_no_plugin_checksum,
 				 "Don't checksum plugins to detect changes");
 
+	opt_register_noarg("--debugger", opt_null, NULL,
+			   "Invoke gdb to lightningd");
 	opt_register_noarg("--dev-no-reconnect", opt_set_invbool,
 			   &ld->reconnect,
 			   "Disable automatic reconnect-attempts by this node, but accept incoming");
@@ -1581,6 +1588,11 @@ static void add_config(struct lightningd *ld,
 		} else if (opt->cb == (void *)plugin_opt_flag_set) {
 			/* Noop, they will get added below along with the
 			 * OPT_HASARG options. */
+#if DEVELOPER
+		/* instead of this, we could maybe change -dev-debugger=lightningd? */
+		} else if (streq(name, "debugger")) {
+			/* Handled early in lightningd's main(), ignored here */
+#endif
 		} else {
 			/* Insert more decodes here! */
 			assert(!"A noarg option was added but was not handled");

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2146,7 +2146,7 @@ void shutdown_plugins(struct lightningd *ld)
 
 	/* We should *stay* dead when restarting the io_loop */
 	assert(list_empty(&ld->subds));
-	assert(!ld->wallet->db);
+//	assert(!ld->wallet->db);
 
 	/* Tell them all to shutdown; if they care. */
 	list_for_each_safe(&ld->plugins->plugins, p, next, list) {

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2144,6 +2144,10 @@ void shutdown_plugins(struct lightningd *ld)
 {
 	struct plugin *p, *next;
 
+	/* We should *stay* dead when restarting the io_loop */
+	assert(list_empty(&ld->subds));
+	assert(!ld->wallet->db);
+
 	/* Tell them all to shutdown; if they care. */
 	list_for_each_safe(&ld->plugins->plugins, p, next, list) {
 		/* Kill immediately, deletes self from list. */

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -16,7 +16,9 @@ enum plugin_state {
 	/* We have to get `init` response */
 	AWAITING_INIT_RESPONSE,
 	/* We have `init` response. */
-	INIT_COMPLETE
+	INIT_COMPLETE,
+	/* Wait for it to self-terminate */
+	SHUTDOWN,
 };
 
 /**
@@ -238,9 +240,16 @@ void plugin_kill(struct plugin *plugin, enum log_level loglevel,
 		 const char *fmt, ...);
 
 /**
- * Tell all the plugins we're shutting down, and free them.
+ * Tell subscribed plugins we're shutting down, wait for them to self-terminate
+ * and free them.
+ *
+ * @keep_db_write_plugins=true: plugins that registered the db_write hook are
+ * kept alive, but still send them a "shutdown" notification when subscribed.
+ *
+ * @keep_db_write_plugins=false: shutdown remaining plugins: send EOF to their
+ * stdin, then wait for them to self-terminate.
  */
-void shutdown_plugins(struct lightningd *ld);
+void shutdown_plugins(struct lightningd *ld, bool keep_db_write_plugins);
 
 /**
  * Returns the plugin which registers the command with name {cmd_name}

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -307,6 +307,16 @@ struct db_write_hook_req {
 	size_t *num_hooks;
 };
 
+bool plugin_registered_db_write_hook(struct plugin *plugin) {
+	const struct plugin_hook *hook = &db_write_hook;
+
+	for (size_t i = 0; i < tal_count(hook->hooks); i++)
+		if (hook->hooks[i]->plugin == plugin)
+			return true;
+
+	return false;
+}
+
 static void db_hook_response(const char *buffer, const jsmntok_t *toks,
 			     const jsmntok_t *idtok,
 			     struct db_write_hook_req *dwh_req)

--- a/lightningd/plugin_hook.h
+++ b/lightningd/plugin_hook.h
@@ -110,6 +110,9 @@ bool plugin_hook_continue(void *arg, const char *buffer, const jsmntok_t *toks);
 struct plugin_hook *plugin_hook_register(struct plugin *plugin,
 					 const char *method);
 
+/* Helper to tell if plugin registered the db_write hook */
+bool plugin_registered_db_write_hook(struct plugin *plugin);
+
 /* Special sync plugin hook for db. */
 void plugin_hook_db_sync(struct db *db);
 

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -20,6 +20,9 @@ void connectd_activate(struct lightningd *ld UNNEEDED)
 /* Generated stub for connectd_init */
 int connectd_init(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "connectd_init called!\n"); abort(); }
+/* Generated stub for daemon_maybe_debug */
+void daemon_maybe_debug(char *argv[])
+{ fprintf(stderr, "daemon_maybe_debug called!\n"); abort(); }
 /* Generated stub for daemon_poll */
 int daemon_poll(struct pollfd *fds UNNEEDED, nfds_t nfds UNNEEDED, int timeout UNNEEDED)
 { fprintf(stderr, "daemon_poll called!\n"); abort(); }

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -198,7 +198,7 @@ void setup_topology(struct chain_topology *topology UNNEEDED,
 		    u32 min_blockheight UNNEEDED, u32 max_blockheight UNNEEDED)
 { fprintf(stderr, "setup_topology called!\n"); abort(); }
 /* Generated stub for shutdown_plugins */
-void shutdown_plugins(struct lightningd *ld UNNEEDED)
+void shutdown_plugins(struct lightningd *ld UNNEEDED, bool keep_db_write_plugins UNNEEDED)
 { fprintf(stderr, "shutdown_plugins called!\n"); abort(); }
 /* Generated stub for stop_topology */
 void stop_topology(struct chain_topology *topo UNNEEDED)

--- a/tests/plugins/dblog.py
+++ b/tests/plugins/dblog.py
@@ -3,6 +3,8 @@
 """
 from pyln.client import Plugin, RpcError
 import sqlite3
+from time import sleep
+import sys
 
 plugin = Plugin()
 plugin.sqlite_pre_init_cmds = []
@@ -48,6 +50,11 @@ def db_write(plugin, writes, **kwargs):
         plugin.conn.execute("COMMIT;")
 
     return {"result": "continue"}
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    """To see if we got any db_write's during shutdown"""
 
 
 plugin.add_option('dblog-file', None, 'The db file to create.')

--- a/tests/plugins/delay_shutdown.py
+++ b/tests/plugins/delay_shutdown.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+'''This plugin is used to delay the plugin shutdown loop
+'''
+
+from pyln.client import Plugin
+from time import sleep
+import sys
+
+plugin = Plugin()
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    delay = int(plugin.get_option('shutdown_delay'))
+    plugin.log("delay shutdown with {}".format(delay))
+    sleep(delay)
+    sys.exit(0)
+
+
+plugin.add_option('shutdown_delay', 0, '', opt_type='int')
+plugin.run()

--- a/tests/plugins/fail_htlcs.py
+++ b/tests/plugins/fail_htlcs.py
@@ -1,16 +1,28 @@
 #!/usr/bin/env python3
 
 from pyln.client import Plugin
+from time import sleep
+import sys
 
 plugin = Plugin()
 
 
 @plugin.hook("htlc_accepted")
 def on_htlc_accepted(onion, plugin, **kwargs):
+    delay = int(plugin.get_option('htlc_accepted_hook_delay'))
+    plugin.log("delay htlc_accepted with {}".format(delay))
+    sleep(delay)
     plugin.log("Failing htlc on purpose")
     plugin.log("onion: %r" % (onion))
     # WIRE_TEMPORARY_NODE_FAILURE = 0x2002
     return {"result": "fail", "failure_message": "2002"}
 
 
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    """Only to not get killed while handling the hook"""
+    sys.exit(0)
+
+
+plugin.add_option('htlc_accepted_hook_delay', 0, '', opt_type='int')
 plugin.run()

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -5,6 +5,7 @@ We just refuse to let them pay invoices with preimages divisible by 16.
 """
 
 from pyln.client import Plugin
+from time import sleep
 
 plugin = Plugin()
 
@@ -15,6 +16,9 @@ def on_payment(payment, plugin, **kwargs):
     print("msat={}".format(payment['msat']))
     print("preimage={}".format(payment['preimage']))
 
+    delay = int(plugin.get_option('hook_delay'))
+    plugin.log("delay hook with {}".format(delay))
+    sleep(delay)
     if payment['preimage'].endswith('0'):
         # WIRE_TEMPORARY_NODE_FAILURE = 0x2002
         return {'failure_message': "2002"}
@@ -22,4 +26,5 @@ def on_payment(payment, plugin, **kwargs):
     return {'result': 'continue'}
 
 
+plugin.add_option('hook_delay', 0, '', opt_type='int')
 plugin.run()

--- a/tests/plugins/reject_some_invoices.py
+++ b/tests/plugins/reject_some_invoices.py
@@ -5,7 +5,6 @@ We just refuse to let them pay invoices with preimages divisible by 16.
 """
 
 from pyln.client import Plugin
-from time import sleep
 
 plugin = Plugin()
 
@@ -16,9 +15,6 @@ def on_payment(payment, plugin, **kwargs):
     print("msat={}".format(payment['msat']))
     print("preimage={}".format(payment['preimage']))
 
-    delay = int(plugin.get_option('hook_delay'))
-    plugin.log("delay hook with {}".format(delay))
-    sleep(delay)
     if payment['preimage'].endswith('0'):
         # WIRE_TEMPORARY_NODE_FAILURE = 0x2002
         return {'failure_message': "2002"}
@@ -26,5 +22,4 @@ def on_payment(payment, plugin, **kwargs):
     return {'result': 'continue'}
 
 
-plugin.add_option('hook_delay', 0, '', opt_type='int')
 plugin.run()

--- a/tests/plugins/reject_some_invoices_2.py
+++ b/tests/plugins/reject_some_invoices_2.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Simple plugin to test the invoice_payment hook chaining during shutdown.
+
+A payment should never be accepted without passing through this plugin.
+"""
+
+from pyln.client import Plugin
+
+plugin = Plugin()
+
+
+@plugin.hook('invoice_payment', after=['reject_some_invoices.py'])
+def on_payment(payment, plugin, **kwargs):
+    if payment['preimage'].endswith('1'):
+        # WIRE_TEMPORARY_CHANNEL_FAILURE = 0x1007
+        return {'failure_message': "1007"}
+
+    return {'result': 'continue'}
+
+
+@plugin.subscribe("shutdown")
+def shutdown(plugin, **kwargs):
+    """
+    Subscribe shutdown because we consider this plugin important and don't want
+    to miss payments that happen just before or during shutdown.
+    """
+
+
+plugin.run()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -318,7 +318,10 @@ def test_htlc_out_timeout(node_factory, bitcoind, executor):
     disconnects = ['-WIRE_REVOKE_AND_ACK']
     # Feerates identical so we don't get gratuitous commit to update them
     l1 = node_factory.get_node(disconnect=disconnects,
-                               options={'dev-no-reconnect': None},
+                               options={'dev-no-reconnect': None,
+                                        # 'debugger': None,
+                                        'log-level': ['debug', 'io:pay'],
+                                        },
                                feerates=(7500, 7500, 7500, 7500))
     l2 = node_factory.get_node()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -423,7 +423,6 @@ def test_pay_plugin(node_factory):
     assert only_one(l1.rpc.help('pay')['help'])['command'] == msg
 
 
-@pytest.mark.xfail(reason="restarting channeld shouldn't be possible during shutdown")
 def test_invoice_payment_hook_chain_shutdown(node_factory, executor):
     """ l1 has two plugins hooked to reject certain invoices. When we shutdown while
         handling the hook and plugins die, the safe default is be to at least
@@ -508,8 +507,6 @@ def test_rpc_command_hook_chain_shutdown(node_factory, executor):
 
 @pytest.mark.openchannel('v1')
 @pytest.mark.openchannel('v2')
-@pytest.mark.xfail(reason="almost nothing shouldn't be possible during shutdown "
-                          "and definitely not opening channels!")
 def test_openchannel_shutdown(node_factory, executor):
     """Example to demonstrate why subdaemons really should be dead and stay dead
        when we are shutting down, i.e. when lightningd's io_loop restarts in
@@ -547,7 +544,6 @@ def test_openchannel_shutdown(node_factory, executor):
 
 @pytest.mark.openchannel('v1')
 @pytest.mark.openchannel('v2')
-@pytest.mark.xfail(reason="connectd still running when calling shutdown_plugins()")
 def test_connected_hook_shutdown(node_factory, executor):
     """l1 connects to l2 which is shutting down while handling the connected hook
     """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2577,7 +2577,7 @@ plugin.run()
     n.stop()
 
 
-def test_plugin_shutdown(node_factory):
+def test_plugin_shutdown(node_factory, executor):
     """test 'shutdown' notifications, via `plugin stop` or via `stop`"""
 
     p = os.path.join(os.getcwd(), "tests/plugins/test_libplugin")
@@ -2600,12 +2600,14 @@ def test_plugin_shutdown(node_factory):
     l1.daemon.wait_for_log(r"test_libplugin: shutdown called")
     l1.daemon.wait_for_log(r"test_libplugin: Timeout on shutdown: killing anyway")
 
-    # Now, should also shutdown or timeout on finish, RPC calls then fail with error code -5
+    # Now, should also shutdown or timeout on finish, RPC calls then fail
     l1.rpc.plugin_start(p, dont_shutdown=True)
-    l1.rpc.stop()
+    f_stop = executor.submit(l1.rpc.stop)
     l1.daemon.wait_for_logs(['test_libplugin: shutdown called',
                              'misc_notifications.py: .* Connection refused',
                              'test_libplugin: failed to self-terminate in time, killing.'])
+
+    f_stop.result()
 
 
 def test_commando(node_factory, executor):

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1017,6 +1017,7 @@ struct db *db_setup(const tal_t *ctx, struct lightningd *ld,
 
 	db->report_changes_fn = plugin_hook_db_sync;
 
+	db->shutdown = &ld->shutdown;
 	db_begin_transaction(db);
 	db->data_version = db_data_version_get(db);
 


### PR DESCRIPTION
Another draft to demonstrate the issues with the current shutdown sequence mentioned in #5859 (zero response so far)
This is work-in-progress, still contains debug code and will probably fail some tests.

But the tests added in 79e49b65e and 91ad51049 demonstrate concrete examples.

**TLDR**: If any plugin subscribed shutdown, you create a potential backdoor during shutdown which allows peers to connect, restart channels, open new channels etc. at the time when plugins (+ their hooks) may already be gone and `lightningd` is halve dead.

Please tell me I am dreaming and this is not an issue.