### PR TITLE
fix(lightningd): mem leak while loading htlcs on not init db

### DIFF
--- a/db/exec.c
+++ b/db/exec.c
@@ -44,7 +44,11 @@ u32 db_data_version_get(struct db *db)
 	struct db_stmt *stmt;
 	u32 version;
 	stmt = db_prepare_v2(db, SQL("SELECT intval FROM vars WHERE name = 'data_version'"));
-	db_query_prepared(stmt);
+	/* postgres will act upset if the table doesn't exist yet. */
+	if (!db_query_prepared(stmt)) {
+		tal_free(stmt);
+		return 0;
+	}
 	/* This fails on uninitialized db, so "0" */
 	if (db_step(stmt))
 		version = db_col_int(stmt, "intval");

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2220,7 +2220,7 @@ void setup_peers(struct lightningd *ld)
 struct htlc_in_map *load_channels_from_wallet(struct lightningd *ld)
 {
 	struct peer *peer;
-	struct htlc_in_map *unconnected_htlcs_in = tal(ld, struct htlc_in_map);
+	struct htlc_in_map *unconnected_htlcs_in;
 	struct peer_node_id_map_iter it;
 
 	/* Load channels from database */
@@ -2242,6 +2242,7 @@ struct htlc_in_map *load_channels_from_wallet(struct lightningd *ld)
 		}
 	}
 
+	unconnected_htlcs_in = tal(ld, struct htlc_in_map);
 	/* Make a copy of the htlc_map: entries removed as they're matched */
 	htlc_in_map_copy(unconnected_htlcs_in, ld->htlcs_in);
 
@@ -2256,6 +2257,7 @@ struct htlc_in_map *load_channels_from_wallet(struct lightningd *ld)
 							       channel,
 							       ld->htlcs_out,
 							       unconnected_htlcs_in)) {
+				tal_free(unconnected_htlcs_in);
 				fatal("could not load outgoing htlcs for channel");
 			}
 		}


### PR DESCRIPTION
Alternative to https://github.com/ElementsProject/lightning/pull/5931

Build on top of https://github.com/ElementsProject/lightning/pull/5929

With the @endothermicdev patch on postgress side, we leave allocated some memory when we had a not working db and we try to load the `unconnected_htlcs_in` from the db but the loading fails due previous db error.

I see that this is not really a leak, because we are aborting the program but imho I think it is better than using `nolek` functions that could hide some bugs in the future if we change our call lifecicle