### PR TITLE
plugins/pay: fix htlc_budget calc when we get temporary_channel_failure

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -380,8 +380,12 @@ static void channel_hints_update(struct payment *p,
 	if (estimated_capacity != NULL)
 		newhint.estimated_capacity = *estimated_capacity;
 
+	/* This happens if we get a temporary channel failure: we don't know
+	 * htlc capacity here, so assume it's not a problem. */
 	if (htlc_budget != NULL)
 		newhint.htlc_budget = *htlc_budget;
+	else
+		newhint.htlc_budget = 20;
 
 	tal_arr_expand(&root->channel_hints, newhint);
 


### PR DESCRIPTION
Valgrind correctly reports it as uninitialized for this log message, and the only way this can happen is channel_hints_update() when we receive a temporary_channel_failure.  Put a dummy value here in this case.

```
Valgrind error file: valgrind-errors.23404
==23404== Conditional jump or move depends on uninitialised value(s)
==23404==    at 0x49E4B56: __vfprintf_internal (vfprintf-internal.c:1516)
==23404==    by 0x49F6519: __vsnprintf_internal (vsnprintf.c:114)
==23404==    by 0x1EBCEB: do_vfmt (str.c:66)
==23404==    by 0x1EBDF8: tal_vfmt_ (str.c:92)
==23404==    by 0x11A336: paymod_log (libplugin-pay.c:167)
==23404==    by 0x11B4B2: payment_chanhints_apply_route (libplugin-pay.c:534)
==23404==    by 0x11E999: payment_compute_onion_payloads (libplugin-pay.c:1707)
==23404==    by 0x11FF4C: payment_continue (libplugin-pay.c:2135)
==23404==    by 0x1245C0: adaptive_splitter_cb (libplugin-pay.c:3800)
==23404==    by 0x11FEF3: payment_continue (libplugin-pay.c:2123)
==23404==    by 0x1205FE: retry_step_cb (libplugin-pay.c:2301)
==23404==    by 0x11FEF3: payment_continue (libplugin-pay.c:2123)
==23404==
```

Changelog-None