### PR TITLE
lightningd: don't send channeld message to onchaind.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -377,7 +377,7 @@ void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage)
 		return;
 	}
 
-	if (channel_on_chain(channel)) {
+	if (streq(channel->owner->name, "onchaind")) {
 		msg = towire_onchaind_known_preimage(hin, preimage);
 	} else {
 		struct fulfilled_htlc fulfilled_htlc;


### PR DESCRIPTION
```
----------------------------- Captured stderr call -----------------------------
Sending onchaind an invalid message 03ed00000000000000004e52a9129a66619d6809b1024eb9a0159f173a988f3a5d0bdd2447b4fcc24cef
lightningd: FATAL SIGNAL 6 (version 3c57147-modded)
```

The channel state can also be `FUNDING_SPEND_SEEN` if onchaind is still starting up.

Changelog-None: Not reported by any user, mainly a test race AFAICT.