### PR TITLE
make: fix make doc error

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -212,7 +212,7 @@ doc/index.rst: $(MANPAGES:=.md)
 	@$(call VERBOSE, "genidx $@", \
 	  find doc -maxdepth 1 -name '*\.[0-9]\.md' | \
 	  cut -b 5- | LC_ALL=C sort | \
-	  sed 's/\(.*\)\.\(.*\).*\.md/\1 <\1.\2.md>/' | \
+	  sed "s/\(.*\)\.\(.*\).*\.md/\1 <\1.\2.md>/" | \
 	  python3 devtools/blockreplace.py doc/index.rst manpages --language=rst --indent "   " \
 	)
 


### PR DESCRIPTION
This seems to fix issue #5941 ( `/bin/sh: line 1: 1.2.md: No such file or directory` )
Looks to me like certain make versions(?) will parse the ')' as function end when not inside " " but ' ' . That will terminate the sed string too early, leaving the unexpanded '1.2.md'.

Changelog-None