### PR TITLE
pyln-testing: fix wait_for_htlcs helper

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1099,14 +1099,13 @@ class LightningNode(object):
     # `scids` can be a list of strings. If unset wait on all channels.
     def wait_for_htlcs(self, scids=None):
         peers = self.rpc.listpeers()['peers']
-        for p, peer in enumerate(peers):
-            if 'channels' in peer:
-                channels_peer = self.rpc.listpeerchannels(peer['id'])
-                for c, channel in enumerate(channels_peer['channels']):
-                    if scids is not None and channel['short_channel_id'] not in scids:
-                        continue
-                    if 'htlcs' in channel:
-                        wait_for(lambda: len(self.rpc.listpeerchannels(peer["id"])['channels'][c]['htlcs']) == 0)
+        for peer in peers:
+            channels = self.rpc.listpeerchannels(peer['id'])['channels']
+            for idx, channel in enumerate(channels):
+                if scids is not None and channel['short_channel_id'] not in scids:
+                    continue
+                if 'htlcs' in channel:
+                    wait_for(lambda: len(self.rpc.listpeerchannels(peer["id"])['channels'][idx]['htlcs']) == 0)
 
     # This sends money to a directly connected peer
     def pay(self, dst, amt, label=None):


### PR DESCRIPTION
When doing the updates on the plugin repo ( https://github.com/lightningd/plugins/pull/422 ), I discovered that the `wait_for_htlcs()` helper function got broken by the `listpeerchannels` upgrade. It's rarely used in the main repo, just at the end of the pyln-testing 'pay' helper.

If unfixed, this bug may result in test flakes when using the `pay` helper, because its not correctly waiting for all HTLCs to be resolved before returning.

Changelog-None