### PR TITLE
valgrind-fix: patch valgrind error on log statement in pay plugin

### DIFF
--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -53,6 +53,13 @@ struct payment_result {
 	int *erring_direction;
 };
 
+struct local_hint {
+	/* How many more htlcs can we send over this channel? Only set if this
+	 * is a local channel, because those are the channels we have exact
+	 * numbers on, and they are the bottleneck onto the network. */
+	u16 htlc_budget;
+};
+
 /* Information about channels we inferred from a) looking at our channels, and
  * b) from failures encountered during attempts to perform a payment. These
  * are attached to the root payment, since that information is
@@ -73,13 +80,9 @@ struct channel_hint {
 	/* Is the channel enabled? */
 	bool enabled;
 
-	/* True if we are one endpoint of this channel */
-	bool local;
+	/* Non-null if we are one endpoint of this channel */
+	struct local_hint *local;
 
-	/* How many more htlcs can we send over this channel? Only set if this
-	 * is a local channel, because those are the channels we have exact
-	 * numbers on, and they are the bottleneck onto the network. */
-	u16 htlc_budget;
 };
 
 /* Each payment goes through a number of steps that are always processed in


### PR DESCRIPTION
Note: updates/overwrites fix from `6176912683ef10e86c3fc119f6641f3a9d0ef56d`; this is a nicer update since it categorically removes the error (embeds the field w/in the 'local-ness' of the hint).

The htlc_budget only exists iff the hint is a 'local' one; we were failing to write to the htlc_budget field for non-local cases.

To avoid this, we make `local` into a struct that contains the fields that pertain to local-only payments (in this case, `htlc_budget`).

Valgrind error file: valgrind-errors.1813487
==1813487== Conditional jump or move depends on uninitialised value(s)
==1813487==    at 0x4A9C958: __vfprintf_internal (vfprintf-internal.c:1687)
==1813487==    by 0x4AB0F99: __vsnprintf_internal (vsnprintf.c:114)
==1813487==    by 0x1D2EF9: do_vfmt (str.c:66)
==1813487==    by 0x1D3006: tal_vfmt_ (str.c:92)
==1813487==    by 0x11A60A: paymod_log (libplugin-pay.c:167)
==1813487==    by 0x11B749: payment_chanhints_apply_route (libplugin-pay.c:534)
==1813487==    by 0x11EB36: payment_compute_onion_payloads (libplugin-pay.c:1707)
==1813487==    by 0x12000F: payment_continue (libplugin-pay.c:2135)
==1813487==    by 0x1245B9: adaptive_splitter_cb (libplugin-pay.c:3800)
==1813487==    by 0x11FFB6: payment_continue (libplugin-pay.c:2123)
==1813487==    by 0x1206BC: retry_step_cb (libplugin-pay.c:2301)
==1813487==    by 0x11FFB6: payment_continue (libplugin-pay.c:2123)
==1813487==
{
   <insert_a_suppression_name_here>
   Memcheck:Cond
   fun:__vfprintf_internal
   fun:__vsnprintf_internal
   fun:do_vfmt
   fun:tal_vfmt_
   fun:paymod_log
   fun:payment_chanhints_apply_route
   fun:payment_compute_onion_payloads
   fun:payment_continue
   fun:adaptive_splitter_cb
   fun:payment_continue
   fun:retry_step_cb
[sesh] 0:[tmux]*Z

Suggested-By: @nothingmuch