### PR TITLE
pyln-client: adds utils cln_parse_rpcversion

### DIFF
--- a/contrib/pyln-client/pyln/client/clnutils.py
+++ b/contrib/pyln-client/pyln/client/clnutils.py
@@ -1,0 +1,23 @@
+import re
+
+
+def cln_parse_rpcversion(string):
+    """
+    Parse cln version string to determine RPC version.
+
+    cln switched from 'semver' alike    `major.minor.sub[rcX][-mod]`
+    to ubuntu style with version 22.11  `yy.mm[.patch][-mod]`
+    make sure we can read all of them for (the next 80 years).
+    """
+    rpcversion = string
+    if rpcversion.startswith('v'):  # strip leading 'v'
+        rpcversion = rpcversion[1:]
+    if rpcversion.find('-') != -1:  # strip mods
+        rpcversion = rpcversion[:rpcversion.find('-')]
+    if re.search('.*(rc[\\d]*)$', rpcversion):  # strip release candidates
+        rpcversion = rpcversion[:rpcversion.find('rc')]
+    if rpcversion.count('.') == 1:  # imply patch version 0 if not given
+        rpcversion = rpcversion + '.0'
+
+    # split and convert numeric string parts to actual integers
+    return list(map(int, rpcversion.split('.')))

--- a/contrib/pyln-client/tests/test_clnutils.py
+++ b/contrib/pyln-client/tests/test_clnutils.py
@@ -1,0 +1,43 @@
+from pyln.client.clnutils import cln_parse_rpcversion
+
+
+def test_rpcversion():
+    foo = cln_parse_rpcversion("0.11.2")
+    assert(foo[0] == 0)
+    assert(foo[1] == 11)
+    assert(foo[2] == 2)
+
+    foo = cln_parse_rpcversion("0.11.2rc2-modded")
+    assert(foo[0] == 0)
+    assert(foo[1] == 11)
+    assert(foo[2] == 2)
+
+    foo = cln_parse_rpcversion("22.11")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 0)
+
+    foo = cln_parse_rpcversion("22.11rc1")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 0)
+
+    foo = cln_parse_rpcversion("22.11rc1-modded")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 0)
+
+    foo = cln_parse_rpcversion("22.11-modded")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 0)
+
+    foo = cln_parse_rpcversion("22.11.0")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 0)
+
+    foo = cln_parse_rpcversion("22.11.1")
+    assert(foo[0] == 22)
+    assert(foo[1] == 11)
+    assert(foo[2] == 1)


### PR DESCRIPTION
This adds the `cln_parse_rpcversion` helper that is already used in various plugins to pyln-client, so it does not need to be copied around anymore.

Changelog-None