### PR TITLE
gci: Re-Add `TEST_NETWORK=liquid-regtest` to CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,24 +178,28 @@ jobs:
             EXPERIMENTAL_FEATURES: 1
             TEST_DB_PROVIDER: sqlite3
             COMPILER: gcc
+            TEST_NETWORK: regtest
           - NAME:  gcc-dev1-exp0
             CFG: gcc-dev1-exp0
             DEVELOPER: 1
             EXPERIMENTAL_FEATURES: 0
             TEST_DB_PROVIDER: sqlite3
             COMPILER: gcc
+            TEST_NETWORK: regtest
           - NAME: gcc-dev0-exp1
             CFG: gcc-dev0-exp1
             DEVELOPER: 0
             EXPERIMENTAL_FEATURES: 1
             TEST_DB_PROVIDER: sqlite3
             COMPILER: gcc
+            TEST_NETWORK: regtest
           - NAME: gcc-dev0-exp0
             CFG: gcc-dev0-exp0
             DEVELOPER: 0
             EXPERIMENTAL_FEATURES: 0
             TEST_DB_PROVIDER: sqlite3
             COMPILER: gcc
+            TEST_NETWORK: regtest
           # While we're at it let's try to compile with clang
           - NAME: clang-dev1-exp1
             CFG: clang-dev1-exp1
@@ -203,6 +207,7 @@ jobs:
             EXPERIMENTAL_FEATURES: 1
             TEST_DB_PROVIDER: sqlite3
             COMPILER: clang
+            TEST_NETWORK: regtest
           # And of course we want to test postgres too
           - NAME: postgres
             CFG: gcc-dev1-exp1
@@ -210,7 +215,16 @@ jobs:
             EXPERIMENTAL_FEATURES: 1
             COMPILER: gcc
             TEST_DB_PROVIDER: postgres
-
+            TEST_NETWORK: regtest
+          # And don't forget about elements (like cdecker did when
+          # reworking the CI...)
+          - NAME: liquid
+            CFG: gcc-dev1-exp1
+            DEVELOPER: 1
+            EXPERIMENTAL_FEATURES: 1
+            COMPILER: gcc
+            TEST_NETWORK: liquid-regtest
+            TEST_DB_PROVIDER: sqlite3
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -245,6 +259,7 @@ jobs:
           PYTEST_PAR: 10
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
+          TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
         run: |
           tar -xaf cln-${CFG}.tar.bz2
           poetry run pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3401,7 +3401,7 @@ def test_closing_higherfee(node_factory, bitcoind, executor):
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
 
     # This causes us to *exceed* previous requirements!
-    l1.daemon.wait_for_log(r'deriving max fee from rate 30000 -> 16560sat \(not 1000000sat\)')
+    l1.daemon.wait_for_log(r'deriving max fee from rate 30000 -> .*sat \(not 1000000sat\)')
 
     # This will fail because l1 restarted!
     with pytest.raises(RpcError, match=r'Connection to RPC server lost.'):


### PR DESCRIPTION
Fixups included for https://github.com/ElementsProject/lightning/pull/5910 while I try to fix remaining failing tests

Other PR included the wrong build which lacked experimental features, causing random-seeming failures.

Maybe a good idea to hard fail if experimental flag is given on a non-experimental build? 