### PR TITLE
Last(?) Updates to dual-funding Spec

### DIFF
--- a/common/features.c
+++ b/common/features.c
@@ -168,12 +168,6 @@ static const struct dependency feature_deps[] = {
 	 * `option_anchors_zero_fee_htlc_tx` | ...      | ...      | `option_static_remotekey`
 	 */
 	{ OPT_ANCHORS_ZERO_FEE_HTLC_TX, OPT_STATIC_REMOTEKEY },
-	/* BOLT-f53ca2301232db780843e894f55d95d512f297f9 #9:
-	 * Name                | Description  | Context  | Dependencies  |
-	 * ...
-	 * `option_dual_fund`  | ...          | ...      | `option_static_remotekey`
-	 */
-	{ OPT_DUAL_FUND, OPT_STATIC_REMOTEKEY },
 	/* BOLT-route-blinding #9:
 	 * Name                | Description  | Context  | Dependencies  |
 	 * ...

--- a/common/psbt_internal.c
+++ b/common/psbt_internal.c
@@ -17,8 +17,8 @@ psbt_input_set_final_witness_stack(const tal_t *ctx,
 
 	for (size_t i = 0; i < tal_count(elements); i++)
 		wally_tx_witness_stack_add(in->final_witness,
-					   elements[i]->witness,
-					   tal_bytelen(elements[i]->witness));
+					   elements[i]->witness_data,
+					   tal_bytelen(elements[i]->witness_data));
 	tal_wally_end(ctx);
 }
 
@@ -78,13 +78,13 @@ psbt_to_witness_stacks(const tal_t *ctx,
 				tal(stacks, struct witness_stack);
 			/* Convert the wally_tx_witness_stack to
 			 * a witness_stack entry */
-			stack->witness_element =
+			stack->witness_elements =
 				tal_arr(stack, struct witness_element *,
 					wtx_s->num_items);
-			for (size_t j = 0; j < tal_count(stack->witness_element); j++) {
-				stack->witness_element[j] = tal(stack,
+			for (size_t j = 0; j < tal_count(stack->witness_elements); j++) {
+				stack->witness_elements[j] = tal(stack,
 								struct witness_element);
-				stack->witness_element[j]->witness =
+				stack->witness_elements[j]->witness_data =
 					tal_dup_arr(stack, u8,
 						    wtx_s->items[j].witness,
 						    wtx_s->items[j].witness_len,

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -171,9 +171,10 @@ struct state {
 	/* Information we need between funding_start and funding_complete */
 	struct basepoints their_points;
 
-	/* hsmd gives us our first per-commitment point, and peer tells us
+	/* hsmd gives us our first+second per-commitment points, and peer tells us
 	 * theirs */
 	struct pubkey first_per_commitment_point[NUM_SIDES];
+	struct pubkey second_per_commitment_point[NUM_SIDES];
 
 	struct channel_id channel_id;
 	u8 channel_flags;
@@ -1101,7 +1102,7 @@ static void handle_tx_sigs(struct state *state, const u8 *msg)
 				      tal_hex(msg, msg));
 
 		elem = cast_const2(const struct witness_element **,
-				   ws[j++]->witness_element);
+				   ws[j++]->witness_elements);
 		psbt_finalize_input(tx_state->psbt, in, elem);
 	}
 
@@ -2231,6 +2232,7 @@ static void accepter_start(struct state *state, const u8 *oc2_msg)
 				    &state->their_points.delayed_payment,
 				    &state->their_points.htlc,
 				    &state->first_per_commitment_point[REMOTE],
+				    &state->second_per_commitment_point[REMOTE],
 				    &state->channel_flags,
 				    &open_tlv))
 		open_err_fatal(state, "Parsing open_channel2 %s",
@@ -2549,6 +2551,7 @@ static void accepter_start(struct state *state, const u8 *oc2_msg)
 				     &state->our_points.delayed_payment,
 				     &state->our_points.htlc,
 				     &state->first_per_commitment_point[LOCAL],
+				     &state->second_per_commitment_point[LOCAL],
 				     a_tlv);
 
 	/* Everything's ok. Let's figure out the actual channel_id now */
@@ -3004,6 +3007,7 @@ static void opener_start(struct state *state, u8 *msg)
 				   &state->our_points.delayed_payment,
 				   &state->our_points.htlc,
 				   &state->first_per_commitment_point[LOCAL],
+				   &state->second_per_commitment_point[LOCAL],
 				   state->channel_flags,
 				   open_tlv);
 
@@ -3032,6 +3036,7 @@ static void opener_start(struct state *state, u8 *msg)
 				      &state->their_points.delayed_payment,
 				      &state->their_points.htlc,
 				      &state->first_per_commitment_point[REMOTE],
+				      &state->second_per_commitment_point[REMOTE],
 				      &a_tlv))
 		open_err_fatal(state,  "Parsing accept_channel2 %s",
 			       tal_hex(msg, msg));

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -603,11 +603,6 @@ static size_t psbt_input_weight(struct wally_psbt *psbt,
 		(psbt->inputs[in].redeem_script_len +
 			(varint_t) varint_size(psbt->inputs[in].redeem_script_len)) * 4;
 
-	/* BOLT-f53ca2301232db780843e894f55d95d512f297f9 #3:
-	 *
-	 * The minimum witness weight for an input is 110.
-	 */
-	weight += 110;
 	return weight;
 }
 

--- a/wire/extracted_peer_07_openchannelv2_updates.patch
+++ b/wire/extracted_peer_07_openchannelv2_updates.patch
@@ -1,0 +1,59 @@
+--- wire/peer_wire.csv	2023-02-02 17:51:50.435463786 -0600
++++ -	2023-02-02 17:51:56.693837258 -0600
+@@ -62,13 +63,13 @@
+ msgdata,tx_signatures,channel_id,channel_id,
+ msgdata,tx_signatures,txid,sha256,
+ msgdata,tx_signatures,num_witnesses,u16,
+-msgdata,tx_signatures,witness_stack,witness_stack,num_witnesses
++msgdata,tx_signatures,witnesses,witness_stack,num_witnesses
+ subtype,witness_stack
+-subtypedata,witness_stack,num_input_witness,u16,
+-subtypedata,witness_stack,witness_element,witness_element,num_input_witness
++subtypedata,witness_stack,num_witness_elements,u16,
++subtypedata,witness_stack,witness_elements,witness_element,num_witness_elements
+ subtype,witness_element
+ subtypedata,witness_element,len,u16,
+-subtypedata,witness_element,witness,byte,len
++subtypedata,witness_element,witness_data,byte,len
+ msgtype,tx_init_rbf,72
+ msgdata,tx_init_rbf,channel_id,channel_id,
+ msgdata,tx_init_rbf,locktime,u32,
+@@ -145,7 +146,7 @@
+ tlvdata,channel_ready_tlvs,short_channel_id,alias,short_channel_id,
+ msgtype,open_channel2,64
+ msgdata,open_channel2,chain_hash,chain_hash,
+-msgdata,open_channel2,zerod_channel_id,channel_id,
++msgdata,open_channel2,temporary_channel_id,channel_id,
+ msgdata,open_channel2,funding_feerate_perkw,u32,
+ msgdata,open_channel2,commitment_feerate_perkw,u32,
+ msgdata,open_channel2,funding_satoshis,u64,
+@@ -161,19 +162,20 @@
+ msgdata,open_channel2,delayed_payment_basepoint,point,
+ msgdata,open_channel2,htlc_basepoint,point,
+ msgdata,open_channel2,first_per_commitment_point,point,
++msgdata,open_channel2,second_per_commitment_point,point,
+ msgdata,open_channel2,channel_flags,byte,
+ msgdata,open_channel2,tlvs,opening_tlvs,
+ tlvtype,opening_tlvs,upfront_shutdown_script,0
+ tlvdata,opening_tlvs,upfront_shutdown_script,shutdown_scriptpubkey,byte,...
+ tlvtype,opening_tlvs,channel_type,1
+ tlvdata,opening_tlvs,channel_type,type,byte,...
+ tlvtype,opening_tlvs,request_funds,3
+ tlvdata,opening_tlvs,request_funds,requested_sats,u64,
+ tlvdata,opening_tlvs,request_funds,blockheight,u32,
+ tlvtype,opening_tlvs,require_confirmed_inputs,2
+ tlvdata,opening_tlvs,require_confirmed_inputs,empty,byte,0
+ msgtype,accept_channel2,65
+-msgdata,accept_channel2,zerod_channel_id,channel_id,
++msgdata,accept_channel2,temporary_channel_id,channel_id,
+ msgdata,accept_channel2,funding_satoshis,u64,
+ msgdata,accept_channel2,dust_limit_satoshis,u64,
+ msgdata,accept_channel2,max_htlc_value_in_flight_msat,u64,
+@@ -187,6 +186,7 @@
+ msgdata,accept_channel2,delayed_payment_basepoint,point,
+ msgdata,accept_channel2,htlc_basepoint,point,
+ msgdata,accept_channel2,first_per_commitment_point,point,
++msgdata,accept_channel2,second_per_commitment_point,point,
+ msgdata,accept_channel2,tlvs,accept_tlvs,
+ tlvtype,accept_tlvs,upfront_shutdown_script,0
+ tlvdata,accept_tlvs,upfront_shutdown_script,shutdown_scriptpubkey,byte,...

--- a/wire/peer_wire.csv
+++ b/wire/peer_wire.csv
@@ -62,13 +62,13 @@ msgtype,tx_signatures,71
 msgdata,tx_signatures,channel_id,channel_id,
 msgdata,tx_signatures,txid,sha256,
 msgdata,tx_signatures,num_witnesses,u16,
-msgdata,tx_signatures,witness_stack,witness_stack,num_witnesses
+msgdata,tx_signatures,witnesses,witness_stack,num_witnesses
 subtype,witness_stack
-subtypedata,witness_stack,num_input_witness,u16,
-subtypedata,witness_stack,witness_element,witness_element,num_input_witness
+subtypedata,witness_stack,num_witness_elements,u16,
+subtypedata,witness_stack,witness_elements,witness_element,num_witness_elements
 subtype,witness_element
 subtypedata,witness_element,len,u16,
-subtypedata,witness_element,witness,byte,len
+subtypedata,witness_element,witness_data,byte,len
 msgtype,tx_init_rbf,72
 msgdata,tx_init_rbf,channel_id,channel_id,
 msgdata,tx_init_rbf,locktime,u32,
@@ -145,7 +145,7 @@ tlvtype,channel_ready_tlvs,short_channel_id,1
 tlvdata,channel_ready_tlvs,short_channel_id,alias,short_channel_id,
 msgtype,open_channel2,64
 msgdata,open_channel2,chain_hash,chain_hash,
-msgdata,open_channel2,zerod_channel_id,channel_id,
+msgdata,open_channel2,temporary_channel_id,channel_id,
 msgdata,open_channel2,funding_feerate_perkw,u32,
 msgdata,open_channel2,commitment_feerate_perkw,u32,
 msgdata,open_channel2,funding_satoshis,u64,
@@ -161,6 +161,7 @@ msgdata,open_channel2,payment_basepoint,point,
 msgdata,open_channel2,delayed_payment_basepoint,point,
 msgdata,open_channel2,htlc_basepoint,point,
 msgdata,open_channel2,first_per_commitment_point,point,
+msgdata,open_channel2,second_per_commitment_point,point,
 msgdata,open_channel2,channel_flags,byte,
 msgdata,open_channel2,tlvs,opening_tlvs,
 tlvtype,opening_tlvs,upfront_shutdown_script,0
@@ -172,7 +173,7 @@ tlvdata,opening_tlvs,request_funds,requested_sats,u64,
 tlvdata,opening_tlvs,request_funds,blockheight,u32,
 tlvtype,opening_tlvs,require_confirmed_inputs,2
 msgtype,accept_channel2,65
-msgdata,accept_channel2,zerod_channel_id,channel_id,
+msgdata,accept_channel2,temporary_channel_id,channel_id,
 msgdata,accept_channel2,funding_satoshis,u64,
 msgdata,accept_channel2,dust_limit_satoshis,u64,
 msgdata,accept_channel2,max_htlc_value_in_flight_msat,u64,
@@ -186,6 +187,7 @@ msgdata,accept_channel2,payment_basepoint,point,
 msgdata,accept_channel2,delayed_payment_basepoint,point,
 msgdata,accept_channel2,htlc_basepoint,point,
 msgdata,accept_channel2,first_per_commitment_point,point,
+msgdata,accept_channel2,second_per_commitment_point,point,
 msgdata,accept_channel2,tlvs,accept_tlvs,
 tlvtype,accept_tlvs,upfront_shutdown_script,0
 tlvdata,accept_tlvs,upfront_shutdown_script,shutdown_scriptpubkey,byte,...
@@ -225,7 +227,7 @@ msgdata,update_add_htlc,payment_hash,sha256,
 msgdata,update_add_htlc,cltv_expiry,u32,
 msgdata,update_add_htlc,onion_routing_packet,byte,1366
 msgdata,update_add_htlc,tlvs,update_add_tlvs,
-tlvtype,update_add_tlvs,blinding,2
+tlvtype,update_add_tlvs,blinding,0
 tlvdata,update_add_tlvs,blinding,blinding,point,
 msgtype,update_fulfill_htlc,130
 msgdata,update_fulfill_htlc,channel_id,channel_id,


### PR DESCRIPTION
Adds requested spec proposal changes, including addition of `est_witness_weight` field and `second_commitment_point` to the open/accept_channel2 messages.

(Note that `accept_channel2` also includes `second_commitment_point`, per commit https://github.com/lightning/bolts/pull/851/commits/ee5bef78aba209ad9f28fbf1f40fb432fea6d108).

Built on top of #5900.

@t-bast this is a good one to test for interop! 