### PR TITLE
pytest: fix flake in test_closing_disconnected_notify

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -152,7 +152,8 @@ def test_closing_disconnected_notify(node_factory, bitcoind, executor):
 
     l1.pay(l2, 200000000)
     l2.stop()
-    wait_for(lambda: not only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'])
+    # Wait until channeld is definitely gone.
+    wait_for(lambda: 'owner' not in only_one(l1.rpc.listpeerchannels()['channels']))
 
     out = subprocess.check_output(['cli/lightning-cli',
                                    '--network={}'.format(TEST_NETWORK),


### PR DESCRIPTION
We might be disconnected, but the subd isn't dead yet:

```
>       assert out[0] == '# peer is offline, will negotiate once they reconnect (5 seconds before unilateral close).'
E       AssertionError: assert '# Timed out, forcing close.' == ('# peer is offline, will negotiate once they reconnect (5 seconds before '\n 'unilateral close).')
E         - # peer is offline, will negotiate once they reconnect (5 seconds before unilateral close).
E         + # Timed out, forcing close.

tests/test_closing.py:164: AssertionError
```

Changelog-None