### PR TITLE
lightningd: don't print zero blockheight while we're syncing.

### DIFF
--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -201,7 +201,7 @@ static void gossipd_new_blockheight_reply(struct subd *gossipd,
 	}
 
 	/* Now, finally update getinfo's blockheight */
-	gossipd->ld->blockheight = ptr2int(blockheight);
+	gossipd->ld->gossip_blockheight = ptr2int(blockheight);
 }
 
 void gossip_notify_new_block(struct lightningd *ld, u32 blockheight)

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -244,7 +244,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 
 	/*~ This is detailed in chaintopology.c */
 	ld->topology = new_topology(ld, ld->log);
-	ld->blockheight = 0;
+	ld->gossip_blockheight = 0;
 	ld->daemon_parent_fd = -1;
 	ld->proxyaddr = NULL;
 	ld->always_use_proxy = false;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -198,7 +198,7 @@ struct lightningd {
 	struct chain_topology *topology;
 
 	/* Blockheight (as acknowledged by gossipd) */
-	u32 blockheight;
+	u32 gossip_blockheight;
 
 	/* HTLCs in flight. */
 	struct htlc_in_map *htlcs_in;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2418,7 +2418,16 @@ static struct command_result *json_getinfo(struct command *cmd,
 	json_array_end(response);
 
 	json_add_string(response, "version", version());
-	json_add_num(response, "blockheight", cmd->ld->blockheight);
+	/* If we're still syncing, put the height we're up to here, so
+	 * they can see progress!  Otherwise use the height gossipd knows
+	 * about, so tests work properly. */
+	if (!topology_synced(cmd->ld->topology)) {
+		json_add_num(response, "blockheight",
+			     get_block_height(cmd->ld->topology));
+	} else {
+		json_add_num(response, "blockheight",
+			     cmd->ld->gossip_blockheight);
+	}
 	json_add_string(response, "network", chainparams->network_name);
 	json_add_amount_msat_compat(response,
 			wallet_total_forward_fees(cmd->ld->wallet),


### PR DESCRIPTION
In v0.11 (71f736678f) we changed lightningd to wait for gossipd to acknowledge blocks before updating blockheight: this resolved a problem which lnprototest had where it wanted to know when we'd fully digested a block.

However, it broke the syncing case: until then we don't even tell gossipd, so this stayed at zero.  We should use the current blockheight for that corner case!

Fixes: #5894
Changelog-Fixed: JSON-RPC: `getinfo` `blockheight` no longer sits on 0 while we sync with bitcoind the first time.
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>