### PR TITLE
make: Add doc/index.rst to generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,7 +589,8 @@ CHECK_GEN_ALL = \
 	$(ALL_GEN_HEADERS) \
 	$(ALL_GEN_SOURCES) \
 	wallet/statements_gettextgen.po \
-	.msggen.json
+	.msggen.json \
+	doc/index.rst
 
 check-gen-updated:  $(CHECK_GEN_ALL)
 	@echo "Checking for generated files being changed by make"


### PR DESCRIPTION
It gets partially regenerated, so include it in the check. This is the root cause for the v22.11-modded issue some have noticed.