### PR TITLE
listpeers: add num_channels

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -702,6 +702,7 @@
             "ListPeers.peers[].id": 1,
             "ListPeers.peers[].log[]": 3,
             "ListPeers.peers[].netaddr[]": 5,
+            "ListPeers.peers[].num_channels": 8,
             "ListPeers.peers[].remote_addr": 7
         },
         "ListpeersPeersChannels": {

--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -131,6 +131,7 @@ message ListpeersResponse {
 message ListpeersPeers {
 	bytes id = 1;
 	bool connected = 2;
+	uint32 num_channels = 8;
 	repeated ListpeersPeersLog log = 3;
 	repeated ListpeersPeersChannels channels = 4;
 	repeated string netaddr = 5;

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -215,6 +215,7 @@ impl From<responses::ListpeersPeers> for pb::ListpeersPeers {
         Self {
             id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             connected: c.connected, // Rule #2 for type boolean
+            num_channels: c.num_channels, // Rule #2 for type u32
             log: c.log.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
             channels: c.channels.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
             netaddr: c.netaddr.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1719,6 +1719,7 @@ pub mod responses {
 	pub struct ListpeersPeers {
 	    pub id: PublicKey,
 	    pub connected: bool,
+	    pub num_channels: u32,
 	    #[serde(skip_serializing_if = "crate::is_none_or_empty")]
 	    pub log: Option<Vec<ListpeersPeersLog>>,
 	    #[deprecated]

--- a/contrib/pyln-testing/pyln/testing/grpc2py.py
+++ b/contrib/pyln-testing/pyln/testing/grpc2py.py
@@ -185,6 +185,7 @@ def listpeers_peers2py(m):
     return remove_default({
         "id": hexlify(m.id),  # PrimitiveField in generate_composite
         "connected": m.connected,  # PrimitiveField in generate_composite
+        "num_channels": m.num_channels,  # PrimitiveField in generate_composite
         "log": [listpeers_peers_log2py(i) for i in m.log],  # ArrayField[composite] in generate_composite
         "channels": [listpeers_peers_channels2py(i) for i in m.channels],  # ArrayField[composite] in generate_composite
         "netaddr": [m.netaddr for i in m.netaddr], # ArrayField[primitive] in generate_composite

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -43,6 +43,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
 
 - **id** (pubkey): the public key of the peer
 - **connected** (boolean): True if the peer is currently connected
+- **num\_channels** (u32): The number of channels the peer has with this node *(added v23.02)*
 - **log** (array of objects, optional): if *level* is specified, logs for this peer:
   - **type** (string) (one of "SKIPPED", "BROKEN", "UNUSUAL", "INFO", "DEBUG", "IO\_IN", "IO\_OUT")
 
@@ -399,4 +400,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:b89450ac6f27e051003bcf0a382b51e117e2832729e9d80b0015d9cebfacfa2c)
+[comment]: # ( SHA256STAMP:227b5af94d1f299a4e88e450c074960ca8d109b634e24693ad389ef02f64f525)

--- a/doc/lightning-sql.7.md
+++ b/doc/lightning-sql.7.md
@@ -299,6 +299,7 @@ The following tables are currently supported:
 - `peers` indexed by `id` (see lightning-listpeers(7))
   - `id` (type `pubkey`, sqltype `BLOB`)
   - `connected` (type `boolean`, sqltype `INTEGER`)
+  - `num_channels` (type `u32`, sqltype `INTEGER`)
   - related table `peers_netaddr`
     - `row` (reference to `peers.rowid`, sqltype `INTEGER`)
     - `arrindex` (index within array, sqltype `INTEGER`)
@@ -471,4 +472,4 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-[comment]: # ( SHA256STAMP:dbb9286cf31dc82b33143d5274b1c4eecc75c5ba1dfc18bdf21b4baab585bd45)
+[comment]: # ( SHA256STAMP:d25af4b0655ebd31db68932c5ea6b532bd134477e42df5d0c7428e4a03fd0335)

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -13,7 +13,8 @@
         "additionalProperties": true,
         "required": [
           "id",
-          "connected"
+          "connected",
+          "num_channels"
         ],
         "properties": {
           "id": {
@@ -23,6 +24,11 @@
           "connected": {
             "type": "boolean",
             "description": "True if the peer is currently connected"
+          },
+          "num_channels": {
+            "type": "u32",
+            "description": "The number of channels the peer has with this node",
+            "added": "v23.02"
           },
           "log": {
             "type": "array",
@@ -1091,6 +1097,7 @@
                 "id": {},
                 "channels": {},
                 "connected": {},
+                "num_channels": {},
                 "htlcs": {},
                 "log": {},
                 "netaddr": {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1932,11 +1932,16 @@ static void json_add_peer(struct lightningd *ld,
 			  const enum log_level *ll)
 {
 	struct channel *channel;
+	u32 num_channels;
 
 	json_object_start(response, NULL);
 	json_add_node_id(response, "id", &p->id);
 
 	json_add_bool(response, "connected", p->connected == PEER_CONNECTED);
+	num_channels = 0;
+	list_for_each(&p->channels, channel, list)
+		num_channels++;
+	json_add_num(response, "num_channels", num_channels);
 
 	/* If it's not connected, features are unreliable: we don't
 	 * store them in the database, and they would only reflect
@@ -1954,7 +1959,6 @@ static void json_add_peer(struct lightningd *ld,
 					fmt_wireaddr(response, p->remote_addr));
 		json_add_hex_talarr(response, "features", p->their_features);
 	}
-
 	if (deprecated_apis) {
 		json_array_start(response, "channels");
 		json_add_uncommitted_channel(response, p->uncommitted_channel, NULL);


### PR DESCRIPTION
This will be helpful for plugins and because of the `listpeerchannels` `listpeers` split, so that we can reduce unnecessary RPC ping/pong calls when `num_channels` is 0.

A lot of plugins still need to iterate both calls, so then they can save some IO load and delays.