### PR TITLE
Update Bitcoin Core to 24.0.1 in other git ci locations

### DIFF
--- a/.github/scripts/install-bitcoind.sh
+++ b/.github/scripts/install-bitcoind.sh
@@ -4,13 +4,13 @@ set -e
 
 DIRNAME="bitcoin-${BITCOIN_VERSION}"
 EDIRNAME="elements-${ELEMENTS_VERSION}"
-FILENAME="${DIRNAME}-x86_64-linux-gnu.tar.bz2"
+FILENAME="${DIRNAME}-x86_64-linux-gnu.tar.gz"
 EFILENAME="${EDIRNAME}-x86_64-linux-gnu.tar.bz2"
 
 cd /tmp/
-wget "https://storage.googleapis.com/c-lightning-tests/$FILENAME"
+wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${FILENAME}"
 wget -q "https://storage.googleapis.com/c-lightning-tests/${EFILENAME}"
-tar -xaf "${FILENAME}"
+tar -xf "${FILENAME}"
 tar -xaf "${EFILENAME}"
 sudo mv "${DIRNAME}"/bin/* "/usr/local/bin"
 sudo mv "${EDIRNAME}"/bin/* "/usr/local/bin"

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -45,12 +45,12 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2021-08-3z1
 
           cd /tmp/ || exit 1
-          wget https://storage.googleapis.com/c-lightning-tests/bitcoin-0.20.1-x86_64-linux-gnu.tar.bz2
-          tar -xjf bitcoin-0.20.1-x86_64-linux-gnu.tar.bz2
-          sudo mv bitcoin-0.20.1/bin/* /usr/local/bin
+          wget https://bitcoincore.org/bin/bitcoin-core-24.0.1/bitcoin-24.0.1-x86_64-linux-gnu.tar.gz
+          tar -xf bitcoin-24.0.1-x86_64-linux-gnu.tar.bz2
+          sudo mv bitcoin-24.0.1/bin/* /usr/local/bin
           rm -rf \
-            bitcoin-0.20.1-x86_64-linux-gnu.tar.gz \
-            bitcoin-0.20.1
+            bitcoin-24.0.1-x86_64-linux-gnu.tar.gz \
+            bitcoin-24.0.1
           
         run: |
           PATH=/root/.local/bin:$PATH

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPAT: 1
-      BITCOIN_VERSION: 0.20.1
+      BITCOIN_VERSION: 24.0.1
       ELEMENTS_VERSION: 0.18.1.8
       RUST_PROFILE: release  # Has to match the one in the compile step
     needs:
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPAT: 1
-      BITCOIN_VERSION: 0.20.1
+      BITCOIN_VERSION: 24.0.1
       ELEMENTS_VERSION: 0.18.1.8
       RUST_PROFILE: release  # Has to match the one in the compile step
       VALGRIND: 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           export PATH="/usr/local/opt:/Users/runner/.local/bin:/Users/runner/Library/Python/3.10/bin:$PATH"
 
-          export BITCOIN_VERSION=0.20.1
+          export BITCOIN_VERSION=24.0.1
           brew install wget autoconf automake libtool python@3.10 gmp gnu-sed gettext libsodium
 
           (


### PR DESCRIPTION
Looks like we missed some spots in https://github.com/ElementsProject/lightning/pull/5813, next time we need to check the right binary is actually being used in CI...