### PR TITLE
fix(grpc): add the num_channels field inside the tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,8 @@ jobs:
 
           # Rename now so we don't clash
           mv testpack.tar.bz2 cln-${CFG}.tar.bz2
+      - name: Check rust packages
+        run: cargo test --all
       - uses: actions/upload-artifact@v2.2.4
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2

--- a/cln-grpc/src/pb.rs
+++ b/cln-grpc/src/pb.rs
@@ -164,6 +164,7 @@ mod test {
                 "127.0.0.1:39152"
               ],
               "features": "8808226aa2",
+              "num_channels": 0,
               "channels": [
                 {
                   "state": "CHANNELD_NORMAL",
@@ -265,6 +266,7 @@ mod test {
                 "127.0.0.1:38321"
               ],
               "features": "8808226aa2",
+              "num_channels": 0,
               "channels": [
                 {
                   "state": "CHANNELD_NORMAL",

--- a/cln-grpc/src/test.rs
+++ b/cln-grpc/src/test.rs
@@ -12,6 +12,7 @@ fn test_listpeers() {
             "127.0.0.1:39152"
           ],
           "features": "8808226aa2",
+          "num_channels": 0,
           "channels": [
             {
               "state": "CHANNELD_NORMAL",
@@ -113,6 +114,7 @@ fn test_listpeers() {
             "127.0.0.1:38321"
           ],
           "features": "8808226aa2",
+          "num_channels": 0,
           "channels": [
             {
               "state": "CHANNELD_NORMAL",


### PR DESCRIPTION
This adds some clean-up code on the rust side and also includes a pre-build check test on the rust side.

Currently, we do not have a strong test suite for rust that can fall inside our own task, maybe we could include it inside our make file logic in the future?

Fixes https://github.com/ElementsProject/lightning/issues/5971