### PR TITLE
ci: add timeout field to max 3h for each task

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -10,6 +10,7 @@ jobs:
   testfreebsd:
     runs-on: macos-10.15
     name: Build and test on FreeBSD
+    timeout-minutes: 120
     env:
       DEVELOPER: 1
       VALGRIND: 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
   prebuild:
     name: Pre-build checks
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     env:
       RUST: 1
       COMPAT: 1
@@ -58,6 +59,7 @@ jobs:
     # on the integration tests), so run them with `valgrind`
     name: Run unit tests
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       COMPAT: 1
       VALGRIND: 1
@@ -92,6 +94,7 @@ jobs:
   compile:
     name: Compile CLN ${{ matrix.cfg }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       COMPAT: 1
     needs:
@@ -161,6 +164,7 @@ jobs:
   integration:
     name: Test CLN ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     env:
       COMPAT: 1
       BITCOIN_VERSION: 24.0.1
@@ -267,6 +271,7 @@ jobs:
   integration-valgrind:
     name: Valgrind Test CLN ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     env:
       COMPAT: 1
       BITCOIN_VERSION: 24.0.1

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,6 +6,7 @@ jobs:
   smoke-test:
     name: Smoke Test macOS
     runs-on: macos-latest
+    timeout-minutes: 120
     env:
       DEVELOPER: 1
       VALGRIND: 0

--- a/.github/workflows/prototest.yaml
+++ b/.github/workflows/prototest.yaml
@@ -9,7 +9,7 @@ jobs:
   proto-test:
     name: Protocol Test Config
     runs-on: ubuntu-22.04
-    timeout-minutes: 300
+    timeout-minutes: 120
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     name: Build and publish ${{ matrix.package }} 🐍
     runs-on: ubuntu-20.04
+    timeout-minutes: 120
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/5976

I forgot to push this yesterday! This proposes to add a limit of 2 hours to the CI I do not know if 2h is a good time, but we can always increase it.

@instagibbs propose to limit only pytest, this will not catch dependencies resolution loop with python that time to time in the past happened

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
Changelog-None