### PR TITLE
be able to skip the protocol test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BOLTVERSION := $(DEFAULT_BOLTVERSION)
 -include config.vars
 
 SORT=LC_ALL=C sort
-
+CHECK_PROTO=1
 
 ifeq ($V,1)
 VERBOSE = $(ECHO) '$(2)'; $(2)
@@ -457,7 +457,11 @@ ifeq ($(PYTEST),)
 	@echo "py.test is required to run the protocol tests, please install using 'pip3 install -r requirements.txt', and rerun 'configure'."; false
 else
 ifeq ($(DEVELOPER),1)
+ifeq ($(CHECK_PROTO), 1)
 	@(cd external/lnprototest && PYTHONPATH=$(MY_CHECK_PYTHONPATH) LIGHTNING_SRC=../.. $(PYTEST) --runner lnprototest.clightning.Runner $(PYTEST_OPTS))
+else
+	@echo "lnprototed is disabled, use CHECK_PROTO=1 to include it"
+endif
 else
 	@echo "lnprototest target requires DEVELOPER=1, skipping"
 endif


### PR DESCRIPTION
Right now it is not possible to run our `make check` without fail in lnprototest due to some bugs that I'm working on.

This PR proposes a change in our make file that allows to skip our lnprototest check and be able to run the tests with the commands that we mention inside the documentation.

An example where it is possible to skip lnprototest is by running the following command `make -j$(nproc) check CHECK_PROTO=0`

P.S: Sorry to be so slow in fixing lnprototest!

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>