### PR TITLE
lightningd: don't put old deprecated `local_msat` and `remote_msat` in listpeerchannels.

### DIFF
--- a/doc/lightning-listpeerchannels.7.md
+++ b/doc/lightning-listpeerchannels.7.md
@@ -56,8 +56,6 @@ On success, an object containing **channels** is returned.  It is an array of ob
 - **funding** (object, optional):
   - **local\_funds\_msat** (msat): Amount of channel we funded
   - **remote\_funds\_msat** (msat): Amount of channel they funded
-  - **local\_msat** (msat, optional): Amount of channel we funded **deprecated, removal in v23.05**
-  - **remote\_msat** (msat, optional): Amount of channel they funded **deprecated, removal in v23.05**
   - **pushed\_msat** (msat, optional): Amount pushed from opener to peer
   - **fee\_paid\_msat** (msat, optional): Amount we paid peer at open
   - **fee\_rcvd\_msat** (msat, optional): Amount we were paid by peer at open
@@ -191,4 +189,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:32eef1dd02f6bdd40e8d81057701e8170fac788f4396e34f5f505efbed360245)
+[comment]: # ( SHA256STAMP:f9919b6967137945cb49392d64a42bd159123b9d3bb83833c5df3bc777065d2e)

--- a/doc/schemas/listpeerchannels.schema.json
+++ b/doc/schemas/listpeerchannels.schema.json
@@ -189,16 +189,6 @@
               "remote_funds_msat"
             ],
             "properties": {
-              "local_msat": {
-                "type": "msat",
-                "deprecated": "v0.12.0",
-                "description": "Amount of channel we funded"
-              },
-              "remote_msat": {
-                "type": "msat",
-                "deprecated": "v0.12.0",
-                "description": "Amount of channel they funded"
-              },
               "pushed_msat": {
                 "type": "msat",
                 "description": "Amount pushed from opener to peer"

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -862,7 +862,8 @@ static void json_add_channel(struct lightningd *ld,
 
 	json_object_start(response, "funding");
 
-	if (deprecated_apis) {
+	/* We don't put v0.12-deprecated fields into listpeerchannels */
+	if (deprecated_apis && !peer) {
 		json_add_sat_only(response, "local_msat", channel->our_funds);
 		json_add_sat_only(response, "remote_msat", peer_funded_sats);
 		json_add_amount_msat_only(response, "pushed_msat", channel->push);
@@ -921,7 +922,7 @@ static void json_add_channel(struct lightningd *ld,
 				  channel->our_funds);
 		json_add_sat_only(response, "remote_funds_msat",
 				  peer_funded_sats);
-		if (!deprecated_apis)
+		if (!deprecated_apis || peer)
 			json_add_amount_msat_only(response, "pushed_msat",
 						  channel->push);
 	}


### PR DESCRIPTION

These were deprecated in v0.12.0, hence scheduled for removal next version anyway (use local_fund_msat and remote_funds_msat).

Changelog-None: introduced in this release