### PR TITLE
pytest: adds an xfail test that shows datastore issues

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2831,6 +2831,19 @@ def test_force_feerates(node_factory):
         "max_acceptable": 150000}
 
 
+@pytest.mark.xfail(strict=True, raises=AssertionError)
+def test_datastore_escapeing(node_factory):
+    """ This test demonstrates that there is some character escaping issue
+        issue in the datastore API and error messages during startup that
+        affect plugins init method. """
+    setdata = '{"foo": "bar"}'
+    l1 = node_factory.get_node()
+    l1.rpc.datastore(key='foo_bar', string=setdata)
+    getdata = l1.rpc.listdatastore('foo_bar')['datastore'][0]['string']
+    assert not l1.daemon.is_in_log(r".*listdatastore error.*token has no index 0.*")
+    assert getdata == setdata
+
+
 def test_datastore(node_factory):
     l1 = node_factory.get_node()
 


### PR DESCRIPTION
So this PR shows two issues:
- The `datastore` API logs errors on plugins init methods  (autoclean, commando, fetchinvoice)  when the datastore is still completely empty, which may impact runtime of internal plugins, as init fails.
- The `datastore` (rightfully) escapes data it gets from a plugin, but does not unwrap that again on retrieval with `listdatastore`:   `'{"foo": "bar"}' != '{\"foo\": \"bar\"}'` 

Following errors are currently logged on master:
```
2023-02-09T20:33:23.585Z DEBUG   plugin-commando: listdatastore error commando/rune_counter: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-commando: listdatastore error commando/secret: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-fetchinvoice: Killing plugin: disabled itself at init: offers not enabled in config
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/succeededforwards/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/failedforwards/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/succeededpays/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/failedpays/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/paidinvoices/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:33:23.585Z DEBUG   plugin-autoclean: listdatastore error autoclean/expiredinvoices/num: Parsing '{datastore:[0:': token has no index 0: []
2023-02-09T20:20:15.353Z DEBUG   lightningd: Looking for [autoclean,failedforwards,num]
2023-02-09T20:20:15.353Z DEBUG   lightningd: Got [foo_bar]
2023-02-09T20:20:15.353Z DEBUG   lightningd: Not interested
```

UPDATE: The error messages are caused in `plugins/libplugin.c` (line 645) which sets a `guide` to $3 = 0x5637f677f2c8 "{datastore:[0:{string:%}]}" , but the datastore is still empty and the output of listdatastore is checked against that and it fails because index `0` is not even there (Yet). This may affect runtime of internal plugins as the init method fails.

The other issue (getting escaped and not unwrapped data back) is less critical.