### PR TITLE
fix: compilation error on armv7l 32 bit

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -2624,7 +2624,7 @@ static void validate_input_unspent(struct bitcoind *bitcoind,
 		u64 serial;
 
 		if (!psbt_get_serial_id(&pv->psbt->inputs[i].unknowns, &serial)) {
-			err = tal_fmt(pv, "PSBT input at index %"PRIu64
+			err = tal_fmt(pv, "PSBT input at index %zu"
 				      " missing serial id", i);
 			pv->invalid_input(pv, err);
 			return;


### PR DESCRIPTION
This fixes the following compilation error
and allow rebuilding again on 32-bit platform.

```
lightningd/dual_open_control.c: In function 'validate_input_unspent':
lightningd/dual_open_control.c:2627:43: error: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'size_t' {aka 'unsigned int'} [-Werror=format=]
 2627 |                         err = tal_fmt(pv, "PSBT input at index %"PRIu64
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~
 2628 |                                       " missing serial id", i);
      |                                                             ~
      |                                                             |
      |                                                             size_t {aka unsigned int}
ccan/ccan/tal/str/str.h:43:46: note: in definition of macro 'tal_fmt'
   43 |         tal_fmt_(ctx, TAL_LABEL(char, "[]"), __VA_ARGS__)
      |                                              ^~~~~~~~~~~

```

PS: apparently I'm the only remaining people that ran cln on an old raspberry pi 2?

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>