### PR TITLE
Fix channel resurrection where a channel update is missing

### DIFF
--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1524,7 +1524,8 @@ bool routing_add_channel_update(struct routing_state *rstate,
 	/* Handle resurrection of zombie channels if the other side of the
 	 * zombie channel has a recent timestamp. */
 	if (zombie && timestamp_reasonable(rstate,
-		chan->half[!direction].bcast.timestamp)) {
+		chan->half[!direction].bcast.timestamp) &&
+		chan->half[!direction].bcast.index) {
 		status_peer_debug(peer ? &peer->id : NULL,
 				  "Resurrecting zombie channel %s.",
 				  type_to_string(tmpctx,


### PR DESCRIPTION
As reported by @whitslack a channel_update is retrieved which appears to have already been deleted.  Check that it exists before resurrecting!

Fixes #5989

Changelog-None