### PR TITLE
pytest: allow ipv6 in test_announce_dns_suppressed

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -179,7 +179,7 @@ def test_announce_dns_suppressed(node_factory, bitcoind):
 
     addresses = only_one(l2.rpc.listnodes(l1.info['id'])['nodes'])['addresses']
     assert len(addresses) == 1
-    assert addresses[0]['type'] == 'ipv4'
+    assert addresses[0]['type'] in ['ipv4', 'ipv6']
     assert addresses[0]['address'] != 'example.com'
     assert addresses[0]['port'] == 1236
 


### PR DESCRIPTION
The test runs fine on CI but can fail locally on IPv6 systems, as the address descriptor is just checked agains IPv4.

Changelog-None