### PR TITLE
test_backfill_scriptpubkeys: stop first cln node before second sub-test

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -291,6 +291,8 @@ def test_backfill_scriptpubkeys(node_factory, bitcoind):
         }
     ]
 
+    l1.stop()
+
     l2 = node_factory.get_node(node_id=3, dbfile='pubkey_regen_commitment_point.sqlite3.xz',
                                options={'database-upgrade': True})
     results = l2.db_query('SELECT hex(prev_out_tx) AS txid, hex(scriptpubkey) AS script FROM outputs')


### PR DESCRIPTION
Should resolve https://github.com/ElementsProject/lightning/issues/5909 , pretty sure the test harness just loses track of the other CLN node.

Also pushed a commit that adds a fixture that runs checks between every test looking for leaked processes and fds.