### PR TITLE
Fix zombie node_announcement handling

### DIFF
--- a/devtools/dump-gossipstore.c
+++ b/devtools/dump-gossipstore.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 		deleted = (flags & GOSSIP_STORE_DELETED_BIT);
 		push = (flags & GOSSIP_STORE_PUSH_BIT);
 		ratelimit = (flags & GOSSIP_STORE_RATELIMIT_BIT);
-		zombie = (msglen & GOSSIP_STORE_ZOMBIE_BIT);
+		zombie = (flags & GOSSIP_STORE_ZOMBIE_BIT);
 
 		msg = tal_arr(NULL, u8, msglen);
 		if (read(fd, msg, msglen) != msglen)

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -879,6 +879,13 @@ u32 gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 			stats[1]++;
 			break;
 		case WIRE_NODE_ANNOUNCEMENT:
+			/* In early v23.02 rcs we had zombie node announcements,
+			 * so throw them away here. */
+			if (be16_to_cpu(hdr.flags) & GOSSIP_STORE_ZOMBIE_BIT) {
+				status_unusual("gossip_store: removing zombie"
+					       " node_announcement from v23.02 rcs");
+				break;
+			}
 			if (!routing_add_node_announcement(rstate,
 							   take(msg), gs->len,
 							   NULL, NULL, spam)) {

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -696,13 +696,6 @@ void gossip_store_mark_cupdate_zombie(struct gossip_store *gs,
 	mark_zombie(gs, bcast, WIRE_CHANNEL_UPDATE);
 }
 
-/* Marks the length field of a node_announcement with the zombie flag bit */
-void gossip_store_mark_nannounce_zombie(struct gossip_store *gs,
-					struct broadcastable *bcast)
-{
-	mark_zombie(gs, bcast, WIRE_NODE_ANNOUNCEMENT);
-}
-
 const u8 *gossip_store_get(const tal_t *ctx,
 			   struct gossip_store *gs,
 			   u64 offset)

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -77,9 +77,6 @@ void gossip_store_mark_channel_zombie(struct gossip_store *gs,
 void gossip_store_mark_cupdate_zombie(struct gossip_store *gs,
 				      struct broadcastable *bcast);
 
-void gossip_store_mark_nannounce_zombie(struct gossip_store *gs,
-					struct broadcastable *bcast);
-
 /**
  * Direct store accessor: loads gossip msg back from store.
  *

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1774,9 +1774,7 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 
 	node = get_node(rstate, &node_id);
 
-	if (node == NULL
-	    || !node_has_broadcastable_channels(node)
-	    || is_node_zombie(node)) {
+	if (node == NULL || !node_has_broadcastable_channels(node)) {
 		struct pending_node_announce *pna;
 		/* BOLT #7:
 		 *

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -484,7 +484,7 @@ static void force_node_announce_rexmit(struct routing_state *rstate,
 						      node->rgraph.timestamp,
 						      is_local,
 						      false,
-						      false,
+						      true,
 						      NULL);
 	}
 }

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1816,9 +1816,12 @@ bool routing_add_node_announcement(struct routing_state *rstate,
 		if (!pna) {
 			if (was_unknown)
 				*was_unknown = true;
-			bad_gossip_order(msg, peer,
-					 type_to_string(tmpctx, struct node_id,
-							&node_id));
+			/* Don't complain if it's a zombie node! */
+			if (!node || !is_node_zombie(node)) {
+				bad_gossip_order(msg, peer,
+						 type_to_string(tmpctx, struct node_id,
+								&node_id));
+			}
 			return false;
 		} else if (timestamp <= pna->timestamp)
 			/* Ignore old ones: they're OK (unless from store). */

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -424,8 +424,10 @@ static bool node_has_broadcastable_channels(struct node *node)
 	for (c = first_chan(node, &i); c; c = next_chan(node, &i)) {
 		if (!is_chan_public(c))
 			continue;
-		if ((is_halfchan_defined(&c->half[0])
-		    || is_halfchan_defined(&c->half[1])) && !is_chan_zombie(c))
+		if (is_chan_zombie(c))
+			continue;
+		if (is_halfchan_defined(&c->half[0])
+		    || is_halfchan_defined(&c->half[1]))
 			return true;
 	}
 	return false;

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -416,7 +416,7 @@ static bool is_node_zombie(struct node* node)
 
 /* We can *send* a channel_announce for a channel attached to this node:
  * we only send once we have a channel_update. */
-static bool node_has_broadcastable_channels(struct node *node)
+bool node_has_broadcastable_channels(const struct node *node)
 {
 	struct chan_map_iter i;
 	struct chan *c;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -434,6 +434,9 @@ bool would_ratelimit_cupdate(struct routing_state *rstate,
 			     const struct half_chan *hc,
 			     u32 timestamp);
 
+/* Does this node have public, non-zombie channels? */
+bool node_has_broadcastable_channels(const struct node *node);
+
 /* Returns an error string if there are unfinalized entries after load */
 const char *unfinalized_entries(const tal_t *ctx, struct routing_state *rstate);
 

--- a/gossipd/test/run-check_channel_announcement.c
+++ b/gossipd/test/run-check_channel_announcement.c
@@ -94,10 +94,6 @@ void gossip_store_mark_channel_zombie(struct gossip_store *gs UNNEEDED,
 void gossip_store_mark_cupdate_zombie(struct gossip_store *gs UNNEEDED,
 				      struct broadcastable *bcast UNNEEDED)
 { fprintf(stderr, "gossip_store_mark_cupdate_zombie called!\n"); abort(); }
-/* Generated stub for gossip_store_mark_nannounce_zombie */
-void gossip_store_mark_nannounce_zombie(struct gossip_store *gs UNNEEDED,
-					struct broadcastable *bcast UNNEEDED)
-{ fprintf(stderr, "gossip_store_mark_nannounce_zombie called!\n"); abort(); }
 /* Generated stub for gossip_store_new */
 struct gossip_store *gossip_store_new(struct routing_state *rstate UNNEEDED,
 				      struct list_head *peers UNNEEDED)

--- a/gossipd/test/run-check_node_announcement.c
+++ b/gossipd/test/run-check_node_announcement.c
@@ -68,6 +68,9 @@ struct oneshot *new_reltimer_(struct timers *timers UNNEEDED,
 			      struct timerel expire UNNEEDED,
 			      void (*cb)(void *) UNNEEDED, void *arg UNNEEDED)
 { fprintf(stderr, "new_reltimer_ called!\n"); abort(); }
+/* Generated stub for node_has_broadcastable_channels */
+bool node_has_broadcastable_channels(const struct node *node UNNEEDED)
+{ fprintf(stderr, "node_has_broadcastable_channels called!\n"); abort(); }
 /* Generated stub for queue_peer_msg */
 void queue_peer_msg(struct peer *peer UNNEEDED, const u8 *msg TAKES UNNEEDED)
 { fprintf(stderr, "queue_peer_msg called!\n"); abort(); }

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -94,6 +94,9 @@ struct oneshot *new_reltimer_(struct timers *timers UNNEEDED,
 			      struct timerel expire UNNEEDED,
 			      void (*cb)(void *) UNNEEDED, void *arg UNNEEDED)
 { fprintf(stderr, "new_reltimer_ called!\n"); abort(); }
+/* Generated stub for node_has_broadcastable_channels */
+bool node_has_broadcastable_channels(const struct node *node UNNEEDED)
+{ fprintf(stderr, "node_has_broadcastable_channels called!\n"); abort(); }
 /* Generated stub for peer_supplied_good_gossip */
 void peer_supplied_good_gossip(struct peer *peer UNNEEDED, size_t amount UNNEEDED)
 { fprintf(stderr, "peer_supplied_good_gossip called!\n"); abort(); }

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -65,10 +65,6 @@ void gossip_store_mark_channel_zombie(struct gossip_store *gs UNNEEDED,
 void gossip_store_mark_cupdate_zombie(struct gossip_store *gs UNNEEDED,
 				      struct broadcastable *bcast UNNEEDED)
 { fprintf(stderr, "gossip_store_mark_cupdate_zombie called!\n"); abort(); }
-/* Generated stub for gossip_store_mark_nannounce_zombie */
-void gossip_store_mark_nannounce_zombie(struct gossip_store *gs UNNEEDED,
-					struct broadcastable *bcast UNNEEDED)
-{ fprintf(stderr, "gossip_store_mark_nannounce_zombie called!\n"); abort(); }
 /* Generated stub for memleak_add_helper_ */
 void memleak_add_helper_(const tal_t *p UNNEEDED, void (*cb)(struct htable *memtable UNNEEDED,
 						    const tal_t *)){ }


### PR DESCRIPTION
This does some cleanups: by getting rid of node_announcements associated with all-zombie nodes, it should fix the underlying issue, too.

Changelog-None (fixes within this release cycle)