### PR TITLE
Report failure to sign psbt inputs by hsmd

### DIFF
--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -496,7 +496,7 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 					    sizeof(privkey.secret.data),
 					    EC_FLAG_GRIND_R) != WALLY_OK) {
 				tal_wally_end(psbt);
-				hsmd_status_broken(
+				hsmd_status_failed(STATUS_FAIL_INTERNAL_ERROR,
 				    "Received wally_err attempting to "
 				    "sign utxo with key %s. PSBT: %s",
 				    type_to_string(tmpctx, struct pubkey,


### PR DESCRIPTION
Currently the failure prints a log and hangs forever; I suspect that isn't the intention.

N.B. `hsmd_status_broken` is only used here so it may be vestigial? 