### PR TITLE
Output `channel_id` in `listfunds`

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -600,6 +600,7 @@
         },
         "ListfundsChannels": {
             "ListFunds.channels[].amount_msat": 3,
+            "ListFunds.channels[].channel_id": 9,
             "ListFunds.channels[].connected": 6,
             "ListFunds.channels[].funding_output": 5,
             "ListFunds.channels[].funding_txid": 4,

--- a/cln-grpc/proto/node.proto
+++ b/cln-grpc/proto/node.proto
@@ -306,6 +306,7 @@ message ListfundsChannels {
 	uint32 funding_output = 5;
 	bool connected = 6;
 	ChannelState state = 7;
+	bytes channel_id = 9;
 	optional string short_channel_id = 8;
 }
 

--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -265,6 +265,7 @@ impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
             funding_output: c.funding_output, // Rule #2 for type u32
             connected: c.connected, // Rule #2 for type boolean
             state: c.state as i32,
+            channel_id: c.channel_id.to_vec(), // Rule #2 for type hash
             short_channel_id: c.short_channel_id.map(|v| v.to_string()), // Rule #2 for type short_channel_id?
         }
     }
@@ -2606,6 +2607,7 @@ impl From<pb::ListfundsChannels> for responses::ListfundsChannels {
             funding_output: c.funding_output, // Rule #1 for type u32
             connected: c.connected, // Rule #1 for type boolean
             state: c.state.try_into().unwrap(),
+            channel_id: Sha256::from_slice(&c.channel_id).unwrap(), // Rule #1 for type hash
             short_channel_id: c.short_channel_id.map(|v| cln_rpc::primitives::ShortChannelId::from_str(&v).unwrap()), // Rule #1 for type short_channel_id?
         }
     }

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1818,6 +1818,7 @@ pub mod responses {
 	    pub connected: bool,
 	    // Path `ListFunds.channels[].state`
 	    pub state: ChannelState,
+	    pub channel_id: Sha256,
 	    #[serde(skip_serializing_if = "Option::is_none")]
 	    pub short_channel_id: Option<ShortChannelId>,
 	}

--- a/contrib/pyln-testing/pyln/testing/grpc2py.py
+++ b/contrib/pyln-testing/pyln/testing/grpc2py.py
@@ -223,6 +223,7 @@ def listfunds_channels2py(m):
         "funding_output": m.funding_output,  # PrimitiveField in generate_composite
         "connected": m.connected,  # PrimitiveField in generate_composite
         "state": str(m.state),  # EnumField in generate_composite
+        "channel_id": hexlify(m.channel_id),  # PrimitiveField in generate_composite
         "short_channel_id": m.short_channel_id,  # PrimitiveField in generate_composite
     })
 

--- a/doc/lightning-listfunds.7.md
+++ b/doc/lightning-listfunds.7.md
@@ -47,6 +47,7 @@ On success, an object is returned, containing:
   - **funding\_output** (u32): the 0-based index of the output in the funding transaction
   - **connected** (boolean): whether the channel peer is connected
   - **state** (string): the channel state, in particular "CHANNELD\_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
+  - **channel\_id** (hash): The full channel\_id (funding txid Xored with output number) *(added v23.02)*
 
   If **state** is "CHANNELD\_NORMAL":
 
@@ -73,4 +74,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:3282d4025e161d6926878a5fc8d78384784885749630f007cc5dfcd8d2794b10)
+[comment]: # ( SHA256STAMP:ae6228c9cc323e0b6486eb4d2695105b087e98770763c6f9e5af3b888fa9520f)

--- a/doc/schemas/listfunds.schema.json
+++ b/doc/schemas/listfunds.schema.json
@@ -143,7 +143,8 @@
           "funding_txid",
           "funding_output",
           "connected",
-          "state"
+          "state",
+          "channel_id"
         ],
         "properties": {
           "peer_id": {
@@ -186,6 +187,11 @@
               "DUALOPEND_AWAITING_LOCKIN"
             ],
             "description": "the channel state, in particular \"CHANNELD_NORMAL\" means the channel can be used normally"
+          },
+          "channel_id": {
+            "type": "hash",
+            "description": "The full channel_id (funding txid Xored with output number)",
+            "added": "v23.05"
           }
         },
         "allOf": [
@@ -215,6 +221,7 @@
                 "funding_output": {},
                 "connected": {},
                 "state": {},
+                "channel_id": {},
                 "short_channel_id": {
                   "type": "short_channel_id",
                   "description": "short channel id of channel"
@@ -251,6 +258,7 @@
                 "funding_output": {},
                 "connected": {},
                 "state": {},
+                "channel_id": {},
                 "short_channel_id": {
                   "type": "short_channel_id",
                   "description": "short channel id of channel (only if funding reached lockin depth before closing)"

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -355,6 +355,7 @@ static struct command_result *json_listfunds(struct command *cmd,
 				      channel_is_connected(c));
 			json_add_string(response, "state",
 					channel_state_name(c));
+			json_add_channel_id(response, "channel_id", &c->cid);
 			if (c->scid)
 				json_add_short_channel_id(response,
 							  "short_channel_id",


### PR DESCRIPTION
See #6020 for context. This is useful, makes more easy use of `dev-forget-channel` to remove channels with no transaction in a blockchain (`CHANNELD_AWAITING_LOCKIN` in my case), can give `channel_id` argument.

Changelog-None