### PR TITLE
keysend: Do not strip TLV types that were allowlisted in `lightningd`

### DIFF
--- a/common/json_parse.h
+++ b/common/json_parse.h
@@ -114,6 +114,9 @@ bool json_to_channel_id(const char *buffer, const jsmntok_t *tok,
 bool json_to_coin_mvt_tag(const char *buffer, const jsmntok_t *tok,
 			  enum mvt_tag *tag);
 
+/* Read a JSON value into an array of u64 */
+bool json_to_uintarr(const char *buffer, const jsmntok_t *tok, u64 **dest);
+
 /* Extract reply path from this JSON */
 struct blinded_path *
 json_to_blinded_path(const tal_t *ctx, const char *buffer, const jsmntok_t *tok);

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -331,6 +331,15 @@ static int tlvfield_cmp(const struct tlv_field *a,
 	return 0;
 }
 
+/* Check to see if a given TLV type is in the allowlist. */
+static bool keysend_accept_extra_tlv_type(u64 type)
+{
+	for (size_t i=0; i<tal_count(accepted_extra_tlvs); i++)
+		if (type == accepted_extra_tlvs[i])
+			return true;
+	return false;
+}
+
 static struct command_result *
 htlc_accepted_invoice_created(struct command *cmd, const char *buf,
 			      const jsmntok_t *result,
@@ -347,6 +356,9 @@ htlc_accepted_invoice_created(struct command *cmd, const char *buf,
 			continue;
 		/* Same with known fields */
 		if (ki->payload->fields[i].meta)
+			continue;
+		/* If the type was explicitly allowed pass it through. */
+		if (keysend_accept_extra_tlv_type(ki->payload->fields[i].numtype))
 			continue;
 		/* Complain about it, at least. */
 		if (ki->preimage_field != &ki->payload->fields[i]) {

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -583,6 +583,14 @@ static const jsmntok_t *sync_req(const tal_t *ctx,
 	return contents;
 }
 
+const jsmntok_t *jsonrpc_request_sync(const tal_t *ctx, struct plugin *plugin,
+				      const char *method,
+				      const struct json_out *params TAKES,
+				      const char **resp)
+{
+	return sync_req(ctx, plugin, method, params, resp);
+}
+
 /* Returns contents of scanning guide on 'result' */
 static const char *rpc_scan_core(const tal_t *ctx,
 				 struct plugin *plugin,

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -478,4 +478,11 @@ void plugin_set_memleak_handler(struct plugin *plugin,
 						 struct htable *memtable));
 #endif /* DEVELOPER */
 
+/* Synchronously call a JSON-RPC method and return its contents and
+ * the parser token. */
+const jsmntok_t *jsonrpc_request_sync(const tal_t *ctx, struct plugin *plugin,
+				      const char *method,
+				      const struct json_out *params TAKES,
+				      const char **resp);
+
 #endif /* LIGHTNING_PLUGINS_LIBPLUGIN_H */


### PR DESCRIPTION
This is a followup on https://github.com/ElementsProject/lightning/pull/5645 which started stripping TLV fields that have an unknown even TLV type, which is correct.

However we also have an allowlist facility in the form of `--accept-extra-tlv-types` that tells `lightningd` that some unknown TLV types can be accepted despite not knowing their semantics. This allows simpler composition of functionality since `keysend` still handles the common functionality of accepting, backfilling the invoice and resolving a payment, while others (plugins or apps) can rely on the `invoice_payment` hook to extract those types. This is for example how Sphinx is implemented.