### PR TITLE
[PATCH] do not send send peerstorage msg when disabled

### DIFF
--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -346,6 +346,9 @@ static struct command_result *peer_after_listdatastore(struct command *cmd,
         	return command_hook_success(cmd);
         struct out_req *req;
 
+	if (!peer_backup)
+		return command_hook_success(cmd);
+
         u8 *payload = towire_your_peer_storage(cmd, hexdata);
 
         plugin_log(cmd->plugin, LOG_DBG,
@@ -443,7 +446,7 @@ static struct command_result *after_listpeers(struct command *cmd,
 		json_to_bool(buf, json_get_member(buf, peer, "connected"),
 			     &is_connected);
 
-		if (is_connected) {
+		if (is_connected && peer_backup) {
 			const jsmntok_t *nodeid;
 			struct node_id node_id;
 


### PR DESCRIPTION
This commit will disable the peer-storage plugins
when the feature is not enabled.

I found this issue with lnprototest, and I guess
we did not find it with a normal run because
other the unknown messages are ignored?

I did a monkey fix, please @adi2011 check the sanity of my patch

Changelog-Fixed: Disable the protocol messages when peerstorage is disabled.