### PR TITLE
fix: increment the timer when we create it and not when we call

### DIFF
--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1317,7 +1317,6 @@ static void call_plugin_timer(struct plugin *p, struct timer *timer)
 {
 	struct plugin_timer *t = container_of(timer, struct plugin_timer, timer);
 
-	p->in_timer++;
 	/* Free this if they don't. */
 	tal_steal(tmpctx, t);
 	t->cb(t->cb_arg);
@@ -1338,6 +1337,7 @@ struct plugin_timer *plugin_timer_(struct plugin *p, struct timerel t,
 	timer_init(&timer->timer);
 	timer_addrel(&p->timers, &timer->timer, t);
 	tal_add_destructor2(timer, destroy_plugin_timer, p);
+	p->in_timer++;
 	return timer;
 }
 


### PR DESCRIPTION
I guess we increment the `in_timer` in the wrong place because each time that we add inside the list is sure that will run inside the plugin loop? 

but not sure what `in_timers` means in this case I did not find any comment for it? Does it keep track of all the timer created or all the timer that is running?

cc @rustyrussell 

Fixes https://github.com/ElementsProject/lightning/issues/5912

To proof correctness lets see if the CI fails wit some related error