### PR TITLE
route: assume both directions disabled

### DIFF
--- a/common/route.c
+++ b/common/route.c
@@ -25,7 +25,7 @@ bool route_can_carry(const struct gossmap *map,
 		       struct amount_msat amount,
 		       void *arg)
 {
-	if (!c->half[dir].enabled)
+	if (!c->half[0].enabled || !c->half[1].enabled)
 		return false;
 	return route_can_carry_even_disabled(map, c, dir, amount, arg);
 }


### PR DESCRIPTION
Usually/Often a channel only gets disabled in one direction. This is because the offline node does not send a channel disabled update. This change takes that into account on initial route finding.

Currently, out of all ~150k mainnet  half-channels, there are `21533` disabled half-channels (~15%). But `6670` channels are only disabled in one direction and `1280` channels are disabled in both directions. This means, explainable, that its often the case a channel is disabled only in one direction, because the peer that went offline does not or can't send an disabled update.

Note: The missing gap of `6670 + 2*1280 < 21533`  is caused by the way my code counted it for channels that have been offline for longer time and only known in one direction. I checked that.  This means we have a total of `21533 - 2*1280 = 18973` or at least `6670` half-channels that are only disabled in one direction, depending on if channels are included that are only known in one direction.

Since both numbers are not small, and the probability to include a offline but enabled channel increases the longer the route is, I think we try a significant number of routes that are deemed to fail anyway. 