### PR TITLE
cln_plugin: exit process when stdin disconnects

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -588,7 +588,8 @@ where
                 }
             }
             Some(Err(e)) => Err(anyhow!("Error reading command: {}", e)),
-            None => Err(anyhow!("Error reading from master")),
+            // Connection to CLN over STDIN has disconnected, so we exit
+            None => std::process::exit(0),
         }
     }
 


### PR DESCRIPTION
What exit code is best here?

It would also be nice to be able to give the plugin an `on_shutdown` callback:
* Perhaps it would get exercised here and whenever the plugin receives a `shutdown` notification?
* Perhaps right here I could just look for a `shutdown` notification handler and just call it? 
* Or maybe these should be 2 different things?