### PR TITLE
cln_plugin: run `cargo fmt`

### DIFF
--- a/plugins/src/codec.rs
+++ b/plugins/src/codec.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use std::{io, str};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::messages::{Notification, Request};
 use crate::messages::JsonRpc;
+use crate::messages::{Notification, Request};
 
 /// A simple codec that parses messages separated by two successive
 /// `\n` newlines.

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -322,7 +322,7 @@ where
             hooks: self.hooks.keys().map(|s| s.clone()).collect(),
             rpcmethods,
             dynamic: self.dynamic,
-	    nonnumericids: true,
+            nonnumericids: true,
         }
     }
 
@@ -458,8 +458,8 @@ where
         // Start the PluginDriver to handle plugin IO
         tokio::spawn(async move {
             if let Err(e) = driver.run(receiver, input, output).await {
-		log::warn!("Plugin loop returned error {:?}", e);
-	    }
+                log::warn!("Plugin loop returned error {:?}", e);
+            }
 
             // Now that we have left the reader loop its time to
             // notify any waiting tasks. This most likely will cause
@@ -526,17 +526,17 @@ where
             // the user-code, which may require some cleanups or
             // similar.
             tokio::select! {
-                e = self.dispatch_one(&mut input, &self.plugin) => {
-                    if let Err(e) = e {
-			return Err(e)
-                    }
-		},
-		v = receiver.recv() => {
-                    output.lock().await.send(
-			v.context("internal communication error")?
-                    ).await?;
-		},
-            }
+                    e = self.dispatch_one(&mut input, &self.plugin) => {
+                        if let Err(e) = e {
+                return Err(e)
+                        }
+            },
+            v = receiver.recv() => {
+                        output.lock().await.send(
+                v.context("internal communication error")?
+                        ).await?;
+            },
+                }
         }
     }
 
@@ -706,7 +706,7 @@ mod test {
 
     #[tokio::test]
     async fn init() {
-	let state = ();
+        let state = ();
         let builder = Builder::new(tokio::io::stdin(), tokio::io::stdout());
         let _ = builder.start(state);
     }

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -41,20 +41,20 @@ pub(crate) enum Request {
 #[serde(tag = "method", content = "params")]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Notification {
-//     ChannelOpened,
-//     ChannelOpenFailed,
-//     ChannelStateChanged,
-//     Connect,
-//     Disconnect,
-//     InvoicePayment,
-//     InvoiceCreation,
-//     Warning,
-//     ForwardEvent,
-//     SendpaySuccess,
-//     SendpayFailure,
-//     CoinMovement,
-//     OpenchannelPeerSigs,
-//     Shutdown,
+    //     ChannelOpened,
+    //     ChannelOpenFailed,
+    //     ChannelStateChanged,
+    //     Connect,
+    //     Disconnect,
+    //     InvoicePayment,
+    //     InvoiceCreation,
+    //     Warning,
+    //     ForwardEvent,
+    //     SendpaySuccess,
+    //     SendpayFailure,
+    //     CoinMovement,
+    //     OpenchannelPeerSigs,
+    //     Shutdown,
 }
 
 #[derive(Deserialize, Debug)]

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -28,7 +28,7 @@ impl Value {
             _ => None,
         }
     }
-    
+
     /// Returns true if the `Value` is an integer between `i64::MIN` and
     /// `i64::MAX`.
     ///
@@ -36,8 +36,6 @@ impl Value {
     /// return the integer value.
     pub fn is_i64(&self) -> bool {
         self.as_i64().is_some()
-            
-        
     }
 
     /// If the `Value` is an integer, represent it as i64. Returns


### PR DESCRIPTION
When I was working on #6036, I had to disable the `cargo fmt` on-save in my editor because would make all these unrelated changes.

Ideally CI would check that `cargo fmt` wouldn't change anything so this stays up-to-date.