### PR TITLE
cln_plugin: add `shutdown()` method to `Plugin`

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -691,12 +691,21 @@ impl<S> Plugin<S>
 where
     S: Send + Clone,
 {
+    /// Wait for plugin shutdown
     pub async fn join(&self) -> Result<(), Error> {
         self.wait_handle
             .subscribe()
             .recv()
             .await
             .context("error waiting for shutdown")
+    }
+
+    /// Request plugin shutdown
+    pub fn shutdown(&self) -> Result<(), Error> {
+        self.wait_handle
+            .send(())
+            .context("error waiting for shutdown")?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This helps avoid a pain-point where [plugin authors need to do shutdown-related cleanup in 2 places](https://github.com/ElementsProject/lightning/issues/6040). Now plugins can just call `plugin.shutdown()` when they receive "shutdown" notification, and do all cleanup in that one place when `plugin.join()` is triggered.

Changelog-None