### PR TITLE
pay: fix delpay to actually delete.

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1702,7 +1702,7 @@ static struct command_result *json_delpay(struct command *cmd,
 				    "No payment for that payment_hash with that partid and groupid");
 	}
 
-	wallet_payment_delete(cmd->ld->wallet, payment_hash, partid, groupid);
+	wallet_payment_delete(cmd->ld->wallet, payment_hash, groupid, partid);
 
 	response = json_stream_success(cmd);
 	json_array_start(response, "payments");


### PR DESCRIPTION
It works for the trivial case, where groupid and partid are the same, but silently deletes nothing in the other cases (or worse, deletes the wrong entry!).

See: #5835
Changelog-Fixed: `delpay`: actually delete the specified payment (mainly found by `autoclean`).