### PR TITLE
Zombie channel patch

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -884,7 +884,7 @@ u32 gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 		case WIRE_NODE_ANNOUNCEMENT:
 			/* In early v23.02 rcs we had zombie node announcements,
 			 * so throw them away here. */
-			if (be16_to_cpu(hdr.flags) & GOSSIP_STORE_ZOMBIE_BIT) {
+			if (zombie) {
 				status_unusual("gossip_store: removing zombie"
 					       " node_announcement from v23.02 rcs");
 				break;

--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -370,7 +370,8 @@ bool routing_add_channel_update(struct routing_state *rstate,
 				u32 index,
 				struct peer *peer,
 				bool ignore_timestamp,
-				bool force_spam_flag);
+				bool force_spam_flag,
+				bool force_zombie_flag);
 /**
  * Add a node_announcement to the network view without checking it
  *


### PR DESCRIPTION
As reported by @m-schmoock, some nodes and channels went missing from the gossmap while running 23.02rc3.  This occurred after restarting the node, which possibly lost some state on the zombie channels.

Changelog-None