### PR TITLE
.gitignore: Add external/*-linux-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ bionic/
 focal/
 jammy/
 release/
+external/*-linux-*


### PR DESCRIPTION
This directory is re-used on systems doing CI, but without ignoring it adds "-modded" to the version, which is misleading.

Changelog-None