### PR TITLE
gossipd: don't send zombie node announcements, load from store correctly

### DIFF
--- a/gossipd/routing.h
+++ b/gossipd/routing.h
@@ -72,6 +72,11 @@ void free_chan(struct routing_state *rstate, struct chan *chan);
  * to indicate this. */
 static inline bool is_chan_public(const struct chan *chan)
 {
+	/* When loading from the gossip_store, zombie channels may also
+	 * temporarily be in the unannounced channel list. However, only public
+	 * channels may be zombies. */
+	if (chan->half[0].zombie || chan->half[1].zombie)
+		return true;
 	return chan->bcast.timestamp != 0;
 }
 


### PR DESCRIPTION
This addresses two issues with gossipd:

Node announcements were mistakenly broadcast for zombie channels (but not the update.)

Zombie flagged channels were mistaken for private channels and ignored during loading, leaving behind the original. This leads to problems for gossip store consumers and during gossip store reloading.

Changelog-Fixed: gossipd: no longer broadcasts node_announcement without update.
Changelog-Fixed: gossip_store: no longer corrupted by failure to load channel announcement.