### PR TITLE
wallet: really allow broken migrations.

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1532,8 +1532,8 @@ static void migrate_channels_scids_as_integers(struct lightningd *ld,
 	}
 
 	if (changes != tal_count(scids))
-		fatal("migrate_channels_scids_as_integers: only converted %zu of %zu scids!",
-		      changes, tal_count(scids));
+		log_broken(ld->log, "migrate_channels_scids_as_integers: only converted %zu of %zu scids!",
+			   changes, tal_count(scids));
 
 	/* FIXME: We cannot use ->delete_columns to remove
 	 * short_channel_id, as other tables reference the channels


### PR DESCRIPTION
e778ebb9af5a6157a4b605a77f87b2c48b9d03b0 ("wallet: only log broken if we have duplicate scids in channels.") downgraded the fatal() to a broken log message, but the user reports it still won't start up.

Perhaps they're hitting the fatal() outside the loop?  (And we're not getting that output).

Maybe-fixes: #6063 ?