### PR TITLE
grpc: Adjust the file permissions on mTLS private keys

### DIFF
--- a/cln-grpc/src/convert.rs
+++ b/cln-grpc/src/convert.rs
@@ -12,7 +12,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use cln_rpc::primitives::PublicKey;
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetinfoOur_features> for pb::GetinfoOurFeatures {
     fn from(c: responses::GetinfoOur_features) -> Self {
         Self {
@@ -24,7 +24,7 @@ impl From<responses::GetinfoOur_features> for pb::GetinfoOurFeatures {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
     fn from(c: responses::GetinfoAddress) -> Self {
         Self {
@@ -35,7 +35,7 @@ impl From<responses::GetinfoAddress> for pb::GetinfoAddress {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetinfoBinding> for pb::GetinfoBinding {
     fn from(c: responses::GetinfoBinding) -> Self {
         Self {
@@ -47,7 +47,7 @@ impl From<responses::GetinfoBinding> for pb::GetinfoBinding {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
     fn from(c: responses::GetinfoResponse) -> Self {
         Self {
@@ -66,15 +66,15 @@ impl From<responses::GetinfoResponse> for pb::GetinfoResponse {
             #[allow(deprecated)]
             msatoshi_fees_collected: c.msatoshi_fees_collected, // Rule #2 for type u64?
             fees_collected_msat: Some(c.fees_collected_msat.into()), // Rule #2 for type msat
-            address: c.address.into_iter().map(|i| i.into()).collect(), // Rule #3 for type GetinfoAddress 
-            binding: c.binding.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            address: c.address.into_iter().map(|i| i.into()).collect(), // Rule #3 for type GetinfoAddress
+            binding: c.binding.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             warning_bitcoind_sync: c.warning_bitcoind_sync, // Rule #2 for type string?
             warning_lightningd_sync: c.warning_lightningd_sync, // Rule #2 for type string?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersLog> for pb::ListpeersPeersLog {
     fn from(c: responses::ListpeersPeersLog) -> Self {
         Self {
@@ -89,7 +89,7 @@ impl From<responses::ListpeersPeersLog> for pb::ListpeersPeersLog {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannelsFeerate> for pb::ListpeersPeersChannelsFeerate {
     fn from(c: responses::ListpeersPeersChannelsFeerate) -> Self {
         Self {
@@ -99,7 +99,7 @@ impl From<responses::ListpeersPeersChannelsFeerate> for pb::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannelsInflight> for pb::ListpeersPeersChannelsInflight {
     fn from(c: responses::ListpeersPeersChannelsInflight) -> Self {
         Self {
@@ -113,7 +113,7 @@ impl From<responses::ListpeersPeersChannelsInflight> for pb::ListpeersPeersChann
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannelsFunding> for pb::ListpeersPeersChannelsFunding {
     fn from(c: responses::ListpeersPeersChannelsFunding) -> Self {
         Self {
@@ -130,7 +130,7 @@ impl From<responses::ListpeersPeersChannelsFunding> for pb::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannelsAlias> for pb::ListpeersPeersChannelsAlias {
     fn from(c: responses::ListpeersPeersChannelsAlias) -> Self {
         Self {
@@ -140,7 +140,7 @@ impl From<responses::ListpeersPeersChannelsAlias> for pb::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannelsHtlcs> for pb::ListpeersPeersChannelsHtlcs {
     fn from(c: responses::ListpeersPeersChannelsHtlcs) -> Self {
         Self {
@@ -155,7 +155,7 @@ impl From<responses::ListpeersPeersChannelsHtlcs> for pb::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
     fn from(c: responses::ListpeersPeersChannels) -> Self {
         Self {
@@ -171,12 +171,12 @@ impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
             last_feerate: c.last_feerate, // Rule #2 for type string?
             next_feerate: c.next_feerate, // Rule #2 for type string?
             next_fee_step: c.next_fee_step, // Rule #2 for type u32?
-            inflight: c.inflight.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            inflight: c.inflight.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             close_to: c.close_to.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             private: c.private, // Rule #2 for type boolean?
             opener: c.opener as i32,
             closer: c.closer.map(|v| v as i32),
-            features: c.features.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpeersPeersChannelsFeatures 
+            features: c.features.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpeersPeersChannelsFeatures
             funding: c.funding.map(|v| v.into()),
             to_us_msat: c.to_us_msat.map(|f| f.into()), // Rule #2 for type msat?
             min_to_us_msat: c.min_to_us_msat.map(|f| f.into()), // Rule #2 for type msat?
@@ -197,7 +197,7 @@ impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
             our_to_self_delay: c.our_to_self_delay, // Rule #2 for type u32?
             max_accepted_htlcs: c.max_accepted_htlcs, // Rule #2 for type u32?
             alias: c.alias.map(|v| v.into()),
-            status: c.status.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            status: c.status.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             in_payments_offered: c.in_payments_offered, // Rule #2 for type u64?
             in_offered_msat: c.in_offered_msat.map(|f| f.into()), // Rule #2 for type msat?
             in_payments_fulfilled: c.in_payments_fulfilled, // Rule #2 for type u64?
@@ -206,38 +206,38 @@ impl From<responses::ListpeersPeersChannels> for pb::ListpeersPeersChannels {
             out_offered_msat: c.out_offered_msat.map(|f| f.into()), // Rule #2 for type msat?
             out_payments_fulfilled: c.out_payments_fulfilled, // Rule #2 for type u64?
             out_fulfilled_msat: c.out_fulfilled_msat.map(|f| f.into()), // Rule #2 for type msat?
-            htlcs: c.htlcs.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            htlcs: c.htlcs.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             close_to_addr: c.close_to_addr, // Rule #2 for type string?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersPeers> for pb::ListpeersPeers {
     fn from(c: responses::ListpeersPeers) -> Self {
         Self {
             id: c.id.serialize().to_vec(), // Rule #2 for type pubkey
             connected: c.connected, // Rule #2 for type boolean
             num_channels: c.num_channels, // Rule #2 for type u32
-            log: c.log.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
-            channels: c.channels.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
-            netaddr: c.netaddr.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            log: c.log.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
+            channels: c.channels.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
+            netaddr: c.netaddr.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             remote_addr: c.remote_addr, // Rule #2 for type string?
             features: c.features.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpeersResponse> for pb::ListpeersResponse {
     fn from(c: responses::ListpeersResponse) -> Self {
         Self {
-            peers: c.peers.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpeersPeers 
+            peers: c.peers.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpeersPeers
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListfundsOutputs> for pb::ListfundsOutputs {
     fn from(c: responses::ListfundsOutputs) -> Self {
         Self {
@@ -254,7 +254,7 @@ impl From<responses::ListfundsOutputs> for pb::ListfundsOutputs {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
     fn from(c: responses::ListfundsChannels) -> Self {
         Self {
@@ -270,17 +270,17 @@ impl From<responses::ListfundsChannels> for pb::ListfundsChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListfundsResponse> for pb::ListfundsResponse {
     fn from(c: responses::ListfundsResponse) -> Self {
         Self {
-            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListfundsOutputs 
-            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListfundsChannels 
+            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListfundsOutputs
+            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListfundsChannels
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SendpayResponse> for pb::SendpayResponse {
     fn from(c: responses::SendpayResponse) -> Self {
         Self {
@@ -303,7 +303,7 @@ impl From<responses::SendpayResponse> for pb::SendpayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListchannelsChannels> for pb::ListchannelsChannels {
     fn from(c: responses::ListchannelsChannels) -> Self {
         Self {
@@ -327,16 +327,16 @@ impl From<responses::ListchannelsChannels> for pb::ListchannelsChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListchannelsResponse> for pb::ListchannelsResponse {
     fn from(c: responses::ListchannelsResponse) -> Self {
         Self {
-            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListchannelsChannels 
+            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListchannelsChannels
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::AddgossipResponse> for pb::AddgossipResponse {
     fn from(c: responses::AddgossipResponse) -> Self {
         Self {
@@ -344,7 +344,7 @@ impl From<responses::AddgossipResponse> for pb::AddgossipResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::AutocleaninvoiceResponse> for pb::AutocleaninvoiceResponse {
     fn from(c: responses::AutocleaninvoiceResponse) -> Self {
         Self {
@@ -355,7 +355,7 @@ impl From<responses::AutocleaninvoiceResponse> for pb::AutocleaninvoiceResponse 
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::CheckmessageResponse> for pb::CheckmessageResponse {
     fn from(c: responses::CheckmessageResponse) -> Self {
         Self {
@@ -365,7 +365,7 @@ impl From<responses::CheckmessageResponse> for pb::CheckmessageResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::CloseResponse> for pb::CloseResponse {
     fn from(c: responses::CloseResponse) -> Self {
         Self {
@@ -376,7 +376,7 @@ impl From<responses::CloseResponse> for pb::CloseResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ConnectAddress> for pb::ConnectAddress {
     fn from(c: responses::ConnectAddress) -> Self {
         Self {
@@ -388,7 +388,7 @@ impl From<responses::ConnectAddress> for pb::ConnectAddress {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ConnectResponse> for pb::ConnectResponse {
     fn from(c: responses::ConnectResponse) -> Self {
         Self {
@@ -400,7 +400,7 @@ impl From<responses::ConnectResponse> for pb::ConnectResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::CreateinvoiceResponse> for pb::CreateinvoiceResponse {
     fn from(c: responses::CreateinvoiceResponse) -> Self {
         Self {
@@ -422,11 +422,11 @@ impl From<responses::CreateinvoiceResponse> for pb::CreateinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::DatastoreResponse> for pb::DatastoreResponse {
     fn from(c: responses::DatastoreResponse) -> Self {
         Self {
-            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string 
+            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string
             generation: c.generation, // Rule #2 for type u64?
             hex: c.hex.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             string: c.string, // Rule #2 for type string?
@@ -434,21 +434,21 @@ impl From<responses::DatastoreResponse> for pb::DatastoreResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::CreateonionResponse> for pb::CreateonionResponse {
     fn from(c: responses::CreateonionResponse) -> Self {
         Self {
             onion: hex::decode(&c.onion).unwrap(), // Rule #2 for type hex
-            shared_secrets: c.shared_secrets.into_iter().map(|i| i.to_vec()).collect(), // Rule #3 for type secret 
+            shared_secrets: c.shared_secrets.into_iter().map(|i| i.to_vec()).collect(), // Rule #3 for type secret
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::DeldatastoreResponse> for pb::DeldatastoreResponse {
     fn from(c: responses::DeldatastoreResponse) -> Self {
         Self {
-            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string 
+            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string
             generation: c.generation, // Rule #2 for type u64?
             hex: c.hex.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             string: c.string, // Rule #2 for type string?
@@ -456,7 +456,7 @@ impl From<responses::DeldatastoreResponse> for pb::DeldatastoreResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::DelexpiredinvoiceResponse> for pb::DelexpiredinvoiceResponse {
     fn from(c: responses::DelexpiredinvoiceResponse) -> Self {
         Self {
@@ -464,7 +464,7 @@ impl From<responses::DelexpiredinvoiceResponse> for pb::DelexpiredinvoiceRespons
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::DelinvoiceResponse> for pb::DelinvoiceResponse {
     fn from(c: responses::DelinvoiceResponse) -> Self {
         Self {
@@ -482,7 +482,7 @@ impl From<responses::DelinvoiceResponse> for pb::DelinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::InvoiceResponse> for pb::InvoiceResponse {
     fn from(c: responses::InvoiceResponse) -> Self {
         Self {
@@ -499,11 +499,11 @@ impl From<responses::InvoiceResponse> for pb::InvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListdatastoreDatastore> for pb::ListdatastoreDatastore {
     fn from(c: responses::ListdatastoreDatastore) -> Self {
         Self {
-            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string 
+            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string
             generation: c.generation, // Rule #2 for type u64?
             hex: c.hex.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             string: c.string, // Rule #2 for type string?
@@ -511,16 +511,16 @@ impl From<responses::ListdatastoreDatastore> for pb::ListdatastoreDatastore {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListdatastoreResponse> for pb::ListdatastoreResponse {
     fn from(c: responses::ListdatastoreResponse) -> Self {
         Self {
-            datastore: c.datastore.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListdatastoreDatastore 
+            datastore: c.datastore.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListdatastoreDatastore
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListinvoicesInvoices> for pb::ListinvoicesInvoices {
     fn from(c: responses::ListinvoicesInvoices) -> Self {
         Self {
@@ -542,16 +542,16 @@ impl From<responses::ListinvoicesInvoices> for pb::ListinvoicesInvoices {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListinvoicesResponse> for pb::ListinvoicesResponse {
     fn from(c: responses::ListinvoicesResponse) -> Self {
         Self {
-            invoices: c.invoices.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListinvoicesInvoices 
+            invoices: c.invoices.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListinvoicesInvoices
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SendonionResponse> for pb::SendonionResponse {
     fn from(c: responses::SendonionResponse) -> Self {
         Self {
@@ -572,7 +572,7 @@ impl From<responses::SendonionResponse> for pb::SendonionResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListsendpaysPayments> for pb::ListsendpaysPayments {
     fn from(c: responses::ListsendpaysPayments) -> Self {
         Self {
@@ -595,16 +595,16 @@ impl From<responses::ListsendpaysPayments> for pb::ListsendpaysPayments {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListsendpaysResponse> for pb::ListsendpaysResponse {
     fn from(c: responses::ListsendpaysResponse) -> Self {
         Self {
-            payments: c.payments.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListsendpaysPayments 
+            payments: c.payments.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListsendpaysPayments
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListtransactionsTransactionsInputs> for pb::ListtransactionsTransactionsInputs {
     fn from(c: responses::ListtransactionsTransactionsInputs) -> Self {
         Self {
@@ -617,7 +617,7 @@ impl From<responses::ListtransactionsTransactionsInputs> for pb::Listtransaction
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListtransactionsTransactionsOutputs> for pb::ListtransactionsTransactionsOutputs {
     fn from(c: responses::ListtransactionsTransactionsOutputs) -> Self {
         Self {
@@ -630,7 +630,7 @@ impl From<responses::ListtransactionsTransactionsOutputs> for pb::Listtransactio
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListtransactionsTransactions> for pb::ListtransactionsTransactions {
     fn from(c: responses::ListtransactionsTransactions) -> Self {
         Self {
@@ -640,22 +640,22 @@ impl From<responses::ListtransactionsTransactions> for pb::ListtransactionsTrans
             txindex: c.txindex, // Rule #2 for type u32
             locktime: c.locktime, // Rule #2 for type u32
             version: c.version, // Rule #2 for type u32
-            inputs: c.inputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactionsInputs 
-            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactionsOutputs 
+            inputs: c.inputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactionsInputs
+            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactionsOutputs
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListtransactionsResponse> for pb::ListtransactionsResponse {
     fn from(c: responses::ListtransactionsResponse) -> Self {
         Self {
-            transactions: c.transactions.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactions 
+            transactions: c.transactions.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListtransactionsTransactions
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::PayResponse> for pb::PayResponse {
     fn from(c: responses::PayResponse) -> Self {
         Self {
@@ -672,7 +672,7 @@ impl From<responses::PayResponse> for pb::PayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListnodesNodesAddresses> for pb::ListnodesNodesAddresses {
     fn from(c: responses::ListnodesNodesAddresses) -> Self {
         Self {
@@ -683,7 +683,7 @@ impl From<responses::ListnodesNodesAddresses> for pb::ListnodesNodesAddresses {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListnodesNodes> for pb::ListnodesNodes {
     fn from(c: responses::ListnodesNodes) -> Self {
         Self {
@@ -692,21 +692,21 @@ impl From<responses::ListnodesNodes> for pb::ListnodesNodes {
             alias: c.alias, // Rule #2 for type string?
             color: c.color.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             features: c.features.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
-            addresses: c.addresses.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            addresses: c.addresses.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListnodesResponse> for pb::ListnodesResponse {
     fn from(c: responses::ListnodesResponse) -> Self {
         Self {
-            nodes: c.nodes.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListnodesNodes 
+            nodes: c.nodes.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListnodesNodes
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::WaitanyinvoiceResponse> for pb::WaitanyinvoiceResponse {
     fn from(c: responses::WaitanyinvoiceResponse) -> Self {
         Self {
@@ -726,7 +726,7 @@ impl From<responses::WaitanyinvoiceResponse> for pb::WaitanyinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::WaitinvoiceResponse> for pb::WaitinvoiceResponse {
     fn from(c: responses::WaitinvoiceResponse) -> Self {
         Self {
@@ -746,7 +746,7 @@ impl From<responses::WaitinvoiceResponse> for pb::WaitinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::WaitsendpayResponse> for pb::WaitsendpayResponse {
     fn from(c: responses::WaitsendpayResponse) -> Self {
         Self {
@@ -768,7 +768,7 @@ impl From<responses::WaitsendpayResponse> for pb::WaitsendpayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::NewaddrResponse> for pb::NewaddrResponse {
     fn from(c: responses::NewaddrResponse) -> Self {
         Self {
@@ -779,7 +779,7 @@ impl From<responses::NewaddrResponse> for pb::NewaddrResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::WithdrawResponse> for pb::WithdrawResponse {
     fn from(c: responses::WithdrawResponse) -> Self {
         Self {
@@ -790,7 +790,7 @@ impl From<responses::WithdrawResponse> for pb::WithdrawResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::KeysendResponse> for pb::KeysendResponse {
     fn from(c: responses::KeysendResponse) -> Self {
         Self {
@@ -807,7 +807,7 @@ impl From<responses::KeysendResponse> for pb::KeysendResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FundpsbtReservations> for pb::FundpsbtReservations {
     fn from(c: responses::FundpsbtReservations) -> Self {
         Self {
@@ -820,7 +820,7 @@ impl From<responses::FundpsbtReservations> for pb::FundpsbtReservations {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FundpsbtResponse> for pb::FundpsbtResponse {
     fn from(c: responses::FundpsbtResponse) -> Self {
         Self {
@@ -829,12 +829,12 @@ impl From<responses::FundpsbtResponse> for pb::FundpsbtResponse {
             estimated_final_weight: c.estimated_final_weight, // Rule #2 for type u32
             excess_msat: Some(c.excess_msat.into()), // Rule #2 for type msat
             change_outnum: c.change_outnum, // Rule #2 for type u32?
-            reservations: c.reservations.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            reservations: c.reservations.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SendpsbtResponse> for pb::SendpsbtResponse {
     fn from(c: responses::SendpsbtResponse) -> Self {
         Self {
@@ -844,7 +844,7 @@ impl From<responses::SendpsbtResponse> for pb::SendpsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SignpsbtResponse> for pb::SignpsbtResponse {
     fn from(c: responses::SignpsbtResponse) -> Self {
         Self {
@@ -853,7 +853,7 @@ impl From<responses::SignpsbtResponse> for pb::SignpsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::UtxopsbtReservations> for pb::UtxopsbtReservations {
     fn from(c: responses::UtxopsbtReservations) -> Self {
         Self {
@@ -866,7 +866,7 @@ impl From<responses::UtxopsbtReservations> for pb::UtxopsbtReservations {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::UtxopsbtResponse> for pb::UtxopsbtResponse {
     fn from(c: responses::UtxopsbtResponse) -> Self {
         Self {
@@ -875,12 +875,12 @@ impl From<responses::UtxopsbtResponse> for pb::UtxopsbtResponse {
             estimated_final_weight: c.estimated_final_weight, // Rule #2 for type u32
             excess_msat: Some(c.excess_msat.into()), // Rule #2 for type msat
             change_outnum: c.change_outnum, // Rule #2 for type u32?
-            reservations: c.reservations.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            reservations: c.reservations.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::TxdiscardResponse> for pb::TxdiscardResponse {
     fn from(c: responses::TxdiscardResponse) -> Self {
         Self {
@@ -890,7 +890,7 @@ impl From<responses::TxdiscardResponse> for pb::TxdiscardResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::TxprepareResponse> for pb::TxprepareResponse {
     fn from(c: responses::TxprepareResponse) -> Self {
         Self {
@@ -901,7 +901,7 @@ impl From<responses::TxprepareResponse> for pb::TxprepareResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::TxsendResponse> for pb::TxsendResponse {
     fn from(c: responses::TxsendResponse) -> Self {
         Self {
@@ -912,7 +912,7 @@ impl From<responses::TxsendResponse> for pb::TxsendResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::DisconnectResponse> for pb::DisconnectResponse {
     fn from(c: responses::DisconnectResponse) -> Self {
         Self {
@@ -920,7 +920,7 @@ impl From<responses::DisconnectResponse> for pb::DisconnectResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FeeratesPerkb> for pb::FeeratesPerkb {
     fn from(c: responses::FeeratesPerkb) -> Self {
         Self {
@@ -936,7 +936,7 @@ impl From<responses::FeeratesPerkb> for pb::FeeratesPerkb {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FeeratesPerkw> for pb::FeeratesPerkw {
     fn from(c: responses::FeeratesPerkw) -> Self {
         Self {
@@ -952,7 +952,7 @@ impl From<responses::FeeratesPerkw> for pb::FeeratesPerkw {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FeeratesOnchain_fee_estimates> for pb::FeeratesOnchainFeeEstimates {
     fn from(c: responses::FeeratesOnchain_fee_estimates) -> Self {
         Self {
@@ -965,7 +965,7 @@ impl From<responses::FeeratesOnchain_fee_estimates> for pb::FeeratesOnchainFeeEs
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FeeratesResponse> for pb::FeeratesResponse {
     fn from(c: responses::FeeratesResponse) -> Self {
         Self {
@@ -977,7 +977,7 @@ impl From<responses::FeeratesResponse> for pb::FeeratesResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::FundchannelResponse> for pb::FundchannelResponse {
     fn from(c: responses::FundchannelResponse) -> Self {
         Self {
@@ -991,7 +991,7 @@ impl From<responses::FundchannelResponse> for pb::FundchannelResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetrouteRoute> for pb::GetrouteRoute {
     fn from(c: responses::GetrouteRoute) -> Self {
         Self {
@@ -1007,16 +1007,16 @@ impl From<responses::GetrouteRoute> for pb::GetrouteRoute {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::GetrouteResponse> for pb::GetrouteResponse {
     fn from(c: responses::GetrouteResponse) -> Self {
         Self {
-            route: c.route.into_iter().map(|i| i.into()).collect(), // Rule #3 for type GetrouteRoute 
+            route: c.route.into_iter().map(|i| i.into()).collect(), // Rule #3 for type GetrouteRoute
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListforwardsForwards> for pb::ListforwardsForwards {
     fn from(c: responses::ListforwardsForwards) -> Self {
         Self {
@@ -1034,16 +1034,16 @@ impl From<responses::ListforwardsForwards> for pb::ListforwardsForwards {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListforwardsResponse> for pb::ListforwardsResponse {
     fn from(c: responses::ListforwardsResponse) -> Self {
         Self {
-            forwards: c.forwards.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListforwardsForwards 
+            forwards: c.forwards.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListforwardsForwards
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpaysPays> for pb::ListpaysPays {
     fn from(c: responses::ListpaysPays) -> Self {
         Self {
@@ -1063,16 +1063,16 @@ impl From<responses::ListpaysPays> for pb::ListpaysPays {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::ListpaysResponse> for pb::ListpaysResponse {
     fn from(c: responses::ListpaysResponse) -> Self {
         Self {
-            pays: c.pays.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpaysPays 
+            pays: c.pays.into_iter().map(|i| i.into()).collect(), // Rule #3 for type ListpaysPays
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::PingResponse> for pb::PingResponse {
     fn from(c: responses::PingResponse) -> Self {
         Self {
@@ -1081,7 +1081,7 @@ impl From<responses::PingResponse> for pb::PingResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SendcustommsgResponse> for pb::SendcustommsgResponse {
     fn from(c: responses::SendcustommsgResponse) -> Self {
         Self {
@@ -1090,7 +1090,7 @@ impl From<responses::SendcustommsgResponse> for pb::SendcustommsgResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SetchannelChannels> for pb::SetchannelChannels {
     fn from(c: responses::SetchannelChannels) -> Self {
         Self {
@@ -1107,16 +1107,16 @@ impl From<responses::SetchannelChannels> for pb::SetchannelChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SetchannelResponse> for pb::SetchannelResponse {
     fn from(c: responses::SetchannelResponse) -> Self {
         Self {
-            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type SetchannelChannels 
+            channels: c.channels.into_iter().map(|i| i.into()).collect(), // Rule #3 for type SetchannelChannels
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SigninvoiceResponse> for pb::SigninvoiceResponse {
     fn from(c: responses::SigninvoiceResponse) -> Self {
         Self {
@@ -1125,7 +1125,7 @@ impl From<responses::SigninvoiceResponse> for pb::SigninvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::SignmessageResponse> for pb::SignmessageResponse {
     fn from(c: responses::SignmessageResponse) -> Self {
         Self {
@@ -1136,7 +1136,7 @@ impl From<responses::SignmessageResponse> for pb::SignmessageResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<responses::StopResponse> for pb::StopResponse {
     fn from(c: responses::StopResponse) -> Self {
         Self {
@@ -1144,7 +1144,7 @@ impl From<responses::StopResponse> for pb::StopResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::GetinfoRequest> for pb::GetinfoRequest {
     fn from(c: requests::GetinfoRequest) -> Self {
         Self {
@@ -1152,7 +1152,7 @@ impl From<requests::GetinfoRequest> for pb::GetinfoRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListpeersRequest> for pb::ListpeersRequest {
     fn from(c: requests::ListpeersRequest) -> Self {
         Self {
@@ -1162,7 +1162,7 @@ impl From<requests::ListpeersRequest> for pb::ListpeersRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListfundsRequest> for pb::ListfundsRequest {
     fn from(c: requests::ListfundsRequest) -> Self {
         Self {
@@ -1171,7 +1171,7 @@ impl From<requests::ListfundsRequest> for pb::ListfundsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendpayRoute> for pb::SendpayRoute {
     fn from(c: requests::SendpayRoute) -> Self {
         Self {
@@ -1183,11 +1183,11 @@ impl From<requests::SendpayRoute> for pb::SendpayRoute {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendpayRequest> for pb::SendpayRequest {
     fn from(c: requests::SendpayRequest) -> Self {
         Self {
-            route: c.route.into_iter().map(|i| i.into()).collect(), // Rule #3 for type SendpayRoute 
+            route: c.route.into_iter().map(|i| i.into()).collect(), // Rule #3 for type SendpayRoute
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             label: c.label, // Rule #2 for type string?
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
@@ -1200,7 +1200,7 @@ impl From<requests::SendpayRequest> for pb::SendpayRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListchannelsRequest> for pb::ListchannelsRequest {
     fn from(c: requests::ListchannelsRequest) -> Self {
         Self {
@@ -1211,7 +1211,7 @@ impl From<requests::ListchannelsRequest> for pb::ListchannelsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::AddgossipRequest> for pb::AddgossipRequest {
     fn from(c: requests::AddgossipRequest) -> Self {
         Self {
@@ -1220,7 +1220,7 @@ impl From<requests::AddgossipRequest> for pb::AddgossipRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::AutocleaninvoiceRequest> for pb::AutocleaninvoiceRequest {
     fn from(c: requests::AutocleaninvoiceRequest) -> Self {
         Self {
@@ -1230,7 +1230,7 @@ impl From<requests::AutocleaninvoiceRequest> for pb::AutocleaninvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::CheckmessageRequest> for pb::CheckmessageRequest {
     fn from(c: requests::CheckmessageRequest) -> Self {
         Self {
@@ -1241,7 +1241,7 @@ impl From<requests::CheckmessageRequest> for pb::CheckmessageRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::CloseRequest> for pb::CloseRequest {
     fn from(c: requests::CloseRequest) -> Self {
         Self {
@@ -1251,12 +1251,12 @@ impl From<requests::CloseRequest> for pb::CloseRequest {
             fee_negotiation_step: c.fee_negotiation_step, // Rule #2 for type string?
             wrong_funding: c.wrong_funding.map(|o|o.into()), // Rule #2 for type outpoint?
             force_lease_closed: c.force_lease_closed, // Rule #2 for type boolean?
-            feerange: c.feerange.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            feerange: c.feerange.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ConnectRequest> for pb::ConnectRequest {
     fn from(c: requests::ConnectRequest) -> Self {
         Self {
@@ -1267,7 +1267,7 @@ impl From<requests::ConnectRequest> for pb::ConnectRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::CreateinvoiceRequest> for pb::CreateinvoiceRequest {
     fn from(c: requests::CreateinvoiceRequest) -> Self {
         Self {
@@ -1278,11 +1278,11 @@ impl From<requests::CreateinvoiceRequest> for pb::CreateinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::DatastoreRequest> for pb::DatastoreRequest {
     fn from(c: requests::DatastoreRequest) -> Self {
         Self {
-            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string 
+            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string
             string: c.string, // Rule #2 for type string?
             hex: c.hex.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             mode: c.mode.map(|v| v as i32),
@@ -1291,7 +1291,7 @@ impl From<requests::DatastoreRequest> for pb::DatastoreRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::CreateonionHops> for pb::CreateonionHops {
     fn from(c: requests::CreateonionHops) -> Self {
         Self {
@@ -1301,11 +1301,11 @@ impl From<requests::CreateonionHops> for pb::CreateonionHops {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::CreateonionRequest> for pb::CreateonionRequest {
     fn from(c: requests::CreateonionRequest) -> Self {
         Self {
-            hops: c.hops.into_iter().map(|i| i.into()).collect(), // Rule #3 for type CreateonionHops 
+            hops: c.hops.into_iter().map(|i| i.into()).collect(), // Rule #3 for type CreateonionHops
             assocdata: hex::decode(&c.assocdata).unwrap(), // Rule #2 for type hex
             session_key: c.session_key.map(|v| v.to_vec()), // Rule #2 for type secret?
             onion_size: c.onion_size.map(|v| v.into()), // Rule #2 for type u16?
@@ -1313,17 +1313,17 @@ impl From<requests::CreateonionRequest> for pb::CreateonionRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::DeldatastoreRequest> for pb::DeldatastoreRequest {
     fn from(c: requests::DeldatastoreRequest) -> Self {
         Self {
-            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string 
+            key: c.key.into_iter().map(|i| i.into()).collect(), // Rule #3 for type string
             generation: c.generation, // Rule #2 for type u64?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::DelexpiredinvoiceRequest> for pb::DelexpiredinvoiceRequest {
     fn from(c: requests::DelexpiredinvoiceRequest) -> Self {
         Self {
@@ -1332,7 +1332,7 @@ impl From<requests::DelexpiredinvoiceRequest> for pb::DelexpiredinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::DelinvoiceRequest> for pb::DelinvoiceRequest {
     fn from(c: requests::DelinvoiceRequest) -> Self {
         Self {
@@ -1343,7 +1343,7 @@ impl From<requests::DelinvoiceRequest> for pb::DelinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::InvoiceRequest> for pb::InvoiceRequest {
     fn from(c: requests::InvoiceRequest) -> Self {
         Self {
@@ -1351,7 +1351,7 @@ impl From<requests::InvoiceRequest> for pb::InvoiceRequest {
             description: c.description, // Rule #2 for type string
             label: c.label, // Rule #2 for type string
             expiry: c.expiry, // Rule #2 for type u64?
-            fallbacks: c.fallbacks.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            fallbacks: c.fallbacks.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             preimage: c.preimage.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
             exposeprivatechannels: c.exposeprivatechannels, // Rule #2 for type boolean?
             cltv: c.cltv, // Rule #2 for type u32?
@@ -1360,16 +1360,16 @@ impl From<requests::InvoiceRequest> for pb::InvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListdatastoreRequest> for pb::ListdatastoreRequest {
     fn from(c: requests::ListdatastoreRequest) -> Self {
         Self {
-            key: c.key.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            key: c.key.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListinvoicesRequest> for pb::ListinvoicesRequest {
     fn from(c: requests::ListinvoicesRequest) -> Self {
         Self {
@@ -1381,7 +1381,7 @@ impl From<requests::ListinvoicesRequest> for pb::ListinvoicesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendonionFirst_hop> for pb::SendonionFirstHop {
     fn from(c: requests::SendonionFirst_hop) -> Self {
         Self {
@@ -1392,7 +1392,7 @@ impl From<requests::SendonionFirst_hop> for pb::SendonionFirstHop {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendonionRequest> for pb::SendonionRequest {
     fn from(c: requests::SendonionRequest) -> Self {
         Self {
@@ -1400,7 +1400,7 @@ impl From<requests::SendonionRequest> for pb::SendonionRequest {
             first_hop: Some(c.first_hop.into()),
             payment_hash: c.payment_hash.to_vec(), // Rule #2 for type hash
             label: c.label, // Rule #2 for type string?
-            shared_secrets: c.shared_secrets.map(|arr| arr.into_iter().map(|i| i.to_vec()).collect()).unwrap_or(vec![]), // Rule #3 
+            shared_secrets: c.shared_secrets.map(|arr| arr.into_iter().map(|i| i.to_vec()).collect()).unwrap_or(vec![]), // Rule #3
             partid: c.partid.map(|v| v.into()), // Rule #2 for type u16?
             bolt11: c.bolt11, // Rule #2 for type string?
             amount_msat: c.amount_msat.map(|f| f.into()), // Rule #2 for type msat?
@@ -1411,7 +1411,7 @@ impl From<requests::SendonionRequest> for pb::SendonionRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListsendpaysRequest> for pb::ListsendpaysRequest {
     fn from(c: requests::ListsendpaysRequest) -> Self {
         Self {
@@ -1422,7 +1422,7 @@ impl From<requests::ListsendpaysRequest> for pb::ListsendpaysRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListtransactionsRequest> for pb::ListtransactionsRequest {
     fn from(c: requests::ListtransactionsRequest) -> Self {
         Self {
@@ -1430,7 +1430,7 @@ impl From<requests::ListtransactionsRequest> for pb::ListtransactionsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::PayRequest> for pb::PayRequest {
     fn from(c: requests::PayRequest) -> Self {
         Self {
@@ -1443,14 +1443,14 @@ impl From<requests::PayRequest> for pb::PayRequest {
             maxdelay: c.maxdelay.map(|v| v.into()), // Rule #2 for type u16?
             exemptfee: c.exemptfee.map(|f| f.into()), // Rule #2 for type msat?
             localinvreqid: c.localinvreqid.map(|v| hex::decode(v).unwrap()), // Rule #2 for type hex?
-            exclude: c.exclude.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            exclude: c.exclude.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             maxfee: c.maxfee.map(|f| f.into()), // Rule #2 for type msat?
             description: c.description, // Rule #2 for type string?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListnodesRequest> for pb::ListnodesRequest {
     fn from(c: requests::ListnodesRequest) -> Self {
         Self {
@@ -1459,7 +1459,7 @@ impl From<requests::ListnodesRequest> for pb::ListnodesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::WaitanyinvoiceRequest> for pb::WaitanyinvoiceRequest {
     fn from(c: requests::WaitanyinvoiceRequest) -> Self {
         Self {
@@ -1469,7 +1469,7 @@ impl From<requests::WaitanyinvoiceRequest> for pb::WaitanyinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::WaitinvoiceRequest> for pb::WaitinvoiceRequest {
     fn from(c: requests::WaitinvoiceRequest) -> Self {
         Self {
@@ -1478,7 +1478,7 @@ impl From<requests::WaitinvoiceRequest> for pb::WaitinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::WaitsendpayRequest> for pb::WaitsendpayRequest {
     fn from(c: requests::WaitsendpayRequest) -> Self {
         Self {
@@ -1490,7 +1490,7 @@ impl From<requests::WaitsendpayRequest> for pb::WaitsendpayRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::NewaddrRequest> for pb::NewaddrRequest {
     fn from(c: requests::NewaddrRequest) -> Self {
         Self {
@@ -1499,7 +1499,7 @@ impl From<requests::NewaddrRequest> for pb::NewaddrRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::WithdrawRequest> for pb::WithdrawRequest {
     fn from(c: requests::WithdrawRequest) -> Self {
         Self {
@@ -1507,12 +1507,12 @@ impl From<requests::WithdrawRequest> for pb::WithdrawRequest {
             satoshi: c.satoshi.map(|o|o.into()), // Rule #2 for type msat_or_all?
             feerate: c.feerate.map(|o|o.into()), // Rule #2 for type feerate?
             minconf: c.minconf.map(|v| v.into()), // Rule #2 for type u16?
-            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::KeysendRequest> for pb::KeysendRequest {
     fn from(c: requests::KeysendRequest) -> Self {
         Self {
@@ -1529,7 +1529,7 @@ impl From<requests::KeysendRequest> for pb::KeysendRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::FundpsbtRequest> for pb::FundpsbtRequest {
     fn from(c: requests::FundpsbtRequest) -> Self {
         Self {
@@ -1545,7 +1545,7 @@ impl From<requests::FundpsbtRequest> for pb::FundpsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendpsbtRequest> for pb::SendpsbtRequest {
     fn from(c: requests::SendpsbtRequest) -> Self {
         Self {
@@ -1555,24 +1555,24 @@ impl From<requests::SendpsbtRequest> for pb::SendpsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SignpsbtRequest> for pb::SignpsbtRequest {
     fn from(c: requests::SignpsbtRequest) -> Self {
         Self {
             psbt: c.psbt, // Rule #2 for type string
-            signonly: c.signonly.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            signonly: c.signonly.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::UtxopsbtRequest> for pb::UtxopsbtRequest {
     fn from(c: requests::UtxopsbtRequest) -> Self {
         Self {
             satoshi: Some(c.satoshi.into()), // Rule #2 for type msat
             feerate: Some(c.feerate.into()), // Rule #2 for type feerate
             startweight: c.startweight, // Rule #2 for type u32
-            utxos: c.utxos.into_iter().map(|i| i.into()).collect(), // Rule #3 for type outpoint 
+            utxos: c.utxos.into_iter().map(|i| i.into()).collect(), // Rule #3 for type outpoint
             reserve: c.reserve, // Rule #2 for type u32?
             reservedok: c.reservedok, // Rule #2 for type boolean?
             locktime: c.locktime, // Rule #2 for type u32?
@@ -1582,7 +1582,7 @@ impl From<requests::UtxopsbtRequest> for pb::UtxopsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::TxdiscardRequest> for pb::TxdiscardRequest {
     fn from(c: requests::TxdiscardRequest) -> Self {
         Self {
@@ -1591,19 +1591,19 @@ impl From<requests::TxdiscardRequest> for pb::TxdiscardRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::TxprepareRequest> for pb::TxprepareRequest {
     fn from(c: requests::TxprepareRequest) -> Self {
         Self {
-            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type outputdesc 
+            outputs: c.outputs.into_iter().map(|i| i.into()).collect(), // Rule #3 for type outputdesc
             feerate: c.feerate.map(|o|o.into()), // Rule #2 for type feerate?
             minconf: c.minconf, // Rule #2 for type u32?
-            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::TxsendRequest> for pb::TxsendRequest {
     fn from(c: requests::TxsendRequest) -> Self {
         Self {
@@ -1612,7 +1612,7 @@ impl From<requests::TxsendRequest> for pb::TxsendRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::DisconnectRequest> for pb::DisconnectRequest {
     fn from(c: requests::DisconnectRequest) -> Self {
         Self {
@@ -1622,7 +1622,7 @@ impl From<requests::DisconnectRequest> for pb::DisconnectRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::FeeratesRequest> for pb::FeeratesRequest {
     fn from(c: requests::FeeratesRequest) -> Self {
         Self {
@@ -1631,7 +1631,7 @@ impl From<requests::FeeratesRequest> for pb::FeeratesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::FundchannelRequest> for pb::FundchannelRequest {
     fn from(c: requests::FundchannelRequest) -> Self {
         Self {
@@ -1644,14 +1644,14 @@ impl From<requests::FundchannelRequest> for pb::FundchannelRequest {
             close_to: c.close_to, // Rule #2 for type string?
             request_amt: c.request_amt.map(|f| f.into()), // Rule #2 for type msat?
             compact_lease: c.compact_lease, // Rule #2 for type string?
-            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            utxos: c.utxos.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             mindepth: c.mindepth, // Rule #2 for type u32?
             reserve: c.reserve.map(|f| f.into()), // Rule #2 for type msat?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::GetrouteRequest> for pb::GetrouteRequest {
     fn from(c: requests::GetrouteRequest) -> Self {
         Self {
@@ -1661,13 +1661,13 @@ impl From<requests::GetrouteRequest> for pb::GetrouteRequest {
             cltv: c.cltv, // Rule #2 for type number?
             fromid: c.fromid.map(|v| v.serialize().to_vec()), // Rule #2 for type pubkey?
             fuzzpercent: c.fuzzpercent, // Rule #2 for type u32?
-            exclude: c.exclude.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3 
+            exclude: c.exclude.map(|arr| arr.into_iter().map(|i| i.into()).collect()).unwrap_or(vec![]), // Rule #3
             maxhops: c.maxhops, // Rule #2 for type u32?
         }
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListforwardsRequest> for pb::ListforwardsRequest {
     fn from(c: requests::ListforwardsRequest) -> Self {
         Self {
@@ -1678,7 +1678,7 @@ impl From<requests::ListforwardsRequest> for pb::ListforwardsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::ListpaysRequest> for pb::ListpaysRequest {
     fn from(c: requests::ListpaysRequest) -> Self {
         Self {
@@ -1689,7 +1689,7 @@ impl From<requests::ListpaysRequest> for pb::ListpaysRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::PingRequest> for pb::PingRequest {
     fn from(c: requests::PingRequest) -> Self {
         Self {
@@ -1700,7 +1700,7 @@ impl From<requests::PingRequest> for pb::PingRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SendcustommsgRequest> for pb::SendcustommsgRequest {
     fn from(c: requests::SendcustommsgRequest) -> Self {
         Self {
@@ -1710,7 +1710,7 @@ impl From<requests::SendcustommsgRequest> for pb::SendcustommsgRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SetchannelRequest> for pb::SetchannelRequest {
     fn from(c: requests::SetchannelRequest) -> Self {
         Self {
@@ -1724,7 +1724,7 @@ impl From<requests::SetchannelRequest> for pb::SetchannelRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SigninvoiceRequest> for pb::SigninvoiceRequest {
     fn from(c: requests::SigninvoiceRequest) -> Self {
         Self {
@@ -1733,7 +1733,7 @@ impl From<requests::SigninvoiceRequest> for pb::SigninvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::SignmessageRequest> for pb::SignmessageRequest {
     fn from(c: requests::SignmessageRequest) -> Self {
         Self {
@@ -1742,7 +1742,7 @@ impl From<requests::SignmessageRequest> for pb::SignmessageRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<requests::StopRequest> for pb::StopRequest {
     fn from(c: requests::StopRequest) -> Self {
         Self {
@@ -1750,7 +1750,8 @@ impl From<requests::StopRequest> for pb::StopRequest {
     }
 }
 
-#[allow(unused_variables)]
+
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetinfoRequest> for requests::GetinfoRequest {
     fn from(c: pb::GetinfoRequest) -> Self {
         Self {
@@ -1758,7 +1759,7 @@ impl From<pb::GetinfoRequest> for requests::GetinfoRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersRequest> for requests::ListpeersRequest {
     fn from(c: pb::ListpeersRequest) -> Self {
         Self {
@@ -1768,7 +1769,7 @@ impl From<pb::ListpeersRequest> for requests::ListpeersRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListfundsRequest> for requests::ListfundsRequest {
     fn from(c: pb::ListfundsRequest) -> Self {
         Self {
@@ -1777,7 +1778,7 @@ impl From<pb::ListfundsRequest> for requests::ListfundsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendpayRoute> for requests::SendpayRoute {
     fn from(c: pb::SendpayRoute) -> Self {
         Self {
@@ -1789,7 +1790,7 @@ impl From<pb::SendpayRoute> for requests::SendpayRoute {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendpayRequest> for requests::SendpayRequest {
     fn from(c: pb::SendpayRequest) -> Self {
         Self {
@@ -1806,7 +1807,7 @@ impl From<pb::SendpayRequest> for requests::SendpayRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListchannelsRequest> for requests::ListchannelsRequest {
     fn from(c: pb::ListchannelsRequest) -> Self {
         Self {
@@ -1817,7 +1818,7 @@ impl From<pb::ListchannelsRequest> for requests::ListchannelsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::AddgossipRequest> for requests::AddgossipRequest {
     fn from(c: pb::AddgossipRequest) -> Self {
         Self {
@@ -1826,7 +1827,7 @@ impl From<pb::AddgossipRequest> for requests::AddgossipRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::AutocleaninvoiceRequest> for requests::AutocleaninvoiceRequest {
     fn from(c: pb::AutocleaninvoiceRequest) -> Self {
         Self {
@@ -1836,7 +1837,7 @@ impl From<pb::AutocleaninvoiceRequest> for requests::AutocleaninvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CheckmessageRequest> for requests::CheckmessageRequest {
     fn from(c: pb::CheckmessageRequest) -> Self {
         Self {
@@ -1847,7 +1848,7 @@ impl From<pb::CheckmessageRequest> for requests::CheckmessageRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CloseRequest> for requests::CloseRequest {
     fn from(c: pb::CloseRequest) -> Self {
         Self {
@@ -1862,7 +1863,7 @@ impl From<pb::CloseRequest> for requests::CloseRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ConnectRequest> for requests::ConnectRequest {
     fn from(c: pb::ConnectRequest) -> Self {
         Self {
@@ -1873,7 +1874,7 @@ impl From<pb::ConnectRequest> for requests::ConnectRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CreateinvoiceRequest> for requests::CreateinvoiceRequest {
     fn from(c: pb::CreateinvoiceRequest) -> Self {
         Self {
@@ -1884,7 +1885,7 @@ impl From<pb::CreateinvoiceRequest> for requests::CreateinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DatastoreRequest> for requests::DatastoreRequest {
     fn from(c: pb::DatastoreRequest) -> Self {
         Self {
@@ -1897,7 +1898,7 @@ impl From<pb::DatastoreRequest> for requests::DatastoreRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CreateonionHops> for requests::CreateonionHops {
     fn from(c: pb::CreateonionHops) -> Self {
         Self {
@@ -1907,7 +1908,7 @@ impl From<pb::CreateonionHops> for requests::CreateonionHops {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CreateonionRequest> for requests::CreateonionRequest {
     fn from(c: pb::CreateonionRequest) -> Self {
         Self {
@@ -1919,7 +1920,7 @@ impl From<pb::CreateonionRequest> for requests::CreateonionRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DeldatastoreRequest> for requests::DeldatastoreRequest {
     fn from(c: pb::DeldatastoreRequest) -> Self {
         Self {
@@ -1929,7 +1930,7 @@ impl From<pb::DeldatastoreRequest> for requests::DeldatastoreRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DelexpiredinvoiceRequest> for requests::DelexpiredinvoiceRequest {
     fn from(c: pb::DelexpiredinvoiceRequest) -> Self {
         Self {
@@ -1938,7 +1939,7 @@ impl From<pb::DelexpiredinvoiceRequest> for requests::DelexpiredinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DelinvoiceRequest> for requests::DelinvoiceRequest {
     fn from(c: pb::DelinvoiceRequest) -> Self {
         Self {
@@ -1949,7 +1950,7 @@ impl From<pb::DelinvoiceRequest> for requests::DelinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::InvoiceRequest> for requests::InvoiceRequest {
     fn from(c: pb::InvoiceRequest) -> Self {
         Self {
@@ -1966,7 +1967,7 @@ impl From<pb::InvoiceRequest> for requests::InvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListdatastoreRequest> for requests::ListdatastoreRequest {
     fn from(c: pb::ListdatastoreRequest) -> Self {
         Self {
@@ -1975,7 +1976,7 @@ impl From<pb::ListdatastoreRequest> for requests::ListdatastoreRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListinvoicesRequest> for requests::ListinvoicesRequest {
     fn from(c: pb::ListinvoicesRequest) -> Self {
         Self {
@@ -1987,7 +1988,7 @@ impl From<pb::ListinvoicesRequest> for requests::ListinvoicesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendonionFirstHop> for requests::SendonionFirst_hop {
     fn from(c: pb::SendonionFirstHop) -> Self {
         Self {
@@ -1998,7 +1999,7 @@ impl From<pb::SendonionFirstHop> for requests::SendonionFirst_hop {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendonionRequest> for requests::SendonionRequest {
     fn from(c: pb::SendonionRequest) -> Self {
         Self {
@@ -2017,7 +2018,7 @@ impl From<pb::SendonionRequest> for requests::SendonionRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListsendpaysRequest> for requests::ListsendpaysRequest {
     fn from(c: pb::ListsendpaysRequest) -> Self {
         Self {
@@ -2028,7 +2029,7 @@ impl From<pb::ListsendpaysRequest> for requests::ListsendpaysRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListtransactionsRequest> for requests::ListtransactionsRequest {
     fn from(c: pb::ListtransactionsRequest) -> Self {
         Self {
@@ -2036,7 +2037,7 @@ impl From<pb::ListtransactionsRequest> for requests::ListtransactionsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::PayRequest> for requests::PayRequest {
     fn from(c: pb::PayRequest) -> Self {
         Self {
@@ -2056,7 +2057,7 @@ impl From<pb::PayRequest> for requests::PayRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListnodesRequest> for requests::ListnodesRequest {
     fn from(c: pb::ListnodesRequest) -> Self {
         Self {
@@ -2065,7 +2066,7 @@ impl From<pb::ListnodesRequest> for requests::ListnodesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitanyinvoiceRequest> for requests::WaitanyinvoiceRequest {
     fn from(c: pb::WaitanyinvoiceRequest) -> Self {
         Self {
@@ -2075,7 +2076,7 @@ impl From<pb::WaitanyinvoiceRequest> for requests::WaitanyinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitinvoiceRequest> for requests::WaitinvoiceRequest {
     fn from(c: pb::WaitinvoiceRequest) -> Self {
         Self {
@@ -2084,7 +2085,7 @@ impl From<pb::WaitinvoiceRequest> for requests::WaitinvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitsendpayRequest> for requests::WaitsendpayRequest {
     fn from(c: pb::WaitsendpayRequest) -> Self {
         Self {
@@ -2096,7 +2097,7 @@ impl From<pb::WaitsendpayRequest> for requests::WaitsendpayRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::NewaddrRequest> for requests::NewaddrRequest {
     fn from(c: pb::NewaddrRequest) -> Self {
         Self {
@@ -2105,7 +2106,7 @@ impl From<pb::NewaddrRequest> for requests::NewaddrRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WithdrawRequest> for requests::WithdrawRequest {
     fn from(c: pb::WithdrawRequest) -> Self {
         Self {
@@ -2118,7 +2119,7 @@ impl From<pb::WithdrawRequest> for requests::WithdrawRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::KeysendRequest> for requests::KeysendRequest {
     fn from(c: pb::KeysendRequest) -> Self {
         Self {
@@ -2135,7 +2136,7 @@ impl From<pb::KeysendRequest> for requests::KeysendRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FundpsbtRequest> for requests::FundpsbtRequest {
     fn from(c: pb::FundpsbtRequest) -> Self {
         Self {
@@ -2151,7 +2152,7 @@ impl From<pb::FundpsbtRequest> for requests::FundpsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendpsbtRequest> for requests::SendpsbtRequest {
     fn from(c: pb::SendpsbtRequest) -> Self {
         Self {
@@ -2161,7 +2162,7 @@ impl From<pb::SendpsbtRequest> for requests::SendpsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SignpsbtRequest> for requests::SignpsbtRequest {
     fn from(c: pb::SignpsbtRequest) -> Self {
         Self {
@@ -2171,7 +2172,7 @@ impl From<pb::SignpsbtRequest> for requests::SignpsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::UtxopsbtRequest> for requests::UtxopsbtRequest {
     fn from(c: pb::UtxopsbtRequest) -> Self {
         Self {
@@ -2188,7 +2189,7 @@ impl From<pb::UtxopsbtRequest> for requests::UtxopsbtRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxdiscardRequest> for requests::TxdiscardRequest {
     fn from(c: pb::TxdiscardRequest) -> Self {
         Self {
@@ -2197,7 +2198,7 @@ impl From<pb::TxdiscardRequest> for requests::TxdiscardRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxprepareRequest> for requests::TxprepareRequest {
     fn from(c: pb::TxprepareRequest) -> Self {
         Self {
@@ -2209,7 +2210,7 @@ impl From<pb::TxprepareRequest> for requests::TxprepareRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxsendRequest> for requests::TxsendRequest {
     fn from(c: pb::TxsendRequest) -> Self {
         Self {
@@ -2218,7 +2219,7 @@ impl From<pb::TxsendRequest> for requests::TxsendRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DisconnectRequest> for requests::DisconnectRequest {
     fn from(c: pb::DisconnectRequest) -> Self {
         Self {
@@ -2228,7 +2229,7 @@ impl From<pb::DisconnectRequest> for requests::DisconnectRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FeeratesRequest> for requests::FeeratesRequest {
     fn from(c: pb::FeeratesRequest) -> Self {
         Self {
@@ -2237,7 +2238,7 @@ impl From<pb::FeeratesRequest> for requests::FeeratesRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
     fn from(c: pb::FundchannelRequest) -> Self {
         Self {
@@ -2257,7 +2258,7 @@ impl From<pb::FundchannelRequest> for requests::FundchannelRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetrouteRequest> for requests::GetrouteRequest {
     fn from(c: pb::GetrouteRequest) -> Self {
         Self {
@@ -2273,7 +2274,7 @@ impl From<pb::GetrouteRequest> for requests::GetrouteRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListforwardsRequest> for requests::ListforwardsRequest {
     fn from(c: pb::ListforwardsRequest) -> Self {
         Self {
@@ -2284,7 +2285,7 @@ impl From<pb::ListforwardsRequest> for requests::ListforwardsRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
     fn from(c: pb::ListpaysRequest) -> Self {
         Self {
@@ -2295,7 +2296,7 @@ impl From<pb::ListpaysRequest> for requests::ListpaysRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::PingRequest> for requests::PingRequest {
     fn from(c: pb::PingRequest) -> Self {
         Self {
@@ -2306,7 +2307,7 @@ impl From<pb::PingRequest> for requests::PingRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendcustommsgRequest> for requests::SendcustommsgRequest {
     fn from(c: pb::SendcustommsgRequest) -> Self {
         Self {
@@ -2316,7 +2317,7 @@ impl From<pb::SendcustommsgRequest> for requests::SendcustommsgRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SetchannelRequest> for requests::SetchannelRequest {
     fn from(c: pb::SetchannelRequest) -> Self {
         Self {
@@ -2330,7 +2331,7 @@ impl From<pb::SetchannelRequest> for requests::SetchannelRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SigninvoiceRequest> for requests::SigninvoiceRequest {
     fn from(c: pb::SigninvoiceRequest) -> Self {
         Self {
@@ -2339,7 +2340,7 @@ impl From<pb::SigninvoiceRequest> for requests::SigninvoiceRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SignmessageRequest> for requests::SignmessageRequest {
     fn from(c: pb::SignmessageRequest) -> Self {
         Self {
@@ -2348,7 +2349,7 @@ impl From<pb::SignmessageRequest> for requests::SignmessageRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::StopRequest> for requests::StopRequest {
     fn from(c: pb::StopRequest) -> Self {
         Self {
@@ -2356,7 +2357,7 @@ impl From<pb::StopRequest> for requests::StopRequest {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetinfoOurFeatures> for responses::GetinfoOur_features {
     fn from(c: pb::GetinfoOurFeatures) -> Self {
         Self {
@@ -2368,7 +2369,7 @@ impl From<pb::GetinfoOurFeatures> for responses::GetinfoOur_features {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetinfoAddress> for responses::GetinfoAddress {
     fn from(c: pb::GetinfoAddress) -> Self {
         Self {
@@ -2379,7 +2380,7 @@ impl From<pb::GetinfoAddress> for responses::GetinfoAddress {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetinfoBinding> for responses::GetinfoBinding {
     fn from(c: pb::GetinfoBinding) -> Self {
         Self {
@@ -2391,7 +2392,7 @@ impl From<pb::GetinfoBinding> for responses::GetinfoBinding {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetinfoResponse> for responses::GetinfoResponse {
     fn from(c: pb::GetinfoResponse) -> Self {
         Self {
@@ -2417,7 +2418,7 @@ impl From<pb::GetinfoResponse> for responses::GetinfoResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersLog> for responses::ListpeersPeersLog {
     fn from(c: pb::ListpeersPeersLog) -> Self {
         Self {
@@ -2432,7 +2433,7 @@ impl From<pb::ListpeersPeersLog> for responses::ListpeersPeersLog {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannelsFeerate> for responses::ListpeersPeersChannelsFeerate {
     fn from(c: pb::ListpeersPeersChannelsFeerate) -> Self {
         Self {
@@ -2442,7 +2443,7 @@ impl From<pb::ListpeersPeersChannelsFeerate> for responses::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannelsInflight> for responses::ListpeersPeersChannelsInflight {
     fn from(c: pb::ListpeersPeersChannelsInflight) -> Self {
         Self {
@@ -2456,7 +2457,7 @@ impl From<pb::ListpeersPeersChannelsInflight> for responses::ListpeersPeersChann
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannelsFunding> for responses::ListpeersPeersChannelsFunding {
     fn from(c: pb::ListpeersPeersChannelsFunding) -> Self {
         Self {
@@ -2471,7 +2472,7 @@ impl From<pb::ListpeersPeersChannelsFunding> for responses::ListpeersPeersChanne
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannelsAlias> for responses::ListpeersPeersChannelsAlias {
     fn from(c: pb::ListpeersPeersChannelsAlias) -> Self {
         Self {
@@ -2481,7 +2482,7 @@ impl From<pb::ListpeersPeersChannelsAlias> for responses::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannelsHtlcs> for responses::ListpeersPeersChannelsHtlcs {
     fn from(c: pb::ListpeersPeersChannelsHtlcs) -> Self {
         Self {
@@ -2496,7 +2497,7 @@ impl From<pb::ListpeersPeersChannelsHtlcs> for responses::ListpeersPeersChannels
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeersChannels> for responses::ListpeersPeersChannels {
     fn from(c: pb::ListpeersPeersChannels) -> Self {
         Self {
@@ -2553,7 +2554,7 @@ state_changes: None,            status: Some(c.status.into_iter().map(|s| s.into
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersPeers> for responses::ListpeersPeers {
     fn from(c: pb::ListpeersPeers) -> Self {
         Self {
@@ -2569,7 +2570,7 @@ impl From<pb::ListpeersPeers> for responses::ListpeersPeers {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpeersResponse> for responses::ListpeersResponse {
     fn from(c: pb::ListpeersResponse) -> Self {
         Self {
@@ -2578,7 +2579,7 @@ impl From<pb::ListpeersResponse> for responses::ListpeersResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListfundsOutputs> for responses::ListfundsOutputs {
     fn from(c: pb::ListfundsOutputs) -> Self {
         Self {
@@ -2595,7 +2596,7 @@ impl From<pb::ListfundsOutputs> for responses::ListfundsOutputs {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListfundsChannels> for responses::ListfundsChannels {
     fn from(c: pb::ListfundsChannels) -> Self {
         Self {
@@ -2611,7 +2612,7 @@ impl From<pb::ListfundsChannels> for responses::ListfundsChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListfundsResponse> for responses::ListfundsResponse {
     fn from(c: pb::ListfundsResponse) -> Self {
         Self {
@@ -2621,7 +2622,7 @@ impl From<pb::ListfundsResponse> for responses::ListfundsResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendpayResponse> for responses::SendpayResponse {
     fn from(c: pb::SendpayResponse) -> Self {
         Self {
@@ -2644,7 +2645,7 @@ impl From<pb::SendpayResponse> for responses::SendpayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListchannelsChannels> for responses::ListchannelsChannels {
     fn from(c: pb::ListchannelsChannels) -> Self {
         Self {
@@ -2668,7 +2669,7 @@ impl From<pb::ListchannelsChannels> for responses::ListchannelsChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListchannelsResponse> for responses::ListchannelsResponse {
     fn from(c: pb::ListchannelsResponse) -> Self {
         Self {
@@ -2677,7 +2678,7 @@ impl From<pb::ListchannelsResponse> for responses::ListchannelsResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::AddgossipResponse> for responses::AddgossipResponse {
     fn from(c: pb::AddgossipResponse) -> Self {
         Self {
@@ -2685,7 +2686,7 @@ impl From<pb::AddgossipResponse> for responses::AddgossipResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::AutocleaninvoiceResponse> for responses::AutocleaninvoiceResponse {
     fn from(c: pb::AutocleaninvoiceResponse) -> Self {
         Self {
@@ -2696,7 +2697,7 @@ impl From<pb::AutocleaninvoiceResponse> for responses::AutocleaninvoiceResponse 
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CheckmessageResponse> for responses::CheckmessageResponse {
     fn from(c: pb::CheckmessageResponse) -> Self {
         Self {
@@ -2706,7 +2707,7 @@ impl From<pb::CheckmessageResponse> for responses::CheckmessageResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CloseResponse> for responses::CloseResponse {
     fn from(c: pb::CloseResponse) -> Self {
         Self {
@@ -2717,7 +2718,7 @@ impl From<pb::CloseResponse> for responses::CloseResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ConnectAddress> for responses::ConnectAddress {
     fn from(c: pb::ConnectAddress) -> Self {
         Self {
@@ -2729,7 +2730,7 @@ impl From<pb::ConnectAddress> for responses::ConnectAddress {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ConnectResponse> for responses::ConnectResponse {
     fn from(c: pb::ConnectResponse) -> Self {
         Self {
@@ -2741,7 +2742,7 @@ impl From<pb::ConnectResponse> for responses::ConnectResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CreateinvoiceResponse> for responses::CreateinvoiceResponse {
     fn from(c: pb::CreateinvoiceResponse) -> Self {
         Self {
@@ -2763,7 +2764,7 @@ impl From<pb::CreateinvoiceResponse> for responses::CreateinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DatastoreResponse> for responses::DatastoreResponse {
     fn from(c: pb::DatastoreResponse) -> Self {
         Self {
@@ -2775,7 +2776,7 @@ impl From<pb::DatastoreResponse> for responses::DatastoreResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::CreateonionResponse> for responses::CreateonionResponse {
     fn from(c: pb::CreateonionResponse) -> Self {
         Self {
@@ -2785,7 +2786,7 @@ impl From<pb::CreateonionResponse> for responses::CreateonionResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DeldatastoreResponse> for responses::DeldatastoreResponse {
     fn from(c: pb::DeldatastoreResponse) -> Self {
         Self {
@@ -2797,7 +2798,7 @@ impl From<pb::DeldatastoreResponse> for responses::DeldatastoreResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DelexpiredinvoiceResponse> for responses::DelexpiredinvoiceResponse {
     fn from(c: pb::DelexpiredinvoiceResponse) -> Self {
         Self {
@@ -2805,7 +2806,7 @@ impl From<pb::DelexpiredinvoiceResponse> for responses::DelexpiredinvoiceRespons
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DelinvoiceResponse> for responses::DelinvoiceResponse {
     fn from(c: pb::DelinvoiceResponse) -> Self {
         Self {
@@ -2823,7 +2824,7 @@ impl From<pb::DelinvoiceResponse> for responses::DelinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::InvoiceResponse> for responses::InvoiceResponse {
     fn from(c: pb::InvoiceResponse) -> Self {
         Self {
@@ -2840,7 +2841,7 @@ impl From<pb::InvoiceResponse> for responses::InvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListdatastoreDatastore> for responses::ListdatastoreDatastore {
     fn from(c: pb::ListdatastoreDatastore) -> Self {
         Self {
@@ -2852,7 +2853,7 @@ impl From<pb::ListdatastoreDatastore> for responses::ListdatastoreDatastore {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListdatastoreResponse> for responses::ListdatastoreResponse {
     fn from(c: pb::ListdatastoreResponse) -> Self {
         Self {
@@ -2861,7 +2862,7 @@ impl From<pb::ListdatastoreResponse> for responses::ListdatastoreResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListinvoicesInvoices> for responses::ListinvoicesInvoices {
     fn from(c: pb::ListinvoicesInvoices) -> Self {
         Self {
@@ -2883,7 +2884,7 @@ impl From<pb::ListinvoicesInvoices> for responses::ListinvoicesInvoices {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListinvoicesResponse> for responses::ListinvoicesResponse {
     fn from(c: pb::ListinvoicesResponse) -> Self {
         Self {
@@ -2892,7 +2893,7 @@ impl From<pb::ListinvoicesResponse> for responses::ListinvoicesResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendonionResponse> for responses::SendonionResponse {
     fn from(c: pb::SendonionResponse) -> Self {
         Self {
@@ -2913,7 +2914,7 @@ impl From<pb::SendonionResponse> for responses::SendonionResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListsendpaysPayments> for responses::ListsendpaysPayments {
     fn from(c: pb::ListsendpaysPayments) -> Self {
         Self {
@@ -2936,7 +2937,7 @@ impl From<pb::ListsendpaysPayments> for responses::ListsendpaysPayments {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListsendpaysResponse> for responses::ListsendpaysResponse {
     fn from(c: pb::ListsendpaysResponse) -> Self {
         Self {
@@ -2945,7 +2946,7 @@ impl From<pb::ListsendpaysResponse> for responses::ListsendpaysResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListtransactionsTransactionsInputs> for responses::ListtransactionsTransactionsInputs {
     fn from(c: pb::ListtransactionsTransactionsInputs) -> Self {
         Self {
@@ -2958,7 +2959,7 @@ impl From<pb::ListtransactionsTransactionsInputs> for responses::Listtransaction
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListtransactionsTransactionsOutputs> for responses::ListtransactionsTransactionsOutputs {
     fn from(c: pb::ListtransactionsTransactionsOutputs) -> Self {
         Self {
@@ -2971,7 +2972,7 @@ impl From<pb::ListtransactionsTransactionsOutputs> for responses::Listtransactio
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListtransactionsTransactions> for responses::ListtransactionsTransactions {
     fn from(c: pb::ListtransactionsTransactions) -> Self {
         Self {
@@ -2987,7 +2988,7 @@ impl From<pb::ListtransactionsTransactions> for responses::ListtransactionsTrans
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListtransactionsResponse> for responses::ListtransactionsResponse {
     fn from(c: pb::ListtransactionsResponse) -> Self {
         Self {
@@ -2996,7 +2997,7 @@ impl From<pb::ListtransactionsResponse> for responses::ListtransactionsResponse 
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::PayResponse> for responses::PayResponse {
     fn from(c: pb::PayResponse) -> Self {
         Self {
@@ -3013,7 +3014,7 @@ impl From<pb::PayResponse> for responses::PayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListnodesNodesAddresses> for responses::ListnodesNodesAddresses {
     fn from(c: pb::ListnodesNodesAddresses) -> Self {
         Self {
@@ -3024,7 +3025,7 @@ impl From<pb::ListnodesNodesAddresses> for responses::ListnodesNodesAddresses {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListnodesNodes> for responses::ListnodesNodes {
     fn from(c: pb::ListnodesNodes) -> Self {
         Self {
@@ -3038,7 +3039,7 @@ impl From<pb::ListnodesNodes> for responses::ListnodesNodes {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListnodesResponse> for responses::ListnodesResponse {
     fn from(c: pb::ListnodesResponse) -> Self {
         Self {
@@ -3047,7 +3048,7 @@ impl From<pb::ListnodesResponse> for responses::ListnodesResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitanyinvoiceResponse> for responses::WaitanyinvoiceResponse {
     fn from(c: pb::WaitanyinvoiceResponse) -> Self {
         Self {
@@ -3067,7 +3068,7 @@ impl From<pb::WaitanyinvoiceResponse> for responses::WaitanyinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitinvoiceResponse> for responses::WaitinvoiceResponse {
     fn from(c: pb::WaitinvoiceResponse) -> Self {
         Self {
@@ -3087,7 +3088,7 @@ impl From<pb::WaitinvoiceResponse> for responses::WaitinvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WaitsendpayResponse> for responses::WaitsendpayResponse {
     fn from(c: pb::WaitsendpayResponse) -> Self {
         Self {
@@ -3109,7 +3110,7 @@ impl From<pb::WaitsendpayResponse> for responses::WaitsendpayResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::NewaddrResponse> for responses::NewaddrResponse {
     fn from(c: pb::NewaddrResponse) -> Self {
         Self {
@@ -3119,7 +3120,7 @@ impl From<pb::NewaddrResponse> for responses::NewaddrResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::WithdrawResponse> for responses::WithdrawResponse {
     fn from(c: pb::WithdrawResponse) -> Self {
         Self {
@@ -3130,7 +3131,7 @@ impl From<pb::WithdrawResponse> for responses::WithdrawResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::KeysendResponse> for responses::KeysendResponse {
     fn from(c: pb::KeysendResponse) -> Self {
         Self {
@@ -3147,7 +3148,7 @@ impl From<pb::KeysendResponse> for responses::KeysendResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FundpsbtReservations> for responses::FundpsbtReservations {
     fn from(c: pb::FundpsbtReservations) -> Self {
         Self {
@@ -3160,7 +3161,7 @@ impl From<pb::FundpsbtReservations> for responses::FundpsbtReservations {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FundpsbtResponse> for responses::FundpsbtResponse {
     fn from(c: pb::FundpsbtResponse) -> Self {
         Self {
@@ -3174,7 +3175,7 @@ impl From<pb::FundpsbtResponse> for responses::FundpsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendpsbtResponse> for responses::SendpsbtResponse {
     fn from(c: pb::SendpsbtResponse) -> Self {
         Self {
@@ -3184,7 +3185,7 @@ impl From<pb::SendpsbtResponse> for responses::SendpsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SignpsbtResponse> for responses::SignpsbtResponse {
     fn from(c: pb::SignpsbtResponse) -> Self {
         Self {
@@ -3193,7 +3194,7 @@ impl From<pb::SignpsbtResponse> for responses::SignpsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::UtxopsbtReservations> for responses::UtxopsbtReservations {
     fn from(c: pb::UtxopsbtReservations) -> Self {
         Self {
@@ -3206,7 +3207,7 @@ impl From<pb::UtxopsbtReservations> for responses::UtxopsbtReservations {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::UtxopsbtResponse> for responses::UtxopsbtResponse {
     fn from(c: pb::UtxopsbtResponse) -> Self {
         Self {
@@ -3220,7 +3221,7 @@ impl From<pb::UtxopsbtResponse> for responses::UtxopsbtResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxdiscardResponse> for responses::TxdiscardResponse {
     fn from(c: pb::TxdiscardResponse) -> Self {
         Self {
@@ -3230,7 +3231,7 @@ impl From<pb::TxdiscardResponse> for responses::TxdiscardResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxprepareResponse> for responses::TxprepareResponse {
     fn from(c: pb::TxprepareResponse) -> Self {
         Self {
@@ -3241,7 +3242,7 @@ impl From<pb::TxprepareResponse> for responses::TxprepareResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::TxsendResponse> for responses::TxsendResponse {
     fn from(c: pb::TxsendResponse) -> Self {
         Self {
@@ -3252,7 +3253,7 @@ impl From<pb::TxsendResponse> for responses::TxsendResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::DisconnectResponse> for responses::DisconnectResponse {
     fn from(c: pb::DisconnectResponse) -> Self {
         Self {
@@ -3260,7 +3261,7 @@ impl From<pb::DisconnectResponse> for responses::DisconnectResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FeeratesPerkb> for responses::FeeratesPerkb {
     fn from(c: pb::FeeratesPerkb) -> Self {
         Self {
@@ -3276,7 +3277,7 @@ impl From<pb::FeeratesPerkb> for responses::FeeratesPerkb {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FeeratesPerkw> for responses::FeeratesPerkw {
     fn from(c: pb::FeeratesPerkw) -> Self {
         Self {
@@ -3292,7 +3293,7 @@ impl From<pb::FeeratesPerkw> for responses::FeeratesPerkw {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FeeratesOnchainFeeEstimates> for responses::FeeratesOnchain_fee_estimates {
     fn from(c: pb::FeeratesOnchainFeeEstimates) -> Self {
         Self {
@@ -3305,7 +3306,7 @@ impl From<pb::FeeratesOnchainFeeEstimates> for responses::FeeratesOnchain_fee_es
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FeeratesResponse> for responses::FeeratesResponse {
     fn from(c: pb::FeeratesResponse) -> Self {
         Self {
@@ -3317,7 +3318,7 @@ impl From<pb::FeeratesResponse> for responses::FeeratesResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::FundchannelResponse> for responses::FundchannelResponse {
     fn from(c: pb::FundchannelResponse) -> Self {
         Self {
@@ -3331,7 +3332,7 @@ impl From<pb::FundchannelResponse> for responses::FundchannelResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetrouteRoute> for responses::GetrouteRoute {
     fn from(c: pb::GetrouteRoute) -> Self {
         Self {
@@ -3346,7 +3347,7 @@ impl From<pb::GetrouteRoute> for responses::GetrouteRoute {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::GetrouteResponse> for responses::GetrouteResponse {
     fn from(c: pb::GetrouteResponse) -> Self {
         Self {
@@ -3355,7 +3356,7 @@ impl From<pb::GetrouteResponse> for responses::GetrouteResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListforwardsForwards> for responses::ListforwardsForwards {
     fn from(c: pb::ListforwardsForwards) -> Self {
         Self {
@@ -3373,7 +3374,7 @@ impl From<pb::ListforwardsForwards> for responses::ListforwardsForwards {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListforwardsResponse> for responses::ListforwardsResponse {
     fn from(c: pb::ListforwardsResponse) -> Self {
         Self {
@@ -3382,7 +3383,7 @@ impl From<pb::ListforwardsResponse> for responses::ListforwardsResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpaysPays> for responses::ListpaysPays {
     fn from(c: pb::ListpaysPays) -> Self {
         Self {
@@ -3402,7 +3403,7 @@ impl From<pb::ListpaysPays> for responses::ListpaysPays {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::ListpaysResponse> for responses::ListpaysResponse {
     fn from(c: pb::ListpaysResponse) -> Self {
         Self {
@@ -3411,7 +3412,7 @@ impl From<pb::ListpaysResponse> for responses::ListpaysResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::PingResponse> for responses::PingResponse {
     fn from(c: pb::PingResponse) -> Self {
         Self {
@@ -3420,7 +3421,7 @@ impl From<pb::PingResponse> for responses::PingResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SendcustommsgResponse> for responses::SendcustommsgResponse {
     fn from(c: pb::SendcustommsgResponse) -> Self {
         Self {
@@ -3429,7 +3430,7 @@ impl From<pb::SendcustommsgResponse> for responses::SendcustommsgResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SetchannelChannels> for responses::SetchannelChannels {
     fn from(c: pb::SetchannelChannels) -> Self {
         Self {
@@ -3446,7 +3447,7 @@ impl From<pb::SetchannelChannels> for responses::SetchannelChannels {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SetchannelResponse> for responses::SetchannelResponse {
     fn from(c: pb::SetchannelResponse) -> Self {
         Self {
@@ -3455,7 +3456,7 @@ impl From<pb::SetchannelResponse> for responses::SetchannelResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SigninvoiceResponse> for responses::SigninvoiceResponse {
     fn from(c: pb::SigninvoiceResponse) -> Self {
         Self {
@@ -3464,7 +3465,7 @@ impl From<pb::SigninvoiceResponse> for responses::SigninvoiceResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::SignmessageResponse> for responses::SignmessageResponse {
     fn from(c: pb::SignmessageResponse) -> Self {
         Self {
@@ -3475,7 +3476,7 @@ impl From<pb::SignmessageResponse> for responses::SignmessageResponse {
     }
 }
 
-#[allow(unused_variables)]
+#[allow(unused_variables,deprecated)]
 impl From<pb::StopResponse> for responses::StopResponse {
     fn from(c: pb::StopResponse) -> Self {
         Self {

--- a/contrib/msggen/msggen/gen/grpc.py
+++ b/contrib/msggen/msggen/gen/grpc.py
@@ -267,7 +267,7 @@ class GrpcConverterGenerator(IGenerator):
         pbname = self.to_camel_case(field.typename)
         # And now we can convert the current field:
         self.write(f"""\
-        #[allow(unused_variables)]
+        #[allow(unused_variables,deprecated)]
         impl From<{prefix}::{field.typename}> for pb::{pbname} {{
             fn from(c: {prefix}::{field.typename}) -> Self {{
                 Self {{
@@ -289,9 +289,9 @@ class GrpcConverterGenerator(IGenerator):
                 }.get(typ, f'i.into()')
 
                 if f.required:
-                    self.write(f"{name}: c.{name}.into_iter().map(|i| {mapping}).collect(), // Rule #3 for type {typ} \n", numindent=3)
+                    self.write(f"{name}: c.{name}.into_iter().map(|i| {mapping}).collect(), // Rule #3 for type {typ}\n", numindent=3)
                 else:
-                    self.write(f"{name}: c.{name}.map(|arr| arr.into_iter().map(|i| {mapping}).collect()).unwrap_or(vec![]), // Rule #3 \n", numindent=3)
+                    self.write(f"{name}: c.{name}.map(|arr| arr.into_iter().map(|i| {mapping}).collect()).unwrap_or(vec![]), // Rule #3\n", numindent=3)
             elif isinstance(f, EnumField):
                 if f.required:
                     self.write(f"{name}: c.{name} as i32,\n", numindent=3)
@@ -391,6 +391,7 @@ class GrpcConverterGenerator(IGenerator):
 
         self.generate_responses(service)
         self.generate_requests(service)
+        self.write("\n")
 
     def write(self, text: str, numindent: int = 0) -> None:
         raw = dedent(text)
@@ -422,7 +423,7 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
         pbname = self.to_camel_case(field.typename)
         # And now we can convert the current field:
         self.write(f"""\
-        #[allow(unused_variables)]
+        #[allow(unused_variables,deprecated)]
         impl From<pb::{pbname}> for {prefix}::{field.typename} {{
             fn from(c: pb::{pbname}) -> Self {{
                 Self {{

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -181,6 +181,11 @@ def test_grpc_generate_certificate(node_factory):
     assert contents[-2] != files[-2].open().read()
     assert contents[-1] != files[-1].open().read()
 
+    keys = [f for f in files if f.name.endswith('-key.pem')]
+    modes = [f.stat().st_mode for f in keys]
+    private = [m % 8 == 0 and (m // 8) % 8 == 0 for m in modes]
+    assert all(private)
+
 
 def test_grpc_no_auto_start(node_factory):
     """Ensure that we do not start cln-grpc unless a port is configured.


### PR DESCRIPTION
The mTLS private key files should be user-readable only, so set the mode accordingly. Also contains a bit of a drive-by fix for deprecated fields in our own code, causing warnings.

Fixes #6064 