### PR TITLE
cln-plugin: Handle incoming events asynchronously

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -811,8 +811,7 @@ install: install-program install-data
 # phase. If you get a missing file/executable while testing on CI it
 # is likely missing from this variable.
 TESTBINS = \
-	target/${RUST_PROFILE}/examples/cln-rpc-getinfo \
-	target/${RUST_PROFILE}/examples/cln-plugin-startup \
+	$(CLN_PLUGIN_EXAMPLES) \
 	tests/plugins/test_libplugin \
 	tests/plugins/test_selfdisable_after_getmanifest \
 	tools/hsmtool

--- a/cln-rpc/Makefile
+++ b/cln-rpc/Makefile
@@ -16,5 +16,8 @@ target/${RUST_PROFILE}/examples/cln-rpc-getinfo: $(shell find cln-rpc -name *.rs
 target/${RUST_PROFILE}/examples/cln-plugin-startup: $(shell find cln-rpc -name *.rs)
 	cargo build ${CARGO_OPTS} --example cln-plugin-startup
 
+target/${RUST_PROFILE}/examples/cln-plugin-reentrant: $(shell find plugins/examples -name *.rs)
+	cargo build ${CARGO_OPTS} --example cln-plugin-reentrant
+
 
 cln-rpc-all: ${CLN_RPC_GEN_ALL} ${CLN_RPC_EXAMPLES}

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -795,7 +795,7 @@ class LightningNode(object):
         if dsn is not None:
             self.daemon.opts['wallet'] = dsn
         if valgrind:
-            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*,*cln-grpc'
+            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*,*cln-*'
             if not valgrind_plugins:
                 trace_skip_pattern += ',*plugins*'
             self.daemon.cmd_prefix = [

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_PAY_SRC := plugins/pay.c
-PLUGIN_PAY_HEADER := 
+PLUGIN_PAY_HEADER :=
 PLUGIN_PAY_OBJS := $(PLUGIN_PAY_SRC:.c=.o)
 
 PLUGIN_AUTOCLEAN_SRC := plugins/autoclean.c
@@ -40,7 +40,7 @@ PLUGIN_FETCHINVOICE_OBJS := $(PLUGIN_FETCHINVOICE_SRC:.c=.o)
 PLUGIN_FETCHINVOICE_HEADER :=
 
 PLUGIN_SQL_SRC := plugins/sql.c
-PLUGIN_SQL_HEADER := 
+PLUGIN_SQL_HEADER :=
 PLUGIN_SQL_OBJS := $(PLUGIN_SQL_SRC:.c=.o)
 
 PLUGIN_SPENDER_SRC :=				\
@@ -188,7 +188,7 @@ plugins/autoclean: $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_O
 
 plugins/chanbackup: $(PLUGIN_chanbackup_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
-plugins/commando: $(PLUGIN_COMMANDO_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) 
+plugins/commando: $(PLUGIN_COMMANDO_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
 # Topology wants to decode node_announcement, and peer_wiregen which
 # pulls in some of bitcoin/.
@@ -232,6 +232,7 @@ plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile config.vars
 
 CLN_PLUGIN_EXAMPLES := \
 	target/${RUST_PROFILE}/examples/cln-plugin-startup \
+	target/${RUST_PROFILE}/examples/cln-plugin-reentrant \
 	target/${RUST_PROFILE}/examples/cln-rpc-getinfo
 
 CLN_PLUGIN_SRC = $(shell find plugins/src -name "*.rs")

--- a/plugins/examples/cln-plugin-reentrant.rs
+++ b/plugins/examples/cln-plugin-reentrant.rs
@@ -1,0 +1,44 @@
+use anyhow::Error;
+use cln_plugin::{Builder, Plugin};
+use serde_json::json;
+use tokio::sync::broadcast;
+
+#[derive(Clone)]
+struct State {
+    tx: broadcast::Sender<()>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let (tx, _) = broadcast::channel(4);
+    let state = State { tx };
+
+    if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
+        .hook("htlc_accepted", htlc_accepted_handler)
+        .rpcmethod("release", "Release all HTLCs we currently hold", release)
+        .start(state)
+        .await?
+    {
+        plugin.join().await?;
+        Ok(())
+    } else {
+        Ok(())
+    }
+}
+
+/// Release all waiting HTLCs
+async fn release(p: Plugin<State>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+    p.state().tx.send(()).unwrap();
+    Ok(json!("Released!"))
+}
+
+async fn htlc_accepted_handler(
+    p: Plugin<State>,
+    v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
+    log::info!("Holding on to incoming HTLC {:?}", v);
+    // Wait for `release` to be called.
+    p.state().tx.subscribe().recv().await.unwrap();
+
+    Ok(json!({"result": "continue"}))
+}

--- a/plugins/src/codec.rs
+++ b/plugins/src/codec.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use std::{io, str};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::messages::{Notification, Request};
 use crate::messages::JsonRpc;
+use crate::messages::{Notification, Request};
 
 /// A simple codec that parses messages separated by two successive
 /// `\n` newlines.

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -41,20 +41,20 @@ pub(crate) enum Request {
 #[serde(tag = "method", content = "params")]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Notification {
-//     ChannelOpened,
-//     ChannelOpenFailed,
-//     ChannelStateChanged,
-//     Connect,
-//     Disconnect,
-//     InvoicePayment,
-//     InvoiceCreation,
-//     Warning,
-//     ForwardEvent,
-//     SendpaySuccess,
-//     SendpayFailure,
-//     CoinMovement,
-//     OpenchannelPeerSigs,
-//     Shutdown,
+    //     ChannelOpened,
+    //     ChannelOpenFailed,
+    //     ChannelStateChanged,
+    //     Connect,
+    //     Disconnect,
+    //     InvoicePayment,
+    //     InvoiceCreation,
+    //     Warning,
+    //     ForwardEvent,
+    //     SendpaySuccess,
+    //     SendpayFailure,
+    //     CoinMovement,
+    //     OpenchannelPeerSigs,
+    //     Shutdown,
 }
 
 #[derive(Deserialize, Debug)]

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -28,7 +28,7 @@ impl Value {
             _ => None,
         }
     }
-    
+
     /// Returns true if the `Value` is an integer between `i64::MIN` and
     /// `i64::MAX`.
     ///
@@ -36,8 +36,6 @@ impl Value {
     /// return the integer value.
     pub fn is_i64(&self) -> bool {
         self.as_i64().is_some()
-            
-        
     }
 
     /// If the `Value` is an integer, represent it as i64. Returns

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -249,10 +249,6 @@ def test_grpc_wrong_auth(node_factory):
     stub.Getinfo(nodepb.GetinfoRequest())
 
 
-@pytest.mark.xfail(
-    reason="Times out because we can't call the RPC method while currently holding on to HTLCs",
-    strict=True,
-)
 def test_cln_plugin_reentrant(node_factory, executor):
     """Ensure that we continue processing events while already handling.
 

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -249,6 +249,46 @@ def test_grpc_wrong_auth(node_factory):
     stub.Getinfo(nodepb.GetinfoRequest())
 
 
+@pytest.mark.xfail(
+    reason="Times out because we can't call the RPC method while currently holding on to HTLCs",
+    strict=True,
+)
+def test_cln_plugin_reentrant(node_factory, executor):
+    """Ensure that we continue processing events while already handling.
+
+    We should be continuing to handle incoming events even though a
+    prior event has not completed. This is important for things like
+    the `htlc_accepted` hook which needs to hold on to multiple
+    incoming HTLCs.
+
+    Scenario: l1 uses an `htlc_accepted` to hold on to incoming HTLCs,
+    and we release them using an RPC method.
+
+    """
+    bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-plugin-reentrant"
+    l1 = node_factory.get_node(options={"plugin": str(bin_path)})
+    l2 = node_factory.get_node()
+    l2.connect(l1)
+    l2.fundchannel(l1)
+
+    # Now create two invoices, and pay them both. Neither should
+    # succeed, but we should queue them on the plugin.
+    i1 = l1.rpc.invoice(label='lbl1', msatoshi='42sat', description='desc')['bolt11']
+    i2 = l1.rpc.invoice(label='lbl2', msatoshi='31337sat', description='desc')['bolt11']
+
+    f1 = executor.submit(l2.rpc.pay, i1)
+    f2 = executor.submit(l2.rpc.pay, i2)
+
+    import time
+    time.sleep(3)
+
+    print("Releasing HTLCs after holding them")
+    l1.rpc.call('release')
+
+    assert f1.result()
+    assert f2.result()
+
+
 def test_grpc_keysend_routehint(bitcoind, node_factory):
     """The routehints are a bit special, test that conversions work.
 


### PR DESCRIPTION
This was reported as an issue with `htlc_accepted` and the `invoice_payment` hooks, not working properly, but the root cause seems to be that we were synchrously handling events, only reading the next once the previous one hast been fully dealt with. This of course doesn't allow for things like holding multiple `htlc_accepted` hook calls, waiting for an incoming notification while processing a hook or request, and prevent reentrant calls into the plugin through the RPC passthrough.

This PR just runs handlers in `async` tasks, freeing the event loop that reads from `lightningd` to read any concurrent events.