### PR TITLE
plugins/pay: revert removal of paying invoice without description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [23.02.2] - 2023-03-14: "CBDC Backing Layer III"
+
+
+### Added
+
+ - JSON-RPC: Restore `pay` for a bolt11 which uses a `description_hash`, without setting `description` (still deprecated, but the world is not ready) [
+
+[#6092]: https://github.com/ElementsProject/lightning/pull/6092
+
+
 ## [23.02.1] - 2023-03-10: "CBDC Backing Layer II"
 
 This release named by @whitslack

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1067,7 +1067,7 @@ static struct command_result *json_pay(struct command *cmd,
 		 * - MUST check that the SHA2 256-bit hash in the `h` field
 		 *   exactly matches the hashed description.
 		 */
-		if (!b11->description) {
+		if (!b11->description && !deprecated_apis) {
 			if (!b11->description_hash) {
 				return command_fail(cmd,
 						    JSONRPC2_INVALID_PARAMS,


### PR DESCRIPTION
It's still deprecated: we need the description since

1. This information is useful for any validation we want to do, such as the HSM, or runes.
2. We want this information in listpays so we can tell what we actually paid.
3. In general, we should never sign commitments to things we don't have!

I expect to have this information about payments *whatever the frontend* is, which is why we deprecated (and then removed) this unintended use.  The spec is pretty clear on this:

BOLT 11 (https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#requirements-3)
```
A reader:
...
  - MUST check that the SHA2 256-bit hash in the `h` field exactly matches the hashed
  description.
```

However, neither BTCPayServer nor lnbits updated despite the long deprecation period, so revert 2afe7a1856b04177898e2dea6b1050d4c8477d87.

Changelog-None: We edit CHANGELOG.md directly for release.