### PR TITLE
fuzz: avoid buffer overflow in bech32 target

### DIFF
--- a/tests/fuzz/fuzz-bech32.c
+++ b/tests/fuzz/fuzz-bech32.c
@@ -19,6 +19,9 @@ void run(const uint8_t *data, size_t size)
 	int wit_version;
 	bech32_encoding benc;
 
+	if (size < 1)
+		return;
+
 	/* Buffer size is defined in each function's doc comment. */
 	bech32_str = malloc(size + strlen(hrp_inv) + 8);
 	benc = data[0] ? BECH32_ENCODING_BECH32 : BECH32_ENCODING_BECH32M;


### PR DESCRIPTION
If the fuzzer passes an empty `data` buffer, the fuzz target currently attempts to read from it. We should short-circuit instead.

Changelog-None