### PR TITLE
fuzz: fix invalid pubkey error

### DIFF
--- a/tests/fuzz/fuzz-close_tx.c
+++ b/tests/fuzz/fuzz-close_tx.c
@@ -71,10 +71,10 @@ void run(const uint8_t *data, size_t size)
 	/* We assert it's valid, so we can't throw garbage at the funding script.. */
 	pk1 = tal(tmpctx, struct pubkey);
 	pk2 = tal(tmpctx, struct pubkey);
-	pubkey_from_hexstr("034fede2c619f647fe7c01d40ae22e4c285291ca2ffb47937bbfb7d6e8285a081f",
-			   PUBKEY_CMPR_LEN, pk1);
-	pubkey_from_hexstr("028dfe31019dd61fa04c76ad065410e5d063ac2949c04c14b214c1b363e517452f",
-			   PUBKEY_CMPR_LEN, pk2);
+	assert(pubkey_from_hexstr("034fede2c619f647fe7c01d40ae22e4c285291ca2ffb47937bbfb7d6e8285a081f",
+				  2 * PUBKEY_CMPR_LEN, pk1));
+	assert(pubkey_from_hexstr("028dfe31019dd61fa04c76ad065410e5d063ac2949c04c14b214c1b363e517452f",
+				  2 * PUBKEY_CMPR_LEN, pk2));
 	funding_script = bitcoin_redeem_2of2(tmpctx, pk1, pk2);
 
 	create_close_tx(tmpctx, chainparams, NULL, NULL, our_script,


### PR DESCRIPTION
`pubkey_from_hexstr` was failing, which we didn't notice because we weren't checking the return value. The problem was that we were passing it a strlen that was half the actual length.

Relevant error:

```
  [libsecp256k1] illegal argument: !secp256k1_fe_is_zero(&ge->x)

  ==417723== ERROR: libFuzzer: deadly signal
    #7 0x7f5deaacc7fb in abort
    #8 0x51b0b0 in secp256k1_default_illegal_callback_fn secp256k1.c
    #9 0x51bd8e in secp256k1_ec_pubkey_serialize
    #10 0x4e235b in pubkey_to_der bitcoin/pubkey.c:29:7
    #11 0x4e2941 in pubkey_cmp bitcoin/pubkey.c:89:2
    #12 0x4e333d in bitcoin_redeem_2of2 bitcoin/script.c:144:6
    #13 0x4f1396 in run tests/fuzz/fuzz-close_tx.c:78:19
```