### PR TITLE
gossip: improve handling of self-generated gossip when sending to peers

### DIFF
--- a/connectd/gossip_store.c
+++ b/connectd/gossip_store.c
@@ -111,7 +111,6 @@ static bool public_msg_type(enum peer_wire type)
 u8 *gossip_store_next(const tal_t *ctx,
 		      int *gossip_store_fd,
 		      u32 timestamp_min, u32 timestamp_max,
-		      bool push_only,
 		      bool with_spam,
 		      size_t *off, size_t *end)
 {
@@ -173,8 +172,6 @@ u8 *gossip_store_next(const tal_t *ctx,
 			msg = tal_free(msg);
 		/* Ignore gossipd internal messages. */
 		} else if (!public_msg_type(type)) {
-			msg = tal_free(msg);
-		} else if (!push && push_only) {
 			msg = tal_free(msg);
 		} else if (!with_spam && ratelimited) {
 			msg = tal_free(msg);

--- a/connectd/gossip_store.c
+++ b/connectd/gossip_store.c
@@ -121,7 +121,7 @@ u8 *gossip_store_next(const tal_t *ctx,
 		struct gossip_hdr hdr;
 		u16 msglen, flags;
 		u32 checksum, timestamp;
-		bool push, ratelimited;
+		bool ratelimited;
 		int type, r;
 
 		r = pread(*gossip_store_fd, &hdr, sizeof(hdr), *off);
@@ -130,7 +130,6 @@ u8 *gossip_store_next(const tal_t *ctx,
 
 		msglen = be16_to_cpu(hdr.len);
 		flags = be16_to_cpu(hdr.flags);
-		push = (flags & GOSSIP_STORE_PUSH_BIT);
 		ratelimited = (flags & GOSSIP_STORE_RATELIMIT_BIT);
 
 		/* Skip any deleted entries. */
@@ -141,8 +140,7 @@ u8 *gossip_store_next(const tal_t *ctx,
 
 		/* Skip any timestamp filtered */
 		timestamp = be32_to_cpu(hdr.timestamp);
-		if (!push &&
-		    !timestamp_filter(timestamp_min, timestamp_max,
+		if (!timestamp_filter(timestamp_min, timestamp_max,
 				      timestamp)) {
 			*off += r + msglen;
 			continue;

--- a/connectd/gossip_store.h
+++ b/connectd/gossip_store.h
@@ -13,7 +13,6 @@
 u8 *gossip_store_next(const tal_t *ctx,
 		      int *gossip_store_fd,
 		      u32 timestamp_min, u32 timestamp_max,
-		      bool push_only,
 		      bool with_spam,
 		      size_t *off, size_t *end);
 

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -505,23 +505,6 @@ static u8 *maybe_from_gossip_store(const tal_t *ctx, struct peer *peer)
 	if (IFDEV(peer->daemon->dev_suppress_gossip, false))
 		return NULL;
 
-	/* BOLT #7:
-	 *   - if the `gossip_queries` feature is negotiated:
-	 *     - MUST NOT relay any gossip messages it did not generate itself,
-	 *       unless explicitly requested.
-	 */
-
-	/* So, even if they didn't send us a timestamp_filter message,
-	 * we *still* send our own gossip. */
-	if (!peer->gs.gossip_timer) {
-		return gossip_store_next(ctx, &peer->daemon->gossip_store_fd,
-					 0, 0xFFFFFFFF,
-					 true,
-					 false,
-					 &peer->gs.off,
-					 &peer->daemon->gossip_store_end);
-	}
-
 	/* Not streaming right now? */
 	if (!peer->gs.active)
 		return NULL;

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -517,7 +517,6 @@ again:
 				peer->gs.timestamp_min,
 				peer->gs.timestamp_max,
 				false,
-				false,
 				&peer->gs.off,
 				&peer->daemon->gossip_store_end);
 	/* Don't send back gossip they sent to us! */

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -46,7 +46,7 @@ u64 gossip_store_add_private_update(struct gossip_store *gs, const u8 *update);
  *            (for appending amounts to channel_announcements for internal use).
  */
 u64 gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg,
-		     u32 timestamp, bool push, bool zombie, bool spam,
+		     u32 timestamp, bool zombie, bool spam,
 		     const u8 *addendum);
 
 

--- a/gossipd/test/run-check_channel_announcement.c
+++ b/gossipd/test/run-check_channel_announcement.c
@@ -61,7 +61,7 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
 		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -32,7 +32,7 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool push UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
 		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1869,11 +1869,9 @@ def test_gossip_ratelimit(node_factory, bitcoind):
     We get BROKEN logs because gossipd talks about non-existent channels to
     lightningd ("**BROKEN** lightningd: Local update for bad scid 103x1x1").
     """
-    l3, = node_factory.get_nodes(
-        1,
-        opts=[{'dev-gossip-time': 1568096251,
-               'allow_broken_log': True}]
-    )
+    l3 = node_factory.get_node(node_id=3,
+                               allow_broken_log=True,
+                               options={'dev-gossip-time': 1568096251})
 
     # Bump to block 102, so the following tx ends up in 103x1:
     bitcoind.generate_block(1)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1397,7 +1397,7 @@ def test_gossipwith(node_factory):
         num_msgs += 1
 
     # one channel announcement, two channel_updates, two node announcements.
-    assert num_msgs == 5
+    assert num_msgs == 7
 
 
 def test_gossip_notices_close(node_factory, bitcoind):


### PR DESCRIPTION
Despite improvements in peer handling and connection, there is still a bottleneck in connectd traversing the entire gossip_store on each new peer connection in order to send our own gossip (anything flagged with `push`.)  This moves the task of streaming our self-generated gossip from connectd to gossipd, gaining efficiency from gossipd's data structures.  As a side effect, the gossip_store push flag becomes superfluous. Additionally, the handling of gossip filtering is also now truly trinary (all/none/stream.)

Changelog-Changed: Self-generated gossip is more efficiently streamed on peer connect; gossip_store push bit removed.