### PR TITLE
Implement registering and sending custom notifications to lightningd

### DIFF
--- a/cln-rpc/Makefile
+++ b/cln-rpc/Makefile
@@ -8,13 +8,13 @@ DEFAULT_TARGETS += $(CLN_RPC_EXAMPLES) $(CLN_RPC_GENALL)
 
 MSGGEN_GENALL += $(CLN_RPC_GENALL)
 
-target/${RUST_PROFILE}/examples/cln-rpc-getinfo: $(shell find cln-rpc -name *.rs)
+target/${RUST_PROFILE}/examples/cln-rpc-getinfo: ${CLN_RPC_SOURCES} cln-rpc/examples/getinfo.rs
 	cargo build ${CARGO_OPTS} --example cln-rpc-getinfo
 
-target/${RUST_PROFILE}/examples/cln-plugin-startup: plugins/examples/cln-plugin-startup.rs
+target/${RUST_PROFILE}/examples/cln-plugin-startup: ${CLN_RPC_SOURCES} plugins/examples/cln-plugin-startup.rs
 	cargo build ${CARGO_OPTS} --example cln-plugin-startup
 
-target/${RUST_PROFILE}/examples/cln-plugin-reentrant: plugins/examples/cln-plugin-reentrant.rs
+target/${RUST_PROFILE}/examples/cln-plugin-reentrant: ${CLN_RPC_SOURCES} plugins/examples/cln-plugin-reentrant.rs
 	cargo build ${CARGO_OPTS} --example cln-plugin-reentrant
 
 

--- a/cln-rpc/Makefile
+++ b/cln-rpc/Makefile
@@ -11,10 +11,10 @@ MSGGEN_GENALL += $(CLN_RPC_GENALL)
 target/${RUST_PROFILE}/examples/cln-rpc-getinfo: $(shell find cln-rpc -name *.rs)
 	cargo build ${CARGO_OPTS} --example cln-rpc-getinfo
 
-target/${RUST_PROFILE}/examples/cln-plugin-startup: $(shell find cln-rpc -name *.rs)
+target/${RUST_PROFILE}/examples/cln-plugin-startup: plugins/examples/cln-plugin-startup.rs
 	cargo build ${CARGO_OPTS} --example cln-plugin-startup
 
-target/${RUST_PROFILE}/examples/cln-plugin-reentrant: $(shell find plugins/examples -name *.rs)
+target/${RUST_PROFILE}/examples/cln-plugin-reentrant: plugins/examples/cln-plugin-reentrant.rs
 	cargo build ${CARGO_OPTS} --example cln-plugin-reentrant
 
 

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -2,8 +2,11 @@
 //! plugins using the Rust API against Core Lightning.
 #[macro_use]
 extern crate serde_json;
-use cln_plugin::{options, Builder, Error, Plugin};
+use cln_plugin::{messages, options, Builder, Error, Plugin};
 use tokio;
+
+const TEST_NOTIF_TAG: &str = "test_custom_notification";
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let state = ();
@@ -25,8 +28,15 @@ async fn main() -> Result<(), anyhow::Error> {
             "Retrieve options from this plugin",
             testoptions,
         )
+        .rpcmethod(
+            "test-custom-notification",
+            "send a test_custom_notification event",
+            test_send_custom_notification,
+        )
         .subscribe("connect", connect_handler)
+        .subscribe("test_custom_notification", test_receive_custom_notification)
         .hook("peer_connected", peer_connected_handler)
+        .notification(messages::NotificationTopic::new(TEST_NOTIF_TAG))
         .start(state)
         .await?
     {
@@ -44,6 +54,26 @@ async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json:
 
 async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!("Hello"))
+}
+
+async fn test_send_custom_notification(
+    p: Plugin<()>,
+    _v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
+    let custom_notification = json!({
+        "test": "test",
+    });
+    p.send_custom_notification(TEST_NOTIF_TAG.to_string(), custom_notification)
+        .await?;
+    Ok(json!("Notification sent"))
+}
+
+async fn test_receive_custom_notification(
+    _p: Plugin<()>,
+    v: serde_json::Value,
+) -> Result<(), Error> {
+    log::info!("Received a test_custom_notification: {}", v);
+    Ok(())
 }
 
 async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -66,6 +66,7 @@ where
     rpcmethods: HashMap<String, AsyncCallback<S>>,
     hooks: HashMap<String, AsyncCallback<S>>,
     subscriptions: HashMap<String, AsyncNotificationCallback<S>>,
+    #[allow(dead_code)] // unsure why rust thinks this field isn't used
     notifications: Vec<NotificationTopic>,
 }
 
@@ -666,7 +667,7 @@ where
             .send(json!({
                 "jsonrpc": "2.0",
                 "method": method,
-                "params": {method: v},
+                "params": v,
             }))
             .await
             .context("sending custom notification")?;

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -5,7 +5,7 @@ use futures::sink::SinkExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 extern crate log;
 use log::trace;
-use messages::Configuration;
+use messages::{Configuration, NotificationTopic};
 use options::ConfigOption;
 use std::collections::HashMap;
 use std::future::Future;
@@ -46,6 +46,7 @@ where
     options: Vec<ConfigOption>,
     rpcmethods: HashMap<String, RpcMethod<S>>,
     subscriptions: HashMap<String, Subscription<S>>,
+    notifications: Vec<NotificationTopic>,
     dynamic: bool,
 }
 
@@ -65,6 +66,7 @@ where
     rpcmethods: HashMap<String, AsyncCallback<S>>,
     hooks: HashMap<String, AsyncCallback<S>>,
     subscriptions: HashMap<String, AsyncNotificationCallback<S>>,
+    notifications: Vec<NotificationTopic>,
 }
 
 /// The [PluginDriver] is used to run the IO loop, reading messages
@@ -115,12 +117,18 @@ where
             subscriptions: HashMap::new(),
             options: vec![],
             rpcmethods: HashMap::new(),
+            notifications: vec![],
             dynamic: false,
         }
     }
 
     pub fn option(mut self, opt: options::ConfigOption) -> Builder<S, I, O> {
         self.options.push(opt);
+        self
+    }
+
+    pub fn notification(mut self, notif: messages::NotificationTopic) -> Builder<S, I, O> {
+        self.notifications.push(notif);
         self
     }
 
@@ -274,6 +282,7 @@ where
             input,
             output,
             rpcmethods,
+            notifications: self.notifications,
             subscriptions,
             options: self.options,
             configuration,
@@ -318,6 +327,7 @@ where
             subscriptions: self.subscriptions.keys().map(|s| s.clone()).collect(),
             hooks: self.hooks.keys().map(|s| s.clone()).collect(),
             rpcmethods,
+            notifications: self.notifications.clone(),
             dynamic: self.dynamic,
             nonnumericids: true,
         }
@@ -647,6 +657,22 @@ impl<S> Plugin<S>
 where
     S: Send + Clone,
 {
+    pub async fn send_custom_notification(
+        &self,
+        method: String,
+        v: serde_json::Value,
+    ) -> Result<(), Error> {
+        self.sender
+            .send(json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": {method: v},
+            }))
+            .await
+            .context("sending custom notification")?;
+        Ok(())
+    }
+
     /// Wait for plugin shutdown
     pub async fn join(&self) -> Result<(), Error> {
         self.wait_handle

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -150,11 +150,31 @@ pub(crate) struct RpcMethod {
     pub(crate) usage: String,
 }
 
+#[derive(Serialize, Default, Debug, Clone)]
+pub struct NotificationTopic {
+    pub method: String,
+}
+
+impl NotificationTopic {
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+}
+
+impl NotificationTopic {
+    pub fn new(method: &str) -> Self {
+        Self {
+            method: method.to_string(),
+        }
+    }
+}
+
 #[derive(Serialize, Default, Debug)]
 pub(crate) struct GetManifestResponse {
     pub(crate) options: Vec<ConfigOption>,
     pub(crate) rpcmethods: Vec<RpcMethod>,
     pub(crate) subscriptions: Vec<String>,
+    pub(crate) notifications: Vec<NotificationTopic>,
     pub(crate) hooks: Vec<String>,
     pub(crate) dynamic: bool,
     pub(crate) nonnumericids: bool,

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -44,7 +44,7 @@ def test_plugin_start(node_factory):
     assert str(bin_path) in l1.rpc.listconfigs()['configs']['plugin']['values_str']
 
     # Now check that the `testmethod was registered ok
-    l1.rpc.help("testmethod") == {
+    assert l1.rpc.help("testmethod") == {
         'help': [
             {
                 'command': 'testmethod ',
@@ -57,6 +57,8 @@ def test_plugin_start(node_factory):
     }
 
     assert l1.rpc.testmethod() == "Hello"
+    assert l1.rpc.test_custom_notification() == "Notification sent"
+    l1.daemon.wait_for_log(r'Received a test_custom_notification')
 
     l1.connect(l2)
     l1.daemon.wait_for_log(r'Got a connect hook call')


### PR DESCRIPTION
The ability to send custom notifications from plugins is needed for a new rust plugin, [smaug](https://github.com/chrisguida/smaug), which, once finished, will watch a descriptor wallet for updates and sends on-chain movements to the `bookkeeper` plugin using custom notifications.

This PR updates the `cln-plugin` create with a new `send_custom_notification` method on the `Plugin` object, which allows plugins to send custom notifications during normal operation. It also expands the `getmanifest` rpc response with a `notifications` array, which is needed in order for the plugin to register which notifications it wants to send with `lightningd`.

Sorry for all the formatting changes, my editor does this automatically on save and I'm unsure how to easily revert these, but I will remove if requested.

Edit: hmm, all my formatting changes are gone. No idea how that happened. Magic!