### PR TITLE
Zero fee htlc prep #4: channel types everywhere, with protocol fixes :(

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -611,8 +611,8 @@ bool psbt_finalize(struct wally_psbt *psbt)
 		const struct wally_map_item *iws;
 
 		iws = wally_map_get_integer(&input->psbt_fields, /* PSBT_IN_WITNESS_SCRIPT */ 0x05);
-		if (!iws || !is_anchor_witness_script(iws->value,
-					      iws->value_len))
+		if (!iws || !is_to_remote_anchored_witness_script(iws->value,
+								  iws->value_len))
 			continue;
 
 		if (input->signatures.num_items != 1)

--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -329,9 +329,9 @@ u8 *scriptpubkey_witness_raw(const tal_t *ctx, u8 version,
  * <remote_pubkey> OP_CHECKSIGVERIFY MAX(1, lease_end - blockheight) OP_CHECKSEQUENCEVERIFY
  */
 
-u8 *anchor_to_remote_redeem(const tal_t *ctx,
-			    const struct pubkey *remote_key,
-			    u32 csv_lock)
+u8 *bitcoin_wscript_to_remote_anchored(const tal_t *ctx,
+				       const struct pubkey *remote_key,
+				       u32 csv_lock)
 {
 	u8 *script = tal_arr(ctx, u8, 0);
 	add_push_key(&script, remote_key);
@@ -339,11 +339,11 @@ u8 *anchor_to_remote_redeem(const tal_t *ctx,
 	add_number(&script, csv_lock);
 	add_op(&script, OP_CHECKSEQUENCEVERIFY);
 
-	assert(is_anchor_witness_script(script, tal_bytelen(script)));
+	assert(is_to_remote_anchored_witness_script(script, tal_bytelen(script)));
 	return script;
 }
 
-bool is_anchor_witness_script(const u8 *script, size_t script_len)
+bool is_to_remote_anchored_witness_script(const u8 *script, size_t script_len)
 {
 	size_t len = 34 + 1 + 1 + 1;
 	/* With option_will_fund, the pushbytes can be up to 2 bytes more

--- a/bitcoin/script.h
+++ b/bitcoin/script.h
@@ -64,9 +64,9 @@ u8 *scriptpubkey_witness_raw(const tal_t *ctx, u8 version,
 			     const u8 *wprog, size_t wprog_size);
 
 /* To-remotekey with csv max(lease_expiry - blockheight, 1) delay. */
-u8 *anchor_to_remote_redeem(const tal_t *ctx,
-			    const struct pubkey *remote_key,
-			    u32 csv_lock);
+u8 *bitcoin_wscript_to_remote_anchored(const tal_t *ctx,
+				       const struct pubkey *remote_key,
+				       u32 csv_lock);
 
 /* Create a witness which spends the 2of2. */
 u8 **bitcoin_witness_2of2(const tal_t *ctx,
@@ -156,8 +156,8 @@ bool is_p2wpkh(const u8 *script, struct bitcoin_address *addr);
 /* Is this one of the four above script types? */
 bool is_known_scripttype(const u8 *script);
 
-/* Is this an anchor witness script? */
-bool is_anchor_witness_script(const u8 *script, size_t script_len);
+/* Is this a to-remote witness script (used for option_anchor_outputs)? */
+bool is_to_remote_anchored_witness_script(const u8 *script, size_t script_len);
 
 /* Are these two scripts equal? */
 bool scripteq(const u8 *s1, const u8 *s2);

--- a/bitcoin/test/run-bitcoin_block_from_hex.c
+++ b/bitcoin/test/run-bitcoin_block_from_hex.c
@@ -69,9 +69,9 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_u8_array */
 void fromwire_u8_array(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, u8 *arr UNNEEDED, size_t num UNNEEDED)
 { fprintf(stderr, "fromwire_u8_array called!\n"); abort(); }
-/* Generated stub for is_anchor_witness_script */
-bool is_anchor_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
-{ fprintf(stderr, "is_anchor_witness_script called!\n"); abort(); }
+/* Generated stub for is_to_remote_anchored_witness_script */
+bool is_to_remote_anchored_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
+{ fprintf(stderr, "is_to_remote_anchored_witness_script called!\n"); abort(); }
 /* Generated stub for pubkey_to_der */
 void pubkey_to_der(u8 der[PUBKEY_CMPR_LEN] UNNEEDED, const struct pubkey *key UNNEEDED)
 { fprintf(stderr, "pubkey_to_der called!\n"); abort(); }

--- a/bitcoin/test/run-psbt-from-tx.c
+++ b/bitcoin/test/run-psbt-from-tx.c
@@ -50,9 +50,9 @@ struct amount_sat amount_tx_fee(u32 fee_per_kw UNNEEDED, size_t weight UNNEEDED)
 void fromwire_sha256_double(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
 			    struct sha256_double *sha256d UNNEEDED)
 { fprintf(stderr, "fromwire_sha256_double called!\n"); abort(); }
-/* Generated stub for is_anchor_witness_script */
-bool is_anchor_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
-{ fprintf(stderr, "is_anchor_witness_script called!\n"); abort(); }
+/* Generated stub for is_to_remote_anchored_witness_script */
+bool is_to_remote_anchored_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
+{ fprintf(stderr, "is_to_remote_anchored_witness_script called!\n"); abort(); }
 /* Generated stub for pubkey_to_der */
 void pubkey_to_der(u8 der[PUBKEY_CMPR_LEN] UNNEEDED, const struct pubkey *key UNNEEDED)
 { fprintf(stderr, "pubkey_to_der called!\n"); abort(); }

--- a/bitcoin/test/run-tx-encode.c
+++ b/bitcoin/test/run-tx-encode.c
@@ -70,9 +70,9 @@ u8 fromwire_u8(const u8 **cursor UNNEEDED, size_t *max UNNEEDED)
 /* Generated stub for fromwire_u8_array */
 void fromwire_u8_array(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, u8 *arr UNNEEDED, size_t num UNNEEDED)
 { fprintf(stderr, "fromwire_u8_array called!\n"); abort(); }
-/* Generated stub for is_anchor_witness_script */
-bool is_anchor_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
-{ fprintf(stderr, "is_anchor_witness_script called!\n"); abort(); }
+/* Generated stub for is_to_remote_anchored_witness_script */
+bool is_to_remote_anchored_witness_script(const u8 *script UNNEEDED, size_t script_len UNNEEDED)
+{ fprintf(stderr, "is_to_remote_anchored_witness_script called!\n"); abort(); }
 /* Generated stub for pubkey_to_der */
 void pubkey_to_der(u8 der[PUBKEY_CMPR_LEN] UNNEEDED, const struct pubkey *key UNNEEDED)
 { fprintf(stderr, "pubkey_to_der called!\n"); abort(); }

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -95,6 +95,15 @@ int bitcoin_tx_add_output(struct bitcoin_tx *tx, const u8 *script,
 	return i;
 }
 
+void bitcoin_tx_remove_output(struct bitcoin_tx *tx, size_t outnum)
+{
+	int ret;
+	ret = wally_tx_remove_output(tx->wtx, outnum);
+	assert(ret == WALLY_OK);
+	ret = wally_psbt_remove_output(tx->psbt, outnum);
+	assert(ret == WALLY_OK);
+}
+
 bool elements_wtx_output_is_fee(const struct wally_tx *tx, int outnum)
 {
 	assert(outnum < tx->num_outputs);

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -104,6 +104,9 @@ int bitcoin_tx_add_output(struct bitcoin_tx *tx, const u8 *script,
 			  const u8 *wscript,
 			  struct amount_sat amount);
 
+/* Remove one output. */
+void bitcoin_tx_remove_output(struct bitcoin_tx *tx, size_t outnum);
+
 /* Set the locktime for a transaction */
 void bitcoin_tx_set_locktime(struct bitcoin_tx *tx, u32 locktime);
 

--- a/channeld/commit_tx.c
+++ b/channeld/commit_tx.c
@@ -304,7 +304,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 		 * Otherwise, this output is a simple P2WPKH to `remotepubkey`.
 		 */
 		if (option_anchor_outputs) {
-			redeem = anchor_to_remote_redeem(tmpctx,
+			redeem = bitcoin_wscript_to_remote_anchored(tmpctx,
 							 &keyset->other_payment_key,
 							 (!side) == lessor ?
 							       csv_lock : 1);

--- a/common/channel_type.c
+++ b/common/channel_type.c
@@ -122,7 +122,8 @@ struct channel_type *channel_type_from(const tal_t *ctx,
 struct channel_type *channel_type_accept(const tal_t *ctx,
 					 const u8 *t,
 					 const struct feature_set *our_features,
-					 const u8 *their_features)
+					 const u8 *their_features,
+					 bool accept_zeroconf)
 {
 	struct channel_type *ctype, proposed;
 	/* Need to copy since we're going to blank variant bits for equality. */
@@ -160,6 +161,15 @@ struct channel_type *channel_type_accept(const tal_t *ctx,
 				return NULL;
 		}
 	}
+
+	/* BOLT #2:
+	 * The receiving node MUST fail the channel if:
+	 *...
+	 *     - if `type` includes `option_zeroconf` and it does not trust the
+	 *       sender to open an unconfirmed channel.
+	 */
+	if (feature_is_set(t, OPT_ZEROCONF) && !accept_zeroconf)
+		return NULL;
 
 	/* Blank variants so we can just check for equality. */
 	for (size_t i = 0; i< ARRAY_SIZE(variants); i++)

--- a/common/channel_type.c
+++ b/common/channel_type.c
@@ -43,6 +43,18 @@ struct channel_type *channel_type_anchor_outputs(const tal_t *ctx)
 	return type;
 }
 
+void channel_type_set_zeroconf(struct channel_type *type)
+{
+	set_feature_bit(&type->features,
+			COMPULSORY_FEATURE(OPT_ZEROCONF));
+}
+
+void channel_type_set_scid_alias(struct channel_type *type)
+{
+	set_feature_bit(&type->features,
+			COMPULSORY_FEATURE(OPT_SCID_ALIAS));
+}
+
 struct channel_type *default_channel_type(const tal_t *ctx,
 					  const struct feature_set *our_features,
 					  const u8 *their_features)
@@ -119,6 +131,7 @@ struct channel_type *channel_type_accept(const tal_t *ctx,
 	static const size_t feats[] = {
 		OPT_ANCHOR_OUTPUTS,
 		OPT_STATIC_REMOTEKEY,
+		OPT_SCID_ALIAS,
 		OPT_ZEROCONF,
 	};
 
@@ -128,6 +141,7 @@ struct channel_type *channel_type_accept(const tal_t *ctx,
 	 *   - `option_zeroconf` (bit 50)
 	 */
 	static const size_t variants[] = {
+		OPT_SCID_ALIAS,
 		OPT_ZEROCONF,
 	};
 

--- a/common/channel_type.h
+++ b/common/channel_type.h
@@ -38,7 +38,8 @@ bool channel_type_eq(const struct channel_type *a,
 struct channel_type *channel_type_accept(const tal_t *ctx,
 					 const u8 *t,
 					 const struct feature_set *our_features,
-					 const u8 *their_features);
+					 const u8 *their_features,
+					 bool accept_zeroconf);
 
 /* Return an array of feature strings indicating channel type. */
 const char **channel_type_name(const tal_t *ctx, const struct channel_type *t);

--- a/common/channel_type.h
+++ b/common/channel_type.h
@@ -10,6 +10,10 @@ struct channel_type *channel_type_none(const tal_t *ctx);
 struct channel_type *channel_type_static_remotekey(const tal_t *ctx);
 struct channel_type *channel_type_anchor_outputs(const tal_t *ctx);
 
+/* channel_type variants */
+void channel_type_set_zeroconf(struct channel_type *channel_type);
+void channel_type_set_scid_alias(struct channel_type *channel_type);
+
 /* Duplicate a channel_type */
 struct channel_type *channel_type_dup(const tal_t *ctx,
 				      const struct channel_type *t);

--- a/common/initial_commit_tx.c
+++ b/common/initial_commit_tx.c
@@ -247,7 +247,7 @@ struct bitcoin_tx *initial_commit_tx(const tal_t *ctx,
 
 		amount = amount_msat_to_sat_round_down(other_pay);
 		if (option_anchor_outputs) {
-			redeem = anchor_to_remote_redeem(tmpctx,
+			redeem = bitcoin_wscript_to_remote_anchored(tmpctx,
 						&keyset->other_payment_key,
 						(!side) == lessor ? csv_lock : 1);
 			scriptpubkey = scriptpubkey_p2wsh(tmpctx, redeem);

--- a/db/bindings.c
+++ b/db/bindings.c
@@ -6,6 +6,7 @@
 #include <ccan/tal/str/str.h>
 #include <ccan/tal/tal.h>
 #include <common/channel_id.h>
+#include <common/channel_type.h>
 #include <common/htlc_state.h>
 #include <common/node_id.h>
 #include <common/onionreply.h>
@@ -129,6 +130,11 @@ void db_bind_txid(struct db_stmt *stmt, int pos, const struct bitcoin_txid *t)
 void db_bind_channel_id(struct db_stmt *stmt, int pos, const struct channel_id *id)
 {
 	db_bind_blob(stmt, pos, id->id, sizeof(id->id));
+}
+
+void db_bind_channel_type(struct db_stmt *stmt, int pos, const struct channel_type *type)
+{
+	db_bind_talarr(stmt, pos, type->features);
 }
 
 void db_bind_node_id(struct db_stmt *stmt, int pos, const struct node_id *id)
@@ -445,6 +451,12 @@ struct bitcoin_tx *db_col_psbt_to_tx(const tal_t *ctx, struct db_stmt *stmt, con
 	if (!psbt)
 		return NULL;
 	return bitcoin_tx_with_psbt(ctx, psbt);
+}
+
+struct channel_type *db_col_channel_type(const tal_t *ctx, struct db_stmt *stmt,
+					 const char *colname)
+{
+	return channel_type_from(ctx, take(db_col_arr(NULL, stmt, colname, u8)));
 }
 
 void *db_col_arr_(const tal_t *ctx, struct db_stmt *stmt, const char *colname,

--- a/db/bindings.h
+++ b/db/bindings.h
@@ -10,6 +10,7 @@
 #include <ccan/time/time.h>
 
 struct channel_id;
+struct channel_type;
 struct db_stmt;
 struct node_id;
 struct onionreply;
@@ -33,6 +34,7 @@ void db_bind_secret(struct db_stmt *stmt, int pos, const struct secret *s);
 void db_bind_secret_arr(struct db_stmt *stmt, int col, const struct secret *s);
 void db_bind_txid(struct db_stmt *stmt, int pos, const struct bitcoin_txid *t);
 void db_bind_channel_id(struct db_stmt *stmt, int pos, const struct channel_id *id);
+void db_bind_channel_type(struct db_stmt *stmt, int pos, const struct channel_type *type);
 void db_bind_node_id(struct db_stmt *stmt, int pos, const struct node_id *ni);
 void db_bind_node_id_arr(struct db_stmt *stmt, int col,
 			 const struct node_id *ids);
@@ -78,6 +80,8 @@ struct secret *db_col_secret_arr(const tal_t *ctx, struct db_stmt *stmt,
 				 const char *colname);
 void db_col_txid(struct db_stmt *stmt, const char *colname, struct bitcoin_txid *t);
 void db_col_channel_id(struct db_stmt *stmt, const char *colname, struct channel_id *dest);
+struct channel_type *db_col_channel_type(const tal_t *ctx, struct db_stmt *stmt,
+					 const char *colname);
 void db_col_node_id(struct db_stmt *stmt, const char *colname, struct node_id *ni);
 struct node_id *db_col_node_id_arr(const tal_t *ctx, struct db_stmt *stmt,
 				   const char *colname);

--- a/db/utils.c
+++ b/db/utils.c
@@ -21,9 +21,13 @@ size_t db_query_colnum(const struct db_stmt *stmt,
 	assert(stmt->query->colnames != NULL);
 
 	col = hash_djb2(colname) % stmt->query->num_colnames;
-	/* Will crash on NULL, which is the Right Thing */
-	while (!streq(stmt->query->colnames[col].sqlname,
-		      colname)) {
+	for (;;) {
+		const char *n = stmt->query->colnames[col].sqlname;
+		if (!n)
+			db_fatal("Unknown column name %s in query %s",
+				 colname, stmt->query->query);
+		if (streq(n, colname))
+			break;
 		col = (col + 1) % stmt->query->num_colnames;
 	}
 

--- a/doc/lightning-listpeerchannels.7.md
+++ b/doc/lightning-listpeerchannels.7.md
@@ -29,7 +29,7 @@ On success, an object containing **channels** is returned.  It is an array of ob
 - **state** (string): the channel state, in particular "CHANNELD\_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
 - **opener** (string): Who initiated the channel (one of "local", "remote")
 - **features** (array of strings):
-  - BOLT #9 features which apply to this channel (one of "option\_static\_remotekey", "option\_anchor\_outputs", "option\_zeroconf")
+  - BOLT #9 features which apply to this channel (one of "option\_static\_remotekey", "option\_anchor\_outputs", "option\_scid\_alias", "option\_zeroconf")
 - **scratch\_txid** (txid, optional): The txid we would use if we went onchain now
 - **channel\_type** (object, optional): channel\_type as negotiated with peer *(added v23.05)*:
   - **bits** (array of u32s): Each bit set in this channel\_type:
@@ -194,4 +194,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:1e589a9e6eace9134d04693dd00caa03da98dd40c2e65d3c675c9bee06daff7f)
+[comment]: # ( SHA256STAMP:98524b075be2355d84732638277bf125549bc7ca21822ed35e1ffd1dff53d7f7)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -69,7 +69,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
   - **state** (string): the channel state, in particular "CHANNELD\_NORMAL" means the channel can be used normally (one of "OPENINGD", "CHANNELD\_AWAITING\_LOCKIN", "CHANNELD\_NORMAL", "CHANNELD\_SHUTTING\_DOWN", "CLOSINGD\_SIGEXCHANGE", "CLOSINGD\_COMPLETE", "AWAITING\_UNILATERAL", "FUNDING\_SPEND\_SEEN", "ONCHAIN", "DUALOPEND\_OPEN\_INIT", "DUALOPEND\_AWAITING\_LOCKIN")
   - **opener** (string): Who initiated the channel (one of "local", "remote")
   - **features** (array of strings):
-    - BOLT #9 features which apply to this channel (one of "option\_static\_remotekey", "option\_anchor\_outputs", "option\_zeroconf")
+    - BOLT #9 features which apply to this channel (one of "option\_static\_remotekey", "option\_anchor\_outputs", "option\_scid\_alias", "option\_zeroconf")
   - **scratch\_txid** (txid, optional): The txid we would use if we went onchain now
   - **feerate** (object, optional): Feerates for the current tx:
     - **perkw** (u32): Feerate per 1000 weight (i.e kSipa)
@@ -398,4 +398,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:156e5622823a8b948c0f15f694afc1d87bb5107091e5b65ee6190b4067661bb4)
+[comment]: # ( SHA256STAMP:c0d0cc8f083168fd76caa2430a7c7d27d72a5273c55fb14b0efcbcb7a87274f4)

--- a/doc/schemas/listpeerchannels.schema.json
+++ b/doc/schemas/listpeerchannels.schema.json
@@ -211,6 +211,7 @@
               "enum": [
                 "option_static_remotekey",
                 "option_anchor_outputs",
+                "option_scid_alias",
                 "option_zeroconf"
               ],
               "description": "BOLT #9 features which apply to this channel"

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -334,6 +334,7 @@
                     "enum": [
                       "option_static_remotekey",
                       "option_anchor_outputs",
+                      "option_scid_alias",
                       "option_zeroconf"
                     ],
                     "description": "BOLT #9 features which apply to this channel"

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -490,9 +490,9 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 			/* It's actually a P2WSH in this case. */
 			if (utxo->close_info && utxo->close_info->option_anchor_outputs) {
 				const u8 *wscript
-					= anchor_to_remote_redeem(tmpctx,
-								  &pubkey,
-								  utxo->close_info->csv);
+					= bitcoin_wscript_to_remote_anchored(tmpctx,
+									     &pubkey,
+									     utxo->close_info->csv);
 				psbt_input_set_witscript(psbt, j, wscript);
 				psbt_input_set_wit_utxo(psbt, j,
 							scriptpubkey_p2wsh(psbt, wscript),

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -196,6 +196,9 @@ u32 delayed_to_us_feerate(struct chain_topology *topo);
 u32 htlc_resolution_feerate(struct chain_topology *topo);
 u32 penalty_feerate(struct chain_topology *topo);
 
+/* Usually we set nLocktime to tip (or recent) like bitcoind does */
+u32 default_locktime(const struct chain_topology *topo);
+
 /**
  * broadcast_tx - Broadcast a single tx, and rebroadcast as reqd (copies tx).
  * @topo: topology

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -627,11 +627,8 @@ struct channel *any_channel_by_scid(struct lightningd *ld,
 			 *   - MUST NOT allow incoming HTLCs to this channel
 			 *     using the real `short_channel_id`
 			 */
-			/* FIXME: We don't keep type is db, so assume all
-			 * private channels which support aliases want this! */
 			if (!privacy_leak_ok
-			    && chan->alias[REMOTE]
-			    && !(chan->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL))
+			    && channel_type_has(chan->type, OPT_SCID_ALIAS))
 				continue;
 			if (chan->scid
 			    && short_channel_id_eq(scid, chan->scid))

--- a/lightningd/hsm_control.h
+++ b/lightningd/hsm_control.h
@@ -22,6 +22,11 @@ bool hsm_capable(struct lightningd *ld, u32 msgtype);
 
 struct ext_key *hsm_init(struct lightningd *ld);
 
+/* Send request to hsmd, get response. */
+const u8 *hsm_sync_req(const tal_t *ctx,
+		       struct lightningd *ld,
+		       const u8 *msg TAKES);
+
 /* Get (and check!) a bip32 derived pubkey */
 void bip32_pubkey(struct lightningd *ld, struct pubkey *pubkey, u32 index);
 

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -174,10 +174,8 @@ static void finish_report(const struct leak_detect *leaks)
 
 		json_add_backtrace(response, backtrace);
 		json_array_start(response, "parents");
-		for (p = tal_parent(i); p; p = tal_parent(p)) {
+		for (p = tal_parent(i); p; p = tal_parent(p))
 			json_add_string(response, NULL, tal_name(p));
-			p = tal_parent(p);
-		}
 		json_array_end(response);
 		json_object_end(response);
 	}

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -964,7 +964,8 @@ bool peer_start_openingd(struct peer *peer, struct peer_fd *peer_fd)
 				   feerate_min(peer->ld, NULL),
 				   feerate_max(peer->ld, NULL),
 				   IFDEV(peer->ld->dev_force_tmp_channel_id, NULL),
-				   peer->ld->config.allowdustreserve);
+				   peer->ld->config.allowdustreserve,
+				   !deprecated_apis);
 	subd_send_msg(uc->open_daemon, take(msg));
 	return true;
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -866,6 +866,8 @@ static void json_add_channel(struct lightningd *ld,
 		json_add_string(response, NULL, "option_anchor_outputs");
 	if (channel_has(channel, OPT_ZEROCONF))
 		json_add_string(response, NULL, "option_zeroconf");
+	if (channel_has(channel, OPT_SCID_ALIAS))
+		json_add_string(response, NULL, "option_scid_alias");
 	json_array_end(response);
 
 	if (!amount_sat_sub(&peer_funded_sats, channel->funding_sats,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -291,6 +291,11 @@ u32 get_feerate(const struct fee_states *fee_states UNNEEDED,
 /* Generated stub for hash_htlc_key */
 size_t hash_htlc_key(const struct htlc_key *htlc_key UNNEEDED)
 { fprintf(stderr, "hash_htlc_key called!\n"); abort(); }
+/* Generated stub for hsm_sync_req */
+const u8 *hsm_sync_req(const tal_t *ctx UNNEEDED,
+		       struct lightningd *ld UNNEEDED,
+		       const u8 *msg TAKES UNNEEDED)
+{ fprintf(stderr, "hsm_sync_req called!\n"); abort(); }
 /* Generated stub for htlc_is_trimmed */
 bool htlc_is_trimmed(enum side htlc_owner UNNEEDED,
 		     struct amount_msat htlc_amount UNNEEDED,

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -2116,7 +2116,7 @@ static u8 *scriptpubkey_to_remote(const tal_t *ctx,
 	 */
 	if (option_anchor_outputs) {
 		return scriptpubkey_p2wsh(ctx,
-					  anchor_to_remote_redeem(tmpctx,
+					  bitcoin_wscript_to_remote_anchored(tmpctx,
 								  remotekey,
 								  csv_lock));
 	} else {

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -2284,7 +2284,8 @@ static void accepter_start(struct state *state, const u8 *oc2_msg)
 			channel_type_accept(state,
 					    open_tlv->channel_type,
 					    state->our_features,
-					    state->their_features);
+					    state->their_features,
+					    state->minimum_depth == 0);
 		if (!state->channel_type) {
 			negotiation_failed(state,
 					   "Did not support channel_type %s",

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -905,7 +905,8 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 			channel_type_accept(state,
 					    open_tlvs->channel_type,
 					    state->our_features,
-					    state->their_features);
+					    state->their_features,
+					    state->minimum_depth == 0);
 		if (!state->channel_type) {
 			negotiation_failed(state,
 					   "Did not support channel_type %s",

--- a/openingd/openingd_wire.csv
+++ b/openingd/openingd_wire.csv
@@ -28,6 +28,8 @@ msgdata,openingd_init,dev_temporary_channel_id,?byte,32
 # reserves? This is explicitly required by the spec for safety
 # reasons, but some implementations and users keep asking for it.
 msgdata,openingd_init,allowdustreserve,bool,
+# Core LN prior to 23.05 didn't like this bit set!
+msgdata,openingd_init,can_set_scid_alias_channel_type,bool,
 
 # Openingd->master: they offered channel, should we continue?
 msgtype,openingd_got_offer,6005

--- a/plugins/bkpr/Makefile
+++ b/plugins/bkpr/Makefile
@@ -37,7 +37,7 @@ PLUGIN_ALL_HEADER += $(BOOKKEEPER_HEADER)
 C_PLUGINS += plugins/bookkeeper
 PLUGINS += plugins/bookkeeper
 
-plugins/bookkeeper: common/bolt12.o common/bolt12_merkle.o $(BOOKKEEPER_OBJS) $(PLUGIN_LIB_OBJS) $(JSMN_OBJTS) $(PLUGIN_COMMON_OBJS) $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) $(DB_OBJS)
+plugins/bookkeeper: common/bolt12.o common/bolt12_merkle.o common/channel_type.o $(BOOKKEEPER_OBJS) $(PLUGIN_LIB_OBJS) $(JSMN_OBJTS) $(PLUGIN_COMMON_OBJS) $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) $(DB_OBJS)
 
 # The following files contain SQL-annotated statements that we need to extact
 BOOKKEEPER_SQL_FILES := 			\

--- a/wallet/reservation.c
+++ b/wallet/reservation.c
@@ -351,22 +351,9 @@ static struct command_result *finish_psbt(struct command *cmd,
 	size_t change_outnum COMPILER_WANTS_INIT("gcc 9.4.0 -Og");
 	u32 current_height = get_block_height(cmd->ld->topology);
 
-	/* Setting the locktime to the next block to be mined has multiple
-	 * benefits:
-	 * - anti fee-snipping (even if not yet likely)
-	 * - less distinguishable transactions (with this we create
-	 *   general-purpose transactions which looks like bitcoind:
-	 *   native segwit, nlocktime set to tip, and sequence set to
-	 *   0xFFFFFFFD by default. Other wallets are likely to implement
-	 *   this too).
-	 */
 	if (!locktime) {
 		locktime = tal(cmd, u32);
-		*locktime = current_height;
-
-		/* Eventually fuzz it too. */
-		if (*locktime > 100 && pseudorand(10) == 0)
-			*locktime -= pseudorand(100);
+		*locktime = default_locktime(cmd->ld->topology);
 	}
 
 	psbt = psbt_using_utxos(cmd, cmd->ld->wallet, utxos,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1748,4 +1748,12 @@ struct wallet_htlc_iter *wallet_htlcs_next(struct wallet *w,
 					   struct amount_msat *msat,
 					   struct sha256 *payment_hash,
 					   enum htlc_state *hstate);
+
+/* Make a PSBT from these utxos, or enhance @base if non-NULL. */
+struct wally_psbt *psbt_using_utxos(const tal_t *ctx,
+				    struct wallet *wallet,
+				    struct utxo **utxos,
+				    u32 nlocktime,
+				    u32 nsequence,
+				    struct wally_psbt *base);
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
~Builds on #6120 so start from `lightningd: expose default_locktime for wider usage.`~ **MERGED**!

This puts channel_type in the db, rather than using separate flags, but doing so revealed that we didn't use it properly in several places.  Those have been fixed, but some of it cannot be done immediately as that would break older nodes.  @cdecker in particular will want to review this!