### PR TITLE
postgres: add missing 'update_count' to stmt

### DIFF
--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -342,7 +342,7 @@ struct fee_sum **find_account_onchain_fees(const tal_t *ctx,
 				     ", CAST(SUM(debit) AS BIGINT) as debit"
 				     " FROM onchain_fees"
 				     " WHERE account_id = ?"
-				     " GROUP BY txid"
+				     " GROUP BY txid, update_count"
 				     " ORDER BY txid, update_count"));
 
 	db_bind_u64(stmt, 0, acct->db_id);


### PR DESCRIPTION
Reported-By: @rustyrussell

Changelog-Fixed: PLUGINS: postgres bookkeeper integration, was missing `update_count` in group by