### PR TITLE
Add msggen generated golang rpc client and plugin driver

### DIFF
--- a/contrib/goln/.gitignore
+++ b/contrib/goln/.gitignore
@@ -1,0 +1,5 @@
+# We provide a library so we don't want to pin the dependencies.
+go.sum
+
+# Ignore the example
+goln-example

--- a/contrib/goln/Makefile
+++ b/contrib/goln/Makefile
@@ -1,0 +1,11 @@
+GOLN_EXAMPLE_BIN="goln-example"
+
+check-go:
+	go test -v ./...
+
+clean-go:
+	go clean
+	rm -f ${GOLN_EXAMPLE_BIN}
+
+example:
+	go build -o ${GOLN_EXAMPLE_BIN} example.go

--- a/contrib/goln/example.go
+++ b/contrib/goln/example.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/elementsproject/lightning/contrib/goln/plugin"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func init() {
+	c := jsonrpc2.NewConn(
+		context.Background(),
+		jsonrpc2.NewBufferedStream(
+			internal.NewReadWriterConn(internal.EOFReader{}, os.Stdout),
+			internal.DoubleNewLineCodec{},
+		),
+		nil,
+	)
+	plugin.InitDefaultLogger(c, plugin.LEVEL_DEBUG)
+	log.Printf("Init logging.")
+}
+
+func main() {
+	quit := make(chan struct{})
+	log.Println("Starting plugin.")
+	builder := plugin.NewBuilder(context.Background(), os.Stdin, os.Stdout).
+		AddOption(plugin.IntOption("my-option", 42, "This is an option (default: 42).")).
+		AddOption(plugin.StringOption("my-deprecated-option", "default-value", "This option is deprecated.").Deprecated()).
+		AddRpcMethod(plugin.NewRpcMethod("test-rpc-method", "amt scid", "description", "long description", myCallback))
+	plugin := builder.Configure()
+	err := plugin.Start()
+	if err != nil {
+		panic(fmt.Sprintf("Got error: %s", err))
+	}
+	log.Println("Plugin initialized.")
+	<-quit
+}
+
+func myCallback(ctx context.Context, req *json.RawMessage) (interface{}, *jsonrpc2.Error) {
+	return CallbackResponse{
+		Got:      string(*req),
+		Number:   100,
+		AndABool: false,
+	}, nil
+}
+
+type CallbackResponse struct {
+	Got      string `json:"request"`
+	Number   int32  `json:"number"`
+	AndABool bool   `json:"boolean"`
+}

--- a/contrib/goln/go.mod
+++ b/contrib/goln/go.mod
@@ -1,0 +1,14 @@
+module github.com/elementsproject/lightning/contrib/goln
+
+go 1.18
+
+require (
+	github.com/sourcegraph/jsonrpc2 v0.2.0
+	github.com/stretchr/testify v1.8.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/contrib/goln/internal/codec.go
+++ b/contrib/goln/internal/codec.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+)
+
+// DoubleNewLineCodec is a simple codec that splits message objects with two
+// consecutive new lines. It implements the jsonrpc2.ObjectCodec
+type DoubleNewLineCodec struct{}
+
+// ReadObject implements jsonrpc2.ObjectCodec
+func (C DoubleNewLineCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
+	var msg []byte
+	for {
+		b, err := stream.ReadByte()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		msg = append(msg, b)
+		// Check if the next two lines are newlines that terminate the message
+		// and start a new message.
+		next, err := stream.Peek(2)
+		if err != nil {
+			return err
+		}
+		if next[0] == '\n' && next[1] == '\n' {
+			_, err = stream.ReadByte()
+			if err != nil {
+				return err
+			}
+			_, err = stream.ReadByte()
+			if err != nil {
+				return err
+			}
+			return json.Unmarshal(msg, v)
+		}
+	}
+}
+
+// WriteObject implements jsonrpc2.ObjectCodec
+func (C DoubleNewLineCodec) WriteObject(stream io.Writer, obj interface{}) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = stream.Write(data)
+	if err != nil {
+		return err
+	}
+	_, err = stream.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+	_, err = stream.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/contrib/goln/internal/net.go
+++ b/contrib/goln/internal/net.go
@@ -1,0 +1,103 @@
+package internal
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+type ReadWriterConn struct {
+	in  io.ReadCloser
+	out io.WriteCloser
+}
+
+// Close implements net.Conn
+func (conn *ReadWriterConn) Close() error {
+	err := conn.in.Close()
+	if err != nil {
+		return err
+	}
+	return conn.out.Close()
+}
+
+// LocalAddr implements net.Conn
+func (conn *ReadWriterConn) LocalAddr() net.Addr {
+	return nil
+}
+
+// Read implements net.Conn
+func (conn *ReadWriterConn) Read(b []byte) (n int, err error) {
+	return conn.in.Read(b)
+}
+
+// RemoteAddr implements net.Conn
+func (conn *ReadWriterConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+// SetDeadline implements net.Conn
+func (conn *ReadWriterConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+// SetReadDeadline implements net.Conn
+func (conn *ReadWriterConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+// SetWriteDeadline implements net.Conn
+func (conn *ReadWriterConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// Write implements net.Conn
+func (conn *ReadWriterConn) Write(b []byte) (n int, err error) {
+	return conn.out.Write(b)
+}
+
+func NewReadWriterConn(in io.ReadCloser, out io.WriteCloser) net.Conn {
+	return &ReadWriterConn{in: in, out: out}
+}
+
+type ReadWriteListener struct {
+	connectionOnce sync.Once
+	closeOnce      sync.Once
+	connChan       chan net.Conn
+
+	in  io.ReadCloser
+	out io.WriteCloser
+}
+
+func NewReadWriteListener(in io.ReadCloser, out io.WriteCloser) net.Listener {
+	lis := new(ReadWriteListener)
+	lis.in = in
+	lis.out = out
+	lis.connChan = make(chan net.Conn, 1)
+	return lis
+}
+
+// Accept implements net.Listener
+func (listener *ReadWriteListener) Accept() (net.Conn, error) {
+	listener.connectionOnce.Do(func() {
+		conn := NewReadWriterConn(listener.in, listener.out)
+		listener.connChan <- conn
+	})
+	conn := <-listener.connChan
+	return conn, nil
+}
+
+// Addr implements net.Listener
+func (listener *ReadWriteListener) Addr() net.Addr {
+	return nil
+}
+
+// Close implements net.Listener
+func (listener *ReadWriteListener) Close() error {
+	listener.closeOnce.Do(func() {
+		listener.in.Close()
+		listener.out.Close()
+		close(listener.connChan)
+	})
+	return nil
+}

--- a/contrib/goln/internal/net_test.go
+++ b/contrib/goln/internal/net_test.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadWriterConn(t *testing.T) {
+	tmp := t.TempDir()
+	tmpIn, err := ioutil.TempFile(tmp, "in")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpIn.Close()
+
+	tmpOut, err := ioutil.TempFile(tmp, "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpOut.Close()
+
+	if _, err := tmpIn.Write([]byte("foo bar")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tmpIn.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	lis := NewReadWriteListener(tmpIn, tmpOut)
+	conn, err := lis.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf = make([]byte, 32)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			_, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+			if _, err = conn.Write(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	if _, err := tmpOut.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	var buf1 = make([]byte, 32)
+	_, err = tmpOut.Read(buf1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, buf, buf1)
+}

--- a/contrib/goln/internal/reader.go
+++ b/contrib/goln/internal/reader.go
@@ -1,0 +1,18 @@
+package internal
+
+import "io"
+
+// EOFReader always returns the `io.EOF` error, indicating that the
+// reader is empty. This is helpful for the jsonrpc2 connection that
+// tries to read from a non-existing `io.Reader`.
+type EOFReader struct{}
+
+// Read implements the io.ReadCloser interface.
+func (EOFReader) Read(p []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+// Close implements the io.ReadCloser interface.
+func (EOFReader) Close() error {
+	return nil
+}

--- a/contrib/goln/plugin/logging.go
+++ b/contrib/goln/plugin/logging.go
@@ -1,0 +1,55 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"log"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// LogLevel are the log levels that are supported by core-lightning.
+type LogLevel string
+
+const (
+	LEVEL_ERROR LogLevel = "error"
+	LEVEL_WARN  LogLevel = "warn"
+	LEVEL_DEBUG LogLevel = "debug"
+	LEVEL_INFO  LogLevel = "info"
+)
+
+type logWriter struct {
+	conn  *jsonrpc2.Conn
+	level LogLevel
+}
+
+// Write implements io.Writer
+func (w *logWriter) Write(p []byte) (n int, err error) {
+	p = bytes.TrimSuffix(p, []byte("\n"))
+	err = w.conn.Notify(context.Background(), "log", logEntry{
+		Level:   string(w.level),
+		Message: string(p),
+	})
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+type logEntry struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+}
+
+// NewLogger returns a logger that logs to core-lightning rpc. These logs will
+// be printed in the core-lightning logs.
+func NewLogger(conn *jsonrpc2.Conn, level LogLevel) *log.Logger {
+	return log.New(&logWriter{conn: conn, level: level}, "", 0)
+}
+
+// InitDefaultLogger initializes the core `log` logger to pass the logs to the
+// core-lightning logger.
+func InitDefaultLogger(conn *jsonrpc2.Conn, level LogLevel) {
+	log.SetFlags(0)
+	log.SetOutput(&logWriter{conn: conn, level: level})
+}

--- a/contrib/goln/plugin/messages.go
+++ b/contrib/goln/plugin/messages.go
@@ -1,0 +1,23 @@
+package plugin
+
+type GetManifestRequest struct {
+	AllowDeprecatedApis bool `json:"allow-deprecated-apis"`
+}
+
+type GetManifestResponse struct {
+	Options       []Option      `json:"options"`
+	RpcMethods    []RpcMethod   `json:"rpcmethods"`
+	Dynamic       bool          `json:"dynamic"`
+	Subscriptions []string      `json:"subscriptions,omitempty"`
+	Hooks         []interface{} `json:"hooks,omitempty"`
+	// FeatureBits   *FeatureBits  `json:"featurebits,omitempty"`
+}
+
+type InitRequest struct {
+	Options       map[string]interface{} `json:"options"`
+	Configuration *Config                `json:"configuration"`
+}
+
+type InitResponse struct {
+	Disable string `json:"disable,omitempty"`
+}

--- a/contrib/goln/plugin/plugin.go
+++ b/contrib/goln/plugin/plugin.go
@@ -1,0 +1,204 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/elementsproject/lightning/contrib/goln/rpc"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type Builder struct {
+	mu sync.Mutex
+
+	in  *os.File
+	out *os.File
+
+	server              *rpc.Server
+	allowDeprecatedApis bool
+	waitInit            chan initData
+
+	options    map[string]*Option
+	rpcMethods map[string]*RpcMethod
+	dynamic    bool
+}
+
+func NewBuilder(ctx context.Context, in *os.File, out *os.File) *Builder {
+	builder := new(Builder)
+	builder.in = in
+	builder.out = out
+	builder.server = rpc.NewServer(ctx)
+	builder.waitInit = make(chan initData, 1)
+	builder.options = make(map[string]*Option)
+	builder.rpcMethods = make(map[string]*RpcMethod)
+
+	// Register plugin startup rpc methods `getmanifest` and `init`.
+	builder.server.RegisterHandler("getmanifest", builder.handleManifest)
+	builder.server.RegisterHandler("init", builder.handleInit)
+
+	return builder
+}
+
+func (builder *Builder) AddOption(o *Option) *Builder {
+	builder.options[o.name] = o
+	return builder
+}
+
+func (builder *Builder) AddRpcMethod(m *RpcMethod) *Builder {
+	builder.rpcMethods[m.name] = m
+	builder.server.RegisterHandler(m.name, func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+		res, err := m.callback(ctx, req.Params)
+		if err != nil {
+			_ = conn.ReplyWithError(ctx, req.ID, err)
+			return
+		}
+		_ = conn.Reply(ctx, req.ID, res)
+	})
+	return builder
+}
+
+func (builder *Builder) Dynamic() *Builder {
+	builder.dynamic = true
+	return builder
+}
+
+func (builder *Builder) startServer() {
+	lis := internal.NewReadWriteListener(builder.in, builder.out)
+	builder.server.Accept(lis)
+}
+
+func (builder *Builder) Configure() Plugin {
+	// Start the server and wait for the `init` message.
+	go builder.startServer()
+	initData := <-builder.waitInit
+
+	builder.mu.Lock()
+	defer builder.mu.Unlock()
+
+	// Unregister handler, we only needed them once.
+	builder.server.UnregisterHandler("getmanifest")
+	builder.server.UnregisterHandler("init")
+
+	// Create new options map with returned values. Only append the returned
+	// options, according to the deprecation settings.
+	options := make(map[string]Option)
+	for k, v := range initData.request.Options {
+		if opt, ok := builder.options[k]; ok {
+			options[k] = Option{
+				name:        opt.name,
+				otype:       opt.otype,
+				value:       v,
+				vdefault:    opt.vdefault,
+				description: opt.description,
+				deprecated:  opt.deprecated,
+				isFlag:      opt.isFlag,
+			}
+		}
+	}
+
+	// Pass rpc-server, options and methods to the plugin.
+	return Plugin{
+		initConn:            initData.conn,
+		initId:              initData.id,
+		in:                  builder.in,
+		out:                 builder.out,
+		server:              builder.server,
+		AllowDeprecatedApis: builder.allowDeprecatedApis,
+		Config:              *initData.request.Configuration,
+		Options:             options,
+	}
+}
+
+func (builder *Builder) handleManifest(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	var r GetManifestRequest
+	err := json.Unmarshal(*req.Params, &r)
+	if err != nil {
+		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInternalError,
+			Message: fmt.Sprintf("could not unmarshal manifest: %s", err),
+		})
+		panic(fmt.Sprintf("could not unmarshal manifest: %s", err))
+	}
+
+	// Return GetManifestResponse to set the command-line options and the
+	// custom rpc methods that get passed through.
+	builder.mu.Lock()
+	builder.allowDeprecatedApis = r.AllowDeprecatedApis
+
+	// Create manifest response, set rpc methods. Options and rpc-methods only
+	// are added to the manifest if they meet the deprecation settings.
+	var result GetManifestResponse
+	result.Dynamic = builder.dynamic
+	for _, v := range builder.rpcMethods {
+		if r.AllowDeprecatedApis || !v.deprecated {
+			result.RpcMethods = append(result.RpcMethods, *v)
+		}
+	}
+	for _, v := range builder.options {
+		if r.AllowDeprecatedApis || !v.deprecated {
+			result.Options = append(result.Options, *v)
+		}
+	}
+	builder.mu.Unlock()
+
+	_ = conn.Reply(ctx, req.ID, result)
+}
+
+func (builder *Builder) handleInit(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	var v InitRequest
+	err := json.Unmarshal(*req.Params, &v)
+	if err != nil {
+		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInternalError,
+			Message: fmt.Sprintf("could not unmarshal init message: %s", err),
+		})
+		panic(fmt.Sprintf("could not unmarshal init message: %s", err))
+	}
+	builder.waitInit <- initData{
+		conn:    conn,
+		id:      &req.ID,
+		request: v,
+	}
+}
+
+type Plugin struct {
+	mu sync.Mutex
+
+	initConn *jsonrpc2.Conn
+	initId   *jsonrpc2.ID
+
+	in     *os.File
+	out    *os.File
+	server *rpc.Server
+
+	AllowDeprecatedApis bool
+	Config              Config
+	Options             map[string]Option
+}
+
+func (plugin *Plugin) Start() error {
+	return plugin.answerInit("")
+}
+
+func (plugin *Plugin) Disable(msg string) error {
+	return plugin.answerInit(msg)
+}
+
+func (plugin *Plugin) answerInit(disableMsg string) error {
+	if plugin.initConn != nil && plugin.initId != nil {
+		err := plugin.initConn.Reply(context.TODO(), *plugin.initId, InitResponse{Disable: disableMsg})
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("plugin has no init connection and/or init id")
+	}
+	plugin.initConn = nil
+	plugin.initId = nil
+	return nil
+}

--- a/contrib/goln/plugin/plugin_test.go
+++ b/contrib/goln/plugin/plugin_test.go
@@ -1,0 +1,28 @@
+package plugin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOption_Marshall checks marshalling of the command-line options that get
+// passed to core-lightning.
+func TestOption_Marshall(t *testing.T) {
+	so := StringOption("so", "default", "description")
+	b, err := json.Marshal(so)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"so","type":"string","default":"default","description":"description"}`, string(b))
+
+	io := IntOption("io", 123, "description").Deprecated()
+	b, err = json.Marshal(io)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"io","type":"int","default":123,"description":"description","deprecated":true}`, string(b))
+
+	bo := BoolOption("bo", true, "description").Flag()
+	b, err = json.Marshal(bo)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"bo","type":"bool","default":true,"description":"description"}`, string(b))
+}

--- a/contrib/goln/plugin/types.go
+++ b/contrib/goln/plugin/types.go
@@ -1,0 +1,207 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elementsproject/lightning/contrib/goln/rpc"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type OptionType string
+
+const (
+	OPTION_TYPE_STRING OptionType = "string"
+	OPTION_TYPE_FLAG   OptionType = "flag"
+	OPTION_TYPE_BOOL   OptionType = "bool"
+	OPTION_TYPE_INT    OptionType = "int"
+)
+
+type allowedOptionTypes interface {
+	~int64 | ~string | ~bool
+}
+
+type Option struct {
+	name        string
+	otype       OptionType
+	value       interface{}
+	vdefault    interface{}
+	description string
+	deprecated  bool
+	isFlag      bool
+}
+
+func StringOption(name string, defaultValue string, description string) *Option {
+	return &Option{
+		name:        name,
+		otype:       OPTION_TYPE_STRING,
+		value:       defaultValue,
+		vdefault:    defaultValue,
+		description: description,
+	}
+}
+
+func IntOption(name string, defaultValue int64, description string) *Option {
+	return &Option{
+		name:        name,
+		otype:       OPTION_TYPE_INT,
+		value:       defaultValue,
+		vdefault:    defaultValue,
+		description: description,
+	}
+}
+
+func BoolOption(name string, defaultValue bool, description string) *Option {
+	return &Option{
+		name:        name,
+		otype:       OPTION_TYPE_BOOL,
+		value:       defaultValue,
+		vdefault:    defaultValue,
+		description: description,
+	}
+}
+
+func (opt *Option) GetStringValue() (string, error) {
+	return getOptionValue[string](opt)
+}
+
+func (opt *Option) GetIntValue() (int64, error) {
+	return getOptionValue[int64](opt)
+}
+
+func (opt *Option) GetBoolValue() (bool, error) {
+	return getOptionValue[bool](opt)
+}
+
+func (opt *Option) IsFlagged() (bool, error) {
+	if opt.isFlag {
+		return opt.GetBoolValue()
+	}
+	return false, fmt.Errorf("option is not a flag")
+}
+
+func getOptionValue[T allowedOptionTypes](opt *Option) (T, error) {
+	val, ok := opt.value.(T)
+	if !ok {
+		return *new(T), fmt.Errorf("can not convert to to type %T", *new(T))
+	}
+	return val, nil
+}
+
+func (opt *Option) Deprecated() *Option {
+	opt.deprecated = true
+	return opt
+}
+
+func (opt *Option) Flag() *Option {
+	opt.isFlag = true
+	return opt
+}
+
+func (opt *Option) MarshalJSON() ([]byte, error) {
+	switch opt.otype {
+	case OPTION_TYPE_STRING:
+		return marshalJSON[string](opt)
+	case OPTION_TYPE_BOOL:
+		return marshalJSON[bool](opt)
+	case OPTION_TYPE_INT:
+		return marshalJSON[int64](opt)
+	default:
+		return nil, fmt.Errorf("unknown option type")
+	}
+}
+
+func marshalJSON[T allowedOptionTypes](opt *Option) ([]byte, error) {
+	def, ok := opt.vdefault.(T)
+	if !ok {
+		return nil, fmt.Errorf("can not convert to to type %T", *new(T))
+	}
+	j := struct {
+		Name        string     `json:"name"`
+		Type        OptionType `json:"type"`
+		Default     T          `json:"default"`
+		Description string     `json:"description"`
+		Deprecated  bool       `json:"deprecated,omitempty"`
+		Categoty    string     `json:"category,omitempty"`
+	}{
+		Name:        opt.name,
+		Type:        opt.otype,
+		Default:     def,
+		Description: opt.description,
+		Deprecated:  opt.deprecated,
+		Categoty:    "",
+	}
+	return json.Marshal(j)
+}
+
+type Callback = func(context.Context, *json.RawMessage) (interface{}, *jsonrpc2.Error)
+
+type RpcMethod struct {
+	name        string
+	usage       string
+	description string
+	long        string
+	deprecated  bool
+	handler     rpc.Handler
+	callback    Callback
+}
+
+func NewRpcMethod(name, usage, description, long string, callback Callback) *RpcMethod {
+	return &RpcMethod{
+		name:        name,
+		usage:       usage,
+		description: description,
+		long:        long,
+		deprecated:  false,
+		callback:    callback,
+	}
+}
+
+func (m *RpcMethod) Deprecated() *RpcMethod {
+	m.deprecated = true
+	return m
+}
+
+func (m *RpcMethod) MarshalJSON() ([]byte, error) {
+	j := struct {
+		Name            string `json:"name"`
+		Usage           string `json:"usage"`
+		Description     string `json:"description"`
+		LongDescription string `json:"long_description"`
+		Deprecated      bool   `json:"deprecated"`
+	}{
+		Name:            m.name,
+		Usage:           m.usage,
+		Description:     m.description,
+		LongDescription: m.long,
+		Deprecated:      m.deprecated,
+	}
+	return json.Marshal(j)
+}
+
+type Config struct {
+	LightningDir string `json:"lightning-dir"`
+	RpcFile      string `json:"rpc-file"`
+	Startup      bool   `json:"startup"`
+	Network      string `json:"network,omitempty"`
+	FeatureSet   struct {
+		Init    string `json:"init"`
+		Node    string `json:"node"`
+		Channel string `json:"channel"`
+		Invoice string `json:"invoice"`
+	} `json:"feature_set"`
+	Proxy struct {
+		Type string `json:"type,omitempty"`
+		Addr string `json:"address,omitempty"`
+		Port uint32 `json:"port,omitempty"`
+	} `json:"proxy,omitempty"`
+	TorV3Enabled   bool `json:"torv3-enabled,omitempty"`
+	AlwaysUseProxy bool `json:"always_use_proxy,omitempty"`
+}
+
+type initData struct {
+	conn    *jsonrpc2.Conn
+	id      *jsonrpc2.ID
+	request InitRequest
+}

--- a/contrib/goln/plugin/types_test.go
+++ b/contrib/goln/plugin/types_test.go
@@ -1,0 +1,90 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOption(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int64", func(t *testing.T) {
+		t.Parallel()
+		exp := int64(42)
+		opt := IntOption("foo", exp, "bar")
+		val, err := opt.GetIntValue()
+		assert.NoError(t, err)
+		assert.Equal(t, exp, val)
+
+		_, err = opt.GetStringValue()
+		assert.Error(t, err)
+
+		_, err = opt.GetBoolValue()
+		assert.Error(t, err)
+
+		b, err := opt.MarshalJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"name":"foo","type":"int","default":42,"description":"bar"}`, string(b))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		t.Parallel()
+
+		exp := "foobar"
+		opt := StringOption("foo", exp, "bar")
+		val, err := opt.GetStringValue()
+		assert.NoError(t, err)
+		assert.Equal(t, exp, val)
+
+		_, err = opt.GetIntValue()
+		assert.Error(t, err)
+
+		_, err = opt.GetBoolValue()
+		assert.Error(t, err)
+
+		b, err := opt.MarshalJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"name":"foo","type":"string","default":"foobar","description":"bar"}`, string(b))
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		t.Parallel()
+
+		exp := true
+		opt := BoolOption("foo", exp, "bar")
+		val, err := opt.GetBoolValue()
+		assert.NoError(t, err)
+		assert.Equal(t, exp, val)
+
+		_, err = opt.GetIntValue()
+		assert.Error(t, err)
+
+		_, err = opt.GetStringValue()
+		assert.Error(t, err)
+
+		b, err := opt.MarshalJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"name":"foo","type":"bool","default":true,"description":"bar"}`, string(b))
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		t.Parallel()
+
+		exp := true
+		opt := BoolOption("foo", exp, "bar").Flag()
+		val, err := opt.IsFlagged()
+		assert.NoError(t, err)
+		assert.Equal(t, exp, val)
+
+		val, err = opt.GetBoolValue()
+		assert.NoError(t, err)
+		assert.Equal(t, exp, val)
+
+		_, err = opt.GetIntValue()
+		assert.Error(t, err)
+
+		_, err = opt.GetStringValue()
+		assert.Error(t, err)
+	})
+}

--- a/contrib/goln/rpc/client.go
+++ b/contrib/goln/rpc/client.go
@@ -1,0 +1,71 @@
+package rpc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type Client struct {
+	mutex      sync.Mutex
+	ctx        context.Context
+	socketAddr string
+	conn       *jsonrpc2.Conn
+	unixConn   net.Conn
+
+	lastId uint64
+}
+
+func NewClient(ctx context.Context, socketAddr string) (*Client, error) {
+	client := &Client{ctx: ctx, socketAddr: socketAddr}
+	if err := client.connect(); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func (client *Client) connect() error {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+
+	// We do not want to connect multiple times.
+	if client.isConnected() {
+		return nil
+	}
+	var err error
+	client.unixConn, err = net.Dial("unix", client.socketAddr)
+	if err != nil {
+		return err
+	}
+	// client.conn.Close()
+	client.conn, err = jsonrpc2.NewConn(client.ctx, jsonrpc2.NewBufferedStream(client.unixConn, internal.DoubleNewLineCodec{}), nil), nil
+	return err
+}
+
+func (client *Client) isConnected() bool {
+	if client.conn == nil {
+		return false
+	}
+	buf := make([]byte, 1)
+	_, err := client.unixConn.Read(buf)
+	return err == nil
+}
+
+func (client *Client) nextId() uint64 {
+	return atomic.AddUint64(&client.lastId, 1)
+}
+
+// Call allows for custom rpc calls, e.g. if one wants to call plugin rpc
+// methods that do not have auto generated methods.
+func (client *Client) Call(method string, params interface{}, result interface{}, opts ...jsonrpc2.CallOption) error {
+	return client.conn.Call(client.ctx, method, params, result, jsonrpc2.PickID(jsonrpc2.ID{Num: client.nextId()}))
+}
+
+// Notify allows for custom rpc notifications.
+func (client *Client) Notify(method string, params interface{}, opts ...jsonrpc2.CallOption) error {
+	return client.conn.Notify(client.ctx, method, params, opts...)
+}

--- a/contrib/goln/rpc/client_test.go
+++ b/contrib/goln/rpc/client_test.go
@@ -1,0 +1,183 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testParams struct {
+	Foo string `json:"foo"`
+	Bar int32  `json:"bar"`
+}
+
+type echoHandler struct {
+	sync.Mutex
+
+	called int32
+	ids    []uint64
+}
+
+func (t *echoHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	t.Lock()
+	t.called++
+	t.ids = append(t.ids, req.ID.Num)
+	t.Unlock()
+
+	var res *testParams
+	_ = json.Unmarshal(*req.Params, &res)
+	_ = conn.Reply(ctx, req.ID, *res)
+}
+
+// TestClient_Notify is a simple functional test that checks if a client
+// can send a notification.
+func TestClient_Notify(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.socket")
+	ctx := context.TODO()
+
+	lis, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	defer lis.Close()
+	done := make(chan struct{})
+	buf := make([]byte, 64)
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			conn, err := lis.Accept()
+			require.NoError(t, err)
+			for {
+				_, err := conn.Read(buf)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	client, err := NewClient(ctx, socket)
+	require.NoError(t, err)
+
+	// var res *testResponse
+	err = client.Notify("foo", testParams{Foo: "foo", Bar: 42})
+	require.NoError(t, err)
+
+	// Close the connection to stop the listener routine
+	client.conn.Close()
+	<-done
+
+	expected := []byte{
+		10, 10, 106, 115, 111, 110, 114, 112,
+		99, 34, 58, 34, 50, 46, 48, 34,
+		44, 34, 109, 101, 116, 104, 111, 100,
+		34, 58, 34, 102, 111, 111, 34, 44,
+		34, 112, 97, 114, 97, 109, 115, 34,
+		58, 123, 34, 102, 111, 111, 34, 58,
+		34, 102, 111, 111, 34, 44, 34, 98,
+		97, 114, 34, 58, 52, 50, 125, 125,
+	}
+	assert.Equal(t, expected, buf)
+}
+
+// TestClient_Call is a simple functional test that checks if a client
+// can `Call` a rpc method.
+func TestClient_Call(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.socket")
+	ctx := context.TODO()
+	lis, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	defer lis.Close()
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			codec := internal.DoubleNewLineCodec{}
+			go jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(conn, codec), &echoHandler{})
+		}
+	}()
+
+	client, err := NewClient(ctx, socket)
+	require.NoError(t, err)
+	defer client.conn.Close()
+
+	request := testParams{Foo: "data", Bar: 420}
+	var response *testParams
+	err = client.Call("mymethod", request, &response)
+	require.NoError(t, err)
+	assert.Equal(t, request.Foo, response.Foo)
+	assert.Equal(t, request.Bar, response.Bar)
+}
+
+// TestClient_CallId checks that the Id is correctly increased on
+// every call by the client.
+func TestClient_CallId(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.socket")
+	ctx := context.TODO()
+	lis, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	defer lis.Close()
+
+	handler := &echoHandler{}
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			codec := internal.DoubleNewLineCodec{}
+			go jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(conn, codec), handler)
+		}
+	}()
+
+	client, err := NewClient(ctx, socket)
+	require.NoError(t, err)
+	defer client.conn.Close()
+
+	nCalls := 100
+	wg := sync.WaitGroup{}
+	for i := 0; i < nCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			request := testParams{Foo: "data", Bar: 420}
+			var response *testParams
+			err := client.Call("mymethod", request, &response)
+			assert.NoError(t, err)
+			assert.Equal(t, request.Foo, response.Foo)
+			assert.Equal(t, request.Bar, response.Bar)
+		}()
+
+	}
+
+	wg.Wait()
+	handler.Lock()
+	defer handler.Unlock()
+	assert.Equal(t, nCalls, len(handler.ids))
+	assert.EqualValues(t, nCalls, max(handler.ids))
+}
+
+func max(i []uint64) uint64 {
+	var max uint64
+	for _, v := range i {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}

--- a/contrib/goln/rpc/messages.go
+++ b/contrib/goln/rpc/messages.go
@@ -1,0 +1,28 @@
+package rpc
+
+import "github.com/sourcegraph/jsonrpc2"
+
+// Example model
+type GetInfoRequest struct{}
+
+// Example model
+type GetInfoResponse struct {
+	Id                  string        `json:"id"`
+	Alias               string        `json:"alias"`
+	Color               string        `json:"color"`
+	NumPeers            int64         `json:"num_peers"`
+	NumPendingChannels  int64         `json:"num_pending_channels"`
+	NumActiveChannels   int64         `json:"num_active_channels"`
+	NumInactiveChannels int64         `json:"num_inactive_channels"`
+	Version             string        `json:"version"`
+	Blockheight         int64         `json:"blockheight"`
+	Network             string        `json:"network"`
+	FeesCollectedMsat   string        `json:"fees_collected_msat"`
+	LightningDir        string        `json:"lightning_dir"`
+	Address             []interface{} `json:"address"`
+}
+
+func (client *Client) GetInfo(req GetInfoRequest, opts ...jsonrpc2.CallOption) (res *GetInfoResponse, err error) {
+	err = client.Call("getinfo", req, &res, opts...)
+	return
+}

--- a/contrib/goln/rpc/server.go
+++ b/contrib/goln/rpc/server.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"context"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type Handler = func(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request)
+
+type Server struct {
+	sync.Mutex
+	ctx     context.Context
+	methods sync.Map
+	run     int32
+}
+
+func NewServer(ctx context.Context) *Server {
+	return &Server{ctx: ctx, methods: sync.Map{}, run: 1}
+}
+
+func (server *Server) Stop() {
+	server.Lock()
+	defer server.Unlock()
+	atomic.StoreInt32(&server.run, 0)
+}
+
+func (server *Server) isStopped() bool {
+	return atomic.LoadInt32(&server.run) == 0
+}
+
+func (server *Server) Accept(lis net.Listener) {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			log.Print(err.Error())
+			return
+		}
+		go jsonrpc2.NewConn(server.ctx, jsonrpc2.NewBufferedStream(conn, internal.DoubleNewLineCodec{}), server)
+	}
+
+}
+
+func (server *Server) RegisterHandler(method string, handler Handler) {
+	server.methods.Store(method, handler)
+}
+
+func (server *Server) UnregisterHandler(method string) {
+	server.methods.Delete(method)
+}
+
+// Handle implements jsonrpc2.Handler
+func (server *Server) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	if server.isStopped() {
+		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
+			Code:    -32000,
+			Message: "Server is stopped",
+		})
+		conn.Close()
+		log.Print("Call of stopped server.")
+		return
+	}
+	if method, ok := server.methods.Load(req.Method); ok {
+		if handler, ok := method.(Handler); ok {
+			handler(ctx, conn, req)
+			return
+		}
+		log.Println("Associated handler is not of type Handler.")
+	}
+	_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
+		Code:    jsonrpc2.CodeMethodNotFound,
+		Message: "Method not found",
+	})
+}

--- a/contrib/goln/rpc/server_test.go
+++ b/contrib/goln/rpc/server_test.go
@@ -1,0 +1,102 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/elementsproject/lightning/contrib/goln/internal"
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordHandler struct {
+	mutex  sync.Mutex
+	called int32
+	params []byte
+}
+
+func (r *recordHandler) Handler(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	r.mutex.Lock()
+	r.called++
+	r.params = *req.Params
+	r.mutex.Unlock()
+	_ = conn.Reply(ctx, req.ID, nil)
+}
+
+func TestServer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.socket")
+
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("error listening to socket: %s", err)
+	}
+	defer lis.Close()
+
+	rh := &recordHandler{}
+
+	// Create server.
+	server := NewServer(context.Background())
+	server.RegisterHandler("record", rh.Handler)
+	go server.Accept(lis)
+
+	// Call `record` method.
+	c, err := net.Dial("unix", socket)
+	require.NoError(t, err)
+	conn := jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(c, internal.DoubleNewLineCodec{}), nil)
+
+	testParams := struct {
+		F1 string `json:"f1"`
+		F2 int32  `json:"f2"`
+	}{
+		F1: "foo",
+		F2: 42,
+	}
+	err = conn.Call(context.Background(), "record", testParams, nil)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(testParams)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, b, rh.params)
+}
+
+func TestServerStop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.socket")
+
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("error listening to socket: %s", err)
+	}
+	defer lis.Close()
+
+	rh := &recordHandler{called: 0}
+
+	// Create server.
+	server := NewServer(context.Background())
+	server.RegisterHandler("record", rh.Handler)
+	go server.Accept(lis)
+
+	// Create client.
+	c, err := net.Dial("unix", socket)
+	require.NoError(t, err)
+	conn := jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(c, internal.DoubleNewLineCodec{}), nil)
+
+	// Stop server and call `record` method.
+	assert.False(t, server.isStopped())
+	server.Stop()
+	assert.True(t, server.isStopped())
+
+	err = conn.Call(context.Background(), "record", "foo", nil)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "jsonrpc2: code -32000 message: Server is stopped")
+	assert.Equal(t, int32(0), rh.called)
+}


### PR DESCRIPTION
This draft works on a rpc client and core-lightning plugin driver for golang that uses msggen for auto generated messages.It is not ready yet but I want to share the progress for an early feedback an possible discussions.

Current state:
- [x] jsonrpc-v2 server/client.
- [x] double new line codec.
- [ ] plugin driver:
  - [x] command line option pass-through
  - [x] rpc-method pass-through
  - [ ] notifications
  - [ ] hooks
  - [x] initialization (manifest and init msg)
  - [x] logging 
- [ ] cln-rpc-client:
  - [ ] generated messages
  - [ ] generated primitives
  - [ ] generated client api
