### PR TITLE
fix helloworld.py example in README for pyln-client

### DIFF
--- a/contrib/pyln-client/README.md
+++ b/contrib/pyln-client/README.md
@@ -96,7 +96,7 @@ def init(options, configuration, plugin):
 
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address):
+def on_connect(plugin, id, address, **kwargs):
     plugin.log("Received connect event for peer {}".format(id))
 
 


### PR DESCRIPTION
Small fix to the [helloworld.py example](https://github.com/ElementsProject/lightning/tree/master/contrib/pyln-client#writing-a-plugin) in the README for pyln-client.

An alternate fix would be to simply link to [this file](https://github.com/ElementsProject/lightning/blob/master/contrib/plugins/helloworld.py), which has more examples and appears to be more up to date.

Let me know if you would like me to implement that instead :)

Changelog-None