### PR TITLE
Early shutdown fix

### DIFF
--- a/common/test/run-channel_type.c
+++ b/common/test/run-channel_type.c
@@ -20,12 +20,18 @@ struct amount_sat amount_sat(u64 satoshis UNNEEDED)
 				       struct amount_sat a UNNEEDED,
 				       struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_add called!\n"); abort(); }
+/* Generated stub for amount_sat_div */
+struct amount_sat amount_sat_div(struct amount_sat sat UNNEEDED, u64 div UNNEEDED)
+{ fprintf(stderr, "amount_sat_div called!\n"); abort(); }
 /* Generated stub for amount_sat_eq */
 bool amount_sat_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_eq called!\n"); abort(); }
 /* Generated stub for amount_sat_greater_eq */
 bool amount_sat_greater_eq(struct amount_sat a UNNEEDED, struct amount_sat b UNNEEDED)
 { fprintf(stderr, "amount_sat_greater_eq called!\n"); abort(); }
+/* Generated stub for amount_sat_mul */
+bool amount_sat_mul(struct amount_sat *res UNNEEDED, struct amount_sat sat UNNEEDED, u64 mul UNNEEDED)
+{ fprintf(stderr, "amount_sat_mul called!\n"); abort(); }
 /* Generated stub for amount_sat_sub */
  bool amount_sat_sub(struct amount_sat *val UNNEEDED,
 				       struct amount_sat a UNNEEDED,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -974,7 +974,7 @@ int main(int argc, char *argv[])
 	 * valgrind will warn us if we make decisions based on uninitialized
 	 * variables. */
 	ld = new_lightningd(NULL);
-	ld->state = LD_STATE_RUNNING;
+	ld->state = LD_STATE_INITIALIZING;
 
 	/*~ We store an copy of our arguments before parsing mangles them, so
 	 * we can re-exec if versions of subdaemons change.  Note the use of
@@ -1174,6 +1174,7 @@ int main(int argc, char *argv[])
 		 type_to_string(tmpctx, struct node_id, &ld->id),
 		 json_escape(tmpctx, (const char *)ld->alias)->s,
 		 tal_hex(tmpctx, ld->rgb), version());
+	ld->state = LD_STATE_RUNNING;
 
 	/*~ If `closefrom_may_be_slow`, we limit ourselves to 4096 file
 	 * descriptors; tell the user about it as that limits the number
@@ -1224,14 +1225,16 @@ int main(int argc, char *argv[])
 	ecdh_hsmd_setup(ld->hsm_fd, hsm_ecdh_failed);
 
 	/*~ The root of every backtrace (almost).  This is our main event
-	 *  loop. */
-	void *io_loop_ret = io_loop_with_timers(ld);
-	/*~ io_loop_with_timers will only exit if we call io_break.
-	 *  At this point in code, we should use io_break(ld) to
-	 *  shut down.
-	 */
-	assert(io_loop_ret == ld);
-	log_debug(ld->log, "io_loop_with_timers: %s", __func__);
+	 *  loop.  We don't even call it if they've already called `stop` */
+	if (!ld->stop_conn) {
+		void *io_loop_ret = io_loop_with_timers(ld);
+		/*~ io_loop_with_timers will only exit if we call io_break.
+		 *  At this point in code, we should use io_break(ld) to
+		 *  shut down.
+		 */
+		assert(io_loop_ret == ld);
+		log_debug(ld->log, "io_loop_with_timers: %s", __func__);
+	}
 
 stop:
 	/* Stop *new* JSON RPC requests. */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -90,6 +90,7 @@ struct config {
 typedef STRMAP(const char *) alt_subdaemon_map;
 
 enum lightningd_state {
+	LD_STATE_INITIALIZING,
 	LD_STATE_RUNNING,
 	LD_STATE_SHUTDOWN,
 };

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3237,3 +3237,23 @@ def test_create_gossip_mesh(node_factory, bitcoind):
     print("nodeids", nodeids)
     print("scids", scids)
     assert False, "Test failed on purpose, grab the gossip store from /tmp/ltests-..."
+
+
+@pytest.mark.xfail(strict=True)
+def test_fast_shutdown(node_factory):
+    l1 = node_factory.get_node(start=False)
+
+    l1.daemon.start(wait_for_initialized=False)
+
+    start_time = time.time()
+    # Keep trying until this succeeds (socket may not exist yet!)
+    while True:
+        if time.time() > start_time + TIMEOUT:
+            raise ValueError("Timeout while waiting for stop to work!")
+        try:
+            l1.rpc.stop()
+        except FileNotFoundError:
+            continue
+        except ConnectionRefusedError:
+            continue
+        break

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3239,7 +3239,6 @@ def test_create_gossip_mesh(node_factory, bitcoind):
     assert False, "Test failed on purpose, grab the gossip store from /tmp/ltests-..."
 
 
-@pytest.mark.xfail(strict=True)
 def test_fast_shutdown(node_factory):
     l1 = node_factory.get_node(start=False)
 


### PR DESCRIPTION
In CI we see crashes when we call `stop` before connectd is setup.  This is not an elegant way to stop, and it's caused by an assertion that the io_loop will be exited by connectd's init reply (not the stop command!).

Simple fix.  Also fixes master which doesn't build RN :(

Fixes https://github.com/ElementsProject/lightning/issues/6130


