### PR TITLE
Update INSTALL.md

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -266,7 +266,7 @@ If you need Python 3.x for mako (or get a mako build error):
     $ brew install pyenv
     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
     $ source ~/.bash_profile
-    $ pyenv install 3.7.8
+    $ pyenv install 3.8.10
     $ pip3 install --upgrade pip
     $ pip3 install poetry
 


### PR DESCRIPTION
error:
```
anmode@Anmols-MacBook-Air lightning % pyenv install 3.7.8   
python-build: use openssl@1.1 from homebrew
python-build: use readline from homebrew
Downloading Python-3.7.8.tar.xz...
-> https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tar.xz
Installing Python-3.7.8...
patching file 'Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst'
patching file configure
patching file configure.ac
python-build: use readline from homebrew
python-build: use zlib from xcode sdk

BUILD FAILED (OS X 13.2.1 using python-build 20180424)

Inspect or clean up the working tree at /var/folders/l2/2157bwts2bxc4ttrrdfgwrj00000gn/T/python-build.20230407001028.86920
Results logged to /var/folders/l2/2157bwts2bxc4ttrrdfgwrj00000gn/T/python-build.20230407001028.86920.log

Last 10 log lines:
checking size of _Bool... 1
checking size of off_t... 8
checking whether to enable large file support... no
checking size of time_t... 8
checking for pthread_t... yes
checking size of pthread_t... 8
checking size of pthread_key_t... 8
checking whether pthread_key_t is compatible with int... no
configure: error: Unexpected output of 'arch' on OSX
make: *** No targets specified and no makefile found.  Stop.
```

after change:
```
anmode@Anmols-MacBook-Air lightning % pyenv install 3.8.10
python-build: use openssl@1.1 from homebrew
python-build: use readline from homebrew
Downloading Python-3.8.10.tar.xz...
-> https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz
Installing Python-3.8.10...
patching file 'Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst'
patching file configure
patching file configure.ac
python-build: use readline from homebrew
python-build: use zlib from xcode sdk
Installed Python-3.8.10 to /Users/anmode/.pyenv/versions/3.8.10
```
Thanks