### PR TITLE
ci: run fuzz regression tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,40 @@ jobs:
           ./configure
           make -j $(nproc) check-units installcheck
 
+  check-fuzz:
+    name: Run fuzz regression tests
+    runs-on: ubuntu-22.04
+    env:
+      COMPAT: 1
+      DEVELOPER: 1
+      EXPERIMENTAL_FEATURES: 1
+      ASAN: 1
+      UBSAN: 1
+      VALGRIND: 0
+    needs:
+      - prebuild
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          bash -x .github/scripts/setup.sh
+          pip install -U pip wheel poetry
+          # Export and then use pip to install into the current env
+          poetry export -o /tmp/requirements.txt --without-hashes --with dev
+          pip install -r /tmp/requirements.txt
+
+      - name: Build
+        run: |
+          ./configure --enable-fuzzing CC=clang
+          make -j $(nproc) check-fuzz
+
   compile:
     name: Compile CLN ${{ matrix.cfg }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
There are several benefits of doing this:
- prevent fuzz target bit rot
- more test coverage in CI
- greater visibility of fuzz tests, encouraging contributions to the seed corpus and tests themselves

Resolves https://github.com/ElementsProject/lightning/issues/6083.

Changelog-None: no user-visible changes --RR