### PR TITLE
Update libwally to 0.8.9

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -642,7 +642,7 @@ bool psbt_finalize(struct wally_psbt *psbt)
 		wally_psbt_input_set_final_witness(input, stack);
 	}
 
-	ok = (wally_psbt_finalize(psbt) == WALLY_OK);
+	ok = (wally_psbt_finalize(psbt, 0 /* flags */) == WALLY_OK);
 	tal_wally_end(psbt);
 
 	return ok && psbt_is_finalized(psbt);


### PR DESCRIPTION
Trivial update, pulls in secp256k1-zkp security update: https://github.com/ElementsProject/libwally-core/releases/tag/release_0.8.9