### PR TITLE
Add an example to lightning-cli help

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -218,6 +218,7 @@ static void human_help(char *buffer, const jsmntok_t *result)
 	tal_free(help);
 
 	printf("---\nrun `lightning-cli help <command>` for more information on a specific command\n");
+        printf("\nExample: \n  lightning-cli invoice amount_msat=300 label=IV1 description=\"my first invoice\" expiry=300 \n---\n");
 }
 
 enum format {


### PR DESCRIPTION
The format may seem trivial but (being used to -option or --option on Linux) I had to use Google to find this out the first time I wanted to use `lightning-cli`. The help file seems perfect for this.

    ---
    run `lightning-cli help <command>` for more information on a specific command

at the end of `help` becomes

    ---
    run `lightning-cli help <command>` for more information on a specific command

    Example:
      lightning-cli invoice amount_msat=300 label=IV1 description="my first invoice" expiry=300
    ---