### PR TITLE
fix: build with gcc 13 with enum and int mismatch

### DIFF
--- a/plugins/spender/multifundchannel.h
+++ b/plugins/spender/multifundchannel.h
@@ -261,7 +261,7 @@ void fail_destination_tok(struct multifundchannel_destination *dest,
 			  const char *buf,
 			  const jsmntok_t *error);
 void fail_destination_msg(struct multifundchannel_destination *dest,
-			  int error_code,
+			  enum jsonrpc_errcode error_code,
 			  const char *err_str TAKES);
 
 /* dest_count - Returns count of destinations using given protocol version */


### PR DESCRIPTION
gcc 13 add an extra check for the enum in the definition of a method. In our case, the code was failing with the following error, and the compiler is right, our definition is different from the implementation.

```
$ make
CC: cc -DBINTOPKGLIBEXECDIR="../libexec/c-lightning" -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror -Wno-maybe-uninitialized -Wshadow=local -std=gnu11 -g -fstack-protector-strong -Og -I ccan -I external/libwally-core/include/ -I external/libwally-core/src/secp256k1/include/ -I external/jsmn/ -I external/libbacktrace/ -I external/gheap/ -I external/x86_64-redhat-linux/libbacktrace-build -I external/libsodium/src/libsodium/include -I external/libsodium/src/libsodium/include/sodium -I external/x86_64-redhat-linux/libsodium-build/src/libsodium/include -I . -I/usr/local/include      -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS  -DCOMPAT_V052=1 -DCOMPAT_V060=1 -DCOMPAT_V061=1 -DCOMPAT_V062=1 -DCOMPAT_V070=1 -DCOMPAT_V072=1 -DCOMPAT_V073=1 -DCOMPAT_V080=1 -DCOMPAT_V081=1 -DCOMPAT_V082=1 -DCOMPAT_V090=1 -DCOMPAT_V0100=1 -DCOMPAT_V0121=1 -DBUILD_ELEMENTS=1  -c -o
LD: cc   -Og  config.vars  -Lexternal/x86_64-redhat-linux -lwallycore -lsecp256k1 -ljsmn -lbacktrace -lsodium -L/usr/local/include -lm -lgmp -lsqlite3  -lz  -o
cc plugins/spender/multifundchannel.c
plugins/spender/multifundchannel.c:71:6: error: conflicting types for ‘fail_destination_msg’ due to enum/integer mismatch; have ‘void(struct multifundchannel_destination *, enum jsonrpc_errcode,  const char *)’ [-Werror=enum-int-mismatch]
   71 | void fail_destination_msg(struct multifundchannel_destination *dest,
      |      ^~~~~~~~~~~~~~~~~~~~
In file included from plugins/spender/multifundchannel.c:13:
./plugins/spender/multifundchannel.h:263:6: note: previous declaration of ‘fail_destination_msg’ with type ‘void(struct multifundchannel_destination *, int,  const char *)’
  263 | void fail_destination_msg(struct multifundchannel_destination *dest,
      |      ^~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:307: plugins/spender/multifundchannel.o] Error 1
```

The gcc 13 is not released yet, but fedora beta is out for public testing, so it is useful fix this error in this release candidate cycle.

Reported-by: @grubles
Fixes https://github.com/ElementsProject/lightning/issues/6175