### PR TITLE
connectd: pass correct buflen to memmem

### DIFF
--- a/connectd/websocketd.c
+++ b/connectd/websocketd.c
@@ -109,6 +109,7 @@ static const char *get_http_hdr(const tal_t *ctx, const u8 *buf, size_t buflen,
 		    && buf[strlen(hdrname)] == ':')
 			break;
 		buf = end + 2;
+		buflen -= hdrlen + 2;
 	}
 
 	buf += strlen(hdrname) + 1;


### PR DESCRIPTION
After the first iteration of the loop, we call `memmem` with a `buflen` that points past the end of `buf`.

In practice we probably never read the uninitialized memory since we guarantee the buffer ends with "\r\n", and since most libc implementations probably read the haystack sequentially. But maybe there's some libc with a crazy optimization out there. It's good to use an accurate `buflen` just in case.

Discovered this while running some unit tests with MSan.

Ref https://github.com/ElementsProject/lightning/issues/6119.