### PR TITLE
Fix incorrect enum gerenation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ focal/
 jammy/
 release/
 .vscode/
+.idea/

--- a/contrib/msggen/msggen/model.py
+++ b/contrib/msggen/msggen/model.py
@@ -214,7 +214,7 @@ class EnumVariant(Field):
         return self.variant
 
     def normalized(self):
-        return self.variant.replace(' ', '_').replace('-', '_').upper()
+        return self.variant.replace(' ', '_').replace('-', '_').replace('/', '_').upper()
 
 
 class EnumField(Field):


### PR DESCRIPTION
Fixing the enum generation. It was going wrong for channel_type: `static_remotekey/even`.