### PR TITLE
jsonrpc: Remove the old "_msat" prefix in the listpeerchannels command

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -486,18 +486,6 @@ static void json_add_htlcs(struct lightningd *ld,
 	json_array_end(response);
 }
 
-/* We do this replication manually because it's an array. */
-static void json_add_sat_only(struct json_stream *result,
-			      const char *fieldname,
-			      struct amount_sat sat)
-{
-	struct amount_msat msat;
-
-	if (amount_sat_to_msat(&msat, sat))
-		json_add_string(result, fieldname,
-				type_to_string(tmpctx, struct amount_msat, &msat));
-}
-
 /* Fee a commitment transaction would currently cost */
 static struct amount_sat commit_txfee(const struct channel *channel,
 				      struct amount_msat amount,
@@ -900,7 +888,7 @@ static void json_add_channel(struct lightningd *ld,
 					   "Overflow adding our_funds to push");
 				total = channel->our_funds;
 			}
-			json_add_sat_only(response, "local_funds_msat", total);
+			json_add_amount_sat_msat(response, "local_funds_msat", total);
 
 			if (!amount_sat_sub(&total, peer_funded_sats, funds)) {
 				log_broken(channel->log,
@@ -908,7 +896,7 @@ static void json_add_channel(struct lightningd *ld,
 					   " peer's funds");
 				total = peer_funded_sats;
 			}
-			json_add_sat_only(response, "remote_funds_msat", total);
+			json_add_amount_sat_msat(response, "remote_funds_msat", total);
 
 			json_add_amount_msat(response, "fee_paid_msat",
 					     channel->push);
@@ -918,7 +906,7 @@ static void json_add_channel(struct lightningd *ld,
 					   "Overflow adding peer funds to push");
 				total = peer_funded_sats;
 			}
-			json_add_sat_only(response, "remote_funds_msat", total);
+			json_add_amount_sat_msat(response, "remote_funds_msat", total);
 
 			if (!amount_sat_sub(&total, channel->our_funds, funds)) {
 				log_broken(channel->log,
@@ -926,15 +914,15 @@ static void json_add_channel(struct lightningd *ld,
 					   " our_funds");
 				total = channel->our_funds;
 			}
-			json_add_sat_only(response, "local_funds_msat", total);
+			json_add_amount_sat_msat(response, "local_funds_msat", total);
 			json_add_amount_msat(response, "fee_rcvd_msat",
 					     channel->push);
 		}
 
 	} else {
-		json_add_sat_only(response, "local_funds_msat",
+		json_add_amount_sat_msat(response, "local_funds_msat",
 				  channel->our_funds);
-		json_add_sat_only(response, "remote_funds_msat",
+		json_add_amount_sat_msat(response, "remote_funds_msat",
 				  peer_funded_sats);
 		json_add_amount_msat(response, "pushed_msat",
 				     channel->push);


### PR DESCRIPTION
This is a regression that we introduced in this release
due to some dirty parts of our codebase.

For historical reasons (I think), we were using a `json_add_sat_only`
procedure defined in `peer_control.c`. So when @rustyrussell removed the _msat,
we thought that all the fields were reflecting the new behavior, but
we were wrong.

This PR fixes this bug and also removes the additional function
from `peer_control.c`. This way, we can be sure that there is no other part
of our codebase that uses this method (except for other `json_add` methods).

Fixes: https://github.com/ElementsProject/lightning/issues/6244
Reported-by: @hMsats
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>