### PR TITLE
add missing htlc states from incoming htlcs

### DIFF
--- a/cln-grpc/proto/primitives.proto
+++ b/cln-grpc/proto/primitives.proto
@@ -50,6 +50,15 @@ enum HtlcState {
       SentRemoveRevocation = 8;
       SentRemoveAckCommit = 9;
       RcvdRemoveAckRevocation = 10;
+      RCVD_ADD_HTLC = 11,
+      RCVD_ADD_COMMIT = 12,
+      SENT_ADD_REVOCATION = 13,
+      SENT_ADD_ACK_COMMIT = 14,
+      SENT_REMOVE_HTLC = 15,
+      SENT_REMOVE_COMMIT = 16,
+      RCVD_REMOVE_REVOCATION = 17,
+      RCVD_REMOVE_ACK_COMMIT = 18,
+      SENT_REMOVE_ACK_REVOCATION = 19,
 }
 
 message ChannelStateChangeCause {}

--- a/cln-grpc/proto/primitives.proto
+++ b/cln-grpc/proto/primitives.proto
@@ -50,15 +50,15 @@ enum HtlcState {
       SentRemoveRevocation = 8;
       SentRemoveAckCommit = 9;
       RcvdRemoveAckRevocation = 10;
-      RCVD_ADD_HTLC = 11,
-      RCVD_ADD_COMMIT = 12,
-      SENT_ADD_REVOCATION = 13,
-      SENT_ADD_ACK_COMMIT = 14,
-      SENT_REMOVE_HTLC = 15,
-      SENT_REMOVE_COMMIT = 16,
-      RCVD_REMOVE_REVOCATION = 17,
-      RCVD_REMOVE_ACK_COMMIT = 18,
-      SENT_REMOVE_ACK_REVOCATION = 19,
+      RCVD_ADD_HTLC = 11;
+      RCVD_ADD_COMMIT = 12;
+      SENT_ADD_REVOCATION = 13;
+      SENT_ADD_ACK_COMMIT = 14;
+      SENT_REMOVE_HTLC = 15;
+      SENT_REMOVE_COMMIT = 16;
+      RCVD_REMOVE_REVOCATION = 17;
+      RCVD_REMOVE_ACK_COMMIT = 18;
+      SENT_REMOVE_ACK_REVOCATION = 19;
 }
 
 message ChannelStateChangeCause {}

--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -40,6 +40,15 @@ pub enum HtlcState {
     SENT_REMOVE_REVOCATION = 8,
     SENT_REMOVE_ACK_COMMIT = 9,
     RCVD_REMOVE_ACK_REVOCATION = 10,
+    RCVD_ADD_HTLC = 11,
+    RCVD_ADD_COMMIT = 12,
+    SENT_ADD_REVOCATION = 13,
+    SENT_ADD_ACK_COMMIT = 14,
+    SENT_REMOVE_HTLC = 15,
+    SENT_REMOVE_COMMIT = 16,
+    RCVD_REMOVE_REVOCATION = 17,
+    RCVD_REMOVE_ACK_COMMIT = 18,
+    SENT_REMOVE_ACK_REVOCATION = 19,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug)]
@@ -319,6 +328,16 @@ impl From<i32> for HtlcState {
             8 => HtlcState::SENT_REMOVE_REVOCATION,
             9 => HtlcState::SENT_REMOVE_ACK_COMMIT,
             10 => HtlcState::RCVD_REMOVE_ACK_REVOCATION,
+            11 => HtlcState::RCVD_ADD_HTLC,
+            12 => HtlcState::RCVD_ADD_COMMIT,
+            13 => HtlcState::SENT_ADD_REVOCATION,
+            14 => HtlcState::SENT_ADD_ACK_COMMIT,
+            15 => HtlcState::SENT_REMOVE_HTLC,
+            16 => HtlcState::SENT_REMOVE_COMMIT,
+            17 => HtlcState::RCVD_REMOVE_REVOCATION,
+            18 => HtlcState::RCVD_REMOVE_ACK_COMMIT,
+            19 => HtlcState::SENT_REMOVE_ACK_REVOCATION,
+
             n => panic!("Unmapped HtlcState variant: {}", n),
         }
     }


### PR DESCRIPTION
While updating my plugins to 23.05 non-deprecated methods i encountered this error 
```
Malformed response from lightningd: unknown variant `SENT_ADD_ACK_COMMIT`, expected one of `SENT_ADD_HTLC`, `SENT_ADD_COMMIT`, `RCVD_ADD_REVOCATION`, `RCVD_ADD_ACK_COMMIT`, `SENT_ADD_ACK_REVOCATION`, `RCVD_ADD_ACK_REVOCATION`, `RCVD_REMOVE_HTLC`, `RCVD_REMOVE_COMMIT`, `SENT_REMOVE_REVOCATION`, `SENT_REMOVE_ACK_COMMIT`, `RCVD_REMOVE_ACK_REVOCATION`"
```
this should fix it

Changelog-None