### PR TITLE
pytest: fix test_cln_plugin_reentrant which panics rust under CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,6 +206,7 @@ jobs:
       BITCOIN_VERSION: 24.0.1
       ELEMENTS_VERSION: 22.0.2
       RUST_PROFILE: release  # Has to match the one in the compile step
+      PYTEST_OPTS: --timeout=1200
     needs:
       - compile
     strategy:
@@ -317,7 +318,7 @@ jobs:
       CFG: gcc-dev1-exp1
       DEVELOPER: 1
       EXPERIMENTAL_FEATURES: 1
-      PYTEST_OPTS: --test-group-random-seed=42
+      PYTEST_OPTS: --test-group-random-seed=42 --timeout=1800
     needs:
       - compile
     strategy:

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pyln.testing import node_pb2 as nodepb
 from pyln.testing import node_pb2_grpc as nodegrpc
 from pyln.testing import primitives_pb2 as primitivespb
-from pyln.testing.utils import env, TEST_NETWORK, wait_for, sync_blockheight
+from pyln.testing.utils import env, TEST_NETWORK, wait_for, sync_blockheight, TIMEOUT
 import grpc
 import pytest
 import subprocess
@@ -275,14 +275,13 @@ def test_cln_plugin_reentrant(node_factory, executor):
     f1 = executor.submit(l2.rpc.pay, i1)
     f2 = executor.submit(l2.rpc.pay, i2)
 
-    import time
-    time.sleep(3)
+    l1.daemon.wait_for_logs(["plugin-cln-plugin-reentrant: Holding on to incoming HTLC Object"] * 2)
 
     print("Releasing HTLCs after holding them")
     l1.rpc.call('release')
 
-    assert f1.result()
-    assert f2.result()
+    assert f1.result(timeout=TIMEOUT)
+    assert f2.result(timeout=TIMEOUT)
 
 
 def test_grpc_keysend_routehint(bitcoind, node_factory):


### PR DESCRIPTION
Test was hastily written, plugin crashed, command didn't return, pytest doesn't run with --timeout: CI just killed it after two hours.

Changelog-None