### PR TITLE
Update libwally to 0.9.0

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -94,6 +94,7 @@ $(TARGET_DIR)/libwally-core-build/src/libwallycore.% $(TARGET_DIR)/libwally-core
 		--prefix=/ \
 		--libdir=/ \
 		--enable-debug \
+	&& cp src/secp256k1/src/libsecp256k1-config.h ../../libwally-core/src/secp256k1/src/libsecp256k1-config.h \
 	&& $(MAKE)
 
 # If we tell Make that the above builds both, it runs it twice in


### PR DESCRIPTION
This patches a sidechannel issue that was present in secp-zkp dependency, and also brings us a step closer to taproot deposit/withdrawal support: https://github.com/ElementsProject/libwally-core/releases/tag/release_0.9.0