### PR TITLE
build: remove gmp

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -80,16 +80,6 @@ then
     rm sqlite-src-3260000.zip
     rm -rf sqlite-src-3260000
 
-    wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz
-    tar xf gmp-6.1.2.tar.xz
-    cd gmp-6.1.2 || exit 1
-    ./configure --disable-assembly --prefix="$QEMU_LD_PREFIX" --host="$TARGET_HOST"
-    make
-    sudo make install
-    cd ..
-    rm gmp-6.1.2.tar.xz
-    rm -rf gmp-6.1.2
-
     ./configure CC="$TARGET_HOST-gcc" --enable-static
 
     make -s -j32 CC="$TARGET_HOST-gcc"

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -24,7 +24,6 @@ sudo apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
      git \
      libc6-dev-arm64-cross \
      libc6-dev-armhf-cross \
-     libgmp-dev \
      libpq-dev \
      libprotobuf-c-dev \
      libsqlite3-dev \

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -36,7 +36,6 @@ jobs:
             autoconf \
             automake \
             libtool \
-            gmp \
             bash \
             gettext \
             sqlite3 \

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -23,7 +23,7 @@ jobs:
           export PATH="/usr/local/opt:/Users/runner/.local/bin:/Users/runner/Library/Python/3.10/bin:$PATH"
 
           export BITCOIN_VERSION=24.1
-          brew install wget autoconf automake libtool python@3.10 gmp gnu-sed gettext libsodium
+          brew install wget autoconf automake libtool python@3.10 gnu-sed gettext libsodium
 
           (
             cd /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,13 +86,6 @@ RUN apt-get install -y --no-install-recommends unzip tclsh \
     && make \
     && make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
 
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-    && tar xvf gmp-6.1.2.tar.xz \
-    && cd gmp-6.1.2 \
-    && ./configure --disable-assembly \
-    && make \
-    && make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
-
 ENV RUST_PROFILE=release
 ENV PATH=$PATH:/root/.cargo/bin/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Makefile
+++ b/Makefile
@@ -258,11 +258,11 @@ LDFLAGS += $(PIE_LDFLAGS) $(CSANFLAGS) $(COPTFLAGS)
 
 ifeq ($(STATIC),1)
 # For MacOS, Jacob Rapoport <jacob@rumblemonkey.com> changed this to:
-#  -L/usr/local/lib -Wl,-lgmp -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
+#  -L/usr/local/lib -lsqlite3 -lz -Wl,-lm -lpthread -ldl $(COVFLAGS)
 # But that doesn't static link.
-LDLIBS = -L$(CPATH) -Wl,-dn -lgmp $(SQLITE3_LDLIBS) -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
+LDLIBS = -L$(CPATH) -Wl,-dn $(SQLITE3_LDLIBS) -lz -Wl,-dy -lm -lpthread -ldl $(COVFLAGS)
 else
-LDLIBS = -L$(CPATH) -lm -lgmp $(SQLITE3_LDLIBS) -lz $(COVFLAGS)
+LDLIBS = -L$(CPATH) -lm $(SQLITE3_LDLIBS) -lz $(COVFLAGS)
 endif
 
 # If we have the postgres client library we need to link against it as well

--- a/configure
+++ b/configure
@@ -205,7 +205,7 @@ usage()
     usage_with_default "--enable/disable-valgrind" "(autodetect)"
     echo "    Run tests with Valgrind"
     usage_with_default "--enable/disable-static" "$STATIC" "enable" "disable"
-    echo "    Static link sqlite3, gmp and zlib libraries"
+    echo "    Static link sqlite3 and zlib libraries"
     usage_with_default "--enable/disable-address-sanitizer" "$ASAN" "enable" "disable"
     echo "    Compile with address-sanitizer"
     usage_with_default "--enable/disable-ub-sanitizer" "$UBSAN" "enable" "disable"

--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -12,7 +12,6 @@ RUN apk update && \
       cargo \
       gettext \
       git \
-      gmp-dev \
       libsodium \
       libtool \
       net-tools \

--- a/contrib/docker/Dockerfile.builder
+++ b/contrib/docker/Dockerfile.builder
@@ -22,7 +22,6 @@ RUN apt-get -qq update && \
 	libtool \
 	libprotobuf-c-dev \
 	libsqlite3-dev \
-	libgmp-dev \
 	git \
 	python3 \
 	valgrind \

--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -9,7 +9,6 @@ RUN dnf update -y && \
 		'Development Tools' && \
 	dnf install -y \
 		clang \
-		gmp-devel \
 		libsq3-devel \
 		python3-devel \
 		python3-mako \

--- a/contrib/docker/Dockerfile.tester
+++ b/contrib/docker/Dockerfile.tester
@@ -27,7 +27,6 @@ RUN apt-get -qq update && \
 	git \
 	libc6-dev-arm64-cross \
 	libc6-dev-armhf-cross \
-	libgmp-dev \
 	libpq-dev \
 	libprotobuf-c-dev \
 	libsqlite3-dev \

--- a/contrib/docker/linuxarm32v7.Dockerfile
+++ b/contrib/docker/linuxarm32v7.Dockerfile
@@ -101,13 +101,6 @@ RUN apt-get install -y --no-install-recommends unzip tclsh \
 && make \
 && make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
 
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-&& tar xvf gmp-6.1.2.tar.xz \
-&& cd gmp-6.1.2 \
-&& ./configure --disable-assembly --prefix=$QEMU_LD_PREFIX --host=${target_host} \
-&& make \
-&& make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
-
 COPY --from=downloader /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 WORKDIR /opt/lightningd
 COPY . /tmp/lightning

--- a/contrib/docker/linuxarm64v8.Dockerfile
+++ b/contrib/docker/linuxarm64v8.Dockerfile
@@ -102,12 +102,6 @@ RUN apt-get install -y --no-install-recommends unzip tclsh \
 && make \
 && make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
 
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-&& tar xvf gmp-6.1.2.tar.xz \
-&& cd gmp-6.1.2 \
-&& ./configure --disable-assembly --prefix=$QEMU_LD_PREFIX --host=${target_host} \
-&& make \
-&& make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
 COPY --from=downloader /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 WORKDIR /opt/lightningd
 COPY . /tmp/lightning

--- a/contrib/docker/scripts/build.sh
+++ b/contrib/docker/scripts/build.sh
@@ -78,16 +78,6 @@ then
     rm sqlite-src-3260000.zip
     rm -rf sqlite-src-3260000
 
-    wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz
-    tar xf gmp-6.1.2.tar.xz
-    cd gmp-6.1.2 || exit 1
-    ./configure --disable-assembly --prefix="$QEMU_LD_PREFIX" --host="$TARGET_HOST"
-    make
-    sudo make install
-    cd ..
-    rm gmp-6.1.2.tar.xz
-    rm -rf gmp-6.1.2
-
     ./configure CC="$TARGET_HOST-gcc" --enable-static
 
     make -j32 CC="$TARGET_HOST-gcc" > /dev/null

--- a/contrib/docker/scripts/setup.sh
+++ b/contrib/docker/scripts/setup.sh
@@ -24,7 +24,6 @@ sudo apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
      git \
      libc6-dev-arm64-cross \
      libc6-dev-armhf-cross \
-     libgmp-dev \
      libpq-dev \
      libprotobuf-c-dev \
      libsqlite3-dev \

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -17,7 +17,6 @@ RUN apt-get update \
 	file \
 	gettext \
 	git \
-	libgmp-dev \
 	libpq-dev \
 	libsodium23 \
 	libtool \

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -17,7 +17,6 @@ RUN apt-get update \
 	file \
 	gettext \
 	git \
-        libgmp-dev \
         libsqlite3-dev \
 	libpq-dev \
 	libsodium23 \

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -20,7 +20,6 @@ Library Requirements
 
 You will need several development libraries:
 * libsqlite3: for database support.
-* libgmp: for secp256k1
 * zlib: for compression routines.
 
 For actually doing development and running the tests, you will also need:
@@ -38,7 +37,7 @@ Get dependencies:
 
     sudo apt-get update
     sudo apt-get install -y \
-      autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev \
+      autoconf automake build-essential git libtool libsqlite3-dev \
       python3 python3-pip net-tools zlib1g-dev libsodium-dev gettext
     pip3 install --upgrade pip
     pip3 install --user poetry
@@ -119,7 +118,6 @@ $ sudo dnf update -y && \
                 clang \
                 gettext \
                 git \
-                gmp-devel \
                 libsq3-devel \
                 python3-devel \
                 python3-pip \
@@ -204,7 +202,7 @@ OS version: OpenBSD 6.7
 
 Install dependencies:
 ```
-pkg_add git python gmake py3-pip libtool gmp
+pkg_add git python gmake py3-pip libtool
 pkg_add automake # (select highest version, automake1.16.2 at time of writing)
 pkg_add autoconf # (select highest version, autoconf-2.69p2 at time of writing)
 ```
@@ -236,7 +234,7 @@ To Build on NixOS
 Use nix-shell launch a shell with a full clightning dev environment:
 
 ```
-$ nix-shell -Q -p gdb sqlite autoconf git clang libtool gmp sqlite autoconf \
+$ nix-shell -Q -p gdb sqlite autoconf git clang libtool sqlite autoconf \
 autogen automake libsodium 'python3.withPackages (p: [p.bitcoinlib])' \
 valgrind --run make
 ```
@@ -246,7 +244,7 @@ To Build on macOS
 
 Assuming you have Xcode and Homebrew installed. Install dependencies:
 
-    $ brew install autoconf automake libtool python3 gmp gnu-sed gettext libsodium protobuf
+    $ brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf
     $ ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
     $ export PATH="/usr/local/opt:$PATH"
 
@@ -407,7 +405,7 @@ Config the arm elf interpreter prefix:
 
     export QEMU_LD_PREFIX=/path/to/raspberry/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/arm-linux-gnueabihf/sysroot/
 
-Obtain and install cross-compiled versions of sqlite3, gmp and zlib:
+Obtain and install cross-compiled versions of sqlite3 and zlib:
 
 Download and build zlib:
 
@@ -424,15 +422,6 @@ Download and build sqlite3:
     unzip sqlite-src-3260000.zip
     cd sqlite-src-3260000
     ./configure --enable-static --disable-readline --disable-threadsafe --disable-load-extension --host=$target_host --prefix=$QEMU_LD_PREFIX
-    make
-    make install
-
-Download and build gmp:
-
-    wget https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz
-    tar xvf gmp-6.1.2.tar.xz
-    cd gmp-6.1.2
-    ./configure --disable-assembly --host=$target_host --prefix=$QEMU_LD_PREFIX
     make
     make install
 
@@ -456,7 +445,7 @@ Get dependencies:
 ```
 apk update
 apk add --virtual .build-deps ca-certificates alpine-sdk autoconf automake git libtool \
-  gmp-dev sqlite-dev python3 py3-mako net-tools zlib-dev libsodium gettext
+  sqlite-dev python3 py3-mako net-tools zlib-dev libsodium gettext
 ```
 Clone lightning:
 ```
@@ -477,7 +466,7 @@ apk del .build-deps
 ```
 Install runtime dependencies:
 ```
-apk add gmp libgcc libsodium sqlite-libs zlib
+apk add libgcc libsodium sqlite-libs zlib
 ```
 
 Additional steps

--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -7,7 +7,6 @@
 #include <ccan/tal/str/str.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <gmp.h>
 #if HAVE_SQLITE3
 # include <sqlite3.h>
 # define IF_SQLITE3(...) __VA_ARGS__
@@ -19,17 +18,14 @@
 
 static const char template[] =
 	"/* Generated file by tools/headerversions, do not edit! */\n"
-	"/* GMP version: %s */\n"
 	IF_SQLITE3("/* SQLITE3 version: %u */\n")
 	"/* ZLIB version: %s */\n"
 	"#include <ccan/err/err.h>\n"
-	"#include <gmp.h>\n"
 	IF_SQLITE3("#include <sqlite3.h>\n")
 	"#include <zlib.h>\n"
 	"\n"
 	"static inline void check_linked_library_versions(void)\n"
 	"{\n"
-	"	char compiled_gmp_version[100];\n"
 	IF_SQLITE3(
 	"       /* Require at least the version we compiled with. */"
 	"	if (SQLITE_VERSION_NUMBER > sqlite3_libversion_number())\n"
@@ -44,15 +40,6 @@ static const char template[] =
 	"	if (zlibVersion()[0] != ZLIB_VERSION[0])\n"
 	"		errx(1, \"zlib version mismatch: compiled %%s, now %%s\",\n"
 	"		     ZLIB_VERSION, zlibVersion());\n"
-	"	/* GMP doesn't say anything, and we have to assemble our own string. */\n"
-	"	snprintf(compiled_gmp_version,  sizeof(compiled_gmp_version),\n"
-	"		 \"%%u.%%u.%%u\",\n"
-	"		 __GNU_MP_VERSION,\n"
-	"		 __GNU_MP_VERSION_MINOR,\n"
-	"		 __GNU_MP_VERSION_PATCHLEVEL);\n"
-	"	if (strcmp(compiled_gmp_version, gmp_version) != 0)\n"
-	"		errx(1, \"gmp version mismatch: compiled %%s, now %%s\",\n"
-	"		     compiled_gmp_version, gmp_version);\n"
 	"}\n";
 
 int main(int argc, char *argv[])
@@ -70,7 +57,6 @@ int main(int argc, char *argv[])
 		err(1, "Reading %s", argv[1]);
 
 	new = tal_fmt(NULL, template,
-		      gmp_version,
 		      IF_SQLITE3(sqlite3_libversion_number(),)
 		      zlibVersion());
 	if (!file || !streq(new, file)) {

--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -70,7 +70,7 @@ case "$PLATFORM" in
 	    exit 1
 	fi
 	DOWNLOAD='sudo apt -y --no-install-recommends --reinstall -d install'
-	PKGS='autoconf automake libtool make gcc libgmp-dev libsqlite3-dev zlib1g-dev libsodium-dev'
+	PKGS='autoconf automake libtool make gcc libsqlite3-dev zlib1g-dev libsodium-dev'
 	INST='sudo dpkg -i'
 	cat > /tmp/SHASUMS <<EOF
 a909ad8b2e97f45960a05458140cff737df30bf7c616778a5a0ca74b9d012d93  /var/cache/apt/archives/autoconf_2.69-11_all.deb
@@ -84,8 +84,6 @@ e426c70a940a7d0c5c95823a5fd01f26bd8bcb08d109df2f8c96c439da8dc440  /var/cache/apt
 69ea1317b37cbd467eb7d216f5d23aa8831d926908e9e12477aa28bdc1d5e62b  /var/cache/apt/archives/libc-dev-bin_2.27-3ubuntu1_amd64.deb
 357185ad09d689b61efda9576888feea2a0f178ae1422cddc6cd0d48f7c22d50  /var/cache/apt/archives/libcilkrts5_7.3.0-16ubuntu3_amd64.deb
 becbeba33d3824aa3c0d1b1e62653fcee776eb7cad631df0748fa77032e293c6  /var/cache/apt/archives/libgcc-7-dev_7.3.0-16ubuntu3_amd64.deb
-77066044de14fbcc4f2326348e24dda33e1106295e9c44748bb457ecd132b823  /var/cache/apt/archives/libgmp-dev_2%3a6.1.2+dfsg-2_amd64.deb
-612ab92cdf2aef4591c3a36e1656e3af9a3fe056989e2ac22e5482017208f736  /var/cache/apt/archives/libgmpxx4ldbl_2%3a6.1.2+dfsg-2_amd64.deb
 445b4569e2d3b72403ce3f79a58021f7d2832ee1e5e1a8e9fea7ab9aadaa0f1c  /var/cache/apt/archives/libitm1_8-20180414-1ubuntu2_amd64.deb
 4aa713aae73c15f3cc968b45cac3b0ae4e5d8c0b39ec35a6a535672fd833eb75  /var/cache/apt/archives/liblsan0_8-20180414-1ubuntu2_amd64.deb
 1bded2761c1213cc3b6bab27f515abff895af51d4b2272d6bddeadbf067a30dc  /var/cache/apt/archives/libmpx2_8-20180414-1ubuntu2_amd64.deb
@@ -108,7 +106,7 @@ EOF
 	    exit 1
 	fi
 	DOWNLOAD='sudo apt -y --no-install-recommends --reinstall -d install'
-	PKGS='autoconf automake libtool make gcc libgmp-dev libsqlite3-dev zlib1g-dev libsodium-dev'
+	PKGS='autoconf automake libtool make gcc libsqlite3-dev zlib1g-dev libsodium-dev'
 	INST='sudo dpkg -i'
 	cat > /tmp/SHASUMS <<EOF
 f554697f01a6267127ef20e6eae4e8ed983507c816475ac72dbb8be26d94c796  /var/cache/apt/archives/autoconf_2.69-11.1_all.deb
@@ -122,7 +120,6 @@ adb78f38fb00c76af4384be7a4c5f41da242e05bea6b0483e03b7e0c86738477  /var/cache/apt
 255ebc78828b1531f83038805dd918a8a60c017f939b07dd614b9fb7f7400df3  /var/cache/apt/archives/libcc1-0_10-20200411-0ubuntu1_amd64.deb
 f0a41d8e8cf379dbbdfc43169f34851ed452b3581e72c6654f2e290caf4e1b20  /var/cache/apt/archives/libcrypt-dev_1%3a4.4.10-10ubuntu4_amd64.deb
 d1db4de59b4184e502407a2abfde23ed1a966e590f17b4d206bdb4fbb7df0040  /var/cache/apt/archives/libgcc-9-dev_9.3.0-10ubuntu2_amd64.deb
-8dd29cf74e89d8555c6057345d40b1e501407ff6ac3a13de35ef8fa5ae6cb300  /var/cache/apt/archives/libgmp-dev_2%3a6.2.0+dfsg-4_amd64.deb
 b1d9556fea9ed94dea7eeebeccc59bf9598a658e77e6dba5b9197d0f1a22059b  /var/cache/apt/archives/libpq-dev_12.2-4_amd64.deb
 af86d031c99bc7db0c8e6a93547a885f48d1f88b683989ac479a9c1b2b9e1781  /var/cache/apt/archives/libpq5_12.2-4_amd64.deb
 2bc3d45c379470ffbe6da5c30edd573c7579331299ad67a04af68f11b1858970  /var/cache/apt/archives/libsodium-dev_1.0.18-1_amd64.deb
@@ -141,7 +138,7 @@ EOF
 	    exit 1
 	fi
 	DOWNLOAD='sudo apt -y --no-install-recommends --reinstall -d install'
-	PKGS='autoconf automake libtool make gcc libgmp-dev libsqlite3-dev zlib1g-dev libsodium-dev'
+	PKGS='autoconf automake libtool make gcc libsqlite3-dev zlib1g-dev libsodium-dev'
 	INST='sudo dpkg -i'
 	cat > /tmp/SHASUMS <<EOF
 96b528889794c4134015a63c75050f93d8aecdf5e3f2a20993c1433f4c61b80e  /var/cache/apt/archives/autoconf_2.71-2_all.deb
@@ -152,7 +149,6 @@ cc37cab5c60bcfe4bbf289a8002f369949a41ed46e8b51a0503a001099370c56  /var/cache/apt
 2f52cdc0aca888bb3995d871a65282107dc7c2a0a4d78f60680f709bdc0875aa  /var/cache/apt/archives/libcc1-0_12-20220319-1ubuntu1_amd64.deb
 a79be2f6e45823dcc09e04d5e98c88ec88d07d5b8895d05b875a8ade8b345efa  /var/cache/apt/archives/libcrypt-dev_1%3a4.4.27-1_amd64.deb
 adae5a301c7899c1bce8ae26b5423716a47e516df25c09d6d536607bc34853bc  /var/cache/apt/archives/libgcc-11-dev_11.2.0-19ubuntu1_amd64.deb
-e4ce547c5c5e4efd98854d06559349b3a03272eb343f1bd8e4ccac7b783229a3  /var/cache/apt/archives/libgmp-dev_2%3a6.2.1+dfsg-3ubuntu1_amd64.deb
 d8b8653388e676a3ae2fcf565c2b1a42a01a1104062317f641e8d24f0eaff9c3  /var/cache/apt/archives/libpq-dev_14.2-1ubuntu1_amd64.deb
 542dcee1409c74d03ecdd4ca4a0cfd467e5d2804d9985b58e39d3c5889a409e3  /var/cache/apt/archives/libpq5_14.2-1ubuntu1_amd64.deb
 885ee09c37d0e37ef6042e8cb4a22ccbab92101f21ab0c8f51ae961e4484407c  /var/cache/apt/archives/libsodium23_1.0.18-1build2_amd64.deb


### PR DESCRIPTION
Core and secp have not used gmp for a very long time now (core disabled it in 2015).