### PR TITLE
rune tweaks

### DIFF
--- a/ccan/ccan/rune/coding.c
+++ b/ccan/ccan/rune/coding.c
@@ -206,7 +206,7 @@ bool rune_condition_is_valid(enum rune_condition cond)
 size_t rune_altern_fieldname_len(const char *alternstr, size_t alternstrlen)
 {
 	for (size_t i = 0; i < alternstrlen; i++) {
-		if (cispunct(alternstr[i]))
+		if (cispunct(alternstr[i]) && alternstr[i] != '_')
 			return i;
 	}
 	return alternstrlen;

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -408,7 +408,8 @@ static const char *check_condition(const tal_t *ctx,
 				size_t off = strlen("pname");
 				/* Remove punctuation! */
 				for (size_t n = off; pmemname[n]; n++) {
-					if (cispunct(pmemname[n]))
+					/* Leave underscores in param names (e.g. amount_msat) */
+					if (cispunct(pmemname[n]) && pmemname[n] != '_')
 						continue;
 					pmemname[off++] = pmemname[n];
 				}

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -428,6 +428,15 @@ static const char *check_condition(const tal_t *ctx,
 	if (!ptok)
 		return rune_alt_single_missing(ctx, alt);
 
+	/* Special case named `*_msat` fields */
+	if (strstarts(alt->fieldname, "pname")
+	    && strends(alt->fieldname, "_msat")) {
+		struct amount_msat amt;
+		parse_amount_msat(&amt, cinfo->buf + ptok->start,
+				  ptok->end - ptok->start);
+		return rune_alt_single_int(ctx, alt, amt.millisatoshis); /* Raw: check rune validity */
+	}
+
 	return rune_alt_single_str(ctx, alt,
 				   cinfo->buf + ptok->start,
 				   ptok->end - ptok->start);


### PR DESCRIPTION
Few small tweaks to allow for

- underscores in parameter name fields
- parsing `_msat` pname fields as msats (which allows for integer level ops on them)