### PR TITLE
Runes: document parameter usage, and let them be ints.

### DIFF
--- a/doc/lightning-commando-rune.7.md
+++ b/doc/lightning-commando-rune.7.md
@@ -34,7 +34,7 @@ being run:
 * method: the command being run, e.g. "method=withdraw".
 * rate: the rate limit, per minute, e.g. "rate=60".
 * pnum: the number of parameters. e.g. "pnum<2".
-* pnameX: the parameter named X. e.g. "pnamedestination=1RustyRX2oai4EYYDpQGWvEL62BBGqN9T".
+* pnameX: the parameter named X (with any punctuation like `_` removed). e.g. "pnamedestination=1RustyRX2oai4EYYDpQGWvEL62BBGqN9T".
 * parrN: the N'th parameter. e.g. "parr0=1RustyRX2oai4EYYDpQGWvEL62BBGqN9T".
 
 RESTRICTION FORMAT

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -427,6 +427,18 @@ static const char *check_condition(const tal_t *ctx,
 	if (!ptok)
 		return rune_alt_single_missing(ctx, alt);
 
+	/* Pass through valid integers as integers. */
+	if (ptok->type == JSMN_PRIMITIVE) {
+		s64 val;
+
+		if (json_to_s64(cinfo->buf, ptok, &val)) {
+			plugin_log(plugin, LOG_DBG, "It's an int %"PRId64, val);
+			return rune_alt_single_int(ctx, alt, val);
+		}
+
+		/* Otherwise, treat it as a string (< and > will fail with
+		 * "is not an integer field") */
+	}
 	return rune_alt_single_str(ctx, alt,
 				   cinfo->buf + ptok->start,
 				   ptok->end - ptok->start);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3124,6 +3124,7 @@ def test_commando_blacklist(node_factory):
     assert blacklisted_rune is True
 
 
+@pytest.mark.slow_test
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
     nodes = node_factory.get_nodes(5)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2991,7 +2991,6 @@ def test_commando_listrunes(node_factory):
     assert not_our_rune['our_rune'] is False
 
 
-@pytest.mark.xfail(strict=True)
 def test_commando_rune_pay_amount(node_factory):
     l1, l2 = node_factory.line_graph(2)
 


### PR DESCRIPTION
(based on #6294 )

Closes: #6288 

I had forgotten that we already strip punctuation from parameter names, so we merely need to treat integer parameters correctly FTW.  And document that `_` stripping!