### PR TITLE
test: rebasing, and handing base ref to doc/Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Rebase
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch origin ${{ github.base_ref }}
+          git rebase origin/${{ github.base_ref }}
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
@@ -48,7 +58,7 @@ jobs:
       - name: Configure
         run: ./configure
       - name: Check source
-        run: make -j 4 check-source
+        run: make -j 4 check-source BASE_REF="origin/${{ github.base_ref }}"
       - name: Check Generated Files have been updated
         run: make -j 4 check-gen-updated
       - name: Check docs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -227,22 +227,22 @@ doc/index.rst: $(MANPAGES:=.md)
 	  python3 devtools/blockreplace.py doc/index.rst manpages --language=rst --indent "   " \
 	)
 
-# For CI to (very roughly!) check that we only deprecated fields, or labelled added ones
-# When running on GitHub (CI=true), we need to fetch origin/master
+# Overridden by GH CI if necessary.
+BASE_REF=master
 schema-added-check:
-	@if ! test -z $$CI; then git fetch origin master; fi; \
-	if git diff origin/master -- doc/schemas | grep -q '^+.*{' && ! git diff origin/master -- doc/schemas | grep -q '^+.*"added"'; then \
-		git diff origin/master -- doc/schemas; \
+	if git show --format=%B -s $(BASE_REF).. | grep -q '^No-schema-diff-check'; then echo $@ suppressed; exit 0; fi; \
+	if git diff $(BASE_REF) -- doc/schemas | grep -q '^+.*{' && ! git diff $(BASE_REF) -- doc/schemas | grep -q '^+.*"added"'; then \
+		git diff $(BASE_REF) -- doc/schemas; \
 		echo 'New schema fields must have "added": "vNEXTVERSION"' >&2; exit 1; \
 	fi
+
 schema-removed-check:
-	@if ! test -z $$CI; then git fetch origin master; fi; \
-	if git diff origin/master -- doc/schemas | grep -q '^-.*{' && ! git diff origin/master -- doc/schemas | grep -q '^-.*"deprecated"' && ! git diff origin/master -- doc/schemas | grep -q '^-.*EXPERIMENTAL_FEATURES'; then \
-		git diff origin/master -- doc/schemas ; \
+	if git show --format=%B -s $(BASE_REF).. | grep -q '^No-schema-diff-check'; then echo $@ suppressed; exit 0; fi; \
+	if git diff $(BASE_REF) -- doc/schemas | grep -q '^-.*{' && ! git diff $(BASE_REF) -- doc/schemas | grep -q '^-.*"deprecated"' && ! git diff $(BASE_REF) -- doc/schemas | grep -q '^-.*EXPERIMENTAL_FEATURES'; then \
+		git diff $(BASE_REF) -- doc/schemas ; \
 		echo 'Schema fields must be "deprecated", with version, not removed' >&2; exit 1; \
 	fi
 
 schema-diff-check: schema-added-check schema-removed-check
 
-# This breaks current commit; will revert after.
-#check-source: schema-diff-check
+check-source: schema-diff-check


### PR DESCRIPTION
CI currently does a merge with master, but that makes it nasty to do a straight diff (which is how we check schemas).

This changes it to do a rebase, which makes it trivial.