### PR TITLE
openingd: work harder to intuit OPT_SCID_ALIAS.

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -964,8 +964,7 @@ bool peer_start_openingd(struct peer *peer, struct peer_fd *peer_fd)
 				   feerate_min(peer->ld, NULL),
 				   feerate_max(peer->ld, NULL),
 				   IFDEV(peer->ld->dev_force_tmp_channel_id, NULL),
-				   peer->ld->config.allowdustreserve,
-				   !deprecated_apis);
+				   peer->ld->config.allowdustreserve);
 	subd_send_msg(uc->open_daemon, take(msg));
 	return true;
 }

--- a/openingd/openingd_wire.csv
+++ b/openingd/openingd_wire.csv
@@ -28,8 +28,6 @@ msgdata,openingd_init,dev_temporary_channel_id,?byte,32
 # reserves? This is explicitly required by the spec for safety
 # reasons, but some implementations and users keep asking for it.
 msgdata,openingd_init,allowdustreserve,bool,
-# Core LN prior to 23.05 didn't like this bit set!
-msgdata,openingd_init,can_set_scid_alias_channel_type,bool,
 
 # Openingd->master: they offered channel, should we continue?
 msgtype,openingd_got_offer,6005


### PR DESCRIPTION
option_scid_alias inside a channel_type allows for more private channels: in particular, it tells the peer that it MUST NOT allow routing via the real short channel id, and MUST use the alias.

It only makes sense (and is only permitted!) on unannounced channels.

Unfortunately, we didn't set this bit in the channel_type in v12.0 when it was introduced, instead relying on the presence of the feature bit with the peer.  This was fixed in 23.05, but:

1. Prior to 23.05 we didn't allow it to be set at all, and
2. LND has a limited set of features they allow, and this isn't allowed without option_anchors_zero_fee_htlc_tx.

We could simply drop this channel_type until we merge anchors, *but* that has nasty privacy implications (you can probe the real channel id).

So, if we don't negotiate anchors (we don't!), we don't set this channel_type bit even if we want it, and *intuit* it, based on:

1. Is this a non-anchor channel_type?
2. Did we both send channel_type?
3. Is this an unannounced channel?
4. Did both peers announce support for scid aliases?

In addition, while looking at the previous backwards-compat code, I realized that v23.05 violated the spec and send accept_channel with OPT_SCID_ALIAS if it intuited it, even if it wasn't offered.  Stop doing this, but allow our peers to.

Fixes: #6208