### PR TITLE
Persist feature bits across restarts

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1351,6 +1351,7 @@ static struct channel *stub_chan(struct command *cmd,
 				0,
 				&nodeid,
 				&wint,
+				NULL,
 				false);
 	}
 

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -73,6 +73,7 @@ struct peer *find_peer_by_dbid(struct lightningd *ld, u64 dbid);
 struct peer *new_peer(struct lightningd *ld, u64 dbid,
 		      const struct node_id *id,
 		      const struct wireaddr_internal *addr,
+			  const u8 *their_features,
 		      bool connected_incoming);
 
 /* Last one out deletes peer.  Also removes from db. */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4393,6 +4393,30 @@ def test_peer_disconnected_reflected_in_channel_state(node_factory):
     wait_for(lambda: only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['peer_connected'] is False)
 
 
+def test_peer_disconnected_has_featurebits(node_factory):
+    """
+    Make sure that if a node is restarted, it still remembers feature
+    bits from a peer it has a channel with but isn't connected to
+    """
+    l1, l2 = node_factory.line_graph(2)
+
+    expected_features = expected_peer_features()
+
+    l1_features = only_one(l2.rpc.listpeers()['peers'])['features']
+    l2_features = only_one(l1.rpc.listpeers()['peers'])['features']
+    assert l1_features == expected_features
+    assert l2_features == expected_features
+
+    l1.stop()
+    l2.stop()
+
+    # Ensure we persisted feature bits and return them even when disconnected
+    l1.start()
+
+    wait_for(lambda: only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'] is False)
+    wait_for(lambda: only_one(l1.rpc.listpeers()['peers'])['features'] == expected_features)
+
+
 @pytest.mark.developer("needs dev-no-reconnect")
 def test_reconnect_no_additional_transient_failure(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, opts=[{'may_reconnect': True},

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -949,6 +949,7 @@ static struct migration dbmigrations[] = {
     {NULL, migrate_invalid_last_tx_psbts},
     {SQL("ALTER TABLE channels ADD channel_type BLOB DEFAULT NULL;"), NULL},
     {NULL, migrate_fill_in_channel_type},
+    {SQL("ALTER TABLE peers ADD feature_bits BLOB DEFAULT NULL;"), NULL},
 };
 
 /**

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1172,7 +1172,7 @@ static bool test_wallet_outputs(struct lightningd *ld, const tal_t *ctx)
 
 	/* Add another utxo that's CSV-locked for 5 blocks */
 	assert(parse_wireaddr_internal(tmpctx, "localhost:1234", 0, false, &addr) == NULL);
-	channel.peer = new_peer(ld, 0, &id, &addr, false);
+	channel.peer = new_peer(ld, 0, &id, &addr, NULL, false);
 	channel.dbid = 1;
 	channel.type = channel_type_anchor_outputs(tmpctx);
 	memset(&u.outpoint, 3, sizeof(u.outpoint));
@@ -1502,7 +1502,7 @@ static bool test_channel_crud(struct lightningd *ld, const tal_t *ctx)
 	c1.first_blocknum = 1;
 	assert(parse_wireaddr_internal(tmpctx, "localhost:1234", 0, false, &addr) == NULL);
 	c1.final_key_idx = 1337;
-	p = new_peer(ld, 0, &id, &addr, false);
+	p = new_peer(ld, 0, &id, &addr, NULL, false);
 	c1.peer = p;
 	c1.dbid = wallet_get_channel_dbid(w);
 	c1.state = CHANNELD_NORMAL;
@@ -1665,7 +1665,7 @@ static bool test_channel_inflight_crud(struct lightningd *ld, const tal_t *ctx)
 	assert(parse_wireaddr_internal(tmpctx, "localhost:1234", 0, false, &addr) == NULL);
 
 	/* new channel! */
-	p = new_peer(ld, 0, &id, &addr, false);
+	p = new_peer(ld, 0, &id, &addr, NULL, false);
 
 	funding_sats = AMOUNT_SAT(4444444);
 	our_sats = AMOUNT_SAT(3333333);


### PR DESCRIPTION
On channel creation with a peer, we can persist feature bits of that peer and load them on restart.

This allows more sane behavior after a restart before we've reconnected with a peer, f.e. when deciding if a peer has opted in to `anysegwit` when creating taproot outputs. Needed for https://github.com/ElementsProject/lightning/pull/6035

This PR doesn't persist for each connection, only on new channel creation.