### PR TITLE
ci: run tests with ASan and UBSan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,6 +400,78 @@ jobs:
           sed -i 's/VALGRIND=0/VALGRIND=1/g' config.vars
           poetry run pytest tests/ -vvv -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
 
+  integration-sanitizers:
+    name: Sanitizers Test CLN
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    env:
+      COMPAT: 1
+      BITCOIN_VERSION: "25.0"
+      ELEMENTS_VERSION: 22.0.2
+      RUST_PROFILE: release
+      ASAN: 1
+      UBSAN: 1
+      VALGRIND: 0
+      DEVELOPER: 1
+      SLOW_MACHINE: 1
+      TEST_DEBUG: 1
+      PYTEST_OPTS: --test-group-random-seed=42 --timeout=1800
+    needs:
+      - prebuild
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - NAME: ASan/UBSan (01/10)
+            PYTEST_OPTS: --test-group=1  --test-group-count=10
+          - NAME: ASan/UBSan (02/10)
+            PYTEST_OPTS: --test-group=2  --test-group-count=10
+          - NAME: ASan/UBSan (03/10)
+            PYTEST_OPTS: --test-group=3  --test-group-count=10
+          - NAME: ASan/UBSan (04/10)
+            PYTEST_OPTS: --test-group=4  --test-group-count=10
+          - NAME: ASan/UBSan (05/10)
+            PYTEST_OPTS: --test-group=5  --test-group-count=10
+          - NAME: ASan/UBSan (06/10)
+            PYTEST_OPTS: --test-group=6  --test-group-count=10
+          - NAME: ASan/UBSan (07/10)
+            PYTEST_OPTS: --test-group=7  --test-group-count=10
+          - NAME: ASan/UBSan (08/10)
+            PYTEST_OPTS: --test-group=8  --test-group-count=10
+          - NAME: ASan/UBSan (09/10)
+            PYTEST_OPTS: --test-group=9  --test-group-count=10
+          - NAME: ASan/UBSan (10/10)
+            PYTEST_OPTS: --test-group=10 --test-group-count=10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          bash -x .github/scripts/setup.sh
+          set -e
+          pip3 install --user pip wheel poetry
+          poetry export -o requirements.txt --with dev --without-hashes
+          python3 -m pip install -r requirements.txt
+          poetry install
+
+      - name: Install bitcoind
+        run: .github/scripts/install-bitcoind.sh
+
+      - name: Build
+        run: |
+          ./configure CC=clang
+          make -j $(nproc)
+
+      - name: Test
+        run: |
+          poetry run pytest tests/ -vvv -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+
   gather:
     # A dummy task that depends on the full matrix of tests, and
     # signals successful completion. Used for the PR status to pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,40 @@ jobs:
           ./configure
           make -j $(nproc) check-units installcheck
 
+  check-units-sanitizers:
+    name: Run unit tests with ASan and UBSan
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      COMPAT: 1
+      ASAN: 1
+      UBSAN: 1
+      VALGRIND: 0
+    needs:
+      - prebuild
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          bash -x .github/scripts/setup.sh
+          sudo apt-get install -y -qq lowdown
+          pip install -U pip wheel poetry
+          # Export and then use pip to install into the current env
+          poetry export -o /tmp/requirements.txt --without-hashes --with dev
+          pip install -r /tmp/requirements.txt
+
+      - name: Build
+        run: |
+          ./configure CC=clang
+          make -j $(nproc) check-units installcheck
+
   check-fuzz:
     name: Run fuzz regression tests
     runs-on: ubuntu-22.04

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -448,6 +448,7 @@ static void get_words(struct words **words) {
 	if (errno == ERANGE || (errno != 0 && val == 0) || endptr == selected || val < 0 || val >= ARRAY_SIZE(languages))
         errx(ERROR_USAGE, "Invalid language selection, select one from the list [0-6].");
 
+	free(selected);
 	bip39_get_wordlist(languages[val].abbr, words);
 }
 
@@ -610,6 +611,8 @@ static int check_hsm(const char *hsm_secret_path)
 		errx(ERROR_KEYDERIV, "resulting hsm_secret did not match");
 
 	printf("OK\n");
+
+	free(passphrase);
 	return 0;
 }
 


### PR DESCRIPTION
Running these sanitizers in CI will help to avoid introducing new memory safety errors.

Closes #6119.