### PR TITLE
pyln-client: make point release to prepare for next release.

### DIFF
--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -3,7 +3,7 @@ from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapHalfchannel, GossmapNodeId, LnFeatureBits
 from .gossmapstats import GossmapStats
 
-__version__ = "23.05"
+__version__ = "23.05.2"
 
 __all__ = [
     "LightningRpc",

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "23.05"
+version = "23.05.2"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"


### PR DESCRIPTION
People running master notice that calling listconfigs fails, because we don't handle objects called xxx_msat correctly (see d348554ff4a2b31a92be1a9741320886d2cc5b75).  This makes it painful to test, until we release a pyln-client version.

Fortunately, the three changes in master are all fully backwards compatible, so we can simply cut a release now and upload to pipy.org.