### PR TITLE
fix(docs): Fix instructions for installing cln on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,9 @@ Pruning (`prune=n` option in `bitcoin.conf`) is partially supported, see [here](
 
 There are 4 supported installation options:
 
- - Installation from the [Ubuntu PPA][ppa].
  - Installation of a pre-compiled binary from the [release page][releases] on GitHub.
  - Using one of the [provided docker images][dockerhub] on the Docker Hub.
  - Compiling the source code yourself as described in the [installation documentation](doc/INSTALL.md).
-
-For the impatient here's the gist of it for Ubuntu:
-
-```bash
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -u ppa:lightningnetwork/ppa
-sudo apt-get install lightningd snapd
-sudo snap install bitcoin-core
-sudo ln -s /snap/bitcoin-core/current/bin/bitcoin{d,-cli} /usr/local/bin/
-```
 
 ### Starting `lightningd`
 
@@ -235,7 +224,6 @@ You should also configure with `--enable-developer` to get additional checks and
 [discord]: https://discord.gg/mE9s4rc5un
 [telegram]: https://t.me/lightningd
 [docs]: https://lightning.readthedocs.org
-[ppa]: https://launchpad.net/~lightningnetwork/+archive/ubuntu/ppa
 [releases]: https://github.com/ElementsProject/lightning/releases
 [dockerhub]: https://hub.docker.com/r/elementsproject/lightningd/
 [jsonrpcspec]: https://www.jsonrpc.org/specification

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -167,7 +167,18 @@ To Build on FreeBSD
 
 OS version: FreeBSD 11.1-RELEASE or above
 
-Core Lightning is in the FreeBSD ports, so install it as any other port
+```
+pkg install git python py39-pip gmake libtool gmp sqlite3 \
+            postgresql13-client gettext autotools
+https://github.com/ElementsProject/lightning.git
+pip install --upgrade pip
+pip3 install mako
+./configure
+gmake -j$(nproc)
+gmake install
+```
+
+Alternately, Core Lightning is in the FreeBSD ports, so install it as any other port
 (dependencies are handled automatically):
 
     # pkg install c-lightning


### PR DESCRIPTION
This commit is adding the instructions for compiling cln on FreeBSD, because it looks like we not longer compile with the FreeBSD package manager, and I have no idea who the mantainer of this package is.

Fixes: https://github.com/ElementsProject/lightning/issues/6301 
Fixes https://github.com/ElementsProject/lightning/issues/6227