### PR TITLE
fix: build on alpine linux

### DIFF
--- a/common/configvar.c
+++ b/common/configvar.c
@@ -4,6 +4,7 @@
 #include <ccan/tal/str/str.h>
 #include <common/configvar.h>
 #include <common/utils.h>
+#include <unistd.h>
 
 struct configvar *configvar_new(const tal_t *ctx,
 				enum configvar_src src,


### PR DESCRIPTION
This fixes the compile issue that we are having on Alpine.

```
cc wallet/wallet.c
cc wallet/walletrpc.c
cc wallet/reservation.c
cc wallet/db_sqlite3_sqlgen.c
cc wallet/db_postgres_sqlgen.c
cc common/addr.c
cc common/bolt11.c
cc common/bolt11_json.c
cc common/bolt12.c
cc common/configdir.c
cc common/configvar.c
cc common/scb_wiregen.c
common/configvar.c: In function 'configvar_remove':
common/configvar.c:118:9: error: unknown type name 'ssize_t'; did you mean 'size_t'?
  118 |         ssize_t prev = -1;
      |         ^~~~~~~
      |         size_t
make: *** [Makefile:292: common/configvar.o] Error 1
make: *** Waiting for unfinished jobs....
```

Reported-by: @gruve-p
Fixes: https://github.com/ElementsProject/lightning/issues/6321