### PR TITLE
Fix deschash escaped json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -410,10 +410,6 @@ jobs:
       BITCOIN_VERSION: "25.0"
       ELEMENTS_VERSION: 22.0.2
       RUST_PROFILE: release
-      ASAN: 1
-      UBSAN: 1
-      VALGRIND: 0
-      DEVELOPER: 1
       SLOW_MACHINE: 1
       TEST_DEBUG: 1
       PYTEST_OPTS: --test-group-random-seed=42 --timeout=1800
@@ -466,12 +462,12 @@ jobs:
 
       - name: Build
         run: |
-          ./configure CC=clang
+          ./configure CC=clang --enable-address-sanitizer --enable-ub-sanitizer --disable-valgrind --enable-developer
           make -j $(nproc)
 
       - name: Test
         run: |
-          poetry run pytest tests/ -vvv -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+          poetry run pytest tests/ -vvv -n 2 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
 
   gather:
     # A dummy task that depends on the full matrix of tests, and

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -893,6 +893,17 @@ struct bolt11 *bolt11_decode_nosig(const tal_t *ctx, const char *str,
 					   "h: does not match description");
 	}
 
+	/* BOLT #11:
+	 * A writer:
+	 *...
+	 * - MUST include either exactly one `d` or exactly one `h` field.
+	 */
+	/* FIXME: It doesn't actually say the reader must check though! */
+	if (!have_field[bech32_charset_rev['d']]
+	    && !have_field[bech32_charset_rev['h']])
+		return decode_fail(b11, fail,
+				   "must have either 'd' or 'h' field");
+
 	hash_u5_done(&hu5, hash);
 	*sig = tal_dup_arr(ctx, u5, data, data_len, 0);
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -1530,7 +1530,7 @@ static struct command_result *json_decodepay(struct command *cmd,
 
 	if (!param(cmd, buffer, params,
 		   p_req("bolt11", param_string, &str),
-		   p_opt("description", param_string, &desc),
+		   p_opt("description", param_escaped_string, &desc),
 		   NULL))
 		return command_param_failed();
 

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1053,24 +1053,6 @@ static struct command_result *json_pay(struct command *cmd,
 			    cmd, JSONRPC2_INVALID_PARAMS,
 			    "Invalid bolt11:"
 			    " sets feature var_onion with no secret");
-
-		/* BOLT #11:
-		 * A reader:
-		 *...
-		 * - MUST check that the SHA2 256-bit hash in the `h` field
-		 *   exactly matches the hashed description.
-		 */
-		if (!b11->description && !deprecated_apis) {
-			if (!b11->description_hash) {
-				return command_fail(cmd,
-						    JSONRPC2_INVALID_PARAMS,
-						    "Invalid bolt11: missing description");
-			}
-			if (!description)
-				return command_fail(cmd,
-						    JSONRPC2_INVALID_PARAMS,
-						    "bolt11 uses description_hash, but you did not provide description parameter");
-		}
 	} else {
 		b12 = invoice_decode(tmpctx, b11str, strlen(b11str),
 				     plugin_feature_set(cmd->plugin),

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1008,7 +1008,7 @@ static struct command_result *json_pay(struct command *cmd,
 		   p_opt("localinvreqid", param_sha256, &local_invreq_id),
 		   p_opt("exclude", param_route_exclusion_array, &exclusions),
 		   p_opt("maxfee", param_msat, &maxfee),
-		   p_opt("description", param_string, &description),
+		   p_opt("description", param_escaped_string, &description),
 #if DEVELOPER
 		   p_opt_def("use_shadow", param_bool, &use_shadow, true),
 #endif

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -724,10 +724,6 @@ def test_invoice_deschash(node_factory, chainparams):
     listinv = only_one(l2.rpc.listinvoices()['invoices'])
     assert listinv['description'] == 'One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon'
 
-    # To pay it we need to provide the (correct!) description.
-    with pytest.raises(RpcError, match=r'you did not provide description parameter'):
-        l1.rpc.pay(inv['bolt11'])
-
     with pytest.raises(RpcError, match=r'does not match description'):
         l1.rpc.pay(inv['bolt11'], description=listinv['description'][:-1])
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5400,3 +5400,17 @@ def test_fetchinvoice_with_no_quantity(node_factory):
     inv = inv['invoice']
     decode_inv = l2.rpc.decode(inv)
     assert decode_inv['invreq_quantity'] == 2, f'`invreq_quantity` in the invoice did not match, received {decode_inv["quantity"]}, expected 2'
+
+
+def test_invoice_pay_desc_with_quotes(node_factory):
+    """Test that we can decode and pay invoice where hashed description contains double quotes"""
+    l1, l2 = node_factory.line_graph(2)
+    description = '[["text/plain","Funding @odell on stacker.news"],["text/identifier","odell@stacker.news"]]'
+
+    invoice = l2.rpc.invoice(label="test12345", amount_msat=1000,
+                             description=description, deschashonly=True)["bolt11"]
+
+    l1.rpc.decodepay(invoice, description)
+
+    # pay an invoice
+    l1.rpc.pay(invoice, description=description)


### PR DESCRIPTION
Fixes: #6085 

Notably, since our deschash comparison was broken, we cannot insist people provide a description, so back off on that deprecation.