### PR TITLE
Notifications serialise connect, disconnect, block_added

### DIFF
--- a/contrib/plugins/helloworld.py
+++ b/contrib/plugins/helloworld.py
@@ -31,13 +31,13 @@ def init(options, configuration, plugin, **kwargs):
 
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address, **kwargs):
-    plugin.log("Received connect event for peer {}".format(id))
+def on_connect(plugin, connect, **kwargs):
+    plugin.log("Received connect event for peer {}".format(connect))
 
 
 @plugin.subscribe("disconnect")
-def on_disconnect(plugin, id, **kwargs):
-    plugin.log("Received disconnect event for peer {}".format(id))
+def on_disconnect(plugin, disconnect, **kwargs):
+    plugin.log("Received disconnect event for peer {}".format(disconnect))
 
 
 @plugin.subscribe("invoice_payment")

--- a/contrib/pylightning/README.md
+++ b/contrib/pylightning/README.md
@@ -94,8 +94,8 @@ def init(options, configuration, plugin):
 
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address):
-    plugin.log("Received connect event for peer {}".format(id))
+def on_connect(plugin, connect):
+    plugin.log("Received connect event for peer {}".format(connect))
 
 
 plugin.add_option('greeting', 'Hello', 'The greeting I should use.')

--- a/contrib/pyln-client/README.md
+++ b/contrib/pyln-client/README.md
@@ -96,8 +96,8 @@ def init(options, configuration, plugin):
 
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address, **kwargs):
-    plugin.log("Received connect event for peer {}".format(id))
+def on_connect(plugin, connect, **kwargs):
+    plugin.log("Received connect event for peer {}".format(connect))
 
 
 plugin.add_option('greeting', 'Hello', 'The greeting I should use.')

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -892,7 +892,7 @@ throughout the node's life as new blocks appear.
 
 ```json
 {
-    "block": {
+    "block_added": {
       "hash": "000000000000000000034bdb3c01652a0aa8f63d32f949313d55af2509f9d245",
       "height": 753304
     }

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -532,7 +532,9 @@ to a peer was lost.
 
 ```json
 {
-  "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+  "disconnect": {
+    "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+  }
 }
 ```
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -517,9 +517,11 @@ to a peer is established. `direction` is either `"in"` or `"out"`.
 
 ```json
 {
-  "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
-  "direction": "in",
-  "address": "1.2.3.4:1234"
+  "connect": {
+    "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
+    "direction": "in",
+    "address": "1.2.3.4:1234"
+  }
 }
 ```
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -852,7 +852,7 @@ current accounts (`account_id` matches the `account_id` emitted from
 
 ```json
 {
-    "balance_snapshots": [
+    "balance_snapshot": [
 	{
 	    'node_id': '035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d',
 	    'blockheight': 101,

--- a/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
+++ b/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
@@ -87,9 +87,11 @@ A notification for topic `connect` is sent every time a new connection to a peer
 
 ```json
 {
-  "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
-  "direction": "in",
-  "address": "1.2.3.4:1234"
+  "connect": {
+    "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432",
+    "direction": "in",
+    "address": "1.2.3.4:1234"
+  }
 }
 ```
 

--- a/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
+++ b/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
@@ -423,7 +423,7 @@ Emitted after each block is received from bitcoind, either during the initial sy
 
 ```json
 {
-    "block": {
+    "block_added": {
       "hash": "000000000000000000034bdb3c01652a0aa8f63d32f949313d55af2509f9d245",
       "height": 753304
     }

--- a/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
+++ b/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
@@ -103,7 +103,9 @@ A notification for topic `disconnect` is sent every time a connection to a peer 
 
 ```json
 {
-  "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+  "disconnect": {
+    "id": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+  }
 }
 ```
 

--- a/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
+++ b/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
@@ -382,7 +382,7 @@ Emitted after we've caught up to the chain head on first start. Lists all curren
 
 ```json
 {
-    "balance_snapshots": [
+    "balance_snapshot": [
 	{
 	    'node_id': '035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d',
 	    'blockheight': 101,

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -596,13 +596,24 @@ void notify_balance_snapshot(struct lightningd *ld,
 	plugins_notify(ld->plugins, take(n));
 }
 
-static void block_added_notification_serialize(struct json_stream *stream,
-					       struct block *block)
+static void json_add_block_added_fields(struct json_stream *stream,
+					   const struct block *block)
 {
-	json_object_start(stream, "block");
 	json_add_string(stream, "hash",
 			type_to_string(tmpctx, struct bitcoin_blkid, &block->blkid));
 	json_add_u32(stream, "height", block->height);
+}
+
+static void block_added_notification_serialize(struct json_stream *stream,
+					       struct block *block)
+{
+	if (deprecated_apis) {
+		json_object_start(stream, "block");
+		json_add_block_added_fields(stream, block);
+		json_object_end(stream);
+	}
+	json_object_start(stream, "block_added");
+	json_add_block_added_fields(stream, block);
 	json_object_end(stream);
 }
 

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -84,10 +84,21 @@ void notify_connect(struct lightningd *ld,
 	plugins_notify(ld->plugins, take(n));
 }
 
+static void json_add_disconnect_fields(struct json_stream *stream,
+					   const struct node_id *nodeid)
+{
+	json_add_node_id(stream, "id", nodeid);
+}
+
 static void disconnect_notification_serialize(struct json_stream *stream,
 					      struct node_id *nodeid)
 {
-	json_add_node_id(stream, "id", nodeid);
+	/* Old style: Add raw fields without disconnect key */
+	if (deprecated_apis)
+		json_add_disconnect_fields(stream, nodeid);
+	json_object_start(stream, "disconnect");
+	json_add_disconnect_fields(stream, nodeid);
+	json_object_end(stream);
 }
 
 REGISTER_NOTIFICATION(disconnect,

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -41,7 +41,7 @@ bool notifications_have_topic(const struct plugins *plugins, const char *topic)
 	return false;
 }
 
-static void connect_notification_serialize(struct json_stream *stream,
+static void json_add_connect_fields(struct json_stream *stream,
 					   const struct node_id *nodeid,
 					   bool incoming,
 					   const struct wireaddr_internal *addr)
@@ -49,6 +49,19 @@ static void connect_notification_serialize(struct json_stream *stream,
 	json_add_node_id(stream, "id", nodeid);
 	json_add_string(stream, "direction", incoming ? "in" : "out");
 	json_add_address_internal(stream, "address", addr);
+}
+
+static void connect_notification_serialize(struct json_stream *stream,
+					   const struct node_id *nodeid,
+					   bool incoming,
+					   const struct wireaddr_internal *addr)
+{
+	/* Old style: Add raw fields without connect key */
+	if (deprecated_apis)
+		json_add_connect_fields(stream, nodeid, incoming, addr);
+	json_object_start(stream, "connect");
+	json_add_connect_fields(stream, nodeid, incoming, addr);
+	json_object_end(stream);
 }
 
 REGISTER_NOTIFICATION(connect,

--- a/tests/plugins/block_added.py
+++ b/tests/plugins/block_added.py
@@ -9,9 +9,9 @@ blocks_catched = []
 
 
 @plugin.subscribe("block_added")
-def notify_block_added(plugin, block, **kwargs):
+def notify_block_added(plugin, block_added, **kwargs):
     global blocks_catched
-    blocks_catched.append(block["height"])
+    blocks_catched.append(block_added["height"])
 
 
 @plugin.method("blockscatched")


### PR DESCRIPTION
- Serialise `connect`, `discnnect` and `block_added`.

Changelog-Added: Plugins: connect, disconnect, block_added notifications now have fields in sub-object of same name (e.g. "connect": {...}), making all notifications uniform
Changelog-Deprecated: Plugins: connect, disconnect, block_added notifications fields outside the sub-object of the same name: e.g. parse .connect.id instead of .id.