### PR TITLE
Fix a typo in the description of field `private`

### DIFF
--- a/doc/lightning-listclosedchannels.7.md
+++ b/doc/lightning-listclosedchannels.7.md
@@ -25,7 +25,7 @@ On success, an object containing **closedchannels** is returned.  It is an array
 
 - **channel\_id** (hash): The full channel\_id (funding txid Xored with output number)
 - **opener** (string): Who initiated the channel (one of "local", "remote")
-- **private** (boolean): if False, we will not announce this channel
+- **private** (boolean): if True, we will not announce this channel
 - **total\_local\_commitments** (u64): Number of commitment transaction we made
 - **total\_remote\_commitments** (u64): Number of commitment transaction they made
 - **total\_htlcs\_sent** (u64): Number of HTLCs we ever sent
@@ -76,4 +76,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning> Lightning
 
-[comment]: # ( SHA256STAMP:0c368cb41f46a2124e9b3f0b760494d1f4b9c3b248267f56b887fbf96f26e176)
+[comment]: # ( SHA256STAMP:3020e068d48a43494983df1a902d7483a52d0c41faef85e6d858dcf7c64c188d)

--- a/doc/lightning-listpeerchannels.7.md
+++ b/doc/lightning-listpeerchannels.7.md
@@ -58,7 +58,7 @@ On success, an object containing **channels** is returned.  It is an array of ob
   - **our\_funding\_msat** (msat): amount we have in the channel
   - **scratch\_txid** (txid): The commitment transaction txid we would use if we went onchain now
 - **close\_to** (hex, optional): scriptPubkey which we have to close to if we mutual close
-- **private** (boolean, optional): if False, we will not announce this channel
+- **private** (boolean, optional): if True, we will not announce this channel
 - **closer** (string, optional): Who initiated the channel close (only present if closing) (one of "local", "remote")
 - **funding** (object, optional):
   - **local\_funds\_msat** (msat): Amount of channel we funded
@@ -196,4 +196,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:dade32248bd309f2514a237cb71be6ddbe12220e1b6899693a032b45b7980a01)
+[comment]: # ( SHA256STAMP:359d0035f98350d2de5f539ce8d2c3d82ccf633d3cbee4ed992a71687a25770a)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -92,7 +92,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **splice\_amount** (integer): The amouont of sats we're splicing in or out *(added v23.08)*
     - **scratch\_txid** (txid): The commitment transaction txid we would use if we went onchain now
   - **close\_to** (hex, optional): scriptPubkey which we have to close to if we mutual close
-  - **private** (boolean, optional): if False, we will not announce this channel
+  - **private** (boolean, optional): if True, we will not announce this channel
   - **closer** (string, optional): Who initiated the channel close (one of "local", "remote")
   - **funding** (object, optional):
     - **local\_funds\_msat** (msat): Amount of channel we funded
@@ -399,4 +399,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:d75b5070288f26a39df39831212f40c397f1389e7c1765f22829d3f3389a56aa)
+[comment]: # ( SHA256STAMP:7402bcd43be7c031c1e8e1ec7a4d58e94beb44ca48ba2f8f06e4ea908ab8940b)

--- a/doc/schemas/listclosedchannels.schema.json
+++ b/doc/schemas/listclosedchannels.schema.json
@@ -73,7 +73,7 @@
           },
           "private": {
             "type": "boolean",
-            "description": "if False, we will not announce this channel"
+            "description": "if True, we will not announce this channel"
           },
           "channel_type": {
             "type": "object",

--- a/doc/schemas/listpeerchannels.schema.json
+++ b/doc/schemas/listpeerchannels.schema.json
@@ -199,7 +199,7 @@
           },
           "private": {
             "type": "boolean",
-            "description": "if False, we will not announce this channel"
+            "description": "if True, we will not announce this channel"
           },
           "opener": {
             "type": "string",

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -315,7 +315,7 @@
                 },
                 "private": {
                   "type": "boolean",
-                  "description": "if False, we will not announce this channel"
+                  "description": "if True, we will not announce this channel"
                 },
                 "opener": {
                   "type": "string",


### PR DESCRIPTION
Change `False` to `True` in the description of the field `private` for the responses of the following calls:
- `listpeers`
- `listpeerchannels`
- `listclosedchannels`

New description is: "if True, we will not announce this channel"