### PR TITLE
Plugin event notification subscription wildcard support

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -659,10 +659,13 @@ class Plugin(object):
             self.log(traceback.format_exc())
 
     def _dispatch_notification(self, request: Request) -> None:
-        if request.method not in self.subscriptions:
-            raise ValueError("No subscription for {name} found.".format(
-                name=request.method))
-        func = self.subscriptions[request.method]
+        if request.method in self.subscriptions:
+            func = self.subscriptions[request.method]
+        # Wildcard 'all' subscriptions using asterisk
+        elif '*' in self.subscriptions:
+            func = self.subscriptions['*']
+        else:
+            raise ValueError(f"No subscription for {request.method} found.")
 
         try:
             self._exec_func(func, request)

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -431,6 +431,13 @@ above for example subscribes to the two topics `connect` and
 corresponding payloads are listed below.
 
 
+### `*`
+
+This is a way of specifying that you want to subscribe to all possible
+event notifications.  It is not recommended, but is useful for plugins
+which want to provide generic infrastructure for others (in future, we
+may add the ability to dynamically subscribe/unsubscribe).
+
 ### `channel_opened`
 
 A notification for topic `channel_opened` is sent if a peer successfully

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -929,6 +929,12 @@ logging or notifications. New rpc calls will fail with error code -5 and (plugin
 responses will be ignored. Because lightningd can crash or be killed, a plugin cannot
 rely on the shutdown notification always been send.
 
+```json
+{
+    "shutdown": {
+    }
+}
+```
 
 ## Hooks
 

--- a/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
+++ b/doc/guides/Developer-s Guide/plugin-development/event-notifications.md
@@ -13,6 +13,13 @@ Event notifications allow a plugin to subscribe to events in `lightningd`. `ligh
 
 Plugins subscribe by returning an array of subscriptions as part of the `getmanifest` response. The result for the `getmanifest` call above for example subscribes to the two topics `connect` and `disconnect`. The topics that are currently defined and the corresponding payloads are listed below.
 
+### `*`
+
+This is a way of specifying that you want to subscribe to all possible
+event notifications.  It is not recommended, but is useful for plugins
+which want to provide generic infrastructure for others (in future, we
+may add the ability to dynamically subscribe/unsubscribe).
+
 ### `channel_opened`
 
 A notification for topic `channel_opened` is sent if a peer successfully funded a channel with us. It contains the peer id, the funding amount (in millisatoshis), the funding transaction id, and a boolean indicating if the funding transaction has been included into a block.

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -700,6 +700,9 @@ bool notify_plugin_shutdown(struct lightningd *ld, struct plugin *p)
 	struct jsonrpc_notification *n =
 		jsonrpc_notification_start(NULL, "shutdown");
 
+	/* Even shutdown should follow the same "object inside notification" pattern */
+	json_object_start(n->stream, "shutdown");
+	json_object_end(n->stream);
 	jsonrpc_notification_end(n);
 	return plugin_single_notify(p, take(n));
 }

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -101,7 +101,8 @@ static void plugin_check_subscriptions(struct plugins *plugins,
 {
 	for (size_t i = 0; i < tal_count(plugin->subscriptions); i++) {
 		const char *topic = plugin->subscriptions[i];
-		if (!notifications_have_topic(plugins, topic))
+		if (!streq(topic, "*")
+		    && !notifications_have_topic(plugins, topic))
 			log_unusual(
 			    plugin->log,
 			    "topic '%s' is not a known notification topic",
@@ -1306,7 +1307,8 @@ static const char *plugin_subscriptions_add(struct plugin *plugin,
 					    const char *buffer,
 					    const jsmntok_t *resulttok)
 {
-	const jsmntok_t *subscriptions =
+	size_t i;
+	const jsmntok_t *s, *subscriptions =
 	    json_get_member(buffer, resulttok, "subscriptions");
 
 	if (!subscriptions) {
@@ -1318,12 +1320,11 @@ static const char *plugin_subscriptions_add(struct plugin *plugin,
 		return tal_fmt(plugin, "\"result.subscriptions\" is not an array");
 	}
 
-	for (int i = 0; i < subscriptions->size; i++) {
+	json_for_each_arr(i, s, subscriptions) {
 		char *topic;
-		const jsmntok_t *s = json_get_arr(subscriptions, i);
 		if (s->type != JSMN_STRING) {
 			return tal_fmt(plugin,
-				       "result.subscriptions[%d] is not a string: '%.*s'", i,
+				       "result.subscriptions[%zu] is not a string: '%.*s'", i,
 					json_tok_full_len(s),
 					json_tok_full(buffer, s));
 		}
@@ -2236,9 +2237,13 @@ void json_add_opt_disable_plugins(struct json_stream *response,
 static bool plugin_subscriptions_contains(struct plugin *plugin,
 					  const char *method)
 {
-	for (size_t i = 0; i < tal_count(plugin->subscriptions); i++)
-		if (streq(method, plugin->subscriptions[i]))
+	for (size_t i = 0; i < tal_count(plugin->subscriptions); i++) {
+		if (streq(method, plugin->subscriptions[i])
+		    /* Asterisk is magic "all" */
+		    || streq(plugin->subscriptions[i], "*")) {
 			return true;
+		}
+	}
 
 	return false;
 }

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1607,7 +1607,8 @@ static void ld_command_handle(struct plugin *plugin,
 #endif
 		for (size_t i = 0; i < plugin->num_notif_subs; i++) {
 			if (streq(cmd->methodname,
-				  plugin->notif_subs[i].name)) {
+				  plugin->notif_subs[i].name)
+			    || streq(plugin->notif_subs[i].name, "*")) {
 				plugin->notif_subs[i].handle(cmd,
 							     plugin->buffer,
 							     paramstok);

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -87,6 +87,7 @@ struct plugin_option {
 
 /* Create an array of these, one for each notification you subscribe to. */
 struct plugin_notification {
+	/* "*" means wildcard: notify me on everything (should be last!) */
 	const char *name;
 	/* The handler must eventually trigger a `notification_handled`
 	 * call.  */

--- a/tests/plugins/all_notifications.py
+++ b/tests/plugins/all_notifications.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+import sys
+
+
+plugin = Plugin()
+
+
+@plugin.subscribe("*")
+def on_any_notification(request, **kwargs):
+    plugin.log("notification {}: {}".format(request.method, kwargs))
+    if request.method == 'shutdown':
+        # A plugin which subscribes to shutdown is expected to exit itself.
+        sys.exit(0)
+
+
+plugin.run()

--- a/tests/plugins/test_libplugin.c
+++ b/tests/plugins/test_libplugin.c
@@ -101,6 +101,17 @@ static struct command_result *json_shutdown(struct command *cmd,
 	plugin_exit(cmd->plugin, 0);
 }
 
+static struct command_result *json_all_notifs(struct command *cmd,
+					      const char *buf,
+					      const jsmntok_t *params)
+{
+	plugin_log(cmd->plugin, LOG_DBG, "all: %s: %.*s",
+		   cmd->methodname,
+		   json_tok_full_len(params),
+		   json_tok_full(buf, params));
+	return notification_handled(cmd);
+}
+
 static struct command_result *testrpc_cb(struct command *cmd,
 					 const char *buf,
 					 const jsmntok_t *params,
@@ -209,6 +220,9 @@ static const struct plugin_notification notifs[] = { {
 	}, {
 		"shutdown",
 		json_shutdown
+	}, {
+		"*",
+		json_all_notifs
 	}
 };
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4266,7 +4266,7 @@ def test_all_subscription(node_factory, directory):
                    "balance_snapshot: {'balance_snapshot': {'node_id': ",
                    "connect: {'connect': {'id': ",
                    "channel_state_changed: {'channel_state_changed': {'peer_id': ",
-                   "shutdown: {}"):
+                   "shutdown: {'shutdown': {}"):
         assert l1.daemon.is_in_log(f".*plugin-all_notifications.py: notification {notstr}.*")
 
     for notstr in ('block_added: ',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4248,3 +4248,20 @@ def test_plugin_persist_option(node_factory):
     assert c['value_str'] == "Static option"
     assert c['plugin'] == plugin_path
     assert l1.rpc.call("hello") == "Static option world"
+
+
+def test_all_subscription(node_factory, directory):
+    """Ensure that registering for all notifications works."""
+    plugin = os.path.join(os.getcwd(), 'tests/plugins/all_notifications.py')
+    
+    l1, l2 = node_factory.line_graph(2, opts={"plugin": plugin})
+
+    l1.stop()
+
+    # There will be a lot of these!
+    for notstr in ("block_added: {'block_added': {'hash': ",
+                   "balance_snapshot: {'balance_snapshot': {'node_id': ",
+                   "connect: {'connect': {'id': ",
+                   "channel_state_changed: {'channel_state_changed': {'peer_id': ",
+                   "shutdown: {}"):
+        assert l1.daemon.is_in_log(f".*plugin-all_notifications.py: notification {notstr}.*")


### PR DESCRIPTION
Subscribing to "" will now give you every event: I've added support to pyln-client and libplugin for this.

Note: you can tell *which* notification it was in Python by having an argument called "request" and looking at "request.method"

Suggested-by: @ShahanaFarooqui 