### PR TITLE
pyln-proto: expose the tlv types

### DIFF
--- a/contrib/pyln-proto/pyln/proto/message/__init__.py
+++ b/contrib/pyln-proto/pyln/proto/message/__init__.py
@@ -1,5 +1,5 @@
 from .array_types import SizedArrayType, DynamicArrayType, EllipsisArrayType
-from .message import MessageNamespace, MessageType, Message, SubtypeType
+from .message import MessageNamespace, MessageType, Message, SubtypeType, TlvStreamType, TlvMessageType
 from .fundamental_types import split_field, FieldType
 
 __all__ = [
@@ -14,6 +14,8 @@ __all__ = [
     "SizedArrayType",
     "DynamicArrayType",
     "EllipsisArrayType",
+    "TlvStreamType",
+    "TlvMessageType",
 
     # fundamental_types
     'byte',


### PR DESCRIPTION
Exposing the tlv types to allow public access to it.

would be nice to have this merged before July to unlock me with lnprototest :)