### PR TITLE
Correct INSTALL.md requirements for OpenBSD

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -198,11 +198,11 @@ Configure lightningd: copy `/usr/local/etc/lightningd-bitcoin.conf.sample` to
 To Build on OpenBSD
 --------------------
 
-OS version: OpenBSD 6.7
+OS version: OpenBSD 7.3
 
 Install dependencies:
 ```
-pkg_add git python gmake py3-pip libtool
+pkg_add git python gmake py3-pip libtool gettext-tools
 pkg_add automake # (select highest version, automake1.16.2 at time of writing)
 pkg_add autoconf # (select highest version, autoconf-2.69p2 at time of writing)
 ```


### PR DESCRIPTION
GNU xgettext is required to compile. It is found in the gettext-tools package in OpenBSD. Tested on OpenBSD 7.3