### PR TITLE
wallet: don't try to set a timer past 2038 on 32-bit platforms.

### DIFF
--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -225,6 +225,11 @@ static void install_expiration_timer(struct invoices *invoices)
 	memset(&expiry, 0, sizeof(expiry));
 	expiry.ts.tv_sec = invoices->min_expiry_time;
 
+	/* Hi!  On a 32 bit time_t platform with an expiry after 2038?  Let's
+	 * not set a timer, assuming you'll upgrade before then! */
+	if (expiry.ts.tv_sec != invoices->min_expiry_time)
+		goto done;
+
 	/* now > expiry */
 	if (time_after(now, expiry))
 		expiry = now;


### PR DESCRIPTION
It'll wrap, probably be in the past, and infinite loop.  This was caused by an invoice with expiry set at 2076.  This wrap caused us to think the expiry has already passed, and keep looping!

Reported-by: @telelvis
Fixes: #6339
Changelog-Fixed: lightnind: don't infinite loop on 32 bit platforms if only invoices are expiring after 2038.