### PR TITLE
Remove --daemon from lightningd.service

### DIFF
--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -15,7 +15,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/lightningd --daemon --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid
+ExecStart=/usr/bin/lightningd --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid
 
 # Creates /run/lightningd owned by bitcoin
 RuntimeDirectory=lightningd
@@ -24,7 +24,7 @@ ConfigurationDirectory=lightningd
 
 User=bitcoin
 Group=bitcoin
-Type=forking
+Type=simple
 PIDFile=/run/lightningd/lightningd.pid
 Restart=on-failure
 


### PR DESCRIPTION
When the `--daemon` flag is used, `lightningd` requires that `--log-file` is used as well. By consequence, the `lightningd.service` didn't work out-of-the-box for me.

This changes also sends the logs to `journald`.
The new approach is consistent with the `bitcoind.service` file in the bitcoin-core repository.

I prefer this approach because it comes with automatic log-rotation. 