### PR TITLE
Avoid cascading failure: give up on incoming HTLCs in time if outgoing is stuck.

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1754,8 +1754,14 @@ void onchain_failed_our_htlc(const struct channel *channel,
 	} else if (hout->in) {
 		log_debug(channel->log, "HTLC id %"PRIu64" has incoming",
 			  htlc->id);
-		local_fail_in_htlc(hout->in,
-				   take(towire_permanent_channel_failure(NULL)));
+ 		/* Careful!  We might have already timed out incoming
+		 * HTLC in consider_failing_incoming */
+		if (hout->in->badonion == 0
+		    && !hout->in->failonion
+		    && !hout->in->preimage) {
+			local_fail_in_htlc(hout->in,
+					   take(towire_permanent_channel_failure(NULL)));
+		}
 		wallet_forwarded_payment_add(hout->key.channel->peer->ld->wallet,
 					 hout->in, FORWARD_STYLE_TLV,
 					 channel_scid_or_local_alias(channel), hout,
@@ -2661,6 +2667,43 @@ static u32 htlc_in_deadline(const struct lightningd *ld,
 	return hin->cltv_expiry - (ld->config.cltv_expiry_delta + 1)/2;
 }
 
+/* onchaind might fail to time out an HTLC: maybe fees spiked, or maybe
+ * it decided it wasn't worthwhile.  This risks cascading failure if
+ * it was routed: the incoming peer will get upset with us, too.
+ *
+ * So, if we're within 3 blocks of this happening, we fail upstream.
+ * It's weird to do this by looking at hout, rather than hin, but
+ * there's a pointer from hout->hin and not vice versa (we don't
+ * normally need it). */
+static void consider_failing_incoming(struct lightningd *ld,
+				      u32 height,
+				      struct htlc_out *hout)
+{
+	/* Already failed or succeeded? */
+	if (hout->failmsg || hout->failonion || hout->preimage)
+		return;
+
+	/* Has no corresponding input we should be stressed about? */
+	if (!hout->in)
+		return;
+
+	/* Already done it once? */
+	if (hout->in->failonion)
+		return;
+
+	/* OK, if we're within 3 blocks of upstream getting upset, force it
+	 * to fail without waiting for onchaind. */
+	if (height + 3 < hout->in->cltv_expiry)
+		return;
+
+	log_unusual(hout->key.channel->log,
+		    "Abandoning unresolved onchain HTLC at block %u"
+		    " (expired at %u) to avoid peer closing incoming HTLC at block %u",
+		    height, hout->cltv_expiry, hout->in->cltv_expiry);
+
+	local_fail_in_htlc(hout->in, take(towire_permanent_channel_failure(NULL)));
+}
+
 void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 {
 	bool removed;
@@ -2687,8 +2730,10 @@ void htlcs_notify_new_block(struct lightningd *ld, u32 height)
 				continue;
 
 			/* Peer on chain already? */
-			if (channel_on_chain(hout->key.channel))
+			if (channel_on_chain(hout->key.channel)) {
+				consider_failing_incoming(ld, height, hout);
 				continue;
+			}
 
 			/* Peer already failed, or we hit it? */
 			if (hout->key.channel->error)

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1499,12 +1499,16 @@ static void handle_preimage(struct tracked_output **outs,
 		if (!ripemd160_eq(&outs[i]->htlc.ripemd, &ripemd))
 			continue;
 
-		/* Too late? */
+		/* If HTLC has timed out, we will already have
+		 * proposed a "ignore this, it's their problem".  But
+		 * now try this proposal instead! */
 		if (outs[i]->resolved) {
-			status_broken("HTLC already resolved by %s"
-				     " when we found preimage",
-				     tx_type_name(outs[i]->resolved->tx_type));
-			return;
+			if (outs[i]->resolved->tx_type != SELF) {
+				status_broken("HTLC already resolved by %s"
+					      " when we found preimage",
+					      tx_type_name(outs[i]->resolved->tx_type));
+				return;
+			}
 		}
 
 		/* stash the payment_hash so we can track this coin movement */

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -197,6 +197,7 @@ static void retry_bcli(void *cb_arg)
 	tal_del_destructor(bcli, destroy_bcli);
 
 	list_add_tail(&bitcoind->pending[bcli->prio], &bcli->list);
+	tal_free(bcli->output);
 	next_bcli(bcli->prio);
 }
 

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3796,7 +3796,6 @@ def test_closing_anchorspend_htlc_tx_rbf(node_factory, bitcoind):
     bitcoind.generate_block(1, needfeerate=4990)
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("needs dev_disconnect")
 @pytest.mark.parametrize("anchors", [False, True])
 def test_htlc_no_force_close(node_factory, bitcoind, anchors):


### PR DESCRIPTION
@t-bast described this issue in general, and here's the fix, with some cleanups on the way.

1. We forward an HTLC.
2. The outgoing channel goes onchain
3. We try to spend the outgoing HTLC (onchain) to time it out.
4. But we either don't pay enough because fees spiked, or with anchors, we decide it's not worthwhile to pay enough fees.
5. HTLC stays open and incoming side gets upset, closing channel.

Our solution is to monitor for this: 

1. If an htlc is incoming, and <= 3 blocks away from timing out
2. And there's a corresponding outgoing
3. And it's onchain (it will be by default, since cltv_delta is 6 (testnet) or 34 (mainnet).
4. Fail the incoming immediately.

This is a risk, of course: the outgoing HTLC could be claimed by the peer.  But that's no worse to us than it not getting mined at all, which we were prepared for.
