### PR TITLE
lnprototest: update to the last version and fix flakiness of lnprototest on CI 

### DIFF
--- a/.github/workflows/prototest.yaml
+++ b/.github/workflows/prototest.yaml
@@ -35,6 +35,7 @@ jobs:
           -e TEST_CMD="make check-protos" \
           -e TEST_GROUP=1 \
           -e TEST_GROUP_COUNT=1 \
+          -e TIMEOUT=120 \
           cln-ci-ubuntu
       - name: Upload Unit Test Results
         if: always()


### PR DESCRIPTION
The lnprototest occasionally fails on our CI due to the
timeout duration we set while waiting for cln to start up.
This timeout is insufficient for machines like the ones
used in the GitHub CI environment.

To address this issue, this commit introduces the use of
environment variables to increase the lnprototest timeout,
ensuring sufficient time for cln to initialize.

Regarding the update of lnprototest version, there is nothing special. Just making some test 
code more general and lnprototest API more consistent