### PR TITLE
channeld: Verify the signature sent by the counterparty (aka do not trust verify)

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1326,9 +1326,7 @@ def test_funding_reorg_remote_lags(node_factory, bitcoind):
     bitcoind.generate_block(1)
     l1.daemon.wait_for_log(r'Peer transient failure .* short_channel_id changed to 104x1x0 \(was 103x1x0\)')
 
-    wait_for(lambda: only_one(l2.rpc.listpeerchannels()['channels'])['status'] == [
-        'CHANNELD_NORMAL:Reconnected, and reestablished.',
-        'CHANNELD_NORMAL:Channel ready for use. They need our announcement signatures.'])
+    l2.daemon.wait_for_logs([r'Peer transient failure in CHANNELD_NORMAL: channeld WARNING: Bad node_signature*'])
 
     # Unblinding l2 brings it back in sync, restarts channeld and sends its announce sig
     l2.daemon.rpcproxy.mock_rpc('getblockhash', None)


### PR DESCRIPTION
This commit addresses an issue to enhance the resilience of core lightning when receiving node announcements.

According to BOLT 7 (The announcement_signatures Message), if the node_signature OR the bitcoin_signature is NOT correct, it is recommended to either send a warning and close the connection or send an error and fail the channel.

In this commit, we take a strict approach. If any error is detected, we send an error and fail the open channel operation. This is because the announcement_signatures operation is optional, and we assume that it must be correct.

lnprototest at commit dea47c29b5541dbfe7fe53cc2598330e897fa4f4 report the following error now.

```
2023-07-06T21:03:20.930Z DEBUG   hsmd: Shutting down

ERROR    root:helpers.py:170 Traceback (most recent call last):
  File "/home/vincent/Github/lightning/external/lnprototest/tests/helpers.py", line 167, in run_runner
    runner.run(test)
  File "/home/vincent/Github/lightning/external/lnprototest/lnprototest/runner.py", line 99, in run
    all_done = sequence.action(self)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/vincent/Github/lightning/external/lnprototest/lnprototest/structure.py", line 55, in action
    all_done &= e.action(runner)
                ^^^^^^^^^^^^^^^^
  File "/home/vincent/Github/lightning/external/lnprototest/lnprototest/event.py", line 365, in action
    raise EventError(self, "{}: message was {}".format(err, msg.to_str()))
lnprototest.errors.EventError: `Expected msgtype-warning, got msgtype-error: message was error channel_id=a37362839b13f61cfe82d35bd397b1264c389b245847cfb6111b38892546dc77 data=4661696c656420746f20766572696679206e6f64655f7369676e61747572652e` on event [{"event": "ExpectMsg", "file": "test_bolt2-01-close_channel.py", "pos": "157"},]
============================================================================================================================================================== short test summary info ===============================================================================================================================================================
FAILED tests/test_bolt2-01-close_channel.py::test_close_channel_shutdown_msg_normal_case_receiver_side - AssertionError: `Expected msgtype-shutdown, got msgtype-error: message was error channel_id=a37362839b13f61cfe82d35bd397b1264c389b245847cfb6111b38892546dc77 data=4661696c656420746f20766572696679206e6f64655f7369676e61747572652e` on event [{"event": "ExpectMsg", "file": "test_bolt2-01-close_channel.py", "pos": "75"},]
FAILED tests/test_bolt2-01-close_channel.py::test_close_channel_shutdown_msg_wrong_script_pubkey_receiver_side - AssertionError: `Expected msgtype-warning, got msgtype-error: message was error channel_id=a37362839b13f61cfe82d35bd397b1264c389b245847cfb6111b38892546dc77 data=4661696c656420746f20766572696679206e6f64655f7369676e61747572652e` on event [{"event": "ExpectMsg", "file": "test_bolt2-01-close_channel.py", "pos": "157"},]

```

This PR shows how useful is lnprototest in debugging issues and make sure that we are protocol compliant, so now lnprototest in this PR should fail, and when this is merged https://github.com/ElementsProject/lightning/pull/6383 the tests should be again happy

P.S: the current version of lnprototest is buggy because relay on cln behavior!

Changelog-Fixes: channeld: Verify the signature sent in announcement_signatures by the counterparty
Reported-by: lnprototest