### PR TITLE
offers: allow overriding offer_node_id when generating an offer

### DIFF
--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -6,7 +6,7 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**offer** *amount* *description* [*issuer*] [*label*] [*quantity\_max*] [*absolute\_expiry*] [*recurrence*] [*recurrence\_base*] [*recurrence\_paywindow*] [*recurrence\_limit*] [*single\_use*]
+**offer** *amount* *description* [*issuer*] [*label*] [*quantity\_max*] [*absolute\_expiry*] [*recurrence*] [*recurrence\_base*] [*recurrence\_paywindow*] [*recurrence\_limit*] [*single\_use*] [*nodeid*]
 
 DESCRIPTION
 -----------
@@ -87,6 +87,9 @@ period which exists.  eg. "12" means there are 13 periods, from 0 to
 *single\_use* (default false) indicates that the offer is only valid
 once; we may issue multiple invoices, but as soon as one is paid all other
 invoices will be expired (i.e. only one person can pay this offer).
+
+*nodeid* (default is this node) indicates the node's public key from
+which to request the invoice.
 
 RETURN VALUE
 ------------

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -281,6 +281,7 @@ struct command_result *json_offer(struct command *cmd,
 	const char *desc, *issuer;
 	struct tlv_offer *offer;
 	struct offer_info *offinfo = tal(cmd, struct offer_info);
+	struct pubkey *offer_node_id;
 
 	offinfo->offer = offer = tlv_offer_new(offinfo);
 
@@ -303,6 +304,7 @@ struct command_result *json_offer(struct command *cmd,
 			 &offer->offer_recurrence_limit),
 		   p_opt_def("single_use", param_bool,
 			     &offinfo->single_use, false),
+		   p_opt("nodeid", param_pubkey, &offer_node_id),
 		   /* FIXME: hints support! */
 		   NULL))
 		return command_param_failed();
@@ -366,7 +368,11 @@ struct command_result *json_offer(struct command *cmd,
 	 * - MUST set `offer_node_id` to the node's public key to request the
 	 *   invoice from.
 	 */
-	offer->offer_node_id = tal_dup(offer, struct pubkey, &id);
+	if (offer_node_id) {
+	    offer->offer_node_id = tal_steal(offer, offer_node_id);
+	} else {
+	    offer->offer_node_id = tal_dup(offer, struct pubkey, &id);
+	}
 
 	/* If they specify a different currency, warn if we can't
 	 * convert it! */


### PR DESCRIPTION
Since offers aren't signed, it's easy in theory to reconstruct the offer some other node would make if you already know the details of what that offer should be. Make it easy in practice as well.