### PR TITLE
wallet: Fixes the compilation error due the db_binindings change 

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1731,8 +1731,8 @@ static void migrate_normalize_invstr(struct lightningd *ld, struct db *db)
 		update_stmt = db_prepare_v2(db, SQL("UPDATE invoices"
 						    " SET bolt11 = ?"
 						    " WHERE id = ?;"));
-		db_bind_text(update_stmt, 0, invstr);
-		db_bind_u64(update_stmt, 1, id);
+		db_bind_text(update_stmt, invstr);
+		db_bind_u64(update_stmt, id);
 		db_exec_prepared_v2(update_stmt);
 
 		tal_free(update_stmt);
@@ -1755,8 +1755,8 @@ static void migrate_normalize_invstr(struct lightningd *ld, struct db *db)
 		update_stmt = db_prepare_v2(db, SQL("UPDATE payments"
 						    " SET bolt11 = ?"
 						    " WHERE id = ?;"));
-		db_bind_text(update_stmt, 0, invstr);
-		db_bind_u64(update_stmt, 1, id);
+		db_bind_text(update_stmt, invstr);
+		db_bind_u64(update_stmt, id);
 		db_exec_prepared_v2(update_stmt);
 
 		tal_free(update_stmt);


### PR DESCRIPTION
Currently our CI is not able to complete the compilation because
there is the following compilation error introduced in 0bcff1e76d

```
cc wallet/db.c
wallet/db.c: In function 'migrate_normalize_invstr':
wallet/db.c:1734:3: error: too many arguments to function 'db_bind_text'
 1734 |   db_bind_text(update_stmt, 0, invstr);
      |   ^~~~~~~~~~~~
In file included from wallet/db.c:10:
./db/bindings.h:25:6: note: declared here
   25 | void db_bind_text(struct db_stmt *stmt, const char *val);
      |      ^~~~~~~~~~~~
wallet/db.c:1735:3: error: too many arguments to function 'db_bind_u64'
 1735 |   db_bind_u64(update_stmt, 1, id);
      |   ^~~~~~~~~~~
In file included from wallet/db.c:10:
./db/bindings.h:23:6: note: declared here
   23 | void db_bind_u64(struct db_stmt *stmt, u64 val);
      |      ^~~~~~~~~~~
wallet/db.c:1758:3: error: too many arguments to function 'db_bind_text'
 1758 |   db_bind_text(update_stmt, 0, invstr);
      |   ^~~~~~~~~~~~
In file included from wallet/db.c:10:
./db/bindings.h:25:6: note: declared here
   25 | void db_bind_text(struct db_stmt *stmt, const char *val);
      |      ^~~~~~~~~~~~
wallet/db.c:1759:3: error: too many arguments to function 'db_bind_u64'
 1759 |   db_bind_u64(update_stmt, 1, id);
      |   ^~~~~~~~~~~
In file included from wallet/db.c:10:
./db/bindings.h:23:6: note: declared here
   23 | void db_bind_u64(struct db_stmt *stmt, u64 val);
      |      ^~~~~~~~~~~
make: *** [Makefile:299: wallet/db.o] Error 1
make: *** Waiting for unfinished jobs....
rm external/build-x86_64-linux-gnu/libwally-core-build/src/secp256k1/libsecp256k1.la
```