### PR TITLE
Fix node announce self-advertize and advertize both sides of channels

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -443,22 +443,19 @@ static void dump_our_gossip(struct daemon *daemon, struct peer *peer)
 
 		if (!is_chan_public(chan)) {
 			/* Don't leak private channels, unless it's with you! */
-			if (!node_id_eq(&chan->nodes[!dir]->id, &peer->id))
-				continue;
-			/* There's no announce for this, of course! */
-			/* Private channel updates are wrapped in the store. */
-			else {
-				if (!is_halfchan_defined(&chan->half[dir]))
-					continue;
+			if (node_id_eq(&chan->nodes[!dir]->id, &peer->id)
+			    && is_halfchan_defined(&chan->half[dir])) {
+				/* There's no announce for this, of course! */
+				/* Private channel updates are wrapped in the store. */
 				queue_priv_update(peer, &chan->half[dir].bcast);
-				continue;
 			}
-		} else {
-			/* Send announce */
-			queue_peer_from_store(peer, &chan->bcast);
+			continue;
 		}
 
-		/* Send update if we have one */
+		/* Send channel_announce */
+		queue_peer_from_store(peer, &chan->bcast);
+
+		/* Send channel_update if we have one */
 		if (is_halfchan_defined(&chan->half[dir]))
 			queue_peer_from_store(peer, &chan->half[dir].bcast);
 	}

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -459,6 +459,10 @@ static void dump_our_gossip(struct daemon *daemon, struct peer *peer)
 		if (is_halfchan_defined(&chan->half[dir]))
 			queue_peer_from_store(peer, &chan->half[dir].bcast);
 	}
+
+	/* If we have one, we should send our own node_announcement */
+	if (me->bcast.index)
+		queue_peer_from_store(peer, &me->bcast);
 }
 
 /*~ This is where connectd tells us about a new peer we might want to

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2297,7 +2297,6 @@ def test_channel_resurrection(node_factory, bitcoind):
             assert ("DELETED" in l)
 
 
-@pytest.mark.xfail(strict=True)
 def test_dump_own_gossip(node_factory):
     """We *should* send all self-related gossip unsolicited, if we have any"""
     l1, l2 = node_factory.line_graph(2, wait_for_announce=True)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1383,9 +1383,10 @@ def test_gossipwith(node_factory):
                          check=True,
                          timeout=TIMEOUT, stdout=subprocess.PIPE).stdout
 
-    num_msgs = 0
+    msgs = set()
     while len(out):
         l, t = struct.unpack('>HH', out[0:4])
+        msg = out[2:2 + l]
         out = out[2 + l:]
 
         # Ignore pings, timestamp_filter
@@ -1393,10 +1394,11 @@ def test_gossipwith(node_factory):
             continue
         # channel_announcement node_announcement or channel_update
         assert t == 256 or t == 257 or t == 258
-        num_msgs += 1
+        msgs.add(msg)
 
     # one channel announcement, two channel_updates, two node announcements.
-    assert num_msgs == 7
+    # due to initial blast, we can have duplicates!
+    assert len(msgs) == 5
 
 
 def test_gossip_notices_close(node_factory, bitcoind):


### PR DESCRIPTION
@endothermicdev investigated this, and we diagnosed together.  It's a regression introduced in v23.05 when we moved "gossip blast" from gossip store into gossipd.

Through the glory of tests, we also fixed a similar issue where we didn't send incoming channel_updates: we never did, but it's a good thing to do!

Fixes: #6410 