### PR TITLE
pyln: Make the grpcio dependencies optional

### DIFF
--- a/contrib/pyln-testing/README.md
+++ b/contrib/pyln-testing/README.md
@@ -31,3 +31,31 @@ checked out source code will also result in the environment picking up these
 changes. Notice however that unreleased versions may change API without
 warning, so test thoroughly with the released version.
 
+## Testing GRPC Bindings
+
+The grpc bindings can be tested by setting the `CLN_TEST_GRPC=1`
+environment variable. This will cause the testing framework to use a
+grpc client to talk to the `cln-grpc` plugin, rather than talking
+directly to the node's JSON-RPC interface. Since the GRPC related
+dependencies are guarded behind a feature flag in `pyln-testing`
+you'll need to install it with the `grpc` feature enabled in order to
+be able to run in this mode.
+
+Below is a diagram of how the normal JSON-RPC interaction looks like,
+followed by one that display the grpc interaction:
+
+```
+CLN -- JSON-RPC -- LightningRpc -- pytest
+\_____CLN_____/    \_______pytest_______/
+```
+
+```
+CLN -- JSON-RPC -- cln-rpc -- rpc2grpc converters -- grpc interface -- python grpc client -- python grpc2json converter -- pytest
+\_____CLN_____/    \___________cln-grpc-plugin____________________/    \__________________________pytest________________________/
+```
+
+As you can see the grpc mode attempts to emulate the simple JSON-RPC
+mode by passing the call through a number of conversions. The last
+step `grpc2json` is rather incomplete, and will cause quite a few
+tests to fail for now, until the conversion is completed and we reach
+feature parity between the interaction modes.

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from pyln.client import RpcError
 from pyln.testing.btcproxy import BitcoinRpcProxy
 from pyln.testing.gossip import GossipStore
-from pyln.testing import grpc
 from collections import OrderedDict
 from decimal import Decimal
 from pyln.client import LightningRpc
@@ -820,6 +819,7 @@ class LightningNode(object):
             self._create_jsonrpc_rpc(jsonschemas)
 
     def _create_grpc_rpc(self):
+        from pyln.testing import grpc
         self.grpc_port = reserve_unused_port()
         d = self.lightning_dir / TEST_NETWORK
         d.mkdir(parents=True, exist_ok=True)

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -21,12 +21,16 @@ pyln-client = ">=23"
 Flask = "^2"
 cheroot = "^8"
 psutil = "^5.9"
-grpcio = "^1"
-pyln-grpc-proto = "^0.1"
+
+grpcio = { version = "^1", optional = true }
+pyln-grpc-proto = { version = "^0.1", optional = true }
 
 [tool.poetry.dev-dependencies]
 pyln-client = { path = "../pyln-client", develop = true}
-pyln-grpc-proto = { path = "../pyln-grpc-proto", develop = true}
+pyln-grpc-proto = { path = "../pyln-grpc-proto", develop = true, optional = true}
+
+[tool.poetry.extras]
+grpc = ["pyln-grpc-proto", "grpcio"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
We also document how the grpc test mode works, and why it currently lacks coverage.

This may help reduce the number of dependencies we pull in as well as sidestepping some esoteric platforms not having precompiled binaries for grpcio causing them to fail.

Changelog-Changed: pyln-testing: The grpc dependencies are now optional.