### PR TITLE
Swap out doc links with link to new doc website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Core Lightning (previously c-lightning) is a lightweight, highly customizable an
     * [Pruning](#pruning)
     * [HD wallet encryption](#hd-wallet-encryption)
 	* [Developers](#developers)
-* [Documentation](https://lightning.readthedocs.io/)
+* [Documentation](https://docs.corelightning.org/docs)
 
 ## Project Status
 
@@ -80,7 +80,7 @@ You can start `lightningd` with the following command:
 lightningd --network=bitcoin --log-level=debug
 ```
 
-This creates a `.lightning/` subdirectory in your home directory: see `man -l doc/lightningd.8` (or https://lightning.readthedocs.io/) for more runtime options.
+This creates a `.lightning/` subdirectory in your home directory: see `man -l doc/lightningd.8` (or https://docs.corelightning.org/docs) for more runtime options.
 
 ### Using The JSON-RPC Interface
 
@@ -225,7 +225,7 @@ You should also configure with `--enable-developer` to get additional checks and
 [ml2]: https://lists.linuxfoundation.org/mailman/listinfo/lightning-dev
 [discord]: https://discord.gg/mE9s4rc5un
 [telegram]: https://t.me/lightningd
-[docs]: https://lightning.readthedocs.org
+[docs]: https://docs.corelightning.org/docs
 [releases]: https://github.com/ElementsProject/lightning/releases
 [dockerhub]: https://hub.docker.com/r/elementsproject/lightningd/
 [jsonrpcspec]: https://www.jsonrpc.org/specification


### PR DESCRIPTION
Just a lil PR to update the docs links, for anyone, like me, who was confused about where the new docs live