### PR TITLE
channeld: don't close connection on invalid badonion code (LND bug?)

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1965,9 +1965,11 @@ static void handle_peer_fail_malformed_htlc(struct peer *peer, const u8 *msg)
 	 *       `error` and fail the channel.
 	 */
 	if (!(failure_code & BADONION)) {
-		peer_failed_warn(peer->pps, &peer->channel_id,
-				 "Bad update_fail_malformed_htlc failure code %u",
-				 failure_code);
+		/* But LND (at least, Bitrefill to Blockstream Store) sends this? */
+		status_unusual("Bad update_fail_malformed_htlc failure code %u",
+			       failure_code);
+		/* We require this internally. */
+		failure_code |= BADONION;
 	}
 
 	e = channel_fail_htlc(peer->channel, LOCAL, id, &htlc);


### PR DESCRIPTION
```
channeld WARNING: Bad update_fail_malformed_htlc failure code 4103
```

Warren Togami reports this happening with Bitrefill on every reconnect, so it's clearly something LND does.

(4103 is TEMPORARY_CHANNEL_FAILURE, which does not belong in update_fail_malformed_htlc).


Changelog-Changed: Protocol: We allow update_fail_malformed_htlc with invalid error codes (LND?)