### PR TITLE
gossipd: don't "unmark" dying channels' updates if we receive them.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -70,7 +70,7 @@ static ssize_t gossip_pwritev(int fd, const struct iovec *iov, int iovcnt,
 #endif /* !HAVE_PWRITEV */
 
 static bool append_msg(int fd, const u8 *msg, u32 timestamp,
-		       bool zombie, bool spam, u64 *len)
+		       bool zombie, bool spam, bool dying, u64 *len)
 {
 	struct gossip_hdr hdr;
 	u32 msglen;
@@ -86,6 +86,8 @@ static bool append_msg(int fd, const u8 *msg, u32 timestamp,
 		hdr.flags |= CPU_TO_BE16(GOSSIP_STORE_RATELIMIT_BIT);
 	if (zombie)
 		hdr.flags |= CPU_TO_BE16(GOSSIP_STORE_ZOMBIE_BIT);
+	if (dying)
+		hdr.flags |= CPU_TO_BE16(GOSSIP_STORE_DYING_BIT);
 	hdr.crc = cpu_to_be32(crc32c(timestamp, msg, msglen));
 	hdr.timestamp = cpu_to_be32(timestamp);
 
@@ -246,7 +248,7 @@ static u32 gossip_store_compact_offline(struct routing_state *rstate)
 	oldlen = lseek(old_fd, SEEK_END, 0);
 	newlen = lseek(new_fd, SEEK_END, 0);
 	append_msg(old_fd, towire_gossip_store_ended(tmpctx, newlen),
-		   0, false, false, &oldlen);
+		   0, false, false, false, &oldlen);
 	close(old_fd);
 	status_debug("gossip_store_compact_offline: %zu deleted, %zu copied",
 		     deleted, count);
@@ -526,7 +528,7 @@ bool gossip_store_compact(struct gossip_store *gs)
 
 	/* Write end marker now new one is ready */
 	append_msg(gs->fd, towire_gossip_store_ended(tmpctx, len),
-		   0, false, false, &gs->len);
+		   0, false, false, false, &gs->len);
 
 	gs->count = count;
 	gs->deleted = 0;
@@ -547,19 +549,19 @@ disable:
 
 u64 gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg,
 		     u32 timestamp, bool zombie,
-		     bool spam, const u8 *addendum)
+		     bool spam, bool dying, const u8 *addendum)
 {
 	u64 off = gs->len;
 
 	/* Should never get here during loading! */
 	assert(gs->writable);
 
-	if (!append_msg(gs->fd, gossip_msg, timestamp, zombie, spam, &gs->len)) {
+	if (!append_msg(gs->fd, gossip_msg, timestamp, zombie, spam, dying, &gs->len)) {
 		status_broken("Failed writing to gossip store: %s",
 			      strerror(errno));
 		return 0;
 	}
-	if (addendum && !append_msg(gs->fd, addendum, 0, false, false, &gs->len)) {
+	if (addendum && !append_msg(gs->fd, addendum, 0, false, false, false, &gs->len)) {
 		status_broken("Failed writing addendum to gossip store: %s",
 			      strerror(errno));
 		return 0;
@@ -576,7 +578,7 @@ u64 gossip_store_add_private_update(struct gossip_store *gs, const u8 *update)
 	/* A local update for an unannounced channel: not broadcastable, but
 	 * otherwise the same as a normal channel_update */
 	const u8 *pupdate = towire_gossip_store_private_update(tmpctx, update);
-	return gossip_store_add(gs, pupdate, 0, false, false, NULL);
+	return gossip_store_add(gs, pupdate, 0, false, false, false, NULL);
 }
 
 void gossip_store_mark_dying(struct gossip_store *gs,
@@ -684,7 +686,7 @@ void gossip_store_mark_channel_deleted(struct gossip_store *gs,
 				       const struct short_channel_id *scid)
 {
 	gossip_store_add(gs, towire_gossip_store_delete_chan(tmpctx, scid),
-			 0, false, false, NULL);
+			 0, false, false, false, NULL);
 }
 
 static void mark_zombie(struct gossip_store *gs,

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -38,14 +38,14 @@ u64 gossip_store_add_private_update(struct gossip_store *gs, const u8 *update);
  * @gs: gossip store
  * @gossip_msg: the gossip message to insert.
  * @timestamp: the timestamp for filtering of this messsage.
- * @push: true if this should be sent to peers despite any timestamp filters.
- * @spam: true if this message is rate-limited and squelched to peers.
  * @zombie: true if this channel is missing a current channel_update.
+ * @spam: true if this message is rate-limited and squelched to peers.
+ * @dying: true if this message is for a dying channel.
  * @addendum: another message to append immediately after this
  *            (for appending amounts to channel_announcements for internal use).
  */
 u64 gossip_store_add(struct gossip_store *gs, const u8 *gossip_msg,
-		     u32 timestamp, bool zombie, bool spam,
+		     u32 timestamp, bool zombie, bool spam, bool dying,
 		     const u8 *addendum);
 
 

--- a/gossipd/test/run-check_channel_announcement.c
+++ b/gossipd/test/run-check_channel_announcement.c
@@ -61,7 +61,7 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED, bool dying UNNEEDED,
 		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */

--- a/gossipd/test/run-txout_failure.c
+++ b/gossipd/test/run-txout_failure.c
@@ -32,7 +32,7 @@ bool cupdate_different(struct gossip_store *gs UNNEEDED,
 { fprintf(stderr, "cupdate_different called!\n"); abort(); }
 /* Generated stub for gossip_store_add */
 u64 gossip_store_add(struct gossip_store *gs UNNEEDED, const u8 *gossip_msg UNNEEDED,
-		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED,
+		     u32 timestamp UNNEEDED, bool zombie UNNEEDED, bool spam UNNEEDED, bool dying UNNEEDED,
 		     const u8 *addendum UNNEEDED)
 { fprintf(stderr, "gossip_store_add called!\n"); abort(); }
 /* Generated stub for gossip_store_add_private_update */


### PR DESCRIPTION
This looked like a test flake, but was real:

```
        l1.daemon.wait_for_log("closing soon due to the funding outpoint being spent")
    
        # We won't gossip the dead channel any more (but we still propagate node_announcement).  But connectd is not explicitly synced, so wait for "a bit".
        time.sleep(1)
>       assert len(get_gossip(l1)) == 2
E       assert 4 == 2
```

We can see that two channel_updates come in *after* we mark it dying:

```
gossipd: channel 103x1x0 closing soon due to the funding outpoint being spent
gossipd: REPLY WIRE_GOSSIPD_NEW_BLOCKHEIGHT_REPLY with 0 fds
022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-gossipd: Received channel_update for channel 103x1x0/0 now DISABLED
022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59-gossipd: Received channel_update for channel 103x1x0/1 now DISABLED
```

We should keep marking channel_updates the same way.