### PR TITLE
ci: Update the upload-artifact step to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
           mv testpack.tar.bz2 cln-${CFG}.tar.bz2
       - name: Check rust packages
         run: cargo test --all
-      - uses: actions/upload-artifact@v2.2.4
+      - uses: actions/upload-artifact@v3
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2
           path: cln-${{ matrix.CFG }}.tar.bz2


### PR DESCRIPTION
GH was complaining about Node v12 being used in v2.2.4. We used to hold back from this upgrade because v3 was breaking quotas, but we should try again.

Changelog-None