### PR TITLE
devtools/print_wire: long long instead of longing

### DIFF
--- a/devtools/print_wire.c
+++ b/devtools/print_wire.c
@@ -91,7 +91,7 @@ bool printwire_s64(const char *fieldname, const u8 **cursor, size_t *plen)
 		printf("**TRUNCATED s64 %s**\n", fieldname);
 		return false;
 	}
-	printf("%ld\n", v);
+	printf("%"PRId64"\n", v);
 	return true;
 }
 


### PR DESCRIPTION
Clang on OpenBSD found this little guy. Build fails without the `%lld`.

```
devtools/print_wire.c:94:18: error: format specifies type 'long' but the argument has type 's64' (aka 'long long') [-Werror,-Wformat]
        printf("%ld\n", v);
                ~~~     ^
                %lld

1 error generated.
gmake: *** [Makefile:299: devtools/print_wire.o] Error 1
```


Changelog-None