### PR TITLE
plugins/bcli: update minimum required bitcoind version.

### DIFF
--- a/contrib/docker/Dockerfile.tester
+++ b/contrib/docker/Dockerfile.tester
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
-MAINTAINER Christian Decker <decker.christian@gmail.com>
+FROM ubuntu:22.04
+LABEL mantainer="Christian Decker <decker.christian@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV BITCOIN_VERSION 0.20.1
-ENV ELEMENTS_VERSION 0.18.1.8
+ENV BITCOIN_VERSION 22.0
+ENV ELEMENTS_VERSION 22.0.2
 
 RUN useradd -ms /bin/bash tester
 RUN mkdir /build /bolts && chown tester -R /build /bolts
@@ -62,16 +62,16 @@ RUN echo "tester ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/tester && \
     chmod 0440 /etc/sudoers.d/tester
 
 RUN cd /tmp/ && \
-	wget https://storage.googleapis.com/c-lightning-tests/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.bz2 && \
-	wget -q https://storage.googleapis.com/c-lightning-tests/elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2 && \
-	tar -xjf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.bz2 && \
-	tar -xjf elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2 && \
-	mv bitcoin-$BITCOIN_VERSION/bin/* /usr/local/bin && \
-	mv elements-$ELEMENTS_VERSION/bin/* /usr/local/bin && \
-	rm -rf \
-	  bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz \
-          bitcoin-$BITCOIN_VERSION \
-          elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2 \
-          elements-$ELEMENTS_VERSION
+    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz && \
+    wget https://github.com/ElementsProject/elements/releases/download/elements-$ELEMENTS_VERSION/elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz && \
+    tar -xzf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz && \
+    tar -xzf elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz && \
+    mv bitcoin-$BITCOIN_VERSION/bin/* /usr/local/bin && \
+    mv elements-$ELEMENTS_VERSION/bin/* /usr/local/bin && \
+    rm -rf \
+       bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz \
+       bitcoin-$BITCOIN_VERSION \
+       elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz \
+       elements-$ELEMENTS_VERSION
 
 USER tester

--- a/contrib/docker/scripts/setup.sh
+++ b/contrib/docker/scripts/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 export DEBIAN_FRONTEND=noninteractive
-export BITCOIN_VERSION=0.20.1
-export ELEMENTS_VERSION=0.18.1.8
+export BITCOIN_VERSION=22.0
+export ELEMENTS_VERSION=22.0.2
 export RUST_VERSION=nightly
 export TZ="Europe/London"
 
@@ -50,19 +50,18 @@ sudo apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
      xsltproc \
      zlib1g-dev
 
-
 (
     cd /tmp/ || exit 1
-    wget https://storage.googleapis.com/c-lightning-tests/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.bz2
-    wget -q https://storage.googleapis.com/c-lightning-tests/elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2
-    tar -xjf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.bz2
-    tar -xjf elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2
+    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
+    wget https://github.com/ElementsProject/elements/releases/download/elements-$ELEMENTS_VERSION/elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz
+    tar -xzf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
+    tar -xzf elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz
     sudo mv bitcoin-$BITCOIN_VERSION/bin/* /usr/local/bin
     sudo mv elements-$ELEMENTS_VERSION/bin/* /usr/local/bin
     rm -rf \
        bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz \
        bitcoin-$BITCOIN_VERSION \
-       elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.bz2 \
+       elements-$ELEMENTS_VERSION-x86_64-linux-gnu.tar.gz \
        elements-$ELEMENTS_VERSION
 )
 

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -918,7 +918,7 @@ static void parse_getnetworkinfo_result(struct plugin *p, const char *buf)
 {
 	const jsmntok_t *result;
 	bool tx_relay;
-	u32 min_version = 160000;
+	u32 min_version = 220000;
 	const char *err;
 
 	result = json_parse_simple(NULL, buf, strlen(buf));


### PR DESCRIPTION
Less than 22 is obsolete anyway, so we should increment this from 16.0 at least!

Closes: #6234
Changelog-None