### PR TITLE
docs: Incorrect params sequence for checkrune command

### DIFF
--- a/doc/lightning-checkrune.7.md
+++ b/doc/lightning-checkrune.7.md
@@ -4,7 +4,7 @@ lightning-checkrune -- Command to Validate Rune
 SYNOPSIS
 --------
 
-**checkrune** [*nodeid*], [*rune*], [*method*] [*params*]
+**checkrune** [*rune*], [*nodeid*], [*method*] [*params*]
 
 DESCRIPTION
 -----------

--- a/doc/schemas/checkrune.request.json
+++ b/doc/schemas/checkrune.request.json
@@ -9,6 +9,10 @@
   ],
   "added": "v23.08",
   "properties": {
+    "rune": {
+      "type": "string",
+      "description": "rune to check for authorization"
+    },
     "nodeid": {
       "type": "string",
       "description": "node id of your node"
@@ -16,10 +20,6 @@
     "method": {
       "type": "string",
       "description": "method for which rune needs to be validated"
-    },
-    "rune": {
-      "type": "string",
-      "description": "rune to check for authorization"
     },
     "params": {
       "oneOf": [


### PR DESCRIPTION
It accepts rune first and nodeid second but the documentation showed incorrect sequence.