### PR TITLE
gossipd: handle upgrade from version 11 gossip_store

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -105,10 +105,12 @@ static bool append_msg(int fd, const u8 *msg, u32 timestamp,
 
 /* v9 added the GOSSIP_STORE_LEN_RATELIMIT_BIT.
  * v10 removed any remaining non-htlc-max channel_update.
+ * v11 mandated channel_updates use the htlc_maximum_msat field
+ * v12 added the zombie flag for expired channel updates
  */
 static bool can_upgrade(u8 oldversion)
 {
-	return oldversion == 9 || oldversion == 10;
+	return oldversion >= 9 && oldversion <= 11;
 }
 
 static bool upgrade_field(u8 oldversion,


### PR DESCRIPTION
We also need a test that will break if you miss updating this test.  Will work on one.