### PR TITLE
lightningd: don't crash if peer manages to spend onchain HTLC after we've abandoned upstream

### DIFF
--- a/lightningd/htlc_end.c
+++ b/lightningd/htlc_end.c
@@ -203,9 +203,9 @@ struct htlc_out *htlc_out_check(const struct htlc_out *hout,
 				return corrupt(abortstr,
 					       "Output failmsg, input preimage");
 		} else if (hout->preimage) {
-			if (hout->in->failonion)
-				return corrupt(abortstr,
-					       "Output preimage, input failonion");
+			/* If we abandoned the HTLC to save the incoming channel,
+			 * (see consider_failing_incoming), hout->in->failonion
+			 * will be set! */
 			if (hout->in->badonion)
 				return corrupt(abortstr,
 					       "Output preimage, input badonion");


### PR DESCRIPTION
Since we now abandon HTLCs to avoid breaking a channel (in limited circumstances), the peer can take the funds if they beat us to spend the HTLC before we timeout.  This is extremely unusual, but finally happend in CI.

First it fails our internal sanity checks, but then it would fail when we tried to fulfill an already-failed HTLC:

```
**BROKEN** lightningd: fulfill_our_htlc_out:Output preimage, input failonion?
**BROKEN** lightningd: FATAL SIGNAL 6 (version f82fedb-modded)
**BROKEN** lightningd: backtrace: common/daemon.c:38 (send_backtrace) 0x55c09b04f0b5
**BROKEN** lightningd: backtrace: common/daemon.c:75 (crashdump) 0x55c09b04f247
**BROKEN** lightningd: backtrace: ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0 ((null)) 0x7f607463551f
**BROKEN** lightningd: backtrace: ./nptl/pthread_kill.c:44 (__pthread_kill_implementation) 0x7f6074689a7c
**BROKEN** lightningd: backtrace: ./nptl/pthread_kill.c:78 (__pthread_kill_internal) 0x7f6074689a7c
**BROKEN** lightningd: backtrace: ./nptl/pthread_kill.c:89 (__GI___pthread_kill) 0x7f6074689a7c
**BROKEN** lightningd: backtrace: ../sysdeps/posix/raise.c:26 (__GI_raise) 0x7f6074635475
**BROKEN** lightningd: backtrace: ./stdlib/abort.c:79 (__GI_abort) 0x7f607461b7f2
**BROKEN** lightningd: backtrace: lightningd/log.c:1016 (fatal_vfmt) 0x55c09afdb7cb
**BROKEN** lightningd: backtrace: lightningd/log.c:1026 (fatal) 0x55c09afdb880
**BROKEN** lightningd: backtrace: lightningd/htlc_end.c:87 (corrupt) 0x55c09afc9472
**BROKEN** lightningd: backtrace: lightningd/htlc_end.c:207 (htlc_out_check) 0x55c09afc9c6b
**BROKEN** lightningd: backtrace: lightningd/peer_htlcs.c:1451 (fulfill_our_htlc_out) 0x55c09b004dd7
**BROKEN** lightningd: backtrace: lightningd/peer_htlcs.c:1526 (onchain_fulfilled_htlc) 0x55c09b0050fe
**BROKEN** lightningd: backtrace: lightningd/onchain_control.c:313 (handle_extracted_preimage) 0x55c09afdf9f8
**BROKEN** lightningd: backtrace: lightningd/onchain_control.c:1423 (onchain_msg) 0x55c09afe2da9
**BROKEN** lightningd: backtrace: lightningd/subd.c:557 (sd_msg_read) 0x55c09b019ac8
```

Changelog-None: broken since last release