### PR TITLE
gossipd: actually update own node announcement if needed

### DIFF
--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -287,6 +287,11 @@ static bool update_own_node_announcement(struct daemon *daemon,
 					 &only_missing_tlv)) {
 			if (always_refresh)
 				goto send;
+			/* Update if old announcement is at least 7 days old. */
+			if (timestamp > self->bcast.timestamp &&
+			    timestamp - self->bcast.timestamp >
+			    GOSSIP_PRUNE_INTERVAL(daemon->rstate->dev_fast_gossip_prune) / 2)
+				goto send;
 			return false;
 		}
 


### PR DESCRIPTION
When an outdated own node announcement is present, it can fail the `nannounce_different` test and also fail to kick off the forced regen timer.

An alternative solution is to manually start the `setup_force_nannounce_regen_timer` from gossip_init, however as `maybe_send_own_node_announce` is already called at init, that seems like a more appropriate event to actually update and broadcast the refreshed node announcement.

Changelog-Fixed: Node announcements are refreshed more reliably.