### PR TITLE
devtools/credit: ! not ^ to invert the match set in sh.

### DIFF
--- a/devtools/credit
+++ b/devtools/credit
@@ -25,8 +25,8 @@ NAMER=""
 BACKUP_NAMER=""
 TOTAL=0
 while read LINE; do
-    COUNT=${LINE%% [^ 0123456789]*}
-    TOTAL=$(($TOTAL + $COUNT))
+    COUNT=${LINE%% [! 0123456789]*}
+    TOTAL=$((TOTAL + COUNT))
     LINE=${LINE#*[1234567890] }
     NAME=${LINE%%|*}
     EMAIL=${LINE#*|}


### PR DESCRIPTION
Script was broken, at least here.

Changelog-None