### PR TITLE
gossipd: tell lightningd about all our previous channel_updates at startup

### DIFF
--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -18,6 +18,12 @@ msgdata,gossipd_init,dev_fast_gossip,bool,
 msgdata,gossipd_init,dev_fast_gossip_prune,bool,
 msgdata,gossipd_init,ip_discovery,u32,
 
+# Gossipd tells us all our public channel_updates before init_reply.
+msgtype,gossipd_init_cupdate,3101
+msgdata,gossipd_init_cupdate,scid,short_channel_id,
+msgdata,gossipd_init_cupdate,len,u16,
+msgdata,gossipd_init_cupdate,cupdate,u8,len
+
 msgtype,gossipd_init_reply,3100
 
 # In developer mode, we can mess with time.


### PR DESCRIPTION
This will at least *help* the case where these were not populated, causing us to send errors without channel_updated appended.

It's not perfect: we can still send such errors if the gossip store is corrupted, and we still send them for private channels, but it should help.

(The much better fix is far more invasive, so slips to next release!)
See: #5822
