### PR TITLE
dual-fund: tx-abort fixups

### DIFF
--- a/common/peer_failed.c
+++ b/common/peer_failed.c
@@ -42,6 +42,7 @@ peer_failed(struct per_peer_state *pps,
 	msg = towire_status_peer_error(NULL, channel_id,
 				       desc,
 				       warn,
+				       false,
 				       msg);
 	peer_billboard(true, desc);
 	peer_fatal_continue(take(msg), pps);
@@ -80,7 +81,8 @@ void peer_failed_err(struct per_peer_state *pps,
 void peer_failed_received_errmsg(struct per_peer_state *pps,
 				 const char *desc,
 				 const struct channel_id *channel_id,
-				 bool warning)
+				 bool warning,
+				 bool abort_restart)
 {
 	u8 *msg;
 
@@ -94,7 +96,7 @@ void peer_failed_received_errmsg(struct per_peer_state *pps,
 		warning = true;
 	}
 	msg = towire_status_peer_error(NULL, channel_id, desc, warning,
-				       NULL);
+				       abort_restart, NULL);
 	peer_billboard(true, "Received %s", desc);
 	peer_fatal_continue(take(msg), pps);
 }

--- a/common/peer_failed.h
+++ b/common/peer_failed.h
@@ -37,7 +37,8 @@ void peer_failed_err(struct per_peer_state *pps,
 void peer_failed_received_errmsg(struct per_peer_state *pps,
 				 const char *desc,
 				 const struct channel_id *channel_id,
-				 bool soft_error)
+				 bool soft_error,
+				 bool abort_restart)
 	NORETURN;
 
 /* I/O error */

--- a/common/peer_status_wire.csv
+++ b/common/peer_status_wire.csv
@@ -8,5 +8,7 @@ msgdata,status_peer_error,channel,channel_id,
 msgdata,status_peer_error,desc,wirestring,
 # Take a deep breath, then try reconnecting to the precious little snowflake.
 msgdata,status_peer_error,warning,bool,
+# From an abort, no reconnect but restart daemon
+msgdata,status_peer_error,abort_do_restart,bool,
 msgdata,status_peer_error,len,u16,
 msgdata,status_peer_error,error_for_them,u8,len

--- a/common/read_peer_msg.c
+++ b/common/read_peer_msg.c
@@ -83,7 +83,7 @@ bool handle_peer_error(struct per_peer_state *pps,
 		}
 
 		/* We hang up when a warning is received. */
-		peer_failed_received_errmsg(pps, err, channel_id, warning);
+		peer_failed_received_errmsg(pps, err, channel_id, warning, false);
 	}
 
 	return false;

--- a/common/wire_error.c
+++ b/common/wire_error.c
@@ -94,7 +94,7 @@ char *sanitize_error(const tal_t *ctx, const u8 *errmsg,
 	else if (fromwire_warning(ctx, errmsg, channel_id, &data))
 		warning = true;
 	else if (fromwire_tx_abort(ctx, errmsg, channel_id, &data))
-		warning = false;
+		warning = true;
 	else
 		return tal_fmt(ctx, "Invalid ERROR message '%s'",
 			       tal_hex(ctx, errmsg));

--- a/lightningd/dual_open_control.h
+++ b/lightningd/dual_open_control.h
@@ -11,7 +11,8 @@ bool peer_start_dualopend(struct peer *peer, struct peer_fd *peer_fd,
 
 bool peer_restart_dualopend(struct peer *peer,
 			    struct peer_fd *peer_fd,
-			    struct channel *channel);
+			    struct channel *channel,
+			    bool from_abort);
 
 void dualopen_tell_depth(struct subd *dualopend,
 			 struct channel *channel,

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -1496,6 +1496,7 @@ static void onchain_error(struct channel *channel,
 			  const struct channel_id *channel_id UNUSED,
 			  const char *desc,
 			  bool warning UNUSED,
+			  bool aborted UNUSED,
 			  const u8 *err_for_them UNUSED)
 {
 	channel_set_owner(channel, NULL);

--- a/lightningd/opening_common.c
+++ b/lightningd/opening_common.c
@@ -96,6 +96,7 @@ void opend_channel_errmsg(struct uncommitted_channel *uc,
 			  const struct channel_id *channel_id UNUSED,
 			  const char *desc,
 			  bool warning UNUSED,
+			  bool aborted UNUSED,
 			  const u8 *err_for_them UNUSED)
 {
 	/* Close fds, if any. */

--- a/lightningd/opening_common.h
+++ b/lightningd/opening_common.h
@@ -112,6 +112,7 @@ void opend_channel_errmsg(struct uncommitted_channel *uc,
 			  const struct channel_id *channel_id UNUSED,
 			  const char *desc,
 			  bool warning UNUSED,
+			  bool aborted UNUSED,
 			  const u8 *err_for_them UNUSED);
 
 void opend_channel_set_billboard(struct uncommitted_channel *uc,

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -97,6 +97,7 @@ void channel_errmsg(struct channel *channel,
 		    const struct channel_id *channel_id,
 		    const char *desc,
 		    bool warning,
+		    bool aborted,
 		    const u8 *err_for_them);
 
 u8 *p2wpkh_for_keyidx(const tal_t *ctx, struct lightningd *ld, u64 keyidx);

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -54,6 +54,7 @@ struct subd {
 		      const struct channel_id *channel_id,
 		      const char *desc,
 		      bool warning,
+		      bool aborted,
 		      const u8 *err_for_them);
 
 	/* Callback to display information for listpeers RPC */
@@ -136,6 +137,7 @@ struct subd *new_channel_subd_(const tal_t *ctx,
 					     const struct channel_id *channel_id,
 					     const char *desc,
 					     bool warning,
+					     bool aborted,
 					     const u8 *err_for_them),
 			       void (*billboardcb)(void *channel, bool perm,
 						   const char *happenings),
@@ -151,7 +153,7 @@ struct subd *new_channel_subd_(const tal_t *ctx,
 					       (channel),		\
 					       struct peer_fd *,	\
 					       const struct channel_id *, \
-					       const char *, bool, const u8 *), \
+					       const char *, bool, bool, const u8 *), \
 			  typesafe_cb_postargs(void, void *, (billboardcb), \
 					       (channel), bool,		\
 					       const char *),		\

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -84,7 +84,7 @@ bool fromwire_status_fail(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, enu
 bool fromwire_status_peer_billboard(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, bool *perm UNNEEDED, wirestring **happenings UNNEEDED)
 { fprintf(stderr, "fromwire_status_peer_billboard called!\n"); abort(); }
 /* Generated stub for fromwire_status_peer_error */
-bool fromwire_status_peer_error(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct channel_id *channel UNNEEDED, wirestring **desc UNNEEDED, bool *warning UNNEEDED, u8 **error_for_them UNNEEDED)
+bool fromwire_status_peer_error(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct channel_id *channel UNNEEDED, wirestring **desc UNNEEDED, bool *warning UNNEEDED, bool *abort_do_restart UNNEEDED, u8 **error_for_them UNNEEDED)
 { fprintf(stderr, "fromwire_status_peer_error called!\n"); abort(); }
 /* Generated stub for fromwire_status_version */
 bool fromwire_status_version(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, wirestring **version UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -796,7 +796,8 @@ struct channel *peer_any_active_channel(struct peer *peer UNNEEDED, bool *others
 /* Generated stub for peer_restart_dualopend */
 bool peer_restart_dualopend(struct peer *peer UNNEEDED,
 			    struct peer_fd *peer_fd UNNEEDED,
-			    struct channel *channel UNNEEDED)
+			    struct channel *channel UNNEEDED,
+			    bool from_abort UNNEEDED)
 { fprintf(stderr, "peer_restart_dualopend called!\n"); abort(); }
 /* Generated stub for peer_start_channeld */
 bool peer_start_channeld(struct channel *channel UNNEEDED,

--- a/lightningd/test/run-shuffle_fds.c
+++ b/lightningd/test/run-shuffle_fds.c
@@ -70,7 +70,7 @@ bool fromwire_status_fail(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, enu
 bool fromwire_status_peer_billboard(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, bool *perm UNNEEDED, wirestring **happenings UNNEEDED)
 { fprintf(stderr, "fromwire_status_peer_billboard called!\n"); abort(); }
 /* Generated stub for fromwire_status_peer_error */
-bool fromwire_status_peer_error(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct channel_id *channel UNNEEDED, wirestring **desc UNNEEDED, bool *warning UNNEEDED, u8 **error_for_them UNNEEDED)
+bool fromwire_status_peer_error(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct channel_id *channel UNNEEDED, wirestring **desc UNNEEDED, bool *warning UNNEEDED, bool *abort_do_restart UNNEEDED, u8 **error_for_them UNNEEDED)
 { fprintf(stderr, "fromwire_status_peer_error called!\n"); abort(); }
 /* Generated stub for fromwire_status_version */
 bool fromwire_status_version(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, wirestring **version UNNEEDED)

--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -33,6 +33,7 @@ msgdata,dualopend_init,require_confirmed_inputs,bool,
 # master-dualopend: peer has reconnected
 msgtype,dualopend_reinit,7001
 msgdata,dualopend_reinit,chainparams,chainparams,
+msgdata,dualopend_reinit,from_abort,bool,
 msgdata,dualopend_reinit,our_feature_set,feature_set,
 msgdata,dualopend_reinit,their_init_features_len,u16,
 msgdata,dualopend_reinit,their_init_features,u8,their_init_features_len

--- a/plugins/funder.c
+++ b/plugins/funder.c
@@ -695,6 +695,8 @@ listfunds_success(struct command *cmd,
 					     committed_funds,
 					     avail_utxos);
 		json_add_bool(req->js, "reservedok", true);
+		/* We don't re-reserve any UTXOS :) */
+		json_add_num(req->js, "reserve", 0);
 	} else {
 		req = jsonrpc_request_start(cmd->plugin, cmd,
 					    "fundpsbt",

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -380,7 +380,6 @@ def test_v2_rbf_single(node_factory, bitcoind, chainparams):
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
-@pytest.mark.xfail
 def test_v2_rbf_abort_retry(node_factory, bitcoind, chainparams):
     l1, l2 = node_factory.get_nodes(2, opts={'wumbo': None,
                                              'allow_warning': True})
@@ -463,7 +462,6 @@ def test_v2_rbf_abort_retry(node_factory, bitcoind, chainparams):
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
-@pytest.mark.xfail
 @pytest.mark.openchannel('v2')
 def test_v2_rbf_abort_channel_opens(node_factory, bitcoind, chainparams):
     l1, l2 = node_factory.get_nodes(2, opts={'wumbo': None,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -629,7 +629,8 @@ void payment_succeeded(struct lightningd *ld UNNEEDED,
 /* Generated stub for peer_restart_dualopend */
 bool peer_restart_dualopend(struct peer *peer UNNEEDED,
 			    struct peer_fd *peer_fd UNNEEDED,
-			    struct channel *channel UNNEEDED)
+			    struct channel *channel UNNEEDED,
+			    bool from_abort UNNEEDED)
 { fprintf(stderr, "peer_restart_dualopend called!\n"); abort(); }
 /* Generated stub for peer_start_channeld */
 bool peer_start_channeld(struct channel *channel UNNEEDED,


### PR DESCRIPTION
Reported by @t-bast from cross-compat with the Eclair dual-funding implementation.

Now we re-init the dualopend daemon when closed from an 'abort'. Seems to work very nicely? 

Also fixes a problem where the channel won't advance to "NORMAL" if aborted on a subsequent RBF attempt.

Also fix bug where the `funder` would increase the reservation on RBFs of already reserved utxos, which then led to us *not* unreserving them on open failure. It's a halfway move towards us not reserving utxos at all during the negotiation phase of a channel open.