### PR TITLE
wallet: fix crash on startup with expired invoices.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -77,6 +77,7 @@
 #include <lightningd/runes.h>
 #include <lightningd/subd.h>
 #include <sys/resource.h>
+#include <wallet/invoices.h>
 #include <wallet/txfilter.h>
 #include <wally_bip32.h>
 
@@ -1191,6 +1192,9 @@ int main(int argc, char *argv[])
 
 	/*~ Finish our runes initialization (includes reading from db) */
 	runes_finish_init(ld->runes);
+
+	/*~ Start expiring old invoices now ld->wallet is set.*/
+	invoices_start_expiration(ld);
 
 	/*~ That's all of the wallet db operations for now. */
 	db_commit_transaction(ld->wallet->db);

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -114,6 +114,9 @@ void htlcs_notify_new_block(struct lightningd *ld UNNEEDED, u32 height UNNEEDED)
 void htlcs_resubmit(struct lightningd *ld UNNEEDED,
 		    struct htlc_in_map *unconnected_htlcs_in STEALS UNNEEDED)
 { fprintf(stderr, "htlcs_resubmit called!\n"); abort(); }
+/* Generated stub for invoices_start_expiration */
+void invoices_start_expiration(struct lightningd *ld UNNEEDED)
+{ fprintf(stderr, "invoices_start_expiration called!\n"); abort(); }
 /* Generated stub for json_add_string */
 void json_add_string(struct json_stream *js UNNEEDED,
 		     const char *fieldname UNNEEDED,

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -913,7 +913,6 @@ def test_listinvoices_index(node_factory, executor):
         assert only_one(l2.rpc.listinvoices(index='updated', start=i, limit=1)['invoices'])['label'] == str(70 + 1 - i)
 
 
-@pytest.mark.xfail(strict=True)
 def test_expiry_startup_crash(node_factory, bitcoind):
     """We crash trying to expire invoice on startup"""
     l1 = node_factory.get_node()

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -914,6 +914,7 @@ def test_listinvoices_index(node_factory, executor):
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', "The DB migration is network specific due to the chain var.")
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This test is based on a sqlite3 snapshot")
 def test_invoices_wait_db_migration(node_factory, bitcoind):
     """Canned db is from v23.02.2's test_invoice_routeboost_private l2"""
     bitcoind.generate_block(28)
@@ -926,6 +927,7 @@ def test_invoices_wait_db_migration(node_factory, bitcoind):
     l2.rpc.invoice(1000, "test", "test")
 
 
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This test is based on a sqlite3 snapshot")
 @unittest.skipIf(TEST_NETWORK != 'regtest', "The DB migration is network specific due to the chain var.")
 def test_invoice_botched_migration(node_factory, chainparams):
     """Test for grubles' case, where they ran successfully with the wrong var: they have *both* last_invoice_created_index *and *last_invoices_created_index* (this can happen if invoice id 1 was deleted, so they didn't die on invoice creation):

--- a/wallet/invoices.c
+++ b/wallet/invoices.c
@@ -6,6 +6,7 @@
 #include <db/exec.h>
 #include <db/utils.h>
 #include <lightningd/invoice.h>
+#include <lightningd/lightningd.h>
 #include <lightningd/wait.h>
 #include <wallet/invoices.h>
 
@@ -115,7 +116,6 @@ static struct invoice_details *wallet_stmt2invoice_details(const tal_t *ctx,
 	return dtl;
 }
 
-static void trigger_expiration(struct invoices *invoices);
 static void install_expiration_timer(struct invoices *invoices);
 
 struct invoices *invoices_new(const tal_t *ctx,
@@ -130,8 +130,6 @@ struct invoices *invoices_new(const tal_t *ctx,
 	list_head_init(&invs->waiters);
 
 	invs->expiration_timer = NULL;
-
-	trigger_expiration(invs);
 	return invs;
 }
 
@@ -783,4 +781,9 @@ u64 invoice_index_update_deldesc(struct lightningd *ld,
 	assert(description);
 	return invoice_index_inc(ld, NULL, label, NULL, description,
 				 WAIT_INDEX_UPDATED);
+}
+
+void invoices_start_expiration(struct lightningd *ld)
+{
+	trigger_expiration(ld->wallet->invoices);
 }

--- a/wallet/invoices.h
+++ b/wallet/invoices.h
@@ -27,6 +27,13 @@ struct invoices *invoices_new(const tal_t *ctx,
 			      struct timers *timers);
 
 /**
+ * invoices_start_expiration - Once ld->wallet complete, we can start expiring.
+ *
+ * @ld - the lightningd object
+ */
+void invoices_start_expiration(struct lightningd *ld);
+
+/**
  * invoices_create - Create a new invoice.
  *
  * @invoices - the invoice handler.

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -117,13 +117,16 @@ struct wallet *wallet_new(struct lightningd *ld, struct timers *timers)
 
 	db_begin_transaction(wallet->db);
 
+	trace_span_start("load_indexes", wallet);
+	load_indexes(wallet->db, ld->indexes);
+	trace_span_end(wallet);
+
 	trace_span_start("invoices_new", wallet);
 	wallet->invoices = invoices_new(wallet, wallet, timers);
 	trace_span_end(wallet);
 
 	trace_span_start("outpointfilters_init", wallet);
 	outpointfilters_init(wallet);
-	load_indexes(wallet->db, ld->indexes);
 	trace_span_end(wallet);
 
 	db_commit_transaction(wallet->db);


### PR DESCRIPTION
We need to set up indexes and ld->wallet before expiring invoices at startup, otherwise we can get a null dereference when invoice startup expires invoices immediately:

```
0x7f271a18d08f ??? /build/glibc-SzIz7B/glibc-2.31/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
0x5581a27dc082 wait_index_increment lightningd/wait.c:112
0x5581a27e331a invoice_index_inc wallet/invoices.c:738
0x5581a27e3dfe invoice_index_update_status wallet/invoices.c:775
0x5581a27e3ea3 trigger_expiration wallet/invoices.c:185
0x5581a27e3f47 invoices_new wallet/invoices.c:134
0x5581a27e8a2c wallet_new wallet/wallet.c:121
0x5581a27b08b5 main lightningd/lightningd.c:1082
```

Fixes: #6457
Changelog-None: introduced in master