### PR TITLE
channeld: don't backtrace if master closes during sync read.

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1023,7 +1023,7 @@ static u8 *master_wait_sync_reply(const tal_t *ctx,
 
 		reply = wire_sync_read(ctx, MASTER_FD);
 		if (!reply)
-			status_failed(STATUS_FAIL_INTERNAL_ERROR,
+			status_failed(STATUS_FAIL_MASTER_IO,
 				      "Could not set sync read from master: %s",
 				      strerror(errno));
 		type = fromwire_peektype(reply);


### PR DESCRIPTION
STATUS_FAIL_MASTER_IO is correct here (and what we use elsewhere): STATUS_FAIL_INTERNAL_ERR prints a worrying backtrace:

```
0x5606a2992bdf send_backtrace
        common/daemon.c:33
0x5606a299ccab status_failed
        common/status.c:221
0x5606a297f4f1 master_wait_sync_reply
        channeld/channeld.c:978
0x5606a29826ef send_commit
        channeld/channeld.c:1379
0x5606a299d06a timer_expired
        common/timeout.c:62
0x5606a2984fcd main
        channeld/channeld.c:4046
0x7fd97dd9ed8f __libc_start_call_main
        ../sysdeps/nptl/libc_start_call_main.h:58
0x7fd97dd9ee3f __libc_start_main_impl
        ../csu/libc-start.c:392
0x5606a297e724 ???
        ???:0
0xffffffffffffffff ???
        ???:0
```

Fixes: #6221
Reported-by: https://github.com/joelklabo