### PR TITLE
CCAN: update for base64 compile fix on ARM.

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2575-g3beff01a
+CCAN version: init-2577-g1ae4c432

--- a/ccan/ccan/base64/base64.c
+++ b/ccan/ccan/base64/base64.c
@@ -31,7 +31,7 @@ static int8_t sixbit_from_b64(const base64_maps_t *maps,
 	int8_t ret;
 
 	ret = maps->decode_map[(unsigned char)b64letter];
-	if (ret == (char)0xff) {
+	if (ret == (int8_t)'\xff') {
 		errno = EDOM;
 		return -1;
 	}
@@ -41,7 +41,7 @@ static int8_t sixbit_from_b64(const base64_maps_t *maps,
 
 bool base64_char_in_alphabet(const base64_maps_t *maps, const char b64char)
 {
-	return (maps->decode_map[(const unsigned char)b64char] != (char)0xff);
+	return (maps->decode_map[(const unsigned char)b64char] != (signed char)'\xff');
 }
 
 void base64_init_maps(base64_maps_t *dest, const char src[64])


### PR DESCRIPTION
```
ccan/ccan/base64/base64.c:34:10: error: result of comparison of constant 255 with expression of type 'int8_t' (aka 'signed char') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
        if (ret == (char)0xff) {
            ~~~ ^  ~~~~~~~~~~
ccan/ccan/base64/base64.c:44:57: error: result of comparison of constant 255 with expression of type 'const signed char' is always true [-Werror,-Wtautological-constant-out-of-range-compare]
        return (maps->decode_map[(const unsigned char)b64char] != (char)0xff);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~
```

Reported-by: Christian Decker