### PR TITLE
channeld: replace `struct splice` with `struct splicing` for OpenBSD.

### DIFF
--- a/channeld/splice.c
+++ b/channeld/splice.c
@@ -17,21 +17,21 @@ struct splice_state *splice_state_new(const tal_t *ctx)
 	return splice_state;
 }
 
-struct splice *splice_new(const tal_t *ctx)
+struct splicing *splicing_new(const tal_t *ctx)
 {
-	struct splice *splice = tal(ctx, struct splice);
+	struct splicing *splicing = tal(ctx, struct splicing);
 
-	splice->opener_relative = 0;
-	splice->accepter_relative = 0;
-	splice->feerate_per_kw = 0;
-	splice->force_feerate = false;
-	splice->force_sign_first = false;
-	splice->mode = false;
-	splice->tx_add_input_count = 0;
-	splice->tx_add_output_count = 0;
-	splice->current_psbt = NULL;
-	splice->received_tx_complete = false;
-	splice->sent_tx_complete = false;
+	splicing->opener_relative = 0;
+	splicing->accepter_relative = 0;
+	splicing->feerate_per_kw = 0;
+	splicing->force_feerate = false;
+	splicing->force_sign_first = false;
+	splicing->mode = false;
+	splicing->tx_add_input_count = 0;
+	splicing->tx_add_output_count = 0;
+	splicing->current_psbt = NULL;
+	splicing->received_tx_complete = false;
+	splicing->sent_tx_complete = false;
 
-	return splice;
+	return splicing;
 }

--- a/channeld/splice.h
+++ b/channeld/splice.h
@@ -34,7 +34,7 @@ struct splice_state *splice_state_new(const tal_t *ctx);
 
 /* An active splice negotiation. Born when splice beings and dies when a splice
  * negotation has finished */
-struct splice {
+struct splicing {
 	/* The opener side's relative balance change */
 	s64 opener_relative;
 	/* The accepter side's relative balance change */
@@ -58,6 +58,6 @@ struct splice {
 };
 
 /* Sets `splice` items to default values */
-struct splice *splice_new(const tal_t *ctx);
+struct splicing *splicing_new(const tal_t *ctx);
 
 #endif /* LIGHTNING_CHANNELD_SPLICE_H */


### PR DESCRIPTION
Since it's only for transitory splicing info, the new name makes sense.

```
cc channeld/channeld.c
In file included from channeld/channeld.c:23:
./channeld/splice.h:37:8: error: redefinition of 'splice'
struct splice {
       ^
/usr/include/sys/socket.h:140:8: note: previous definition is here
struct  splice {
        ^
```

Reported-by: @grubles

Fixes: #6486