### PR TITLE
Fix: Remove Sync requirements on Futures returned in the Rust plugin library.

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -104,7 +104,7 @@ where
 impl<S, I, O> Builder<S, I, O>
 where
     O: Send + AsyncWrite + Unpin + 'static,
-    S: Clone + Sync + Send + Clone + 'static,
+    S: Clone + Sync + Send + 'static,
     I: AsyncRead + Send + Unpin + 'static,
 {
     pub fn new(input: I, output: O) -> Self {
@@ -146,7 +146,7 @@ where
     where
         C: Send + Sync + 'static,
         C: Fn(Plugin<S>, Request) -> F + 'static,
-        F: Future<Output = Result<(), Error>> + Send + Sync + 'static,
+        F: Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.subscriptions.insert(
             topic.to_string(),
@@ -162,7 +162,7 @@ where
     where
         C: Send + Sync + 'static,
         C: Fn(Plugin<S>, Request) -> F + 'static,
-        F: Future<Output = Response> + Send + Sync + 'static,
+        F: Future<Output = Response> + Send + 'static,
     {
         self.hooks.insert(
             hookname.to_string(),
@@ -179,7 +179,7 @@ where
     where
         C: Send + Sync + 'static,
         C: Fn(Plugin<S>, Request) -> F + 'static,
-        F: Future<Output = Response> + Send + Sync + 'static,
+        F: Future<Output = Response> + Send + 'static,
     {
         self.rpcmethods.insert(
             name.to_string(),
@@ -504,7 +504,7 @@ where
 
 impl<S> PluginDriver<S>
 where
-    S: Send + Clone + Sync,
+    S: Send + Clone,
 {
     /// Run the plugin until we get a shutdown command.
     async fn run<I, O>(


### PR DESCRIPTION
See: https://github.com/bitcoindevkit/bdk/issues/1047#issuecomment-1660645669

In general, futures produced by most libraries in the ecosystem of Rust, and bounds placed on users of famous runtimes like tokio and its spawn method all lack Sync requirements.

Because of this, anyone who creates a callback using any sort of library that returns a non-Sync future (which most libraries fit this description) inside of it will get some cryptic error messages (async error messages still leave a lot to be desired).

Removing these Sync requirements will make the library more useful.