### PR TITLE
meta: Adjust `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,5 @@ contrib/pyln-testing/   @cdecker
 # Needed to ensure hsmd wire compatibility between releases
 hsmd/hsmd_wire.csv      @cdecker
 
-wallet/invoices.*          @ZmnSCPxj
-plugins/multifundchannel.c @ZmnSCPxj
-doc/BACKUP.md              @ZmnSCPxj
-
 # See https://help.github.com/articles/about-codeowners/ for more
 # information

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ contrib/msggen/         @cdecker
 contrib/pyln-client/    @cdecker
 contrib/pyln-testing/   @cdecker
 # Needed to ensure hsmd wire compatibility between releases
-hsmd/hsmd_wire.csv      @cdecker
+hsmd/hsmd_wire.csv      @cdecker @ksedgwic @devrandom
 
 # See https://help.github.com/articles/about-codeowners/ for more
 # information


### PR DESCRIPTION
The VLS team have asked to be pinged whenever there is a breaking change in the signer interface, and this is a good first approximation. I'll try to stay on top of other breaking changes and ping them accordingly.

Changelog-None