### PR TITLE
renepay: Use macros instead of manual format types

### DIFF
--- a/plugins/renepay/pay.c
+++ b/plugins/renepay/pay.c
@@ -877,9 +877,9 @@ payment_listsendpays_previous(
 
 		plugin_log(pay_plugin->plugin,LOG_DBG,
 			   "There are pending sendpays to this invoice. "
-			   "groupid = %ld, "
+			   "groupid = %"PRIu64" "
 			   "delivering = %s, "
-			   "last_partid = %ld",
+			   "last_partid = %"PRIu64,
 			   last_pending_group_id,
 			   type_to_string(tmpctx,struct amount_msat,&p->total_delivering),
 			   last_pending_partid);

--- a/plugins/renepay/pay_flow.h
+++ b/plugins/renepay/pay_flow.h
@@ -51,7 +51,7 @@ static inline const char* fmt_payflow_key(
 {
 	char *str = tal_fmt(
 		ctx,
-		"key: groupid=%ld, partid=%ld, payment_hash=%s",
+		"key: groupid=%"PRIu64", partid=%"PRIu64", payment_hash=%s",
 		k->groupid,k->partid,
 		type_to_string(ctx,struct sha256,k->payment_hash));
 	return str;


### PR DESCRIPTION
Ran into this issue compiling master on Mac

Fixes #6491 