### PR TITLE
splicing: Remove dependency on experimental_dual_fund

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,6 @@ jobs:
             COMPILER: gcc
             TEST_NETWORK: regtest
             DEVELOPER: 1
-            EXPERIMENTAL_DUAL_FUND: 1
             EXPERIMENTAL_SPLICING: 1
     steps:
       - name: Checkout

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1197,8 +1197,6 @@ static char *opt_set_splicing(struct lightningd *ld)
 	feature_set_or(ld->our_features,
 		       take(feature_set_for_feature(NULL,
 						    OPTIONAL_FEATURE(OPT_SPLICE))));
-	/* Splicing requires dual-fund to be enabled */
-	opt_set_dual_fund(ld);
 	return NULL;
 }
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,6 @@ def expected_peer_features(wumbo_channels=False, extra=[]):
         # option_dual_fund
         features += [29]
     if EXPERIMENTAL_SPLICING:
-        features += [29]  # option_dual_fund
         features += [35]  # option_quiesce
         features += [63]  # option_splice
     return hex_bits(features + extra)
@@ -60,7 +59,6 @@ def expected_node_features(wumbo_channels=False, extra=[]):
         # option_dual_fund
         features += [29]
     if EXPERIMENTAL_SPLICING:
-        features += [29]  # option_dual_fund
         features += [35]  # option_quiesce
         features += [63]  # option_splice
     return hex_bits(features + extra)


### PR DESCRIPTION
Splicing should work automatically on v1 or v2 channels so this requirement isn’t needed.

Changelog-None