### PR TITLE
renepay: fix issue 6493

### DIFF
--- a/plugins/renepay/pay.c
+++ b/plugins/renepay/pay.c
@@ -186,7 +186,7 @@ static struct command_result *handle_unhandleable_error(struct renepay * renepay
 
 	if (n == 1)
 	{
-		payflow_fail(flow);
+		// payflow_fail(flow);
 		return renepay_fail(renepay, PAY_UNPARSEABLE_ONION,
 				    "Got %s from the destination", what);
 	}
@@ -225,7 +225,7 @@ static struct command_result *addgossip_done(struct command *cmd,
 
 	/* Release this: if it's the last flow we'll retry immediately */
 
-	payflow_fail(adg->flow);
+	// payflow_fail(adg->flow);
 	tal_free(adg);
 	renepay_settimer(renepay);
 
@@ -386,7 +386,7 @@ static struct command_result *flow_sendpay_failed(struct command *cmd,
 	 * We just disable this scid. */
 	tal_arr_expand(&renepay->disabled, flow->path_scids[0]);
 
-	payflow_fail(flow);
+	// payflow_fail(flow);
 	return command_still_pending(cmd);
 }
 
@@ -1727,6 +1727,11 @@ static struct command_result *notification_sendpay_failure(
 			"sendpay_failure does not correspond to a renepay attempt, %s",
 			fmt_payflow_key(tmpctx,&key));
 		goto done;
+	}else
+	{
+		// mark for failure
+		tal_add_destructor(flow,payflow_fail);
+		flow = tal_steal(tmpctx,flow);
 	}
 
 	// 3. process failure
@@ -1739,7 +1744,6 @@ static struct command_result *notification_sendpay_failure(
 		handle_sendpay_failure_renepay(cmd,buf,resulttok,renepay,flow);
 
 	done:
-	if(flow) payflow_fail(flow);
 	return notification_handled(cmd);
 }
 

--- a/plugins/renepay/pay_flow.c
+++ b/plugins/renepay/pay_flow.c
@@ -623,7 +623,7 @@ struct amount_msat payflow_delivered(const struct pay_flow *flow)
 	return flow->amounts[tal_count(flow->amounts)-1];
 }
 
-struct pay_flow* payflow_fail(struct pay_flow *flow)
+void payflow_fail(struct pay_flow *flow)
 {
 	debug_assert(flow);
 	struct payment * p = flow->payment;
@@ -632,9 +632,6 @@ struct pay_flow* payflow_fail(struct pay_flow *flow)
 	payment_fail(p);
 	amount_msat_reduce(&p->total_delivering, payflow_delivered(flow));
 	amount_msat_reduce(&p->total_sent, flow->amounts[0]);
-
-	/* Release the HTLCs in the uncertainty_network. */
-	return tal_free(flow);
 }
 
 

--- a/plugins/renepay/pay_flow.h
+++ b/plugins/renepay/pay_flow.h
@@ -107,6 +107,6 @@ struct amount_msat payflow_delivered(const struct pay_flow *flow);
 /* Removes amounts from payment and frees flow pointer.
  * A possible destructor for flow would remove HTLCs from the
  * uncertainty_network and remove the flow from any data structure. */
-struct pay_flow* payflow_fail(struct pay_flow *flow);
+void payflow_fail(struct pay_flow *flow);
 
 #endif /* LIGHTNING_PLUGINS_RENEPAY_PAY_FLOW_H */

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -4,7 +4,6 @@ from utils import only_one, wait_for, mine_funding_to_announce, sync_blockheight
 import pytest
 import random
 import time
-import json
 
 
 def test_simple(node_factory):
@@ -285,18 +284,10 @@ def test_hardmpp(node_factory):
     start_channels([(l1, l2, 10000000), (l2, l4, 3000000), (l4, l6, 10000000),
                     (l1, l3, 10000000), (l3, l5, 1000000), (l5, l6, 10000000)])
 
-    with open('/tmp/l1-chans.txt', 'w') as f:
-        print(json.dumps(l1.rpc.listchannels()), file=f)
-
     inv = l4.rpc.invoice('any', 'any', 'description')
     l2.rpc.call('pay', {'bolt11': inv['bolt11'], 'amount_msat': 2000000000})
     l2.wait_for_htlcs()
     assert l4.rpc.listinvoices()["invoices"][0]["amount_received_msat"] == 2000000000
-
-    with open('/tmp/l2-peerchan.txt', 'w') as f:
-        print(json.dumps(l2.rpc.listpeerchannels()), file=f)
-    with open('/tmp/l3-peerchan.txt', 'w') as f:
-        print(json.dumps(l3.rpc.listpeerchannels()), file=f)
 
     inv2 = l6.rpc.invoice("1800000sat", "inv2", 'description')
     l1.rpc.call(


### PR DESCRIPTION
`handle_sendpay_fail` has a very complicated logic, this was leading to multiple calls to `payflow_fail`.
Fix by adding `payflow_fail` as destructor and the flow is allocated in `tmpctx`.

(hopefully) Solves issue #6493 