### PR TITLE
makefile: py plugins installed twice with `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -799,7 +799,7 @@ install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $
 	$(INSTALL_PROGRAM) $(BIN_PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(PKGLIBEXEC_PROGRAMS) $(DESTDIR)$(pkglibexecdir)
 	[ -z "$(PLUGINS)" ] || $(INSTALL_PROGRAM) $(PLUGINS) $(DESTDIR)$(plugindir)
-	for PY in $(PY_PLUGINS); do DIR=`dirname $$PY`; DST=$(DESTDIR)$(plugindir)/`basename $$DIR`; $(INSTALL_PROGRAM) -d $$DIR; cp -a $$DIR $$DST ; done
+	for PY in $(PY_PLUGINS); do DIR=`dirname $$PY`; DST=$(DESTDIR)$(plugindir)/`basename $$DIR`; if [ -d $$DST ]; then rm -rf $$DST; fi; $(INSTALL_PROGRAM) -d $$DIR; cp -a $$DIR $$DST ; done
 
 MAN1PAGES = $(filter %.1,$(MANPAGES))
 MAN5PAGES = $(filter %.5,$(MANPAGES))


### PR DESCRIPTION
Steps to Reproduce: Run `sudo make install` then again `sudo make install` without uninstalling plugins in between. First command will install the plugin at `/usr/local/libexec/c-lightning/plugins/clnrest` as expected but the second command will install it inside the first folder like `/usr/local/libexec/c-lightning/plugins/clnrest/clnrest`.

Fix: Check and delete if the folder already exists.