### PR TITLE
use `%zu` format specifier for `size_t` values

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3349,7 +3349,7 @@ static void resume_splice_negotiation(struct peer *peer,
 
 	if (tal_count(inws) > current_psbt->num_inputs)
 		peer_failed_warn(peer->pps, &peer->channel_id,
-				 "%lu too many witness elements received",
+				 "%zu too many witness elements received",
 				 tal_count(inws) - current_psbt->num_inputs);
 
 	/* We put the PSBT + sigs all together */

--- a/common/test/run-codex32.c
+++ b/common/test/run-codex32.c
@@ -425,7 +425,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < ARRAY_SIZE(addr_invalid1); i++) {
 		parts = codex32_decode(tmpctx, NULL, addr_invalid1[i], &fail);
 		if (parts) {
-			printf("payload ==  %ld\n", tal_bytelen(parts->payload));
+			printf("payload ==  %zu\n", tal_bytelen(parts->payload));
 			abort();
 		} else {
 			assert(streq(fail, "Invalid checksum!") ||
@@ -473,7 +473,7 @@ int main(int argc, char *argv[])
 	for (size_t i = 0; i < ARRAY_SIZE(addr_invalid2); i++) {
 		parts = codex32_decode(tmpctx, NULL, addr_invalid2[i], &fail);
 		if (parts) {
-			printf("payload %ld\n", tal_bytelen(parts->payload));
+			printf("payload %zu\n", tal_bytelen(parts->payload));
 			abort();
 		} else {
 			assert(streq(fail, "Invalid payload!") ||

--- a/plugins/renepay/test/run-payflow_map.c
+++ b/plugins/renepay/test/run-payflow_map.c
@@ -69,8 +69,8 @@ static void valgrind_ok1(void)
 
 		printf("key1 = %s\n",fmt_payflow_key(local_ctx,&p1->key));
 		printf("key1 = %s\n",fmt_payflow_key(local_ctx,&p2->key));
-		printf("key hash 1 = %ld\n",payflow_key_hash(p1->key));
-		printf("key hash 2 = %ld\n",payflow_key_hash(p2->key));
+		printf("key hash 1 = %zu\n",payflow_key_hash(p1->key));
+		printf("key hash 2 = %zu\n",payflow_key_hash(p2->key));
 
 		payflow_map_add(map,p1); tal_add_destructor2(p1,destroy_payflow,map);
 		payflow_map_add(map,p2); tal_add_destructor2(p2,destroy_payflow,map);


### PR DESCRIPTION
`%lu` is inappropriate on 32-bit ARM systems, which define `size_t` as `unsigned int`, not as `unsigned long`.

`%ld` is inappropriate everywhere, as `size_t` is an unsigned type.