### PR TITLE
Disconnect on channeld death due to HTLC addition timeout

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3641,7 +3641,6 @@ def test_close_weight_estimate(node_factory, bitcoind):
     assert signed_weight + 6 >= final_estimate  # 70byte signature
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("needs dev_disconnect")
 def test_onchain_close_upstream(node_factory, bitcoind):
     """https://github.com/ElementsProject/lightning/issues/4649

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3641,6 +3641,7 @@ def test_close_weight_estimate(node_factory, bitcoind):
     assert signed_weight + 6 >= final_estimate  # 70byte signature
 
 
+@pytest.mark.xfail(strict=True)
 @pytest.mark.developer("needs dev_disconnect")
 def test_onchain_close_upstream(node_factory, bitcoind):
     """https://github.com/ElementsProject/lightning/issues/4649
@@ -3676,6 +3677,10 @@ We send an HTLC, and peer unilaterally closes: do we close upstream?
 
     with pytest.raises(RpcError, match=r'WIRE_TEMPORARY_CHANNEL_FAILURE \(reply from remote\)'):
         l1.rpc.waitsendpay(ph2, timeout=TIMEOUT)
+
+    # An important response to the timeout is to force a reconnect,
+    # since the problem may be TCP connectivity.
+    assert only_one(l2.rpc.listpeerchannels(l3.info['id'])['channels'])['peer_connected'] is False
 
     # Make close unilaterally.
     l3.rpc.close(l2.info['id'], 1)


### PR DESCRIPTION
This can be cause by TCP/Tor silently disconnecting so we don't receive messages, so it's best to force a reconnect.

Fixes: #6506 