### PR TITLE
plugins: fix error report from bitcoin-cli exec failure.

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -298,15 +298,15 @@ static void next_bcli(enum bitcoind_prio prio)
 
 	bcli->pid = pipecmdarr(&in, &bcli->fd, &bcli->fd,
 			       cast_const2(char **, bcli->args));
+	if (bcli->pid < 0)
+		plugin_err(bcli->cmd->plugin, "%s exec failed: %s",
+			   bcli->args[0], strerror(errno));
+
 
 	if (bitcoind->rpcpass)
 		write_all(in, bitcoind->rpcpass, strlen(bitcoind->rpcpass));
 
 	close(in);
-
-	if (bcli->pid < 0)
-		plugin_err(bcli->cmd->plugin, "%s exec failed: %s",
-			   bcli->args[0], strerror(errno));
 
 	bcli->start = time_now();
 


### PR DESCRIPTION
We've stomped errno, so if exec fails we don't get a reliable result:

```
2023-08-07T17:58:45.713Z **BROKEN** plugin-bcli: bitcoin-cli exec failed: Bad file descriptor
```

See: #6529