### PR TITLE
gossipd: ignore redundant node_announcement in gossip_store.

### DIFF
--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -926,8 +926,9 @@ u32 gossip_store_load(struct routing_state *rstate, struct gossip_store *gs)
 			if (!routing_add_node_announcement(rstate,
 							   take(msg), gs->len,
 							   NULL, NULL, spam)) {
-				bad = "Bad node_announcement";
-				goto badmsg;
+				/* FIXME: This has been reported: routing.c
+				 * has logged, so ignore. */
+				break;
 			}
 			stats[2]++;
 			break;


### PR DESCRIPTION
Don't know how this is happening, but it is not harmful to ignore it for now.

Fixes: #6531
Changelog-None