### PR TITLE
Double nannounce patch

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2385,7 +2385,6 @@ def test_dump_own_gossip(node_factory):
     assert expect == []
 
 
-@pytest.mark.xfail
 @pytest.mark.developer("needs --dev-gossip-time")
 @unittest.skipIf(
     TEST_NETWORK != 'regtest',


### PR DESCRIPTION
When loading from the gossip store under a particular scenario:
   channel announcement
   node announcement
   node announcement (spam)
   channel update
There should be two node announcements pending the first channel update.  This case was not handled and the spam announcement was overwriting the broadcastable announcement causing gossipd to lose track of it.  The answer is to properly load the spam announcement alongside the broadcastable one once the channel is created.

Fixes: #6531