### PR TITLE
pay: still use channels for routehints even if peer says it's disabled.

### DIFF
--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -566,10 +566,12 @@ static struct command_result *json_listincoming(struct command *cmd,
 		const u8 *peer_features;
 
 		ourchan = gossmap_nth_chan(gossmap, me, i, &dir);
-		/* If its half is disabled, ignore. */
-		if (!ourchan->half[!dir].enabled)
+		/* Entirely missing?  Ignore. */
+		if (ourchan->cupdate_off[!dir] == 0)
 			continue;
-
+		/* We used to ignore if the peer said it was disabled,
+		 * but we have a report of LND telling us our unannounced
+		 * channel is disabled, so we still use them. */
 		peer = gossmap_nth_node(gossmap, ourchan, !dir);
 		scid = gossmap_chan_scid(gossmap, ourchan);
 


### PR DESCRIPTION
We have a report that LND said our (unannounced) channel was disabled, so we didn't use it for routehints.  We're better off ignoring that in this case (if the peer is actually not connected, the routehint code will check that and ignore anyway).

Fixes: #6555
Changelog-Changed: pay: use channels in routehints even if peer says they're "disabled" (LND compat)
