### PR TITLE
splice: prevent splice going to onchaind & race prevention

### DIFF
--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -176,6 +176,7 @@ new_inflight(struct channel *channel,
 	inflight->lease_amt = lease_amt;
 
 	inflight->i_am_initiator = i_am_initiator;
+	inflight->splice_locked_memonly = false;
 
 	list_add_tail(&channel->inflights, &inflight->list);
 	tal_add_destructor(inflight, destroy_inflight);

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -63,6 +63,16 @@ struct channel_inflight {
 
 	/* Did I initate this splice attempt? */
 	bool i_am_initiator;
+
+	/* Note: This field is not stored in the database.
+	 *
+	 * After splice_locked, we need a way to stop the chain watchers from
+	 * thinking the old channel was spent.
+	 *
+	 * Leaving the inflight in memory-only with splice_locked true leaves
+	 * moves the responsiblity of cleaning up the inflight to the watcher,
+	 * avoiding any potential race conditions. */
+	bool splice_locked_memonly;
 };
 
 struct open_attempt {

--- a/tests/test_splicing.py
+++ b/tests/test_splicing.py
@@ -2,6 +2,7 @@ from fixtures import *  # noqa: F401,F403
 from utils import TEST_NETWORK
 import pytest
 import unittest
+import time
 
 
 @pytest.mark.openchannel('v1')
@@ -34,3 +35,7 @@ def test_splice(node_factory, bitcoind):
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
+
+    # Check that the splice doesn't generate a unilateral close transaction
+    time.sleep(5)
+    assert l1.db_query("SELECT count(*) as c FROM channeltxs;")[0]['c'] == 0

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2323,7 +2323,8 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 	/* Update the inflights also */
 	struct channel_inflight *inflight;
 	list_for_each(&chan->inflights, inflight, list)
-		wallet_inflight_save(w, inflight);
+		if (!inflight->splice_locked_memonly)
+			wallet_inflight_save(w, inflight);
 
 	db_bind_talarr(stmt, last_sent_commit);
 	db_bind_u64(stmt, chan->dbid);


### PR DESCRIPTION
Don’t send the funding spend to onchaind if we detect it in inflights (aka. a splice). While we already prevented onchaind_funding_spent from being called directly, the call to wallet_channeltxs_add meant onchaind_funding_spent would be called *anyway* on restart. This is now fixed.

Additionally there was a potential for a race problem depending on the firing order of the channel depth and and funding spent events.

Instead of requiring these events fire in a specific order, we make a special “memory only” inflight object to prevent the race regardless of firing order.

Fixes #6533