### PR TITLE
cli: don't crash when there's no argument

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -650,7 +650,7 @@ int main(int argc, char *argv[])
 	jsmntok_t *toks;
 	const jsmntok_t *result, *error, *id;
 	const tal_t *ctx = tal(NULL, char);
-	char *net_dir, *rpc_filename;
+	char *config_filename, *base_dir, *net_dir, *rpc_filename;
 	jsmn_parser parser;
 	int parserr;
 	enum format format = DEFAULT_FORMAT;
@@ -668,7 +668,8 @@ int main(int argc, char *argv[])
 	setup_option_allocators();
 
 	opt_exitcode = ERROR_USAGE;
-	minimal_config_opts(ctx, argc, argv, &net_dir, &rpc_filename);
+	minimal_config_opts(ctx, argc, argv, &config_filename, &base_dir,
+			    &net_dir, &rpc_filename);
 
 	opt_register_noarg("--help|-h", opt_usage_and_exit,
 			   "<command> [<params>...]", "Show this message. Use the command help (without hyphens -- \"lightning-cli help\") to get a list of all RPC commands");

--- a/common/configdir.c
+++ b/common/configdir.c
@@ -281,16 +281,18 @@ static struct configvar **gather_cmdline_args(const tal_t *ctx,
 
 void minimal_config_opts(const tal_t *ctx,
 			 int argc, char *argv[],
+			 char **config_filename,
+			 char **basedir,
 			 char **config_netdir,
 			 char **rpc_filename)
 {
-	char *unused_filename, *unused_basedir;
-
 	initial_config_opts(tmpctx, &argc, argv, false,
-			    &unused_filename,
-			    &unused_basedir,
+			    config_filename,
+			    basedir,
 			    config_netdir,
 			    rpc_filename);
+	tal_steal(ctx, *config_filename);
+	tal_steal(ctx, *basedir);
 	tal_steal(ctx, *config_netdir);
 	tal_steal(ctx, *rpc_filename);
 }

--- a/common/configdir.h
+++ b/common/configdir.h
@@ -15,6 +15,8 @@ void setup_option_allocators(void);
 /* Minimal config parsing for tools: use opt_early_parse/opt_parse after */
 void minimal_config_opts(const tal_t *ctx,
 			 int argc, char *argv[],
+			 char **config_filename,
+			 char **basedir,
 			 char **config_netdir,
 			 char **rpc_filename);
 

--- a/devtools/checkchannels.c
+++ b/devtools/checkchannels.c
@@ -109,6 +109,7 @@ static void copy_column(void *dst, size_t size,
 
 int main(int argc, char *argv[])
 {
+	char *config_filename, *base_dir;
 	char *net_dir, *rpc_filename, *hsmfile, *dbfile;
 	sqlite3 *sql;
 	sqlite3_stmt *stmt;
@@ -124,7 +125,8 @@ int main(int argc, char *argv[])
 
 	setup_option_allocators();
 
-	minimal_config_opts(top_ctx, argc, argv, &net_dir, &rpc_filename);
+	minimal_config_opts(top_ctx, argc, argv, &config_filename, &base_dir,
+			    &net_dir, &rpc_filename);
 
 	opt_register_noarg("-v|--verbose", opt_set_bool, &verbose,
 			 "Print everything");

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1195,6 +1195,13 @@ def test_daemon_option(node_factory):
         assert 'No child process' not in f.read()
 
 
+def test_cli_no_argument():
+    """If no arguments are provided, should display help and exit."""
+    out = subprocess.run(['cli/lightning-cli'], stdout=subprocess.PIPE)
+    assert out.returncode in [0, 2]  # returns 2 if lightning-rpc not available
+    assert "Usage: cli/lightning-cli <command> [<params>...]" in out.stdout.decode()
+
+
 @pytest.mark.developer("needs DEVELOPER=1")
 def test_blockchaintrack(node_factory, bitcoind):
     """Check that we track the blockchain correctly across reorgs


### PR DESCRIPTION
This should provide the default help message and exit, but freeing pointers passed to the default config setup lead to a segmentation fault when help tries to provide usage and triggers the callback.

```
Program received signal SIGSEGV, Segmentation fault.
__strlen_generic () at ../sysdeps/aarch64/multiarch/../strlen.S:98
98	../sysdeps/aarch64/multiarch/../strlen.S: No such file or directory.
(gdb) bt
#0  __strlen_generic () at ../sysdeps/aarch64/multiarch/../strlen.S:98
#1  0x000000555555b9f0 in opt_show_charp (
    buf=0x7ffffff0a0 "\"Usage: /usr/local/bin/lightning-cli <command> [<params>...]\n--conf=<file>     \"...", len=80, p=0x7ffffff150)
    at ccan/ccan/opt/helpers.c:216
#2  0x000000555555d9b4 in add_desc (
    base=0x555557dff8 "Usage: /usr/local/bin/lightning-cli <command> [<params>...]\n--conf=<file>", ' ' <repeats 13 times>, "Specify configuration file\n", ' ' <repeats 27 times>, "(default: \"Usage: /usr/local/bin/lightning-cli <command> [<p"..., len=0x7ffffff130, 
    max=0x7ffffff128, indent=26, width=137, opt=0x555557dbd0) at ccan/ccan/opt/usage.c:154
#3  0x000000555555df5c in opt_usage (argv0=0x7ffffff687 "/usr/local/bin/lightning-cli", extra=0x55555659b0 "<command> [<params>...]")
    at ccan/ccan/opt/usage.c:232
#4  0x0000005555554674 in main (argc=1, argv=0x7ffffff448) at cli/lightning-cli.c:705
```

Changelog-Fixed: lightning-cli properly returns help without argument