### PR TITLE
gossmap: fix false valgrind uninitialized error on arm64, ppc.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -318,9 +318,14 @@ static u32 init_chan_arr(struct gossmap_chan *chan_arr, size_t start)
 	for (i = start; i < tal_count(chan_arr) - 1; i++) {
 		chan_arr[i].cann_off = i + 1;
 		chan_arr[i].plus_scid_off = 0;
+		/* We don't need to initialize this, *but* on some platforms
+		 * (ppc, arm64) valgrind complains: this is a bitfield shared
+		 * with plus_scid_off */
+		chan_arr[i].private = false;
 	}
 	chan_arr[i].cann_off = UINT_MAX;
 	chan_arr[i].plus_scid_off = 0;
+	chan_arr[i].private = false;
 	return start;
 }
 


### PR DESCRIPTION
Doesn't happen on x86, but struct gossmap_chan defines:

```
	u32 private: 1;
	u32 plus_scid_off: 31;
```

And complains when we initialize plus_scid_off and access it later:

```
VALGRIND=1 valgrind -q --error-exitcode=7 --track-origins=yes --leak-check=full --show-reachable=yes --errors-for-leak-kinds=all plugins/renepay/test/run-mcf > /dev/null
==186886== Conditional jump or move depends on uninitialised value(s)
==186886==    at 0x10076388: chan_iter (gossmap.c:1098)
==186886==    by 0x100797F3: gossmap_next_chan (gossmap.c:1112)
==186886==    by 0x1008C5AF: main (run-mcf.c:309)
==186886==  Uninitialised value was created by a heap allocation
==186886==    at 0x40F0A44: malloc (vg_replace_malloc.c:431)
==186886==    by 0x10072BAF: allocate (tal.c:256)
==186886==    by 0x100737A7: tal_alloc_ (tal.c:463)
==186886==    by 0x100738DF: tal_alloc_arr_ (tal.c:506)
==186886==    by 0x10079507: load_gossip_store (gossmap.c:690)
==186886==    by 0x10079667: gossmap_load (gossmap.c:978)
==186886==    by 0x1008C4AF: main (run-mcf.c:295)
```

Reported-by: @grubles

Fixes: #6557