### PR TITLE
openingd: Defer zeroconf check until we called the `openchannel` hook

### DIFF
--- a/common/channel_type.c
+++ b/common/channel_type.c
@@ -142,8 +142,7 @@ struct channel_type *channel_type_from(const tal_t *ctx,
 struct channel_type *channel_type_accept(const tal_t *ctx,
 					 const u8 *t,
 					 const struct feature_set *our_features,
-					 const u8 *their_features,
-					 bool accept_zeroconf)
+					 const u8 *their_features)
 {
 	struct channel_type *ctype, proposed;
 	/* Need to copy since we're going to blank variant bits for equality. */
@@ -182,15 +181,6 @@ struct channel_type *channel_type_accept(const tal_t *ctx,
 				return NULL;
 		}
 	}
-
-	/* BOLT #2:
-	 * The receiving node MUST fail the channel if:
-	 *...
-	 *     - if `type` includes `option_zeroconf` and it does not trust the
-	 *       sender to open an unconfirmed channel.
-	 */
-	if (feature_is_set(t, OPT_ZEROCONF) && !accept_zeroconf)
-		return NULL;
 
 	/* Blank variants so we can just check for equality. */
 	for (size_t i = 0; i< ARRAY_SIZE(variants); i++)

--- a/common/channel_type.h
+++ b/common/channel_type.h
@@ -42,8 +42,7 @@ bool channel_type_eq(const struct channel_type *a,
 struct channel_type *channel_type_accept(const tal_t *ctx,
 					 const u8 *t,
 					 const struct feature_set *our_features,
-					 const u8 *their_features,
-					 bool accept_zeroconf);
+					 const u8 *their_features);
 
 /* Return an array of feature strings indicating channel type. */
 const char **channel_type_name(const tal_t *ctx, const struct channel_type *t);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -725,7 +725,8 @@ openchannel_hook_final(struct openchannel_hook_payload *payload STEALS)
 		      take(towire_openingd_got_offer_reply(NULL, errmsg,
 							   our_upfront_shutdown_script,
 							   upfront_shutdown_script_wallet_index,
-							   payload->uc->reserve)));
+							   payload->uc->reserve,
+							   payload->uc->minimum_depth)));
 }
 
 static bool

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -2259,8 +2259,7 @@ static void accepter_start(struct state *state, const u8 *oc2_msg)
 			channel_type_accept(state,
 					    open_tlv->channel_type,
 					    state->our_features,
-					    state->their_features,
-					    state->minimum_depth == 0);
+					    state->their_features);
 		if (!state->channel_type) {
 			negotiation_failed(state,
 					   "Did not support channel_type %s",

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -965,16 +965,9 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	 */
 	if (open_tlvs->channel_type) {
 		open_channel_had_channel_type = true;
-		/* Tentatively accept OPT_ZEROCONF. We'll check
-		 * further down again. This is required because we
-		 * haven't talked to the openchannel hook at this
-		 * point. */
-		state->channel_type =
-			channel_type_accept(state,
-					    open_tlvs->channel_type,
-					    state->our_features,
-					    state->their_features,
-					    true);
+		state->channel_type = channel_type_accept(
+		    state, open_tlvs->channel_type, state->our_features,
+		    state->their_features);
 		if (!state->channel_type) {
 			negotiation_failed(state,
 					   "Did not support channel_type %s",
@@ -1137,6 +1130,12 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 		return NULL;
 	}
 
+	/* BOLT #2:
+	 * The receiving node MUST fail the channel if:
+	 *...
+	 *     - if `type` includes `option_zeroconf` and it does not trust the
+	 *       sender to open an unconfirmed channel.
+	 */
 	if (channel_type_has(state->channel_type, OPT_ZEROCONF) &&
 	    state->minimum_depth > 0) {
 		negotiation_failed(

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -965,12 +965,16 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	 */
 	if (open_tlvs->channel_type) {
 		open_channel_had_channel_type = true;
+		/* Tentatively accept OPT_ZEROCONF. We'll check
+		 * further down again. This is required because we
+		 * haven't talked to the openchannel hook at this
+		 * point. */
 		state->channel_type =
 			channel_type_accept(state,
 					    open_tlvs->channel_type,
 					    state->our_features,
 					    state->their_features,
-					    state->minimum_depth == 0);
+					    true);
 		if (!state->channel_type) {
 			negotiation_failed(state,
 					   "Did not support channel_type %s",

--- a/openingd/openingd_wire.csv
+++ b/openingd/openingd_wire.csv
@@ -51,6 +51,7 @@ msgdata,openingd_got_offer_reply,shutdown_len,u16,
 msgdata,openingd_got_offer_reply,our_shutdown_scriptpubkey,?u8,shutdown_len
 msgdata,openingd_got_offer_reply,our_shutdown_wallet_index,?u32,
 msgdata,openingd_got_offer_reply,reserve,?amount_sat,
+msgdata,openingd_got_offer_reply,mindepth,u32,
 
 #include <common/penalty_base.h>
 # Openingd->master: we've successfully offered channel.


### PR DESCRIPTION
We were rejecting zeroconf channels outright, before checking the return value of the `openchannel` hook, as that was available only slightly later. Between CLN nodes that worked because we don't actually use featurebit 50 in the `channel_type`, making it optional, and we then just send `channel_ready` over when we're... well... ready.

`lnd` on the other hand is explicit in its expectations and actually uses the mandatory zeroconf bit, which we would reject because at the verification time the hooks hadn't been called yet, and therefore we could not possibly know if we'll accept it or not (the default `mindepth=1` meant we never accepted zeroconf right out of the gate).