### PR TITLE
More flake test fixes

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1276,7 +1276,8 @@ static void peer_connected_hook_final(struct peer_connected_hook_payload *payloa
 
 	/* connect appropriate subds for all (active) channels! */
 	list_for_each(&peer->channels, channel, list) {
-		if (channel_active(channel)) {
+		/* FIXME: It can race by opening a channel before this! */
+		if (channel_active(channel) && !channel->owner) {
 			log_debug(channel->log, "Peer has reconnected, state %s: connecting subd",
 				  channel_state_name(channel));
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -469,7 +469,7 @@ def test_plugin_connected_hook_chaining(node_factory):
     try:
         l3.connect(l1)
     except RpcError as err:
-        assert "disconnected during connection" in err.error
+        assert "disconnected during connection" in err.error['message']
 
     l1.daemon.wait_for_logs([
         f"peer_connected_logger_a {l3id}",


### PR DESCRIPTION
1. subd gratuitous restart during tests
2. timeout during autoclean

Sometimes valgrind on these lowend boxes makes things *really* slow cf. our pytest framework...