### PR TITLE
plugins/renepay: don't free waiting-for-addgossip flow!

### DIFF
--- a/plugins/renepay/payment.c
+++ b/plugins/renepay/payment.c
@@ -216,7 +216,8 @@ void payment_reconsider(struct payment *payment)
 			final_msg = tal_steal(tmpctx, i->final_msg);
 			break;
 		case PAY_FLOW_FAILED_GOSSIP_PENDING:
-			break;
+			/* Don't free, it's still going! */
+			continue;
 		case PAY_FLOW_SUCCESS:
 			if (payment->preimage) {
 				/* This should be impossible without breaking SHA256 */


### PR DESCRIPTION
```
Aug 18 13:45:13  lightningd: 0x7fa921f8ffcf ???
Aug 18 13:45:13  lightningd:         ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
Aug 18 13:45:13  lightningd: 0x55b3bb54e6d3 pay_flow_finished_adding_gossip
Aug 18 13:45:13  lightningd:         plugins/renepay/pay_flow.c:675
Aug 18 13:45:13  lightningd: 0x55b3bb54af25 addgossip_done
Aug 18 13:45:13  lightningd:         plugins/renepay/pay.c:171
```

The assert we fail is almost certainly due to the flow being freed:

```
struct pf_result *pay_flow_finished_adding_gossip(struct pay_flow *pf)
{
	assert(pf->state == PAY_FLOW_FAILED_GOSSIP_PENDING);
```

Reported-by: https://github.com/daywalker90
Fixes: #6567