### PR TITLE
renepay: hack in workaround spendable reduction for release.

### DIFF
--- a/plugins/renepay/uncertainty_network.c
+++ b/plugins/renepay/uncertainty_network.c
@@ -326,6 +326,13 @@ bool uncertainty_network_update_from_listpeerchannels(
 						 dir);
 		}
 
+		/* FIXME: There is a bug with us trying to send more down a local
+		 * channel (after fees) than it has capacity.  For now, we reduce
+		 * our capacity by 1% of total, to give fee headroom. */
+		if (!amount_msat_sub(&spendable, spendable,
+				     amount_msat_div(p->amount, 100)))
+			spendable = AMOUNT_MSAT(0);
+
 		// TODO(eduardo): this includes pending HTLC of previous
 		// payments!
 		/* We know min and max liquidity exactly now! */


### PR DESCRIPTION
```
Flow 391: amount=23528000msat prob=0.000 fees=1023msat delay=140 path=-2471854x37x4/1(min=max=23528783msat)->-2414928x98x0/0->
Flow 391: Failure of 23529023msat for 2471854x37x4/1 capacity [23528783msat,23528783msat] -> [23528783msat,23528783msat]
```

We added fees and went over capacity!  This screams of a deeper logic bug, but renepay is experimental and it's release day so hack around it for now...

Reported-by: https://github.com/daywalker90
See: #6599