### PR TITLE
clnrest: Change process method to fork

### DIFF
--- a/plugins/clnrest/clnrest.py
+++ b/plugins/clnrest/clnrest.py
@@ -4,6 +4,7 @@ try:
     import sys
     import os
     import time
+    import multiprocessing
     from gunicorn import glogging  # noqa: F401
     from gunicorn.workers import sync  # noqa: F401
 
@@ -26,6 +27,7 @@ except ModuleNotFoundError as err:
                       'result': {'disable': str(err)}}))
     sys.exit(1)
 
+multiprocessing.set_start_method('fork')
 
 jobs = {}
 app = Flask(__name__)


### PR DESCRIPTION
On mac the clnrest plugin hangs on log messages, causing it to never run.

This guide suggests switching to fork’ing instead of spwan’ing https://superfastpython.com/multiprocessing-common-errors/#Error_2_print_Does_Not_Work_In_Child_Processes

Switching to fork fixes the hang on Mac.

Changelog-None