### PR TITLE
ci: Track flakyness of tests by collecting them on a server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Rebase
         # We can't rebase if we're on master already.
-        if: github.ref == 'refs/heads/master'
+        if: github.ref != 'refs/heads/master'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ env:
   # of a bit of compile time.
   RUST_PROFILE: release
   SLOW_MACHINE: 1
+  CI_SERVER: "http://35.239.136.52:3170"
 
 jobs:
   prebuild:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,74 @@
+import pytest
+import subprocess
+from urllib import request
+import os
+import json
+from time import time
+
+server = os.environ.get("CI_SERVER", None)
+
+github_sha = subprocess.check_output([
+    "git",
+    "rev-parse",
+    "HEAD"
+]).decode('ASCII').strip()
+
+github_ref_name = subprocess.check_output([
+    "git",
+    "rev-parse",
+    "--abbrev-ref",
+    "HEAD"
+]).decode('ASCII').strip()
+
+run_id = os.environ.get("GITHUB_RUN_ID", None)
+run_number = os.environ.get("GITHUB_RUN_NUMBER", None)
+
+result = {
+    "github_repository": os.environ.get("GITHUB_REPOSITORY", None),
+    "github_sha": os.environ.get("GITHUB_SHA", github_sha),
+    "github_ref": os.environ.get("GITHUB_REF", None),
+    "github_ref_name": github_ref_name,
+    "github_run_id": int(run_id) if run_id else None,
+    "github_head_ref": os.environ.get("GITHUB_HEAD_REF", None),
+    "github_run_number": int(run_number) if run_number else None,
+    "github_base_ref": os.environ.get("GITHUB_BASE_REF", None),
+    "github_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", None),
+}
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_pyfunc_call(pyfuncitem):
+    global result
+    result = result.copy()
+    result['testname'] = pyfuncitem.name
+    result['start_time'] = int(time())
+    outcome = yield
+    result['end_time'] = int(time())
+    # outcome.excinfo may be None or a (cls, val, tb) tuple
+
+    if outcome.excinfo is None:
+        result['outcome'] = "success"
+    else:
+        result['outcome'] = "fail"
+
+    print(result)
+
+    if not server:
+        return
+
+    try:
+        req = request.Request(
+            f"{server}/hook/test",
+            method="POST"
+        )
+        req.add_header("Content-Type", "application/json")
+
+        request.urlopen(
+            req,
+            data=json.dumps(result).encode('ASCII'),
+        )
+    except ConnectionError as e:
+        print(f"Could not report testrun: {e}")
+    except Exception as e:
+        import warnings
+        warnings.warn(f"Error reporting testrun: {e}: {e.read()}")


### PR DESCRIPTION
This just adds a simple collection of test metadata (disabled by default, but enabled on CI since we don't want to snoop on devs). This is used to collect the stability or lack thereof (flaky tests) and be able to re-enable the `--force-flaky` flag on CI.

IMHO there is no added value in forcing devs to watch their CI and rerunning failed ones blindly because of flaky tests.

My goal is to track flakyness on `master` as groundtruth, and then open issues to address flaky tests based on that information. We still need to determine what percentage of flakyness is acceptable but we can do so better once we have some real data.

There is some concern that we end up papering over real issues, however I'd argue that training devs to just hit rerun without looking at the issue is worse.