### PR TITLE
plugin/clnrest: do not read json payload if data length is zero

### DIFF
--- a/plugins/clnrest/utilities/rpc_routes.py
+++ b/plugins/clnrest/utilities/rpc_routes.py
@@ -48,7 +48,10 @@ class RpcMethodResource(Resource):
 
         try:
             if request.is_json:
-                payload = request.get_json()
+                if len(request.data) != 0:
+                    payload = request.get_json()
+                else:
+                    payload = {}
             else:
                 payload = request.form.to_dict()
             return call_rpc_method(plugin, rpc_method, payload), 201

--- a/plugins/clnrest/utilities/shared.py
+++ b/plugins/clnrest/utilities/shared.py
@@ -53,7 +53,10 @@ def verify_rune(plugin, request):
         raise Exception('{ "error": {"code": 403, "message": "Not authorized: Missing rune"} }')
 
     if request.is_json:
-        rpc_params = request.get_json()
+        if len(request.data) != 0:
+            rpc_params = request.get_json()
+        else:
+            rpc_params = {}
     else:
         rpc_params = request.form.to_dict()
 


### PR DESCRIPTION
OpenAPI readme always includes `content-type: application/json` header, even when body parameters are empty. But the server expects data if the content-type has been sent. This results in a "Server Error" response for non-param requests from readme doc. This only affects readme requests as it is designed to send the header by default.

Changelog-None