### PR TITLE
lightningd: fix memleak flake when onchaind exits.

### DIFF
--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -372,13 +372,15 @@ static void handle_onchain_htlc_timeout(struct channel *channel, const u8 *msg)
 
 static void handle_irrevocably_resolved(struct channel *channel, const u8 *msg UNUSED)
 {
+	struct subd *onchaind = channel->owner;
+
 	/* FIXME: Implement check_htlcs to ensure no dangling hout->in ptrs! */
 	free_htlcs(channel->peer->ld, channel);
 
 	log_info(channel->log, "onchaind complete, forgetting peer");
 
-	/* This will also free onchaind. */
 	delete_channel(channel);
+	tal_free(onchaind);
 }
 
 


### PR DESCRIPTION
The comment says that freeing the channel will free the subd, but it's wrong! So there's a space between us freeing the channel, and onchaind exiting, which means we temporarily have no reference to onchaind:

```
ERROR tests/test_closing.py::test_onchain_middleman_simple[True] - ValueError:
Node errors:
Global errors:
 - Node /tmp/ltests-7dmxqe4u/test_onchain_middleman_simple_1/lightning-1/ has memory leaks: [
    {
        "backtrace": [
            "ccan/ccan/tal/tal.c:477 (tal_alloc_)",
            "ccan/ccan/io/io.c:91 (io_new_conn_)",
            "lightningd/subd.c:776 (new_subd)",
            "lightningd/subd.c:831 (new_channel_subd_)",
            "lightningd/onchain_control.c:1559 (onchaind_funding_spent)",
            "lightningd/peer_control.c:1977 (funding_spent)",
            "lightningd/watch.c:271 (txowatch_fire)",
            "lightningd/chaintopology.c:83 (filter_block_txs)",
            "lightningd/chaintopology.c:989 (add_tip)",
            "lightningd/chaintopology.c:1082 (get_new_block)",
            "lightningd/bitcoind.c:497 (getrawblockbyheight_callback)",
            "lightningd/plugin.c:593 (plugin_response_handle)",
            "lightningd/plugin.c:704 (plugin_read_json_one)",
            "lightningd/plugin.c:749 (plugin_read_json)",
            "ccan/ccan/io/io.c:59 (next_plan)",
            "ccan/ccan/io/io.c:407 (do_plan)",
            "ccan/ccan/io/io.c:417 (io_ready)",
            "ccan/ccan/io/poll.c:453 (io_loop)",
            "lightningd/io_loop_with_timers.c:22 (io_loop_with_timers)",
            "lightningd/lightningd.c:1332 (main)"
        ],
        "label": "ccan/ccan/io/io.c:91:struct io_conn",
        "parents": [
            "lightningd/lightningd.c:111:struct lightningd"
        ],
        "value": "0x55893d3f7a18"
    }
]
```