### PR TITLE
Add data field to RpcError

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Error, Result};
 use bitcoin::hashes::Hash as BitcoinHash;
 use serde::{Deserialize, Serialize};
 use serde::{Deserializer, Serializer};
+use serde_json::Value;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::string::ToString;
@@ -768,6 +769,7 @@ impl<'de> Deserialize<'de> for Routehint {
 pub struct RpcError {
     pub code: Option<i32>,
     pub message: String,
+    pub data: Option<Value>,
 }
 
 impl Display for RpcError {


### PR DESCRIPTION
Some methods like waitsendpay return important information inside an RpcError's `data` field when called via cli. cln-rpc did not have this field. I added it as a serde_json::Value. We can probably do better with specific Error responses but for now this is an easy fix so i dont have to do
```
 Command::new(lightning_cli)
        .arg("--lightning-dir=".to_string() + lightning_dir.to_str().unwrap())
        .arg("--conf=".to_string() + lightning_conf)
        .arg("waitsendpay")
        .arg((payment_hash).to_string())
        .arg(timeout.to_string())
        .output()
        .await;
```
to get the erroring node and reason from a sendpay.