### PR TITLE
docker: make available bitcoind binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /opt/bitcoin && cd /opt/bitcoin \
     && grep $BITCOIN_TARBALL bitcoin | tee SHA256SUMS \
     && sha256sum -c SHA256SUMS \
     && BD=bitcoin-$BITCOIN_VERSION/bin \
-    && tar -xzvf $BITCOIN_TARBALL $BD/bitcoin-cli --strip-components=1 \
+    && tar -xzvf $BITCOIN_TARBALL $BD/ --strip-components=1 \
     && rm $BITCOIN_TARBALL
 
 ENV LITECOIN_VERSION 0.16.3


### PR DESCRIPTION
The cln-regtest-demo tries to run `bitcoind` but this docker image only contains `bitcoin-cli`, this change to include `bitcoind` seems innocent enough.

I pushed a "test" version here https://hub.docker.com/layers/blockstream/lightningd/ep-v23.08/images/sha256-d8d8093bea4a3c028eee2c16ac27ffb41981ae79d366fc355c7fe54321e66b27?context=explore which is currently powering cln-regtest-demo, the size difference between current `elementsproject/lightning` is roughly 30MB.