### PR TITLE
Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .?submodules=1

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
-use flake .?submodules=1
+export PROJECT_ROOT=$PWD
+use flake --impure

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,10 @@ release/
 
 # Ignore release verification Sha256Sums
 SHA256SUMS-*
+
+# Ignore nix outputs
+result
+result-[0-9]*
+
+# Ignore .direnv cache
+.direnv

--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,7 @@ ifeq ($(PYTEST),)
 	@echo "py.test is required to run the protocol tests, please install using 'pip3 install -r requirements.txt', and rerun 'configure'."; false
 else
 ifeq ($(DEVELOPER),1)
-	@(cd external/lnprototest && PYTHONPATH=$(MY_CHECK_PYTHONPATH) LIGHTNING_SRC=../.. $(PYTEST) --runner lnprototest.clightning.Runner $(PYTEST_OPTS))
+	@(cd external/lnprototest && LIGHTNING_SRC=../.. $(PYTEST) --runner lnprototest.clightning.Runner $(PYTEST_OPTS))
 else
 	@echo "lnprototest target requires DEVELOPER=1, skipping"
 endif
@@ -471,7 +471,7 @@ ifeq ($(PYTEST),)
 	exit 1
 else
 # Explicitly hand DEVELOPER and VALGRIND so you can override on make cmd line.
-	PYTHONPATH=$(MY_CHECK_PYTHONPATH) TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
+	TEST_DEBUG=1 DEVELOPER=$(DEVELOPER) VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
 endif
 
 check-fuzz: $(ALL_FUZZ_TARGETS)
@@ -532,7 +532,7 @@ PYSRC=$(shell git ls-files "*.py" | grep -v /text.py)
 # allows it to find that
 PYLN_PATH=$(shell pwd)/lightningd:$(PATH)
 check-pyln-%: $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS)
-	@(cd contrib/$(shell echo $@ | cut -b 7-) && PATH=$(PYLN_PATH) PYTHONPATH=$(MY_CHECK_PYTHONPATH) $(MAKE) check)
+	@(cd contrib/$(shell echo $@ | cut -b 7-) && PATH=$(PYLN_PATH) $(MAKE) check)
 
 check-python: check-python-flake8 check-pytest-pyln-proto check-pyln-client check-pyln-testing
 
@@ -544,7 +544,7 @@ check-python-flake8:
 	@flake8 --ignore=E501,E731,E741,W503,F541,E275 --exclude $(shell echo ${PYTHON_GENERATED} | sed 's/ \+/,/g') ${PYSRC}
 
 check-pytest-pyln-proto:
-	PATH=$(PYLN_PATH) PYTHONPATH=$(MY_CHECK_PYTHONPATH) $(PYTEST) contrib/pyln-proto/tests/
+	PATH=$(PYLN_PATH) $(PYTEST) contrib/pyln-proto/tests/
 
 check-includes: check-src-includes check-hdr-includes
 	@tools/check-includes.sh

--- a/flake.lock
+++ b/flake.lock
@@ -18,27 +18,106 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1693844670,
-        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693998442,
+        "narHash": "sha256-HQwzZK2UOTaHvh/mlO2D+CzG30laReMewJBp8PgcXVY=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "28995cdf05d693a5c48b25c205c1f30e73064a76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693844670,
+        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (pkgs) lib;
+    in {
+      packages = rec {
+        default = cln;
+        cln = pkgs.clightning.overrideAttrs (upstream: rec {
+          name = "cln";
+          version = "${self.lastModifiedDate}-flake-${self.dirtyShortRev}"; # TODO emulate git describe using CHANGELOG.md or fetch git? impure runCommand?
+          makeFlags = [ "VERSION=${version}" "MTIME=${self.lastModifiedDate}" ];
+          src = ./.;
+        });
+      };
+      formatter = pkgs.alejandra;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,27 +2,99 @@
   description = "A very basic flake";
 
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/23.05";
     flake-utils.url = "github:numtide/flake-utils";
+    poetry2nix = {
+      url = "github:nix-community/poetry2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    poetry2nix,
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       inherit (pkgs) lib;
+
+      inherit
+        (poetry2nix.legacyPackages.${system})
+        defaultPoetryOverrides
+        mkPoetryEnv
+        mkPoetryEditablePackage
+        ;
     in {
       packages = rec {
         default = cln;
-        cln = pkgs.clightning.overrideAttrs (upstream: rec {
+        cln = (pkgs.callPackage ("${nixpkgs}/pkgs/applications/blockchains/clightning") {
+          python3 = cln-meta-project; # FIXME neither this nor cln-meta-project.python actually works, but this is conceptually the right thing IIUC
+        }).overrideAttrs (upstream: rec {
           name = "cln";
           version = "${self.lastModifiedDate}-flake-${self.dirtyShortRev}"; # TODO emulate git describe using CHANGELOG.md or fetch git? impure runCommand?
-          makeFlags = [ "VERSION=${version}" "MTIME=${self.lastModifiedDate}" ];
+          makeFlags = ["VERSION=${version}" "MTIME=${self.lastModifiedDate}"];
+          nativeBuildInputs = [ cln-meta-project ] ++ upstream.nativeBuildInputs; # FIXME why does python3 in callPackage not work? work around by placing cln-meta-project's python first
           src = ./.;
+          # configureFlags = ["--enable-developer"]; # default flags disable developer and valgrind
+          doCheck = true;
+          # TODO remove PYTHONPATH
+          postPatch = upstream.postPatch +
+            ''
+            patchShebangs tools/check-*.sh
+          '';
         });
+
+        cln-meta-project = mkPoetryEnv {
+          projectDir = ./.;
+
+          # See https://github.com/nix-community/poetry2nix/blob/master/docs/edgecases.md
+          overrides = defaultPoetryOverrides.extend (self: super:
+            lib.genAttrs [
+              "protobuf3"
+              "pytest-custom-exit-code"
+              "pytest-test-groups"
+            ] (name:
+              super.${name}.overridePythonAttrs (old: {
+                nativeBuildInputs = (old.nativeBuildInputs or []) ++ [self.setuptools];
+              }))
+          // {
+            python-bitcoinlib = super.python-bitcoinlib.overridePythonAttrs (old: {
+              postPatch = pkgs.python3Packages.bitcoinlib.postPatch; # fixes libssl loading
+            });
+          });
+
+          # FIXME why does contrib/pyln-grpc-proto have its own poetry.lock?
+          # TODO external/lnprototest/
+          editablePackageSources = let
+            # set PROJECT_ROOT environment variable and use --impure to obtain an
+            # editable project directory, e.g. `PROJECT_ROOT=$PWD nix develop --impure`
+            impureRoot = builtins.getEnv "PROJECT_ROOT";
+            root =
+              if impureRoot == ""
+              then ./.
+              else impureRoot;
+          in
+            lib.genAttrs [
+              "pyln-client"
+              "pyln-proto"
+              "pyln-grpc-proto"
+              "pyln-spec"
+              "pyln-testing"
+            ] (name: root + "/contrib/${name}");
+          preferWheels = builtins.getEnv "PREFER_WHEELS" == "1"; # requires --impure to take effect, quicker to build
+        };
       };
+
+      # devShells = {
+      #   default = pkgs.mkShell {
+      #     buildInputs = [
+      #       pkgs.poetry
+      #     ];
+      #   };
+      # };
+
       formatter = pkgs.alejandra;
     });
 }


### PR DESCRIPTION
per @chrisguida's request, cc @jurraca, opening a draft PR for a new flake.nix

disabling `doCheck = true` is enough to build from source using `nix build ".?submodules=1"`, and in `nix develop` the python interpreter is set up with the poetry dependencies, but that's as far as I got, this does not yet work.


TODO:

- [x] reuse upstream clightning package
- [ ] poetry2nix based python environment
  - [ ] figure out why `callPackages` python override from poetry2nix built environment is not doing the right thing, currently there's an ugly workaround (prepending to nativeBuildInputs)
  - [ ] ensure pyproject.toml & poetry.lock files are adequately imported, and poetry2nix is used correctly WRT multiple subdirectories in `contrib` (do they need separate derivations?)
  - [ ] use nix supplied python environment in make check
    - right now i just deleted PYTHONPATH bits from the Makefile to get the wrapped interpreter in the build environment, this works for some deps but not pyln-testing
- [ ] get `doCheck` in derivation working
- [ ] devshell with additional tools
  - [ ] `nixpkgs.poetry` (poetry itself is not supposed to be a dep of pyproject.toml)
  - [ ] bitcoin core (required for testing)
  - [ ] valgrind, etc - other tools used for --enable-developer
- [ ] crane based rust derivations
- [ ] nix flake checks
  - [ ] various extended developer tests could be set up with source filtering for efficient caching, this would make `git rebase --exec 'nix flake check'` pretty reasonable