### PR TITLE
[cln-rpc]: switch from ToString to Display for ShortChannelId

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -165,9 +165,9 @@ impl FromStr for ShortChannelId {
         ))
     }
 }
-impl ToString for ShortChannelId {
-    fn to_string(&self) -> String {
-        format!("{}x{}x{}", self.block(), self.txindex(), self.outnum())
+impl Display for ShortChannelId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}x{}x{}", self.block(), self.txindex(), self.outnum())
     }
 }
 impl ShortChannelId {


### PR DESCRIPTION
It is recommend to implement `Display` instead of [ToString](https://doc.rust-lang.org/std/string/trait.ToString.html)

This also provides `.to_string()` but has the advantage that things like `info!("{}", scid)` just work without `.to_string()`