### PR TITLE
[cln-rpc]: add Eq, PartialOrd, Ord, Hash to ShortChannelId

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -125,7 +125,7 @@ impl std::ops::Sub for Amount {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShortChannelId(u64);
 
 impl Serialize for ShortChannelId {


### PR DESCRIPTION
I don't know if this can be problematic, but it would be nice to have so i can do things like comparison, `sort_by(|x| x.scid)` or scids as keys in `HashMap`/`BTreeMap` without converting them to `String` first.