### PR TITLE
ci: Unbreak the liquid-regtest run on Github Actions

### DIFF
--- a/.github/scripts/install-bitcoind.sh
+++ b/.github/scripts/install-bitcoind.sh
@@ -8,12 +8,21 @@ FILENAME="${DIRNAME}-x86_64-linux-gnu.tar.gz"
 EFILENAME="${EDIRNAME}-x86_64-linux-gnu.tar.gz"
 
 cd /tmp/
-wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${FILENAME}"
-wget "https://github.com/ElementsProject/elements/releases/download/elements-${ELEMENTS_VERSION}/${EFILENAME}"
-tar -xf "${FILENAME}"
-tar -xf "${EFILENAME}"
-sudo mv "${DIRNAME}"/bin/* "/usr/local/bin"
-sudo mv "${EDIRNAME}"/bin/* "/usr/local/bin"
 
+# Since we inadvertently broke `elementsd` support in the past we only
+# want to download and enable the daemon that is actually going to be
+# used when running in CI. Otherwise we could end up accidentally
+# testing against `bitcoind` but still believe that we ran against
+# `elementsd`.
+if [ "$TEST_NETWORK" = "liquid-regtest" ]; then
+    wget "https://github.com/ElementsProject/elements/releases/download/elements-${ELEMENTS_VERSION}/${EFILENAME}"
+    tar -xf "${EFILENAME}"
+    sudo mv "${EDIRNAME}"/bin/* "/usr/local/bin"
+    rm -rf "${EFILENAME}" "${EDIRNAME}"
+else
+    wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${FILENAME}"
+    tar -xf "${FILENAME}"
+    sudo mv "${DIRNAME}"/bin/* "/usr/local/bin"
+    rm -rf "${FILENAME}" "${DIRNAME}"
+fi
 
-rm -rf "${FILENAME}" "${EFILENAME}" "${DIRNAME}" "${EDIRNAME}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,6 +282,18 @@ jobs:
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2
 
+      - name: Unpack pre-built CLN
+        env:
+          CFG: ${{ matrix.CFG }}
+        run: |
+          tar -xaf cln-${CFG}.tar.bz2
+
+      - name: Switch network
+        if: ${{ matrix.TEST_NETWORK == 'liquid-regtest' }}
+        run: |
+          # Loading the network from config.vars rather than the envvar is a terrible idea...
+          sed -i 's/TEST_NETWORK=regtest/TEST_NETWORK=liquid-regtest/g' config.vars
+
       - name: Test
         env:
           COMPILER: ${{ matrix.COMPILER }}
@@ -296,7 +308,6 @@ jobs:
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
           LIGHTNINGD_POSTGRES_NO_VACUUM: 1
         run: |
-          tar -xaf cln-${CFG}.tar.bz2
           VALGRIND=0 poetry run pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
 
   integration-valgrind:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,6 +295,7 @@ jobs:
         run: |
           # Loading the network from config.vars rather than the envvar is a terrible idea...
           sed -i 's/TEST_NETWORK=regtest/TEST_NETWORK=liquid-regtest/g' config.vars
+          cat config.vars
 
       - name: Test
         env:
@@ -310,6 +311,8 @@ jobs:
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
           LIGHTNINGD_POSTGRES_NO_VACUUM: 1
         run: |
+          env
+          cat config.vars
           VALGRIND=0 poetry run pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
 
   integration-valgrind:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,6 +162,7 @@ jobs:
       - name: Install dependencies
         run: |
           bash -x .github/scripts/setup.sh
+          sudo apt-get update -qq
           sudo apt-get install -y -qq lowdown
           pip install -U pip wheel poetry
           # Export and then use pip to install into the current env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,6 +275,8 @@ jobs:
           poetry install
 
       - name: Install bitcoind
+        env:
+          TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
         run: .github/scripts/install-bitcoind.sh
 
       - name: Download build

--- a/tests/plugins/badestimate.py
+++ b/tests/plugins/badestimate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import subprocess
+import os
 
 from pyln.client import Plugin
 
@@ -8,8 +9,12 @@ from pyln.client import Plugin
 plugin = Plugin()
 
 
+network = os.environ.get("TEST_NETWORK", "regtest")
+cli = "bitcoin-cli" if network == "regtest" else "elements-cli"
+
+
 def bcli(plugin, cmd):
-    ret = subprocess.run(['bitcoin-cli',
+    ret = subprocess.run([cli,
                           '-datadir={}'.format(plugin.get_option("bitcoin-datadir")),
                           '-rpcuser={}'.format(plugin.get_option("bitcoin-rpcuser")),
                           '-rpcpassword={}'.format(plugin.get_option("bitcoin-rpcpassword")),


### PR DESCRIPTION
Turns out we stopped using the `TEST_NETWORK` envvar and relied exclusively on `config.vars`. This broke the `liquid-regtest` tests on GCI...