### PR TITLE
Makefile: regnerate config.vars if configure changes (recently PYTHON var)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,12 +289,10 @@ show-flags: config.vars
 	@$(ECHO) "CC: $(CC) $(CFLAGS) -c -o"
 	@$(ECHO) "LD: $(LINK.o) $(filter-out %.a,$^) $(LOADLIBES) $(EXTERNAL_LDLIBS) $(LDLIBS) -o"
 
-ccan/config.h: config.vars configure ccan/tools/configurator/configurator.c
+# We will re-generate, but we won't generate for the first time!
+ccan/config.h config.vars &: configure ccan/tools/configurator/configurator.c
+	@if [ ! -f config.vars ]; then echo 'File config.vars not found: you must run ./configure before running make.' >&2; exit 1; fi
 	./configure --reconfigure
-
-config.vars:
-	@echo 'File config.vars not found: you must run ./configure before running make.' >&2
-	@exit 1
 
 %.o: %.c
 	@$(call VERBOSE, "cc $<", $(CC) $(CFLAGS) -c -o $@ $<)


### PR DESCRIPTION
We didn't want a rule to generate config.vars, since user should run configure manually with their desired options.  However, we do want to be able to *refresh* it, because otherwise, if we need a new configuration var for our Makefile, it won't get refreshed:

```
$ make
CC: cc -DBINTOPKGLIBEXECDIR="../libexec/c-lightning" -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror -Wshadow=local -std=gnu11 -g -fstack-protector-strong  -I ccan -I external/libwally-core/include/ -I external/libwally-core/src/secp256k1/include/ -I external/jsmn/ -I external/libbacktrace/ -I external/gheap/ -I external/build-x86_64-linux-gnu/libbacktrace-build -I external/libsodium/src/libsodium/include -I external/libsodium/src/libsodium/include/sodium -I external/build-x86_64-linux-gnu/libsodium-build/src/libsodium/include -I . -I/usr/local/include  -I/usr/include/postgresql   -DCCAN_TAKE_DEBUG=1 -DCCAN_TAL_DEBUG=1 -DCCAN_JSON_OUT_DEBUG=1 -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS  -DCOMPAT_V052=1 -DCOMPAT_V060=1 -DCOMPAT_V061=1 -DCOMPAT_V062=1 -DCOMPAT_V070=1 -DCOMPAT_V072=1 -DCOMPAT_V073=1 -DCOMPAT_V080=1 -DCOMPAT_V081=1 -DCOMPAT_V082=1 -DCOMPAT_V090=1 -DCOMPAT_V0100=1 -DCOMPAT_V0121=1  -DBUILD_ELEMENTS=1 -c -o
PYTHONPATH=contrib/msggen  contrib/msggen/msggen/__main__.py
LD: cc     config.vars  -Lexternal/build-x86_64-linux-gnu -lwallycore -lsecp256k1 -ljsmn -lbacktrace -lsodium -L/usr/local/include -lm -lsqlite3  -lz  -L/usr/lib/x86_64-linux-gnu -lpq -o
/bin/sh: 1: contrib/msggen/msggen/__main__.py: Permission denied
make: *** [Makefile:371: cln-grpc/proto/node.proto] Error 126
make: *** Waiting for unfinished jobs....
```

Here, PYTHON is the new var (here, unset).  If we were building a binary, we'd depend on config.h, and the Makefile says how to refresh that.  But the Makefile includes config.vars (causing an implicit dependency) so we really should have a rule to make that.