### PR TITLE
RPC: Allow signed values in raw command line

### DIFF
--- a/ccan/ccan/opt/parse.c
+++ b/ccan/ccan/opt/parse.c
@@ -92,8 +92,11 @@ int parse_one(int *argc, char *argv[], enum opt_type is_early, unsigned *offset,
 		arg = 1;
 	} else {
 		for (arg = 1; argv[arg]; arg++) {
-			if (argv[arg][0] == '-')
-				break;
+			if (argv[arg][0] == '-') {
+				/* Negative numerical values are not options */
+				if (argv[arg][1] < '0' || argv[arg][1] > '9')
+					break;
+			}
 		}
 	}
 


### PR DESCRIPTION
without the need to use the -k explicit keys and values mode.

ChangeLog-Added: Allow negative values for splice-out to use the raw command line without needing the use of explicit key/value -k option.

Fixes #6612