### PR TITLE
Makefile: don't delete python-generated files in distclean.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -697,11 +697,11 @@ default-targets: $(DEFAULT_TARGETS)
 
 distclean: clean
 	$(RM) ccan/config.h config.vars
-	$(RM) $(PYTHON_GENERATED)
 
 maintainer-clean: distclean
 	@echo 'This command is intended for maintainers to use; it'
 	@echo 'deletes files that may need special tools to rebuild.'
+	$(RM) $(PYTHON_GENERATED)
 
 # We used to have gen_ files, now we have _gen files.
 obsclean:


### PR DESCRIPTION
We do not, in fact, require Python to build, so we should still work after `make distclean`.

Fixes:  #6536