### PR TITLE
Dockerfile: Remove deprecated GMP dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,13 +89,6 @@ RUN apt-get install -y --no-install-recommends unzip tclsh \
     && make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
 
 USER root
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-    && tar xvf gmp-6.1.2.tar.xz \
-    && cd gmp-6.1.2 \
-    && ./configure --disable-assembly \
-    && make \
-    && make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
-
 ENV RUST_PROFILE=release
 ENV PATH=$PATH:/root/.cargo/bin/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/contrib/docker/Dockerfile.arm64v8
+++ b/contrib/docker/Dockerfile.arm64v8
@@ -94,13 +94,6 @@ RUN apt-get install -y --no-install-recommends unzip tclsh \
     && make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
 
 USER root
-RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
-    && tar xvf gmp-6.1.2.tar.xz \
-    && cd gmp-6.1.2 \
-    && ./configure --disable-assembly \
-    && make \
-    && make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
-
 ENV RUST_PROFILE=release
 ENV PATH=$PATH:/root/.cargo/bin/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
This PR removes deprecated GMP dependency since libsecp256k1 provides all the necessary functionality.

Enjoy faster build!