### PR TITLE
gci: Update apt cache before installing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,6 +363,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update -qq
           sudo apt-get install -yyq valgrind
           pip3 install --user pip wheel poetry
           poetry install


### PR DESCRIPTION
CI was broken due to an outdated repository cache, pointing to a yanked file.

Changelog-None