### PR TITLE
pytest: fix renepay test_shadow flake.

### DIFF
--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -37,8 +37,8 @@ def test_shadow(node_factory):
     l1, l2, l3 = node_factory.line_graph(3,
                                          wait_for_announce=True,
                                          opts=[{},
-                                               {'fee-base': 2000, 'fee-per-satoshi': 20, 'cltv-delta': 20},
-                                               {'fee-base': 3000, 'fee-per-satoshi': 30, 'cltv-delta': 30}])
+                                               {'fee-base': 20, 'fee-per-satoshi': 20, 'cltv-delta': 20},
+                                               {'fee-base': 30, 'fee-per-satoshi': 30, 'cltv-delta': 30}])
 
     # Shadow doesn't always happen (50% chance)!
     for i in range(20):


### PR DESCRIPTION
Sometimes we don't shadow because it would break our budget:

```
    def test_shadow(node_factory):
        '''Make sure we shadow correctly.'''
        l1, l2, l3 = node_factory.line_graph(3,
                                             wait_for_announce=True,
                                             opts=[{},
                                                   {'fee-base': 2000, 'fee-per-satoshi': 20, 'cltv-delta': 20},
                                                   {'fee-base': 3000, 'fee-per-satoshi': 30, 'cltv-delta': 30}])
    
        # Shadow doesn't always happen (50% chance)!
        for i in range(20):
            inv = l2.rpc.invoice(123000, f'test_renepay{i}', 'description')['bolt11']
            details = l1.rpc.call('renepay', {'invstring': inv})
            assert details['status'] == 'complete'
            assert details['amount_msat'] == Millisatoshi(123000)
            assert details['destination'] == l2.info['id']
    
>           line = l1.daemon.wait_for_log("No MPP, so added .*msat shadow fee")

tests/test_renepay.py:51:
```

```
lightningd-1 2023-09-12T05:08:39.699Z UNUSUAL plugin-cln-renepay: No shadow fee for flow 0/1: fee would add 5005msat to 123000msat, exceeding budget 128000msat.
```