### PR TITLE
`Makefile`: use `xargs -0` consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ $(GRPC_GEN)&: cln-grpc/proto/node.proto cln-grpc/proto/primitives.proto
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/node.proto --python_out=$(GRPC_PATH)/ --grpc_python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/primitives.proto --python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	find $(GRPC_DIR)/ -type f -name "*.py" -print0 | xargs -0 sed -i'.bak' -e 's/^import \(.*\)_pb2 as .*__pb2/from pyln.grpc import \1_pb2 as \1__pb2/g'
-	find $(GRPC_DIR)/ -type f -name "*.py.bak" -print0 | xargs rm -f
+	find $(GRPC_DIR)/ -type f -name "*.py.bak" -print0 | xargs -0 rm -f
 endif
 
 # We make pretty much everything depend on these.
@@ -545,13 +545,13 @@ check-includes: check-src-includes check-hdr-includes
 
 # cppcheck gets confused by list_for_each(head, i, list): thinks i is uninit.
 .cppcheck-suppress:
-	@git ls-files -- "*.c" "*.h" | grep -vE '^(ccan|contrib)/' | xargs grep -n '_for_each' | sed 's/\([^:]*:.*\):.*/uninitvar:\1/' > $@
+	@git ls-files -z -- "*.c" "*.h" | grep -vzE '^(ccan|contrib)/' | xargs -0 grep -n '_for_each' | sed 's/\([^:]*:.*\):.*/uninitvar:\1/' > $@
 
 check-cppcheck: .cppcheck-suppress
-	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -- "*.c" "*.h" | grep -vE '^ccan/' | xargs cppcheck  ${CPPCHECK_OPTS}
+	@trap 'rm -f .cppcheck-suppress' 0; git ls-files -z -- "*.c" "*.h" | grep -vzE '^ccan/' | xargs -0 cppcheck  ${CPPCHECK_OPTS}
 
 check-shellcheck:
-	@git ls-files -- "*.sh" | xargs shellcheck -f gcc
+	@git ls-files -z -- "*.sh" | xargs -0 shellcheck -f gcc
 
 check-setup_locale:
 	@tools/check-setup_locale.sh
@@ -615,10 +615,10 @@ ncc: ${TARGET_DIR}/libwally-core-build/src/libwallycore.la
 
 # Ignore test/ directories.
 TAGS:
-	$(RM) TAGS; find * -name test -type d -prune -o -name '*.[ch]' -print -o -name '*.py' -print | xargs etags --append
+	$(RM) TAGS; find * -name test -type d -prune -o \( -name '*.[ch]' -o -name '*.py' \) -print0 | xargs -0 etags --append
 
 tags:
-	$(RM) tags; find * -name test -type d -prune -o -name '*.[ch]' -print -o -name '*.py' -print | xargs ctags --append
+	$(RM) tags; find * -name test -type d -prune -o \( -name '*.[ch]' -o -name '*.py' \) -print0 | xargs -0 ctags --append
 
 ccan/ccan/cdump/tools/cdump-enumstr: ccan/ccan/cdump/tools/cdump-enumstr.o $(CDUMP_OBJS) $(CCAN_OBJS)
 


### PR DESCRIPTION
In its default mode, `xargs` interprets any whitespace as a delimiter, and it interprets single and double quotes and backslashes specially. This can play havoc when fed by tools that don't escape these special characters in their output.

Fortunately, `xargs` (at least the GNU and macOS versions of it) has a `-0` option that changes the behavior so that only NUL characters act as delimiters, and no other characters have any special meaning. Use this option consistently to avoid any nasty surprises.

Note that `git-ls-files` has a `-z` option that causes it to terminate filenames on output with a NUL character instead of a newline, and `grep` has a `-z` option that causes it to operate on NUL-terminated records rather than on lines. Use these options together with `xargs -0`.

Note: This commit corrects an oversight introduced in 9d94687b0d822468cd91a1710fcbb0bcd28a27ec.