### PR TITLE
runes: Use next id from runes table not `runes_uniqueid` from `vars`

### DIFF
--- a/lightningd/runes.c
+++ b/lightningd/runes.c
@@ -225,7 +225,7 @@ void runes_finish_init(struct runes *runes)
 {
 	struct lightningd *ld = runes->ld;
 
-	runes->next_unique_id = db_get_intvar(ld->wallet->db, "runes_uniqueid", 0);
+	runes->next_unique_id = wallet_get_rune_next_unique_id(runes, ld->wallet);
 	runes->blacklist = wallet_get_runes_blacklist(runes, ld->wallet);
 
 	/* Initialize usage table and start flush timer. */
@@ -640,7 +640,6 @@ static struct command_result *json_createrune(struct command *cmd,
 	/* Insert into DB*/
 	wallet_rune_insert(cmd->ld->wallet, ras->rune);
 	cmd->ld->runes->next_unique_id = cmd->ld->runes->next_unique_id + 1;
-	db_set_intvar(cmd->ld->wallet->db, "runes_uniqueid", cmd->ld->runes->next_unique_id);
 	return reply_with_rune(cmd, NULL, NULL, ras->rune);
 }
 

--- a/tests/test_runes.py
+++ b/tests/test_runes.py
@@ -661,3 +661,6 @@ def test_id_migration(node_factory):
                  'YPojv9qgHPa3im0eiqRb-g8aRq76OasyfltGGqdFUOU9MyZpZF4wMjJkMjIzNjIwYTM1OWE0N2ZmNyZtZXRob2Q9bGlzdHBlZXJz',
                  'enX0sTpHB8y1ktyTAF80CnEvGetG340Ne3AGItudBS49NCZwbnVtPTA='):
         assert 'stored' not in only_one(l1.rpc.showrunes(rune)['runes'])
+
+    # Our migration should have removed this row now
+    assert l1.db_query("SELECT * FROM vars WHERE name = 'runes_uniqueid';") == []

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -977,6 +977,7 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE channel_funding_inflights ADD i_am_initiator INTEGER DEFAULT 0"), NULL},
     {SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL},
     {NULL, migrate_runes_idfix},
+    {SQL("DELETE FROM vars WHERE name = 'runes_uniqueid'"), NULL},
 };
 
 /**

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -5662,6 +5662,21 @@ struct wallet_htlc_iter *wallet_htlcs_next(struct wallet *w,
 	return iter;
 }
 
+u64 wallet_get_rune_next_unique_id(const tal_t *ctx, struct wallet *wallet)
+{
+	struct db_stmt *stmt;
+	u64 next_unique_id;
+
+	stmt = db_prepare_v2(wallet->db, SQL("SELECT (COALESCE(MAX(id), -1) + 1) FROM runes"));
+	db_query_prepared(stmt);
+	db_step(stmt);
+
+	next_unique_id = db_col_u64(stmt, "(COALESCE(MAX(id), -1) + 1)");
+
+	tal_free(stmt);
+	return next_unique_id;
+}
+
 struct rune_blacklist *wallet_get_runes_blacklist(const tal_t *ctx, struct wallet *wallet)
 {
 	struct db_stmt *stmt;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1622,6 +1622,13 @@ struct rune_blacklist {
 };
 
 /**
+ * Load the next unique id for rune from the db.
+ * @ctx: tal ctx for return to be tallocated from
+ * @wallet: the wallet
+ */
+u64 wallet_get_rune_next_unique_id(const tal_t *ctx, struct wallet *wallet);
+
+/**
  * Load the blacklist from the db.
  * @ctx: tal ctx for return to be tallocated from
  * @wallet: the wallet


### PR DESCRIPTION
Changelog-Fixed: runes: use runes table `id` instead `runes_uniqueid` from `vars` because it returns incorrect unique id if rune/s migrated from datastore.

Issue (#6696):
The issue occurs when user saves the rune (created by commando-rune) in the datastore with v23.02 and then upgrades the DB with v23.08. This upgrade calls migrate_datastore_commando_runes function to migrate runes from datastore to runes table. But it does not increment runes_uniqueid of vars table. So when user creates a new rune, CLN gets old next_unique_id and fails with UNIQUE_ID constraint error.
This issue effects Umbrel's users and users who saved their runes from older version in the datastore.

Solution 1:
- Add another migration function to recalculate `runes_uniqueid` and update vars table.
- Update `runes_uniqueid` in vars table in `migrate_datastore_commando_runes` for users who are yet to update.

Solution 2:
- Do not use `runes_uniqueid`, instead calculate the `next_unique_id` from `runes` table.
- `id` can be auto generated for runes insert but we still need to maintain it in runes because:
        - It is also required by `rune_derive_start`
        - counter starts from 1 (not 0) if not explicitly passed to the query.

Implemented solution 2 as it is clean and future proof.
