### PR TITLE
wallet: fix migration order.

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -975,8 +975,8 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE htlc_sigs ADD inflight_tx_outnum INTEGER"), NULL},
     {SQL("ALTER TABLE channel_funding_inflights ADD splice_amnt BIGINT DEFAULT 0"), NULL},
     {SQL("ALTER TABLE channel_funding_inflights ADD i_am_initiator INTEGER DEFAULT 0"), NULL},
-    {SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL},
     {NULL, migrate_runes_idfix},
+    {SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL},
 };
 
 /**


### PR DESCRIPTION
We must always append.  Changing the order now won't change anything for those who have already migrated, or haven't done the last two migrations, but will prevent anyone who upgraded to the last-but-one migration.

Fixes eacf0b502c28662b515eaec2f3e975ac51423f20.