### PR TITLE
hsmd: name the hsmd_ready_channel to hsmd_setup_channel

### DIFF
--- a/common/hsm_version.h
+++ b/common/hsm_version.h
@@ -17,6 +17,7 @@
  * v4 with sign_htlc_tx_mingle: b9247e75d41ee1b3fc2f7db0bac8f4e92d544ab2f017d430ae3a000589c384e5
  * v4 with splicing: 06f21012936f825913af289fa81af1512c9ada1cb97c611698975a8fd287edbb
  * v4 with capabilities called permissions: 7c5bf8ec7cf30302740db85260a9d1ac2c5b0323a2376c28df6b611831f91655
+ * v4 with renaming of channel_ready to setup_channel: 60b92a0930b631cc77df564cb9235e6cb220f4337a2bb00e5153145e0bf8c80e
  */
 #define HSM_MIN_VERSION 3
 #define HSM_MAX_VERSION 4

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -644,7 +644,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 			return handle_memleak(conn, c, c->msg_in);
 		/* fall thru */
 	case WIRE_HSMD_NEW_CHANNEL:
-	case WIRE_HSMD_READY_CHANNEL:
+	case WIRE_HSMD_SETUP_CHANNEL:
 	case WIRE_HSMD_SIGN_COMMITMENT_TX:
 	case WIRE_HSMD_VALIDATE_COMMITMENT_TX:
 	case WIRE_HSMD_VALIDATE_REVOCATION:
@@ -689,7 +689,7 @@ static struct io_plan *handle_client(struct io_conn *conn, struct client *c)
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
-	case WIRE_HSMD_READY_CHANNEL_REPLY:
+	case WIRE_HSMD_SETUP_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -69,25 +69,25 @@ msgdata,hsmd_get_channel_basepoints_reply,funding_pubkey,pubkey,
 
 #include <common/channel_type.h>
 # Provide channel parameters.
-msgtype,hsmd_ready_channel,31
-msgdata,hsmd_ready_channel,is_outbound,bool,
-msgdata,hsmd_ready_channel,channel_value,amount_sat,
-msgdata,hsmd_ready_channel,push_value,amount_msat,
-msgdata,hsmd_ready_channel,funding_txid,bitcoin_txid,
-msgdata,hsmd_ready_channel,funding_txout,u16,
-msgdata,hsmd_ready_channel,local_to_self_delay,u16,
-msgdata,hsmd_ready_channel,local_shutdown_script_len,u16,
-msgdata,hsmd_ready_channel,local_shutdown_script,u8,local_shutdown_script_len
-msgdata,hsmd_ready_channel,local_shutdown_wallet_index,?u32,
-msgdata,hsmd_ready_channel,remote_basepoints,basepoints,
-msgdata,hsmd_ready_channel,remote_funding_pubkey,pubkey,
-msgdata,hsmd_ready_channel,remote_to_self_delay,u16,
-msgdata,hsmd_ready_channel,remote_shutdown_script_len,u16,
-msgdata,hsmd_ready_channel,remote_shutdown_script,u8,remote_shutdown_script_len
-msgdata,hsmd_ready_channel,channel_type,channel_type,
+msgtype,hsmd_setup_channel,31
+msgdata,hsmd_setup_channel,is_outbound,bool,
+msgdata,hsmd_setup_channel,channel_value,amount_sat,
+msgdata,hsmd_setup_channel,push_value,amount_msat,
+msgdata,hsmd_setup_channel,funding_txid,bitcoin_txid,
+msgdata,hsmd_setup_channel,funding_txout,u16,
+msgdata,hsmd_setup_channel,local_to_self_delay,u16,
+msgdata,hsmd_setup_channel,local_shutdown_script_len,u16,
+msgdata,hsmd_setup_channel,local_shutdown_script,u8,local_shutdown_script_len
+msgdata,hsmd_setup_channel,local_shutdown_wallet_index,?u32,
+msgdata,hsmd_setup_channel,remote_basepoints,basepoints,
+msgdata,hsmd_setup_channel,remote_funding_pubkey,pubkey,
+msgdata,hsmd_setup_channel,remote_to_self_delay,u16,
+msgdata,hsmd_setup_channel,remote_shutdown_script_len,u16,
+msgdata,hsmd_setup_channel,remote_shutdown_script,u8,remote_shutdown_script_len
+msgdata,hsmd_setup_channel,channel_type,channel_type,
 
-# No value returned.
-msgtype,hsmd_ready_channel_reply,131
+# No value returned.,
+msgtype,hsmd_setup_channel_reply,131
 
 # Return signature for a funding tx.
 #include <common/utxo.h>

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -45,6 +45,8 @@ struct hsmd_client *hsmd_client_new_main(const tal_t *ctx, u64 capabilities,
 }
 
 struct hsmd_client *hsmd_client_new_peer(const tal_t *ctx, u64 capabilities,
+
+
 					 u64 dbid,
 					 const struct node_id *peer_id,
 					 void *extra)
@@ -92,7 +94,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 
 	case WIRE_HSMD_GET_PER_COMMITMENT_POINT:
 	case WIRE_HSMD_CHECK_FUTURE_SECRET:
-	case WIRE_HSMD_READY_CHANNEL:
+	case WIRE_HSMD_SETUP_CHANNEL:
 		return (client->capabilities & HSM_PERM_COMMITMENT_POINT) != 0;
 
 	case WIRE_HSMD_SIGN_REMOTE_COMMITMENT_TX:
@@ -141,7 +143,7 @@ bool hsmd_check_client_capabilities(struct hsmd_client *client,
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
-	case WIRE_HSMD_READY_CHANNEL_REPLY:
+	case WIRE_HSMD_SETUP_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:
@@ -333,7 +335,7 @@ static bool mem_is_zero(const void *mem, size_t len)
 
 /* ~This stub implementation is overriden by fully validating signers
  * that need the unchanging channel parameters. */
-static u8 *handle_ready_channel(struct hsmd_client *c, const u8 *msg_in)
+static u8 *handle_setup_channel(struct hsmd_client *c, const u8 *msg_in)
 {
 	bool is_outbound;
 	struct amount_sat channel_value;
@@ -350,7 +352,7 @@ static u8 *handle_ready_channel(struct hsmd_client *c, const u8 *msg_in)
 	struct amount_msat value_msat;
 	struct channel_type *channel_type;
 
-	if (!fromwire_hsmd_ready_channel(tmpctx, msg_in, &is_outbound,
+	if (!fromwire_hsmd_setup_channel(tmpctx, msg_in, &is_outbound,
 					&channel_value, &push_value, &funding_txid,
 					&funding_txout, &local_to_self_delay,
 					&local_shutdown_script,
@@ -372,7 +374,7 @@ static u8 *handle_ready_channel(struct hsmd_client *c, const u8 *msg_in)
 	assert(local_to_self_delay > 0);
 	assert(remote_to_self_delay > 0);
 
-	return towire_hsmd_ready_channel_reply(NULL);
+	return towire_hsmd_setup_channel_reply(NULL);
 }
 
 /*~ For almost every wallet tx we use the BIP32 seed, but not for onchain
@@ -1900,8 +1902,8 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 
 	case WIRE_HSMD_NEW_CHANNEL:
 		return handle_new_channel(client, msg);
-	case WIRE_HSMD_READY_CHANNEL:
-		return handle_ready_channel(client, msg);
+	case WIRE_HSMD_SETUP_CHANNEL:
+		return handle_setup_channel(client, msg);
 	case WIRE_HSMD_GET_OUTPUT_SCRIPTPUBKEY:
 		return handle_get_output_scriptpubkey(client, msg);
 	case WIRE_HSMD_CHECK_FUTURE_SECRET:
@@ -1978,7 +1980,7 @@ u8 *hsmd_handle_client_message(const tal_t *ctx, struct hsmd_client *client,
 	case WIRE_HSMD_CUPDATE_SIG_REPLY:
 	case WIRE_HSMD_CLIENT_HSMFD_REPLY:
 	case WIRE_HSMD_NEW_CHANNEL_REPLY:
-	case WIRE_HSMD_READY_CHANNEL_REPLY:
+	case WIRE_HSMD_SETUP_CHANNEL_REPLY:
 	case WIRE_HSMD_NODE_ANNOUNCEMENT_SIG_REPLY:
 	case WIRE_HSMD_SIGN_WITHDRAWAL_REPLY:
 	case WIRE_HSMD_SIGN_INVOICE_REPLY:

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -1908,7 +1908,7 @@ static u8 *accepter_commits(struct state *state,
 			      "to msats");
 
 	/*~ Report the channel parameters to the signer. */
-	msg = towire_hsmd_ready_channel(NULL,
+	msg = towire_hsmd_setup_channel(NULL,
 				       false,	/* is_outbound */
 				       total,
 				       our_msats,
@@ -1924,8 +1924,8 @@ static u8 *accepter_commits(struct state *state,
 				       state->channel_type);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
-	if (!fromwire_hsmd_ready_channel_reply(msg))
-		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
+	if (!fromwire_hsmd_setup_channel_reply(msg))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad setup_channel_reply %s",
 			      tal_hex(tmpctx, msg));
 
 	tal_free(state->channel);
@@ -2642,7 +2642,7 @@ static u8 *opener_commits(struct state *state,
 	}
 
 	/*~ Report the channel parameters to the signer. */
-	msg = towire_hsmd_ready_channel(NULL,
+	msg = towire_hsmd_setup_channel(NULL,
 				       true,	/* is_outbound */
 				       total,
 				       their_msats,
@@ -2658,7 +2658,7 @@ static u8 *opener_commits(struct state *state,
 				       state->channel_type);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
-	if (!fromwire_hsmd_ready_channel_reply(msg))
+	if (!fromwire_hsmd_setup_channel_reply(msg))
 		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
 			      tal_hex(tmpctx, msg));
 

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -606,7 +606,7 @@ static bool funder_finalize_channel_setup(struct state *state,
 	struct wally_tx_output *direct_outputs[NUM_SIDES];
 
 	/*~ Channel is ready; Report the channel parameters to the signer. */
-	msg = towire_hsmd_ready_channel(NULL,
+	msg = towire_hsmd_setup_channel(NULL,
 				       true,	/* is_outbound */
 				       state->funding_sats,
 				       state->push_msat,
@@ -622,8 +622,8 @@ static bool funder_finalize_channel_setup(struct state *state,
 				       state->channel_type);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
-	if (!fromwire_hsmd_ready_channel_reply(msg))
-		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
+	if (!fromwire_hsmd_setup_channel_reply(msg))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad setup_channel_reply %s",
 			      tal_hex(tmpctx, msg));
 
 	/*~ Now we can initialize the `struct channel`.  This represents
@@ -1196,7 +1196,7 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 	}
 
 	/*~ Channel is ready; Report the channel parameters to the signer. */
-	msg = towire_hsmd_ready_channel(NULL,
+	msg = towire_hsmd_setup_channel(NULL,
 				       false,	/* is_outbound */
 				       state->funding_sats,
 				       state->push_msat,
@@ -1212,8 +1212,8 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 				       state->channel_type);
 	wire_sync_write(HSM_FD, take(msg));
 	msg = wire_sync_read(tmpctx, HSM_FD);
-	if (!fromwire_hsmd_ready_channel_reply(msg))
-		status_failed(STATUS_FAIL_HSM_IO, "Bad ready_channel_reply %s",
+	if (!fromwire_hsmd_setup_channel_reply(msg))
+		status_failed(STATUS_FAIL_HSM_IO, "Bad setup_channel_reply %s",
 			      tal_hex(tmpctx, msg));
 
 	/* Now we can create the channel structure. */


### PR DESCRIPTION
Originally VLS used hsmd_ready_channel as an early call during channel setup, but later the BOLT-2 spec changed the name of funding_locked to channel_ready.

This is very confusing because the hsmd_ready_channel is not directly related to the new channel_ready.

This commit is renaming the hsmd_ready_channel to hsmd_setup_channel.

Fixes: https://github.com/ElementsProject/lightning/issues/6717
Suggested-by: @ksedgwic