### PR TITLE
Document where getroute gets its data from

### DIFF
--- a/doc/lightning-getroute.7.md
+++ b/doc/lightning-getroute.7.md
@@ -12,7 +12,11 @@ DESCRIPTION
 
 The **getroute** RPC command attempts to find the best route for the
 payment of *amount\_msat* to lightning node *id*, such that the payment will
-arrive at *id* with *cltv*-blocks to spare (default 9).
+arrive at *id* with *cltv*-blocks to spare (default 9). It should be
+noted that **getroute** does not inspect the local state of the channels,
+its decisions are based on the gossip messages stored in
+gossip\_store. Therefore it'll be unaware of the local channel's state
+and balances.
 
 *amount\_msat* is in millisatoshi precision; it can be a whole number, or a
 whole number ending in *msat* or *sat*, or a number with three decimal


### PR DESCRIPTION
Since it's a common misconception that getroute would know about the state of local channels, mention in the lightning-getroute(7) man page that this is not the case.   See #5879

Changelog-None