### PR TITLE
lightningd: fix assertion when funding depth changes fast.

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1041,10 +1041,10 @@ static enum watch_result opening_depth_cb(struct lightningd *ld,
 		wallet_channel_save(ld->wallet, inflight->channel);
 	}
 
-	dualopend_tell_depth(inflight->channel, txid, depth);
-
 	if (depth >= inflight->channel->minimum_depth)
 		update_channel_from_inflight(ld, inflight->channel, inflight);
+
+	dualopend_tell_depth(inflight->channel, txid, depth);
 
 	return KEEP_WATCHING;
 }


### PR DESCRIPTION
We didn't apply the inflight to the channel struct before asserting, so we can break test_rbf_non_last_mined:

```
lightningd: lightningd/dual_open_control.c:981: dualopend_tell_depth: Assertion `bitcoin_txid_eq(&channel->funding.txid, txid)' failed.
```