### PR TITLE
Print steal tracking when a memleak is detected

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -5585,7 +5585,7 @@ static void handle_dev_memleak(struct peer *peer, const u8 *msg)
 	/* Now delete peer and things it has pointers to. */
 	memleak_scan_obj(memtable, peer);
 
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	wire_sync_write(MASTER_FD,
 			 take(towire_channeld_dev_memleak_reply(NULL,
 							       found_leak)));

--- a/closingd/closingd.c
+++ b/closingd/closingd.c
@@ -559,7 +559,7 @@ static void closing_dev_memleak(const tal_t *ctx,
 	memleak_ptr(memtable, scriptpubkey[REMOTE]);
 	memleak_ptr(memtable, funding_wscript);
 
-	dump_memleak(memtable, memleak_status_broken);
+	dump_memleak(memtable, memleak_status_broken, NULL);
 }
 
 /* Figure out what weight we actually expect for this closing tx (using zero fees

--- a/common/status.c
+++ b/common/status.c
@@ -235,7 +235,7 @@ void master_badmsg(u32 type_expected, const u8 *msg)
 }
 
 /* Print BROKEN status: callback for dump_memleak. */
-void memleak_status_broken(const char *fmt, ...)
+void memleak_status_broken(void *unused, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);

--- a/common/status.h
+++ b/common/status.h
@@ -71,6 +71,6 @@ void status_send_fatal(const u8 *msg TAKES) NORETURN;
 void status_send_fd(int fd);
 
 /* Print BROKEN status: callback for dump_memleak. */
-void memleak_status_broken(const char *fmt, ...);
+void memleak_status_broken(void *unused, const char *fmt, ...);
 
 #endif /* LIGHTNING_COMMON_STATUS_H */

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1861,7 +1861,7 @@ static void dev_connect_memleak(struct daemon *daemon, const u8 *msg)
 	memleak_scan_obj(memtable, daemon);
 	memleak_scan_htable(memtable, &daemon->peers->raw);
 
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	daemon_conn_send(daemon->master,
 			 take(towire_connectd_dev_memleak_reply(NULL,
 							      found_leak)));

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -966,7 +966,7 @@ static void dev_gossip_memleak(struct daemon *daemon, const u8 *msg)
 	memleak_scan_obj(memtable, daemon);
 	memleak_scan_htable(memtable, &daemon->peers->raw);
 
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	daemon_conn_send(daemon->master,
 			 take(towire_gossipd_dev_memleak_reply(NULL,
 							      found_leak)));

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -573,7 +573,7 @@ static struct io_plan *handle_memleak(struct io_conn *conn,
 	memleak_ptr(memtable, dev_force_privkey);
 	memleak_ptr(memtable, dev_force_bip32_seed);
 
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	reply = towire_hsmd_dev_memleak_reply(NULL, found_leak);
 	return req_reply(conn, c, take(reply));
 }

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1606,7 +1606,7 @@ static void handle_dev_memleak(struct tracked_output ***outs, const u8 *msg)
 	memleak_remove_globals(memtable, tal_parent(*outs));
 	memleak_scan_obj(memtable, *outs);
 
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	wire_sync_write(REQ_FD,
 			take(towire_onchaind_dev_memleak_reply(NULL,
 							      found_leak)));

--- a/onchaind/test/run-grind_feerate-bug.c
+++ b/onchaind/test/run-grind_feerate-bug.c
@@ -30,10 +30,11 @@ bool derive_keyset(const struct pubkey *per_commitment_point UNNEEDED,
 		   bool option_static_remotekey UNNEEDED,
 		   struct keyset *keyset UNNEEDED)
 { fprintf(stderr, "derive_keyset called!\n"); abort(); }
-/* Generated stub for dump_memleak */
-bool dump_memleak(struct htable *memtable UNNEEDED,
-		  void  (*print)(const char *fmt UNNEEDED, ...))
-{ fprintf(stderr, "dump_memleak called!\n"); abort(); }
+/* Generated stub for dump_memleak_ */
+bool dump_memleak_(struct htable *memtable UNNEEDED,
+		   void  (*print)(void *arg UNNEEDED, const char *fmt UNNEEDED, ...) UNNEEDED,
+		   void *arg UNNEEDED)
+{ fprintf(stderr, "dump_memleak_ called!\n"); abort(); }
 /* Generated stub for fromwire_basepoints */
 void fromwire_basepoints(const u8 **ptr UNNEEDED, size_t *max UNNEEDED,
 			 struct basepoints *b UNNEEDED)
@@ -101,7 +102,7 @@ void memleak_scan_obj(struct htable *memtable UNNEEDED, const void *obj UNNEEDED
 struct htable *memleak_start(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "memleak_start called!\n"); abort(); }
 /* Generated stub for memleak_status_broken */
-void memleak_status_broken(const char *fmt UNNEEDED, ...)
+void memleak_status_broken(void *unused UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "memleak_status_broken called!\n"); abort(); }
 /* Generated stub for new_coin_channel_close */
 struct chain_coin_mvt *new_coin_channel_close(const tal_t *ctx UNNEEDED,

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -29,10 +29,11 @@ bool derive_keyset(const struct pubkey *per_commitment_point UNNEEDED,
 		   bool option_static_remotekey UNNEEDED,
 		   struct keyset *keyset UNNEEDED)
 { fprintf(stderr, "derive_keyset called!\n"); abort(); }
-/* Generated stub for dump_memleak */
-bool dump_memleak(struct htable *memtable UNNEEDED,
-		  void  (*print)(const char *fmt UNNEEDED, ...))
-{ fprintf(stderr, "dump_memleak called!\n"); abort(); }
+/* Generated stub for dump_memleak_ */
+bool dump_memleak_(struct htable *memtable UNNEEDED,
+		   void  (*print)(void *arg UNNEEDED, const char *fmt UNNEEDED, ...) UNNEEDED,
+		   void *arg UNNEEDED)
+{ fprintf(stderr, "dump_memleak_ called!\n"); abort(); }
 /* Generated stub for fromwire */
 const u8 *fromwire(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, void *copy UNNEEDED, size_t n UNNEEDED)
 { fprintf(stderr, "fromwire called!\n"); abort(); }
@@ -148,7 +149,7 @@ void memleak_scan_obj(struct htable *memtable UNNEEDED, const void *obj UNNEEDED
 struct htable *memleak_start(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "memleak_start called!\n"); abort(); }
 /* Generated stub for memleak_status_broken */
-void memleak_status_broken(const char *fmt UNNEEDED, ...)
+void memleak_status_broken(void *unused UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "memleak_status_broken called!\n"); abort(); }
 /* Generated stub for new_coin_channel_close */
 struct chain_coin_mvt *new_coin_channel_close(const tal_t *ctx UNNEEDED,

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -976,7 +976,7 @@ static void handle_dev_memleak(struct state *state, const u8 *msg)
 	memleak_scan_obj(memtable, state);
 
 	/* If there's anything left, dump it to logs, and return true. */
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	wire_sync_write(REQ_FD,
 			take(towire_dualopend_dev_memleak_reply(NULL,
 							        found_leak)));

--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -1419,7 +1419,7 @@ static void handle_dev_memleak(struct state *state, const u8 *msg)
 	memleak_scan_obj(memtable, state);
 
 	/* If there's anything left, dump it to logs, and return true. */
-	found_leak = dump_memleak(memtable, memleak_status_broken);
+	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	wire_sync_write(REQ_FD,
 			take(towire_openingd_dev_memleak_reply(NULL,
 							      found_leak)));

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1513,14 +1513,12 @@ void plugin_log(struct plugin *p, enum log_level l, const char *fmt, ...)
 	va_end(ap);
 }
 
-/* Hack since we have no extra ptr to log_memleak */
-static struct plugin *memleak_plugin;
-static void PRINTF_FMT(1,2) log_memleak(const char *fmt, ...)
+static void PRINTF_FMT(2,3) log_memleak(struct plugin *plugin, const char *fmt, ...)
 {
 	va_list ap;
 
 	va_start(ap, fmt);
-	plugin_logv(memleak_plugin, LOG_BROKEN, fmt, ap);
+	plugin_logv(plugin, LOG_BROKEN, fmt, ap);
 	va_end(ap);
 }
 
@@ -1546,8 +1544,7 @@ static void memleak_check(struct plugin *plugin, struct command *cmd)
 	if (plugin->mark_mem)
 		plugin->mark_mem(plugin, memtable);
 
-	memleak_plugin = plugin;
-	dump_memleak(memtable, log_memleak);
+	dump_memleak(memtable, log_memleak, plugin);
 }
 
 void plugin_set_memleak_handler(struct plugin *plugin,


### PR DESCRIPTION
There are two reasons a memleak can be hard to find even when we show where it's allocated:
1. That pointer is overridden somewhere without being freed.
2. The pointer is tal_steal() onto something else, which doesn't free it.

We can't do much about the former case, but we can definitely do the latter!

Changelog-None: developer infrastructure