### PR TITLE
clnrest: refactoring

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -27,7 +27,7 @@ You will need some Python packages if you want to use clnrest.  Unfortunately th
 
 ```
 sudo apt-get install python3-json5 python3-flask python3-gunicorn
-pip3 install --user flask_restx pyln-client
+pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
 ```
 
 If you're on a different distribution or OS, you can compile the source by following the instructions from [Installing from Source](<>).

--- a/plugins/clnrest/utilities/generate_certs.py
+++ b/plugins/clnrest/utilities/generate_certs.py
@@ -5,98 +5,65 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 import datetime
+from utilities.shared import validate_ip4
 
 
-def generate_ca_cert(certs_path):
-    # Generate CA Private Key
-    ca_private_key = ec.generate_private_key(ec.SECP256R1())
+def save_cert(entity_type, cert, private_key, certs_path):
+    """Serialize and save certificates and keys.
+    `entity_type` is either "ca", "client" or "server"."""
+    with open(os.path.join(certs_path, f"{entity_type}.pem"), "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+    with open(os.path.join(certs_path, f"{entity_type}-key.pem"), "wb") as f:
+        f.write(private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()))
 
-    # Generate CA Public Key
-    ca_public_key = ca_private_key.public_key()
 
-    # Generate CA Certificate
-    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u"cln Root REST CA")])
+def create_cert_builder(subject_name, issuer_name, public_key, rest_host):
+    list_sans = [x509.DNSName("cln"), x509.DNSName("localhost")]
+    if validate_ip4(rest_host) is True:
+        list_sans.append(x509.IPAddress(ipaddress.IPv4Address(rest_host)))
 
-    ca_cert = (
+    return (
         x509.CertificateBuilder()
-        .subject_name(ca_subject)
-        .issuer_name(ca_subject)
-        .public_key(ca_public_key)
+        .subject_name(subject_name)
+        .issuer_name(issuer_name)
+        .public_key(public_key)
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.datetime.utcnow())
         .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=10 * 365))  # Ten years validity
-        .add_extension(x509.SubjectAlternativeName([x509.DNSName(u"cln"), x509.DNSName(u'localhost'), x509.IPAddress(ipaddress.IPv4Address(u'127.0.0.1'))]), critical=False)
-        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
-        .sign(ca_private_key, hashes.SHA256())
+        .add_extension(x509.SubjectAlternativeName(list_sans), critical=False)
     )
 
-    # Create the certs directory if it does not exist
-    os.makedirs(certs_path, exist_ok=True)
 
-    # Serialize CA certificate and write to disk
-    with open(os.path.join(certs_path, "ca.pem"), "wb") as f:
-        f.write(ca_cert.public_bytes(serialization.Encoding.PEM))
+def generate_cert(entity_type, ca_subject, ca_private_key, rest_host, certs_path):
+    # Generate Key pair
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_key = private_key.public_key()
 
-    # Serialize and save the private key to a PEM file (CA)
-    with open(os.path.join(certs_path, "ca-key.pem"), "wb") as f:
-        f.write(ca_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
-        ))
-
-    return ca_subject, ca_private_key
-
-
-def generate_client_server_certs(certs_path, ca_subject, ca_private_key):
-    # Generate Server and Client Private Keys
-    server_private_key = ec.generate_private_key(ec.SECP256R1())
-    client_private_key = ec.generate_private_key(ec.SECP256R1())
-
-    # Generate Server and Client Public Keys
-    server_public_key = server_private_key.public_key()
-    client_public_key = client_private_key.public_key()
-
-    # Generate Server and Client Certificates
-    for entity_type in ["server", "client"]:
-        public_key = server_public_key if entity_type == "server" else client_public_key
-
+    # Generate Certificates
+    if isinstance(ca_subject, x509.Name):
         subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, f"cln rest {entity_type}")])
-
+        cert_builder = create_cert_builder(subject, ca_subject, public_key, rest_host)
+        cert = cert_builder.sign(ca_private_key, hashes.SHA256())
+    else:
+        ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u"cln Root REST CA")])
+        ca_private_key, ca_public_key = private_key, public_key
+        cert_builder = create_cert_builder(ca_subject, ca_subject, ca_public_key, rest_host)
         cert = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(ca_subject)
-            .public_key(public_key)
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.utcnow())
-            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=10 * 365))  # Ten years validity
-            .add_extension(x509.SubjectAlternativeName([x509.DNSName(u"cln"), x509.DNSName(u'localhost'), x509.IPAddress(ipaddress.IPv4Address(u'127.0.0.1'))]), critical=False)
+            cert_builder
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
             .sign(ca_private_key, hashes.SHA256())
         )
 
-        # Serialize Server and Client certificates and write to disk
-        with open(os.path.join(certs_path, f"{entity_type}.pem"), "wb") as f:
-            f.write(cert.public_bytes(serialization.Encoding.PEM))
-
-    # Serialize Private Keys (Server)
-    with open(os.path.join(certs_path, "server-key.pem"), "wb") as f:
-        f.write(server_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
-        ))
-
-    # Serialize Private Keys (Client)
-    with open(os.path.join(certs_path, "client-key.pem"), "wb") as f:
-        f.write(client_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
-        ))
+    os.makedirs(certs_path, exist_ok=True)
+    save_cert(entity_type, cert, private_key, certs_path)
+    return ca_subject, ca_private_key
 
 
-def generate_certs(plugin, certs_path):
-    ca_subject, ca_private_key = generate_ca_cert(certs_path)
-    generate_client_server_certs(certs_path, ca_subject, ca_private_key)
+def generate_certs(plugin, rest_host, certs_path):
+    ca_subject, ca_private_key = generate_cert("ca", None, None, rest_host, certs_path)
+    generate_cert("client", ca_subject, ca_private_key, rest_host, certs_path)
+    generate_cert("server", ca_subject, ca_private_key, rest_host, certs_path)
     plugin.log(f"Certificates Generated!", "debug")

--- a/plugins/clnrest/utilities/rpc_plugin.py
+++ b/plugins/clnrest/utilities/rpc_plugin.py
@@ -8,4 +8,4 @@ plugin.add_option(name="rest-protocol", default="https", description="REST serve
 plugin.add_option(name="rest-host", default="127.0.0.1", description="REST server host", opt_type="string", deprecated=False)
 plugin.add_option(name="rest-port", default=None, description="REST server port to listen", opt_type="int", deprecated=False)
 plugin.add_option(name="rest-cors-origins", default="*", description="Cross origin resource sharing origins", opt_type="string", deprecated=False, multi=True)
-plugin.add_option(name="rest-csp", default="default-src 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';", description="Content security policy (CSP) for the server", opt_type="string", deprecated=False, multi=True)
+plugin.add_option(name="rest-csp", default="default-src 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';", description="Content security policy (CSP) for the server", opt_type="string", deprecated=False, multi=False)


### PR DESCRIPTION
While working on testcases, I found few bugs in `clnrest` that were fixed along the way:

- `clnrest` self-signed certificates adds `rest-host` IP in Subject Alternative Name
- Fixed: Only runes which authorise the `listclnrest-notifications` method are allowed to get notifications

Changelog-Fixed: websocket server notifications are available with `readonly` runes

Link to #6436.