### PR TITLE
Plugin and broadcast cleanups

### DIFF
--- a/lightningd/anchorspend.c
+++ b/lightningd/anchorspend.c
@@ -386,7 +386,7 @@ bool commit_tx_boost(struct channel *channel,
 		 fmt_amount_sat(tmpctx, adet->anchor_spend_fee));
 
 	/* Send it! */
-	broadcast_tx(ld->topology, channel, take(newtx), NULL, true, 0, NULL,
+	broadcast_tx(adet, ld->topology, channel, take(newtx), NULL, true, 0, NULL,
 		     refresh_anchor_spend, adet);
 	return true;
 }

--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -404,10 +404,7 @@ static void sendrawtx_callback(const char *buf, const jsmntok_t *toks,
 					     err);
 	}
 
-	db_begin_transaction(call->bitcoind->ld->wallet->db);
 	call->cb(call->bitcoind, success, errmsg, call->cb_arg);
-	db_commit_transaction(call->bitcoind->ld->wallet->db);
-
 	tal_free(call);
 }
 
@@ -472,9 +469,7 @@ getrawblockbyheight_callback(const char *buf, const jsmntok_t *toks,
 	 * with NULL values. */
 	err = json_scan(tmpctx, buf, toks, "{result:{blockhash:null}}");
 	if (!err) {
-		db_begin_transaction(call->bitcoind->ld->wallet->db);
 		call->cb(call->bitcoind, NULL, NULL, call->cb_arg);
-		db_commit_transaction(call->bitcoind->ld->wallet->db);
 		goto clean;
 	}
 
@@ -493,9 +488,7 @@ getrawblockbyheight_callback(const char *buf, const jsmntok_t *toks,
 				     "getrawblockbyheight",
 				     "bad block");
 
-	db_begin_transaction(call->bitcoind->ld->wallet->db);
 	call->cb(call->bitcoind, &blkid, blk, call->cb_arg);
-	db_commit_transaction(call->bitcoind->ld->wallet->db);
 
 clean:
 	tal_free(call);
@@ -574,10 +567,8 @@ static void getchaininfo_callback(const char *buf, const jsmntok_t *toks,
 		bitcoin_plugin_error(call->bitcoind, buf, toks, "getchaininfo",
 				     "bad 'result' field: %s", err);
 
-	db_begin_transaction(call->bitcoind->ld->wallet->db);
 	call->cb(call->bitcoind, chain, headers, blocks, ibd,
 		 call->first_call, call->cb_arg);
-	db_commit_transaction(call->bitcoind->ld->wallet->db);
 
 	tal_free(call);
 }
@@ -640,9 +631,7 @@ static void getutxout_callback(const char *buf, const jsmntok_t *toks,
 
 	err = json_scan(tmpctx, buf, toks, "{result:{script:null}}");
 	if (!err) {
-		db_begin_transaction(call->bitcoind->ld->wallet->db);
 		call->cb(call->bitcoind, NULL, call->cb_arg);
-		db_commit_transaction(call->bitcoind->ld->wallet->db);
 		goto clean;
 	}
 
@@ -654,9 +643,7 @@ static void getutxout_callback(const char *buf, const jsmntok_t *toks,
 		bitcoin_plugin_error(call->bitcoind, buf, toks, "getutxout",
 				     "bad 'result' field: %s", err);
 
-	db_begin_transaction(call->bitcoind->ld->wallet->db);
 	call->cb(call->bitcoind, &txout, call->cb_arg);
-	db_commit_transaction(call->bitcoind->ld->wallet->db);
 
 clean:
 	tal_free(call);

--- a/lightningd/bitcoind.h
+++ b/lightningd/bitcoind.h
@@ -63,15 +63,17 @@ void bitcoind_estimate_fees(struct bitcoind *bitcoind,
 				       u32 feerate_floor,
 				       const struct feerate_est *feerates));
 
-void bitcoind_sendrawtx_(struct bitcoind *bitcoind,
+/* If ctx is freed, cb won't be called! */
+void bitcoind_sendrawtx_(const tal_t *ctx,
+			 struct bitcoind *bitcoind,
 			 const char *id_prefix TAKES,
 			 const char *hextx,
 			 bool allowhighfees,
 			 void (*cb)(struct bitcoind *bitcoind,
 				    bool success, const char *msg, void *),
 			 void *arg);
-#define bitcoind_sendrawtx(bitcoind_, id_prefix, hextx, allowhighfees, cb, arg)	\
-	bitcoind_sendrawtx_((bitcoind_), (id_prefix), (hextx),		\
+#define bitcoind_sendrawtx(ctx, bitcoind_, id_prefix, hextx, allowhighfees, cb, arg) \
+	bitcoind_sendrawtx_((ctx), (bitcoind_), (id_prefix), (hextx),	\
 			    (allowhighfees),				\
 			    typesafe_cb_preargs(void, void *,		\
 						(cb), (arg),		\

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -145,7 +145,7 @@ static void broadcast_remainder(struct bitcoind *bitcoind,
 	}
 
 	/* Broadcast next one. */
-	bitcoind_sendrawtx(bitcoind,
+	bitcoind_sendrawtx(bitcoind, bitcoind,
 			   txs->cmd_id[txs->cursor], txs->txs[txs->cursor],
 			   txs->allowhighfees[txs->cursor],
 			   broadcast_remainder, txs);
@@ -299,7 +299,7 @@ void broadcast_tx_(struct chain_topology *topo,
 		  cmd_id ? " for " : "", cmd_id ? cmd_id : "");
 
 	wallet_transaction_add(topo->ld->wallet, tx->wtx, 0, 0);
-	bitcoind_sendrawtx(topo->bitcoind, otx->cmd_id,
+	bitcoind_sendrawtx(topo->bitcoind, topo->bitcoind, otx->cmd_id,
 			   fmt_bitcoin_tx(tmpctx, otx->tx),
 			   allowhighfees,
 			   broadcast_done, otx);

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -212,7 +212,7 @@ u32 default_locktime(const struct chain_topology *topo);
  * @cmd_id: the JSON command id which triggered this (or NULL).
  * @allowhighfees: set to true to override the high-fee checks in the backend.
  * @minblock: minimum block we can send it at (or 0).
- * @finished: if non-NULL, call that when sendrawtransaction returns; if it returns true, don't rebroadcast.
+ * @finished: if non-NULL, call every time sendrawtransaction returns; if it returns true, don't rebroadcast.
  * @refresh: if non-NULL, callback before re-broadcasting (can replace tx):
  *           if returns false, delete.
  * @cbarg: argument for @finished and @refresh

--- a/lightningd/chaintopology.h
+++ b/lightningd/chaintopology.h
@@ -205,6 +205,7 @@ u32 default_locktime(const struct chain_topology *topo);
 
 /**
  * broadcast_tx - Broadcast a single tx, and rebroadcast as reqd (copies tx).
+ * @ctx: context: when this is freed, callback/retransmission don't happen.
  * @topo: topology
  * @channel: the channel responsible for this (stop broadcasting if freed).
  * @tx: the transaction
@@ -216,9 +217,9 @@ u32 default_locktime(const struct chain_topology *topo);
  *           if returns false, delete.
  * @cbarg: argument for @finished and @refresh
  */
-#define broadcast_tx(topo, channel, tx, cmd_id, allowhighfees,		\
+#define broadcast_tx(ctx, topo, channel, tx, cmd_id, allowhighfees,	\
 		     minblock, finished, refresh, cbarg)		\
-	broadcast_tx_((topo), (channel), (tx), (cmd_id), (allowhighfees), \
+	broadcast_tx_((ctx), (topo), (channel), (tx), (cmd_id), (allowhighfees), \
 		      (minblock),					\
 		      typesafe_cb_preargs(bool, void *,			\
 					  (finished), (cbarg),		\
@@ -231,7 +232,8 @@ u32 default_locktime(const struct chain_topology *topo);
 					  const struct bitcoin_tx **),	\
 		      (cbarg))
 
-void broadcast_tx_(struct chain_topology *topo,
+void broadcast_tx_(const tal_t *ctx,
+		   struct chain_topology *topo,
 		   struct channel *channel,
 		   const struct bitcoin_tx *tx TAKES,
 		   const char *cmd_id, bool allowhighfees, u32 minblock,

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -484,6 +484,7 @@ static void send_splice_tx(struct channel *channel,
 	info->err_msg = NULL;
 
 	bitcoind_sendrawtx(ld->topology->bitcoind,
+			   ld->topology->bitcoind,
 			   cc ? cc->cmd->id : NULL,
 			   tal_hex(tmpctx, tx_bytes),
 			   false,

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1735,6 +1735,7 @@ static void send_funding_tx(struct channel *channel,
 		  type_to_string(tmpctx, struct wally_tx, cs->wtx));
 
 	bitcoind_sendrawtx(ld->topology->bitcoind,
+			   ld->topology->bitcoind,
 			   channel->open_attempt
 			   ? (channel->open_attempt->cmd
 			      ? channel->open_attempt->cmd->id

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -921,7 +921,6 @@ static void listincoming_done(const char *buffer,
 			      const jsmntok_t *idtok UNUSED,
 			      struct invoice_info *info)
 {
-	struct lightningd *ld = info->cmd->ld;
 	struct command_result *ret;
 	bool warning_mpp, warning_capacity, warning_deadends, warning_offline, warning_private_unused;
 
@@ -934,8 +933,6 @@ static void listincoming_done(const char *buffer,
 	if (ret)
 		return;
 
-	/* We're actually outside a db transaction here: spooky! */
-	db_begin_transaction(ld->wallet->db);
 	invoice_complete(info,
 			 false,
 			 warning_mpp,
@@ -943,7 +940,6 @@ static void listincoming_done(const char *buffer,
 			 warning_deadends,
 			 warning_offline,
 			 warning_private_unused);
-	db_commit_transaction(ld->wallet->db);
 }
 
 /* Since this is a dev-only option, we will crash if dev-routes is not

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -1070,7 +1070,7 @@ static void create_onchain_tx(struct channel *channel,
 
 	/* We allow "excessive" fees, as we may be fighting with censors and
 	 * we'd rather spend fees than have our adversary win. */
-	broadcast_tx(ld->topology,
+	broadcast_tx(channel, ld->topology,
 		     channel, take(tx), NULL, true, info->minblock,
 		     NULL, consider_onchain_rebroadcast, take(info));
 
@@ -1270,7 +1270,7 @@ static void handle_onchaind_spend_htlc_success(struct channel *channel,
 
 	log_debug(channel->log, "Broadcast for onchaind tx %s",
 		  type_to_string(tmpctx, struct bitcoin_tx, tx));
-	broadcast_tx(channel->peer->ld->topology,
+	broadcast_tx(channel, channel->peer->ld->topology,
 		     channel, take(tx), NULL, false,
 		     info->minblock, NULL,
 		     consider_onchain_htlc_tx_rebroadcast, take(info));
@@ -1352,7 +1352,7 @@ static void handle_onchaind_spend_htlc_timeout(struct channel *channel,
 
 	log_debug(channel->log, "Broadcast for onchaind tx %s",
 		  type_to_string(tmpctx, struct bitcoin_tx, tx));
-	broadcast_tx(channel->peer->ld->topology,
+	broadcast_tx(channel, channel->peer->ld->topology,
 		     channel, take(tx), NULL, false,
 		     info->minblock, NULL,
 		     consider_onchain_htlc_tx_rebroadcast, take(info));

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -771,7 +771,7 @@ static void dev_register_opts(struct lightningd *ld)
 	/* We might want to debug plugins, which are started before normal
 	 * option parsing */
 	clnopt_witharg("--dev-debugger=<subprocess>", OPT_EARLY|OPT_DEV,
-		       opt_set_charp, NULL,
+		       opt_set_charp, opt_show_charp,
 		       &ld->dev_debug_subprocess,
 		       "Invoke gdb at start of <subprocess>");
 	clnopt_noarg("--dev-no-plugin-checksum", OPT_EARLY|OPT_DEV,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -305,7 +305,7 @@ static struct bitcoin_tx *sign_and_send_last(const tal_t *ctx,
 
 	/* Keep broadcasting until we say stop (can fail due to dup,
 	 * if they beat us to the broadcast). */
-	broadcast_tx(ld->topology, channel, tx, cmd_id, false, 0,
+	broadcast_tx(channel, ld->topology, channel, tx, cmd_id, false, 0,
 		     commit_tx_send_finished, commit_tx_boost, take(adet));
 
 	return tx;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -73,6 +73,9 @@ struct plugin {
 	/* An array of subscribed topics */
 	char **subscriptions;
 
+	/* Currently pending requests by their request ID */
+	STRMAP(struct jsonrpc_request *) pending_requests;
+
 	/* An array of currently pending RPC method calls, to be killed if the
 	 * plugin exits. */
 	struct list_head pending_rpccalls;
@@ -105,8 +108,6 @@ struct plugins {
 	struct list_head plugins;
 	bool startup;
 
-	/* Currently pending requests by their request ID */
-	STRMAP(struct jsonrpc_request *) pending_requests;
 	struct logger *log;
 
 	struct lightningd *ld;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -76,10 +76,6 @@ struct plugin {
 	/* Currently pending requests by their request ID */
 	STRMAP(struct jsonrpc_request *) pending_requests;
 
-	/* An array of currently pending RPC method calls, to be killed if the
-	 * plugin exits. */
-	struct list_head pending_rpccalls;
-
 	/* If set, the plugin is so important that if it terminates early,
 	 * C-lightning should terminate as well.  */
 	bool important;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -108,6 +108,10 @@ struct plugins {
 	struct list_head plugins;
 	bool startup;
 
+	/* Normally we want to wrap callbacks in a db transaction, but
+	 * not for the db hook servicing */
+	bool want_db_transaction;
+
 	struct logger *log;
 
 	struct lightningd *ld;

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -73,7 +73,7 @@ struct plugin {
 	/* An array of subscribed topics */
 	char **subscriptions;
 
-	/* Currently pending requests by their request ID */
+	/* Our pending requests by their request ID */
 	STRMAP(struct jsonrpc_request *) pending_requests;
 
 	/* If set, the plugin is so important that if it terminates early,
@@ -322,9 +322,13 @@ void plugins_notify(struct plugins *plugins,
 
 /**
  * Send a jsonrpc_request to the specified plugin
+ * @plugin: the plugin to send the request to
+ * @req: the request.
+ *
+ * If @req is freed, any response from the plugin is ignored.
  */
 void plugin_request_send(struct plugin *plugin,
-			 struct jsonrpc_request *req TAKES);
+			 struct jsonrpc_request *req);
 
 /**
  * Callback called when parsing options. It just stores the value in

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -51,7 +51,8 @@ char *bolt11_encode_(const tal_t *ctx UNNEEDED,
 		     void *arg UNNEEDED)
 { fprintf(stderr, "bolt11_encode_ called!\n"); abort(); }
 /* Generated stub for broadcast_tx_ */
-void broadcast_tx_(struct chain_topology *topo UNNEEDED,
+void broadcast_tx_(const tal_t *ctx UNNEEDED,
+		   struct chain_topology *topo UNNEEDED,
 		   struct channel *channel UNNEEDED,
 		   const struct bitcoin_tx *tx TAKES UNNEEDED,
 		   const char *cmd_id UNNEEDED, bool allowhighfees UNNEEDED, u32 minblock UNNEEDED,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1836,7 +1836,6 @@ def test_bcli(node_factory, bitcoind, chainparams):
     assert not resp["success"] and "decode failed" in resp["errmsg"]
 
 
-@pytest.mark.xfail(strict=True)
 def test_hook_crash(node_factory, executor, bitcoind):
     """Verify that we fail over if a plugin crashes while handling a hook.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1478,7 +1478,6 @@ def test_sendpay_notifications_nowaiter(node_factory):
     assert len(results['sendpay_failure']) == 1
 
 
-@pytest.mark.xfail(strict=True)
 def test_rpc_command_hook(node_factory):
     """Test the `rpc_command` hook chain"""
     plugin = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1478,6 +1478,7 @@ def test_sendpay_notifications_nowaiter(node_factory):
     assert len(results['sendpay_failure']) == 1
 
 
+@pytest.mark.xfail(strict=True)
 def test_rpc_command_hook(node_factory):
     """Test the `rpc_command` hook chain"""
     plugin = [
@@ -1835,6 +1836,7 @@ def test_bcli(node_factory, bitcoind, chainparams):
     assert not resp["success"] and "decode failed" in resp["errmsg"]
 
 
+@pytest.mark.xfail(strict=True)
 def test_hook_crash(node_factory, executor, bitcoind):
     """Verify that we fail over if a plugin crashes while handling a hook.
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -60,7 +60,8 @@ bool blinding_next_pubkey(const struct pubkey *pk UNNEEDED,
 			  struct pubkey *next UNNEEDED)
 { fprintf(stderr, "blinding_next_pubkey called!\n"); abort(); }
 /* Generated stub for broadcast_tx_ */
-void broadcast_tx_(struct chain_topology *topo UNNEEDED,
+void broadcast_tx_(const tal_t *ctx UNNEEDED,
+		   struct chain_topology *topo UNNEEDED,
 		   struct channel *channel UNNEEDED,
 		   const struct bitcoin_tx *tx TAKES UNNEEDED,
 		   const char *cmd_id UNNEEDED, bool allowhighfees UNNEEDED, u32 minblock UNNEEDED,

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -1000,7 +1000,7 @@ static struct command_result *json_sendpsbt(struct command *cmd,
 	}
 
 	/* Now broadcast the transaction */
-	bitcoind_sendrawtx(cmd->ld->topology->bitcoind,
+	bitcoind_sendrawtx(sending, cmd->ld->topology->bitcoind,
 			   cmd->id,
 			   tal_hex(tmpctx,
 				   linearize_wtx(tmpctx, sending->wtx)),


### PR DESCRIPTION
These were pre-work I had to do when cleaning anchors.  The plugin code was confusing, so I unified the "forwarding a JSON request" vs "our own JSON request", especially handling the plugin dying during these (we didn't handle the latter case at all, we would deref freed memory).

I then go on to refine our broadcast interfaces, since we're going to need a more powerful mechanism for using anchors on the peer's commitment txs.