### PR TITLE
lightningd: use CPFP on peer's commitment tx if we can't broadcast our own

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1169,9 +1169,7 @@ static u8 *sending_commitsig_msg(const tal_t *ctx,
 				 struct penalty_base *pbase,
 				 const struct fee_states *fee_states,
 				 const struct height_states *blockheight_states,
-				 const struct htlc **changed_htlcs,
-				 const struct bitcoin_signature *commit_sig,
-				 const struct bitcoin_signature *htlc_sigs)
+				 const struct htlc **changed_htlcs)
 {
 	struct changed_htlc *changed;
 	u8 *msg;
@@ -1181,8 +1179,7 @@ static u8 *sending_commitsig_msg(const tal_t *ctx,
 	changed = changed_htlc_arr(tmpctx, changed_htlcs);
 	msg = towire_channeld_sending_commitsig(ctx, remote_commit_index,
 						pbase, fee_states,
-						blockheight_states, changed,
-						commit_sig, htlc_sigs);
+						blockheight_states, changed);
 	return msg;
 }
 
@@ -1568,9 +1565,7 @@ static u8 *send_commit_part(struct peer *peer,
 		msg = sending_commitsig_msg(NULL, remote_index, pbase,
 					    peer->channel->fee_states,
 					    peer->channel->blockheight_states,
-					    changed_htlcs,
-					    &commit_sig,
-					    htlc_sigs);
+					    changed_htlcs);
 		/* Message is empty; receiving it is the point. */
 		master_wait_sync_reply(tmpctx, peer, take(msg),
 				       WIRE_CHANNELD_SENDING_COMMITSIG_REPLY);

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1533,11 +1533,11 @@ static u8 *send_commit_part(struct peer *peer,
 		derive_channel_id(cs_tlv->splice_info, funding);
 	}
 
-	txs = channel_splice_txs(tmpctx, funding, funding_sats, &htlc_map,
-				 direct_outputs, &funding_wscript,
-				 peer->channel, &peer->remote_per_commit,
-				 remote_index, REMOTE,
-				 splice_amnt, remote_splice_amnt);
+	txs = channel_txs(tmpctx, funding, funding_sats, &htlc_map,
+			  direct_outputs, &funding_wscript,
+			  peer->channel, &peer->remote_per_commit,
+			  remote_index, REMOTE,
+			  splice_amnt, remote_splice_amnt);
 	htlc_sigs =
 	    calc_commitsigs(tmpctx, peer, txs, funding_wscript, htlc_map,
 			    remote_index, &commit_sig);
@@ -2047,11 +2047,11 @@ static struct commitsig *handle_peer_commit_sig(struct peer *peer,
 		funding_sats = peer->channel->funding_sats;
 	}
 
-	txs = channel_splice_txs(tmpctx, &outpoint, funding_sats, &htlc_map,
-				 NULL, &funding_wscript, peer->channel,
-				 &peer->next_local_per_commit,
-				 peer->next_index[LOCAL], LOCAL, splice_amnt,
-				 remote_splice_amnt);
+	txs = channel_txs(tmpctx, &outpoint, funding_sats, &htlc_map,
+			  NULL, &funding_wscript, peer->channel,
+			  &peer->next_local_per_commit,
+			  peer->next_index[LOCAL], LOCAL, splice_amnt,
+			  remote_splice_amnt);
 
 	/* Set the commit_sig on the commitment tx psbt */
 	if (!psbt_input_set_signature(txs[0]->psbt, 0,

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -137,9 +137,6 @@ msgdata,channeld_sending_commitsig,blockheight_states,height_states,
 # SENT_ADD_COMMIT, SENT_REMOVE_ACK_COMMIT, SENT_ADD_ACK_COMMIT, SENT_REMOVE_COMMIT
 msgdata,channeld_sending_commitsig,num_changed,u16,
 msgdata,channeld_sending_commitsig,changed,changed_htlc,num_changed
-msgdata,channeld_sending_commitsig,commit_sig,bitcoin_signature,
-msgdata,channeld_sending_commitsig,num_htlc_sigs,u16,
-msgdata,channeld_sending_commitsig,htlc_sigs,bitcoin_signature,num_htlc_sigs
 
 # Wait for reply, to make sure it's on disk before we send commit.
 msgtype,channeld_sending_commitsig_reply,1120

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -128,6 +128,18 @@ msgdata,channeld_got_splice_locked,locked_txid,bitcoin_txid,
 
 #include <common/penalty_base.h>
 
+subtype,local_anchor_info
+subtypedata,local_anchor_info,commitment_weight,u32,
+subtypedata,local_anchor_info,commitment_fee,amount_sat,
+subtypedata,local_anchor_info,anchor_point,bitcoin_outpoint,
+
+# lightningd needs to track our anchor outputs on remote txs.
+# This includes splices, so there could be more than one!
+msgtype,channeld_local_anchor_info,1003
+msgdata,channeld_local_anchor_info,remote_commitnum,u64,
+msgdata,channeld_local_anchor_info,num_anchors,u16,
+msgdata,channeld_local_anchor_info,anchors,local_anchor_info,num_anchors
+
 # When we send a commitment_signed message, tell master.
 msgtype,channeld_sending_commitsig,1020
 msgdata,channeld_sending_commitsig,commitnum,u64,
@@ -137,6 +149,7 @@ msgdata,channeld_sending_commitsig,blockheight_states,height_states,
 # SENT_ADD_COMMIT, SENT_REMOVE_ACK_COMMIT, SENT_ADD_ACK_COMMIT, SENT_REMOVE_COMMIT
 msgdata,channeld_sending_commitsig,num_changed,u16,
 msgdata,channeld_sending_commitsig,changed,changed_htlc,num_changed
+
 
 # Wait for reply, to make sure it's on disk before we send commit.
 msgtype,channeld_sending_commitsig_reply,1120

--- a/channeld/commit_tx.h
+++ b/channeld/commit_tx.h
@@ -63,8 +63,9 @@ bool commit_tx_amount_trimmed(const struct htlc **htlcs,
  * @obscured_commitment_number: number to encode in commitment transaction
  * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @option_anchor_outputs: does option_anchor_outputs apply to this channel?
+ * @option_anchors_zero_fee_htlc_tx: does option_anchors_zero_fee_htlc_tx apply to this channel?
  * @side: side to generate commitment transaction for.
- * @option_anchor_outputs: does option_anchor_outputs apply to this channel?
+ * @anchor_outnum: set to index of local anchor, or -1 if none.
  *
  * We need to be able to generate the remote side's tx to create signatures,
  * but the BOLT is expressed in terms of generating our local commitment
@@ -90,6 +91,7 @@ struct bitcoin_tx *commit_tx(const tal_t *ctx,
 			     u64 obscured_commitment_number,
 			     bool option_anchor_outputs,
 			     bool option_anchors_zero_fee_htlc_tx,
-			     enum side side);
+			     enum side side,
+			     int *anchor_outnum);
 
 #endif /* LIGHTNING_CHANNELD_COMMIT_TX_H */

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -315,6 +315,7 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 	const struct htlc **committed;
 	struct keyset keyset;
 	struct amount_msat side_pay, other_side_pay;
+	int local_anchor;
 
 	if (!derive_keyset(per_commitment_point,
 			   &channel->basepoints[side],
@@ -363,7 +364,7 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 	    commitment_number ^ channel->commitment_number_obscurer,
 	    channel_has(channel, OPT_ANCHOR_OUTPUTS),
 	    channel_has(channel, OPT_ANCHORS_ZERO_FEE_HTLC_TX),
-	    side);
+	    side, &local_anchor);
 
 	/* Set the remote/local pubkeys on the commitment tx psbt */
 	psbt_input_add_pubkey(txs[0]->psbt, 0,

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -299,32 +299,17 @@ static void add_htlcs(struct bitcoin_tx ***txs,
 
 /* FIXME: We could cache these. */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
+				const struct bitcoin_outpoint *funding,
+				struct amount_sat funding_sats,
 				const struct htlc ***htlcmap,
 				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,
 				u64 commitment_number,
-				enum side side)
-{
-	return channel_splice_txs(ctx, &channel->funding, channel->funding_sats,
-				  htlcmap, direct_outputs, funding_wscript,
-				  channel, per_commitment_point,
-				  commitment_number, side, 0, 0);
-}
-
-struct bitcoin_tx **channel_splice_txs(const tal_t *ctx,
-				       const struct bitcoin_outpoint *funding,
-				       struct amount_sat funding_sats,
-				       const struct htlc ***htlcmap,
-				       struct wally_tx_output *direct_outputs[NUM_SIDES],
-				       const u8 **funding_wscript,
-				       const struct channel *channel,
-				       const struct pubkey *per_commitment_point,
-				       u64 commitment_number,
-				       enum side side,
-				       s64 splice_amnt,
-				       s64 remote_splice_amnt)
+				enum side side,
+				s64 splice_amnt,
+				s64 remote_splice_amnt)
 {
 	struct bitcoin_tx **txs;
 	const struct htlc **committed;

--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -309,13 +309,13 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				u64 commitment_number,
 				enum side side,
 				s64 splice_amnt,
-				s64 remote_splice_amnt)
+				s64 remote_splice_amnt,
+				int *other_anchor_outnum)
 {
 	struct bitcoin_tx **txs;
 	const struct htlc **committed;
 	struct keyset keyset;
 	struct amount_msat side_pay, other_side_pay;
-	int local_anchor;
 
 	if (!derive_keyset(per_commitment_point,
 			   &channel->basepoints[side],
@@ -364,7 +364,7 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 	    commitment_number ^ channel->commitment_number_obscurer,
 	    channel_has(channel, OPT_ANCHOR_OUTPUTS),
 	    channel_has(channel, OPT_ANCHORS_ZERO_FEE_HTLC_TX),
-	    side, &local_anchor);
+	    side, other_anchor_outnum);
 
 	/* Set the remote/local pubkeys on the commitment tx psbt */
 	psbt_input_add_pubkey(txs[0]->psbt, 0,

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -66,6 +66,7 @@ struct channel *new_full_channel(const tal_t *ctx,
  * @side: which side to get the commitment transaction for
  * @local_splice_amnt: how much is being spliced in (or out, if -ve) of local side.
  * @remote_splice_amnt: how much is being spliced in (or out, if -ve) of remote side.
+ * @other_anchor_outnum: which output (-1 if none) is the !!side anchor
  *
  * Returns the unsigned commitment transaction for the committed state
  * for @side, followed by the htlc transactions in output order and
@@ -82,7 +83,8 @@ struct bitcoin_tx **channel_txs(const tal_t *ctx,
 				u64 commitment_number,
 				enum side side,
 				s64 local_splice_amnt,
-				s64 remote_splice_amnt);
+				s64 remote_splice_amnt,
+				int *local_anchor_outnum);
 
 /**
  * actual_feerate: what is the actual feerate for the local side.

--- a/channeld/full_channel.h
+++ b/channeld/full_channel.h
@@ -55,42 +55,34 @@ struct channel *new_full_channel(const tal_t *ctx,
 /**
  * channel_txs: Get the current commitment and htlc txs for the channel.
  * @ctx: tal context to allocate return value from.
- * @channel: The channel to evaluate
+ * @funding: the outpoint we're spending
+ * @funding_sats: the amount of @funding
  * @htlc_map: Pointer to htlcs for each tx output (allocated off @ctx).
  * @direct_outputs: If non-NULL, fill with pointers to the direct (non-HTLC) outputs (or NULL if none).
  * @funding_wscript: Pointer to wscript for the funding tx output
+ * @channel: The channel to evaluate
  * @per_commitment_point: Per-commitment point to determine keys
  * @commitment_number: The index of this commitment.
  * @side: which side to get the commitment transaction for
+ * @local_splice_amnt: how much is being spliced in (or out, if -ve) of local side.
+ * @remote_splice_amnt: how much is being spliced in (or out, if -ve) of remote side.
  *
  * Returns the unsigned commitment transaction for the committed state
  * for @side, followed by the htlc transactions in output order and
  * fills in @htlc_map, or NULL on key derivation failure.
  */
 struct bitcoin_tx **channel_txs(const tal_t *ctx,
+				const struct bitcoin_outpoint *funding,
+				struct amount_sat funding_sats,
 				const struct htlc ***htlcmap,
 				struct wally_tx_output *direct_outputs[NUM_SIDES],
 				const u8 **funding_wscript,
 				const struct channel *channel,
 				const struct pubkey *per_commitment_point,
 				u64 commitment_number,
-				enum side side);
-
-/* Version of `channel_txs` that lets you specify a custom funding outpoint
- * and funding_sats.
- */
-struct bitcoin_tx **channel_splice_txs(const tal_t *ctx,
-				       const struct bitcoin_outpoint *funding,
-				       struct amount_sat funding_sats,
-				       const struct htlc ***htlcmap,
-				       struct wally_tx_output *direct_outputs[NUM_SIDES],
-				       const u8 **funding_wscript,
-				       const struct channel *channel,
-				       const struct pubkey *per_commitment_point,
-				       u64 commitment_number,
-				       enum side side,
-				       s64 splice_amnt,
-				       s64 remote_splice_amnt);
+				enum side side,
+				s64 local_splice_amnt,
+				s64 remote_splice_amnt);
 
 /**
  * actual_feerate: what is the actual feerate for the local side.

--- a/channeld/test/run-commit_tx.c
+++ b/channeld/test/run-commit_tx.c
@@ -542,6 +542,7 @@ int main(int argc, const char *argv[])
 	bool option_anchor_outputs = false;
 	bool option_anchors_zero_fee_htlc_tx = false;
 	bool option_static_remotekey = false;
+	int local_anchor;
 
 	/* Allow us to check static-remotekey BOLT 3 vectors, too */
 	if (argv[1] && streq(argv[1], "--static-remotekey"))
@@ -822,7 +823,7 @@ int main(int argc, const char *argv[])
 		       NULL, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       option_anchor_outputs,
 		       option_anchors_zero_fee_htlc_tx,
-		       LOCAL);
+		       LOCAL, &local_anchor);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
 			&funding,
@@ -839,7 +840,7 @@ int main(int argc, const char *argv[])
 			NULL, &htlc_map2, NULL, commitment_number ^ cn_obscurer,
 			option_anchor_outputs,
 			option_anchors_zero_fee_htlc_tx,
-			REMOTE);
+			REMOTE, &local_anchor);
 	tx_must_be_eq(tx, tx2);
 	report(tx, wscript, &x_remote_funding_privkey, &remote_funding_pubkey,
 	       &local_funding_privkey, &local_funding_pubkey,
@@ -891,7 +892,7 @@ int main(int argc, const char *argv[])
 		       htlcs, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       option_anchor_outputs,
 		       option_anchors_zero_fee_htlc_tx,
-		       LOCAL);
+		       LOCAL, &local_anchor);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
 			&funding,
@@ -909,7 +910,7 @@ int main(int argc, const char *argv[])
 			commitment_number ^ cn_obscurer,
 			option_anchor_outputs,
 			option_anchors_zero_fee_htlc_tx,
-			REMOTE);
+			REMOTE, &local_anchor);
 	tx_must_be_eq(tx, tx2);
 	report(tx, wscript, &x_remote_funding_privkey, &remote_funding_pubkey,
 	       &local_funding_privkey, &local_funding_pubkey,
@@ -949,7 +950,7 @@ int main(int argc, const char *argv[])
 				  commitment_number ^ cn_obscurer,
 				  option_anchor_outputs,
 				  option_anchors_zero_fee_htlc_tx,
-				  LOCAL);
+				  LOCAL, &local_anchor);
 		/* This is what it would look like for peer generating it! */
 		tx2 = commit_tx(tmpctx,
 				&funding,
@@ -967,7 +968,7 @@ int main(int argc, const char *argv[])
 				commitment_number ^ cn_obscurer,
 				option_anchor_outputs,
 				option_anchors_zero_fee_htlc_tx,
-				REMOTE);
+				REMOTE, &local_anchor);
 		tx_must_be_eq(newtx, tx2);
 #ifdef DEBUG
 		if (feerate_per_kw % 100000 == 0)
@@ -1011,7 +1012,7 @@ int main(int argc, const char *argv[])
 			       commitment_number ^ cn_obscurer,
 			       option_anchor_outputs,
 			       option_anchors_zero_fee_htlc_tx,
-			       LOCAL);
+			       LOCAL, &local_anchor);
 		report(tx, wscript,
 		       &x_remote_funding_privkey, &remote_funding_pubkey,
 		       &local_funding_privkey, &local_funding_pubkey,
@@ -1063,7 +1064,7 @@ int main(int argc, const char *argv[])
 				  commitment_number ^ cn_obscurer,
 				  option_anchor_outputs,
 				  option_anchors_zero_fee_htlc_tx,
-				  LOCAL);
+				  LOCAL, &local_anchor);
 		report(newtx, wscript,
 		       &x_remote_funding_privkey, &remote_funding_pubkey,
 		       &local_funding_privkey, &local_funding_pubkey,
@@ -1142,7 +1143,7 @@ int main(int argc, const char *argv[])
 			       commitment_number ^ cn_obscurer,
 			       option_anchor_outputs,
 			       option_anchors_zero_fee_htlc_tx,
-			       LOCAL);
+			       LOCAL, &local_anchor);
 		report(tx, wscript,
 		       &x_remote_funding_privkey, &remote_funding_pubkey,
 		       &local_funding_privkey, &local_funding_pubkey,
@@ -1199,7 +1200,7 @@ int main(int argc, const char *argv[])
 		       htlcs, &htlc_map, NULL, commitment_number ^ cn_obscurer,
 		       option_anchor_outputs,
 		       option_anchors_zero_fee_htlc_tx,
-		       LOCAL);
+		       LOCAL, &local_anchor);
 	print_superverbose = false;
 	tx2 = commit_tx(tmpctx,
 			&funding,
@@ -1217,7 +1218,7 @@ int main(int argc, const char *argv[])
 			commitment_number ^ cn_obscurer,
 			option_anchor_outputs,
 			option_anchors_zero_fee_htlc_tx,
-			REMOTE);
+			REMOTE, &local_anchor);
 	tx_must_be_eq(tx, tx2);
 	report(tx, wscript, &x_remote_funding_privkey, &remote_funding_pubkey,
 	       &local_funding_privkey, &local_funding_pubkey,

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -541,7 +541,8 @@ int main(int argc, const char *argv[])
 
 	txs = channel_txs(tmpctx, &funding, funding_amount,
 			  &htlc_map, NULL, &funding_wscript_alt,
-			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0,
+			  &local_anchor);
 	assert(tal_count(txs) == 1);
 	assert(tal_count(htlc_map) == 2);
 	assert(scripteq(funding_wscript_alt, funding_wscript));
@@ -549,7 +550,8 @@ int main(int argc, const char *argv[])
 
 	txs2 = channel_txs(tmpctx, &funding, funding_amount,
 			   &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0,
+			   &local_anchor);
 	txs_must_be_eq(txs, txs2);
 
 	/* BOLT #3:
@@ -577,11 +579,13 @@ int main(int argc, const char *argv[])
 
 	txs = channel_txs(tmpctx, &funding, funding_amount,
 			  &htlc_map, NULL, &funding_wscript,
-			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0,
+			  &local_anchor);
 	assert(tal_count(txs) == 1);
 	txs2 = channel_txs(tmpctx, &funding, funding_amount,
 			   &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0,
+			   &local_anchor);
 	txs_must_be_eq(txs, txs2);
 
 	update_feerate(lchannel, feerate_per_kw[LOCAL]);
@@ -597,11 +601,13 @@ int main(int argc, const char *argv[])
 
 	txs = channel_txs(tmpctx, &funding, funding_amount,
 			  &htlc_map, NULL, &funding_wscript,
-			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0,
+			  &local_anchor);
 	assert(tal_count(txs) == 6);
 	txs2 = channel_txs(tmpctx, &funding, funding_amount,
 			   &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0,
+			   &local_anchor);
 	txs_must_be_eq(txs, txs2);
 
 	/* FIXME: Compare signatures! */
@@ -675,13 +681,15 @@ int main(int argc, const char *argv[])
 		txs = channel_txs(tmpctx, &funding, funding_amount,
 				  &htlc_map, NULL, &funding_wscript,
 				  lchannel, &local_per_commitment_point, 42,
-				  LOCAL, 0, 0);
+				  LOCAL, 0, 0,
+				  &local_anchor);
 		tx_must_be_eq(txs[0], raw_tx);
 
 		txs2 = channel_txs(tmpctx, &funding, funding_amount,
 				   &htlc_map, NULL, &funding_wscript,
 				   rchannel, &local_per_commitment_point,
-				   42, REMOTE, 0, 0);
+				   42, REMOTE, 0, 0,
+				   &local_anchor);
 		txs_must_be_eq(txs, txs2);
 	}
 

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -537,17 +537,17 @@ int main(int argc, const char *argv[])
 			   NULL, &htlc_map, NULL, 0x2bb038521914 ^ 42,
 			   option_anchor_outputs, option_anchors_zero_fee_htlc_tx, LOCAL);
 
-	txs = channel_txs(tmpctx,
+	txs = channel_txs(tmpctx, &funding, funding_amount,
 			  &htlc_map, NULL, &funding_wscript_alt,
-			  lchannel, &local_per_commitment_point, 42, LOCAL);
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
 	assert(tal_count(txs) == 1);
 	assert(tal_count(htlc_map) == 2);
 	assert(scripteq(funding_wscript_alt, funding_wscript));
 	tx_must_be_eq(txs[0], raw_tx);
 
-	txs2 = channel_txs(tmpctx,
+	txs2 = channel_txs(tmpctx, &funding, funding_amount,
 			   &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE);
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
 	txs_must_be_eq(txs, txs2);
 
 	/* BOLT #3:
@@ -573,11 +573,13 @@ int main(int argc, const char *argv[])
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
-			  lchannel, &local_per_commitment_point, 42, LOCAL);
+	txs = channel_txs(tmpctx, &funding, funding_amount,
+			  &htlc_map, NULL, &funding_wscript,
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
 	assert(tal_count(txs) == 1);
-	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE);
+	txs2 = channel_txs(tmpctx, &funding, funding_amount,
+			   &htlc_map, NULL, &funding_wscript,
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
 	txs_must_be_eq(txs, txs2);
 
 	update_feerate(lchannel, feerate_per_kw[LOCAL]);
@@ -591,11 +593,13 @@ int main(int argc, const char *argv[])
 	assert(lchannel->view[REMOTE].owed[REMOTE].millisatoshis
 	       == rchannel->view[LOCAL].owed[LOCAL].millisatoshis);
 
-	txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
-			  lchannel, &local_per_commitment_point, 42, LOCAL);
+	txs = channel_txs(tmpctx, &funding, funding_amount,
+			  &htlc_map, NULL, &funding_wscript,
+			  lchannel, &local_per_commitment_point, 42, LOCAL, 0, 0);
 	assert(tal_count(txs) == 6);
-	txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
-			   rchannel, &local_per_commitment_point, 42, REMOTE);
+	txs2 = channel_txs(tmpctx, &funding, funding_amount,
+			   &htlc_map, NULL, &funding_wscript,
+			   rchannel, &local_per_commitment_point, 42, REMOTE, 0, 0);
 	txs_must_be_eq(txs, txs2);
 
 	/* FIXME: Compare signatures! */
@@ -665,14 +669,16 @@ int main(int argc, const char *argv[])
 		    0x2bb038521914 ^ 42,
 		    option_anchor_outputs, option_anchors_zero_fee_htlc_tx, LOCAL);
 
-		txs = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
+		txs = channel_txs(tmpctx, &funding, funding_amount,
+				  &htlc_map, NULL, &funding_wscript,
 				  lchannel, &local_per_commitment_point, 42,
-				  LOCAL);
+				  LOCAL, 0, 0);
 		tx_must_be_eq(txs[0], raw_tx);
 
-		txs2 = channel_txs(tmpctx, &htlc_map, NULL, &funding_wscript,
+		txs2 = channel_txs(tmpctx, &funding, funding_amount,
+				   &htlc_map, NULL, &funding_wscript,
 				   rchannel, &local_per_commitment_point,
-				   42, REMOTE);
+				   42, REMOTE, 0, 0);
 		txs_must_be_eq(txs, txs2);
 	}
 

--- a/channeld/test/run-full_channel.c
+++ b/channeld/test/run-full_channel.c
@@ -364,6 +364,7 @@ int main(int argc, const char *argv[])
 	bool option_anchor_outputs = false;
 	bool option_anchors_zero_fee_htlc_tx = false;
 	u32 blockheight = 0;
+	int local_anchor;
 	size_t i;
 
 	chainparams = chainparams_for_network("bitcoin");
@@ -535,7 +536,8 @@ int main(int argc, const char *argv[])
 			   to_local,
 			   to_remote,
 			   NULL, &htlc_map, NULL, 0x2bb038521914 ^ 42,
-			   option_anchor_outputs, option_anchors_zero_fee_htlc_tx, LOCAL);
+			   option_anchor_outputs, option_anchors_zero_fee_htlc_tx,
+			   LOCAL, &local_anchor);
 
 	txs = channel_txs(tmpctx, &funding, funding_amount,
 			  &htlc_map, NULL, &funding_wscript_alt,
@@ -667,7 +669,8 @@ int main(int argc, const char *argv[])
 		    &keyset, feerate_per_kw[LOCAL], local_config->dust_limit,
 		    to_local, to_remote, htlcs, &htlc_map, NULL,
 		    0x2bb038521914 ^ 42,
-		    option_anchor_outputs, option_anchors_zero_fee_htlc_tx, LOCAL);
+		    option_anchor_outputs, option_anchors_zero_fee_htlc_tx,
+		    LOCAL, &local_anchor);
 
 		txs = channel_txs(tmpctx, &funding, funding_amount,
 				  &htlc_map, NULL, &funding_wscript,

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -422,9 +422,10 @@ int main(int argc, char *argv[])
 	if (!per_commit_point(&localseed, &local_per_commit_point, commitnum))
 		errx(1, "Bad deriving local per-commitment-point");
 
-	local_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+	local_txs = channel_txs(NULL, &channel->funding, channel->funding_sats,
+				&htlcmap, NULL, &funding_wscript, channel,
 				&local_per_commit_point, commitnum,
-				LOCAL);
+				LOCAL, 0, 0);
 
 	printf("## local_commitment\n"
 	       "# input amount %s, funding_wscript %s, pubkey %s\n",
@@ -532,9 +533,10 @@ int main(int argc, char *argv[])
 	/* Create the remote commitment tx */
 	if (!per_commit_point(&remoteseed, &remote_per_commit_point, commitnum))
 		errx(1, "Bad deriving remote per-commitment-point");
-	remote_txs = channel_txs(NULL, &htlcmap, NULL, &funding_wscript, channel,
+	remote_txs = channel_txs(NULL, &channel->funding, channel->funding_sats,
+				 &htlcmap, NULL, &funding_wscript, channel,
 				 &remote_per_commit_point, commitnum,
-				 REMOTE);
+				 REMOTE, 0, 0);
 
 	printf("## remote_commitment\n"
 	       "# input amount %s, funding_wscript %s, key %s\n",

--- a/devtools/mkcommit.c
+++ b/devtools/mkcommit.c
@@ -270,6 +270,7 @@ int main(int argc, char *argv[])
 	const struct channel_type *channel_type;
 	struct sha256_double hash;
 	u32 blockheight = 0;
+	int local_anchor_outnum;
 
 	setup_locale();
 	chainparams = chainparams_for_network("bitcoin");
@@ -425,7 +426,7 @@ int main(int argc, char *argv[])
 	local_txs = channel_txs(NULL, &channel->funding, channel->funding_sats,
 				&htlcmap, NULL, &funding_wscript, channel,
 				&local_per_commit_point, commitnum,
-				LOCAL, 0, 0);
+				LOCAL, 0, 0, &local_anchor_outnum);
 
 	printf("## local_commitment\n"
 	       "# input amount %s, funding_wscript %s, pubkey %s\n",
@@ -536,7 +537,7 @@ int main(int argc, char *argv[])
 	remote_txs = channel_txs(NULL, &channel->funding, channel->funding_sats,
 				 &htlcmap, NULL, &funding_wscript, channel,
 				 &remote_per_commit_point, commitnum,
-				 REMOTE, 0, 0);
+				 REMOTE, 0, 0, &local_anchor_outnum);
 
 	printf("## remote_commitment\n"
 	       "# input amount %s, funding_wscript %s, key %s\n",

--- a/lightningd/anchorspend.h
+++ b/lightningd/anchorspend.h
@@ -12,10 +12,10 @@ struct anchor_details *create_anchor_details(const tal_t *ctx,
 					     struct channel *channel,
 					     const struct bitcoin_tx *tx);
 
-/* Actual commit_tx refresh function: does CPFP using anchors if
- * worthwhile. */
-bool commit_tx_boost(struct channel *channel,
-		     const struct bitcoin_tx **tx,
-		     struct anchor_details *adet);
+/* Called when commit_tx returns from sendrawtx.
+ * Not called once commit_tx is mined, however. */
+void commit_tx_boost(struct channel *channel,
+		     struct anchor_details *adet,
+		     bool success);
 
 #endif /* LIGHTNING_LIGHTNINGD_ANCHORSPEND_H */

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -300,7 +300,7 @@ void broadcast_tx_(const tal_t *ctx,
 		  cmd_id ? " for " : "", cmd_id ? cmd_id : "");
 
 	wallet_transaction_add(topo->ld->wallet, tx->wtx, 0, 0);
-	bitcoind_sendrawtx(ctx, topo->bitcoind, otx->cmd_id,
+	bitcoind_sendrawtx(otx, topo->bitcoind, otx->cmd_id,
 			   fmt_bitcoin_tx(tmpctx, otx->tx),
 			   allowhighfees,
 			   broadcast_done, otx);

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -1228,6 +1228,9 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_CHANNELD_SENDING_COMMITSIG:
 		peer_sending_commitsig(sd->channel, msg);
 		break;
+	case WIRE_CHANNELD_LOCAL_ANCHOR_INFO:
+		/* FIXME */
+		break;
 	case WIRE_CHANNELD_GOT_COMMITSIG:
 		peer_got_commitsig(sd->channel, msg);
 		break;

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2059,8 +2059,6 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 	struct height_states *blockheight_states;
 	struct changed_htlc *changed_htlcs;
 	size_t i, maxid = 0, num_local_added = 0;
-	struct bitcoin_signature commit_sig;
-	struct bitcoin_signature *htlc_sigs;
 	struct lightningd *ld = channel->peer->ld;
 	struct penalty_base *pbase;
 
@@ -2069,8 +2067,7 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 						&pbase,
 						&fee_states,
 						&blockheight_states,
-						&changed_htlcs,
-						&commit_sig, &htlc_sigs)
+						&changed_htlcs)
 	    || !fee_states_valid(fee_states, channel->opener)
 	    || !height_states_valid(blockheight_states, channel->opener)) {
 		channel_internal_error(channel, "bad channel_sending_commitsig %s",

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -170,9 +170,9 @@ struct command_result *command_success(struct command *cmd UNNEEDED,
 
 { fprintf(stderr, "command_success called!\n"); abort(); }
 /* Generated stub for commit_tx_boost */
-bool commit_tx_boost(struct channel *channel UNNEEDED,
-		     const struct bitcoin_tx **tx UNNEEDED,
-		     struct anchor_details *adet UNNEEDED)
+void commit_tx_boost(struct channel *channel UNNEEDED,
+		     struct anchor_details *adet UNNEEDED,
+		     bool success UNNEEDED)
 { fprintf(stderr, "commit_tx_boost called!\n"); abort(); }
 /* Generated stub for connect_any_cmd_id */
 const char *connect_any_cmd_id(const tal_t *ctx UNNEEDED,
@@ -1032,6 +1032,9 @@ struct amount_msat wallet_total_forward_fees(struct wallet *w UNNEEDED)
 void wallet_transaction_add(struct wallet *w UNNEEDED, const struct wally_tx *tx UNNEEDED,
 			    const u32 blockheight UNNEEDED, const u32 txindex UNNEEDED)
 { fprintf(stderr, "wallet_transaction_add called!\n"); abort(); }
+/* Generated stub for wallet_transaction_height */
+u32 wallet_transaction_height(struct wallet *w UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)
+{ fprintf(stderr, "wallet_transaction_height called!\n"); abort(); }
 /* Generated stub for watch_opening_inflight */
 void watch_opening_inflight(struct lightningd *ld UNNEEDED,
 			    struct channel_inflight *inflight UNNEEDED)

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -986,6 +986,14 @@ static struct migration dbmigrations[] = {
      NULL},
     {SQL("ALTER TABLE invoices ADD paid_txid BLOB DEFAULT NULL"), NULL},
     {SQL("ALTER TABLE invoices ADD paid_outnum INTEGER DEFAULT NULL"), NULL},
+    {SQL("CREATE TABLE local_anchors ("
+	 "  channel_id BIGSERIAL REFERENCES channels(id),"
+	 "  commitment_index BIGINT,"
+	 "  commitment_txid BLOB,"
+	 "  commitment_anchor_outnum INTEGER,"
+	 "  commitment_fee BIGINT,"
+	 "  commitment_weight INTEGER)"), NULL},
+    {SQL("CREATE INDEX local_anchors_idx ON local_anchors (channel_id)"), NULL},
 };
 
 /**

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -191,7 +191,7 @@ bool fromwire_channeld_got_revoke(const tal_t *ctx UNNEEDED, const void *p UNNEE
 bool fromwire_channeld_offer_htlc_reply(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *id UNNEEDED, u8 **failuremsg UNNEEDED, wirestring **failurestr UNNEEDED)
 { fprintf(stderr, "fromwire_channeld_offer_htlc_reply called!\n"); abort(); }
 /* Generated stub for fromwire_channeld_sending_commitsig */
-bool fromwire_channeld_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct penalty_base **pbase UNNEEDED, struct fee_states **fee_states UNNEEDED, struct height_states **blockheight_states UNNEEDED, struct changed_htlc **changed UNNEEDED, struct bitcoin_signature *commit_sig UNNEEDED, struct bitcoin_signature **htlc_sigs UNNEEDED)
+bool fromwire_channeld_sending_commitsig(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, u64 *commitnum UNNEEDED, struct penalty_base **pbase UNNEEDED, struct fee_states **fee_states UNNEEDED, struct height_states **blockheight_states UNNEEDED, struct changed_htlc **changed UNNEEDED)
 { fprintf(stderr, "fromwire_channeld_sending_commitsig called!\n"); abort(); }
 /* Generated stub for fromwire_connectd_peer_connected */
 bool fromwire_connectd_peer_connected(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, struct node_id *id UNNEEDED, u64 *counter UNNEEDED, struct wireaddr_internal *addr UNNEEDED, struct wireaddr **remote_addr UNNEEDED, bool *incoming UNNEEDED, u8 **features UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -119,9 +119,9 @@ struct command_result *command_success(struct command *cmd UNNEEDED,
 
 { fprintf(stderr, "command_success called!\n"); abort(); }
 /* Generated stub for commit_tx_boost */
-bool commit_tx_boost(struct channel *channel UNNEEDED,
-		     const struct bitcoin_tx **tx UNNEEDED,
-		     struct anchor_details *adet UNNEEDED)
+void commit_tx_boost(struct channel *channel UNNEEDED,
+		     struct anchor_details *adet UNNEEDED,
+		     bool success UNNEEDED)
 { fprintf(stderr, "commit_tx_boost called!\n"); abort(); }
 /* Generated stub for connect_any_cmd_id */
 const char *connect_any_cmd_id(const tal_t *ctx UNNEEDED,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -24,6 +24,7 @@ struct node_id;
 struct oneshot;
 struct peer;
 struct timers;
+struct local_anchor_info;
 
 struct wallet {
 	struct lightningd *ld;
@@ -1698,4 +1699,38 @@ void wallet_insert_blacklist(struct wallet *wallet, const struct rune_blacklist 
  */
 void wallet_delete_blacklist(struct wallet *wallet, const struct rune_blacklist *entry);
 
+/**
+ * wallet_set_local_anchor -- Set local anchor point for a remote commitment tx
+ * @w: wallet containing the channel
+ * @channel_id: channel database id
+ * @anchor: the local_anchor_info describing the remote commitment tx.
+ * @remote_index: the (remote) commitment index
+ */
+void wallet_set_local_anchor(struct wallet *w,
+			     u64 channel_id,
+			     const struct local_anchor_info *anchor,
+			     u64 remote_index);
+
+/**
+ * wallet_remove_local_anchors -- Remove old local anchor points
+ * @w: wallet containing the channel
+ * @channel_id: channel database id
+ * @old_remote_index: the (remote) commitment index to remove
+ *
+ * Since we only have to keep the last two, we use this to remove the
+ * old entries for the channel.
+ */
+void wallet_remove_local_anchors(struct wallet *w,
+				 u64 channel_id,
+				 u64 old_remote_index);
+
+/**
+ * wallet_get_local_anchors -- Get all local anchor points for remote commitment txs
+ * @ctx: tal context for returned array
+ * @w: wallet containing the channel
+ * @channel_id: channel database id
+ */
+struct local_anchor_info *wallet_get_local_anchors(const tal_t *ctx,
+						   struct wallet *w,
+						   u64 channel_id);
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
~Based on #6751~ (Merged!)

@t-bast pointed out that we should do this.  He's right, but I didn't want to try to reconstruct the peer's commitment transaction, so I save them at signing time: we only need to keep information about anchors on the last two commitment transactions, worst case (there may be more than two, due to splicing), as earlier ones are sure to be revoked.