### PR TITLE
contrib: add `developer` option to config file in startup_regtest.sh.

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -97,6 +97,7 @@ start_nodes() {
 		# If we've configured to use developer, add dev options
 		if $LIGHTNINGD --help | grep -q dev-fast-gossip; then
 			cat <<- EOF >> "/tmp/l$i-$network/config"
+			developer
 			dev-fast-gossip
 			dev-bitcoind-poll=5
 			experimental-dual-fund


### PR DESCRIPTION
Without `developer` option, after compiling CLN and sourcing `contrib/startup_regtest.sh`, if we try to start 2 nodes on regtest running the command `start_ln` we get the following error:

```
lightningd: Config file /tmp/l1-regtest/config line 6: dev-fast-gossip: requires --developer
...
lightningd: Config file /tmp/l2-regtest/config line 6: dev-fast-gossip: requires --developer
```
