### PR TITLE
Restore any missing psbt metadata that resource constrained signers strip

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -86,6 +86,22 @@ struct wally_psbt *new_psbt(const tal_t *ctx, const struct wally_tx *wtx)
 	return psbt;
 }
 
+struct wally_psbt *combine_psbt(const tal_t *ctx,
+				const struct wally_psbt *psbt0,
+				const struct wally_psbt *psbt1)
+{
+	struct wally_psbt *combined_psbt;
+	tal_wally_start();
+	if (wally_psbt_clone_alloc(psbt0, 0, &combined_psbt) != WALLY_OK)
+		abort();
+	if (wally_psbt_combine(combined_psbt, psbt1) != WALLY_OK) {
+		tal_wally_end_onto(ctx, combined_psbt, struct wally_psbt);
+		return tal_free(combined_psbt);
+	}
+	tal_wally_end_onto(ctx, combined_psbt, struct wally_psbt);
+	return combined_psbt;
+}
+
 bool psbt_is_finalized(const struct wally_psbt *psbt)
 {
 	size_t is_finalized;

--- a/bitcoin/psbt.h
+++ b/bitcoin/psbt.h
@@ -51,6 +51,17 @@ struct wally_psbt *new_psbt(const tal_t *ctx,
 struct wally_psbt *clone_psbt(const tal_t *ctx, struct wally_psbt *psbt);
 
 /**
+ * combine_psbt - Combine two PSBT into a cloned copy
+ *
+ * @ctx - allocation context
+ * @psbt0 - one psbt
+ * @psbt1 - other psbt
+ */
+struct wally_psbt *combine_psbt(const tal_t *ctx,
+				const struct wally_psbt *psbt0,
+				const struct wally_psbt *psbt1);
+
+/**
  * psbt_is_finalized - Check if tx is ready to be extracted
  *
  * The libwally library requires a transaction be *ready* for


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/6764

This is an alternate approach to #6766 .  By combining the signed psbt back into the
pre-signed psbt any metadata that a resource constrained signer (VLS) strips (`input.utxo`) will be restored.