### PR TITLE
lightnind: print the version of cln early

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1038,6 +1038,7 @@ int main(int argc, char *argv[])
 	 * variables. */
 	ld = new_lightningd(NULL);
 	ld->state = LD_STATE_INITIALIZING;
+	log_info(ld->log, "%s", version());
 
 	/*~ We store an copy of our arguments before parsing mangles them, so
 	 * we can re-exec if versions of subdaemons change.  Note the use of

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3014,7 +3014,7 @@ def test_notimestamp_logging(node_factory):
     # Make sure this is specified *before* other options!
     l1.daemon.early_opts.insert(0, '--log-timestamps=false')
     l1.start()
-    assert l1.daemon.logs[0].startswith("lightningd-1 DEBUG")
+    assert l1.daemon.logs[0].startswith("lightningd-1 INFO")
 
     assert l1.rpc.listconfigs()['configs']['log-timestamps']['value_bool'] is False
 


### PR DESCRIPTION
As a node matures and is no longer new, it can take some time 
to determine which version of `cln` it's running.

To address this, we now display the version earlier. This ensures 
that even in the event of a crash, we're aware of the running version.


```
(cln-meta-project-py3.11) ➜  lightning git:(macros/log-version) ✗ ./lightningd/lightningd
2023-10-12T19:21:00.899Z INFO    lightningd: lightningd v23.08.1-209-gae94be4-modded
2023-10-12T19:21:00.994Z INFO    lightningd: Creating configuration directory /home/vincent/.lightning/bitcoin
2023-10-12T19:21:01.235Z INFO    lightningd: Creating database
2023-10-12T19:21:01.279Z UNUSUAL hsmd: HSM: created new hsm_secret file

Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?

Make sure you have bitcoind running and that bitcoin-cli is able to connect to bitcoind.

You can verify that your Bitcoin Core installation is ready for use by running:

    $ bitcoin-cli echo 'hello world'
2023-10-12T19:21:01.349Z **BROKEN** plugin-bcli: \nCould not connect to bitcoind using bitcoin-cli. Is bitcoind running?\n\nMake sure you have bitcoind running and that bitcoin-cli is able to connect to bitcoind.\n\nYou can verify that your Bitcoin Core installation is ready for use by running:\n\n    $ bitcoin-cli echo 'hello world'\n
2023-10-12T19:21:01.349Z INFO    plugin-bcli: Killing plugin: exited before we sent init
The Bitcoin backend died.
```

Fixes: https://github.com/ElementsProject/lightning/issues/6374