### PR TITLE
Much more powerful `check` command, and new `recover` command

### DIFF
--- a/common/json_param.h
+++ b/common/json_param.h
@@ -43,11 +43,19 @@ struct command;
 struct command_result;
 
 /*
- * Parse the json tokens.  @params can be an array of values or an object
- * of named values.
+ * All-in-one: parse the json tokens.  @params can be an array of
+ * values or an object of named values.
  */
 bool param(struct command *cmd, const char *buffer,
 	   const jsmntok_t params[], ...) LAST_ARG_NULL;
+
+/*
+ * Version which *doesn't* fail if command_check_only(cmd) is true:
+ * allows you can do extra checks after, but MUST still fail with
+ * command_param_failed(); if command_check_only(cmd) is true! */
+bool param_check(struct command *cmd,
+		 const char *buffer,
+		 const jsmntok_t tokens[], ...) LAST_ARG_NULL;
 
 /*
  * The callback signature.

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -129,6 +129,9 @@ enum jsonrpc_errcode {
 	RUNE_NOT_PERMITTED = 1502,
 	RUNE_BLACKLISTED = 1503,
 
+	/* Errors from recover command */
+	RECOVER_NODE_IN_USE = 1600,
+
 	/* Errors from wait* commands */
 	WAIT_TIMEOUT = 2000,
 };

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1543,6 +1543,9 @@ static void connect_activate(struct daemon *daemon, const u8 *msg)
 								 ->is_websocket),
 						       daemon));
 		}
+	} else {
+		for (size_t i = 0; i < tal_count(daemon->listen_fds); i++)
+			close(daemon->listen_fds[i]->fd);
 	}
 
 	/* Free, with NULL assignment just as an extra sanity check. */

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -715,6 +715,22 @@ class PrettyPrintingLightningRpc(LightningRpc):
                     testpayload[k] = v
             schemas[0].validate(testpayload)
 
+        if method != 'check':
+            if isinstance(payload, dict):
+                checkpayload = payload.copy()
+                checkpayload['command_to_check'] = method
+            elif payload is None:
+                checkpayload = [method]
+            else:
+                checkpayload = [method] + list(payload)
+
+            # This can fail, that's fine!  But causes lightningd to check
+            # that we don't access db.
+            try:
+                LightningRpc.call(self, 'check', checkpayload)
+            except ValueError:
+                pass
+
         res = LightningRpc.call(self, method, payload, cmdprefix, filter)
         self.logger.debug(json.dumps({
             "id": id,

--- a/db/common.h
+++ b/db/common.h
@@ -64,6 +64,9 @@ struct db {
 
 	/* Set by --developer */
 	bool developer;
+
+	/* Fatal if we try to write to db */
+	bool readonly;
 };
 
 struct db_query {

--- a/db/exec.c
+++ b/db/exec.c
@@ -142,6 +142,11 @@ bool db_in_transaction(struct db *db)
 	return db->in_transaction;
 }
 
+void db_set_readonly(struct db *db, bool readonly)
+{
+	db->readonly = readonly;
+}
+
 void db_commit_transaction(struct db *db)
 {
 	bool ok;

--- a/db/exec.h
+++ b/db/exec.h
@@ -48,5 +48,9 @@ bool db_in_transaction(struct db *db);
  */
 void db_commit_transaction(struct db *db);
 
+/**
+ * db_set_readonly - make writes fatal or allowed.
+ */
+void db_set_readonly(struct db *db, bool readonly);
 
 #endif /* LIGHTNING_DB_EXEC_H */

--- a/db/utils.c
+++ b/db/utils.c
@@ -173,6 +173,9 @@ void db_exec_prepared_v2(struct db_stmt *stmt TAKES)
 {
 	bool ret = stmt->db->config->exec_fn(stmt);
 
+	if (stmt->db->readonly)
+		assert(stmt->query->readonly);
+
 	/* If this was a write we need to bump the data_version upon commit. */
 	stmt->db->dirty = stmt->db->dirty || !stmt->query->readonly;
 
@@ -334,6 +337,7 @@ struct db *db_open_(const tal_t *ctx, const char *filename,
 	db->developer = developer;
 	db->errorfn = errorfn;
 	db->errorfn_arg = arg;
+	db->readonly = false;
 	list_head_init(&db->pending_statements);
 	if (!strstr(db->filename, "://"))
 		db_fatal(db, "Could not extract driver name from \"%s\"", db->filename);

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -87,6 +87,7 @@ MANPAGES := doc/lightning-cli.1 \
 	doc/lightning-plugin.7 \
 	doc/lightning-preapproveinvoice.7 \
 	doc/lightning-preapprovekeysend.7 \
+	doc/lightning-recover.7 \
 	doc/lightning-recoverchannel.7 \
 	doc/lightning-renepay.7 \
 	doc/lightning-renepaystatus.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -99,6 +99,7 @@ Core Lightning Documentation
    lightning-plugin <lightning-plugin.7.md>
    lightning-preapproveinvoice <lightning-preapproveinvoice.7.md>
    lightning-preapprovekeysend <lightning-preapprovekeysend.7.md>
+   lightning-recover <lightning-recover.7.md>
    lightning-recoverchannel <lightning-recoverchannel.7.md>
    lightning-renepay <lightning-renepay.7.md>
    lightning-renepaystatus <lightning-renepaystatus.7.md>

--- a/doc/lightning-check.7.md
+++ b/doc/lightning-check.7.md
@@ -9,14 +9,18 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **check** RPC command verifies another command's parameters without
-running it.
+The **check** RPC command verifies another command without actually 
+making any changes.
 
 The *command\_to\_check* is the name of the relevant command.
 
 *parameters* is the command's parameters.
 
-This does not guarantee successful execution of the command in all
+This is guaranteed to be safe, and will do all checks up to the point
+where something in the system would need to be altered (such as checking
+that channels are in the right state, peers connected, etc).
+
+It does not guarantee successful execution of the command in all
 cases. For example, a call to lightning-getroute(7) may still fail to
 find a route even if checking the parameters succeeds.
 

--- a/doc/lightning-recover.7.md
+++ b/doc/lightning-recover.7.md
@@ -1,0 +1,42 @@
+lightning-recover -- Reinitialize Your Node for Recovery
+========================================================
+
+SYNOPSIS
+--------
+
+**recover** *hsmsecret*
+
+DESCRIPTION
+-----------
+
+The **recover** RPC command wipes your node and restarts it with
+the `--recover` option.  This is only permitted if the node is unused:
+no channels, no bitcoin addresses issued (you can use `check` to see
+if recovery is possible).
+
+*hsmsecret* is either a codex32 secret starting with "cl1" as returned
+by `hsmtool getcodexsecret`, or a raw 64 character hex string.
+
+NOTE: this command only currently works with the `sqlite3` database backend.
+
+RETURN VALUE
+------------
+
+On success, an empty object is returned, and your node is restarted.
+
+AUTHOR
+------
+
+Rusty Russell <<rusty@blockstream.com>> is mainly responsible.
+
+SEE ALSO
+--------
+
+lightning-hsmtool(7)
+
+RESOURCES
+---------
+
+Main web site: <https://github.com/ElementsProject/lightning>
+
+[comment]: # ( SHA256STAMP:9cfaa9eb4609b36accc3e3b12a352c00ddd402307e4461f4df274146d12f6eb0)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -294,9 +294,9 @@ connections; default is not to activate the plugin at all.
 
 ### Lightning node customization options
 
-* **recover**=*codex32secret*
+* **recover**=*hsmsecret*
 
-  Restore the node from a 32-byte secret encoded as a codex32 secret string: this will fail if the `hsm_secret` file exists.  Your node will start the node in offline mode, for manual recovery.  The secret can be extracted from the `hsm_secret` using hsmtool(8).
+  Restore the node from a 32-byte secret encoded as either a codex32 secret string or a 64-character hex string: this will fail if the `hsm_secret` file exists.  Your node will start the node in offline mode, for manual recovery.  The secret can be extracted from the `hsm_secret` using hsmtool(8).
 
 * **alias**=*NAME*
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -429,15 +429,15 @@ static struct command_result *json_setleaserates(struct command *cmd,
 	struct amount_msat *channel_fee_base_msat, *lease_base_msat;
 	u32 *lease_basis, *channel_fee_max_ppt, *funding_weight;
 
-	if (!param(cmd, buffer, params,
-		   p_req("lease_fee_base_msat", param_msat, &lease_base_msat),
-		   p_req("lease_fee_basis", param_number, &lease_basis),
-		   p_req("funding_weight", param_number, &funding_weight),
-		   p_req("channel_fee_max_base_msat", param_msat,
-			 &channel_fee_base_msat),
-		   p_req("channel_fee_max_proportional_thousandths",
-			 param_number, &channel_fee_max_ppt),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("lease_fee_base_msat", param_msat, &lease_base_msat),
+			 p_req("lease_fee_basis", param_number, &lease_basis),
+			 p_req("funding_weight", param_number, &funding_weight),
+			 p_req("channel_fee_max_base_msat", param_msat,
+			       &channel_fee_base_msat),
+			 p_req("channel_fee_max_proportional_thousandths",
+			       param_number, &channel_fee_max_ppt),
+			 NULL))
 		return command_param_failed();
 
 	rates = tal(tmpctx, struct lease_rates);
@@ -457,6 +457,9 @@ static struct command_result *json_setleaserates(struct command *cmd,
 	if (channel_fee_base_msat->millisatoshis > rates->channel_fee_max_base_msat) /* Raw: comparison */
 		return command_fail_badparam(cmd, "channel_fee_max_base_msat",
 					     buffer, params, "Overflow");
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	/* Call gossipd, let them know we've got new rates */
 	subd_send_msg(cmd->ld->gossip,

--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -239,10 +239,10 @@ static struct command_result *json_makesecret(struct command *cmd,
 	struct json_stream *response;
 	struct secret secret;
 
-	if (!param(cmd, buffer, params,
-		   p_opt("hex", param_bin_from_hex, &data),
-		   p_opt("string", param_string, &strdata),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_opt("hex", param_bin_from_hex, &data),
+			 p_opt("string", param_string, &strdata),
+			 NULL))
 		return command_param_failed();
 
 	if (strdata) {
@@ -256,6 +256,8 @@ static struct command_result *json_makesecret(struct command *cmd,
 					    "Must have either hex or string");
 	}
 
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	u8 *msg = towire_hsmd_derive_secret(cmd, data);
 	if (!wire_sync_write(cmd->ld->hsm_fd, take(msg)))

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -1099,20 +1099,20 @@ static struct command_result *json_invoice(struct command *cmd,
 	info = tal(cmd, struct invoice_info);
 	info->cmd = cmd;
 
-	if (!param(cmd, buffer, params,
-		   p_req("amount_msat|msatoshi", param_positive_msat_or_any, &msatoshi_val),
-		   p_req("label", param_label, &info->label),
-		   p_req("description", param_escaped_string, &desc_val),
-		   p_opt_def("expiry", param_u64, &expiry, 3600*24*7),
-		   p_opt("fallbacks", param_array, &fallbacks),
-		   p_opt("preimage", param_preimage, &preimage),
-		   p_opt("exposeprivatechannels", param_chanhints,
-			 &info->chanhints),
-		   p_opt_def("cltv", param_number, &cltv,
-			     cmd->ld->config.cltv_final),
-		   p_opt_def("deschashonly", param_bool, &hashonly, false),
-		   p_opt("dev-routes", param_array, &dev_routes),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("amount_msat|msatoshi", param_positive_msat_or_any, &msatoshi_val),
+			 p_req("label", param_label, &info->label),
+			 p_req("description", param_escaped_string, &desc_val),
+			 p_opt_def("expiry", param_u64, &expiry, 3600*24*7),
+			 p_opt("fallbacks", param_array, &fallbacks),
+			 p_opt("preimage", param_preimage, &preimage),
+			 p_opt("exposeprivatechannels", param_chanhints,
+			       &info->chanhints),
+			 p_opt_def("cltv", param_number, &cltv,
+				   cmd->ld->config.cltv_final),
+			 p_opt_def("deschashonly", param_bool, &hashonly, false),
+			 p_opt("dev-routes", param_array, &dev_routes),
+			 NULL))
 		return command_param_failed();
 
 	if (dev_routes && !cmd->ld->developer)
@@ -1132,6 +1132,9 @@ static struct command_result *json_invoice(struct command *cmd,
 				    BOLT11_FIELD_BYTE_LIMIT,
 				    strlen(desc_val));
 	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	if (fallbacks) {
 		size_t i;
@@ -1280,15 +1283,15 @@ static struct command_result *json_listinvoices(struct command *cmd,
 	u32 *listlimit;
 	char *fail;
 
-	if (!param(cmd, buffer, params,
-		   p_opt("label", param_label, &label),
-		   p_opt("invstring", param_invstring, &invstring),
-		   p_opt("payment_hash", param_sha256, &payment_hash),
-		   p_opt("offer_id", param_sha256, &offer_id),
-		   p_opt("index", param_index, &listindex),
-		   p_opt_def("start", param_u64, &liststart, 0),
-		   p_opt("limit", param_u32, &listlimit),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_opt("label", param_label, &label),
+			 p_opt("invstring", param_invstring, &invstring),
+			 p_opt("payment_hash", param_sha256, &payment_hash),
+			 p_opt("offer_id", param_sha256, &offer_id),
+			 p_opt("index", param_index, &listindex),
+			 p_opt_def("start", param_u64, &liststart, 0),
+			 p_opt("limit", param_u32, &listlimit),
+			 NULL))
 		return command_param_failed();
 
 	/* Yeah, I wasn't sure about this style either.  It's curt though! */
@@ -1328,6 +1331,9 @@ static struct command_result *json_listinvoices(struct command *cmd,
 		}
 	}
 
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	response = json_stream_success(cmd);
 	json_array_start(response, "invoices");
 	json_add_invoices(response, wallet, label, payment_hash, offer_id,
@@ -1358,11 +1364,11 @@ static struct command_result *json_delinvoice(struct command *cmd,
 	struct wallet *wallet = cmd->ld->wallet;
 	bool *deldesc;
 
-	if (!param(cmd, buffer, params,
-		   p_req("label", param_label, &label),
-		   p_req("status", param_string, &status),
-		   p_opt_def("desconly", param_bool, &deldesc, false),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("label", param_label, &label),
+			 p_req("status", param_string, &status),
+			 p_opt_def("desconly", param_bool, &deldesc, false),
+			 NULL))
 		return command_param_failed();
 
 	if (!invoices_find_by_label(wallet->invoices, &inv_dbid, label)) {
@@ -1391,6 +1397,9 @@ static struct command_result *json_delinvoice(struct command *cmd,
 			return command_fail(cmd, INVOICE_NO_DESCRIPTION,
 					    "Invoice description already removed");
 
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
+
 		if (!invoices_delete_description(wallet->invoices, inv_dbid,
 						 details->label, details->description)) {
 			log_broken(cmd->ld->log,
@@ -1401,6 +1410,9 @@ static struct command_result *json_delinvoice(struct command *cmd,
 		}
 		details->description = tal_free(details->description);
 	} else {
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
+
 		if (!invoices_delete(wallet->invoices, inv_dbid,
 				     details->state,
 				     details->label,
@@ -1517,14 +1529,17 @@ static struct command_result *json_waitinvoice(struct command *cmd,
 	struct wallet *wallet = cmd->ld->wallet;
 	struct json_escape *label;
 
-	if (!param(cmd, buffer, params,
-		   p_req("label", param_label, &label),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("label", param_label, &label),
+			 NULL))
 		return command_param_failed();
 
 	if (!invoices_find_by_label(wallet->invoices, &inv_dbid, label)) {
 		return command_fail(cmd, LIGHTNINGD, "Label not found");
 	}
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	details = invoices_get_details(cmd, cmd->ld->wallet->invoices, inv_dbid);
 
 	/* If paid or expired return immediately */
@@ -1558,10 +1573,10 @@ static struct command_result *json_decodepay(struct command *cmd,
 	const char *str, *desc;
 	char *fail;
 
-	if (!param(cmd, buffer, params,
-		   p_req("bolt11", param_invstring, &str),
-		   p_opt("description", param_escaped_string, &desc),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("bolt11", param_invstring, &str),
+			 p_opt("description", param_escaped_string, &desc),
+			 NULL))
 		return command_param_failed();
 
 	b11 = bolt11_decode(cmd, str, cmd->ld->our_features, desc, NULL,
@@ -1570,6 +1585,9 @@ static struct command_result *json_decodepay(struct command *cmd,
 	if (!b11) {
 		return command_fail(cmd, LIGHTNINGD, "Invalid bolt11: %s", fail);
 	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	response = json_stream_success(cmd);
 	json_add_bolt11(response, b11);
@@ -1679,11 +1697,11 @@ static struct command_result *json_createinvoice(struct command *cmd,
 	bool have_n;
 	char *fail;
 
-	if (!param(cmd, buffer, params,
-		   p_req("invstring", param_invstring, &invstring),
-		   p_req("label", param_label, &label),
-		   p_req("preimage", param_preimage, &preimage),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("invstring", param_invstring, &invstring),
+			 p_req("label", param_label, &label),
+			 p_req("preimage", param_preimage, &preimage),
+			 NULL))
 		return command_param_failed();
 
 	sha256(&payment_hash, preimage, sizeof(*preimage));
@@ -1706,6 +1724,9 @@ static struct command_result *json_createinvoice(struct command *cmd,
 		if (!sha256_eq(&payment_hash, &b11->payment_hash))
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Incorrect preimage");
+
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
 
 		if (!invoices_create(cmd->ld->wallet->invoices,
 				     &inv_dbid,
@@ -1797,6 +1818,10 @@ static struct command_result *json_createinvoice(struct command *cmd,
 		if (!inv->offer_description)
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Missing description in invoice");
+
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
+
 		desc = tal_strndup(cmd,
 				   inv->offer_description,
 				   tal_bytelen(inv->offer_description));
@@ -1924,9 +1949,9 @@ static struct command_result *json_signinvoice(struct command *cmd,
 	bool have_n;
 	char *fail;
 
-	if (!param(cmd, buffer, params,
-		   p_req("invstring", param_invstring, &invstring),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("invstring", param_invstring, &invstring),
+			 NULL))
 		return command_param_failed();
 
 	b11 = bolt11_decode_nosig(cmd, invstring, cmd->ld->our_features,
@@ -1950,6 +1975,9 @@ static struct command_result *json_signinvoice(struct command *cmd,
 	if (!b11->description && !b11->description_hash)
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				    "Missing description in invoice");
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	response = json_stream_success(cmd);
 	json_add_invstring(response, b11enc);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -1849,11 +1849,6 @@ static struct command_result *json_preapproveinvoice(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
-	/* Strip optional URI preamble. */
-	if (strncmp(invstring, "lightning:", 10) == 0 ||
-	    strncmp(invstring, "LIGHTNING:", 10) == 0)
-		invstring += 10;
-
 	msg = hsm_sync_req(tmpctx, cmd->ld,
 			   take(towire_hsmd_preapprove_invoice(NULL, invstring)));
         if (!fromwire_hsmd_preapprove_invoice_reply(msg, &approved))

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -396,9 +396,9 @@ static struct command_result *json_help(struct command *cmd,
 	struct json_command **commands;
 	const struct json_command *one_cmd;
 
-	if (!param(cmd, buffer, params,
-		   p_opt("command", param_string, &cmdname),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_opt("command", param_string, &cmdname),
+			 NULL))
 		return command_param_failed();
 
 	commands = cmd->ld->jsonrpc->commands;
@@ -418,6 +418,9 @@ static struct command_result *json_help(struct command *cmd,
 					    cmdname);
 	} else
 		one_cmd = NULL;
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	asort(commands, tal_count(commands), compare_commands_name, NULL);
 

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1522,7 +1522,10 @@ static struct command_result *json_check(struct command *cmd,
 	json_tok_remove(&mod_params, mod_params, name_tok, 1);
 
 	cmd->mode = CMD_CHECK;
+	/* Make *sure* it doesn't try to manip db! */
+	db_set_readonly(cmd->ld->wallet->db, true);
 	res = cmd->json_cmd->dispatch(cmd, buffer, mod_params, mod_params);
+	db_set_readonly(cmd->ld->wallet->db, false);
 
 	/* CMD_CHECK always makes it "fail" parameter parsing. */
 	assert(res == &param_failed);

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -14,12 +14,15 @@
  */
 /* eg: { "jsonrpc":"2.0", "method" : "dev-echo", "params" : [ "hello", "Arabella!" ], "id" : "1" } */
 #include "config.h"
+#include <ccan/array_size/array_size.h>
 #include <ccan/asort/asort.h>
 #include <ccan/err/err.h>
 #include <ccan/io/io.h>
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/json_out/json_out.h>
+#include <ccan/tal/path/path.h>
 #include <ccan/tal/str/str.h>
+#include <common/codex32.h>
 #include <common/configdir.h>
 #include <common/json_command.h>
 #include <common/json_filter.h>
@@ -27,9 +30,12 @@
 #include <common/memleak.h>
 #include <common/timeout.h>
 #include <common/trace.h>
+#include <db/common.h>
 #include <db/exec.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <lightningd/jsonrpc.h>
+#include <lightningd/options.h>
 #include <lightningd/plugin_hook.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -184,19 +190,14 @@ static const struct json_command help_command = {
 };
 AUTODATA(json_command, &help_command);
 
-static struct command_result *json_stop(struct command *cmd,
-					const char *buffer,
-					const jsmntok_t *obj UNNEEDED,
-					const jsmntok_t *params)
+/* We prepare a canned JSON response, for top level to write as reply
+ * immediately before we exit. */
+static struct command_result *prepare_stop_conn(struct command *cmd,
+						const char *why)
 {
 	struct json_out *jout;
 	const char *p;
 	size_t len;
-
-	if (!param(cmd, buffer, params, NULL))
-		return command_param_failed();
-
-	log_unusual(cmd->ld->log, "JSON-RPC shutdown");
 
 	/* With rpc_command_hook, jcon might have closed in the meantime! */
 	if (!cmd->jcon) {
@@ -215,7 +216,7 @@ static struct command_result *json_stop(struct command *cmd,
 	/* Copy input id token exactly */
 	memcpy(json_out_member_direct(jout, "id", strlen(cmd->id)),
 	       cmd->id, strlen(cmd->id));
-	json_out_addstr(jout, "result", "Shutdown complete");
+	json_out_addstr(jout, "result", why);
 	json_out_end(jout, '}');
 	json_out_finished(jout);
 
@@ -230,6 +231,18 @@ static struct command_result *json_stop(struct command *cmd,
 	return command_still_pending(cmd);
 }
 
+static struct command_result *json_stop(struct command *cmd,
+					const char *buffer,
+					const jsmntok_t *obj UNNEEDED,
+					const jsmntok_t *params)
+{
+	if (!param(cmd, buffer, params, NULL))
+		return command_param_failed();
+
+	log_unusual(cmd->ld->log, "JSON-RPC shutdown");
+	return prepare_stop_conn(cmd, "Shutdown complete");
+}
+
 static const struct json_command stop_command = {
 	"stop",
 	"utility",
@@ -237,6 +250,113 @@ static const struct json_command stop_command = {
 	"Shut down the lightningd process"
 };
 AUTODATA(json_command, &stop_command);
+
+static bool have_channels(struct lightningd *ld)
+{
+	struct peer_node_id_map_iter it;
+	struct peer *peer;
+
+	for (peer = peer_node_id_map_first(ld->peers, &it);
+	     peer;
+	     peer = peer_node_id_map_next(ld->peers, &it)) {
+		if (peer->uncommitted_channel)
+			return true;
+		if (!list_empty(&peer->channels))
+			return true;
+	}
+	return false;
+}
+
+static struct command_result *param_codex32_or_hex(struct command *cmd,
+						   const char *name,
+						   const char *buffer,
+						   const jsmntok_t *tok,
+						   const char **hsm_secret)
+{
+	char *err;
+	const u8 *payload;
+
+	*hsm_secret = json_strdup(cmd, buffer, tok);
+	err = hsm_secret_arg(tmpctx, *hsm_secret, &payload);
+	if (err)
+		return command_fail_badparam(cmd, name, buffer, tok, err);
+	return NULL;
+}
+
+/* We cannot --recover unless these files are not in place. */
+static void move_prerecover_files(const char *dir)
+{
+	const char *files[] = {
+		"lightningd.sqlite3",
+		"emergency.recover",
+		"hsm_secret",
+	};
+
+	if (mkdir(dir, 0770) != 0)
+		fatal("Could not make %s: %s", dir, strerror(errno));
+	for (size_t i = 0; i < ARRAY_SIZE(files); i++) {
+		if (rename(files[i], path_join(tmpctx, dir, files[i])) != 0) {
+			fatal("Could not move %s: %s", files[i], strerror(errno));
+		}
+	}
+}
+
+static struct command_result *json_recover(struct command *cmd,
+					   const char *buffer,
+					   const jsmntok_t *obj UNNEEDED,
+					   const jsmntok_t *params)
+{
+	const char *hsm_secret, *dir;
+
+	if (!param_check(cmd, buffer, params,
+			 p_req("hsmsecret", param_codex32_or_hex, &hsm_secret),
+			 NULL))
+		return command_param_failed();
+
+	/* FIXME: How do we "move" the Postgres DB? */
+	if (!streq(cmd->ld->wallet->db->config->name, "sqlite3"))
+		return command_fail(cmd, LIGHTNINGD,
+				    "Only sqlite3 supported for recover command");
+
+	/* Check this is an empty node! */
+	if (db_get_intvar(cmd->ld->wallet->db, "bip32_max_index", 0) != 0) {
+		return command_fail(cmd, RECOVER_NODE_IN_USE,
+				    "Node has already issued bitcoin addresses!");
+	}
+
+	if (have_channels(cmd->ld)) {
+		return command_fail(cmd, RECOVER_NODE_IN_USE,
+				    "Node has channels!");
+	}
+
+	/* Don't try to add --recover to cmdline twice! */
+	if (cmd->ld->recover != NULL) {
+		return command_fail(cmd, RECOVER_NODE_IN_USE,
+				    "Already doing recover");
+	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	dir = tal_fmt(tmpctx, "lightning.pre-recover.%u", getpid());
+	log_unusual(cmd->ld->log,
+		    "JSON-RPC recovery command: moving existing files to %s", dir);
+
+	move_prerecover_files(dir);
+
+	/* Top level with add --recover=... here */
+	cmd->ld->recover_secret = tal_steal(cmd->ld, hsm_secret);
+	cmd->ld->try_reexec = true;
+	return prepare_stop_conn(cmd, "Recovery restart in progress");
+}
+
+static const struct json_command recover_command = {
+	"recover",
+	"utility",
+	json_recover,
+	"Restart an unused lightning node with --recover"
+};
+AUTODATA(json_command, &recover_command);
 
 struct slowcmd {
 	struct command *cmd;

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -15,7 +15,9 @@ enum command_mode {
 	/* Create command usage string, nothing else. */
 	CMD_USAGE,
 	/* Check parameters, nothing else. */
-	CMD_CHECK
+	CMD_CHECK,
+	/* Check parameters, and one failed. */
+	CMD_CHECK_FAILED,
 };
 
 /* Context for a command (from JSON, but might outlive the connection!). */
@@ -147,6 +149,11 @@ struct logger *command_log(struct command *cmd);
 
 /* To return if param() fails. */
 extern struct command_result *command_param_failed(void)
+	 WARN_UNUSED_RESULT;
+
+/* To return after param_check() succeeds but we're still
+ * command_check_only(cmd). */
+struct command_result *command_check_done(struct command *cmd)
 	 WARN_UNUSED_RESULT;
 
 /* Wrapper for pending commands (ignores return) */

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -371,6 +371,8 @@ struct lightningd {
 
 	/* Should we re-exec ourselves instead of just exiting? */
 	bool try_reexec;
+	/* If set, we are to restart with --recover=... */
+	const char *recover_secret;
 
 	/* Array of (even) TLV types that we should allow. This is required
 	 * since we otherwise would outright reject them. */

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -222,13 +222,16 @@ static struct command_result *json_memleak(struct command *cmd,
 	bool found_leak;
 	struct leak_detect *leaks;
 
-	if (!param(cmd, buffer, params, NULL))
+	if (!param_check(cmd, buffer, params, NULL))
 		return command_param_failed();
 
 	if (!getenv("LIGHTNINGD_DEV_MEMLEAK")) {
 		return command_fail(cmd, LIGHTNINGD,
 				    "Leak detection needs $LIGHTNINGD_DEV_MEMLEAK");
 	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	leaks = tal(cmd, struct leak_detect);
 	leaks->cmd = cmd;

--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -203,9 +203,9 @@ static struct command_result *json_disableoffer(struct command *cmd,
 	const struct json_escape *label;
 	enum offer_status status;
 
-	if (!param(cmd, buffer, params,
-		   p_req("offer_id", param_sha256, &offer_id),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("offer_id", param_sha256, &offer_id),
+			 NULL))
 		return command_param_failed();
 
 	b12 = wallet_offer_find(tmpctx, wallet, offer_id, &label, &status);
@@ -215,6 +215,10 @@ static struct command_result *json_disableoffer(struct command *cmd,
 	if (!offer_status_active(status))
 		return command_fail(cmd, OFFER_ALREADY_DISABLED,
 				    "offer is not active");
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	status = wallet_offer_disable(wallet, offer_id, status);
 
 	response = json_stream_success(cmd);
@@ -398,13 +402,13 @@ static struct command_result *json_createinvoicerequest(struct command *cmd,
 	struct sha256 invreq_id;
 	const char *b12str;
 
-	if (!param(cmd, buffer, params,
-		   p_req("bolt12", param_b12_invreq, &invreq),
-		   p_req("savetodb", param_bool, &save),
-		   p_opt_def("exposeid", param_bool, &exposeid, false),
-		   p_opt("recurrence_label", param_label, &label),
-		   p_opt_def("single_use", param_bool, &single_use, true),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("bolt12", param_b12_invreq, &invreq),
+			 p_req("savetodb", param_bool, &save),
+			 p_opt_def("exposeid", param_bool, &exposeid, false),
+			 p_opt("recurrence_label", param_label, &label),
+			 p_opt_def("single_use", param_bool, &single_use, true),
+			 NULL))
 		return command_param_failed();
 
 	if (*single_use)
@@ -458,6 +462,9 @@ static struct command_result *json_createinvoicerequest(struct command *cmd,
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				    "Invalid tweak");
 	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	/* BOLT-offers #12:
 	 *  - MUST set `signature`.`sig` as detailed in
@@ -610,9 +617,9 @@ static struct command_result *json_disableinvoicerequest(struct command *cmd,
 	const struct json_escape *label;
 	enum offer_status status;
 
-	if (!param(cmd, buffer, params,
-		   p_req("invreq_id", param_sha256, &invreq_id),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("invreq_id", param_sha256, &invreq_id),
+			 NULL))
 		return command_param_failed();
 
 	b12 = wallet_invoice_request_find(tmpctx, wallet, invreq_id,
@@ -623,6 +630,10 @@ static struct command_result *json_disableinvoicerequest(struct command *cmd,
 	if (!offer_status_active(status))
 		return command_fail(cmd, OFFER_ALREADY_DISABLED,
 				    "invoice_request is not active");
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	status = wallet_invoice_request_disable(wallet, invreq_id, status);
 
 	response = json_stream_success(cmd);

--- a/lightningd/options.h
+++ b/lightningd/options.h
@@ -15,6 +15,18 @@ void handle_opts(struct lightningd *ld);
 /* Derive default color and alias from the pubkey. */
 void setup_color_and_alias(struct lightningd *ld);
 
+/**
+ * hsm_secret_arg - parse an hsm_secret as hex or codex32
+ * @ctx: context to allocate @hsm_secret from
+ * @arg: string to parse
+ * @hsm_secret: set on success.
+ *
+ * Returns NULL on success (and sets hsm_secret) otherwise, error msg
+ */
+char *hsm_secret_arg(const tal_t *ctx,
+		     const char *arg,
+		     const u8 **hsm_secret);
+
 enum opt_autobool {
 	OPT_AUTOBOOL_FALSE = 0,
 	OPT_AUTOBOOL_TRUE = 1,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2955,10 +2955,10 @@ static struct command_result *json_dev_ignore_htlcs(struct command *cmd,
 	struct peer *peer;
 	bool *ignore;
 
-	if (!param(cmd, buffer, params,
-		   p_req("id", param_node_id, &peerid),
-		   p_req("ignore", param_bool, &ignore),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("id", param_node_id, &peerid),
+			 p_req("ignore", param_bool, &ignore),
+			 NULL))
 		return command_param_failed();
 
 	peer = peer_by_id(cmd->ld, peerid);
@@ -2966,6 +2966,9 @@ static struct command_result *json_dev_ignore_htlcs(struct command *cmd,
 		return command_fail(cmd, LIGHTNINGD,
 				    "Could not find channel with that peer");
 	}
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	peer->dev_ignore_htlcs = *ignore;
 
 	return command_success(cmd, json_stream_success(cmd));

--- a/lightningd/ping.c
+++ b/lightningd/ping.c
@@ -45,11 +45,11 @@ static struct command_result *json_ping(struct command *cmd,
 	struct node_id *id;
 	u8 *msg;
 
-	if (!param(cmd, buffer, params,
-		   p_req("id", param_node_id, &id),
-		   p_opt_def("len", param_number, &len, 128),
-		   p_opt_def("pongbytes", param_number, &pongbytes, 128),
-		   NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_req("id", param_node_id, &id),
+			 p_opt_def("len", param_number, &len, 128),
+			 p_opt_def("pongbytes", param_number, &pongbytes, 128),
+			 NULL))
 		return command_param_failed();
 
 	/* BOLT #1:
@@ -79,6 +79,9 @@ static struct command_result *json_ping(struct command *cmd,
 
 	if (!peer_by_id(cmd->ld, id))
 		return command_fail(cmd, LIGHTNINGD, "Peer not connected");
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
 
 	msg = towire_connectd_ping(NULL, id, *pongbytes, *len);
 	subd_req(cmd, cmd->ld->connectd, take(msg), -1, 0, ping_reply, cmd);

--- a/lightningd/runes.c
+++ b/lightningd/runes.c
@@ -647,13 +647,17 @@ static struct command_result *json_blacklistrune(struct command *cmd,
 	u64 *start, *end;
 	struct rune_blacklist *entry, *newblacklist;
 
-	if (!param(cmd, buffer, params,
-		   p_opt("start", param_u64, &start), p_opt("end", param_u64, &end), NULL))
+	if (!param_check(cmd, buffer, params,
+			 p_opt("start", param_u64, &start), p_opt("end", param_u64, &end), NULL))
 		return command_param_failed();
 
 	if (end && !start) {
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS, "Can not specify end without start");
 	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
 	if (!start) {
 		return list_blacklist(cmd);
 	}

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -132,6 +132,13 @@ void channeld_tell_depth(struct channel *channel UNNEEDED,
 const char *cmd_id_from_close_command(const tal_t *ctx UNNEEDED,
 				      struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED)
 { fprintf(stderr, "cmd_id_from_close_command called!\n"); abort(); }
+/* Generated stub for command_check_done */
+struct command_result *command_check_done(struct command *cmd)
+
+{ fprintf(stderr, "command_check_done called!\n"); abort(); }
+/* Generated stub for command_check_only */
+bool command_check_only(const struct command *cmd UNNEEDED)
+{ fprintf(stderr, "command_check_only called!\n"); abort(); }
 /* Generated stub for command_fail */
 struct command_result *command_fail(struct command *cmd UNNEEDED, enum jsonrpc_errcode code UNNEEDED,
 				    const char *fmt UNNEEDED, ...)
@@ -737,6 +744,11 @@ struct command_result *param_channel_id(struct command *cmd UNNEEDED,
 					const jsmntok_t *tok UNNEEDED,
 					struct channel_id **cid UNNEEDED)
 { fprintf(stderr, "param_channel_id called!\n"); abort(); }
+/* Generated stub for param_check */
+bool param_check(struct command *cmd UNNEEDED,
+		 const char *buffer UNNEEDED,
+		 const jsmntok_t tokens[] UNNEEDED, ...)
+{ fprintf(stderr, "param_check called!\n"); abort(); }
 /* Generated stub for param_escaped_string */
 struct command_result *param_escaped_string(struct command *cmd UNNEEDED,
 					    const char *name UNNEEDED,

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -13,6 +13,9 @@ void db_begin_transaction_(struct db *db UNNEEDED, const char *location UNNEEDED
 /* Generated stub for db_commit_transaction */
 void db_commit_transaction(struct db *db UNNEEDED)
 { fprintf(stderr, "db_commit_transaction called!\n"); abort(); }
+/* Generated stub for db_get_intvar */
+s64 db_get_intvar(struct db *db UNNEEDED, const char *varname UNNEEDED, s64 defval UNNEEDED)
+{ fprintf(stderr, "db_get_intvar called!\n"); abort(); }
 /* Generated stub for db_set_readonly */
 void db_set_readonly(struct db *db UNNEEDED, bool readonly UNNEEDED)
 { fprintf(stderr, "db_set_readonly called!\n"); abort(); }
@@ -44,6 +47,11 @@ void fromwire_node_id(const u8 **cursor UNNEEDED, size_t *max UNNEEDED, struct n
 /* Generated stub for get_feerate_floor */
 u32 get_feerate_floor(const struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "get_feerate_floor called!\n"); abort(); }
+/* Generated stub for hsm_secret_arg */
+char *hsm_secret_arg(const tal_t *ctx UNNEEDED,
+		     const char *arg UNNEEDED,
+		     const u8 **hsm_secret UNNEEDED)
+{ fprintf(stderr, "hsm_secret_arg called!\n"); abort(); }
 /* Generated stub for htlc_resolution_feerate */
 u32 htlc_resolution_feerate(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "htlc_resolution_feerate called!\n"); abort(); }

--- a/lightningd/test/run-jsonrpc.c
+++ b/lightningd/test/run-jsonrpc.c
@@ -13,6 +13,9 @@ void db_begin_transaction_(struct db *db UNNEEDED, const char *location UNNEEDED
 /* Generated stub for db_commit_transaction */
 void db_commit_transaction(struct db *db UNNEEDED)
 { fprintf(stderr, "db_commit_transaction called!\n"); abort(); }
+/* Generated stub for db_set_readonly */
+void db_set_readonly(struct db *db UNNEEDED, bool readonly UNNEEDED)
+{ fprintf(stderr, "db_set_readonly called!\n"); abort(); }
 /* Generated stub for delayed_to_us_feerate */
 u32 delayed_to_us_feerate(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "delayed_to_us_feerate called!\n"); abort(); }
@@ -94,6 +97,11 @@ struct command_result *param_bool(struct command *cmd UNNEEDED, const char *name
 				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				  bool **b UNNEEDED)
 { fprintf(stderr, "param_bool called!\n"); abort(); }
+/* Generated stub for param_check */
+bool param_check(struct command *cmd UNNEEDED,
+		 const char *buffer UNNEEDED,
+		 const jsmntok_t tokens[] UNNEEDED, ...)
+{ fprintf(stderr, "param_check called!\n"); abort(); }
 /* Generated stub for param_ignore */
 struct command_result *param_ignore(struct command *cmd UNNEEDED, const char *name UNNEEDED,
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4409,3 +4409,9 @@ def test_reconnect_no_additional_transient_failure(node_factory, bitcoind):
 
     # We should not see a "Peer transient failure" after restart of l1
     assert not l1.daemon.is_in_log(f"{l2id}-chan#1: Peer transient failure in CHANNELD_NORMAL: Disconnected", start=offset1)
+
+
+def test_offline_fd_check(node_factory):
+    # if get_node starts it, it'll expect an address, so do it manually.
+    l1 = node_factory.get_node(options={"offline": None}, start=False)
+    l1.daemon.start()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1835,8 +1835,9 @@ def test_check_command(node_factory):
 
     l1.rpc.check(command_to_check='help')
     l1.rpc.check(command_to_check='help', command='check')
-    # Note: this just checks form, not whether it's valid!
-    l1.rpc.check(command_to_check='help', command='badcommand')
+    # Actually checks that command is there!
+    with pytest.raises(RpcError, match=r'Unknown command'):
+        l1.rpc.check(command_to_check='help', command='badcommand')
     with pytest.raises(RpcError, match=r'Unknown command'):
         l1.rpc.check(command_to_check='badcommand')
     with pytest.raises(RpcError, match=r'unknown parameter'):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1399,8 +1399,14 @@ def test_recover(node_factory, bitcoind):
     l1.daemon.opts.update({"recover": "CL10LEETSLLHDMN9M42VCSAMX24ZRXGS3QQAT3LTDVAKMT73"})
     l1.daemon.start(wait_for_initialized=False, stderr_redir=True)
     assert l1.daemon.wait() == 1
-    assert l1.daemon.is_in_stderr(r"Expected 32 Byte secret: ffeeddccbbaa99887766554433221100")
+    assert l1.daemon.is_in_stderr(r"Invalid length: must be 32 bytes")
 
+    # Can do HSM secret in hex, too!
+    l1.daemon.opts["recover"] = "6c696768746e696e672d31000000000000000000000000000000000000000000"
+    l1.daemon.start()
+    l1.stop()
+
+    # And can start without recovery, of course!
     l1.daemon.opts.pop("recover")
     l1.start()
 

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -92,6 +92,13 @@ void channeld_tell_depth(struct channel *channel UNNEEDED,
 const char *cmd_id_from_close_command(const tal_t *ctx UNNEEDED,
 				      struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED)
 { fprintf(stderr, "cmd_id_from_close_command called!\n"); abort(); }
+/* Generated stub for command_check_done */
+struct command_result *command_check_done(struct command *cmd)
+
+{ fprintf(stderr, "command_check_done called!\n"); abort(); }
+/* Generated stub for command_check_only */
+bool command_check_only(const struct command *cmd UNNEEDED)
+{ fprintf(stderr, "command_check_only called!\n"); abort(); }
 /* Generated stub for command_fail */
 struct command_result *command_fail(struct command *cmd UNNEEDED, enum jsonrpc_errcode code UNNEEDED,
 				    const char *fmt UNNEEDED, ...)
@@ -590,6 +597,11 @@ struct command_result *param_channel_id(struct command *cmd UNNEEDED,
 					const jsmntok_t *tok UNNEEDED,
 					struct channel_id **cid UNNEEDED)
 { fprintf(stderr, "param_channel_id called!\n"); abort(); }
+/* Generated stub for param_check */
+bool param_check(struct command *cmd UNNEEDED,
+		 const char *buffer UNNEEDED,
+		 const jsmntok_t tokens[] UNNEEDED, ...)
+{ fprintf(stderr, "param_check called!\n"); abort(); }
 /* Generated stub for param_loglevel */
 struct command_result *param_loglevel(struct command *cmd UNNEEDED,
 				      const char *name UNNEEDED,


### PR DESCRIPTION
Closes: #6616 

With a fairly simple sweep, I could make `check` powerful enough that `check recover` does what the proposed `recover-possible` command was for.  Overall, really happy with this change!

So now, you can get a node to recover through the RPC api, great for front-ends like RTL, Zeus, etc.