### PR TITLE
doc: fix display of lists and code blocks in manpages.

### DIFF
--- a/doc/lightning-addpsbtoutput.7.md
+++ b/doc/lightning-addpsbtoutput.7.md
@@ -31,6 +31,7 @@ EXAMPLE USAGE
 
 Here is a command to make a PSBT with a 100,000 sat output that leads
 to the on-chain wallet.
+
 ```shell
 lightning-cli addpsbtoutput 100000sat
 ```

--- a/doc/lightning-checkmessage.7.md
+++ b/doc/lightning-checkmessage.7.md
@@ -21,6 +21,7 @@ matches for any one of them.  Note: this is implemented far more
 efficiently than trying each one, so performance is not a concern.
 
 On failure, an error is returned and core lightning exit with the following error code:
+
 - -32602: Parameter missed or malformed;
 - 1301: *pubkey* not found in the graph.
 

--- a/doc/lightning-checkrune.7.md
+++ b/doc/lightning-checkrune.7.md
@@ -26,6 +26,7 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - RUNE\_NOT\_AUTHORIZED (1501): rune is not for this node (or perhaps completely invalid)
 - RUNE\_NOT\_PERMITTED (1502): rune does not allow this usage (includes a detailed reason why)
 - RUNE\_BLACKLISTED (1503): rune has been explicitly blacklisted.
@@ -33,7 +34,7 @@ The following error codes may occur:
 AUTHOR
 ------
 
-Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible 
+Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible
 for consolidating logic from commando.
 
 SEE ALSO

--- a/doc/lightning-close.7.md
+++ b/doc/lightning-close.7.md
@@ -41,13 +41,14 @@ can be an integer in which case it is interpreted as number of satoshis
 to step at a time. Or it can be an integer followed by "%" to designate
 a percentage of the interval to give up. A few examples, assuming the peer
 proposes a closing fee of 3000 satoshi and our estimate shows it must be 4000:
-* "10": our next proposal will be 4000-10=3990.
-* "10%": our next proposal will be 4000-(10% of (4000-3000))=3900.
-* "1": our next proposal will be 3999. This is the most extreme case when we
+
+- "10": our next proposal will be 4000-10=3990.
+- "10%": our next proposal will be 4000-(10% of (4000-3000))=3900.
+- "1": our next proposal will be 3999. This is the most extreme case when we
 insist on our fee as much as possible.
-* "100%": our next proposal will be 3000. This is the most relaxed case when
+- "100%": our next proposal will be 3000. This is the most relaxed case when
 we quickly accept the peer's proposal.
- 
+
 The default is "50%".
 
 *wrong\_funding* can only be specified if both sides have offered

--- a/doc/lightning-connect.7.md
+++ b/doc/lightning-connect.7.md
@@ -19,6 +19,7 @@ be of the form *id@host* or *id@host:port*. In this case, the *host* and
 *host* is the peer's hostname or IP address.
 
 If not specified, the *port* depends on the current network:
+
 - bitcoin **mainnet**: 9735.
 - bitcoin **testnet**: 19735.
 - bitcoin **signet**: 39735.

--- a/doc/lightning-createinvoice.7.md
+++ b/doc/lightning-createinvoice.7.md
@@ -57,6 +57,7 @@ lightning-listinvoices(7) to query whether this invoice was created or
 not.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 900: An invoice with the given *label* already exists.
 

--- a/doc/lightning-datastore.7.md
+++ b/doc/lightning-datastore.7.md
@@ -44,6 +44,7 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - 1202: The key already exists (and mode said it must not)
 - 1203: The key does not exist (and mode said it must)
 - 1204: The generation was wrong (and generation was specified)

--- a/doc/lightning-deldatastore.7.md
+++ b/doc/lightning-deldatastore.7.md
@@ -30,6 +30,7 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - 1200: the key does not exist
 - 1201: the key does exist, but the generation is wrong
 - -32602: invalid parameters

--- a/doc/lightning-emergencyrecover.7.md
+++ b/doc/lightning-emergencyrecover.7.md
@@ -21,6 +21,7 @@ RETURN VALUE
 ------------
 
 On success, an object is returned, containing:
+
 - **stubs** (array of hexs):
   - Each item is the channel ID of the channel successfully inserted
 

--- a/doc/lightning-fetchinvoice.7.md
+++ b/doc/lightning-fetchinvoice.7.md
@@ -68,6 +68,7 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 1002: Offer has expired.
 - 1003: Cannot find a route to the node making the offer.

--- a/doc/lightning-fundchannel.7.md
+++ b/doc/lightning-fundchannel.7.md
@@ -95,6 +95,7 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 300: The maximum allowed funding amount is exceeded.
 - 301: There are not enough funds in the internal wallet (including fees) to create the transaction.

--- a/doc/lightning-invoice.7.md
+++ b/doc/lightning-invoice.7.md
@@ -30,7 +30,7 @@ of this invoice.
 The *description* is a short description of purpose of payment, e.g. *1
 cup of coffee*. This value is encoded into the BOLT11 invoice and is
 viewable by any node you send this invoice to (unless *deschashonly* is
-true as described below). It must be UTF-8, and cannot use *\\u* JSON 
+true as described below). It must be UTF-8, and cannot use *\\u* JSON
 escape codes.
 
 The *expiry* is optionally the time the invoice is valid for, in seconds.
@@ -100,6 +100,7 @@ lightning-listinvoices(7) to query whether this invoice was created or
 not.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 900: An invoice with the given *label* already exists.
 - 901: An invoice with the given *preimage* already exists.

--- a/doc/lightning-invoicerequest.7.md
+++ b/doc/lightning-invoicerequest.7.md
@@ -65,6 +65,7 @@ should use lightning-listinvoicerequests(7) to query whether it was
 created or not.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 
 AUTHOR

--- a/doc/lightning-keysend.7.md
+++ b/doc/lightning-keysend.7.md
@@ -88,6 +88,7 @@ The following warnings may also be returned:
 You can monitor the progress and retries of a payment using the lightning-paystatus(7) command.
 
 The following error codes may occur:
+
 - `-1`: Catchall nonspecific error.
 - `203`: Permanent failure at destination. The *data* field of the error will be routing failure object.
 - `205`: Unable to find a route.
@@ -95,6 +96,7 @@ The following error codes may occur:
 - `210`: Payment timed out without a payment in progress.
 
 A routing failure object has the fields below:
+
 - `erring_index`: The index of the node along the route that reported the error. 0 for the local node, 1 for the first hop, and so on.
 - `erring_node`: The hex string of the pubkey id of the node that reported the error.
 - `erring_channel`: The short channel ID of the channel that has the error, or *0:0:0* if the destination node raised the error.

--- a/doc/lightning-listdatastore.7.md
+++ b/doc/lightning-listdatastore.7.md
@@ -30,6 +30,7 @@ On success, an object containing **datastore** is returned.  It is an array of o
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - -32602: invalid parameters.
 
 AUTHOR

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -185,6 +185,7 @@ On success, an object with a "peers" key is returned containing a list
 of 0 or more objects.
 
 Each object in the list contains the following data:
+
 - *id* : The unique id of the peer
 - *connected* : A boolean value showing the connection status
 - *netaddr* : A list of network addresses the node is listening on

--- a/doc/lightning-listtransactions.7.md
+++ b/doc/lightning-listtransactions.7.md
@@ -45,6 +45,7 @@ On success, an object containing **transactions** is returned.  It is an array o
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 On failure, one of the following error codes may be returned:
+
 - -32602: Error in given parameters.
 
 EXAMPLE JSON RESPONSE

--- a/doc/lightning-makesecret.7.md
+++ b/doc/lightning-makesecret.7.md
@@ -26,6 +26,7 @@ On success, an object is returned, containing:
 
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 
 AUTHOR

--- a/doc/lightning-multifundchannel.7.md
+++ b/doc/lightning-multifundchannel.7.md
@@ -117,6 +117,7 @@ On success, an object is returned, containing:
 On failure, none of the channels are created.
 
 The following error codes may occur:
+
 * -1: Catchall nonspecific error.
 - 300: The maximum allowed funding amount is exceeded.
 - 301: There are not enough funds in the internal wallet (including fees) to create the transaction.

--- a/doc/lightning-multiwithdraw.7.md
+++ b/doc/lightning-multiwithdraw.7.md
@@ -45,6 +45,7 @@ On failure, an error is reported and the withdrawal transaction is not
 created.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 301: There are not enough funds in the internal wallet (including
 fees) to create the transaction.

--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -112,6 +112,7 @@ If the offer already existed, and is still active, that is returned;
 if it's not active then this call fails.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 1000: Offer with this offer\_id already exists (but is not active).
 

--- a/doc/lightning-openchannel_update.7.md
+++ b/doc/lightning-openchannel_update.7.md
@@ -41,12 +41,15 @@ On success, an object is returned, containing:
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 If *commitments\_secured* is true, will also return:
+
 - The derived *channel\_id*.
 - A *close\_to* script, iff a `close_to` address was provided to
   `openchannel_init` and the peer supports `option_upfront_shutdownscript`.
 - The *funding\_outnum*, the index of the funding output for this channel
   in the funding transaction.
 
+On error, the returned object will contain `code` and `message` properties,
+with `code` being one of the following:
 
 - -32602: If the given parameters are wrong.
 - -1: Catchall nonspecific error.

--- a/doc/lightning-pay.7.md
+++ b/doc/lightning-pay.7.md
@@ -115,6 +115,7 @@ You can monitor the progress and retries of a payment using the
 lightning-paystatus(7) command.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 201: Already paid with this *hash* using different amount or
 destination.
@@ -137,6 +138,7 @@ Error codes 202 and 204 will only get reported at **sendpay**; in
 **pay** we will keep retrying if we would have gotten those errors.
 
 A routing failure object has the fields below:
+
 - *erring\_index*: The index of the node along the route that reported
 the error. 0 for the local node, 1 for the first hop, and so on.
 - *erring\_node*: The hex string of the pubkey id of the node that

--- a/doc/lightning-plugin.7.md
+++ b/doc/lightning-plugin.7.md
@@ -29,9 +29,14 @@ killed and restarted except if its an important (or builtin) plugin.
 If the plugin doesn't complete the "getmanifest" and "init" handshakes within 60 seconds,
 the command will timeout and kill the plugin.
 Additional *options* may be passed to the plugin, but requires all parameters to
-be passed as keyword=value pairs, for example:
- `lightning-cli -k plugin subcommand=start plugin=helloworld.py greeting='A crazy'`
-(using the `-k|--keyword` option is recommended)
+be passed as keyword=value pairs using the  `-k|--keyword` option which
+is recommended. For example the following command starts the plugin
+helloworld.py (present in the plugin directory) with the option
+greeting set to 'A crazy':
+
+```
+lightning-cli -k plugin subcommand=start plugin=helloworld.py greeting='A crazy'
+```
 
 *subcommand* **stop** takes a plugin executable *path* or *name* as argument and stops the plugin.
 If the plugin subscribed to "shutdown", it may take up to 30 seconds before this

--- a/doc/lightning-recoverchannel.7.md
+++ b/doc/lightning-recoverchannel.7.md
@@ -23,6 +23,7 @@ RETURN VALUE
 ------------
 
 On success, an object is returned, containing:
+
 - **stubs** (array of hexs):
   - Each item is the channel ID of the channel successfully inserted
 

--- a/doc/lightning-renepay.7.md
+++ b/doc/lightning-renepay.7.md
@@ -116,22 +116,15 @@ lightning-renepaystatus(7) command.
 
 The following error codes may occur:
 
--1: Catchall nonspecific error.
-
-200: Other payment attempts are in progress.
-
-203: Permanent failure at destination.
-
-205: Unable to find a route.
-
-206: Payment routes are too expensive.
-
-207: Invoice expired. Payment took too long before expiration, or
+- -1: Catchall nonspecific error.
+- 200: Other payment attempts are in progress.
+- 203: Permanent failure at destination.
+- 205: Unable to find a route.
+- 206: Payment routes are too expensive.
+- 207: Invoice expired. Payment took too long before expiration, or
 already expired at the time you initiated payment.
-
-210: Payment timed out without a payment in progress.
-
-212: Invoice is invalid.
+- 210: Payment timed out without a payment in progress.
+- 212: Invoice is invalid.
 
 AUTHOR
 ------

--- a/doc/lightning-reserveinputs.7.md
+++ b/doc/lightning-reserveinputs.7.md
@@ -47,6 +47,7 @@ which was reserved:
 On failure, an error is reported and no UTXOs are reserved.
 
 The following error codes may occur:
+
 - -32602: Invalid parameter, such as specifying a spent/reserved input in *psbt*.
 
 AUTHOR

--- a/doc/lightning-sendinvoice.7.md
+++ b/doc/lightning-sendinvoice.7.md
@@ -60,6 +60,7 @@ If **status** is "paid":
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 1002: Offer has expired.
 - 1003: Cannot find a route to the node making the offer.

--- a/doc/lightning-sendpay.7.md
+++ b/doc/lightning-sendpay.7.md
@@ -99,6 +99,7 @@ error from the final destination implies the payment should not be
 retried.
 
 The following error codes may occur:
+
 -   -1: Catchall nonspecific error.
 -   201: Already paid with this *hash* using different amount or
     destination.
@@ -112,6 +113,7 @@ The following error codes may occur:
 -   212: *localinvreqid* refers to an invalid, or used, local invoice\_request.
 
 A routing failure object has the fields below:
+
 -   *erring\_index*. The index of the node along the route that reported
     the error. 0 for the local node, 1 for the first hop, and so on.
 -   *erring\_node*. The hex string of the pubkey id of the node that

--- a/doc/lightning-setchannel.7.md
+++ b/doc/lightning-setchannel.7.md
@@ -93,6 +93,7 @@ ERRORS
 ------
 
 The following error codes may occur:
+
 - -1: Channel is in incorrect state, i.e. Catchall nonspecific error.
 - -32602: JSONRPC2\_INVALID\_PARAMS, i.e. Given id is not a channel ID
 or short channel ID.

--- a/doc/lightning-setconfig.7.md
+++ b/doc/lightning-setconfig.7.md
@@ -38,6 +38,7 @@ ERRORS
 ------
 
 The following error codes may occur:
+
 - -32602: JSONRPC2\_INVALID\_PARAMS, i.e. the parameter is not dynamic, or the val was invalid.
 
 AUTHOR

--- a/doc/lightning-signinvoice.7.md
+++ b/doc/lightning-signinvoice.7.md
@@ -29,6 +29,7 @@ On success, an object is returned, containing:
 On failure, an error is returned.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 
 AUTHOR

--- a/doc/lightning-splice_init.7.md
+++ b/doc/lightning-splice_init.7.md
@@ -38,6 +38,7 @@ lightning-cli splice_init -- $CHANNEL_ID -100000
 Here is an example set of splice commands that will splice in 100,000 sats to
 the first channel that comes out of `listpeerchannels`. The example assumes
 you already have at least one confirmed channel.
+
 ```shell
 RESULT=$(lightning-cli listpeerchannels);
 CHANNEL_ID=$(echo $RESULT| jq -r ".channels[0].channel_id");
@@ -65,6 +66,7 @@ lightning-cli splice_signed $CHANNEL_ID $PSBT
 Here is an example set of splice commands that will splice out 100,000 sats from
  first channel that comes out of `listpeerchannels`. The example assumes
 you already have at least one confirmed channel.
+
 ```shell
 RESULT=$(lightning-cli listpeerchannels);
 CHANNEL_ID=$(echo $RESULT| jq -r ".channels[0].channel_id");

--- a/doc/lightning-splice_signed.7.md
+++ b/doc/lightning-splice_signed.7.md
@@ -27,6 +27,7 @@ to it or it will fail.
 
 In this example we funded the psbt from our lightning node, so we can use the
 lightning node to sign for its funds.
+
 ```shell
 RESULT=$(lightning-cli signpsbt $PSBT)
 PSBT=$(echo $RESULT | jq -r ".signed_psbt")
@@ -38,6 +39,7 @@ lightning-cli splice_signed $CHANNEL_ID $PSBT
 Here is a full example set of splice commands that will splice in 100,000 sats
 to the first channel that comes out of `listpeerchannels`. The example assumes
 you already have at least one confirmed channel.
+
 ```shell
 RESULT=$(lightning-cli listpeerchannels)
 CHANNEL_ID=$(echo $RESULT| jq -r ".channels[0].channel_id")

--- a/doc/lightning-splice_update.7.md
+++ b/doc/lightning-splice_update.7.md
@@ -35,6 +35,7 @@ perform additional validation or strategy adjustment.
 Typically, `splice_update` will return `commitments_secured` true after one call
 but you should assume it will need multiple calls. Here is an example way to
 call `splice_update`
+
 ```shell
 RESULT="{\"commitments_secured\":false}"
 while [[ $(echo $RESULT | jq -r ".commitments_secured") == "false" ]]
@@ -51,6 +52,7 @@ to make additional changes.
 Here is a full example set of splice commands that will splice in 100,000 sats
 to the first channel that comes out of `listpeerchannels`. The example assumes
 you already have at least one confirmed channel.
+
 ```shell
 RESULT=$(lightning-cli listpeerchannels)
 CHANNEL_ID=$(echo $RESULT| jq -r ".channels[0].channel_id")

--- a/doc/lightning-sql.7.md
+++ b/doc/lightning-sql.7.md
@@ -88,6 +88,7 @@ a foreign key.
 
 [comment]: # (GENERATE-DOC-START)
 The following tables are currently supported:
+
 - `bkpr_accountevents` (see lightning-bkpr-listaccountevents(7))
   - `account` (type `string`, sqltype `TEXT`)
   - `type` (type `string`, sqltype `TEXT`)

--- a/doc/lightning-txdiscard.7.md
+++ b/doc/lightning-txdiscard.7.md
@@ -28,6 +28,7 @@ happen due to incorrect usage, such as **txdiscard** or **txsend**
 already being called for *txid*.
 
 The following error codes may occur:
+
 - -1: An unknown *txid*.
 
 AUTHOR

--- a/doc/lightning-txprepare.7.md
+++ b/doc/lightning-txprepare.7.md
@@ -57,6 +57,7 @@ On success, an object is returned, containing:
 On failure, an error is reported and the transaction is not created.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 301: There are not enough funds in the internal wallet (including
 fees) to create the transaction.

--- a/doc/lightning-txsend.7.md
+++ b/doc/lightning-txsend.7.md
@@ -28,6 +28,7 @@ On failure, an error is reported (from bitcoind), and the inputs from
 the transaction are unreserved.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 
 AUTHOR

--- a/doc/lightning-unreserveinputs.7.md
+++ b/doc/lightning-unreserveinputs.7.md
@@ -38,6 +38,7 @@ If **reserved** is *true*:
 On failure, an error is reported and no UTXOs are unreserved.
 
 The following error codes may occur:
+
 - -32602: Invalid parameter, i.e. an unparseable PSBT.
 
 AUTHOR

--- a/doc/lightning-wait.7.md
+++ b/doc/lightning-wait.7.md
@@ -15,11 +15,13 @@ events have happened (**wait** with a *nextvalue* of 0 is a way of getting
 the current index, though naturally this is racy!).
 
 *indexname* is one of `created`, `updated` or `deleted`:
+
 - `created` is incremented by one for every new object.
 - `updated` is incremented by one every time an object is changed.
 - `deleted` is incremented by one every time an object is deleted.
 
 *subsystem* is one of:
+
 - `invoices`: corresponding to `listinvoices`.
 
 

--- a/doc/lightning-waitsendpay.7.md
+++ b/doc/lightning-waitsendpay.7.md
@@ -61,6 +61,7 @@ final destination, the route table will no longer be updated. Use the
 route.
 
 The following error codes may occur:
+
 -   -1: Catchall nonspecific error.
 -   200: Timed out before the payment could complete.
 -   202: Unparseable onion reply. The *data* field of the error will
@@ -77,6 +78,7 @@ The following error codes may occur:
     old databases.
 
 A routing failure object has the fields below:
+
 -   *erring\_index*: The index of the node along the route that reported
     the error. 0 for the local node, 1 for the first hop, and so on.
 -   *erring\_node*: The hex string of the pubkey id of the node that

--- a/doc/lightning-withdraw.7.md
+++ b/doc/lightning-withdraw.7.md
@@ -48,6 +48,7 @@ On failure, an error is reported and the withdrawal transaction is not
 created.
 
 The following error codes may occur:
+
 - -1: Catchall nonspecific error.
 - 301: There are not enough funds in the internal wallet (including
 fees) to create the transaction.

--- a/doc/reckless.7.md
+++ b/doc/reckless.7.md
@@ -17,6 +17,7 @@ lightningd config file. Reckless does all of these by invoking:
 **reckless** **install** *plugin\_name*
 
 reckless will exit early in the event that:
+
 - the plugin is not found in any available source repositories
 - dependencies are not sucessfully installed
 - the plugin fails to execute
@@ -99,6 +100,7 @@ permanent alias in this case.
 For Plugin Developers:
 
 To make your plugin compatible with reckless install:
+
 - Choose a unique plugin name.
 - The plugin entrypoint is inferred.  Naming your plugin executable
     the same as your plugin name will allow reckless to identify it
@@ -139,4 +141,3 @@ RESOURCES
 ---------
 
 Main web site: <https://github.com/ElementsProject/lightning>
-


### PR DESCRIPTION
The conversion from markdown to manpages does not display lists and code blocks correctly if they are not preceded by an empty line.

So empty lines have been added where necessary.