### PR TITLE
build: fix compilation issue on OpenBSD

### DIFF
--- a/common/daemon.c
+++ b/common/daemon.c
@@ -136,6 +136,10 @@ const char *backtrace_symname(const tal_t *ctx, const void *addr)
 {
 	return "unknown (backtrace unsupported)";
 }
+
+static void add_steal_notifiers(const tal_t *root)
+{
+}
 #endif
 
 int daemon_poll(struct pollfd *fds, nfds_t nfds, int timeout)


### PR DESCRIPTION
During our development, we modified the way
we report backtraces.

On a minimal configuration in OpenBSD, it seems that we no longer compile from commit a9f26b7d07 because
our conditional code is buggy.

With the following compiler

```
vultr# cc -v
OpenBSD clang version 13.0.0
Target: amd64-unknown-openbsd7.3
Thread model: posix
InstalledDir: /usr/bin
```

We have the following error

```
cc common/channel_id.c
cc common/daemon.c
common/daemon.c:218:2: error: implicit declaration of function 'add_steal_notifiers' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        add_steal_notifiers(NULL);
        ^
1 error generated.
gmake: *** [Makefile:298: common/daemon.o] Error 1
```

Reported-by: @grubles
Fixes https://github.com/ElementsProject/lightning/issues/6701