### PR TITLE
runes: bug fix for db failure to upgrade due to runes table alteratio…

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -975,8 +975,8 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE htlc_sigs ADD inflight_tx_outnum INTEGER"), NULL},
     {SQL("ALTER TABLE channel_funding_inflights ADD splice_amnt BIGINT DEFAULT 0"), NULL},
     {SQL("ALTER TABLE channel_funding_inflights ADD i_am_initiator INTEGER DEFAULT 0"), NULL},
-    {SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL},
     {NULL, migrate_runes_idfix},
+    {SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL},
     {SQL("DELETE FROM vars WHERE name = 'runes_uniqueid'"), NULL},
 };
 


### PR DESCRIPTION
…n #6770

While rebasing the PR for per rune restriction, I unintentionally merged the `{SQL("ALTER TABLE runes ADD last_used_nsec BIGINT DEFAULT NULL"), NULL}` database alteration command ahead of `{NULL, migrate_runes_idfix}` ([commit](https://github.com/ElementsProject/lightning/commit/eacf0b502c28662b515eaec2f3e975ac51423f20#diff-1abcdf1b9d822b30079d6450b790274bdfb7c7fa04baa43ad2d9bd449865d4c9R978)).

`migrate_runes_idfix` was the 234th change (deployed with version 23.08.1) and adding the `last_used_nsec` column should have been the next (235th, added in current release) change. Due to this incorrect ordering, nodes updating from version 23.08.1 to the `master` branch will not add the `last_used_nsec` column as they should, and instead execute `migrate_runes_idfix` again, leading to the error in issue https://github.com/ElementsProject/lightning/issues/6770.

After the reordering, `db_get_runes` method also has to be fixed for only selecting `rune` NOT `last_used_nsec`. Because this column was added after `migrate_runes_idfix` calls it. I am tempted to change the method name from `db_get_runes` to `db_migrate_runes` for more clarity on its functionality though.

Changelog-None.