### PR TITLE
Real checkrune fix

### DIFF
--- a/lightningd/runes.c
+++ b/lightningd/runes.c
@@ -827,10 +827,7 @@ static struct command_result *json_checkrune(struct command *cmd,
 	cinfo.runes = cmd->ld->runes;
 	cinfo.peer = nodeid;
 	cinfo.buf = buffer;
-	if (method != NULL && streq(method, ""))
-		cinfo.method = NULL;
-	else
-		cinfo.method = method;
+	cinfo.method = method;
 	cinfo.params = methodparams;
 	cinfo.now = time_now();
 	strmap_init(&cinfo.cached_params);

--- a/plugins/clnrest/utilities/shared.py
+++ b/plugins/clnrest/utilities/shared.py
@@ -62,10 +62,8 @@ def verify_rune(plugin, request):
     else:
         rpc_params = request.form.to_dict()
 
-    try:
-        rpc_method = request.view_args["rpc_method"]
-    except Exception:
-        rpc_method = ""
+    # None, if this isn't present.
+    rpc_method = request.view_args.get("rpc_method")
 
     return call_rpc_method(plugin, "checkrune",
                            {"rune": rune,

--- a/tests/test_runes.py
+++ b/tests/test_runes.py
@@ -594,8 +594,8 @@ def test_missing_method_or_nodeid(node_factory):
         l1.rpc.checkrune(rune=rune4, nodeid=l1.info['id'])
 
 
-def test_rune_method_not_equal_and_method_empty(node_factory):
-    """Test `checkrune` when `method` parameter is the empty string and a `method` is negated in the rune."""
+def test_rune_method_missing(node_factory):
+    """Test `checkrune` when `method` parameter not set `method` is negated in the rune."""
     l1 = node_factory.get_node()
     rune = l1.rpc.createrune(restrictions=[["method/getinfo"]])['rune']
 
@@ -603,7 +603,18 @@ def test_rune_method_not_equal_and_method_empty(node_factory):
         l1.rpc.checkrune(rune=rune, method='getinfo')
     assert l1.rpc.checkrune(rune=rune, method='invoice')['valid'] is True
     with pytest.raises(RpcError, match='Not permitted: method not present'):
-        l1.rpc.checkrune(rune=rune, method='')
+        l1.rpc.checkrune(rune=rune, method=None)
+
+    rune2 = l1.rpc.createrune(restrictions=[["method!"]])['rune']
+    with pytest.raises(RpcError, match='Not permitted: method is present'):
+        l1.rpc.checkrune(rune=rune2, method='getinfo')
+
+    with pytest.raises(RpcError, match='Not permitted: method is present'):
+        l1.rpc.checkrune(rune=rune2, method='')
+
+    # These two are equivalent (our Python wrapper removes None params)
+    l1.rpc.checkrune(rune=rune2)
+    l1.rpc.checkrune(rune=rune2, method=None)
 
 
 def test_invalid_restrictions(node_factory):


### PR DESCRIPTION
This reverts and fixes #6759.  The root problem is that clnrest was specifying method as the empty string, instead of not specifying it at all.

With that changed, the previous behavior is correct.  @tonyaldon 