### PR TITLE
Simplify use of channel_update

### DIFF
--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -332,7 +332,7 @@ msgtype,channeld_send_error_reply,1108
 # Channeld: tell gossipd to make this channel_update.
 msgtype,channeld_local_channel_update,1013
 msgdata,channeld_local_channel_update,short_channel_id,short_channel_id,
-msgdata,channeld_local_channel_update,disable,bool,
+msgdata,channeld_local_channel_update,enable,bool,
 msgdata,channeld_local_channel_update,cltv_expiry_delta,u16,
 msgdata,channeld_local_channel_update,htlc_minimum_msat,amount_msat,
 msgdata,channeld_local_channel_update,fee_base_msat,u32,

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -34,17 +34,12 @@ msgdata,channeld_init,remote_basepoints,basepoints,
 msgdata,channeld_init,remote_per_commit,pubkey,
 msgdata,channeld_init,old_remote_per_commit,pubkey,
 msgdata,channeld_init,opener,enum side,
-msgdata,channeld_init,fee_base,u32,
-msgdata,channeld_init,fee_proportional,u32,
-msgdata,channeld_init,htlc_minimum_msat,amount_msat,
-msgdata,channeld_init,htlc_maximum_msat,amount_msat,
 msgdata,channeld_init,local_msatoshi,amount_msat,
 msgdata,channeld_init,our_basepoints,basepoints,
 msgdata,channeld_init,our_funding_pubkey,pubkey,
 msgdata,channeld_init,local_node_id,node_id,
 msgdata,channeld_init,remote_node_id,node_id,
 msgdata,channeld_init,commit_msec,u32,
-msgdata,channeld_init,cltv_delta,u16,
 msgdata,channeld_init,last_was_revoke,bool,
 msgdata,channeld_init,num_last_sent_commit,u16,
 msgdata,channeld_init,last_sent_commit,changed_htlc,num_last_sent_commit
@@ -310,13 +305,6 @@ msgtype,channeld_fail_fallen_behind,1028
 # This is NULL if option_static_remotekey.
 msgdata,channeld_fail_fallen_behind,remote_per_commitment_point,?pubkey,
 
-# Handle a channel-specific configuration change
-msgtype,channeld_config_channel,1029
-msgdata,channeld_config_channel,feerate_base,?u32,
-msgdata,channeld_config_channel,feerate_ppm,?u32,
-msgdata,channeld_config_channel,htlc_minimum,?amount_msat,
-msgdata,channeld_config_channel,htlc_maximum,?amount_msat,
-
 # When we receive announcement_signatures for channel announce
 msgtype,channeld_got_announcement,1017
 msgdata,channeld_got_announcement,remote_ann_node_sig,secp256k1_ecdsa_signature,
@@ -329,16 +317,9 @@ msgdata,channeld_send_error,reason,wirestring,
 # Tell master channeld has sent the error message.
 msgtype,channeld_send_error_reply,1108
 
-# Channeld: tell gossipd to make this channel_update.
+# Channeld: tell gossipd to make channel_update to enable/disable.
 msgtype,channeld_local_channel_update,1013
-msgdata,channeld_local_channel_update,short_channel_id,short_channel_id,
 msgdata,channeld_local_channel_update,enable,bool,
-msgdata,channeld_local_channel_update,cltv_expiry_delta,u16,
-msgdata,channeld_local_channel_update,htlc_minimum_msat,amount_msat,
-msgdata,channeld_local_channel_update,fee_base_msat,u32,
-msgdata,channeld_local_channel_update,fee_proportional_millionths,u32,
-msgdata,channeld_local_channel_update,htlc_maximum_msat,amount_msat,
-msgdata,channeld_local_channel_update,public,bool,
 
 # Channeld: tell gossipd about our channel_announcement
 msgtype,channeld_local_channel_announcement,1014

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -81,8 +81,6 @@ msgdata,channeld_init,dev_disable_commit,?u32,
 msgdata,channeld_init,num_penalty_bases,u32,
 msgdata,channeld_init,pbases,penalty_base,num_penalty_bases
 msgdata,channeld_init,reestablish_only,bool,
-msgdata,channeld_init,channel_update_len,u16,
-msgdata,channeld_init,channel_update,u8,channel_update_len
 msgdata,channeld_init,experimental_upgrade,bool,
 msgdata,channeld_init,num_inflights,u16,
 msgdata,channeld_init,inflights,inflight,num_inflights
@@ -330,14 +328,6 @@ msgdata,channeld_send_error,reason,wirestring,
 
 # Tell master channeld has sent the error message.
 msgtype,channeld_send_error_reply,1108
-
-# Tell channeld about the latest channel_update
-msgtype,channeld_channel_update,1001
-msgdata,channeld_channel_update,len,u16,
-msgdata,channeld_channel_update,msg,u8,len
-
-# Tell lightningd we used the latest channel_update for an error.
-msgtype,channeld_used_channel_update,1102
 
 # Channeld: tell gossipd to make this channel_update.
 msgtype,channeld_local_channel_update,1013

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -903,7 +903,7 @@ class LightningNode(object):
 
         if wait_for_announce:
             self.bitcoin.generate_block(5)
-            wait_for(lambda: ['alias' in e for e in self.rpc.listnodes(remote_node.info['id'])['nodes']])
+            wait_for(lambda: ['alias' in e for e in self.rpc.listnodes(remote_node.info['id'])['nodes']] == [True])
 
         return {'address': addr, 'wallettxid': wallettxid, 'fundingtx': res['tx']}
 

--- a/gossipd/gossip_generation.c
+++ b/gossipd/gossip_generation.c
@@ -520,7 +520,7 @@ static u8 *sign_and_timestamp_update(const tal_t *ctx,
 static u8 *create_unsigned_update(const tal_t *ctx,
 				  const struct short_channel_id *scid,
 				  int direction,
-				  bool disable,
+				  bool enable,
 				  u16 cltv_expiry_delta,
 				  struct amount_msat htlc_minimum,
 				  struct amount_msat htlc_maximum,
@@ -547,7 +547,7 @@ static u8 *create_unsigned_update(const tal_t *ctx,
 	 * | 1             | `disable`   | Disable the channel.             |
 	 */
 	channel_flags = direction;
-	if (disable)
+	if (!enable)
 		channel_flags |= ROUTING_FLAGS_DISABLED;
 
 	/* BOLT #7:
@@ -796,7 +796,7 @@ void handle_local_channel_update(struct daemon *daemon, const u8 *msg)
 {
 	struct node_id id;
 	struct short_channel_id scid;
-	bool disable;
+	bool enable;
 	u16 cltv_expiry_delta;
 	struct amount_msat htlc_minimum, htlc_maximum;
 	u32 fee_base_msat, fee_proportional_millionths;
@@ -809,7 +809,7 @@ void handle_local_channel_update(struct daemon *daemon, const u8 *msg)
 	if (!fromwire_gossipd_local_channel_update(msg,
 						   &id,
 						   &scid,
-						   &disable,
+						   &enable,
 						   &cltv_expiry_delta,
 						   &htlc_minimum,
 						   &fee_base_msat,
@@ -837,7 +837,7 @@ void handle_local_channel_update(struct daemon *daemon, const u8 *msg)
 	}
 
 	unsigned_update = create_unsigned_update(tmpctx, &scid, direction,
-						 disable, cltv_expiry_delta,
+						 enable, cltv_expiry_delta,
 						 htlc_minimum, htlc_maximum,
 						 fee_base_msat,
 						 fee_proportional_millionths,

--- a/gossipd/gossipd_wire.csv
+++ b/gossipd/gossipd_wire.csv
@@ -106,7 +106,7 @@ msgdata,gossipd_got_local_channel_update,channel_update,u8,len
 msgtype,gossipd_local_channel_update,3004
 msgdata,gossipd_local_channel_update,id,node_id,
 msgdata,gossipd_local_channel_update,short_channel_id,short_channel_id,
-msgdata,gossipd_local_channel_update,disable,bool,
+msgdata,gossipd_local_channel_update,enable,bool,
 msgdata,gossipd_local_channel_update,cltv_expiry_delta,u16,
 msgdata,gossipd_local_channel_update,htlc_minimum_msat,amount_msat,
 msgdata,gossipd_local_channel_update,fee_base_msat,u32,

--- a/gossipd/test/run-check_node_announcement.c
+++ b/gossipd/test/run-check_node_announcement.c
@@ -31,7 +31,7 @@ void daemon_conn_send(struct daemon_conn *dc UNNEEDED, const u8 *msg UNNEEDED)
 struct peer *find_peer(struct daemon *daemon UNNEEDED, const struct node_id *id UNNEEDED)
 { fprintf(stderr, "find_peer called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_local_channel_update */
-bool fromwire_gossipd_local_channel_update(const void *p UNNEEDED, struct node_id *id UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, bool *disable UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, struct amount_msat *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED, struct amount_msat *htlc_maximum_msat UNNEEDED, bool *public UNNEEDED)
+bool fromwire_gossipd_local_channel_update(const void *p UNNEEDED, struct node_id *id UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, bool *enable UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, struct amount_msat *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED, struct amount_msat *htlc_maximum_msat UNNEEDED, bool *public UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_local_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_used_local_channel_update */
 bool fromwire_gossipd_used_local_channel_update(const void *p UNNEEDED, struct short_channel_id *scid UNNEEDED)

--- a/gossipd/test/run-crc32_of_update.c
+++ b/gossipd/test/run-crc32_of_update.c
@@ -56,7 +56,7 @@ struct peer *first_random_peer(struct daemon *daemon UNNEEDED,
 bool fromwire_gossipd_dev_set_max_scids_encode_size(const void *p UNNEEDED, u32 *max UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_dev_set_max_scids_encode_size called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_local_channel_update */
-bool fromwire_gossipd_local_channel_update(const void *p UNNEEDED, struct node_id *id UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, bool *disable UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, struct amount_msat *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED, struct amount_msat *htlc_maximum_msat UNNEEDED, bool *public UNNEEDED)
+bool fromwire_gossipd_local_channel_update(const void *p UNNEEDED, struct node_id *id UNNEEDED, struct short_channel_id *short_channel_id UNNEEDED, bool *enable UNNEEDED, u16 *cltv_expiry_delta UNNEEDED, struct amount_msat *htlc_minimum_msat UNNEEDED, u32 *fee_base_msat UNNEEDED, u32 *fee_proportional_millionths UNNEEDED, struct amount_msat *htlc_maximum_msat UNNEEDED, bool *public UNNEEDED)
 { fprintf(stderr, "fromwire_gossipd_local_channel_update called!\n"); abort(); }
 /* Generated stub for fromwire_gossipd_used_local_channel_update */
 bool fromwire_gossipd_used_local_channel_update(const void *p UNNEEDED, struct short_channel_id *scid UNNEEDED)

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -1204,6 +1204,21 @@ static void handle_channel_upgrade(struct channel *channel,
 	wallet_channel_save(channel->peer->ld->wallet, channel);
 }
 
+static void handle_local_channel_update(struct channel *channel,
+					const u8 *msg)
+{
+	bool enable;
+
+	if (!fromwire_channeld_local_channel_update(msg, &enable)) {
+		channel_internal_error(channel,
+				       "bad channeld_local_channel_update %s",
+				       tal_hex(channel, msg));
+		return;
+	}
+
+	tell_gossipd_local_channel_update(channel->peer->ld, channel, enable);
+}
+
 static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 {
 	enum channeld_wire t = fromwire_peektype(msg);
@@ -1240,7 +1255,7 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 		handle_error_channel(sd->channel, msg);
 		break;
 	case WIRE_CHANNELD_LOCAL_CHANNEL_UPDATE:
-		tell_gossipd_local_channel_update(sd->ld, sd->channel, msg);
+		handle_local_channel_update(sd->channel, msg);
 		break;
 	case WIRE_CHANNELD_LOCAL_CHANNEL_ANNOUNCEMENT:
 		tell_gossipd_local_channel_announce(sd->ld, sd->channel, msg);
@@ -1294,7 +1309,6 @@ static unsigned channel_msg(struct subd *sd, const u8 *msg, const int *fds)
 	case WIRE_CHANNELD_DEV_REENABLE_COMMIT:
 	case WIRE_CHANNELD_FEERATES:
 	case WIRE_CHANNELD_BLOCKHEIGHT:
-	case WIRE_CHANNELD_CONFIG_CHANNEL:
 	case WIRE_CHANNELD_DEV_MEMLEAK:
 	case WIRE_CHANNELD_DEV_QUIESCE:
 	case WIRE_CHANNELD_GOT_INFLIGHT:
@@ -1510,17 +1524,12 @@ bool peer_start_channeld(struct channel *channel,
 				       &channel->channel_info.remote_per_commit,
 				       &channel->channel_info.old_remote_per_commit,
 				       channel->opener,
-				       channel->feerate_base,
-				       channel->feerate_ppm,
-				       channel->htlc_minimum_msat,
-				       channel->htlc_maximum_msat,
 				       channel->our_msat,
 				       &channel->local_basepoints,
 				       &channel->local_funding_pubkey,
 				       &ld->id,
 				       &channel->peer->id,
 				       cfg->commit_time_ms,
-				       cfg->cltv_expiry_delta,
 				       channel->last_was_revoke,
 				       channel->last_sent_commit,
 				       channel->next_index[LOCAL],

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -321,13 +321,13 @@ void tell_gossipd_local_channel_update(struct lightningd *ld,
 				       const u8 *msg)
 {
 	struct short_channel_id scid;
-	bool disable, public;
+	bool enable, public;
 	u16 cltv_expiry_delta;
 	struct amount_msat htlc_minimum_msat;
 	u32 fee_base_msat, fee_proportional_millionths;
 	struct amount_msat htlc_maximum_msat;
 
-	if (!fromwire_channeld_local_channel_update(msg, &scid, &disable,
+	if (!fromwire_channeld_local_channel_update(msg, &scid, &enable,
 						    &cltv_expiry_delta,
 						    &htlc_minimum_msat,
 						    &fee_base_msat,
@@ -355,7 +355,7 @@ void tell_gossipd_local_channel_update(struct lightningd *ld,
 			   (NULL,
 			    &channel->peer->id,
 			    channel->scid ? channel->scid : channel->alias[LOCAL],
-			    disable,
+			    enable,
 			    ld->config.cltv_expiry_delta,
 			    channel->htlc_minimum_msat,
 			    channel->feerate_base,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -343,18 +343,25 @@ void tell_gossipd_local_channel_update(struct lightningd *ld,
 	if (!ld->gossip)
 		return;
 
+	assert(short_channel_id_eq(channel->scid ? channel->scid : channel->alias[LOCAL], &scid));
+	assert(cltv_expiry_delta == ld->config.cltv_expiry_delta);
+	assert(amount_msat_eq(htlc_minimum_msat, channel->htlc_minimum_msat));
+	assert(fee_base_msat == channel->feerate_base);
+	assert(fee_proportional_millionths == channel->feerate_ppm);
+	assert(amount_msat_eq(htlc_maximum_msat, channel->htlc_maximum_msat));
+
 	subd_send_msg(ld->gossip,
 		      take(towire_gossipd_local_channel_update
 			   (NULL,
 			    &channel->peer->id,
-			    &scid,
+			    channel->scid ? channel->scid : channel->alias[LOCAL],
 			    disable,
-			    cltv_expiry_delta,
-			    htlc_minimum_msat,
-			    fee_base_msat,
-			    fee_proportional_millionths,
-			    htlc_maximum_msat,
-			    public)));
+			    ld->config.cltv_expiry_delta,
+			    channel->htlc_minimum_msat,
+			    channel->feerate_base,
+			    channel->feerate_ppm,
+			    channel->htlc_maximum_msat,
+			    channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL)));
 }
 
 void tell_gossipd_local_channel_announce(struct lightningd *ld,

--- a/lightningd/gossip_control.h
+++ b/lightningd/gossip_control.h
@@ -19,7 +19,7 @@ void gossip_notify_new_block(struct lightningd *ld, u32 blockheight);
 /* channeld tells us stuff, we tell gossipd. */
 void tell_gossipd_local_channel_update(struct lightningd *ld,
 				       struct channel *channel,
-				       const u8 *msg);
+				       bool enabled);
 void tell_gossipd_local_channel_announce(struct lightningd *ld,
 					 struct channel *channel,
 					 const u8 *msg);

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -527,6 +527,11 @@ static void rcvd_htlc_reply(struct subd *subd, const u8 *msg, const int *fds UNU
 	}
 
 	if (tal_count(failmsg)) {
+		/* It's our job to append the channel_update */
+		if (fromwire_peektype(failmsg) & UPDATE) {
+			const u8 *update = get_channel_update(hout->key.channel);
+			towire(&failmsg, update, tal_bytelen(update));
+		}
 		hout->failmsg = tal_steal(hout, failmsg);
 		if (hout->am_origin) {
 			char *localfail = tal_fmt(msg, "%s: %s",

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -875,15 +875,17 @@ void subd_send_fd(struct subd *sd UNNEEDED, int fd UNNEEDED)
 /* Generated stub for subd_send_msg */
 void subd_send_msg(struct subd *sd UNNEEDED, const u8 *msg_out UNNEEDED)
 { fprintf(stderr, "subd_send_msg called!\n"); abort(); }
+/* Generated stub for tell_gossipd_local_channel_update */
+void tell_gossipd_local_channel_update(struct lightningd *ld UNNEEDED,
+				       struct channel *channel UNNEEDED,
+				       bool enabled UNNEEDED)
+{ fprintf(stderr, "tell_gossipd_local_channel_update called!\n"); abort(); }
 /* Generated stub for towire_bigsize */
 void towire_bigsize(u8 **pptr UNNEEDED, const bigsize_t val UNNEEDED)
 { fprintf(stderr, "towire_bigsize called!\n"); abort(); }
 /* Generated stub for towire_channel_id */
 void towire_channel_id(u8 **pptr UNNEEDED, const struct channel_id *channel_id UNNEEDED)
 { fprintf(stderr, "towire_channel_id called!\n"); abort(); }
-/* Generated stub for towire_channeld_config_channel */
-u8 *towire_channeld_config_channel(const tal_t *ctx UNNEEDED, u32 *feerate_base UNNEEDED, u32 *feerate_ppm UNNEEDED, struct amount_msat *htlc_minimum UNNEEDED, struct amount_msat *htlc_maximum UNNEEDED)
-{ fprintf(stderr, "towire_channeld_config_channel called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channeld_dev_memleak called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -737,6 +737,11 @@ void subkey_from_hmac(const char *prefix UNNEEDED,
 		      const struct secret *base UNNEEDED,
 		      struct secret *key UNNEEDED)
 { fprintf(stderr, "subkey_from_hmac called!\n"); abort(); }
+/* Generated stub for tell_gossipd_local_channel_update */
+void tell_gossipd_local_channel_update(struct lightningd *ld UNNEEDED,
+				       struct channel *channel UNNEEDED,
+				       bool enabled UNNEEDED)
+{ fprintf(stderr, "tell_gossipd_local_channel_update called!\n"); abort(); }
 /* Generated stub for to_canonical_invstr */
 const char *to_canonical_invstr(const tal_t *ctx UNNEEDED, const char *invstring UNNEEDED)
 { fprintf(stderr, "to_canonical_invstr called!\n"); abort(); }
@@ -747,9 +752,6 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 					  void *) UNNEEDED,
 			       void *arg UNNEEDED)
 { fprintf(stderr, "topology_add_sync_waiter_ called!\n"); abort(); }
-/* Generated stub for towire_channeld_config_channel */
-u8 *towire_channeld_config_channel(const tal_t *ctx UNNEEDED, u32 *feerate_base UNNEEDED, u32 *feerate_ppm UNNEEDED, struct amount_msat *htlc_minimum UNNEEDED, struct amount_msat *htlc_maximum UNNEEDED)
-{ fprintf(stderr, "towire_channeld_config_channel called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channeld_dev_memleak called!\n"); abort(); }


### PR DESCRIPTION
This is only the beginning of the cleanup I wanted to perform, but the rest requires that gossipd no longer handle private gossip, which will not be in this release.

Nonetheless, this removes some fairly complex code, so nice to have: channeld used to make the updates, and tell lightningd to tell gossipd, and now lightningd does it itself.