### PR TITLE
pytest: fix flake in test_even_sendcustommsg

### DIFF
--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -564,6 +564,8 @@ void set_custommsgs(struct daemon *daemon, const u8 *msg)
 	tal_free(daemon->custom_msgs);
 	if (!fromwire_connectd_set_custommsgs(daemon, msg, &daemon->custom_msgs))
 		master_badmsg(WIRE_CONNECTD_SET_CUSTOMMSGS, msg);
+	status_debug("Now allowing %zu custom message types",
+		     tal_count(daemon->custom_msgs));
 }
 
 void send_custommsg(struct daemon *daemon, const u8 *msg)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3617,6 +3617,7 @@ def test_even_sendcustommsg(node_factory):
     # Now with a plugin which allows it
     l1.connect(l2)
     l2.rpc.plugin_start(os.path.join(os.getcwd(), "tests/plugins/allow_even_msgs.py"))
+    l2.daemon.wait_for_log("connectd.*Now allowing 1 custom message types")
 
     l1.rpc.sendcustommsg(l2.info['id'], msg)
     l2.daemon.wait_for_log(r'\[IN\] {}'.format(msg))


### PR DESCRIPTION
Make sure plugin has got message to connectd before sending!

```
    def test_even_sendcustommsg(node_factory):
        l1, l2 = node_factory.get_nodes(2, opts={'log-level': 'io',
                                                 'allow_warning': True})
        l1.connect(l2)
    
        # Even-numbered message
        msg = hex(43690)[2:] + ('ff' * 30) + 'bb'
    
        # l2 will hang up when it gets this.
        l1.rpc.sendcustommsg(l2.info['id'], msg)
        l2.daemon.wait_for_log(r'\[IN\] {}'.format(msg))
        l1.daemon.wait_for_log('Invalid unknown even msg')
        wait_for(lambda: l1.rpc.listpeers(l2.info['id'])['peers'] == [])
    
        # Now with a plugin which allows it
        l1.connect(l2)
        l2.rpc.plugin_start(os.path.join(os.getcwd(), "tests/plugins/allow_even_msgs.py"))
    
        l1.rpc.sendcustommsg(l2.info['id'], msg)
        l2.daemon.wait_for_log(r'\[IN\] {}'.format(msg))
>       l2.daemon.wait_for_log(r'allow_even_msgs.*Got message 43690')

tests/test_misc.py:3623: 
...
>                   raise TimeoutError('Unable to find "{}" in logs.'.format(exs))
E                   TimeoutError: Unable to find "[re.compile('allow_even_msgs.*Got message 43690')]" in logs.

contrib/pyln-testing/pyln/testing/utils.py:327: TimeoutError
```