### PR TITLE
lightningd: don't re-enter transaction if we have to call plugin_exclusive_loop

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2391,8 +2391,11 @@ void *plugins_exclusive_loop(struct plugin **plugins)
 		io_conn_exclusive(plugins[i]->stdout_conn, true);
 	}
 
+	/* We don't want to try to open another transaction: we're in one! */
+	plugins[0]->plugins->want_db_transaction = false;
 	/* We don't service timers here, either! */
 	ret = io_loop(NULL, NULL);
+	plugins[0]->plugins->want_db_transaction = true;
 	log_debug(plugins[0]->plugins->ld->log, "io_loop: %s", __func__);
 
 	for (i = 0; i < tal_count(plugins); ++i) {

--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -360,10 +360,7 @@ void plugin_hook_db_sync(struct db *db)
 		plugin_request_send(plugin_arr[i], req);
 	}
 
-	/* We don't want to try to open another transaction: we're in one! */
-	plugins->want_db_transaction = false;
 	ret = plugins_exclusive_loop(plugin_arr);
-	plugins->want_db_transaction = true;
 
 	/* We can be called on way out of an io_loop, which is already breaking.
 	 * That will make this immediately return; save the break value and call


### PR DESCRIPTION
```
Already in transaction from lightningd/plugin.c:727
```

There are two callers, and one didn't disable transactions, so do it in plugin_exclusive_loop.