### PR TITLE
splice: Update test for new logs

### DIFF
--- a/tests/test_splicing.py
+++ b/tests/test_splicing.py
@@ -35,6 +35,7 @@ def test_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -129,6 +130,7 @@ def test_splice_listnodes(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     bitcoind.generate_block(7)
 
@@ -162,6 +164,7 @@ def test_splice_out(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -217,6 +220,7 @@ def test_invalid_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -265,6 +269,7 @@ def test_commit_crash_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     time.sleep(1)
 


### PR DESCRIPTION
The log messages were changed but the test fields weren’t updated, resulting in some test flakiness. Being more explicit with the log message we’re looking for should help.

Fixes #6803