### PR TITLE
splice[FLAKE]: stale channel announcement fix

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -563,6 +563,12 @@ static void announce_channel(struct peer *peer)
 {
 	u8 *cannounce;
 
+	/* If we splice quickly enough, the initial channel announcement may
+	 * still be pending. This old announcement is made stale by splicing,
+	 * so we ommit it. */
+	if (!peer->have_sigs[LOCAL] || !peer->have_sigs[REMOTE])
+		return;
+
 	cannounce = create_channel_announcement(tmpctx, peer);
 
 	wire_sync_write(MASTER_FD,


### PR DESCRIPTION
Under certain conditions, when splicing a new channel quickly enough, an old channel announcement would emit *after* `mutual_splice_lock` and *before* announcement signature exchange.

Since the original channeld wouldn’t start the announcement timer until signatures were exchagned, this wasn’t an issue before.

Now splicing enables us to go from having announcement sigs to losing them, so we have to be prepared for this case.

Fixes: https://github.com/ElementsProject/lightning/issues/6810

Changelog-None