### PR TITLE
Remove error from startup_regtest when loading wallet

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -143,14 +143,14 @@ start_ln() {
 	while ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest ping 2> /tmp/null; do echo "awaiting bitcoind..." && sleep 1; done
 
 	# Check if default wallet exists
-	if ! bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
+	if ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
 		# wallet dir does not exist, create one
 		echo "Making \"default\" bitcoind wallet."
 		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest createwallet default >/dev/null 2>&1
 	fi
 
 	# Check if default wallet is loaded
-	if ! bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest listwallets | jq -r '.[]' | grep -wqe 'default' ; then
+	if ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest listwallets | jq -r '.[]' | grep -wqe 'default' ; then
 		echo "Loading \"default\" bitcoind wallet."
 		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest loadwallet default >/dev/null 2>&1
 	fi
@@ -160,7 +160,7 @@ start_ln() {
 		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 1 "$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getnewaddress)" > /dev/null
 	fi
 
-	alias bt-cli='bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest'
+	alias bt-cli='bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest'
 
 	if [ -z "$1" ]; then
 		nodes=2

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -142,17 +142,24 @@ start_ln() {
 	# Wait for it to start.
 	while ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest ping 2> /tmp/null; do echo "awaiting bitcoind..." && sleep 1; done
 
-	# Kick it out of initialblockdownload if necessary
-	if bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getblockchaininfo | grep -q 'initialblockdownload.*true'; then
-		# Modern bitcoind needs createwallet
+	# Check if default wallet exists
+	if ! bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
+		# wallet dir does not exist, create one
 		echo "Making \"default\" bitcoind wallet."
 		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest createwallet default >/dev/null 2>&1
-		# But it might already exist, load it
-	        bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest loadwallet default
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 1 "$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getnewaddress)" > /dev/null
-	else
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest loadwallet default
 	fi
+
+	# Check if default wallet is loaded
+	if ! bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest listwallets | jq -r '.[]' | grep -wqe 'default' ; then
+		echo "Loading \"default\" bitcoind wallet."
+		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest loadwallet default >/dev/null 2>&1
+	fi
+
+	# Kick it out of initialblockdownload if necessary
+	if bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getblockchaininfo | grep -q 'initialblockdownload.*true'; then
+		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 1 "$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getnewaddress)" > /dev/null
+	fi
+
 	alias bt-cli='bitcoin-cli -datadir=$PATH_TO_BITCOIN -regtest'
 
 	if [ -z "$1" ]; then


### PR DESCRIPTION
When trying to initialize `bitcoind` on regtest I was always getting an error related to the creation or loading of the default wallet.
For instance
```
$ start_ln 4
Bitcoin Core starting
awaiting bitcoind...
Making "default" bitcoind wallet.
error code: -35
error message:
Wallet "default" is already loaded.
```
This prevents the use of `startup_regtest.sh` logic inside bash scripts where `set -e` is stated.

I've added a logic that first checks if the default wallet exists before trying to create it,
and then another to check if the wallet is loaded before trying to load it.