### PR TITLE
Minimal update fix

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -814,22 +814,6 @@ static void tell_master_local_cupdates(struct daemon *daemon)
 	}
 }
 
-/* Disables all channels connected to our node. */
-static void gossip_disable_local_channels(struct daemon *daemon)
-{
-	struct node *local_node = get_node(daemon->rstate, &daemon->id);
-	struct chan_map_iter i;
-	struct chan *c;
-
-	/* We don't have a local_node, so we don't have any channels yet
-	 * either */
-	if (!local_node)
-		return;
-
-	for (c = first_chan(local_node, &i); c; c = next_chan(local_node, &i))
-		local_disable_chan(daemon, c, half_chan_idx(local_node, c));
-}
-
 struct peer *first_random_peer(struct daemon *daemon,
 			       struct peer_node_id_map_iter *it)
 {
@@ -896,9 +880,6 @@ static void gossip_init(struct daemon *daemon, const u8 *msg)
 	 * be the gossip_store mtime. */
 	if (daemon->rstate->last_timestamp > timestamp)
 		daemon->rstate->last_timestamp = timestamp;
-
-	/* Now disable all local channels, they can't be connected yet. */
-	gossip_disable_local_channels(daemon);
 
 	/* If that announced channels, we can announce ourselves (options
 	 * or addresses might have changed!) */

--- a/gossipd/routing.c
+++ b/gossipd/routing.c
@@ -1471,8 +1471,10 @@ bool routing_add_channel_update(struct routing_state *rstate,
 		}
 
 		/* Make sure it's not spamming us (private channel
-		 * updates are never considered spam) */
+		 * updates are never considered spam, nor is anything
+		 * we send ourselves!) */
 		if (is_chan_public(chan)
+		    && !local_direction(rstate, chan, NULL)
 		    && !ratelimit(rstate,
 				  &hc->tokens, hc->bcast.timestamp, timestamp)) {
 			status_peer_debug(source_peer,


### PR DESCRIPTION
This is not the complete gossipd rework I wanted, but this disables both "mark channels disabled at startup" and spam detection for our own channel_updates.

Fixes: https://github.com/ElementsProject/lightning/issues/5523 any more.

Next version, we will simplify gossipd by removing private information, allowing this code to be cleaned up greatly.