### PR TITLE
Update fee hysteresis

### DIFF
--- a/doc/getting-started/getting-started/configuration.md
+++ b/doc/getting-started/getting-started/configuration.md
@@ -313,6 +313,11 @@ The [`lightning-listconfigs`](ref:lightning-listconfigs) command will output a v
   The percentage of _estimatesmartfee 2/CONSERVATIVE_ to use for the commitment  
   transactions: default is 100.
 
+- **commit-feerate-offset**=_INTEGER_
+
+  The additional feerate a channel opener adds to their preferred feerate to
+  lessen the odds of a disconnect due to feerate disagreement (default 5).
+
 - **max-concurrent-htlcs**=_INTEGER_
 
   Number of HTLCs one channel can handle concurrently in each direction.  

--- a/doc/lightning-listconfigs.7.md
+++ b/doc/lightning-listconfigs.7.md
@@ -281,6 +281,9 @@ On success, an object is returned, containing:
   - **commit-fee** (object, optional):
     - **value\_int** (u64): field from config or cmdline, or default
     - **source** (string): source of configuration setting
+  - **commit-feerate-offset** (object, optional):
+    - **value\_int** (u32): field from config or cmdline, or default
+    - **source** (string): source of configuration setting
 - **# version** (string, optional): Special field indicating the current version **deprecated, removal in v24.05**
 - **plugins** (array of objects, optional) **deprecated, removal in v24.05**:
   - **path** (string): Full path of the plugin
@@ -359,6 +362,7 @@ On success, an object is returned, containing:
 - **developer** (boolean, optional): Whether developer mode is enabled *(added v23.08)*
 - **commit-fee** (u64, optional): The percentage of the 6-block fee estimate to use for commitment transactions **deprecated, removal in v24.05** *(added v23.05)*
 - **min-emergency-msat** (msat, optional): field from config or cmdline, or default *(added v23.08)*
+- **commit-feerate-offset** (u32, optional): additional commitment feerate applied by channel owner *(added v23.11)*
 
 [comment]: # (GENERATE-FROM-SCHEMA-END)
 
@@ -476,4 +480,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning>
 
-[comment]: # ( SHA256STAMP:cc7b6d10f93b9efb34ad76d0cc2273d29189a8dd7ef4acef2e5227755c279ea8)
+[comment]: # ( SHA256STAMP:245e056bdda7c8015917c89e243a0fd3bdd1512ca760da5d7f0a284cb3214ef7)

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -420,6 +420,11 @@ opens a channel before the channel is usable.
   The percentage of *estimatesmartfee 2/CONSERVATIVE* to use for the commitment
 transactions: default is 100.
 
+* **commit-feerate-offset**=*INTEGER*
+
+  The additional feerate a channel opener adds to their preferred feerate to
+lessen the odds of a disconnect due to feerate disagreement (default 5).
+
 * **max-concurrent-htlcs**=*INTEGER*
 
   Number of HTLCs one channel can handle concurrently in each direction.

--- a/doc/schemas/listconfigs.schema.json
+++ b/doc/schemas/listconfigs.schema.json
@@ -1351,6 +1351,24 @@
               "description": "source of configuration setting"
             }
           }
+        },
+        "commit-feerate-offset": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_int",
+            "source"
+          ],
+          "properties": {
+            "value_int": {
+              "type": "u32",
+              "description": "field from config or cmdline, or default"
+            },
+            "source": {
+              "type": "string",
+              "description": "source of configuration setting"
+            }
+          }
         }
       }
     },
@@ -1770,6 +1788,11 @@
       "type": "msat",
       "added": "v23.08",
       "description": "field from config or cmdline, or default"
+    },
+    "commit-feerate-offset": {
+      "type": "u32",
+      "added": "v23.11",
+      "description": "additional commitment feerate applied by channel owner"
     }
   }
 }

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -56,6 +56,13 @@ void channel_update_feerates(struct lightningd *ld, const struct channel *channe
 	else
 		min_feerate = feerate_min(ld, NULL);
 	max_feerate = feerate_max(ld, NULL);
+	/* The channel opener should use a slightly higher than minimal feerate
+	 * in order to avoid excessive feerate disagreements */
+	if (channel->opener == LOCAL) {
+		feerate += ld->config.feerate_offset;
+		if (feerate > max_feerate)
+			feerate = max_feerate;
+	}
 
 	if (channel->ignore_fee_limits || ld->config.ignore_fee_limits) {
 		min_feerate = 1;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -93,6 +93,9 @@ struct config {
 
 	/* Percent of CONSERVATIVE/2 feerate we'll use for commitment txs. */
 	u64 commit_fee_percent;
+
+	/* Commit feerate offset above min_feerate to use as a channel opener */
+	u32 feerate_offset;
 };
 
 typedef STRMAP(const char *) alt_subdaemon_map;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -948,6 +948,7 @@ static const struct config testnet_config = {
 
 	.max_fee_multiplier = 10,
 	.commit_fee_percent = 100,
+	.feerate_offset = 5,
 };
 
 /* aka. "Dude, where's my coins?" */
@@ -1022,6 +1023,7 @@ static const struct config mainnet_config = {
 
 	.max_fee_multiplier = 10,
 	.commit_fee_percent = 100,
+	.feerate_offset = 5,
 };
 
 static void check_config(struct lightningd *ld)

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1578,6 +1578,10 @@ static void register_opts(struct lightningd *ld)
 	clnopt_witharg("--commit-fee", OPT_SHOWINT,
 		       opt_set_u64, opt_show_u64, &ld->config.commit_fee_percent,
 		       "Percentage of fee to request for their commitment");
+	clnopt_witharg("--commit-feerate-offset", OPT_SHOWINT,
+		       opt_set_u32, opt_show_u32, &ld->config.feerate_offset,
+		       "Additional feerate per kw to apply to feerate updates "
+		       "as the channel opener");
 	clnopt_witharg("--min-emergency-msat", OPT_SHOWMSATS,
 		       opt_set_sat_nondust, opt_show_sat, &ld->emergency_sat,
 		       "Amount to leave in wallet for spending anchor closes");

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1251,7 +1251,7 @@ def test_penalty_htlc_tx_fulfill(node_factory, bitcoind, chainparams, anchors):
 
     # reconnect with l1, which will fulfill the payment
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.daemon.wait_for_log('got commitsig .*: feerate 11000, blockheight: 0, 0 added, 1 fulfilled, 0 failed, 0 changed')
+    l2.daemon.wait_for_log('got commitsig .*: feerate 11005, blockheight: 0, 0 added, 1 fulfilled, 0 failed, 0 changed')
 
     # l2 moves on for closed l3
     bitcoind.generate_block(1)
@@ -1463,7 +1463,7 @@ def test_penalty_htlc_tx_timeout(node_factory, bitcoind, chainparams, anchors):
 
     # reconnect with l1, which will fulfill the payment
     l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l2.daemon.wait_for_log('got commitsig .*: feerate {}, blockheight: 0, 0 added, 1 fulfilled, 0 failed, 0 changed'.format(3750 if anchors else 11000))
+    l2.daemon.wait_for_log('got commitsig .*: feerate {}, blockheight: 0, 0 added, 1 fulfilled, 0 failed, 0 changed'.format(3755 if anchors else 11005))
 
     # l2 moves on for closed l3
     bitcoind.generate_block(1, wait_for_mempool=1)
@@ -2650,12 +2650,12 @@ def test_onchain_different_fees(node_factory, bitcoind, executor):
 
     # Both sides should have correct feerate
     assert l1.db_query('SELECT min_possible_feerate, max_possible_feerate FROM channels;') == [{
-        'min_possible_feerate': 5000,
-        'max_possible_feerate': 11000
+        'min_possible_feerate': 5005,
+        'max_possible_feerate': 11005
     }]
     assert l2.db_query('SELECT min_possible_feerate, max_possible_feerate FROM channels;') == [{
-        'min_possible_feerate': 5000,
-        'max_possible_feerate': 11000
+        'min_possible_feerate': 5005,
+        'max_possible_feerate': 11005
     }]
 
     bitcoind.generate_block(5)


### PR DESCRIPTION
This gets the channel opener to propose a higher feerate than what they would actually prefer to use (the minimum realistic fee.)  This may address some feerate disagreements which lead to disconnects with peers due to non-exactly matching feerates as described in #6756.  This may be due to differing mempool configuration, or fee estimation.  Either way, some additional tolerance set by opener by default should improve the situation.

I'm not sure if we want this option exposed, but it seemed appropriate.  The default is 5, which only covers rounding errors, but there are reports of CLN<->CLN fee disagreements by just 1sat per kw difference.  Additional data may be useful to adjust this default.

Changelog-Added: Added option --commit-fee-offset to potentially reduce feerate update disagreements