### PR TITLE
ci: Possible fix for CI_SERVER issue in VLS CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   # of a bit of compile time.
   RUST_PROFILE: release
   SLOW_MACHINE: 1
-  CI_SERVER: "http://35.239.136.52:3170"
+  CI_SERVER_URL: "http://35.239.136.52:3170"
 
 jobs:
   prebuild:

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ import json
 from time import time
 import unittest
 
-server = os.environ.get("CI_SERVER", None)
+server = os.environ.get("CI_SERVER_URL", None)
 
 github_sha = (
     subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ASCII").strip()


### PR DESCRIPTION
Code using `CI_SERVER` was added recently to track something.  It attempts to short-cut if `CI_SERVER` is not set, but on gitlab it is set to `yes`.  https://docs.gitlab.com/ee/ci/variables/

Instead use `CI_SERVER_URL`, maybe that is what is intended?

VLS CI was failing on all skipped tests with:
```
=================================== FAILURES ===================================
[31m[1m_____________________ test_bookkeeping_missed_chans_pushed _____________________[0m
[gw6] linux -- Python 3.10.12 /usr/bin/python3

pyfuncitem = <Function test_bookkeeping_missed_chans_pushed>

    @pytest.hookimpl(hookwrapper=True)
    def pytest_pyfunc_call(pyfuncitem):
        global result
        result = result.copy()
        result["testname"] = pyfuncitem.name
        result["start_time"] = int(time())
        outcome = yield
        result["end_time"] = int(time())
        # outcome.excinfo may be None or a (cls, val, tb) tuple
    
        if outcome.excinfo is None:
            result["outcome"] = "success"
        elif outcome.excinfo[0] == unittest.case.SkipTest:
            result["outcome"] = "skip"
        else:
            result["outcome"] = "fail"
    
        print(result)
    
        if not server:
            return
    
        try:
>           req = request.Request(f"{server}/hook/test", method="POST")

[1m[31mconftest.py[0m:60: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[1m[31m/usr/lib/python3.10/urllib/request.py[0m:322: in __init__
    self.full_url = url
[1m[31m/usr/lib/python3.10/urllib/request.py[0m:348: in full_url
    self._parse()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.Request object at 0x7f06c1b99270>

    def _parse(self):
        self.type, rest = _splittype(self._full_url)
        if self.type is None:
>           raise ValueError("unknown url type: %r" % self.full_url)
[1m[31mE           ValueError: unknown url type: 'yes/hook/test'[0m

[1m[31m/usr/lib/python3.10/urllib/request.py[0m:377: ValueError

[33mDuring handling of the above exception, another exception occurred:[0m
```