### PR TITLE
Fix broken docker images for release build

### DIFF
--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -30,5 +30,5 @@ RUN wget https://bitcoin.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_
     mv bitcoin-$BITCOIN_VERSION/share/man/man1/* /usr/share/man/man1 && \
     rm -rf bitcoin.tar.gz bitcoin-$BITCOIN_VERSION
 
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install python-bitcoinlib pytest setuptools pytest-test-groups flake8 pytest-rerunfailures ephemeral-port-reserve
+RUN python3 -m pip install --force-reinstall -U pip setuptools && \
+    python3 -m pip install python-bitcoinlib pytest pytest-test-groups flake8 pytest-rerunfailures ephemeral-port-reserve

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -45,7 +45,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \
     rm rustup-install.sh && \
-    /root/.cargo/bin/rustup install 1.65
+    /root/.cargo/bin/rustup install 1.73
 
 # Download protoc manually, it is in the update repos which we
 # disabled above, so `apt-get` can't find it anymore.

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -46,7 +46,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \
     rm rustup-install.sh && \
-    /root/.cargo/bin/rustup install 1.65
+    /root/.cargo/bin/rustup install 1.73
 
 # Download protoc manually, it is in the update repos which we
 # disabled above, so `apt-get` can't find it anymore.


### PR DESCRIPTION
Fedora needs a fix for a broken `setuptools` installation and the ubuntu images a rust version upgrade