### PR TITLE
Deduplicate Changelog.md generated links

### DIFF
--- a/devtools/changelog.py
+++ b/devtools/changelog.py
@@ -81,14 +81,14 @@ def get_log_entries(commitrange):
 
 
 def linkify(entries):
-    links = []
+    links = {}
     for e in entries:
-        links.append(Link(
+        links[e.pullreq] = (Link(
             ref='#{}'.format(e.pullreq),
             content=e.content,
             url="https://github.com/ElementsProject/lightning/pull/{}".format(e.pullreq)
         ))
-    return list(set(links))
+    return list(set(links.values()))
 
 
 def group(entries):


### PR DESCRIPTION
The `devtools/changelog.py` method `linkify` produces duplicate link entries if we have more than one changelog line in a PR. This change removes the duplicates so that we only have one link per PR.