### PR TITLE
cln-grpc: Patches rpc-file path

### DIFF
--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -3,7 +3,7 @@ use cln_grpc::pb::node_server::NodeServer;
 use cln_plugin::{options, Builder};
 use log::{debug, warn};
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 mod tls;
 
@@ -17,7 +17,6 @@ struct PluginState {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     debug!("Starting grpc plugin");
-    let path = Path::new("lightning-rpc");
 
     let directory = std::env::current_dir()?;
 
@@ -50,7 +49,7 @@ async fn main() -> Result<()> {
     let (identity, ca_cert) = tls::init(&directory)?;
 
     let state = PluginState {
-        rpc_path: path.into(),
+        rpc_path: PathBuf::from(plugin.configuration().rpc_file.as_str()),
         identity,
         ca_cert,
     };


### PR DESCRIPTION
`cln-gprc` is assuming the `rpc-file` path is set as default, which may not always be the case. Set the path the what the plugin manager reports

## Context

Lately, Polar for macOS has been unable to deploy CLN nodes due to an issue with how the `rpc-file` is generated on the docker volume (see https://github.com/jamaljsr/polar/issues/779 for details). Recently, a workaround has been found, consisting of moving the `rpc-file` outside of its default location. However, doing so makes `cln-grpc` unable to connect to the backend.

This can be worked around by creating a simlink in the default location to point to where `lightning-rpc` is actually located. However, the underlying issue lies in `cln-grpc` not getting the info from `cln-plugin` but instead, assuming the location of the file.