### PR TITLE
Update pyln-testing cheroot dependency

### DIFF
--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -19,7 +19,7 @@ python-bitcoinlib = "^0.11.0"
 jsonschema = "^4.4.0"
 pyln-client = ">=23"
 Flask = "^2"
-cheroot = "^8"
+cheroot = ">=8 <=10"
 psutil = "^5.9"
 requests = "^2.31.0"
 


### PR DESCRIPTION
pyln-testing depends on cheroot~=8 which depends on pkg_resources.

In python3.11 this has been deprecated which results in the following warning

```
.../venv/lib/python3.11/site-packages/cheroot/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources
```