### PR TITLE
Flake fix + more debug logging

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -953,8 +953,7 @@ def test_rbf_reconnect_tx_construct(node_factory, bitcoind, chainparams):
     # l2 reconnects, but doesn't have l1's commitment
     l2.daemon.wait_for_logs([r'Got dualopend reestablish',
                              r'No commitment, not sending our sigs',
-                             # This is a BROKEN log, it's expected!
-                             r'dualopend daemon died before signed PSBT returned'])
+                             r' Owning subdaemon dualopend died'])
 
     # We don't have the commtiments yet, there's no scratch_txid
     inflights = only_one(l1.rpc.listpeerchannels()['channels'])['inflight']


### PR DESCRIPTION
Fixes a race condition in a test that was causing some misery (cc @ddustin) and add logging to help debug a few other weird flake cases/problems. 

- Coin movement assertions were causing problems
- Unsure why a rawtx failed to decode in bitcoind