### PR TITLE
make: always generate proto files sans rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,8 @@ ifneq ($(FUZZING),0)
 endif
 ifneq ($(RUST),0)
 	include cln-rpc/Makefile
-	include cln-grpc/Makefile
+endif
+include cln-grpc/Makefile
 
 $(MSGGEN_GENALL)&: doc/schemas/*.request.json doc/schemas/*.schema.json
 	PYTHONPATH=contrib/msggen $(PYTHON) contrib/msggen/msggen/__main__.py
@@ -389,7 +390,6 @@ $(GRPC_GEN)&: cln-grpc/proto/node.proto cln-grpc/proto/primitives.proto
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/primitives.proto --python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	find $(GRPC_DIR)/ -type f -name "*.py" -print0 | xargs -0 sed -i'.bak' -e 's/^import \(.*\)_pb2 as .*__pb2/from pyln.grpc import \1_pb2 as \1__pb2/g'
 	find $(GRPC_DIR)/ -type f -name "*.py.bak" -print0 | xargs -0 rm -f
-endif
 
 # We make pretty much everything depend on these.
 ALL_GEN_HEADERS := $(filter %gen.h,$(ALL_C_HEADERS))

--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -16,7 +16,8 @@ RUN apk update && \
       libtool \
       net-tools \
       postgresql-dev \
-      py3-mako \
+      linux-headers \
+      py3-pip \
       python3 \
       python3-dev \
       sqlite-dev \
@@ -29,6 +30,9 @@ COPY . /source
 
 RUN git clone /source /repo --recursive && \
     cd /repo && \
+    python3 -m pip install poetry && \
+    poetry export --without-hashes --with=dev > requirements.txt && \
+    python3 -m pip install -r requirements.txt --ignore-installed --force && \
     ./configure --enable-static --prefix=/usr && \
     make -j $(nproc) && \
     make install


### PR DESCRIPTION
Generating the msggen proto files doesn’t require rust (even though it generates rust files).

Keep getting in this loop where my docs don't match CI and it's because the doc scripts were never running on my machine and I didn't enable rust.

Other's will probably run into this problem and it's quite hard to figure out.

Spotted by @niftynei and @chrisguida 

