### PR TITLE
Remove pyln-client json monkey patch for _msat fields to Millisatoshis

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -682,7 +682,6 @@ class Plugin(object):
         # then utf8 ourselves.
         s = bytes(json.dumps(
             obj,
-            cls=LightningRpc.LightningJSONEncoder,
             ensure_ascii=False
         ) + "\n\n", encoding='utf-8')
         with self.write_lock:

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -348,8 +348,8 @@ def _extra_validator(is_request: bool):
             return False
 
     def is_msat_response(checker, instance):
-        """An integer, but we convert to Millisatoshi in JSON parsing"""
-        return type(instance) is Millisatoshi
+        """A positive integer"""
+        return type(instance) is int and instance >= 0
 
     def is_txid(checker, instance):
         """Bitcoin transaction ID"""

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -684,12 +684,11 @@ class PrettyPrintingLightningRpc(LightningRpc):
     Also validates (optional) schemas for us.
     """
     def __init__(self, socket_path, executor=None, logger=logging,
-                 patch_json=True, jsonschemas={}):
+                 jsonschemas={}):
         super().__init__(
             socket_path,
             executor,
             logger,
-            patch_json,
         )
         self.jsonschemas = jsonschemas
         self.check_request_schemas = True

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3716,7 +3716,7 @@ def test_closing_anchorspend_htlc_tx_rbf(node_factory, bitcoind):
     assert 'anchors_zero_fee_htlc_tx/even' in only_one(l1.rpc.listpeerchannels()['channels'])['channel_type']['names']
 
     # We reduce l1's UTXOs so it's forced to use more than one UTXO to push.
-    fundsats = int(only_one(l1.rpc.listfunds()['outputs'])['amount_msat'].to_satoshi())
+    fundsats = int(Millisatoshi(only_one(l1.rpc.listfunds()['outputs'])['amount_msat']).to_satoshi())
     psbt = l1.rpc.fundpsbt("all", "1000perkw", 1000)['psbt']
     # Pay 5k sats in fees, send most to l2
     psbt = l1.rpc.addpsbtoutput(fundsats - 20000 - 5000, psbt, destination=l2.rpc.newaddr()['bech32'])['psbt']
@@ -3909,7 +3909,7 @@ def test_peer_anchor_push(node_factory, bitcoind, executor, chainparams):
                                          wait_for_announce=True)
 
     # We splinter l2's funds so it's forced to use more than one UTXO to push.
-    fundsats = int(only_one(l2.rpc.listfunds()['outputs'])['amount_msat'].to_satoshi())
+    fundsats = int(Millisatoshi(only_one(l2.rpc.listfunds()['outputs'])['amount_msat']).to_satoshi())
     OUTPUT_SAT = 10000
     NUM_OUTPUTS = 10
     psbt = l2.rpc.fundpsbt("all", "1000perkw", 1000)['psbt']

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -803,7 +803,7 @@ def test_multiplexed_rpc(node_factory):
     # (delaying completion should mean we don't see the other commands intermingled).
     for i in commands:
         obj, buff = l1.rpc._readobj(sock, buff)
-        assert obj['id'] == l1.rpc.decoder.decode(i.decode("UTF-8"))['id']
+        assert obj['id'] == json.loads(i.decode("UTF-8"))['id']
     sock.close()
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -171,15 +171,13 @@ def test_millisatoshi_passthrough(node_factory):
     plugin_path = os.path.join(os.getcwd(), 'tests/plugins/millisatoshis.py')
     n = node_factory.get_node(options={'plugin': plugin_path, 'log-level': 'io'})
 
-    # By keyword
+    # By keyword (plugin literally returns Millisatoshi, which becomes a string)
     ret = n.rpc.call('echo', {'msat': Millisatoshi(17), 'not_an_msat': '22msat'})['echo_msat']
-    assert type(ret) == Millisatoshi
-    assert ret == Millisatoshi(17)
+    assert Millisatoshi(ret) == Millisatoshi(17)
 
     # By position
     ret = n.rpc.call('echo', [Millisatoshi(18), '22msat'])['echo_msat']
-    assert type(ret) == Millisatoshi
-    assert ret == Millisatoshi(18)
+    assert Millisatoshi(ret) == Millisatoshi(18)
 
 
 def test_rpc_passthrough(node_factory):

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -205,13 +205,11 @@ def test_amounts(node_factory):
 
     invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
 
-    assert isinstance(invoice['amount_msat'], Millisatoshi)
     assert invoice['amount_msat'] == Millisatoshi(123456)
 
     l1.rpc.call('renepay', {'invstring': inv, 'dev_use_shadow': False})
 
     invoice = only_one(l2.rpc.listinvoices('test_pay_amounts')['invoices'])
-    assert isinstance(invoice['amount_received_msat'], Millisatoshi)
     assert invoice['amount_received_msat'] >= Millisatoshi(123456)
 
 
@@ -268,7 +266,6 @@ def test_limits(node_factory):
     l1.rpc.call(
         'renepay', {'invstring': inv2['bolt11']})
     invoice = only_one(l6.rpc.listinvoices('inv2')['invoices'])
-    assert isinstance(invoice['amount_received_msat'], Millisatoshi)
     assert invoice['amount_received_msat'] >= Millisatoshi('800000sat')
 
 
@@ -358,5 +355,4 @@ def test_hardmpp(node_factory):
     json.loads("".join([l for l in lines if not l.startswith('#')]))
     l1.wait_for_htlcs()
     invoice = only_one(l6.rpc.listinvoices('inv2')['invoices'])
-    assert isinstance(invoice['amount_received_msat'], Millisatoshi)
     assert invoice['amount_received_msat'] >= Millisatoshi('1800000sat')


### PR DESCRIPTION
This was interfering with other JSON usages (confusingly!) such as clnrest.  We only did it because _msat fields used to be strings.

Leaves the generic fallback to ".to_json" to marshall *into* JSON though.