### PR TITLE
splice: fix WIRE_HSMD_SIGN_SPLICE_TX capability check

### DIFF
--- a/lightningd/hsm_control.c
+++ b/lightningd/hsm_control.c
@@ -167,7 +167,7 @@ struct ext_key *hsm_init(struct lightningd *ld)
 	}
 
 	if (feature_offered(ld->our_features->bits[INIT_FEATURE],
-			    WIRE_HSMD_SIGN_SPLICE_TX)
+			    OPT_EXPERIMENTAL_SPLICE)
 	    && !hsm_capable(ld, WIRE_HSMD_SIGN_SPLICE_TX)) {
 		fatal("--experimental-splicing needs HSM capable of signing splices!");
 	}


### PR DESCRIPTION
Fixes #6866

Changelog-Fixed: The WIRE_HSMD_SIGN_SPLICE_TX HSM capability is now correctly checked.