### PR TITLE
cln-rpc: rewrite is_none_or_empty to not use clone()

### DIFF
--- a/cln-rpc/src/lib.rs
+++ b/cln-rpc/src/lib.rs
@@ -130,9 +130,7 @@ fn is_none_or_empty<T>(f: &Option<Vec<T>>) -> bool
 where
     T: Clone,
 {
-    // TODO Find a better way to check, possibly without cloning
-    let f = f.clone();
-    f.is_none() || f.unwrap().is_empty()
+    f.as_ref().map_or(true, |value| value.is_empty())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This should be the same, but without cloning.