### PR TITLE
docs: Recovery using database

### DIFF
--- a/doc/beginners-guide/backup-and-recovery.md
+++ b/doc/beginners-guide/backup-and-recovery.md
@@ -113,32 +113,3 @@ lightningd also stores detailed information of funds locked in Lightning Network
 Real-time database replication is the recommended approach to backing up node data. Tools for replication are currently in active development, using the db write plugin hook.
 
 Click [here](doc:advanced-db-backup) to learn more about advanced DB backup methods.
-
-
-## Recovery
-
-> 🚧 
->
-> **Only** recover from database if you are sure that it is **latest**.
->
-> Snapshot-style backups of the lightningd database is **discouraged**, as _any_ loss of state may result in permanent loss of funds. 
->
-> See the  [penalty mechanism](https://github.com/lightning/bolts/blob/master/05-onchain.md#revoked-transaction-close-handling) for more details.
-
-
-### Using `emergency.recover`
-
-  - Copy the valid binary formatted `hsm_secret` into `$LIGHTNINGDIR` directory
-  - Copy the latest `emergency.recover` backup file into the `$LIGHTNINGDIR` before starting up the node
-  - Start `lightningd`
-  - Run `lightning-cli emergencyrecover` (RPC command)[https://docs.corelightning.org/reference/lightning-emergencyrecover] to recover all the channels on the node.
-  - Wait until your peer force closes the channel and the node would automatically sweep the funds. This could take some time.
-
-
-### Using `--recover` flag
-
-  - Copy the latest `emergency.recover` backup file into the `$LIGHTNINGDIR` before starting up the node
-  - Start `lightningd --recover=<codex32secret>`. It will automatically generate your node's hsm_secret using the codex32 secret.
-  - The node will initiate in offline mode. As a result, it won't establish connections with peers automatically. 
-  - Restart `lightningd`.
-  - Run `lightning-cli emergencyrecover` (RPC command)[https://docs.corelightning.org/reference/lightning-emergencyrecover] to recover all the channels on the node.

--- a/doc/beginners-guide/backup-and-recovery/recovery.md
+++ b/doc/beginners-guide/backup-and-recovery/recovery.md
@@ -1,5 +1,5 @@
 ---
-title: "Wallet Recovery"
+title: "Wallet recovery"
 slug: "recovery"
 excerpt: "Learn about various recovery methods."
 hidden: false

--- a/doc/beginners-guide/backup-and-recovery/recovery.md
+++ b/doc/beginners-guide/backup-and-recovery/recovery.md
@@ -1,0 +1,46 @@
+---
+title: "Wallet Recovery"
+slug: "recovery"
+excerpt: "Learn about various recovery methods."
+hidden: false
+---
+
+
+## Recovery
+
+
+### Using `emergency.recover`
+
+  - Copy the valid binary formatted `hsm_secret` into `$LIGHTNINGDIR` directory
+  - Copy the latest `emergency.recover` backup file into the `$LIGHTNINGDIR` before starting up the node
+  - Start `lightningd`
+  - Run `lightning-cli emergencyrecover` (RPC command)[https://docs.corelightning.org/reference/lightning-emergencyrecover] to recover all the channels on the node
+  - Wait until your peer force closes the channel and the node would automatically sweep the funds. This could take some time
+
+
+### Using `--recover` flag
+
+  - Copy the latest `emergency.recover` backup file into the `$LIGHTNINGDIR` before starting up the node
+  - Start `lightningd --recover=<codex32secret>`. It will automatically generate your node's hsm_secret using the codex32 secret
+  - The node will initiate in offline mode. As a result, it won't establish connections with peers automatically
+  - Restart `lightningd`
+  - Run `lightning-cli emergencyrecover` (RPC command)[https://docs.corelightning.org/reference/lightning-emergencyrecover] to recover all the channels on the node
+
+
+> 🚧 
+>
+> **Only** recover from database if you are sure that it is **latest**.
+>
+> Snapshot-style backups of the lightningd database is **discouraged**, as _any_ loss of state may result in permanent loss of funds. 
+>
+> See the  [penalty mechanism](https://github.com/lightning/bolts/blob/master/05-onchain.md#revoked-transaction-close-handling) for more details.
+
+
+### Using database
+
+If you already have **latest** wallet backup and hsm_secret, it is technically not recovery. It is similar to restarting your lightning node.
+
+  - Copy the DB backup `lightningd.sqlite3` from your NFS backup directory into `$LIGHTNINGDIR` directory
+  - Either copy the valid binary formatted `hsm_secret` into `$LIGHTNINGDIR` directory and start `lightningd`
+  - Or start lightningd with recover flag (`lightningd --recover=<codex32secret>`)
+  - Note that `emergency.recover` backup file is not required here but you can copy it into `$LIGHTNINGDIR` directory (if exists)

--- a/doc/beginners-guide/backup.md
+++ b/doc/beginners-guide/backup.md
@@ -1,7 +1,7 @@
 ---
-title: "Backup and recovery"
-slug: "backup-and-recovery"
-excerpt: "Learn the various backup and recovery options available for your Core Lightning node."
+title: "Backup your wallet"
+slug: "backup"
+excerpt: "Learn the various backup options available for your Core Lightning node."
 hidden: false
 createdAt: "2022-11-18T16:28:17.292Z"
 updatedAt: "2023-04-22T12:51:49.775Z"


### PR DESCRIPTION
- Adds instructions to recover the wallet with database
- Breaks the recovery subtitle into separate page

Changelog-None.