### PR TITLE
clnrest: Import sys in except clause explicitly

### DIFF
--- a/plugins/clnrest/clnrest.py
+++ b/plugins/clnrest/clnrest.py
@@ -26,6 +26,7 @@ try:
 except ModuleNotFoundError as err:
     # OK, something is not installed?
     import json
+    import sys
     getmanifest = json.loads(sys.stdin.readline())
     print(json.dumps({'jsonrpc': "2.0",
                       'id': getmanifest['id'],


### PR DESCRIPTION
This fixes a crash on startup of core-lightning where gevent could not be imported. This happens before sys is imported and throws us into the except clause which calls sys.
By importing it explicitly in the except clause we are not dependend of the order of imports in the try bracket.