### PR TITLE
Clnrest notifications remove msat

### DIFF
--- a/common/json_stream.c
+++ b/common/json_stream.c
@@ -614,7 +614,7 @@ void json_add_amount_msat(struct json_stream *result,
 			  const char *msatfieldname,
 			  struct amount_msat msat)
 {
-	assert(strends(msatfieldname, "_msat"));
+	assert(strends(msatfieldname, "_msat") || streq(msatfieldname, "msat"));
 	json_add_u64(result, msatfieldname, msat.millisatoshis); /* Raw: low-level helper */
 }
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -223,9 +223,7 @@ invoice_payment_serialize(struct invoice_payment_hook_payload *payload,
 	json_object_start(stream, "payment");
 	json_add_escaped_string(stream, "label", payload->label);
 	json_add_preimage(stream, "preimage", &payload->preimage);
-	json_add_string(stream, "msat",
-			type_to_string(tmpctx, struct amount_msat,
-				       &payload->msat));
+	json_add_amount_msat(stream, "msat", payload->msat);
 
 	if (payload->ld->developer && payload->set)
 		invoice_payment_add_tlvs(stream, payload->set);

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -165,8 +165,7 @@ static void invoice_payment_notification_serialize(struct json_stream *stream,
 						   const struct bitcoin_outpoint *outpoint)
 {
 	json_object_start(stream, "invoice_payment");
-	json_add_string(stream, "msat",
-			type_to_string(tmpctx, struct amount_msat, &amount));
+	json_add_amount_msat(stream, "msat", amount);
 	json_add_hex(stream, "preimage", &preimage, sizeof(preimage));
 	if (outpoint)
 		json_add_outpoint(stream, "outpoint", outpoint);
@@ -201,9 +200,7 @@ static void invoice_creation_notification_serialize(struct json_stream *stream,
 {
 	json_object_start(stream, "invoice_creation");
 	if (amount != NULL)
-		json_add_string(
-		    stream, "msat",
-		    type_to_string(tmpctx, struct amount_msat, amount));
+		json_add_amount_msat(stream, "msat", *amount);
 
 	json_add_hex(stream, "preimage", &preimage, sizeof(preimage));
 	json_add_escaped_string(stream, "label", label);

--- a/tests/test_clnrest.py
+++ b/tests/test_clnrest.py
@@ -375,7 +375,6 @@ def test_clnrest_websocket_rune_no_listnotifications(node_factory):
     assert len([n for n in notifications if n.find('invoice_creation') > 0]) == 0
 
 
-@pytest.mark.xfail(strict=True)
 def test_clnrest_numeric_msat_notification(node_factory):
     """Test that msat fields are integers in notifications also."""
     # start a node with clnrest

--- a/tests/test_clnrest.py
+++ b/tests/test_clnrest.py
@@ -252,7 +252,7 @@ def test_clnrest_large_response(node_factory):
 # to complain with the errors F811 like this "F811 redefinition of
 # unused 'message'".
 
-def notifications_received_via_websocket(l1, base_url, http_session):
+def notifications_received_via_websocket(l1, base_url, http_session, rpc_method='invoice', rpc_params=[100000, 'label', 'description']):
     """Return the list of notifications received by the websocket client.
 
     We try to connect to the websocket server running at `base_url`
@@ -271,8 +271,9 @@ def notifications_received_via_websocket(l1, base_url, http_session):
         notifications.append(data)
     sio.connect(base_url)
     time.sleep(2)
-    # trigger `invoice_creation` notification
-    l1.rpc.invoice(10000, "label", "description")
+    # trigger notification by calling method
+    rpc_call = getattr(l1.rpc, rpc_method)
+    rpc_call(*rpc_params)
     time.sleep(2)
     sio.disconnect()
     return notifications

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1269,7 +1269,7 @@ def test_invoice_payment_notification(node_factory):
     l1.dev_pay(inv1['bolt11'], dev_use_shadow=False)
 
     l2.daemon.wait_for_log(r"Received invoice_payment event for label {},"
-                           " preimage {}, and amount of {}msat"
+                           " preimage {}, and amount of {}"
                            .format(label, preimage, msats))
 
 
@@ -1286,7 +1286,7 @@ def test_invoice_creation_notification(node_factory):
     l2.rpc.invoice(msats, label, 'description', preimage=preimage)
 
     l2.daemon.wait_for_log(r"Received invoice_creation event for label {},"
-                           " preimage {}, and amount of {}msat"
+                           " preimage {}, and amount of {}"
                            .format(label, preimage, msats))
 
 


### PR DESCRIPTION
Changelog-Fixed: JSON-RPC: Plugin notification `msat` fields in `invoice_payment` and `invoice_created` hooks now a number, not a string with "msat" suffix.
Changelog-Fixed: JSON-RPC: Plugin hook `payment` `msat` field is now a number, not a string with "msat" suffix.