### PR TITLE
coin_mvt: use the `lightning_hrp` for *all* coin movement currency

### DIFF
--- a/lightningd/coin_mvts.c
+++ b/lightningd/coin_mvts.c
@@ -25,7 +25,7 @@ void notify_chain_mvt(struct lightningd *ld, const struct chain_coin_mvt *mvt)
 	u32 timestamp;
 
 	timestamp = time_now().ts.tv_sec;
-	cm = finalize_chain_mvt(mvt, mvt, chainparams->onchain_hrp,
+	cm = finalize_chain_mvt(mvt, mvt, chainparams->lightning_hrp,
 				timestamp, &ld->id);
 	notify_coin_mvt(ld, cm);
 }


### PR DESCRIPTION
We were (dumbly?) using the `onchain_hrp` for 'chain_mvts' and the `lightning_hrp` for 'channel_mvts'.

This works fine everywhere *except* for on a signet, where we use different prefixes.

Since the lightning-hrp set is more diversified (testnet btc
+ signet btc use the same HRP 'onchain'), let's use that.

Should have zero impact on anything other than nodes running on signet.

To preserve your current accounts database without needing to delete, restart, execute the following: (note preferrably when your node isn't running).

```
UPDATE chain_events SET currency = 'tbs' WHERE currency = 'tb';
```

Fixes #6534

Changelog-Fixed: `bkpr-listbalances` would crash for nodes on signet with payments in channels, because onchain events were using a different currency than inchannel events.