### PR TITLE
build: 32-bit status_debug fix

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -5147,7 +5147,7 @@ static void peer_reconnect(struct peer *peer,
 	}
 
 	status_debug("Got reestablish commit=%"PRIu64" revoke=%"PRIu64
-		     " inflights: %lu, active splices: %"PRIu32,
+		     " inflights: %zu, active splices: %"PRIu32,
 		     next_commitment_number,
 		     next_revocation_number,
 		     tal_count(peer->splice_state->inflights),


### PR DESCRIPTION
FIx build error on 32bit system:
```
cc channeld/channeld.c
In file included from channeld/channeld.c:41:
channeld/channeld.c: In function ‘peer_reconnect’:
channeld/channeld.c:5149:15: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 6 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
 5149 |  status_debug("Got reestablish commit=%"PRIu64" revoke=%"PRIu64
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
./common/status.h:41:28: note: in definition of macro ‘status_debug’
   41 |  status_fmt(LOG_DBG, NULL, __VA_ARGS__)
      |                            ^~~~~~~~~~~
channeld/channeld.c:5150:23: note: format string is defined here
 5150 |        " inflights: %lu, active splices: %"PRIu32,
      |                     ~~^
      |                       |
      |                       long unsigned int
      |                     %u

```