### PR TITLE
Fix getemergency segfault

### DIFF
--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -74,7 +74,7 @@ This produces the same results as lightning-commando-rune(7) on a fresh node.
 You will still need to create a rune once the node starts, if you want commando to work (as it is only activated once it has generated one).
 
 **getcodexsecret** *hsm\_secret\_path* *id*
-  Print out the BIP-93 formatted HSM secret, for use with `--recover`.  The `id` is any 4 character string you can use to identify this secret (e.g. `adi0`): it cannot contain `i`, `o`, or `b`, but can contain digits except `1`.
+  Print out the BIP-93 formatted HSM secret, for use with `--recover`.  The `id` is any 4 character string you can use to identify this secret (e.g. `ad00`): it cannot contain `i`, `o`, or `b`, but can contain digits except `1`.
 
 **getemergencyrecover** *emergency.recover\_path*
   Print out the bech32 encoded emergency.recover file.

--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -76,6 +76,9 @@ You will still need to create a rune once the node starts, if you want commando 
 **getcodexsecret** *hsm\_secret\_path* *id*
   Print out the BIP-93 formatted HSM secret, for use with `--recover`.  The `id` is any 4 character string you can use to identify this secret (e.g. `adi0`): it cannot contain `i`, `o`, or `b`, but can contain digits except `1`.
 
+**getemergencyrecover** *emergency.recover\_path*
+  Print out the bech32 encoded emergency.recover file.
+
 BUGS
 ----
 

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -47,7 +47,7 @@ static void show_usage(const char *progname)
 	printf("	- dumponchaindescriptors <path/to/hsm_secret> [network]\n");
 	printf("	- makerune <path/to/hsm_secret>\n");
 	printf("	- getcodexsecret <path/to/hsm_secret> <id>\n");
-	printf("        - getemergencyrecover <path/to/emergency.recover>\n");
+	printf("	- getemergencyrecover <path/to/emergency.recover>\n");
 	exit(0);
 }
 
@@ -788,7 +788,7 @@ int main(int argc, char *argv[])
 	}
 
 	if(streq(method, "getcodexsecret")) {
-		if (argc < 2)
+		if (argc < 4)
 			show_usage(argv[0]);
 		return make_codexsecret(argv[2], argv[3]);
 	}


### PR DESCRIPTION
+ A doc entry for `getemergencyrecover`
+ I changed the example of `getcodexsecret` as it contained a disallowed character `i`. I guess this was an honor to @adi2011 so sorry for the change (shall we keep it? ^^).