### PR TITLE
startup_regtest.sh: updates + improvements

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -147,27 +147,21 @@ start_nodes() {
 		log-file=$LIGHTNING_DIR/l$i/log
 		addr=localhost:$socket
 		allow-deprecated-apis=false
+		developer
+		dev-fast-gossip
+		dev-bitcoind-poll=5
+		experimental-dual-fund
+		experimental-splicing
+		experimental-offers
+		funder-policy=match
+		funder-policy-mod=100
+		funder-min-their-funding=10000
+		funder-per-channel-max=100000
+		funder-fuzz-percent=0
+		lease-fee-base-sat=2sat
+		lease-fee-basis=50
+		invoices-onchain-fallback
 		EOF
-
-		# If we've configured to use developer, add dev options
-		if "$LIGHTNINGD" --help | grep -q dev-fast-gossip; then
-			cat <<- EOF >> "$LIGHTNING_DIR/l$i/config"
-			developer
-			dev-fast-gossip
-			dev-bitcoind-poll=5
-			experimental-dual-fund
-			experimental-splicing
-			experimental-offers
-			funder-policy=match
-			funder-policy-mod=100
-			funder-min-their-funding=10000
-			funder-per-channel-max=100000
-			funder-fuzz-percent=0
-			lease-fee-base-sat=2sat
-			lease-fee-basis=50
-			invoices-onchain-fallback
-			EOF
-		fi
 
 
 		# Start the lightning nodes

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -27,37 +27,92 @@
 ##  $ destroy_ln # clean up the lightning directories
 ##
 
-# Do the Right Thing if we're currently in top of srcdir.
-if [ -z "$PATH_TO_LIGHTNING" ] && [ -x cli/lightning-cli ] && [ -x lightningd/lightningd ]; then
-	PATH_TO_LIGHTNING=$(pwd)
+
+# We've got a legacy problem is that PATH_TO_LIGHTNING is the
+# path to the lightningd / lightning-cli and PATH_TO_BITCOIN
+# is the path to the bitcoin data dir. These are not the same
+# things (data directories vs binary locations). 
+# Ideally we'd let users set each of these four
+# things independently. Unless we rename stuff, this going to
+# be problematic. 
+#
+# Instead we rename them and throw up
+# if you're using the old ones.
+if [ -n "$PATH_TO_LIGHTNING" ]; then
+    echo PATH_TO_LIGHTNING is no longer supported, please use LIGHTNING_BIN
+    return 1
 fi
 
-if [ -z "$PATH_TO_LIGHTNING" ]; then
+if [ -n "$PATH_TO_BITCOIN" ]; then
+    echo PATH_TO_BITCOIN is no longer supported, please use BITCOIN_DIR
+    return 1
+fi
+
+
+# Do the Right Thing if we're currently in top of srcdir.
+if [ -z "$LIGHTNING_BIN" ] && [ -x cli/lightning-cli ] && [ -x lightningd/lightningd ]; then
+	LIGHTNING_BIN=$(pwd)
+fi
+
+if [ -z "$LIGHTNING_BIN" ]; then
 	# Already installed maybe?  Prints
 	# shellcheck disable=SC2039
-	type lightning-cli || return
+	type lightning-cli >/dev/null 2>&1 || return
 	# shellcheck disable=SC2039
-	type lightningd || return
+	type lightningd >/dev/null 2>&1 || return
 	LCLI=lightning-cli
 	LIGHTNINGD=lightningd
 else
-	LCLI="$PATH_TO_LIGHTNING"/cli/lightning-cli
-	LIGHTNINGD="$PATH_TO_LIGHTNING"/lightningd/lightningd
+	LCLI="$LIGHTNING_BIN"/cli/lightning-cli
+	LIGHTNINGD="$LIGHTNING_BIN"/lightningd/lightningd
 	# This mirrors "type" output above.
-	echo lightning-cli is "$LCLI"
-	echo lightningd is "$LIGHTNINGD"
 fi
 
-if [ -z "$PATH_TO_BITCOIN" ]; then
+if [ -z "$LIGHTNING_DIR" ]; then
+    # Default is to use the /tmp directory
+    LIGHTNING_DIR=/tmp
+fi
+
+if [ -z "$BITCOIN_DIR" ]; then
 	if [ -d "$HOME/.bitcoin" ]; then
-		PATH_TO_BITCOIN="$HOME/.bitcoin"
+		BITCOIN_DIR="$HOME/.bitcoin"
 	elif [ -d "$HOME/Library/Application Support/Bitcoin/" ]; then
-		PATH_TO_BITCOIN="$HOME/Library/Application Support/Bitcoin/"
+		BITCOIN_DIR="$HOME/Library/Application Support/Bitcoin/"
 	else
-		echo "\$PATH_TO_BITCOIN not set to a .bitcoin dir?" >&2
+		echo "\$BITCOIN_DIR not set to a .bitcoin dir?" >&2
 		return
 	fi
 fi
+
+# shellcheck disable=SC2153
+if [ -z "$BITCOIN_BIN" ]; then
+	# Already installed maybe?  Prints
+	# shellcheck disable=SC2039
+	type bitcoin-cli >/dev/null 2>&1 || return
+	# shellcheck disable=SC2039
+	type bitcoind >/dev/null 2>&1 || return
+	BCLI=bitcoin-cli
+	BITCOIND=bitcoind
+else
+    BCLI="$BITCOIN_BIN"/bitcoin-cli
+    BITCOIND="$BITCOIN_BIN"/bitcoind
+fi
+
+
+echo lightning-cli is "$LCLI"
+echo lightningd is "$LIGHTNINGD"
+echo lightning-dir is "$LIGHTNING_DIR"
+export LCLI="$LCLI"
+export LIGHTNINGD="$LIGHTNINGD"
+export LIGHTNING_DIR="$LIGHTNING_DIR"
+
+echo bitcoin-cli is "$BCLI"
+echo bitcoind is "$BITCOIND"
+echo bitcoin-dir is "$BITCOIN_DIR"
+export BCLI="$BCLI"
+export BITCOIND="$BITCOIND"
+export BITCOIN_DIR="$BITCOIN_DIR"
+
 
 start_nodes() {
 	if [ -z "$1" ]; then
@@ -84,19 +139,19 @@ start_nodes() {
 
 	for i in $(seq "$node_count"); do
 		socket=$(( 7070 + i * 101))
-		mkdir -p "/tmp/l$i-$network"
+		mkdir -p "$LIGHTNING_DIR/l$i"
 		# Node config
-		cat <<- EOF > "/tmp/l$i-$network/config"
+		cat <<- EOF > "$LIGHTNING_DIR/l$i/config"
 		network=$network
 		log-level=debug
-		log-file=/tmp/l$i-$network/log
+		log-file=$LIGHTNING_DIR/l$i/log
 		addr=localhost:$socket
 		allow-deprecated-apis=false
 		EOF
 
 		# If we've configured to use developer, add dev options
-		if $LIGHTNINGD --help | grep -q dev-fast-gossip; then
-			cat <<- EOF >> "/tmp/l$i-$network/config"
+		if "$LIGHTNINGD" --help | grep -q dev-fast-gossip; then
+			cat <<- EOF >> "$LIGHTNING_DIR/l$i/config"
 			developer
 			dev-fast-gossip
 			dev-bitcoind-poll=5
@@ -116,12 +171,12 @@ start_nodes() {
 
 
 		# Start the lightning nodes
-		test -f "/tmp/l$i-$network/lightningd-$network.pid" || \
-			$EATMYDATA "$LIGHTNINGD" "--network=$network" "--lightning-dir=/tmp/l$i-$network" "--bitcoin-datadir=$PATH_TO_BITCOIN" "--database-upgrade=true" &
+		test -f "$LIGHTNING_DIR/l$i/lightningd-$network.pid" || \
+			$EATMYDATA "$LIGHTNINGD" "--network=$network" "--lightning-dir=$LIGHTNING_DIR/l$i" "--bitcoin-datadir=$BITCOIN_DIR" "--database-upgrade=true" &
 		# shellcheck disable=SC2139 disable=SC2086
-		alias l$i-cli="$LCLI --lightning-dir=/tmp/l$i-$network"
+		alias l$i-cli="$LCLI --lightning-dir=$LIGHTNING_DIR/l$i"
 		# shellcheck disable=SC2139 disable=SC2086
-		alias l$i-log="less /tmp/l$i-$network/log"
+		alias l$i-log="less $LIGHTNING_DIR/l$i/log"
 	done
 
 	if [ -z "$EATMYDATA" ]; then
@@ -136,31 +191,31 @@ start_nodes() {
 
 start_ln() {
 	# Start bitcoind in the background
-	test -f "$PATH_TO_BITCOIN/regtest/bitcoind.pid" || \
-		bitcoind -datadir="$PATH_TO_BITCOIN" -regtest -txindex -fallbackfee=0.00000253 -daemon
+	test -f "$BITCOIN_DIR/regtest/bitcoind.pid" || \
+		"$BITCOIND" -datadir="$BITCOIN_DIR" -regtest -txindex -fallbackfee=0.00000253 -daemon
 
 	# Wait for it to start.
-	while ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest ping 2> /tmp/null; do echo "awaiting bitcoind..." && sleep 1; done
+	while ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest ping 2> /tmp/null; do echo "awaiting bitcoind..." && sleep 1; done
 
 	# Check if default wallet exists
-	if ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
+	if ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
 		# wallet dir does not exist, create one
 		echo "Making \"default\" bitcoind wallet."
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest createwallet default >/dev/null 2>&1
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest createwallet default >/dev/null 2>&1
 	fi
 
 	# Check if default wallet is loaded
-	if ! bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest listwallets | jq -r '.[]' | grep -wqe 'default' ; then
+	if ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest listwallets | jq -r '.[]' | grep -wqe 'default' ; then
 		echo "Loading \"default\" bitcoind wallet."
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest loadwallet default >/dev/null 2>&1
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest loadwallet default >/dev/null 2>&1
 	fi
 
 	# Kick it out of initialblockdownload if necessary
-	if bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getblockchaininfo | grep -q 'initialblockdownload.*true'; then
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 1 "$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest getnewaddress)" > /dev/null
+	if "$BCLI" -datadir="$BITCOIN_DIR" -regtest getblockchaininfo | grep -q 'initialblockdownload.*true'; then
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest generatetoaddress 1 "$($BCLI -datadir="$BITCOIN_DIR" -regtest getnewaddress)" > /dev/null
 	fi
 
-	alias bt-cli='bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest'
+	alias bt-cli='"$BCLI" -datadir="$BITCOIN_DIR" -regtest'
 
 	if [ -z "$1" ]; then
 		nodes=2
@@ -174,16 +229,16 @@ start_ln() {
 ensure_bitcoind_funds() {
 
 	if [ -z "$ADDRESS" ]; then
-		ADDRESS=$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest "$WALLET" getnewaddress)
+		ADDRESS=$("$BCLI" -datadir="$BITCOIN_DIR" -regtest "$WALLET" getnewaddress)
 	fi
 
-	balance=$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest "$WALLET" getbalance)
+	balance=$("$BCLI" -datadir="$BITCOIN_DIR" -regtest "$WALLET" getbalance)
 
 	if [ 1 -eq "$(echo "$balance"'<1' | bc -l)" ]; then
 
 		printf "%s" "Mining into address " "$ADDRESS""... "
 
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 100 "$ADDRESS" > /dev/null
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest generatetoaddress 100 "$ADDRESS" > /dev/null
 
 		echo "done."
 	fi
@@ -210,11 +265,11 @@ fund_nodes() {
 
 	WALLET="-rpcwallet=$WALLET"
 
-	ADDRESS=$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest "$WALLET" getnewaddress)
+	ADDRESS=$("$BCLI" -datadir="$BITCOIN_DIR" -regtest "$WALLET" getnewaddress)
 
 	ensure_bitcoind_funds
 
-	echo "bitcoind balance:" "$(bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest "$WALLET" getbalance)"
+	echo "bitcoind balance:" "$("$BCLI" -datadir="$BITCOIN_DIR" -regtest "$WALLET" getbalance)"
 
 	last_node=""
 
@@ -229,22 +284,22 @@ fund_nodes() {
 		node2=$i
 		last_node=$i
 
-		L2_NODE_ID=$($LCLI -F --lightning-dir=/tmp/l"$node2"-regtest getinfo | sed -n 's/^id=\(.*\)/\1/p')
-		L2_NODE_PORT=$($LCLI -F --lightning-dir=/tmp/l"$node2"-regtest getinfo | sed -n 's/^binding\[0\].port=\(.*\)/\1/p')
+		L2_NODE_ID=$("$LCLI" -F --lightning-dir="$LIGHTNING_DIR"/l"$node2" getinfo | sed -n 's/^id=\(.*\)/\1/p')
+		L2_NODE_PORT=$("$LCLI" -F --lightning-dir="$LIGHTNING_DIR"/l"$node2" getinfo | sed -n 's/^binding\[0\].port=\(.*\)/\1/p')
 
-		$LCLI -H --lightning-dir=/tmp/l"$node1"-regtest connect "$L2_NODE_ID"@localhost:"$L2_NODE_PORT" > /dev/null
+		"$LCLI" -H --lightning-dir="$LIGHTNING_DIR"/l"$node1" connect "$L2_NODE_ID"@localhost:"$L2_NODE_PORT" > /dev/null
 
-		L1_WALLET_ADDR=$($LCLI -F --lightning-dir=/tmp/l"$node1"-regtest newaddr | sed -n 's/^bech32=\(.*\)/\1/p')
+		L1_WALLET_ADDR=$($LCLI -F --lightning-dir=$LIGHTNING_DIR/l"$node1" newaddr | sed -n 's/^bech32=\(.*\)/\1/p')
 
 		ensure_bitcoind_funds
 
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest "$WALLET" sendtoaddress "$L1_WALLET_ADDR" 1 > /dev/null
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest "$WALLET" sendtoaddress "$L1_WALLET_ADDR" 1 > /dev/null
 
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 1 "$ADDRESS" > /dev/null
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest generatetoaddress 1 "$ADDRESS" > /dev/null
 
 		printf "%s" "Waiting for lightning node funds... "
 
-		while ! $LCLI -F --lightning-dir=/tmp/l"$node1"-regtest listfunds | grep -q "outputs"
+		while ! "$LCLI" -F --lightning-dir="$LIGHTNING_DIR"/l"$node1" listfunds | grep -q "outputs"
 		do
 			sleep 1
 		done
@@ -253,13 +308,13 @@ fund_nodes() {
 
 		printf "%s" "Funding channel from node " "$node1" " to node " "$node2"". "
 
-		$LCLI --lightning-dir=/tmp/l"$node1"-regtest fundchannel "$L2_NODE_ID" 1000000 > /dev/null
+		"$LCLI" --lightning-dir="$LIGHTNING_DIR"/l"$node1" fundchannel "$L2_NODE_ID" 1000000 > /dev/null
 
-		bitcoin-cli -datadir="$PATH_TO_BITCOIN" -regtest generatetoaddress 6 "$ADDRESS" > /dev/null
+		"$BCLI" -datadir="$BITCOIN_DIR" -regtest generatetoaddress 6 "$ADDRESS" > /dev/null
 
 		printf "%s" "Waiting for confirmation... "
 
-		while ! $LCLI -F --lightning-dir=/tmp/l"$node1"-regtest listchannels | grep -q "channels"
+		while ! "$LCLI" -F --lightning-dir=$LIGHTNING_DIR/l"$node1" listchannels | grep -q "channels"
 		do
 			sleep 1
 		done
@@ -273,9 +328,9 @@ stop_nodes() {
 	network=${1:-regtest}
 	if [ -n "$LN_NODES" ]; then
 		for i in $(seq "$LN_NODES"); do
-			test ! -f "/tmp/l$i-$network/lightningd-$network.pid" || \
-				(kill "$(cat "/tmp/l$i-$network/lightningd-$network.pid")"; \
-				rm "/tmp/l$i-$network/lightningd-$network.pid")
+			test ! -f "$LIGHTNING_DIR/l$i/lightningd-$network.pid" || \
+				(kill "$(cat "$LIGHTNING_DIR/l$i/lightningd-$network.pid")"; \
+				rm "$LIGHTNING_DIR/l$i/lightningd-$network.pid")
 			unalias "l$i-cli"
 			unalias "l$i-log"
 		done
@@ -284,30 +339,29 @@ stop_nodes() {
 
 stop_ln() {
 	stop_nodes "$@"
-	test ! -f "$PATH_TO_BITCOIN/regtest/bitcoind.pid" || \
-		(kill "$(cat "$PATH_TO_BITCOIN/regtest/bitcoind.pid")"; \
-		rm "$PATH_TO_BITCOIN/regtest/bitcoind.pid")
+	test ! -f "$BITCOIN_DIR/regtest/bitcoind.pid" || \
+		(kill "$(cat "$BITCOIN_DIR/regtest/bitcoind.pid")"; \
+		rm "$BITCOIN_DIR/regtest/bitcoind.pid")
 
 	unset LN_NODES
 	unalias bt-cli
 }
 
 destroy_ln() {
-	network=${1:-regtest}
-	rm -rf /tmp/l[0-9]*-"$network"
+	rm -rf $LIGHTNING_DIR/l[0-9]*
 }
 
 start_elem() {
-	if [ -z "$PATH_TO_ELEMENTS" ]; then
+	if [ -z "$ELEMENTS_DIR" ]; then
 		if [ -d "$HOME/.elements" ]; then
-			PATH_TO_ELEMENTS="$HOME/.elements"
+			ELEMENTS_DIR="$HOME/.elements"
 		else
-			echo "\$PATH_TO_ELEMENTS not set to a .elements dir" >&2
+			echo "\$ELEMENTS_DIR not set to a .elements dir" >&2
 			return
 		fi
 	fi
 
-	test -f "$PATH_TO_ELEMENTS/liquid-regtest/bitcoin.pid" || \
+	test -f "$ELEMENTS_DIR/liquid-regtest/bitcoin.pid" || \
 		elementsd -chain=liquid-regtest -printtoconsole -logtimestamps -nolisten -validatepegin=0 -con_blocksubsidy=5000000000 -daemon
 
 	# Wait for it to start.
@@ -331,9 +385,9 @@ start_elem() {
 
 stop_elem() {
 	stop_nodes "$1" liquid-regtest
-	test ! -f "$PATH_TO_ELEMENTS/liquid-regtest/bitcoind.pid" || \
-		(kill "$(cat "$PATH_TO_ELEMENTS/liquid-regtest/bitcoind.pid")"; \
-		rm "$PATH_TO_ELEMENTS/liquid-regtest/bitcoind.pid")
+	test ! -f "$ELEMENTS_DIR/liquid-regtest/bitcoind.pid" || \
+		(kill "$(cat "$ELEMENTS_DIR/liquid-regtest/bitcoind.pid")"; \
+		rm "$ELEMENTS_DIR/liquid-regtest/bitcoind.pid")
 
 	unset LN_NODES
 	unalias et-cli
@@ -343,8 +397,8 @@ connect() {
 	if [ -z "$1" ] || [ -z "$2" ]; then
 		printf "usage: connect 1 2\n"
 	else
-		to=$($LCLI --lightning-dir="/tmp/l$2-$network" -F getinfo | grep '^\(id\|binding\[0\]\.\(address\|port\)\)' | cut -d= -f2- | tr '\n' ' ' | (read -r ID ADDR PORT; echo "$ID@${ADDR}:$PORT"))
-		$LCLI --lightning-dir="/tmp/l$1-$network" connect "$to"
+		to=$("$LCLI" --lightning-dir="$LIGHTNING_DIR/l$2" -F getinfo | grep '^\(id\|binding\[0\]\.\(address\|port\)\)' | cut -d= -f2- | tr '\n' ' ' | (read -r ID ADDR PORT; echo "$ID@${ADDR}:$PORT"))
+		"$LCLI" --lightning-dir="$LIGHTNING_DIR"/l"$1" connect "$to"
 	fi
 }
 


### PR DESCRIPTION
Few updates to the startup_regtest.sh utility.

- Remove `PATH_TO_LIGHTNING` and `PATH_TO_BITCOIN`
- Introduce `LIGHTNING_BIN`, `LIGHTNING_DIR`, `BITCOIN_BIN`, `BITCOIN_DIR`. Now you can set where bitcoind/bitcoin datadir/lightningd/lightning-dir are!
- Update default setting for `funder` to always contribute funds
- Update `fund_nodes` to fund the 2nd node so it makes balanced channels by default