### PR TITLE
renepay: add self-pay feature

### DIFF
--- a/plugins/renepay/payment.c
+++ b/plugins/renepay/payment.c
@@ -200,7 +200,7 @@ void payment_assert_delivering_all(const struct payment *p)
 	}
 }
 
-static struct command_result *payment_success(struct payment *p)
+struct command_result *payment_success(struct payment *p)
 {
 	/* We only finish command once: its destructor clears this. */
 	if (!p->cmd)

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -178,4 +178,6 @@ struct command_result *payment_fail(
 	enum jsonrpc_errcode code,
 	const char *fmt, ...);
 
+struct command_result *payment_success(struct payment *p);
+
 #endif /* LIGHTNING_PLUGINS_RENEPAY_PAYMENT_H */


### PR DESCRIPTION
Self-pay feature for `renepay`, based on the implementation of self-pay for the default `pay` plugin.

Fixes #6606