### PR TITLE
Renepay: htlc limits on mcf

### DIFF
--- a/plugins/renepay/flow.h
+++ b/plugins/renepay/flow.h
@@ -272,4 +272,16 @@ bool flows_fit_amount(const tal_t *ctx, struct amount_msat *amount_allocated,
 		      const struct gossmap *gossmap,
 		      struct chan_extra_map *chan_extra_map, char **fail);
 
+/* Helpers to get the htlc_max and htlc_min of a channel. */
+static inline struct amount_msat
+channel_htlc_max(const struct gossmap_chan *chan, const int dir)
+{
+	return amount_msat(fp16_to_u64(chan->half[dir].htlc_max));
+}
+static inline struct amount_msat
+channel_htlc_min(const struct gossmap_chan *chan, const int dir)
+{
+	return amount_msat(fp16_to_u64(chan->half[dir].htlc_min));
+}
+
 #endif /* LIGHTNING_PLUGINS_RENEPAY_FLOW_H */

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -1355,12 +1355,8 @@ get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
 				    inf_htlc_max, channel_htlc_max(c, dir));
 			}
 
-			s64 htlc_max = inf_htlc_max.millisatoshis /
-				       1000; /* Raw: need htlc_max in sats to do
-						arithmetic operations. */
-			s64 htlc_min = (sup_htlc_min.millisatoshis + 999) /
-				       1000; /* Raw: need htlc_min in sats to do
-					       arithmetic operations. */
+			s64 htlc_max=inf_htlc_max.millisatoshis/1000;/* Raw: need htlc_max in sats to do arithmetic operations.*/
+			s64 htlc_min=(sup_htlc_min.millisatoshis+999)/1000;/* Raw: need htlc_min in sats to do arithmetic operations.*/
 
 			if (htlc_min > htlc_max) {
 				/* htlc_min is too big or htlc_max is too small,

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -397,3 +397,32 @@ def test_fee_allocation(node_factory):
     l1.wait_for_htlcs()
     invoice = only_one(l4.rpc.listinvoices('inv')['invoices'])
     assert invoice['amount_received_msat'] >= Millisatoshi('1500000sat')
+
+
+def test_htlc_max(node_factory):
+    '''
+    Topology:
+    1----2----4
+    |         |
+    3----5----6
+    '''
+    opts = [
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0},
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0},
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0},
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0,
+            'htlc-maximum-msat': 500000000},
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0,
+            'htlc-maximum-msat': 500000000},
+        {'disable-mpp': None, 'fee-base': 0, 'fee-per-satoshi': 0},
+    ]
+    l1, l2, l3, l4, l5, l6 = node_factory.get_nodes(6, opts=opts)
+    start_channels([(l1, l2, 10000000), (l2, l4, 1000000), (l4, l6, 2000000),
+                    (l1, l3, 10000000), (l3, l5, 1000000), (l5, l6, 2000000)])
+
+    inv = l6.rpc.invoice("1800000sat", "inv", 'description')
+
+    l1.rpc.call('renepay', {'invstring': inv['bolt11']})
+    l1.wait_for_htlcs()
+    invoice = only_one(l6.rpc.listinvoices('inv')['invoices'])
+    assert invoice['amount_received_msat'] >= Millisatoshi('1800000sat')


### PR DESCRIPTION
Usually `minflow` would first compute a MCF solution and then construct routes based on that.
Neither of these steps would take into account the limits `htlc_min` and `htlc_max` on channels.

PR #6893 removes a portion of the amount committed to the routes if they exceed the `htlc_max`,
but that PR assumes that that excess is small and it is due to the MCF not taking into account the
addition of fees to the flow. If the amount committed to a route exceeds the `htlc_max` in a great
amount, we would be better off to allocate that difference in other routes by recomputing MCF.
But we don't have a check for the size of that number and we just assume that the excess is small.

I think a better way to constraint the flow with respect to the `htlc_max` (and `htlc_min`) bounds is
to do it at a lower level: either when computing MCF or when dissecting the solution into routes.
The easiest solution is the latter and this is what we do in the current PR.

Once the MCF is solved, we start constructing flow routes. On those routes we can compute the 
smallest of the `htlc_max` and the biggest of the `htlc_min` and use those as limits to the amount
we can send. When these flow routes are passed to `flows_fit_amount` we will be assured that any
amount exceeding `htlc_max` would be because of the addition of fees.

- [x] implementation
- [x] write tests