### PR TITLE
chore(CI): Increase the timeout to publish to test.pypi.org

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -71,6 +71,7 @@ jobs:
         WORKDIR: ${{ matrix.WORKDIR }}
       run: |
         cd ${{ env.WORKDIR}}
+        python3 -m pip config set global.timeout 150
         poetry config repositories.testpypi https://test.pypi.org/legacy/
         poetry publish --repository testpypi --no-interaction
 
@@ -83,4 +84,5 @@ jobs:
         cd ${{ env.WORKDIR}}
         export VERSION=$(git describe --abbrev=0)
         make upgrade-version NEW_VERSION=$VERSION
+        python3 -m pip config set global.timeout 150
         poetry publish --no-interaction


### PR DESCRIPTION
`poetry publish` is currently failing with this error:

```
Publishing pyln-grpc-proto (v23.11.post) to testpypi
 - Uploading pyln_grpc_proto-23.11.post0-py3-none-any.whl 0%

 - Uploading pyln_grpc_proto-23.11.post0-py3-none-any.whl 100% - Uploading pyln_grpc_proto-23.11.post0.tar.gz 0%

 - Uploading pyln_grpc_proto-23.11.post0.tar.gz 100%
HTTPSConnectionPool(host='test.pypi.org', port=443): Read timed out. (read timeout=15)
```

Hopefully by 10xing the timeout we can get this working again. I expect it is just slow to process on the `test.pypi.org` instance.