### PR TITLE
misc: Improve generated traces from common/trace.c

### DIFF
--- a/common/trace.h
+++ b/common/trace.h
@@ -1,6 +1,10 @@
 #ifndef LIGHTNING_COMMON_TRACE_H
 #define LIGHTNING_COMMON_TRACE_H
 #include "config.h"
+#include <ccan/short_types/short_types.h>
+
+#define SPAN_ID_SIZE 8
+#define TRACE_ID_SIZE 16
 
 void trace_span_start(const char *name, const void *key);
 void trace_span_end(const void *key);
@@ -8,5 +12,6 @@ void trace_span_suspend(const void *key);
 void trace_span_resume(const void *key);
 void trace_span_tag(const void *key, const char *name, const char *value);
 void trace_cleanup(void);
+void trace_span_remote(u8 trace_id[TRACE_ID_SIZE], u8 span_id[SPAN_ID_SIZE]);
 
 #endif /* LIGHTNING_COMMON_TRACE_H */


### PR DESCRIPTION
The integration with opentelemetry was sub-optimal: it was generating jaeger-style traces, with short traceIds and we were considering the entire lifetime as a single trace. This PR changes that to a trace for startup and then a trace for any event that doesn't already have a parent.

We also allow using the `CLN_TRACEPARENT` envvar to attach the startup to a remote / external trace, potentially by whatever started the main process. This is useful to see the startup trace in the wider context of whatever tooling is built around it.

Changelog-Added: tracing: It is now possible to inject a parent for the startup trace by setting the `CLN_TRACEPARENT` envvar