### PR TITLE
psbt-fix: set to NULL, which will cleanup dangling pointer

### DIFF
--- a/common/psbt_internal.c
+++ b/common/psbt_internal.c
@@ -65,7 +65,7 @@ psbt_input_set_final_witness_stack(const tal_t *ctx,
 	size_t size, max = tal_count(data);
 	bool ok;
 
-	wally_tx_witness_stack_free(in->final_witness);
+	wally_psbt_input_set_final_witness(in, NULL);
 
 	/* FIXME: return an error?? */
 	if (!next_size(&data, &max, &size))


### PR DESCRIPTION
On July 18th, @jgriffiths wrote:

> You need to set this to NULL after freeing it, otherwise if line 72 returns you have a dangling pointer and potential later use-after-free here. Alternately use wally_psbt_set_input_final_witness(NULL) which will free any existing witness and set the value to NULL.

Reported-By: @jgriffiths


See original report: https://github.com/ElementsProject/lightning/pull/6391#pullrequestreview-1535809620