### PR TITLE
Initialise final_tx

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3458,7 +3458,7 @@ static void resume_splice_negotiation(struct peer *peer,
 	u32 chan_output_index;
 	struct bitcoin_signature their_sig;
 	struct pubkey *their_pubkey;
-	struct bitcoin_tx *final_tx;
+	struct bitcoin_tx *final_tx = NULL;
 	struct bitcoin_txid final_txid;
 	u8 **wit_stack;
 	struct tlv_txsigs_tlvs *txsig_tlvs, *their_txsigs_tlvs;

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3458,7 +3458,7 @@ static void resume_splice_negotiation(struct peer *peer,
 	u32 chan_output_index;
 	struct bitcoin_signature their_sig;
 	struct pubkey *their_pubkey;
-	struct bitcoin_tx *final_tx = NULL;
+	struct bitcoin_tx *final_tx;
 	struct bitcoin_txid final_txid;
 	u8 **wit_stack;
 	struct tlv_txsigs_tlvs *txsig_tlvs, *their_txsigs_tlvs;

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3703,6 +3703,11 @@ static void resume_splice_negotiation(struct peer *peer,
 
 		final_tx = bitcoin_tx_with_psbt(tmpctx, current_psbt);
 
+		msg = towire_channeld_splice_confirmed_signed(tmpctx, final_tx,
+							      chan_output_index);
+		wire_sync_write(MASTER_FD, take(msg));
+		send_channel_update(peer, true);
+
 		wit_stack = bitcoin_witness_2of2(final_tx, &splice_sig,
 						 &their_sig,
 						 &peer->channel->funding_pubkey[LOCAL],
@@ -3729,14 +3734,6 @@ static void resume_splice_negotiation(struct peer *peer,
 	}
 
 	peer->splicing = tal_free(peer->splicing);
-
-	if (recv_signature) {
-		msg = towire_channeld_splice_confirmed_signed(tmpctx, final_tx,
-							      chan_output_index);
-		wire_sync_write(MASTER_FD, take(msg));
-
-		send_channel_update(peer, true);
-	}
 }
 
 static struct inflight *inflights_new(struct peer *peer)


### PR DESCRIPTION
Compilation fails on gcc with -O3
```
channeld/channeld.c: In function ‘resume_splice_negotiation’:                                                                                                                 
channeld/channeld.c:3734:23: error: ‘final_tx’ may be used uninitialized [-Werror=maybe-uninitialized]                                                                        
 3734 |                 msg = towire_channeld_splice_confirmed_signed(tmpctx, final_tx,                                                                                       
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                       
 3735 |                                                               chan_output_index);                                                                                   
      |                                                               ~~~~~~~~~~~~~~~~~~                                                                                      
channeld/channeld.c:3461:28: note: ‘final_tx’ was declared here                                                                                                               
 3461 |         struct bitcoin_tx *final_tx;                                                                                                                                  
      |                            ^~~~~~~~         
```                                                         
With this error message.