### PR TITLE
configure: abort on UBSan failure

### DIFF
--- a/configure
+++ b/configure
@@ -165,10 +165,7 @@ set_defaults()
 	fi
     fi
     if [ "$UBSAN" != 0 ]; then
-	CSANFLAGS="$CSANFLAGS -fsanitize=undefined"
-	if [ "$DEBUGBUILD" != 0 ]; then
-	    CSANFLAGS="$CSANFLAGS -fno-sanitize-recover=undefined"
-	fi
+	CSANFLAGS="$CSANFLAGS -fsanitize=undefined -fno-sanitize-recover=undefined"
     fi
     if [ "$FUZZING" != 0 ]; then
 	FUZZFLAGS="-fsanitize=fuzzer-no-link -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"


### PR DESCRIPTION
By default, UBSan reports runtime errors but does not stop execution. We already abort in debug builds, and this commit makes us also abort in regular builds when UBSan is enabled. Arguably, this is what users expect when they enable UBSan, so it is a good default.

I know I've missed some UBSan bugs in the past because of this issue, and @dergoegge mentioned that this also happened to him.