### PR TITLE
subd: Do not send feerate updates to non-channeld subds

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -93,6 +93,11 @@ static void try_update_feerates(struct lightningd *ld, struct channel *channel)
 	if (!channel->owner)
 		return;
 
+	/* The feerate message is only understood by `channeld` so
+	 * don't attempt to send it to other subds*/
+	if (!streq(channel->owner->name, "channeld"))
+		return;
+
 	channel_update_feerates(ld, channel);
 }
 


### PR DESCRIPTION
Turns out we were sending feerate updates to daemons that do not understand it. Don't do that!

Closes #6932

Changelog-Fixed: channeld: We could crash `closingd` by sending it a `channeld` message