### PR TITLE
Fix onchain fees lookup query

### DIFF
--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -342,7 +342,7 @@ struct fee_sum **find_account_onchain_fees(const tal_t *ctx,
 				     ", CAST(SUM(debit) AS BIGINT) as debit"
 				     " FROM onchain_fees"
 				     " WHERE account_id = ?"
-				     " GROUP BY txid, update_count"
+				     " GROUP BY txid"
 				     " ORDER BY txid, update_count"));
 
 	db_bind_u64(stmt, acct->db_id);

--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -343,7 +343,7 @@ struct fee_sum **find_account_onchain_fees(const tal_t *ctx,
 				     " FROM onchain_fees"
 				     " WHERE account_id = ?"
 				     " GROUP BY txid"
-				     " ORDER BY txid, update_count"));
+				     " ORDER BY txid"));
 
 	db_bind_u64(stmt, acct->db_id);
 	db_query_prepared(stmt);

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -483,8 +483,6 @@ def test_bookkeeping_missed_chans_pushed(node_factory, bitcoind):
     _check_events(l2, channel_id, exp_events)
 
 
-@pytest.mark.xfail
-@pytest.mark.timeout(15)
 @unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
 @pytest.mark.openchannel('v1')
 def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
@@ -562,8 +560,6 @@ def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
     assert bkpr_total_fee_btc == getblock_fee_btc
 
 
-@pytest.mark.xfail
-@pytest.mark.timeout(15)
 @unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
 @pytest.mark.openchannel('v2')
 def test_bookkeeping_inspect_mfc_dual_funded(node_factory, bitcoind):

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -534,11 +534,11 @@ def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
     channel_13_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_13_channel_id)['txs'][0]['fees_paid_msat']
     channel_14_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
 
-    bkpr_total_fee_btc = (channel_12_multifundchannel_fee_msat
-                          + channel_13_multifundchannel_fee_msat
-                          + channel_14_multifundchannel_fee_msat).to_btc()
+    bkpr_total_fee_msat = (channel_12_multifundchannel_fee_msat
+                           + channel_13_multifundchannel_fee_msat
+                           + channel_14_multifundchannel_fee_msat)
 
-    assert bkpr_total_fee_btc == getblock_fee_btc
+    assert bkpr_total_fee_msat == int(getblock_fee_btc * 100000000000)
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
@@ -602,14 +602,14 @@ def test_bookkeeping_inspect_mfc_dual_funded(node_factory, bitcoind):
     channel_14_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
     channel_41_multifundchannel_fee_msat = l4.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
 
-    bkpr_total_fee_btc = (channel_12_multifundchannel_fee_msat
-                          + channel_21_multifundchannel_fee_msat
-                          + channel_13_multifundchannel_fee_msat
-                          + channel_31_multifundchannel_fee_msat
-                          + channel_14_multifundchannel_fee_msat
-                          + channel_41_multifundchannel_fee_msat).to_btc()
+    bkpr_total_fee_msat = (channel_12_multifundchannel_fee_msat
+                           + channel_21_multifundchannel_fee_msat
+                           + channel_13_multifundchannel_fee_msat
+                           + channel_31_multifundchannel_fee_msat
+                           + channel_14_multifundchannel_fee_msat
+                           + channel_41_multifundchannel_fee_msat)
 
-    assert bkpr_total_fee_btc == getblock_fee_btc
+    assert bkpr_total_fee_msat == int(getblock_fee_btc * 100000000000)
 
 
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "turns off bookkeeper at start")

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -520,26 +520,8 @@ def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
     wait_for(lambda: l1.channel_state(l3) == 'CHANNELD_NORMAL')
     wait_for(lambda: l1.channel_state(l4) == 'CHANNELD_NORMAL')
 
-    # calculate the tx fee from bitcoin-cli by subtracting the multifundchannel tx inputs and outputs
+    # now use getblock to get the tx fee from bitcoin-cli's perspective
     multifundchannel_rawtx = l1.bitcoin.rpc.getrawtransaction(multifundchannel_txid, True)
-
-    inputs_total_btc = 0
-    vins = multifundchannel_rawtx['vin']
-    for vin in vins:
-        temp_txid = vin['txid']
-        temp_vout = vin['vout']
-        temp_rawtx = l1.bitcoin.rpc.getrawtransaction(temp_txid, True)
-        output_amount_btc = temp_rawtx['vout'][temp_vout]['value']
-        inputs_total_btc += output_amount_btc
-
-    outputs_total_btc = 0
-    vouts = multifundchannel_rawtx['vout']
-    for vout in vouts:
-        outputs_total_btc += vout['value']
-
-    calculated_total_fees_btc = inputs_total_btc - outputs_total_btc
-
-    # now use getblock to get the tx fee also from bitcoin-cli's perspective
     blockhash = multifundchannel_rawtx['blockhash']
     getblock_tx = l1.bitcoin.rpc.getblock(blockhash, 2)['tx']
     getblock_fee_btc = 0
@@ -556,7 +538,6 @@ def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
                           + channel_13_multifundchannel_fee_msat
                           + channel_14_multifundchannel_fee_msat).to_btc()
 
-    assert bkpr_total_fee_btc == calculated_total_fees_btc
     assert bkpr_total_fee_btc == getblock_fee_btc
 
 
@@ -604,26 +585,8 @@ def test_bookkeeping_inspect_mfc_dual_funded(node_factory, bitcoind):
     wait_for(lambda: l1.channel_state(l3) == 'CHANNELD_NORMAL')
     wait_for(lambda: l1.channel_state(l4) == 'CHANNELD_NORMAL')
 
-    # calculate the tx fee from bitcoin-cli by subtracting the multifundchannel tx inputs and outputs
+    # now use getblock to get the tx fee from bitcoin-cli's perspective
     multifundchannel_rawtx = l1.bitcoin.rpc.getrawtransaction(multifundchannel_txid, True)
-
-    inputs_total_btc = 0
-    vins = multifundchannel_rawtx['vin']
-    for vin in vins:
-        temp_txid = vin['txid']
-        temp_vout = vin['vout']
-        temp_rawtx = l1.bitcoin.rpc.getrawtransaction(temp_txid, True)
-        output_amount_btc = temp_rawtx['vout'][temp_vout]['value']
-        inputs_total_btc += output_amount_btc
-
-    outputs_total_btc = 0
-    vouts = multifundchannel_rawtx['vout']
-    for vout in vouts:
-        outputs_total_btc += vout['value']
-
-    calculated_total_fees_btc = inputs_total_btc - outputs_total_btc
-
-    # now use getblock to get the tx fee also from bitcoin-cli's perspective
     blockhash = multifundchannel_rawtx['blockhash']
     getblock_tx = l1.bitcoin.rpc.getblock(blockhash, 2)['tx']
     getblock_fee_btc = 0
@@ -646,7 +609,6 @@ def test_bookkeeping_inspect_mfc_dual_funded(node_factory, bitcoind):
                           + channel_14_multifundchannel_fee_msat
                           + channel_41_multifundchannel_fee_msat).to_btc()
 
-    assert bkpr_total_fee_btc == calculated_total_fees_btc
     assert bkpr_total_fee_btc == getblock_fee_btc
 
 

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -483,6 +483,177 @@ def test_bookkeeping_missed_chans_pushed(node_factory, bitcoind):
     _check_events(l2, channel_id, exp_events)
 
 
+@pytest.mark.xfail
+@pytest.mark.timeout(15)
+@unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
+@pytest.mark.openchannel('v1')
+def test_bookkeeping_inspect_multifundchannel(node_factory, bitcoind):
+    """
+    Test that bookkeeper splits multifundchannel fees correctly for single funded channels.
+    For single funded channels, l1 pays the entirety of the fee associated with multifundchannel, and the fee is
+    split into each channel and is viewed from the opener's perspective.
+    """
+    l1, l2, l3, l4 = node_factory.get_nodes(4)
+
+    l1.fundwallet(200000000)
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
+
+    destinations = [{"id": '{}@localhost:{}'.format(l2.info['id'], l2.port),
+                     "amount": 25000},
+                    {"id": '{}@localhost:{}'.format(l3.info['id'], l3.port),
+                     "amount": 25000},
+                    {"id": '{}@localhost:{}'.format(l4.info['id'], l4.port),
+                     "amount": 25000}]
+
+    multifundchannel_return = l1.rpc.multifundchannel(destinations)
+
+    multifundchannel_txid = multifundchannel_return['txid']
+
+    channel_ids = multifundchannel_return['channel_ids']
+
+    channel_12_channel_id = channel_ids[0]['channel_id']
+    channel_13_channel_id = channel_ids[1]['channel_id']
+    channel_14_channel_id = channel_ids[2]['channel_id']
+
+    bitcoind.generate_block(1, wait_for_mempool=[multifundchannel_txid])
+    wait_for(lambda: l1.channel_state(l2) == 'CHANNELD_NORMAL')
+    wait_for(lambda: l1.channel_state(l3) == 'CHANNELD_NORMAL')
+    wait_for(lambda: l1.channel_state(l4) == 'CHANNELD_NORMAL')
+
+    # calculate the tx fee from bitcoin-cli by subtracting the multifundchannel tx inputs and outputs
+    multifundchannel_rawtx = l1.bitcoin.rpc.getrawtransaction(multifundchannel_txid, True)
+
+    inputs_total_btc = 0
+    vins = multifundchannel_rawtx['vin']
+    for vin in vins:
+        temp_txid = vin['txid']
+        temp_vout = vin['vout']
+        temp_rawtx = l1.bitcoin.rpc.getrawtransaction(temp_txid, True)
+        output_amount_btc = temp_rawtx['vout'][temp_vout]['value']
+        inputs_total_btc += output_amount_btc
+
+    outputs_total_btc = 0
+    vouts = multifundchannel_rawtx['vout']
+    for vout in vouts:
+        outputs_total_btc += vout['value']
+
+    calculated_total_fees_btc = inputs_total_btc - outputs_total_btc
+
+    # now use getblock to get the tx fee also from bitcoin-cli's perspective
+    blockhash = multifundchannel_rawtx['blockhash']
+    getblock_tx = l1.bitcoin.rpc.getblock(blockhash, 2)['tx']
+    getblock_fee_btc = 0
+    for tx in getblock_tx:
+        if tx['txid'] == multifundchannel_txid:
+            getblock_fee_btc = tx['fee']
+
+    # now sum bookkeeper fees for each channel to get the total fees for this tx
+    channel_12_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_12_channel_id)['txs'][0]['fees_paid_msat']
+    channel_13_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_13_channel_id)['txs'][0]['fees_paid_msat']
+    channel_14_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
+
+    bkpr_total_fee_btc = (channel_12_multifundchannel_fee_msat
+                          + channel_13_multifundchannel_fee_msat
+                          + channel_14_multifundchannel_fee_msat).to_btc()
+
+    assert bkpr_total_fee_btc == calculated_total_fees_btc
+    assert bkpr_total_fee_btc == getblock_fee_btc
+
+
+@pytest.mark.xfail
+@pytest.mark.timeout(15)
+@unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
+@pytest.mark.openchannel('v2')
+def test_bookkeeping_inspect_mfc_dual_funded(node_factory, bitcoind):
+    """
+    Test that bookkeeper splits multifundchannel fees correctly for dual funded channels.
+    For dual funded channels, the other nodes also pay part of the fees associated with multifundchannel, since they
+    are also funding the channel.  To calculate the total fees spent for the multifundchannel tx, the
+    other nodes' fees paid must be included.
+    """
+    opts = {'experimental-dual-fund': None, 'funder-policy': 'match',
+            'funder-policy-mod': 100, 'funder-lease-requests-only': False}
+    l1, l2, l3, l4 = node_factory.get_nodes(4, opts=opts)
+
+    l1.fundwallet(2000000000)
+    l2.fundwallet(2000000000)
+    l3.fundwallet(2000000000)
+    l4.fundwallet(2000000000)
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
+
+    destinations = [{"id": '{}@localhost:{}'.format(l2.info['id'], l2.port),
+                     "amount": 25000,
+                     "announce": True},
+                    {"id": '{}@localhost:{}'.format(l3.info['id'], l3.port),
+                     "amount": 25000,
+                     "announce": True},
+                    {"id": '{}@localhost:{}'.format(l4.info['id'], l4.port),
+                     "amount": 25000,
+                     "announce": True}]
+
+    multifundchannel_return = l1.rpc.multifundchannel(destinations)
+    multifundchannel_txid = multifundchannel_return['txid']
+    channel_ids = multifundchannel_return['channel_ids']
+
+    channel_12_channel_id = channel_ids[0]['channel_id']
+    channel_13_channel_id = channel_ids[1]['channel_id']
+    channel_14_channel_id = channel_ids[2]['channel_id']
+
+    bitcoind.generate_block(5, wait_for_mempool=[multifundchannel_txid])
+    wait_for(lambda: l1.channel_state(l2) == 'CHANNELD_NORMAL')
+    wait_for(lambda: l1.channel_state(l3) == 'CHANNELD_NORMAL')
+    wait_for(lambda: l1.channel_state(l4) == 'CHANNELD_NORMAL')
+
+    # calculate the tx fee from bitcoin-cli by subtracting the multifundchannel tx inputs and outputs
+    multifundchannel_rawtx = l1.bitcoin.rpc.getrawtransaction(multifundchannel_txid, True)
+
+    inputs_total_btc = 0
+    vins = multifundchannel_rawtx['vin']
+    for vin in vins:
+        temp_txid = vin['txid']
+        temp_vout = vin['vout']
+        temp_rawtx = l1.bitcoin.rpc.getrawtransaction(temp_txid, True)
+        output_amount_btc = temp_rawtx['vout'][temp_vout]['value']
+        inputs_total_btc += output_amount_btc
+
+    outputs_total_btc = 0
+    vouts = multifundchannel_rawtx['vout']
+    for vout in vouts:
+        outputs_total_btc += vout['value']
+
+    calculated_total_fees_btc = inputs_total_btc - outputs_total_btc
+
+    # now use getblock to get the tx fee also from bitcoin-cli's perspective
+    blockhash = multifundchannel_rawtx['blockhash']
+    getblock_tx = l1.bitcoin.rpc.getblock(blockhash, 2)['tx']
+    getblock_fee_btc = 0
+    for tx in getblock_tx:
+        if tx['txid'] == multifundchannel_txid:
+            getblock_fee_btc = tx['fee']
+
+    # now sum bookkeeper fees for each node to get the total fees for this tx
+    channel_12_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_12_channel_id)['txs'][0]['fees_paid_msat']
+    channel_21_multifundchannel_fee_msat = l2.rpc.bkpr_inspect(channel_12_channel_id)['txs'][0]['fees_paid_msat']
+    channel_13_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_13_channel_id)['txs'][0]['fees_paid_msat']
+    channel_31_multifundchannel_fee_msat = l3.rpc.bkpr_inspect(channel_13_channel_id)['txs'][0]['fees_paid_msat']
+    channel_14_multifundchannel_fee_msat = l1.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
+    channel_41_multifundchannel_fee_msat = l4.rpc.bkpr_inspect(channel_14_channel_id)['txs'][0]['fees_paid_msat']
+
+    bkpr_total_fee_btc = (channel_12_multifundchannel_fee_msat
+                          + channel_21_multifundchannel_fee_msat
+                          + channel_13_multifundchannel_fee_msat
+                          + channel_31_multifundchannel_fee_msat
+                          + channel_14_multifundchannel_fee_msat
+                          + channel_41_multifundchannel_fee_msat).to_btc()
+
+    assert bkpr_total_fee_btc == calculated_total_fees_btc
+    assert bkpr_total_fee_btc == getblock_fee_btc
+
+
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "turns off bookkeeper at start")
 @unittest.skipIf(TEST_NETWORK != 'regtest', "network fees hardcoded")
 @pytest.mark.openchannel('v1', 'Uses push-msat')


### PR DESCRIPTION
[issue #6800](https://github.com/ElementsProject/lightning/issues/6800)

Grouping by `update_count` resulted in a crash due to a bad arithmetic assert in `recorder.c` line 365 calculating negative fees  caused by the returned rows not being consolidated.  This removes that update_count grouping and adds tests for single and dual funded channels.

---
**Update**

update_count is just the count of the records for a tx.  To calculate onchain fees
for an account we must sum all credits vs debits.  We don't need to GROUP BY update_count
nor ORDER BY update_count since it is just a running index of updates to this tx, so it can be removed.  

Previously...
Postgres was not happy with not having update_count in the GROUP BY if it was used in ORDER BY.  
The two pull requests below added update_count to this query for postgres:
 #6141
 #6128 
 
 However that resulted in a bad query result in certain situations as referenced in [issue #6800 (https://github.com/ElementsProject/lightning/issues/6800)

the bad query resulted in something like this: 
```
row  txid  credit  debit
1    blob  1000167000  0
2    blob  0  1000167000
```

which results in a failed assert due to bad arithmetic (0 - 1000167000 = negative number for a fee):
```
		ok = amount_msat_sub(&sum->fees_paid, sum->fees_paid, amt);
		assert(ok);
```
		
and would runtime crash bookkeeper inspect().

now removing update_count (what this pr originally did) from GROUP BY (but leaving it in ORDER BY) results in something like this:
```
row  txid  credit  debit
1    blob 1000167000 1000167000
```

and works for sqlite3 which is less strict on the sql standard.  However the postgres tests were failing for the above reason.

Instead of adding update_count to the SELECT column, I remove it from this query entirely.  Based on this, I don't believe we need it.  


