### PR TITLE
Splice: Complete tx_abort implementation

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1631,7 +1631,7 @@ static void send_revocation(struct peer *peer,
 	peer_write(peer->pps, take(msg));
 }
 
-static struct inflight *last_inflight(struct peer *peer)
+static struct inflight *last_inflight(const struct peer *peer)
 {
 	size_t count = tal_count(peer->splice_state->inflights);
 
@@ -1641,15 +1641,15 @@ static struct inflight *last_inflight(struct peer *peer)
 	return NULL;
 }
 
-static size_t last_inflight_index(struct peer *peer)
+static size_t last_inflight_index(const struct peer *peer)
 {
 	assert(tal_count(peer->splice_state->inflights) > 0);
 
 	return tal_count(peer->splice_state->inflights) - 1;
 }
 
-static u32 find_channel_funding_input(struct wally_psbt *psbt,
-				      struct bitcoin_outpoint *funding)
+static u32 find_channel_funding_input(const struct wally_psbt *psbt,
+				      const struct bitcoin_outpoint *funding)
 {
 	for (size_t i = 0; i < psbt->num_inputs; i++) {
 		struct bitcoin_outpoint psbt_outpoint;
@@ -1695,7 +1695,7 @@ static bool missing_user_signatures(const struct peer *peer,
 				    const struct inflight *inflight)
 {
 	int sigs_needed;
-	u32 i, splice_funding_index;
+	u32 splice_funding_index;
 	const struct witness **outws;
 	enum tx_role our_role = inflight->i_am_initiator
 				? TX_INITIATOR : TX_ACCEPTER;
@@ -1706,7 +1706,7 @@ static bool missing_user_signatures(const struct peer *peer,
 	splice_funding_index = find_channel_funding_input(inflight->psbt,
 							  &peer->channel->funding);
 	sigs_needed = 0;
-	for (i = 0; i < inflight->psbt->num_inputs; i++) {
+	for (u32 i = 0; i < inflight->psbt->num_inputs; i++) {
 		struct wally_psbt_input *in = &inflight->psbt->inputs[i];
 		u64 in_serial;
 
@@ -1734,7 +1734,7 @@ static void check_tx_abort(struct peer *peer, const u8 *msg)
 	struct channel_id channel_id;
 	u8 *reason;
 
-	if (!msg || fromwire_peektype(msg) != WIRE_TX_ABORT)
+	if (fromwire_peektype(msg) != WIRE_TX_ABORT)
 		return;
 
 	if (have_i_signed_inflight(peer, inflight)) {

--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -10,6 +10,7 @@
 #include <common/derive_basepoints.h>
 #include <common/features.h>
 #include <common/fee_states.h>
+#include <wire/peer_wire.h>
 
 # Begin!  (passes gossipd-client fd)
 msgtype,channeld_init,1000
@@ -279,6 +280,12 @@ msgdata,channeld_splice_funding_error,opener_error,bool,
 # channeld->master: A splice state error has occured
 msgtype,channeld_splice_state_error,7221
 msgdata,channeld_splice_state_error,state_error,wirestring,
+
+# channeld->master: Peer rejected our splice
+msgtype,channeld_splice_abort,7223
+msgdata,channeld_splice_abort,did_i_initiate,bool,
+msgdata,channeld_splice_abort,inflight_outpoint,?bitcoin_outpoint,
+msgdata,channeld_splice_abort,reason,?wirestring,
 
 # Tell peer to shut down channel.
 msgtype,channeld_send_shutdown,1023

--- a/channeld/splice.c
+++ b/channeld/splice.c
@@ -30,6 +30,7 @@ struct splicing *splicing_new(const tal_t *ctx)
 	splicing->current_psbt = NULL;
 	splicing->received_tx_complete = false;
 	splicing->sent_tx_complete = false;
+	splicing->tx_sig_msg = NULL;
 
 	return splicing;
 }

--- a/channeld/splice.h
+++ b/channeld/splice.h
@@ -51,6 +51,8 @@ struct splicing {
 	bool received_tx_complete;
 	/* If, in the last splice_update, we sent tx_complete */
 	bool sent_tx_complete;
+	/* If our peer signs early, we allow that and cache it here */
+	const u8 *tx_sig_msg;
 };
 
 /* Sets `splice` items to default values */

--- a/common/interactivetx.h
+++ b/common/interactivetx.h
@@ -77,10 +77,13 @@ struct interactivetx_context *new_interactivetx_context(const tal_t *ctx,
  * out -> true means the last message from the peer was 'tx_complete'.
  *
  * Returns NULL on success or a description of the error on failure.
+ *
+ * If `tx_abort` is received, NULL is returned and `abort_msg` will be set to
  */
 char *process_interactivetx_updates(const tal_t *ctx,
 				    struct interactivetx_context *ictx,
-				    bool *received_tx_complete);
+				    bool *received_tx_complete,
+				    u8 **abort_msg);
 
 /* If the given ictx would cause `process_interactivetx_updates to send tx
  * changes when called. Returns true if an error occurs

--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -77,6 +77,7 @@ enum jsonrpc_errcode {
 	SPLICE_STATE_ERROR = 358,
 	SPLICE_LOW_FEE = 359,
 	SPLICE_HIGH_FEE = 360,
+	SPLICE_ABORT = 362,
 
 	/* `connect` errors */
 	CONNECT_NO_KNOWN_ADDRESS = 400,

--- a/common/wire_error.c
+++ b/common/wire_error.c
@@ -84,7 +84,7 @@ char *sanitize_error(const tal_t *ctx, const u8 *errmsg,
 	struct channel_id dummy;
 	u8 *data;
 	size_t i;
-	char *tag;
+	const char *tag;
 
 	if (!channel_id)
 		channel_id = &dummy;

--- a/common/wire_error.c
+++ b/common/wire_error.c
@@ -84,17 +84,17 @@ char *sanitize_error(const tal_t *ctx, const u8 *errmsg,
 	struct channel_id dummy;
 	u8 *data;
 	size_t i;
-	bool warning;
+	char *tag;
 
 	if (!channel_id)
 		channel_id = &dummy;
 
 	if (fromwire_error(ctx, errmsg, channel_id, &data))
-		warning = false;
+		tag = "ERROR";
 	else if (fromwire_warning(ctx, errmsg, channel_id, &data))
-		warning = true;
+		tag = "WARNING";
 	else if (fromwire_tx_abort(ctx, errmsg, channel_id, &data))
-		warning = true;
+		tag = "ABORT";
 	else
 		return tal_fmt(ctx, "Invalid ERROR message '%s'",
 			       tal_hex(ctx, errmsg));
@@ -118,7 +118,7 @@ char *sanitize_error(const tal_t *ctx, const u8 *errmsg,
 	}
 
 	return tal_fmt(ctx, "%s%s%s: %.*s",
-		       warning ? "WARNING" : "ERROR",
+		       tag,
 		       channel_id_is_all(channel_id) ? "": " channel ",
 		       channel_id_is_all(channel_id) ? ""
 		       : type_to_string(tmpctx, struct channel_id, channel_id),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -396,18 +396,18 @@ def test_opening_tiny_channel(node_factory, anchors):
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
 
-    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING).*channel capacity is .*, which is below .*sat'):
+    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING|ABORT).*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l2, l2_min_capacity + overhead - 1)
     assert only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected']
 
     l1.fundchannel(l2, l2_min_capacity + overhead)
 
-    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING).*channel capacity is .*, which is below .*sat'):
+    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING|ABORT).*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l3, l3_min_capacity + overhead - 1)
     assert only_one(l1.rpc.listpeers(l3.info['id'])['peers'])['connected']
     l1.fundchannel(l3, l3_min_capacity + overhead)
 
-    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING).*channel capacity is .*, which is below .*sat'):
+    with pytest.raises(RpcError, match=r'They sent (ERROR|WARNING|ABORT).*channel capacity is .*, which is below .*sat'):
         l1.fundchannel(l4, l4_min_capacity + overhead - 1)
     assert only_one(l1.rpc.listpeers(l4.info['id'])['peers'])['connected']
     l1.fundchannel(l4, l4_min_capacity + overhead)

--- a/tests/test_splicing.py
+++ b/tests/test_splicing.py
@@ -196,7 +196,7 @@ def test_invalid_splice(node_factory, bitcoind):
     # The splicing inflight should not have been left pending in the DB
     assert l1.db_query("SELECT count(*) as c FROM channel_funding_inflights;")[0]['c'] == 0
 
-    l1.daemon.wait_for_log(r'Peer has reconnected, state CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'Restarting channeld after tx_abort on CHANNELD_NORMAL channel')
 
     assert l1.db_query("SELECT count(*) as c FROM channel_funding_inflights;")[0]['c'] == 0
 
@@ -250,7 +250,7 @@ def test_commit_crash_splice(node_factory, bitcoind):
     # The splicing inflight should have been left pending in the DB
     assert l1.db_query("SELECT count(*) as c FROM channel_funding_inflights;")[0]['c'] == 1
 
-    l1.daemon.wait_for_log(r'Peer has reconnected, state CHANNELD_NORMAL')
+    l1.daemon.wait_for_log(r'Restarting channeld after tx_abort on CHANNELD_NORMAL channel')
 
     assert l1.db_query("SELECT count(*) as c FROM channel_funding_inflights;")[0]['c'] == 1
 

--- a/tests/test_splicing_disconnect.py
+++ b/tests/test_splicing_disconnect.py
@@ -100,17 +100,14 @@ def test_splice_disconnect_commit(node_factory, bitcoind, executor):
     # Should reconnect, and reestablish the splice.
     l2.start()
 
+    # Splice should be abandoned via tx_abort
+
     # Wait until nodes are reconnected
     l1.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_REESTABLISH')
     l2.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_REESTABLISH')
 
-    bitcoind.generate_block(6, wait_for_mempool=1)
-
-    l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-
-    inv = l2.rpc.invoice(10**2, '3', 'no_3')
-    l1.rpc.pay(inv['bolt11'])
+    l1.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_READY')
+    l2.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_READY')
 
     # Check that the splice doesn't generate a unilateral close transaction
     time.sleep(5)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1259,8 +1259,8 @@ void wallet_inflight_add(struct wallet *w, struct channel_inflight *inflight)
 	tal_free(stmt);
 }
 
-void wallet_inflight_del(struct wallet *w, struct channel *chan,
-			 struct channel_inflight *inflight)
+void wallet_inflight_del(struct wallet *w, const struct channel *chan,
+			 const struct channel_inflight *inflight)
 {
 	struct db_stmt *stmt;
 
@@ -1273,8 +1273,6 @@ void wallet_inflight_del(struct wallet *w, struct channel *chan,
 	db_bind_txid(stmt, &inflight->funding->outpoint.txid);
 	db_bind_int(stmt, inflight->funding->outpoint.n);
 	db_exec_prepared_v2(take(stmt));
-
-	tal_free(inflight);
 }
 
 void wallet_inflight_save(struct wallet *w,

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1259,6 +1259,24 @@ void wallet_inflight_add(struct wallet *w, struct channel_inflight *inflight)
 	tal_free(stmt);
 }
 
+void wallet_inflight_del(struct wallet *w, struct channel *chan,
+			 struct channel_inflight *inflight)
+{
+	struct db_stmt *stmt;
+
+	/* Remove inflight from the channel */
+	stmt = db_prepare_v2(w->db, SQL("DELETE FROM channel_funding_inflights"
+					" WHERE channel_id = ?"
+					"   AND funding_tx_id = ?"
+					"   AND funding_tx_outnum = ?"));
+	db_bind_u64(stmt, chan->dbid);
+	db_bind_txid(stmt, &inflight->funding->outpoint.txid);
+	db_bind_int(stmt, inflight->funding->outpoint.n);
+	db_exec_prepared_v2(take(stmt));
+
+	tal_free(inflight);
+}
+
 void wallet_inflight_save(struct wallet *w,
 			  struct channel_inflight *inflight)
 {

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -621,6 +621,12 @@ void wallet_channel_insert(struct wallet *w, struct channel *chan);
 void wallet_inflight_add(struct wallet *w, struct channel_inflight *inflight);
 
 /**
+ * Delete an inflight transaction for a channel
+ */
+void wallet_inflight_del(struct wallet *w, struct channel *chan,
+			 struct channel_inflight *inflight);
+
+/**
  * Update an existing inflight channel transaction
  */
 void wallet_inflight_save(struct wallet *w,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -623,8 +623,8 @@ void wallet_inflight_add(struct wallet *w, struct channel_inflight *inflight);
 /**
  * Delete an inflight transaction for a channel
  */
-void wallet_inflight_del(struct wallet *w, struct channel *chan,
-			 struct channel_inflight *inflight);
+void wallet_inflight_del(struct wallet *w, const struct channel *chan,
+			 const struct channel_inflight *inflight);
 
 /**
  * Update an existing inflight channel transaction


### PR DESCRIPTION
Adds support for `tx_abort` including sending, receiving, and ACK'ing.

When `tx_abort` is confirmed in `channeld` we notify `lightningd` and shutdown. `lightningd` then restarts the channeld daemon.

This is all done without breaking the connection and special care is made to connect the daemon to the existing connection through a `connectd` fd.