### PR TITLE
gha: Add `--skip-existing` option to publish to testpypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -74,7 +74,7 @@ jobs:
         cd ${{ env.WORKDIR}}
         python3 -m pip config set global.timeout 150
         poetry config repositories.testpypi https://test.pypi.org/legacy/
-        poetry publish --repository testpypi --no-interaction
+        poetry publish --repository testpypi --no-interaction --skip-existing
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags') && github.repository == 'ElementsProject/lightning'


### PR DESCRIPTION
We don't want to fail testing on `master` ever!

Changelog-None