### PR TITLE
Dual-funding: permit re-negotiation of require-confirmed on RBFs

### DIFF
--- a/openingd/dualopend_wire.csv
+++ b/openingd/dualopend_wire.csv
@@ -118,11 +118,16 @@ msgdata,dualopend_got_rbf_offer,our_last_funding,amount_sat,
 msgdata,dualopend_got_rbf_offer,funding_feerate_per_kw,u32,
 msgdata,dualopend_got_rbf_offer,locktime,u32,
 msgdata,dualopend_got_rbf_offer,requested_lease,?amount_sat,
+msgdata,dualopend_got_rbf_offer,require_confirmed_inputs,bool,
 
 # master->dualopend: reply back with our funding info/contribs
 msgtype,dualopend_got_rbf_offer_reply,7505
 msgdata,dualopend_got_rbf_offer_reply,our_funding,amount_sat,
 msgdata,dualopend_got_rbf_offer_reply,psbt,wally_psbt,
+
+# dualopend->master: update to require_confirmed_inputs preference
+msgtype,dualopend_update_require_confirmed,7511
+msgdata,dualopend_update_require_confirmed,require_confirmed_inputs,bool,
 
 # dualopend->master: is this a valid RBF candidate transaction?
 msgtype,dualopend_rbf_validate,7506

--- a/tests/fuzz/fuzz-wire-tx_ack_rbf.c
+++ b/tests/fuzz/fuzz-wire-tx_ack_rbf.c
@@ -31,10 +31,14 @@ static bool equal(const struct tx_ack_rbf *x, const struct tx_ack_rbf *y)
 		return false;
 
 	assert(x->tlvs && y->tlvs);
-	return memeq(x->tlvs->funding_output_contribution,
-		     tal_bytelen(x->tlvs->funding_output_contribution),
-		     y->tlvs->funding_output_contribution,
-		     tal_bytelen(y->tlvs->funding_output_contribution));
+	if (!memeq(x->tlvs->funding_output_contribution,
+		   tal_bytelen(x->tlvs->funding_output_contribution),
+		   y->tlvs->funding_output_contribution,
+		   tal_bytelen(y->tlvs->funding_output_contribution)))
+		return false;
+
+	return !!x->tlvs->require_confirmed_inputs ==
+	       !!y->tlvs->require_confirmed_inputs;
 }
 
 void run(const u8 *data, size_t size)

--- a/tests/fuzz/fuzz-wire-tx_init_rbf.c
+++ b/tests/fuzz/fuzz-wire-tx_init_rbf.c
@@ -36,10 +36,14 @@ static bool equal(const struct tx_init_rbf *x, const struct tx_init_rbf *y)
 		return false;
 
 	assert(x->tlvs && y->tlvs);
-	return memeq(x->tlvs->funding_output_contribution,
+	if (!memeq(x->tlvs->funding_output_contribution,
 		     tal_bytelen(x->tlvs->funding_output_contribution),
 		     y->tlvs->funding_output_contribution,
-		     tal_bytelen(y->tlvs->funding_output_contribution));
+		     tal_bytelen(y->tlvs->funding_output_contribution)))
+		return false;
+
+	return !!x->tlvs->require_confirmed_inputs ==
+	       !!y->tlvs->require_confirmed_inputs;
 }
 
 void run(const u8 *data, size_t size)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2270,9 +2270,10 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 					"  remote_feerate_ppm=?," // 48
 					"  remote_cltv_expiry_delta=?," // 49
 					"  remote_htlc_minimum_msat=?," // 50
-					"  remote_htlc_maximum_msat=?,"
-					"  last_stable_connection=?"
-					" WHERE id=?"));
+					"  remote_htlc_maximum_msat=?," // 51
+					"  last_stable_connection=?" // 52
+					"  require_confirm_inputs_remote=?" // 53
+					" WHERE id=?")); // 54
 	db_bind_u64(stmt, chan->their_shachain.id);
 	if (chan->scid)
 		db_bind_short_channel_id(stmt, chan->scid);
@@ -2369,6 +2370,8 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 		db_bind_null(stmt);
 	}
 	db_bind_u64(stmt, chan->last_stable_connection);
+
+	db_bind_int(stmt, chan->req_confirmed_ins[REMOTE]);
 	db_bind_u64(stmt, chan->dbid);
 	db_exec_prepared_v2(take(stmt));
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2271,7 +2271,7 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 					"  remote_cltv_expiry_delta=?," // 49
 					"  remote_htlc_minimum_msat=?," // 50
 					"  remote_htlc_maximum_msat=?," // 51
-					"  last_stable_connection=?" // 52
+					"  last_stable_connection=?," // 52
 					"  require_confirm_inputs_remote=?" // 53
 					" WHERE id=?")); // 54
 	db_bind_u64(stmt, chan->their_shachain.id);

--- a/wire/extracted_peer_03_dual-funding.patch
+++ b/wire/extracted_peer_03_dual-funding.patch
@@ -1,6 +1,6 @@
 --- wire/peer_wire.csv.raw	2023-09-11 13:32:30.677617251 +0930
 +++ wire/peer_wire.csv.openchannel2	2023-09-11 13:31:47.906308397 +0930
-@@ -37,6 +37,51 @@
+@@ -37,6 +37,53 @@
  tlvdata,n2,tlv1,amount_msat,tu64,
  tlvtype,n2,tlv2,11
  tlvdata,n2,tlv2,cltv_expiry,tu32,
@@ -40,11 +40,13 @@
 +msgdata,tx_init_rbf,tlvs,tx_init_rbf_tlvs,
 +tlvtype,tx_init_rbf_tlvs,funding_output_contribution,0
 +tlvdata,tx_init_rbf_tlvs,funding_output_contribution,satoshis,s64,
++tlvtype,tx_init_rbf_tlvs,require_confirmed_inputs,2
 +msgtype,tx_ack_rbf,73
 +msgdata,tx_ack_rbf,channel_id,channel_id,
 +msgdata,tx_ack_rbf,tlvs,tx_ack_rbf_tlvs,
 +tlvtype,tx_ack_rbf_tlvs,funding_output_contribution,0
 +tlvdata,tx_ack_rbf_tlvs,funding_output_contribution,satoshis,s64,
++tlvtype,tx_ack_rbf_tlvs,require_confirmed_inputs,2
 +msgtype,tx_abort,74
 +msgdata,tx_abort,channel_id,channel_id,
 +msgdata,tx_abort,len,u16,

--- a/wire/peer_wire.csv
+++ b/wire/peer_wire.csv
@@ -76,11 +76,13 @@ msgdata,tx_init_rbf,feerate,u32,
 msgdata,tx_init_rbf,tlvs,tx_init_rbf_tlvs,
 tlvtype,tx_init_rbf_tlvs,funding_output_contribution,0
 tlvdata,tx_init_rbf_tlvs,funding_output_contribution,satoshis,s64,
+tlvtype,tx_init_rbf_tlvs,require_confirmed_inputs,2
 msgtype,tx_ack_rbf,73
 msgdata,tx_ack_rbf,channel_id,channel_id,
 msgdata,tx_ack_rbf,tlvs,tx_ack_rbf_tlvs,
 tlvtype,tx_ack_rbf_tlvs,funding_output_contribution,0
 tlvdata,tx_ack_rbf_tlvs,funding_output_contribution,satoshis,s64,
+tlvtype,tx_ack_rbf_tlvs,require_confirmed_inputs,2
 msgtype,tx_abort,74
 msgdata,tx_abort,channel_id,channel_id,
 msgdata,tx_abort,len,u16,


### PR DESCRIPTION
Be explicit about the `require-confirmed` requirements for RBFs as well as initial txs.

Updates CLN to conform to the latest spec draft, including https://github.com/lightning/bolts/pull/851/commits/27ffef47aee985d37dcef85d528719f9a4608400
Be explicit about the require-confirmed requirements for RBFs as well as initial txs.

Initially we were re-using the value at start for any subsequent renegotiations, but with this patch we
now use whatever the system-wide setting is at the time that we attempt an RBF. This makes it easier to test
and allows you to (with some effort) update what channels request at a system level.

Requested-By: @t-bast 