### PR TITLE
pytest: Add `system-progres` DB provider and allow pyln-testing to run on older CLN versions too

### DIFF
--- a/contrib/pyln-testing/pyln/testing/db.py
+++ b/contrib/pyln-testing/pyln/testing/db.py
@@ -101,6 +101,7 @@ class PostgresDb(object):
         cur = conn.cursor()
         cur.execute("DROP DATABASE {};".format(self.dbname))
         cur.close()
+        conn.close()
 
 
 class SqliteDbProvider(object):
@@ -223,3 +224,49 @@ class PostgresDbProvider(object):
         self.proc.send_signal(signal.SIGINT)
         self.proc.wait()
         shutil.rmtree(self.pgdir)
+
+
+class SystemPostgresProvider(PostgresDbProvider):
+    """A Postgres DB variant that uses an existing instance on the system.
+
+    The specifics of the DB admin connection are passed in via
+    `CLN_TEST_POSTGRES_DSN`, or uses `dbname=template1 user=postgres
+    host=localhost port=5432` by default. The DSN must have permission
+    to create new roles and schemas.
+
+    Currently only supports postgres instances running on the default
+    port (5432).
+
+    """
+
+    def __init__(self, directory):
+        self.directory = directory
+        self.dbs: List[str] = []
+        self.admin_dsn = os.environ.get(
+            "CLN_TEST_POSTGRES_DSN",
+            "dbname=template1 user=postgres host=127.0.0.1 port=5432"
+        )
+        self.port = 5432
+
+    def start(self):
+        """We assume the postgres instance is already running, so this is a no-op. """
+
+    def connect(self):
+        return psycopg2.connect(self.admin_dsn)
+
+    def get_db(self, node_directory, testname, node_id):
+        # Random suffix to avoid collisions on repeated tests
+        nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+        dbname = "{}_{}_{}".format(testname, node_id, nonce)
+
+        conn = self.connect()
+        conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        cur = conn.cursor()
+        cur.execute("CREATE DATABASE {} TEMPLATE template0;".format(dbname))
+        cur.close()
+        conn.close()
+        db = PostgresDb(dbname, self.port)
+        return db
+
+    def stop(self):
+        """Cleanup the schemas we created. """

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from pyln.testing.db import SqliteDbProvider, PostgresDbProvider
+from pyln.testing.db import SqliteDbProvider, PostgresDbProvider, SystemPostgresProvider
 from pyln.testing.utils import NodeFactory, BitcoinD, ElementsD, env, LightningNode, TEST_DEBUG
 from pyln.client import Millisatoshi
 from typing import Dict
@@ -601,6 +601,7 @@ def checkMemleak(node):
 providers = {
     'sqlite3': SqliteDbProvider,
     'postgres': PostgresDbProvider,
+    'system-postgres': SystemPostgresProvider
 }
 
 

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -646,6 +646,9 @@ class LightningD(TailableProc):
     def cmd_line(self):
 
         opts = []
+        for k, v in self.early_opts.items():
+            opts.append(f'--{k}{"=" + v if v is not None else ""}')
+
         for k, v in self.opts.items():
             if v is None:
                 opts.append("--{}".format(k))
@@ -655,7 +658,7 @@ class LightningD(TailableProc):
             else:
                 opts.append("--{}={}".format(k, v))
 
-        return self.cmd_prefix + [self.executable] + self.early_opts + opts
+        return self.cmd_prefix + [self.executable] + opts
 
     def start(self, stdin=None, wait_for_initialized=True, stderr_redir=False):
         self.opts['bitcoin-rpcport'] = self.rpcproxy.rpcport


### PR DESCRIPTION
This tackles two problems:

 - By using a system-wide installed `postgres` we can cut down on the overhead of spinning the DB up and down for the tests. More importantly this allows us to run the tests as `root`, since we no longer run into `postgres` complaining about not wanting to run as `root`. This is for example the case if we run in CI or in docker, where the files are often owned by `root`, and having to switch to another user can result in permission issues.
 - The recent v23.11 release of `pyln-testing` broke backwards compatibility with prior CLN versions because it just bluntly assumes `--developer` is a valid CLI option. It was introduced in v23.11 and therefore causes all prior versions to just `abort()`.

