### PR TITLE
ccan: fix compilation error about const types

### DIFF
--- a/ccan/ccan/fdpass/fdpass.c
+++ b/ccan/ccan/fdpass/fdpass.c
@@ -4,6 +4,8 @@
 #include <errno.h>
 #include <string.h>
 
+#define BUF_SIZE CMSG_SPACE(sizeof(fd))
+
 bool fdpass_send(int sockout, int fd)
 {
 	/* From the cmsg(3) manpage: */
@@ -13,7 +15,7 @@ bool fdpass_send(int sockout, int fd)
 	char c = 0;
 	union {         /* Ancillary data buffer, wrapped in a union
 			   in order to ensure it is suitably aligned */
-		char buf[CMSG_SPACE(sizeof(fd))];
+		char buf[BUF_SIZE];
 		struct cmsghdr align;
 	} u;
 
@@ -50,7 +52,7 @@ int fdpass_recv(int sockin)
 	char c;
 	union {         /* Ancillary data buffer, wrapped in a union
 			   in order to ensure it is suitably aligned */
-		char buf[CMSG_SPACE(sizeof(fd))];
+		char buf[BUF_SIZE];
 		struct cmsghdr align;
 	} u;
 


### PR DESCRIPTION
This commit fixes the following build error

ccan/ccan/fdpass/fdpass.c:16:8: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant] char buf[CMSG_SPACE(sizeof(fd))];

This is strange from a UNIX perspective because the macros return a size_t and the size_t is an unsigned integer type that should be compatible with the array declaration.

But for some plaform/or compilers this looks like not true?

Maybe Fixes https://github.com/ElementsProject/lightning/issues/6910 