### PR TITLE
fix: load script

### DIFF
--- a/doc/developers-guide/developers-guide.md
+++ b/doc/developers-guide/developers-guide.md
@@ -19,7 +19,7 @@ cd contrib
 Load the script, using `source` so it can set aliases:
 
 ```shell
-source contrib/startup_regtest.sh
+source startup_regtest.sh
 ```
 
 Start up the nodeset:


### PR DESCRIPTION
Currently, when inside the contrib folder, the script startup_regtest.sh is being sourced using the path contrib/startup_regtest.sh. However, for proper execution, we should use the relative path source startup_regtest.sh instead. This adjustment ensures that the script is loaded correctly when working within the contrib directory.

![image](https://github.com/ElementsProject/lightning/assets/97520428/1b645460-e774-4cbb-a30a-ad52c998d21a)
