### PR TITLE
meta: CLN V23.11.2 hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [23.11.1] - 2023-12-15: "Bitcoin Orangepaper"
+
+This is a hotfix release to address a couple of issues in the release.
+
+### Fixed
+
+ - channeld: We could crash `closingd` by sending it a `channeld` message ([#6937])
+
+[#6937]: https://github.com/ElementsProject/lightning/pull/6937
+
+[v23.11.1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11.1
+
 ## [23.11] - 2023-11-28: "Bitcoin Orangepaper"
 
 This release named by Shahana Farooqui
@@ -149,7 +162,7 @@ Bugfix release for bad issues found since 23.08 which can't wait for 23.11, and 
 
  - Protocol: Fixed a wrong number type being used in routes ([#6642])
  - JSON-RPC: `showrunes` on a specific rune would always say `stored`: false. ([#6640])
- - MacOS: `clnrest` now works ([#6605]) 
+ - MacOS: `clnrest` now works ([#6605])
  - Build: test for `python3` or `python`, rather than assuming `python3` ([#6630])
 
 
@@ -417,7 +430,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for changes.
  - JSON-RPC: `close`, `fundchannel`, `fundpsbt`, `multifundchannel`, `multiwithdraw`, `txprepare`, `upgradewallet`, `withdraw` `feerate` (`feerange` for `close`) expressed as, "delayed_to_us", "htlc_resolution", "max_acceptable" or "min_acceptable".  Use explicit block counts or *slow*/*normal*/*urgent*/*minimum*. ([#6120])
  - Plugins: `estimatefees` returning feerates by name (e.g. "opening"); use `fee_floor` and `feerates`. ([#6120])
  - Protocol: Not setting `option_scid_alias` in `option_channel` `channel_type` for unannounced channels. ([#6136])
- 
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [23.11.2] - 2023-12-22: "Bitcoin Orangepaper"
+
+This is a hotfix release to address BOLT 11 invoice compatibility.
+
+### Fixed
+
+ - invoice: Force cltv field inclusion in BOLT 11 invoice, for old implementations still defaulting to 9 blocks ([#6957])
+
+[#6957]: https://github.com/ElementsProject/lightning/pull/6957
+
+
 ## [23.11.1] - 2023-12-15: "Bitcoin Orangepaper"
 
 This is a hotfix release to address a couple of issues in the release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [v23.11rc3] - 2023-11-02: "Bitcoin Orangepaper"
+## [23.11] - 2023-11-28: "Bitcoin Orangepaper"
 
 This release named by Shahana Farooqui
 
@@ -81,6 +81,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for changes.
  - Rune: use runes table `id` instead `runes_uniqueid` from `vars` because it returns incorrect unique id if rune/s migrated from datastore. ([#6715])
  - Added docs, testing, and some fixes related to splicing out, insufficent balance handling, and restarting during a splice. ([#6677])
  - The WIRE_HSMD_SIGN_SPLICE_TX HSM capability is now correctly checked. ([#6867])
+ - Hsmtool: Fix segmentation fault when calling `getcodexsecret` without id. ([#6895])
 
 
 ### EXPERIMENTAL
@@ -125,6 +126,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for changes.
 [#6876]: https://github.com/ElementsProject/lightning/pull/6876
 [#6840]: https://github.com/ElementsProject/lightning/pull/6840
 [#6884]: https://github.com/ElementsProject/lightning/pull/6884
+[#6895]: https://github.com/ElementsProject/lightning/pull/6895
 
 
 ## [23.08.1] - 2023-09-12: "Satoshi's Successor II"
@@ -2757,6 +2759,7 @@ There predate the BOLT specifications, and are only of vague historic interest:
 6. [0.5.1] - 2016-10-21
 7. [0.5.2] - 2016-11-21: "Bitcoin Savings & Trust Daily Interest II"
 
+[23.11]: https://github.com/ElementsProject/lightning/releases/tag/v23.11
 [23.05]: https://github.com/ElementsProject/lightning/releases/tag/v23.05
 [23.02.1]: https://github.com/ElementsProject/lightning/releases/tag/v23.02.1
 [23.02]: https://github.com/ElementsProject/lightning/releases/tag/v23.02

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -5147,7 +5147,7 @@ static void peer_reconnect(struct peer *peer,
 	}
 
 	status_debug("Got reestablish commit=%"PRIu64" revoke=%"PRIu64
-		     " inflights: %lu, active splices: %"PRIu32,
+		     " inflights: %zu, active splices: %"PRIu32,
 		     next_commitment_number,
 		     next_revocation_number,
 		     tal_count(peer->splice_state->inflights),

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -1327,8 +1327,10 @@ char *bolt11_encode_(const tal_t *ctx,
 	 *   - if the `c` field (`min_final_cltv_expiry_delta`) is not provided:
 	 *     - MUST use an expiry delta of at least 18 when making the payment
 	 */
-	if (b11->min_final_cltv_expiry != 18)
-		encode_c(&data, b11->min_final_cltv_expiry);
+	/* FIXME: Only encode if non-default once all implementations update
+	 * default min_final_cltv_expiry_delta to 18. Forcing inclusion in the
+	 * interrim to ensure compatibility with existing nodes. */
+	encode_c(&data, b11->min_final_cltv_expiry);
 
 	for (size_t i = 0; i < tal_count(b11->fallbacks); i++)
 		encode_f(&data, b11->fallbacks[i]);

--- a/common/test/run-bolt11.c
+++ b/common/test/run-bolt11.c
@@ -494,11 +494,11 @@ int main(int argc, char *argv[])
 	badstr = bolt11_encode(tmpctx, b11, false, test_sign, NULL);
 	assert(streq(badstr, "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"));
 	dev_bolt11_old_order = false;
-	dev_bolt11_omit_c_value = false;
 
 	/* Otherwise it does it normally */
 	badstr = bolt11_encode(tmpctx, b11, false, test_sign, NULL);
 	assert(streq(badstr, "lnbc25m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q4psqqqqqqqqqqqqqqqqsgq8w9mkdh2n9pmrsg5natjffcgjpp5caamstsq5pm03v2c7ca5ej3plyrfe3vyzl76v6wex4r8rd6rdvys4a35983n6wrzegcwfl2gl4qqxh98vj"));
+	dev_bolt11_omit_c_value = false;
 
 	/* Empty set of allowed bits, ensures this fails! */
 	fset = tal(tmpctx, struct feature_set);

--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -3,7 +3,7 @@ from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapHalfchannel, GossmapNodeId, LnFeatureBits
 from .gossmapstats import GossmapStats
 
-__version__ = "23.11"
+__version__ = "23.11.1"
 
 __all__ = [
     "LightningRpc",

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-client"
-version = "23.11"
+version = "23.11.1"
 description = "Client library and plugin library for Core Lightning"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-proto/pyln/proto/__init__.py
+++ b/contrib/pyln-proto/pyln/proto/__init__.py
@@ -4,7 +4,7 @@ from .invoice import Invoice
 from .onion import OnionPayload, TlvPayload, LegacyOnionPayload
 from .wire import LightningConnection, LightningServerSocket
 
-__version__ = "23.11"
+__version__ = "23.11.1"
 
 __all__ = [
     "Invoice",

--- a/contrib/pyln-proto/pyproject.toml
+++ b/contrib/pyln-proto/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-proto"
-version = "23.11"
+version = "23.11.1"
 description = "This package implements some of the Lightning Network protocol in pure python. It is intended for protocol testing and some minor tooling only. It is not deemed secure enough to handle any amount of real funds (you have been warned!)."
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/contrib/pyln-testing/pyln/testing/__init__.py
+++ b/contrib/pyln-testing/pyln/testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "23.11"
+__version__ = "23.11.1"
 
 __all__ = [
     "__version__",

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyln-testing"
-version = "23.11"
+version = "23.11.1"
 description = "Test your Core Lightning integration, plugins or whatever you want"
 authors = ["Christian Decker <decker.christian@gmail.com>"]
 license = "BSD-MIT"

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -93,6 +93,11 @@ static void try_update_feerates(struct lightningd *ld, struct channel *channel)
 	if (!channel->owner)
 		return;
 
+	/* The feerate message is only understood by `channeld` so
+	 * don't attempt to send it to other subds*/
+	if (!streq(channel->owner->name, "channeld"))
+		return;
+
 	channel_update_feerates(ld, channel);
 }
 


### PR DESCRIPTION
@endothermicdev discovered that lnd nodes still default to a final CLTV delta of 9 blocks rather than the 18 blocks (3 years ago: https://github.com/lightning/bolts/pull/785).

We were always adding this optional parameter during the migration from default=9 to default=18 to prevent ambiguity, but it turns out that migration phase is not complete, and there are old implementations still defaulting to 9 blocks.

This hotfix just undoes that optional parameter and now always includes it.