### PR TITLE
configure: Use the system `PKG_CONFIG_PATH`

### DIFF
--- a/configure
+++ b/configure
@@ -17,7 +17,7 @@ export PKG_CONFIG_PATH=/opt/homebrew/opt/sqlite/lib/pkgconfig
 else
 CPATH=/usr/local/lib
 LIBRARY_PATH=/usr/local/lib
-export PKG_CONFIG_PATH=/usr/local/opt/sqlite/lib/pkgconfig
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/sqlite/lib/pkgconfig
 fi
 
 : ${PKG_CONFIG=pkg-config}


### PR DESCRIPTION
I noticed this while working on a nix devShell to work on CLN. We are
blanked overriding the `pkg-config` search path, which can cause some
trouble. Specifically `nix` uses content addressable locations, and
macOS arm64 and x84_64 use separate `pkg-config` search paths, and by
overwriting it we can cause a mix of different architectures failing
the compilation

Changelog-Fixed: configure: We now respect the `PKG_CONFIG_PATH` environment variable