### PR TITLE
doc:correct listrunes's link

### DIFF
--- a/doc/developers-guide/app-development/rest.md
+++ b/doc/developers-guide/app-development/rest.md
@@ -78,7 +78,7 @@ With the default configurations, the Swagger user interface will be available at
 The POST method requires `rune` header for authorization.
 
 - A new `rune` can be created via [createrune](https://docs.corelightning.org/reference/lightning-createrune) or the list of 
-existing runes can be retrieved with [listrunes](https://docs.corelightning.org/reference/lightning-listrunes) command.
+existing runes can be retrieved with [listrunes](https://docs.corelightning.org/reference/lightning-commando-listrunes) command.
 
 Note: in version v23.08, a parameter `Nodeid` was required to be the id of the node we're talking to (see `id (pubkey)` received 
 from [getinfo](https://docs.corelightning.org/reference/lightning-getinfo)). You can still send this for backwards compatiblity, 


### PR DESCRIPTION
original listrunes's link is wrong, should use this:[iightning-commando-listrunes -- Command to list previously generated runes](https://docs.corelightning.org/reference/lightning-commando-listrunes)

**before**
<img width="1359" alt="image" src="https://github.com/ElementsProject/lightning/assets/153181187/e8a7240b-6c18-4b3f-9eda-9d278fd3808f">


**after**
<img width="1104" alt="image" src="https://github.com/ElementsProject/lightning/assets/153181187/1c3e4f50-2542-4d6a-a2e1-52244a987633">
