### PR TITLE
core: Defer script extraction until we know it's needed

### DIFF
--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -10,9 +10,6 @@
 #include <common/utils.h>
 #include <sodium/randombytes.h>
 
-/* To push 0-75 bytes onto stack. */
-#define OP_PUSHBYTES(val) (val)
-
 /* Bitcoin's OP_HASH160 is RIPEMD(SHA256()) */
 static void hash160(struct ripemd160 *redeemhash, const void *mem, size_t len)
 {

--- a/bitcoin/script.h
+++ b/bitcoin/script.h
@@ -13,6 +13,9 @@ struct ripemd160;
 struct rel_locktime;
 struct abs_locktime;
 
+/* To push 0-75 bytes onto stack. */
+#define OP_PUSHBYTES(val) (val)
+
 /* tal_count() gives the length of the script. */
 u8 *bitcoin_redeem_2of2(const tal_t *ctx,
 			const struct pubkey *key1,

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -324,6 +324,16 @@ const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
 	return cln_wally_tx_output_get_script(ctx, output);
 }
 
+bool bitcoin_tx_output_script_is_p2wsh(const struct bitcoin_tx *tx, int outnum)
+{	const struct wally_tx_output *output;
+	assert(outnum < tx->wtx->num_outputs);
+	output = &tx->wtx->outputs[outnum];
+
+	return output->script_len == BITCOIN_SCRIPTPUBKEY_P2WSH_LEN &&
+	       output->script[0] == OP_0 &&
+	       output->script[1] == OP_PUSHBYTES(sizeof(struct sha256));
+}
+
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx,
 				    int outnum)
 {

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -155,6 +155,14 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
 
 /**
+ * Return `true` if the given output is a P2WSH output.
+ *
+ * This is useful if you want to peek at the script, without having to
+ * extract it first.
+ */
+bool bitcoin_tx_output_script_is_p2wsh(const struct bitcoin_tx *tx, int outnum);
+
+/**
  * Helper to get the script of a script's output as a tal_arr
  *
  * The script attached to a `wally_tx_output` is not a `tal_arr`, so in order to keep the

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -965,11 +965,12 @@ static void topo_add_utxos(struct chain_topology *topo, struct block *b)
 			if (!amount_asset_is_main(&amt))
 				continue; /* Ignore non-policy asset outputs */
 
-			const u8 *script = bitcoin_tx_output_get_script(tmpctx, tx, n);
-			if (!is_p2wsh(script, NULL))
+			if (!bitcoin_tx_output_script_is_p2wsh(tx, n))
 				continue; /* We only care about p2wsh utxos */
 
 			struct bitcoin_outpoint outpoint = { b->txids[i], n };
+			const u8 *script =
+			    bitcoin_tx_output_get_script(tmpctx, tx, n);
 			wallet_utxoset_add(topo->ld->wallet, &outpoint,
 					   b->height, i, script,
 					   amount_asset_to_sat(&amt));


### PR DESCRIPTION
We were always allocating space and copying the scripts from the
outputs, and then immediately discarding them again if they weren't
P2WSH outputs. This patch adds an introspection method, and then uses
it to determine whether we're interested in the output before cloning
the script. This should save us almost 1 allocation and 1 deallocation
for each output in a block (thousands).

Builds on top of #6983 
