### PR TITLE
hsmtool: add feature to dump private keys

### DIFF
--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -58,13 +58,18 @@ Specify *password* if the `hsm_secret` is encrypted.
 **checkhsm** *hsm\_secret\_path*
   Checks that hsm\_secret matches a BIP39 passphrase.
 
-**dumponchaindescriptors** *hsm\_secret* \[*password*\] \[*network*\]
+**dumponchaindescriptors** \[*--show-secrets*\] *hsm\_secret* \[*network*\]
   Dump output descriptors for our onchain wallet.
+This command requires the path to the hsm\_secret containing the wallet seed.
+If the flag *--show-secrets* is set the command will show the BIP32 extended private
+keys, otherwise the extended public keys will be shown.
 The descriptors can be used by external services to be able to generate
-addresses for our onchain wallet. (for example on `bitcoind` using the
-`importmulti` or `importdescriptors` RPC calls)
-We need the path to the hsm\_secret containing the wallet seed, and an optional
-(skip using `""`) password if it was encrypted.
+addresses for our onchain wallet or to spend those funds
+provided that the private keys are visible with *--show-secrets*.
+The descriptors can be loaded into a bitcoin-core wallet for example,
+using the `importmulti` or `importdescriptors` RPC calls.
+If the hsm\_secret was encrypted the command will prompt for a decryption
+password.
 To generate descriptors using testnet master keys, you may specify *testnet* as
 the last parameter. By default, mainnet-encoded keys are generated.
 

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -44,7 +44,7 @@ static void show_usage(const char *progname)
 	       "<path/to/hsm_secret>\n");
 	printf("	- generatehsm <path/to/new/hsm_secret>\n");
 	printf("	- checkhsm <path/to/new/hsm_secret>\n");
-	printf("	- dumponchaindescriptors <path/to/hsm_secret> [network]\n");
+	printf("	- dumponchaindescriptors <path/to/hsm_secret> [network] [show_secrets: true/false]\n");
 	printf("	- makerune <path/to/hsm_secret>\n");
 	printf("	- getcodexsecret <path/to/hsm_secret> <id>\n");
 	printf("	- getemergencyrecover <path/to/emergency.recover>\n");
@@ -570,14 +570,15 @@ static int generate_hsm(const char *hsm_secret_path)
 	return 0;
 }
 
-static int dumponchaindescriptors(const char *hsm_secret_path, const char *old_passwd UNUSED,
-				  const u32 version)
+static int dumponchaindescriptors(const char *hsm_secret_path,
+				  const char *old_passwd UNUSED,
+				  const u32 version, bool show_secrets)
 {
 	struct secret hsm_secret;
 	u8 bip32_seed[BIP32_ENTROPY_LEN_256];
 	u32 salt = 0;
 	struct ext_key master_extkey;
-	char *enc_xpub, *descriptor;
+	char *enc_xkey, *descriptor;
 	struct descriptor_checksum checksum;
 
 	get_hsm_secret(&hsm_secret, hsm_secret_path);
@@ -595,31 +596,38 @@ static int dumponchaindescriptors(const char *hsm_secret_path, const char *old_p
 	} while (bip32_key_from_seed(bip32_seed, sizeof(bip32_seed),
 				     version, 0, &master_extkey) != WALLY_OK);
 
-	if (bip32_key_to_base58(&master_extkey, BIP32_FLAG_KEY_PUBLIC, &enc_xpub) != WALLY_OK)
-		errx(ERROR_LIBWALLY, "Can't encode xpub");
+	if (show_secrets) {
+		if (bip32_key_to_base58(&master_extkey, BIP32_FLAG_KEY_PRIVATE,
+					&enc_xkey) != WALLY_OK)
+			errx(ERROR_LIBWALLY, "Can't encode xpriv");
+	} else {
+		if (bip32_key_to_base58(&master_extkey, BIP32_FLAG_KEY_PUBLIC,
+					&enc_xkey) != WALLY_OK)
+			errx(ERROR_LIBWALLY, "Can't encode xpub");
+	}
 
 	/* Now we format the descriptor strings (we only ever create P2TR, P2WPKH, and
 	 * P2SH-P2WPKH outputs). */
 
-	descriptor = tal_fmt(NULL, "wpkh(%s/0/0/*)", enc_xpub);
+	descriptor = tal_fmt(NULL, "wpkh(%s/0/0/*)", enc_xkey);
 	if (!descriptor_checksum(descriptor, strlen(descriptor), &checksum))
 		errx(ERROR_LIBWALLY, "Can't derive descriptor checksum for wpkh");
 	printf("%s#%s\n", descriptor, checksum.csum);
 	tal_free(descriptor);
 
-	descriptor = tal_fmt(NULL, "sh(wpkh(%s/0/0/*))", enc_xpub);
+	descriptor = tal_fmt(NULL, "sh(wpkh(%s/0/0/*))", enc_xkey);
 	if (!descriptor_checksum(descriptor, strlen(descriptor), &checksum))
 		errx(ERROR_LIBWALLY, "Can't derive descriptor checksum for sh(wpkh)");
 	printf("%s#%s\n", descriptor, checksum.csum);
 	tal_free(descriptor);
 
-	descriptor = tal_fmt(NULL, "tr(%s/0/0/*)", enc_xpub);
+	descriptor = tal_fmt(NULL, "tr(%s/0/0/*)", enc_xkey);
 	if (!descriptor_checksum(descriptor, strlen(descriptor), &checksum))
 		errx(ERROR_LIBWALLY, "Can't derive descriptor checksum for tr");
 	printf("%s#%s\n", descriptor, checksum.csum);
 	tal_free(descriptor);
 
-	wally_free_string(enc_xpub);
+	wally_free_string(enc_xkey);
 
 	return 0;
 }
@@ -755,6 +763,8 @@ int main(int argc, char *argv[])
 
 	if (streq(method, "dumponchaindescriptors")) {
 		char *net = NULL;
+		char *show_secrets_str = NULL;
+		bool show_secrets = false;
 		u32 version;
 
 		if (argc < 3)
@@ -772,7 +782,21 @@ int main(int argc, char *argv[])
 		else
 			version = BIP32_VER_MAIN_PRIVATE;
 
-		return dumponchaindescriptors(argv[2], NULL, version);
+		if (argc > 4)
+			show_secrets_str = argv[4];
+
+		if (show_secrets_str) {
+			if (streq(show_secrets_str, "true"))
+				show_secrets = true;
+			else if (streq(show_secrets_str, "false"))
+				show_secrets = false;
+			else
+				errx(ERROR_USAGE, "show_secrets should be "
+						  "either true or false.");
+		} else
+			show_secrets = false;
+
+		return dumponchaindescriptors(argv[2], NULL, version, show_secrets);
 	}
 
 	if (streq(method, "checkhsm")) {


### PR DESCRIPTION
I would like to have a feature in core-lightning to export the private keys used by the on-chain wallet.
This feature would allow to control the funds using a 3rd party software, personally I don't like to have funds that can only be recovered with a single wallet.

Currently core-lightning has a tool to generate the `hsm_secret` from a mnemonic sentence (+ passphrase), but this mechanics is not compliant with BIP39. The `hsm_secret` itself is not even the seed of the BIP32 wallet, and the HD wallet does not use BIP43 purpose derivation for the different types of addresses (wpkh, sh(wpkh), tr) instead a single extended key is used in all three wallets. That said one cannot just put the original mnemonic into another wallet and derive the public and private keys, and neither plug `hsm_secret` into any other software wallet.

For that reason the only thing we can export from core-lightning to recover our HD wallet from another software are the wallet descriptors. One can call `tools/hsmtools dumponchaindescriptors` to perform that task. Unfortunately this will print only the public descriptors and not the private keys.

A work-around is to write oneself the code necessary to derive the extended private keys (or the descriptors) for example [cln_tools.py](https://github.com/Lagrang3/hackbitcoin/blob/489719830d51639665c7546b685447f7de4903e5/hackbitcoin/cln_tools.py) that I wrote after a couple of days tinkering.
But I think a functionality like this is needed into core-lightning.

The discussion in #1762 is relevant to this PR.

To-do list:
- [x] documentation
- [ ] tests 
- [x] also pass the CI tests