### PR TITLE
cln_rpc: Ignore flakey test

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -775,6 +775,8 @@ mod test {
         let _ = builder.start(state);
     }
 
+    // This test appears to be flakey
+    #[ignore]
     #[tokio::test]
     async fn logs_become_json_rpc_notifications() {
         // The input and output for testing the plugin behavior


### PR DESCRIPTION
I've written this test earlier.
It appears to be flakey and fails from time to time.

I'd propose to ignore the test temporarily.