### PR TITLE
Enhance plugin_log_handle to accommodate multi-line messages

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -525,12 +525,8 @@ static const char *plugin_log_handle(struct plugin *plugin,
 		lines = tal_strsplit(tmpctx, log_msg, "\n", STR_EMPTY_OK);
 
 		for (size_t i = 0; lines[i]; i++) {
-			bool call_notifier2 = call_notifier;
-			/* Call notifier only for the last message to avoid Python errors. */
-			if (lines[i+1] != NULL)
-				call_notifier2 = false;
 			/* FIXME: Let plugin specify node_id? */
-			log_(plugin->log, level, NULL, call_notifier2, "%s", lines[i]);
+			log_(plugin->log, level, NULL, call_notifier, "%s", lines[i]);
 		}
 	} else {
 		log_(plugin->log, level, NULL, call_notifier, "%.*s",

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -3,6 +3,7 @@
 #include <ccan/ccan/tal/grab_file/grab_file.h>
 #include <ccan/crc32c/crc32c.h>
 #include <ccan/io/io.h>
+#include <ccan/json_escape/json_escape.h>
 #include <ccan/mem/mem.h>
 #include <ccan/opt/opt.h>
 #include <ccan/pipecmd/pipecmd.h>
@@ -512,9 +513,50 @@ static const char *plugin_log_handle(struct plugin *plugin,
 	}
 
 	call_notifier = (level == LOG_BROKEN || level == LOG_UNUSUAL)? true : false;
-	/* FIXME: Let plugin specify node_id? */
-	log_(plugin->log, level, NULL, call_notifier, "%.*s", msgtok->end - msgtok->start,
-	     plugin->buffer + msgtok->start);
+
+	/* Unescape log message. */
+	tal_t *ctx = tal(NULL, char);
+	const char *log_escaped = plugin->buffer + msgtok->start;
+	const size_t log_escaped_len = msgtok->end - msgtok->start;
+	struct json_escape *esc = json_escape_string_(ctx, log_escaped, log_escaped_len);
+	const char *log_msg = json_escape_unescape(ctx, esc);
+
+	/* Find last line. */
+	const char *log_msg2 = log_msg;
+	const char *last_msg;
+	while (true) {
+		const char *msg_end = strchr(log_msg2, '\n');
+		if (!msg_end) {
+			break;
+		}
+		int msg_len = msg_end - log_msg2;
+		if (msg_len > 0) {
+			last_msg = log_msg2;
+		}
+		log_msg2 = msg_end + 1;
+	}
+
+	/* Split to lines and log them separately. */
+	while (true) {
+		const char *msg_end = strchr(log_msg, '\n');
+		if (!msg_end) {
+			break;
+		}
+		int msg_len = msg_end - log_msg;
+		if (msg_len > 0) {
+			/* Call notifier only for the last message to avoid Python errors. */
+			bool call_notifier2 = call_notifier;
+			if (log_msg != last_msg) {
+				call_notifier2 = false;
+			}
+			/* FIXME: Let plugin specify node_id? */
+			log_(plugin->log, level, NULL, call_notifier2, "%.*s", msg_len, log_msg);
+		}
+		log_msg = msg_end + 1;
+	}
+
+	tal_free(ctx);
+
 	return NULL;
 }
 

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -65,10 +65,10 @@ def test_plugin_start(node_factory):
 
     l1.rpc.setconfig("test-dynamic-option", True)
     assert l1.rpc.listconfigs("test-dynamic-option")["configs"]["test-dynamic-option"]["value_bool"]
-    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option \\"true\\"'))
+    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option "true"'))
     l1.rpc.setconfig("test-dynamic-option", False)
     assert not l1.rpc.listconfigs("test-dynamic-option")["configs"]["test-dynamic-option"]["value_bool"]
-    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option \\"false\\"'))
+    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option "false"'))
 
 
 def test_plugin_options_handle_defaults(node_factory):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2157,7 +2157,7 @@ def test_bitcoind_fail_first(node_factory, bitcoind):
     # first.
     timeout = 5 if 5 < TIMEOUT // 3 else TIMEOUT // 3
     l1 = node_factory.get_node(start=False,
-                               broken_log=r'plugin-bcli: .*-stdinrpcpass getblockhash 100 exited 1 \(after [0-9]* other errors\)',
+                               broken_log=r'plugin-bcli: .*(-stdinrpcpass getblockhash 100 exited 1 \(after [0-9]* other errors\)|we have been retrying command for)',
                                may_fail=True,
                                options={'bitcoin-retry-timeout': timeout})
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4808,7 +4808,7 @@ def test_dev_rawrequest(node_factory):
     # Get fetchinvoice to make us an invoice_request
     l1.rpc.call('fetchinvoice', {'offer': offer['bolt12']})
 
-    m = re.search(r'invoice_request: \\"([a-z0-9]*)\\"', l1.daemon.is_in_log('invoice_request:'))
+    m = re.search(r'invoice_request: "([a-z0-9]*)"', l1.daemon.is_in_log('invoice_request:'))
     ret = l1.rpc.call('dev-rawrequest', {'invreq': m.group(1),
                                          'nodeid': l2.info['id'],
                                          'timeout': 10})
@@ -5936,7 +5936,7 @@ def test_offer_experimental_fields(node_factory):
         l2.rpc.fetchinvoice(mangled)
 
     # invice request contains the unknown field
-    m = re.search(r'invoice_request: \\"([a-z0-9]*)\\"', l2.daemon.is_in_log('invoice_request:'))
+    m = re.search(r'invoice_request: "([a-z0-9]*)"', l2.daemon.is_in_log('invoice_request:'))
     assert l1.rpc.decode(m.group(1))['unknown_invoice_request_tlvs'] == [{'type': 1000000001, 'length': 1, 'value': '00'}]
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1256,7 +1256,7 @@ def test_htlc_accepted_hook_forward_restart(node_factory, executor):
 def test_warning_notification(node_factory):
     """ test 'warning' notifications
     """
-    l1 = node_factory.get_node(options={'plugin': os.path.join(os.getcwd(), 'tests/plugins/pretend_badlog.py')}, broken_log=r'Test warning notification\(for broken event\)')
+    l1 = node_factory.get_node(options={'plugin': os.path.join(os.getcwd(), 'tests/plugins/pretend_badlog.py')}, broken_log=r'Test warning notification\(for broken event\)|LINE[12]')
 
     # 1. test 'warn' level
     event = "Test warning notification(for unusual event)"
@@ -1282,6 +1282,15 @@ def test_warning_notification(node_factory):
     l1.daemon.wait_for_log('plugin-pretend_badlog.py: time: *')
     l1.daemon.wait_for_log('plugin-pretend_badlog.py: source: plugin-pretend_badlog.py')
     l1.daemon.wait_for_log('plugin-pretend_badlog.py: log: Test warning notification\\(for broken event\\)')
+
+    # Test linesplitting while we're here
+    l1.rpc.call('pretendbad', {'event': 'LINE1\nLINE2', 'level': 'error'})
+    l1.daemon.wait_for_log(r'\*\*BROKEN\*\* plugin-pretend_badlog.py: LINE1')
+    l1.daemon.wait_for_log(r'\*\*BROKEN\*\* plugin-pretend_badlog.py: LINE2')
+    l1.daemon.wait_for_log('plugin-pretend_badlog.py: Received warning')
+    l1.daemon.wait_for_log('plugin-pretend_badlog.py: log: LINE1')
+    l1.daemon.wait_for_log('plugin-pretend_badlog.py: Received warning')
+    l1.daemon.wait_for_log('plugin-pretend_badlog.py: log: LINE2')
 
 
 def test_invoice_payment_notification(node_factory):

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -434,11 +434,11 @@ def test_xpay_takeover(node_factory, executor):
     # Other args fail.
     inv = l3.rpc.invoice('any', "test_xpay_takeover7", "test_xpay_takeover7")
     l1.rpc.pay(inv['bolt11'], amount_msat=10000, label='test_xpay_takeover7')
-    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg \\"label\\"\)')
+    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg "label"\)')
 
     inv = l3.rpc.invoice('any', "test_xpay_takeover8", "test_xpay_takeover8")
     l1.rpc.pay(inv['bolt11'], amount_msat=10000, riskfactor=1)
-    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg \\"riskfactor\\"\)')
+    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg "riskfactor"\)')
 
     # Test that it's really dynamic.
     l1.rpc.setconfig('xpay-handle-pay', False)


### PR DESCRIPTION
Previously, the code utilized JSON-encoded text to pass log messages to the log_() function, resulting in new lines being printed to the log as '\n'. This commit addresses this issue by unescaping and splitting the log message into lines, with each non-empty line being logged separately.

It is deemed acceptable to pass non-printable characters to log_() since they are replaced with "?" in the logv() function, invoked by log_(). Therefore, leaving lines JSON unescaped is permissible.

It's important to note that only the last log_() call may have call_notifier set to true. This adjustment is crucial to prevent Python tracebacks complaining about a broken pipe after lightningd exits.

Fixes: https://github.com/ElementsProject/lightning/issues/4912

Tested:

```
./lightningd/lightningd  
2024-02-08T20:33:17.642Z INFO    lightningd: v23.11-257-g968d6d6-modded

Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?

Make sure you have bitcoind running and that bitcoin-cli is able to connect to bitcoind.

You can verify that your Bitcoin Core installation is ready for use by running:

    $ bitcoin-cli echo 'hello world'
2024-02-08T20:33:18.227Z **BROKEN** plugin-bcli: Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?
2024-02-08T20:33:18.227Z **BROKEN** plugin-bcli: Make sure you have bitcoind running and that bitcoin-cli is able to connect to bitcoind.
2024-02-08T20:33:18.227Z **BROKEN** plugin-bcli: You can verify that your Bitcoin Core installation is ready for use by running:
2024-02-08T20:33:18.227Z **BROKEN** plugin-bcli:     $ bitcoin-cli echo 'hello world'
2024-02-08T20:33:18.227Z INFO    plugin-bcli: Killing plugin: exited before we sent init
The Bitcoin backend died.
```