### PR TITLE
cln-grpc: Derive serde Serialize/Deserialize for protobuf types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "hex",
  "log",
  "prost",
+ "serde",
  "serde_json",
  "tonic",
  "tonic-build",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 cln-rpc = { path="../cln-rpc/", version = "^0.1", optional = true }
 tonic = { version = "0.8", features = ["tls", "transport"] }
 prost = "0.11"
+serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.3"
 bitcoin = { version = "0.30", features = [ "serde" ] }
 

--- a/cln-grpc/build.rs
+++ b/cln-grpc/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     let builder = tonic_build::configure();
     builder
+        .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&["proto/node.proto"], &["proto"])
         .unwrap();


### PR DESCRIPTION
This PR adds serde annotations that help serializing / deserializing the cln-grpc protobuf types to and from json.