### PR TITLE
gossip: Cherry pick test fixes out of 

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1801,7 +1801,8 @@ def test_onchaind_replay(node_factory, bitcoind):
     l1, l2 = node_factory.line_graph(2, opts=[{'watchtime-blocks': 201, 'cltv-delta': 101,
                                                'disconnect': disconnects,
                                                'feerates': (7500, 7500, 7500, 7500)},
-                                              {'watchtime-blocks': 201, 'cltv-delta': 101}])
+                                              {'watchtime-blocks': 201, 'cltv-delta': 101}],
+                                     wait_for_announce=True)
 
     inv = l2.rpc.invoice(10**8, 'onchaind_replay', 'desc')
     rhash = inv['payment_hash']

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -215,6 +215,12 @@ def test_last_tx_psbt_upgrade(node_factory, bitcoind):
 
     bitcoind.rpc.decoderawtransaction(last_txs[1].hex())
 
+    # FIXME: gossipd gets upset, since it seems like the db with remote announcement_sigs was
+    # actually from l2, not l1.  But if we make this l1, then last_tx changes, so we just
+    # filter out gossipd messages here (we will still detect other broken msgs!)
+    l1.daemon.logs = [l for l in l1.daemon.logs if 'gossipd' not in l]
+    l2.daemon.logs = [l for l in l2.daemon.logs if 'gossipd' not in l]
+
 
 @pytest.mark.slow_test
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "This test is based on a sqlite3 snapshot")

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1987,8 +1987,12 @@ def test_addgossip(node_factory):
     l1.daemon.logsearch_start = 0
     ann = l1.daemon.wait_for_log(r"\[(OUT|IN)\] 0100.*")  # Either direction will suppress the other.
 
-    upd1 = l1.daemon.is_in_log(r"\[OUT\] 0102.*")
-    upd2 = l2.daemon.is_in_log(r"\[OUT\] 0102.*")
+    l2.daemon.logsearch_start = 0
+    l2.daemon.wait_for_log(r"\[(OUT|IN)\] 0100.*")
+
+    # Be sure not to get the *private* updates!
+    upd1 = l1.daemon.is_in_log(r"\[OUT\] 0102.*", start=l1.daemon.logsearch_start)
+    upd2 = l2.daemon.is_in_log(r"\[OUT\] 0102.*", start=l2.daemon.logsearch_start)
 
     nann1 = l1.daemon.is_in_log(r"\[OUT\] 0101.*")
     nann2 = l2.daemon.is_in_log(r"\[OUT\] 0101.*")

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -46,12 +46,6 @@ def test_gossip_pruning(node_factory, bitcoind):
     wait_for(lambda: [c['active'] for c in l2.rpc.listchannels()['channels']] == [True] * 4)
     wait_for(lambda: [c['active'] for c in l3.rpc.listchannels()['channels']] == [True] * 4)
 
-    # Also check that it sends a redundant node_announcement.
-    wait_for(lambda: 'last_timestamp' in only_one(l2.rpc.listnodes(l1.info['id'])['nodes']))
-    ts1 = only_one(l2.rpc.listnodes(l1.info['id'])['nodes'])['last_timestamp']
-    wait_for(lambda: only_one(l2.rpc.listnodes(l1.info['id'])['nodes'])['last_timestamp'] != ts1)
-    assert only_one(l2.rpc.listnodes(l1.info['id'])['nodes'])['last_timestamp'] >= ts1 + 24
-
     # All of them should send a keepalive message (after 30 seconds)
     l1.daemon.wait_for_logs([
         'Sending keepalive channel_update for {}'.format(scid1),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1319,9 +1319,7 @@ def test_funding_reorg_remote_lags(node_factory, bitcoind):
     wait_for(lambda: l2.is_local_channel_active('104x1x0'))
     assert [c for c in l2.rpc.listpeerchannels()['channels'] if c['short_channel_id'] == '103x1x0'] == []
 
-    wait_for(lambda: only_one(l2.rpc.listpeerchannels()['channels'])['status'] == [
-        'CHANNELD_NORMAL:Reconnected, and reestablished.',
-        'CHANNELD_NORMAL:Channel ready for use. Channel announced.'])
+    wait_for(lambda: [c['short_channel_id'] for c in l2.rpc.listchannels()['channels']] == ['104x1x0'] * 2)
 
     l1.rpc.close(l2.info['id'])
     bitcoind.generate_block(1, True)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2543,10 +2543,6 @@ def test_anchor_min_emergency(bitcoind, node_factory):
     with pytest.raises(RpcError, match=r'We would not have enough left for min-emergency-msat 25000sat'):
         l1.rpc.withdraw(addr2, 'all')
 
-    # Make sure channeld tells gossipd about channel before we close, otherwise
-    # we get spurious "bad gossip" complaints if l2 sends channel_updates.
-    l1.daemon.wait_for_log("received private channel announcement from channeld")
-
     # Even with onchain anchor channel, it still keeps reserve (just in case!).
     l1.rpc.close(l2.info['id'])
     bitcoind.generate_block(1, wait_for_mempool=1)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1830,6 +1830,7 @@ def test_zeroconf_forward(node_factory, bitcoind):
     l2.fundwallet(10**7)
     l2.rpc.fundchannel(l3.info['id'], 10**6, mindepth=0)
     wait_for(lambda: l3.rpc.listincoming()['incoming'] != [])
+    wait_for(lambda: only_one(l3.rpc.listincoming()['incoming'])['incoming_capacity_msat'] != 0)
 
     # Make sure (esp in non-dev-mode) blockheights agree so we don't WIRE_EXPIRY_TOO_SOON...
     sync_blockheight(bitcoind, [l1, l2, l3])

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2076,6 +2076,9 @@ def test_zeroconf_multichan_forward(node_factory):
     # Just making sure the allowlisted node_id matches.
     assert l2.info['id'] == node_id
 
+    # Create invoice which doesn't use zeroconf channel as routehint!
+    inv = l3.rpc.invoice(amount_msat=10000, label='lbl1', description='desc')['bolt11']
+
     # Now create a channel that is twice as large as the real channel,
     # and don't announce it.
     l2.fundwallet(10**7)
@@ -2084,7 +2087,6 @@ def test_zeroconf_multichan_forward(node_factory):
     l2.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_READY')
     l3.daemon.wait_for_log(r'peer_in WIRE_CHANNEL_READY')
 
-    inv = l3.rpc.invoice(amount_msat=10000, label='lbl1', description='desc')['bolt11']
     l1.rpc.pay(inv)
 
     for c in l2.rpc.listpeerchannels(l3.info['id'])['channels']:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4125,8 +4125,8 @@ def test_sql(node_factory, bitcoind):
     # This has to wait for the hold_invoice plugin to let go!
     txid = l1.rpc.close(l2.info['id'])['txid']
     bitcoind.generate_block(13, wait_for_mempool=txid)
-    wait_for(lambda: len(l3.rpc.listchannels()['channels']) == 2)
-    assert len(l3.rpc.sql("SELECT * FROM channels;")['rows']) == 2
+    wait_for(lambda: len(l3.rpc.listchannels(source=l1.info['id'])['channels']) == 0)
+    assert len(l3.rpc.sql("SELECT * FROM channels WHERE source = X'{}';".format(l1.info['id']))['rows']) == 0
     l3.daemon.wait_for_log("Deleting channel: {}".format(scid))
 
     # No deprecated fields!

--- a/tests/test_splicing.py
+++ b/tests/test_splicing.py
@@ -37,7 +37,6 @@ def test_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -81,7 +80,7 @@ def test_splice_gossip(node_factory, bitcoind):
     assert post_splice_scid != pre_splice_scid
 
     # l3 should see the new channel now.
-    wait_for(lambda: l3.rpc.listchannels(short_channel_id=post_splice_scid)['channels'] != [])
+    wait_for(lambda: len(l3.rpc.listchannels(short_channel_id=post_splice_scid)['channels']) == 2)
     assert len(l3.rpc.listchannels(short_channel_id=pre_splice_scid)['channels']) == 2
 
     bitcoind.generate_block(7)
@@ -132,7 +131,6 @@ def test_splice_listnodes(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     bitcoind.generate_block(7)
 
@@ -166,7 +164,6 @@ def test_splice_out(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -223,7 +220,6 @@ def test_invalid_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -273,7 +269,6 @@ def test_commit_crash_splice(node_factory, bitcoind):
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     time.sleep(1)
 

--- a/tests/test_splicing_disconnect.py
+++ b/tests/test_splicing_disconnect.py
@@ -4,7 +4,7 @@ import unittest
 import time
 from pyln.testing.utils import EXPERIMENTAL_DUAL_FUND
 from utils import (
-    TEST_NETWORK, first_scid
+    TEST_NETWORK
 )
 
 
@@ -53,7 +53,6 @@ def test_splice_disconnect_sig(node_factory, bitcoind):
 
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])
@@ -109,7 +108,6 @@ def test_splice_disconnect_commit(node_factory, bitcoind, executor):
 
     l1.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')
-    l1.daemon.wait_for_log(r'private channel announcement from channeld for ' + first_scid(l1, l2))
 
     inv = l2.rpc.invoice(10**2, '3', 'no_3')
     l1.rpc.pay(inv['bolt11'])


### PR DESCRIPTION
If I understood correctly, the tests work pre- and post-private gossip change
so no need to be bundling them with that change at all. Cherry-picking the 
test changes so we don't have to carry them around as much, and they seem
to be useful independently of the gossip rework.