### PR TITLE
topology: don't call gossmap for locally added channels.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -1249,6 +1249,8 @@ void gossmap_chan_get_update_details(const struct gossmap *map,
 	const size_t htlc_maximum_off = fee_prop_off + 4;
 
 	assert(gossmap_chan_set(chan, dir));
+	/* Not allowed on local updates! */
+	assert(chan->cann_off < map->map_size);
 
 	if (timestamp)
 		*timestamp = map_be32(map, timestamp_off);

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -155,7 +155,7 @@ u8 *gossmap_node_get_features(const tal_t *ctx,
 			      const struct gossmap_node *n);
 
 /* Returns details from channel_update (must be gossmap_chan_set, and
- * does not work for local_updatechan! */
+ * does not work for local_updatechan)! */
 void gossmap_chan_get_update_details(const struct gossmap *map,
 				     const struct gossmap_chan *chan,
 				     int dir,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3785,6 +3785,7 @@ def test_upgrade_statickey_onchaind(node_factory, executor, bitcoind):
 
     bitcoind.generate_block(100, wait_for_mempool=txid)
     # This works even if they disconnect and listpeerchannels() is empty:
+    wait_for(lambda: l1.rpc.listpeerchannels()['channels'] == [])
     wait_for(lambda: l2.rpc.listpeerchannels()['channels'] == [])
 
     # TEST 2: Cheat from post-upgrade.
@@ -3817,6 +3818,7 @@ def test_upgrade_statickey_onchaind(node_factory, executor, bitcoind):
 
     bitcoind.generate_block(100, wait_for_mempool=txid)
     # This works even if they disconnect and listpeers() is empty:
+    wait_for(lambda: len(l1.rpc.listpeerchannels()['channels']) == 0)
     wait_for(lambda: len(l2.rpc.listpeerchannels()['channels']) == 0)
 
     # TEST 3: Unilateral close from pre-upgrade
@@ -3852,6 +3854,7 @@ def test_upgrade_statickey_onchaind(node_factory, executor, bitcoind):
     bitcoind.generate_block(100, wait_for_mempool=txid)
 
     # This works even if they disconnect and listpeerchannels() is empty:
+    wait_for(lambda: len(l1.rpc.listpeerchannels()['channels']) == 0)
     wait_for(lambda: len(l2.rpc.listpeerchannels()['channels']) == 0)
 
     # TEST 4: Unilateral close from post-upgrade


### PR DESCRIPTION
This happens in deprecated mode, and we get bogus results.  Valgrind caught it!  

Bonus: fix another flake.

Changelog-None: Introduced in recent gossip changes.