### PR TITLE
Offers deprecate string recurrence

### DIFF
--- a/common/json_param.c
+++ b/common/json_param.c
@@ -204,17 +204,6 @@ static int comp_by_name(const struct param *a, const struct param *b,
 	return strcmp(a->name, b->name);
 }
 
-static int comp_by_arg(const struct param *a, const struct param *b,
-		       void *unused)
-{
-	/* size_t could be larger than int: don't turn a 4bn difference into 0 */
-	if (a->arg > b->arg)
-		return 1;
-	else if (a->arg < b->arg)
-		return -1;
-	return 0;
-}
-
 /* This comparator is a bit different, but works well.
  * Return 0 if @a is optional and @b is required. Otherwise return 1.
  */
@@ -267,7 +256,6 @@ static void check_params(const struct param *params)
 
 	/* check for repeated names and args */
 	check_unique(copy, comp_by_name);
-	check_unique(copy, comp_by_arg);
 
 	tal_free(copy);
 }

--- a/common/test/run-param.c
+++ b/common/test/run-param.c
@@ -352,13 +352,6 @@ static void bad_programmer(void)
 	      p_req("repeat", param_millionths, &fpval), NULL);
 	assert(paramcheck_assert_failed);
 
-	/* check for repeated arguments */
-	paramcheck_assert_failed = false;
-	param(cmd, j->buffer, j->toks,
-	      p_req("u64", param_u64, &ival),
-	      p_req("repeated-arg", param_u64, &ival), NULL);
-	assert(paramcheck_assert_failed);
-
 	paramcheck_assert_failed = false;
 	param(cmd, j->buffer, j->toks,
 	      p_req("u64", (param_cbx) NULL, NULL), NULL);

--- a/doc/developers-guide/deprecations.md
+++ b/doc/developers-guide/deprecations.md
@@ -48,6 +48,7 @@ hidden: false
 | estimatefees.min_acceptable          | Field              | v23.05           | v24.05         | `min_acceptable` feerate (implementation-specific, use modern feerates)                                                                                                         |
 | estimatefees.max_acceptable          | Field              | v23.05           | v24.05         | `max_acceptable` feerate (implementation-specific, use modern feerates)                                                                                                         |
 | commando.missing_id                  | Parameter          | v23.02           | v24.02         | Incoming JSON commands without an `id` field                                                                                                                                    |
+| offer.recurrence_base.at_prefix      | Parameter          | v24.02           | v24.05         | `recurrence_base` with `@` prefix (use `recurrence_start_any_period`)                                                                                                           |
 
 
 Inevitably there are features which need to change: either to be generalized, or removed when they can no longer be supported.

--- a/doc/lightning-offer.7.md
+++ b/doc/lightning-offer.7.md
@@ -6,7 +6,8 @@ SYNOPSIS
 
 **(WARNING: experimental-offers only)**
 
-**offer** *amount* *description* [*issuer*] [*label*] [*quantity\_max*] [*absolute\_expiry*] [*recurrence*] [*recurrence\_base*] [*recurrence\_paywindow*] [*recurrence\_limit*] [*single\_use*]
+**offer** *amount* *description* [*issuer*] [*label*] [*quantity\_max*] [*absolute\_expiry*] [*recurrence*] [*recurrence\_base*] [*recurrence\_paywindow*] [*recurrence\_limit*] [*single\_use*] [*recurrence\_start\_any\
+_period*]
 
 DESCRIPTION
 -----------
@@ -61,12 +62,9 @@ offer.  The semantics of recurrence is fairly predictable, but fully
 documented in BOLT 12.  e.g. "4weeks".
 
 *recurrence\_base* is an optional time in seconds since the first day
-of 1970 UTC, optionally with a "@" prefix.  This indicates when the
+of 1970 UTC.  This indicates when the
 first period begins; without this, the recurrence periods start from
-the first invoice.  The "@" prefix means that the invoice must start
-by paying the first period; otherwise it is permitted to start at any
-period.  This is encoded in the offer.  e.g. "@1609459200" indicates
-you must start paying on the 1st January 2021.
+the first invoice.
 
 *recurrence\_paywindow* is an optional argument of form
 '-time+time[%]'.  The first time is the number of seconds before the
@@ -86,6 +84,11 @@ period which exists.  eg. "12" means there are 13 periods, from 0 to
 *single\_use* (default false) indicates that the offer is only valid
 once; we may issue multiple invoices, but as soon as one is paid all other
 invoices will be expired (i.e. only one person can pay this offer).
+
+*recurrence\_start\_any\_period* (default true) means that the invoice must
+start by paying during any period; otherwise it must start by paying
+at the first period.  Setting this to false only makes sense if
+*recurrence\_base* was provided.  This is encoded in the offer.
 
 RETURN VALUE
 ------------

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4380,10 +4380,26 @@ def test_offer(node_factory, bitcoind):
 
     # Test base
     # (1456740000 == 10:00:00 (am) UTC on 29 February, 2016)
+
+    # This is deprecated, try modern alternative:
+    with pytest.raises(RpcError, match='invalid token'):
+        l1.rpc.call('offer', {'amount': '100000sat',
+                              'description': 'quantity_max test',
+                              'recurrence': '10minutes',
+                              'recurrence_base': '@1456740000'})
+
+    # Cannot use recurrence_start_any_period without recurrence_base
+    with pytest.raises(RpcError, match='Cannot set to false without specifying recurrence_base'):
+        l1.rpc.call('offer', {'amount': '100000sat',
+                              'description': 'quantity_max test',
+                              'recurrence': '10minutes',
+                              'recurrence_start_any_period': False})
+
     ret = l1.rpc.call('offer', {'amount': '100000sat',
                                 'description': 'quantity_max test',
                                 'recurrence': '10minutes',
-                                'recurrence_base': '@1456740000'})
+                                'recurrence_base': 1456740000,
+                                'recurrence_start_any_period': False})
     offer = only_one(l1.rpc.call('listoffers', [ret['offer_id']])['offers'])
     output = subprocess.check_output([bolt12tool, 'decode',
                                       offer['bolt12']]).decode('UTF-8')


### PR DESCRIPTION
@cdecker points out that it's ugly to have a string variant, and I agree.  Deprecate now (quickly, it's experimental) so GRPC/Rust bindings don't have to support it!