### PR TITLE
regtest: fix check for bitcoin-cli

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -56,11 +56,11 @@ fi
 
 if [ -z "$LIGHTNING_BIN" ]; then
 	# Already installed maybe?  Prints
-	if [ ! "$(type lightning-cli >/dev/null 2>&1)" ]; then
+	if ! type lightning-cli >/dev/null 2>&1 ; then
 		echo lightning-cli: not found
 		return 1
 	fi
-	if [ ! "$(type lightningd >/dev/null 2>&1)" ]; then
+	if ! type lightningd >/dev/null 2>&1 ; then
 		echo lightningd: not found
 		return 1
 	fi
@@ -93,11 +93,11 @@ fi
 # shellcheck disable=SC2153
 if [ -z "$BITCOIN_BIN" ]; then
 	# Already installed maybe?  Prints
-	if [ ! "$(type bitcoin-cli >/dev/null 2>&1)" ]; then
+	if ! type bitcoin-cli >/dev/null 2>&1 ; then
 		echo bitcoin-cli: not found
 		return 1
 	fi
-	if [ ! "$(type bitcoind >/dev/null 2>&1)" ]; then
+	if ! type bitcoind >/dev/null 2>&1 ; then
 		echo bitcoind: not found
 		return 1
 	fi


### PR DESCRIPTION
Opsie: I pushed a bug in #6966, the `startup_regtest.sh` 
test that checks if `bitcoin-cli`, `bitcoind`, `lightning-cli` and `lightningd` are found as executables is broken.
This PR fixes that.

