### PR TITLE
repro: `multifundchannel` and `all` amount

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -23113,7 +23113,7 @@
                 ]
               },
               "amount": {
-                "type": "msat",
+                "type": "msat_or_all",
                 "description": [
                   "Amount in satoshis taken from the internal wallet to fund the channel (but if we have any anchor channels, this will always leave at least `min-emergency-msat` as change). The string *all* can be used to specify all available funds (or 16,777,215 satoshi if more is available and large channels were not negotiated with the peer). Otherwise it is in satoshi precision; it can be a whole number, a whole number ending in *sat*, a whole number ending in *000msat*, or a number with 1 to 8 decimal places ending in *btc*. The value cannot be less than the dust limit, currently 546 satoshi as of this writing, nor more than 16,777,215 satoshi (unless large channels were negotiated with the peer)."
                 ]

--- a/doc/schemas/lightning-multifundchannel.json
+++ b/doc/schemas/lightning-multifundchannel.json
@@ -36,7 +36,7 @@
               ]
             },
             "amount": {
-              "type": "msat",
+              "type": "msat_or_all",
               "description": [
                 "Amount in satoshis taken from the internal wallet to fund the channel (but if we have any anchor channels, this will always leave at least `min-emergency-msat` as change). The string *all* can be used to specify all available funds (or 16,777,215 satoshi if more is available and large channels were not negotiated with the peer). Otherwise it is in satoshi precision; it can be a whole number, a whole number ending in *sat*, a whole number ending in *000msat*, or a number with 1 to 8 decimal places ending in *btc*. The value cannot be less than the dust limit, currently 546 satoshi as of this writing, nor more than 16,777,215 satoshi (unless large channels were negotiated with the peer)."
               ]

--- a/plugins/spender/multifundchannel.c
+++ b/plugins/spender/multifundchannel.c
@@ -1267,6 +1267,19 @@ after_fundpsbt(struct command *cmd,
 		    || !amount_msat_to_sat(&all->amount, msat))
 			goto fail;
 
+		/* Subtract amounts we're using for the other outputs */
+		for (size_t i = 0; i < tal_count(mfc->destinations); i++) {
+			if (mfc->destinations[i].all)
+				continue;
+			if (!amount_sat_sub(&all->amount,
+					    all->amount,
+					    mfc->destinations[i].amount)) {
+				return mfc_fail(mfc, JSONRPC2_INVALID_PARAMS,
+						"Insufficient funds for `all`"
+						" output");
+			}
+		}
+
 		/* Remove the 'all' flag.  */
 		all->all = false;
 

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2682,7 +2682,6 @@ def test_opening_explicit_channel_type(node_factory, bitcoind):
     assert only_one(l3.rpc.listpeerchannels()['channels'])['channel_type']['bits'] == [STATIC_REMOTEKEY]
 
 
-@pytest.mark.xfail(strict=True)
 def test_multifunding_all_amount(node_factory, bitcoind):
     l1, l2, l3 = node_factory.get_nodes(3)
 


### PR DESCRIPTION
related issue: https://github.com/ElementsProject/lightning/issues/6664

Using `"amount": "all"` is atleast in multifundchannel broken. I could not find a test for it so i wrote a simple test for it. Didn't know 100% where to put it or what to put for the `@`, but this test fails with:
```
pyln.client.lightning.RpcError: RPC call failed: method: multifundchannel, payload: {'destinations': [{'id': '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59@localhost:35399', 'amount': 50000}, {'id': '035d2b1192dfba134e10e540875d366ebc8bc353d5aa766b80c090b39c3a5d885d@localhost:42377', 'amount': 'all'}], 'minchannels': 2}, error: {'code': -1, 'message': 'Error broadcasting transaction: error code: -26\\nerror message:\\nbad-txns-in-belowout, value in (0.02) < value out (0.02045073). Unsent tx discarded 020000000001014953a8be36fba5a3be8813cb8464a5db17b9a5d59175e2f7d9205b36aaf9b2be0100000000fdffffff0250c30000000000002200205b8cd3b914cf67cdd8fa6273c930353dd36476734fbd962102c2df53b90880cd41711e0000000000220020b5534649d83864bf66a7c404ff30ee074a302e0095899686beb5d8dae0e3d87002473044022053a89a5c8f590220ae299cb4fcdaffe3bc134c7fe0402258298691485a2c23cf02206710c2332bd35ac2bcfb9e4a40b9459187f861b9cb9a3b9386c4abf20e09a799012103d745445c9362665f22e0d96e9e766f273f3260dea39c8a76bfa05dd2684ddccf66000000'}
```

important part: `value in (0.02) < value out (0.02045073)`

Expectation is that this test passes and not tries to inflate bitcoin.