### PR TITLE
`cln_plugin` Refactor ConfigOption

### DIFF
--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -12,15 +12,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let state = ();
 
     if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
-        .option(
-            options::ConfigOption::new_i64_with_default(
-                "test-option",
-                42,
-                "a test-option with default 42",
-            )
-            .build(),
-        )
-        .option(options::ConfigOption::new_opt_i64("opt-option", "An optional option").build())
+        .option(options::ConfigOption::new_i64_with_default(
+            "test-option",
+            42,
+            "a test-option with default 42",
+        ))
+        .option(options::ConfigOption::new_i64_no_default(
+            "opt-option",
+            "An optional option",
+        ))
         .rpcmethod("testmethod", "This is a test", testmethod)
         .rpcmethod(
             "testoptions",

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
 async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!({
-        "opt-option": format!("{:?}", p.option("opt-option").unwrap())
+        "opt-option": format!("{:?}", p.option_str("opt-option").unwrap())
     }))
 }
 

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -12,16 +12,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let state = ();
 
     if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
-        .option(options::ConfigOption::new(
-            "test-option",
-            options::Value::Integer(42),
-            "a test-option with default 42",
-        ))
-        .option(options::ConfigOption::new(
-            "opt-option",
-            options::Value::OptInteger,
-            "An optional option",
-        ))
+        .option(
+            options::ConfigOption::new_i64_with_default(
+                "test-option",
+                42,
+                "a test-option with default 42",
+            )
+            .build(),
+        )
+        .option(options::ConfigOption::new_opt_i64("opt-option", "An optional option").build())
         .rpcmethod("testmethod", "This is a test", testmethod)
         .rpcmethod(
             "testoptions",

--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
             "grpc-port",
             -1,
             "Which port should the grpc plugin listen for incoming connections?",
-        ).build())
+        ))
         .configure()
         .await?
     {

--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -22,11 +22,11 @@ async fn main() -> Result<()> {
     let directory = std::env::current_dir()?;
 
     let plugin = match Builder::new(tokio::io::stdin(), tokio::io::stdout())
-        .option(options::ConfigOption::new(
+        .option(options::ConfigOption::new_i64_with_default(
             "grpc-port",
-            options::Value::Integer(-1),
+            -1,
             "Which port should the grpc plugin listen for incoming connections?",
-        ))
+        ).build())
         .configure()
         .await?
     {

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -130,8 +130,11 @@ where
         }
     }
 
-    pub fn option(mut self, opt: options::UntypedConfigOption) -> Builder<S, I, O> {
-        self.options.insert(opt.name().to_string(), opt);
+    pub fn option<V: options::OptionType>(
+        mut self,
+        opt: options::ConfigOption<V>,
+    ) -> Builder<S, I, O> {
+        self.options.insert(opt.name().to_string(), opt.build());
         self
     }
 

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,4 +1,4 @@
-use crate::options::ConfigOption;
+use crate::options::UntypedConfigOption;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -171,7 +171,7 @@ impl NotificationTopic {
 
 #[derive(Serialize, Default, Debug)]
 pub(crate) struct GetManifestResponse {
-    pub(crate) options: Vec<ConfigOption>,
+    pub(crate) options: Vec<UntypedConfigOption>,
     pub(crate) rpcmethods: Vec<RpcMethod>,
     pub(crate) subscriptions: Vec<String>,
     pub(crate) notifications: Vec<NotificationTopic>,
@@ -180,7 +180,7 @@ pub(crate) struct GetManifestResponse {
     pub(crate) featurebits: FeatureBits,
     pub(crate) nonnumericids: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub(crate) custommessages : Vec<u16>
+    pub(crate) custommessages: Vec<u16>,
 }
 
 #[derive(Serialize, Default, Debug, Clone)]

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -143,7 +143,6 @@ pub mod config_type {
     pub struct Flag;
 }
 
-
 /// Config values are represented as an i64. No default is used
 pub type IntegerConfigOption<'a> = ConfigOption<'a, config_type::Integer>;
 /// Config values are represented as a String. No default is used.
@@ -158,7 +157,6 @@ pub type DefaultStringConfigOption<'a> = ConfigOption<'a, config_type::DefaultSt
 pub type DefaultBooleanConfigOption<'a> = ConfigOption<'a, config_type::DefaultBoolean>;
 /// Config value is represented as a flag
 pub type FlagConfigOption<'a> = ConfigOption<'a, config_type::Flag>;
-
 
 pub trait OptionType {
     type OutputValue;
@@ -614,8 +612,7 @@ mod test {
         // The main goal of this test is to test compilation
 
         // Initiate every type as a const
-        const _: FlagConfigOption =
-            ConfigOption::new_flag("flag-option", "A flag option");
+        const _: FlagConfigOption = ConfigOption::new_flag("flag-option", "A flag option");
         const _: DefaultBooleanConfigOption =
             ConfigOption::new_bool_with_default("bool-option", false, "A boolean option");
         const _: BooleanConfigOption =

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -67,18 +67,20 @@ def test_plugin_start(node_factory):
     l1.daemon.wait_for_log(r'Got a connect notification')
 
 
-def test_plugin_optional_opts(node_factory):
+def test_plugin_options_handle_defaults(node_factory):
     """Start a minimal plugin and ensure it is well-behaved
     """
     bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-plugin-startup"
-    l1 = node_factory.get_node(options={"plugin": str(bin_path), 'opt-option': 31337})
+    l1 = node_factory.get_node(options={"plugin": str(bin_path), 'opt-option': 31337, "test-option": 31338})
     opts = l1.rpc.testoptions()
-    print(opts)
+    assert opts["opt-option"] == 31337
+    assert opts["test-option"] == 31338
 
     # Do not set any value, should be None now
     l1 = node_factory.get_node(options={"plugin": str(bin_path)})
     opts = l1.rpc.testoptions()
-    print(opts)
+    assert opts["opt-option"] is None, "opt-option has no default"
+    assert opts["test-option"] == 42, "test-option has a default of 42"
 
 
 def test_grpc_connect(node_factory):


### PR DESCRIPTION
This PR contains breaking changes.

I refactored `ConfigOption` in the `cln_plugin` crate and added some basic documentation.
It becomes easier to request the configured value of the `ConfigOption`.

I've marked this as draft because I still want to add some integration tests