### PR TITLE
Fix gossip code when channels are marked dying

### DIFF
--- a/common/gossip_store.h
+++ b/common/gossip_store.h
@@ -44,8 +44,8 @@ struct gossip_rcvd_filter;
  * gossip_hdr -- On-disk format header.
  */
 struct gossip_hdr {
-	beint16_t flags; /* Length of message after header. */
-	beint16_t len; /* GOSSIP_STORE_xxx_BIT flags. */
+	beint16_t flags; /* GOSSIP_STORE_xxx_BIT flags. */
+	beint16_t len; /* Length of message after header. */
 	beint32_t crc; /* crc of message of timestamp, after header. */
 	beint32_t timestamp; /* timestamp of msg. */
 };

--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -1093,6 +1093,19 @@ bool gossmap_chan_is_localmod(const struct gossmap *map,
 	return c->cann_off >= map->map_size;
 }
 
+bool gossmap_chan_is_dying(const struct gossmap *map,
+			   const struct gossmap_chan *c)
+{
+	struct gossip_hdr ghdr;
+	size_t off;
+
+	/* FIXME: put this flag in plus_scid_off instead? */
+	off = c->cann_off - sizeof(ghdr);
+	map_copy(map, off, &ghdr, sizeof(ghdr));
+
+	return ghdr.flags & CPU_TO_BE16(GOSSIP_STORE_DYING_BIT);
+}
+
 bool gossmap_chan_get_capacity(const struct gossmap *map,
 			       const struct gossmap_chan *c,
 			       struct amount_sat *amount)

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -122,6 +122,10 @@ void gossmap_remove_localmods(struct gossmap *map,
 bool gossmap_chan_is_localmod(const struct gossmap *map,
 			      const struct gossmap_chan *c);
 
+/* Is this channel dying? */
+bool gossmap_chan_is_dying(const struct gossmap *map,
+			   const struct gossmap_chan *c);
+
 /* Each channel has a unique (low) index. */
 u32 gossmap_node_idx(const struct gossmap *map, const struct gossmap_node *node);
 u32 gossmap_chan_idx(const struct gossmap *map, const struct gossmap_chan *chan);

--- a/connectd/gossip_store.c
+++ b/connectd/gossip_store.c
@@ -138,8 +138,10 @@ u8 *gossip_store_next(const tal_t *ctx,
 
 		/* Skip any timestamp filtered */
 		timestamp = be32_to_cpu(hdr.timestamp);
-		if (!timestamp_filter(timestamp_min, timestamp_max,
-				      timestamp)) {
+		/* Note: channel_announcements without a channel_update yet
+		 * will have 0 timestamp (we don't know).  Better to send them. */
+		if (timestamp &&
+		    !timestamp_filter(timestamp_min, timestamp_max, timestamp)) {
 			*off += r + msglen;
 			continue;
 		}

--- a/devtools/dump-gossipstore.c
+++ b/devtools/dump-gossipstore.c
@@ -12,7 +12,7 @@
 
 /* Current versions we support */
 #define GSTORE_MAJOR 0
-#define GSTORE_MINOR 12
+#define GSTORE_MINOR 14
 
 int main(int argc, char *argv[])
 {

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -82,6 +82,24 @@ u64 gossip_store_set_flag(struct gossip_store *gs,
 		       u64 offset, u16 flag, int type);
 
 /**
+ * Clear a flag the record at this offset (offset is that of
+ * record!).  OK if it's not currently set.
+ *
+ * In developer mode, checks that type is correct.
+ */
+void gossip_store_clear_flag(struct gossip_store *gs,
+			     u64 offset, u16 flag, int type);
+
+/**
+ * Get flags from the record at this offset (offset is that of
+ * record!).
+ *
+ * In developer mode, checks that type is correct.
+ */
+u16 gossip_store_get_flags(struct gossip_store *gs,
+			   u64 offset, int type);
+
+/**
  * Direct store accessor: get timestamp header for a record.
  *
  * Offset is *after* the header.

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -216,8 +216,12 @@ static bool any_cannounce_preceeds_offset(struct gossmap *gossmap,
 
 		if (chan == exclude_chan)
 			continue;
-		if (chan->cann_off < offset)
-			return true;
+		if (chan->cann_off > offset)
+			continue;
+		/* Dying channels don't help! */
+		if (gossmap_chan_is_dying(gossmap, chan))
+			continue;
+		return true;
 	}
 	return false;
 }

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1960,9 +1960,9 @@ def test_gossip_not_dying(node_factory, bitcoind):
 
     l1.daemon.wait_for_log("closing soon due to the funding outpoint being spent")
 
-    # We won't gossip the dead channel any more (but we still propagate node_announcement).  But connectd is not explicitly synced, so wait for "a bit".
+    # We won't gossip the dead channel any more, nor the node_announcements.  But connectd is not explicitly synced, so wait for "a bit".
     time.sleep(1)
-    assert len(get_gossip(l1)) == 2
+    assert get_gossip(l1) == []
 
 
 def test_dump_own_gossip(node_factory):


### PR DESCRIPTION
The "bad gossip" flakes were caused by the fact that:
1. When we see a channel close, we simply mark the channel_announce `dying` which means we don't propagate it.
2. We did not maintain this dying bit in various cases:
   1. We did not set it on the node_announcement once all channels are dying.
   2. Not *unset* it on the node_announcement if we see another channel confirmed.
   3. Nor did we set it if a new channel_update came in on a dying channel (we still accept updates!)
   4. Nor did we preserve it in node_announcements if we have to move it when all preceding channels are eliminated.
   5. We did not set it on fresh node_announcements if all channels were dying.
   6. We did not ignore dying channel_announcements when figuring out if we had to move the node_announcement.
  
I added a dev sanity check which helped test all of these!