### PR TITLE
Renepay concurrency

### DIFF
--- a/plugins/renepay/pay.c
+++ b/plugins/renepay/pay.c
@@ -739,6 +739,13 @@ payment_listsendpays_previous(
 			pending_group_id = groupid;
 			if (partid > max_pending_partid)
 				max_pending_partid = partid;
+
+			if (!amount_msat_add(&pending_msat, pending_msat,
+					     this_msat))
+				plugin_err(pay_plugin->plugin,
+					   "%s (line %d) msat overflow.",
+					   __PRETTY_FUNCTION__, __LINE__);
+
 		} else
 			assert(streq(status, "failed"));
 	}

--- a/plugins/renepay/pay.h
+++ b/plugins/renepay/pay.h
@@ -65,6 +65,7 @@ struct pay_plugin {
 
 	/* All the struct payment */
 	struct list_head payments;
+	struct payment_map *payment_map;
 
 	/* Per-channel metadata: some persists between payments */
 	struct chan_extra_map *chan_extra_map;

--- a/plugins/renepay/payment.c
+++ b/plugins/renepay/payment.c
@@ -12,7 +12,6 @@ struct payment *payment_new(const tal_t *ctx,
 			    const char *invstr TAKES,
 			    const char *label TAKES,
 			    const char *description TAKES,
-			    const struct sha256 *local_offer_id TAKES,
 			    const struct secret *payment_secret TAKES,
 			    const u8 *payment_metadata TAKES,
 			    const struct route_info **routes TAKES,
@@ -24,8 +23,8 @@ struct payment *payment_new(const tal_t *ctx,
 			    u64 retryfor,
 			    u16 final_cltv,
 			    /* Tweakable in --developer mode */
-			    u64 base_fee_penalty,
-			    u64 prob_cost_factor,
+			    u64 base_fee_penalty_millionths,
+			    u64 prob_cost_factor_millionths,
 			    u64 riskfactor_millionths,
 			    u64 min_prob_success_millionths,
 			    bool use_shadow)
@@ -67,11 +66,10 @@ struct payment *payment_new(const tal_t *ctx,
 	p->label = tal_strdup_or_null(p, label);
 
 	p->delay_feefactor = riskfactor_millionths / 1e6;
-	p->base_fee_penalty = base_fee_penalty;
-	p->prob_cost_factor = prob_cost_factor;
+	p->base_fee_penalty = base_fee_penalty_millionths / 1e6;
+	p->prob_cost_factor = prob_cost_factor_millionths / 1e6;
 	p->min_prob_success = min_prob_success_millionths / 1e6;
 
-	p->local_offer_id = tal_dup_or_null(p, struct sha256, local_offer_id);
 	p->use_shadow = use_shadow;
 	p->groupid=1;
 

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -115,6 +115,31 @@ struct payment {
 	u64 groupid;
 };
 
+static inline const struct sha256 payment_hash(const struct payment *p)
+{
+	return p->payment_hash;
+}
+
+static inline size_t payment_hash64(const struct sha256 h)
+{
+	return ((u64) h.u.u32[1] << 32) ^ h.u.u32[0];
+}
+
+static inline bool payment_hash_eq(const struct payment *p,
+				   const struct sha256 h)
+{
+	return p->payment_hash.u.u32[0] == h.u.u32[0] &&
+	       p->payment_hash.u.u32[1] == h.u.u32[1] &&
+	       p->payment_hash.u.u32[2] == h.u.u32[2] &&
+	       p->payment_hash.u.u32[3] == h.u.u32[3] &&
+	       p->payment_hash.u.u32[4] == h.u.u32[4] &&
+	       p->payment_hash.u.u32[5] == h.u.u32[5] &&
+	       p->payment_hash.u.u32[6] == h.u.u32[6] &&
+	       p->payment_hash.u.u32[7] == h.u.u32[7];
+}
+
+HTABLE_DEFINE_TYPE(struct payment, payment_hash, payment_hash64,
+		   payment_hash_eq, payment_map);
 
 struct payment *payment_new(const tal_t *ctx,
 			    struct command *cmd,

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -108,12 +108,6 @@ struct payment {
 	/* prob. cost =
 	 * 	- prob_cost_factor * log prob. */
 
-
-	/* If this is paying a local offer, this is the one (sendpay ensures we
-	 * don't pay twice for single-use offers) */
-	// TODO(eduardo): this is not being used!
-	struct sha256 *local_offer_id;
-
 	/* --developer allows disabling shadow route */
 	bool use_shadow;
 
@@ -127,7 +121,7 @@ struct payment *payment_new(const tal_t *ctx,
 			    const char *invstr TAKES,
 			    const char *label TAKES,
 			    const char *description TAKES,
-			    const struct sha256 *local_offer_id TAKES,
+			    // const struct sha256 *local_offer_id TAKES,
 			    const struct secret *payment_secret TAKES,
 			    const u8 *payment_metadata TAKES,
 			    const struct route_info **routes TAKES,


### PR DESCRIPTION
This PR is about refactoring `renepay` pipeline, because the current implementation is a bit messy and it fails to handle concurrent payment requests.

Fixes issue #7035.