### PR TITLE
Add no-reconnect-private option to disable automatic reconnect-attempts to peers connected to our node with private channels only

### DIFF
--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -391,6 +391,16 @@ void try_reconnect(const tal_t *ctx,
 {
 	if (!peer->ld->reconnect)
 		return;
+	if (!peer->ld->reconnect_private) {
+		u32 public_channels = 0;
+		struct channel *channel;
+		list_for_each(&peer->channels, channel, list) {
+			if (channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL)
+				public_channels++;
+		}
+		if (public_channels == 0)
+			return;
+	}
 
 	/* Did we last attempt to connect recently?  Enter backoff mode. */
 	if (time_less(time_between(time_now(), peer->last_connect_attempt),

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -243,6 +243,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->listen = true;
 	ld->autolisten = true;
 	ld->reconnect = true;
+	ld->reconnect_private = true;
 	ld->try_reexec = false;
 	ld->recover_secret = NULL;
 	ld->db_upgrade_ok = NULL;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -172,6 +172,9 @@ struct lightningd {
 	/* Do we want to reconnect to other peers? */
 	bool reconnect;
 
+	/* Do we want to reconnect to other peers having only unannouced channels with us? */
+	bool reconnect_private;
+
 	/* How many outstanding startup connection attempts? */
 	size_t num_startup_connects;
 

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -804,6 +804,10 @@ static void dev_register_opts(struct lightningd *ld)
 		     opt_set_invbool,
 		     &ld->reconnect,
 		     "Disable automatic reconnect-attempts by this node, but accept incoming");
+	clnopt_noarg("--dev-no-reconnect-private", OPT_DEV,
+		     opt_set_invbool,
+		     &ld->reconnect_private,
+		     "Disable automatic reconnect-attempts to peers with private channel(s) only, but accept incoming");
 	clnopt_noarg("--dev-fast-reconnect", OPT_DEV,
 		     opt_set_bool,
 		     &ld->dev_fast_reconnect,


### PR DESCRIPTION
When a node has lot of private channels to nodes which are not always online, the is no reason to try to reconnect to them because they can be offline for long period of time.