### PR TITLE
channeld: fix update_fee cap.

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3376,9 +3376,9 @@ def test_feerate_spam(node_factory, chainparams):
     # Now change feerates to something l1 can't afford.
     l1.set_feerates((200000, 200000, 200000, 200000))
 
-    # It will raise as far as it can (30000)
+    # It will raise as far as it can (30551)
     if 'anchors_zero_fee_htlc_tx/even' in only_one(l1.rpc.listpeerchannels()['channels'])['channel_type']['names']:
-        maxfeerate = 30000
+        maxfeerate = 30551
     else:
         maxfeerate = 48000
     l1.daemon.wait_for_log('Setting REMOTE feerate to {}'.format(maxfeerate))


### PR DESCRIPTION
We would sometimes propose fees which we couldn't afford, and thus the peer would get upset: if we didn't recover it could cause force closes.

This was because we didn't take into account that pending htlcs will remove our total available funds.

Changelog-Fixes: Protocol: Don't upset peers by sending `update_fee` with fees we cannot afford in the case where HTLCs are large.