### PR TITLE
Fix incorrect hex value for Signet port

### DIFF
--- a/bitcoin/chainparams.h
+++ b/bitcoin/chainparams.h
@@ -29,7 +29,7 @@ struct chainparams {
 	 *
 	 * - Bitcoin mainet with port number 9735 or the corresponding hexadecimal `0x2607`;
 	 * - Bitcoin testnet with port number 19735 (`0x4D17`);
-	 * - Bitcoin signet with port number 39735 (`0xF87`).
+	 * - Bitcoin signet with port number 39735 (`0x9B37`).
 	 */
 	const int ln_port;
 	const char *cli;

--- a/contrib/pyln-spec/bolt1/pyln/spec/bolt1/text.py
+++ b/contrib/pyln-spec/bolt1/pyln/spec/bolt1/text.py
@@ -10,7 +10,7 @@ The default TCP port depends on the network used. The most common networks are:
 
 - Bitcoin mainet with port number 9735 or the corresponding hexadecimal `0x2607`;
 - Bitcoin testnet with port number 19735 (`0x4D17`);
-- Bitcoin signet with port number 39735 (`0xF87`).
+- Bitcoin signet with port number 39735 (`0x9B37`).
 
 The Unicode code point for LIGHTNING <sup>[1](#reference-1)</sup>, and the port convention try to follow the Bitcoin Core convention.
 


### PR DESCRIPTION
The comments in chainparams.h list Signet's port hex as 0xF87 which should be 0x9B77. This needs updating to match the actual port value