### PR TITLE
connectd: fix bad assert.

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -723,10 +723,7 @@ static struct io_plan *conn_init(struct io_conn *conn,
 			      "Can't connect to forproxy address");
 		break;
 	case ADDR_INTERNAL_WIREADDR:
-		/* DNS should have been resolved before */
-		assert(addr->u.wireaddr.wireaddr.type != ADDR_TYPE_DNS);
-		/* If it was a Tor address, we wouldn't be here. */
-		assert(!is_toraddr((char*)addr->u.wireaddr.wireaddr.addr));
+		/* DNS should have been resolved before, and Tor should not be here! */
 		ai = wireaddr_to_addrinfo(tmpctx, &addr->u.wireaddr.wireaddr);
 		break;
 	}


### PR DESCRIPTION
This code was trying to check that the address type is not one of the ADDR_TYPE_TOR* types, but the is_toraddr() function checks a domain name!  The cast should have been a clue that this was wrong!

Anyway, wireaddr_to_addrinfo() aborts on these cases already, so the asserts here are superfluous.

Found in unrelated CI run:

```
Valgrind error file: valgrind-errors.20610
==20610== Conditional jump or move depends on uninitialised value(s)
==20610==    at 0x484ED28: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20610==    by 0x138FA3: is_toraddr (wireaddr.c:344)
==20610==    by 0x11499B: conn_init (connectd.c:729)
==20610==    by 0x28FD73: next_plan (io.c:59)
==20610==    by 0x28FF94: io_new_conn_ (io.c:116)
==20610==    by 0x11531B: try_connect_one_addr (connectd.c:927)
==20610==    by 0x1182A8: try_connect_peer (connectd.c:1781)
==20610==    by 0x11834E: connect_to_peer (connectd.c:1797)
==20610==    by 0x119241: recv_req (connectd.c:2074)
==20610==    by 0x12836F: handle_read (daemon_conn.c:35)
==20610==    by 0x28FD73: next_plan (io.c:59)
==20610==    by 0x2909A8: do_plan (io.c:407)
==20610==
```