### PR TITLE
Add --bitcoin-rpcclienttimeout CLI parameter

### DIFF
--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -132,6 +132,12 @@ This is not valid within the per-network configuration file.
 
   The bitcoind(1) RPC port to connect to.
 
+* **bitcoin-rpcclienttimeout**=*SECONDS* [plugin `bcli`]
+
+  The bitcoind(1) RPC client timeout in seconds. Default is set to 60
+instead of 900 to match bitcoin-retry-timeout default. When set
+explicitly, the higher value of it and bitcoin-retry-timeout is used.
+
 * **bitcoin-retry-timeout**=*SECONDS* [plugin `bcli`]
 
   Number of seconds to keep trying a bitcoin-cli(1) command. If the

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -59,6 +59,7 @@ struct bitcoind {
 
 	/* Passthrough parameters for bitcoin-cli */
 	char *rpcuser, *rpcpass, *rpcconnect, *rpcport;
+	u64 rpcclienttimeout;
 
 	/* Whether we fake fees (regtest) */
 	bool fake_fees;
@@ -104,6 +105,16 @@ static const char **gather_argsv(const tal_t *ctx, const char *cmd, va_list ap)
 		add_arg(&args, chainparams->cli_args);
 	if (bitcoind->datadir)
 		add_arg(&args, tal_fmt(args, "-datadir=%s", bitcoind->datadir));
+	if (bitcoind->rpcclienttimeout) {
+		/* Use the maximum value of rpcclienttimeout and retry_timeout to avoid
+		   the bitcoind backend hanging for too long. */
+		if (bitcoind->retry_timeout &&
+		    bitcoind->retry_timeout > bitcoind->rpcclienttimeout)
+			bitcoind->rpcclienttimeout = bitcoind->retry_timeout;
+
+		add_arg(&args,
+			tal_fmt(args, "-rpcclienttimeout=%ld", bitcoind->rpcclienttimeout));
+	}
 	if (bitcoind->rpcconnect)
 		add_arg(&args,
 			tal_fmt(args, "-rpcconnect=%s", bitcoind->rpcconnect));
@@ -1105,6 +1116,9 @@ static struct bitcoind *new_bitcoind(const tal_t *ctx)
 	bitcoind->rpcpass = NULL;
 	bitcoind->rpcconnect = NULL;
 	bitcoind->rpcport = NULL;
+	/* Do not exceed retry_timeout value to avoid a bitcoind hang,
+	   although normal rpcclienttimeout default value is 900. */
+	bitcoind->rpcclienttimeout = 60;
 	bitcoind->dev_no_fake_fees = false;
 
 	return bitcoind;
@@ -1144,6 +1158,10 @@ int main(int argc, char *argv[])
 				  "int",
 				  "bitcoind RPC host's port",
 				  charp_option, &bitcoind->rpcport),
+		    plugin_option("bitcoin-rpcclienttimeout",
+				  "int",
+				  "bitcoind RPC timeout in seconds during HTTP requests",
+				  u64_option, &bitcoind->rpcclienttimeout),
 		    plugin_option("bitcoin-retry-timeout",
 				  "string",
 				  "how long to keep retrying to contact bitcoind"


### PR DESCRIPTION
This is a first pass at #2817.  It adds a `--bitcoin-rpcclienttimeout` parameter to `bcli`. It seems those parameters are automatically pulled in as `lightningd` parameters as well. Instead of setting the default value at `900` per the `bitcoind`, we set it to match the `retry_timeout` and then choose the maximum value from arguments gathered by the user.

Don't have much experience in C, but open to learn and contribute to this project where I can.