### PR TITLE
hsmtool.c - Fixes cosmetic off-by-one error 

### DIFF
--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -474,7 +474,7 @@ static void get_words(struct words **words) {
 	for (size_t i = 0; i < ARRAY_SIZE(languages); i++) {
 		printf("  %zu) %s (%s)\n", i, languages[i].name, languages[i].abbr);
 	}
-	printf("Select [0-%zu]: ", ARRAY_SIZE(languages));
+	printf("Select [0-%zu]: ", ARRAY_SIZE(languages)-1);
 	fflush(stdout);
 
 	char *selected = NULL;


### PR DESCRIPTION
This line is a cosmetic off-by-one error. There are 7 languages defined, but because counting starts at 0, the display shows "Select [0-7]" when in fact only 0-6 are valid choices.