### PR TITLE
Faster block sync

### DIFF
--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -10,6 +10,9 @@
 #include <common/utils.h>
 #include <sodium/randombytes.h>
 
+/* To push 0-75 bytes onto stack. */
+#define OP_PUSHBYTES(val) (val)
+
 /* Bitcoin's OP_HASH160 is RIPEMD(SHA256()) */
 static void hash160(struct ripemd160 *redeemhash, const void *mem, size_t len)
 {

--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -476,10 +476,8 @@ u8 *p2wpkh_scriptcode(const tal_t *ctx, const struct pubkey *key)
 	return script;
 }
 
-bool is_p2pkh(const u8 *script, struct bitcoin_address *addr)
+bool is_p2pkh(const u8 *script, size_t script_len, struct bitcoin_address *addr)
 {
-	size_t script_len = tal_count(script);
-
 	if (script_len != BITCOIN_SCRIPTPUBKEY_P2PKH_LEN)
 		return false;
 	if (script[0] != OP_DUP)
@@ -497,10 +495,8 @@ bool is_p2pkh(const u8 *script, struct bitcoin_address *addr)
 	return true;
 }
 
-bool is_p2sh(const u8 *script, struct ripemd160 *addr)
+bool is_p2sh(const u8 *script, size_t script_len, struct ripemd160 *addr)
 {
-	size_t script_len = tal_count(script);
-
 	if (script_len != BITCOIN_SCRIPTPUBKEY_P2SH_LEN)
 		return false;
 	if (script[0] != OP_HASH160)
@@ -514,10 +510,8 @@ bool is_p2sh(const u8 *script, struct ripemd160 *addr)
 	return true;
 }
 
-bool is_p2wsh(const u8 *script, struct sha256 *addr)
+bool is_p2wsh(const u8 *script, size_t script_len, struct sha256 *addr)
 {
-	size_t script_len = tal_count(script);
-
 	if (script_len != BITCOIN_SCRIPTPUBKEY_P2WSH_LEN)
 		return false;
 	if (script[0] != OP_0)
@@ -529,10 +523,8 @@ bool is_p2wsh(const u8 *script, struct sha256 *addr)
 	return true;
 }
 
-bool is_p2wpkh(const u8 *script, struct bitcoin_address *addr)
+bool is_p2wpkh(const u8 *script, size_t script_len, struct bitcoin_address *addr)
 {
-	size_t script_len = tal_count(script);
-
 	if (script_len != BITCOIN_SCRIPTPUBKEY_P2WPKH_LEN)
 		return false;
 	if (script[0] != OP_0)
@@ -544,10 +536,8 @@ bool is_p2wpkh(const u8 *script, struct bitcoin_address *addr)
 	return true;
 }
 
-bool is_p2tr(const u8 *script, u8 xonly_pubkey[32])
+bool is_p2tr(const u8 *script, size_t script_len, u8 xonly_pubkey[32])
 {
-	size_t script_len = tal_count(script);
-
 	if (script_len != BITCOIN_SCRIPTPUBKEY_P2TR_LEN)
 		return false;
 	if (script[0] != OP_1)
@@ -560,17 +550,20 @@ bool is_p2tr(const u8 *script, u8 xonly_pubkey[32])
 	return true;
 }
 
-bool is_known_scripttype(const u8 *script)
+bool is_known_scripttype(const u8 *script, size_t script_len)
 {
-	return is_p2wpkh(script, NULL) || is_p2wsh(script, NULL)
-		|| is_p2sh(script, NULL) || is_p2pkh(script, NULL)
-		|| is_p2tr(script, NULL);
+	return is_p2wpkh(script, script_len, NULL)
+		|| is_p2wsh(script, script_len, NULL)
+		|| is_p2sh(script, script_len, NULL)
+		|| is_p2pkh(script, script_len, NULL)
+		|| is_p2tr(script, script_len, NULL);
 }
 
-bool is_known_segwit_scripttype(const u8 *script)
+bool is_known_segwit_scripttype(const u8 *script, size_t script_len)
 {
-	return is_p2wpkh(script, NULL) || is_p2wsh(script, NULL)
-		|| is_p2tr(script, NULL);
+	return is_p2wpkh(script, script_len, NULL)
+		|| is_p2wsh(script, script_len, NULL)
+		|| is_p2tr(script, script_len, NULL);
 }
 
 u8 **bitcoin_witness_sig_and_element(const tal_t *ctx,

--- a/bitcoin/script.c
+++ b/bitcoin/script.c
@@ -993,12 +993,8 @@ bool is_anchor_witness_script(const u8 *script, size_t script_len)
 
 bool scripteq(const u8 *s1, const u8 *s2)
 {
-	memcheck(s1, tal_count(s1));
-	memcheck(s2, tal_count(s2));
-
-	if (tal_count(s1) != tal_count(s2))
-		return false;
-	if (tal_count(s1) == 0)
-		return true;
-	return memcmp(s1, s2, tal_count(s1)) == 0;
+	size_t s1_len = tal_count(s1), s2_len = tal_count(s2);
+	memcheck(s1, s1_len);
+	memcheck(s2, s2_len);
+	return memeq(s1, s1_len, s2, s2_len);
 }

--- a/bitcoin/script.h
+++ b/bitcoin/script.h
@@ -13,9 +13,6 @@ struct ripemd160;
 struct rel_locktime;
 struct abs_locktime;
 
-/* To push 0-75 bytes onto stack. */
-#define OP_PUSHBYTES(val) (val)
-
 /* tal_count() gives the length of the script. */
 u8 *bitcoin_redeem_2of2(const tal_t *ctx,
 			const struct pubkey *key1,

--- a/bitcoin/script.h
+++ b/bitcoin/script.h
@@ -159,25 +159,25 @@ u8 *bitcoin_wscript_anchor(const tal_t *ctx,
 			   const struct pubkey *funding_pubkey);
 
 /* Is this a pay to pubkey hash? (extract addr if not NULL) */
-bool is_p2pkh(const u8 *script, struct bitcoin_address *addr);
+bool is_p2pkh(const u8 *script, size_t script_len, struct bitcoin_address *addr);
 
 /* Is this a pay to script hash? (extract addr if not NULL) */
-bool is_p2sh(const u8 *script, struct ripemd160 *addr);
+bool is_p2sh(const u8 *script, size_t script_len, struct ripemd160 *addr);
 
 /* Is this (version 0) pay to witness script hash? (extract addr if not NULL) */
-bool is_p2wsh(const u8 *script, struct sha256 *addr);
+bool is_p2wsh(const u8 *script, size_t script_len, struct sha256 *addr);
 
 /* Is this (version 0) pay to witness pubkey hash? (extract addr if not NULL) */
-bool is_p2wpkh(const u8 *script, struct bitcoin_address *addr);
+bool is_p2wpkh(const u8 *script, size_t script_len, struct bitcoin_address *addr);
 
 /* Is this a taproot output? (extract xonly_pubkey bytes if not NULL) */
-bool is_p2tr(const u8 *script, u8 xonly_pubkey[32]);
+bool is_p2tr(const u8 *script, size_t script_len, u8 xonly_pubkey[32]);
 
 /* Is this one of the above script types? */
-bool is_known_scripttype(const u8 *script);
+bool is_known_scripttype(const u8 *script, size_t script_len);
 
 /* Is this a witness script type? */
-bool is_known_segwit_scripttype(const u8 *script);
+bool is_known_segwit_scripttype(const u8 *script, size_t script_len);
 
 /* Is this a to-remote witness script (used for option_anchor_outputs)? */
 bool is_to_remote_anchored_witness_script(const u8 *script, size_t script_len);

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -302,28 +302,6 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 	wally_psbt_output_set_amount(&tx->psbt->outputs[outnum], satoshis);
 }
 
-const u8 *cln_wally_tx_output_get_script(const tal_t *ctx,
-					 const struct wally_tx_output *output)
-{
-	if (output->script == NULL) {
-		/* This can happen for coinbase transactions and pegin
-		 * transactions */
-		return NULL;
-	}
-
-	return tal_dup_arr(ctx, u8, output->script, output->script_len, 0);
-}
-
-const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
-				       const struct bitcoin_tx *tx, int outnum)
-{
-	const struct wally_tx_output *output;
-	assert(outnum < tx->wtx->num_outputs);
-	output = &tx->wtx->outputs[outnum];
-
-	return cln_wally_tx_output_get_script(ctx, output);
-}
-
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx,
 				    int outnum)
 {

--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -324,16 +324,6 @@ const u8 *bitcoin_tx_output_get_script(const tal_t *ctx,
 	return cln_wally_tx_output_get_script(ctx, output);
 }
 
-bool bitcoin_tx_output_script_is_p2wsh(const struct bitcoin_tx *tx, int outnum)
-{	const struct wally_tx_output *output;
-	assert(outnum < tx->wtx->num_outputs);
-	output = &tx->wtx->outputs[outnum];
-
-	return output->script_len == BITCOIN_SCRIPTPUBKEY_P2WSH_LEN &&
-	       output->script[0] == OP_0 &&
-	       output->script[1] == OP_PUSHBYTES(sizeof(struct sha256));
-}
-
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx,
 				    int outnum)
 {

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -145,25 +145,6 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 				  struct amount_sat amount);
 
 /**
- * Helper to get the script of a script's output as a tal_arr
- *
- * Internally we use a `wally_tx` to represent the transaction. The script
- * attached to a `wally_tx_output` is not a `tal_arr`, so in order to keep the
- * comfort of being able to call `tal_bytelen` and similar on a script we just
- * return a `tal_arr` clone of the original script.
- */
-const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
-
-/**
- * Helper to get the script of a script's output as a tal_arr
- *
- * The script attached to a `wally_tx_output` is not a `tal_arr`, so in order to keep the
- * comfort of being able to call `tal_bytelen` and similar on a script we just
- * return a `tal_arr` clone of the original script.
- */
-const u8 *cln_wally_tx_output_get_script(const tal_t *ctx,
-					 const struct wally_tx_output *output);
-/**
  * Helper to get a witness script for an output.
  */
 u8 *bitcoin_tx_output_get_witscript(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);

--- a/bitcoin/tx.h
+++ b/bitcoin/tx.h
@@ -155,14 +155,6 @@ void bitcoin_tx_output_set_amount(struct bitcoin_tx *tx, int outnum,
 const u8 *bitcoin_tx_output_get_script(const tal_t *ctx, const struct bitcoin_tx *tx, int outnum);
 
 /**
- * Return `true` if the given output is a P2WSH output.
- *
- * This is useful if you want to peek at the script, without having to
- * extract it first.
- */
-bool bitcoin_tx_output_script_is_p2wsh(const struct bitcoin_tx *tx, int outnum);
-
-/**
  * Helper to get the script of a script's output as a tal_arr
  *
  * The script attached to a `wally_tx_output` is not a `tal_arr`, so in order to keep the

--- a/channeld/watchtower.c
+++ b/channeld/watchtower.c
@@ -80,8 +80,12 @@ penalty_tx_create(const tal_t *ctx,
 
 	bitcoin_tx_add_output(tx, final_scriptpubkey, NULL, to_them_sats);
 	assert((final_index == NULL) == (final_ext_key == NULL));
-	if (final_index)
-		psbt_add_keypath_to_last_output(tx, *final_index, final_ext_key, is_p2tr(final_scriptpubkey, NULL));
+	if (final_index) {
+		size_t script_len = tal_bytelen(final_scriptpubkey);
+		bool is_tr = is_p2tr(final_scriptpubkey, script_len, NULL);
+		psbt_add_keypath_to_last_output(tx, *final_index,
+						final_ext_key, is_tr);
+        }
 
 	/* Worst-case sig is 73 bytes */
 	weight = bitcoin_tx_weight(tx) + 1 + 3 + 73 + 0 + tal_count(wscript);

--- a/common/addr.c
+++ b/common/addr.c
@@ -7,30 +7,31 @@
 
 char *encode_scriptpubkey_to_addr(const tal_t *ctx,
 				  const struct chainparams *chainparams,
-				  const u8 *scriptPubkey)
+				  const u8 *scriptpubkey)
 {
 	char *out;
-	size_t scriptLen = tal_bytelen(scriptPubkey);
+	const size_t script_len = tal_bytelen(scriptpubkey);
 	struct bitcoin_address pkh;
 	struct ripemd160 sh;
 	int witver;
 
-	if (is_p2pkh(scriptPubkey, &pkh))
+	if (is_p2pkh(scriptpubkey, script_len, &pkh))
 		return bitcoin_to_base58(ctx, chainparams, &pkh);
 
-	if (is_p2sh(scriptPubkey, &sh))
+	if (is_p2sh(scriptpubkey, script_len, &sh))
 		return p2sh_to_base58(ctx, chainparams, &sh);
 
 	out = tal_arr(ctx, char, 73 + strlen(chainparams->onchain_hrp));
-	if (is_p2tr(scriptPubkey, NULL))
+	if (is_p2tr(scriptpubkey, script_len, NULL))
 		witver = 1;
-	else if (is_p2wpkh(scriptPubkey, NULL) || is_p2wsh(scriptPubkey, NULL))
+	else if (is_p2wpkh(scriptpubkey, script_len, NULL)
+		 || is_p2wsh(scriptpubkey, script_len, NULL))
 		witver = 0;
 	else {
 		return tal_free(out);
 	}
 	if (!segwit_addr_encode(out, chainparams->onchain_hrp, witver,
-				scriptPubkey + 2, scriptLen - 2))
+				scriptpubkey + 2, script_len - 2))
 		return tal_free(out);
 
 	return out;

--- a/common/addr.c
+++ b/common/addr.c
@@ -21,15 +21,15 @@ char *encode_scriptpubkey_to_addr(const tal_t *ctx,
 	if (is_p2sh(scriptpubkey, script_len, &sh))
 		return p2sh_to_base58(ctx, chainparams, &sh);
 
-	out = tal_arr(ctx, char, 73 + strlen(chainparams->onchain_hrp));
 	if (is_p2tr(scriptpubkey, script_len, NULL))
 		witver = 1;
 	else if (is_p2wpkh(scriptpubkey, script_len, NULL)
 		 || is_p2wsh(scriptpubkey, script_len, NULL))
 		witver = 0;
 	else {
-		return tal_free(out);
+		return NULL;
 	}
+	out = tal_arr(ctx, char, 73 + strlen(chainparams->onchain_hrp));
 	if (!segwit_addr_encode(out, chainparams->onchain_hrp, witver,
 				scriptpubkey + 2, script_len - 2))
 		return tal_free(out);

--- a/common/addr.h
+++ b/common/addr.h
@@ -6,6 +6,6 @@
 /* Given a scriptPubkey, return an encoded address for p2pkh/p2w{pkh,sh}/p2tr */
 char *encode_scriptpubkey_to_addr(const tal_t *ctx,
 				  const struct chainparams *chainparams,
-				  const u8 *scriptPubkey);
+				  const u8 *scriptpubkey);
 
 #endif /* LIGHTNING_COMMON_ADDR_H */

--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -1133,6 +1133,7 @@ static void encode_f(u5 **data, const u8 *fallback)
 	struct bitcoin_address pkh;
 	struct ripemd160 sh;
 	struct sha256 wsh;
+	const size_t fallback_len = tal_bytelen(fallback);
 
 	/* BOLT #11:
 	 *
@@ -1140,15 +1141,15 @@ static void encode_f(u5 **data, const u8 *fallback)
 	 * witness version and program, OR to `17` followed by a
 	 * public key hash, OR to `18` followed by a script hash.
 	 */
-	if (is_p2pkh(fallback, &pkh)) {
+	if (is_p2pkh(fallback, fallback_len, &pkh)) {
 		push_fallback_addr(data, 17, &pkh, sizeof(pkh));
-	} else if (is_p2sh(fallback, &sh)) {
+	} else if (is_p2sh(fallback, fallback_len, &sh)) {
 		push_fallback_addr(data, 18, &sh, sizeof(sh));
-	} else if (is_p2wpkh(fallback, &pkh)) {
+	} else if (is_p2wpkh(fallback, fallback_len, &pkh)) {
 		push_fallback_addr(data, 0, &pkh, sizeof(pkh));
-	} else if (is_p2wsh(fallback, &wsh)) {
+	} else if (is_p2wsh(fallback, fallback_len, &wsh)) {
 		push_fallback_addr(data, 0, &wsh, sizeof(wsh));
-	} else if (tal_count(fallback) > 1
+	} else if (fallback_len > 1
 		   && fallback[0] >= 0x50
 		   && fallback[0] < (0x50+16)) {
 		/* Other (future) witness versions: turn OP_N into N */
@@ -1157,7 +1158,7 @@ static void encode_f(u5 **data, const u8 *fallback)
 	} else {
 		/* Copy raw. */
 		push_field(data, 'f',
-			   fallback, tal_count(fallback) * CHAR_BIT);
+			   fallback, fallback_len * CHAR_BIT);
 	}
 }
 

--- a/common/bolt11_json.c
+++ b/common/bolt11_json.c
@@ -15,17 +15,18 @@ static void json_add_fallback(struct json_stream *response,
 			      const struct chainparams *chain)
 {
 	char *addr;
+	const size_t fallback_len = tal_bytelen(fallback);
 
 	json_object_start(response, fieldname);
-	if (is_p2pkh(fallback, NULL)) {
+	if (is_p2pkh(fallback, fallback_len, NULL)) {
 		json_add_string(response, "type", "P2PKH");
-	} else if (is_p2sh(fallback, NULL)) {
+	} else if (is_p2sh(fallback, fallback_len, NULL)) {
 		json_add_string(response, "type", "P2SH");
-	} else if (is_p2wpkh(fallback, NULL)) {
+	} else if (is_p2wpkh(fallback, fallback_len, NULL)) {
 		json_add_string(response, "type", "P2WPKH");
-	} else if (is_p2wsh(fallback, NULL)) {
+	} else if (is_p2wsh(fallback, fallback_len, NULL)) {
 		json_add_string(response, "type", "P2WSH");
-	} else if (is_p2tr(fallback, NULL)) {
+	} else if (is_p2tr(fallback, fallback_len, NULL)) {
 		json_add_string(response, "type", "P2TR");
 	}
 

--- a/common/close_tx.c
+++ b/common/close_tx.c
@@ -50,9 +50,12 @@ struct bitcoin_tx *create_close_tx(const tal_t *ctx,
 		/* One output is to us. */
 		bitcoin_tx_add_output(tx, script, NULL, to_us);
 		assert((local_wallet_index == NULL) == (local_wallet_ext_key == NULL));
-		if (local_wallet_index)
+		if (local_wallet_index) {
+			size_t script_len = tal_bytelen(script);
 			psbt_add_keypath_to_last_output(
-				tx, *local_wallet_index, local_wallet_ext_key, is_p2tr(script, NULL));
+				tx, *local_wallet_index, local_wallet_ext_key,
+				is_p2tr(script, script_len, NULL));
+                }
 		num_outputs++;
 	}
 

--- a/common/shutdown_scriptpubkey.c
+++ b/common/shutdown_scriptpubkey.c
@@ -8,11 +8,11 @@
  *         push of 2 to 40 bytes
  *         (witness program versions 1 through 16)
  */
-static bool is_valid_witnessprog(const u8 *scriptpubkey)
+static bool is_valid_witnessprog(const u8 *scriptpubkey, size_t scriptpubkey_len)
 {
 	size_t pushlen;
 
-	if (tal_bytelen(scriptpubkey) < 2)
+	if (scriptpubkey_len < 2)
 		return false;
 
 	switch (scriptpubkey[0]) {
@@ -39,7 +39,7 @@ static bool is_valid_witnessprog(const u8 *scriptpubkey)
 
 	pushlen = scriptpubkey[1];
 	/* Must be all of the rest of scriptpubkey */
-	if (2 + pushlen != tal_bytelen(scriptpubkey)) {
+	if (2 + pushlen != scriptpubkey_len) {
 		return false;
 	}
 
@@ -50,13 +50,14 @@ bool valid_shutdown_scriptpubkey(const u8 *scriptpubkey,
 				 bool anysegwit,
 				 bool allow_oldstyle)
 {
+	const size_t script_len = tal_bytelen(scriptpubkey);
 	if (allow_oldstyle) {
-		if (is_p2pkh(scriptpubkey, NULL)
-		    || is_p2sh(scriptpubkey, NULL))
+		if (is_p2pkh(scriptpubkey, script_len, NULL)
+		    || is_p2sh(scriptpubkey, script_len, NULL))
 			return true;
 	}
 
-	return is_p2wpkh(scriptpubkey, NULL)
-		|| is_p2wsh(scriptpubkey, NULL)
-		|| (anysegwit && is_valid_witnessprog(scriptpubkey));
+	return is_p2wpkh(scriptpubkey, script_len, NULL)
+		|| is_p2wsh(scriptpubkey, script_len, NULL)
+		|| (anysegwit && is_valid_witnessprog(scriptpubkey, script_len));
 }

--- a/devtools/bolt11-cli.c
+++ b/devtools/bolt11-cli.c
@@ -123,23 +123,25 @@ int main(int argc, char *argv[])
                 struct bitcoin_address pkh;
                 struct ripemd160 sh;
                 struct sha256 wsh;
+                const u8 *fallback = b11->fallbacks[i];
+                const size_t fallback_len = tal_bytelen(fallback);
 
-		printf("fallback: %s\n", tal_hex(ctx, b11->fallbacks[i]));
-                if (is_p2pkh(b11->fallbacks[i], &pkh)) {
+		printf("fallback: %s\n", tal_hex(ctx, fallback));
+                if (is_p2pkh(fallback, fallback_len, &pkh)) {
 			printf("fallback-P2PKH: %s\n",
 			       bitcoin_to_base58(ctx, b11->chain,
 						 &pkh));
-                } else if (is_p2sh(b11->fallbacks[i], &sh)) {
+                } else if (is_p2sh(fallback, fallback_len, &sh)) {
 			printf("fallback-P2SH: %s\n",
 			       p2sh_to_base58(ctx,
 					      b11->chain,
 					      &sh));
-                } else if (is_p2wpkh(b11->fallbacks[i], &pkh)) {
+                } else if (is_p2wpkh(fallback, fallback_len, &pkh)) {
                         char out[73 + strlen(b11->chain->onchain_hrp)];
                         if (segwit_addr_encode(out, b11->chain->onchain_hrp, 0,
                                                (const u8 *)&pkh, sizeof(pkh)))
 				printf("fallback-P2WPKH: %s\n", out);
-                } else if (is_p2wsh(b11->fallbacks[i], &wsh)) {
+                } else if (is_p2wsh(fallback, fallback_len, &wsh)) {
                         char out[73 + strlen(b11->chain->onchain_hrp)];
                         if (segwit_addr_encode(out, b11->chain->onchain_hrp, 0,
                                                (const u8 *)&wsh, sizeof(wsh)))

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -548,7 +548,9 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 			 * requires the HSM to find the pubkey, and we
 			 * skip doing that until now as a bit of a reduction
 			 * of complexity in the calling code */
-			psbt_input_add_pubkey(psbt, j, &pubkey, utxo->scriptPubkey && is_p2tr(utxo->scriptPubkey, NULL));
+			const size_t script_len = tal_bytelen(utxo->scriptPubkey);
+			psbt_input_add_pubkey(psbt, j, &pubkey,
+					      is_p2tr(utxo->scriptPubkey, script_len, NULL));
 
 			/* It's actually a P2WSH in this case. */
 			if (utxo->close_info && utxo->close_info->option_anchors) {

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -965,12 +965,11 @@ static void topo_add_utxos(struct chain_topology *topo, struct block *b)
 			if (!amount_asset_is_main(&amt))
 				continue; /* Ignore non-policy asset outputs */
 
-			if (!bitcoin_tx_output_script_is_p2wsh(tx, n))
+			const u8 *script = bitcoin_tx_output_get_script(tmpctx, tx, n);
+			if (!is_p2wsh(script, NULL))
 				continue; /* We only care about p2wsh utxos */
 
 			struct bitcoin_outpoint outpoint = { b->txids[i], n };
-			const u8 *script =
-			    bitcoin_tx_output_get_script(tmpctx, tx, n);
 			wallet_utxoset_add(topo->ld->wallet, &outpoint,
 					   b->height, i, script,
 					   amount_asset_to_sat(&amt));

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -461,12 +461,10 @@ void peer_start_closingd(struct channel *channel, struct peer_fd *peer_fd)
 	struct ext_key *local_wallet_ext_key = NULL;
 	u32 index_val;
 	struct ext_key ext_key_val;
-	bool is_p2sh;
 	if (wallet_can_spend(
 		    ld->wallet,
 		    channel->shutdown_scriptpubkey[LOCAL],
-		    &index_val,
-		    &is_p2sh)) {
+		    &index_val)) {
 		if (bip32_key_from_parent(
 			    ld->bip32_base,
 			    index_val,
@@ -690,8 +688,6 @@ static struct command_result *json_close(struct command *cmd,
 	assert(channel->final_key_idx <= UINT32_MAX);
 
 	if (close_to_script) {
-		bool is_p2sh;
-
 		if (!tal_arr_eq(close_to_script, channel->shutdown_scriptpubkey[LOCAL])
 		    && !cmd->ld->dev_allow_shutdown_destination_change) {
 			const u8 *defp2tr, *defp2wpkh;
@@ -727,7 +723,7 @@ static struct command_result *json_close(struct command *cmd,
 
 		/* If they give a local address, adjust final_key_idx. */
 		if (!wallet_can_spend(cmd->ld->wallet, close_to_script,
-				      &final_key_idx, &is_p2sh)) {
+				      &final_key_idx)) {
 			final_key_idx = channel->final_key_idx;
 		}
 	} else {

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -179,19 +179,15 @@ static struct amount_sat calc_tx_fee(struct amount_sat sat_in,
 {
 	struct amount_asset amt;
 	struct amount_sat fee = sat_in;
-	const u8 *oscript;
-	size_t scriptlen;
-	for (size_t i = 0; i < tx->wtx->num_outputs; i++) {
-		amt = bitcoin_tx_output_get_amount(tx, i);
-		oscript = bitcoin_tx_output_get_script(NULL, tx, i);
-		scriptlen = tal_bytelen(oscript);
-		tal_free(oscript);
 
-		if (chainparams->is_elements && scriptlen == 0)
+	for (size_t i = 0; i < tx->wtx->num_outputs; i++) {
+		const struct wally_tx_output *txout = &tx->wtx->outputs[i];
+		if (chainparams->is_elements && !txout->script_len)
 			continue;
 
 		/* Ignore outputs that are not denominated in our main
 		 * currency. */
+		amt = bitcoin_tx_output_get_amount(tx, i);
 		if (!amount_asset_is_main(&amt))
 			continue;
 

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -698,11 +698,9 @@ openchannel2_hook_cb(struct openchannel2_payload *payload STEALS)
 	/* Determine the wallet index for our_shutdown_scriptpubkey,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(dualopend->ld->wallet,
 			     payload->our_shutdown_scriptpubkey,
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		our_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*our_shutdown_script_wallet_index = found_wallet_index;
 	} else
@@ -3176,11 +3174,9 @@ static struct command_result *json_openchannel_init(struct command *cmd,
 	/* Determine the wallet index for our_upfront_shutdown_script,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(cmd->ld->wallet,
 			     oa->our_upfront_shutdown_script,
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		our_upfront_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*our_upfront_shutdown_script_wallet_index = found_wallet_index;
 	} else
@@ -3776,11 +3772,9 @@ static struct command_result *json_queryrates(struct command *cmd,
 	/* Determine the wallet index for our_upfront_shutdown_script,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(cmd->ld->wallet,
 			     oa->our_upfront_shutdown_script,
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		our_upfront_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*our_upfront_shutdown_script_wallet_index = found_wallet_index;
 	} else
@@ -4126,11 +4120,9 @@ bool peer_restart_dualopend(struct peer *peer,
 	/* Determine the wallet index for the LOCAL shutdown_scriptpubkey,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(peer->ld->wallet,
 			     channel->shutdown_scriptpubkey[LOCAL],
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		local_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*local_shutdown_script_wallet_index = found_wallet_index;
 	} else

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -717,11 +717,9 @@ openchannel_hook_final(struct openchannel_hook_payload *payload STEALS)
 	/* Determine the wallet index for our_upfront_shutdown_script,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(payload->openingd->ld->wallet,
 			     our_upfront_shutdown_script,
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		upfront_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*upfront_shutdown_script_wallet_index = found_wallet_index;
 	} else
@@ -1321,11 +1319,9 @@ static struct command_result *json_fundchannel_start(struct command *cmd,
 	/* Determine the wallet index for our_upfront_shutdown_script,
 	 * NULL if not found. */
 	u32 found_wallet_index;
-	bool is_p2sh;
 	if (wallet_can_spend(fc->cmd->ld->wallet,
 			     fc->our_upfront_shutdown_script,
-			     &found_wallet_index,
-			     &is_p2sh)) {
+			     &found_wallet_index)) {
 		upfront_shutdown_script_wallet_index = tal(tmpctx, u32);
 		*upfront_shutdown_script_wallet_index = found_wallet_index;
 	} else

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -2050,10 +2050,9 @@ static const size_t *match_htlc_output(const tal_t *ctx,
 				       u8 **htlc_scripts)
 {
 	size_t *matches = tal_arr(ctx, size_t, 0);
-	const u8 *script = tal_dup_arr(tmpctx, u8, out->script, out->script_len,
-				       0);
+
 	/* Must be a p2wsh output */
-	if (!is_p2wsh(script, NULL))
+	if (!is_p2wsh(out->script, out->script_len, NULL))
 		return matches;
 
 	for (size_t i = 0; i < tal_count(htlc_scripts); i++) {
@@ -2062,7 +2061,7 @@ static const size_t *match_htlc_output(const tal_t *ctx,
 			continue;
 
 		sha256(&sha, htlc_scripts[i], tal_count(htlc_scripts[i]));
-		if (memeq(script + 2, tal_count(script) - 2, &sha, sizeof(sha)))
+		if (memeq(out->script + 2, out->script_len - 2, &sha, sizeof(sha)))
 			tal_arr_expand(&matches, i);
 	}
 	return matches;

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -993,8 +993,7 @@ static char *check_balances(const tal_t *ctx,
 
 static bool is_segwit_output(struct wally_tx_output *output)
 {
-	const u8 *script = cln_wally_tx_output_get_script(tmpctx, output);
-	return is_known_segwit_scripttype(script);
+	return is_known_segwit_scripttype(output->script, output->script_len);
 }
 
 static void set_remote_upfront_shutdown(struct state *state,
@@ -1973,7 +1972,7 @@ static bool run_tx_interactive(struct state *state,
 			 * The receiving node: ...
 			 * - MAY fail the negotiation if `script`
 			 *   is non-standard */
-			if (!is_known_scripttype(scriptpubkey)) {
+			if (!is_known_scripttype(scriptpubkey, tal_bytelen(scriptpubkey))) {
 				open_abort(state, "Script is not standard");
 				return false;
 			}

--- a/wallet/txfilter.c
+++ b/wallet/txfilter.c
@@ -84,12 +84,8 @@ void txfilter_add_derkey(struct txfilter *filter,
 bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx)
 {
 	for (size_t i = 0; i < tx->wtx->num_outputs; i++) {
-		const u8 *oscript = bitcoin_tx_output_get_script(tmpctx, tx, i);
-
-		if (!oscript)
-			continue;
-
-		if (scriptpubkeyset_get(&filter->scriptpubkeyset, oscript))
+		const struct wally_tx_output *txout = &tx->wtx->outputs[i];
+		if (txfilter_scriptpubkey_matches(filter, txout->script))
 			return true;
 	}
 	return false;
@@ -97,6 +93,8 @@ bool txfilter_match(const struct txfilter *filter, const struct bitcoin_tx *tx)
 
 bool txfilter_scriptpubkey_matches(const struct txfilter *filter, const u8 *scriptPubKey)
 {
+	if (!scriptPubKey)
+		return false;
 	return scriptpubkeyset_get(&filter->scriptpubkeyset, scriptPubKey) != NULL;
 }
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -815,11 +815,11 @@ bool wallet_can_spend(struct wallet *w, const u8 *script,
 
 	bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
 	for (i = 0; i <= bip32_max_index + w->keyscan_gap; i++) {
+		const u32 flags = BIP32_FLAG_KEY_PUBLIC | BIP32_FLAG_SKIP_HASH;
 		u8 *s;
 
 		if (bip32_key_from_parent(w->ld->bip32_base, i,
-					  BIP32_FLAG_KEY_PUBLIC, &ext)
-		    != WALLY_OK) {
+					  flags, &ext) != WALLY_OK) {
 			abort();
 		}
 		s = scriptpubkey_p2wpkh_derkey(w, ext.pub_key);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -798,7 +798,7 @@ bool wallet_can_spend(struct wallet *w, const u8 *script,
 		      u32 *index, bool *output_is_p2sh)
 {
 	struct ext_key ext;
-	u64 bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
+	u64 bip32_max_index;
 	size_t script_len = tal_bytelen(script);
 	u32 i;
 
@@ -812,6 +812,7 @@ bool wallet_can_spend(struct wallet *w, const u8 *script,
 	else
 		return false;
 
+	bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
 	for (i = 0; i <= bip32_max_index + w->keyscan_gap; i++) {
 		u8 *s;
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -799,14 +799,15 @@ bool wallet_can_spend(struct wallet *w, const u8 *script,
 {
 	struct ext_key ext;
 	u64 bip32_max_index = db_get_intvar(w->db, "bip32_max_index", 0);
+	size_t script_len = tal_bytelen(script);
 	u32 i;
 
 	/* If not one of these, can't be for us. */
-	if (is_p2sh(script, NULL))
+	if (is_p2sh(script, script_len, NULL))
 		*output_is_p2sh = true;
-	else if (is_p2wpkh(script, NULL))
+	else if (is_p2wpkh(script, script_len, NULL))
 		*output_is_p2sh = false;
-	else if (is_p2tr(script, NULL))
+	else if (is_p2tr(script, script_len, NULL))
 		*output_is_p2sh = false;
 	else
 		return false;
@@ -4353,8 +4354,8 @@ bool wallet_outpoint_spend(struct wallet *w, const tal_t *ctx, const u32 blockhe
 
 void wallet_utxoset_add(struct wallet *w,
 			const struct bitcoin_outpoint *outpoint,
-			const u32 blockheight,
-			const u32 txindex, const u8 *scriptpubkey,
+			const u32 blockheight, const u32 txindex,
+			const u8 *scriptpubkey, size_t scriptpubkey_len,
 			struct amount_sat sat)
 {
 	struct db_stmt *stmt;
@@ -4373,7 +4374,7 @@ void wallet_utxoset_add(struct wallet *w,
 	db_bind_int(stmt, blockheight);
 	db_bind_null(stmt);
 	db_bind_int(stmt, txindex);
-	db_bind_talarr(stmt, scriptpubkey);
+	db_bind_blob(stmt, scriptpubkey, scriptpubkey_len);
 	db_bind_amount_sat(stmt, &sat);
 	db_exec_prepared_v2(take(stmt));
 

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1146,8 +1146,8 @@ struct outpoint *wallet_outpoint_for_scid(struct wallet *w, tal_t *ctx,
 
 void wallet_utxoset_add(struct wallet *w,
 			const struct bitcoin_outpoint *outpoint,
-			const u32 blockheight,
-			const u32 txindex, const u8 *scriptpubkey,
+			const u32 blockheight, const u32 txindex,
+			const u8 *scriptpubkey, size_t scriptpubkey_len,
 			struct amount_sat sat);
 
 /**

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -567,10 +567,10 @@ struct utxo **wallet_utxo_boost(const tal_t *ctx,
  * @w: (in) wallet holding the pubkeys to check against (privkeys are on HSM)
  * @script: (in) the script to check
  * @index: (out) the bip32 derivation index that matched the script
- * @output_is_p2sh: (out) whether the script is a p2sh, or p2wpkh
  */
-bool wallet_can_spend(struct wallet *w, const u8 *script,
-		      u32 *index, bool *output_is_p2sh);
+bool wallet_can_spend(struct wallet *w,
+		      const u8 *script,
+		      u32 *index);
 
 /**
  * wallet_get_newindex - get a new index from the wallet.

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -664,12 +664,8 @@ static void match_psbt_outputs_to_wallet(struct wally_psbt *psbt,
 		const u8 *script = psbt->outputs[outndx].script;
 		const size_t script_len = psbt->outputs[outndx].script_len;
 		u32 index;
-		bool is_p2sh;
 
-		if (!script_len)
-			continue;
-
-		if (!wallet_can_spend(w, script, &index, &is_p2sh))
+		if (!wallet_can_spend(w, script, &index))
 			continue;
 
 		if (bip32_key_from_parent(
@@ -872,7 +868,6 @@ static void maybe_notify_new_external_send(struct lightningd *ld,
 	struct bitcoin_outpoint outpoint;
 	struct amount_sat amount;
 	u32 index;
-	bool is_p2sh;
 	const u8 *script;
 
 	/* If it's not going to an external address, ignore */
@@ -881,8 +876,8 @@ static void maybe_notify_new_external_send(struct lightningd *ld,
 
 	/* If it's going to our wallet, ignore */
 	script = wally_psbt_output_get_script(tmpctx,
-					    &psbt->outputs[outnum]);
-	if (wallet_can_spend(ld->wallet, script, &index, &is_p2sh))
+					      &psbt->outputs[outnum]);
+	if (wallet_can_spend(ld->wallet, script, &index))
 		return;
 
 	outpoint.txid = *txid;

--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -660,14 +660,13 @@ static void match_psbt_outputs_to_wallet(struct wally_psbt *psbt,
 {
 	tal_wally_start();
 	for (size_t outndx = 0; outndx < psbt->num_outputs; ++outndx) {
+		struct ext_key ext;
+		const u8 *script = psbt->outputs[outndx].script;
+		const size_t script_len = psbt->outputs[outndx].script_len;
 		u32 index;
 		bool is_p2sh;
-		const u8 *script;
-		struct ext_key ext;
 
-		script = wally_psbt_output_get_script(tmpctx,
-						    &psbt->outputs[outndx]);
-		if (!script)
+		if (!script_len)
 			continue;
 
 		if (!wallet_can_spend(w, script, &index, &is_p2sh))
@@ -678,7 +677,8 @@ static void match_psbt_outputs_to_wallet(struct wally_psbt *psbt,
 			abort();
 		}
 
-		psbt_output_set_keypath(index, &ext, is_p2tr(script, NULL),
+		psbt_output_set_keypath(index, &ext,
+					is_p2tr(script, script_len, NULL),
 					&psbt->outputs[outndx]);
 	}
 	tal_wally_end(psbt);


### PR DESCRIPTION
Per discussion on https://github.com/ElementsProject/lightning/pull/6984, adding another introspection wrapper to avoid non-interesting matches is non-optimal. It's a duplicate of the is_xxx script call already exposed, and it doesn't fix the many other places where allocations are made unnecessarily.

It seems the original rationale for the copies is behaviour that was since fixed (see commit descriptions for details). But also, the script introspection functions are inconsistent w.r.t taking lengths. Removing this inconsistency by adding length args exposes a lot of places that were allocating redundantly which this PR addresses. In particular, we avoid allocations for interesting scripts which https://github.com/ElementsProject/lightning/pull/6984 does not. We are then able to remove the allocating wrapper calls completely, ending up with less code overall.

There are 2 other drive-by fixes to improve performance: Avoid DB queries for non-interesting script types, and avoid computing unused key fingerprints when identifying wallet addresses. The latter in particular avoids a hash160 for every key tested, which is all used wallet keys plus the gap limit in the case of negative lookups, for every potentially interesting tx output.

The end result is less code, more code consistency and much less memory/cpu usage, especially for large wallets/after many txs have been made.

Reverts/replaces https://github.com/ElementsProject/lightning/pull/6984.

cc: @cdecker 