### PR TITLE
hsmtool.c - Added new method to enable creation of hsm_file from cmd-line args

### DIFF
--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -53,8 +53,8 @@ and is usually no greater than the number of channels that the node has
 ever had.
 Specify *password* if the `hsm_secret_path` is encrypted.
 
-**generatehsm** *hsm\_secret\_path*
-  Generates a new hsm\_secret using BIP39.
+**generatehsm** *hsm\_secret\_path* \[*lang* *seed\_phrase*  \[*passphrase*\]\]
+  Generates a new hsm\_secret using BIP39.  If lang, seed\_phrase and optional passphrase are not provided they will be prompted for.  *lang* can be "en" (English), "es" (Spanish), "fr" (French), "it" ("Italian"), "jp" (Japanese), "zhs" (Chinese Simplified) or "zht" ("Chinese Traditional"). Note that the seed phrase consists of multiple words, so should be surrounded by quotes.
 
 **checkhsm** *hsm\_secret\_path*
   Checks that hsm\_secret matches a BIP39 passphrase.
@@ -117,4 +117,3 @@ COPYING
 Note: the modules in the ccan/ directory have their own licenses, but
 the rest of the code is covered by the BSD-style MIT license.
 Main web site: <https://github.com/ElementsProject/lightning>
-

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1383,6 +1383,27 @@ def test_hsmtool_generatehsm(node_factory):
     # We can start the node with this hsm_secret
     l1.start()
     assert l1.info['id'] == '02244b73339edd004bc6dfbb953a87984c88e9e7c02ca14ef6ec593ca6be622ba7'
+    l1.stop()
+
+    # We can do the entire thing non-interactive!
+    os.remove(hsm_path)
+    subprocess.check_output(["tools/hsmtool",
+                             "generatehsm", hsm_path,
+                             "en",
+                             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"])
+    assert open(hsm_path, "rb").read().hex() == "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1"
+
+    # Including passphrase
+    os.remove(hsm_path)
+    subprocess.check_output(["tools/hsmtool",
+                             "generatehsm", hsm_path,
+                             "en",
+                             "ritual idle hat sunny universe pluck key alpha wing cake have wedding",
+                             "This is actually not a passphrase"])
+
+    l1.start()
+    assert l1.info['id'] == '02244b73339edd004bc6dfbb953a87984c88e9e7c02ca14ef6ec593ca6be622ba7'
+    l1.stop()
 
 
 # this test does a 'listtransactions' on a yet unconfirmed channel

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -43,7 +43,7 @@ static void show_usage(const char *progname)
 	       "<path/to/hsm_secret>\n");
 	printf("	- guesstoremote <P2WPKH address> <node id> <tries> "
 	       "<path/to/hsm_secret>\n");
-	printf("	- generatehsm <path/to/new/hsm_secret> [<language_id> <word list> [<password>]");
+	printf("	- generatehsm <path/to/new/hsm_secret> [<language_id> <word list> [<password>]]\n");
 	printf("	- checkhsm <path/to/new/hsm_secret>\n");
 	printf("	- dumponchaindescriptors [--show-secrets] <path/to/hsm_secret> [network]\n");
 	printf("	- makerune <path/to/hsm_secret>\n");


### PR DESCRIPTION
Creating a hsm_file with `hsmtool` is currently an interactive process in terminal where user is expected to make choices for language, typing in seed phrase, etc. This works well, but is difficult to utilize for automated installs (ie. Docker, unattended-installs, etc). 

This adds a new method: `generatehsmbyargs` that allows the user to input all required args on command-line and generate the hsm_file without terminal interaction. 

Also the documentation was `lightning-hsmtool.8.md` updated to include new method. 

All existing functionality was preserved, this only added a new method. 