### PR TITLE
Update installation.md - ubuntu

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -83,9 +83,7 @@ Get dependencies:
 sudo apt-get update
 sudo apt-get install -y \
   autoconf automake build-essential git libtool libsqlite3-dev \
-  python3 python3-pip net-tools zlib1g-dev libsodium-dev gettext
-pip3 install --upgrade pip
-pip3 install --user poetry
+  python3 python3-poetry net-tools zlib1g-dev libsodium-dev gettext
 ```
 
 If you don't have Bitcoin installed locally you'll need to install that as well. It's now available via [snapd](https://snapcraft.io/bitcoin-core).


### PR DESCRIPTION
It's been a couple of months since trying to install anything not as root on a Debian-based system with pip fails like so:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```