### PR TITLE
`cln_plugin` : Support wildcard subscriptions

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -253,10 +253,14 @@ PLUGIN_BASES := $(PLUGINS:plugins/%=%) $(PY_PLUGINS:plugins/%=%)
 plugins/list_of_builtin_plugins_gen.h: plugins/Makefile Makefile config.vars
 	@$(call VERBOSE,GEN $@,echo "static const char *list_of_builtin_plugins[] = { $(PLUGIN_BASES:%=\"%\",) NULL };" > $@)
 
+target/${RUST_PROFILE}/examples/cln-subscribe-wildcard: ${CLN_PLUGIN_SRC} plugins/examples/cln-subscribe-wildcard.rs
+	cargo build ${CARGO_OPTS} --example cln-subscribe-wildcard
+
 CLN_PLUGIN_EXAMPLES := \
 	target/${RUST_PROFILE}/examples/cln-plugin-startup \
 	target/${RUST_PROFILE}/examples/cln-plugin-reentrant \
-	target/${RUST_PROFILE}/examples/cln-rpc-getinfo
+	target/${RUST_PROFILE}/examples/cln-rpc-getinfo \
+	target/${RUST_PROFILE}/examples/cln-subscribe-wildcard
 
 CLN_PLUGIN_SRC = $(shell find plugins/src -name "*.rs")
 

--- a/plugins/examples/cln-subscribe-wildcard.rs
+++ b/plugins/examples/cln-subscribe-wildcard.rs
@@ -1,0 +1,35 @@
+/// This plug-in subscribes to the wildcard-notifications
+/// and creates a corresponding log-entry
+
+use anyhow::Result;
+use cln_plugin::{Builder, Plugin};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let state = ();
+
+    let configured = Builder::new(tokio::io::stdin(), tokio::io::stdout())
+        .subscribe("*", handle_wildcard_notification)
+        .start(state)
+        .await?;
+
+    match configured {
+	Some(p) => p.join().await?,
+	None => return Ok(()) // cln was started with --help
+    };
+
+    Ok(())
+}
+
+async fn handle_wildcard_notification(_plugin: Plugin<()>, value : serde_json::Value) -> Result<()> {
+    let notification_type : String = value
+	.as_object()
+	.unwrap()
+	.keys()
+	.next()
+	.unwrap()
+	.into();
+
+    log::info!("Received notification {}", notification_type);
+    Ok(())
+}

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -384,7 +384,6 @@ def test_grpc_decode(node_factory):
     print(res)
 
 
-@pytest.mark.xfail(strict=True)
 def test_rust_plugin_subscribe_wildcard(node_factory):
     """ Creates a plugin that loads the subscribe_wildcard plugin
     """

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -382,3 +382,16 @@ def test_grpc_decode(node_factory):
         string=inv.bolt11
     ))
     print(res)
+
+
+@pytest.mark.xfail(strict=True)
+def test_rust_plugin_subscribe_wildcard(node_factory):
+    """ Creates a plugin that loads the subscribe_wildcard plugin
+    """
+    bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-subscribe-wildcard"
+    l1 = node_factory.get_node(options={"plugin": bin_path})
+    l2 = node_factory.get_node()
+
+    l2.connect(l1)
+
+    l1.daemon.wait_for_log("Received notification connect")


### PR DESCRIPTION
In Core Lightning plugins can subscribe to notifications using a wildcard `*`.
When the wildcard is used the plugin will receive all notifications.

This behavior was not supported by `cln_plugin`.
The first 2 commits create a plug-in that listens to the the wildcard `*`-subscription
and test the behavior. It appears that `cln_plugin` accepts the subscription but fails when the first plug-in message
is received.

The last commit adapts the `cln_plugin`-crate to support the wildcard.


