### PR TITLE
pay: Prevent duplicate preapproveinvoice calls

### DIFF
--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -432,6 +432,10 @@ struct route_exclusions_data {
 	struct route_exclusion **exclusions;
 };
 
+struct preapproveinvoice_data {
+	bool approved;
+};
+
 /* List of globally available payment modifiers. */
 REGISTER_PAYMENT_MODIFIER_HEADER(retry, struct retry_mod_data);
 REGISTER_PAYMENT_MODIFIER_HEADER(routehints, struct routehints_data);
@@ -453,7 +457,7 @@ REGISTER_PAYMENT_MODIFIER_HEADER(local_channel_hints, void);
  * each of those channels can bear.  */
 REGISTER_PAYMENT_MODIFIER_HEADER(payee_incoming_limit, void);
 REGISTER_PAYMENT_MODIFIER_HEADER(route_exclusions, struct route_exclusions_data);
-REGISTER_PAYMENT_MODIFIER_HEADER(check_preapproveinvoice, void);
+REGISTER_PAYMENT_MODIFIER_HEADER(check_preapproveinvoice, struct preapproveinvoice_data);
 
 
 struct payment *payment_new(tal_t *ctx, struct command *cmd,


### PR DESCRIPTION
So far we would call `preapproveinvoice` once for each payment split,
i.e., at least once per HTLC, and potentially more often. There is no
point in doing so repeatedly, and especially in remote signer setup
this is actually counterproductive due to the additional roundtrips.

Changelog-Changed pay: Improved performance by removing repeated `preapproveinvoice` calls
