### PR TITLE
renepay: bugfix situation with htlcmax=htlcmin

### DIFF
--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -1230,6 +1230,8 @@ struct list_data
 
 static inline uint64_t pseudorand_interval(uint64_t a, uint64_t b)
 {
+	if (a == b)
+		return b;
 	assert(b > a);
 	return a + pseudorand(b - a);
 }


### PR DESCRIPTION
In some weird situations it may happen that some channel along the route could have htlcmax=htlcmin, so that the supremum of htlcmin and the infimum of htlcmax are the same number. In that case there is only one allowed amount that can go through that route.
Without this patch renepay would not handle correctly this cornercase.

Solves issue #7115 