### PR TITLE
crates workflow: add protoc to workflow environment

### DIFF
--- a/.github/workflows/crate-io.yml
+++ b/.github/workflows/crate-io.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
       - uses: katyo/publish-crates@v2
         with:
           path: './cln-rpc'

--- a/.github/workflows/crate-io.yml
+++ b/.github/workflows/crate-io.yml
@@ -1,6 +1,7 @@
 ---
 name: "Release Rust 🦀"
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"


### PR DESCRIPTION
https://github.com/ElementsProject/lightning/actions/runs/8204293180/job/22438677830
errored because the workflow doesn't have protoc. This might fix it 