### PR TITLE
doc: Clarify listpeerchannels documentation.

### DIFF
--- a/doc/lightning-listpeerchannels.7.md
+++ b/doc/lightning-listpeerchannels.7.md
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **listpeerchannels** RPC command returns data on channels of the network, with the possibility to filter the channels by node id.
+The **listpeerchannels** RPC command returns data on this node's channels, with the possibility to filter the channels by the id of a remote node.
 
 If no *id* is supplied, then channel data on all lightning nodes that are
 connected, or not connected but have open channels with this node, are


### PR DESCRIPTION
This is to clarify the listpeerchannels documentation.  I had been reading it as though listpeerchannels returns all channels in the network, which while developing a frontend did not make sense so I spent time testing in startup_regtest.sh to figure out what it really does.  I think this clarification would help others in the future.  