### PR TITLE
doc: Fix two typos in documentation and schema descriptions

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -6878,7 +6878,7 @@
             },
             "min_to_us_msat": {
               "type": "msat",
-              "description": "Least amount owed to us ever.  If the peer were to succesfully steal from us, this is the amount we would still retain."
+              "description": "Least amount owed to us ever.  If the peer were to successfully steal from us, this is the amount we would still retain."
             },
             "max_to_us_msat": {
               "type": "msat",
@@ -10690,7 +10690,7 @@
                   "splice_amount": {
                     "type": "integer",
                     "added": "v23.08",
-                    "description": "The amouont of sats we're splicing in or out"
+                    "description": "The amount of sats we're splicing in or out"
                   },
                   "our_funding_msat": {
                     "type": "msat",
@@ -10777,7 +10777,7 @@
             },
             "min_to_us_msat": {
               "type": "msat",
-              "description": "Least amount owed to us ever.  If the peer were to succesfully steal from us, this is the amount we would still retain."
+              "description": "Least amount owed to us ever.  If the peer were to successfully steal from us, this is the amount we would still retain."
             },
             "max_to_us_msat": {
               "type": "msat",
@@ -11858,7 +11858,7 @@
                         "splice_amount": {
                           "type": "integer",
                           "added": "v23.08",
-                          "description": "The amouont of sats we're splicing in or out"
+                          "description": "The amount of sats we're splicing in or out"
                         },
                         "scratch_txid": {
                           "type": "txid",

--- a/doc/lightning-listclosedchannels.7.md
+++ b/doc/lightning-listclosedchannels.7.md
@@ -77,4 +77,4 @@ RESOURCES
 
 Main web site: <https://github.com/ElementsProject/lightning> Lightning
 
-[comment]: # ( SHA256STAMP:559d917217fe6d765d8bf019e46bf03d37dae9a437e530b1456252bcb901cbc9)
+[comment]: # ( SHA256STAMP:3b61019ef50de78d4a93f93f763c1e3c5877b238a4eba5d12033f9a99756e541)

--- a/doc/lightning-listpeerchannels.7.md
+++ b/doc/lightning-listpeerchannels.7.md
@@ -68,7 +68,7 @@ On success, an object containing **channels** is returned.  It is an array of ob
   - **funding\_outnum** (u32): The 0-based output number of the funding transaction which opens the channel
   - **feerate** (string): The feerate for this funding transaction in per-1000-weight, with "kpw" appended
   - **total\_funding\_msat** (msat): total amount in the channel
-  - **splice\_amount** (integer): The amouont of sats we're splicing in or out *(added v23.08)*
+  - **splice\_amount** (integer): The amount of sats we're splicing in or out *(added v23.08)*
   - **our\_funding\_msat** (msat): amount we have in the channel
   - **scratch\_txid** (txid, optional): The commitment transaction txid we would use if we went onchain now
 - **close\_to** (hex, optional): scriptPubkey which we have to close to if we mutual close
@@ -221,4 +221,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:02dbb15d46497d33808d1bc021cb604529546b94f46d8de285d7b47f4615a516)
+[comment]: # ( SHA256STAMP:27dac0fd7ddb3fa596a5cab7209cf1ab07e1d59b590fb2a371fb95ef23c68643)

--- a/doc/lightning-listpeers.7.md
+++ b/doc/lightning-listpeers.7.md
@@ -89,7 +89,7 @@ On success, an object containing **peers** is returned.  It is an array of objec
     - **feerate** (string): The feerate for this funding transaction in per-1000-weight, with "kpw" appended
     - **total\_funding\_msat** (msat): total amount in the channel
     - **our\_funding\_msat** (msat): amount we have in the channel
-    - **splice\_amount** (integer): The amouont of sats we're splicing in or out *(added v23.08)*
+    - **splice\_amount** (integer): The amount of sats we're splicing in or out *(added v23.08)*
     - **scratch\_txid** (txid): The commitment transaction txid we would use if we went onchain now
   - **close\_to** (hex, optional): scriptPubkey which we have to close to if we mutual close
   - **private** (boolean, optional): if True, we will not announce this channel
@@ -400,4 +400,4 @@ Main web site: <https://github.com/ElementsProject/lightning> Lightning
 RFC site (BOLT \#9):
 <https://github.com/lightning/bolts/blob/master/09-features.md>
 
-[comment]: # ( SHA256STAMP:5b622ce05ce081a3184b01dc1cf5d2d5882293e171b3a3a118efff3748d8e25a)
+[comment]: # ( SHA256STAMP:98b23c18900ae0d623910d0ec4d59bdb0cd77c88ad02b497ac86dad35df82859)

--- a/doc/schemas/listclosedchannels.schema.json
+++ b/doc/schemas/listclosedchannels.schema.json
@@ -155,7 +155,7 @@
           },
           "min_to_us_msat": {
             "type": "msat",
-            "description": "Least amount owed to us ever.  If the peer were to succesfully steal from us, this is the amount we would still retain."
+            "description": "Least amount owed to us ever.  If the peer were to successfully steal from us, this is the amount we would still retain."
           },
           "max_to_us_msat": {
             "type": "msat",

--- a/doc/schemas/listpeerchannels.schema.json
+++ b/doc/schemas/listpeerchannels.schema.json
@@ -278,7 +278,7 @@
                 "splice_amount": {
                   "type": "integer",
                   "added": "v23.08",
-                  "description": "The amouont of sats we're splicing in or out"
+                  "description": "The amount of sats we're splicing in or out"
                 },
                 "our_funding_msat": {
                   "type": "msat",
@@ -365,7 +365,7 @@
           },
           "min_to_us_msat": {
             "type": "msat",
-            "description": "Least amount owed to us ever.  If the peer were to succesfully steal from us, this is the amount we would still retain."
+            "description": "Least amount owed to us ever.  If the peer were to successfully steal from us, this is the amount we would still retain."
           },
           "max_to_us_msat": {
             "type": "msat",

--- a/doc/schemas/listpeers.schema.json
+++ b/doc/schemas/listpeers.schema.json
@@ -305,7 +305,7 @@
                       "splice_amount": {
                         "type": "integer",
                         "added": "v23.08",
-                        "description": "The amouont of sats we're splicing in or out"
+                        "description": "The amount of sats we're splicing in or out"
                       },
                       "scratch_txid": {
                         "type": "txid",

--- a/plugins/spender/openchannel.c
+++ b/plugins/spender/openchannel.c
@@ -71,7 +71,7 @@ static bool update_parent_psbt(const tal_t *ctx,
 	struct wally_psbt *clone, *new_node_copy;
 
 	/* Clone the parent, so we don't make any changes to it
-	 * until we've succesfully done everything */
+	 * until we've successfully done everything */
 
 	/* Only failure is alloc, should we even check? */
 	tal_wally_start();


### PR DESCRIPTION
Fix typo where "amouont" should be "amount" in the splicing documentation.
Fix typo "succesfully" needing to be "successfully"