### PR TITLE
offer: expose a way to derive a payer-id from the metadata

### DIFF
--- a/doc/schemas/lightning-derivepayerid.json
+++ b/doc/schemas/lightning-derivepayerid.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "derivepayerid",
+  "title": "Derive the Payer Id from a provided invreq_metadata",
+  "description": [
+    "The **derivepayerid** gives the possibility to derive a payer id froma invreq_metadata."
+  ],
+  "request": {
+    "required": [],
+    "properties": {}
+  },
+  "response": {
+    "required": [
+      "payer_id",
+    ],
+  },
+  "errors": [
+    "On failure, one of the following error codes may be returned:",
+    "",
+    "- -32602: Error in given parameters or some error happened during the command process."
+  ],
+  "author": [
+    "Vincenzo Palazzo <<vincenzo.palazzo@protonmail.com>> wrote the initial version of this man page,",
+    "but many others did the hard work of actually implementing this rpc command."
+  ],
+  "see_also": [
+    "lightning-decode(7)",
+    "lightning-fetchinvoice(7)",
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -540,6 +540,36 @@ static const struct json_command payersign_command = {
 };
 AUTODATA(json_command, &payersign_command);
 
+static struct command_result *json_derivepayerid(struct command *cmd,
+					     const char *buffer,
+					     const jsmntok_t *obj UNNEEDED,
+					     const jsmntok_t *params)
+{
+	struct json_stream *response;
+	u8 *invreq_metadata;
+	struct pubkey key;
+
+	if (!param(cmd, buffer, params,
+		   p_req("metadata", param_bin_from_hex, &invreq_metadata),
+		   NULL))
+		return command_param_failed();
+
+	payer_key(cmd->ld, invreq_metadata, tal_bytelen(invreq_metadata), &key);
+
+	response = json_stream_success(cmd);
+	json_add_pubkey(response, "payer_id", &key);
+	return command_success(cmd, response);
+}
+
+static const struct json_command derivepayerid_command = {
+	"derivepayerid",
+	"payment",
+	json_derivepayerid,
+	"Derive the Payer Id from the {invreq_metadata} {merkle}",
+};
+AUTODATA(json_command, &derivepayerid_command);
+
+
 static struct command_result *json_listinvoicerequests(struct command *cmd,
 						       const char *buffer,
 						       const jsmntok_t *obj UNNEEDED,


### PR DESCRIPTION
The `invreq_payerid` is obtained during the offer fetching process by tweaking the bolt12 public key (which is derived from the main secret).

Currently, there exists no means to validate our bolt 12 invoice as there is no public API accessible for retrieving the bolt12 public key and performing the necessary tweak.

So, this commit introduces the functionality to address this limitation.

This should be an valid alternative to this https://github.com/ElementsProject/lightning/pull/7123

I finger out that I reading code skill are better than reading and understand a bolt, I am arriving the point of full understand bolt12 (maybe)
