### PR TITLE
Support multiple cln-version in pyln-testing

### DIFF
--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -2,6 +2,7 @@ from .lightning import LightningRpc, RpcError, Millisatoshi
 from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapHalfchannel, GossmapNodeId, LnFeatureBits
 from .gossmapstats import GossmapStats
+from .version import NodeVersion
 
 __version__ = "24.11"
 
@@ -20,4 +21,5 @@ __all__ = [
     "GossmapNodeId",
     "LnFeatureBits",
     "GossmapStats",
+    "NodeVersion"
 ]

--- a/contrib/pyln-client/pyln/client/__init__.py
+++ b/contrib/pyln-client/pyln/client/__init__.py
@@ -2,7 +2,7 @@ from .lightning import LightningRpc, RpcError, Millisatoshi
 from .plugin import Plugin, monkey_patch, RpcException
 from .gossmap import Gossmap, GossmapNode, GossmapChannel, GossmapHalfchannel, GossmapNodeId, LnFeatureBits
 from .gossmapstats import GossmapStats
-from .version import NodeVersion
+from .version import NodeVersion, VersionSpec
 
 __version__ = "24.11"
 
@@ -21,5 +21,6 @@ __all__ = [
     "GossmapNodeId",
     "LnFeatureBits",
     "GossmapStats",
-    "NodeVersion"
+    "NodeVersion",
+    "VersionSpec",
 ]

--- a/contrib/pyln-client/pyln/client/version.py
+++ b/contrib/pyln-client/pyln/client/version.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import total_ordering
+import re
+from typing import List, Optional, Protocol, runtime_checkable, Union
+
+
+@total_ordering
+@dataclass
+class NodeVersion:
+    """NodeVersion
+
+    NodeVersion represents a Core Lightning Version. It also contains a scheme
+    to compare versions against each-other.
+
+    The main use-case to compare versions is to test for the availability of a feature.
+    An example is the `--developer` flag which was introduced in cln v23.11
+
+    We define the following rules
+    - `v23.11` == `v23.11`
+       Obviously a version is equal to it-self.
+    - `v23.11rc3` == `v23.11rc1` == `v23.11`
+      We don't add new features in release-candidates and therefore the feature-set is the same.
+      This is also more ergonomic for a dev that wants to know if the `--developer` flag is available.
+      See `strict_equal` if an exact match is required
+    - `v23.11` < `v24.02`
+      The oldest version is the smallest
+    """
+
+    version: str
+
+    def to_parts(self) -> List[_NodeVersionPart]:
+        parts = self.version[1:].split(".")
+        # If the first part contains a v we will ignore it
+        if not parts[0][0].isdigit():
+            parts[0] = parts[1:]
+
+        return [_NodeVersionPart.parse(p) for p in parts]
+
+    def strict_equal(self, other: NodeVersion) -> bool:
+        if not isinstance(other, NodeVersion):
+            raise TypeError(
+                "`other` is expected to be of type `NodeVersion` but is `{type(other)}`"
+            )
+        else:
+            return self.version == other.version
+
+    def __eq__(self, other: Union[NodeVersion, str]) -> bool:
+        if isinstance(other, str):
+            other = NodeVersion(other)
+        if not isinstance(other, NodeVersion):
+            return False
+        else:
+            self_parts = [p.num for p in self.to_parts()]
+            other_parts = [p.num for p in other.to_parts()]
+
+            if len(self_parts) != len(other_parts):
+                return False
+
+            for ps, po in zip(self_parts, other_parts):
+                if ps != po:
+                    return False
+            return True
+
+    def __lt__(self, other: Union[NodeVersion, str]) -> bool:
+        if isinstance(other, str):
+            other = NodeVersion(other)
+        if not isinstance(other, NodeVersion):
+            return NotImplemented
+        else:
+            self_parts = [p.num for p in self.to_parts()]
+            other_parts = [p.num for p in other.to_parts()]
+
+            # zip truncates to shortes length
+            for sp, op in zip(self_parts, other_parts):
+                if sp < op:
+                    return True
+                if sp > op:
+                    return False
+
+            # If the initial parts are all equal the longest version is the biggest
+            #
+            # self = 'v24.02'
+            # other = 'v24.02.1'
+            return len(self_parts) < len(other_parts)
+
+    def matches(self, version_spec: VersionSpecLike) -> bool:
+        """Returns True if the version matches the spec
+
+        The `version_spec` can be represented as a string and has 8 operators
+        which are `=`, `===`, `!=`, `!===`, `<`, `<=`, `>`, `>=`.
+
+        The `=` is the equality operator. The verson_spec `=v24.02` matches
+        all versions that equal `v24.02` including release candidates such as `v24.02rc1`.
+        You can use the strict-equality operator `===` if strict equality is required.
+
+        Specifiers can be combined by separating the with a comma ','. The `version_spec`
+        `>=v23.11, <v24.02" includes any version which is greater than or equal to `v23.11`
+        and smaller than `v24.02`.
+        """
+        spec = VersionSpec.parse(version_spec)
+        return spec.matches(self)
+
+
+@dataclass
+class _NodeVersionPart:
+    num: int
+    text: Optional[str] = None
+
+    @classmethod
+    def parse(cls, part: str) -> _NodeVersionPart:
+        # We assume all parts start with a number and are followed by a text
+        # E.g: v24.01rc2 has two parts
+        # - "24"    -> num = 24, text = None
+        # - "01rc"  -> num = 01, text = "rc"
+
+        number = re.search(r"\d+", part).group()
+        text = part[len(number):]
+        text_opt = text if text != "" else None
+        return _NodeVersionPart(int(number), text_opt)
+
+
+@runtime_checkable
+class VersionSpec(Protocol):
+    def matches(self, other: NodeVersionLike) -> bool:
+        ...
+
+    @classmethod
+    def parse(cls, spec: VersionSpecLike) -> VersionSpec:
+        if isinstance(spec, VersionSpec):
+            return spec
+        else:
+            parts = [p.strip() for p in spec.split(",")]
+            subspecs = [_CompareSpec.parse(p) for p in parts]
+            return _AndVersionSpecifier(subspecs)
+
+
+@dataclass
+class _AndVersionSpecifier(VersionSpec):
+    specs: List[VersionSpec]
+
+    def matches(self, other: NodeVersionLike) -> bool:
+        for spec in self.specs:
+            if not spec.matches(other):
+                return False
+        return True
+
+
+_OPERATORS = [
+    "===",  # Strictly equal
+    "!===",  # not strictly equal
+    "=",  # Equal
+    ">=",  # Greater or equal
+    "<=",  # Less or equal
+    "<",  # less
+    ">",  # greater than
+    "!=",  # not equal
+]
+
+
+@dataclass
+class _CompareSpec(VersionSpec):
+    operator: str
+    version: NodeVersion
+
+    def __post_init__(self):
+        if self.operator not in _OPERATORS:
+            raise ValueError(f"Invalid operator '{self.operator}'")
+
+    def matches(self, other: NodeVersionLike):
+        if isinstance(other, str):
+            other = NodeVersion(other)
+        if self.operator == "===":
+            return other.strict_equal(self.version)
+        if self.operator == "!===":
+            return not other.strict_equal(self.version)
+        if self.operator == "=":
+            return other == self.version
+        if self.operator == ">=":
+            return other >= self.version
+        if self.operator == "<=":
+            return other <= self.version
+        if self.operator == "<":
+            return other < self.version
+        if self.operator == ">":
+            return other > self.version
+        if self.operator == "!=":
+            return other != self.version
+        else:
+            ValueError("Unknown operator")
+
+    @classmethod
+    def parse(cls, spec_string: str) -> _CompareSpec:
+        spec_string = spec_string.strip()
+
+        for op in _OPERATORS:
+            if spec_string.startswith(op):
+                version = spec_string[len(op):]
+                version = version.strip()
+                return _CompareSpec(op, NodeVersion(version))
+
+        raise ValueError(f"Failed to parse '{spec_string}'")
+
+
+NodeVersionLike = Union[NodeVersion, str]
+VersionSpecLike = Union[VersionSpec, str]
+
+__all__ = [NodeVersion, NodeVersionLike, VersionSpec, VersionSpecLike]

--- a/contrib/pyln-client/pyln/client/version.py
+++ b/contrib/pyln-client/pyln/client/version.py
@@ -6,6 +6,9 @@ import re
 from typing import List, Optional, Protocol, runtime_checkable, Union
 
 
+_MODDED_PATTERN = "[0-9a-f]+-modded"
+
+
 @total_ordering
 @dataclass
 class NodeVersion:
@@ -51,6 +54,11 @@ class NodeVersion:
             other = NodeVersion(other)
         if not isinstance(other, NodeVersion):
             return False
+
+        if self.strict_equal(other):
+            return True
+        elif re.match(_MODDED_PATTERN, self.version):
+            return False
         else:
             self_parts = [p.num for p in self.to_parts()]
             other_parts = [p.num for p in other.to_parts()]
@@ -68,6 +76,13 @@ class NodeVersion:
             other = NodeVersion(other)
         if not isinstance(other, NodeVersion):
             return NotImplemented
+
+        # If we are in CI the version will by a hex ending on modded
+        # We will assume it is the latest version
+        if re.match(_MODDED_PATTERN, self.version):
+            return False
+        elif re.match(_MODDED_PATTERN, other.version):
+            return True
         else:
             self_parts = [p.num for p in self.to_parts()]
             other_parts = [p.num for p in other.to_parts()]

--- a/contrib/pyln-client/tests/test_version.py
+++ b/contrib/pyln-client/tests/test_version.py
@@ -83,3 +83,9 @@ def test_compare_spec_from_string():
 
     assert not list_spec.matches("v24.02rc1")
     assert not list_spec.matches("v23.11")
+
+
+def test_ci_modded_version_is_always_latest():
+    v1 = NodeVersion("1a86e50-modded")
+
+    assert v1 > NodeVersion("v24.02")

--- a/contrib/pyln-client/tests/test_version.py
+++ b/contrib/pyln-client/tests/test_version.py
@@ -32,6 +32,7 @@ def test_equality_classes_in_node_versions():
     assert NodeVersion("v24.02") == NodeVersion("v24.02")
     assert NodeVersion("v24.02") == NodeVersion("v24.02rc1")
     assert NodeVersion("v24.02rc1") == NodeVersion("v24.02")
+    assert NodeVersion("v24.11-217-g77989b1-modded") == NodeVersion("v24.11")
 
     assert NodeVersion("v24.02") != NodeVersion("v24.02.1")
     assert NodeVersion("v24.02rc1") != NodeVersion("v24.02.1")

--- a/contrib/pyln-client/tests/test_version.py
+++ b/contrib/pyln-client/tests/test_version.py
@@ -1,0 +1,85 @@
+from pyln.client.version import NodeVersion, VersionSpec, _NodeVersionPart, _CompareSpec
+
+
+def test_create_version():
+    # These are the strings returned by `lightningd --version`
+    _ = NodeVersion("v24.02")
+    _ = NodeVersion("23.08.1")
+
+
+def test_parse_parts():
+    assert _NodeVersionPart.parse("2rc2") == _NodeVersionPart(2, "rc2")
+    assert _NodeVersionPart.parse("0rc1") == _NodeVersionPart(0, "rc1")
+    assert _NodeVersionPart.parse("2") == _NodeVersionPart(2, None)
+    assert _NodeVersionPart.parse("2").text is None
+
+
+def test_version_to_parts():
+
+    assert NodeVersion("v24.02rc1").to_parts() == [
+        _NodeVersionPart(24),
+        _NodeVersionPart(2, "rc1"),
+    ]
+
+    assert NodeVersion("v24.02.1").to_parts() == [
+        _NodeVersionPart(24),
+        _NodeVersionPart(2),
+        _NodeVersionPart(1),
+    ]
+
+
+def test_equality_classes_in_node_versions():
+    assert NodeVersion("v24.02") == NodeVersion("v24.02")
+    assert NodeVersion("v24.02") == NodeVersion("v24.02rc1")
+    assert NodeVersion("v24.02rc1") == NodeVersion("v24.02")
+
+    assert NodeVersion("v24.02") != NodeVersion("v24.02.1")
+    assert NodeVersion("v24.02rc1") != NodeVersion("v24.02.1")
+    assert NodeVersion("v23.10") != NodeVersion("v23.02")
+
+
+def test_inequality_of_node_versions():
+    assert not NodeVersion("v24.02.1") > NodeVersion("v24.02.1")
+    assert NodeVersion("v24.02.1") > NodeVersion("v24.02")
+    assert NodeVersion("v24.02.1") > NodeVersion("v24.02rc1")
+    assert NodeVersion("v24.02.1") > NodeVersion("v23.05")
+
+    assert NodeVersion("v24.02.1") >= NodeVersion("v24.02.1")
+    assert NodeVersion("v24.02.1") >= NodeVersion("v24.02")
+    assert NodeVersion("v24.02.1") >= NodeVersion("v24.02rc1")
+    assert NodeVersion("v24.02.1") >= NodeVersion("v23.05")
+
+    assert NodeVersion("v24.02.1") <= NodeVersion("v24.02.1")
+    assert not NodeVersion("v24.02.1") <= NodeVersion("v24.02")
+    assert not NodeVersion("v24.02.1") <= NodeVersion("v24.02rc1")
+    assert not NodeVersion("v24.02.1") <= NodeVersion("v23.05")
+
+    assert not NodeVersion("v24.02.1") < NodeVersion("v24.02.1")
+    assert not NodeVersion("v24.02.1") < NodeVersion("v24.02")
+    assert not NodeVersion("v24.02.1") < NodeVersion("v24.02rc1")
+    assert not NodeVersion("v24.02.1") < NodeVersion("v23.05")
+
+
+def test_comparision_parse():
+    assert _CompareSpec.parse("===v24.02").operator == "==="
+    assert _CompareSpec.parse("=v24.02").operator == "="
+    assert _CompareSpec.parse("!===v24.02").operator == "!==="
+    assert _CompareSpec.parse("!=v24.02").operator == "!="
+    assert _CompareSpec.parse(">v24.02").operator == ">"
+    assert _CompareSpec.parse("<v24.02").operator == "<"
+    assert _CompareSpec.parse(">=v24.02").operator == ">="
+    assert _CompareSpec.parse("<=v24.02").operator == "<="
+
+
+def test_compare_spec_from_string():
+    assert VersionSpec.parse("=v24.02").matches("v24.02rc1")
+    assert VersionSpec.parse("=v24.02").matches("v24.02")
+    assert not VersionSpec.parse("=v24.02").matches("v24.02.1")
+
+    # Yes, I use weird spaces here as a part of the test
+    list_spec = VersionSpec.parse(">=    v24.02, !=== v24.02rc1")
+    assert list_spec.matches("v24.02")
+    assert list_spec.matches("v24.02.1")
+
+    assert not list_spec.matches("v24.02rc1")
+    assert not list_spec.matches("v23.11")

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -612,10 +612,8 @@ class LightningD(TailableProc):
         self.opts = LIGHTNINGD_CONFIG.copy()
 
         # Query the version of the cln-binary
-        cln_version_proc = subprocess.run(
-            [self.executable, "--version"],
-            stdout=subprocess.PIPE)
-        self.cln_version = NodeVersion(cln_version_proc.stdout.decode('ascii').strip())
+        cln_version_proc = subprocess.check_output([self.executable, "--version"])
+        self.cln_version = NodeVersion(cln_version_proc.decode('ascii').strip())
 
         opts = {
             'lightning-dir': lightning_dir,

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -653,8 +653,11 @@ class LightningD(TailableProc):
         # In case you want specific ordering!
         self.early_opts = []
 
-        if VersionSpec.parse(">=v23.11").matches(self.cln_version):
-            self.early_opts.append('--developer')
+        try:
+            if VersionSpec.parse(">=v23.11").matches(self.cln_version):
+                self.early_opts.append('--developer')
+        except Exception:
+            raise ValueError(f"Invalid version {type(self.cln_version)} - {self.cln_version}")
 
     def cleanup(self):
         # To force blackhole to exit, disconnect file must be truncated!

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -596,10 +596,11 @@ class LightningD(TailableProc):
             port=9735,
             random_hsm=False,
             node_id=0,
+            executable=None,
     ):
         # We handle our own version of verbose, below.
         TailableProc.__init__(self, lightning_dir, verbose=False)
-        self.executable = 'lightningd'
+        self.executable = "lightningd" if executable is None else executable
         self.lightning_dir = lightning_dir
         self.port = port
         self.cmd_prefix = []
@@ -759,6 +760,7 @@ class LightningNode(object):
                  db=None, port=None, grpc_port=None, disconnect=None, random_hsm=None, options=None,
                  jsonschemas={},
                  valgrind_plugins=True,
+                 executable=None,
                  **kwargs):
         self.bitcoin = bitcoind
         self.executor = executor
@@ -781,6 +783,7 @@ class LightningNode(object):
         self.daemon = LightningD(
             lightning_dir, bitcoindproxy=bitcoind.get_proxy(),
             port=port, random_hsm=random_hsm, node_id=node_id,
+            executable=executable,
         )
 
         self.disconnect = disconnect

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,6 +16,9 @@ def node_cls():
 
 class LightningNode(utils.LightningNode):
     def __init__(self, *args, **kwargs):
+        # Yes, we really want to test the local development version, not
+        # something in out path.
+        kwargs["executable"] = "lightningd/lightningd"
         utils.LightningNode.__init__(self, *args, **kwargs)
 
         # This is a recent innovation, and we don't want to nail pyln-testing to this version.
@@ -49,10 +52,6 @@ class LightningNode(utils.LightningNode):
         if db_type == 'postgres':
             accts_db = self.db.provider.get_db('', 'accounts', 0)
             self.daemon.opts['bookkeeper-db'] = accts_db.get_dsn()
-
-        # Yes, we really want to test the local development version, not
-        # something in out path.
-        self.daemon.executable = 'lightningd/lightningd'
 
 
 class CompatLevel(object):


### PR DESCRIPTION
It is sometimes useful to use `pyln-testing` also on older versions of Core Lightning. In greenlight we use `pyln-testing` to test our scheduler which has to support multiple versions of Core Lightning at the same time.

A similar issue exists for plug-in developers that want to support a range of cln-versions.

This PR introduces `NodeVersion` in `pyln-client` which can be used to compare the versions `lightningd` and test if the version is greater or not.

It also modifes `pyln-testing` so it will only use the `--developer` flag if it is available. 
