### PR TITLE
Faster startup

### DIFF
--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -2964,131 +2964,23 @@ static struct command_result *init_set_feerate(struct command *cmd,
 	return NULL;
 }
 
-static struct command_result *json_openchannel_init(struct command *cmd,
-						    const char *buffer,
-						    const jsmntok_t *obj UNNEEDED,
-						    const jsmntok_t *params)
+static struct command_result *openchannel_init(struct command *cmd,
+					       struct peer *peer,
+					       struct amount_sat amount,
+					       struct amount_sat request_amt,
+					       const struct wally_psbt *psbt,
+					       u32 feerate_per_kw_funding,
+					       u32 feerate_per_kw,
+					       const u8 *our_upfront_shutdown_script,
+					       bool announce_channel,
+					       const struct lease_rates *rates,
+					       const struct channel_type *ctype)
 {
-	struct node_id *id;
-	struct peer *peer;
-	struct channel *channel;
-	bool *announce_channel;
-	u32 *feerate_per_kw_funding;
-	u32 *feerate_per_kw;
-	struct amount_sat *amount, psbt_val, *request_amt;
-	struct wally_psbt *psbt;
-	const u8 *our_upfront_shutdown_script;
 	u32 *our_upfront_shutdown_script_wallet_index;
+	u32 found_wallet_index;
+	struct channel *channel;
 	struct open_attempt *oa;
-	struct lease_rates *rates;
-	struct command_result *res;
-	struct channel_type *ctype;
 	int fds[2];
-
-	if (!param_check(cmd, buffer, params,
-			 p_req("id", param_node_id, &id),
-			 p_req("amount", param_sat, &amount),
-			 p_req("initialpsbt", param_psbt, &psbt),
-			 p_opt("commitment_feerate", param_feerate, &feerate_per_kw),
-			 p_opt("funding_feerate", param_feerate, &feerate_per_kw_funding),
-			 p_opt_def("announce", param_bool, &announce_channel, true),
-			 p_opt("close_to", param_bitcoin_address, &our_upfront_shutdown_script),
-			 p_opt_def("request_amt", param_sat, &request_amt, AMOUNT_SAT(0)),
-			 p_opt("compact_lease", param_lease_hex, &rates),
-			 p_opt("channel_type", param_channel_type, &ctype),
-			 NULL))
-		return command_param_failed();
-
-	/* We only deal in v2 */
-	if (!psbt_set_version(psbt, 2)) {
-		return command_fail(cmd, LIGHTNINGD, "Could not set PSBT version.");
-	}
-
-	/* Gotta expect some rates ! */
-	if (!amount_sat_zero(*request_amt) && !rates)
-		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				    "Must pass in 'compact_lease' if requesting"
-				    " funds from peer");
-	psbt_val = AMOUNT_SAT(0);
-	for (size_t i = 0; i < psbt->num_inputs; i++) {
-		struct amount_sat in_amt = psbt_input_get_amount(psbt, i);
-		if (!amount_sat_add(&psbt_val, psbt_val, in_amt))
-			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-					    "Overflow in adding PSBT input"
-					    " values. %s",
-					    fmt_wally_psbt(tmpctx, psbt));
-	}
-
-	/* If they don't pass in at least enough in the PSBT to cover
-	 * their amount, nope */
-	if (!amount_sat_greater(psbt_val, *amount))
-		return command_fail(cmd, FUND_CANNOT_AFFORD,
-				    "Provided PSBT cannot afford funding of "
-				    "amount %s. %s",
-				    fmt_amount_sat(tmpctx, *amount),
-				    fmt_wally_psbt(tmpctx, psbt));
-
-	res = init_set_feerate(cmd, &feerate_per_kw, &feerate_per_kw_funding);
-	if (res)
-		return res;
-
-	if (!topology_synced(cmd->ld->topology)) {
-		return command_fail(cmd, FUNDING_STILL_SYNCING_BITCOIN,
-				    "Still syncing with bitcoin network");
-	}
-
-	peer = peer_by_id(cmd->ld, id);
-	if (!peer) {
-		return command_fail(cmd, FUNDING_UNKNOWN_PEER, "Unknown peer");
-	}
-
-	if (!feature_negotiated(cmd->ld->our_features,
-			        peer->their_features,
-				OPT_DUAL_FUND)) {
-		return command_fail(cmd, FUNDING_V2_NOT_SUPPORTED,
-				    "v2 openchannel not supported "
-				    "by peer");
-	}
-
-	if (ctype &&
-	    !cmd->ld->dev_any_channel_type &&
-	    !channel_type_accept(tmpctx,
-				 ctype->features,
-				 cmd->ld->our_features)) {
-		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-				    "channel_type not supported");
-	}
-
-	/* BOLT #2:
-	 *  - if both nodes advertised `option_support_large_channel`:
-	 *    - MAY set `funding_satoshis` greater than or equal to 2^24 satoshi.
-	 *  - otherwise:
-	 *    - MUST set `funding_satoshis` to less than 2^24 satoshi.
-	 */
-	if (!feature_negotiated(cmd->ld->our_features,
-				peer->their_features, OPT_LARGE_CHANNELS)
-	    && amount_sat_greater(*amount, chainparams->max_funding))
-		return command_fail(cmd, FUND_MAX_EXCEEDED,
-				    "Amount exceeded %s",
-				    fmt_amount_sat(tmpctx, chainparams->max_funding));
-
-	/* Add serials to any input that's missing them */
-	psbt_add_serials(psbt, TX_INITIATOR);
-
-	/* We require the PSBT to meet certain criteria such as
-	 * extra, proprietary fields (`serial_id`s) or
-	 * to have a `redeemscripts` iff the inputs are P2SH.
-	 *
-	 * Since this is externally provided, we confirm that
-	 * they've done the right thing / haven't lost any required info.
-	 */
-	if (!psbt_has_required_fields(psbt))
-		return command_fail(cmd, FUNDING_PSBT_INVALID,
-				    "PSBT is missing required fields %s",
-				    fmt_wally_psbt(tmpctx, psbt));
-
-	if (command_check_only(cmd))
-		return command_check_done(cmd);
 
 	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, fds) != 0) {
 		return command_fail(cmd, FUND_MAX_EXCEEDED,
@@ -3108,14 +3000,14 @@ static struct command_result *json_openchannel_init(struct command *cmd,
 	channel->opener = LOCAL;
 	channel->open_attempt = oa = new_channel_open_attempt(channel);
 	channel->channel_flags = OUR_CHANNEL_FLAGS;
-	oa->funding = *amount;
+	oa->funding = amount;
 	oa->cmd = cmd;
 
-	if (!*announce_channel) {
+	if (!announce_channel) {
 		channel->channel_flags &= ~CHANNEL_FLAGS_ANNOUNCE_CHANNEL;
 		log_info(peer->ld->log,
 			 "Will open private channel with node %s",
-			 fmt_node_id(tmpctx, id));
+			 fmt_node_id(tmpctx, &peer->id));
 	}
 
 	/* Needs to be stolen away from cmd */
@@ -3125,25 +3017,23 @@ static struct command_result *json_openchannel_init(struct command *cmd,
 
 	/* Determine the wallet index for our_upfront_shutdown_script,
 	 * NULL if not found. */
-	u32 found_wallet_index;
 	if (wallet_can_spend(cmd->ld->wallet,
 			     oa->our_upfront_shutdown_script,
 			     &found_wallet_index)) {
-		our_upfront_shutdown_script_wallet_index = tal(tmpctx, u32);
-		*our_upfront_shutdown_script_wallet_index = found_wallet_index;
+		our_upfront_shutdown_script_wallet_index = &found_wallet_index;
 	} else
 		our_upfront_shutdown_script_wallet_index = NULL;
 
 	oa->open_msg = towire_dualopend_opener_init(oa,
-					   psbt, *amount,
+					   psbt, amount,
 					   oa->our_upfront_shutdown_script,
 					   our_upfront_shutdown_script_wallet_index,
-					   *feerate_per_kw,
+					   feerate_per_kw,
 					   unilateral_feerate(cmd->ld->topology, true),
-					   *feerate_per_kw_funding,
+					   feerate_per_kw_funding,
 					   channel->channel_flags,
-					   amount_sat_zero(*request_amt) ?
-						NULL : request_amt,
+					   amount_sat_zero(request_amt) ?
+						NULL : &request_amt,
 					   get_block_height(cmd->ld->topology),
 					   false,
 					   ctype,
@@ -3167,6 +3057,182 @@ static struct command_result *json_openchannel_init(struct command *cmd,
 							     &channel->cid)));
 	subd_send_fd(peer->ld->connectd, fds[1]);
 	return command_still_pending(cmd);
+}
+
+struct openchannel_init_info {
+	struct command *cmd;
+	struct node_id *id;
+	struct amount_sat *amount, *request_amt;
+	struct wally_psbt *psbt;
+	u32 *feerate_per_kw_funding, *feerate_per_kw;
+	const u8 *our_upfront_shutdown_script;
+	bool *announce_channel;
+	struct lease_rates *rates;
+	struct channel_type *ctype;
+};
+
+static void openchannel_init_after_sync(struct chain_topology *topo,
+					struct openchannel_init_info *info)
+{
+	struct peer *peer;
+
+	/* Look up peer again in case it's gone! */
+	peer = peer_by_id(info->cmd->ld, info->id);
+	if (!peer) {
+		was_pending(command_fail(info->cmd, FUNDING_UNKNOWN_PEER, "Unknown peer"));
+		return;
+	}
+
+	if (!feature_negotiated(info->cmd->ld->our_features,
+			        peer->their_features,
+				OPT_DUAL_FUND)) {
+		was_pending(command_fail(info->cmd, FUNDING_V2_NOT_SUPPORTED,
+					 "v2 openchannel not supported "
+					 "by peer"));
+		return;
+	}
+
+	openchannel_init(info->cmd, peer,
+			 *info->amount,
+			 *info->request_amt,
+			 info->psbt,
+			 *info->feerate_per_kw_funding, *info->feerate_per_kw,
+			 info->our_upfront_shutdown_script,
+			 *info->announce_channel,
+			 info->rates, info->ctype);
+}
+
+static struct command_result *json_openchannel_init(struct command *cmd,
+						    const char *buffer,
+						    const jsmntok_t *obj UNNEEDED,
+						    const jsmntok_t *params)
+{
+	struct openchannel_init_info *info = tal(cmd, struct openchannel_init_info);
+	struct peer *peer;
+	struct amount_sat psbt_val;
+	struct command_result *res;
+
+	info->cmd = cmd;
+	if (!param_check(cmd, buffer, params,
+			 p_req("id", param_node_id, &info->id),
+			 p_req("amount", param_sat, &info->amount),
+			 p_req("initialpsbt", param_psbt, &info->psbt),
+			 p_opt("commitment_feerate", param_feerate, &info->feerate_per_kw),
+			 p_opt("funding_feerate", param_feerate, &info->feerate_per_kw_funding),
+			 p_opt_def("announce", param_bool, &info->announce_channel, true),
+			 p_opt("close_to", param_bitcoin_address, &info->our_upfront_shutdown_script),
+			 p_opt_def("request_amt", param_sat, &info->request_amt, AMOUNT_SAT(0)),
+			 p_opt("compact_lease", param_lease_hex, &info->rates),
+			 p_opt("channel_type", param_channel_type, &info->ctype),
+			 NULL))
+		return command_param_failed();
+
+	/* We only deal in v2 */
+	if (!psbt_set_version(info->psbt, 2)) {
+		return command_fail(cmd, LIGHTNINGD, "Could not set PSBT version.");
+	}
+
+	/* Gotta expect some rates ! */
+	if (!amount_sat_zero(*info->request_amt) && !info->rates)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Must pass in 'compact_lease' if requesting"
+				    " funds from peer");
+	psbt_val = AMOUNT_SAT(0);
+	for (size_t i = 0; i < info->psbt->num_inputs; i++) {
+		struct amount_sat in_amt = psbt_input_get_amount(info->psbt, i);
+		if (!amount_sat_add(&psbt_val, psbt_val, in_amt))
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Overflow in adding PSBT input"
+					    " values. %s",
+					    fmt_wally_psbt(tmpctx, info->psbt));
+	}
+
+	/* If they don't pass in at least enough in the PSBT to cover
+	 * their amount, nope */
+	if (!amount_sat_greater(psbt_val, *info->amount))
+		return command_fail(cmd, FUND_CANNOT_AFFORD,
+				    "Provided PSBT cannot afford funding of "
+				    "amount %s. %s",
+				    fmt_amount_sat(tmpctx, *info->amount),
+				    fmt_wally_psbt(tmpctx, info->psbt));
+
+	res = init_set_feerate(cmd, &info->feerate_per_kw, &info->feerate_per_kw_funding);
+	if (res)
+		return res;
+
+	peer = peer_by_id(cmd->ld, info->id);
+	if (!peer) {
+		return command_fail(cmd, FUNDING_UNKNOWN_PEER, "Unknown peer");
+	}
+
+	if (!feature_negotiated(cmd->ld->our_features,
+			        peer->their_features,
+				OPT_DUAL_FUND)) {
+		return command_fail(cmd, FUNDING_V2_NOT_SUPPORTED,
+				    "v2 openchannel not supported "
+				    "by peer");
+	}
+
+	if (info->ctype &&
+	    !cmd->ld->dev_any_channel_type &&
+	    !channel_type_accept(tmpctx,
+				 info->ctype->features,
+				 cmd->ld->our_features)) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "channel_type not supported");
+	}
+
+	/* BOLT #2:
+	 *  - if both nodes advertised `option_support_large_channel`:
+	 *    - MAY set `funding_satoshis` greater than or equal to 2^24 satoshi.
+	 *  - otherwise:
+	 *    - MUST set `funding_satoshis` to less than 2^24 satoshi.
+	 */
+	if (!feature_negotiated(cmd->ld->our_features,
+				peer->their_features, OPT_LARGE_CHANNELS)
+	    && amount_sat_greater(*info->amount, chainparams->max_funding))
+		return command_fail(cmd, FUND_MAX_EXCEEDED,
+				    "Amount exceeded %s",
+				    fmt_amount_sat(tmpctx, chainparams->max_funding));
+
+	/* Add serials to any input that's missing them */
+	psbt_add_serials(info->psbt, TX_INITIATOR);
+
+	/* We require the PSBT to meet certain criteria such as
+	 * extra, proprietary fields (`serial_id`s) or
+	 * to have a `redeemscripts` iff the inputs are P2SH.
+	 *
+	 * Since this is externally provided, we confirm that
+	 * they've done the right thing / haven't lost any required info.
+	 */
+	if (!psbt_has_required_fields(info->psbt))
+		return command_fail(cmd, FUNDING_PSBT_INVALID,
+				    "PSBT is missing required fields %s",
+				    fmt_wally_psbt(tmpctx, info->psbt));
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	if (!topology_synced(cmd->ld->topology)) {
+		json_notify_fmt(cmd, LOG_UNUSUAL,
+				"Waiting to sync with bitcoind network (block %u of %u)",
+				get_block_height(cmd->ld->topology),
+				get_network_blockheight(cmd->ld->topology));
+
+		topology_add_sync_waiter(cmd, cmd->ld->topology,
+					 openchannel_init_after_sync,
+					 info);
+		return command_still_pending(cmd);
+	}
+
+	return openchannel_init(cmd, peer,
+				*info->amount,
+				*info->request_amt,
+				info->psbt,
+				*info->feerate_per_kw_funding, *info->feerate_per_kw,
+				info->our_upfront_shutdown_script,
+				*info->announce_channel,
+				info->rates, info->ctype);
 }
 
 static void psbt_request_valid(struct psbt_validator *pv)

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -731,20 +731,27 @@ void json_notify_fmt(struct command *cmd,
 {
 	va_list ap;
 	struct json_stream *js;
+	const char *msg;
 
+	va_start(ap, fmt);
+	msg = tal_vfmt(tmpctx, fmt, ap);
+	va_end(ap);
+
+	/* Help for tests */
+	log_debug(cmd->ld->log, "NOTIFY %s %s %s",
+		  cmd->id, log_level_name(level), msg);
 	if (!cmd->send_notifications)
 		return;
 
 	js = json_stream_raw_for_cmd(cmd);
 
-	va_start(ap, fmt);
 	json_object_start(js, NULL);
 	json_add_string(js, "jsonrpc", "2.0");
 	json_add_string(js, "method", "message");
 	json_object_start(js, "params");
 	json_add_id(js, cmd->id);
 	json_add_string(js, "level", log_level_name(level));
-	json_add_string(js, "message", tal_vfmt(tmpctx, fmt, ap));
+	json_add_string(js, "message", msg);
 	json_object_end(js);
 	json_object_end(js);
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1161,17 +1161,6 @@ static struct command_result *fundchannel_start(struct command *cmd,
 	peer->uncommitted_channel->fc = tal_steal(peer->uncommitted_channel, fc);
 	fc->uc = peer->uncommitted_channel;
 
-	/* BOLT #2:
-	 *
-	 * The sender:
-	 *   - if `channel_type` includes `option_zeroconf`:
-	 *      - MUST set `minimum_depth` to zero.
-	 *   - otherwise:
-	 *     - SHOULD set `minimum_depth` to a number of blocks it
-	 *       considers reasonable to avoid double-spending of the
-	 *       funding transaction.
-	 */
-	/* FIXME: What does that quote have to do with this??? --RR */
 	fc->uc->minimum_depth = mindepth;
 
 	fc->uc->reserve = tal_steal(fc->uc, reserve);
@@ -1262,7 +1251,7 @@ static struct command_result *json_fundchannel_start(struct command *cmd,
 			 p_opt_def("announce", param_bool, &announce_channel, true),
 			 p_opt("close_to", param_bitcoin_address, &fc->our_upfront_shutdown_script),
 			 p_opt("push_msat", param_msat, &push_msat),
-			 p_opt_def("mindepth", param_u32, &mindepth, cmd->ld->config.anchor_confirms),
+			 p_opt("mindepth", param_u32, &mindepth),
 			 p_opt("reserve", param_sat, &reserve),
 			 p_opt("channel_type", param_channel_type, &ctype),
 			 NULL))
@@ -1277,9 +1266,32 @@ static struct command_result *json_fundchannel_start(struct command *cmd,
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "channel_type not supported");
 		}
+		/* BOLT #2:
+		 *
+		 * The sender:
+		 *   - if `channel_type` includes `option_zeroconf`:
+		 *      - MUST set `minimum_depth` to zero.
+		 *   - otherwise:
+		 *     - SHOULD set `minimum_depth` to a number of blocks it
+		 *       considers reasonable to avoid double-spending of the
+		 *       funding transaction.
+		 */
+		if (channel_type_has(ctype, OPT_ZEROCONF)) {
+			if (mindepth && *mindepth != 0) {
+				return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+						    "Cannot set non-zero mindepth for zero-conf channel_type");
+			}
+			if (!mindepth) {
+				mindepth = tal(cmd, u32);
+				*mindepth = 0;
+			}
+		}
 	} else {
 		fc->channel_type = NULL;
 	}
+
+	if (!mindepth)
+		mindepth = tal_dup(cmd, u32, &cmd->ld->config.anchor_confirms);
 
 	if (push_msat && amount_msat_greater_sat(*push_msat, *amount))
 		return command_fail(cmd, FUND_CANNOT_AFFORD,

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -732,7 +732,8 @@ static const u8 *send_onion(const tal_t *ctx, struct lightningd *ld,
 	const u8 *onion;
 	unsigned int base_expiry;
 
-	base_expiry = get_block_height(ld->topology) + 1;
+	/* Use bitcoind's block height, even if we're behind in processing */
+	base_expiry = get_network_blockheight(ld->topology) + 1;
 	onion = serialize_onionpacket(tmpctx, packet);
 	return send_htlc_out(ctx, channel, first_hop->amount,
 			     base_expiry + first_hop->delay,
@@ -1166,8 +1167,9 @@ send_payment(struct lightningd *ld,
 	bool ret;
 	u8 *onion;
 
-	/* Expiry for HTLCs is absolute.  And add one to give some margin. */
-	base_expiry = get_block_height(ld->topology) + 1;
+	/* Expiry for HTLCs is absolute.  And add one to give some margin,
+	   and use bitcoind's block height, even if we're behind in processing */
+	base_expiry = get_network_blockheight(ld->topology) + 1;
 
 	path = sphinx_path_new(tmpctx, rhash->u.u8);
 	/* Extract IDs for each hop: create_onionpacket wants array. */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -629,10 +629,12 @@ const u8 *send_htlc_out(const tal_t *ctx,
 							channel_update_for_error(tmpctx, out));
 	}
 
+	/* Note: we allow outgoing HTLCs before sync, for fast startup. */
 	if (!topology_synced(out->peer->ld->topology)) {
-		log_info(out->log, "Attempt to send HTLC but still syncing"
-			 " with bitcoin network");
-		return towire_temporary_node_failure(ctx);
+		log_debug(out->log, "Sending HTLC while still syncing"
+			  " with bitcoin network (%u vs %u)",
+			  get_block_height(out->peer->ld->topology),
+			  get_network_blockheight(out->peer->ld->topology));
 	}
 
 	/* Make peer's daemon own it, catch if it dies. */

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -188,9 +188,9 @@ def test_lightningd_still_loading(node_factory, bitcoind, executor):
     # Make sure it's connected to l2 (otherwise we get TEMPORARY_CHANNEL_FAILURE)
     wait_for(lambda: only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['connected'])
 
-    # Payments will fail.  FIXME: More informative msg?
-    with pytest.raises(RpcError, match=r'TEMPORARY_NODE_FAILURE'):
-        l1.pay(l2, 1000)
+    # Payments will succced.
+    l1.pay(l2, 1000)
+    assert l1.daemon.is_in_log(r"Sending HTLC while still syncing with bitcoin network \(104 vs 105\)")
 
     # Can't fund a new channel.
     l1.rpc.connect(l3.info['id'], 'localhost', l3.port)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -2167,55 +2167,55 @@ def test_setchannel_usage(node_factory, bitcoind):
 def test_setchannel_state(node_factory, bitcoind):
     # TEST SETUP
     #
-    # [l0] --> [l1] --> [l2]
+    # [l1] --> [l2] --> [l3]
     #
-    # Initiate channel [l1,l2] and try to set feerates other states than
+    # Initiate channel [l2,l3] and try to set feerates other states than
     # CHANNELD_NORMAL or CHANNELD_AWAITING_LOCKIN. Should raise error.
-    # Use l0 to make a forward through l1/l2 for testing.
+    # Use l1 to make a forward through l2/l3 for testing.
     DEF_BASE = 0
     DEF_PPM = 0
 
-    l0, l1, l2 = node_factory.get_nodes(3, opts={
+    l1, l2, l3 = node_factory.get_nodes(3, opts={
         'fee-base': DEF_BASE,
         'fee-per-satoshi': DEF_PPM
     })
 
     # connection and funding
-    l0.rpc.connect(l1.info['id'], 'localhost', l1.port)
-    l0.fundchannel(l1, 1000000, wait_for_active=True)
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
-    scid, _ = l1.fundchannel(l2, 1000000, wait_for_active=False)
+    l1.fundchannel(l2, 1000000, wait_for_active=True)
+    l2.rpc.connect(l3.info['id'], 'localhost', l3.port)
+    scid, _ = l2.fundchannel(l3, 1000000, wait_for_active=False)
 
     # try setting the fee in state AWAITING_LOCKIN should be possible
-    # assert(l1.channel_state(l2) == "CHANNELD_AWAITING_LOCKIN")
-    result = l1.rpc.setchannel(l2.info['id'], 42, 0)
-    assert(result['channels'][0]['peer_id'] == l2.info['id'])
+    # assert(l2.channel_state(l3) == "CHANNELD_AWAITING_LOCKIN")
+    result = l2.rpc.setchannel(l3.info['id'], 42, 0)
+    assert(result['channels'][0]['peer_id'] == l3.info['id'])
     # cid = result['channels'][0]['channel_id']
 
     # test routing correct new fees once routing is established
-    mine_funding_to_announce(bitcoind, [l0, l1, l2])
+    mine_funding_to_announce(bitcoind, [l1, l2, l3])
 
-    l0.wait_for_route(l2)
-    inv = l2.rpc.invoice(100000, 'test_setchannel_state', 'desc')['bolt11']
-    result = l0.dev_pay(inv, dev_use_shadow=False)
+    l1.wait_for_route(l3)
+    inv = l3.rpc.invoice(100000, 'test_setchannel_state', 'desc')['bolt11']
+    result = l1.dev_pay(inv, dev_use_shadow=False)
     assert result['status'] == 'complete'
     assert result['amount_sent_msat'] == 100042
 
-    # Disconnect and unilaterally close from l2 to l1
-    l2.rpc.disconnect(l1.info['id'], force=True)
-    result = l2.rpc.close(scid, 1)
+    # Disconnect and unilaterally close from l3 to l2
+    l3.rpc.disconnect(l2.info['id'], force=True)
+    result = l3.rpc.close(scid, 1)
     assert result['type'] == 'unilateral'
 
-    # wait for l1 to see unilateral close via bitcoin network
-    while l1.channel_state(l2) == "CHANNELD_NORMAL":
+    # wait for l2 to see unilateral close via bitcoin network
+    while l2.channel_state(l3) == "CHANNELD_NORMAL":
         bitcoind.generate_block(1)
-    # assert l1.channel_state(l2) == "FUNDING_SPEND_SEEN"
+    # assert l2.channel_state(l3) == "FUNDING_SPEND_SEEN"
 
     # Try to setchannel in order to raise expected error.
     # To reduce false positive flakes, only test if state is not NORMAL anymore.
     with pytest.raises(RpcError, match=r'-1.*'):
-        # l1.rpc.setchannel(l2.info['id'], 10, 1)
-        l1.rpc.setchannel(l2.info['id'], 10, 1)
+        # l2.rpc.setchannel(l3.info['id'], 10, 1)
+        l2.rpc.setchannel(l3.info['id'], 10, 1)
 
 
 def test_setchannel_routing(node_factory, bitcoind):

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -336,6 +336,9 @@ bool fromwire_openingd_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNE
 /* Generated stub for get_block_height */
 u32 get_block_height(const struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "get_block_height called!\n"); abort(); }
+/* Generated stub for get_network_blockheight */
+u32 get_network_blockheight(const struct chain_topology *topo UNNEEDED)
+{ fprintf(stderr, "get_network_blockheight called!\n"); abort(); }
 /* Generated stub for hsmd_wire_name */
 const char *hsmd_wire_name(int e UNNEEDED)
 { fprintf(stderr, "hsmd_wire_name called!\n"); abort(); }


### PR DESCRIPTION
Don't require us to be fully synced with bitcoind before we allow certain operations:
1. Allow outgoing HTLCs immediately.
2. Wait for openchannel_init/openchannel_bump/fundchannel_start instead of failing.
3. Use bitcoind's height, not ours, for CLTV values on payments.

This means Greenlight doesn't have to block operations while waiting for block sync.