### PR TITLE
hsmd: make get_per_commitment_point unconditionally safe by not returning secret

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -1420,11 +1420,8 @@ static void start_commit_timer(struct peer *peer)
 }
 
 /* Fetch the requested point. The secret is no longer returned, use
- * revoke_commitment.
- *
- * NOTE - Because the internals of this call also release the secret
- * from a revoked commitment it is an error to call this past the next
- * commitment.
+ * revoke_commitment instead.  It is legal to call this on any
+ * commitment (including distant future).
  */
 static void get_per_commitment_point(u64 index, struct pubkey *point)
 {

--- a/common/hsm_version.h
+++ b/common/hsm_version.h
@@ -25,7 +25,8 @@
  * v5 drop init v2: 5024454532fe5a78bb7558000cb344190888b9915360d3d56ddca22eaba9b872
  * v5 with dev_preinit: b93e18534a468a4aa9f7015db42e9c363c32aeee5f9146b36dc953ebbdc3d33c
  * v5 with preapprove_check: 0ed6dd4ea2c02b67c51b1420b3d07ab2227a4c06ce7e2942d946967687e9baf7
+ * v6 no secret from get_per_commitment_point: 0cad1790beb3473d64355f4cb4f64daa80c28c8a241998b7ef0223385d7ffff9
 */
 #define HSM_MIN_VERSION 5
-#define HSM_MAX_VERSION 5
+#define HSM_MAX_VERSION 6
 #endif /* LIGHTNING_COMMON_HSM_VERSION_H */

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -511,8 +511,8 @@ static struct io_plan *init_hsm(struct io_conn *conn,
 		discard_key(take(hsm_encryption_key));
 
 	/* Define the minimum common max version for the hsmd one */
-	u64 mutual_version = maxversion < our_maxversion ? maxversion : our_maxversion;
-	return req_reply(conn, c, hsmd_init(hsm_secret, mutual_version,
+	hsmd_mutual_version = maxversion < our_maxversion ? maxversion : our_maxversion;
+	return req_reply(conn, c, hsmd_init(hsm_secret, hsmd_mutual_version,
 					    bip32_key_version));
 }
 

--- a/hsmd/hsmd.c
+++ b/hsmd/hsmd.c
@@ -457,7 +457,7 @@ static struct io_plan *init_hsm(struct io_conn *conn,
 	struct secret *hsm_encryption_key;
 	struct bip32_key_version bip32_key_version;
 	u32 minversion, maxversion;
-	const u32 our_minversion = 4, our_maxversion = 5;
+	const u32 our_minversion = 4, our_maxversion = 6;
 
 	/* This must be lightningd. */
 	assert(is_lightningd(c));

--- a/hsmd/hsmd_wire.csv
+++ b/hsmd/hsmd_wire.csv
@@ -324,10 +324,12 @@ msgdata,hsmd_sign_splice_tx,input_index,u32,
 msgtype,hsmd_sign_tx_reply,112
 msgdata,hsmd_sign_tx_reply,sig,bitcoin_signature,
 
-# Openingd/channeld/onchaind asks for Nth per_commitment_point, if > 2, gets N-2 secret.
+# Openingd/channeld/onchaind asks for Nth per_commitment_point
+# Prior to HSM_VERSION 6 we will return an old_commitment_secret
 msgtype,hsmd_get_per_commitment_point,18
 msgdata,hsmd_get_per_commitment_point,n,u64,
 
+# IMPORTANT - Beginning HSM_VERSION 6 we never return an old_commitment_secret
 msgtype,hsmd_get_per_commitment_point_reply,118
 msgdata,hsmd_get_per_commitment_point_reply,per_commitment_point,pubkey,
 msgdata,hsmd_get_per_commitment_point_reply,old_commitment_secret,?secret,

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -15,6 +15,9 @@
 #include <sodium/utils.h>
 #include <wally_psbt.h>
 
+/* The negotiated protocol version ends up in here. */
+u64 hsmd_mutual_version;
+
 /* If they specify --dev-force-privkey it ends up in here. */
 struct privkey *dev_force_privkey;
 /* If they specify --dev-force-bip32-seed it ends up in here. */

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -1206,7 +1206,7 @@ static u8 *handle_get_per_commitment_point(struct hsmd_client *c, const u8 *msg_
 		return hsmd_status_bad_request_fmt(
 		    c, msg_in, "bad per_commit_point %" PRIu64, n);
 
-	if (n >= 2) {
+	if (hsmd_mutual_version < 6 && n >= 2) {
 		old_secret = tal(tmpctx, struct secret);
 		if (!per_commit_secret(&shaseed, old_secret, n - 2)) {
 			return hsmd_status_bad_request_fmt(

--- a/hsmd/libhsmd.h
+++ b/hsmd/libhsmd.h
@@ -89,6 +89,9 @@ void hsmd_status_failed(enum status_failreason code,
 bool hsmd_check_client_capabilities(struct hsmd_client *client,
 				    enum hsmd_wire t);
 
+/* The negotiated protocol version ends up in here. */
+extern u64 hsmd_mutual_version;
+
 /* If they specify --dev-force-privkey it ends up in here. */
 extern struct privkey *dev_force_privkey;
 /* If they specify --dev-force-bip32-seed it ends up in here. */


### PR DESCRIPTION
Removes returned old_secret from get_per_commitment_point making it safe to call on all commits

Motivation: When get_per_commitment_point returns the old secret it implies a revocation of index - 2. This causes a crash when VLS has validated a commitment but not seen the following revoke of the prior and the channel is asynchronously restarted. See https://gitlab.com/lightning-signer/validating-lightning-signer/-/issues/469

The last two commits in this PR are somewhat optional: by increasing the HSM_VERSION to 6 we can inform the signer that it should never return an old_secret (and therefore can't fail). The native hsmd implementation doesn't have the safety issue and it would be ok to leave it at HSM_VERSION 5. But it's cleaner to have consistent semantics.

All but the last two commits in the PR sequence are cleanup and reduction refactoring and worth considering even if an HSM_VERSION change is not considered.

Cleanup and refactoring Includes:
- prune unreachable pre HSM_VERSION 5 code
- factor out unneeded make_revocation_msg_from_secret
- split get_per_commitment_point uses into separate functions (one for point, one for secret)
- make the negotiated hsmd version available to libhsmd