### PR TITLE
Remove spurious import

### DIFF
--- a/cln-grpc/src/pb.rs
+++ b/cln-grpc/src/pb.rs
@@ -1,8 +1,6 @@
 tonic::include_proto!("cln");
 
 #[cfg(feature = "server")]
-pub use crate::pb::convert::*;
-#[cfg(feature = "server")]
 pub use cln_rpc::primitives::Sha256;
 #[cfg(feature = "server")]
 mod convert {


### PR DESCRIPTION
The import is spurious and results in a warning when building the code.
I have removed the line to make the warning disappear
