### PR TITLE
pay: fix re-adding payment amount back to estimated capacity

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -583,15 +583,19 @@ apply_changes:
 				curhint->local->htlc_budget--;
 		}
 
-		if (remove && !amount_msat_add(
+		/* Don't get fancy and replace this with remove && !amount_msat_add
+		 * It won't work! */
+		if (remove) {
+			if (!amount_msat_add(
 			    &curhint->estimated_capacity,
 			    curhint->estimated_capacity,
 			    curhop->amount)) {
-			/* This should never happen, it'd mean
-			 * that we unapply a route that would
-			 * result in a msatoshi
-			 * wrap-around. */
-			abort();
+				/* This should never happen, it'd mean
+				 * that we unapply a route that would
+				 * result in a msatoshi
+				 * wrap-around. */
+				abort();
+			}
 		} else if (!amount_msat_sub(
 				   &curhint->estimated_capacity,
 				   curhint->estimated_capacity,


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/lightning/issues/7177

Below lines of code failed to actually re-add the amount back to the channel hint's estimated capacity.
https://github.com/ElementsProject/lightning/blob/4b8d2617bbbc678a67376b32332804b66a691034/plugins/libplugin-pay.c#L586-L589

I'm not sure why tbh, it seems like a reasonable piece of code. However, it made the corresponding test (added in this PR) fail, because the channel hint's estimated capacity of the sender's own channel was below the amount he was trying to send. I tested this by logging the `channel_hints` before and after the operation in those lines. When _substracting_ the amount (`remove == false`) the estimated capacity of the sender's channel after the operation was smaller than before the operation. When _adding_ the amount back (`remove == true`) the estimated capacity of the sender's channel after the operation was equal to what it was before the operation.

The consequence of this was that the estimated channel capacity in the sender's own channel was ever decreasing during the `pay` lifecycle. 