### PR TITLE
msggen: add `missing-grpc` command

### DIFF
--- a/contrib/msggen/msggen/__main__.py
+++ b/contrib/msggen/msggen/__main__.py
@@ -10,6 +10,7 @@ from msggen.utils import load_jsonrpc_service, combine_schemas
 import logging
 from msggen.patch import VersionAnnotationPatch, OptionalPatch, OverridePatch
 from msggen.checks import VersioningCheck
+from msggen.utils.utils import check_missing
 
 
 logging.basicConfig(
@@ -102,6 +103,7 @@ def main():
     bundle.add_argument('schema_dir', action='store')
 
     subcmds.add_parser("generate", help="generate all files")
+    subcmds.add_parser("missing-grpc", help="print all rpc commands missing from grpc")
     args = parser.parse_args()
 
     if args.silent:
@@ -118,6 +120,11 @@ def main():
         print(f"Combining schemas from {src.resolve()} into {dest.resolve()}")
         schema = combine_schemas(src, dest)
         print(f"Created {dest} from {len(schema)} files")
+    elif args.command == 'missing-grpc':
+        print("Missing RPC commands in grpc:")
+        missing = check_missing()
+        for name in missing:
+            print(name)
 
 
 if __name__ == "__main__":

--- a/contrib/msggen/msggen/utils/utils.py
+++ b/contrib/msggen/msggen/utils/utils.py
@@ -5,6 +5,147 @@ from msggen.model import Method, CompositeField, Service, Notification, TypeName
 import functools
 from collections import OrderedDict
 
+grpc_method_names = [
+    "Getinfo",
+    "ListPeers",
+    "ListFunds",
+    "SendPay",
+    "ListChannels",
+    "AddGossip",
+    "AddPsbtOutput",
+    "AutoClean-Once",
+    "AutoClean-Status",
+    "CheckMessage",
+    "Close",
+    "Connect",
+    "CreateInvoice",
+    "Datastore",
+    "DatastoreUsage",
+    "CreateOnion",
+    "DelDatastore",
+    "DelInvoice",
+    "Dev-Forget-Channel",
+    "EmergencyRecover",
+    "Recover",
+    "RecoverChannel",
+    "Invoice",
+    "InvoiceRequest",
+    "DisableInvoiceRequest",
+    "ListInvoiceRequests",
+    "ListDatastore",
+    "ListInvoices",
+    "SendOnion",
+    "ListSendPays",
+    "ListTransactions",
+    "MakeSecret",
+    "Pay",
+    "ListNodes",
+    "WaitAnyInvoice",
+    "WaitInvoice",
+    "WaitSendPay",
+    "NewAddr",
+    "Withdraw",
+    "KeySend",
+    "FundPsbt",
+    "SendPsbt",
+    "SignPsbt",
+    "UtxoPsbt",
+    "TxDiscard",
+    "TxPrepare",
+    "TxSend",
+    "ListPeerChannels",
+    "ListClosedChannels",
+    "DecodePay",
+    "Decode",
+    "DelPay",
+    "DelForward",
+    "DisableOffer",
+    "Disconnect",
+    "Feerates",
+    "FetchInvoice",
+    "FundChannel_Cancel",
+    "FundChannel_Complete",
+    "FundChannel",
+    "FundChannel_Start",
+    "GetLog",
+    "FunderUpdate",
+    "GetRoute",
+    "ListForwards",
+    "ListOffers",
+    "ListPays",
+    "ListHtlcs",
+    "MultiFundChannel",
+    "MultiWithdraw",
+    "Offer",
+    "OpenChannel_Abort",
+    "OpenChannel_Bump",
+    "OpenChannel_Init",
+    "OpenChannel_Signed",
+    "OpenChannel_Update",
+    # "parsefeerate",
+    "Ping",
+    "Plugin",
+    "RenePayStatus",
+    "RenePay",
+    "ReserveInputs",
+    "SendCustomMsg",
+    "SendInvoice",
+    "SendOnionMessage",
+    "SetChannel",
+    "SetConfig",
+    "SetPsbtVersion",
+    "SignInvoice",
+    "SignMessage",
+    "Splice_Init",
+    "Splice_Signed",
+    "Splice_Update",
+    "UnreserveInputs",
+    "UpgradeWallet",
+    "WaitBlockHeight",
+    "Wait",
+    "ListConfigs",
+    # "check",  # No point in mapping this one
+    "Stop",
+    # "notifications",  # No point in mapping this
+    "Help",
+    "PreApproveKeysend",
+    "PreApproveInvoice",
+    "StaticBackup",
+    "Bkpr-ChannelsApy",
+    "Bkpr-DumpIncomeCsv",
+    "Bkpr-Inspect",
+    "Bkpr-ListAccountEvents",
+    "Bkpr-ListBalances",
+    "Bkpr-ListIncome",
+    "BlacklistRune",
+    "CheckRune",
+    "CreateRune",
+    "ShowRunes",
+]
+
+grpc_notification_names = [
+    {
+        "name": "block_added",
+        "typename": "BlockAdded"
+    },
+    {
+        "name": "channel_open_failed",
+        "typename": "ChannelOpenFailed"
+    },
+    {
+        "name": "channel_opened",
+        "typename": "ChannelOpened"
+    },
+    {
+        "name": "connect",
+        "typename": "Connect"
+    },
+    {
+        "name": "custommsg",
+        "typename": "CustomMsg"
+    },
+]
+
 
 def combine_schemas(schema_dir: Path, dest: Path):
     """Enumerate all schema files, and combine it into a single JSON file."""
@@ -50,6 +191,17 @@ def get_schema_bundle():
     return json.load(p)
 
 
+def check_missing():
+    """Check for missing gRPC commands in the schema.
+    """
+    schema = get_schema_bundle()
+    command_names = set(
+        full_name.replace("lightning-", "").replace(".json", "") for full_name in schema["methods"].keys()
+    )
+    lower_method_names = set(name.lower() for name in grpc_method_names)
+    return command_names - lower_method_names
+
+
 def load_jsonrpc_method(name):
     """Load a method based on the file naming conventions for the JSON-RPC.
     """
@@ -89,151 +241,8 @@ def load_notification(name, typename: TypeName):
 
 
 def load_jsonrpc_service():
-    # FIXME: Maybe this list should be located somewhere other than utils so
-    #  it's more intuitive to remember to update when new RPC calls are added?
-    method_names = [
-        "Getinfo",
-        "ListPeers",
-        "ListFunds",
-        "SendPay",
-        "ListChannels",
-        "AddGossip",
-        "AddPsbtOutput",
-        "AutoClean-Once",
-        "AutoClean-Status",
-        "CheckMessage",
-        "Close",
-        "Connect",
-        "CreateInvoice",
-        "Datastore",
-        "DatastoreUsage",
-        "CreateOnion",
-        "DelDatastore",
-        "DelInvoice",
-        "Dev-Forget-Channel",
-        "EmergencyRecover",
-        "Recover",
-        "RecoverChannel",
-        "Invoice",
-        "InvoiceRequest",
-        "DisableInvoiceRequest",
-        "ListInvoiceRequests",
-        "ListDatastore",
-        "ListInvoices",
-        "SendOnion",
-        "ListSendPays",
-        "ListTransactions",
-        "MakeSecret",
-        "Pay",
-        "ListNodes",
-        "WaitAnyInvoice",
-        "WaitInvoice",
-        "WaitSendPay",
-        "NewAddr",
-        "Withdraw",
-        "KeySend",
-        "FundPsbt",
-        "SendPsbt",
-        "SignPsbt",
-        "UtxoPsbt",
-        "TxDiscard",
-        "TxPrepare",
-        "TxSend",
-        "ListPeerChannels",
-        "ListClosedChannels",
-        "DecodePay",
-        "Decode",
-        "DelPay",
-        "DelForward",
-        "DisableOffer",
-        "Disconnect",
-        "Feerates",
-        "FetchInvoice",
-        "FundChannel_Cancel",
-        "FundChannel_Complete",
-        "FundChannel",
-        "FundChannel_Start",
-        "GetLog",
-        "FunderUpdate",
-        "GetRoute",
-        "ListForwards",
-        "ListOffers",
-        "ListPays",
-        "ListHtlcs",
-        "MultiFundChannel",
-        "MultiWithdraw",
-        "Offer",
-        "OpenChannel_Abort",
-        "OpenChannel_Bump",
-        "OpenChannel_Init",
-        "OpenChannel_Signed",
-        "OpenChannel_Update",
-        # "parsefeerate",
-        "Ping",
-        "Plugin",
-        "RenePayStatus",
-        "RenePay",
-        "ReserveInputs",
-        "SendCustomMsg",
-        "SendInvoice",
-        "SendOnionMessage",
-        "SetChannel",
-        "SetConfig",
-        "SetPsbtVersion",
-        "SignInvoice",
-        "SignMessage",
-        "Splice_Init",
-        "Splice_Signed",
-        "Splice_Update",
-        "UnreserveInputs",
-        "UpgradeWallet",
-        "WaitBlockHeight",
-        "Wait",
-        "ListConfigs",
-        # "check",  # No point in mapping this one
-        "Stop",
-        # "notifications",  # No point in mapping this
-        "Help",
-        "PreApproveKeysend",
-        "PreApproveInvoice",
-        "StaticBackup",
-        "Bkpr-ChannelsApy",
-        "Bkpr-DumpIncomeCsv",
-        "Bkpr-Inspect",
-        "Bkpr-ListAccountEvents",
-        "Bkpr-ListBalances",
-        "Bkpr-ListIncome",
-        "BlacklistRune",
-        "CheckRune",
-        "CreateRune",
-        "ShowRunes",
-    ]
-
-    notification_names = [
-        {
-            "name": "block_added",
-            "typename": "BlockAdded"
-        },
-        {
-            "name": "channel_open_failed",
-            "typename": "ChannelOpenFailed"
-        },
-        {
-            "name": "channel_opened",
-            "typename": "ChannelOpened"
-        },
-        {
-            "name": "connect",
-            "typename": "Connect"
-        },
-        {
-            "name": "custommsg",
-            "typename": "CustomMsg"
-        },
-    ]
-
-    methods = [load_jsonrpc_method(name) for name in method_names]
-    notifications = [load_notification(name=names["name"], typename=names["typename"]) for names in notification_names]
+    methods = [load_jsonrpc_method(name) for name in grpc_method_names]
+    notifications = [load_notification(name=names["name"], typename=names["typename"]) for names in grpc_notification_names]
     service = Service(name="Node", methods=methods, notifications=notifications)
     service.includes = ['primitives.proto']  # Make sure we have the primitives included.
     return service


### PR DESCRIPTION
This PR adds a `missing-grpc` command to msggen which can be used to track down missing grpc methods: https://github.com/ElementsProject/lightning/issues/7167#issuecomment-2016969997
It currently outputs:
```
Missing RPC commands in grpc:
delforward
makesecret
reserveinputs
batching
upgradewallet
openchannel_signed
dev-forget-channel
renepaystatus
autoclean-status
delpay
fundchannel_complete
bkpr-listaccountevents
emergencyrecover
check
sql-template
splice_init
commando-blacklist
openchannel_abort
showrunes
getlog
listinvoicerequests
parsefeerate
multiwithdraw
openchannel_init
disableinvoicerequest
splice_signed
disableoffer
commando-listrunes
notifications
openchannel_bump
bkpr-dumpincomecsv
autoclean-once
checkrune
recoverchannel
fundchannel_start
deprecations
splice_update
bkpr-channelsapy
blacklistrune
sendonionmessage
recover
addpsbtoutput
unreserveinputs
listconfigs
plugin
createrune
fundchannel_cancel
commando-rune
listsqlschemas
commando
help
multifundchannel
renepay
openchannel_update
funderupdate
bkpr-inspect
bkpr-listbalances
sendinvoice
invoicerequest
setpsbtversion
setconfig
```