### PR TITLE
newaddr: various fixes for msggen and docs

### DIFF
--- a/.msggen.json
+++ b/.msggen.json
@@ -330,7 +330,6 @@
         "NewaddrAddresstype": {
             "all": 2,
             "bech32": 0,
-            "p2sh-segwit": 1,
             "p2tr": 3
         },
         "PayStatus": {
@@ -1562,7 +1561,6 @@
         },
         "NewaddrResponse": {
             "NewAddr.bech32": 1,
-            "NewAddr.p2sh-segwit": 2,
             "NewAddr.p2tr": 3
         },
         "OfferRecurrence": {
@@ -5620,10 +5618,6 @@
         "NewAddr.bech32": {
             "added": "pre-v0.10.1",
             "deprecated": false
-        },
-        "NewAddr.p2sh-segwit": {
-            "added": "pre-v0.10.1",
-            "deprecated": "v23.02"
         },
         "NewAddr.p2tr": {
             "added": "v23.08",

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ lightning-cli newaddr
 
 `lightningd` will register the funds once the transaction is confirmed.
 
-You may need to generate a p2sh-segwit address if the faucet does not support bech32:
+Alternatively you can generate a taproot address should your source of funds support it:
 
 ```bash
-# Return a p2sh-segwit address
-lightning-cli newaddr p2sh-segwit
+# Return a taproot address
+lightning-cli newaddr p2tr
 ```
 
 Confirm `lightningd` got funds by:

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -199,13 +199,13 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeersLevel {
 	    #[serde(rename = "io")]
-	    IO,
+	    IO = 0,
 	    #[serde(rename = "debug")]
-	    DEBUG,
+	    DEBUG = 1,
 	    #[serde(rename = "info")]
-	    INFO,
+	    INFO = 2,
 	    #[serde(rename = "unusual")]
-	    UNUSUAL,
+	    UNUSUAL = 3,
 	}
 
 	impl TryFrom<i32> for ListpeersLevel {
@@ -516,15 +516,15 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DatastoreMode {
 	    #[serde(rename = "must-create")]
-	    MUST_CREATE,
+	    MUST_CREATE = 0,
 	    #[serde(rename = "must-replace")]
-	    MUST_REPLACE,
+	    MUST_REPLACE = 1,
 	    #[serde(rename = "create-or-replace")]
-	    CREATE_OR_REPLACE,
+	    CREATE_OR_REPLACE = 2,
 	    #[serde(rename = "must-append")]
-	    MUST_APPEND,
+	    MUST_APPEND = 3,
 	    #[serde(rename = "create-or-append")]
-	    CREATE_OR_APPEND,
+	    CREATE_OR_APPEND = 4,
 	}
 
 	impl TryFrom<i32> for DatastoreMode {
@@ -667,11 +667,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 0,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 1,
 	    #[serde(rename = "unpaid")]
-	    UNPAID,
+	    UNPAID = 2,
 	}
 
 	impl TryFrom<i32> for DelinvoiceStatus {
@@ -783,9 +783,9 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListinvoicesIndex {
 	    #[serde(rename = "created")]
-	    CREATED,
+	    CREATED = 0,
 	    #[serde(rename = "updated")]
-	    UPDATED,
+	    UPDATED = 1,
 	}
 
 	impl TryFrom<i32> for ListinvoicesIndex {
@@ -896,11 +896,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListsendpaysStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 1,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 2,
 	}
 
 	impl TryFrom<i32> for ListsendpaysStatus {
@@ -929,9 +929,9 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListsendpaysIndex {
 	    #[serde(rename = "created")]
-	    CREATED,
+	    CREATED = 0,
 	    #[serde(rename = "updated")]
-	    UPDATED,
+	    UPDATED = 1,
 	}
 
 	impl TryFrom<i32> for ListsendpaysIndex {
@@ -1156,11 +1156,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum NewaddrAddresstype {
 	    #[serde(rename = "bech32")]
-	    BECH32,
+	    BECH32 = 0,
 	    #[serde(rename = "p2tr")]
-	    P2TR,
+	    P2TR = 3,
 	    #[serde(rename = "all")]
-	    ALL,
+	    ALL = 2,
 	}
 
 	impl TryFrom<i32> for NewaddrAddresstype {
@@ -1589,9 +1589,9 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum FeeratesStyle {
 	    #[serde(rename = "perkb")]
-	    PERKB,
+	    PERKB = 0,
 	    #[serde(rename = "perkw")]
-	    PERKW,
+	    PERKW = 1,
 	}
 
 	impl TryFrom<i32> for FeeratesStyle {
@@ -1756,13 +1756,13 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsStatus {
 	    #[serde(rename = "offered")]
-	    OFFERED,
+	    OFFERED = 0,
 	    #[serde(rename = "settled")]
-	    SETTLED,
+	    SETTLED = 1,
 	    #[serde(rename = "local_failed")]
-	    LOCAL_FAILED,
+	    LOCAL_FAILED = 2,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 3,
 	}
 
 	impl TryFrom<i32> for ListforwardsStatus {
@@ -1793,9 +1793,9 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsIndex {
 	    #[serde(rename = "created")]
-	    CREATED,
+	    CREATED = 0,
 	    #[serde(rename = "updated")]
-	    UPDATED,
+	    UPDATED = 1,
 	}
 
 	impl TryFrom<i32> for ListforwardsIndex {
@@ -1880,11 +1880,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpaysStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 1,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 2,
 	}
 
 	impl TryFrom<i32> for ListpaysStatus {
@@ -2207,11 +2207,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitSubsystem {
 	    #[serde(rename = "invoices")]
-	    INVOICES,
+	    INVOICES = 0,
 	    #[serde(rename = "forwards")]
-	    FORWARDS,
+	    FORWARDS = 1,
 	    #[serde(rename = "sendpays")]
-	    SENDPAYS,
+	    SENDPAYS = 2,
 	}
 
 	impl TryFrom<i32> for WaitSubsystem {
@@ -2240,11 +2240,11 @@ pub mod requests {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitIndexname {
 	    #[serde(rename = "created")]
-	    CREATED,
+	    CREATED = 0,
 	    #[serde(rename = "updated")]
-	    UPDATED,
+	    UPDATED = 1,
 	    #[serde(rename = "deleted")]
-	    DELETED,
+	    DELETED = 2,
 	}
 
 	impl TryFrom<i32> for WaitIndexname {
@@ -2436,15 +2436,15 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetinfoAddressType {
 	    #[serde(rename = "dns")]
-	    DNS,
+	    DNS = 0,
 	    #[serde(rename = "ipv4")]
-	    IPV4,
+	    IPV4 = 1,
 	    #[serde(rename = "ipv6")]
-	    IPV6,
+	    IPV6 = 2,
 	    #[serde(rename = "torv2")]
-	    TORV2,
+	    TORV2 = 3,
 	    #[serde(rename = "torv3")]
-	    TORV3,
+	    TORV3 = 4,
 	}
 
 	impl TryFrom<i32> for GetinfoAddressType {
@@ -2487,17 +2487,17 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetinfoBindingType {
 	    #[serde(rename = "local socket")]
-	    LOCAL_SOCKET,
+	    LOCAL_SOCKET = 0,
 	    #[serde(rename = "websocket")]
-	    WEBSOCKET,
+	    WEBSOCKET = 5,
 	    #[serde(rename = "ipv4")]
-	    IPV4,
+	    IPV4 = 1,
 	    #[serde(rename = "ipv6")]
-	    IPV6,
+	    IPV6 = 2,
 	    #[serde(rename = "torv2")]
-	    TORV2,
+	    TORV2 = 3,
 	    #[serde(rename = "torv3")]
-	    TORV3,
+	    TORV3 = 4,
 	}
 
 	impl TryFrom<i32> for GetinfoBindingType {
@@ -2583,19 +2583,19 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeersPeersLogType {
 	    #[serde(rename = "SKIPPED")]
-	    SKIPPED,
+	    SKIPPED = 0,
 	    #[serde(rename = "BROKEN")]
-	    BROKEN,
+	    BROKEN = 1,
 	    #[serde(rename = "UNUSUAL")]
-	    UNUSUAL,
+	    UNUSUAL = 2,
 	    #[serde(rename = "INFO")]
-	    INFO,
+	    INFO = 3,
 	    #[serde(rename = "DEBUG")]
-	    DEBUG,
+	    DEBUG = 4,
 	    #[serde(rename = "IO_IN")]
-	    IO_IN,
+	    IO_IN = 5,
 	    #[serde(rename = "IO_OUT")]
-	    IO_OUT,
+	    IO_OUT = 6,
 	}
 
 	impl TryFrom<i32> for ListpeersPeersLogType {
@@ -2682,13 +2682,13 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListfundsOutputsStatus {
 	    #[serde(rename = "unconfirmed")]
-	    UNCONFIRMED,
+	    UNCONFIRMED = 0,
 	    #[serde(rename = "confirmed")]
-	    CONFIRMED,
+	    CONFIRMED = 1,
 	    #[serde(rename = "spent")]
-	    SPENT,
+	    SPENT = 2,
 	    #[serde(rename = "immature")]
-	    IMMATURE,
+	    IMMATURE = 3,
 	}
 
 	impl TryFrom<i32> for ListfundsOutputsStatus {
@@ -2769,9 +2769,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum SendpayStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 1,
 	}
 
 	impl TryFrom<i32> for SendpayStatus {
@@ -2932,11 +2932,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum CloseType {
 	    #[serde(rename = "mutual")]
-	    MUTUAL,
+	    MUTUAL = 0,
 	    #[serde(rename = "unilateral")]
-	    UNILATERAL,
+	    UNILATERAL = 1,
 	    #[serde(rename = "unopened")]
-	    UNOPENED,
+	    UNOPENED = 2,
 	}
 
 	impl TryFrom<i32> for CloseType {
@@ -2987,9 +2987,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ConnectDirection {
 	    #[serde(rename = "in")]
-	    IN,
+	    IN = 0,
 	    #[serde(rename = "out")]
-	    OUT,
+	    OUT = 1,
 	}
 
 	impl TryFrom<i32> for ConnectDirection {
@@ -3016,15 +3016,15 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ConnectAddressType {
 	    #[serde(rename = "local socket")]
-	    LOCAL_SOCKET,
+	    LOCAL_SOCKET = 0,
 	    #[serde(rename = "ipv4")]
-	    IPV4,
+	    IPV4 = 1,
 	    #[serde(rename = "ipv6")]
-	    IPV6,
+	    IPV6 = 2,
 	    #[serde(rename = "torv2")]
-	    TORV2,
+	    TORV2 = 3,
 	    #[serde(rename = "torv3")]
-	    TORV3,
+	    TORV3 = 4,
 	}
 
 	impl TryFrom<i32> for ConnectAddressType {
@@ -3090,11 +3090,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum CreateinvoiceStatus {
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 0,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 1,
 	    #[serde(rename = "unpaid")]
-	    UNPAID,
+	    UNPAID = 2,
 	}
 
 	impl TryFrom<i32> for CreateinvoiceStatus {
@@ -3260,11 +3260,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DelinvoiceStatus {
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 0,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 1,
 	    #[serde(rename = "unpaid")]
-	    UNPAID,
+	    UNPAID = 2,
 	}
 
 	impl TryFrom<i32> for DelinvoiceStatus {
@@ -3387,11 +3387,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListinvoicesInvoicesStatus {
 	    #[serde(rename = "unpaid")]
-	    UNPAID,
+	    UNPAID = 0,
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 1,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 2,
 	}
 
 	impl TryFrom<i32> for ListinvoicesInvoicesStatus {
@@ -3479,9 +3479,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum SendonionStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 1,
 	}
 
 	impl TryFrom<i32> for SendonionStatus {
@@ -3549,11 +3549,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListsendpaysPaymentsStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 1,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 2,
 	}
 
 	impl TryFrom<i32> for ListsendpaysPaymentsStatus {
@@ -3676,11 +3676,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum PayStatus {
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 0,
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 1,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 2,
 	}
 
 	impl TryFrom<i32> for PayStatus {
@@ -3736,15 +3736,15 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListnodesNodesAddressesType {
 	    #[serde(rename = "dns")]
-	    DNS,
+	    DNS = 0,
 	    #[serde(rename = "ipv4")]
-	    IPV4,
+	    IPV4 = 1,
 	    #[serde(rename = "ipv6")]
-	    IPV6,
+	    IPV6 = 2,
 	    #[serde(rename = "torv2")]
-	    TORV2,
+	    TORV2 = 3,
 	    #[serde(rename = "torv3")]
-	    TORV3,
+	    TORV3 = 4,
 	}
 
 	impl TryFrom<i32> for ListnodesNodesAddressesType {
@@ -3818,9 +3818,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitanyinvoiceStatus {
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 0,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 1,
 	}
 
 	impl TryFrom<i32> for WaitanyinvoiceStatus {
@@ -3896,9 +3896,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitinvoiceStatus {
 	    #[serde(rename = "paid")]
-	    PAID,
+	    PAID = 0,
 	    #[serde(rename = "expired")]
-	    EXPIRED,
+	    EXPIRED = 1,
 	}
 
 	impl TryFrom<i32> for WaitinvoiceStatus {
@@ -3974,7 +3974,7 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitsendpayStatus {
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 0,
 	}
 
 	impl TryFrom<i32> for WaitsendpayStatus {
@@ -4079,7 +4079,7 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum KeysendStatus {
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 0,
 	}
 
 	impl TryFrom<i32> for KeysendStatus {
@@ -4281,33 +4281,33 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeerchannelsChannelsState {
 	    #[serde(rename = "OPENINGD")]
-	    OPENINGD,
+	    OPENINGD = 0,
 	    #[serde(rename = "CHANNELD_AWAITING_LOCKIN")]
-	    CHANNELD_AWAITING_LOCKIN,
+	    CHANNELD_AWAITING_LOCKIN = 1,
 	    #[serde(rename = "CHANNELD_NORMAL")]
-	    CHANNELD_NORMAL,
+	    CHANNELD_NORMAL = 2,
 	    #[serde(rename = "CHANNELD_SHUTTING_DOWN")]
-	    CHANNELD_SHUTTING_DOWN,
+	    CHANNELD_SHUTTING_DOWN = 3,
 	    #[serde(rename = "CLOSINGD_SIGEXCHANGE")]
-	    CLOSINGD_SIGEXCHANGE,
+	    CLOSINGD_SIGEXCHANGE = 4,
 	    #[serde(rename = "CLOSINGD_COMPLETE")]
-	    CLOSINGD_COMPLETE,
+	    CLOSINGD_COMPLETE = 5,
 	    #[serde(rename = "AWAITING_UNILATERAL")]
-	    AWAITING_UNILATERAL,
+	    AWAITING_UNILATERAL = 6,
 	    #[serde(rename = "FUNDING_SPEND_SEEN")]
-	    FUNDING_SPEND_SEEN,
+	    FUNDING_SPEND_SEEN = 7,
 	    #[serde(rename = "ONCHAIN")]
-	    ONCHAIN,
+	    ONCHAIN = 8,
 	    #[serde(rename = "DUALOPEND_OPEN_INIT")]
-	    DUALOPEND_OPEN_INIT,
+	    DUALOPEND_OPEN_INIT = 9,
 	    #[serde(rename = "DUALOPEND_AWAITING_LOCKIN")]
-	    DUALOPEND_AWAITING_LOCKIN,
+	    DUALOPEND_AWAITING_LOCKIN = 10,
 	    #[serde(rename = "CHANNELD_AWAITING_SPLICE")]
-	    CHANNELD_AWAITING_SPLICE,
+	    CHANNELD_AWAITING_SPLICE = 11,
 	    #[serde(rename = "DUALOPEND_OPEN_COMMITTED")]
-	    DUALOPEND_OPEN_COMMITTED,
+	    DUALOPEND_OPEN_COMMITTED = 12,
 	    #[serde(rename = "DUALOPEND_OPEN_COMMIT_READY")]
-	    DUALOPEND_OPEN_COMMIT_READY,
+	    DUALOPEND_OPEN_COMMIT_READY = 13,
 	}
 
 	impl TryFrom<i32> for ListpeerchannelsChannelsState {
@@ -4442,9 +4442,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpeerchannelsChannelsHtlcsDirection {
 	    #[serde(rename = "in")]
-	    IN,
+	    IN = 0,
 	    #[serde(rename = "out")]
-	    OUT,
+	    OUT = 1,
 	}
 
 	impl TryFrom<i32> for ListpeerchannelsChannelsHtlcsDirection {
@@ -4630,17 +4630,17 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListclosedchannelsClosedchannelsClose_cause {
 	    #[serde(rename = "unknown")]
-	    UNKNOWN,
+	    UNKNOWN = 0,
 	    #[serde(rename = "local")]
-	    LOCAL,
+	    LOCAL = 1,
 	    #[serde(rename = "user")]
-	    USER,
+	    USER = 2,
 	    #[serde(rename = "remote")]
-	    REMOTE,
+	    REMOTE = 3,
 	    #[serde(rename = "protocol")]
-	    PROTOCOL,
+	    PROTOCOL = 4,
 	    #[serde(rename = "onchain")]
-	    ONCHAIN,
+	    ONCHAIN = 5,
 	}
 
 	impl TryFrom<i32> for ListclosedchannelsClosedchannelsClose_cause {
@@ -4731,15 +4731,15 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DecodepayFallbacksType {
 	    #[serde(rename = "P2PKH")]
-	    P2PKH,
+	    P2PKH = 0,
 	    #[serde(rename = "P2SH")]
-	    P2SH,
+	    P2SH = 1,
 	    #[serde(rename = "P2WPKH")]
-	    P2WPKH,
+	    P2WPKH = 2,
 	    #[serde(rename = "P2WSH")]
-	    P2WSH,
+	    P2WSH = 3,
 	    #[serde(rename = "P2TR")]
-	    P2TR,
+	    P2TR = 4,
 	}
 
 	impl TryFrom<i32> for DecodepayFallbacksType {
@@ -4826,17 +4826,17 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum DecodeType {
 	    #[serde(rename = "bolt12 offer")]
-	    BOLT12_OFFER,
+	    BOLT12_OFFER = 0,
 	    #[serde(rename = "bolt12 invoice")]
-	    BOLT12_INVOICE,
+	    BOLT12_INVOICE = 1,
 	    #[serde(rename = "bolt12 invoice_request")]
-	    BOLT12_INVOICE_REQUEST,
+	    BOLT12_INVOICE_REQUEST = 2,
 	    #[serde(rename = "bolt11 invoice")]
-	    BOLT11_INVOICE,
+	    BOLT11_INVOICE = 3,
 	    #[serde(rename = "rune")]
-	    RUNE,
+	    RUNE = 4,
 	    #[serde(rename = "emergency recover")]
-	    EMERGENCY_RECOVER,
+	    EMERGENCY_RECOVER = 5,
 	}
 
 	impl TryFrom<i32> for DecodeType {
@@ -5254,7 +5254,7 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum GetrouteRouteStyle {
 	    #[serde(rename = "tlv")]
-	    TLV,
+	    TLV = 0,
 	}
 
 	impl TryFrom<i32> for GetrouteRouteStyle {
@@ -5306,13 +5306,13 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsForwardsStatus {
 	    #[serde(rename = "offered")]
-	    OFFERED,
+	    OFFERED = 0,
 	    #[serde(rename = "settled")]
-	    SETTLED,
+	    SETTLED = 1,
 	    #[serde(rename = "local_failed")]
-	    LOCAL_FAILED,
+	    LOCAL_FAILED = 2,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 3,
 	}
 
 	impl TryFrom<i32> for ListforwardsForwardsStatus {
@@ -5343,9 +5343,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListforwardsForwardsStyle {
 	    #[serde(rename = "legacy")]
-	    LEGACY,
+	    LEGACY = 0,
 	    #[serde(rename = "tlv")]
-	    TLV,
+	    TLV = 1,
 	}
 
 	impl TryFrom<i32> for ListforwardsForwardsStyle {
@@ -5440,11 +5440,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListpaysPaysStatus {
 	    #[serde(rename = "pending")]
-	    PENDING,
+	    PENDING = 0,
 	    #[serde(rename = "failed")]
-	    FAILED,
+	    FAILED = 1,
 	    #[serde(rename = "complete")]
-	    COMPLETE,
+	    COMPLETE = 2,
 	}
 
 	impl TryFrom<i32> for ListpaysPaysStatus {
@@ -5519,9 +5519,9 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum ListhtlcsHtlcsDirection {
 	    #[serde(rename = "out")]
-	    OUT,
+	    OUT = 0,
 	    #[serde(rename = "in")]
-	    IN,
+	    IN = 1,
 	}
 
 	impl TryFrom<i32> for ListhtlcsHtlcsDirection {
@@ -5805,11 +5805,11 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum WaitSubsystem {
 	    #[serde(rename = "invoices")]
-	    INVOICES,
+	    INVOICES = 0,
 	    #[serde(rename = "forwards")]
-	    FORWARDS,
+	    FORWARDS = 1,
 	    #[serde(rename = "sendpays")]
-	    SENDPAYS,
+	    SENDPAYS = 2,
 	}
 
 	impl TryFrom<i32> for WaitSubsystem {
@@ -5860,7 +5860,7 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum StopResult {
 	    #[serde(rename = "Shutdown complete")]
-	    SHUTDOWN_COMPLETE,
+	    SHUTDOWN_COMPLETE = 0,
 	}
 
 	impl TryFrom<i32> for StopResult {

--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -1168,7 +1168,7 @@ pub mod requests {
 	    fn try_from(c: i32) -> Result<NewaddrAddresstype, anyhow::Error> {
 	        match c {
 	    0 => Ok(NewaddrAddresstype::BECH32),
-	    1 => Ok(NewaddrAddresstype::P2TR),
+	    3 => Ok(NewaddrAddresstype::P2TR),
 	    2 => Ok(NewaddrAddresstype::ALL),
 	            o => Err(anyhow::anyhow!("Unknown variant {} for enum NewaddrAddresstype", o)),
 	        }
@@ -2505,11 +2505,11 @@ pub mod responses {
 	    fn try_from(c: i32) -> Result<GetinfoBindingType, anyhow::Error> {
 	        match c {
 	    0 => Ok(GetinfoBindingType::LOCAL_SOCKET),
-	    1 => Ok(GetinfoBindingType::WEBSOCKET),
-	    2 => Ok(GetinfoBindingType::IPV4),
-	    3 => Ok(GetinfoBindingType::IPV6),
-	    4 => Ok(GetinfoBindingType::TORV2),
-	    5 => Ok(GetinfoBindingType::TORV3),
+	    5 => Ok(GetinfoBindingType::WEBSOCKET),
+	    1 => Ok(GetinfoBindingType::IPV4),
+	    2 => Ok(GetinfoBindingType::IPV6),
+	    3 => Ok(GetinfoBindingType::TORV2),
+	    4 => Ok(GetinfoBindingType::TORV3),
 	            o => Err(anyhow::anyhow!("Unknown variant {} for enum GetinfoBindingType", o)),
 	        }
 	    }
@@ -5596,13 +5596,13 @@ pub mod responses {
 	#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 	pub enum MultifundchannelFailedMethod {
 	    #[serde(rename = "connect")]
-	    CONNECT,
+	    CONNECT = 0,
 	    #[serde(rename = "openchannel_init")]
-	    OPENCHANNEL_INIT,
+	    OPENCHANNEL_INIT = 1,
 	    #[serde(rename = "fundchannel_start")]
-	    FUNDCHANNEL_START,
+	    FUNDCHANNEL_START = 2,
 	    #[serde(rename = "fundchannel_complete")]
-	    FUNDCHANNEL_COMPLETE,
+	    FUNDCHANNEL_COMPLETE = 3,
 	}
 
 	impl TryFrom<i32> for MultifundchannelFailedMethod {

--- a/contrib/msggen/msggen/__main__.py
+++ b/contrib/msggen/msggen/__main__.py
@@ -44,10 +44,10 @@ def add_handler_get_grpc2py(generator_chain: GeneratorChain):
     generator_chain.add_generator(Grpc2PyGenerator(dest))
 
 
-def add_handler_gen_rust_jsonrpc(generator_chain: GeneratorChain):
+def add_handler_gen_rust_jsonrpc(generator_chain: GeneratorChain, meta):
     fname = Path("cln-rpc") / "src" / "model.rs"
     dest = open(fname, "w")
-    generator_chain.add_generator(RustGenerator(dest))
+    generator_chain.add_generator(RustGenerator(dest, meta))
 
 
 def load_msggen_meta():
@@ -81,7 +81,7 @@ def run():
     generator_chain = GeneratorChain()
 
     add_handler_gen_grpc(generator_chain, meta)
-    add_handler_gen_rust_jsonrpc(generator_chain)
+    add_handler_gen_rust_jsonrpc(generator_chain, meta)
     add_handler_get_grpc2py(generator_chain)
 
     generator_chain.generate(service)

--- a/contrib/pyln-testing/pyln/testing/grpc.py
+++ b/contrib/pyln-testing/pyln/testing/grpc.py
@@ -133,11 +133,6 @@ class LightningGrpc(object):
         payload = clnpb.NewaddrRequest(addresstype=atype)
         res = grpc2py.newaddr2py(self.stub.NewAddr(payload))
 
-        # Need to remap the bloody spelling of p2sh-segwit to match
-        # addresstype.
-        if 'p2sh_segwit' in res:
-            res['p2sh-segwit'] = res['p2sh_segwit']
-            del res['p2sh_segwit']
         return res
 
     def listfunds(self, spent=None):

--- a/contrib/pyln-testing/pyln/testing/grpc.py
+++ b/contrib/pyln-testing/pyln/testing/grpc.py
@@ -119,8 +119,7 @@ class LightningGrpc(object):
         enum = {
             None: 0,
             "BECH32": 0,
-            "P2SH_SEGWIT": 1,
-            "P2SH-SEGWIT": 1,
+            "P2TR": 3,
             "ALL": 2
         }
         if addresstype is not None:

--- a/doc/beginners-guide/opening-channels.md
+++ b/doc/beginners-guide/opening-channels.md
@@ -16,11 +16,11 @@ lightning-cli newaddr
 
 `lightningd` will register the funds once the transaction is confirmed.
 
-You may need to generate a p2sh-segwit address if the faucet does not support bech32:
+Alternatively you can generate a taproot address should your source of funds support it:
 
 ```shell
-# Return a p2sh-segwit address
-lightning-cli newaddr p2sh-segwit
+# Return a taproot address
+lightning-cli newaddr p2tr
 ```
 
 

--- a/doc/lightningd.8.md
+++ b/doc/lightningd.8.md
@@ -103,11 +103,10 @@ elided, specify it if you selected your own *lightning-dir*):
 
     $ lightning-cli newaddr
 
-This will provide a native SegWit bech32 address. In case all your money
-is in services that do not support native SegWit and have to use
-P2SH-wrapped addresses, instead use:
+This will provide a native SegWit bech32 address. Alternatively you can
+generate a taproot address with:
 
-    $ lightning-cli newaddr p2sh-segwit
+    $ lightning-cli newaddr p2tr
 
 Transfer a small amount of onchain funds to the given address. Check the
 status of all your funds (onchain and on-Lightning) via

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2019,6 +2019,7 @@ def test_newaddr(node_factory, chainparams):
     both = l1.rpc.newaddr('all')
     assert 'p2sh-segwit' not in both
     assert both['bech32'].startswith(chainparams['bip173_prefix'])
+    assert both['p2tr'].startswith(chainparams['bip173_prefix'])
 
 
 def test_bitcoind_fail_first(node_factory, bitcoind):


### PR DESCRIPTION
There were various occurences of `p2sh-segwit` still left in msggen, tests and documentation. So i removed them. I also updated some documentation files to reflect the current state of `newaddr`.

Is it problematic that the values in `message NewaddrResponse` changed?

Fixes: #6996 
Replaces: #7146 