### PR TITLE
plugin/clnrest: Adding new config param as `clnrest-swagger-root`

### DIFF
--- a/doc/developers-guide/app-development/rest.md
+++ b/doc/developers-guide/app-development/rest.md
@@ -72,6 +72,8 @@ clnrest-cors-origins=https?://127.0.0.1:([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}
 
 ```
 
+- --clnrest-swagger-root: Root url for Swagger UI. Default is `/`. Example: `clnrest-swagger-root=/doc`
+
 ## Server
 
 With the default configurations, the Swagger user interface will be available at https://127.0.0.1:3010/. 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -664,6 +664,10 @@ authenticate to the Tor control port.
 
   Creates a whitelist of trusted content sources that can run on a webpage and helps mitigate the risk of attacks. Default CSP is `default-src 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';`.
 
+* **clnrest-swagger-root**=*URL*  [plugin `clnrest.py`]
+
+  Root url for Swagger UI. Default is `/`.
+
 * **wss-bind-addr**=*\[IPADDRESS\[:PORT\]\]|SOCKETPATH|HOSTNAME\[:PORT\]* [plugin `wss-proxy.py`]
 
   Sets the WSS address.

--- a/plugins/clnrest/clnrest.py
+++ b/plugins/clnrest/clnrest.py
@@ -100,7 +100,7 @@ def ws_connect():
 
 
 def create_app():
-    from utilities.shared import REST_CORS_ORIGINS
+    from utilities.shared import REST_CORS_ORIGINS, SWAGGER_ROOT
     global app
     app.config["SECRET_KEY"] = os.urandom(24).hex()
     authorizations = {
@@ -108,7 +108,7 @@ def create_app():
     }
     CORS(app, resources={r"/*": {"origins": REST_CORS_ORIGINS}})
     blueprint = Blueprint("api", __name__)
-    api = Api(blueprint, version="1.0", title="Core Lightning Rest", description="Core Lightning REST API Swagger", authorizations=authorizations, security=["rune"])
+    api = Api(blueprint, version="1.0", doc=SWAGGER_ROOT, title="Core Lightning Rest", description="Core Lightning REST API Swagger", authorizations=authorizations, security=["rune"])
     app.register_blueprint(blueprint)
     api.add_namespace(rpcns, path="/v1")
 

--- a/plugins/clnrest/utilities/rpc_plugin.py
+++ b/plugins/clnrest/utilities/rpc_plugin.py
@@ -9,3 +9,4 @@ plugin.add_option(name="clnrest-host", default="127.0.0.1", description="REST se
 plugin.add_option(name="clnrest-port", default=None, description="REST server port to listen", opt_type="int", deprecated=False)
 plugin.add_option(name="clnrest-cors-origins", default="*", description="Cross origin resource sharing origins", opt_type="string", deprecated=False, multi=True)
 plugin.add_option(name="clnrest-csp", default="default-src 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';", description="Content security policy (CSP) for the server", opt_type="string", deprecated=False, multi=False)
+plugin.add_option(name="clnrest-swagger-root", default="/", description="Root path for Swagger UI", opt_type="string", deprecated=False, multi=False)

--- a/plugins/clnrest/utilities/shared.py
+++ b/plugins/clnrest/utilities/shared.py
@@ -3,7 +3,7 @@ import ipaddress
 import pyln.client
 
 
-CERTS_PATH, REST_PROTOCOL, REST_HOST, REST_PORT, REST_CSP, REST_CORS_ORIGINS = "", "", "", "", "", []
+CERTS_PATH, REST_PROTOCOL, REST_HOST, REST_PORT, REST_CSP, SWAGGER_ROOT, REST_CORS_ORIGINS = "", "", "", "", "", "", []
 
 
 class RuneError(Exception):
@@ -41,7 +41,7 @@ def validate_port(port):
 def set_config(options):
     if 'clnrest-port' not in options:
         return "`clnrest-port` option is not configured"
-    global CERTS_PATH, REST_PROTOCOL, REST_HOST, REST_PORT, REST_CSP, REST_CORS_ORIGINS
+    global CERTS_PATH, REST_PROTOCOL, REST_HOST, REST_PORT, REST_CSP, SWAGGER_ROOT, REST_CORS_ORIGINS
 
     REST_PORT = int(options["clnrest-port"])
     if validate_port(REST_PORT) is False:
@@ -57,6 +57,7 @@ def set_config(options):
 
     CERTS_PATH = str(options["clnrest-certs"])
     REST_CSP = str(options["clnrest-csp"])
+    SWAGGER_ROOT = str(options["clnrest-swagger-root"])
     cors_origins = options["clnrest-cors-origins"]
     REST_CORS_ORIGINS.clear()
     for origin in cors_origins:


### PR DESCRIPTION
For BTCPay, the swaggerUI doesn't come up because it assume that it is running on the base of the domain. It will be easier to use, for BTCPay and others, if the SwaggerUI's root url can be configured.

- Updated config params and plugin
- Updated documentation

Changelog-Added: Added a new configuration for clnrest plugin to change the default Swagger UI path from `/` to custom url.