### PR TITLE
Pay listpeerchannels fix

### DIFF
--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -2113,11 +2113,6 @@ static struct listpeers_channel *json_to_listpeers_channel(const tal_t *ctx,
 
 	chan = tal(ctx, struct listpeers_channel);
 
-	json_to_node_id(buffer, idtok, &chan->id);
-	json_to_bool(buffer, conntok, &chan->connected);
-	json_to_bool(buffer, privtok, &chan->private);
-	chan->state = json_strdup(chan, buffer, statetok);
-	json_to_txid(buffer, ftxidtok, &chan->funding_txid);
 	if (scidtok != NULL) {
 		assert(dirtok != NULL);
 		chan->scid = tal(chan, struct short_channel_id);
@@ -2153,6 +2148,12 @@ static struct listpeers_channel *json_to_listpeers_channel(const tal_t *ctx,
 	 * It's not a real channel (yet), so ignore it! */
 	if (!chan->scid && !chan->alias[LOCAL])
 		return tal_free(chan);
+
+	json_to_node_id(buffer, idtok, &chan->id);
+	json_to_bool(buffer, conntok, &chan->connected);
+	json_to_bool(buffer, privtok, &chan->private);
+	chan->state = json_strdup(chan, buffer, statetok);
+	json_to_txid(buffer, ftxidtok, &chan->funding_txid);
 
 	json_to_int(buffer, dirtok, &chan->direction);
 	json_to_msat(buffer, tmsattok, &chan->total_msat);

--- a/tests/plugins/openchannel_hook_delay.py
+++ b/tests/plugins/openchannel_hook_delay.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Plugin to test openchannel_hook
+
+Will simply accept any channel. Useful fot testing chained hook.
+"""
+
+from pyln.client import Plugin
+import time
+
+plugin = Plugin()
+
+
+@plugin.hook('openchannel')
+def on_openchannel(openchannel, plugin, **kwargs):
+    delaytime = float(plugin.get_option('delaytime'))
+    msg = f'delaying WIRE_ACCEPT_CHANNEL for {delaytime}s'
+    plugin.log(msg)
+    time.sleep(delaytime)
+    return {'result': 'continue'}
+
+
+@plugin.hook('openchannel2')
+def on_openchannel2(openchannel2, plugin, **kwargs):
+    delaytime = float(plugin.get_option('delaytime'))
+    msg = f'delaying WIRE_ACCEPT_CHANNEL for {delaytime}s'
+    plugin.log(msg)
+    time.sleep(delaytime)
+    return {'result': 'continue'}
+
+
+plugin.add_option('delaytime', '10', 'How long to hold the WIRE_OPEN_CHANNEL.')
+plugin.run()

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5590,7 +5590,6 @@ def test_pay_partial_msat(node_factory, executor):
     l3pay.result(TIMEOUT)
 
 
-@pytest.mark.xfail(strict=True)
 def test_pay_while_opening_channel(node_factory, bitcoind, executor):
     delay_plugin = {'plugin': os.path.join(os.getcwd(),
                                            'tests/plugins/openchannel_hook_delay.py'),


### PR DESCRIPTION
Uncommited channels are missing several fields which would normally bepopulated by an active channel.  This simply skips them for the purposes of finding a route.  The particular culprit was:
    {
      "peer_id": "038cd9f3679d5b39bb2105978467918d549572de472f07dd729e37c7a6377d41d5",
      "peer_connected": true,
      "state": "OPENINGD",
      "owner": "lightning_openingd",
      "opener": "local",
      "to_us_msat": 8317559000,
      "total_msat": 8317559000,
      "features": [
        "option_static_remotekey",
        "option_anchors_zero_fee_htlc_tx"
      ]
    }
    
Fixes #7197 - SEGV in direct_pay_listpeerchannels when field private missing

Changelog-Fixed: Fixed crash in pay plugin caused by parsing uncommitted dual open channels