### PR TITLE
Fetch block from a peer if we don't have it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,7 +212,7 @@ jobs:
     timeout-minutes: 120
     env:
       BITCOIN_VERSION: "26.1"
-      ELEMENTS_VERSION: 22.0.2
+      ELEMENTS_VERSION: 23.2.1
       RUST_PROFILE: release  # Has to match the one in the compile step
       PYTEST_OPTS: --timeout=1200 --force-flaky
     needs:
@@ -320,7 +320,7 @@ jobs:
     timeout-minutes: 120
     env:
       BITCOIN_VERSION: "26.1"
-      ELEMENTS_VERSION: 22.0.2
+      ELEMENTS_VERSION: 23.2.1
       RUST_PROFILE: release  # Has to match the one in the compile step
       CFG: compile-gcc
       PYTEST_OPTS: --test-group-random-seed=42 --timeout=1800 --force-flaky
@@ -390,7 +390,7 @@ jobs:
     timeout-minutes: 120
     env:
       BITCOIN_VERSION: "26.1"
-      ELEMENTS_VERSION: 22.0.2
+      ELEMENTS_VERSION: 23.2.1
       RUST_PROFILE: release
       SLOW_MACHINE: 1
       TEST_DEBUG: 1

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -1004,17 +1004,7 @@ static struct command_result *sendrawtransaction(struct command *cmd,
 		return command_param_failed();
 
 	if (*allowhighfees) {
-		if (bitcoind->version >= 190001)
-			/* Starting in 19.0.1, second argument is
-			 * maxfeerate, which when set to 0 means
-			 * no max feerate.
-			 */
 			highfeesarg = "0";
-		else
-			/* in older versions, second arg is allowhighfees,
-			 * set to true to allow high fees.
-			 */
-			highfeesarg = "true";
 	} else
 		highfeesarg = NULL;
 

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -562,7 +562,7 @@ struct getrawblock_stash {
 	const char *block_hex;
 };
 
-static struct command_result *process_getrawblock(struct bitcoin_cli *bcli)
+static struct command_result *process_rawblock(struct bitcoin_cli *bcli)
 {
 	struct json_stream *response;
 	struct getrawblock_stash *stash = bcli->stash;
@@ -575,6 +575,17 @@ static struct command_result *process_getrawblock(struct bitcoin_cli *bcli)
 	json_add_string(response, "block", stash->block_hex);
 
 	return command_finished(bcli->cmd, response);
+}
+
+static struct command_result *process_getrawblock(struct bitcoin_cli *bcli)
+{
+	/* We failed to get the raw block. */
+	if (bcli->exitstatus && *bcli->exitstatus != 0) {
+		/* retry */
+		return NULL;
+	}
+
+	return process_rawblock(bcli);
 }
 
 static struct command_result *
@@ -607,7 +618,7 @@ static struct command_result *process_getblockhash(struct bitcoin_cli *bcli)
 		return command_err_bcli_badjson(bcli, "bad blockhash");
 	}
 
-	start_bitcoin_cli(NULL, bcli->cmd, process_getrawblock, false,
+	start_bitcoin_cli(NULL, bcli->cmd, process_getrawblock, true,
 			  BITCOIND_HIGH_PRIO, stash,
 			  "getblock",
 			  stash->block_hash,

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -600,6 +600,19 @@ getrawblockbyheight_notfound(struct bitcoin_cli *bcli)
 	return command_finished(bcli->cmd, response);
 }
 
+static struct command_result *getrawblock(struct bitcoin_cli *bcli)
+{
+	struct getrawblock_stash *stash = bcli->stash;
+
+	start_bitcoin_cli(NULL, bcli->cmd, process_getrawblock, true,
+			  BITCOIND_HIGH_PRIO, stash, "getblock",
+			  stash->block_hash,
+			  /* Non-verbose: raw block. */
+			  "0", NULL);
+
+	return command_still_pending(bcli->cmd);
+}
+
 static struct command_result *process_getblockhash(struct bitcoin_cli *bcli)
 {
 	struct getrawblock_stash *stash = bcli->stash;
@@ -618,15 +631,7 @@ static struct command_result *process_getblockhash(struct bitcoin_cli *bcli)
 		return command_err_bcli_badjson(bcli, "bad blockhash");
 	}
 
-	start_bitcoin_cli(NULL, bcli->cmd, process_getrawblock, true,
-			  BITCOIND_HIGH_PRIO, stash,
-			  "getblock",
-			  stash->block_hash,
-			  /* Non-verbose: raw block. */
-			  "0",
-			  NULL);
-
-	return command_still_pending(bcli->cmd);
+	return getrawblock(bcli);
 }
 
 /* Get a raw block given its height.

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -592,14 +592,12 @@ static struct command_result *process_getblockfrompeer(struct bitcoin_cli *bcli)
 		 * block from peer */
 		plugin_log(bcli->cmd->plugin, LOG_DBG,
 			   "failed to fetch block %s from peer %i, skip.",
-			   stash->block_hash, stash->peers[0]);
+			   stash->block_hash, stash->peers[tal_count(stash->peers) - 1]);
 	} else {
 		plugin_log(bcli->cmd->plugin, LOG_DBG,
 			   "try to fetch block %s from peer %i.",
-			   stash->block_hash, stash->peers[0]);
+			   stash->block_hash, stash->peers[tal_count(stash->peers) - 1]);
 	}
-
-	stash->peers[0] = stash->peers[tal_count(stash->peers) - 1];
 	tal_resize(&stash->peers, tal_count(stash->peers) - 1);
 
 	/* `getblockfrompeer` is an async call. sleep for a second to allow the

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -208,19 +208,19 @@ def test_bitcoin_pruned(node_factory, bitcoind):
     l1.daemon.rpcproxy.mock_rpc("getblockfrompeer", mock_getblockfrompeer())
     l1.start(wait_for_bitcoind_sync=False)
 
-    # check that we fetched a block from a peer (1st peer in this case).
+    # check that we fetched a block from a peer (1st peer (from the back) in this case).
     pruned_block = bitcoind.rpc.getblockhash(bitcoind.rpc.getblockcount())
     l1.daemon.wait_for_log(f"failed to fetch block {pruned_block} from the bitcoin backend")
-    l1.daemon.wait_for_log(rf"try to fetch block {pruned_block} from peer 1")
+    l1.daemon.wait_for_log(rf"try to fetch block {pruned_block} from peer 3")
     l1.daemon.wait_for_log(rf"Adding block (\d+): {pruned_block}")
 
-    # check that we can also fetch from a peer > 1st.
+    # check that we can also fetch from a peer > 1st (from the back).
     l1.daemon.rpcproxy.mock_rpc("getblockfrompeer", mock_getblockfrompeer(error=True, release_after=2))
     bitcoind.generate_block(1)
 
     pruned_block = bitcoind.rpc.getblockhash(bitcoind.rpc.getblockcount())
     l1.daemon.wait_for_log(f"failed to fetch block {pruned_block} from the bitcoin backend")
-    l1.daemon.wait_for_log(rf"failed to fetch block {pruned_block} from peer 1")
+    l1.daemon.wait_for_log(rf"failed to fetch block {pruned_block} from peer 3")
     l1.daemon.wait_for_log(rf"try to fetch block {pruned_block} from peer (\d+)")
     l1.daemon.wait_for_log(rf"Adding block (\d+): {pruned_block}")
 


### PR DESCRIPTION
This PR adds a path in the `bcli` plugin that utilizes `getblockfrompeer` to try to fetch a block from a peer in case that we don't know about the block. This is something that happens when core lightning tries to fetch a block from bitcoind that has already been pruned by bitcoind.

`getblockfrompeer` has been introduced in `v23.0.0`. The call asks a given peer for a block that the local node does not know about. Even though `getblockfrompeer` does not make any guarantees about whether the block will be fetched (or pruned again right away), the success probabilities are really high if we just try long enough.

Here is a brief description about what happens now if core lightning asks for a block
a) get blockhash for height x
b) try to get block from bitcoind:
  - found the block: perfect! return rawblock
  - did not find the block: iterate through the peers and ask them for the block, jump back to b) after asking a peer.

resolves #7201 
