### PR TITLE
CI: upgrade CI actions to latest releases

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   testfreebsd:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     name: Build and test on FreeBSD
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v1
       with:
         usesh: true
         prepare: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           git rebase origin/${{ github.base_ref }}
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -93,10 +93,10 @@ jobs:
             VALGRIND: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -125,7 +125,7 @@ jobs:
           mv testpack.tar.bz2 cln-${CFG}.tar.bz2
       - name: Check rust packages
         run: cargo test --all
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2
           path: cln-${{ matrix.CFG }}.tar.bz2
@@ -150,10 +150,10 @@ jobs:
             VALGRIND: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -170,7 +170,7 @@ jobs:
           git clone https://github.com/lightning/bolts.git ../${BOLTDIR}
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2
 
@@ -186,10 +186,10 @@ jobs:
       - prebuild
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -261,10 +261,10 @@ jobs:
             EXPERIMENTAL_SPLICING: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -279,7 +279,7 @@ jobs:
         run: .github/scripts/install-bitcoind.sh
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cln-${{ matrix.CFG }}.tar.bz2
 
@@ -352,10 +352,10 @@ jobs:
             PYTEST_OPTS: --test-group=10 --test-group-count=10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -370,7 +370,7 @@ jobs:
         run: .github/scripts/install-bitcoind.sh
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cln-compile-gcc.tar.bz2
 
@@ -423,10 +423,10 @@ jobs:
             PYTEST_OPTS: --test-group=10 --test-group-count=10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -441,7 +441,7 @@ jobs:
         run: .github/scripts/install-bitcoind.sh
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cln-compile-clang-sanitizers.tar.bz2
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,8 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 on:
   # Only deploy if we're the result of a PR being merged
+  workflow_dispatch:
   push:
-    workflow_dispatch:
     branches:
       - master
     tags:
@@ -38,7 +38,7 @@ jobs:
           #- PACKAGE: pyn-bolt7
           #  WORKDIR: contrib/pyln-spec/bolt7/
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         # Need to fetch entire history in order to locate the version tag
         fetch-depth: 0

--- a/.github/workflows/rdme-docs-sync.yml
+++ b/.github/workflows/rdme-docs-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Sync doc/getting-started/ 🚀
         uses: readmeio/rdme@v8

--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 


### PR DESCRIPTION
Github actions was complaining about deprecated CI actions so i updated them all to the latest release version.

The recommended v1 FreeBSD action requries `runs-on: ubuntu-latest`.