### PR TITLE
Fix CLN service startup failure by trimming trailing spaces in config parameters

### DIFF
--- a/common/configvar.c
+++ b/common/configvar.c
@@ -51,6 +51,20 @@ const struct opt_table *configvar_unparsed(struct configvar *cv)
 	return ot;
 }
 
+static void trim_whitespace(const char *s)
+{
+	size_t len = strlen(s);
+
+	/* Cast away const to allow modifications */
+	char *mutable_s = (char *)s;
+
+	while (len > 0 && isspace((unsigned char)mutable_s[len - 1]))
+		len--;
+
+	/* Move null terminator to the end of the trimmed string */
+	memmove(mutable_s + len, mutable_s + strlen(s), 1);
+}
+
 const char *configvar_parse(struct configvar *cv,
 			    bool early,
 			    bool full_knowledge,
@@ -82,6 +96,8 @@ const char *configvar_parse(struct configvar *cv,
 	} else {
 		if (!cv->optarg)
 			return "requires an argument";
+		if (!(ot->type & OPT_KEEP_WHITESPACE))
+			trim_whitespace(cv->optarg);
 		return ot->cb_arg(cv->optarg, ot->u.arg);
 	}
 }

--- a/common/configvar.c
+++ b/common/configvar.c
@@ -31,7 +31,7 @@ const struct opt_table *configvar_unparsed(struct configvar *cv)
 		ot = opt_find_short(cv->configline[0]);
 		cv->optarg = NULL;
 	} else {
-		ot = opt_find_long(cv->configline, &cv->optarg);
+		ot = opt_find_long(cv->configline, cast_const2(const char **, &cv->optarg));
 	}
 	if (!ot)
 		return NULL;
@@ -51,18 +51,13 @@ const struct opt_table *configvar_unparsed(struct configvar *cv)
 	return ot;
 }
 
-static void trim_whitespace(const char *s)
+static void trim_whitespace(char *s)
 {
 	size_t len = strlen(s);
 
-	/* Cast away const to allow modifications */
-	char *mutable_s = (char *)s;
-
-	while (len > 0 && isspace((unsigned char)mutable_s[len - 1]))
+	while (len > 0 && cisspace(s[len - 1]))
 		len--;
-
-	/* Move null terminator to the end of the trimmed string */
-	memmove(mutable_s + len, mutable_s + strlen(s), 1);
+	s[len] = '\0';
 }
 
 const char *configvar_parse(struct configvar *cv,

--- a/common/configvar.h
+++ b/common/configvar.h
@@ -60,6 +60,8 @@ struct configvar {
 #define OPT_SHOWBOOL (1 << (OPT_USER_START+5))
 /* Can be changed at runtime: cb will get called with NULL for `check`! */
 #define OPT_DYNAMIC (1 << (OPT_USER_START+6))
+/* Keep whitespace at the end of the option argument */
+#define OPT_KEEP_WHITESPACE (1 << (OPT_USER_START+7))
 
 /* Use this instead of opt_register_*_arg if you want OPT_* from above */
 #define clnopt_witharg(names, type, cb, show, arg, desc)		\

--- a/common/configvar.h
+++ b/common/configvar.h
@@ -35,13 +35,13 @@ struct configvar {
 	/* Where did we get this from? */
 	enum configvar_src src;
 	/* Never NULL, the whole line */
-	const char *configline;
+	char *configline;
 
 	/* These are filled in by configvar_parse */
 	/* The variable name (without any =) */
 	const char *optvar;
 	/* NULL for no-arg options, otherwise points after =. */
-	const char *optarg;
+	char *optarg;
 	/* Was this overridden by a following option? */
 	bool overridden;
 };

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -83,6 +83,14 @@ re-enable it.  Unless we've made a horrible mistake it's probably time
 to complain or fix to whatever is using the old API.  It can be
 specified multiple times for different features.
 
+### Whitespace Handling
+
+Because it's a common error, we automatically trim whitespace from the
+end of most configuration options. Exceptions are noted below:
+
+- `log-prefix`: Preserves whitespace at the end.
+- `alias`: Preserves whitespace at the end.
+
 ### Bitcoin control options:
 
 Bitcoin control options:

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -915,9 +915,8 @@ void opt_register_logging(struct lightningd *ld)
 		       opt_set_bool_arg, opt_show_bool,
 		       &ld->log_book->print_timestamps,
 		       "prefix log messages with timestamp");
-	opt_register_early_arg("--log-prefix", arg_log_prefix, show_log_prefix,
-			       ld->log_book,
-			       "log prefix");
+	clnopt_witharg("--log-prefix", OPT_EARLY|OPT_KEEP_WHITESPACE,
+		       arg_log_prefix, show_log_prefix, ld->log_book, "log prefix");
 	clnopt_witharg("--log-file=<file>",
 		       OPT_EARLY|OPT_MULTI,
 		       arg_log_to_file, NULL, ld,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1887,9 +1887,9 @@ void handle_early_opts(struct lightningd *ld, int argc, char *argv[])
 }
 
 /* Free *str, set *str to copy with `cln` prepended */
-static void prefix_cln(const char **str STEALS)
+static void prefix_cln(char **str STEALS)
 {
-	const char *newstr = tal_fmt(tal_parent(*str), "cln%s", *str);
+	char *newstr = tal_fmt(tal_parent(*str), "cln%s", *str);
 	tal_free(*str);
 	*str = newstr;
 }
@@ -1910,7 +1910,7 @@ static void fixup_clnrest_options(struct lightningd *ld)
 		    && !strstarts(cv->configline, "rest-certs="))
 			continue;
 		/* Did some (plugin) claim it? */
-		if (opt_find_long(cv->configline, &cv->optarg))
+		if (opt_find_long(cv->configline, cast_const2(const char **, &cv->optarg)))
 			continue;
 		if (!opt_deprecated_ok(ld,
 				       tal_strndup(tmpctx, cv->configline,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1525,9 +1525,8 @@ static void register_opts(struct lightningd *ld)
 		     opt_lightningd_usage, ld, "Print this message.");
 	opt_register_arg("--rgb", opt_set_rgb, opt_show_rgb, ld,
 			 "RRGGBB hex color for node");
-	opt_register_arg("--alias", opt_set_alias, opt_show_alias, ld,
-			 "Up to 32-byte alias for node");
-
+	clnopt_witharg("--alias", OPT_KEEP_WHITESPACE, opt_set_alias,
+		       opt_show_alias, ld, "Up to 32-byte alias for node");
 	opt_register_arg("--pid-file=<file>", opt_set_talstr, opt_show_charp,
 			 &ld->pidfile,
 			 "Specify pid file");


### PR DESCRIPTION
fixes #7132


I would really appreciate some friendly feedback on this, as it is my first PR to the project and I might have misunderstood or missed important details.

~~I did find a similar function `strip_trailing_whitespace` in `plugins/bcli.c`, but from what I understand, having `void trim_trailing_spaces(char *str);` in `ccan` would still be beneficial, right?~~