### PR TITLE
docker: Fix jq installation error for focal

### DIFF
--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -24,8 +24,11 @@ RUN apt-get update \
 	sudo \
 	unzip \
 	wget \
-    jq \
 	zip
+
+# Download and install jq from official repository
+RUN wget -O /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 \
+    && chmod +x /usr/local/bin/jq
 
 # install Python3.8 (more reproducible than relying on python3-setuptools)
 RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \


### PR DESCRIPTION
`jq` is not available in the default repositories of the Ubuntu Focal image. To resolve this, adding the official jq package repository and then installing it.

Changelog-None.