### PR TITLE
poetry: Use non-package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+package-mode=false
 name = "cln-meta-project"
 version = "0.1.0"
 description = "Just a helper to get our python dependencies under control"


### PR DESCRIPTION
Since `poetry=1.8.0` there is a non-package mode. This can be used to
create `pyproject.toml` files that are only used to track dependencies.

Performing `poetry install` in the project-root with a recent version of `poetry`
is currently generating a warning which will become an error in the
future.

Setting `package-mode=false` makes this error go away.

A side-effect is that the `name`, `version` and `description` in the
`pyproject.toml`-file will be ignored. Keeping the parameters in the
`pyproject.toml` file ensures it will still work for developers who are
using `poetry<1.8.0`.
