### PR TITLE
pyln-client: pass through level parameter on command notifications.

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -707,7 +707,7 @@ class Plugin(object):
     def notify_message(self, request: Request, message: str,
                        level: str = 'info') -> None:
         """Send a notification message to sender of this request"""
-        request.notify(message=message)
+        request.notify(message=message, level=level)
 
     def notify_progress(self, request: Request,
                         progress: int, progress_total: int,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2268,7 +2268,6 @@ def test_htlc_accepted_hook_crash(node_factory, executor):
         f.result(10)
 
 
-@pytest.mark.skip("With newer GCC versions reports a '*** buffer overflow detected ***: terminated'")
 def test_notify(node_factory):
     """Test that notifications from plugins get ignored"""
     plugins = [os.path.join(os.getcwd(), 'tests/plugins/notify.py'),
@@ -2292,17 +2291,17 @@ def test_notify(node_factory):
         else:
             assert out[2 + i].endswith("|\r")
 
-    assert out[102] == '# Beginning stage 2\n'
-    assert out[103] == '\r'
-
+    # These messages are DEBUG level, and default is INFO, so there is no
+    # "'# Beginning stage 2\n'
+    assert out[102] == '\r'
     for i in range(10):
-        assert out[104 + i].startswith("# Stage 2/2 {:>2}/10 |".format(1 + i))
+        assert out[103 + i].startswith("# Stage 2/2 {:>2}/10 |".format(1 + i))
         if i == 9:
-            assert out[104 + i].endswith("|\n")
+            assert out[103 + i].endswith("|\n")
         else:
-            assert out[104 + i].endswith("|\r")
-    assert out[114] == '"This worked"\n'
-    assert len(out) == 115
+            assert out[103 + i].endswith("|\r")
+    assert out[113] == '"This worked"\n'
+    assert len(out) == 114
 
     # At debug level, we get the second prompt.
     out = subprocess.check_output(['cli/lightning-cli',


### PR DESCRIPTION
Without this, everything came out as level INFO.

Changelog-Fixed: pyln-client: Fix Plugin.notify_message() not to ignore `level` parameter.