### PR TITLE
Pyln: support dynamic config options

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -330,8 +330,10 @@ class Plugin(object):
         `deprecated` True means that it won't appear unless `allow-deprecated-apis`
         is true (the default), or if list of version string (e.g. "v23.08"), then
         start deprecation cycle at that version (and removal after second entry in list).
+
+        You can override `setconfig` to intercept changes to dynamic options.
         """
-        if name in self.methods:
+        if name in self.methods and self.methods != self._set_config:
             raise ValueError(
                 "Name {} is already bound to a method.".format(name)
             )

--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -974,11 +974,10 @@ class Plugin(object):
             return self._exec_func(self.child_init, request)
         return None
 
-    def _set_config(self, **_) -> None:
+    def _set_config(self, config: str, val: Optional[Any]) -> None:
         """Called when the value of a dynamic option is changed
-        For now we don't do anything.
         """
-        pass
+        self.options[config]['value'] = val
 
 
 class PluginStream(object):

--- a/tests/plugins/dynamic_option.py
+++ b/tests/plugins/dynamic_option.py
@@ -9,4 +9,10 @@ plugin.add_option(
     default="initial",
     dynamic=True)
 
+
+@plugin.method('dynamic-option-report')
+def record_lookup(plugin):
+    return {'test-dynamic-config': plugin.get_option('test-dynamic-config')}
+
+
 plugin.run()

--- a/tests/plugins/dynamic_option.py
+++ b/tests/plugins/dynamic_option.py
@@ -15,4 +15,10 @@ def record_lookup(plugin):
     return {'test-dynamic-config': plugin.get_option('test-dynamic-config')}
 
 
+@plugin.method('setconfig')
+def setconfig(plugin, config, val, **kwargs):
+    plugin.log(f"Setting config {config} to {val}")
+    plugin.options[config]['value'] = val
+
+
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4261,8 +4261,10 @@ def test_dynamic_option_python_plugin(node_factory):
 
     assert result["configs"]["test-dynamic-config"]["value_str"] == "initial"
 
+    assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'initial'}
     result = ln.rpc.setconfig("test-dynamic-config", "changed")
     assert result["config"]["value_str"] == "changed"
+    assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'changed'}
 
 
 def test_renepay_not_important(node_factory):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4266,6 +4266,8 @@ def test_dynamic_option_python_plugin(node_factory):
     assert result["config"]["value_str"] == "changed"
     assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'changed'}
 
+    ln.daemon.wait_for_log('dynamic_option.py:.*Setting config test-dynamic-config to changed')
+
 
 def test_renepay_not_important(node_factory):
     # I mean, it's *important*, it's just not "mission-critical" just yet!


### PR DESCRIPTION
We added `dynamic` boolean parameter for config options, but never seemed to finish it?  This actually does something when they get set!