### PR TITLE
pyln: Add a dynamic configs and a callback for changes

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -390,7 +390,8 @@ class Plugin(object):
 
     def add_option(self, name: str, default: Optional[str],
                    description: Optional[str],
-                   opt_type: str = "string", deprecated: Union[bool, List[str]] = None,
+                   opt_type: str = "string",
+                   deprecated: Optional[Union[bool, List[str]]] = None,
                    multi: bool = False,
                    dynamic=False,
                    on_change: Optional[Callable[["Plugin", str, Optional[Any]], None]] = None,
@@ -424,7 +425,7 @@ class Plugin(object):
         }
 
     def add_flag_option(self, name: str, description: str,
-                        deprecated: Union[bool, List[str]] = None,
+                        deprecated: Optional[Union[bool, List[str]]] = None,
                         dynamic: bool = False) -> None:
         """Add a flag option that we'd like to register with lightningd.
 

--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -974,11 +974,10 @@ class Plugin(object):
             return self._exec_func(self.child_init, request)
         return None
 
-    def _set_config(self, **_) -> None:
+    def _set_config(self, config: str, val: Optional[Any]) -> None:
         """Called when the value of a dynamic option is changed
-        For now we don't do anything.
         """
-        pass
+        self.options[config]['value'] = val
 
 
 class PluginStream(object):

--- a/tests/plugins/dynamic_option.py
+++ b/tests/plugins/dynamic_option.py
@@ -9,4 +9,10 @@ plugin.add_option(
     default="initial",
     dynamic=True)
 
+
+@plugin.method('dynamic-option-report')
+def record_lookup(plugin):
+    return {'test-dynamic-config': plugin.get_option('test-dynamic-config')}
+
+
 plugin.run()

--- a/tests/plugins/dynamic_option.py
+++ b/tests/plugins/dynamic_option.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from pyln.client import Plugin
+from pyln.client import Plugin, RpcException
 from typing import Any, Optional
 
 plugin = Plugin()
@@ -14,6 +14,8 @@ def on_config_change(plugin, config: str, value: Optional[Any]) -> None:
     """Callback method called when a config value is changed.
     """
     plugin.log(f"Setting config {config} to {value}")
+    if value == 'bad value':
+        raise RpcException("I don't like bad values!")
 
 
 plugin.add_option(

--- a/tests/plugins/dynamic_option.py
+++ b/tests/plugins/dynamic_option.py
@@ -1,18 +1,28 @@
 #!/usr/bin/env python3
 from pyln.client import Plugin
+from typing import Any, Optional
 
 plugin = Plugin()
-
-plugin.add_option(
-    name="test-dynamic-config",
-    description="A config option which can be changed at run-time",
-    default="initial",
-    dynamic=True)
 
 
 @plugin.method('dynamic-option-report')
 def record_lookup(plugin):
     return {'test-dynamic-config': plugin.get_option('test-dynamic-config')}
+
+
+def on_config_change(plugin, config: str, value: Optional[Any]) -> None:
+    """Callback method called when a config value is changed.
+    """
+    plugin.log(f"Setting config {config} to {value}")
+
+
+plugin.add_option(
+    name="test-dynamic-config",
+    description="A config option which can be changed at run-time",
+    default="initial",
+    dynamic=True,
+    on_change=on_config_change,
+)
 
 
 plugin.run()

--- a/tests/plugins/zeroconf-selective.py
+++ b/tests/plugins/zeroconf-selective.py
@@ -21,8 +21,8 @@ def on_openchannel(openchannel, plugin, **kwargs):
 
 plugin.add_option(
     'zeroconf-allow',
+    '03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f',
     'A node_id to allow zeroconf channels from',
-    '03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f'
 )
 
 plugin.add_option(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4319,6 +4319,10 @@ def test_dynamic_option_python_plugin(node_factory):
     assert result["config"]["value_str"] == "changed"
     assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'changed'}
 
+    ln.daemon.wait_for_log(
+        'dynamic_option.py:.*Setting config test-dynamic-config to changed'
+    )
+
 
 def test_renepay_not_important(node_factory):
     # I mean, it's *important*, it's just not "mission-critical" just yet!

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4323,6 +4323,12 @@ def test_dynamic_option_python_plugin(node_factory):
         'dynamic_option.py:.*Setting config test-dynamic-config to changed'
     )
 
+    with pytest.raises(RpcError, match="I don't like bad values!"):
+        ln.rpc.setconfig("test-dynamic-config", "bad value")
+
+    # Does not alter value!
+    assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'changed'}
+
 
 def test_renepay_not_important(node_factory):
     # I mean, it's *important*, it's just not "mission-critical" just yet!

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4314,8 +4314,10 @@ def test_dynamic_option_python_plugin(node_factory):
 
     assert result["configs"]["test-dynamic-config"]["value_str"] == "initial"
 
+    assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'initial'}
     result = ln.rpc.setconfig("test-dynamic-config", "changed")
     assert result["config"]["value_str"] == "changed"
+    assert ln.rpc.dynamic_option_report() == {'test-dynamic-config': 'changed'}
 
 
 def test_renepay_not_important(node_factory):


### PR DESCRIPTION
This is an alternative to #7288, that uses a callback per config
option rather than hooking the `setconfig` function entirely. This
allows us to react to individual config options changing, while still
maintaining the default `setconfig` behavior.
