### PR TITLE
cln-plugin: Add dynamic configs and a callback for changes

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -778,7 +778,7 @@ where
                                     .send(json!({
                                     "jsonrpc": "2.0",
                                     "id": id,
-                                    "error": e.to_string(),
+                                    "error": parse_error(e.to_string()),
                                     }))
                                     .await
                                     .context("returning custom error"),
@@ -893,6 +893,23 @@ pub enum FeatureBitsKind {
     Channel,
     Invoice,
     Init,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+struct RpcError {
+    pub code: Option<i32>,
+    pub message: String,
+    pub data: Option<serde_json::Value>,
+}
+fn parse_error(error: String) -> RpcError {
+    match serde_json::from_str::<RpcError>(&error) {
+        Ok(o) => o,
+        Err(_) => RpcError {
+            code: Some(-32700),
+            message: error,
+            data: None,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -76,6 +76,7 @@
 //!     default : (), // We provide no default here
 //!     description : "A config option of type string that takes no default",
 //!     deprecated : false,     // Option is not deprecated
+//!     dynamic: false, //Option is not dynamic
 //! };
 //! ```
 //!
@@ -420,6 +421,7 @@ pub struct ConfigOption<'a, V: OptionType<'a>> {
     pub default: V::DefaultValue,
     pub description: &'a str,
     pub deprecated: bool,
+    pub dynamic: bool,
 }
 
 impl<'a, V: OptionType<'a>> ConfigOption<'a, V> {
@@ -430,6 +432,7 @@ impl<'a, V: OptionType<'a>> ConfigOption<'a, V> {
             default: <V as OptionType>::convert_default(&self.default),
             description: self.description.to_string(),
             deprecated: self.deprecated,
+            dynamic: self.dynamic,
         }
     }
 }
@@ -445,7 +448,12 @@ impl<'a> DefaultStringConfigOption<'a> {
             default: default,
             description: description,
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -456,7 +464,12 @@ impl<'a> StringConfigOption<'a> {
             default: (),
             description: description,
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -467,7 +480,12 @@ impl<'a> DefaultIntegerConfigOption<'a> {
             default: default,
             description: description,
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -478,7 +496,12 @@ impl<'a> IntegerConfigOption<'a> {
             default: (),
             description: description,
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -489,7 +512,12 @@ impl<'a> BooleanConfigOption<'a> {
             description,
             default: (),
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -500,7 +528,12 @@ impl<'a> DefaultBooleanConfigOption<'a> {
             description,
             default: default,
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -511,7 +544,12 @@ impl<'a> FlagConfigOption<'a> {
             description,
             default: (),
             deprecated: false,
+            dynamic: false,
         }
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -530,6 +568,7 @@ pub struct UntypedConfigOption {
     description: String,
     #[serde(skip_serializing_if = "is_false")]
     deprecated: bool,
+    dynamic: bool,
 }
 
 impl UntypedConfigOption {
@@ -538,6 +577,10 @@ impl UntypedConfigOption {
     }
     pub fn default(&self) -> &Option<Value> {
         &self.default
+    }
+    pub fn dynamic(mut self) -> Self {
+        self.dynamic = true;
+        self
     }
 }
 
@@ -569,6 +612,7 @@ mod test {
                         "description":"description",
                         "default": "default",
                         "type": "string",
+                        "dynamic": false,
                     }),
             ),
             (
@@ -578,15 +622,21 @@ mod test {
                         "description":"description",
                         "default": 42,
                         "type": "int",
+                        "dynamic": false,
                     }),
             ),
             (
-                ConfigOption::new_bool_with_default("name", true, "description").build(),
+                {
+                    ConfigOption::new_bool_with_default("name", true, "description")
+                        .build()
+                        .dynamic()
+                },
                 json!({
                 "name": "name",
                         "description":"description",
                         "default": true,
                         "type": "bool",
+                        "dynamic": true,
                     }),
             ),
             (
@@ -595,7 +645,8 @@ mod test {
                     "name" : "name",
                     "description": "description",
                     "type" : "flag",
-                    "default" : false
+                    "default" : false,
+                    "dynamic": false,
                 }),
             ),
         ];

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -66,6 +66,13 @@ def test_plugin_start(node_factory):
     l1.daemon.wait_for_log(r'Got a connect hook call')
     l1.daemon.wait_for_log(r'Got a connect notification')
 
+    l1.rpc.setconfig("test-dynamic-option", True)
+    assert l1.rpc.listconfigs("test-dynamic-option")["configs"]["test-dynamic-option"]["value_bool"]
+    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option \\"true\\"'))
+    l1.rpc.setconfig("test-dynamic-option", False)
+    assert not l1.rpc.listconfigs("test-dynamic-option")["configs"]["test-dynamic-option"]["value_bool"]
+    wait_for(lambda: l1.daemon.is_in_log(r'cln-plugin-startup: Got dynamic option change: test-dynamic-option \\"false\\"'))
+
 
 def test_plugin_options_handle_defaults(node_factory):
     """Start a minimal plugin and ensure it is well-behaved


### PR DESCRIPTION
I want this in cln-plugin: #7289

So this is my take for cln-plugin on it. The formatting changes are because @cdecker is not using `rustfmt` like a good boy and i noticed it too late, sorry. Some things get a bit weird here and there but overall it works! 

I wanted existing projects to not have to do any changes if they were using static options (so all of them up to now), that's why i added the dynamic switch as a function, instead of an extra argument to the `new_*` functions.

Let me know what you think.