### PR TITLE
[RFC] bitcoind: make valid json as response of the estimation fee

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -908,8 +908,8 @@ static struct command_result *estimatefees_next(struct command *cmd,
 		if (!stash->perkb[i])
 			continue;
 		json_object_start(response, NULL);
-		json_add_u32(response, "blocks", estimatefee_params[i].blocks);
-		json_add_feerate(response, "feerate", cmd, stash, stash->perkb[i]);
+		json_add_feerate(response, tal_fmt(tmpctx, "%d", estimatefee_params[i].blocks),
+				 cmd, stash, stash->perkb[i]);
 		json_object_end(response);
 	}
 	json_array_end(response);


### PR DESCRIPTION
I know that @rustyrussell will yell at me, but I am also yelling at him with this RFC.

----
I was debugging an issue with the folgore plugin, and I noted that the new estimated fee is not defining a valid json

```json
{
	"feerate_floor": 1,
	"feerates": {
		{ "blocks": 2, "feerate": 1 },
		{ "blocks": 6, "feerate": 1 },
		{ "blocks": 12, "feerate": 1 }
		{ "blocks": 100, "feerate": 1 }
	}
}
```

the `feerates` is an object of an object, but the inner object is not a value `key-value` pair, so this breaks modern parsers

My suggestion is to move the object as follows

```json
{
	"feerate_floor": 1,
	"feerates": {
		"2": 1,
		"6": 1,
		"12": 1,
		"100": 1,
	}
}
```

---
An online parser like https://jsonformatter.org/ generate the following error

Parse error on line 3:
...1,	"feerates": {		{ "blocks": 2, "feer
---------------------^
Expecting 'STRING', '}', got '{'

----

N.B: I hate my proposal, but it is the cleanest thing I could come up with, so please suggest a better format if you have another one.