### PR TITLE
[RFC]: make dev-rescan-outputs safe to use

### DIFF
--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1773,4 +1773,15 @@ void wallet_remove_local_anchors(struct wallet *w,
 struct local_anchor_info *wallet_get_local_anchors(const tal_t *ctx,
 						   struct wallet *w,
 						   u64 channel_id);
+
+/**
+ * This does not deseave documentation, if you do not know why this exist
+ * you should not use it.
+ *
+ * FYI: git grep is your friend :) */
+bool wallet_force_update_output_status(struct wallet *w,
+				       const struct bitcoin_txid *prev_txid,
+				       const u64 *prev_vout,
+				       enum output_status status,
+				       const u64 *spentheight);
 #endif /* LIGHTNING_WALLET_WALLET_H */


### PR DESCRIPTION
This PR should be title "Never assume that some shit works". Thanks for @niftynei that wake up me and said "Hey this is a DB shit", and thanks to @rustyrussell to waste 20 minutes debugging my problem.

But now, back to the patch description
---

Working to fix the following issue

```
 error: {\\\"code\\\":-25,\\\"message\\\":\\\"bad-txns-inputs-missingorspent\\\"}\") })
2024-03-25T14:05:44.178Z DEBUG   lightningd: Expected error broadcasting
tx
020000000001018c9e9f69341019c959b5526231e2bd52bd1e7227a3b72fa40e095ed283b7ddbb0000000000cae9f0800199c20000000000002200203251c1d74d76a6a487afca13913bc09fb3cc766e12efe938c049a1c432316bcf040047304402201a96b84a9e234172ade0f055be867097ac480c2d21f8163f449bde67266dda15022060fe38faed61d573db32ab5d48a3a9eff1f9e27f7adc51e86cb7b22878aad66a014730440220764c985c44e8ae0e303c46588090dea100c997b42ba9bdec7fa66bc68f5cc1fe02205200f62950b4ac4d8a297a97bb30fdc92edd43f5fccaf35b31a46e6963f42f4d0147522102b7c0c24f0a4ed6880289c17132f63c7a9ace2db1dfbc0baaf03a19916cfc867e210382323ae01328ab397c250a3120567531e76970a8c88795cac03e488dafe81b4252ae8ea0b720:
[400] Unknown error (sendrawtransaction RPC error:
{\"code\":-25,\"message\":\"bad-txns-inputs-missingorspent\"})
```

The problem is that my database is marking the outputs with the state `AVAILABLE` but they are spent, so we should look at the spend height and just mark with a spent status, but due that we can have other kind of status inside the database, it is better that we make a double check with an external explorer.

This PR add the necessary RPC methods to fix the issue.

Fixes: https://github.com/ElementsProject/lightning/issues/7172

Co-Developed-by: Rusty Russell <rusty@rustcorp.com.au>
Co-Developer-by: @niftynei 