### PR TITLE
doc: Updating installation instructions for python plugins

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -24,13 +24,6 @@ Then you can fetch a pre-compiled binary from the [releases](https://github.com/
 sudo tar -xvf <release>.tar.xz -C /usr/local --strip-components=2
 ```
 
-You will need some Python packages if you want to use clnrest.  Unfortunately there are some Python packages which are not packaged in Ubuntu, and so you will need to force installation of these (I recommend --user which will install them in your own .local directory, so at least you won't run the risk of breaking Python globally!).
-
-```
-sudo apt-get install python3-json5 python3-flask python3-gunicorn
-pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
-```
-
 If you're on a different distribution or OS, you can compile the source by following the instructions from [Installing from Source](<>).
 
 # Docker
@@ -72,6 +65,27 @@ For actually doing development and running the tests, you will also need:
 - valgrind: for extra debugging checks
 
 You will also need a version of bitcoind with segregated witness and `estimatesmartfee` with `ECONOMICAL` mode support, such as the 0.16 or above.
+
+## Python plugins
+
+You will need some Python packages if you want to use python plugins. Unfortunately there are some Python packages which are not packaged in Ubuntu, and so you will need to force installation of these (I recommend --user which will install them in your own .local directory, so at least you won't run the risk of breaking Python globally!).
+
+### clnrest
+
+Installation steps for clnrest are:
+
+```
+sudo apt-get install python3-json5 python3-flask python3-gunicorn
+pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
+```
+
+### wss-proxy
+
+For wss-proxy, you need to install below libraries:
+
+```
+pip3 install --user pyln-client websockets
+```
 
 ## To Build on Ubuntu
 


### PR DESCRIPTION
Previously, we only had a single python plugin `clnrest` and the instructions were embedded under other heading.

Adding a new heading for python plugins and their installation instructions will make it easier for users to locate them.

Changelog-None.