### PR TITLE
Reply to invoice_request even if we need to make explicit connection to node

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -428,6 +428,8 @@ void close_random_connection(struct daemon *daemon)
 				break;
 		}
 		peer = peer_htable_next(daemon->peers, &it);
+		if (!peer)
+			peer = peer_htable_first(daemon->peers, &it);
 	}
 
 	if (best_peer) {

--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1412,7 +1412,8 @@ static void connect_init(struct daemon *daemon, const u8 *msg)
 		&daemon->announce_websocket,
 		&daemon->dev_fast_gossip,
 		&dev_disconnect,
-		&daemon->dev_no_ping_timer)) {
+		&daemon->dev_no_ping_timer,
+		&daemon->dev_handshake_no_reply)) {
 		/* This is a helper which prints the type expected and the actual
 		 * message, then exits (it should never be called!). */
 		master_badmsg(WIRE_CONNECTD_INIT, msg);

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -266,7 +266,9 @@ struct daemon {
 	int dev_disconnect_fd;
 	/* Did we exhaust fds?  If so, skip dev_report_fds */
 	bool dev_exhausted_fds;
-};
+	/* Allow connections in, but don't send anything */
+	bool dev_handshake_no_reply;
+ };
 
 /* Called by io_tor_connect once it has a connection out. */
 struct io_plan *connection_out(struct io_conn *conn, struct connecting *connect);

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -40,6 +40,16 @@ enum pong_expect_type {
 	PONG_EXPECTED_PROBING = 2,
 };
 
+/*~ We classify connections by loose priority */
+enum connection_prio {
+	/* We deliberately connected to them. */
+	PRIO_DELIBERATE,
+	/* They connected to us, unsolicited. */
+	PRIO_UNSOLICITED,
+	/* We connected, but transiently. */
+	PRIO_TRANSIENT,
+};
+
 /*~ We keep a hash table (ccan/htable) of peers, which tells us what peers are
  * already connected (by peer->id). */
 struct peer {
@@ -90,8 +100,8 @@ struct peer {
 	/* Last time we received traffic */
 	struct timeabs last_recv_time;
 
-	/* Were we explicitly told to connect to this peer? */
-	bool deliberate_connection;
+	/* How important does this peer seem to be? */
+	enum connection_prio prio;
 
 	bool dev_read_enabled;
 	/* If non-NULL, this counts down; 0 means disable */
@@ -144,6 +154,9 @@ struct connecting {
 
 	/* Accumulated errors */
 	char *errors;
+
+	/* Is this a transient connection? */
+	bool transient;
 };
 
 static const struct node_id *connecting_keyof(const struct connecting *connecting)

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -264,6 +264,8 @@ struct daemon {
 	bool dev_suppress_gossip;
 	/* dev_disconnect file */
 	int dev_disconnect_fd;
+	/* Did we exhaust fds?  If so, skip dev_report_fds */
+	bool dev_exhausted_fds;
 };
 
 /* Called by io_tor_connect once it has a connection out. */

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -163,3 +163,5 @@ msgtype,connectd_start_shutdown_reply,2131
 # master -> connect: stop sending gossip.
 msgtype,connectd_dev_suppress_gossip,2032
 
+# master -> connect: waste all your fds.
+msgtype,connectd_dev_exhaust_fds,2036

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -55,6 +55,7 @@ msgdata,connectd_connect_to_peer,len,u32,
 msgdata,connectd_connect_to_peer,addrs,wireaddr,len
 msgdata,connectd_connect_to_peer,addrhint,?wireaddr_internal,
 msgdata,connectd_connect_to_peer,dns_fallback,bool,
+msgdata,connectd_connect_to_peer,transient,bool,
 
 # Connectd->master: connect failed.
 msgtype,connectd_connect_failed,2020

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -25,6 +25,8 @@ msgdata,connectd_init,dev_fast_gossip,bool,
 # If this is set, then fd 5 is dev_disconnect_fd.
 msgdata,connectd_init,dev_disconnect,bool,
 msgdata,connectd_init,dev_no_ping_timer,bool,
+# Allow incoming connections, but don't talk.
+msgdata,connectd_init,dev_noreply,bool,
 
 # Connectd->master, here are the addresses I bound, can announce.
 msgtype,connectd_init_reply,2100

--- a/connectd/peer_exchange_initmsg.c
+++ b/connectd/peer_exchange_initmsg.c
@@ -295,5 +295,9 @@ struct io_plan *peer_exchange_initmsg(struct io_conn *conn,
 		break;
 	}
 
+	/* Don't converse if we said "no reply" */
+	if (daemon->dev_handshake_no_reply)
+		return io_wait(conn, peer->msg, io_never, NULL);
+
 	return io_write(conn, peer->msg, tal_bytelen(peer->msg), next, peer);
 }

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -747,8 +747,8 @@ corresponding functionality, which are in draft status ([bolt][bolt] #798) as [b
 
 * **fetchinvoice-noconnect**
 
-  Specifying this prevents `fetchinvoice` and `sendinvoice` from
-trying to connect directly to the offering node as a last resort.
+  Specifying this prevents `fetchinvoice`, `sendinvoice` and replying
+to invoice request from trying to connect directly to the offering node as a last resort.
 
 * **experimental-shutdown-wrong-funding**
 

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -611,6 +611,7 @@ static unsigned connectd_msg(struct subd *connectd, const u8 *msg, const int *fd
 	case WIRE_CONNECTD_CUSTOMMSG_OUT:
 	case WIRE_CONNECTD_START_SHUTDOWN:
 	case WIRE_CONNECTD_SET_CUSTOMMSGS:
+	case WIRE_CONNECTD_DEV_EXHAUST_FDS:
 	/* This is a reply, so never gets through to here. */
 	case WIRE_CONNECTD_INIT_REPLY:
 	case WIRE_CONNECTD_ACTIVATE_REPLY:
@@ -932,3 +933,26 @@ static const struct json_command dev_report_fds = {
 	.dev_only = true,
 };
 AUTODATA(json_command, &dev_report_fds);
+
+static struct command_result *json_dev_connectd_exhaust_fds(struct command *cmd,
+							    const char *buffer,
+							    const jsmntok_t *obj UNNEEDED,
+							    const jsmntok_t *params)
+{
+	if (!param(cmd, buffer, params, NULL))
+		return command_param_failed();
+
+	subd_send_msg(cmd->ld->connectd,
+		      take(towire_connectd_dev_exhaust_fds(NULL)));
+
+	return command_success(cmd, json_stream_success(cmd));
+}
+
+static const struct json_command dev_connectd_exhaust_fds = {
+	"dev-connectd-exhaust-fds",
+	"developer",
+	json_dev_connectd_exhaust_fds,
+	"Make connectd run out of file descriptors",
+	.dev_only = true,
+};
+AUTODATA(json_command, &dev_connectd_exhaust_fds);

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -764,7 +764,8 @@ int connectd_init(struct lightningd *ld)
 	    !ld->deprecated_ok,
 	    ld->dev_fast_gossip,
 	    ld->dev_disconnect_fd >= 0,
-	    ld->dev_no_ping_timer);
+	    ld->dev_no_ping_timer,
+	    ld->dev_handshake_no_reply);
 
 	subd_req(ld->connectd, ld->connectd, take(msg), -1, 0,
 		 connect_init_done, NULL);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -148,6 +148,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_allow_shutdown_destination_change = false;
 	ld->dev_hsmd_no_preapprove_check = false;
 	ld->dev_hsmd_fail_preapprove = false;
+	ld->dev_handshake_no_reply = false;
 
 	/*~ We try to ensure enough fds for twice the number of channels
 	 * we start with.  We have a developer option to change that factor

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -356,6 +356,9 @@ struct lightningd {
 	bool dev_hsmd_no_preapprove_check;
 	bool dev_hsmd_fail_preapprove;
 
+	/* Tell connectd not to talk after handshake */
+	bool dev_handshake_no_reply;
+
 	/* tor support */
 	struct wireaddr *proxyaddr;
 	bool always_use_proxy;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -952,6 +952,10 @@ static void dev_register_opts(struct lightningd *ld)
 		       opt_set_u32, opt_show_u32,
 		       &ld->fd_limit_multiplier,
 		       "Try to set fd limit to this many times by number of channels (default: 2)");
+	clnopt_noarg("--dev-handshake-no-reply", OPT_DEV,
+		     opt_set_bool,
+		     &ld->dev_handshake_no_reply,
+		     "Don't send or read init message after connection");
 	/* This is handled directly in daemon_developer_mode(), so we ignore it here */
 	clnopt_noarg("--dev-debug-self", OPT_DEV,
 		     opt_ignore,

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -31,11 +31,11 @@ PLUGIN_PAY_LIB_SRC := plugins/libplugin-pay.c
 PLUGIN_PAY_LIB_HEADER := plugins/libplugin-pay.h
 PLUGIN_PAY_LIB_OBJS := $(PLUGIN_PAY_LIB_SRC:.c=.o)
 
-PLUGIN_OFFERS_SRC := plugins/offers.c plugins/offers_offer.c plugins/offers_invreq_hook.c plugins/offers_inv_hook.c
+PLUGIN_OFFERS_SRC := plugins/offers.c plugins/offers_offer.c plugins/offers_invreq_hook.c plugins/offers_inv_hook.c plugins/establish_onion_path.c
 PLUGIN_OFFERS_OBJS := $(PLUGIN_OFFERS_SRC:.c=.o)
 PLUGIN_OFFERS_HEADER := $(PLUGIN_OFFERS_SRC:.c=.h)
 
-PLUGIN_FETCHINVOICE_SRC := plugins/fetchinvoice.c
+PLUGIN_FETCHINVOICE_SRC := plugins/fetchinvoice.c plugins/establish_onion_path.c
 PLUGIN_FETCHINVOICE_OBJS := $(PLUGIN_FETCHINVOICE_SRC:.c=.o)
 PLUGIN_FETCHINVOICE_HEADER :=
 
@@ -212,7 +212,7 @@ $(PLUGIN_KEYSEND_OBJS): $(PLUGIN_PAY_LIB_HEADER)
 
 plugins/spenderp: bitcoin/block.o bitcoin/preimage.o bitcoin/psbt.o common/psbt_open.o common/json_channel_type.o common/channel_type.o common/features.o wire/peer_wiregen.o $(PLUGIN_SPENDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
-plugins/offers: $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/addr.o common/bolt12.o common/bolt12_merkle.o common/bolt11_json.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o common/blindedpath.o common/invoice_path_id.o common/blinding.o common/hmac.o common/json_blinded_path.o common/gossmap.o common/fp16.o $(JSMN_OBJS)
+plugins/offers: $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/addr.o common/bolt12.o common/bolt12_merkle.o common/bolt11_json.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o common/blindedpath.o common/invoice_path_id.o common/blinding.o common/hmac.o common/json_blinded_path.o common/gossmap.o common/fp16.o $(JSMN_OBJS) common/dijkstra.o common/route.o common/gossmods_listpeerchannels.o 
 
 plugins/fetchinvoice: $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/bolt12.o common/bolt12_merkle.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o $(JSMN_OBJS) common/gossmap.o common/fp16.o common/dijkstra.o common/route.o common/blindedpath.o common/hmac.o common/blinding.o common/gossmods_listpeerchannels.o
 

--- a/plugins/establish_onion_path.c
+++ b/plugins/establish_onion_path.c
@@ -1,0 +1,177 @@
+#include "config.h"
+#include <ccan/tal/str/str.h>
+#include <common/dijkstra.h>
+#include <common/gossmap.h>
+#include <common/gossmods_listpeerchannels.h>
+#include <common/json_stream.h>
+#include <common/route.h>
+#include <plugins/establish_onion_path.h>
+
+struct connect_info {
+	struct pubkey local_id, dst;
+	const char *connect_disable;
+	struct gossmap *gossmap;
+	struct command_result *(*cb)(struct command *,
+				     const struct pubkey *,
+				     void *arg);
+	struct command_result *(*fail)(struct command *, const char *,
+				       void *arg);
+	void *arg;
+};
+
+static struct command_result *connect_ok(struct command *cmd,
+					 const char *buf,
+					 const jsmntok_t *result,
+					 struct connect_info *ci)
+{
+	struct pubkey *path = tal_arr(tmpctx, struct pubkey, 2);
+
+	/* Create direct mini-path */
+	path[0] = ci->local_id;
+	path[1] = ci->dst;
+
+	return ci->cb(cmd, path, ci->arg);
+}
+
+static struct command_result *command_failed(struct command *cmd,
+					     const char *buf,
+					     const jsmntok_t *result,
+					     struct connect_info *ci)
+{
+	return ci->fail(cmd, json_strdup(tmpctx, buf, result), ci->arg);
+}
+
+static struct command_result *connect_direct(struct command *cmd,
+					     struct connect_info *ci)
+{
+	struct out_req *req;
+
+	if (ci->connect_disable) {
+		return ci->fail(cmd,
+				tal_fmt(tmpctx, "%s set: not initiating a new connection",
+					ci->connect_disable),
+				ci->arg);
+	}
+
+	req = jsonrpc_request_start(cmd->plugin, cmd,
+				    "connect", connect_ok, command_failed, ci);
+	json_add_pubkey(req->js, "id", &ci->dst);
+	return send_outreq(cmd->plugin, req);
+}
+
+static bool can_carry_onionmsg(const struct gossmap *map,
+			       const struct gossmap_chan *c,
+			       int dir,
+			       struct amount_msat amount UNUSED,
+			       void *arg UNUSED)
+{
+	const struct gossmap_node *n;
+	/* Don't use it if either side says it's disabled */
+	if (!c->half[dir].enabled || !c->half[!dir].enabled)
+		return false;
+
+	/* Check features of recipient */
+	n = gossmap_nth_node(map, c, !dir);
+	return gossmap_node_get_feature(map, n, OPT_ONION_MESSAGES) != -1;
+}
+
+static const struct pubkey *path_to_node(const tal_t *ctx,
+					 struct gossmap *gossmap,
+					 struct plugin *plugin,
+					 const char *buf,
+					 const jsmntok_t *listpeerchannels,
+					 const struct pubkey *local_id,
+					 const struct pubkey *dst_key)
+{
+	struct route_hop *r;
+	const struct dijkstra *dij;
+	const struct gossmap_node *src;
+	const struct gossmap_node *dst;
+	struct pubkey *nodes;
+	struct gossmap_localmods *mods;
+	struct node_id local_nodeid, dst_nodeid;
+
+	node_id_from_pubkey(&local_nodeid, local_id);
+	node_id_from_pubkey(&dst_nodeid, dst_key);
+	mods = gossmods_from_listpeerchannels(tmpctx, &local_nodeid, buf, listpeerchannels,
+					      false, gossmod_add_localchan, NULL);
+
+	gossmap_apply_localmods(gossmap, mods);
+	dst = gossmap_find_node(gossmap, &dst_nodeid);
+	if (!dst)
+		goto fail;
+
+	/* If we don't exist in gossip, routing can't happen. */
+	src = gossmap_find_node(gossmap, &local_nodeid);
+	if (!src)
+		goto fail;
+
+	dij = dijkstra(tmpctx, gossmap, dst, AMOUNT_MSAT(0), 0,
+		       can_carry_onionmsg, route_score_shorter, NULL);
+
+	r = route_from_dijkstra(tmpctx, gossmap, dij, src, AMOUNT_MSAT(0), 0);
+	if (!r)
+		goto fail;
+
+	nodes = tal_arr(ctx, struct pubkey, tal_count(r) + 1);
+	nodes[0] = *local_id;
+	for (size_t i = 0; i < tal_count(r); i++) {
+		if (!pubkey_from_node_id(&nodes[i+1], &r[i].node_id)) {
+			plugin_err(plugin, "Could not convert nodeid %s",
+				   fmt_node_id(tmpctx, &r[i].node_id));
+		}
+	}
+
+	gossmap_remove_localmods(gossmap, mods);
+	return nodes;
+
+fail:
+	gossmap_remove_localmods(gossmap, mods);
+	return NULL;
+}
+
+static struct command_result *listpeerchannels_done(struct command *cmd,
+						    const char *buf,
+						    const jsmntok_t *result,
+						    struct connect_info *ci)
+{
+	const struct pubkey *path;
+
+	path = path_to_node(tmpctx, ci->gossmap, cmd->plugin, buf, result,
+			    &ci->local_id, &ci->dst);
+	if (!path)
+		return connect_direct(cmd, ci);
+
+	return ci->cb(cmd, path, ci->arg);
+}
+
+struct command_result *establish_onion_path_(struct command *cmd,
+					     struct gossmap *gossmap,
+					     const struct pubkey *local_id,
+					     const struct pubkey *dst,
+					     const char *connect_disable,
+					     struct command_result *(*success)(struct command *,
+									       const struct pubkey *,
+									       void *arg),
+					     struct command_result *(*fail)(struct command *,
+									    const char *why,
+									    void *arg),
+					     void *arg)
+{
+	struct connect_info *ci = tal(cmd, struct connect_info);
+	struct out_req *req;
+
+	ci->local_id = *local_id;
+	ci->dst = *dst;
+	ci->cb = success;
+	ci->fail = fail;
+	ci->arg = arg;
+	ci->connect_disable = connect_disable;
+	ci->gossmap = gossmap;
+
+	req = jsonrpc_request_start(cmd->plugin, cmd, "listpeerchannels",
+				    listpeerchannels_done,
+				    command_failed,
+				    ci);
+	return send_outreq(cmd->plugin, req);
+}

--- a/plugins/establish_onion_path.h
+++ b/plugins/establish_onion_path.h
@@ -1,0 +1,46 @@
+#ifndef LIGHTNING_PLUGINS_ESTABLISH_ONION_PATH_H
+#define LIGHTNING_PLUGINS_ESTABLISH_ONION_PATH_H
+#include "config.h"
+#include <ccan/typesafe_cb/typesafe_cb.h>
+#include <plugins/libplugin.h>
+
+/**
+ * establish_onion_path: derive (or connect) a path to this peer.
+ * @cmd: the command context
+ * @gossmap: a gossip map to do lookup in
+ * @local_id: our own id
+ * @dst: the destination node
+ * @connect_disable: if non-null, the arg name which is disabling direct connection
+ * @success: the success callback
+ * @fail: the failure callback
+ * @arg: callback argument
+ *
+ * If it cannot find an onion-message-carrying path, will connect directly,
+ * unless connect_disable is non-NULL.
+ */
+struct command_result *establish_onion_path_(struct command *cmd,
+					     struct gossmap *gossmap,
+					     const struct pubkey *local_id,
+					     const struct pubkey *dst,
+					     const char *connect_disable,
+					     struct command_result *(*success)(struct command *,
+									   const struct pubkey *,
+									   void *arg),
+					     struct command_result *(*fail)(struct command *,
+									const char *why,
+									void *arg),
+					     void *arg);
+
+#define establish_onion_path(cmd, gossmap, local_id, id, disable, success, fail, arg) \
+	establish_onion_path_((cmd), (gossmap), (local_id), (id), (disable), \
+			      typesafe_cb_preargs(struct command_result *, void *, \
+						  (success), (arg),	\
+						  struct command *,	\
+						  const struct pubkey *), \
+			      typesafe_cb_preargs(struct command_result *, void *, \
+						  (fail), (arg),	\
+						  struct command *,	\
+						  const char *),	\
+			      (arg))
+
+#endif /* LIGHTNING_PLUGINS_ESTABLISH_ONION_PATH_H */

--- a/plugins/establish_onion_path.h
+++ b/plugins/establish_onion_path.h
@@ -4,6 +4,8 @@
 #include <ccan/typesafe_cb/typesafe_cb.h>
 #include <plugins/libplugin.h>
 
+struct gossmap;
+
 /**
  * establish_onion_path: derive (or connect) a path to this peer.
  * @cmd: the command context

--- a/plugins/fetchinvoice.c
+++ b/plugins/fetchinvoice.c
@@ -789,7 +789,7 @@ connect_direct(struct command *cmd,
 	node_id_from_pubkey(&ca->node_id, dst);
 
 	/* Make a direct path -> dst. */
-	sent->path = tal_arr(sent, struct pubkey, 2);
+ 	sent->path = tal_arr(sent, struct pubkey, 2);
 	sent->path[0] = local_id;
 	if (!pubkey_from_node_id(&sent->path[1], &ca->node_id)) {
 		/* Should not happen! */

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -31,6 +31,7 @@ struct pubkey id;
 u32 blockheight;
 u16 cltv_final;
 bool offers_enabled;
+bool disable_connect;
 struct secret invoicesecret_base;
 static struct gossmap *global_gossmap;
 
@@ -84,8 +85,8 @@ static struct command_result *sendonionmessage_error(struct command *cmd,
 /* So, you gave us a reply scid?  Let's do the lookup then!  And no,
  * we won't accept private channels, just public ones.
  */
-static bool convert_to_scidd(struct command *cmd,
-			     struct sciddir_or_pubkey *sciddpk)
+bool convert_to_scidd(struct command *cmd,
+		      struct sciddir_or_pubkey *sciddpk)
 {
 	struct gossmap *gossmap = get_gossmap(cmd->plugin);
 	struct gossmap_chan *chan;
@@ -1233,9 +1234,11 @@ static const char *init(struct plugin *p,
 		 take(json_out_obj(NULL, NULL, NULL)),
 		 "{configs:"
 		 "{cltv-final:{value_int:%},"
-		 "experimental-offers:{set:%}}}",
+		 "experimental-offers:{set:%}},"
+		 "fetchinvoice-noconnect?:{set:%}}",
 		 JSON_SCAN(json_to_u16, &cltv_final),
-		 JSON_SCAN(json_to_bool, &offers_enabled));
+		 JSON_SCAN(json_to_bool, &offers_enabled),
+		 JSON_SCAN(json_to_bool, &disable_connect));
 
 	rpc_scan(p, "makesecret",
 		 take(json_out_obj(NULL, "string", INVOICE_PATH_BASE_STRING)),

--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -5,6 +5,10 @@
 struct command_result;
 struct command;
 
+/* If they give us an scid, do a lookup */
+bool convert_to_scidd(struct command *cmd,
+		      struct sciddir_or_pubkey *sciddpk);
+
 /* Helper to send a reply */
 struct command_result *WARN_UNUSED_RESULT
 send_onion_reply(struct command *cmd,

--- a/plugins/offers_invreq_hook.h
+++ b/plugins/offers_invreq_hook.h
@@ -7,6 +7,7 @@ extern u16 cltv_final;
 extern u32 blockheight;
 extern struct secret invoicesecret_base;
 extern struct pubkey id;
+extern bool disable_connect;
 
 /* We got an onionmessage with an invreq! */
 struct command_result *handle_invoice_request(struct command *cmd,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4617,3 +4617,35 @@ def test_connect_transient(node_factory):
     l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
     assert l1.rpc.listpeers(l3.info['id'])['peers'] == []
     assert l1.daemon.is_in_log(fr"due to stress, randomly closing peer {l3.info['id']} \(score 0\)")
+
+
+def test_connect_transient_pending(node_factory, bitcoind, executor):
+    """Test that we kick out in-connection transient connections"""
+    l1, l2, l3, l4 = node_factory.get_nodes(4, opts=[{},
+                                                     {'dev-handshake-no-reply': None},
+                                                     {'dev-handshake-no-reply': None},
+                                                     {}])
+
+    # This will block...
+    fut1 = executor.submit(l1.rpc.connect, l2.info['id'], 'localhost', l2.port)
+    fut2 = executor.submit(l1.rpc.connect, l3.info['id'], 'localhost', l3.port)
+
+    assert not l1.daemon.is_in_log("due to stress, closing transient connect attempt")
+
+    # Wait until those connects in progress.
+    l2.daemon.wait_for_log("Connect IN")
+    l3.daemon.wait_for_log("Connect IN")
+
+    # Now force exhaustion.
+    l1.rpc.dev_connectd_exhaust_fds()
+
+    # This one will kick out one of the others.
+    l1.rpc.connect(l4.info['id'], 'localhost', l4.port)
+    line = l1.daemon.wait_for_log("due to stress, closing transient connect attempt")
+    peerid = re.search(r'due to stress, closing transient connect attempt to (.*)', line).groups()[0]
+
+    with pytest.raises(RpcError, match="Terminated due to too many connections"):
+        if peerid == l2.info['id']:
+            fut1.result(TIMEOUT)
+        else:
+            fut2.result(TIMEOUT)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4723,6 +4723,28 @@ def test_fetchinvoice_autoconnect(node_factory, bitcoind):
     assert l3.rpc.listpeers(l2.info['id'])['peers'] != []
 
 
+def test_fetchinvoice_disconnected_reply(node_factory, bitcoind):
+    """We ask for invoice, but reply path doesn't lead directly from recipient"""
+    l1, l2, l3 = node_factory.get_nodes(3,
+                                        opts={'experimental-offers': None,
+                                              'may_reconnect': True,
+                                              'dev-no-reconnect': None,
+                                              'dev-allow-localhost': None})
+    l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    # Make l1, l2 public (so l3 can auto connect).
+    node_factory.join_nodes([l1, l2], wait_for_announce=True)
+    wait_for(lambda: l3.rpc.listnodes(l1.info['id'])['nodes'] != [])
+
+    offer = l3.rpc.offer(amount='5msat', description='test_fetchinvoice_disconnected_reply')
+
+    # l2 sets reply_path to be l1->l2, l3 will connect to l1 to send reply.
+    # FIXME: if code were smarter, it would simply send via l2, and this test
+    # would have to get more sophisticated!
+    l2.rpc.fetchinvoice(offer=offer['bolt12'], dev_reply_path=[l1.info['id'], l2.info['id']])
+    assert only_one(l1.rpc.listpeers(l3.info['id'])['peers'])
+
+
 def test_pay_blockheight_mismatch(node_factory, bitcoind):
     """Test that we can send a payment even if not caught up with the chain.
 


### PR DESCRIPTION
This is vital for LDK interop!  They give us a reply path which isn't an immediate peer.

So we do that.  Now we have to handle the case where an attacker makes us open many connections, so we demark these in connectd as "transient" so it knows to throw them away under stress.

Closes: https://github.com/ElementsProject/lightning/issues/7110

