### PR TITLE
renepay: test channel capacity unavailable

### DIFF
--- a/lightningd/test/run-log-pruning.c
+++ b/lightningd/test/run-log-pruning.c
@@ -84,9 +84,6 @@ const char *log_level_name(enum log_level level UNNEEDED)
 bool log_level_parse(const char *levelstr UNNEEDED, size_t len UNNEEDED,
 		     enum log_level *level UNNEEDED)
 { fprintf(stderr, "log_level_parse called!\n"); abort(); }
-/* Generated stub for node_id_to_hexstr */
-char *node_id_to_hexstr(const tal_t *ctx UNNEEDED, const struct node_id *id UNNEEDED)
-{ fprintf(stderr, "node_id_to_hexstr called!\n"); abort(); }
 /* Generated stub for notify_log */
 void notify_log(struct lightningd *ld UNNEEDED, const struct log_entry *l UNNEEDED)
 { fprintf(stderr, "notify_log called!\n"); abort(); }

--- a/plugins/bkpr/test/run-bkpr_db.c
+++ b/plugins/bkpr/test/run-bkpr_db.c
@@ -96,7 +96,7 @@ const char *htlc_state_name(enum htlc_state s UNNEEDED)
 { fprintf(stderr, "htlc_state_name called!\n"); abort(); }
 /* Generated stub for is_asterix_notification */
 bool is_asterix_notification(const char *notification_name UNNEEDED,
-			   const char *subscriptions UNNEEDED)
+			     const char *subscriptions UNNEEDED)
 { fprintf(stderr, "is_asterix_notification called!\n"); abort(); }
 /* Generated stub for json_get_id */
 const char *json_get_id(const tal_t *ctx UNNEEDED,

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -102,7 +102,7 @@ const char *htlc_state_name(enum htlc_state s UNNEEDED)
 { fprintf(stderr, "htlc_state_name called!\n"); abort(); }
 /* Generated stub for is_asterix_notification */
 bool is_asterix_notification(const char *notification_name UNNEEDED,
-			   const char *subscriptions UNNEEDED)
+			     const char *subscriptions UNNEEDED)
 { fprintf(stderr, "is_asterix_notification called!\n"); abort(); }
 /* Generated stub for json_get_id */
 const char *json_get_id(const tal_t *ctx UNNEEDED,

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -31,7 +31,7 @@ void payment_collect_results(struct payment *payment,
 /* Announce that this route is pending and needs to be kept in the waiting list
  * for notifications. */
 void route_pending_register(struct routetracker *routetracker,
-			    const struct route *route);
+			    struct route *route);
 
 /* Sends a sendpay request for this route. */
 struct command_result *route_sendpay_request(struct command *cmd,

--- a/plugins/renepay/test/Makefile
+++ b/plugins/renepay/test/Makefile
@@ -10,9 +10,14 @@ $(PLUGIN_RENEPAY_TEST_OBJS): $(PLUGIN_RENEPAY_SRC)
 
 PLUGIN_RENEPAY_TEST_COMMON_OBJS :=		\
 	plugins/renepay/dijkstra.o		\
-	plugins/renepay/chan_extra.o
+	plugins/renepay/chan_extra.o		\
+	bitcoin/chainparams.o			\
+	common/gossmap.o			\
+	common/fp16.o				\
+	common/dijkstra.o			\
+	gossipd/gossip_store_wiregen.o
 
-$(PLUGIN_RENEPAY_TEST_PROGRAMS): $(PLUGIN_RENEPAY_TEST_COMMON_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) bitcoin/chainparams.o common/gossmap.o common/fp16.o common/dijkstra.o gossipd/gossip_store_wiregen.o
+$(PLUGIN_RENEPAY_TEST_PROGRAMS): $(PLUGIN_RENEPAY_TEST_COMMON_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 
 check-renepay: $(PLUGIN_RENEPAY_TEST_PROGRAMS:%=unittest/%)
 

--- a/plugins/renepay/test/common.h
+++ b/plugins/renepay/test/common.h
@@ -1,0 +1,110 @@
+#ifndef LIGHTNING_PLUGINS_RENEPAY_TEST_COMMON_H
+#define LIGHTNING_PLUGINS_RENEPAY_TEST_COMMON_H
+#include "config.h"
+#include <common/gossip_store.h>
+#include <gossipd/gossip_store_wiregen.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <wire/peer_wiregen.h>
+
+static const char *print_routes(const tal_t *ctx,
+			       struct route **routes)
+{
+	tal_t *this_ctx = tal(ctx, tal_t);
+	char *buff = tal_fmt(ctx, "%zu routes\n", tal_count(routes));
+	for (size_t i = 0; i < tal_count(routes); i++) {
+		struct amount_msat fee, delivered;
+
+		delivered = route_delivers(routes[i]);
+		fee = route_fees(routes[i]);
+		tal_append_fmt(&buff, "   %s", fmt_route_path(this_ctx, routes[i]));
+		tal_append_fmt(&buff, " %s delivered with fee %s\n",
+			       fmt_amount_msat(this_ctx, delivered),
+			       fmt_amount_msat(this_ctx, fee));
+	}
+
+	tal_free(this_ctx);
+	return buff;
+}
+
+static void write_to_store(int store_fd, const u8 *msg)
+{
+	struct gossip_hdr hdr;
+
+	hdr.flags = cpu_to_be16(0);
+	hdr.len = cpu_to_be16(tal_count(msg));
+	/* We don't actually check these! */
+	hdr.crc = 0;
+	hdr.timestamp = 0;
+	assert(write(store_fd, &hdr, sizeof(hdr)) == sizeof(hdr));
+	assert(write(store_fd, msg, tal_count(msg)) == tal_count(msg));
+}
+
+static void add_connection(int store_fd,
+			   const struct node_id *from,
+			   const struct node_id *to,
+			   struct short_channel_id scid,
+			   struct amount_msat min,
+			   struct amount_msat max,
+			   u32 base_fee, s32 proportional_fee,
+			   u32 delay,
+			   struct amount_sat capacity,
+			   bool add_capacity)
+{
+	secp256k1_ecdsa_signature dummy_sig;
+	struct secret not_a_secret;
+	struct pubkey dummy_key;
+	u8 *msg;
+	const struct node_id *ids[2];
+
+	/* So valgrind doesn't complain */
+	memset(&dummy_sig, 0, sizeof(dummy_sig));
+	memset(&not_a_secret, 1, sizeof(not_a_secret));
+	pubkey_from_secret(&not_a_secret, &dummy_key);
+
+	if (node_id_cmp(from, to) > 0) {
+		ids[0] = to;
+		ids[1] = from;
+	} else {
+		ids[0] = from;
+		ids[1] = to;
+	}
+	msg = towire_channel_announcement(tmpctx, &dummy_sig, &dummy_sig,
+					  &dummy_sig, &dummy_sig,
+					  /* features */ NULL,
+					  &chainparams->genesis_blockhash,
+					  scid,
+					  ids[0], ids[1],
+					  &dummy_key, &dummy_key);
+	write_to_store(store_fd, msg);
+
+	if (add_capacity) {
+		msg = towire_gossip_store_channel_amount(tmpctx, capacity);
+		write_to_store(store_fd, msg);
+	}
+
+	u8 flags = node_id_idx(from, to);
+
+	msg = towire_channel_update(tmpctx,
+				    &dummy_sig,
+				    &chainparams->genesis_blockhash,
+				    scid, 0,
+				    ROUTING_OPT_HTLC_MAX_MSAT,
+				    flags,
+				    delay,
+				    min,
+				    base_fee,
+				    proportional_fee,
+				    max);
+	write_to_store(store_fd, msg);
+}
+
+static void node_id_from_privkey(const struct privkey *p, struct node_id *id)
+{
+	struct pubkey k;
+	pubkey_from_privkey(p, &k);
+	node_id_from_pubkey(id, &k);
+}
+
+
+#endif /* LIGHTNING_PLUGINS_RENEPAY_TEST_COMMON_H */

--- a/plugins/renepay/test/run-bottleneck.c
+++ b/plugins/renepay/test/run-bottleneck.c
@@ -56,6 +56,8 @@ static const char *print_flows(const tal_t *ctx, const char *desc,
 
 #define NUM_NODES 8
 
+static void remove_file(char *fname) { assert(!remove(fname)); }
+
 int main(int argc, char *argv[])
 {
 	int fd;
@@ -67,6 +69,7 @@ int main(int argc, char *argv[])
 	chainparams = chainparams_for_network("regtest");
 
 	fd = tmpdir_mkstemp(tmpctx, "run-bottleneck.XXXXXX", &gossfile);
+	tal_add_destructor(gossfile, remove_file);
 	assert(write(fd, empty_map, sizeof(empty_map)) == sizeof(empty_map));
 
 	gossmap = gossmap_load(tmpctx, gossfile, NULL);

--- a/plugins/renepay/test/run-mcf-diamond.c
+++ b/plugins/renepay/test/run-mcf-diamond.c
@@ -93,6 +93,8 @@ static const char* print_flows(
 	return buff;
 }
 
+static void remove_file(char *fname) { assert(!remove(fname)); }
+
 int main(int argc, char *argv[])
 {
 	int fd;
@@ -108,6 +110,7 @@ int main(int argc, char *argv[])
 	common_setup(argv[0]);
 
 	fd = tmpdir_mkstemp(tmpctx, "run-not_mcf-diamond.XXXXXX", &gossfile);
+	tal_add_destructor(gossfile, remove_file);
 	assert(write_all(fd, empty_map, sizeof(empty_map)));
 
 	gossmap = gossmap_load(tmpctx, gossfile, NULL);

--- a/plugins/renepay/test/run-mcf.c
+++ b/plugins/renepay/test/run-mcf.c
@@ -341,6 +341,8 @@ static const char *print_flows(
 	return buff;
 }
 
+static void remove_file(char *fname) { assert(!remove(fname)); }
+
 int main(int argc, char *argv[])
 {
 	int fd;
@@ -362,11 +364,11 @@ int main(int argc, char *argv[])
 	common_setup(argv[0]);
 
 	fd = tmpdir_mkstemp(tmpctx, "run-not_mcf.XXXXXX", &gossfile);
+	tal_add_destructor(gossfile, remove_file);
 	assert(write_all(fd, canned_map, sizeof(canned_map)));
 
 	gossmap = gossmap_load(tmpctx, gossfile, NULL);
 	assert(gossmap);
-	remove(gossfile);
 
 	/* There is a public channel 2<->3 (103x1x0), and 1<->2 (110x1x1). */
 	assert(node_id_from_hexstr("0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518", 66, &l1));

--- a/plugins/renepay/test/run-missingcapacity.c
+++ b/plugins/renepay/test/run-missingcapacity.c
@@ -1,0 +1,167 @@
+/* Checks that uncertainty_update and get_routes can handle a gossmap where the
+ * capacity of some channels are missing.
+ *
+ * */
+#include "config.h"
+
+#include "../disabledmap.c"
+#include "../errorcodes.c"
+#include "../flow.c"
+#include "../mcf.c"
+#include "../route.c"
+#include "../routebuilder.c"
+#include "../uncertainty.c"
+#include "common.h"
+
+#include <bitcoin/chainparams.h>
+#include <bitcoin/preimage.h>
+#include <ccan/str/hex/hex.h>
+#include <common/setup.h>
+#include <common/utils.h>
+#include <sodium/randombytes.h>
+
+static u8 empty_map[] = {10};
+
+#define NUM_NODES 4
+
+int main(int argc, char *argv[])
+{
+	int fd;
+	char *gossfile;
+	struct gossmap *gossmap;
+	struct node_id nodes[NUM_NODES];
+
+	common_setup(argv[0]);
+	chainparams = chainparams_for_network("regtest");
+
+	fd = tmpdir_mkstemp(tmpctx, "run-missingcapacity.XXXXXX", &gossfile);
+	assert(write(fd, empty_map, sizeof(empty_map)) == sizeof(empty_map));
+
+	gossmap = gossmap_load(tmpctx, gossfile, NULL);
+	assert(gossmap);
+
+	for (size_t i = 0; i < NUM_NODES; i++) {
+		struct privkey tmp;
+		memset(&tmp, i+1, sizeof(tmp));
+		node_id_from_privkey(&tmp, &nodes[i]);
+	}
+
+	/* We will try a payment from 1 to 4.
+	 * There are two possible routes 1->2->4 or 1->3->4.
+	 * However, we will simulate that we don't have channel 3->4's capacity
+	 * in the gossmap (see #7194). We expect that 3->4 it's simply ignored
+	 * and only route through 1->2->4 is used.
+	 *
+	 * +--2--+
+	 * |     |
+	 * 1     4
+	 * |     |
+	 * +--3--+
+	 *
+	 * */
+	struct short_channel_id scid;
+
+ 	assert(mk_short_channel_id(&scid, 1, 2, 0));
+ 	add_connection(fd, &nodes[0], &nodes[1], scid,
+ 		       AMOUNT_MSAT(0),
+ 		       AMOUNT_MSAT(1000 * 1000 * 1000),
+ 		       0, 0, 5,
+ 		       AMOUNT_SAT(1000 * 1000),
+		       /* add capacity? = */ true);
+
+	assert(mk_short_channel_id(&scid, 2, 4, 0));
+ 	add_connection(fd, &nodes[1], &nodes[3], scid,
+ 		       AMOUNT_MSAT(0),
+ 		       AMOUNT_MSAT(1000 * 1000 * 1000),
+ 		       0, 0, 5,
+ 		       AMOUNT_SAT(1000 * 1000),
+		       /* add capacity? = */ true);
+
+	assert(mk_short_channel_id(&scid, 1, 3, 0));
+ 	add_connection(fd, &nodes[0], &nodes[2], scid,
+ 		       AMOUNT_MSAT(0),
+ 		       AMOUNT_MSAT(1000 * 1000 * 1000),
+ 		       0, 0, 5,
+ 		       AMOUNT_SAT(1000 * 1000),
+		       /* add capacity? = */ true);
+
+	assert(mk_short_channel_id(&scid, 3, 4, 0));
+ 	add_connection(fd, &nodes[2], &nodes[3], scid,
+ 		       AMOUNT_MSAT(0),
+ 		       AMOUNT_MSAT(1000 * 1000 * 1000),
+ 		       0, 0, 5,
+ 		       AMOUNT_SAT(1000 * 1000),
+		       /* add capacity? = */ false);
+
+	assert(gossmap_refresh(gossmap, NULL));
+	struct uncertainty *uncertainty = uncertainty_new(tmpctx);
+	int skipped_count =
+	    uncertainty_update(uncertainty, gossmap);
+	assert(skipped_count==1);
+
+	struct preimage preimage;
+
+	struct amount_msat maxfee = AMOUNT_MSAT(20*1000);
+	struct payment_info pinfo;
+	pinfo.invstr = NULL;
+	pinfo.label = NULL;
+	pinfo.description = NULL;
+	pinfo.payment_secret = NULL;
+	pinfo.payment_metadata = NULL;
+	pinfo.routehints = NULL;
+	pinfo.destination = nodes[3];
+	pinfo.amount = AMOUNT_MSAT(100 * 1000 * 1000);
+
+	assert(amount_msat_add(&pinfo.maxspend, maxfee, pinfo.amount));
+	pinfo.maxdelay = 100;
+	pinfo.final_cltv = 5;
+
+	pinfo.start_time = time_now();
+	pinfo.stop_time = timeabs_add(pinfo.start_time, time_from_sec(10000));
+
+	pinfo.base_fee_penalty = 1e-5;
+	pinfo.prob_cost_factor = 1e-5;
+	pinfo.delay_feefactor = 1e-6;
+	pinfo.min_prob_success = 0.9;
+	pinfo.use_shadow = false;
+
+	randombytes_buf(&preimage, sizeof(preimage));
+	sha256(&pinfo.payment_hash, &preimage, sizeof(preimage));
+
+	struct disabledmap *disabledmap = disabledmap_new(tmpctx);
+
+	enum jsonrpc_errcode errcode;
+	const char *err_msg;
+
+	u64 groupid = 1;
+	u64 next_partid=1;
+
+	struct route **routes = get_routes(
+		/* ctx */tmpctx,
+		/* payment */&pinfo,
+		/* source */&nodes[0],
+		/* destination */&nodes[3],
+		/* gossmap */gossmap,
+		/* uncertainty */uncertainty,
+		disabledmap,
+		/* amount */ pinfo.amount,
+		/* feebudget */maxfee,
+		&next_partid,
+		groupid,
+		&errcode,
+		&err_msg);
+
+	assert(routes);
+
+	if (!routes) {
+		printf("get_route failed with error %d: %s", errcode, err_msg);
+	} else {
+		printf("get_routes: %s\n", print_routes(tmpctx, routes));
+		assert(tal_count(routes) == 1);
+		assert(tal_count(routes[0]->hops) == 2);
+		assert(node_id_eq(&routes[0]->hops[0].node_id, &nodes[1]));
+		assert(node_id_eq(&routes[0]->hops[1].node_id, &nodes[3]));
+	}
+	common_shutdown();
+}
+

--- a/plugins/renepay/test/run-missingcapacity.c
+++ b/plugins/renepay/test/run-missingcapacity.c
@@ -24,6 +24,8 @@ static u8 empty_map[] = {10};
 
 #define NUM_NODES 4
 
+static void remove_file(char *fname) { assert(!remove(fname)); }
+
 int main(int argc, char *argv[])
 {
 	int fd;
@@ -35,6 +37,7 @@ int main(int argc, char *argv[])
 	chainparams = chainparams_for_network("regtest");
 
 	fd = tmpdir_mkstemp(tmpctx, "run-missingcapacity.XXXXXX", &gossfile);
+	tal_add_destructor(gossfile, remove_file);
 	assert(write(fd, empty_map, sizeof(empty_map)) == sizeof(empty_map));
 
 	gossmap = gossmap_load(tmpctx, gossfile, NULL);
@@ -162,6 +165,7 @@ int main(int argc, char *argv[])
 		assert(node_id_eq(&routes[0]->hops[0].node_id, &nodes[1]));
 		assert(node_id_eq(&routes[0]->hops[1].node_id, &nodes[3]));
 	}
+
 	common_shutdown();
 }
 

--- a/plugins/renepay/test/run-testflow.c
+++ b/plugins/renepay/test/run-testflow.c
@@ -517,10 +517,7 @@ static void test_edge_probability(void)
 	assert(fabs(edge_probability(min,max,X,f)-0.0)< eps);
 }
 
-static void remove_file(char *fname)
-{
-	assert(!remove(fname));
-}
+static void remove_file(char *fname) { assert(!remove(fname)); }
 
 static void test_flow_to_route(void)
 {
@@ -530,7 +527,7 @@ static void test_flow_to_route(void)
 
 	char *gossfile;
 	int fd = tmpdir_mkstemp(this_ctx,"run-testflow.XXXXXX",&gossfile);
-	tal_add_destructor(gossfile,remove_file);
+	tal_add_destructor(gossfile, remove_file);
 
 	assert(write_all(fd,canned_map,sizeof(canned_map)));
 	struct gossmap *gossmap = gossmap_load(this_ctx,gossfile,NULL);


### PR DESCRIPTION
Add a test that checks `get_route` and `uncertainty_update` behavior's handling of missing channel capacities.

As pointed out in PR #7194: renepay couldn't handle a failed call to `gossmap_chan_get_capacity` leading to
```
2024-04-02T15:27:49.4484027Z lightningd-1 2024-04-02T15:21:59.115Z **BROKEN** plugin-cln-renepay: uncertainty_network_update (line 175) unable to fetch channel capacity
```
in rare cases.

After #7125 this issue was fixed, this PR adds a unit test to confirm that.
Therefore #7194 can be closed.