### PR TITLE
doc: update rpc docs before pushing to readme

### DIFF
--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -22,6 +22,20 @@ jobs:
     - name: Install requests module
       run: python -m pip install requests
 
+    - name: Install dependencies
+      run: bash -x .github/scripts/setup.sh
+
+    - name: Build
+      run: |
+        ./configure --enable-debugbuild
+        make -j $(nproc)
+        make -j $(nproc) check-gen-updated
+
+    - name: Make docs
+      run: |
+        make doc-all
+        make check-doc
+
     - name: Set environment variable and run
       env:
         README_API_KEY: ${{ secrets.README_API_KEY }}  

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -1,7 +1,7 @@
 from fixtures import *  # noqa: F401,F403
 from pathlib import Path
 from pyln import grpc as clnpb
-from pyln.testing.utils import env, TEST_NETWORK, wait_for, sync_blockheight, TIMEOUT, reserve_unused_port
+from pyln.testing.utils import env, TEST_NETWORK, wait_for, sync_blockheight, TIMEOUT
 from utils import first_scid
 import grpc
 import pytest
@@ -403,7 +403,7 @@ def test_rust_plugin_subscribe_wildcard(node_factory):
 
 
 def test_grpc_block_added_notifications(node_factory, bitcoind):
-    grpc_port = reserve_unused_port()
+    grpc_port = node_factory.get_unused_port()
 
     l1 = node_factory.get_node(options={"grpc-port": str(grpc_port)})
 
@@ -421,7 +421,7 @@ def test_grpc_block_added_notifications(node_factory, bitcoind):
 
 
 def test_grpc_connect_notification(node_factory):
-    grpc_port = reserve_unused_port()
+    grpc_port = node_factory.get_unused_port()
 
     l1 = node_factory.get_node(options={"grpc-port": str(grpc_port)})
     l2 = node_factory.get_node()
@@ -436,7 +436,7 @@ def test_grpc_connect_notification(node_factory):
 
 
 def test_grpc_custommsg_notification(node_factory):
-    grpc_port = reserve_unused_port()
+    grpc_port = node_factory.get_unused_port()
 
     l1 = node_factory.get_node(options={"grpc-port": str(grpc_port)})
     l2 = node_factory.get_node()


### PR DESCRIPTION
Now that our rpc documenation is generated from schema (since [#6995](https://github.com/ElementsProject/lightning/pull/6995)), we need to build the docs before trying to update the rdme contents.  The goal is to fix the following issue with the rdme-rpc-sync workflow:

Run python .github/scripts/sync-rpc-cmds.py
lightning-addgossip		lightning-addgossip.7.md
Traceback (most recent call last):
  File .github/scripts/sync-rpc-cmds.py, line 92, in <module>
    main()
  File .github/scripts/sync-rpc-cmds.py, line 82, in main
    with open(doc/ + file) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'doc/lightning-addgossip.7.md'