### PR TITLE
common: Fix off-by-one in `from_bech32_charset`

### DIFF
--- a/common/bech32_util.c
+++ b/common/bech32_util.c
@@ -82,9 +82,9 @@ bool from_bech32_charset(const tal_t *ctx,
 	u5data = tal_arr(NULL, u5, datalen);
 	for (size_t i = 0; i < datalen; i++) {
 		int c = sep[1+i];
-		if (c < 0 || c > 128)
-			goto fail;
 		c = fixup_char(c, &upper, &lower);
+		if (c < 0 || c >= 128)
+			goto fail;
 		if (bech32_charset_rev[c] == -1)
 			goto fail;
 		u5data[i] = bech32_charset_rev[c];


### PR DESCRIPTION
`bech32_charset_rev` is only 128 bytes in size but the `c < 0 || c > 128` check allows for `c` to be equal to 128 which would be out-of-bounds. Fix this off-by-one bug by changing the check to `c >= 128`.

Found by fuzzing the existing `fuzz-bolt12-bech32-decode` harness with UBSan (triggering input: `MUgwMEowMDBKMDMzMzMzgDMzSkswSzNLS0s=`).

```
common/bech32_util.c:88:7: runtime error: index 128 out of bounds for type 'const int8_t[128]' (aka 'const signed char[128]')
SUMMARY: UndefinedBehaviorSanitizer: out-of-bounds-index common/bech32_util.c:88:7 in 
```