### PR TITLE
meta: update mocks

### DIFF
--- a/lightningd/test/run-log-pruning.c
+++ b/lightningd/test/run-log-pruning.c
@@ -84,9 +84,6 @@ const char *log_level_name(enum log_level level UNNEEDED)
 bool log_level_parse(const char *levelstr UNNEEDED, size_t len UNNEEDED,
 		     enum log_level *level UNNEEDED)
 { fprintf(stderr, "log_level_parse called!\n"); abort(); }
-/* Generated stub for node_id_to_hexstr */
-char *node_id_to_hexstr(const tal_t *ctx UNNEEDED, const struct node_id *id UNNEEDED)
-{ fprintf(stderr, "node_id_to_hexstr called!\n"); abort(); }
 /* Generated stub for notify_log */
 void notify_log(struct lightningd *ld UNNEEDED, const struct log_entry *l UNNEEDED)
 { fprintf(stderr, "notify_log called!\n"); abort(); }

--- a/plugins/bkpr/test/run-bkpr_db.c
+++ b/plugins/bkpr/test/run-bkpr_db.c
@@ -96,7 +96,7 @@ const char *htlc_state_name(enum htlc_state s UNNEEDED)
 { fprintf(stderr, "htlc_state_name called!\n"); abort(); }
 /* Generated stub for is_asterix_notification */
 bool is_asterix_notification(const char *notification_name UNNEEDED,
-			   const char *subscriptions UNNEEDED)
+			     const char *subscriptions UNNEEDED)
 { fprintf(stderr, "is_asterix_notification called!\n"); abort(); }
 /* Generated stub for json_get_id */
 const char *json_get_id(const tal_t *ctx UNNEEDED,

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -102,7 +102,7 @@ const char *htlc_state_name(enum htlc_state s UNNEEDED)
 { fprintf(stderr, "htlc_state_name called!\n"); abort(); }
 /* Generated stub for is_asterix_notification */
 bool is_asterix_notification(const char *notification_name UNNEEDED,
-			   const char *subscriptions UNNEEDED)
+			     const char *subscriptions UNNEEDED)
 { fprintf(stderr, "is_asterix_notification called!\n"); abort(); }
 /* Generated stub for json_get_id */
 const char *json_get_id(const tal_t *ctx UNNEEDED,


### PR DESCRIPTION
cc lightningd/test/run-log-pruning.c
lightningd/test/run-log-pruning.c:88:7: error: no previous prototype for ‘node_id_to_hexstr’ [-Werror=missing-prototypes]
   88 | char *node_id_to_hexstr(const tal_t *ctx UNNEEDED, const struct node_id *id UNNEEDED)
      |       ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Reported-by: @grubles 