### PR TITLE
doc: readme sync trigger fix

### DIFF
--- a/.github/workflows/rdme-docs-sync.yml
+++ b/.github/workflows/rdme-docs-sync.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - 'doc/**'
+  workflow_dispatch:
 
 jobs:
   rdme-docs-sync:  

--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - 'master'
     paths:
-      - 'doc/**.md'
+      - 'doc/schemas/lightning-*.json'
+      - 'doc/*.1.md'
+      - 'doc/*.5.md'
+      - 'doc/*.8.md'
+      - 'doc/lightningd-*.7.md'
+  workflow_dispatch:
 
 jobs:
   rdme-rpc-sync:
@@ -19,22 +24,17 @@ jobs:
       with:
         python-version: '3.8'
 
-    - name: Install requests module
-      run: python -m pip install requests
+    - name: Install python modules
+      run: |
+        python -m pip install requests mako
 
     - name: Install dependencies
       run: bash -x .github/scripts/setup.sh
 
-    - name: Build
+    - name: Build (including rpc .md files)
       run: |
         ./configure --enable-debugbuild
         make -j $(nproc)
-        make -j $(nproc) check-gen-updated
-
-    - name: Make docs
-      run: |
-        make doc-all
-        make check-doc
 
     - name: Set environment variable and run
       env:

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -19294,7 +19294,7 @@
       "rpc": "listpeerchannels",
       "title": "Command returning data on channels of connected lightning nodes",
       "description": [
-        "The **listpeerchannels** RPC command returns data on channels of the network, with the possibility to filter the channels by node id.",
+        "The **listpeerchannels** RPC command returns list of this node's channels, with the possibility to filter them by peer's node id.",
         "",
         "If no *id* is supplied, then channel data on all lightning nodes that are connected, or not connected but have open channels with this node, are returned."
       ],
@@ -19674,7 +19674,7 @@
                         "type": "integer",
                         "added": "v23.08",
                         "description": [
-                          "The amouont of sats we're splicing in or out."
+                          "The amount of sats we're splicing in or out."
                         ]
                       },
                       "our_funding_msat": {

--- a/doc/schemas/lightning-listpeerchannels.json
+++ b/doc/schemas/lightning-listpeerchannels.json
@@ -6,7 +6,7 @@
   "rpc": "listpeerchannels",
   "title": "Command returning data on channels of connected lightning nodes",
   "description": [
-    "The **listpeerchannels** RPC command returns data on channels of the network, with the possibility to filter the channels by node id.",
+    "The **listpeerchannels** RPC command returns list of this node's channels, with the possibility to filter them by peer's node id.",
     "",
     "If no *id* is supplied, then channel data on all lightning nodes that are connected, or not connected but have open channels with this node, are returned."
   ],
@@ -386,7 +386,7 @@
                     "type": "integer",
                     "added": "v23.08",
                     "description": [
-                      "The amouont of sats we're splicing in or out."
+                      "The amount of sats we're splicing in or out."
                     ]
                   },
                   "our_funding_msat": {


### PR DESCRIPTION
Issue: rpc documentation on the readme server is not being updated.

Updating the path from `doc/**.md` to `doc/schemas/lightning-*.json` for triggering the action because all `doc/*.7.md` files are fully generated by the `tools/fromschema.py` now.

Added manual trigger event for readme's documentation update.

Changelog-None.