### PR TITLE
doc: Updating python grpcio-tool dependency

### DIFF
--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -10,6 +10,7 @@ on:
       - 'doc/*.5.md'
       - 'doc/*.8.md'
       - 'doc/lightningd-*.7.md'
+      - 'doc/reckless.7.md'
   workflow_dispatch:
 
 jobs:
@@ -19,14 +20,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: 3.8
 
     - name: Install python modules
       run: |
-        python -m pip install requests mako
+        python -m pip install requests mako grpcio-tools
 
     - name: Install dependencies
       run: bash -x .github/scripts/setup.sh
@@ -38,5 +39,5 @@ jobs:
 
     - name: Set environment variable and run
       env:
-        README_API_KEY: ${{ secrets.README_API_KEY }}  
+        README_API_KEY: ${{ secrets.README_API_KEY }}
       run: python .github/scripts/sync-rpc-cmds.py


### PR DESCRIPTION
Issue: rpc documentation on the readme server is not being updated.

It is an extension of PR #7326 to fix runtime error from github actions.

Changelog-None.