### PR TITLE
Renepay relax knowledge

### DIFF
--- a/plugins/renepay/Makefile
+++ b/plugins/renepay/Makefile
@@ -24,6 +24,7 @@ PLUGIN_RENEPAY_HDRS :=				\
 	plugins/renepay/payment.h		\
 	plugins/renepay/payment_info.h		\
 	plugins/renepay/chan_extra.h		\
+	plugins/renepay/renepayconfig.h		\
 	plugins/renepay/route.h			\
 	plugins/renepay/routebuilder.h		\
 	plugins/renepay/routetracker.h		\

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -8,6 +8,7 @@
 #include <plugins/renepay/mcf.h>
 #include <plugins/renepay/mods.h>
 #include <plugins/renepay/payplugin.h>
+#include <plugins/renepay/renepayconfig.h>
 #include <plugins/renepay/route.h>
 #include <plugins/renepay/routebuilder.h>
 #include <plugins/renepay/routetracker.h>
@@ -18,8 +19,6 @@
 #define OP_NULL NULL
 #define OP_CALL (void *)1
 #define OP_IF (void *)2
-
-#define COLLECTOR_TIME_WINDOW_MSEC 50
 
 void *payment_virtual_program[];
 

--- a/plugins/renepay/payplugin.h
+++ b/plugins/renepay/payplugin.h
@@ -6,6 +6,7 @@
 #include <plugins/libplugin.h>
 #include <plugins/renepay/flow.h>
 #include <plugins/renepay/payment.h>
+#include <plugins/renepay/renepayconfig.h>
 #include <plugins/renepay/uncertainty.h>
 
 // TODO(eduardo): renepaystatus should be similar to paystatus
@@ -19,15 +20,6 @@
 // TODO(eduardo): write a man entry for renepay
 // TODO(eduardo): check if paynotes are meaningful
 // TODO(eduardo): remove assertions, introduce LOG_BROKEN messages
-
-#define MAX_NUM_ATTEMPTS 10
-
-/* Time lapse used to wait for failed sendpays before try_paying. */
-#define TIMER_COLLECT_FAILURES_MSEC 250
-
-/* Knowledge is proportionally decreased with time up to TIMER_FORGET_SEC when
- * we forget everything. */
-#define TIMER_FORGET_SEC 3600
 
 // TODO(eduardo): Test ideas
 // - make a payment to a node that is hidden behind private channels, check that

--- a/plugins/renepay/renepayconfig.h
+++ b/plugins/renepay/renepayconfig.h
@@ -1,0 +1,14 @@
+#ifndef LIGHTNING_PLUGINS_RENEPAY_RENEPAYCONFIG_H
+#define LIGHTNING_PLUGINS_RENEPAY_RENEPAYCONFIG_H
+#include "config.h"
+
+#define MAX_NUM_ATTEMPTS 10
+
+/* Knowledge is proportionally decreased with time up to TIMER_FORGET_SEC when
+ * we forget everything. */
+#define TIMER_FORGET_SEC 3600
+
+/* Time lapse used to wait for failed sendpays. */
+#define COLLECTOR_TIME_WINDOW_MSEC 50
+
+#endif /* LIGHTNING_PLUGINS_RENEPAY_RENEPAYCONFIG_H */

--- a/plugins/renepay/uncertainty.h
+++ b/plugins/renepay/uncertainty.h
@@ -55,4 +55,14 @@ bool uncertainty_set_liquidity(struct uncertainty *uncertainty,
 struct chan_extra *uncertainty_find_channel(struct uncertainty *uncertainty,
 					    const struct short_channel_id scid);
 
+/* Adds randomness to the current state simulating the natural evolution of the
+ * liquidity in the network. It should be a markovian process with the minimum
+ * requirement that the transition operator T satisfies:
+ *	T(t1) T(t2) = T(t1+t2)
+ * i.e. the transition operator is a one parameter semigroup.
+ * For the moment we omit the continuous and linear aspects of the problem for a
+ * lack for formulation. */
+enum renepay_errorcode uncertainty_relax(struct uncertainty *uncertainty,
+					 double seconds);
+
 #endif /* LIGHTNING_PLUGINS_RENEPAY_UNCERTAINTY_H */


### PR DESCRIPTION
Add a payment modifier that relaxes the knowledge of the uncertainty network as a function of time.
We already had this functionality in version 24.02 but it was missing after the code refactor #7125.