### PR TITLE
Gossmap crash fix

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -1444,3 +1444,9 @@ u8 *gossmap_node_get_features(const tal_t *ctx,
 	map_copy(map, n->nann_off + feature_len_off + 2, ret, feature_len);
 	return ret;
 }
+
+size_t gossmap_lengths(const struct gossmap *map, size_t *total)
+{
+	*total = map->map_size;
+	return map->map_end;
+}

--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -458,9 +458,16 @@ static struct gossmap_chan *add_channel(struct gossmap *map,
 	map_nodeid(map, cannounce_off + plus_scid_off + 8, &node_id[0]);
 	map_nodeid(map, cannounce_off + plus_scid_off + 8 + PUBKEY_CMPR_LEN, &node_id[1]);
 
-	/* We 1should not get duplicates. */
+	/* We should not get duplicates. */
 	scid.u64 = map_be64(map, cannounce_off + plus_scid_off);
-	assert(!gossmap_find_chan(map, &scid));
+	chan = gossmap_find_chan(map, &scid);
+	if (chan) {
+		/* FIXME: Report this better! */
+		warnx("gossmap: redundant channel_announce for %s, offsets %u and %zu!",
+		      fmt_short_channel_id(tmpctx, scid),
+		      chan->cann_off, cannounce_off);
+		return NULL;
+	}
 
 	/* We carefully map pointers to indexes, since new_node can move them! */
 	n[0] = gossmap_find_node(map, &node_id[0]);

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -257,4 +257,7 @@ size_t gossmap_num_chans(const struct gossmap *map);
 struct gossmap_chan *gossmap_first_chan(const struct gossmap *map);
 struct gossmap_chan *gossmap_next_chan(const struct gossmap *map,
 				       struct gossmap_chan *prev);
+
+/* For debugging: returns length read, and total known length of file */
+size_t gossmap_lengths(const struct gossmap *map, size_t *total);
 #endif /* LIGHTNING_COMMON_GOSSMAP_H */

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -600,3 +600,8 @@ void gossip_store_set_timestamp(struct gossip_store *gs, u64 offset, u32 timesta
 			      "Failed writing header to re-timestamp @%"PRIu64": %s",
 			      offset, strerror(errno));
 }
+
+u64 gossip_store_len_written(const struct gossip_store *gs)
+{
+	return gs->len;
+}

--- a/gossipd/gossip_store.h
+++ b/gossipd/gossip_store.h
@@ -113,4 +113,8 @@ u32 gossip_store_get_timestamp(struct gossip_store *gs, u64 offset);
  */
 void gossip_store_set_timestamp(struct gossip_store *gs, u64 offset, u32 timestamp);
 
+/**
+ * For debugging.
+ */
+u64 gossip_store_len_written(const struct gossip_store *gs);
 #endif /* LIGHTNING_GOSSIPD_GOSSIP_STORE_H */


### PR DESCRIPTION
https://github.com/ElementsProject/lightning/issues/7249

Can't see how this is happening on a fresh gossip store, but avoid crashing if it does, and put in more sanity checks in the only place I can see that we might do this.