### PR TITLE
docker: Add missing git dependency for Fedora Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -19,6 +19,7 @@ RUN dnf update -y && \
 		net-tools \
 		valgrind \
 		wget \
+		git \
 		jq \
 		xz \
 		zlib-devel && \

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -148,7 +148,7 @@ for target in $TARGETS; do
         echo "Building Fedora Image"
         DOCKERFILE=contrib/docker/Dockerfile.builder.fedora
         TAG=fedora
-        docker build -f $DOCKERFILE -t $TAG .
+        docker build -f $DOCKERFILE -t $TAG --load .
         docker run --rm=true -v "$(pwd)":/src:ro -v "$RELEASEDIR":/release $TAG /src/tools/build-release.sh --inside-docker "$VERSION" "$platform"
         docker run --rm=true -w /build $TAG rm -rf /"$VERSION-$platform" /build
         echo "Fedora Image Built"


### PR DESCRIPTION
Fedora image building by build-release.sh currently throws error ` git: command not found`.

Fixed it by adding git in the Dockerfile and loading the image in the script.

Changelog-None.