### PR TITLE
renepay: bugfix reading pending sendpays

### DIFF
--- a/plugins/renepay/payplugin.h
+++ b/plugins/renepay/payplugin.h
@@ -89,9 +89,4 @@ struct pay_plugin {
 /* Set in init */
 extern struct pay_plugin *pay_plugin;
 
-/* Returns NULL if OK, otherwise an error msg and sets *ecode */
-const char *try_paying(const tal_t *ctx,
-		       struct payment *payment,
-		       enum jsonrpc_errcode *ecode);
-
 #endif /* LIGHTNING_PLUGINS_RENEPAY_PAYPLUGIN_H */

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -134,6 +134,28 @@ void route_pending_register(struct routetracker *routetracker,
 	}
 }
 
+bool routetracker_get_amount(struct routetracker *routetracker,
+			     struct amount_msat *amount,
+			     struct amount_msat *amount_sent)
+{
+	assert(routetracker);
+	assert(amount);
+	assert(amount_sent);
+
+	*amount = AMOUNT_MSAT(0);
+	*amount_sent = AMOUNT_MSAT(0);
+
+	struct route_map *rmap = routetracker->pending_routes;
+	struct route_map_iter it;
+	for (struct route *r = route_map_first(rmap, &it); r;
+	     r = route_map_next(rmap, &it)) {
+		if (!amount_msat_add(amount, *amount, route_delivers(r)) ||
+		    !amount_msat_add(amount_sent, *amount_sent, route_sends(r)))
+			return false;
+	}
+	return true;
+}
+
 static void route_result_collected(struct routetracker *routetracker,
 				   struct route *route TAKES)
 {

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -50,6 +50,11 @@ struct command_result *notification_sendpay_success(struct command *cmd,
 void route_failure_register(struct routetracker *routetracker,
 			    struct route *route);
 
+/* How much is the amount being tracked. */
+bool routetracker_get_amount(struct routetracker *routetracker,
+			     struct amount_msat *amount,
+			     struct amount_msat *amount_sent);
+
 // FIXME: double-check that we actually get one notification for each sendpay,
 // ie. that after some time we don't have yet pending sendpays for old failed or
 // successful payments that we havent processed because we haven't received the


### PR DESCRIPTION
When renepay starts, one of the first operations it does is to check for pending sendpays for the same invoice. Those are added up to an internal database to keep track of. Also the amount they deliver to the destination is computed so that the current payment rpc call would try to complete the payment for whatever amount remains to pay. For an incomplete payment after calling the RPC renepay I found this in the logs:

2024-05-22T19:44:19.853Z DEBUG   plugin-cln-renepay: There are pending sendpays to this invoice. groupid = 6 delivering = 0msat, last_partid = 10

Where `delivering` should correspond to the sum of the amounts delivered by pending routes.