### PR TITLE
onchaind: replay using real block data, not db

### DIFF
--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -1242,6 +1242,12 @@ void gossmap_manage_channel_spent(struct gossmap_manage *gm,
 		return;
 	}
 
+	/* Is it already dying?  It's lightningd re-telling us */
+	for (size_t i = 0; i < tal_count(gm->dying_channels); i++) {
+		if (short_channel_id_eq(gm->dying_channels[i].scid, scid))
+			return;
+	}
+
 	/* BOLT #7:
 	 *   - once its funding output has been spent OR reorganized out:
 	 *     - SHOULD forget a channel after a 12-block delay.

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -609,6 +609,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->last_stable_connection = last_stable_connection;
 	channel->stable_conn_timer = NULL;
 	channel->onchaind_replay_watches = NULL;
+	channel->num_onchain_spent_calls = 0;
 	channel->stats = *stats;
 	channel->state_changes = tal_steal(channel, state_changes);
 

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -310,6 +310,7 @@ struct channel *new_unsaved_channel(struct peer *peer,
 	channel->ignore_fee_limits = ld->config.ignore_fee_limits;
 	channel->last_stable_connection = 0;
 	channel->stable_conn_timer = NULL;
+	channel->onchaind_replay_watches = NULL;
 	/* Nothing happened yet */
 	memset(&channel->stats, 0, sizeof(channel->stats));
 	channel->state_changes = tal_arr(channel, struct channel_state_change *, 0);
@@ -607,6 +608,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->ignore_fee_limits = ignore_fee_limits;
 	channel->last_stable_connection = last_stable_connection;
 	channel->stable_conn_timer = NULL;
+	channel->onchaind_replay_watches = NULL;
 	channel->stats = *stats;
 	channel->state_changes = tal_steal(channel, state_changes);
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -194,6 +194,9 @@ struct channel {
 	/* Watch we have on funding output. */
 	struct txowatch *funding_spend_watch;
 
+	/* If we're doing a replay for onchaind, here are the txids it's watching */
+	struct replay_tx_hash *onchaind_replay_watches;
+
 	/* Our original funds, in funding amount */
 	struct amount_sat our_funds;
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -196,6 +196,10 @@ struct channel {
 
 	/* If we're doing a replay for onchaind, here are the txids it's watching */
 	struct replay_tx_hash *onchaind_replay_watches;
+	/* Number of outstanding onchaind_spent calls */
+	size_t num_onchain_spent_calls;
+	/* Height we're replaying at (if onchaind_replay_watches set) */
+	u32 onchaind_replay_height;
 
 	/* Our original funds, in funding amount */
 	struct amount_sat our_funds;

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -222,6 +222,10 @@ static void gossipd_new_blockheight_reply(struct subd *gossipd,
 
 	/* Now, finally update getinfo's blockheight */
 	gossipd->ld->gossip_blockheight = ptr2int(blockheight);
+
+	/* And use that to trim old entries in the UTXO set */
+	wallet_utxoset_prune(gossipd->ld->wallet,
+			     gossipd->ld->gossip_blockheight);
 }
 
 void gossip_notify_new_block(struct lightningd *ld, u32 blockheight)

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -251,9 +251,25 @@ static void gossipd_init_done(struct subd *gossipd,
 			      const int *fds,
 			      void *unused)
 {
+	struct lightningd *ld = gossipd->ld;
+	u32 oldspends;
+
 	/* Any channels without channel_updates, we populate now: gossipd
 	 * might have lost its gossip_store. */
-	channel_gossip_init_done(gossipd->ld);
+	channel_gossip_init_done(ld);
+
+	/* Tell it about any closures it might have missed! */
+	oldspends = wallet_utxoset_oldest_spentheight(tmpctx, ld->wallet);
+	if (oldspends) {
+		while (oldspends <= get_block_height(ld->topology)) {
+			const struct short_channel_id *scids;
+
+			scids = wallet_utxoset_get_spent(tmpctx, ld->wallet,
+							 oldspends);
+			gossipd_notify_spends(ld, oldspends, scids);
+			oldspends++;
+		}
+	}
 
 	/* Break out of loop, so we can begin */
 	log_debug(gossipd->ld->log, "io_break: %s", __func__);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -208,9 +208,8 @@ static enum watch_result onchain_tx_watched(struct lightningd *ld,
 		return KEEP_WATCHING;
 	}
 
-	/* Store the channeltx so we can replay later */
-	wallet_channeltxs_add(ld->wallet, channel,
-			      WIRE_ONCHAIND_DEPTH, txid, 0, blockheight);
+	/* Store so we remember if we crash, and can replay later */
+	wallet_insert_funding_spend(ld->wallet, channel, txid, 0, blockheight);
 
 	onchain_tx_depth(channel, txid, depth);
 	return KEEP_WATCHING;
@@ -245,14 +244,6 @@ static enum watch_result onchain_txo_watched(struct channel *channel,
 					     size_t input_num,
 					     const struct block *block)
 {
-	struct bitcoin_txid txid;
-	bitcoin_txid(tx, &txid);
-
-	/* Store the channeltx so we can replay later */
-	wallet_channeltxs_add(channel->peer->ld->wallet, channel,
-			      WIRE_ONCHAIND_SPENT, &txid, input_num,
-			      block->height);
-
 	onchain_txo_spent(channel, tx, input_num, block->height);
 
 	/* We don't need to keep watching: If this output is double-spent

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2208,8 +2208,8 @@ static enum watch_result funding_spent(struct channel *channel,
 		}
 	}
 
-	wallet_channeltxs_add(channel->peer->ld->wallet, channel,
-			      WIRE_ONCHAIND_INIT, &txid, 0, block->height);
+	wallet_insert_funding_spend(channel->peer->ld->wallet, channel,
+				    &txid, 0, block->height);
 
 	return onchaind_funding_spent(channel, tx, block->height);
 }

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -142,13 +142,15 @@ static struct subd_req *add_req(const tal_t *ctx,
 				struct subd *sd, int type, size_t num_fds_in,
 				void (*replycb)(struct subd *, const u8 *, const int *,
 						void *),
-				void *replycb_data)
+				void *replycb_data TAKES)
 {
 	struct subd_req *sr = tal(sd, struct subd_req);
 
 	sr->type = type;
 	sr->replycb = replycb;
 	sr->replycb_data = replycb_data;
+	if (taken(replycb_data))
+		tal_steal(sr, replycb_data);
 	sr->num_reply_fds = num_fds_in;
 
 	/* We don't allocate sr off ctx, because we still have to handle the
@@ -852,7 +854,7 @@ struct subd_req *subd_req_(const tal_t *ctx,
 			   const u8 *msg_out,
 			   int fd_out, size_t num_fds_in,
 			   void (*replycb)(struct subd *, const u8 *, const int *, void *),
-			   void *replycb_data)
+			   void *replycb_data TAKES)
 {
 	/* Grab type now in case msg_out is taken() */
 	int type = fromwire_peektype(msg_out);

--- a/lightningd/subd.h
+++ b/lightningd/subd.h
@@ -178,7 +178,7 @@ void subd_send_fd(struct subd *sd, int fd);
  * @fd_out: if >=0 fd to pass at the end of the message (closed after)
  * @num_fds_in: how many fds to read in to hand to @replycb if it's a reply.
  * @replycb: callback (inside db transaction) when reply comes in (can free subd)
- * @replycb_data: final arg to hand to @replycb
+ * @replycb_data: final arg to hand to @replycb (can be TAKE())
  *
  * @replycb cannot free @sd, so it returns false to remove it.
  * Note that @replycb is called for replies of type @msg_out + SUBD_REPLY_OFFSET
@@ -196,7 +196,7 @@ struct subd_req *subd_req_(const tal_t *ctx,
 	       const u8 *msg_out,
 	       int fd_out, size_t num_fds_in,
 	       void (*replycb)(struct subd *, const u8 *, const int *, void *),
-	       void *replycb_data);
+	       void *replycb_data TAKES);
 
 /**
  * subd_release_channel - shut down a subdaemon which no longer owns the channel.

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -1025,11 +1025,6 @@ const char *version(void)
 /* Generated stub for wallet_channel_save */
 void wallet_channel_save(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED)
 { fprintf(stderr, "wallet_channel_save called!\n"); abort(); }
-/* Generated stub for wallet_channeltxs_add */
-void wallet_channeltxs_add(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED,
-			    const int type UNNEEDED, const struct bitcoin_txid *txid UNNEEDED,
-			   const u32 input_num UNNEEDED, const u32 blockheight UNNEEDED)
-{ fprintf(stderr, "wallet_channeltxs_add called!\n"); abort(); }
 /* Generated stub for wallet_delete_peer_if_unused */
 void wallet_delete_peer_if_unused(struct wallet *w UNNEEDED, u64 peer_dbid UNNEEDED)
 { fprintf(stderr, "wallet_delete_peer_if_unused called!\n"); abort(); }
@@ -1053,6 +1048,12 @@ bool wallet_htlcs_load_out_for_channel(struct wallet *wallet UNNEEDED,
 /* Generated stub for wallet_init_channels */
 bool wallet_init_channels(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_init_channels called!\n"); abort(); }
+/* Generated stub for wallet_insert_funding_spend */
+void wallet_insert_funding_spend(struct wallet *w UNNEEDED,
+				 const struct channel *chan UNNEEDED,
+				 const struct bitcoin_txid *txid UNNEEDED,
+				 const u32 input_num UNNEEDED, const u32 blockheight UNNEEDED)
+{ fprintf(stderr, "wallet_insert_funding_spend called!\n"); abort(); }
 /* Generated stub for wallet_offer_find */
 char *wallet_offer_find(const tal_t *ctx UNNEEDED,
 			struct wallet *w UNNEEDED,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -939,7 +939,7 @@ struct subd_req *subd_req_(const tal_t *ctx UNNEEDED,
 	       const u8 *msg_out UNNEEDED,
 	       int fd_out UNNEEDED, size_t num_fds_in UNNEEDED,
 	       void (*replycb)(struct subd * UNNEEDED, const u8 * UNNEEDED, const int * UNNEEDED, void *) UNNEEDED,
-	       void *replycb_data UNNEEDED)
+	       void *replycb_data TAKES UNNEEDED)
 { fprintf(stderr, "subd_req_ called!\n"); abort(); }
 /* Generated stub for subd_send_fd */
 void subd_send_fd(struct subd *sd UNNEEDED, int fd UNNEEDED)

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1195,7 +1195,7 @@ static bool output_spent(struct tracked_output ***outs,
 			 u32 input_num,
 			 u32 tx_blockheight)
 {
-	bool interesting;
+	bool interesting = false;
 
 	for (size_t i = 0; i < tal_count(*outs); i++) {
 		struct tracked_output *out = (*outs)[i];
@@ -1220,7 +1220,7 @@ static bool output_spent(struct tracked_output ***outs,
 
 			record_coin_movements(out, tx_blockheight,
 					      &tx_parts->txid);
-			return interesting;
+			break;
 		}
 
 		htlc_outpoint.txid = tx_parts->txid;

--- a/onchaind/onchaind_wire.csv
+++ b/onchaind/onchaind_wire.csv
@@ -67,14 +67,14 @@ msgdata,onchaind_spent,tx,tx_parts,
 msgdata,onchaind_spent,input_num,u32,
 msgdata,onchaind_spent,blockheight,u32,
 
+# onchaind->master: do we want to continue watching this?
+msgtype,onchaind_spent_reply,5104
+msgdata,onchaind_spent_reply,interested,bool,
+
 # master->onchaind: We will receive more than one of these, as depth changes.
 msgtype,onchaind_depth,5005
 msgdata,onchaind_depth,txid,bitcoin_txid,
 msgdata,onchaind_depth,depth,u32,
-
-# onchaind->master: We don't want to watch this tx, or its outputs
-msgtype,onchaind_unwatch_tx,5006
-msgdata,onchaind_unwatch_tx,txid,bitcoin_txid,
 
 # master->onchaind: We know HTLC preimage
 msgtype,onchaind_known_preimage,5007

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -334,9 +334,9 @@ u8 *towire_onchaind_spend_penalty(const tal_t *ctx UNNEEDED, const struct bitcoi
 /* Generated stub for towire_onchaind_spend_to_us */
 u8 *towire_onchaind_spend_to_us(const tal_t *ctx UNNEEDED, const struct bitcoin_outpoint *outpoint UNNEEDED, struct amount_sat outpoint_amount UNNEEDED, u32 minblock UNNEEDED, u64 commit_num UNNEEDED, const u8 *wscript UNNEEDED)
 { fprintf(stderr, "towire_onchaind_spend_to_us called!\n"); abort(); }
-/* Generated stub for towire_onchaind_unwatch_tx */
-u8 *towire_onchaind_unwatch_tx(const tal_t *ctx UNNEEDED, const struct bitcoin_txid *txid UNNEEDED)
-{ fprintf(stderr, "towire_onchaind_unwatch_tx called!\n"); abort(); }
+/* Generated stub for towire_onchaind_spent_reply */
+u8 *towire_onchaind_spent_reply(const tal_t *ctx UNNEEDED, bool interested UNNEEDED)
+{ fprintf(stderr, "towire_onchaind_spent_reply called!\n"); abort(); }
 /* Generated stub for towire_secp256k1_ecdsa_signature */
 void towire_secp256k1_ecdsa_signature(u8 **pptr UNNEEDED,
 			      const secp256k1_ecdsa_signature *signature UNNEEDED)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1848,7 +1848,7 @@ def test_onchaind_replay(node_factory, bitcoind):
     l1.restart()
 
     # Can't wait for it, it's after the "Server started" wait in restart()
-    assert l1.daemon.is_in_log(r'Restarting onchaind for channel')
+    assert l1.daemon.is_in_log(r'Restarting onchaind \(ONCHAIN\): closed in block 109')
 
     # l1 should still notice that the funding was spent and that we should react to it
     _, txid, blocks = l1.wait_for_onchaind_tx('OUR_DELAYED_RETURN_TO_WALLET',

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1021,6 +1021,7 @@ static struct migration dbmigrations[] = {
     {SQL("ALTER TABLE channels ADD remote_htlc_minimum_msat BIGINT DEFAULT NULL;"), NULL},
     {SQL("ALTER TABLE channels ADD last_stable_connection BIGINT DEFAULT 0;"), NULL},
     {NULL, migrate_initialize_alias_local},
+    /* FIXME: Remove now-unused type column from channeltxs */
 };
 
 /**

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -985,7 +985,7 @@ struct subd_req *subd_req_(const tal_t *ctx UNNEEDED,
 	       const u8 *msg_out UNNEEDED,
 	       int fd_out UNNEEDED, size_t num_fds_in UNNEEDED,
 	       void (*replycb)(struct subd * UNNEEDED, const u8 * UNNEEDED, const int * UNNEEDED, void *) UNNEEDED,
-	       void *replycb_data UNNEEDED)
+	       void *replycb_data TAKES UNNEEDED)
 { fprintf(stderr, "subd_req_ called!\n"); abort(); }
 /* Generated stub for subd_send_fd */
 void subd_send_fd(struct subd *sd UNNEEDED, int fd UNNEEDED)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -4198,7 +4198,7 @@ bool wallet_sanity_check(struct wallet *w)
 /**
  * wallet_utxoset_prune -- Remove spent UTXO entries that are old
  */
-static void wallet_utxoset_prune(struct wallet *w, const u32 blockheight)
+void wallet_utxoset_prune(struct wallet *w, u32 blockheight)
 {
 	struct db_stmt *stmt;
 
@@ -4236,9 +4236,6 @@ void wallet_block_add(struct wallet *w, struct block *b)
 		db_bind_null(stmt);
 	}
 	db_exec_prepared_v2(take(stmt));
-
-	/* Now cleanup UTXOs that we don't care about anymore */
-	wallet_utxoset_prune(w, b->height);
 }
 
 void wallet_block_remove(struct wallet *w, struct block *b)

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -4462,6 +4462,26 @@ wallet_utxoset_get_spent(const tal_t *ctx, struct wallet *w,
 	return db_scids(ctx, stmt);
 }
 
+u32 wallet_utxoset_oldest_spentheight(const tal_t *ctx, struct wallet *w)
+{
+	struct db_stmt *stmt;
+	u32 height;
+	stmt = db_prepare_v2(w->db, SQL("SELECT"
+					" spendheight "
+					"FROM utxoset "
+					"WHERE spendheight IS NOT NULL "
+					"ORDER BY spendheight ASC "
+					"LIMIT 1"));
+	db_query_prepared(stmt);
+
+	if (db_step(stmt))
+		height = db_col_int(stmt, "spendheight");
+	else
+		height = 0;
+	tal_free(stmt);
+	return height;
+}
+
 const struct short_channel_id *
 wallet_utxoset_get_created(const tal_t *ctx, struct wallet *w,
 			   u32 blockheight)

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1138,6 +1138,9 @@ wallet_utxoset_get_spent(const tal_t *ctx, struct wallet *w, u32 blockheight);
 /* Prune all UTXO entries spent (far) below this block height */
 void wallet_utxoset_prune(struct wallet *w, u32 blockheight);
 
+/* Get oldest spendheight (or 0 if none), to catch up */
+u32 wallet_utxoset_oldest_spentheight(const tal_t *ctx, struct wallet *w);
+
 /**
  * Retrieve all UTXO entries that were created at a given blockheight.
  */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1181,22 +1181,13 @@ struct bitcoin_txid *wallet_transactions_by_height(const tal_t *ctx,
 						   const u32 blockheight);
 
 /**
- * Store transactions of interest in the database to replay on restart
+ * Store funding txid spend to start replay on restart
+ * Note that tx should already be saved by wallet_transaction_add!
  */
-void wallet_channeltxs_add(struct wallet *w, struct channel *chan,
-			    const int type, const struct bitcoin_txid *txid,
-			   const u32 input_num, const u32 blockheight);
-
-/**
- * List channels for which we had an onchaind running
- */
-u32 *wallet_onchaind_channels(const tal_t *ctx, struct wallet *w);
-
-/**
- * Get transactions that we'd like to replay for a channel.
- */
-struct channeltx *wallet_channeltxs_get(const tal_t *ctx, struct wallet *w,
-					u32 channel_id);
+void wallet_insert_funding_spend(struct wallet *w,
+				 const struct channel *chan,
+				 const struct bitcoin_txid *txid,
+				 const u32 input_num, const u32 blockheight);
 
 /**
  * Get the transaction which spend funding for this channel, if any.

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1135,6 +1135,9 @@ void wallet_utxoset_add(struct wallet *w,
 const struct short_channel_id *
 wallet_utxoset_get_spent(const tal_t *ctx, struct wallet *w, u32 blockheight);
 
+/* Prune all UTXO entries spent (far) below this block height */
+void wallet_utxoset_prune(struct wallet *w, u32 blockheight);
+
 /**
  * Retrieve all UTXO entries that were created at a given blockheight.
  */

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1199,6 +1199,14 @@ struct channeltx *wallet_channeltxs_get(const tal_t *ctx, struct wallet *w,
 					u32 channel_id);
 
 /**
+ * Get the transaction which spend funding for this channel, if any.
+ */
+struct bitcoin_tx *wallet_get_funding_spend(const tal_t *ctx,
+					    struct wallet *w,
+					    u64 channel_id,
+					    u32 *blockheight);
+
+/**
  * Add of update a forwarded_payment
  */
 void wallet_forwarded_payment_add(struct wallet *w, const struct htlc_in *in,


### PR DESCRIPTION
We have a report of onchaind not sweeping properly.  It seems to be missing an output during replay, which makes sense since Greenlight restarts nodes (a lot!).

See https://github.com/Blockstream/greenlight/issues/433

I've also got a similar issue on my node, but I assumed that was me corrupting the database by editing it long ago.  I will, however, test this fix on my node too...