### PR TITLE
hsmtool: implement new `derivetoremote` method

### DIFF
--- a/doc/lightning-hsmtool.8.md
+++ b/doc/lightning-hsmtool.8.md
@@ -53,6 +53,15 @@ and is usually no greater than the number of channels that the node has
 ever had.
 Specify *password* if the `hsm_secret` is encrypted.
 
+**derivetoremote** *node\_id* *channel\_dbid* \[*commitment\_point*\] *hsm\_secret*
+  Derive the private key to our funds from a remote unilateral close of a channel.
+The peer must be the one to close the channel (and the funds will remain
+unrecoverable until the channel is closed).
+*channel\_dbid* is the identifier of the channel in the CLN database.
+If *commitment\_point* is omitted, then the channel is assumed to have been
+negotiated with `option_static_remotekey`;
+otherwise, *commitment\_point* is the remote per-commitment point.
+
 **generatehsm** *hsm\_secret\_path*
   Generates a new hsm\_secret using BIP39.
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -18,7 +18,7 @@ tools/headerversions: $(FORCE) tools/headerversions.o libccan.a
 tools/headerversions.o: ccan/config.h
 tools/check-bolt: tools/check-bolt.o $(TOOLS_COMMON_OBJS)
 
-tools/hsmtool: tools/hsmtool.o $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/autodata.o common/bech32.o common/bech32_util.o common/bigsize.o common/codex32.o common/configdir.o common/configvar.o common/derive_basepoints.o common/descriptor_checksum.o common/hsm_encryption.o common/node_id.o common/version.o wire/fromwire.o wire/towire.o
+tools/hsmtool: tools/hsmtool.o $(TOOLS_COMMON_OBJS) $(BITCOIN_OBJS) common/amount.o common/autodata.o common/bech32.o common/bech32_util.o common/bigsize.o common/codex32.o common/configdir.o common/configvar.o common/derive_basepoints.o common/descriptor_checksum.o common/hsm_encryption.o common/key_derive.o common/node_id.o common/version.o wire/fromwire.o wire/towire.o
 
 tools/lightning-hsmtool: tools/hsmtool
 	cp $< $@

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -17,8 +17,10 @@
 #include <common/descriptor_checksum.h>
 #include <common/errcode.h>
 #include <common/hsm_encryption.h>
+#include <common/key_derive.h>
 #include <common/node_id.h>
 #include <common/utils.h>
+#include <common/utxo.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -42,6 +44,8 @@ static void show_usage(const char *progname)
 	printf("	- dumpcommitments <node id> <channel dbid> <depth> "
 	       "<path/to/hsm_secret>\n");
 	printf("	- guesstoremote <P2WPKH address> <node id> <tries> "
+	       "<path/to/hsm_secret>\n");
+	printf("	- derivetoremote <node id> <channel dbid> [<cmt pt>] "
 	       "<path/to/hsm_secret>\n");
 	printf("	- generatehsm <path/to/new/hsm_secret>\n");
 	printf("	- checkhsm <path/to/new/hsm_secret>\n");
@@ -118,7 +122,7 @@ static void get_encrypted_hsm_secret(struct secret *hsm_secret,
 }
 
 /* Taken from hsmd. */
-static void get_channel_seed(struct secret *channel_seed, struct node_id *peer_id,
+static void get_channel_seed(struct secret *channel_seed, const struct node_id *peer_id,
                              u64 dbid, struct secret *hsm_secret)
 {
 	struct secret channel_base;
@@ -454,6 +458,32 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 	return 1;
 }
 
+static int derive_to_remote(const struct unilateral_close_info *info, const char *hsm_secret_path)
+{
+	struct secret hsm_secret, channel_seed, basepoint_secret;
+	struct pubkey basepoint;
+	struct privkey privkey;
+
+	secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY
+	                                         | SECP256K1_CONTEXT_SIGN);
+
+	get_hsm_secret(&hsm_secret, hsm_secret_path);
+	get_channel_seed(&channel_seed, &info->peer_id, info->channel_id, &hsm_secret);
+	if (!derive_payment_basepoint(&channel_seed, &basepoint, &basepoint_secret))
+		errx(ERROR_KEYDERIV, "Could not derive basepoints for dbid %"PRIu64
+		                     " and channel seed %s.", info->channel_id,
+		                     fmt_secret(tmpctx, &channel_seed));
+	if (!info->commitment_point)
+		privkey.secret = basepoint_secret;
+	else if (!derive_simple_privkey(&basepoint_secret, &basepoint, info->commitment_point, &privkey))
+		errx(ERROR_KEYDERIV, "Could not derive simple privkey for dbid %"PRIu64
+		                     ", channel seed %s, and commitment point %s.", info->channel_id,
+		                     fmt_secret(tmpctx, &channel_seed),
+		                     fmt_pubkey(tmpctx, info->commitment_point));
+	printf("privkey : %s\n", fmt_secret(tmpctx, &privkey.secret));
+	return 0;
+}
+
 static void get_words(struct words **words) {
 	struct wordlist_lang {
 		char *abbr;
@@ -744,6 +774,23 @@ int main(int argc, char *argv[])
 			errx(ERROR_USAGE, "Bad node id");
 		return guess_to_remote(argv[2], &node_id, atol(argv[4]),
 		                       argv[5]);
+	}
+
+	if (streq(method, "derivetoremote")) {
+		/*  node_id    channel_id    [commitment_point]    hsm_secret  */
+		if (argc < 5 || argc > 6)
+			show_usage(argv[0]);
+		struct unilateral_close_info info = { };
+		struct pubkey commitment_point;
+		if (!node_id_from_hexstr(argv[2], strlen(argv[2]), &info.peer_id))
+			errx(ERROR_USAGE, "Bad node id");
+		info.channel_id = atoll(argv[3]);
+		if (argc == 6) {
+			if (!pubkey_from_hexstr(argv[4], strlen(argv[4]), &commitment_point))
+				errx(ERROR_USAGE, "Bad commitment point");
+			info.commitment_point = &commitment_point;
+		}
+		return derive_to_remote(&info, argv[argc - 1]);
 	}
 
 	if (streq(method, "generatehsm")) {


### PR DESCRIPTION
This method has a similar purpose as `guesstoremote` but is for use when the channel's database ID is known. It produces the private key that can spend the to_remote output of the peer's commitment transaction. It assumes the channel was negotiated with `option_static_remotekey` unless the optional per-commitment point argument is provided.

**Changelog-Added:** hsmtool has a new `derivetoremote` method.

---

**Motivation:** I implemented this method so that I could import my funds from remote unilateral closures into other wallets. While `guesstoremote` could mostly get the job done, it's needlessly slow when we already know the database ID of the channel, and it doesn't work at all for channels that were negotiated without `option_static_remotekey`.