### PR TITLE
rune: Do not return rune value in error messages

### DIFF
--- a/common/json_command.h
+++ b/common/json_command.h
@@ -33,6 +33,18 @@ command_fail_badparam(struct command *cmd,
 			    json_tok_full(buffer, tok));
 }
 
+/* Convenient wrapper for "paramname: msg: invalid token".
+ * It is useful for secrets/runes errors. */
+static inline struct command_result *
+command_fail_badparam_novalue(struct command *cmd,
+		      const char *paramname,
+		      const char *msg)
+{
+	return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+			    "%s: %s: invalid token",
+			    paramname, msg);
+}
+
 /* Also caller supplied: is this invoked simply to get usage? */
 bool command_usage_only(const struct command *cmd);
 

--- a/lightningd/runes.c
+++ b/lightningd/runes.c
@@ -202,11 +202,11 @@ static struct command_result *param_rune(struct command *cmd, const char *name,
 	(*rune_and_string)->runestr = json_strdup(*rune_and_string, buffer, tok);
 	(*rune_and_string)->rune = rune_from_base64(cmd, (*rune_and_string)->runestr);
 	if (!(*rune_and_string)->rune)
-		return command_fail_badparam(cmd, name, buffer, tok,
+		return command_fail_badparam_novalue(cmd, name,
 					     "should be base64 string");
 	/* We always create runes with integer unique ids: accept no less! */
 	if (!unique_id_num((*rune_and_string)->rune, &uid))
-		return command_fail_badparam(cmd, name, buffer, tok,
+		return command_fail_badparam_novalue(cmd, name,
 					     "should have valid numeric unique_id");
 
 	return NULL;

--- a/tests/test_runes.py
+++ b/tests/test_runes.py
@@ -426,6 +426,18 @@ def test_badrune(node_factory):
                 except RpcError:
                     pass
 
+    # Invalid rune should be caught and error message should not include rune value
+    with pytest.raises(RpcError, match='invalid token') as exc_info:
+        l1.rpc.checkrune(rune=rune['rune'] + '"')
+    assert exc_info.value.error['code'] == -32602
+    assert exc_info.value.error['message'] == 'rune: should be base64 string: invalid token'
+
+    # Also test that other method (with non-secret param) returns the value in the error message
+    with pytest.raises(RpcError, match='invalid token') as exc_info:
+        l1.rpc.blacklistrune([3])
+    assert exc_info.value.error['code'] == -32602
+    assert exc_info.value.error['message'] == "start: should be an unsigned 64 bit integer: invalid token '[3]'"
+
 
 def test_checkrune(node_factory):
     l1 = node_factory.get_node()


### PR DESCRIPTION
Currently, when a typo occurs in a rune value, it is considered an invalid rune and the error message includes the rune value also. This can inadvertently expose the rune.

Reference: https://github.com/ElementsProject/lightning/issues/7338

Changelog-Fixed: Removed rune value from error messages.