### PR TITLE
Properly send reestablish on close channels, do it simpler.

### DIFF
--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -901,6 +901,11 @@ void report_subd_memleak(struct leak_detect *leak_detect UNNEEDED, struct subd *
 void resolve_close_command(struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED,
 			   bool cooperative UNNEEDED, const struct bitcoin_tx *close_tx UNNEEDED)
 { fprintf(stderr, "resolve_close_command called!\n"); abort(); }
+/* Generated stub for shachain_get_secret */
+bool shachain_get_secret(const struct shachain *shachain UNNEEDED,
+			 u64 commit_num UNNEEDED,
+			 struct secret *preimage UNNEEDED)
+{ fprintf(stderr, "shachain_get_secret called!\n"); abort(); }
 /* Generated stub for start_leak_request */
 void start_leak_request(const struct subd_req *req UNNEEDED,
 			struct leak_detect *leak_detect UNNEEDED)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4126,7 +4126,6 @@ def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
     bitcoind.generate_block(1, wait_for_mempool=2)
 
 
-@pytest.mark.xfail(strict=True)
 def test_onchain_reestablish_reply(node_factory, bitcoind, executor):
     l1, l2, l3 = node_factory.line_graph(3, opts={'may_reconnect': True,
                                                   'dev-no-reconnect': None})

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4124,3 +4124,57 @@ def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
                              'hsmd: Unilateral close output, deriving secrets'])
 
     bitcoind.generate_block(1, wait_for_mempool=2)
+
+
+@pytest.mark.xfail(strict=True)
+def test_onchain_reestablish_reply(node_factory, bitcoind, executor):
+    l1, l2, l3 = node_factory.line_graph(3, opts={'may_reconnect': True,
+                                                  'dev-no-reconnect': None})
+
+    # Make l1 close unilaterally.
+    l1.rpc.disconnect(l2.info['id'], force=True)
+    l1.rpc.close(l2.info['id'], unilateraltimeout=1)
+
+    # l2 doesn't know, reconnection should get REESTABLISH *then* error.
+    l2.rpc.connect(l1.info['id'], 'localhost', l1.port)
+
+    # We should exchange messages
+    l2.daemon.wait_for_logs(["peer_out WIRE_CHANNEL_REESTABLISH",
+                             "peer_in WIRE_CHANNEL_REESTABLISH"])
+    # It should be OK
+    l2.daemon.wait_for_log("Reconnected, and reestablished.")
+
+    # Then we get the error, close.
+    l2.daemon.wait_for_log("peer_in WIRE_ERROR")
+    assert only_one(l2.rpc.listpeerchannels(l1.info['id'])['channels'])['state'] == 'AWAITING_UNILATERAL'
+    # Mine it now so we don't confuse the code below.
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    # For l2->l2, try:
+    # 1. are not in the initial state, and
+    # 2. actually onchain.
+    l2.rpc.pay(l3.rpc.invoice(200000000, 'test', 'test')['bolt11'])
+
+    # We block l3 from seeing close, so it will try to reestablish.
+    def no_new_blocks(req):
+        return {"error": "go away"}
+    l3.daemon.rpcproxy.mock_rpc('getblockhash', no_new_blocks)
+
+    l2.rpc.disconnect(l3.info['id'], force=True)
+    l2.rpc.close(l3.info['id'], unilateraltimeout=1)
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    wait_for(lambda: only_one(l2.rpc.listpeerchannels(l3.info['id'])['channels'])['state'] == 'ONCHAIN')
+
+    # l3 doesn't know, reconnection should get REESTABLISH *then* error.
+    l3.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    # We should exchange messages
+    l3.daemon.wait_for_logs(["peer_out WIRE_CHANNEL_REESTABLISH",
+                             "peer_in WIRE_CHANNEL_REESTABLISH"])
+    # It should be OK
+    l3.daemon.wait_for_log("Reconnected, and reestablished.")
+
+    # Then we get the error, close.
+    l3.daemon.wait_for_log("peer_in WIRE_ERROR")
+    assert only_one(l3.rpc.listpeerchannels(l2.info['id'])['channels'])['state'] == 'AWAITING_UNILATERAL'

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -986,6 +986,9 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 /* Generated stub for towire_announcement_signatures */
 u8 *towire_announcement_signatures(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, struct short_channel_id short_channel_id UNNEEDED, const secp256k1_ecdsa_signature *node_signature UNNEEDED, const secp256k1_ecdsa_signature *bitcoin_signature UNNEEDED)
 { fprintf(stderr, "towire_announcement_signatures called!\n"); abort(); }
+/* Generated stub for towire_channel_reestablish */
+u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *channel_reestablish UNNEEDED)
+{ fprintf(stderr, "towire_channel_reestablish called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channeld_dev_memleak called!\n"); abort(); }


### PR DESCRIPTION
We used to fire up channeld to send this, but:
1. That's silly, we have all the information to make it ourselves.
2. We didn't do it if there was an error on the channel, which as of 24.02
   there always is!
3. When it did work, running channeld *stops* onchaind, indefinitely slowing recovery.

Fixes: https://github.com/Blockstream/greenlight/issues/433
