### PR TITLE
Renepay simpler routetracking

### DIFF
--- a/plugins/renepay/json.h
+++ b/plugins/renepay/json.h
@@ -8,6 +8,9 @@
 struct routekey *tal_routekey_from_json(const tal_t *ctx, const char *buf,
 					const jsmntok_t *obj);
 
+struct route *tal_route_from_json(const tal_t *ctx, const char *buf,
+				  const jsmntok_t *obj);
+
 struct payment_result *tal_sendpay_result_from_json(const tal_t *ctx,
 						    const char *buffer,
 						    const jsmntok_t *toks);

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -32,7 +32,7 @@ static void memleak_mark(struct plugin *p, struct htable *memtable)
 	memleak_scan_htable(memtable,
 			    &pay_plugin->uncertainty->chan_extra_map->raw);
 	memleak_scan_htable(memtable, &pay_plugin->payment_map->raw);
-	memleak_scan_htable(memtable, &pay_plugin->route_map->raw);
+	memleak_scan_htable(memtable, &pay_plugin->pending_routes->raw);
 }
 
 static const char *init(struct plugin *p,
@@ -70,8 +70,8 @@ static const char *init(struct plugin *p,
 	pay_plugin->payment_map = tal(pay_plugin, struct payment_map);
 	payment_map_init(pay_plugin->payment_map);
 
-	pay_plugin->route_map = tal(pay_plugin,struct route_map);
-	route_map_init(pay_plugin->route_map);
+	pay_plugin->pending_routes = tal(pay_plugin, struct route_map);
+	route_map_init(pay_plugin->pending_routes);
 
 	pay_plugin->gossmap = gossmap_load(pay_plugin,
 					   GOSSIP_STORE_FILENAME,

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -89,7 +89,7 @@ static const char *init(struct plugin *p,
 		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
 			   "%s: uncertainty was updated but %d channels have "
 			   "been ignored.",
-			   __PRETTY_FUNCTION__, skipped_count);
+			   __func__, skipped_count);
 
 	plugin_set_memleak_handler(p, memleak_mark);
 	return NULL;

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -38,7 +38,7 @@ static void memleak_mark(struct plugin *p, struct htable *memtable)
 static const char *init(struct plugin *p,
 			const char *buf UNUSED, const jsmntok_t *config UNUSED)
 {
-	size_t num_channel_updates_rejected;
+	size_t num_channel_updates_rejected = 0;
 
 	tal_steal(p, pay_plugin);
 	pay_plugin->plugin = p;

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -1193,7 +1193,7 @@ static u32 find_positive_balance(
 	 * algorithm does not come up with spurious flow cycles. */
 	while(balance[final_idx]<=0)
 	{
-		// printf("%s: node = %d\n",__PRETTY_FUNCTION__,final_idx);
+		// printf("%s: node = %d\n",__func__,final_idx);
 		u32 updated_idx=INVALID_INDEX;
 		struct gossmap_node *cur
 			= gossmap_node_byidx(gossmap,final_idx);

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -899,7 +899,7 @@ collect_results_done(struct command *cmd UNUSED, const char *buf UNUSED,
 	payment->retry = false;
 
 	/* pending sendpay callbacks should be zero */
-	if (routetracker_count_sent(payment->routetracker)>0)
+	if (!routetracker_have_results(payment->routetracker))
 		return payment_continue(payment);
 
 	/* all sendpays have been sent, look for success */

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -113,7 +113,7 @@ static bool success_data_from_listsendpays(const char *buf,
 	size_t i;
 	const char *err;
 	const jsmntok_t *t;
-	assert(arr && arr->type == JSMN_ARRAY && arr->size);
+	assert(arr && arr->type == JSMN_ARRAY);
 
 	success->parts = 0;
 	success->deliver_msat = AMOUNT_MSAT(0);
@@ -192,17 +192,10 @@ static struct command_result *previoussuccess_done(struct command *cmd,
 		    json_tok_full_len(result), json_tok_full(buf, result));
 	}
 
-	/* There are no success sendpays. */
-	if (!arr->size)
-		return payment_continue(payment);
-
 	struct success_data success;
 	if (!success_data_from_listsendpays(buf, arr, &success)) {
-		plugin_err(
-		    pay_plugin->plugin,
-		    "%s (line %d) Expected at least one success sendpay but "
-		    "function success_data_from_listsendpays returns error.",
-		    __PRETTY_FUNCTION__, __LINE__);
+		/* There are no success sendpays. */
+		return payment_continue(payment);
 	}
 
 	payment->payment_info.start_time.ts.tv_sec = success.created_at;

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -461,7 +461,7 @@ static struct command_result *refreshgossmap_cb(struct payment *payment)
 	assert(payment);
 	assert(payment->local_gossmods);
 
-	size_t num_channel_updates_rejected;
+	size_t num_channel_updates_rejected = 0;
 	bool gossmap_changed =
 	    gossmap_refresh(pay_plugin->gossmap, &num_channel_updates_rejected);
 

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -797,12 +797,12 @@ static struct command_result *collect_results_cb(struct payment *payment)
 	payment_collect_results(payment, &payment_preimage, &final_error, &final_msg);
 
 	if (payment_preimage) {
-		/* If we have the preimate that means one succeed, we
+		/* If we have the preimage that means one succeed, we
 		 * inmediately finish the payment. */
 		if (!amount_msat_greater_eq(payment->total_delivering,
 					    payment->payment_info.amount)) {
-			plugin_err(
-			    pay_plugin->plugin,
+			plugin_log(
+			    pay_plugin->plugin, LOG_UNUSUAL,
 			    "%s: received a success sendpay for this "
 			    "payment but the total delivering amount %s "
 			    "is less than the payment amount %s.",

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -129,13 +129,13 @@ static bool success_data_from_listsendpays(const char *buf,
 			plugin_err(
 			    pay_plugin->plugin,
 			    "%s (line %d) missing status token from json.",
-			    __PRETTY_FUNCTION__, __LINE__);
+			    __func__, __LINE__);
 		const char *status = json_strdup(tmpctx, buf, status_tok);
 		if (!status)
 			plugin_err(
 			    pay_plugin->plugin,
 			    "%s (line %d) failed to allocate status string.",
-			    __PRETTY_FUNCTION__, __LINE__);
+			    __func__, __LINE__);
 
 		if (streq(status, "complete")) {
 			/* FIXME we assume amount_msat is always present, but
@@ -160,7 +160,7 @@ static bool success_data_from_listsendpays(const char *buf,
 					   "%s (line %d) json_scan of "
 					   "listsendpay returns the "
 					   "following error: %s",
-					   __PRETTY_FUNCTION__, __LINE__, err);
+					   __func__, __LINE__, err);
 			success->groupid = groupid;
 			/* Now we know the payment completed. */
 			if (!amount_msat_add(&success->deliver_msat,
@@ -170,7 +170,7 @@ static bool success_data_from_listsendpays(const char *buf,
 					     success->sent_msat, this_sent))
 				plugin_err(pay_plugin->plugin,
 					   "%s (line %d) amount_msat overflow.",
-					   __PRETTY_FUNCTION__, __LINE__);
+					   __func__, __LINE__);
 
 			success->parts++;
 		}
@@ -482,7 +482,7 @@ static struct command_result *refreshgossmap_cb(struct payment *payment)
 			    pay_plugin->plugin, LOG_UNUSUAL,
 			    "%s: uncertainty was updated but %d channels have "
 			    "been ignored.",
-			    __PRETTY_FUNCTION__, skipped_count);
+			    __func__, skipped_count);
 	}
 	return payment_continue(payment);
 }
@@ -597,7 +597,7 @@ static struct command_result *routehints_done(struct command *cmd UNUSED,
 		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
 			   "%s: uncertainty was updated but %d channels have "
 			   "been ignored.",
-			   __PRETTY_FUNCTION__, skipped_count);
+			   __func__, skipped_count);
 
 	return payment_continue(payment);
 }
@@ -631,7 +631,7 @@ static struct command_result *compute_routes_cb(struct payment *payment)
 	    tal_count(routetracker->computed_routes))
 		plugin_err(pay_plugin->plugin,
 			   "%s: no previously computed routes expected.",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 
 	struct amount_msat feebudget, fees_spent, remaining;
 
@@ -639,14 +639,14 @@ static struct command_result *compute_routes_cb(struct payment *payment)
 	if (!amount_msat_sub(&feebudget, payment->payment_info.maxspend,
 			     payment->payment_info.amount))
 		plugin_err(pay_plugin->plugin, "%s: fee budget is negative?",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 
 	/* Fees spent so far */
 	if (!amount_msat_sub(&fees_spent, payment->total_sent,
 			     payment->total_delivering))
 		plugin_err(pay_plugin->plugin,
 			   "%s: total_delivering is greater than total_sent?",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 
 	/* Remaining fee budget. */
 	if (!amount_msat_sub(&feebudget, feebudget, fees_spent))
@@ -658,7 +658,7 @@ static struct command_result *compute_routes_cb(struct payment *payment)
 		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
 			   "%s: Payment is pending with full amount already "
 			   "committed. We skip the computation of new routes.",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 		return payment_continue(payment);
 	}
 
@@ -724,7 +724,7 @@ static struct command_result *send_routes_cb(struct payment *payment)
 	    tal_count(routetracker->computed_routes) == 0) {
 		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
 			   "%s: there are no routes to send, skipping.",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 		return payment_continue(payment);
 	}
 	struct command *cmd = payment_command(payment);
@@ -806,7 +806,7 @@ static struct command_result *collect_results_cb(struct payment *payment)
 			    "%s: received a success sendpay for this "
 			    "payment but the total delivering amount %s "
 			    "is less than the payment amount %s.",
-			    __PRETTY_FUNCTION__,
+			    __func__,
 			    fmt_amount_msat(tmpctx, payment->total_delivering),
 			    fmt_amount_msat(tmpctx,
 					    payment->payment_info.amount));
@@ -930,7 +930,7 @@ static struct command_result *pendingsendpays_done(struct command *cmd,
 		payment_note(payment, LOG_DBG,
 			     "%s: Payment completed before computing the next "
 			     "round of routes.",
-			     __PRETTY_FUNCTION__);
+			     __func__);
 		return payment_success(payment, &success.preimage);
 	}
 
@@ -950,7 +950,7 @@ static struct command_result *pendingsendpays_done(struct command *cmd,
 			plugin_err(pay_plugin->plugin,
 				   "%s json_scan of listsendpay returns the "
 				   "following error: %s",
-				   __PRETTY_FUNCTION__, err);
+				   __func__, err);
 
 		if (streq(status, "pending")) {
 			pending_group_id = groupid;
@@ -985,7 +985,7 @@ static struct command_result *pendingsendpays_done(struct command *cmd,
 			plugin_err(pay_plugin->plugin,
 				   "%s json_scan of listsendpay returns the "
 				   "following error: %s",
-				   __PRETTY_FUNCTION__, err);
+				   __func__, err);
 
 		/* If we decide to create a new group, we base it on
 		 * max_group_id */
@@ -1011,7 +1011,7 @@ static struct command_result *pendingsendpays_done(struct command *cmd,
 					     this_sent))
 				plugin_err(pay_plugin->plugin,
 					   "%s (line %d) amount_msat overflow.",
-					   __PRETTY_FUNCTION__, __LINE__);
+					   __func__, __LINE__);
 		}
 		assert(!streq(status, "complete"));
 	}

--- a/plugins/renepay/payment.c
+++ b/plugins/renepay/payment.c
@@ -105,7 +105,6 @@ struct payment *payment_new(
 	p->retry = false;
 	p->waitresult_timer = NULL;
 
-	p->routes_computed = NULL;
 	p->routetracker = new_routetracker(p, p);
 	return p;
 }
@@ -124,7 +123,6 @@ static void payment_cleanup(struct payment *p)
 	disabledmap_reset(p->disabledmap);
 	p->waitresult_timer = tal_free(p->waitresult_timer);
 
-	p->routes_computed = tal_free(p->routes_computed);
 	routetracker_cleanup(p->routetracker);
 }
 
@@ -198,12 +196,6 @@ bool payment_update(
 	p->retry = false;
 	p->waitresult_timer = tal_free(p->waitresult_timer);
 
-	/* It is weird to have routes here stuck. */
-	if (p->routes_computed)
-		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
-			   "We have %zu unsent routes in this payment.",
-			   tal_count(p->routes_computed));
-	p->routes_computed = tal_free(p->routes_computed);
 	return true;
 }
 

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -12,10 +12,6 @@ enum payment_status { PAYMENT_PENDING, PAYMENT_SUCCESS, PAYMENT_FAIL };
 
 struct payment {
 	/* Inside pay_plugin->payments list */
-	// TODO: probably not necessary after we store all payments in a
-	// hashtable instead of a list
-	struct list_node list;
-
 	struct payment_info payment_info;
 
 

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -71,7 +71,6 @@ struct payment {
 	/* Timer we use to wait for results. */
 	struct plugin_timer *waitresult_timer;
 
-	struct route **routes_computed;
 	struct routetracker *routetracker;
 };
 

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -147,11 +147,19 @@ struct command *payment_command(struct payment *p);
 /* get me the result of this payment, not necessarily a completed payment */
 struct json_stream *payment_result(struct payment *p, struct command *cmd);
 
-/* flag the payment as success and write the preimage as proof */
+/* Flag the payment as success and write the preimage as proof. */
+void register_payment_success(struct payment *payment,
+			      const struct preimage *preimage TAKES);
+/* Flag the payment as success and write the preimage as proof and end the
+ * payment execution. */
 struct command_result *payment_success(struct payment *payment,
 				       const struct preimage *preimage TAKES);
 
-/* flag the payment as failed and write the reason */
+/* Flag the payment as failed and write the reason. */
+void register_payment_fail(struct payment *payment, enum jsonrpc_errcode code,
+			   const char *fmt, ...);
+/* Flag the payment as failed and write the reason and end the payment
+ * execution. */
 struct command_result *payment_fail(struct payment *payment,
 				    enum jsonrpc_errcode code, const char *fmt,
 				    ...);

--- a/plugins/renepay/payplugin.h
+++ b/plugins/renepay/payplugin.h
@@ -57,7 +57,6 @@ struct pay_plugin {
 	bool exp_offers;
 
 	/* All the struct payment */
-	struct list_head payments;
 	struct payment_map *payment_map;
 
 	/* Per-channel metadata: some persists between payments */

--- a/plugins/renepay/payplugin.h
+++ b/plugins/renepay/payplugin.h
@@ -64,7 +64,7 @@ struct pay_plugin {
 	struct uncertainty *uncertainty;
 
 	/* Pending sendpays (to match notifications to). */
-	struct route_map *route_map;
+	struct route_map *pending_routes;
 
 	bool debug_mcf;
 	bool debug_payflow;

--- a/plugins/renepay/payplugin.h
+++ b/plugins/renepay/payplugin.h
@@ -63,7 +63,9 @@ struct pay_plugin {
 	/* Per-channel metadata: some persists between payments */
 	struct uncertainty *uncertainty;
 
-	/* Pending sendpays (to match notifications to). */
+	/* Pending sendpays. Each pending route has an associated HTLC data in
+	 * the uncertainty network. Pending routes are matched against sendpay
+	 * notifications. */
 	struct route_map *pending_routes;
 
 	bool debug_mcf;

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -5,13 +5,6 @@
 
 #include <stdio.h>
 
-// static void uncertainty_commit_routes(struct uncertainty *uncertainty,
-// 				   struct route **routes)
-// {
-// 	const size_t N = tal_count(routes);
-// 	for (size_t i = 0; i < N; i++)
-// 		uncertainty_commit_htlcs(uncertainty, routes[i]);
-// }
 static void uncertainty_remove_routes(struct uncertainty *uncertainty,
 				   struct route **routes)
 {

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -229,7 +229,7 @@ struct route **get_routes(const tal_t *ctx,
 				    ctx, ecode, fail, PLUGIN_ERROR,
 				    "%s: flow is delivering to destination "
 				    "(%s) more than requested (%s)",
-				    __PRETTY_FUNCTION__,
+				    __func__,
 				    fmt_amount_msat(this_ctx, flows[i]->amount),
 				    fmt_amount_msat(this_ctx,
 						    amount_to_deliver));
@@ -285,7 +285,7 @@ struct route **get_routes(const tal_t *ctx,
 				tal_report_error(
 				    ctx, ecode, fail, PLUGIN_ERROR,
 				    "%s failed to build route from flow.",
-				    __PRETTY_FUNCTION__);
+				    __func__);
 				goto function_fail;
 			}
 
@@ -347,7 +347,7 @@ struct route **get_routes(const tal_t *ctx,
 				    ctx, ecode, fail, PLUGIN_ERROR,
 				    "%s routing fees (%s) exceed fee "
 				    "budget (%s).",
-				    __PRETTY_FUNCTION__,
+				    __func__,
 				    fmt_amount_msat(this_ctx, fee),
 				    fmt_amount_msat(this_ctx, feebudget));
 				goto function_fail;
@@ -361,7 +361,7 @@ struct route **get_routes(const tal_t *ctx,
 				    ctx, ecode, fail, PLUGIN_ERROR,
 				    "%s: route delivering to destination (%s) "
 				    "is more than requested (%s)",
-				    __PRETTY_FUNCTION__,
+				    __func__,
 				    fmt_amount_msat(this_ctx, delivering),
 				    fmt_amount_msat(this_ctx,
 						    amount_to_deliver));

--- a/plugins/renepay/routefail.c
+++ b/plugins/renepay/routefail.c
@@ -43,13 +43,14 @@ struct command_result *routefail_start(const tal_t *ctx, struct route *route,
 	return update_gossip(r);
 }
 
-static struct command_result *routefail_end(struct routefail *r)
+static struct command_result *routefail_end(struct routefail *r TAKES)
 {
 	/* Notify the tracker that route has failed and routefail have completed
 	 * handling all possible errors cases. */
 	struct command *cmd = r->cmd;
 	route_failure_register(r->payment->routetracker, r->route);
-	tal_free(r);
+	if (taken(r))
+		r = tal_steal(tmpctx, r);
 	return notification_handled(cmd);
 }
 
@@ -428,5 +429,5 @@ static struct command_result *handle_failure(struct routefail *r)
 
 		break;
 	}
-	return routefail_end(r);
+	return routefail_end(take(r));
 }

--- a/plugins/renepay/routefail.c
+++ b/plugins/renepay/routefail.c
@@ -33,7 +33,7 @@ struct command_result *routefail_start(const tal_t *ctx, struct route *route,
 	if (payment == NULL)
 		plugin_err(pay_plugin->plugin,
 			   "%s: payment with hash %s not found.",
-			   __PRETTY_FUNCTION__,
+			   __func__,
 			   fmt_sha256(tmpctx, &route->key.payment_hash));
 
 	r->payment = payment;

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -402,7 +402,7 @@ struct command_result *notification_sendpay_failure(struct command *cmd,
 
 	/* we do some error processing steps before calling
 	 * route_failure_register. */
-	return routefail_start(route, route, cmd);
+	return routefail_start(payment, route, cmd);
 }
 
 struct command_result *notification_sendpay_success(struct command *cmd,

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -13,7 +13,7 @@ static struct payment *route_get_payment_verify(struct route *route)
 	if (!payment)
 		plugin_err(pay_plugin->plugin,
 			   "%s: no payment associated with routekey %s",
-			   __PRETTY_FUNCTION__,
+			   __func__,
 			   fmt_routekey(tmpctx, &route->key));
 	return payment;
 }
@@ -162,14 +162,14 @@ static void route_pending_register(struct routetracker *routetracker,
 	if (route_map_get(pay_plugin->pending_routes, &route->key))
 		plugin_err(pay_plugin->plugin,
 			   "%s: tracking a route (%s) duplicate?",
-			   __PRETTY_FUNCTION__,
+			   __func__,
 			   fmt_routekey(tmpctx, &route->key));
 
 	if (!route_map_del(routetracker->sent_routes, route))
 		plugin_err(pay_plugin->plugin,
 			   "%s: tracking a route (%s) not computed by this "
 			   "payment call",
-			   __PRETTY_FUNCTION__,
+			   __func__,
 			   fmt_routekey(tmpctx, &route->key));
 
 	uncertainty_commit_htlcs(pay_plugin->uncertainty, route);
@@ -179,7 +179,7 @@ static void route_pending_register(struct routetracker *routetracker,
 	    !tal_add_destructor2(route, remove_route,
 				 pay_plugin->pending_routes))
 		plugin_err(pay_plugin->plugin, "%s: failed to register route.",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 
 	if (!amount_msat_add(&payment->total_sent, payment->total_sent,
 			     route_sends(route)) ||
@@ -188,7 +188,7 @@ static void route_pending_register(struct routetracker *routetracker,
 			     route_delivers(route))) {
 		plugin_err(pay_plugin->plugin,
 			   "%s: amount_msat arithmetic overflow.",
-			   __PRETTY_FUNCTION__);
+			   __func__);
 	}
 }
 
@@ -249,7 +249,7 @@ static struct command_result *sendpay_failed(struct command *cmd,
 	if (!route_map_del(routetracker->sent_routes, route))
 		plugin_err(pay_plugin->plugin,
 			   "%s: route (%s) is not marked as sent",
-			   __PRETTY_FUNCTION__,
+			   __func__,
 			   fmt_routekey(tmpctx, &route->key));
 	tal_free(route);
 	return command_still_pending(cmd);
@@ -290,7 +290,7 @@ void payment_collect_results(struct payment *payment,
 				   "%s: current groupid=%" PRIu64
 				   ", but recieved a sendpay result with "
 				   "groupid=%" PRIu64,
-				   __PRETTY_FUNCTION__, payment->groupid,
+				   __func__, payment->groupid,
 				   r->key.groupid);
 			continue;
 		}
@@ -314,7 +314,7 @@ void payment_collect_results(struct payment *payment,
 			plugin_err(pay_plugin->plugin,
 				   "%s: routes do not add up to "
 				   "payment total amount.",
-				   __PRETTY_FUNCTION__);
+				   __func__);
 		}
 	}
 	for (size_t i = 0; i < ncompleted; i++)

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -85,8 +85,8 @@ static void route_sendpay_fail(struct routetracker *routetracker,
  *	- after a sendpay is accepted,
  *	- or after listsendpays reveals some pending route that we didn't
  *	previously know about. */
-void route_pending_register(struct routetracker *routetracker,
-			    struct route *route)
+static void route_pending_register(struct routetracker *routetracker,
+				   struct route *route)
 {
 	assert(route);
 	assert(routetracker);
@@ -100,7 +100,7 @@ void route_pending_register(struct routetracker *routetracker,
 			   "%s: tracking a route (%s) duplicate?",
 			   __PRETTY_FUNCTION__,
 			   fmt_routekey(tmpctx, &route->key));
-	
+
 	if (!route_map_del(routetracker->sent_routes, route))
 		plugin_err(pay_plugin->plugin,
 			   "%s: tracking a route (%s) not computed by this "

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -10,12 +10,13 @@ struct routetracker{
 	/* Routes that we sendpay and are still waiting for rpc returning
 	 * success. */
 	struct route_map *sent_routes;
-	struct route_map *pending_routes;
+
+	/* Routes that have concluded (either SENDPAY_FAILED or
+	 * SENDPAY_COMPLETE). */
 	struct route **finalized_routes;
 };
 
 struct routetracker *new_routetracker(const tal_t *ctx, struct payment *payment);
-// bool routetracker_is_ready(const struct routetracker *routetracker);
 void routetracker_cleanup(struct routetracker *routetracker);
 
 bool routetracker_have_results(struct routetracker *routetracker);
@@ -51,11 +52,6 @@ struct command_result *notification_sendpay_success(struct command *cmd,
 /* Notify the tracker that this route has failed. */
 void route_failure_register(struct routetracker *routetracker,
 			    struct route *route);
-
-/* How much is the amount being tracked. */
-bool routetracker_get_amount(struct routetracker *routetracker,
-			     struct amount_msat *amount,
-			     struct amount_msat *amount_sent);
 
 // FIXME: double-check that we actually get one notification for each sendpay,
 // ie. that after some time we don't have yet pending sendpays for old failed or

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -7,7 +7,8 @@
 #include <plugins/renepay/route.h>
 
 struct routetracker{
-	struct payment *payment;
+	/* Routes that we sendpay and are still waiting for rpc returning
+	 * success. */
 	struct route_map *sent_routes;
 	struct route_map *pending_routes;
 	struct route **finalized_routes;
@@ -16,7 +17,8 @@ struct routetracker{
 struct routetracker *new_routetracker(const tal_t *ctx, struct payment *payment);
 // bool routetracker_is_ready(const struct routetracker *routetracker);
 void routetracker_cleanup(struct routetracker *routetracker);
-size_t routetracker_count_sent(struct routetracker *routetracker);
+
+bool routetracker_have_results(struct routetracker *routetracker);
 
 /* The payment has a list of route that have "returned". Calling this function
  * payment will look through that list and process those routes' results:

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -31,11 +31,6 @@ void payment_collect_results(struct payment *payment,
 			     enum jsonrpc_errcode *final_error,
 			     const char **final_msg);
 
-/* Announce that this route is pending and needs to be kept in the waiting list
- * for notifications. */
-void route_pending_register(struct routetracker *routetracker,
-			    struct route *route);
-
 /* Sends a sendpay request for this route. */
 struct command_result *route_sendpay_request(struct command *cmd,
 					     struct route *route,

--- a/plugins/renepay/routetracker.h
+++ b/plugins/renepay/routetracker.h
@@ -7,6 +7,9 @@
 #include <plugins/renepay/route.h>
 
 struct routetracker{
+	/* Routes that we compute and are kept here before sending them. */
+	struct route **computed_routes;
+
 	/* Routes that we sendpay and are still waiting for rpc returning
 	 * success. */
 	struct route_map *sent_routes;
@@ -33,7 +36,7 @@ void payment_collect_results(struct payment *payment,
 
 /* Sends a sendpay request for this route. */
 struct command_result *route_sendpay_request(struct command *cmd,
-					     struct route *route,
+					     struct route *route TAKES,
 					     struct payment *payment);
 
 struct command_result *notification_sendpay_failure(struct command *cmd,

--- a/plugins/renepay/test/run-route_map.c
+++ b/plugins/renepay/test/run-route_map.c
@@ -32,7 +32,7 @@ static void destroy_route(
 		struct route_map * map)
 {
 	printf("calling %s with  %s\n",
-		__PRETTY_FUNCTION__,
+		__func__,
 		fmt_routekey(tmpctx,&route->key));
 	route_map_del(map, route);
 }


### PR DESCRIPTION
While fixing the bug #7337 I have realized that the mechanism for tracking pending routes internally in renepay is way too complicated, prone to bugs. 
With this PR I wan to reduce that complexity by relying in the internal state as little as possible and using
lightningd as oracle. The tradeoff is that now there is an extra rpc call `listsendpays` for every route computation cycle;
this IO communication is way more expensive that checking the internal database. However the bottleneck of the payment
is the time spent waiting for onion messages from peers, not RPC communication with ligthningd and neither the computation
of the routes.