### PR TITLE
offer: make the blockheight nullable

### DIFF
--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -1232,7 +1232,6 @@ static const char *init(struct plugin *p,
 	rpc_scan(p, "getchaininfo",
 		 take(json_out_obj(NULL, "last_height", NULL)),
 		 "{headercount:%}", JSON_SCAN(json_to_u32, &blockheight));
-	assert(blockheight);
 
 	rpc_scan(p, "listconfigs",
 		 take(json_out_obj(NULL, NULL, NULL)),


### PR DESCRIPTION
Our CI do not catch this because we mine 100 blocks to make the funds usable.

However, it is possible to avoid this kind of crash, because
our assert is "wrong" because blockheight can be 0 and the
assert can fail.

In addition, the `rpc_scan` already checks for nullability, so the
assert is redundant

```
2024-06-07T14:14:29.278Z INFO    lightningd: v24.05-modded
2024-06-07T14:14:37.158Z INFO    lightningd: v24.05-modded
2024-06-07T14:14:29.329Z INFO    lightningd: Creating configuration directory /root/.lightning/signet
2024-06-07T14:14:37.589Z INFO    plugin-bcli: bitcoin-cli initialized and connected to bitcoind.
2024-06-07T14:14:29.715Z INFO    lightningd: Creating database
2024-06-07T14:14:37.591Z UNUSUAL lightningd: Waiting for initial block download (this can take a while!)
2024-06-07T14:14:29.752Z UNUSUAL hsmd: HSM: created new hsm_secret file
2024-06-07T14:14:37.603Z INFO    plugin-reckless-wrapper.py: initializing reckless-wrapper.py.
2024-06-07T14:14:29.798Z INFO    plugin-bcli: bitcoin-cli initialized and connected to bitcoind.
2024-06-07T14:14:29.802Z UNUSUAL lightningd: Waiting for initial block download (this can take a while!)
offers: plugins/offers.c:1235: init: Assertion `blockheight' failed.
2024-06-07T14:14:29.814Z INFO    plugin-reckless-wrapper.py: initializing reckless-wrapper.py.
offers: FATAL SIGNAL 6 (version v24.05-modded)
0x57ab55a56485 send_backtrace
2024-06-07T14:14:29.818Z INFO    plugin-chanbackup: Creating Emergency Recovery
   common/daemon.c:33
offers: plugins/offers.c:1235: init: Assertion `blockheight' failed.
offers: FATAL SIGNAL 6 (version v24.05-modded)
0x57ab55a5650d crashdump
   common/daemon.c:75
0x59f3ed3ba485 send_backtrace
0x7dd20b02213f ???
   common/daemon.c:33
   ???:0
0x59f3ed3ba50d crashdump
0x7dd20ae59ce1 ???
   common/daemon.c:75
   ???:0
0x7dd20ae43536 ???
0x764fa583813f ???
   ???:0
0x7dd20ae4340e ???
   ???:0
0x7dd20ae52661 ???
   ???:0
   ???:0
0x57ab55a3effe init
   plugins/offers.c:1235
0x764fa566fce1 ???
0x57ab55a4763f handle_init
   ???:0
   plugins/libplugin.c:1376
0x57ab55a478ee ld_command_handle
0x764fa5659536 ???
   plugins/libplugin.c:1797
0x57ab55a47ec0 ld_read_json_one
   plugins/libplugin.c:1979
   ???:0
0x57ab55a47f49 ld_read_json
0x764fa565940e ???
   plugins/libplugin.c:1999
   ???:0
0x57ab55b934cc next_plan
0x764fa5668661 ???
   ccan/ccan/io/io.c:60
   ???:0
0x57ab55b93953 do_plan
0x59f3ed3a2ffe init
   ccan/ccan/io/io.c:408
   plugins/offers.c:1235
0x57ab55b939ec io_ready
   ccan/ccan/io/io.c:418
0x59f3ed3ab63f handle_init
0x57ab55b95302 io_loop
   plugins/libplugin.c:1376
   ccan/ccan/io/poll.c:455
0x59f3ed3ab8ee ld_command_handle
0x57ab55a486dc plugin_main
   plugins/libplugin.c:1797
   plugins/libplugin.c:2209
0x59f3ed3abec0 ld_read_json_one
0x57ab55a3f36d main
   plugins/libplugin.c:1979
   plugins/offers.c:1285
0x59f3ed3abf49 ld_read_json
0x7dd20ae44d09 ???
   plugins/libplugin.c:1999
   ???:0
0x59f3ed4f74cc next_plan
0x57ab55a3c799 ???
   ccan/ccan/io/io.c:60
0x59f3ed4f7953 do_plan
   ???:0
   ccan/ccan/io/io.c:408
0xffffffffffffffff ???
0x59f3ed4f79ec io_ready
   ccan/ccan/io/io.c:418
   ???:0
offers: FATAL SIGNAL 11 (version v24.05-modded)
0x59f3ed4f9302 io_loop
   ccan/ccan/io/poll.c:455
0x57ab55a56485 send_backtrace
0x59f3ed3ac6dc plugin_main
   common/daemon.c:33
   plugins/libplugin.c:2209
0x57ab55a5650d crashdump
0x59f3ed3a336d main
   plugins/offers.c:1285
   common/daemon.c:75
0x7dd20b02213f ???
0x764fa565ad09 ???
   ???:0
   ???:0
0x59f3ed3a0799 ???
0x0 ???
   ???:0
   ???:0
2024-06-07T14:14:37.734Z INFO    plugin-offers: Killing plugin: exited before replying to init
0xffffffffffffffff ???
   ???:0
2024-06-07T14:14:37.734Z **BROKEN** plugin-offers: Plugin marked as important, shutting down lightningd!
offers: FATAL SIGNAL 11 (version v24.05-modded)
0x59f3ed3ba485 send_backtrace
   common/daemon.c:33
0x59f3ed3ba50d crashdump
   common/daemon.c:75
0x764fa583813f ???
   ???:0
0x0 ???
   ???:0
2024-06-07T14:14:29.823Z INFO    plugin-bookkeeper: Creating database
2024-06-07T14:14:29.883Z INFO    plugin-offers: Killing plugin: exited before replying to init
2024-06-07T14:14:29.883Z **BROKEN** plugin-offers: Plugin marked as important, shutting down lightning!
```

Reported-by: @farscapian
Link: https://github.com/ElementsProject/lightning/issues/7378