### PR TITLE
docker: poetry install before make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,11 @@ RUN ( ! [ -n "${target_host}" ] ) || \
 RUN ( ! [ "${target_host}" = "arm-linux-gnueabihf" ] ) || \
     (sed -i '/documentation = "https:\/\/docs.rs\/cln-grpc"/a include = ["**\/*.*"]' cln-grpc/Cargo.toml)
 
+# Ensure that the desired grpcio-tools & protobuf versions are installed
+# https://github.com/ElementsProject/lightning/pull/7376#issuecomment-2161102381
+RUN /root/.local/bin/poetry lock --no-update && \
+    /root/.local/bin/poetry install
+
 RUN ./configure --prefix=/tmp/lightning_install --enable-static && \
     make && \
     /root/.local/bin/poetry run make install


### PR DESCRIPTION
Issue: Docker images for v24.05 were built on clean lightning directory and the published image should be running on v24.05 but it is running as v24.05-modded.

Root cause: Dockerfile builder was running different versions of grpcio-tools and protobuf. It resulted in auto generated update of contrib/pyln-grpc-proto/pyln/grpc/node_pb2.py and contrib/pyln-grpc-proto/pyln/grpc/primitive_pb2.py files.

Solution: Run `poetry install` before make in the dockerfile's builder stage to ensure that the grpcio-tools and protobuf versions are the same.

References:
https://github.com/ElementsProject/lightning/issues/7370#issuecomment-2152952820 
https://github.com/ElementsProject/lightning/pull/7376#issuecomment-2161102381

Changelog-None.