### PR TITLE
Commando updating removal version for rpcs

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -3273,7 +3273,7 @@
       "added": "v23.05",
       "deprecated": [
         "v23.08",
-        "v24.08"
+        "v25.02"
       ],
       "rpc": "commando-blacklist",
       "title": "Command to prevent a rune from working",
@@ -3415,7 +3415,7 @@
       "added": "v23.05",
       "deprecated": [
         "v23.08",
-        "v24.05"
+        "v25.02"
       ],
       "rpc": "commando-listrunes",
       "title": "Command to list previously generated runes",
@@ -3712,7 +3712,7 @@
       "additionalProperties": false,
       "deprecated": [
         "v23.08",
-        "v23.05"
+        "v25.02"
       ],
       "rpc": "commando-rune",
       "title": "Command to Authorize Remote Peer Access",

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -5679,12 +5679,16 @@
                       "first_scid": {
                         "added": "v23.05",
                         "type": "short_channel_id",
-                        "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                        "description": [
+                          "the short channel id of the start of the path (alternative to first_node_id)"
+                        ]
                       },
                       "first_scid_dir": {
                         "added": "v23.05",
                         "type": "u32",
-                        "description": "which end of the first_scid is the start of the path"
+                        "description": [
+                          "which end of the first_scid is the start of the path"
+                        ]
                       },
                       "blinding": {
                         "type": "pubkey",
@@ -6066,12 +6070,16 @@
                       "first_scid": {
                         "added": "v23.05",
                         "type": "short_channel_id",
-                        "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                        "description": [
+                          "the short channel id of the start of the path (alternative to first_node_id)"
+                        ]
                       },
                       "first_scid_dir": {
                         "added": "v23.05",
                         "type": "u32",
-                        "description": "which end of the first_scid is the start of the path"
+                        "description": [
+                          "which end of the first_scid is the start of the path"
+                        ]
                       },
                       "blinding": {
                         "type": "pubkey",
@@ -6550,12 +6558,16 @@
                       "first_scid": {
                         "added": "v23.05",
                         "type": "short_channel_id",
-                        "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                        "description": [
+                          "the short channel id of the start of the path (alternative to first_node_id)"
+                        ]
                       },
                       "first_scid_dir": {
                         "added": "v23.05",
                         "type": "u32",
-                        "description": "which end of the first_scid is the start of the path"
+                        "description": [
+                          "which end of the first_scid is the start of the path"
+                        ]
                       },
                       "blinding": {
                         "type": "pubkey",
@@ -6763,12 +6775,16 @@
                       "first_scid": {
                         "added": "v23.05",
                         "type": "short_channel_id",
-                        "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                        "description": [
+                          "the short channel id of the start of the path (alternative to first_node_id)"
+                        ]
                       },
                       "first_scid_dir": {
                         "added": "v23.05",
                         "type": "u32",
-                        "description": "which end of the first_scid is the start of the path"
+                        "description": [
+                          "which end of the first_scid is the start of the path"
+                        ]
                       },
                       "blinding": {
                         "type": "pubkey",

--- a/doc/developers-guide/deprecations.md
+++ b/doc/developers-guide/deprecations.md
@@ -25,6 +25,9 @@ hidden: false
 | plugin.nonumericids                  | Getmanifest Reply  | v23.08           | v24.08         | Plugins must specify that they can accept non-numeric command ids (numeric ids are deprecated)                                                                                  |
 | listchannels.include_private         | Field(s)           | v24.02           | v24.08         | `listchannels` including private channels (now use listpeerchannels which gives far more detail)                                                                                |
 | max-locktime-blocks                  | Config             | v24.05           | v24.11         | --max-locktime-blocks is now set to 2016 in the BOLT 4 spec                                                                                                                     |
+| commando-rune                        | Command            | v23.08           | v25.02         | replaced with `lightning-createrune`                                                                                                   |
+| commando-listrunes                   | Command            | v23.08           | v25.02         | replaced with `lightning-showrunes`                                                                                                    |
+| commando-blacklist                   | Command            | v23.08           | v25.02         | replaced with `lightning-blacklistrune`                                                                                                |
 
 
 Inevitably there are features which need to change: either to be generalized, or removed when they can no longer be supported.

--- a/doc/schemas/lightning-commando-blacklist.json
+++ b/doc/schemas/lightning-commando-blacklist.json
@@ -5,7 +5,7 @@
   "added": "v23.05",
   "deprecated": [
     "v23.08",
-    "v24.08"
+    "v25.02"
   ],
   "rpc": "commando-blacklist",
   "title": "Command to prevent a rune from working",

--- a/doc/schemas/lightning-commando-listrunes.json
+++ b/doc/schemas/lightning-commando-listrunes.json
@@ -5,7 +5,7 @@
   "added": "v23.05",
   "deprecated": [
     "v23.08",
-    "v24.05"
+    "v25.02"
   ],
   "rpc": "commando-listrunes",
   "title": "Command to list previously generated runes",

--- a/doc/schemas/lightning-commando-rune.json
+++ b/doc/schemas/lightning-commando-rune.json
@@ -4,7 +4,7 @@
   "additionalProperties": false,
   "deprecated": [
     "v23.08",
-    "v23.05"
+    "v25.02"
   ],
   "rpc": "commando-rune",
   "title": "Command to Authorize Remote Peer Access",

--- a/doc/schemas/lightning-decode.json
+++ b/doc/schemas/lightning-decode.json
@@ -189,12 +189,16 @@
                   "first_scid": {
                     "added": "v23.05",
                     "type": "short_channel_id",
-                    "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                    "description": [
+                      "the short channel id of the start of the path (alternative to first_node_id)"
+                    ]
                   },
                   "first_scid_dir": {
                     "added": "v23.05",
                     "type": "u32",
-                    "description": "which end of the first_scid is the start of the path"
+                    "description": [
+                      "which end of the first_scid is the start of the path"
+                    ]
                   },
                   "blinding": {
                     "type": "pubkey",
@@ -576,12 +580,16 @@
                   "first_scid": {
                     "added": "v23.05",
                     "type": "short_channel_id",
-                    "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                    "description": [
+                      "the short channel id of the start of the path (alternative to first_node_id)"
+                    ]
                   },
                   "first_scid_dir": {
                     "added": "v23.05",
                     "type": "u32",
-                    "description": "which end of the first_scid is the start of the path"
+                    "description": [
+                      "which end of the first_scid is the start of the path"
+                    ]
                   },
                   "blinding": {
                     "type": "pubkey",
@@ -1060,12 +1068,16 @@
                   "first_scid": {
                     "added": "v23.05",
                     "type": "short_channel_id",
-                    "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                    "description": [
+                      "the short channel id of the start of the path (alternative to first_node_id)"
+                    ]
                   },
                   "first_scid_dir": {
                     "added": "v23.05",
                     "type": "u32",
-                    "description": "which end of the first_scid is the start of the path"
+                    "description": [
+                      "which end of the first_scid is the start of the path"
+                    ]
                   },
                   "blinding": {
                     "type": "pubkey",
@@ -1273,12 +1285,16 @@
                   "first_scid": {
                     "added": "v23.05",
                     "type": "short_channel_id",
-                    "description": "the short channel id of the start of the path (alternative to first_n  ode_id)"
+                    "description": [
+                      "the short channel id of the start of the path (alternative to first_node_id)"
+                    ]
                   },
                   "first_scid_dir": {
                     "added": "v23.05",
                     "type": "u32",
-                    "description": "which end of the first_scid is the start of the path"
+                    "description": [
+                      "which end of the first_scid is the start of the path"
+                    ]
                   },
                   "blinding": {
                     "type": "pubkey",

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -811,6 +811,8 @@ static const struct plugin_command commands[] = { {
 	"Create or restrict a rune",
 	"Takes an optional {rune} with optional {restrictions} and returns {rune}",
 	json_commando_rune,
+	"v23.08",
+	"v25.02",
 	},
 	{
 	"commando-listrunes",
@@ -818,6 +820,8 @@ static const struct plugin_command commands[] = { {
 	"List runes we have created earlier",
 	"Takes an optional {rune} and returns list of {rune}",
 	json_commando_listrunes,
+	"v23.08",
+	"v25.02",
 	},
 	{
 	"commando-blacklist",
@@ -825,6 +829,8 @@ static const struct plugin_command commands[] = { {
 	"Blacklist a rune or range of runes by unique id",
 	"Takes an optional {start} and an optional {end} and returns {blacklist} array containing {start}, {end}",
 	json_commando_blacklist,
+	"v23.08",
+	"v25.02",
 	},
 };
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1149,7 +1149,7 @@ def test_cli(node_factory):
 
 def test_cli_commando(node_factory):
     l1, l2 = node_factory.line_graph(2, fundchannel=False,
-                                     opts={'log-level': 'io'})
+                                     opts={'log-level': 'io', 'allow-deprecated-apis': True})
     rune = l2.rpc.commando_rune()['rune']
 
     # Invalid peer id.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2669,7 +2669,7 @@ def test_plugin_shutdown(node_factory):
 
 def test_commando(node_factory, executor):
     l1, l2 = node_factory.line_graph(2, fundchannel=False,
-                                     opts={'log-level': 'io'})
+                                     opts={'log-level': 'io', 'allow-deprecated-apis': True})
 
     rune = l1.rpc.commando_rune()['rune']
 
@@ -2765,7 +2765,9 @@ def test_commando(node_factory, executor):
 
 
 def test_commando_rune(node_factory):
-    l1, l2 = node_factory.line_graph(2, fundchannel=False)
+    l1, l2 = node_factory.line_graph(2, fundchannel=False, opts={
+        'allow-deprecated-apis': True,
+    })
 
     rune1 = l1.rpc.commando_rune()
     assert rune1['rune'] == 'OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA=='
@@ -2904,7 +2906,9 @@ def test_commando_rune(node_factory):
 
 
 def test_commando_listrunes(node_factory):
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={
+        'allow-deprecated-apis': True,
+    })
     rune = l1.rpc.commando_rune()
     assert rune == {
         'rune': 'OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==',
@@ -2944,7 +2948,9 @@ def test_commando_listrunes(node_factory):
 
 
 def test_commando_rune_pay_amount(node_factory):
-    l1, l2 = node_factory.line_graph(2)
+    l1, l2 = node_factory.line_graph(2, opts={
+        'allow-deprecated-apis': True,
+    })
 
     # This doesn't really work, since amount_msat is illegal if invoice
     # includes an amount, and runes aren't smart enough to decode bolt11!
@@ -2996,7 +3002,9 @@ def test_commando_rune_pay_amount(node_factory):
 
 
 def test_commando_blacklist(node_factory):
-    l1, l2 = node_factory.get_nodes(2)
+    l1, l2 = node_factory.get_nodes(2, opts={
+        'allow-deprecated-apis': True,
+    })
 
     l2.connect(l1)
     rune0 = l1.rpc.commando_rune()
@@ -3079,7 +3087,9 @@ def test_commando_blacklist(node_factory):
 @pytest.mark.slow_test
 def test_commando_stress(node_factory, executor):
     """Stress test to slam commando with many large queries"""
-    nodes = node_factory.get_nodes(5)
+    nodes = node_factory.get_nodes(5, opts={
+        'allow-deprecated-apis': True,
+    })
 
     rune = nodes[0].rpc.commando_rune()['rune']
     for n in nodes[1:]:
@@ -3115,7 +3125,9 @@ def test_commando_stress(node_factory, executor):
 
 def test_commando_badrune(node_factory):
     """Test invalid UTF-8 encodings in rune: used to make us kill the offers plugin which implements decode, as it gave bad utf8!"""
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={
+        'allow-deprecated-apis': True,
+    })
     l1.rpc.decode('5zi6-ugA6hC4_XZ0R7snl5IuiQX4ugL4gm9BQKYaKUU9gCZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5Jm1ldGhvZC9saXN0ZGF0YXN0b3Jl')
     rune = l1.rpc.commando_rune(restrictions="readonly")
 

--- a/tests/test_runes.py
+++ b/tests/test_runes.py
@@ -10,7 +10,9 @@ import unittest
 
 
 def test_createrune(node_factory):
-    l1 = node_factory.get_node()
+    l1 = node_factory.get_node(options={
+        'allow-deprecated-apis': True,
+    })
 
     # l1's master rune secret is edb8893c04fdeef8f5f06ed70edef309a5c83f20624594e136e392504a270c40
     rune1 = l1.rpc.createrune()

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1679,7 +1679,9 @@ def test_upgradewallet(node_factory, bitcoind):
 
 def test_hsmtool_makerune(node_factory):
     """Test we can make a valid rune before the node really exists"""
-    l1 = node_factory.get_node(start=False)
+    l1 = node_factory.get_node(start=False, options={
+        'allow-deprecated-apis': True,
+    })
 
     # get_node() creates a secret, but in usual case we generate one.
     hsm_path = os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, "hsm_secret")


### PR DESCRIPTION
We documented them as deprecated in v23.08 but unintentionally didn't deprecate them in the code. Thus we are starting their *actual* deprecation cycle from v24.08 release.

Updated removal version for commands `commando-rune`, `commando-listrunes`, and `commando-blacklist`.

Changelog-None.