### PR TITLE
doc(build): improve Ubuntu build dependencies in installation doc

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -96,7 +96,7 @@ Get dependencies:
 ```shell
 sudo apt-get update
 sudo apt-get install -y \
-  jq autoconf automake build-essential git libtool libsqlite3-dev \
+  jq autoconf automake build-essential git libtool libsqlite3-dev libffi-dev \
   python3 python3-pip net-tools zlib1g-dev libsodium-dev gettext
 pip3 install --upgrade pip
 pip3 install --user poetry

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -34,10 +34,10 @@ To install the Docker image for the latest stable release:
 docker pull elementsproject/lightningd:latest
 ```
 
-To install for a specific version, for example, 23.11.2:
+To install for a specific version, for example, 24.05:
 
 ```shell
-docker pull elementsproject/lightningd:v23.11.2
+docker pull elementsproject/lightningd:v24.05
 ```
 
 See all of the docker images for Core Lightning on [Docker Hub](https://hub.docker.com/r/elementsproject/lightningd/tags).
@@ -122,7 +122,7 @@ cd lightning
 Checkout a release tag:
 
 ```shell
-git checkout v23.11.2
+git checkout v24.05
 ```
 
 For development or running tests, get additional dependencies:
@@ -225,7 +225,7 @@ cd lightning
 Checkout a release tag:
 
 ```shell
-git checkout v23.11.2
+git checkout v24.05
 ```
 
 Build and install lightning:
@@ -399,7 +399,7 @@ cd lightning
 Checkout a release tag:
 
 ```shell
-git checkout v23.11.2
+git checkout v24.05
 ```
 
 Build lightning:

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -66,27 +66,6 @@ For actually doing development and running the tests, you will also need:
 
 You will also need a version of bitcoind with segregated witness and `estimatesmartfee` with `ECONOMICAL` mode support, such as the 0.16 or above.
 
-## Python plugins
-
-You will need some Python packages if you want to use python plugins. Unfortunately there are some Python packages which are not packaged in Ubuntu, and so you will need to force installation of these (I recommend --user which will install them in your own .local directory, so at least you won't run the risk of breaking Python globally!).
-
-### clnrest
-
-Installation steps for clnrest are:
-
-```
-sudo apt-get install python3-pip python3-json5 python3-flask python3-gunicorn libsecp256k1-dev
-pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
-```
-
-### wss-proxy
-
-For wss-proxy, you need to install below libraries:
-
-```
-pip3 install --user pyln-client websockets
-```
-
 ## To Build on Ubuntu
 
 OS version: Ubuntu 15.10 or above
@@ -605,4 +584,25 @@ Install runtime dependencies:
 
 ```shell
 apk add libgcc libsodium sqlite-libs zlib
+```
+
+## Python plugins
+
+You will need some Python packages if you want to use python plugins. Unfortunately there are some Python packages which are not packaged in Ubuntu, and so you will need to force installation of these (I recommend --user which will install them in your own .local directory, so at least you won't run the risk of breaking Python globally!).
+
+### clnrest
+
+Installation steps for clnrest are:
+
+```
+sudo apt-get install python3-json5 python3-flask python3-gunicorn
+pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
+```
+
+### wss-proxy
+
+For wss-proxy, you need to install below libraries:
+
+```
+pip3 install --user pyln-client websockets
 ```

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -130,6 +130,7 @@ For development or running tests, get additional dependencies:
 ```shell
 sudo apt-get install -y valgrind libpq-dev shellcheck cppcheck \
   libsecp256k1-dev lowdown
+pip3 install pytest
 ```
 
 If you can't install `lowdown`, a version will be built in-tree.

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -75,7 +75,7 @@ You will need some Python packages if you want to use python plugins. Unfortunat
 Installation steps for clnrest are:
 
 ```
-sudo apt-get install python3-json5 python3-flask python3-gunicorn libsecp256k1-dev
+sudo apt-get install python3-pip python3-json5 python3-flask python3-gunicorn libsecp256k1-dev
 pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
 ```
 

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -596,7 +596,7 @@ Installation steps for clnrest are:
 
 ```
 sudo apt-get install python3-json5 python3-flask python3-gunicorn
-pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
+pip3 install --user flask-cors flask-restx pyln-client flask-socketio gevent gevent-websocket
 ```
 
 ### wss-proxy

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -75,7 +75,7 @@ You will need some Python packages if you want to use python plugins. Unfortunat
 Installation steps for clnrest are:
 
 ```
-sudo apt-get install python3-json5 python3-flask python3-gunicorn
+sudo apt-get install python3-json5 python3-flask python3-gunicorn libsecp256k1-dev
 pip3 install --user flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket
 ```
 


### PR DESCRIPTION
This PR adds two dependencies to fix fatal errors when building from source on a fresh install of Ubuntu 24.04 LTS.

## Error 1 - `ffi.h: No such file or directory`

This error occurs when installing the python dependencies `requirements.txt` file.

```text
    x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/home/user1/myenv/include -I/usr/include/python3.12 -c c/_cffi_backend.c -o build/temp.linux-x86_64-cpython-312/c/_cffi_backend.o
    c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
       15 | #include <ffi.h>
          |          ^~~~~~~
    compilation terminated.
    error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
    [end of output]

note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed building wheel for cffi
```

The workaround is to install the required dependency via `apt install libffi-dev` then re-run `pip3 install -r plugins/clnrest/requirements.txt`. Evidence in [this pastebin](https://pastebin.com/CU9KtU06).

The `libffi-dev` dependency should be available on all modern Ubuntu versions, including [20.04 focal](https://packages.ubuntu.com/focal/libffi-dev), [22.04 jammy](https://packages.ubuntu.com/jammy/libffi-dev), and [24.04 noble](https://packages.ubuntu.com/noble/libffi-dev), so adding this additional dependency is unlikely to cause issues for users.

## Error 2 - `libsecp256k1/autogen.sh: 3: autoreconf: not found`

This error occurs when installing the python dependencies for the clnrest plugin.

```text
      copying coincurve/py.typed -> build/lib.linux-x86_64-cpython-312/coincurve
      running build_clib
      /tmp/pip-install-wzwxs8jt/coincurve_9dfe5f159c734244b1d8b14dec959349/libsecp256k1/autogen.sh: 3: autoreconf: not found
      Traceback (most recent call last):
        File "/home/user1/Downloads/lightning/myenv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
```

The workaround is to install the required dependency via `apt install libsecp256k1-dev` then re-run `pip install flask-cors flask_restx pyln-client flask-socketio gevent gevent-websocket`. Evidence in [this pastebin](https://pastebin.com/gJCqDrc3).

The `libsecp256k1-dev` dependency should be available on all modern Ubuntu versions, including [20.04 focal](https://packages.ubuntu.com/focal/libsecp256k1-dev), [22.04 jammy](https://packages.ubuntu.com/jammy/libsecp256k1-dev), and [24.04 noble](https://packages.ubuntu.com/noble/libsecp256k1-dev), so adding this additional dependency is unlikely to cause issues for users.

## Other changes

- Add python3-pip to the clnrest dependencies
- Add pytest to the development dependencies, for `make check`
- Bump the doc version of lightning to 24.05