### PR TITLE
docker: Update github actions for Docker releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,35 +16,39 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
+    - name: Set up version
+      id: set-version
+      run: |
+        if [ "${{ github.event.inputs.version }}" != "" ]; then
+          VERSION=${{ github.event.inputs.version }}
+        elif [ "${{ github.ref_type }}" == "tag" ]; then
+          VERSION=${{ github.ref_name }}
+        else
+          echo "No version provided and no tag found."
+          exit 1
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         tags: |
-          elementsproject/lightningd:${{ github.event.inputs.version }}
-          # Commenting the next line to avoid replacing the latest tag with the testing image
-          # I will uncomment it once the testing is done and images are ready for production
-          # elementsproject/lightningd:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+          elementsproject/lightningd:$VERSION
+          elementsproject/lightningd:latest


### PR DESCRIPTION
This PR is adding github action for auto Docker releases. This will streamline Docker image builds & releases for enhanced efficiency, reliability, and consistency in managing Docker-based deployments.

The build & release event will be triggered:
- On any new tag creation without "rc" suffix.
- Manually for testing purposes.

Reference: PR #7331 was also merged to add the original .yml for testing. This is the final PR after it's successful testing.

Changelog-None.