### PR TITLE
configure: don't sanitize function call types.

### DIFF
--- a/configure
+++ b/configure
@@ -165,7 +165,7 @@ set_defaults()
 	fi
     fi
     if [ "$UBSAN" != 0 ]; then
-	CSANFLAGS="$CSANFLAGS -fsanitize=undefined -fno-sanitize-recover=undefined"
+	CSANFLAGS="$CSANFLAGS -fsanitize=undefined -fno-sanitize=function -fno-sanitize-recover=undefined"
     fi
     if [ "$FUZZING" != 0 ]; then
 	FUZZFLAGS="-fsanitize=fuzzer-no-link -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"


### PR DESCRIPTION
We do this with typesafe_cb and it's so useful I'm not going to remove it.  But clang 18 complains:

```
ccan/ccan/tal/tal.c:246:6: runtime error: call to function destroy_conn_close_fd through pointer to incorrect function type 'void (*)(void *)'
/home/rusty/devel/cvs/lightning/ccan/ccan/io/poll.c:251: note: destroy_conn_close_fd defined here
```