### PR TITLE
meta: fix fuzz compilation error

### DIFF
--- a/ccan/ccan/cdump/cdump.c
+++ b/ccan/ccan/cdump/cdump.c
@@ -608,19 +608,19 @@ static bool tok_take_enum(struct parse_state *ps)
 }
 
 static bool gather_undefines(const char *name,
-			     struct cdump_type *t,
-			     cdump_map_t *undefs)
+			     void *t,
+			     void *undefs)
 {
 	if (!type_defined(t))
-		strmap_add(undefs, name, t);
+		strmap_add((cdump_map_t *)undefs, name, (struct cdump_type *)t);
 	return true;
 }
 
 static bool remove_from_map(const char *name,
-			    struct cdump_type *t,
-			    cdump_map_t *map)
+			    void *t,
+			    void *map)
 {
-	strmap_del(map, name, NULL);
+	strmap_del((cdump_map_t *)map, name, NULL);
 	return true;
 }
 

--- a/ccan/ccan/cdump/tools/cdump-enumstr.c
+++ b/ccan/ccan/cdump/tools/cdump-enumstr.c
@@ -2,19 +2,21 @@
 #include <ccan/tal/grab_file/grab_file.h>
 #include <ccan/err/err.h>
 
-static bool dump_map(const char *name, struct cdump_type *t, void *unused)
+static bool dump_map(const char *name, void *t, void *unused)
 {
 	size_t i;
+	struct cdump_type *tt;
 
 	printf("struct {\n"
 	       "	enum %s v;\n"
 	       "	const char *name;\n"
 	       "} enum_%s_names[] = {\n", name, name);
 
-	for (i = 0; i < tal_count(t->u.enum_vals); i++)
+	tt = (struct cdump_type *)t;
+	for (i = 0; i < tal_count(tt->u.enum_vals); i++)
 		printf("	{ %s, \"%s\" },\n",
-		       t->u.enum_vals[i].name,
-		       t->u.enum_vals[i].name);
+		       tt->u.enum_vals[i].name,
+		       tt->u.enum_vals[i].name);
 	printf("	{ 0, NULL } };\n");
 	return true;
 }


### PR DESCRIPTION
With clang version

➜  lightning git:(macros/fuzz-compilation) ✗ clang --version clang version 17.0.6
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /bin

It generates the following compilation error.

```
ccan/ccan/cdump/tools/cdump-enumstr common/htlc_state.h > common/htlc_state_names_gen.h ccan/ccan/strmap/strmap.c:186:10: runtime error: call to function gather_undefines through pointer to incorrect function type 'bool (*)(const char *, void *, void *)' /home/vincent/github/work/workspace/lightning/ccan/ccan/cdump/cdump.c:613: note: gather_undefines defined here SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ccan/ccan/strmap/strmap.c:186:10 in make: *** [common/Makefile:149: common/htlc_state_names_gen.h] Error 1
```

Fixes: https://github.com/ElementsProject/lightning/issues/7414
Suggested-by: @morehouse


P.S: this code needs to be upstream to ccan, but looks like in the last period we are not following anymore this rule?