### PR TITLE
clnrest: Fixes `ssl_version` deprecated warning

### DIFF
--- a/plugins/clnrest/clnrest.py
+++ b/plugins/clnrest/clnrest.py
@@ -157,7 +157,8 @@ def set_application_options(plugin):
             "loglevel": "warning",
             "certfile": f"{CERTS_PATH}/client.pem",
             "keyfile": f"{CERTS_PATH}/client-key.pem",
-            "ssl_version": ssl.PROTOCOL_TLSv1_2
+            "cafile": f"{CERTS_PATH}/ca.pem",
+            "ssl": ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_SERVER),
         }
     return options
 


### PR DESCRIPTION
Reference Issue #6931: Fixes `Warning: option ssl_version is deprecated and it is ignored. Use ssl_context instead.`

Curl example with https: 
```
curl --cacert /path/to/certs/ca.pem --header 'Rune: ZrAK...E9MA==' --request POST --url https://127.0.0.1:3010/v1/getinfo
```

Changelog-None.