### PR TITLE
doc: Updated warning box for wss-proxy

### DIFF
--- a/doc/developers-guide/app-development/wss-proxy.md
+++ b/doc/developers-guide/app-development/wss-proxy.md
@@ -19,6 +19,14 @@ Install required packages with `pip install -r plugins/wss-proxy/requirements.tx
 
 ## Configuration
 
+> 🚧 
+> 
+> Note: The wss-proxy plugin expects CLN to be listening on a websocket.
+>
+> In other words, CLN config option `bind-addr` starting with `ws` (`bind-addr=ws:...`)
+>
+> is required for wss-proxy to connect.
+
 If `wss-bind-addr` is not specified, the plugin will disable itself.
 
 - --wss-bind-addr: WSS proxy address to connect with WS. Format <wss-host>:<wss-port>.


### PR DESCRIPTION
Bug Fix: The wss-proxy plugin throws error `plugin-wss-proxy: Killing plugin: disabled itself at init: Error in parsing options: 'NoneType' object is not subscriptable` if CLN is not listening on websocket.

Reference: https://github.com/ElementsProject/lightning/issues/7386#issuecomment-2175766309

Changelog-None.