### PR TITLE
Fix: Add `notifications.rs` to $(CHECK_GEN_ALL) target

### DIFF
--- a/cln-rpc/Makefile
+++ b/cln-rpc/Makefile
@@ -2,7 +2,7 @@ cln-rpc-wrongdir:
 	$(MAKE) -C .. cln-rpc-all
 
 CLN_RPC_EXAMPLES := target/${RUST_PROFILE}/examples/cln-rpc-getinfo
-CLN_RPC_GENALL = cln-rpc/src/model.rs
+CLN_RPC_GENALL = cln-rpc/src/model.rs cln-rpc/src/notifications.rs
 CLN_RPC_SOURCES = $(shell find cln-rpc -name *.rs) ${CLN_RPC_GENALL}
 DEFAULT_TARGETS += $(CLN_RPC_EXAMPLES) $(CLN_RPC_GENALL)
 


### PR DESCRIPTION
The file `cln-rpc/src/notifications.rs` is generated by `msggen`.

The `Makefile` has tooling to update the file when needed
- `make check-gen-updated` should error if file isn't properly updated
- `make gen` updates the file

This comit fixes both behaviors mentioned above.