### PR TITLE
fundchannel: remove crash on race condition

### DIFF
--- a/plugins/spender/openchannel.c
+++ b/plugins/spender/openchannel.c
@@ -591,17 +591,9 @@ static struct command_result *json_peer_sigs(struct command *cmd,
 	 * "UPDATED" still. We check that SIGNED is hit before
 	 * we mark ourselves as ready to send the sigs, so it's ok
 	 * to relax this check */
-	if (dest->state == MULTIFUNDCHANNEL_UPDATED)
+	if (dest->state != MULTIFUNDCHANNEL_SECURED)
 		dest->state = MULTIFUNDCHANNEL_SIGNED_NOT_SECURED;
 	else {
-		if (dest->state != MULTIFUNDCHANNEL_SECURED) {
-			plugin_log(cmd->plugin, LOG_BROKEN,
-				   "mfc %"PRIu64":`openchannel_peer_sigs` "
-				   " expected state MULTIFUNDCHANNEL_SECURED (%d),"
-				   " state is %d", dest->mfc->id,
-				   MULTIFUNDCHANNEL_SECURED,
-				   dest->state);
-		}
 		dest->state = MULTIFUNDCHANNEL_SIGNED;
 	}
 
@@ -826,12 +818,13 @@ perform_openchannel_update(struct multifundchannel_command *mfc)
 						     dest->error_message);
 
 		if (dest->state == MULTIFUNDCHANNEL_SECURED ||
-			dest->state == MULTIFUNDCHANNEL_SIGNED) {
+		    dest->state == MULTIFUNDCHANNEL_SIGNED) {
 			ready_count++;
 			continue;
 		}
 
 		assert(dest->state == MULTIFUNDCHANNEL_UPDATED ||
+		       dest->state == MULTIFUNDCHANNEL_SIGNED_NOT_SECURED ||
 			dest->state == MULTIFUNDCHANNEL_STARTED);
 	}
 


### PR DESCRIPTION
If the peer sends you their signatures before we return from the *first* openchannel_update then the state would still be in MULTIFUNDCHANNEL_STARTED (not UPDATED) and we'd incorrectly switch the state to MULTIFUNDCHANNEL_SIGNED, which would plunge us headfirst into `check_sigs_ready`.

However the `mfc->txid` hadn't been set yet, so we'd crash when trying to confirm that we've got sigs for the correct txid. Oops.

To fix this, we simply invert the check such that the *only* state that will move into SIGNED is SECURED