### PR TITLE
chore: add ShortChannelId::to_u64

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -260,6 +260,9 @@ impl ShortChannelId {
     pub fn outnum(&self) -> u16 {
         self.0 as u16 & 0xFFFF
     }
+    pub fn to_u64(&self) -> u64 {
+        self.0
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -793,7 +796,7 @@ mod test {
         });
 
         let p: FundchannelResponse = serde_json::from_value(r).unwrap();
-	    assert_eq!(p.channel_type.unwrap().bits, vec![1,3,5]);
+        assert_eq!(p.channel_type.unwrap().bits, vec![1, 3, 5]);
     }
 }
 


### PR DESCRIPTION
In Fedimint we currently call `ShortChannelId::block`, `ShortChannelId::txindex`, and `ShortChannelId::outnum` and then convert these three fields to a `u64`:

https://github.com/fedimint/fedimint/blob/31bbcf6c8d4b2552112bfd525cfa7f0ce06ce0c6/gateway/ln-gateway/src/bin/cln_extension.rs#L1025-L1030

This struct is already represented internally as a `u64`, let's use it!