### PR TITLE
Part 3: offers with paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -752,8 +752,8 @@ $(ALL_TEST_PROGRAMS:%=update-mocks/%.c): $(ALL_GEN_HEADERS) $(EXTERNAL_LIBS) lib
 update-mocks/%: % $(ALL_GEN_HEADERS) $(ALL_GEN_SOURCES)
 	@MAKE=$(MAKE) tools/update-mocks.sh "$*" $(SUPPRESS_OUTPUT)
 
-unittest/%: %
-	$(VG) $(VG_TEST_ARGS) $* > /dev/null
+unittest/%: % bolt-precheck
+	BOLTDIR=$(LOCAL_BOLTDIR) $(VG) $(VG_TEST_ARGS) $* > /dev/null
 
 # Installation directories
 exec_prefix = $(PREFIX)

--- a/common/Makefile
+++ b/common/Makefile
@@ -71,6 +71,7 @@ COMMON_SRC_NOGEN :=				\
 	common/onion_decode.c			\
 	common/onion_encode.c			\
 	common/onionreply.c			\
+	common/onion_message.c			\
 	common/onion_message_parse.c		\
 	common/peer_billboard.c			\
 	common/peer_failed.c			\

--- a/common/onion_message.c
+++ b/common/onion_message.c
@@ -1,0 +1,228 @@
+#include "config.h"
+#include <assert.h>
+#include <bitcoin/pubkey.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/cast/cast.h>
+#include <common/blindedpath.h>
+#include <common/onion_message.h>
+#include <common/sphinx.h>
+#include <sodium.h>
+#include <wire/onion_wire.h>
+
+struct tlv_encrypted_data_tlv **new_encdata_tlvs(const tal_t *ctx,
+						 const struct pubkey *ids,
+						 const struct short_channel_id **scids)
+{
+	struct tlv_encrypted_data_tlv **etlvs;
+
+	etlvs = tal_arr(ctx, struct tlv_encrypted_data_tlv *, tal_count(ids));
+	for (size_t i = 0; i < tal_count(etlvs); i++) {
+		etlvs[i] = tlv_encrypted_data_tlv_new(etlvs);
+		if (i+1 < tal_count(scids) && scids[i+1]) {
+			etlvs[i]->short_channel_id = tal_dup(etlvs[i],
+							     struct short_channel_id,
+							     scids[i+1]);
+		} else if (i + 1 < tal_count(ids)) {
+			etlvs[i]->next_node_id = tal_dup(etlvs[i],
+							 struct pubkey,
+							 &ids[i+1]);
+		}
+	}
+	return etlvs;
+}
+
+/* We can extract nodeid from ids[], but usually we can get it from the
+ * previous next_node_id. */
+static const struct pubkey *
+get_nodeid(const struct tlv_encrypted_data_tlv **tlvs,
+	   const struct pubkey *ids,
+	   size_t i)
+{
+	if (i == 0)
+		return &ids[0];
+
+	if (tlvs[i-1]->next_node_id == NULL) {
+		/* If you didn't set next_node_id you have to set
+		 * short_channel_id! */
+		assert(tlvs[i-1]->short_channel_id);
+		assert(i < tal_count(ids));
+		return &ids[i];
+	}
+
+	return tlvs[i-1]->next_node_id;
+}
+
+/* Stage 1: tlv_encrypted_data_tlv[] -> struct blinded_path.
+ * Optional array of node_ids, consulted iff tlv uses scid in one entry. */
+struct blinded_path *blinded_path_from_encdata_tlvs(const tal_t *ctx,
+						    const struct tlv_encrypted_data_tlv **tlvs,
+						    const struct pubkey *ids)
+{
+	struct privkey first_blinding, blinding_iter;
+	struct blinded_path *path;
+	size_t nhops = tal_count(ids);
+	const struct pubkey *nodeid;
+
+	path = tal(ctx, struct blinded_path);
+
+	assert(nhops > 0);
+	assert(tal_count(ids) > 0);
+
+	randombytes_buf(&first_blinding, sizeof(first_blinding));
+	if (!pubkey_from_privkey(&first_blinding, &path->blinding))
+		abort();
+	sciddir_or_pubkey_from_pubkey(&path->first_node_id, &ids[0]);
+
+	path->path = tal_arr(ctx, struct onionmsg_hop *, nhops);
+
+	blinding_iter = first_blinding;
+	for (size_t i = 0; i < nhops; i++) {
+		nodeid = get_nodeid(tlvs, ids, i);
+
+		path->path[i] = tal(path->path, struct onionmsg_hop);
+		path->path[i]->encrypted_recipient_data
+			= encrypt_tlv_encrypted_data(path->path[i],
+						     &blinding_iter,
+						     nodeid,
+						     tlvs[i],
+						     &blinding_iter,
+						     &path->path[i]->blinded_node_id);
+	}
+
+	return path;
+}
+
+/* Stage 2: turn struct blinded_path into array of tlv_onionmsg_tlv.
+ * You normally then add fields to the final tlv_onionmsg_tlv. */
+struct tlv_onionmsg_tlv **onionmsg_tlvs_from_blinded_path(const tal_t *ctx,
+							  const struct blinded_path *bpath)
+{
+	size_t nhops = tal_count(bpath->path);
+	struct tlv_onionmsg_tlv **otlvs = tal_arr(ctx, struct tlv_onionmsg_tlv *, nhops);
+
+	for (size_t i = 0; i < nhops; i++) {
+		otlvs[i] = tlv_onionmsg_tlv_new(otlvs);
+		otlvs[i]->encrypted_recipient_data
+			= tal_dup_talarr(otlvs[i], u8,
+					 bpath->path[i]->encrypted_recipient_data);
+	}
+
+	return otlvs;
+}
+
+/* Stage 3: linearize each struct tlv_onionmsg_tlv into sphinx_hops (taking ids from bpath) */
+struct sphinx_hop **onionmsg_tlvs_to_hops(const tal_t *ctx,
+					  const struct blinded_path *bpath,
+					  const struct tlv_onionmsg_tlv **tlvs)
+{
+	size_t nhops = tal_count(tlvs);
+	struct sphinx_hop **hops = tal_arr(ctx, struct sphinx_hop *, nhops);
+
+	assert(tal_count(bpath->path) == nhops);
+	for (size_t i = 0; i < nhops; i++) {
+		u8 *payload;
+		hops[i] = tal(hops, struct sphinx_hop);
+		hops[i]->pubkey = bpath->path[i]->blinded_node_id;
+		/* We use a temporary here since ->raw_payload is const */
+		payload = tal_arr(hops[i], u8, 0);
+		towire_tlv_onionmsg_tlv(&payload, tlvs[i]);
+		hops[i]->raw_payload = payload;
+	}
+
+	return hops;
+}
+
+struct blinded_path *incoming_message_blinded_path(const tal_t *ctx,
+						   const struct pubkey *ids,
+						   const struct short_channel_id **scids,
+						   const struct secret *path_secret)
+{
+	struct tlv_encrypted_data_tlv **etlvs;
+	size_t nhops = tal_count(ids);
+
+	assert(nhops > 0);
+	etlvs = new_encdata_tlvs(tmpctx, ids, scids);
+
+	/* Put path_secret into final hop (us) */
+	etlvs[nhops-1]->path_id = tal_dup_arr(etlvs[nhops-1], u8,
+					      path_secret->data,
+					      ARRAY_SIZE(path_secret->data), 0);
+
+	return blinded_path_from_encdata_tlvs(ctx,
+					      cast_const2(const struct tlv_encrypted_data_tlv **, etlvs),
+					      ids);
+}
+
+static void extend_blinded_path(struct blinded_path *bpath,
+				const struct onionmsg_hop *hop)
+{
+	struct onionmsg_hop *newhop = tal(bpath->path, struct onionmsg_hop);
+        newhop->blinded_node_id = hop->blinded_node_id;
+	newhop->encrypted_recipient_data = tal_dup_talarr(newhop, u8, hop->encrypted_recipient_data);
+	tal_arr_expand(&bpath->path, newhop);
+}
+
+struct onion_message *outgoing_onion_message(const tal_t *ctx,
+					     const struct pubkey *ids,
+					     const struct short_channel_id **scids,
+					     const struct blinded_path *their_path,
+					     struct tlv_onionmsg_tlv *final_tlv STEALS)
+{
+	struct onion_message *omsg;
+	struct blinded_path *our_path;
+	const struct blinded_path *combined_path;
+	struct tlv_encrypted_data_tlv **etlvs = new_encdata_tlvs(tmpctx, ids, scids);
+	struct tlv_onionmsg_tlv **otlvs;
+
+	assert(tal_count(ids) > 0);
+
+	if (their_path) {
+		struct tlv_encrypted_data_tlv *pre_final;
+
+		/* Path must lead to blinded path! */
+		if (their_path->first_node_id.is_pubkey)
+			assert(pubkey_eq(&ids[tal_count(ids)-1], &their_path->first_node_id.pubkey));
+
+		/* If we don't actually have any path, it's all them. */
+		if (tal_count(ids) == 1) {
+			combined_path = their_path;
+			goto wrap;
+		}
+
+		/* We need to tell last hop to hand blinded_path blinding for next hop */
+		pre_final = etlvs[tal_count(ids)-2];
+		pre_final->next_blinding_override = tal_dup(pre_final,
+							    struct pubkey,
+							    &their_path->blinding);
+	}
+
+	our_path = blinded_path_from_encdata_tlvs(tmpctx,
+						  cast_const2(const struct tlv_encrypted_data_tlv **, etlvs),
+						  ids);
+
+	/* Extend with their blinded path if there is one */
+	if (their_path) {
+		/* Remove final one, since it's actually the first one in blinded path. */
+		tal_resize(&our_path->path, tal_count(our_path->path)-1);
+		for (size_t i = 0; i < tal_count(their_path->path); i++)
+			extend_blinded_path(our_path, their_path->path[i]);
+	}
+
+	combined_path = our_path;
+
+wrap:
+	/* Now wrap in onionmsg_tlvs */
+	otlvs = onionmsg_tlvs_from_blinded_path(tmpctx, combined_path);
+
+	/* Transfer encrypted blob into final tlv, and use it to replace last tlv */
+	final_tlv->encrypted_recipient_data = tal_steal(final_tlv, otlvs[tal_count(otlvs)-1]->encrypted_recipient_data);
+	tal_free(otlvs[tal_count(otlvs)-1]);
+	otlvs[tal_count(otlvs)-1] = tal_steal(otlvs, final_tlv);
+
+	/* Now populate the onion message to return */
+	omsg = tal(ctx, struct onion_message);
+	omsg->first_blinding = combined_path->blinding;
+	omsg->hops = onionmsg_tlvs_to_hops(omsg, combined_path,
+					   cast_const2(const struct tlv_onionmsg_tlv **, otlvs));
+	return omsg;
+}

--- a/common/onion_message.h
+++ b/common/onion_message.h
@@ -1,0 +1,130 @@
+#ifndef LIGHTNING_COMMON_ONION_MESSAGE_H
+#define LIGHTNING_COMMON_ONION_MESSAGE_H
+#include "config.h"
+#include <ccan/tal/tal.h>
+#include <common/sciddir_or_pubkey.h>
+#include <common/utils.h>
+
+struct tlv_onionmsg_tlv;
+struct secret;
+
+/* Onion messages are kind of complicated, so read carefully!
+ *
+ * An onion message is an array of struct tlv_onionmsg_tlv:
+ * encrypted struct tlv_encrypted_data_tlv:
+ *	encrypted_recipient_data
+ *
+ * The final entry can also have unencrypted fields:
+ * 	struct blinded_path *reply_path;
+ *	u8 *invoice_request;
+ *	u8 *invoice;
+ *	u8 *invoice_error;
+ *
+ * The struct tlv_encrypted_data_tlv contains the interesting things:
+ *
+ * Intermediate nodes:
+ *	short_channel_id/next_node_id (always)
+ *	next_blinding_override (optional)
+ *	payment_relay/payment_constraints (required, for payments only)
+ *	allowed_features (optional)
+ *
+ * Final nodes:
+ *      path_id (so it can tell blinded path was correctly used).
+ */
+
+/* Low level routines: */
+
+/**
+ * Stage 0: populate tlv_encrypted_data_tlv[] array.
+ * @ctx: tal context
+ * @ids: array of pubkeys defining path destinations
+ * @scids: optional array of scids: if non-NULL, use this instead of pubkey for
+ *         next hop values.
+ *
+ * This simply populates the short_channel_id/next_node_id fields; you will want to
+ * add others.
+ */
+struct tlv_encrypted_data_tlv **new_encdata_tlvs(const tal_t *ctx,
+						 const struct pubkey *ids,
+						 const struct short_channel_id **scids);
+
+/**
+ * Stage 1: tlv_encrypted_data_tlv[] -> struct blinded_path.
+ * @ctx: tal context
+ * @tlvs: tlvs to be encrypted
+ * @ids: array of pubkeys.
+ *
+ * ids[0] needs to be first node id, but rest don't have to be there unless
+ * a tlv uses short_channel_id instead of next_node_id.
+ *
+ * You can turn the first_node_id into an scidd after if you want to.
+ */
+struct blinded_path *blinded_path_from_encdata_tlvs(const tal_t *ctx,
+						    const struct tlv_encrypted_data_tlv **tlvs,
+						    const struct pubkey *ids);
+
+/**
+ * Stage 2: turn struct blinded_path into array of tlv_onionmsg_tlv.
+ * @ctx: tal context
+ * @bpath: path containing the encrypted blobs.
+ *
+ * You normally then add payload fields to the final tlv_onionmsg_tlv.
+ */
+struct tlv_onionmsg_tlv **onionmsg_tlvs_from_blinded_path(const tal_t *ctx,
+							  const struct blinded_path *bpath);
+
+/**
+ * Stage 3: linearize each struct tlv_onionmsg_tlv into onionmsg_hops
+ * @ctx: tal context
+ * @bpath: the path (for the pubkeys)
+ * @tlvs: the tlvs for each hop.
+ *
+ * This is the format the sphinx wants to encode the actual onion message.
+ */
+struct sphinx_hop **onionmsg_tlvs_to_hops(const tal_t *ctx,
+					  const struct blinded_path *bpath,
+					  const struct tlv_onionmsg_tlv **tlvs);
+
+
+/* Stage 4: turn into sphinx_hop * into linear onionmsg (e.g. via injectonionmessage,
+ * or directly using common/sphinx.c) */
+
+/* Higher level helpers. */
+
+/**
+ * incoming_message_blinded_path - create incoming blinded path for messages.
+ * @ctx: context to tallocate off
+ * @ids: array of node ids.
+ * @scids: optional, if these are set, use these for directions instead of node ids.
+ * @path_secret: put this into final entry, so we can verify.
+ */
+struct blinded_path *incoming_message_blinded_path(const tal_t *ctx,
+						   const struct pubkey *ids,
+						   const struct short_channel_id **scids,
+						   const struct secret *path_secret);
+
+
+/* A ready-to-be-encrypted-and-sent onion message. */
+struct onion_message {
+	struct pubkey first_blinding;
+	struct sphinx_hop **hops;
+};
+
+/**
+ * outgoing_message_tlvs - create encrypted blobs to send msg
+ * @ctx: context to tallocate off
+ * @ids: array of node ids (first is our peer, must be at least one).
+ * @scids: optional, if these are set, use these for directions instead of node ids.
+ * @their_path: blinded path they told us to use for reply (or NULL)
+ * @final_tlv: extra fields to put in final tlv (consumed)
+ *
+ * If @their_path is set, the final @ids entry must be @their_path->first_node_id.
+ * We cannot check this if their_path->first_node_id is not a pubkey, of course.
+ */
+struct onion_message *outgoing_onion_message(const tal_t *ctx,
+					     const struct pubkey *ids,
+					     const struct short_channel_id **scids,
+					     const struct blinded_path *their_path,
+					     struct tlv_onionmsg_tlv *final_tlv STEALS);
+
+#endif /* LIGHTNING_COMMON_ONION_MESSAGE_H */

--- a/common/test/run-bolt12-offer-decode.c
+++ b/common/test/run-bolt12-offer-decode.c
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt12/offers-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-bolt12_decode.c
+++ b/common/test/run-bolt12_decode.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt12/format-string-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-bolt12_merkle-json.c
+++ b/common/test/run-bolt12_merkle-json.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt12/merkle-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-bolt12_period.c
+++ b/common/test/run-bolt12_period.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt12/offer-period-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-onion-test-vector.c
+++ b/common/test/run-onion-test-vector.c
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt04/onion-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-route_blinding_onion_test.c
+++ b/common/test/run-route_blinding_onion_test.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt04/blinded-payment-onion-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/common/test/run-route_blinding_test.c
+++ b/common/test/run-route_blinding_test.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 		char *dir = getenv("BOLTDIR");
 		json = grab_file(tmpctx,
 				 path_join(tmpctx,
-					   dir ? dir : "../bolts",
+					   dir ? dir : ".tmp.lightningrfc",
 					   "bolt04/route-blinding-test.json"));
 		if (!json) {
 			printf("test file not found, skipping\n");

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -31,13 +31,9 @@ PLUGIN_PAY_LIB_SRC := plugins/libplugin-pay.c
 PLUGIN_PAY_LIB_HEADER := plugins/libplugin-pay.h
 PLUGIN_PAY_LIB_OBJS := $(PLUGIN_PAY_LIB_SRC:.c=.o)
 
-PLUGIN_OFFERS_SRC := plugins/offers.c plugins/offers_offer.c plugins/offers_invreq_hook.c plugins/offers_inv_hook.c plugins/establish_onion_path.c
+PLUGIN_OFFERS_SRC := plugins/offers.c plugins/offers_offer.c plugins/offers_invreq_hook.c plugins/offers_inv_hook.c plugins/establish_onion_path.c plugins/fetchinvoice.c
 PLUGIN_OFFERS_OBJS := $(PLUGIN_OFFERS_SRC:.c=.o)
 PLUGIN_OFFERS_HEADER := $(PLUGIN_OFFERS_SRC:.c=.h)
-
-PLUGIN_FETCHINVOICE_SRC := plugins/fetchinvoice.c plugins/establish_onion_path.c
-PLUGIN_FETCHINVOICE_OBJS := $(PLUGIN_FETCHINVOICE_SRC:.c=.o)
-PLUGIN_FETCHINVOICE_HEADER :=
 
 PLUGIN_SQL_SRC := plugins/sql.c
 PLUGIN_SQL_HEADER :=
@@ -72,7 +68,6 @@ PLUGIN_ALL_SRC :=				\
 	$(PLUGIN_chanbackup_SRC)		\
 	$(PLUGIN_BCLI_SRC)			\
 	$(PLUGIN_COMMANDO_SRC)			\
-	$(PLUGIN_FETCHINVOICE_SRC)		\
 	$(PLUGIN_FUNDER_SRC)			\
 	$(PLUGIN_TOPOLOGY_SRC)			\
 	$(PLUGIN_KEYSEND_SRC)			\
@@ -97,7 +92,6 @@ C_PLUGINS :=					\
 	plugins/chanbackup			\
 	plugins/bcli				\
 	plugins/commando			\
-	plugins/fetchinvoice			\
 	plugins/funder				\
 	plugins/topology			\
 	plugins/keysend				\
@@ -215,8 +209,6 @@ $(PLUGIN_KEYSEND_OBJS): $(PLUGIN_PAY_LIB_HEADER)
 plugins/spenderp: bitcoin/block.o bitcoin/preimage.o bitcoin/psbt.o common/psbt_open.o common/json_channel_type.o common/channel_type.o common/features.o wire/peer_wiregen.o $(PLUGIN_SPENDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
 plugins/offers: $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/addr.o common/bolt12.o common/bolt12_merkle.o common/bolt11_json.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o common/blindedpath.o common/invoice_path_id.o common/blinding.o common/hmac.o common/json_blinded_path.o common/gossmap.o common/fp16.o $(JSMN_OBJS) common/dijkstra.o common/route.o common/gossmods_listpeerchannels.o 
-
-plugins/fetchinvoice: $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/bolt12.o common/bolt12_merkle.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o $(JSMN_OBJS) common/gossmap.o common/fp16.o common/dijkstra.o common/route.o common/blindedpath.o common/hmac.o common/blinding.o common/gossmods_listpeerchannels.o
 
 plugins/funder: bitcoin/psbt.o common/psbt_open.o $(PLUGIN_FUNDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -208,7 +208,7 @@ $(PLUGIN_KEYSEND_OBJS): $(PLUGIN_PAY_LIB_HEADER)
 
 plugins/spenderp: bitcoin/block.o bitcoin/preimage.o bitcoin/psbt.o common/psbt_open.o common/json_channel_type.o common/channel_type.o common/features.o wire/peer_wiregen.o $(PLUGIN_SPENDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
-plugins/offers: $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/addr.o common/bolt12.o common/bolt12_merkle.o common/bolt11_json.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o common/blindedpath.o common/invoice_path_id.o common/blinding.o common/hmac.o common/json_blinded_path.o common/gossmap.o common/fp16.o $(JSMN_OBJS) common/dijkstra.o common/route.o common/gossmods_listpeerchannels.o 
+plugins/offers: $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/addr.o common/bolt12.o common/bolt12_merkle.o common/bolt11_json.o common/iso4217.o $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o common/blindedpath.o common/invoice_path_id.o common/blinding.o common/hmac.o common/json_blinded_path.o common/gossmap.o common/fp16.o $(JSMN_OBJS) common/dijkstra.o common/route.o common/gossmods_listpeerchannels.o common/onion_message.o
 
 plugins/funder: bitcoin/psbt.o common/psbt_open.o $(PLUGIN_FUNDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 

--- a/plugins/establish_onion_path.h
+++ b/plugins/establish_onion_path.h
@@ -18,7 +18,7 @@ struct gossmap;
  * @arg: callback argument
  *
  * If it cannot find an onion-message-carrying path, will connect directly,
- * unless connect_disable is non-NULL.
+ * unless connect_disable is non-NULL.  First pubkey is always us.
  */
 struct command_result *establish_onion_path_(struct command *cmd,
 					     struct gossmap *gossmap,

--- a/plugins/fetchinvoice.h
+++ b/plugins/fetchinvoice.h
@@ -1,0 +1,27 @@
+#ifndef LIGHTNING_PLUGINS_FETCHINVOICE_H
+#define LIGHTNING_PLUGINS_FETCHINVOICE_H
+#include "config.h"
+
+struct command_result;
+struct command;
+
+struct command_result *json_fetchinvoice(struct command *cmd,
+					 const char *buffer,
+					 const jsmntok_t *params);
+
+struct command_result *json_sendinvoice(struct command *cmd,
+					const char *buffer,
+					const jsmntok_t *params);
+
+struct command_result *json_dev_rawrequest(struct command *cmd,
+					   const char *buffer,
+					   const jsmntok_t *params);
+
+struct command_result *recv_modern_onion_message(struct command *cmd,
+						 const char *buf,
+						 const jsmntok_t *params);
+struct command_result *invoice_payment(struct command *cmd,
+				       const char *buf,
+				       const jsmntok_t *params);
+
+#endif /* LIGHTNING_PLUGINS_FETCHINVOICE_H */

--- a/plugins/fetchinvoice.h
+++ b/plugins/fetchinvoice.h
@@ -17,9 +17,13 @@ struct command_result *json_dev_rawrequest(struct command *cmd,
 					   const char *buffer,
 					   const jsmntok_t *params);
 
-struct command_result *recv_modern_onion_message(struct command *cmd,
-						 const char *buf,
-						 const jsmntok_t *params);
+/* Returns NULL if this wasn't one of ours. */
+struct command_result *handle_invoice_onion_message(struct command *cmd,
+						    const char *buf,
+						    const jsmntok_t *om,
+						    const struct secret *pathsecret);
+
+/* invoice_payment hook */
 struct command_result *invoice_payment(struct command *cmd,
 				       const char *buf,
 				       const jsmntok_t *params);

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -36,6 +36,7 @@ u16 cltv_final;
 bool offers_enabled;
 bool disable_connect;
 struct secret invoicesecret_base;
+struct secret offerblinding_base;
 static struct gossmap *global_gossmap;
 
 static void init_gossmap(struct plugin *plugin)
@@ -1323,6 +1324,11 @@ static const char *init(struct plugin *p,
 		 take(json_out_obj(NULL, "string", INVOICE_PATH_BASE_STRING)),
 		 "{secret:%}",
 		 JSON_SCAN(json_to_secret, &invoicesecret_base));
+
+	rpc_scan(p, "makesecret",
+		 take(json_out_obj(NULL, "string", "offer-blinded-path")),
+		 "{secret:%}",
+		 JSON_SCAN(json_to_secret, &offerblinding_base));
 
 	return NULL;
 }

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -255,7 +255,7 @@ static struct command_result *onion_message_recv(struct command *cmd,
 		if (reply_path)
 			return handle_invoice_request(cmd,
 						      invreqbin,
-						      reply_path);
+						      reply_path, secret);
 		else
 			plugin_log(cmd->plugin, LOG_DBG,
 				   "invoice_request without reply_path");
@@ -265,7 +265,7 @@ static struct command_result *onion_message_recv(struct command *cmd,
 	if (invtok) {
 		const u8 *invbin = json_tok_bin_from_hex(tmpctx, buf, invtok);
 		if (invbin)
-			return handle_invoice(cmd, invbin, reply_path);
+			return handle_invoice(cmd, invbin, reply_path, secret);
 	}
 
 	return command_hook_success(cmd);

--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -17,8 +17,13 @@ extern bool disable_connect;
 extern u16 cltv_final;
 /* Current header_count */
 extern u32 blockheight;
-/* Basis for invoice secrets */
+/* Basis for invoice path_secrets */
 extern struct secret invoicesecret_base;
+/* Base for offers path_secrets */
+extern struct secret offerblinding_base;
+
+/* This is me. */
+extern struct pubkey id;
 
 /* If they give us an scid, do a lookup */
 bool convert_to_scidd(struct command *cmd,

--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -4,6 +4,20 @@
 
 struct command_result;
 struct command;
+struct plugin;
+
+/* This is me. */
+extern struct pubkey id;
+/* Are offers enabled? */
+extern bool offers_enabled;
+/* --fetchinvoice-noconnect */
+extern bool disable_connect;
+/* --cltv-final */
+extern u16 cltv_final;
+/* Current header_count */
+extern u32 blockheight;
+/* Basis for invoice secrets */
+extern struct secret invoicesecret_base;
 
 /* If they give us an scid, do a lookup */
 bool convert_to_scidd(struct command *cmd,
@@ -14,4 +28,7 @@ struct command_result *WARN_UNUSED_RESULT
 send_onion_reply(struct command *cmd,
 		 struct blinded_path *reply_path,
 		 struct tlv_onionmsg_tlv *payload);
+
+/* Get the (latest) gossmap */
+struct gossmap *get_gossmap(struct plugin *plugin);
 #endif /* LIGHTNING_PLUGINS_OFFERS_H */

--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -4,6 +4,7 @@
 
 struct command_result;
 struct command;
+struct onion_message;
 struct plugin;
 
 /* This is me. */
@@ -28,6 +29,34 @@ struct command_result *WARN_UNUSED_RESULT
 send_onion_reply(struct command *cmd,
 		 struct blinded_path *reply_path,
 		 struct tlv_onionmsg_tlv *payload);
+
+/* Helper to send an onion message */
+#define inject_onionmessage(cmd, omsg, success, fail, arg)		\
+	inject_onionmessage_((cmd), (omsg),				\
+			     typesafe_cb_preargs(struct command_result *, void *, \
+						 (success), (arg),	\
+						 struct command *,	\
+						 const char *,		\
+						 const jsmntok_t *),	\
+			     typesafe_cb_preargs(struct command_result *, void *, \
+						 (fail), (arg),		\
+						 struct command *,	\
+						 const char *,		\
+						 const jsmntok_t *),	\
+			     (arg))
+
+struct command_result *
+inject_onionmessage_(struct command *cmd,
+		     const struct onion_message *omsg,
+		     struct command_result *(*cb)(struct command *command,
+						  const char *buf,
+						  const jsmntok_t *result,
+						  void *arg),
+		     struct command_result *(*errcb)(struct command *command,
+						     const char *buf,
+						     const jsmntok_t *result,
+						     void *arg),
+		     void *arg);
 
 /* Get the (latest) gossmap */
 struct gossmap *get_gossmap(struct plugin *plugin);

--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -24,7 +24,7 @@ extern struct secret invoicesecret_base;
 bool convert_to_scidd(struct command *cmd,
 		      struct sciddir_or_pubkey *sciddpk);
 
-/* Helper to send a reply */
+/* Helper to send a reply (connecting if required), and discard result */
 struct command_result *WARN_UNUSED_RESULT
 send_onion_reply(struct command *cmd,
 		 struct blinded_path *reply_path,

--- a/plugins/offers_inv_hook.c
+++ b/plugins/offers_inv_hook.c
@@ -47,12 +47,13 @@ fail_inv_level(struct command *cmd,
 	if (l == LOG_BROKEN)
 		msg = "Internal error";
 
+	/* Get path (maybe connect) to send reply */
 	err = tlv_invoice_error_new(cmd);
 	/* Remove NUL terminator */
 	err->error = tal_dup_arr(err, char, msg, strlen(msg), 0);
 	/* FIXME: Add suggested_value / erroneous_field! */
 
-	payload = tlv_onionmsg_tlv_new(tmpctx);
+	payload = tlv_onionmsg_tlv_new(NULL);
 	payload->invoice_error = tal_arr(payload, u8, 0);
 	towire_tlv_invoice_error(&payload->invoice_error, err);
 	return send_onion_reply(cmd, inv->reply_path, payload);

--- a/plugins/offers_inv_hook.h
+++ b/plugins/offers_inv_hook.h
@@ -6,6 +6,7 @@
 /* We got an onionmessage with an invoice!  reply_path could be NULL. */
 struct command_result *handle_invoice(struct command *cmd,
 				      const u8 *invbin,
-				      struct blinded_path *reply_path STEALS);
+				      struct blinded_path *reply_path STEALS,
+				      const struct secret *secret);
 
 #endif /* LIGHTNING_PLUGINS_OFFERS_INV_HOOK_H */

--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -19,8 +19,6 @@
 #include <secp256k1_schnorrsig.h>
 #include <sodium.h>
 
-static struct gossmap *global_gossmap;
-
 /* We need to keep the reply path around so we can reply with invoice */
 struct invreq {
 	struct tlv_invoice_request *invreq;
@@ -99,31 +97,6 @@ fail_internalerr(struct command *cmd,
 	va_end(ap);
 
 	return ret;
-}
-
-static void init_gossmap(struct plugin *plugin)
-{
-	size_t num_cupdates_rejected;
-	global_gossmap
-		= notleak_with_children(gossmap_load(NULL,
-						     GOSSIP_STORE_FILENAME,
-						     &num_cupdates_rejected));
-	if (!global_gossmap)
-		plugin_err(plugin, "Could not load gossmap %s: %s",
-			   GOSSIP_STORE_FILENAME, strerror(errno));
-	if (num_cupdates_rejected)
-		plugin_log(plugin, LOG_DBG,
-			   "gossmap ignored %zu channel updates",
-			   num_cupdates_rejected);
-}
-
-static struct gossmap *get_gossmap(struct plugin *plugin)
-{
-	if (!global_gossmap)
-		init_gossmap(plugin);
-	else
-		gossmap_refresh(global_gossmap, NULL);
-	return global_gossmap;
 }
 
 #define invreq_must_have(cmd_, ir_, fld_)				\

--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -187,7 +187,7 @@ static struct command_result *createinvoice_done(struct command *cmd,
 	}
 
 	payload = tlv_onionmsg_tlv_new(tmpctx);
-	payload->invoice = rawinv;
+	payload->invoice = tal_steal(payload, rawinv);
 	return send_onion_reply(cmd, ir->reply_path, payload);
 }
 

--- a/plugins/offers_invreq_hook.h
+++ b/plugins/offers_invreq_hook.h
@@ -3,12 +3,6 @@
 #include "config.h"
 #include <plugins/libplugin.h>
 
-extern u16 cltv_final;
-extern u32 blockheight;
-extern struct secret invoicesecret_base;
-extern struct pubkey id;
-extern bool disable_connect;
-
 /* We got an onionmessage with an invreq! */
 struct command_result *handle_invoice_request(struct command *cmd,
 					      const u8 *invreqbin,

--- a/plugins/offers_invreq_hook.h
+++ b/plugins/offers_invreq_hook.h
@@ -6,5 +6,6 @@
 /* We got an onionmessage with an invreq! */
 struct command_result *handle_invoice_request(struct command *cmd,
 					      const u8 *invreqbin,
-					      struct blinded_path *reply_path STEALS);
+					      struct blinded_path *reply_path STEALS,
+					      const struct secret *secret TAKES);
 #endif /* LIGHTNING_PLUGINS_OFFERS_INVREQ_HOOK_H */

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -7,6 +7,7 @@
 #include <common/json_param.h>
 #include <common/json_stream.h>
 #include <common/overflows.h>
+#include <plugins/offers.h>
 #include <plugins/offers_offer.h>
 #include <sodium/randombytes.h>
 

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -3,9 +3,11 @@
 #include <ccan/array_size/array_size.h>
 #include <ccan/tal/str/str.h>
 #include <common/bolt12.h>
+#include <common/invoice_path_id.h>
 #include <common/iso4217.h>
 #include <common/json_param.h>
 #include <common/json_stream.h>
+#include <common/onion_message.h>
 #include <common/overflows.h>
 #include <plugins/offers.h>
 #include <plugins/offers_offer.h>
@@ -286,6 +288,105 @@ static struct command_result *currency_done(struct command *cmd,
 	return create_offer(cmd, offinfo);
 }
 
+static bool json_to_short_channel_id_dir(const char *buffer, const jsmntok_t *tok,
+					 struct short_channel_id_dir *scidd)
+{
+	jsmntok_t scidtok, numtok;
+	u32 dir;
+
+	if (!split_tok(buffer, tok, '/', &scidtok, &numtok))
+		return false;
+
+	if (!json_to_short_channel_id(buffer, &scidtok, &scidd->scid))
+		return false;
+
+	if (!json_to_u32(buffer, &numtok, &dir) || (dir > 1))
+		return false;
+
+	scidd->dir = dir;
+	return true;
+}
+
+static bool json_to_sciddir_or_pubkey(const char *buffer, const jsmntok_t *tok,
+				      struct sciddir_or_pubkey *sciddir_or_pubkey)
+{
+	struct pubkey pk;
+	struct short_channel_id_dir scidd;
+
+	if (json_to_pubkey(buffer, tok, &pk)) {
+		sciddir_or_pubkey_from_pubkey(sciddir_or_pubkey, &pk);
+		return true;
+	} else if (json_to_short_channel_id_dir(buffer, tok, &scidd)) {
+		sciddir_or_pubkey_from_scidd(sciddir_or_pubkey, &scidd);
+		return true;
+	}
+
+	return false;
+}
+
+struct path {
+	/* Optional: a scid as the entry point */
+	struct short_channel_id_dir *first_scidd;
+	/* A node id for every element on the path */
+	struct pubkey *path;
+};
+
+static struct command_result *param_paths(struct command *cmd, const char *name,
+					  const char *buffer, const jsmntok_t *tok,
+					  struct path ***paths)
+{
+	size_t i;
+	const jsmntok_t *t;
+
+	if (tok->type != JSMN_ARRAY)
+		return command_fail_badparam(cmd, name, buffer, tok, "Must be array");
+
+	*paths = tal_arr(cmd, struct path *, tok->size);
+	json_for_each_arr(i, t, tok) {
+		size_t j;
+		const jsmntok_t *p;
+
+		if (t->type != JSMN_ARRAY || t->size == 0) {
+			return command_fail_badparam(cmd, name, buffer, t,
+						     "Must be array of non-empty arrays");
+		}
+
+		(*paths)[i] = tal(*paths, struct path);
+		(*paths)[i]->path = tal_arr((*paths)[i], struct pubkey, t->size);
+		json_for_each_arr(j, p, t) {
+			struct pubkey pk;
+			if (j == 0) {
+				struct sciddir_or_pubkey init;
+				if (!json_to_sciddir_or_pubkey(buffer, p, &init)) {
+					return command_fail_badparam(cmd, name, buffer, p,
+								     "invalid pubkey/sciddir");
+				}
+				if (!init.is_pubkey) {
+					(*paths)[i]->first_scidd = tal_dup((*paths)[i],
+									  struct short_channel_id_dir,
+									  &init.scidd);
+					if (!convert_to_scidd(cmd, &init))
+						return command_fail_badparam(cmd, name, buffer, p,
+									     "unknown sciddir");
+				} else {
+					(*paths)[i]->first_scidd = NULL;
+				}
+				pk = init.pubkey;
+			} else {
+				if (!json_to_pubkey(buffer, p, &pk)) {
+					return command_fail_badparam(cmd, name, buffer, p,
+								     "invalid pubkey");
+				}
+			}
+			if (j == t->size - 1 && !pubkey_eq(&pk, &id))
+				return command_fail_badparam(cmd, name, buffer, p,
+							     "final pubkey must be this node");
+			(*paths)[i]->path[j] = pk;
+		}
+	}
+	return NULL;
+}
+
 struct command_result *json_offer(struct command *cmd,
 				  const char *buffer,
 				  const jsmntok_t *params)
@@ -293,6 +394,7 @@ struct command_result *json_offer(struct command *cmd,
 	const char *desc, *issuer;
 	struct tlv_offer *offer;
 	struct offer_info *offinfo = tal(cmd, struct offer_info);
+	struct path **paths;
 
 	offinfo->offer = offer = tlv_offer_new(offinfo);
 
@@ -318,7 +420,7 @@ struct command_result *json_offer(struct command *cmd,
 		   p_opt("recurrence_start_any_period",
 			 param_recurrence_start_any_period,
 			 &offer->offer_recurrence_base),
-		   /* FIXME: hints support! */
+		   p_opt("dev_paths", param_paths, &paths),
 		   NULL))
 		return command_param_failed();
 
@@ -388,6 +490,32 @@ struct command_result *json_offer(struct command *cmd,
 	 *   invoice from.
 	 */
 	offer->offer_node_id = tal_dup(offer, struct pubkey, &id);
+
+	/* Now rest of offer will not change: we use pathless offer to create secret. */
+	if (paths) {
+		const u8 *path_secret;
+		struct secret blinding_path_secret;
+		struct sha256 offer_id;
+		/* Note: "id" of offer minus paths */
+		offer_offer_id(offer, &offer_id);
+
+		/* We can check this when they try to take up offer. */
+		path_secret = invoice_path_id(tmpctx, &offerblinding_base, &offer_id);
+		assert(tal_count(path_secret) == sizeof(blinding_path_secret));
+		memcpy(&blinding_path_secret, path_secret, sizeof(blinding_path_secret));
+
+		offer->offer_paths = tal_arr(offer, struct blinded_path *, tal_count(paths));
+		for (size_t i = 0; i < tal_count(paths); i++) {
+			offer->offer_paths[i] = incoming_message_blinded_path(offer->offer_paths,
+									      paths[i]->path,
+									      NULL,
+									      &blinding_path_secret);
+			/* Override entry point if they said to */
+			if (paths[i]->first_scidd)
+				sciddir_or_pubkey_from_scidd(&offer->offer_paths[i]->first_node_id,
+							     paths[i]->first_scidd);
+		}
+	}
 
 	/* If they specify a different currency, warn if we can't
 	 * convert it! */

--- a/plugins/offers_offer.h
+++ b/plugins/offers_offer.h
@@ -3,9 +3,6 @@
 #include "config.h"
 #include <plugins/libplugin.h>
 
-extern struct pubkey id;
-extern bool offers_enabled;
-
 struct command_result *json_offer(struct command *cmd,
 				  const char *buffer,
 				  const jsmntok_t *params);

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5674,22 +5674,59 @@ def test_pay_while_opening_channel(node_factory, bitcoind, executor):
     l1.rpc.pay(inv['bolt11'])
 
 
-def test_offer_paths(node_factory):
+def test_offer_paths(node_factory, bitcoind):
+    opts = {'experimental-offers': None,
+            'dev-allow-localhost': None}
+
     # Need to announce channels to use their scid in offers anyway!
-    l1, l2, l3 = node_factory.line_graph(3,
-                                         opts={'experimental-offers': None},
-                                         wait_for_announce=True)
+    l1, l2, l3, l4 = node_factory.line_graph(4,
+                                             opts=opts,
+                                             wait_for_announce=True)
 
     chan = only_one(l1.rpc.listpeerchannels()['channels'])
     scidd = "{}/{}".format(chan['short_channel_id'], chan['direction'])
     offer = l2.rpc.offer(amount='100sat', description='test_offer_paths',
-                         dev_paths=[[scidd, l2.info['id']], [l3.info['id'], l2.info['id']]])
+                         dev_paths=[[scidd, l2.info['id']],
+                                    [l3.info['id'], l2.info['id']]])
 
     paths = l1.rpc.decode(offer['bolt12'])['offer_paths']
     assert len(paths) == 2
     assert paths[0]['first_scid'] == chan['short_channel_id']
     assert paths[0]['first_scid_dir'] == chan['direction']
     assert paths[1]['first_node_id'] == l3.info['id']
+
+    l5 = node_factory.get_node(options=opts)
+
+    # Get all the gossip, so we have addresses
+    l5.rpc.connect(l1.info['id'], 'localhost', l1.port)
+    wait_for(lambda: len(l5.rpc.listnodes()['nodes']) == 4 and all(['addresses' in n for n in l5.rpc.listnodes()['nodes']]))
+
+    # We have a path ->l1 (head of blinded path), so we can use that without connecting.
+    l5.rpc.fetchinvoice(offer=offer['bolt12'])
+    assert not l5.daemon.is_in_log('connecting directly to')
+
+    # Make scid path invalid by closing it
+    close = l1.rpc.close(paths[0]['first_scid'])
+    bitcoind.generate_block(13, wait_for_mempool=close['txid'])
+    wait_for(lambda: l5.rpc.listchannels(paths[0]['first_scid']) == {'channels': []})
+
+    # Now connect l5->l4, and it will be able to reach l3 via that, and join blinded path.
+    l5.rpc.connect(l4.info['id'], 'localhost', l4.port)
+    l5.rpc.fetchinvoice(offer=offer['bolt12'])
+    assert not l5.daemon.is_in_log('connecting')
+
+    # This will make us connect straight to l3 to use blinded path from there.
+    l5.rpc.disconnect(l4.info['id'])
+    l5.rpc.fetchinvoice(offer=offer['bolt12'])
+    assert l5.daemon.is_in_log('connecting')
+
+    # Restart l5 with fetchinvoice-noconnect and it will fail.
+    l5.stop()
+    l5.daemon.opts['fetchinvoice-noconnect'] = None
+    l5.start()
+
+    with pytest.raises(RpcError, match=f"Failed: could not route or connect directly to blinded path at {l3.info['id']}: fetchinvoice-noconnect set: not initiating a new connection"):
+        l5.rpc.fetchinvoice(offer=offer['bolt12'])
 
 
 def test_pay_legacy_forward(node_factory, bitcoind, executor):

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4246,6 +4246,7 @@ def test_mpp_overload_payee(node_factory, bitcoind):
     l1.rpc.pay(inv)
 
 
+@unittest.skipIf(TEST_NETWORK != 'regtest', "Canned offer is network specific")
 def test_offer_needs_option(node_factory):
     """Make sure we don't make offers without offer command"""
     l1 = node_factory.get_node()
@@ -4254,8 +4255,8 @@ def test_offer_needs_option(node_factory):
     with pytest.raises(RpcError, match='experimental-offers not enabled'):
         l1.rpc.call('invoicerequest', {'amount': '2msat',
                                        'description': 'simple test'})
-    with pytest.raises(RpcError, match='Unknown command'):
-        l1.rpc.call('fetchinvoice', {'offer': 'aaaa'})
+    with pytest.raises(RpcError, match='experimental-offers not enabled'):
+        l1.rpc.call('fetchinvoice', {'offer': 'lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqyqs5pr5v4ehg93pqfnwgkvdr57yzh6h92zg3qctvrm7w38djg67kzcm4yeg8vc4cq63s'})
 
     # Decode still works though
     assert l1.rpc.decode('lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqyqs5pr5v4ehg93pqfnwgkvdr57yzh6h92zg3qctvrm7w38djg67kzcm4yeg8vc4cq63s')['valid']

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5674,6 +5674,24 @@ def test_pay_while_opening_channel(node_factory, bitcoind, executor):
     l1.rpc.pay(inv['bolt11'])
 
 
+def test_offer_paths(node_factory):
+    # Need to announce channels to use their scid in offers anyway!
+    l1, l2, l3 = node_factory.line_graph(3,
+                                         opts={'experimental-offers': None},
+                                         wait_for_announce=True)
+
+    chan = only_one(l1.rpc.listpeerchannels()['channels'])
+    scidd = "{}/{}".format(chan['short_channel_id'], chan['direction'])
+    offer = l2.rpc.offer(amount='100sat', description='test_offer_paths',
+                         dev_paths=[[scidd, l2.info['id']], [l3.info['id'], l2.info['id']]])
+
+    paths = l1.rpc.decode(offer['bolt12'])['offer_paths']
+    assert len(paths) == 2
+    assert paths[0]['first_scid'] == chan['short_channel_id']
+    assert paths[0]['first_scid_dir'] == chan['direction']
+    assert paths[1]['first_node_id'] == l3.info['id']
+
+
 def test_pay_legacy_forward(node_factory, bitcoind, executor):
     """We removed legacy in 22.11, and LND will still send them for
     route hints!  See


### PR DESCRIPTION
~(Based on #7455)~ Merged!

We unify our onion_message construction routines and use them with the new "injectonionmessage" RPC.  This means we properly support routing where the start of the blinded path is not an immediate peer, which will happen more as the network of onion-message-enabled nodes expands.

We also, finally, add support for offers which use blinded paths, though we don't create them ourselves (except via a dev parameter for testing).
