### PR TITLE
plugins/sql: allow datetime functions

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -28469,6 +28469,9 @@
         "* avg",
         "* coalesce",
         "* count",
+        "* date",
+        "* datetime",
+        "* julianday",
         "* hex",
         "* quote",
         "* length",
@@ -28477,8 +28480,12 @@
         "* upper",
         "* min",
         "* max",
+        "* strftime",
         "* sum",
-        "* total"
+        "* time",
+        "* timediff",
+        "* total",
+        "* unixepoch"
       ],
       "tables": [
         "Note that the first column of every table is a unique integer called `rowid`: this is used for related tables to refer to specific rows in their parent. sqlite3 usually has this as an implicit column, but we make it explicit as the implicit version is not allowed to be used as a foreign key.",

--- a/doc/schemas/lightning-sql-template.json
+++ b/doc/schemas/lightning-sql-template.json
@@ -90,6 +90,9 @@
     "* avg",
     "* coalesce",
     "* count",
+    "* date",
+    "* datetime",
+    "* julianday",
     "* hex",
     "* quote",
     "* length",
@@ -98,8 +101,12 @@
     "* upper",
     "* min",
     "* max",
+    "* strftime",
     "* sum",
-    "* total"
+    "* time",
+    "* timediff",
+    "* total",
+    "* unixepoch"
   ],
   "tables": [
     "Note that the first column of every table is a unique integer called `rowid`: this is used for related tables to refer to specific rows in their parent. sqlite3 usually has this as an implicit column, but we make it explicit as the implicit version is not allowed to be used as a foreign key.",

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -334,6 +334,20 @@ static int sqlite_authorize(void *dbq_, int code,
 			return SQLITE_OK;
 		if (streq(b, "total"))
 			return SQLITE_OK;
+		if (streq(b, "date"))
+			return SQLITE_OK;
+		if (streq(b, "datetime"))
+			return SQLITE_OK;
+		if (streq(b, "julianday"))
+			return SQLITE_OK;
+		if (streq(b, "strftime"))
+			return SQLITE_OK;
+		if (streq(b, "time"))
+			return SQLITE_OK;
+		if (streq(b, "timediff"))
+			return SQLITE_OK;
+		if (streq(b, "unixepoch"))
+			return SQLITE_OK;
 	}
 
 	/* See https://www.sqlite.org/c3ref/c_alter_table.html to decode these! */


### PR DESCRIPTION
Hi. I'm using the SQL plugin to perform analytics on my node. It would be very useful to be able to use the date/time functions so that only the required data is returned.

I've written some queries to test this change and it works as expected.