### PR TITLE
build: disable-grpc flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,8 +367,10 @@ ifneq ($(FUZZING),0)
 endif
 ifneq ($(RUST),0)
 	include cln-rpc/Makefile
+ifneq ($(GRPC),0)
+	include cln-grpc/Makefile
 endif
-include cln-grpc/Makefile
+endif
 
 ifneq ($V,1)
 MSGGEN_ARGS := -s
@@ -377,6 +379,7 @@ endif
 $(MSGGEN_GENALL)&: contrib/msggen/msggen/schema.json
 	@$(call VERBOSE, "msggen $@", PYTHONPATH=contrib/msggen $(PYTHON) contrib/msggen/msggen/__main__.py $(MSGGEN_ARGS) generate)
 
+ifneq ($(GRPC),0)
 # The compiler assumes that the proto files are in the same
 # directory structure as the generated files will be. Since we
 # don't do that we need to path the files up.
@@ -395,6 +398,7 @@ $(GRPC_GEN) &: cln-grpc/proto/node.proto cln-grpc/proto/primitives.proto
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/primitives.proto --python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	find $(GRPC_DIR)/ -type f -name "*.py" -print0 | xargs -0 sed -i'.bak' -e 's/^import \(.*\)_pb2 as .*__pb2/from pyln.grpc import \1_pb2 as \1__pb2/g'
 	find $(GRPC_DIR)/ -type f -name "*.py.bak" -print0 | xargs -0 rm -f
+endif
 
 # We make pretty much everything depend on these.
 ALL_GEN_HEADERS := $(filter %gen.h,$(ALL_C_HEADERS))

--- a/configure
+++ b/configure
@@ -179,6 +179,7 @@ set_defaults()
     VALGRIND=${VALGRIND:-$(default_valgrind_setting)}
     TEST_NETWORK=${TEST_NETWORK:-regtest}
     RUST=${RUST:-$(default_rust_setting)}
+    GRPC=1
 }
 
 usage()
@@ -220,6 +221,8 @@ usage()
     echo "    Compile with fuzzing"
     usage_with_default "--enable/disable-rust" "$RUST" "enable" "disable"
     echo "    Compile with Rust support"
+    usage_with_default "--enable/disable-grpc" "$GRPC" "enable" "disable"
+    echo "    Compile with cln-grpc plugin"
     exit 1
 }
 
@@ -283,6 +286,8 @@ for opt in "$@"; do
 	--disable-fuzzing) FUZZING=0;;
 	--enable-rust) RUST=1;;
 	--disable-rust) RUST=0;;
+	--enable-grpc) GRPC=1;;
+	--disable-grpc) GRPC=0;;
 	--help|-h) usage;;
 	*)
 	    echo "Unknown option '$opt'" >&2
@@ -543,6 +548,7 @@ add_var HAVE_LOWDOWN "$HAVE_LOWDOWN"
 add_var SHA256SUM "$SHA256SUM"
 add_var FUZZING "$FUZZING"
 add_var RUST "$RUST"
+add_var GRPC "$GRPC"
 add_var PYTHON "$PYTHON"
 
 # Hack to avoid sha256 name clash with libwally: will be fixed when that

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -117,12 +117,14 @@ PLUGINS := $(C_PLUGINS)
 PLUGIN_ALL_OBJS := $(PLUGIN_ALL_SRC:.c=.o)
 
 ifneq ($(RUST),0)
+ifneq ($(GRPC),0)
 # Builtin plugins must be in this plugins dir to work when we're executed
 # *without* make install.
 plugins/cln-grpc: target/${RUST_PROFILE}/cln-grpc
 	@cp $< $@
 
 PLUGINS += plugins/cln-grpc
+endif
 endif
 
 PLUGIN_COMMON_OBJS :=				\
@@ -264,7 +266,10 @@ target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC} ${CLN_GRPC_PLUGIN_SRC}
 	cargo build ${CARGO_OPTS} --bin cln-grpc
 
 ifneq ($(RUST),0)
-DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES) plugins/cln-grpc
+DEFAULT_TARGETS += $(CLN_PLUGIN_EXAMPLES)
+ifneq ($(GRPC),0)
+DEFAULT_TARGETS += plugins/cln-grpc
+endif
 endif
 
 clean: plugins-clean


### PR DESCRIPTION
related: #7473 

When enabling the cln-grpc plugin to run by default, uses should have the option to opt out of it at build time.
