### PR TITLE
pay: Share channel_hints across payments and plugins

### DIFF
--- a/common/json_parse.c
+++ b/common/json_parse.c
@@ -5,7 +5,6 @@
 #include <bitcoin/privkey.h>
 #include <bitcoin/psbt.h>
 #include <bitcoin/pubkey.h>
-#include <bitcoin/short_channel_id.h>
 #include <bitcoin/tx.h>
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/mem/mem.h>
@@ -572,6 +571,25 @@ bool json_to_short_channel_id(const char *buffer, const jsmntok_t *tok,
 {
 	return (short_channel_id_from_str(buffer + tok->start,
 					  tok->end - tok->start, scid));
+}
+
+bool json_to_short_channel_id_dir(const char *buffer, const jsmntok_t *tok,
+				  struct short_channel_id_dir *scidd)
+{
+	jsmntok_t scidtok, numtok;
+	u32 dir;
+
+	if (!split_tok(buffer, tok, '/', &scidtok, &numtok))
+		return false;
+
+	if (!json_to_short_channel_id(buffer, &scidtok, &scidd->scid))
+		return false;
+
+	if (!json_to_u32(buffer, &numtok, &dir) || (dir > 1))
+		return false;
+
+	scidd->dir = dir;
+	return true;
 }
 
 bool json_to_txid(const char *buffer, const jsmntok_t *tok,

--- a/common/json_parse.h
+++ b/common/json_parse.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNING_COMMON_JSON_PARSE_H
 #define LIGHTNING_COMMON_JSON_PARSE_H
 #include "config.h"
+#include <bitcoin/short_channel_id.h>
 #include <ccan/crypto/sha256/sha256.h>
 #include <common/coin_mvt.h>
 #include <common/errcode.h>
@@ -109,6 +110,10 @@ bool json_to_outpoint(const char *buffer, const jsmntok_t *tok,
 /* Extract a channel id from this */
 bool json_to_channel_id(const char *buffer, const jsmntok_t *tok,
 			struct channel_id *cid);
+
+/* Extract a channel id + dir from this */
+bool json_to_short_channel_id_dir(const char *buffer, const jsmntok_t *tok,
+				  struct short_channel_id_dir *scidd);
 
 /* Extract a coin movement 'tag' from this */
 bool json_to_coin_mvt_tag(const char *buffer, const jsmntok_t *tok,

--- a/common/json_stream.c
+++ b/common/json_stream.c
@@ -3,7 +3,6 @@
 #include <bitcoin/preimage.h>
 #include <bitcoin/privkey.h>
 #include <bitcoin/psbt.h>
-#include <bitcoin/short_channel_id.h>
 #include <bitcoin/signature.h>
 #include <bitcoin/tx.h>
 #include <ccan/io/io.h>
@@ -483,6 +482,16 @@ void json_add_short_channel_id(struct json_stream *response,
 			 short_channel_id_blocknum(scid),
 			 short_channel_id_txnum(scid),
 			 short_channel_id_outnum(scid));
+}
+
+void json_add_short_channel_id_dir(struct json_stream *response,
+			       const char *fieldname,
+			       struct short_channel_id_dir scidd)
+{
+	json_add_str_fmt(response, fieldname, "%dx%dx%d/%d",
+			 short_channel_id_blocknum(scidd.scid),
+			 short_channel_id_txnum(scidd.scid),
+			 short_channel_id_outnum(scidd.scid), scidd.dir);
 }
 
 static void json_add_address_fields(struct json_stream *response,

--- a/common/json_stream.h
+++ b/common/json_stream.h
@@ -5,6 +5,7 @@
 #define LIGHTNING_COMMON_JSON_STREAM_H
 #include "config.h"
 
+#include <bitcoin/short_channel_id.h>
 #define JSMN_STRICT 1
 # include <external/jsmn/jsmn.h>
 
@@ -312,6 +313,11 @@ void json_add_outpoint(struct json_stream *result, const char *fieldname,
 void json_add_short_channel_id(struct json_stream *response,
 			       const char *fieldname,
 			       struct short_channel_id id);
+
+/* '"fieldname" : "1234:5:6/1"' */
+void json_add_short_channel_id_dir(struct json_stream *response,
+				   const char *fieldname,
+				   struct short_channel_id_dir idd);
 
 /* JSON serialize a network address for a node */
 void json_add_address(struct json_stream *response, const char *fieldname,

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -386,6 +386,16 @@ void payment_start(struct payment *p)
 	payment_start_at_blockheight(p, INVALID_BLOCKHEIGHT);
 }
 
+static void channel_hint_to_json(const char *name, const struct channel_hint *hint, struct json_stream *dest)
+{
+	json_object_start(dest, name);
+	json_add_u32(dest, "timestamp", hint->timestamp);
+	json_add_short_channel_id_dir(dest, "scid", hint->scid);
+	json_add_amount_msat(dest, "capacity_msat", hint->estimated_capacity);
+	json_add_bool(dest, "enabled", hint->enabled);
+	json_object_end(dest);
+}
+
 /**
  * Notify subscribers of the `channel_hint` topic about a changed hint
  *
@@ -405,7 +415,7 @@ static void channel_hint_notify(struct plugin *plugin,
 	    plugin_notification_start(plugin, "channel_hint_update");
 
 	/* The timestamp used to decay the observation over time. */
-	json_add_u32(js, "timestamp", hint->timestamp);
+	channel_hint_to_json("channel_hint", hint, js);
 	plugin_notification_end(plugin, js);
 }
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -397,11 +397,30 @@ static void channel_hint_to_json(const char *name, const struct channel_hint *hi
 }
 
 /**
- * Notify subscribers of the `channel_hint` topic about a changed hint
+ * Load a channel_hint from its JSON representation.
  *
- * We share the channel_hints across payments, and across plugins, in order to
- * maximize the context they have when performing payments.
+ * @return The initialized `channel_hint` or `NULL` if we encountered a parsing
+ *         error.
  */
+/*
+static struct channel_hint *channel_hint_from_json(const tal_t *ctx,
+						   const char *buffer,
+						   const jsmntok_t *toks)
+{
+	const char *ret;
+	struct channel_hint *hint = tal(ctx, struct channel_hint);
+	ret = json_scan(ctx, buffer, toks,
+			"{timestamp:%,scid:%,capacity_msat:%,enabled:%}",
+			JSON_SCAN(json_to_u32, &hint->timestamp),
+			JSON_SCAN(json_to_short_channel_id_dir, &hint->scid),
+			JSON_SCAN(json_to_msat, &hint->estimated_capacity),
+			JSON_SCAN(json_to_bool, &hint->enabled));
+
+	if (ret != NULL)
+		hint = tal_free(hint);
+	return hint;
+}
+*/
     /**
      * Notify subscribers of the `channel_hint` topic about a changed hint
      *

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -68,6 +68,13 @@ struct local_hint {
  * get remove on failure. Success keeps the capacities, since the capacities
  * changed due to the successful HTLCs. */
 struct channel_hint {
+	/* The timestamp this observation was made. Used to let the
+	 * constraint expressed by this hint decay over time, until it
+	 * is fully relaxed, at which point we can forget about it
+	 * (the structural information is the best we can do in that
+	 * case).
+	 */
+	u32 timestamp;
 	/* The short_channel_id we're going to use when referring to
 	 * this channel. This can either be the real scid, or the
 	 * local alias. The `pay` algorithm doesn't really care which

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -350,25 +350,6 @@ static struct command_result *currency_done(struct command *cmd,
 	return maybe_add_path(cmd, offinfo);
 }
 
-static bool json_to_short_channel_id_dir(const char *buffer, const jsmntok_t *tok,
-					 struct short_channel_id_dir *scidd)
-{
-	jsmntok_t scidtok, numtok;
-	u32 dir;
-
-	if (!split_tok(buffer, tok, '/', &scidtok, &numtok))
-		return false;
-
-	if (!json_to_short_channel_id(buffer, &scidtok, &scidd->scid))
-		return false;
-
-	if (!json_to_u32(buffer, &numtok, &dir) || (dir > 1))
-		return false;
-
-	scidd->dir = dir;
-	return true;
-}
-
 static bool json_to_sciddir_or_pubkey(const char *buffer, const jsmntok_t *tok,
 				      struct sciddir_or_pubkey *sciddir_or_pubkey)
 {

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1522,6 +1522,7 @@ static const struct plugin_command commands[] = {
 static const char *notification_topics[] = {
 	"pay_success",
 	"pay_failure",
+	"channel_hint_update",
 };
 
 int main(int argc, char *argv[])

--- a/plugins/test/run-route-calc.c
+++ b/plugins/test/run-route-calc.c
@@ -81,6 +81,10 @@ void json_add_amount_msat(struct json_stream *result UNNEEDED,
 			  struct amount_msat msat)
 
 { fprintf(stderr, "json_add_amount_msat called!\n"); abort(); }
+/* Generated stub for json_add_bool */
+void json_add_bool(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		   bool value UNNEEDED)
+{ fprintf(stderr, "json_add_bool called!\n"); abort(); }
 /* Generated stub for json_add_hex_talarr */
 void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 			 const char *fieldname UNNEEDED,
@@ -116,6 +120,11 @@ void json_add_short_channel_id(struct json_stream *response UNNEEDED,
 			       const char *fieldname UNNEEDED,
 			       struct short_channel_id id UNNEEDED)
 { fprintf(stderr, "json_add_short_channel_id called!\n"); abort(); }
+/* Generated stub for json_add_short_channel_id_dir */
+void json_add_short_channel_id_dir(struct json_stream *response UNNEEDED,
+				   const char *fieldname UNNEEDED,
+				   struct short_channel_id_dir idd UNNEEDED)
+{ fprintf(stderr, "json_add_short_channel_id_dir called!\n"); abort(); }
 /* Generated stub for json_add_string */
 void json_add_string(struct json_stream *js UNNEEDED,
 		     const char *fieldname UNNEEDED,

--- a/plugins/test/run-route-overlong.c
+++ b/plugins/test/run-route-overlong.c
@@ -78,6 +78,10 @@ void json_add_amount_msat(struct json_stream *result UNNEEDED,
 			  struct amount_msat msat)
 
 { fprintf(stderr, "json_add_amount_msat called!\n"); abort(); }
+/* Generated stub for json_add_bool */
+void json_add_bool(struct json_stream *result UNNEEDED, const char *fieldname UNNEEDED,
+		   bool value UNNEEDED)
+{ fprintf(stderr, "json_add_bool called!\n"); abort(); }
 /* Generated stub for json_add_hex_talarr */
 void json_add_hex_talarr(struct json_stream *result UNNEEDED,
 			 const char *fieldname UNNEEDED,
@@ -113,6 +117,11 @@ void json_add_short_channel_id(struct json_stream *response UNNEEDED,
 			       const char *fieldname UNNEEDED,
 			       struct short_channel_id id UNNEEDED)
 { fprintf(stderr, "json_add_short_channel_id called!\n"); abort(); }
+/* Generated stub for json_add_short_channel_id_dir */
+void json_add_short_channel_id_dir(struct json_stream *response UNNEEDED,
+				   const char *fieldname UNNEEDED,
+				   struct short_channel_id_dir idd UNNEEDED)
+{ fprintf(stderr, "json_add_short_channel_id_dir called!\n"); abort(); }
 /* Generated stub for json_add_string */
 void json_add_string(struct json_stream *js UNNEEDED,
 		     const char *fieldname UNNEEDED,


### PR DESCRIPTION
While performing a payment we attempt to get several HTLCs through
from the sender to the destination. Some of these attempts may fail,
due to temporary unavailability, insufficient balance, or many other
reasons. We use `channel_hint`s to track these failures and compile
the observations into a more detailed view of the network.

So far we were just forgetting all of the inferred information once
the payment is done, however this information is useful for later
payments too, as it allows us to skip attempts that are unlikely to
succeed, and essentially continue the exploration where the previous
payments have left off.

The main issue we face is how do we relax the hints over time, such
that we maximize their usefulness by allowing us to skip channels that
are unlikely to succeed, while at the same time minimizing the false
negative rate where we skip a channel that would have worked, based on
the prior observations. We implement it here as a linear decay, in
line with the leaky bucket rate limiting algorithm.

We model the sharing of the `channel_hint`s as notifications since we
might want to share observations across multiple plugins, and maybe
even across multiple nodes, if they are operated by the same
operator. DO NOT accept `channel_hint` notifications from untrusted
sources, as they can be used directly to steer the route selection.

Changelog-Added: pay: Payments now emit `channel_hint_updated` notification to share inferred balances and observations across multiple payments.


This is part of the following PR set:

```mermaid
graph TD;
    CLN7487 --> CLN7494;
    click CLN7487 "https://github.com/ElementsProject/lightning/pull/7487"
    click CLN7494 "https://github.com/ElementsProject/lightning/pull/7494"
    style CLN7487 fill:#AAFFAA
```