### PR TITLE
common: fix endless loop in gossmap iteration.

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -1634,6 +1634,8 @@ void gossmap_iter_fast_forward(const struct gossmap *map,
 
 		if (be32_to_cpu(ghdr.timestamp) >= timestamp)
 			break;
+
+		iter->offset += be16_to_cpu(ghdr.len) + sizeof(ghdr);
 	}
 }
 


### PR DESCRIPTION
If we need to iterate forward to find a timestamp (only happens if we have gossip older than 2 hours), we didn't exit the loop, as it didn't actually move the offset.

Fixes: https://github.com/ElementsProject/lightning/issues/7462