### PR TITLE
Gossmap topology compression and helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -658,7 +658,7 @@ $(ALL_TEST_PROGRAMS) $(ALL_FUZZ_TARGETS): %: %.o
 # uses some ccan modules internally).  We want to rely on -lwallycore etc.
 # (as per EXTERNAL_LDLIBS) so we filter them out here.
 $(ALL_PROGRAMS) $(ALL_TEST_PROGRAMS):
-	@$(call VERBOSE, "ld $@", $(LINK.o) $(filter-out %.a,$^) $(LOADLIBES) $(EXTERNAL_LDLIBS) $(LDLIBS) libccan.a -o $@)
+	@$(call VERBOSE, "ld $@", $(LINK.o) $(filter-out %.a,$^) $(LOADLIBES) $(EXTERNAL_LDLIBS) $(LDLIBS) libccan.a $($(@)_LDLIBS) -o $@)
 
 # We special case the fuzzing target binaries, as they need to link against libfuzzer,
 # which brings its own main().

--- a/configure
+++ b/configure
@@ -367,6 +367,20 @@ trap "rm -f $CONFIG_VAR_FILE.$$" 0
 
 $CONFIGURATOR --extra-tests --autotools-style --var-file=$CONFIG_VAR_FILE.$$ --header-file=$CONFIG_HEADER.$$ --configurator-cc="$CONFIGURATOR_CC" --wrapper="$CONFIGURATOR_WRAPPER" "$CC" ${CWARNFLAGS-$BASE_WARNFLAGS} $CDEBUGFLAGS $COPTFLAGS $CSANFLAGS -I$CPATH -L$LIBRARY_PATH $SQLITE3_CFLAGS $POSTGRES_INCLUDE <<EOF
 
+var=HAVE_ZLIB
+desc=zlib support
+style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE
+link=-lz
+code=
+#include <zlib.h>
+#include <stdlib.h>
+
+int main(void)
+{
+	gzFile f = gzopen("/dev/null", "wb");
+	return f != NULL ? 0 : 1;
+}
+/*END*/
 var=HAVE_GOOD_LIBSODIUM
 desc=libsodium with IETF chacha20 variants
 style=DEFINES_EVERYTHING|EXECUTE|MAY_NOT_COMPILE

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -11,6 +11,11 @@ ALL_C_SOURCES += $(DEVTOOLS_TOOL_SRC)
 ALL_C_HEADERS +=
 ALL_PROGRAMS += $(DEVTOOLS)
 
+# gossmap-compress wants -lz if we say we have it.
+ifeq ($(HAVE_ZLIB),1)
+devtools/gossmap-compress_LDLIBS=-lz
+endif # ZLIB
+
 DEVTOOLS_COMMON_OBJS :=				\
 	common/amount.o				\
 	common/autodata.o			\

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -57,7 +57,7 @@ devtools/bolt11-cli: $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(BITCOIN_OBJS) wire/f
 
 devtools/encodeaddr: common/utils.o common/bech32.o devtools/encodeaddr.o
 
-devtools/gossmap-compress: $(DEVTOOLS_COMMON_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o wire/tlvstream.o common/gossmap.o common/fp16.o devtools/gossmap-compress.o
+devtools/gossmap-compress: $(DEVTOOLS_COMMON_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o wire/tlvstream.o common/gossmap.o common/fp16.o devtools/gossmap-compress.o gossipd/gossip_store_wiregen.o
 
 devtools/bolt12-cli: $(DEVTOOLS_COMMON_OBJS) $(BITCOIN_OBJS) wire/bolt12_wiregen.o wire/fromwire.o wire/towire.o common/bolt12.o common/bolt12_merkle.o devtools/bolt12-cli.o common/setup.o common/iso4217.o
 

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,4 +1,4 @@
-DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore devtools/mkcommit devtools/mkfunding devtools/mkclose devtools/mkgossip devtools/mkencoded devtools/mkquery devtools/lightning-checkmessage devtools/topology devtools/route devtools/bolt12-cli devtools/encodeaddr devtools/features devtools/fp16 devtools/rune
+DEVTOOLS := devtools/bolt11-cli devtools/decodemsg devtools/onion devtools/dump-gossipstore devtools/gossipwith devtools/create-gossipstore devtools/mkcommit devtools/mkfunding devtools/mkclose devtools/mkgossip devtools/mkencoded devtools/mkquery devtools/lightning-checkmessage devtools/topology devtools/route devtools/bolt12-cli devtools/encodeaddr devtools/features devtools/fp16 devtools/rune devtools/gossmap-compress
 ifeq ($(HAVE_SQLITE3),1)
 DEVTOOLS += devtools/checkchannels
 endif
@@ -56,6 +56,8 @@ devtools/fp16: common/fp16.o common/utils.o common/setup.o common/autodata.o dev
 devtools/bolt11-cli: $(DEVTOOLS_COMMON_OBJS) $(JSMN_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o devtools/bolt11-cli.o
 
 devtools/encodeaddr: common/utils.o common/bech32.o devtools/encodeaddr.o
+
+devtools/gossmap-compress: $(DEVTOOLS_COMMON_OBJS) $(BITCOIN_OBJS) wire/fromwire.o wire/towire.o wire/tlvstream.o common/gossmap.o common/fp16.o devtools/gossmap-compress.o
 
 devtools/bolt12-cli: $(DEVTOOLS_COMMON_OBJS) $(BITCOIN_OBJS) wire/bolt12_wiregen.o wire/fromwire.o wire/towire.o common/bolt12.o common/bolt12_merkle.o devtools/bolt12-cli.o common/setup.o common/iso4217.o
 

--- a/devtools/gossmap-compress.c
+++ b/devtools/gossmap-compress.c
@@ -1,0 +1,363 @@
+#include "config.h"
+#include <ccan/asort/asort.h>
+#include <ccan/err/err.h>
+#include <ccan/opt/opt.h>
+#include <ccan/read_write_all/read_write_all.h>
+#include <ccan/tal/grab_file/grab_file.h>
+#include <ccan/tal/str/str.h>
+#include <common/bigsize.h>
+#include <common/gossmap.h>
+#include <common/setup.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static bool verbose = false;
+
+/* All {numbers} are bigsize.
+ *
+ * <FILE> := <HEADER> <CHANNEL_ENDS> <CAPACITIES> <DISABLEDS> <HTLC_MINS> <HTLC_MAXS> <BASEFEES> <PROPFEES> <DELAYS>
+ * <HEADER> := "GOSSMAP_COMPRESSv1\0"
+ * <CHANNEL_ENDS> := {channel_count} {start_nodeidx}*{channel_count} {end_nodeidx}*{channel_count}
+ *  This describes each attached channel, eg if there are two
+ *  channels, node 0 to node 1 and node 0 to node 2, this would be:
+ *   2 0 0 1 2
+ *
+ * <DISABLEDS> := <DISABLED>* {channel_count*2}
+ * <DISABLED> := {chanidx}*2+{direction}
+ *  Selection of disabled channels and directions, expected to only be a few.  Indexes into the
+ *  first channel_ends array.  Terminated by invalid index.
+ *
+ * <CAPACITIES> := <CAPACITY_TEMPLATES> {channel_count}*{capacity_idx}
+ * <CAPACITY_TEMPLATES> := {capacity_count} {channel_count}*{capacity}
+ *  This is one satoshi amount per channel.
+ *
+ * <HTLC_MINS> := <HTLC_MIN_TEMPLATES> {channel_count*2}*{htlc_min_idx}
+ * <HTLC_MIN_TEMPLATES> := {htlc_min_count} {htlc_min_count}*{htlc_min}
+ *  These templates are all of the same form.  A set of values, followed by
+ *  an index into these values for each direction of each channel, in order
+ *  1. 0'th channel 1st direction
+ *  2. 0'th channel 2nd direction
+ *  3. 1'st channel 1st direction
+ *  4. 1'st channel 2nd direction
+ *
+ * <HTLC_MAXS> := <HTLC_MAX_TEMPLATES> {channel_count*2}*{htlc_max_idx}
+ *  Note that values 0 and 1 are special: 0 == channel capacity, 1 == 0.99 * channel capacity.
+ * <HTLC_MAX_TEMPLATES> := {htlc_max_count} {htlc_max_count}*{htlc_max}
+ * <BASEFEES> := <BASEFEE_TEMPLATES> {channel_count*2}*{basefee_idx}
+ * <BASEFEE_TEMPLATES> := {basefee_count} {basefee_count}*{basefee}
+ * <PROPFEES> := <PROPFEE_TEMPLATES> {channel_count*2}*{propfee_idx}
+ * <PROPFEE_TEMPLATES> := {propfee_count} {propfee_count}*{propfee}
+ * <DELAYS> := <DELAY_TEMPLATES> {channel_count*2}*{delay_idx}
+ * <DELAY_TEMPLATES> := {delay_count} {delay_count}*{delay}
+ */
+
+#define GC_HEADER "GOSSMAP_COMPRESSv1"
+#define GC_HEADERLEN (sizeof(GC_HEADER))
+
+static int cmp_node_num_chans(struct gossmap_node *const *a,
+			      struct gossmap_node *const *b,
+			      void *unused)
+{
+	return (int)(*a)->num_chans - (int)(*b)->num_chans;
+}
+
+static void write_bigsize(int outfd, u64 val)
+{
+	u8 buf[BIGSIZE_MAX_LEN];
+	size_t len;
+
+	len = bigsize_put(buf, val);
+	if (!write_all(outfd, buf, len))
+		errx(1, "Writing bigsize");
+}
+
+static int cmp_u64(const u64 *a,
+		   const u64 *b,
+		   void *unused)
+{
+	if (*a > *b)
+		return 1;
+	else if (*a < *b)
+		return -1;
+	return 0;
+}
+
+static const u64 *deduplicate(const tal_t *ctx, const u64 *vals)
+{
+	u64 *sorted;
+	u64 *dedup;
+	size_t n;
+
+	/* Sort and remove dups */
+	sorted = tal_dup_talarr(tmpctx, u64, vals);
+	asort(sorted, tal_count(sorted), cmp_u64, NULL);
+
+	dedup = tal_arr(ctx, u64, tal_count(sorted));
+	n = 0;
+	dedup[n++] = sorted[0];
+	for (size_t i = 1; i < tal_count(sorted); i++) {
+		if (sorted[i] == dedup[n-1])
+			continue;
+		dedup[n++] = sorted[i];
+	}
+	tal_resize(&dedup, n);
+
+	return dedup;
+}
+
+static size_t find_index(const u64 *template, u64 val)
+{
+	for (size_t i = 0; i < tal_count(template); i++) {
+		if (template[i] == val)
+			return i;
+	}
+	abort();
+}
+
+/* All templates are of the same form.  Output all the distinct values, then
+ * write out which one is used by each channel */
+static void write_template_and_values(int outfd, const u64 *vals, const char *what)
+{
+	/* Sort and remove dups */
+	const u64 *template = deduplicate(tmpctx, vals);
+
+	if (verbose)
+		printf("%zu unique %s\n", tal_count(template), what);
+
+	assert(tal_count(vals) >= tal_count(template));
+
+	/* Write template. */
+	write_bigsize(outfd, tal_count(template));
+	for (size_t i = 0; i < tal_count(template); i++)
+		write_bigsize(outfd, template[i]);
+
+	/* Tie every channel into the template.  O(N^2) but who
+	 * cares? */
+	for (size_t i = 0; i < tal_count(vals); i++) {
+		write_bigsize(outfd, find_index(template, vals[i]));
+	}
+}
+
+static void write_bidir_perchan(int outfd,
+				struct gossmap *gossmap,
+				struct gossmap_chan **chans,
+				u64 (*get_value)(struct gossmap *,
+						 const struct gossmap_chan *,
+						 int),
+				const char *what)
+{
+	u64 *vals = tal_arr(tmpctx, u64, tal_count(chans) * 2);
+
+	for (size_t i = 0; i < tal_count(chans); i++) {
+		for (size_t dir = 0; dir < 2; dir++) {
+			if (chans[i]->half[dir].enabled)
+				vals[i*2+dir] = get_value(gossmap, chans[i], dir);
+			else
+				vals[i*2+dir] = 0;
+		}
+	}
+
+	write_template_and_values(outfd, vals, what);
+}
+
+static u64 get_htlc_min(struct gossmap *gossmap,
+			const struct gossmap_chan *chan,
+			int dir)
+{
+	struct amount_msat msat;
+	gossmap_chan_get_update_details(gossmap, chan, dir,
+					NULL, NULL, NULL, NULL, NULL, &msat, NULL);
+	return msat.millisatoshis; /* Raw: compressed format */
+}
+
+static u64 get_htlc_max(struct gossmap *gossmap,
+			const struct gossmap_chan *chan,
+			int dir)
+{
+	struct amount_msat msat, capacity_msat;
+	struct amount_sat capacity_sats;
+	gossmap_chan_get_capacity(gossmap, chan, &capacity_sats);
+	gossmap_chan_get_update_details(gossmap, chan, dir,
+					NULL, NULL, NULL, NULL, NULL, NULL, &msat);
+
+	/* Special value for the common case of "max_htlc == capacity" */
+	if (amount_msat_eq_sat(msat, capacity_sats)) {
+		return 0;
+	}
+	/* Other common case: "max_htlc == 99% capacity" */
+	if (amount_sat_to_msat(&capacity_msat, capacity_sats)
+	    && amount_msat_scale(&capacity_msat, capacity_msat, 0.99)
+	    && amount_msat_eq(msat, capacity_msat)) {
+		return 1;
+	}
+	return msat.millisatoshis; /* Raw: compressed format */
+}
+
+static u64 get_basefee(struct gossmap *gossmap,
+		       const struct gossmap_chan *chan,
+		       int dir)
+{
+	u32 basefee;
+	gossmap_chan_get_update_details(gossmap, chan, dir,
+					NULL, NULL, NULL, &basefee, NULL, NULL, NULL);
+	return basefee;
+}
+
+static u64 get_propfee(struct gossmap *gossmap,
+		       const struct gossmap_chan *chan,
+		       int dir)
+{
+	u32 propfee;
+	gossmap_chan_get_update_details(gossmap, chan, dir,
+					NULL, NULL, NULL, NULL, &propfee, NULL, NULL);
+	return propfee;
+}
+
+static u64 get_delay(struct gossmap *gossmap,
+		     const struct gossmap_chan *chan,
+		     int dir)
+{
+	return chan->half[dir].delay;
+}
+
+int main(int argc, char *argv[])
+{
+	int infd, outfd;
+	common_setup(argv[0]);
+	setup_locale();
+
+	opt_register_noarg("--verbose|-v", opt_set_bool, &verbose,
+			   "Print details.");
+	opt_register_noarg("--help|-h", opt_usage_and_exit,
+			   "[decompress|compress] infile outfile"
+			   "Compress or decompress a gossmap file",
+			   "Print this message.");
+
+	opt_parse(&argc, argv, opt_log_stderr_exit);
+	if (argc != 4)
+		opt_usage_and_exit("Needs 4 arguments");
+
+	infd = open(argv[2], O_RDONLY);
+	if (infd < 0)
+		opt_usage_and_exit(tal_fmt(tmpctx, "Cannot open %s for reading: %s",
+					   argv[2], strerror(errno)));
+	outfd = open(argv[3], O_WRONLY|O_CREAT|O_TRUNC, 0666);
+	if (outfd < 0)
+		opt_usage_and_exit(tal_fmt(tmpctx, "Cannot open %s for writing: %s",
+					   argv[3], strerror(errno)));
+
+	if (streq(argv[1], "compress")) {
+		struct gossmap_node **nodes, *n;
+		size_t *node_to_compr_idx;
+		size_t node_count, channel_count;
+		struct gossmap_chan **chans, *c;
+
+		struct gossmap *gossmap = gossmap_load_fd(tmpctx, infd, NULL, NULL, NULL);
+		if (!gossmap)
+			opt_usage_and_exit("Cannot read gossmap");
+
+		nodes = tal_arr(gossmap, struct gossmap_node *, gossmap_max_node_idx(gossmap));
+		for (node_count = 0, n = gossmap_first_node(gossmap);
+		     n;
+		     n = gossmap_next_node(gossmap, n), node_count++) {
+			nodes[node_count] = n;
+		}
+		tal_resize(&nodes, node_count);
+		if (verbose)
+			printf("%zu nodes\n", node_count);
+
+		/* nodes with most channels go first */
+		asort(nodes, tal_count(nodes), cmp_node_num_chans, NULL);
+
+		/* Create map of gossmap index to compression index */
+		node_to_compr_idx = tal_arr(nodes, size_t, gossmap_max_node_idx(gossmap));
+		for (size_t i = 0; i < tal_count(nodes); i++)
+			node_to_compr_idx[gossmap_node_idx(gossmap, nodes[i])] = i;
+
+		if (!write_all(outfd, GC_HEADER, GC_HEADERLEN))
+			err(1, "Writing header");
+
+		/* Now, output channels.  First get exact count. */
+		for (channel_count = 0, c = gossmap_first_chan(gossmap);
+		     c;
+		     c = gossmap_next_chan(gossmap, c)) {
+			channel_count++;
+		}
+
+		if (verbose)
+			printf("%zu channels\n", channel_count);
+		chans = tal_arr(gossmap, struct gossmap_chan *, channel_count);
+
+		/*  * <CHANNEL_ENDS> := {channel_count} {start_nodeidx}*{channel_count} {end_nodeidx}*{channel_count} */
+		write_bigsize(outfd, channel_count);
+		size_t chanidx = 0;
+		/* We iterate nodes to get to channels.  This gives us nicer ordering for compression */
+		for (size_t wanted_dir = 0; wanted_dir < 2; wanted_dir++) {
+			for (n = gossmap_first_node(gossmap); n; n = gossmap_next_node(gossmap, n)) {
+				for (size_t i = 0; i < n->num_chans; i++) {
+					int dir;
+					c = gossmap_nth_chan(gossmap, n, i, &dir);
+					if (dir != wanted_dir)
+						continue;
+
+					write_bigsize(outfd,
+						      node_to_compr_idx[gossmap_node_idx(gossmap, n)]);
+					/* First time reflects channel index for reader */
+					if (wanted_dir == 0)
+						chans[chanidx++] = c;
+				}
+			}
+		}
+
+		/* <DISABLEDS> := <DISABLED>* {channel_count*2} */
+		/* <DISABLED> := {chanidx}*2+{direction} */
+		size_t num_disabled = 0;
+		size_t num_unknown = 0;
+		for (size_t i = 0; i < channel_count; i++) {
+			for (size_t dir = 0; dir < 2; dir++) {
+				if (chans[i]->cupdate_off[dir] == 0)
+					num_unknown++;
+				if (!chans[i]->half[dir].enabled) {
+					write_bigsize(outfd, i * 2 + dir);
+					num_disabled++;
+				}
+			}
+		}
+		write_bigsize(outfd, channel_count * 2);
+		if (verbose)
+			printf("%zu disabled channels (%zu no update)\n", num_disabled, num_unknown);
+
+		/* <CAPACITIES> := <CAPACITY_TEMPLATES> {channel_count}*{capacity_idx} */
+		/* <CAPACITY_TEMPLATES> := {capacity_count} {capacity_count}*{capacity} */
+		u64 *vals = tal_arr(chans, u64, channel_count);
+		for (size_t i = 0; i < channel_count; i++) {
+			struct amount_sat sats;
+			gossmap_chan_get_capacity(gossmap, chans[i], &sats);
+			vals[i] = sats.satoshis; /* Raw: compression format */
+		}
+		write_template_and_values(outfd, vals, "capacities");
+
+		/* These are all of same form: one entry per direction per channel */
+		/* <HTLC_MINS> := <HTLC_MIN_TEMPLATES> {channel_count}*{htlc_min_idx} */
+		/* <HTLC_MIN_TEMPLATES> := {htlc_min_count} {htlc_min_count}*{htlc_min} */
+		/* <HTLC_MAXS> := <HTLC_MAX_TEMPLATES> {channel_count}*{htlc_max_idx} */
+		/* <HTLC_MAX_TEMPLATES> := {htlc_max_count} {htlc_max_count}*{htlc_max} */
+		/* <BASEFEES> := <BASEFEE_TEMPLATES> {channel_count}*{basefee_idx} */
+		/* <BASEFEE_TEMPLATES> := {basefee_count} {basefee_count}*{basefee} */
+		/* <PROPFEES> := <PROPFEE_TEMPLATES> {channel_count}*{propfee_idx} */
+		/* <PROPFEE_TEMPLATES> := {propfee_count} {propfee_count}*{propfee} */
+		/* <DELAYS> := <DELAY_TEMPLATES> {channel_count}*{delay_idx} */
+		/* <DELAY_TEMPLATES> := {delay_count} {delay_count}*{delay} */
+		write_bidir_perchan(outfd, gossmap, chans, get_htlc_min, "htlc_min");
+		write_bidir_perchan(outfd, gossmap, chans, get_htlc_max, "htlc_max");
+		write_bidir_perchan(outfd, gossmap, chans, get_basefee, "basefee");
+		write_bidir_perchan(outfd, gossmap, chans, get_propfee, "propfee");
+		write_bidir_perchan(outfd, gossmap, chans, get_delay, "delay");
+	} else if (streq(argv[1], "decompress")) {
+		errx(1, "NYI");
+	} else
+		opt_usage_and_exit("Unknown command");
+
+	common_shutdown();
+}

--- a/devtools/gossmap-compress.c
+++ b/devtools/gossmap-compress.c
@@ -7,7 +7,6 @@
 #include <ccan/mem/mem.h>
 #include <ccan/opt/opt.h>
 #include <ccan/read_write_all/read_write_all.h>
-#include <ccan/tal/grab_file/grab_file.h>
 #include <ccan/tal/str/str.h>
 #include <common/bigsize.h>
 #include <common/gossip_store.h>
@@ -16,8 +15,29 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <gossipd/gossip_store_wiregen.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <wire/peer_wiregen.h>
+#if HAVE_ZLIB
+#include <zlib.h>
+#else
+/* Worst... zlib... ever! */
+#define gzFile int
+#define gzdopen(fd, mode) (fd)
+#define gzclose(outf) close(outf)
+static int gzread(int fd, void *buf, size_t len)
+{
+	if (read_all(fd, buf, len))
+		return len;
+	return 0;
+}
+static int gzwrite(int fd, const void *buf, size_t len)
+{
+	if (write_all(fd, buf, len))
+		return len;
+	return 0;
+}
+#endif
 
 static unsigned int verbose = 0;
 
@@ -70,35 +90,35 @@ static int cmp_node_num_chans(struct gossmap_node *const *a,
 	return (int)(*a)->num_chans - (int)(*b)->num_chans;
 }
 
-static void write_bigsize(int outfd, u64 val)
+static void write_bigsize(gzFile outf, u64 val)
 {
 	u8 buf[BIGSIZE_MAX_LEN];
 	size_t len;
 
 	len = bigsize_put(buf, val);
-	if (!write_all(outfd, buf, len))
-		errx(1, "Writing bigsize");
+	if (gzwrite(outf, buf, len) == 0)
+		err(1, "Writing bigsize");
 }
 
-static u64 read_bigsize(int infd)
+static u64 read_bigsize(gzFile inf)
 {
 	u64 val;
 	u8 buf[BIGSIZE_MAX_LEN];
 
-	if (!read_all(infd, buf, 1))
+	if (gzread(inf, buf, 1) != 1)
 		errx(1, "Reading bigsize");
 
 	switch (buf[0]) {
 	case 0xfd:
-		if (!read_all(infd, buf+1, 2))
+		if (gzread(inf, buf+1, 2) != 2)
 			errx(1, "Reading bigsize");
 		break;
 	case 0xfe:
-		if (!read_all(infd, buf+1, 4))
+		if (gzread(inf, buf+1, 4) != 4)
 			errx(1, "Reading bigsize");
 		break;
 	case 0xff:
-		if (!read_all(infd, buf+1, 8))
+		if (gzread(inf, buf+1, 8) != 8)
 			errx(1, "Reading bigsize");
 		break;
 	}
@@ -153,7 +173,7 @@ static size_t find_index(const u64 *template, u64 val)
 
 /* All templates are of the same form.  Output all the distinct values, then
  * write out which one is used by each channel */
-static void write_template_and_values(int outfd, const u64 *vals, const char *what)
+static void write_template_and_values(gzFile outf, const u64 *vals, const char *what)
 {
 	/* Sort and remove dups */
 	const u64 *template = deduplicate(tmpctx, vals);
@@ -164,18 +184,18 @@ static void write_template_and_values(int outfd, const u64 *vals, const char *wh
 	assert(tal_count(vals) >= tal_count(template));
 
 	/* Write template. */
-	write_bigsize(outfd, tal_count(template));
+	write_bigsize(outf, tal_count(template));
 	for (size_t i = 0; i < tal_count(template); i++)
-		write_bigsize(outfd, template[i]);
+		write_bigsize(outf, template[i]);
 
 	/* Tie every channel into the template.  O(N^2) but who
 	 * cares? */
 	for (size_t i = 0; i < tal_count(vals); i++) {
-		write_bigsize(outfd, find_index(template, vals[i]));
+		write_bigsize(outf, find_index(template, vals[i]));
 	}
 }
 
-static void write_bidir_perchan(int outfd,
+static void write_bidir_perchan(gzFile outf,
 				struct gossmap *gossmap,
 				struct gossmap_chan **chans,
 				u64 (*get_value)(struct gossmap *,
@@ -194,7 +214,7 @@ static void write_bidir_perchan(int outfd,
 		}
 	}
 
-	write_template_and_values(outfd, vals, what);
+	write_template_and_values(outf, vals, what);
 }
 
 static u64 get_htlc_min(struct gossmap *gossmap,
@@ -420,13 +440,13 @@ static void write_update(int outfd,
 	write_msg_to_gstore(outfd, take(msg));
 }
 
-static const u64 *read_template(const tal_t *ctx, int infd, const char *what)
+static const u64 *read_template(const tal_t *ctx, gzFile inf, const char *what)
 {
-	size_t count = read_bigsize(infd);
+	size_t count = read_bigsize(inf);
 	u64 *template = tal_arr(ctx, u64, count);
 
 	for (size_t i = 0; i < count; i++)
-		template[i] = read_bigsize(infd);
+		template[i] = read_bigsize(inf);
 
 	if (verbose)
 		printf("%zu unique %s\n", count, what);
@@ -434,9 +454,9 @@ static const u64 *read_template(const tal_t *ctx, int infd, const char *what)
 	return template;
 }
 
-static u64 read_val(int infd, const u64 *template)
+static u64 read_val(gzFile inf, const u64 *template)
 {
-	size_t idx = read_bigsize(infd);
+	size_t idx = read_bigsize(inf);
 	assert(idx < tal_count(template));
 	return template[idx];
 }
@@ -478,6 +498,7 @@ int main(int argc, char *argv[])
 		size_t *node_to_compr_idx;
 		size_t node_count, channel_count;
 		struct gossmap_chan **chans, *c;
+		gzFile outf = gzdopen(outfd, "wb9");
 
 		struct gossmap *gossmap = gossmap_load_fd(tmpctx, infd, NULL, NULL, NULL);
 		if (!gossmap)
@@ -501,7 +522,7 @@ int main(int argc, char *argv[])
 		for (size_t i = 0; i < tal_count(nodes); i++)
 			node_to_compr_idx[gossmap_node_idx(gossmap, nodes[i])] = i;
 
-		if (!write_all(outfd, GC_HEADER, GC_HEADERLEN))
+		if (gzwrite(outf, GC_HEADER, GC_HEADERLEN) == 0)
 			err(1, "Writing header");
 
 		/* Now, output channels.  First get exact count. */
@@ -516,7 +537,7 @@ int main(int argc, char *argv[])
 		chans = tal_arr(gossmap, struct gossmap_chan *, channel_count);
 
 		/*  * <CHANNEL_ENDS> := {channel_count} {start_nodeidx}*{channel_count} {end_nodeidx}*{channel_count} */
-		write_bigsize(outfd, channel_count);
+		write_bigsize(outf, channel_count);
 		size_t chanidx = 0;
 		/* We iterate nodes to get to channels.  This gives us nicer ordering for compression */
 		for (size_t wanted_dir = 0; wanted_dir < 2; wanted_dir++) {
@@ -527,7 +548,7 @@ int main(int argc, char *argv[])
 					if (dir != wanted_dir)
 						continue;
 
-					write_bigsize(outfd,
+					write_bigsize(outf,
 						      node_to_compr_idx[gossmap_node_idx(gossmap, n)]);
 					/* First time reflects channel index for reader */
 					if (wanted_dir == 0)
@@ -545,12 +566,12 @@ int main(int argc, char *argv[])
 				if (chans[i]->cupdate_off[dir] == 0)
 					num_unknown++;
 				if (!chans[i]->half[dir].enabled) {
-					write_bigsize(outfd, i * 2 + dir);
+					write_bigsize(outf, i * 2 + dir);
 					num_disabled++;
 				}
 			}
 		}
-		write_bigsize(outfd, channel_count * 2);
+		write_bigsize(outf, channel_count * 2);
 		if (verbose)
 			printf("%zu disabled channels (%zu no update)\n", num_disabled, num_unknown);
 
@@ -562,7 +583,7 @@ int main(int argc, char *argv[])
 			gossmap_chan_get_capacity(gossmap, chans[i], &sats);
 			vals[i] = sats.satoshis; /* Raw: compression format */
 		}
-		write_template_and_values(outfd, vals, "capacities");
+		write_template_and_values(outf, vals, "capacities");
 
 		/* These are all of same form: one entry per direction per channel */
 		/* <HTLC_MINS> := <HTLC_MIN_TEMPLATES> {channel_count}*{htlc_min_idx} */
@@ -575,11 +596,12 @@ int main(int argc, char *argv[])
 		/* <PROPFEE_TEMPLATES> := {propfee_count} {propfee_count}*{propfee} */
 		/* <DELAYS> := <DELAY_TEMPLATES> {channel_count}*{delay_idx} */
 		/* <DELAY_TEMPLATES> := {delay_count} {delay_count}*{delay} */
-		write_bidir_perchan(outfd, gossmap, chans, get_htlc_min, "htlc_min");
-		write_bidir_perchan(outfd, gossmap, chans, get_htlc_max, "htlc_max");
-		write_bidir_perchan(outfd, gossmap, chans, get_basefee, "basefee");
-		write_bidir_perchan(outfd, gossmap, chans, get_propfee, "propfee");
-		write_bidir_perchan(outfd, gossmap, chans, get_delay, "delay");
+		write_bidir_perchan(outf, gossmap, chans, get_htlc_min, "htlc_min");
+		write_bidir_perchan(outf, gossmap, chans, get_htlc_max, "htlc_max");
+		write_bidir_perchan(outf, gossmap, chans, get_basefee, "basefee");
+		write_bidir_perchan(outf, gossmap, chans, get_propfee, "propfee");
+		write_bidir_perchan(outf, gossmap, chans, get_delay, "delay");
+		gzclose(outf);
 	} else if (streq(argv[1], "decompress")) {
 		char hdr[GC_HEADERLEN];
 		size_t channel_count, chanidx;
@@ -596,19 +618,20 @@ int main(int argc, char *argv[])
 		} *chans;
 		const u8 version = GOSSIP_STORE_VER;
 		size_t disabled_count;
+		gzFile inf = gzdopen(infd, "rb");
 
-		if (!read_all(infd, hdr, sizeof(hdr))
+		if (gzread(inf, hdr, sizeof(hdr)) != sizeof(hdr)
 		    || !memeq(hdr, sizeof(hdr), GC_HEADER, GC_HEADERLEN))
 			errx(1, "Not a valid compressed gossmap header");
-		channel_count = read_bigsize(infd);
+		channel_count = read_bigsize(inf);
 		if (verbose)
 			printf("%zu channels\n", channel_count);
 		chans = tal_arrz(tmpctx, struct fakechan, channel_count);
 
 		for (size_t i = 0; i < channel_count; i++)
-			chans[i].node1 = read_bigsize(infd);
+			chans[i].node1 = read_bigsize(inf);
 		for (size_t i = 0; i < channel_count; i++)
-			chans[i].node2 = read_bigsize(infd);
+			chans[i].node2 = read_bigsize(inf);
 
 		if (verbose >= 2) {
 			for (size_t i = 0; i < channel_count; i++) {
@@ -623,27 +646,27 @@ int main(int argc, char *argv[])
 		}
 
 		disabled_count = 0;
-		while ((chanidx = read_bigsize(infd)) < channel_count*2) {
+		while ((chanidx = read_bigsize(inf)) < channel_count*2) {
 			disabled_count++;
 			chans[chanidx/2].half[chanidx%2].disabled = true;
 		}
 		if (verbose)
 			printf("%zu disabled\n", disabled_count);
 
-		template = read_template(tmpctx, infd, "capacities");
+		template = read_template(tmpctx, inf, "capacities");
 		for (size_t i = 0; i < channel_count; i++)
-			chans[i].capacity = read_val(infd, template);
+			chans[i].capacity = read_val(inf, template);
 
-		template = read_template(tmpctx, infd, "htlc_min");
+		template = read_template(tmpctx, inf, "htlc_min");
 		for (size_t i = 0; i < channel_count; i++) {
 			for (size_t dir = 0; dir < 2; dir++) {
-				chans[i].half[dir].htlc_min = read_val(infd, template);
+				chans[i].half[dir].htlc_min = read_val(inf, template);
 			}
 		}
-		template = read_template(tmpctx, infd, "htlc_max");
+		template = read_template(tmpctx, inf, "htlc_max");
 		for (size_t i = 0; i < channel_count; i++) {
 			for (size_t dir = 0; dir < 2; dir++) {
-				u64 v = read_val(infd, template);
+				u64 v = read_val(inf, template);
 				if (v == 0)
 					v = chans[i].capacity;
 				else if (v == 1)
@@ -651,27 +674,28 @@ int main(int argc, char *argv[])
 				chans[i].half[dir].htlc_max = v;
 			}
 		}
-		template = read_template(tmpctx, infd, "basefee");
+		template = read_template(tmpctx, inf, "basefee");
 		for (size_t i = 0; i < channel_count; i++) {
 			for (size_t dir = 0; dir < 2; dir++) {
-				chans[i].half[dir].basefee = read_val(infd, template);
+				chans[i].half[dir].basefee = read_val(inf, template);
 			}
 		}
-		template = read_template(tmpctx, infd, "propfee");
+		template = read_template(tmpctx, inf, "propfee");
 		for (size_t i = 0; i < channel_count; i++) {
 			for (size_t dir = 0; dir < 2; dir++) {
-				chans[i].half[dir].propfee = read_val(infd, template);
+				chans[i].half[dir].propfee = read_val(inf, template);
 			}
 		}
-		template = read_template(tmpctx, infd, "delay");
+		template = read_template(tmpctx, inf, "delay");
 		for (size_t i = 0; i < channel_count; i++) {
 			for (size_t dir = 0; dir < 2; dir++) {
-				chans[i].half[dir].delay = read_val(infd, template);
+				chans[i].half[dir].delay = read_val(inf, template);
 			}
 		}
 
 		/* Now write out gossmap */
-		write(outfd, &version, 1);
+		if (write(outfd, &version, 1) != 1)
+			err(1, "Failed to write output");
 		for (size_t i = 0; i < channel_count; i++) {
 			write_announce(outfd,
 				       chans[i].node1,
@@ -689,6 +713,7 @@ int main(int argc, char *argv[])
 					     chans[i].half[dir].delay);
 			}
 		}
+		gzclose(inf);
 	} else
 		opt_usage_and_exit("Unknown command");
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2156,18 +2156,13 @@ def test_generate_gossip_store(node_factory):
                                        htlc_max=5000000 - 11,
                                        basefee=11,
                                        propfee=11)
-    gsfile = generate_gossip_store(chans)
+    gsfile, nodemap = generate_gossip_store(chans)
 
     # Set up l1 with this as the gossip_store
     shutil.copy(gsfile.name, os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, 'gossip_store'))
     l1.start()
 
-    nodes = ['03c581bf310c4c97b05e5e6fed2f82d872f388ec9ab7f1feddfd5380ddb3c6531c',
-             '03091f559e2704cd80e41cd103ca4a60fd91010927674016b09f40c1d450368cf4',
-             '0255a0e1286c832286eda137bbefe17f21af265a08bbea481a6ea96b9f4b5f84ac',
-             '02ec99a74a8c8d10853e1a3b0806556abda6798a68a0cedca4c766b5f6cf314f22',
-             '02c5ad36f9c80ca70d4f88d50f17be2f1f481f37086dbf3433473765a0027ecd63']
-
+    nodes = [nodemap[i] for i in range(0, 5)]
     expected = []
     chancount = 0
     for c in chans:

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2144,18 +2144,17 @@ def test_generate_gossip_store(node_factory):
     l1 = node_factory.get_node(start=False)
     chans = [GenChannel(0, 1),
              GenChannel(0, 2, capacity_sats=5000),
-             GenChannel(0, 3),
+             GenChannel(0, 3,
+                        forward=GenChannel.Half(enabled=False,
+                                                htlc_min=10,
+                                                htlc_max=5000000 - 10,
+                                                basefee=10,
+                                                propfee=10),
+                        reverse=GenChannel.Half(htlc_min=11,
+                                                htlc_max=5000000 - 11,
+                                                basefee=11,
+                                                propfee=11)),
              GenChannel(0, 4)]
-    chans[2].half[0] = GenChannel.Half(enabled=False,
-                                       htlc_min=10,
-                                       htlc_max=5000000 - 10,
-                                       basefee=10,
-                                       propfee=10)
-
-    chans[2].half[1] = GenChannel.Half(htlc_min=11,
-                                       htlc_max=5000000 - 11,
-                                       basefee=11,
-                                       propfee=11)
     gsfile, nodemap = generate_gossip_store(chans)
 
     # Set up l1 with this as the gossip_store

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -436,7 +436,7 @@ def scriptpubkey_addr(scriptpubkey):
 
 class GenChannel(object):
     class Half(object):
-        def __init__(self, htlc_max, enabled=True, htlc_min=0, basefee=0, propfee=1, delay=6):
+        def __init__(self, enabled=True, htlc_min=0, htlc_max=None, basefee=0, propfee=1, delay=6):
             self.enabled = enabled
             self.htlc_min = htlc_min
             self.htlc_max = htlc_max
@@ -444,12 +444,20 @@ class GenChannel(object):
             self.propfee = propfee
             self.delay = delay
 
-    def __init__(self, node1, node2, capacity_sats=1000000):
+    def __init__(self, node1, node2, capacity_sats=1000000, forward=None, reverse=None):
+        """We fill in htlc_max on half to == capacity, if not set"""
         self.node1 = node1
         self.node2 = node2
+        if forward is None:
+            forward = GenChannel.Half()
+        if reverse is None:
+            reverse = GenChannel.Half()
+        if forward.htlc_max is None:
+            forward.htlc_max = capacity_sats * 1000
+        if reverse.htlc_max is None:
+            reverse.htlc_max = capacity_sats * 1000
         self.capacity_sats = capacity_sats
-        self.half = [GenChannel.Half(htlc_max=capacity_sats * 1000),
-                     GenChannel.Half(htlc_max=capacity_sats * 1000)]
+        self.half = [forward, reverse]
 
 
 def generate_gossip_store(channels):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -453,7 +453,7 @@ class GenChannel(object):
 
 
 def generate_gossip_store(channels):
-    """Returns a gossip store file with the given channels in it.
+    """Returns a gossip store file with the given channels in it, and a map of node labels -> ids
     """
     nodes = []
 
@@ -541,11 +541,15 @@ def generate_gossip_store(channels):
     cfile.flush()
 
     outfile = tempfile.NamedTemporaryFile(prefix='gossip-store-')
-    subprocess.run(['devtools/gossmap-compress',
-                    'decompress',
-                    cfile.name,
-                    outfile.name],
-                   check=True)
+    nodeids = subprocess.check_output(['devtools/gossmap-compress',
+                                       'decompress',
+                                       cfile.name,
+                                       outfile.name]).decode('utf-8').splitlines()
     cfile.close()
 
-    return outfile
+    # Create map of their node names to the ids.
+    nodemap = {}
+    for i, n in enumerate(nodeids):
+        nodemap[nodes[i]] = n
+
+    return outfile, nodemap


### PR DESCRIPTION
I've been meaning to do this for a while: create a format for representing the gossip map topology for testing routing.  My gossip store shrinks to about 500k in this format, which is something we could actually check into the repository for testing.

It also provides a nice way to create topologies for python tests.