### PR TITLE
ci: Pin `rustc` to version 1.78 due to a type inference regression

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -e
 export DEBIAN_FRONTEND=noninteractive
-export RUST_VERSION=stable
+
+# Fix the RUST_VERSION as 1.80 appears to have a regression (the
+# `time` crate about a missing type annotation.)
+export RUST_VERSION=1.78
 
 sudo useradd -ms /bin/bash tester
 sudo apt-get update -qq
@@ -55,6 +58,9 @@ sudo chmod 0440 /etc/sudoers.d/tester
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
      -y --default-toolchain ${RUST_VERSION}
+
+echo "rustc version = $(rustc --version)"
+echo "cargo version = $(cargo --version)"
 
 # We also need a relatively recent protobuf-compiler, at least 3.12.0,
 # in order to support the experimental `optional` flag.


### PR DESCRIPTION
It appears as if there is a type inference regression in `rustc` resulting in the following errors:

``` raw
cargo build --profile=release --quiet --bin cln-grpc
error[E0282]: type annotations needed for `Box<_>`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.29/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
make: *** [plugins/Makefile:264: target/release/cln-grpc] Error 101
```

Let's see if pinning to a prior version (known to work on a dev machine) works.