### PR TITLE
new notifications: `plugin_stopped` and `plugin_started`

### DIFF
--- a/doc/developers-guide/plugin-development/event-notifications.md
+++ b/doc/developers-guide/plugin-development/event-notifications.md
@@ -519,3 +519,51 @@ In the shutdown case, plugins should not interact with lightnind except via (id-
     }
 }
 ```
+
+### `plugin_started` (v25.02 onward) 
+
+Emitted when a plugin has completed startup.
+
+```json
+{
+  "plugin_started": {
+    "plugin_name": "example_plugin",
+    "plugin_path": "/path/to/example_plugin.py",
+    "methods": [
+      "example_method1",
+      "example_method2",
+      "example_method3"
+    ]
+  }
+}
+```
+
+Where:
+
+- `plugin_name`: The short name of the plugin.
+- `plugin_path`: The full file path to the plugin executable.
+- `methods`: An array of RPC method names that the plugin registered.
+
+### `plugin_stopped` (v25.02 onward) 
+
+Emitted when a plugin has been stopped or has exited.
+
+```json
+{
+  "plugin_stopped": {
+    "plugin_name": "example_plugin",
+    "plugin_path": "/path/to/example_plugin.py",
+    "methods": [
+      "example_method1",
+      "example_method2",
+      "example_method3"
+    ]
+  }
+}
+```
+
+Where:
+
+- `plugin_name`: The short name of the plugin.
+- `plugin_path`: The full file path to the plugin executable.
+- `methods`: An array of RPC method names that the plugin registered.

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -678,8 +678,8 @@ void notify_log(struct lightningd *ld, const struct log_entry *l)
 	notify_send(ld, n);
 }
 
-static void plugin_started_notification_serialize(struct json_stream *stream,
-						  struct plugin *plugin)
+static void plugin_notification_serialize(struct json_stream *stream,
+					  struct plugin *plugin)
 {
 	json_add_string(stream, "plugin_name", plugin->shortname);
 	json_add_string(stream, "plugin_path", plugin->cmd);
@@ -695,20 +695,8 @@ REGISTER_NOTIFICATION(plugin_started);
 void notify_plugin_started(struct lightningd *ld, struct plugin *plugin)
 {
 	struct jsonrpc_notification *n = notify_start("plugin_started");
-	plugin_started_notification_serialize(n->stream, plugin);
+	plugin_notification_serialize(n->stream, plugin);
 	notify_send(ld, n);
-}
-
-static void plugin_stopped_notification_serialize(struct json_stream *stream,
-						  struct plugin *plugin)
-{
-	json_add_string(stream, "plugin_name", plugin->shortname);
-	json_add_string(stream, "plugin_path", plugin->cmd);
-	json_array_start(stream, "methods");
-	for (size_t i = 0; i < tal_count(plugin->methods); i++) {
-		json_add_string(stream, NULL, plugin->methods[i]);
-	}
-	json_array_end(stream);
 }
 
 REGISTER_NOTIFICATION(plugin_stopped);
@@ -716,6 +704,6 @@ REGISTER_NOTIFICATION(plugin_stopped);
 void notify_plugin_stopped(struct lightningd *ld, struct plugin *plugin)
 {
 	struct jsonrpc_notification *n = notify_start("plugin_stopped");
-	plugin_stopped_notification_serialize(n->stream, plugin);
+	plugin_notification_serialize(n->stream, plugin);
 	notify_send(ld, n);
 }

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -677,3 +677,45 @@ void notify_log(struct lightningd *ld, const struct log_entry *l)
 	log_notification_serialize(n->stream, l);
 	notify_send(ld, n);
 }
+
+static void plugin_started_notification_serialize(struct json_stream *stream,
+						  struct plugin *plugin)
+{
+	json_add_string(stream, "plugin_name", plugin->shortname);
+	json_add_string(stream, "plugin_path", plugin->cmd);
+	json_array_start(stream, "methods");
+	for (size_t i = 0; i < tal_count(plugin->methods); i++) {
+		json_add_string(stream, NULL, plugin->methods[i]);
+	}
+	json_array_end(stream);
+}
+
+REGISTER_NOTIFICATION(plugin_started);
+
+void notify_plugin_started(struct lightningd *ld, struct plugin *plugin)
+{
+	struct jsonrpc_notification *n = notify_start("plugin_started");
+	plugin_started_notification_serialize(n->stream, plugin);
+	notify_send(ld, n);
+}
+
+static void plugin_stopped_notification_serialize(struct json_stream *stream,
+						  struct plugin *plugin)
+{
+	json_add_string(stream, "plugin_name", plugin->shortname);
+	json_add_string(stream, "plugin_path", plugin->cmd);
+	json_array_start(stream, "methods");
+	for (size_t i = 0; i < tal_count(plugin->methods); i++) {
+		json_add_string(stream, NULL, plugin->methods[i]);
+	}
+	json_array_end(stream);
+}
+
+REGISTER_NOTIFICATION(plugin_stopped);
+
+void notify_plugin_stopped(struct lightningd *ld, struct plugin *plugin)
+{
+	struct jsonrpc_notification *n = notify_start("plugin_stopped");
+	plugin_stopped_notification_serialize(n->stream, plugin);
+	notify_send(ld, n);
+}

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -116,4 +116,7 @@ bool notify_deprecated_oneshot(struct lightningd *ld,
 bool notify_plugin_shutdown(struct lightningd *ld, struct plugin *p);
 /* Inform the plugin when a log line is emitted */
 void notify_log(struct lightningd *ld, const struct log_entry *l);
+
+void notify_plugin_started(struct lightningd *ld, struct plugin *plugin);
+void notify_plugin_stopped(struct lightningd *ld, struct plugin *plugin);
 #endif /* LIGHTNING_LIGHTNINGD_NOTIFICATION_H */

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -301,6 +301,8 @@ static void destroy_plugin(struct plugin *p)
 
 	if (tal_count(p->custom_msgs))
 		tell_connectd_custommsgs(p->plugins);
+
+	notify_plugin_stopped(p->plugins->ld, p);
 }
 
 static u32 file_checksum(struct lightningd *ld, const char *path)
@@ -2136,6 +2138,7 @@ static void plugin_config_cb(const char *buffer,
 	}
 	if (tal_count(plugin->custom_msgs))
 		tell_connectd_custommsgs(plugin->plugins);
+	notify_plugin_started(plugin->plugins->ld, plugin);
 	check_plugins_initted(plugin->plugins);
 }
 


### PR DESCRIPTION
Send `plugin_started` when a plugin has completed startup and send `plugin_stopped` when a plugin is shutdown.

This PR follows the same motivations as #7507, and is the second piece of what will be required for other plugins such as clnrest to dynamically register and drop routes.

## What's changed?

Added two new notifications: `plugin_started` and `plugin_stopped`

Updated the docs with the schemas for these notifications