### PR TITLE
Askrene: an EXPERIMENTAL MCF plugin and infrastructure

### DIFF
--- a/bitcoin/short_channel_id.h
+++ b/bitcoin/short_channel_id.h
@@ -41,6 +41,12 @@ struct short_channel_id_dir {
 	int dir;
 };
 
+static inline bool short_channel_id_dir_eq(const struct short_channel_id_dir *a,
+					   const struct short_channel_id_dir *b)
+{
+	return short_channel_id_eq(a->scid, b->scid) && a->dir == b->dir;
+}
+
 static inline u32 short_channel_id_blocknum(struct short_channel_id scid)
 {
 	return scid.u64 >> 40;

--- a/common/amount.h
+++ b/common/amount.h
@@ -144,6 +144,19 @@ bool amount_msat_eq_sat(struct amount_msat msat, struct amount_sat sat);
 /* a / b */
 double amount_msat_ratio(struct amount_msat a, struct amount_msat b);
 
+/* min(a,b) and max(a,b) */
+static inline struct amount_msat amount_msat_min(struct amount_msat a,
+						 struct amount_msat b)
+{
+	return amount_msat_less(a, b) ? a : b;
+}
+
+static inline struct amount_msat amount_msat_max(struct amount_msat a,
+						 struct amount_msat b)
+{
+	return amount_msat_greater(a, b) ? a : b;
+}
+
 /* Check whether this asset is actually the main / fee-paying asset of the
  * current chain. */
 bool amount_asset_is_main(struct amount_asset *asset);

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -161,7 +161,7 @@ static inline bool gossmap_chan_set(const struct gossmap_chan *chan, int dir)
 	return chan->cupdate_off[dir] != 0;
 }
 
-/* Return capacity if it's known (fails only on race condition, or a local mod) */
+/* Return capacity if it's known (fails on a local mod) */
 bool gossmap_chan_get_capacity(const struct gossmap *map,
 			       const struct gossmap_chan *c,
 			       struct amount_sat *amount);

--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -242,6 +242,19 @@ bool gossmap_chan_has_capacity(const struct gossmap_chan *chan,
 			       int direction,
 			       struct amount_msat amount);
 
+/* Convenience routines to get htlc min/max as amount_msat */
+static inline struct amount_msat
+gossmap_chan_htlc_max(const struct gossmap_chan *chan, const int dir)
+{
+	return amount_msat(fp16_to_u64(chan->half[dir].htlc_max));
+}
+
+static inline struct amount_msat
+gossmap_chan_htlc_min(const struct gossmap_chan *chan, const int dir)
+{
+	return amount_msat(fp16_to_u64(chan->half[dir].htlc_min));
+}
+
 /* Remove a channel from the map (warning! realloc can move gossmap_chan
  * and gossmap_node ptrs!) */
 void gossmap_remove_chan(struct gossmap *map, struct gossmap_chan *chan);

--- a/common/json_param.c
+++ b/common/json_param.c
@@ -520,6 +520,18 @@ struct command_result *param_sha256(struct command *cmd, const char *name,
 				     "should be a 32 byte hex value");
 }
 
+struct command_result *param_u16(struct command *cmd, const char *name,
+				 const char *buffer, const jsmntok_t *tok,
+				 uint16_t **num)
+{
+	*num = tal(cmd, uint16_t);
+	if (json_to_u16(buffer, tok, *num))
+		return NULL;
+
+	return command_fail_badparam(cmd, name, buffer, tok,
+				     "should be an unsigned 16 bit integer");
+}
+
 struct command_result *param_u32(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t *tok,
 				 uint32_t **num)

--- a/common/json_param.h
+++ b/common/json_param.h
@@ -220,6 +220,11 @@ struct command_result *param_sha256(struct command *cmd, const char *name,
 				    struct sha256 **hash);
 
 /* Extract number from this (may be a string, or a number literal) */
+struct command_result *param_u16(struct command *cmd, const char *name,
+				 const char *buffer, const jsmntok_t *tok,
+				 uint16_t **num);
+
+/* Extract number from this (may be a string, or a number literal) */
 struct command_result *param_u32(struct command *cmd, const char *name,
 				 const char *buffer, const jsmntok_t *tok,
 				 uint32_t **num);

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -192,6 +192,660 @@
         }
       ]
     },
+    "lightning-askrene-age.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-age",
+      "title": "Command for expiring information in a layer (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-age** RPC command tells askrene that information added to a layer by *askrene-inform-channel* beyond a certain age is less useful.  It currently completely forgets constraints older than *cutoff*."
+      ],
+      "request": {
+        "required": [
+          "layer",
+          "cutoff"
+        ],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The name of the layer to apply this change to."
+            ]
+          },
+          "cutoff": {
+            "type": "u64",
+            "description": [
+              "The UNIX timestamp: constraints older than this will be forgotten."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "layer",
+          "num_removed"
+        ],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The *layer* parameter provided."
+            ]
+          },
+          "num_removed": {
+            "type": "u64",
+            "description": [
+              "The number of constraints removed from *layer*"
+            ]
+          }
+        }
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-listlayers(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-create-channel.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-create-channel",
+      "title": "Command to add a channel to layer (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-create-channel** RPC command tells askrene to populate one direction of a channel in the given layer.  If the channel already exists, it will be overridden.  If the layer does not exist, it will be created."
+      ],
+      "request": {
+        "required": [
+          "layer",
+          "source",
+          "destination",
+          "short_channel_id",
+          "capacity_msat",
+          "htlc_min",
+          "htlc_max",
+          "base_fee",
+          "proportional_fee",
+          "delay"
+        ],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The name of the layer to apply this change to."
+            ]
+          },
+          "source": {
+            "type": "pubkey",
+            "description": [
+              "The source node id for the channel."
+            ]
+          },
+          "destination": {
+            "type": "pubkey",
+            "description": [
+              "The destination node id for the channel."
+            ]
+          },
+          "short_channel_id": {
+            "type": "short_channel_id",
+            "description": [
+              "The short channel id for the channel.  If a channel with this short channel id already exists in *layer*, the *source*, *destination* and *capacity_msat* must be the same."
+            ]
+          },
+          "capacity_msat": {
+            "type": "msat",
+            "description": [
+              "The capacity (onchain size) of the channel."
+            ]
+          },
+          "htlc_min": {
+            "type": "msat",
+            "description": [
+              "The minimum value allowed in this direction."
+            ]
+          },
+          "htlc_max": {
+            "type": "msat",
+            "description": [
+              "The maximum value allowed in this direction."
+            ]
+          },
+          "base_fee": {
+            "type": "msat",
+            "description": [
+              "The base fee to apply to use the channel in this direction."
+            ]
+          },
+          "proportional_fee": {
+            "type": "u32",
+            "description": [
+              "The proportional fee (in parts per million) to apply to use the channel in this direction."
+            ]
+          },
+          "delay": {
+            "type": "u16",
+            "description": [
+              "The CLTV delay required for this direction."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [],
+        "properties": {}
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-listlayers(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-disable-node.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-disable-node",
+      "title": "Command to disable all channels to/from a node in a layer (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-disable-node** RPC command tells askrene to disable all channels connected to a node whenever the given layer is used.  This is mainly useful to force the use of alternate paths: while individual channels can be disabled using askrene-create-channel or askrene-inform-channel, that would be racy if new channels appeared."
+      ],
+      "request": {
+        "required": [
+          "layer",
+          "node"
+        ],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The name of the layer to apply this change to."
+            ]
+          },
+          "node": {
+            "type": "pubkey",
+            "description": [
+              "The node to disable.  It does not need to exist."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [],
+        "properties": {}
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-listlayers(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-inform-channel.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-inform-channel",
+      "title": "Command to add channel capacity restrictions to layer (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-inform-channel** RPC command tells askrene about the minimum or maximum current capacity of a given channel.  It can be applied whether the curren channel exists or not.  If the layer does not exist, it will be created."
+      ],
+      "request": {
+        "required": [
+          "layer",
+          "short_channel_id",
+          "direction"
+        ],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The name of the layer to apply this change to."
+            ]
+          },
+          "short_channel_id": {
+            "type": "short_channel_id",
+            "description": [
+              "The short channel id to apply this change to."
+            ]
+          },
+          "direction": {
+            "type": "u32",
+            "description": [
+              "The direction to apply this change to."
+            ]
+          },
+          "maximum_msat": {
+            "type": "msat",
+            "description": [
+              "The maximum value which this channel could pass.  This or *minimum_msat* must be specified, but not both."
+            ]
+          },
+          "minimum_msat": {
+            "type": "msat",
+            "description": [
+              "The minumum value which this channel could pass.  This or *minimum_msat* must be specified, but not both."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "constraint"
+        ],
+        "properties": {
+          "constraint": {
+            "type": "object",
+            "required": [
+              "short_channel_id",
+              "direction",
+              "timestamp"
+            ],
+            "properties": {
+              "short_channel_id": {
+                "type": "short_channel_id",
+                "description": [
+                  "The *short_channel_id* specified."
+                ]
+              },
+              "direction": {
+                "type": "u32",
+                "description": [
+                  "The *direction* specified."
+                ]
+              },
+              "timestamp": {
+                "type": "u64",
+                "description": [
+                  "The UNIX time (seconds since 1970) this was created."
+                ]
+              },
+              "maximum_msat": {
+                "type": "msat",
+                "description": [
+                  "The *minimum_msat* (if specified)"
+                ]
+              },
+              "minimum_msat": {
+                "type": "msat",
+                "description": [
+                  "The *maximum_msat* (if specified)"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-listlayers(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-listlayers.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-listlayers",
+      "title": "Command to display information about layers (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-listlayers** RPC command reports any modifications each layer (or, the layer specified) would make to the topology, if it were used for *getroutes*."
+      ],
+      "request": {
+        "required": [],
+        "properties": {
+          "layer": {
+            "type": "string",
+            "description": [
+              "The name of the layer to report on."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "layers"
+        ],
+        "properties": {
+          "layers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "layer",
+                "disabled_nodes",
+                "created_channels",
+                "constraints"
+              ],
+              "properties": {
+                "layer": {
+                  "type": "string",
+                  "description": [
+                    "The name of the layer."
+                  ]
+                },
+                "disabled_nodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "pubkey",
+                    "description": [
+                      "The id of the disabled node."
+                    ]
+                  }
+                },
+                "created_channels": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "source",
+                      "destination",
+                      "short_channel_id",
+                      "capacity_msat",
+                      "htlc_minimum_msat",
+                      "htlc_maximum_msat",
+                      "fee_base_msat",
+                      "fee_proportional_millionths",
+                      "delay"
+                    ],
+                    "properties": {
+                      "source": {
+                        "type": "pubkey",
+                        "description": [
+                          "The source node id for the channel."
+                        ]
+                      },
+                      "destination": {
+                        "type": "pubkey",
+                        "description": [
+                          "The destination node id for the channel."
+                        ]
+                      },
+                      "short_channel_id": {
+                        "type": "short_channel_id",
+                        "description": [
+                          "The short channel id for the channel."
+                        ]
+                      },
+                      "capacity_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The capacity (onchain size) of the channel."
+                        ]
+                      },
+                      "htlc_minimum_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The minimum value allowed in this direction."
+                        ]
+                      },
+                      "htlc_maximum_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The maximum value allowed in this direction."
+                        ]
+                      },
+                      "fee_base_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The base fee to apply to use the channel in this direction."
+                        ]
+                      },
+                      "fee_proportional_millionths": {
+                        "type": "u32",
+                        "description": [
+                          "The proportional fee (in parts per million) to apply to use the channel in this direction."
+                        ]
+                      },
+                      "delay": {
+                        "type": "u16",
+                        "description": [
+                          "The CLTV delay required for this direction."
+                        ]
+                      }
+                    }
+                  }
+                },
+                "constraints": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "short_channel_id",
+                      "direction"
+                    ],
+                    "properties": {
+                      "short_channel_id": {
+                        "type": "short_channel_id",
+                        "description": [
+                          "The short channel id."
+                        ]
+                      },
+                      "direction": {
+                        "type": "u32",
+                        "description": [
+                          "The direction."
+                        ]
+                      },
+                      "maximum_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The maximum value which this channel could pass.  This or *minimum_msat* will be present, but not both."
+                        ]
+                      },
+                      "minimum_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The minimum value which this channel could pass.  This or *minimum_msat* will be present, but not both."
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-reserve.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-reserve",
+      "title": "Command for informing askrene that you are trying a path (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-reserve** RPC command tells askrene that a path is being attempted.  This allows it to take that into account when other *getroutes* calls are made.  You should call **askrene-unreserve** after the attempt has completed.",
+        "",
+        "Note that additional properties inside the *path* elements are ignored, which is useful when used with the result of *getroutes*."
+      ],
+      "request": {
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "short_channel_id",
+                "direction",
+                "amount_msat"
+              ],
+              "properties": {
+                "short_channel_id": {
+                  "type": "short_channel_id",
+                  "description": [
+                    "The channel joining these nodes."
+                  ]
+                },
+                "direction": {
+                  "type": "u32",
+                  "description": [
+                    "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+                  ]
+                },
+                "amount_msat": {
+                  "type": "msat",
+                  "description": [
+                    "The amount to send into this hop."
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "response": {
+        "required": [],
+        "properties": {}
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-unreserve(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-listlayers(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
+    "lightning-askrene-unreserve.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "askrene-unreserve",
+      "title": "Command for informing askrene that you are no longer trying a path (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **askrene-unreserve** RPC command tells askrene that a path attempt has finished: it should only be called after a successful **askrene-reserve** call.",
+        "",
+        "Note that additional properties inside the *path* elements are ignored, which is useful when used with the result of *getroutes*."
+      ],
+      "request": {
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "short_channel_id",
+                "direction",
+                "amount_msat"
+              ],
+              "properties": {
+                "short_channel_id": {
+                  "type": "short_channel_id",
+                  "description": [
+                    "The channel joining these nodes."
+                  ]
+                },
+                "direction": {
+                  "type": "u32",
+                  "description": [
+                    "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+                  ]
+                },
+                "amount_msat": {
+                  "type": "msat",
+                  "description": [
+                    "The amount to send into this hop."
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "response": {
+        "required": [],
+        "properties": {}
+      },
+      "see_also": [
+        "lightning-getroutes(7)",
+        "lightning-askrene-reserve(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-listlayers(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
     "lightning-autoclean-once.json": {
       "$schema": "../rpc-schema-draft.json",
       "type": "object",
@@ -12736,6 +13390,180 @@
             ]
           }
         }
+      ]
+    },
+    "lightning-getroutes.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "getroutes",
+      "title": "Command for routing a payment (EXPERIMENTAL)",
+      "description": [
+        "WARNING: experimental, so API may change.",
+        "",
+        "The **getroutes** RPC command attempts to find the best set of paths for the payment from *source* to *destination* of *amount_msat*, using the given *layers* on top of the gossip information.  The result is constrained by *maxfee*, and will arrive at the destiation with *finalcltv*.",
+        "",
+        "Layers are generally maintained by plugins, either to contain persistent information about capacities which have been discovered, or to contain transient information for this particular payment (such as blinded paths or routehints).",
+        "",
+        "There are two automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities, and *auto.sourcefree* overrides all channels leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node."
+      ],
+      "categories": [
+        "readonly"
+      ],
+      "request": {
+        "required": [
+          "source",
+          "destination",
+          "amount_msat",
+          "layers",
+          "maxfee_msat",
+          "finalcltv"
+        ],
+        "properties": {
+          "source": {
+            "type": "pubkey",
+            "description": [
+              "Node pubkey to start the paths"
+            ]
+          },
+          "destination": {
+            "type": "pubkey",
+            "description": [
+              "Node pubkey to end the paths"
+            ]
+          },
+          "amount_msat": {
+            "type": "msat",
+            "description": [
+              "Amount to send. It can be a whole number, or a whole number ending in *msat* or *sat*, or a number with three decimal places ending in *sat*, or a number with 1 to 11 decimal places ending in *btc*."
+            ]
+          },
+          "layers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": [
+                "Layer to apply to the gossip map before attempting to find routes."
+              ]
+            }
+          },
+          "maxfee_msat": {
+            "type": "msat",
+            "description": [
+              "Maximum fee to spend: we will never return a set of routes more expensive than this. It can be a whole number, or a whole number ending in *msat* or *sat*, or a number with three decimal places ending in *sat*, or a number with 1 to 11 decimal places ending in *btc*."
+            ]
+          },
+          "finalcltv": {
+            "type": "u32",
+            "description": [
+              "Number of blocks for the final node.  We need to know this because no HTLC is allowed to have a CLTV delay more than 2016 blocks."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "probability_ppm",
+          "routes"
+        ],
+        "properties": {
+          "probability_ppm": {
+            "type": "u64",
+            "description": [
+              "The estimated probability of success using these routes, in millionths."
+            ]
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "probability_ppm",
+                "amount_msat",
+                "path"
+              ],
+              "properties": {
+                "probability_ppm": {
+                  "type": "u64",
+                  "description": [
+                    "The estimated probability of success using this route, in millionths."
+                  ]
+                },
+                "amount_msat": {
+                  "type": "msat",
+                  "description": [
+                    "The amount delivered to the *destination* by this path."
+                  ]
+                },
+                "path": {
+                  "type": "array",
+                  "description": [
+                    "The hops to get from *source* to *destination*."
+                  ],
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "short_channel_id",
+                      "direction",
+                      "next_node_id",
+                      "amount_msat",
+                      "delay"
+                    ],
+                    "properties": {
+                      "short_channel_id": {
+                        "type": "short_channel_id",
+                        "description": [
+                          "The channel joining these nodes."
+                        ]
+                      },
+                      "direction": {
+                        "type": "u32",
+                        "description": [
+                          "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+                        ]
+                      },
+                      "amount_msat": {
+                        "type": "msat",
+                        "description": [
+                          "The amount to send into this hop."
+                        ]
+                      },
+                      "next_node_id": {
+                        "type": "pubkey",
+                        "description": [
+                          "The peer id at the end of this hop."
+                        ]
+                      },
+                      "delay": {
+                        "type": "u32",
+                        "description": [
+                          "The total CLTV expected by the node at the start of this hop."
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "author": [
+        "<<lagrang3@protonmail.com>> wrote the minimum-cost-flow solver, Rusty Russell <<rusty@rustcorp.com.au>> wrote the API and this documentation."
+      ],
+      "see_also": [
+        "lightning-askrene-reserve(7)",
+        "lightning-askrene-unreserve(7)",
+        "lightning-askrene-disable-node(7)",
+        "lightning-askrene-create-channel(7)",
+        "lightning-askrene-inform-channel(7)",
+        "lightning-askrene-report(7)",
+        "lightning-askrene-age(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
       ]
     },
     "lightning-help.json": {

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,6 +6,12 @@ doc-wrongdir:
 
 GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-addpsbtoutput.7 \
+	doc/lightning-askrene-create-channel.7 \
+	doc/lightning-askrene-disable-node.7 \
+	doc/lightning-askrene-inform-channel.7 \
+	doc/lightning-askrene-listlayers.7 \
+	doc/lightning-askrene-reserve.7 \
+	doc/lightning-askrene-unreserve.7 \
 	doc/lightning-autoclean-once.7 \
 	doc/lightning-autoclean-status.7 \
 	doc/lightning-batching.7 \
@@ -53,6 +59,7 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-getinfo.7 \
 	doc/lightning-getlog.7 \
 	doc/lightning-getroute.7 \
+	doc/lightning-getroutes.7 \
 	doc/lightning-help.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-invoicerequest.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,12 @@ Core Lightning Documentation
  .. block_start manpages
    lightning-addgossip <lightning-addgossip.7.md>
    lightning-addpsbtoutput <lightning-addpsbtoutput.7.md>
+   lightning-askrene-create-channel <lightning-askrene-create-channel.7.md>
+   lightning-askrene-disable-node <lightning-askrene-disable-node.7.md>
+   lightning-askrene-inform-channel <lightning-askrene-inform-channel.7.md>
+   lightning-askrene-listlayers <lightning-askrene-listlayers.7.md>
+   lightning-askrene-reserve <lightning-askrene-reserve.7.md>
+   lightning-askrene-unreserve <lightning-askrene-unreserve.7.md>
    lightning-autoclean-once <lightning-autoclean-once.7.md>
    lightning-autoclean-status <lightning-autoclean-status.7.md>
    lightning-batching <lightning-batching.7.md>
@@ -62,6 +68,7 @@ Core Lightning Documentation
    lightning-getinfo <lightning-getinfo.7.md>
    lightning-getlog <lightning-getlog.7.md>
    lightning-getroute <lightning-getroute.7.md>
+   lightning-getroutes <lightning-getroutes.7.md>
    lightning-help <lightning-help.7.md>
    lightning-hsmtool <lightning-hsmtool.8.md>
    lightning-invoice <lightning-invoice.7.md>

--- a/doc/schemas/lightning-askrene-age.json
+++ b/doc/schemas/lightning-askrene-age.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-age",
+  "title": "Command for expiring information in a layer (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-age** RPC command tells askrene that information added to a layer by *askrene-inform-channel* beyond a certain age is less useful.  It currently completely forgets constraints older than *cutoff*."
+  ],
+  "request": {
+    "required": [
+      "layer",
+      "cutoff"
+    ],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The name of the layer to apply this change to."
+        ]
+      },
+      "cutoff": {
+        "type": "u64",
+        "description": [
+          "The UNIX timestamp: constraints older than this will be forgotten."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "layer",
+      "num_removed"
+    ],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The *layer* parameter provided."
+        ]
+      },
+      "num_removed": {
+        "type": "u64",
+        "description": [
+          "The number of constraints removed from *layer*"
+        ]
+      }
+    }
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-listlayers(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-create-channel.json
+++ b/doc/schemas/lightning-askrene-create-channel.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-create-channel",
+  "title": "Command to add a channel to layer (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-create-channel** RPC command tells askrene to populate one direction of a channel in the given layer.  If the channel already exists, it will be overridden.  If the layer does not exist, it will be created."
+  ],
+  "request": {
+    "required": [
+      "layer",
+      "source",
+      "destination",
+      "short_channel_id",
+      "capacity_msat",
+      "htlc_min",
+      "htlc_max",
+      "base_fee",
+      "proportional_fee",
+      "delay"
+    ],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The name of the layer to apply this change to."
+        ]
+      },
+      "source": {
+        "type": "pubkey",
+        "description": [
+          "The source node id for the channel."
+        ]
+      },
+      "destination": {
+        "type": "pubkey",
+        "description": [
+          "The destination node id for the channel."
+        ]
+      },
+      "short_channel_id": {
+        "type": "short_channel_id",
+        "description": [
+          "The short channel id for the channel.  If a channel with this short channel id already exists in *layer*, the *source*, *destination* and *capacity_msat* must be the same."
+        ]
+      },
+      "capacity_msat": {
+        "type": "msat",
+        "description": [
+          "The capacity (onchain size) of the channel."
+        ]
+      },
+      "htlc_min": {
+        "type": "msat",
+        "description": [
+          "The minimum value allowed in this direction."
+        ]
+      },
+      "htlc_max": {
+        "type": "msat",
+        "description": [
+          "The maximum value allowed in this direction."
+        ]
+      },
+      "base_fee": {
+        "type": "msat",
+        "description": [
+          "The base fee to apply to use the channel in this direction."
+        ]
+      },
+      "proportional_fee": {
+        "type": "u32",
+        "description": [
+          "The proportional fee (in parts per million) to apply to use the channel in this direction."
+        ]
+      },
+      "delay": {
+        "type": "u16",
+        "description": [
+          "The CLTV delay required for this direction."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [],
+    "properties": {}
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-listlayers(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-disable-node.json
+++ b/doc/schemas/lightning-askrene-disable-node.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-disable-node",
+  "title": "Command to disable all channels to/from a node in a layer (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-disable-node** RPC command tells askrene to disable all channels connected to a node whenever the given layer is used.  This is mainly useful to force the use of alternate paths: while individual channels can be disabled using askrene-create-channel or askrene-inform-channel, that would be racy if new channels appeared."
+  ],
+  "request": {
+    "required": [
+      "layer",
+      "node"
+    ],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The name of the layer to apply this change to."
+        ]
+      },
+      "node": {
+        "type": "pubkey",
+        "description": [
+          "The node to disable.  It does not need to exist."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [],
+    "properties": {}
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-listlayers(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-inform-channel.json
+++ b/doc/schemas/lightning-askrene-inform-channel.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-inform-channel",
+  "title": "Command to add channel capacity restrictions to layer (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-inform-channel** RPC command tells askrene about the minimum or maximum current capacity of a given channel.  It can be applied whether the curren channel exists or not.  If the layer does not exist, it will be created."
+  ],
+  "request": {
+    "required": [
+      "layer",
+      "short_channel_id",
+      "direction"
+    ],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The name of the layer to apply this change to."
+        ]
+      },
+      "short_channel_id": {
+        "type": "short_channel_id",
+        "description": [
+          "The short channel id to apply this change to."
+        ]
+      },
+      "direction": {
+        "type": "u32",
+        "description": [
+          "The direction to apply this change to."
+        ]
+      },
+      "maximum_msat": {
+        "type": "msat",
+        "description": [
+          "The maximum value which this channel could pass.  This or *minimum_msat* must be specified, but not both."
+        ]
+      },
+      "minimum_msat": {
+        "type": "msat",
+        "description": [
+          "The minumum value which this channel could pass.  This or *minimum_msat* must be specified, but not both."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "constraint"
+    ],
+    "properties": {
+      "constraint": {
+        "type": "object",
+        "required": [
+          "short_channel_id",
+          "direction",
+          "timestamp"
+        ],
+        "properties": {
+          "short_channel_id": {
+            "type": "short_channel_id",
+            "description": [
+              "The *short_channel_id* specified."
+            ]
+          },
+          "direction": {
+            "type": "u32",
+            "description": [
+              "The *direction* specified."
+            ]
+          },
+          "timestamp": {
+            "type": "u64",
+            "description": [
+              "The UNIX time (seconds since 1970) this was created."
+            ]
+          },
+          "maximum_msat": {
+            "type": "msat",
+            "description": [
+              "The *minimum_msat* (if specified)"
+            ]
+          },
+          "minimum_msat": {
+            "type": "msat",
+            "description": [
+              "The *maximum_msat* (if specified)"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-listlayers(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-listlayers.json
+++ b/doc/schemas/lightning-askrene-listlayers.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-listlayers",
+  "title": "Command to display information about layers (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-listlayers** RPC command reports any modifications each layer (or, the layer specified) would make to the topology, if it were used for *getroutes*."
+  ],
+  "request": {
+    "required": [],
+    "properties": {
+      "layer": {
+        "type": "string",
+        "description": [
+          "The name of the layer to report on."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "layers"
+    ],
+    "properties": {
+      "layers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "layer",
+            "disabled_nodes",
+            "created_channels",
+            "constraints"
+          ],
+          "properties": {
+            "layer": {
+              "type": "string",
+              "description": [
+                "The name of the layer."
+              ]
+            },
+            "disabled_nodes": {
+              "type": "array",
+              "items": {
+                "type": "pubkey",
+                "description": [
+                  "The id of the disabled node."
+                ]
+              }
+            },
+            "created_channels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "source",
+                  "destination",
+                  "short_channel_id",
+                  "capacity_msat",
+                  "htlc_minimum_msat",
+                  "htlc_maximum_msat",
+                  "fee_base_msat",
+                  "fee_proportional_millionths",
+                  "delay"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "pubkey",
+                    "description": [
+                      "The source node id for the channel."
+                    ]
+                  },
+                  "destination": {
+                    "type": "pubkey",
+                    "description": [
+                      "The destination node id for the channel."
+                    ]
+                  },
+                  "short_channel_id": {
+                    "type": "short_channel_id",
+                    "description": [
+                      "The short channel id for the channel."
+                    ]
+                  },
+                  "capacity_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The capacity (onchain size) of the channel."
+                    ]
+                  },
+                  "htlc_minimum_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The minimum value allowed in this direction."
+                    ]
+                  },
+                  "htlc_maximum_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The maximum value allowed in this direction."
+                    ]
+                  },
+                  "fee_base_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The base fee to apply to use the channel in this direction."
+                    ]
+                  },
+                  "fee_proportional_millionths": {
+                    "type": "u32",
+                    "description": [
+                      "The proportional fee (in parts per million) to apply to use the channel in this direction."
+                    ]
+                  },
+                  "delay": {
+                    "type": "u16",
+                    "description": [
+                      "The CLTV delay required for this direction."
+                    ]
+                  }
+                }
+              }
+            },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "short_channel_id",
+                  "direction"
+                ],
+                "properties": {
+                  "short_channel_id": {
+                    "type": "short_channel_id",
+                    "description": [
+                      "The short channel id."
+                    ]
+                  },
+                  "direction": {
+                    "type": "u32",
+                    "description": [
+                      "The direction."
+                    ]
+                  },
+                  "maximum_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The maximum value which this channel could pass.  This or *minimum_msat* will be present, but not both."
+                    ]
+                  },
+                  "minimum_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The minimum value which this channel could pass.  This or *minimum_msat* will be present, but not both."
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-reserve.json
+++ b/doc/schemas/lightning-askrene-reserve.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-reserve",
+  "title": "Command for informing askrene that you are trying a path (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-reserve** RPC command tells askrene that a path is being attempted.  This allows it to take that into account when other *getroutes* calls are made.  You should call **askrene-unreserve** after the attempt has completed.",
+    "",
+    "Note that additional properties inside the *path* elements are ignored, which is useful when used with the result of *getroutes*."
+  ],
+  "request": {
+    "required": [
+      "path"
+    ],
+    "properties": {
+      "path": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "short_channel_id",
+            "direction",
+            "amount_msat"
+          ],
+          "properties": {
+            "short_channel_id": {
+              "type": "short_channel_id",
+              "description": [
+                "The channel joining these nodes."
+              ]
+            },
+            "direction": {
+              "type": "u32",
+              "description": [
+                "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+              ]
+            },
+            "amount_msat": {
+              "type": "msat",
+              "description": [
+                "The amount to send into this hop."
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "response": {
+    "required": [],
+    "properties": {}
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-unreserve(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-listlayers(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-askrene-unreserve.json
+++ b/doc/schemas/lightning-askrene-unreserve.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "askrene-unreserve",
+  "title": "Command for informing askrene that you are no longer trying a path (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **askrene-unreserve** RPC command tells askrene that a path attempt has finished: it should only be called after a successful **askrene-reserve** call.",
+    "",
+    "Note that additional properties inside the *path* elements are ignored, which is useful when used with the result of *getroutes*."
+  ],
+  "request": {
+    "required": [
+      "path"
+    ],
+    "properties": {
+      "path": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "short_channel_id",
+            "direction",
+            "amount_msat"
+          ],
+          "properties": {
+            "short_channel_id": {
+              "type": "short_channel_id",
+              "description": [
+                "The channel joining these nodes."
+              ]
+            },
+            "direction": {
+              "type": "u32",
+              "description": [
+                "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+              ]
+            },
+            "amount_msat": {
+              "type": "msat",
+              "description": [
+                "The amount to send into this hop."
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "response": {
+    "required": [],
+    "properties": {}
+  },
+  "see_also": [
+    "lightning-getroutes(7)",
+    "lightning-askrene-reserve(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-listlayers(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/doc/schemas/lightning-getroutes.json
+++ b/doc/schemas/lightning-getroutes.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "getroutes",
+  "title": "Command for routing a payment (EXPERIMENTAL)",
+  "description": [
+    "WARNING: experimental, so API may change.",
+    "",
+    "The **getroutes** RPC command attempts to find the best set of paths for the payment from *source* to *destination* of *amount_msat*, using the given *layers* on top of the gossip information.  The result is constrained by *maxfee*, and will arrive at the destiation with *finalcltv*.",
+    "",
+    "Layers are generally maintained by plugins, either to contain persistent information about capacities which have been discovered, or to contain transient information for this particular payment (such as blinded paths or routehints).",
+    "",
+    "There are two automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities, and *auto.sourcefree* overrides all channels leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node."
+  ],
+  "categories": [
+    "readonly"
+  ],
+  "request": {
+    "required": [
+      "source",
+      "destination",
+      "amount_msat",
+      "layers",
+      "maxfee_msat",
+      "finalcltv"
+    ],
+    "properties": {
+      "source": {
+        "type": "pubkey",
+        "description": [
+          "Node pubkey to start the paths"
+        ]
+      },
+      "destination": {
+        "type": "pubkey",
+        "description": [
+          "Node pubkey to end the paths"
+        ]
+      },
+      "amount_msat": {
+        "type": "msat",
+        "description": [
+          "Amount to send. It can be a whole number, or a whole number ending in *msat* or *sat*, or a number with three decimal places ending in *sat*, or a number with 1 to 11 decimal places ending in *btc*."
+        ]
+      },
+      "layers": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": [
+            "Layer to apply to the gossip map before attempting to find routes."
+          ]
+        }
+      },
+      "maxfee_msat": {
+        "type": "msat",
+        "description": [
+          "Maximum fee to spend: we will never return a set of routes more expensive than this. It can be a whole number, or a whole number ending in *msat* or *sat*, or a number with three decimal places ending in *sat*, or a number with 1 to 11 decimal places ending in *btc*."
+        ]
+      },
+      "finalcltv": {
+        "type": "u32",
+        "description": [
+          "Number of blocks for the final node.  We need to know this because no HTLC is allowed to have a CLTV delay more than 2016 blocks."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "probability_ppm",
+      "routes"
+    ],
+    "properties": {
+      "probability_ppm": {
+        "type": "u64",
+        "description": [
+          "The estimated probability of success using these routes, in millionths."
+        ]
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "probability_ppm",
+            "amount_msat",
+            "path"
+          ],
+          "properties": {
+            "probability_ppm": {
+              "type": "u64",
+              "description": [
+                "The estimated probability of success using this route, in millionths."
+              ]
+            },
+            "amount_msat": {
+              "type": "msat",
+              "description": [
+                "The amount delivered to the *destination* by this path."
+              ]
+            },
+            "path": {
+              "type": "array",
+              "description": [
+                "The hops to get from *source* to *destination*."
+              ],
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "short_channel_id",
+                  "direction",
+                  "next_node_id",
+                  "amount_msat",
+                  "delay"
+                ],
+                "properties": {
+                  "short_channel_id": {
+                    "type": "short_channel_id",
+                    "description": [
+                      "The channel joining these nodes."
+                    ]
+                  },
+                  "direction": {
+                    "type": "u32",
+                    "description": [
+                      "0 if this channel is traversed from lesser to greater **id**, otherwise 1."
+                    ]
+                  },
+                  "amount_msat": {
+                    "type": "msat",
+                    "description": [
+                      "The amount to send into this hop."
+                    ]
+                  },
+                  "next_node_id": {
+                    "type": "pubkey",
+                    "description": [
+                      "The peer id at the end of this hop."
+                    ]
+                  },
+                  "delay": {
+                    "type": "u32",
+                    "description": [
+                      "The total CLTV expected by the node at the start of this hop."
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "author": [
+    "<<lagrang3@protonmail.com>> wrote the minimum-cost-flow solver, Rusty Russell <<rusty@rustcorp.com.au>> wrote the API and this documentation."
+  ],
+  "see_also": [
+    "lightning-askrene-reserve(7)",
+    "lightning-askrene-unreserve(7)",
+    "lightning-askrene-disable-node(7)",
+    "lightning-askrene-create-channel(7)",
+    "lightning-askrene-inform-channel(7)",
+    "lightning-askrene-report(7)",
+    "lightning-askrene-age(7)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -100,7 +100,8 @@ C_PLUGINS :=					\
 	plugins/recover				\
 	plugins/txprepare			\
 	plugins/cln-renepay			\
-	plugins/spenderp
+	plugins/spenderp			\
+	plugins/cln-askrene
 
 PY_PLUGINS :=					\
 	plugins/clnrest/clnrest \
@@ -176,6 +177,7 @@ PLUGIN_COMMON_OBJS :=				\
 	wire/tlvstream.o			\
 	wire/towire.o
 
+include plugins/askrene/Makefile
 include plugins/bkpr/Makefile
 include plugins/renepay/Makefile
 

--- a/plugins/askrene/Makefile
+++ b/plugins/askrene/Makefile
@@ -1,5 +1,5 @@
-PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c
-PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h
+PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c plugins/askrene/layer.c
+PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h plugins/askrene/layer.h
 PLUGIN_ASKRENE_OBJS := $(PLUGIN_ASKRENE_SRC:.c=.o)
 
 $(PLUGIN_ASKRENE_OBJS): $(PLUGIN_ASKRENE_HEADER)

--- a/plugins/askrene/Makefile
+++ b/plugins/askrene/Makefile
@@ -1,0 +1,10 @@
+PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c
+PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h
+PLUGIN_ASKRENE_OBJS := $(PLUGIN_ASKRENE_SRC:.c=.o)
+
+$(PLUGIN_ASKRENE_OBJS): $(PLUGIN_ASKRENE_HEADER)
+
+ALL_C_SOURCES += $(PLUGIN_ASKRENE_SRC)
+ALL_C_HEADERS += $(PLUGIN_ASKRENE_HEADER)
+
+plugins/cln-askrene: $(PLUGIN_ASKRENE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) bitcoin/chainparams.o common/gossmap.o common/sciddir_or_pubkey.o common/gossmods_listpeerchannels.o common/fp16.o common/dijkstra.o common/bolt12.o common/bolt12_merkle.o wire/bolt12_wiregen.o wire/onion_wiregen.o

--- a/plugins/askrene/Makefile
+++ b/plugins/askrene/Makefile
@@ -1,5 +1,5 @@
-PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c plugins/askrene/layer.c plugins/askrene/reserve.c
-PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h plugins/askrene/layer.h plugins/askrene/reserve.h
+PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c plugins/askrene/layer.c plugins/askrene/reserve.c plugins/askrene/mcf.c plugins/askrene/dijkstra.c plugins/askrene/flow.c 
+PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h plugins/askrene/layer.h plugins/askrene/reserve.h plugins/askrene/mcf.h plugins/askrene/dijkstra.h plugins/askrene/flow.h
 PLUGIN_ASKRENE_OBJS := $(PLUGIN_ASKRENE_SRC:.c=.o)
 
 $(PLUGIN_ASKRENE_OBJS): $(PLUGIN_ASKRENE_HEADER)

--- a/plugins/askrene/Makefile
+++ b/plugins/askrene/Makefile
@@ -1,5 +1,5 @@
-PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c plugins/askrene/layer.c
-PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h plugins/askrene/layer.h
+PLUGIN_ASKRENE_SRC := plugins/askrene/askrene.c plugins/askrene/layer.c plugins/askrene/reserve.c
+PLUGIN_ASKRENE_HEADER := plugins/askrene/askrene.h plugins/askrene/layer.h plugins/askrene/reserve.h
 PLUGIN_ASKRENE_OBJS := $(PLUGIN_ASKRENE_SRC:.c=.o)
 
 $(PLUGIN_ASKRENE_OBJS): $(PLUGIN_ASKRENE_HEADER)

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -226,18 +226,10 @@ void get_constraints(const struct route_query *rq,
 					   fmt_amount_sat(tmpctx, cap));
 			}
 		} else {
-			/* Local channel? */
-			const struct local_channel *lc;
-
-			/* In case it's not, set max to htlc max. */
-			*max = amount_msat(fp16_to_u64(chan->half[dir].htlc_max));
-			for (size_t i = 0; i < tal_count(rq->layers); i++) {
-				lc = layer_find_local_channel(rq->layers[i], scidd.scid);
-				if (lc) {
-					*max = local_channel_capacity(lc);
-					break;
-				}
-			}
+			/* Shouldn't happen: local channels have explicit constraints */
+			plugin_log(rq->plugin, LOG_BROKEN,
+				   "Channel %s without capacity?",
+				   fmt_short_channel_id(tmpctx, scidd.scid));
 		}
 	}
 

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -1,0 +1,403 @@
+/* All your payment questions answered!
+ *
+ * This powerful oracle combines data from the network, and then
+ * determines optimal routes.
+ *
+ * When you feed it information, these are remembered as "layers", so you
+ * can ask questions with (or without) certain layers.
+ */
+#include "config.h"
+#include <ccan/array_size/array_size.h>
+#include <common/gossmap.h>
+#include <common/json_param.h>
+#include <common/json_stream.h>
+#include <common/route.h>
+#include <errno.h>
+#include <plugins/askrene/askrene.h>
+#include <plugins/libplugin.h>
+
+static struct askrene *get_askrene(struct plugin *plugin)
+{
+	return plugin_get_data(plugin, struct askrene);
+}
+
+/* JSON helpers */
+static struct command_result *param_string_array(struct command *cmd,
+						 const char *name,
+						 const char *buffer,
+						 const jsmntok_t *tok,
+						 const char ***arr)
+{
+	size_t i;
+	const jsmntok_t *t;
+
+	if (tok->type != JSMN_ARRAY)
+		return command_fail_badparam(cmd, name, buffer, tok, "should be an array");
+
+	*arr = tal_arr(cmd, const char *, tok->size);
+	json_for_each_arr(i, t, tok) {
+		if (t->type != JSMN_STRING)
+			return command_fail_badparam(cmd, name, buffer, t, "should be a string");
+		(*arr)[i] = json_strdup(*arr, buffer, t);
+	}
+	return NULL;
+}
+
+static bool json_to_zero_or_one(const char *buffer, const jsmntok_t *tok, int *num)
+{
+	u32 v32;
+	if (!json_to_u32(buffer, tok, &v32))
+		return false;
+	if (v32 != 0 && v32 != 1)
+		return false;
+	*num = v32;
+	return true;
+}
+
+static struct command_result *param_zero_or_one(struct command *cmd,
+						const char *name,
+						const char *buffer,
+						const jsmntok_t *tok,
+						int **num)
+{
+	*num = tal(cmd, int);
+	if (json_to_zero_or_one(buffer, tok, *num))
+		return NULL;
+
+	return command_fail_badparam(cmd, name, buffer, tok,
+				     "should be 0 or 1");
+}
+
+struct reserve_path {
+	struct short_channel_id_dir *scidds;
+	struct amount_msat *amounts;
+};
+
+static struct command_result *parse_reserve_path(struct command *cmd,
+						 const char *name,
+						 const char *buffer,
+						 const jsmntok_t *tok,
+						 struct short_channel_id_dir *scidd,
+						 struct amount_msat *amount)
+{
+	const char *err;
+
+	err = json_scan(tmpctx, buffer, tok, "{short_channel_id:%,direction:%,amount_msat:%s}",
+			JSON_SCAN(json_to_short_channel_id, &scidd->scid),
+			JSON_SCAN(json_to_zero_or_one, &scidd->dir),
+			JSON_SCAN(json_to_msat, amount));
+	if (err)
+		return command_fail_badparam(cmd, name, buffer, tok, err);
+	return NULL;
+}
+
+static struct command_result *param_reserve_path(struct command *cmd,
+						 const char *name,
+						 const char *buffer,
+						 const jsmntok_t *tok,
+						 struct reserve_path **path)
+{
+	size_t i;
+	const jsmntok_t *t;
+
+	if (tok->type != JSMN_ARRAY)
+		return command_fail_badparam(cmd, name, buffer, tok, "should be an array");
+
+	*path = tal(cmd, struct reserve_path);
+	(*path)->scidds = tal_arr(cmd, struct short_channel_id_dir, tok->size);
+	(*path)->amounts = tal_arr(cmd, struct amount_msat, tok->size);
+	json_for_each_arr(i, t, tok) {
+		struct command_result *ret;
+
+		ret = parse_reserve_path(cmd, name, buffer, t,
+					 &(*path)->scidds[i],
+					 &(*path)->amounts[i]);
+		if (ret)
+			return ret;
+	}
+	return NULL;
+}
+
+/* Returns an error message, or sets *routes */
+static const char *get_routes(struct command *cmd,
+			      const struct node_id *source,
+			      const struct node_id *dest,
+			      struct amount_msat amount,
+			      const char **layers,
+			      struct route ***routes)
+{
+	/* FIXME: Do route here!  This is a dummy, single "direct" route. */
+	*routes = tal_arr(cmd, struct route *, 1);
+	(*routes)[0]->success_prob = 1;
+	(*routes)[0]->hops = tal_arr((*routes)[0], struct route_hop, 1);
+	(*routes)[0]->hops[0].scid.u64 = 0x0000010000020003ULL;
+	(*routes)[0]->hops[0].direction = 0;
+	(*routes)[0]->hops[0].node_id = *dest;
+	(*routes)[0]->hops[0].amount = amount;
+	(*routes)[0]->hops[0].delay = 6;
+
+	return NULL;
+}
+
+static struct command_result *json_getroutes(struct command *cmd,
+					     const char *buffer,
+					     const jsmntok_t *params)
+{
+	struct node_id *dest, *source;
+	const char **layers;
+	struct amount_msat *amount;
+	struct route **routes;
+	struct json_stream *response;
+	const char *err;
+
+	if (!param(cmd, buffer, params,
+		   p_req("source", param_node_id, &source),
+		   p_req("destination", param_node_id, &dest),
+		   p_req("amount_msat", param_msat, &amount),
+		   p_req("layers", param_string_array, &layers),
+		   NULL))
+		return command_param_failed();
+
+	err = get_routes(cmd, source, dest, *amount, layers, &routes);
+	if (err)
+		return command_fail(cmd, PAY_ROUTE_NOT_FOUND, "%s", err);
+
+	response = jsonrpc_stream_success(cmd);
+	json_object_start(response, "routes");
+	json_array_start(response, "routes");
+	for (size_t i = 0; i < tal_count(routes); i++) {
+		json_add_u64(response, "probability_ppm", (u64)(routes[i]->success_prob * 1000000));
+		json_array_start(response, "path");
+		for (size_t j = 0; j < tal_count(routes[i]->hops); j++) {
+			const struct route_hop *r = &routes[i]->hops[j];
+			json_add_short_channel_id(response, "short_channel_id", r->scid);
+			json_add_u32(response, "direction", r->direction);
+			json_add_node_id(response, "node_id", &r->node_id);
+			json_add_amount_msat(response, "amount", r->amount);
+			json_add_u32(response, "delay", r->delay);
+		}
+		json_array_end(response);
+	}
+	json_array_end(response);
+	json_object_end(response);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_reserve(struct command *cmd,
+						   const char *buffer,
+						   const jsmntok_t *params)
+{
+	struct reserve_path *path;
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params,
+		   p_req("path", param_reserve_path, &path),
+		   NULL))
+		return command_param_failed();
+
+	response = jsonrpc_stream_success(cmd);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_unreserve(struct command *cmd,
+						     const char *buffer,
+						     const jsmntok_t *params)
+{
+	struct reserve_path *path;
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params,
+		   p_req("path", param_reserve_path, &path),
+		   NULL))
+		return command_param_failed();
+
+	response = jsonrpc_stream_success(cmd);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_create_channel(struct command *cmd,
+							  const char *buffer,
+							  const jsmntok_t *params)
+{
+	const char *layername;
+	struct node_id *src, *dst;
+	struct short_channel_id *scid;
+	struct amount_msat *capacity;
+	struct json_stream *response;
+	struct amount_msat *htlc_min, *htlc_max, *base_fee;
+	u32 *proportional_fee;
+	u16 *delay;
+
+	if (!param_check(cmd, buffer, params,
+			 p_req("layer", param_string, &layername),
+			 p_req("source", param_node_id, &src),
+			 p_req("destination", param_node_id, &dst),
+			 p_req("short_channel_id", param_short_channel_id, &scid),
+			 p_req("capacity_msat", param_msat, &capacity),
+			 p_req("htlc_minimum_msat", param_msat, &htlc_min),
+			 p_req("htlc_maximum_msat", param_msat, &htlc_max),
+			 p_req("fee_base_msat", param_msat, &base_fee),
+			 p_req("fee_proportional_millionths", param_u32, &proportional_fee),
+			 p_req("delay", param_u16, &delay),
+			 NULL))
+		return command_param_failed();
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	response = jsonrpc_stream_success(cmd);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_inform_channel(struct command *cmd,
+							    const char *buffer,
+							    const jsmntok_t *params)
+{
+	const char *layername;
+	struct short_channel_id *scid;
+	int *direction;
+	struct json_stream *response;
+	struct amount_msat *max, *min;
+
+	if (!param_check(cmd, buffer, params,
+			 p_req("layer", param_string, &layername),
+			 p_req("short_channel_id", param_short_channel_id, &scid),
+			 p_req("direction", param_zero_or_one, &direction),
+			 p_opt("minimum_msat", param_msat, &min),
+			 p_opt("maximum_msat", param_msat, &max),
+			 NULL))
+		return command_param_failed();
+
+	if ((!min && !max) || (min && max)) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Must specify exactly one of maximum_msat/minimum_msat");
+	}
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	response = jsonrpc_stream_success(cmd);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_disable_node(struct command *cmd,
+							const char *buffer,
+							const jsmntok_t *params)
+{
+	struct node_id *node;
+	const char *layername;
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params,
+		   p_req("layer", param_string, &layername),
+		   p_req("node", param_node_id, &node),
+		   NULL))
+		return command_param_failed();
+
+	response = jsonrpc_stream_success(cmd);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_listlayers(struct command *cmd,
+						      const char *buffer,
+						      const jsmntok_t *params)
+{
+	const char *layername;
+	struct json_stream *response;
+
+	if (!param(cmd, buffer, params,
+		   p_req("layer", param_string, &layername),
+		   NULL))
+		return command_param_failed();
+
+	response = jsonrpc_stream_success(cmd);
+	json_array_start(response, "layers");
+	json_object_start(response, NULL);
+	json_add_string(response, "layer", layername);
+	json_array_start(response, "disabled_nodes");
+	json_array_end(response);
+	json_array_start(response, "created_channels");
+	json_array_end(response);
+	json_array_start(response, "capacities");
+	json_array_end(response);
+	json_object_end(response);
+	json_array_end(response);
+	return command_finished(cmd, response);
+}
+
+static struct command_result *json_askrene_age(struct command *cmd,
+						 const char *buffer,
+						 const jsmntok_t *params)
+{
+	const char *layername;
+	struct json_stream *response;
+	u64 *cutoff;
+
+	if (!param(cmd, buffer, params,
+		   p_req("layer", param_string, &layername),
+		   p_req("cutoff", param_u64, &cutoff),
+		   NULL))
+		return command_param_failed();
+
+	response = jsonrpc_stream_success(cmd);
+	json_add_string(response, "layer", layername);
+	return command_finished(cmd, response);
+}
+
+static const struct plugin_command commands[] = {
+	{
+		"getroutes",
+		json_getroutes,
+	},
+	{
+		"askrene-reserve",
+		json_askrene_reserve,
+	},
+	{
+		"askrene-unreserve",
+		json_askrene_unreserve,
+	},
+	{
+		"askrene-disable-node",
+		json_askrene_disable_node,
+	},
+	{
+		"askrene-create-channel",
+		json_askrene_create_channel,
+	},
+	{
+		"askrene-inform-channel",
+		json_askrene_inform_channel,
+	},
+	{
+		"askrene-listlayers",
+		json_askrene_listlayers,
+	},
+	{
+		"askrene-age",
+		json_askrene_age,
+	},
+};
+
+static const char *init(struct plugin *plugin,
+			const char *buf UNUSED, const jsmntok_t *config UNUSED)
+{
+	struct askrene *askrene = tal(plugin, struct askrene);
+	askrene->plugin = plugin;
+	askrene->gossmap = gossmap_load(askrene, GOSSIP_STORE_FILENAME, NULL);
+
+	if (!askrene->gossmap)
+		plugin_err(plugin, "Could not load gossmap %s: %s",
+			   GOSSIP_STORE_FILENAME, strerror(errno));
+
+	plugin_set_data(plugin, askrene);
+	(void)get_askrene(plugin);
+	return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true, NULL, commands, ARRAY_SIZE(commands),
+	            NULL, 0, NULL, 0, NULL, 0, NULL);
+}

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -178,7 +178,7 @@ static fp16_t *get_capacities(const tal_t *ctx,
  * channels.  This wouldn't be right if we looped back through ourselves,
  * but we won't. */
 /* FIXME: We could cache this until gossmap changes... */
-static void add_free_source(struct command *cmd,
+static void add_free_source(struct plugin *plugin,
 			    struct gossmap *gossmap,
 			    struct gossmap_localmods *localmods,
 			    const struct node_id *source)
@@ -206,7 +206,7 @@ static void add_free_source(struct command *cmd,
 					      /* Keep enabled flag */
 					      c->half[dir].enabled,
 					      dir))
-			plugin_err(cmd->plugin, "Could not zero fee on local %s",
+			plugin_err(plugin, "Could not zero fee on local %s",
 				   fmt_short_channel_id(tmpctx, scid));
 	}
 }
@@ -262,7 +262,7 @@ static const char *get_routes(struct command *cmd,
 	}
 
 	if (have_layer(layers, "auto.sourcefree"))
-		add_free_source(cmd, askrene->gossmap, localmods, source);
+		add_free_source(cmd->plugin, askrene->gossmap, localmods, source);
 
 	/* Clear scids with reservations, too, so we don't have to look up
 	 * all the time! */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -1,6 +1,9 @@
 #ifndef LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H
 #define LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H
 #include "config.h"
+#include <bitcoin/short_channel_id.h>
+#include <ccan/list/list.h>
+#include <common/amount.h>
 
 /* We reserve a path being used.  This records how many and how much */
 struct reserve {
@@ -21,6 +24,8 @@ struct route {
 struct askrene {
 	struct plugin *plugin;
 	struct gossmap *gossmap;
+	/* List of layers */
+	struct list_head layers;
 };
 
 #endif /* LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -1,0 +1,26 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H
+#define LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H
+#include "config.h"
+
+/* We reserve a path being used.  This records how many and how much */
+struct reserve {
+	size_t num_htlcs;
+	struct short_channel_id_dir sciddir;
+	struct amount_msat amount;
+};
+
+/* A single route. */
+struct route {
+	/* Actual path to take */
+	struct route_hop *hops;
+	/* Probability estimate (0-1) */
+	double success_prob;
+};
+
+/* Grab-bag of "globals" for this plugin */
+struct askrene {
+	struct plugin *plugin;
+	struct gossmap *gossmap;
+};
+
+#endif /* LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -5,13 +5,6 @@
 #include <ccan/list/list.h>
 #include <common/amount.h>
 
-/* We reserve a path being used.  This records how many and how much */
-struct reserve {
-	size_t num_htlcs;
-	struct short_channel_id_dir sciddir;
-	struct amount_msat amount;
-};
-
 /* A single route. */
 struct route {
 	/* Actual path to take */
@@ -26,6 +19,8 @@ struct askrene {
 	struct gossmap *gossmap;
 	/* List of layers */
 	struct list_head layers;
+	/* In-flight payment attempts */
+	struct reserve_hash *reserved;
 };
 
 #endif /* LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -5,6 +5,8 @@
 #include <ccan/list/list.h>
 #include <common/amount.h>
 
+struct gossmap_chan;
+
 /* A single route. */
 struct route {
 	/* Actual path to take */
@@ -22,5 +24,27 @@ struct askrene {
 	/* In-flight payment attempts */
 	struct reserve_hash *reserved;
 };
+
+/* Information for a single route query. */
+struct route_query {
+	/* Plugin pointer, for logging mainly */
+	struct plugin *plugin;
+
+	/* This is *not* updated during a query!  Has all layers applied. */
+	const struct gossmap *gossmap;
+
+	/* We need to take in-flight payments into account */
+	const struct reserve_hash *reserved;
+
+	/* Array of layers we're applying */
+	const struct layer **layers;
+};
+
+/* Given a gossmap channel, get the current known min/max */
+void get_constraints(const struct route_query *rq,
+		     const struct gossmap_chan *chan,
+		     int dir,
+		     struct amount_msat *min,
+		     struct amount_msat *max);
 
 #endif /* LIGHTNING_PLUGINS_ASKRENE_ASKRENE_H */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -5,6 +5,7 @@
 #include <ccan/list/list.h>
 #include <common/amount.h>
 #include <common/fp16.h>
+#include <common/node_id.h>
 
 struct gossmap_chan;
 
@@ -26,6 +27,8 @@ struct askrene {
 	struct reserve_hash *reserved;
 	/* Compact cache of gossmap capacities */
 	fp16_t *capacities;
+	/* My own id */
+	struct node_id my_id;
 };
 
 /* Information for a single route query. */

--- a/plugins/askrene/askrene.h
+++ b/plugins/askrene/askrene.h
@@ -4,6 +4,7 @@
 #include <bitcoin/short_channel_id.h>
 #include <ccan/list/list.h>
 #include <common/amount.h>
+#include <common/fp16.h>
 
 struct gossmap_chan;
 
@@ -23,6 +24,8 @@ struct askrene {
 	struct list_head layers;
 	/* In-flight payment attempts */
 	struct reserve_hash *reserved;
+	/* Compact cache of gossmap capacities */
+	fp16_t *capacities;
 };
 
 /* Information for a single route query. */
@@ -38,6 +41,9 @@ struct route_query {
 
 	/* Array of layers we're applying */
 	const struct layer **layers;
+
+	/* Cache of channel capacities for non-reserved, unknown channels. */
+	fp16_t *capacities;
 };
 
 /* Given a gossmap channel, get the current known min/max */

--- a/plugins/askrene/dijkstra.c
+++ b/plugins/askrene/dijkstra.c
@@ -1,0 +1,186 @@
+#define NDEBUG 1
+#include "config.h"
+#include <plugins/askrene/dijkstra.h>
+
+/* In the heap we keep node idx, but in this structure we keep the distance
+ * value associated to every node, and their position in the heap as a pointer
+ * so that we can update the nodes inside the heap when the distance label is
+ * changed.
+ *
+ * Therefore this is no longer a multipurpose heap, the node_idx must be an
+ * index between 0 and less than max_num_nodes. */
+struct dijkstra {
+	//
+	s64 *distance;
+	u32 *base;
+	u32 **heapptr;
+	size_t heapsize;
+	struct gheap_ctx gheap_ctx;
+};
+
+static const s64 INFINITE = INT64_MAX;
+
+/* Required a global dijkstra for gheap. */
+static struct dijkstra *global_dijkstra;
+
+/* The heap comparer for Dijkstra search. Since the top element must be the one
+ * with the smallest distance, we use the operator >, rather than <. */
+static int dijkstra_less_comparer(
+	const void *const ctx UNUSED,
+	const void *const a,
+	const void *const b)
+{
+	return global_dijkstra->distance[*(u32*)a]
+		> global_dijkstra->distance[*(u32*)b];
+}
+
+/* The heap move operator for Dijkstra search. */
+static void dijkstra_item_mover(void *const dst, const void *const src)
+{
+	u32 src_idx = *(u32*)src;
+	*(u32*)dst = src_idx;
+
+	// we keep track of the pointer position of each element in the heap,
+	// for easy update.
+	global_dijkstra->heapptr[src_idx] = dst;
+}
+
+/* Allocation of resources for the heap. */
+struct dijkstra *dijkstra_new(const tal_t *ctx, size_t max_num_nodes)
+{
+	struct dijkstra *dijkstra = tal(ctx, struct dijkstra);
+
+	dijkstra->distance = tal_arr(dijkstra,s64,max_num_nodes);
+	dijkstra->base = tal_arr(dijkstra,u32,max_num_nodes);
+	dijkstra->heapptr = tal_arrz(dijkstra,u32*,max_num_nodes);
+
+	dijkstra->heapsize=0;
+
+	dijkstra->gheap_ctx.fanout=2;
+	dijkstra->gheap_ctx.page_chunks=1024;
+	dijkstra->gheap_ctx.item_size=sizeof(dijkstra->base[0]);
+	dijkstra->gheap_ctx.less_comparer=dijkstra_less_comparer;
+	dijkstra->gheap_ctx.less_comparer_ctx=NULL;
+	dijkstra->gheap_ctx.item_mover=dijkstra_item_mover;
+
+	return dijkstra;
+}
+
+
+void dijkstra_init(struct dijkstra *dijkstra)
+{
+	const size_t max_num_nodes = tal_count(dijkstra->distance);
+	dijkstra->heapsize=0;
+	for(size_t i=0;i<max_num_nodes;++i)
+	{
+		dijkstra->distance[i]=INFINITE;
+		dijkstra->heapptr[i] = NULL;
+	}
+}
+size_t dijkstra_size(const struct dijkstra *dijkstra)
+{
+	return dijkstra->heapsize;
+}
+
+size_t dijkstra_maxsize(const struct dijkstra *dijkstra)
+{
+	return tal_count(dijkstra->distance);
+}
+
+static void dijkstra_append(struct dijkstra *dijkstra, u32 node_idx, s64 distance)
+{
+	assert(dijkstra_size(dijkstra) < dijkstra_maxsize(dijkstra));
+	assert(node_idx < dijkstra_maxsize(dijkstra));
+
+	const size_t pos = dijkstra->heapsize;
+
+	dijkstra->base[pos]=node_idx;
+	dijkstra->distance[node_idx]=distance;
+	dijkstra->heapptr[node_idx] = &(dijkstra->base[pos]);
+	dijkstra->heapsize++;
+}
+
+void dijkstra_update(struct dijkstra *dijkstra, u32 node_idx, s64 distance)
+{
+	assert(node_idx < dijkstra_maxsize(dijkstra));
+
+	if(!dijkstra->heapptr[node_idx])
+	{
+		// not in the heap
+		dijkstra_append(dijkstra, node_idx,distance);
+		global_dijkstra = dijkstra;
+		gheap_restore_heap_after_item_increase(
+			&dijkstra->gheap_ctx,
+			dijkstra->base,
+			dijkstra->heapsize,
+			dijkstra->heapptr[node_idx]
+				- dijkstra->base);
+		global_dijkstra = NULL;
+		return;
+	}
+
+	if(dijkstra->distance[node_idx] > distance)
+	{
+		// distance decrease
+		dijkstra->distance[node_idx] = distance;
+
+		global_dijkstra = dijkstra;
+		gheap_restore_heap_after_item_increase(
+			&dijkstra->gheap_ctx,
+			dijkstra->base,
+			dijkstra->heapsize,
+			dijkstra->heapptr[node_idx]
+				- dijkstra->base);
+		global_dijkstra = NULL;
+	}else
+	{
+		// distance increase
+		dijkstra->distance[node_idx] = distance;
+
+		global_dijkstra = dijkstra;
+		gheap_restore_heap_after_item_decrease(
+			&dijkstra->gheap_ctx,
+			dijkstra->base,
+			dijkstra->heapsize,
+			dijkstra->heapptr[node_idx]
+				- dijkstra->base);
+		global_dijkstra = NULL;
+
+	}
+  	// assert(gheap_is_heap(&dijkstra->gheap_ctx,
+	//                      dijkstra->base,
+	// 		     dijkstra_size()));
+}
+
+u32 dijkstra_top(const struct dijkstra *dijkstra)
+{
+	return dijkstra->base[0];
+}
+
+bool dijkstra_empty(const struct dijkstra *dijkstra)
+{
+	return dijkstra->heapsize==0;
+}
+
+void dijkstra_pop(struct dijkstra *dijkstra)
+{
+	if(dijkstra->heapsize==0)
+		return;
+
+	const u32 top = dijkstra_top(dijkstra);
+	assert(dijkstra->heapptr[top]==dijkstra->base);
+
+	global_dijkstra = dijkstra;
+	gheap_pop_heap(
+		&dijkstra->gheap_ctx,
+		dijkstra->base,
+		dijkstra->heapsize--);
+	global_dijkstra = NULL;
+
+	dijkstra->heapptr[top]=NULL;
+}
+
+const s64* dijkstra_distance_data(const struct dijkstra *dijkstra)
+{
+	return dijkstra->distance;
+}

--- a/plugins/askrene/dijkstra.h
+++ b/plugins/askrene/dijkstra.h
@@ -1,0 +1,30 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_DIJKSTRA_H
+#define LIGHTNING_PLUGINS_ASKRENE_DIJKSTRA_H
+#include "config.h"
+#include <ccan/short_types/short_types.h>
+#include <ccan/tal/tal.h>
+#include <gheap.h>
+
+/* Allocation of resources for the heap. */
+struct dijkstra *dijkstra_new(const tal_t *ctx, size_t max_num_nodes);
+
+/* Initialization of the heap for a new Dijkstra search. */
+void dijkstra_init(struct dijkstra *dijkstra);
+
+/* Inserts a new element in the heap. If node_idx was already in the heap then
+ * its distance value is updated. */
+void dijkstra_update(struct dijkstra *dijkstra, u32 node_idx, s64 distance);
+
+u32 dijkstra_top(const struct dijkstra *dijkstra);
+bool dijkstra_empty(const struct dijkstra *dijkstra);
+void dijkstra_pop(struct dijkstra *dijkstra);
+
+const s64* dijkstra_distance_data(const struct dijkstra *dijkstra);
+
+/* Number of elements on the heap. */
+size_t dijkstra_size(const struct dijkstra *dijkstra);
+
+/* Maximum number of elements the heap can host */
+size_t dijkstra_maxsize(const struct dijkstra *dijkstra);
+
+#endif /* LIGHTNING_PLUGINS_ASKRENE_DIJKSTRA_H */

--- a/plugins/askrene/flow.c
+++ b/plugins/askrene/flow.c
@@ -320,8 +320,8 @@ bool flow_spend(struct amount_msat *ret, struct flow *flow)
 	const size_t pathlen = tal_count(flow->path);
 	struct amount_msat spend = flow->amount;
 
-	for (int i = (int)pathlen - 2; i >= 0; i--) {
-		const struct half_chan *h = flow_edge(flow, i + 1);
+	for (int i = (int)pathlen - 1; i >= 0; i--) {
+		const struct half_chan *h = flow_edge(flow, i);
 		if (!amount_msat_add_fee(&spend, h->base_fee,
 					 h->proportional_fee))
 			goto function_fail;

--- a/plugins/askrene/flow.c
+++ b/plugins/askrene/flow.c
@@ -1,0 +1,451 @@
+#include "config.h"
+#include <assert.h>
+#include <ccan/tal/str/str.h>
+#include <ccan/tal/tal.h>
+#include <common/fp16.h>
+#include <common/overflows.h>
+#include <math.h>
+#include <plugins/askrene/flow.h>
+#include <stdio.h>
+
+#ifndef SUPERVERBOSE
+#define SUPERVERBOSE(...)
+#else
+#define SUPERVERBOSE_ENABLED 1
+#endif
+
+struct amount_msat *tal_flow_amounts(const tal_t *ctx, const struct flow *flow)
+{
+	const size_t pathlen = tal_count(flow->path);
+	struct amount_msat *amounts = tal_arr(ctx, struct amount_msat, pathlen);
+	amounts[pathlen - 1] = flow->amount;
+
+	for (int i = (int)pathlen - 2; i >= 0; i--) {
+		const struct half_chan *h = flow_edge(flow, i + 1);
+		amounts[i] = amounts[i + 1];
+		if (!amount_msat_add_fee(&amounts[i], h->base_fee,
+					 h->proportional_fee))
+			goto function_fail;
+	}
+
+	return amounts;
+
+function_fail:
+	return tal_free(amounts);
+}
+
+const char *fmt_flows(const tal_t *ctx, const struct gossmap *gossmap,
+		      struct chan_extra_map *chan_extra_map,
+		      struct flow **flows)
+{
+	tal_t *this_ctx = tal(ctx, tal_t);
+	double tot_prob =
+	    flowset_probability(tmpctx, flows, gossmap, chan_extra_map, NULL);
+	assert(tot_prob >= 0);
+	char *buff = tal_fmt(ctx, "%zu subflows, prob %2lf\n", tal_count(flows),
+			     tot_prob);
+	for (size_t i = 0; i < tal_count(flows); i++) {
+		struct amount_msat fee, delivered;
+		tal_append_fmt(&buff, "   ");
+		for (size_t j = 0; j < tal_count(flows[i]->path); j++) {
+			struct short_channel_id scid =
+			    gossmap_chan_scid(gossmap, flows[i]->path[j]);
+			tal_append_fmt(&buff, "%s%s", j ? "->" : "",
+				       fmt_short_channel_id(this_ctx, scid));
+		}
+		delivered = flows[i]->amount;
+		if (!flow_fee(&fee, flows[i])) {
+			abort();
+		}
+		tal_append_fmt(&buff, " prob %.2f, %s delivered with fee %s\n",
+			       flows[i]->success_prob,
+			       fmt_amount_msat(this_ctx, delivered),
+			       fmt_amount_msat(this_ctx, fee));
+	}
+
+	tal_free(this_ctx);
+	return buff;
+}
+
+/* Returns the greatest amount we can deliver to the destination using this
+ * route. It takes into account the current knowledge, pending HTLC,
+ * htlc_max and fees.
+ *
+ * It fails if the maximum that we can
+ * deliver at node i is smaller than the minimum required to forward the least
+ * amount greater than zero to the next node. */
+enum askrene_errorcode
+flow_maximum_deliverable(struct amount_msat *max_deliverable,
+			 const struct flow *flow,
+			 const struct gossmap *gossmap,
+			 struct chan_extra_map *chan_extra_map,
+			 const struct gossmap_chan **bad_channel)
+{
+	assert(tal_count(flow->path) > 0);
+	assert(tal_count(flow->dirs) > 0);
+	assert(tal_count(flow->path) == tal_count(flow->dirs));
+	struct amount_msat x;
+	enum askrene_errorcode err;
+
+	err = channel_liquidity(&x, gossmap, chan_extra_map, flow->path[0],
+			       flow->dirs[0]);
+	if(err){
+		if(bad_channel)*bad_channel = flow->path[0];
+		return err;
+	}
+	x = amount_msat_min(x, channel_htlc_max(flow->path[0], flow->dirs[0]));
+
+	if(amount_msat_zero(x))
+	{
+		if(bad_channel)*bad_channel = flow->path[0];
+		return ASKRENE_BAD_CHANNEL;
+	}
+
+	for (size_t i = 1; i < tal_count(flow->path); ++i) {
+		// ith node can forward up to 'liquidity_cap' because of the ith
+		// channel liquidity bound
+		struct amount_msat liquidity_cap;
+
+		err = channel_liquidity(&liquidity_cap, gossmap, chan_extra_map,
+				       flow->path[i], flow->dirs[i]);
+		if(err) {
+			if(bad_channel)*bad_channel = flow->path[i];
+			return err;
+		}
+
+		/* ith node can receive up to 'x', therefore he will not forward
+		 * more than 'forward_cap' that we compute below inverting the
+		 * fee equation. */
+		struct amount_msat forward_cap;
+		err = channel_maximum_forward(&forward_cap, flow->path[i],
+					     flow->dirs[i], x);
+		if(err)
+		{
+			if(bad_channel)*bad_channel = flow->path[i];
+			return err;
+		}
+		struct amount_msat x_new =
+		    amount_msat_min(forward_cap, liquidity_cap);
+		x_new = amount_msat_min(
+		    x_new, channel_htlc_max(flow->path[i], flow->dirs[i]));
+
+		/* safety check: amounts decrease along the route */
+		assert(amount_msat_less_eq(x_new, x));
+
+		if(amount_msat_zero(x_new))
+		{
+			if(bad_channel)*bad_channel = flow->path[i];
+			return ASKRENE_BAD_CHANNEL;
+		}
+
+		/* safety check: the max liquidity in the next hop + fees cannot
+		 be greater than the max liquidity in the current hop, IF the
+		 next hop is non-zero. */
+		struct amount_msat x_check = x_new;
+		assert(
+		    amount_msat_add_fee(&x_check, flow_edge(flow, i)->base_fee,
+					flow_edge(flow, i)->proportional_fee));
+		assert(amount_msat_less_eq(x_check, x));
+
+		x = x_new;
+	}
+	assert(!amount_msat_zero(x));
+	*max_deliverable = x;
+	return ASKRENE_NOERROR;
+}
+
+/* Returns the smallest amount we can send so that the destination can get one
+ * HTLC of any size. It takes into account htlc_min and fees.
+ * */
+// static enum askrene_errorcode
+// flow_minimum_sendable(struct amount_msat *min_sendable UNUSED,
+// 		      const struct flow *flow UNUSED,
+// 		      const struct gossmap *gossmap UNUSED,
+// 		      struct chan_extra_map *chan_extra_map UNUSED)
+// {
+// 	// TODO
+// 	return ASKRENE_NOERROR;
+// }
+
+/* How much do we deliver to destination using this set of routes */
+bool flowset_delivers(struct amount_msat *delivers, struct flow **flows)
+{
+	struct amount_msat final = AMOUNT_MSAT(0);
+	for (size_t i = 0; i < tal_count(flows); i++) {
+		if (!amount_msat_add(&final, flows[i]->amount, final))
+			return false;
+	}
+	*delivers = final;
+	return true;
+}
+
+/* Checks if the flows satisfy the liquidity bounds imposed by the known maximum
+ * liquidity and pending HTLCs.
+ *
+ * FIXME The function returns false even in the case of failure. The caller has
+ * no way of knowing the difference between a failure of evaluation and a
+ * negative answer. */
+// static bool check_liquidity_bounds(struct flow **flows,
+// 				   const struct gossmap *gossmap,
+// 				   struct chan_extra_map *chan_extra_map)
+// {
+// 	bool check = true;
+// 	for (size_t i = 0; i < tal_count(flows); ++i) {
+// 		struct amount_msat max_deliverable;
+// 		if (!flow_maximum_deliverable(&max_deliverable, flows[i],
+// 					      gossmap, chan_extra_map))
+// 			return false;
+// 		struct amount_msat delivers = flow_delivers(flows[i]);
+// 		check &= amount_msat_less_eq(delivers, max_deliverable);
+// 	}
+// 	return check;
+// }
+
+/* Compute the prob. of success of a set of concurrent set of flows.
+ *
+ * IMPORTANT: this is not simply the multiplication of the prob. of success of
+ * all of them, because they're not independent events. A flow that passes
+ * through a channel c changes that channel's liquidity and then if another flow
+ * passes through that same channel the previous liquidity change must be taken
+ * into account.
+ *
+ * 	P(A and B) != P(A) * P(B),
+ *
+ * but
+ *
+ * 	P(A and B) = P(A) * P(B | A)
+ *
+ * also due to the linear form of P() we have
+ *
+ * 	P(A and B) = P(A + B)
+ * 	*/
+struct chan_inflight_flow
+{
+	struct amount_msat half[2];
+};
+
+// TODO(eduardo): here chan_extra_map should be const
+// TODO(eduardo): here flows should be const
+double flowset_probability(const tal_t *ctx, struct flow **flows,
+			   const struct gossmap *const gossmap,
+			   struct chan_extra_map *chan_extra_map, char **fail)
+{
+	assert(flows);
+	assert(gossmap);
+	assert(chan_extra_map);
+	tal_t *this_ctx = tal(ctx, tal_t);
+	double prob = 1.0;
+
+	// TODO(eduardo): should it be better to use a map instead of an array
+	// here?
+	const size_t max_num_chans = gossmap_max_chan_idx(gossmap);
+	struct chan_inflight_flow *in_flight =
+	    tal_arr(this_ctx, struct chan_inflight_flow, max_num_chans);
+
+	for (size_t i = 0; i < max_num_chans; ++i) {
+		in_flight[i].half[0] = in_flight[i].half[1] = AMOUNT_MSAT(0);
+	}
+
+	for (size_t i = 0; i < tal_count(flows); ++i) {
+		const struct flow *f = flows[i];
+		const size_t pathlen = tal_count(f->path);
+		struct amount_msat *amounts = tal_flow_amounts(this_ctx, f);
+		if (!amounts)
+		{
+			if (fail)
+			*fail = tal_fmt(
+			    ctx,
+			    "failed to compute amounts along the path");
+			goto function_fail;
+		}
+
+		for (size_t j = 0; j < pathlen; ++j) {
+			const struct chan_extra_half *h =
+			    get_chan_extra_half_by_chan(gossmap, chan_extra_map,
+							f->path[j], f->dirs[j]);
+			if (!h) {
+				if (fail)
+				*fail = tal_fmt(
+				    ctx,
+				    "channel not found in chan_extra_map");
+				goto function_fail;
+			}
+			const u32 c_idx = gossmap_chan_idx(gossmap, f->path[j]);
+			const int c_dir = f->dirs[j];
+
+			const struct amount_msat deliver = amounts[j];
+
+			struct amount_msat prev_flow;
+			if (!amount_msat_add(&prev_flow, h->htlc_total,
+					     in_flight[c_idx].half[c_dir])) {
+				if (fail)
+				*fail = tal_fmt(
+				    ctx, "in-flight amount_msat overflow");
+				goto function_fail;
+			}
+
+			double edge_prob =
+			    edge_probability(h->known_min, h->known_max,
+					     prev_flow, deliver);
+			if (edge_prob < 0) {
+				if (fail)
+				*fail = tal_fmt(ctx,
+						"edge_probability failed");
+				goto function_fail;
+			}
+			prob *= edge_prob;
+
+			if (!amount_msat_add(&in_flight[c_idx].half[c_dir],
+					     in_flight[c_idx].half[c_dir],
+					     deliver)) {
+				if (fail)
+				*fail = tal_fmt(
+				    ctx, "in-flight amount_msat overflow");
+				goto function_fail;
+			}
+		}
+	}
+	tal_free(this_ctx);
+	return prob;
+
+	function_fail:
+	tal_free(this_ctx);
+	return -1;
+}
+
+bool flow_spend(struct amount_msat *ret, struct flow *flow)
+{
+	assert(ret);
+	assert(flow);
+	const size_t pathlen = tal_count(flow->path);
+	struct amount_msat spend = flow->amount;
+
+	for (int i = (int)pathlen - 2; i >= 0; i--) {
+		const struct half_chan *h = flow_edge(flow, i + 1);
+		if (!amount_msat_add_fee(&spend, h->base_fee,
+					 h->proportional_fee))
+			goto function_fail;
+	}
+
+	*ret = spend;
+	return true;
+
+function_fail:
+	return false;
+}
+
+bool flow_fee(struct amount_msat *ret, struct flow *flow)
+{
+	assert(ret);
+	assert(flow);
+	struct amount_msat fee;
+	struct amount_msat spend;
+	if (!flow_spend(&spend, flow))
+		goto function_fail;
+	if (!amount_msat_sub(&fee, spend, flow->amount))
+		goto function_fail;
+
+	*ret = fee;
+	return true;
+
+function_fail:
+	return false;
+}
+
+bool flowset_fee(struct amount_msat *ret, struct flow **flows)
+{
+	assert(ret);
+	assert(flows);
+	struct amount_msat fee = AMOUNT_MSAT(0);
+	for (size_t i = 0; i < tal_count(flows); i++) {
+		struct amount_msat this_fee;
+		if (!flow_fee(&this_fee, flows[i]))
+			return false;
+		if (!amount_msat_add(&fee, this_fee, fee))
+			return false;
+	}
+	*ret = fee;
+	return true;
+}
+
+/* Helper to access the half chan at flow index idx */
+const struct half_chan *flow_edge(const struct flow *flow, size_t idx)
+{
+	assert(flow);
+	assert(idx < tal_count(flow->path));
+	return &flow->path[idx]->half[flow->dirs[idx]];
+}
+
+/* Assign the delivered amount to the flow if it fits
+ the path maximum capacity. */
+bool flow_assign_delivery(struct flow *flow, const struct gossmap *gossmap,
+			  struct chan_extra_map *chan_extra_map,
+			  struct amount_msat requested_amount)
+{
+	struct amount_msat max_deliverable = AMOUNT_MSAT(0);
+	if (flow_maximum_deliverable(&max_deliverable, flow, gossmap,
+				      chan_extra_map, NULL))
+		return false;
+	assert(!amount_msat_zero(max_deliverable));
+	flow->amount = amount_msat_min(requested_amount, max_deliverable);
+	return true;
+}
+
+/* Helper function to find the success_prob for a single flow
+ *
+ * IMPORTANT: flow->success_prob is misleading, because that's the prob. of
+ * success provided that there are no other flows in the current MPP flow set.
+ * */
+double flow_probability(struct flow *flow, const struct gossmap *gossmap,
+			struct chan_extra_map *chan_extra_map)
+{
+	assert(flow);
+	assert(gossmap);
+	assert(chan_extra_map);
+	const size_t pathlen = tal_count(flow->path);
+	struct amount_msat spend = flow->amount;
+	double prob = 1.0;
+
+	for (int i = (int)pathlen - 1; i >= 0; i--) {
+		const struct half_chan *h = flow_edge(flow, i);
+		const struct chan_extra_half *eh = get_chan_extra_half_by_chan(
+		    gossmap, chan_extra_map, flow->path[i], flow->dirs[i]);
+
+		prob *= edge_probability(eh->known_min, eh->known_max,
+					 eh->htlc_total, spend);
+
+		if (prob < 0)
+			goto function_fail;
+		if (!amount_msat_add_fee(&spend, h->base_fee,
+					 h->proportional_fee))
+			goto function_fail;
+	}
+
+	return prob;
+
+function_fail:
+	return -1.;
+}
+
+u64 flow_delay(const struct flow *flow)
+{
+	u64 delay = 0;
+	for (size_t i = 0; i < tal_count(flow->path); i++)
+		delay += flow_edge(flow, i)->delay;
+	return delay;
+}
+
+u64 flows_worst_delay(struct flow **flows)
+{
+	u64 maxdelay = 0;
+	for (size_t i = 0; i < tal_count(flows); i++) {
+		u64 delay = flow_delay(flows[i]);
+		if (delay > maxdelay)
+			maxdelay = delay;
+	}
+	return maxdelay;
+}
+
+#ifndef SUPERVERBOSE_ENABLED
+#undef SUPERVERBOSE
+#endif

--- a/plugins/askrene/flow.h
+++ b/plugins/askrene/flow.h
@@ -60,10 +60,6 @@ static inline struct amount_msat flow_delivers(const struct flow *flow)
 	return flow->amount;
 }
 
-struct amount_msat *tal_flow_amounts(const tal_t *ctx,
-				     struct plugin *plugin,
-				     const struct flow *flow);
-
 /* FIXME: remove */
 enum askrene_errorcode {
 	ASKRENE_NOERROR = 0,

--- a/plugins/askrene/flow.h
+++ b/plugins/askrene/flow.h
@@ -1,0 +1,99 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_FLOW_H
+#define LIGHTNING_PLUGINS_ASKRENE_FLOW_H
+#include "config.h"
+#include <bitcoin/short_channel_id.h>
+#include <ccan/htable/htable_type.h>
+#include <common/amount.h>
+#include <common/gossmap.h>
+
+/* An actual partial flow. */
+struct flow {
+	const struct gossmap_chan **path;
+	/* The directions to traverse. */
+	int *dirs;
+	/* Amounts for this flow (fees mean this shrinks across path). */
+	double success_prob;
+	struct amount_msat amount;
+};
+
+const char *fmt_flows(const tal_t *ctx, const struct gossmap *gossmap,
+		      struct chan_extra_map *chan_extra_map,
+		      struct flow **flows);
+
+/* Helper to access the half chan at flow index idx */
+const struct half_chan *flow_edge(const struct flow *flow, size_t idx);
+
+/* A big number, meaning "don't bother" (not infinite, since you may add) */
+#define FLOW_INF_COST 100000000.0
+
+/* Cost function to send @f msat through @c in direction @dir,
+ * given we already have a flow of prev_flow. */
+double flow_edge_cost(const struct gossmap *gossmap,
+		      const struct gossmap_chan *c, int dir,
+		      const struct amount_msat known_min,
+		      const struct amount_msat known_max,
+		      struct amount_msat prev_flow,
+		      struct amount_msat f,
+		      double mu,
+		      double basefee_penalty,
+		      double delay_riskfactor);
+
+/* Compute the prob. of success of a set of concurrent set of flows. */
+double flowset_probability(const tal_t *ctx, struct flow **flows,
+			   const struct gossmap *const gossmap,
+			   struct chan_extra_map *chan_extra_map, char **fail);
+
+/* How much do we need to send to make this flow arrive. */
+bool flow_spend(struct amount_msat *ret, struct flow *flow);
+
+/* How much do we pay in fees to make this flow arrive. */
+bool flow_fee(struct amount_msat *ret, struct flow *flow);
+
+bool flowset_fee(struct amount_msat *fee, struct flow **flows);
+
+bool flowset_delivers(struct amount_msat *delivers, struct flow **flows);
+
+static inline struct amount_msat flow_delivers(const struct flow *flow)
+{
+	return flow->amount;
+}
+
+struct amount_msat *tal_flow_amounts(const tal_t *ctx, const struct flow *flow);
+
+/* FIXME: remove */
+enum askrene_errorcode {
+	ASKRENE_NOERROR = 0,
+
+	ASKRENE_AMOUNT_OVERFLOW,
+	ASKRENE_CHANNEL_NOT_FOUND,
+	ASKRENE_BAD_CHANNEL,
+	ASKRENE_BAD_ALLOCATION,
+	ASKRENE_PRECONDITION_ERROR,
+	ASKRENE_UNEXPECTED,
+};
+
+enum askrene_errorcode
+flow_maximum_deliverable(struct amount_msat *max_deliverable,
+			 const struct flow *flow,
+			 const struct gossmap *gossmap,
+			 struct chan_extra_map *chan_extra_map,
+			 const struct gossmap_chan **bad_channel);
+
+/* Assign the delivered amount to the flow if it fits
+ the path maximum capacity. */
+bool flow_assign_delivery(struct flow *flow, const struct gossmap *gossmap,
+			  struct chan_extra_map *chan_extra_map,
+			  struct amount_msat requested_amount);
+
+double flow_probability(struct flow *flow, const struct gossmap *gossmap,
+			struct chan_extra_map *chan_extra_map);
+
+u64 flow_delay(const struct flow *flow);
+u64 flows_worst_delay(struct flow **flows);
+
+struct flow **
+flows_ensure_liquidity_constraints(const tal_t *ctx, struct flow **flows TAKES,
+				   const struct gossmap *gossmap,
+				   struct chan_extra_map *chan_extra_map);
+
+#endif /* LIGHTNING_PLUGINS_ASKRENE_FLOW_H */

--- a/plugins/askrene/flow.h
+++ b/plugins/askrene/flow.h
@@ -44,21 +44,24 @@ double flowset_probability(const tal_t *ctx, struct flow **flows,
 			   struct chan_extra_map *chan_extra_map, char **fail);
 
 /* How much do we need to send to make this flow arrive. */
-bool flow_spend(struct amount_msat *ret, struct flow *flow);
+struct amount_msat flow_spend(struct plugin *plugin, const struct flow *flow);
 
 /* How much do we pay in fees to make this flow arrive. */
-bool flow_fee(struct amount_msat *ret, struct flow *flow);
+struct amount_msat flow_fee(struct plugin *plugin, const struct flow *flow);
 
-bool flowset_fee(struct amount_msat *fee, struct flow **flows);
+struct amount_msat flowset_fee(struct plugin *plugin, struct flow **flows);
 
-bool flowset_delivers(struct amount_msat *delivers, struct flow **flows);
+struct amount_msat flowset_delivers(struct plugin *plugin,
+				    struct flow **flows);
 
 static inline struct amount_msat flow_delivers(const struct flow *flow)
 {
 	return flow->amount;
 }
 
-struct amount_msat *tal_flow_amounts(const tal_t *ctx, const struct flow *flow);
+struct amount_msat *tal_flow_amounts(const tal_t *ctx,
+				     struct plugin *plugin,
+				     const struct flow *flow);
 
 /* FIXME: remove */
 enum askrene_errorcode {
@@ -85,7 +88,9 @@ bool flow_assign_delivery(struct flow *flow, const struct gossmap *gossmap,
 			  struct chan_extra_map *chan_extra_map,
 			  struct amount_msat requested_amount);
 
-double flow_probability(struct flow *flow, const struct gossmap *gossmap,
+double flow_probability(const struct flow *flow,
+			struct plugin *plugin,
+			const struct gossmap *gossmap,
 			struct chan_extra_map *chan_extra_map);
 
 u64 flow_delay(const struct flow *flow);

--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -253,6 +253,26 @@ const struct constraint *layer_update_constraint(struct layer *layer,
 	return c;
 }
 
+void layer_clear_overridden_capacities(const struct layer *layer,
+				       const struct gossmap *gossmap,
+				       fp16_t *capacities)
+{
+	struct constraint_hash_iter conit;
+	struct constraint *con;
+
+	for (con = constraint_hash_first(layer->constraints, &conit);
+	     con;
+	     con = constraint_hash_next(layer->constraints, &conit)) {
+		struct gossmap_chan *c = gossmap_find_chan(gossmap, &con->key.scidd.scid);
+		size_t idx;
+		if (!c)
+			continue;
+		idx = gossmap_chan_idx(gossmap, c);
+		if (idx < tal_count(capacities))
+			capacities[idx] = 0;
+	}
+}
+
 size_t layer_trim_constraints(struct layer *layer, u64 cutoff)
 {
 	size_t num_removed = 0;

--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -1,0 +1,376 @@
+#include "config.h"
+#include <ccan/array_size/array_size.h>
+#include <ccan/htable/htable_type.h>
+#include <ccan/tal/str/str.h>
+#include <common/json_stream.h>
+#include <common/memleak.h>
+#include <plugins/askrene/askrene.h>
+#include <plugins/askrene/layer.h>
+
+/* A channels which doesn't (necessarily) exist in the gossmap. */
+struct local_channel {
+	/* Canonical order, n1 < n2 */
+	struct node_id n1, n2;
+	struct short_channel_id scid;
+	struct amount_msat capacity;
+
+	struct added_channel_half {
+		/* Other fields only valid if this is true */
+		bool enabled;
+		u16 delay;
+		u32 proportional_fee;
+		struct amount_msat base_fee;
+		struct amount_msat htlc_min, htlc_max;
+	} half[2];
+};
+
+static const struct constraint_key *
+constraint_key(const struct constraint *c)
+{
+	return &c->key;
+}
+
+static size_t hash_constraint_key(const struct constraint_key *key)
+{
+	/* scids cost money to generate, so simple hash works here */
+	return (key->scidd.scid.u64 >> 32) ^ (key->scidd.scid.u64)
+		^ (key->scidd.dir << 1) ^ (key->type);
+}
+
+static inline bool constraint_eq_key(const struct constraint *c,
+				     const struct constraint_key *key)
+{
+	return short_channel_id_dir_eq(&key->scidd, &c->key.scidd) && key->type == c->key.type;
+}
+
+HTABLE_DEFINE_TYPE(struct constraint, constraint_key, hash_constraint_key,
+		   constraint_eq_key, constraint_hash);
+
+static struct short_channel_id
+local_channel_scid(const struct local_channel *lc)
+{
+	return lc->scid;
+}
+
+static size_t hash_scid(const struct short_channel_id scid)
+{
+	/* scids cost money to generate, so simple hash works here */
+	return (scid.u64 >> 32) ^ (scid.u64 >> 16) ^ scid.u64;
+}
+
+static inline bool local_channel_eq_scid(const struct local_channel *lc,
+					 const struct short_channel_id scid)
+{
+	return short_channel_id_eq(scid, lc->scid);
+}
+
+HTABLE_DEFINE_TYPE(struct local_channel, local_channel_scid, hash_scid,
+		   local_channel_eq_scid, local_channel_hash);
+
+struct layer {
+	/* Inside global list of layers */
+	struct list_node list;
+
+	/* Unique identifiers */
+	const char *name;
+
+	/* Completely made up local additions, indexed by scid */
+	struct local_channel_hash *local_channels;
+
+	/* Additional info, indexed by scid+dir */
+	struct constraint_hash *constraints;
+
+	/* Nodes to completely disable (tal_arr) */
+	struct node_id *disabled_nodes;
+};
+
+struct layer *new_layer(struct askrene *askrene, const char *name)
+{
+	struct layer *l = tal(askrene, struct layer);
+
+	l->name = tal_strdup(l, name);
+	l->local_channels = tal(l, struct local_channel_hash);
+	local_channel_hash_init(l->local_channels);
+	l->constraints = tal(l, struct constraint_hash);
+	constraint_hash_init(l->constraints);
+	l->disabled_nodes = tal_arr(l, struct node_id, 0);
+
+	list_add(&askrene->layers, &l->list);
+	return l;
+}
+
+/* Swap if necessary to make into BOLT-7 order.  Return direction. */
+static int canonicalize_node_order(const struct node_id **n1,
+				   const struct node_id **n2)
+{
+	const struct node_id *tmp;
+
+	if (node_id_cmp(*n1, *n2) < 0)
+		return 0;
+	tmp = *n2;
+	*n2 = *n1;
+	*n1 = tmp;
+	return 1;
+}
+
+struct layer *find_layer(struct askrene *askrene, const char *name)
+{
+	struct layer *l;
+	list_for_each(&askrene->layers, l, list) {
+		if (streq(l->name, name))
+			return l;
+	}
+	return NULL;
+}
+
+const char *layer_name(const struct layer *layer)
+{
+	return layer->name;
+}
+
+static struct local_channel *new_local_channel(struct layer *layer,
+					       const struct node_id *n1,
+					       const struct node_id *n2,
+					       struct short_channel_id scid,
+					       struct amount_msat capacity)
+{
+	struct local_channel *lc = tal(layer, struct local_channel);
+	lc->n1 = *n1;
+	lc->n2 = *n2;
+	lc->scid = scid;
+	lc->capacity = capacity;
+
+	for (size_t i = 0; i < ARRAY_SIZE(lc->half); i++)
+		lc->half[i].enabled = false;
+
+	local_channel_hash_add(layer->local_channels, lc);
+	return lc;
+}
+
+bool layer_check_local_channel(const struct local_channel *lc,
+			       const struct node_id *n1,
+			       const struct node_id *n2,
+			       struct amount_msat capacity)
+{
+	canonicalize_node_order(&n1, &n2);
+	return node_id_eq(&lc->n1, n1)
+		&& node_id_eq(&lc->n2, n2)
+		&& amount_msat_eq(lc->capacity, capacity);
+}
+
+/* Update a local channel to a layer: fails if you try to change capacity or nodes! */
+void layer_update_local_channel(struct layer *layer,
+				const struct node_id *src,
+				const struct node_id *dst,
+				struct short_channel_id scid,
+				struct amount_msat capacity,
+				struct amount_msat base_fee,
+				u32 proportional_fee,
+				u16 delay,
+				struct amount_msat htlc_min,
+				struct amount_msat htlc_max)
+{
+	struct local_channel *lc = local_channel_hash_get(layer->local_channels, scid);
+	int dir = canonicalize_node_order(&src, &dst);
+
+	if (lc) {
+		assert(layer_check_local_channel(lc, src, dst, capacity));
+	} else {
+		lc = new_local_channel(layer, src, dst, scid, capacity);
+	}
+
+	lc->half[dir].enabled = true;
+	lc->half[dir].htlc_min = htlc_min;
+	lc->half[dir].htlc_max = htlc_max;
+	lc->half[dir].base_fee = base_fee;
+	lc->half[dir].proportional_fee = proportional_fee;
+	lc->half[dir].delay = delay;
+}
+
+struct amount_msat local_channel_capacity(const struct local_channel *lc)
+{
+	return lc->capacity;
+}
+
+const struct local_channel *layer_find_local_channel(const struct layer *layer,
+						     struct short_channel_id scid)
+{
+	return local_channel_hash_get(layer->local_channels, scid);
+}
+
+static struct constraint *layer_find_constraint_nonconst(const struct layer *layer,
+							 const struct short_channel_id_dir *scidd,
+							 enum constraint_type type)
+{
+	struct constraint_key k = { *scidd, type };
+	return constraint_hash_get(layer->constraints, &k);
+}
+
+/* Public one returns const */
+const struct constraint *layer_find_constraint(const struct layer *layer,
+					       const struct short_channel_id_dir *scidd,
+					       enum constraint_type type)
+{
+	return layer_find_constraint_nonconst(layer, scidd, type);
+}
+
+const struct constraint *layer_update_constraint(struct layer *layer,
+						 const struct short_channel_id_dir *scidd,
+						 enum constraint_type type,
+						 u64 timestamp,
+						 struct amount_msat limit)
+{
+	struct constraint *c = layer_find_constraint_nonconst(layer, scidd, type);
+	if (!c) {
+		c = tal(layer, struct constraint);
+		c->key.scidd = *scidd;
+		c->key.type = type;
+		c->limit = limit;
+		constraint_hash_add(layer->constraints, c);
+	} else {
+		switch (type) {
+		case CONSTRAINT_MIN:
+			/* Increase minimum? */
+			if (amount_msat_greater(limit, c->limit))
+				c->limit = limit;
+			break;
+		case CONSTRAINT_MAX:
+			/* Decrease maximum? */
+			if (amount_msat_less(limit, c->limit))
+				c->limit = limit;
+			break;
+		}
+	}
+	c->timestamp = timestamp;
+	return c;
+}
+
+size_t layer_trim_constraints(struct layer *layer, u64 cutoff)
+{
+	size_t num_removed = 0;
+	struct constraint_hash_iter conit;
+	struct constraint *con;
+
+	for (con = constraint_hash_first(layer->constraints, &conit);
+	     con;
+	     con = constraint_hash_next(layer->constraints, &conit)) {
+		if (con->timestamp < cutoff) {
+			constraint_hash_delval(layer->constraints, &conit);
+			tal_free(con);
+			num_removed++;
+		}
+	}
+	return num_removed;
+}
+
+void layer_add_disabled_node(struct layer *layer, const struct node_id *node)
+{
+	tal_arr_expand(&layer->disabled_nodes, *node);
+}
+
+static void json_add_local_channel(struct json_stream *response,
+				   const char *fieldname,
+				   const struct local_channel *lc,
+				   int dir)
+{
+	json_object_start(response, fieldname);
+
+	if (dir == 0) {
+		json_add_node_id(response, "source", &lc->n1);
+		json_add_node_id(response, "destination", &lc->n2);
+	} else {
+		json_add_node_id(response, "source", &lc->n2);
+		json_add_node_id(response, "destination", &lc->n1);
+	}
+	json_add_short_channel_id(response, "short_channel_id", lc->scid);
+	json_add_amount_msat(response, "capacity_msat", lc->capacity);
+	json_add_amount_msat(response, "htlc_minimum_msat", lc->half[dir].htlc_min);
+	json_add_amount_msat(response, "htlc_maximum_msat", lc->half[dir].htlc_max);
+	json_add_amount_msat(response, "fee_base_msat", lc->half[dir].base_fee);
+	json_add_u32(response, "fee_proportional_millionths", lc->half[dir].proportional_fee);
+	json_add_u32(response, "delay", lc->half[dir].delay);
+
+	json_object_end(response);
+}
+
+void json_add_constraint(struct json_stream *js,
+			 const char *fieldname,
+			 const struct constraint *c,
+			 const struct layer *layer)
+{
+	json_object_start(js, fieldname);
+	if (layer)
+		json_add_string(js, "layer", layer->name);
+	json_add_short_channel_id(js, "short_channel_id", c->key.scidd.scid);
+	json_add_u32(js, "direction", c->key.scidd.dir);
+	json_add_u64(js, "timestamp", c->timestamp);
+	switch (c->key.type) {
+	case CONSTRAINT_MIN:
+		json_add_amount_msat(js, "minimum_msat", c->limit);
+		break;
+	case CONSTRAINT_MAX:
+		json_add_amount_msat(js, "maximum_msat", c->limit);
+		break;
+	}
+	json_object_end(js);
+}
+
+static void json_add_layer(struct json_stream *js,
+			   const char *fieldname,
+			   const struct layer *layer)
+{
+	struct local_channel_hash_iter lcit;
+	const struct local_channel *lc;
+	struct constraint_hash_iter conit;
+	const struct constraint *c;
+
+	json_object_start(js, fieldname);
+	json_add_string(js, "layer", layer->name);
+	json_array_start(js, "disabled_nodes");
+	for (size_t i = 0; i < tal_count(layer->disabled_nodes); i++)
+		json_add_node_id(js, NULL, &layer->disabled_nodes[i]);
+	json_array_end(js);
+	json_array_start(js, "created_channels");
+	for (lc = local_channel_hash_first(layer->local_channels, &lcit);
+	     lc;
+	     lc = local_channel_hash_next(layer->local_channels, &lcit)) {
+		for (size_t i = 0; i < ARRAY_SIZE(lc->half); i++) {
+			if (lc->half[i].enabled)
+				json_add_local_channel(js, NULL, lc, i);
+		}
+	}
+	json_array_end(js);
+	json_array_start(js, "constraints");
+	for (c = constraint_hash_first(layer->constraints, &conit);
+	     c;
+	     c = constraint_hash_next(layer->constraints, &conit)) {
+		json_add_constraint(js, NULL, c, NULL);
+	}
+	json_array_end(js);
+	json_object_end(js);
+}
+
+void json_add_layers(struct json_stream *js,
+		     struct askrene *askrene,
+		     const char *fieldname,
+		     const char *layername)
+{
+	struct layer *l;
+
+	json_array_start(js, fieldname);
+	list_for_each(&askrene->layers, l, list) {
+		if (layername && !streq(l->name, layername))
+			continue;
+		json_add_layer(js, NULL, l);
+	}
+	json_array_end(js);
+}
+
+void layer_memleak_mark(struct askrene *askrene, struct htable *memtable)
+{
+	struct layer *l;
+	list_for_each(&askrene->layers, l, list) {
+		memleak_scan_htable(memtable, &l->constraints->raw);
+		memleak_scan_htable(memtable, &l->local_channels->raw);
+	}
+}

--- a/plugins/askrene/layer.h
+++ b/plugins/askrene/layer.h
@@ -1,0 +1,104 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_LAYER_H
+#define LIGHTNING_PLUGINS_ASKRENE_LAYER_H
+/* A layer is the group of information maintained by askrene.  The caller
+ * specifies which layers to use when asking for a route, and tell askrene
+ * what layer to add new information to.
+ *
+ * Layers can be used to shape local decisions (for this payment, add these
+ * connections, or disable all connections to this node).  You can also,
+ * in theory, export a layer, or import a layer from another source, to see
+ * what the results are when that layer is included. */
+#include "config.h"
+#include <bitcoin/short_channel_id.h>
+#include <common/amount.h>
+#include <common/node_id.h>
+
+struct askrene;
+struct layer;
+struct json_stream;
+
+enum constraint_type {
+	CONSTRAINT_MIN,
+	CONSTRAINT_MAX,
+};
+
+struct constraint_key {
+	struct short_channel_id_dir scidd;
+	enum constraint_type type;
+};
+
+/* A constraint reflects something we learned about a channel */
+struct constraint {
+	struct constraint_key key;
+	/* Time this constraint was last updated */
+	u64 timestamp;
+	struct amount_msat limit;
+};
+
+/* Look up a layer by name. */
+struct layer *find_layer(struct askrene *askrene, const char *name);
+
+/* Create new layer by name. */
+struct layer *new_layer(struct askrene *askrene, const char *name);
+
+/* Get the name of the layer */
+const char *layer_name(const struct layer *layer);
+
+/* Find a local channel in a layer */
+const struct local_channel *layer_find_local_channel(const struct layer *layer,
+						     struct short_channel_id scid);
+
+/* Get capacity of that channel. */
+struct amount_msat local_channel_capacity(const struct local_channel *lc);
+
+/* Check local channel matches these */
+bool layer_check_local_channel(const struct local_channel *lc,
+			       const struct node_id *n1,
+			       const struct node_id *n2,
+			       struct amount_msat capacity);
+
+/* Update a local channel to a layer: fails if you try to change capacity or nodes! */
+void layer_update_local_channel(struct layer *layer,
+				const struct node_id *src,
+				const struct node_id *dst,
+				struct short_channel_id scid,
+				struct amount_msat capacity,
+				struct amount_msat base_fee,
+				u32 proportional_fee,
+				u16 delay,
+				struct amount_msat htlc_min,
+				struct amount_msat htlc_max);
+
+/* Find a constraint in a layer. */
+const struct constraint *layer_find_constraint(const struct layer *layer,
+					       const struct short_channel_id_dir *scidd,
+					       enum constraint_type type);
+
+/* Add/update a constraint on a layer. */
+const struct constraint *layer_update_constraint(struct layer *layer,
+						 const struct short_channel_id_dir *scidd,
+						 enum constraint_type type,
+						 u64 timestamp,
+						 struct amount_msat limit);
+
+/* Remove constraints older then cutoff: returns num removed. */
+size_t layer_trim_constraints(struct layer *layer, u64 cutoff);
+
+/* Add a disabled node to a layer. */
+void layer_add_disabled_node(struct layer *layer, const struct node_id *node);
+
+/* Print out a json object per layer, or all if layer is NULL */
+void json_add_layers(struct json_stream *js,
+		     struct askrene *askrene,
+		     const char *fieldname,
+		     const char *layername);
+
+/* Print a single constraint */
+void json_add_constraint(struct json_stream *js,
+			 const char *fieldname,
+			 const struct constraint *c,
+			 const struct layer *layer);
+
+/* Scan for memleaks */
+void layer_memleak_mark(struct askrene *askrene, struct htable *memtable);
+#endif /* LIGHTNING_PLUGINS_ASKRENE_LAYER_H */

--- a/plugins/askrene/layer.h
+++ b/plugins/askrene/layer.h
@@ -81,6 +81,11 @@ const struct constraint *layer_update_constraint(struct layer *layer,
 						 u64 timestamp,
 						 struct amount_msat limit);
 
+/* Add local channels from this layer */
+void layer_add_localmods(struct layer *layer,
+			 const struct gossmap *gossmap,
+			 struct gossmap_localmods *localmods);
+
 /* Remove constraints older then cutoff: returns num removed. */
 size_t layer_trim_constraints(struct layer *layer, u64 cutoff);
 

--- a/plugins/askrene/layer.h
+++ b/plugins/askrene/layer.h
@@ -41,6 +41,9 @@ struct layer *find_layer(struct askrene *askrene, const char *name);
 /* Create new layer by name. */
 struct layer *new_layer(struct askrene *askrene, const char *name);
 
+/* New temporary layer (not in askrene's hash table) */
+struct layer *new_temp_layer(const tal_t *ctx, const char *name);
+
 /* Get the name of the layer */
 const char *layer_name(const struct layer *layer);
 
@@ -87,9 +90,10 @@ const struct constraint *layer_update_constraint(struct layer *layer,
 						 u64 timestamp,
 						 struct amount_msat limit);
 
-/* Add local channels from this layer */
-void layer_add_localmods(struct layer *layer,
+/* Add local channels from this layer.  zero_cost means set fees and delay to 0. */
+void layer_add_localmods(const struct layer *layer,
 			 const struct gossmap *gossmap,
+			 bool zero_cost,
 			 struct gossmap_localmods *localmods);
 
 /* Remove constraints older then cutoff: returns num removed. */

--- a/plugins/askrene/layer.h
+++ b/plugins/askrene/layer.h
@@ -69,6 +69,12 @@ void layer_update_local_channel(struct layer *layer,
 				struct amount_msat htlc_min,
 				struct amount_msat htlc_max);
 
+/* If any capacities of channels are limited, unset the corresponding element in
+ * the capacities[] array */
+void layer_clear_overridden_capacities(const struct layer *layer,
+				       const struct gossmap *gossmap,
+				       fp16_t *capacities);
+
 /* Find a constraint in a layer. */
 const struct constraint *layer_find_constraint(const struct layer *layer,
 					       const struct short_channel_id_dir *scidd,

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -1184,6 +1184,7 @@ static inline uint64_t pseudorand_interval(uint64_t a, uint64_t b)
  * gossmap that corresponds to this flow. */
 static struct flow **
 get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
+	       struct plugin *plugin,
 	       const bitmap *disabled,
 
 	       // chan_extra_map cannot be const because we use it to keep
@@ -1354,10 +1355,9 @@ get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
 			// accuracy
 			struct amount_msat delivered = amount_msat(delta*1000);
 			if (!amount_msat_sub(&delivered, delivered, excess)) {
-				if (fail)
-				*fail = tal_fmt(
-				    ctx, "unable to substract excess");
-				goto function_fail;
+				plugin_err(plugin, "Unable to subtract excess %s from %s",
+					   fmt_amount_msat(excess),
+					   fmt_amount_msat(delivered));
 			}
 			excess = amount_msat(0);
 			fp->amount = delivered;

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -8,8 +8,8 @@
 #include <common/utils.h>
 #include <math.h>
 #include <plugins/askrene/mcf.h>
-#include <plugins/renepay/dijkstra.h>
-#include <plugins/renepay/flow.h>
+#include <plugins/askrene/dijkstra.h>
+#include <plugins/askrene/flow.h>
 #include <stdint.h>
 
 /* # Optimal payments

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -1,0 +1,1835 @@
+#include "config.h"
+#include <assert.h>
+#include <ccan/list/list.h>
+#include <ccan/lqueue/lqueue.h>
+#include <ccan/tal/str/str.h>
+#include <ccan/tal/tal.h>
+#include <common/pseudorand.h>
+#include <common/utils.h>
+#include <math.h>
+#include <plugins/renepay/dijkstra.h>
+#include <plugins/renepay/flow.h>
+#include <plugins/renepay/mcf.h>
+#include <stdint.h>
+
+/* # Optimal payments
+ *
+ * In this module we reduce the routing optimization problem to a linear
+ * cost optimization problem and find a solution using MCF algorithms.
+ * The optimization of the routing itself doesn't need a precise numerical
+ * solution, since we can be happy near optimal results; e.g. paying 100 msat or
+ * 101 msat for fees doesn't make any difference if we wish to deliver 1M sats.
+ * On the other hand, we are now also considering Pickhard's
+ * [1] model to improve payment reliability,
+ * hence our optimization moves to a 2D space: either we like to maximize the
+ * probability of success of a payment or minimize the routing fees, or
+ * alternatively we construct a function of the two that gives a good compromise.
+ *
+ * Therefore from now own, the definition of optimal is a matter of choice.
+ * To simplify the API of this module, we think the best way to state the
+ * problem is:
+ *
+ * 	Find a routing solution that pays the least of fees while keeping
+ * 	the probability of success above a certain value `min_probability`.
+ *
+ *
+ * # Fee Cost
+ *
+ * Routing fees is non-linear function of the payment flow x, that's true even
+ * without the base fee:
+ *
+ * 	fee_msat = base_msat + floor(millionths*x_msat / 10^6)
+ *
+ * We approximate this fee into a linear function by computing a slope `c_fee` such
+ * that:
+ *
+ * 	fee_microsat = c_fee * x_sat
+ *
+ * Function `linear_fee_cost` computes `c_fee` based on the base and
+ * proportional fees of a channel.
+ * The final product if microsat because if only
+ * the proportional fee was considered we can have c_fee = millionths.
+ * Moving to costs based in msats means we have to either truncate payments
+ * below 1ksats or estimate as 0 cost for channels with less than 1000ppm.
+ *
+ * TODO(eduardo): shall we build a linear cost function in msats?
+ *
+ * # Probability cost
+ *
+ * The probability of success P of the payment is the product of the prob. of
+ * success of forwarding parts of the payment over all routing channels. This
+ * problem is separable if we log it, and since we would like to increase P,
+ * then we can seek to minimize -log(P), and that's our prob. cost function [1].
+ *
+ * 	- log P = sum_{i} - log P_i
+ *
+ * The probability of success `P_i` of sending some flow `x` on a channel with
+ * liquidity l in the range a<=l<b is
+ *
+ * 	P_{a,b}(x) = (b-x)/(b-a); for x > a
+ * 		   = 1.         ; for x <= a
+ *
+ * Notice that unlike the similar formula in [1], the one we propose does not
+ * contain the quantization shot noise for counting states. The formula remains
+ * valid independently of the liquidity units (sats or msats).
+ *
+ * The cost associated to probability P is then -k log P, where k is some
+ * constant. For k=1 we get the following table:
+ *
+ * 	prob | cost
+ * 	-----------
+ * 	0.01 | 4.6
+ * 	0.02 | 3.9
+ * 	0.05 | 3.0
+ * 	0.10 | 2.3
+ * 	0.20 | 1.6
+ * 	0.50 | 0.69
+ * 	0.80 | 0.22
+ * 	0.90 | 0.10
+ * 	0.95 | 0.05
+ * 	0.98 | 0.02
+ * 	0.99 | 0.01
+ *
+ * Clearly -log P(x) is non-linear; we try to linearize it piecewise:
+ * split the channel into 4 arcs representing 4 liquidity regions:
+ *
+ * 	arc_0 -> [0, a)
+ * 	arc_1 -> [a, a+(b-a)*f1)
+ * 	arc_2 -> [a+(b-a)*f1, a+(b-a)*f2)
+ * 	arc_3 -> [a+(b-a)*f2, a+(b-a)*f3)
+ *
+ * where f1 = 0.5, f2 = 0.8, f3 = 0.95;
+ * We fill arc_0's capacity with complete certainty P=1, then if more flow is
+ * needed we start filling the capacity in arc_1 until the total probability
+ * of success reaches P=0.5, then arc_2 until P=1-0.8=0.2, and finally arc_3 until
+ * P=1-0.95=0.05. We don't go further than 5% prob. of success per channel.
+
+ * TODO(eduardo): this channel linearization is hard coded into
+ * `CHANNEL_PIVOTS`, maybe we can parametrize this to take values from the config file.
+ *
+ * With this choice, the slope of the linear cost function becomes:
+ *
+ * 	m_0 = 0
+ * 	m_1 = 1.38 k /(b-a)
+ * 	m_2 = 3.05 k /(b-a)
+ * 	m_3 = 9.24 k /(b-a)
+ *
+ * Notice that one of the assumptions in [2] for the MCF problem is that flows
+ * and the slope of the costs functions are integer numbers. The only way we
+ * have at hand to make it so, is to choose a universal value of `k` that scales
+ * up the slopes so that floor(m_i) is not zero for every arc.
+ *
+ * # Combine fee and prob. costs
+ *
+ * We attempt to solve the original problem of finding the solution that
+ * pays the least fees while keeping the prob. of success above a certain value,
+ * by constructing a cost function which is a linear combination of fee and
+ * prob. costs.
+ * TODO(eduardo): investigate how this procedure is justified,
+ * possibly with the use of Lagrange optimization theory.
+ *
+ * At first, prob. and fee costs live in different dimensions, they cannot be
+ * summed, it's like comparing apples and oranges.
+ * However we propose to scale the prob. cost by a global factor k that
+ * translates into the monetization of prob. cost.
+ *
+ * k/1000, for instance, becomes the equivalent monetary cost
+ * of increasing the probability of success by 0.1% for P~100%.
+ *
+ * The input parameter `prob_cost_factor` in the function `minflow` is defined
+ * as the PPM from the delivery amount `T` we are *willing to pay* to increase the
+ * prob. of success by 0.1%:
+ *
+ * 	k_microsat = floor(1000*prob_cost_factor * T_sat)
+ *
+ * Is this enough to make integer prob. cost per unit flow?
+ * For `prob_cost_factor=10`; i.e. we pay 10ppm for increasing the prob. by
+ * 0.1%, we get that
+ *
+ * 	-> any arc with (b-a) > 10000 T, will have zero prob. cost, which is
+ * 	reasonable because even if all the flow passes through that arc, we get
+ * 	a 1.3 T/(b-a) ~ 0.01% prob. of failure at most.
+ *
+ * 	-> if (b-a) ~ 10000 T, then the arc will have unit cost, or just that we
+ * 	pay 1 microsat for every sat we send through this arc.
+ *
+ * 	-> it would be desirable to have a high proportional fee when (b-a)~T,
+ * 	because prob. of failure start to become very high.
+ * 	In this case we get to pay 10000 microsats for every sat.
+ *
+ * Once `k` is fixed then we can combine the linear prob. and fee costs, both
+ * are in monetary units.
+ *
+ * Note: with costs in microsats, because slopes represent ppm and flows are in
+ * sats, then our integer bounds with 64 bits are such that we can move as many
+ * as 10'000 BTC without overflow:
+ *
+ * 	10^6 (max ppm) * 10^8 (sats per BTC) * 10^4 = 10^18
+ *
+ * # References
+ *
+ * [1] Pickhardt and Richter, https://arxiv.org/abs/2107.05322
+ * [2] R.K. Ahuja, T.L. Magnanti, and J.B. Orlin. Network Flows:
+ * Theory, Algorithms, and Applications. Prentice Hall, 1993.
+ *
+ *
+ * TODO(eduardo) it would be interesting to see:
+ * how much do we pay for reliability?
+ * Cost_fee(most reliable solution) - Cost_fee(cheapest solution)
+ *
+ * TODO(eduardo): it would be interesting to see:
+ * how likely is the most reliable path with respect to the cheapest?
+ * Prob(reliable)/Prob(cheapest) = Exp(Cost_prob(cheapest)-Cost_prob(reliable))
+ *
+ * */
+
+#define PARTS_BITS 2
+#define CHANNEL_PARTS (1 << PARTS_BITS)
+
+// These are the probability intervals we use to decompose a channel into linear
+// cost function arcs.
+static const double CHANNEL_PIVOTS[]={0,0.5,0.8,0.95};
+
+static const s64 INFINITE = INT64_MAX;
+static const u64 INFINITE_MSAT = UINT64_MAX;
+static const u32 INVALID_INDEX = 0xffffffff;
+static const s64 MU_MAX = 128;
+
+/* Let's try this encoding of arcs:
+ * Each channel `c` has two possible directions identified by a bit
+ * `half` or `!half`, and each one of them has to be
+ * decomposed into 4 liquidity parts in order to
+ * linearize the cost function, but also to solve MCF
+ * problem we need to keep track of flows in the
+ * residual network hence we need for each directed arc
+ * in the network there must be another arc in the
+ * opposite direction refered to as it's dual. In total
+ * 1+2+1 additional bits of information:
+ *
+ * 	(chan_idx)(half)(part)(dual)
+ *
+ * That means, for each channel we need to store the
+ * information of 16 arcs. If we implement a convex-cost
+ * solver then we can reduce that number to size(half)size(dual)=4.
+ *
+ * In the adjacency of a `node` we are going to store
+ * the outgoing arcs. If we ever need to loop over the
+ * incoming arcs then we will define a reverse adjacency
+ * API.
+ * Then for each outgoing channel `(c,half)` there will
+ * be 4 parts for the actual residual capacity, hence
+ * with the dual bit set to 0:
+ *
+ * 	(c,half,0,0)
+ * 	(c,half,1,0)
+ * 	(c,half,2,0)
+ * 	(c,half,3,0)
+ *
+ * and also we need to consider the dual arcs
+ * corresponding to the channel direction `(c,!half)`
+ * (the dual has reverse direction):
+ *
+ * 	(c,!half,0,1)
+ * 	(c,!half,1,1)
+ * 	(c,!half,2,1)
+ * 	(c,!half,3,1)
+ *
+ * These are the 8 outgoing arcs relative to `node` and
+ * associated with channel `c`. The incoming arcs will
+ * be:
+ *
+ * 	(c,!half,0,0)
+ * 	(c,!half,1,0)
+ * 	(c,!half,2,0)
+ * 	(c,!half,3,0)
+ *
+ * 	(c,half,0,1)
+ * 	(c,half,1,1)
+ * 	(c,half,2,1)
+ * 	(c,half,3,1)
+ *
+ * but they will be stored as outgoing arcs on the peer
+ * node `next`.
+ *
+ * I hope this will clarify my future self when I forget.
+ *
+ * */
+
+/*
+ * We want to use the whole number here for convenience, but
+ * we can't us a union, since bit order is implementation-defined and
+ * we want chanidx on the highest bits:
+ *
+ * [ 0       1 2     3            4 5 6 ... 31 ]
+ *   dual    part    chandir      chanidx
+ */
+struct arc {
+	u32 idx;
+};
+
+#define ARC_DUAL_BITOFF (0)
+#define ARC_PART_BITOFF (1)
+#define ARC_CHANDIR_BITOFF (1 + PARTS_BITS)
+#define ARC_CHANIDX_BITOFF (1 + PARTS_BITS + 1)
+#define ARC_CHANIDX_BITS  (32 - ARC_CHANIDX_BITOFF)
+
+/* How many arcs can we have for a single channel?
+ * linearization parts, both directions, and dual */
+#define ARCS_PER_CHANNEL ((size_t)1 << (PARTS_BITS + 1 + 1))
+
+static inline void arc_to_parts(struct arc arc,
+				u32 *chanidx,
+				int *chandir,
+				u32 *part,
+				bool *dual)
+{
+	if (chanidx)
+		*chanidx = (arc.idx >> ARC_CHANIDX_BITOFF);
+	if (chandir)
+		*chandir = (arc.idx >> ARC_CHANDIR_BITOFF) & 1;
+	if (part)
+		*part = (arc.idx >> ARC_PART_BITOFF) & ((1 << PARTS_BITS)-1);
+	if (dual)
+		*dual = (arc.idx >> ARC_DUAL_BITOFF) & 1;
+}
+
+static inline struct arc arc_from_parts(u32 chanidx, int chandir, u32 part, bool dual)
+{
+	struct arc arc;
+
+	assert(part < CHANNEL_PARTS);
+	assert(chandir == 0 || chandir == 1);
+	assert(chanidx < (1U << ARC_CHANIDX_BITS));
+	arc.idx = ((u32)dual << ARC_DUAL_BITOFF)
+		| (part << ARC_PART_BITOFF)
+		| ((u32)chandir << ARC_CHANDIR_BITOFF)
+		| (chanidx << ARC_CHANIDX_BITOFF);
+	return arc;
+}
+
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+struct pay_parameters {
+	/* The gossmap we are using */
+	struct gossmap *gossmap;
+	const struct gossmap_node *source;
+	const struct gossmap_node *target;
+
+	/* Extra information we intuited about the channels */
+	struct chan_extra_map *chan_extra_map;
+
+	/* Optional bitarray of disabled channels. */
+	const bitmap *disabled;
+
+	// how much we pay
+	struct amount_msat amount;
+
+	// channel linearization parameters
+	double cap_fraction[CHANNEL_PARTS],
+	       cost_fraction[CHANNEL_PARTS];
+
+	struct amount_msat max_fee;
+	double min_probability;
+	double delay_feefactor;
+	double base_fee_penalty;
+	u32 prob_cost_factor;
+};
+
+/* Representation of the linear MCF network.
+ * This contains the topology of the extended network (after linearization and
+ * addition of arc duality).
+ * This contains also the arc probability and linear fee cost, as well as
+ * capacity; these quantities remain constant during MCF execution. */
+struct linear_network
+{
+	u32 *arc_tail_node;
+	// notice that a tail node is not needed,
+	// because the tail of arc is the head of dual(arc)
+
+	struct arc *node_adjacency_next_arc;
+	struct arc *node_adjacency_first_arc;
+
+	// probability and fee cost associated to an arc
+	s64 *arc_prob_cost, *arc_fee_cost;
+	s64 *capacity;
+
+	size_t max_num_arcs,max_num_nodes;
+};
+
+/* This is the structure that keeps track of the network properties while we
+ * seek for a solution. */
+struct residual_network {
+	/* residual capacity on arcs */
+	s64 *cap;
+
+	/* some combination of prob. cost and fee cost on arcs */
+	s64 *cost;
+
+	/* potential function on nodes */
+	s64 *potential;
+};
+
+/* Helper function.
+ * Given an arc idx, return the dual's idx in the residual network. */
+static struct arc arc_dual(struct arc arc)
+{
+	arc.idx ^= (1U << ARC_DUAL_BITOFF);
+	return arc;
+}
+/* Helper function. */
+static bool arc_is_dual(struct arc arc)
+{
+	bool dual;
+	arc_to_parts(arc, NULL, NULL, NULL, &dual);
+	return dual;
+}
+
+/* Helper function.
+ * Given an arc of the network (not residual) give me the flow. */
+static s64 get_arc_flow(
+		const struct residual_network *network,
+		const struct arc arc)
+{
+	assert(!arc_is_dual(arc));
+	assert(arc_dual(arc).idx < tal_count(network->cap));
+	return network->cap[ arc_dual(arc).idx ];
+}
+
+/* Helper function.
+ * Given an arc idx, return the node from which this arc emanates in the residual network. */
+static u32 arc_tail(const struct linear_network *linear_network,
+                    const struct arc arc)
+{
+	assert(arc.idx < tal_count(linear_network->arc_tail_node));
+	return linear_network->arc_tail_node[ arc.idx ];
+}
+/* Helper function.
+ * Given an arc idx, return the node that this arc is pointing to in the residual network. */
+static u32 arc_head(const struct linear_network *linear_network,
+                    const struct arc arc)
+{
+	const struct arc dual = arc_dual(arc);
+	assert(dual.idx < tal_count(linear_network->arc_tail_node));
+	return linear_network->arc_tail_node[dual.idx];
+}
+
+/* Helper function.
+ * Given node idx `node`, return the idx of the first arc whose tail is `node`.
+ * */
+static struct arc node_adjacency_begin(
+		const struct linear_network * linear_network,
+		const u32 node)
+{
+	assert(node < tal_count(linear_network->node_adjacency_first_arc));
+	return linear_network->node_adjacency_first_arc[node];
+}
+
+/* Helper function.
+ * Is this the end of the adjacency list. */
+static bool node_adjacency_end(const struct arc arc)
+{
+	return arc.idx == INVALID_INDEX;
+}
+
+/* Helper function.
+ * Given node idx `node` and `arc`, returns the idx of the next arc whose tail is `node`. */
+static struct arc node_adjacency_next(
+		const struct linear_network *linear_network,
+		const struct arc arc)
+{
+	assert(arc.idx < tal_count(linear_network->node_adjacency_next_arc));
+	return linear_network->node_adjacency_next_arc[arc.idx];
+}
+
+static bool channel_is_available(const struct gossmap_chan *c, int dir,
+				 const struct gossmap *gossmap,
+				 const bitmap *disabled)
+{
+	if (!gossmap_chan_set(c, dir))
+		return false;
+
+	const u32 chan_id = gossmap_chan_idx(gossmap, c);
+	return !bitmap_test_bit(disabled, chan_id);
+}
+
+// TODO(eduardo): unit test this
+/* Split a directed channel into parts with linear cost function. */
+static bool linearize_channel(const struct pay_parameters *params,
+			      const struct gossmap_chan *c, const int dir,
+			      s64 *capacity, s64 *cost)
+{
+	struct chan_extra_half *extra_half = get_chan_extra_half_by_chan(
+							params->gossmap,
+							params->chan_extra_map,
+							c,
+							dir);
+
+	if (!extra_half) {
+		return false;
+	}
+
+	assert(
+	    amount_msat_less_eq(extra_half->htlc_total, extra_half->known_max));
+	assert(
+	    amount_msat_less_eq(extra_half->known_min, extra_half->known_max));
+
+	s64 h = extra_half->htlc_total.millisatoshis/1000; /* Raw: linearize_channel */
+	s64 a = extra_half->known_min.millisatoshis/1000, /* Raw: linearize_channel */
+	    b = 1 + extra_half->known_max.millisatoshis/1000; /* Raw: linearize_channel */
+
+	/* If HTLCs add up to more than the known_max it means we have a
+	 * completely wrong knowledge. */
+	// assert(h<b);
+	/* HTLCs allocated could instead be greater than known_min, we enter in
+	 * the uncertainty region. If h>a it doesn't mean automatically that our
+	 * known_min should have been updated, because we reserve this HTLC
+	 * after sendpay behind the scenes it might happen that sendpay failed
+	 * because of insufficient funds we haven't noticed yet. */
+	// assert(h<=a);
+
+	/* We reduce this channel capacity because HTLC are reserving liquidity. */
+	a -= h;
+	b -= h;
+	a = MAX(a,0);
+	b = MAX(a+1,b);
+
+	/* An extra bound on capacity, here we use it to reduce the flow such
+	 * that it does not exceed htlcmax. */
+	s64 cap_on_capacity =
+	 channel_htlc_max(c, dir).millisatoshis/1000; /* Raw: linearize_channel */
+
+	capacity[0]=a;
+	cost[0]=0;
+	for(size_t i=1;i<CHANNEL_PARTS;++i)
+	{
+		capacity[i] = MIN(params->cap_fraction[i]*(b-a), cap_on_capacity);
+		cap_on_capacity -= capacity[i];
+		assert(cap_on_capacity>=0);
+
+		cost[i] = params->cost_fraction[i]
+		          *params->amount.millisatoshis /* Raw: linearize_channel */
+		          *params->prob_cost_factor*1.0/(b-a);
+	}
+	return true;
+}
+
+static struct residual_network *
+alloc_residual_network(const tal_t *ctx, const size_t max_num_nodes,
+		      const size_t max_num_arcs)
+{
+	struct residual_network *residual_network =
+	    tal(ctx, struct residual_network);
+	if (!residual_network)
+		goto function_fail;
+
+	residual_network->cap = tal_arrz(residual_network, s64, max_num_arcs);
+	residual_network->cost = tal_arrz(residual_network, s64, max_num_arcs);
+	residual_network->potential =
+	    tal_arrz(residual_network, s64, max_num_nodes);
+
+	if (!residual_network->cap || !residual_network->cost ||
+	    !residual_network->potential) {
+		goto function_fail;
+	}
+	return residual_network;
+
+	function_fail:
+	return tal_free(residual_network);
+}
+
+static void init_residual_network(
+		const struct linear_network * linear_network,
+		struct residual_network* residual_network)
+{
+	const size_t max_num_arcs = linear_network->max_num_arcs;
+	const size_t max_num_nodes = linear_network->max_num_nodes;
+
+	for(struct arc arc = {0};arc.idx < max_num_arcs; ++arc.idx)
+	{
+		if(arc_is_dual(arc))
+			continue;
+
+		struct arc dual = arc_dual(arc);
+		residual_network->cap[arc.idx]=linear_network->capacity[arc.idx];
+		residual_network->cap[dual.idx]=0;
+
+		residual_network->cost[arc.idx]=residual_network->cost[dual.idx]=0;
+	}
+	for(u32 i=0;i<max_num_nodes;++i)
+	{
+		residual_network->potential[i]=0;
+	}
+}
+
+static void combine_cost_function(
+		const struct linear_network* linear_network,
+		struct residual_network *residual_network,
+		s64 mu)
+{
+	for(struct arc arc = {0};arc.idx < linear_network->max_num_arcs; ++arc.idx)
+	{
+		if(arc_tail(linear_network,arc)==INVALID_INDEX)
+			continue;
+
+		const s64 pcost = linear_network->arc_prob_cost[arc.idx],
+		          fcost = linear_network->arc_fee_cost[arc.idx];
+
+		const s64 combined = pcost==INFINITE || fcost==INFINITE ? INFINITE :
+		                     mu*fcost + (MU_MAX-1-mu)*pcost;
+
+		residual_network->cost[arc.idx]
+			= mu==0 ? pcost :
+			          (mu==(MU_MAX-1) ? fcost : combined);
+	}
+}
+
+static void linear_network_add_adjacenct_arc(
+		struct linear_network *linear_network,
+		const u32 node_idx,
+		const struct arc arc)
+{
+	assert(arc.idx < tal_count(linear_network->arc_tail_node));
+	linear_network->arc_tail_node[arc.idx] = node_idx;
+
+	assert(node_idx < tal_count(linear_network->node_adjacency_first_arc));
+	const struct arc first_arc = linear_network->node_adjacency_first_arc[node_idx];
+
+	assert(arc.idx < tal_count(linear_network->node_adjacency_next_arc));
+	linear_network->node_adjacency_next_arc[arc.idx]=first_arc;
+
+	assert(node_idx < tal_count(linear_network->node_adjacency_first_arc));
+	linear_network->node_adjacency_first_arc[node_idx]=arc;
+}
+
+/* Get the fee cost associated to this directed channel.
+ * Cost is expressed as PPM of the payment.
+ *
+ * Choose and integer `c_fee` to linearize the following fee function
+ *
+ *  	fee_msat = base_msat + floor(millionths*x_msat / 10^6)
+ *
+ * into
+ *
+ *  	fee_microsat = c_fee * x_sat
+ *
+ *  use `base_fee_penalty` to weight the base fee and `delay_feefactor` to
+ *  weight the CLTV delay.
+ *  */
+static s64 linear_fee_cost(
+		const struct gossmap_chan *c,
+		const int dir,
+		double base_fee_penalty,
+		double delay_feefactor)
+{
+	assert(c);
+	assert(dir==0 || dir==1);
+	s64 pfee = c->half[dir].proportional_fee,
+	    bfee = c->half[dir].base_fee,
+	    delay = c->half[dir].delay;
+
+	return pfee + bfee* base_fee_penalty+ delay*delay_feefactor;
+}
+
+static struct linear_network *
+init_linear_network(const tal_t *ctx, const struct pay_parameters *params,
+		    char **fail)
+{
+	tal_t *this_ctx = tal(ctx,tal_t);
+
+	struct linear_network * linear_network = tal(ctx, struct linear_network);
+	if (!linear_network) {
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of linear_network");
+		goto function_fail;
+	}
+
+	const size_t max_num_chans = gossmap_max_chan_idx(params->gossmap);
+	const size_t max_num_arcs = max_num_chans * ARCS_PER_CHANNEL;
+	const size_t max_num_nodes = gossmap_max_node_idx(params->gossmap);
+
+	linear_network->max_num_arcs = max_num_arcs;
+	linear_network->max_num_nodes = max_num_nodes;
+
+	linear_network->arc_tail_node = tal_arr(linear_network,u32,max_num_arcs);
+	if(!linear_network->arc_tail_node)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of arc_tail_node");
+		goto function_fail;
+	}
+	for(size_t i=0;i<tal_count(linear_network->arc_tail_node);++i)
+		linear_network->arc_tail_node[i]=INVALID_INDEX;
+
+	linear_network->node_adjacency_next_arc = tal_arr(linear_network,struct arc,max_num_arcs);
+	if(!linear_network->node_adjacency_next_arc)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of node_adjacency_next_arc");
+		goto function_fail;
+	}
+	for(size_t i=0;i<tal_count(linear_network->node_adjacency_next_arc);++i)
+		linear_network->node_adjacency_next_arc[i].idx=INVALID_INDEX;
+
+	linear_network->node_adjacency_first_arc = tal_arr(linear_network,struct arc,max_num_nodes);
+	if(!linear_network->node_adjacency_first_arc)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of node_adjacency_first_arc");
+		goto function_fail;
+	}
+	for(size_t i=0;i<tal_count(linear_network->node_adjacency_first_arc);++i)
+		linear_network->node_adjacency_first_arc[i].idx=INVALID_INDEX;
+
+	linear_network->arc_prob_cost = tal_arr(linear_network,s64,max_num_arcs);
+	if(!linear_network->arc_prob_cost)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of arc_prob_cost");
+		goto function_fail;
+	}
+	for(size_t i=0;i<tal_count(linear_network->arc_prob_cost);++i)
+		linear_network->arc_prob_cost[i]=INFINITE;
+
+	linear_network->arc_fee_cost = tal_arr(linear_network,s64,max_num_arcs);
+	if(!linear_network->arc_fee_cost)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of arc_fee_cost");
+		goto function_fail;
+	}
+	for(size_t i=0;i<tal_count(linear_network->arc_fee_cost);++i)
+		linear_network->arc_fee_cost[i]=INFINITE;
+
+	linear_network->capacity = tal_arrz(linear_network,s64,max_num_arcs);
+	if(!linear_network->capacity)
+	{
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation of capacity");
+		goto function_fail;
+	}
+
+	for(struct gossmap_node *node = gossmap_first_node(params->gossmap);
+	    node;
+	    node=gossmap_next_node(params->gossmap,node))
+	{
+		const u32 node_id = gossmap_node_idx(params->gossmap,node);
+
+		for(size_t j=0;j<node->num_chans;++j)
+		{
+			int half;
+			const struct gossmap_chan *c = gossmap_nth_chan(params->gossmap,
+			                                                node, j, &half);
+
+			if (!channel_is_available(c, half, params->gossmap,
+						  params->disabled))
+				continue;
+
+			const u32 chan_id = gossmap_chan_idx(params->gossmap, c);
+
+			const struct gossmap_node *next = gossmap_nth_node(params->gossmap,
+									   c,!half);
+
+			const u32 next_id = gossmap_node_idx(params->gossmap,next);
+
+			if(node_id==next_id)
+				continue;
+
+			// `cost` is the word normally used to denote cost per
+			// unit of flow in the context of MCF.
+			s64 prob_cost[CHANNEL_PARTS], capacity[CHANNEL_PARTS];
+
+			// split this channel direction to obtain the arcs
+			// that are outgoing to `node`
+			if (!linearize_channel(params, c, half,
+					       capacity, prob_cost)) {
+				if(fail)
+				*fail =
+				    tal_fmt(ctx, "linearize_channel failed");
+				goto function_fail;
+			}
+
+			const s64 fee_cost = linear_fee_cost(c,half,
+						params->base_fee_penalty,
+						params->delay_feefactor);
+
+			// let's subscribe the 4 parts of the channel direction
+			// (c,half), the dual of these guys will be subscribed
+			// when the `i` hits the `next` node.
+			for(size_t k=0;k<CHANNEL_PARTS;++k)
+			{
+				// if(capacity[k]==0)continue;
+
+				struct arc arc = arc_from_parts(chan_id, half, k, false);
+
+				linear_network_add_adjacenct_arc(linear_network,node_id,arc);
+
+				linear_network->capacity[arc.idx] = capacity[k];
+				linear_network->arc_prob_cost[arc.idx] = prob_cost[k];
+
+				linear_network->arc_fee_cost[arc.idx] = fee_cost;
+
+				// + the respective dual
+				struct arc dual = arc_dual(arc);
+
+				linear_network_add_adjacenct_arc(linear_network,next_id,dual);
+
+				linear_network->capacity[dual.idx] = 0;
+				linear_network->arc_prob_cost[dual.idx] = -prob_cost[k];
+
+				linear_network->arc_fee_cost[dual.idx] = -fee_cost;
+			}
+		}
+	}
+
+	tal_free(this_ctx);
+	return linear_network;
+
+	function_fail:
+	tal_free(this_ctx);
+	return tal_free(linear_network);
+}
+
+/* Simple queue to traverse the network. */
+struct queue_data
+{
+	u32 idx;
+	struct lqueue_link ql;
+};
+
+// TODO(eduardo): unit test this
+/* Finds an admissible path from source to target, traversing arcs in the
+ * residual network with capacity greater than 0.
+ * The path is encoded into prev, which contains the idx of the arcs that are
+ * traversed. */
+static bool
+find_admissible_path(const tal_t *ctx,
+		     const struct linear_network *linear_network,
+		     const struct residual_network *residual_network,
+		     const u32 source, const u32 target, struct arc *prev)
+{
+	tal_t *this_ctx = tal(ctx,tal_t);
+
+	bool target_found = false;
+
+	for(size_t i=0;i<tal_count(prev);++i)
+		prev[i].idx=INVALID_INDEX;
+
+	// The graph is dense, and the farthest node is just a few hops away,
+	// hence let's BFS search.
+	LQUEUE(struct queue_data,ql) myqueue = LQUEUE_INIT;
+	struct queue_data *qdata;
+
+	qdata = tal(this_ctx,struct queue_data);
+	qdata->idx = source;
+	lqueue_enqueue(&myqueue,qdata);
+
+	while(!lqueue_empty(&myqueue))
+	{
+		qdata = lqueue_dequeue(&myqueue);
+		u32 cur = qdata->idx;
+
+		tal_free(qdata);
+
+		if(cur==target)
+		{
+			target_found = true;
+			break;
+		}
+
+		for(struct arc arc = node_adjacency_begin(linear_network,cur);
+		        !node_adjacency_end(arc);
+			arc = node_adjacency_next(linear_network,arc))
+		{
+			// check if this arc is traversable
+			if(residual_network->cap[arc.idx] <= 0)
+				continue;
+
+			u32 next = arc_head(linear_network,arc);
+
+			assert(next < tal_count(prev));
+
+			// if that node has been seen previously
+			if(prev[next].idx!=INVALID_INDEX)
+				continue;
+
+			prev[next] = arc;
+
+			qdata = tal(this_ctx,struct queue_data);
+			qdata->idx = next;
+			lqueue_enqueue(&myqueue,qdata);
+		}
+	}
+	tal_free(this_ctx);
+	return target_found;
+}
+
+/* Get the max amount of flow one can send from source to target along the path
+ * encoded in `prev`. */
+static s64 get_augmenting_flow(
+		const struct linear_network* linear_network,
+		const struct residual_network *residual_network,
+	        const u32 source,
+		const u32 target,
+		const struct arc *prev)
+{
+	s64 flow = INFINITE;
+
+	u32 cur = target;
+	while(cur!=source)
+	{
+		assert(cur<tal_count(prev));
+		const struct arc arc = prev[cur];
+		flow = MIN(flow , residual_network->cap[arc.idx]);
+
+		// we are traversing in the opposite direction to the flow,
+		// hence the next node is at the tail of the arc.
+		cur = arc_tail(linear_network,arc);
+	}
+
+	assert(flow<INFINITE && flow>0);
+	return flow;
+}
+
+/* Augment a `flow` amount along the path defined by `prev`.*/
+static void augment_flow(
+		const struct linear_network *linear_network,
+		struct residual_network *residual_network,
+	        const u32 source,
+		const u32 target,
+		const struct arc *prev,
+		s64 flow)
+{
+	u32 cur = target;
+
+	while(cur!=source)
+	{
+		assert(cur < tal_count(prev));
+		const struct arc arc = prev[cur];
+		const struct arc dual = arc_dual(arc);
+
+		assert(arc.idx < tal_count(residual_network->cap));
+		assert(dual.idx < tal_count(residual_network->cap));
+
+		residual_network->cap[arc.idx] -= flow;
+		residual_network->cap[dual.idx] += flow;
+
+		assert(residual_network->cap[arc.idx] >=0 );
+
+		// we are traversing in the opposite direction to the flow,
+		// hence the next node is at the tail of the arc.
+		cur = arc_tail(linear_network,arc);
+	}
+}
+
+
+// TODO(eduardo): unit test this
+/* Finds any flow that satisfy the capacity and balance constraints of the
+ * uncertainty network. For the balance function condition we have:
+ * 	balance(source) = - balance(target) = amount
+ * 	balance(node) = 0 , for every other node
+ * Returns an error code if no feasible flow is found.
+ *
+ * 13/04/2023 This implementation uses a simple augmenting path approach.
+ * */
+static bool find_feasible_flow(const tal_t *ctx,
+			       const struct linear_network *linear_network,
+			       struct residual_network *residual_network,
+			       const u32 source, const u32 target, s64 amount,
+			       char **fail)
+{
+	assert(amount>=0);
+	tal_t *this_ctx = tal(ctx,tal_t);
+
+	/* path information
+	 * prev: is the id of the arc that lead to the node. */
+	struct arc *prev = tal_arr(this_ctx,struct arc,linear_network->max_num_nodes);
+	if(!prev)
+	{
+		if(fail)
+		*fail = tal_fmt(ctx, "bad allocation of prev");
+		goto function_fail;
+	}
+
+	while(amount>0)
+	{
+		// find a path from source to target
+		if (!find_admissible_path(this_ctx, linear_network,
+					  residual_network, source, target,
+					  prev))
+
+		{
+			if(fail)
+			*fail = tal_fmt(ctx, "find_admissible_path failed");
+			goto function_fail;
+		}
+
+		// traverse the path and see how much flow we can send
+		s64 delta = get_augmenting_flow(linear_network,
+						residual_network,
+						source,target,prev);
+
+		// commit that flow to the path
+		delta = MIN(amount,delta);
+		assert(delta>0 && delta<=amount);
+
+		augment_flow(linear_network,residual_network,source,target,prev,delta);
+		amount -= delta;
+	}
+
+	tal_free(this_ctx);
+	return true;
+
+	function_fail:
+	tal_free(this_ctx);
+	return false;
+}
+
+// TODO(eduardo): unit test this
+/* Similar to `find_admissible_path` but use Dijkstra to optimize the distance
+ * label. Stops when the target is hit. */
+static bool find_optimal_path(const tal_t *ctx, struct dijkstra *dijkstra,
+			      const struct linear_network *linear_network,
+			      const struct residual_network *residual_network,
+			      const u32 source, const u32 target,
+			      struct arc *prev, char **fail)
+{
+	tal_t *this_ctx = tal(ctx,tal_t);
+	bool target_found = false;
+
+	bitmap *visited = tal_arrz(this_ctx, bitmap,
+					BITMAP_NWORDS(linear_network->max_num_nodes));
+
+	if(!visited)
+	{
+		if(fail)
+		*fail = tal_fmt(ctx, "bad allocation of visited");
+		goto finish;
+	}
+
+
+	for(size_t i=0;i<tal_count(prev);++i)
+		prev[i].idx=INVALID_INDEX;
+
+	const s64 *const distance=dijkstra_distance_data(dijkstra);
+
+	dijkstra_init(dijkstra);
+	dijkstra_update(dijkstra,source,0);
+
+	while(!dijkstra_empty(dijkstra))
+	{
+		u32 cur = dijkstra_top(dijkstra);
+		dijkstra_pop(dijkstra);
+
+		if(bitmap_test_bit(visited,cur))
+			continue;
+
+		bitmap_set_bit(visited,cur);
+
+		if(cur==target)
+		{
+			target_found = true;
+			break;
+		}
+
+		for(struct arc arc = node_adjacency_begin(linear_network,cur);
+		        !node_adjacency_end(arc);
+			arc = node_adjacency_next(linear_network,arc))
+		{
+			// check if this arc is traversable
+			if(residual_network->cap[arc.idx] <= 0)
+				continue;
+
+			u32 next = arc_head(linear_network,arc);
+
+			s64 cij = residual_network->cost[arc.idx]
+					- residual_network->potential[cur]
+					+ residual_network->potential[next];
+
+			// Dijkstra only works with non-negative weights
+			assert(cij>=0);
+
+			if(distance[next]<=distance[cur]+cij)
+				continue;
+
+			dijkstra_update(dijkstra,next,distance[cur]+cij);
+			prev[next]=arc;
+		}
+	}
+
+	if (!target_found && fail)
+		*fail = tal_fmt(ctx, "no route to destination");
+
+	finish:
+	tal_free(this_ctx);
+	return target_found;
+}
+
+/* Set zero flow in the residual network. */
+static void zero_flow(
+		const struct linear_network *linear_network,
+		struct residual_network *residual_network)
+{
+	for(u32 node=0;node<linear_network->max_num_nodes;++node)
+	{
+		residual_network->potential[node]=0;
+		for(struct arc arc=node_adjacency_begin(linear_network,node);
+			  !node_adjacency_end(arc);
+			  arc = node_adjacency_next(linear_network,arc))
+		{
+			if(arc_is_dual(arc))continue;
+
+			struct arc dual = arc_dual(arc);
+
+			residual_network->cap[arc.idx] = linear_network->capacity[arc.idx];
+			residual_network->cap[dual.idx] = 0;
+		}
+	}
+}
+
+// TODO(eduardo): unit test this
+/* Starting from a feasible flow (satisfies the balance and capacity
+ * constraints), find a solution that minimizes the network->cost function.
+ *
+ * TODO(eduardo) The MCF must be called several times until we get a good
+ * compromise between fees and probabilities. Instead of re-computing the MCF at
+ * each step, we might use the previous flow result, which is not optimal in the
+ * current iteration but I might be not too far from the truth.
+ * It comes to mind to use cycle cancelling. */
+static bool optimize_mcf(const tal_t *ctx, struct dijkstra *dijkstra,
+			 const struct linear_network *linear_network,
+			 struct residual_network *residual_network,
+			 const u32 source, const u32 target, const s64 amount,
+			 char **fail)
+{
+	assert(amount>=0);
+	tal_t *this_ctx = tal(ctx,tal_t);
+	char *errmsg;
+
+	zero_flow(linear_network,residual_network);
+	struct arc *prev = tal_arr(this_ctx,struct arc,linear_network->max_num_nodes);
+
+	const s64 *const distance = dijkstra_distance_data(dijkstra);
+
+	s64 remaining_amount = amount;
+
+	while(remaining_amount>0)
+	{
+		if (!find_optimal_path(this_ctx, dijkstra, linear_network,
+				       residual_network, source, target, prev,
+				       &errmsg)) {
+			if (fail)
+			*fail =
+			    tal_fmt(ctx, "find_optimal_path failed: %s",
+				    errmsg);
+			goto function_fail;
+		}
+
+		// traverse the path and see how much flow we can send
+		s64 delta = get_augmenting_flow(linear_network,residual_network,source,target,prev);
+
+		// commit that flow to the path
+		delta = MIN(remaining_amount,delta);
+		assert(delta>0 && delta<=remaining_amount);
+
+		augment_flow(linear_network,residual_network,source,target,prev,delta);
+		remaining_amount -= delta;
+
+		// update potentials
+		for(u32 n=0;n<linear_network->max_num_nodes;++n)
+		{
+			// see page 323 of Ahuja-Magnanti-Orlin
+			residual_network->potential[n] -= MIN(distance[target],distance[n]);
+
+			/* Notice:
+			 * if node i is permanently labeled we have
+			 * 	d_i<=d_t
+			 * which implies
+			 * 	MIN(d_i,d_t) = d_i
+			 * if node i is temporarily labeled we have
+			 * 	d_i>=d_t
+			 * which implies
+			 * 	MIN(d_i,d_t) = d_t
+			 * */
+		}
+	}
+	tal_free(this_ctx);
+	return true;
+
+	function_fail:
+
+	tal_free(this_ctx);
+	return false;
+}
+
+// flow on directed channels
+struct chan_flow
+{
+	s64 half[2];
+};
+
+/* Search in the network a path of positive flow until we reach a node with
+ * positive balance. */
+static u32 find_positive_balance(
+		const struct gossmap *gossmap,
+		const bitmap *disabled,
+		const struct chan_flow *chan_flow,
+		const u32 start_idx,
+		const s64 *balance,
+
+		const struct gossmap_chan **prev_chan,
+		int *prev_dir,
+		u32 *prev_idx)
+{
+	u32 final_idx = start_idx;
+
+	/* TODO(eduardo)
+	 * This is guaranteed to halt if there are no directed flow cycles.
+	 * There souldn't be any. In fact if cost is strickly
+	 * positive, then flow cycles do not exist at all in the
+	 * MCF solution. But if cost is allowed to be zero for
+	 * some arcs, then we might have flow cyles in the final
+	 * solution. We must somehow ensure that the MCF
+	 * algorithm does not come up with spurious flow cycles. */
+	while(balance[final_idx]<=0)
+	{
+		// printf("%s: node = %d\n",__PRETTY_FUNCTION__,final_idx);
+		u32 updated_idx=INVALID_INDEX;
+		struct gossmap_node *cur
+			= gossmap_node_byidx(gossmap,final_idx);
+
+		for(size_t i=0;i<cur->num_chans;++i)
+		{
+			int dir;
+			const struct gossmap_chan *c
+				= gossmap_nth_chan(gossmap,
+				                   cur,i,&dir);
+
+			if (!channel_is_available(c, dir, gossmap, disabled))
+				continue;
+
+			const u32 c_idx = gossmap_chan_idx(gossmap,c);
+
+			// follow the flow
+			if(chan_flow[c_idx].half[dir]>0)
+			{
+				const struct gossmap_node *next
+					= gossmap_nth_node(gossmap,c,!dir);
+				u32 next_idx = gossmap_node_idx(gossmap,next);
+
+
+				prev_dir[next_idx] = dir;
+				prev_chan[next_idx] = c;
+				prev_idx[next_idx] = final_idx;
+
+				updated_idx = next_idx;
+				break;
+			}
+		}
+
+		assert(updated_idx!=INVALID_INDEX);
+		assert(updated_idx!=final_idx);
+
+		final_idx = updated_idx;
+	}
+	return final_idx;
+}
+
+struct list_data
+{
+	struct list_node list;
+	struct flow *flow_path;
+};
+
+static inline uint64_t pseudorand_interval(uint64_t a, uint64_t b)
+{
+	if (a == b)
+		return b;
+	assert(b > a);
+	return a + pseudorand(b - a);
+}
+
+/* Given a flow in the residual network, build a set of payment flows in the
+ * gossmap that corresponds to this flow. */
+static struct flow **
+get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
+	       const bitmap *disabled,
+
+	       // chan_extra_map cannot be const because we use it to keep
+	       // track of htlcs and in_flight sats.
+	       struct chan_extra_map *chan_extra_map,
+	       const struct linear_network *linear_network,
+	       const struct residual_network *residual_network,
+
+	       // how many msats in excess we paid for not having msat accuracy
+	       // in the MCF solver
+	       struct amount_msat excess,
+
+	       // error message
+	       char **fail)
+{
+	tal_t *this_ctx = tal(ctx,tal_t);
+	struct flow **flows = tal_arr(ctx,struct flow*,0);
+
+	assert(amount_msat_less(excess, AMOUNT_MSAT(1000)));
+
+	const size_t max_num_chans = gossmap_max_chan_idx(gossmap);
+	struct chan_flow *chan_flow = tal_arrz(this_ctx,struct chan_flow,max_num_chans);
+
+	const size_t max_num_nodes = gossmap_max_node_idx(gossmap);
+	s64 *balance = tal_arrz(this_ctx,s64,max_num_nodes);
+
+	const struct gossmap_chan **prev_chan
+		= tal_arr(this_ctx,const struct gossmap_chan *,max_num_nodes);
+
+
+	int *prev_dir = tal_arr(this_ctx,int,max_num_nodes);
+	u32 *prev_idx = tal_arr(this_ctx,u32,max_num_nodes);
+
+	if (!chan_flow || !balance || !prev_chan || !prev_idx || !prev_dir) {
+		if (fail)
+		*fail = tal_fmt(ctx, "bad allocation");
+		goto function_fail;
+	}
+
+	// Convert the arc based residual network flow into a flow in the
+	// directed channel network.
+	// Compute balance on the nodes.
+	for(u32 n = 0;n<max_num_nodes;++n)
+	{
+		for(struct arc arc = node_adjacency_begin(linear_network,n);
+		        !node_adjacency_end(arc);
+			arc = node_adjacency_next(linear_network,arc))
+		{
+			if(arc_is_dual(arc))
+				continue;
+			u32 m = arc_head(linear_network,arc);
+			s64 flow = get_arc_flow(residual_network,arc);
+			u32 chanidx;
+			int chandir;
+
+			balance[n] -= flow;
+			balance[m] += flow;
+
+			arc_to_parts(arc, &chanidx, &chandir, NULL, NULL);
+			chan_flow[chanidx].half[chandir] +=flow;
+		}
+
+	}
+
+
+	// Select all nodes with negative balance and find a flow that reaches a
+	// positive balance node.
+	for(u32 node_idx=0;node_idx<max_num_nodes;++node_idx)
+	{
+		// for(size_t i=0;i<tal_count(prev_idx);++i)
+		// {
+		// 	prev_idx[i]=INVALID_INDEX;
+		// }
+		// this node has negative balance, flows leaves from here
+		while(balance[node_idx]<0)
+		{
+			prev_chan[node_idx]=NULL;
+			u32 final_idx = find_positive_balance(
+			    gossmap, disabled, chan_flow, node_idx, balance,
+			    prev_chan, prev_dir, prev_idx);
+
+			/* For each route we will compute the highest htlc_min
+			 * and the smallest htlc_max and use those to constraint
+			 * the flow we will allocate. */
+			struct amount_msat sup_htlc_min = AMOUNT_MSAT_INIT(0),
+					   inf_htlc_max =
+					       AMOUNT_MSAT_INIT(INFINITE_MSAT);
+
+			s64 delta=-balance[node_idx];
+			int length = 0;
+			delta = MIN(delta,balance[final_idx]);
+
+			// walk backwards, get me the length and the max flow we
+			// can send.
+			for(u32 cur_idx = final_idx;
+			    cur_idx!=node_idx;
+			    cur_idx=prev_idx[cur_idx])
+			{
+				assert(cur_idx!=INVALID_INDEX);
+
+				const int dir = prev_dir[cur_idx];
+				const struct gossmap_chan *const c = prev_chan[cur_idx];
+				const u32 c_idx = gossmap_chan_idx(gossmap,c);
+
+				delta=MIN(delta,chan_flow[c_idx].half[dir]);
+				length++;
+
+				/* obtain the supremum htlc_min along the route
+				 */
+				sup_htlc_min = amount_msat_max(
+				    sup_htlc_min, channel_htlc_min(c, dir));
+
+				/* obtain the infimum htlc_max along the route
+				 */
+				inf_htlc_max = amount_msat_min(
+				    inf_htlc_max, channel_htlc_max(c, dir));
+			}
+
+			s64 htlc_max=inf_htlc_max.millisatoshis/1000;/* Raw: need htlc_max in sats to do arithmetic operations.*/
+			s64 htlc_min=(sup_htlc_min.millisatoshis+999)/1000;/* Raw: need htlc_min in sats to do arithmetic operations.*/
+
+			if (htlc_min > htlc_max) {
+				/* htlc_min is too big or htlc_max is too small,
+				 * we cannot send `delta` along this route.
+				 *
+				 * FIXME: We try anyways because failing
+				 * channels will be blacklisted downstream. */
+				htlc_min = 0;
+			}
+
+			/* If we divide this route into different flows make it
+			 * random to avoid routing nodes making correlations. */
+			if (delta > htlc_max) {
+				// FIXME: choosing a number in the range
+				// [htlc_min, htlc_max] or
+				// [0.5 htlc_max, htlc_max]
+				// The choice of the fraction was completely
+				// arbitrary.
+				delta = pseudorand_interval(
+				    MAX(htlc_min, (htlc_max * 50) / 100),
+				    htlc_max);
+			}
+
+			struct flow *fp = tal(this_ctx,struct flow);
+			fp->path = tal_arr(fp,const struct gossmap_chan *,length);
+			fp->dirs = tal_arr(fp,int,length);
+
+			balance[node_idx] += delta;
+			balance[final_idx]-= delta;
+
+			// walk backwards, substract flow
+			for(u32 cur_idx = final_idx;
+			    cur_idx!=node_idx;
+			    cur_idx=prev_idx[cur_idx])
+			{
+				assert(cur_idx!=INVALID_INDEX);
+
+				const int dir = prev_dir[cur_idx];
+				const struct gossmap_chan *const c = prev_chan[cur_idx];
+				const u32 c_idx = gossmap_chan_idx(gossmap,c);
+
+				length--;
+				fp->path[length]=c;
+				fp->dirs[length]=dir;
+				// notice: fp->path and fp->dirs have the path
+				// in the correct order.
+
+				chan_flow[c_idx].half[prev_dir[cur_idx]]-=delta;
+			}
+
+			assert(delta>0);
+
+			// substract the excess of msats for not having msat
+			// accuracy
+			struct amount_msat delivered = amount_msat(delta*1000);
+			if (!amount_msat_sub(&delivered, delivered, excess)) {
+				if (fail)
+				*fail = tal_fmt(
+				    ctx, "unable to substract excess");
+				goto function_fail;
+			}
+			excess = amount_msat(0);
+			fp->amount = delivered;
+
+			fp->success_prob =
+			    flow_probability(fp, gossmap, chan_extra_map);
+			if (fp->success_prob < 0) {
+				if (fail)
+					*fail =
+					    tal_fmt(ctx, "failed to compute "
+							 "flow probability");
+				goto function_fail;
+			}
+
+			// add fp to flows
+			tal_arr_expand(&flows, fp);
+		}
+	}
+
+	/* Establish ownership. */
+	for(size_t i=0;i<tal_count(flows);++i)
+	{
+		flows[i] = tal_steal(flows,flows[i]);
+		assert(flows[i]);
+	}
+	if (fail)
+		*fail = NULL;
+	tal_free(this_ctx);
+	return flows;
+
+	function_fail:
+	tal_free(this_ctx);
+	return tal_free(flows);
+}
+
+/* Given the constraints on max fee and min prob.,
+ * is the flow A better than B? */
+static bool is_better(
+		struct amount_msat max_fee,
+		double min_probability,
+
+		struct amount_msat A_fee,
+		double A_prob,
+
+		struct amount_msat B_fee,
+		double B_prob)
+{
+	bool A_fee_pass = amount_msat_less_eq(A_fee,max_fee);
+	bool B_fee_pass = amount_msat_less_eq(B_fee,max_fee);
+	bool A_prob_pass = A_prob >= min_probability;
+	bool B_prob_pass = B_prob >= min_probability;
+
+	// all bounds are met
+	if(A_fee_pass && B_fee_pass && A_prob_pass && B_prob_pass)
+	{
+		// prefer lower fees
+		goto fees_or_prob;
+	}
+
+	// prefer the solution that satisfies both bounds
+	if(!(A_fee_pass && A_prob_pass) && (B_fee_pass && B_prob_pass))
+	{
+		return false;
+	}
+	// prefer the solution that satisfies both bounds
+	if((A_fee_pass && A_prob_pass) && !(B_fee_pass && B_prob_pass))
+	{
+		return true;
+	}
+
+	// no solution satisfies both bounds
+
+	// bound on fee is met
+	if(A_fee_pass && B_fee_pass)
+	{
+		// pick the highest prob.
+		return A_prob > B_prob;
+	}
+
+	// bound on prob. is met
+	if(A_prob_pass && B_prob_pass)
+	{
+		goto fees_or_prob;
+	}
+
+	// prefer the solution that satisfies the bound on fees
+	if(A_fee_pass && !B_fee_pass)
+	{
+		return true;
+	}
+	if(B_fee_pass && !A_fee_pass)
+	{
+		return false;
+	}
+
+	// none of them satisfy the fee bound
+
+	// prefer the solution that satisfies the bound on prob.
+	if(A_prob_pass && !B_prob_pass)
+	{
+		return true;
+	}
+	if(B_prob_pass && !A_prob_pass)
+	{
+		return true;
+	}
+
+	// no bound whatsoever is satisfied
+
+	fees_or_prob:
+
+	// fees are the same, wins the highest prob.
+	if(amount_msat_eq(A_fee,B_fee))
+	{
+		return A_prob > B_prob;
+	}
+
+	// go for fees
+	return amount_msat_less_eq(A_fee,B_fee);
+}
+
+/* Channels that are not in the chan_extra_map should be disabled. */
+static bool check_disabled(const bitmap *disabled,
+			   const struct gossmap *gossmap,
+			   const struct chan_extra_map *chan_extra_map)
+{
+	assert(disabled);
+	assert(gossmap);
+	assert(chan_extra_map);
+
+	if(tal_bytelen(disabled) != bitmap_sizeof(gossmap_max_chan_idx(gossmap)))
+		return false;
+
+	for (struct gossmap_chan *chan = gossmap_first_chan(gossmap); chan;
+	     chan = gossmap_next_chan(gossmap, chan)) {
+		const u32 chan_id = gossmap_chan_idx(gossmap, chan);
+		if (bitmap_test_bit(disabled, chan_id))
+			continue;
+
+		struct short_channel_id scid = gossmap_chan_scid(gossmap, chan);
+		struct chan_extra *ce =
+		    chan_extra_map_get(chan_extra_map, scid);
+		if (!ce)
+			return false;
+	}
+	return true;
+}
+
+// TODO(eduardo): choose some default values for the minflow parameters
+/* eduardo: I think it should be clear that this module deals with linear
+ * flows, ie. base fees are not considered. Hence a flow along a path is
+ * described with a sequence of directed channels and one amount.
+ * In the `pay_flow` module there are dedicated routes to compute the actual
+ * amount to be forward on each hop.
+ *
+ * TODO(eduardo): notice that we don't pay fees to forward payments with local
+ * channels and we can tell with absolute certainty the liquidity on them.
+ * Check that local channels have fee costs = 0 and bounds with certainty (min=max). */
+// TODO(eduardo): we should LOG_DBG the process of finding the MCF while
+// adjusting the frugality factor.
+struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
+		      const struct gossmap_node *source,
+		      const struct gossmap_node *target,
+		      struct chan_extra_map *chan_extra_map,
+		      const bitmap *disabled, struct amount_msat amount,
+		      struct amount_msat max_fee, double min_probability,
+		      double delay_feefactor, double base_fee_penalty,
+		      u32 prob_cost_factor, char **fail)
+{
+	tal_t *this_ctx = tal(ctx,tal_t);
+	char *errmsg;
+	struct flow **best_flow_paths = NULL;
+
+	struct pay_parameters *params = tal(this_ctx,struct pay_parameters);
+	struct dijkstra *dijkstra;
+
+	params->gossmap = gossmap;
+	params->source = source;
+	params->target = target;
+	params->chan_extra_map = chan_extra_map;
+
+	params->disabled = disabled;
+
+	if (!check_disabled(disabled, gossmap, chan_extra_map)) {
+		if (fail)
+			*fail = tal_fmt(ctx, "Invalid disabled bitmap.");
+		goto function_fail;
+	}
+
+	params->amount = amount;
+
+	// template the channel partition into linear arcs
+	params->cap_fraction[0]=0;
+	params->cost_fraction[0]=0;
+	for(size_t i =1;i<CHANNEL_PARTS;++i)
+	{
+		params->cap_fraction[i]=CHANNEL_PIVOTS[i]-CHANNEL_PIVOTS[i-1];
+		params->cost_fraction[i]=
+			log((1-CHANNEL_PIVOTS[i-1])/(1-CHANNEL_PIVOTS[i]))
+			/params->cap_fraction[i];
+
+		// printf("channel part: %ld, fraction: %lf, cost_fraction: %lf\n",
+		//	i,params->cap_fraction[i],params->cost_fraction[i]);
+	}
+
+	params->max_fee = max_fee;
+	params->min_probability = min_probability;
+	params->delay_feefactor = delay_feefactor;
+	params->base_fee_penalty = base_fee_penalty;
+	params->prob_cost_factor = prob_cost_factor;
+
+	// build the uncertainty network with linearization and residual arcs
+	struct linear_network *linear_network= init_linear_network(this_ctx, params, &errmsg);
+	if (!linear_network) {
+		if(fail)
+		*fail = tal_fmt(ctx, "init_linear_network failed: %s",
+				errmsg);
+		goto function_fail;
+	}
+
+	struct residual_network *residual_network =
+	    alloc_residual_network(this_ctx, linear_network->max_num_nodes,
+				  linear_network->max_num_arcs);
+	if (!residual_network) {
+		if (fail)
+		*fail = tal_fmt(
+		    ctx, "failed to allocate the residual network");
+		goto function_fail;
+	}
+
+	dijkstra = dijkstra_new(this_ctx, gossmap_max_node_idx(params->gossmap));
+
+	const u32 target_idx = gossmap_node_idx(params->gossmap,target);
+	const u32 source_idx = gossmap_node_idx(params->gossmap,source);
+
+	init_residual_network(linear_network,residual_network);
+
+	struct amount_msat best_fee;
+	double best_prob_success;
+
+	/* TODO(eduardo):
+	 * Some MCF algorithms' performance depend on the size of maxflow. If we
+	 * were to work in units of msats we 1. risking overflow when computing
+	 * costs and 2. we risk a performance overhead for no good reason.
+	 *
+	 * Working in units of sats was my first choice, but maybe working in
+	 * units of 10, or 100 sats could be even better.
+	 *
+	 * IDEA: define the size of our precision as some parameter got at
+	 * runtime that depends on the size of the payment and adjust the MCF
+	 * accordingly.
+	 * For example if we are trying to pay 1M sats our precision could be
+	 * set to 1000sat, then channels that had capacity for 3M sats become 3k
+	 * flow units. */
+	const u64 pay_amount_msats = params->amount.millisatoshis % 1000; /* Raw: minflow */
+	const u64 pay_amount_sats = params->amount.millisatoshis/1000 /* Raw: minflow */
+			+ (pay_amount_msats ? 1 : 0);
+	const struct amount_msat excess
+		= amount_msat(pay_amount_msats ? 1000 - pay_amount_msats : 0);
+
+	if (!find_feasible_flow(this_ctx, linear_network, residual_network,
+				source_idx, target_idx, pay_amount_sats,
+				&errmsg)) {
+		// there is no flow that satisfy the constraints, we stop here
+		if(fail)
+		*fail = tal_fmt(ctx, "failed to find a feasible flow: %s", errmsg);
+		goto function_fail;
+	}
+
+	// first flow found
+	best_flow_paths = get_flow_paths(
+	    this_ctx, params->gossmap, params->disabled, params->chan_extra_map,
+	    linear_network, residual_network, excess, &errmsg);
+	if (!best_flow_paths) {
+		if (fail)
+		*fail =
+		    tal_fmt(ctx, "get_flow_paths failed: %s", errmsg);
+		goto function_fail;
+	}
+	best_flow_paths = tal_steal(ctx, best_flow_paths);
+
+	best_prob_success =
+	    flowset_probability(this_ctx, best_flow_paths, params->gossmap,
+				params->chan_extra_map, &errmsg);
+	if (best_prob_success < 0) {
+		if (fail)
+		*fail =
+		    tal_fmt(ctx, "flowset_probability failed: %s", errmsg);
+		goto function_fail;
+	}
+	if (!flowset_fee(&best_fee, best_flow_paths)) {
+		if (fail)
+		*fail =
+		    tal_fmt(ctx, "flowset_fee failed on MaxFlow phase");
+		goto function_fail;
+	}
+
+	// binary search for a value of `mu` that fits our fee and prob.
+	// constraints.
+	// mu=0 corresponds to only probabilities
+	// mu=MU_MAX-1 corresponds to only fee
+	s64 mu_left = 0, mu_right = MU_MAX;
+	while(mu_left<mu_right)
+	{
+
+		s64 mu = (mu_left + mu_right)/2;
+
+		combine_cost_function(linear_network,residual_network,mu);
+
+		/* We solve a linear MCF problem. */
+		if(!optimize_mcf(this_ctx, dijkstra,linear_network,residual_network,
+				source_idx,target_idx,pay_amount_sats, &errmsg))
+		{
+			// optimize_mcf doesn't fail unless there is a bug.
+			if (fail)
+			*fail =
+			    tal_fmt(ctx, "optimize_mcf failed: %s", errmsg);
+			goto function_fail;
+		}
+
+		struct flow **flow_paths;
+		/* We dissect the solution of the MCF into payment routes.
+		 * Actual amounts considering fees are computed for every
+		 * channel in the routes. */
+		flow_paths =
+		    get_flow_paths(this_ctx, params->gossmap, params->disabled,
+				   params->chan_extra_map, linear_network,
+				   residual_network, excess, &errmsg);
+		if(!flow_paths)
+		{
+			// get_flow_paths doesn't fail unless there is a bug.
+			if (fail)
+			*fail =
+			    tal_fmt(ctx, "get_flow_paths failed: %s", errmsg);
+			goto function_fail;
+		}
+
+		double prob_success =
+		    flowset_probability(this_ctx, flow_paths, params->gossmap,
+					params->chan_extra_map, &errmsg);
+		if (prob_success < 0) {
+			// flowset_probability doesn't fail unless there is a bug.
+			if (fail)
+			*fail =
+			    tal_fmt(ctx, "flowset_probability: %s", errmsg);
+			goto function_fail;
+		}
+
+		struct amount_msat fee;
+		if (!flowset_fee(&fee, flow_paths)) {
+			// flowset_fee doesn't fail unless there is a bug.
+			if (fail)
+			*fail =
+			    tal_fmt(ctx, "flowset_fee failed evaluating MinCostFlow candidate");
+			goto function_fail;
+		}
+
+		/* Is this better than the previous one? */
+		if(!best_flow_paths ||
+			is_better(params->max_fee,params->min_probability,
+				  fee,prob_success,
+			          best_fee, best_prob_success))
+		{
+
+			best_flow_paths = tal_free(best_flow_paths);
+			best_flow_paths = tal_steal(ctx,flow_paths);
+
+			best_fee = fee;
+			best_prob_success=prob_success;
+			flow_paths = NULL;
+		}
+		/* I don't like this candidate. */
+		else
+			tal_free(flow_paths);
+
+		if(amount_msat_greater(fee,params->max_fee))
+		{
+			// too expensive
+			mu_left = mu+1;
+
+		}else if(prob_success < params->min_probability)
+		{
+			// too unlikely
+			mu_right = mu;
+		}else
+		{
+			// with mu constraints are satisfied, now let's optimize
+			// the fees
+			mu_left = mu+1;
+		}
+	}
+
+	tal_free(this_ctx);
+	return best_flow_paths;
+
+	function_fail:
+	tal_free(this_ctx);
+	return tal_free(best_flow_paths);
+}
+

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -3,11 +3,10 @@
 /* Eduardo Quintela's (lagrang3@protonmail.com) Min Cost Flow implementation
  * from renepay, as modified to fit askrene */
 #include "config.h"
-#include <ccan/bitmap/bitmap.h>
 #include <common/amount.h>
 #include <common/gossmap.h>
 
-struct chan_extra_map;
+struct route_query;
 
 enum {
 	RENEPAY_ERR_OK,
@@ -52,7 +51,8 @@ enum {
  *
  * Return a series of subflows which deliver amount to target, or NULL.
  */
-struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
+struct flow **minflow(const tal_t *ctx,
+		      const struct route_query *rq,
 		      const struct gossmap_node *source,
 		      const struct gossmap_node *target,
 		      struct amount_msat amount,

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -1,0 +1,68 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_MCF_H
+#define LIGHTNING_PLUGINS_ASKRENE_MCF_H
+/* Eduardo Quintela's (lagrang3@protonmail.com) Min Cost Flow implementation
+ * from renepay, as modified to fit askrene */
+#include "config.h"
+#include <ccan/bitmap/bitmap.h>
+#include <common/amount.h>
+#include <common/gossmap.h>
+
+struct chan_extra_map;
+
+enum {
+	RENEPAY_ERR_OK,
+	// No feasible flow found, either there is not enough known liquidity (or capacity)
+	// in the channels to complete the payment
+	RENEPAY_ERR_NOFEASIBLEFLOW,
+	// There is at least one feasible flow, but the the cheapest solution that we
+	// found is too expensive, we return the result anyways.
+	RENEPAY_ERR_NOCHEAPFLOW
+};
+
+
+
+/**
+ * optimal_payment_flow - API for min cost flow function(s).
+ * @ctx: context to allocate returned flows from
+ * @gossmap: the gossip map
+ * @source: the source to start from
+ * @target: the target to pay
+ * @chan_extra_map: hashtable of extra per-channel information
+ * @disabled: NULL, or a bitmap by channel index of channels not to use.
+ * @amount: the amount we want to reach @target
+ *
+ * @max_fee: the maximum allowed in fees
+ *
+ * @min_probability: minimum probability accepted
+ *
+ * @delay_feefactor converts 1 block delay into msat, as if it were an additional
+ * fee.  So if a CLTV delay on a node is 5 blocks, that's treated as if it
+ * were a fee of 5 * @delay_feefactor.
+ *
+ * @base_fee_penalty: factor to compute additional proportional cost from each
+ * unit of base fee. So #base_fee_penalty will be added to the effective
+ * proportional fee for each msat of base fee.
+ *
+ * 	effective_ppm = proportional_fee + base_fee_msat * base_fee_penalty
+ *
+ * @prob_cost_factor: factor used to monetize the probability cost. It is
+ * defined as the number of ppm (parts per million of the total payment) we
+ * are willing to pay to improve the probability of success by 0.1%.
+ *
+ * 	k_microsat = floor(1000*prob_cost_factor * payment_sat)
+ *
+ * this k is used to compute a prob. cost in units of microsats
+ *
+ * 	cost(payment) = - k_microsat * log Prob(payment)
+ *
+ * Return a series of subflows which deliver amount to target, or NULL.
+ */
+struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
+		      const struct gossmap_node *source,
+		      const struct gossmap_node *target,
+		      struct chan_extra_map *chan_extra_map,
+		      const bitmap *disabled, struct amount_msat amount,
+		      struct amount_msat max_fee, double min_probability,
+		      double delay_feefactor, double base_fee_penalty,
+		      u32 prob_cost_factor, char **fail);
+#endif /* LIGHTNING_PLUGINS_ASKRENE_MCF_H */

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -27,13 +27,8 @@ enum {
  * @gossmap: the gossip map
  * @source: the source to start from
  * @target: the target to pay
- * @chan_extra_map: hashtable of extra per-channel information
- * @disabled: NULL, or a bitmap by channel index of channels not to use.
  * @amount: the amount we want to reach @target
- *
- * @max_fee: the maximum allowed in fees
- *
- * @min_probability: minimum probability accepted
+ * @mu: 0 = corresponds to only probabilities, 100 corresponds to only fee.
  *
  * @delay_feefactor converts 1 block delay into msat, as if it were an additional
  * fee.  So if a CLTV delay on a node is 5 blocks, that's treated as if it
@@ -60,9 +55,9 @@ enum {
 struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
 		      const struct gossmap_node *source,
 		      const struct gossmap_node *target,
-		      struct chan_extra_map *chan_extra_map,
-		      const bitmap *disabled, struct amount_msat amount,
-		      struct amount_msat max_fee, double min_probability,
-		      double delay_feefactor, double base_fee_penalty,
-		      u32 prob_cost_factor, char **fail);
+		      struct amount_msat amount,
+		      u32 mu,
+		      double delay_feefactor,
+		      double base_fee_penalty,
+		      u32 prob_cost_factor);
 #endif /* LIGHTNING_PLUGINS_ASKRENE_MCF_H */

--- a/plugins/askrene/reserve.c
+++ b/plugins/askrene/reserve.c
@@ -1,0 +1,119 @@
+#include "config.h"
+#include <assert.h>
+#include <ccan/htable/htable_type.h>
+#include <plugins/askrene/reserve.h>
+
+/* Hash table for reservations */
+static const struct short_channel_id_dir *
+reserve_scidd(const struct reserve *r)
+{
+	return &r->scidd;
+}
+
+static size_t hash_scidd(const struct short_channel_id_dir *scidd)
+{
+	/* scids cost money to generate, so simple hash works here */
+	return (scidd->scid.u64 >> 32) ^ (scidd->scid.u64 >> 16) ^ (scidd->scid.u64 << 1) ^ scidd->dir;
+}
+
+static bool reserve_eq_scidd(const struct reserve *r,
+			     const struct short_channel_id_dir *scidd)
+{
+	return short_channel_id_dir_eq(scidd, &r->scidd);
+}
+
+HTABLE_DEFINE_TYPE(struct reserve, reserve_scidd, hash_scidd,
+		   reserve_eq_scidd, reserve_hash);
+
+struct reserve_hash *new_reserve_hash(const tal_t *ctx)
+{
+	struct reserve_hash *reserved = tal(ctx, struct reserve_hash);
+	reserve_hash_init(reserved);
+	return reserved;
+}
+
+/* Find a reservation for this scidd (if any!) */
+const struct reserve *find_reserve(const struct reserve_hash *reserved,
+				   const struct short_channel_id_dir *scidd)
+{
+	return reserve_hash_get(reserved, scidd);
+}
+
+/* Create a new (empty) reservation */
+static struct reserve *new_reserve(struct reserve_hash *reserved,
+				   const struct short_channel_id_dir *scidd)
+{
+	struct reserve *r = tal(reserved, struct reserve);
+
+	r->num_htlcs = 0;
+	r->amount = AMOUNT_MSAT(0);
+	r->scidd = *scidd;
+
+	reserve_hash_add(reserved, r);
+	return r;
+}
+
+static void del_reserve(struct reserve_hash *reserved, struct reserve *r)
+{
+	assert(r->num_htlcs == 0);
+
+	reserve_hash_del(reserved, r);
+	tal_free(r);
+}
+
+/* Add to existing reservation (false if would overflow). */
+static bool add(struct reserve *r, struct amount_msat amount)
+{
+	if (!amount_msat_add(&r->amount, r->amount, amount))
+		return false;
+	r->num_htlcs++;
+	return true;
+}
+
+static bool remove(struct reserve *r, struct amount_msat amount)
+{
+	if (r->num_htlcs == 0)
+		return false;
+	if (!amount_msat_sub(&r->amount, r->amount, amount))
+		return false;
+	r->num_htlcs--;
+	return true;
+}
+
+/* Atomically add to reserves, or fail.
+ * Returns offset of failure, or num on success */
+size_t reserves_add(struct reserve_hash *reserved,
+		    const struct short_channel_id_dir *scidds,
+		    const struct amount_msat *amounts,
+		    size_t num)
+{
+	for (size_t i = 0; i < num; i++) {
+		struct reserve *r = reserve_hash_get(reserved, &scidds[i]);
+		if (!r)
+			r = new_reserve(reserved, &scidds[i]);
+		if (!add(r, amounts[i])) {
+			reserves_remove(reserved, scidds, amounts, i);
+			return i;
+		}
+	}
+	return num;
+}
+
+/* Atomically remove from reserves, to fail.
+ * Returns offset of failure or tal_count(scidds) */
+size_t reserves_remove(struct reserve_hash *reserved,
+		       const struct short_channel_id_dir *scidds,
+		       const struct amount_msat *amounts,
+		       size_t num)
+{
+	for (size_t i = 0; i < num; i++) {
+		struct reserve *r = reserve_hash_get(reserved, &scidds[i]);
+		if (!r || !remove(r, amounts[i])) {
+			reserves_add(reserved, scidds, amounts, i);
+			return i;
+		}
+		if (r->num_htlcs == 0)
+			del_reserve(reserved, r);
+	}
+	return num;
+}

--- a/plugins/askrene/reserve.h
+++ b/plugins/askrene/reserve.h
@@ -1,0 +1,38 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_RESERVE_H
+#define LIGHTNING_PLUGINS_ASKRENE_RESERVE_H
+/* We have to know what payments are in progress, so we can take into
+ * account the reduced capacity of channels.  We do this by telling
+ * everyone to reserve / unreserve paths as they use them. */
+#include "config.h"
+#include <bitcoin/short_channel_id.h>
+#include <common/amount.h>
+
+/* We reserve a path being used.  This records how many and how much */
+struct reserve {
+	size_t num_htlcs;
+	struct short_channel_id_dir scidd;
+	struct amount_msat amount;
+};
+
+/* Initialize hash table for reservations */
+struct reserve_hash *new_reserve_hash(const tal_t *ctx);
+
+/* Find a reservation for this scidd (if any!) */
+const struct reserve *find_reserve(const struct reserve_hash *reserved,
+				   const struct short_channel_id_dir *scidd);
+
+/* Atomically add to reserves, or fail.
+ * Returns offset of failure, or num on success */
+size_t reserves_add(struct reserve_hash *reserved,
+		    const struct short_channel_id_dir *scidds,
+		    const struct amount_msat *amounts,
+		    size_t num);
+
+/* Atomically remove from reserves, to fail.
+ * Returns offset of failure or tal_count(scidds) */
+size_t reserves_remove(struct reserve_hash *reserved,
+		       const struct short_channel_id_dir *scidds,
+		       const struct amount_msat *amounts,
+		       size_t num);
+
+#endif /* LIGHTNING_PLUGINS_ASKRENE_RESERVE_H */

--- a/plugins/askrene/reserve.h
+++ b/plugins/askrene/reserve.h
@@ -6,6 +6,7 @@
 #include "config.h"
 #include <bitcoin/short_channel_id.h>
 #include <common/amount.h>
+#include <common/fp16.h>
 
 /* We reserve a path being used.  This records how many and how much */
 struct reserve {
@@ -35,4 +36,8 @@ size_t reserves_remove(struct reserve_hash *reserved,
 		       const struct amount_msat *amounts,
 		       size_t num);
 
+/* Clear capacities array where we have reserves */
+void reserves_clear_capacities(struct reserve_hash *reserved,
+			       const struct gossmap *gossmap,
+			       fp16_t *capacities);
 #endif /* LIGHTNING_PLUGINS_ASKRENE_RESERVE_H */

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -805,7 +805,8 @@ int main(int argc, char *argv[])
 	setup_locale();
 
 	timer_cinfo = new_clean_info(NULL, NULL);
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL,
+		    commands, ARRAY_SIZE(commands),
 	            NULL, 0, NULL, 0, NULL, 0,
 		    plugin_option_dynamic("autoclean-cycle",
 					  "int",

--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -1171,7 +1171,7 @@ int main(int argc, char *argv[])
 	/* Initialize our global context object here to handle startup options. */
 	bitcoind = new_bitcoind(NULL);
 
-	plugin_main(argv, init, PLUGIN_STATIC, false /* Do not init RPC on startup*/,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, false /* Do not init RPC on startup*/,
 		    NULL, commands, ARRAY_SIZE(commands),
 		    NULL, 0, NULL, 0, NULL, 0,
 		    plugin_option("bitcoin-datadir",

--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1809,7 +1809,7 @@ int main(int argc, char *argv[])
 	datadir = NULL;
 	db_dsn = NULL;
 
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 		    notifs, ARRAY_SIZE(notifs),
 		    NULL, 0,

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -827,7 +827,7 @@ int main(int argc, char *argv[])
 {
         setup_locale();
 
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 		    notifs, ARRAY_SIZE(notifs), hooks, ARRAY_SIZE(hooks),
 		    NULL, 0,  /* Notification topics we publish */

--- a/plugins/commando.c
+++ b/plugins/commando.c
@@ -825,7 +825,7 @@ static const struct plugin_command commands[] = { {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 	            NULL, 0,
 		    hooks, ARRAY_SIZE(hooks),

--- a/plugins/funder.c
+++ b/plugins/funder.c
@@ -1695,7 +1695,7 @@ int main(int argc, char **argv)
 	/* Our default funding policy is fixed (0msat) */
 	current_policy = default_funder_policy(NULL, FIXED, 0);
 
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true,
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true,
 		    NULL,
 		    commands, ARRAY_SIZE(commands),
 		    notifs, ARRAY_SIZE(notifs),

--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -594,7 +594,7 @@ int main(int argc, char *argv[])
 		features->bits[i] = tal_arr(features, u8, 0);
 	set_feature_bit(&features->bits[NODE_ANNOUNCE_FEATURE], KEYSEND_FEATUREBIT);
 
-	plugin_main(argv, init, PLUGIN_STATIC, true, features, commands,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, features, commands,
 		    ARRAY_SIZE(commands), NULL, 0, hooks, ARRAY_SIZE(hooks),
 		    notification_topics, ARRAY_SIZE(notification_topics), NULL);
 }

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -79,6 +79,9 @@ struct plugin {
 	/* to append to all our command ids */
 	const char *id;
 
+	/* Data for the plugin user */
+	void *data;
+
 	/* options to i-promise-to-fix-broken-api-user */
 	const char **beglist;
 
@@ -2179,6 +2182,7 @@ static struct plugin *new_plugin(const tal_t *ctx,
 void plugin_main(char *argv[],
 		 const char *(*init)(struct plugin *p,
 				     const char *buf, const jsmntok_t *),
+		 void *data,
 		 const enum plugin_restartability restartability,
 		 bool init_rpc,
 		 struct feature_set *features STEALS,
@@ -2208,6 +2212,7 @@ void plugin_main(char *argv[],
 			    init, restartability, init_rpc, features, commands,
 			    num_commands, notif_subs, num_notif_subs, hook_subs,
 			    num_hook_subs, notif_topics, num_notif_topics, ap);
+	plugin_set_data(plugin, data);
 	va_end(ap);
 	setup_command_usage(plugin);
 
@@ -2413,4 +2418,16 @@ notification_handled(struct command *cmd)
 bool plugin_developer_mode(const struct plugin *plugin)
 {
 	return plugin->developer;
+}
+
+void plugin_set_data(struct plugin *plugin, void *data TAKES)
+{
+	if (taken(data))
+		tal_steal(plugin, data);
+	plugin->data = data;
+}
+
+void *plugin_get_data_(struct plugin *plugin)
+{
+	return plugin->data;
 }

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -440,6 +440,11 @@ static inline void *plugin_option_jsonfmt_check(bool (*jsonfmt)(struct plugin *,
 /* Is --developer enabled? */
 bool plugin_developer_mode(const struct plugin *plugin);
 
+/* Store a single pointer for our state in the plugin */
+void plugin_set_data(struct plugin *plugin, void *data TAKES);
+void *plugin_get_data_(struct plugin *plugin);
+#define plugin_get_data(plugin, type) ((type *)(plugin_get_data_(plugin)))
+
 /* Macro to define arguments */
 #define plugin_option_(name, type, description, set, jsonfmt, arg, dev_only, depr_start, depr_end, dynamic) \
 	(name),								\
@@ -504,6 +509,7 @@ void NORETURN LAST_ARG_NULL plugin_main(char *argv[],
 					const char *(*init)(struct plugin *p,
 							    const char *buf,
 							    const jsmntok_t *),
+					void *data TAKES,
 					const enum plugin_restartability restartability,
 					bool init_rpc,
 					struct feature_set *features STEALS,

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -1473,7 +1473,7 @@ int main(int argc, char *argv[])
 
 	/* We deal in UTC; mktime() uses local time */
 	setenv("TZ", "", 1);
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL,
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true, NULL,
 		    commands, ARRAY_SIZE(commands),
 		    notifications, ARRAY_SIZE(notifications),
 		    hooks, ARRAY_SIZE(hooks),

--- a/plugins/pay.c
+++ b/plugins/pay.c
@@ -1527,7 +1527,7 @@ static const char *notification_topics[] = {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands,
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true, NULL, commands,
 		    ARRAY_SIZE(commands), NULL, 0, NULL, 0,
 		    notification_topics, ARRAY_SIZE(notification_topics),
 		    plugin_option("disable-mpp", "flag",

--- a/plugins/recover.c
+++ b/plugins/recover.c
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
 {
         setup_locale();
 
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL,
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL,
 		    NULL, 0,
 		    NULL, 0, NULL, 0,
 		    NULL, 0,  /* Notification topics we publish */

--- a/plugins/renepay/chan_extra.h
+++ b/plugins/renepay/chan_extra.h
@@ -115,19 +115,6 @@ struct chan_extra *new_chan_extra(struct chan_extra_map *chan_extra_map,
 				  const struct short_channel_id scid,
 				  struct amount_msat capacity);
 
-/* Helper to find the min of two amounts */
-static inline struct amount_msat amount_msat_min(struct amount_msat a,
-						 struct amount_msat b)
-{
-	return amount_msat_less(a, b) ? a : b;
-}
-/* Helper to find the max of two amounts */
-static inline struct amount_msat amount_msat_max(struct amount_msat a,
-						 struct amount_msat b)
-{
-	return amount_msat_greater(a, b) ? a : b;
-}
-
 /* Update the knowledge that this (channel,direction) can send x msat.*/
 enum renepay_errorcode
 chan_extra_can_send(struct chan_extra_map *chan_extra_map,
@@ -189,18 +176,6 @@ enum renepay_errorcode channel_liquidity(struct amount_msat *liquidity,
 					 struct chan_extra_map *chan_extra_map,
 					 const struct gossmap_chan *chan,
 					 const int dir);
-
-/* Helpers to get the htlc_max and htlc_min of a channel. */
-static inline struct amount_msat
-channel_htlc_max(const struct gossmap_chan *chan, const int dir)
-{
-	return amount_msat(fp16_to_u64(chan->half[dir].htlc_max));
-}
-static inline struct amount_msat
-channel_htlc_min(const struct gossmap_chan *chan, const int dir)
-{
-	return amount_msat(fp16_to_u64(chan->half[dir].htlc_min));
-}
 
 /* inputs
  * @chan: a channel

--- a/plugins/renepay/flow.c
+++ b/plugins/renepay/flow.c
@@ -93,7 +93,7 @@ flow_maximum_deliverable(struct amount_msat *max_deliverable,
 		if(bad_channel)*bad_channel = flow->path[0];
 		return err;
 	}
-	x = amount_msat_min(x, channel_htlc_max(flow->path[0], flow->dirs[0]));
+	x = amount_msat_min(x, gossmap_chan_htlc_max(flow->path[0], flow->dirs[0]));
 
 	if(amount_msat_zero(x))
 	{
@@ -127,7 +127,7 @@ flow_maximum_deliverable(struct amount_msat *max_deliverable,
 		struct amount_msat x_new =
 		    amount_msat_min(forward_cap, liquidity_cap);
 		x_new = amount_msat_min(
-		    x_new, channel_htlc_max(flow->path[i], flow->dirs[i]));
+		    x_new, gossmap_chan_htlc_max(flow->path[i], flow->dirs[i]));
 
 		/* safety check: amounts decrease along the route */
 		assert(amount_msat_less_eq(x_new, x));

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -411,7 +411,7 @@ int main(int argc, char *argv[])
 
 	plugin_main(
 		argv,
-		init,
+		init, NULL,
 		PLUGIN_RESTARTABLE,
 		/* init_rpc */ true,
 		/* features */ NULL,

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -497,7 +497,7 @@ static bool linearize_channel(const struct pay_parameters *params,
 	/* An extra bound on capacity, here we use it to reduce the flow such
 	 * that it does not exceed htlcmax. */
 	s64 cap_on_capacity =
-	 channel_htlc_max(c, dir).millisatoshis/1000; /* Raw: linearize_channel */
+	 gossmap_chan_htlc_max(c, dir).millisatoshis/1000; /* Raw: linearize_channel */
 
 	capacity[0]=a;
 	cost[0]=0;
@@ -1363,12 +1363,12 @@ get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
 				/* obtain the supremum htlc_min along the route
 				 */
 				sup_htlc_min = amount_msat_max(
-				    sup_htlc_min, channel_htlc_min(c, dir));
+				    sup_htlc_min, gossmap_chan_htlc_min(c, dir));
 
 				/* obtain the infimum htlc_max along the route
 				 */
 				inf_htlc_max = amount_msat_min(
-				    inf_htlc_max, channel_htlc_max(c, dir));
+				    inf_htlc_max, gossmap_chan_htlc_max(c, dir));
 			}
 
 			s64 htlc_max=inf_htlc_max.millisatoshis/1000;/* Raw: need htlc_max in sats to do arithmetic operations.*/

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -86,9 +86,9 @@ route_check_constraints(struct route *route, struct gossmap *gossmap,
 
 		// check that we stay within the htlc max and min limits
 		if (amount_msat_greater(hop->amount,
-					channel_htlc_max(chan, dir)) ||
+					gossmap_chan_htlc_max(chan, dir)) ||
 		    amount_msat_less(hop->amount,
-				     channel_htlc_min(chan, dir))) {
+				     gossmap_chan_htlc_min(chan, dir))) {
 			bitmap_set_bit(disabled_bitmap,
 				       gossmap_chan_idx(gossmap, chan));
 			return RENEPAY_BAD_CHANNEL;

--- a/plugins/spender/main.c
+++ b/plugins/spender/main.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 	notifs = tal_arr(NULL, struct plugin_notification, 0);
 	tal_expand(&notifs, openchannel_notifs, num_openchannel_notifs);
 
-	plugin_main(argv, &spender_init, PLUGIN_STATIC, true,
+	plugin_main(argv, &spender_init, NULL, PLUGIN_STATIC, true,
 		    NULL,
 		    take(commands), tal_count(commands),
 		    take(notifs), tal_count(notifs),

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -1650,7 +1650,7 @@ int main(int argc, char *argv[])
 		common_shutdown();
 		return 0;
 	}
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true, NULL, commands, ARRAY_SIZE(commands),
 	            NULL, 0, NULL, 0, NULL, 0,
 		    plugin_option_dev("dev-sqlfilename",
 				      "string",

--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -747,6 +747,6 @@ static const struct plugin_command commands[] = {
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_STATIC, true, NULL, commands, ARRAY_SIZE(commands),
+	plugin_main(argv, init, NULL, PLUGIN_STATIC, true, NULL, commands, ARRAY_SIZE(commands),
 	            NULL, 0, NULL, 0, NULL, 0, NULL);
 }

--- a/plugins/txprepare.c
+++ b/plugins/txprepare.c
@@ -668,6 +668,6 @@ static const char *init(struct plugin *p,
 int main(int argc, char *argv[])
 {
 	setup_locale();
-	plugin_main(argv, init, PLUGIN_RESTARTABLE, true, NULL, commands,
+	plugin_main(argv, init, NULL, PLUGIN_RESTARTABLE, true, NULL, commands,
 		    ARRAY_SIZE(commands), NULL, 0, NULL, 0, NULL, 0, NULL);
 }

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1,0 +1,104 @@
+from fixtures import *  # noqa: F401,F403
+from utils import (
+    only_one, first_scid
+)
+import time
+
+
+def test_layers(node_factory):
+    """Test manipulating information in layers"""
+    l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True)
+
+    assert l2.rpc.askrene_listlayers() == {'layers': []}
+    assert l2.rpc.askrene_listlayers('test_layers') == {'layers': []}
+
+    expect = {'layer': 'test_layers',
+              'disabled_nodes': [],
+              'created_channels': [],
+              'constraints': []}
+    l2.rpc.askrene_disable_node('test_layers', l1.info['id'])
+    expect['disabled_nodes'].append(l1.info['id'])
+    assert l2.rpc.askrene_listlayers('test_layers') == {'layers': [expect]}
+    assert l2.rpc.askrene_listlayers() == {'layers': [expect]}
+    assert l2.rpc.askrene_listlayers('test_layers2') == {'layers': []}
+
+    # Tell it l3 connects to l1!
+    l2.rpc.askrene_create_channel('test_layers',
+                                  l3.info['id'],
+                                  l1.info['id'],
+                                  '0x0x1',
+                                  '1000000sat',
+                                  100, '900000sat',
+                                  1, 2, 18)
+    expect['created_channels'].append({'source': l3.info['id'],
+                                       'destination': l1.info['id'],
+                                       'short_channel_id': '0x0x1',
+                                       'capacity_msat': 1000000000,
+                                       'htlc_minimum_msat': 100,
+                                       'htlc_maximum_msat': 900000000,
+                                       'fee_base_msat': 1,
+                                       'fee_proportional_millionths': 2,
+                                       'delay': 18})
+    assert l2.rpc.askrene_listlayers('test_layers') == {'layers': [expect]}
+
+    # We can tell it about made up channels...
+    first_timestamp = int(time.time())
+    l2.rpc.askrene_inform_channel('test_layers',
+                                  '0x0x1',
+                                  1,
+                                  100000)
+    last_timestamp = int(time.time()) + 1
+    expect['constraints'].append({'short_channel_id': '0x0x1',
+                                  'direction': 1,
+                                  'minimum_msat': 100000})
+    # Check timestamp first.
+    listlayers = l2.rpc.askrene_listlayers('test_layers')
+    ts1 = only_one(only_one(listlayers['layers'])['constraints'])['timestamp']
+    assert first_timestamp <= ts1 <= last_timestamp
+    expect['constraints'][0]['timestamp'] = ts1
+    assert listlayers == {'layers': [expect]}
+
+    # Make sure timestamps differ!
+    time.sleep(2)
+
+    # We can tell it about existing channels...
+    scid12 = first_scid(l1, l2)
+    first_timestamp = int(time.time())
+    l2.rpc.askrene_inform_channel(layer='test_layers',
+                                  short_channel_id=scid12,
+                                  # This is l2 -> l1
+                                  direction=0,
+                                  maximum_msat=12341234)
+    last_timestamp = int(time.time()) + 1
+    expect['constraints'].append({'short_channel_id': scid12,
+                                  'direction': 0,
+                                  'timestamp': first_timestamp,
+                                  'maximum_msat': 12341234})
+    # Check timestamp first.
+    listlayers = l2.rpc.askrene_listlayers('test_layers')
+    ts2 = only_one([c['timestamp'] for c in only_one(listlayers['layers'])['constraints'] if c['short_channel_id'] == scid12])
+    assert first_timestamp <= ts2 <= last_timestamp
+    expect['constraints'][1]['timestamp'] = ts2
+
+    # Could be either order!
+    actual = expect.copy()
+    if only_one(listlayers['layers'])['constraints'][0]['short_channel_id'] == scid12:
+        actual['constraints'] = [expect['constraints'][1], expect['constraints'][0]]
+    assert listlayers == {'layers': [actual]}
+
+    # Now test aging: ts1 does nothing.
+    assert l2.rpc.askrene_age('test_layers', ts1) == {'layer': 'test_layers', 'num_removed': 0}
+    listlayers = l2.rpc.askrene_listlayers('test_layers')
+    assert listlayers == {'layers': [actual]}
+
+    # ts1+1 removes first inform
+    assert l2.rpc.askrene_age('test_layers', ts1 + 1) == {'layer': 'test_layers', 'num_removed': 1}
+    del expect['constraints'][0]
+    listlayers = l2.rpc.askrene_listlayers('test_layers')
+    assert listlayers == {'layers': [expect]}
+
+    # ts2+1 removes other.
+    assert l2.rpc.askrene_age('test_layers', ts2 + 1) == {'layer': 'test_layers', 'num_removed': 1}
+    del expect['constraints'][0]
+    listlayers = l2.rpc.askrene_listlayers('test_layers')
+    assert listlayers == {'layers': [expect]}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -460,7 +460,7 @@ class GenChannel(object):
         self.half = [forward, reverse]
 
 
-def generate_gossip_store(channels):
+def generate_gossip_store(channels, nodeids=[]):
     """Returns a gossip store file with the given channels in it, and a map of node labels -> ids
     """
     nodes = []
@@ -550,6 +550,7 @@ def generate_gossip_store(channels):
 
     outfile = tempfile.NamedTemporaryFile(prefix='gossip-store-')
     nodeids = subprocess.check_output(['devtools/gossmap-compress',
+                                       '--nodes={}'.format(','.join(nodeids)),
                                        'decompress',
                                        cfile.name,
                                        outfile.name]).decode('utf-8').splitlines()


### PR DESCRIPTION
(Builds on #7495)

This steals the min-cost-flow implementation from renepay, neatens it up for standalone use, and wraps it in an API.  At the heart of the API is "getroutes", but much of the API concerns managing *layers*: these contain additional information about topology and capacity of channels.

It doesn't *do* very much by itself, but it does making building a pay plugin much simpler, and it makes testing (and benchmarking) simpler too.