### PR TITLE
lightningd: don't create a second peer on stub recover if one already exists

### DIFF
--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1473,7 +1473,10 @@ static struct channel *stub_chan(struct command *cmd,
 		log_debug(cmd->ld->log, "channel %s already exists!",
 				fmt_channel_id(tmpctx, &cid));
 		return NULL;
-	} else {
+	}
+
+	peer = peer_by_id(cmd->ld, &nodeid);
+	if (!peer) {
 		struct wireaddr_internal wint;
 
 		wint.itype = ADDR_INTERNAL_WIREADDR;


### PR DESCRIPTION


This was confusing to debug, but if the peer already exists we must not create a second one.