### PR TITLE
pyln-client: Deprecate category, desc and long description from method

### DIFF
--- a/doc/developers-guide/plugin-development/a-day-in-the-life-of-a-plugin.md
+++ b/doc/developers-guide/plugin-development/a-day-in-the-life-of-a-plugin.md
@@ -51,14 +51,11 @@ The `getmanifest` method is required for all plugins and will be called on start
   "rpcmethods": [
     {
       "name": "hello",
-      "usage": "[name]",
-      "description": "Returns a personalized greeting for {greeting} (set via options)."
+      "usage": "[name]"
     },
     {
       "name": "gettime",
       "usage": "",
-      "description": "Returns the current time in {timezone}",
-      "long_description": "Returns the current time in the timezone that is given as the only parameter.\nThis description may be quite long and is allowed to span multiple lines.",
       "deprecated": false
     }
   ],
@@ -101,7 +98,7 @@ The `getmanifest` method is required for all plugins and will be called on start
 
 During startup the `options` will be added to the list of command line options that `lightningd` accepts. If any `options` "name" is already taken startup will abort. The above will add a `--greeting` option with a default value of `World` and the specified description. _Notice that currently string, integers, bool, and flag options are supported._ If an option specifies `dynamic`: `true`, then it should allow a `setconfig` call for that option after initialization.
 
-The `rpcmethods` are methods that will be exposed via `lightningd`'s JSON-RPC over Unix-Socket interface, just like the builtin commands. Any parameters given to the JSON-RPC calls will be passed through verbatim. Notice that the `name`, `description` and `usage` fields are mandatory, while the `long_description` can be omitted (it'll be set to `description` if it was not provided). `usage` should surround optional parameter names in `[]`.
+The `rpcmethods` are methods that will be exposed via `lightningd`'s JSON-RPC over Unix-Socket interface, just like the builtin commands. Any parameters given to the JSON-RPC calls will be passed through verbatim. Notice that the `name` and `usage` fields are mandatory. `usage` should surround optional parameter names in `[]`.
 
 `options` and `rpcmethods` can mark themselves `deprecated: true` if you plan on removing them: this will disable them if the user sets `allow-deprecated-apis` to false, or in `--developer` mode.  You can also specify `deprecated` as an array of one or two version numbers, indicating when deprecation starts, and the final version it will be permitted, e.g. `"deprecated": ["v24.02", "v24.02"]`.  If only one version number is given, then the final version will be 6 months after the start version.
 

--- a/doc/developers-guide/plugin-development/json-rpc-passthrough.md
+++ b/doc/developers-guide/plugin-development/json-rpc-passthrough.md
@@ -7,9 +7,7 @@ updatedAt: "2023-02-03T08:53:50.840Z"
 ---
 Plugins may register their own JSON-RPC methods that are exposed through the JSON-RPC provided by `lightningd`. This provides users with a single interface to interact with, while allowing the addition of custom methods without having to modify the daemon itself.
 
-JSON-RPC methods are registered as part of the `getmanifest` result. Each registered method must provide a `name` and a `description`. An optional `long_description` may also be  
-provided. This information is then added to the internal dispatch table, and used to return the help text when using `lightning-cli
-help`, and the methods can be called using the `name`.
+JSON-RPC methods are registered as part of the `getmanifest` result. Each registered method must provide a `name`. This information is then added to the internal dispatch table, and used to return the help text when using `lightning-cli help`, and the methods can be called using the `name`.
 
 For example, `getmanifest` result will register two methods, called `hello` and `gettime`:
 
@@ -18,14 +16,11 @@ For example, `getmanifest` result will register two methods, called `hello` and 
   "rpcmethods": [
     {
       "name": "hello",
-      "usage": "[name]",
-      "description": "Returns a personalized greeting for {greeting} (set via options)."
+      "usage": "[name]"
     },
     {
       "name": "gettime",
-      "description": "Returns the current time in {timezone}",
       "usage": "",
-      "long_description": "Returns the current time in the timezone that is given as the only parameter.\nThis description may be quite long and is allowed to span multiple lines."
     }
   ],
   ...


### PR DESCRIPTION
Category, description and long description from `json_command` and `plugin_command` have been removed in favour of reading them from json schema.  Reference PR: #7485 

Deprecating them in pyln-client as well. They will be removed completely in future releases.

Changelog-Deprecated: pyln-client: category, description and long descriptions for RPC commands are deprecated now.