### PR TITLE
lightningd: implement `enableoffer`.

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -9341,6 +9341,7 @@
         "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
       ],
       "see_also": [
+        "lightning-enableoffer(7)",
         "lightning-offer(7)",
         "lightning-listoffers(7)"
       ],
@@ -9499,6 +9500,112 @@
             "stubs": [
               "c00734472f344fdadd0bf787de182e5cf144ccda5d731b0f7c75befd1f1eff52"
             ]
+          }
+        }
+      ]
+    },
+    "lightning-enableoffer.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "disableoffer",
+      "title": "Command for re-enabling an offer",
+      "warning": "experimental-offers only",
+      "description": [
+        "The **enableoffer** RPC command enables an offer, after it has been disabled."
+      ],
+      "request": {
+        "required": [
+          "offer_id"
+        ],
+        "properties": {
+          "offer_id": {
+            "type": "hash",
+            "description": [
+              "The id we use to identify this offer."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "offer_id",
+          "active",
+          "single_use",
+          "bolt12",
+          "used"
+        ],
+        "properties": {
+          "offer_id": {
+            "type": "hash",
+            "description": [
+              "The merkle hash of the offer."
+            ]
+          },
+          "active": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": [
+              "Whether the offer can produce invoices/payments."
+            ]
+          },
+          "single_use": {
+            "type": "boolean",
+            "description": [
+              "Whether the offer is disabled after first successful use."
+            ]
+          },
+          "bolt12": {
+            "type": "string",
+            "description": [
+              "The bolt12 string representing this offer."
+            ]
+          },
+          "used": {
+            "type": "boolean",
+            "description": [
+              "Whether the offer has had an invoice paid / payment made."
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": [
+              "The label provided when offer was created."
+            ]
+          }
+        },
+        "pre_return_value_notes": [
+          "Note: the returned object is the same format as **listoffers**."
+        ]
+      },
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "see_also": [
+        "lightning-offer(7)",
+        "lightning-disableoffer(7)",
+        "lightning-listoffers(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ],
+      "examples": [
+        {
+          "request": {
+            "id": "example:enableoffer#1",
+            "method": "enableoffer",
+            "params": {
+              "offer_id": "713a16ccd4eb10438bdcfbc2c8276be301020dd9d489c530773ba64f3b33307d"
+            }
+          },
+          "response": {
+            "offer_id": "053a5c566fbea2681a5ff9c05a913da23e45b95d09ef5bd25d7d408f23da7084",
+            "active": true,
+            "single_use": false,
+            "bolt12": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqvqcdgq2z9pk7enxv4jjqen0wgs8yatnw3ujz83qkc6rvp4j28rt3dtrn32zkvdy7efhnlrpr5rp5geqxs783wtlj550qs8czzku4nk3pqp6m593qxgunzuqcwkmgqkmp6ty0wyvjcqdguv3pnpukedwn6cr87m89t74h3auyaeg89xkvgzpac70z3m9rn5xzu28c",
+            "used": false
           }
         }
       ]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,6 +67,7 @@ Core Lightning Documentation
    lightning-invoice <lightning-invoice.7.md>
    lightning-invoicerequest <lightning-invoicerequest.7.md>
    lightning-keysend <lightning-keysend.7.md>
+   lightning-listaddresses <lightning-listaddresses.7.md>
    lightning-listchannels <lightning-listchannels.7.md>
    lightning-listclosedchannels <lightning-listclosedchannels.7.md>
    lightning-listconfigs <lightning-listconfigs.7.md>

--- a/doc/schemas/lightning-enableoffer.json
+++ b/doc/schemas/lightning-enableoffer.json
@@ -3,12 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "rpc": "disableoffer",
-  "title": "Command for removing an offer",
+  "title": "Command for re-enabling an offer",
   "warning": "experimental-offers only",
   "description": [
-    "The **disableoffer** RPC command disables an offer, so that no further invoices will be given out.",
-    "",
-    "We currently don't support deletion of offers, so offers are not forgotten entirely (there may be invoices which refer to this offer)."
+    "The **enableoffer** RPC command enables an offer, after it has been disabled."
   ],
   "request": {
     "required": [
@@ -41,7 +39,7 @@
       "active": {
         "type": "boolean",
         "enum": [
-          false
+          true
         ],
         "description": [
           "Whether the offer can produce invoices/payments."
@@ -80,8 +78,8 @@
     "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
   ],
   "see_also": [
-    "lightning-enableoffer(7)",
     "lightning-offer(7)",
+    "lightning-disableoffer(7)",
     "lightning-listoffers(7)"
   ],
   "resources": [
@@ -90,15 +88,15 @@
   "examples": [
     {
       "request": {
-        "id": "example:disableoffer#1",
-        "method": "disableoffer",
+        "id": "example:enableoffer#1",
+        "method": "enableoffer",
         "params": {
           "offer_id": "713a16ccd4eb10438bdcfbc2c8276be301020dd9d489c530773ba64f3b33307d"
         }
       },
       "response": {
         "offer_id": "053a5c566fbea2681a5ff9c05a913da23e45b95d09ef5bd25d7d408f23da7084",
-        "active": false,
+        "active": true,
         "single_use": false,
         "bolt12": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqvqcdgq2z9pk7enxv4jjqen0wgs8yatnw3ujz83qkc6rvp4j28rt3dtrn32zkvdy7efhnlrpr5rp5geqxs783wtlj550qs8czzku4nk3pqp6m593qxgunzuqcwkmgqkmp6ty0wyvjcqdguv3pnpukedwn6cr87m89t74h3auyaeg89xkvgzpac70z3m9rn5xzu28c",
         "used": false

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4768,6 +4768,36 @@ def test_fetchinvoice_disconnected_reply(node_factory, bitcoind):
     assert l3.rpc.listpeers(l1.info['id']) == {'peers': []}
 
 
+def test_enableoffer(node_factory):
+    l1, l2 = node_factory.line_graph(2, opts={'experimental-offers': None})
+
+    # Normal offer, works as expected
+    offer1 = l2.rpc.call('offer', {'amount': '2msat',
+                                   'description': 'test_disableoffer_reenable'})
+    assert offer1['created'] is True
+    l1.rpc.fetchinvoice(offer=offer1['bolt12'])
+
+    l2.rpc.disableoffer(offer_id=offer1['offer_id'])
+
+    with pytest.raises(RpcError, match="Offer no longer available"):
+        l1.rpc.fetchinvoice(offer=offer1['bolt12'])
+
+    with pytest.raises(RpcError, match="1000.*Already exists, but isn't active"):
+        l2.rpc.call('offer', {'amount': '2msat',
+                              'description': 'test_disableoffer_reenable'})
+
+    l2.rpc.enableoffer(offer_id=offer1['offer_id'])
+    l1.rpc.fetchinvoice(offer=offer1['bolt12'])
+
+    # Can't enable twice.
+    with pytest.raises(RpcError, match="1001.*offer already active"):
+        l2.rpc.enableoffer(offer_id=offer1['offer_id'])
+
+    # Can't enable unknown.
+    with pytest.raises(RpcError, match="Unknown offer"):
+        l1.rpc.enableoffer(offer_id=offer1['offer_id'])
+
+
 def test_pay_blockheight_mismatch(node_factory, bitcoind):
     """Test that we can send a payment even if not caught up with the chain.
 

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -5568,6 +5568,20 @@ enum offer_status wallet_offer_disable(struct wallet *w,
 	return newstatus;
 }
 
+enum offer_status wallet_offer_enable(struct wallet *w,
+				      const struct sha256 *offer_id,
+				      enum offer_status s)
+{
+	enum offer_status newstatus;
+
+	assert(!offer_status_active(s));
+
+	newstatus = offer_status_in_db(s | OFFER_STATUS_ACTIVE_F);
+	offer_status_update(w->db, offer_id, s, newstatus);
+
+	return newstatus;
+}
+
 void wallet_offer_mark_used(struct db *db, const struct sha256 *offer_id)
 {
 	struct db_stmt *stmt;

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -1467,6 +1467,18 @@ enum offer_status wallet_offer_disable(struct wallet *w,
 	NO_NULL_ARGS;
 
 /**
+ * Enable an offer in the database.
+ * @w: the wallet
+ * @offer_id: the merkle root
+ * @s: the current status (must not be active).
+ *
+ * Must exist.  Returns new status. */
+enum offer_status wallet_offer_enable(struct wallet *w,
+				      const struct sha256 *offer_id,
+				      enum offer_status s)
+	NO_NULL_ARGS;
+
+/**
  * Mark an offer in the database used.
  * @w: the wallet
  * @offer_id: the merkle root, as used for signing (must be unique)


### PR DESCRIPTION
Since you are not allowed to create an offer which is exists but is disabled, we should allow re-enabling.

Fixes: https://github.com/ElementsProject/lightning/issues/7360