### PR TITLE
bugfix: node refuses to re-start after emergency recover

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1693,6 +1693,7 @@ static struct channel *wallet_stmt2channel(struct wallet *w, struct db_stmt *stm
 		db_col_signature(stmt, "last_sig", &last_sig->s);
 		last_sig->sighash_type = SIGHASH_ALL;
 	} else {
+		db_col_ignore(stmt, "last_sig");
 		last_tx = NULL;
 		last_sig = NULL;
 	}


### PR DESCRIPTION
one of the fields in the database isn't read/accessed during stub reinitialization, so my node crashes on restarts.

patched my node and it resolves the issue (node can now restart after emergency recover called on empty database)

error:

```
Never accessed column last_sig in query SELECT  id, peer_id, scid, full_channel_id, channel_config_local, channel_config_remote, state, funder, channel_flags, require_confirm_inputs_local, require_confirm_inputs_remote, minimum_depth, next_index_local, next_index_remote, next_htlc_id, funding_tx_id, funding_tx_outnum, funding_satoshi, our_funding_satoshi, funding_locked_remote, push_msatoshi, msatoshi_local, fundingkey_remote, revocation_basepoint_remote, payment_basepoint_remote, htlc_basepoint_remote, delayed_payment_basepoint_remote, per_commit_remote, old_per_commit_remote, shachain_remote_id, shutdown_scriptpubkey_remote, shutdown_keyidx_local, last_sent_commit_state, last_sent_commit_id, last_tx, last_sig, last_was_revoke, first_blocknum, min_possible_feerate, max_possible_feerate, msatoshi_to_us_min, msatoshi_to_us_max, future_per_commitment_point, last_sent_commit, feerate_base, feerate_ppm, remote_upfront_shutdown_script, local_static_remotekey_start, remote_static_remotekey_start, channel_type, shutdown_scriptpubkey_local, closer, state_change_reason, revocation_basepoint_local, payment_basepoint_local, htlc_basepoint_local, delayed_payment_basepoint_local, funding_pubkey_local, shutdown_wrong_txid, shutdown_wrong_outnum, lease_expiry, lease_commit_sig, lease_chan_max_msat, lease_chan_max_ppt, htlc_minimum_msat, htlc_maximum_msat, alias_local, alias_remote, ignore_fee_limits, remote_feerate_base, remote_feerate_ppm, remote_cltv_expiry_delta, remote_htlc_minimum_msat, remote_htlc_maximum_msat, last_stable_connection FROM channels WHERE state != ?;
```