### PR TITLE
Makefile: clean up install path handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ CPATH := /usr/local/include
 LIBRARY_PATH := /usr/local/lib
 endif
 
-CPPFLAGS += -DCLN_NEXT_VERSION="\"$(CLN_NEXT_VERSION)\"" -DBINTOPKGLIBEXECDIR="\"$(shell sh tools/rel.sh $(bindir) $(pkglibexecdir))\"" -DCCAN_TAL_NEVER_RETURN_NULL=1
+CPPFLAGS += -DCLN_NEXT_VERSION="\"$(CLN_NEXT_VERSION)\"" -DPKGLIBEXECDIR="\"$(pkglibexecdir)\"" -DPLUGINDIR="\"$(plugindir)\"" -DCCAN_TAL_NEVER_RETURN_NULL=1
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I$(CPATH) $(SQLITE3_CFLAGS) $(POSTGRES_INCLUDE) $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) $(CSANFLAGS)
 
 # If CFLAGS is already set in the environment of make (to whatever value, it
@@ -882,7 +882,7 @@ uninstall:
 installcheck: all-programs
 	@rm -rf testinstall || true
 	$(MAKE) DESTDIR=$$(pwd)/testinstall install
-	testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
+	DEV_LIGHTNINGD_DESTDIR_PREFIX=$$(pwd)/testinstall/ testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
 	$(MAKE) DESTDIR=$$(pwd)/testinstall uninstall
 	@if test `find testinstall '!' -type d | wc -l` -ne 0; then \
 		echo 'make uninstall left some files in testinstall directory!'; \

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -108,7 +108,7 @@ enum lightningd_state {
 
 struct lightningd {
 	/* The directory to find all the subdaemons. */
-	const char *daemon_dir;
+	const char *subdaemon_dir;
 
 	/* Are deprecated APIs enabled? */
 	bool deprecated_ok;

--- a/tools/rel.sh
+++ b/tools/rel.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-from=${1}
-to=${2}
-common=$(printf '%s\n%s' "${from}" "${to}" | sed 'N;s/\(.*\).*\n\1.*$/\1/' | sed 's@/[^/]*$@/@')
-prefix=$(printf '%s\n' "${from#"$common"}" | sed 's@[^/][^/]*@..@g')
-printf '%s\n' "$prefix/${to#"$common"}"


### PR DESCRIPTION
We had some weird code to try to do relative paths.  Instead, use absolute ones and keep life simple.  Also rename "daemon_dir" to the clearer "subdaemon_dir" as that's what it's used for.

This might help https://github.com/ElementsProject/lightning/pull/7511#issuecomment-2261549499
