### PR TITLE
CI: don't fall over if cannot connect to upload server.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,4 +69,4 @@ def pytest_pyfunc_call(pyfuncitem):
     except Exception as e:
         import warnings
 
-        warnings.warn(f"Error reporting testrun: {e}: {e.read()}")
+        warnings.warn(f"Error reporting testrun: {e}")


### PR DESCRIPTION
```
>           warnings.warn(f"Error reporting testrun: {e}: {e.read()}")
E           AttributeError: 'URLError' object has no attribute 'read'
```