### PR TITLE
bookkeeper, meet splicing

### DIFF
--- a/common/coin_mvt.h
+++ b/common/coin_mvt.h
@@ -14,7 +14,7 @@ enum mvt_type {
 	CHANNEL_MVT = 1,
 };
 
-#define NUM_MVT_TAGS (CHANNEL_PROPOSED + 1)
+#define NUM_MVT_TAGS (SPLICE + 1)
 enum mvt_tag {
 	DEPOSIT = 0,
 	WITHDRAWAL = 1,
@@ -40,6 +40,7 @@ enum mvt_tag {
 	LEASED = 21,
 	STEALABLE = 22,
 	CHANNEL_PROPOSED = 23,
+	SPLICE = 24,
 };
 
 struct channel_coin_mvt {
@@ -181,13 +182,15 @@ struct chain_coin_mvt *new_onchaind_deposit(const tal_t *ctx,
 	NON_NULL_ARGS(2);
 
 struct chain_coin_mvt *new_coin_channel_close(const tal_t *ctx,
+					      const struct channel_id *chan_id,
 					      const struct bitcoin_txid *txid,
 					      const struct bitcoin_outpoint *out,
 					      u32 blockheight,
 					      const struct amount_msat amount,
 					      const struct amount_sat output_val,
-					      u32 output_count)
-	NON_NULL_ARGS(2, 3);
+					      u32 output_count,
+					      bool is_splice)
+	NON_NULL_ARGS(3, 4);
 
 struct chain_coin_mvt *new_coin_channel_open_proposed(const tal_t *ctx,
 						      const struct channel_id *chan_id,

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -3463,14 +3463,15 @@ int main(int argc, char *argv[])
 			   FUNDING_OUTPUT, NULL, NULL, NULL);
 
 	/* Record funding output spent */
-	send_coin_mvt(take(new_coin_channel_close(NULL, &tx->txid,
+	send_coin_mvt(take(new_coin_channel_close(NULL, NULL, &tx->txid,
 						  &funding, tx_blockheight,
 						  our_msat,
 						  funding_sats,
 						  is_elements(chainparams) ?
 						  /* Minus 1, fee output */
 						  tal_count(tx->outputs) - 1 :
-						  tal_count(tx->outputs))));
+						  tal_count(tx->outputs),
+						  /* is_splice? */ false)));
 
 	status_debug("Remote per-commit point: %s",
 		     fmt_pubkey(tmpctx, &remote_per_commit_point));

--- a/onchaind/test/run-grind_feerate-bug.c
+++ b/onchaind/test/run-grind_feerate-bug.c
@@ -103,12 +103,14 @@ void memleak_status_broken(void *unused UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "memleak_status_broken called!\n"); abort(); }
 /* Generated stub for new_coin_channel_close */
 struct chain_coin_mvt *new_coin_channel_close(const tal_t *ctx UNNEEDED,
+					      const struct channel_id *chan_id UNNEEDED,
 					      const struct bitcoin_txid *txid UNNEEDED,
 					      const struct bitcoin_outpoint *out UNNEEDED,
 					      u32 blockheight UNNEEDED,
 					      const struct amount_msat amount UNNEEDED,
 					      const struct amount_sat output_val UNNEEDED,
-					      u32 output_count)
+					      u32 output_count UNNEEDED,
+					      bool is_splice)
 
 { fprintf(stderr, "new_coin_channel_close called!\n"); abort(); }
 /* Generated stub for new_coin_external_deposit */

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -153,12 +153,14 @@ void memleak_status_broken(void *unused UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "memleak_status_broken called!\n"); abort(); }
 /* Generated stub for new_coin_channel_close */
 struct chain_coin_mvt *new_coin_channel_close(const tal_t *ctx UNNEEDED,
+					      const struct channel_id *chan_id UNNEEDED,
 					      const struct bitcoin_txid *txid UNNEEDED,
 					      const struct bitcoin_outpoint *out UNNEEDED,
 					      u32 blockheight UNNEEDED,
 					      const struct amount_msat amount UNNEEDED,
 					      const struct amount_sat output_val UNNEEDED,
-					      u32 output_count)
+					      u32 output_count UNNEEDED,
+					      bool is_splice)
 
 { fprintf(stderr, "new_coin_channel_close called!\n"); abort(); }
 /* Generated stub for new_coin_external_deposit */

--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -671,6 +671,7 @@ static bool new_missed_channel_account(struct command *cmd,
 		chain_ev->payment_id = NULL;
 		chain_ev->ignored = false;
 		chain_ev->stealable = false;
+		chain_ev->splice_close = false;
 		chain_ev->desc = NULL;
 
 		/* Update the account info too */
@@ -1458,9 +1459,11 @@ parse_and_log_chain_move(struct command *cmd,
 
 	e->ignored = false;
 	e->stealable = false;
+	e->splice_close = false;
 	for (size_t i = 0; i < tal_count(tags); i++) {
 		e->ignored |= tags[i] == IGNORED;
 		e->stealable |= tags[i] == STEALABLE;
+		e->splice_close |= tags[i] == SPLICE;
 	}
 
 	db_begin_transaction(db);

--- a/plugins/bkpr/chain_event.h
+++ b/plugins/bkpr/chain_event.h
@@ -34,6 +34,10 @@ struct chain_event {
 	 * we'll need to watch it for longer */
 	bool stealable;
 
+	/* Is this chain event because of a splice
+	 * confirmation? */
+	bool splice_close;
+
 	/* Is this a rebalance event? */
 	bool rebalance;
 

--- a/plugins/bkpr/db.c
+++ b/plugins/bkpr/db.c
@@ -99,6 +99,7 @@ static struct migration db_migrations[] = {
 	{SQL("ALTER TABLE chain_events ADD ev_desc TEXT DEFAULT NULL;"), NULL},
 	{SQL("ALTER TABLE channel_events ADD ev_desc TEXT DEFAULT NULL;"), NULL},
 	{SQL("ALTER TABLE channel_events ADD rebalance_id BIGINT DEFAULT NULL;"), NULL},
+	{SQL("ALTER TABLE chain_events ADD spliced INTEGER DEFAULT 0;"), NULL},
 	{NULL, migration_remove_dupe_lease_fees}
 };
 

--- a/plugins/bkpr/recorder.c
+++ b/plugins/bkpr/recorder.c
@@ -1294,6 +1294,7 @@ void maybe_update_account(struct db *db,
 			case TO_MINER:
 			case LEASE_FEE:
 			case STEALABLE:
+			case SPLICE:
 				/* Ignored */
 				break;
 		}

--- a/plugins/bkpr/test/run-recorder.c
+++ b/plugins/bkpr/test/run-recorder.c
@@ -355,6 +355,8 @@ static bool chain_events_eq(struct chain_event *e1, struct chain_event *e2)
 	if (e1->desc)
 		CHECK(streq(e1->desc, e2->desc));
 
+	CHECK(e1->splice_close == e2->splice_close);
+
 	return true;
 }
 
@@ -406,6 +408,7 @@ static struct chain_event *make_chain_event(const tal_t *ctx,
 	ev->blockheight = blockheight;
 	ev->ignored = false;
 	ev->stealable = false;
+	ev->splice_close = false;
 	ev->desc = tal_fmt(ev, "hello hello");
 	memset(&ev->outpoint.txid, outpoint_char, sizeof(struct bitcoin_txid));
 	ev->outpoint.n = outnum;
@@ -1084,6 +1087,7 @@ static bool test_chain_event_crud(const tal_t *ctx, struct plugin *p)
 	ev1->blockheight = 1919191;
 	ev1->ignored = false;
 	ev1->stealable  = false;
+	ev1->splice_close = false;
 	memset(&ev1->outpoint.txid, 'D', sizeof(struct bitcoin_txid));
 	ev1->outpoint.n = 1;
 	ev1->spending_txid = tal(ctx, struct bitcoin_txid);
@@ -1105,6 +1109,7 @@ static bool test_chain_event_crud(const tal_t *ctx, struct plugin *p)
 	ev2->blockheight = 1919191;
 	ev2->ignored = false;
 	ev2->stealable = false;
+	ev2->splice_close = false;
 	memset(&ev2->outpoint.txid, 'D', sizeof(struct bitcoin_txid));
 	ev2->outpoint.n = 1;
 	ev2->spending_txid = NULL;
@@ -1124,6 +1129,7 @@ static bool test_chain_event_crud(const tal_t *ctx, struct plugin *p)
 	ev3->blockheight = 3939393;
 	ev3->ignored = false;
 	ev3->stealable = false;
+	ev3->splice_close = false;
 	memset(&ev3->outpoint.txid, 'E', sizeof(struct bitcoin_txid));
 	ev3->outpoint.n = 1;
 	ev3->spending_txid = tal(ctx, struct bitcoin_txid);
@@ -1351,6 +1357,7 @@ static bool test_account_crud(const tal_t *ctx, struct plugin *p)
 	ev1->blockheight = 1919191;
 	ev1->ignored = false;
 	ev1->stealable = false;
+	ev1->splice_close = false;
 	memset(&ev1->outpoint.txid, 'D', sizeof(struct bitcoin_txid));
 	ev1->outpoint.n = 1;
 	ev1->spending_txid = tal(ctx, struct bitcoin_txid);

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1002,7 +1002,7 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 u8 *towire_announcement_signatures(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, struct short_channel_id short_channel_id UNNEEDED, const secp256k1_ecdsa_signature *node_signature UNNEEDED, const secp256k1_ecdsa_signature *bitcoin_signature UNNEEDED)
 { fprintf(stderr, "towire_announcement_signatures called!\n"); abort(); }
 /* Generated stub for towire_channel_reestablish */
-u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *channel_reestablish UNNEEDED)
+u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *tlvs UNNEEDED)
 { fprintf(stderr, "towire_channel_reestablish called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)


### PR DESCRIPTION
update the coin-movment notifications and the bookkeeper respectively so that splices are properly accounted for (quite literally).

Prior to this we haven't been logging the spend of the funding output for splices (they're simply not recorded). 

Will update with a PR built on #6980 which includes tests for these.