### PR TITLE
Add getemergencyrecoverdata RPC Command to Fetch Data from emergency.recover File

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -12256,6 +12256,54 @@
         }
       ]
     },
+    "lightning-getemergencyrecoverdata.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "getemergencyrecoverdata",
+      "title": "Command to fetch data from the emergency.recover file",
+      "description": [
+        "The **getemergencyrecoverdata** RPC command is used to fetch data from the emergency.recover file, which contains encrypted data."
+      ],
+      "request": {
+        "required": [],
+        "properties": {}
+      },
+      "response": {
+        "required": [
+          "filedata"
+        ],
+        "properties": {
+          "filedata": {
+            "type": "hex",
+            "description": [
+              "The raw, hex-encoded, emergency.recover file"
+            ]
+          }
+        }
+      },
+      "author": [
+        "Aditya <<aditya.sharma20111@gmail.com>> is mainly responsible."
+      ],
+      "see_also": [
+        "lightning-getsharedsecret(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ],
+      "examples": [
+        {
+          "request": {
+            "id": "example:getemergencyrecoverdata#1",
+            "method": "getemergencyrecoverdata",
+            "params": {}
+          },
+          "response": {
+            "filedata": "5b3142fa0dd1115c29654b44780dcd9cf56cd53f9168061e964b39f3ce596962594b25660cba5d90ef07cfccbe1620f378ef284c7d1afed49d"
+          }
+        }
+      ]
+    },
     "lightning-getinfo.json": {
       "$schema": "../rpc-schema-draft.json",
       "type": "object",

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,6 +56,7 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-fundchannel_start.7 \
 	doc/lightning-funderupdate.7 \
 	doc/lightning-fundpsbt.7 \
+	doc/lightning-getemergencyrecoverdata.7 \
 	doc/lightning-getinfo.7 \
 	doc/lightning-getlog.7 \
 	doc/lightning-getroute.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,6 +65,7 @@ Core Lightning Documentation
    lightning-fundchannel_start <lightning-fundchannel_start.7.md>
    lightning-funderupdate <lightning-funderupdate.7.md>
    lightning-fundpsbt <lightning-fundpsbt.7.md>
+   lightning-getemergencyrecoverdata <lightning-getemergencyrecoverdata.7.md>
    lightning-getinfo <lightning-getinfo.7.md>
    lightning-getlog <lightning-getlog.7.md>
    lightning-getroute <lightning-getroute.7.md>

--- a/doc/schemas/lightning-getemergencyrecoverdata.json
+++ b/doc/schemas/lightning-getemergencyrecoverdata.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "getemergencyrecoverdata",
+  "title": "Command to fetch data from the emergency.recover file",
+  "description": [
+    "The **getemergencyrecoverdata** RPC command is used to fetch data from the emergency.recover file, which contains encrypted data."
+  ],
+  "request": {
+    "required": [],
+    "properties": {}
+  },
+  "response": {
+    "required": [
+      "filedata"
+    ],
+    "properties": {
+      "filedata": {
+        "type": "hex",
+        "description": [
+          "The raw, hex-encoded, emergency.recover file"
+        ]
+      }
+    }
+  },
+  "author": [
+    "Aditya <<aditya.sharma20111@gmail.com>> is mainly responsible."
+  ],
+  "see_also": [
+    "lightning-getsharedsecret(7)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ],
+  "examples": [
+    {
+      "request": {
+        "id": "example:getemergencyrecoverdata#1",
+        "method": "getemergencyrecoverdata",
+        "params": {}
+      },
+      "response": {
+        "filedata": "5b3142fa0dd1115c29654b44780dcd9cf56cd53f9168061e964b39f3ce596962594b25660cba5d90ef07cfccbe1620f378ef284c7d1afed49d"
+      }
+    }
+  ]
+}

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -757,6 +757,23 @@ static struct command_result *json_restorefrompeer(struct command *cmd,
 				     	    NULL);
 }
 
+static struct command_result *json_getemergencyrecoverdata(struct command *cmd,
+						    	const char *buf,
+						    	const jsmntok_t *params)
+{
+	u8 *filedata;
+	if (!param(cmd, buf, params, NULL))
+		return command_param_failed();
+
+	struct json_stream *response;
+
+	filedata = get_file_data(tmpctx, cmd->plugin);
+	response = jsonrpc_stream_success(cmd);
+	json_add_hex(response, "filedata", filedata, tal_bytelen(filedata));
+
+	return command_finished(cmd, response);
+}
+
 static const char *init(struct plugin *p,
 			const char *buf UNUSED,
 			const jsmntok_t *config UNUSED)
@@ -816,6 +833,10 @@ static const struct plugin_command commands[] = {
 	{
 		"emergencyrecover",
 		json_emergencyrecover,
+	},
+	{
+		"getemergencyrecoverdata",
+		json_getemergencyrecoverdata,
 	},
 	{
 		"restorefrompeer",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2867,6 +2867,18 @@ def test_recoverchannel(node_factory):
     assert stubs[0] == "c3a7b9d74a174497122bc52d74d6d69836acadc77e0429c6d8b68b48d5c9139a"
 
 
+def test_getemergencyrecoverdata(node_factory):
+    """
+    Test getemergencyrecoverdata
+    """
+    l1 = node_factory.get_node()
+    filedata = l1.rpc.getemergencyrecoverdata()['filedata']
+
+    with open(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, "emergency.recover"), "rb") as f:
+        lines = f.read().hex()
+    assert lines == filedata
+
+
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "deletes database, which is assumed sqlite3")
 def test_emergencyrecover(node_factory, bitcoind):
     """


### PR DESCRIPTION
This Pull Request introduces a new RPC command, `getemergencyrecoverdata`, designed to fetch and return data from the emergency.recover file.

Addresses #7283