### PR TITLE
Renepay const prob cost

### DIFF
--- a/plugins/renepay/flow.c
+++ b/plugins/renepay/flow.c
@@ -179,6 +179,15 @@ bool flowset_delivers(struct amount_msat *delivers, struct flow **flows)
 	return true;
 }
 
+/* FIXME: pass a pointer to const here */
+size_t flowset_size(struct flow **flows)
+{
+	size_t size = 0;
+	for (size_t i = 0; i < tal_count(flows); i++)
+		size += tal_count(flows[i]->path);
+	return size;
+}
+
 /* Checks if the flows satisfy the liquidity bounds imposed by the known maximum
  * liquidity and pending HTLCs.
  *

--- a/plugins/renepay/flow.h
+++ b/plugins/renepay/flow.h
@@ -55,6 +55,9 @@ bool flowset_fee(struct amount_msat *fee, struct flow **flows);
 
 bool flowset_delivers(struct amount_msat *delivers, struct flow **flows);
 
+/* how many channels are being used */
+size_t flowset_size(struct flow **flows);
+
 static inline struct amount_msat flow_delivers(const struct flow *flow)
 {
 	return flow->amount;

--- a/plugins/renepay/mcf.h
+++ b/plugins/renepay/mcf.h
@@ -61,6 +61,7 @@ struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
 		      struct chan_extra_map *chan_extra_map,
 		      const bitmap *disabled, struct amount_msat amount,
 		      struct amount_msat max_fee, double min_probability,
+		      double base_probability,
 		      double delay_feefactor, double base_fee_penalty,
 		      u32 prob_cost_factor, char **fail);
 #endif /* LIGHTNING_PLUGINS_RENEPAY_MCF_H */

--- a/plugins/renepay/payment.c
+++ b/plugins/renepay/payment.c
@@ -32,6 +32,7 @@ struct payment *payment_new(
 	    u64 prob_cost_factor_millionths,
 	    u64 riskfactor_millionths,
 	    u64 min_prob_success_millionths,
+	    u64 base_prob_success_millionths,
 	    bool use_shadow,
 	    const struct route_exclusion **exclusions)
 {
@@ -81,6 +82,7 @@ struct payment *payment_new(
 	pinfo->prob_cost_factor = prob_cost_factor_millionths / 1e6;
 	pinfo->delay_feefactor = riskfactor_millionths / 1e6;
 	pinfo->min_prob_success = min_prob_success_millionths / 1e6;
+	pinfo->base_prob_success = base_prob_success_millionths / 1e6;
 	pinfo->use_shadow = use_shadow;
 
 
@@ -146,6 +148,7 @@ bool payment_update(
 		u64 prob_cost_factor_millionths,
 		u64 riskfactor_millionths,
 		u64 min_prob_success_millionths,
+		u64 base_prob_success_millionths,
 		bool use_shadow,
 		const struct route_exclusion **exclusions)
 {
@@ -170,6 +173,7 @@ bool payment_update(
 	pinfo->prob_cost_factor = prob_cost_factor_millionths / 1e6;
 	pinfo->delay_feefactor = riskfactor_millionths / 1e6;
 	pinfo->min_prob_success = min_prob_success_millionths / 1e6;
+	pinfo->base_prob_success = base_prob_success_millionths / 1e6;
 	pinfo->use_shadow = use_shadow;
 
 

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -117,6 +117,7 @@ struct payment *payment_new(
 	u64 prob_cost_factor_millionths,
 	u64 riskfactor_millionths,
 	u64 min_prob_success_millionths,
+	u64 base_prob_success_millionths,
 	bool use_shadow,
 	const struct route_exclusion **exclusions);
 
@@ -131,6 +132,7 @@ bool payment_update(
 	u64 prob_cost_factor_millionths,
 	u64 riskfactor_millionths,
 	u64 min_prob_success_millionths,
+	u64 base_prob_success_millionths,
 	bool use_shadow,
 	const struct route_exclusion **exclusions);
 

--- a/plugins/renepay/payment_info.h
+++ b/plugins/renepay/payment_info.h
@@ -61,6 +61,10 @@ struct payment_info {
 	double prob_cost_factor;
 	/* prob. cost = - prob_cost_factor * log prob. */
 
+	/* The probability for a channel to be able to forward an amount
+	 * greater than zero. */
+	double base_prob_success;
+
 	/* Penalty for CLTV delays */
 	double delay_feefactor;
 

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -151,6 +151,7 @@ struct route **get_routes(const tal_t *ctx,
 	struct route **routes = tal_arr(ctx, struct route *, 0);
 
 	double probability_budget = payment_info->min_prob_success;
+	const double base_probability = payment_info->base_prob_success;
 	double delay_feefactor = payment_info->delay_feefactor;
 	const double base_fee_penalty = payment_info->base_fee_penalty;
 	const double prob_cost_factor = payment_info->prob_cost_factor;
@@ -215,8 +216,11 @@ struct route **get_routes(const tal_t *ctx,
 		    minflow(this_ctx, gossmap, src, dst,
 			    uncertainty_get_chan_extra_map(uncertainty),
 			    disabled_bitmap, amount_to_deliver, feebudget,
-			    probability_budget, delay_feefactor,
-			    base_fee_penalty, prob_cost_factor, &errmsg);
+			    probability_budget,
+			    base_probability,
+			    delay_feefactor,
+			    base_fee_penalty,
+			    prob_cost_factor, &errmsg);
 		delay_feefactor_updated = false;
 
 		if (!flows) {

--- a/plugins/renepay/test/run-bottleneck.c
+++ b/plugins/renepay/test/run-bottleneck.c
@@ -202,6 +202,7 @@ int main(int argc, char *argv[])
  		    AMOUNT_MSAT(100 * 1000 * 1000),
  		    /* max_fee = */ AMOUNT_MSAT(20 * 1000 * 1000),
  		    /* min probability = */ 0.9,
+		    /* base probability = */ 1.0,
  		    /* delay fee factor = */ 1e-6,
  		    /* base fee penalty */ 10,
  		    /* prob cost factor = */ 10, &errmsg);
@@ -239,6 +240,7 @@ int main(int argc, char *argv[])
 	pinfo.prob_cost_factor = 1e-5;
 	pinfo.delay_feefactor = 1e-6;
 	pinfo.min_prob_success = 0.9;
+	pinfo.base_prob_success = 1.0;
 	pinfo.use_shadow = false;
 
 	randombytes_buf(&preimage, sizeof(preimage));

--- a/plugins/renepay/test/run-mcf-diamond.c
+++ b/plugins/renepay/test/run-mcf-diamond.c
@@ -194,6 +194,7 @@ int main(int argc, char *argv[])
 			AMOUNT_MSAT(1000000), // 1000 sats
 			 /* max_fee = */ AMOUNT_MSAT(10000), // 10 sats
 			 /* min probability = */ 0.8, // 80%
+			 /* base probability = */ 1.0,
 			 /* delay fee factor = */ 0,
 			 /* base fee penalty */ 0,
 			 /* prob cost factor = */ 1,

--- a/plugins/renepay/test/run-mcf.c
+++ b/plugins/renepay/test/run-mcf.c
@@ -399,6 +399,7 @@ int main(int argc, char *argv[])
 			AMOUNT_MSAT(500000000),
 			 /* max_fee = */ AMOUNT_MSAT(1000000), // 1k sats
 			 /* min probability = */ 0.1,
+			 /* base probability = */ 1.0,
 			 /* delay fee factor = */ 1,
 			 /* base fee penalty */ 1,
 			 /* prob cost factor = */ 10,
@@ -564,6 +565,7 @@ int main(int argc, char *argv[])
 			 /* amount = */ AMOUNT_MSAT(500000000), //500k sats
 			 /* max_fee = */ AMOUNT_MSAT(1000000), // 1k sats
 			 /* min probability = */ 0.1, // 10%
+			 /* base probability = */ 1.0,
 			 /* delay fee factor = */ 1,
 			 /* base fee penalty */ 1,
 			 /* prob cost factor = */ 10,

--- a/plugins/renepay/test/run-missingcapacity.c
+++ b/plugins/renepay/test/run-missingcapacity.c
@@ -133,6 +133,7 @@ int main(int argc, char *argv[])
 	pinfo.prob_cost_factor = 1e-5;
 	pinfo.delay_feefactor = 1e-6;
 	pinfo.min_prob_success = 0.9;
+	pinfo.base_prob_success = 1.0;
 	pinfo.use_shadow = false;
 
 	randombytes_buf(&preimage, sizeof(preimage));


### PR DESCRIPTION
The probability for a success forward of `x` amount on a channel is now
computed as:
```
        P_success(x) = b * P_rene(x)
```
where `P_rene(x)` is the probability distribution proposed by @renepickhardt 
with a uniform distribution on the known liquidity of the
channel and `b` is a new parameter we add in this PR, by the name of
"base probability". The "base probability" represents the probability
for a channel in the network chosen at random to be able to forward at
least 1msat, ie. of being alive, non-depleted and with at least one HTLC
slot. We don't know the value of 'b', but for the moment we assume that
it is 0.98 and use that as default.

As a consequence the probability cost becomes non-linear and non-convex
because of the additional constant term:
```
        Cost(x) = - log P_success(x)
                = - log b   -  log P_rene(x)
                = - log b  +  Cost_rene(x)
```
We currently don't handle well base fees and neither this additional
"base probability" but we can as a first approximation linearize the
cost function in this way:
```
        Cost_linear(x) = (- log b)*x  +  Cost_rene_linear(x)
```