### PR TITLE
bookkeeper: fix uninitialized variable.

### DIFF
--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1724,6 +1724,7 @@ static struct command_result *json_utxo_deposit(struct command *cmd, const char 
 	ev->spending_txid = NULL;
 	ev->payment_id = NULL;
 	ev->desc = NULL;
+	ev->splice_close = false;
 
 	plugin_log(cmd->plugin, LOG_DBG, "%s (%s|%s) %s -%s %"PRIu64" %d %s",
 		   move_tag, ev->tag, ev->acct_name,

--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1719,6 +1719,7 @@ static struct command_result *json_utxo_deposit(struct command *cmd, const char 
 	ev->ignored = false;
 	ev->stealable = false;
 	ev->rebalance = false;
+	ev->splice_close = false;
 	ev->debit = AMOUNT_MSAT(0);
 	ev->output_value = ev->credit;
 	ev->spending_txid = NULL;
@@ -1797,6 +1798,7 @@ static struct command_result *json_utxo_spend(struct command *cmd, const char *b
 	ev->ignored = false;
 	ev->stealable = false;
 	ev->rebalance = false;
+	ev->splice_close = false;
 	ev->credit = AMOUNT_MSAT(0);
 	ev->output_value = ev->debit;
 	ev->payment_id = NULL;


### PR DESCRIPTION
Valgrind found this.  I think two PRs were added in parallel, which is why we only found it after merge:

```
2024-08-09T01:57:23.7375752Z ==34263== Uninitialised byte(s) found during client check request
2024-08-09T01:57:23.7376275Z ==34263==    at 0x172405: memcheck_ (mem.h:247)
2024-08-09T01:57:23.7376661Z ==34263==    by 0x172585: db_bind_int (bindings.c:49)
2024-08-09T01:57:23.7377086Z ==34263==    by 0x126233: log_chain_event (recorder.c:2057)
2024-08-09T01:57:23.7377544Z ==34263==    by 0x11BF8B: json_utxo_deposit (bookkeeper.c:1735)
2024-08-09T01:57:23.7378207Z ==34263==    by 0x12BED3: ld_command_handle (libplugin.c:1847)
2024-08-09T01:57:23.7378674Z ==34263==    by 0x12C649: ld_read_json_one (libplugin.c:1998)
2024-08-09T01:57:23.7379114Z ==34263==    by 0x12C780: ld_read_json (libplugin.c:2018)
2024-08-09T01:57:23.7379534Z ==34263==    by 0x2990CB: next_plan (io.c:60)
2024-08-09T01:57:23.7379881Z ==34263==    by 0x299D21: do_plan (io.c:422)
2024-08-09T01:57:23.7380230Z ==34263==    by 0x299D88: io_ready (io.c:439)
2024-08-09T01:57:23.7380585Z ==34263==    by 0x29C1BC: io_loop (poll.c:455)
2024-08-09T01:57:23.7380980Z ==34263==    by 0x12D439: plugin_main (libplugin.c:2230)
```