### PR TITLE
cln-plugin: add multi options for String and i64

### DIFF
--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -3,10 +3,11 @@
 #[macro_use]
 extern crate serde_json;
 use cln_plugin::options::{
-    self, BooleanConfigOption, DefaultIntegerConfigOption, IntegerConfigOption,
+    self, BooleanConfigOption, DefaultIntegerArrayConfigOption, DefaultIntegerConfigOption,
+    DefaultStringArrayConfigOption, IntegerArrayConfigOption, IntegerConfigOption,
+    StringArrayConfigOption,
 };
 use cln_plugin::{messages, Builder, Error, Plugin};
-use tokio;
 
 const TEST_NOTIF_TAG: &str = "test_custom_notification";
 
@@ -18,6 +19,32 @@ const TEST_OPTION: DefaultIntegerConfigOption = DefaultIntegerConfigOption::new_
 
 const TEST_OPTION_NO_DEFAULT: IntegerConfigOption =
     IntegerConfigOption::new_i64_no_default("opt-option", "An option without a default");
+
+const TEST_MULTI_STR_OPTION: StringArrayConfigOption =
+    StringArrayConfigOption::new_str_arr_no_default(
+        "multi-str-option",
+        "An option that can have multiple string values",
+    );
+
+const TEST_MULTI_STR_OPTION_DEFAULT: DefaultStringArrayConfigOption =
+    DefaultStringArrayConfigOption::new_str_arr_with_default(
+        "multi-str-option-default",
+        "Default1",
+        "An option that can have multiple string values with defaults",
+    );
+
+const TEST_MULTI_I64_OPTION: IntegerArrayConfigOption =
+    IntegerArrayConfigOption::new_i64_arr_no_default(
+        "multi-i64-option",
+        "An option that can have multiple i64 values",
+    );
+
+const TEST_MULTI_I64_OPTION_DEFAULT: DefaultIntegerArrayConfigOption =
+    DefaultIntegerArrayConfigOption::new_i64_arr_with_default(
+        "multi-i64-option-default",
+        -42,
+        "An option that can have multiple i64 values with defaults",
+    );
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -33,6 +60,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .option(TEST_OPTION)
         .option(TEST_OPTION_NO_DEFAULT)
         .option(test_dynamic_option)
+        .option(TEST_MULTI_STR_OPTION)
+        .option(TEST_MULTI_STR_OPTION_DEFAULT)
+        .option(TEST_MULTI_I64_OPTION)
+        .option(TEST_MULTI_I64_OPTION_DEFAULT)
         .setconfig_callback(setconfig_callback)
         .rpcmethod("testmethod", "This is a test", testmethod)
         .rpcmethod(
@@ -79,10 +110,18 @@ async fn setconfig_callback(
 async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     let test_option = p.option(&TEST_OPTION)?;
     let test_option_no_default = p.option(&TEST_OPTION_NO_DEFAULT)?;
+    let test_multi_str_option = p.option(&TEST_MULTI_STR_OPTION)?;
+    let test_multi_str_option_default = p.option(&TEST_MULTI_STR_OPTION_DEFAULT)?;
+    let test_multi_i64_option = p.option(&TEST_MULTI_I64_OPTION)?;
+    let test_multi_i64_option_default = p.option(&TEST_MULTI_I64_OPTION_DEFAULT)?;
 
     Ok(json!({
         "test-option": test_option,
-        "opt-option" : test_option_no_default
+        "opt-option" : test_option_no_default,
+        "multi-str-option": test_multi_str_option,
+        "multi-str-option-default": test_multi_str_option_default,
+        "multi-i64-option": test_multi_i64_option,
+        "multi-i64-option-default": test_multi_i64_option_default,
     }))
 }
 

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -437,6 +437,15 @@ where
             let option_value: Option<options::Value> = match (json_value, default_value) {
                 (None, None) => None,
                 (None, Some(default)) => Some(default.clone()),
+                (Some(JValue::Array(a)), _) => match a.first() {
+                    Some(JValue::String(_)) => Some(OValue::StringArray(
+                        a.iter().map(|x| x.as_str().unwrap().to_string()).collect(),
+                    )),
+                    Some(JValue::Number(_)) => Some(OValue::IntegerArray(
+                        a.iter().map(|x| x.as_i64().unwrap()).collect(),
+                    )),
+                    _ => panic!("Array type not supported for option: {}", name),
+                },
                 (Some(JValue::String(s)), _) => Some(OValue::String(s.to_string())),
                 (Some(JValue::Number(i)), _) => Some(OValue::Integer(i.as_i64().unwrap())),
                 (Some(JValue::Bool(b)), _) => Some(OValue::Boolean(*b)),

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -74,16 +74,34 @@ def test_plugin_options_handle_defaults(node_factory):
     """Start a minimal plugin and ensure it is well-behaved
     """
     bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-plugin-startup"
-    l1 = node_factory.get_node(options={"plugin": str(bin_path), 'opt-option': 31337, "test-option": 31338})
+    l1 = node_factory.get_node(
+        options={
+            "plugin": str(bin_path),
+            "opt-option": 31337,
+            "test-option": 31338,
+            "multi-str-option": ["String1", "String2"],
+            "multi-str-option-default": ["NotDefault1", "NotDefault2"],
+            "multi-i64-option": [1, 2, 3, 4],
+            "multi-i64-option-default": [5, 6],
+        }
+    )
     opts = l1.rpc.testoptions()
     assert opts["opt-option"] == 31337
     assert opts["test-option"] == 31338
+    assert opts["multi-str-option"] == ["String1", "String2"]
+    assert opts["multi-str-option-default"] == ["NotDefault1", "NotDefault2"]
+    assert opts["multi-i64-option"] == [1, 2, 3, 4]
+    assert opts["multi-i64-option-default"] == [5, 6]
 
     # Do not set any value, should be None now
     l1 = node_factory.get_node(options={"plugin": str(bin_path)})
     opts = l1.rpc.testoptions()
     assert opts["opt-option"] is None, "opt-option has no default"
     assert opts["test-option"] == 42, "test-option has a default of 42"
+    assert opts["multi-str-option"] is None
+    assert opts["multi-str-option-default"] == ["Default1"]
+    assert opts["multi-i64-option"] is None
+    assert opts["multi-i64-option-default"] == [-42]
 
 
 def test_grpc_connect(node_factory):


### PR DESCRIPTION
cln-plugin was missing multi-style options. This PR adds them for `string` and `int`