### PR TITLE
Re-export `tonic` in `cln-grpc`

### DIFF
--- a/cln-grpc/src/lib.rs
+++ b/cln-grpc/src/lib.rs
@@ -1,6 +1,8 @@
 // Huge json!() macros require lots of recursion
 #![recursion_limit = "1024"]
 
+pub use tonic;
+
 #[cfg(feature = "server")]
 mod convert;
 pub mod pb;


### PR DESCRIPTION
Using `cln-grpc` in an outside crate is somewhat tricky. We currently do not have a way to describe the type of `T` in `NodeClient<T>`

The export allows the user to write the snippet below.

```rust
struct App {
  grpc_client: NodeClient<cln_grpc::tonic::transport::Channel>
}

impl App {

  fn create(destination: AsRef<str>) -> Self {
    NodeClient::connect(destination.as_ref())
      .await
      .unwrap("Failed to connect")
  }
}

async fn main() {
  App::create("http://localhost:1234")
}
```