### PR TITLE
renepay: small tweak to decay time

### DIFF
--- a/plugins/renepay/renepayconfig.h
+++ b/plugins/renepay/renepayconfig.h
@@ -6,7 +6,7 @@
 
 /* Knowledge is proportionally decreased with time up to TIMER_FORGET_SEC when
  * we forget everything. */
-#define TIMER_FORGET_SEC 3600
+#define TIMER_FORGET_SEC 600000
 
 /* Time lapse used to wait for failed sendpays. */
 #define COLLECTOR_TIME_WINDOW_MSEC 50


### PR DESCRIPTION
The time of decay "TIMER_FORGET_SEC" was set to 1 hour, which is very low, it would make the plugin try depleted channels after just a couple of seconds for very small amounts.
I set it to 1 week ~ 6e5 seconds.

This improvement combined with #7540 is truly making Rene pay again!
Tested on mainnet with small amounts.