### PR TITLE
lightningd: handle duplicate watches on the same thing correctly.

### DIFF
--- a/lightningd/watch.h
+++ b/lightningd/watch.h
@@ -89,10 +89,9 @@ void txowatch_fire(const struct txowatch *txow,
 bool watching_txid(const struct chain_topology *topo,
 		   const struct bitcoin_txid *txid);
 
-/* FIXME: Implement bitcoin_tx_dup() so we tx arg can be TAKEN */
 void txwatch_inform(const struct chain_topology *topo,
 		    const struct bitcoin_txid *txid,
-		    const struct bitcoin_tx *tx_may_steal);
+		    struct bitcoin_tx *tx TAKES);
 
 void watch_topology_changed(struct chain_topology *topo);
 #endif /* LIGHTNING_LIGHTNINGD_WATCH_H */


### PR DESCRIPTION
Our hash tables allow duplicate keys, and we use that in a few places. However, the get() function only returns the first, so it's not a good idea with such hash tables.

Another patch fixes this at a deeper level (using different hash table types depending on whether this table can have duplicates), but this is the minimal fix for existing code.

This may be the cause behind us occasionally missing onchain events:

Fixes: https://github.com/ElementsProject/lightning/issues/7460
Fixes: https://github.com/ElementsProject/lightning/issues/7377
Fixes: https://github.com/ElementsProject/lightning/issues/7118
Fixes: https://github.com/ElementsProject/lightning/issues/6951

This fixes them in future: fixing them now will require something else.


Changelog-Fixed: lightningd: occasionally we could miss transaction outputs (not telling gossipd, or even onchaind)