### PR TITLE
GitHub docker testing

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,12 +3,27 @@ name: Build and push multi-platform docker images
 on:
   push:
     tags:
-      - '^v[0-9]{2}\.[0-9]{2}(\.[0-9]{1,2})?$'
+      - '^v[0-9]{2}\.[0-9]{2}(\.[0-9]{1,2})?([a-zA-Z0-9]*)?$'
   workflow_dispatch:
     inputs:
       version:
         description: 'Release version'
         required: true
+
+      repository-name:
+        description: 'Docker repository name'
+        default: 'elementsproject'
+        required: false
+
+      platforms-to-build:
+        description: 'List of platforms to build'
+        default: 'linux/amd64,linux/arm64,linux/arm/v7'
+        required: false
+  
+      push-latest:
+        description: 'Push the latest tag also?'
+        default: 'false'
+        required: false
 
 jobs:
   build:
@@ -30,8 +45,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Set up version
-      id: set-version
+    - name: Set up values
+      id: set-values
       run: |
         if [ "${{ github.event.inputs.version }}" != "" ]; then
           VERSION=${{ github.event.inputs.version }}
@@ -42,13 +57,58 @@ jobs:
           exit 1
         fi
         echo "VERSION=$VERSION" >> $GITHUB_ENV
-        
+
+        if [ "${{ github.event.inputs.repository-name }}" != "" ]; then
+          REPONAME=${{ github.event.inputs.repository-name }}
+        else
+          REPONAME="elementsproject"
+        fi
+        echo "REPONAME=$REPONAME" >> $GITHUB_ENV
+
+        if [ "${{ github.event.inputs.platforms-to-build }}" != "" ]; then
+          PLATFORMS=${{ github.event.inputs.platforms-to-build }}
+        else
+          PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+        fi
+        echo "PLATFORMS=$PLATFORMS" >> $GITHUB_ENV
+
+        if [
+          "${{ github.event.inputs.push-latest }}" == "true" ||
+          ( "${{ github.ref_type }}" == "tag" && [[ ! "${{ env.VERSION }}" =~ rc ]] )
+        ]; then
+          PUSHLATEST="true"
+        else
+          PUSHLATEST="false"
+        fi
+        echo "PUSHLATEST=$PUSHLATEST" >> $GITHUB_ENV
+
+    - name: Set Tags
+      id: set-tags
+      run: |
+        TAGS="${{ env.REPONAME }}/lightningd:${{ env.VERSION }}"
+        if [ "${{ env.PUSHLATEST }}" == "true" ]; then
+          TAGS="$TAGS,${{ env.REPONAME }}/lightningd:latest"
+        fi
+        echo "TAGS=$TAGS" >> $GITHUB_ENV
+
+    - name: Print GitHub Ref Values
+      run: |
+        echo "GITHUB REF TYPE: ${{ github.ref_type }}"
+        echo "GITHUB REF NAME: ${{ github.ref_name }}"
+        echo "EVENT INPUT VERSION: ${{ github.event.inputs.version }}"
+        echo "EVENT INPUT REPO: ${{ github.event.inputs.repository-name }}"
+        echo "EVENT INPUT PLATFORMS: ${{ github.event.inputs.platforms-to-build }}"
+        echo "EVENT INPUT PUSH LATEST: ${{ github.event.inputs.push-latest }}"
+        echo "VERSION ENV: ${{ env.VERSION }}"
+        echo "REPO NAME: ${{ env.REPONAME }}"
+        echo "PLATFORMS: ${{ env.PLATFORMS }}"
+        echo "PUSH LATEST: ${{ env.PUSHLATEST }}"
+        echo "TAGS: ${{ env.TAGS }}"
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
         context: .
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
-        tags: |
-          elementsproject/lightningd:$VERSION
-          elementsproject/lightningd:latest
+        platforms: ${{ env.PLATFORMS }}
+        tags: ${{ env.TAGS }}


### PR DESCRIPTION
- Temporarily adding `rc` tag trigger, some input variables & more logs for testing `Build and push multi-platform docker images` action flow before the final release.

- **Poetry on arm32:** The Docker build for `linux/arm/v7` failed in recent RC releases on the Poetry installation step in the `builder-python` stage. This issue occurred because the `builder-python` stage builds on target's arch but poetry was unable to install on arm/v7 without rust >= v1.56.1.
    - **Solution:** Instead of installing poetry on the `builder-python` stage, we leveraged the existing multi-arch `builder` stage, which already had Poetry. Now, we export the dependencies from `pyproject.toml` to `requirements.txt` within the `builder` stage and then copy `requirements.txt` to the `builder-python` stage for pip installation.

- **Cryptography installation:** python installations for `pyln-proto` started failing due to Cryptography upgrade from v41 to v42 (PR #7475). It is because now Cryptography needs cargo/rust also.
    - **Solution:** Installing cargo in `builder-python` stage also.

- **Configure Prefix:** Previously, we used `RUN ./configure --prefix=/tmp/lightning_install --enable-static` in the `builder` image and then copied `/tmp/lightning_install` from the `builder` stage to `/usr/local` in the `final` stage. However, this approach is now causing errors due to missing binaries/plugins at their default locations.
    - **Solution:** We are now configuring the installation to use the default location (`/usr/local`). To prevent the local image size from increasing by up to 87MB, instead of copying the entire `/usr/local/` directory, we are explicitly copying only the core lightning binaries.

Changelog-Fixed: Fixes failing Docker build for `arm32` arch.
