### PR TITLE
lightningd: fix trivial memleak.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -533,7 +533,7 @@ static const char *find_my_directory(const tal_t *ctx, const char *argv0)
 /* Determine the correct daemon dir. */
 static void find_subdaemons_and_plugins(struct lightningd *ld, const char *argv0)
 {
-	const char *my_path = find_my_directory(NULL, argv0);
+	const char *my_path = find_my_directory(tmpctx, argv0);
 	const char *prefix;
 
 	/* If we're running in-tree, all the subdaemons are with lightningd. */


### PR DESCRIPTION
Mainly, it just causes complaints if we're running a lightningd which is installed (in which case, my_path is not stolen, unlike running locally installed).

Reported-by: daywalker90
Fixes: https://github.com/ElementsProject/lightning/issues/7569
Changelog-None: regression this release