### PR TITLE
pyln-testing: fix catching of memleak/broken errors at exit.

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -605,6 +605,7 @@ def checkBadGossip(node):
 
 
 def checkBroken(node):
+    node.daemon.logs_catchup()
     broken_lines = [l for l in node.daemon.logs if '**BROKEN**' in l]
     if node.broken_log:
         ex = re.compile(node.broken_log)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -514,7 +514,9 @@ def test_penalty_inhtlc(node_factory, bitcoind, executor, chainparams, anchors):
 
     # FIXME: | for dicts was added in Python 3.9 apparently.
     l1, l2 = node_factory.line_graph(2, opts=[{**opts, **{'may_fail': True,
-                                                          'feerates': (7500, 7500, 7500, 7500)}},
+                                                          'feerates': (7500, 7500, 7500, 7500),
+                                                          # We try to cheat!
+                                                          'broken_log': r"onchaind-chan#[0-9]*: Could not find resolution for output .*: did \*we\* cheat\?"}},
                                               opts])
 
     channel_id = first_channel_id(l1, l2)
@@ -646,7 +648,9 @@ def test_penalty_outhtlc(node_factory, bitcoind, executor, chainparams, anchors)
     # Feerates identical so we don't get gratuitous commit to update them
     l1, l2 = node_factory.line_graph(2,
                                      opts=[{**opts, **{'may_fail': True,
-                                                       'feerates': (7500, 7500, 7500, 7500)}},
+                                                       'feerates': (7500, 7500, 7500, 7500),
+                                                       # We try to cheat!
+                                                       'broken_log': r"onchaind-chan#[0-9]*: Could not find resolution for output .*: did \*we\* cheat\?"}},
                                            opts])
     channel_id = first_channel_id(l1, l2)
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2020,7 +2020,8 @@ def test_dump_own_gossip(node_factory):
 def test_listchannels_deprecated_local(node_factory, bitcoind):
     """Test listchannels shows local/private channels only in deprecated mode"""
     l1, l2, l3 = node_factory.get_nodes(3,
-                                        opts=[{}, {'allow-deprecated-apis': True}, {}])
+                                        opts=[{}, {'allow-deprecated-apis': True,
+                                                   'broken_log': 'plugin-topology: DEPRECATED API USED: listchannels.include_private'}, {}])
     # This will be in block 103
     node_factory.join_nodes([l1, l2], wait_for_announce=False)
     l1l2 = first_scid(l1, l2)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1921,7 +1921,8 @@ def test_logging(node_factory):
 @unittest.skipIf(VALGRIND,
                  "Valgrind sometimes fails assert on injected SEGV")
 def test_crashlog(node_factory):
-    l1 = node_factory.get_node(may_fail=True)
+    l1 = node_factory.get_node(may_fail=True,
+                               broken_log=' lightningd: ')
 
     def has_crash_log(n):
         files = os.listdir(os.path.join(n.daemon.lightning_dir, TEST_NETWORK))
@@ -2305,7 +2306,8 @@ def test_dev_force_bip32_seed(node_factory):
 
 
 def test_dev_demux(node_factory):
-    l1 = node_factory.get_node(may_fail=True)
+    l1 = node_factory.get_node(may_fail=True,
+                               broken_log=' lightningd: ')
 
     # Check should work.
     l1.rpc.check(command_to_check='dev', subcommand='crash')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1668,7 +1668,7 @@ def test_libplugin_deprecated(node_factory):
                                         'somearg-deprecated': 'test_opt depr',
                                         'allow-deprecated-apis': True},
                                # testrpc-deprecated causes a complaint!
-                               )
+                               broken_log='DEPRECATED API USED')
 
     assert l1.daemon.is_in_log("somearg = test_opt depr")
     l1.rpc.help('testrpc-deprecated')
@@ -2006,7 +2006,9 @@ def test_watchtower(node_factory, bitcoind, directory, chainparams):
     p = os.path.join(os.path.dirname(__file__), "plugins/watchtower.py")
     l1, l2 = node_factory.line_graph(
         2,
-        opts=[{'may_fail': True}, {'plugin': p}]
+        opts=[{'may_fail': True,
+               'broken_log': r"onchaind-chan#[0-9]*: Could not find resolution for output .*: did \*we\* cheat\?"},
+              {'plugin': p}]
     )
     channel_id = l1.rpc.listpeerchannels()['channels'][0]['channel_id']
 


### PR DESCRIPTION
Commit 901342b50d0adb2d77418b1382cff4b289c7c9b3 ("pyln-testing: require explicit pattern for BROKEN messages.") changed to a manual scan of logs rather than using is_in_log, so it needs to manually refresh, otherwise we miss final log messages.

This causes us to often miss memleak messages, which are printed only in the exit path!

Reported-by: Lagrang3
Fixes: https://github.com/ElementsProject/lightning/issues/7565