### PR TITLE
renepay: bugfix assertion htlc_total<=known_max

### DIFF
--- a/plugins/renepay/chan_extra.h
+++ b/plugins/renepay/chan_extra.h
@@ -140,7 +140,8 @@ chan_extra_commit_htlc(struct chan_extra_map *chan_extra_map,
 enum renepay_errorcode
 chan_extra_set_liquidity(struct chan_extra_map *chan_extra_map,
 			 const struct short_channel_id_dir *scidd,
-			 struct amount_msat x);
+			 struct amount_msat min,
+			 struct amount_msat max);
 
 /* Update the knowledge that this (channel,direction) has sent x msat.*/
 enum renepay_errorcode

--- a/plugins/renepay/flow.h
+++ b/plugins/renepay/flow.h
@@ -43,7 +43,8 @@ double flow_edge_cost(const struct gossmap *gossmap,
 /* Compute the prob. of success of a set of concurrent set of flows. */
 double flowset_probability(const tal_t *ctx, struct flow **flows,
 			   const struct gossmap *const gossmap,
-			   struct chan_extra_map *chan_extra_map, char **fail);
+			   struct chan_extra_map *chan_extra_map,
+			   bool compute_fees, char **fail);
 
 /* How much do we need to send to make this flow arrive. */
 bool flow_spend(struct amount_msat *ret, struct flow *flow);
@@ -63,7 +64,8 @@ static inline struct amount_msat flow_delivers(const struct flow *flow)
 	return flow->amount;
 }
 
-struct amount_msat *tal_flow_amounts(const tal_t *ctx, const struct flow *flow);
+struct amount_msat *tal_flow_amounts(const tal_t *ctx, const struct flow *flow,
+				     bool compute_fees);
 
 enum renepay_errorcode
 flow_maximum_deliverable(struct amount_msat *max_deliverable,
@@ -79,7 +81,8 @@ bool flow_assign_delivery(struct flow *flow, const struct gossmap *gossmap,
 			  struct amount_msat requested_amount);
 
 double flow_probability(struct flow *flow, const struct gossmap *gossmap,
-			struct chan_extra_map *chan_extra_map);
+			struct chan_extra_map *chan_extra_map,
+			bool compute_fees);
 
 u64 flow_delay(const struct flow *flow);
 u64 flows_worst_delay(struct flow **flows);

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -470,8 +470,14 @@ static bool linearize_channel(const struct pay_parameters *params,
 		return false;
 	}
 
-	assert(
-	    amount_msat_less_eq(extra_half->htlc_total, extra_half->known_max));
+	/* FIXME: this assertion has been reported to be triggered in issue
+	 * #7535. A quick and dirty solution is to comment it and work-around
+	 * this case. But in principle if we do things the right way we should
+	 * not have htlc_total>known_max. The problem is likely to be
+	 * asynchronous way in which reserved htlcs are removed and known_max is
+	 * updated. */
+	// assert(
+	//    amount_msat_less_eq(extra_half->htlc_total, extra_half->known_max));
 	assert(
 	    amount_msat_less_eq(extra_half->known_min, extra_half->known_max));
 

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -1449,9 +1449,8 @@ get_flow_paths(const tal_t *ctx, const struct gossmap *gossmap,
 			excess = amount_msat(0);
 			fp->amount = delivered;
 
-
 			fp->success_prob =
-			    flow_probability(fp, gossmap, chan_extra_map)
+			    flow_probability(fp, gossmap, chan_extra_map, false)
 			    * pow(base_probability, tal_count(fp->path));
 			if (fp->success_prob < 0) {
 				if (fail)
@@ -1737,12 +1736,14 @@ struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
 
 	best_prob_success =
 	    flowset_probability(this_ctx, best_flow_paths, params->gossmap,
-				params->chan_extra_map, &errmsg)
+				params->chan_extra_map, false, &errmsg)
 	    * pow(params->base_probability, flowset_size(best_flow_paths));
 	if (best_prob_success < 0) {
 		if (fail)
-		*fail =
-		    tal_fmt(ctx, "flowset_probability failed: %s", errmsg);
+			*fail = tal_fmt(
+			    ctx,
+			    "flowset_probability failed on MaxFlow phase: %s",
+			    errmsg);
 		goto function_fail;
 	}
 	if (!flowset_fee(&best_fee, best_flow_paths)) {
@@ -1795,7 +1796,7 @@ struct flow **minflow(const tal_t *ctx, struct gossmap *gossmap,
 
 		double prob_success =
 		    flowset_probability(this_ctx, flow_paths, params->gossmap,
-					params->chan_extra_map, &errmsg)
+					params->chan_extra_map, false, &errmsg)
 		    * pow(params->base_probability, flowset_size(flow_paths));
 		if (prob_success < 0) {
 			// flowset_probability doesn't fail unless there is a bug.

--- a/plugins/renepay/mcf.c
+++ b/plugins/renepay/mcf.c
@@ -481,7 +481,7 @@ static bool linearize_channel(const struct pay_parameters *params,
 	assert(
 	    amount_msat_less_eq(extra_half->known_min, extra_half->known_max));
 
-	s64 h = extra_half->htlc_total.millisatoshis/1000; /* Raw: linearize_channel */
+	s64 h = (extra_half->htlc_total.millisatoshis+999)/1000; /* Raw: linearize_channel */
 	s64 a = extra_half->known_min.millisatoshis/1000, /* Raw: linearize_channel */
 	    b = 1 + extra_half->known_max.millisatoshis/1000; /* Raw: linearize_channel */
 

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -654,7 +654,8 @@ static struct command_result *compute_routes_cb(struct payment *payment)
 
 	/* How much are we still trying to send? */
 	if (!amount_msat_sub(&remaining, payment->payment_info.amount,
-			     payment->total_delivering)) {
+			     payment->total_delivering) ||
+	    amount_msat_zero(remaining)) {
 		plugin_log(pay_plugin->plugin, LOG_UNUSUAL,
 			   "%s: Payment is pending with full amount already "
 			   "committed. We skip the computation of new routes.",

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -1127,6 +1127,7 @@ static struct command_result *channelfilter_cb(struct payment *payment)
 	 * HTLC_MAX_FRACTION. */
 	htlc_max_threshold = MIN(htlc_max_threshold, HTLC_MAX_STOP_MSAT);
 
+	gossmap_apply_localmods(pay_plugin->gossmap, payment->local_gossmods);
 	for (const struct gossmap_node *node =
 		 gossmap_first_node(pay_plugin->gossmap);
 	     node; node = gossmap_next_node(pay_plugin->gossmap, node)) {
@@ -1147,6 +1148,7 @@ static struct command_result *channelfilter_cb(struct payment *payment)
 			}
 		}
 	}
+	gossmap_remove_localmods(pay_plugin->gossmap, payment->local_gossmods);
 	// FIXME: prune the network over other parameters, eg. capacity,
 	// fees, ...
 	plugin_log(pay_plugin->plugin, LOG_DBG,

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -1200,21 +1200,22 @@ void *payment_virtual_program[] = {
     /*2*/ OP_CALL, &selfpay_pay_mod,
     /*4*/ OP_CALL, &knowledgerelax_pay_mod,
     /*6*/ OP_CALL, &getmychannels_pay_mod,
-    /*8*/ OP_CALL, &routehints_pay_mod,
-    /*10*/OP_CALL, &channelfilter_pay_mod,
+    /*8*/ OP_CALL, &refreshgossmap_pay_mod,
+    /*10*/ OP_CALL, &routehints_pay_mod,
+    /*12*/OP_CALL, &channelfilter_pay_mod,
     // TODO shadow_additions
     /* do */
-	    /*12*/ OP_CALL, &pendingsendpays_pay_mod,
-	    /*14*/ OP_CALL, &checktimeout_pay_mod,
-	    /*16*/ OP_CALL, &refreshgossmap_pay_mod,
-	    /*18*/ OP_CALL, &compute_routes_pay_mod,
-	    /*20*/ OP_CALL, &send_routes_pay_mod,
+	    /*14*/ OP_CALL, &pendingsendpays_pay_mod,
+	    /*16*/ OP_CALL, &checktimeout_pay_mod,
+	    /*18*/ OP_CALL, &refreshgossmap_pay_mod,
+	    /*20*/ OP_CALL, &compute_routes_pay_mod,
+	    /*22*/ OP_CALL, &send_routes_pay_mod,
 	    /*do*/
-		    /*22*/ OP_CALL, &sleep_pay_mod,
-		    /*24*/ OP_CALL, &collect_results_pay_mod,
+		    /*24*/ OP_CALL, &sleep_pay_mod,
+		    /*26*/ OP_CALL, &collect_results_pay_mod,
 	    /*while*/
-	    /*26*/ OP_IF, &nothaveresults_pay_cond, (void *)22,
+	    /*28*/ OP_IF, &nothaveresults_pay_cond, (void *)24,
     /* while */
-    /*29*/ OP_IF, &retry_pay_cond, (void *)12,
-    /*32*/ OP_CALL, &end_pay_mod, /* safety net, default failure if reached */
-    /*34*/ NULL};
+    /*31*/ OP_IF, &retry_pay_cond, (void *)14,
+    /*34*/ OP_CALL, &end_pay_mod, /* safety net, default failure if reached */
+    /*36*/ NULL};

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -166,6 +166,11 @@ struct route **get_routes(const tal_t *ctx,
 				 "Failed to build disabled_bitmap.");
 		goto function_fail;
 	}
+	if (amount_msat_zero(amount_to_deliver)) {
+		tal_report_error(ctx, ecode, fail, PLUGIN_ERROR,
+				 "amount to deliver is zero");
+		goto function_fail;
+	}
 
 	/* Also disable every channel that we don't have in the chan_extra_map.
 	 * We might have channels in the gossmap that are not usable for
@@ -280,7 +285,7 @@ struct route **get_routes(const tal_t *ctx,
 
 			const double prob = flow_probability(
 			    flows[i], gossmap,
-			    uncertainty_get_chan_extra_map(uncertainty));
+			    uncertainty_get_chan_extra_map(uncertainty), true);
 			if (prob < 0) {
 				// should not happen
 				tal_report_error(ctx, ecode, fail, PLUGIN_ERROR,

--- a/plugins/renepay/test/common.h
+++ b/plugins/renepay/test/common.h
@@ -18,7 +18,8 @@ static const char *print_routes(const tal_t *ctx,
 		delivered = route_delivers(routes[i]);
 		fee = route_fees(routes[i]);
 		tal_append_fmt(&buff, "   %s", fmt_route_path(this_ctx, routes[i]));
-		tal_append_fmt(&buff, " %s delivered with fee %s\n",
+		tal_append_fmt(&buff, " prob %.2f, %s delivered with fee %s\n",
+			       routes[i]->success_prob,
 			       fmt_amount_msat(this_ctx, delivered),
 			       fmt_amount_msat(this_ctx, fee));
 	}

--- a/plugins/renepay/test/run-bottleneck.c
+++ b/plugins/renepay/test/run-bottleneck.c
@@ -34,7 +34,7 @@ static const char *print_flows(const tal_t *ctx, const char *desc,
 {
 	tal_t *this_ctx = tal(ctx, tal_t);
 	double tot_prob =
-	    flowset_probability(tmpctx, flows, gossmap, chan_extra_map, NULL);
+	    flowset_probability(tmpctx, flows, gossmap, chan_extra_map, false, NULL);
 	assert(tot_prob >= 0);
 	char *buff = tal_fmt(ctx, "%s: %zu subflows, prob %2lf\n", desc,
 			     tal_count(flows), tot_prob);
@@ -190,7 +190,8 @@ int main(int argc, char *argv[])
 	assert(skipped_count==0);
 
 	bitmap *disabled = tal_arrz(
- 	    tmpctx, bitmap, BITMAP_NWORDS(gossmap_max_chan_idx(gossmap)));
+	    tmpctx, bitmap, 2 * BITMAP_NWORDS(gossmap_max_chan_idx(gossmap)));
+	assert(disabled);
 
 	char *errmsg;
  	struct flow **flows;
@@ -208,11 +209,11 @@ int main(int argc, char *argv[])
  		    /* prob cost factor = */ 10, &errmsg);
 
 	if (!flows) {
-  		printf("Minflow has failed with: %s", errmsg);
-  		// assert(0 && "minflow failed");
-  	}
+		printf("Minflow has failed with: %s\n", errmsg);
+		assert(flows);
+	}
 
- 	if(flows)
+	if(flows)
   	printf("%s\n", print_flows(tmpctx, "Simple minflow", gossmap,
   				   uncertainty->chan_extra_map, flows));
 
@@ -274,10 +275,9 @@ int main(int argc, char *argv[])
 		&errcode,
 		&err_msg);
 
-	assert(routes);
-
 	if (!routes) {
-		printf("get_route failed with error %d: %s", errcode, err_msg);
+		printf("get_route failed with error %d: %s\n", errcode, err_msg);
+		assert(routes);
 	}
  	if(routes)
   	printf("get_routes: %s\n", print_routes(tmpctx, routes));

--- a/plugins/renepay/test/run-mcf-diamond.c
+++ b/plugins/renepay/test/run-mcf-diamond.c
@@ -69,7 +69,7 @@ static const char* print_flows(
 {
 	tal_t *this_ctx = tal(ctx,tal_t);
 	double tot_prob =
-	    flowset_probability(tmpctx, flows, gossmap, chan_extra_map, NULL);
+	    flowset_probability(tmpctx, flows, gossmap, chan_extra_map, false, NULL);
 	assert(tot_prob>=0);
 	char *buff = tal_fmt(ctx,"%s: %zu subflows, prob %2lf\n", desc, tal_count(flows),tot_prob);
 	for (size_t i = 0; i < tal_count(flows); i++) {

--- a/plugins/renepay/test/run-mcf.c
+++ b/plugins/renepay/test/run-mcf.c
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
 
 	printf("Checking results.\n");
 	/* Should go 1->2->3 */
-	amounts = tal_flow_amounts(tmpctx, flows[0]);
+	amounts = tal_flow_amounts(tmpctx, flows[0], true);
 	assert(amounts);
 	assert(tal_count(flows) == 1);
 	assert(tal_count(flows[0]->path) == 2);
@@ -440,7 +440,7 @@ int main(int argc, char *argv[])
 
 	/* Each one has probability ~ 0.5 */
 	assert(flows[0]->success_prob > 0.249);
-	assert(flows[0]->success_prob <= 0.250);
+	assert(flows[0]->success_prob <= 0.251);
 
 
 	/* Should have filled in some extra data! */

--- a/plugins/renepay/test/run-testflow.c
+++ b/plugins/renepay/test/run-testflow.c
@@ -695,7 +695,7 @@ static void test_flow_to_route(void)
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, deliver));
-	assert(fabs(flow_probability(F, gossmap, chan_extra_map) - 0.5)<eps);
+	assert(fabs(flow_probability(F, gossmap, chan_extra_map, true) - 0.5)<eps);
 
 	// flow 3->4->5
 	F = tal(this_ctx, struct flow);
@@ -711,7 +711,7 @@ static void test_flow_to_route(void)
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250050016)));
-	assert(fabs(flow_probability(F, gossmap, chan_extra_map) - 1.)<eps);
+	assert(fabs(flow_probability(F, gossmap, chan_extra_map, true) - 1.)<eps);
 
 	// flow 2->3->4->5
 	F = tal(this_ctx, struct flow);
@@ -729,7 +729,7 @@ static void test_flow_to_route(void)
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250087534)));
-	assert(fabs(flow_probability(F, gossmap, chan_extra_map) - 1. + 250.087534/2000)<eps);
+	assert(fabs(flow_probability(F, gossmap, chan_extra_map, true) - 1. + 250.087534/2000)<eps);
 
 	// flow 1->2->3->4->5
 	F = tal(this_ctx, struct flow);
@@ -749,7 +749,7 @@ static void test_flow_to_route(void)
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250112544)));
-	assert(fabs(flow_probability(F, gossmap, chan_extra_map) - 0.43728117)<eps);
+	assert(fabs(flow_probability(F, gossmap, chan_extra_map, true) - 0.43728117)<eps);
 
 	tal_free(this_ctx);
 }

--- a/plugins/renepay/uncertainty.c
+++ b/plugins/renepay/uncertainty.c
@@ -164,11 +164,12 @@ uncertainty_add_channel(struct uncertainty *uncertainty,
 
 bool uncertainty_set_liquidity(struct uncertainty *uncertainty,
 			       const struct short_channel_id_dir *scidd,
-			       struct amount_msat amount)
+			       struct amount_msat min,
+			       struct amount_msat max)
 {
 	// FIXME check error
 	enum renepay_errorcode err = chan_extra_set_liquidity(
-	    uncertainty->chan_extra_map, scidd, amount);
+	    uncertainty->chan_extra_map, scidd, min, max);
 
 	return err == RENEPAY_NOERROR;
 }

--- a/plugins/renepay/uncertainty.h
+++ b/plugins/renepay/uncertainty.h
@@ -50,7 +50,8 @@ uncertainty_add_channel(struct uncertainty *uncertainty,
 
 bool uncertainty_set_liquidity(struct uncertainty *uncertainty,
 			       const struct short_channel_id_dir *scidd,
-			       struct amount_msat amount);
+			       struct amount_msat min,
+			       struct amount_msat max);
 
 struct chan_extra *uncertainty_find_channel(struct uncertainty *uncertainty,
 					    const struct short_channel_id scid);

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -768,3 +768,29 @@ def test_privatechan(node_factory, bitcoind):
     l1.wait_for_htlcs()
     invoice = only_one(l4.rpc.listinvoices("inv")["invoices"])
     assert invoice["amount_received_msat"] >= Millisatoshi("1000sat")
+
+
+def test_hardmpp2(node_factory, bitcoind):
+    """Credits to @daywalker90 for this test case."""
+    opts = {"disable-mpp": None, "fee-base": 0, "fee-per-satoshi": 10}
+    l1, l2, l3 = node_factory.get_nodes(3, opts=opts)
+    start_channels(
+        [
+            (l1, l2, 100_000),
+            (l1, l2, 200_000),
+            (l1, l2, 300_000),
+            (l1, l2, 400_000),
+            (l2, l3, 100_000),
+            (l2, l3, 200_000),
+            (l2, l3, 300_000),
+            (l2, l3, 600_000),
+        ]
+    )
+    # FIXME: changing the last channel from 600k to 400k will fail the test due
+    # to l2 not accepting to forward any amount above 200k with error:
+    # CHANNEL_ERR_CHANNEL_CAPACITY_EXCEEDED, still investigating
+    inv = l3.rpc.invoice("800000sat", "inv", "description")
+    l1.rpc.call("renepay", {"invstring": inv["bolt11"]})
+    l1.wait_for_htlcs()
+    receipt = only_one(l3.rpc.listinvoices("inv")["invoices"])
+    assert receipt["amount_received_msat"] == Millisatoshi("800000sat")


### PR DESCRIPTION
~~Make knowledge update and removal of pending HTLCs atomic to avoid race conditions.~~
A quick and dirty solution: comment the assertion making sure the rest of the code in `linearize_channel` can handle the
offending cases (for which `known_max<htlc_total`).

Fixes #7535.