### PR TITLE
Sql plugin crash fix

### DIFF
--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -1581,6 +1581,14 @@ static const char *fmt_indexes(const tal_t *ctx, const char *table)
 	return tal_fmt(ctx, " indexed by `%s`", ret);
 }
 
+static const char *json_prefix(const tal_t *ctx,
+			       const struct table_desc *td)
+{
+	if (td->is_subobject)
+		return tal_fmt(ctx, "%s%s.", json_prefix(tmpctx, td->parent), td->cmdname);
+	return "";
+}
+
 static void print_columns(const struct table_desc *td, const char *indent,
 			  const char *objsrc)
 {
@@ -1603,7 +1611,8 @@ static void print_columns(const struct table_desc *td, const char *indent,
 				const char *subobjsrc;
 
 				subobjsrc = tal_fmt(tmpctx,
-						    ", from JSON object `%s`",
+						    ", from JSON object `%s%s`",
+						    json_prefix(tmpctx, td),
 						    td->columns[i]->jsonname);
 				print_columns(subtd, indent, subobjsrc);
 			}
@@ -1613,7 +1622,8 @@ static void print_columns(const struct table_desc *td, const char *indent,
 		if (streq(objsrc, "")
 		    && td->columns[i]->jsonname
 		    && !streq(td->columns[i]->dbname, td->columns[i]->jsonname)) {
-			origin = tal_fmt(tmpctx, ", from JSON field `%s`",
+			origin = tal_fmt(tmpctx, ", from JSON field `%s%s`",
+					 json_prefix(tmpctx, td),
 					 td->columns[i]->jsonname);
 		} else
 			origin = "";

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -534,7 +534,11 @@ static struct command_result *process_json_obj(struct command *cmd,
 			if (!col->sub->is_subobject)
 				continue;
 
-			coltok = json_get_member(buf, t, col->jsonname);
+			/* This can happen if the field is missing */
+			if (!t)
+				coltok = NULL;
+			else
+				coltok = json_get_member(buf, t, col->jsonname);
 			ret = process_json_obj(cmd, buf, coltok, col->sub, row, this_rowid,
 					       NULL, sqloff, stmt);
 			if (ret)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4393,3 +4393,23 @@ def test_autoclean_batch(node_factory):
     l1.rpc.setconfig('autoclean-cycle', 5)
     wait_for(lambda: l1.rpc.autoclean_status('expiredinvoices')
              == {'autoclean': {'expiredinvoices': {'enabled': True, 'cleaned': 200, 'age': 2}}})
+
+
+def test_sql_crash(node_factory, bitcoind):
+    """sub-object with inner-sub-object is missing -> Crash.  This only
+    happens for local and remote inside listpeerchannels.update (for
+    now).
+
+    """
+    l1, l2 = node_factory.line_graph(2, fundchannel=False)
+
+    addr = l1.rpc.newaddr()['bech32']
+    bitcoind.rpc.sendtoaddress(addr, 1)
+    bitcoind.generate_block(1)
+
+    wait_for(lambda: l1.rpc.listfunds()['outputs'] != [])
+
+    l1.rpc.fundchannel_start(l2.info['id'], '10000000sat')
+
+    assert 'updates' not in only_one(l1.rpc.listpeerchannels()['channels'])
+    l1.rpc.sql(f"SELECT * FROM peerchannels;")


### PR DESCRIPTION
Fixes a crash when there is a missing object which has subobjects (only happens in one place, listpeerchannels on unfinished channel which doesn't have an `updates` object yet).

Fixes: https://github.com/ElementsProject/lightning/issues/7505
