### PR TITLE
Fix: don't send anchorspends for onchain commitment txs

### DIFF
--- a/lightningd/anchorspend.c
+++ b/lightningd/anchorspend.c
@@ -270,7 +270,7 @@ static struct bitcoin_tx *spend_anchor(const tal_t *ctx,
 	struct amount_msat total_value;
 	const u8 *msg;
 
-	/* Estimate weight of spend tx plus commitment_tx (not including any UTXO we add) */
+	/* Estimate weight of anchorspend tx plus commitment_tx (not including any UTXO we add) */
 	base_weight = bitcoin_tx_core_weight(2, 1)
 		+ bitcoin_tx_input_weight(false,
 					  bitcoin_tx_input_sig_weight()

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -908,7 +908,7 @@ void channel_set_state(struct channel *channel,
 		       enum channel_state old_state,
 		       enum channel_state state,
 		       enum state_change reason,
-		       char *why)
+		       const char *why)
 {
 	bool was_important;
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -765,7 +765,7 @@ void channel_set_state(struct channel *channel,
 		       enum channel_state old_state,
 		       enum channel_state state,
 		       enum state_change reason,
-		       char *why);
+		       const char *why);
 
 const char *channel_change_state_reason_str(enum state_change reason);
 

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -752,6 +752,14 @@ void channel_fail_permanent(struct channel *channel,
 			    enum state_change reason,
 			    const char *fmt,
 			    ...);
+
+/* Channel has failed, give up on it, specifically because we saw this tx spend it. */
+void channel_fail_saw_onchain(struct channel *channel,
+			      enum state_change reason,
+			      const struct bitcoin_tx *tx,
+			      const char *fmt,
+			      ...);
+
 /* Forget the channel. This is only used for the case when we "receive" error
  * during CHANNELD_AWAITING_LOCKIN if we are "fundee". */
 void channel_fail_forget(struct channel *channel, const char *fmt, ...);

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -331,7 +331,7 @@ static void peer_closing_complete(struct channel *channel, const u8 *msg)
 			  "Closing complete");
 
 	/* Channel gets dropped to chain cooperatively. */
-	drop_to_chain(channel->peer->ld, channel, true, true /* rebroadcast */);
+	drop_to_chain(channel->peer->ld, channel, true, NULL);
 }
 
 static void peer_closing_notify(struct channel *channel, const u8 *msg)

--- a/lightningd/closing_control.c
+++ b/lightningd/closing_control.c
@@ -52,7 +52,7 @@ struct close_command {
 /* Resolve a single close command. */
 static void
 resolve_one_close_command(struct close_command *cc, bool cooperative,
-			  struct bitcoin_tx **close_txs)
+			  const struct bitcoin_tx **close_txs)
 {
 	assert(tal_count(close_txs));
 	struct json_stream *result = json_stream_success(cc->cmd);
@@ -107,7 +107,7 @@ const char *cmd_id_from_close_command(const tal_t *ctx,
 
 /* Resolve a close command for a channel that will be closed soon. */
 void resolve_close_command(struct lightningd *ld, struct channel *channel,
-			   bool cooperative, struct bitcoin_tx **close_txs)
+			   bool cooperative, const struct bitcoin_tx **close_txs)
 {
 	struct close_command *cc;
 	struct close_command *n;

--- a/lightningd/closing_control.h
+++ b/lightningd/closing_control.h
@@ -14,7 +14,7 @@ const char *cmd_id_from_close_command(const tal_t *ctx,
 
 /* Resolve a close command for a channel that will be closed soon. */
 void resolve_close_command(struct lightningd *ld, struct channel *channel,
-			   bool cooperative, struct bitcoin_tx **close_txs);
+			   bool cooperative, const struct bitcoin_tx **close_txs);
 
 void peer_start_closingd(struct channel *channel,
 			 struct peer_fd *peer_fd);

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -1708,8 +1708,9 @@ enum watch_result onchaind_funding_spent(struct channel *channel,
 	if (channel->closer != NUM_SIDES)
 		reason = REASON_UNKNOWN;  /* will use last cause as reason */
 
-	channel_fail_permanent(channel, reason,
-			       "Funding transaction spent");
+	channel_fail_saw_onchain(channel, reason,
+				 tx,
+				 "Funding transaction spent");
 
 	/* If we haven't posted the open event yet, post an open */
 	if (!channel->scid || !channel->remote_channel_ready) {

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -342,7 +342,7 @@ static void handle_onchain_log_coin_move(struct channel *channel, const u8 *msg)
 		return;
 	}
 
-	/* Any 'ignored' payments get registed to the wallet */
+	/* Any 'ignored' payments get registered to the wallet */
 	if (!mvt->account_name)
 		mvt->account_name = fmt_channel_id(mvt,
 						   &channel->cid);

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -394,7 +394,7 @@ void drop_to_chain(struct lightningd *ld, struct channel *channel,
 			    "Not dropping our unilateral close onchain since "
 			    "we already saw theirs confirm.");
 	} else {
-		struct bitcoin_tx **txs = tal_arr(tmpctx, struct bitcoin_tx*, 0);
+		const struct bitcoin_tx **txs = tal_arr(tmpctx, const struct bitcoin_tx*, 0);
 
 		/* We need to drop *every* commitment transaction to chain */
 		if (!cooperative && !list_empty(&channel->inflights)) {

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -113,16 +113,12 @@ void peer_set_dbid(struct peer *peer, u64 dbid);
 /* At startup, re-send any transactions we want bitcoind to have */
 void resend_closing_transactions(struct lightningd *ld);
 
-/**
- * Initiate the close of a channel.
- *
- * @param rebroadcast: Whether we should be broadcasting our
- *   commitment transaction in order to close the channel, or not.
- */
-void drop_to_chain(struct lightningd *ld,
-		   struct channel *channel,
+/* Initiate the close of a channel, maybe broadcast.  If we've seen a
+ * unilateral close, pass it here (means we don't need to broadcast
+ * our own, or any anchors). */
+void drop_to_chain(struct lightningd *ld, struct channel *channel,
 		   bool cooperative,
-		   bool rebroadcast);
+		   const struct bitcoin_tx *unilateral_tx);
 
 void update_channel_from_inflight(struct lightningd *ld,
 				  struct channel *channel,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -91,6 +91,13 @@ void channel_fail_permanent(struct channel *channel UNNEEDED,
 			    const char *fmt UNNEEDED,
 			    ...)
 { fprintf(stderr, "channel_fail_permanent called!\n"); abort(); }
+/* Generated stub for channel_fail_saw_onchain */
+void channel_fail_saw_onchain(struct channel *channel UNNEEDED,
+			      enum state_change reason UNNEEDED,
+			      const struct bitcoin_tx *tx UNNEEDED,
+			      const char *fmt UNNEEDED,
+			      ...)
+{ fprintf(stderr, "channel_fail_saw_onchain called!\n"); abort(); }
 /* Generated stub for channel_fail_transient */
 void channel_fail_transient(struct channel *channel UNNEEDED,
 			    bool disconnect UNNEEDED,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -927,7 +927,7 @@ void report_subd_memleak(struct leak_detect *leak_detect UNNEEDED, struct subd *
 { fprintf(stderr, "report_subd_memleak called!\n"); abort(); }
 /* Generated stub for resolve_close_command */
 void resolve_close_command(struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED,
-			   bool cooperative UNNEEDED, struct bitcoin_tx **close_txs UNNEEDED)
+			   bool cooperative UNNEEDED, const struct bitcoin_tx **close_txs UNNEEDED)
 { fprintf(stderr, "resolve_close_command called!\n"); abort(); }
 /* Generated stub for send_backtrace */
 void send_backtrace(const char *why UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -944,7 +944,7 @@ void report_subd_memleak(struct leak_detect *leak_detect UNNEEDED, struct subd *
 { fprintf(stderr, "report_subd_memleak called!\n"); abort(); }
 /* Generated stub for resolve_close_command */
 void resolve_close_command(struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED,
-			   bool cooperative UNNEEDED, struct bitcoin_tx **close_txs UNNEEDED)
+			   bool cooperative UNNEEDED, const struct bitcoin_tx **close_txs UNNEEDED)
 { fprintf(stderr, "resolve_close_command called!\n"); abort(); }
 /* Generated stub for rune_is_ours */
 const char *rune_is_ours(struct lightningd *ld UNNEEDED, const struct rune *rune UNNEEDED)


### PR DESCRIPTION
Ordering we were using for setting the channel state was causing us to send anchorspend transactions for onchain commitments.

This would occasionally show up in the CI as a flake, due to a race condition with onchaind adding commitment tx utxos that were then picked up in the anchorspend construction, which would fail due to bookkeeper assertions around spent/unspent utxos. (See #7526)

Also includes a fix to not include currently CSV locked outputs in the construction of anchorspends.

Fixes #7526

