### PR TITLE
lightningd: fix another trivial memleak when running installed version.

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -554,7 +554,7 @@ static void find_subdaemons_and_plugins(struct lightningd *ld, const char *argv0
 		prefix = "";
 	ld->subdaemon_dir = tal_fmt(ld, "%s%s", prefix, PKGLIBEXECDIR);
 	plugins_set_builtin_plugins_dir(ld->plugins,
-					tal_fmt(ld->plugins, "%s%s", prefix, PLUGINDIR));
+					tal_fmt(tmpctx, "%s%s", prefix, PLUGINDIR));
 }
 
 /*~ We like to free everything on exit, so valgrind doesn't complain (valgrind


### PR DESCRIPTION
```
**BROKEN** lightningd: MEMLEAK: 0x55ff8e8ec268
**BROKEN** lightningd:   label=char[]
**BROKEN** lightningd:   alloc:
**BROKEN** lightningd:     ccan/ccan/tal/tal.c:488 (tal_alloc_)
**BROKEN** lightningd:     ccan/ccan/tal/tal.c:517 (tal_alloc_arr_)
**BROKEN** lightningd:     ccan/ccan/tal/str/str.c:81 (tal_vfmt_)
**BROKEN** lightningd:     ccan/ccan/tal/str/str.c:37 (tal_fmt_)
**BROKEN** lightningd:     lightningd/lightningd.c:557 (find_subdaemons_and_plugins)
**BROKEN** lightningd:     lightningd/lightningd.c:1196 (main)
**BROKEN** lightningd:   parents:
**BROKEN** lightningd:     struct plugins
```

Changelog-None: Introduced this release.
Fixes: https://github.com/ElementsProject/lightning/issues/7590
