### PR TITLE
Add strict-forwarding option

### DIFF
--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -151,6 +151,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_hsmd_no_preapprove_check = false;
 	ld->dev_hsmd_fail_preapprove = false;
 	ld->dev_handshake_no_reply = false;
+	ld->dev_strict_forwarding = false;
 
 	/*~ We try to ensure enough fds for twice the number of channels
 	 * we start with.  We have a developer option to change that factor

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -362,6 +362,10 @@ struct lightningd {
 	/* Tell connectd not to talk after handshake */
 	bool dev_handshake_no_reply;
 
+	/* Remove the freedom to choose select between parallel channels to
+	 * forward a payment. */
+	bool dev_strict_forwarding;
+
 	/* tor support */
 	struct wireaddr *proxyaddr;
 	bool always_use_proxy;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -956,6 +956,10 @@ static void dev_register_opts(struct lightningd *ld)
 		     opt_set_bool,
 		     &ld->dev_handshake_no_reply,
 		     "Don't send or read init message after connection");
+	clnopt_noarg("--dev-strict-forwarding", OPT_DEV,
+		     opt_set_bool,
+		     &ld->dev_strict_forwarding,
+		     "Forward HTLCs along the channel specified");
 	clnopt_noarg("--dev-throttle-gossip", OPT_DEV,
 		     opt_set_bool,
 		     &ld->dev_throttle_gossip,

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1288,7 +1288,11 @@ static struct channel_id *calc_forwarding_channel(struct lightningd *ld,
 		c = NULL;
 	}
 
-	best = best_channel(ld, peer, p->amt_to_forward, c);
+	if (!ld->dev_strict_forwarding)
+		best = best_channel(ld, peer, p->amt_to_forward, c);
+	else
+		best = c;
+
 	if (!c) {
 		if (!best)
 			return NULL;


### PR DESCRIPTION
# Add strict forwarding option

## Description

When receiving a forward request lightningd selects the best channel with
the next peer based on its ability to add an HTLC and its spendable amount.
If two forwarding request arrive at the same time pointing to the same
peer we can have a race condition in which both HTLCs compete
concurrently for the same spendable amount.

There shouldn't be a race condition if both requests are supposed to be
allocated on different parallel channels. However, non-strict forwarding is allowed
in the protocol and it is reasonable that node operators can decide which channel
to use when forwarding to a peer.

Therefore we add configuration option `dev-strict-forwarding` default to false,
to enforce strict forwarding. With that flag we no longer need to skip  parallel channel
tests in renepay (9d88ce3).


## Related Issues

- Closes #7605

## Changes Made
- [x] **Feature**: the ability to turn off non-strict forwarding as a configuration option.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes

This is not a solution to the race condition, it only avoids it by removing the freedom to choose the forward channel.
