### PR TITLE
lightningd: bulk query state changes and stats

### DIFF
--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -130,6 +130,12 @@ const char *channel_state_name(const struct channel *channel UNNEEDED)
 /* Generated stub for channel_state_str */
 const char *channel_state_str(enum channel_state state UNNEEDED)
 { fprintf(stderr, "channel_state_str called!\n"); abort(); }
+/* Generated stub for channel_stats_eq */
+bool channel_stats_eq(const struct channel_stats_list *a UNNEEDED, const u64 *b UNNEEDED)
+{ fprintf(stderr, "channel_stats_eq called!\n"); abort(); }
+/* Generated stub for channel_stats_hash */
+size_t channel_stats_hash(const u64 *out UNNEEDED)
+{ fprintf(stderr, "channel_stats_hash called!\n"); abort(); }
 /* Generated stub for channel_type_has */
 bool channel_type_has(const struct channel_type *type UNNEEDED, int feature UNNEEDED)
 { fprintf(stderr, "channel_type_has called!\n"); abort(); }
@@ -931,6 +937,12 @@ bool shachain_get_secret(const struct shachain *shachain UNNEEDED,
 void start_leak_request(const struct subd_req *req UNNEEDED,
 			struct leak_detect *leak_detect UNNEEDED)
 { fprintf(stderr, "start_leak_request called!\n"); abort(); }
+/* Generated stub for state_change_list_eq */
+bool state_change_list_eq(const struct state_change_list *a UNNEEDED, const u64 *b UNNEEDED)
+{ fprintf(stderr, "state_change_list_eq called!\n"); abort(); }
+/* Generated stub for state_change_list_hash */
+size_t state_change_list_hash(const u64 *out UNNEEDED)
+{ fprintf(stderr, "state_change_list_hash called!\n"); abort(); }
 /* Generated stub for subd_req_ */
 struct subd_req *subd_req_(const tal_t *ctx UNNEEDED,
 	       struct subd *sd UNNEEDED,
@@ -1023,9 +1035,13 @@ const char *version(void)
 /* Generated stub for wallet_channel_save */
 void wallet_channel_save(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED)
 { fprintf(stderr, "wallet_channel_save called!\n"); abort(); }
-/* Generated stub for wallet_channel_stats_load */
-void wallet_channel_stats_load(struct wallet *w UNNEEDED, u64 cdbid UNNEEDED, struct channel_stats *stats UNNEEDED)
-{ fprintf(stderr, "wallet_channel_stats_load called!\n"); abort(); }
+/* Generated stub for wallet_channel_stats_get */
+struct channel_stats_map *wallet_channel_stats_get(struct wallet *w UNNEEDED)
+{ fprintf(stderr, "wallet_channel_stats_get called!\n"); abort(); }
+/* Generated stub for wallet_channel_stats_peer_get */
+struct channel_stats_map *wallet_channel_stats_peer_get(struct wallet *w UNNEEDED,
+			       			    u64 peer_id UNNEEDED)
+{ fprintf(stderr, "wallet_channel_stats_peer_get called!\n"); abort(); }
 /* Generated stub for wallet_channeltxs_add */
 void wallet_channeltxs_add(struct wallet *w UNNEEDED, struct channel *chan UNNEEDED,
 			    const int type UNNEEDED, const struct bitcoin_txid *txid UNNEEDED,
@@ -1062,11 +1078,15 @@ char *wallet_offer_find(const tal_t *ctx UNNEEDED,
 			enum offer_status *status)
 
 { fprintf(stderr, "wallet_offer_find called!\n"); abort(); }
-/* Generated stub for wallet_state_change_get */
-struct state_change_entry *wallet_state_change_get(const tal_t *ctx UNNEEDED,
-						   struct wallet *w UNNEEDED,
-						   u64 channel_id UNNEEDED)
-{ fprintf(stderr, "wallet_state_change_get called!\n"); abort(); }
+/* Generated stub for wallet_state_changes_get */
+struct channel_state_change_map *wallet_state_changes_get(const tal_t *ctx UNNEEDED,
+					  		  struct wallet *w UNNEEDED)
+{ fprintf(stderr, "wallet_state_changes_get called!\n"); abort(); }
+/* Generated stub for wallet_state_changes_peer_get */
+struct channel_state_change_map *wallet_state_changes_peer_get(const tal_t *ctx UNNEEDED,
+							       struct wallet *w UNNEEDED,
+							       u64 peer_id UNNEEDED)
+{ fprintf(stderr, "wallet_state_changes_peer_get called!\n"); abort(); }
 /* Generated stub for wallet_total_forward_fees */
 struct amount_msat wallet_total_forward_fees(struct wallet *w UNNEEDED)
 { fprintf(stderr, "wallet_total_forward_fees called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1002,7 +1002,7 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 u8 *towire_announcement_signatures(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, struct short_channel_id short_channel_id UNNEEDED, const secp256k1_ecdsa_signature *node_signature UNNEEDED, const secp256k1_ecdsa_signature *bitcoin_signature UNNEEDED)
 { fprintf(stderr, "towire_announcement_signatures called!\n"); abort(); }
 /* Generated stub for towire_channel_reestablish */
-u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *tlvs UNNEEDED)
+u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *channel_reestablish UNNEEDED)
 { fprintf(stderr, "towire_channel_reestablish called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -670,13 +670,24 @@ void wallet_state_change_add(struct wallet *w,
 			     enum state_change cause,
 			     const char *message);
 
-/**
- * Gets all state change history entries for a channel from the database
- */
-struct state_change_entry *wallet_state_change_get(const tal_t *ctx,
-						   struct wallet *w,
-						   u64 channel_id);
+struct state_change_list {
+	u64 channel_id;
+	struct state_change_entry *entries;
+};
 
+size_t state_change_list_hash(const u64 *out);
+const u64 *state_change_list_keyof(const struct state_change_list *out);
+bool state_change_list_eq(const struct state_change_list *a, const u64 *b);
+
+HTABLE_DEFINE_TYPE(struct state_change_list, state_change_list_keyof,
+		   state_change_list_hash,  state_change_list_eq,
+		   channel_state_change_map);
+
+struct channel_state_change_map *wallet_state_changes_peer_get(const tal_t *ctx,
+							       struct wallet *w,
+							       u64 peer_id);
+struct channel_state_change_map *wallet_state_changes_get(const tal_t *ctx,
+					  		  struct wallet *w);
 /**
  * wallet_delete_peer_if_unused -- After no more channels in peer, forget about it
  */
@@ -723,6 +734,20 @@ void wallet_channel_stats_incr_out_fulfilled(struct wallet *w, u64 cdbid, struct
  * @stats: location to load statistics to
  */
 void wallet_channel_stats_load(struct wallet *w, u64 cdbid, struct channel_stats *stats);
+
+struct channel_stats_list {
+	u64 channel_id;
+	struct channel_stats *stats;
+};
+size_t channel_stats_hash(const u64 *out);
+const u64 *channel_stats_keyof(const struct channel_stats_list *out);
+bool channel_stats_eq(const struct channel_stats_list *a, const u64 *b);
+HTABLE_DEFINE_TYPE(struct channel_stats_list, channel_stats_keyof,
+		   channel_stats_hash, channel_stats_eq, channel_stats_map);
+
+struct channel_stats_map *wallet_channel_stats_peer_get(struct wallet *w,
+			       			    u64 peer_id);
+struct channel_stats_map *wallet_channel_stats_get(struct wallet *w);
 
 /**
  * Retrieve the blockheight of the last block processed by lightningd.


### PR DESCRIPTION
# listpeerchannels: bulk query state changes and stats

## Description
State changes were fetched from the database in `listpeerchannels` sequentially for every channel. The performance overhead for large nodes was very high. This commit loads state changes once at the start of the listpeerchannels call, then passes the appropriate state changes to the underlying function that maps into json.

## Changes Made
- [ ] **Feature**: Brief description of the new feature or functionality added.
- [ ] **Bug Fix**: Brief description of the bug fixed and how it was resolved.
- [x] **Refactor**: Any code improvements or refactoring done without changing the functionality.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes
This PR comes from a trace of a slow `pay` call on a node with many channels. 
