### PR TITLE
script: Updating SHASUMS for updated zlib1g-dev in Ubuntu Noble

### DIFF
--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -135,7 +135,7 @@ f11b4d687a305dd7ee47a384d82a9bf04de913362df9efa67d2a029ae65051a9  /var/cache/apt
 d23577c43936fedd8c4fa1337a6e960a6e71e94ac164d7a15c46ea96bf21265d  /var/cache/apt/archives/libsqlite3-dev_3.45.1-1ubuntu2_amd64.deb
 9d1d707179675d38e024bb13613b1d99e0d33fa6c45e5f3bcba19340781781d3  /var/cache/apt/archives/libtool_2.4.7-7build1_all.deb
 1fe6a815b56c7b6e9ce4086a363f09444bbd0a0d30e230c453d0b78e44b57a99  /var/cache/apt/archives/make_4.3-4.1build2_amd64.deb
-7360405fbf49e35dca2f7a4ebeac7d4fe5fe3b2db99adac70e11e104f53b2642  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg-3.1ubuntu2_amd64.deb
+023cbe9dbf0af87f10e54e342c67571874e412b9950d89c6cd7b010be2e67c3c  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg-3.1ubuntu2.1_amd64.deb
 EOF
 	;;
     *)


### PR DESCRIPTION
> ### ⚠️ **IMPORTANT:**
> **Feature freeze date for v24.08 is _Aug 5th_.**
>
> **RC1 is scheduled on _Aug 10th_, RC2 on _Aug 15_, ...**
>
> **The final release is on _Aug 22nd_.**

### Issue:
Since we added support for Ubuntu 24.04, it was installing `zlib1g-dev` version `1:1.3.dfsg-3.1ubuntu2`. However zlib released minor update version `1:1.3.dfsg-3.1ubuntu2.1` on Aug 9th.

```
zlib (1:1.3.dfsg-3.1ubuntu2.1) noble-proposed; urgency=medium

  * SRU: LP: #2076340: No-change rebuild to pick up changed build flags
    on ppc64 and s390x.
```

Which changed SHASUMS for our noble repro-build.sh and broke the build-release process. 

### Solution:
1: Either we can update the script with the latest zlib1g-dev SHASUMS Or
2: Lock the zlib1g-dev version to `1:1.3.dfsg-3.1ubuntu2`.

For now, I am updating the SHASUMS & version but we can re-consider locking it if the issue keeps repeating in future CLN releases (due to frequent zlib minor version updates).

Changelog-Fixed: core lightning's reproducible build for Ubuntu v24.04 (noble).