### PR TITLE
Log if builtin plugin fails to start

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2536,14 +2536,19 @@ void plugins_set_builtin_plugins_dir(struct plugins *plugins,
 				     const char *dir)
 {
 	/*~ Load the builtin plugins as important.  */
-	for (size_t i = 0; list_of_builtin_plugins[i]; ++i)
-		plugin_register(plugins,
-				take(path_join(NULL, dir,
-					       list_of_builtin_plugins[i])),
-				NULL,
-				/* important = */
-				!streq(list_of_builtin_plugins[i], "cln-renepay"),
-				NULL, NULL);
+	for (size_t i = 0; list_of_builtin_plugins[i]; ++i) {
+		struct plugin *p = plugin_register(
+		    plugins,
+		    take(path_join(NULL, dir, list_of_builtin_plugins[i])),
+		    NULL,
+		    /* important = */
+		    !streq(list_of_builtin_plugins[i], "cln-renepay"), NULL,
+		    NULL);
+		if (!p)
+			log_unusual(
+			    plugins->log, "failed to register plugin %s",
+			    path_join(tmpctx, dir, list_of_builtin_plugins[i]));
+	}
 }
 
 void shutdown_plugins(struct lightningd *ld)


### PR DESCRIPTION
# Log if builtin plugin fails to start

## Description

Lightningd should log if a builtin plugin fails to start instead of silently skip over it.

## Related Issues

This would allow to debug situations like #7595.

## Changes Made
- [x] **Feature**: Just add a log when lightningd starts.
- [ ] **Bug Fix**: Brief description of the bug fixed and how it was resolved.
- [ ] **Refactor**: Any code improvements or refactoring done without changing the functionality.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [ ] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes

