### PR TITLE
lightningd: fix up installs in subdirectories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ CPATH := /usr/local/include
 LIBRARY_PATH := /usr/local/lib
 endif
 
-CPPFLAGS += -DCLN_NEXT_VERSION="\"$(CLN_NEXT_VERSION)\"" -DPKGLIBEXECDIR="\"$(pkglibexecdir)\"" -DPLUGINDIR="\"$(plugindir)\"" -DCCAN_TAL_NEVER_RETURN_NULL=1
+CPPFLAGS += -DCLN_NEXT_VERSION="\"$(CLN_NEXT_VERSION)\"" -DPKGLIBEXECDIR="\"$(pkglibexecdir)\"" -DBINDIR="\"$(bindir)\"" -DPLUGINDIR="\"$(plugindir)\"" -DCCAN_TAL_NEVER_RETURN_NULL=1
 CFLAGS = $(CPPFLAGS) $(CWARNFLAGS) $(CDEBUGFLAGS) $(COPTFLAGS) -I $(CCANDIR) $(EXTERNAL_INCLUDE_FLAGS) -I . -I$(CPATH) $(SQLITE3_CFLAGS) $(POSTGRES_INCLUDE) $(FEATURES) $(COVFLAGS) $(DEV_CFLAGS) -DSHACHAIN_BITS=48 -DJSMN_PARENT_LINKS $(PIE_CFLAGS) $(COMPAT_CFLAGS) $(CSANFLAGS)
 
 # If CFLAGS is already set in the environment of make (to whatever value, it
@@ -886,7 +886,7 @@ uninstall:
 installcheck: all-programs
 	@rm -rf testinstall || true
 	$(MAKE) DESTDIR=$$(pwd)/testinstall install
-	DEV_LIGHTNINGD_DESTDIR_PREFIX=$$(pwd)/testinstall/ testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
+	testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
 	$(MAKE) DESTDIR=$$(pwd)/testinstall uninstall
 	@if test `find testinstall '!' -type d | wc -l` -ne 0; then \
 		echo 'make uninstall left some files in testinstall directory!'; \


### PR DESCRIPTION
Commit a1fdeee76b "Makefile: clean up install path handling." broke the ability to configure with one path and then run in a different path.  Turns out people actually do this!  So, we have to use relative paths, compared to our existing binary.

Fixes: https://github.com/ElementsProject/lightning/issues/7595

> ### ⚠️ **IMPORTANT:**
> **Feature freeze date for v24.08 is _Aug 5th_.**
>
> **RC1 is scheduled on _Aug 10th_, RC2 on _Aug 15_, ...**
>
> **The final release is on _Aug 22nd_.**


# Pull Request Title

## Description
Please provide a brief summary of the changes made in this PR. What does it do, and why is it necessary?

## Related Issues
List any related issues, bugs, or feature requests that are being addressed by this PR. Link them using GitHub's closing syntax (e.g., `Closes #123`).

- Closes #issue_number

## Changes Made
- [ ] **Feature**: Brief description of the new feature or functionality added.
- [ ] **Bug Fix**: Brief description of the bug fixed and how it was resolved.
- [ ] **Refactor**: Any code improvements or refactoring done without changing the functionality.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [ ] Changelog has been added in relevant commit/s.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated as needed.
- [ ] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes
Any additional information or context about this PR that reviewers should know.
