### PR TITLE
libplugin-pay: use map for channel hints

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2909,18 +2909,17 @@ static bool routehint_excluded(struct payment *p,
 		 * channel, which is greater than the destination.
 		 */
 		struct channel_hint *hint;
-		struct channel_hint_map_iter iter;
-		for (hint = channel_hint_map_first(hints, &iter);
-		     hint;
-		     hint = channel_hint_map_next(hints, &iter)) {
-			if (!short_channel_id_eq(hint->scid.scid, r->short_channel_id))
-				continue;
-			/* We exclude on equality because we set the estimate
-			 * to the smallest failed attempt.  */
-			if (amount_msat_greater_eq(needed_capacity,
+		struct short_channel_id_dir scidd;
+		scidd.scid = r->short_channel_id;
+		scidd.dir = node_id_cmp(&routehint->pubkey,
+					p->pay_destination) > 0 ? 1 : 0;
+
+		hint = channel_hint_map_get(hints, &scidd);
+		/* We exclude on equality because we set the estimate
+		* to the smallest failed attempt.  */
+		if (hint && amount_msat_greater_eq(needed_capacity,
 						   hint->estimated_capacity))
-				return true;
-		}
+			return true;
 	}
 	return false;
 }

--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -172,6 +172,16 @@ struct payment_constraints {
 	u32 cltv_budget;
 };
 
+size_t channel_hint_hash(const struct short_channel_id_dir *out);
+
+const struct short_channel_id_dir *channel_hint_keyof(const struct channel_hint *out);
+
+bool channel_hint_eq(const struct channel_hint *a,
+		     const struct short_channel_id_dir *b);
+
+HTABLE_DEFINE_TYPE(struct channel_hint, channel_hint_keyof,
+	channel_hint_hash, channel_hint_eq, channel_hint_map)
+
 struct payment {
 	/* Usually in global payments list */
 	struct list_node list;
@@ -268,9 +278,9 @@ struct payment {
 	struct route_info **routes;
 	const u8 *features;
 
-	/* tal_arr of channel_hints we incrementally learn while performing
-	 * payment attempts. */
-	struct channel_hint *channel_hints;
+	/* htable of channel_hints we incrementally learn while performing
+	 * payment attempts, indexed by scid and direction. */
+	struct channel_hint_map *channel_hints;
 	struct node_id *excluded_nodes;
 
 	/* Optional temporarily excluded channels/nodes (i.e. this routehint) */

--- a/plugins/test/run-route-calc.c
+++ b/plugins/test/run-route-calc.c
@@ -259,6 +259,12 @@ struct json_stream *jsonrpc_stream_fail(struct command *cmd UNNEEDED,
 /* Generated stub for jsonrpc_stream_success */
 struct json_stream *jsonrpc_stream_success(struct command *cmd UNNEEDED)
 { fprintf(stderr, "jsonrpc_stream_success called!\n"); abort(); }
+/* Generated stub for memleak_add_helper_ */
+void memleak_add_helper_(const tal_t *p UNNEEDED, void (*cb)(struct htable *memtable UNNEEDED,
+						    const tal_t *)){ }
+/* Generated stub for memleak_scan_htable */
+void memleak_scan_htable(struct htable *memtable UNNEEDED, const struct htable *ht UNNEEDED)
+{ fprintf(stderr, "memleak_scan_htable called!\n"); abort(); }
 /* Generated stub for notleak_ */
 void *notleak_(void *ptr UNNEEDED, bool plus_children UNNEEDED)
 { fprintf(stderr, "notleak_ called!\n"); abort(); }

--- a/plugins/test/run-route-overlong.c
+++ b/plugins/test/run-route-overlong.c
@@ -256,6 +256,12 @@ struct json_stream *jsonrpc_stream_fail(struct command *cmd UNNEEDED,
 /* Generated stub for jsonrpc_stream_success */
 struct json_stream *jsonrpc_stream_success(struct command *cmd UNNEEDED)
 { fprintf(stderr, "jsonrpc_stream_success called!\n"); abort(); }
+/* Generated stub for memleak_add_helper_ */
+void memleak_add_helper_(const tal_t *p UNNEEDED, void (*cb)(struct htable *memtable UNNEEDED,
+						    const tal_t *)){ }
+/* Generated stub for memleak_scan_htable */
+void memleak_scan_htable(struct htable *memtable UNNEEDED, const struct htable *ht UNNEEDED)
+{ fprintf(stderr, "memleak_scan_htable called!\n"); abort(); }
 /* Generated stub for notleak_ */
 void *notleak_(void *ptr UNNEEDED, bool plus_children UNNEEDED)
 { fprintf(stderr, "notleak_ called!\n"); abort(); }


### PR DESCRIPTION
# libplugin-pay: use map for channel hints

## Description
This commit fixes a "FIXME: This is slow" in the pay plugin. For nodes with many channels this is a tremendous improvement in pay performance. PR #7611 improves payment performance from 15 seconds to 13.5 seconds on one of our nodes. This commit improves payment performance from 13.5 seconds to 5.7 seconds.

## Changes Made
- [ ] **Feature**: Brief description of the new feature or functionality added.
- [ ] **Bug Fix**: Brief description of the bug fixed and how it was resolved.
- [x] **Refactor**: Any code improvements or refactoring done without changing the functionality.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.
