### PR TITLE
askrene: fixup fee and delay computation

### DIFF
--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -439,6 +439,8 @@ static const char *get_routes(const tal_t *ctx,
 			struct gossmap_node *far_end;
 			const struct half_chan *h = flow_edge(flows[i], j);
 
+			rh->amount = msat;
+			rh->delay = delay;
 			if (!amount_msat_add_fee(&msat, h->base_fee, h->proportional_fee))
 				plugin_err(plugin, "Adding fee to amount");
 			delay += h->delay;
@@ -447,8 +449,6 @@ static const char *get_routes(const tal_t *ctx,
 			rh->direction = flows[i]->dirs[j];
 			far_end = gossmap_nth_node(rq->gossmap, flows[i]->path[j], !flows[i]->dirs[j]);
 			gossmap_node_get_id(rq->gossmap, far_end, &rh->node_id);
-			rh->amount = msat;
-			rh->delay = delay;
 		}
 		(*amounts)[i] = flows[i]->delivers;
 	}


### PR DESCRIPTION
# Askrene fixup fee and delay computation

## Description

Sendpay's API expects a route description where the i-th hop contains an amount corresponding to "The amount expected by the node at the end of this hop" and a delay field corresponding to "The total CLTV expected by the node at the end of this hop".
That means the final amount and the final cltv is what is expected in the last hop and we compute backwards from there
the amounts and delays for the rest of the hops.

Eg. the chain of nodes
N1 ---> N2 ---> N3 ---> N4

where
N1-->N2 are connected by channel c12 with zero proportional fee and 3 base fee, delay 6
N2-->N3 are connected by channel c23 with zero proportional fee and 10 base fee, delay 6
N3-->N4 are connected by channel c34 with zero base fee and 2 ppm proportional fee, delay 6

If we want to send x=1e6 msat with final CLTV=10, sendpay expects
[{channel: c12, node: N2, delay: 22, amount: 1000012msat},
 {channel: c23, node: N3, delay: 16, amount: 1000002msat},
 {channel: c34, node: N4, delay: 10, amount: 1000000msat}]