### PR TITLE
exposesecret: a way to back up the hsm_secret via rpc (if enabled!)

### DIFF
--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
 CCAN imported from http://ccodearchive.net.
 
-CCAN version: init-2587-gf927e4be
+CCAN version: init-2589-g161fe383

--- a/ccan/ccan/opt/opt.h
+++ b/ccan/ccan/opt/opt.h
@@ -530,7 +530,7 @@ struct opt_table *opt_find_short(char arg);
  * You can set bits in type e.g. (1<<OPT_USER_START) to (1<<OPT_USER_END)
  * when calling _opt_register. */
 #define OPT_USER_START 8
-#define OPT_USER_END 15
+#define OPT_USER_END 30
 
 /* Below here are private declarations. */
 /* You can use this directly to build tables, but the macros will ensure
@@ -540,7 +540,7 @@ enum opt_type {
 	OPT_HASARG = 2,		/* -f arg|--foo=arg|--foo arg */
 	OPT_SUBTABLE = 4,	/* Actually, longopt points to a subtable... */
 	OPT_EARLY = 8,		/* Parse this from opt_early_parse() only. */
-	OPT_END = 16,		/* End of the table. */
+	OPT_END = 31,		/* End of the table. */
 
 	/* Make sure no compiler will assume we never have large
 	 * values in the enum! */

--- a/ccan/ccan/tcon/tcon.h
+++ b/ccan/ccan/tcon/tcon.h
@@ -147,7 +147,7 @@
  * It evaluates to @x so you can chain it.
  */
 #define tcon_check_ptr(x, canary, expr)				\
-	(sizeof((expr) ? (expr) : &(x)->_tcon[0].canary) ? (x) : (x))
+	(sizeof(0 ? (expr) : &(x)->_tcon[0].canary) ? (x) : (x))
 
 /**
  * tcon_type - the type within a container (or void *)

--- a/common/configvar.h
+++ b/common/configvar.h
@@ -62,6 +62,8 @@ struct configvar {
 #define OPT_DYNAMIC (1 << (OPT_USER_START+6))
 /* Keep whitespace at the end of the option argument */
 #define OPT_KEEP_WHITESPACE (1 << (OPT_USER_START+7))
+/* Don't show value in listconfigs */
+#define OPT_CONCEAL (1 << (OPT_USER_START+8))
 
 /* Use this instead of opt_register_*_arg if you want OPT_* from above */
 #define clnopt_witharg(names, type, cb, show, arg, desc)		\

--- a/common/hsm_encryption.c
+++ b/common/hsm_encryption.c
@@ -7,22 +7,25 @@
 #include <unistd.h>
 
 int hsm_secret_encryption_key_with_exitcode(const char *pass, struct secret *key,
-					      char **err_msg)
+					    const char **err_msg)
 {
 	u8 salt[16] = "c-lightning\0\0\0\0\0";
 
 	/* Don't swap the encryption key ! */
 	if (sodium_mlock(key->data, sizeof(key->data)) != 0) {
-		*err_msg = "Could not lock hsm_secret encryption key memory.";
+		if (err_msg)
+			*err_msg = "Could not lock hsm_secret encryption key memory.";
 		return EXITCODE_HSM_GENERIC_ERROR;
 	}
 
 	/* Check bounds. */
 	if (strlen(pass) < crypto_pwhash_argon2id_PASSWD_MIN) {
-		*err_msg = "Password too short to be able to derive a key from it.";
+		if (err_msg)
+			*err_msg = "Password too short to be able to derive a key from it.";
 		return EXITCODE_HSM_BAD_PASSWORD;
 	} else if (strlen(pass) > crypto_pwhash_argon2id_PASSWD_MAX) {
-		*err_msg = "Password too long to be able to derive a key from it.";
+		if (err_msg)
+			*err_msg = "Password too long to be able to derive a key from it.";
 		return EXITCODE_HSM_BAD_PASSWORD;
 	}
 
@@ -33,7 +36,8 @@ int hsm_secret_encryption_key_with_exitcode(const char *pass, struct secret *key
 			  crypto_pwhash_argon2id_OPSLIMIT_MODERATE,
 			  crypto_pwhash_argon2id_MEMLIMIT_MODERATE,
 			  crypto_pwhash_ALG_ARGON2ID13) != 0) {
-		*err_msg = "Could not derive a key from the password.";
+		if (err_msg)
+			*err_msg = "Could not derive a key from the password.";
 		return EXITCODE_HSM_BAD_PASSWORD;
 	}
 
@@ -112,7 +116,7 @@ static bool getline_stdin_pass(char **passwd, size_t *passwd_size)
 	return true;
 }
 
-char *read_stdin_pass_with_exit_code(char **reason, int *exit_code)
+char *read_stdin_pass_with_exit_code(const char **reason, int *exit_code)
 {
 	struct termios current_term, temp_term;
 	char *passwd = NULL;

--- a/common/hsm_encryption.h
+++ b/common/hsm_encryption.h
@@ -27,7 +27,7 @@ struct encrypted_hsm_secret {
  * On success, 0 is returned, on error a value > 0 is returned and it can be used as exit code.
  */
 int hsm_secret_encryption_key_with_exitcode(const char *pass, struct secret *key,
-					    char **err_msg);
+					    const char **err_msg);
 
 /** Encrypt the hsm_secret using a previously derived encryption key.
  * @encryption_key: the key derived from the passphrase.
@@ -62,7 +62,7 @@ void discard_key(struct secret *key TAKES);
  *
  * Caller must free the string as it does tal-reallocate getline's output.
  */
-char *read_stdin_pass_with_exit_code(char **reason, int *exit_code);
+char *read_stdin_pass_with_exit_code(const char **reason, int *exit_code);
 
 /** Returns -1 on error (and sets errno), 0 if not encrypted, 1 if it is */
 int is_hsm_secret_encrypted(const char *path);

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -11045,6 +11045,64 @@
         }
       ]
     },
+    "lightning-exposesecret.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "exposesecret",
+      "title": "Command for extracting the hsm_secret file for backup",
+      "description": [
+        "The **exposesecret** RPC command allows you to read the HSM secret, and does not work with encrypted hsm secrets.  It only operates if the `exposesecret-passphrase` has been set in the configuration."
+      ],
+      "request": {
+        "required": [
+          "passphrase"
+        ],
+        "properties": {
+          "passphrase": {
+            "type": "string",
+            "description": [
+              "The passphrase, which must match the `exposesecret-passphrase` configuration parameter."
+            ]
+          },
+          "identifier": {
+            "type": "string",
+            "description": [
+              "A four-character, valid lowercase bech32 string (not 1, i, o or b) to use in the resulting BIP-93 output.  If not specified, this is generated from the node alias."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "identifier",
+          "codex32"
+        ],
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "description": [
+              "The four-character identifier used in the codex32 output.  Redundant, but presented separately for clarity."
+            ]
+          },
+          "codex32": {
+            "type": "string",
+            "description": [
+              "The full codex32-encoded (i.e. BIP-93 encoded) HSM secret."
+            ]
+          }
+        }
+      },
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "see_also": [
+        "lightning-hsmtool(8)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ]
+    },
     "lightning-feerates.json": {
       "$schema": "../rpc-schema-draft.json",
       "type": "object",

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,6 +48,7 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-disableoffer.7 \
 	doc/lightning-disconnect.7 \
 	doc/lightning-emergencyrecover.7 \
+	doc/lightning-exposesecret.7 \
 	doc/lightning-feerates.7 \
 	doc/lightning-fetchinvoice.7 \
 	doc/lightning-fundchannel_cancel.7 \

--- a/doc/developers-guide/plugin-development/a-day-in-the-life-of-a-plugin.md
+++ b/doc/developers-guide/plugin-development/a-day-in-the-life-of-a-plugin.md
@@ -124,10 +124,11 @@ Plugins are free to register any `name` for their `rpcmethod` as long as the nam
 
 There are currently four supported option 'types':
 
-- string: a string
-- bool: a boolean
-- int: parsed as a signed integer (64-bit)
-- flag: no-arg flag option. Presented as `true` if config specifies it.
+- `string`: a string
+- `string-conceal`: a string which will appear as "..." in `listconfigs`.
+- `bool`: a boolean
+- `int`: parsed as a signed integer (64-bit)
+- `flag`: no-arg flag option. Presented as `true` if config specifies it.
 
 In addition, string and int types can specify `"multi": true` to indicate they can be specified multiple times.  These will always be represented in `init` as a (possibly empty) JSON array. "multi" flag types do not make  
 sense.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -57,6 +57,7 @@ Core Lightning Documentation
    lightning-disableoffer <lightning-disableoffer.7.md>
    lightning-disconnect <lightning-disconnect.7.md>
    lightning-emergencyrecover <lightning-emergencyrecover.7.md>
+   lightning-exposesecret <lightning-exposesecret.7.md>
    lightning-feerates <lightning-feerates.7.md>
    lightning-fetchinvoice <lightning-fetchinvoice.7.md>
    lightning-fundchannel <lightning-fundchannel.7.md>

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -697,6 +697,11 @@ authenticate to the Tor control port.
 
   Defines the path for WSS cert & key. Default path is same as RPC file path to utilize gRPC/clnrest's client certificate. If it is missing at the configured location, new identity (`client.pem` and `client-key.pem`) will be generated.
 
+* **exposesecret-passphrase**=*passphrase*  [plugin `exposesecret`]
+
+  Defines a passphrase which will let users extract the `hsm_secret` using the `exposesecret` command.  If this is not set, the `exposesecret` command always fails.
+
+
 ### Lightning Plugins
 
 lightningd(8) supports plugins, which offer additional configuration

--- a/doc/schemas/lightning-exposesecret.json
+++ b/doc/schemas/lightning-exposesecret.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "exposesecret",
+  "title": "Command for extracting the hsm_secret file for backup",
+  "description": [
+    "The **exposesecret** RPC command allows you to read the HSM secret, and does not work with encrypted hsm secrets.  It only operates if the `exposesecret-passphrase` has been set in the configuration."
+  ],
+  "request": {
+    "required": [
+      "passphrase"
+    ],
+    "properties": {
+      "passphrase": {
+        "type": "string",
+        "description": [
+          "The passphrase, which must match the `exposesecret-passphrase` configuration parameter."
+        ]
+      },
+      "identifier": {
+        "type": "string",
+        "description": [
+          "A four-character, valid lowercase bech32 string (not 1, i, o or b) to use in the resulting BIP-93 output.  If not specified, this is generated from the node alias."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "identifier",
+      "codex32"
+    ],
+    "properties": {
+      "identifier": {
+        "type": "string",
+        "description": [
+          "The four-character identifier used in the codex32 output.  Redundant, but presented separately for clarity."
+        ]
+      },
+      "codex32": {
+        "type": "string",
+        "description": [
+          "The full codex32-encoded (i.e. BIP-93 encoded) HSM secret."
+        ]
+      }
+    }
+  },
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "see_also": [
+    "lightning-hsmtool(8)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ]
+}

--- a/lightningd/configs.c
+++ b/lightningd/configs.c
@@ -65,6 +65,9 @@ static const char *get_opt_val(const struct opt_table *ot,
 			       char buf[],
 			       const struct configvar *cv)
 {
+	if (ot->type & OPT_CONCEAL)
+		return "...";
+
 	if (ot->show == (void *)opt_show_charp) {
 		/* Don't truncate or quote! */
 		return *(char **)ot->u.carg;

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -637,7 +637,8 @@ static void prompt(struct lightningd *ld, const char *str)
  */
 static char *opt_set_hsm_password(struct lightningd *ld)
 {
-	char *passwd, *passwd_confirmation, *err_msg;
+	char *passwd, *passwd_confirmation;
+	const char *err_msg;
 	int is_encrypted;
 
         is_encrypted = is_hsm_secret_encrypted("hsm_secret");
@@ -657,13 +658,13 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 
 	passwd = read_stdin_pass_with_exit_code(&err_msg, &opt_exitcode);
 	if (!passwd)
-		return err_msg;
+		return cast_const(char *, err_msg);
 	if (!is_encrypted) {
 		prompt(ld, "Confirm hsm_secret password:");
 		fflush(stdout);
 		passwd_confirmation = read_stdin_pass_with_exit_code(&err_msg, &opt_exitcode);
 		if (!passwd_confirmation)
-			return err_msg;
+			return cast_const(char *, err_msg);
 
 		if (!streq(passwd, passwd_confirmation)) {
 			opt_exitcode = EXITCODE_HSM_BAD_PASSWORD;
@@ -677,7 +678,7 @@ static char *opt_set_hsm_password(struct lightningd *ld)
 
 	opt_exitcode = hsm_secret_encryption_key_with_exitcode(passwd, ld->config.keypass, &err_msg);
 	if (opt_exitcode > 0)
-		return err_msg;
+		return cast_const(char *, err_msg);
 
 	ld->encrypted_hsm = true;
 	free(passwd);

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -2095,8 +2095,10 @@ void add_config_deprecated(struct lightningd *ld,
 			if (!opt->show(buf, sizeof(buf) - sizeof("..."), opt->u.carg))
 				buf[0] = '\0';
 
-			if ((opt->type & OPT_SHOWINT)
-			    || (opt->type & OPT_SHOWMSATS)) {
+			if (opt->type & OPT_CONCEAL) {
+				strcpy(buf, "...");
+			} else if ((opt->type & OPT_SHOWINT)
+				   || (opt->type & OPT_SHOWMSATS)) {
 				if (streq(buf, "")
 				    || strspn(buf, "-0123456789.") != strlen(buf))
 					errx(1, "Bad literal for %s: %s", name0, buf);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -1168,7 +1168,10 @@ static const char *plugin_opt_add(struct plugin *plugin, const char *buffer,
 		/* These all take an arg. */
 		char *(*cb_arg)(const char *optarg, void *arg);
 
-		if (json_tok_streq(buffer, typetok, "string")) {
+		if (json_tok_streq(buffer, typetok, "string-conceal")) {
+			optflags |= OPT_CONCEAL;
+			cb_arg = (void *)plugin_opt_string_check;
+		} else if (json_tok_streq(buffer, typetok, "string")) {
 			cb_arg = (void *)plugin_opt_string_check;
 		} else if (json_tok_streq(buffer, typetok, "int")) {
 			cb_arg = (void *)plugin_opt_long_check;

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -18,3 +18,4 @@ cln-renepay
 recover
 cln-askrene
 recklessrpc
+exposesecret

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -39,6 +39,10 @@ PLUGIN_SQL_SRC := plugins/sql.c
 PLUGIN_SQL_HEADER :=
 PLUGIN_SQL_OBJS := $(PLUGIN_SQL_SRC:.c=.o)
 
+PLUGIN_EXPOSESECRET_SRC := plugins/exposesecret.c
+PLUGIN_EXPOSESECRET_HEADER :=
+PLUGIN_EXPOSESECRET_OBJS := $(PLUGIN_EXPOSESECRET_SRC:.c=.o)
+
 PLUGIN_SPENDER_SRC :=				\
 	plugins/spender/fundchannel.c		\
 	plugins/spender/main.c			\
@@ -73,6 +77,7 @@ PLUGIN_ALL_SRC :=				\
 	$(PLUGIN_COMMANDO_SRC)			\
 	$(PLUGIN_FUNDER_SRC)			\
 	$(PLUGIN_TOPOLOGY_SRC)			\
+	$(PLUGIN_EXPOSESECRET_SRC)		\
 	$(PLUGIN_KEYSEND_SRC)			\
 	$(PLUGIN_TXPREPARE_SRC)			\
 	$(PLUGIN_LIB_SRC)			\
@@ -98,6 +103,7 @@ C_PLUGINS :=					\
 	plugins/commando			\
 	plugins/funder				\
 	plugins/topology			\
+	plugins/exposesecret			\
 	plugins/keysend				\
 	plugins/offers				\
 	plugins/pay				\
@@ -207,6 +213,8 @@ plugins/commando: $(PLUGIN_COMMANDO_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJ
 plugins/topology: common/route.o common/dijkstra.o common/gossmap.o common/sciddir_or_pubkey.o common/fp16.o wire/peer_wiregen.o wire/channel_type_wiregen.o bitcoin/block.o bitcoin/preimage.o common/gossmods_listpeerchannels.o  $(PLUGIN_TOPOLOGY_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
 plugins/txprepare: $(PLUGIN_TXPREPARE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
+
+plugins/exposesecret: $(PLUGIN_EXPOSESECRET_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) common/hsm_encryption.o common/codex32.o
 
 plugins/bcli: $(PLUGIN_BCLI_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 

--- a/plugins/exposesecret.c
+++ b/plugins/exposesecret.c
@@ -1,0 +1,163 @@
+#include "config.h"
+#include <bitcoin/privkey.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/crypto/hkdf_sha256/hkdf_sha256.h>
+#include <ccan/crypto/sha256/sha256.h>
+#include <ccan/tal/grab_file/grab_file.h>
+#include <ccan/tal/str/str.h>
+#include <common/bech32.h>
+#include <common/codex32.h>
+#include <common/json_param.h>
+#include <common/json_stream.h>
+#include <errno.h>
+#include <plugins/libplugin.h>
+
+/* Information this plugin wants to keep. */
+struct exposesecret {
+	char *exposure_passphrase;
+	struct pubkey our_node_id;
+	const char *our_node_alias;
+};
+
+static struct exposesecret *exposesecret_data(struct plugin *plugin)
+{
+	return plugin_get_data(plugin, struct exposesecret);
+}
+
+/* Don't let compiler do clever things, which would allow the caller
+ * to measure time, and figure out how much of the passphrase matched! */
+static bool compare_passphrases(const char *a, const char *b)
+{
+	struct sha256 a_sha, b_sha;
+
+	/* Technically, this gives information about passphrase length, but
+	 * they can also just brute force it if it is small, so this doesn't
+	 * add much!  Also, hashing messes with timing quite a bit. */
+	sha256(&a_sha, a, strlen(a));
+	sha256(&b_sha, b, strlen(b));
+
+	return sha256_eq(&a_sha, &b_sha);
+}
+
+static struct command_result *json_exposesecret(struct command *cmd,
+						const char *buffer,
+						const jsmntok_t *params)
+{
+	const struct exposesecret *exposesecret = exposesecret_data(cmd->plugin);
+	struct json_stream *js;
+	u8 *contents;
+	const char *id, *passphrase, *err;
+	struct secret hsm_secret;
+	struct privkey node_privkey;
+	struct pubkey node_id;
+	char *bip93;
+	u32 salt = 0;
+
+	if (!param_check(cmd, buffer, params,
+			 p_req("passphrase", param_string, &passphrase),
+			 p_opt("identifier", param_string, &id),
+			 NULL))
+		return command_param_failed();
+
+	if (!exposesecret->exposure_passphrase)
+		return command_fail(cmd, LIGHTNINGD, "exposesecrets-passphrase is not set");
+
+	/* Technically, this could become a timing oracle. */
+	if (!compare_passphrases(exposesecret->exposure_passphrase, passphrase))
+		return command_fail(cmd, LIGHTNINGD, "passphrase does not match exposesecrets-passphrase");
+
+	contents = grab_file(tmpctx, "hsm_secret");
+	if (!contents)
+		return command_fail(cmd, LIGHTNINGD, "Could not open hsm_secret: %s", strerror(errno));
+
+	/* grab_file adds a \0 byte at the end for convenience */
+	if (tal_bytelen(contents) == sizeof(hsm_secret) + 1) {
+		memcpy(&hsm_secret, contents, sizeof(hsm_secret));
+	} else {
+		return command_fail(cmd, LIGHTNINGD, "Not a valid hsm_secret file?  Bad length (maybe encrypted?)");
+	}
+
+	/* Before we expose it, check it's correct! */
+	hkdf_sha256(&node_privkey, sizeof(node_privkey),
+		    &salt, sizeof(salt),
+		    &hsm_secret,
+		    sizeof(hsm_secret),
+		    "nodeid", 6);
+
+	/* Should not happen! */
+	if (!pubkey_from_privkey(&node_privkey, &node_id))
+		return command_fail(cmd, LIGHTNINGD, "Invalid private key?");
+
+	if (!pubkey_eq(&node_id, &exposesecret->our_node_id))
+		return command_fail(cmd, LIGHTNINGD, "This hsm_secret is not for the current node");
+
+	/* If they didn't give an identifier, we make an appropriate one! */
+	if (!id) {
+		size_t off = 0;
+		/* If we run out of alias, use x. */
+		char idstr[] = "xxxx";
+
+		for (size_t i = 0; idstr[off]; i++) {
+			unsigned char c = exposesecret->our_node_alias[i];
+			if (c == 0)
+				break;
+			if (c >= sizeof(bech32_charset_rev))
+				continue;
+			/* Convert to lower case */
+ 			c = tolower(c);
+			/* Must be a valid bech32 char now */
+			if (bech32_charset_rev[c] == -1)
+				continue;
+			idstr[off++] = c;
+		}
+
+		id = tal_strdup(cmd, idstr);
+	}
+
+	/* This also cannot fail! */
+	err = codex32_secret_encode(tmpctx, "cl", id, 0, hsm_secret.data, 32, &bip93);
+	if (err)
+		return command_fail(cmd, LIGHTNINGD, "Unexpected failure encoding hsm_secret: %s", err);
+
+	/* If we're just checking, stop */
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	js = jsonrpc_stream_success(cmd);
+	json_add_string(js, "identifier", id);
+	json_add_string(js, "codex32", bip93);
+	return command_finished(cmd, js);
+}
+
+static const char *init(struct plugin *plugin,
+			const char *buf UNUSED, const jsmntok_t *config UNUSED)
+{
+	struct exposesecret *exposesecret = exposesecret_data(plugin);
+	rpc_scan(plugin, "getinfo",
+		 take(json_out_obj(NULL, NULL, NULL)),
+		 "{id:%,alias:%}",
+		 JSON_SCAN(json_to_pubkey, &exposesecret->our_node_id),
+		 JSON_SCAN_TAL(exposesecret, json_strdup, &exposesecret->our_node_alias));
+	return NULL;
+}
+
+static const struct plugin_command commands[] = {
+	{
+		"exposesecret",
+		json_exposesecret,
+	}
+};
+
+int main(int argc, char *argv[])
+{
+	setup_locale();
+
+	struct exposesecret *exposesecret = talz(NULL, struct exposesecret);
+	plugin_main(argv, init, take(exposesecret),
+		    PLUGIN_RESTARTABLE, true, NULL, commands, ARRAY_SIZE(commands),
+	            NULL, 0, NULL, 0, NULL, 0,
+		    plugin_option("exposesecret-passphrase", "string",
+				  "Enable exposesecret command to allow HSM Secret backup, with this passphrase",
+				  charp_option, NULL, &exposesecret->exposure_passphrase),
+		    NULL);
+}

--- a/plugins/exposesecret.c
+++ b/plugins/exposesecret.c
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
 	plugin_main(argv, init, take(exposesecret),
 		    PLUGIN_RESTARTABLE, true, NULL, commands, ARRAY_SIZE(commands),
 	            NULL, 0, NULL, 0, NULL, 0,
-		    plugin_option("exposesecret-passphrase", "string",
+		    plugin_option("exposesecret-passphrase", "string-conceal",
 				  "Enable exposesecret command to allow HSM Secret backup, with this passphrase",
 				  charp_option, NULL, &exposesecret->exposure_passphrase),
 		    NULL);

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4439,6 +4439,10 @@ def test_listchannels_broken_message(node_factory):
 def test_exposesecret(node_factory):
     l1, l2 = node_factory.get_nodes(2, opts=[{'exposesecret-passphrase': "test_exposesecret"}, {}])
 
+    # listconfigs will conceal the value for us, even if we ask directly.
+    l1.rpc.listconfigs()['configs']['exposesecret-passphrase']['value_str'] == '...'
+    l1.rpc.listconfigs('exposesecret-passphrase')['configs']['exposesecret-passphrase']['value_str'] == '...'
+
     # l2 won't expose the secret!
     with pytest.raises(RpcError, match="exposesecrets-passphrase is not set"):
         l2.rpc.exposesecret(passphrase='test_exposesecret')

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -104,7 +104,7 @@ static void get_encrypted_hsm_secret(struct secret *hsm_secret,
 {
 	struct secret key;
 	struct encrypted_hsm_secret encrypted_secret;
-	char *err;
+	const char *err;
 	int exit_code;
 
 	grab_hsm_file(hsm_secret_path,
@@ -183,7 +183,8 @@ static void get_hsm_secret(struct secret *hsm_secret,
 	/* This checks the file existence, too. */
 	if (hsm_secret_is_encrypted(hsm_secret_path)) {
 		int exit_code;
-		char *err, *passwd;
+		char *passwd;
+		const char *err;
 
 		printf("Enter hsm_secret password:\n");
 		fflush(stdout);
@@ -201,8 +202,8 @@ static int decrypt_hsm(const char *hsm_secret_path)
 {
 	int fd;
 	struct secret hsm_secret;
-	char *passwd, *err;
-	const char *dir, *backup;
+	char *passwd;
+	const char *dir, *backup, *err;
 	int exit_code = 0;
 	/* This checks the file existence, too. */
 	if (!hsm_secret_is_encrypted(hsm_secret_path))
@@ -292,8 +293,8 @@ static int encrypt_hsm(const char *hsm_secret_path)
 	int fd;
 	struct secret key, hsm_secret;
 	struct encrypted_hsm_secret encrypted_hsm_secret;
-	char *passwd, *passwd_confirmation, *err;
-	const char *dir, *backup;
+	char *passwd, *passwd_confirmation;
+	const char *err, *dir, *backup;
 	int exit_code = 0;
 
 	/* This checks the file existence, too. */
@@ -524,7 +525,8 @@ static void read_mnemonic(char *mnemonic) {
 static int generate_hsm(const char *hsm_secret_path)
 {
 	char mnemonic[BIP39_WORDLIST_LEN];
-	char *passphrase, *err;
+	char *passphrase;
+	const char *err;
 	int exit_code = 0;
 
 	read_mnemonic(mnemonic);
@@ -639,7 +641,8 @@ static int check_hsm(const char *hsm_secret_path)
 	u8 bip32_seed[BIP39_SEED_LEN_512];
 	size_t bip32_seed_len;
 	int exit_code;
-	char *passphrase, *err;
+	char *passphrase;
+	const char *err;
 
 	get_hsm_secret(&hsm_secret, hsm_secret_path);
 


### PR DESCRIPTION
As co-programmed with @ShahanaFarooqui .

If you set `exposesecret-passphrase` you can use that to retrieve the hsm_secret using the `exposesecret` command.  It doesn't handle encrypted hsm secrets (if you're prepared type in the secret on every start, you don't want this).