### PR TITLE
Repro nightly builds

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -1,0 +1,69 @@
+---
+# https://docs.corelightning.org/docs/repro
+name: Repro Build Nightly
+on:
+  # 05:00 Berlin, 03:00 UTC, 23:00 New York, 20:00 Los Angeles
+  schedule:
+    - cron: "0 3 * * *"
+jobs:
+  ubuntu-noble:
+    name: Ubuntu Noble Repro build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Build environment setup
+        run: |
+          echo "Building base image for noble"
+          docker run --rm -v $(pwd):/build ubuntu:noble bash -c "apt-get update && apt-get install -y debootstrap && debootstrap noble /build/noble"
+          tar -C noble -c . | docker import - noble
+
+      - name: Builder image setup
+        run: docker build -t cl-repro-noble - < contrib/reprobuild/Dockerfile.noble
+
+      - name: Create release directory
+        run: mkdir $GITHUB_WORKSPACE/release
+
+      - name: Build using the builder image, storing version and Git state
+        run: |
+          # Perform the repro build.
+          docker run --name cl-build -v $GITHUB_WORKSPACE:/repo -e FORCE_MTIME=$(date +%F) -t cl-repro-noble
+
+          # Commit the image in order to inspect the build later.
+          docker commit cl-build cl-release
+
+          # Inspect the version.
+          docker run --rm -v $GITHUB_WORKSPACE:/repo -t cl-release bash -c "make version > /repo/release/version.txt"
+
+          # Inspect the Git tree state.
+          docker run --rm -v $GITHUB_WORKSPACE:/repo -t cl-release bash -c "\
+              git --no-pager status > /repo/release/git.log && \
+              git --no-pager diff >> /repo/release/git.log"
+
+          # Change permissions on the release files for access by build environment.
+          docker run --rm -v $GITHUB_WORKSPACE:/repo -t cl-repro-noble chmod -R 777 /repo/release
+
+      - name: Assert clean version and release
+        run: |
+          echo 'Version:'
+          cat release/version.txt
+          echo -e
+
+          releasefile=$(ls release/clightning-*)
+          echo 'Release file:'
+          ls -al release/clightning-*
+          echo -e
+
+          if [ -n "$(cat release/version.txt | sed -n '/-modded/p')" ] || \
+             [ -n "$(echo $releasefile | sed -n '/-modded/p')" ]
+          then
+            echo "Git Status and Diff:"
+            cat release/git.log
+            echo -e
+
+            echo 'Error: release modded / dirty tree.'
+            exit 1
+          else
+            echo 'Success! Clean release.'
+          fi

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -6,29 +6,36 @@ on:
   schedule:
     - cron: "0 3 * * *"
 jobs:
-  ubuntu-noble:
-    name: Ubuntu Noble Repro build
+  ubuntu:
+    name: "Ubuntu repro build: ${{ matrix.version }}"
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false    # Let each build finish.
+      matrix:
+        version: ['focal', 'jammy', 'noble']
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
 
       - name: Build environment setup
         run: |
-          echo "Building base image for noble"
-          docker run --rm -v $(pwd):/build ubuntu:noble bash -c "apt-get update && apt-get install -y debootstrap && debootstrap noble /build/noble"
-          tar -C noble -c . | docker import - noble
+          echo "Building base image for ${{ matrix.version }}"
+          sudo docker run --rm -v $(pwd):/build ubuntu:${{ matrix.version }} bash -c "\
+              apt-get update && \
+              apt-get install -y debootstrap && \
+              debootstrap ${{ matrix.version }} /build/${{ matrix.version }}"
+          sudo tar -C ${{ matrix.version }} -c . | docker import - ${{ matrix.version }}
 
       - name: Builder image setup
-        run: docker build -t cl-repro-noble - < contrib/reprobuild/Dockerfile.noble
+        run: docker build -t cl-repro-${{ matrix.version }} - < contrib/reprobuild/Dockerfile.${{ matrix.version }}
 
-      - name: Create release directory
-        run: mkdir $GITHUB_WORKSPACE/release
-
-      - name: Build using the builder image, storing version and Git state
+      - name: Build using the builder image and store Git state
         run: |
+          # Create release directory.
+          mkdir $GITHUB_WORKSPACE/release
+
           # Perform the repro build.
-          docker run --name cl-build -v $GITHUB_WORKSPACE:/repo -e FORCE_MTIME=$(date +%F) -t cl-repro-noble
+          docker run --name cl-build -v $GITHUB_WORKSPACE:/repo -e FORCE_MTIME=$(date +%F) -t cl-repro-${{ matrix.version }}
 
           # Commit the image in order to inspect the build later.
           docker commit cl-build cl-release
@@ -41,8 +48,8 @@ jobs:
               git --no-pager status > /repo/release/git.log && \
               git --no-pager diff >> /repo/release/git.log"
 
-          # Change permissions on the release files for access by build environment.
-          docker run --rm -v $GITHUB_WORKSPACE:/repo -t cl-repro-noble chmod -R 777 /repo/release
+          # Change permissions on the release files for access by the runner environment.
+          sudo chown -R runner $GITHUB_WORKSPACE/release
 
       - name: Assert clean version and release
         run: |

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -5,6 +5,8 @@ on:
   # 05:00 Berlin, 03:00 UTC, 23:00 New York, 20:00 Los Angeles
   schedule:
     - cron: "0 3 * * *"
+  workflow_dispatch:
+
 jobs:
   ubuntu:
     name: "Ubuntu repro build: ${{ matrix.version }}"

--- a/Makefile
+++ b/Makefile
@@ -899,8 +899,11 @@ installcheck: all-programs
 	fi
 	@rm -rf testinstall || true
 
+version:
+	@echo ${VERSION}
+
 .PHONY: installdirs install-program install-data install uninstall \
-	installcheck ncc bin-tarball show-flags
+	installcheck ncc bin-tarball show-flags version
 
 # Make a tarball of opt/clightning/, optionally with label for distribution.
 ifneq ($(VERSION),)

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -44,12 +44,12 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
     libsqlite3-dev \
     libssl-dev \
     zlib1g-dev && \
-    pyenv install 3.8.0 && \
-    pyenv global 3.8.0
+    pyenv install 3.10.0 && \
+    pyenv global 3.10.0
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools
+    && pip install poetry mako grpcio-tools==1.62.2
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \


### PR DESCRIPTION
# Repro nightly builds

## Description
This pull request attempts to address #7117 to implement Github Actions CI/CD to perform nightly reproducible builds. The goal is to catch local file changes that might emerge through the build process and result in a `-modded` release version. Currently supporting `focal`, `jammy` and `noble` Ubuntu releases.

Have been testing by adding the following to the `on` key of `.github/workflows/repro.yml`:
```
  push:
    branches:
      - 7117-repro-nightly-builds
```

Add adding some temporary commit to dirty the tree in the `contrib/reprobuild/Dockerfile.[release]`

## Related Issues
- Closes #7117 and hopes to score the bounty :)

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commits.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes
- Added an entry to the CHANGELOG -- it was the first one observed since the last release, so also added the front matter.
- I started this work a few days ago, without realizing there was a "expiration" date on the Sphinx bounty entry for Aug. 2, 2024. Just before submitting this PR, and rebasing against `master`, I've noticed @ShahanaFarooqui has made a few commits regarding the repro build process. Don't mean to be stepping on toes! I don't know if this work overlaps, and I'm hoping it still qualifies for the bounty, but if not, please consider it as an alternative submission to whatever planning around repro builds made since Aug. 2.