### PR TITLE
cln-rpc: Make `description` field of `Wait(any)invoiceResponse` optional string

### DIFF
--- a/cln-rpc/src/model.rs
+++ b/cln-rpc/src/model.rs
@@ -5702,7 +5702,8 @@ pub mod responses {
 	    pub updated_index: Option<u64>,
 	    // Path `WaitAnyInvoice.status`
 	    pub status: WaitanyinvoiceStatus,
-	    pub description: String,
+	    #[serde(skip_serializing_if = "Option::is_none")]
+	    pub description: Option<String>,
 	    pub expires_at: u64,
 	    pub label: String,
 	    pub payment_hash: Sha256,
@@ -5778,7 +5779,8 @@ pub mod responses {
 	    pub updated_index: Option<u64>,
 	    // Path `WaitInvoice.status`
 	    pub status: WaitinvoiceStatus,
-	    pub description: String,
+	    #[serde(skip_serializing_if = "Option::is_none")]
+	    pub description: Option<String>,
 	    pub expires_at: u64,
 	    pub label: String,
 	    pub payment_hash: Sha256,


### PR DESCRIPTION
# cln-rpc: Make `description` field of `Wait(any)invoiceResponse` optional string

## Description

In case of a bolt12 invoice, the description field is missing in `waitinvoice` and `waitanyinvoice` responses. Make it optional in the rust struct.

## Related Issues

N/A afaik

## Changes Made
- **Bug Fix**:  Make `description` field of `WaitanyinvoiceResponse` an optional string.
  
## Checklist

Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [ ] Tests have been added or updated to cover the changes: i don't know where to add it, there doesn't seem an existing test for this
- [ ] Documentation has been updated as needed: i don't think there is documentation for this struct
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Review note

Might want to be sure that this is the only response where this is needed? It looks like most invoice response structs have optional description, but not all:

- `CreateinvoiceResponse`
- `SendinvoiceResponse`

I don't think these have a possible BOLT12 path but not sure.

Also this is API breaking-I don't know how versioning is handled in the crate.
