### PR TITLE
lightningd: make sure channels always have a local alias.

### DIFF
--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -513,6 +513,11 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->remote_channel_ready = remote_channel_ready;
 	channel->scid = tal_steal(channel, scid);
 	channel->alias[LOCAL] = tal_dup_or_null(channel, struct short_channel_id, alias_local);
+	/* We always make sure this is set (historical channels from db might not) */
+	if (!channel->alias[LOCAL]) {
+		channel->alias[LOCAL] = tal(channel, struct short_channel_id);
+		randombytes_buf(channel->alias[LOCAL], sizeof(struct short_channel_id));
+	}
 	channel->alias[REMOTE] = tal_steal(channel, alias_remote);  /* Haven't gotten one yet. */
 	channel->cid = *cid;
 	channel->our_msat = our_msat;

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -28,7 +28,6 @@
 #include <lightningd/plugin_hook.h>
 #include <lightningd/subd.h>
 #include <openingd/openingd_wiregen.h>
-#include <sodium/randombytes.h>
 #include <wally_psbt.h>
 
 void json_add_uncommitted_channel(struct command *cmd,
@@ -108,7 +107,6 @@ wallet_commit_channel(struct lightningd *ld,
 	s64 final_key_idx;
 	u64 static_remotekey_start;
 	u32 lease_start_blockheight = 0; /* No leases on v1 */
-	struct short_channel_id local_alias;
 	struct timeabs timestamp;
 	bool any_active = peer_any_channel(uc->peer, channel_state_wants_peercomms, NULL);
 
@@ -158,9 +156,6 @@ wallet_commit_channel(struct lightningd *ld,
 	else
 		static_remotekey_start = 0x7FFFFFFFFFFFFFFF;
 
-	/* This won't clash, we don't even bother checking */
-	randombytes_buf(&local_alias, sizeof(local_alias));
-
 	channel = new_channel(uc->peer, uc->dbid,
 			      NULL, /* No shachain yet */
 			      CHANNELD_AWAITING_LOCKIN,
@@ -178,7 +173,7 @@ wallet_commit_channel(struct lightningd *ld,
 			      local_funding,
 			      false, /* !remote_channel_ready */
 			      NULL, /* no scid yet */
-			      &local_alias,
+			      NULL, /* assign random local alias */
 			      NULL, /* They haven't told us an alias yet */
 			      cid,
 			      /* The three arguments below are msatoshi_to_us,


### PR DESCRIPTION
If we pull and old channel from the database, it might not.

Fixes: https://github.com/ElementsProject/lightning/issues/7645
Changelog-Fixes: lightningd: crash when starting channeld for older channel with no local alias.
