### PR TITLE
cln-plugin: Change default log level filter back to INFO

### DIFF
--- a/plugins/src/logging.rs
+++ b/plugins/src/logging.rs
@@ -80,7 +80,10 @@ mod trace {
     where
         O: AsyncWrite + Send + Unpin + 'static,
     {
-        let filter = tracing_subscriber::filter::EnvFilter::from_env("CLN_PLUGIN_LOG");
+        let filter = tracing_subscriber::filter::EnvFilter::builder()
+            .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+            .with_env_var("CLN_PLUGIN_LOG")
+            .from_env_lossy();
         let sender = start_writer(out);
 
         tracing_subscriber::registry()


### PR DESCRIPTION
# cln-plugin: Change default log level filter back to INFO

## Description

In commit 60e1532dd89ec8a434ce4b31359c54558c41b4b1 (released in crate 0.1.8), which switched the logging framework to tracing-subscriber, the default log level filter was (accidentally) set to ERROR and above, instead of INFO and above.

Change this back to INFO as it was before. It can still be overridden with environment variable `CLN_PLUGIN_LOG`.

Follows the example in https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#method.from_env

## Related Issues

- Closes #7658.

## Changes Made

Changelog-Fixed: cln-plugin: Change default log level filter back to INFO

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- N/A Tests have been added or updated to cover the changes.
- N/A Documentation has been updated as needed.
- N/A Any relevant comments or `TODOs` have been addressed or removed.
