### PR TITLE
pyln-testing: Fix BitcoinD FD leak

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -164,6 +164,8 @@ def bitcoind(directory, teardown_checks):
         bitcoind.proc.kill()
     bitcoind.proc.wait()
 
+    bitcoind.cleanup_files()
+
 
 class TeardownErrors(object):
     def __init__(self):

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -256,6 +256,14 @@ class TailableProc(object):
         self.proc.kill()
         self.proc.wait()
 
+    def cleanup_files(self):
+        """Ensure files are closed."""
+        for f in ["stdout_write", "stderr_write", "stdout_read", "stderr_read"]:
+            try:
+                getattr(self, f).close()
+            except Exception:
+                pass
+
     def logs_catchup(self):
         """Save the latest stdout / stderr contents; return true if we got anything.
         """


### PR DESCRIPTION
# Fix BitcoinD FD leak in pyln-testing

## Description
This PR adds a post-yield resolver sanity-check to the `bitcoind` test fixture to be sure file descriptors are not leaking.

## Related Issues
- Closes #7130 (if it works)
- I made this PR with the faint hope that it might be related to the build failures in #7310 as well. Need to trigger CI to see...

## Changes Made
- [ ] **Feature**: Brief description of the new feature or functionality added.
- [x] **Bug Fix**: Brief description of the bug fixed and how it was resolved.
- [ ] **Refactor**: Any code improvements or refactoring done without changing the functionality.

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated as needed.
- [ ] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes
Please let me know if there is a more elegant way to do this, or more appropriate place to put it.
