### PR TITLE
Add extra configuration options to gRPC

### DIFF
--- a/doc/getting-started/getting-started/configuration.md
+++ b/doc/getting-started/getting-started/configuration.md
@@ -235,9 +235,20 @@ The [`lightning-listconfigs`](ref:lightning-listconfigs) command will output a v
   If you have an unencrypted `hsm_secret` you want to encrypt on-disk, or vice versa,  
   see [`lightning-hsmtool`](ref:lightning-hsmtool).
 
+- **grpc-scheme**=_scheme_ [plugin `cln-grpc`]
+
+  The scheme on which the gRPC plugin will listen for incoming connections. The default is `https`.
+  The interface supports both `http` and `https`. However, `http` can only be used if `grpc-host`
+  is set to a loopback address which is `127.0.0.1` for IPv4.
+
+- **grpc-host**=_HOST_ [plugin `cln-grpc`]
+
+  The IP address for the gRPC plugin to listen for incoming connections;
+  The default is the IPv4 loopback address `127.0.0.1`.
+
 - **grpc-port**=_portnum_ [plugin `cln-grpc`]
 
-  The port number for the GRPC plugin to listen for incoming connections; default is not to activate the plugin at all.
+  The port number for the GRPC plugin to listen for incoming connections. Default is 9736.
 
 ### Lightning node customization options
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -310,15 +310,21 @@ If there is no `hsm_secret` yet, `lightningd` will create a new encrypted secret
 If you have an unencrypted `hsm_secret` you want to encrypt on-disk, or vice versa,
 see lightning-hsmtool(8).
 
+* **grpc-scheme**=*scheme* [plugin `cln-grpc`]
+
+  The scheme on which the gRPC plugin will listen for incoming connections. The 
+  default is `https`. The interface supports both `http` and `https`.
+  However, `http` can only be used if `grpc-host` is set to a loopback address
+  which is `127.0.0.1` for IPv4.
 
 * **grpc-host**=*HOST* [plugin `cln-grpc`]
 
-  Defines the GRPC server host. Default is 127.0.0.1.
+  The IP address for the gRPC plugin to listen for incoming connections;
+  The default is the IPv4 loopback address `127.0.0.1`.
 
 * **grpc-port**=*portnum* [plugin `cln-grpc`]
 
-  The port number for the GRPC plugin to listen for incoming
-connections. Default is 9736.
+  The port number for the GRPC plugin to listen for incoming connections. Default is 9736.
 
 * **grpc-msg-buffer-size**=*number* [plugin `cln-grpc`]
 

--- a/plugins/grpc-plugin/src/router.rs
+++ b/plugins/grpc-plugin/src/router.rs
@@ -1,0 +1,46 @@
+use std::net::{IpAddr, SocketAddr};
+
+use anyhow::Context;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::{PluginState, OPTION_GRPC_HOST, OPTION_GRPC_PORT};
+
+use cln_plugin::ConfiguredPlugin;
+pub struct GrpcRouterConfig {
+    host: IpAddr,
+    port: u16,
+}
+
+impl GrpcRouterConfig {
+    pub fn from_configured_plugin<I, O>(
+        plugin: &ConfiguredPlugin<PluginState, I, O>,
+    ) -> anyhow::Result<Option<Self>>
+    where
+        I: AsyncRead + Send + Unpin + 'static,
+        O: AsyncWrite + Send + Unpin + 'static,
+    {
+        let port = plugin.option(&OPTION_GRPC_PORT).unwrap();
+        let port = u16::try_from(port).with_context(|| {
+            format!(
+                "Invalid config for {}. The value {} is out-of-bounds.",
+                OPTION_GRPC_PORT.name(),
+                port
+            )
+        })?;        
+
+        let host = plugin.option(&OPTION_GRPC_HOST).unwrap();
+        let host = host.parse::<IpAddr>().with_context(|| {
+            format!(
+                "Invalid config for {}. '{}' is not a valid ip-address.",
+                OPTION_GRPC_HOST.name(),
+                host
+            )
+        })?;
+
+        Ok(Some(GrpcRouterConfig { host, port }))
+    }
+
+    pub fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.host, self.port)
+    }
+}

--- a/plugins/grpc-plugin/src/router.rs
+++ b/plugins/grpc-plugin/src/router.rs
@@ -1,14 +1,35 @@
 use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
 
 use anyhow::Context;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::{PluginState, OPTION_GRPC_HOST, OPTION_GRPC_PORT};
-
 use cln_plugin::ConfiguredPlugin;
+
+use crate::{PluginState, OPTION_GRPC_HOST, OPTION_GRPC_PORT, OPTION_GRPC_SCHEME};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GrpcRouterScheme {
+    HTTP,
+    HTTPS,
+}
+
+impl FromStr for GrpcRouterScheme {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" => Ok(GrpcRouterScheme::HTTP),
+            "https" => Ok(GrpcRouterScheme::HTTPS),
+            _ => anyhow::bail!("Invalid scheme"),
+        }
+    }
+}
+
 pub struct GrpcRouterConfig {
-    host: IpAddr,
-    port: u16,
+    pub scheme: GrpcRouterScheme,
+    pub host: IpAddr,
+    pub port: u16,
 }
 
 impl GrpcRouterConfig {
@@ -28,6 +49,15 @@ impl GrpcRouterConfig {
             )
         })?;        
 
+        let scheme = plugin.option(&OPTION_GRPC_SCHEME).unwrap();
+        let scheme = scheme.parse::<GrpcRouterScheme>().with_context(|| {
+            format!(
+                "Invalid config for {}. The config '{}' is invalid. Use either 'http' or 'https'.",
+                OPTION_GRPC_SCHEME.name(),
+                scheme
+            )
+        })?;
+
         let host = plugin.option(&OPTION_GRPC_HOST).unwrap();
         let host = host.parse::<IpAddr>().with_context(|| {
             format!(
@@ -37,7 +67,12 @@ impl GrpcRouterConfig {
             )
         })?;
 
-        Ok(Some(GrpcRouterConfig { host, port }))
+        if GrpcRouterScheme::HTTP == scheme && !host.is_loopback() {
+            anyhow::bail!("Invalid config: Scheme 'http' is only allowed on a loopback address. Try setting {} to 127.0.0.1",
+            OPTION_GRPC_HOST.name());
+        }
+
+        Ok(Some(GrpcRouterConfig { scheme, host, port }))
     }
 
     pub fn socket_addr(&self) -> SocketAddr {


### PR DESCRIPTION
# Pull Request Title

## Description
I've added a few configuration options to the gRPC-plugin.

- `grpc-ip-address`: I've changed the default ip-address to which the gRPC interface will bind from `0.0.0.0` to `127.0.0.1`. This new default should be more secure. Users who need to access the gRPC-interface externally can set `grpc-ip-address` to the port they like. Users can also configure an IPv6 address.
- `grpc-scheme`: Previously, the gRPC connection only allowed https over mTLS. Configurting mTLS is somewhat cumbersome. Users that only need the gRPC interface locally can now set `grpc-scheme=http`. This will only work if `grpc-ip-address` is set to a loopback address (127.0.0.1 or equivalent for IPv6).


## Related Issues

- Closes https://github.com/ElementsProject/lightning/issues/7654

## Changes Made
- [ x ] **Feature**: More config options for gRPC interface

## Checklist
Ensure the following tasks are completed before submitting the PR:

- [x] Changelog has been added in relevant commit/s.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated as needed.
- [x] Any relevant comments or `TODOs` have been addressed or removed.

## Additional Notes
Any additional information or context about this PR that reviewers should know.
