### PR TITLE
pytests: extend the offline mode testcase

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4492,10 +4492,15 @@ def test_reconnect_no_additional_transient_failure(node_factory, bitcoind):
     assert not l1.daemon.is_in_log(f"{l2id}-chan#1: Peer transient failure in CHANNELD_NORMAL: Disconnected", start=offset1)
 
 
-def test_offline_fd_check(node_factory):
+@pytest.mark.xfail(strict=True)
+def test_offline(node_factory):
     # if get_node starts it, it'll expect an address, so do it manually.
     l1 = node_factory.get_node(options={"offline": None}, start=False)
     l1.daemon.start()
+
+    # we expect it to log offline mode an not to create any listener
+    assert l1.daemon.is_in_log("Started in offline mode!")
+    assert not l1.daemon.is_in_log("connectd: Created listener on")
 
 
 def test_last_stable_connection(node_factory):


### PR DESCRIPTION
# Offline mode working properly?

## Description
I discovered that a node even and specifically when started `--offline` mode still tries to acquire a listening socket (and would fail to start if it is already bound!)
Also noteworthy, that an `--offline` node can make outbound connections when done via CLI (or by a plugin like clboss or similar).

## What this PR does
Extend the testcase a bit and make it an `xfail` for the time being.

## What needs to be done
I think that an offline node needs to be really offline, because it may harm developers when trying to debug real world data 'in offline mode' and then a connection is made by mistake and a live network channel can end up in an invalid state.

This means that it should not try to bind a listening socket as well as forbid to make manual connections via cli, because a plugin that does not know the node is 'offline' can accidentally make a connection.