### PR TITLE
pytests: further extend the offline mode testcase 

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -1008,7 +1008,8 @@ class LightningNode(object):
         # Cache `getinfo`, we'll be using it a lot
         self.info = self.rpc.getinfo()
         # This shortcut is sufficient for our simple tests.
-        self.port = self.info['binding'][0]['port']
+        if 'binding' in self.info:
+            self.port = self.info['binding'][0]['port']
         self.gossip_store.open()  # Reopen the gossip_store now that we should have one
         if wait_for_bitcoind_sync and not self.is_synced_with_bitcoin(self.info):
             wait_for(lambda: self.is_synced_with_bitcoin())


### PR DESCRIPTION
# Just more on the xfail testcase

Now the testscase reflects what I would expect from an `--offline` node:
 - no creation of a listener
 - also no cli connections (e.g. by plugin)
