### PR TITLE
tools/headerversions.c: fix build without SQLite

### DIFF
--- a/tools/headerversions.c
+++ b/tools/headerversions.c
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
 	if (!file && errno != ENOENT)
 		err(1, "Reading %s", argv[1]);
 
-	new = tal_fmt(NULL, template,
-		      IF_SQLITE3(sqlite3_libversion_number()));
+	new = tal_fmt(NULL, template
+		      IF_SQLITE3(, sqlite3_libversion_number()));
 	if (!file || !streq(new, file)) {
 		int fd = open(argv[1], O_TRUNC|O_WRONLY|O_CREAT, 0666);
 		if (fd < 0)


### PR DESCRIPTION
Commit 531845971cf94d8e5c0de67c8531578bc2656353 broke the build without SQLite because this code:

	new = tal_fmt(NULL, template,
	              IF_SQLITE3(sqlite3_libversion_number()));

preprocesses into:

	new = tal_fmt(NULL, template,
	              );

which has a syntax error. Fix it by moving the comma into the macro argument.

Fixes: 531845971cf94d8e5c0de67c8531578bc2656353
Changelog-None

> [!IMPORTANT]
> Open for merging new PRs until the next PR freeze date is confirmed!

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.