### PR TITLE
pyln_client: (re-)adds method description to usage via docstring

### DIFF
--- a/contrib/pyln-client/tests/test_plugin.py
+++ b/contrib/pyln-client/tests/test_plugin.py
@@ -435,3 +435,22 @@ def test_duplicate_result():
     ba = p._bind_kwargs(test4, {}, req)
     with pytest.raises(ValueError, match=r'current state is RequestState\.FINISHED(.*\n*.*)*MARKER4'):
         test4(*ba.args)
+
+
+def test_usage():
+    p = Plugin(autopatch=False)
+
+    @p.method("some_method")
+    def some_method(some_arg: str = None):
+        """some description"""
+        pass
+
+    manifest = p._getmanifest()
+    usage = p.get_usage()
+
+    assert manifest['rpcmethods'][0]['name'] == 'some_method'
+    assert "some_arg" in manifest['rpcmethods'][0]['usage']
+    assert "some description" in manifest['rpcmethods'][0]['usage']
+    assert "some_method" in usage
+    assert "some_arg" in usage
+    assert "some description" in usage

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -196,7 +196,7 @@ def test_rpc_passthrough(node_factory):
     assert(len(cmd) == 1)
 
     # Make sure usage message is present.
-    assert only_one(n.rpc.help('hello')['help'])['command'] == 'hello [name]'
+    assert only_one(n.rpc.help('hello')['help'])['command'].startswith('hello [name]')
     # While we're at it, let's check that helloworld.py is logging
     # correctly via the notifications plugin->lightningd
     assert n.daemon.is_in_log('Plugin helloworld.py initialized')


### PR DESCRIPTION
The extended usage information (long_description) has been removed a while ago without proper replacement. ( commit 2ff3e55f0  Date:   Mon Jul 29 17:58:43 2024 -0700 )

# This PR does the following:
 - adds a optional `description` parameter to a plugin method via docstring that will (if set) be appended with a newline following the generated usage argument list.
 - adds method usage to plugin.print_usage()
 - adds a testcase that checks if extended usage information is passed to manifest json and `print_usage`
 
 # Things to think about
 - Maybe we want to add an optional getmanifest json description field and use that instead of internally appending it with newline to the usage