### PR TITLE
pytest: DX - Support targeting specific tests using `make pytest` w/ `PYTEST_TESTS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,11 @@ else
 PYTEST_OPTS += -x
 endif
 
+# Allow for targeting specific tests by setting the PYTEST_TESTS environment variable.
+ifeq ($(PYTEST_TESTS),)
+PYTEST_TESTS = "tests/"
+endif
+
 check-units:
 
 check: check-units installcheck pytest
@@ -466,7 +471,7 @@ ifeq ($(PYTEST),)
 	exit 1
 else
 # Explicitly hand VALGRIND so you can override on make cmd line.
-	PYTHONPATH=$(MY_CHECK_PYTHONPATH) TEST_DEBUG=1 VALGRIND=$(VALGRIND) $(PYTEST) tests/ $(PYTEST_OPTS)
+	PYTHONPATH=$(MY_CHECK_PYTHONPATH) TEST_DEBUG=1 VALGRIND=$(VALGRIND) $(PYTEST) $(PYTEST_TESTS) $(PYTEST_OPTS)
 endif
 
 check-fuzz: $(ALL_FUZZ_TARGETS)

--- a/doc/contribute-to-core-lightning/testing.md
+++ b/doc/contribute-to-core-lightning/testing.md
@@ -43,6 +43,10 @@ There are four kinds of tests:
 
   You can also append `-k TESTNAME` to run a single test.  Environment variables `DEBUG_SUBD=<subdaemon>` and `TIMEOUT=<seconds>` can be useful for debugging subdaemons on individual tests, and `DEBUG_LIGHTNINGD` for attaching a debugger to each `lightningd` instance created.
 
+  Alternatively, to run a specific test via the `Makefile`, you can specify the test by setting the environment variable `PYTEST_TESTS`:
+
+  `PYTEST_TESTS="tests/test_askrene.py::test_layers" make pytest`
+
 - **pylightning tests** - will check contrib pylightning for codestyle and run the tests in `contrib/pylightning/tests` afterwards:
 
   `make check-python`
@@ -52,14 +56,28 @@ Our Github Actions instance (see `.github/workflows/*.yml`) runs all these for e
 #### Additional Environment Variables
 
 ```text
-TEST_CHECK_DBSTMTS=[0|1]            - When running blackbox tests, this will
-                                      load a plugin that logs all compiled
-                                      and expanded database statements.
-                                      Note: Only SQLite3.
-TEST_DB_PROVIDER=[sqlite3|postgres] - Selects the database to use when running
-                                      blackbox tests.
-EXPERIMENTAL_DUAL_FUND=[0|1]        - Enable dual-funding tests.
-EXPERIMENTAL_SPLICING=[0|1]         - Enable splicing tests.
+EXPERIMENTAL_DUAL_FUND=[0|1]          - Enable dual-funding tests.
+EXPERIMENTAL_SPLICING=[0|1]           - Enable splicing tests.
+TEST_CHECK_DBSTMTS=[0|1]              - When running blackbox tests, this will
+                                        load a plugin that logs all compiled
+                                        and expanded database statements.
+                                        Note: Only SQLite3.
+TEST_DB_PROVIDER=[sqlite3|postgres]   - Selects the database to use when running
+                                        blackbox tests.
+TEST_DEBUG=[0|1]                      - Enable additional debug logging output
+                                        during tests.
+TEST_NETWORK=[regtest|liquid-regtest] - Select the test network to use. Default is
+                                        to 'regtest'.
+TIMEOUT                               - Override the default timeout value for
+                                        API calls.
+PYTEST_PAR=[1-n]                      - Number of processes to use when running
+                                        the blackbox the tests in parallel.
+PYTEST_TESTS="tests/"                 - Target a specific set of blackbox tests
+                                        when running 'make pytest'. Pass a string
+                                        of Pytest test targets.
+SLOW_MACHINE=[0|1]                    - Set sensible defaults for running tests
+                                        in resource-constrained environments.
+VALGRIND=[0|1]                        - Run the tests with Valgrind.
 ```
 
 #### Troubleshooting


### PR DESCRIPTION
This is a small PR intended to slightly improve developer experience. When running the Pytest integration testing suite locally using the command `make pytest`, the build system takes care of altering the local context variable `PYTHONPATH` to make sure contributed modules are accessible to the process. While this works great for running the entire test suite, oftentimes developers are concerned with repeatedly running a subset of the tests, the particular test relevant to the functionality they are working on, or some problematic tests which the suite reports failing.

Currently, in order to target specific tests for a `pytest` run, a developer might:
1. Run `make pytest`
2. Observe the output to discern and capture the computed value for `PYTHONPATH`
3. Copy this value
4. Export the value as a local `PYTHONPATH` variable
5. Run `pytest` outside of the `Makefile` context and feeding in the targeted list of files and tests cases to the local command

This PR suggests supporting the pass-through of a variable named `PYTEST_TESTS` which defaults to `tests/` and can be set in a similar fashion to `PYTEST_PAR` and `PYTEST_OPTS`. This would allow developers to skip a few steps in setting up their local environment for running `pytest` and enjoy some of the `Makefile`'s sane defaults if desired. For example,

```
PYTEST_TESTS="tests/test_askrene.py::test_layers" make pytest
```

Certainly, experienced CLN developers already have more convenient workflows, so please let me know if there is a more accessible convention for this.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.