### PR TITLE
gossmap: ensure chan not null

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -979,6 +979,8 @@ void gossmap_remove_localmods(struct gossmap *map,
 	for (size_t i = 0; i < n; i++) {
 		const struct localmod *mod = &localmods->mods[i];
 		struct gossmap_chan *chan = gossmap_find_chan(map, &mod->scid);
+		if (chan == NULL)
+			continue;
 
 		/* If that's a local channel, remove it now. */
 		if (chan->cann_off >= map->map_size) {


### PR DESCRIPTION
Ignore localmods that don't have a corresponding entry in the gossmap.

A crash was observed on this branch: https://github.com/breez/lightning/tree/cln-v24.08-breez with commit https://github.com/breez/lightning/commit/bc9e4f56c324216f5f0f15be07f6ad4f9a46e597

```
pay: FATAL SIGNAL 11 (version v24.08-4-gbc9e4f5-modded)
0x5584c2da9cbf send_backtrace
        common/daemon.c:33
0x5584c2da9d44 crashdump
        common/daemon.c:75
0x7fc69664858f ???
        ???:0
0x5584c2dc2864 gossmap_remove_localmods
        common/gossmap.c:984
0x5584c2d94b2f put_gossmap
        plugins/libplugin-pay.c:62
0x5584c2d9ac32 routehint_step_cb
        plugins/libplugin-pay.c:3171
0x5584c2d98fda payment_continue
        plugins/libplugin-pay.c:2450
0x5584c2d99928 shadow_route_cb
        plugins/libplugin-pay.c:3529
0x5584c2d98fda payment_continue
        plugins/libplugin-pay.c:2450
0x5584c2d9b585 direct_pay_override
        plugins/libplugin-pay.c:3550
0x5584c2d9b7a8 direct_pay_listpeerchannels
        plugins/libplugin-pay.c:3621
0x5584c2d93713 handle_rpc_reply
        plugins/libplugin.c:1016
0x5584c2d938b7 rpc_read_response_one
        plugins/libplugin.c:1202
0x5584c2d93964 rpc_conn_read_response
        plugins/libplugin.c:1226
0x5584c2ef37cc next_plan
        ccan/ccan/io/io.c:60
0x5584c2ef3c57 do_plan
        ccan/ccan/io/io.c:422
0x5584c2ef3d10 io_ready
        ccan/ccan/io/io.c:439
0x5584c2ef55fc io_loop
        ccan/ccan/io/poll.c:455
0x5584c2d94006 plugin_main
        plugins/libplugin.c:2230
0x5584c2d8f029 main
        plugins/pay.c:1533
0x7fc696632c89 ???
        ???:0
0x7fc696632d44 ???
        ???:0
0x5584c2d8b7b0 ???
        ???:0
0xffffffffffffffff ???
        ???:0
```

The branch contains changes compared to v24.08, namely 
- https://github.com/ElementsProject/lightning/pull/7628
- https://github.com/ElementsProject/lightning/pull/7611
- https://github.com/ElementsProject/lightning/pull/7636

But I don't think they were related to the crash.
A simple null check should suffice here?

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.