### PR TITLE
lightningd: remove incorrect old-payment-htlc-delete logic.

### DIFF
--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -3287,25 +3287,6 @@ struct htlc_stub *wallet_htlc_stubs(const tal_t *ctx, struct wallet *wallet,
 	return stubs;
 }
 
-void wallet_local_htlc_out_delete(struct wallet *wallet,
-				  struct channel *chan,
-				  const struct sha256 *payment_hash,
-				  u64 partid)
-{
-	struct db_stmt *stmt;
-
-	stmt = db_prepare_v2(wallet->db, SQL("DELETE FROM channel_htlcs"
-					     " WHERE direction = ?"
-					     " AND origin_htlc = ?"
-					     " AND payment_hash = ?"
-					     " AND partid = ?;"));
-	db_bind_int(stmt, DIRECTION_OUTGOING);
-	db_bind_int(stmt, 0);
-	db_bind_sha256(stmt, payment_hash);
-	db_bind_u64(stmt, partid);
-	db_exec_prepared_v2(take(stmt));
-}
-
 /* FIXME: reorder! */
 static
 struct wallet_payment *wallet_payment_new(const tal_t *ctx,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -900,18 +900,6 @@ void wallet_payment_delete(struct wallet *wallet,
 			   const enum payment_status *status);
 
 /**
- * wallet_local_htlc_out_delete - Remove a local outgoing failed HTLC
- *
- * This is not a generic HTLC cleanup!  This is specifically for the
- * narrow (and simple!) case of removing the HTLC associated with a
- * local outgoing payment.
- */
-void wallet_local_htlc_out_delete(struct wallet *wallet,
-				  struct channel *chan,
-				  const struct sha256 *payment_hash,
-				  u64 partid);
-
-/**
  * wallet_payment_by_hash - Retrieve a specific payment
  *
  * Given the `payment_hash` retrieve the matching payment.


### PR DESCRIPTION
This was incorrect once we stopped removing old payments on failure, which was the reason we had to remove the HTLCs.

It also removed by partid, which is wrong since it should have done old_payment->partid and old_payment->groupid!

(This is a subset of https://github.com/ElementsProject/lightning/pull/7640)