### PR TITLE
topology: call listpeerchannels_done directly

### DIFF
--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -381,7 +381,6 @@ static void gossmod_add_unknown_localchan(struct gossmap_localmods *mods,
 			      buf, chantok, gossmap);
 }
 
-/* FIXME: We don't need this listpeerchannels at all if not deprecated! */
 static struct command_result *listpeerchannels_done(struct command *cmd,
 					     const char *buf,
 					     const jsmntok_t *result,
@@ -472,9 +471,18 @@ static struct command_result *json_listchannels(struct command *cmd,
 				    "Can only specify one of "
 				    "`short_channel_id`, "
 				    "`source` or `destination`");
-	req = jsonrpc_request_start(cmd->plugin, cmd, "listpeerchannels",
+
+	// FIXME: Once this deprecation is removed, `listpeerchannels_done` can
+	// be embedded in the current function.
+	if (command_deprecated_in_ok(cmd, "include_private", "v24.02", "v24.08")) {
+		req = jsonrpc_request_start(cmd->plugin, cmd, "listpeerchannels",
 				    listpeerchannels_done, forward_error, opts);
-	return send_outreq(cmd->plugin, req);
+		return send_outreq(cmd->plugin, req);
+	}
+
+	// If deprecations are not necessary, call listpeerchannels_done directly,
+	// the output will not be used there.
+	return listpeerchannels_done(cmd, NULL, NULL, opts);
 }
 
 static void json_add_node(struct json_stream *js,


### PR DESCRIPTION
When cln is run without deprecated apis, the `listchannels` call would still query `listpeerchannels`, even though it wouldn't use the result. This adds unnecessary time to the call. Especially in case the node has many channels. This commit skips the listpeerchannels call in case the outcome won't be used.

Changelog-Fixed: Improve listchannels performance

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.