### PR TITLE
pay-plugin: less listpeerchannels load

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -3517,6 +3517,7 @@ static void direct_pay_cb(struct direct_pay_data *d, struct payment *p)
 				    direct_pay_listpeerchannels,
 				    direct_pay_listpeerchannels,
 				    p);
+	json_add_node_id(req->js, "id", p->route_destination);
 	send_outreq(p->plugin, req);
 }
 

--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -2603,6 +2603,8 @@ local_channel_hints_listpeerchannels(struct command *cmd, const char *buffer,
 	 * otherwise start out as excluded and remain so until
 	 * forever. */
 	channel_hint_set_update(payment_root(p)->hints, time_now());
+	p->mods = gossmods_from_listpeerchannels(
+	    p, p->local_id, buffer, toks, true, gossmod_add_localchan, NULL);
 
 	payment_continue(p);
 	return command_still_pending(cmd);


### PR DESCRIPTION
The direct_pay payment modifier would query all peer channels, while
only the channels of the given peer suffices.

Multiple places in the pay lifecycle depend on mods to be set. By
setting the mods directly after the first listpeerchannels call,
subsequent calls to listpeerchannels are avoided.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.