### PR TITLE
Gossmap: remove channel announcement from map when deleted from store

### DIFF
--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -318,6 +318,7 @@ static void remove_channel(struct gossmap_manage *gm,
 					      GOSSIP_STORE_DYING_BIT,
 					      WIRE_NODE_ANNOUNCEMENT);
 	}
+	gossmap_remove_chan(gossmap, chan);
 }
 
 static u32 get_timestamp(struct gossmap *gossmap,

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -619,7 +619,7 @@ void gossmap_manage_handle_get_txout_reply(struct gossmap_manage *gm, const u8 *
 
 	pca = map_del(&gm->pending_ann_map, scid);
 	if (!pca) {
-		/* If we looking specifically for this, we no longer
+		/* If we were looking specifically for this, we no longer
 		 * are (but don't penalize sender: we don't know if it was
 		 * good or bad). */
 		remove_unknown_scid(gm->daemon->seeker, &scid, true);
@@ -704,7 +704,7 @@ bad:
 	txout_failures_add(gm->txf, scid);
 out:
 	tal_free(pca);
-	/* If we looking specifically for this, we no longer are. */
+	/* If we were looking specifically for this, we no longer are. */
 	remove_unknown_scid(gm->daemon->seeker, &scid, false);
 }
 
@@ -774,7 +774,7 @@ static const char *process_channel_update(const tal_t *ctx,
 	} else {
 		/* Is this the first update in either direction?  If so,
 		 * rewrite channel_announcement so timestamp is correct. */
-		if (!gossmap_chan_set(chan, dir))
+		if (!gossmap_chan_set(chan, !dir))
 			gossip_store_set_timestamp(gm->daemon->gs, chan->cann_off, timestamp);
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> Open for merging new PRs until the next PR freeze date is confirmed!

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

Looking at #7689, it appears gossmap still has a reference to a deleted channel.  I think this is a bug, but adding the deleted channel to the txout_failures map causes any lookup of the channel to be avoided for some time afterward, so it's hard to catch.  However, once the txout_failures map is also pruned, and a fresh channel update comes in, we again try to look up the channel announcement, which has already been marked deleted in the gossip store, causing the crash.

The resolution could be either allowing the deleted channel announcement to be accessed again anyhow, or, just removing it from the map entirely so we can forget about it entirely and move on.  Here I've opted for the latter.

Testing is difficult, as there's a one hour pruning cycling on the txout_failures map.  Maybe we can make this timeout shorter when dev-fast-gossip-prune is set?