### PR TITLE
meta: Mark the root pyproject as not a package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ name = "cln-meta-project"
 version = "0.1.0"
 description = "Just a helper to get our python dependencies under control"
 authors = ["Christian Decker <cdecker@blockstream.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 # Build dependencies belong here


### PR DESCRIPTION
This was complaining a whole bunch when running poetry install in the root.
Marking as not an installable package removes that warning.
