### PR TITLE
64 bit gs offsets to fix gossip_store crashes

### DIFF
--- a/common/gossmap.h
+++ b/common/gossmap.h
@@ -12,18 +12,18 @@ struct sciddir_or_pubkey;
 
 struct gossmap_node {
 	/* Offset in memory map for node_announce, or 0. */
-	u32 nann_off;
+	u64 nann_off;
 	u32 num_chans;
 	u32 *chan_idxs;
 };
 
 struct gossmap_chan {
-	u32 cann_off;
-	/* Technically redundant, but we have a hole anyway: from cann_off */
-	u32 plus_scid_off;
+	u64 cann_off;
+	/* FIXME: Technically redundant */
+	u64 plus_scid_off;
 	/* Offsets of cupdates (0 if missing).  Logically inside half_chan,
 	 * but that would add padding. */
-	u32 cupdate_off[2];
+	u64 cupdate_off[2];
 	/* two nodes we connect (lesser idx first) */
 	struct half_chan {
 		/* Top bit indicates it's enabled */
@@ -57,7 +57,7 @@ struct gossmap *gossmap_load(const tal_t *ctx, const char *filename,
 			 typesafe_cb_preargs(bool, void *, (unknown_record), (cbarg), \
 					     struct gossmap *,		\
 					     int type,			\
-					     size_t off,		\
+					     u64 off,			\
 					     size_t msglen),		\
 			 (cbarg))
 
@@ -70,7 +70,7 @@ struct gossmap *gossmap_load_fd_(const tal_t *ctx, int fd,
 						      void *cb_arg),
 				 bool (*unknown_record)(struct gossmap *map,
 							int type,
-							size_t off,
+							u64 off,
 							size_t msglen,
 							void *cb_arg),
 				 void *cb_arg);
@@ -306,7 +306,7 @@ void gossmap_iter_fast_forward(const struct gossmap *map,
 void gossmap_iter_end(const struct gossmap *map, struct gossmap_iter *iter);
 
 /* For debugging: returns length read, and total known length of file */
-size_t gossmap_lengths(const struct gossmap *map, size_t *total);
+u64 gossmap_lengths(const struct gossmap *map, u64 *total);
 
 /* Debugging: connectd wants to enumerate fds */
 int gossmap_fd(const struct gossmap *map);

--- a/gossipd/gossip_store.c
+++ b/gossipd/gossip_store.c
@@ -555,7 +555,7 @@ void gossip_store_del(struct gossip_store *gs,
 		      u64 offset,
 		      int type)
 {
-	u32 next_index;
+	u64 next_index;
 
 	assert(offset > sizeof(struct gossip_hdr));
 	next_index = gossip_store_set_flag(gs, offset,

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -654,24 +654,24 @@ void gossmap_manage_handle_get_txout_reply(struct gossmap_manage *gm, const u8 *
 
 	/* We have reports of doubled-up channel_announcements, hence this check! */
 	struct gossmap_chan *chan;
-	size_t before_length_processed, before_total_length;
+	u64 before_length_processed, before_total_length;
 
 	before_length_processed = gossmap_lengths(gm->raw_gossmap, &before_total_length);
 	chan = gossmap_find_chan(gm->raw_gossmap, &scid);
 	if (chan) {
-		status_broken("Redundant channel_announce for scid %s at off %u (gossmap %zu/%zu, store %"PRIu64")",
+		status_broken("Redundant channel_announce for scid %s at off %"PRIu64" (gossmap %"PRIu64"/%"PRIu64", store %"PRIu64")",
 			      fmt_short_channel_id(tmpctx, scid), chan->cann_off,
 			      before_length_processed, before_total_length,
 			      gossip_store_len_written(gm->daemon->gs));
 		goto out;
 	} else {
-		size_t after_length_processed, after_total_length;
+		u64 after_length_processed, after_total_length;
 		/* Good, now try refreshing in case it somehow slipped in! */
 		gossmap = gossmap_manage_get_gossmap(gm);
 		after_length_processed = gossmap_lengths(gm->raw_gossmap, &after_total_length);
 		chan = gossmap_find_chan(gm->raw_gossmap, &scid);
 		if (chan) {
-			status_broken("Redundant channel_announce *AFTER REFRESH* for scid %s at off %u (gossmap was %zu/%zu, now %zu/%zu, store %"PRIu64")",
+			status_broken("Redundant channel_announce *AFTER REFRESH* for scid %s at off %"PRIu64" (gossmap was %"PRIu64"/%"PRIu64", now %"PRIu64"/%"PRIu64", store %"PRIu64")",
 				      fmt_short_channel_id(tmpctx, scid), chan->cann_off,
 				      before_length_processed, before_total_length,
 				      after_length_processed, after_total_length,

--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -510,7 +510,7 @@ static void json_add_node(struct json_stream *js,
 						&na_tlvs)) {
 			plugin_log(plugin, LOG_BROKEN,
 				   "Cannot parse stored node_announcement"
-				   " for %s at %u: %s",
+				   " for %s at %"PRIu64": %s",
 				   fmt_node_id(tmpctx, &node_id),
 				   n->nann_off,
 				   tal_hex(tmpctx, nannounce));


### PR DESCRIPTION
Since we don't compact the gossmap on the fly (FIXME!) we can easily surpass 4GB in the gossmap, and 32 bit offsets are not sufficient.

I'm a bit surprised we don't crash immediately, but we've definitely seen issues.

Changelog-Fixed: gossipd: crash errors with large gossip_store (>4MB) growth on longer-running nodes.
Fixes: #7689 (maybe!)