### PR TITLE
doc: gRPC SSL certificate documentation improvements

### DIFF
--- a/doc/developers-guide/app-development/grpc.md
+++ b/doc/developers-guide/app-development/grpc.md
@@ -25,7 +25,7 @@ The plugin only runs when `lightningd` is configured with the option `--grpc-por
 - `server.pem` and `server-key.pem`: this is the identity (certificate and private key) used by the plugin to authenticate itself. It is signed by the CA, and the client will verify its identity.
 - `client.pem` and `client-key.pem`: this is an example identity that can be used by a client to connect to the plugin, and issue requests. It is also signed by the CA.
 
-These files are generated with sane defaults, however you can generate custom certificates should you require some changes (see [below](doc:app-development#generating-custom-certificates) for details).
+These files are generated with sane defaults, however you can generate custom certificates should you require some changes (see [below](doc:grpc#generating-custom-certificates) for details).
 
 The client needs a valid mTLS identity in order to connect to the plugin, so copy over the `ca.pem`, `client.pem` and `client-key.pem` files from the node to your project directory.
 
@@ -107,7 +107,7 @@ used as `--grpc-port` option when we started our node.
 
 In this example, we first load the client identity as well as the CA certificate so we can verify the server's identity against it. We then create a `creds` instance using those details. Next we open a secure channel, i.e., a channel over TLS with verification of identities.
 
-Notice that we override the expected SSL name with `cln`. This is required because the plugin does not know the domain under which it will be reachable, and will therefore use `cln` as a standin. See [custom certificate generation](doc:app-development#generating-custom-certificates) for how this could be changed.
+Notice that we override the expected SSL name with `cln`. This is required because the plugin does not know the domain under which it will be reachable, and will therefore use `cln` as a standin. See [custom certificate generation](doc:grpc#generating-custom-certificates) for how this could be changed.
 
 We then use the channel to instantiate the `NodeStub` representing the service and its methods, so we can finally call the `Getinfo` method with default arguments.
 


### PR DESCRIPTION
## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.

Adds some additional documentation around generating custom gRPC SSL certificates.
1. Fixes anchor links to point to the `gprc` page instead of redirecting to `app-development`.
2. Adds a clarifying example depicting that "lightning" directory should actually be the network subdirectory, as certs are stored there.
3. Adds an additional section of documentation for generating SSL certificates using Subject Alternative Names.

## Context

After struggling with properly generating custom certificates for a long time while trying to run the API under both Tor and SSL, as well as allow another local service to communicate with the gRPC APIs, I'm submitting the process that worked for me as candidate for documentation improvements. From memory, the problematic issues were:

1) Generating new certificates using the existing documentation didn't preserve the `SAN` from the original default certificate, including `localhost`, `127.0.0.1` and `cln` etc.
2) Generating a new certificate using the existing documentation suggests to use `CN` for the "production" domain, but browsers and other common SSL client libraries complain that verification via `SAN` is required and throw an error (as of circa 2017?).

## Caveat

Not exactly an SSL expert here, so a review on best practices would be appreciated. I used the following resources to assemble this solution:
* https://docs.corelightning.org/docs/grpc
* https://gist.github.com/yidas/af42d2952d85c0951c1722fcd68716c6
* https://docs.openssl.org/3.0/man1/openssl-req/#configuration-file-format

Also, this [page](https://raymii.org/s/tutorials/OpenSSL_generate_self_signed_cert_with_Subject_Alternative_name_oneliner.html) suggests it could be possible to do this with a one-liner due to this `openssl` [commit](https://github.com/levitte/openssl/commit/ab14453730ca8e9f8281b3c47470f76448fb69d3). Just saying, there may be a better way to do this.