### PR TITLE
gossipd: extra debugging when inject fails.

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -534,7 +534,10 @@ static void inject_gossip(struct daemon *daemon, const u8 *msg)
 	case WIRE_CHANNEL_UPDATE:
 		err = gossmap_manage_channel_update(tmpctx,
 						    daemon->gm,
-						    take(goss), NULL);
+						    goss, NULL);
+		if (err)
+			status_debug("update %s gave error %s",
+				     tal_hex(tmpctx, goss), err);
 		break;
 	default:
 		err = tal_fmt(tmpctx, "unknown gossip type %i",

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -734,8 +734,11 @@ static const char *process_channel_update(const tal_t *ctx,
 	chan = gossmap_find_chan(gossmap, &scid);
 	if (!chan) {
 		/* Did we explicitly reject announce?  Ignore completely. */
-		if (in_txout_failures(gm->txf, scid))
+		if (in_txout_failures(gm->txf, scid)) {
+			status_debug("Previously-rejected announce for %s",
+				     fmt_short_channel_id(tmpctx, scid));
 			return NULL;
+		}
 
 		/* Seeker may want to ask about this. */
 		query_unknown_channel(gm->daemon, source_peer, scid);
@@ -767,6 +770,8 @@ static const char *process_channel_update(const tal_t *ctx,
 		u32 prev_timestamp
 			= gossip_store_get_timestamp(gm->daemon->gs, chan->cupdate_off[dir]);
 		if (prev_timestamp >= timestamp) {
+			status_debug("Too-old update for %s",
+				     fmt_short_channel_id(tmpctx, scid));
 			/* Too old, ignore */
 			return NULL;
 		}
@@ -850,11 +855,15 @@ const char *gossmap_manage_channel_update(const tal_t *ctx,
 	}
 
 	/* Don't accept ancient or far-future timestamps. */
-	if (!timestamp_reasonable(gm->daemon, timestamp))
+	if (!timestamp_reasonable(gm->daemon, timestamp)) {
+		status_debug("Unreasonable timestamp in %s", tal_hex(tmpctx, update));
 		return NULL;
+	}
 
 	/* Still waiting? */
 	if (map_get(&gm->pending_ann_map, scid)) {
+		status_debug("Enqueueing update for announcne %s",
+			     tal_hex(tmpctx, update));
 		enqueue_cupdate(&gm->pending_cupdates,
 				scid,
 				&signature,
@@ -873,6 +882,8 @@ const char *gossmap_manage_channel_update(const tal_t *ctx,
 
 	/* Too early? */
 	if (map_get(&gm->early_ann_map, scid)) {
+		status_debug("Enqueueing update for too early %s",
+			     tal_hex(tmpctx, update));
 		enqueue_cupdate(&gm->early_cupdates,
 				scid,
 				&signature,

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1845,8 +1845,8 @@ def test_addgossip(node_factory):
                                      opts={'log-level': 'io'})
 
     # We should get two node_announcements, one channel_announcement, and two
-    # channel_update.
-    l3 = node_factory.get_node()
+    # channel_update.  We deliberately inject bad gossip!
+    l3 = node_factory.get_node(allow_bad_gossip=True)
 
     # 0x0100 = channel_announcement
     # 0x0102 = channel_update


### PR DESCRIPTION
test_closing_different_fees fails:

```
2024-10-14T08:43:30.2733614Z
2024-10-14T08:43:30.2734133Z         # Now wait for them all to hit normal state, do payments
2024-10-14T08:43:30.2735205Z >       l1.daemon.wait_for_logs(['update for channel .* now ACTIVE'] * num_peers
2024-10-14T08:43:30.2736233Z                                 + ['to CHANNELD_NORMAL'] * num_peers)
2024-10-14T08:43:30.2736725Z
2024-10-14T08:43:30.2736903Z tests/test_closing.py:230:
...
2024-10-14T08:43:30.2761325Z E                   TimeoutError: Unable to find "[re.compile('update for channel .* now ACTIVE')]" in logs.
```

For some reason one of the channel_update injections does *not* evoke this message from gossipd...

> [!IMPORTANT]
> Open for merging new PRs until the next PR freeze date is confirmed!

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.