### PR TITLE
lightningd: Default value for `received_time` in `listforwards` to 0

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -19748,7 +19748,7 @@
                 "received_time": {
                   "type": "number",
                   "description": [
-                    "The UNIX timestamp when this was received."
+                    "The UNIX timestamp when this was received (may be zero for old forwards)."
                   ]
                 },
                 "out_channel": {

--- a/doc/schemas/lightning-listforwards.json
+++ b/doc/schemas/lightning-listforwards.json
@@ -129,7 +129,7 @@
             "received_time": {
               "type": "number",
               "description": [
-                "The UNIX timestamp when this was received."
+                "The UNIX timestamp when this was received (may be zero for old forwards)."
               ]
             },
             "out_channel": {

--- a/lightningd/forwards.c
+++ b/lightningd/forwards.c
@@ -134,19 +134,11 @@ void json_add_forwarding_fields(struct json_stream *response,
 		json_add_string(response, "style",
 				forward_style_name(cur->forward_style));
 
-#ifdef COMPAT_V070
-		/* If a forwarding doesn't have received_time it was created
-		 * before we added the tracking, do not include it here. */
-	if (cur->received_time.ts.tv_sec) {
-		json_add_timeabs(response, "received_time", cur->received_time);
-		if (cur->resolved_time)
-			json_add_timeabs(response, "resolved_time", *cur->resolved_time);
-	}
-#else
+	/* Forwards didn't originally have received_time. They should be 0
+	   in the database due to a previous migration. */
 	json_add_timeabs(response, "received_time", cur->received_time);
 	if (cur->resolved_time)
 		json_add_timeabs(response, "resolved_time", *cur->resolved_time);
-#endif
 }
 
 static void listforwardings_add_forwardings(struct json_stream *response,


### PR DESCRIPTION
This pull request fixes #7157 by altering the JsonRpc return value of `listforwards` to always return a value for the `received_time` field, initializing it to `0` if not found. These values could be missing as a result of forwarding attempts that were created prior the implementation of tracking this data, ostensibly in `v0.7.0` (?).

This also removes the `COMPAT_V070` compiler directive logic for `forwards.c`. Since `received_time` is `required` by the JSON schema, the old backward compatibility strategy is breaking and no longer viable.

## Alternative implementation approaches

I wasn't 100% sure which layer to address this issue in. Some alternative implementation ideas were:

1. Add a `default` key to the `received_time` field in the `listforwards` response definition in the JSON schema [here](https://github.com/ElementsProject/lightning/blob/fe344ee75b8a5475a1735574eac4d1c64aad559d/doc/schemas/lightning-listforwards.json#L129). This didn't produce any change to `cln-rpc/src/model.rs`, so the assumption is this is unsupported.
2. Remove `received_time` as a `required` field in the response schema [here](https://github.com/ElementsProject/lightning/blob/fe344ee75b8a5475a1735574eac4d1c64aad559d/doc/schemas/lightning-listforwards.json#L89). Decided against this because it felt like more of a breaking change to the API from a client perspective.
3. ~Create a database migration altering the `forwards` table setting `received_time` to 0.~ (see [comment below](#issuecomment-2419179548))
4. Remove the conditional code in `forwards.c` processed by the `COMPAT_V070` compiler directive. The compatibility changes are turned on but they are incompatible with the current schema's field requirement for `received_time`. Need to ask out under which conditions compatibility can be removed. <--- ended up doing this one :)

## Questions

1. Can the backwards compatibility for `listforwards` be removed? <--- ended up doing this :)
2. Doubtful, but is there a way to use conditionals which test for previous `COMPAT_V*` versions in the command schemas, `lightning-listfowards.json` with the idea of conditionally requiring the field?
3. Can we consider `COMPAT_V070` be considered fully deprecated, @cdecker mentioned on Discord it's generally 6 months, but this seems ancient?

> [!IMPORTANT]
> Open for merging new PRs until the next PR freeze date is confirmed!

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.