### PR TITLE
Injectpaymentonion

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -51,6 +51,7 @@ enum jsonrpc_errcode {
 	PAY_INSUFFICIENT_FUNDS = 215,
 	PAY_UNREACHABLE = 216,
 	PAY_USER_ERROR = 217,
+	PAY_INJECTPAYMENTONION_FAILED = 218,
 
 	/* `fundchannel` or `withdraw` errors */
 	FUND_MAX_EXCEEDED = 300,

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -14979,6 +14979,131 @@
         }
       ]
     },
+    "lightning-injectpaymentonion.json": {
+      "$schema": "../rpc-schema-draft.json",
+      "type": "object",
+      "additionalProperties": false,
+      "rpc": "injectpaymentonion",
+      "title": "Send a payment with a custom onion packet",
+      "description": [
+        "The **injectpaymentonion** RPC command causes the node to receive a payment attempt similar to the way it would receive one from a peer. The onion packet is unwrapped, then handled normally: either as a local payment, or forwarded to the next peer.",
+        "Compared to lightning-sendonion(7): the handling of blinded paths and self-payments is trivial, and the interface blocks until the payment succeeds or fails."
+      ],
+      "request": {
+        "required": [
+          "onion",
+          "payment_hash",
+          "amount_msat",
+          "cltv_expiry",
+          "partid",
+          "groupid"
+        ],
+        "properties": {
+          "onion": {
+            "type": "hex",
+            "description": [
+              "Hex-encoded 1366 bytes long blob that was returned by either of the tools that can generate onions. It contains the payloads destined for each hop and some metadata. Please refer to [BOLT 04][bolt04] for further details. If is specific to the route that is being used and the *payment_hash* used to construct, and therefore cannot be reused for other payments or to attempt a separate route. The custom onion can generally be created using the `devtools/onion` CLI tool, or the **createonion** RPC command."
+            ]
+          },
+          "payment_hash": {
+            "type": "hash",
+            "description": [
+              "Specifies the 32 byte hex-encoded hash to use as a challenge to the HTLC that we are sending. It is specific to the onion and has to match the one the onion was created with."
+            ]
+          },
+          "amount_msat": {
+            "type": "msat",
+            "description": [
+              "The amount for the first HTLC in millisatoshis.  This is also the amount which will be forwarded to the first peer (if any) as we do not charge fees on our own payments."
+            ]
+          },
+          "cltv_expiry": {
+            "type": "u16",
+            "description": [
+              "The cltv_expiry for the first HTLC in blocks.  This must be greater than the current blockheight."
+            ]
+          },
+          "partid": {
+            "type": "u64",
+            "description": [
+              "The non-zero identifier for multiple parallel partial payments with the same *payment_hash*."
+            ]
+          },
+          "groupid": {
+            "type": "u64",
+            "description": [
+              "Grouping key to disambiguate multiple attempts to pay the same *payment_hash*.  All payments in other groups must be completed before starting a new group."
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": [
+              "Can be used to provide a human readable reference to retrieve the payment at a later time."
+            ]
+          },
+          "invstring": {
+            "type": "string",
+            "description": [
+              "Usually a bolt11 or bolt12 string, which, it will be returned in *waitsendpay* and *listsendpays* results."
+            ]
+          },
+          "localinvreqid": {
+            "type": "hash",
+            "description": [
+              "`localinvreqid` is used by offers to link a payment attempt to a local `invoice_request` offer created by lightningd-invoicerequest(7)."
+            ]
+          }
+        }
+      },
+      "response": {
+        "required": [
+          "created_index",
+          "created_at",
+          "completed_at",
+          "payment_preimage"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "u64",
+            "description": [
+              "The UNIX timestamp showing when this payment was initiated."
+            ]
+          },
+          "completed_at": {
+            "type": "u64",
+            "description": [
+              "The UNIX timestamp showing when this payment was completed."
+            ]
+          },
+          "created_index": {
+            "type": "u64",
+            "description": [
+              "1-based index indicating order this payment was created in."
+            ]
+          }
+        }
+      },
+      "errors": [
+        "The following error codes may occur:",
+        "",
+        "- 218: injectpaymentonion failed",
+        "",
+        "The *onionreply* is returned in the error details, which can be unwrapped to discover the error"
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+      ],
+      "see_also": [
+        "lightning-createonion(7)",
+        "lightning-sendonion(7)",
+        "lightning-listsendpays(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>",
+        "",
+        "[bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md"
+      ]
+    },
     "lightning-invoice.json": {
       "$schema": "../rpc-schema-draft.json",
       "type": "object",

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -66,6 +66,7 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-getroute.7 \
 	doc/lightning-getroutes.7 \
 	doc/lightning-help.7 \
+	doc/lightning-injectpaymentonion.7 \
 	doc/lightning-invoice.7 \
 	doc/lightning-invoicerequest.7 \
 	doc/lightning-keysend.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -76,6 +76,7 @@ Core Lightning Documentation
    lightning-getroutes <lightning-getroutes.7.md>
    lightning-help <lightning-help.7.md>
    lightning-hsmtool <lightning-hsmtool.8.md>
+   lightning-injectpaymentonion <lightning-injectpaymentonion.7.md>
    lightning-invoice <lightning-invoice.7.md>
    lightning-invoicerequest <lightning-invoicerequest.7.md>
    lightning-keysend <lightning-keysend.7.md>

--- a/doc/schemas/lightning-injectpaymentonion.json
+++ b/doc/schemas/lightning-injectpaymentonion.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "../rpc-schema-draft.json",
+  "type": "object",
+  "additionalProperties": false,
+  "rpc": "injectpaymentonion",
+  "title": "Send a payment with a custom onion packet",
+  "description": [
+    "The **injectpaymentonion** RPC command causes the node to receive a payment attempt similar to the way it would receive one from a peer. The onion packet is unwrapped, then handled normally: either as a local payment, or forwarded to the next peer.",
+    "Compared to lightning-sendonion(7): the handling of blinded paths and self-payments is trivial, and the interface blocks until the payment succeeds or fails."
+  ],
+  "request": {
+    "required": [
+      "onion",
+      "payment_hash",
+      "amount_msat",
+      "cltv_expiry",
+      "partid",
+      "groupid"
+    ],
+    "properties": {
+      "onion": {
+        "type": "hex",
+        "description": [
+          "Hex-encoded 1366 bytes long blob that was returned by either of the tools that can generate onions. It contains the payloads destined for each hop and some metadata. Please refer to [BOLT 04][bolt04] for further details. If is specific to the route that is being used and the *payment_hash* used to construct, and therefore cannot be reused for other payments or to attempt a separate route. The custom onion can generally be created using the `devtools/onion` CLI tool, or the **createonion** RPC command."
+        ]
+      },
+      "payment_hash": {
+        "type": "hash",
+        "description": [
+          "Specifies the 32 byte hex-encoded hash to use as a challenge to the HTLC that we are sending. It is specific to the onion and has to match the one the onion was created with."
+        ]
+      },
+      "amount_msat": {
+        "type": "msat",
+        "description": [
+          "The amount for the first HTLC in millisatoshis.  This is also the amount which will be forwarded to the first peer (if any) as we do not charge fees on our own payments."
+        ]
+      },
+      "cltv_expiry": {
+        "type": "u16",
+        "description": [
+          "The cltv_expiry for the first HTLC in blocks.  This must be greater than the current blockheight."
+        ]
+      },
+      "partid": {
+        "type": "u64",
+        "description": [
+          "The non-zero identifier for multiple parallel partial payments with the same *payment_hash*."
+        ]
+      },
+      "groupid": {
+        "type": "u64",
+        "description": [
+          "Grouping key to disambiguate multiple attempts to pay the same *payment_hash*.  All payments in other groups must be completed before starting a new group."
+        ]
+      },
+      "label": {
+        "type": "string",
+        "description": [
+          "Can be used to provide a human readable reference to retrieve the payment at a later time."
+        ]
+      },
+      "invstring": {
+        "type": "string",
+        "description": [
+          "Usually a bolt11 or bolt12 string, which, it will be returned in *waitsendpay* and *listsendpays* results."
+        ]
+      },
+      "localinvreqid": {
+        "type": "hash",
+        "description": [
+          "`localinvreqid` is used by offers to link a payment attempt to a local `invoice_request` offer created by lightningd-invoicerequest(7)."
+        ]
+      }
+    }
+  },
+  "response": {
+    "required": [
+      "created_index",
+      "created_at",
+      "completed_at",
+      "payment_preimage"
+    ],
+    "properties": {
+      "created_at": {
+        "type": "u64",
+        "description": [
+          "The UNIX timestamp showing when this payment was initiated."
+        ]
+      },
+      "completed_at": {
+        "type": "u64",
+        "description": [
+          "The UNIX timestamp showing when this payment was completed."
+        ]
+      },
+      "created_index": {
+        "type": "u64",
+        "description": [
+          "1-based index indicating order this payment was created in."
+        ]
+      }
+    }
+  },
+  "errors": [
+    "The following error codes may occur:",
+    "",
+    "- 218: injectpaymentonion failed",
+    "",
+    "The *onionreply* is returned in the error details, which can be unwrapped to discover the error"
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> is mainly responsible."
+  ],
+  "see_also": [
+    "lightning-createonion(7)",
+    "lightning-sendonion(7)",
+    "lightning-listsendpays(7)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>",
+    "",
+    "[bolt04]: https://github.com/lightning/bolts/blob/master/04-onion-routing.md"
+  ]
+}

--- a/lightningd/htlc_set.c
+++ b/lightningd/htlc_set.c
@@ -115,7 +115,7 @@ void htlc_set_add(struct lightningd *ld,
 	if (!details) {
 		log_debug(hin->key.channel->log, "payment failed: %s", err);
 		local_fail_in_htlc(hin,
-				   take(failmsg_incorrect_or_unknown(NULL, ld, hin)));
+				   take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
 		return;
 	}
 
@@ -125,7 +125,7 @@ void htlc_set_add(struct lightningd *ld,
 		log_debug(ld->log, "Missing payment_secret, but required for %s",
 			  fmt_sha256(tmpctx, &hin->payment_hash));
 		local_fail_in_htlc(hin,
-				   take(failmsg_incorrect_or_unknown(NULL, ld, hin)));
+				   take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
 		return;
 	}
 
@@ -149,7 +149,7 @@ void htlc_set_add(struct lightningd *ld,
 		/* We check this now, since we want to fail with this as soon
 		 * as possible, to avoid other probing attacks. */
 		if (!payment_secret) {
-			local_fail_in_htlc(hin, take(failmsg_incorrect_or_unknown(NULL, ld, hin)));
+			local_fail_in_htlc(hin, take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
 			return;
 		}
 		tal_arr_expand(&set->htlcs, hin);
@@ -215,7 +215,7 @@ void htlc_set_add(struct lightningd *ld,
 	/* This catches the case of the first payment in a set. */
 	if (!payment_secret) {
 		htlc_set_fail(set,
-			      take(failmsg_incorrect_or_unknown(NULL, ld, hin)));
+			      take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
 		return;
 	}
 }

--- a/lightningd/htlc_set.c
+++ b/lightningd/htlc_set.c
@@ -8,15 +8,32 @@
 #include <lightningd/lightningd.h>
 #include <lightningd/peer_htlcs.h>
 
-/* If an HTLC times out, we need to free entire set, since we could be processing
- * it in invoice.c right now. */
-static void htlc_set_hin_destroyed(struct htlc_in *hin,
-				   struct htlc_set *set)
+static struct incoming_payment *new_inpay(const tal_t *ctx,
+					  struct logger *log,
+					  struct amount_msat msat,
+					  void (*fail)(void *, const u8 *),
+					  void (*succeeded)(void *,
+							    const struct preimage *),
+					  void *arg)
 {
-	for (size_t i = 0; i < tal_count(set->htlcs); i++) {
-		if (set->htlcs[i] == hin) {
+	struct incoming_payment *inpay = tal(ctx, struct incoming_payment);
+	inpay->log = log;
+	inpay->msat = msat;
+	inpay->fail = fail;
+	inpay->succeeded = succeeded;
+	inpay->arg = arg;
+	return inpay;
+}
+
+/* If an HTLC times out, we need to free entire set, since we could be
+ * processing it in invoice.c right now. */
+static void htlc_set_inpay_destroyed(struct incoming_payment *inpay,
+				     struct htlc_set *set)
+{
+	for (size_t i = 0; i < tal_count(set->inpays); i++) {
+		if (set->inpays[i] == inpay) {
 			/* Don't try to re-fail this HTLC! */
-			tal_arr_remove(&set->htlcs, i);
+			tal_arr_remove(&set->inpays, i);
 			/* Kind of the correct failure code. */
 			htlc_set_fail(set, take(towire_mpp_timeout(NULL)));
 			return;
@@ -49,42 +66,45 @@ void htlc_set_fail_(struct htlc_set *set, const u8 *failmsg TAKES,
 	if (taken(failmsg))
 		tal_steal(set, failmsg);
 
-	for (size_t i = 0; i < tal_count(set->htlcs); i++) {
+	for (size_t i = 0; i < tal_count(set->inpays); i++) {
 		const u8 *this_failmsg;
 
 		/* Don't remove from set */
-		tal_del_destructor2(set->htlcs[i], htlc_set_hin_destroyed, set);
+		tal_del_destructor2(set->inpays[i], htlc_set_inpay_destroyed, set);
 
 		if (tal_bytelen(failmsg) == 0)
-			this_failmsg = towire_incorrect_or_unknown_payment_details(tmpctx, set->htlcs[i]->msat, get_block_height(set->ld->topology));
+			this_failmsg = towire_incorrect_or_unknown_payment_details(tmpctx, set->inpays[i]->msat, get_block_height(set->ld->topology));
 		else
 			this_failmsg = failmsg;
 
-		log_debug(set->htlcs[i]->key.channel->log,
+		log_debug(set->inpays[i]->log,
 			  "failing with %s: %s:%u",
 			  onion_wire_name(fromwire_peektype(this_failmsg)),
 			  file, line);
-		local_fail_in_htlc(set->htlcs[i], this_failmsg);
+		/* Attach inpays[i] to set so it's freed below (not with arg) */
+		tal_steal(set->inpays, set->inpays[i]);
+		set->inpays[i]->fail(set->inpays[i]->arg, this_failmsg);
 	}
 	tal_free(set);
 }
 
 void htlc_set_fulfill(struct htlc_set *set, const struct preimage *preimage)
 {
-	for (size_t i = 0; i < tal_count(set->htlcs); i++) {
+	for (size_t i = 0; i < tal_count(set->inpays); i++) {
 		/* Don't remove from set */
-		tal_del_destructor2(set->htlcs[i], htlc_set_hin_destroyed, set);
+		tal_del_destructor2(set->inpays[i],
+				    htlc_set_inpay_destroyed, set);
 
-		/* mark that we filled -- needed for tagging coin mvt */
-		set->htlcs[i]->we_filled = tal(set->htlcs[i], bool);
-		*set->htlcs[i]->we_filled = true;
-		fulfill_htlc(set->htlcs[i], preimage);
+		/* Reparent set->inpays[i] so it's freed with set */
+		tal_steal(set->inpays, set->inpays[i]);
+		set->inpays[i]->succeeded(set->inpays[i]->arg, preimage);
 	}
 	tal_free(set);
 }
 
 static struct htlc_set *new_htlc_set(struct lightningd *ld,
-				     struct htlc_in *hin,
+				     struct incoming_payment *inpay,
+				     const struct sha256 *payment_hash,
 				     struct amount_msat total_msat)
 {
 	struct htlc_set *set;
@@ -92,10 +112,10 @@ static struct htlc_set *new_htlc_set(struct lightningd *ld,
 	set = tal(ld, struct htlc_set);
 	set->ld = ld;
 	set->total_msat = total_msat;
-	set->payment_hash = hin->payment_hash;
+	set->payment_hash = *payment_hash;
 	set->so_far = AMOUNT_MSAT(0);
-	set->htlcs = tal_arr(set, struct htlc_in *, 1);
-	set->htlcs[0] = hin;
+	set->inpays = tal_arr(set, struct incoming_payment *, 1);
+	set->inpays[0] = inpay;
 
 	/* BOLT #4:
 	 * - MUST fail all HTLCs in the HTLC set after some reasonable
@@ -110,11 +130,17 @@ static struct htlc_set *new_htlc_set(struct lightningd *ld,
 	return set;
 }
 
-void htlc_set_add(struct lightningd *ld,
-		  struct htlc_in *hin,
-		  struct amount_msat total_msat,
-		  const struct secret *payment_secret)
+void htlc_set_add_(struct lightningd *ld,
+		   struct logger *log,
+		   struct amount_msat msat,
+		   struct amount_msat total_msat,
+		   const struct sha256 *payment_hash,
+		   const struct secret *payment_secret,
+		   void (*fail)(void *, const u8 *),
+		   void (*succeeded)(void *, const struct preimage *),
+		   void *arg)
 {
+	struct incoming_payment *inpay;
 	struct htlc_set *set;
 	const struct invoice_details *details;
 	const char *err;
@@ -125,23 +151,21 @@ void htlc_set_add(struct lightningd *ld,
 	 *     [Failure Messages](#failure-messages)
 	 *     - Note: "amount paid" specified there is the `total_msat` field.
 	 */
-	details = invoice_check_payment(tmpctx, ld, &hin->payment_hash,
+	details = invoice_check_payment(tmpctx, ld, payment_hash,
 					total_msat, payment_secret, &err);
 	if (!details) {
-		log_debug(hin->key.channel->log, "payment failed: %s", err);
-		local_fail_in_htlc(hin,
-				   take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
+		log_debug(log, "payment failed: %s", err);
+		fail(arg, take(failmsg_incorrect_or_unknown(NULL, ld, msat)));
 		return;
 	}
 
 	/* If we insist on a payment secret, it must always have it */
 	if (feature_is_set(details->features, COMPULSORY_FEATURE(OPT_PAYMENT_SECRET))
 	    && !payment_secret) {
-		log_debug(hin->key.channel->log,
+		log_debug(log,
 			  "Missing payment_secret, but required for %s",
-			  fmt_sha256(tmpctx, &hin->payment_hash));
-		local_fail_in_htlc(hin,
-				   take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
+			  fmt_sha256(tmpctx, payment_hash));
+		fail(arg, take(failmsg_incorrect_or_unknown(NULL, ld, msat)));
 		return;
 	}
 
@@ -149,9 +173,10 @@ void htlc_set_add(struct lightningd *ld,
 	 *  - otherwise, if it supports `basic_mpp`:
 	 *    - MUST add it to the HTLC set corresponding to that `payment_hash`.
 	 */
-	set = htlc_set_map_get(ld->htlc_sets, &hin->payment_hash);
+	inpay = new_inpay(arg, log, msat, fail, succeeded, arg);
+	set = htlc_set_map_get(ld->htlc_sets, payment_hash);
 	if (!set)
-		set = new_htlc_set(ld, hin, total_msat);
+		set = new_htlc_set(ld, inpay, payment_hash, total_msat);
 	else {
 		/* BOLT #4:
 		 *
@@ -165,48 +190,48 @@ void htlc_set_add(struct lightningd *ld,
 		/* We check this now, since we want to fail with this as soon
 		 * as possible, to avoid other probing attacks. */
 		if (!payment_secret) {
-			log_debug(hin->key.channel->log,
+			log_debug(log,
 				  "Missing payment_secret, but required for MPP");
-			local_fail_in_htlc(hin, take(failmsg_incorrect_or_unknown(NULL, ld, hin->msat)));
+			fail(arg, take(failmsg_incorrect_or_unknown(NULL, ld, msat)));
 			return;
 		}
-		tal_arr_expand(&set->htlcs, hin);
+		tal_arr_expand(&set->inpays, inpay);
 	}
 
 	/* Remove from set should hin get destroyed somehow */
-	tal_add_destructor2(hin, htlc_set_hin_destroyed, set);
+	tal_add_destructor2(inpay, htlc_set_inpay_destroyed, set);
 
 	/* BOLT #4:
 	 * - SHOULD fail the entire HTLC set if `total_msat` is not
 	 *   the same for all HTLCs in the set.
 	 */
 	if (!amount_msat_eq(total_msat, set->total_msat)) {
-		log_unusual(ld->log, "Failing HTLC set %s:"
+		log_unusual(log, "Failing HTLC set %s:"
 			    " total_msat %s new htlc total %s",
 			    fmt_sha256(tmpctx, &set->payment_hash),
 			    fmt_amount_msat(tmpctx, set->total_msat),
 			    fmt_amount_msat(tmpctx, total_msat));
 		htlc_set_fail(set,
 			      take(towire_final_incorrect_htlc_amount(NULL,
-								      hin->msat)));
+								      msat)));
 		return;
 	}
 
-	if (!amount_msat_accumulate(&set->so_far, hin->msat)) {
+	if (!amount_msat_accumulate(&set->so_far, msat)) {
 		log_unusual(ld->log, "Failing HTLC set %s:"
 			    " overflow adding %s+%s",
 			    fmt_sha256(tmpctx, &set->payment_hash),
 			    fmt_amount_msat(tmpctx, set->so_far),
-			    fmt_amount_msat(tmpctx, hin->msat));
+			    fmt_amount_msat(tmpctx, msat));
 		htlc_set_fail(set,
 			      take(towire_final_incorrect_htlc_amount(NULL,
-								      hin->msat)));
+								      msat)));
 		return;
 	}
 
 	log_debug(ld->log,
 		  "HTLC set contains %zu HTLCs, for a total of %s out of %s (%spayment_secret)",
-		  tal_count(set->htlcs),
+		  tal_count(set->inpays),
 		  fmt_amount_msat(tmpctx, set->so_far),
 		  fmt_amount_msat(tmpctx, total_msat),
 		  payment_secret ? "" : "no "

--- a/lightningd/htlc_set.h
+++ b/lightningd/htlc_set.h
@@ -9,15 +9,28 @@
 #include <common/utils.h>
 #include <wire/onion_wire.h>
 
-struct htlc_in;
 struct lightningd;
+struct logger;
+
+/* Could be an incoming HTLC, could be a local payment */
+struct incoming_payment {
+	/* Where to log */
+	struct logger *log;
+	/* Amount of this payment */
+	struct amount_msat msat;
+	/* If it fails */
+	void (*fail)(void *arg, const u8 *failmsg TAKES);
+	/* If it succeeded: here's the preimage. */
+	void (*succeeded)(void *arg, const struct preimage *preimage);
+	void *arg;
+};
 
 /* Set of incoming HTLCs for multi-part-payments */
 struct htlc_set {
 	struct lightningd *ld;
 	struct amount_msat total_msat, so_far;
 	struct sha256 payment_hash;
-	struct htlc_in **htlcs;
+	struct incoming_payment **inpays;
 	struct oneshot *timeout;
 };
 
@@ -43,11 +56,28 @@ HTABLE_DEFINE_TYPE(struct htlc_set,
 		   htlc_set_eq,
 		   htlc_set_map);
 
-/* Handles hin: if it completes a set, hands that to invoice_try_pay */
-void htlc_set_add(struct lightningd *ld,
-		  struct htlc_in *hin,
-		  struct amount_msat total_msat,
-		  const struct secret *payment_secret);
+/* Handles arg: if it completes a set, calls invoice_try_pay */
+void htlc_set_add_(struct lightningd *ld,
+		   struct logger *log,
+		   struct amount_msat msat,
+		   struct amount_msat total_msat,
+		   const struct sha256 *payment_hash,
+		   const struct secret *payment_secret,
+		   void (*fail)(void *, const u8 *),
+		   void (*succeeded)(void *, const struct preimage *),
+		   void *arg);
+
+#define htlc_set_add(ld, log, msat, total_msat, payment_hash, payment_secret, \
+		     fail, succeeded, arg)				\
+	htlc_set_add_((ld), (log), (msat), (total_msat), (payment_hash), \
+		      (payment_secret),					\
+		      typesafe_cb_postargs(void, void *,		\
+					   (fail), (arg),		\
+					   const u8 *),			\
+		      typesafe_cb_postargs(void, void *,		\
+					   (succeeded), (arg),		\
+					   const struct preimage *),	\
+		      (arg))
 
 /* Fail every htlc in the set: frees set.  If failmsg is NULL/zero-length,
  * it sends each one a WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS. */

--- a/lightningd/htlc_set.h
+++ b/lightningd/htlc_set.h
@@ -14,6 +14,7 @@ struct lightningd;
 
 /* Set of incoming HTLCs for multi-part-payments */
 struct htlc_set {
+	struct lightningd *ld;
 	struct amount_msat total_msat, so_far;
 	struct sha256 payment_hash;
 	struct htlc_in **htlcs;
@@ -48,8 +49,12 @@ void htlc_set_add(struct lightningd *ld,
 		  struct amount_msat total_msat,
 		  const struct secret *payment_secret);
 
-/* Fail every htlc in the set: frees set */
-void htlc_set_fail(struct htlc_set *set, const u8 *failmsg TAKES);
+/* Fail every htlc in the set: frees set.  If failmsg is NULL/zero-length,
+ * it sends each one a WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS. */
+#define htlc_set_fail(set, failmsg)				\
+	htlc_set_fail_((set), (failmsg), __FILE__, __LINE__)
+void htlc_set_fail_(struct htlc_set *set, const u8 *failmsg TAKES,
+		    const char *file, int line);
 
 /* Fulfill every htlc in the set: frees set */
 void htlc_set_fulfill(struct htlc_set *set, const struct preimage *preimage);

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -176,10 +176,14 @@ static void invoice_payment_add_tlvs(struct json_stream *stream,
 {
 	struct htlc_in *hin;
 	const struct tlv_payload *tlvs;
-	assert(tal_count(hset->htlcs) > 0);
+	assert(tal_count(hset->inpays) > 0);
+
+	/* Only do this if it's actually an HTLC */
+	if ((void *)hset->inpays[0]->fail != (void *)local_fail_in_htlc)
+		return;
 
 	/* Pick the first HTLC as representative for the entire set. */
-	hin = hset->htlcs[0];
+	hin = hset->inpays[0]->arg;
 
 	tlvs = hin->payload->tlv;
 
@@ -291,7 +295,7 @@ invoice_payment_hooks_done(struct invoice_payment_hook_payload *payload STEALS)
 	log_info(ld->log, "Resolved invoice '%s' with amount %s in %zu htlcs",
 		 payload->label->s,
 		 fmt_amount_msat(tmpctx, payload->msat),
-		 payload->set ? tal_count(payload->set->htlcs) : 0);
+		 payload->set ? tal_count(payload->set->inpays) : 0);
 	if (payload->set)
 		htlc_set_fulfill(payload->set, &payload->preimage);
 

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -242,7 +242,7 @@ static const u8 *hook_gives_failmsg(const tal_t *ctx,
 		if (json_tok_streq(buffer, resulttok, "continue")) {
 			return NULL;
 		} else if (json_tok_streq(buffer, resulttok, "reject")) {
-			return failmsg_incorrect_or_unknown(ctx, ld, hin);
+			return failmsg_incorrect_or_unknown(ctx, ld, hin->msat);
 		} else
 			fatal("Invalid invoice_payment hook result: %.*s",
 			      toks[0].end - toks[0].start, buffer);
@@ -275,7 +275,7 @@ invoice_payment_hooks_done(struct invoice_payment_hook_payload *payload STEALS)
 	 * we can also fail */
 	if (!invoices_find_by_label(ld->wallet->invoices, &inv_dbid, payload->label)) {
 		htlc_set_fail(payload->set, take(failmsg_incorrect_or_unknown(
-							 NULL, ld, payload->set->htlcs[0])));
+							 NULL, ld, payload->set->htlcs[0]->msat)));
 		return;
 	}
 
@@ -284,7 +284,7 @@ invoice_payment_hooks_done(struct invoice_payment_hook_payload *payload STEALS)
 			      payload->label, payload->outpoint)) {
 		if (payload->set)
 			htlc_set_fail(payload->set, take(failmsg_incorrect_or_unknown(
-								NULL, ld, payload->set->htlcs[0])));
+								NULL, ld, payload->set->htlcs[0]->msat)));
 		return;
 	}
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -2,10 +2,12 @@
 #include <ccan/json_escape/json_escape.h>
 #include <ccan/mem/mem.h>
 #include <ccan/tal/str/str.h>
+#include <common/blinding.h>
 #include <common/bolt12_merkle.h>
 #include <common/configdir.h>
 #include <common/json_command.h>
 #include <common/json_param.h>
+#include <common/onion_decode.h>
 #include <common/onionreply.h>
 #include <common/route.h>
 #include <common/timeout.h>
@@ -587,11 +589,9 @@ void payment_failed(struct lightningd *ld,
 		failstr = localfail;
 		pay_errcode = PAY_TRY_OTHER_ROUTE;
 	} else if (payment->path_secrets == NULL) {
-		/* This was a payment initiated with `sendonion`, we therefore
+		/* This was a payment initiated with `sendonion`/`injectonionmessage`, we therefore
 		 * don't have the path secrets and cannot decode the error
-		 * onion. Let's store it and hope whatever called `sendonion`
-		 * knows how to deal with these. */
-
+		 * onion. We hand it to the user. */
 		pay_errcode = PAY_UNPARSEABLE_ONION;
 		fail = NULL;
 		failstr = NULL;
@@ -1671,6 +1671,389 @@ static const struct json_command waitsendpay_command = {
 	json_waitsendpay,
 };
 AUTODATA(json_command, &waitsendpay_command);
+
+static struct command_result *
+injectonion_fail(struct command *cmd,
+		 const struct wallet_payment *payment,
+		 enum jsonrpc_errcode pay_errcode,
+		 const struct onionreply *onionreply,
+		 const struct routing_failure *fail,
+		 const char *errmsg,
+		 struct secret *shared_secret)
+{
+	struct json_stream *js;
+
+	/* Turn local errors into onion reply. */
+	if (!onionreply)
+		onionreply = create_onionreply(tmpctx, shared_secret, fail->msg);
+
+	js = json_stream_fail(cmd, PAY_INJECTPAYMENTONION_FAILED, errmsg);
+	/* We wrap the onion reply, as it expects. */
+	json_add_hex_talarr(js, "onionreply",
+			    wrap_onionreply(tmpctx, shared_secret, onionreply)
+			    ->contents);
+
+	json_object_end(js);
+	return command_failed(cmd, js);
+}
+
+static struct command_result *
+injectonion_succeed(struct command *cmd,
+		    const struct wallet_payment *payment,
+		    void *unused)
+{
+	struct json_stream *response = json_stream_success(cmd);
+
+	assert(payment->status == PAYMENT_COMPLETE);
+
+	json_add_u64(response, "created_index", payment->id);
+	json_add_u32(response, "created_at", payment->timestamp);
+	json_add_u32(response, "completed_at", *payment->completed_at);
+	json_add_preimage(response, "payment_preimage", payment->payment_preimage);
+	return command_success(cmd, response);
+}
+
+struct selfpay {
+	struct command *cmd;
+	struct secret shared_secret;
+	u64 partid, groupid;
+	struct sha256 payment_hash;
+};
+
+/* FIXME: Map errors better using payment_failed? */
+static void selfpay_mpp_fail(struct selfpay *selfpay, const u8 *failmsg TAKES)
+{
+	struct onionreply *reply = create_onionreply(tmpctx, &selfpay->shared_secret, failmsg);
+
+	if (taken(failmsg))
+		tal_steal(selfpay->cmd, failmsg);
+
+	payment_failed(selfpay->cmd->ld,
+		       selfpay->cmd->ld->log,
+		       &selfpay->payment_hash,
+		       selfpay->partid,
+		       selfpay->groupid,
+		       reply,
+		       NULL,
+		       NULL);
+}
+
+static void selfpay_mpp_succeeded(struct selfpay *selfpay,
+				  const struct preimage *preimage)
+{
+	payment_succeeded(selfpay->cmd->ld,
+			  &selfpay->payment_hash,
+			  selfpay->partid,
+			  selfpay->groupid,
+			  preimage);
+}
+
+static struct command_result *param_u64_nonzero(struct command *cmd,
+						const char *name,
+						const char *buffer,
+						const jsmntok_t *tok,
+						u64 **val)
+{
+	struct command_result *res = param_u64(cmd, name, buffer, tok, val);
+	if (res == NULL && *val == 0)
+		res = command_fail_badparam(cmd, name, buffer, tok,
+					    "Must be non-zero");
+	return res;
+}
+
+static void register_payment_and_waiter(struct command *cmd,
+					const struct sha256 *payment_hash,
+					u64 partid, u64 groupid,
+					struct amount_msat msat,
+					struct amount_msat msat_sent,
+					struct amount_msat total_msat,
+					const char *label,
+					const char *invstring,
+					struct sha256 *local_invreq_id,
+					const struct secret *shared_secret)
+{
+	wallet_add_payment(cmd,
+			   cmd->ld->wallet,
+			   time_now().ts.tv_sec,
+			   NULL,
+			   payment_hash,
+			   partid,
+			   groupid,
+			   PAYMENT_PENDING,
+			   NULL,
+			   msat,
+			   msat_sent,
+			   total_msat,
+			   NULL,
+			   NULL,
+			   NULL,
+			   NULL,
+			   invstring,
+			   label,
+			   NULL,
+			   NULL,
+			   local_invreq_id);
+
+	/* Now we wait for htlc to resolve (it will need shared_secret!) */
+	add_waitsendpay_waiter(cmd->ld, cmd, payment_hash, partid, groupid,
+			       injectonion_succeed, injectonion_fail,
+			       tal_dup(cmd, struct secret, shared_secret));
+}
+
+static struct command_result *json_injectpaymentonion(struct command *cmd,
+						      const char *buffer,
+						      const jsmntok_t *obj UNNEEDED,
+						      const jsmntok_t *params)
+{
+	u8 *onion;
+	enum onion_wire failcode;
+	struct sha256 *payment_hash;
+	struct lightningd *ld = cmd->ld;
+	const char *label, *invstring;
+	struct pubkey *blinding, *next_path_key;
+	struct amount_msat *msat;
+	u32 *cltv;
+	u64 *partid, *groupid;
+	struct sha256 *local_invreq_id;
+	struct secret shared_secret;
+	struct onionpacket *op;
+	struct onion_payload *payload;
+	struct route_step *rs;
+	u64 failtlvtype;
+	size_t failtlvpos;
+	struct channel *next;
+	struct command_result *ret;
+	const u8 *failmsg;
+	struct htlc_out *hout;
+
+	if (!param_check(cmd, buffer, params,
+			 p_req("onion", param_bin_from_hex, &onion),
+			 p_req("payment_hash", param_sha256, &payment_hash),
+			 p_req("amount_msat", param_msat, &msat),
+			 p_req("cltv_expiry", param_u32, &cltv),
+			 p_req("partid", param_u64_nonzero, &partid),
+			 p_req("groupid", param_u64, &groupid),
+			 p_opt("blinding", param_pubkey, &blinding),
+			 p_opt("label", param_escaped_string, &label),
+			 p_opt("invstring", param_invstring, &invstring),
+			 p_opt("localinvreqid", param_sha256, &local_invreq_id),
+			 NULL))
+		return command_param_failed();
+
+	/* Safety check: reconcile this with previous attempts, check
+	 * partid/groupid uniqueness: we don't know amount or total. */
+	ret = check_progress(cmd->ld, cmd, payment_hash, AMOUNT_MSAT(0),
+			     AMOUNT_MSAT(0),
+			     *partid, *groupid, NULL);
+	if (ret)
+		return ret;
+
+	/* This checks we're not trying to pay our a locally-generated
+	 * invoice_request more than once. */
+	ret = check_invoice_request_usage(cmd, local_invreq_id);
+	if (ret)
+		return ret;
+
+	if (tal_bytelen(onion) != TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE)) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "onion must be %u bytes long",
+				    TOTAL_PACKET_SIZE(ROUTING_INFO_SIZE));
+	}
+
+	op = parse_onionpacket(tmpctx, onion, tal_bytelen(onion),
+			       &failcode);
+	if (!op) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Could not parse onion: %s",
+				    onion_wire_name(failcode));
+	}
+
+	if (!ecdh_maybe_blinding(&op->ephemeralkey,
+				 blinding,
+				 &shared_secret)) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Could not tweak ephemeral key");
+	}
+
+	rs = process_onionpacket(tmpctx, op, &shared_secret,
+				 payment_hash->u.u8,
+				 sizeof(payment_hash->u.u8));
+	if (!rs) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Could not process onion");
+	}
+
+	payload = onion_decode(tmpctx, rs, blinding,
+			       cmd->ld->accept_extra_tlv_types,
+			       *msat, *cltv,
+			       &failtlvtype,
+			       &failtlvpos);
+	if (!payload) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Onion decode for %s failed at type %"PRIu64" offset %zu",
+				    tal_hex(tmpctx, rs->raw_payload),
+				    failtlvtype, failtlvpos);
+	}
+
+	if (payload->final) {
+		struct selfpay *selfpay;
+
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
+
+		selfpay = tal(cmd, struct selfpay);
+		selfpay->cmd = cmd;
+		selfpay->shared_secret = shared_secret;
+		selfpay->partid = *partid;
+		selfpay->groupid = *groupid;
+		selfpay->payment_hash = *payment_hash;
+
+		/* We actually *do* know msat delivered and total msat, but
+		 * then check_progress will complain on the next part, because
+		 * we don't know it then, so leave them 0 */
+		register_payment_and_waiter(cmd,
+					    payment_hash,
+					    *partid, *groupid,
+					    AMOUNT_MSAT(0), *msat, AMOUNT_MSAT(0),
+					    label, invstring, local_invreq_id,
+					    &shared_secret);
+
+		/* Mark it pending now, though htlc_set_add might
+		 * not resolve immediately */
+		fixme_ignore(command_still_pending(cmd));
+		htlc_set_add(cmd->ld, cmd->ld->log, *msat, *payload->total_msat,
+			     payment_hash, payload->payment_secret,
+			     selfpay_mpp_fail, selfpay_mpp_succeeded,
+			     selfpay);
+		return command_its_complicated("htlc_set_add may have immediately succeeded or failed");
+	}
+
+	/* If they use scid, we use exactly the channel they tell us to here! */
+	if (payload->forward_channel) {
+		next = any_channel_by_scid(cmd->ld,
+					   *payload->forward_channel,
+					   false);
+		if (!next)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Unknown scid %s",
+					    fmt_short_channel_id(tmpctx,
+								 *payload->forward_channel));
+
+		if (!channel_state_can_add_htlc(next->state)) {
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "channel %s in state %s",
+					    fmt_short_channel_id(tmpctx,
+								 *payload->forward_channel),
+					    channel_state_str(next->state));
+		}
+	} else {
+		struct node_id nid;
+		struct peer *next_peer;
+
+		node_id_from_pubkey(&nid, payload->forward_node_id);
+		next_peer = peer_by_id(cmd->ld, &nid);
+		if (!next_peer)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Unknown peer %s",
+					    fmt_node_id(tmpctx, &nid));
+
+		next = best_channel(cmd->ld, next_peer, *msat, NULL);
+		if (!next)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "No available channel with peer %s",
+					    fmt_node_id(tmpctx, &nid));
+	}
+
+	if (amount_msat_greater(*msat, next->htlc_maximum_msat)
+	    || amount_msat_less(*msat, next->htlc_minimum_msat)) {
+		/* Are we in old-range grace-period? */
+		if (!time_before(time_now(), next->old_feerate_timeout)
+		    || amount_msat_less(*msat, next->old_htlc_minimum_msat)
+		    || amount_msat_greater(*msat, next->old_htlc_maximum_msat)) {
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Amount %s not in htlc min/max range %s-%s",
+					    fmt_amount_msat(tmpctx, *msat),
+					    fmt_amount_msat(tmpctx, next->htlc_minimum_msat),
+					    fmt_amount_msat(tmpctx, next->htlc_maximum_msat));
+		}
+		log_info(next->log,
+			 "Allowing payment using older htlc_minimum/maximum_msat");
+	}
+
+	/* BOLT #2:
+	 *
+	 * An offering node:
+	 *   - MUST estimate a timeout deadline for each HTLC it offers.
+	 *   - MUST NOT offer an HTLC with a timeout deadline before its
+	 *     `cltv_expiry`.
+	 */
+	/* In our case, G = 1, so we need to expire it one after it's expiration.
+	 * But never offer an expired HTLC; that's dumb. */
+	if (get_block_height(cmd->ld->topology) >= *cltv) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Expiry cltv %u too close to current %u",
+				    *cltv,
+				    get_block_height(ld->topology));
+	}
+
+	/* BOLT #4:
+	 *
+	 *  - if the `cltv_expiry` is more than `max_htlc_cltv` in the future:
+	 *     - return an `expiry_too_far` error.
+	 */
+	if (get_block_height(ld->topology)
+	    + ld->config.max_htlc_cltv < *cltv) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Expiry cltv %u too far from current %u + max %u",
+				    *cltv,
+				    get_block_height(ld->topology),
+				    ld->config.max_htlc_cltv);
+	}
+
+	/* We could have blinding from cmdline or from inside onion. */
+	if (payload->path_key) {
+		struct sha256 sha;
+		blinding_hash_e_and_ss(payload->path_key,
+				       &payload->blinding_ss,
+				       &sha);
+		next_path_key = tal(tmpctx, struct pubkey);
+		blinding_next_path_key(payload->path_key, &sha,
+				       next_path_key);
+	} else
+		next_path_key = NULL;
+
+	if (command_check_only(cmd))
+		return command_check_done(cmd);
+
+	register_payment_and_waiter(cmd,
+				    payment_hash,
+				    *partid, *groupid,
+				    AMOUNT_MSAT(0), *msat, AMOUNT_MSAT(0),
+				    label, invstring, local_invreq_id,
+				    &shared_secret);
+
+	failmsg = send_htlc_out(tmpctx, next, *msat,
+				/* We set final_msat to the same, so fees == 0
+				 * (in fact, we don't know!) */
+				*cltv, *msat,
+				payment_hash,
+				next_path_key, *partid, *groupid,
+				serialize_onionpacket(tmpctx, rs->next),
+				NULL, &hout);
+	if (failmsg) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Could not send to first peer: %s",
+				    onion_wire_name(fromwire_peektype(failmsg)));
+	}
+	return command_still_pending(cmd);
+}
+
+static const struct json_command injectpaymentonion_command = {
+	"injectpaymentonion",
+	json_injectpaymentonion,
+};
+AUTODATA(json_command, &injectpaymentonion_command);
+
 
 static u64 sendpay_index_inc(struct lightningd *ld,
 			     const struct sha256 *payment_hash,

--- a/lightningd/pay.h
+++ b/lightningd/pay.h
@@ -18,8 +18,13 @@ void payment_succeeded(struct lightningd *ld,
 		       u64 partid, u64 groupid,
 		       const struct preimage *rval);
 
-/* hout->failmsg or hout->failonion must be set. */
-void payment_failed(struct lightningd *ld, const struct htlc_out *hout,
+/* failmsg or failonion must be set. */
+void payment_failed(struct lightningd *ld,
+		    struct logger *log,
+		    const struct sha256 *payment_hash,
+		    u64 partid, u64 groupid,
+		    const struct onionreply *failonion,
+		    const u8 *failmsg,
 		    const char *localfail);
 
 /* This json will be also used in 'sendpay_success' notifictaion. */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -739,13 +739,13 @@ const u8 *send_htlc_out(const tal_t *ctx,
 
 /* What's the best channel to this peer?
  * If @hint is set, channel must match that one. */
-static struct channel *best_channel(struct lightningd *ld,
-				    const struct peer *next_peer,
-				    struct amount_msat amt_to_forward,
-				    struct channel *hint)
+struct channel *best_channel(struct lightningd *ld,
+			     const struct peer *next_peer,
+			     struct amount_msat amt_to_forward,
+			     const struct channel *hint)
 {
 	struct amount_msat best_spendable = AMOUNT_MSAT(0);
-	struct channel *channel, *best = hint;
+	struct channel *channel, *best = cast_const(struct channel *, hint);
 
 	/* Seek channel with largest spendable! */
 	list_for_each(&next_peer->channels, channel, list) {
@@ -1202,9 +1202,9 @@ htlc_accepted_hook_final(struct htlc_accepted_hook_payload *request STEALS)
 }
 
 /* Apply tweak to ephemeral key if path_key is non-NULL, then do ECDH */
-static bool ecdh_maybe_blinding(const struct pubkey *ephemeral_key,
-				const struct pubkey *path_key,
-				struct secret *ss)
+bool ecdh_maybe_blinding(const struct pubkey *ephemeral_key,
+			 const struct pubkey *path_key,
+			 struct secret *ss)
 {
 	struct pubkey point = *ephemeral_key;
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -277,13 +277,13 @@ void local_fail_in_htlc(struct htlc_in *hin, const u8 *failmsg TAKES)
 /* Helper to create (common) WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS */
 const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx,
 					struct lightningd *ld,
-					const struct htlc_in *hin,
+					struct amount_msat msat,
 					const char *file, int line)
 {
 	log_debug(ld->log, "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: %s:%u",
 		  file, line);
 	return towire_incorrect_or_unknown_payment_details(
-		ctx, hin->msat,
+		ctx, msat,
 		get_block_height(ld->topology));
 }
 
@@ -477,7 +477,7 @@ static void handle_localpay(struct htlc_in *hin,
 			  hin->cltv_expiry,
 			  get_block_height(ld->topology),
 			  ld->config.cltv_final);
-		failmsg = failmsg_incorrect_or_unknown(NULL, ld, hin);
+		failmsg = failmsg_incorrect_or_unknown(NULL, ld, hin->msat);
 		goto fail;
 	}
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -275,13 +275,10 @@ void local_fail_in_htlc(struct htlc_in *hin, const u8 *failmsg TAKES)
 }
 
 /* Helper to create (common) WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS */
-const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx,
-					struct lightningd *ld,
-					struct amount_msat msat,
-					const char *file, int line)
+const u8 *failmsg_incorrect_or_unknown(const tal_t *ctx,
+				       struct lightningd *ld,
+				       struct amount_msat msat)
 {
-	log_debug(ld->log, "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS: %s:%u",
-		  file, line);
 	return towire_incorrect_or_unknown_payment_details(
 		ctx, msat,
 		get_block_height(ld->topology));

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -62,11 +62,11 @@ void local_fail_in_htlc_needs_update(struct htlc_in *hin,
 				     const struct short_channel_id *failmsg_scid);
 
 /* Helper to create (common) WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS */
-#define failmsg_incorrect_or_unknown(ctx, ld, hin) \
-	failmsg_incorrect_or_unknown_((ctx), (ld), (hin), __FILE__, __LINE__)
+#define failmsg_incorrect_or_unknown(ctx, ld, msat) \
+	failmsg_incorrect_or_unknown_((ctx), (ld), (msat), __FILE__, __LINE__)
 
 const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx,
 					struct lightningd *ld,
-					const struct htlc_in *hin,
+					struct amount_msat msat,
 					const char *file, int line);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -62,11 +62,7 @@ void local_fail_in_htlc_needs_update(struct htlc_in *hin,
 				     const struct short_channel_id *failmsg_scid);
 
 /* Helper to create (common) WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS */
-#define failmsg_incorrect_or_unknown(ctx, ld, msat) \
-	failmsg_incorrect_or_unknown_((ctx), (ld), (msat), __FILE__, __LINE__)
-
-const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx,
-					struct lightningd *ld,
-					struct amount_msat msat,
-					const char *file, int line);
+const u8 *failmsg_incorrect_or_unknown(const tal_t *ctx,
+				       struct lightningd *ld,
+				       struct amount_msat msat);
 #endif /* LIGHTNING_LIGHTNINGD_PEER_HTLCS_H */

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -54,6 +54,18 @@ void fixup_htlcs_out(struct lightningd *ld);
 void htlcs_resubmit(struct lightningd *ld,
 		    struct htlc_in_map *unconnected_htlcs_in STEALS);
 
+/* Apply tweak to ephemeral key if path_key is non-NULL, then do ECDH */
+bool ecdh_maybe_blinding(const struct pubkey *ephemeral_key,
+			 const struct pubkey *path_key,
+			 struct secret *ss);
+
+/* Select best (highest capacity) to peer.  If hint is set, must match that
+ * feerate */
+struct channel *best_channel(struct lightningd *ld,
+			     const struct peer *next_peer,
+			     struct amount_msat amt_to_forward,
+			     const struct channel *hint);
+
 /* For HTLCs which terminate here, invoice payment calls one of these. */
 void fulfill_htlc(struct htlc_in *hin, const struct preimage *preimage);
 void local_fail_in_htlc(struct htlc_in *hin, const u8 *failmsg TAKES);

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -251,12 +251,6 @@ u8 *encrypt_tlv_encrypted_data(const tal_t *ctx UNNEEDED,
 			       struct pubkey *node_alias)
 
 { fprintf(stderr, "encrypt_tlv_encrypted_data called!\n"); abort(); }
-/* Generated stub for failmsg_incorrect_or_unknown_ */
-const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx UNNEEDED,
-					struct lightningd *ld UNNEEDED,
-					struct amount_msat msat UNNEEDED,
-					const char *file UNNEEDED, int line UNNEEDED)
-{ fprintf(stderr, "failmsg_incorrect_or_unknown_ called!\n"); abort(); }
 /* Generated stub for fatal */
 void   fatal(const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "fatal called!\n"); abort(); }
@@ -375,9 +369,10 @@ bool htlc_is_trimmed(enum side htlc_owner UNNEEDED,
 /* Generated stub for htlc_max_possible_send */
 struct amount_msat htlc_max_possible_send(const struct channel *channel UNNEEDED)
 { fprintf(stderr, "htlc_max_possible_send called!\n"); abort(); }
-/* Generated stub for htlc_set_fail */
-void htlc_set_fail(struct htlc_set *set UNNEEDED, const u8 *failmsg TAKES UNNEEDED)
-{ fprintf(stderr, "htlc_set_fail called!\n"); abort(); }
+/* Generated stub for htlc_set_fail_ */
+void htlc_set_fail_(struct htlc_set *set UNNEEDED, const u8 *failmsg TAKES UNNEEDED,
+		    const char *file UNNEEDED, int line UNNEEDED)
+{ fprintf(stderr, "htlc_set_fail_ called!\n"); abort(); }
 /* Generated stub for htlc_set_fulfill */
 void htlc_set_fulfill(struct htlc_set *set UNNEEDED, const struct preimage *preimage UNNEEDED)
 { fprintf(stderr, "htlc_set_fulfill called!\n"); abort(); }

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -694,6 +694,9 @@ struct jsonrpc_request *jsonrpc_request_start_(
 void kill_uncommitted_channel(struct uncommitted_channel *uc UNNEEDED,
 			      const char *why UNNEEDED)
 { fprintf(stderr, "kill_uncommitted_channel called!\n"); abort(); }
+/* Generated stub for local_fail_in_htlc */
+void local_fail_in_htlc(struct htlc_in *hin UNNEEDED, const u8 *failmsg TAKES UNNEEDED)
+{ fprintf(stderr, "local_fail_in_htlc called!\n"); abort(); }
 /* Generated stub for lockin_complete */
 void lockin_complete(struct channel *channel UNNEEDED,
 		     enum channel_state expected_state UNNEEDED)

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -254,7 +254,7 @@ u8 *encrypt_tlv_encrypted_data(const tal_t *ctx UNNEEDED,
 /* Generated stub for failmsg_incorrect_or_unknown_ */
 const u8 *failmsg_incorrect_or_unknown_(const tal_t *ctx UNNEEDED,
 					struct lightningd *ld UNNEEDED,
-					const struct htlc_in *hin UNNEEDED,
+					struct amount_msat msat UNNEEDED,
 					const char *file UNNEEDED, int line UNNEEDED)
 { fprintf(stderr, "failmsg_incorrect_or_unknown_ called!\n"); abort(); }
 /* Generated stub for fatal */

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -152,6 +152,9 @@ struct command_result *command_failed(struct command *cmd UNNEEDED,
 				      struct json_stream *result)
 
 { fprintf(stderr, "command_failed called!\n"); abort(); }
+/* Generated stub for command_its_complicated */
+struct command_result *command_its_complicated(const char *why UNNEEDED)
+{ fprintf(stderr, "command_its_complicated called!\n"); abort(); }
 /* Generated stub for command_param_failed */
 struct command_result *command_param_failed(void)
 
@@ -840,6 +843,11 @@ struct command_result *param_number(struct command *cmd UNNEEDED, const char *na
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				    unsigned int **num UNNEEDED)
 { fprintf(stderr, "param_number called!\n"); abort(); }
+/* Generated stub for param_pubkey */
+struct command_result *param_pubkey(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				    struct pubkey **pubkey UNNEEDED)
+{ fprintf(stderr, "param_pubkey called!\n"); abort(); }
 /* Generated stub for param_secret */
 struct command_result *param_secret(struct command *cmd UNNEEDED, const char *name UNNEEDED,
 				    const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -359,12 +359,17 @@ bool htlc_is_trimmed(enum side htlc_owner UNNEEDED,
 		     bool option_anchor_outputs UNNEEDED,
 		     bool option_anchors_zero_fee_htlc_tx UNNEEDED)
 { fprintf(stderr, "htlc_is_trimmed called!\n"); abort(); }
-/* Generated stub for htlc_set_add */
-void htlc_set_add(struct lightningd *ld UNNEEDED,
-		  struct htlc_in *hin UNNEEDED,
-		  struct amount_msat total_msat UNNEEDED,
-		  const struct secret *payment_secret UNNEEDED)
-{ fprintf(stderr, "htlc_set_add called!\n"); abort(); }
+/* Generated stub for htlc_set_add_ */
+void htlc_set_add_(struct lightningd *ld UNNEEDED,
+		   struct logger *log UNNEEDED,
+		   struct amount_msat msat UNNEEDED,
+		   struct amount_msat total_msat UNNEEDED,
+		   const struct sha256 *payment_hash UNNEEDED,
+		   const struct secret *payment_secret UNNEEDED,
+		   void (*fail)(void * UNNEEDED, const u8 *) UNNEEDED,
+		   void (*succeeded)(void * UNNEEDED, const struct preimage *) UNNEEDED,
+		   void *arg UNNEEDED)
+{ fprintf(stderr, "htlc_set_add_ called!\n"); abort(); }
 /* Generated stub for invoice_check_payment */
 const struct invoice_details *invoice_check_payment(const tal_t *ctx UNNEEDED,
 						    struct lightningd *ld UNNEEDED,


### PR DESCRIPTION
This is a new RPC, improving on `sendonion`, which takes the same path as an onion coming in an HTLC from a peer.  This vastly simplifies handling cases like blinded paths which start at this peer, and self-pay: both are handled automatically.

In addition, the call simply blocks, rather than requiring another call to receive the results.