### PR TITLE
Aggressive Gossip Seeker

### DIFF
--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -83,6 +83,23 @@ void peer_supplied_good_gossip(struct daemon *daemon,
 	peer->gossip_counter += amount;
 }
 
+/* Increase a peer's query_reply_counter, if peer not NULL */
+void peer_supplied_query_response(struct daemon *daemon,
+				  const struct node_id *source_peer,
+				  size_t amount)
+{
+	struct peer *peer;
+
+	if (!source_peer)
+		return;
+
+	peer = find_peer(daemon, source_peer);
+	if (!peer)
+		return;
+
+	peer->query_reply_counter += amount;
+}
+
 /* Queue a gossip message for the peer: connectd simply forwards it to
  * the peer. */
 void queue_peer_msg(struct daemon *daemon,
@@ -124,6 +141,7 @@ static void connectd_new_peer(struct daemon *daemon, const u8 *msg)
 	/* Populate the rest of the peer info. */
 	peer->daemon = daemon;
 	peer->gossip_counter = 0;
+	peer->query_reply_counter = 0;
 	peer->scid_queries = NULL;
 	peer->scid_query_idx = 0;
 	peer->scid_query_nodes = NULL;

--- a/gossipd/gossipd.h
+++ b/gossipd/gossipd.h
@@ -100,6 +100,9 @@ struct peer {
 	/* How much contribution have we made to gossip? */
 	size_t gossip_counter;
 
+	/* How much gossip have we sent in response to gossip queries? */
+	size_t query_reply_counter;
+
 	/* The two features gossip cares about (so far) */
 	bool gossip_queries_feature, initial_routing_sync_feature;
 
@@ -128,10 +131,15 @@ struct peer {
 /* Search for a peer. */
 struct peer *find_peer(struct daemon *daemon, const struct node_id *id);
 
-/* This peer (may be NULL) gave is valid gossip. */
+/* This peer (may be NULL) gave us valid gossip. */
 void peer_supplied_good_gossip(struct daemon *daemon,
 			       const struct node_id *source_peer,
 			       size_t amount);
+
+/* Increase peer's query_reply_counter, if peer not NULL */
+void peer_supplied_query_response(struct daemon *daemon,
+				  const struct node_id *source_peer,
+				  size_t amount);
 
 /* Get a random peer.  NULL if no peers. */
 struct peer *first_random_peer(struct daemon *daemon,

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -804,11 +804,15 @@ static const char *process_channel_update(const tal_t *ctx,
 					    htlc_maximum_msat);
 	}
 
+	/* Used to evaluate gossip peers' performance */
+	peer_supplied_good_gossip(gm->daemon, source_peer, 1);
+
 	status_peer_debug(source_peer,
 			  "Received channel_update for channel %s/%d now %s",
 			  fmt_short_channel_id(tmpctx, scid),
 			  dir,
 			  channel_flags & ROUTING_FLAGS_DISABLED ? "DISABLED" : "ACTIVE");
+
 	return NULL;
 }
 
@@ -940,6 +944,9 @@ static void process_node_announcement(struct gossmap_manage *gm,
 	/* Now delete old */
 	if (gossmap_node_announced(node))
 		gossip_store_del(gm->daemon->gs, node->nann_off, WIRE_NODE_ANNOUNCEMENT);
+
+	/* Used to evaluate gossip peers' performance */
+	peer_supplied_good_gossip(gm->daemon, source_peer, 1);
 
 	status_peer_debug(source_peer,
 			  "Received node_announcement for node %s",

--- a/gossipd/queries.c
+++ b/gossipd/queries.c
@@ -338,7 +338,7 @@ const u8 *handle_reply_channel_range(struct peer *peer, const u8 *msg)
 
 	/* Credit peer for answering gossip, so seeker doesn't get upset:
 	 * since scids are only 8 bytes, use a discount over normal gossip. */
-	peer_supplied_good_gossip(peer->daemon, &peer->id, tal_count(scids) / 20);
+	peer_supplied_query_response(peer->daemon, &peer->id, tal_count(scids) / 20);
 
 	/* Old code used to set this to 1 all the time; not setting it implies
 	 * we're talking to an upgraded node. */

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -74,7 +74,7 @@ struct seeker {
 	bool unknown_nodes;
 
 	/* Peers we've asked to stream us gossip (set to NULL if peer dies) */
-	struct peer *gossiper[5];
+	struct peer *gossiper[10];
 
 	/* A peer that told us about unknown gossip (set to NULL if peer dies). */
 	struct peer *preferred_peer;

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -113,7 +113,7 @@ static bool selected_peer(struct seeker *seeker, struct peer *peer)
 
 	/* Give it some grace in case we immediately hit timer */
 	seeker->prev_gossip_count
-		= peer->gossip_counter - GOSSIP_SEEKER_INTERVAL(seeker);
+		= peer->query_reply_counter - GOSSIP_SEEKER_INTERVAL(seeker);
 	return true;
 }
 
@@ -197,9 +197,9 @@ static bool peer_made_progress(struct seeker *seeker, const struct peer *peer)
 	/* Has it made progress (at least one valid update per second)?  If
 	 * not, we assume it's finished, and if it hasn't, we'll end up
 	 * querying backwards in next steps. */
-	if (peer->gossip_counter
+	if (peer->query_reply_counter
 	    >= seeker->prev_gossip_count + GOSSIP_SEEKER_INTERVAL(seeker)) {
-		seeker->prev_gossip_count = peer->gossip_counter;
+		seeker->prev_gossip_count = peer->query_reply_counter;
 		return true;
 	}
 
@@ -867,7 +867,7 @@ static void check_probe(struct seeker *seeker,
 
 	status_peer_debug(&peer->id,
 			  "has only moved gossip %zu->%zu for probe, giving up on it",
-			  seeker->prev_gossip_count, peer->gossip_counter);
+			  seeker->prev_gossip_count, peer->query_reply_counter);
 	seeker->random_peer = NULL;
 	restart(seeker);
 }

--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -924,12 +924,12 @@ static void maybe_rotate_gossipers(struct seeker *seeker)
 			goto set_gossiper;
 		}
 	}
-	/* Otherwise, rotate out a gossiper ~once per hour. */
-	if (pseudorand(60) != 0)
+	/* Otherwise, rotate out worst gossiper every 30 minutes on average. */
+	if (pseudorand(25) != 0)
 		return;
 	/* Don't evaluate gossip performance at a faster rate than
 	 * new gossip is periodically emitted. */
-	if (seeker->new_gossiper_elapsed < 3)
+	if (seeker->new_gossiper_elapsed < 5)
 		return;
 	u32 lowest_count = UINT_MAX;
 	for (int j = 0; j < ARRAY_SIZE(seeker->gossiper); j++) {

--- a/gossipd/test/run-extended-info.c
+++ b/gossipd/test/run-extended-info.c
@@ -42,11 +42,11 @@ struct short_channel_id *decode_short_ids(const tal_t *ctx UNNEEDED, const u8 *e
 void fromwire_sciddir_or_pubkey(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
 				struct sciddir_or_pubkey *sciddpk UNNEEDED)
 { fprintf(stderr, "fromwire_sciddir_or_pubkey called!\n"); abort(); }
-/* Generated stub for peer_supplied_good_gossip */
-void peer_supplied_good_gossip(struct daemon *daemon UNNEEDED,
-			       const struct node_id *source_peer UNNEEDED,
-			       size_t amount UNNEEDED)
-{ fprintf(stderr, "peer_supplied_good_gossip called!\n"); abort(); }
+/* Generated stub for peer_supplied_query_response */
+void peer_supplied_query_response(struct daemon *daemon UNNEEDED,
+				  const struct node_id *source_peer UNNEEDED,
+				  size_t amount UNNEEDED)
+{ fprintf(stderr, "peer_supplied_query_response called!\n"); abort(); }
 /* Generated stub for queue_peer_msg */
 void queue_peer_msg(struct daemon *daemon UNNEEDED,
 		    const struct node_id *peer UNNEEDED,

--- a/plugins/test/run-route-calc.c
+++ b/plugins/test/run-route-calc.c
@@ -283,7 +283,7 @@ void memleak_scan_htable(struct htable *memtable UNNEEDED, const struct htable *
 void *notleak_(void *ptr UNNEEDED, bool plus_children UNNEEDED)
 { fprintf(stderr, "notleak_ called!\n"); abort(); }
 /* Generated stub for plugin_err */
-void  plugin_err(struct plugin *p UNNEEDED, const char *fmt UNNEEDED, ...)
+void   plugin_err(struct plugin *p UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "plugin_err called!\n"); abort(); }
 /* Generated stub for plugin_log */
 void plugin_log(struct plugin *p UNNEEDED, enum log_level l UNNEEDED, const char *fmt UNNEEDED, ...)

--- a/plugins/test/run-route-overlong.c
+++ b/plugins/test/run-route-overlong.c
@@ -280,7 +280,7 @@ void memleak_scan_htable(struct htable *memtable UNNEEDED, const struct htable *
 void *notleak_(void *ptr UNNEEDED, bool plus_children UNNEEDED)
 { fprintf(stderr, "notleak_ called!\n"); abort(); }
 /* Generated stub for plugin_err */
-void  plugin_err(struct plugin *p UNNEEDED, const char *fmt UNNEEDED, ...)
+void   plugin_err(struct plugin *p UNNEEDED, const char *fmt UNNEEDED, ...)
 { fprintf(stderr, "plugin_err called!\n"); abort(); }
 /* Generated stub for plugin_log */
 void plugin_log(struct plugin *p UNNEEDED, enum log_level l UNNEEDED, const char *fmt UNNEEDED, ...)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2256,13 +2256,14 @@ def test_gossip_force_broadcast_channel_msgs(node_factory, bitcoind):
     assert tally['query_short_channel_ids'] <= 1
     assert tally['query_channel_range'] <= 1
     assert tally['ping'] <= 1
+    assert tally['gossip_filter'] >= 1
     del tally['query_short_channel_ids']
     del tally['query_channel_range']
     del tally['ping']
+    del tally['gossip_filter']
     assert tally == {'channel_announce': 1,
                      'channel_update': 1,
-                     'node_announce': 1,
-                     'gossip_filter': 1}
+                     'node_announce': 1}
 
     # Make sure l1 sees l2's channel update
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)


### PR DESCRIPTION
> [!IMPORTANT]
> Open for merging new PRs until the next PR freeze date is confirmed!

## Checklist

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

The gossip seeker has been getting less reliable with nodes often failing to provide a full gossip sync when requested and/or miss gossip when streaming.  This PR does several thing to address this:
1. Increase the number of gossipers we stream from: 5 -> 10.
2. Ask a random peer for a full resync every hour.  Previously this was only once at startup.
3. Drop the worst performing gossip streamer, not a random one.
4. Rotate out the worst gossip streaming peer every ~30 minutes (was ~hourly.)

Considering a blackbox test for gossip rotation, but it's probabilistic, which makes it more difficult to test reliably.