### PR TITLE
Update emergency.recover after every 'commitment_revocation' so that user can sweep funds by penalty transaction.

### DIFF
--- a/common/scb_wire.csv
+++ b/common/scb_wire.csv
@@ -1,23 +1,52 @@
-#include <common/node_id.h>
-#include <common/channel_id.h>
-#include <common/wireaddr.h>
-#include <common/channel_type.h>
-#include <common/amount.h>
 #include <bitcoin/tx.h>
+#include <ccan/crypto/shachain/shachain.h>
+#include <common/amount.h>
+#include <common/channel_id.h>
+#include <common/channel_type.h>
+#include <common/derive_basepoints.h>
+#include <common/htlc_wire.h>
+#include <common/node_id.h>
+#include <common/wireaddr.h>
 
-# scb_chan stores min. info required to sweep the peer's force close.
-subtype,scb_chan
-subtypedata,scb_chan,id,u64,
-subtypedata,scb_chan,cid,channel_id,
-subtypedata,scb_chan,node_id,node_id,
-subtypedata,scb_chan,unused,u8,
-subtypedata,scb_chan,addr,wireaddr,
-subtypedata,scb_chan,funding,bitcoin_outpoint,
-subtypedata,scb_chan,funding_sats,amount_sat,
-subtypedata,scb_chan,type,channel_type,
+tlvtype,scb_tlvs,shachain,1,
+tlvdata,scb_tlvs,shachain,their_shachain,shachain,
+tlvtype,scb_tlvs,basepoints,3,
+tlvdata,scb_tlvs,basepoints,their_basepoint,basepoints,
+tlvtype,scb_tlvs,opener,5,
+tlvdata,scb_tlvs,opener,opener,enum side,
+tlvtype,scb_tlvs,remote_to_self_delay,7,
+tlvdata,scb_tlvs,remote_to_self_delay,remote_to_self_delay,u16,
+
+# legacy_scb_chan stores min. info required to sweep the peer's force close.
+subtype,legacy_scb_chan
+subtypedata,legacy_scb_chan,id,u64,
+subtypedata,legacy_scb_chan,cid,channel_id,
+subtypedata,legacy_scb_chan,node_id,node_id,
+subtypedata,legacy_scb_chan,unused,u8,
+subtypedata,legacy_scb_chan,addr,wireaddr,
+subtypedata,legacy_scb_chan,funding,bitcoin_outpoint,
+subtypedata,legacy_scb_chan,funding_sats,amount_sat,
+subtypedata,legacy_scb_chan,type,channel_type,
 
 msgtype,static_chan_backup,6135,
 msgdata,static_chan_backup,version,u64,
 msgdata,static_chan_backup,timestamp,u32,
 msgdata,static_chan_backup,num,u16,
-msgdata,static_chan_backup,channels,scb_chan,num
+msgdata,static_chan_backup,channels,legacy_scb_chan,num
+
+subtype,modern_scb_chan
+subtypedata,modern_scb_chan,id,u64,
+subtypedata,modern_scb_chan,cid,channel_id,
+subtypedata,modern_scb_chan,node_id,node_id,
+subtypedata,modern_scb_chan,addr,wireaddr,
+subtypedata,modern_scb_chan,funding,bitcoin_outpoint,
+subtypedata,modern_scb_chan,funding_sats,amount_sat,
+subtypedata,modern_scb_chan,type,channel_type,
+subtypedata,modern_scb_chan,len_tlv,u32,
+subtypedata,modern_scb_chan,tlvs,scb_tlvs,len_tlv
+
+msgtype,static_chan_backup_with_tlvs,6137,
+msgdata,static_chan_backup_with_tlvs,version,u64,
+msgdata,static_chan_backup_with_tlvs,timestamp,u32,
+msgdata,static_chan_backup_with_tlvs,num,u16,
+msgdata,static_chan_backup_with_tlvs,channels,modern_scb_chan,num

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -334,7 +334,7 @@ struct channel {
 
 	/* `Channel-shell` of this channel
 	 * (Minimum information required to backup this channel). */
-	struct scb_chan *scb;
+	struct modern_scb_chan *scb;
 
 	/* Do we allow the peer to set any fee it wants? */
 	bool ignore_fee_limits;

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1462,14 +1462,21 @@ wallet_commit_channel(struct lightningd *ld,
 	channel->min_possible_feerate = commitment_feerate;
 	channel->max_possible_feerate = commitment_feerate;
 	if (channel->peer->addr.itype == ADDR_INTERNAL_WIREADDR) {
-		channel->scb = tal(channel, struct scb_chan);
+		channel->scb = tal(channel, struct modern_scb_chan);
 		channel->scb->id = channel->dbid;
-		channel->scb->unused = 0;
 		channel->scb->addr = channel->peer->addr.u.wireaddr.wireaddr;
 		channel->scb->node_id = channel->peer->id;
 		channel->scb->funding = *funding;
 		channel->scb->cid = channel->cid;
 		channel->scb->funding_sats = total_funding;
+
+		struct tlv_scb_tlvs *scb_tlvs = tlv_scb_tlvs_new(channel);
+		scb_tlvs->shachain = &channel->their_shachain.chain;
+		scb_tlvs->basepoints = &channel_info->theirbase;
+		scb_tlvs->opener = &channel->opener;
+		scb_tlvs->remote_to_self_delay = &channel_info->their_config.to_self_delay;
+
+		channel->scb->tlvs = scb_tlvs;
 	} else
 		channel->scb = NULL;
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2368,7 +2368,11 @@ static void json_add_scb(struct command *cmd,
 {
 	u8 *scb = tal_arr(cmd, u8, 0);
 
-	towire_scb_chan(&scb, c->scb);
+	/* Update shachain & basepoints in SCB. */
+	c->scb->tlvs->shachain = &c->their_shachain.chain;
+	c->scb->tlvs->basepoints = &c->channel_info.theirbase;
+	towire_modern_scb_chan(&scb, c->scb);
+
 	json_add_hex_talarr(response, fieldname,
 			    scb);
 }

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -1012,6 +1012,9 @@ u8 *towire_hsmd_sign_commitment_tx(const tal_t *ctx UNNEEDED, const struct node_
 /* Generated stub for towire_hsmd_sign_invoice */
 u8 *towire_hsmd_sign_invoice(const tal_t *ctx UNNEEDED, const u8 *u5bytes UNNEEDED, const u8 *hrp UNNEEDED)
 { fprintf(stderr, "towire_hsmd_sign_invoice called!\n"); abort(); }
+/* Generated stub for towire_modern_scb_chan */
+void towire_modern_scb_chan(u8 **p UNNEEDED, const struct modern_scb_chan *modern_scb_chan UNNEEDED)
+{ fprintf(stderr, "towire_modern_scb_chan called!\n"); abort(); }
 /* Generated stub for towire_node_id */
 void towire_node_id(u8 **pptr UNNEEDED, const struct node_id *id UNNEEDED)
 { fprintf(stderr, "towire_node_id called!\n"); abort(); }
@@ -1021,9 +1024,6 @@ u8 *towire_onchaind_dev_memleak(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_openingd_dev_memleak */
 u8 *towire_openingd_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_openingd_dev_memleak called!\n"); abort(); }
-/* Generated stub for towire_scb_chan */
-void towire_scb_chan(u8 **p UNNEEDED, const struct scb_chan *scb_chan UNNEEDED)
-{ fprintf(stderr, "towire_scb_chan called!\n"); abort(); }
 /* Generated stub for towire_warningfmt */
 u8 *towire_warningfmt(const tal_t *ctx UNNEEDED,
 		      const struct channel_id *channel UNNEEDED,

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -223,7 +223,7 @@ plugins/pay: $(PLUGIN_PAY_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_PAY_LIB_OBJS) $(PLUG
 
 plugins/autoclean: $(PLUGIN_AUTOCLEAN_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 
-plugins/chanbackup: $(PLUGIN_chanbackup_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) common/scb_wiregen.o wire/channel_type_wiregen.o
+plugins/chanbackup: $(PLUGIN_chanbackup_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) common/scb_wiregen.o wire/channel_type_wiregen.o common/htlc_wire.o common/onionreply.o common/derive_basepoints.o
 
 plugins/commando: $(PLUGIN_COMMANDO_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS)
 

--- a/tools/gen/header_template
+++ b/tools/gen/header_template
@@ -37,28 +37,6 @@ const char *${enum_set['name']}_name(int e);
 bool ${enum_set['name']}_is_defined(u16 type);
 % endfor
 
-## Structs for subtypes + tlv messages
-% for struct in structs:
-struct ${struct.struct_name()} {
-        % for f in struct.fields.values():
-            % for c in f.field_comments:
-        /* ${c} */
-            % endfor
-        % if bool(f.len_field_of):
-<% continue %>
-        % endif
-            % if f.is_varlen() and f.type_obj.is_varsize():
-        ${f.type_obj.type_name()} **${f.name};
-            % elif f.is_varlen() or f.type_obj.is_varsize():
-        ${f.type_obj.type_name()} *${f.name};
-            % elif f.is_array():
-        ${f.type_obj.type_name()} ${f.name}[${f.count}];
-            % else:
-        ${f.type_obj.type_name()} ${f.name};
-            % endif
-        % endfor
-};
-% endfor
 ## Structs for TLVs
 % for tlv in tlvs.values():
 struct ${tlv.struct_name()} {
@@ -79,6 +57,29 @@ struct ${tlv.struct_name()} {
         struct ${msg.struct_name()} *${msg.name};
 	% endif
     % endfor
+};
+% endfor
+
+## Structs for subtypes + tlv messages
+% for struct in structs:
+struct ${struct.struct_name()} {
+        % for f in struct.fields.values():
+            % for c in f.field_comments:
+        /* ${c} */
+            % endfor
+        % if bool(f.len_field_of):
+<% continue %>
+        % endif
+            % if f.is_varlen() and f.type_obj.is_varsize():
+        ${f.type_obj.type_name()} **${f.name};
+            % elif f.is_varlen() or f.type_obj.is_varsize():
+        ${f.type_obj.type_name()} *${f.name};
+            % elif f.is_array():
+        ${f.type_obj.type_name()} ${f.name}[${f.count}];
+            % else:
+        ${f.type_obj.type_name()} ${f.name};
+            % endif
+        % endfor
 };
 % endfor
 

--- a/tools/gen/header_template
+++ b/tools/gen/header_template
@@ -70,7 +70,7 @@ struct ${struct.struct_name()} {
         % if bool(f.len_field_of):
 <% continue %>
         % endif
-            % if f.is_varlen() and f.type_obj.is_varsize():
+            % if not f.type_obj.is_tlv() and f.is_varlen() and f.type_obj.is_varsize():
         ${f.type_obj.type_name()} **${f.name};
             % elif f.is_varlen() or f.type_obj.is_varsize():
         ${f.type_obj.type_name()} *${f.name};

--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -66,6 +66,8 @@ towire_${type_obj.name}_array(${ptr}, ${fieldname}, ${f.size('tal_count(' + fiel
 towire_${type_obj.name}(${ptr}, ${f.name});
 % elif is_single_ptr:
 towire_${type_obj.name}(${ptr}, ${'*' if type_obj.is_assignable() else ''}${fieldname});
+%elif f.type_obj.is_tlv():
+towire_tlv_${type_obj.name}(${ptr}, ${'' if type_obj.is_assignable() or type_obj.is_varsize() else '&'}${fieldname});
 % else:
 towire_${type_obj.name}(${ptr}, ${'' if type_obj.is_assignable() or type_obj.is_varsize() else '&'}${fieldname});
 % endif
@@ -74,6 +76,8 @@ towire_${type_obj.name}(${ptr}, ${'' if type_obj.is_assignable() or type_obj.is_
 <%def name="fromwire_subtype_field(fieldname, f, ctx, is_ptr)">\
 <%
     type_ = f.type_obj.name
+    if f.type_obj.is_tlv():
+	type_ = 'tlv_' + type_
     typename = f.type_obj.type_name()
     if f.type_obj.is_varsize():
 	typename += ' *'

--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -51,7 +51,7 @@ bool ${enum_set['name']}_is_defined(u16 type)
 ## START PARTIALS
 ## Subtype and TLV-msg towire_
 <%def name="towire_subtype_field(fieldname, f, type_obj, is_single_ptr, ptr)">\
-% if f.is_array() or f.is_varlen():
+% if not f.type_obj.is_tlv() and (f.is_array() or f.is_varlen()):
     % if type_obj.has_array_helper():
 towire_${type_obj.name}_array(${ptr}, ${fieldname}, ${f.size('tal_count(' + fieldname + ')')});
     % else:
@@ -82,7 +82,7 @@ towire_${type_obj.name}(${ptr}, ${'' if type_obj.is_assignable() or type_obj.is_
     if f.type_obj.is_varsize():
 	typename += ' *'
 %>\
-% if f.is_array() or f.is_varlen():
+% if not f.type_obj.is_tlv() and (f.is_array() or f.is_varlen()):
     % if f.type_obj.has_array_helper():
     ## We assume array helpers only deal with things literally transcribed!!
 	% if f.is_varlen():
@@ -116,8 +116,10 @@ ${fieldname} = ${f.size('*plen')} ? tal_arr(${ctx}, ${typename}, 0) : NULL;
     % endif
     % if f.type_obj.is_assignable():
 ${ f.name if f.len_field_of else fieldname} = fromwire_${type_}(cursor, plen);
-    % elif f.type_obj.is_varsize():
+    % elif f.type_obj.is_varsize() and not f.type_obj.is_tlv():
 ${fieldname} = fromwire_${type_}(${ctx}, cursor, plen);
+    % elif f.type_obj.is_tlv() and f.is_varlen():
+${fieldname} = fromwire_${type_}(${ctx}, cursor, &(size_t){(size_t)${f.size()}});
     % else:
 fromwire_${type_}(cursor, plen, &${fieldname});
     % endif
@@ -138,7 +140,14 @@ fromwire_${type_}(cursor, plen, &${fieldname});
 ${static}void towire_${subtype.name}(u8 **p, const ${subtype.type_name()} *${subtype.name})
 {
 	% for f in subtype.get_len_fields():
+	 % if not subtype.find_data_field(f.len_field_of).type_obj.is_tlv():  # Check if this signify length of TLV.
 	${f.type_obj.type_name()} ${f.name} = tal_count(${subtype.name}->${f.len_field_of});
+	 % else:
+	 /* Length of serialized tlv. */
+	u8 *tmp = tal_arr(tmpctx, u8, 0);
+	towire_tlv_${subtype.find_data_field(f.len_field_of).type_obj.name}(&tmp, ${subtype.name}->${f.len_field_of});
+	${f.type_obj.type_name()} ${f.name} = tal_bytelen(tmp);
+   	 % endif
 	% endfor
 
 	% for f in subtype.fields.values():

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -249,7 +249,8 @@ class Type(FieldSet):
         'tx_parts',
         'wally_psbt',
         'wally_tx',
-        'scb_chan',
+        'legacy_scb_chan',
+        'modern_scb_chan',
         'inflight',
     ]
 

--- a/tools/generate-wire.py
+++ b/tools/generate-wire.py
@@ -590,6 +590,9 @@ def main(options, args=None, output=sys.stdout, lines=None):
                 else:
                     count = tokens[4]
 
+                if tokens[3] in master.tlvs:
+                    type_obj.tlv = master.tlvs[tokens[3]]
+
                 subtype.add_data_field(tokens[2], type_obj, count, comments=list(comment_set),
                                        optional=optional)
                 comment_set = []

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -293,9 +293,6 @@ const u8 *psbt_fixup(const tal_t *ctx UNNEEDED, const u8 *psbtblob UNNEEDED)
 struct htlc_in *remove_htlc_in_by_dbid(struct htlc_in_map *remaining_htlcs_in UNNEEDED,
 				       u64 dbid UNNEEDED)
 { fprintf(stderr, "remove_htlc_in_by_dbid called!\n"); abort(); }
-/* Generated stub for rune_is_ours */
-const char *rune_is_ours(struct lightningd *ld UNNEEDED, const struct rune *rune UNNEEDED)
-{ fprintf(stderr, "rune_is_ours called!\n"); abort(); }
 /* Generated stub for rune_unique_id */
 u64 rune_unique_id(const struct rune *rune UNNEEDED)
 { fprintf(stderr, "rune_unique_id called!\n"); abort(); }

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -20,6 +20,7 @@ static void test_error(struct lightningd *ld, bool fatal, const char *fmt, va_li
 	wallet_err = tal_vfmt(NULL, fmt, ap);
 }
 
+#include "common/scb_wiregen.c"
 #include "wallet/wallet.c"
 #include "lightningd/hsm_control.c"
 #include "lightningd/htlc_end.c"
@@ -277,6 +278,13 @@ u64 forward_index_update_status(struct lightningd *ld UNNEEDED,
 				struct amount_msat in_amount UNNEEDED,
 				const struct short_channel_id *out_channel UNNEEDED)
 { fprintf(stderr, "forward_index_update_status called!\n"); abort(); }
+/* Generated stub for fromwire_channel_id */
+bool fromwire_channel_id(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
+			 struct channel_id *channel_id UNNEEDED)
+{ fprintf(stderr, "fromwire_channel_id called!\n"); abort(); }
+/* Generated stub for fromwire_channel_type */
+struct channel_type *fromwire_channel_type(const tal_t *ctx UNNEEDED, const u8 **cursor UNNEEDED, size_t *plen UNNEEDED)
+{ fprintf(stderr, "fromwire_channel_type called!\n"); abort(); }
 /* Generated stub for fromwire_channeld_dev_memleak_reply */
 bool fromwire_channeld_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEEDED)
 { fprintf(stderr, "fromwire_channeld_dev_memleak_reply called!\n"); abort(); }
@@ -349,6 +357,12 @@ bool fromwire_onchaind_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNE
 /* Generated stub for fromwire_openingd_dev_memleak_reply */
 bool fromwire_openingd_dev_memleak_reply(const void *p UNNEEDED, bool *leak UNNEEDED)
 { fprintf(stderr, "fromwire_openingd_dev_memleak_reply called!\n"); abort(); }
+/* Generated stub for fromwire_tlv */
+bool fromwire_tlv(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
+		  const struct tlv_record_type *types UNNEEDED, size_t num_types UNNEEDED,
+		  void *record UNNEEDED, struct tlv_field **fields UNNEEDED,
+		  const u64 *extra_types UNNEEDED, size_t *err_off UNNEEDED, u64 *err_type UNNEEDED)
+{ fprintf(stderr, "fromwire_tlv called!\n"); abort(); }
 /* Generated stub for get_block_height */
 u32 get_block_height(const struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "get_block_height called!\n"); abort(); }
@@ -950,9 +964,6 @@ void report_subd_memleak(struct leak_detect *leak_detect UNNEEDED, struct subd *
 void resolve_close_command(struct lightningd *ld UNNEEDED, struct channel *channel UNNEEDED,
 			   bool cooperative UNNEEDED, const struct bitcoin_tx **close_txs UNNEEDED)
 { fprintf(stderr, "resolve_close_command called!\n"); abort(); }
-/* Generated stub for rune_is_ours */
-const char *rune_is_ours(struct lightningd *ld UNNEEDED, const struct rune *rune UNNEEDED)
-{ fprintf(stderr, "rune_is_ours called!\n"); abort(); }
 /* Generated stub for rune_unique_id */
 u64 rune_unique_id(const struct rune *rune UNNEEDED)
 { fprintf(stderr, "rune_unique_id called!\n"); abort(); }
@@ -1030,9 +1041,15 @@ void topology_add_sync_waiter_(const tal_t *ctx UNNEEDED,
 /* Generated stub for towire_announcement_signatures */
 u8 *towire_announcement_signatures(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, struct short_channel_id short_channel_id UNNEEDED, const secp256k1_ecdsa_signature *node_signature UNNEEDED, const secp256k1_ecdsa_signature *bitcoin_signature UNNEEDED)
 { fprintf(stderr, "towire_announcement_signatures called!\n"); abort(); }
+/* Generated stub for towire_channel_id */
+void towire_channel_id(u8 **pptr UNNEEDED, const struct channel_id *channel_id UNNEEDED)
+{ fprintf(stderr, "towire_channel_id called!\n"); abort(); }
 /* Generated stub for towire_channel_reestablish */
 u8 *towire_channel_reestablish(const tal_t *ctx UNNEEDED, const struct channel_id *channel_id UNNEEDED, u64 next_commitment_number UNNEEDED, u64 next_revocation_number UNNEEDED, const struct secret *your_last_per_commitment_secret UNNEEDED, const struct pubkey *my_current_per_commitment_point UNNEEDED, const struct tlv_channel_reestablish_tlvs *channel_reestablish UNNEEDED)
 { fprintf(stderr, "towire_channel_reestablish called!\n"); abort(); }
+/* Generated stub for towire_channel_type */
+void towire_channel_type(u8 **p UNNEEDED, const struct channel_type *channel_type UNNEEDED)
+{ fprintf(stderr, "towire_channel_type called!\n"); abort(); }
 /* Generated stub for towire_channeld_dev_memleak */
 u8 *towire_channeld_dev_memleak(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_channeld_dev_memleak called!\n"); abort(); }
@@ -1152,15 +1169,17 @@ u8 *towire_openingd_dev_memleak(const tal_t *ctx UNNEEDED)
 /* Generated stub for towire_permanent_channel_failure */
 u8 *towire_permanent_channel_failure(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_permanent_channel_failure called!\n"); abort(); }
-/* Generated stub for towire_scb_chan */
-void towire_scb_chan(u8 **p UNNEEDED, const struct scb_chan *scb_chan UNNEEDED)
-{ fprintf(stderr, "towire_scb_chan called!\n"); abort(); }
 /* Generated stub for towire_temporary_channel_failure */
 u8 *towire_temporary_channel_failure(const tal_t *ctx UNNEEDED, const u8 *channel_update UNNEEDED)
 { fprintf(stderr, "towire_temporary_channel_failure called!\n"); abort(); }
 /* Generated stub for towire_temporary_node_failure */
 u8 *towire_temporary_node_failure(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_temporary_node_failure called!\n"); abort(); }
+/* Generated stub for towire_tlv */
+void towire_tlv(u8 **pptr UNNEEDED,
+		const struct tlv_record_type *types UNNEEDED, size_t num_types UNNEEDED,
+		const void *record UNNEEDED)
+{ fprintf(stderr, "towire_tlv called!\n"); abort(); }
 /* Generated stub for towire_unknown_next_peer */
 u8 *towire_unknown_next_peer(const tal_t *ctx UNNEEDED)
 { fprintf(stderr, "towire_unknown_next_peer called!\n"); abort(); }


### PR DESCRIPTION
This PR would enable nodes to create penalty transaction when the peer publishes an old revoked state using the emergency.recover.

Addresses: #7696