### PR TITLE
lightningd: fix rpc_command hook

### DIFF
--- a/lightningd/plugin_hook.c
+++ b/lightningd/plugin_hook.c
@@ -217,7 +217,7 @@ bool plugin_hook_call_(struct lightningd *ld, const struct plugin_hook *hook,
 		       const char *cmd_id TAKES,
 		       tal_t *cb_arg STEALS)
 {
-	if (tal_count(hook->hooks)) {
+	if (tal_count(hook->hooks) && !ld->plugins->startup) {
 		/* If we have a plugin that has registered for this
 		 * hook, serialize and call it */
 		/* FIXME: technically this is a leak, but we don't


### PR DESCRIPTION
When trying to subscribe renepay to an rpc_command hook I noticed the initialization of the plugins will time out.
It seems that at initialization we have a recursive hook call that keeps lightningd hooked to synchronous communication with the subscriber. By letting hooks apply only after plugin startup the problem is fixed.

Changelog-Fixed: lightningd: fixes rpc_command hooks causing a infinite io loop at plugin initialization