### PR TITLE
bolt12: fix typo about parameters name in err str

### DIFF
--- a/plugins/fetchinvoice.c
+++ b/plugins/fetchinvoice.c
@@ -881,7 +881,7 @@ struct command_result *json_fetchinvoice(struct command *cmd,
 	} else {
 		if (!msat)
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
-					    "msatoshi parameter required");
+					    "amount_msat parameter required");
 		invreq->invreq_amount = tal_dup(invreq, u64,
 						&msat->millisatoshis); /* Raw: tu64 */
 	}

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4514,7 +4514,7 @@ def test_fetchinvoice(node_factory, bitcoind):
     # If no amount is specified in offer, one must be in invoice.
     offer_noamount = l3.rpc.call('offer', {'amount': 'any',
                                            'description': 'any amount test'})
-    with pytest.raises(RpcError, match="msatoshi parameter required"):
+    with pytest.raises(RpcError, match="amount_msat parameter required"):
         l1.rpc.call('fetchinvoice', {'offer': offer_noamount['bolt12']})
     inv1 = l1.rpc.call('fetchinvoice', {'offer': offer_noamount['bolt12'], 'amount_msat': 100})
     # But amount won't appear in changes


### PR DESCRIPTION
Cherry-picking a small patch found in https://github.com/ElementsProject/lightning/pull/7786 and leaving the `git rebase` magic resolving commit history when merged
____

- [X] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
