### PR TITLE
renepay: pay BOLT11 invoices with description_hash

### DIFF
--- a/plugins/renepay/json.c
+++ b/plugins/renepay/json.c
@@ -226,8 +226,11 @@ void json_add_payment(struct json_stream *s, const struct payment *payment)
 	json_add_sha256(s, "payment_hash", &pinfo->payment_hash);
 	json_add_node_id(s, "destination", &pinfo->destination);
 
+	/* FIXME: we have not declared "description" in renepay's response
+	 * schema
 	if (pinfo->description)
 		json_add_string(s, "description", pinfo->description);
+	*/
 
 	json_add_timeabs(s, "created_at", pinfo->start_time);
 	json_add_u64(s, "groupid", payment->groupid);

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -256,24 +256,6 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 				    "Invalid bolt11:"
 				    " sets feature var_onion with no secret");
-	/* BOLT #11:
-	 * A reader:
-	 *...
-	 * - MUST check that the SHA2 256-bit hash in the `h` field
-	 *   exactly matches the hashed description.
-	 */
-	if (!b11->description) {
-		if (!b11->description_hash)
-			return command_fail(
-			    cmd, JSONRPC2_INVALID_PARAMS,
-			    "Invalid bolt11: missing description");
-
-		if (!description)
-			return command_fail(
-			    cmd, JSONRPC2_INVALID_PARAMS,
-			    "bolt11 uses description_hash, but you did "
-			    "not provide description parameter");
-	}
 
 	if (b11->msat) {
 		// amount is written in the invoice


### PR DESCRIPTION
This remove an unnecessary check for existing description field if the description_hash is provided in the invoice. The bolt11_decode function already checks the description against the hash if both are provided.

Changelog-Fix: renepay: allow to pay BOLT11 invoices with description_hash, the description field is made optional

Fixes #7777 