### PR TITLE
build: add `all-fuzz-programs` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -694,6 +694,7 @@ update-ccan:
 
 # Now ALL_PROGRAMS is fully populated, we can expand it.
 all-programs: $(ALL_PROGRAMS)
+all-fuzz-programs: $(ALL_FUZZ_TARGETS)
 all-test-programs: $(ALL_TEST_PROGRAMS) $(ALL_FUZZ_TARGETS)
 default-targets: $(DEFAULT_TARGETS)
 


### PR DESCRIPTION
Downstream, having a target for just building, but not running (i.e
`check-fuzz`) the fuzz targets, would be useful. Currently we just apply
this patch before building lightning in various workflows. However if
it's possible to have this upstreamed, as a convenience, that'd be
great.

Changelog-None