### PR TITLE
pyln-testing: don't fail to start node if we have no Rust.

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -830,7 +830,7 @@ class LightningNode(object):
             if SLOW_MACHINE:
                 self.daemon.cmd_prefix += ['--read-inline-info=no']
 
-        if self.daemon.opts.get('disable-plugin') == 'cln-grpc':
+        if self.daemon.opts.get('disable-plugin') == 'cln-grpc' or env('RUST') == '0':
             self.grpc_port = None
         else:
             if grpc_port:


### PR DESCRIPTION
No cln-grpc means no "grpc-port" option!  I often test this way, with RUST=0 for speed.

Changelog-None