### PR TITLE
configure: Fix PostgreSQL detection and configuration

### DIFF
--- a/configure
+++ b/configure
@@ -358,8 +358,8 @@ fi
 POSTGRES_INCLUDE=""
 POSTGRES_LDLIBS=""
 if command -v "${PG_CONFIG}" >/dev/null; then
-    POSTGRES_INCLUDE="-I$("${PG_CONFIG}" --includedir)"
-    POSTGRES_LDLIBS="-L$("${PG_CONFIG}" --libdir) -lpq"
+    POSTGRES_INCLUDE="$("${PKG_CONFIG}" --silence-errors --cflags libpq || :)"
+    POSTGRES_LDLIBS="$("${PKG_CONFIG}" --silence-errors --libs libpq || :)"
 fi
 
 # Clean up on exit.


### PR DESCRIPTION
Fix PostgreSQL detection and configuration when cross build for arm-linux-gnueabihf

**before:**
```
POSTGRES_INCLUDE = -I/usr/include/postgresql
POSTGRES_LDLIBS = -L/usr/lib/x86_64-linux-gnu -lpq
```
**after:**
```
POSTGRES_INCLUDE = -I/usr/arm-linux-gnueabihf/include
POSTGRES_LDLIBS = -L/usr/arm-linux-gnueabihf/lib -lpq
```
