### PR TITLE
lightningd: fix clang 19 compile error.

### DIFF
--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -944,7 +944,7 @@ char *opt_subd_dev_disconnect(const char *optarg, struct lightningd *ld)
 /* If test specified that this disconnection should cause permanent failure */
 bool dev_disconnect_permanent(struct lightningd *ld)
 {
-	char permfail[strlen("PERMFAIL")];
+	char permfail[sizeof("PERMFAIL") - 1];
 	int r;
 
 	if (ld->dev_disconnect_fd == -1)


### PR DESCRIPTION
```
Ubuntu clang version 19.1.0 (++20240901083933+6d7e428df611-1~exp1~20240901084058.28)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-19/bin

./configure CC=clang-19
make -j17
<snip>
cc lightningd/offer.c
cc lightningd/signmessage.c
lightningd/subd.c:945:16: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  945 |         char permfail[strlen("PERMFAIL")];
      |                       ^~~~~~~~~~~~~~~~~~
cc wallet/db.c
```


Changelog-Fixed: build: fix overzealous warning from clang 19.

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

Fixes: #7634
