### PR TITLE
Anchor code cleanup: always use anchors, but only boost to estimateblockfee 12.

### DIFF
--- a/lightningd/anchorspend.c
+++ b/lightningd/anchorspend.c
@@ -219,7 +219,7 @@ struct anchor_details *create_anchor_details(const tal_t *ctx,
 		final_deadline = adet->vals[tal_count(adet->vals) - 1].block;
 
 	/* "Two weeks later" */
-	v.block = final_deadline + 2016;
+	v.block = final_deadline + ld->dev_low_prio_anchor_blocks;
 	v.msat = AMOUNT_MSAT(0);
 	v.important = false;
 	tal_arr_expand(&adet->vals, v);

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -295,6 +295,7 @@ struct channel *new_unsaved_channel(struct peer *peer,
 	channel->old_feerate_timeout.ts.tv_nsec = 0;
 	/* closer not yet known */
 	channel->closer = NUM_SIDES;
+	channel->close_attempt_height = 0;
 	channel->close_blockheight = NULL;
 	/* In case someone looks at channels before open negotiation,
 	 * initialize this with default */
@@ -437,6 +438,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    u64 remote_static_remotekey_start,
 			    const struct channel_type *type STEALS,
 			    enum side closer,
+			    u32 close_attempt_height,
 			    enum state_change reason,
 			    /* NULL or stolen */
 			    const struct bitcoin_outpoint *shutdown_wrong_funding,
@@ -607,6 +609,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	list_head_init(&channel->inflights);
 
 	channel->closer = closer;
+	channel->close_attempt_height = close_attempt_height;
 	channel->close_blockheight = NULL;
 	channel->state_change_cause = reason;
 	channel->ignore_fee_limits = ignore_fee_limits;

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -305,6 +305,9 @@ struct channel {
 	/* the one that initiated a bilateral close, NUM_SIDES if unknown. */
 	enum side closer;
 
+	/* Block height we tried to close at (0 = not tried) */
+	u32 close_attempt_height;
+
 	/* Block height we saw closing tx at */
 	u32 *close_blockheight;
 
@@ -413,6 +416,7 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 			    u64 remote_static_remotekey_start,
 			    const struct channel_type *type STEALS,
 			    enum side closer,
+			    u32 close_attempt_height,
 			    enum state_change reason,
 			    /* NULL or stolen */
 			    const struct bitcoin_outpoint *shutdown_wrong_funding STEALS,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -143,6 +143,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->dev_no_htlc_timeout = false;
 	ld->dev_no_version_checks = false;
 	ld->dev_max_funding_unconfirmed = 2016;
+	ld->dev_low_prio_anchor_blocks = 2016;
 	ld->dev_ignore_modern_onion = false;
 	ld->dev_disable_commit = -1;
 	ld->dev_no_ping_timer = false;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -307,6 +307,9 @@ struct lightningd {
 	bool dev_throttle_gossip;
 	bool dev_suppress_gossip;
 
+	/* How long to aim for low-priority commitment closes */
+	u32 dev_low_prio_anchor_blocks;
+
 	/* Speedup reconnect delay, for testing. */
 	bool dev_fast_reconnect;
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -216,6 +216,7 @@ wallet_commit_channel(struct lightningd *ld,
 			      static_remotekey_start, static_remotekey_start,
 			      type,
 			      NUM_SIDES, /* closer not yet known */
+			      0, /* no close_attempt_height */
 			      uc->fc ? REASON_USER : REASON_REMOTE,
 			      NULL,
 			      take(new_height_states(NULL, uc->fc ? LOCAL : REMOTE,
@@ -1592,6 +1593,7 @@ static struct channel *stub_chan(struct command *cmd,
 			      0, 0,
 			      type,
 			      NUM_SIDES, /* closer not yet known */
+			      0, /* no close_attempt_height */
 			      REASON_REMOTE,
 			      NULL,
 			      take(new_height_states(ld->wallet, LOCAL,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -969,15 +969,19 @@ static void dev_register_opts(struct lightningd *ld)
 		     opt_set_bool,
 		     &ld->dev_limit_connections_inflight,
 		     "Throttle connection limiting down for testing.");
+	clnopt_witharg("--autoconnect-seeker-peers", OPT_SHOWINT,
+		       opt_set_u32, opt_show_u32,
+		       &ld->autoconnect_seeker_peers,
+		       "Seeker autoconnects to maintain this minimum number of gossip peers");
+	clnopt_witharg("--dev-low-prio-anchor-blocks", OPT_DEV|OPT_SHOWINT,
+		       opt_set_u32, opt_show_u32,
+		       &ld->dev_low_prio_anchor_blocks,
+		       "How many blocks to aim for low-priority anchor closes (default: 2016)");
 	/* This is handled directly in daemon_developer_mode(), so we ignore it here */
 	clnopt_noarg("--dev-debug-self", OPT_DEV,
 		     opt_ignore,
 		     NULL,
 		     "Fire up a terminal window with a debugger in it on initialization");
-	clnopt_witharg("--autoconnect-seeker-peers", OPT_SHOWINT,
-		       opt_set_u32, opt_show_u32,
-		       &ld->autoconnect_seeker_peers,
-		       "Seeker autoconnects to maintain this minimum number of gossip peers");
 }
 
 static const struct config testnet_config = {

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -369,6 +369,12 @@ void drop_to_chain(struct lightningd *ld, struct channel *channel,
 	/* If this was triggered by a close command, get a copy of the cmd id */
 	cmd_id = cmd_id_from_close_command(tmpctx, ld, channel);
 
+	/* Set close attempt height (for anchor rexmission) */
+	if (channel->close_attempt_height == 0) {
+		channel->close_attempt_height = get_block_height(ld->topology);
+		wallet_channel_save(channel->peer->ld->wallet, channel);
+	}
+
 	/* BOLT #2:
 	 *
 	 * - if `next_revocation_number` is greater than expected

--- a/wallet/db.c
+++ b/wallet/db.c
@@ -1029,6 +1029,7 @@ static struct migration dbmigrations[] = {
     {NULL, insert_addrtype_to_addresses},
     {SQL("ALTER TABLE channel_funding_inflights ADD remote_funding BLOB DEFAULT NULL;"), NULL},
     {SQL("ALTER TABLE peers ADD last_known_address BLOB DEFAULT NULL;"), NULL},
+    {SQL("ALTER TABLE channels ADD close_attempt_height INTEGER DEFAULT 0;"), NULL},
 };
 
 /**

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -178,6 +178,7 @@ struct channel *new_channel(struct peer *peer UNNEEDED, u64 dbid UNNEEDED,
 			    u64 remote_static_remotekey_start UNNEEDED,
 			    const struct channel_type *type STEALS UNNEEDED,
 			    enum side closer UNNEEDED,
+			    u32 close_attempt_height UNNEEDED,
 			    enum state_change reason UNNEEDED,
 			    /* NULL or stolen */
 			    const struct bitcoin_outpoint *shutdown_wrong_funding STEALS UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1999,7 +1999,7 @@ static bool test_channel_inflight_crud(struct lightningd *ld, const tal_t *ctx)
 			   &pk, NULL,
 			   1000, 100,
 			   NULL, 0, 0, channel_type_static_remotekey(NULL),
-			   LOCAL, REASON_UNKNOWN,
+			   LOCAL, 0, REASON_UNKNOWN,
 			   NULL,
 			   new_height_states(w, LOCAL,
 					     &lease_blockheight_start),

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1874,6 +1874,7 @@ static struct channel *wallet_stmt2channel(struct wallet *w, struct db_stmt *stm
 			   db_col_u64(stmt, "remote_static_remotekey_start"),
 			   type,
 			   db_col_int(stmt, "closer"),
+			   db_col_int(stmt, "close_attempt_height"),
 			   state_change_in_db(db_col_int(stmt, "state_change_reason")),
 			   shutdown_wrong_funding,
 			   take(height_states),
@@ -2089,6 +2090,7 @@ static bool wallet_channels_load_active(struct wallet *w)
 					", out_payments_fulfilled"
 					", out_msatoshi_offered"
 					", out_msatoshi_fulfilled"
+					", close_attempt_height"
 					" FROM channels"
                                         " WHERE state != ?;")); //? 0
 	db_bind_int(stmt, CLOSED);
@@ -2337,8 +2339,9 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 					"  remote_htlc_minimum_msat=?," // 50
 					"  remote_htlc_maximum_msat=?," // 51
 					"  last_stable_connection=?," // 52
-					"  require_confirm_inputs_remote=?" // 53
-					" WHERE id=?")); // 54
+					"  require_confirm_inputs_remote=?," // 53
+					"  close_attempt_height=?" // 54
+					" WHERE id=?")); // 55
 	db_bind_u64(stmt, chan->their_shachain.id);
 	if (chan->scid)
 		db_bind_short_channel_id(stmt, *chan->scid);
@@ -2437,6 +2440,7 @@ void wallet_channel_save(struct wallet *w, struct channel *chan)
 	db_bind_u64(stmt, chan->last_stable_connection);
 
 	db_bind_int(stmt, chan->req_confirmed_ins[REMOTE]);
+	db_bind_int(stmt, chan->close_attempt_height);
 	db_bind_u64(stmt, chan->dbid);
 	db_exec_prepared_v2(take(stmt));
 


### PR DESCRIPTION
If a commitment tx isnt' urgent (no HTLCs) we didn't create an anchor at all.  This is problematic as the user doesn't have a good way to do it themselves.

1. Always make an anchor if feeboost needed.
2. Always aim for 12 blocks away, at best (starts at 2 weeks).
3. Remember when we started closing, so this timing works across restarts.
4. Fix error where we would use the wrong values if we failed to create a PSBT in the loop (but we would update feerate etc).