### PR TITLE
pytest: fix test_pay tests now we've deprecated experimental-offers.

### DIFF
--- a/tests/autogenerate-rpc-examples.py
+++ b/tests/autogenerate-rpc-examples.py
@@ -201,7 +201,6 @@ def setup_test_nodes(node_factory, bitcoind):
         options = [
             {
                 'experimental-dual-fund': None,
-                'experimental-offers': None,
                 'may_reconnect': True,
                 'dev-hsmd-no-preapprove-check': None,
                 'allow-deprecated-apis': True,

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -6706,9 +6706,7 @@ def test_parallel_channels_reserve(node_factory, bitcoind):
 
 def test_fetchinvoice_with_payer_metadata(node_factory, bitcoind):
     # We remove the conversion plugin on l3, causing it to get upset.
-    l1, l2 = node_factory.line_graph(2, wait_for_announce=True,
-                                     opts=[{'experimental-offers': None},
-                                           {'experimental-offers': None}])
+    l1, l2 = node_factory.line_graph(2, wait_for_announce=True)
 
     # Simple default offer first.
     offer = l2.rpc.call('offer', {'amount': 'any'})


### PR DESCRIPTION
The test was merged after it was deprecated, and autogenerate-rpc-examples isn't run by CI.

Changelog-None