### PR TITLE
ci: Fix and improve tracing in CI

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -28,6 +28,7 @@ sudo apt-get -qq install --no-install-recommends --allow-unauthenticated -yy \
      libsqlite3-dev \
      libtool \
      libxml2-utils \
+     systemtap-sdt-dev \
      locales \
      net-tools \
      postgresql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update -qq && \
         python3-pip \
         python3-venv \
         python3-setuptools \
+        systemtap-sdt-dev \
         libev-dev \
         libevent-dev \
         qemu-user-static \

--- a/common/trace.c
+++ b/common/trace.c
@@ -96,6 +96,13 @@ static void trace_inject_traceparent(void)
 	}
 }
 
+static void trace_free(void)
+{
+	current = NULL;
+	free(active_spans);
+	active_spans = NULL;
+}
+
 static void trace_init(void) {
 	if (active_spans)
 		return;
@@ -103,6 +110,7 @@ static void trace_init(void) {
 
 	current = NULL;
 	trace_inject_traceparent();
+	atexit(trace_free);
 }
 
 /**

--- a/common/trace.c
+++ b/common/trace.c
@@ -250,6 +250,7 @@ void trace_span_start(const char *name, const void *key)
 
 	current = s;
 	DTRACE_PROBE1(lightningd, span_start, s->id);
+	trace_print_backtrace(current, stderr);
 }
 
 void trace_span_remote(u8 trace_id[TRACE_ID_SIZE], u8 span_id[SPAN_ID_SIZE])
@@ -265,9 +266,9 @@ void trace_span_end(const void *key)
 
 	if (s != current) {
 		fprintf(stderr, "Ending current span with another span. This is the current span:\n");
+		trace_print_backtrace(s, stderr);
 		trace_print_backtrace(current, stderr);
 		fprintf(stderr, "Whereas span to end is this:\n");
-		trace_print_backtrace(s, stderr);
 		fprintf(stderr, "The spans have to match.\n");
 		abort();
 	}

--- a/common/trace.c
+++ b/common/trace.c
@@ -246,7 +246,11 @@ void trace_span_end(const void *key)
 	size_t numkey = trace_key(key);
 	struct span *s = trace_span_find(numkey);
 	assert(s && "Span to end not found");
-	assert(s == current && "Ending a span that isn't the current one");
+
+	if (s != current) {
+		fprintf(stderr, "Ending current span %s with a span %s, is this a mixup?\n", current->name, s->name);
+		abort();
+	}
 
 	struct timeabs now = time_now();
 	s->end_time = (now.ts.tv_sec * 1000000) + now.ts.tv_nsec / 1000;

--- a/contrib/docker/Dockerfile.builder
+++ b/contrib/docker/Dockerfile.builder
@@ -35,7 +35,8 @@ RUN apt-get -qq update && \
 	lowdown \
 	wget \
 	jq \
-	gettext \
+        gettext \
+        systemtap-sdt-dev \
 	xsltproc \
 	zlib1g-dev && \
 	rm -rf /var/lib/apt/lists/*

--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -9,19 +9,20 @@ RUN dnf update -y && \
 		'Development Tools' && \
 	dnf install -y \
 		clang \
-		libsq3-devel \
-		python3-devel \
-		python3-mako \
-        python3-pip \
-        python3-virtualenv \
-		python3-setuptools \
-		redhat-lsb \
-		net-tools \
-		valgrind \
-		wget \
 		git \
 		jq \
-		xz \
+		libsq3-devel \
+		net-tools \
+		python3-devel \
+		python3-mako \
+		python3-setuptools \
+		redhat-lsb \
+		valgrind \
+		wget \
+                python3-pip \
+                python3-virtualenv \
+                systemtap-sdt-devel \
+                xz \
 		zlib-devel && \
 	dnf clean all
 

--- a/contrib/docker/Dockerfile.tester
+++ b/contrib/docker/Dockerfile.tester
@@ -45,6 +45,7 @@ RUN apt-get -qq update && \
 	qemu-user-static \
 	shellcheck \
 	software-properties-common \
+	systemtap-sdt-dev \
 	sudo \
 	tcl \
 	unzip \

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -21,7 +21,8 @@ RUN apt-get update \
 	libsodium23 \
 	libtool \
 	m4 \
-	sudo \
+        sudo \
+        systemtap-sdt-dev \
 	unzip \
 	wget \
 	git \

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -22,6 +22,7 @@ RUN apt-get update \
 	libsodium23 \
 	libtool \
 	m4 \
+        systemtap-sdt-dev \
 	sudo \
 	unzip \
 	wget \

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -17,16 +17,17 @@ RUN apt-get update \
 	file \
 	gettext \
 	git \
-    curl \
-    libsqlite3-dev \
+        curl \
+        libsqlite3-dev \
 	libpq-dev \
 	libsodium23 \
 	libtool \
 	m4 \
+        systemtap-sdt-dev \
 	sudo \
 	unzip \
 	wget \
-    jq \
+        jq \
 	zip
 
 # Configure /repo/.git as 'safe.directory'

--- a/db/utils.c
+++ b/db/utils.c
@@ -142,7 +142,7 @@ bool db_query_prepared_canfail(struct db_stmt *stmt)
 	bool ret;
 	assert(stmt->query->readonly);
 	trace_span_start("db_query_prepared", stmt);
-	trace_span_tag(&ret, "query", stmt->query->query);
+	trace_span_tag(stmt, "query", stmt->query->query);
 	ret = stmt->db->config->query_fn(stmt);
 	stmt->executed = true;
 	list_del_from(&stmt->db->pending_statements, &stmt->list);

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1175,7 +1175,7 @@ int main(int argc, char *argv[])
 	bool try_reexec;
 	size_t num_channels;
 
-	trace_span_start("lightningd/startup", argv);
+	trace_span_start("lightningd/startup", &exit_code);
 
 	/*~ What happens in strange locales should stay there. */
 	setup_locale();
@@ -1409,7 +1409,7 @@ int main(int argc, char *argv[])
 	/*~ Now handle sigchld, so we can clean up appropriately. */
 	sigchld_conn = notleak(io_new_conn(ld, sigchld_rfd, sigchld_rfd_in, ld));
 
-	trace_span_end(argv);
+	trace_span_end(&exit_code);
 
 	/*~ Mark ourselves live.
 	 *

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -1175,7 +1175,7 @@ int main(int argc, char *argv[])
 	bool try_reexec;
 	size_t num_channels;
 
-	trace_span_start("lightningd/startup", &exit_code);
+	trace_span_start("lightningd/startup", argv);
 
 	/*~ What happens in strange locales should stay there. */
 	setup_locale();
@@ -1409,7 +1409,7 @@ int main(int argc, char *argv[])
 	/*~ Now handle sigchld, so we can clean up appropriately. */
 	sigchld_conn = notleak(io_new_conn(ld, sigchld_rfd, sigchld_rfd_in, ld));
 
-	trace_span_end(&exit_code);
+	trace_span_end(argv);
 
 	/*~ Mark ourselves live.
 	 *


### PR DESCRIPTION
Looks like I missed one mismatched span pointer. To avoid this going
forward we also enable `systemtap-sdt-dev` on all builds on CI, and in
reprobuilds, because we want operators to have the option of just
starting to trace.

Added @ShahanaFarooqui as reviewer since she revisited the reprobuild
recently, and we should likely discuss if tracing enabled everywhere
is as desirable as I think :-)

Closes #7843
