### PR TITLE
pytest: allow a second gossip filter in test

### DIFF
--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2310,7 +2310,7 @@ def test_gossip_force_broadcast_channel_msgs(node_factory, bitcoind):
                             '--no-gossip',
                             '--hex',
                             '--network={}'.format(TEST_NETWORK),
-                            '--max-messages={}'.format(7),
+                            '--max-messages={}'.format(8),
                             '--timeout-after={}'.format(120),
                             '{}@localhost:{}'.format(l1.info['id'], l1.port)],
                            check=True,
@@ -2323,7 +2323,8 @@ def test_gossip_force_broadcast_channel_msgs(node_factory, bitcoind):
     del tally['query_short_channel_ids']
     del tally['query_channel_range']
     del tally['ping']
+    assert tally['gossip_filter'] >= 1
+    del tally['gossip_filter']
     assert tally == {'channel_announce': 1,
                      'channel_update': 3,
-                     'node_announce': 1,
-                     'gossip_filter': 1}
+                     'node_announce': 1}


### PR DESCRIPTION
Not sure why this didn't cause a problem in [7768](https://github.com/ElementsProject/lightning/pull/7768), but I'm assuming that's the cause.  The extra timestamp filter message is allowing gossipwith to cut off before catching the last channel update.

Fixes: 7849

Changelog-None

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
