### PR TITLE
pyln-client: restore backwards compatibility with CLN prior to 24.08

### DIFF
--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -948,9 +948,16 @@ class Plugin(object):
                 doc = "Undocumented RPC method from a plugin."
             doc = re.sub('\n+', ' ', doc)
 
+            # For compatibility with lightningd prior to 24.08, we must
+            # provide a description.  Ignored by 24.08 onwards,
+            description = method.description
+            if description is None:
+                description = ""
+
             methods.append({
                 'name': method.name,
-                'usage': method.get_usage()
+                'usage': method.get_usage(),
+                'description': description,
             })
 
         manifest = {


### PR DESCRIPTION
24.05 and before requires a "description" field.  We should not have removed it here until that was EOL!

Changelog-Fixed: pyln-client: plugins now compatible with CLN <= 24.05 (broken in 24.08)
Reported-by: Christian Decker
