### PR TITLE
startup_regtest: remove experimental-offers flag

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -190,7 +190,6 @@ start_nodes() {
 		dev-bitcoind-poll=5
 		experimental-dual-fund
 		experimental-splicing
-		experimental-offers
 		funder-policy=match
 		funder-policy-mod=100
 		funder-min-their-funding=10000


### PR DESCRIPTION
The script doesn't work if this flag is present. Offers are now default on.