### PR TITLE
`lightningd/test/Makefile`: add missing dependency on `header_versions_gen.h`

### DIFF
--- a/lightningd/test/Makefile
+++ b/lightningd/test/Makefile
@@ -7,6 +7,9 @@ LIGHTNINGD_TEST_PROGRAMS := $(LIGHTNINGD_TEST_OBJS:.o=)
 ALL_C_SOURCES += $(LIGHTNINGD_TEST_SRC)
 ALL_TEST_PROGRAMS += $(LIGHTNINGD_TEST_PROGRAMS)
 
+# run-find_my_abspath.c includes lightningd.c, which includes header_versions_gen.h
+lightningd/test/run-find_my_abspath.o: header_versions_gen.h
+
 LIGHTNINGD_TEST_COMMON_OBJS :=			\
 	common/amount.o				\
 	common/autodata.o			\


### PR DESCRIPTION
`lightningd/test/run-find_my_abspath.c` includes `../lightningd.c`, which includes `header_versions_gen.h`, a generated header file.

`lightningd/Makefile` correctly declares that `lightningd/lightningd.o` depends on `header_versions_gen.h`, but `lightningd/test/Makefile` lacks any such declaration regarding `lightningd/test/run-find_my_abspath.c`, which leads to build failure:

    In file included from lightningd/test/run-find_my_abspath.c:5:
    lightningd/test/../lightningd.c:64:10: fatal error: header_versions_gen.h: No such file or directory
       64 | #include <header_versions_gen.h>
          |          ^~~~~~~~~~~~~~~~~~~~~~~

Declare the missing dependency in `lightningd/test/Makefile` so that Make will ensure that `header_versions_gen.h` is generated before it attempts to build `lightningd/test/run-find_my_abspath.o`.

**Changelog-None**

---

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
