### PR TITLE
pyln-testing: disable seeker autoconnect by default

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -816,6 +816,8 @@ class LightningNode(object):
             self.daemon.opts["experimental-dual-fund"] = None
         if EXPERIMENTAL_SPLICING:
             self.daemon.opts["experimental-splicing"] = None
+        # Avoid test flakes cause by this option unless explicitly set.
+        self.daemon.opts.update({"autoconnect-seeker-peers": 0})
 
         if options is not None:
             self.daemon.opts.update(options)


### PR DESCRIPTION
This avoids potential test flakes, but the `autoconnect-seeker-peers` option can be explicitly set if needed for testing.

Changelog-None

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
