### PR TITLE
grpc: Silence the notification spam

### DIFF
--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -138,9 +138,12 @@ async fn handle_notification(plugin: Plugin<PluginState>, value: serde_json::Val
             log::debug!("Failed to parse notification from lightningd {:?}", err);
         }
         Ok(notification) => {
-            if let Err(err) = plugin.state().events.send(notification) {
-                log::warn!("Failed to broadcast notification {:?}", err)
-            }
+	    /* Depending on whether or not there is a wildcard
+	     * subscription we may receive notifications for which we
+	     * don't have a handler. We suppress the `SendError` which
+	     * would indicate there is no subscriber for the given
+	     * topic. */
+	    let _ = plugin.state().events.send(notification);
         }
     };
     Ok(())


### PR DESCRIPTION

We were logging notifications for which we do not have a handler registered.
That worked until we introduced the wildcard subscription, which the grpc plugin
uses. With this the guarantee that for each subscribed topic we had a corresponding
handler is no longer true, and the warning doesn't really add any information
to the logs, so we just stop logging.

Closes https://github.com/ElementsProject/lightning/issues/7836