### PR TITLE
Makefile: ensure that cln-grpc depends on msggen generated rust files.

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -296,7 +296,7 @@ CLN_PLUGIN_EXAMPLES := \
 CLN_PLUGIN_SRC = $(shell find plugins/src -name "*.rs")
 CLN_GRPC_PLUGIN_SRC = $(shell find plugins/grpc-plugin/src -name "*.rs")
 
-target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC} ${CLN_GRPC_PLUGIN_SRC} $(MSGGEN_GEN_ALL)
+target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC} ${CLN_GRPC_PLUGIN_SRC} $(MSGGEN_GENALL)
 	cargo build ${CARGO_OPTS} --bin cln-grpc
 
 ifneq ($(RUST),0)


### PR DESCRIPTION
The nightly CI in the plugins repo is failing to build CLN right now:

```
make: cargo: No such file or directory
cargo build --quiet --bin cln-grpc
make: *** [plugins/Makefile:300: target/debug/cln-grpc] Error 127
```

I believe this is because `MSGGEN_GEN_ALL` ensures `contrib/msggen/msggen/schema.json` is available while for building `cln-grpc` we need the actual rust files which are ensured by `MSGGEN_GENALL`

With this change i got the CI building again.