### PR TITLE
connectd: force our own channel gossip to more peers

### DIFF
--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -212,7 +212,7 @@ static struct oneshot *gossip_stream_timer(struct peer *peer)
 }
 
 /* Statistically, how many peers to we tell about each channel? */
-#define GOSSIP_SPAM_REDUNDANCY 5
+#define GOSSIP_SPAM_REDUNDANCY 50
 
 /* BOLT #7:
  * A node:


### PR DESCRIPTION
@vincenzopalazzo points out that large nodes are not always getting their own channel gossip out reliably.  The number of peers we spam our own channel gossip to is limited to save large nodes on startup, but this should be relaxed slightly to ensure propagation.

Changelog-Fixed: Own-channel gossip is broadcast to more peers on connect.

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
