### PR TITLE
Enable seeker autoconnect when started with no peers, disable when --offline

### DIFF
--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -550,6 +550,7 @@ static char *opt_set_offline(struct lightningd *ld)
 	ld->reconnect = false;
 	ld->listen = false;
 	log_info(ld->log, "Started in offline mode!");
+	ld->autoconnect_seeker_peers=0;
 	return NULL;
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

Testing the seeker autoconnect, I realized it should probably work even with no peers initially connected.  This PR allows the seeker to try autoconnecting in that case, and also entirely disables autoconnect when `--offline` is set.
