### PR TITLE
gossipd: fix crash in seeker rotation code.

### DIFF
--- a/gossipd/seeker.c
+++ b/gossipd/seeker.c
@@ -904,7 +904,8 @@ static void reset_gossip_performance_metrics(struct seeker *seeker)
 {
 	seeker->new_gossiper_elapsed = 0;
 	for (int i = 0; i < tal_count(seeker->gossiper); i++) {
-		seeker->gossiper[i]->gossip_counter = 0;
+		if (seeker->gossiper[i])
+			seeker->gossiper[i]->gossip_counter = 0;
 	}
 }
 


### PR DESCRIPTION
Reported-by: hMsats
Fixes: https://github.com/ElementsProject/lightning/issues/7875

Changelog-None: introduced in rc1
