### PR TITLE
connectd: fix crash when we get an incoming conn while outgoing attempt is ratelimited

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -390,8 +390,10 @@ struct io_plan *peer_connected(struct io_conn *conn,
 
 	if (connect) {
 		/*~ Now we've connected, disable the callback which would
-		 * cause us to to try the next address on failure. */
-		io_set_finish(connect->conn, NULL, NULL);
+		 * cause us to to try the next address on failure (if it's
+		 * in progress right now) */
+		if (connect->conn)
+			io_set_finish(connect->conn, NULL, NULL);
 		tal_free(connect);
 	}
 


### PR DESCRIPTION

```
Program received signal SIGSEGV, Segmentation fault.
0x000000001014e9d8 in io_set_finish_ (conn=0x0, finish=0x0, arg=0x0) at ccan/ccan/io/io.c:137
137             conn->finish = finish;
(gdb) bt
    incoming=true) at connectd/connectd.c:394
```

Fixes: #7871
Reported-by: grubles

Changelog-None: broken in this release

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
