### PR TITLE
dx: Add pre-commit as a central linter, formatter and checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.8.0
+  hooks:
+    # Run the linter.
+    - id: ruff
+      args: [ --diff ]
+      exclude: "contrib/pyln-grpc-proto/pyln/grpc/(primitives|node)_pb2(|_grpc).py"
+    # Run the formatter.
+    - id: ruff-format
+      args: [ --diff ]
+      exclude: "contrib/pyln-grpc-proto/pyln/grpc/(primitives|node)_pb2(|_grpc).py"


### PR DESCRIPTION
We have quite the variety of different formatters, checkers and linters:

 - [x] Python formatting, code style and linting
 - `shellcheck` run via `make`
 - `check-amount-access` grepping for access to the `u64` inside of the `amount_msat` and `amount_sat` structs.
 - JSON-Schema formatting
 - `discouraged-fundctions`
 - `check-gen-updated`
 - `check-includes`
   - `check-src-includes`
   - `check-hdr-includes`
 - `check-hsm-versions`
 - `check-manpages`
 - `check-spelling`
 - `check-whitespace`

For many of these we have custom scripts that require us to maintain
them as well, despite there being off-the-shelf tooling that allows us
to check and enfore these.


`pre-commit` standardizes the execution of these checkers, running
them against the proposed changes in a PR. It allows for checking and
fixing as separate steps, so CI can just check, and show the diff of
changes that would have been applied.

The `--from-ref` and `--to-ref` params help us to limit the scope of
the checks to the proposed changes, allowing us to incrementally adopt
these standards as we visit the files.

If you adopt a new file, i.e., modify a file that has not been checked
before, you might want to just quickly run `pre-commit run
--from-ref=master --to-ref=HEAD` after the first modification, and fix
up any lints or failing checks before moving on to actually
implementing your changes. This keeps the lint cleanup separate from
logic changes that are to be reviewed.
