### PR TITLE
wire: call unknown types "UNKNOWN X" not "INVALID X".

### DIFF
--- a/channeld/full_channel.c
+++ b/channeld/full_channel.c
@@ -1658,13 +1658,13 @@ bool channel_force_htlcs(struct channel *channel,
 
 const char *channel_add_err_name(enum channel_add_err e)
 {
-	static char invalidbuf[sizeof("INVALID ") + STR_MAX_CHARS(e)];
+	static char invalidbuf[sizeof("UNKNOWN ") + STR_MAX_CHARS(e)];
 
 	for (size_t i = 0; enum_channel_add_err_names[i].name; i++) {
 		if (enum_channel_add_err_names[i].v == e)
 			return enum_channel_add_err_names[i].name;
 	}
-	snprintf(invalidbuf, sizeof(invalidbuf), "INVALID %i", e);
+	snprintf(invalidbuf, sizeof(invalidbuf), "UNKNOWN %i", e);
 	return invalidbuf;
 }
 

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -219,7 +219,7 @@ json_add_routefail_info(struct json_stream *js,
 	json_add_num(js, "erring_index", erring_index);
 	json_add_num(js, "failcode", failcode);
 	/* FIXME: Better way to detect this? */
-	if (!strstarts(failcodename, "INVALID "))
+	if (!strstarts(failcodename, "UNKNOWN "))
 		json_add_string(js, "failcodename", failcodename);
 
 	if (erring_node != NULL)

--- a/lightningd/subd.c
+++ b/lightningd/subd.c
@@ -839,7 +839,7 @@ void subd_send_msg(struct subd *sd, const u8 *msg_out)
 	u16 type = fromwire_peektype(msg_out);
 	/* FIXME: We should use unique upper bits for each daemon, then
 	 * have generate-wire.py add them, just assert here. */
-	if (strstarts(sd->msgname(type), "INVALID"))
+	if (strstarts(sd->msgname(type), "UNKNOWN"))
 		fatal("Sending %s an invalid message %s", sd->name, tal_hex(tmpctx, msg_out));
 	msg_enqueue(sd->outq, msg_out);
 }

--- a/tools/gen/impl_template
+++ b/tools/gen/impl_template
@@ -24,7 +24,7 @@ ${i}
 
 const char *${enum_set['name']}_name(int e)
 {
-	static char invalidbuf[sizeof("INVALID ") + STR_MAX_CHARS(e)];
+	static char invalidbuf[sizeof("UNKNOWN ") + STR_MAX_CHARS(e)];
 
 	switch ((enum ${enum_set['name']})e) {
     % for msg in enum_set['set']:
@@ -32,7 +32,7 @@ const char *${enum_set['name']}_name(int e)
     % endfor
 	}
 
-	snprintf(invalidbuf, sizeof(invalidbuf), "INVALID %i", e);
+	snprintf(invalidbuf, sizeof(invalidbuf), "UNKNOWN %i", e);
 	return invalidbuf;
 }
 


### PR DESCRIPTION
It's freaking people out when they see things like:

```
 2024-11-11T05:26:41.281Z DEBUG ...53c-connectd: peer_out INVALID 22859
```

Fixes: https://github.com/ElementsProject/lightning/issues/7802
