### PR TITLE
build: fixup check for `HAVE_GOOD_LIBSODIUM`

### DIFF
--- a/configure
+++ b/configure
@@ -398,10 +398,11 @@ int main(void)
 {
 	crypto_secretstream_xchacha20poly1305_state crypto_state;
 	unsigned char header[crypto_secretstream_xchacha20poly1305_HEADERBYTES];
-	unsigned char data[] = { 1, 2, 3 };
+	unsigned char key[crypto_secretstream_xchacha20poly1305_KEYBYTES];
 
+	crypto_secretstream_xchacha20poly1305_keygen(key);
 	crypto_secretstream_xchacha20poly1305_init_push(&crypto_state, header,
-	                                                data);
+	                                                key);
 	printf("%p\n", crypto_aead_chacha20poly1305_ietf_encrypt);
 	printf("%d\n", crypto_aead_chacha20poly1305_ietf_NPUBBYTES);
 	return 0;


### PR DESCRIPTION
The current check fails when building with newer GCC, i.e:
```bash
error: ‘crypto_secretstream_xchacha20poly1305_init_push’ reading 32 bytes from a region of size 3 [-Werror=stringop-overread]
   12 |         crypto_secretstream_xchacha20poly1305_init_push(&crypto_state, header,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   13 |                                                         data);
```

This inadvertently results in the release binaries for Ubuntu 22.04 & 24.04, not having a runtime libsodium dependency, but instead using the bundled lib.

It's not clear to me this is actually enough to fix (all) the release builds, as the build containers need to have `libsodium-dev`, not just `libsodium` in them, and it's not clear to me which packages are actually present looking at the repro build scripts.

Changelog-Fixed: build: libsodium configure check fixed to work with newer GCC.