### PR TITLE
ci: remove macOS gettext symlinking

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -327,7 +327,6 @@ Assuming you have Xcode and Homebrew installed. Install dependencies:
 
 ```shell
 brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf
-ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
 export PATH="/usr/local/opt:$PATH"
 ```
 


### PR DESCRIPTION
This doesn't do anything, because it's trying to create a symlink for a verison that doesn't exist. The version of `gettext` currently installed via brew is `0.22.5`.

In any case, on any recent macOS system, this should not be necessary.

Changelog-None.