### PR TITLE
logs: Correct a sign mismatch printing the depth change

### DIFF
--- a/lightningd/watch.c
+++ b/lightningd/watch.c
@@ -208,8 +208,8 @@ static bool txw_fire(struct txwatch *txw,
 
 	if (txw->depth == -1) {
 		log_debug(txw->topo->log,
-			  "Got first depth change ->%u for %s",
-			  txw->depth,
+			  "Got first depth change 0->%u for %s",
+			  depth,
 			  fmt_bitcoin_txid(tmpctx, &txw->txid));
 	} else {
 		/* zero depth signals a reorganization */


### PR DESCRIPTION
We are checking if `txw->depth` is `-1` and then print it, when we clearly want `depth` instead.

Changelog-Fixed logs: When printing depths some unsigned numbers could overflow

