### PR TITLE
rust: bump versions for 24.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cln-grpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cln-grpc",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."
@@ -15,7 +15,7 @@ server = ["cln-rpc"]
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-cln-rpc = { path="../cln-rpc/", version = "0.2", optional = true }
+cln-rpc = { path="../cln-rpc/", version = "0.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tonic = { version = "0.11", features = ["tls", "transport"] }
 prost = "0.12"
@@ -28,7 +28,7 @@ tokio-util = "0.7.10"
 
 [dev-dependencies]
 serde_json = "1.0.72"
-cln-rpc = { path="../cln-rpc/", version = "0.2" }
+cln-rpc = { path="../cln-rpc/", version = "0.3" }
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-rpc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "An async RPC client for Core Lightning."

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-plugin"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."
@@ -27,4 +27,4 @@ tracing = { version = "^0.1", features = ["async-await", "log"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", ] }
-cln-grpc = { version = "0.2", path = "../cln-grpc" }
+cln-grpc = { version = "0.3", path = "../cln-grpc" }

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cln-grpc-plugin"
-version = "0.2.0"
+version = "0.3.0"
 
 description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. Authentication is done via mTLS."
 license = "MIT"
@@ -17,9 +17,9 @@ anyhow = "1.0"
 log = "0.4"
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 prost = "0.12"
-cln-grpc = { version = "0.2", features = ["server"], path = "../../cln-grpc"}
-cln-plugin = { version = "0.2", path = "../../plugins" }
-cln-rpc = { version = "0.2", path = "../../cln-rpc" }
+cln-grpc = { version = "0.3", features = ["server"], path = "../../cln-grpc"}
+cln-plugin = { version = "0.3", path = "../../plugins" }
+cln-rpc = { version = "0.3", path = "../../cln-rpc" }
 serde_json = "1.0.113"
 
 [dependencies.tokio]


### PR DESCRIPTION
Need to bump these versions for release so the CI job publishes them to crates.io. I found some minor breaking changes so i bumped it to 0.3 (some removals and non-Option->Option changes)