### PR TITLE
reduce xpay INFO verbosity

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1774,7 +1774,7 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 	method_tok = json_get_member(buf, rpc_tok, "method");
 	params_tok = json_get_member(buf, rpc_tok, "params");
 	id_tok = json_get_member(buf, rpc_tok, "id");
-	plugin_log(cmd->plugin, LOG_INFORM, "Got command %s",
+	plugin_log(cmd->plugin, LOG_DBG, "Got command %s",
 		   json_strdup(tmpctx, buf, method_tok));
 
 	if (!json_tok_streq(buf, method_tok, "pay"))


### PR DESCRIPTION
My lightningd logs are getting hammered by a particular log from v24.11's xpay plugin:

```
2024-12-11T16:29:03.439Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:29:03.440Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:30:02.530Z INFO    plugin-cln-xpay: Got command listpeerchannels
2024-12-11T16:30:03.440Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:30:03.441Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:31:03.493Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:31:03.493Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:32:03.495Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:32:03.496Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:33:03.555Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:33:03.555Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:34:03.589Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:34:03.589Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:35:02.592Z INFO    plugin-cln-xpay: Got command listpeerchannels
2024-12-11T16:35:03.590Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:35:03.590Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:36:03.649Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:36:03.650Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:37:03.696Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:37:03.699Z INFO    plugin-cln-xpay: Got command datastore
2024-12-11T16:38:03.751Z INFO    plugin-cln-xpay: Got command askrene-age
2024-12-11T16:38:03.752Z INFO    plugin-cln-xpay: Got command datastore
...
```

IMO it would make more sense to have this as a debug level log.