### PR TITLE
splice: errno header redirection failure

### DIFF
--- a/common/splice_script.c
+++ b/common/splice_script.c
@@ -11,8 +11,8 @@
 #include <common/json_parse_simple.h>
 #include <common/splice_script.h>
 #include <ctype.h>
+#include <errno.h>
 #include <inttypes.h>
-#include <sys/errno.h>
 
 #define SCRIPT_DUMP_TOKENS 0
 #define SCRIPT_DUMP_SEGMENTS 0


### PR DESCRIPTION
header sys/errno.h gets re-directed to errno.h leading to warning and then failure so instead directly referencing the header

fixes #7939, #7922

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
