### PR TITLE
xpay-handle-pay: bugfix, handle null parameters

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1914,6 +1914,12 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 		bolt11 = params_tok + 1;
 		if (params_tok->size == 2)
 			amount_msat = json_next(bolt11);
+
+		/* some arguments could have null values in the list */
+		if (bolt11 && json_tok_is_null(buf, bolt11))
+			bolt11 = NULL;
+		if (amount_msat && json_tok_is_null(buf, amount_msat))
+			amount_msat = NULL;
 	} else if (params_tok->type == JSMN_OBJECT) {
 		const jsmntok_t *t, *maxfeepercent = NULL, *exemptfee = NULL;
 		size_t i;

--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1888,6 +1888,9 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 	const char *maxfee = NULL;
 	struct json_stream *response;
 
+	/* pay extra params */
+	const jsmntok_t *maxfeepercent = NULL, *exemptfee = NULL;
+
 	if (!xpay->take_over_pay)
 		goto dont_redirect;
 
@@ -1921,7 +1924,7 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 		if (amount_msat && json_tok_is_null(buf, amount_msat))
 			amount_msat = NULL;
 	} else if (params_tok->type == JSMN_OBJECT) {
-		const jsmntok_t *t, *maxfeepercent = NULL, *exemptfee = NULL;
+		const jsmntok_t *t;
 		size_t i;
 
 		json_for_each_obj(i, t, params_tok) {
@@ -1947,22 +1950,22 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 				goto dont_redirect;
 			}
 		}
-		if (!bolt11) {
-			plugin_log(cmd->plugin, LOG_INFORM,
-				   "Not redirecting pay (missing bolt11 parameter)");
-			goto dont_redirect;
-		}
-		/* If this returns NULL, we let pay handle the weird case */
-		if (!calc_maxfee(cmd, &maxfee, buf,
-				 bolt11, amount_msat,
-				 exemptfee, maxfeepercent)) {
-			plugin_log(cmd->plugin, LOG_INFORM,
-				   "Not redirecting pay (weird maxfee params)");
-			goto dont_redirect;
-		}
 	} else {
 		plugin_log(cmd->plugin, LOG_INFORM,
 			   "Not redirecting pay (unexpected params type)");
+		goto dont_redirect;
+	}
+
+	if (!bolt11) {
+		plugin_log(cmd->plugin, LOG_INFORM,
+			   "Not redirecting pay (missing bolt11 parameter)");
+		goto dont_redirect;
+	}
+	/* If this returns NULL, we let pay handle the weird case */
+	if (!calc_maxfee(cmd, &maxfee, buf, bolt11, amount_msat, exemptfee,
+			 maxfeepercent)) {
+		plugin_log(cmd->plugin, LOG_INFORM,
+			   "Not redirecting pay (weird maxfee params)");
 		goto dont_redirect;
 	}
 


### PR DESCRIPTION
Changelog-Fixed: xpay-handle-pay: handle null parameters passed in the "param" list.

Solves issue #7953 