### PR TITLE
plugins/bcli: use -rpcwait to simplify waiting for bitcoind to warm up

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -1044,59 +1044,45 @@ static void parse_getnetworkinfo_result(struct plugin *p, const char *buf)
 
 static void wait_and_check_bitcoind(struct plugin *p)
 {
-	int in, from, status, ret;
+	int in, from, status;
 	pid_t child;
-	const char **cmd = gather_args(bitcoind, "getnetworkinfo", NULL);
-	bool printed = false;
+	const char **cmd = gather_args(
+	    bitcoind, "-rpcwait", "-rpcwaittimeout=30", "getnetworkinfo", NULL);
 	char *output = NULL;
 
-	for (;;) {
-		tal_free(output);
+	child = pipecmdarr(&in, &from, &from, cast_const2(char **, cmd));
 
-		child = pipecmdarr(&in, &from, &from, cast_const2(char **, cmd));
+	if (bitcoind->rpcpass)
+		write_all(in, bitcoind->rpcpass, strlen(bitcoind->rpcpass));
 
-		if (bitcoind->rpcpass)
-			write_all(in, bitcoind->rpcpass, strlen(bitcoind->rpcpass));
+	close(in);
 
-		close(in);
+	if (child < 0) {
+		if (errno == ENOENT)
+			bitcoind_failure(
+			    p,
+			    "bitcoin-cli not found. Is bitcoin-cli "
+			    "(part of Bitcoin Core) available in your PATH?");
+		plugin_err(p, "%s exec failed: %s", cmd[0], strerror(errno));
+	}
 
-		if (child < 0) {
-			if (errno == ENOENT)
-				bitcoind_failure(p, "bitcoin-cli not found. Is bitcoin-cli "
-						    "(part of Bitcoin Core) available in your PATH?");
-			plugin_err(p, "%s exec failed: %s", cmd[0], strerror(errno));
-		}
+	output = grab_fd(cmd, from);
 
-		output = grab_fd(cmd, from);
+	waitpid(child, &status, 0);
 
-		while ((ret = waitpid(child, &status, 0)) < 0 && errno == EINTR);
-		if (ret != child)
-			bitcoind_failure(p, tal_fmt(bitcoind, "Waiting for %s: %s",
-						    cmd[0], strerror(errno)));
-		if (!WIFEXITED(status))
-			bitcoind_failure(p, tal_fmt(bitcoind, "Death of %s: signal %i",
-						   cmd[0], WTERMSIG(status)));
+	if (!WIFEXITED(status))
+		bitcoind_failure(p, tal_fmt(bitcoind, "Death of %s: signal %i",
+					    cmd[0], WTERMSIG(status)));
 
-		if (WEXITSTATUS(status) == 0)
-			break;
-
-		/* bitcoin/src/rpc/protocol.h:
-		 *	RPC_IN_WARMUP = -28, //!< Client still warming up
-		 */
-		if (WEXITSTATUS(status) != 28) {
-			if (WEXITSTATUS(status) == 1)
-				bitcoind_failure(p, "Could not connect to bitcoind using"
-						    " bitcoin-cli. Is bitcoind running?");
-			bitcoind_failure(p, tal_fmt(bitcoind, "%s exited with code %i: %s",
-						    cmd[0], WEXITSTATUS(status), output));
-		}
-
-		if (!printed) {
-			plugin_log(p, LOG_UNUSUAL,
-				   "Waiting for bitcoind to warm up...");
-			printed = true;
-		}
-		sleep(1);
+	if (WEXITSTATUS(status) != 0) {
+		if (WEXITSTATUS(status) == 1)
+			bitcoind_failure(p,
+					 "RPC connection timed out. Could "
+					 "not connect to bitcoind using "
+					 "bitcoin-cli. Is bitcoind running?");
+		bitcoind_failure(p,
+				 tal_fmt(bitcoind, "%s exited with code %i: %s",
+					 cmd[0], WEXITSTATUS(status), output));
 	}
 
 	parse_getnetworkinfo_result(p, output);


### PR DESCRIPTION
Replaced custom wait logic with the `-rpcwait` flag in bitcoin-cli to handle waiting for bitcoind to warm up. Added a timer to print the warm-up message only if bitcoind doesn't start serving RPC calls within `30 seconds`. 
This simplifies the code and ensures that errors unrelated to warmup are passed up directly without additional checks.

Fixes: #3505

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
