### PR TITLE
ci: Fix broken CI after locking versions

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testfreebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build and test on FreeBSD
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
         run: |
           bash -x .github/scripts/setup.sh
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt
@@ -145,6 +146,7 @@ jobs:
         run: |
           set -e
           pip3 install --user pip wheel poetry
+          poetry self add poetry-plugin-export
           poetry export -o requirements.txt --with dev --without-hashes
           python3 -m pip install -r requirements.txt
           ./configure --enable-debugbuild CC="$COMPILER" ${{ matrix.COPTFLAGS_VAR }}
@@ -193,6 +195,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq lowdown
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt
@@ -227,6 +230,7 @@ jobs:
         run: |
           bash -x .github/scripts/setup.sh
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt

--- a/.github/workflows/crate-io.yml
+++ b/.github/workflows/crate-io.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release_rust:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   smoke-test:
     name: Smoke Test macOS
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 120
     strategy:
       fail-fast: true
@@ -27,25 +27,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          export PATH="/usr/local/opt:/Users/runner/.local/bin:/Users/runner/Library/Python/3.10/bin:$PATH"
+          export PATH="/usr/local/opt:/Users/runner/.local/bin:/opt/homebrew/bin/python3.10/bin:$PATH"
 
-          brew install wget autoconf automake libtool python@3.10 gnu-sed gettext libsodium protobuf
-
-          python3.10 -m pip install -U --user poetry wheel pip
+          brew install gnu-sed python@3.10 autoconf automake libtool protobuf
+          python3.10 -m pip install -U --user poetry==1.8.0 wheel pip mako
           python3.10 -m poetry install
-          python3.10 -m pip install -U --user mako
 
-          sudo ln -s /usr/local/Cellar/gettext/0.20.1/bin/xgettext /usr/local/opt
-
-      - name: Build and install
+      - name: Build and install CLN
         run: |
           export CPATH=/opt/homebrew/include
           export LIBRARY_PATH=/opt/homebrew/lib
 
           python3.10 -m poetry run ./configure --disable-valgrind --disable-compat
           python3.10 -m poetry run make
-
-          # sudo PATH="/usr/local/opt:$PATH" LIBRARY_PATH=/opt/homebrew/lib CPATH=/opt/homebrew/include make install
 
       - name: Start bitcoind in regtest mode
         run: |
@@ -58,11 +52,11 @@ jobs:
           bitcoin-cli -regtest generatetoaddress 1 $(bitcoin-cli -regtest getnewaddress)
           sleep 2
 
-      - name: Start lightningd in regtest mode
+      - name: Start CLN in regtest mode
         run: |
           lightningd/lightningd --network=regtest --log-file=/tmp/l1.log --daemon
           sleep 5
 
-      - name: Verify lightningd is running
+      - name: Verify CLN is running
         run: |
           cli/lightning-cli --regtest getinfo

--- a/.github/workflows/rdme-docs-sync.yml
+++ b/.github/workflows/rdme-docs-sync.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rdme-docs-sync:  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repo 📚
         uses: actions/checkout@v4

--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   rdme-rpc-sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ ENV PYTHON_VERSION=3
 RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
 RUN pip3 install --upgrade pip setuptools wheel
+RUN poetry self add poetry-plugin-export
 
 RUN wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz -O zlib.tar.gz && \
     wget -q https://www.sqlite.org/2019/sqlite-src-3290000.zip -O sqlite.zip
@@ -198,6 +199,7 @@ RUN ( ! [ "${target_host}" = "arm-linux-gnueabihf" ] ) || \
 # Ensure that the desired grpcio-tools & protobuf versions are installed
 # https://github.com/ElementsProject/lightning/pull/7376#issuecomment-2161102381
 RUN poetry lock --no-update && poetry install
+RUN poetry self add poetry-plugin-export
 
 # Ensure that git differences are removed before making bineries, to avoid `-modded` suffix
 # poetry.lock changed due to pyln-client, pyln-proto and pyln-testing version updates

--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -37,3 +37,4 @@ ENV PATH=/opt/venv/bin:${PATH}
 RUN python3 -m pip install pip wheel && \
     python3 -m virtualenv /opt/venv && \
     /opt/venv/bin/python3 -m pip install --force-reinstall -U pip poetry wheel
+RUN poetry self add poetry-plugin-export

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -49,7 +49,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools==1.62.2
+    && pip install poetry mako grpcio-tools==1.62.2 && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -47,7 +47,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools
+    && pip install poetry mako grpcio-tools && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -45,7 +45,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools
+    && pip install poetry mako grpcio-tools && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
+++ b/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
@@ -1,6 +1,3 @@
-[project]
-dependencies = ["pyln-client"]
-
 [tool.poetry]
 name = "testplugpyproj"
 version = "0.1.0"


### PR DESCRIPTION
These workflows are failing due to the update of `ubuntu-latest` from version `22.04` to `24.04`. For now, we can lock the Ubuntu version to `22.04` to resolve the issue and plan to update to `24.04` once it becomes more stable on GitHub Actions.

Reference: https://github.com/actions/runner-images/issues/10636

Changelog-None.