### PR TITLE
doc: Add newly added bkpr RPCs in documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,6 +23,8 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-batching.7 \
 	doc/lightning-bkpr-channelsapy.7 \
 	doc/lightning-bkpr-dumpincomecsv.7 \
+	doc/lightning-bkpr-editdescriptionbyoutpoint.7 \
+	doc/lightning-bkpr-editdescriptionbypaymentid.7 \
 	doc/lightning-bkpr-inspect.7 \
 	doc/lightning-bkpr-listaccountevents.7 \
 	doc/lightning-bkpr-listbalances.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,8 @@ Core Lightning Documentation
    lightning-batching <lightning-batching.7.md>
    lightning-bkpr-channelsapy <lightning-bkpr-channelsapy.7.md>
    lightning-bkpr-dumpincomecsv <lightning-bkpr-dumpincomecsv.7.md>
+   lightning-bkpr-editdescriptionbyoutpoint <lightning-bkpr-editdescriptionbyoutpoint.7.md>
+   lightning-bkpr-editdescriptionbypaymentid <lightning-bkpr-editdescriptionbypaymentid.7.md>
    lightning-bkpr-inspect <lightning-bkpr-inspect.7.md>
    lightning-bkpr-listaccountevents <lightning-bkpr-listaccountevents.7.md>
    lightning-bkpr-listbalances <lightning-bkpr-listbalances.7.md>


### PR DESCRIPTION
Adding the newly introduced RPCs, `editdescriptionbyoutpoint` and `editdescriptionbypaymentid`, to the `Makefile` for generating the corresponding `.md` files required for the documentation portal.

Changelog-None.