### PR TITLE
ci: Install `poetry-plugin-export` for poetry export command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
         run: |
           bash -x .github/scripts/setup.sh
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt
@@ -145,6 +146,7 @@ jobs:
         run: |
           set -e
           pip3 install --user pip wheel poetry
+          poetry self add poetry-plugin-export
           poetry export -o requirements.txt --with dev --without-hashes
           python3 -m pip install -r requirements.txt
           ./configure --enable-debugbuild CC="$COMPILER" ${{ matrix.COPTFLAGS_VAR }}
@@ -193,6 +195,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq lowdown
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt
@@ -227,6 +230,7 @@ jobs:
         run: |
           bash -x .github/scripts/setup.sh
           pip install -U pip wheel poetry
+          poetry self add poetry-plugin-export
           # Export and then use pip to install into the current env
           poetry export -o /tmp/requirements.txt --without-hashes --with dev
           pip install -r /tmp/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ ENV PYTHON_VERSION=3
 RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
 RUN pip3 install --upgrade pip setuptools wheel
+RUN poetry self add poetry-plugin-export
 
 RUN wget -q https://zlib.net/fossils/zlib-1.2.13.tar.gz -O zlib.tar.gz && \
     wget -q https://www.sqlite.org/2019/sqlite-src-3290000.zip -O sqlite.zip
@@ -198,6 +199,7 @@ RUN ( ! [ "${target_host}" = "arm-linux-gnueabihf" ] ) || \
 # Ensure that the desired grpcio-tools & protobuf versions are installed
 # https://github.com/ElementsProject/lightning/pull/7376#issuecomment-2161102381
 RUN poetry lock --no-update && poetry install
+RUN poetry self add poetry-plugin-export
 
 # Ensure that git differences are removed before making bineries, to avoid `-modded` suffix
 # poetry.lock changed due to pyln-client, pyln-proto and pyln-testing version updates

--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -37,3 +37,4 @@ ENV PATH=/opt/venv/bin:${PATH}
 RUN python3 -m pip install pip wheel && \
     python3 -m virtualenv /opt/venv && \
     /opt/venv/bin/python3 -m pip install --force-reinstall -U pip poetry wheel
+RUN poetry self add poetry-plugin-export

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -49,7 +49,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools==1.62.2
+    && pip install poetry mako grpcio-tools==1.62.2 && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -47,7 +47,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools
+    && pip install poetry mako grpcio-tools && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -45,7 +45,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
 
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && pip install poetry mako grpcio-tools
+    && pip install poetry mako grpcio-tools && \
+    poetry self add poetry-plugin-export
 
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \

--- a/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
+++ b/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
@@ -1,6 +1,3 @@
-[project]
-dependencies = ["pyln-client"]
-
 [tool.poetry]
 name = "testplugpyproj"
 version = "0.1.0"


### PR DESCRIPTION
Poetry will no longer include the `poetry-plugin-export` plugin by default, which is essential for exporting dependencies. So, we now need to install it explicitly.

Fixes CI error `The command "export" does not exist.`

Changelog-None.
