### PR TITLE
renepay: bugfix: read groupids as u64

### DIFF
--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -96,9 +96,9 @@ static const char *init(struct command *init_cmd,
 	return NULL;
 }
 
-static struct command_result *json_paystatus(struct command *cmd,
-					     const char *buf,
-					     const jsmntok_t *params)
+static struct command_result *json_renepaystatus(struct command *cmd,
+						 const char *buf,
+						 const jsmntok_t *params)
 {
 	const char *invstring;
 	struct json_stream *ret;
@@ -161,8 +161,8 @@ static struct command_result * payment_start(struct payment *p)
 	return payment_continue(p);
 }
 
-static struct command_result *json_pay(struct command *cmd, const char *buf,
-				       const jsmntok_t *params)
+static struct command_result *json_renepay(struct command *cmd, const char *buf,
+					   const jsmntok_t *params)
 {
 	/* === Parse command line arguments === */
 	// TODO check if we leak some of these temporary variables
@@ -452,11 +452,11 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 static const struct plugin_command commands[] = {
 	{
 		"renepaystatus",
-		json_paystatus
+		json_renepaystatus
 	},
 	{
 		"renepay",
-		json_pay
+		json_renepay
 	},
 	{
 		"renesendpay",

--- a/plugins/renepay/route.c
+++ b/plugins/renepay/route.c
@@ -1,8 +1,8 @@
 #include "config.h"
 #include <plugins/renepay/route.h>
 
-struct route *new_route(const tal_t *ctx, u32 groupid,
-			u32 partid, struct sha256 payment_hash,
+struct route *new_route(const tal_t *ctx, u64 groupid,
+			u64 partid, struct sha256 payment_hash,
 			struct amount_msat amount_deliver,
 			struct amount_msat amount_sent)
 {
@@ -32,7 +32,7 @@ struct route *new_route(const tal_t *ctx, u32 groupid,
  * @gossmap: global gossmap
  * @flow: the flow to convert to route */
 struct route *flow_to_route(const tal_t *ctx,
-			    u32 groupid, u32 partid, struct sha256 payment_hash,
+			    u64 groupid, u64 partid, struct sha256 payment_hash,
 			    u32 final_cltv, struct gossmap *gossmap,
 			    struct flow *flow,
 			    bool blinded_destination)
@@ -83,7 +83,7 @@ function_fail:
 }
 
 struct route **flows_to_routes(const tal_t *ctx,
-			       u32 groupid, u32 partid,
+			       u64 groupid, u64 partid,
 			       struct sha256 payment_hash, u32 final_cltv,
 			       struct gossmap *gossmap, struct flow **flows)
 {

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -117,19 +117,19 @@ static inline bool routekey_equal(const struct route *route,
 HTABLE_DEFINE_NODUPS_TYPE(struct route, route_get_key, routekey_hash, routekey_equal,
 			  route_map);
 
-struct route *new_route(const tal_t *ctx, u32 groupid,
-			u32 partid, struct sha256 payment_hash,
+struct route *new_route(const tal_t *ctx, u64 groupid,
+			u64 partid, struct sha256 payment_hash,
 			struct amount_msat amount,
 			struct amount_msat amount_sent);
 
 struct route *flow_to_route(const tal_t *ctx,
-			    u32 groupid, u32 partid, struct sha256 payment_hash,
+			    u64 groupid, u64 partid, struct sha256 payment_hash,
 			    u32 final_cltv, struct gossmap *gossmap,
 			    struct flow *flow,
 			    bool blinded_destination);
 
 struct route **flows_to_routes(const tal_t *ctx,
-			       u32 groupid, u32 partid,
+			       u64 groupid, u64 partid,
 			       struct sha256 payment_hash, u32 final_cltv,
 			       struct gossmap *gossmap, struct flow **flows);
 


### PR DESCRIPTION
Allow renepay to read group ids from listsenpay with values that fit into u64 integer type.
Previously renepay was using a mixture of u32 and u64 types to handle group ids.

Changelog-Fixed: renepay: read groupids as u64 integers.

Fixes #7968 
