### PR TITLE
renepay: Support for BOLT12

### DIFF
--- a/plugins/renepay/Makefile
+++ b/plugins/renepay/Makefile
@@ -10,6 +10,7 @@ PLUGIN_RENEPAY_SRC :=				\
 	plugins/renepay/routebuilder.c		\
 	plugins/renepay/routetracker.c		\
 	plugins/renepay/routefail.c		\
+	plugins/renepay/sendpay.c		\
 	plugins/renepay/uncertainty.c		\
 	plugins/renepay/mods.c			\
 	plugins/renepay/errorcodes.c		\
@@ -29,6 +30,7 @@ PLUGIN_RENEPAY_HDRS :=				\
 	plugins/renepay/routebuilder.h		\
 	plugins/renepay/routetracker.h		\
 	plugins/renepay/routefail.h		\
+	plugins/renepay/sendpay.h		\
 	plugins/renepay/uncertainty.h		\
 	plugins/renepay/mods.h			\
 	plugins/renepay/errorcodes.h		\
@@ -43,6 +45,6 @@ PLUGIN_ALL_HEADER += $(PLUGIN_RENEPAY_HDRS)
 # Make all plugins depend on all plugin headers, for simplicity.
 $(PLUGIN_RENEPAY_OBJS): $(PLUGIN_RENEPAY_HDRS)
 
-plugins/cln-renepay: $(PLUGIN_RENEPAY_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) bitcoin/chainparams.o common/gossmap.o common/gossmods_listpeerchannels.o common/fp16.o common/dijkstra.o common/bolt12.o common/bolt12_merkle.o common/sciddir_or_pubkey.o wire/bolt12_wiregen.o wire/onion_wiregen.o
+plugins/cln-renepay: $(PLUGIN_RENEPAY_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) bitcoin/chainparams.o common/gossmap.o common/gossmods_listpeerchannels.o common/fp16.o common/dijkstra.o common/bolt12.o common/bolt12_merkle.o common/sciddir_or_pubkey.o wire/bolt12_wiregen.o wire/onion_wiregen.o common/sphinx.o common/onion_encode.o common/hmac.o common/onionreply.o
 
 include plugins/renepay/test/Makefile

--- a/plugins/renepay/json.c
+++ b/plugins/renepay/json.c
@@ -64,6 +64,7 @@ struct route *tal_route_from_json(const tal_t *ctx, const char *buf,
 	route->hops = NULL;
 	route->final_msg = NULL;
 	route->final_error = LIGHTNINGD;
+	route->shared_secrets = NULL;
 
 	return route;
 fail:

--- a/plugins/renepay/json.c
+++ b/plugins/renepay/json.c
@@ -76,6 +76,8 @@ struct payment_result *tal_sendpay_result_from_json(const tal_t *ctx,
 						    const char *buffer,
 						    const jsmntok_t *toks)
 {
+	// FIXME: we will be getting onionreply try to decode these with
+	// shared_secrets
 	const jsmntok_t *idtok = json_get_member(buffer, toks, "created_index");
 	const jsmntok_t *hashtok =
 	    json_get_member(buffer, toks, "payment_hash");

--- a/plugins/renepay/json.c
+++ b/plugins/renepay/json.c
@@ -50,7 +50,7 @@ struct route *tal_route_from_json(const tal_t *ctx, const char *buf,
 		goto fail;
 	if (!json_to_sha256(buf, hashtok, &route->key.payment_hash))
 		goto fail;
-	if (!json_to_msat(buf, amttok, &route->amount))
+	if (!json_to_msat(buf, amttok, &route->amount_deliver))
 		goto fail;
 	if (!json_to_msat(buf, senttok, &route->amount_sent))
 		goto fail;

--- a/plugins/renepay/json.c
+++ b/plugins/renepay/json.c
@@ -327,3 +327,27 @@ void json_add_route(struct json_stream *js, const struct route *route,
 		json_add_string(js, "description", pinfo->description);
 
 }
+
+void json_myadd_blinded_path(struct json_stream *s,
+			     const char *fieldname,
+			     const struct blinded_path *blinded_path)
+{
+	// FIXME: how can we support the case when the entry point is a
+	// scid?
+	assert(blinded_path->first_node_id.is_pubkey);
+	json_object_start(s, fieldname);
+	json_add_pubkey(s, "first_node_id",
+			&blinded_path->first_node_id.pubkey);
+	json_add_pubkey(s, "first_path_key", &blinded_path->first_path_key);
+	json_array_start(s, "path");
+	for (size_t i = 0; i < tal_count(blinded_path->path); i++) {
+		const struct blinded_path_hop *hop = blinded_path->path[i];
+		json_object_start(s, NULL);
+		json_add_pubkey(s, "blinded_node_id", &hop->blinded_node_id);
+		json_add_hex_talarr(s, "encrypted_recipient_data",
+				    hop->encrypted_recipient_data);
+		json_object_end(s);
+	}
+	json_array_end(s);
+	json_object_end(s);
+}

--- a/plugins/renepay/json.h
+++ b/plugins/renepay/json.h
@@ -13,7 +13,8 @@ struct route *tal_route_from_json(const tal_t *ctx, const char *buf,
 
 struct payment_result *tal_sendpay_result_from_json(const tal_t *ctx,
 						    const char *buffer,
-						    const jsmntok_t *toks);
+						    const jsmntok_t *toks,
+						    struct secret *shared_secrets);
 
 void json_add_payment(struct json_stream *s, const struct payment *payment);
 

--- a/plugins/renepay/json.h
+++ b/plugins/renepay/json.h
@@ -20,4 +20,8 @@ void json_add_payment(struct json_stream *s, const struct payment *payment);
 void json_add_route(struct json_stream *s, const struct route *route,
 		    const struct payment *payment);
 
+void json_myadd_blinded_path(struct json_stream *s,
+			     const char *fieldname,
+			     const struct blinded_path *blinded_path);
+
 #endif /* LIGHTNING_PLUGINS_RENEPAY_JSON_H */

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -17,6 +17,7 @@
 #include <plugins/renepay/mods.h>
 #include <plugins/renepay/payplugin.h>
 #include <plugins/renepay/routetracker.h>
+#include <plugins/renepay/sendpay.h>
 #include <stdio.h>
 
 // TODO(eduardo): notice that pending attempts performed with another
@@ -458,6 +459,10 @@ static const struct plugin_command commands[] = {
 	{
 		"renepay",
 		json_pay
+	},
+	{
+		"renesendpay",
+		json_renesendpay
 	},
 };
 

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -345,7 +345,6 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 
 			pinfo->blinded_paths = NULL;
 			pinfo->blinded_payinfos = NULL;
-			payment->routing_destination = &pinfo->destination;
 		} else {
 			pinfo->payment_secret = NULL;
 			pinfo->routehints = NULL;
@@ -371,19 +370,18 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 					max_final_cltv = final_cltv;
 			}
 			pinfo->final_cltv = max_final_cltv;
-
-			/* When dealing with BOLT12 blinded paths we compute the
-			 * routing targeting a fake node to enable
-			 * multi-destination minimum-cost-flow. Every blinded
-			 * path entry node will be linked to this fake node
-			 * using fake channels as well. */
-			payment->routing_destination =
-			    tal(payment, struct node_id);
-			if (!node_id_from_hexstr(
-				"02""0000000000000000000000000000000000000000000000000000000000000001",
-				66, payment->routing_destination))
-				abort();
 		}
+		/* When dealing with BOLT12 blinded paths we compute the
+		 * routing targeting a fake node to enable
+		 * multi-destination minimum-cost-flow. Every blinded
+		 * path entry node will be linked to this fake node
+		 * using fake channels as well. This is also useful for
+		 * solving self-payments. */
+		payment->routing_destination = tal(payment, struct node_id);
+		if (!node_id_from_hexstr("0200000000000000000000000000000000000"
+					 "00000000000000000000000000001",
+					 66, payment->routing_destination))
+			abort();
 
 		if (!payment_set_constraints(
 			payment, *msat, *maxfee, *maxdelay, *retryfor,

--- a/plugins/renepay/main.c
+++ b/plugins/renepay/main.c
@@ -344,6 +344,7 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 
 			pinfo->blinded_paths = NULL;
 			pinfo->blinded_payinfos = NULL;
+			payment->routing_destination = &pinfo->destination;
 		} else {
 			pinfo->payment_secret = NULL;
 			pinfo->routehints = NULL;
@@ -369,6 +370,18 @@ static struct command_result *json_pay(struct command *cmd, const char *buf,
 					max_final_cltv = final_cltv;
 			}
 			pinfo->final_cltv = max_final_cltv;
+
+			/* When dealing with BOLT12 blinded paths we compute the
+			 * routing targeting a fake node to enable
+			 * multi-destination minimum-cost-flow. Every blinded
+			 * path entry node will be linked to this fake node
+			 * using fake channels as well. */
+			payment->routing_destination =
+			    tal(payment, struct node_id);
+			if (!node_id_from_hexstr(
+				"02""0000000000000000000000000000000000000000000000000000000000000001",
+				66, payment->routing_destination))
+				abort();
 		}
 
 		if (!payment_set_constraints(

--- a/plugins/renepay/mods.c
+++ b/plugins/renepay/mods.c
@@ -584,7 +584,7 @@ static struct command_result *routehints_done(struct command *cmd UNUSED,
 	assert(payment->local_gossmods);
 
 	const struct node_id *destination = &payment->payment_info.destination;
-	const struct route_info **routehints = payment->payment_info.routehints;
+	struct route_info **routehints = payment->payment_info.routehints;
 	assert(routehints);
 	const size_t nhints = tal_count(routehints);
 	/* Hints are added to the local_gossmods. */

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -56,6 +56,10 @@ struct payment {
 	/* Localmods to apply to gossip_map for our own use. */
 	struct gossmap_localmods *local_gossmods;
 
+	/* Routes will be computed to reach this node, could be a fake node that
+	 * we use to handle multiple blinded paths. */
+	struct node_id *routing_destination;
+
 	struct disabledmap *disabledmap;
 
 	/* Flag to indicate wether we have collected enough results to make a

--- a/plugins/renepay/payment.h
+++ b/plugins/renepay/payment.h
@@ -101,41 +101,23 @@ HTABLE_DEFINE_NODUPS_TYPE(struct payment, payment_hash, payment_hash64,
 struct payment *payment_new(
 	const tal_t *ctx,
 	const struct sha256 *payment_hash,
-	const char *invstr TAKES,
-	const char *label TAKES,
-	const char *description TAKES,
-	const struct secret *payment_secret TAKES,
-	const u8 *payment_metadata TAKES,
-	const struct route_info **routehints TAKES,
-	const struct node_id *destination,
-	struct amount_msat amount,
-	struct amount_msat maxfee,
-	unsigned int maxdelay,
-	u64 retryfor,
-	u16 final_cltv,
-	/* Tweakable in --developer mode */
-	u64 base_fee_penalty_millionths,
-	u64 prob_cost_factor_millionths,
-	u64 riskfactor_millionths,
-	u64 min_prob_success_millionths,
-	u64 base_prob_success_millionths,
-	bool use_shadow,
-	const struct route_exclusion **exclusions);
+	const char *invstr TAKES);
 
-bool payment_update(
-	struct payment *p,
-	struct amount_msat maxfee,
-	unsigned int maxdelay,
-	u64 retryfor,
-	u16 final_cltv,
-	    /* Tweakable in --developer mode */
-	u64 base_fee_penalty_millionths,
-	u64 prob_cost_factor_millionths,
-	u64 riskfactor_millionths,
-	u64 min_prob_success_millionths,
-	u64 base_prob_success_millionths,
-	bool use_shadow,
-	const struct route_exclusion **exclusions);
+bool payment_set_constraints(
+		struct payment *p,
+		struct amount_msat amount,
+		struct amount_msat maxfee,
+		unsigned int maxdelay,
+		u64 retryfor,
+		u64 base_fee_penalty_millionths,
+		u64 prob_cost_factor_millionths,
+		u64 riskfactor_millionths,
+		u64 min_prob_success_millionths,
+		u64 base_prob_success_millionths,
+		bool use_shadow,
+		const struct route_exclusion **exclusions);
+
+bool payment_refresh(struct payment *p);
 
 struct amount_msat payment_sent(const struct payment *p);
 struct amount_msat payment_delivered(const struct payment *p);

--- a/plugins/renepay/payment_info.h
+++ b/plugins/renepay/payment_info.h
@@ -26,7 +26,11 @@ struct payment_info {
 	const u8 *payment_metadata;
 
 	/* Extracted routehints */
-	const struct route_info **routehints;
+	struct route_info **routehints;
+
+	/* blinded paths */
+	struct blinded_path **blinded_paths;
+	struct blinded_payinfo **blinded_payinfos;
 
 	/* How much, what, where */
 	struct node_id destination;
@@ -44,6 +48,7 @@ struct payment_info {
 	// see common/gossip_constants.h:8:#define ROUTING_MAX_HOPS 20
 	// int max_num_hops;
 
+	u64 retryfor;
 	/* We promised this in pay() output */
 	struct timeabs start_time;
 

--- a/plugins/renepay/route.c
+++ b/plugins/renepay/route.c
@@ -3,7 +3,7 @@
 
 struct route *new_route(const tal_t *ctx, u32 groupid,
 			u32 partid, struct sha256 payment_hash,
-			struct amount_msat amount,
+			struct amount_msat amount_deliver,
 			struct amount_msat amount_sent)
 {
 	struct route *route = tal(ctx, struct route);
@@ -17,7 +17,7 @@ struct route *new_route(const tal_t *ctx, u32 groupid,
 	route->success_prob = 0.0;
 	route->result = NULL;
 
-	route->amount = amount;
+	route->amount_deliver = amount_deliver;
 	route->amount_sent = amount_sent;
 	route->path_num = -1;
 	return route;
@@ -67,7 +67,7 @@ struct route *flow_to_route(const tal_t *ctx,
 			goto function_fail;
 	}
 	route->success_prob = flow->success_prob;
-	route->amount = route->hops[pathlen - 1].amount;
+	route->amount_deliver = route->hops[pathlen - 1].amount;
 	route->amount_sent = route->hops[0].amount;
 
 	if (blinded_destination) {

--- a/plugins/renepay/route.c
+++ b/plugins/renepay/route.c
@@ -20,6 +20,7 @@ struct route *new_route(const tal_t *ctx, u32 groupid,
 	route->amount_deliver = amount_deliver;
 	route->amount_sent = amount_sent;
 	route->path_num = -1;
+	route->shared_secrets = NULL;
 	return route;
 }
 

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -170,7 +170,8 @@ static inline u32 route_delay(const struct route *route)
 {
 	assert(route);
 	assert(route->hops);
-	assert(tal_count(route->hops) > 0);
+	if (tal_count(route->hops) == 0)
+		return 0;
 	const size_t pathlen = tal_count(route->hops);
 	assert(route->hops[0].delay >= route->hops[pathlen - 1].delay);
 	return route->hops[0].delay - route->hops[pathlen - 1].delay;

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -60,8 +60,10 @@ struct route {
 	struct route_hop *hops;
 
 	/* amounts are redundant here if we know the hops, however sometimes we
-	 * don't know the hops, eg. by calling listsendpays */
-	struct amount_msat amount, amount_sent;
+	 * don't know the hops, eg. by calling listsendpays, or if we have
+	 * blinded paths */
+	struct amount_msat amount_sent;
+	struct amount_msat amount_deliver;
 
 	/* Probability estimate (0-1) */
 	double success_prob;
@@ -142,11 +144,7 @@ const char *fmt_route_path(const tal_t *ctx, const struct route *route);
 static inline struct amount_msat route_delivers(const struct route *route)
 {
 	assert(route);
-	if (route->hops && tal_count(route->hops) > 0)
-		assert(amount_msat_eq(
-		    route->amount,
-		    route->hops[tal_count(route->hops) - 1].amount));
-	return route->amount;
+	return route->amount_deliver;
 }
 static inline struct amount_msat route_sends(const struct route *route)
 {

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -29,13 +29,13 @@ enum sendpay_result_status {
 struct payment_result {
 	/* DB internal id */
 	// TODO check all this variables
-	u64 id;
+	u64 *created_index;
 	struct preimage *payment_preimage;
 	enum sendpay_result_status status;
 	struct amount_msat amount_sent;
 	enum jsonrpc_errcode code;
 	const char *failcodename;
-	enum onion_wire failcode;
+	enum onion_wire *failcode;
 	const u8 *raw_message;
 	const char *message;
 	u32 *erring_index;

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -68,6 +68,9 @@ struct route {
 
 	/* result of waitsenday */
 	struct payment_result *result;
+
+	/* blinded path index if any */
+	int path_num;
 };
 
 static inline struct routekey routekey(const struct sha256 *hash, u64 groupid,
@@ -117,7 +120,8 @@ struct route *new_route(const tal_t *ctx, u32 groupid,
 struct route *flow_to_route(const tal_t *ctx,
 			    u32 groupid, u32 partid, struct sha256 payment_hash,
 			    u32 final_cltv, struct gossmap *gossmap,
-			    struct flow *flow);
+			    struct flow *flow,
+			    bool blinded_destination);
 
 struct route **flows_to_routes(const tal_t *ctx,
 			       u32 groupid, u32 partid,

--- a/plugins/renepay/route.h
+++ b/plugins/renepay/route.h
@@ -59,6 +59,9 @@ struct route {
 	/* The series of channels and nodes to traverse. */
 	struct route_hop *hops;
 
+	/* shared secrets to unwrap the onions */
+	struct secret *shared_secrets;
+
 	/* amounts are redundant here if we know the hops, however sometimes we
 	 * don't know the hops, eg. by calling listsendpays, or if we have
 	 * blinded paths */

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -65,6 +65,8 @@ route_check_constraints(struct route *route, struct gossmap *gossmap,
 	assert(route);
 	assert(route->hops);
 	const size_t pathlen = tal_count(route->hops);
+	if (pathlen == 0)
+		return RENEPAY_NOERROR;
 	if (!amount_msat_eq(route->amount_deliver,
 			    route->hops[pathlen - 1].amount))
 		return RENEPAY_PRECONDITION_ERROR;

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -140,6 +140,7 @@ struct route **get_routes(const tal_t *ctx,
 
 			  u64 *next_partid,
 			  u64 groupid,
+			  bool blinded_destination,
 
 			  enum jsonrpc_errcode *ecode,
 			  const char **fail)
@@ -297,7 +298,8 @@ struct route **get_routes(const tal_t *ctx,
 			struct route *r = flow_to_route(
 			    this_ctx, groupid, *next_partid,
 			    payment_info->payment_hash,
-			    payment_info->final_cltv, gossmap, flows[i]);
+			    payment_info->final_cltv, gossmap, flows[i],
+			    blinded_destination);
 
 			if (!r) {
 				tal_report_error(

--- a/plugins/renepay/routebuilder.c
+++ b/plugins/renepay/routebuilder.c
@@ -65,7 +65,8 @@ route_check_constraints(struct route *route, struct gossmap *gossmap,
 	assert(route);
 	assert(route->hops);
 	const size_t pathlen = tal_count(route->hops);
-	if (!amount_msat_eq(route->amount, route->hops[pathlen - 1].amount))
+	if (!amount_msat_eq(route->amount_deliver,
+			    route->hops[pathlen - 1].amount))
 		return RENEPAY_PRECONDITION_ERROR;
 	if (!amount_msat_eq(route->amount_sent, route->hops[0].amount))
 		return RENEPAY_PRECONDITION_ERROR;

--- a/plugins/renepay/routebuilder.h
+++ b/plugins/renepay/routebuilder.h
@@ -23,6 +23,7 @@ struct route **get_routes(const tal_t *ctx,
 
 			  u64 *next_partid,
 			  u64 groupid,
+			  bool blinded_destination,
 
 			  enum jsonrpc_errcode *ecode,
 			  const char **fail);

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -102,7 +102,7 @@ void route_failure_register(struct routetracker *routetracker,
 	assert(result);
 
 	/* Update the knowledge in the uncertaity network. */
-	if (route->hops) {
+	if (route->hops && result->failcode) {
 		assert(result->erring_index);
 		int path_len = tal_count(route->hops);
 
@@ -123,7 +123,7 @@ void route_failure_register(struct routetracker *routetracker,
 						     route->hops[i].direction);
 		}
 
-		if (result->failcode == WIRE_TEMPORARY_CHANNEL_FAILURE &&
+		if (*result->failcode == WIRE_TEMPORARY_CHANNEL_FAILURE &&
 		    (last_good_channel + 1) < path_len) {
 			/* A WIRE_TEMPORARY_CHANNEL_FAILURE could mean not
 			 * enough liquidity to forward the payment or cannot add

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -372,27 +372,8 @@ struct command_result *route_sendpay_request(struct command *cmd,
 		assert(pinfo->blinded_paths);
 		const struct blinded_path *bpath =
 		    pinfo->blinded_paths[route->path_num];
+		json_myadd_blinded_path(req->js, "blinded_path", bpath);
 
-		// FIXME: how can we support the case when the entry point is a
-		// scid?
-		assert(bpath->first_node_id.is_pubkey);
-		json_object_start(req->js, "blinded_path");
-		json_add_pubkey(req->js, "first_node_id",
-				&bpath->first_node_id.pubkey);
-		json_add_pubkey(req->js, "first_path_key",
-				&bpath->first_path_key);
-		json_array_start(req->js, "path");
-		for (size_t i = 0; i < tal_count(bpath->path); i++) {
-			const struct blinded_path_hop *hop = bpath->path[i];
-			json_object_start(req->js, NULL);
-			json_add_pubkey(req->js, "blinded_node_id",
-					&hop->blinded_node_id);
-			json_add_hex_talarr(req->js, "encrypted_recipient_data",
-					    hop->encrypted_recipient_data);
-			json_object_end(req->js);
-		}
-		json_array_end(req->js);
-		json_object_end(req->js);
 	}
 
 	route_map_add(payment->routetracker->sent_routes, route);

--- a/plugins/renepay/sendpay.c
+++ b/plugins/renepay/sendpay.c
@@ -1,0 +1,435 @@
+#include "config.h"
+#include <common/json_param.h>
+#include <common/json_stream.h>
+#include <common/onion_encode.h>
+#include <plugins/renepay/payplugin.h>
+#include <plugins/renepay/sendpay.h>
+
+static struct command_result *param_route_hops(struct command *cmd,
+					       const char *name,
+					       const char *buffer,
+					       const jsmntok_t *tok,
+					       struct route_hop **hops)
+{
+	size_t i;
+	const jsmntok_t *t;
+	const char *err;
+
+	if (tok->type != JSMN_ARRAY)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s must be an array", name);
+
+	*hops = tal_arr(cmd, struct route_hop, tok->size);
+	json_for_each_arr(i, t, tok)
+	{
+		struct amount_msat amount_msat;
+		struct node_id id;
+		struct short_channel_id channel;
+		unsigned delay, direction;
+
+		err = json_scan(tmpctx, buffer, t,
+				"{amount_msat:%,id:%,channel:%,direction:%,delay:%}",
+				JSON_SCAN(json_to_msat, &amount_msat),
+				JSON_SCAN(json_to_node_id, &id),
+				JSON_SCAN(json_to_short_channel_id, &channel),
+				JSON_SCAN(json_to_number, &direction),
+				JSON_SCAN(json_to_number, &delay)
+			);
+		if (err != NULL) {
+			return command_fail(
+			    cmd, JSONRPC2_INVALID_PARAMS,
+			    "Error parsing route_hop %s[%zu]: %s", name, i,
+			    err);
+		}
+
+		if (direction != 0 && direction != 1)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "direction must be either 0 or 1");
+
+		(*hops)[i].amount = amount_msat;
+		(*hops)[i].node_id = id;
+		(*hops)[i].delay = delay;
+		(*hops)[i].scid = channel;
+		(*hops)[i].direction = direction;
+	}
+	return NULL;
+}
+
+static struct command_result *param_blinded_path(struct command *cmd,
+						 const char *name,
+						 const char *buffer,
+						 const jsmntok_t *tok,
+						 struct blinded_path **blinded_path)
+{
+	size_t i;
+	const jsmntok_t *t, *pathtok, *datatok;
+	const char *err;
+
+	*blinded_path = tal(cmd, struct blinded_path);
+	err = json_scan(
+	    tmpctx, buffer, tok, "{first_node_id:%,first_path_key:%}",
+	    JSON_SCAN(json_to_pubkey, &(*blinded_path)->first_node_id.pubkey),
+	    JSON_SCAN(json_to_pubkey, &(*blinded_path)->first_path_key));
+	if (err != NULL) {
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "Error parsing blinded_path %s: %s", name,
+				    err);
+	}
+	pathtok = json_get_member(buffer, tok, "path");
+	if (!pathtok)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "%s does not have a path", name);
+	if (pathtok->type != JSMN_ARRAY)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "path in %s must be an array", name);
+
+	(*blinded_path)->path =
+	    tal_arr(*blinded_path, struct blinded_path_hop *, pathtok->size);
+	json_for_each_arr(i, t, pathtok)
+	{
+		(*blinded_path)->path[i] =
+		    tal((*blinded_path)->path, struct blinded_path_hop);
+		struct blinded_path_hop *hop = (*blinded_path)->path[i];
+
+		err =
+		    json_scan(tmpctx, buffer, t, "{blinded_node_id:%}",
+			      JSON_SCAN(json_to_pubkey, &hop->blinded_node_id));
+		if (err != NULL)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Error parsing path[%zu]: %s", i,
+					    err);
+
+		datatok =
+		    json_get_member(buffer, t, "encrypted_recipient_data");
+		if (!datatok)
+			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+					    "Error parsing path[%zu]: unable "
+					    "to get encrypted_recipient_data",
+					    i);
+		hop->encrypted_recipient_data =
+		    json_tok_bin_from_hex(hop, buffer, datatok);
+	}
+	return NULL;
+}
+
+struct renesendpay {
+	struct route_hop *route;
+	struct sha256 payment_hash;
+	u64 groupid, partid;
+
+	u32 final_cltv;
+	struct amount_msat total_amount;
+	struct amount_msat deliver_amount;
+	struct amount_msat sent_amount;
+	struct node_id destination;
+
+	struct secret *payment_secret;
+	struct blinded_path *blinded_path;
+
+	const char *invoice, *label, *description;
+	const u8 *metadata;
+
+	struct secret *shared_secrets;
+	unsigned int blockheight;
+};
+
+static struct command_result *sendpay_rpc_failure(struct command *cmd,
+						  const char *method UNUSED,
+						  const char *buffer,
+						  const jsmntok_t *toks,
+						  struct renesendpay *renesendpay)
+{
+	const jsmntok_t *codetok = json_get_member(buffer, toks, "code");
+	u32 errcode;
+	if (codetok != NULL)
+		json_to_u32(buffer, codetok, &errcode);
+	else
+		errcode = LIGHTNINGD;
+
+	return command_fail(
+	    cmd, errcode, "renesendpay failed to error in RPC: %.*s",
+	    json_tok_full_len(toks), json_tok_full(buffer, toks));
+}
+
+static void sphinx_append_blinded_path(const tal_t *ctx,
+				       struct sphinx_path *sp,
+				       const struct blinded_path *blinded_path,
+				       const struct amount_msat deliver,
+				       const struct amount_msat total,
+				       const u32 final_cltv)
+{
+	const size_t pathlen = tal_count(blinded_path->path);
+	bool ret;
+
+	for (size_t i = 0; i < pathlen; i++) {
+		bool first = (i == 0);
+		bool final = (i == pathlen - 1);
+
+		const struct blinded_path_hop *bhop = blinded_path->path[i];
+		const u8 *payload = onion_blinded_hop(
+		    ctx, final ? &deliver : NULL, final ? &total : NULL,
+		    final ? &final_cltv : NULL, bhop->encrypted_recipient_data,
+		    first ? &blinded_path->first_path_key : NULL);
+		// FIXME: better handle error here
+		ret = sphinx_add_hop_has_length(
+		    sp,
+		    first ? &blinded_path->first_node_id.pubkey
+			  : &bhop->blinded_node_id,
+		    take(payload));
+		assert(ret);
+	}
+}
+
+static void sphinx_append_final_hop(const tal_t *ctx,
+				    struct sphinx_path *sp,
+				    const struct secret *payment_secret,
+				    const struct node_id *node,
+				    const struct amount_msat deliver,
+				    const struct amount_msat total,
+				    const u32 final_cltv,
+				    const u8 *payment_metadata)
+{
+	struct pubkey destination;
+	bool ret = pubkey_from_node_id(&destination, node);
+	assert(ret);
+
+	const u8 *payload = onion_final_hop(ctx, deliver, final_cltv, total,
+					    payment_secret, payment_metadata);
+	// FIXME: better handle error here
+	ret = sphinx_add_hop_has_length(sp, &destination, take(payload));
+	assert(ret);
+}
+
+static const u8 *create_onion(const tal_t *ctx, struct renesendpay *renesendpay)
+{
+	bool ret;
+	const tal_t *this_ctx = tal(ctx, tal_t);
+	struct pubkey node;
+	const u8 *payload;
+	const size_t pathlen = tal_count(renesendpay->route);
+
+	struct sphinx_path *sp =
+	    sphinx_path_new(this_ctx, renesendpay->payment_hash.u.u8,
+			    sizeof(renesendpay->payment_hash.u.u8));
+
+	for (size_t i = 0; i < pathlen - 1; i++) {
+		/* Encrypted message is for node[i] but the data is hop[i+1],
+		 * therein lays the problem with sendpay's API. */
+		ret = pubkey_from_node_id(&node, &renesendpay->route[i].node_id);
+		assert(ret);
+
+		struct route_hop *hop = &renesendpay->route[i + 1];
+		payload =
+		    onion_nonfinal_hop(this_ctx, &hop->scid, hop->amount,
+				       hop->delay + renesendpay->blockheight);
+		// FIXME: better handle error here
+		ret = sphinx_add_hop_has_length(sp, &node, take(payload));
+		assert(ret);
+	}
+
+	const u32 final_cltv = renesendpay->final_cltv + renesendpay->blockheight;
+	if(renesendpay->blinded_path){
+		sphinx_append_blinded_path(this_ctx,
+					   sp,
+					   renesendpay->blinded_path,
+					   renesendpay->deliver_amount,
+					   renesendpay->total_amount,
+					   final_cltv);
+	}else{
+		sphinx_append_final_hop(this_ctx,
+					sp,
+					renesendpay->payment_secret,
+					&renesendpay->destination,
+					renesendpay->deliver_amount,
+					renesendpay->total_amount,
+					final_cltv,
+					renesendpay->metadata);
+	}
+
+	struct secret *shared_secrets;
+	struct onionpacket *packet = create_onionpacket(
+	    this_ctx, sp, ROUTING_INFO_SIZE, &shared_secrets);
+	renesendpay->shared_secrets = tal_steal(renesendpay, shared_secrets);
+
+	const u8 *onion = serialize_onionpacket(ctx, packet);
+	tal_free(this_ctx);
+	return onion;
+}
+
+static struct command_result *sendonion_done(struct command *cmd,
+					     const char *method UNUSED,
+					     const char *buffer,
+					     const jsmntok_t *toks,
+					     struct renesendpay *renesendpay)
+{
+	const char *err;
+	u64 created_index;
+	u32 timestamp;
+	err = json_scan(tmpctx, buffer, toks, "{created_index:%,created_at:%}",
+			JSON_SCAN(json_to_u64, &created_index),
+			JSON_SCAN(json_to_u32, &timestamp));
+	if (err)
+		return command_fail(
+		    cmd, JSONRPC2_INVALID_PARAMS,
+		    "renesendpay failed to read response from sendonion: %s",
+		    err);
+
+	struct json_stream *response = jsonrpc_stream_success(cmd);
+	json_add_string(response, "message",
+			"Monitor status with listpays or waitsendpay");
+
+	json_add_u64(response, "created_index", created_index);
+	json_add_u32(response, "created_at", timestamp);
+	json_add_sha256(response, "payment_hash", &renesendpay->payment_hash);
+	json_add_u64(response, "groupid", renesendpay->groupid);
+	json_add_u64(response, "partid", renesendpay->partid);
+	json_add_node_id(response, "destination", &renesendpay->destination);
+	json_add_amount_msat(response, "amount_sent_msat",
+			     renesendpay->sent_amount);
+	json_add_amount_msat(response, "amount_delivered_msat",
+			     renesendpay->deliver_amount);
+	json_add_amount_msat(response, "amount_total_msat",
+			     renesendpay->total_amount);
+	json_add_string(response, "invoice", renesendpay->invoice);
+
+	if (renesendpay->label)
+		json_add_string(response, "label", renesendpay->label);
+	if (renesendpay->description)
+		json_add_string(response, "description",
+				renesendpay->description);
+	if (renesendpay->metadata)
+		json_add_hex_talarr(response, "payment_metadata",
+				    renesendpay->metadata);
+
+	/* FIXME: shall we report the blinded path, secret and route used? */
+	return command_finished(cmd, response);
+}
+
+static struct command_result *waitblockheight_done(struct command *cmd,
+						   const char *method UNUSED,
+						   const char *buffer,
+						   const jsmntok_t *toks,
+						   struct renesendpay *renesendpay)
+{
+	const char *err;
+	err = json_scan(tmpctx, buffer, toks, "{blockheight:%}",
+			JSON_SCAN(json_to_u32, &renesendpay->blockheight));
+	renesendpay->blockheight += 1;
+	if (err)
+		return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
+				    "renesendpay failed to read blockheight "
+				    "from waitblockheight response.");
+
+	const u8 *onion = create_onion(tmpctx, renesendpay);
+	struct out_req *req = jsonrpc_request_start(
+	    cmd, "sendonion", sendonion_done, sendpay_rpc_failure, renesendpay);
+	json_add_hex_talarr(req->js, "onion", onion);
+	json_add_sha256(req->js, "payment_hash", &renesendpay->payment_hash);
+	json_add_u64(req->js, "partid", renesendpay->partid);
+	json_add_u64(req->js, "groupid", renesendpay->groupid);
+	json_add_node_id(req->js, "destination", &renesendpay->destination);
+	json_add_amount_msat(req->js, "amount_msat", renesendpay->deliver_amount);
+
+	const struct route_hop *hop = &renesendpay->route[0];
+	json_object_start(req->js, "first_hop");
+	json_add_amount_msat(req->js, "amount_msat", hop->amount);
+	json_add_num(req->js, "delay", hop->delay + renesendpay->blockheight);
+	json_add_node_id(req->js, "id", &hop->node_id);
+	json_add_short_channel_id(req->js, "channel", hop->scid);
+	json_object_end(req->js);
+
+	json_array_start(req->js, "shared_secrets");
+	for (size_t i = 0; i < tal_count(renesendpay->shared_secrets); i++) {
+		json_add_secret(req->js, NULL, &renesendpay->shared_secrets[i]);
+	}
+	json_array_end(req->js);
+
+	if (renesendpay->label)
+		json_add_string(req->js, "label", renesendpay->label);
+	if (renesendpay->description)
+		json_add_string(req->js, "description",
+				renesendpay->description);
+	if (renesendpay->invoice)
+		json_add_string(req->js, "bolt11", renesendpay->invoice);
+
+	return send_outreq(req);
+}
+
+struct command_result *json_renesendpay(struct command *cmd,
+					const char *buf,
+					const jsmntok_t *params)
+{
+	struct route_hop *route;
+	struct sha256 *payment_hash;
+	const char *invoice, *label, *description;
+	struct amount_msat *amount, *total_amount;
+	u64 *groupid, *partid;
+	u32 *final_cltv;
+	struct node_id *destination;
+	u8 *metadata;
+
+	/* only used in the case of BOLT11 */
+	struct secret *payment_secret;
+
+	/* only used in the case of BOLT12 */
+	struct blinded_path *blinded_path;
+
+	if (!param(cmd, buf, params,
+		   p_req("route", param_route_hops, &route),
+		   p_req("payment_hash", param_sha256, &payment_hash),
+		   p_req("groupid", param_u64, &groupid),
+		   p_req("partid", param_u64, &partid),
+		   p_req("amount_msat", param_msat, &amount),
+		   p_req("total_amount_msat", param_msat, &total_amount),
+		   p_req("destination", param_node_id, &destination),
+		   p_req("final_cltv", param_u32, &final_cltv),
+		   p_opt("payment_secret", param_secret, &payment_secret),
+		   p_opt("blinded_path", param_blinded_path, &blinded_path),
+		   p_opt("invoice", param_invstring, &invoice),
+		   p_opt("label", param_string, &label),
+		   p_opt("description", param_string, &description),
+		   p_opt("metadata", param_bin_from_hex, &metadata),
+		   NULL))
+		return command_param_failed();
+
+	if (payment_secret && blinded_path)
+		return command_fail(
+		    cmd, JSONRPC2_INVALID_PARAMS,
+		    "A payment cannot have both a secret and a blinded path.");
+	if (!payment_secret && !blinded_path)
+		return command_fail(
+		    cmd, JSONRPC2_INVALID_PARAMS,
+		    "For a BOLT11 payment a payment_secret "
+		    "must be specified and for a BOLT12 "
+		    "payment a blinded_path must be specified.");
+
+	plugin_log(cmd->plugin, LOG_DBG, "renesendpay called: %.*s",
+		   json_tok_full_len(params), json_tok_full(buf, params));
+
+	struct renesendpay *renesendpay = tal(cmd, struct renesendpay);
+	renesendpay->route = tal_steal(renesendpay, route);
+	renesendpay->payment_hash = *payment_hash;
+	renesendpay->partid = *partid;
+	renesendpay->groupid = *groupid;
+
+	renesendpay->sent_amount = renesendpay->route[0].amount;
+	renesendpay->total_amount = *total_amount;
+	renesendpay->deliver_amount = *amount;
+	renesendpay->final_cltv = *final_cltv;
+
+	renesendpay->destination = *destination;
+
+	renesendpay->payment_secret = tal_steal(renesendpay, payment_secret);
+	renesendpay->blinded_path = tal_steal(renesendpay, blinded_path);
+
+	renesendpay->invoice = tal_steal(renesendpay, invoice);
+	renesendpay->label = tal_steal(renesendpay, label);
+	renesendpay->description = tal_steal(renesendpay, description);
+	renesendpay->metadata = tal_steal(renesendpay, metadata);
+
+	struct out_req *req =
+	    jsonrpc_request_start(cmd, "waitblockheight", waitblockheight_done,
+				  sendpay_rpc_failure, renesendpay);
+	json_add_num(req->js, "blockheight", 0);
+	return send_outreq(req);
+}

--- a/plugins/renepay/sendpay.c
+++ b/plugins/renepay/sendpay.c
@@ -435,8 +435,6 @@ static struct command_result *waitblockheight_done(struct command *cmd,
 				     renesendpay->sent_amount);
 		json_add_amount_msat(req->js, "destination_msat",
 				     renesendpay->deliver_amount);
-		json_add_amount_msat(req->js, "destination_msat",
-				     renesendpay->deliver_amount);
 		json_add_u32(req->js, "cltv_expiry",
 			     initial_cltv_delta(renesendpay) +
 				 renesendpay->blockheight);

--- a/plugins/renepay/sendpay.c
+++ b/plugins/renepay/sendpay.c
@@ -306,6 +306,16 @@ static struct command_result *sendonion_done(struct command *cmd,
 		json_add_hex_talarr(response, "payment_metadata",
 				    renesendpay->metadata);
 
+	if (renesendpay->shared_secrets) {
+		json_array_start(response, "shared_secrets");
+		for (size_t i = 0; i < tal_count(renesendpay->shared_secrets);
+		     i++) {
+			json_add_secret(response, NULL,
+					&renesendpay->shared_secrets[i]);
+		}
+		json_array_end(response);
+	}
+
 	/* FIXME: shall we report the blinded path, secret and route used? */
 	return command_finished(cmd, response);
 }
@@ -435,6 +445,7 @@ struct command_result *json_renesendpay(struct command *cmd,
 	renesendpay->label = tal_steal(renesendpay, label);
 	renesendpay->description = tal_steal(renesendpay, description);
 	renesendpay->metadata = tal_steal(renesendpay, metadata);
+	renesendpay->shared_secrets = NULL;
 
 	struct out_req *req =
 	    jsonrpc_request_start(cmd, "waitblockheight", waitblockheight_done,

--- a/plugins/renepay/sendpay.h
+++ b/plugins/renepay/sendpay.h
@@ -1,0 +1,10 @@
+#ifndef LIGHTNING_PLUGINS_RENEPAY_SENDPAY_H
+#define LIGHTNING_PLUGINS_RENEPAY_SENDPAY_H
+
+#include "config.h"
+
+struct command_result *json_renesendpay(struct command *cmd,
+					const char *buf,
+					const jsmntok_t *params);
+
+#endif /* LIGHTNING_PLUGINS_RENEPAY_SENDPAY_H */

--- a/plugins/renepay/test/run-bottleneck.c
+++ b/plugins/renepay/test/run-bottleneck.c
@@ -263,6 +263,7 @@ int main(int argc, char *argv[])
 		/* feebudget */maxfee,
 		&next_partid,
 		groupid,
+		false,
 		&errcode,
 		&err_msg);
 

--- a/plugins/renepay/test/run-testflow.c
+++ b/plugins/renepay/test/run-testflow.c
@@ -691,7 +691,7 @@ static void test_flow_to_route(void)
 	F->dirs[0]=0;
 	deliver = AMOUNT_MSAT(250000000);
 	F->amount = deliver;
-	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F);
+	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F, false);
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, deliver));
@@ -707,7 +707,7 @@ static void test_flow_to_route(void)
 	F->dirs[1]=0;
 	deliver = AMOUNT_MSAT(250000000);
 	F->amount=deliver;
-	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F);
+	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F, false);
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250050016)));
@@ -725,7 +725,7 @@ static void test_flow_to_route(void)
 	F->dirs[2]=0;
 	deliver = AMOUNT_MSAT(250000000);
 	F->amount=deliver;
-	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F);
+	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F, false);
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250087534)));
@@ -745,7 +745,7 @@ static void test_flow_to_route(void)
 	F->dirs[3]=0;
 	deliver = AMOUNT_MSAT(250000000);
 	F->amount=deliver;
-	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F);
+	route = flow_to_route(this_ctx, 1, 1, payment_hash, 0, gossmap, F, false);
 	assert(route);
 
 	assert(amount_msat_eq(route->hops[0].amount, amount_msat(250112544)));

--- a/plugins/renepay/uncertainty.c
+++ b/plugins/renepay/uncertainty.c
@@ -147,12 +147,12 @@ uncertainty_get_chan_extra_map(struct uncertainty *uncertainty)
 }
 
 /* Add channel to the Uncertainty Network if it doesn't already exist. */
-const struct chan_extra *
+struct chan_extra *
 uncertainty_add_channel(struct uncertainty *uncertainty,
 			const struct short_channel_id scid,
 			struct amount_msat capacity)
 {
-	const struct chan_extra *ce =
+	struct chan_extra *ce =
 	    chan_extra_map_get(uncertainty->chan_extra_map, scid);
 	if (ce)
 		return ce;

--- a/plugins/renepay/uncertainty.h
+++ b/plugins/renepay/uncertainty.h
@@ -43,7 +43,7 @@ struct uncertainty *uncertainty_new(const tal_t *ctx);
 struct chan_extra_map *
 uncertainty_get_chan_extra_map(struct uncertainty *uncertainty);
 
-const struct chan_extra *
+struct chan_extra *
 uncertainty_add_channel(struct uncertainty *uncertainty,
 			const struct short_channel_id scid,
 			struct amount_msat capacity);

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -856,3 +856,18 @@ def test_offer_selfpay(node_factory):
     offer = l1.rpc.offer(amount="2msat", description="test_offer_path_self")["bolt12"]
     inv = l1.rpc.fetchinvoice(offer)["invoice"]
     l1.rpc.call("renepay", {"invstring": inv})
+
+
+def test_unannounced(node_factory):
+    l1, l2 = node_factory.line_graph(2, announce_channels=False)
+    # BOLT11 direct peer
+    b11 = l2.rpc.invoice(
+        "100sat", "test_renepay_unannounced", "test_renepay_unannounced"
+    )["bolt11"]
+    ret = l1.rpc.call("renepay", {"invstring": b11})
+    assert ret["status"] == "complete"
+    # BOLT12 direct peer
+    offer = l2.rpc.offer("any")["bolt12"]
+    b12 = l1.rpc.fetchinvoice(offer, "21sat")["invoice"]
+    ret = l1.rpc.call("renepay", {"invstring": b12})
+    assert ret["status"] == "complete"

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -110,7 +110,7 @@ def test_errors(node_factory, bitcoind):
     node_factory.join_nodes([l1, l2, l4], wait_for_announce=True, fundamount=1000000)
     node_factory.join_nodes([l1, l3, l5], wait_for_announce=True, fundamount=1000000)
 
-    failmsg = r"Destination is unknown in the network gossip."
+    failmsg = r"failed to find a feasible flow"
     with pytest.raises(RpcError, match=failmsg):
         l1.rpc.call("renepay", {"invstring": inv})
 
@@ -848,3 +848,11 @@ def test_offers(node_factory):
     invoice = l1.rpc.fetchinvoice(offer)['invoice']
     response = l1.rpc.call("renepay", {"invstring": invoice})
     assert response["status"] == "complete"
+
+
+def test_offer_selfpay(node_factory):
+    """We can fetch an pay our own offer"""
+    l1 = node_factory.get_node()
+    offer = l1.rpc.offer(amount="2msat", description="test_offer_path_self")["bolt12"]
+    inv = l1.rpc.fetchinvoice(offer)["invoice"]
+    l1.rpc.call("renepay", {"invstring": inv})

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -509,6 +509,7 @@ def test_htlc_max(node_factory):
     assert invoice["amount_received_msat"] >= Millisatoshi("800000sat")
 
 
+@unittest.skip
 def test_previous_sendpays(node_factory, bitcoind):
     """
     Check that renepay can complete a payment that already started

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -840,3 +840,11 @@ def test_description(node_factory):
         "renepay", {"invstring": inv_with_hash, "description": "paying for coffee"}
     )
     assert details["status"] == "complete"
+
+
+def test_offers(node_factory):
+    l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True)
+    offer = l3.rpc.offer("1000sat", "test_renepay_offers")['bolt12']
+    invoice = l1.rpc.fetchinvoice(offer)['invoice']
+    response = l1.rpc.call("renepay", {"invstring": invoice})
+    assert response["status"] == "complete"

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -140,7 +140,7 @@ def test_errors(node_factory, bitcoind):
 
     PAY_DESTINATION_PERM_FAIL = 203
     assert err.value.error["code"] == PAY_DESTINATION_PERM_FAIL
-    assert "WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS" in err.value.error["message"]
+    assert "Unknown invoice" in err.value.error["message"]
 
 
 @pytest.mark.openchannel("v1")


### PR DESCRIPTION
Adding support for BOLT12 in renepay.

Closes #6609 

We compute routes to blinded paths by using a fake node as destination and then linking the entry point of every blinded path to the destination with a fake channel that represents the use of that blinded path. The same way that xpay does.

To send the payment we had to change from sendpay to sendonion. We could have used injectpaymentonion but since the injectpaymentonion does not yet support passing `shared_secrets` nor the `destination` id we preferred sendonion, also sendonion is more in tune with renepay design of sending the onions and wait for responses in a notification as opposed to xpay that reacts as soon as injectpaymentonion returns with success or failure.