### PR TITLE
Add ‘v’ to the version from zipfile release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #! /usr/bin/make
 
 # Extract version from git, or if we're from a zipfile, use dirname
-VERSION=$(shell git describe --tags --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc\-]*\)$$|\1|gp')
+VERSION=$(shell git describe --tags --always --dirty=-modded --abbrev=7 2>/dev/null || pwd | sed -n 's|.*/c\{0,1\}lightning-v\{0,1\}\([0-9a-f.rc\-]*\)$$|v\1|gp')
 
 # Next release.
 CLN_NEXT_VERSION := v24.11


### PR DESCRIPTION
When building from a release zipfile and there is no `git` present, the version number lacks a ‘v’.

This triggers db.c to fail its `is_released_version` check, which fails because the version does not start with a ‘v’ — thereby the database upgrade is rejected.

Issue reported by TonyV on Discord:
“Hey guys, I just upgraded to the latest release and am now getting
```
Refusing to irreversibly upgrade db from version 219 to 261 in non-final version 24.11.1 (use --database-upgrade=true to override)
```
I have the db backed up... but am I good to make those changes without breaking my channels?”

Changelog-Changed: Fix for people upgrading using source release zip packages.