### PR TITLE
pyln-client+cli: Fix formatting issues for plugin description in lightning-cli help

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -197,8 +197,8 @@ static void human_help(char *buffer, const jsmntok_t *result)
 	for (i = 0; i < tal_count(help); i++) {
 		const jsmntok_t *command;
 		command = json_get_member(buffer, help[i], "command");
-		printf("%.*s\n\n",
-		       command->end - command->start, buffer + command->start);
+		human_readable(buffer, command, '\n');
+		printf("\n");
 	}
 	tal_free(help);
 

--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -84,7 +84,9 @@ class Method(object):
                 args.append("[%s]" % arg)
 
         if self.description is not None:
-            args.append("\n%s" % self.description)
+            doc = inspect.getdoc(self.func)
+            doc = re.sub('\n', '\n ', doc)
+            args.append(" \n %s" % doc)
 
         return " ".join(args)
 

--- a/contrib/pyln-client/pyln/client/plugin.py
+++ b/contrib/pyln-client/pyln/client/plugin.py
@@ -938,16 +938,6 @@ class Plugin(object):
                               'after': method.after})
                 continue
 
-            doc = inspect.getdoc(method.func)
-            if not doc:
-                self.log(
-                    'RPC method \'{}\' does not have a docstring.'.format(
-                        method.name
-                    )
-                )
-                doc = "Undocumented RPC method from a plugin."
-            doc = re.sub('\n+', ' ', doc)
-
             # For compatibility with lightningd prior to 24.08, we must
             # provide a description.  Ignored by 24.08 onwards,
             description = method.description

--- a/tests/plugins/multiline-help.py
+++ b/tests/plugins/multiline-help.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin, Millisatoshi
+
+
+plugin = Plugin()
+
+
+@plugin.method("helpme")
+def helpme(plugin, msat: Millisatoshi):
+    """This is a message which consumes multiple lines and thus should
+    be well-formatted by lightning-cli help
+
+    """
+    return {'help': msat}
+
+
+plugin.run()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1148,6 +1148,28 @@ def test_cli(node_factory):
     assert [l for l in lines if not re.search(r'^help\[[0-9]*\].', l)] == ['format-hint=simple']
 
 
+def test_cli_multiline_help(node_factory):
+    l1 = node_factory.get_node(options={'plugin': os.path.join(os.getcwd(), 'tests/plugins/multiline-help.py')})
+
+    out = subprocess.check_output(['cli/lightning-cli',
+                                   '--network={}'.format(TEST_NETWORK),
+                                   '--lightning-dir={}'
+                                   .format(l1.daemon.lightning_dir),
+                                   'help']).decode('utf-8')
+    assert ("helpme msat  \n"
+            " This is a message which consumes multiple lines and thus should\n"
+            " be well-formatted by lightning-cli help\n" in out)
+
+    out = subprocess.check_output(['cli/lightning-cli',
+                                   '--network={}'.format(TEST_NETWORK),
+                                   '--lightning-dir={}'
+                                   .format(l1.daemon.lightning_dir),
+                                   'help', 'helpme']).decode('utf-8')
+    assert out == ("helpme msat  \n"
+                   " This is a message which consumes multiple lines and thus should\n"
+                   " be well-formatted by lightning-cli help\n")
+
+
 def test_cli_commando(node_factory):
     l1, l2 = node_factory.line_graph(2, fundchannel=False,
                                      opts={'log-level': 'io', 'allow-deprecated-apis': True})


### PR DESCRIPTION
Fixes: #8020 

- **Improved formatting of plugin descriptions displayed in the `lightning-cli help` output**: Previously, the descriptions contained unnecessary `\n` characters when shown as a single line, which affected readability.  
  **Proposed Solution**: Replace `\n` with `|` as the line separator when output is displayed in a single line, for better clarity and consistency.

- **Removed unused variables and related code from `pyln-client`**: For example, the `doc` variable in `pyln/client/plugin.py` was declared but never utilized, and related code was cleaned up to improve maintainability.

> [!IMPORTANT]
> 24.11 FREEZE NOVEMBER 7TH: Non-bugfix PRs not ready by this date will wait for 25.02.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
