### PR TITLE
Splice: Stricter interop errors

### DIFF
--- a/common/interactivetx.c
+++ b/common/interactivetx.c
@@ -225,8 +225,8 @@ static char *send_next(const tal_t *ctx,
 
 		wally_psbt_input_get_outpoint(&in->input, &point);
 
-		/* If this the shared channel input, we send funding txid in
-		 * in tlvs and do not send prevtx */
+		/* If this is the shared channel input, we send funding txid in
+		 * tlvs and do not send prevtx */
  		if (ictx->shared_outpoint
  			&& bitcoin_outpoint_eq(&point, ictx->shared_outpoint)) {
 			struct tlv_tx_add_input_tlvs *tlvs = tal(tmpctx, struct tlv_tx_add_input_tlvs);

--- a/common/interactivetx.c
+++ b/common/interactivetx.c
@@ -493,6 +493,12 @@ char *process_interactivetx_updates(const tal_t *ctx,
 						       " did not set"
 						       " interactivetx"
 						       " funding_tx");
+				if (tx_bytes)
+					return tal_fmt(ctx, "Peer used"
+						       " shared_input_txid %s,"
+						       " also included prevtx,"
+						       " only one is allowed.",
+						       fmt_bitcoin_txid(ctx, tlvs->shared_input_txid));
 				tx = ictx->funding_tx;
 			}
 			else {


### PR DESCRIPTION
Splice: Stricter interop errors

Error when our peer tries to use the shared output txid as well as the prevtx bytes.