### PR TITLE
doc: Add new createrune example

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -5873,6 +5873,127 @@
                   }
                 ],
                 "restrictions_as_english": "id equal to 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 AND method equal to listpeers AND pnum equal to 1 AND pnameid starts with 0266e4598d1d3c415f57 OR parr0 starts with 0266e4598d1d3c415f57"
+              },
+              {
+                "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+                "unique_id": "5",
+                "restrictions": [
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "list",
+                        "condition": "^",
+                        "english": "method starts with list"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "get",
+                        "condition": "^",
+                        "english": "method starts with get"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "summary",
+                        "condition": "=",
+                        "english": "method equal to summary"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "=",
+                        "english": "method equal to pay"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "=",
+                        "english": "method equal to xpay"
+                      }
+                    ],
+                    "english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "listdatastore",
+                        "condition": "/",
+                        "english": "method unequal to listdatastore"
+                      }
+                    ],
+                    "english": "method unequal to listdatastore"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "/",
+                        "english": "method unequal to pay"
+                      },
+                      {
+                        "fieldname": "per",
+                        "value": "1day",
+                        "condition": "=",
+                        "english": "per equal to 1day"
+                      }
+                    ],
+                    "english": "method unequal to pay OR per equal to 1day"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "/",
+                        "english": "method unequal to pay"
+                      },
+                      {
+                        "fieldname": "pnameamount_msat",
+                        "value": "100000001",
+                        "condition": "<",
+                        "english": "pnameamount_msat < 100000001"
+                      }
+                    ],
+                    "english": "method unequal to pay OR pnameamount_msat < 100000001"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "/",
+                        "english": "method unequal to xpay"
+                      },
+                      {
+                        "fieldname": "per",
+                        "value": "1day",
+                        "condition": "=",
+                        "english": "per equal to 1day"
+                      }
+                    ],
+                    "english": "method unequal to xpay OR per equal to 1day"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "/",
+                        "english": "method unequal to xpay"
+                      },
+                      {
+                        "fieldname": "pnameamount_msat",
+                        "value": "100000001",
+                        "condition": "<",
+                        "english": "pnameamount_msat < 100000001"
+                      }
+                    ],
+                    "english": "method unequal to xpay OR pnameamount_msat < 100000001"
+                  }
+                ],
+                "restrictions_as_english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay AND method unequal to listdatastore AND method unequal to pay OR per equal to 1day AND method unequal to pay OR pnameamount_msat < 100000001 AND method unequal to xpay OR per equal to 1day AND method unequal to xpay OR pnameamount_msat < 100000001"
               }
             ]
           }
@@ -5986,8 +6107,25 @@
         "* `!`: only passes if the *name* does *not* exist. e.g. `pnamedestination!`.",
         "Every other operator except `#` fails if *name* does not exist!"
       ],
+      "sharing_runes": [
+        "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
+        "",
+        "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
+        "",
+        "Christian Decker came up with the name \"commando\", which almost excuses his previous adoption of the name \"Eltoo\"."
+      ],
+      "see_also": [
+        "lightning-commando(7)",
+        "lightning-decode(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ],
       "usage": [
-        "You can use lightning-decode(7) to examine runes you have been given:",
+        "- You can use lightning-decode(7) to examine runes you have been given:",
         "",
         "```shell",
         "lightning-cli decode tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y",
@@ -6036,24 +6174,13 @@
         "   ],",
         "   \"valid\": true",
         "}",
+        "```",
+        "",
+        "- You can use lightning-checkrune(7) to verify whether a rune is valid for a specific method and its parameters:",
+        "",
+        "```shell",
+        "lightning-cli checkrune -k 'rune'=tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y 'method'='invoice' 'params'='{\"amount_msat\": 100000001, \"label\": \"invoicelabel\"', \"description\": \"Checking rune validity\"}'",
         "```"
-      ],
-      "sharing_runes": [
-        "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
-        "",
-        "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
-      ],
-      "author": [
-        "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
-        "",
-        "Christian Decker came up with the name \"commando\", which almost excuses his previous adoption of the name \"Eltoo\"."
-      ],
-      "see_also": [
-        "lightning-commando(7)",
-        "lightning-decode(7)"
-      ],
-      "resources": [
-        "Main web site: <https://github.com/ElementsProject/lightning>"
       ],
       "examples": [
         {
@@ -6246,6 +6373,60 @@
           "response": {
             "rune": "7nvN7uG2CyTOXe3dYQL38YVdGsnD6d5VNNyeHVl6inc9NCZpZD0wMjY2ZTQ1OThkMWQzYzQxNWY1NzJhODQ4ODgzMGI2MGY3ZTc0NGVkOTIzNWViMGIxYmE5MzI4M2IzMTVjMDM1MTgmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjY2ZTQ1OThkMWQzYzQxNWY1N3xwYXJyMF4wMjY2ZTQ1OThkMWQzYzQxNWY1NyZ0aW1lPCIkKCgkKGRhdGUgKyVzKSArIDI0KjYwKjYwKSkifHJhdGU9Mg==",
             "unique_id": "4"
+          }
+        },
+        {
+          "description": [
+            "Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:",
+            "",
+            "`[[\"method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)\"],[\"method/listdatastore\"]]`.",
+            "",
+            "However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:",
+            "",
+            "- method^list|method^get|method=summary|method=pay|method=xpay",
+            "- method/listdatastore",
+            "- method/pay|per=1day",
+            "- method/pay|pnameamount\\_msat<100000001",
+            "- method/xpay|per=1day",
+            "- method/xpay|pnameamount\\_msat<100000001"
+          ],
+          "request": {
+            "id": "example:commando-rune#9",
+            "method": "commando-rune",
+            "params": {
+              "restrictions": [
+                [
+                  "method^list",
+                  "method^get",
+                  "method=summary",
+                  "method=pay",
+                  "method=xpay"
+                ],
+                [
+                  "method/listdatastore"
+                ],
+                [
+                  "method/pay",
+                  "per=1day"
+                ],
+                [
+                  "method/pay",
+                  "pnameamount_msat<100000001"
+                ],
+                [
+                  "method/xpay",
+                  "per=1day"
+                ],
+                [
+                  "method/xpay",
+                  "pnameamount_msat<100000001"
+                ]
+              ]
+            }
+          },
+          "response": {
+            "rune": "QqgK4ZNJOwMjhUAQhHcnkTBXRoLghhPcJVR_Zew97ug9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+            "unique_id": "5"
           }
         }
       ]
@@ -7150,8 +7331,25 @@
         "* `!`: only passes if the *name* does *not* exist. e.g. `pnamedestination!`.",
         "Every other operator except `#` fails if *name* does not exist!"
       ],
+      "sharing_runes": [
+        "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
+        "",
+        "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if your rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
+      ],
+      "author": [
+        "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
+        "",
+        "Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible for migrating commando-rune to createrune."
+      ],
+      "see_also": [
+        "lightning-commando-rune(7)",
+        "lightning-checkrune(7)"
+      ],
+      "resources": [
+        "Main web site: <https://github.com/ElementsProject/lightning>"
+      ],
       "usage": [
-        "You can use lightning-decode(7) to examine runes you have been given:",
+        "- You can use lightning-decode(7) to examine runes you have been given:",
         "",
         "```shell",
         "lightning-cli decode tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y",
@@ -7200,24 +7398,13 @@
         "   ],",
         "   \"valid\": true",
         "}",
+        "```",
+        "",
+        "- You can use lightning-checkrune(7) to verify whether a rune is valid for a specific method and its parameters:",
+        "",
+        "```shell",
+        "lightning-cli checkrune -k 'rune'=tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y 'method'='invoice' 'params'='{\"amount_msat\": 100000001, \"label\": \"invoicelabel\"', \"description\": \"Checking rune validity\"}'",
         "```"
-      ],
-      "sharing_runes": [
-        "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
-        "",
-        "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
-      ],
-      "author": [
-        "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
-        "",
-        "Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible for migrating commando-rune to createrune."
-      ],
-      "see_also": [
-        "lightning-commando-rune(7)",
-        "lightning-checkrune(7)"
-      ],
-      "resources": [
-        "Main web site: <https://github.com/ElementsProject/lightning>"
       ],
       "examples": [
         {
@@ -7410,6 +7597,60 @@
           "response": {
             "rune": "GJb2PC-4jYslzIVz6-425bOtpkz_A_zaEhekPlrXdj09NCZpZD0wMjY2ZTQ1OThkMWQzYzQxNWY1NzJhODQ4ODgzMGI2MGY3ZTc0NGVkOTIzNWViMGIxYmE5MzI4M2IzMTVjMDM1MTgmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjY2ZTQ1OThkMWQzYzQxNWY1N3xwYXJyMF4wMjY2ZTQ1OThkMWQzYzQxNWY1NyZ0aW1lPCIkKCgkKGRhdGUgKyVzKSArIDI0KjYwKjYwKSkifHJhdGU9Mg==",
             "unique_id": "4"
+          }
+        },
+        {
+          "description": [
+            "Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:",
+            "",
+            "`[[\"method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)\"],[\"method/listdatastore\"]]`.",
+            "",
+            "However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:",
+            "",
+            "- method^list|method^get|method=summary|method=pay|method=xpay",
+            "- method/listdatastore",
+            "- method/pay|per=1day",
+            "- method/pay|pnameamount\\_msat<100000001",
+            "- method/xpay|per=1day",
+            "- method/xpay|pnameamount\\_msat<100000001"
+          ],
+          "request": {
+            "id": "example:createrune#9",
+            "method": "createrune",
+            "params": {
+              "restrictions": [
+                [
+                  "method^list",
+                  "method^get",
+                  "method=summary",
+                  "method=pay",
+                  "method=xpay"
+                ],
+                [
+                  "method/listdatastore"
+                ],
+                [
+                  "method/pay",
+                  "per=1day"
+                ],
+                [
+                  "method/pay",
+                  "pnameamount_msat<100000001"
+                ],
+                [
+                  "method/xpay",
+                  "per=1day"
+                ],
+                [
+                  "method/xpay",
+                  "pnameamount_msat<100000001"
+                ]
+              ]
+            }
+          },
+          "response": {
+            "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+            "unique_id": "5"
           }
         }
       ]
@@ -32878,6 +33119,127 @@
                   }
                 ],
                 "restrictions_as_english": "id equal to 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 AND method equal to listpeers AND pnum equal to 1 AND pnameid starts with 0266e4598d1d3c415f57 OR parr0 starts with 0266e4598d1d3c415f57"
+              },
+              {
+                "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+                "unique_id": "5",
+                "restrictions": [
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "list",
+                        "condition": "^",
+                        "english": "method starts with list"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "get",
+                        "condition": "^",
+                        "english": "method starts with get"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "summary",
+                        "condition": "=",
+                        "english": "method equal to summary"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "=",
+                        "english": "method equal to pay"
+                      },
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "=",
+                        "english": "method equal to xpay"
+                      }
+                    ],
+                    "english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "listdatastore",
+                        "condition": "/",
+                        "english": "method unequal to listdatastore"
+                      }
+                    ],
+                    "english": "method unequal to listdatastore"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "/",
+                        "english": "method unequal to pay"
+                      },
+                      {
+                        "fieldname": "per",
+                        "value": "1day",
+                        "condition": "=",
+                        "english": "per equal to 1day"
+                      }
+                    ],
+                    "english": "method unequal to pay OR per equal to 1day"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "pay",
+                        "condition": "/",
+                        "english": "method unequal to pay"
+                      },
+                      {
+                        "fieldname": "pnameamount_msat",
+                        "value": "100000001",
+                        "condition": "<",
+                        "english": "pnameamount_msat < 100000001"
+                      }
+                    ],
+                    "english": "method unequal to pay OR pnameamount_msat < 100000001"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "/",
+                        "english": "method unequal to xpay"
+                      },
+                      {
+                        "fieldname": "per",
+                        "value": "1day",
+                        "condition": "=",
+                        "english": "per equal to 1day"
+                      }
+                    ],
+                    "english": "method unequal to xpay OR per equal to 1day"
+                  },
+                  {
+                    "alternatives": [
+                      {
+                        "fieldname": "method",
+                        "value": "xpay",
+                        "condition": "/",
+                        "english": "method unequal to xpay"
+                      },
+                      {
+                        "fieldname": "pnameamount_msat",
+                        "value": "100000001",
+                        "condition": "<",
+                        "english": "pnameamount_msat < 100000001"
+                      }
+                    ],
+                    "english": "method unequal to xpay OR pnameamount_msat < 100000001"
+                  }
+                ],
+                "restrictions_as_english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay AND method unequal to listdatastore AND method unequal to pay OR per equal to 1day AND method unequal to pay OR pnameamount_msat < 100000001 AND method unequal to xpay OR per equal to 1day AND method unequal to xpay OR pnameamount_msat < 100000001"
               }
             ]
           }

--- a/doc/schemas/lightning-commando-listrunes.json
+++ b/doc/schemas/lightning-commando-listrunes.json
@@ -399,6 +399,127 @@
               }
             ],
             "restrictions_as_english": "id equal to 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 AND method equal to listpeers AND pnum equal to 1 AND pnameid starts with 0266e4598d1d3c415f57 OR parr0 starts with 0266e4598d1d3c415f57"
+          },
+          {
+            "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+            "unique_id": "5",
+            "restrictions": [
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "list",
+                    "condition": "^",
+                    "english": "method starts with list"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "get",
+                    "condition": "^",
+                    "english": "method starts with get"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "summary",
+                    "condition": "=",
+                    "english": "method equal to summary"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "=",
+                    "english": "method equal to pay"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "=",
+                    "english": "method equal to xpay"
+                  }
+                ],
+                "english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "listdatastore",
+                    "condition": "/",
+                    "english": "method unequal to listdatastore"
+                  }
+                ],
+                "english": "method unequal to listdatastore"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "/",
+                    "english": "method unequal to pay"
+                  },
+                  {
+                    "fieldname": "per",
+                    "value": "1day",
+                    "condition": "=",
+                    "english": "per equal to 1day"
+                  }
+                ],
+                "english": "method unequal to pay OR per equal to 1day"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "/",
+                    "english": "method unequal to pay"
+                  },
+                  {
+                    "fieldname": "pnameamount_msat",
+                    "value": "100000001",
+                    "condition": "<",
+                    "english": "pnameamount_msat < 100000001"
+                  }
+                ],
+                "english": "method unequal to pay OR pnameamount_msat < 100000001"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "/",
+                    "english": "method unequal to xpay"
+                  },
+                  {
+                    "fieldname": "per",
+                    "value": "1day",
+                    "condition": "=",
+                    "english": "per equal to 1day"
+                  }
+                ],
+                "english": "method unequal to xpay OR per equal to 1day"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "/",
+                    "english": "method unequal to xpay"
+                  },
+                  {
+                    "fieldname": "pnameamount_msat",
+                    "value": "100000001",
+                    "condition": "<",
+                    "english": "pnameamount_msat < 100000001"
+                  }
+                ],
+                "english": "method unequal to xpay OR pnameamount_msat < 100000001"
+              }
+            ],
+            "restrictions_as_english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay AND method unequal to listdatastore AND method unequal to pay OR per equal to 1day AND method unequal to pay OR pnameamount_msat < 100000001 AND method unequal to xpay OR per equal to 1day AND method unequal to xpay OR pnameamount_msat < 100000001"
           }
         ]
       }

--- a/doc/schemas/lightning-commando-rune.json
+++ b/doc/schemas/lightning-commando-rune.json
@@ -105,8 +105,25 @@
     "* `!`: only passes if the *name* does *not* exist. e.g. `pnamedestination!`.",
     "Every other operator except `#` fails if *name* does not exist!"
   ],
+  "sharing_runes": [
+    "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
+    "",
+    "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
+    "",
+    "Christian Decker came up with the name \"commando\", which almost excuses his previous adoption of the name \"Eltoo\"."
+  ],
+  "see_also": [
+    "lightning-commando(7)",
+    "lightning-decode(7)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ],
   "usage": [
-    "You can use lightning-decode(7) to examine runes you have been given:",
+    "- You can use lightning-decode(7) to examine runes you have been given:",
     "",
     "```shell",
     "lightning-cli decode tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y",
@@ -155,24 +172,13 @@
     "   ],",
     "   \"valid\": true",
     "}",
+    "```",
+    "",
+    "- You can use lightning-checkrune(7) to verify whether a rune is valid for a specific method and its parameters:",
+    "",
+    "```shell",
+    "lightning-cli checkrune -k 'rune'=tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y 'method'='invoice' 'params'='{\"amount_msat\": 100000001, \"label\": \"invoicelabel\"', \"description\": \"Checking rune validity\"}'",
     "```"
-  ],
-  "sharing_runes": [
-    "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
-    "",
-    "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
-  ],
-  "author": [
-    "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
-    "",
-    "Christian Decker came up with the name \"commando\", which almost excuses his previous adoption of the name \"Eltoo\"."
-  ],
-  "see_also": [
-    "lightning-commando(7)",
-    "lightning-decode(7)"
-  ],
-  "resources": [
-    "Main web site: <https://github.com/ElementsProject/lightning>"
   ],
   "examples": [
     {
@@ -365,6 +371,60 @@
       "response": {
         "rune": "7nvN7uG2CyTOXe3dYQL38YVdGsnD6d5VNNyeHVl6inc9NCZpZD0wMjY2ZTQ1OThkMWQzYzQxNWY1NzJhODQ4ODgzMGI2MGY3ZTc0NGVkOTIzNWViMGIxYmE5MzI4M2IzMTVjMDM1MTgmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjY2ZTQ1OThkMWQzYzQxNWY1N3xwYXJyMF4wMjY2ZTQ1OThkMWQzYzQxNWY1NyZ0aW1lPCIkKCgkKGRhdGUgKyVzKSArIDI0KjYwKjYwKSkifHJhdGU9Mg==",
         "unique_id": "4"
+      }
+    },
+    {
+      "description": [
+        "Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:",
+        "",
+        "`[[\"method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)\"],[\"method/listdatastore\"]]`.",
+        "",
+        "However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:",
+        "",
+        "- method^list|method^get|method=summary|method=pay|method=xpay",
+        "- method/listdatastore",
+        "- method/pay|per=1day",
+        "- method/pay|pnameamount\\_msat<100000001",
+        "- method/xpay|per=1day",
+        "- method/xpay|pnameamount\\_msat<100000001"
+      ],
+      "request": {
+        "id": "example:commando-rune#9",
+        "method": "commando-rune",
+        "params": {
+          "restrictions": [
+            [
+              "method^list",
+              "method^get",
+              "method=summary",
+              "method=pay",
+              "method=xpay"
+            ],
+            [
+              "method/listdatastore"
+            ],
+            [
+              "method/pay",
+              "per=1day"
+            ],
+            [
+              "method/pay",
+              "pnameamount_msat<100000001"
+            ],
+            [
+              "method/xpay",
+              "per=1day"
+            ],
+            [
+              "method/xpay",
+              "pnameamount_msat<100000001"
+            ]
+          ]
+        }
+      },
+      "response": {
+        "rune": "QqgK4ZNJOwMjhUAQhHcnkTBXRoLghhPcJVR_Zew97ug9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+        "unique_id": "5"
       }
     }
   ]

--- a/doc/schemas/lightning-createrune.json
+++ b/doc/schemas/lightning-createrune.json
@@ -108,8 +108,25 @@
     "* `!`: only passes if the *name* does *not* exist. e.g. `pnamedestination!`.",
     "Every other operator except `#` fails if *name* does not exist!"
   ],
+  "sharing_runes": [
+    "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
+    "",
+    "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if your rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
+  ],
+  "author": [
+    "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
+    "",
+    "Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible for migrating commando-rune to createrune."
+  ],
+  "see_also": [
+    "lightning-commando-rune(7)",
+    "lightning-checkrune(7)"
+  ],
+  "resources": [
+    "Main web site: <https://github.com/ElementsProject/lightning>"
+  ],
   "usage": [
-    "You can use lightning-decode(7) to examine runes you have been given:",
+    "- You can use lightning-decode(7) to examine runes you have been given:",
     "",
     "```shell",
     "lightning-cli decode tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y",
@@ -158,24 +175,13 @@
     "   ],",
     "   \"valid\": true",
     "}",
+    "```",
+    "",
+    "- You can use lightning-checkrune(7) to verify whether a rune is valid for a specific method and its parameters:",
+    "",
+    "```shell",
+    "lightning-cli checkrune -k 'rune'=tU-RLjMiDpY2U0o3W1oFowar36RFGpWloPbW9-RuZdo9MyZpZD0wMjRiOWExZmE4ZTAwNmYxZTM5MzdmNjVmNjZjNDA4ZTZkYThlMWNhNzI4ZWE0MzIyMmE3MzgxZGYxY2M0NDk2MDUmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjRiOWExZmE4ZTAwNmYxZTM5M3xwYXJyMF4wMjRiOWExZmE4ZTAwNmYxZTM5MyZ0aW1lPDE2NTY5MjA1MzgmcmF0ZT0y 'method'='invoice' 'params'='{\"amount_msat\": 100000001, \"label\": \"invoicelabel\"', \"description\": \"Checking rune validity\"}'",
     "```"
-  ],
-  "sharing_runes": [
-    "Because anyone can add a restriction to a rune, you can always turn a normal rune into a read-only rune, or restrict access for 30 minutes from the time you give it to someone. Adding restrictions before sharing runes is best practice.",
-    "",
-    "If a rune has a ratelimit, any derived rune will have the same id, and thus will compete for that ratelimit. You might want to consider adding a tighter ratelimit to a rune before sharing it, so you will keep the remainder. For example, if you rune has a limit of 60 times per minute, adding a limit of 5 times per minute and handing that rune out means you can still use your original rune 55 times per minute."
-  ],
-  "author": [
-    "Rusty Russell <<rusty@rustcorp.com.au>> wrote the original Python commando.py plugin, the in-tree commando plugin, and this manual page.",
-    "",
-    "Shahana Farooqui <<sfarooqui@blockstream.com>> is mainly responsible for migrating commando-rune to createrune."
-  ],
-  "see_also": [
-    "lightning-commando-rune(7)",
-    "lightning-checkrune(7)"
-  ],
-  "resources": [
-    "Main web site: <https://github.com/ElementsProject/lightning>"
   ],
   "examples": [
     {
@@ -368,6 +374,60 @@
       "response": {
         "rune": "GJb2PC-4jYslzIVz6-425bOtpkz_A_zaEhekPlrXdj09NCZpZD0wMjY2ZTQ1OThkMWQzYzQxNWY1NzJhODQ4ODgzMGI2MGY3ZTc0NGVkOTIzNWViMGIxYmE5MzI4M2IzMTVjMDM1MTgmbWV0aG9kPWxpc3RwZWVycyZwbnVtPTEmcG5hbWVpZF4wMjY2ZTQ1OThkMWQzYzQxNWY1N3xwYXJyMF4wMjY2ZTQ1OThkMWQzYzQxNWY1NyZ0aW1lPCIkKCgkKGRhdGUgKyVzKSArIDI0KjYwKjYwKSkifHJhdGU9Mg==",
         "unique_id": "4"
+      }
+    },
+    {
+      "description": [
+        "Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:",
+        "",
+        "`[[\"method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)\"],[\"method/listdatastore\"]]`.",
+        "",
+        "However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:",
+        "",
+        "- method^list|method^get|method=summary|method=pay|method=xpay",
+        "- method/listdatastore",
+        "- method/pay|per=1day",
+        "- method/pay|pnameamount\\_msat<100000001",
+        "- method/xpay|per=1day",
+        "- method/xpay|pnameamount\\_msat<100000001"
+      ],
+      "request": {
+        "id": "example:createrune#9",
+        "method": "createrune",
+        "params": {
+          "restrictions": [
+            [
+              "method^list",
+              "method^get",
+              "method=summary",
+              "method=pay",
+              "method=xpay"
+            ],
+            [
+              "method/listdatastore"
+            ],
+            [
+              "method/pay",
+              "per=1day"
+            ],
+            [
+              "method/pay",
+              "pnameamount_msat<100000001"
+            ],
+            [
+              "method/xpay",
+              "per=1day"
+            ],
+            [
+              "method/xpay",
+              "pnameamount_msat<100000001"
+            ]
+          ]
+        }
+      },
+      "response": {
+        "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+        "unique_id": "5"
       }
     }
   ]

--- a/doc/schemas/lightning-showrunes.json
+++ b/doc/schemas/lightning-showrunes.json
@@ -374,6 +374,127 @@
               }
             ],
             "restrictions_as_english": "id equal to 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518 AND method equal to listpeers AND pnum equal to 1 AND pnameid starts with 0266e4598d1d3c415f57 OR parr0 starts with 0266e4598d1d3c415f57"
+          },
+          {
+            "rune": "iP1FQEsFmPsu-XW7w8uXIJaJb7jU9PqOfkmXlOyWMuA9NSZtZXRob2RebGlzdHxtZXRob2ReZ2V0fG1ldGhvZD1zdW1tYXJ5fG1ldGhvZD1wYXl8bWV0aG9kPXhwYXkmbWV0aG9kL2xpc3RkYXRhc3RvcmUmbWV0aG9kL3BheXxwZXI9MWRheSZtZXRob2QvcGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAxJm1ldGhvZC94cGF5fHBlcj0xZGF5Jm1ldGhvZC94cGF5fHBuYW1lYW1vdW50X21zYXQ8MTAwMDAwMDAx",
+            "unique_id": "5",
+            "restrictions": [
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "list",
+                    "condition": "^",
+                    "english": "method starts with list"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "get",
+                    "condition": "^",
+                    "english": "method starts with get"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "summary",
+                    "condition": "=",
+                    "english": "method equal to summary"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "=",
+                    "english": "method equal to pay"
+                  },
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "=",
+                    "english": "method equal to xpay"
+                  }
+                ],
+                "english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "listdatastore",
+                    "condition": "/",
+                    "english": "method unequal to listdatastore"
+                  }
+                ],
+                "english": "method unequal to listdatastore"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "/",
+                    "english": "method unequal to pay"
+                  },
+                  {
+                    "fieldname": "per",
+                    "value": "1day",
+                    "condition": "=",
+                    "english": "per equal to 1day"
+                  }
+                ],
+                "english": "method unequal to pay OR per equal to 1day"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "pay",
+                    "condition": "/",
+                    "english": "method unequal to pay"
+                  },
+                  {
+                    "fieldname": "pnameamount_msat",
+                    "value": "100000001",
+                    "condition": "<",
+                    "english": "pnameamount_msat < 100000001"
+                  }
+                ],
+                "english": "method unequal to pay OR pnameamount_msat < 100000001"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "/",
+                    "english": "method unequal to xpay"
+                  },
+                  {
+                    "fieldname": "per",
+                    "value": "1day",
+                    "condition": "=",
+                    "english": "per equal to 1day"
+                  }
+                ],
+                "english": "method unequal to xpay OR per equal to 1day"
+              },
+              {
+                "alternatives": [
+                  {
+                    "fieldname": "method",
+                    "value": "xpay",
+                    "condition": "/",
+                    "english": "method unequal to xpay"
+                  },
+                  {
+                    "fieldname": "pnameamount_msat",
+                    "value": "100000001",
+                    "condition": "<",
+                    "english": "pnameamount_msat < 100000001"
+                  }
+                ],
+                "english": "method unequal to xpay OR pnameamount_msat < 100000001"
+              }
+            ],
+            "restrictions_as_english": "method starts with list OR method starts with get OR method equal to summary OR method equal to pay OR method equal to xpay AND method unequal to listdatastore AND method unequal to pay OR per equal to 1day AND method unequal to pay OR pnameamount_msat < 100000001 AND method unequal to xpay OR per equal to 1day AND method unequal to xpay OR pnameamount_msat < 100000001"
           }
         ]
       }

--- a/tests/autogenerate-rpc-examples.py
+++ b/tests/autogenerate-rpc-examples.py
@@ -767,6 +767,19 @@ def generate_runes_examples(l1, l2, l3):
         update_example(node=l2, method='createrune', params={'restrictions': [[f'id={l1.info["id"]}'], ['method=listpeers'], ['pnum=1'], [f'pnameid={l1.info["id"]}', f'parr0={l1.info["id"]}']]}, description=["Let's create a rune which lets a specific peer run listpeers on themselves:"])
         rune_l25 = update_example(node=l2, method='createrune', params={'restrictions': [[f'id={l1.info["id"]}'], ['method=listpeers'], ['pnum=1'], [f'pnameid^{trimmed_id}', f'parr0^{trimmed_id}']]}, description=["This allows `listpeers` with 1 argument (`pnum=1`), which is either by name (`pnameid`), or position (`parr0`). We could shorten this in several ways: either allowing only positional or named parameters, or by testing the start of the parameters only. Here's an example which only checks the first 10 bytes of the `listpeers` parameter:"])
         update_example(node=l2, method='createrune', params=[rune_l25['rune'], [['time<"$(($(date +%s) + 24*60*60))"', 'rate=2']]], description=["Before we give this to our peer, let's add two more restrictions: that it only be usable for 24 hours from now (`time<`), and that it can only be used twice a minute (`rate=2`). `date +%s` can give us the current time in seconds:"])
+        update_example(node=l2, method='createrune', params={'restrictions': [['method^list', 'method^get', 'method=summary', 'method=pay', 'method=xpay'], ['method/listdatastore'], ['method/pay', 'per=1day'], ['method/pay', 'pnameamount_msat<100000001'], ['method/xpay', 'per=1day'], ['method/xpay', 'pnameamount_msat<100000001']]},
+                       description=['Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:',
+                                    '',
+                                    '`[["method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)"],["method/listdatastore"]]`.',
+                                    '',
+                                    'However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:',
+                                    '',
+                                    '- method^list|method^get|method=summary|method=pay|method=xpay',
+                                    '- method/listdatastore',
+                                    '- method/pay|per=1day',
+                                    '- method/pay|pnameamount\\_msat<100000001',
+                                    '- method/xpay|per=1day',
+                                    '- method/xpay|pnameamount\\_msat<100000001'])
         update_example(node=l2, method='commando-listrunes', params={'rune': rune_l23['rune']})
         update_example(node=l2, method='commando-listrunes', params={})
         commando_res1 = update_example(node=l1, method='commando', params={'peer_id': l2.info['id'], 'rune': rune_l21['rune'], 'method': 'newaddr', 'params': {'addresstype': 'p2tr'}})
@@ -799,6 +812,19 @@ def generate_runes_examples(l1, l2, l3):
         update_example(node=l1, method='commando-rune', params={'restrictions': [[f'id={l1.info["id"]}'], ['method=listpeers'], ['pnum=1'], [f'pnameid={l1.info["id"]}', f'parr0={l1.info["id"]}']]}, description=["Let's create a rune which lets a specific peer run listpeers on themselves:"])
         rune_l15 = update_example(node=l1, method='commando-rune', params={'restrictions': [[f'id={l1.info["id"]}'], ['method=listpeers'], ['pnum=1'], [f'pnameid^{trimmed_id}', f'parr0^{trimmed_id}']]}, description=["This allows `listpeers` with 1 argument (`pnum=1`), which is either by name (`pnameid`), or position (`parr0`). We could shorten this in several ways: either allowing only positional or named parameters, or by testing the start of the parameters only. Here's an example which only checks the first 10 bytes of the `listpeers` parameter:"])
         update_example(node=l1, method='commando-rune', params=[rune_l15['rune'], [['time<"$(($(date +%s) + 24*60*60))"', 'rate=2']]], description=["Before we give this to our peer, let's add two more restrictions: that it only be usable for 24 hours from now (`time<`), and that it can only be used twice a minute (`rate=2`). `date +%s` can give us the current time in seconds:"])
+        update_example(node=l1, method='commando-rune', params={'restrictions': [['method^list', 'method^get', 'method=summary', 'method=pay', 'method=xpay'], ['method/listdatastore'], ['method/pay', 'per=1day'], ['method/pay', 'pnameamount_msat<100000001'], ['method/xpay', 'per=1day'], ['method/xpay', 'pnameamount_msat<100000001']]},
+                       description=['Now, let us create a rune with `read-only` restrictions, extended to only allow sending payments of `less than 100,000 sats per day` using either the `pay` or `xpay` method. Ideally, the condition would look something like:',
+                                    '',
+                                    '`[["method^list or method^get or ((method=pay or method=xpay) and per=1day and pnameamount\\_msat<100000001)"],["method/listdatastore"]]`.',
+                                    '',
+                                    'However, since brackets and AND conditions within OR are currently not supported for rune creation, we can restructure the conditions as follows:',
+                                    '',
+                                    '- method^list|method^get|method=summary|method=pay|method=xpay',
+                                    '- method/listdatastore',
+                                    '- method/pay|per=1day',
+                                    '- method/pay|pnameamount\\_msat<100000001',
+                                    '- method/xpay|per=1day',
+                                    '- method/xpay|pnameamount\\_msat<100000001'])
         REPLACE_RESPONSE_VALUES.extend([
             {'data_keys': ['last_used'], 'original_value': showrunes_res1['runes'][0]['last_used'], 'new_value': NEW_VALUES_LIST['time_at_800']},
             {'data_keys': ['last_used'], 'original_value': showrunes_res2['runes'][1]['last_used'], 'new_value': NEW_VALUES_LIST['time_at_800']},

--- a/tools/md2man.sh
+++ b/tools/md2man.sh
@@ -17,7 +17,7 @@ TITLELINE="$(head -n1 "$SOURCE")"
 # because it is used in the examples to run it in the shell, eg. $(lightning-cli listpeerchannels)
 SOURCE=$(tail -n +3 "$SOURCE" | sed -E '
     :a;N;$!ba;
-    s#\s*<details>\s*<summary>\s*<span style="font-size: 1\.5em; font-weight: bold;">EXAMPLES</span><br>\s*</summary>#\n\nEXAMPLES\n------------\n#g;
+    s#EXAMPLES\n------------#\nEXAMPLES\n------------\n#g;
     s#Request:#Request:\n#g;
     s#Response:#Response:\n#g;
     s#(\(lightning-cli)#\x1#ig;


### PR DESCRIPTION
- Moved the `Usage` section further down in `createrune` and `commando-rune` for improved UX.
- Added a new example for creating a rune with `read-only` restrictions, extending it to allow only payments of `less than 100,000 sats per day` using the `pay` or `xpay` methods.
- Adjusted formatting by appending an extra space after the `dependentUpon` condition, fixing `[*start* [*end*]][*relist*]` to `[*start* [*end*]] [*relist*]`.
- Relocated `Examples` from the expandable section to a standard heading, as examples are now already placed at the end of the page.

Changelog-None.
