### PR TITLE
Update Rust version 1.73 to 1.75 for Ubuntu Dockerfiles

### DIFF
--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -55,7 +55,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \
     rm rustup-install.sh && \
-    /root/.cargo/bin/rustup install 1.73
+    /root/.cargo/bin/rustup install 1.75
 
 # Download protoc manually, it is in the update repos which we
 # disabled above, so `apt-get` can't find it anymore.

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -53,7 +53,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \
     rm rustup-install.sh && \
-    /root/.cargo/bin/rustup install 1.73
+    /root/.cargo/bin/rustup install 1.75
 
 # Download protoc manually, it is in the update repos which we
 # disabled above, so `apt-get` can't find it anymore.

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -51,7 +51,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && python3 /tmp
 RUN wget https://sh.rustup.rs -O rustup-install.sh && \
     bash rustup-install.sh --default-toolchain none --quiet -y && \
     rm rustup-install.sh && \
-    /root/.cargo/bin/rustup install 1.73
+    /root/.cargo/bin/rustup install 1.75
 
 # Download protoc manually, it is in the update repos which we
 # disabled above, so `apt-get` can't find it anymore.


### PR DESCRIPTION
After merging the Rust-based `clnrest` plugin into the master, all three reproducible build scripts failed with the following error:

```
error: package `socketioxide v0.15.1` cannot be built because it requires rustc 1.75.0 or newer, while the currently active rustc version is 1.73.0
Either upgrade to rustc 1.75.0 or newer, or use
cargo update -p socketioxide@0.15.1 --precise ver
where `ver` is the latest version of `socketioxide` supporting rustc 1.73.0
make: *** [plugins/Makefile:304: target/release/clnrest] Error 101
```

To resolve this, we can either downgrade `socketioxide` to `v0.11.1`, which is compatible with `Rust >=v1.67` OR Upgrade Rust to `v1.75`.

Since the latest Rust version is `1.84`, upgrading to `1.75` seems like a reasonable choice, as it is already 13 months old.

Changelog-None.
