### PR TITLE
splice: Don’t let users do unsigned splices

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -813,7 +813,9 @@ static struct command_result *json_signpsbt(struct command *cmd,
 
 	if (tal_count(utxos) == 0)
 		return command_fail(cmd, LIGHTNINGD,
-				    "No wallet inputs to sign");
+				    "No wallet inputs to sign. Are you sure you"
+				    " added inputs to this PSBT? If not, then"
+				    " there is no need to sign it.");
 
 	if (command_check_only(cmd))
 		return command_check_done(cmd);


### PR DESCRIPTION
If a user tries to do a splice without signing their inputs we now provide them with a nice error message and cancel the RPC since that wouldn’t be productive for the user anyway.

We also add a helpful message if they do the opposite — try to sign a PSBT where they did not add any inputs.

Resolves #8011 and addresses `signpsbt` error confusion here: https://github.com/ElementsProject/lightning/issues/8030#issuecomment-2612550043