### PR TITLE
lightningd: don't kill onchaind if we are forcing a disconnect.

### DIFF
--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -542,6 +542,9 @@ void force_peer_disconnect(struct lightningd *ld,
 		if (!c->owner)
 			continue;
 
+		if (!channel_state_wants_peercomms(c->state))
+			continue;
+
 		log_debug(c->log, "Forcing disconnect due to %s", why);
 		/* This frees c! */
 		if (channel_state_uncommitted(c->state))


### PR DESCRIPTION
We thought it was a good idea to terminate channel subds, but we included onchaind as well!

```
2025-01-29T21:31:46.053Z UNUSUAL 03…00-channeld-chan#255683: Adding HTLC 1737 too slow: killing connection
2025-01-29T21:31:46.053Z INFO    03…00-chan#255683: Peer transient failure in CHANNELD_NORMAL: Adding HTLC timed out: killed connection
2025-01-29T21:31:46.053Z DEBUG   03…00-channeld-chan#255683: Status closed, but not exited. Killing
2025-01-29T21:31:46.054Z DEBUG   03…00-chan#255683: Failing HTLC 1738 due to peer death
2025-01-29T21:31:46.058Z DEBUG   03…00-chan#255683: Failing HTLC 1737 due to peer death
2025-01-29T21:31:46.058Z DEBUG   03…00-chan#255673: Forcing disconnect due to One channel had an error
2025-01-29T21:31:46.059Z DEBUG   03…00-onchaind-chan#255673: Status closed, but not exited. Killing
2025-01-29T21:31:46.093Z DEBUG   03…00-connectd: disconnect_peer
2025-01-29T21:31:46.093Z DEBUG   03…00-lightningd: peer_disconnect_done
```

Reported-by: @whitslack
Fixes: https://github.com/ElementsProject/lightning/issues/8055
Changelog-Fixed: onchaind: don't die if we fail an unrelated channel with the same peer.
