### PR TITLE
lightningd: increase startup time for plugins to 120 seconds.

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -33,13 +33,9 @@
 /* Only this file can include this generated header! */
 # include <plugins/list_of_builtin_plugins_gen.h>
 
-/* How many seconds may the plugin take to reply to the `getmanifest`
- * call? This is the maximum delay to `lightningd --help` and until
- * we can start the main `io_loop` to communicate with peers. If this
- * hangs we can't do much, so we put an upper bound on the time we're
- * willing to wait. Plugins shouldn't do any initialization in the
- * `getmanifest` call anyway, that's what `init` is for. */
-#define PLUGIN_MANIFEST_TIMEOUT 60
+/* How many seconds may the plugin take frome the `getmanifest`
+ * call to replying to the init call? */
+#define PLUGIN_STARTUP_TIMEOUT 120
 
 static void memleak_help_pending_requests(struct htable *memtable,
 					  struct plugin *plugin)
@@ -2012,7 +2008,7 @@ static void plugin_set_timeout(struct plugin *p)
 	else {
 		p->timeout_timer
 			= new_reltimer(p->plugins->ld->timers, p,
-				       time_from_sec(PLUGIN_MANIFEST_TIMEOUT),
+				       time_from_sec(PLUGIN_STARTUP_TIMEOUT),
 				       plugin_manifest_timeout, p);
 	}
 }


### PR DESCRIPTION
Raspberry Pi, with bitcoind running and full gossip topology may actually hit this, and we have a report in practice.

Note that the comment is wrong, so fix that too.

Fixes: https://github.com/ElementsProject/lightning/issues/7724
Reported-by: m-schmoock

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
