### PR TITLE
dev: startup_regtest using wrong null dir

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -242,7 +242,7 @@ start_ln() {
 		"$BITCOIND" -datadir="$BITCOIN_DIR" -regtest -txindex -fallbackfee=0.00000253 -daemon
 
 	# Wait for it to start.
-	while ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest ping 2> /tmp/null; do echo "awaiting bitcoind..." && sleep 1; done
+	while ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest ping 2> /dev/null; do echo "awaiting bitcoind..." && sleep 1; done
 
 	# Check if default wallet exists
 	if ! "$BCLI" -datadir="$BITCOIN_DIR" -regtest listwalletdir | jq -r '.wallets[] | .name' | grep -wqe 'default' ; then
@@ -445,7 +445,7 @@ start_elem() {
 		elementsd -chain=liquid-regtest -printtoconsole -logtimestamps -nolisten -validatepegin=0 -con_blocksubsidy=5000000000 -daemon
 
 	# Wait for it to start.
-	while ! elements-cli -chain=liquid-regtest ping 2> /tmp/null; do echo "awaiting elementsd..." && sleep 1; done
+	while ! elements-cli -chain=liquid-regtest ping 2> /dev/null; do echo "awaiting elementsd..." && sleep 1; done
 
 	# Kick it out of initialblockdownload if necessary
 	if elements-cli -chain=liquid-regtest getblockchaininfo | grep -q 'initialblockdownload.*true'; then


### PR DESCRIPTION
Switching to /dev/null instead of typo’d /tmp/null

/tmp/null isn't correct -- it should be /dev/null
