### PR TITLE
pyln-testing: Removing the `lightning-` prefix check for pyln-testing

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -458,8 +458,8 @@ def jsonschemas():
 
     schemas = {}
     for fname in schemafiles:
-        if fname.startswith('lightning-') and fname.endswith('.json'):
-            base = fname.replace('lightning-', '').replace('.json', '')
+        if fname.endswith('.json'):
+            base = fname.replace('.json', '')
             # Request is 0 and Response is 1
             schemas[base] = _load_schema(os.path.join('doc/schemas', fname))
     return schemas


### PR DESCRIPTION
Currently, pyln tests fail if the `lightning-` prefix is removed from `schema/*.json` files. In this release, we will update pyln to remove its reliance on this prefix, and in the next release, we will remove the prefixes from the files as well.

Changelog-None.
