### PR TITLE
offers: add a blinded path if we have no advertized address.

### DIFF
--- a/plugins/offers.h
+++ b/plugins/offers.h
@@ -92,4 +92,6 @@ struct command_result *find_best_peer_(struct command *cmd,
 					    const struct chaninfo *),	\
 			(arg))
 
+/* Do we want a blinded path from a peer? */
+bool we_want_blinded_path(struct plugin *plugin);
 #endif /* LIGHTNING_PLUGINS_OFFERS_H */

--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -352,11 +352,7 @@ static struct command_result *found_best_peer(struct command *cmd,
 static struct command_result *add_blindedpaths(struct command *cmd,
 					       struct invreq *ir)
 {
-	struct node_id local_nodeid;
-
-	/* Don't bother if we're public */
-	node_id_from_pubkey(&local_nodeid, &id);
-	if (gossmap_find_node(get_gossmap(cmd->plugin), &local_nodeid))
+	if (!we_want_blinded_path(cmd->plugin))
 		create_invoicereq(cmd, ir);
 
 	return find_best_peer(cmd, OPT_ROUTE_BLINDING,

--- a/plugins/offers_offer.c
+++ b/plugins/offers_offer.c
@@ -329,10 +329,7 @@ static struct command_result *maybe_add_path(struct command *cmd,
 	 *       publicly reachable nodes.
 	 */
 	if (!offinfo->offer->offer_paths) {
-		struct node_id local_nodeid;
-
-		node_id_from_pubkey(&local_nodeid, &id);
-		if (!gossmap_find_node(get_gossmap(cmd->plugin), &local_nodeid))
+		if (we_want_blinded_path(cmd->plugin))
 			return find_best_peer(cmd, OPT_ONION_MESSAGES,
 					      found_best_peer, offinfo);
 	}
@@ -661,7 +658,6 @@ struct command_result *json_invoicerequest(struct command *cmd,
 	struct tlv_invoice_request *invreq;
 	struct amount_msat *msat;
 	bool *single_use;
-	struct node_id local_nodeid;
 
 	invreq = tlv_invoice_request_new(cmd);
 
@@ -732,8 +728,7 @@ struct command_result *json_invoicerequest(struct command *cmd,
 
 	/* FIXME: We only set blinded path if private, we should allow
 	 * setting otherwise! */
-	node_id_from_pubkey(&local_nodeid, &id);
-	if (!gossmap_find_node(get_gossmap(cmd->plugin), &local_nodeid)) {
+	if (we_want_blinded_path(cmd->plugin)) {
 		struct invrequest_data *idata = tal(cmd, struct invrequest_data);
 		idata->invreq = invreq;
 		idata->single_use = *single_use;


### PR DESCRIPTION
Suggested-by: Matt Corallo
Fixes: https://github.com/ElementsProject/lightning/issues/7806
Changelog-Changed: Offers: we will use a blinded path if we have no advertized address (so payers wouldn't be able to connect directly).
