### PR TITLE
askrene-bias-channel: bias call add up.

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -309,6 +309,14 @@
               "The bias, positive being good and negative being bad (0 being no bias).  Useful values are +/-1 through +/-10, though -100 through +100 are possible values."
             ]
           },
+          "relative": {
+            "type": "boolean",
+            "added": "v25.05",
+            "default": false,
+            "description": [
+              "The bias will be added to the previous value."
+            ]
+          },
           "description": {
             "type": "string",
             "description": [
@@ -29249,6 +29257,11 @@
                 "dynamic": false
               },
               {
+                "name": "/root/lightning/plugins/cln-lsps-client",
+                "active": true,
+                "dynamic": false
+              },
+              {
                 "name": "/root/lightning/plugins/bookkeeper",
                 "active": true,
                 "dynamic": false
@@ -29378,6 +29391,11 @@
               },
               {
                 "name": "/root/lightning/plugins/cln-grpc",
+                "active": true,
+                "dynamic": false
+              },
+              {
+                "name": "/root/lightning/plugins/cln-lsps-client",
                 "active": true,
                 "dynamic": false
               },

--- a/doc/schemas/askrene-bias-channel.json
+++ b/doc/schemas/askrene-bias-channel.json
@@ -33,6 +33,14 @@
           "The bias, positive being good and negative being bad (0 being no bias).  Useful values are +/-1 through +/-10, though -100 through +100 are possible values."
         ]
       },
+      "relative": {
+        "type": "boolean",
+        "added": "v25.05",
+        "default": false,
+        "description": [
+          "The bias will be added to the previous value."
+        ]
+      },
       "description": {
         "type": "string",
         "description": [

--- a/doc/schemas/plugin.json
+++ b/doc/schemas/plugin.json
@@ -298,6 +298,11 @@
             "dynamic": false
           },
           {
+            "name": "/root/lightning/plugins/cln-lsps-client",
+            "active": true,
+            "dynamic": false
+          },
+          {
             "name": "/root/lightning/plugins/bookkeeper",
             "active": true,
             "dynamic": false
@@ -427,6 +432,11 @@
           },
           {
             "name": "/root/lightning/plugins/cln-grpc",
+            "active": true,
+            "dynamic": false
+          },
+          {
+            "name": "/root/lightning/plugins/cln-lsps-client",
             "active": true,
             "dynamic": false
           },

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -1098,18 +1098,20 @@ static struct command_result *json_askrene_bias_channel(struct command *cmd,
 	const char *description;
 	s8 *bias;
 	const struct bias *b;
+	bool *relative;
 
 	if (!param(cmd, buffer, params,
 		   p_req("layer", param_known_layer, &layer),
 		   p_req("short_channel_id_dir", param_short_channel_id_dir, &scidd),
 		   p_req("bias", param_s8_hundred, &bias),
+		   p_opt_def("relative", param_bool, &relative, false),
 		   p_opt("description", param_string, &description),
 		   NULL))
 		return command_param_failed();
 	plugin_log(cmd->plugin, LOG_TRACE, "%s called: %.*s", __func__,
 		   json_tok_full_len(params), json_tok_full(buffer, params));
 
-	b = layer_set_bias(layer, scidd, description, *bias);
+	b = layer_set_bias(layer, scidd, description, *bias, *relative);
 	response = jsonrpc_stream_success(cmd);
 	json_array_start(response, "biases");
 	if (b)

--- a/plugins/askrene/layer.h
+++ b/plugins/askrene/layer.h
@@ -59,7 +59,8 @@ void layer_add_local_channel(struct layer *layer,
 const struct bias *layer_set_bias(struct layer *layer,
 				  const struct short_channel_id_dir *scidd,
 				  const char *description TAKES,
-				  s8 bias_factor);
+				  s8 bias_factor,
+				  bool relative);
 
 /* Update details on a channel (could be in this layer, or another) */
 void layer_add_update_channel(struct layer *layer,


### PR DESCRIPTION
The channel bias feature is not being used yet by any plugin, so this hopefully doesn't break any working code.
When askrene-bias-channel is called the bias quantity is added on top of any previous biased already present on that channel instead of overwriting it.

Changelog-Changed: askrene-bias-channel: bias call add up.

The use case I envision is the following in the context of a payment plugin:

Stack biases on channels that fail often with weird errors and avoid DoS:
- plugin sends payment for computed route
- route fails with weird error such as `WIRE_AMOUNT_BELOW_MINIMUM` indicating that we need to update the gossmap
- we don't have to trust this channel is behaving correctly, so we update the gossmap and we add some negative bias to it.
- next time we fail the payment again with the same channel we add more bias to it. Eventually this channel will be completely avoided.
