### PR TITLE
common: fix memcpy error in Fischer-Yates shuffle.

### DIFF
--- a/common/pseudorand.c
+++ b/common/pseudorand.c
@@ -80,6 +80,9 @@ void tal_arr_randomize_(void *arr, size_t elemsize)
 		size_t j = i + pseudorand(n - i);
 		char tmp[elemsize];
 
+		/* Technically, memcpy in place is undefined (src and dest overlap). */
+		if (j == i)
+			continue;
 		memcpy(tmp, carr + i * elemsize, elemsize);
 		memcpy(carr + i * elemsize, carr + j * elemsize, elemsize);
 		memcpy(carr + j * elemsize, tmp, elemsize);


### PR DESCRIPTION
Reported by Grubles on ARM64:

```
VALGRIND=1 valgrind -q --error-exitcode=7 --track-origins=yes --leak-check=full --show-reachable=yes --errors-for-leak-kinds=all common/test/run-tal_arr_randomize > /dev/null
==151138== Source and destination overlap in memcpy(0x4d69f08, 0x4d69f08, 8)
==151138==    at 0x48CB68C: __GI_memcpy (vg_replace_strmem.c:1147)
==151138==    by 0x41B50B: tal_arr_randomize_ (pseudorand.c:84)
==151138==    by 0x41BB07: main (run-tal_arr_randomize.c:166)
==151138==
make: *** [Makefile:750: unittest/common/test/run-tal_arr_randomize] Error 7
```

It is correct: you can't overlap src and dst in memcpy.  It *probably* works in this case, but it's undefined!

Fixes: https://github.com/ElementsProject/lightning/issues/7030
Changelog-None: unit tests only (probably!)