### PR TITLE
cln-grpc, clnrest: workaround for logging before shutdown

### DIFF
--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -206,7 +206,7 @@ def test_grpc_default_port_auto_starts(node_factory):
     # Check that the plugin is active
     assert grpcplugin is not None
     # Check that the plugin is listening on the default port
-    assert l1.daemon.is_in_log(f'plugin-cln-grpc: Plugin logging initialized')
+    assert l1.daemon.is_in_log(r'serving grpc on 127.0.0.1:9736')
     # Check that the certificates are generated
     assert len([f for f in os.listdir(Path(l1.daemon.lightning_dir) / TEST_NETWORK) if re.match(r".*\.pem$", f)]) >= 6
 


### PR DESCRIPTION
Changelog-Fixed: cln-grpc and clnrest errors that cause them to stop will now log

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.

I consider this a bug fix pr for 25.02