### PR TITLE
docs: fix JSON indentation in 'connect' example

### DIFF
--- a/doc/developers-guide/plugin-development/event-notifications.md
+++ b/doc/developers-guide/plugin-development/event-notifications.md
@@ -106,9 +106,9 @@ A notification for topic `connect` is sent every time a new connection to a peer
       "address" : "127.0.0.1",
       "port" : 38012,
       "type" : "ipv4"
-  },
-  "direction" : "in",
-  "id" : "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59"
+    },
+    "direction" : "in",
+    "id" : "022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59"
   }
 }
 ```


### PR DESCRIPTION
> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [X] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [X] Tests have been added or modified to reflect the changes.
- [X] Documentation has been reviewed and updated as needed.
- [X] Related issues have been listed and linked, including any that this PR closes.

Adjusted the indentation in the JSON example for the 'connect' command to improve readability and maintain consistency with other examples in the Core Lightning documentation.
