### PR TITLE
pyln-testing: Fix for disabled schema check

### DIFF
--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -459,7 +459,7 @@ def jsonschemas():
     schemas = {}
     for fname in schemafiles:
         if fname.endswith('.json'):
-            base = fname.replace('.json', '')
+            base = fname.replace('lightning-', '').replace('.json', '')
             # Request is 0 and Response is 1
             schemas[base] = _load_schema(os.path.join('doc/schemas', fname))
     return schemas


### PR DESCRIPTION
In a previous [commit](https://github.com/ElementsProject/lightning/pull/8065/commits), I mistakenly removed the `lightning-` replacement logic from the base name also. This commit restores that functionality to re-enable schema checks.

Changelog-None.
