### PR TITLE
testing: don't try to valgrind clnrest, it's Rust.

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -826,7 +826,7 @@ class LightningNode(object):
         if dsn is not None:
             self.daemon.opts['wallet'] = dsn
         if valgrind:
-            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*,*cln-grpc*'
+            trace_skip_pattern = '*python*,*bitcoin-cli*,*elements-cli*,*cln-grpc*,*clnrest*'
             if not valgrind_plugins:
                 trace_skip_pattern += ',*plugins*'
             self.daemon.cmd_prefix = [


### PR DESCRIPTION
This happened in CI:

```
valgrind error file: valgrind-errors.16800
==16800== Thread 4 tokio-runtime-w:
==16800== Conditional jump or move depends on uninitialised value(s)
==16800==    at 0x2466BF: _ZN175_$LT$axum..middleware..from_fn..FromFn$LT$F$C$S$C$I$C$$LP$T1$C$T2$C$T3$RP$$GT$$u20$as$u20$tower_service..Service$LT$http..request..Request$LT$axum_core..body..Body$GT$$GT$$GT$4call28_$u7b$$u7b$closure$u7d$$u7d$17h4cc36de5dd56d9feE.llvm.119371497468325184 (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x57BFFA: <axum::middleware::from_fn::ResponseFuture as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x37312B: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x372D8D: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x372F59: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x373A88: <tower::util::map_response::MapResponseFuture<F,N> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x32100D: <tower::util::oneshot::Oneshot<S,Req> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x38E326: _ZN91_$LT$axum..routing..route..RouteFuture$LT$E$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h3f11114fc5dd51f8E.llvm.194396656150191000 (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x372315: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x372C05: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x371A15: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==    by 0x373A48: <tower::util::map_response::MapResponseFuture<F,N> as core::future::future::Future>::poll (in /home/runner/work/lightning/lightning/plugins/clnrest)
==16800==
```
Changelog-None: changed this release.