### PR TITLE
pytest: fix test_xpay_bolt12_no_mpp

### DIFF
--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -653,7 +653,8 @@ def test_xpay_no_mpp(node_factory, chainparams):
 
 def test_xpay_bolt12_no_mpp(node_factory, chainparams):
     """We should not (yet!) avoid mpp if BOLT12 invoice doesn't say we should"""
-    l1, l2, l3, l4 = node_factory.get_nodes(4, opts=[{}, {}, {'dev-force-features': -17}, {}])
+    # l4 needs dev-allow-localhost so it considers itself to have an advertized address, and doesn't create a blinded path from l2/l4.
+    l1, l2, l3, l4 = node_factory.get_nodes(4, opts=[{}, {}, {'dev-force-features': -17, 'dev-allow-localhost': None}, {}])
     node_factory.join_nodes([l1, l2, l3], wait_for_announce=True)
     node_factory.join_nodes([l1, l4, l3], wait_for_announce=True)
 


### PR DESCRIPTION
When we merged blinded paths for nodes with no address (6e4ff6a7d283ef199f93625c3b1ecb73e56b8c10), this test broke.  We need to prevent that, otherwise:

```
>       assert ret['successful_parts'] == 2
E       assert 1 == 2

tests/test_xpay.py:677: AssertionError
```

Changelog-None