### PR TITLE
xpay: reduce log entries on rpc_command hook

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1930,11 +1930,12 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 	method_tok = json_get_member(buf, rpc_tok, "method");
 	params_tok = json_get_member(buf, rpc_tok, "params");
 	id_tok = json_get_member(buf, rpc_tok, "id");
-	plugin_log(cmd->plugin, LOG_DBG, "Got command %s",
-		   json_strdup(tmpctx, buf, method_tok));
 
 	if (!json_tok_streq(buf, method_tok, "pay"))
 		goto dont_redirect;
+
+	plugin_log(cmd->plugin, LOG_DBG, "Got command %s",
+		   json_strdup(tmpctx, buf, method_tok));
 
 	/* Array params?  Only handle up to two args (bolt11, msat) */
 	if (params_tok->type == JSMN_ARRAY) {


### PR DESCRIPTION
Don't print unnecessary log entries every time we receive an `rpc_command` hook event. Only log when `pay` is called.

Fixes issue #8025 