### PR TITLE
Fix --dev-dev-no-reconnect-private on restart

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2551,6 +2551,11 @@ static void setup_peer(struct peer *peer)
 			break;
 		}
 
+		/* Don't reconnect for private channels if --dev-no-reconnect-private */
+		if (!channel->peer->ld->reconnect_private
+		    && !(channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL))
+			continue;
+
 		if (channel_state_wants_peercomms(channel->state))
 			connect = true;
 		if (channel_important_filter(channel, NULL))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4756,7 +4756,6 @@ def test_onionmessage_forward_fail(node_factory, bitcoind):
     l2.daemon.is_in_log('plugin-onionmessage_forward_fail_notification.py: Received onionmessage_forward_fail')
 
 
-@pytest.mark.xfail(strict=True)
 def test_private_channel_no_reconnect(node_factory):
     l1, l2 = node_factory.line_graph(2,
                                      announce_channels=False,


### PR DESCRIPTION
Thanks to @cdecker for the report.  This should be a simply cherry-pick for v24.11 as well.

