### PR TITLE
docs: update Bitcoin Core install docs

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -359,12 +359,12 @@ pip install poetry
 If you don't have bitcoind installed locally you'll need to install that as well:
 
 ```shell
-brew install berkeley-db4 boost miniupnpc pkg-config libevent
+brew install boost cmake pkg-config libevent
 git clone https://github.com/bitcoin/bitcoin
 cd bitcoin
-./autogen.sh
-./configure
-make src/bitcoind src/bitcoin-cli && make install
+cmake -B build
+cmake --build build --target bitcoind bitcoin-cli
+cmake --install build --component bitcoind && cmake --install build --component bitcoin-cli
 ```
 
 Clone lightning:


### PR DESCRIPTION
Bitcoin Core has switched to using CMake as its build system. Update the docs here so that they will work.
`berkeley-db4` is removed, because it should not be used for new installs of Core (it's deprecated, and slated for removal).
`miniupnpc` is removed, because Core no-longer uses that dependency (the functionality has been implemented internally).
macOS ships with a version of sqlite that will be picked up and used for wallets.

Changelog-None.