### PR TITLE
pyln-testing: fix unknown option compatibility with older cln versions

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -835,7 +835,11 @@ class LightningNode(object):
         if EXPERIMENTAL_SPLICING:
             self.daemon.opts["experimental-splicing"] = None
         # Avoid test flakes cause by this option unless explicitly set.
-        self.daemon.opts.update({"autoconnect-seeker-peers": 0})
+        try:
+            if VersionSpec.parse(">=v24.11").matches(self.cln_version):
+                self.daemon.opts.update({"autoconnect-seeker-peers": 0})
+        except Exception:
+            raise ValueError(f"Invalid version {type(self.cln_version)} - {self.cln_version}")
 
         if options is not None:
             self.daemon.opts.update(options)

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -615,6 +615,12 @@ class LightningD(TailableProc):
         cln_version_proc = subprocess.check_output([self.executable, "--version"])
         self.cln_version = NodeVersion(cln_version_proc.decode('ascii').strip())
 
+        try:
+            if VersionSpec.parse("<=v24.02.2").matches(self.cln_version):
+                self.opts['log-level'] = "debug"
+        except Exception:
+            raise ValueError(f"Invalid version {type(self.cln_version)} - {self.cln_version}")
+
         opts = {
             'lightning-dir': lightning_dir,
             'addr': '127.0.0.1:{}'.format(port),


### PR DESCRIPTION
Changelog-None

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.


Following https://github.com/ElementsProject/lightning/pull/7173 i tested one of my plugins with cln 24.05 and noticed that tests are failing because of `lightningd: --autoconnect-seeker-peers=0: unknown option` so let's use the new version comparison to only set it in cln versions after the option was introduced (24.11)