### PR TITLE
doc: Add enableoffer in makefile

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -12640,7 +12640,7 @@
     "lightning-enableoffer.json": {
       "$schema": "../rpc-schema-draft.json",
       "type": "object",
-      "rpc": "disableoffer",
+      "rpc": "enableoffer",
       "title": "Command for re-enabling an offer",
       "description": [
         "The **enableoffer** RPC command enables an offer, after it has been disabled."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -57,6 +57,7 @@ GENERATE_MARKDOWN := doc/lightning-addgossip.7 \
 	doc/lightning-disableoffer.7 \
 	doc/lightning-disconnect.7 \
 	doc/lightning-emergencyrecover.7 \
+	doc/lightning-enableoffer.7 \
 	doc/lightning-exposesecret.7 \
 	doc/lightning-feerates.7 \
 	doc/lightning-fetchinvoice.7 \

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,6 +66,7 @@ Core Lightning Documentation
    lightning-disableoffer <lightning-disableoffer.7.md>
    lightning-disconnect <lightning-disconnect.7.md>
    lightning-emergencyrecover <lightning-emergencyrecover.7.md>
+   lightning-enableoffer <lightning-enableoffer.7.md>
    lightning-exposesecret <lightning-exposesecret.7.md>
    lightning-feerates <lightning-feerates.7.md>
    lightning-fetchinvoice <lightning-fetchinvoice.7.md>

--- a/doc/schemas/lightning-enableoffer.json
+++ b/doc/schemas/lightning-enableoffer.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../rpc-schema-draft.json",
   "type": "object",
-  "rpc": "disableoffer",
+  "rpc": "enableoffer",
   "title": "Command for re-enabling an offer",
   "description": [
     "The **enableoffer** RPC command enables an offer, after it has been disabled."


### PR DESCRIPTION
The `enableoffer` JSON schema is present, but it is not included in the `GENERATE_MARKDOWN` list within the Makefile. This resulted into missing `.7` and `.7.md` files, leading to missing manpage and the documentation portal page.

Changelog-None.

Fixes #8079.