### PR TITLE
Unilateral lease close fixes

### DIFF
--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -1109,6 +1109,7 @@ static void resolve_htlc_tx(struct tracked_output ***outs,
 
 	msg = towire_onchaind_spend_to_us(NULL,
 					  &outpoint, amt,
+					  to_self_delay[LOCAL],
 					  rel_blockheight(out, to_self_delay[LOCAL]),
 					  commit_num,
 					  wscript);
@@ -2156,6 +2157,7 @@ static void our_unilateral_to_us(struct tracked_output ***outs,
 
 	msg = towire_onchaind_spend_to_us(NULL,
 					  outpoint, amt,
+					  sequence,
 					  rel_blockheight(out, sequence),
 					  commit_num,
 					  local_wscript);

--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -2129,7 +2129,7 @@ static void our_unilateral_to_us(struct tracked_output ***outs,
 				 const struct bitcoin_outpoint *outpoint,
 				 u32 tx_blockheight,
 				 struct amount_sat amt,
-				 u16 sequence,
+				 u32 sequence,
 				 const u8 *local_scriptpubkey,
 				 const u8 *local_wscript)
 {
@@ -2156,7 +2156,7 @@ static void our_unilateral_to_us(struct tracked_output ***outs,
 
 	msg = towire_onchaind_spend_to_us(NULL,
 					  outpoint, amt,
-					  rel_blockheight(out, to_self_delay[LOCAL]),
+					  rel_blockheight(out, sequence),
 					  commit_num,
 					  local_wscript);
 
@@ -2166,7 +2166,7 @@ static void our_unilateral_to_us(struct tracked_output ***outs,
 	 * output is *resolved* by the spending transaction
 	 */
 	propose_resolution_to_master(out, take(msg),
-				     rel_blockheight(out, to_self_delay[LOCAL]),
+				     rel_blockheight(out, sequence),
 				     OUR_DELAYED_RETURN_TO_WALLET);
 }
 

--- a/onchaind/onchaind_wire.csv
+++ b/onchaind/onchaind_wire.csv
@@ -129,6 +129,7 @@ msgdata,onchaind_notify_coin_mvt,mvt,chain_coin_mvt,
 msgtype,onchaind_spend_to_us,5040
 msgdata,onchaind_spend_to_us,outpoint,bitcoin_outpoint,
 msgdata,onchaind_spend_to_us,outpoint_amount,amount_sat,
+msgdata,onchaind_spend_to_us,sequence,u32,
 msgdata,onchaind_spend_to_us,minblock,u32,
 msgdata,onchaind_spend_to_us,commit_num,u64,
 msgdata,onchaind_spend_to_us,wscript_len,u32,

--- a/onchaind/test/run-grind_feerate.c
+++ b/onchaind/test/run-grind_feerate.c
@@ -332,7 +332,7 @@ u8 *towire_onchaind_spend_htlc_timeout(const tal_t *ctx UNNEEDED, const struct b
 u8 *towire_onchaind_spend_penalty(const tal_t *ctx UNNEEDED, const struct bitcoin_outpoint *outpoint UNNEEDED, struct amount_sat outpoint_amount UNNEEDED, const struct secret *remote_per_commitment_secret UNNEEDED, const u8 *stack_elem UNNEEDED, const u8 *wscript UNNEEDED)
 { fprintf(stderr, "towire_onchaind_spend_penalty called!\n"); abort(); }
 /* Generated stub for towire_onchaind_spend_to_us */
-u8 *towire_onchaind_spend_to_us(const tal_t *ctx UNNEEDED, const struct bitcoin_outpoint *outpoint UNNEEDED, struct amount_sat outpoint_amount UNNEEDED, u32 minblock UNNEEDED, u64 commit_num UNNEEDED, const u8 *wscript UNNEEDED)
+u8 *towire_onchaind_spend_to_us(const tal_t *ctx UNNEEDED, const struct bitcoin_outpoint *outpoint UNNEEDED, struct amount_sat outpoint_amount UNNEEDED, u32 sequence UNNEEDED, u32 minblock UNNEEDED, u64 commit_num UNNEEDED, const u8 *wscript UNNEEDED)
 { fprintf(stderr, "towire_onchaind_spend_to_us called!\n"); abort(); }
 /* Generated stub for towire_onchaind_spent_reply */
 u8 *towire_onchaind_spent_reply(const tal_t *ctx UNNEEDED, bool interested UNNEEDED)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -907,7 +907,6 @@ def test_channel_lease_post_expiry(node_factory, bitcoind, chainparams):
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
 @pytest.mark.slow_test
-@pytest.mark.xfail(strict=True)
 def test_channel_lease_unilat_closes(node_factory, bitcoind):
     '''
     Check that channel leases work

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -907,6 +907,7 @@ def test_channel_lease_post_expiry(node_factory, bitcoind, chainparams):
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
 @pytest.mark.slow_test
+@pytest.mark.xfail(strict=True)
 def test_channel_lease_unilat_closes(node_factory, bitcoind):
     '''
     Check that channel leases work
@@ -978,6 +979,12 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
     _, txid, blocks = l1.wait_for_onchaind_tx('OUR_DELAYED_RETURN_TO_WALLET',
                                               'OUR_UNILATERAL/DELAYED_OUTPUT_TO_US')
     assert blocks == 4
+
+    # Note that l3 has the whole lease delay (minus blocks already mined)
+    _, _, l3blocks = l3.wait_for_onchaind_tx('OUR_DELAYED_RETURN_TO_WALLET',
+                                             'OUR_UNILATERAL/DELAYED_OUTPUT_TO_US')
+    assert l3blocks == 4032 - 6 - 2 - 1
+
     bitcoind.generate_block(blocks)
     l1.mine_txid_or_rbf(txid, numblocks=1)
     l1.daemon.wait_for_log('Resolved OUR_UNILATERAL/DELAYED_OUTPUT_TO_US by our proposal OUR_DELAYED_RETURN_TO_WALLET')
@@ -1006,9 +1013,14 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
 
     l2.rpc.withdraw(l2.rpc.newaddr()['bech32'], "all", utxos=[utxo1])
 
-    # l3 cleans up their to-self after their lease expires
-    l3.wait_for_onchaind_tx('OUR_DELAYED_RETURN_TO_WALLET',
-                            'OUR_UNILATERAL/DELAYED_OUTPUT_TO_US')
+    # We actually mined this many blocks already, so we should see this message:
+    l3.daemon.wait_for_log('waiting confirmation that we spent DELAYED_OUTPUT_TO_US .* using OUR_DELAYED_RETURN_TO_WALLET')
+    l3.daemon.wait_for_log('sendrawtx exit 0')
+
+    # Depending on timing, l3 might have already got this to bitcoind before
+    # the last block.  But generate one just in case.
+    bitcoind.generate_block(1)
+    l3.daemon.wait_for_log('Resolved OUR_UNILATERAL/DELAYED_OUTPUT_TO_US by our proposal OUR_DELAYED_RETURN_TO_WALLET')
 
     # We were making a journal_entry for anchors, but now we ignore them
     incomes = l2.rpc.bkpr_listincome()['income_events']


### PR DESCRIPTION
We got the nSequence wrong if there's a lease in progress.  Increase test coverage, and then make the two fixes where we used the "to-self-delay" (which is correct for the non-lease case).

Fixes: #7460 