### PR TITLE
gossipd, chanbackup: reduce logging levels

### DIFF
--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -824,7 +824,7 @@ static const char *process_channel_update(const tal_t *ctx,
 		u32 prev_timestamp
 			= gossip_store_get_timestamp(gm->gs, chan->cupdate_off[dir]);
 		if (prev_timestamp >= timestamp) {
-			status_debug("Too-old update for %s",
+			status_trace("Too-old update for %s",
 				     fmt_short_channel_id(tmpctx, scid));
 			/* Too old, ignore */
 			return NULL;

--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -543,7 +543,7 @@ static struct command_result *after_staticbackup(struct command *cmd,
 	const jsmntok_t *scbs = json_get_member(buf, params, "scb");
 	struct out_req *req;
 	json_to_scb_chan(buf, scbs, &scb_chan);
-	plugin_log(cmd->plugin, LOG_INFORM, "Updating the SCB");
+	plugin_log(cmd->plugin, LOG_DBG, "Updating the SCB");
 
 	update_scb(cmd->plugin, scb_chan);
 	struct info *info = tal(cmd, struct info);


### PR DESCRIPTION
The vast majority of incoming channel updates seem to be cut due to age, which results in noisy logs.  Similarly, the chanbackup logging verbosity might better match the equivalent actions in channeld, which are at the debug level.

Fixes: #8058

Changelog-None: introduced in 25.02

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
