### PR TITLE
askrene-inform-channel: change order of operations

### DIFF
--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -1022,11 +1022,11 @@ static struct command_result *json_askrene_inform_channel(struct command *cmd,
 	case INFORM_CONSTRAINED:
 		/* It didn't pass, so minimal assumption is that reserve was all used
 		 * then there we were one msat short. */
-		if (!amount_msat_sub(amount, *amount, AMOUNT_MSAT(1)))
-			*amount = AMOUNT_MSAT(0);
 		if (!reserve_accumulate(askrene->reserved, scidd, amount))
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Amount overflow with reserves");
+		if (!amount_msat_sub(amount, *amount, AMOUNT_MSAT(1)))
+			*amount = AMOUNT_MSAT(0);
 		if (command_check_only(cmd))
 			return command_check_done(cmd);
 		c = layer_add_constraint(layer, scidd, time_now().ts.tv_sec,


### PR DESCRIPTION
There are two ways a plugin can use the `askrene-inform-channel` API on a payment failure: before or after calling
`askrene-unreserve`.

# Case 1

A plugin's logic could be the following:
- compute routes
- send routes
- call `askrene-reserve` 

Then on failure
- call `askrene-unreserve`
- call `askrene-inform-channel amount=x inform=constrained`

It is important to ensure that `askrene-inform-channel` is called once `askrene-unreserve` has completed,
because the upper bound on the liquidity is computed as
```
upperBound = reserves + amount - 1
```
Therefore a race condition here would alter the results by double counting the value of `amount`.

# Case 2

Alternatively the plugin's logic could inverse the order of operations in the case of failure:

- call `askrene-inform-channel amount=0 inform=constrained`
- call `askrene-unreserve`

In the first call we set `amount=0` because the route amount is already included in the reserves.
Also in this case it is important to make sure that `askrene-unreserve` is being called after `askrene-inform-channel`
or we would be under-counting.


However this second approach would give an off-by-one upperBound because the way `askrene-inform-channel`
is implemented.

Mathematically we want:
```
upperBound = reserves + amount - 1
```
But since the amounts are unsigned integers, the implementation is actually
```
upperBound = reserves + max(amount-1, 0)
```
Which for example with `reserves=10` and `amount=0` gives `upperBound = 10` instead of the expected value `upperBound=9`.

This this PR I change the order of the addition and subtraction operations to have
```
upperBound = max(reserves+amount-1, 0)
```

So that the case 2 can still be a valid use case.