### PR TITLE
askrene: fix integer overflow for dummy channels

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -581,11 +581,9 @@ bool amount_msat_fee(struct amount_msat *fee,
 	 *    - fee_base_msat + ( amount_to_forward * fee_proportional_millionths / 1000000 )
 	 */
 	fee_base.millisatoshis = fee_base_msat;
-
-	if (mul_overflows_u64(amt.millisatoshis, fee_proportional_millionths))
+	if (!amount_msat_mul_div(&fee_prop, amt, fee_proportional_millionths,
+				 1000000))
 		return false;
-	fee_prop.millisatoshis = amt.millisatoshis * fee_proportional_millionths
-		/ 1000000;
 
 	return amount_msat_add(fee, fee_base, fee_prop);
 }

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1420,3 +1420,39 @@ def test_askrene_fake_channeld(node_factory, bitcoind):
                                                       'constrained')
                     else:
                         raise err
+
+
+def test_simple_dummy_channel(node_factory):
+    """Test if askrene can resolve a route with dummy channels, ie. channels
+    that we might set artificially to resolve blinded paths and self payments,
+    they have unlimited capacities and possibly zero fees."""
+    ALOT = "2100000000000000sat"
+    node1 = "020000000000000000000000000000000000000000000000000000000000000001"
+    node2 = "020000000000000000000000000000000000000000000000000000000000000002"
+    l1 = node_factory.get_node()
+    l1.rpc.askrene_create_layer("mylayer")
+    l1.rpc.askrene_create_channel(
+        layer="mylayer",
+        source=node1,
+        destination=node2,
+        short_channel_id="0x0x0",
+        capacity_msat=ALOT,
+    )
+    l1.rpc.askrene_update_channel(
+        layer="mylayer",
+        short_channel_id_dir="0x0x0/0",
+        enabled=True,
+        htlc_minimum_msat=0,
+        htlc_maximum_msat=ALOT,
+        fee_base_msat=0,
+        fee_proportional_millionths=0,
+        cltv_expiry_delta=5,
+    )
+    l1.rpc.getroutes(
+        source=node1,
+        destination=node2,
+        amount_msat=100,
+        maxfee_msat=5000,
+        final_cltv=5,
+        layers=["mylayer"],
+    )


### PR DESCRIPTION
We may introduce high capacity channels in askrene to represent problems
with multiple destinations (eg. multiple blinded paths) or to solve
self-payments. The integer computation of the deliverable amount through
these channels (I tested this with a channel with 21M bitcoin) would
fail due to an integer overflow in the function `amount_msat_sub_fee`,
21M BTC = 21 x 10^17 msat, which overflows u64 integers when multiplied
by 10^6. We have fixed `amount_msat_sub_fee` operations, so that it
doesn't overflow.

Basically we had the following integer operation:
```
floor(x * a/b)
```
where `a<b` and `a=10^6`, so the result fits in u64. The problem is that we first compute `a*x` and then divide by `b`.
`a*x` can overflow.
We fixed the operation by splitting `x = q_x * b + r_x` where `q_x = floor(x/b)` and `r_x = x mod b`, so that
our computation reduces to:
```
a * q_x + floor(a*r_x / b)
```
The value `a*q_x <= x ` does not overflow. So the only dangerous operation is `a*r_x`,
but `a*r_x  < a*b`, so if `a*b` does not overflow then the entire operation is safe to compute.
In our case `a=10^6` and `b = 10^6 + ppm`, so unless `ppm ~ 10^12`, which is an absurd value,
the above operation is guaranteed to be successful. 