### PR TITLE
Channel gossip rework

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -4788,7 +4788,8 @@ static void peer_in(struct peer *peer, const u8 *msg)
 	check_tx_abort(peer, msg, NULL);
 
 	/* If we're in STFU mode and aren't waiting for a STFU mode
-	 * specific message, the only valid message was tx_abort */
+	 * specific message, the only valid message was tx_abort (or a
+	 * belated announcement_signatures!) */
 	if (is_stfu_active(peer) && !peer->stfu_wait_single_msg) {
 		if (peer->splicing && type == WIRE_TX_SIGNATURES) {
 			if (peer->splicing->tx_sig_msg)
@@ -4798,7 +4799,7 @@ static void peer_in(struct peer *peer, const u8 *msg)
 			peer->splicing->tx_sig_msg = tal_steal(peer->splicing,
 							       msg);
 			return;
-		} else {
+		} else if (type != WIRE_ANNOUNCEMENT_SIGNATURES) {
 			peer_failed_warn(peer->pps, &peer->channel_id,
 					 "Received message %s when only TX_ABORT was"
 					 " valid", peer_wire_name(type));

--- a/closingd/closingd.c
+++ b/closingd/closingd.c
@@ -267,8 +267,8 @@ receive_offer(struct per_peer_state *pps,
 		 */
 		else if (fromwire_peektype(msg) == WIRE_SHUTDOWN)
 			msg = tal_free(msg);
-		/* channeld may have sent ping: ignore pong! */
-		else if (fromwire_peektype(msg) == WIRE_PONG)
+		/* We can get announcement signatures: too late! */
+		else if (fromwire_peektype(msg) == WIRE_ANNOUNCEMENT_SIGNATURES)
 			msg = tal_free(msg);
 	} while (!msg);
 

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -832,9 +832,11 @@ static const char *process_channel_update(const tal_t *ctx,
 		u32 prev_timestamp
 			= gossip_store_get_timestamp(gm->gs, chan->cupdate_off[dir]);
 		if (prev_timestamp >= timestamp) {
-			status_trace("Too-old update for %s",
-				     fmt_short_channel_id(tmpctx, scid));
-			/* Too old, ignore */
+			/* Don't spam the logs for duplicates! */
+			if (timestamp < prev_timestamp)
+				status_trace("Too-old update for %s",
+					     fmt_short_channel_id(tmpctx, scid));
+			/* Too old / redundant, ignore */
 			return NULL;
 		}
 	} else {

--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -822,7 +822,7 @@ static void updates_complete(struct chain_topology *topo)
 {
 	if (!bitcoin_blkid_eq(&topo->tip->blkid, &topo->prev_tip)) {
 		/* Tell lightningd about new block. */
-		notify_new_block(topo->bitcoind->ld, topo->tip->height);
+		notify_new_block(topo->bitcoind->ld);
 
 		/* Tell watch code to re-evaluate all txs. */
 		watch_topology_changed(topo);
@@ -838,7 +838,7 @@ static void updates_complete(struct chain_topology *topo)
 
 		/* Send out an account balance snapshot */
 		if (!first_update_complete) {
-			send_account_balance_snapshot(topo->ld, topo->tip->height);
+			send_account_balance_snapshot(topo->ld);
 			first_update_complete = true;
 		}
 	}

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -322,7 +322,6 @@ struct channel *new_unsaved_channel(struct peer *peer,
 	/* Nothing happened yet */
 	memset(&channel->stats, 0, sizeof(channel->stats));
 	channel->state_changes = tal_arr(channel, struct channel_state_change *, 0);
-	channel->replied_to_announcement_sigs = false;
 
 	/* No shachain yet */
 	channel->their_shachain.id = 0;
@@ -633,7 +632,6 @@ struct channel *new_channel(struct peer *peer, u64 dbid,
 	channel->num_onchain_spent_calls = 0;
 	channel->stats = *stats;
 	channel->state_changes = tal_steal(channel, state_changes);
-	channel->replied_to_announcement_sigs = false;
 
  	/* Populate channel->channel_gossip */
 	channel_gossip_init(channel, take(peer_update));

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -353,9 +353,6 @@ struct channel {
 
 	/* Our change history. */
 	struct channel_state_change **state_changes;
-
-	/* Have we replied to announcement_signatures once? */
-	bool replied_to_announcement_sigs;
 };
 
 /* Is channel owned (and should be talking to peer) */

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -610,6 +610,29 @@ static inline bool channel_state_failing_onchain(enum channel_state state)
 	abort();
 }
 
+static inline bool channel_state_funding_spent_onchain(enum channel_state state)
+{
+	switch (state) {
+	case CHANNELD_AWAITING_LOCKIN:
+	case CHANNELD_NORMAL:
+	case CHANNELD_AWAITING_SPLICE:
+	case CLOSINGD_SIGEXCHANGE:
+	case CHANNELD_SHUTTING_DOWN:
+	case CLOSINGD_COMPLETE:
+	case DUALOPEND_OPEN_INIT:
+	case DUALOPEND_OPEN_COMMIT_READY:
+	case DUALOPEND_OPEN_COMMITTED:
+	case DUALOPEND_AWAITING_LOCKIN:
+	case AWAITING_UNILATERAL:
+		return false;
+	case CLOSED:
+	case FUNDING_SPEND_SEEN:
+	case ONCHAIN:
+		return true;
+	}
+	abort();
+}
+
 static inline bool channel_state_pre_open(enum channel_state state)
 {
 	switch (state) {

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -22,8 +22,7 @@ void channeld_tell_depth(struct channel *channel,
 			 u32 depth);
 
 /* Notify channels of new blocks. */
-void channel_notify_new_block(struct lightningd *ld,
-			      u32 block_height);
+void channel_notify_new_block(struct lightningd *ld);
 
 /* Cancel the channel after `fundchannel_complete` succeeds
  * but before funding broadcasts. */

--- a/lightningd/channel_gossip.c
+++ b/lightningd/channel_gossip.c
@@ -755,8 +755,7 @@ void channel_gossip_scid_changed(struct channel *channel)
 
 /* Block height changed */
 static void new_blockheight(struct lightningd *ld,
-			    struct channel *channel,
-			    u32 block_height)
+			    struct channel *channel)
 {
 	switch (channel->channel_gossip->state) {
 	case CGOSSIP_PRIVATE:
@@ -765,7 +764,7 @@ static void new_blockheight(struct lightningd *ld,
 	case CGOSSIP_NOT_USABLE:
 		return;
 	case CGOSSIP_NOT_DEEP_ENOUGH:
-		if (!channel_announceable(channel, block_height)) {
+		if (!channel_announceable(channel, get_block_height(ld->topology))) {
 			check_channel_gossip(channel);
 			return;
 		}
@@ -776,8 +775,7 @@ static void new_blockheight(struct lightningd *ld,
 	fatal("Bad channel_gossip_state %u", channel->channel_gossip->state);
 }
 
-void channel_gossip_notify_new_block(struct lightningd *ld,
-				     u32 block_height)
+void channel_gossip_notify_new_block(struct lightningd *ld)
 {
 	struct peer *peer;
 	struct channel *channel;
@@ -791,7 +789,7 @@ void channel_gossip_notify_new_block(struct lightningd *ld,
 			if (!channel->channel_gossip)
 				continue;
 
-			new_blockheight(ld, channel, block_height);
+			new_blockheight(ld, channel);
 			check_channel_gossip(channel);
 		}
 	}

--- a/lightningd/channel_gossip.h
+++ b/lightningd/channel_gossip.h
@@ -23,8 +23,7 @@ void channel_gossip_update(struct channel *channel);
 void channel_gossip_scid_changed(struct channel *channel);
 
 /* Block height changed */
-void channel_gossip_notify_new_block(struct lightningd *ld,
-				     u32 block_height);
+void channel_gossip_notify_new_block(struct lightningd *ld);
 
 /* Got announcement_signatures from peer */
 void channel_gossip_got_announcement_sigs(struct channel *channel,

--- a/lightningd/coin_mvts.c
+++ b/lightningd/coin_mvts.c
@@ -103,7 +103,7 @@ static bool report_chan_balance(const struct channel *chan)
 	abort();
 }
 
-void send_account_balance_snapshot(struct lightningd *ld, u32 blockheight)
+void send_account_balance_snapshot(struct lightningd *ld)
 {
 	struct balance_snapshot *snap = tal(NULL, struct balance_snapshot);
 	struct account_balance *bal;
@@ -112,7 +112,7 @@ void send_account_balance_snapshot(struct lightningd *ld, u32 blockheight)
 	struct peer *p;
 	struct peer_node_id_map_iter it;
 
-	snap->blockheight = blockheight;
+	snap->blockheight = get_block_height(ld->topology);
 	snap->timestamp = time_now().ts.tv_sec;
 	snap->node_id = &ld->our_nodeid;
 

--- a/lightningd/coin_mvts.h
+++ b/lightningd/coin_mvts.h
@@ -36,5 +36,5 @@ struct channel_coin_mvt *new_channel_mvt_routed_hout(const tal_t *ctx,
 						     struct htlc_out *hout,
 						     struct channel *channel);
 
-void send_account_balance_snapshot(struct lightningd *ld, u32 blockheight);
+void send_account_balance_snapshot(struct lightningd *ld);
 #endif /* LIGHTNING_LIGHTNINGD_COIN_MVTS_H */

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -4126,7 +4126,7 @@ bool peer_start_dualopend(struct peer *peer,
 	 *       funding transaction.
 	 */
 	/* FIXME: We should override this to 0 in the openchannel2 hook of we want zeroconf*/
-	channel->minimum_depth = peer->ld->config.anchor_confirms;
+	channel->minimum_depth = peer->ld->config.funding_confirms;
 
 	msg = towire_dualopend_init(NULL, chainparams,
 				    peer->ld->our_features,

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -254,8 +254,10 @@ static void gossipd_new_blockheight_reply(struct subd *gossipd,
 			     gossipd->ld->gossip_blockheight);
 }
 
-void gossip_notify_new_block(struct lightningd *ld, u32 blockheight)
+void gossip_notify_new_block(struct lightningd *ld)
 {
+	u32 blockheight = get_block_height(ld->topology);
+
 	/* Only notify gossipd once we're synced. */
 	if (!topology_synced(ld->topology))
 		return;
@@ -268,7 +270,7 @@ void gossip_notify_new_block(struct lightningd *ld, u32 blockheight)
 static void gossip_topology_synced(struct chain_topology *topo, void *unused)
 {
 	/* Now we start telling gossipd about blocks. */
-	gossip_notify_new_block(topo->ld, get_block_height(topo));
+	gossip_notify_new_block(topo->ld);
 }
 
 /* We make sure gossipd is started before plugins (which may want gossip_map) */

--- a/lightningd/gossip_control.h
+++ b/lightningd/gossip_control.h
@@ -14,6 +14,6 @@ void gossipd_notify_spends(struct lightningd *ld,
 			   u32 blockheight,
 			   const struct short_channel_id *scids);
 
-void gossip_notify_new_block(struct lightningd *ld, u32 blockheight);
+void gossip_notify_new_block(struct lightningd *ld);
 
 #endif /* LIGHTNING_LIGHTNINGD_GOSSIP_CONTROL_H */

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -775,14 +775,14 @@ static int io_poll_lightningd(struct pollfd *fds, nfds_t nfds, int timeout)
  * like this, and it's always better to have compile-time calls than runtime,
  * as it makes the code more explicit.  But pasting in direct calls is also an
  * abstraction violation, so we use this middleman function. */
-void notify_new_block(struct lightningd *ld, u32 block_height)
+void notify_new_block(struct lightningd *ld)
 {
 	/* Inform our subcomponents individually. */
-	htlcs_notify_new_block(ld, block_height);
-	channel_notify_new_block(ld, block_height);
-	channel_gossip_notify_new_block(ld, block_height);
-	gossip_notify_new_block(ld, block_height);
-	waitblockheight_notify_new_block(ld, block_height);
+	htlcs_notify_new_block(ld);
+	channel_notify_new_block(ld);
+	channel_gossip_notify_new_block(ld);
+	gossip_notify_new_block(ld);
+	waitblockheight_notify_new_block(ld);
 }
 
 static void on_sigint(int _ UNUSED)

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -21,8 +21,8 @@ struct config {
 	/* How long do we let them lock up our funds? (blocks: 2016 by spec) */
 	u32 max_htlc_cltv;
 
-	/* How many confirms until we consider an anchor "settled". */
-	u32 anchor_confirms;
+	/* How many confirms until we consider a funding tx "settled". */
+	u32 funding_confirms;
 
 	/* Minimum CLTV to subtract from incoming HTLCs to outgoing */
 	u32 cltv_expiry_delta;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -443,7 +443,7 @@ const char *subdaemon_path(const tal_t *ctx, const struct lightningd *ld, const 
 void test_subdaemons(const struct lightningd *ld);
 
 /* Notify lightningd about new blocks. */
-void notify_new_block(struct lightningd *ld, u32 block_height);
+void notify_new_block(struct lightningd *ld);
 
 /* Signal a clean exit from lightningd.
  * NOTE! This function **returns**.

--- a/lightningd/opening_common.c
+++ b/lightningd/opening_common.c
@@ -62,7 +62,7 @@ new_uncommitted_channel(struct peer *peer)
 	 *       funding transaction.
 	 */
 	 /* We override this in openchannel hook if we want zeroconf */
-	uc->minimum_depth = ld->config.anchor_confirms;
+	uc->minimum_depth = ld->config.funding_confirms;
 
 	/* Use default 1% reserve if not otherwise specified. If this
 	 * is not-NULL it will be used by openingd as absolute value

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -1301,7 +1301,7 @@ static struct command_result *json_fundchannel_start(struct command *cmd,
 	}
 
 	if (!mindepth)
-		mindepth = tal_dup(cmd, u32, &cmd->ld->config.anchor_confirms);
+		mindepth = tal_dup(cmd, u32, &cmd->ld->config.funding_confirms);
 
 	if (push_msat && amount_msat_greater_sat(*push_msat, *amount))
 		return command_fail(cmd, FUND_CANNOT_AFFORD,

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -961,7 +961,7 @@ static const struct config testnet_config = {
 	.max_htlc_cltv = 2016,
 
 	/* We're fairly trusting, under normal circumstances. */
-	.anchor_confirms = 1,
+	.funding_confirms = 1,
 
 	/* Testnet blockspace is free. */
 	.max_concurrent_htlcs = 483,
@@ -1029,7 +1029,7 @@ static const struct config mainnet_config = {
 	.max_htlc_cltv = 2016,
 
 	/* We're fairly trusting, under normal circumstances. */
-	.anchor_confirms = 3,
+	.funding_confirms = 3,
 
 	/* While up to 483 htlcs are possible we do 30 by default (as eclair does) to save blockspace */
 	.max_concurrent_htlcs = 30,
@@ -1103,8 +1103,8 @@ static void check_config(struct lightningd *ld)
 	if (ld->config.max_concurrent_htlcs < 1 || ld->config.max_concurrent_htlcs > 483)
 		fatal("--max-concurrent-htlcs value must be between 1 and 483 it is: %u",
 		      ld->config.max_concurrent_htlcs);
-	if (ld->config.anchor_confirms == 0)
-		fatal("anchor-confirms must be greater than zero");
+	if (ld->config.funding_confirms == 0)
+		fatal("funding-confirms must be greater than zero");
 
 	if (ld->always_use_proxy && !ld->proxyaddr)
 		fatal("--always-use-proxy needs --proxy");
@@ -1501,7 +1501,7 @@ static void register_opts(struct lightningd *ld)
 	opt_register_arg("--max-locktime-blocks", opt_set_max_htlc_cltv, NULL,
 			 ld, opt_hidden);
 	clnopt_witharg("--funding-confirms", OPT_SHOWINT, opt_set_u32, opt_show_u32,
-			 &ld->config.anchor_confirms,
+			 &ld->config.funding_confirms,
 			 "Confirmations required for funding transaction");
 	clnopt_witharg("--require-confirmed-inputs", OPT_SHOWBOOL,
 		       opt_set_bool_arg, opt_show_bool,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2979,9 +2979,9 @@ timeout_waitblockheight_waiter(struct waitblockheight_waiter *w)
 				 "Timed out."));
 }
 /* Called by lightningd at each new block.  */
-void waitblockheight_notify_new_block(struct lightningd *ld,
-				      u32 block_height)
+void waitblockheight_notify_new_block(struct lightningd *ld)
 {
+	u32 block_height = get_block_height(ld->topology);
 	struct waitblockheight_waiter *w, *n;
 	char *to_delete = tal(NULL, char);
 
@@ -2996,8 +2996,7 @@ void waitblockheight_notify_new_block(struct lightningd *ld,
 		list_del(&w->list);
 		w->removed = true;
 		tal_steal(to_delete, w);
-		was_pending(waitblockheight_complete(w->cmd,
-						     block_height));
+		was_pending(waitblockheight_complete(w->cmd, block_height));
 	}
 	tal_free(to_delete);
 }

--- a/lightningd/peer_control.h
+++ b/lightningd/peer_control.h
@@ -155,8 +155,7 @@ struct leak_detect;
 void peer_dev_memleak(struct lightningd *ld, struct leak_detect *leaks);
 
 /* Triggered at each new block.  */
-void waitblockheight_notify_new_block(struct lightningd *ld,
-				      u32 block_height);
+void waitblockheight_notify_new_block(struct lightningd *ld);
 
 
 /* JSON parameter by channel_id or scid (caller must check state!) */

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2786,9 +2786,10 @@ static void consider_failing_incoming(struct lightningd *ld,
 	local_fail_in_htlc(hout->in, take(towire_permanent_channel_failure(NULL)));
 }
 
-void htlcs_notify_new_block(struct lightningd *ld, u32 height)
+void htlcs_notify_new_block(struct lightningd *ld)
 {
 	bool removed;
+	u32 height = get_block_height(ld->topology);
 
 	/* BOLT #2:
 	 *

--- a/lightningd/peer_htlcs.h
+++ b/lightningd/peer_htlcs.h
@@ -46,7 +46,7 @@ void onchain_failed_our_htlc(const struct channel *channel,
 void onchain_fulfilled_htlc(struct channel *channel,
 			    const struct preimage *preimage);
 
-void htlcs_notify_new_block(struct lightningd *ld, u32 height);
+void htlcs_notify_new_block(struct lightningd *ld);
 
 /* Only defined if COMPAT_V061 */
 void fixup_htlcs_out(struct lightningd *ld);

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -11,12 +11,10 @@ int unused_main(int argc, char *argv[]);
 void begin_topology(struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "begin_topology called!\n"); abort(); }
 /* Generated stub for channel_gossip_notify_new_block */
-void channel_gossip_notify_new_block(struct lightningd *ld UNNEEDED,
-				     u32 block_height UNNEEDED)
+void channel_gossip_notify_new_block(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "channel_gossip_notify_new_block called!\n"); abort(); }
 /* Generated stub for channel_notify_new_block */
-void channel_notify_new_block(struct lightningd *ld UNNEEDED,
-			      u32 block_height UNNEEDED)
+void channel_notify_new_block(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "channel_notify_new_block called!\n"); abort(); }
 /* Generated stub for connectd_activate */
 void connectd_activate(struct lightningd *ld UNNEEDED)
@@ -112,7 +110,7 @@ bool fromwire_status_version(const tal_t *ctx UNNEEDED, const void *p UNNEEDED, 
 void gossip_init(struct lightningd *ld UNNEEDED, int connectd_fd UNNEEDED)
 { fprintf(stderr, "gossip_init called!\n"); abort(); }
 /* Generated stub for gossip_notify_new_block */
-void gossip_notify_new_block(struct lightningd *ld UNNEEDED, u32 blockheight UNNEEDED)
+void gossip_notify_new_block(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "gossip_notify_new_block called!\n"); abort(); }
 /* Generated stub for handle_early_opts */
 void handle_early_opts(struct lightningd *ld UNNEEDED, int argc UNNEEDED, char *argv[])
@@ -130,7 +128,7 @@ size_t hash_htlc_key(const struct htlc_key *htlc_key UNNEEDED)
 struct ext_key *hsm_init(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "hsm_init called!\n"); abort(); }
 /* Generated stub for htlcs_notify_new_block */
-void htlcs_notify_new_block(struct lightningd *ld UNNEEDED, u32 height UNNEEDED)
+void htlcs_notify_new_block(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "htlcs_notify_new_block called!\n"); abort(); }
 /* Generated stub for htlcs_resubmit */
 void htlcs_resubmit(struct lightningd *ld UNNEEDED,
@@ -283,8 +281,7 @@ struct txfilter *txfilter_new(const tal_t *ctx UNNEEDED)
 const char *version(void)
 { fprintf(stderr, "version called!\n"); abort(); }
 /* Generated stub for waitblockheight_notify_new_block */
-void waitblockheight_notify_new_block(struct lightningd *ld UNNEEDED,
-				      u32 block_height UNNEEDED)
+void waitblockheight_notify_new_block(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "waitblockheight_notify_new_block called!\n"); abort(); }
 /* Generated stub for wallet_begin_old_close_rescan */
 void wallet_begin_old_close_rescan(struct lightningd *ld UNNEEDED)

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -374,9 +374,6 @@ bool fromwire_tlv(const u8 **cursor UNNEEDED, size_t *max UNNEEDED,
 		  void *record UNNEEDED, struct tlv_field **fields UNNEEDED,
 		  const u64 *extra_types UNNEEDED, size_t *err_off UNNEEDED, u64 *err_type UNNEEDED)
 { fprintf(stderr, "fromwire_tlv called!\n"); abort(); }
-/* Generated stub for get_block_height */
-u32 get_block_height(const struct chain_topology *topo UNNEEDED)
-{ fprintf(stderr, "get_block_height called!\n"); abort(); }
 /* Generated stub for get_network_blockheight */
 u32 get_network_blockheight(const struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "get_network_blockheight called!\n"); abort(); }
@@ -1308,6 +1305,12 @@ void txfilter_add_scriptpubkey(struct txfilter *filter UNNEEDED, const u8 *scrip
 {
 	if (taken(script))
 		tal_free(script);
+}
+
+/* Can actually be called by new_channel */
+u32 get_block_height(const struct chain_topology *topo UNNEEDED)
+{
+	return 0;
 }
 
 /**


### PR DESCRIPTION
~(Based on #8135)~ Merged into master

I tried modifying our state machine to allow us to send (as allowed in the latest spec revisions) announcement_signatures before 6 blocks have passed.  However, our state machine did not capture the entire state, so it proved fragile.  The result is a rework on the state machine to be more robust.