### PR TITLE
onchaind: fix crash if we enounter a tx with no witness.

### DIFF
--- a/onchaind/onchaind.c
+++ b/onchaind/onchaind.c
@@ -774,7 +774,7 @@ static bool resolved_by_proposal(struct tracked_output *out,
 		return false;
 
 	input = which_input_spends(tx_parts, &out->outpoint);
-	if (!input)
+	if (!input || !input->witness)
 		return false;
 	if (!onchain_witness_element_matches(out->proposal->welements, input))
 		return false;


### PR DESCRIPTION
This can happen if a descendent tx has no witness and we don't tell the main daemon in time that we're not iterested.

Fixes: https://github.com/ElementsProject/lightning/issues/8133
Changelog-Fixed: lightningd: onchaind crash when seeing unrelated txs (usually when catching up with old closes)
