### PR TITLE
Update listsendpays documentation to explain when amount_msat is not present

### DIFF
--- a/doc/schemas/lightning-listsendpays.json
+++ b/doc/schemas/lightning-listsendpays.json
@@ -144,7 +144,7 @@
             "amount_msat": {
               "type": "msat",
               "description": [
-                "The amount delivered to destination (if known)."
+                "The amount delivered to destination (if known). This field might not be present if the payment is still pending or if the amount delivered to the destination is not known."
               ]
             },
             "destination": {
@@ -326,7 +326,8 @@
       }
     },
     "pre_return_value_notes": [
-      "Note that the returned array is ordered by increasing *id*."
+      "Note that the returned array is ordered by increasing *id*.",
+      "If the `amount_msat` field is not present, it means the payment is still pending or the amount delivered to the destination is not known."
     ]
   },
   "author": [


### PR DESCRIPTION
Fixes #6909

Update the documentation of `listsendpays` to be more explicit about when the `amount_msat` field might not be present.

* Update the description of the `amount_msat` field in `doc/schemas/lightning-listsendpays.json` to explain that it might not be present if the payment is still pending or if the amount delivered to the destination is not known.
* Add a note in the `response` section to indicate that if the `amount_msat` field is not present, it means the payment is still pending or the amount delivered to the destination is not known.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ElementsProject/lightning/pull/8144?shareId=66ef07f1-a678-4e01-8cad-3b594440b1e7).