### PR TITLE
build (macos): do not overwrite `PKG_CONFIG_PATH` variable

### DIFF
--- a/configure
+++ b/configure
@@ -13,7 +13,7 @@ ARCH=$(uname -m)
 if [ "$OS-$ARCH" = "Darwin-arm64" ]; then
 CPATH=/opt/homebrew/include
 LIBRARY_PATH=/opt/homebrew/lib
-export PKG_CONFIG_PATH=/opt/homebrew/opt/sqlite/lib/pkgconfig
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/opt/homebrew/opt/sqlite/lib/pkgconfig
 else
 CPATH=/usr/local/lib
 LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

---
macOS configure script overwrites user provided PKG_CONFIG_PATH instead of appending to it

fixes Homebrew/homebrew-core/pull/210080