### PR TITLE
crates: bump versions to 0.4.0 for CLN 25.02 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cln-grpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc-plugin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cln-grpc",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "clnrest"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum 0.8.1",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."
@@ -15,7 +15,7 @@ server = ["cln-rpc"]
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-cln-rpc = { path="../cln-rpc/", version = "0.3", optional = true }
+cln-rpc = { path="../cln-rpc/", version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tonic = { version = "0.11", features = ["tls", "transport"] }
 prost = "0.12"
@@ -28,7 +28,7 @@ tokio-util = "0.7.10"
 
 [dev-dependencies]
 serde_json = "1.0.72"
-cln-rpc = { path="../cln-rpc/", version = "0.3" }
+cln-rpc = { path="../cln-rpc/", version = "0.4" }
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-rpc"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "An async RPC client for Core Lightning."

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-plugin"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."
@@ -27,4 +27,4 @@ tracing = { version = "^0.1", features = ["async-await", "log"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", ] }
-cln-grpc = { version = "0.3", path = "../cln-grpc" }
+cln-grpc = { version = "0.4", path = "../cln-grpc" }

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cln-grpc-plugin"
-version = "0.3.0"
+version = "0.4.0"
 
 description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. Authentication is done via mTLS."
 license = "MIT"
@@ -17,9 +17,9 @@ anyhow = "1.0"
 log = "0.4"
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 prost = "0.12"
-cln-grpc = { version = "0.3", features = ["server"], path = "../../cln-grpc"}
-cln-plugin = { version = "0.3", path = "../../plugins" }
-cln-rpc = { version = "0.3", path = "../../cln-rpc" }
+cln-grpc = { version = "0.4", features = ["server"], path = "../../cln-grpc"}
+cln-plugin = { version = "0.4", path = "../../plugins" }
+cln-rpc = { version = "0.4", path = "../../cln-rpc" }
 serde_json = "1.0.113"
 
 [dependencies.tokio]

--- a/plugins/rest-plugin/Cargo.toml
+++ b/plugins/rest-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clnrest"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Transforms RPC calls into REST APIs"
@@ -27,7 +27,7 @@ utoipa = { version = "5", features = ['axum_extras'] }
 log-panics = "2"
 socketioxide = "0.15"
 
-cln-plugin = { version = "0.3", path = "../../plugins" }
-cln-rpc = { version = "0.3", path = "../../cln-rpc" }
+cln-plugin = { version = "0.4", path = "../../plugins" }
+cln-rpc = { version = "0.4", path = "../../cln-rpc" }
 utoipa-swagger-ui = { version = "9.0.0", features = ["vendored", "axum"] }
 


### PR DESCRIPTION
Changelog-None

These need to be bumped for publishing by the CI job. We had breaking changes so we need a 0.x.0 bump.