### PR TITLE
opening: Do not forget `zeroconf` channels due to funding timeout

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -1958,8 +1958,12 @@ is_fundee_should_forget(struct lightningd *ld,
 	if (block_height - channel->first_blocknum < max_funding_unconfirmed)
 		return false;
 
-	/* If we've got funds in the channel, don't forget it */
+	/* If we've got funds in the channel initially, don't forget it */
 	if (!amount_sat_is_zero(channel->our_funds))
+		return false;
+
+	/* If we ever had a stake in the channel, don't forget it. */
+	if (!amount_msat_is_zero(channel->msat_to_us_max))
 		return false;
 
 	/* Ah forget it! */


### PR DESCRIPTION
This addresses #8147.

We used to forget channels if a) we were the fundee, i.e., had no
stake in the channel, and b) the channel did not confirm in 2016
blocks / 2 weeks.

The first implication is no longer true: with `zeroconf` support we
can have a stake in a channel, despite not being confirmed yet. With
this assumption no longer true we now need to explicitly check that we
own no funds in the channel on top of checking if we had contributed
to the funding.