### PR TITLE
pytest: fix CI hang.

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4721,12 +4721,19 @@ def test_connect_ratelimit(node_factory, bitcoind):
     # Suspend the others, to make sure they cannot respond too fast.
     for n in nodes:
         os.kill(n.daemon.proc.pid, signal.SIGSTOP)
-    l1.start()
 
-    # The first will be ok, but others should block and be unblocked.
-    l1.daemon.wait_for_logs((['Unblocking for ']
-                             + ['Too many connections, waiting'])
-                            * (len(nodes) - 1))
+    try:
+        l1.start()
+
+        # The first will be ok, but others should block and be unblocked.
+        l1.daemon.wait_for_logs((['Unblocking for ']
+                                 + ['Too many connections, waiting'])
+                                * (len(nodes) - 1))
+    except Exception as err:
+        # Resume, so pytest doesn't hang!
+        for n in nodes:
+            os.kill(n.daemon.proc.pid, signal.SIGCONT)
+        raise err
 
     # Resume them
     for n in nodes:


### PR DESCRIPTION
This finally happened on my local build machine, so I tracked it down using py-spy, `apt-get install python3-dbg` and `py-local`.

Turns out the dev-memleak command was hanging, and the processes were stuck in SIGSTOP.  There are only two places we send that, and sure enough, this was the test which was running at the time.

Changelog-None
