### PR TITLE
Wally 1.4.0 update

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -761,10 +761,9 @@ struct wally_psbt *psbt_from_b64(const tal_t *ctx,
 				 size_t b64len)
 {
 	struct wally_psbt *psbt;
-	char *str = tal_strndup(tmpctx, b64, b64len);
 
 	tal_wally_start();
-	if (wally_psbt_from_base64(str, /* flags */ 0, &psbt) == WALLY_OK)
+	if (wally_psbt_from_base64_n(b64, b64len, /* flags */ 0, &psbt) == WALLY_OK)
 		tal_add_destructor(psbt, psbt_destroy);
 	else
 		psbt = NULL;

--- a/hsmd/libhsmd.c
+++ b/hsmd/libhsmd.c
@@ -547,6 +547,7 @@ static void hsm_key_for_utxo(struct privkey *privkey, struct pubkey *pubkey,
  * add a partial sig for each */
 static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 {
+	bool is_cache_enabled = false;
 	for (size_t i = 0; i < tal_count(utxos); i++) {
 		struct utxo *utxo = utxos[i];
 		for (size_t j = 0; j < psbt->num_inputs; j++) {
@@ -584,6 +585,11 @@ static void sign_our_inputs(struct utxo **utxos, struct wally_psbt *psbt)
 							utxo->amount);
 			}
 			tal_wally_start();
+			if (!is_cache_enabled) {
+				/* Enable caching signature sub-hashes */
+				wally_psbt_signing_cache_enable(psbt, 0);
+				is_cache_enabled = true;
+			}
 			if (wally_psbt_sign(psbt, privkey.secret.data,
 					    sizeof(privkey.secret.data),
 					    EC_FLAG_GRIND_R) != WALLY_OK) {


### PR DESCRIPTION
Not an important update, but is required for Elements p2tr support whenever that is due.

Supersedes https://github.com/ElementsProject/lightning/pull/8098 using the just minted wally release. Removes now-redundant serialized psbt copies, and enables signature hash caching for faster PSBT signing.

The code that creates signature hashes with transactions should be migrated to PSBT, it's kind of a mix currently and the APIs exposed/wally APIs used don't lend themselves to caching or taproot signing. Thats out of scope for this PR though.

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
