### PR TITLE
make: remove old clnrest directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -816,6 +816,7 @@ install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $
 	@$(NORMAL_INSTALL)
 	$(INSTALL_PROGRAM) $(BIN_PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(PKGLIBEXEC_PROGRAMS) $(DESTDIR)$(pkglibexecdir)
+	@if [ -d "$(DESTDIR)$(plugindir)/clnrest" ]; then rm -rf $(DESTDIR)$(plugindir)/clnrest; fi
 	[ -z "$(PLUGINS)" ] || $(INSTALL_PROGRAM) $(PLUGINS) $(DESTDIR)$(plugindir)
 	for PY in $(PY_PLUGINS); do DIR=`dirname $$PY`; DST=$(DESTDIR)$(plugindir)/`basename $$DIR`; if [ -d $$DST ]; then rm -rf $$DST; fi; $(INSTALL_PROGRAM) -d $$DIR; cp -a $$DIR $$DST ; done
 


### PR DESCRIPTION
Since clnrest is no longer a python plugin it's old directory was not removed by the existing code and leads to an error when running `make install` when upgrading to cln 25.02 from an older version that was previously installed.
Users had to see the error during `make install` and remove the directory themselves and run `make install` again to fix this. The PR hopefully takes care of that automatically.

Fixes https://github.com/ElementsProject/lightning/issues/8141

Don't know if it fixes the nix issue mentioned