### PR TITLE
docs: add RUST_PROFILE to installation steps

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -135,8 +135,8 @@ To build CLN for production:
 ```shell
 poetry install
 ./configure
-poetry run make -j$(($(nproc)-1))
-sudo make install
+RUST_PROFILE=release make
+sudo RUST_PROFILE=release make install
 ```
 
 > 📘 


### PR DESCRIPTION
We should definitely add the tip that people shouold set RUST_PROFILE=release for production builds somewhere, since the default is debug!