### PR TITLE
Handle closed channels better.

### DIFF
--- a/channeld/channeld_wire.csv
+++ b/channeld/channeld_wire.csv
@@ -72,7 +72,6 @@ msgdata,channeld_init,desired_type,channel_type,
 msgdata,channeld_init,dev_disable_commit,?u32,
 msgdata,channeld_init,num_penalty_bases,u32,
 msgdata,channeld_init,pbases,penalty_base,num_penalty_bases
-msgdata,channeld_init,reestablish_only,bool,
 msgdata,channeld_init,experimental_upgrade,bool,
 msgdata,channeld_init,num_inflights,u16,
 msgdata,channeld_init,inflights,inflight,num_inflights

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -99,6 +99,8 @@ void delete_channel(struct channel *channel STEALS, bool completely_eliminate)
 		/* Never open at all, not ours. */
 		if (completely_eliminate)
 			wallet_channel_delete(ld->wallet, channel);
+		else
+			wallet_load_one_closed_channel(ld->wallet, ld->closed_channels, channel->dbid);
 	}
 
 	/* Tell the hsm to forget the channel, needs to be after it's

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -479,7 +479,8 @@ channel_current_inflight(const struct channel *channel);
 /* What's the last feerate used for a funding tx on this channel? */
 u32 channel_last_funding_feerate(const struct channel *channel);
 
-void delete_channel(struct channel *channel STEALS);
+/* Only set completely_eliminate for never-existed channels */
+void delete_channel(struct channel *channel STEALS, bool completely_eliminate);
 
 const char *channel_state_name(const struct channel *channel);
 const char *channel_state_str(enum channel_state state);

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -1321,7 +1321,7 @@ static void forget(struct channel *channel)
 	channel->forgets = tal_arr(channel, struct command *, 0);
 
 	/* Forget the channel. */
-	delete_channel(channel);
+	delete_channel(channel, false);
 
 	for (size_t i = 0; i < tal_count(forgets); i++) {
 		assert(!forgets[i]->json_stream);
@@ -2017,8 +2017,8 @@ void channel_notify_new_block(struct lightningd *ld,
 			    block_height - channel->first_blocknum,
 			    fmt_bitcoin_txid(tmpctx, &channel->funding.txid));
 		/* FIXME: Send an error packet for this case! */
-		/* And forget it. */
-		delete_channel(channel);
+		/* And forget it. COMPLETELY. */
+		delete_channel(channel, true);
 	}
 
 	tal_free(to_forget);

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -363,7 +363,7 @@ static void handle_splice_abort(struct lightningd *ld,
 		return;
 	}
 
-	if (peer_start_channeld(channel, pfd, NULL, false, false)) {
+	if (peer_start_channeld(channel, pfd, NULL, false)) {
 		subd_send_msg(ld->connectd,
 			      take(towire_connectd_peer_connect_subd(NULL,
 			      					     &peer->id,
@@ -1641,8 +1641,7 @@ static void channel_control_errmsg(struct channel *channel,
 bool peer_start_channeld(struct channel *channel,
 			 struct peer_fd *peer_fd,
 			 const u8 *fwd_msg,
-			 bool reconnected,
-			 bool reestablish_only)
+			 bool reconnected)
 {
 	u8 *initmsg;
 	int hsmfd;
@@ -1865,7 +1864,6 @@ bool peer_start_channeld(struct channel *channel,
 					     ? NULL
 					     : (u32 *)&ld->dev_disable_commit,
 				       pbases,
-				       reestablish_only,
 				       ld->experimental_upgrade_protocol,
 				       cast_const2(const struct inflight **,
 						   inflights),

--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include <ccan/asort/asort.h>
 #include <ccan/cast/cast.h>
 #include <ccan/mem/mem.h>
 #include <ccan/tal/str/str.h>
@@ -1927,18 +1928,8 @@ is_fundee_should_forget(struct lightningd *ld,
 			struct channel *channel,
 			u32 block_height)
 {
-	/* BOLT #2:
-	 *
-	 * A non-funding node (fundee):
-	 *   - SHOULD forget the channel if it does not see the
-	 * correct funding transaction after a timeout of 2016 blocks.
-	 */
-	u32 max_funding_unconfirmed;
-
-	if (ld->developer)
-		max_funding_unconfirmed = ld->dev_max_funding_unconfirmed;
-	else
-		max_funding_unconfirmed = 2016;
+	/* 2016 by default */
+	u32 max_funding_unconfirmed = ld->dev_max_funding_unconfirmed;
 
 	/* Only applies if we are fundee. */
 	if (channel->opener == LOCAL)
@@ -1969,15 +1960,41 @@ is_fundee_should_forget(struct lightningd *ld,
 	return true;
 }
 
+/* We want in ascending order, so oldest channels first */
+static int cmp_channel_start(struct channel *const *a, struct channel *const *b, void *unused)
+{
+	if ((*a)->first_blocknum < (*b)->first_blocknum)
+		return -1;
+	else if ((*a)->first_blocknum > (*b)->first_blocknum)
+		return 1;
+	return 0;
+}
+
 /* Notify all channels of new blocks. */
 void channel_notify_new_block(struct lightningd *ld,
 			      u32 block_height)
 {
 	struct peer *peer;
 	struct channel *channel;
-	struct channel **to_forget = tal_arr(NULL, struct channel *, 0);
+	struct channel **to_forget = tal_arr(tmpctx, struct channel *, 0);
 	size_t i;
 	struct peer_node_id_map_iter it;
+
+	/* BOLT #2:
+	 *
+	 * A non-funding node (fundee):
+	 *   - SHOULD forget the channel if it does not see the
+	 * correct funding transaction after a timeout of 2016 blocks.
+	 */
+
+	/* But we give some latitude!  Boltz reported that after a months-long
+	 * fee spike, they had some failed opens when the tx finally got mined.
+	 * They're individually cheap, keep the latest 100. */
+	size_t forgettable_channels_to_keep = 100;
+
+	/* For testing */
+	if (ld->dev_max_funding_unconfirmed != 2016)
+		forgettable_channels_to_keep = 1;
 
 	/* FIXME: keep separate block-aware channel structure instead? */
 	for (peer = peer_node_id_map_first(ld->peers, &it);
@@ -1986,13 +2003,12 @@ void channel_notify_new_block(struct lightningd *ld,
 		list_for_each(&peer->channels, channel, list) {
 			if (channel_state_uncommitted(channel->state))
 				continue;
-			if (is_fundee_should_forget(ld, channel, block_height)) {
+			if (is_fundee_should_forget(ld, channel, block_height))
 				tal_arr_expand(&to_forget, channel);
-			} else
-				/* Let channels know about new blocks,
-				 * required for lease updates */
-				try_update_blockheight(ld, channel,
-						       block_height);
+
+			/* Let channels know about new blocks,
+			 * required for lease updates */
+			try_update_blockheight(ld, channel, block_height);
 		}
 	}
 
@@ -2004,7 +2020,11 @@ void channel_notify_new_block(struct lightningd *ld,
 	 * just the freeing of the channel that occurs, but the
 	 * potential destruction of the peer that invalidates
 	 * memory the inner loop is accessing. */
-	for (i = 0; i < tal_count(to_forget); ++i) {
+	if (tal_count(to_forget) < forgettable_channels_to_keep)
+		return;
+
+	asort(to_forget, tal_count(to_forget), cmp_channel_start, NULL);
+	for (i = 0; i + forgettable_channels_to_keep < tal_count(to_forget); ++i) {
 		channel = to_forget[i];
 		/* Report it first. */
 		log_unusual(channel->log,
@@ -2020,8 +2040,6 @@ void channel_notify_new_block(struct lightningd *ld,
 		/* And forget it. COMPLETELY. */
 		delete_channel(channel, true);
 	}
-
-	tal_free(to_forget);
 }
 
 /* Since this could vanish while we're checking with bitcoind, we need to save

--- a/lightningd/channel_control.h
+++ b/lightningd/channel_control.h
@@ -13,8 +13,7 @@ struct peer;
 bool peer_start_channeld(struct channel *channel,
 			 struct peer_fd *peer_fd,
 			 const u8 *fwd_msg,
-			 bool reconnected,
-			 bool reestablish_only);
+			 bool reconnected);
 
 /* Send message to channeld (if connected) to tell it about depth
  * c.f. dualopen_tell_depth! */

--- a/lightningd/closed_channel.h
+++ b/lightningd/closed_channel.h
@@ -30,4 +30,19 @@ struct closed_channel {
 	u64 last_stable_connection;
 };
 
+static inline const struct channel_id *keyof_closed_channel(const struct closed_channel *cc)
+{
+	return &cc->cid;
+}
+
+size_t hash_cid(const struct channel_id *cid);
+
+static inline bool closed_channel_eq_cid(const struct closed_channel *cc, const struct channel_id *cid)
+{
+	return channel_id_eq(cid, &cc->cid);
+}
+
+HTABLE_DEFINE_NODUPS_TYPE(struct closed_channel, keyof_closed_channel, hash_cid, closed_channel_eq_cid,
+			  closed_channel_map);
+
 #endif /* LIGHTNING_LIGHTNINGD_CLOSED_CHANNEL_H */

--- a/lightningd/closed_channel.h
+++ b/lightningd/closed_channel.h
@@ -28,6 +28,8 @@ struct closed_channel {
 	enum state_change state_change_cause;
 	bool leased;
 	u64 last_stable_connection;
+	/* NULL for older closed channels */
+	const struct shachain *their_shachain;
 };
 
 static inline const struct channel_id *keyof_closed_channel(const struct closed_channel *cc)

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -1990,7 +1990,7 @@ static void handle_channel_locked(struct subd *dualopend,
 	channel_watch_funding(dualopend->ld, channel);
 
 	/* FIXME: LND sigs/update_fee msgs? */
-	peer_start_channeld(channel, peer_fd, NULL, false, NULL);
+	peer_start_channeld(channel, peer_fd, NULL, false);
 	return;
 }
 

--- a/lightningd/dual_open_control.c
+++ b/lightningd/dual_open_control.c
@@ -67,7 +67,7 @@ void channel_unsaved_close_conn(struct channel *channel, const char *why)
 
 	assert(channel->owner);
 	channel_set_owner(channel, NULL);
-	delete_channel(channel);
+	delete_channel(channel, false);
 }
 
 static void channel_saved_err_broken_reconn(struct channel *channel,
@@ -3959,13 +3959,13 @@ static void dualopen_errmsg(struct channel *channel,
 	if (channel_state_uncommitted(channel->state)) {
 		log_info(channel->log, "%s", "Unsaved peer failed."
 			 " Deleting channel.");
-		delete_channel(channel);
+		delete_channel(channel, false);
 		return;
 	}
 	if ((warning || disconnect) && channel_state_open_uncommitted(channel->state)) {
 		log_info(channel->log, "%s", "Commit ready peer failed."
 			 " Deleting channel.");
-		delete_channel(channel);
+		delete_channel(channel, false);
 		return;
 	}
 
@@ -4009,7 +4009,7 @@ static void dualopen_errmsg(struct channel *channel,
 			if (channel_state_open_uncommitted(channel->state)) {
 				log_info(channel->log, "%s", "Commit ready peer can't reconnect."
 					 " Deleting channel.");
-				delete_channel(channel);
+				delete_channel(channel, false);
 				return;
 			}
 			char *err = restart_dualopend(tmpctx,

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -67,6 +67,7 @@
 #include <lightningd/channel.h>
 #include <lightningd/channel_control.h>
 #include <lightningd/channel_gossip.h>
+#include <lightningd/closed_channel.h>
 #include <lightningd/coin_mvts.h>
 #include <lightningd/connect_control.h>
 #include <lightningd/gossip_control.h>
@@ -211,6 +212,11 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	 * in limbo until we get all the parts, or we time them out. */
 	ld->htlc_sets = tal(ld, struct htlc_set_map);
 	htlc_set_map_init(ld->htlc_sets);
+
+	/*~ We keep a map of closed channels.  Mainly so we can respond to peers
+	 * who talk to us about long-closed channels. */
+	ld->closed_channels = tal(ld, struct closed_channel_map);
+	closed_channel_map_init(ld->closed_channels);
 
 	/*~ We have a multi-entry log-book infrastructure: we define a 10MB log
 	 * book to hold all the entries (and trims as necessary), and multiple

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -280,6 +280,9 @@ struct lightningd {
 	/* Contains the codex32 string used with --recover flag */
 	char *recover;
 
+	/* Any channels which are already closed */
+	struct closed_channel_map *closed_channels;
+
 	/* 2, unless overridden by --dev-fd-limit-multiplier */
 	u32 fd_limit_multiplier;
 

--- a/lightningd/memdump.c
+++ b/lightningd/memdump.c
@@ -11,6 +11,7 @@
 #include <gossipd/gossipd_wiregen.h>
 #include <hsmd/hsmd_wiregen.h>
 #include <lightningd/chaintopology.h>
+#include <lightningd/closed_channel.h>
 #include <lightningd/hsm_control.h>
 #include <lightningd/jsonrpc.h>
 #include <lightningd/lightningd.h>
@@ -201,6 +202,7 @@ static bool lightningd_check_leaks(struct command *cmd)
 	memleak_scan_htable(memtable, &ld->htlc_sets->raw);
 	memleak_scan_htable(memtable, &ld->peers->raw);
 	memleak_scan_htable(memtable, &ld->peers_by_dbid->raw);
+	memleak_scan_htable(memtable, &ld->closed_channels->raw);
 	wallet_memleak_scan(memtable, ld->wallet);
 
 	/* Now delete ld and those which it has pointers to. */

--- a/lightningd/onchain_control.c
+++ b/lightningd/onchain_control.c
@@ -528,7 +528,7 @@ static void handle_irrevocably_resolved(struct channel *channel, const u8 *msg U
 	log_info(channel->log, "onchaind complete, forgetting peer");
 
 	/* This will also free onchaind. */
-	delete_channel(channel);
+	delete_channel(channel, false);
 }
 
 

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -455,7 +455,7 @@ static void opening_funder_finished(struct subd *openingd, const u8 *resp,
 	tell_connectd_peer_importance(channel->peer, was_important);
 
 	/* If this fails, it cleans up */
-	if (!peer_start_channeld(channel, peer_fd, NULL, false, NULL))
+	if (!peer_start_channeld(channel, peer_fd, NULL, false))
 		return;
 
 	funding_success(channel);
@@ -562,7 +562,7 @@ static void opening_fundee_finished(struct subd *openingd,
 		wallet_penalty_base_add(ld->wallet, channel->dbid, pbase);
 
 	/* On to normal operation (frees if it fails!) */
-	if (peer_start_channeld(channel, peer_fd, fwd_msg, false, NULL))
+	if (peer_start_channeld(channel, peer_fd, fwd_msg, false))
 		tal_free(uc);
 	return;
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1362,8 +1362,7 @@ static void connect_activate_subd(struct lightningd *ld, struct channel *channel
 
 		if (peer_start_channeld(channel,
 					pfd,
-					NULL, true,
-					NULL)) {
+					NULL, true)) {
 			goto tell_connectd;
 		}
 		close(other_fd);
@@ -1879,8 +1878,7 @@ void peer_spoke(struct lightningd *ld, const u8 *msg)
 				/* Tell channeld to handle reestablish, then it will call closingd */
 				if (peer_start_channeld(channel,
 							pfd,
-							NULL, true,
-							NULL)) {
+							NULL, true)) {
 					goto tell_connectd;
 				}
 				error = towire_warningfmt(tmpctx, &channel_id,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -519,7 +519,7 @@ void channel_errmsg(struct channel *channel,
 	if (channel_state_uncommitted(channel->state)) {
 		log_info(channel->log, "%s", "Unsaved peer failed."
 			 " Deleting channel.");
-		delete_channel(channel);
+		delete_channel(channel, false);
 		return;
 	}
 
@@ -3432,7 +3432,7 @@ static void process_dev_forget_channel(struct bitcoind *bitcoind UNUSED,
 	forget->channel->error = towire_errorfmt(forget->channel,
 						 &forget->channel->cid,
 						 "dev_forget_channel");
-	delete_channel(forget->channel);
+	delete_channel(forget->channel, false);
 
 	was_pending(command_success(forget->cmd, response));
 }

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -44,6 +44,7 @@
 #include <lightningd/channel.h>
 #include <lightningd/channel_control.h>
 #include <lightningd/channel_gossip.h>
+#include <lightningd/closed_channel.h>
 #include <lightningd/closing_control.h>
 #include <lightningd/connect_control.h>
 #include <lightningd/dual_open_control.h>
@@ -1797,7 +1798,10 @@ void peer_connected(struct lightningd *ld, const u8 *msg)
 	plugin_hook_call_peer_connected(ld, cmd_id, hook_payload);
 }
 
-static void send_reestablish(struct lightningd *ld, struct channel *channel)
+static void send_reestablish(struct peer *peer,
+			     const struct channel_id *cid,
+			     const struct shachain *their_shachain,
+			     u64 local_next_index)
 {
 	u8 *msg;
 	struct secret last_remote_per_commit_secret;
@@ -1810,30 +1814,42 @@ static void send_reestablish(struct lightningd *ld, struct channel *channel)
 	 *       - MUST set `your_last_per_commitment_secret` to the last
 	 *         `per_commitment_secret` it received
 	 */
-	num_revocations = revocations_received(&channel->their_shachain.chain);
+	num_revocations = revocations_received(their_shachain);
 	if (num_revocations == 0)
 		memset(&last_remote_per_commit_secret, 0,
 		       sizeof(last_remote_per_commit_secret));
-	else if (!shachain_get_secret(&channel->their_shachain.chain,
+	else if (!shachain_get_secret(their_shachain,
 				      num_revocations-1,
 				      &last_remote_per_commit_secret)) {
-		channel_fail_permanent(channel,
-				       REASON_LOCAL,
-				       "Could not get revocation secret %"PRIu64,
-				       num_revocations-1);
+		log_peer_broken(peer->ld->log, &peer->id,
+				"%s: cannot get shachain secret %"PRIu64" to send reestablish",
+				fmt_channel_id(tmpctx, cid), num_revocations-1);
 		return;
 	}
 
-	msg = towire_channel_reestablish(tmpctx, &channel->cid,
-					 channel->next_index[LOCAL],
+	/* BOLT #2:
+	 * The sending node:
+	 *   - MUST set `next_commitment_number` to the commitment number of the
+	 *   next `commitment_signed` it expects to receive.
+	 *   - MUST set `next_revocation_number` to the commitment number of the
+	 *   next `revoke_and_ack` message it expects to receive.
+	 *   - MUST set `my_current_per_commitment_point` to a valid point.
+	 *   - if `next_revocation_number` equals 0:
+	 *     - MUST set `your_last_per_commitment_secret` to all zeroes
+	 *   - otherwise:
+	 *     - MUST set `your_last_per_commitment_secret` to the last `per_commitment_secret` it received
+	 */
+	msg = towire_channel_reestablish(tmpctx, cid,
+					 local_next_index,
 					 num_revocations,
 					 &last_remote_per_commit_secret,
-					 &channel->channel_info.remote_per_commit,
+					 /* Any valid point works, since static_remotekey */
+					 &peer->ld->our_pubkey,
 					 /* No upgrade for you, since we're closed! */
 					 NULL);
-	subd_send_msg(ld->connectd,
-		      take(towire_connectd_peer_send_msg(NULL, &channel->peer->id,
-							 channel->peer->connectd_counter,
+	subd_send_msg(peer->ld->connectd,
+		      take(towire_connectd_peer_send_msg(NULL, &peer->id,
+							 peer->connectd_counter,
 							 msg)));
 }
 
@@ -1847,6 +1863,7 @@ void peer_spoke(struct lightningd *ld, const u8 *msg)
 	u16 msgtype;
 	u64 connectd_counter;
 	struct channel *channel;
+	struct closed_channel *closed_channel;
 	struct channel_id channel_id;
 	struct peer *peer;
 	bool dual_fund;
@@ -1885,7 +1902,9 @@ void peer_spoke(struct lightningd *ld, const u8 *msg)
 							  "Trouble in paradise?");
 				goto send_error;
 			}
-			send_reestablish(ld, channel);
+			send_reestablish(peer, &channel->cid,
+					 &channel->their_shachain.chain,
+					 channel->next_index[LOCAL]);
 		}
 
 		/* If we have a canned error for this channel, send it now */
@@ -1978,6 +1997,20 @@ void peer_spoke(struct lightningd *ld, const u8 *msg)
 		/* FIXME: Send informative error? */
 		close(other_fd);
 		return;
+
+	case WIRE_CHANNEL_REESTABLISH:
+		/* Maybe a previously closed channel? */
+		closed_channel = closed_channel_map_get(peer->ld->closed_channels, &channel_id);
+		if (closed_channel && closed_channel->their_shachain) {
+			send_reestablish(peer, &closed_channel->cid,
+					 closed_channel->their_shachain,
+					 closed_channel->next_index[LOCAL]);
+			log_peer_info(ld->log, &peer->id, "Responded to reestablish for long-closed channel %s",
+				      fmt_channel_id(tmpctx, &channel_id));
+			error = towire_errorfmt(tmpctx, &channel_id,
+						"Channel is closed and forgotten");
+			goto send_error;
+		}
 	}
 
 	/* Weird message?  Log and reply with error. */

--- a/lightningd/test/run-find_my_abspath.c
+++ b/lightningd/test/run-find_my_abspath.c
@@ -120,6 +120,9 @@ void handle_early_opts(struct lightningd *ld UNNEEDED, int argc UNNEEDED, char *
 /* Generated stub for handle_opts */
 void handle_opts(struct lightningd *ld UNNEEDED)
 { fprintf(stderr, "handle_opts called!\n"); abort(); }
+/* Generated stub for hash_cid */
+size_t hash_cid(const struct channel_id *cid UNNEEDED)
+{ fprintf(stderr, "hash_cid called!\n"); abort(); }
 /* Generated stub for hash_htlc_key */
 size_t hash_htlc_key(const struct htlc_key *htlc_key UNNEEDED)
 { fprintf(stderr, "hash_htlc_key called!\n"); abort(); }

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -243,7 +243,7 @@ struct anchor_details *create_anchor_details(const tal_t *ctx UNNEEDED,
 					     const struct bitcoin_tx *tx UNNEEDED)
 { fprintf(stderr, "create_anchor_details called!\n"); abort(); }
 /* Generated stub for delete_channel */
-void delete_channel(struct channel *channel STEALS UNNEEDED)
+void delete_channel(struct channel *channel STEALS UNNEEDED, bool completely_eliminate UNNEEDED)
 { fprintf(stderr, "delete_channel called!\n"); abort(); }
 /* Generated stub for depthcb_update_scid */
 bool depthcb_update_scid(struct channel *channel UNNEEDED,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -362,6 +362,9 @@ u32 get_feerate(const struct fee_states *fee_states UNNEEDED,
 		enum side opener UNNEEDED,
 		enum side side UNNEEDED)
 { fprintf(stderr, "get_feerate called!\n"); abort(); }
+/* Generated stub for hash_cid */
+size_t hash_cid(const struct channel_id *cid UNNEEDED)
+{ fprintf(stderr, "hash_cid called!\n"); abort(); }
 /* Generated stub for hash_htlc_key */
 size_t hash_htlc_key(const struct htlc_key *htlc_key UNNEEDED)
 { fprintf(stderr, "hash_htlc_key called!\n"); abort(); }

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -904,8 +904,7 @@ bool peer_restart_dualopend(struct peer *peer UNNEEDED,
 bool peer_start_channeld(struct channel *channel UNNEEDED,
 			 struct peer_fd *peer_fd UNNEEDED,
 			 const u8 *fwd_msg UNNEEDED,
-			 bool reconnected UNNEEDED,
-			 bool reestablish_only UNNEEDED)
+			 bool reconnected UNNEEDED)
 { fprintf(stderr, "peer_start_channeld called!\n"); abort(); }
 /* Generated stub for peer_start_dualopend */
 bool peer_start_dualopend(struct peer *peer UNNEEDED, struct peer_fd *peer_fd UNNEEDED,

--- a/tests/plugins/channeld_fakenet.c
+++ b/tests/plugins/channeld_fakenet.c
@@ -1057,7 +1057,6 @@ static struct channel *handle_init(struct info *info, const u8 *init_msg)
 	u32 minimum_depth, lease_expiry;
 	struct secret last_remote_per_commit_secret;
 	struct penalty_base *pbases;
-	bool reestablish_only;
 	struct channel_type *channel_type;
 	u32 feerate_min, feerate_max, feerate_penalty;
 	struct pubkey remote_per_commit;
@@ -1137,7 +1136,6 @@ static struct channel *handle_init(struct info *info, const u8 *init_msg)
 				    &channel_type,
 				    &dev_disable_commit,
 				    &pbases,
-				    &reestablish_only,
 				    &experimental_upgrade,
 				    &inflights,
 				    &local_alias))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1393,7 +1393,7 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     except RpcError as err:
         assert "disconnected during connection" in err.error
 
-    l1.daemon.wait_for_log('Unknown channel .* for WIRE_CHANNEL_REESTABLISH')
+    l1.daemon.wait_for_log('Responded to reestablish for long-closed channel')
     wait_for(lambda: len(l1.rpc.listpeers()['peers']) == 0)
     wait_for(lambda: len(l2.rpc.listpeers()['peers']) == 0)
 

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -285,7 +285,8 @@ struct peer *new_peer(struct lightningd *ld UNNEEDED, u64 dbid UNNEEDED,
 		      bool connected_incoming UNNEEDED)
 { fprintf(stderr, "new_peer called!\n"); abort(); }
 /* Generated stub for notify_chain_mvt */
-void notify_chain_mvt(struct lightningd *ld UNNEEDED, const struct chain_coin_mvt *mvt UNNEEDED)
+void notify_chain_mvt(struct lightningd *ld UNNEEDED,
+		      const struct chain_coin_mvt *chain_mvt UNNEEDED)
 { fprintf(stderr, "notify_chain_mvt called!\n"); abort(); }
 /* Generated stub for notify_forward_event */
 void notify_forward_event(struct lightningd *ld UNNEEDED,

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -112,6 +112,9 @@ void get_channel_basepoints(struct lightningd *ld UNNEEDED,
 			    struct basepoints *local_basepoints UNNEEDED,
 			    struct pubkey *local_funding_pubkey UNNEEDED)
 { fprintf(stderr, "get_channel_basepoints called!\n"); abort(); }
+/* Generated stub for hash_cid */
+size_t hash_cid(const struct channel_id *cid UNNEEDED)
+{ fprintf(stderr, "hash_cid called!\n"); abort(); }
 /* Generated stub for htlc_in_check */
 struct htlc_in *htlc_in_check(const struct htlc_in *hin UNNEEDED, const char *abortstr UNNEEDED)
 { fprintf(stderr, "htlc_in_check called!\n"); abort(); }
@@ -285,8 +288,7 @@ struct peer *new_peer(struct lightningd *ld UNNEEDED, u64 dbid UNNEEDED,
 		      bool connected_incoming UNNEEDED)
 { fprintf(stderr, "new_peer called!\n"); abort(); }
 /* Generated stub for notify_chain_mvt */
-void notify_chain_mvt(struct lightningd *ld UNNEEDED,
-		      const struct chain_coin_mvt *chain_mvt UNNEEDED)
+void notify_chain_mvt(struct lightningd *ld UNNEEDED, const struct chain_coin_mvt *mvt UNNEEDED)
 { fprintf(stderr, "notify_chain_mvt called!\n"); abort(); }
 /* Generated stub for notify_forward_event */
 void notify_forward_event(struct lightningd *ld UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -940,8 +940,7 @@ bool peer_restart_dualopend(struct peer *peer UNNEEDED,
 bool peer_start_channeld(struct channel *channel UNNEEDED,
 			 struct peer_fd *peer_fd UNNEEDED,
 			 const u8 *fwd_msg UNNEEDED,
-			 bool reconnected UNNEEDED,
-			 bool reestablish_only UNNEEDED)
+			 bool reconnected UNNEEDED)
 { fprintf(stderr, "peer_start_channeld called!\n"); abort(); }
 /* Generated stub for peer_start_dualopend */
 bool peer_start_dualopend(struct peer *peer UNNEEDED, struct peer_fd *peer_fd UNNEEDED,

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -380,6 +380,9 @@ u32 get_block_height(const struct chain_topology *topo UNNEEDED)
 /* Generated stub for get_network_blockheight */
 u32 get_network_blockheight(const struct chain_topology *topo UNNEEDED)
 { fprintf(stderr, "get_network_blockheight called!\n"); abort(); }
+/* Generated stub for hash_cid */
+size_t hash_cid(const struct channel_id *cid UNNEEDED)
+{ fprintf(stderr, "hash_cid called!\n"); abort(); }
 /* Generated stub for hsmd_wire_name */
 const char *hsmd_wire_name(int e UNNEEDED)
 { fprintf(stderr, "hsmd_wire_name called!\n"); abort(); }
@@ -701,12 +704,10 @@ struct uncommitted_channel *new_uncommitted_channel(struct peer *peer UNNEEDED)
 bool node_announcement_same(const u8 *nann1 UNNEEDED, const u8 *nann2 UNNEEDED)
 { fprintf(stderr, "node_announcement_same called!\n"); abort(); }
 /* Generated stub for notify_chain_mvt */
-void notify_chain_mvt(struct lightningd *ld UNNEEDED,
-		      const struct chain_coin_mvt *chain_mvt UNNEEDED)
+void notify_chain_mvt(struct lightningd *ld UNNEEDED, const struct chain_coin_mvt *mvt UNNEEDED)
 { fprintf(stderr, "notify_chain_mvt called!\n"); abort(); }
 /* Generated stub for notify_channel_mvt */
-void notify_channel_mvt(struct lightningd *ld UNNEEDED,
-			const struct channel_coin_mvt *chan_mvt UNNEEDED)
+void notify_channel_mvt(struct lightningd *ld UNNEEDED, const struct channel_coin_mvt *mvt UNNEEDED)
 { fprintf(stderr, "notify_channel_mvt called!\n"); abort(); }
 /* Generated stub for notify_channel_open_failed */
 void notify_channel_open_failed(struct lightningd *ld UNNEEDED,
@@ -2118,7 +2119,7 @@ static bool test_channel_inflight_crud(struct lightningd *ld, const tal_t *ctx)
 
 	/* do inflights get cleared when the channel is closed?*/
 	dbid = chan->dbid;
-	delete_channel(chan, false); /* Also clears up peer! */
+	delete_channel(chan, true); /* Also clears up peer! */
 	CHECK_MSG(count_inflights(w, dbid) == 0, "inflights cleaned up");
 	db_commit_transaction(w->db);
 	CHECK_MSG(!wallet_err, wallet_err);
@@ -2364,6 +2365,8 @@ int main(int argc, const char *argv[])
 	ld->htlcs_out = tal(ld, struct htlc_out_map);
 	htlc_out_map_init(ld->htlcs_out);
 	list_head_init(&ld->wait_commands);
+	ld->closed_channels = tal(ld, struct closed_channel_map);
+	closed_channel_map_init(ld->closed_channels);
 
 	/* We do a runtime test here, so we still check compile! */
 	if (HAVE_SQLITE3) {

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -701,10 +701,12 @@ struct uncommitted_channel *new_uncommitted_channel(struct peer *peer UNNEEDED)
 bool node_announcement_same(const u8 *nann1 UNNEEDED, const u8 *nann2 UNNEEDED)
 { fprintf(stderr, "node_announcement_same called!\n"); abort(); }
 /* Generated stub for notify_chain_mvt */
-void notify_chain_mvt(struct lightningd *ld UNNEEDED, const struct chain_coin_mvt *mvt UNNEEDED)
+void notify_chain_mvt(struct lightningd *ld UNNEEDED,
+		      const struct chain_coin_mvt *chain_mvt UNNEEDED)
 { fprintf(stderr, "notify_chain_mvt called!\n"); abort(); }
 /* Generated stub for notify_channel_mvt */
-void notify_channel_mvt(struct lightningd *ld UNNEEDED, const struct channel_coin_mvt *mvt UNNEEDED)
+void notify_channel_mvt(struct lightningd *ld UNNEEDED,
+			const struct channel_coin_mvt *chan_mvt UNNEEDED)
 { fprintf(stderr, "notify_channel_mvt called!\n"); abort(); }
 /* Generated stub for notify_channel_open_failed */
 void notify_channel_open_failed(struct lightningd *ld UNNEEDED,
@@ -2116,7 +2118,7 @@ static bool test_channel_inflight_crud(struct lightningd *ld, const tal_t *ctx)
 
 	/* do inflights get cleared when the channel is closed?*/
 	dbid = chan->dbid;
-	delete_channel(chan); /* Also clears up peer! */
+	delete_channel(chan, false); /* Also clears up peer! */
 	CHECK_MSG(count_inflights(w, dbid) == 0, "inflights cleaned up");
 	db_commit_transaction(w->db);
 	CHECK_MSG(!wallet_err, wallet_err);

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -1672,7 +1672,7 @@ static struct short_channel_id *db_col_optional_scid(const tal_t *ctx,
 	if (db_col_is_null(stmt, colname))
 		return NULL;
 
-	scid = tal(tmpctx, struct short_channel_id);
+	scid = tal(ctx, struct short_channel_id);
 	*scid = db_col_short_channel_id(stmt, colname);
 	return scid;
 }

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -700,6 +700,11 @@ void wallet_channel_close(struct wallet *w,
 			  const struct channel *chan);
 
 /**
+ * If it was never used, we can forget it entirely after wallet_channel_close.
+ */
+void wallet_channel_delete(struct wallet *w, const struct channel *channel);
+
+/**
  * Adds a channel state change history entry into the database
  */
 void wallet_state_change_add(struct wallet *w,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -21,6 +21,7 @@ struct amount_msat;
 struct invoices;
 struct channel;
 struct channel_inflight;
+struct closed_channel_map;
 struct htlc_in;
 struct htlc_in_map;
 struct htlc_out;
@@ -733,13 +734,25 @@ bool wallet_init_channels(struct wallet *w);
 
 /**
  * wallet_load_closed_channels -- Loads dead channels.
- * @ctx: context to allocate returned array from
  * @w: wallet to load from
+ * @cc_map: the map to fill
  *
  * These will be all state CLOSED.
  */
-struct closed_channel **wallet_load_closed_channels(const tal_t *ctx,
-						    struct wallet *w);
+void wallet_load_closed_channels(struct wallet *w,
+				 struct closed_channel_map *cc_map);
+
+/**
+ * wallet_load_one_closed_channel -- Loads one single (just-closed) channel.
+ * @w: wallet to load from
+ * @cc_map: the map to fill
+ * @wallet_id: the id of the channel.
+ *
+ * Must be newly closed via wallet_channel_close().
+ */
+void wallet_load_one_closed_channel(struct wallet *w,
+				    struct closed_channel_map *cc_map,
+				    u64 wallet_id);
 
 /**
  * wallet_channel_stats_incr_* - Increase channel statistics.


### PR DESCRIPTION
This does several nice things:
1. Cleans up our closed channel handling.
2. Loosens the timeout of 2016 blocks on unopened channels: we allow 100 channels to go over that before we start timing them out (requested by @michael1011 )

