### PR TITLE
dev: Start `dev-listaddrs` index from 1 not 0

### DIFF
--- a/wallet/walletrpc.c
+++ b/wallet/walletrpc.c
@@ -287,7 +287,7 @@ static struct command_result *json_listaddrs(struct command *cmd,
 	response = json_stream_success(cmd);
 	json_array_start(response, "addresses");
 
-	for (s64 keyidx = 0; keyidx <= *bip32_max_index; keyidx++) {
+	for (s64 keyidx = 1; keyidx <= *bip32_max_index; keyidx++) {
 
 		if (keyidx == BIP32_INITIAL_HARDENED_CHILD){
 			break;


### PR DESCRIPTION
Adopting the same `list` standard as other RPCs, where the start index begins at 1.

Changelog-None.
