### PR TITLE
Making `lightningd.service` consistent with `make install`

### DIFF
--- a/contrib/init/lightningd.service
+++ b/contrib/init/lightningd.service
@@ -15,7 +15,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/lightningd --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid
+ExecStart=/usr/local/bin/lightningd --conf /etc/lightningd/lightningd.conf --pid-file=/run/lightningd/lightningd.pid
 
 # Creates /run/lightningd owned by bitcoin
 RuntimeDirectory=lightningd


### PR DESCRIPTION
Following the installation process on the [docs](https://github.com/ElementsProject/lightning/blob/master/doc/getting-started/getting-started/installation.md), the `make install` command installs binaries into `/usr/local/bin`, which is inconsistent with the service file `lightningd.service`, which look for `lightningd` into `/usr/bin`