### PR TITLE
lightningd: allow bitcoind_getrawblockbyheight callback to free call struct

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -477,8 +477,14 @@ getrawblockbyheight_callback(const char *buf, const jsmntok_t *toks,
 	const char *block_str, *err;
 	struct bitcoin_blkid blkid;
 	struct bitcoin_block *blk;
+	const tal_t *ctx;
 	trace_span_resume(call);
 	trace_span_end(call);
+
+	/* Callback may free parent of call, so steal onto context to
+	 * free if it doesn't */
+	ctx = tal(NULL, char);
+	tal_steal(ctx, call);
 
 	/* If block hash is `null`, this means not found! Call the callback
 	 * with NULL values. */
@@ -506,7 +512,7 @@ getrawblockbyheight_callback(const char *buf, const jsmntok_t *toks,
 	call->cb(call->bitcoind, call->height, &blkid, blk, call->cb_arg);
 
 clean:
-	tal_free(call);
+	tal_free(ctx);
 }
 
 void bitcoind_getrawblockbyheight_(const tal_t *ctx,


### PR DESCRIPTION
Fixes: https://github.com/ElementsProject/lightning/issues/8182

Use the indirect-free trick, otherwise this can happen:

```
2025-03-28T10:46:16.437Z BROKEN lightningd: FATAL SIGNAL 6 (version v25.02)
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: common/daemon.c:41 (send_backtrace) 0x6447525af68c
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: common/daemon.c:78 (crashdump) 0x6447525af6db
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0 ((null)) 0x7783e2c4532f
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ./nptl/pthread_kill.c:44 (__pthread_kill_implementation) 0x7783e2c9eb2c
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ./nptl/pthread_kill.c:78 (__pthread_kill_internal) 0x7783e2c9eb2c
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ./nptl/pthread_kill.c:89 (__GI___pthread_kill) 0x7783e2c9eb2c
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ../sysdeps/posix/raise.c:26 (__GI_raise) 0x7783e2c4527d
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ./stdlib/abort.c:79 (__GI_abort) 0x7783e2c288fe
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ccan/ccan/tal/tal.c:95 (call_error) 0x644752675535
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ccan/ccan/tal/tal.c:169 (check_bounds) 0x6447526755de
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ccan/ccan/tal/tal.c:180 (to_tal_hdr) 0x644752675618
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: ccan/ccan/tal/tal.c:525 (tal_free) 0x644752676001
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: lightningd/bitcoind.c:509 (getrawblockbyheight_callback) 0x64475252c01b
2025-03-28T10:46:16.437Z BROKEN lightningd: backtrace: lightningd/plugin.c:661 (plugin_response_handle) 0x64475257be0a
```

Changelog-Fixed: lightningd: occasional crash on bitcoind callback.

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
