### PR TITLE
common: fix crash when we have a localmod with unrepresentable fee values

### DIFF
--- a/common/gossmap.c
+++ b/common/gossmap.c
@@ -551,10 +551,11 @@ static void fill_from_update(struct gossmap *map,
 	    || hc->delay != delay) {
 		hc->htlc_max = 0;
 		hc->enabled = false;
-		logcb(cbarg, LOG_DBG,
-		      "Bad cupdate for %s, ignoring (delta=%u, fee=%u/%u)",
-		      fmt_short_channel_id_dir(tmpctx, scidd),
-		      delay, base_fee, proportional_fee);
+		if (logcb)
+			logcb(cbarg, LOG_DBG,
+			      "Bad cupdate for %s, ignoring (delta=%u, fee=%u/%u)",
+			      fmt_short_channel_id_dir(tmpctx, scidd),
+			      delay, base_fee, proportional_fee);
 	}
 }
 


### PR DESCRIPTION
We handed NULL as the logcb, resulting in a very uninformative crash:

```
2025-03-14T03:46:36.447Z INFO    lightningd: Server started with public key 03d67f36c4f81789e2fe425028bacc96b199813eae426c517f589a45f1136c1fe5, alias Jubilee (color #dc42f4) and lightningd v25.02
topology: FATAL SIGNAL 11 (version v25.02)
0x560037f64aad send_backtrace
        common/daemon.c:33
0x560037f64b49 crashdump
        common/daemon.c:78
0x7f6c41ff351f ???
        ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
0x0 ???
        ???:0
```

Changelog-Fixed: `topology` crash on invoice creation if a peer had a really high feerate.
Fixes: https://github.com/ElementsProject/lightning/issues/8156

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
