### PR TITLE
lightningd: fix anchorspend HTLC deadline logic.

### DIFF
--- a/lightningd/anchorspend.c
+++ b/lightningd/anchorspend.c
@@ -204,7 +204,12 @@ struct anchor_details *create_anchor_details(const tal_t *ctx,
 			continue;
 
 		v.msat = hout->msat;
-		v.block = hout->cltv_expiry;
+		/* Our real deadline here is the INCOMING htlc.  If it's us, use the default so we don't leak
+		 * too much information about it. */
+		if (hout->in)
+			v.block = hout->in->cltv_expiry;
+		else
+			v.block = hout->cltv_expiry + ld->config.cltv_expiry_delta;
 		v.important = true;
 		tal_arr_expand(&adet->vals, v);
 	}


### PR DESCRIPTION
It's not the *outgoing* HTLC which sets the deadline, it's the incoming.

Reported-by: @whitslack

Changelog-Fixed: Protocol: Egregious anchor fee paid for unilateral close txs due to HTLC timeouts; it's not as urgent as our code made out!
Fixes: https://github.com/ElementsProject/lightning/issues/8174

(There are other issues with our exact feerate calculation, but those will come in a separate PR for the next release)