### PR TITLE
[WIP] pre-commit hooks demo

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,5 @@ UseTab: Always
 BreakBeforeBraces: Linux
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
+SortIncludes: CaseSensitive
+IncludeBlocks: Preserve

--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,3 @@
+connectd
+crate
+mut

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+
+count = true
+ignore-words = .codespellignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,14 @@ repos:
   hooks:
     - id: shellcheck
       args: [ -fgcc ]
+
+- repo: local
+  hooks:
+    # Reimplementation of `make check-amount-access` for pygrep.
+    - id: check-amount-access
+      name: Check amount_msat and amount_sat members are not accessed directly
+      description: "Don't access amount_msat and amount_sat members directly without a good reason since it risks overflow."
+      language: pygrep
+      entry: (->|\.)(milli)?satoshis(?!.*\/\*\ Raw:)|(?<!sizeof)\(struct\ amount_(m)?sat\)
+      types: [ c ]
+      exclude: common/amount|.*/test/.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,25 @@ repos:
       description: Checks for common misspellings.
       exclude: ccan|contrib|tests/fuzz/corpora
 
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v3.6.0
+  hooks:
+    - id: conventional-pre-commit
+      stages: [commit-msg]
+      args:
+        - --scopes=askrene,bkpr,channeld,cli,closingd,cln-grpc,cln-rpc,common,connectd,db,gossipd,hsmd,lightningd,onchaind,openingd,pay,pylightning,pyln-client,pyln-spec,pyln-testing,pytest,splice,tools,wallet,wire,xpay
+        - --verbose
+        - build
+        - chore
+        - ci
+        - docs
+        - feat
+        - fix
+        - style
+        - refactor
+        - perf
+        - test
+
 - repo: local
   hooks:
     # Reimplementation of `make check-amount-access` for pygrep.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,11 @@ repos:
       entry: (->|\.)(milli)?satoshis(?!.*\/\*\ Raw:)|(?<!sizeof)\(struct\ amount_(m)?sat\)
       types: [ c ]
       exclude: common/amount|.*/test/.*
+
+    # Reimplementation of `make check-discouraged-functions` for pygrep.
+    - id: check-discouraged-functions
+      name: Check for usage of discouraged funtions
+      language: pygrep
+      entry: '[^a-z_/](?:fgets|fputs|gets|scanf|sprintf)\('
+      types: [ c ]
+      exclude: ccan|contrib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,29 @@ repos:
       entry: clang-format
       types: [ c ]
 
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.30.0
+  hooks:
+    - id: check-jsonschema
+      name: check doc JSON schemas
+      args: ["--schemafile", "doc/rpc-schema-draft.json"]
+      files: ^doc/schemas/.*\.json$
+      types: [ json ]
+
+    - id: check-metaschema
+      name: check doc JSON metaschemas
+      args: ["--verbose"]
+      files: ^doc/schemas/.*\.json$
+      types: [ json ]
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+    - id: pretty-format-json
+      args: [ "--indent", "2", "--no-sort-keys" ]
+      files: ^doc/schemas/.*\.json$
+      types: [ json ]
+
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,13 @@ repos:
       entry: clang-format
       types: [ c ]
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+    - id: codespell
+      description: Checks for common misspellings.
+      exclude: ccan|contrib|tests/fuzz/corpora
+
 - repo: local
   hooks:
     # Reimplementation of `make check-amount-access` for pygrep.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,9 @@ repos:
     - id: ruff-format
       args: [ --diff ]
       exclude: "contrib/pyln-grpc-proto/pyln/grpc/(primitives|node)_pb2(|_grpc).py"
+
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
+  hooks:
+    - id: shellcheck
+      args: [ -fgcc ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,18 @@ repos:
     - id: shellcheck
       args: [ -fgcc ]
 
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v19.1.4
+  hooks:
+    - id: clang-format
+      description: Runs formatting checks on the c code and and throws errors if suggestions
+        are detected, without modifying the code. Style is defined in `.clang-format`. When
+        encountering formatting-related errors, run `clang-format -i <path-to-file>` to make
+        (destructively) the suggestions and evalute the resulting diff for more context.
+      args: [ --dry-run, -Werror ]
+      entry: clang-format
+      types: [ c ]
+
 - repo: local
   hooks:
     # Reimplementation of `make check-amount-access` for pygrep.


### PR DESCRIPTION
This PR expands upon #7884 to demo some potential DX improvements through adding [pre-commit](https://pre-commit.com) hooks. It contains the following features:
- Run `shellcheck`.
- Re-implements `make check-amount-access` as a local pygrep hook.
- Implements a clang-format hook to fail on suggestion warnings with additional configuration to sort includes.
- Re-implements `make check-discouraged-functions` as a local pygrep hook.
- Runs `codespell` to check for common spelling errors.
- Runs [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema) to validate schemas and metaschemeas in the `doc/` directory.
    - Last checked, this exposed a few invalidations in a few of the the schema definitions, and seems particularly useful.
- Pretty-formats the `JSON` schemas
- Checks Git commit message conforms to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard, using a best-guess prototype for the list of application scopes.

Many of these experiments output a lot of errors/warnings against the existing code. Generally, `pre-commit` should be only checking the current changeset and provoking the developer to address issues incrementally. Interested parties can run specific hooks on the entire codebase with `pre-commit run --all-files [hook-id]`

Particular checks and standards may not be applicable or aligned with the workflow of the maintainers. I'd be happy and interested to break this work into separate PRs for specific hooks where there is interest, or explore adding more.

Relates to #7765.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

