### PR TITLE
trace: handle key being freed while suspended.

### DIFF
--- a/common/trace.h
+++ b/common/trace.h
@@ -15,8 +15,10 @@ void trace_span_remote(u8 trace_id[TRACE_ID_SIZE], u8 span_id[SPAN_ID_SIZE]);
 
 #define TRACE_LBL __FILE__ ":" stringify(__LINE__)
 void trace_span_suspend_(const void *key, const char *lbl);
+void trace_span_suspend_may_free_(const void *key, const char *lbl);
 void trace_span_resume_(const void *key, const char *lbl);
 #define trace_span_suspend(key) trace_span_suspend_(key, TRACE_LBL)
+#define trace_span_suspend_may_free(key) trace_span_suspend_may_free_(key, TRACE_LBL)
 #define trace_span_resume(key) trace_span_resume_(key, TRACE_LBL)
 
 #endif /* LIGHTNING_COMMON_TRACE_H */

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -1110,7 +1110,7 @@ send_outreq(const struct out_req *req)
 	 * callback. */
 	trace_span_start("jsonrpc", req);
 	trace_span_tag(req, "id", req->id);
-	trace_span_suspend(req);
+	trace_span_suspend_may_free(req);
 
 	ld_rpc_send(req->cmd->plugin, req->js);
 	notleak_with_children(req->cmd);


### PR DESCRIPTION
This happens with autoclean, which does a datastore request then frees the parent command without waiting for a response (see clean_finished).

This leaks a trace, and causes a crash if the pointer is later reused.

My solution is to create a trace variant which declares the trace key to be a tal ptr and then we can clean up in the destructor if this happens. This fixes the issue for me.
