### PR TITLE
make: remove plugins/clnrest dir prior to building clnrest

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -304,6 +304,7 @@ CLN_REST_PLUGIN_SRC = $(shell find plugins/rest-plugin/src -name "*.rs")
 target/${RUST_PROFILE}/cln-grpc: ${CLN_PLUGIN_SRC} ${CLN_GRPC_PLUGIN_SRC} $(MSGGEN_GENALL) $(MSGGEN_GEN_ALL)
 	cargo build ${CARGO_OPTS} --bin cln-grpc
 target/${RUST_PROFILE}/clnrest: ${CLN_REST_PLUGIN_SRC}
+	@if [ -d "plugins/clnrest" ]; then rm -rf plugins/clnrest; fi
 	cargo build ${CARGO_OPTS} --bin clnrest
 
 ifneq ($(RUST),0)


### PR DESCRIPTION
Inspired by #8159, this should be the last step to cleaning up traces of the old plugin during build - `make clean` and `make install` have already been addressed.

When building in the same directory used for <=v24.11, this would occur:
  cp: cannot create regular file plugins/clnrest: Permission denied
  make: *** [plugins/Makefile:149: plugins/clnrest] Error 1
  make: *** Waiting for unfinished jobs....

Remove the old directory so the new rust binary can take its place.

Changelog-Fixed: `make` cleans up old clnrest directory prior to building the new plugin.

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
