### PR TITLE
docs: Update install docs for v25.02

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -44,7 +44,7 @@ See all of the docker images for Core Lightning on [Docker Hub](https://hub.dock
 
 # Third-party apps
 
-For a GUI experience, you can install and use Core Lightning via a variety of third-party applications such as [Ride the Lightning](https://www.ridethelightning.info/), [Umbrel](https://getumbrel.com/), [BTCPayServer](https://btcpayserver.org/), [Raspiblitz](https://raspiblitz.org/), [Embassy](https://start9.com/). 
+For a GUI experience, you can install and use Core Lightning via a variety of third-party applications such as [Ride the Lightning](https://www.ridethelightning.info/), [Umbrel](https://getumbrel.com/), [BTCPayServer](https://btcpayserver.org/), [Raspiblitz](https://raspiblitz.org/), and [Start9](https://start9.com/).
 
 Core Lightning is also available on nixOS via the [nix-bitcoin](https://github.com/fort-nix/nix-bitcoin/) project.
 
@@ -64,7 +64,7 @@ For actually doing development and running the tests, you will also need:
 - pip3: to install python-bitcoinlib
 - valgrind: for extra debugging checks
 
-You will also need a version of bitcoind with segregated witness and `estimatesmartfee` with `ECONOMICAL` mode support, such as the 0.16 or above.
+You will also need a version of bitcoind with segregated witness and `estimatesmartfee` with `ECONOMICAL` mode support. Version 0.16 or above should work.
 
 ## To Build on Ubuntu
 
@@ -80,6 +80,9 @@ sudo apt-get install -y \
 pip3 install --upgrade pip
 pip3 install --user poetry
 ```
+
+(If installing `poetry` with `pip` as above fails, try installing it with the [official poetry installer](https://python-poetry.org/docs/#installing-with-the-official-installer).)
+
 
 If you don't have Bitcoin installed locally you'll need to install that as well. It's now available via [snapd](https://snapcraft.io/bitcoin-core).
 
@@ -101,7 +104,7 @@ cd lightning
 Checkout a release tag:
 
 ```shell
-git checkout v24.05
+git checkout v25.02
 ```
 
 For development or running tests, get additional dependencies:
@@ -114,7 +117,7 @@ pip3 install pytest
 
 If you can't install `lowdown`, a version will be built in-tree.
 
-If you want to build the Rust plugins (currently, cln-grpc and clnrest, which changed from Python to Rust as of v25.02):
+If you want to build the Rust plugins (currently cln-grpc and clnrest, which changed from Python to Rust as of v25.02):
 
 ```shell
 sudo apt-get install -y cargo rustfmt protobuf-compiler
@@ -127,25 +130,22 @@ sudo apt-get install -y cargo rustfmt protobuf-compiler
 
 There are two ways to build core lightning, and this depends on how you want use it.
 
-To build cln to just install a tagged or master version you can use the following commands:
+To build CLN for production:
 
 ```shell
-pip3 install --upgrade pip
-pip3 install mako
-pip3 install grpcio-tools
+poetry install
 ./configure
-make
+poetry run make -j$(($(nproc)-1))
 sudo make install
 ```
 
 > 📘 
 > 
-> If you want disable Rust because you do not want use it or simple you do not want the grpc-plugin, you can use `./configure --disable-rust`.
+> If you want disable Rust because you do not want use it or you do not want `cln-grpc` or `clnrest`, you can use `./configure --disable-rust`.
 
-To build core lightning for development purpose you can use the following commands:
+To build CLN for development:
 
 ```shell
-pip3 install poetry
 poetry shell
 ```
 


### PR DESCRIPTION
Also removes usage of pip due to this error that crops up on newer versions of Ubuntu:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

I've been recommending installing Poetry from the official installer for the past several months and it always works.

Changelog-None

> [!IMPORTANT]
> 25.02 FREEZE JANUARY 31ST: Non-bugfix PRs not ready by this date will wait for 25.05.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
