### PR TITLE
ci: Checkout with fresh tags in case the old tag reference is corrupted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Determine version


### PR DESCRIPTION
The workflow fails to trigger manually after recreating the release tag. It should support re-running even if the tag was previously deleted and recreated.

Changelog-None.
