### PR TITLE
doc: recommend rustup for Debian systems

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -114,11 +114,16 @@ pip3 install pytest
 
 If you can't install `lowdown`, a version will be built in-tree.
 
-If you want to build the Rust plugins (currently, cln-grpc):
+If you want to build the Rust plugins (currently, cln-grpc and clnrest, which changed from Python to Rust as of v25.02):
 
 ```shell
 sudo apt-get install -y cargo rustfmt protobuf-compiler
 ```
+
+> 📘 
+> 
+> If your build fails because of your Rust version, you might want to check out [rustup](https://rustup.rs/) to install a newer version
+
 
 There are two ways to build core lightning, and this depends on how you want use it.
 


### PR DESCRIPTION
Debian packages rust 1.63 and new lightning users will run into issues following the installation docs if they do not have a newer version

Changelog-None

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 12TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 23rd_, RC2 on _May 26th_, ...
>
> The final release is on MAY 29TH.