### PR TITLE
`cln-rpc/Makefile`: fix typo `CLN_RPC_GEN_ALL`=>`CLN_RPC_GENALL`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ include devtools/Makefile
 include tools/Makefile
 ifneq ($(RUST),0)
 include cln-rpc/Makefile
+include cln-grpc/Makefile
 endif
 include plugins/Makefile
 include tests/plugins/Makefile

--- a/cln-rpc/Makefile
+++ b/cln-rpc/Makefile
@@ -18,4 +18,4 @@ target/${RUST_PROFILE}/examples/cln-plugin-reentrant: ${CLN_RPC_SOURCES} plugins
 	cargo build ${CARGO_OPTS} --example cln-plugin-reentrant
 
 
-cln-rpc-all: ${CLN_RPC_GEN_ALL} ${CLN_RPC_EXAMPLES}
+cln-rpc-all: ${CLN_RPC_GENALL} ${CLN_RPC_EXAMPLES}


### PR DESCRIPTION
I noticed a typo in `cln-rpc/Makefile` while trying to hunt down why Make was remaking targets.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
