### PR TITLE
fuzz-tests: Add fuzz target for closing_complete

### DIFF
--- a/tests/fuzz/fuzz-wire-closing_complete.c
+++ b/tests/fuzz/fuzz-wire-closing_complete.c
@@ -1,0 +1,50 @@
+#include "config.h"
+#include <assert.h>
+#include <ccan/mem/mem.h>
+#include <tests/fuzz/libfuzz.h>
+#include <tests/fuzz/wire.h>
+#include <wire/peer_wire.h>
+
+struct closing_complete {
+	struct channel_id channel_id;
+	u32 locktime;
+	struct amount_sat fee_satoshis;
+	u8 *closer_scriptpubkey, *closee_scriptpubkey;
+	struct tlv_closing_tlvs *tlvs;
+};
+
+static void *encode(const tal_t *ctx, const struct closing_complete *s)
+{
+	return towire_closing_complete(ctx, &s->channel_id, s->closer_scriptpubkey,
+					s->closee_scriptpubkey, s->fee_satoshis, s->locktime, s->tlvs);
+}
+
+static struct closing_complete *decode(const tal_t *ctx, const void *p)
+{
+	struct closing_complete *s = tal(ctx, struct closing_complete);
+
+	if (fromwire_closing_complete(s, p, &s->channel_id, &s->closer_scriptpubkey,
+					&s->closee_scriptpubkey, &s->fee_satoshis, &s->locktime, &s->tlvs))
+		return s;
+	return tal_free(s);
+}
+
+static bool equal(const struct closing_complete *x,
+		  const struct closing_complete *y)
+{
+	size_t upto_closer_scriptpubkey = (uintptr_t)&x->closer_scriptpubkey - (uintptr_t)x;
+	if (memcmp(x, y, upto_closer_scriptpubkey) != 0)
+		return false;
+
+	assert(tal_arr_eq(x->closer_scriptpubkey, y->closer_scriptpubkey));
+	assert(tal_arr_eq(x->closee_scriptpubkey, y->closee_scriptpubkey));
+
+	assert(x->tlvs && y->tlvs);
+	return tal_arr_eq(x->tlvs->closer_and_closee_outputs, y->tlvs->closer_and_closee_outputs);
+}
+
+void run(const u8 *data, size_t size)
+{
+	test_decode_encode(data, size, WIRE_CLOSING_COMPLETE,
+			   struct closing_complete);
+}


### PR DESCRIPTION
`closing_signed` and `closing_complete` are channel closing negotiation messages defined in [BOLT #2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md).

While `closing_signed` has a wire fuzz test, `closing_complete` does not. Add a test to perform a round-trip encoding check (towire -> fromwire) similar to the other wire fuzzers.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
