### PR TITLE
Enforce minimum witness program length for fallback addresses in BOLT11 parsing

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -420,7 +420,7 @@ static const char *decode_f(struct bolt11 *b11,
 				       "f: witness v1 bad length %zu",
 				       tal_count(f));
 		}
-		if (tal_count(f) > 40) {
+		if (tal_count(f) > 40 || tal_count(f) < 2) {
 			return tal_fmt(b11,
 				       "f: witness v%"PRIu64" bad length %zu",
 				       version,


### PR DESCRIPTION
This PR fixes an issue with BOLT11 fallback address validation discovered through differential fuzzing between Lightning implementations. Core Lightning was accepting invoices with non-standard witness address fallbacks that other implementations correctly reject.

While comparing parse results from LND, LDK, and Core Lightning using the [bitcoinfuzz PR #132](https://github.com/brunoerg/bitcoinfuzz/pull/132), I found that Core Lightning enforces the 40-byte upper limit for witness programs as per BIP-141, but doesn't check the 2-byte minimum length requirement.

The fix is minimal: adding a lower bound check to ensure witness programs are at least 2 bytes long, bringing Core Lightning in line with both the BIP-141 specification and other Lightning implementations.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
