### PR TITLE
`cln-grpc` Expose `NotificationStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "cfg-if",
  "cln-rpc",
  "futures-core",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cln-grpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -15,12 +15,13 @@ server = ["cln-rpc"]
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-cln-rpc = { path="../cln-rpc/", version = "0.4", optional = true }
+cln-rpc = { path = "../cln-rpc/", version = "0.4", optional = true }
+cfg-if = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tonic = { version = "0.11", features = ["tls", "transport"] }
 prost = "0.12"
 hex = "0.4.3"
-bitcoin = { version = "0.31", features = [ "serde" ] }
+bitcoin = { version = "0.31", features = ["serde"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio = { version = "1.36.0", features = ["sync"] }
 futures-core = "0.3.30"
@@ -28,7 +29,7 @@ tokio-util = "0.7.10"
 
 [dev-dependencies]
 serde_json = "1.0.72"
-cln-rpc = { path="../cln-rpc/", version = "0.4" }
+cln-rpc = { path = "../cln-rpc/", version = "0.4" }
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/cln-grpc/src/lib.rs
+++ b/cln-grpc/src/lib.rs
@@ -1,15 +1,15 @@
 // Huge json!() macros require lots of recursion
 #![recursion_limit = "1024"]
 
-#[cfg(feature = "server")]
-mod convert;
 pub mod pb;
 
-#[cfg(feature = "server")]
-mod server;
-
-#[cfg(feature = "server")]
-pub use crate::server::Server;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "server")] {
+        mod convert;
+        mod server;
+        pub use server::Server;
+    }
+}
 
 #[cfg(test)]
 mod test;

--- a/cln-grpc/src/lib.rs
+++ b/cln-grpc/src/lib.rs
@@ -8,6 +8,7 @@ cfg_if::cfg_if! {
         mod convert;
         mod server;
         pub use server::Server;
+        pub use server::NotificationStream;
     }
 }
 


### PR DESCRIPTION
This PR exposes the `NotificationStream` of the grpc server implementation. This is required for wrapping services to be able to pass down any notification stream.
