### PR TITLE
Fix nagle, other minor optimizations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -624,7 +624,6 @@ jobs:
       - check-units
       - integration-valgrind
       - integration-sanitizers
-      - update-docs-examples
       - min-btc-support
       - check-flake
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,7 @@ jobs:
     needs:
       - compile
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - NAME: gcc
@@ -356,7 +356,7 @@ jobs:
     needs:
       - compile
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - NAME: Valgrind (01/10)
@@ -425,7 +425,7 @@ jobs:
     needs:
       - compile
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - NAME: ASan/UBSan (01/10)
@@ -485,7 +485,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
-      fail-fast: true
+      fail-fast: false
     env:
       VALGRIND: 0
       GENERATE_EXAMPLES: 1
@@ -532,7 +532,7 @@ jobs:
     needs:
       - compile
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - NAME: clang

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,7 +209,7 @@ jobs:
       - name: Check
         run: |
           tar -xaf cln-${{ matrix.CFG }}.tar.bz2
-          make -j $(nproc) check-units installcheck VALGRIND=${{ matrix.VALGRIND }}
+          eatmydata make -j $(nproc) check-units installcheck VALGRIND=${{ matrix.VALGRIND }}
 
   check-fuzz:
     name: Run fuzz regression tests
@@ -343,7 +343,7 @@ jobs:
         run: |
           env
           cat config.vars
-          VALGRIND=0 poetry run pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
+          VALGRIND=0 poetry run eatmydata pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
 
   integration-valgrind:
     name: Valgrind Test CLN ${{ matrix.name }}
@@ -411,7 +411,7 @@ jobs:
           SLOW_MACHINE: 1
           TEST_DEBUG: 1
         run: |
-          VALGRIND=1 poetry run pytest tests/ -vvv -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+          VALGRIND=1 poetry run eatmydata pytest tests/ -vvv -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
 
   integration-sanitizers:
     name: Sanitizers Test CLN
@@ -477,7 +477,7 @@ jobs:
 
       - name: Test
         run: |
-          poetry run pytest tests/ -vvv -n 2 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+          poetry run eatmydata pytest tests/ -vvv -n 2 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
 
   update-docs-examples:
     name: Update examples in doc schemas (disabled temporarily!)
@@ -520,7 +520,7 @@ jobs:
           tar -xaf cln-compile-gcc.tar.bz2
       - name: Test
         run: |
-          make -j $(nproc) check-doc-examples
+          eatmydata make -j $(nproc) check-doc-examples
 
   min-btc-support:
     name: Test minimum supported BTC v${{ matrix.MIN_BTC_VERSION }} with ${{ matrix.NAME }}
@@ -592,7 +592,7 @@ jobs:
         run: |
           env
           cat config.vars
-          VALGRIND=0 poetry run pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
+          VALGRIND=0 poetry run eatmydata pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
 
   check-flake:
     name: Check Nix Flake

--- a/common/daemon.c
+++ b/common/daemon.c
@@ -222,8 +222,11 @@ bool daemon_developer_mode(char *argv[])
 		kill(getpid(), SIGSTOP);
 	}
 
-	/* This checks for any tal_steal loops! */
-	add_steal_notifiers(NULL);
+	/* This checks for any tal_steal loops, but it's not free:
+	 * only use if we're already using the fairly heavy memleak
+	 * detection. */
+	if (getenv("LIGHTNINGD_DEV_MEMLEAK"))
+		add_steal_notifiers(NULL);
 
 	return true;
 }

--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -307,8 +307,6 @@ void setup_peer_gossip_store(struct peer *peer,
 static void set_urgent_flag(struct peer *peer, bool urgent)
 {
 	int val;
-	int opt;
-	const char *optname;
 
 	if (urgent == peer->urgent)
 		return;
@@ -318,23 +316,13 @@ static void set_urgent_flag(struct peer *peer, bool urgent)
 	if (peer->is_websocket != NORMAL_SOCKET)
 		return;
 
-#ifdef TCP_CORK
-	opt = TCP_CORK;
-	optname = "TCP_CORK";
-#elif defined(TCP_NODELAY)
-	opt = TCP_NODELAY;
-	optname = "TCP_NODELAY";
-#else
-#error "Please report platform with neither TCP_CORK nor TCP_NODELAY?"
-#endif
-
 	val = urgent;
 	if (setsockopt(io_conn_fd(peer->to_peer),
-		       IPPROTO_TCP, opt, &val, sizeof(val)) != 0
+		       IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != 0
 	    /* This actually happens in testing, where we blackhole the fd */
 	    && peer->daemon->dev_disconnect_fd == -1) {
-		status_broken("setsockopt %s=1 fd=%u: %s",
-			      optname, io_conn_fd(peer->to_peer),
+		status_broken("setsockopt TCP_NODELAY=1 fd=%u: %s",
+			      io_conn_fd(peer->to_peer),
 			      strerror(errno));
 	}
 	peer->urgent = urgent;

--- a/gossipd/gossipd.c
+++ b/gossipd/gossipd.c
@@ -479,6 +479,7 @@ static void dev_gossip_memleak(struct daemon *daemon, const u8 *msg)
 	memleak_scan_obj(memtable, daemon);
 	memleak_scan_htable(memtable, &daemon->peers->raw);
 	dev_seeker_memleak(memtable, daemon->seeker);
+	gossmap_manage_memleak(memtable, daemon->gm);
 
 	found_leak = dump_memleak(memtable, memleak_status_broken, NULL);
 	daemon_conn_send(daemon->master,

--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -6,6 +6,7 @@
 #include <common/daemon_conn.h>
 #include <common/gossip_store.h>
 #include <common/gossmap.h>
+#include <common/memleak.h>
 #include <common/status.h>
 #include <common/timeout.h>
 #include <common/wire_error.h>
@@ -467,6 +468,13 @@ static bool setup_gossmap(struct gossmap_manage *gm,
 		return false;
 	}
 	return true;
+}
+
+void gossmap_manage_memleak(struct htable *memtable,
+			    const struct gossmap_manage *gm)
+{
+	memleak_scan_uintmap(memtable, &gm->pending_ann_map.map);
+	memleak_scan_uintmap(memtable, &gm->early_ann_map.map);
 }
 
 struct gossmap_manage *gossmap_manage_new(const tal_t *ctx,

--- a/gossipd/gossmap_manage.h
+++ b/gossipd/gossmap_manage.h
@@ -111,4 +111,7 @@ void gossmap_manage_tell_lightningd_locals(struct daemon *daemon,
  * The seeker uses this if we're at startup and want complete gossip.
  */
 bool gossmap_manage_populated(const struct gossmap_manage *gm);
+
+/* For memleak to see inside of maps */
+void gossmap_manage_memleak(struct htable *memtable, const struct gossmap_manage *gm);
 #endif /* LIGHTNING_GOSSIPD_GOSSMAP_MANAGE_H */

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -208,6 +208,13 @@ static void log_to_files(const char *log_prefix,
 {
 	char tstamp[sizeof("YYYY-mm-ddTHH:MM:SS.nnnZ ")];
 	char *entry, nodestr[hex_str_size(PUBKEY_CMPR_LEN)];
+	char buf[sizeof("%s%s%s %s-%s: %s\n")
+		 + strlen(log_prefix)
+		 + sizeof(tstamp)
+		 + strlen(level_prefix(level))
+		 + sizeof(nodestr)
+		 + strlen(entry_prefix)
+		 + strlen(str)];
 	bool filtered;
 
 	if (print_timestamps) {
@@ -235,14 +242,18 @@ static void log_to_files(const char *log_prefix,
 					entry_prefix, str, dir, hex);
 		tal_free(hex);
 	} else {
+		size_t len;
+		entry = buf;
 		if (!node_id)
-			entry = tal_fmt(tmpctx, "%s%s%s %s: %s\n",
-					log_prefix, tstamp, level_prefix(level), entry_prefix, str);
+			len = snprintf(buf, sizeof(buf),
+				       "%s%s%s %s: %s\n",
+				       log_prefix, tstamp, level_prefix(level), entry_prefix, str);
 		else
-			entry = tal_fmt(tmpctx, "%s%s%s %s-%s: %s\n",
-					log_prefix, tstamp, level_prefix(level),
-					nodestr,
-					entry_prefix, str);
+			len = snprintf(buf, sizeof(buf), "%s%s%s %s-%s: %s\n",
+				       log_prefix, tstamp, level_prefix(level),
+				       nodestr,
+				       entry_prefix, str);
+		assert(len < sizeof(buf));
 	}
 
 	/* In complex configurations, we tell loggers to overshare: then we

--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -207,7 +207,7 @@ static void log_to_files(const char *log_prefix,
 			 struct log_file **log_files)
 {
 	char tstamp[sizeof("YYYY-mm-ddTHH:MM:SS.nnnZ ")];
-	char *entry, *nodestr;
+	char *entry, nodestr[hex_str_size(PUBKEY_CMPR_LEN)];
 	bool filtered;
 
 	if (print_timestamps) {
@@ -218,9 +218,10 @@ static void log_to_files(const char *log_prefix,
 		tstamp[0] = '\0';
 
 	if (node_id)
-		nodestr = fmt_node_id(tmpctx, node_id);
+		hex_encode(node_id->k, sizeof(node_id->k),
+			   nodestr, sizeof(nodestr));
 	else
-		nodestr = "";
+		nodestr[0] = '\0';
 	if (level == LOG_IO_IN || level == LOG_IO_OUT) {
 		const char *dir = level == LOG_IO_IN ? "[IN]" : "[OUT]";
 		char *hex = tal_hexstr(NULL, io, io_len);

--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -2447,6 +2447,20 @@ static bool plugin_subscriptions_contains(struct plugin *plugin,
 	return false;
 }
 
+bool plugins_anyone_cares(struct plugins *plugins, const char *method)
+{
+	struct plugin *p;
+
+	if (!plugins)
+		return false;
+
+	list_for_each(&plugins->plugins, p, list) {
+		if (plugin_subscriptions_contains(p, method))
+			return true;
+	}
+	return false;
+}
+
 bool plugin_single_notify(struct plugin *p,
 			  const struct jsonrpc_notification *n TAKES)
 {

--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -366,6 +366,9 @@ void plugins_set_builtin_plugins_dir(struct plugins *plugins,
 /* Is this option for a plugin? */
 bool is_plugin_opt(const struct opt_table *ot);
 
+/* Does any plugin care about this notification? */
+bool plugins_anyone_cares(struct plugins *plugins, const char *method);
+
 /* Add this field if this ot is owned by a plugin */
 void json_add_config_plugin(struct json_stream *stream,
 			    const struct plugins *plugins,

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4185,7 +4185,7 @@ def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
     node_factory.join_nodes([l1, l2], wait_for_announce=True)
     node_factory.join_nodes([l3, l2], wait_for_announce=True)
     l3.rpc.pay(l2.rpc.invoice(200000000, 'test2', 'test2')['bolt11'])
-    wait_for(lambda: only_one(l2.rpc.listpeerchannels(l3.info['id'])['channels'])['htlcs'] != [])
+    wait_for(lambda: only_one(l2.rpc.listpeerchannels(l3.info['id'])['channels'])['htlcs'] == [])
 
     # Get HTLC stuck, so l2 has reason to push commitment tx.
     amt = 100_000_000

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -932,6 +932,9 @@ def test_channel_lease_unilat_closes(node_factory, bitcoind):
     l2.fundwallet(20000000)
     l3.fundwallet(20000000)
 
+    # Make sure we are at known height for lease.
+    sync_blockheight(bitcoind, [l1, l2, l3])
+
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     rates = l1.rpc.dev_queryrates(l2.info['id'], amount, amount)
     # l1 leases a channel from l2

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4311,7 +4311,7 @@ def test_onchain_slow_anchor(node_factory, bitcoind):
     height = bitcoind.rpc.getblockchaininfo()['blocks']
     l1.daemon.wait_for_log(r"Low-priority anchorspend aiming for block {} \(feerate 7458\)".format(height + 13))
     # Can be out-by-one (short sig)!
-    l1.daemon.wait_for_log(r"Anchorspend for local commit tx fee 9377sat \(w=722\), commit_tx fee 1735sat \(w=768\): package feerate 7457 perkw")
+    l1.daemon.wait_for_log(r"Anchorspend for local commit tx fee (9377|9369)sat \(w=722\), commit_tx fee 1735sat \(w=76[78]\): package feerate 7457 perkw")
     assert not l1.daemon.is_in_log("Low-priority anchorspend aiming for block {}".format(height + 12))
 
     bitcoind.generate_block(1)

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4042,6 +4042,7 @@ def test_peer_anchor_push(node_factory, bitcoind, executor, chainparams):
     # As blocks pass, we will use anchor to boost l3's tx.
     for block, feerate in zip(range(120, 124), (12000, 13000, 14000, 15000)):
         l2.daemon.wait_for_log(fr"Worth fee [0-9]*sat for remote commit tx to get 100000000msat at block 125 \(\+{125 - block}\) at feerate {feerate}perkw")
+        l2.daemon.wait_for_log("sendrawtx exit 0")
         # Check feerate for entire package (commitment tx + anchor) is ~ correct
         details = bitcoind.rpc.getrawmempool(True).values()
         total_weight = sum([d['weight'] for d in details])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4846,6 +4846,41 @@ def test_no_delay(node_factory):
     assert end < start + 100 * 0.5
 
 
+@unittest.skipIf(os.getenv('TEST_BENCH', '0') == '0', "For profiling")
+def test_bench(node_factory):
+    """Is our Nagle disabling for critical messages working?"""
+    l1, l2 = node_factory.get_nodes(2, opts={'start': False,
+                                             'commit-time': 0})
+
+    # memleak detection plays havoc with profiles.
+    del l1.daemon.env["LIGHTNINGD_DEV_MEMLEAK"]
+    del l2.daemon.env["LIGHTNINGD_DEV_MEMLEAK"]
+
+    l1.start()
+    l2.start()
+    node_factory.join_nodes([l1, l2])
+
+    scid = only_one(l1.rpc.listpeerchannels()['channels'])['short_channel_id']
+    routestep = {
+        'amount_msat': 100,
+        'id': l2.info['id'],
+        'delay': 5,
+        'channel': scid
+    }
+
+    start = time.time()
+    # If we were stupid enough to leave Nagle enabled, this would add 200ms
+    # seconds delays each way!
+    for _ in range(1000):
+        phash = random.randbytes(32).hex()
+        l1.rpc.sendpay([routestep], phash)
+        with pytest.raises(RpcError, match="WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS"):
+            l1.rpc.waitsendpay(phash)
+    end = time.time()
+    duration = end - start
+    assert duration == 0
+
+
 def test_listpeerchannels_by_scid(node_factory):
     l1, l2, l3 = node_factory.line_graph(3, announce_channels=False)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4822,6 +4822,31 @@ def test_private_channel_no_reconnect(node_factory):
     assert only_one(l1.rpc.listpeers()['peers'])['connected'] is False
 
 
+@pytest.mark.xfail(strict=True)
+@unittest.skipIf(VALGRIND, "We assume machine is reasonably fast")
+def test_no_delay(node_factory):
+    """Is our Nagle disabling for critical messages working?"""
+    l1, l2 = node_factory.line_graph(2)
+
+    scid = only_one(l1.rpc.listpeerchannels()['channels'])['short_channel_id']
+    routestep = {
+        'amount_msat': 100,
+        'id': l2.info['id'],
+        'delay': 5,
+        'channel': scid
+    }
+    start = time.time()
+    # If we were stupid enough to leave Nagle enabled, this would add 200ms
+    # seconds delays each way!
+    for _ in range(100):
+        phash = random.randbytes(32).hex()
+        l1.rpc.sendpay([routestep], phash)
+        with pytest.raises(RpcError, match="WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS"):
+            l1.rpc.waitsendpay(phash)
+    end = time.time()
+    assert end < start + 100 * 0.5
+
+
 def test_listpeerchannels_by_scid(node_factory):
     l1, l2, l3 = node_factory.line_graph(3, announce_channels=False)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4780,9 +4780,11 @@ def test_onionmessage_forward_fail(node_factory, bitcoind):
                                          opts=[{},
                                                {'dev-allow-localhost': None,
                                                 'may_reconnect': True,
+                                                'dev-no-reconnect': None,
                                                 'plugin': os.path.join(os.getcwd(), 'tests/plugins/onionmessage_forward_fail_notification.py'),
                                                 },
                                                {'dev-allow-localhost': None,
+                                                'dev-no-reconnect': None,
                                                 'may_reconnect': True}])
 
     offer = l3.rpc.offer(300, "test_onionmessage_forward_fail")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4822,7 +4822,6 @@ def test_private_channel_no_reconnect(node_factory):
     assert only_one(l1.rpc.listpeers()['peers'])['connected'] is False
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(VALGRIND, "We assume machine is reasonably fast")
 def test_no_delay(node_factory):
     """Is our Nagle disabling for critical messages working?"""

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1060,14 +1060,13 @@ def test_rbf_reconnect_tx_sigs(node_factory, bitcoind, chainparams):
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
 def test_rbf_to_chain_before_commit(node_factory, bitcoind, chainparams):
-    disconnects = ['=WIRE_TX_ADD_INPUT',  # Initial funding succeeds
-                   '=WIRE_COMMITMENT_SIGNED',
+    disconnects = ['=WIRE_COMMITMENT_SIGNED',
                    '-WIRE_COMMITMENT_SIGNED']
     l1, l2 = node_factory.get_nodes(2,
-                                    opts=[{'disconnect': disconnects,
-                                           'may_reconnect': True,
+                                    opts=[{'may_reconnect': True,
                                            'dev-no-reconnect': None},
-                                          {'may_reconnect': True,
+                                          {'disconnect': disconnects,
+                                           'may_reconnect': True,
                                            'dev-no-reconnect': None}])
 
     l1.rpc.connect(l2.info['id'], 'localhost', l2.port)

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -3423,11 +3423,10 @@ def test_reject_invalid_payload(node_factory):
                      first_hop=first_hop,
                      payment_hash=inv['payment_hash'],
                      shared_secrets=onion['shared_secrets'])
-
-    l2.daemon.wait_for_log(r'Failing HTLC because of an invalid payload')
-
     with pytest.raises(RpcError, match=r'WIRE_INVALID_ONION_PAYLOAD'):
         l1.rpc.waitsendpay(inv['payment_hash'])
+
+    l2.daemon.wait_for_log(r'Failing HTLC because of an invalid payload')
 
 
 @unittest.skip("Test is flaky causing CI to be unusable.")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -658,3 +658,18 @@ def serialize_payload_final_tlv(amount_msat, delay, total_msat, blockheight, pay
     #        * [`tu64`:`total_msat`]
     payload.add_field(8, bytes.fromhex(payment_secret) + tu64_encode(int(total_msat)))
     return payload.to_bytes()
+
+
+# I wish we could force libwally to use different entropy and thus force it to
+# create 71-byte sigs always!
+def did_short_sig(node):
+    # This can take a moment to appear in the log!
+    time.sleep(1)
+    return node.daemon.is_in_log('overgrind: short signature length')
+
+
+def check_feerate(node, actual_feerate, expected_feerate):
+    # Feerate can't be lower.
+    assert actual_feerate > expected_feerate - 2
+    if not did_short_sig(node):
+        assert actual_feerate < expected_feerate + 2


### PR DESCRIPTION
I noticed we were not going as fast as we should, in a 100-payments test.  Turns out our Nagle-suppressing code was wrong!  

Then I continued with minor optimization until our profiling basically only contained sqlite operations, resulting in an 8% speedup in bouncing payments. (when eatmydata was used).

(Dropped patch which speeds CI using eatmydata, as it broke too much!)