### PR TITLE
pytest: fix more flakes

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3048,7 +3048,8 @@ def test_recover_plugin(node_factory, bitcoind):
         feerates=(7500, 7500, 7500, 7500),
         options={
             'log-level': 'info',
-            'experimental-peer-storage': None
+            'experimental-peer-storage': None,
+            'dev-no-reconnect': None,
         },
     )
     l2 = node_factory.get_node(
@@ -3058,7 +3059,8 @@ def test_recover_plugin(node_factory, bitcoind):
         allow_bad_gossip=True,
         options={
             'log-level': 'info',
-            'experimental-peer-storage': None
+            'experimental-peer-storage': None,
+            'dev-no-reconnect': None,
         },
     )
 


### PR DESCRIPTION
1. Flake where we manually reconnected while autoreconnect is happening.
2. get_channel_scid() returns the *first* channel, and we want all the channels. So they may not actually be all visible in gossip.

```
    @unittest.skipIf(TEST_NETWORK == 'liquid-regtest', "broken for some reason")
    def test_hardmpp2(node_factory, bitcoind):
        """Credits to @daywalker90 for this test case."""
        opts = {"disable-mpp": None, "fee-base": 0, "fee-per-satoshi": 10}
        l1, l2, l3 = node_factory.get_nodes(3, opts=opts)
        start_channels(
            [
                (l1, l2, 100_000),
                (l1, l2, 200_000),
                (l1, l2, 300_000),
                (l1, l2, 400_000),
                (l2, l3, 100_000),
                (l2, l3, 200_000),
                (l2, l3, 300_000),
                (l2, l3, 600_000),
            ]
        )
        # FIXME: changing the last channel from 600k to 400k will fail the test due
        # to l2 not accepting to forward any amount above 200k with error:
        # CHANNEL_ERR_CHANNEL_CAPACITY_EXCEEDED, still investigating
        inv = l3.rpc.invoice("800000sat", "inv", "description")
>       l1.rpc.call("renepay", {"invstring": inv["bolt11"]})

tests/test_renepay.py:797: 
...
        elif "error" in resp:
>           raise RpcError(method, payload, resp['error'])
E           pyln.client.lightning.RpcError: RPC call failed: method: renepay, payload: {'invstring': 'lnbcrt8m1pnl3zfksp54n6vhkrcj0nkn2uqhf232v62539048u2ree4g9ssytm47gasgctspp58twj5xf4h57s4h0rhy55p5q6nry36glummjexsf4lc446je7y27qdqjv3jhxcmjd9c8g6t0dcxqyjw5qcqp9rzjqgkjyd3q5dv6gllh77kygly9c3kfy0d9xwyjyxsq2nq3c83u5vw4jqqqvuqqqzqqqqqqqqqqqqqqqzsqqcrzjqgkjyd3q5dv6gllh77kygly9c3kfy0d9xwyjyxsq2nq3c83u5vw4jqqqvuqqqpcqqqqqqqqqqqqqqzsqqcrzjqgkjyd3q5dv6gllh77kygly9c3kfy0d9xwyjyxsq2nq3c83u5vw4jqqqvuqqqqgqqqqqqqqqqqqqqzsqqcrzjqgkjyd3q5dv6gllh77kygly9c3kfy0d9xwyjyxsq2nq3c83u5vw4jqqqvuqqqpqqqqqqqqqqqqqqqzsqqc9qxpqysgqtgxcneu0u7xvetgh2kqmey86jssweneat5vx3fppuaphl9v9jweqa2ymczg9klau9jmsm6pm7m3cd28pggp7avuukjqxg63wy2vuvtcpggz4vt'}, error: {'code': 205, 'message': "minflow couldn't find a feasible flow: failed to find a feasible flow: find_admissible_path failed"}
```
Changelog-None: CI