### PR TITLE
ci: Fix the FreeBSD CI run

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -53,8 +53,8 @@ jobs:
 
         run: |
           PATH=/root/.local/bin:$PATH
-          pip install --user -U wheel pip
-          pip install --user -U -r requirements.txt
+          pip install --user -U wheel pip poetry
+          pip install --user -U .
 
           # Install utilities that aren't dependencies, but make
           # running tests easier/feasible on CI (and pytest which

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -27,7 +27,7 @@ jobs:
           pkg install -y \
             bash \
             wget \
-            python38 \
+            python3 \
             gmake \
             git \
             python \
@@ -41,8 +41,8 @@ jobs:
             lowdown \
             curl
 
-            python3.8 -m ensurepip
-            python3.8 -m pip install --upgrade pip
+            python3 -m ensurepip
+            python3 -m pip install --upgrade pip
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-11-28
 
             cd /tmp/ || exit 1

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -46,10 +46,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-11-28
 
             cd /tmp/ || exit 1
-            wget https://bitcoincore.org/bin/bitcoin-core-${{ matrix.bitcoind-version }}/bitcoin-${{ matrix.bitcoind-version }}-x86_64-linux-gnu.tar.gz
-            tar -xf bitcoin-${{ matrix.bitcoind-version }}-x86_64-linux-gnu.tar.bz2
+            wget https://bitcoincore.org/bin/bitcoin-core-${{ matrix.bitcoind-version }}/bitcoin-${{ matrix.bitcoind-version }}-x86_64-linux-gnu.tar.gz -O /tmp/bitcoin.tar.gz
+            tar -xf /tmp/bitcoin.tar.gz
             sudo mv bitcoin-${{ matrix.bitcoind-version }}/bin/* /usr/local/bin
-            rm -rf bitcoin-${{ matrix.bitcoind-version }}-x86_64-linux-gnu.tar.gz bitcoin-${{ matrix.bitcoind-version }}
+            rm -rf /tmp/bitcoin.tar.gz bitcoin-${{ matrix.bitcoind-version }}
 
         run: |
           PATH=/root/.local/bin:$PATH

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -48,7 +48,7 @@ jobs:
             cd /tmp/ || exit 1
             wget https://bitcoincore.org/bin/bitcoin-core-${{ matrix.bitcoind-version }}/bitcoin-${{ matrix.bitcoind-version }}-x86_64-linux-gnu.tar.gz -O /tmp/bitcoin.tar.gz
             tar -xf /tmp/bitcoin.tar.gz
-            sudo mv bitcoin-${{ matrix.bitcoind-version }}/bin/* /usr/local/bin
+            mv bitcoin-${{ matrix.bitcoind-version }}/bin/* /usr/local/bin
             rm -rf /tmp/bitcoin.tar.gz bitcoin-${{ matrix.bitcoind-version }}
 
         run: |


### PR DESCRIPTION
We were overly specific in selecting `python38`. As that has now
reached its EOL, the package to install would be `python39`, however
there is a meta-pacakge `python3` that I think we can keep using
without having to bump the package name on the next EOL event.