### PR TITLE
db: replace UPDATE FROM syntax for SQLite compat

### DIFF
--- a/wallet/db.c
+++ b/wallet/db.c
@@ -2043,11 +2043,10 @@ static void migrate_convert_old_channel_keyidx(struct lightningd *ld,
 
 	stmt = db_prepare_v2(db, SQL("UPDATE addresses"
 				     " SET addrtype = ?"
-				     " FROM channels "
-				     " WHERE addresses.keyidx = channels.shutdown_keyidx_local"
-				     " AND channels.state != ?"
-				     " AND channels.state != ?"
-				     " AND channels.state != ?"));
+				     " WHERE keyidx IN (SELECT shutdown_keyidx_local FROM channels"
+				     "                  WHERE state != ?"
+				     "                  AND state != ?"
+				     "                  AND state != ?)"));
 	db_bind_int(stmt, wallet_addrtype_in_db(ADDR_ALL));
 	/* If we might have already seen onchain funds, we need to rescan */
 	db_bind_int(stmt, channel_state_in_db(FUNDING_SPEND_SEEN));


### PR DESCRIPTION
Introduced the use of UPDATE FROM syntax in SQLite queries, which is not supported in versions prior to 3.33.0.

This causes issues on systems with older SQLite versions,
 as reported in issue #8231. Rewrite the query in
 migrate_convert_old_channel_keyidx() to use a subquery
 with IN clause instead of UPDATE FROM, ensuring compatibility with
 older SQLite versions.

Fixes [68f3649d6b9fc65ece3f1dc3e2f7e6a053170ea5](https://github.com/ElementsProject/lightning/issues/8231)
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 12TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 23rd_, RC2 on _May 26th_, ...
>
> The final release is on MAY 29TH.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [X] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [X] Related issues have been listed and linked, including any that this PR closes.
