### PR TITLE
Change LOG_INFORM to LOG_TRACE in chanbackup

### DIFF
--- a/plugins/chanbackup.c
+++ b/plugins/chanbackup.c
@@ -452,7 +452,7 @@ static struct command_result *after_send_scb_single(struct command *cmd,
 						    const jsmntok_t *params,
 						    struct info *info)
 {
-        plugin_log(cmd->plugin, LOG_INFORM, "Peer storage sent!");
+        plugin_log(cmd->plugin, LOG_TRACE, "Peer storage sent!");
 	if (--info->idx != 0)
 		return command_still_pending(cmd);
 


### PR DESCRIPTION
plugin_log inside after_send_scb_single was logging after sending peer storage to each peer which could lead to spam in logs for big nodes, hence we should reduce the log level to log_trace for it.

Closes: #8251