### PR TITLE
plugins: wss-proxy should not return invalid JSON if sed does not exist.

### DIFF
--- a/plugins/wss-proxy/wss-proxy
+++ b/plugins/wss-proxy/wss-proxy
@@ -6,6 +6,7 @@ if ! type python3 > /dev/null 2>&1; then
     # No python3 binary.
     # Fortunately, CLN gives us JSON in a very standard way, so we can assume:
     # Eg. {"jsonrpc":"2.0","id":2,"method":"getmanifest","params":{}}\n\n
+    set -e
     read -r JSON
     read -r _
     id=$(echo "$JSON" | sed 's/.*"id" *: *\([^,]*\),.*/\1/')


### PR DESCRIPTION
We try to do a JSON response if Python is not present, but it assumes sed.  We should cleanly exit on errors.

Before:

```
$ PATH=/tmp ./plugins/wss-proxy/wss-proxy
Something

./plugins/wss-proxy/wss-proxy: 12: sed: not found
{"jsonrpc":"2.0","id":,"result":{"disable":"No python3 binary found"}}
```

After:

```
$ PATH=/tmp ./plugins/wss-proxy/wss-proxy
something

./plugins/wss-proxy/wss-proxy: 12: sed: not found
```

Changelog-None
Reported-by: @cdecker 