### PR TITLE
cln-plugin: trace level logging support

### DIFF
--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -76,6 +76,7 @@ async fn main() -> Result<(), anyhow::Error> {
             "send a test_custom_notification event",
             test_send_custom_notification,
         )
+        .rpcmethod("test-log-levels", "send on all log levels", test_log_levels)
         .subscribe("connect", connect_handler)
         .subscribe("test_custom_notification", test_receive_custom_notification)
         .hook("peer_connected", peer_connected_handler)
@@ -160,4 +161,16 @@ async fn peer_connected_handler(
 ) -> Result<serde_json::Value, Error> {
     log::info!("Got a connect hook call: {}", v);
     Ok(json!({"result": "continue"}))
+}
+
+async fn test_log_levels(
+    _p: Plugin<()>,
+    _v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
+    log::trace!("log::trace! working");
+    log::debug!("log::debug! working");
+    log::info!("log::info! working");
+    log::warn!("log::warn! working");
+    log::error!("log::error! working");
+    Ok(json!({}))
 }

--- a/plugins/src/logging.rs
+++ b/plugins/src/logging.rs
@@ -22,6 +22,7 @@ enum LogLevel {
     Info,
     Warn,
     Error,
+    Trace,
 }
 
 impl From<log::Level> for LogLevel {
@@ -30,7 +31,8 @@ impl From<log::Level> for LogLevel {
             log::Level::Error => LogLevel::Error,
             log::Level::Warn => LogLevel::Warn,
             log::Level::Info => LogLevel::Info,
-            log::Level::Debug | log::Level::Trace => LogLevel::Debug,
+            log::Level::Debug => LogLevel::Debug,
+            log::Level::Trace => LogLevel::Trace,
         }
     }
 }
@@ -130,7 +132,7 @@ mod trace {
                 &Level::ERROR => LogLevel::Error,
                 &Level::INFO => LogLevel::Info,
                 &Level::WARN => LogLevel::Warn,
-                &Level::TRACE => LogLevel::Debug,
+                &Level::TRACE => LogLevel::Trace,
             }
         }
     }

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -105,6 +105,20 @@ def test_plugin_options_handle_defaults(node_factory):
     assert opts["multi-i64-option-default"] == [-42]
 
 
+def test_plugin_log_levels(node_factory):
+    """Start a minimal plugin and ensure it logs all levels"""
+    bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-plugin-startup"
+    l1 = node_factory.get_node(
+        options={"plugin": str(bin_path)}, broken_log=r"log::error! working"
+    )
+    l1.rpc.test_log_levels()
+    wait_for(lambda: l1.daemon.is_in_log(r"cln-plugin-startup: log::trace! working"))
+    wait_for(lambda: l1.daemon.is_in_log(r"cln-plugin-startup: log::debug! working"))
+    wait_for(lambda: l1.daemon.is_in_log(r"cln-plugin-startup: log::info! working"))
+    wait_for(lambda: l1.daemon.is_in_log(r"cln-plugin-startup: log::warn! working"))
+    wait_for(lambda: l1.daemon.is_in_log(r"cln-plugin-startup: log::error! working"))
+
+
 def test_grpc_connect(node_factory):
     """Attempts to connect to the grpc interface and call getinfo"""
     # These only exist if we have rust!


### PR DESCRIPTION
Now that libplugin can log to trace (https://github.com/ElementsProject/lightning/pull/8258/commits/6381fd2aa2b1c2b7e7e04dd8a9f5e6a16e7f7df0) we can enable it in cln-plugin! I don't know if it's possible to check for the actual log level in the test? Does this require a changelog entry?

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 05TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 12th_, RC2 on _May 16th_, ...
>
> The final release is on MAY 20TH.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
