### PR TITLE
pyln-client: Adding dev_offer, dev_fetchinvoice commands (fixes CI)

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -777,6 +777,28 @@ class LightningRpc(UnixDomainSocketRpc):
         }
         return self.call("fetchinvoice", payload)
 
+    def dev_fetchinvoice(self, offer, amount_msat=None, quantity=None, recurrence_counter=None,
+                         recurrence_start=None, recurrence_label=None, timeout=None, payer_note=None,
+                         payer_metadata=None, bip353=None, dev_reply_path=None, dev_path_use_scidd=None):
+        """
+        A dev version of `fetchinvoice`, used for testing. Fetch an invoice for an offer.
+        """
+        payload = {
+            "offer": offer,
+            "amount_msat": amount_msat,
+            "quantity": quantity,
+            "recurrence_counter": recurrence_counter,
+            "recurrence_start": recurrence_start,
+            "recurrence_label": recurrence_label,
+            "timeout": timeout,
+            "payer_note": payer_note,
+            "payer_metadata": payer_metadata,
+            "bip353": bip353,
+            "dev_reply_path": dev_reply_path,
+            "dev_path_use_scidd": dev_path_use_scidd,
+        }
+        return self.call("fetchinvoice", payload)
+
     def fundchannel(self, node_id, amount, feerate=None, announce=True,
                     minconf=None, utxos=None, push_msat=None, close_to=None,
                     request_amt=None, compact_lease=None,
@@ -1144,6 +1166,30 @@ class LightningRpc(UnixDomainSocketRpc):
             "recurrence_limit": recurrence_limit,
             "single_use": single_use,
             "recurrence_start_any_period": recurrence_start_any_period,
+        }
+        return self.call("offer", payload)
+
+    def dev_offer(self, amount, description=None, issuer=None, label=None, quantity_max=None, absolute_expiry=None,
+                  recurrence=None, recurrence_base=None, recurrence_paywindow=None, recurrence_limit=None,
+                  single_use=None, recurrence_start_any_period=None, dev_paths=None):
+        """
+        A dev version of `offer`, used for testing. Create an offer (or returns an existing one), which is a precursor to creating one or more invoices.
+        It automatically enables the processing of an incoming invoice_request, and issuing of invoices.
+        """
+        payload = {
+            "amount": amount,
+            "description": description,
+            "issuer": issuer,
+            "label": label,
+            "quantity_max": quantity_max,
+            "absolute_expiry": absolute_expiry,
+            "recurrence": recurrence,
+            "recurrence_base": recurrence_base,
+            "recurrence_paywindow": recurrence_paywindow,
+            "recurrence_limit": recurrence_limit,
+            "single_use": single_use,
+            "recurrence_start_any_period": recurrence_start_any_period,
+            "dev_paths": dev_paths,
         }
         return self.call("offer", payload)
 

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -402,6 +402,8 @@ def _extra_validator(is_request: bool):
 
     def is_currency(checker, instance):
         """currency including currency code"""
+        if isinstance(instance, int):
+            return False
         pattern = re.compile(r'^\d+(\.\d+)?[A-Z][A-Z][A-Z]$')
         if pattern.match(instance):
             return True

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2759,7 +2759,7 @@ def test_zeroconf_forget(node_factory, bitcoind, dopay: bool):
     time.sleep(5)
 
     have_forgotten = l2.daemon.is_in_log(
-        r"UNUSUAL {}-chan#1: Forgetting channel: It has been 51 blocks without the funding transaction ".format(l1.info['id'])
+        r"UNUSUAL {}-chan#1: Forgetting channel: It has been 5[0-9] blocks without the funding transaction ".format(l1.info['id'])
     )
 
     if dopay:

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4737,7 +4737,7 @@ def test_fetchinvoice_disconnected_reply(node_factory, bitcoind):
 
     # l2 is already connected to l3, so it can fetch.  It specifies a reply
     # path of l1->l2.  l3 knows it can simply route reply to l1 via l2.
-    l2.rpc.fetchinvoice(offer=offer['bolt12'], dev_reply_path=[l1.info['id'], l2.info['id']])
+    l2.rpc.dev_fetchinvoice(offer=offer['bolt12'], dev_reply_path=[l1.info['id'], l2.info['id']])
     assert l3.rpc.listpeers(l1.info['id']) == {'peers': []}
 
 
@@ -5709,7 +5709,7 @@ def test_blinded_reply_path_scid(node_factory):
 
     chan = only_one(l1.rpc.listpeerchannels()['channels'])
     scidd = "{}/{}".format(chan['short_channel_id'], chan['direction'])
-    inv = l1.rpc.fetchinvoice(offer=offer['bolt12'], dev_path_use_scidd=scidd)['invoice']
+    inv = l1.rpc.dev_fetchinvoice(offer=offer['bolt12'], dev_path_use_scidd=scidd)['invoice']
 
     l1.rpc.pay(inv)
 
@@ -5740,9 +5740,9 @@ def test_offer_paths(node_factory, bitcoind):
 
     chan = only_one(l1.rpc.listpeerchannels()['channels'])
     scidd = "{}/{}".format(chan['short_channel_id'], chan['direction'])
-    offer = l2.rpc.offer(amount='100sat', description='test_offer_paths',
-                         dev_paths=[[scidd, l2.info['id']],
-                                    [l3.info['id'], l2.info['id']]])
+    offer = l2.rpc.dev_offer(amount='100sat', description='test_offer_paths',
+                             dev_paths=[[scidd, l2.info['id']],
+                                        [l3.info['id'], l2.info['id']]])
 
     paths = l1.rpc.decode(offer['bolt12'])['offer_paths']
     assert len(paths) == 2


### PR DESCRIPTION
CI was broken by https://github.com/ElementsProject/lightning/pull/8178. In the tests lines like 

```
l2.rpc.dev_fetchinvoice(offer=offer['bolt12'], dev_reply_path=[l1.info['id'], l2.info['id']])
```

would now call the new commands from https://github.com/ElementsProject/lightning/pull/8178 but they are missing the dev arguments. Since in the past these were not included aswell i have added `dev_` versions of these (like `dev_pay`) and renamed the calls to these where dev options were used. Also, since now these new commands were used, calling `offer` with an int failed in the `is_currency` check, since it expected a string. `offer` does allow ints in the spec so i fixed `is_currency`

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 05TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 12th_, RC2 on _May 16th_, ...
>
> The final release is on MAY 20TH.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
