### PR TITLE
doc: Remove mentions of 'helpme' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ the lightning network.
 There are also numerous plugins available for Core Lightning which add
 capabilities: in particular there's a collection at: https://github.com/lightningd/plugins
 
-Including [helpme][helpme-github] which guides you through setting up
-your first channels and customizing your node.
-
 For a less reckless experience, you can encrypt the HD wallet seed:
  see [HD wallet encryption](#hd-wallet-encryption).
 

--- a/doc/beginners-guide/beginners-guide.md
+++ b/doc/beginners-guide/beginners-guide.md
@@ -57,6 +57,6 @@ Useful commands:
 
 Once you've started for the first time, there's a script called `contrib/bootstrap-node.sh` which will connect you to other nodes on the lightning network.
 
-There are also numerous plugins available for Core Lightning which add capabilities: see the [Plugins](doc:plugins) guide, and check out the plugin collection at: <https://github.com/lightningd/plugins>, including [helpme](https://github.com/lightningd/plugins/tree/master/helpme) which guides you through setting up your first channels and customising your node.
+There are also numerous plugins available for Core Lightning which add capabilities: see the [Plugins](doc:plugins) guide, and check out the plugin collection at: <https://github.com/lightningd/plugins>.
 
 For a less reckless experience, you can encrypt the HD wallet seed: see [HD wallet encryption](doc:backup-and-recovery#hsm-secret-backup).

--- a/doc/node-operators-guide/faq.md
+++ b/doc/node-operators-guide/faq.md
@@ -8,34 +8,6 @@ updatedAt: "2023-07-05T09:42:38.017Z"
 ---
 # General questions
 
-### I don't know where to start, help me !
-
-There is a Core Lightning plugin specifically for this purpose, it's called [`helpme`](https://github.com/lightningd/plugins/tree/master/helpme).
-
-Assuming you have followed the [installation steps](doc:installation), have `lightningd` up and running, and `lightning-cli` in your `$PATH` you can start the plugin like so:
-
-```shell
-# Clone the plugins repository
-git clone https://github.com/lightningd/plugins
-# Make sure the helpme plugin is executable (git should have already handled this)
-chmod +x plugins/helpme/helpme.py
-# Install its dependencies (there is only one actually)
-pip3 install --user -r plugins/helpme/requirements.txt
-# Then just start it :)
-lightning-cli plugin start $PWD/plugins/helpme/helpme.py
-```
-
-
-
-The plugin registers a new command `helpme` which will guide you through the main  
-components of C-lightning:
-
-```shell
-lightning-cli helpme
-```
-
-
-
 ### How to get the balance of each channel ?
 
 You can use the `listfunds` command and take a ratio of `our_amount_msat` over  


### PR DESCRIPTION
Links to 'helpme' plugin on the website are dead. It turned out that plugin has been archived but website has not been updated.

This PR removes mentions of the plugin form README and doc. It removes FAQ's section _**I don't know where to start, help me !**_ without substitution.