### PR TITLE
Fix connect address failures

### DIFF
--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -296,10 +296,6 @@ struct daemon {
 	 * resort, but doing so leaks our address so can be disabled. */
 	bool use_dns;
 
-	/* The address that the broken response returns instead of
-	 * NXDOMAIN. NULL if we have not detected a broken resolver. */
-	struct sockaddr *broken_resolver_response;
-
 	/* File descriptors to listen on once we're activated. */
 	const struct listen_fd **listen_fds;
 

--- a/connectd/connectd.h
+++ b/connectd/connectd.h
@@ -149,7 +149,10 @@ struct important_id {
 
 	struct node_id id;
 	struct wireaddr_internal *addrs;
+
+	/* Backoff timer (increases by 2 each time) */
 	size_t reconnect_secs;
+	struct oneshot *reconnect_timer;
 };
 
 static const struct node_id *important_id_keyof(const struct important_id *imp)

--- a/connectd/connectd_wire.csv
+++ b/connectd/connectd_wire.csv
@@ -65,7 +65,6 @@ msgtype,connectd_connect_to_peer,2001
 msgdata,connectd_connect_to_peer,id,node_id,
 msgdata,connectd_connect_to_peer,len,u32,
 msgdata,connectd_connect_to_peer,addrs,wireaddr_internal,len
-msgdata,connectd_connect_to_peer,dns_fallback,bool,
 msgdata,connectd_connect_to_peer,transient,bool,
 
 # Connectd->master: connect failed.

--- a/lightningd/connect_control.c
+++ b/lightningd/connect_control.c
@@ -237,7 +237,7 @@ static struct command_result *json_connect(struct command *cmd,
 	}
 
 	subd_send_msg(cmd->ld->connectd,
-		      take(towire_connectd_connect_to_peer(NULL, &id_addr.id, addr, true, true)));
+		      take(towire_connectd_connect_to_peer(NULL, &id_addr.id, addr, true)));
 
 	/* Leave this here for peer_connected, connect_failed or peer_disconnect_done. */
 	new_connect(cmd->ld, &id_addr.id, cmd);
@@ -436,7 +436,7 @@ void connectd_connect_to_peer(struct lightningd *ld,
 	}
 	subd_send_msg(peer->ld->connectd,
 		      take(towire_connectd_connect_to_peer(NULL, &peer->id,
-							   waddr, true,
+							   waddr,
 							   !is_important)));
 }
 

--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -188,7 +188,6 @@ static void handle_connect_to_peer(struct subd *gossip, const u8 *msg)
 	connectmsg = towire_connectd_connect_to_peer(NULL,
 						     &id,
 						     NULL,	//addrhint,
-						     false,	//dns_fallback
 						     true);	//transient
 	subd_send_msg(gossip->ld->connectd, take(connectmsg));
 }


### PR DESCRIPTION
Remove DNS lookups altogether which are fairly useless and cause problems (being sync!).  And remove an ugliness where we could have multiple reconnect timers running at once.

Fixes: https://github.com/ElementsProject/lightning/issues/7913
Fixes: #8157