### PR TITLE
common/bolt11: validate public keys in routing hints

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -501,6 +501,9 @@ static const char *decode_r(struct bolt11 *b11,
 		if (!fromwire_route_info(&r8, &rlen, &ri)) {
 			return tal_fmt(b11, "r: hop %zu truncated", n);
 		}
+		if (!node_id_valid(&ri.pubkey)) {
+			return tal_fmt(b11, "r: hop %zu pubkey invalid", n);
+		}
 		tal_arr_expand(&r, ri);
 	} while (rlen);
 

--- a/common/test/run-bolt11.c
+++ b/common/test/run-bolt11.c
@@ -731,6 +731,11 @@ int main(int argc, char *argv[])
 	assert(!bolt11_decode(tmpctx, "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdqcgfskggz423rz6wp6yrc2pgpqcqpjmyveg8ccprmlssyae9l33an2m0qz3qcfcavt7wdzrdqyx5q7hqmp7ne08uvwlwaaqwt4lxgmjh5gce3hv0m8tzwkzfshpdv9d5p9pcsp5v86r0", NULL, NULL, NULL, &fail));
 	assert(streq(fail, "d: invalid utf8"));
 
+	/* Invalid private routes. */
+	/* Invalid route pubkey. */
+	assert(!bolt11_decode(tmpctx, "lnbc1qqygh9qpp50qzxqqqqqpqqrzjcqqqqqqqqqqqqqqqqqqqqqqqqqqcqpjqqqqqqrzjcqqqqqcqpjqqqqqqqqqqqqqqqqqqqqqqqqqcq9qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqdqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlqqqqqqqqqqqqqqqqqqqqqqq4murj7", NULL, NULL, NULL, &fail));
+	assert(streq(fail, "r: hop 0 pubkey invalid"));
+
 	/* FIXME: Test the others! */
 	common_shutdown();
 }


### PR DESCRIPTION
This PR adds validation of public keys in BOLT11 routing hints to prevent processing of malformed public keys. Without this validation, invalid public keys could be accepted.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
