### PR TITLE
psbt: unused code path could leak

### DIFF
--- a/bitcoin/tx.c
+++ b/bitcoin/tx.c
@@ -553,7 +553,7 @@ struct bitcoin_tx *bitcoin_tx_with_psbt(const tal_t *ctx, struct wally_psbt *psb
 	size_t locktime;
 
 	if (!taken(psbt))
-		psbt = clone_psbt(NULL, psbt);
+		psbt = clone_psbt(tmpctx, psbt);
 
 	wally_psbt_get_locktime(psbt, &locktime);
 	struct bitcoin_tx *tx = bitcoin_tx(ctx, chainparams,


### PR DESCRIPTION
If `wally_psbt_extract ` fails the function returns early leaking psbt, if it was `taken()`.

Throw it on tmpctx so its not leaked in this case.

Changelog-None