### PR TITLE
common/amount: prevent scaling with invalid factors in amount scale functions

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -336,6 +336,9 @@ WARN_UNUSED_RESULT bool amount_msat_scale(struct amount_msat *val,
 					  struct amount_msat msat,
 					  double scale)
 {
+	if (scale != scale || scale < 0)
+		return false;
+
 	double scaled = msat.millisatoshis * scale;
 
 	/* If mantissa is < 64 bits, a naive "if (scaled >
@@ -350,6 +353,9 @@ WARN_UNUSED_RESULT bool amount_sat_scale(struct amount_sat *val,
 					 struct amount_sat sat,
 					 double scale)
 {
+	if (scale != scale || scale < 0)
+		return false;
+
 	double scaled = sat.satoshis * scale;
 
 	/* If mantissa is < 64 bits, a naive "if (scaled >


### PR DESCRIPTION
Add checks in `amount_msat_scale()` and `amount_sat_scale()` to return false when the scaling factor is -NaN or negative.

This is important as the scaling factor may come from external sources like wire, which can cause runtime errors if not handled properly.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
