### PR TITLE
ci: Fix noble repro build by updating sqlite3 version and shasums

### DIFF
--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -133,7 +133,7 @@ cc3f9f7a1e576173fb59c36652c0a67c6426feae752b352404ba92dfcb1b26c9  /var/cache/apt
 5ae9a98e73545002cd891f028859941af2a3c760cb6190e635c7ef36953912de  /var/cache/apt/archives/automake_1%3a1.16.5-1.3ubuntu1_all.deb
 0e0bb8b25153ed1c44ab92bc219eed469fcb5820c5c0bc6454b2fd366a33d3ee  /var/cache/apt/archives/gcc_4%3a13.2.0-7ubuntu1_amd64.deb
 f11b4d687a305dd7ee47a384d82a9bf04de913362df9efa67d2a029ae65051a9  /var/cache/apt/archives/libsodium-dev_1.0.18-1build3_amd64.deb
-ce9a34ae09d8f3c8ec13c9e23372c029894e840f3fa1ce5d6bb41f58e9164d91  /var/cache/apt/archives/libsqlite3-dev_3.45.1-1ubuntu2.1_amd64.deb
+67819a30934b772bcc41ca991cc99c4616ccb212b90cd3f9796e8eacca23cc3e  /var/cache/apt/archives/libsqlite3-dev_3.45.1-1ubuntu2.3_amd64.deb
 9d1d707179675d38e024bb13613b1d99e0d33fa6c45e5f3bcba19340781781d3  /var/cache/apt/archives/libtool_2.4.7-7build1_all.deb
 1fe6a815b56c7b6e9ce4086a363f09444bbd0a0d30e230c453d0b78e44b57a99  /var/cache/apt/archives/make_4.3-4.1build2_amd64.deb
 023cbe9dbf0af87f10e54e342c67571874e412b9950d89c6cd7b010be2e67c3c  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg-3.1ubuntu2.1_amd64.deb


### PR DESCRIPTION
The reproducible build is currently failing on Ubuntu Noble, causing the daily `Repro Build Nightly` GitHub action to fail and triggering email notifications.

This update resolves the issue by adjusting the default sqlite3 version and checksums to match the packages now available in Noble, allowing the image to build successfully.

Changelog-None.

