### PR TITLE
Askrene: add Goldberg-Tarjan's MCF solver

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -532,6 +532,13 @@ struct amount_msat amount_msat_div(struct amount_msat msat, u64 div)
 	return msat;
 }
 
+struct amount_msat amount_msat_div_ceil(struct amount_msat msat, u64 div)
+{
+	u64 res = msat.millisatoshis / div;
+	msat.millisatoshis = res + (div * res == msat.millisatoshis ? 0 : 1);
+	return msat;
+}
+
 struct amount_sat amount_sat_div(struct amount_sat sat, u64 div)
 {
 	sat.satoshis /= div;

--- a/common/amount.h
+++ b/common/amount.h
@@ -104,7 +104,13 @@ WARN_UNUSED_RESULT bool amount_sat_add_sat_s64(struct amount_sat *val,
 WARN_UNUSED_RESULT bool amount_msat_accumulate(struct amount_msat *a,
 					       struct amount_msat b);
 
+/* returns floor(msat/div) */
 struct amount_msat amount_msat_div(struct amount_msat msat, u64 div);
+
+/* returns ceil(msat/div) */
+struct amount_msat amount_msat_div_ceil(struct amount_msat msat, u64 div);
+
+/* returns floor(sat/div) */
 struct amount_sat amount_sat_div(struct amount_sat sat, u64 div);
 
 bool amount_sat_mul(struct amount_sat *res, struct amount_sat sat, u64 mul);

--- a/common/test/run-amount.c
+++ b/common/test/run-amount.c
@@ -163,6 +163,75 @@ static void test_amount_with_fee(void)
 			    2100000001234567890ULL);
 }
 
+static void test_case_amount_div(u64 input, u64 div, u64 expected)
+{
+	struct amount_msat msat = amount_msat(input);
+	struct amount_msat expected_msat = amount_msat(expected);
+	struct amount_msat result_msat = amount_msat_div(msat, div);
+	assert(amount_msat_eq(result_msat, expected_msat));
+}
+
+static void test_case_amount_div_ceil(u64 input, u64 div, u64 expected)
+{
+	struct amount_msat msat = amount_msat(input);
+	struct amount_msat expected_msat = amount_msat(expected);
+	struct amount_msat result_msat = amount_msat_div_ceil(msat, div);
+	assert(amount_msat_eq(result_msat, expected_msat));
+}
+
+static void test_amount_div(void)
+{
+	test_case_amount_div(1, 1, 1);
+	test_case_amount_div(1, 2, 0);
+	test_case_amount_div(1, 3, 0);
+
+	test_case_amount_div(2, 1, 2);
+	test_case_amount_div(2, 2, 1);
+	test_case_amount_div(2, 3, 0);
+
+	test_case_amount_div(3, 1, 3);
+	test_case_amount_div(3, 2, 1);
+	test_case_amount_div(3, 3, 1);
+	test_case_amount_div(3, 4, 0);
+
+	test_case_amount_div(10, 1, 10);
+	test_case_amount_div(10, 2, 5);
+	test_case_amount_div(10, 3, 3);
+	test_case_amount_div(10, 4, 2);
+	test_case_amount_div(10, 5, 2);
+	test_case_amount_div(10, 6, 1);
+	test_case_amount_div(10, 7, 1);
+	test_case_amount_div(10, 8, 1);
+	test_case_amount_div(10, 9, 1);
+	test_case_amount_div(10, 10, 1);
+	test_case_amount_div(10, 11, 0);
+
+	test_case_amount_div_ceil(1, 1, 1);
+	test_case_amount_div_ceil(1, 2, 1);
+	test_case_amount_div_ceil(1, 3, 1);
+
+	test_case_amount_div_ceil(2, 1, 2);
+	test_case_amount_div_ceil(2, 2, 1);
+	test_case_amount_div_ceil(2, 3, 1);
+
+	test_case_amount_div_ceil(3, 1, 3);
+	test_case_amount_div_ceil(3, 2, 2);
+	test_case_amount_div_ceil(3, 3, 1);
+	test_case_amount_div_ceil(3, 4, 1);
+
+	test_case_amount_div_ceil(10, 1, 10);
+	test_case_amount_div_ceil(10, 2, 5);
+	test_case_amount_div_ceil(10, 3, 4);
+	test_case_amount_div_ceil(10, 4, 3);
+	test_case_amount_div_ceil(10, 5, 2);
+	test_case_amount_div_ceil(10, 6, 2);
+	test_case_amount_div_ceil(10, 7, 2);
+	test_case_amount_div_ceil(10, 8, 2);
+	test_case_amount_div_ceil(10, 9, 2);
+	test_case_amount_div_ceil(10, 10, 1);
+	test_case_amount_div_ceil(10, 11, 1);
+}
+
 #define FAIL_MSAT(msatp, str)					\
 	assert(!parse_amount_msat((msatp), (str), strlen(str)))
 #define PASS_MSAT(msatp, str, val)					\
@@ -330,5 +399,6 @@ int main(int argc, char *argv[])
 	}
 
 	test_amount_with_fee();
+	test_amount_div();
 	common_shutdown();
 }

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -16125,7 +16125,7 @@
         "",
         "Layers are generally maintained by plugins, either to contain persistent information about capacities which have been discovered, or to contain transient information for this particular payment (such as blinded paths or routehints).",
         "",
-        "There are three automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities. *auto.sourcefree* overrides all channels (including those from previous layers) leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node.  And *auto.no_mpp_support* forces getroutes to return a single flow, though only basic checks are done that the result is useful."
+        "There are three automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities. *auto.sourcefree* overrides all channels (including those from previous layers) leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node.  And *auto.no_mpp_support* forces getroutes to return a single path solution which is useful for payments for which MPP is not supported."
       ],
       "categories": [
         "readonly"

--- a/doc/schemas/getroutes.json
+++ b/doc/schemas/getroutes.json
@@ -11,7 +11,7 @@
     "",
     "Layers are generally maintained by plugins, either to contain persistent information about capacities which have been discovered, or to contain transient information for this particular payment (such as blinded paths or routehints).",
     "",
-    "There are three automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities. *auto.sourcefree* overrides all channels (including those from previous layers) leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node.  And *auto.no_mpp_support* forces getroutes to return a single flow, though only basic checks are done that the result is useful."
+    "There are three automatic layers: *auto.localchans* contains information on local channels from this node (including non-public ones), and their exact current spendable capacities. *auto.sourcefree* overrides all channels (including those from previous layers) leading out of the *source* to be zero fee and zero delay.  These are both useful in the case where the source is the current node.  And *auto.no_mpp_support* forces getroutes to return a single path solution which is useful for payments for which MPP is not supported."
   ],
   "categories": [
     "readonly"

--- a/plugins/askrene/Makefile
+++ b/plugins/askrene/Makefile
@@ -22,6 +22,7 @@ PLUGIN_ASKRENE_HEADER := \
 	plugins/askrene/explain_failure.h \
 	plugins/askrene/graph.h \
 	plugins/askrene/priorityqueue.h \
+	plugins/askrene/queue.h \
 	plugins/askrene/algorithm.h
 
 PLUGIN_ASKRENE_OBJS := $(PLUGIN_ASKRENE_SRC:.c=.o)

--- a/plugins/askrene/algorithm.h
+++ b/plugins/askrene/algorithm.h
@@ -176,4 +176,23 @@ bool mcf_refinement(const tal_t *ctx,
 		    const s64 *cost,
 		    s64 *potential);
 
+/* Minimum-Cost Flow "cost scaling, push/relabel"
+ *
+ * see Goldberg-Tarjan "Finding Minimum-Cost Circulations by Successive
+ * Approximation" Math. of Op. Research, Vol. 15, No. 3 (Aug. 1990), pp.
+ * 430--466.
+ *
+ * @ctx: allocator.
+ * @graph: graph, assumes the existence of reverse (dual) arcs.
+ * @supply: supply/demand encoding, supply[i]>0 for source nodes and supply[i]<0
+ * for sinks. It is modified by the algorithm execution. When a feasible
+ * solution is found supply[i] = 0 for every node.
+ * @residual_capacity: residual capacity on arcs, here the final solution is
+ * encoded.
+ * @cost: cost per unit of flow on arcs. It is assumed that dual arcs have the
+ * opposite cost of its twin: cost[i] = -cost[dual(i)].
+ * */
+bool goldberg_tarjan_mcf(const tal_t *ctx, const struct graph *graph,
+			 s64 *supply, s64 *residual_capacity, const s64 *cost);
+
 #endif /* LIGHTNING_PLUGINS_ASKRENE_ALGORITHM_H */

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -19,11 +19,9 @@
 #include <errno.h>
 #include <math.h>
 #include <plugins/askrene/askrene.h>
-#include <plugins/askrene/explain_failure.h>
 #include <plugins/askrene/flow.h>
 #include <plugins/askrene/layer.h>
 #include <plugins/askrene/mcf.h>
-#include <plugins/askrene/refine.h>
 #include <plugins/askrene/reserve.h>
 
 /* "spendable" for a channel assumes a single HTLC: for additional HTLCs,
@@ -333,22 +331,6 @@ const char *fmt_flow_full(const tal_t *ctx,
 	return str;
 }
 
-static struct amount_msat linear_flows_cost(struct flow **flows,
-					    struct amount_msat total_amount,
-					    double delay_feefactor)
-{
-	struct amount_msat total = AMOUNT_MSAT(0);
-
-	for (size_t i = 0; i < tal_count(flows); i++) {
-		if (!amount_msat_accumulate(&total,
-					    linear_flow_cost(flows[i],
-							     total_amount,
-							     delay_feefactor)))
-			abort();
-	}
-	return total;
-}
-
 /* Returns an error message, or sets *routes */
 static const char *get_routes(const tal_t *ctx,
 			      struct command *cmd,
@@ -371,8 +353,6 @@ static const char *get_routes(const tal_t *ctx,
 	struct route_query *rq = tal(ctx, struct route_query);
 	struct flow **flows;
 	const struct gossmap_node *srcnode, *dstnode;
-	double delay_feefactor;
-	u32 mu;
 	const char *ret;
 	struct timerel time_delta;
 	struct timemono time_start = time_mono();
@@ -446,109 +426,15 @@ static const char *get_routes(const tal_t *ctx,
 		goto fail;
 	}
 
-	delay_feefactor = 1.0/1000000;
-
-	/* First up, don't care about fees (well, just enough to tiebreak!) */
-	mu = 1;
-	flows = minflow(rq, rq, srcnode, dstnode, amount,
-			mu, delay_feefactor, single_path);
-	if (!flows) {
-		ret = explain_failure(ctx, rq, srcnode, dstnode, amount);
+	/* FIXME: single_path should signal a change in algorithm. */
+	ret = default_routes(rq, rq, srcnode, dstnode, amount, single_path,
+			     maxfee, finalcltv, maxdelay, &flows, probability);
+	if (ret) {
 		goto fail;
 	}
-
-	/* Too much delay? */
-	while (finalcltv + flows_worst_delay(flows) > maxdelay) {
-		delay_feefactor *= 2;
-		rq_log(tmpctx, rq, LOG_UNUSUAL,
-		       "The worst flow delay is %"PRIu64" (> %i), retrying with delay_feefactor %f...",
-		       flows_worst_delay(flows), maxdelay - finalcltv, delay_feefactor);
-		flows = minflow(rq, rq, srcnode, dstnode, amount,
-				mu, delay_feefactor, single_path);
-		if (!flows || delay_feefactor > 10) {
-			ret = rq_log(ctx, rq, LOG_UNUSUAL,
-				     "Could not find route without excessive delays");
-			goto fail;
-		}
-	}
-
-	/* Too expensive? */
-too_expensive:
-	while (amount_msat_greater(flowset_fee(rq->plugin, flows), maxfee)) {
-		struct flow **new_flows;
-
-		if (mu == 1)
-			mu = 10;
-		else
-			mu += 10;
-		rq_log(tmpctx, rq, LOG_UNUSUAL,
-		       "The flows had a fee of %s, greater than max of %s, retrying with mu of %u%%...",
-		       fmt_amount_msat(tmpctx, flowset_fee(rq->plugin, flows)),
-		       fmt_amount_msat(tmpctx, maxfee),
-		       mu);
-		new_flows = minflow(rq, rq, srcnode, dstnode, amount,
-				    mu > 100 ? 100 : mu, delay_feefactor, single_path);
-		if (!flows || mu >= 100) {
-			ret = rq_log(ctx, rq, LOG_UNUSUAL,
-				     "Could not find route without excessive cost");
-			goto fail;
-		}
-
-		/* This is possible, because MCF's linear fees are not the same. */
-		if (amount_msat_greater(flowset_fee(rq->plugin, new_flows),
-					flowset_fee(rq->plugin, flows))) {
-			struct amount_msat old_cost = linear_flows_cost(flows, amount, delay_feefactor);
-			struct amount_msat new_cost = linear_flows_cost(new_flows, amount, delay_feefactor);
-			if (amount_msat_greater_eq(new_cost, old_cost)) {
-				rq_log(tmpctx, rq, LOG_BROKEN, "Old flows cost %s:",
-				       fmt_amount_msat(tmpctx, old_cost));
-				for (size_t i = 0; i < tal_count(flows); i++) {
-					rq_log(tmpctx, rq, LOG_BROKEN,
-					       "Flow %zu/%zu: %s (linear cost %s)", i, tal_count(flows),
-					       fmt_flow_full(tmpctx, rq, flows[i]),
-					       fmt_amount_msat(tmpctx, linear_flow_cost(flows[i],
-											amount,
-											delay_feefactor)));
-				}
-				rq_log(tmpctx, rq, LOG_BROKEN, "Old flows cost %s:",
-				       fmt_amount_msat(tmpctx, new_cost));
-				for (size_t i = 0; i < tal_count(new_flows); i++) {
-					rq_log(tmpctx, rq, LOG_BROKEN,
-					       "Flow %zu/%zu: %s (linear cost %s)", i, tal_count(new_flows),
-					       fmt_flow_full(tmpctx, rq, new_flows[i]),
-					       fmt_amount_msat(tmpctx, linear_flow_cost(new_flows[i],
-											amount,
-											delay_feefactor)));
-				}
-			}
-		}
-		tal_free(flows);
-		flows = new_flows;
-	}
-
-	if (finalcltv + flows_worst_delay(flows) > maxdelay) {
-		ret = rq_log(ctx, rq, LOG_UNUSUAL,
-			     "Could not find route without excessive cost or delays");
-		goto fail;
-	}
-
-	/* The above did not take into account the extra funds to pay
-	 * fees, so we try to adjust now.  We could re-run MCF if this
-	 * fails, but failure basically never happens where payment is
-	 * still possible */
-	ret = refine_with_fees_and_limits(ctx, rq, amount, &flows, probability);
-	if (ret)
-		goto fail;
-
-	/* Again, a tiny corner case: refine step can make us exceed maxfee */
-	if (amount_msat_greater(flowset_fee(rq->plugin, flows), maxfee)) {
-		rq_log(tmpctx, rq, LOG_UNUSUAL,
-		       "After final refinement, fee was excessive: retrying");
-		goto too_expensive;
-	}
-
-	rq_log(tmpctx, rq, LOG_DBG, "Final answer has %zu flows with mu=%u",
-	       tal_count(flows), mu);
+	assert(tal_count(flows) > 0);
+	rq_log(tmpctx, rq, LOG_DBG, "Final answer has %zu flows",
+	       tal_count(flows));
 
 	/* Convert back into routes, with delay and other information fixed */
 	*routes = tal_arr(ctx, struct route *, tal_count(flows));

--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -337,6 +337,8 @@ enum algorithm {
 	/* Algorithm that finds the optimal routing solution constrained to a
 	 * single path. */
 	ALGO_SINGLE_PATH,
+	/* Min. Cost Flow by Successive Approximations, aka. Cost Scaling. */
+	ALGO_GOLDBERG_TARJAN,
 };
 
 static struct command_result *
@@ -349,6 +351,8 @@ param_algorithm(struct command *cmd, const char *name, const char *buffer,
 		**algo = ALGO_DEFAULT;
 	else if (streq(algo_str, "single-path"))
 		**algo = ALGO_SINGLE_PATH;
+	else if (streq(algo_str, "goldberg-tarjan"))
+		**algo = ALGO_GOLDBERG_TARJAN;
 	else
 		return command_fail_badparam(cmd, name, buffer, tok,
 					     "unknown algorithm");
@@ -604,6 +608,10 @@ static struct command_result *do_getroutes(struct command *cmd,
 		    rq, rq, srcnode, dstnode, *info->amount,
 		    *info->maxfee, *info->finalcltv, *info->maxdelay, &flows,
 		    &probability);
+	} else if (*info->dev_algo == ALGO_GOLDBERG_TARJAN) {
+		err = goldberg_tarjan_routes(
+		    rq, rq, srcnode, dstnode, *info->amount, *info->maxfee,
+		    *info->finalcltv, *info->maxdelay, &flows, &probability);
 	} else {
 		assert(*info->dev_algo == ALGO_DEFAULT);
 		err = default_routes(rq, rq, srcnode, dstnode, *info->amount,

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <ccan/asort/asort.h>
 #include <ccan/bitmap/bitmap.h>
+#include <ccan/err/err.h>
 #include <ccan/list/list.h>
 #include <ccan/tal/str/str.h>
 #include <ccan/tal/tal.h>
@@ -158,6 +159,10 @@
  * Prob(reliable)/Prob(cheapest) = Exp(Cost_prob(cheapest)-Cost_prob(reliable))
  *
  * */
+
+#define PANIC(message)                                                         \
+	errx(1, "Panic in function %s line %d: %s", __func__, __LINE__,        \
+	     message);
 
 #define PARTS_BITS 2
 #define CHANNEL_PARTS (1 << PARTS_BITS)
@@ -317,6 +322,28 @@ static void set_capacity(s64 *capacity, u64 value, u64 *cap_on_capacity)
 {
 	*capacity = MIN(value, *cap_on_capacity);
 	*cap_on_capacity -= *capacity;
+}
+
+/* FIXME: unit test this */
+/* The probability of forwarding a payment amount given a high and low liquidity
+ * bounds.
+ * @low: the liquidity is known to be greater or equal than "low"
+ * @high: the liquidity is known to be less than "high"
+ * @amount: how much is required to forward */
+static double pickhardt_richter_probability(struct amount_msat low,
+					    struct amount_msat high,
+					    struct amount_msat amount)
+{
+	struct amount_msat all_states, good_states;
+	if (amount_msat_greater_eq(amount, high))
+		return 0.0;
+	if (!amount_msat_sub(&amount, amount, low))
+		return 1.0;
+	if (!amount_msat_sub(&all_states, high, low))
+		PANIC("we expect high > low");
+	if (!amount_msat_sub(&good_states, all_states, amount))
+		PANIC("we expect high > amount");
+	return amount_msat_ratio(good_states, all_states);
 }
 
 // TODO(eduardo): unit test this
@@ -867,6 +894,46 @@ get_flow_paths(const tal_t *ctx,
 	return flows;
 }
 
+/* Given a single path build a flow set. */
+static struct flow **
+get_flow_singlepath(const tal_t *ctx, const struct pay_parameters *params,
+		    const struct graph *graph, const struct gossmap *gossmap,
+		    const struct node source, const struct node destination,
+		    const u64 pay_amount, const struct arc *prev)
+{
+	struct flow **flows = tal_arr(ctx, struct flow *, 0);
+
+	size_t length = 0;
+
+	for (u32 cur_idx = destination.idx; cur_idx != source.idx;) {
+		assert(cur_idx != INVALID_INDEX);
+		length++;
+		struct arc arc = prev[cur_idx];
+		struct node next = arc_tail(graph, arc);
+		cur_idx = next.idx;
+	}
+	struct flow *f = tal(ctx, struct flow);
+	f->path = tal_arr(f, const struct gossmap_chan *, length);
+	f->dirs = tal_arr(f, int, length);
+
+	for (u32 cur_idx = destination.idx; cur_idx != source.idx;) {
+		int chandir;
+		u32 chanidx;
+		struct arc arc = prev[cur_idx];
+		arc_to_parts(arc, &chanidx, &chandir, NULL, NULL);
+
+		length--;
+		f->path[length] = gossmap_chan_byidx(gossmap, chanidx);
+		f->dirs[length] = chandir;
+
+		struct node next = arc_tail(graph, arc);
+		cur_idx = next.idx;
+	}
+	f->delivers = params->amount;
+	tal_arr_expand(&flows, f);
+	return flows;
+}
+
 // TODO(eduardo): choose some default values for the minflow parameters
 /* eduardo: I think it should be clear that this module deals with linear
  * flows, ie. base fees are not considered. Hence a flow along a path is
@@ -1025,6 +1092,186 @@ static struct amount_msat linear_flows_cost(struct flow **flows,
 	return total;
 }
 
+/* Initialize the data vectors for the single-path solver. */
+static void init_linear_network_single_path(
+    const tal_t *ctx, const struct pay_parameters *params, struct graph **graph,
+    double **arc_prob_cost, s64 **arc_fee_cost, s64 **arc_capacity)
+{
+	const size_t max_num_chans = gossmap_max_chan_idx(params->rq->gossmap);
+	const size_t max_num_arcs = max_num_chans * ARCS_PER_CHANNEL;
+	const size_t max_num_nodes = gossmap_max_node_idx(params->rq->gossmap);
+
+	*graph = graph_new(ctx, max_num_nodes, max_num_arcs, ARC_DUAL_BITOFF);
+	*arc_prob_cost = tal_arr(ctx, double, max_num_arcs);
+	for (size_t i = 0; i < max_num_arcs; ++i)
+		(*arc_prob_cost)[i] = DBL_MAX;
+
+	*arc_fee_cost = tal_arr(ctx, s64, max_num_arcs);
+	for (size_t i = 0; i < max_num_arcs; ++i)
+		(*arc_fee_cost)[i] = INT64_MAX;
+	*arc_capacity = tal_arrz(ctx, s64, max_num_arcs);
+
+	const struct gossmap *gossmap = params->rq->gossmap;
+
+	for (struct gossmap_node *node = gossmap_first_node(gossmap); node;
+	     node = gossmap_next_node(gossmap, node)) {
+		const u32 node_id = gossmap_node_idx(gossmap, node);
+
+		for (size_t j = 0; j < node->num_chans; ++j) {
+			int half;
+			const struct gossmap_chan *c =
+			    gossmap_nth_chan(gossmap, node, j, &half);
+                        struct amount_msat mincap, maxcap;
+
+			if (!gossmap_chan_set(c, half) ||
+			    !c->half[half].enabled)
+				continue;
+
+			/* If a channel cannot forward the total amount we don't
+			 * use it. */
+			if (amount_msat_less(params->amount,
+					     gossmap_chan_htlc_min(c, half)) ||
+			    amount_msat_greater(params->amount,
+						gossmap_chan_htlc_max(c, half)))
+				continue;
+
+			get_constraints(params->rq, c, half, &mincap, &maxcap);
+			/* Assume if min > max, min is wrong */
+			if (amount_msat_greater(mincap, maxcap))
+				mincap = maxcap;
+			/* It is preferable to work on 1msat past the known
+			 * bound. */
+			if (!amount_msat_accumulate(&maxcap, amount_msat(1)))
+				PANIC("maxcap + 1msat overflows");
+
+			/* If amount is greater than the known liquidity upper
+			 * bound we get infinite probability cost. */
+			if (amount_msat_greater_eq(params->amount, maxcap))
+				continue;
+
+			const u32 chan_id = gossmap_chan_idx(gossmap, c);
+
+			const struct gossmap_node *next =
+			    gossmap_nth_node(gossmap, c, !half);
+
+			const u32 next_id = gossmap_node_idx(gossmap, next);
+
+			/* channel to self? */
+			if (node_id == next_id)
+				continue;
+
+			struct arc arc =
+			    arc_from_parts(chan_id, half, 0, false);
+
+			graph_add_arc(*graph, arc, node_obj(node_id),
+				      node_obj(next_id));
+
+			(*arc_capacity)[arc.idx] = 1;
+			(*arc_prob_cost)[arc.idx] =
+			    (-1.0) * log(pickhardt_richter_probability(
+					 mincap, maxcap, params->amount));
+
+			struct amount_msat fee;
+			if (!amount_msat_fee(&fee, params->amount,
+					     c->half[half].base_fee,
+					     c->half[half].proportional_fee))
+				PANIC("fee overflow");
+			u32 fee_msat;
+			if (!amount_msat_to_u32(fee, &fee_msat))
+				PANIC("fee does not fit in u32");
+			(*arc_fee_cost)[arc.idx] =
+			    fee_msat +
+			    params->delay_feefactor * c->half[half].delay;
+		}
+	}
+}
+
+/* Similar to minflow but computes routes that have a single path. */
+struct flow **single_path_flow(const tal_t *ctx, const struct route_query *rq,
+			       const struct gossmap_node *source,
+			       const struct gossmap_node *target,
+			       struct amount_msat amount, u32 mu,
+			       double delay_feefactor)
+{
+	struct flow **flow_paths;
+	/* We allocate everything off this, and free it at the end,
+	 * as we can be called multiple times without cleaning tmpctx! */
+	tal_t *working_ctx = tal(NULL, char);
+	struct pay_parameters *params = tal(working_ctx, struct pay_parameters);
+
+	params->rq = rq;
+	params->source = source;
+	params->target = target;
+	params->amount = amount;
+	/* for the single-path solver the accuracy does not detriment
+	 * performance */
+	params->accuracy = amount;
+	params->delay_feefactor = delay_feefactor;
+	params->base_fee_penalty = base_fee_penalty_estimate(amount);
+
+	struct graph *graph;
+	double *arc_prob_cost;
+	s64 *arc_fee_cost;
+	s64 *arc_capacity;
+
+	init_linear_network_single_path(working_ctx, params, &graph,
+					&arc_prob_cost, &arc_fee_cost,
+					&arc_capacity);
+
+	const struct node dst = {.idx = gossmap_node_idx(rq->gossmap, target)};
+	const struct node src = {.idx = gossmap_node_idx(rq->gossmap, source)};
+
+	const size_t max_num_nodes = graph_max_num_nodes(graph);
+	const size_t max_num_arcs = graph_max_num_arcs(graph);
+
+	s64 *potential = tal_arrz(working_ctx, s64, max_num_nodes);
+	s64 *distance = tal_arrz(working_ctx, s64, max_num_nodes);
+	s64 *arc_cost = tal_arrz(working_ctx, s64, max_num_arcs);
+	struct arc *prev = tal_arrz(working_ctx, struct arc, max_num_nodes);
+
+	combine_cost_function(working_ctx, graph, arc_prob_cost, arc_fee_cost,
+			      rq->biases, mu, arc_cost);
+
+	/* We solve a linear cost flow problem. */
+	if (!dijkstra_path(working_ctx, graph, src, dst,
+			   /* prune = */ true, arc_capacity,
+			   /*threshold = */ 1, arc_cost, potential, prev,
+			   distance)) {
+                /* This might fail if we are unable to find a suitable route, it
+                 * doesn't mean the plugin is broken, that's why we LOG_INFORM. */
+		rq_log(tmpctx, rq, LOG_INFORM,
+		       "%s: could not find a feasible single path", __func__);
+		goto fail;
+	}
+	const u64 pay_amount =
+	    amount_msat_ratio_ceil(params->amount, params->accuracy);
+
+	/* We dissect the flow into payment routes.
+	 * Actual amounts considering fees are computed for every
+	 * channel in the routes. */
+	flow_paths = get_flow_singlepath(ctx, params, graph, rq->gossmap,
+					 src, dst, pay_amount, prev);
+	if (!flow_paths) {
+		rq_log(tmpctx, rq, LOG_BROKEN,
+		       "%s: failed to extract flow paths from the single-path "
+		       "solution",
+		       __func__);
+		goto fail;
+	}
+	if (tal_count(flow_paths) != 1) {
+		rq_log(
+		    tmpctx, rq, LOG_BROKEN,
+		    "%s: single-path solution returned a multi route solution",
+		    __func__);
+		goto fail;
+	}
+	tal_free(working_ctx);
+	return flow_paths;
+
+fail:
+	tal_free(working_ctx);
+	return NULL;
+}
 
 const char *default_routes(const tal_t *ctx, struct route_query *rq,
 			   const struct gossmap_node *srcnode,

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -952,8 +952,7 @@ struct flow **minflow(const tal_t *ctx,
 		      const struct gossmap_node *target,
 		      struct amount_msat amount,
 		      u32 mu,
-		      double delay_feefactor,
-		      bool single_part)
+		      double delay_feefactor)
 {
 	struct flow **flow_paths;
 	/* We allocate everything off this, and free it at the end,
@@ -1044,31 +1043,6 @@ struct flow **minflow(const tal_t *ctx,
 		goto fail;
 	}
 	tal_free(working_ctx);
-
-	/* This is dumb, but if you don't support MPP you don't deserve any
-	 * better.  Pile it into the largest part if not already. */
-	if (single_part) {
-		struct flow *best = flow_paths[0];
-		for (size_t i = 1; i < tal_count(flow_paths); i++) {
-			if (amount_msat_greater(flow_paths[i]->delivers, best->delivers))
-				best = flow_paths[i];
-		}
-		for (size_t i = 0; i < tal_count(flow_paths); i++) {
-			if (flow_paths[i] == best)
-				continue;
-			if (!amount_msat_accumulate(&best->delivers,
-						    flow_paths[i]->delivers)) {
-				rq_log(tmpctx, rq, LOG_BROKEN,
-				       "%s: failed to extract accumulate flow paths %s+%s",
-				       __func__,
-				       fmt_amount_msat(tmpctx, best->delivers),
-				       fmt_amount_msat(tmpctx, flow_paths[i]->delivers));
-				goto fail;
-			}
-		}
-		flow_paths[0] = best;
-		tal_resize(&flow_paths, 1);
-	}
 	return flow_paths;
 
 fail:
@@ -1273,13 +1247,16 @@ fail:
 	return NULL;
 }
 
-const char *default_routes(const tal_t *ctx, struct route_query *rq,
-			   const struct gossmap_node *srcnode,
-			   const struct gossmap_node *dstnode,
-			   struct amount_msat amount, bool single_path,
-			   struct amount_msat maxfee, u32 finalcltv,
-			   u32 maxdelay, struct flow ***flows,
-			   double *probability)
+static const char *
+linear_routes(const tal_t *ctx, struct route_query *rq,
+	      const struct gossmap_node *srcnode,
+	      const struct gossmap_node *dstnode, struct amount_msat amount,
+	      struct amount_msat maxfee, u32 finalcltv, u32 maxdelay,
+	      struct flow ***flows, double *probability,
+	      struct flow **(*solver)(const tal_t *, const struct route_query *,
+				      const struct gossmap_node *,
+				      const struct gossmap_node *,
+				      struct amount_msat, u32, double))
 {
 	*flows = NULL;
 	const char *ret;
@@ -1288,8 +1265,7 @@ const char *default_routes(const tal_t *ctx, struct route_query *rq,
 	/* First up, don't care about fees (well, just enough to tiebreak!) */
 	u32 mu = 1;
 	tal_free(*flows);
-	*flows = minflow(ctx, rq, srcnode, dstnode, amount, mu, delay_feefactor,
-			single_path);
+	*flows = solver(ctx, rq, srcnode, dstnode, amount, mu, delay_feefactor);
 	if (!*flows) {
 		ret = explain_failure(ctx, rq, srcnode, dstnode, amount);
 		goto fail;
@@ -1304,8 +1280,8 @@ const char *default_routes(const tal_t *ctx, struct route_query *rq,
 		       flows_worst_delay(*flows), maxdelay - finalcltv,
 		       delay_feefactor);
 		tal_free(*flows);
-		*flows = minflow(ctx, rq, srcnode, dstnode, amount, mu,
-				delay_feefactor, single_path);
+		*flows = solver(ctx, rq, srcnode, dstnode, amount, mu,
+				delay_feefactor);
 		if (!*flows || delay_feefactor > 10) {
 			ret = rq_log(
 			    ctx, rq, LOG_UNUSUAL,
@@ -1328,9 +1304,8 @@ too_expensive:
 		       "retrying with mu of %u%%...",
 		       fmt_amount_msat(tmpctx, flowset_fee(rq->plugin, *flows)),
 		       fmt_amount_msat(tmpctx, maxfee), mu);
-		new_flows =
-		    minflow(ctx, rq, srcnode, dstnode, amount,
-			    mu > 100 ? 100 : mu, delay_feefactor, single_path);
+		new_flows = solver(ctx, rq, srcnode, dstnode, amount,
+				   mu > 100 ? 100 : mu, delay_feefactor);
 		if (!*flows || mu >= 100) {
 			ret = rq_log(
 			    ctx, rq, LOG_UNUSUAL,
@@ -1410,4 +1385,28 @@ too_expensive:
 fail:
 	assert(ret != NULL);
 	return ret;
+}
+
+const char *default_routes(const tal_t *ctx, struct route_query *rq,
+			   const struct gossmap_node *srcnode,
+			   const struct gossmap_node *dstnode,
+			   struct amount_msat amount, struct amount_msat maxfee,
+			   u32 finalcltv, u32 maxdelay, struct flow ***flows,
+			   double *probability)
+{
+	return linear_routes(ctx, rq, srcnode, dstnode, amount, maxfee,
+			     finalcltv, maxdelay, flows, probability, minflow);
+}
+
+const char *single_path_routes(const tal_t *ctx, struct route_query *rq,
+			       const struct gossmap_node *srcnode,
+			       const struct gossmap_node *dstnode,
+			       struct amount_msat amount,
+			       struct amount_msat maxfee, u32 finalcltv,
+			       u32 maxdelay, struct flow ***flows,
+			       double *probability)
+{
+	return linear_routes(ctx, rq, srcnode, dstnode, amount, maxfee,
+			     finalcltv, maxdelay, flows, probability,
+			     single_path_flow);
 }

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -40,4 +40,14 @@ struct amount_msat linear_flow_cost(const struct flow *flow,
 				    struct amount_msat total_amount,
 				    double delay_feefactor);
 
+/* A wrapper to the min. cost flow solver that actually takes into consideration
+ * the extra msats per channel needed to pay for fees. */
+const char *default_routes(const tal_t *ctx, struct route_query *rq,
+			   const struct gossmap_node *srcnode,
+			   const struct gossmap_node *dstnode,
+			   struct amount_msat amount, bool single_path,
+			   struct amount_msat maxfee, u32 finalcltv,
+			   u32 maxdelay, struct flow ***flows,
+			   double *probability);
+
 #endif /* LIGHTNING_PLUGINS_ASKRENE_MCF_H */

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -31,8 +31,7 @@ struct flow **minflow(const tal_t *ctx,
 		      const struct gossmap_node *target,
 		      struct amount_msat amount,
 		      u32 mu,
-		      double delay_feefactor,
-		      bool single_part);
+		      double delay_feefactor);
 
 /**
  * API for min cost single path.
@@ -67,9 +66,18 @@ struct amount_msat linear_flow_cost(const struct flow *flow,
 const char *default_routes(const tal_t *ctx, struct route_query *rq,
 			   const struct gossmap_node *srcnode,
 			   const struct gossmap_node *dstnode,
-			   struct amount_msat amount, bool single_path,
+			   struct amount_msat amount,
 			   struct amount_msat maxfee, u32 finalcltv,
 			   u32 maxdelay, struct flow ***flows,
 			   double *probability);
+
+/* A wrapper to the single-path constrained solver. */
+const char *single_path_routes(const tal_t *ctx, struct route_query *rq,
+			       const struct gossmap_node *srcnode,
+			       const struct gossmap_node *dstnode,
+			       struct amount_msat amount,
+			       struct amount_msat maxfee, u32 finalcltv,
+			       u32 maxdelay, struct flow ***flows,
+			       double *probability);
 
 #endif /* LIGHTNING_PLUGINS_ASKRENE_MCF_H */

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -34,6 +34,28 @@ struct flow **minflow(const tal_t *ctx,
 		      double delay_feefactor,
 		      bool single_part);
 
+/**
+ * API for min cost single path.
+ * @ctx: context to allocate returned flows from
+ * @rq: the route_query we're processing (for logging)
+ * @source: the source to start from
+ * @target: the target to pay
+ * @amount: the amount we want to reach @target
+ * @mu: 0 = corresponds to only probabilities, 100 corresponds to only fee.
+ * @delay_feefactor: convert 1 block delay into msat.
+ *
+ * @delay_feefactor converts 1 block delay into msat, as if it were an additional
+ * fee.  So if a CLTV delay on a node is 5 blocks, that's treated as if it
+ * were a fee of 5 * @delay_feefactor.
+ *
+ * Returns an array with one flow which deliver amount to target, or NULL.
+ */
+struct flow **single_path_flow(const tal_t *ctx, const struct route_query *rq,
+			       const struct gossmap_node *source,
+			       const struct gossmap_node *target,
+			       struct amount_msat amount, u32 mu,
+			       double delay_feefactor);
+
 /* To sanity check: this is the approximation mcf uses for the cost
  * of each channel. */
 struct amount_msat linear_flow_cost(const struct flow *flow,

--- a/plugins/askrene/mcf.h
+++ b/plugins/askrene/mcf.h
@@ -80,4 +80,13 @@ const char *single_path_routes(const tal_t *ctx, struct route_query *rq,
 			       u32 maxdelay, struct flow ***flows,
 			       double *probability);
 
+/* A wrapper to the Goldberg-Tarjan's MCF solver. */
+const char *goldberg_tarjan_routes(const tal_t *ctx, struct route_query *rq,
+				   const struct gossmap_node *srcnode,
+				   const struct gossmap_node *dstnode,
+				   struct amount_msat amount,
+				   struct amount_msat maxfee, u32 finalcltv,
+				   u32 maxdelay, struct flow ***flows,
+				   double *probability);
+
 #endif /* LIGHTNING_PLUGINS_ASKRENE_MCF_H */

--- a/plugins/askrene/queue.h
+++ b/plugins/askrene/queue.h
@@ -1,0 +1,108 @@
+#ifndef LIGHTNING_PLUGINS_ASKRENE_QUEUE_H
+#define LIGHTNING_PLUGINS_ASKRENE_QUEUE_H
+
+#include "config.h"
+#include <ccan/compiler/compiler.h>
+#include <ccan/lqueue/lqueue.h>
+#include <ccan/tal/tal.h>
+
+/* Generic and efficient queue based on ccan/lqueue for primitive data.
+ * The size of the cache of 64 is the smallest power of two for which I obtain a
+ * significant time improvement over directly using lqueue, ie. one lqueue
+ * element for each item in the queue. For a small problem sizes (~10) the
+ * speed-up is 3x, for large problem sizes
+ * (>1000) the speed-up is 7x.
+ * ~0.5 operations/nsec */
+
+#define QUEUE_CACHE_SIZE 64
+
+#define QUEUE_DEFINE_TYPE(type, name)                                          \
+	struct name##_qcache_ {                                                \
+		struct lqueue_link qlink;                                      \
+		int begin, end;                                                \
+		type data[QUEUE_CACHE_SIZE];                                   \
+	};                                                                     \
+	static inline UNNEEDED bool name##_qcache_empty_(                      \
+	    const struct name##_qcache_ *qc)                                   \
+	{                                                                      \
+		return qc->begin == qc->end;                                   \
+	}                                                                      \
+	/* UB if _qcache is empty */                                           \
+	static inline UNNEEDED type name##_qcache_front_(                      \
+	    const struct name##_qcache_ *qc)                                   \
+	{                                                                      \
+		return qc->data[qc->begin];                                    \
+	}                                                                      \
+	static inline UNNEEDED type name##_qcache_pop_(                        \
+	    struct name##_qcache_ *qc)                                         \
+	{                                                                      \
+		type r = name##_qcache_front_(qc);                             \
+		qc->begin++;                                                   \
+		if (qc->begin >= qc->end) {                                    \
+			qc->begin = qc->end = 0;                               \
+		}                                                              \
+		return r;                                                      \
+	}                                                                      \
+	static inline UNNEEDED bool name##_qcache_insert_(                     \
+	    struct name##_qcache_ *qc, type element)                           \
+	{                                                                      \
+		if (qc->end == QUEUE_CACHE_SIZE) {                             \
+			return false;                                          \
+		}                                                              \
+		qc->data[qc->end++] = element;                                 \
+		return true;                                                   \
+	}                                                                      \
+	static inline UNNEEDED void name##_qcache_init_(                       \
+	    struct name##_qcache_ *qc)                                         \
+	{                                                                      \
+		qc->begin = qc->end = 0;                                       \
+	}                                                                      \
+	struct name {                                                          \
+		const tal_t *ctx;                                              \
+		struct lqueue_ lq;                                             \
+	};                                                                     \
+	static inline UNNEEDED bool name##_empty(const struct name *q)         \
+	{                                                                      \
+		return lqueue_empty_(&q->lq);                                  \
+	}                                                                      \
+	static inline UNNEEDED type name##_front(const struct name *q)         \
+	{                                                                      \
+		type r;                                                        \
+		const struct name##_qcache_ *qc =                              \
+		    (const struct name##_qcache_ *)lqueue_front_(&q->lq);      \
+		r = name##_qcache_front_(qc);                                  \
+		return r;                                                      \
+	}                                                                      \
+	static inline UNNEEDED type name##_pop(struct name *q)                 \
+	{                                                                      \
+		type r;                                                        \
+		struct name##_qcache_ *qc =                                    \
+		    (struct name##_qcache_ *)lqueue_front_(&q->lq);            \
+		r = name##_qcache_pop_(qc);                                    \
+		if (qc && name##_qcache_empty_(qc)) {                          \
+			lqueue_dequeue_(&q->lq);                               \
+			tal_free(qc);                                          \
+		}                                                              \
+		return r;                                                      \
+	}                                                                      \
+	static inline UNNEEDED void name##_init(struct name *q,                \
+						const tal_t *ctx)              \
+	{                                                                      \
+		q->ctx = ctx;                                                  \
+		lqueue_init_(&q->lq, NULL);                                    \
+	}                                                                      \
+	static inline UNNEEDED void name##_insert(struct name *q,              \
+						  type element)                \
+	{                                                                      \
+		struct name##_qcache_ *qc =                                    \
+		    (struct name##_qcache_ *)lqueue_back_(&q->lq);             \
+		if (qc && name##_qcache_insert_(qc, element))                  \
+			return;                                                \
+		qc = tal(q->ctx, struct name##_qcache_);                       \
+		name##_qcache_init_(qc);                                       \
+		name##_qcache_insert_(qc, element);                            \
+		lqueue_enqueue_(&q->lq, (struct lqueue_link *)qc);             \
+	}                                                                      \
+	/* QUEUE_DEFINE_TYPE */
+
+#endif /* LIGHTNING_PLUGINS_ASKRENE_QUEUE_H */

--- a/plugins/askrene/test/run-queue.c
+++ b/plugins/askrene/test/run-queue.c
@@ -1,0 +1,78 @@
+#include "config.h"
+#include <common/setup.h>
+#include <stdlib.h>
+
+#include "../queue.h"
+
+/* a queue for int */
+QUEUE_DEFINE_TYPE(int, iqueue);
+
+int main(int argc, char *argv[])
+{
+	common_setup(argv[0]);
+	int x;
+	struct iqueue q;
+	iqueue_init(&q, NULL);
+
+	iqueue_insert(&q, 1);
+	x = iqueue_pop(&q);
+	assert(x == 1);
+
+	iqueue_insert(&q, 2);
+	x = iqueue_pop(&q);
+	assert(x == 2);
+
+	iqueue_insert(&q, 3);
+	iqueue_insert(&q, 4);
+	x = iqueue_pop(&q);
+	assert(x == 3);
+	x = iqueue_pop(&q);
+	assert(x == 4);
+
+	iqueue_insert(&q, 5);
+	iqueue_insert(&q, 6);
+	x = iqueue_pop(&q);
+	assert(x == 5);
+	iqueue_insert(&q, 7);
+	x = iqueue_pop(&q);
+	assert(x == 6);
+	x = iqueue_pop(&q);
+	assert(x == 7);
+
+	for (int i = 1; i <= 10000; i++)
+		iqueue_insert(&q, i);
+	for (int i = 1; i <= 10000; i++) {
+		x = iqueue_pop(&q);
+		assert(x == i);
+	}
+
+	const int MAX_ITEM = 1000000;
+	int expected_front = 1, next_insert = 1;
+
+	do {
+		if (iqueue_empty(&q) && next_insert > MAX_ITEM)
+			break;
+
+		if (iqueue_empty(&q)) {
+			/* we can only insert */
+			iqueue_insert(&q, next_insert++);
+		} else if (next_insert > MAX_ITEM) {
+			/* we can only pop */
+			x = iqueue_pop(&q);
+			assert(x == expected_front);
+			expected_front++;
+		} else {
+			/* we can both insert and pop, throw a coin */
+			if (rand() % 2) {
+				iqueue_insert(&q, next_insert++);
+			} else {
+				x = iqueue_pop(&q);
+				assert(x == expected_front);
+				expected_front++;
+			}
+		}
+	} while (1);
+
+	common_shutdown();
+	return 0;
+}

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1204,7 +1204,7 @@ def test_real_data(node_factory, bitcoind):
     # CI, it's slow.
     if SLOW_MACHINE:
         limit = 25
-        expected = (6, 25, 1544756, 142986, 91)
+        expected = (5, 25, 1567536, 142772, 91)
     else:
         limit = 100
         expected = (9, 95, 6347877, 566288, 92)
@@ -1321,7 +1321,7 @@ def test_real_biases(node_factory, bitcoind):
     # CI, it's slow.
     if SLOW_MACHINE:
         limit = 25
-        expected = ({1: 5, 2: 7, 4: 7, 8: 11, 16: 14, 32: 19, 64: 25, 100: 25}, 0)
+        expected = ({1: 6, 2: 6, 4: 7, 8: 12, 16: 14, 32: 19, 64: 25, 100: 25}, 0)
     else:
         limit = 100
         expected = ({1: 23, 2: 31, 4: 40, 8: 53, 16: 70, 32: 82, 64: 96, 100: 96}, 0)


### PR DESCRIPTION
With this PR I want to make an algorithmic improvement to the MCF solve in askrene.

First: I would like to constrain the number of flow units to 1M by setting the accuracy of the solver
to the total payment amount divided by 1M. Some MCF algorithms like "successive shortest path" (SSP)
have theoretical complexity bounds that depend on that number.

Second: I would like to prune the set of arcs in the network. I can achieve this by setting a limit to the sum
of the arc capacities that correspond to the same channel to 1M, which is the maximum number of flow units
that we send from the source to the destination. Notice that due to the piece-wise linearization of the channel
cost function, one channel becomes several arcs in the MCF network, therefore we can discard the higher cost
arcs of a channel linearization if the lower cost arcs already sum up to 1M in flow capacity.

Third: I would like to add an experimental option to switch the algorithm of the MCF solver to the well
known and highly efficient "Cost Scaling" solution by Goldberg-Tarjan 1990 [1] with heuristics [2].

To use it you would add the parameter `dev_algorithm=goldberg-tarjan`, for example:
```
lightning-cli -k getroutes source=$source destination=$destination amount_msat=1000sat final_cltv=6 layers="[]" maxfee_msat=1sat dev_algorithm="goldberg-tarjan"
```

Depends on #8299

[1] Finding Minimum-Cost Circulation by Successive Approximation. Goldberg and Tarjan. Mathematics of Operations Research, Vol. 15, No. 3 (1990), pp. 430--466.
[2] An efficient Implementation of a Scaling Minimum-Cost Flow Algorithm. Goldberg. Journal of Algorithms 22, 1--29 (1997).