### PR TITLE
CI: Update Ubuntu version from 20 to 22 for Github Actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   deploy:
     name: Build and publish ${{ matrix.package }} 🐍
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     strategy:
       fail-fast: true


### PR DESCRIPTION
Ubuntu 20.04 reached its end-of-life (EOL) on April 15, 2025, and GitHub Actions subsequently removed the Ubuntu 20.04 LTS runner. As a result, we must upgrade all workflow runners to at least Ubuntu 22.04. Currently, this update has only been applied to pypi.yml for core-lightning.

Changelog-None.
