### PR TITLE
testing: Add a system-provided postgres for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,6 +310,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check disk space pre-cleanup
+        run: df -h
+      - name: Free up disk space
+        # We need more space than GHA usually provides when testing
+        # against the `postgres` service. This step frees some space
+        # on the volume containing tools, in the hope of freeing
+        # enough space for postgres tests to succeed.
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # Enable all cleanup options
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          swift: true
+          golang: true
+          php: true
+      - name: Check disk space pre-cleanup
+        run: df -h
+        
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,7 +267,7 @@ jobs:
           - NAME: postgres
             CFG: compile-gcc
             COMPILER: gcc
-            TEST_DB_PROVIDER: postgres
+            TEST_DB_PROVIDER: system-postgres
             TEST_NETWORK: regtest
           # And don't forget about elements (like cdecker did when
           # reworking the CI...)
@@ -290,6 +290,22 @@ jobs:
             COMPILER: gcc
             TEST_NETWORK: regtest
             EXPERIMENTAL_SPLICING: 1
+    services:
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: "-c max_connections=2000"
+        ports:
+          - "5432:5432"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -340,6 +356,8 @@ jobs:
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
           LIGHTNINGD_POSTGRES_NO_VACUUM: 1
+          # Yes, that DSN is silly :-) It's only used for the TEST_DB_PROVIDER=system-postgres
+          CLN_TEST_POSTGRES_DSN: "postgres://postgres:postgres@127.0.0.1:5432/postgres"
         run: |
           env
           cat config.vars

--- a/contrib/pyln-testing/pyln/testing/db.py
+++ b/contrib/pyln-testing/pyln/testing/db.py
@@ -122,6 +122,7 @@ class PostgresDb(BaseDb):
         cur = conn.cursor()
         cur.execute("DROP DATABASE {};".format(self.dbname))
         cur.close()
+        conn.close()
 
     def wipe_db(self):
         cur = self.conn.cursor()

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from pyln.testing.db import SqliteDbProvider, PostgresDbProvider
+from pyln.testing.db import SqliteDbProvider, PostgresDbProvider, SystemPostgresDbProvider
 from pyln.testing.utils import NodeFactory, BitcoinD, ElementsD, env, LightningNode, TEST_DEBUG, TEST_NETWORK
 from pyln.client import Millisatoshi
 from typing import Dict
@@ -640,6 +640,7 @@ def checkMemleak(node):
 providers = {
     'sqlite3': SqliteDbProvider,
     'postgres': PostgresDbProvider,
+    'system-postgres': SystemPostgresDbProvider,
 }
 
 


### PR DESCRIPTION
- **testing: Add a system-postgres mode for faster testing**

Postgres can be slow to spin up and down clusters for each test. This
patch allows us to just test against an externally managed postgres
instance. This is particularly interesting in CI, where we can run a
postgres service in a separate container.

The provider still uses nonce-based multitenancy. It tries to clean
up, but it can fail if a test gets interrupted or teardown fails.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [-] Tests have been added or modified to reflect the changes.
- [-] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

Changelog-None
