### PR TITLE
Askrene: prune and cap

### DIFF
--- a/common/amount.c
+++ b/common/amount.c
@@ -532,6 +532,13 @@ struct amount_msat amount_msat_div(struct amount_msat msat, u64 div)
 	return msat;
 }
 
+struct amount_msat amount_msat_div_ceil(struct amount_msat msat, u64 div)
+{
+	u64 res = msat.millisatoshis / div;
+	msat.millisatoshis = res + (div * res == msat.millisatoshis ? 0 : 1);
+	return msat;
+}
+
 struct amount_sat amount_sat_div(struct amount_sat sat, u64 div)
 {
 	sat.satoshis /= div;

--- a/common/amount.h
+++ b/common/amount.h
@@ -104,7 +104,13 @@ WARN_UNUSED_RESULT bool amount_sat_add_sat_s64(struct amount_sat *val,
 WARN_UNUSED_RESULT bool amount_msat_accumulate(struct amount_msat *a,
 					       struct amount_msat b);
 
+/* returns floor(msat/div) */
 struct amount_msat amount_msat_div(struct amount_msat msat, u64 div);
+
+/* returns ceil(msat/div) */
+struct amount_msat amount_msat_div_ceil(struct amount_msat msat, u64 div);
+
+/* returns floor(sat/div) */
 struct amount_sat amount_sat_div(struct amount_sat sat, u64 div);
 
 bool amount_sat_mul(struct amount_sat *res, struct amount_sat sat, u64 mul);

--- a/common/test/run-amount.c
+++ b/common/test/run-amount.c
@@ -163,6 +163,75 @@ static void test_amount_with_fee(void)
 			    2100000001234567890ULL);
 }
 
+static void test_case_amount_div(u64 input, u64 div, u64 expected)
+{
+	struct amount_msat msat = amount_msat(input);
+	struct amount_msat expected_msat = amount_msat(expected);
+	struct amount_msat result_msat = amount_msat_div(msat, div);
+	assert(amount_msat_eq(result_msat, expected_msat));
+}
+
+static void test_case_amount_div_ceil(u64 input, u64 div, u64 expected)
+{
+	struct amount_msat msat = amount_msat(input);
+	struct amount_msat expected_msat = amount_msat(expected);
+	struct amount_msat result_msat = amount_msat_div_ceil(msat, div);
+	assert(amount_msat_eq(result_msat, expected_msat));
+}
+
+static void test_amount_div(void)
+{
+	test_case_amount_div(1, 1, 1);
+	test_case_amount_div(1, 2, 0);
+	test_case_amount_div(1, 3, 0);
+
+	test_case_amount_div(2, 1, 2);
+	test_case_amount_div(2, 2, 1);
+	test_case_amount_div(2, 3, 0);
+
+	test_case_amount_div(3, 1, 3);
+	test_case_amount_div(3, 2, 1);
+	test_case_amount_div(3, 3, 1);
+	test_case_amount_div(3, 4, 0);
+
+	test_case_amount_div(10, 1, 10);
+	test_case_amount_div(10, 2, 5);
+	test_case_amount_div(10, 3, 3);
+	test_case_amount_div(10, 4, 2);
+	test_case_amount_div(10, 5, 2);
+	test_case_amount_div(10, 6, 1);
+	test_case_amount_div(10, 7, 1);
+	test_case_amount_div(10, 8, 1);
+	test_case_amount_div(10, 9, 1);
+	test_case_amount_div(10, 10, 1);
+	test_case_amount_div(10, 11, 0);
+
+	test_case_amount_div_ceil(1, 1, 1);
+	test_case_amount_div_ceil(1, 2, 1);
+	test_case_amount_div_ceil(1, 3, 1);
+
+	test_case_amount_div_ceil(2, 1, 2);
+	test_case_amount_div_ceil(2, 2, 1);
+	test_case_amount_div_ceil(2, 3, 1);
+
+	test_case_amount_div_ceil(3, 1, 3);
+	test_case_amount_div_ceil(3, 2, 2);
+	test_case_amount_div_ceil(3, 3, 1);
+	test_case_amount_div_ceil(3, 4, 1);
+
+	test_case_amount_div_ceil(10, 1, 10);
+	test_case_amount_div_ceil(10, 2, 5);
+	test_case_amount_div_ceil(10, 3, 4);
+	test_case_amount_div_ceil(10, 4, 3);
+	test_case_amount_div_ceil(10, 5, 2);
+	test_case_amount_div_ceil(10, 6, 2);
+	test_case_amount_div_ceil(10, 7, 2);
+	test_case_amount_div_ceil(10, 8, 2);
+	test_case_amount_div_ceil(10, 9, 2);
+	test_case_amount_div_ceil(10, 10, 1);
+	test_case_amount_div_ceil(10, 11, 1);
+}
+
 #define FAIL_MSAT(msatp, str)					\
 	assert(!parse_amount_msat((msatp), (str), strlen(str)))
 #define PASS_MSAT(msatp, str, val)					\
@@ -330,5 +399,6 @@ int main(int argc, char *argv[])
 	}
 
 	test_amount_with_fee();
+	test_amount_div();
 	common_shutdown();
 }

--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -969,10 +969,15 @@ struct flow **minflow(const tal_t *ctx,
 	params->source = source;
 	params->target = target;
 	params->amount = amount;
-	params->accuracy = AMOUNT_MSAT(1000);
-	/* FIXME: params->accuracy = amount_msat_max(amount_msat_div(amount,
-	 * 1000), AMOUNT_MSAT(1));
+	/* -> We reduce the granularity of the flow by limiting the subdivision
+	 * of the payment amount into 1000 units of flow. That reduces the
+	 * computational burden for algorithms that depend on it, eg. "capacity
+	 * scaling" and "successive shortest path".
+	 * -> Using Ceil operation instead of Floor so that
+	 *      accuracy x 1000 >= amount
 	 * */
+	params->accuracy =
+	    amount_msat_max(AMOUNT_MSAT(1), amount_msat_div_ceil(amount, 1000));
 
 	// template the channel partition into linear arcs
 	params->cap_fraction[0]=0;

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1204,10 +1204,10 @@ def test_real_data(node_factory, bitcoind):
     # CI, it's slow.
     if SLOW_MACHINE:
         limit = 25
-        expected = (6, 25, 1544756, 142986, 91)
+        expected = (5, 25, 1567535, 142772, 91)
     else:
         limit = 100
-        expected = (9, 95, 6347877, 566288, 92)
+        expected = (9, 96, 6563767, 629671, 91)
 
     fees = {}
     for n in range(0, limit):
@@ -1321,10 +1321,10 @@ def test_real_biases(node_factory, bitcoind):
     # CI, it's slow.
     if SLOW_MACHINE:
         limit = 25
-        expected = ({1: 5, 2: 7, 4: 7, 8: 11, 16: 14, 32: 19, 64: 25, 100: 25}, 0)
+        expected = ({1: 6, 2: 6, 4: 7, 8: 12, 16: 14, 32: 19, 64: 25, 100: 25}, 0)
     else:
         limit = 100
-        expected = ({1: 23, 2: 31, 4: 40, 8: 53, 16: 70, 32: 82, 64: 96, 100: 96}, 0)
+        expected = ({1: 22, 2: 25, 4: 36, 8: 52, 16: 69, 32: 80, 64: 96, 100: 96}, 0)
 
     l1.rpc.askrene_create_layer('biases')
     num_changed = {}

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1204,10 +1204,10 @@ def test_real_data(node_factory, bitcoind):
     # CI, it's slow.
     if SLOW_MACHINE:
         limit = 25
-        expected = (5, 25, 1567535, 142772, 91)
+        expected = (6, 25, 1568821, 143649, 91)
     else:
         limit = 100
-        expected = (9, 96, 6563767, 629671, 91)
+        expected = (9, 96, 6565467, 630668, 91)
 
     fees = {}
     for n in range(0, limit):
@@ -1324,7 +1324,7 @@ def test_real_biases(node_factory, bitcoind):
         expected = ({1: 6, 2: 6, 4: 7, 8: 12, 16: 14, 32: 19, 64: 25, 100: 25}, 0)
     else:
         limit = 100
-        expected = ({1: 22, 2: 25, 4: 36, 8: 52, 16: 69, 32: 80, 64: 96, 100: 96}, 0)
+        expected = ({1: 22, 2: 25, 4: 36, 8: 53, 16: 69, 32: 80, 64: 96, 100: 96}, 0)
 
     l1.rpc.askrene_create_layer('biases')
     num_changed = {}


### PR DESCRIPTION
This PR depends on #8299 and supersedes #8314.

With this PR I want to make a small improvement to the MCF solver in askrene.

First: I would like to constrain the number of flow units to 1000 by setting the accuracy of the solver
to the total payment amount divided by 1000. Some MCF algorithms like "successive shortest path" (SSP)
have theoretical complexity bounds that depend on that number.
Note: the 1000 number is arbitrary, the smaller it is we may reduce the solver's runtime but we lose
a accuracy.

Second: I would like to prune the set of arcs in the network. I can achieve this by setting a limit to the sum
of the arc capacities that correspond to the same channel to U, the maximum number of flow units
in the payment. Notice that due to the piece-wise linearization of the channel
cost function, one channel becomes several arcs in the MCF network, therefore we can discard the higher cost
arcs of a channel linearization if the lower cost arcs already sum up to U in flow capacity.
