### PR TITLE
lightningd: fix log crash on weird escape lines from plugin.

### DIFF
--- a/lightningd/plugin.c
+++ b/lightningd/plugin.c
@@ -522,6 +522,10 @@ static const char *plugin_log_handle(struct plugin *plugin,
 		const char *log_msg = json_escape_unescape(tmpctx, esc);
 		char **lines;
 
+		/* Weird \ escapes aren't handled by json_escape_unescape.  This is for you, clboss! */
+		if (!log_msg)
+			goto print_raw;
+
 		lines = tal_strsplit(tmpctx, log_msg, "\n", STR_EMPTY_OK);
 
 		for (size_t i = 0; lines[i]; i++) {
@@ -529,6 +533,7 @@ static const char *plugin_log_handle(struct plugin *plugin,
 			log_(plugin->log, level, NULL, call_notifier, "%s", lines[i]);
 		}
 	} else {
+	print_raw:
 		log_(plugin->log, level, NULL, call_notifier, "%.*s",
 		     msgtok->end - msgtok->start,
 		     plugin->buffer + msgtok->start);


### PR DESCRIPTION
Apparently clboss gives us \u UTF codes.  We don't support that (use UTF-8 directly)

```
126	../sysdeps/x86_64/multiarch/strlen-vec.S: No such file or directory.
(gdb) bt
    label=label@entry=0x63e2f9604db9 "char *[]") at ccan/ccan/tal/str/str.c:137
    complete=complete@entry=0x7ffe9090b0f6, destroyed=destroyed@entry=0x7ffe9090b0f7) at lightningd/plugin.c:773
```

Reported-by: Ken Sedgwick
Fixes: #8338
Changelog-None: broken in this release

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 05TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 12th_, RC2 on _May 16th_, ...
>
> The final release is on MAY 20TH.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
