### PR TITLE
CHANGELOG.md: warn that spec compliance mean we broke splicing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This release named by @USERNAME.
 
+**WARNING**: `--experimental-splicing` is incompatible with previous CLN versions!  You will not
+              be able to reestablish channels with older nodes at all, if this is enabled!
+
 ### Added
 
  - Protocol: we now offer peer storage to any peers who create a channel. ([#8140])
@@ -30,7 +33,7 @@ This release named by @USERNAME.
 
 ### Changed
 
- - Splicing: The splicing protocol is now compatible with Eclair. ([#8021])
+ - Splicing: The splicing protocol is now compatible with Eclair, incompatible with previous CLN versions ([#8021])
  - Protocol: We now exchange `announcement_signatures` as soon as we're ready, rather than waiting for 6 blocks (as per recent BOLT update.) ([#8136])
  - Protocol: We won't forget still-opening channels after 2016 blocks, unless there are more than 100. ([#8162])
  - Reckless: Accepts a source url or local directory as an argument to `reckless install`. ([#8266])


### PR DESCRIPTION
The TLV numbers for splicing were used by the upgrade protocol, and we always demarshal TLVs:

```
rusty@rusty-Framework:~/devel/cvs/lightning ((v25.02.1))$ ./devtools/decodemsg 00883d448f5a4d2d82c861a1e60ba317f5c848989d8c92f65833ff85cc82cb96adf500000000000000c600000000000000c559ebae46ed6f64c3e7c0005494bc684a630223d4b942a7e09b76742727b863cc02aac24eb41bbcfd77cb2e75f51bc5d298a6862cd7c2478268aa67572d8a08311801203d448f5a4d2d82c861a1e60ba317f5c848989d8c92f65833ff85cc82cb96adf503203d448f5a4d2d82c861a1e60ba317f5c848989d8c92f65833ff85cc82cb96adf5
WIRE_CHANNEL_REESTABLISH:
channel_id=3d448f5a4d2d82c861a1e60ba317f5c848989d8c92f65833ff85cc82cb96adf5
next_commitment_number=198
next_revocation_number=197
your_last_per_commitment_secret=59ebae46ed6f64c3e7c0005494bc684a630223d4b942a7e09b76742727b863cc
my_current_per_commitment_point=02aac24eb41bbcfd77cb2e75f51bc5d298a6862cd7c2478268aa67572d8a083118
channel_reestablish={
type=1
len=32
(msg_name=next_to_send)
commitment_number=**TRUNCATED tu64 channel_reestablish.channel_reestablish.commitment_number**
**TRUNCATED TLV channel_reestablish.channel_reestablish**
Segmentation fault (core dumped)
```


Closes: #8337
Changelog-None: literally changing CHANGELOG.md