### PR TITLE
pytest: fix flake in test_anchorspend_using_to_remote

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4165,7 +4165,10 @@ def test_closing_ignore_fee_limits(node_factory, bitcoind, executor):
 def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
     """Make sure we can use `to_remote` output of previous close to spend anchor"""
     # Try with old output from both anchor and non-anchor channel.
-    l4_opts = {}
+
+    # We want l2 to process the WIRE_UPDATE_FULFILL_HTLC, so l4 drops
+    # on WIRE_REVOKE_AND_ACK after that.
+    l4_opts = {'disconnect': ['-WIRE_REVOKE_AND_ACK*2']}
     if anchors is False:
         l4_opts['dev-force-features'] = "-23"
 
@@ -4178,11 +4181,12 @@ def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
     # this to use anchor.
     node_factory.join_nodes([l4, l2])
 
-    # l4 unilaterally closes, l2 gets to-remote with its output.
+    # l4 disconnects after receiving fulfill.  It then unilaterally
+    # closes, l2 gets to-remote with its output.
     l4.rpc.pay(l2.rpc.invoice(100000000, 'test', 'test')['bolt11'])
     wait_for(lambda: only_one(l4.rpc.listpeerchannels()['channels'])['htlcs'] != [])
 
-    l4.rpc.disconnect(l2.info['id'], force=True)
+    wait_for(lambda: only_one(l4.rpc.listpeers()['peers'])['connected'] is False)
     close = l4.rpc.close(l2.info['id'], 1)
     bitcoind.generate_block(1, wait_for_mempool=only_one(close['txids']))
     wait_for(lambda: len(l2.rpc.listfunds()['outputs']) == 1)


### PR DESCRIPTION
With recent changes, particularly using postgres, we can finish the HTLC before we force close, so the test fails.  Insert an explicit hangup here so we reliably get the result we expect:

```
    @pytest.mark.parametrize("anchors", [False, True])
    @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd anchors not supportd')
    def test_anchorspend_using_to_remote(node_factory, bitcoind, anchors):
        """Make sure we can use `to_remote` output of previous close to spend anchor"""
        # Try with old output from both anchor and non-anchor channel.
        l4_opts = {}
        if anchors is False:
            l4_opts['dev-force-features'] = "-23"
    
        l1, l2, l3, l4 = node_factory.get_nodes(4, opts=[{},
                                                         {},
                                                         {'disconnect': ['-WIRE_UPDATE_FULFILL_HTLC']},
                                                         l4_opts])
    
        # Give l2 some funds, from a to-remote output.  It will have to spend
        # this to use anchor.
        node_factory.join_nodes([l4, l2])
    
        # l4 unilaterally closes, l2 gets to-remote with its output.
        l4.rpc.pay(l2.rpc.invoice(100000000, 'test', 'test')['bolt11'])
>       wait_for(lambda: only_one(l4.rpc.listpeerchannels()['channels'])['htlcs'] != [])

tests/test_closing.py:4183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

success = <function test_anchorspend_using_to_remote.<locals>.<lambda> at 0x7f8293e7fe20>
timeout = 180

    def wait_for(success, timeout=TIMEOUT):
        start_time = time.time()
        interval = 0.25
        while not success():
            time_left = start_time + timeout - time.time()
            if time_left <= 0:
>               raise ValueError("Timeout while waiting for {}".format(success))
E               ValueError: Timeout while waiting for <function test_anchorspend_using_to_remote.<locals>.<lambda> at 0x7f8293e7fe20>

```
Changelog-None: flake fixes