### PR TITLE
wallet: initialize previously closed channels

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -122,6 +122,12 @@ def test_closing_simple(node_factory, bitcoind, chainparams):
     tags = check_utxos_channel(l1, [channel_id], expected_1)
     check_utxos_channel(l2, [channel_id], expected_2, tags)
 
+    # Forget channel
+    bitcoind.generate_block(50)
+    sync_blockheight(bitcoind, [l1])
+    l1.restart()
+    assert only_one(l1.rpc.listclosedchannels()['closedchannels'])['channel_id'] == channel_id
+
 
 def test_closing_while_disconnected(node_factory, bitcoind, executor):
     l1, l2 = node_factory.line_graph(2, opts={'may_reconnect': True})

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2344,6 +2344,7 @@ bool wallet_init_channels(struct wallet *w)
 {
 	/* We set the max channel database id separately */
 	set_max_channel_dbid(w);
+	wallet_load_closed_channels(w, w->ld->closed_channels);
 	return wallet_channels_load_active(w);
 }
 


### PR DESCRIPTION
This seems to have been inadvertently omitted in the recent closed channel refactor.

Fixes: #8346

Changelog-None: Changed this release.

> [!IMPORTANT]
>
> 25.05 FREEZE MAY 05TH: Non-bugfix PRs not ready by this date will wait for 25.08.
>
> RC1 is scheduled on _May 12th_, RC2 on _May 16th_, ...
>
> The final release is on MAY 20TH.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
