### PR TITLE
python: raise minimum supported python version to 3.9

### DIFF
--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install python modules
       run: |

--- a/contrib/cln-tracer/pyproject.toml
+++ b/contrib/cln-tracer/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Christian Decker <decker.christian@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 bcc = "^0.1.10"
 opentelemetry-proto = "^1.21.0"
 

--- a/contrib/pyln-client/pyproject.toml
+++ b/contrib/pyln-client/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 pyln-proto = ">=23"
 pyln-bolt7 = ">=1.0"
 

--- a/contrib/pyln-grpc-proto/pyproject.toml
+++ b/contrib/pyln-grpc-proto/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 grpcio = "*"
 protobuf = "5.29.4"
 

--- a/contrib/pyln-proto/pyproject.toml
+++ b/contrib/pyln-proto/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 base58 = "^2.1.1"
 bitstring = "^4.1.0"
 coincurve = "^20"

--- a/contrib/pyln-spec/bolt1/pyproject.toml
+++ b/contrib/pyln-spec/bolt1/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 pyln-proto = "^0.10.2"

--- a/contrib/pyln-spec/bolt2/pyproject.toml
+++ b/contrib/pyln-spec/bolt2/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 pyln-proto = "^0.10.2"

--- a/contrib/pyln-spec/bolt4/pyproject.toml
+++ b/contrib/pyln-spec/bolt4/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 pyln-proto = "^0.10.2"

--- a/contrib/pyln-spec/bolt7/pyproject.toml
+++ b/contrib/pyln-spec/bolt7/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 pyln-proto = "^0.10.2"

--- a/contrib/pyln-testing/pyproject.toml
+++ b/contrib/pyln-testing/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 pytest = "^7"
 ephemeral-port-reserve = "^1.1.4"
 psycopg2-binary = "^2.9"

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -35,7 +35,7 @@ RUN chown root:root /usr/lib/sudo/sudoers.so
 RUN wget -O /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 \
     && chmod +x /usr/local/bin/jq
 
-# install Python3.8 (more reproducible than relying on python3-setuptools)
+# install Python3.10 (more reproducible than relying on python3-setuptools)
 RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
     apt-get install -y --no-install-recommends \
     libbz2-dev \

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -294,7 +294,7 @@ pkg_add autoconf # (select highest version, autoconf-2.69p2 at time of writing)
 Install `mako` otherwise we run into build errors:
 
 ```shell
-pip3.8 install --user poetry
+pip3 install --user poetry
 poetry install
 ```
 
@@ -356,7 +356,7 @@ If you need Python 3.x for mako (or get a mako build error):
 brew install pyenv
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
 source ~/.bash_profile
-pyenv install 3.8.10
+pyenv install 3.9
 pip install --upgrade pip
 pip install poetry==2.0.1
 ```

--- a/plugins/wss-proxy/pyproject.toml
+++ b/plugins/wss-proxy/pyproject.toml
@@ -5,7 +5,7 @@ description = "Web secure socket proxy"
 authors = ["ShahanaFarooqui <sfarooqui@blockstream.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 pyln-client = ">=24.11 <25.09"
 websockets = "^12.0"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1019,30 +1019,6 @@ test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "p
 type = ["pytest-mypy"]
 
 [[package]]
-name = "importlib-resources"
-version = "6.4.5"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_version < \"3.9\""
-files = [
-    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
-    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1121,9 +1097,7 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 jsonschema-specifications = ">=2023.03.6"
-pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 referencing = ">=0.28.4"
 rpds-py = ">=0.7.1"
 
@@ -1144,7 +1118,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 referencing = ">=0.31.0"
 
 [[package]]
@@ -1322,19 +1295,6 @@ groups = ["dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
-]
-
-[[package]]
-name = "pkgutil-resolve-name"
-version = "1.3.10"
-description = "Resolve a name to an object."
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-markers = "python_version < \"3.9\""
-files = [
-    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
-    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 
 [[package]]
@@ -1545,7 +1505,7 @@ name = "pyln-client"
 version = "25.05rc1"
 description = "Client library and plugin library for Core Lightning"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 groups = ["main", "dev"]
 files = []
 develop = true
@@ -1563,7 +1523,7 @@ name = "pyln-grpc-proto"
 version = "0.1.2"
 description = "The compiled GRPC proto for CLN"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 groups = ["main", "dev"]
 files = []
 develop = true
@@ -1581,7 +1541,7 @@ name = "pyln-proto"
 version = "25.05rc1"
 description = "This package implements some of the Lightning Network protocol in pure python. It is intended for protocol testing and some minor tooling only. It is not deemed secure enough to handle any amount of real funds (you have been warned!)."
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 groups = ["main", "dev"]
 files = []
 develop = true
@@ -1602,7 +1562,7 @@ name = "pyln-testing"
 version = "25.05rc1"
 description = "Test your Core Lightning integration, plugins or whatever you want"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 groups = ["dev"]
 files = []
 develop = true
@@ -2200,7 +2160,7 @@ name = "wss-proxy"
 version = "25.05rc1"
 description = "Web secure socket proxy"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.9"
 groups = ["main"]
 files = []
 develop = true
@@ -2236,5 +2196,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.8.1,<4.0"
-content-hash = "e07068cbadfe73a4db739197abeba3c1feba25a61bebad2447a3f21be88e1071"
+python-versions = ">=3.9,<4.0"
+content-hash = "9613aba2ff439af2a285f3f3f56fbd4c30bb10ac665eabe772cce151ec0887fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Christian Decker <cdecker@blockstream.com>"]
 
 [tool.poetry.dependencies]
 # Build dependencies belong here
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 pyln-client = { path = "contrib/pyln-client", develop = true }
 pyln-proto = { path = "contrib/pyln-proto", develop = true }
 pyln-grpc-proto = { path = "contrib/pyln-grpc-proto", develop = true }

--- a/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
+++ b/tests/data/recklessrepo/lightningd/testplugpyproj/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Alex Myers <alex@endothermic.dev>"]
 
 [tool.poetry.dependencies]
 # Build dependencies belong here
-python = "^3.8"
+python = "^3.9"
 pyln-client = "^23.11"
 
 [build-system]


### PR DESCRIPTION
Python 3.8 is EOL since October 2024: https://devguide.python.org/versions/

I'm also not aware of any supported OS using python 3.8. Python 3.8 is also holding back quite a few package upgrades where most of them start support at 3.9

Ubuntu starts at 3.10: https://packages.ubuntu.com/search?keywords=python3&searchon=names&suite=all&section=all
Debian old stable starts at 3.9: https://packages.debian.org/search?keywords=python3&searchon=names&suite=all&section=all
