### PR TITLE
common/bolt12: fix `tlv_span()` behaviour with empty `tlvstream`

### DIFF
--- a/common/bolt12.c
+++ b/common/bolt12.c
@@ -613,16 +613,26 @@ size_t tlv_span(const u8 *tlvstream, u64 minfield, u64 maxfield,
 	size_t tlvlen = tal_bytelen(tlvstream);
 	const u8 *start, *end;
 
-	start = end = NULL;
+	start = NULL;
+	end = tlvstream;
 	while (tlvlen) {
 		const u8 *before = cursor;
 		bigsize_t type = fromwire_bigsize(&cursor, &tlvlen);
+		if (!cursor)
+			break;
+
 		bigsize_t len = fromwire_bigsize(&cursor, &tlvlen);
+		if (!cursor)
+			break;
+
 		if (type >= minfield && start == NULL)
 			start = before;
 		if (type > maxfield)
 			break;
 		fromwire_pad(&cursor, &tlvlen, len);
+		if (!cursor)
+			break;
+
 		end = cursor;
 	}
 	if (!start)

--- a/common/test/run-tlv_span.c
+++ b/common/test/run-tlv_span.c
@@ -131,6 +131,22 @@ int main(int argc, char *argv[])
 	len = tlv_span(wire, 0, 1, &start);
 	assert(start == 0);
 	assert(len == strlen("0010b8538094dbd70d8a0f0439d8e64f766f") / 2);
+
+	/* Simulate an empty tlvstream */
+	wire = tal_arr(tmpctx, u8, 0);
+	len = tlv_span(wire, 0, UINT64_MAX, &start);
+	assert(start == 0);
+	assert(len == 0);
+
+	/* Simulate a TLV stream where the payload is shorter
+	 * than its length field indicates.
+	 */
+	wire = tal_hexdata(tmpctx, "0502beef0a03de", strlen("0502beef0a03de"));
+	len = tlv_span(wire, 0, UINT64_MAX, &start);
+	assert(start == 0);
+	/* The span should cover only the first valid record, which is 4 bytes long. */
+	assert(len == 4);
+
 	common_shutdown();
 	return 0;
 }


### PR DESCRIPTION
When `tlv_span()` receives an empty `tlvsteam`, it sets the value of `startp` to `start` - `tlvstream` = `NULL` - `tlvstream`, where `tlvstream` is a pointer.

This is undefined behaviour. Add a guard against it by correcting the initial value of `end`.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

CC: @morehouse 