### PR TITLE
CI: add job to automate crate version bumping PR

### DIFF
--- a/.github/workflows/crate-bump.yml
+++ b/.github/workflows/crate-bump.yml
@@ -1,0 +1,100 @@
+name: Bump Rust 🦀 crate versions
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+[0-9a-z]+'
+  workflow_dispatch:
+    inputs:
+      dist-location:
+        description: 'Distribution location'
+        type: choice
+        options:
+          - rc
+          - major
+          - minor
+        default: 'rc'
+        required: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        # Need to fetch entire history in order to locate the version tag
+        fetch-depth: 0
+
+    - name: Check version tag
+      run: >-
+        git describe --tags --always --dirty=-modded --abbrev=7
+
+    - name: Set up values
+      id: set-values
+      run: |
+        if [[ "${{ github.event.inputs.dist-location }}" != "" ]]; then
+          DISTLOCATION=${{ github.event.inputs.dist-location }}
+        elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            DISTLOCATION="major"
+          elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DISTLOCATION="minor"
+          elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+[0-9a-z]+$ ]]; then
+            DISTLOCATION="rc"
+          else
+            echo "Tag format not recognized"
+            exit 1
+          fi
+        else
+          echo "Neither tag nor workflow dispatch"
+          exit 1
+        fi
+        echo "DISTLOCATION=$DISTLOCATION" >> $GITHUB_OUTPUT
+        echo "EVENT DISTLOCATION: ${{ github.event.inputs.dist-location }}"
+        echo "DISTRIBUTION LOCATION: $DISTLOCATION"
+
+    - name: Setup rust
+      uses: dtolnay/rust-toolchain@1.77
+
+    - name: Install cargo release
+      run: |
+        cargo install --locked cargo-release --version 0.25.10
+
+    - name: Bump rc version
+      if: github.repository == 'daywalker90/lightning' && steps.set-values.outputs.DISTLOCATION == 'rc'
+      run: |
+        cargo release version -p cln-rpc -p cln-grpc -p cln-plugin rc --execute --no-confirm
+
+    - name: Bump minor release version
+      if: github.repository == 'daywalker90/lightning' && steps.set-values.outputs.DISTLOCATION == 'major'
+      run: |
+        cargo release version -p cln-rpc -p cln-grpc -p cln-plugin minor --execute --no-confirm
+
+    - name: Bump patch release version
+      if: github.repository == 'daywalker90/lightning' && steps.set-values.outputs.DISTLOCATION == 'minor'
+      run: |
+        cargo release version -p cln-rpc -p cln-grpc -p cln-plugin patch --execute --no-confirm
+
+    - name: Create Pull Request
+      if: github.repository == 'ElementsProject/lightning'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "crates: Bump crate versions for ${{ github.ref_name }}"
+        title: "Bump crate versions for ${{ github.ref_name }}"
+        body: |
+          This PR bumps the crate versions for:
+          - cln-rpc
+          - cln-grpc
+          - cln-plugin
+
+          Triggered by tag: ${{ github.ref_name }}
+          Distribution location: ${{ steps.set-values.outputs.DISTLOCATION }}
+        branch: "bump-crate-versions-${{ github.ref_name }}"
+        base: master
+        labels: version-bump, automated
+        delete-branch: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ members = [
     "plugins/rest-plugin",
     "plugins/lsps-plugin",
 ]
+
+[workspace.dependencies]
+cln-rpc = { path = "cln-rpc", version = "0.4.0" }
+cln-grpc = { path = "cln-grpc", version = "0.4.1" }
+cln-plugin = { path = "plugins", version = "0.4.0" }

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -15,7 +15,7 @@ server = ["cln-rpc"]
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-cln-rpc = { path = "../cln-rpc/", version = "0.4", optional = true }
+cln-rpc = { workspace = true, optional = true }
 cfg-if = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tonic = { version = "0.11", features = ["tls", "transport"] }
@@ -29,7 +29,7 @@ tokio-util = "0.7.10"
 
 [dev-dependencies]
 serde_json = "1.0.72"
-cln-rpc = { path = "../cln-rpc/", version = "0.4" }
+cln-rpc = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -27,4 +27,4 @@ tracing = { version = "^0.1", features = ["async-await", "log"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", ] }
-cln-grpc = { version = "0.4", path = "../cln-grpc" }
+cln-grpc = { workspace = true }

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -17,9 +17,9 @@ anyhow = "1.0"
 log = "0.4"
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 prost = "0.12"
-cln-grpc = { version = "0.4", features = ["server"], path = "../../cln-grpc"}
-cln-plugin = { version = "0.4", path = "../../plugins" }
-cln-rpc = { version = "0.4", path = "../../cln-rpc" }
+cln-grpc = { workspace = true, features = ["server"]}
+cln-plugin = { workspace = true }
+cln-rpc = { workspace = true }
 serde_json = "1.0.113"
 
 [dependencies.tokio]

--- a/plugins/lsps-plugin/Cargo.toml
+++ b/plugins/lsps-plugin/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/service.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-cln-plugin = { version = "0.4", path = "../" }
-cln-rpc = { version = "0.4", path = "../../cln-rpc" }
+cln-plugin = { workspace = true }
+cln-rpc = { workspace = true }
 hex = "0.4"
 log = "0.4"
 rand = "0.9"

--- a/plugins/rest-plugin/Cargo.toml
+++ b/plugins/rest-plugin/Cargo.toml
@@ -27,7 +27,7 @@ utoipa = { version = "5", features = ['axum_extras'] }
 log-panics = "2"
 socketioxide = "0.15"
 
-cln-plugin = { version = "0.4", path = "../../plugins" }
-cln-rpc = { version = "0.4", path = "../../cln-rpc" }
+cln-plugin = { workspace = true }
+cln-rpc = { workspace = true }
 utoipa-swagger-ui = { version = "9.0.0", features = ["vendored", "axum"] }
 


### PR DESCRIPTION
I want these to go out faster after a CLN release so here's a github action that will automatically create a PR (like https://github.com/daywalker90/lightning/pull/20) to bump crate versions very similar to the python action. It works for rc, major and minor releases. Merging that PR will trigger the other action to publish them. 

Please check that the Workflow permissions under "Settings->Actions->General" are "Read and Write Permissions" aswell as "Allow GitHub Actions to create and approve pull requests".

For this i had to centralize the version management of the affected crates.