### PR TITLE
Document listsendpays amount msat better

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -21942,7 +21942,7 @@
                       "amount_msat": {
                         "type": "msat",
                         "description": [
-                          "The amount of millisatoshi we intended to send to the destination."
+                          "The amount of millisatoshi we intended to send to the destination. This can only be missing in the case of someone manually calling sendonion without the `amount_msat` parameter (which no plugin currently does)."
                         ]
                       },
                       "amount_sent_msat": {
@@ -24449,7 +24449,7 @@
                 "amount_msat": {
                   "type": "msat",
                   "description": [
-                    "The amount delivered to destination (if known)."
+                    "The amount delivered to destination (if known). This is not known in the case where sendonion(7) was used to manually initiate a payment without the `amount_msat` parameter."
                   ]
                 },
                 "destination": {

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -29732,6 +29732,7 @@
       "rpc": "sendonion",
       "title": "Send a payment with a custom onion packet",
       "description": [
+        "Note: you probably want to use the more modern and flexible `injectpaymentonion` command instead of this.",
         "The **sendonion** RPC command can be used to initiate a payment attempt with a custom onion packet. The onion packet is used to deliver instructions for hops along the route on how to behave. Normally these instructions are indications on where to forward a payment and what parameters to use, or contain details of the payment for the final hop. However, it is possible to add arbitrary information for hops in the custom onion, allowing for custom extensions that are not directly supported by Core Lightning.",
         "",
         "If the first element of *route* does not have \"channel\" set, a suitable channel (if any) will be chosen, otherwise that specific short-channel-id is used. The following is an example of a 3 hop onion:",
@@ -30057,6 +30058,7 @@
         "Christian Decker <<decker.christian@gmail.com>> is mainly responsible."
       ],
       "see_also": [
+        "lightning-injectpaymentonion(7)",
         "lightning-createonion(7)",
         "lightning-sendpay(7)",
         "lightning-listsendpays(7)"

--- a/doc/schemas/listpays.json
+++ b/doc/schemas/listpays.json
@@ -192,7 +192,7 @@
                   "amount_msat": {
                     "type": "msat",
                     "description": [
-                      "The amount of millisatoshi we intended to send to the destination."
+                      "The amount of millisatoshi we intended to send to the destination. This can only be missing in the case of someone manually calling sendonion without the `amount_msat` parameter (which no plugin currently does)."
                     ]
                   },
                   "amount_sent_msat": {

--- a/doc/schemas/listsendpays.json
+++ b/doc/schemas/listsendpays.json
@@ -144,7 +144,7 @@
             "amount_msat": {
               "type": "msat",
               "description": [
-                "The amount delivered to destination (if known)."
+                "The amount delivered to destination (if known). This is not known in the case where sendonion(7) was used to manually initiate a payment without the `amount_msat` parameter."
               ]
             },
             "destination": {

--- a/doc/schemas/sendonion.json
+++ b/doc/schemas/sendonion.json
@@ -4,6 +4,7 @@
   "rpc": "sendonion",
   "title": "Send a payment with a custom onion packet",
   "description": [
+    "Note: you probably want to use the more modern and flexible `injectpaymentonion` command instead of this.",
     "The **sendonion** RPC command can be used to initiate a payment attempt with a custom onion packet. The onion packet is used to deliver instructions for hops along the route on how to behave. Normally these instructions are indications on where to forward a payment and what parameters to use, or contain details of the payment for the final hop. However, it is possible to add arbitrary information for hops in the custom onion, allowing for custom extensions that are not directly supported by Core Lightning.",
     "",
     "If the first element of *route* does not have \"channel\" set, a suitable channel (if any) will be chosen, otherwise that specific short-channel-id is used. The following is an example of a 3 hop onion:",
@@ -329,6 +330,7 @@
     "Christian Decker <<decker.christian@gmail.com>> is mainly responsible."
   ],
   "see_also": [
+    "lightning-injectpaymentonion(7)",
     "lightning-createonion(7)",
     "lightning-sendpay(7)",
     "lightning-listsendpays(7)"


### PR DESCRIPTION
Need to specify exactly when this field is missing: turns out is "never" is.

Also, we noticed that sendonion does not refer to the modern coolness of injectpaymentonion!

Fixes: https://github.com/ElementsProject/lightning/issues/6909
Closes: https://github.com/ElementsProject/lightning/pull/8144
Changelog-None: doc only


