### PR TITLE
chore: nix flake update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: |
-      github.event.action != 'edited' || 
+      github.event.action != 'edited' ||
       contains(github.event.pull_request.body, 'Changelog')
     env:
       BOLTDIR: bolts
@@ -595,6 +595,25 @@ jobs:
           env
           cat config.vars
           VALGRIND=0 uv run eatmydata pytest tests/ -vvv -n ${PYTEST_PAR} ${PYTEST_OPTS}
+
+  check-flake:
+    name: Check Nix Flake
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v8
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Check flake
+        run: nix flake check
 
   gather:
     # A dummy task that depends on the full matrix of tests, and

--- a/doc/developers-guide/developers-guide.md
+++ b/doc/developers-guide/developers-guide.md
@@ -62,8 +62,6 @@ The entry point is `flake.nix` in the root of the project, where the inputs and 
 
 `nix develop .#rust` will create a shell env for developing rust.
 
-`nix build .?submodules=1` will build the default package (cln).
+`nix build` will build the default package (cln).
 
-`nix flake check .?submodules=1` will build the cln and rust packages. Rust tests are run during the build. There are also checks to run cargo audit and nixfmt.
-
-If you have nix installed you can use `nix run "git+https://github.com/hashrelay/lightning?ref=flake&submodules=1#lightningd"` to run lightningd without having to manually clone the repo. This make use of the flake output apps.
+`nix flake check` will build the cln and rust packages. Rust tests are run during the build. There are also checks to run cargo audit and nixfmt.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1727353582,
-        "narHash": "sha256-2csMEEOZhvowVKZNBHk1kMJqk72ZMrPj9LQYCzP6EKs=",
+        "lastModified": 1750151065,
+        "narHash": "sha256-il+CAqChFIB82xP6bO43dWlUVs+NlG7a4g8liIP5HcI=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "cb905e6e405834bdff1eb1e20c9b10edb5403889",
+        "rev": "7573f55ba337263f61167dbb0ea926cdc7c8eb5d",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1727316705,
-        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -51,45 +51,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727540905,
-        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
+        "lastModified": 1761373498,
+        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
+        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1726871744,
-        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -104,14 +91,16 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1727431250,
-        "narHash": "sha256-uGRlRT47ecicF9iLD1G3g43jn2e+b5KaMptb59LHnvM=",
+        "lastModified": 1761311587,
+        "narHash": "sha256-Msq86cR5SjozQGCnC6H8C+0cD4rnx91BPltZ9KK613Y=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "879b29ae9a0378904fbbefe0dadaed43c8905754",
+        "rev": "2eddae033e4e74bf581c2d1dfa101f9033dbd2dc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,18 +2,23 @@
   description = "Core Lightning (CLN): A specification compliant Lightning Network implementation in C";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     crane.url = "github:ipetkov/crane";
 
-    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     advisory-db = {
       url = "github:rustsec/advisory-db";
       flake = false;
     };
+
+    self.submodules = true;
   };
 
   outputs =
@@ -29,6 +34,7 @@
         inputs.treefmt-nix.flakeModule
         ./nix/pkgs/flake-module.nix
         ./nix/checks/flake-module.nix
+        ./nix/apps.nix
         ./nix/shells.nix
         ./nix/treefmt.nix
       ];
@@ -44,20 +50,6 @@
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [ (final: prev: { craneLib = (inputs.crane.mkLib pkgs); }) ];
-          };
-          apps = {
-            lightningd = {
-              program = "${self'.packages.cln}/bin/lightningd";
-            };
-            lightning-cli = {
-              program = "${self'.packages.cln}/bin/lightning-cli";
-            };
-            lightning-hsmtool = {
-              program = "${self'.packages.cln}/bin/lightning-hsmtool";
-            };
-            reckless = {
-              program = "${self'.packages.cln}/bin/reckless";
-            };
           };
         };
     };

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,31 @@
+{ ... }:
+{
+  perSystem =
+    {
+      config,
+      pkgs,
+      system,
+      self',
+      ...
+    }:
+    {
+      apps = {
+        lightningd = {
+          program = "${self'.packages.cln}/bin/lightningd";
+          meta.description = "Core Lightning daemon";
+        };
+        lightning-cli = {
+          program = "${self'.packages.cln}/bin/lightning-cli";
+          meta.description = "Core Lightning command line interface";
+        };
+        lightning-hsmtool = {
+          program = "${self'.packages.cln}/bin/lightning-hsmtool";
+          meta.description = "Core Lightning HSM tool";
+        };
+        reckless = {
+          program = "${self'.packages.cln}/bin/reckless";
+          meta.description = "Core Lightning reckless tool";
+        };
+      };
+    };
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -26,26 +26,27 @@ stdenv.mkDerivation {
   # when building on darwin we need cctools to provide the correct libtool
   # as libwally-core detects the host as darwin and tries to add the -static
   # option to libtool, also we have to add the modified gsed package.
-  nativeBuildInputs =
-    [
-      autoconf
-      autogen
-      automake
-      gettext
-      gitMinimal
-      postgresql
-      libtool
-      lowdown
-      pkgconf
-      py3
-      unzip
-      which
-    ]
-    ++ lib.optionals postgresSupport [ postgresql ]
-    ++ lib.optionals stdenv.isDarwin [
-      cctools
-      darwin.autoSignDarwinBinariesHook
-    ];
+  nativeBuildInputs = [
+    autoconf
+    autogen
+    automake
+    gettext
+    gitMinimal
+    libtool
+    lowdown
+    pkgconf
+    py3
+    unzip
+    which
+  ]
+  ++ lib.optionals postgresSupport [
+    libpq
+    libpq.pg_config
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    cctools
+    darwin.autoSignDarwinBinariesHook
+  ];
 
   buildInputs = [
     gmp


### PR DESCRIPTION
Updated nixpkgs to unstable (stable channels are really for whole NixOS systems).
Replaced cln package postgresql dependency with much smaller libpq.
Utilise new `inputs.self.submodules` feature to simplify flake use.

Fixes #8328 and #8320 

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
