### PR TITLE
pytest: fix flakes in test_splicing_rbf, test_reconnect_signed, test_htlc_no_force_close

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -3882,7 +3882,7 @@ def test_htlc_no_force_close(node_factory, bitcoind, anchors):
         for opt in opts:
             opt['dev-force-features'] = "-23"
 
-    l1, l2, l3 = node_factory.line_graph(3, opts=opts)
+    l1, l2, l3 = node_factory.line_graph(3, opts=opts, wait_for_announce=True)
 
     MSATS = 12300000
     inv = l3.rpc.invoice(MSATS, 'label', 'description')
@@ -3911,11 +3911,11 @@ def test_htlc_no_force_close(node_factory, bitcoind, anchors):
     # l3 gets upset, drops to chain when there are < 4 blocks remaining.
     # But tx doesn't get mined...
     bitcoind.generate_block(8)
-    l3.daemon.wait_for_log("Peer permanent failure in CHANNELD_NORMAL: Fulfilled HTLC 0 SENT_REMOVE_.* cltv 114 hit deadline")
+    l3.daemon.wait_for_log("Peer permanent failure in CHANNELD_NORMAL: Fulfilled HTLC 0 SENT_REMOVE_.* cltv 119 hit deadline")
 
     # l2 closes drops the commitment tx at block 115 (one block after timeout)
     bitcoind.generate_block(4)
-    l2.daemon.wait_for_log("Peer permanent failure in CHANNELD_NORMAL: Offered HTLC 0 SENT_ADD_ACK_REVOCATION cltv 114 hit deadline")
+    l2.daemon.wait_for_log("Peer permanent failure in CHANNELD_NORMAL: Offered HTLC 0 SENT_ADD_ACK_REVOCATION cltv 119 hit deadline")
     l1.set_feerates((15000, 15000, 15000, 15000))
 
     # Two more blocks, with no htlc tx.
@@ -3926,7 +3926,7 @@ def test_htlc_no_force_close(node_factory, bitcoind, anchors):
     bitcoind.generate_block(1, needfeerate=9999999)
 
     # l2 will have abandoned l2->l3 HTLC to close l1->l2.
-    l2.daemon.wait_for_log(r'Abandoning unresolved onchain HTLC at block 117 \(expired at 114\) to avoid peer closing incoming HTLC at block 120')
+    l2.daemon.wait_for_log(r'Abandoning unresolved onchain HTLC at block 122 \(expired at 119\) to avoid peer closing incoming HTLC at block 125')
 
     # l1 should not have force-closed, htlc should be finished by l2.
     assert not l1.daemon.is_in_log('Peer permanent failure in CHANNELD_NORMAL')

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4056,6 +4056,7 @@ def test_peer_anchor_push(node_factory, bitcoind, executor, chainparams):
         l2.daemon.wait_for_log("sendrawtx exit 0")
         # Check feerate for entire package (commitment tx + anchor) is ~ correct
         details = bitcoind.rpc.getrawmempool(True).values()
+        print(f"mempool = {details}")
         total_weight = sum([d['weight'] for d in details])
         total_fees = sum([float(d['fees']['base']) * 100_000_000 for d in details])
         total_feerate_perkw = total_fees / total_weight * 1000

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -654,12 +654,13 @@ def test_disconnect_half_signed_v2(node_factory):
 @pytest.mark.openchannel('v2')
 def test_reconnect_signed(node_factory):
     # This will fail *after* both sides consider channel opening.
-    disconnects = ['<WIRE_FUNDING_SIGNED']
     if EXPERIMENTAL_DUAL_FUND:
-        disconnects = ['<WIRE_COMMITMENT_SIGNED']
-
-    l1 = node_factory.get_node(may_reconnect=True, disconnect=disconnects)
-    l2 = node_factory.get_node(may_reconnect=True)
+        # Definitely in DUALOPEND_OPEN_COMMITTED once it's trying to send this.
+        l1 = node_factory.get_node(may_reconnect=True)
+        l2 = node_factory.get_node(may_reconnect=True, disconnect=['-WIRE_TX_SIGNATURES'])
+    else:
+        l1 = node_factory.get_node(may_reconnect=True, disconnect=['<WIRE_FUNDING_SIGNED'])
+        l2 = node_factory.get_node(may_reconnect=True)
 
     l1.fundwallet(2000000)
 

--- a/tests/test_splicing.py
+++ b/tests/test_splicing.py
@@ -91,6 +91,9 @@ def test_splice_rbf(node_factory, bitcoind):
     inv = l2.rpc.invoice(10**2, '2', 'no_2')
     l1.rpc.pay(inv['bolt11'])
 
+    # Make sure l1 doesn't unilateral close if HTLC hasn't completely settled before deadline.
+    wait_for(lambda: only_one(l1.rpc.listpeerchannels()['channels'])['htlcs'] == [])
+
     bitcoind.generate_block(6, wait_for_mempool=1)
 
     l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')


### PR DESCRIPTION
# FIRST FLAKE

We get a unilateral close if the blocks come too fast:

```
>       l2.daemon.wait_for_log(r'CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')

tests/test_splicing.py:96:
...
>                   raise TimeoutError('Unable to find "{}" in logs.'.format(exs))
E                   TimeoutError: Unable to find "[re.compile('CHANNELD_AWAITING_SPLICE to CHANNELD_NORMAL')]" in logs.
```

Here:

```
lightningd-2 2025-07-08T12:08:30.430Z DEBUG   lightningd: Adding block 114: 542499dfc63bc94c0ba0a3d81bdaff07ab73ba9aebddd4c2ae4b2e0c1e8bd15f
...
lightningd-2 2025-07-08T12:08:30.459Z UNUSUAL 0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-chan#1: Peer permanent failure in CHANNELD_AWAITING_SPLICE: Fulfilled HTLC 1 RCVD_REMOVE_REVOCATION cltv11 4 hit deadline (reason=protocol)
lightningd-2 2025-07-08T12:08:30.469Z DEBUG   0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-channeld-chan#1: Status closed, but not exited. Killing
lightningd-2 2025-07-08T12:08:30.475Z INFO    0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518-chan#1: State changed from CHANNELD_AWAITING_SPLICE to AWAITING_UNILATERAL
```

# SECOND FLAKE

```
>       l1.rpc.fundchannel(l2.info['id'], CHANNEL_SIZE)

tests/test_connection.py:667:
...
>           raise RpcError(method, payload, resp['error'])
E           pyln.client.lightning.RpcError: RPC call failed: method: fundchannel, payload: {'id': '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59', 'amount': 50000, 'announce': True}, error: {'code': -1, 'message': 'Disconnected', 'data': {'id': '022d223620a359a47ff7f7ac447c85c46c923da53389221a0054c11c1e3ca31d59', 'method': 'openchannel_update'}}
```

What happens here is complicated.

1. dualopend never processes the WIRE_COMMITMENT_SIGNED message, meaning it doesn't consider it worth
   trying to reconnect.
2. Normally, on disconnect, we give subds time to process packets and then notice the disconnect.
3. But, if we can another connection, we terminate the (old) subds immediately.
4. When lightningd transitions the channel from DUALOPEND_OPEN_INIT to DUALOPEND_OPEN_COMMIT_READY,
   it tells connectd this peer is important.
5. Normally, this causes a reconnect one second after hangup.
6. However, if we've already disconnected, it makes connectd reconnect immediately.  This causes
   the test flake, if dualopend hasn't processed the message, and thus changed the state to
   DUALOPEND_OPEN_COMMITTED: we don't reconnect and instead fail the fundchannel() call.

Changelog-None
