### PR TITLE
doc: fix typo and missing `ws:` prefix documentation.

### DIFF
--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -610,7 +610,7 @@ is not specified, a DNS lookup may be done to resolve `HOSTNAME` or `TORIPADDRES
   If `HOSTNAME` was given that resolves to a local interface, the daemon
 will bind to that interface.
 
-* **bind-addr**=*\[IPADDRESS\[:PORT\]\]|SOCKETPATH|HOSTNAME\[:PORT\]*
+* **bind-addr**=*\[ws:\]\[IPADDRESS\[:PORT\]\]|SOCKETPATH|HOSTNAME\[:PORT\]*
 
   Set an IP address or UNIX domain socket to listen to, but do not
 announce. A UNIX domain socket is distinguished from an IP address by
@@ -620,6 +620,11 @@ beginning with a */*.
 IPv6 on all interfaces, '0.0.0.0' means bind to all IPv4
 interfaces, '::' means 'bind to all IPv6 interfaces'.  'PORT' is
 not specified, 9735 is used.
+
+   The `ws:` prefix indicates to expect connections to use the
+RFC-6455 WebSocket protocol instead of raw TCP/IP.  This is more
+usable by web browsers directly, but often requires a reverse proxy
+to speak TLS ("wss").
 
   This option can be used multiple times to add more addresses, and
 its use disables autolisten.  If necessary, and 'always-use-proxy'

--- a/doc/lightningd-rpc.7.md
+++ b/doc/lightningd-rpc.7.md
@@ -101,7 +101,7 @@ referred to in addition to simple JSON types:
 * `u64`: a JSON number without decimal point in the range 0 to 18446744073709551615 inclusive.
 * `u32`: a JSON number without decimal point in the range 0 to 4294967295 inclusive.
 * `u16`: a JSON number without decimal point in the range 0 to 65535 inclusive.
-* `u16`: a JSON number without decimal point in the range 0 to 255 inclusive.
+* `u8`: a JSON number without decimal point in the range 0 to 255 inclusive.
 * `pubkey`: a 66-character `hex` which is an SEC-1 encoded secp256k1 point (usually used as a public key).
 * `msat`: a `u64` which indicates an amount of millisatoshis.  Deprecated: may also be a string of the number, with "msat" appended.  As an input parameter, lightningd(8) will accept strings with suffixes (see below).
 * `txid`: a 64-character `hex` Bitcoin transaction identifier.


### PR DESCRIPTION
Changelog-None