### PR TITLE
common: set `errno=0` before calling `strto{l,ul,ull}`

### DIFF
--- a/common/bolt11.c
+++ b/common/bolt11.c
@@ -810,6 +810,7 @@ struct bolt11 *bolt11_decode_nosig(const tal_t *ctx, const char *str,
 		 * anything except a `multiplier` (see table above)... MUST fail the
 		 * payment.
 		 **/
+		errno = 0;
 		amount = strtoull(amountstr, &end, 10);
 		if (amount == ULLONG_MAX && errno == ERANGE)
 			return decode_fail(b11, fail,

--- a/common/json_parse.c
+++ b/common/json_parse.c
@@ -233,6 +233,7 @@ static void parse_number(const char **guide, u32 *number)
 	char *endp;
 	long int l;
 
+	errno = 0;
 	l = strtol(*guide, &endp, 10);
 	assert(endp != *guide);
 	assert(errno != ERANGE);
@@ -518,6 +519,7 @@ bool json_to_bitcoin_amount(const char *buffer, const jsmntok_t *tok,
 	char *end;
 	unsigned long btc, sat;
 
+	errno = 0;
 	btc = strtoul(buffer + tok->start, &end, 10);
 	if (btc == ULONG_MAX && errno == ERANGE)
 		return false;

--- a/common/json_parse_simple.c
+++ b/common/json_parse_simple.c
@@ -71,6 +71,7 @@ bool json_to_u64(const char *buffer, const jsmntok_t *tok, u64 *num)
 	char *end;
 	unsigned long long l;
 
+	errno = 0;
 	l = strtoull(buffer + tok->start, &end, 0);
 	if (end != buffer + tok->end)
 		return false;
@@ -93,6 +94,7 @@ bool json_to_s64(const char *buffer, const jsmntok_t *tok, s64 *num)
 	char *end;
 	long long l;
 
+	errno = 0;
 	l = strtoll(buffer + tok->start, &end, 0);
 	if (end != buffer + tok->end)
 		return false;
@@ -134,7 +136,7 @@ bool json_to_double(const char *buffer, const jsmntok_t *tok, double *num)
 	if (end != buffer + tok->end)
 		return false;
 
-	/* Check for overflow */
+	/* Check for overflow/underflow */
 	if (errno == ERANGE)
 		return false;
 


### PR DESCRIPTION
The `strto{l,ul,ull}` functions do not set `errno` upon a successful return, so a successful return from a maximally valued input could be misinterpreted as an overflow error if `errno` happened already to be set to `ERANGE` before the call. To guard against this edge case, always set `errno` to zero before calling these functions if checking `errno` afterward.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages). **Trivial fix warrants no changelog message.**
- [x] Tests have been added or modified to reflect the changes. **Don't think it's worth writing tests for this edge case.**
- [x] Documentation has been reviewed and updated as needed. **There's no documentation to update.**
- [x] Related issues have been listed and linked, including any that this PR closes. **I doubt this has been reported, or else it would already have been fixed (I hope), but I didn't check.**
