### PR TITLE
common/json_parse_simple: drop redundant and wrong `json_str_to_u64()`

### DIFF
--- a/common/json_param.c
+++ b/common/json_param.c
@@ -975,8 +975,7 @@ struct command_result *param_extra_tlvs(struct command *cmd, const char *name,
 		/* Accept either bare ints as keys (not spec
 		 * compliant, but simpler), or ints in strings, which
 		 * are JSON spec compliant. */
-		if (!(json_str_to_u64(buffer, curr, &f->numtype) ||
-		      json_to_u64(buffer, curr, &f->numtype))) {
+		if (!json_to_u64(buffer, curr, &f->numtype)) {
 			return command_fail(
 			    cmd, JSONRPC2_INVALID_PARAMS,
 			    "\"%s\" is not a valid numeric TLV type.",

--- a/common/json_parse_simple.c
+++ b/common/json_parse_simple.c
@@ -109,19 +109,6 @@ bool json_to_s64(const char *buffer, const jsmntok_t *tok, s64 *num)
 	return true;
 }
 
-bool json_str_to_u64(const char *buffer, const jsmntok_t *tok, u64 *num)
-{
-	jsmntok_t temp;
-	if (tok->type != JSMN_STRING)
-		return false;
-
-	temp = *tok;
-	temp.start += 1;
-	temp.end -= 1;
-
-	return json_to_u64(buffer, &temp, num);
-}
-
 bool json_to_double(const char *buffer, const jsmntok_t *tok, double *num)
 {
 	char *end;

--- a/common/json_parse_simple.h
+++ b/common/json_parse_simple.h
@@ -42,10 +42,6 @@ bool json_to_u64(const char *buffer, const jsmntok_t *tok, u64 *num);
 /* Extract signed 64 bit integer from this (may be a string, or a number literal) */
 bool json_to_s64(const char *buffer, const jsmntok_t *tok, s64 *num);
 
-/* Extract number from string. The number must be the entirety of the
- * string between the '"' */
-bool json_str_to_u64(const char *buffer, const jsmntok_t *tok, u64 *num);
-
 /* Extract number from this (may be a string, or a number literal) */
 bool json_to_u32(const char *buffer, const jsmntok_t *tok, u32 *num);
 


### PR DESCRIPTION
The `json_str_to_u64()` function contains incorrect logic. It chops one character off of the beginning and end of the JSMN token and then parses the remainder as a `u64`, but `JSMN_STRING` tokens already do not include the enclosing quotation marks, so `json_str_to_u64()` would actually parse the JSON string `"1234"` into the integer 23. Oops! Also note that it would simply fail on all input strings shorter than two characters since `tok->end` would wind up *before* `tok->start`.

Just drop the function entirely. It was only used in one place, and that place explicitly doesn't care whether its input is a JSON number or a numeric string, and it was already calling `json_to_u64()` as an alternative, and that function already accepts both JSON strings and JSON numbers as input, so the call to `json_str_to_u64()` would have been entirely redundant if it had been correct.

**Changelog-Fixed:** The `keysend` command no longer corrupts the type numbers of extra TLVs when they are specified as numeric strings longer than 2 digits.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes. **I'm not confident that I know how to do this well, but I could take a crack at it if it's really necessary.**
- [x] Documentation has been reviewed and updated as needed. **The logic was previously wrong, so presumably this fix brings the behavior in line with the existing documentation.**
- [x] Related issues have been listed and linked, including any that this PR closes. **I didn't find any.**
