### PR TITLE
Avoid extra copy when unescaping JSON strings

### DIFF
--- a/ccan/ccan/json_escape/json_escape.h
+++ b/ccan/ccan/json_escape/json_escape.h
@@ -41,4 +41,8 @@ struct json_escape *json_escape_string_(const tal_t *ctx,
 /* Be very careful here!  Can fail!  Doesn't handle \u: use UTF-8 please. */
 const char *json_escape_unescape(const tal_t *ctx,
 				 const struct json_escape *esc);
+
+/* Be very careful here!  Can fail!  Doesn't handle \u: use UTF-8 please. */
+const char *json_escape_unescape_len(const tal_t *ctx,
+				     const char *esc TAKES, size_t len);
 #endif /* CCAN_JSON_ESCAPE_H */

--- a/common/json_param.c
+++ b/common/json_param.c
@@ -444,11 +444,9 @@ struct command_result *param_escaped_string(struct command *cmd,
 					    const char **str)
 {
 	if (tok->type == JSMN_STRING) {
-		struct json_escape *esc;
 		/* jsmn always gives us ~ well-formed strings. */
-		esc = json_escape_string_(cmd, buffer + tok->start,
-					  tok->end - tok->start);
-		*str = json_escape_unescape(cmd, esc);
+		*str = json_escape_unescape_len(cmd, buffer + tok->start,
+						tok->end - tok->start);
 		if (*str)
 			return NULL;
 	}

--- a/common/test/run-bolt12_decode.c
+++ b/common/test/run-bolt12_decode.c
@@ -190,13 +190,11 @@ int main(int argc, char *argv[])
 		char *fail;
 		const char *str;
 		size_t dlen;
-		struct json_escape *esc;
 
 		assert(json_to_bool(json, json_get_member(json, t, "valid"), &valid));
 		strtok = json_get_member(json, t, "string");
-		esc = json_escape_string_(tmpctx, json + strtok->start,
-					  strtok->end - strtok->start);
-		str = json_escape_unescape(tmpctx, esc);
+		str = json_escape_unescape_len(tmpctx, json + strtok->start,
+					       strtok->end - strtok->start);
 		actual = (string_to_data(tmpctx, str, strlen(str),
 					 "lno", &dlen, &fail) != NULL);
 		assert(actual == valid);

--- a/lightningd/jsonrpc.c
+++ b/lightningd/jsonrpc.c
@@ -1393,20 +1393,14 @@ static void setup_command_usage(struct lightningd *ld,
 bool jsonrpc_command_add(struct jsonrpc *rpc, struct json_command *command,
 			 const char *usage TAKES)
 {
-	struct json_escape *esc;
 	const char *unescaped;
 
 	if (!command_add(rpc, command))
 		return false;
 
-	esc = json_escape_string_(tmpctx, usage, strlen(usage));
-	unescaped = json_escape_unescape(command, esc);
+	unescaped = json_escape_unescape_len(command, usage, strlen(usage));
 	if (!unescaped)
-		unescaped = tal_strdup(command, usage);
-	else {
-		if (taken(usage))
-			tal_free(usage);
-	}
+		return false;
 
 	strmap_add(&rpc->usagemap, command->name, unescaped);
 	tal_add_destructor2(command, destroy_json_command, rpc);

--- a/lightningd/runes.c
+++ b/lightningd/runes.c
@@ -484,10 +484,8 @@ static struct rune_altern *rune_altern_from_json(const tal_t *ctx,
 	/* We still need to unescape here, for \\ -> \.  JSON doesn't
 	 * allow unnecessary \ */
 	const char *unescape;
-	struct json_escape *e = json_escape_string_(tmpctx,
-						    buffer + tok->start,
-						    tok->end - tok->start);
-	unescape = json_escape_unescape(tmpctx, e);
+	unescape = json_escape_unescape_len(tmpctx, buffer + tok->start,
+					    tok->end - tok->start);
 	if (!unescape)
 		return NULL;
 


### PR DESCRIPTION
Make use of rustyrussell/ccan#123 to avoid making an extra copy of escaped JSON strings just to unescape them.

Note that `jsonrpc_command_add(…)` no longer accepts usage strings containing invalid escape sequences. (Previously, it would quietly accept such a string without unescaping anything.)

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages). **Not significant enough to warrant a changelog entry.**
- [x] Tests have been added or modified to reflect the changes. **Existing tests already check relevant functionality.**
- [x] Documentation has been reviewed and updated as needed. **Not a user-facing change.**
- [x] Related issues have been listed and linked, including any that this PR closes. **None relevant.**
