### PR TITLE
bech32: add BIP-173 padding validation

### DIFF
--- a/common/bech32_util.h
+++ b/common/bech32_util.h
@@ -13,7 +13,7 @@ void bech32_push_bits(u5 **data, const void *src, size_t nbits);
 /**
  * Push the bytes in src in 8 bit format onto the end of data.
  */
-void bech32_pull_bits(u8 **data, const u5 *src, size_t nbits);
+bool bech32_pull_bits(u8 **data, const u5 *src, size_t nbits);
 
 /**
  * Checksumless bech32 routines.

--- a/plugins/offers.c
+++ b/plugins/offers.c
@@ -477,7 +477,9 @@ static u8 *encrypted_decode(const tal_t *ctx, const char *str, char **fail) {
 		goto fail;
 	}
 	u8 *data8bit = tal_arr(data, u8, 0);
-	bech32_pull_bits(&data8bit, data, datalen*5);
+	if (!bech32_pull_bits(&data8bit, data, datalen*5)) {
+		goto fail;
+	}
 
 	return data8bit;
 fail:


### PR DESCRIPTION
@brunoerg has been doing differential fuzzing on `CLightning` and discovered an offer that crashes our differential fuzzing target in `bitcoinfuzz`. I found that `CLightning` accepts malformed offers containing invalid bech32 data that violates the BIP-173 specification, creating interoperability issues with other Lightning implementations (`rust-lightning`, `lightning-kmp`) that correctly reject such data.

BIP-173 says:
> Re-arrange those bits into groups of 8 bits. Any incomplete group at the end MUST be 4 bits or less, MUST be all zeroes, and is discarded.

offer:
```
lno1qgqqvqtezcss8kkkkkkkkkk3srkklllllllvw03s33s333p444444444444pgqpq8
```

lightning-kmp check: https://github.com/ACINQ/bitcoin-kmp/blob/master/src/commonMain/kotlin/fr/acinq/bitcoin/Bech32.kt#L206

rust-lightning check: https://github.com/rust-bitcoin/rust-bech32/blob/master/src/primitives/iter.rs#L180

BOLT12 is missing a test case like this. Perhaps this could be a useful new test vector?

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
