### PR TITLE
common: fix dangling memory allocation in `daemon_conn_new_()`

### DIFF
--- a/common/daemon_conn.c
+++ b/common/daemon_conn.c
@@ -143,7 +143,7 @@ struct daemon_conn *daemon_conn_new_(const tal_t *ctx, int fd,
 				     void (*outq_empty)(void *),
 				     void *arg)
 {
-	struct daemon_conn *dc = tal(NULL, struct daemon_conn);
+	struct daemon_conn *dc = tal(ctx, struct daemon_conn);
 
 	dc->recv = recv;
 	dc->outq_empty = outq_empty;


### PR DESCRIPTION
Changelog-Fixed: Use the correct context in `daemon_conn_new_()` by allocating `struct daemon_conn` with `ctx` instead of `NULL`.

This ensures proper ownership and cleanup of `daemon_conn` objects, avoiding memory leaks.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

CC: @morehouse 