### PR TITLE
Reckless uv installer

### DIFF
--- a/tools/reckless
+++ b/tools/reckless
@@ -821,6 +821,9 @@ class InferInstall():
             for tier in range(0, 10):
                 # Look for each installers preferred entrypoint format first
                 for inst in INSTALLERS:
+                    # All of this installer's entrypoint options exhausted.
+                    if tier >= len(inst.entries):
+                        continue
                     fmt = inst.entries[tier]
                     if '{name}' in fmt:
                         pre = fmt.split('{name}')[0]

--- a/tools/reckless
+++ b/tools/reckless
@@ -1398,13 +1398,13 @@ def install(plugin_name: str) -> Union[str, None]:
     src = None
     if direct_location:
         logging.debug(f"install of {name} requested from {direct_location}")
-        src = InstInfo(name, direct_location, None)
-        if not src.get_inst_details():
-            src = None
+        src = InstInfo(name, direct_location, name)
         # Treating a local git repo as a directory allows testing
         # uncommitted changes.
         if src and src.srctype == Source.LOCAL_REPO:
             src.srctype = Source.DIRECTORY
+        if not src.get_inst_details():
+            src = None
     if not direct_location or not src:
         log.debug(f"Searching for {name}")
         if search(name):

--- a/tools/reckless
+++ b/tools/reckless
@@ -986,6 +986,37 @@ def cargo_installation(cloned_plugin: InstInfo):
     return cloned_plugin
 
 
+def install_python_uv(cloned_plugin: InstInfo):
+    """This uses the rust-based python plugin manager uv to manage the python
+    installation and create a virtual environment."""
+
+    source = Path(cloned_plugin.source_loc) / 'source' / cloned_plugin.name
+    # This virtual env path matches the other python installations and allows
+    # creating the wrapper in the same manner. Otherwise uv would build it in
+    # the source/{name} subdirectory.
+    cloned_plugin.venv = Path('.venv')
+
+    # We want the virtual env at the head of our directory structure and uv
+    # will need a pyproject.toml there in order to get started.
+    (Path(cloned_plugin.source_loc) / 'pyproject.toml').\
+        symlink_to(source / 'pyproject.toml')
+
+    call = ['uv', '-v', 'sync']
+    uv = run(call, cwd=str(cloned_plugin.source_loc), stdout=PIPE, stderr=PIPE,
+             text=True, check=False)
+    if uv.returncode != 0:
+        for line in uv.stderr.splitlines():
+            log.debug(line)
+        log.error('Failed to install virtual environment')
+        raise InstallationFailure('Failed to create virtual environment!')
+
+    # Delete entrypoint symlink so that a venv wrapper can take it's place
+    (Path(cloned_plugin.source_loc) / cloned_plugin.entry).unlink()
+
+    create_wrapper(cloned_plugin)
+    return cloned_plugin
+
+
 python3venv = Installer('python3venv', exe='python3',
                         manager='pip', entry='{name}.py')
 python3venv.add_entrypoint('{name}')
@@ -997,6 +1028,7 @@ poetryvenv = Installer('poetryvenv', exe='python3',
                        manager='poetry', entry='{name}.py')
 poetryvenv.add_entrypoint('{name}')
 poetryvenv.add_entrypoint('__init__.py')
+poetryvenv.add_dependency_file('poetry.lock')
 poetryvenv.add_dependency_file('pyproject.toml')
 poetryvenv.dependency_call = install_to_python_virtual_environment
 
@@ -1007,6 +1039,9 @@ pyprojectViaPip.add_entrypoint('__init__.py')
 pyprojectViaPip.add_dependency_file('pyproject.toml')
 pyprojectViaPip.dependency_call = install_to_python_virtual_environment
 
+pythonuv = Installer('pythonuv', exe='python3', manager='uv', entry="{name}.py")
+pythonuv.add_dependency_file('uv.lock')
+pythonuv.dependency_call = install_python_uv
 
 # Nodejs plugin installer
 nodejs = Installer('nodejs', exe='node',
@@ -1020,7 +1055,8 @@ rust_cargo = Installer('rust', manager='cargo', entry='Cargo.toml')
 rust_cargo.add_dependency_file('Cargo.toml')
 rust_cargo.dependency_call = cargo_installation
 
-INSTALLERS = [python3venv, poetryvenv, pyprojectViaPip, nodejs, rust_cargo]
+INSTALLERS = [pythonuv, python3venv, poetryvenv, pyprojectViaPip, nodejs,
+              rust_cargo]
 
 
 def help_alias(targets: list):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 25.09 FREEZE July 28TH: Non-bugfix PRs not ready by this date will wait for 25.12.
>
> RC1 is scheduled on _August 11th_
>
> The final release is scheduled for September 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.

This PR allows reckless to use the uv python package manager when installing plugins.  It maintains the same virtual environment location and source code location as used by the pip and poetry installers.  There's also a driveby fix of an obscure direct install bug.