### PR TITLE
configure: Add macOS-specific debug flags for libbacktrace compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,6 +825,12 @@ install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $
 	@if [ -d "$(DESTDIR)$(plugindir)/wss-proxy" ]; then rm -rf $(DESTDIR)$(plugindir)/wss-proxy; fi
 	[ -z "$(PLUGINS)" ] || $(INSTALL_PROGRAM) $(PLUGINS) $(DESTDIR)$(plugindir)
 	for PY in $(PY_PLUGINS); do DIR=`dirname $$PY`; DST=$(DESTDIR)$(plugindir)/`basename $$DIR`; if [ -d $$DST ]; then rm -rf $$DST; fi; $(INSTALL_PROGRAM) -d $$DIR; cp -a $$DIR $$DST ; done
+ifeq ($(OS),Darwin)
+	# Install dSYM bundles alongside binaries on macOS
+	for BIN in $(BIN_PROGRAMS); do if [ -d $$BIN.dSYM ]; then cp -a $$BIN.dSYM $(DESTDIR)$(bindir)/; fi; done
+	for BIN in $(PKGLIBEXEC_PROGRAMS); do if [ -d $$BIN.dSYM ]; then cp -a $$BIN.dSYM $(DESTDIR)$(pkglibexecdir)/; fi; done
+	for PLUGIN in $(PLUGINS); do if [ -d $$PLUGIN.dSYM ]; then cp -a $$PLUGIN.dSYM $(DESTDIR)$(plugindir)/; fi; done
+endif
 
 MAN1PAGES = $(filter %.1,$(MANPAGES))
 MAN5PAGES = $(filter %.5,$(MANPAGES))

--- a/Makefile
+++ b/Makefile
@@ -684,12 +684,18 @@ $(ALL_TEST_PROGRAMS) $(ALL_FUZZ_TARGETS): %: %.o
 # (as per EXTERNAL_LDLIBS) so we filter them out here.
 $(ALL_PROGRAMS) $(ALL_TEST_PROGRAMS):
 	@$(call VERBOSE, "ld $@", $(LINK.o) $(filter-out %.a,$^) $(LOADLIBES) $(EXTERNAL_LDLIBS) $(LDLIBS) libccan.a $($(@)_LDLIBS) -o $@)
+ifeq ($(OS),Darwin)
+	@$(call VERBOSE, "dsymutil $@", dsymutil $@)
+endif
 
 # We special case the fuzzing target binaries, as they need to link against libfuzzer,
 # which brings its own main().
 FUZZ_LDFLAGS = -fsanitize=fuzzer
 $(ALL_FUZZ_TARGETS):
 	@$(call VERBOSE, "ld $@", $(LINK.o) $(filter-out %.a,$^) $(LOADLIBES) $(EXTERNAL_LDLIBS) $(LDLIBS) libccan.a $(FUZZ_LDFLAGS) -o $@)
+ifeq ($(OS),Darwin)
+	@$(call VERBOSE, "dsymutil $@", dsymutil $@)
+endif
 
 
 # Everything depends on the CCAN headers, and Makefile

--- a/configure
+++ b/configure
@@ -151,7 +151,7 @@ set_defaults()
             # Detect macOS and use appropriate debug flags for libbacktrace compatibility
     if [ "$(uname -s)" = "Darwin" ]; then
         # Always override to avoid DWARF 5
-        CDEBUGFLAGS="-std=gnu11 -g -gdwarf-4 -fstack-protector-strong"
+        CDEBUGFLAGS="-std=gnu11 -g -gdwarf-4 -fno-standalone-debug -fstack-protector-strong"
 
         # Optional: confirm dsymutil is available
         if ! command -v dsymutil >/dev/null 2>&1; then

--- a/configure
+++ b/configure
@@ -148,7 +148,18 @@ set_defaults()
     # which matters since you might explicitly set of these blank.
     PREFIX=${PREFIX:-/usr/local}
     CC=${CC:-cc}
-    CDEBUGFLAGS=${CDEBUGFLAGS--std=gnu11 -g -fstack-protector-strong}
+            # Detect macOS and use appropriate debug flags for libbacktrace compatibility
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # Always override to avoid DWARF 5
+        CDEBUGFLAGS="-std=gnu11 -g -gdwarf-4 -fstack-protector-strong"
+
+        # Optional: confirm dsymutil is available
+        if ! command -v dsymutil >/dev/null 2>&1; then
+            echo "Warning: dsymutil not found. Install Xcode Command Line Tools for better debug support."
+        fi
+    else
+        CDEBUGFLAGS=${CDEBUGFLAGS--std=gnu11 -g -fstack-protector-strong}
+    fi
     DEBUGBUILD=${DEBUGBUILD:-0}
     COMPAT=${COMPAT:-1}
     STATIC=${STATIC:-0}
@@ -194,6 +205,9 @@ usage()
     usage_with_default "CWARNFLAGS" "$DEFAULT_CWARNFLAGS"
     usage_with_default "COPTFLAGS" "$DEFAULT_COPTFLAGS"
     usage_with_default "CDEBUGFLAGS" "$CDEBUGFLAGS"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "    Note: On macOS, -g is used instead of -g3 for libbacktrace compatibility"
+    fi
     usage_with_default "CONFIGURATOR_CC" "${CONFIGURATOR_CC:-$CC}"
     echo "    To override compile line for configurator itself"
     usage_with_default "PYTEST" "$PYTEST"


### PR DESCRIPTION
On macOS, libbacktrace was failing to find debug information due to:
1. Debug symbols not being properly linked with dsymutil
2. Apple Clang 17.0.0 generating DWARF 5 which libbacktrace couldn't parse

In this commit we address both issues:

Debug symbol accessibility:
- Add dsymutil integration in Makefile to properly link debug symbols

DWARF format compatibility:
- Force -gdwarf-4 instead of default DWARF 5 to avoid "DW_FORM_addrx value out of range" errors
- Update the version of libbacktrace being used in core-lightning (see [commit](https://github.com/ianlancetaylor/libbacktrace/commit/d48f84034ce3e53e501d10593710d025cb1121db))

Changelog-added: libbacktrace works with macOS

Example stacktrace:
```
sangbida@Sangbidas-MacBook-Pro lightning % ./lightningd/lightningd
lightningd: FATAL SIGNAL 6 (version v25.05-62-g3622a81-modded)
0x102833dcb send_backtrace
        common/daemon.c:33
0x1028344db crashdump
        common/daemon.c:78
0x185a6f623 ???
        ???:0
0x185a3588b ???
        ???:0
0x18593ec5f ???
        ???:0
0x1027ae32b main
        lightningd/lightningd.c:1217
zsh: abort      ./lightningd/lightningd
```
> [!IMPORTANT]
>
> 25.09 FREEZE July 28TH: Non-bugfix PRs not ready by this date will wait for 25.12.
>
> RC1 is scheduled on _August 11th_
>
> The final release is scheduled for September 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
