### PR TITLE
Add `json_object` and `json_group_array` support in sql plugin

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -32538,7 +32538,9 @@
         "* time",
         "* timediff",
         "* total",
-        "* unixepoch"
+        "* unixepoch",
+        "* json_object",
+        "* json_group_array"
       ],
       "tables": [
         "Note that the first column of every table is a unique integer called `rowid`: this is used for related tables to refer to specific rows in their parent. sqlite3 usually has this as an implicit column, but we make it explicit as the implicit version is not allowed to be used as a foreign key.",

--- a/doc/schemas/sql-template.json
+++ b/doc/schemas/sql-template.json
@@ -107,7 +107,9 @@
     "* time",
     "* timediff",
     "* total",
-    "* unixepoch"
+    "* unixepoch",
+    "* json_object",
+    "* json_group_array"
   ],
   "tables": [
     "Note that the first column of every table is a unique integer called `rowid`: this is used for related tables to refer to specific rows in their parent. sqlite3 usually has this as an implicit column, but we make it explicit as the implicit version is not allowed to be used as a foreign key.",

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -352,6 +352,10 @@ static int sqlite_authorize(void *dbq_, int code,
 			return SQLITE_OK;
 		if (streq(b, "unixepoch"))
 			return SQLITE_OK;
+		if (streq(b, "json_object"))
+			return SQLITE_OK;
+		if (streq(b, "json_group_array"))
+			return SQLITE_OK;
 	}
 
 	/* See https://www.sqlite.org/c3ref/c_alter_table.html to decode these! */


### PR DESCRIPTION
Changelog-Added: Plugins: `sql` also supports functions `json_object(key1, value1, ...)` to construct JSON objects and `json_group_array(value)` to aggregate rows into JSON array.

Security Considerations
- No new SQL injection risks: Functions only process explicitly provided column values (no arbitrary string parsing).
- Explicit column requirements: Wildcards (*) are not supported, all fields must be named (e.g., json_object('peer_id', id)).
- Permission-bound data access: Functions adhere to the same table/row permissions as the underlying query.

Performance Impact
- Optimized native execution: Leverages SQLite’s built-in JSON1 extension (when available) for efficiency.
- Moderate CPU overhead: Complex nesting may impact performance on large datasets but still faster than application-layer JSON conversion.

