### PR TITLE
Add Bolt references and conform to them

### DIFF
--- a/channeld/splice.c
+++ b/channeld/splice.c
@@ -8,7 +8,6 @@ struct splice_state *splice_state_new(const tal_t *ctx)
 	splice_state->count = 0;
 	splice_state->locked_ready[LOCAL] = false;
 	splice_state->locked_ready[REMOTE] = false;
-	splice_state->await_commitment_succcess = false;
 	splice_state->inflights = NULL;
 	splice_state->remote_locked_txid = NULL;
 

--- a/channeld/splice.h
+++ b/channeld/splice.h
@@ -17,8 +17,6 @@ struct splice_state {
 	struct short_channel_id last_short_channel_id;
 	/* Tally of which sides are locked, or not */
 	bool locked_ready[NUM_SIDES];
-	/* Set to true when commitment cycle completes successfully */
-	bool await_commitment_succcess;
 	/* The txid of which splice inflight was confirmed */
 	struct bitcoin_txid locked_txid;
 	/* The txid our peer locked their splice on */


### PR DESCRIPTION
Adding Bolt references around `commitment_signed` logic and conforming to them.

This allows us to remove the `await_commitment_succcess` logic which was never elegant anyway, nice!

While we’re there we remove a parameter from `handle_peer_commit_sig_batch` that shouldn’t have been there anyway.