### PR TITLE
avoid UB when calling ctype functions

### DIFF
--- a/common/json_parse.c
+++ b/common/json_parse.c
@@ -30,7 +30,7 @@ bool json_to_millionths(const char *buffer, const jsmntok_t *tok,
 
 	*millionths = 0;
 	for (int i = tok->start; i < tok->end; i++) {
-		if (isdigit(buffer[i])) {
+		if (cisdigit(buffer[i])) {
 			has_digits = true;
 			/* Ignore too much precision */
 			if (decimal_places >= 0 && ++decimal_places > 6)

--- a/common/splice_script.c
+++ b/common/splice_script.c
@@ -503,7 +503,7 @@ char *fmt_splice_script_compiler_error(const tal_t *ctx,
 
 static bool is_whitespace(char c)
 {
-	return isspace(c);
+	return cisspace(c);
 }
 
 static struct splice_script_error *clean_whitespace(const tal_t *ctx,

--- a/db/db_sqlite3.c
+++ b/db/db_sqlite3.c
@@ -456,7 +456,7 @@ static const char *find_column_name(const tal_t *ctx,
 {
 	size_t start = 0;
 
-	while (isspace(sqlpart[start]))
+	while (cisspace(sqlpart[start]))
 		start++;
 	*after = strspn(sqlpart + start, "abcdefghijklmnopqrstuvwxyz_0123456789") + start;
 	if (*after == start || !cisspace(sqlpart[*after]))

--- a/devtools/onion.c
+++ b/devtools/onion.c
@@ -145,7 +145,7 @@ static void do_decode(int argc, char **argv, const u8 *assocdata)
 	size_t hexlen = strlen(hextemp);
 
 	// trim trailing whitespace
-	while (isspace(hextemp[hexlen-1]))
+	while (cisspace(hextemp[hexlen-1]))
 		hexlen--;
 
 	serialized = tal_hexdata(hextemp, hextemp, hexlen);


### PR DESCRIPTION
The character classification functions in `<ctype.h>` are designed to classify characters returned by `<stdio.h>` `getchar()` and friends, which return characters as signed integers in the range 0 to 255 or `EOF`. The behavior of the ctype functions is undefined if they are passed a value outside of that range, which may happen if they are passed a `char`-typed value and the system's `char` type is signed.

`<ccan/str/str.h>` defines some inline utility functions that perform the necessary cast to coerce a `char`-typed argument into the allowed value range. Call these wrappers instead of the bare ctype functions when classifying `char`-typed characters.

**Changelog-None**

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes. **Not applicable.**
- [x] Documentation has been reviewed and updated as needed. **Not applicable.**
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
