### PR TITLE
connectd: demote “Peer did not close, forcing close” to `UNUSUAL`

### DIFF
--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -107,7 +107,7 @@ static void maybe_free_peer(struct peer *peer)
 static void close_peer_io_timeout(struct peer *peer)
 {
 	/* BROKEN means we'll trigger CI if we see it, though it's possible */
-	status_peer_broken(&peer->id, "Peer did not close, forcing close");
+	status_peer_unusual(&peer->id, "Peer did not close, forcing close");
 	io_close(peer->to_peer);
 }
 


### PR DESCRIPTION
This message is logged when connectd tries to shut down a peer connection but the transmit buffer remains full for too long, maybe because the peer has crashed or has lost connectivity. Logging this message at the `BROKEN` level is inappropriate because `BROKEN` is intended to flag logic errors that imply incorrect code in CLN. The error in question here is actually a _runtime_ error, which does not imply incorrect code (at least on our side), so demote the log message to the `UNUSUAL` level. (Even this is still probably too severe, as this message is logged rather more frequently than "unusual" would suggest.)

Changelog-None
Closes: https://github.com/ElementsProject/lightning/issues/5678

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes. **Not applicable.**
- [x] Documentation has been reviewed and updated as needed. **Not applicable.**
- [x] Related issues have been listed and linked, including any that this PR closes.
