### PR TITLE
ci: Retry CI workflow with Changelog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,7 @@ on:
     branches:
       - "master"
   pull_request:
-
-# Run CI when PR is edited and description contains Changelog
-if: |
-  github.event.action != 'edited' || 
-  contains(github.event.pull_request.body, 'Changelog')
-
+    types: [opened, synchronize, edited]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -27,6 +22,9 @@ jobs:
     name: Pre-build checks
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    if: |
+      github.event.action != 'edited' || 
+      contains(tolower(github.event.pull_request.body), 'changelog')
     env:
       BOLTDIR: bolts
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,11 @@ on:
       - "master"
   pull_request:
 
+# Run CI when PR is edited and description contains Changelog
+if: |
+  github.event.action != 'edited' || 
+  contains(github.event.pull_request.body, 'Changelog')
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Run CI when PR is edited and description contains Changelog

> [!IMPORTANT]
>
> 25.09 FREEZE July 28TH: Non-bugfix PRs not ready by this date will wait for 25.12.
>
> RC1 is scheduled on _August 11th_
>
> The final release is scheduled for September 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.

Changelog-None
