### PR TITLE
Fix three resource leaks

### DIFF
--- a/contrib/pyln-client/pyln/client/lightning.py
+++ b/contrib/pyln-client/pyln/client/lightning.py
@@ -254,9 +254,12 @@ class UnixSocket(object):
                 # Open an fd to our home directory, that we can then find
                 # through `/proc/self/fd` and access the contents.
                 dirfd = os.open(dirname, os.O_DIRECTORY | os.O_RDONLY)
-                short_path = "/proc/self/fd/%d/%s" % (dirfd, basename)
-                self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                self.sock.connect(short_path)
+                try:
+                    short_path = "/proc/self/fd/%d/%s" % (dirfd, basename)
+                    self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    self.sock.connect(short_path)
+                finally:
+                    os.close(dirfd)
             elif (e.args[0] == "AF_UNIX path too long" and os.uname()[0] == "Darwin"):
                 temp_dir = tempfile.mkdtemp()
                 temp_link = os.path.join(temp_dir, "socket_link")

--- a/contrib/pyln-testing/pyln/testing/fixtures.py
+++ b/contrib/pyln-testing/pyln/testing/fixtures.py
@@ -512,6 +512,9 @@ def node_factory(request, directory, test_name, bitcoind, executor, db_provider,
     if not ok:
         map_node_error(nf.nodes, prinErrlog, "some node failed unexpected, non-empty errlog file")
 
+    for n in nf.nodes:
+        n.daemon.cleanup_files()
+
 
 def getErrlog(node):
     for error_file in os.listdir(node.daemon.lightning_dir):

--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -60,7 +60,8 @@ def env(name, default=None):
     """
     fname = 'config.vars'
     if os.path.exists(fname):
-        lines = open(fname, 'r').readlines()
+        with open(fname, 'r') as f:
+            lines = f.readlines()
         config = dict([(line.rstrip().split('=', 1)) for line in lines])
     else:
         config = {}


### PR DESCRIPTION
* **pyln-client** has a resource leak in `UnixSocket.__init__(…)` in the fallback path that is executed when the RPC socket path is longer than can fit in a `struct sockaddr_un`. This was causing file descriptor exhaustion in pytests.
    https://github.com/ElementsProject/lightning/blob/fcd92febad83e84f2bea866f244959b8d760bade/contrib/pyln-client/pyln/client/lightning.py#L256
* **pyln-testing** has a resource leak in `utils.env(…)` when reading `config.vars`.
    https://github.com/ElementsProject/lightning/blob/fcd92febad83e84f2bea866f244959b8d760bade/contrib/pyln-testing/pyln/testing/utils.py#L63
* **pyln-testing** has a resource leak in `node_factory`, as it neglects to call `cleanup_files()` on the `LightningD` instances produced by the factory.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed. **Not applicable.**
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
