### PR TITLE
tests: work around socket path name too long on Linux

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,6 +21,11 @@ class LightningNode(utils.LightningNode):
         kwargs["executable"] = "lightningd/lightningd"
         utils.LightningNode.__init__(self, *args, **kwargs)
 
+        # Avoid socket path name too long on Linux
+        if os.uname()[0] == 'Linux' and \
+                len(str(self.lightning_dir / TEST_NETWORK / 'lightning-rpc')) >= 108:
+            self.daemon.opts['rpc-file'] = '/proc/self/cwd/lightning-rpc'
+
         # This is a recent innovation, and we don't want to nail pyln-testing to this version.
         self.daemon.opts['dev-crash-after'] = 3600
 

--- a/tests/test_cln_rs.py
+++ b/tests/test_cln_rs.py
@@ -27,6 +27,8 @@ def test_rpc_client(node_factory):
     l1 = node_factory.get_node()
     bin_path = Path.cwd() / "target" / RUST_PROFILE / "examples" / "cln-rpc-getinfo"
     rpc_path = Path(l1.daemon.lightning_dir) / TEST_NETWORK / "lightning-rpc"
+    if len(str(rpc_path)) >= 108 and os.uname()[0] == 'Linux':
+        rpc_path = Path('/proc/self/cwd') / os.path.relpath(rpc_path)
     out = subprocess.check_output([bin_path, rpc_path], stderr=subprocess.STDOUT)
     assert(b'0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518' in out)
 


### PR DESCRIPTION
When running the integration test suite in a deeply nested directory tree, the path name of the Unix domain socket might be longer than can fit in a `struct sockaddr_un`. On Linux, we can use the `/proc/self/cwd` trick to shorten the path name.

**Changelog-Fixed:** Integration tests no longer fail when run in a deeply nested directory on Linux.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
