### PR TITLE
pyln-testing: pass timeout to `BitcoinProxy`

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -364,8 +364,9 @@ class SimpleBitcoinProxy:
     throwaway connections. This is easier than to reach into the RPC
     library to close, reopen and reauth upon failure.
     """
-    def __init__(self, btc_conf_file, *args, **kwargs):
+    def __init__(self, btc_conf_file, timeout=TIMEOUT, *args, **kwargs):
         self.__btc_conf_file__ = btc_conf_file
+        self.__timeout__ = timeout
 
     def __getattr__(self, name):
         if name.startswith('__') and name.endswith('__'):
@@ -373,7 +374,8 @@ class SimpleBitcoinProxy:
             raise AttributeError
 
         # Create a callable to do the actual call
-        proxy = BitcoinProxy(btc_conf_file=self.__btc_conf_file__)
+        proxy = BitcoinProxy(btc_conf_file=self.__btc_conf_file__,
+                             timeout=self.__timeout__)
 
         def f(*args):
             logging.debug("Calling {name} with arguments {args}".format(


### PR DESCRIPTION
The `bitcoin.rpc.DEFAULT_HTTP_TIMEOUT` of 30 seconds may not be enough time to generate a block when the test machine is under load. Pass `pyln.testing.utils.TIMEOUT` to `bitcoin.rpc.RawProxy` to allow extra time: currently 60 seconds by default or 180 seconds if `SLOW_MACHINE` is set.

Changelog-None

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes. **Not applicable.**
- [x] Documentation has been reviewed and updated as needed. **Not applicable.**
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
