### PR TITLE
plugins: generate certificates with required extensions

### DIFF
--- a/plugins/rest-plugin/src/certs.rs
+++ b/plugins/rest-plugin/src/certs.rs
@@ -12,6 +12,8 @@ pub fn generate_certificates(certs_path: &PathBuf, rest_host: &str) -> Result<()
         "localhost".to_string(),
     ])?;
     ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params.key_usages.push(rcgen::KeyUsagePurpose::KeyCertSign);
+    ca_params.use_authority_key_identifier_extension = true;
     let ca_key = KeyPair::generate()?;
     let ca_cert = ca_params.self_signed(&ca_key)?;
 
@@ -30,6 +32,10 @@ pub fn generate_certificates(certs_path: &PathBuf, rest_host: &str) -> Result<()
         "localhost".to_string(),
     ])?;
     server_params.is_ca = rcgen::IsCa::NoCa;
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::DigitalSignature);
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyEncipherment);
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyAgreement);
+    server_params.use_authority_key_identifier_extension = true;
     server_params.distinguished_name = DistinguishedName::new();
     server_params
         .distinguished_name

--- a/plugins/wss-proxy-plugin/src/certs.rs
+++ b/plugins/wss-proxy-plugin/src/certs.rs
@@ -18,6 +18,8 @@ pub fn generate_certificates(certs_path: &PathBuf, wss_host: &[String]) -> Resul
         "localhost".to_string(),
     ])?;
     ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params.key_usages.push(rcgen::KeyUsagePurpose::KeyCertSign);
+    ca_params.use_authority_key_identifier_extension = true;
     let ca_key = KeyPair::generate()?;
     let ca_cert = ca_params.self_signed(&ca_key)?;
 
@@ -36,6 +38,10 @@ pub fn generate_certificates(certs_path: &PathBuf, wss_host: &[String]) -> Resul
         "localhost".to_string(),
     ])?;
     server_params.is_ca = rcgen::IsCa::NoCa;
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::DigitalSignature);
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyEncipherment);
+    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyAgreement);
+    server_params.use_authority_key_identifier_extension = true;
     server_params.distinguished_name = DistinguishedName::new();
     server_params
         .distinguished_name


### PR DESCRIPTION
Recent versions of `urllib3` fail certificate verification if certificates lack the Authority Key Identifier or Key Usages extensions:

```
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: CA cert does not include key usage extension (_ssl.c:1032)
```

Luckily, `rcgen` offers parameters in its `CertificateParams` structure to add these extensions. Let's use them.
    
**Changelog-Fixed:** Certificates auto-generated by grpc-plugin, rest-plugin, and wss-proxy-plugin now include the required Authority Key Identifier and Key Usages extensions.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
