### PR TITLE
`test_coinmoves.py::test_coinmoves_unilateral_htlc_timeout`: use `pytest.approx` for change amount

### DIFF
--- a/tests/test_coinmoves.py
+++ b/tests/test_coinmoves.py
@@ -738,10 +738,10 @@ def test_coinmoves_unilateral_htlc_timeout(node_factory, bitcoind):
                          'utxo': f"{fundchannel['txid']}:{fundchannel['outnum'] ^ 1}"},
                         {'account_id': 'wallet',  # change from anchor spend
                          'blockheight': 104,
-                         'credit_msat': 15579000,
+                         'credit_msat': pytest.approx(15579000, abs=7000),
                          'debit_msat': 0,
                          'extra_tags': [],
-                         'output_msat': 15579000,
+                         'output_msat': pytest.approx(15579000, abs=7000),
                          'primary_tag': 'deposit',
                          'utxo': f"{anchor_spend_txid}:0"},
                         {'account_id': fundchannel['channel_id'],


### PR DESCRIPTION
Change amount can vary slightly. Exact comparisons cause test flakiness.

Sometimes I get an `AssertionError` because the change output is 15586 sat instead of the expected 15579 sat. Maybe this is due to a shorter-than-usual signature encoding. Use `pytest.approx` to allow the actual change amount to be within 7 sat of 15579 sat. (If the discrepancy is indeed due to a short signature encoding, then this could _still_ be too strict, with a probability of 1 in 256, as theoretically a signature component could have a value arbitrarily close to zero.)

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes. **None found.**
