### PR TITLE
pay: fix uninitialized var in debug output.

### DIFF
--- a/plugins/libplugin-pay.c
+++ b/plugins/libplugin-pay.c
@@ -449,7 +449,7 @@ static void channel_hints_update(struct payment *p,
 			   "estimated capacity %s",
 			   fmt_short_channel_id_dir(tmpctx, &hint->scid),
 			   hint->enabled ? "true" : "false",
-			   fmt_amount_msat(tmpctx, hint->estimated_capacity));
+			   hint->enabled ? fmt_amount_msat(tmpctx, hint->estimated_capacity) : "UNKNOWN");
 		channel_hint_notify(p->plugin, hint);
 	}
 }


### PR DESCRIPTION
@nepet noted that Valgrind complained.  Nobody really cares though? TL;DR: if channel isn't enabled, estimate isn't set.


Changelog-None: CI only
Fixes: https://github.com/ElementsProject/lightning/issues/8487
