### PR TITLE
CHANGELOG.md: note that we broke custom rust notifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Note: release schedule moved one month: this is v25.09, and all deprecations inc
  - libplugin: you can now call the synchronous API functions at any time (not just in the init callback). ([#8410])
  - Plugins: "utxo_deposit" notification is allowed to have missing `transfer_from`, and null is not considered an account name. ([#8410])
  - Plugins: `sql` tables `forwards`, `htlcs`, `invoices`, `sendpays` all use `created_index` as their primary key (and `rowid` is now an alias to this). ([#8410])
+ - Rust: custom notifications fields no longer wrapped in `payload` object, and `origin` is now outside the `params` object ([#8376])
 
 
 ### Deprecated


### PR DESCRIPTION
Sorry :(

We chose to update our own few custom plugin notifications by manually creating the deprecated fields and adding the new ones, rather than having lightningd fix them up.  But this didn't apply to other plugins which might issue their own notifications: in particular, this hit @daywalker90.

Simply documenting this is lazy, but we're close to release and I don't expect anyone else to be affected.

Reported-by: @daywalker90
Changelog-None
Fixes: #8478 