### PR TITLE
bkpr: don't leak event in fillin_apy_acct_details.

### DIFF
--- a/plugins/bkpr/channelsapy.c
+++ b/plugins/bkpr/channelsapy.c
@@ -117,7 +117,7 @@ static void fillin_apy_acct_details(const struct bkpr *bkpr,
 
 	/* if this account is closed, add closing blockheight */
 	if (acct->closed_event_db_id) {
-		ev = find_chain_event_by_id(acct, bkpr, cmd,
+		ev = find_chain_event_by_id(tmpctx, bkpr, cmd,
 					    *acct->closed_event_db_id);
 		assert(ev);
 		apy->end_blockheight = ev->blockheight;


### PR DESCRIPTION
Now accounts are not transient, we can't use them as temporary parents:

```
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper: MEMLEAK: 0x5e3bf926ce28
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:   label=plugins/bkpr/sql.c:109:struct chain_event
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:   alloc:
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     ccan/ccan/tal/tal.c:488 (tal_alloc_)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/sql.c:109 (chain_events)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/sql.c:197 (chain_events_from_sql)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/recorder.c:352 (find_chain_event_by_id)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/channelsapy.c:120 (fillin_apy_acct_details)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/channelsapy.c:172 (compute_channel_apys)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/bookkeeper.c:220 (getblockheight_done)
lightningd-2 2025-08-28T02:36:35.629Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1134 (handle_rpc_reply)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1438 (rpc_read_response_one)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1462 (rpc_conn_read_response)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:60 (next_plan)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:422 (do_plan)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:439 (io_ready)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/poll.c:455 (io_loop)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:2564 (plugin_main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/bookkeeper.c:1547 (main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ../sysdeps/nptl/libc_start_call_main.h:58 (__libc_start_call_main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ../csu/libc-start.c:360 (__libc_start_main_impl)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:   steal:
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/tal/tal.c:559 (tal_steal_)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/recorder.c:361 (find_chain_event_by_id)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/channelsapy.c:120 (fillin_apy_acct_details)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/channelsapy.c:172 (compute_channel_apys)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/bookkeeper.c:220 (getblockheight_done)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1134 (handle_rpc_reply)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1438 (rpc_read_response_one)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:1462 (rpc_conn_read_response)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:60 (next_plan)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:422 (do_plan)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/io.c:439 (io_ready)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ccan/ccan/io/poll.c:455 (io_loop)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/libplugin.c:2564 (plugin_main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/bookkeeper.c:1547 (main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ../sysdeps/nptl/libc_start_call_main.h:58 (__libc_start_call_main)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     ../csu/libc-start.c:360 (__libc_start_main_impl)
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:   parents:
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/account.c:51:struct account
lightningd-2 2025-08-28T02:36:35.630Z **BROKEN** plugin-bookkeeper:     plugins/bkpr/bookkeeper.c:1546:struct bkpr
```

Changelog-None