### PR TITLE
Fix release process: make update-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -756,7 +756,7 @@ clean: obsclean
 
 # See doc/contribute-to-core-lightning/contributor-workflow.md
 PYLNS=client proto testing
-update-versions: update-pyln-versions update-reckless-version update-dot-version update-doc-examples
+update-versions: update-pyln-versions update-reckless-version update-dot-version # FIXME: update-doc-examples
 	@uv lock
 
 update-pyln-versions: $(PYLNS:%=update-pyln-version-%)


### PR DESCRIPTION
We should not be editing versions manually!  `uv run make update-versions` should do it.  Fix it.

Changelog-None: release process.