### PR TITLE
Small xpay improvements.

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1718,6 +1718,8 @@ do_fetchinvoice(struct command *cmd, const char *offerstr, struct xpay_params *x
 {
 	struct out_req *req;
 
+	plugin_notify_message(cmd, LOG_INFORM, "Fetching invoice for offer");
+	plugin_notify_message(cmd, LOG_DBG, "offer is %s", offerstr);
 	req = jsonrpc_request_start(cmd, "fetchinvoice",
 				    invoice_fetched,
 				    forward_error,
@@ -1831,6 +1833,7 @@ static struct command_result *json_xpay_params(struct command *cmd,
 		if (command_check_only(cmd))
 			return command_check_done(cmd);
 
+		plugin_notify_message(cmd, LOG_INFORM, "DNS lookup for %s", invstring);
 		req = jsonrpc_request_start(cmd, "fetchbip353",
 					    bip353_fetched,
 					    forward_error, xparams);

--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -1828,6 +1828,9 @@ static struct command_result *json_xpay_params(struct command *cmd,
 		xparams->dev_maxparts = *maxparts;
 		xparams->bip353 = invstring;
 
+		if (command_check_only(cmd))
+			return command_check_done(cmd);
+
 		req = jsonrpc_request_start(cmd, "fetchbip353",
 					    bip353_fetched,
 					    forward_error, xparams);

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -1010,3 +1010,10 @@ def test_xpay_bip353(node_factory):
 
     node_factory.join_nodes([l2, l1])
     l2.rpc.xpay('fake@fake.com', 100)
+
+    # BOLT #12:
+    # - if it received the offer from which it constructed this `invoice_request` using BIP 353 resolution:
+    # - MUST include `invreq_bip_353_name` with,
+    #   - `name` set to the post-₿, pre-@ part of the BIP 353 HRN,
+    #   - `domain` set to the post-@ part of the BIP 353 HRN.
+    assert l1.rpc.decode(only_one(l1.rpc.listinvoices()['invoices'])['bolt12'])['invreq_bip_353_name'] == {'name': 'fake', 'domain': 'fake.com'}

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -1017,3 +1017,8 @@ def test_xpay_bip353(node_factory):
     #   - `name` set to the post-₿, pre-@ part of the BIP 353 HRN,
     #   - `domain` set to the post-@ part of the BIP 353 HRN.
     assert l1.rpc.decode(only_one(l1.rpc.listinvoices()['invoices'])['bolt12'])['invreq_bip_353_name'] == {'name': 'fake', 'domain': 'fake.com'}
+
+    # We provide notifications of progress!
+    l2.daemon.wait_for_log('plugin-cln-xpay: notify msg info: DNS lookup for fake@fake.com')
+    l2.daemon.wait_for_log('plugin-cln-xpay: notify msg info: Fetching invoice for offer')
+    l2.daemon.wait_for_log(f'plugin-cln-xpay: notify msg debug: offer is {offer}')


### PR DESCRIPTION
1. Don't fetchinvoice if we're running the check command.
2. Test (successfully!) that we fill in the BIP353 fields in the invoice request.
3. Provide helpful notifications to the caller as we resolve the BIP353 and fetchinvoice.

Changelog-None: minor
Closes: #8515 