### PR TITLE
ci: Add a new step to update pyln versions out of WORKDIR

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -67,6 +67,13 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v5
 
+    - name: Update pyln versions
+      id: update-versions
+      run: |
+        export VERSION=$(git describe --tags --abbrev=0)
+        echo "Pyln VERSION: $VERSION"
+        make update-pyln-versions NEW_VERSION=$VERSION
+
     - name: Publish distribution 📦 to Test PyPI
       if: github.repository == 'ElementsProject/lightning' && steps.set-values.outputs.DISTLOCATION == 'test'
       env:
@@ -84,10 +91,6 @@ jobs:
         WORKDIR: ${{ matrix.WORKDIR }}
       run: |
         echo "UV VERSION PUBLISH: $(uv --version)"
-        cd ${{ env.WORKDIR }}
-        export VERSION=$(git describe --tags --abbrev=0)
         echo "Pyln VERSION: $VERSION"
-        make update-pyln-versions NEW_VERSION=$VERSION
-        cd /github/workspace
         uv build --package ${{ matrix.PACKAGE }}
         uv publish


### PR DESCRIPTION
The Publish distribution stage was failing because it executed the update-pyln-versions script from within the WORKDIR, which created an invalid context. To resolve this, we have decoupled the process, separating the updating of version state into its own step that runs from the root directory before the publish operation. 

Changelog-None.
