### PR TITLE
docker: Dockerfile fixes after poetry to uv migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,8 +363,9 @@ checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 
 [[package]]
 name = "bitcoin-payment-instructions"
-version = "0.4.0"
-source = "git+https://github.com/rust-bitcoin/bitcoin-payment-instructions.git?rev=d071ce27734ca13be2471f81abf8699d902c3a10#d071ce27734ca13be2471f81abf8699d902c3a10"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f00d509810205bfef492f1d6cefe1e2ac35b5e66675d51642315ddc5cee0e78"
 dependencies = [
  "bitcoin 0.32.6",
  "dnssec-prover",

--- a/plugins/bip353-plugin/Cargo.toml
+++ b/plugins/bip353-plugin/Cargo.toml
@@ -19,9 +19,7 @@ log-panics = "2"
 
 cln-plugin = { version = "0.5", path = "../../plugins" }
 
-bitcoin-payment-instructions = { git = "https://github.com/rust-bitcoin/bitcoin-payment-instructions.git", rev = "d071ce27734ca13be2471f81abf8699d902c3a10", features = [
-    "http",
-] }
+bitcoin-payment-instructions = { version = "0.5.0", features = ["http"] }
 
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",


### PR DESCRIPTION
Cargo utilizes `git ls-remote` to resolve git dependencies specified by commit hashes. GitHub only advertises commits that are reachable from branches, tags, or PR references. The `bip353-plugin` was referencing an orphaned commit in the `bitcoin-payment-instructions` dependency that was unreachable through any advertised reference. This is resolved by installing the tarball release `v0.5.0`.

Changelog-None.
