### PR TITLE
keysend: enforce BOLT11 description length limit

### DIFF
--- a/plugins/keysend.c
+++ b/plugins/keysend.c
@@ -4,6 +4,7 @@
 #include <ccan/asort/asort.h>
 #include <ccan/cast/cast.h>
 #include <ccan/tal/str/str.h>
+#include <common/bolt11.h>
 #include <common/gossmap.h>
 #include <common/json_param.h>
 #include <common/json_stream.h>
@@ -563,7 +564,7 @@ static struct command_result *htlc_accepted_call(struct command *cmd,
 					   (const char *)desc_field->value);
 		json_add_string(req->js, "description", desc);
 		/* Don't exceed max possible desc length! */
-		if (strlen(desc) > 1023)
+		if (strlen(desc) >= BOLT11_FIELD_BYTE_LIMIT)
 			json_add_bool(req->js, "deschashonly", true);
 	} else {
 		json_add_string(req->js, "description", "keysend");


### PR DESCRIPTION
The keysend plugin uses `> 1023` as the cutoff for description length when inserting an invoice. This was inconsistent with `lightnind/invoice.c`, which enforces the BOLT11 description field limit defined in `common/bolt11.h`.

This patch switches to using `BOLT11_FIELD_BYTE_LIMIT` directly. As a result, keysend no longer fails on descriptions between 641–1023 bytes, which previously caused unexpected failures.

A new regression test (`test_keysend_description_size_limit`) exercises boundary cases just below, at, and above the limit.

Changelog-None

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
