### PR TITLE
pyln-testing: set 'dev-save-plugin-io' only on CLN v25.09 and later

### DIFF
--- a/contrib/pyln-testing/pyln/testing/utils.py
+++ b/contrib/pyln-testing/pyln/testing/utils.py
@@ -857,7 +857,8 @@ class LightningNode(object):
 
         jsondir = Path(lightning_dir) / "plugin-io"
         jsondir.mkdir()
-        self.daemon.opts['dev-save-plugin-io'] = jsondir
+        if self.cln_version >= "v25.09":
+            self.daemon.opts['dev-save-plugin-io'] = jsondir
 
         if options is not None:
             self.daemon.opts.update(options)


### PR DESCRIPTION
Can we please get a pyln-testing v25.9.1 release with this change? That way it stays compatible with older CLN versions without having to rewrite every test and disable it manually.
