### PR TITLE
Added fixed SOURCE_DATE_EPOCH flag for reproducible ubuntu builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ endif
 
 RUST_PROFILE ?= debug
 ifneq ($(RUST_PROFILE),debug)
-CARGO_OPTS := --profile=$(RUST_PROFILE) --quiet
+CARGO_OPTS := --profile=$(RUST_PROFILE) --locked --quiet
 else
 CARGO_OPTS := --quiet
 endif

--- a/contrib/reprobuild/Dockerfile.focal
+++ b/contrib/reprobuild/Dockerfile.focal
@@ -2,6 +2,7 @@ FROM focal
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV SOURCE_DATE_EPOCH=1672531200
 ENV RUST_PROFILE=release
 ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:/root/.cargo/bin:/root/.local/bin:$PATH
 ENV PROTOC_VERSION=29.4

--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -2,6 +2,7 @@ FROM jammy
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV SOURCE_DATE_EPOCH=1672531200
 ENV RUST_PROFILE=release
 ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:/root/.cargo/bin:/root/.local/bin:$PATH
 ENV PROTOC_VERSION=29.4

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -2,6 +2,7 @@ FROM ubuntu:noble
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV SOURCE_DATE_EPOCH=1672531200
 ENV RUST_PROFILE=release
 ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:/root/.cargo/bin:/root/.local/bin:$PATH
 ENV PROTOC_VERSION=29.4


### PR DESCRIPTION
clnrest's `utoipa-swagger-ui` library has an indirect `rust-embed` dependency which by default includes timestamps in build. It results in non-deterministic build for clnrest. Using environment variable `SOURCE_DATE_EPOCH` with fixed value will enforce a consistent timestamp for builds.

Also adding the `--locked` flag to ensure the release build uses exact dependencies from Cargo.lock. The `--locked` flag is particularly important for deterministic builds as it prevents Cargo from updating the lockfile.

Fixes #8288.

Changelog-Fixed: Core lightning builds for Ubuntu Focal, Jammy and Noble are deterministic again.
