### PR TITLE
fix: Remove "Printing" (and related) from listdatastore debug log.

### DIFF
--- a/lightningd/datastore.c
+++ b/lightningd/datastore.c
@@ -222,10 +222,6 @@ static struct command_result *json_listdatastore(struct command *cmd,
 		   NULL))
 		return command_param_failed();
 
-	if (key)
-		log_debug(cmd->ld->log, "Looking for %s",
-			  datastore_key_fmt(tmpctx, key));
-
 	response = json_stream_success(cmd);
 	json_array_start(response, "datastore");
 
@@ -235,12 +231,9 @@ static struct command_result *json_listdatastore(struct command *cmd,
 	     stmt = wallet_datastore_next(cmd, key,
 					  stmt, &k, &data,
 					  &generation)) {
-		log_debug(cmd->ld->log, "Got %s",
-			  datastore_key_fmt(tmpctx, k));
 
 		/* Don't list sub-children, except as summary to show it exists. */
 		if (tal_count(k) > tal_count(key) + 1) {
-			log_debug(cmd->ld->log, "Too long");
 			if (!prev_k || !datastore_key_startswith(k, prev_k)) {
 				prev_k = tal_dup_arr(cmd, const char *, k,
 						     tal_count(key) + 1, 0);
@@ -249,7 +242,6 @@ static struct command_result *json_listdatastore(struct command *cmd,
 				json_object_end(response);
 			}
 		} else {
-			log_debug(cmd->ld->log, "Printing");
 			json_object_start(response, NULL);
 			json_add_datastore(response, k, data, generation);
 			json_object_end(response);


### PR DESCRIPTION
I'm noticing a lot of entries in the `debug` log as such:

`439Z DEBUG   lightningd: Printing`

There doesn't seem to be any other helpful information. Assumption is that this was a debugging exercise that wasn't fully removed, but I could be wrong. This PR removes that line in the `listdatastore` RPC.

Changelog-None

> [!IMPORTANT]
>
> 25.12 FREEZE October 27th: Non-bugfix PRs not ready by this date will wait for 26.03.
>
> RC1 is scheduled on _November 10th_
>
> The final release is scheduled for December 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
