### PR TITLE
Fix bkpr rebalance parsing on startup

### DIFF
--- a/plugins/bkpr/rebalances.c
+++ b/plugins/bkpr/rebalances.c
@@ -135,7 +135,7 @@ struct rebalances *init_rebalances(const tal_t *ctx,
 			goto weird;
 
 		/* key = ["bookkeeper", "rebalances", "<lesser>-<greater>"] */
-		if (!split_tok(buf, keytok + 2, '-', &lessertok, &greatertok))
+		if (!split_tok(buf, keytok + 3, '-', &lessertok, &greatertok))
 			goto weird;
 
 		if (!json_to_u64(buf, &lessertok, &lesser)

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -760,7 +760,6 @@ def test_empty_node(node_factory, bitcoind):
         l1.rpc.bkpr_inspect('wallet')
 
 
-@pytest.mark.xfail(strict=True)
 def test_rebalance_tracking(node_factory, bitcoind):
     """
     We identify rebalances (invoices paid and received by our node),


### PR DESCRIPTION
We test rebalances, but we didn't *restart* and check persistence :(

Not sure if this fixes the *crash* though...

See: https://github.com/ElementsProject/lightning/issues/8549