### PR TITLE
workflow: Add uv installation step

### DIFF
--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -29,6 +29,9 @@ jobs:
       run: |
         python -m pip install requests mako grpcio-tools
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Install dependencies
       run: bash -x .github/scripts/setup.sh
 


### PR DESCRIPTION
RPC documentation is not syncing on readme server with error `uv: command not found`.

Changelog-None.
