### PR TITLE
add .clangd to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ plugins/cln-grpc
 plugins/clnrest
 plugins/wss-proxy
 plugins/cln-bip353
+.clangd
 
 # Build directories
 bionic/


### PR DESCRIPTION
I use .clangd to configure compiler flags for the lsp (language server) I use in nvim.
More specific to stop the lsp from crashing due too many errors.
```
CompileFlags:
  Add: -ferror-limit=0
```
