### PR TITLE
Don't set feature-bits when plugin is disabled

### DIFF
--- a/lightningd/plugin.h
+++ b/lightningd/plugin.h
@@ -120,6 +120,9 @@ struct plugin {
 
 	/* Can this handle check commands? */
 	bool can_check;
+
+	/* custom feature-bits */
+	struct feature_set *fset;
 };
 
 /**


### PR DESCRIPTION
We need to remove the feature-bits set after a plugins `getmanifest` response when the `init` response disables the plugin.

Fixes tests on #8227 that fail due to feature-bit assumptions.