### PR TITLE
Revert "update makefile to remove hsm_encryption"

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -41,6 +41,7 @@ FUZZ_COMMON_OBJS := \
 	common/features.o				\
 	common/fee_states.o				\
 	common/hash_u5.o				\
+	common/hsm_encryption.o				\
 	common/htlc_state.o				\
 	common/initial_channel.o			\
 	common/initial_commit_tx.o			\


### PR DESCRIPTION
This reverts commit 084b03375cac181c7ddeba7204a11e2877645003.

Fixes the build:

```
/usr/bin/ld: tests/fuzz/fuzz-hsm_encryption.o: in function `run':
/home/rusty/devel/cvs/lightning/tests/fuzz/fuzz-hsm_encryption.c:28:(.text.run[run]+0x375): undefined reference to `hsm_secret_encryption_key_with_exitcode'
/usr/bin/ld: /home/rusty/devel/cvs/lightning/tests/fuzz/fuzz-hsm_encryption.c:30:(.text.run[run]+0x3ee): undefined reference to `encrypt_hsm_secret'
/usr/bin/ld: /home/rusty/devel/cvs/lightning/tests/fuzz/fuzz-hsm_encryption.c:32:(.text.run[run]+0x459): undefined reference to `decrypt_hsm_secret'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:703: tests/fuzz/fuzz-hsm_encryption] Error 1
```

Changelog-None