### PR TITLE
fix: add null check for fail pointer in injectonion_fail

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1698,7 +1698,7 @@ injectonion_fail(struct command *cmd,
 		const u8 *err;
 
 		/* Local error with no context, use default error */
-		if (fail->msg)
+		if (fail && fail->msg)
 			err = fail->msg;
 		else
 			err = towire_temporary_channel_failure(tmpctx, NULL);


### PR DESCRIPTION
Fix segmentation fault in injectonion_fail when fail parameter is NULL.

This follows the same pattern used elsewhere in the codebase.

Fixes: https://github.com/ElementsProject/lightning/issues/8593

> [!IMPORTANT]
>
> 25.12 FREEZE October 27th: Non-bugfix PRs not ready by this date will wait for 26.03.
>
> RC1 is scheduled on _November 10th_
>
> The final release is scheduled for December 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
