### PR TITLE
tools: Read the correct default-key from gpgconf

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -228,7 +228,7 @@ if [ -z "${TARGETS##* sign *}" ]; then
     echo "Signing Release"
     cd release/ || exit
     sha256sum clightning-"$VERSION"* > SHA256SUMS-"$VERSION"
-    gpg -sb --armor -o SHA256SUMS-"$VERSION".asc "$(gpgconf --list-options gpg | awk -F: '$1 == "default-key" {print $10}' | tr -d '"')" SHA256SUMS-"$VERSION"
+    gpg -sb --armor --default-key "$(gpgconf --list-options gpg | awk -F: '$1 == "default-key" {print $10}' | tr -d '"')" -o SHA256SUMS-"$VERSION".asc SHA256SUMS-"$VERSION"
     cd ..
     echo "Release Signed"
 fi


### PR DESCRIPTION
Workflow error `gpg: using "4129A994AA7E9852" is thrown due to incorrect gpg parsing. Update the awk parsing logic to properly locate and extract the key fingerprint within the gpgconf --list-options output structure, ensuring automated signing uses the correct key.

Changelog-None.

Failed Reference Action: https://github.com/ElementsProject/lightning/actions/runs/18514310328