### PR TITLE
makefile: fix glob expansion for macOS

### DIFF
--- a/bitcoin/Makefile
+++ b/bitcoin/Makefile
@@ -47,7 +47,16 @@ ALL_C_SOURCES += $(BITCOIN_SRC)
 check-makefile: check-bitcoin-makefile
 
 check-bitcoin-makefile:
-	@if [ "`echo bitcoin/*.h`" != "$(BITCOIN_HEADERS)" ]; then echo BITCOIN_HEADERS incorrect; exit 1; fi
+	@MISSING="$(filter-out $(BITCOIN_HEADERS), $(wildcard bitcoin/*.h))"; \
+	EXTRA="$(filter-out $(wildcard bitcoin/*.h), $(BITCOIN_HEADERS))"; \
+	if [ -n "$$MISSING" ]; then \
+		echo "BITCOIN_HEADERS missing: $$MISSING"; \
+		exit 1; \
+	fi; \
+	if [ -n "$$EXTRA" ]; then \
+		echo "BITCOIN_HEADERS has non-existent: $$EXTRA"; \
+		exit 1; \
+	fi
 
 check-whitespace: check-whitespace/bitcoin/Makefile
 


### PR DESCRIPTION
when bash expands bitcoin/*.h, it returns the files in lexicographically sorted order by default this is not necessarily the case for macOS so it has be explicitly sorted. I get a fairly uninformative error like this:

make: *** [check-bitcoin-makefile] Error 1

The error is now more informative and does not error on a clean branch on macOS:

BITCOIN_HEADERS missing: bitcoin/signature.h bitcoin/tx_parts.h bitcoin/tx.h bitcoin/varint.h
make: *** [check-bitcoin-makefile] Error 1

Changelog-None 
