### PR TITLE
lightningd: fix compilation for older compilers.

### DIFF
--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <ccan/cast/cast.h>
+#include <ccan/json_escape/json_escape.h> /* Ubuntu focal's gcc needs json_escape defined */
 #include <common/bolt12_id.h>
 #include <common/bolt12_merkle.h>
 #include <common/json_command.h>


### PR DESCRIPTION
gcc 9.3.0-10 (Ubunto Focal):

```
cc lightningd/offer.c
In file included from ccan/ccan/cast/cast.h:6,
                 from lightningd/offer.c:2:
lightningd/offer.c: In function 'json_createoffer':
ccan/ccan/cast/cast.h:115:13: error: dereferencing pointer to incomplete type 'struct json_escape'
  115 |  __typeof__(**(union { int z; __typeof__(expr) x; }){0}.x)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ccan/ccan/build_assert/build_assert.h:38:24: note: in definition of macro 'BUILD_ASSERT_OR_ZERO'
   38 |  (sizeof(char [1 - 2*!(cond)]) - 1)
      |                        ^~~~
ccan/ccan/cast/cast.h:122:31: note: in expansion of macro 'cast_const_strip2'
  122 |  __builtin_types_compatible_p(cast_const_strip2(expr),  \
      |                               ^~~~~~~~~~~~~~~~~
ccan/ccan/cast/cast.h:59:35: note: in expansion of macro 'cast_const_compat2'
   59 |         (0 ? BUILD_ASSERT_OR_ZERO(cast_const_compat2((expr), type)) :   \
      |                                   ^~~~~~~~~~~~~~~~~~
lightningd/offer.c:105:12: note: in expansion of macro 'cast_const2'
  105 |            cast_const2(const struct json_escape **,
      |            ^~~~~~~~~~~
ccan/ccan/cast/cast.h:115:13: error: dereferencing pointer to incomplete type 'const struct json_escape'
  115 |  __typeof__(**(union { int z; __typeof__(expr) x; }){0}.x)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ccan/ccan/build_assert/build_assert.h:38:24: note: in definition of macro 'BUILD_ASSERT_OR_ZERO'
   38 |  (sizeof(char [1 - 2*!(cond)]) - 1)
      |                        ^~~~
ccan/ccan/cast/cast.h:123:10: note: in expansion of macro 'cast_const_strip2'
  123 |          cast_const_strip2(type))
      |          ^~~~~~~~~~~~~~~~~
ccan/ccan/cast/cast.h:59:35: note: in expansion of macro 'cast_const_compat2'
   59 |         (0 ? BUILD_ASSERT_OR_ZERO(cast_const_compat2((expr), type)) :   \
      |                                   ^~~~~~~~~~~~~~~~~~
lightningd/offer.c:105:12: note: in expansion of macro 'cast_const2'
  105 |            cast_const2(const struct json_escape **,
      |            ^~~~~~~~~~~
make: *** [Makefile:320: lightningd/offer.o] Error 1
```

Reported-by: Shahana
Changelog-None: broken only in master.