### PR TITLE
Fix listpays still pending when using xpay/injectpaymentonion

### DIFF
--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -2076,19 +2076,11 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 	if (command_check_only(cmd))
 		return command_check_done(cmd);
 
-	register_payment_and_waiter(cmd,
-				    payment_hash,
-				    *partid, *groupid,
-				    *destination_msat, *msat, AMOUNT_MSAT(0),
-				    label, invstring, local_invreq_id,
-				    &shared_secret,
-				    destination);
-
-	/* If unknown, we set this equal (so accounting logs 0 fees) */
-	if (amount_msat_eq(*destination_msat, AMOUNT_MSAT(0)))
-		*destination_msat = *msat;
 	failmsg = send_htlc_out(tmpctx, next, *msat,
-				*cltv, *destination_msat,
+				*cltv,
+				/* If unknown, we set this equal (so accounting logs 0 fees) */
+				amount_msat_eq(*destination_msat, AMOUNT_MSAT(0))
+				? *msat : *destination_msat,
 				payment_hash,
 				next_path_key, NULL, *partid, *groupid,
 				serialize_onionpacket(tmpctx, rs->next),
@@ -2098,6 +2090,16 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 				    "Could not send to first peer: %s",
 				    onion_wire_name(fromwire_peektype(failmsg)));
 	}
+
+	/* Now HTLC is created, we can add the payment as pending */
+	register_payment_and_waiter(cmd,
+				    payment_hash,
+				    *partid, *groupid,
+				    *destination_msat, *msat, AMOUNT_MSAT(0),
+				    label, invstring, local_invreq_id,
+				    &shared_secret,
+				    destination);
+
 	return command_still_pending(cmd);
 }
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -6755,7 +6755,6 @@ def test_injectpaymentonion_failures(node_factory, executor):
     assert 'onionreply' in err.value.error['data']
 
 
-@pytest.mark.xfail(strict=True)
 def test_injectpaymentonion_peerfail(node_factory, executor):
     l1, l2 = node_factory.line_graph(2,
                                      opts=[{'may_reconnect': True,


### PR DESCRIPTION
Fixes: https://github.com/ElementsProject/lightning/issues/8629

There was a corner case where we created a pending payment but then didn't create an outgoing htlc (most simply, when the peer wasn't connected!).  Test that, and fix the ordering, then finally add a db migration which cleans up any previous ones.