### PR TITLE
Fix bookkeeper parallel crash

### DIFF
--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -1222,8 +1222,10 @@ parse_and_log_chain_move(struct command *cmd,
 	if (e->origin_acct)
 		find_or_create_account(cmd, bkpr, e->origin_acct);
 
-	/* Make this visible for queries (we expect increasing!) */
-	assert(e->db_id > bkpr->chainmoves_index);
+	/* Make this visible for queries (we expect increasing!).  If we raced, this is not true. */
+	if (e->db_id <= bkpr->chainmoves_index)
+		return;
+
 	bkpr->chainmoves_index = e->db_id;
 
 	/* This event *might* have implications for account;
@@ -1336,8 +1338,9 @@ parse_and_log_channel_move(struct command *cmd,
 			   " but no account exists %s",
 			   acct_name);
 
-	/* Make this visible for queries (we expect increasing!) */
-	assert(e->db_id > bkpr->channelmoves_index);
+	/* Make this visible for queries (we expect increasing!).  If we raced, this is not true. */
+	if (e->db_id <= bkpr->channelmoves_index)
+		return;
 	bkpr->channelmoves_index = e->db_id;
 
 	/* Check for invoice desc data, necessary */

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -1195,7 +1195,6 @@ def test_listincome_timebox(node_factory, bitcoind):
     assert [i for i in incomes if i['timestamp'] > first_one] == []
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(TEST_NETWORK != 'regtest', "Snapshots are bitcoin regtest.")
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "uses snapshots")
 def test_bkpr_parallel(node_factory, bitcoind, executor):


### PR DESCRIPTION
@michael1011 reported a crash in bookkeeper, which indeed happened when multiple commands were in flight during startup.  Refreshing in parallel is harmless, except for the assertion...