### PR TITLE
Fix bookkeeper blockheight read on restart

### DIFF
--- a/plugins/bkpr/blockheights.c
+++ b/plugins/bkpr/blockheights.c
@@ -140,7 +140,7 @@ struct blockheights *init_blockheights(const tal_t *ctx,
 		if (keytok->size != 3)
 			goto weird;
 
-		if (!json_to_txid(buf, keytok + 2, &txid))
+		if (!json_to_txid(buf, keytok + 3, &txid))
 			goto weird;
 		if (!json_hex_to_be32(buf, hextok, &be_blockheight))
 			goto weird;

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -1164,7 +1164,6 @@ def test_migration_no_bkpr(node_factory, bitcoind):
                           'type': 'channel'}]
 
 
-@pytest.mark.xfail(strict=True)
 @unittest.skipIf(TEST_NETWORK != 'regtest', "External wallet support doesn't work with elements yet.")
 def test_listincome_timebox(node_factory, bitcoind):
     l1 = node_factory.get_node()


### PR DESCRIPTION
We complain:
```
lightningd-1 2025-10-31T00:55:00.377Z **BROKEN** plugin-bookkeeper: Unparsable blockheight datastore entry: {"key":["bookkeeper","blockheights","756999f870a7a7c97f5c143f12b9096a50d1b1acd74aeb9ab2dc251a5c361494"],"generation":0,"hex":"00000067"}
```

And we don't have the blockheight:

```
                   {
                       'account': 'external',
         -             'blockheight': 103,
         ?                            - -
         +             'blockheight': 0,
                       'credit_msat': 555555000,
                       'currency': 'bcrt',
                       'debit_msat': 0,
                       'origin': 'wallet',
                       'outpoint': '756999f870a7a7c97f5c143f12b9096a50d1b1acd74aeb9ab2dc251a5c361494:0',
                       'tag': 'deposit',
                       'timestamp': 1761872097,
                       'type': 'chain',
                   },
```

Reported-by: @michael1011