### PR TITLE
autoclean: don't increment num_cleaned when record wasn't even a candidate

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -1862,7 +1862,9 @@
               "    * `succeededpays`: payment attempts which succeeded (`complete` in listpays `status`).",
               "    * `expiredinvoices`: invoices which were not paid (and cannot be) (`expired` in listinvoices `status`).",
               "    * `paidinvoices`: invoices which were paid (`paid` in listinvoices `status).",
-              "    * `networkevents`: all events in listnetworkevents (added *v25.12*)"
+              "    * `networkevents`: all events in listnetworkevents (added *v25.12*)",
+              "",
+              "NOTE: until v25.12, the `uncleaned` field contained all entries not removed (e.g. in `failedforwards` it counted all forwards, not just failed ones).  This was an interface only an engineer could love, so it was fixed."
             ]
           },
           "age": {
@@ -1894,13 +1896,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of successful forwards deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of successful forwards *not* deleted (too new)."
                     ]
                   }
                 }
@@ -1916,13 +1918,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of failed forwards deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of failed forwards *not* deleted (too new)."
                     ]
                   }
                 }
@@ -1938,13 +1940,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of successful payments deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of successful forwards *not* deleted (too new)."
                     ]
                   }
                 }
@@ -1960,13 +1962,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of unsuccessful payments deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of unsuccessful payments *not* deleted (too new)."
                     ]
                   }
                 }
@@ -1982,13 +1984,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of paid invoices deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of paid invoices *not* deleted (too new)."
                     ]
                   }
                 }
@@ -2004,13 +2006,13 @@
                   "cleaned": {
                     "type": "u64",
                     "description": [
-                      "Total number of deletions done this run."
+                      "The number of expired invoices deleted."
                     ]
                   },
                   "uncleaned": {
                     "type": "u64",
                     "description": [
-                      "The total number of entries *not* deleted this run."
+                      "The number of expired invoices *not* deleted (too new)."
                     ]
                   }
                 }

--- a/doc/schemas/autoclean-once.json
+++ b/doc/schemas/autoclean-once.json
@@ -32,7 +32,9 @@
           "    * `succeededpays`: payment attempts which succeeded (`complete` in listpays `status`).",
           "    * `expiredinvoices`: invoices which were not paid (and cannot be) (`expired` in listinvoices `status`).",
           "    * `paidinvoices`: invoices which were paid (`paid` in listinvoices `status).",
-          "    * `networkevents`: all events in listnetworkevents (added *v25.12*)"
+          "    * `networkevents`: all events in listnetworkevents (added *v25.12*)",
+          "",
+          "NOTE: until v25.12, the `uncleaned` field contained all entries not removed (e.g. in `failedforwards` it counted all forwards, not just failed ones).  This was an interface only an engineer could love, so it was fixed."
         ]
       },
       "age": {
@@ -64,13 +66,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of successful forwards deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of successful forwards *not* deleted (too new)."
                 ]
               }
             }
@@ -86,13 +88,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of failed forwards deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of failed forwards *not* deleted (too new)."
                 ]
               }
             }
@@ -108,13 +110,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of successful payments deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of successful forwards *not* deleted (too new)."
                 ]
               }
             }
@@ -130,13 +132,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of unsuccessful payments deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of unsuccessful payments *not* deleted (too new)."
                 ]
               }
             }
@@ -152,13 +154,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of paid invoices deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of paid invoices *not* deleted (too new)."
                 ]
               }
             }
@@ -174,13 +176,13 @@
               "cleaned": {
                 "type": "u64",
                 "description": [
-                  "Total number of deletions done this run."
+                  "The number of expired invoices deleted."
                 ]
               },
               "uncleaned": {
                 "type": "u64",
                 "description": [
-                  "The total number of entries *not* deleted this run."
+                  "The number of expired invoices *not* deleted (too new)."
                 ]
               }
             }

--- a/plugins/autoclean.c
+++ b/plugins/autoclean.c
@@ -555,13 +555,11 @@ static struct command_result *list_done(struct command *cmd,
 
 		variant = ops->get_variant(buf, t, subsystem, &timestamp);
 		if (!variant) {
-			subsystem->num_uncleaned++;
 			continue;
 		}
 
 		/* Continue if we don't care. */
 		if (variant->age == 0) {
-			subsystem->num_uncleaned++;
 			continue;
 		}
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3124,7 +3124,7 @@ def test_autoclean_once(node_factory):
     # Make sure > 1 second old!
     time.sleep(2)
     assert (l1.rpc.autoclean_once('failedpays', 1)
-            == {'autoclean': {'failedpays': {'cleaned': 1, 'uncleaned': 1}}})
+            == {'autoclean': {'failedpays': {'cleaned': 1, 'uncleaned': 0}}})
 
     assert (l1.rpc.autoclean_once('succeededpays', 1)
             == {'autoclean': {'succeededpays': {'cleaned': 1, 'uncleaned': 0}}})
@@ -3133,7 +3133,7 @@ def test_autoclean_once(node_factory):
     assert l1.rpc.autoclean_status() == expected[0]
 
     assert (l2.rpc.autoclean_once('failedforwards', 1)
-            == {'autoclean': {'failedforwards': {'cleaned': 1, 'uncleaned': 1}}})
+            == {'autoclean': {'failedforwards': {'cleaned': 1, 'uncleaned': 0}}})
     expected[1]['autoclean']['failedforwards']['cleaned'] = 1
     assert l2.rpc.autoclean_status() == expected[1]
 
@@ -3143,7 +3143,7 @@ def test_autoclean_once(node_factory):
     assert l2.rpc.autoclean_status() == expected[1]
 
     assert (l3.rpc.autoclean_once('expiredinvoices', 1)
-            == {'autoclean': {'expiredinvoices': {'cleaned': 1, 'uncleaned': 1}}})
+            == {'autoclean': {'expiredinvoices': {'cleaned': 1, 'uncleaned': 0}}})
     expected[2]['autoclean']['expiredinvoices']['cleaned'] = 1
     assert l3.rpc.autoclean_status() == expected[2]
 


### PR DESCRIPTION
For example, `autoclean-once failedforwards` would count every non-failed forwards as "uncleaned".

This is both technically correct and completely useless.

Fixes: https://github.com/ElementsProject/lightning/issues/8632
Reported-by: @grubles and several other sharp-eyed users.

From the documentation:

 "NOTE: until v25.12, the `uncleaned` field contained all entries not removed (e.g. in `failedforwards` it counted all forwards, not just failed ones).  This was an interface only an engineer could love, so it was fixed."