### PR TITLE
Fix `Release` action failure due to change in `.asc` suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,6 @@ jobs:
           sudo apt-get install -y lowdown
           ./configure
           tools/build-release.sh --without-zip sign
-          mv release/SHA256SUMS.${{ env.version }}.asc${{ steps.gpg.outputs.keyid  }} release/SHA256SUMS.${{ env.version }}.asc
 
       - name: Upload signed artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reference failed action: https://github.com/ElementsProject/lightning/actions/runs/19059214625/job/54436935119
Reference commit: https://github.com/ElementsProject/lightning/commit/ea2f7607b8ff08c6312e09caab22e07f1d0853e7

Changelog-None.
