### PR TITLE
Docker image building will fail due to utoipa git url dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,8 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "utoipa"
 version = "5.4.0"
-source = "git+https://github.com/rustyrussell/utoipa.git#26f4908b092a4a746cbec935e05165852ea01289"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -3137,7 +3138,8 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.4.0"
-source = "git+https://github.com/rustyrussell/utoipa.git#26f4908b092a4a746cbec935e05165852ea01289"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3148,7 +3150,8 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui"
 version = "9.0.2"
-source = "git+https://github.com/rustyrussell/utoipa.git#26f4908b092a4a746cbec935e05165852ea01289"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum 0.8.4",
  "base64 0.22.1",
@@ -3166,7 +3169,8 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui-vendored"
 version = "0.1.2"
-source = "git+https://github.com/rustyrussell/utoipa.git#26f4908b092a4a746cbec935e05165852ea01289"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "valuable"

--- a/plugins/rest-plugin/Cargo.toml
+++ b/plugins/rest-plugin/Cargo.toml
@@ -26,12 +26,11 @@ rcgen = "0.13"
 hyper = "1"
 tower= "0.5"
 tower-http = { version = "0.6", features = ["cors", "set-header"] }
-utoipa = { git = "https://github.com/rustyrussell/utoipa.git", features = ['axum_extras'] }
+utoipa = { version = "5", features = ['axum_extras'] }
 
 log-panics = "2"
 socketioxide = "0.15"
 
 cln-plugin = { version = "0.5", path = "../../plugins" }
 cln-rpc = { version = "0.5", path = "../../cln-rpc" }
-utoipa-swagger-ui = { git = "https://github.com/rustyrussell/utoipa.git", features = ["vendored", "axum"] }
-
+utoipa-swagger-ui = { version = "9.0.0", features = ["vendored", "axum"] }


### PR DESCRIPTION
This reverts [commit](https://github.com/ElementsProject/lightning/pull/8536/commits/cd1ec7216b66bb2f84244ab8c186a003b49d55d6), as an alternative fix has already been introduced in PR #8547 to restore reproducible builds.

This reversion is necessary otherwise Docker image building will fail with GitHub Actions or via build-release.sh. The issue arises from Cargo’s inability to resolve the git URL dependencies for clnrest’s utoipa and utoipa-swagger-ui packages within these build contexts. While direct `docker buildx` commands succeeds, Github Action or build-release.sh modifies the build context in a way that prevents Cargo from locating the specific git commit for these dependencies.

References:
[Discussion](https://github.com/ElementsProject/lightning/pull/8530#issuecomment-3248713576)
[Failed Action](https://github.com/ElementsProject/lightning/actions/runs/17435823432)
[PR with the fix](https://github.com/ElementsProject/lightning/pull/8547)

Changelog-None.
