### PR TITLE
docs: update archlinux build instructions

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -417,8 +417,7 @@ sudo PATH="/usr/local/opt:$PATH"  LIBRARY_PATH=/opt/homebrew/lib CPATH=/opt/home
 Install dependencies:
 
 ```shell
-pacman --sync autoconf automake gcc git make python-pip
-pip install --user poetry
+pacman --sync autoconf automake gcc git make python-poetry python-mako lowdown jq
 ```
 
 Clone Core Lightning:
@@ -436,10 +435,10 @@ python -m poetry install
 python -m poetry run make
 ```
 
-Launch Core Lightning:
+Install
 
-```
-./lightningd/lightningd
+```shell
+sudo python -m poetry run make install
 ```
 
 ## To cross-compile for Android


### PR DESCRIPTION
Updated docs to use what worked for me on Archlinux because the current docs didn't work when I tried. Current version also makes it harder using pip to install poetry when it's already available from extra on python-poetry package so I changed that and I'm also adding other dependencies that were needed to build and run.