### PR TITLE
fuzz: fix compilation.

### DIFF
--- a/channeld/channeld_htlc.h
+++ b/channeld/channeld_htlc.h
@@ -1,6 +1,8 @@
 #ifndef LIGHTNING_CHANNELD_CHANNELD_HTLC_H
 #define LIGHTNING_CHANNELD_CHANNELD_HTLC_H
 #include "config.h"
+#include <ccan/crypto/sha256/sha256.h>
+#include <common/amount.h>
 #include <common/htlc.h>
 #include <common/pseudorand.h>
 


### PR DESCRIPTION
Header changes in master broke this upon rebase :(

```
In file included from ./channeld/full_channel.h:5,
                 from tests/fuzz/fuzz-full_channel.c:7:
./channeld/channeld_htlc.h:13:28: error: field ‘amount’ has incomplete type
   13 |         struct amount_msat amount;
      |                            ^~~~~~
./channeld/channeld_htlc.h:17:23: error: field ‘rhash’ has incomplete type
   17 |         struct sha256 rhash;
      |                       ^~~~~
```
Changelog-None