### PR TITLE
lightningd: add peer_id to htlc_accepted_hook

### DIFF
--- a/doc/developers-guide/plugin-development/hooks.md
+++ b/doc/developers-guide/plugin-development/hooks.md
@@ -400,6 +400,7 @@ The payload of the hook call has the following format:
 
 ```json
 {
+  "peer_id": "02df5ffe895c778e10f7742a6c5b8a0cefbe9465df58b92fadeb883752c8107c8f",
   "onion": {
     "payload": "",
     "short_channel_id": "1x2x3",
@@ -425,6 +426,7 @@ The payload of the hook call has the following format:
 
 For detailed information about each field please refer to [BOLT 04 of the specification](https://github.com/lightning/bolts/blob/master/04-onion-routing.md), the following is just a brief summary:
 
+- `peer_id`: is the id of the peer that offered us this htlc.
 - `onion`:
   - `payload` contains the unparsed payload that was sent to us from the sender of the payment.
   - `short_channel_id` determines the channel that the sender is hinting   should be used next.  Not present if we're the final destination.

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -1193,6 +1193,9 @@ static void htlc_accepted_hook_serialize(struct htlc_accepted_hook_payload *p,
 	    tal_fmt(hin, "Waiting for the htlc_accepted hook of plugin %s",
 		    plugin->shortname);
 
+	if (p->channel && p->channel->peer)
+		json_add_node_id(s, "peer_id", &p->channel->peer->id);
+
 	json_object_start(s, "onion");
 
 	json_add_hex_talarr(s, "payload", rs->raw_payload);


### PR DESCRIPTION
> [!IMPORTANT]
>
> 25.12 FREEZE October 27th: Non-bugfix PRs not ready by this date will wait for 26.03.
>
> RC1 is scheduled on _November 10th_
>
> The final release is scheduled for December 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.

This PR adds the id of the peer that offered us an HTLC as `peer_id` to the `htlc_accepted` hook. This can be useful in some cases - including for the LSPS-client.