### PR TITLE
lightningd: fix access to bcli plugin once it's freed.

### DIFF
--- a/lightningd/gossip_control.c
+++ b/lightningd/gossip_control.c
@@ -102,6 +102,10 @@ static void get_txout(struct subd *gossip, const u8 *msg)
 		subd_send_msg(gossip, take(towire_gossipd_get_txout_reply(
 						   NULL, scid, AMOUNT_SAT(0), NULL)));
 	} else {
+		/* If we're shutting down, don't ask plugins */
+		if (gossip->ld->state == LD_STATE_SHUTDOWN)
+			return;
+
 		/* Make a pointer of a copy of scid here, for got_filteredblock */
 		bitcoind_getfilteredblock(topo->bitcoind, topo->bitcoind,
 					  short_channel_id_blocknum(scid),


### PR DESCRIPTION
As seen in CI:

```
2025-11-13T07:47:16.5733646Z Valgrind error file: valgrind-errors.46048
2025-11-13T07:47:16.5733739Z ==46048== Invalid read of size 8
2025-11-13T07:47:16.5733869Z ==46048==    at 0x2F2B47: strmap_add_ (strmap.c:69)
2025-11-13T07:47:16.5734014Z ==46048==    by 0x212066: plugin_request_send (plugin.c:2509)
2025-11-13T07:47:16.5734160Z ==46048==    by 0x18FA54: bitcoin_plugin_send (bitcoind.c:123)
2025-11-13T07:47:16.5734329Z ==46048==    by 0x190AA7: bitcoind_getrawblockbyheight_ (bitcoind.c:537)
2025-11-13T07:47:16.5734490Z ==46048==    by 0x1917E3: bitcoind_getfilteredblock_ (bitcoind.c:857)
2025-11-13T07:47:16.5734615Z ==46048==    by 0x1BE2DC: get_txout (gossip_control.c:106)
2025-11-13T07:47:16.5734750Z ==46048==    by 0x1BE88A: gossip_msg (gossip_control.c:212)
2025-11-13T07:47:16.5734860Z ==46048==    by 0x21BD60: sd_msg_read (subd.c:560)
2025-11-13T07:47:16.5734962Z ==46048==    by 0x2E416D: next_plan (io.c:60)
2025-11-13T07:47:16.5735074Z ==46048==    by 0x2E4DC3: do_plan (io.c:422)
2025-11-13T07:47:16.5735175Z ==46048==    by 0x2E4E2A: io_ready (io.c:439)
2025-11-13T07:47:16.5735294Z ==46048==    by 0x2E727E: io_loop (poll.c:455)
2025-11-13T07:47:16.5735464Z ==46048==  Address 0x5ec7518 is 216 bytes inside a block of size 288 free'd
2025-11-13T07:47:16.5735692Z ==46048==    at 0x484B27F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
2025-11-13T07:47:16.5735798Z ==46048==    by 0x2F767C: del_tree (tal.c:456)
2025-11-13T07:47:16.5735902Z ==46048==    by 0x2F795D: tal_free (tal.c:532)
2025-11-13T07:47:16.5736018Z ==46048==    by 0x20C30D: plugin_kill (plugin.c:468)
2025-11-13T07:47:16.5736147Z ==46048==    by 0x20D0EE: plugin_conn_finish (plugin.c:853)
2025-11-13T07:47:16.5736265Z ==46048==    by 0x2E6AF6: destroy_conn (poll.c:246)
2025-11-13T07:47:16.5736397Z ==46048==    by 0x2E6B1A: destroy_conn_close_fd (poll.c:252)
2025-11-13T07:47:16.5736504Z ==46048==    by 0x2F6FC9: notify (tal.c:246)
2025-11-13T07:47:16.5736602Z ==46048==    by 0x2F75AA: del_tree (tal.c:437)
2025-11-13T07:47:16.5736707Z ==46048==    by 0x2F795D: tal_free (tal.c:532)
2025-11-13T07:47:16.5736812Z ==46048==    by 0x2E4FF6: io_close (io.c:496)
2025-11-13T07:47:16.5736920Z ==46048==    by 0x2E72A5: io_loop (poll.c:459)
```

Changelog-None: exposed by recent plugin changes.
