### PR TITLE
Add `mtime` constant for reproducible Fedora tarball

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -18,7 +18,8 @@ if [ "$1" = "--inside-docker" ]; then
     ./configure
     uv run make -j"$MAKEPAR" VERSION="$VER"
     uv run make -j"$MAKEPAR" install DESTDIR=/"$VER-$PLTFM-$PLTFMVER-$ARCH" RUST_PROFILE=release
-    cd /"$VER-$PLTFM-$PLTFMVER-$ARCH" && tar cvfz /release/clightning-"$VER-$PLTFM-$PLTFMVER-$ARCH".tar.gz -- *
+    cd /"$VER-$PLTFM-$PLTFMVER-$ARCH"
+    tar cvfz /release/clightning-"$VER-$PLTFM-$PLTFMVER-$ARCH".tar.gz --mtime='@1672531200' -- *
     echo "Inside docker: build finished"
     exit 0
 fi


### PR DESCRIPTION
Changelog-Fixed: Fedora releases are also deterministic now.
