### PR TITLE
onion: add payload type tracking to route_step and onion_payload

### DIFF
--- a/common/onion_decode.c
+++ b/common/onion_decode.c
@@ -200,6 +200,7 @@ struct onion_payload *onion_decode(const tal_t *ctx,
 	size_t max = tal_bytelen(cursor), len;
 
 	p->final = (rs->nextcase == ONION_END);
+	p->type = rs->type;
 
 	/* BOLT #4:
 	 * 1. type: `hop_payloads`

--- a/common/onion_encode.c
+++ b/common/onion_encode.c
@@ -2,7 +2,6 @@
 #include <assert.h>
 #include <ccan/cast/cast.h>
 #include <common/onion_encode.h>
-#include <common/sphinx.h>
 #include <common/utils.h>
 
 /* BOLT #4:

--- a/common/onion_encode.h
+++ b/common/onion_encode.h
@@ -3,14 +3,10 @@
 #include "config.h"
 #include <bitcoin/privkey.h>
 #include <common/amount.h>
+#include <common/sphinx.h>
 
 struct route_step;
 struct tlv_encrypted_data_tlv_payment_relay;
-
-enum onion_payload_type {
-	ONION_V0_PAYLOAD = 0,
-	ONION_TLV_PAYLOAD = 1,
-};
 
 struct onion_payload {
 	enum onion_payload_type type;

--- a/common/sphinx.c
+++ b/common/sphinx.c
@@ -684,6 +684,7 @@ struct route_step *process_onionpacket(
 		size_t legacy_max = 32;
 		u8 *onwire_tlv;
 
+		step->type = ONION_V0_PAYLOAD;
 		legacy->amt_to_forward = tal(legacy, u64);
 		legacy->outgoing_cltv_value = tal(legacy, u32);
 		legacy->short_channel_id = tal(legacy, struct short_channel_id);
@@ -718,6 +719,7 @@ struct route_step *process_onionpacket(
 		payload_size = 32;
 		fromwire_pad(&cursor, &max, payload_size);
 	} else {
+		step->type = ONION_TLV_PAYLOAD;
 		/* FIXME: raw_payload *includes* the length, which is redundant and
 		 * means we can't just ust fromwire_tal_arrn. */
 		fromwire_pad(&cursor, &max, payload_size);

--- a/common/sphinx.h
+++ b/common/sphinx.h
@@ -59,7 +59,13 @@ struct sphinx_hop {
 	const u8 *raw_payload;
 };
 
+enum onion_payload_type {
+	ONION_V0_PAYLOAD = 0,
+	ONION_TLV_PAYLOAD = 1,
+};
+
 struct route_step {
+	enum onion_payload_type type;
 	enum route_next_case nextcase;
 	struct onionpacket *next;
 	u8 *raw_payload;


### PR DESCRIPTION
Move `onion_payload_type` enum to `sphinx.h` and add type field to both `route_step` and `onion_payload` structures. This allows code to easily determine whether it's dealing with legacy v0 or modern TLV payloads without re-parsing the raw payload.

The type is set during onion processing in `process_onionpacket()` based on the payload format detected, then propagated to onion_payload in `onion_decode()`.

Changelog-None