### PR TITLE
Change method name of lsps-jitchannel

### DIFF
--- a/plugins/lsps-plugin/src/client.rs
+++ b/plugins/lsps-plugin/src/client.rs
@@ -78,9 +78,9 @@ async fn main() -> Result<(), anyhow::Error> {
             on_lsps_lsps2_approve,
         )
         .rpcmethod(
-            "lsps-jitchannel",
+            "lsps-lsps2-invoice",
             "Requests a new jit channel from LSP and returns the matching invoice",
-            on_lsps_jitchannel,
+            on_lsps_lsps2_invoice,
         )
         .hook("invoice_payment", on_invoice_payment)
         .hook("htlc_accepted", on_htlc_accepted)
@@ -285,7 +285,7 @@ async fn on_lsps_lsps2_approve(
 /// RPC Method handler for `lsps-jitchannel`.
 /// Calls lsps2.get_info, selects parameters, calculates fee, calls lsps2.buy,
 /// creates invoice.
-async fn on_lsps_jitchannel(
+async fn on_lsps_lsps2_invoice(
     p: cln_plugin::Plugin<State>,
     v: serde_json::Value,
 ) -> Result<serde_json::Value, anyhow::Error> {

--- a/tests/test_cln_lsps.py
+++ b/tests/test_cln_lsps.py
@@ -149,7 +149,7 @@ def test_lsps2_buyjitchannel_no_mpp_var_invoice(node_factory, bitcoind):
         "short_channel_id"
     ]
 
-    inv = l1.rpc.lsps_jitchannel(
+    inv = l1.rpc.lsps_lsps2_invoice(
         lsp_id=l2.info["id"],
         amount_msat="any",
         description="lsp-jit-channel-0",
@@ -239,7 +239,7 @@ def test_lsps2_buyjitchannel_mpp_fixed_invoice(node_factory, bitcoind):
     ]
 
     amt = 10_000_000
-    inv = l1.rpc.lsps_jitchannel(
+    inv = l1.rpc.lsps_lsps2_invoice(
         lsp_id=l2.info["id"],
         amount_msat=f"{amt}msat",
         description="lsp-jit-channel-0",


### PR DESCRIPTION
> [!IMPORTANT]
>
> 25.12 FREEZE October 27th: Non-bugfix PRs not ready by this date will wait for 26.03.
>
> RC1 is scheduled on _November 10th_
>
> The final release is scheduled for December 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.

The original method name was lsps-lsps2-invoice but I somehow messed it up and renamed it during a rebase.