### PR TITLE
CI: don't run configure on *host* for release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      # tools/build-release.sh requires lowdown
-      - name: Prepare base environment
-        run: |
-          sudo apt-get install -y lowdown
-          ./configure
-
       - name: Build environment setup
         run: |
           distribution=$(echo ${{ matrix.target }} | cut -d'-' -f3)


### PR DESCRIPTION
It breaks, but more importantly we don't need to install lowdown any more, since the check in build-release.sh has been removed.

```
Run sudo apt-get install -y lowdown
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  lowdown
0 upgraded, 1 newly installed, 0 to remove and 21 not upgraded.
Need to get 129 kB of archives.
After this operation, 314 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 lowdown amd64 1.1.0-1 [129 kB]
Fetched 129 kB in 0s (2971 kB/s)
Selecting previously unselected package lowdown.
(Reading database ...
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 216225 files and directories currently installed.)
Preparing to unpack .../lowdown_1.1.0-1_amd64.deb ...
Unpacking lowdown (1.1.0-1) ...
Setting up lowdown (1.1.0-1) ...
Processing triggers for man-db (2.12.0-4build2) ...
Not building database; man-db/auto-update is not 'true'.

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.
checking for getpagesize() in <unistd.h>... yes
checking for isblank() in <ctype.h>... yes
checking for little endian... yes
checking for memmem in <string.h>... yes
checking for memrchr in <string.h>... yes
checking for mmap() declaration... yes
checking for /proc/self/maps exists... yes
checking for qsort_r cmp takes trailing arg... yes
checking for __attribute__((section)) and __start/__stop... yes
checking for stack grows upwards... no
checking for statement expression support... yes
checking for <sys/filio.h>... no
checking for <sys/termios.h>... yes
checking for <sys/unistd.h>... yes
checking for __typeof__ support... yes
checking for unaligned access to int... yes
checking for utime() declaration... yes
checking for __attribute__((warn_unused_result))... yes
checking for #pragma omp and -fopenmp support... yes
checking for <valgrind/memcheck.h>... no
checking for working <ucontext.h... yes
checking for passing pointers via makecontext()... yes
checking for __builtin_cpu_supports()... yes
checking for closefrom() offered by system... yes
checking for F_CLOSEM defined for fctnl.... no
checking for close_range syscall available as __NR_close_range.... yes
checking for F_MAXFD defined for fcntl.... no
checking for zlib support... yes
checking for libsodium with IETF chacha20 variants... no
checking for sqlite3... yes
checking for postgres... yes
checking for User Statically-Defined Tracing (USDT)... no
checking for compiler is GCC... yes
checking for GCC version is 7 or above... yes
Writing variables to config.vars.2200... yes
Writing header to ccan/config.h.2200... yes
checking for python3-mako... not found
checking for lowdown... found
checking for sha256sum... found
checking for jq... found
Setting PREFIX... /usr/local
Setting CC... cc
Setting CONFIGURATOR_CC... cc
Setting CWARNFLAGS... -Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror -Wno-maybe-uninitialized -Wshadow=local
Setting CDEBUGFLAGS... -std=gnu11 -g -fstack-protector-strong
Setting COPTFLAGS... -Og
CSANFLAGS not found
FUZZFLAGS not found
FUZZER_LIB not found
LLVM_LDFLAGS not found
SQLITE3_CFLAGS not found
Setting SQLITE3_LDLIBS... -lsqlite3
Setting POSTGRES_INCLUDE... -I/usr/include/postgresql
Setting POSTGRES_LDLIBS... -L/usr/lib/x86_64-linux-gnu -lpq
SODIUM_CFLAGS not found
SODIUM_LDLIBS not found
Setting VALGRIND... 0
Setting DEBUGBUILD... 0
Setting COMPAT... 1
Setting PYTEST... python3 -m pytest
Setting STATIC... 0
Setting CLANG_COVERAGE... 0
Setting ASAN... 0
Setting UBSAN... 0
Setting TEST_NETWORK... regtest
Setting HAVE_PYTHON3_MAKO... 0
Setting SHA256SUM... sha256sum
Setting FUZZING... 0
Setting RUST... 1
Setting PYTHON... python3
Setting SED... sed
*** We need a libsodium >= 1.0.4 (released 2015-06-11).
Error: Process completed with exit code 1.
```
Changelog-None: release process fix