### PR TITLE
fuzz: fix uninitialized variable in fuzz-handle_onion_message

### DIFF
--- a/tests/fuzz/fuzz-handle_onion_message.c
+++ b/tests/fuzz/fuzz-handle_onion_message.c
@@ -75,12 +75,12 @@ void init(int *argc, char ***argv)
 
 void run(const uint8_t *data, size_t size)
 {
-	if (setjmp(fuzz_env) != 0)
-		goto cleanup;
-
-	struct daemon *daemon;
+	struct daemon *daemon = NULL;
 	struct peer *peer;
 	struct pubkey dummy_key;
+
+	if (setjmp(fuzz_env) != 0)
+		goto cleanup;
 
 	memset(&dummy_key, 'c', sizeof(dummy_key));
 


### PR DESCRIPTION
Newer clang versions have stricter `-Wsometimes-uninitialized` checking that catches this.

Fixes #8683