### PR TITLE
Release: make Fedora tarball a set order.

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -19,7 +19,7 @@ if [ "$1" = "--inside-docker" ]; then
     uv run make -j"$MAKEPAR" VERSION="$VER"
     uv run make -j"$MAKEPAR" install DESTDIR=/"$VER-$PLTFM-$PLTFMVER-$ARCH" RUST_PROFILE=release
     cd /"$VER-$PLTFM-$PLTFMVER-$ARCH"
-    tar cvfz /release/clightning-"$VER-$PLTFM-$PLTFMVER-$ARCH".tar.gz --mtime='@1672531200' -- *
+    LC_ALL=C tar --sort=name -c -v -z -f /release/clightning-"$VER-$PLTFM-$PLTFMVER-$ARCH".tar.gz --mtime='@1672531200' -- *
     echo "Inside docker: build finished"
     exit 0
 fi


### PR DESCRIPTION
For some reason, Ubuntu doesn't have a problem here, but Fedora's tarballs are in undefined order, making them not reproducible.

Changelog-None