### PR TITLE
pay: Limit splitting when CLTV budget exhausted

### DIFF
--- a/plugins/libplugin-pay.h
+++ b/plugins/libplugin-pay.h
@@ -279,6 +279,9 @@ struct payment {
 	 * amount. */
 	bool failroute_retry;
 
+	/* Set when CLTV budget exceeded. Limits further splitting. */
+	bool cltv_budget_exceeded;
+
 	/* A unique id for the root of this payment.  */
 	u64 id;
 


### PR DESCRIPTION
When a payment fails due to CLTV budget constraints, the adaptive splitter creates excessive sub-payments before hitting its lower amount limit. Issue #8167 showed partid reaching 5787+.

The fix adds a `cltv_budget_exceeded` flag and limits split depth to 3 when set.

Depth 3 means:
- Depth 0: root can split → 2 children
- Depth 1: children can split → 4 grandchildren
- Depth 2: grandchildren can split → 8 great-grandchildren
- Depth 3+: blocked from splitting

This gives max 8 leaf payments exploring different amounts, which empirical testing showed is sufficient for getroute to find lower-constraint paths when they exist. The fix converts O(2^n) exponential to O(1) constant.

Depth counts only SPLIT operations, not retries. The `retry_pay_mod` also creates child payments, but these are retries of the same amount, not splits. Without this distinction, retries would be incorrectly counted as depth, blocking legitimate splits prematurely.

Fixes #8167