### PR TITLE
ci: Remove lowdown and configure from the sign release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,10 +161,7 @@ jobs:
         run: echo "default-key ${{ steps.gpg.outputs.keyid }}" >> ~/.gnupg/gpg.conf
 
       - name: Sign release
-        run: |
-          sudo apt-get install -y lowdown
-          ./configure
-          tools/build-release.sh --without-zip sign
+        run: tools/build-release.sh --without-zip sign
 
       - name: Upload signed artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Changelog-None: Fixes draft release creation in CI.
