### PR TITLE
xpay: fix misleading "route hint" label in error messages

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -522,7 +522,9 @@ static const char *describe_scidd(struct attempt *attempt, size_t index)
 
 	/* Routehint?  Often they are a single hop. */
 	if (tal_count(payment->route_hints) == 1
-	    && tal_count(payment->route_hints[0]) == 1)
+	    && tal_count(payment->route_hints[0]) == 1
+	    && short_channel_id_eq(scidd.scid,
+				   payment->route_hints[0][0].short_channel_id))
 		return tal_fmt(tmpctx, "the invoice's route hint (%s)",
 			       fmt_short_channel_id_dir(tmpctx, &scidd));
 


### PR DESCRIPTION
describe_scidd() was saying "for the invoice's route hint" for any error
when there was a single-hop route hint, even when the failure was on some
unrelated intermediate channel.

Now it checks the channel actually is the route hint before labeling it.

Fixes: #8252