### PR TITLE
lightningd: fix db constraint error when fixing up old blocks.

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -1420,7 +1420,7 @@ void setup_topology(struct chain_topology *topo)
 	fixup = db_get_intvar(topo->ld->wallet->db, "fixup_block_scan", -1);
 	if (fixup == -1) {
 		/* Never done fixup: this is set to non-zero if we have blocks. */
-		topo->old_block_scan = wallet_blocks_minheight(topo->ld->wallet);
+		topo->old_block_scan = wallet_blocks_contig_minheight(topo->ld->wallet);
 		db_set_intvar(topo->ld->wallet->db, "fixup_block_scan",
 			      topo->old_block_scan);
 	} else {

--- a/wallet/wallet.c
+++ b/wallet/wallet.c
@@ -2554,16 +2554,22 @@ u32 wallet_blocks_maxheight(struct wallet *w)
 	return max;
 }
 
-u32 wallet_blocks_minheight(struct wallet *w)
+u32 wallet_blocks_contig_minheight(struct wallet *w)
 {
 	u32 min = 0;
-	struct db_stmt *stmt = db_prepare_v2(w->db, SQL("SELECT MIN(height) FROM blocks;"));
+	struct db_stmt *stmt = db_prepare_v2(w->db, SQL("SELECT MAX(b.height)"
+							"  FROM blocks b"
+							"  WHERE NOT EXISTS ("
+							"    SELECT 1"
+							"    FROM blocks b2"
+							"    WHERE b2.height = b.height - 1)"));
 	db_query_prepared(stmt);
 
-	/* If we ever processed a block we'll get the latest block in the chain */
+	/* If we ever processed a block we'll get the first block in
+	 * the last run of blocks */
 	if (db_step(stmt)) {
-		if (!db_col_is_null(stmt, "MIN(height)")) {
-			min = db_col_int(stmt, "MIN(height)");
+		if (!db_col_is_null(stmt, "MAX(b.height)")) {
+			min = db_col_int(stmt, "MAX(b.height)");
 		}
 	}
 	tal_free(stmt);

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -790,13 +790,14 @@ void wallet_channel_stats_incr_out_fulfilled(struct wallet *w, u64 cdbid, struct
 u32 wallet_blocks_maxheight(struct wallet *w);
 
 /**
- * Retrieve the blockheight of the first block processed by lightningd.
+ * Retrieve the blockheight of the first block processed by lightningd (ignoring
+ * backfilled blocks for gossip).
  *
  * Will return the 0 if the wallet was never used before.
  *
  * @w: wallet to load from.
  */
-u32 wallet_blocks_minheight(struct wallet *w);
+u32 wallet_blocks_contig_minheight(struct wallet *w);
 
 /**
  * wallet_extract_owned_outputs - given a tx, extract all of our outputs


### PR DESCRIPTION
It's very hard to reproduce, since we only consider UTXOs we are watching, but scanning from the first block we know about is wrong, because we don't care about blocks which we only put in the db in response to old gossip queries.

I'm not sure how Sjors got into the state where they see their own UTXO spend in a block they don't have in the database, but we shouldn't crash:

```
2025-12-07T11:25:18.163Z **BROKEN** lightningd: Error executing statement: wallet/wallet.c:4913: UPDATE outputs SET spend_height = ?,  status = ? WHERE prev_out_tx = ? AND prev_out_index = ?: FOREIGN KEY constraint failed
2025-12-07T11:25:18.163Z **BROKEN** lightningd: Error executing statement: wallet/wallet.c:4913: UPDATE outputs SET spend_height = ?,  status = ? WHERE prev_out_tx = ? AND prev_out_index = ?: FOREIGN KEY constraint failed
2025-12-07T11:25:18.179Z **BROKEN** lightningd: FATAL SIGNAL 6 (version v25.12)
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: common/daemon.c:46 (send_backtrace) 0x5e263feb9292
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: common/daemon.c:83 (crashdump) 0x5e263feb92e1
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f64532f
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f69eb2c
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f64527d
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f6288fe
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/log.c:1054 (fatal_vfmt) 0x5e263fe38e10
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: wallet/db.c:95 (db_error) 0x5e263fe6f7ef
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: db/utils.c:326 (db_fatal) 0x5e263feaa797
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: db/utils.c:200 (db_exec_prepared_v2) 0x5e263feaab85
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: wallet/wallet.c:4924 (wallet_outpoint_spend) 0x5e263fe7de2f
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/chaintopology.c:929 (topo_update_spends) 0x5e263fe0af81
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/chaintopology.c:1532 (fixup_scan_block) 0x5e263fe0c268
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/bitcoind.c:503 (getrawblockbyheight_callback) 0x5e263fe09280
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:701 (plugin_response_handle) 0x5e263fe5bf2b
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:790 (plugin_read_json) 0x5e263fe610e7
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:60 (next_plan) 0x5e263fef3629
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:422 (do_plan) 0x5e263fef3afa
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:439 (io_ready) 0x5e263fef3bb7
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: ccan/ccan/io/poll.c:470 (io_loop) 0x5e263fef55c5
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/io_loop_with_timers.c:22 (io_loop_with_timers) 0x5e263fe308e9
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: lightningd/lightningd.c:1492 (main) 0x5e263fe363ce
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f62a1c9
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x70ee6f62a28a
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x5e263fe06bf4
2025-12-07T11:25:18.180Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0xffffffffffffffff
```

Changelog-Fixes: lightningd: crash on fixup scan with old blocks.
Closes: #8765 