### PR TITLE
Fix gossipd node announcement ordering

### DIFF
--- a/gossipd/gossmap_manage.c
+++ b/gossipd/gossmap_manage.c
@@ -300,7 +300,7 @@ static void remove_channel(struct gossmap_manage *gm,
 
 		/* Maybe this was the last channel_announcement which preceeded node_announcement? */
 		if (chan->cann_off < node->nann_off
-		    && any_cannounce_preceeds_offset(gossmap, node, chan, node->nann_off)) {
+		    && !any_cannounce_preceeds_offset(gossmap, node, chan, node->nann_off)) {
 			const u8 *nannounce;
 			u32 timestamp;
 

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -2372,7 +2372,6 @@ def test_incoming_unreasonable(node_factory):
     l3.rpc.listincoming()
 
 
-@pytest.mark.xfail(strict=True)
 def test_gossmap_lost_node(node_factory, bitcoind):
     l1, l2, l3, l4 = node_factory.line_graph(4, wait_for_announce=True)
 


### PR DESCRIPTION
Found a bug where we were not keeping our gossip_store in order, when a channel was deleted and that was the last channel_announcement preceding a node_announcement.  This is actually a little unusual, but it's now fixed.