### PR TITLE
readme: change links for 'Useful commands' from local to a web doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ will offer specific information on that command.
 
 Useful commands:
 
-* [newaddr](doc/lightning-newaddr.7.md): get a bitcoin address to deposit funds into your lightning node.
-* [listfunds](doc/lightning-listfunds.7.md): see where your funds are.
-* [connect](doc/lightning-connect.7.md): connect to another lightning node.
-* [fundchannel](doc/lightning-fundchannel.7.md): create a channel to another connected node.
-* [invoice](doc/lightning-invoice.7.md): create an invoice to get paid by another node.
-* [pay](doc/lightning-pay.7.md): pay someone else's invoice.
-* [plugin](doc/lightning-plugin.7.md): commands to control extensions.
+* [newaddr](https://docs.corelightning.org/reference/newaddr): get a bitcoin address to deposit funds into your lightning node.
+* [listfunds](https://docs.corelightning.org/reference/listfunds): see where your funds are.
+* [connect](https://docs.corelightning.org/reference/connect): connect to another lightning node.
+* [fundchannel](https://docs.corelightning.org/reference/fundchannel): create a channel to another connected node.
+* [invoice](https://docs.corelightning.org/reference/invoice): create an invoice to get paid by another node.
+* [pay](https://docs.corelightning.org/reference/pay): pay someone else's invoice.
+* [plugin](https://docs.corelightning.org/reference/plugin): commands to control extensions.
 
 ### Care And Feeding Of Your New Lightning Node
 


### PR DESCRIPTION
# Problem
URLs to RPC calls in [README.md](https://github.com/ElementsProject/lightning/blob/master/README.md#using-the-json-rpc-interface) (Useful commands) lead to nowhere. They're referencing locally generated doc files which are not present in the repo

# Solution
Change urls from locally generated files to `https://docs.corelightning.org/reference/ + <rpc-cmd>`

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
