### PR TITLE
Reduce pytest reruns from 10 to 4 to improve CI stability 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,13 @@ env:
   RUST_PROFILE: release
   SLOW_MACHINE: 1
   CI_SERVER_URL: "http://35.239.136.52:3170"
-  PYTEST_OPTS_BASE: "--reruns=10 -vvv --junit-xml=report.xml --timeout=1800 --durations=10"
+  PYTEST_OPTS_BASE: "--reruns=4 -vvv --junit-xml=report.xml --timeout=1800 --durations=10"
 
 jobs:
   prebuild:
     name: Pre-build checks
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 60
     if: |
       github.event.action != 'edited' ||
       contains(github.event.pull_request.body, 'Changelog')
@@ -536,7 +536,7 @@ jobs:
   integration-sanitizers:
     name: Sanitizers Test CLN
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 150
     env:
       RUST_PROFILE: release
       SLOW_MACHINE: 1


### PR DESCRIPTION
While reruns are useful for mitigating flaky tests, a high rerun count significantly increases execution time for long-running integration tests (e.g. regtest / Docker-based setups). In the worst case, a single flaky test can run for nearly an hour, increasing the risk of GitHub Actions runner timeouts and unnecessary resource consumption.

Reducing the reruns to 4 provides a better balance by:
- Limiting excessive re-execution of long-running tests
- Reducing overall CI runtime and runner usage
- Surfacing persistent or systemic issues earlier, rather than masking them with repeated retries

If a test consistently requires more than a few reruns to pass, it is likely indicative of a real issue rather than transient flakiness.

Changelog-None: CI enhancement only.
