### PR TITLE
Fix build on Alpine Linux

### DIFF
--- a/common/configvar.c
+++ b/common/configvar.c
@@ -4,6 +4,7 @@
 #include <ccan/tal/str/str.h>
 #include <common/configvar.h>
 #include <common/utils.h>
+#include <unistd.h>
 
 struct configvar *configvar_new(const tal_t *ctx,
 				enum configvar_src src,


### PR DESCRIPTION
This [cleanup commit](https://github.com/ElementsProject/lightning/commit/6e5cb299ddb4ba3201927f04c5ee7020f5c34865#diff-6d3d5d2d57c39de52aee14680255b34deb873fc3cf02ca38d2143607120e7600) broke the build of CLN v25.12 on Alpine Linux:

```
common/configvar.c:118:9: error: unknown type name 'ssize_t'; did you mean 'size_t'?
  118 |         ssize_t prev = -1;
      |         ^~~~~~~
      |         size_t
```

This commit restores the [original fix](https://github.com/ElementsProject/lightning/commit/53154a40a55ab803ceef0dcc8e62f7424111714a) for this issue.

Changelog-None