### PR TITLE
Fixed: enableoffer: Adding an error when trying to activate an used single use offer

### DIFF
--- a/common/jsonrpc_errors.h
+++ b/common/jsonrpc_errors.h
@@ -116,6 +116,7 @@ enum jsonrpc_errcode {
 	OFFER_BAD_INVREQ_REPLY = 1004,
 	OFFER_TIMEOUT = 1005,
 	OFFER_ALREADY_ENABLED = 1006,
+	OFFER_USED_SINGLE_USE = 1007,
 
 	/* Errors from datastore command */
 	DATASTORE_DEL_DOES_NOT_EXIST = 1200,

--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -282,6 +282,10 @@ static struct command_result *json_enableoffer(struct command *cmd,
 		return command_fail(cmd, OFFER_ALREADY_ENABLED,
 				    "offer already active");
 
+	if (offer_status_single(status) && offer_status_used(status))
+		return command_fail(cmd, OFFER_USED_SINGLE_USE,
+				    "cannot activate an used single use offer");
+
 	if (command_check_only(cmd))
 		return command_check_done(cmd);
 

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -4530,7 +4530,6 @@ def test_fetchinvoice_3hop(node_factory, bitcoind):
     l1.rpc.call('fetchinvoice', {'offer': offer1['bolt12']})
 
 
-@pytest.mark.xfail(strict=True)
 def test_fetchinvoice(node_factory, bitcoind):
     # We remove the conversion plugin on l3, causing it to get upset.
     l1, l2, l3 = node_factory.line_graph(3, wait_for_announce=True,


### PR DESCRIPTION
Without this PR, attempting to activate an used single use offer (which has been automatically disabled) causes a hard crash of lightningd. With this PR, the enableoffer command returns an error in this situation instead, as it should not be possible to enable such an offer.

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
