### PR TITLE
Fix: Add destructor to free strmap memory in sql plugin

### DIFF
--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -150,6 +150,11 @@ struct sql {
 	u64 next_rowid;
 };
 
+static void destroy_sql(struct sql *sql)
+{
+	strmap_clear(&sql->tablemap);
+}
+
 static struct sql *sql_of(struct plugin *plugin)
 {
 	return plugin_get_data(plugin, struct sql);
@@ -1986,6 +1991,7 @@ int main(int argc, char *argv[])
 	}
 
 	sql = tal(NULL, struct sql);
+	tal_add_destructor(sql, destroy_sql);
 	sql->dbfilename = NULL;
 	sql->gosstore_fd = -1;
 	sql->gosstore_nodes_off = sql->gosstore_channels_off = 0;

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -168,6 +168,11 @@ struct sql {
 	struct command *waitcmd;
 };
 
+static void destroy_sql(struct sql *sql)
+{
+	strmap_clear(&sql->tablemap);
+}
+
 static struct sql *sql_of(struct plugin *plugin)
 {
 	return plugin_get_data(plugin, struct sql);
@@ -2213,6 +2218,7 @@ int main(int argc, char *argv[])
 	}
 
 	sql = tal(NULL, struct sql);
+	tal_add_destructor(sql, destroy_sql);
 	sql->dbfilename = NULL;
 	sql->gosstore_fd = -1;
 	sql->gosstore_nodes_off = sql->gosstore_channels_off = 0;

--- a/plugins/sql.c
+++ b/plugins/sql.c
@@ -2213,6 +2213,7 @@ int main(int argc, char *argv[])
 
 		printf("The following tables are currently supported:\n");
 		strmap_iterate(&tablemap, print_one_table, NULL);
+		strmap_clear(&tablemap);
 		common_shutdown();
 		return 0;
 	}


### PR DESCRIPTION
(Fixes #8802 )

## Problem

When building with Clang and sanitizers enabled on Ubuntu 24.04, LeakSanitizer detects 1392 bytes of leaked memory in the sql plugin during `init_tablemap()`:

## Solution

Added a `destroy_sql()` destructor function that calls `strmap_clear(&sql->tablemap)` to properly free the internal strmap tree nodes. The destructor is registered with `tal_add_destructor(sql, destroy_sql)` in `main()`. Destructor to clean up strmap internal nodes.

Note: table_desc structures are tal-allocated as children of plugin context,
so they're freed automatically. This only cleans up the strmap tree overhead. 

```c
static void destroy_sql(struct sql *sql)
{
    strmap_clear(&sql->tablemap);
}
```
This ensures all memory is properly freed when the sql plugin terminates, resolving the LeakSanitizer errors.

Changelog-Fixed: Memory leak in sql plugin - freed strmap internal nodes on plugin cleanup (1392 bytes)

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
