### PR TITLE
Askrene: fix infinite cost assertion

### DIFF
--- a/plugins/askrene/mcf.c
+++ b/plugins/askrene/mcf.c
@@ -1157,11 +1157,8 @@ static void init_linear_network_single_path(
 					     c->half[half].base_fee,
 					     c->half[half].proportional_fee))
 				abort();
-			u32 fee_msat;
-			if (!amount_msat_to_u32(fee, &fee_msat))
-				continue;
 			(*arc_fee_cost)[arc.idx] =
-			    fee_msat +
+			    fee.millisatoshis + /* Raw: fee cost */
 			    params->delay_feefactor * c->half[half].delay;
 		}
 	}

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -1961,7 +1961,6 @@ def test_splice_dying_channel(node_factory, bitcoind):
     assert set([only_one(r['path'])['short_channel_id_dir'] for r in routes]) == set([pre_splice_scidd, post_splice_scidd])
 
 
-@unittest.skip
 def test_excessive_fee_cost(node_factory):
     """Produce a arc with very large fee cost that triggers an assertion in
     askrene's single path solver."""


### PR DESCRIPTION
Fix a plugin crash triggered during single path payments when a channel fees doesn't fit u32.
Addresses one of the assertions mentioned in #8823.