### PR TITLE
contrib: ignore cache when rebuilding docker builder images

### DIFF
--- a/contrib/cl-repro.sh
+++ b/contrib/cl-repro.sh
@@ -23,5 +23,5 @@ for v in focal jammy noble; do
   sudo docker run ubuntu:$v cat /etc/lsb-release
   echo "Building CL repro $v:"
   # shellcheck disable=SC2024
-  sudo docker build -t cl-repro-$v - < "$LIGHTNING_DIR"/contrib/reprobuild/Dockerfile.$v
+  sudo docker build --no-cache -t cl-repro-$v - < "$LIGHTNING_DIR"/contrib/reprobuild/Dockerfile.$v
 done


### PR DESCRIPTION
This caused issues when dependencies were updated do to cached images continuing to be used.

Changelog-None

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
