### PR TITLE
Fedora shasums are not matching due to different `SOURCE_DATE_EPOCH` for `clnrest`

### DIFF
--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -2,6 +2,8 @@ FROM fedora:40
 
 ENV UV_PYTHON=3.12
 ENV BITCOIN_VERSION=27.1
+ENV SOURCE_DATE_EPOCH=1672531200
+ENV RUSTFLAGS="-C link-arg=-Wl,--build-id=none"
 
 WORKDIR /tmp
 
@@ -20,7 +22,6 @@ RUN dnf update -y && \
 		jq \
 		xz \
 		zlib-devel \
-		cargo \
 		libsodium-devel \
 		which \
 		sed \
@@ -35,7 +36,7 @@ RUN dnf update -y && \
 	dnf clean all
 
 # Install Rust via rustup (for lockfile v4 support)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.92.0
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install lowdown

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -177,7 +177,7 @@ for target in $TARGETS; do
         TAG=fedora
         DOCKERFILE=contrib/docker/Dockerfile.builder.fedora
         FEDORA_VERSION=$(grep -oP '^FROM fedora:\K[0-9]+' "$DOCKERFILE")
-        docker build -f $DOCKERFILE -t $TAG --load .
+        docker build --no-cache -f $DOCKERFILE -t $TAG --load .
         docker run --rm=true -v "$(pwd)":/src:ro -v "$RELEASEDIR":/release $TAG /src/tools/build-release.sh --inside-docker "$VERSION" "$platform" "$FEDORA_VERSION" "$ARCH" "$MAKEPAR"
         docker run --rm=true -w /build $TAG rm -rf /"$VERSION-$platform-$FEDORA_VERSION-$ARCH" /build
         echo "Fedora Image Built"


### PR DESCRIPTION
#### Problem:
- tar archives had different checksums despite identical file listings
- Only 368 bytes differed between CI and local builds in the `clnrest` binary

#### Why `--mtime` alone wasn't enough:
- `--mtime=@1672531200' only sets file timestamps in tar metadata
- Build IDs and compiler-embedded timestamps are actual bytes INSIDE binaries
- These internal bytes differed even though file `mtimes` were identical

#### Solution:
- Add `SOURCE_DATE_EPOCH=1672531200` for reproducible compilation by enforcing a consistent timestamp for Fedora build. Similar to Ubuntu fix in [commit]( https://github.com/ElementsProject/lightning/commit/490fb0fc3b55284d47f8d391a7301c857e425b68)
- Add `RUSTFLAGS="-C link-arg=-Wl,--build-id=none"` to disable random Build IDs
- Added `no-cache` to Fedora build
- Pin Rust version to `1.92.0` prevent toolchain drift (change "stable" to specific version)

This ensures bit-for-bit identical builds across different machines and times.

---------------
Difference:
$ tar -xzf ci/clightning-v25.12.1-Fedora-40-amd64.tar.gz -C /tmp/ci
$ tar -xzf local/clightning-v25.12.1-Fedora-40-amd64.tar.gz -C /tmp/local
$ diff -r /tmp/ci /tmp/local
- Binary files /tmp/ci/usr/local/libexec/c-lightning/plugins/clnrest and /tmp/local/usr/local/libexec/c-lightning/plugins/clnrest differ

---------------
- Without `SOURCE_DATE_EPOCH`:
    - Attempt 1:
1e47a4dbc1fe6ca81bf1e42f2303250d31ffc9683bee92e632a9c6f27de9bf0d  clightning-v25.12.1-Fedora-40-amd64.tar.gz
e74adc347f5d5de45ecc9de7116fdc44ae6e13e2291a81c0ce45370bba78e0a6  clightning-v25.12.1.zip
    - Attempt 2:
1c2de1fa4466da9aa19d57c0a0b313d9e961a7078c46e8780d511bea12dd47a1  clightning-v25.12.1-Fedora-40-amd64.tar.gz
e74adc347f5d5de45ecc9de7116fdc44ae6e13e2291a81c0ce45370bba78e0a6  clightning-v25.12.1.zip

- With `SOURCE_DATE_EPOCH`:
    - Attempt 1:
4c94888a08b8d94d8a0ed034ede224c1ab34b012028090343e832ad822dd6d4f  clightning-v25.12.1-Fedora-40-amd64.tar.gz
089f1d5235e3086dad338e012d32531291ffda14094e0e985c76d0adc8abd0af  clightning-v25.12.1.zip
    - Attempt 2:
4c94888a08b8d94d8a0ed034ede224c1ab34b012028090343e832ad822dd6d4f  clightning-v25.12.1-Fedora-40-amd64.tar.gz
089f1d5235e3086dad338e012d32531291ffda14094e0e985c76d0adc8abd0af  clightning-v25.12.1.zip

Changelog-Fixed: Core lightning builds for Fedora on all systems are deterministic.