### PR TITLE
Implement graceful shutdown procedure

### DIFF
--- a/contrib/lightning-graceful-stop.sh
+++ b/contrib/lightning-graceful-stop.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+: "${TIMEOUT:=${1:-60}}"
+let DEADLINE=EPOCHSECONDS+TIMEOUT
+
+lightning-cli() {
+	echo lightning-cli "${@@Q}" >&2
+	command lightning-cli "${@}" >&2
+}
+
+lightning-cli setconfig snub-idle-channels true true
+while (( EPOCHSECONDS < DEADLINE )) ; do
+	echo "Attempting graceful stop ($((DEADLINE - EPOCHSECONDS))s remaining) ..."
+	while read -r rpc ; do
+		if [[ "${rpc}" == '# '* ]] ; then
+			set ${rpc}
+			echo "# ${2} reestablished channels, ${3} outstanding HTLCs" >&2
+			next_expiry=${4}
+		else
+			eval "lightning-cli ${rpc}"
+			if [[ "${rpc}" == stop ]] ; then
+				echo 'Graceful stop succeeded.'
+				exit 0
+			fi
+		fi
+	done < <(command lightning-cli listpeerchannels | jq -r '
+		reduce (.channels[] | select(.state | IN("CHANNELD_NORMAL", "CHANNELD_AWAITING_SPLICE")))
+			as { $peer_id, $peer_connected, $reestablished, $state, $htlcs }
+		(
+			{};
+			.[$peer_id] |= (
+				.connected |= . or $peer_connected |
+				.reestablished += if $reestablished then 1 else 0 end |
+				.htlcs += ($htlcs | length) |
+				.next_expiry |= ([. // empty, $htlcs[].expiry] | min)
+			)
+		) |
+		(
+			"# \(map(.reestablished) | add) \(map(.htlcs) | add) \(map(.next_expiry // empty) | min)",
+			if all(.reestablished == 0) and all(.htlcs == 0) then
+				"stop"
+			else
+				to_entries[] |
+				select(.value | .connected and .reestablished > 0 and .htlcs == 0) |
+				@sh "disconnect \(.key) true"
+			end
+		)
+	')
+	sleep 1
+done
+let headercount=$(command lightning-cli getchaininfo | jq '.headercount')
+fmt --width="${COLUMNS:-80}" <<EOF
+
+Graceful stop timed out after ${TIMEOUT} seconds.
+An outstanding HTLC will next expire at block height ${next_expiry} in about $((next_expiry - headercount))0 minutes.
+The node is still trying to stop gracefully.
+To cancel, run \`lightning-cli setconfig snub-idle-channels false true\`.
+EOF
+exit 1

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -253,6 +253,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	ld->discovered_ip_v6 = NULL;
 	ld->listen = true;
 	ld->autolisten = true;
+	ld->snub_idle_channels = false;
 	ld->reconnect = true;
 	ld->reconnect_private = true;
 	ld->try_reexec = false;

--- a/lightningd/lightningd.h
+++ b/lightningd/lightningd.h
@@ -179,6 +179,10 @@ struct lightningd {
 	/* Do we want to guess addresses to listen and announce? */
 	bool autolisten;
 
+	/* Do we want to avoid reestablishing channels with zero outstanding HTLCs?
+	 * This is useful for gracefully stopping the node. */
+	bool snub_idle_channels;
+
 	/* Setup: Addresses to bind/announce to the network (tal_count()) */
 	struct wireaddr_internal *proposed_wireaddr;
 	/* Setup: And the bitset for each, whether to listen, announce or both */

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -109,6 +109,17 @@ static char *opt_set_s32(const char *arg, s32 *u)
 	return NULL;
 }
 
+static char *opt_set_bool_dynamic(const char *arg, bool *b)
+{
+	bool ignored;
+
+	/* In case we're called for arg checking only */
+	if (!b)
+		b = &ignored;
+
+	return opt_set_bool_arg(arg, b);
+}
+
 char *opt_set_autobool_arg(const char *arg, enum opt_autobool *b)
 {
 	if (!strcasecmp(arg, "yes") ||
@@ -1585,6 +1596,10 @@ static void register_opts(struct lightningd *ld)
 		       "Sets the public TCP port to use for announcing discovered IPs.");
 	opt_register_noarg("--offline", opt_set_offline, ld,
 			   "Start in offline-mode (do not automatically reconnect and do not accept incoming connections)");
+	clnopt_witharg("--snub-idle-channels", OPT_SHOWBOOL|OPT_DYNAMIC,
+		       opt_set_bool_dynamic, opt_show_bool,
+		       &ld->snub_idle_channels,
+		       "If true, do not reestablish channels with zero outstanding HTLCs");
 	clnopt_witharg("--autolisten", OPT_SHOWBOOL,
 		       opt_set_bool_arg, opt_show_bool,
 		       &ld->autolisten,

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1382,6 +1382,13 @@ peer_connected_serialize(struct peer_connected_hook_payload *payload,
 	json_object_end(stream); /* .peer */
 }
 
+static bool should_snub_channel(const struct lightningd *ld,
+				/*const*/ struct channel *channel)
+{
+	return ld->snub_idle_channels && !channel_state_closed(channel->state) &&
+		!channel_has_htlc_out(channel) && !channel_has_htlc_in(channel);
+}
+
 /* Talk to connectd about an active channel */
 static void connect_activate_subd(struct lightningd *ld, struct channel *channel)
 {
@@ -1558,6 +1565,12 @@ static void peer_connected_hook_final(struct peer_connected_hook_payload *payloa
 	list_for_each(&peer->channels, channel, list) {
 		/* FIXME: It can race by opening a channel before this! */
 		if (channel_state_wants_peercomms(channel->state) && !channel->owner) {
+			if (should_snub_channel(ld, channel)) {
+				log_debug(channel->log,
+					  "Peer has reconnected, but channel is snubbed; "
+					  "not connecting subd");
+				continue;
+			}
 			log_debug(channel->log, "Peer has reconnected, state %s: connecting subd",
 				  channel_state_name(channel));
 
@@ -2064,6 +2077,22 @@ void handle_peer_spoke(struct lightningd *ld, const u8 *msg)
 				return;
 			}
 
+			if (msgtype == WIRE_CHANNEL_REESTABLISH &&
+			    should_snub_channel(ld, channel)) {
+				log_debug(channel->log,
+					  "Peer sent channel_reestablish, but channel is snubbed; "
+					  "sending warning and ignoring");
+				error = towire_warningfmt(tmpctx, &channel_id,
+							  "Declining to reestablish idle channel "
+							  "because this node will be halting soon.");
+				/* Don't goto send_error; we don't want to disconnect. */
+				subd_send_msg(ld->connectd,
+					      take(towire_connectd_peer_send_msg(NULL, &peer->id,
+										 peer->connectd_counter,
+										 error)));
+				return;
+			}
+
 			log_debug(channel->log, "channel already active");
 			if (channel->state == DUALOPEND_AWAITING_LOCKIN) {
 				pfd = sockpair(tmpctx, channel, &other_fd, &error);
@@ -2098,7 +2127,7 @@ void handle_peer_spoke(struct lightningd *ld, const u8 *msg)
 		}
 		if (peer->uncommitted_channel) {
 			error = towire_errorfmt(tmpctx, &channel_id,
-						"Multiple simulteneous opens not supported");
+						"Multiple simultaneous opens not supported");
 			goto send_error;
 		}
 		peer->uncommitted_channel = new_uncommitted_channel(peer);
@@ -2868,7 +2897,8 @@ static void setup_peer(struct peer *peer)
 		    && !(channel->channel_flags & CHANNEL_FLAGS_ANNOUNCE_CHANNEL))
 			continue;
 
-		if (channel_state_wants_peercomms(channel->state))
+		if (channel_state_wants_peercomms(channel->state) &&
+		    !should_snub_channel(ld, channel))
 			connect = true;
 		if (channel_important_filter(channel, NULL))
 			important = true;


### PR DESCRIPTION
[BOLT 2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#message-retransmission) says:

> A node, […] upon reconnection, if a channel is [not] in an error state, […] MUST wait to receive the other node's `channel_reestablish` message before sending any other messages for that channel.

We can abuse this requirement to implement a [graceful shutdown](https://github.com/ElementsProject/lightning/issues/4842) procedure:

1. Set a flag that precludes lightningd from sending `channel_reestablish` messages for any channels that have exactly zero outstanding HTLCs.
2. Disconnect all peers that have exactly zero outstanding HTLCs in all of their channels with this node.
3. If no channels are "reestablished" and no channels have any outstanding HTLCs, then it is now _impossible_ for any peers to add any new HTLCs to our channels, so we can safely shut down.
4. Otherwise, wait for some outstanding HTLC to settle, and then return to step 2.
5. If graceful shutdown is taking too long, then report to the user the approximate time until an outstanding HTLC next expires, and abort.

This PR has two objectives:

* Add a `snub-idle-channels` dynamic config variable that, when set to `true`, makes lightningd:
    * no longer spawn `channeld` subdaemons for channels that have no outstanding HTLCs;
    * as an optimization, no longer attempt to auto-reconnect to peers with whom we have no outstanding HTLCs;
    * ignore all received `channel_reestablish` messages for channels that have no outstanding HTLCs,
        * …but send a warning to the peer informing them that their channel reestablishment is being ignored because this peer imminently will be shutting down.
* Add a `contrib/lightning-graceful-stop.sh` script that utilizes `snub-idle-channels` to implement the graceful shutdown procedure outlined above.

I have tested this graceful shutdown procedure on my own production node with great success. In under a minute my node dropped from over 30 outstanding HTLCs to 14, all of which were "stuck." The shutdown script reported that the next expiration was 140 blocks away, giving me plenty of time to power off my node and perform a hardware upgrade. If I had been willing to wait for _all_ of my outstanding HTLCs to be resolved, then I could have stopped my node _indefinitely_ with no danger of any forced unilateral closures. (Of course, my peers could still _voluntarily_ choose to unilaterally close my channels with them if they grew tired of waiting for my node to reappear in the network, but that's not the concern that graceful shutdown is attempting to address.)

Note that there is still one edge case that this graceful shutdown strategy doesn't solve. If a peer has transmitted a new commitment containing a new HTLC, but we never transmitted our own new commitment containing that same new HTLC (either because we never received the peer's new commitment or because we restarted before we could send our own new commitment), then we will not know about (or will have forgotten) the new HTLC, and we will believe that the channel is safe to snub even though the peer _would_ retransmit their new commitment containing the new HTLC if we allowed them to reestablish the channel. I am not certain, but it may be possible to use the fields in the `channel_reestablish` message received from the peer to ascertain whether the peer has new HTLCs that they need to retransmit to us, and if they do, then we shouldn't snub the channel even if we are currently aware of no outstanding HTLCs in it.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
