### PR TITLE
chore: Add some run metadata to generated reports.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ import unittest
 
 server = os.environ.get("CI_SERVER_URL", None)
 
+
 github_sha = (
     subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ASCII").strip()
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from pyln.testing.utils import EXPERIMENTAL_DUAL_FUND, VALGRIND, SLOW_MACHINE
 
@@ -39,3 +40,50 @@ def pytest_runtest_setup(item):
             pytest.skip('v1-only test, EXPERIMENTAL_DUAL_FUND=1')
     if "slow_test" in item.keywords and VALGRIND and SLOW_MACHINE:
         pytest.skip("Skipping slow tests under VALGRIND")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Add environment variables to JUnit XML report.
+
+    This hook runs on the master node in pytest-xdist to add properties
+    directly to the JUnit XML report. This works around the limitation
+    that record_testsuite_property doesn't work with pytest-xdist.
+
+    We use tryfirst=True so we run before the junitxml plugin writes the file.
+
+    See: https://github.com/pytest-dev/pytest/issues/7767
+    """
+    # Check if we're on the master node (not a worker)
+    # Workers have the workeroutput attribute
+    if hasattr(session.config, "workeroutput"):
+        return
+
+    # Find the LogXML instance among registered plugins
+    # We need to search through all plugins because it's not directly accessible
+    xml = None
+    for plugin in session.config.pluginmanager.get_plugins():
+        if hasattr(plugin, "add_global_property"):
+            xml = plugin
+            break
+
+    if xml is None:
+        return
+
+    # List of environment variables to include in the report
+    include = [
+        "GITHUB_ACTION_REPOSITORY",
+        "GITHUB_EVENT_NAME",
+        "GITHUB_HEAD_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_NUMBER",
+        "RUNNER_ARCH",
+        "RUNNER_OS",
+    ]
+
+    # Add properties to the XML report
+    for name in include:
+        if name in os.environ:
+            xml.add_global_property(name, os.environ[name])


### PR DESCRIPTION
Our internal QA team would like to have the ability of linking directly to a run from the test report, so here we just add any envvar that might be of interest for cross-linking.