### PR TITLE
Added: Support for non-final onion messages hops to self

### DIFF
--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -6125,6 +6125,23 @@ def test_offer_with_private_channels_multyhop2(node_factory):
     l1.rpc.pay(invoice)
 
 
+def test_offer_with_private_channels_multyhop_with_dummy_hop(node_factory):
+    """We should be able to fetch an invoice through a private path with dummy hops and pay the invoice"""
+    l1, l2, l3, l4, l5 = node_factory.line_graph(5, fundchannel=False)
+
+    node_factory.join_nodes([l1, l2], wait_for_announce=True)
+    node_factory.join_nodes([l2, l3], wait_for_announce=True)
+    node_factory.join_nodes([l3, l4], wait_for_announce=True)
+    node_factory.join_nodes([l3, l5], announce_channels=False)
+    wait_for(lambda: ['alias' in n for n in l4.rpc.listnodes()['nodes']] == [True, True, True, True])
+
+    offer = l5.rpc.call('offer', {'amount': '2msat',
+                                  'description': 'test_offer_with_private_channels_multyhop2',
+                                  'dev_paths': [[l3.info['id'], l5.info['id'], l5.info['id']]]})['bolt12']
+    invoice = l1.rpc.fetchinvoice(offer=offer)["invoice"]
+    l1.rpc.pay(invoice)
+
+
 def diamond_network(node_factory):
     """Build a diamond, with a cheap route, that is exhausted. The
     first payment should try that route first, learn it's exhausted,


### PR DESCRIPTION
onion_message_parse: Adding a loop to process non-final onion messages hops to self, such as when dummy hops are used for a node with no announced channel. This allows to fully verify these hops and to properly derive the last path key, which can then be used for signing invoices, such as when combined with https://github.com/ElementsProject/lightning/pull/8853 . This will also be useful when generating invoices that contain blinded paths with multiple hops.

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
