### PR TITLE
tests: opening channel forcing feerate while lightningd unable to est…

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -17,6 +17,27 @@ def find_next_feerate(node, peer):
     chan = only_one(node.rpc.listpeerchannels(peer.info['id'])['channels'])
     return chan['next_feerate']
 
+@pytest.mark.openchannel('v1')
+@unittest.skipIf(TEST_NETWORK != 'regtest', "requires regtest")
+def test_open_with_unknown_feerates(node_factory, bitcoind):
+    """
+    Test openchannel when feerates are unknown (like on signet/testnet with empty mempool).
+    """
+    opts = {
+        'ignore-fee-limits': True,
+        'feerates': {252, 252, 252, 252}, 
+        'dev-no-fake-fees': True,
+    }
+
+    l1, l2 = node_factory.line_graph(2, opts=[opts, opts])
+
+    # Verify fee estimation is failing
+    l1.daemon.wait_for_log('Unable to estimate any fees')
+    l2.daemon.wait_for_log('Unable to estimate any fees')
+
+    with pytest.raises(RpcError):
+        l1.rpc.fundchannel(id=l2.info['id'], amount=1000000, feerate=100, minconf=0)
+
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')


### PR DESCRIPTION
…imate fees

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`


I wrote a test to prove #8852.

Basically, in a situation where lightningd is not able to estimate fees because the mempool is empty, if I try to open a channel forcing the feerate, the `fundchannel` call fails anyway.
