### PR TITLE
test: test open channel with unknown fees

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -19,13 +19,13 @@ def find_next_feerate(node, peer):
 
 @pytest.mark.openchannel('v1')
 @unittest.skipIf(TEST_NETWORK != 'regtest', "requires regtest")
-def test_open_with_unknown_feerates(node_factory, bitcoind):
+def test_opening_with_unknown_feerates(node_factory, bitcoind):
     """
     Test openchannel when feerates are unknown (like on signet/testnet with empty mempool).
     """
     opts = {
         'ignore-fee-limits': True,
-        'feerates': {252, 252, 252, 252}, 
+        'feerates': None, 
         'dev-no-fake-fees': True,
     }
 
@@ -35,8 +35,8 @@ def test_open_with_unknown_feerates(node_factory, bitcoind):
     l1.daemon.wait_for_log('Unable to estimate any fees')
     l2.daemon.wait_for_log('Unable to estimate any fees')
 
-    with pytest.raises(RpcError):
-        l1.rpc.fundchannel(id=l2.info['id'], amount=1000000, feerate=100, minconf=0)
+    with pytest.raises(RpcError) as e:
+        l1.rpc.fundchannel(id=l2.info['id'], amount=1000000, feerate='252perkw', minconf=0)
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -17,6 +17,27 @@ def find_next_feerate(node, peer):
     chan = only_one(node.rpc.listpeerchannels(peer.info['id'])['channels'])
     return chan['next_feerate']
 
+@pytest.mark.openchannel('v1')
+@unittest.skipIf(TEST_NETWORK != 'regtest', "requires regtest")
+def test_open_with_unknown_feerates(node_factory, bitcoind):
+    """
+    Test openchannel when feerates are unknown (like on signet/testnet with empty mempool).
+    """
+    opts = {
+        'ignore-fee-limits': True,
+        'feerates': {252, 252, 252, 252}, 
+        'dev-no-fake-fees': True,
+    }
+
+    l1, l2 = node_factory.line_graph(2, opts=[opts, opts])
+
+    # Verify fee estimation is failing
+    l1.daemon.wait_for_log('Unable to estimate any fees')
+    l2.daemon.wait_for_log('Unable to estimate any fees')
+
+    with pytest.raises(RpcError):
+        l1.rpc.fundchannel(id=l2.info['id'], amount=1000000, feerate=100, minconf=0)
+
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -43,7 +43,7 @@ def test_opening_with_unknown_feerates(node_factory, bitcoind):
         l1.rpc.fundchannel(l2.info['id'], 1000000, minconf=0)
     
     # Opening should work fine since fees are specified manually
-    l1.rpc.fundchannel(l1.info['id'], 1000000, feerate='1perkw',minconf=0)
+    l1.rpc.fundchannel(l2.info['id'], 1000000, feerate='1perkw', minconf=0)
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

### Additional info
To run the test: `EXPERIMENTAL_DUAL_FUND=0 uv run python -m pytest -vvvv tests/test_opening.py::test_opening_with_unknown_feerates`

Note that in the same node configuration (`dev-no-fake-fees=true`):
1. if the `experimental-dual-fund` is enabled, the channel will open only if `feerate` is specified in the `fundchannel` call (test at #8864 ), otherwise it will raise

```
{'code': 501, 'message': 'Cannot estimate fees (yet)'}
```
2. if f the `experimental-dual-fund` is NOT enabled, the channel funding will fail both if the `feerate` is specified or not.

Changelog-None
