### PR TITLE
Gossmap: compaction support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,7 +312,7 @@ jobs:
       - name: Test
         env:
           SLOW_MACHINE: 1
-          PYTEST_PAR: 10
+          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
@@ -430,7 +430,7 @@ jobs:
           COMPAT: 1
           CFG: ${{ matrix.CFG }}
           SLOW_MACHINE: 1
-          PYTEST_PAR: 10
+          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
@@ -524,8 +524,9 @@ jobs:
         env:
           SLOW_MACHINE: 1
           TEST_DEBUG: 1
+          PYTEST_PAR: 2
         run: |
-          VALGRIND=1 uv run eatmydata pytest tests/ -n 3 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+          VALGRIND=1 uv run eatmydata pytest tests/ -n ${PYTEST_PAR} ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -613,8 +614,10 @@ jobs:
         run: tar -xvjf cln-compile-clang-sanitizers.tar.bz2
 
       - name: Test
+        env:
+          PYTEST_PAR: 2
         run: |
-          uv run eatmydata pytest tests/ -n 2 ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
+          uv run eatmydata pytest tests/ -n ${PYTEST_PAR} ${PYTEST_OPTS}  ${{ matrix.PYTEST_OPTS }}
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -737,7 +740,7 @@ jobs:
           COMPAT: 1
           CFG: ${{ matrix.CFG }}
           SLOW_MACHINE: 1
-          PYTEST_PAR: 10
+          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}


### PR DESCRIPTION
~Based on #8878~ -- Merged

We used to do compaction of the gossip store, but it was buggy.  So now we do it on every startup (which is slow).  Better is to do it when required, using a separate process.

