### PR TITLE
Docs: Update mac instructions to gmake

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -351,7 +351,7 @@ You are using brew in Intel compatibility mode. The simplest solution is to remo
 
 Install dependencies:
 ```shell
-brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf lowdown pkgconf openssl
+brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf lowdown pkgconf openssl make
 export PATH="/opt/homebrew/opt/:$PATH"
 export CPATH=/opt/homebrew/include
 export LIBRARY_PATH=/opt/homebrew/lib
@@ -398,7 +398,7 @@ uv sync --all-extras --all-groups --frozen
 
 If you see `/usr/local` in the log, an Intel compatability dependency has been picked up. The simplest solution is to remove brew entirely, reinstall it, and start these instructions over.
 ```shell
-uv run make
+uv run gmake
 ```
 
 Running lightning:
@@ -412,14 +412,14 @@ bitcoind &
 ./cli/lightning-cli help
 ```
 
-To install the built binaries into your system, you'll need to run `make install`:
+To install the built binaries into your system, you'll need to run `gmake install`:
 ```shell
-make install
+gmake install
 ```
 
 You may need to use this command instead. Confirm the exported PATH, CPATH, and LIBRARY_PATH environment variables set earlier are still present.
 ```shell
-sudo make install
+sudo gmake install
 ```
 
 ## To Build on macOS Intel
@@ -428,7 +428,7 @@ Assuming you have Xcode and Homebrew installed.
 
 Install dependencies:
 ```shell
-brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf lowdown pkgconf openssl
+brew install autoconf automake libtool python3 gnu-sed gettext libsodium protobuf lowdown pkgconf openssl make
 export PATH="/usr/local/opt/:$PATH"
 export CPATH=/usr/local/include
 export LIBRARY_PATH=/usr/local/lib
@@ -471,7 +471,7 @@ Build lightning:
 ```shell
 uv sync --all-extras --all-groups --frozen
 ./configure
-uv run make
+uv run gmake
 ```
 
 Running lightning:
@@ -485,9 +485,9 @@ bitcoind &
 ./cli/lightning-cli help
 ```
 
-To install the built binaries into your system, you'll need to run `make install`:
+To install the built binaries into your system, you'll need to run `gmake install`:
 ```shell
-make install
+gmake install
 ```
 
 ## To Build on Arch Linux


### PR DESCRIPTION
Apple bundles a rather old version of GNU Make: 3.81. Our Makefiles use the &: feature which requires version 4.3. Apparently Apple isn’t updating GNU Make anymore due to a licensing issue.

Switching the instructions over to using gmake installed from the brew package manager, which currently installs 4.4.1

ChangelogNone
