### PR TITLE
Test channel lifecycle after being offline

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -30,6 +30,65 @@ import time
 import unittest
 
 
+
+def test_ch_life_with_receiving_node_up_after_a_while(node_factory, bitcoind):
+    """
+    Test channel lifecycle with receiving node restart after a while.
+    """
+    l1, l2 = node_factory.get_nodes(2)
+    l1.fundwallet(10000000)
+    l2.fundwallet(10000000)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.fundchannel(l2.info['id'], 500000, minconf=0)
+
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    l1.daemon.wait_for_log(' to CHANNELD_NORMAL')
+
+    chan12 = l1.get_channel_scid(l2)
+
+    dust_limit = only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['dust_limit_msat']
+
+    inv = l2.rpc.invoice(dust_limit + 1000, 'test1', 'description1')
+    l1.rpc.pay(inv['bolt11'])
+
+    wait_for(lambda: only_one(l1.rpc.listpeerchannels()['channels'])['htlcs'] == [])
+    wait_for(lambda: only_one(l2.rpc.listpeerchannels()['channels'])['htlcs'] == [])
+
+    l2.stop()
+
+    l1.rpc.close(chan12, 1)
+
+    bitcoind.generate_block(1, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l1])
+
+    l1_channel = only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])
+    assert all('ONCHAIN' in status for status in l1_channel['status'])
+
+    sync_blockheight(bitcoind, [l1])
+
+    l1_addr = l1.rpc.newaddr()['p2tr']
+
+    assert len(l1.rpc.listfunds()['outputs']) > 0, "l1 has no outputs to withdraw"
+
+    l1.rpc.withdraw(l1_addr, 'all')
+
+    bitcoind.generate_block(510, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l1])
+
+    l2.start()
+
+    funds_l1 = l1.rpc.listfunds()
+    total_funds_l1 = sum([output['amount_msat'] for output in funds_l1['outputs']])
+    assert 950000000 <= total_funds_l1 < 10000000000, f"Total funds {total_funds_l1} not in expected range"
+
+    funds_l2 = l2.rpc.listfunds()
+    total_funds_l2 = sum([output['amount_msat'] for output in funds_l2['outputs']])
+
+    assert total_funds_l2 > 10000000000, f"Total funds {total_funds_l2} not in expected range"
+    
+
 @pytest.mark.parametrize("old_hsmsecret", [False, True])
 def test_names(node_factory, old_hsmsecret):
     if old_hsmsecret:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -30,7 +30,6 @@ import time
 import unittest
 
 
-
 def test_ch_life_with_receiving_node_up_after_a_while(node_factory, bitcoind):
     """
     Test channel lifecycle with receiving node restart after a while.
@@ -74,7 +73,7 @@ def test_ch_life_with_receiving_node_up_after_a_while(node_factory, bitcoind):
 
     l1.rpc.withdraw(l1_addr, 'all')
 
-    bitcoind.generate_block(510, wait_for_mempool=1)
+    bitcoind.generate_block(210, wait_for_mempool=1)
     sync_blockheight(bitcoind, [l1])
 
     l2.start()
@@ -85,9 +84,64 @@ def test_ch_life_with_receiving_node_up_after_a_while(node_factory, bitcoind):
 
     funds_l2 = l2.rpc.listfunds()
     total_funds_l2 = sum([output['amount_msat'] for output in funds_l2['outputs']])
-
     assert total_funds_l2 > 10000000000, f"Total funds {total_funds_l2} not in expected range"
-    
+
+
+def test_ch_life_with_opening_node_up_after_a_while(node_factory, bitcoind):
+    """
+    Test channel lifecycle with opening node restart after a while.
+    """
+    l1, l2 = node_factory.get_nodes(2, opts=[{'feerates': (7500, 7500, 7500, 7500)}, {}])
+    l1.fundwallet(10000000)
+    l2.fundwallet(10000000)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.rpc.fundchannel(l2.info['id'], 500000, minconf=0)
+
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    l1.daemon.wait_for_log(' to CHANNELD_NORMAL')
+
+    chan12 = l1.get_channel_scid(l2)
+
+    dust_limit = only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['dust_limit_msat']
+
+    inv = l2.rpc.invoice(dust_limit + 1000, 'test1', 'description1')
+    l1.rpc.pay(inv['bolt11'])
+
+    wait_for(lambda: only_one(l1.rpc.listpeerchannels()['channels'])['htlcs'] == [])
+    wait_for(lambda: only_one(l2.rpc.listpeerchannels()['channels'])['htlcs'] == [])
+
+    l1.stop()
+
+    l2.rpc.close(chan12, 1)
+
+    bitcoind.generate_block(1, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l2])
+
+    l2_channel = only_one(l2.rpc.listpeerchannels(l1.info['id'])['channels'])
+    assert all('ONCHAIN' in status for status in l2_channel['status'])
+
+    sync_blockheight(bitcoind, [l2])
+
+    l2_addr = l2.rpc.newaddr()['p2tr']
+
+    assert len(l2.rpc.listfunds()['outputs']) > 0, "l2 has no outputs to withdraw"
+
+    l2.rpc.withdraw(l2_addr, 'all')
+    bitcoind.generate_block(210, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l2])
+
+    l1.start()
+
+    funds_l1 = l1.rpc.listfunds()
+    total_funds_l1 = sum([output['amount_msat'] for output in funds_l1['outputs']])
+    assert 950000000 <= total_funds_l1 < 10000000000, f"Total funds {total_funds_l1} not in expected range"
+
+    funds_l2 = l2.rpc.listfunds()
+    total_funds_l2 = sum([output['amount_msat'] for output in funds_l2['outputs']])
+    assert total_funds_l2 > 10000000000, f"Total funds {total_funds_l2} not in expected range"
+
 
 @pytest.mark.parametrize("old_hsmsecret", [False, True])
 def test_names(node_factory, old_hsmsecret):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`


### Rationale
Test the ability of the node in different roles (opening/receiving) to correctly handle and resolve a channel after being offline for hundreds of blocks.

In case the node that goes offline is the opening one, the node gets stuck trying to RBF the `DELAYED_OUTPUT_TO_US` transaction, as reported in #8882 

Changelog-None