### PR TITLE
tests: Test that when a node loses state and the closing transaction has HTLC outputs

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -30,6 +30,105 @@ import time
 import unittest
 
 
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "deletes database, which is assumed sqlite3")
+def test_lost_state_htlc_tx_onchaind_crash(node_factory, bitcoind, executor):
+    """
+    Test that when a node loses state and the closing transaction has HTLC outputs,
+    onchaind fails to resolve the HTLC output because it doesn't know about it.
+    """
+    # l1 will lose state and fail to resolve HTLC outputs
+    # Use disconnect to stop l2 from fulfilling the HTLC, keeping it in flight
+    # Use dev-no-reconnect to prevent auto-reconnection that would allow HTLC fulfillment
+    l1, l2 = node_factory.get_nodes(2, opts=[
+        {'may_reconnect': True,
+         'dev-no-reconnect': None,
+         'allow_bad_gossip': True,
+         'rescan': 10,
+         # onchaind will fail to resolve the HTLC output
+         'broken_log': r"onchaind-chan#[0-9]*: Could not find resolution for output [0-9]+",
+         'may_fail': True},
+        {'may_reconnect': True,
+         'dev-no-reconnect': None,
+         # Disconnect when l2 tries to send UPDATE_FULFILL_HTLC, keeping HTLC pending
+         'disconnect': ['-WIRE_UPDATE_FULFILL_HTLC']}
+    ])
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    c12, channel_info = l2.fundchannel(l1, 10**6)
+
+    # Move some funds to l1 so both sides have balance
+    l2.rpc.pay(l1.rpc.invoice(400000000, 'initial', 'initial transfer')['bolt11'])
+
+    # Wait for channel to be fully settled
+    wait_for(lambda: all([only_one(ch.rpc.listpeerchannels()['channels'])['htlcs'] == [] for ch in (l1, l2)]))
+
+    # Start a payment from l1 to l2 - l2 will disconnect before fulfilling
+    inv = l2.rpc.invoice(100000000, 'htlc_test', 'test htlc')
+    t = executor.submit(l1.rpc.pay, inv['bolt11'])
+
+    # Wait for l2 to disconnect (it received the HTLC and tried to fulfill)
+    l2.daemon.wait_for_log('dev_disconnect')
+
+    # l2 should have the HTLC in its commitment now
+    # Sign l2's commitment which has the HTLC in it
+    tx_with_htlc = l2.rpc.dev_sign_last_tx(l1.info['id'])['tx']
+
+    # Decode to verify we have more than 2 outputs (anchors + HTLC + balances)
+    decoded = bitcoind.rpc.decoderawtransaction(tx_with_htlc)
+    num_outputs = len(decoded['vout'])
+    # With anchors: 2 anchor outputs + at least 1 HTLC + up to 2 balance outputs
+    # Minimum 4 outputs (could be 5 if both balances are non-dust)
+    assert num_outputs >= 4, f"Expected at least 4 outputs, got {num_outputs}"
+
+    # Stop l1 and delete its database to simulate lost state
+    l1.stop()
+    os.unlink(os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, "lightningd.sqlite3"))
+
+    # Restart l1 (without dev-no-reconnect so it can reconnect) and use emergency recovery
+    del l1.daemon.opts['dev-no-reconnect']
+    l1.start()
+    assert l1.daemon.is_in_log('Server started with public key')
+
+    stubs = l1.rpc.emergencyrecover()["stubs"]
+    assert len(stubs) == 1
+    assert stubs[0] == channel_info["channel_id"]
+
+    # Reconnect to l2 - this will trigger the bogus reestablish
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    # l1 will send bogus reestablish to trigger peer to close
+    l1.daemon.wait_for_log('Sending a bogus channel_reestablish message to make the peer unilaterally close the channel.')
+
+    # Now broadcast the commitment transaction with the HTLC
+    # This simulates the peer force-closing with a commitment that has HTLCs
+    # that l1 no longer knows about due to lost state
+    bitcoind.rpc.sendrawtransaction(tx_with_htlc)
+    bitcoind.generate_block(1)
+
+    sync_blockheight(bitcoind, [l1, l2])
+
+    # l1's onchaind should fail to resolve the HTLC output because it has lost state
+    # The channel should show lost_state: true
+    wait_for(lambda: l1.rpc.listpeerchannels()['channels'][0].get('lost_state', False) is True)
+
+    # onchaind should fail trying to resolve the HTLC output it doesn't know about
+    l1.daemon.wait_for_log(r"onchaind-chan#[0-9]*: Could not find resolution for output [0-9]+")
+
+    # The channel should be in ONCHAIN state with onchaind having died
+    wait_for(lambda: 'ONCHAIN' in l1.rpc.listpeerchannels()['channels'][0]['state'])
+    l1.daemon.wait_for_log('Owning subdaemon onchaind died')
+
+    # Verify the status shows onchaind died
+    status = l1.rpc.listpeerchannels()['channels'][0]['status']
+    assert any('onchaind died' in s for s in status), f"Expected onchaind died status, got: {status}"
+
+    # Clean up - cancel the stuck payment
+    try:
+        t.cancel()
+    except Exception:
+        pass
+
+
 @pytest.mark.parametrize("old_hsmsecret", [False, True])
 def test_names(node_factory, old_hsmsecret):
     if old_hsmsecret:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,20 +62,12 @@ def test_lost_state_htlc_tx_onchaind_crash(node_factory, bitcoind, executor):
     # Wait for channel to be fully settled
     wait_for(lambda: all([only_one(ch.rpc.listpeerchannels()['channels'])['htlcs'] == [] for ch in (l1, l2)]))
 
-    # Start a payment from l1 to l2 - l2 will disconnect before fulfilling
-    inv = l2.rpc.invoice(100000000, 'htlc_test', 'test htlc')
-    t = executor.submit(l1.rpc.pay, inv['bolt11'])
-
     # Wait for l2 to disconnect (it received the HTLC and tried to fulfill)
     l2.daemon.wait_for_log('dev_disconnect')
 
     # l2 should have the HTLC in its commitment now
     # Sign l2's commitment which has the HTLC in it
     tx_with_htlc = l2.rpc.dev_sign_last_tx(l1.info['id'])['tx']
-
-    # Get channel dust limit for reference
-    dust_limit_msat = only_one([ch['dust_limit_msat'] for ch in l2.rpc.listpeerchannels()['channels'] if ch['peer_id'] == l1.info['id']])
-    dust_limit_sat = dust_limit_msat // 1000
 
     # Decode to verify we have more than 2 outputs (anchors + HTLC + balances)
     decoded = bitcoind.rpc.decoderawtransaction(tx_with_htlc)


### PR DESCRIPTION
## Scenario
In order to reproduce the issue reported in #8880 where `onchaind` makes node crashes after CLN has lost a channel state (due to database deletion/corruption) and encounters a force-close transaction containing HTLC outputs that it no longer has knowledge of.

### Background
A commitment transaction with anchors typically has 5 outputs ([here](https://mempool.space/tx/d9be1412596fab9b9c0417010393c2493f208220dac0efb2bb5f76be020d6db3?showFlow=false#flow) an example):
1. Local anchor - for fee bumping
2. Remote anchor - for fee bumping
3. to_local output - funds belonging to the broadcaster (timelocked)
4. to_remote output - funds belonging to the counterparty
HTLC output(s) - pending payments in-flight

When a node loses its database, it loses:
* The commitment number and per-commitment secrets
* Knowledge of any in-flight HTLCs
* The scripts needed to identify and claim HTLC outputs

### Test Steps
1. Create two nodes with anchors (default). `l1` will lose state, `l2` has a disconnect trigger on `WIRE_UPDATE_FULFILL_HTLC`
2. `l2` funds a channel to `l1` (1M sats)
3. `l2` pays `l1`400k sats so both sides have funds
4. `l1` starts a payment to `l2`. `l2` receives the HTLC but disconnects before sending the fulfill message
5. Sign `l2`'s commitment transaction which contains the pending HTLC (verifies 4+ outputs: 2 anchors + HTLC + balances)
6. Stop `l1`, delete its database
7. Restart `l1` and use `emergencyrecover()` to stub the channel
8. Reconnect to `l2`, which triggers the bogus reestablish
9. The captured commitment is broadcast on-chain
10. `l1`'s onchaind fails with "Could not find resolution for output X" because it doesn't know about the HTLC


The test will fail before its end, when l1 will resing with `bitcoind`, with the command `sync_blockheight(bitcoind, [l1, l2])`

Changelog-None