### PR TITLE
CI: reduce parallelism for pytest.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ env:
   SLOW_MACHINE: 1
   CI_SERVER_URL: "http://35.239.136.52:3170"
   PYTEST_OPTS_BASE: "-vvv --junit-xml=report.xml --timeout=1800 --durations=10"
+  # With 4 CPUS, not much point going over parallelism 5
+  PYTEST_PAR: 5
   TEST_LOG_IGNORE_ERRORS: "1"
 
 jobs:
@@ -312,7 +314,6 @@ jobs:
       - name: Test
         env:
           SLOW_MACHINE: 1
-          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
@@ -430,7 +431,6 @@ jobs:
           COMPAT: 1
           CFG: ${{ matrix.CFG }}
           SLOW_MACHINE: 1
-          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
@@ -740,7 +740,6 @@ jobs:
           COMPAT: 1
           CFG: ${{ matrix.CFG }}
           SLOW_MACHINE: 1
-          PYTEST_PAR: 4
           TEST_DEBUG: 1
           TEST_DB_PROVIDER: ${{ matrix.TEST_DB_PROVIDER }}
           TEST_NETWORK: ${{ matrix.TEST_NETWORK }}


### PR DESCRIPTION
In November 2022 we seemed to increase parallelism from 2 and 3 to 10! That is a huge load for these CI boxes, and does explain some of our flakes.

We only run in parallel because some tests sleep, but it's diminishing returns (GH runners have 4 VCPUs, 16GB RAM).

This reduces it so:
- Normal runs are -n 4
- Valgrind runs are -n 2
- Sanitizer runs are -n 3

Typical times before:

Sanitizers Test CLN (ASan/UBSan (01/12), 1, --test-group=1 --test-group-count=12) (pull_request)Successful in 70m
Sanitizers Test CLN (ASan/UBSan (02/12), 2, --test-group=2 --test-group-count=12) (pull_request)Successful in 97m
Sanitizers Test CLN (ASan/UBSan (03/12), 3, --test-group=3 --test-group-count=12) (pull_request)Successful in 87m
Sanitizers Test CLN (ASan/UBSan (04/12), 4, --test-group=4 --test-group-count=12) (pull_request)Successful in 86m
Sanitizers Test CLN (ASan/UBSan (05/12), 5, --test-group=5 --test-group-count=12) (pull_request)Successful in 83m
Sanitizers Test CLN (ASan/UBSan (06/12), 6, --test-group=6 --test-group-count=12) (pull_request)Successful in 86m
Sanitizers Test CLN (ASan/UBSan (07/12), 7, --test-group=7 --test-group-count=12) (pull_request)Successful in 88m
Sanitizers Test CLN (ASan/UBSan (08/12), 8, --test-group=8 --test-group-count=12) (pull_request)Successful in 76m
Sanitizers Test CLN (ASan/UBSan (09/12), 9, --test-group=9 --test-group-count=12) (pull_request)Successful in 86m
Sanitizers Test CLN (ASan/UBSan (10/12), 10, --test-group=10 --test-group-count=12) (pull_request)Successful in 82m
Sanitizers Test CLN (ASan/UBSan (11/12), 11, --test-group=11 --test-group-count=12) (pull_request)Successful in 78m
Sanitizers Test CLN (ASan/UBSan (12/12), 12, --test-group=12 --test-group-count=12) (pull_request)Successful in 74m
Test CLN clang (pull_request)Successful in 109m
Test CLN dual-fund (pull_request)Successful in 20m
Test CLN gcc (pull_request)Failing after 97m
Test CLN liquid (pull_request)Successful in 84m
Test CLN postgres (pull_request)Successful in 101m
Test CLN splicing (pull_request)Successful in 98m
Test minimum supported BTC v25.0 with clang (pull_request)Successful in 105m
Valgrind Test CLN Valgrind (01/10) (pull_request)Successful in 40m
Valgrind Test CLN Valgrind (02/10) (pull_request)Successful in 41m
Valgrind Test CLN Valgrind (03/10) (pull_request)Successful in 42m
Valgrind Test CLN Valgrind (04/10) (pull_request)Successful in 41m
Valgrind Test CLN Valgrind (05/10) (pull_request)Successful in 44m
Valgrind Test CLN Valgrind (06/10) (pull_request)Successful in 38m
Valgrind Test CLN Valgrind (07/10) (pull_request)Successful in 44m
Valgrind Test CLN Valgrind (08/10) (pull_request)Successful in 45m
Valgrind Test CLN Valgrind (09/10) (pull_request)Successful in 39m
Valgrind Test CLN Valgrind (10/10) (pull_request)Successful in 39m

Changelog-None: CI only