### PR TITLE
opening: reject fundchannel_complete with unsigned non-segwit inputs

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1776,6 +1776,39 @@ def test_funding_external_wallet(node_factory, bitcoind):
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+@pytest.mark.openchannel('v1')
+def test_fundchannel_complete_rejects_nonsegwit_unsigned(node_factory, bitcoind):
+    l1, l2 = node_factory.get_nodes(2)
+    l1.connect(l2)
+
+    amount = 1_000_000
+
+    start = l1.rpc.fundchannel_start(l2.info['id'], amount)
+    funding_addr = start['funding_address']
+
+    # P2PKH (non-segwit) input.
+    legacy_addr = bitcoind.rpc.getnewaddress("", "legacy")
+    bitcoind.rpc.sendtoaddress(legacy_addr, 0.05)
+    bitcoind.generate_block(1)
+
+    utxos = bitcoind.rpc.listunspent(1, 9999999, [legacy_addr])
+    assert len(utxos) > 0
+    utxo = utxos[0]
+
+    psbt = bitcoind.rpc.walletcreatefundedpsbt(
+        [{"txid": utxo['txid'], "vout": utxo['vout']}],
+        [{funding_addr: amount / 10**8}],
+        0,
+        {"add_inputs": False}
+    )['psbt']
+
+    with pytest.raises(RpcError, match=r'non-segwit and unsigned'):
+        l1.rpc.fundchannel_complete(l2.info['id'], psbt)
+
+    l1.rpc.fundchannel_cancel(l2.info['id'])
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v1')  # We manually turn on dual-funding for select nodes
 def test_multifunding_v1_v2_mixed(node_factory, bitcoind):
     '''


### PR DESCRIPTION
We can't know the txid of an unsigned PSBT with non-segwit (legacy P2PKH/P2SH) inputs. wally_psbt_extract() fills in an empty scriptSig for unsigned inputs, giving a txid that changes once the user signs and broadcasts. openingd then waits forever for a tx it will never see.

Fixes #8897
Fixes #8892