### PR TITLE
Fix F541: replace f-strings with no placeholders in lightning tests

### DIFF
--- a/contrib/api/generate-python-docs.py
+++ b/contrib/api/generate-python-docs.py
@@ -116,7 +116,7 @@ INDEX_HTML_TEMPLATE = """<!DOCTYPE html>
 
 def generate_docs(output_dir: Path, repo_root: Path):
     """Generate documentation for all packages."""
-    print(f"Generating Python documentation for all workspace packages...")
+    print("Generating Python documentation for all workspace packages...")
     print(f"Output directory: {output_dir}")
 
     # Clean and create output directory

--- a/contrib/msggen/msggen/gen/grpc/convert.py
+++ b/contrib/msggen/msggen/gen/grpc/convert.py
@@ -65,14 +65,14 @@ class GrpcConverterGenerator(IGenerator):
                 # The inner conversion applied to each element in the
                 # array. The current item is called `i`
                 mapping = {
-                    "hex": f"hex::decode(i).unwrap()",
-                    "secret": f"i.to_vec()",
-                    "hash": f"<Sha256 as AsRef<[u8]>>::as_ref(&i).to_vec()",
-                    "short_channel_id": f"i.to_string()",
-                    "short_channel_id_dir": f"i.to_string()",
-                    "pubkey": f"i.serialize().to_vec()",
-                    "txid": f"hex::decode(i).unwrap()",
-                }.get(typ, f"i.into()")
+                    "hex": "hex::decode(i).unwrap()",
+                    "secret": "i.to_vec()",
+                    "hash": "<Sha256 as AsRef<[u8]>>::as_ref(&i).to_vec()",
+                    "short_channel_id": "i.to_string()",
+                    "short_channel_id_dir": "i.to_string()",
+                    "pubkey": "i.serialize().to_vec()",
+                    "txid": "hex::decode(i).unwrap()",
+                }.get(typ, "i.into()")
 
                 self.write(f"// Field: {f.path}\n", numindent=3)
                 if not f.optional:
@@ -145,7 +145,7 @@ class GrpcConverterGenerator(IGenerator):
                 )
 
                 if f.deprecated:
-                    self.write(f"#[allow(deprecated)]\n", numindent=3)
+                    self.write("#[allow(deprecated)]\n", numindent=3)
                 self.write(f"{name}: {rhs}, // Rule #2 for type {typ}\n", numindent=3)
 
             elif isinstance(f, CompositeField):
@@ -156,10 +156,10 @@ class GrpcConverterGenerator(IGenerator):
                     rhs = f"c.{name}.map(|v| v.into())"
                 self.write(f"{name}: {rhs},\n", numindent=3)
         self.write(
-            f"""\
-                }}
-            }}
-        }}
+            """\
+                }
+            }
+        }
 
         """
         )

--- a/contrib/msggen/msggen/gen/grpc/proto.py
+++ b/contrib/msggen/msggen/gen/grpc/proto.py
@@ -158,7 +158,7 @@ class GrpcGenerator(IGenerator):
             )
 
         self.write(
-            f"""}}
+            """}
         """
         )
 
@@ -230,7 +230,7 @@ class GrpcGenerator(IGenerator):
 
     def generate(self, service: Service) -> None:
         """Generate the GRPC protobuf file and write to `dest`"""
-        self.write(f"""syntax = "proto3";\npackage cln;\n""")
+        self.write("""syntax = "proto3";\npackage cln;\n""")
         self.write(
             """
         // This file was automatically derived from the JSON-RPC schemas in

--- a/contrib/msggen/msggen/gen/grpc/server.py
+++ b/contrib/msggen/msggen/gen/grpc/server.py
@@ -28,18 +28,18 @@ class GrpcServerGenerator(IGenerator):
 
     def generate(self, service: Service) -> None:
         self.write(
-            f"""\
+            """\
         use crate::pb::node_server::Node;
         use crate::pb;
-        use cln_rpc::{{Request, Response, ClnRpc}};
+        use cln_rpc::{Request, Response, ClnRpc};
         use cln_rpc::notifications::Notification;
         use anyhow::Result;
-        use std::path::{{Path, PathBuf}};
+        use std::path::{Path, PathBuf};
         use std::pin::Pin;
-        use std::task::{{Context, Poll}};
+        use std::task::{Context, Poll};
         use cln_rpc::model::requests;
-        use log::{{debug, trace}};
-        use tonic::{{Code, Status}};
+        use log::{debug, trace};
+        use tonic::{Code, Status};
         use tokio::sync::broadcast;
         use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
         use tokio_stream::wrappers::BroadcastStream;
@@ -47,72 +47,72 @@ class GrpcServerGenerator(IGenerator):
 
         #[derive(Clone)]
         pub struct Server
-        {{
+        {
             rpc_path: PathBuf,
             events : broadcast::Sender<Notification>
-        }}
+        }
 
         impl Server
-        {{
+        {
             pub async fn new(
                 path: &Path,
                 events : broadcast::Sender<Notification>
             ) -> Result<Self>
-            {{
-                Ok(Self {{
+            {
+                Ok(Self {
                     rpc_path: path.to_path_buf(),
                     events : events
-                }})
-            }}
-        }}
+                })
+            }
+        }
 
-        pub struct NotificationStream<T> {{
+        pub struct NotificationStream<T> {
             inner : Pin<Box<BroadcastStream<Notification>>>,
             fn_filter_map : fn(Notification) -> Option<T>
-        }}
+        }
 
-        impl<T : 'static + Send + Clone> tokio_stream::Stream for NotificationStream<T> {{
+        impl<T : 'static + Send + Clone> tokio_stream::Stream for NotificationStream<T> {
 
             type Item = Result<T, tonic::Status>;
 
-            fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {{
-                while let Poll::Ready(result) = self.inner.as_mut().poll_next(cx) {{
+            fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                while let Poll::Ready(result) = self.inner.as_mut().poll_next(cx) {
                     // None is used here to signal that we have reached the end of stream
                     // If inner ends the stream by returning None we do the same
-                    if result.is_none() {{
+                    if result.is_none() {
                         return Poll::Ready(None)
-                    }}
+                    }
                     let result: Result<cln_rpc::Notification, BroadcastStreamRecvError> = result.unwrap();
 
-                    match result {{
-                        Err(BroadcastStreamRecvError::Lagged(lag)) => {{
+                    match result {
+                        Err(BroadcastStreamRecvError::Lagged(lag)) => {
                             // In this error case we've missed some notifications
                             // We log the error to core lightning and forward
                             // this information to the client
-                            log::warn!("Due to lag the grpc-server skipped {{}} notifications", lag);
+                            log::warn!("Due to lag the grpc-server skipped {} notifications", lag);
                             return Poll::Ready(Some(Err(
                                 Status::data_loss(
-                                    format!("Skipped up to {{}} notifications", lag)))))
-                        }}
-                        Ok(notification) => {{
+                                    format!("Skipped up to {} notifications", lag)))))
+                        }
+                        Ok(notification) => {
                             let filtered = (self.fn_filter_map)(notification);
-                            match filtered {{
+                            match filtered {
                                 Some(n) => return Poll::Ready(Some(Ok(n))),
-                                None => {{
+                                None => {
                                     // We ignore the message if it isn't a match.
                                     // e.g: A `ChannelOpenedStream` will ignore `CustomMsgNotifications`
-                                }}
-                            }}
-                        }}
-                    }}
-                }}
+                                }
+                            }
+                        }
+                    }
+                }
                 Poll::Pending
-            }}
-        }}
+            }
+        }
 
         #[tonic::async_trait]
         impl Node for Server
-        {{
+        {
         """,
             numindent=0,
         )

--- a/contrib/msggen/msggen/gen/grpc/unconvert.py
+++ b/contrib/msggen/msggen/gen/grpc/unconvert.py
@@ -49,21 +49,21 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
             if isinstance(f, ArrayField):
                 typ = f.itemtype.typename
                 mapping = {
-                    "hex": f"hex::encode(s)",
-                    "u32": f"s",
-                    "secret": f"s.try_into().unwrap()",
-                    "hash": f"Sha256::from_slice(&s).unwrap()",
-                    "short_channel_id": f"cln_rpc::primitives::ShortChannelId::from_str(&s).unwrap()",
-                    "short_channel_id_dir": f"cln_rpc::primitives::ShortChannelIdDir::from_str(&s).unwrap()",
-                    "pubkey": f"PublicKey::from_slice(&s).unwrap()",
-                    "txid": f"hex::encode(s)",
-                }.get(typ, f"s.into()")
+                    "hex": "hex::encode(s)",
+                    "u32": "s",
+                    "secret": "s.try_into().unwrap()",
+                    "hash": "Sha256::from_slice(&s).unwrap()",
+                    "short_channel_id": "cln_rpc::primitives::ShortChannelId::from_str(&s).unwrap()",
+                    "short_channel_id_dir": "cln_rpc::primitives::ShortChannelIdDir::from_str(&s).unwrap()",
+                    "pubkey": "PublicKey::from_slice(&s).unwrap()",
+                    "txid": "hex::encode(s)",
+                }.get(typ, "s.into()")
 
                 # TODO fix properly
                 if typ in ["ListtransactionsTransactionsType"]:
                     continue
                 if name == "state_changes":
-                    self.write(f" state_changes: None,")
+                    self.write(" state_changes: None,")
                     continue
 
                 if not f.optional:
@@ -154,10 +154,10 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
                 self.write(f"{name}: {rhs},\n", numindent=3)
 
         self.write(
-            f"""\
-                }}
-            }}
-        }}
+            """\
+                }
+            }
+        }
 
         """
         )

--- a/contrib/msggen/msggen/gen/grpc2py.py
+++ b/contrib/msggen/msggen/gen/grpc2py.py
@@ -214,7 +214,7 @@ class Grpc2PyGenerator(IGenerator):
                     cleanup=False,
                 )
 
-        self.write(f"    }})\n", cleanup=False)
+        self.write("    })\n", cleanup=False)
 
         # Add ourselves to the converters so if we were generated as a
         # dependency for a composite they can find us again. We have

--- a/contrib/msggen/msggen/gen/rpc/rust.py
+++ b/contrib/msggen/msggen/gen/rpc/rust.py
@@ -189,10 +189,10 @@ def gen_enum(e, meta, override):
         norm = v.normalized()
         decl += f'            {typename}::{norm} => "{norm}",\n'
     decl += dedent(
-        f"""\
-            }}.to_string()
-        }}
-    }}
+        """\
+            }.to_string()
+        }
+    }
 
     """
     )
@@ -206,7 +206,7 @@ def gen_enum(e, meta, override):
         defi += rename_if_necessary(str(e.name), e.name.normalized())
         defi += f"    pub {e.name.normalized()}: {typename},\n"
     else:
-        defi = f'    #[serde(skip_serializing_if = "Option::is_none")]\n'
+        defi = '    #[serde(skip_serializing_if = "Option::is_none")]\n'
         defi += f"    pub {e.name.normalized()}: Option<{typename}>,\n"
 
     return defi, decl
@@ -233,7 +233,7 @@ def rename_if_necessary(original, name):
     if str(original) != str(name):
         return f'    #[serde(rename = "{original}")]\n'
     else:
-        return f""
+        return ""
 
 
 def gen_array(a, meta, override=None):
@@ -318,7 +318,7 @@ class RustGenerator(IGenerator):
             #[allow(unused_imports)]
             use crate::primitives::*;
             #[allow(unused_imports)]
-            use serde::{{Deserialize, Serialize}};
+            use serde::{Deserialize, Serialize};
             use core::fmt::Debug;
             use std::collections::HashMap;
             use super::{IntoRequest, Request, TypedRequest};
@@ -366,7 +366,7 @@ class RustGenerator(IGenerator):
             #[allow(unused_imports)]
             use crate::primitives::*;
             #[allow(unused_imports)]
-            use serde::{{Deserialize, Serialize}};
+            use serde::{Deserialize, Serialize};
             use super::{TryFromResponseError, Response};
 
         """
@@ -403,13 +403,13 @@ class RustGenerator(IGenerator):
     def generate_enums(self, service: Service):
         """The Request and Response enums serve as parsing primitives."""
         self.write(
-            f"""\
-        use serde::{{Deserialize, Serialize}};
+            """\
+        use serde::{Deserialize, Serialize};
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
         #[serde(tag = "method", content = "params")]
         #[serde(rename_all = "lowercase")]
-        pub enum Request {{
+        pub enum Request {
         """
         )
 
@@ -423,13 +423,13 @@ class RustGenerator(IGenerator):
             )
 
         self.write(
-            f"""\
-        }}
+            """\
+        }
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
         #[serde(tag = "method", content = "result")]
         #[serde(rename_all = "lowercase")]
-        pub enum Response {{
+        pub enum Response {
         """
         )
 
@@ -443,8 +443,8 @@ class RustGenerator(IGenerator):
             )
 
         self.write(
-            f"""\
-        }}
+            """\
+        }
 
         """
         )

--- a/tests/autogenerate-rpc-examples.py
+++ b/tests/autogenerate-rpc-examples.py
@@ -391,7 +391,7 @@ def update_examples_in_schema_files():
     with open(TEMP_EXAMPLES_FILE, 'w+', encoding='utf-8') as file:
         json.dump({'new_values_list': NEW_VALUES_LIST, 'replace_response_values': REPLACE_RESPONSE_VALUES[4:], 'examples_json': EXAMPLES_JSON, 'updated_examples_json': updated_examples}, file, indent=2, ensure_ascii=False)
 
-    logger.info(f'Updated All Examples in Schema Files!')
+    logger.info('Updated All Examples in Schema Files!')
     return None
 
 
@@ -1138,12 +1138,12 @@ def generate_wait_examples(l1, l2, bitcoind, executor):
         if curr_blockheight < 130:
             bitcoind.generate_block(130 - curr_blockheight)
             sync_blockheight(bitcoind, [l2])
-        update_example(node=l2, method='waitblockheight', params={'blockheight': 126}, description=[f'This will return immediately since the current blockheight exceeds the requested waitblockheight.'])
+        update_example(node=l2, method='waitblockheight', params={'blockheight': 126}, description=['This will return immediately since the current blockheight exceeds the requested waitblockheight.'])
         wbh = executor.submit(l2.rpc.waitblockheight, curr_blockheight + 1, 600)
         bitcoind.generate_block(1)
         sync_blockheight(bitcoind, [l2])
         wbhres = wbh.result(5)
-        update_example(node=l2, method='waitblockheight', params={'blockheight': curr_blockheight + 1, 'timeout': 600}, response=wbhres, description=[f'This will return after the next block is mined because requested waitblockheight is one block higher than the current blockheight.'])
+        update_example(node=l2, method='waitblockheight', params={'blockheight': curr_blockheight + 1, 'timeout': 600}, response=wbhres, description=['This will return after the next block is mined because requested waitblockheight is one block higher than the current blockheight.'])
         REPLACE_RESPONSE_VALUES.extend([
             {'data_keys': ['payment_hash'], 'original_value': wspc_res['details']['payment_hash'], 'new_value': NEW_VALUES_LIST['payment_hash_wspc_1']},
             {'data_keys': ['paid_at'], 'original_value': waires['paid_at'], 'new_value': NEW_VALUES_LIST['time_at_850']},
@@ -1257,7 +1257,7 @@ def generate_utils_examples(l1, l2, l3, l4, l5, l6, c23_2, c34_2, inv_l11, inv_l
 
         # SQL
         update_example(node=l1, method='sql', params={'query': 'SELECT id FROM peers'}, description=['A simple peers selection query:'])
-        update_example(node=l1, method='sql', params=[f"SELECT label, description, status FROM invoices WHERE label='label inv_l12'"], description=["A statement containing `=` needs `-o` in shell:"])
+        update_example(node=l1, method='sql', params=["SELECT label, description, status FROM invoices WHERE label='label inv_l12'"], description=["A statement containing `=` needs `-o` in shell:"])
         sql_res3 = l1.rpc.sql(f"SELECT nodeid FROM nodes WHERE nodeid != x'{l3.info['id']}'")
         update_example(node=l1, method='sql', params=[f"SELECT nodeid FROM nodes WHERE nodeid != x'{NEW_VALUES_LIST['l3_id']}'"], description=['If you want to get specific nodeid values from the nodes table:'], response=sql_res3)
         sql_res4 = l1.rpc.sql(f"SELECT nodeid FROM nodes WHERE nodeid IN (x'{l1.info['id']}', x'{l3.info['id']}')")
@@ -1523,7 +1523,7 @@ def generate_channels_examples(node_factory, bitcoind, l1, l3, l4, l5):
         utxo = f"{outputs[0]['txid']}:{outputs[0]['output']}"
         c41res = update_example(node=l4, method='fundchannel',
                                 params={'id': l1.info['id'], 'amount': 'all', 'feerate': 'normal', 'push_msat': 100000, 'utxos': [utxo]},
-                                description=[f'This example shows how to to open new channel with peer 1 from one whole utxo (you can use **listfunds** command to get txid and vout):'])
+                                description=['This example shows how to to open new channel with peer 1 from one whole utxo (you can use **listfunds** command to get txid and vout):'])
         # Close newly funded channels to bring the setup back to initial state
         l3.rpc.close(c35res['channel_id'])
         l4.rpc.close(c41res['channel_id'])
@@ -1592,7 +1592,7 @@ def generate_channels_examples(node_factory, bitcoind, l1, l3, l4, l5):
         ]
         example_destinations_2 = [
             {
-                'id': f'fakenodeid' + ('03' * 28) + '@127.0.0.1:19736',
+                'id': 'fakenodeid' + ('03' * 28) + '@127.0.0.1:19736',
                 'amount': 50000
             },
             {
@@ -1695,7 +1695,7 @@ def generate_autoclean_delete_examples(l1, l2, l3, l4, l5, c12, c23):
     try:
         logger.info('Auto-clean and Delete Start...')
         l2.rpc.close(l5.info['id'])
-        dfc_res1 = update_example(node=l2, method='dev-forget-channel', params={'id': l5.info['id']}, description=[f'Forget a channel by peer pubkey when only one channel exists with the peer:'])
+        dfc_res1 = update_example(node=l2, method='dev-forget-channel', params={'id': l5.info['id']}, description=['Forget a channel by peer pubkey when only one channel exists with the peer:'])
 
         # Create invoices for delpay and delinvoice examples
         inv_l35 = l3.rpc.invoice('50000sat', 'lbl_l35', 'l35 description')
@@ -1740,7 +1740,7 @@ def generate_autoclean_delete_examples(l1, l2, l3, l4, l5, c12, c23):
             update_example(node=l2, method='delforward', params={'in_channel': c12, 'in_htlc_id': local_failed_forwards[0]['in_htlc_id'], 'status': 'local_failed'})
         if len(failed_forwards) > 0 and 'in_htlc_id' in failed_forwards[0]:
             update_example(node=l2, method='delforward', params={'in_channel': c12, 'in_htlc_id': failed_forwards[0]['in_htlc_id'], 'status': 'failed'})
-        dfc_res2 = update_example(node=l2, method='dev-forget-channel', params={'id': l3.info['id'], 'short_channel_id': c23, 'force': True}, description=[f'Forget a channel by short channel id when peer has multiple channels:'])
+        dfc_res2 = update_example(node=l2, method='dev-forget-channel', params={'id': l3.info['id'], 'short_channel_id': c23, 'force': True}, description=['Forget a channel by short channel id when peer has multiple channels:'])
 
         # Autoclean
         update_example(node=l2, method='autoclean-once', params=['failedpays', 1])

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4075,7 +4075,7 @@ def test_peer_anchor_push(node_factory, bitcoind, executor, chainparams):
         assert len(bitcoind.rpc.getrawmempool()) == 2
 
     # Feerate tops out at +1, so this is the same.  This time we mine it!
-    l2.daemon.wait_for_log(fr"Worth fee [0-9]*sat for remote commit tx to get 100000000msat at block 125 \(\+1\) at feerate 15000perkw")
+    l2.daemon.wait_for_log(r"Worth fee [0-9]*sat for remote commit tx to get 100000000msat at block 125 \(\+1\) at feerate 15000perkw")
     l2.daemon.wait_for_log("sendrawtx exit 0")
 
     bitcoind.generate_block(1, needfeerate=15000)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4831,7 +4831,7 @@ def test_networkevents(node_factory, executor):
                         'peer_id': l2.info['id'],
                         'type': 'connect_fail',
                         'connect_attempted': True,
-                        'reason': f'All addresses failed: 127.0.0.1:1: Connection establishment: Connection refused. '}]
+                        'reason': 'All addresses failed: 127.0.0.1:1: Connection establishment: Connection refused. '}]
 
     # Connect failed because unreachable
     with pytest.raises(RpcError, match="Connection establishment: Connection timed out."):
@@ -4844,7 +4844,7 @@ def test_networkevents(node_factory, executor):
                         'peer_id': l2.info['id'],
                         'type': 'connect_fail',
                         'connect_attempted': True,
-                        'reason': f'All addresses failed: 1.1.1.1:8081: Connection establishment: Connection timed out. '}]
+                        'reason': 'All addresses failed: 1.1.1.1:8081: Connection establishment: Connection timed out. '}]
 
     # Connect failed because it doesn't advertize any addresses.
     with pytest.raises(RpcError, match="Unable to connect, no address known for peer"):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3032,9 +3032,9 @@ def test_custommsg_triggers_notification(node_factory):
 
     # TODO: Check if the peer_id and payload matches
     peer_id = l2.info["id"]
-    l1.daemon.wait_for_log(f"Received a custommsg with data")
+    l1.daemon.wait_for_log("Received a custommsg with data")
     l1.daemon.wait_for_log(f"peer_id={peer_id}")
-    l1.daemon.wait_for_log(f"payload=77770012")
+    l1.daemon.wait_for_log("payload=77770012")
 
 
 def test_makesecret(node_factory):

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2223,7 +2223,7 @@ def test_zeroreserve_alldust(node_factory):
     l1.fundwallet(10**6)
     error = (f'channel funding {minfunding}sat too small for chosen parameters: '
              f'a total of {maxhtlc * 2} HTLCs with dust value {mindust}sat would '
-             f'result in a commitment_transaction without outputs')
+             'result in a commitment_transaction without outputs')
 
     # This is right on the edge, and should fail
     with pytest.raises(RpcError, match=error):
@@ -2921,7 +2921,7 @@ def test_zeroconf_withhold(node_factory, bitcoind, stay_withheld, mutual_close):
         funds = l1.rpc.listfunds()
         for utxo in funds['outputs']:
             assert utxo['status'] == 'confirmed', \
-                f"UTXO still reserved after withheld close"
+                "UTXO still reserved after withheld close"
     else:
         if mutual_close:
             wait_for(lambda: only_one(l1.rpc.listpeerchannels()['channels'])['state'] == 'CLOSINGD_COMPLETE')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4603,8 +4603,8 @@ def test_all_subscription(node_factory, directory):
         assert l2.daemon.is_in_log(f'.*test_libplugin: all: {notstr}.*')
 
     # shutdown and connect are subscribed before the wildcard, so is handled by that handler
-    assert not l2.daemon.is_in_log(f'.*test_libplugin: all: shutdown.*')
-    assert not l2.daemon.is_in_log(f'.*test_libplugin: all: connect.*')
+    assert not l2.daemon.is_in_log('.*test_libplugin: all: shutdown.*')
+    assert not l2.daemon.is_in_log('.*test_libplugin: all: connect.*')
 
 
 def test_dynamic_option_python_plugin(node_factory):
@@ -4714,7 +4714,7 @@ def test_sql_crash(node_factory, bitcoind):
     l1.rpc.fundchannel_start(l2.info['id'], '10000000sat')
 
     assert 'updates' not in only_one(l1.rpc.listpeerchannels()['channels'])
-    l1.rpc.sql(f"SELECT * FROM peerchannels;")
+    l1.rpc.sql("SELECT * FROM peerchannels;")
 
 
 def test_sql_parallel(node_factory, executor):
@@ -5070,7 +5070,7 @@ def test_pay_plugin_notifications(node_factory, bitcoind, chainparams):
     l1.rpc.pay(inv1['bolt11'])
 
     # It gets a channel hint update notification
-    line = l1.daemon.wait_for_log(f"plugin-all_notifications.py: notification channel_hint_update: ")
+    line = l1.daemon.wait_for_log("plugin-all_notifications.py: notification channel_hint_update: ")
     dict_str = line.split("notification channel_hint_update: ", 1)[1]
     data = zero_timestamps(ast.literal_eval(dict_str))
 
@@ -5087,7 +5087,7 @@ def test_pay_plugin_notifications(node_factory, bitcoind, chainparams):
     assert data == channel_hint_update
 
     # It gets a success notification
-    line = l1.daemon.wait_for_log(f"plugin-all_notifications.py: notification pay_success: ")
+    line = l1.daemon.wait_for_log("plugin-all_notifications.py: notification pay_success: ")
     dict_str = line.split("notification pay_success: ", 1)[1]
     data = ast.literal_eval(dict_str)
     success_core = {'payment_hash': inv1['payment_hash'],
@@ -5103,7 +5103,7 @@ def test_pay_plugin_notifications(node_factory, bitcoind, chainparams):
     with pytest.raises(RpcError, match="WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS"):
         l1.rpc.pay(inv2['bolt11'])
 
-    line = l1.daemon.wait_for_log(f"plugin-all_notifications.py: notification pay_failure: ")
+    line = l1.daemon.wait_for_log("plugin-all_notifications.py: notification pay_failure: ")
     dict_str = line.split("notification pay_failure: ", 1)[1]
     data = ast.literal_eval(dict_str)
     failure_core = {'payment_hash': inv2['payment_hash'], 'bolt11': inv2['bolt11'], 'error': {'message': 'failed: WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (reply from remote)'}}

--- a/tests/test_reckless.py
+++ b/tests/test_reckless.py
@@ -88,7 +88,7 @@ def canned_github_server(directory):
     yield
     # Delete requirements.txt from the testplugpass directory
     with open(requirements_file_path, 'w') as f:
-        f.write(f"pyln-client\n\n")
+        f.write("pyln-client\n\n")
     server.terminate()
 
 
@@ -100,7 +100,7 @@ class RecklessResult:
         self.stderr = stderr
 
     def __repr__(self):
-        return f'self.returncode, self.stdout, self.stderr'
+        return 'self.returncode, self.stdout, self.stderr'
 
     def search_stdout(self, regex):
         """return the matching regex line from reckless output."""

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1881,7 +1881,7 @@ def test_bip86_deterministic_addresses(node_factory):
     assert addr1_1 == addr2_1, f"Addresses for index 1 don't match: {addr1_1} != {addr2_1}"
 
     # Addresses should be different for different indices
-    assert addr1_0 != addr1_1, f"Addresses for different indices should be different"
+    assert addr1_0 != addr1_1, "Addresses for different indices should be different"
 
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', "BIP86 tests are regtest-specific")
@@ -2874,7 +2874,7 @@ def test_rescan_missing_utxo(node_factory, bitcoind):
     l3.daemon.wait_for_log("Scanning for missed UTXOs finished")
 
     # Found it?
-    assert only_one(l3.db_query(f"SELECT spendheight as spendheight FROM utxoset WHERE blockheight=103 AND txindex=1"))['spendheight'] == 129
+    assert only_one(l3.db_query("SELECT spendheight as spendheight FROM utxoset WHERE blockheight=103 AND txindex=1"))['spendheight'] == 129
 
     # Restart will NOT invoke scan.
     oldstart_l3 = l3.daemon.logsearch_start

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -630,7 +630,7 @@ def test_xpay_no_mpp(node_factory, chainparams):
                                           f"currency={chainparams['bip173_prefix']}",
                                           f"p={no_mpp['payment_hash']}",
                                           f"s={no_mpp['payment_secret']}",
-                                          f"d=Paying l3 without mpp",
+                                          "d=Paying l3 without mpp",
                                           f"amount={AMOUNT}"]).decode('utf-8').strip()
 
     # This should not mpp!


### PR DESCRIPTION
Changelog-None

## About PR
This PR fixes flake8 F541 (f-strings missing placeholders) by replacing f-strings that contain no placeholders with plain strings in the lightning test files. These were lint errors only but reduce noise and avoid confusion.

## Why
F541 indicates an f-string with no {} placeholders — likely a typo. Replacing with a plain string removes the lint error and clarifies intent.

## How to Test
flake8 lightning/tests || true

## Checklist
- [x] Changelog-None
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] Important All PRs must consider how to reverse any persistent changes for tools/lightning-downgrade