### PR TITLE
installation.md: Fixed syntax in dependencies script for Fedora

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -158,8 +158,8 @@ Get dependencies:
 ```shell
 sudo dnf update -y && \
         sudo dnf groupinstall -y \
-                'C Development Tools and Libraries' \
-                'Development Tools' && \
+                'c-development' \
+                'development-tools' && \
         sudo dnf install -y \
                 clang \
                 gettext \
@@ -179,7 +179,8 @@ sudo dnf update -y && \
                 sed \
                 protobuf-compiler \
                 protobuf-devel \
-                postgresql-devel && \
+                postgresql-devel \
+                python3-mako && \
         sudo dnf clean all
 ```
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

# Fixed syntax error
The new dnf5 version needed some modification to the dependencies installation script.
The overall installation.md guide about Fedora-based systems is still not working though. Linking related [issue](https://github.com/ElementsProject/lightning/issues/8930).

Tested on Fedora v43

Changelog-None.
