### PR TITLE
chaintopology: fix infinite RBF loop after replacement tx is confirmed

### DIFF
--- a/lightningd/chaintopology.c
+++ b/lightningd/chaintopology.c
@@ -166,8 +166,13 @@ static void rebroadcast_txs(struct chain_topology *topo)
 	for (otx = outgoing_tx_map_first(topo->outgoing_txs, &it); otx;
 	     otx = outgoing_tx_map_next(topo->outgoing_txs, &it)) {
 		struct tx_rebroadcast *txrb;
-		/* Already sent? */
-		if (wallet_transaction_height(topo->ld->wallet, &otx->txid))
+		struct bitcoin_txid cur_txid;
+
+		/* Already confirmed?  Use the txid of the current tx, not the
+		 * original otx->txid: refresh() may have replaced otx->tx with
+		 * a higher-fee version whose txid differs from the map key. */
+		bitcoin_txid(otx->tx, &cur_txid);
+		if (wallet_transaction_height(topo->ld->wallet, &cur_txid))
 			continue;
 
 		/* Don't send ones which aren't ready yet.  Note that if the

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1725,6 +1725,77 @@ def test_penalty_rbf_normal(node_factory, bitcoind, executor, chainparams, ancho
     check_utxos_channel(l2, [channel_id], expected_2)
 
 
+def test_onchain_rbf_stops_after_confirmation(node_factory, bitcoind):
+    """Penalty tx RBF stops once the replacement tx is confirmed."""
+
+    to_self_delay = 10
+    opts = {'watchtime-blocks': to_self_delay, 'dev-force-features': "-23"}
+
+    # l1 is the thief; allow it to fail.
+    l1 = node_factory.get_node(options=opts, may_fail=True)
+    l2 = node_factory.get_node(options=opts)
+
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+    l1.fundchannel(l2, 10**7)
+
+    # Save l1's current commitment before it is revoked.
+    theft_tx = l1.rpc.dev_sign_last_tx(l2.info['id'])['tx']
+
+    # Advance the commitment state — the saved commitment is now revoked.
+    l1.pay(l2, 1000000)
+    l1.rpc.stop()
+
+    # Censor l2 so the penalty tx never reaches miners.
+    def censoring_sendrawtx(r):
+        return {'id': r['id'], 'result': {}}
+    l2.daemon.rpcproxy.mock_rpc('sendrawtransaction', censoring_sendrawtx)
+
+    # l1 broadcasts the revoked commitment.
+    bitcoind.rpc.sendrawtransaction(theft_tx)
+    bitcoind.generate_block(1)
+    l2.daemon.wait_for_log(' to ONCHAIN')
+
+    _, txid, blocks = l2.wait_for_onchaind_tx('OUR_PENALTY_TX',
+                                              'THEIR_REVOKED_UNILATERAL/DELAYED_CHEAT_OUTPUT_TO_THEM')
+    assert blocks == 0  # penalty tx is immediately broadcastable
+
+    # Each block brings the deadline (close_blockheight + to_self_delay) closer
+    # so feerate_for_target() returns a higher fee and onchaind emits INFO-level "RBF onchain txid".
+    for _ in range(3):
+        bitcoind.generate_block(1)
+        l2.daemon.wait_for_log('RBF onchain txid')
+
+    # Stop censoring.  Generate a block to trigger rebroadcast (the penalty tx
+    # enters bitcoind's mempool) but filter it out so the next block mines it.
+    l2.daemon.rpcproxy.mock_rpc('sendrawtransaction', None)
+    bitcoind.generate_block(1, needfeerate=10000000)
+    l2.daemon.wait_for_log('RBF onchain txid')
+
+    # Mine the penalty tx (single output, no in-flight HTLCs).
+    bitcoind.generate_block(1, wait_for_mempool=1)
+    sync_blockheight(bitcoind, [l2])
+
+    l2.daemon.wait_for_log('Resolved THEIR_REVOKED_UNILATERAL/DELAYED_CHEAT_OUTPUT_TO_THEM'
+                           ' by our proposal OUR_PENALTY_TX')
+
+    # Record log position right after confirmation.
+    log_pos = l2.daemon.logsearch_start
+
+    # Bump feerate: any spurious rebroadcast would compute a higher fee
+    # (newfee > info->fee) and emit "RBF onchain txid" at INFO level.
+    # Without the fix: wallet_transaction_height(original_txid) returns 0
+    # because the stale original txid was never mined (only the replacement
+    # was), so consider_onchain_rebroadcast keeps firing indefinitely.
+    l2.set_feerates([10000] * 4, False)
+
+    # rebroadcast_txs() fires on every new block (chaintopology.c ~line 854).
+    bitcoind.generate_block(2)
+    sync_blockheight(bitcoind, [l2])
+
+    assert not l2.daemon.is_in_log('RBF onchain txid', start=log_pos), \
+        "node kept RBF-ing penalty tx after the replacement was confirmed"
+
+
 def test_onchain_first_commit(node_factory, bitcoind):
     """Onchain handling where opener immediately drops to chain"""
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

## Problem
This issue raised twice. Last time has been raised on #8921.
`rebroadcast_txs()` in `lightningd/chaintopology.c` iterates over all pending outgoing transactions once per block and, for each one, asks: *"has this tx already been confirmed?"* before deciding whether to rebroadcast or RBF it.  The confirmation check is:

```c
if (wallet_transaction_height(topo->ld->wallet, &otx->txid))
    continue;
```

`otx->txid` is initialised from the tx that was originally broadcast and is also the key of the `outgoing_tx_map` hash table.  It is **never updated** after a replacement (RBF) transaction is created.

When `otx->refresh` (i.e. `consider_onchain_rebroadcast()`) is called, it may produce a higher-fee replacement and write it into `otx->tx`.  The replacement has a *different* txid, but `otx->txid` still holds the original.  The original was never mined (only the replacement was) so `wallet_transaction_height(original_txid)` returns 0 forever, the `continue`
is never taken, and `consider_onchain_rebroadcast` is invoked on every subsequent block even though the output is already resolved.

### Test scenario rationale: Why penalty transactions trigger this and to-local sweeps do not

The bug requires actual fee escalation to be observable: `consider_onchain_rebroadcast` only emits an INFO log and produces a new tx when `newfee > info->fee`.  Fee escalation happens when `feerate_for_target(deadline)` returns an increasing value.

* **Penalty tx** — deadline is `close_blockheight + to_self_delay`.  With   `watchtime-blocks = 10` the deadline is only 10 blocks away at close, so `feerate_for_target` returns a higher value on each new block.
* **To-local sweep** — deadline is `slow_sweep_deadline` (~300 blocks, hardcoded).  `feerate_for_target` returns `FEERATE_FLOOR` until the sweep is imminent, so fees never change, no new tx is produced, and the bug is
  invisible.

### Why mutating `otx->txid` directly would crash

The first attempted fix (`bitcoin_txid(otx->tx, &otx->txid)` after the refresh call) caused a `SIGABRT` / `SIGSEGV` on shutdown.  `otx->txid` is the key of the `outgoing_tx_map` htable (`keyof_outgoing_tx_map` returns `&t->txid`).  Changing the key in-place while the entry lives in the table corrupts its internal bucket chain, producing a use-after-free when the topology is torn down in `destroy_chain_topology`.

## Suggested Fix

Instead of storing a separate up-to-date txid (which would require touching the map key or adding a new field), we compute the txid of the *current* `otx->tx` on the fly at the top of the loop:

```c
struct bitcoin_txid cur_txid;
bitcoin_txid(otx->tx, &cur_txid);
if (wallet_transaction_height(topo->ld->wallet, &cur_txid))
    continue;
```

`otx->tx` is always the latest version of the transaction: it is set to the original tx at broadcast time and updated by each successful `refresh()` call. So `bitcoin_txid(otx->tx)` naturally tracks whichever version was most recently
broadcast (including any RBF replacement) without touching the map key.

`otx->txid` is left completely unchanged.

The SHA-256d required by `bitcoin_txid` is negligible compared with the round-trip to bitcoind that follows immediately; the cost is not a concern.