### PR TITLE
xpay: handle pay ignoring unknown arguments

### DIFF
--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -2457,10 +2457,9 @@ static struct command_result *handle_rpc_command(struct command *cmd,
 				maxdelay = t + 1;
 			else {
 				plugin_log(cmd->plugin, LOG_INFORM,
-					   "Not redirecting pay (unknown arg %.*s)",
+					   "Unknown arg %.*s, xpay will ignore it.",
 					   json_tok_full_len(t),
 					   json_tok_full(buf, t));
-				goto dont_redirect;
 			}
 		}
 	} else {

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -450,14 +450,16 @@ def test_xpay_takeover(node_factory, executor):
                              inv, "10000", 'label'])
     l1.daemon.wait_for_log(r'Not redirecting pay \(only handle 1 or 2 args\): ')
 
-    # Other args fail.
+    # Other args are ignored.
     inv = l3.rpc.invoice('any', "test_xpay_takeover7", "test_xpay_takeover7")
     l1.rpc.pay(inv['bolt11'], amount_msat=10000, label='test_xpay_takeover7')
-    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg "label"\)')
+    l1.daemon.wait_for_log('Unknown arg "label", xpay will ignore it.')
+    l1.daemon.wait_for_log('Redirecting pay->xpay')
 
     inv = l3.rpc.invoice('any', "test_xpay_takeover8", "test_xpay_takeover8")
     l1.rpc.pay(inv['bolt11'], amount_msat=10000, riskfactor=1)
-    l1.daemon.wait_for_log(r'Not redirecting pay \(unknown arg "riskfactor"\)')
+    l1.daemon.wait_for_log('Unknown arg "riskfactor", xpay will ignore it.')
+    l1.daemon.wait_for_log('Redirecting pay->xpay')
 
     # Test that it's really dynamic.
     l1.rpc.setconfig('xpay-handle-pay', False)


### PR DESCRIPTION
If `xpay-handle-pay` is true we redirect to `xpay` and ignore unknown arguments without falling back to `pay`.

Fixes issue #8928.