### PR TITLE
rust libraries: update bitcoin to 0.32.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,8 +265,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin-internals",
+ "bitcoin_hashes",
 ]
 
 [[package]]
@@ -283,30 +283,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
-name = "bitcoin"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals 0.2.0",
- "bitcoin_hashes 0.13.0",
- "hex-conservative 0.1.2",
- "hex_lit",
- "secp256k1 0.28.2",
- "serde",
-]
 
 [[package]]
 name = "bitcoin"
@@ -315,22 +294,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
- "bech32 0.11.1",
- "bitcoin-internals 0.3.0",
+ "bech32",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
- "hex-conservative 0.2.2",
+ "bitcoin_hashes",
+ "hex-conservative",
  "hex_lit",
- "secp256k1 0.29.1",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-dependencies = [
+ "secp256k1",
  "serde",
 ]
 
@@ -339,6 +310,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -352,7 +326,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd1e2069af33b2796a0d81097ffbe42eb0e85f9d9890bfc022f6960433f7399"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin",
  "dnssec-prover",
  "getrandom 0.3.4",
  "lightning",
@@ -368,17 +342,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals 0.3.0",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
+ "bitcoin-internals",
  "serde",
 ]
 
@@ -389,7 +353,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.2",
+ "hex-conservative",
+ "serde",
 ]
 
 [[package]]
@@ -469,7 +434,7 @@ name = "cln-bip353"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitcoin 0.32.8",
+ "bitcoin",
  "bitcoin-payment-instructions",
  "bytes",
  "cln-plugin",
@@ -502,10 +467,10 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
- "bitcoin 0.31.2",
+ "bitcoin",
  "cfg-if",
  "cln-rpc",
  "futures-core",
@@ -539,11 +504,11 @@ dependencies = [
 
 [[package]]
 name = "cln-lsps"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.31.2",
+ "bitcoin",
  "chrono",
  "cln-plugin",
  "cln-rpc",
@@ -559,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -577,10 +542,10 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
- "bitcoin 0.31.2",
+ "bitcoin",
  "bytes",
  "env_logger",
  "futures-util",
@@ -756,7 +721,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
  "tokio",
 ]
 
@@ -1105,12 +1070,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -1559,8 +1518,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
 dependencies = [
- "bech32 0.11.1",
- "bitcoin 0.32.8",
+ "bech32",
+ "bitcoin",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
@@ -1575,8 +1534,8 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
- "bech32 0.11.1",
- "bitcoin 0.32.8",
+ "bech32",
+ "bitcoin",
  "lightning-types",
 ]
 
@@ -1586,7 +1545,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin",
 ]
 
 [[package]]
@@ -2484,32 +2443,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "secp256k1-sys 0.9.2",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
-dependencies = [
- "cc",
+ "bitcoin_hashes",
+ "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ members = [
 ]
 
 [workspace.dependencies]
-cln-rpc = { path = "cln-rpc", version = "0.5.0" }
-cln-grpc = { path = "cln-grpc", version = "0.5.0" }
-cln-plugin = { path = "plugins", version = "0.5.0" }
+cln-rpc = { path = "cln-rpc", version = "0.6.0" }
+cln-grpc = { path = "cln-grpc", version = "0.6.0" }
+cln-plugin = { path = "plugins", version = "0.6.0" }

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 tonic = { version = "0.11", features = ["tls", "transport"] }
 prost = "0.12"
 hex = "0.4.3"
-bitcoin = { version = "0.31", features = ["serde"] }
+bitcoin = { version = "0.32.2", features = ["serde"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio = { version = "1.36.0", features = ["sync"] }
 futures-core = "0.3.30"

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-rpc"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "An async RPC client for Core Lightning."
@@ -14,7 +14,7 @@ path = "examples/getinfo.rs"
 
 [dependencies]
 anyhow = "1.0"
-bitcoin = { version = "0.31", features = [ "serde" ] }
+bitcoin = { version = "0.32.2", features = [ "serde" ] }
 bytes = "1"
 futures-util = { version = "0.3", features = [ "sink" ] }
 hex = "0.4.3"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-plugin"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."

--- a/plugins/bip353-plugin/Cargo.toml
+++ b/plugins/bip353-plugin/Cargo.toml
@@ -17,7 +17,7 @@ tokio = "1"
 
 log-panics = "2"
 
-cln-plugin = { version = "0.5", path = "../../plugins" }
+cln-plugin = { workspace = true }
 
 bitcoin-payment-instructions = { version = "0.5.0", features = ["http"] }
 

--- a/plugins/lsps-plugin/Cargo.toml
+++ b/plugins/lsps-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-lsps"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]
@@ -14,7 +14,7 @@ path = "src/service.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bitcoin = "0.31"
+bitcoin = "0.32.2"
 chrono = { version= "0.4.42", features = ["serde"] }
 cln-plugin = { workspace = true }
 cln-rpc = { workspace = true }


### PR DESCRIPTION
Boost cln-rpc, cln-grpc, cln-plugin and lsps-plugin versions to use bitcoin 0.32.2 for compatibility with rust lightning libraries.

Changelog-None.