### PR TITLE
Test to reproduce `MEMLEAK` caused by `openchannel_update` by passing wrong psbt

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3045,9 +3045,9 @@ def test_openchannel_wrong_psbt_doesnt_crash_peer(node_factory, bitcoind):
 
     # Build two PSBTs spending different UTXOs
     psbt_a_res = l1.rpc.utxopsbt(chan_amount, 'opening', 250, [utxo_a],
-                                  excess_as_change=True)
+                                 excess_as_change=True)
     psbt_b = l1.rpc.utxopsbt(chan_amount, 'opening', 250, [utxo_b],
-                              excess_as_change=True)['psbt']
+                             excess_as_change=True)['psbt']
     funding_feerate = '{}perkw'.format(psbt_a_res['feerate_per_kw'])
 
     init = l1.rpc.openchannel_init(l2.info['id'], chan_amount, psbt_a_res['psbt'],

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3018,3 +3018,44 @@ def test_zeroconf_withhold_htlc_failback(node_factory, bitcoind):
 
     # l1's channel to l2 is still normal — no force-close
     assert only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['state'] == 'CHANNELD_NORMAL'
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+@pytest.mark.openchannel('v2')
+def test_openchannel_wrong_psbt_doesnt_crash_peer(node_factory, bitcoind):
+    """Test passing a wrong PSBT to openchannel_update must not crash the peer.
+    """
+    l1, l2 = node_factory.get_nodes(2, opts={'may_reconnect': True})
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    chan_amount = 100000
+    amount_btc = 0.02
+
+    # Fund l1 with two separate UTXOs so we can build two genuinely different PSBTs
+    bitcoind.rpc.sendmany("", {
+        l1.rpc.newaddr()['p2tr']: amount_btc,
+        l1.rpc.newaddr()['p2tr']: amount_btc,
+    })
+    bitcoind.generate_block(1)
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) >= 2)
+
+    utxos = l1.rpc.listfunds()['outputs']
+    utxo_a = '{}:{}'.format(utxos[0]['txid'], utxos[0]['output'])
+    utxo_b = '{}:{}'.format(utxos[1]['txid'], utxos[1]['output'])
+
+    # Build two PSBTs spending different UTXOs
+    psbt_a_res = l1.rpc.utxopsbt(chan_amount, 'opening', 250, [utxo_a],
+                                  excess_as_change=True)
+    psbt_b = l1.rpc.utxopsbt(chan_amount, 'opening', 250, [utxo_b],
+                              excess_as_change=True)['psbt']
+    funding_feerate = '{}perkw'.format(psbt_a_res['feerate_per_kw'])
+
+    init = l1.rpc.openchannel_init(l2.info['id'], chan_amount, psbt_a_res['psbt'],
+                                   funding_feerate=funding_feerate)
+    chan_id = init['channel_id']
+
+    # Pass the wrong PSBT (different inputs).
+    l1.rpc.call('openchannel_update', {'channel_id': chan_id, 'psbt': psbt_b})
+
+    # AFTER FIXME:l2 must still be running and responsive
+    # assert l2.rpc.getinfo()['id'] == l2.info['id']


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Test to reproduce #8954

Changelog-None