### PR TITLE
CI: Update Mac CI to use gmake

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           export PATH="/usr/local/opt:/Users/runner/.local/bin:/opt/homebrew/bin/python3.10/bin:$PATH"
 
-          brew install gnu-sed autoconf automake libtool protobuf openssl lowdown libsodium
+          brew install gnu-sed autoconf automake libtool protobuf openssl lowdown libsodium make
 
           # https://github.com/grpc/grpc/issues/31737#issuecomment-1323796842
           export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -50,7 +50,7 @@ jobs:
           export LIBRARY_PATH=/opt/homebrew/lib
 
           uv run ./configure --disable-valgrind --disable-compat
-          uv run make
+          uv run gmake
 
       - name: Start bitcoind in regtest mode
         run: |


### PR DESCRIPTION
`gmake` is kept up to date while `make` is apple’s built in mac that is not updated and very old at this point.