### PR TITLE
msggen: Add UnionField support to future oneOf fields for oneOf schemas

### DIFF
--- a/contrib/msggen/msggen/checks.py
+++ b/contrib/msggen/msggen/checks.py
@@ -15,6 +15,10 @@ class Check(ABC):
             if isinstance(f, model.ArrayField):
                 self.visit(f.itemtype)
                 recurse(f.itemtype)
+            elif isinstance(f, model.UnionField):
+                for v in f.variants:
+                    self.visit(v)
+                    recurse(v)
             elif isinstance(f, model.CompositeField):
                 for c in f.fields:
                     self.visit(c)

--- a/contrib/msggen/msggen/gen/grpc/convert.py
+++ b/contrib/msggen/msggen/gen/grpc/convert.py
@@ -1,6 +1,7 @@
 # A grpc model
-from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, Service
-from msggen.gen.grpc.util import notification_typename_overrides
+from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, UnionField, Service
+from msggen.gen.grpc.util import notification_typename_overrides, camel_to_snake, union_variant_suffix
+from msggen.gen.rpc.rust import union_variant_name
 from msggen.gen import IGenerator
 from typing import TextIO
 from textwrap import indent, dedent
@@ -16,6 +17,86 @@ class GrpcConverterGenerator(IGenerator):
     def generate_array(self, prefix, field: ArrayField, override):
         if isinstance(field.itemtype, CompositeField):
             self.generate_composite(prefix, field.itemtype, override)
+
+    def union_variant_conversion(self, f, val="v"):
+        """Generate the conversion expression for a single union variant value."""
+        if isinstance(f, PrimitiveField):
+            mapping = {
+                "short_channel_id": f"{val}.to_string()",
+                "short_channel_id_dir": f"{val}.to_string()",
+                "pubkey": f"{val}.serialize().to_vec()",
+                "hex": f"hex::decode({val}).unwrap()",
+                "txid": f"hex::decode({val}).unwrap()",
+                "hash": f"<Sha256 as AsRef<[u8]>>::as_ref(&{val}).to_vec()",
+                "secret": f"{val}.to_vec()",
+                "msat": f"{val}.into()",
+                "msat_or_all": f"{val}.into()",
+                "msat_or_any": f"{val}.into()",
+                "sat": f"{val}.into()",
+                "sat_or_all": f"{val}.into()",
+                "feerate": f"{val}.into()",
+                "outpoint": f"{val}.into()",
+            }.get(f.typename, val)
+            return mapping
+        elif isinstance(f, ArrayField):
+            inner_mapping = {
+                "short_channel_id": "i.to_string()",
+                "short_channel_id_dir": "i.to_string()",
+                "pubkey": "i.serialize().to_vec()",
+                "hex": "hex::decode(i).unwrap()",
+                "txid": "hex::decode(i).unwrap()",
+            }.get(f.itemtype.typename, "i.into()")
+            return f"{val}.into_iter().map(|i| {inner_mapping}).collect()"
+        elif isinstance(f, EnumField):
+            return f"{val} as i32"
+        elif isinstance(f, CompositeField):
+            return f"{val}.into()"
+        return val
+
+    def generate_union(self, prefix, field: UnionField, parent_typename, override=None):
+        """Generate From impl for a union type (cln-rpc enum -> pb oneof)."""
+        if override is None:
+            override = lambda x: x
+
+        typename = str(field.typename)
+        pbname = override(self.to_camel_case(str(override(parent_typename))))
+        pb_mod = camel_to_snake(pbname)
+        oneof_name = field.normalized()
+        # The prost enum name is CamelCase of the oneof field name
+        pb_oneof_enum = self.to_camel_case(oneof_name[0].upper() + oneof_name[1:])
+
+        self.write(
+            f"""\
+        impl From<{prefix}::{typename}> for pb::{pb_mod}::{pb_oneof_enum} {{
+            fn from(c: {prefix}::{typename}) -> Self {{
+                match c {{
+        """
+        )
+
+        for v in field.variants:
+            vname = union_variant_name(v)
+            suffix = union_variant_suffix(v)
+            pb_variant = self.to_camel_case(f"{oneof_name}_{suffix}")
+            pb_variant = pb_variant[0].upper() + pb_variant[1:]
+            if isinstance(v, ArrayField):
+                wrapper_name = override(f"{parent_typename}{suffix}Wrapper")
+                wrapper_pb = self.to_camel_case(str(wrapper_name))
+                self.write(
+                    f"            {prefix}::{typename}::{vname}(v) => pb::{pb_mod}::{pb_oneof_enum}::{pb_variant}(pb::{wrapper_pb} {{ items: v.into_iter().map(|i| {self.union_variant_conversion(v.itemtype, 'i')}).collect() }}),\n"
+                )
+            else:
+                self.write(
+                    f"            {prefix}::{typename}::{vname}(v) => pb::{pb_mod}::{pb_oneof_enum}::{pb_variant}({self.union_variant_conversion(v)}),\n"
+                )
+
+        self.write(
+            f"""\
+                }}
+            }}
+        }}
+
+        """
+        )
 
     def generate_composite(self, prefix, field: CompositeField, override=None):
         """Generates the conversions from JSON-RPC to GRPC."""
@@ -34,6 +115,8 @@ class GrpcConverterGenerator(IGenerator):
                 self.generate_array(prefix, f, override)
             elif isinstance(f, CompositeField):
                 self.generate_composite(prefix, f, override)
+            elif isinstance(f, UnionField):
+                self.generate_union(prefix, f, str(field.typename), override)
 
         pbname = override(self.to_camel_case(str(override(field.typename))))
 
@@ -153,6 +236,13 @@ class GrpcConverterGenerator(IGenerator):
                 else:
                     rhs = f"c.{name}.map(|v| v.into())"
                 self.write(f"{name}: {rhs},\n", numindent=3)
+
+            elif isinstance(f, UnionField):
+                if not f.optional:
+                    self.write(f"{name}: Some(c.{name}.into()),\n", numindent=3)
+                else:
+                    self.write(f"{name}: c.{name}.map(|v| v.into()),\n", numindent=3)
+
         self.write(
             f"""\
                 }}

--- a/contrib/msggen/msggen/gen/grpc/proto.py
+++ b/contrib/msggen/msggen/gen/grpc/proto.py
@@ -8,6 +8,7 @@ from msggen.gen.grpc.util import (
     typemap,
     method_name_overrides,
     notification_typename_overrides,
+    union_variant_suffix,
 )
 from msggen.model import (
     ArrayField,
@@ -15,6 +16,7 @@ from msggen.model import (
     CompositeField,
     EnumField,
     PrimitiveField,
+    UnionField,
     Service,
     MethodName,
     TypeName,
@@ -177,6 +179,32 @@ class GrpcGenerator(IGenerator):
 
         self.write(f"""{prefix}}}\n""", False)
 
+    def union_variant_proto_type(self, f, parent_typename):
+        """Return the protobuf type name for a union variant field."""
+        if isinstance(f, PrimitiveField):
+            return typemap.get(f.typename, f.typename)
+        elif isinstance(f, EnumField):
+            return str(f.typename)
+        elif isinstance(f, CompositeField):
+            return str(f.typename)
+        elif isinstance(f, ArrayField):
+            # oneof cannot contain repeated, so we need a wrapper message
+            return f"{parent_typename}{union_variant_suffix(f)}Wrapper"
+        return "bytes"
+
+    def generate_union_wrapper_messages(self, u: UnionField, parent_typename, typename_override=None):
+        """Generate wrapper messages for array variants inside a union (oneof can't contain repeated)."""
+        if typename_override is None:
+            typename_override = lambda x: x
+
+        for v in u.variants:
+            if isinstance(v, ArrayField):
+                wrapper_name = f"{parent_typename}{union_variant_suffix(v)}Wrapper"
+                item_type = typemap.get(v.itemtype.typename, v.itemtype.typename)
+                self.write(f"\nmessage {typename_override(wrapper_name)} {{\n", False)
+                self.write(f"\trepeated {item_type} items = 1;\n", False)
+                self.write(f"}}\n", False)
+
     def generate_message(self, message: CompositeField, typename_override=None):
         if message.omit():
             return
@@ -185,6 +213,11 @@ class GrpcGenerator(IGenerator):
         # This is equivalent to do not override
         if typename_override is None:
             typename_override = lambda x: x
+
+        # Generate wrapper messages for any union fields first
+        for f in message.fields:
+            if isinstance(f, UnionField):
+                self.generate_union_wrapper_messages(f, str(message.typename), typename_override)
 
         self.write(
             f"""
@@ -203,7 +236,26 @@ class GrpcGenerator(IGenerator):
 
             opt = "optional " if f.optional and not (isinstance(f, PrimitiveField) and f.typename == "string_map") else ""
 
-            if isinstance(f, ArrayField):
+            if isinstance(f, UnionField):
+                self.write(f"\toneof {f.normalized()} {{\n", False)
+                first_variant = True
+                for v in f.variants:
+                    suffix = union_variant_suffix(v)
+                    vname = f"{f.normalized()}_{suffix}"
+                    vtype = self.union_variant_proto_type(v, str(message.typename))
+                    vtype = typename_override(vtype)
+                    if first_variant:
+                        # Reuse the original field number for backward compat
+                        vnum = i
+                        first_variant = False
+                    else:
+                        # Allocate new numbers for additional variants
+                        parent = ".".join(f.path.split(".")[:-1])
+                        vfield = PrimitiveField(suffix, f"{parent}.{f.normalized()}_{suffix}", "", added=f.added, deprecated=f.deprecated)
+                        vnum = self.field2number(message.typename, vfield)
+                    self.write(f"\t\t{vtype} {vname} = {vnum};\n", False)
+                self.write(f"\t}}\n", False)
+            elif isinstance(f, ArrayField):
                 typename = f.override(
                     typemap.get(f.itemtype.typename, f.itemtype.typename)
                 )
@@ -264,5 +316,8 @@ def gather_subfields(field: Field) -> List[Field]:
     elif isinstance(field, ArrayField):
         fields = []
         fields.extend(gather_subfields(field.itemtype))
+    elif isinstance(field, UnionField):
+        for v in field.variants:
+            fields.extend(gather_subfields(v))
 
     return fields

--- a/contrib/msggen/msggen/gen/grpc/unconvert.py
+++ b/contrib/msggen/msggen/gen/grpc/unconvert.py
@@ -1,6 +1,8 @@
 # A grpc model
-from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, Service
+from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, UnionField, Service
 from msggen.gen.grpc.convert import GrpcConverterGenerator
+from msggen.gen.grpc.util import camel_to_snake, union_variant_suffix
+from msggen.gen.rpc.rust import union_variant_name
 
 
 class GrpcUnconverterGenerator(GrpcConverterGenerator):
@@ -11,6 +13,79 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
 
         # TODO Temporarily disabled since the use of overrides is lossy
         # self.generate_responses(service)
+
+    def unconvert_variant_value(self, f, val="v"):
+        """Generate the reverse conversion expression for a union variant value (pb -> cln-rpc)."""
+        if isinstance(f, PrimitiveField):
+            return {
+                "short_channel_id": f"cln_rpc::primitives::ShortChannelId::from_str(&{val}).unwrap()",
+                "short_channel_id_dir": f"cln_rpc::primitives::ShortChannelIdDir::from_str(&{val}).unwrap()",
+                "pubkey": f"PublicKey::from_slice(&{val}).unwrap()",
+                "hex": f"hex::encode({val})",
+                "txid": f"hex::encode({val})",
+                "hash": f"Sha256::from_slice(&{val}).unwrap()",
+                "secret": f"{val}.try_into().unwrap()",
+                "msat": f"{val}.into()",
+                "msat_or_all": f"{val}.into()",
+                "msat_or_any": f"{val}.into()",
+                "sat": f"{val}.into()",
+                "sat_or_all": f"{val}.into()",
+                "feerate": f"{val}.into()",
+                "outpoint": f"{val}.into()",
+            }.get(f.typename, val)
+        elif isinstance(f, ArrayField):
+            inner_mapping = {
+                "short_channel_id": "cln_rpc::primitives::ShortChannelId::from_str(&s).unwrap()",
+                "short_channel_id_dir": "cln_rpc::primitives::ShortChannelIdDir::from_str(&s).unwrap()",
+                "pubkey": "PublicKey::from_slice(&s).unwrap()",
+                "hex": "hex::encode(s)",
+                "txid": "hex::encode(s)",
+            }.get(f.itemtype.typename, "s.into()")
+            return f"{val}.items.into_iter().map(|s| {inner_mapping}).collect()"
+        elif isinstance(f, EnumField):
+            return f"{val}.try_into().unwrap()"
+        elif isinstance(f, CompositeField):
+            return f"{val}.into()"
+        return val
+
+    def generate_union_unconvert(self, prefix, field: UnionField, parent_typename, override=None):
+        """Generate From impl for pb oneof -> cln-rpc union type."""
+        if override is None:
+            override = lambda x: x
+
+        typename = str(field.typename)
+        pbname = self.to_camel_case(str(parent_typename))
+        pb_mod = camel_to_snake(pbname)
+        oneof_name = field.normalized()
+        pb_oneof_enum = self.to_camel_case(oneof_name[0].upper() + oneof_name[1:])
+
+        self.write(
+            f"""\
+        impl From<pb::{pb_mod}::{pb_oneof_enum}> for {prefix}::{typename} {{
+            fn from(c: pb::{pb_mod}::{pb_oneof_enum}) -> Self {{
+                match c {{
+        """
+        )
+
+        for v in field.variants:
+            vname = union_variant_name(v)
+            suffix = union_variant_suffix(v)
+            pb_variant = self.to_camel_case(f"{oneof_name}_{suffix}")
+            pb_variant = pb_variant[0].upper() + pb_variant[1:]
+            conv = self.unconvert_variant_value(v)
+
+            self.write(
+                f"            pb::{pb_mod}::{pb_oneof_enum}::{pb_variant}(v) => {prefix}::{typename}::{vname}({conv}),\n"
+            )
+
+        self.write(
+            f"""\
+                }}
+            }}
+        }}
+
+        """
+        )
 
     def generate_composite(self, prefix, field: CompositeField, override=None) -> None:
         # First pass: generate any sub-fields before we generate the
@@ -26,6 +101,8 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
                 self.generate_array(prefix, f, override)
             elif isinstance(f, CompositeField):
                 self.generate_composite(prefix, f, override)
+            elif isinstance(f, UnionField):
+                self.generate_union_unconvert(prefix, f, str(field.typename), override)
 
         has_deprecated = any([f.deprecated for f in field.fields])
         deprecated = ",deprecated" if has_deprecated else ""
@@ -150,6 +227,12 @@ class GrpcUnconverterGenerator(GrpcConverterGenerator):
                 else:
                     rhs = f"c.{name}.map(|v| v.into())"
                 self.write(f"{name}: {rhs},\n", numindent=3)
+
+            elif isinstance(f, UnionField):
+                if not f.optional:
+                    self.write(f"{name}: c.{name}.unwrap().into(),\n", numindent=3)
+                else:
+                    self.write(f"{name}: c.{name}.map(|v| v.into()),\n", numindent=3)
 
         self.write(
             f"""\

--- a/contrib/msggen/msggen/gen/grpc/util.py
+++ b/contrib/msggen/msggen/gen/grpc/util.py
@@ -80,3 +80,36 @@ def camel_to_snake(camel_case: str):
     snake = re.sub(r"(?<!^)(?=[A-Z])", "_", camel_case).lower()
     snake = snake.replace("-", "")
     return snake
+
+
+def union_variant_suffix(f):
+    """Generate a short suffix for a union variant field name in proto/grpc contexts."""
+    from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField
+    if isinstance(f, PrimitiveField):
+        return {
+            "boolean": "bool",
+            "string": "string",
+            "integer": "int",
+            "u32": "u32",
+            "u64": "u64",
+            "short_channel_id": "scid",
+            "short_channel_id_dir": "sciddir",
+            "msat": "msat",
+            "msat_or_all": "msat_or_all",
+            "msat_or_any": "msat_or_any",
+            "sat": "sat",
+            "sat_or_all": "sat_or_all",
+            "pubkey": "pubkey",
+            "hex": "hex",
+            "number": "number",
+            "feerate": "feerate",
+            "currency": "currency",
+        }.get(f.typename, f.typename)
+    elif isinstance(f, ArrayField):
+        inner = union_variant_suffix(f.itemtype)
+        return f"arr_{inner}"
+    elif isinstance(f, EnumField):
+        return str(f.typename).lower()
+    elif isinstance(f, CompositeField):
+        return str(f.typename).lower()
+    return "unknown"

--- a/contrib/msggen/msggen/gen/grpc2py.py
+++ b/contrib/msggen/msggen/gen/grpc2py.py
@@ -5,7 +5,7 @@ the node over the GRPC interface.
 
 """
 
-from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, Service
+from msggen.model import ArrayField, CompositeField, EnumField, PrimitiveField, UnionField, Service
 from msggen.gen import IGenerator
 import logging
 from textwrap import dedent
@@ -210,6 +210,13 @@ class Grpc2PyGenerator(IGenerator):
                 name = f.name
                 self.write(
                     f'        "{name}": str(m.{f.name.normalized()}),  # EnumField in generate_composite\n',
+                    cleanup=False,
+                )
+
+            elif isinstance(f, UnionField):
+                oneof_name = f.normalized()
+                self.write(
+                    f'        "{name}": getattr(m, m.WhichOneof("{oneof_name}")) if m.WhichOneof("{oneof_name}") else None,  # UnionField\n',
                     cleanup=False,
                 )
 

--- a/contrib/msggen/msggen/gen/rpc/rust.py
+++ b/contrib/msggen/msggen/gen/rpc/rust.py
@@ -9,6 +9,7 @@ from msggen.model import (
     CompositeField,
     EnumField,
     PrimitiveField,
+    UnionField,
     Service,
     Method,
 )
@@ -74,10 +75,107 @@ def normalize_varname(field):
     return field
 
 
+def union_variant_name(field):
+    """Generate a Rust enum variant name from a union variant's field type."""
+    if isinstance(field, PrimitiveField):
+        return {
+            "boolean": "Bool",
+            "string": "String",
+            "integer": "Int",
+            "u32": "U32",
+            "u64": "U64",
+            "short_channel_id": "ShortChannelId",
+            "short_channel_id_dir": "ShortChannelIdDir",
+            "msat": "Msat",
+            "msat_or_all": "MsatOrAll",
+            "msat_or_any": "MsatOrAny",
+            "sat": "Sat",
+            "sat_or_all": "SatOrAll",
+            "pubkey": "Pubkey",
+            "hex": "Hex",
+            "txid": "Txid",
+            "number": "Number",
+            "float": "Float",
+            "feerate": "Feerate",
+            "outpoint": "Outpoint",
+            "outputdesc": "OutputDesc",
+            "hash": "Hash",
+            "secret": "Secret",
+            "currency": "Currency",
+        }.get(field.typename, field.typename.capitalize())
+    elif isinstance(field, ArrayField):
+        inner = union_variant_name(field.itemtype)
+        return f"ArrayOf{inner}"
+    elif isinstance(field, EnumField):
+        return str(field.typename)
+    elif isinstance(field, CompositeField):
+        return str(field.typename)
+    else:
+        return "Unknown"
+
+
+def union_variant_type(field):
+    """Generate the Rust type for a union variant."""
+    if isinstance(field, PrimitiveField):
+        return typemap.get(field.typename, field.typename)
+    elif isinstance(field, ArrayField):
+        inner = union_variant_type(field.itemtype)
+        return f"{'Vec<' * field.dims}{inner}{'>' * field.dims}"
+    elif isinstance(field, EnumField):
+        return str(field.typename)
+    elif isinstance(field, CompositeField):
+        return str(field.typename)
+    else:
+        return "serde_json::Value"
+
+
+def gen_union(u, meta):
+    defi, decl = "", ""
+    if u.omit():
+        return "", ""
+
+    typename = str(u.typename)
+
+    # Generate sub-type declarations for composite/enum variants
+    for v in u.variants:
+        if isinstance(v, CompositeField):
+            _, vdecl = gen_composite(v, meta)
+            decl += vdecl
+        elif isinstance(v, EnumField):
+            _, vdecl = gen_enum(v, meta, None)
+            decl += vdecl
+
+    decl += f"#[derive(Clone, Debug, Deserialize, Serialize)]\n"
+    decl += f"#[serde(untagged)]\n"
+    decl += f"pub enum {typename} {{\n"
+
+    for v in u.variants:
+        vname = union_variant_name(v)
+        vtype = union_variant_type(v)
+        decl += f"    {vname}({vtype}),\n"
+
+    decl += "}\n\n"
+
+    name = u.name.normalized()
+    org = str(u.name)
+    if u.deprecated:
+        defi += "    #[deprecated]\n"
+    defi += rename_if_necessary(org, name)
+    if not u.optional:
+        defi += f"    pub {name}: {typename},\n"
+    else:
+        defi += f'    #[serde(skip_serializing_if = "Option::is_none")]\n'
+        defi += f"    pub {name}: Option<{typename}>,\n"
+
+    return defi, decl
+
+
 def gen_field(field, meta, override=None):
     if field.omit():
         return ("", "")
-    if isinstance(field, CompositeField):
+    if isinstance(field, UnionField):
+        return gen_union(field, meta)
+    elif isinstance(field, CompositeField):
         return gen_composite(field, meta, override)
     elif isinstance(field, EnumField):
         return gen_enum(field, meta, override)
@@ -246,6 +344,8 @@ def gen_array(a, meta, override=None):
     elif isinstance(a.itemtype, CompositeField):
         itemtype = a.itemtype.typename
     elif isinstance(a.itemtype, EnumField):
+        itemtype = a.itemtype.typename
+    elif isinstance(a.itemtype, UnionField):
         itemtype = a.itemtype.typename
 
     if itemtype is None:

--- a/contrib/msggen/msggen/model.py
+++ b/contrib/msggen/msggen/model.py
@@ -159,6 +159,9 @@ class Service:
             elif isinstance(field, ArrayField):
                 fields = []
                 fields.extend(gather_subfields(field.itemtype))
+            elif isinstance(field, UnionField):
+                for v in field.variants:
+                    fields.extend(gather_subfields(v))
 
             return fields
 
@@ -299,6 +302,9 @@ class CompositeField(Field):
                 if isinstance(field, ArrayField):
                     field.itemtype.path = fpath
 
+            elif "oneOf" in ftype:
+                field = UnionField.from_js(ftype, fpath)
+
             elif "type" not in ftype:
                 logger.warning(f"Unmanaged {fpath}, it doesn't have a type")
                 continue
@@ -411,13 +417,15 @@ class UnionField(Field):
 
             elif child_js["type"] in PrimitiveField.types:
                 itemtype = PrimitiveField(
-                    child_js["type"], path, child_js.get("description", "")
+                    child_js["type"], path, child_js.get("description", ""),
+                    added=child_js.get("added", None), deprecated=child_js.get("deprecated", None),
                 )
             elif child_js["type"] == "array":
                 itemtype = ArrayField.from_js(path, child_js)
             variants.append(itemtype)
 
-        return UnionField(path, js.get('description', None), variants)
+        return UnionField(path, js.get('description', None), variants,
+                          added=js.get('added', None), deprecated=js.get('deprecated', None))
 
 
 class PrimitiveField(Field):
@@ -522,6 +530,7 @@ InvoiceLabelField = PrimitiveField("string", None, None, added=None, deprecated=
 DatastoreKeyField = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)
 DatastoreUsageKeyField = ArrayField(itemtype=PrimitiveField("string", None, None, added="v23.11", deprecated=None), dims=1, path=None, description=None, added="v23.11", deprecated=None)
 InvoiceExposeprivatechannelsField = ArrayField(itemtype=PrimitiveField("short_channel_id", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)
+
 PayExclude = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)
 RenePayExclude = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added="v24.08", deprecated=None)
 RoutehintListField = PrimitiveField(
@@ -531,7 +540,6 @@ RoutehintListField = PrimitiveField(
     added=None,
     deprecated=None
 )
-SetConfigValField = PrimitiveField("string", None, None, added=None, deprecated=None)
 DecodeRoutehintListField = PrimitiveField(
     "DecodeRoutehintList",
     None,
@@ -539,6 +547,8 @@ DecodeRoutehintListField = PrimitiveField(
     added=None,
     deprecated=None
 )
+SetConfigValField = PrimitiveField("string", None, None, added=None, deprecated=None)
+OfferStringField = PrimitiveField("string", None, None, added=None, deprecated=None)
 CreateRuneRestrictionsField = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)
 CheckRuneParamsField = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)
 ChainMovesExtraTagsField = ArrayField(itemtype=PrimitiveField("string", None, None, added=None, deprecated=None), dims=1, path=None, description=None, added=None, deprecated=None)

--- a/contrib/msggen/msggen/patch.py
+++ b/contrib/msggen/msggen/patch.py
@@ -28,6 +28,10 @@ class Patch(ABC):
             if isinstance(f, model.ArrayField):
                 self.visit(f.itemtype, f, inherited_added=f.added or inherited_added, inherited_deprecated=f.deprecated or inherited_deprecated)
                 recurse(f.itemtype, inherited_added=f.added or inherited_added, inherited_deprecated=f.deprecated or inherited_deprecated)
+            elif isinstance(f, model.UnionField):
+                for v in f.variants:
+                    self.visit(v, f, inherited_added=f.added or inherited_added, inherited_deprecated=f.deprecated or inherited_deprecated)
+                    recurse(v, inherited_added=f.added or inherited_added, inherited_deprecated=f.deprecated or inherited_deprecated)
             elif isinstance(f, model.CompositeField):
                 for c in f.fields:
                     self.visit(c, f, inherited_added=inherited_added, inherited_deprecated=inherited_deprecated)


### PR DESCRIPTION
## Summary

`msggen` could not handle `oneOf` fields in JSON schemas. Every `oneOf` field was manually overridden to a single type, which dropped some variants. This PR adds `UnionField` support to all generators so that future `oneOf` fields are automatically handled without needing manual overrides. Existing overrides are preserved to avoid breaking changes.



For example, `invoice.exposeprivatechannels` accepts `true`, `["1x1x3"]`, or `"1x1x3"` in JSON-RPC, but cln-rpc only generated `Option<Vec<ShortChannelId>>`, making it impossible to pass `true` through the typed API.

## Changes

**model.py:**
- Fix `UnionField.from_js()` constructor bug (missing `added`/`deprecated` args)
- Add top-level `oneOf` detection in `CompositeField.from_js()`
- Existing overrides are preserved

**Generators (6 files)- ready for future oneOf fields :**
- `rust.py`: Generate `#[serde(untagged)]` enums
- `proto.py`: Generate protobuf `oneof` blocks with array wrapper messages
- `convert.py` / `unconvert.py`: Generate bidirectional `From` impls
- `grpc2py.py`: Generate `WhichOneof()`-based conversion
- `notification.py`: Automatically supported via `rust.py`'s `gen_field`

**Traversal:**
- `patch.py`, `checks.py`: Add recursion into `UnionField` variants

## Tests

- `cargo test -p cln-rpc` — passed
- `cargo test -p cln-grpc --features server` — passed (4/4)
- `msggen generate` — runs without errors

## Related

Resolves #8961, #8964