### PR TITLE
contrib: update Fedora builder to use bitcoincore.org for Bitcoin 29.0

### DIFF
--- a/contrib/docker/Dockerfile.builder.fedora
+++ b/contrib/docker/Dockerfile.builder.fedora
@@ -51,7 +51,7 @@ RUN wget https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_1_0_2.t
 	rm -rf VERSION_1_0_2.tar.gz lowdown-VERSION_1_0_2
 
 # Install Bitcoin Core
-RUN wget https://storage.googleapis.com/c-lightning-tests/bitcoind/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
     -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
     mv bitcoin-$BITCOIN_VERSION/bin/bitcoin* /usr/local/bin/ && \


### PR DESCRIPTION
The Fedora release builder was fetching Bitcoin Core from a Blockstream GCS bucket which no longer exists. I'm updating the script instead to fetch it directly from the bitcoincore.org url

Changelog-None