### PR TITLE
Makefile: remove build prerequisites from install targets (fixes #8971)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,7 +934,9 @@ installdirs:
 
 # $(PLUGINS) is defined in plugins/Makefile.
 
-install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $(PY_PLUGINS)
+# make install should only copy pre-built files, never trigger builds.
+# Building is done via 'make' or 'make all'; see #8971.
+install-program: installdirs
 	@$(NORMAL_INSTALL)
 	$(INSTALL_PROGRAM) $(BIN_PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(PKGLIBEXEC_PROGRAMS) $(DESTDIR)$(pkglibexecdir)
@@ -955,7 +957,7 @@ MAN7PAGES = $(filter %.7,$(MANPAGES))
 MAN8PAGES = $(filter %.8,$(MANPAGES))
 DOC_DATA = README.md LICENSE
 
-install-data: installdirs $(MAN1PAGES) $(MAN5PAGES) $(MAN7PAGES) $(MAN8PAGES) $(DOC_DATA)
+install-data: installdirs
 	@$(NORMAL_INSTALL)
 	$(INSTALL_DATA) $(MAN1PAGES) $(DESTDIR)$(man1dir)
 	$(INSTALL_DATA) $(MAN5PAGES) $(DESTDIR)$(man5dir)


### PR DESCRIPTION
Fixes #8971

## Problem
`make install` triggers builds (wiregen, rust compilation, python scripts) because both `install-program` and `install-data` list build outputs (`$(BIN_PROGRAMS)`, `$(PKGLIBEXEC_PROGRAMS)`, `$(PLUGINS)`, `$(PY_PLUGINS)`, `$(MAN1PAGES)`, etc.) as Makefile prerequisites.

This means `make install` can fail if build dependencies are missing, even when all artifacts are already built. This is particularly problematic for:
- Package managers that run `make install` in a clean environment
- Users who built with `uv run make` but install with plain `make install`
- CI pipelines that separate build and install steps

## Fix
Remove build output prerequisites from both `install-program` and `install-data` targets so `make install` only copies pre-built files, as documented in the comment now added to the Makefile.

Building remains available via `make` or `make all`.

## Changes
- `Makefile`: 2-line change (remove `$(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $(PY_PLUGINS)` from install-program, remove `$(MAN1PAGES) $(MAN5PAGES) $(MAN7PAGES) $(MAN8PAGES) $(DOC_DATA)` from install-data)
- Added clarifying comment referencing #8971