### PR TITLE
askrene: deprecate auto.no_mpp_support layer in favor of maxparts=1

### DIFF
--- a/doc/developers-guide/plugin-development/event-notifications.md
+++ b/doc/developers-guide/plugin-development/event-notifications.md
@@ -181,6 +181,19 @@ A notification for topic `invoice_creation` is sent every time an invoice is cre
 }
 ```
 
+If the invoice is associated with a BOLT 12 offer, an `offer_id` field will be present:
+
+```json
+{
+  "invoice_creation": {
+    "label": "unique-label-for-invoice",
+    "preimage": "0000000000000000000000000000000000000000000000000000000000000000",
+    "msat": 10000,
+    "offer_id": "b1d1062abc09790a68be83e4c257614a57978e4053a954bfee5909ed71e23e03"
+  }
+}
+```
+
 Before version `23.11` the `msat` field was a string with msat-suffix, e.g: `"10000msat"`.
 
 ### `warning`

--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -872,7 +872,7 @@ invoice_complete(struct invoice_info *info,
 	json_add_u64(response, "created_index", details->created_index);
 
 	notify_invoice_creation(info->cmd->ld, info->b11->msat,
-				&info->payment_preimage, info->label);
+				&info->payment_preimage, info->label, NULL);
 
 	if (warning_no_listincoming)
 		json_add_string(response, "warning_listincoming",
@@ -1725,7 +1725,7 @@ static struct command_result *json_createinvoice(struct command *cmd,
 				     NULL))
 			return fail_exists(cmd, label);
 
-		notify_invoice_creation(cmd->ld, b11->msat, preimage, label);
+		notify_invoice_creation(cmd->ld, b11->msat, preimage, label, NULL);
 	} else {
 		struct tlv_invoice *inv;
 		struct sha256 offer_id, *local_offer_id;
@@ -1822,7 +1822,7 @@ static struct command_result *json_createinvoice(struct command *cmd,
 				     local_offer_id))
 			return fail_exists(cmd, label);
 
-		notify_invoice_creation(cmd->ld, &msat,	preimage, label);
+		notify_invoice_creation(cmd->ld, &msat, preimage, label, local_offer_id);
 	}
 
 	response = json_stream_success(cmd);

--- a/lightningd/notification.c
+++ b/lightningd/notification.c
@@ -221,13 +221,16 @@ void notify_invoice_payment(struct lightningd *ld,
 static void invoice_creation_notification_serialize(struct json_stream *stream,
 						    const struct amount_msat *amount,
 						    const struct preimage *preimage,
-						    const struct json_escape *label)
+						    const struct json_escape *label,
+						    const struct sha256 *offer_id)
 {
 	if (amount != NULL)
 		json_add_amount_msat(stream, "msat", *amount);
 
 	json_add_preimage(stream, "preimage", preimage);
 	json_add_escaped_string(stream, "label", label);
+	if (offer_id)
+		json_add_sha256(stream, "offer_id", offer_id);
 }
 
 REGISTER_NOTIFICATION(invoice_creation)
@@ -235,12 +238,13 @@ REGISTER_NOTIFICATION(invoice_creation)
 void notify_invoice_creation(struct lightningd *ld,
 			     const struct amount_msat *amount,
 			     const struct preimage *preimage,
-			     const struct json_escape *label)
+			     const struct json_escape *label,
+			     const struct sha256 *offer_id)
 {
 	struct jsonrpc_notification *n = notify_start(ld, "invoice_creation");
 	if (!n)
 		return;
-	invoice_creation_notification_serialize(n->stream, amount, preimage, label);
+	invoice_creation_notification_serialize(n->stream, amount, preimage, label, offer_id);
 	notify_send(ld, n);
 }
 

--- a/lightningd/notification.h
+++ b/lightningd/notification.h
@@ -42,7 +42,8 @@ void notify_invoice_payment(struct lightningd *ld,
 void notify_invoice_creation(struct lightningd *ld,
 			     const struct amount_msat *amount,
 			     const struct preimage *preimage,
-			     const struct json_escape *label);
+			     const struct json_escape *label,
+			     const struct sha256 *offer_id);
 
 void notify_channel_opened(struct lightningd *ld,
 			   const struct node_id *node_id,

--- a/lightningd/test/run-invoice-select-inchan.c
+++ b/lightningd/test/run-invoice-select-inchan.c
@@ -530,7 +530,8 @@ void notify_disconnect(struct lightningd *ld UNNEEDED, const struct node_id *nod
 void notify_invoice_creation(struct lightningd *ld UNNEEDED,
 			     const struct amount_msat *amount UNNEEDED,
 			     const struct preimage *preimage UNNEEDED,
-			     const struct json_escape *label UNNEEDED)
+			     const struct json_escape *label UNNEEDED,
+			     const struct sha256 *offer_id UNNEEDED)
 { fprintf(stderr, "notify_invoice_creation called!\n"); abort(); }
 /* Generated stub for notify_invoice_payment */
 void notify_invoice_payment(struct lightningd *ld UNNEEDED,


### PR DESCRIPTION
## Summary
- Deprecate the `auto.no_mpp_support` magic layer in askrene's `getroutes` using `command_deprecated_in_ok` (v25.09 -> v26.08)
- Update xpay to use `maxparts=1` instead of adding the `auto.no_mpp_support` layer when MPP is disabled
- Update all tests to use `maxparts=1` instead of the deprecated layer
- Update documentation to note the deprecation

Now that `getroutes` has a `maxparts` parameter, callers can simply set `maxparts=1` to force single-path routing instead of using the magic layer name.

Fixes https://github.com/ElementsProject/lightning/issues/8871

## Test plan
- [ ] CI passes
- [ ] `test_getroutes_single_path` passes with `maxparts=1`
- [ ] `test_excessive_fee_cost` passes with `maxparts=1`
- [ ] `test_impossible_payment` passes with `maxparts=1`
- [ ] xpay no-MPP payments still work via `maxparts=1`