### PR TITLE
lightningd: don't disconnect when sending error for unknown channel_reestablish

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2137,6 +2137,21 @@ void handle_peer_spoke(struct lightningd *ld, const u8 *msg)
 						"Channel is closed and forgotten");
 			goto send_error;
 		}
+		/* Unknown channel: send error but don't disconnect.
+		 * If we hang up, the peer's dualopend may not
+		 * receive the error (it races with the disconnect),
+		 * leaving the peer with a saved channel that we
+		 * don't know about, causing an infinite reconnect
+		 * loop. */
+		log_peer_unusual(ld->log, &peer->id,
+				 "Unknown channel %s for %s",
+				 fmt_channel_id(tmpctx,
+						&channel_id),
+				 peer_wire_name(msgtype));
+		error = towire_errorfmt(tmpctx, &channel_id,
+					"Unknown channel for %s",
+					peer_wire_name(msgtype));
+		goto send_error_nohangup;
 	}
 
 	/* Weird message?  Log and reply with error. */
@@ -2160,6 +2175,15 @@ send_error:
 		      take(towire_connectd_disconnect_peer(NULL,
 							&peer->id,
 							peer->connectd_counter)));
+	return;
+
+send_error_nohangup:
+	log_peer_debug(ld->log, &peer->id, "Telling connectd to send error %s",
+		       tal_hex(tmpctx, error));
+	subd_send_msg(ld->connectd,
+		      take(towire_connectd_peer_send_msg(NULL, &peer->id,
+							 peer->connectd_counter,
+							 error)));
 	return;
 
 tell_connectd:


### PR DESCRIPTION
## Summary
- When receiving `WIRE_CHANNEL_REESTABLISH` for an unknown channel, send the error without disconnecting
- Prevents a race where the disconnect arrives before the error, leaving the peer with a stale saved channel in `DUALOPEND_OPEN_COMMIT_READY` that retries indefinitely

The bug: during dual-funding, if one side saves the channel (reaches `DUALOPEND_OPEN_COMMIT_READY`) but the other deletes its unsaved copy on disconnect, reconnects create an infinite loop. The saved side sends `CHANNEL_REESTABLISH`, the other side sends error + disconnect. The disconnect races with the error delivery -- if the peer's `dualopend` doesn't receive the error before the socket closes, `dualopen_errmsg` is called with `disconnect=false`, which calls `channel_fail_transient` instead of deleting the channel, and the cycle repeats.

By not disconnecting, the error reliably reaches the peer's `dualopend`, which processes it via `peer_failed_received_errmsg(disconnect=true)` and properly deletes the stale channel.

## Test plan
- [ ] Verify `make check-units` passes (done locally)
- [ ] CI integration tests, particularly `test_disconnect_opener`

Fixes https://github.com/ElementsProject/lightning/issues/8822