### PR TITLE
cln-grpc-plugin: bump version to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc-plugin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cln-grpc",

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cln-grpc-plugin"
-version = "0.5.0"
+version = "0.6.0"
 
 description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. Authentication is done via mTLS."
 license = "MIT"
@@ -17,7 +17,7 @@ anyhow = "1.0"
 log = "0.4"
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 prost = "0.12"
-cln-grpc = { workspace = true, features = ["server"]}
+cln-grpc = { workspace = true, features = ["server"] }
 cln-plugin = { workspace = true }
 cln-rpc = { workspace = true }
 serde_json = "1.0.113"


### PR DESCRIPTION
otherwise our CI action complains about inconsistency

This will cause a new release to crates.io.
