### PR TITLE
Makefile: move build prereqs from install-data to installcheck/bin-tarball (fixes #8971)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -955,7 +955,7 @@ MAN7PAGES = $(filter %.7,$(MANPAGES))
 MAN8PAGES = $(filter %.8,$(MANPAGES))
 DOC_DATA = README.md LICENSE
 
-install-data: installdirs $(MAN1PAGES) $(MAN5PAGES) $(MAN7PAGES) $(MAN8PAGES) $(DOC_DATA)
+install-data: installdirs
 	@$(NORMAL_INSTALL)
 	$(INSTALL_DATA) $(MAN1PAGES) $(DESTDIR)$(man1dir)
 	$(INSTALL_DATA) $(MAN5PAGES) $(DESTDIR)$(man5dir)
@@ -1020,7 +1020,7 @@ uninstall:
 	  rm -f $(DESTDIR)$(docdir)/`basename $$f`; \
 	done
 
-installcheck: all-programs
+installcheck: all-programs doc-all default-targets
 	@rm -rf testinstall || true
 	$(MAKE) DESTDIR=$$(pwd)/testinstall install
 	testinstall$(bindir)/lightningd --test-daemons-only --lightning-dir=testinstall
@@ -1042,7 +1042,7 @@ ifneq ($(VERSION),)
 bin-tarball: clightning-$(VERSION)-$(DISTRO).tar.xz
 clightning-$(VERSION)-$(DISTRO).tar.xz: DESTDIR=$(shell pwd)/
 clightning-$(VERSION)-$(DISTRO).tar.xz: prefix=opt/clightning
-clightning-$(VERSION)-$(DISTRO).tar.xz: install
+clightning-$(VERSION)-$(DISTRO).tar.xz: install doc-all default-targets
 	trap "rm -rf opt" 0; tar cvfa $@ opt/
 endif
 


### PR DESCRIPTION
## Summary

Replaces #8976 (from deleted account) with the correct approach per maintainer feedback from @vincenzopalazzo.

## Problem

`make install` triggers builds (doc generation, Rust compilation) because `install-data` depends on manpage and Rust targets. This breaks when `make install` is run with `sudo` (different environment — missing Python deps, Rust toolchain).

Fixes #8971

## Changes

1. **Remove build prereqs from `install-data`** — it now only depends on `installdirs`. `make install` becomes a pure copy operation.

2. **Add `doc-all default-targets` to `installcheck`** — ensures manpages and Rust plugins are built before the install-check test runs on clean trees.

3. **Add `doc-all default-targets` to `bin-tarball`** — ensures the distribution tarball includes complete artifacts (manpages, Rust plugins).

## Why this is better than #8976

The previous PR simply dropped the prereqs without moving them, which broke `installcheck`, `check`, and `bin-tarball` on clean trees. This version moves them to the correct targets that actually need them.

## Testing

- Verified that `install-data` now has no build dependencies
- `installcheck` and `bin-tarball` retain their required build deps
- `make install` will only copy already-built artifacts

cc @vincenzopalazzo — does this address your concerns from #8976?
Changelog-None: broken in this release.