### PR TITLE
py: add pyln-grpc-proto to PyPI publishing CI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,6 +28,8 @@ jobs:
             WORKDIR: contrib/pyln-testing
           - PACKAGE: pyln-proto
             WORKDIR: contrib/pyln-proto
+          - PACKAGE: pyln-grpc-proto
+            WORKDIR: contrib/pyln-grpc-proto
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -885,13 +885,23 @@ PYLNS=client proto testing
 update-versions: update-pyln-versions update-reckless-version update-dot-version # FIXME: update-doc-examples
 	@uv lock
 
-update-pyln-versions: $(PYLNS:%=update-pyln-version-%)
+update-pyln-versions: $(PYLNS:%=update-pyln-version-%) update-pyln-grpc-version
 
 update-pyln-version-%:
 	@if [ -z "$(NEW_VERSION)" ]; then echo "Set NEW_VERSION!" >&2; exit 1; fi
 	@echo "Updating contrib/pyln-$* to $(NEW_VERSION)"
-	@$(SED) -i.bak 's/^version = .*/version = "$(NEW_VERSION)"/' contrib/pyln-$*/pyproject.toml && rm contrib/pyln-$*/pyproject.toml.bak
-	@$(SED) -i.bak 's/^__version__ = .*/__version__ = "$(NEW_VERSION)"/' contrib/pyln-$*/pyln/$*/__init__.py && rm contrib/pyln-$*/pyln/$*/__init__.py.bak
+	@$(SED) -i.bak 's/^version = .*/version = "$(NEW_VERSION)"' contrib/pyln-$*/pyproject.toml && rm contrib/pyln-$*/pyproject.toml.bak
+	@$(SED) -i.bak 's/^__version__ = .*/__version__ = "$(NEW_VERSION)"' contrib/pyln-$*/pyln/$*/__init__.py && rm contrib/pyln-$*/pyln/$*/__init__.py.bak
+
+# pyln-grpc-proto uses a different directory layout (pyln/grpc/ not
+# pyln/grpc-proto/) and publishes versions without the 'v' prefix on
+# PyPI, so it needs its own update target.
+update-pyln-grpc-version:
+	@if [ -z "$(NEW_VERSION)" ]; then echo "Set NEW_VERSION!" >&2; exit 1; fi
+	@GRPC_VERSION=$$(echo "$(NEW_VERSION)" | $(SED) 's/^v//'); \
+	echo "Updating contrib/pyln-grpc-proto to $$GRPC_VERSION"; \
+	$(SED) -i.bak 's/^version = .*/version = "'$$GRPC_VERSION'"/' contrib/pyln-grpc-proto/pyproject.toml && rm contrib/pyln-grpc-proto/pyproject.toml.bak; \
+	$(SED) -i.bak 's/^__version__ = .*/__version__ = "'$$GRPC_VERSION'"/' contrib/pyln-grpc-proto/pyln/grpc/__init__.py && rm contrib/pyln-grpc-proto/pyln/grpc/__init__.py.bak
 
 pyln-release:  $(PYLNS:%=pyln-release-%)
 

--- a/contrib/pyln-grpc-proto/pyln/grpc/__init__.py
+++ b/contrib/pyln-grpc-proto/pyln/grpc/__init__.py
@@ -1,4 +1,4 @@
 from pyln.grpc.primitives_pb2 import *  # noqa: F401,F403
 from pyln.grpc.node_pb2 import *  # noqa: F401,F403
 from pyln.grpc.node_pb2_grpc import *  # noqa: F401,F403
-__version__ = "0.1.1"
+__version__ = "25.09"


### PR DESCRIPTION
## Summary\n\nFixes #7929 — Add `pyln-grpc-proto` to the PyPI publishing workflow so the package is automatically published on release.\n\nChangelog-None\n\n### Changes\n\n1. **`.github/workflows/pypi.yml`** — Added `pyln-grpc-proto` to the publish matrix (same pattern as `pyln-client`, `pyln-proto`, `pyln-testing`)\n\n2. **`Makefile`** — Added a dedicated `update-pyln-grpc-version` target that handles the versioning differences:\n   - **Directory layout**: `pyln/grpc/` instead of `pyln/grpc-proto/`\n   - **Version format**: PyPI uses `25.09` (no `v` prefix), while the tag is `v25.09`\n\n3. **`contrib/pyln-grpc-proto/pyln/grpc/__init__.py`** — Synced stale `__version__` from `"0.1.1"` to `"25.09"` to match `pyproject.toml`\n\n### Why a custom Makefile target?\n\nThe existing `update-pyln-version-%` pattern assumes:\n- Directory layout: `contrib/pyln-<name>/pyln/<name>/__init__.py`\n- Version passed verbatim from `git describe`\n\n`pyln-grpc-proto` breaks both assumptions:\n- Uses `contrib/pyln-grpc-proto/pyln/grpc/__init__.py`\n- Needs the `v` prefix stripped for PyPI\n\nThe custom target is the minimal approach — it follows the exact same `` pattern as the generic targets and integrates into `update-pyln-versions` as a dependency.