### PR TITLE
lightningd/peer_control: initialize error pointer in handle_peer_spoke

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1993,7 +1993,7 @@ void handle_peer_spoke(struct lightningd *ld, const u8 *msg)
 	struct channel_id channel_id;
 	struct peer *peer;
 	bool dual_fund;
-	const u8 *error;
+	const u8 *error = NULL;
 	int other_fd;
 	struct peer_fd *pfd;
 	char *errmsg;

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2017,7 +2017,7 @@ void handle_peer_spoke(struct lightningd *ld, const u8 *msg)
 	struct channel_id channel_id;
 	struct peer *peer;
 	bool dual_fund;
-	const u8 *error;
+	const u8 *error = NULL;
 	int other_fd;
 	struct peer_fd *pfd;
 	char *errmsg;


### PR DESCRIPTION
## Summary

Fixes #8849

## The Bug

In `lightningd/peer_control.c`, the `handle_peer_spoke()` function declares a local pointer variable `error` without initialization:

```c
const u8 *error;
```

Several error paths jump to the `send_error` label where `error` is dereferenced — specifically passed to `tal_hex(tmpctx, error)` and `towire_connectd_peer_send_msg()`. If `error` is not initialized before reaching `send_error`, this is undefined behavior (likely a segfault).

The affected `goto send_error` paths are all on `sockpair()` failure:
- Line ~2019 (CLOSINGD_COMPLETE state, reestablish path)
- Line ~2063 (DUALOPEND_AWAITING_LOCKIN restart path)
- Line ~2100 (WIRE_OPEN_CHANNEL new channel path)
- Line ~2119 (WIRE_OPEN_CHANNEL2 dual-fund path)

While `sockpair()` currently does set the `error` pointer via its output parameter on failure, the uninitialized declaration is still undefined behavior and fragile against future code changes.

## The Fix

Initialize `error` to `NULL` at declaration:

```c
const u8 *error = NULL;
```

This is the minimal, defensive fix that prevents undefined behavior regardless of which path reaches `send_error`.