### PR TITLE
Fix/bitcoin block null check

### DIFF
--- a/bitcoin/block.c
+++ b/bitcoin/block.c
@@ -210,6 +210,8 @@ bitcoin_block_from_hex(const tal_t *ctx, const struct chainparams *chainparams,
 	b->txids = tal_arr(b, struct bitcoin_txid, num);
 	for (i = 0; i < num; i++) {
 		b->tx[i] = pull_bitcoin_tx_only(b->tx, &p, &len);
+		if (!b->tx[i])
+    			return tal_free(b);
 		b->tx[i]->chainparams = chainparams;
 		bitcoin_txid(b->tx[i], &b->txids[i]);
 	}


### PR DESCRIPTION
Problem described in #9002  Found during investigation of #8973  

Commit 40dd780ea switched from pull_bitcoin_tx to pull_bitcoin_tx_only
but did not add a null check, causing a segfault (FATAL SIGNAL 11) if
pull_bitcoin_tx_only returns NULL due to a malformed block response
from bitcoind.

Add null check consistent with existing patterns in the codebase and
with pull_bitcoin_tx itself.

This commit adds the corrections.

Please review as AI found this fix. 

This is my first ever commit, please excuse errors and feel free to edit.

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
