### PR TITLE
crates: upgrade to 2024 edition and set and check MSRV of 1.85

### DIFF
--- a/.github/workflows/rust-msrv.yml
+++ b/.github/workflows/rust-msrv.yml
@@ -1,0 +1,26 @@
+name: Rust MSRV verification test
+on:
+  pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  msrv-test:
+    name: Rust MSRV verification test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Check MSRV
+        run: cargo hack check --rust-version --workspace --all-targets --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -252,7 +252,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -365,9 +365,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -380,24 +380,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -417,9 +417,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -458,8 +458,8 @@ dependencies = [
  "log",
  "log-panics",
  "rand 0.9.2",
- "reqwest 0.13.1",
- "rustls 0.23.36",
+ "reqwest 0.13.2",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tokio",
@@ -576,7 +576,7 @@ dependencies = [
  "quick-xml",
  "rcgen",
  "roxmltree_to_serde",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "serde_qs",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -816,9 +816,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -828,11 +828,10 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -842,6 +841,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -854,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
  "tokio",
@@ -864,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -879,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -889,15 +894,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -906,15 +911,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -923,21 +928,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -947,7 +952,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -993,8 +997,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1046,6 +1063,15 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1229,7 +1255,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1250,14 +1276,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1266,7 +1291,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1274,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1378,6 +1403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,15 +1453,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1458,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1471,7 +1502,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1480,16 +1511,40 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1501,16 +1556,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lightning"
@@ -1550,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1628,9 +1689,9 @@ checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1666,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1745,15 +1806,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -1812,18 +1873,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1832,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1887,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1959,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1971,6 +2032,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2051,14 +2118,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2068,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2079,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2127,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2144,7 +2211,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -2239,11 +2306,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2278,15 +2345,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -2341,10 +2408,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2380,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2397,9 +2464,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2412,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2463,11 +2530,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2476,13 +2543,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2623,15 +2696,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2654,12 +2727,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2739,9 +2812,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2797,12 +2870,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2909,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2919,7 +2992,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2936,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2972,7 +3045,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -3122,7 +3195,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -3192,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3245,9 +3318,15 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3373,18 +3452,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3395,23 +3483,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3419,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3432,18 +3516,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3451,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3570,15 +3688,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3625,28 +3734,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3668,12 +3760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,12 +3776,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3716,22 +3796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3752,12 +3820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,12 +3836,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3800,12 +3856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,12 +3874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,9 +3885,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3862,7 +3994,7 @@ dependencies = [
  "log",
  "log-panics",
  "rcgen",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tokio",
@@ -3922,18 +4054,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4016,15 +4148,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ debug = 0
 codegen-units = 32
 
 [workspace]
-resolver = "2"
+resolver = "3"
+package.rust-version = "1.85.0"
 members = [
     "cln-rpc",
     "cln-grpc",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -7,6 +7,7 @@ description = "The Core Lightning API as grpc primitives. Provides the bindings 
 homepage = "https://github.com/ElementsProject/lightning/tree/master/cln-grpc"
 repository = "https://github.com/ElementsProject/lightning"
 documentation = "https://docs.rs/cln-grpc"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-grpc"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."
 homepage = "https://github.com/ElementsProject/lightning/tree/master/cln-grpc"

--- a/cln-grpc/src/test.rs
+++ b/cln-grpc/src/test.rs
@@ -1,6 +1,7 @@
 use crate::pb::*;
 use serde_json::json;
 
+#[cfg(feature = "server")]
 #[test]
 fn test_listpeers() {
     let j: serde_json::Value = json!({
@@ -230,6 +231,7 @@ fn test_listpeers() {
     // assert_eq!(j, j2); // TODO, still some differences to fix
 }
 
+#[cfg(feature = "server")]
 #[test]
 fn test_getinfo() {
     let j = json!({
@@ -254,6 +256,7 @@ fn test_getinfo() {
     //assert_eq!(j, j2);
 }
 
+#[cfg(feature = "server")]
 #[test]
 fn test_keysend() {
     let g =

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -7,6 +7,7 @@ description = "An async RPC client for Core Lightning."
 homepage = "https://github.com/ElementsProject/lightning/tree/master/cln-rpc"
 repository = "https://github.com/ElementsProject/lightning"
 documentation = "https://docs.rs/cln-rpc"
+rust-version.workspace = true
 
 [[example]]
 name = "cln-rpc-getinfo"
@@ -14,17 +15,17 @@ path = "examples/getinfo.rs"
 
 [dependencies]
 anyhow = "1.0"
-bitcoin = { version = "0.32.2", features = [ "serde" ] }
+bitcoin = { version = "0.32.2", features = ["serde"] }
 bytes = "1"
-futures-util = { version = "0.3", features = [ "sink" ] }
+futures-util = { version = "0.3", features = ["sink"] }
 hex = "0.4.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["net"]}
+tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 
 [dev-dependencies]
 env_logger = "0.10"
-tokio = { version = "1", features = ["net", "macros", "rt-multi-thread"]}
+tokio = { version = "1", features = ["net", "macros", "rt-multi-thread"] }
 tokio-test = "0.4.3"

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-rpc"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "An async RPC client for Core Lightning."
 homepage = "https://github.com/ElementsProject/lightning/tree/master/cln-rpc"

--- a/cln-rpc/examples/getinfo.rs
+++ b/cln-rpc/examples/getinfo.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Context};
-use cln_rpc::{model::requests::GetinfoRequest, ClnRpc, Request};
+use anyhow::{Context, anyhow};
+use cln_rpc::{ClnRpc, Request, model::requests::GetinfoRequest};
 use std::env::args;
 use std::path::Path;
 use tokio;

--- a/cln-rpc/src/jsonrpc.rs
+++ b/cln-rpc/src/jsonrpc.rs
@@ -1,8 +1,8 @@
 //! Common structs to handle JSON-RPC decoding and encoding. They are
 //! generic over the Notification and Request types.
 
-use serde::ser::{SerializeStruct, Serializer};
 use serde::de::{self, Deserializer};
+use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::Debug;

--- a/cln-rpc/src/lib.rs
+++ b/cln-rpc/src/lib.rs
@@ -79,15 +79,15 @@ use crate::codec::JsonCodec;
 pub use anyhow::Error;
 use anyhow::Result;
 use core::fmt::Debug;
-use futures_util::sink::SinkExt;
 use futures_util::StreamExt;
+use futures_util::sink::SinkExt;
 use log::{debug, trace};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
 pub mod codec;
@@ -559,8 +559,11 @@ mod test {
     #[test]
     fn serialize_custom_msg_notification() {
         let msg = CustomMsgNotification {
-            peer_id : PublicKey::from_str("0364aeb75519be29d1af7b8cc6232dbda9fdabb79b66e4e1f6a223750954db210b").unwrap(),
-            payload : String::from("941746573749")
+            peer_id: PublicKey::from_str(
+                "0364aeb75519be29d1af7b8cc6232dbda9fdabb79b66e4e1f6a223750954db210b",
+            )
+            .unwrap(),
+            payload: String::from("941746573749"),
         };
 
         let notification = Notification::CustomMsg(msg);
@@ -576,14 +579,16 @@ mod test {
                 }
             )
         );
-
     }
 
     #[test]
     fn serialize_block_added_notification() {
         let block_added = BlockAddedNotification {
-            hash : crate::primitives::Sha256::from_str("000000000000000000000acab8abe0c67a52ed7e5a90a19c64930ff11fa84eca").unwrap(),
-            height : 830702
+            hash: crate::primitives::Sha256::from_str(
+                "000000000000000000000acab8abe0c67a52ed7e5a90a19c64930ff11fa84eca",
+            )
+            .unwrap(),
+            height: 830702,
         };
 
         let notification = Notification::BlockAdded(block_added);
@@ -613,6 +618,6 @@ mod test {
             }
         });
 
-        let _ : Notification = serde_json::from_value(connect_json).unwrap();
+        let _: Notification = serde_json::from_value(connect_json).unwrap();
     }
 }

--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -1,6 +1,6 @@
 //! Primitive types representing [`Amount`]s, [`PublicKey`]s, ...
 use anyhow::Context;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 use bitcoin::hashes::Hash as BitcoinHash;
 use serde::{Deserialize, Serialize};
 use serde::{Deserializer, Serializer};

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -7,6 +7,7 @@ description = "A CLN plugin library. Write your plugin in Rust."
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"
 repository = "https://github.com/ElementsProject/lightning"
 documentation = "https://docs.rs/cln-plugin"
+rust-version.workspace = true
 
 [[example]]
 name = "cln-plugin-startup"
@@ -19,12 +20,18 @@ log = { version = "^0.4", features = ['std'] }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "1.0.72"
 tokio-util = { version = "0.7", features = ["codec"] }
-tokio = { version="1", features = ['io-std', 'rt', 'sync', 'macros', 'io-util'] }
+tokio = { version = "1", features = [
+    'io-std',
+    'rt',
+    'sync',
+    'macros',
+    'io-util',
+] }
 tokio-stream = "0.1"
 futures = "0.3"
 tracing-subscriber = { version = "^0.3", features = ["env-filter", "tracing"] }
 tracing = { version = "^0.1", features = ["async-await", "log"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", ] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 cln-grpc = { workspace = true }

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-plugin"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"

--- a/plugins/bip353-plugin/Cargo.toml
+++ b/plugins/bip353-plugin/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "BIP-353 lookups"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"
 repository = "https://github.com/ElementsProject/lightning"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/plugins/bip353-plugin/Cargo.toml
+++ b/plugins/bip353-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-bip353"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "BIP-353 lookups"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"

--- a/plugins/bip353-plugin/src/config.rs
+++ b/plugins/bip353-plugin/src/config.rs
@@ -1,4 +1,4 @@
-use cln_plugin::{messages::ProxyInfo, Plugin};
+use cln_plugin::{Plugin, messages::ProxyInfo};
 
 pub fn get_proxy(plugin: Plugin<()>) -> Option<ProxyInfo> {
     match plugin.configuration().always_use_proxy {

--- a/plugins/bip353-plugin/src/main.rs
+++ b/plugins/bip353-plugin/src/main.rs
@@ -15,11 +15,22 @@ mod config;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), anyhow::Error> {
+    unsafe {
+        // SAFETY:
+        // `std::env::set_var` is unsafe in Rust 2024 because environment variables
+        // are process-global and unsynchronized. Concurrent reads/writes from
+        // multiple threads can cause undefined behavior.
+        //
+        // This call happens at process startup, before any threads are spawned and
+        // before any code that may read environment variables is executed.
+        // Therefore, no concurrent access is possible.
+        std::env::set_var(
+            "CLN_PLUGIN_LOG",
+            "cln_plugin=info,cln_rpc=info,cln_bip353=trace,warn",
+        )
+    };
+
     log_panics::init();
-    std::env::set_var(
-        "CLN_PLUGIN_LOG",
-        "cln_plugin=info,cln_rpc=info,cln_bip353=trace,warn",
-    );
 
     let plugin = match Builder::new(tokio::io::stdin(), tokio::io::stdout())
         .rpcmethod_from_builder(

--- a/plugins/bip353-plugin/src/main.rs
+++ b/plugins/bip353-plugin/src/main.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use anyhow::anyhow;
 use bitcoin::hex::DisplayHex;
 use bitcoin_payment_instructions::{
-    hrn_resolution::HumanReadableName, http_resolver::HTTPHrnResolver, PaymentInstructions,
-    PaymentMethod, PossiblyResolvedPaymentMethod,
+    PaymentInstructions, PaymentMethod, PossiblyResolvedPaymentMethod,
+    hrn_resolution::HumanReadableName, http_resolver::HTTPHrnResolver,
 };
 use cln_plugin::{Builder, Plugin, RpcMethodBuilder};
 use serde::Serialize;

--- a/plugins/currencyrate-plugin/Cargo.toml
+++ b/plugins/currencyrate-plugin/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Fetches currency rates"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"
 repository = "https://github.com/ElementsProject/lightning"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/plugins/currencyrate-plugin/Cargo.toml
+++ b/plugins/currencyrate-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-currencyrate"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "Fetches currency rates"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"

--- a/plugins/currencyrate-plugin/src/main.rs
+++ b/plugins/currencyrate-plugin/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use cln_plugin::options::StringArrayConfigOption;
 use cln_plugin::{Builder, ConfiguredPlugin, Plugin, RpcMethodBuilder};
 use cln_rpc::ClnRpc;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::str::FromStr;
@@ -190,7 +190,10 @@ async fn currencyrate(plugin: Plugin<PluginState>, args: Value) -> Result<Value,
     }
 }
 
-async fn listcurrencyrates(plugin: Plugin<PluginState>, args: Value) -> Result<Value, anyhow::Error> {
+async fn listcurrencyrates(
+    plugin: Plugin<PluginState>,
+    args: Value,
+) -> Result<Value, anyhow::Error> {
     let currency = match args {
         Value::Array(values) => {
             let currency = values

--- a/plugins/currencyrate-plugin/src/main.rs
+++ b/plugins/currencyrate-plugin/src/main.rs
@@ -30,11 +30,22 @@ struct PluginState {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), anyhow::Error> {
+    unsafe {
+        // SAFETY:
+        // `std::env::set_var` is unsafe in Rust 2024 because environment variables
+        // are process-global and unsynchronized. Concurrent reads/writes from
+        // multiple threads can cause undefined behavior.
+        //
+        // This call happens at process startup, before any threads are spawned and
+        // before any code that may read environment variables is executed.
+        // Therefore, no concurrent access is possible.
+        std::env::set_var(
+            "CLN_PLUGIN_LOG",
+            "cln_plugin=info,cln_rpc=info,cln_currencyrate=debug,warn",
+        )
+    };
+
     log_panics::init();
-    std::env::set_var(
-        "CLN_PLUGIN_LOG",
-        "cln_plugin=info,cln_rpc=info,cln_currencyrate=debug,warn",
-    );
 
     let _ = rustls::crypto::ring::default_provider().install_default();
 

--- a/plugins/examples/cln-plugin-startup.rs
+++ b/plugins/examples/cln-plugin-startup.rs
@@ -7,7 +7,7 @@ use cln_plugin::options::{
     DefaultStringArrayConfigOption, IntegerArrayConfigOption, IntegerConfigOption,
     StringArrayConfigOption,
 };
-use cln_plugin::{messages, Builder, Error, HookBuilder, Plugin};
+use cln_plugin::{Builder, Error, HookBuilder, Plugin, messages};
 
 const TEST_NOTIF_TAG: &str = "test_custom_notification";
 

--- a/plugins/examples/cln-subscribe-wildcard.rs
+++ b/plugins/examples/cln-subscribe-wildcard.rs
@@ -1,6 +1,5 @@
 /// This plug-in subscribes to the wildcard-notifications
 /// and creates a corresponding log-entry
-
 use anyhow::Result;
 use cln_plugin::{Builder, Plugin};
 
@@ -14,21 +13,15 @@ async fn main() -> Result<()> {
         .await?;
 
     match configured {
-	Some(p) => p.join().await?,
-	None => return Ok(()) // cln was started with --help
+        Some(p) => p.join().await?,
+        None => return Ok(()), // cln was started with --help
     };
 
     Ok(())
 }
 
-async fn handle_wildcard_notification(_plugin: Plugin<()>, value : serde_json::Value) -> Result<()> {
-    let notification_type : String = value
-	.as_object()
-	.unwrap()
-	.keys()
-	.next()
-	.unwrap()
-	.into();
+async fn handle_wildcard_notification(_plugin: Plugin<()>, value: serde_json::Value) -> Result<()> {
+    let notification_type: String = value.as_object().unwrap().keys().next().unwrap().into();
 
     log::info!("Received notification {}", notification_type);
     Ok(())

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -7,6 +7,7 @@ description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. A
 license = "MIT"
 repository = "https://github.com/ElementsProject/lightning"
 documentation = "https://docs.rs/crate/cln-grpc-plugin/"
+rust-version.workspace = true
 
 [[bin]]
 name = "cln-grpc"

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "cln-grpc-plugin"
 version = "0.6.0"
 

--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use cln_grpc::pb::node_server::NodeServer;
-use cln_plugin::{options, Builder, Plugin};
+use cln_plugin::{Builder, Plugin, options};
 use cln_rpc::notifications::Notification;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -30,10 +30,12 @@ const OPTION_GRPC_HOST: options::DefaultStringConfigOption =
         "Which host should the grpc listen for incomming connections?",
     );
 
-const OPTION_GRPC_MSG_BUFFER_SIZE : options::DefaultIntegerConfigOption = options::ConfigOption::new_i64_with_default(
-    "grpc-msg-buffer-size",
-    1024,
-    "Number of notifications which can be stored in the grpc message buffer. Notifications can be skipped if this buffer is full");
+const OPTION_GRPC_MSG_BUFFER_SIZE: options::DefaultIntegerConfigOption =
+    options::ConfigOption::new_i64_with_default(
+        "grpc-msg-buffer-size",
+        1024,
+        "Number of notifications which can be stored in the grpc message buffer. Notifications can be skipped if this buffer is full",
+    );
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {

--- a/plugins/grpc-plugin/src/main.rs
+++ b/plugins/grpc-plugin/src/main.rs
@@ -37,10 +37,20 @@ const OPTION_GRPC_MSG_BUFFER_SIZE : options::DefaultIntegerConfigOption = option
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    std::env::set_var(
-        "CLN_PLUGIN_LOG",
-        "cln_plugin=info,cln_rpc=info,cln_grpc=debug,debug",
-    );
+    unsafe {
+        // SAFETY:
+        // `std::env::set_var` is unsafe in Rust 2024 because environment variables
+        // are process-global and unsynchronized. Concurrent reads/writes from
+        // multiple threads can cause undefined behavior.
+        //
+        // This call happens at process startup, before any threads are spawned and
+        // before any code that may read environment variables is executed.
+        // Therefore, no concurrent access is possible.
+        std::env::set_var(
+            "CLN_PLUGIN_LOG",
+            "cln_plugin=info,cln_rpc=info,cln_grpc=debug,debug",
+        )
+    };
 
     let directory = std::env::current_dir()?;
 

--- a/plugins/grpc-plugin/src/tls.rs
+++ b/plugins/grpc-plugin/src/tls.rs
@@ -101,8 +101,12 @@ fn generate_or_load_identity(
             params.key_usages.push(rcgen::KeyUsagePurpose::KeyCertSign);
         } else {
             params.is_ca = rcgen::IsCa::NoCa;
-            params.key_usages.push(rcgen::KeyUsagePurpose::DigitalSignature);
-            params.key_usages.push(rcgen::KeyUsagePurpose::KeyEncipherment);
+            params
+                .key_usages
+                .push(rcgen::KeyUsagePurpose::DigitalSignature);
+            params
+                .key_usages
+                .push(rcgen::KeyUsagePurpose::KeyEncipherment);
             params.key_usages.push(rcgen::KeyUsagePurpose::KeyAgreement);
         }
         params

--- a/plugins/lsps-plugin/Cargo.toml
+++ b/plugins/lsps-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cln-lsps"
 version = "0.1.1"
-edition = "2021"
+edition = "2024"
 rust-version.workspace = true
 
 [[bin]]

--- a/plugins/lsps-plugin/Cargo.toml
+++ b/plugins/lsps-plugin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cln-lsps"
 version = "0.1.1"
 edition = "2021"
+rust-version.workspace = true
 
 [[bin]]
 name = "cln-lsps-client"
@@ -15,7 +16,7 @@ path = "src/service.rs"
 anyhow = "1.0"
 async-trait = "0.1"
 bitcoin = "0.32.2"
-chrono = { version= "0.4.42", features = ["serde"] }
+chrono = { version = "0.4.42", features = ["serde"] }
 cln-plugin = { workspace = true }
 cln-rpc = { workspace = true }
 hex = "0.4"

--- a/plugins/lsps-plugin/src/client.rs
+++ b/plugins/lsps-plugin/src/client.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, bail, Context};
-use bitcoin::hashes::{hex::FromHex, sha256, Hash};
+use anyhow::{Context, anyhow, bail};
+use bitcoin::hashes::{Hash, hex::FromHex, sha256};
 use chrono::{Duration, Utc};
 use cln_lsps::{
     cln_adapters::{
@@ -13,16 +13,17 @@ use cln_lsps::{
     core::{
         client::LspsClient,
         features::is_feature_bit_set_reversed,
-        tlv::{encode_tu64, TLV_FORWARD_AMT, TLV_PAYMENT_SECRET},
+        tlv::{TLV_FORWARD_AMT, TLV_PAYMENT_SECRET, encode_tu64},
         transport::{MultiplexedTransport, PendingRequests},
     },
     proto::{
-        lsps0::{Msat, LSPS0_MESSAGE_TYPE, LSP_FEATURE_BIT},
-        lsps2::{compute_opening_fee, Lsps2BuyResponse, Lsps2GetInfoResponse, OpeningFeeParams},
+        lsps0::{LSP_FEATURE_BIT, LSPS0_MESSAGE_TYPE, Msat},
+        lsps2::{Lsps2BuyResponse, Lsps2GetInfoResponse, OpeningFeeParams, compute_opening_fee},
     },
 };
-use cln_plugin::{options, HookBuilder, HookFilter};
+use cln_plugin::{HookBuilder, HookFilter, options};
 use cln_rpc::{
+    ClnRpc,
     model::{
         requests::{
             DatastoreMode, DatastoreRequest, DeldatastoreRequest, DelinvoiceRequest,
@@ -31,7 +32,6 @@ use cln_rpc::{
         responses::InvoiceResponse,
     },
     primitives::{Amount, AmountOrAny, PublicKey, ShortChannelId},
-    ClnRpc,
 };
 use log::{debug, info, warn};
 use rand::{CryptoRng, Rng};
@@ -522,16 +522,20 @@ async fn on_invoice_payment(
     // Delete DS-entries.
     let dir = p.configuration().lightning_dir;
     let rpc_path = Path::new(&dir).join(&p.configuration().rpc_file);
-    let mut cln_client = ok_or_continue!(cln_rpc::ClnRpc::new(rpc_path.clone())
-        .await
-        .context("failed to connect to core-lightning"));
-    ok_or_continue!(cln_client
-        .call_typed(&DeldatastoreRequest {
-            key: vec!["lsps".to_string(), "invoice".to_string(), hash.to_string()],
-            generation: None,
-        })
-        .await
-        .context("failed to delete datastore record"));
+    let mut cln_client = ok_or_continue!(
+        cln_rpc::ClnRpc::new(rpc_path.clone())
+            .await
+            .context("failed to connect to core-lightning")
+    );
+    ok_or_continue!(
+        cln_client
+            .call_typed(&DeldatastoreRequest {
+                key: vec!["lsps".to_string(), "invoice".to_string(), hash.to_string()],
+                generation: None,
+            })
+            .await
+            .context("failed to delete datastore record")
+    );
 
     Ok(serde_json::json!({"result": "continue"}))
 }
@@ -558,20 +562,24 @@ async fn on_htlc_accepted(
     // Check that the htlc belongs to a jit-channel request.
     let dir = p.configuration().lightning_dir;
     let rpc_path = Path::new(&dir).join(&p.configuration().rpc_file);
-    let mut cln_client = ok_or_continue!(cln_rpc::ClnRpc::new(rpc_path.clone())
-        .await
-        .context("failed to connect to core-lightning"));
+    let mut cln_client = ok_or_continue!(
+        cln_rpc::ClnRpc::new(rpc_path.clone())
+            .await
+            .context("failed to connect to core-lightning")
+    );
 
-    let lsp_data = ok_or_continue!(cln_client
-        .call_typed(&ListdatastoreRequest {
-            key: Some(vec![
-                "lsps".to_string(),
-                "invoice".to_string(),
-                hex::encode(&req.htlc.payment_hash),
-            ]),
-        })
-        .await
-        .context("failed to fetch datastore record"));
+    let lsp_data = ok_or_continue!(
+        cln_client
+            .call_typed(&ListdatastoreRequest {
+                key: Some(vec![
+                    "lsps".to_string(),
+                    "invoice".to_string(),
+                    hex::encode(&req.htlc.payment_hash),
+                ]),
+            })
+            .await
+            .context("failed to fetch datastore record")
+    );
 
     // If we don't know about this payment it's not an LSP payment, continue.
     some_or_continue!(lsp_data.datastore.first());
@@ -601,18 +609,20 @@ async fn on_htlc_accepted(
         // FIXME: If we are strict, we should reject the htlc here.
     }
 
-    let inv_res = ok_or_continue!(cln_client
-        .call_typed(&ListinvoicesRequest {
-            index: None,
-            invstring: None,
-            label: None,
-            limit: None,
-            offer_id: None,
-            payment_hash: Some(hex::encode(&req.htlc.payment_hash)),
-            start: None,
-        })
-        .await
-        .context("failed to get invoice"));
+    let inv_res = ok_or_continue!(
+        cln_client
+            .call_typed(&ListinvoicesRequest {
+                index: None,
+                invstring: None,
+                label: None,
+                limit: None,
+                offer_id: None,
+                payment_hash: Some(hex::encode(&req.htlc.payment_hash)),
+                start: None,
+            })
+            .await
+            .context("failed to get invoice")
+    );
 
     let invoice = some_or_continue!(
         inv_res.invoices.first(),
@@ -629,9 +639,11 @@ async fn on_htlc_accepted(
     ps.extend_from_slice(&payment_data[0..32]);
     ps.extend(encode_tu64(total_amt));
     payload.insert(TLV_PAYMENT_SECRET, ps);
-    let payload_bytes = ok_or_continue!(payload
-        .to_bytes()
-        .context("failed to encode payload as bytes"));
+    let payload_bytes = ok_or_continue!(
+        payload
+            .to_bytes()
+            .context("failed to encode payload as bytes")
+    );
 
     info!(
         "Amended onion payload with forward_amt={} and total_msat={}",
@@ -659,9 +671,11 @@ async fn on_openchannel(
 
     let dir = p.configuration().lightning_dir;
     let rpc_path = Path::new(&dir).join(&p.configuration().rpc_file);
-    let mut cln_client = ok_or_continue!(cln_rpc::ClnRpc::new(rpc_path.clone())
-        .await
-        .context("failed to connect to core-lightning"));
+    let mut cln_client = ok_or_continue!(
+        cln_rpc::ClnRpc::new(rpc_path.clone())
+            .await
+            .context("failed to connect to core-lightning")
+    );
 
     let ds_req = ListdatastoreRequest {
         key: Some(vec![
@@ -670,10 +684,12 @@ async fn on_openchannel(
             req.openchannel.id.clone(),
         ]),
     };
-    let ds_res = ok_or_continue!(cln_client
-        .call_typed(&ds_req)
-        .await
-        .context("failed to get datastore record"));
+    let ds_res = ok_or_continue!(
+        cln_client
+            .call_typed(&ds_req)
+            .await
+            .context("failed to get datastore record")
+    );
 
     if let Some(_rec) = ds_res.datastore.iter().next() {
         info!(
@@ -766,7 +782,7 @@ async fn check_peer_lsp_status(
             return Ok(PeerLspStatus {
                 connected: false,
                 has_lsp_feature: false,
-            })
+            });
         }
         Some(p) => p,
     };

--- a/plugins/lsps-plugin/src/cln_adapters/rpc.rs
+++ b/plugins/lsps-plugin/src/cln_adapters/rpc.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use cln_rpc::{
+    ClnRpc,
     model::{
         requests::{
             DatastoreMode, DatastoreRequest, DeldatastoreRequest, FundchannelRequest,
@@ -23,7 +24,6 @@ use cln_rpc::{
         responses::ListdatastoreResponse,
     },
     primitives::{Amount, AmountOrAll, ChannelState, Sha256, ShortChannelId},
-    ClnRpc,
 };
 use core::fmt;
 use serde::Serialize;

--- a/plugins/lsps-plugin/src/cln_adapters/sender.rs
+++ b/plugins/lsps-plugin/src/cln_adapters/sender.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
-use cln_rpc::{model::requests::SendcustommsgRequest, ClnRpc};
+use cln_rpc::{ClnRpc, model::requests::SendcustommsgRequest};
 use std::path::PathBuf;
 
 #[derive(Clone)]

--- a/plugins/lsps-plugin/src/core/lsps2/htlc.rs
+++ b/plugins/lsps-plugin/src/core/lsps2/htlc.rs
@@ -1,14 +1,13 @@
 use crate::{
     core::{
         lsps2::provider::{DatastoreProvider, LightningProvider, Lsps2OfferProvider},
-        tlv::{TlvStream, TLV_FORWARD_AMT},
+        tlv::{TLV_FORWARD_AMT, TlvStream},
     },
     proto::{
         lsps0::{Msat, ShortChannelId},
         lsps2::{
-            compute_opening_fee,
+            Lsps2PolicyGetChannelCapacityRequest, compute_opening_fee,
             failure_codes::{TEMPORARY_CHANNEL_FAILURE, UNKNOWN_NEXT_PEER},
-            Lsps2PolicyGetChannelCapacityRequest,
         },
     },
 };
@@ -160,12 +159,12 @@ impl<A: DatastoreProvider + Lsps2OfferProvider + LightningProvider> HtlcAccepted
                     reason: RejectReason::InsufficientForFee {
                         fee: Msat::from_msat(fee),
                     },
-                })
+                });
             }
             None => {
                 return Ok(HtlcDecision::Reject {
                     reason: RejectReason::FeeOverflow,
-                })
+                });
             }
         };
 
@@ -186,7 +185,7 @@ impl<A: DatastoreProvider + Lsps2OfferProvider + LightningProvider> HtlcAccepted
             None => {
                 return Ok(HtlcDecision::Reject {
                     reason: RejectReason::PolicyDenied,
-                })
+                });
             }
         };
 
@@ -243,9 +242,9 @@ mod tests {
         DatastoreEntry, Lsps2PolicyGetChannelCapacityResponse, Lsps2PolicyGetInfoRequest,
         Lsps2PolicyGetInfoResponse, OpeningFeeParams, Promise,
     };
-    use anyhow::{anyhow, Result as AnyResult};
+    use anyhow::{Result as AnyResult, anyhow};
     use async_trait::async_trait;
-    use bitcoin::hashes::{sha256::Hash as Sha256, Hash};
+    use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
     use bitcoin::secp256k1::PublicKey;
     use chrono::{TimeZone, Utc};
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/plugins/lsps-plugin/src/core/lsps2/service.rs
+++ b/plugins/lsps-plugin/src/core/lsps2/service.rs
@@ -146,7 +146,7 @@ mod tests {
         Lsps2PolicyGetChannelCapacityResponse, Lsps2PolicyGetInfoResponse, OpeningFeeParams,
         PolicyOpeningFeeParams, Promise,
     };
-    use anyhow::{anyhow, Result as AnyResult};
+    use anyhow::{Result as AnyResult, anyhow};
     use chrono::{TimeZone, Utc};
     use std::sync::{Arc, Mutex};
 

--- a/plugins/lsps-plugin/src/core/router.rs
+++ b/plugins/lsps-plugin/src/core/router.rs
@@ -1,6 +1,6 @@
 use crate::proto::jsonrpc::{RpcError, RpcErrorExt};
 use bitcoin::secp256k1::PublicKey;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::value::RawValue;
 use std::{collections::HashMap, future::Future, pin::Pin};
 
@@ -124,7 +124,7 @@ impl JsonRpcRouter {
                 return Some(error_response(
                     None,
                     RpcError::parse_error("failed to parse request"),
-                ))
+                ));
             }
         };
 

--- a/plugins/lsps-plugin/src/core/tlv.rs
+++ b/plugins/lsps-plugin/src/core/tlv.rs
@@ -1,4 +1,4 @@
-use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
 use std::{convert::TryFrom, fmt};
 use thiserror::Error;
 
@@ -411,7 +411,7 @@ mod tests {
         ]);
 
         let bytes = stream.to_bytes()?; // just ensure it encodes
-                                        // Decode back to confirm roundtrip/canonical encodings accepted
+        // Decode back to confirm roundtrip/canonical encodings accepted
         let back = TlvStream::from_bytes(&bytes)?;
         assert_eq!(back.0[0].type_, 0x00fc);
         assert_eq!(back.0[1].type_, 0x00fd);

--- a/plugins/lsps-plugin/src/core/transport.rs
+++ b/plugins/lsps-plugin/src/core/transport.rs
@@ -2,10 +2,10 @@ use crate::proto::jsonrpc::{JsonRpcResponse, RequestObject};
 use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use core::fmt::Debug;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use thiserror::Error;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{Mutex, oneshot};
 
 /// Transport-specific errors that may occur when sending or receiving JSON-RPC
 /// messages.

--- a/plugins/lsps-plugin/src/proto/jsonrpc.rs
+++ b/plugins/lsps-plugin/src/proto/jsonrpc.rs
@@ -1,5 +1,5 @@
-use rand::{rngs::OsRng, TryRngCore as _};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use rand::{TryRngCore as _, rngs::OsRng};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{self, Value};
 use std::fmt;
 
@@ -225,12 +225,12 @@ impl<'de, R: DeserializeOwned> Deserialize<'de> for JsonRpcResponse<R> {
             (Some(_), Some(_)) => {
                 return Err(serde::de::Error::custom(
                     "Response cannot have both result and error",
-                ))
+                ));
             }
             (None, None) => {
                 return Err(serde::de::Error::custom(
                     "Response must have either result or error",
-                ))
+                ));
             }
         };
 
@@ -420,9 +420,11 @@ mod test_message_serialization {
             const METHOD: &'static str = "say_hello";
         }
         let rpc_request = SayHelloRequest.into_request();
-        assert!(!serde_json::to_string(&rpc_request)
-            .expect("could not convert to json")
-            .contains("\"params\""));
+        assert!(
+            !serde_json::to_string(&rpc_request)
+                .expect("could not convert to json")
+                .contains("\"params\"")
+        );
     }
 
     #[test]

--- a/plugins/lsps-plugin/src/proto/lsps0.rs
+++ b/plugins/lsps-plugin/src/proto/lsps0.rs
@@ -1,6 +1,6 @@
 use crate::proto::jsonrpc::{JsonRpcRequest, RpcError};
 use core::fmt;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use thiserror::Error;
 
 const MSAT_PER_SAT: u64 = 1_000;

--- a/plugins/lsps-plugin/src/proto/lsps2.rs
+++ b/plugins/lsps-plugin/src/proto/lsps2.rs
@@ -2,7 +2,7 @@ use crate::proto::{
     jsonrpc::{JsonRpcRequest, RpcError},
     lsps0::{DateTime, Msat, Ppm, ShortChannelId},
 };
-use bitcoin::hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
+use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
 use chrono::Utc;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ pub trait ShortChannelIdJITExt {
 
 impl ShortChannelIdJITExt for ShortChannelId {
     fn generate_jit(blockheight: u32, distance: u32) -> Self {
-        use rand::{rng, Rng as _};
+        use rand::{Rng as _, rng};
 
         let mut rng = rng();
         let block = blockheight + distance;
@@ -428,10 +428,12 @@ mod tests {
         let result = serde_json::from_str::<TestData>(&json);
         assert!(result.is_err());
         // Check the error message relates to our PromiseError
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("promise string is too long"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("promise string is too long")
+        );
     }
 
     #[test]
@@ -442,10 +444,12 @@ mod tests {
         assert!(result.is_err());
         // This error occurs when Serde tries to deserialize 123 as the String
         // required by `try_from = "String"`.
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("invalid type: integer"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid type: integer")
+        );
     }
 
     #[test]

--- a/plugins/lsps-plugin/src/service.rs
+++ b/plugins/lsps-plugin/src/service.rs
@@ -12,9 +12,9 @@ use cln_lsps::{
         },
         server::LspsService,
     },
-    proto::lsps0::{Msat, LSPS0_MESSAGE_TYPE},
+    proto::lsps0::{LSPS0_MESSAGE_TYPE, Msat},
 };
-use cln_plugin::{options, HookBuilder, HookFilter, Plugin};
+use cln_plugin::{HookBuilder, HookFilter, Plugin, options};
 use log::{debug, error, trace};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/plugins/rest-plugin/Cargo.toml
+++ b/plugins/rest-plugin/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Transforms RPC calls into REST APIs"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"
 repository = "https://github.com/ElementsProject/lightning"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/plugins/rest-plugin/Cargo.toml
+++ b/plugins/rest-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clnrest"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "Transforms RPC calls into REST APIs"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"

--- a/plugins/rest-plugin/src/certs.rs
+++ b/plugins/rest-plugin/src/certs.rs
@@ -12,7 +12,9 @@ pub fn generate_certificates(certs_path: &PathBuf, rest_host: &str) -> Result<()
         "localhost".to_string(),
     ])?;
     ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
-    ca_params.key_usages.push(rcgen::KeyUsagePurpose::KeyCertSign);
+    ca_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyCertSign);
     ca_params.use_authority_key_identifier_extension = true;
     let ca_key = KeyPair::generate()?;
     let ca_cert = ca_params.self_signed(&ca_key)?;
@@ -32,9 +34,15 @@ pub fn generate_certificates(certs_path: &PathBuf, rest_host: &str) -> Result<()
         "localhost".to_string(),
     ])?;
     server_params.is_ca = rcgen::IsCa::NoCa;
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::DigitalSignature);
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyEncipherment);
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyAgreement);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::DigitalSignature);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyEncipherment);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyAgreement);
     server_params.use_authority_key_identifier_extension = true;
     server_params.distinguished_name = DistinguishedName::new();
     server_params

--- a/plugins/rest-plugin/src/handlers.rs
+++ b/plugins/rest-plugin/src/handlers.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, process};
 
 use anyhow::anyhow;
 use axum::{
-    body::{to_bytes, Body},
+    body::{Body, to_bytes},
     extract::{Extension, Json, Path},
     http::{self, Request, StatusCode},
     middleware::Next,
@@ -10,17 +10,17 @@ use axum::{
 };
 use cln_plugin::Plugin;
 use cln_rpc::{
-    model::{requests::HelpRequest, responses::HelpResponse},
     RpcError,
+    model::{requests::HelpRequest, responses::HelpResponse},
 };
 use serde_json::json;
 use socketioxide::extract::{Data, SocketRef};
 use std::fmt::Write;
 
 use crate::{
+    SWAGGER_FALLBACK,
     shared::{call_rpc, filter_json, path_to_rest_map_and_params, verify_rune},
     structs::{AppError, CheckRuneParams, ClnrestMap, PluginState},
-    SWAGGER_FALLBACK,
 };
 
 /* Handler for list-methods */
@@ -122,7 +122,7 @@ pub async fn call_rpc_method(
                 code: None,
                 data: None,
                 message: format!("Could not read request body: {}", e),
-            }))
+            }));
         }
     };
 

--- a/plugins/rest-plugin/src/main.rs
+++ b/plugins/rest-plugin/src/main.rs
@@ -8,10 +8,10 @@ use std::{
 
 use anyhow::anyhow;
 use axum::{
+    Extension, Router,
     http::{HeaderName, HeaderValue},
     middleware,
     routing::{any, get},
-    Extension, Router,
 };
 use axum_server::tls_rustls::RustlsConfig;
 use certs::{do_certificates_exist, generate_certificates};
@@ -22,7 +22,7 @@ use handlers::{
 };
 use options::*;
 use serde_json::json;
-use socketioxide::{handler::ConnectHandler, SocketIo, SocketIoBuilder};
+use socketioxide::{SocketIo, SocketIoBuilder, handler::ConnectHandler};
 use tokio::{
     sync::mpsc::{self, Receiver},
     time,

--- a/plugins/rest-plugin/src/main.rs
+++ b/plugins/rest-plugin/src/main.rs
@@ -48,11 +48,22 @@ mod structs;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    unsafe {
+        // SAFETY:
+        // `std::env::set_var` is unsafe in Rust 2024 because environment variables
+        // are process-global and unsynchronized. Concurrent reads/writes from
+        // multiple threads can cause undefined behavior.
+        //
+        // This call happens at process startup, before any threads are spawned and
+        // before any code that may read environment variables is executed.
+        // Therefore, no concurrent access is possible.
+        std::env::set_var(
+            "CLN_PLUGIN_LOG",
+            "cln_plugin=info,cln_rpc=info,clnrest=debug,warn",
+        )
+    };
+
     log_panics::init();
-    std::env::set_var(
-        "CLN_PLUGIN_LOG",
-        "cln_plugin=info,cln_rpc=info,clnrest=debug,warn",
-    );
 
     let _ = rustls::crypto::ring::default_provider().install_default();
 

--- a/plugins/rest-plugin/src/options.rs
+++ b/plugins/rest-plugin/src/options.rs
@@ -7,17 +7,17 @@ use std::{
 use anyhow::anyhow;
 use axum::http::HeaderValue;
 use cln_plugin::{
+    ConfiguredPlugin,
     options::{
         ConfigOption, DefaultStringArrayConfigOption, DefaultStringConfigOption,
         IntegerConfigOption, StringConfigOption,
     },
-    ConfiguredPlugin,
 };
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::{
-    structs::{ClnrestOptions, ClnrestProtocol},
     PluginState,
+    structs::{ClnrestOptions, ClnrestProtocol},
 };
 
 pub const OPT_CLNREST_PORT: IntegerConfigOption =
@@ -94,7 +94,7 @@ pub fn parse_options(
 
     let swagger = match plugin.option(&OPT_CLNREST_SWAGGER)? {
         swag if !swag.starts_with('/') => {
-            return Err(anyhow!("`clnrest-swagger-root` must start with `/`"))
+            return Err(anyhow!("`clnrest-swagger-root` must start with `/`"));
         }
         swag => swag,
     };

--- a/plugins/rest-plugin/src/shared.rs
+++ b/plugins/rest-plugin/src/shared.rs
@@ -1,12 +1,12 @@
 use axum::http;
 use cln_plugin::Plugin;
 use cln_rpc::{
-    model::responses::{CheckruneResponse, ShowrunesResponse},
     ClnRpc, RpcError,
+    model::responses::{CheckruneResponse, ShowrunesResponse},
 };
 use serde_json::json;
 
-use crate::{structs::AppError, CheckRuneParams, ClnrestMap, PluginState};
+use crate::{CheckRuneParams, ClnrestMap, PluginState, structs::AppError};
 
 pub async fn verify_rune(
     plugin: &Plugin<PluginState>,

--- a/plugins/rest-plugin/src/structs.rs
+++ b/plugins/rest-plugin/src/structs.rs
@@ -16,11 +16,11 @@ use serde_json::json;
 use tokio::sync::mpsc::Sender;
 use tower_http::cors::CorsLayer;
 use utoipa::{
-    openapi::{
-        security::{ApiKey, ApiKeyValue, SecurityScheme},
-        Components,
-    },
     Modify, OpenApi,
+    openapi::{
+        Components,
+        security::{ApiKey, ApiKeyValue, SecurityScheme},
+    },
 };
 
 #[derive(Debug)]

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -336,7 +336,7 @@ where
             None => {
                 return Err(anyhow!(
                     "Lost connection to lightning expecting getmanifest"
-                ))
+                ));
             }
         };
         let (init_id, configuration) = match input.next().await {
@@ -834,10 +834,14 @@ where
                 trace!("Received a message: {:?}", msg);
                 match msg {
                     messages::JsonRpc::Request(_id, _p) => {
-                        todo!("This is unreachable until we start filling in messages:Request. Until then the custom dispatcher below is used exclusively.");
+                        todo!(
+                            "This is unreachable until we start filling in messages:Request. Until then the custom dispatcher below is used exclusively."
+                        );
                     }
                     messages::JsonRpc::Notification(_n) => {
-                        todo!("As soon as we define the full structure of the messages::Notification we'll get here. Until then the custom dispatcher below is used.")
+                        todo!(
+                            "As soon as we define the full structure of the messages::Notification we'll get here. Until then the custom dispatcher below is used."
+                        )
                     }
                     messages::JsonRpc::CustomRequest(id, request) => {
                         trace!("Dispatching custom method {:?}", request);

--- a/plugins/src/logging.rs
+++ b/plugins/src/logging.rs
@@ -4,8 +4,8 @@ use futures::SinkExt;
 use serde::Serialize;
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
-use tokio::sync::mpsc;
 use tokio::sync::Mutex;
+use tokio::sync::mpsc;
 use tokio_util::codec::FramedWrite;
 
 #[derive(Clone, Debug, Serialize)]
@@ -74,8 +74,8 @@ where
 mod trace {
     use super::*;
     use tracing::Level;
-    use tracing_subscriber::prelude::*;
     use tracing_subscriber::Layer;
+    use tracing_subscriber::prelude::*;
 
     /// Initialize the logger starting a flusher to the passed in sink.
     pub fn init<O>(out: Arc<Mutex<FramedWrite<O, JsonCodec>>>) -> Result<(), log::SetLoggerError>

--- a/plugins/src/messages.rs
+++ b/plugins/src/messages.rs
@@ -1,5 +1,5 @@
-use crate::options::UntypedConfigOption;
 use crate::HookFilter;
+use crate::options::UntypedConfigOption;
 use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/plugins/src/options.rs
+++ b/plugins/src/options.rs
@@ -132,8 +132,8 @@
 //!     Ok(())
 //! }
 //! ```
-use serde::ser::{SerializeSeq, Serializer};
 use serde::Serialize;
+use serde::ser::{SerializeSeq, Serializer};
 
 pub mod config_type {
     #[derive(Clone, Debug)]

--- a/plugins/wss-proxy-plugin/Cargo.toml
+++ b/plugins/wss-proxy-plugin/Cargo.toml
@@ -6,23 +6,41 @@ license = "MIT"
 description = "WSS Proxy plugin"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"
 repository = "https://github.com/ElementsProject/lightning"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"
 log = { version = "0.4", features = ['std'] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version="1", features = ['io-std', 'rt-multi-thread', 'sync', 'macros', 'io-util'] }
+tokio = { version = "1", features = [
+    'io-std',
+    'rt-multi-thread',
+    'sync',
+    'macros',
+    'io-util',
+] }
 rcgen = "0.13"
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
 
 tokio-tungstenite = { version = "0.26", features = ["tokio-rustls"] }
 
-rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"]}
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"]}
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "logging",
+    "std",
+    "tls12",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+    "logging",
+    "tls12",
+] }
 
 log-panics = "2"
 
 cln-plugin = { workspace = true }
 cln-rpc = { workspace = true }
-

--- a/plugins/wss-proxy-plugin/Cargo.toml
+++ b/plugins/wss-proxy-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wss-proxy"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "WSS Proxy plugin"
 homepage = "https://github.com/ElementsProject/lightning/tree/master/plugins"

--- a/plugins/wss-proxy-plugin/src/certs.rs
+++ b/plugins/wss-proxy-plugin/src/certs.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use rcgen::{CertificateParams, DistinguishedName, Ia5String, KeyPair};
+use rustls::ServerConfig;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::ServerConfig;
 use std::fs;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
@@ -18,7 +18,9 @@ pub fn generate_certificates(certs_path: &PathBuf, wss_host: &[String]) -> Resul
         "localhost".to_string(),
     ])?;
     ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
-    ca_params.key_usages.push(rcgen::KeyUsagePurpose::KeyCertSign);
+    ca_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyCertSign);
     ca_params.use_authority_key_identifier_extension = true;
     let ca_key = KeyPair::generate()?;
     let ca_cert = ca_params.self_signed(&ca_key)?;
@@ -38,9 +40,15 @@ pub fn generate_certificates(certs_path: &PathBuf, wss_host: &[String]) -> Resul
         "localhost".to_string(),
     ])?;
     server_params.is_ca = rcgen::IsCa::NoCa;
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::DigitalSignature);
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyEncipherment);
-    server_params.key_usages.push(rcgen::KeyUsagePurpose::KeyAgreement);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::DigitalSignature);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyEncipherment);
+    server_params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyAgreement);
     server_params.use_authority_key_identifier_extension = true;
     server_params.distinguished_name = DistinguishedName::new();
     server_params

--- a/plugins/wss-proxy-plugin/src/main.rs
+++ b/plugins/wss-proxy-plugin/src/main.rs
@@ -2,14 +2,14 @@ use std::{net::SocketAddr, process, sync::Arc};
 
 use anyhow::anyhow;
 use certs::get_tls_config;
-use cln_plugin::{options::ConfigOption, Builder};
+use cln_plugin::{Builder, options::ConfigOption};
 
 use futures_util::{SinkExt, StreamExt};
-use options::{parse_options, WssproxyOptions, OPT_WSS_BIND_ADDR, OPT_WSS_CERTS_DIR};
+use options::{OPT_WSS_BIND_ADDR, OPT_WSS_CERTS_DIR, WssproxyOptions, parse_options};
 use rustls::ServerConfig;
 use tokio::net::{TcpListener, TcpStream};
-use tokio_rustls::{server::TlsStream, TlsAcceptor};
-use tokio_tungstenite::{accept_async, WebSocketStream};
+use tokio_rustls::{TlsAcceptor, server::TlsStream};
+use tokio_tungstenite::{WebSocketStream, accept_async};
 
 mod certs;
 mod options;

--- a/plugins/wss-proxy-plugin/src/main.rs
+++ b/plugins/wss-proxy-plugin/src/main.rs
@@ -16,11 +16,22 @@ mod options;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    unsafe {
+        // SAFETY:
+        // `std::env::set_var` is unsafe in Rust 2024 because environment variables
+        // are process-global and unsynchronized. Concurrent reads/writes from
+        // multiple threads can cause undefined behavior.
+        //
+        // This call happens at process startup, before any threads are spawned and
+        // before any code that may read environment variables is executed.
+        // Therefore, no concurrent access is possible.
+        std::env::set_var(
+            "CLN_PLUGIN_LOG",
+            "cln_plugin=info,cln_rpc=info,wss_proxy=debug,warn",
+        )
+    };
+
     log_panics::init();
-    std::env::set_var(
-        "CLN_PLUGIN_LOG",
-        "cln_plugin=info,cln_rpc=info,wss_proxy=debug,warn",
-    );
 
     let opt_wss_proxy_bind_addr = ConfigOption::new_str_arr_no_default(
         OPT_WSS_BIND_ADDR,

--- a/plugins/wss-proxy-plugin/src/options.rs
+++ b/plugins/wss-proxy-plugin/src/options.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::anyhow;
 use cln_plugin::ConfiguredPlugin;
-use cln_rpc::{model::requests::ListconfigsRequest, ClnRpc};
+use cln_rpc::{ClnRpc, model::requests::ListconfigsRequest};
 
 pub const OPT_WSS_BIND_ADDR: &str = "wss-bind-addr";
 pub const OPT_WSS_CERTS_DIR: &str = "wss-certs";


### PR DESCRIPTION
Previously the MSRV was only implied as 1.85 in some places in the project. Now we set it explicitly for cargo and check it on any rust related file changes with a CI job and make full use of it with the new 2024 edition.

I've ran `cargo fix --edition` and three changes were noticeable:
- `set_var` is now unsafe, i've added a SAFETY comment on each to explain why
  this is fine here.
- conversions of several `if let` to `match` because of the new [`if let` temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html) 
  I have reviewed and restored all of them since the behaviour was the same on each.
- the macro `expr` was converted to `expr_2021` in the lsps plugin, i have reverted those
  as well since we don't use `const` or `_` expressions: [Macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html)

Also a `cargo fmt --all` run for the new formatting rules of 2024 edition

These changes will make `cargo update` on all rust versions use the new resolver to upgrade dependencies only as far as 1.85 supports. That is only part of ensuring the MSRV and it's also not perfect. There might also be new code patterns not supported by 1.85 so we need the CI job to verify the MSRV.

We do all this so people with current distros don't necessarily need to install and manage rust with `rustup`.