### PR TITLE
connectd: remove DNS seeds entirely.

### DIFF
--- a/connectd/connectd.c
+++ b/connectd/connectd.c
@@ -1829,30 +1829,6 @@ static void connect_activate(struct daemon *daemon, const u8 *msg)
 			 take(towire_connectd_activate_reply(NULL, errmsg)));
 }
 
-/* BOLT #10:
- *
- * The DNS seed:
- *   ...
- *   - upon receiving a _node_ query:
- *     - MUST select the record matching the `node_id`, if any, AND return all
- *       addresses associated with that node.
- */
-static const char **seednames(const tal_t *ctx, const struct node_id *id)
-{
-	char bech32[100];
-	u5 *data = tal_arr(ctx, u5, 0);
-	const char **seednames = tal_arr(ctx, const char *, 0);
-
-	bech32_push_bits(&data, id->k, ARRAY_SIZE(id->k)*8);
-	bech32_encode(bech32, "ln", data, tal_count(data), sizeof(bech32),
-		      BECH32_ENCODING_BECH32);
-	/* This is cdecker's seed */
-	tal_arr_expand(&seednames, tal_fmt(seednames, "%s.lseed.bitcoinstats.com", bech32));
-	/* This is darosior's seed */
-	tal_arr_expand(&seednames, tal_fmt(seednames, "%s.lseed.darosior.ninja", bech32));
-	return seednames;
-}
-
 static bool addr_in(const struct wireaddr_internal *needle,
 		    const struct wireaddr_internal haystack[])
 {
@@ -1869,7 +1845,6 @@ static void try_connect_peer(struct daemon *daemon,
 			     struct wireaddr_internal *addrs TAKES,
 			     const char *reason TAKES)
 {
-	bool use_proxy = daemon->always_use_proxy;
 	struct connecting *connect;
 	struct peer *peer;
 
@@ -1895,22 +1870,6 @@ static void try_connect_peer(struct daemon *daemon,
 		}
 
 		return;
-	}
-
-	if (tal_count(addrs) == 0) {
-		/* Don't resolve via DNS seed if we're supposed to use proxy. */
-		if (use_proxy) {
-			/* You're allowed to use names with proxies; in fact it's
-			 * a good idea. */
-			struct wireaddr_internal unresolved;
-			const char **hostnames = seednames(tmpctx, id);
-			for (size_t i = 0; i < tal_count(hostnames); i++) {
-				wireaddr_from_unresolved(&unresolved,
-				                         hostnames[i],
-				                         chainparams_get_ln_port(chainparams));
-				tal_arr_expand(&addrs, unresolved);
-			}
-		}
 	}
 
 	/* Still no address?  Fail immediately.  Important ones get


### PR DESCRIPTION
For 25.05 (0a94f3b5706cd06e69ca120f1b77da8562cd2453) we removed DNS lookups, but we left them for the corner case where a proxy is used.  darosior points out that his is no longer functional, which brought my attention to this vestigial corner case.

Changelog-None: we said we'd removed them earlier!
Reported-by: darosior
Closes: https://github.com/ElementsProject/lightning/pull/8968
