### PR TITLE
Fix injectpaymentonion fees

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -16124,7 +16124,7 @@
           "amount_msat": {
             "type": "msat",
             "description": [
-              "The amount for the first HTLC in millisatoshis.  This is also the amount which will be forwarded to the first peer (if any) as we do not charge fees on our own payments.  Note: this is shown in listsendpays as `amount_sent_msat`."
+              "The amount in millisatoshis this node would receive from a peer before forwarding the payment to the next."
             ]
           },
           "cltv_expiry": {

--- a/doc/schemas/injectpaymentonion.json
+++ b/doc/schemas/injectpaymentonion.json
@@ -34,7 +34,7 @@
       "amount_msat": {
         "type": "msat",
         "description": [
-          "The amount for the first HTLC in millisatoshis.  This is also the amount which will be forwarded to the first peer (if any) as we do not charge fees on our own payments.  Note: this is shown in listsendpays as `amount_sent_msat`."
+          "The amount in millisatoshis this node would receive from a peer before forwarding the payment to the next."
         ]
       },
       "cltv_expiry": {

--- a/lightningd/pay.c
+++ b/lightningd/pay.c
@@ -1973,7 +1973,7 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 		register_payment_and_waiter(cmd,
 					    payment_hash,
 					    *partid, *groupid,
-					    *destination_msat, *msat, AMOUNT_MSAT(0),
+					    *destination_msat, payload->amt_to_forward, AMOUNT_MSAT(0),
 					    label, invstring, local_invreq_id,
 					    &shared_secret,
 					    destination);
@@ -1981,7 +1981,7 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 		/* Mark it pending now, though htlc_set_add might
 		 * not resolve immediately */
 		fixme_ignore(command_still_pending(cmd));
-		htlc_set_add(cmd->ld, cmd->ld->log, *msat, *payload->total_msat,
+		htlc_set_add(cmd->ld, cmd->ld->log, payload->amt_to_forward, *payload->total_msat,
 			     NULL, payment_hash, payload->payment_secret,
 			     selfpay_mpp_fail, selfpay_mpp_succeeded,
 			     selfpay);
@@ -2017,22 +2017,22 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 					    "Unknown peer %s",
 					    fmt_node_id(tmpctx, &nid));
 
-		next = best_channel(cmd->ld, next_peer, *msat, NULL);
+		next = best_channel(cmd->ld, next_peer, payload->amt_to_forward, NULL);
 		if (!next)
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "No available channel with peer %s",
 					    fmt_node_id(tmpctx, &nid));
 	}
 
-	if (amount_msat_greater(*msat, next->htlc_maximum_msat)
-	    || amount_msat_less(*msat, next->htlc_minimum_msat)) {
+	if (amount_msat_greater(payload->amt_to_forward, next->htlc_maximum_msat)
+	    || amount_msat_less(payload->amt_to_forward, next->htlc_minimum_msat)) {
 		/* Are we in old-range grace-period? */
 		if (!timemono_before(time_mono(), next->old_feerate_timeout)
-		    || amount_msat_less(*msat, next->old_htlc_minimum_msat)
-		    || amount_msat_greater(*msat, next->old_htlc_maximum_msat)) {
+		    || amount_msat_less(payload->amt_to_forward, next->old_htlc_minimum_msat)
+		    || amount_msat_greater(payload->amt_to_forward, next->old_htlc_maximum_msat)) {
 			return command_fail(cmd, JSONRPC2_INVALID_PARAMS,
 					    "Amount %s not in htlc min/max range %s-%s",
-					    fmt_amount_msat(tmpctx, *msat),
+					    fmt_amount_msat(tmpctx, payload->amt_to_forward),
 					    fmt_amount_msat(tmpctx, next->htlc_minimum_msat),
 					    fmt_amount_msat(tmpctx, next->htlc_maximum_msat));
 		}
@@ -2085,11 +2085,11 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 	if (command_check_only(cmd))
 		return command_check_done(cmd);
 
-	failmsg = send_htlc_out(tmpctx, next, *msat,
+	failmsg = send_htlc_out(tmpctx, next, payload->amt_to_forward,
 				*cltv,
 				/* If unknown, we set this equal (so accounting logs 0 fees) */
 				amount_msat_eq(*destination_msat, AMOUNT_MSAT(0))
-				? *msat : *destination_msat,
+				? payload->amt_to_forward : *destination_msat,
 				payment_hash,
 				next_path_key, NULL, *partid, *groupid,
 				serialize_onionpacket(tmpctx, rs->next),
@@ -2104,7 +2104,7 @@ static struct command_result *json_injectpaymentonion(struct command *cmd,
 	register_payment_and_waiter(cmd,
 				    payment_hash,
 				    *partid, *groupid,
-				    *destination_msat, *msat, AMOUNT_MSAT(0),
+				    *destination_msat, payload->amt_to_forward, AMOUNT_MSAT(0),
 				    label, invstring, local_invreq_id,
 				    &shared_secret,
 				    destination);

--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -346,6 +346,13 @@ static struct amount_msat initial_sent(const struct attempt *attempt)
 {
 	if (tal_count(attempt->hops) == 0)
 		return attempt->delivers;
+	return attempt->hops[0].amount_out;
+}
+
+static struct amount_msat inject_amount(const struct attempt *attempt)
+{
+	if (tal_count(attempt->hops) == 0)
+		return attempt->delivers;
 	return attempt->hops[0].amount_in;
 }
 
@@ -1151,7 +1158,7 @@ static struct command_result *do_inject(struct command *aux_cmd,
 	json_add_hex_talarr(req->js, "onion", onion);
 	json_add_sha256(req->js, "payment_hash", &attempt->payment->payment_hash);
 	/* If no route, its the same as delivery (self-pay) */
-	json_add_amount_msat(req->js, "amount_msat", initial_sent(attempt));
+	json_add_amount_msat(req->js, "amount_msat", inject_amount(attempt));
 	json_add_u32(req->js, "cltv_expiry", initial_cltv_delta(attempt) + effective_bheight);
 	json_add_u64(req->js, "partid", attempt->partid);
 	json_add_u64(req->js, "groupid", attempt->payment->group_id);
@@ -1466,7 +1473,8 @@ static struct command_result *getroutes_for(struct command *aux_cmd,
 	json_array_start(req->js, "layers");
 	/* Add local channels */
 	json_add_string(req->js, NULL, "auto.localchans");
-	/* We don't pay fees for ourselves */
+	/* For the MCF computation we must discard the cost of routing through
+	 * our own channels because we don't pay fees for that. */
 	json_add_string(req->js, NULL, "auto.sourcefree");
 	/* Add xpay global channel */
 	json_add_string(req->js, NULL, "xpay");

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -6360,7 +6360,7 @@ def test_injectpaymentonion_selfpay(node_factory, executor):
              'payload': serialize_payload_final_tlv(333, 18, 1000, blockheight, inv5['payment_secret']).hex()}]
     onion1 = l1.rpc.createonion(hops=hops1, assocdata=inv5['payment_hash'])
     hops2 = [{'pubkey': l1.info['id'],
-             'payload': serialize_payload_final_tlv(666, 18, 1000, blockheight, inv5['payment_secret']).hex()}]
+             'payload': serialize_payload_final_tlv(667, 18, 1000, blockheight, inv5['payment_secret']).hex()}]
     onion2 = l1.rpc.createonion(hops=hops2, assocdata=inv5['payment_hash'])
 
     fut1 = executor.submit(l1.rpc.injectpaymentonion,

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -1072,3 +1072,38 @@ def test_xpay_blockheight_mismatch(node_factory, bitcoind, executor):
     # Now let it catch up, and it will retry, and succeed.
     l1.daemon.rpcproxy.mock_rpc('getblockhash')
     fut.result(TIMEOUT)
+
+
+@pytest.mark.xfail(strict=True)
+def test_blinded_path_fees(node_factory):
+    """Test that we don't send the amount+fees to our direct peer (we should
+    only send the required amount) when the sending node is the entry point in
+    the blinded path."""
+    AMT_MSAT = 10000
+    FEES_MSAT = 5000
+    l1, l2 = node_factory.get_nodes(
+        2, opts={"may_reconnect": True, "fee-base": FEES_MSAT, "fee-per-satoshi": 0}
+    )
+    node_factory.join_nodes([l1, l2], wait_for_announce=True)
+
+    offer = l2.rpc.offer(amount="any", fronting_nodes=[l1.info["id"]])["bolt12"]
+    b12 = l1.rpc.fetchinvoice(offer, AMT_MSAT)["invoice"]
+
+    b12_decode = l1.rpc.decode(b12)
+    assert b12_decode["invoice_amount_msat"] == AMT_MSAT
+    assert len(b12_decode["invoice_paths"]) == 1
+    assert b12_decode["invoice_paths"][0]["first_node_id"] == l1.info["id"]
+    assert b12_decode["invoice_paths"][0]["payinfo"]["fee_base_msat"] == FEES_MSAT
+    assert b12_decode["invoice_paths"][0]["payinfo"]["fee_proportional_millionths"] == 0
+
+    ret = l1.rpc.xpay(invstring=b12)
+    assert ret["failed_parts"] == 0
+    assert ret["successful_parts"] == 1
+    assert ret["amount_msat"] == AMT_MSAT
+    assert ret["amount_sent_msat"] == AMT_MSAT + FEES_MSAT
+
+    # we pay fees to ourselves
+    htlcs = l1.rpc.listhtlcs()["htlcs"]
+    assert len(htlcs) == 1
+    assert htlcs[0]["payment_hash"] == b12_decode["invoice_payment_hash"]
+    assert htlcs[0]["amount_msat"] == AMT_MSAT

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -1074,7 +1074,6 @@ def test_xpay_blockheight_mismatch(node_factory, bitcoind, executor):
     fut.result(TIMEOUT)
 
 
-@pytest.mark.xfail(strict=True)
 def test_blinded_path_fees(node_factory):
     """Test that we don't send the amount+fees to our direct peer (we should
     only send the required amount) when the sending node is the entry point in

--- a/tests/test_xpay.py
+++ b/tests/test_xpay.py
@@ -1099,9 +1099,8 @@ def test_blinded_path_fees(node_factory):
     assert ret["failed_parts"] == 0
     assert ret["successful_parts"] == 1
     assert ret["amount_msat"] == AMT_MSAT
-    assert ret["amount_sent_msat"] == AMT_MSAT + FEES_MSAT
+    assert ret["amount_sent_msat"] == AMT_MSAT
 
-    # we pay fees to ourselves
     htlcs = l1.rpc.listhtlcs()["htlcs"]
     assert len(htlcs) == 1
     assert htlcs[0]["payment_hash"] == b12_decode["invoice_payment_hash"]


### PR DESCRIPTION
Fixes issue #9006.

According to the description of `injectpaymentonion` this command simulates an incoming htlc from a peer.
The onion to us contains the information to deduce the next hop.
To be consistent with this this description, the command parameter `amount_msat` should correspond to the
amount the peer has provided to us and not the amount we should forward to our next peer.

The intention is deduced from this statement
```c
	payload = onion_decode(tmpctx, rs, blinding,
			       cmd->ld->accept_extra_tlv_types,
			       *msat, *cltv,
			       &failtlvtype,
			       &failtlvpos,
			       &explanation);
```
`msat` is the `amount_msat` parameter from the RPC, therefore is interpreted as the `amount_in`.
We did not see this before because we were using `auto.sourcefree` layer.

