### PR TITLE
pytest: fix test on MacOS -- still BROKEN message from l1 during teardown

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1797,11 +1797,15 @@ def test_ipv4_and_ipv6(node_factory):
         assert bind[1]['address'] == '0.0.0.0'
         assert int(bind[1]['port']) == port
     else:
-        # Assume we're IPv4 only...
         assert len(bind) == 1
-        assert bind[0]['type'] == 'ipv4'
-        assert bind[0]['address'] == '0.0.0.0'
-        assert int(bind[0]['port']) == port
+        if bind[0]['type'] == 'ipv4':
+            assert bind[0]['type'] == 'ipv4'
+            assert bind[0]['address'] == '0.0.0.0'
+            assert int(bind[0]['port']) == port
+        else:
+            assert bind[0]['type'] == 'ipv6'
+            assert bind[0]['address'] == '::'
+            assert int(bind[0]['port']) == port
 
 
 @unittest.skipIf(TEST_NETWORK == 'liquid-regtest', "Fees on elements are different")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

fix pyrest FAILED issue mentioned in #9013 