### PR TITLE
pytest: fix flake in test_easy_splice_out_into_channel

### DIFF
--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -708,10 +708,8 @@ def test_easy_splice_out_into_channel(node_factory, bitcoind, chainparams):
     bitcoind.generate_block(6, wait_for_mempool=1)
     l2.daemon.wait_for_log(r'lightningd, splice_locked clearing inflights')
 
-    p1 = only_one(l1.rpc.listpeerchannels()['channels'])
-    p2 = only_one(l3.rpc.listpeerchannels()['channels'])
-    assert 'inflight' not in p1
-    assert 'inflight' not in p2
+    wait_for(lambda: 'inflight' not in only_one(l1.rpc.listpeerchannels()['channels']))
+    wait_for(lambda: 'inflight' not in only_one(l3.rpc.listpeerchannels()['channels']))
 
     wait_for(lambda: len(l2.rpc.listfunds()['outputs']) == 1)
     wait_for(lambda: len(l2.rpc.listfunds()['channels']) == 2)


### PR DESCRIPTION
```
2026-04-01T07:56:01.0560642Z >       assert 'inflight' not in p1
2026-04-01T07:56:01.0581633Z E       AssertionError: assert 'inflight' not in {'peer_id': '033845802d25b4e074ccfd7cd8b339a41dc75bf9978a034800444b51d42b07799a', 'peer_connected': True, 'reestablished': True, 'channel_type': {'bits': [12, 22], 'names': ['static_remotekey/even', 'anchors/even']}, 'updates': {'local': {'htlc_minimum_msat': 0, 'htlc_maximum_msat': 990000000, 'cltv_expiry_delta': 6, 'fee_base_msat': 1, 'fee_proportional_millionths': 10}, 'remote': {'htlc_minimum_msat': 0, 'htlc_maximum_msat': 990000000, 'cltv_expiry_delta': 6, 'fee_base_msat': 1, 'fee_proportional_millionths': 10}}, 'state': 'CHANNELD_AWAITING_SPLICE', 'scratch_txid': 'bf969125a0929605ba1e007912173fbf55cc67e19963e6d87a66066b7d764d9d', 'last_tx_fee_msat': 4545000, 'lost_state': False, 'feerate': {'perkw': 3750, 'perkb': 15000}, 'owner': 'channeld', 'short_channel_id': '103x2x0', 'direction': 1, 'channel_id': '68c2b5982e67b7dbd42d310e2dd481831c5add0d6a541fec6e26d000fd0ea0f4', 'funding_txid': 'f4a00efd00d0266eec1f546a0ddd5a1c8381d42d0e312dd4dbb7672e98b5c268', 'funding_outnum': 0, 'initial_feerate': '939perkw', 'last_feerate': '939perkw', 'next_feerate': '978perkw', 'inflight': [{'funding_txid': '88f913adf41749a106c97cea7a6f6e448efa73fc6bc9325b78802188d8b0b67d', 'funding_outnum': 1, 'feerate': '939perkw', 'total_funding_msat': 1100000000, 'our_funding_msat': 1000000000, 'splice_amount': 0, 'scratch_txid': '1076f7048d0c1debb7bf2e1d448b3f1345a6973e24dc6a2fadade67ef75133aa'}], 'close_to_addr': 'bcrt1p9r2qj40kfad955p2arkd70lpyh0epugjljrm2djh6483kqffg04q9fufhw', 'close_to': '512028d40955f64f5a5a502ae8ecdf3fe125df90f112fc87b53657d54f1b012943ea', 'private': False, 'opener': 'local', 'alias': {'local': '7654047x8069664x16198', 'remote': '14528636x6434403x24187'}, 'features': ['option_static_remotekey', 'option_anchors'], 'funding': {'local_funds_msat': 1000000000, 'remote_funds_msat': 0, 'pushed_msat': 0, 'psbt': 'cHNidP8BAgQCAAAAAQMEZgAAAAEEAQEBBQECAQYBAwH7BAIAAAAAAQBxAgAAAAE/IGufqbpSEgvYbw685nDEyMxGKL9FlQilR593oz4l8wAAAAAA/f///wLzbOcpAQAAABYAFLikxoEHURUNIRqJZO+hZBpDIRdbgIQeAAAAAAAWABTiR1/vOKdPfmxe7PFjWeVXM/PEamUAAAABAR+AhB4AAAAAABYAFOJHX+84p09+bF7s8WNZ5Vcz88RqAQhrAkcwRAIgffBOLzpOGluuXVQL3+Nh57/v1KiZMmTQ8azbTp1uvq8CIEEJMg/FcFFBRhJEEj7+qSAWJ1zYMoTRkLXnz2kYn1t+ASECAuzPYkKg0uX0lzjSQPmcEN8Qg4GvjKKB1Kggpt1l4X8BDiBsxRVtCsARg7eO1wBCa1Q9QSO1uVsgKM0CdYaTNqNDaQEPBAEAAAABEAT9////DPwJbGlnaHRuaW5nAgIAAQz8CWxpZ2h0bmluZwEItnNGZ/Bz25IAAQMIQEIPAAAAAAABBCIAIAudZByKBPnrEYNlicb4obXo+9D41IAxB52EsOTPC6lrAAEDCAEvDwAAAAAAAQQiUSCfpNJOnaQ8W/j8DZc21ORFI4rNcU0GgRbfUWXQeR26HSEHoyOuZ721tL0aN6eJJY4wZEeSiAU21KuPQRiZUZCCbScJAIgBXIECAAAADPwJbGlnaHRuaW5nAQixrSLGhyK6fAA=', 'withheld': False}, 'to_us_msat': 1000000000, 'min_to_us_msat': 1000000000, 'max_to_us_msat': 1000000000, 'total_msat': 1000000000, 'fee_base_msat': 1, 'fee_proportional_millionths': 10, 'dust_limit_msat': 546000, 'their_max_htlc_value_in_flight_msat': 18446744073709551615, 'our_max_htlc_value_in_flight_msat': 18446744073709551615, 'their_reserve_msat': 10000000, 'our_reserve_msat': 10000000, 'spendable_msat': 978718000, 'receivable_msat': 0, 'minimum_htlc_in_msat': 0, 'minimum_htlc_out_msat': 0, 'maximum_htlc_out_msat': 990000000, 'their_to_self_delay': 5, 'our_to_self_delay': 5, 'max_accepted_htlcs': 483, 'state_changes': [{'timestamp': '2026-04-01T07:52:32.735Z', 'old_state': 'CHANNELD_AWAITING_LOCKIN', 'new_state': 'CHANNELD_NORMAL', 'cause': 'user', 'message': 'Lockin complete'}, {'timestamp': '2026-04-01T07:52:51.053Z', 'old_state': 'CHANNELD_NORMAL', 'new_state': 'CHANNELD_AWAITING_SPLICE', 'cause': 'remote', 'message': 'Splice signatures sent'}], 'status': ['CHANNELD_NORMAL:Channel ready for use.'], 'in_payments_offered': 0, 'in_offered_msat': 0, 'in_payments_fulfilled': 0, 'in_fulfilled_msat': 0, 'out_payments_offered': 0, 'out_offered_msat': 0, 'out_payments_fulfilled': 0, 'out_fulfilled_msat': 0, 'htlcs': []}
2026-04-01T07:56:01.0603053Z
2026-04-01T07:56:01.0607410Z tests/test_splice.py:713: AssertionError
```

We need to wait for this, as l1 and l3 may not have seen block yet.

Changelog-None: flake