### PR TITLE
CI: Check generated docs on Mac

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,6 +51,7 @@ jobs:
 
           uv run ./configure --disable-valgrind --disable-compat
           uv run make
+          uv run make check-gen-updated
 
       - name: Start bitcoind in regtest mode
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,6 +51,7 @@ jobs:
 
           uv run ./configure --disable-valgrind --disable-compat
           uv run gmake
+          uv run gmake check-gen-updated
 
       - name: Start bitcoind in regtest mode
         run: |


### PR DESCRIPTION
Test that the docs generated on Mac match the docs in the commit

There is a recurring issue that appears to be a mismatch between how docs are generated on Mac vs Linux. Adding this test to CI should help make it more clear when this divergence occurs.