### PR TITLE
pytest: test spliceout exceeds channel balance

### DIFF
--- a/plugins/spender/splice.c
+++ b/plugins/spender/splice.c
@@ -187,7 +187,7 @@ static struct command_result *do_fail(struct command *cmd,
 		   "splice_error(psbt:%p, splice_cmd:%p, str: %s)",
 		   splice_cmd->psbt, splice_cmd, str ?: "");
 
-	abort_pkg = tal(cmd->plugin, struct abort_pkg);
+	abort_pkg = tal(cmd, struct abort_pkg);
 	abort_pkg->splice_cmd = tal_steal(abort_pkg, splice_cmd);
 	abort_pkg->str = tal_strdup(abort_pkg, str);
 	abort_pkg->code = code;

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -1,6 +1,6 @@
 from fixtures import *  # noqa: F401,F403
 from pathlib import Path
-from pyln.client import Millisatoshi
+from pyln.client import RpcError, Millisatoshi
 import pytest
 import re
 import unittest
@@ -716,3 +716,16 @@ def test_easy_splice_out_into_channel(node_factory, bitcoind, chainparams):
 
     end_chan1_balance = Millisatoshi(bkpr_account_balance(l2, chan1))
     assert initial_chan1_balance + Millisatoshi(spliceamt * 1000) == end_chan1_balance
+
+
+@pytest.mark.xfail(strict=True)
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+def test_spliceout_exceeds_channel_balance(node_factory):
+    l1, l2 = node_factory.line_graph(2, fundamount=1000000, wait_for_announce=True,
+                                     opts={'experimental-splicing': None})
+    with pytest.raises(RpcError):
+        l1.rpc.spliceout("*:?", "99999999")  # way more than channel holds
+    p1 = only_one(l1.rpc.listpeerchannels(peer_id=l2.info['id'])['channels'])
+    assert 'inflight' not in p1

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -723,6 +723,7 @@ def test_easy_splice_out_into_channel(node_factory, bitcoind, chainparams):
 @pytest.mark.openchannel('v2')
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 def test_spliceout_exceeds_channel_balance(node_factory):
+    """Test splicing out more than the channel balance fails"""
     l1, l2 = node_factory.line_graph(2, fundamount=1000000, wait_for_announce=True,
                                      opts={'experimental-splicing': None})
     with pytest.raises(RpcError):

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -718,7 +718,6 @@ def test_easy_splice_out_into_channel(node_factory, bitcoind, chainparams):
     assert initial_chan1_balance + Millisatoshi(spliceamt * 1000) == end_chan1_balance
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.openchannel('v1')
 @pytest.mark.openchannel('v2')
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.

Changelog-None

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`


Test to reproduce #9041