### PR TITLE
Makefile: don't try to make generate files .INTERMEDIATE.

### DIFF
--- a/wire/Makefile
+++ b/wire/Makefile
@@ -109,8 +109,6 @@ wire/channel_type_wiregen.c_args := $(wire/channel_type_wiregen.h_args)
 WIRE_GENERATED := $(filter %printgen.h %printgen.c %wiregen.h %wiregen.c, $(WIRE_SRC) $(WIRE_HEADERS))
 $(WIRE_GENERATED): wire/Makefile
 
-# You don't need to keep these if they don't exist.
-.INTERMEDIATE: $(WIRE_GENERATED)
 
 maintainer-clean: wire-maintainer-clean
 


### PR DESCRIPTION
Because they get deleted, `make install` ends up regenerating them, and they trigger object rebuilds.

Fixes: https://github.com/ElementsProject/lightning/issues/8971

Changelog-None