### PR TITLE
startup_regtest.sh refactor

### DIFF
--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -406,13 +406,14 @@ stop_nodes() {
 }
 
 stop_ln() {
-	stop_nodes "$@"
-	test ! -f "$BITCOIN_DIR/regtest/bitcoind.pid" || \
-		(kill "$(cat "$BITCOIN_DIR/regtest/bitcoind.pid")"; \
-		rm "$BITCOIN_DIR/regtest/bitcoind.pid")
+	network=${1:-regtest}
+	stop_nodes "$network"
+	test ! -f "$BITCOIN_DIR/$network/bitcoind.pid" || \
+		(kill "$(cat "$BITCOIN_DIR/$network/bitcoind.pid")"; \
+		rm "$BITCOIN_DIR/$network/bitcoind.pid")
 
 	unset LN_NODES
-	unalias bt-cli
+	unalias bt-cli 2>/dev/null || true
 }
 
 node_info() {

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -428,6 +428,14 @@ node_info() {
 }
 
 destroy_ln() {
+	if [ -n "$LN_NODES" ]; then
+		printf "Nodes are still running. Stop them now with stop_ln? [y/N] "
+		read -r yn
+		case "$yn" in
+			[Yy]*) stop_ln ;;
+			*) echo "Aborting. Call stop_ln before destroy_ln."; return 1 ;;
+		esac
+	fi
 	rm -rf "$LIGHTNING_DIR"/l[0-9]*
 }
 

--- a/contrib/startup_regtest.sh
+++ b/contrib/startup_regtest.sh
@@ -428,6 +428,15 @@ node_info() {
 }
 
 destroy_ln() {
+	network=${1:-regtest}
+	if [ -n "$LN_NODES" ]; then
+		printf "Nodes are still running. Stop them now with stop_ln? [y/N] "
+		read -r yn
+		case "$yn" in
+			[Yy]*) stop_ln "$network" ;;
+			*) echo "Aborting. Call stop_ln before destroy_ln."; return 1 ;;
+		esac
+	fi
 	rm -rf "$LIGHTNING_DIR"/l[0-9]*
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.

Changelog-None

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`


## Content

Me and @enaples are working on improving startup_regtest.sh as it

- config is now called lightning.conf
- experimental-splicing is now default and shouldn't be called explicitly
- adding support for manual fee rate setting from conf
- check if other instances of lightningd are already running with same config when launching the script
- improve functions documentation
- more if needed