### PR TITLE
pytest: test utxopsbt with multiple taproot inputs does not crash the…

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3031,10 +3031,10 @@ def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
 
     amount = 200000
 
-    bitcoind.rpc.sendmany("", 
+    bitcoind.rpc.sendmany("",
                           {l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8,
                            l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8})
-    
+
     bitcoind.generate_block(1)
 
     wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 2)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1,3 +1,5 @@
+from itertools import count
+
 from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from pyln.client import RpcError, Millisatoshi
@@ -3018,3 +3020,34 @@ def test_zeroconf_withhold_htlc_failback(node_factory, bitcoind):
 
     # l1's channel to l2 is still normal — no force-close
     assert only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['state'] == 'CHANNELD_NORMAL'
+
+
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
+    """Test signpsbt when a PSBT has a multiple taproot input"""
+    l1 = node_factory.get_node(opts=[{'experimental-dual-fund': None}])
+
+    amount = 200000
+
+    bitcoind.rpc.sendmany("", 
+                          {l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8,
+                           l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8})
+    
+    bitcoind.generate_block(1)
+
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 2)
+
+    bitcoind.generate_block(6)
+    outputs = l1.rpc.listfunds()['outputs']
+
+    tx_list = []
+    for o in outputs:
+        txid = o['txid']
+        vout = o['output']
+        tx_list.append(f"{txid}:{vout}")
+
+    psbt = l1.rpc.utxopsbt("all", "300perkw", 1000, tx_list)['psbt']
+
+    result = l1.rpc.signpsbt(psbt)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -1,5 +1,3 @@
-from itertools import count
-
 from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from pyln.client import RpcError, Millisatoshi
@@ -3050,4 +3048,4 @@ def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
 
     psbt = l1.rpc.utxopsbt("all", "300perkw", 1000, tx_list)['psbt']
 
-    result = l1.rpc.signpsbt(psbt)
+    l1.rpc.signpsbt(psbt)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3089,3 +3089,32 @@ def test_no_retransmit_confirmed_funding(node_factory):
     # Should not have attempted (and failed) to re-broadcast the funding tx.
     assert not l1.daemon.is_in_log('Failed to re-transmit funding tx')
     assert not l1.daemon.is_in_log('Successfully rexmitted funding tx')
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
+    """Test signpsbt when a PSBT has a multiple taproot input"""
+    l1 = node_factory.get_node(options={'experimental-dual-fund': None})
+
+    amount = 200000
+
+    bitcoind.rpc.sendmany("",
+                          {l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8,
+                           l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8})
+
+    bitcoind.generate_block(1)
+
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 2)
+
+    bitcoind.generate_block(6)
+    outputs = l1.rpc.listfunds()['outputs']
+
+    tx_list = []
+    for o in outputs:
+        txid = o['txid']
+        vout = o['output']
+        tx_list.append(f"{txid}:{vout}")
+
+    psbt = l1.rpc.utxopsbt("all", "300perkw", 1000, tx_list)['psbt']
+
+    l1.rpc.signpsbt(psbt)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3091,30 +3091,75 @@ def test_no_retransmit_confirmed_funding(node_factory):
     assert not l1.daemon.is_in_log('Successfully rexmitted funding tx')
 
 
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
-def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
-    """Test signpsbt when a PSBT has a multiple taproot input"""
-    l1 = node_factory.get_node(options={'experimental-dual-fund': None})
+def test_signpsbt_taproot_no_outputs_does_not_crash(node_factory, bitcoind):
+    """signpsbt on an output-less PSBT must fail the RPC, not kill the node.
+
+    utxopsbt(satoshi="all") hands back a template with inputs but no
+    outputs. A taproot sighash commits to the outputs, so libwally cannot
+    sign it (expected). What is not expected is that hsmd turns
+    that refusal into hsmd_status_failed(), which takes the whole node down.
+
+    The number of inputs is irrelevant here: one taproot input is enough.
+    """
+    l1 = node_factory.get_node()
 
     amount = 200000
-
-    bitcoind.rpc.sendmany("",
-                          {l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8,
-                           l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8})
-
+    bitcoind.rpc.sendtoaddress(l1.rpc.newaddr('all')['p2tr'], amount / 10 ** 8)
     bitcoind.generate_block(1)
 
-    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 2)
-
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 1)
     bitcoind.generate_block(6)
-    outputs = l1.rpc.listfunds()['outputs']
 
-    tx_list = []
-    for o in outputs:
-        txid = o['txid']
-        vout = o['output']
-        tx_list.append(f"{txid}:{vout}")
+    tx_list = ["{}:{}".format(o['txid'], o['output'])
+               for o in l1.rpc.listfunds()['outputs']]
 
     psbt = l1.rpc.utxopsbt("all", "300perkw", 1000, tx_list)['psbt']
 
-    l1.rpc.signpsbt(psbt)
+    # Don't match on the message: depending on which failure wins the race
+    # we see either "Connection to RPC server lost" or "HSM gave bad
+    # sign_withdrawal_reply".
+    with pytest.raises(RpcError):
+        l1.rpc.signpsbt(psbt)
+
+    # FIXME: hsmd hits a wally_err in sign_our_inputs() and calls
+    # hsmd_status_failed(STATUS_FAIL_INTERNAL_ERROR), so the node is gone by
+    # now and this raises instead of returning.  It should have rejected the
+    # PSBT and stayed up.
+    assert l1.rpc.getinfo()['id'] is not None
+
+
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+def test_signpsbt_multiple_taproot_inputs(node_factory, bitcoind):
+    """signpsbt must produce a valid signature for every taproot input."""
+    l1 = node_factory.get_node()
+
+    amount = 200000
+    bitcoind.rpc.sendmany("",
+                          {l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8,
+                           l1.rpc.newaddr('all')['p2tr']: amount / 10 ** 8})
+    bitcoind.generate_block(1)
+
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 2)
+    bitcoind.generate_block(6)
+
+    tx_list = ["{}:{}".format(o['txid'], o['output'])
+               for o in l1.rpc.listfunds()['outputs']]
+
+    # Leave the excess as a change output
+    psbt = l1.rpc.utxopsbt(amount // 2, "300perkw", 1000, tx_list,
+                           excess_as_change=True)['psbt']
+    signed = l1.rpc.signpsbt(psbt)['signed_psbt']
+
+    # Every input must actually carry a taproot key-path signature
+    decoded = bitcoind.rpc.decodepsbt(l1.rpc.setpsbtversion(signed, 0)['psbt'])
+    assert len(decoded['inputs']) == 2
+    for inp in decoded['inputs']:
+        assert 'taproot_key_path_sig' in inp
+
+    l1.rpc.sendpsbt(signed)
+    bitcoind.generate_block(1, wait_for_mempool=1)


### PR DESCRIPTION
… node

> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.

Changelog-None

## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Test to reproduce #9054 