### PR TITLE
pytest: test that `multifundchannel` does not crash the node

### DIFF
--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3024,10 +3024,9 @@ def test_zeroconf_withhold_htlc_failback(node_factory, bitcoind):
 @pytest.mark.openchannel('v2')
 def test_multifunding_with_many_input(node_factory, bitcoind):
     """Test that multifundchannel can handle a large number of inputs."""
-    l1, l2= node_factory.get_nodes(2, opts={'old_hsmsecret': True})
+    l1, l2 = node_factory.get_nodes(2, opts={'old_hsmsecret': True})
 
-    amount =1000000
-
+    amount = 1000000
 
     addr = l1.rpc.newaddr('all')['p2tr']
     bitcoind.rpc.sendtoaddress(addr, amount / 10**8)
@@ -3038,10 +3037,9 @@ def test_multifunding_with_many_input(node_factory, bitcoind):
     destinations = [{"id": '{}@localhost:{}'.format(l2.info['id'], l2.port),
                      "amount": 'all'},
                     ]
-    
-    utxo = [f"{txid}:{vout}" 
-            for txid, vout in [(o['txid'], o['output']) 
-            for o in l1.rpc.listfunds()['outputs']]]
+
+    utxo = [f"{txid}:{vout}"
+            for txid, vout in [(o['txid'], o['output']) for o in l1.rpc.listfunds()['outputs']]]
 
     # add duplicate
     utxo.append(utxo[0])
@@ -3054,4 +3052,3 @@ def test_multifunding_with_many_input(node_factory, bitcoind):
 
     inv = l2.rpc.invoice(5000, 'i1', 'i1')['bolt11']
     l1.rpc.pay(inv)
-

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3018,3 +3018,40 @@ def test_zeroconf_withhold_htlc_failback(node_factory, bitcoind):
 
     # l1's channel to l2 is still normal — no force-close
     assert only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['state'] == 'CHANNELD_NORMAL'
+
+
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
+def test_multifunding_with_many_input(node_factory, bitcoind):
+    """Test that multifundchannel can handle a large number of inputs."""
+    l1, l2= node_factory.get_nodes(2, opts={'old_hsmsecret': True})
+
+    amount =1000000
+
+
+    addr = l1.rpc.newaddr('all')['p2tr']
+    bitcoind.rpc.sendtoaddress(addr, amount / 10**8)
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    wait_for(lambda: len(l1.rpc.listfunds()['outputs']) == 1)
+
+    destinations = [{"id": '{}@localhost:{}'.format(l2.info['id'], l2.port),
+                     "amount": 'all'},
+                    ]
+    
+    utxo = [f"{txid}:{vout}" 
+            for txid, vout in [(o['txid'], o['output']) 
+            for o in l1.rpc.listfunds()['outputs']]]
+
+    # add duplicate
+    utxo.append(utxo[0])
+
+    l1.rpc.multifundchannel(destinations, minconf=1, utxos=utxo)
+
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    wait_for(lambda: [c['state'] for c in (l1.rpc.listpeerchannels()['channels'])] == ['CHANNELD_NORMAL'])
+
+    inv = l2.rpc.invoice(5000, 'i1', 'i1')['bolt11']
+    l1.rpc.pay(inv)
+


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.04 FREEZE March 11th: Non-bugfix PRs not ready by this date will wait for 26.06.
>
> RC1 is scheduled on _March 23rd_
>
> The final release is scheduled for April 15th.

Changelog-None


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Reproduce issue [9033](https://github.com/ElementsProject/lightning/issues/9033)

If there are duplicate taproot transactions in the `utxo` argument specified in the `multifundchannel` RPC command, the node crashes.

The issue is present either the hsm_secret in the old or new (mnemonic) format.