### PR TITLE
cln-plugin: add support for structured logging dependencies

### DIFF
--- a/plugins/src/logging.rs
+++ b/plugins/src/logging.rs
@@ -116,10 +116,21 @@ mod trace {
         ) {
             let mut extractor = LogExtract::default();
             event.record(&mut extractor);
-            let message = match extractor.msg {
+            let mut message = match extractor.msg {
                 Some(m) => m,
                 None => return,
             };
+
+            // Append any additional fields to the message
+            if !extractor.fields.is_empty() {
+                let fields_str: Vec<String> = extractor
+                    .fields
+                    .iter()
+                    .map(|(k, v)| format!("{}=\"{}\"", k, v))
+                    .collect();
+                message = format!("{} [{}]", message, fields_str.join(", "));
+            }
+
             let level = event.metadata().level().into();
             self.sender.send(LogEntry { level, message }).unwrap();
         }
@@ -141,14 +152,26 @@ mod trace {
     #[derive(Default)]
     struct LogExtract {
         msg: Option<String>,
+        fields: Vec<(String, String)>,
     }
 
     impl tracing::field::Visit for LogExtract {
         fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-            if field.name() != "message" {
-                return;
+            let field_name = field.name();
+            let field_value = format!("{value:?}");
+
+            if field_name == "message" {
+                self.msg = Some(field_value);
+            } else if !is_log_metadata_field(field_name) {
+                self.fields.push((field_name.to_owned(), field_value));
             }
-            self.msg = Some(format!("{:?}", value));
         }
+    }
+
+    fn is_log_metadata_field(name: &str) -> bool {
+        matches!(
+            name,
+            "log.target" | "log.module_path" | "log.file" | "log.line"
+        )
     }
 }


### PR DESCRIPTION
We filter out the metadata fields from the log-tracing bridge
