### PR TITLE
common/wireaddr: fix GCC 15 const-qualifier errors

### DIFF
--- a/common/wireaddr.c
+++ b/common/wireaddr.c
@@ -291,10 +291,10 @@ char *fmt_wireaddr(const tal_t *ctx, const struct wireaddr *a)
 bool separate_address_and_port(const tal_t *ctx, const char *arg,
 			       char **addr, u16 *port)
 {
-	char *portcolon;
+	const char *portcolon;
 
 	if (strstarts(arg, "[")) {
-		char *end = strchr(arg, ']');
+		const char *end = strchr(arg, ']');
 		if (!end)
 			return false;
 		/* Copy inside [] */


### PR DESCRIPTION
## Summary

- GCC 15 propagates the `const` qualifier through `strchr`/`strrchr`, so the result of `strchr(const char *, c)` is `const char *`. The two locals in `separate_address_and_port` were declared as `char *`, tripping `-Werror=discarded-qualifiers` on Arch Linux / GCC 15.2.1.
- Change `portcolon` and `end` to `const char *`. Both are only read (pointer arithmetic and comparisons), so no behavior change.

Fixes #9074.

## Test plan

- [x] `make common/wireaddr.o` — compiles cleanly
- [x] `make common/test/run-ip_port_parsing && common/test/run-ip_port_parsing` — passes