### PR TITLE
both bolt.observer and LN Node Insights has been down for awhile

### DIFF
--- a/doc/node-operators-guide/analytics.md
+++ b/doc/node-operators-guide/analytics.md
@@ -18,6 +18,4 @@ There are a handful of third-party GUI tools that provide analytics on the top o
 
 - [Ride-the-Lightning](https://www.ridethelightning.info/)
 - [Umbrel](https://getumbrel.com/)
-- [bolt.observer](https://bolt.observer)
-- [LN Node Insights](https://lnnodeinsight.com/)
 - [Munin](https://github.com/lduchosal/munin-clightning)


### PR DESCRIPTION
Changelog-None
Both bolt.observer and LN Node Insights has been down for awhile
RTL works exclusively with LND, so is irrelevant here.

- [V] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [V] Tests have been added or modified to reflect the changes.
- [V] Documentation has been reviewed and updated as needed.
- [V] Related issues have been listed and linked, including any that this PR closes.
- [V] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
