### PR TITLE
pytest: fix flake in test_closing_anchorspend_htlc_tx_rbf

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -8,7 +8,7 @@ from utils import (
     scriptpubkey_addr, calc_lease_fee,
     check_utxos_channel, check_coin_moves,
     mine_funding_to_announce, check_inspect_channel,
-    first_scid, check_feerate, did_short_sig
+    first_scid, check_feerate
 )
 
 from typing import List, Optional
@@ -3836,7 +3836,7 @@ def test_closing_anchorspend_htlc_tx_rbf(node_factory, bitcoind):
     total_weight = sum([d['weight'] for d in details])
     total_fees = sum([float(d['fees']['base']) * 100_000_000 for d in details])
     total_feerate_perkw = total_fees / total_weight * 1000
-    assert did_short_sig(l1) or 2000 - 1 < total_feerate_perkw < 2000 + 1
+    check_feerate([l1], total_feerate_perkw, 2000)
 
     # But we don't mine it!  And fees go up again!
     l1.set_feerates((3000, 3000, 3000, 3000))
@@ -3851,7 +3851,7 @@ def test_closing_anchorspend_htlc_tx_rbf(node_factory, bitcoind):
     total_weight = sum([d['weight'] for d in details])
     total_fees = sum([float(d['fees']['base']) * 100_000_000 for d in details])
     total_feerate_perkw = total_fees / total_weight * 1000
-    assert did_short_sig(l1) or 3000 - 1 < total_feerate_perkw < 3000 + 1
+    check_feerate([l1], total_feerate_perkw, 3000)
 
     # And now we'll get it in (there's some rounding, so feerate a bit lower!)
     bitcoind.generate_block(1, needfeerate=2990)


### PR DESCRIPTION
Fixes: #9088

```
FAILED tests/test_closing.py::test_closing_anchorspend_htlc_tx_rbf - assert (None or 3001.3083296990844 < (3000 + 1))
 +  where None = did_short_sig(<fixtures.LightningNode object at 0x7f1a89bb9c90>)
```

The previous fix #9027 misdiagnosed the cause: the identical value 3001.3083296990844 appears with and without a short signature, so this is not signature-length variation but deterministic floating-point rounding in `fees / weight * 1000` for this specific transaction structure. Replace the hand-rolled ±1 assertions with check_feerate(), which already uses a ±2 window and has the did_short_sig escape hatch built in.

Changelog-None