### PR TITLE
crates: bump cln-rpc, cln-grpc and cln-plugin to v0.7.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc-plugin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cln-grpc",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ members = [
 ]
 
 [workspace.dependencies]
-cln-rpc = { path = "cln-rpc", version = "0.6.0" }
-cln-grpc = { path = "cln-grpc", version = "0.6.0" }
-cln-plugin = { path = "plugins", version = "0.6.0" }
+cln-rpc = { path = "cln-rpc", version = "0.7.0" }
+cln-grpc = { path = "cln-grpc", version = "0.7.0" }
+cln-plugin = { path = "plugins", version = "0.7.0" }

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-rpc"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "An async RPC client for Core Lightning."

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-plugin"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cln-grpc-plugin"
-version = "0.6.0"
+version = "0.7.0"
 
 description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. Authentication is done via mTLS."
 license = "MIT"


### PR DESCRIPTION
Now that we have all the notifications and hooks in there we should push a new release! I checked and it's technically a breaking change since offer related structs have a new field `force_paths`.