### PR TITLE
No -Werror on non-debug builds, check 32 bit build in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,6 +312,42 @@ jobs:
         run: |
           uv run eatmydata make -j $(nproc) check-units installcheck VALGRIND=${{ matrix.VALGRIND }} CARGO=false CC=devtools/cc-nobuild SUPPRESS_GENERATION=1
 
+  compile-32bit:
+    name: Build 32-bit (size_t != 64-bit warnings)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs:
+      - prebuild
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add i386 architecture
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        env:
+          TEST_NETWORK: ${{ matrix.TEST_NETWORK }}
+        run: |
+          bash -x .github/scripts/setup.sh
+          sudo apt-get install --no-install-recommends -yy \
+            gcc-multilib \
+            libsodium-dev:i386 \
+            libsqlite3-dev:i386 \
+            zlib1g-dev:i386
+
+      - name: Build
+        env:
+          PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig
+        run: |
+          ./configure --disable-rust --enable-debugbuild CC="gcc -m32" 
+          uv run make -j $(nproc) all-programs
+
   check-fuzz:
     name: Run fuzz regression tests
     runs-on: ubuntu-24.04
@@ -905,11 +941,12 @@ jobs:
       - min-btc-support
       - check-downgrade
       - check-compiled-source
+      - compile-32bit
     if: ${{ always() }}
     steps:
       - name: Complete
         env:
-          JOB_NAMES: "FIRST_INTEGRATION FULL_INTEGRATION CHECK_UNITS VALGRIND SANITIZERS BTC CHECK_COMPILED_SOURCE"
+          JOB_NAMES: "FIRST_INTEGRATION FULL_INTEGRATION CHECK_UNITS VALGRIND SANITIZERS BTC CHECK_COMPILED_SOURCE COMPILE_32BIT"
           FIRST_INTEGRATION: ${{ needs['first-integration'].result }}
           FULL_INTEGRATION: ${{ needs['full-integration'].result }}
           CHECK_UNITS: ${{ needs['check-units'].result }}
@@ -919,6 +956,7 @@ jobs:
           BTC: ${{ needs['min-btc-support'].result }}
           CHECK_DOWNGRADE: ${{ needs['check-downgrade'].result }}
           CHECK_COMPILED_SOURCE: ${{ needs['check-compiled-source'].result }}
+          COMPILE_32BIT: ${{ needs['compile-32bit'].result }}
         run: |
           failed=""
           for name in $JOB_NAMES; do

--- a/configure
+++ b/configure
@@ -78,7 +78,7 @@ default_python()
     PYTHON_BINS="python3 python"
     for p in $PYTHON_BINS; do
         if [ "$(which $p)" != "" ] ; then
-            if $p --version 2>&1 | grep -q "Python 3."; then
+            if uv run $p --version 2>&1 | grep -q "Python 3."; then
                 echo "$p"
                 return
             fi
@@ -116,14 +116,14 @@ default_pytest()
 	# want to only call which on the executable
 	exe=$(echo "$p" | awk '{print $1}')
 	# shellcheck disable=SC2086
-	if [ "$(which $exe)" != "" ] ; then
-	    "$p" --version 2>&1 | grep -q "pytest" || continue
+	if [ "$(uv run which $exe)" != "" ] ; then
+	    uv run "$p" --version 2>&1 | grep -q "pytest" || continue
 	    echo "$p"
 	    return
 	fi
     done
 
-    if $1 -c "import pytest" 2>/dev/null; then
+    if uv run $1 -c "import pytest" 2>/dev/null; then
         echo "$1 -m pytest"
         return
     fi

--- a/configure
+++ b/configure
@@ -536,12 +536,6 @@ code=
 /*END*/
 EOF
 
-if check_command 'python3-mako' python3 -c 'import mako'; then
-    HAVE_PYTHON3_MAKO=1
-else
-    HAVE_PYTHON3_MAKO=0
-fi
-
 if ! check_command 'lowdown' lowdown; then
     echo "*** We need lowdown!" >&2
     exit 1
@@ -638,7 +632,6 @@ add_var CLANG_COVERAGE "$CLANG_COVERAGE"
 add_var ASAN "$ASAN"
 add_var UBSAN "$UBSAN"
 add_var TEST_NETWORK "$TEST_NETWORK"
-add_var HAVE_PYTHON3_MAKO "$HAVE_PYTHON3_MAKO"
 add_var SHA256SUM "$SHA256SUM"
 add_var FUZZING "$FUZZING"
 add_var RUST "$RUST"

--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@ set -e
 CONFIGURATOR=ccan/tools/configurator/configurator
 CONFIG_VAR_FILE=config.vars
 CONFIG_HEADER=ccan/config.h
-BASE_WARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition -Werror"
+BASE_WARNFLAGS="-Wall -Wundef -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wold-style-definition"
 
 OS=$(uname -s)
 ARCH=$(uname -m)
@@ -51,7 +51,7 @@ default_coptflags()
     fi
 }
 
-# Given COPTFLAGS, HAVE_GCC and HAVE_MODERN_GCC, what CWARNFLAGS to default to?
+# Given COPTFLAGS, HAVE_GCC, HAVE_MODERN_GCC and DEBUGBUILD, what CWARNFLAGS to default to?
 default_cwarnflags()
 {
     F=$BASE_WARNFLAGS
@@ -65,6 +65,10 @@ default_cwarnflags()
 	# Recent clang understands that, but at least our MacOS CI doesn't, so keep
 	# this gcc-only.
 	F="$F -Wshadow=local"
+    fi
+    # Debug builds get -Werror (great for CI!)
+    if [ "$4" = 1 ]; then
+	F="$F -Werror"
     fi
     echo "$F"
 }
@@ -220,7 +224,8 @@ have_function_sections()
     TMPOBJFILE=$CONFIG_VAR_FILE.$$.o
     
     echo "int foo(void); int foo(void) { return 0; }" > $TMPCFILE
-    $1 $2 -ffunction-sections -Wl,--gc-sections -c $TMPCFILE -o $TMPOBJFILE
+    # We *want* this to fail if we get a warning, hence use -Werror.
+    $1 $2 -Werror -ffunction-sections -Wl,--gc-sections -c $TMPCFILE -o $TMPOBJFILE
 }
 
 usage()
@@ -231,7 +236,7 @@ usage()
     set_defaults
     DEFAULT_COPTFLAGS="$(default_coptflags $DEBUGBUILD)"
     # We assume we have a modern gcc.
-    DEFAULT_CWARNFLAGS="$(default_cwarnflags ""$DEFAULT_COPTFLAGS"" 1 1)"
+    DEFAULT_CWARNFLAGS="$(default_cwarnflags ""$DEFAULT_COPTFLAGS"" 1 1 ""$DEBUGBUILD"")"
     usage_with_default "CC" "$CC"
     usage_with_default "CWARNFLAGS" "$DEFAULT_CWARNFLAGS"
     usage_with_default "COPTFLAGS" "$DEFAULT_COPTFLAGS"
@@ -601,7 +606,8 @@ fi
 if [ -z ${CWARNFLAGS+x} ]; then
     CWARNFLAGS=$(default_cwarnflags "$COPTFLAGS" \
 		    $(sed -n 's/^HAVE_GCC=//p' < $CONFIG_VAR_FILE.$$) \
-		    $(sed -n 's/^HAVE_MODERN_GCC=//p' < $CONFIG_VAR_FILE.$$) )
+		    $(sed -n 's/^HAVE_MODERN_GCC=//p' < $CONFIG_VAR_FILE.$$) \
+		    "$DEBUGBUILD")
 fi
 
 add_var PREFIX "$PREFIX"

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -6,8 +6,6 @@
 # We generate the files, and then we attempt to compile
 # and run a test case.
 
-# We don't run these at all unless mako is installed.
-ifeq ($(HAVE_PYTHON3_MAKO),1)
 check-units: check-tools
 
 TOOL_TEST_INCL_SRC := tools/test/enum.c
@@ -44,7 +42,6 @@ tools/test/print_gen.c: $(TOOLS_WIRE_DEPS)
 ALL_TEST_PROGRAMS += $(TOOL_TEST_PROGRAMS)
 
 check-tools: $(TOOL_TEST_PROGRAMS:%=unittest/%)
-endif # HAVE_PYTHON3_MAKO
 
 clean: tools-test-clean
 


### PR DESCRIPTION
This delayed the previous release, as 32 bit didn't build and this was only caught in the docker build phase of release.  And future version of gcc add new warnings, which stops build entirely for users, so avoid -Werror for them