### PR TITLE
fix: default message padding to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ This release is named by @Chand-ra.
 
 ### Added
 
- - Protocol: we now pad all peer messages to make them the same length (excluding LND < v21 and current Eclair). ([#8893], [#9022])
- - Config: `message-padding` option can be set to `false` to disable it for all peers. ([#9068])
+ - Protocol: peer message padding can make messages uniform length, but is disabled by default for compatibility. ([#8893], [#9022])
+ - Config: `message-padding=true` enables peer message padding for all peers. ([#9068])
  - JSON-RPC: `bkpr-report` allows flexible summaries of bookkeeper income. ([#8937])
  - Config: `bkpr-currency` option to record conversion rate at each bookkeeper event. ([#8937])
  - JSON-RPC: `currencyconvert` and `currencyrate` via the new plugin `cln-currencyrate` ([#8842], [#8937])

--- a/Makefile
+++ b/Makefile
@@ -584,8 +584,8 @@ LOCAL_BOLTDIR=.tmp.lightningrfc
 bolt-precheck:
 	@[ -d $(BOLTDIR) ] || exit 0; set -e; if [ -z "$(BOLTVERSION)" ]; then rm -rf $(LOCAL_BOLTDIR); ln -sf $(BOLTDIR) $(LOCAL_BOLTDIR); exit 0; fi; [ "$$(git -C $(LOCAL_BOLTDIR) rev-list --max-count=1 HEAD 2>/dev/null)" != "$(BOLTVERSION)" ] || exit 0; rm -rf $(LOCAL_BOLTDIR) && git clone -q $(BOLTDIR) $(LOCAL_BOLTDIR) && cd $(LOCAL_BOLTDIR) && git checkout -q $(BOLTVERSION)
 
-PYSRC=$(shell git ls-files "*.py" | grep -v /text.py)
-RUSTSRC=$(shell git ls-files "*.rs")
+PYSRC=$(filter-out $(PYTHON_GENERATED),$(shell git ls-files "*.py" | grep -v /text.py))
+RUSTSRC=$(filter-out $(CLN_GRPC_GENALL),$(shell git ls-files "*.rs"))
 
 check-source-bolt: $(ALL_NONGEN_SRCFILES:%=bolt-check/%) $(PYSRC:%=bolt-check-py/%) $(RUSTSRC:%=bolt-check-rs/%)
 

--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -709,9 +709,9 @@ all DNS lookups, to avoid leaking information.
 
 * **message-padding**=*BOOL*
 
-  Normally `connectd` will send extra bytes to peers to make messages
-uniform length.  Some implementations don't accept these extra bytes:
-if we can't detect them, this option sets to `false` will disable it.
+  If `message-padding=true`, connectd will send extra bytes to peers to make
+messages uniform length. This defaults to false because some deployed
+implementations reject the no-reply pings used for padding.
 
 * **tor-service-password**=*PASSWORD*
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -373,10 +373,11 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 
 	ld->fronting_nodes = tal_arr(ld, struct node_id, 0);
 
-	/*~ connectd usually uses "no-reply" pings to fill out messages
-	 * where needed to make them uniform length.  Some implementations
-	 * don't like it, so it can be disabled. */
-	ld->message_padding = true;
+	/*~ connectd can use "no-reply" pings to fill out messages where needed
+	 * to make them uniform length. Deployed implementations can reject those
+	 * pings, so default to compatibility; operators can opt in with
+	 * --message-padding=true. */
+	ld->message_padding = false;
 
 	return ld;
 }

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1671,7 +1671,7 @@ static void register_opts(struct lightningd *ld)
 	clnopt_witharg("--message-padding", OPT_SHOWBOOL,
 		       opt_set_bool_arg, opt_show_bool,
 		       &ld->message_padding,
-		       "If true (the default), pad all messages to peers to make them equal length");
+		       "If true, pad messages to peers to make them equal length (default: false)");
 
 	dev_register_opts(ld);
 }


### PR DESCRIPTION
## Summary
- Default `--message-padding` to `false`.
- Keep padding available as an opt-in with `--message-padding=true`.
- Update docs/help/changelog to match the compatibility default.

## Rationale
- CLN padding uses BOLT-valid no-reply pings.
- Deployed LND versions before lightningnetwork/lnd@08b26b613745d5e1e63abed15746045d03c8f27a reject those pings with `pong bytes exceeded`.
- Defaulting off avoids disconnects/channel-open failures while preserving the feature for operators who opt in.

Mitigates ElementsProject/lightning#9108

## Test plan
- `git diff --check`
- `make lightningd/lightningd.o` (fails locally because the worktree is not configured: `config.vars` is missing and `./configure` has not been run)
