### PR TITLE
config: change message-padding to false by default.

### DIFF
--- a/doc/lightningd-config.5.md
+++ b/doc/lightningd-config.5.md
@@ -709,9 +709,9 @@ all DNS lookups, to avoid leaking information.
 
 * **message-padding**=*BOOL*
 
-  Normally `connectd` will send extra bytes to peers to make messages
-uniform length.  Some implementations don't accept these extra bytes:
-if we can't detect them, this option sets to `false` will disable it.
+  If set to `true`, `connectd` will send extra bytes to peers to make messages
+uniform length.  Some implementations don't accept these extra bytes,
+and our detection of them is not always reliable, so this option defaults to `false`.
 
 * **tor-service-password**=*PASSWORD*
 

--- a/lightningd/lightningd.c
+++ b/lightningd/lightningd.c
@@ -377,7 +377,7 @@ static struct lightningd *new_lightningd(const tal_t *ctx)
 	/*~ connectd usually uses "no-reply" pings to fill out messages
 	 * where needed to make them uniform length.  Some implementations
 	 * don't like it, so it can be disabled. */
-	ld->message_padding = true;
+	ld->message_padding = false;
 
 	return ld;
 }

--- a/lightningd/options.c
+++ b/lightningd/options.c
@@ -1671,7 +1671,7 @@ static void register_opts(struct lightningd *ld)
 	clnopt_witharg("--message-padding", OPT_SHOWBOOL,
 		       opt_set_bool_arg, opt_show_bool,
 		       &ld->message_padding,
-		       "If true (the default), pad all messages to peers to make them equal length");
+		       "If true, pad all messages to peers to make them equal length");
 
 	dev_register_opts(ld);
 }

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4900,7 +4900,7 @@ def test_constant_packet_size(node_factory, tcp_capture):
     Test that TCP packets between nodes are constant size.  This will be skipped unless
     you can run `dumpcap` (usually means you have to be in the `wireshark` group).
     """
-    l1, l2, l3, l4 = node_factory.get_nodes(4)
+    l1, l2, l3, l4 = node_factory.get_nodes(4, opts={'message-padding': True})
 
     # Encrypted setup BOLT 8 has some short packets.
     l1.connect(l2)


### PR DESCRIPTION
Too many reports of problems with weird nodes.

Changelog-Changed: Protocol: `message-padding` defaults to false, due to poor detection of broken implementations.

Closes: #9114

(This JUST changes that, and fixes all the documenation, and #9114 did other things too).