### PR TITLE
pytest: fix use of deprecated `getroute` in tests/test_misc.py::test_graceful_htlc

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4337,7 +4337,7 @@ def test_graceful_htlc(node_factory, executor):
                                                {'plugin': os.path.join(os.getcwd(), 'tests/plugins/hold_invoice.py')}])
 
     inv = l3.rpc.invoice(10000, 'hold', 'hold invoice')
-    route = l1.rpc.getroute(l3.info['id'], 10000, 1)['route']
+    route = l1.single_route(l3.info['id'], 10000)
     l1.rpc.sendpay(route, inv['payment_hash'], payment_secret=inv['payment_secret'])
     wait_for(lambda: len(only_one(l3.rpc.listpeerchannels()['channels'])['htlcs']) == 1)
 


### PR DESCRIPTION
Merge conflict:

```
FAILED tests/test_misc.py::test_graceful_htlc - pyln.client.lightning.RpcError: RPC call failed: method: getroute, payload: {'id': '03cecbfdc68544cc596223b68ce0710c9e5d2c9cb317ee07822d95079acc703d31', 'amount_msat': 10000, 'riskfactor': 1, 'cltv': 9}, error: {'code': -32601, 'message': 'Command "getroute" is deprecated'}
```

Changelog-None