### PR TITLE
CI: update github actions in preparation of node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -75,14 +75,14 @@ jobs:
           fi
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -104,7 +104,7 @@ jobs:
           uv run make -j $(nproc) check-source BASE_REF="origin/${{ github.base_ref }}" CARGO=false CC=devtools/cc-nobuild SUPPRESS_GENERATION=1
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-prebuild
           path: report.xml
@@ -149,17 +149,17 @@ jobs:
             DEBUG_BUILD:
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -171,7 +171,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - run: sccache --zero-stats
 
       - name: Build
@@ -190,7 +190,7 @@ jobs:
 
           # Rename now so we don't clash
           mv testpack.tar.gz cln-${{ matrix.CFG }}.tar.gz
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
           path: cln-${{ matrix.CFG }}.tar.gz
@@ -204,17 +204,17 @@ jobs:
         CFG: [compile-gcc]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -226,7 +226,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -238,7 +238,7 @@ jobs:
           tar xaf cln-${{ matrix.CFG }}.tar.gz
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - run: sccache --zero-stats
 
       - name: Check
@@ -269,17 +269,17 @@ jobs:
             VALGRIND: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -293,7 +293,7 @@ jobs:
           git clone https://github.com/lightning/bolts.git ../${BOLTDIR}
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -306,7 +306,7 @@ jobs:
 
       # external/Makefile uses `TARGET_DIR := external/build-$(shell ${CC} -dumpmachine)` so we need sccache to "work" for that.
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Check
         run: |
@@ -320,7 +320,7 @@ jobs:
       - prebuild
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Add i386 architecture
         run: |
@@ -328,7 +328,7 @@ jobs:
           sudo apt-get update -qq
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         env:
@@ -355,17 +355,17 @@ jobs:
       - prebuild
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -377,7 +377,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - run: sccache --zero-stats
 
       - name: Build
@@ -408,17 +408,17 @@ jobs:
             TEST_NETWORK: liquid-regtest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -430,7 +430,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -472,7 +472,7 @@ jobs:
           sg wireshark "uv run eatmydata pytest tests/test_downgrade.py -n $(($(nproc) + 1)) ${PYTEST_OPTS}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-check-downgrade-${{ matrix.TEST_DB_PROVIDER }}-${{ matrix.TEST_NETWORK }}
           path: report.xml
@@ -499,17 +499,17 @@ jobs:
         TEST_NETWORK: [regtest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -521,7 +521,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -549,7 +549,7 @@ jobs:
           VALGRIND=0 sg wireshark "uv run eatmydata pytest tests/ -n $(($(nproc) + 1)) ${PYTEST_OPTS} --test-group=${{ matrix.GROUP }} --test-group-count=${{ matrix.GROUP_COUNT }}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-first-integration-${{ matrix.GROUP }}
           path: report.xml
@@ -590,17 +590,17 @@ jobs:
             EXPERIMENTAL_DUAL_FUND: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -612,7 +612,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -647,7 +647,7 @@ jobs:
           VALGRIND=0 sg wireshark "uv run eatmydata pytest tests/ -n $(($(nproc) + 1)) ${PYTEST_OPTS}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-integration-${{ matrix.name }}
           path: report.xml
@@ -669,17 +669,17 @@ jobs:
         GROUP_COUNT: [12]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -689,7 +689,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -709,7 +709,7 @@ jobs:
           VALGRIND=1 sg wireshark "uv run eatmydata pytest tests/ -n $(($(nproc) + 1)) ${PYTEST_OPTS} --test-group=${{ matrix.GROUP }} --test-group-count=${{ matrix.GROUP_COUNT }}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-integration-valgrind-${{ matrix.GROUP }}
           path: report.xml
@@ -733,17 +733,17 @@ jobs:
         GROUP_COUNT: [6]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -755,7 +755,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -773,7 +773,7 @@ jobs:
           sg wireshark "uv run eatmydata pytest tests/ -n $(($(nproc) + 1)) ${PYTEST_OPTS} --test-group=${{ matrix.GROUP }} --test-group-count=${{ matrix.GROUP_COUNT }}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-integration-sanitizers-${{ matrix.GROUP }}
           path: report.xml
@@ -796,16 +796,16 @@ jobs:
       - compile
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -815,7 +815,7 @@ jobs:
           bash -x .github/scripts/setup.sh
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
       - name: Unpack prebuilt binaries
@@ -832,7 +832,7 @@ jobs:
           uv run eatmydata make -j $(($(nproc) + 1)) check-doc-examples CARGO=false CC=devtools/cc-nobuild SUPPRESS_GENERATION=1
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-update-docs-examples
           path: report.xml
@@ -858,17 +858,17 @@ jobs:
             MIN_BTC_VERSION: "25.0"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/ci-cache
           key: apt-${{ runner.os }}
@@ -892,7 +892,7 @@ jobs:
         run: rm -rf "bitcoin-${{ matrix.MIN_BTC_VERSION }}-x86_64-linux-gnu.tar.gz" "bitcoin-${{ matrix.MIN_BTC_VERSION }}"
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-${{ matrix.CFG }}.tar.gz
 
@@ -919,7 +919,7 @@ jobs:
           VALGRIND=0 sg wireshark "uv run eatmydata pytest tests/ -n $(($(nproc) + 1)) ${PYTEST_OPTS}"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-min-btc-support-${{ matrix.NAME }}
           path: report.xml

--- a/.github/workflows/coverage-nightly.yaml
+++ b/.github/workflows/coverage-nightly.yaml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: bash -x .github/scripts/setup.sh
@@ -38,7 +38,7 @@ jobs:
           uv run make -j $(nproc) testpack.tar.bz2
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cln-coverage-build
           path: testpack.tar.bz2
@@ -60,15 +60,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: bash -x .github/scripts/setup.sh
@@ -77,7 +77,7 @@ jobs:
         run: bash -x .github/scripts/install-bitcoind.sh
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-coverage-build
 
@@ -97,7 +97,7 @@ jobs:
           uv run eatmydata pytest tests/ -n ${PYTEST_PAR} -vvv
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-raw-${{ matrix.name }}
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install LLVM tools
         run: |
@@ -123,7 +123,7 @@ jobs:
           sudo ln -sf /usr/bin/llvm-cov-18 /usr/bin/llvm-cov
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cln-coverage-build
 
@@ -131,7 +131,7 @@ jobs:
         run: tar -xaf testpack.tar.bz2
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-raw-*
           path: coverage-artifacts
@@ -155,7 +155,7 @@ jobs:
           ./contrib/coverage/generate-coverage-report.sh
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: coverage/merged.profdata
           flags: integration-tests
@@ -164,7 +164,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-html-report
           path: coverage/html

--- a/.github/workflows/crate-io.yml
+++ b/.github/workflows/crate-io.yml
@@ -10,7 +10,7 @@ jobs:
   release_rust:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
       - uses: katyo/publish-crates@v2

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -41,19 +41,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.ref }}  # Ensures the branch triggering the workflow is checked out
         fetch-depth: 0
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -120,7 +120,7 @@ jobs:
         echo "ENV TAGS: ${{ env.TAGS }}"
 
     - name: Build and push Docker tag - ${{ env.TAGS }}
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/docs-nightly.yaml
+++ b/.github/workflows/docs-nightly.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare documentation directory
         run: |
@@ -85,7 +85,7 @@ jobs:
           EOF
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: project-docs
           path: docs-output

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -13,7 +13,7 @@ jobs:
         bitcoind-version: ["27.1"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Bitcoin ${{ matrix.bitcoind-version }} & install binaries
         run: |
@@ -26,12 +26,12 @@ jobs:
           rm -rf bitcoin-${BITCOIND_VERSION}-${TARGET_ARCH}.tar.gz bitcoin-${BITCOIND_VERSION}
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -47,24 +47,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: coverage-html-report
           path: site-staging/coverage
 
       - name: Download Python docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: python-api-docs
           path: site-staging/python
 
       - name: Download project docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: project-docs
@@ -289,16 +289,16 @@ jobs:
           EOF
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site-staging
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Add summary
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,7 +30,7 @@ jobs:
             WORKDIR: contrib/pyln-proto
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Need to fetch entire history in order to locate the version tag
         fetch-depth: 0
@@ -60,12 +60,12 @@ jobs:
         echo "DISTRIBUTION LOCATION: $DISTLOCATION"
   
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
 
     - name: Update pyln versions
       id: update-versions

--- a/.github/workflows/python-docs-nightly.yaml
+++ b/.github/workflows/python-docs-nightly.yaml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |
@@ -39,7 +39,7 @@ jobs:
           make python-docs
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-api-docs
           path: docs/python

--- a/.github/workflows/rdme-docs-sync.yml
+++ b/.github/workflows/rdme-docs-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync doc/getting-started/ 🚀
         uses: readmeio/rdme@v10

--- a/.github/workflows/readme-rpc-sync.yml
+++ b/.github/workflows/readme-rpc-sync.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9
 
@@ -32,7 +32,7 @@ jobs:
         python -m pip install requests mako grpcio-tools
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
 
     - name: Install dependencies
       run: bash -x .github/scripts/setup.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -77,7 +77,7 @@ jobs:
           - 'bin-Ubuntu-noble'
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Upload target artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: release/
           name: ${{ matrix.target }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Merge artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: c-lightning-${{ env.version }}
           pattern: bin-*
@@ -138,20 +138,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: c-lightning-${{ env.version }}
           path: release/
 
       - name: Import GPG keys
         id: gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -164,7 +164,7 @@ jobs:
         run: tools/build-release.sh --without-zip sign
 
       - name: Upload signed artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: c-lightning-${{ env.version }}
           overwrite: true
@@ -188,7 +188,7 @@ jobs:
 
       - name: Prepare release draft
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'yes')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "${{ env.version }} ${{ steps.release_data.outputs.release_title }}"
           tag_name: ${{ env.version }}

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -17,7 +17,7 @@ jobs:
         version: ['focal', 'jammy', 'noble']
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build environment setup - ${{ matrix.version }}
         run: |
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Upload release artifact - ${{ matrix.version }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.version }}
           path: release
@@ -89,7 +89,7 @@ jobs:
 
       - name: Send email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v17
         with:
           server_address: smtp.gmail.com
           server_port: 587


### PR DESCRIPTION
On june 2nd (in 3 weeks) github will deprecate node.js 20 for all github actions at which point they will no longer work without setting an env variable. In september even that won't work anymore. I updated all actions where possible. I found these actions that still have not updated to node.js 24:

- [setup-protoc](https://github.com/arduino/setup-protoc) no commits in 2 years, PR for node.js 24 exists but no maintainer response
- [publish-crates](https://github.com/katyo/publish-crates) no commit in a year, no PR, created an issue
- [rdme](https://github.com/readmeio/rdme)  maintained and if i understand correctly the next patch version is compatible with node.js 24 and by us specifying only the major version we should automatically use that

This mostly affects the workflow responsible for publishing our rust crates to crates.io.