### PR TITLE
Fix failed to retransmit funding tx

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -565,11 +565,15 @@ void resend_opening_transactions(struct lightningd *ld)
 	     peer = peer_node_id_map_next(ld->peers, &it)) {
 		list_for_each(&peer->channels, channel, list) {
 			struct wally_tx *wtx;
-			if (channel_state_uncommitted(channel->state))
+			/* Only states where the funding/splice tx might
+			 * still be unconfirmed.  channel->depth can't be
+			 * used here: it's reset to 0 on DB load and only
+			 * repopulated once topology starts. */
+			if (channel->state != CHANNELD_AWAITING_LOCKIN
+			    && channel->state != DUALOPEND_AWAITING_LOCKIN
+			    && channel->state != CHANNELD_AWAITING_SPLICE)
 				continue;
 			if (!channel->funding_psbt || channel->withheld)
-				continue;
-			if (channel->depth != 0)
 				continue;
 			wtx = psbt_final_tx(tmpctx, channel->funding_psbt);
 			if (!wtx)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3087,5 +3087,5 @@ def test_no_retransmit_confirmed_funding(node_factory):
     l1.restart()
 
     # Should not have attempted (and failed) to re-broadcast the funding tx.
-    assert l1.daemon.is_in_log('Failed to re-transmit funding tx')
+    assert not l1.daemon.is_in_log('Failed to re-transmit funding tx')
     assert not l1.daemon.is_in_log('Successfully rexmitted funding tx')

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3073,3 +3073,19 @@ def test_zeroconf_withhold_htlc_failback(node_factory, bitcoind):
 
     # l1's channel to l2 is still normal — no force-close
     assert only_one(l1.rpc.listpeerchannels(l2.info['id'])['channels'])['state'] == 'CHANNELD_NORMAL'
+
+
+@pytest.mark.openchannel('v1')
+@pytest.mark.openchannel('v2')
+def test_no_retransmit_confirmed_funding(node_factory):
+    """An channel must not trigger funding tx re-transmission on restart."""
+    l1, _ = node_factory.line_graph(2, wait_for_announce=True)
+
+    # Channel is in CHANNELD_NORMAL and funding tx is confirmed.
+    assert only_one(l1.rpc.listpeerchannels()['channels'])['state'] == 'CHANNELD_NORMAL'
+
+    l1.restart()
+
+    # Should not have attempted (and failed) to re-broadcast the funding tx.
+    assert l1.daemon.is_in_log('Failed to re-transmit funding tx')
+    assert not l1.daemon.is_in_log('Successfully rexmitted funding tx')


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Fix issue #9091 
Changelog-Fixed: lightningd: don't spuriously try to re-broadcast funding txs of already-confirmed channels on startup.
