### PR TITLE
tests: fix test_low_fd_limit failing on RLIM_INFINITY platforms

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -60,6 +60,7 @@ jobs:
           PYTEST_OPTS: "-vvv --timeout=1800 --durations=10"
           PYTEST_TESTS: |
             tests/test_misc.py::test_ipv4_and_ipv6
+            tests/test_misc.py::test_low_fd_limit
             tests/test_connection.py::test_websocket
             tests/test_connection.py::test_wss_proxy
             tests/test_plugin.py::test_inline_plugin_wait_for_log_no_selfmatch

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4998,8 +4998,16 @@ def test_set_feerate_offset(node_factory, bitcoind):
 def test_low_fd_limit(node_factory, bitcoind):
     limits = resource.getrlimit(resource.RLIMIT_NOFILE)
 
-    # We assume this, otherwise l2 cannot increase limits!
-    if limits[0] == limits[1]:
+    # dev-fd-limit-multiplier is a u32, so values > UINT32_MAX fail option
+    # parsing. macOS also reports RLIM_INFINITY as the hard limit, making
+    # "ask for more than the hard limit" meaningless.  Cap to a bounded
+    # ceiling so the test works on any platform.
+    TEST_CEILING = 65536
+    if limits[1] == resource.RLIM_INFINITY or limits[1] > TEST_CEILING:
+        limits = (TEST_CEILING // 2, TEST_CEILING)
+        resource.setrlimit(resource.RLIMIT_NOFILE, limits)
+    elif limits[0] == limits[1]:
+        # We assume this, otherwise l2 cannot increase limits!
         limits = (limits[1] // 2, limits[1])
         resource.setrlimit(resource.RLIMIT_NOFILE, limits)
 


### PR DESCRIPTION
## Problem

`test_low_fd_limit` fails on macOS and any platform where `RLIMIT_NOFILE` hard limit is `RLIM_INFINITY` (or larger than `UINT32_MAX`).

The test passes `limits[1]` and `limits[1]+1` directly as `--dev-fd-limit-multiplier`, which is a **u32** option. When the hard limit is `RLIM_INFINITY` (= `9223372036854775807` on macOS), both values overflow u32, `opt_set_u32` returns "out of range", and lightningd exits with code 1 — causing both nodes to fail to start with:

```
TimeoutError: Unable to find "Server started with public key" in logs
```

Closes #9015

## Fix

Cap to `TEST_CEILING = 65536` when the hard limit is `RLIM_INFINITY` or exceeds the ceiling, then halve the soft limit as the test requires. The existing `soft == hard` halving path is preserved as the `elif` fallback for normal bounded limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)