### PR TITLE
invoice: fix false BROKEN log in cmp_rr_number when sort self-compares

### DIFF
--- a/lightningd/invoice.c
+++ b/lightningd/invoice.c
@@ -606,9 +606,12 @@ static int cmp_rr_number(const struct routehint_candidate *a,
 	if (a->c->rr_number < b->c->rr_number)
 		return -1;
 
-	/* They're unique, so can't be equal */
-	log_broken(ld->log, "Two equal candidates %p and %p, channels %p and %p, rr_number %"PRIu64" and %"PRIu64,
-		   a, b, a->c, b->c, a->c->rr_number, b->c->rr_number);
+	/* rr_numbers are unique per channel; equal means same channel.
+	 * Some qsort implementations (notably macOS) compare an element
+	 * with itself, so a->c == b->c is expected and not a bug. */
+	if (a->c != b->c)
+		log_broken(ld->log, "Two equal candidates %p and %p, channels %p and %p, rr_number %"PRIu64" and %"PRIu64,
+			   a, b, a->c, b->c, a->c->rr_number, b->c->rr_number);
 	return 0;
 }
 


### PR DESCRIPTION
- `cmp_rr_number()` in `lightningd/invoice.c` logged BROKEN whenever two candidates had equal `rr_numbers`, but some `qsort` implementations (notably macOS) call the comparator with the same element against itself (`a == b`)
- When `a == b`, `a->c == b->c` trivially — not a data corruption
- Guard the BROKEN log with `if (a->c != b->c)`: only log BROKEN when genuinely different channels share an `rr_number`
- This silences the spurious BROKEN log on macOS that caused `test_xpay_limited_max_accepted_htlcs` to fail with "had BROKEN or That's weird messages" and exit with return code 1

Closes #9035

🤖 Generated with [Claude Code](https://claude.ai/claude-code)