### PR TITLE
ecdh_hsmd: ensure HSM fd is blocking on setup

### DIFF
--- a/common/ecdh_hsmd.c
+++ b/common/ecdh_hsmd.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <assert.h>
+#include <ccan/io/io.h>
 #include <common/ecdh.h>
 #include <common/ecdh_hsmd.h>
 #include <common/utils.h>
@@ -33,4 +34,6 @@ void ecdh_hsmd_setup(int hsm_fd,
 {
 	stashed_hsm_fd = hsm_fd;
 	stashed_failed = failed;
+	/* Like read_fds in subd.c: don't trust sender's O_NONBLOCK state (issue #9060). */
+	io_fd_block(hsm_fd, true);
 }


### PR DESCRIPTION
- On macOS under load, socketpair fds sent via SCM_RIGHTS can have O_NONBLOCK set (from `io_new_conn` called on the sender's end in `hsmd:pass_client_hsmfd`), causing `wire_sync_read` to return NULL with EAGAIN and killing connectd/channeld with "*BROKEN* STATUS_FAIL_HSM_IO: No hsmd ECDH response"
- Fix mirrors the existing "Don't trust subd to set it blocking" pattern in `lightningd/subd.c:read_fds` — call `io_fd_block(hsm_fd, true)` in `ecdh_hsmd_setup`, which is used by connectd, channeld, and lightningd itself
- Applies to both responder (Act 1) and initiator (Act 3) NOISE handshake paths that call `ecdh()`

Closes #9060

🤖 Generated with [Claude Code](https://claude.ai/claude-code)