### PR TITLE
CHANGELOG.md: put missing CHANGELOG entries in for PR 9136.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Note: You should always set `allow-deprecated-apis=false` to test for changes.
 ### Removed
 
  - JSON-RPC: `exclude` parameter to `pay` (when `xpay-handle-pay` is True): craft a layer with desired modifications and pass it to `xpay` `layers`. ([#9110])
+ - Plugins: `channel_state_changed` notification `message` field being `null`: it will be omitted instead (deprecated v25.12, disabled v26.04) ([#9136])
+ - JSON-RPC: `listpeerchannels` value `max_total_htlc_in_msat`: use `our_max_htlc_value_in_flight_msat` instead to follow spec naming convention (deprecated v25.02). ([#9136])
 
 
 ### Fixed
@@ -95,6 +97,7 @@ Note: You should always set `allow-deprecated-apis=false` to test for changes.
 [#9116]: https://github.com/ElementsProject/lightning/pull/9116
 [#8942]: https://github.com/ElementsProject/lightning/pull/8942
 [#8922]: https://github.com/ElementsProject/lightning/pull/8922
+[#9136]: https://github.com/ElementsProject/lightning/pull/9136
 [26.06rc1]: https://github.com/ElementsProject/lightning/releases/tag/v26.06rc1
 
 ## [26.04.1] - 2026-04-25: "Negative Routing Fees II"


### PR DESCRIPTION
Removals should be documented with Changelog-Removed lines, mirroring the old Deprecated line.

In this case, the `max_total_htlc_in_msat` removal was premature: we try to give one version AFTER the deprecation period.

That way users can re-enable the feature if they need to, using `--i-promise-to-fix-broken-api-user=listpeerchannels.max_total_htlc_in_msat` and we can decide whether to defer removal, re-enable, even un-deprecate (or get whatever tool they are using fixed).

It's happened a few times in the past that nobody tested with deprecations disabled, and users got stuck when they upgraded :(
Changelog-None