### PR TITLE
docs: fixing Fedora installation

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -157,7 +157,7 @@ OS version: Fedora 39 or above
 Get dependencies:
 ```shell
 sudo dnf update -y && \
-        sudo dnf groupinstall -y \
+        sudo dnf group install -y \
                 'c-development' \
                 'development-tools' && \
         sudo dnf install -y \
@@ -178,7 +178,9 @@ sudo dnf update -y && \
                 which \
                 sed \
                 postgresql-devel \
-                python3-mako && \
+                python3-mako \
+                openssl \
+                openssl-devel && \
         sudo dnf clean all
 ```
 
@@ -186,6 +188,12 @@ Install Rust via rustup (required for Cargo lockfile v4 support):
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
+```
+
+Install uv (Python package manager, used by the build):
+```shell
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Install lowdown (for documentation generation):
@@ -204,7 +212,7 @@ rm -rf /tmp/VERSION_1_0_2.tar.gz /tmp/lowdown-VERSION_1_0_2
 
 Make sure you have [bitcoind](https://github.com/bitcoin/bitcoin) available to run.
 
-Clone lightning:
+Clone lightning (including submodules):
 ```shell
 git clone https://github.com/ElementsProject/lightning.git
 cd lightning
@@ -212,14 +220,15 @@ cd lightning
 
 Checkout a release tag:
 ```shell
-git checkout v24.05
+git checkout v26.04
 ```
 
 Build and install lightning:
 ```shell
+uv sync --all-extras --all-groups --frozen
 ./configure
-make
-sudo make install
+RUST_PROFILE=release uv run make -j$(nproc)
+sudo RUST_PROFILE=release make install
 ```
 
 Running lightning (mainnet):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Changelog-None

## Rationale

The Fedora build instructions in `doc/getting-started/getting-started/installation.md` had drifted from the actual working procedure and no longer produced a successful build on a clean Fedora 39 system. The steps were verified end-to-end inside a clean `fedora:39` container, and this PR brings the guide in line with what actually works.

### What changed and why

- **`dnf groupinstall` → `dnf group install`** — `groupinstall` is deprecated in modern `dnf`; the space-separated form is the supported syntax.
- **Added `openssl` and `openssl-devel`** — required at build/link time; the build fails on a minimal Fedora image without them.
- **Added a `uv` install step** — the build now drives Python dependencies through `uv` (consistent with the Ubuntu section already in this same file), so it must be installed before `make`.
- **Build commands updated** — replaced bare `make` / `sudo make install` with the `uv sync` + `RUST_PROFILE=release uv run make` + `sudo RUST_PROFILE=release make install` flow that the Ubuntu section already documents. This is the supported path; the old commands no longer build cleanly.
- **Release tag bumped** `v24.05` → `v26.04` — the previous example tag is two years stale.


### Verification

Using docker for double-checking the procedure:

```
#!/usr/bin/env bash
# Usage:
#   ./build_cln.sh [CONTAINER_NAME] [FEDORA_VERSION] [GIT_TAG]
# Defaults:
#   CONTAINER_NAME = cln-build
#   FEDORA_VERSION = 39
#   GIT_TAG        = v26.04

set -euo pipefail

CONTAINER_NAME="${1:-cln-build}"
FEDORA_VERSION="${2:-39}"
GIT_TAG="${3:-v26.04}"

# Convenience function — used for every docker exec from here on
fctr() { docker exec "${CONTAINER_NAME}" bash -c "$1"; }

echo "==> Starting container '${CONTAINER_NAME}' (fedora:${FEDORA_VERSION})"
docker run --name "${CONTAINER_NAME}" -d "fedora:${FEDORA_VERSION}" sleep infinity

echo "==> Installing system dependencies"
fctr "
  dnf update -y && \
  dnf group install -y \
    'c-development' \
    'development-tools' && \
  dnf install -y \
    clang \
    gettext \
    git \
    gmp-devel \
    libsq3-devel \
    python3-devel \
    python3-pip \
    python3-setuptools \
    net-tools \
    valgrind \
    wget \
    jq \
    zlib-devel \
    libsodium-devel \
    which \
    sed \
    protobuf-compiler \
    protobuf-devel \
    postgresql-devel \
    python3-mako \
    openssl \
    openssl-devel && \
  dnf clean all
"

echo "==> Installing Rust (rustup)"
fctr "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y"

echo "==> Installing uv (Python package manager)"
fctr "curl -LsSf https://astral.sh/uv/install.sh | sh"

echo "==> Installing lowdown"
fctr "
  cd /tmp && \
  wget https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_1_0_2.tar.gz && \
  tar -xzf VERSION_1_0_2.tar.gz && \
  cd lowdown-VERSION_1_0_2 && \
  ./configure && \
  make && \
  make install && \
  ldconfig && \
  cd / && \
  rm -rf /tmp/VERSION_1_0_2.tar.gz /tmp/lowdown-VERSION_1_0_2
"

echo "==> Cloning Core Lightning (tag: ${GIT_TAG})"
fctr "
  git clone https://github.com/ElementsProject/lightning.git && \
  cd lightning && \
  git checkout ${GIT_TAG} && \
  git submodule update --init --recursive
"

echo "==> Building and installing Core Lightning"
fctr "
  source \$HOME/.cargo/env && \
  export PATH=\"\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\" && \
  cd lightning && \
  uv sync --all-extras --all-groups --frozen && \
  ./configure && \
  RUST_PROFILE=release uv run make -j\$(nproc) && \
  RUST_PROFILE=release make install
"

echo "==> Verifying installation"
fctr "lightningd --version"
fctr "lightning-cli --version"

echo "==> Cleaning up container '${CONTAINER_NAME}'"
docker stop "${CONTAINER_NAME}"
docker rm "${CONTAINER_NAME}"

echo "==> Done."
```


