### PR TITLE
CI: remove focal and add resolute Ubuntu builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ release/
 focal/
 jammy/
 noble/
+resolute/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,12 @@ on:
         required: true
       skip_validation:
         description: Skip release validation for untagged commit testing
-        default: no
-        type: choice
-        options:
-          - yes
-          - no
+        default: false
+        type: boolean
       create_release:
         description: Create a draft release
-        default: no
-        type: choice
-        options:
-          - yes
-          - no
+        default: false
+        type: boolean
 
 jobs:
   check:
@@ -54,7 +48,7 @@ jobs:
           echo "Determined version: $VERSION"
 
       - name: Validate release
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_validation != 'yes'
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_validation) }}
         run: tools/check-release.sh --version=${VERSION}
 
       - name: Catpure version output
@@ -72,9 +66,9 @@ jobs:
       matrix:
         target:
           - 'bin-Fedora'
-          - 'bin-Ubuntu-focal'
           - 'bin-Ubuntu-jammy'
           - 'bin-Ubuntu-noble'
+          - 'bin-Ubuntu-resolute'
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -99,7 +93,7 @@ jobs:
       - name: Build release
         run: |
           # Allow build release to execute if manually triggered for testing
-          if [ "${{ github.event_name }}" == "workflow_dispatch" && github.event.inputs.skip_validation == 'yes' ]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.skip_validation }}" == "true" ]]; then
             tools/build-release.sh ${{ matrix.target }} --force-version "${{ env.version }}" --force-unclean --force-mtime "$(date +%Y-%m-%d)"
           else
             tools/build-release.sh ${{ matrix.target }}
@@ -187,7 +181,7 @@ jobs:
           echo "release_title=$RELEASE_TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release draft
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'yes')
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release) }}
         uses: softprops/action-gh-release@v3
         with:
           name: "${{ env.version }} ${{ steps.release_data.outputs.release_title }}"

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false    # Let each build finish.
       matrix:
-        version: ['focal', 'jammy', 'noble']
+        version: ['jammy', 'noble', 'resolute']
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -93,6 +93,7 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
+          secure: true
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
           from: ${{ secrets.EMAIL_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ bionic/
 focal/
 jammy/
 noble/
+resolute/
 release/
 .vscode/
 .cache/

--- a/contrib/cl-repro.sh
+++ b/contrib/cl-repro.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# This script creates base images for focal, jammy, and noble. Then it builds the
-# cl-repro-focal, cl-repro-jammy, and cl-repro-noble builder images. The base images are created using
+# This script creates base images for jammy, noble, and resolute. Then it builds the
+# cl-repro-jammy, cl-repro-noble, and cl-repro-resolute builder images. The base images are created using
 # debootstrap, and the cl-repro images are created using the Dockerfiles in
 # contrib/reprobuild. These builder images will finally be used to build the
 # reproducible binaries.
@@ -14,7 +14,7 @@ LIGHTNING_DIR=$PWD
 LIGHTNING_DIR=$(echo "$LIGHTNING_DIR" | sed 's|/contrib$||')
 echo "Lightning Directory: $LIGHTNING_DIR"
 
-for v in focal jammy noble; do
+for v in jammy noble resolute; do
   echo "Building base image for $v"
   sudo docker run -v "$LIGHTNING_DIR":/build ubuntu:$v \
 	bash -c "apt-get update && apt-get install -y debootstrap && debootstrap $v /build/$v"

--- a/contrib/reprobuild/Dockerfile.resolute
+++ b/contrib/reprobuild/Dockerfile.resolute
@@ -1,4 +1,4 @@
-FROM focal
+FROM ubuntu:resolute
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -18,41 +18,29 @@ RUN apt-get update \
     file \
     gettext \
     git \
+    curl \
+    libsqlite3-dev \
     libpq-dev \
     libsodium23 \
     libsodium-dev \
+    lowdown \
     libtool \
     m4 \
     sudo \
     unzip \
     wget \
-    zip \
-    && cd /tmp \
-    && wget https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_1_0_2.tar.gz \
-    && tar -xzf VERSION_1_0_2.tar.gz \
-    && cd lowdown-VERSION_1_0_2 \
-    && ./configure \
-    && make \
-    && make install \
-    && ldconfig \
-    && cd / \
-    && rm -rf /tmp/VERSION_1_0_2.tar.gz /tmp/lowdown-VERSION_1_0_2
+    jq \
+    zip
 
-# Ensure correct ownership
-RUN chown root:root /etc/sudoers
-RUN chown root:root /usr/lib/sudo/sudoers.so
+# Configure /repo/.git as 'safe.directory'
+RUN git config --global --add safe.directory /repo/.git
 
-# Download and install jq from official repository
-RUN wget -O /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 \
-    && chmod +x /usr/local/bin/jq
-
-# install Python3.10 (more reproducible than relying on python3-setuptools)
+# Install Python3.10 (more reproducible than relying on python3-setuptools)
 RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
     apt-get install -y --no-install-recommends \
     libbz2-dev \
     libffi-dev \
     libreadline-dev \
-    libsqlite3-dev \
     libssl-dev \
     zlib1g-dev && \
     pyenv install 3.10.0 && \

--- a/doc/getting-started/advanced-setup/repro.md
+++ b/doc/getting-started/advanced-setup/repro.md
@@ -41,20 +41,20 @@ the non-updated repos).
 
 The following table lists the codenames of distributions that we currently support:
 
-- Ubuntu 20.04:
-  - Distribution Version: 20.04
-  - Codename: focal
 - Ubuntu 22.04:
   - Distribution Version: 22.04
   - Codename: jammy
 - Ubuntu 24.04:
   - Distribution Version: 24.04
   - Codename: noble
+- Ubuntu 26.04:
+  - Distribution Version: 26.04
+  - Codename: resolute
 
 Depending on your host OS release you might not have `debootstrap` manifests for versions newer than your host OS. Due to this we run the `debootstrap` commands in a container of the latest version itself:
 
 ```shell
-for v in focal jammy noble; do
+for v in jammy noble resolute; do
   echo "Building base image for $v"
   docker run --rm -v $(pwd):/build ubuntu:$v \
 	bash -c "apt-get update && apt-get install -y debootstrap && debootstrap $v /build/$v"
@@ -86,9 +86,9 @@ For this purpose we have a number of Dockerfiles in the [`contrib/reprobuild`](h
 We can then build the builder image by calling `docker build` and passing it the `Dockerfile`:
 
 ```shell
-docker build -t cl-repro-focal - < contrib/reprobuild/Dockerfile.focal
 docker build -t cl-repro-jammy - < contrib/reprobuild/Dockerfile.jammy
 docker build -t cl-repro-noble - < contrib/reprobuild/Dockerfile.noble
+docker build -t cl-repro-resolute - < contrib/reprobuild/Dockerfile.resolute
 ```
 
 Since we pass the `Dockerfile` through `stdin` the build command will not create a context, i.e., the current directory is not passed to `docker` and it'll be independent of the currently checked out version. This also means that you will be able to reuse the docker image for future builds, and don't have to repeat this dance every time. Verifying the `Dockerfile` therefore is  
@@ -102,9 +102,9 @@ Finally, after finishing the environment setup we can perform the actual build. 
 We'll need the release directory available for this, so create it now if it doesn't exist:`mkdir release`, then we can simply execute the following command inside the git repository (remember to checkout the tag you are trying to build):
 
 ```bash
-docker run --rm -v $(pwd):/repo -ti cl-repro-focal
 docker run --rm -v $(pwd):/repo -ti cl-repro-jammy
 docker run --rm -v $(pwd):/repo -ti cl-repro-noble
+docker run --rm -v $(pwd):/repo -ti cl-repro-resolute
 ```
 
 The last few lines of output also contain the `sha256sum` hashes of all artifacts, so if you're just verifying the build those are the lines that are of interest to you:
@@ -123,7 +123,7 @@ The release captain is in charge of creating the manifest, whereas contributors 
 ## Script build-release
 1: Pull latest code from master
 
-2: Run the `tools/build-release.sh bin-Fedora bin-Ubuntu sign` script. This will create a release directory, build binaries for Fedora, and build binaries for Ubuntu (Focal, Jammy, and Noble). Finally, it will sign the ZIP, Fedora, and Ubuntu builds.
+2: Run the `tools/build-release.sh bin-Fedora bin-Ubuntu sign` script. This will create a release directory, build binaries for Fedora, and build binaries for Ubuntu (Jammy, Noble, and Resolute). Finally, it will sign the ZIP, Fedora, and Ubuntu builds.
 
 ## Manual
 The release captain creates the manifest as follows:
@@ -143,7 +143,7 @@ gpg -sb --armor SHA256SUMS
 
 2: Copy above files in the lightning directory.
 
-3: Run `tools/build-release.sh --verify` script. It will build binaries for Ubuntu (Focal, Jammy & Noble), verify zip & Ubuntu builds while copying Fedora checksums from the release captain's file.
+3: Run `tools/build-release.sh --verify` script. It will build binaries for Ubuntu (Jammy, Noble & Resolute), verify zip & Ubuntu builds while copying Fedora checksums from the release captain's file.
 
 4. Then send the resulting `release/SHA256SUMS.asc` file to the release captain so it can be merged with the other signatures into `SHASUMS.asc`.
 
@@ -200,9 +200,9 @@ Producing output similar to the following:
 ```shell
 sha256sum: clightning-v24.11-Fedora-35-amd64.tar.gz: No such file or directory
 clightning-v24.11-Fedora-35-amd64.tar.gz: FAILED open or read
-clightning-v24.11-Ubuntu-20.04.tar.xz: OK
 clightning-v24.11-Ubuntu-22.04.tar.xz: OK
 clightning-v24.11-Ubuntu-24.04.tar.xz: OK
+clightning-v24.11-Ubuntu-26.04.tar.xz: OK
 clightning-v24.11.zip: OK
 sha256sum: WARNING: 1 listed file could not be read
 ```

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,6 +1,10 @@
 #! /bin/sh
 set -e
 
+echo "RAW ARGS: [$*]"
+echo "ARG COUNT: $#"
+echo "ARG1: [$1]"
+
 # When run inside docker (from below), we do build and drop result in /release
 if [ "$1" = "--inside-docker" ]; then
     echo "Inside docker: starting build"
@@ -32,44 +36,54 @@ SUDO=
 ALL_TARGETS="bin-Fedora bin-Ubuntu docker sign"
 # ALL_TARGETS="bin-Fedora bin-Ubuntu tarball deb docker sign"
 
-for arg; do
-    case "$arg" in
-    --force-version=*)
-        FORCE_VERSION=${arg#*=}
-        ;;
-    --force-unclean)
-        FORCE_UNCLEAN=true
-        ;;
-    --force-mtime=*)
-        FORCE_MTIME=${arg#*=}
-        ;;
-    --verify)
-        VERIFY_RELEASE=true
-        ;;
-    --without-zip)
-        WITHOUT_ZIP=true
-        ;;
-    --sudo)
-        SUDO=sudo
-        ;;
-    --help)
-        echo "Usage: [--force-version=<ver>] [--force-unclean] [--force-mtime=YYYY-MM-DD] [--verify] [TARGETS]"
-        echo Known targets: "$ALL_TARGETS"
-        echo "Example: tools/build-release.sh"
-        echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 bin-Fedora bin-Ubuntu sign"
-        echo "Example: tools/build-release.sh --verify"
-        echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 --verify"
-        echo "Example: tools/build-release.sh docker"
-        echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 docker"
-        exit 0
-        ;;
-    -*)
-        echo "Unknown arg $arg" >&2
-        exit 1
-        ;;
-    *)
-        break
-        ;;
+TARGETS=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force-version=*)
+            FORCE_VERSION=${1#*=}
+            ;;
+        --force-version)
+            shift
+            FORCE_VERSION=$1
+            ;;
+        --force-unclean)
+            FORCE_UNCLEAN=true
+            ;;
+        --force-mtime=*)
+            FORCE_MTIME=${1#*=}
+            ;;
+        --force-mtime)
+            shift
+            FORCE_MTIME=$1
+            ;;
+        --verify)
+            VERIFY_RELEASE=true
+            ;;
+        --without-zip)
+            WITHOUT_ZIP=true
+            ;;
+        --sudo)
+            SUDO=sudo
+            ;;
+        --help)
+            echo "Usage: [--force-version=<ver>] [--force-unclean] [--force-mtime=YYYY-MM-DD] [--verify] [TARGETS]"
+            echo Known targets: "$ALL_TARGETS"
+            echo "Example: tools/build-release.sh"
+            echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 bin-Fedora bin-Ubuntu sign"
+            echo "Example: tools/build-release.sh --verify"
+            echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 --verify"
+            echo "Example: tools/build-release.sh docker"
+            echo "Example: tools/build-release.sh --force-version=v23.05 --force-unclean --force-mtime=2023-05-01 docker"
+            exit 0
+            ;;
+        -*)
+            echo "Unknown arg $1" >&2
+            exit 1
+            ;;
+        *)
+            TARGETS="$TARGETS $1"
+            ;;
     esac
     shift
 done
@@ -124,11 +138,7 @@ if [ "$VERIFY_RELEASE" = "true" ]; then
     fi
 fi
 
-if [ "$#" = 0 ]; then
-    TARGETS=" $ALL_TARGETS "
-else
-    TARGETS=" $* "
-fi
+TARGETS=${TARGETS:-$ALL_TARGETS}
 
 RELEASEDIR="$(pwd)/release"
 BARE_VERSION="$(echo "${VERSION}" | sed 's/^v//g')"
@@ -184,7 +194,7 @@ for target in $TARGETS; do
         ;;
     Ubuntu*)
         distributions=${platform#Ubuntu-}
-        [ "$distributions" = "Ubuntu" ] && distributions="focal jammy noble"
+        [ "$distributions" = "Ubuntu" ] && distributions="jammy noble resolute"
         for d in $distributions; do
             # Capitalize the first letter of distro
             D=$(echo "$d" | awk '{print toupper(substr($0,1,1))substr($0,2)}')

--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -80,31 +80,6 @@ PKGS='autoconf automake libtool make gcc libsqlite3-dev zlib1g-dev libsodium-dev
 INST='sudo dpkg -i'
 
 case "$PLATFORM" in
-    Ubuntu-20.04)
-	cat > /tmp/SHASUMS <<EOF
-f554697f01a6267127ef20e6eae4e8ed983507c816475ac72dbb8be26d94c796  /var/cache/apt/archives/autoconf_2.69-11.1_all.deb
-a517394d9dce4a4cc734e45d5b9b5f17fe43d6682843f480b942426736d12050  /var/cache/apt/archives/automake_1%3a1.16.1-4ubuntu6_all.deb
-716a1922077df772dcd8d4e462e1c5a9570c48871cbee062c23ae348b3a08fa1  /var/cache/apt/archives/autotools-dev_20180224.1_all.deb
-3ba573c01939749cbe8a315fee33f49e7bcf8ff23b024e4230fe6d45f85b2a15  /var/cache/apt/archives/gcc-9-base_9.3.0-10ubuntu2_amd64.deb
-22f0282dc1549a4f5715b94e9c71ed0e96c400d522ec15453e1a8000d45ea8d7  /var/cache/apt/archives/gcc-9_9.3.0-10ubuntu2_amd64.deb
-78ab6a8841c68300ba39992e8e33190371e133b3592c601ed3052d54e2ba59ea  /var/cache/apt/archives/gcc_4%3a9.3.0-1ubuntu2_amd64.deb
-51bf3e807747de738435e9aa4213f43ec62769d7178614e4db9de387446c714e  /var/cache/apt/archives/libc-dev-bin_2.31-0ubuntu9_amd64.deb
-adb78f38fb00c76af4384be7a4c5f41da242e05bea6b0483e03b7e0c86738477  /var/cache/apt/archives/libc6-dev_2.31-0ubuntu9_amd64.deb
-255ebc78828b1531f83038805dd918a8a60c017f939b07dd614b9fb7f7400df3  /var/cache/apt/archives/libcc1-0_10-20200411-0ubuntu1_amd64.deb
-f0a41d8e8cf379dbbdfc43169f34851ed452b3581e72c6654f2e290caf4e1b20  /var/cache/apt/archives/libcrypt-dev_1%3a4.4.10-10ubuntu4_amd64.deb
-d1db4de59b4184e502407a2abfde23ed1a966e590f17b4d206bdb4fbb7df0040  /var/cache/apt/archives/libgcc-9-dev_9.3.0-10ubuntu2_amd64.deb
-b1d9556fea9ed94dea7eeebeccc59bf9598a658e77e6dba5b9197d0f1a22059b  /var/cache/apt/archives/libpq-dev_12.2-4_amd64.deb
-af86d031c99bc7db0c8e6a93547a885f48d1f88b683989ac479a9c1b2b9e1781  /var/cache/apt/archives/libpq5_12.2-4_amd64.deb
-2bc3d45c379470ffbe6da5c30edd573c7579331299ad67a04af68f11b1858970  /var/cache/apt/archives/libsodium-dev_1.0.18-1_amd64.deb
-2790af911186c8c8f34270199ac553ee43704f007d6af064205319d03b591f3c  /var/cache/apt/archives/libsodium23_1.0.18-1_amd64.deb
-6d8f20d36b47a2ebc64c1cdd09acbe98c2786ee6f6ef49c84e0277e5b5453709  /var/cache/apt/archives/libsqlite3-0_3.31.1-4_amd64.deb
-7b81b1f3c1b811b12ce7fa23cc4dc7e1e45700a158a674a2eb7ee6f5a4f10f2f  /var/cache/apt/archives/libsqlite3-dev_3.31.1-4_amd64.deb
-a7d59420134a8307eb11ef79b68e2b35cadc794a60f82c87f4583e37c763fd01  /var/cache/apt/archives/linux-libc-dev_5.4.0-26.30_amd64.deb
-1ffa955ebb58829f3ab0debf7ad57b150887f6a44769edbaef68b8da9d95f306  /var/cache/apt/archives/m4_1.4.18-4_amd64.deb
-41e534af98cdb6219bc98fa4276d9c928a0862b8b373d49ee1fbe0ae5db64dc2  /var/cache/apt/archives/make_4.2.1-1.2_amd64.deb
-9cd69c847d7b12bd9cb2c58afe8bd17fb3973361716af71eb45c0f2b6d7e6884  /var/cache/apt/archives/zlib1g-dev_1%3a1.2.11.dfsg-2ubuntu1_amd64.deb
-EOF
-	;;
     Ubuntu-22.04)
 	cat > /tmp/SHASUMS <<EOF
 96b528889794c4134015a63c75050f93d8aecdf5e3f2a20993c1433f4c61b80e  /var/cache/apt/archives/autoconf_2.71-2_all.deb
@@ -139,6 +114,18 @@ bd3e8cd6ab8cf731d8a8a15333831b9081a94ebefe22236fc8713975fe7a6d3a  /var/cache/apt
 9d1d707179675d38e024bb13613b1d99e0d33fa6c45e5f3bcba19340781781d3  /var/cache/apt/archives/libtool_2.4.7-7build1_all.deb
 1fe6a815b56c7b6e9ce4086a363f09444bbd0a0d30e230c453d0b78e44b57a99  /var/cache/apt/archives/make_4.3-4.1build2_amd64.deb
 023cbe9dbf0af87f10e54e342c67571874e412b9950d89c6cd7b010be2e67c3c  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg-3.1ubuntu2.1_amd64.deb
+EOF
+	;;
+    Ubuntu-26.04)
+    cat > /tmp/SHASUMS <<EOF
+9edd0db0fa94580ab013529d6842a8e89b8ed22ab337da5e95cbb43971978815  /var/cache/apt/archives/autoconf_2.72-3.1ubuntu2_all.deb
+1a443abf03a5af97f4493405e22eba52fd6935a8b0583ac32fb88b3727563e53  /var/cache/apt/archives/automake_1%3a1.18.1-3build1_all.deb
+d780844418b745c432a5d6c85f055625f37e27523b026baee0c87d386a0aab0a  /var/cache/apt/archives/gcc_4%3a15.2.0-5ubuntu1_amd64.deb
+34e8337b30160458f44bada750c9e94ec18ec5ac087e2428043ddb04625226cc  /var/cache/apt/archives/libsodium-dev_1.0.18-2_amd64.deb
+0f57948b8c1d4f369f14dc3897d4985227020d57b798a7ddd1b9acb2a8ea430d  /var/cache/apt/archives/libsqlite3-dev_3.46.1-9_amd64.deb
+5b3146cd9d380e4725fc5b5e54795ae1f72d165d93e68ce29076b69762661fd4  /var/cache/apt/archives/libtool_2.5.4-9_all.deb
+a86f39d57a32b7c919c0ad721fc2f17ab533a42fda348c8d81a4eea1577a014f  /var/cache/apt/archives/make_4.4.1-3_amd64.deb
+601b9f92a04ea9ff7de6f60f60c34f2e2743f9c478125ac9e413f29a1fa728d9  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg+really1.3.1-1ubuntu3_amd64.deb
 EOF
 	;;
     *)


### PR DESCRIPTION
Also fixed untagged, manual triggers of the release workflow. `contrib/reprobuild/Dockerfile.resolute` is just a copy of noble with the release name changed.

I wasn't sure which sha sums i shuold use in `tools/repro-build.sh` so please double check that i included the correct files with the correct sha sums. I just mirrored the noble ones and the workflow worked.

Manually triggered run: https://github.com/daywalker90/lightning/actions/runs/26511823759/job/78078246616
Tag-triggered run: https://github.com/daywalker90/lightning/actions/runs/26514637288/job/78093470969

Both fail at the import gpg keys step of course, since it's my fork.

The resulting resolute archive is slightly bigger than noble/jammy, no idea why. (~35 vs ~41 MB)