### PR TITLE
Fix base image inconsistency in reprobuild for noble & resolute

### DIFF
--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM noble
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -8,7 +8,8 @@ ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:/root/.cargo/bin:/root/.local/bin:$
 ENV PROTOC_VERSION=29.4
 
 RUN sed -i '/updates/d' /etc/apt/sources.list && \
-    sed -i '/security/d' /etc/apt/sources.list
+    sed -i '/security/d' /etc/apt/sources.list && \
+    sed -i 's/^deb \(.*\) noble main$/deb \1 noble main universe/' /etc/apt/sources.list
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/contrib/reprobuild/Dockerfile.resolute
+++ b/contrib/reprobuild/Dockerfile.resolute
@@ -1,4 +1,4 @@
-FROM ubuntu:resolute
+FROM resolute
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -8,7 +8,8 @@ ENV PATH=/root/.pyenv/shims:/root/.pyenv/bin:/root/.cargo/bin:/root/.local/bin:$
 ENV PROTOC_VERSION=29.4
 
 RUN sed -i '/updates/d' /etc/apt/sources.list && \
-    sed -i '/security/d' /etc/apt/sources.list
+    sed -i '/security/d' /etc/apt/sources.list && \
+    sed -i 's/^deb \(.*\) resolute main$/deb \1 resolute main universe/' /etc/apt/sources.list
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tools/repro-build.sh
+++ b/tools/repro-build.sh
@@ -107,13 +107,12 @@ EOF
     Ubuntu-24.04)
 	cat > /tmp/SHASUMS <<EOF
 cc3f9f7a1e576173fb59c36652c0a67c6426feae752b352404ba92dfcb1b26c9  /var/cache/apt/archives/autoconf_2.71-3_all.deb
-5ae9a98e73545002cd891f028859941af2a3c760cb6190e635c7ef36953912de  /var/cache/apt/archives/automake_1%3a1.16.5-1.3ubuntu1_all.deb
 0e0bb8b25153ed1c44ab92bc219eed469fcb5820c5c0bc6454b2fd366a33d3ee  /var/cache/apt/archives/gcc_4%3a13.2.0-7ubuntu1_amd64.deb
-bd3e8cd6ab8cf731d8a8a15333831b9081a94ebefe22236fc8713975fe7a6d3a  /var/cache/apt/archives/libsodium-dev_1.0.18-1ubuntu0.24.04.1_amd64.deb
-5131ce3d7cdb7193bcef1b402741a0e0f436e25a50e65443fffcc7064e2cd780  /var/cache/apt/archives/libsqlite3-dev_3.45.1-1ubuntu2.5_amd64.deb
+f11b4d687a305dd7ee47a384d82a9bf04de913362df9efa67d2a029ae65051a9  /var/cache/apt/archives/libsodium-dev_1.0.18-1build3_amd64.deb
+d23577c43936fedd8c4fa1337a6e960a6e71e94ac164d7a15c46ea96bf21265d  /var/cache/apt/archives/libsqlite3-dev_3.45.1-1ubuntu2_amd64.deb
 9d1d707179675d38e024bb13613b1d99e0d33fa6c45e5f3bcba19340781781d3  /var/cache/apt/archives/libtool_2.4.7-7build1_all.deb
 1fe6a815b56c7b6e9ce4086a363f09444bbd0a0d30e230c453d0b78e44b57a99  /var/cache/apt/archives/make_4.3-4.1build2_amd64.deb
-023cbe9dbf0af87f10e54e342c67571874e412b9950d89c6cd7b010be2e67c3c  /var/cache/apt/archives/zlib1g-dev_1%3a1.3.dfsg-3.1ubuntu2.1_amd64.deb
+0b93d16d7498f092fa3070fbbad28cdbc6b3d640f1a7681b96fc37f20d1219f1  /var/cache/apt/archives/zlib1g_1%3a1.3.dfsg-3.1ubuntu2_amd64.deb
 EOF
 	;;
     Ubuntu-26.04)


### PR DESCRIPTION
`cln-repro-*` images use minimal debootstrapped base images (jammy, noble, resolute) with additional layers from `contrib/reprobuild/`. Currently, `Dockerfile.noble` and `Dockerfile.resolute` incorrectly pull from `ubuntu:noble` and `ubuntu:resolute` instead of using the debootstrapped `noble` and `resolute` base images, breaking consistency with `Dockerfile.jammy`. This PR corrects the base images for noble and resolute. No changes needed for jammy.

Changelog-None.