### PR TITLE
plugins: rename bwatch output binary to cln-bwatch

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -22,4 +22,4 @@ exposesecret
 cln-xpay
 cln-lsps-client
 cln-lsps-service
-bwatch
+cln-bwatch

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -122,7 +122,7 @@ C_PLUGINS :=					\
 	plugins/autoclean			\
 	plugins/chanbackup			\
 	plugins/bcli				\
-	plugins/bwatch/bwatch			\
+	plugins/cln-bwatch			\
 	plugins/commando			\
 	plugins/funder				\
 	plugins/topology			\
@@ -205,7 +205,7 @@ plugins/bwatch/bwatch_store.o: $(PLUGIN_BWATCH_HEADER)
 plugins/bwatch/bwatch_scanner.o: $(PLUGIN_BWATCH_HEADER)
 plugins/bwatch/bwatch_interface.o: $(PLUGIN_BWATCH_HEADER)
 plugins/bwatch/bwatch_wiregen.o: $(PLUGIN_BWATCH_HEADER)
-plugins/bwatch/bwatch: $(PLUGIN_BWATCH_OBJS) $(PLUGIN_LIB_OBJS) libcommon.a
+plugins/cln-bwatch: $(PLUGIN_BWATCH_OBJS) $(PLUGIN_LIB_OBJS) libcommon.a
 
 plugins/keysend: $(PLUGIN_KEYSEND_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_PAY_LIB_OBJS) libcommon.a
 $(PLUGIN_KEYSEND_OBJS): $(PLUGIN_PAY_LIB_HEADER) libcommon.a


### PR DESCRIPTION
The bwatch plugin lived in plugins/bwatch/ and output its binary as plugins/bwatch/bwatch. This caused make install to install it flat as <plugindir>/bwatch, while lightningd expected it at <plugindir>/bwatch/bwatch, so plugin registration failed at startup with "failed to register plugin".

Fix by renaming the output to plugins/cln-bwatch, following the same convention as cln-renepay, cln-xpay and cln-askrene.

Changelog-Fixed: bwatch plugin failed to register on startup after make install

Fixes #9191 
