### PR TITLE
Preserve nested plugin subdir on make install (bwatch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -955,6 +955,13 @@ installdirs:
 	$(MKDIR_P) $(DESTDIR)$(docdir)
 
 # $(PLUGINS) is defined in plugins/Makefile.
+# Most plugins are a single binary that installs directly into plugindir
+# (e.g. plugins/pay -> plugindir/pay).  A few live in their own subdir and
+# lightningd looks them up by that nested name (e.g. plugins/bwatch/bwatch ->
+# plugindir/bwatch/bwatch; see PLUGIN_BASES in plugins/Makefile).  Those must
+# keep their subdir when installed, instead of being flattened to plugindir.
+FLAT_PLUGINS := $(foreach p,$(PLUGINS),$(if $(findstring /,$(p:plugins/%=%)),,$(p)))
+NESTED_PLUGINS := $(filter-out $(FLAT_PLUGINS),$(PLUGINS))
 
 install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $(PY_PLUGINS)
 	@$(NORMAL_INSTALL)
@@ -962,13 +969,14 @@ install-program: installdirs $(BIN_PROGRAMS) $(PKGLIBEXEC_PROGRAMS) $(PLUGINS) $
 	$(INSTALL_PROGRAM) $(PKGLIBEXEC_PROGRAMS) $(DESTDIR)$(pkglibexecdir)
 	@if [ -d "$(DESTDIR)$(plugindir)/clnrest" ]; then rm -rf $(DESTDIR)$(plugindir)/clnrest; fi
 	@if [ -d "$(DESTDIR)$(plugindir)/wss-proxy" ]; then rm -rf $(DESTDIR)$(plugindir)/wss-proxy; fi
-	[ -z "$(PLUGINS)" ] || $(INSTALL_PROGRAM) $(PLUGINS) $(DESTDIR)$(plugindir)
+	[ -z "$(FLAT_PLUGINS)" ] || $(INSTALL_PROGRAM) $(FLAT_PLUGINS) $(DESTDIR)$(plugindir)
+	for PLUGIN in $(NESTED_PLUGINS); do DST=$(DESTDIR)$(plugindir)/`echo $$PLUGIN | sed 's|^plugins/||'`; $(MKDIR_P) `dirname $$DST`; $(INSTALL_PROGRAM) $$PLUGIN $$DST; done
 	for PY in $(PY_PLUGINS); do DIR=`dirname $$PY`; DST=$(DESTDIR)$(plugindir)/`basename $$DIR`; if [ -d $$DST ]; then rm -rf $$DST; fi; $(INSTALL_PROGRAM) -d $$DIR; cp -a $$DIR $$DST ; done
 ifeq ($(OS),Darwin)
 	# Install dSYM bundles alongside binaries on macOS
 	for BIN in $(BIN_PROGRAMS); do if [ -d $$BIN.dSYM ]; then cp -a $$BIN.dSYM $(DESTDIR)$(bindir)/; fi; done
 	for BIN in $(PKGLIBEXEC_PROGRAMS); do if [ -d $$BIN.dSYM ]; then cp -a $$BIN.dSYM $(DESTDIR)$(pkglibexecdir)/; fi; done
-	for PLUGIN in $(PLUGINS); do if [ -d $$PLUGIN.dSYM ]; then cp -a $$PLUGIN.dSYM $(DESTDIR)$(plugindir)/; fi; done
+	for PLUGIN in $(PLUGINS); do if [ -d $$PLUGIN.dSYM ]; then DSTDIR=$(DESTDIR)$(plugindir)/`dirname \`echo $$PLUGIN | sed 's|^plugins/||'\``; $(MKDIR_P) $$DSTDIR; cp -a $$PLUGIN.dSYM $$DSTDIR/; fi; done
 endif
 
 MAN1PAGES = $(filter %.1,$(MANPAGES))
@@ -1009,9 +1017,14 @@ uninstall:
 	  $(ECHO) rm -f $(DESTDIR)$(bindir)/`basename $$f`; \
 	  rm -f $(DESTDIR)$(bindir)/`basename $$f`; \
 	done
-	@for f in $(PLUGINS); do \
+	@for f in $(FLAT_PLUGINS); do \
 	  $(ECHO) rm -f $(DESTDIR)$(plugindir)/`basename $$f`; \
 	  rm -f $(DESTDIR)$(plugindir)/`basename $$f`; \
+	done
+	@for f in $(NESTED_PLUGINS); do \
+	  d=`echo $$f | sed 's|^plugins/||;s|/.*||'`; \
+	  $(ECHO) rm -rf $(DESTDIR)$(plugindir)/$$d; \
+	  rm -rf $(DESTDIR)$(plugindir)/$$d; \
 	done
 	@for f in $(PY_PLUGINS); do \
 	  $(ECHO) rm -rf $(DESTDIR)$(plugindir)/$$(basename $$(dirname $$f)); \

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5331,3 +5331,46 @@ def test_tracing_socket(node_factory):
         for key in ("id", "name", "timestamp", "duration", "traceId"):
             assert key in span, f"Missing key {key} in span {span}"
         assert span["localEndpoint"] == {"serviceName": "lightningd"}
+
+
+# FIXME: This regression test exists because `bwatch` is the first builtin
+# plugin whose binary lives in its own subdirectory (plugins/bwatch/bwatch).
+# `make install` used to flatten every plugin into plugindir, so bwatch landed
+# at plugindir/bwatch (a file) while lightningd looked it up at
+# plugindir/bwatch/bwatch and failed to register it (see issue #9193).
+# This test can be removed once the bwatch plugin is stable and the install
+# layout is no longer in flux.
+def test_install_preserves_nested_plugin_path(tmp_path):
+    """`make install` must keep plugins/bwatch/bwatch nested, not flatten it."""
+    srcdir = Path(__file__).parent.parent
+
+    make = shutil.which("make")
+    if make is None:
+        pytest.skip("make not available")
+
+    # Only meaningful in a configured + built source tree.
+    if not (srcdir / "config.vars").exists():
+        pytest.skip("not a configured source tree (no config.vars)")
+    if not (srcdir / "plugins" / "bwatch" / "bwatch").exists():
+        pytest.skip("bwatch plugin not built")
+
+    destdir = tmp_path / "destdir"
+    completed = subprocess.run(
+        [make, "-C", str(srcdir), "DESTDIR={}".format(destdir), "install-program"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    assert completed.returncode == 0, completed.stdout.decode("utf-8", "replace")
+
+    nested = glob.glob(str(destdir / "**" / "plugins" / "bwatch" / "bwatch"),
+                       recursive=True)
+    flattened = [p for p in glob.glob(str(destdir / "**" / "plugins" / "bwatch"),
+                                      recursive=True)
+                 if os.path.isfile(p)]
+
+    assert nested, (
+        "bwatch was not installed at plugins/bwatch/bwatch; "
+        "flattened candidates: {}".format(flattened)
+    )
+    assert not flattened, (
+        "bwatch was flattened to plugins/bwatch instead of plugins/bwatch/bwatch"
+    )


### PR DESCRIPTION
## Summary
- Source installs of v26.06 fail at startup with `UNUSUAL plugin-manager: failed to register plugin .../plugins/bwatch/bwatch` because `make install` flattens the `bwatch` binary
- Root cause: `bwatch` is the first builtin plugin whose binary lives in its own subdir (`plugins/bwatch/bwatch`), but `install-program` installed every plugin flat into `plugindir`, so it landed at `plugindir/bwatch` (a file) while `lightningd` looks it up at `plugindir/bwatch/bwatch`
- Split `$(PLUGINS)` into flat and nested sets so nested plugins keep their subdirectory on install, leaving the flat install path unchanged

## Detail
`PLUGIN_BASES := $(PLUGINS:plugins/%=%)` in `plugins/Makefile` strips the `plugins/` prefix, so `bwatch` enters `list_of_builtin_plugins` as `bwatch/bwatch` and `plugins_set_builtin_plugins_dir()` registers it at `plugindir/bwatch/bwatch`.

`install-program` then ran `$(INSTALL_PROGRAM) $(PLUGINS) $(DESTDIR)$(plugindir)`. `install <files...> <dir>` flattens each source to its basename, so `plugins/bwatch/bwatch` was installed as the regular file `plugindir/bwatch`, and registration failed. Every other C plugin (`plugins/pay`, `plugins/sql`, ...) and the Rust plugins are flat, so they were unaffected.

Fix splits `$(PLUGINS)` into `FLAT_PLUGINS` and `NESTED_PLUGINS`: flat plugins install straight into `plugindir` exactly as before, nested ones keep their subdir. `uninstall` and the macOS dSYM copy follow the nested layout so `installcheck` leaves nothing behind.

Fixes #9193
Changelog-Fixed: plugins: `bwatch` is no longer flattened on `make install`, fixing 'failed to register plugin' at startup.

## Test plan
- [ ] CI passes (`installcheck` exercises install + uninstall + `lightningd --test-daemons-only`)
- [ ] Verify `bwatch` installs at `plugindir/bwatch/bwatch`, not flattened to `plugindir/bwatch`
- [ ] Verify flat plugins (`pay`, `sql`, ...) still install directly into `plugindir`
- [ ] Verify `make uninstall` removes the whole `bwatch` subdir, leaving no files
- New `tests/test_misc.py::test_install_preserves_nested_plugin_path` reproduces the flattening; it carries a `FIXME` noting it can be dropped once the `bwatch` plugin is stable

----

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [X] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [X] Related issues have been listed and linked, including any that this PR closes.