### PR TITLE
Fix release sign target detection when passed as single argument

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -209,7 +209,7 @@ for target in $TARGETS; do
     esac
 done
 
-if [ -z "${TARGETS##* docker *}" ]; then
+if [ -z "${TARGETS##* docker *}" ] || [ -z "${TARGETS##* docker}" ]; then
     echo "Building Docker Images"
     DOCKER_USER="elementsproject"
     echo "Creating multi-platform images tagged as $VERSION and latest"
@@ -230,7 +230,7 @@ if [ -z "${TARGETS##* docker *}" ]; then
     echo "Pushed multi-platform images tagged as $VERSION and latest"
 fi
 
-if [ -z "${TARGETS##* sign *}" ]; then
+if [ -z "${TARGETS##* sign *}" ] || [ -z "${TARGETS##* sign}" ]; then
     echo "Signing Release"
     cd release/ || exit
     sha256sum clightning-"$VERSION"-*.tar.* clightning-"$VERSION".zip > SHA256SUMS-"$VERSION"


### PR DESCRIPTION
The sign target detection uses pattern matching that requires spaces on both sides of "sign" in the TARGETS variable. When only "sign" is passed as an argument, TARGETS becomes " sign" (leading space only), causing the condition to fail.

Add an additional pattern match to detect "sign" with a leading space but no trailing space, which occurs when "sign" is the only target or the last target in the list.

This regression seems to have been exposed by GitHub Actions runner updates (Ubuntu 22.04 → 24.04), which changed argument passing behavior.

Changelog-None: Fixes the release signing issue only.

Fixes #9198.