### PR TITLE
docs: Updated Archlinux installation guide

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -517,6 +517,7 @@ git checkout v26.06.1
 
 Build and install Core Lightning:
 ```shell
+UV_PYTHON=3.12
 uv sync --all-extras --all-groups --frozen
 ./configure
 RUST_PROFILE=release uv run make

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -493,7 +493,7 @@ gmake install
 
 Install dependencies:
 ```shell
-pacman -Sy autoconf automake gcc git make python-pip which libtool lowdown jq libsodium
+pacman -Syu base-devel git which sqlite gmp libsodium lowdown jq python-pip protobuf pkgconf
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
@@ -507,7 +507,7 @@ cd lightning
 
 If you want to build the Rust plugins (cln-grpc, clnrest, cln-bip353 and wss-proxy):
 ```shell
-pacman -Sy cargo rustfmt
+pacman -Syu cargo rustfmt
 ```
 
 Checkout a release tag:

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -510,7 +510,12 @@ If you want to build the Rust plugins (cln-grpc, clnrest, cln-bip353 and wss-pro
 pacman -Sy cargo rustfmt
 ```
 
-Build Core Lightning:
+Checkout a release tag:
+```shell
+git checkout v26.06.1
+```
+
+Build and install Core Lightning:
 ```shell
 uv sync --all-extras --all-groups --frozen
 ./configure
@@ -518,8 +523,12 @@ RUST_PROFILE=release uv run make
 sudo RUST_PROFILE=release make install
 ```
 
+> 📘
+>
+> If you want to disable Rust because you don't need it or its plugins (cln-grpc, clnrest, cln-bip353 or wss-proxy), you can use `./configure --disable-rust`.
+
 Launch Core Lightning:
-```
+```shell
 lightningd
 ```
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

### Changes
Changelog-None

1. Replaced minimal `pacman` installation with the full package list
2. Added `rustup` installation step
3. Substituted `poetry` with `uv` for Python dependency management
4. Switched to the right installation procedure using uv (`uv sync` --> `./configure` --> `make install`)

In order to test the installation steps, the following bash script has been used on Apple Silicon:
```
#!/usr/bin/env bash
# Usage:
#   ./build_cln_arch.sh [CONTAINER_NAME] [ARCH_IMAGE] [GIT_TAG]
# Defaults:
#   CONTAINER_NAME = cln-arch-build
#   ARCH_IMAGE     = archlinux:latest
#   GIT_TAG        = v26.06.2

set -euo pipefail

CONTAINER_NAME="${1:-cln-arch-build}"
ARCH_IMAGE="${2:-archlinux:latest}"
GIT_TAG="${3:-v26.06.2}"

# Convenience function — used for every docker exec from here on
fctr() { docker exec "${CONTAINER_NAME}" bash -c "$1"; }

echo "==> Starting container '${CONTAINER_NAME}' (${ARCH_IMAGE})"
docker run --platform linux/amd64 --dns 1.1.1.1 --dns 8.8.8.8 --name "${CONTAINER_NAME}" -d "${ARCH_IMAGE}" sleep infinity

echo "==> Bypassing pacman sandboxing for ARM64 emulation compatibility"
# Injects flags directly into the [options] section of pacman.conf
fctr "sed -i '/^\[options\]/a DisableSandboxSyscalls\nDisableSandboxFilesystem' /etc/pacman.conf"

echo "==> Installing system dependencies"
fctr "
  pacman -Syu --noconfirm base-devel git which gmp sqlite protobuf  lowdown jq libsodium pkgconf
"

echo "==> Installing Rust"
fctr "pacman -Syu --noconfirm cargo rustfmt"

echo "==> Installing uv (Python package manager)"
fctr "curl -LsSf https://astral.sh/uv/install.sh | sh"

echo "==> Cloning Core Lightning (tag: ${GIT_TAG})"
fctr "
  git clone https://github.com/ElementsProject/lightning.git && \
  cd lightning && \
  git checkout ${GIT_TAG}
"

echo "==> Building and installing Core Lightning"
fctr "
  source \$HOME/.local/bin/env && \
  export PATH=\"\$HOME/.local/bin:/usr/local/bin:\$PATH\" && \
  export UV_PYTHON=3.12 && \
  cd lightning && \
  uv sync --all-extras --all-groups --frozen && \
  ./configure && \
  RUST_PROFILE=release uv run make && \
  RUST_PROFILE=release make install
"

echo "==> Verifying installation"
fctr "export PATH=\"/usr/local/bin:\$PATH\" && lightningd --version"
fctr "export PATH=\"/usr/local/bin:\$PATH\" && lightning-cli --version"
echo "==> Cleaning up container '${CONTAINER_NAME}'"
docker stop "${CONTAINER_NAME}"
docker rm "${CONTAINER_NAME}"

echo "==> Done."
```