### PR TITLE
nix: fix `nix build` and simplify NixOS install docs

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -317,13 +317,40 @@ Finally, build `c-lightning`:
 
 ## To Build on NixOS
 
-Use nix-shell launch a shell with a full Core Lightning dev environment:
+Core Lightning ships a [Nix flake](https://nixos.wiki/wiki/Flakes), so on NixOS
+you don't need to install any build dependencies by hand. Make sure the
+`nix-command` and `flakes` features are enabled.
+
+Build and run directly from the repository; the git submodules are fetched
+automatically and the binaries are placed under `./result/bin`:
 ```shell
-nix-shell -Q -p gdb sqlite autoconf git clang libtool sqlite autoconf \
-autogen automake gmp zlib gettext libsodium poetry 'python3.withPackages (p: [p.bitcoinlib])' \
-valgrind --run "./configure && poetry shell"
-poetry install
-make
+nix build github:ElementsProject/lightning
+
+# Or run them straight away:
+nix run github:ElementsProject/lightning#lightningd -- --version
+nix run github:ElementsProject/lightning#lightning-cli -- --version
+```
+
+Build a specific release by appending the tag, or install into your profile:
+```shell
+nix build github:ElementsProject/lightning/v26.06.1
+nix profile install github:ElementsProject/lightning
+```
+
+From a local checkout, append `?submodules=1` so the build sees the submodules:
+```shell
+git clone https://github.com/ElementsProject/lightning.git
+cd lightning
+git checkout v26.06.1
+nix build ".?submodules=1"
+./result/bin/lightningd --version
+```
+
+To build with PostgreSQL support use the `cln-postgres` package, and for a
+development shell with the full toolchain use `nix develop`:
+```shell
+nix build ".?submodules=1#cln-postgres"
+nix develop
 ```
 
 ## To Build on macOS Apple Silicon

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -66,7 +66,8 @@ stdenv.mkDerivation {
           tools/update-mocks.sh \
           tools/mockup.sh \
           tools/fromschema.py \
-          devtools/sql-rewrite.py
+          devtools/sql-rewrite.py \
+          devtools/blockreplace.py
       ''
     else
       ''
@@ -75,6 +76,11 @@ stdenv.mkDerivation {
       '';
 
   configureFlags = [ "--disable-valgrind" ];
+
+  # ./configure detects Python via `uv` (configure:default_python), which is not
+  # part of this derivation. Point it at the python3 we already provide so the
+  # codegen steps that call $(PYTHON) (e.g. devtools/blockreplace.py) work.
+  preConfigure = "export PYTHON=python3";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

## Rationale
CLN's `./configure` detects Python through `uv` (see `default_python` in `configure`), which the cln derivation does not provide, so PYTHON ends up empty and the build fails when a Makefile step runs `$(PYTHON) devtools/blockreplace.py`. Set `PYTHON=python3` in `preConfigure` (the derivation already ships a python3 with mako/grpcio-tools) and add `blockreplace.py` to `patchShebangs`.

With `nix build` working again, replace the stale poetry-based NixOS section of the install guide with the flake commands (`nix build` / `nix run` / `nix profile install` / `nix develop`). 

Verified in a nixos/nix container: nix build ".?submodules=1" produces lightningd/lightning-cli v26.06.1.

Changelog-Fixed: nix: the flake build (`nix build`) no longer fails because `./configure` cannot detect Python.

### Script to test and reproduce
```
#!/usr/bin/env bash
# Usage:
#   ./build_cln_nixos.sh [GIT_REF] [GIT_REPO] [NIX_IMAGE] [NIX_CORES]
# Defaults:
#   GIT_REF   = test-installation-documentation-nixos
#   GIT_REPO  = https://github.com/enaples/lightning.git
#   NIX_IMAGE = nixos/nix:latest
#   NIX_CORES = 2
#
# NOTE on container mechanics (NOT part of the documented steps):
#  * The nixos/nix image cannot be driven with `docker exec` under linux/amd64
#    QEMU emulation (runc fails with "openat etc/group: path escapes from
#    parent"). So, like the Fedora/Arch scripts run one step per `docker exec`,
#    here we run one step per `docker run`. State is carried between steps by two
#    named volumes: one for the Nix store (/nix) and one for the checkout (/work).
#    The ./result symlink and its store paths both live in those volumes, so the
#    verify steps can run in their own containers.
#  * NIX_CONFIG sets `filter-syscalls = false` because Nix's seccomp BPF filter
#    cannot be loaded under QEMU emulation. NIX_PATH points <nixpkgs> at the
#    flake registry (used only to fetch git in the clone/checkout steps).
#  * NIX_CORES / CARGO_BUILD_JOBS cap parallelism: a release-profile rustc is
#    memory-hungry under emulation and OOM-kills the build (signal 9) at high
#    parallelism on a small Docker memory allotment.
# None of these are needed on a real NixOS host.

set -euo pipefail

GIT_REF="${1:-test-installation-documentation-nixos}"
GIT_REPO="${2:-https://github.com/enaples/lightning.git}"
NIX_IMAGE="${3:-nixos/nix:latest}"
NIX_CORES="${4:-2}"

NIX_VOL="cln-nixos-store"
WORK_VOL="cln-nixos-work"

# Volumes are kept between runs by default so an interrupted/OOM build can be
# resumed cheaply (compiled crates stay cached). Run with CLEAN=1 to wipe them.
CLEAN="${CLEAN:-0}"

# Run one build step in a fresh container that shares the persistent Nix store
# and work volumes.
drun() {
  docker run --rm --platform linux/amd64 \
    -v "${NIX_VOL}:/nix" \
    -v "${WORK_VOL}:/work" \
    -w /work \
    -e NIX_CONFIG=$'experimental-features = nix-command flakes\nfilter-syscalls = false' \
    -e NIX_PATH='nixpkgs=flake:nixpkgs' \
    -e CARGO_BUILD_JOBS="${NIX_CORES}" \
    "${NIX_IMAGE}" sh -c "$1"
}

cleanup() {
  echo "==> (volumes kept for resume; run CLEAN=1 ./build_cln_nixos.sh to wipe)"
}
trap cleanup EXIT

if [ "${CLEAN}" = "1" ]; then
  echo "==> CLEAN=1: removing existing volumes for a fresh build"
  docker volume rm "${NIX_VOL}" "${WORK_VOL}" >/dev/null 2>&1 || true
fi

echo "==> Cloning Core Lightning (${GIT_REPO})"
# Idempotent so the script can be re-run against kept volumes after an OOM.
drun "[ -d lightning/.git ] || nix shell nixpkgs#git --command git clone ${GIT_REPO} lightning"

echo "==> Checking out ${GIT_REF}"
drun "cd lightning && nix shell nixpkgs#git --command git fetch origin ${GIT_REF} && nix shell nixpkgs#git --command git checkout FETCH_HEAD"

echo "==> Initialising git submodules"
drun "cd lightning && nix shell nixpkgs#git --command git submodule update --init --recursive"

echo "==> Building the flake package: nix build .?submodules=1 (cores=${NIX_CORES})"
# packages.default == cln (nix/pkgs/flake-module.nix). ?submodules=1 is required
# because the build depends on git submodules. Binaries land under ./result/bin.
drun "cd lightning && nix build \".?submodules=1\" --cores ${NIX_CORES} --max-jobs 1 --print-build-logs"

echo "==> Verifying lightningd version"
drun "cd lightning && ./result/bin/lightningd --version"

echo "==> Verifying lightning-cli version"
drun "cd lightning && ./result/bin/lightning-cli --version"

echo "==> Done. NixOS flake build verified (${GIT_REPO} @ ${GIT_REF})."
```