### PR TITLE
doc: modernize Alpine build instructions

### DIFF
--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -619,8 +619,27 @@ A working example that compiles both bitcoind and Core Lightning for Armbian can
 Get dependencies:
 ```shell
 apk update
-apk add --virtual .build-deps ca-certificates alpine-sdk autoconf automake git libtool \
-sqlite-dev python3 py3-mako net-tools zlib-dev libsodium gettext
+apk add --no-cache \
+  alpine-sdk autoconf automake libtool gmp-dev sqlite-dev python3 python3-dev \
+  py3-pip py3-mako net-tools zlib-dev libsodium libsodium-dev gettext gettext-dev \
+  musl-dev gcc git jq curl wget bash ca-certificates protobuf protobuf-dev \
+  postgresql-dev lowdown
+```
+
+Install Rust via rustup (required for Cargo:
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. $HOME/.cargo/env
+```
+
+> 📘
+>
+> The `rust`/`cargo` packages shipped by some Alpine releases can be older than Core Lightning's minimum supported Rust version (1.85.0), so installing the toolchain via rustup is recommended.
+
+Install uv for Python dependency management:
+```shell
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Clone lightning:
@@ -630,23 +649,22 @@ cd lightning
 git submodule update --init --recursive
 ```
 
+Checkout a release tag:
+```shell
+git checkout v26.06.1
+```
+
 Build and install:
 ```shell
+uv sync --all-extras --all-groups --frozen
 ./configure
-make
-make install
+RUST_PROFILE=release uv run make -j$(nproc)
+RUST_PROFILE=release make install
 ```
 
-Clean up:
-```shell
-cd .. && rm -rf lightning
-apk del .build-deps
-```
-
-Install runtime dependencies:
-```shell
-apk add libgcc libsodium sqlite-libs zlib
-```
+> 📘
+>
+> If you want to disable Rust because you don't need it or its plugins (cln-grpc, clnrest, cln-bip353 or wss-proxy), you can use `./configure --disable-rust` and skip the rustup step above.
 
 ## Python plugins
 

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -101,7 +101,7 @@ cd lightning
 
 Checkout a release tag:
 ```shell
-git checkout v25.02
+git checkout v26.09
 ```
 
 For development or running tests, get additional dependencies:
@@ -214,7 +214,7 @@ cd lightning
 
 Checkout a release tag:
 ```shell
-git checkout v24.05
+git checkout v26.09
 ```
 
 Build and install lightning:
@@ -388,7 +388,7 @@ cd lightning
 
 Checkout a release tag:
 ```shell
-git checkout v24.05
+git checkout v26.09
 ```
 
 Build lightning:
@@ -465,7 +465,7 @@ cd lightning
 
 Checkout a release tag:
 ```shell
-git checkout v24.05
+git checkout v26.09
 ```
 
 Build lightning:
@@ -619,14 +619,23 @@ A working example that compiles both bitcoind and Core Lightning for Armbian can
 Get dependencies:
 ```shell
 apk update
-apk add --no-cache \
+```
+
+Install the runtime dependencies (these must stay installed to run `lightningd`):
+```shell
+apk add --no-cache libgcc libsodium sqlite-libs zlib libpq
+```
+
+Install the build dependencies as a virtual package so they can be removed later:
+```shell
+apk add --no-cache --virtual .build-deps \
   alpine-sdk autoconf automake libtool gmp-dev sqlite-dev python3 python3-dev \
-  py3-pip py3-mako net-tools zlib-dev libsodium libsodium-dev gettext gettext-dev \
+  py3-pip py3-mako net-tools zlib-dev libsodium-dev gettext gettext-dev \
   musl-dev gcc git jq curl wget bash ca-certificates protobuf protobuf-dev \
   postgresql-dev lowdown
 ```
 
-Install Rust via rustup (required for Cargo:
+Install Rust via rustup (required for Cargo):
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 . $HOME/.cargo/env
@@ -651,7 +660,7 @@ git submodule update --init --recursive
 
 Checkout a release tag:
 ```shell
-git checkout v26.06.1
+git checkout v26.09
 ```
 
 Build and install:
@@ -665,6 +674,13 @@ RUST_PROFILE=release make install
 > 📘
 >
 > If you want to disable Rust because you don't need it or its plugins (cln-grpc, clnrest, cln-bip353 or wss-proxy), you can use `./configure --disable-rust` and skip the rustup step above.
+
+Clean up (recommended to keep a minimal Alpine image):
+```shell
+cd .. && rm -rf lightning
+apk del .build-deps
+rm -rf "$HOME/.rustup" "$HOME/.cargo" "$HOME/.local/share/uv" "$HOME/.cache/uv"
+```
 
 ## Python plugins
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`


## What changes
The Alpine compile guide still used the old `./configure && make` flow without Rust or `uv`. Update it to match the current build: install `rustup` (packaged rust/cargo can be older than the 1.85.0 MSRV), install `uv` for Python deps, and build with
`RUST_PROFILE=release uv run make`.

Changelog-None