### PR TITLE
Fix crash long logs

### DIFF
--- a/lightningd/log.c
+++ b/lightningd/log.c
@@ -660,11 +660,7 @@ void logv(struct logger *log, enum log_level level,
 	size_t log_len;
 	char *logmsg;
 
-	/* This is WARN_UNUSED_RESULT, because everyone should somehow deal
-	 * with OOM, even though nobody does. */
-	if (vasprintf(&logmsg, fmt, ap) == -1)
-		abort();
-
+	logmsg = tal_vfmt(tmpctx, fmt, ap);
 	log_len = strlen(logmsg);
 
 	/* Sanitize any non-printable characters, and replace with '?' */
@@ -685,7 +681,7 @@ void logv(struct logger *log, enum log_level level,
 			       l.time,
 			       l.prefix->prefix,
 			       logmsg);
-	free(logmsg);
+	tal_free(logmsg);
 
 	errno = save_errno;
 }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5404,3 +5404,19 @@ def test_tracing_socket(node_factory):
         for key in ("id", "name", "timestamp", "duration", "traceId"):
             assert key in span, f"Missing key {key} in span {span}"
         assert span["localEndpoint"] == {"serviceName": "lightningd"}
+
+
+@pytest.mark.xfail(strict=True)
+def test_long_logs(node_factory):
+    """A plugin that creates a very long log entry. Lightningd should truncate
+    the output and not crash."""
+
+    def setup(plugin):
+        @plugin.method("produce-log")
+        def prod_log(plugin):
+            """Produce a silly and very long log message."""
+            plugin.log("X" * 300000)
+            return {}
+
+    l1 = node_factory.get_node(inline_plugin=setup)
+    l1.rpc.call("produce-log")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5406,7 +5406,6 @@ def test_tracing_socket(node_factory):
         assert span["localEndpoint"] == {"serviceName": "lightningd"}
 
 
-@pytest.mark.xfail(strict=True)
 def test_long_logs(node_factory):
     """A plugin that creates a very long log entry. Lightningd should truncate
     the output and not crash."""


### PR DESCRIPTION
~~Depends on #9138, because I am using the nice inline plugin test interface.~~

   lightningd: fix crash after truncating long log messages
    
    We were using vasprintf to generate the log line and then using free to
    deallocate the string. However, in the case of a very long log line
    a new pointer was created with tal_fmt and then tried to use free on it.
    
    This was introduced in commit: 4d8f923a9a1468b8987dbb48e8fc988747f8c62f
    
    ```
    free(): invalid pointer
    lightningd: FATAL SIGNAL 6 (version v26.06-21-gebc5dc2)
    0x563dab20be43 send_backtrace
            common/daemon.c:38
    0x563dab20becd crashdump
            common/daemon.c:83
    0x7f0cf0c96def ???
            ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
    0x7f0cf0ceb95c __pthread_kill_implementation
            ./nptl/pthread_kill.c:44
    0x7f0cf0c96cc1 __GI_raise
            ../sysdeps/posix/raise.c:26
    0x7f0cf0c7f4ab __GI_abort
            ./stdlib/abort.c:77
    0x7f0cf0c80290 __libc_message_impl
            ../sysdeps/posix/libc_fatal.c:134
    0x7f0cf0cf5464 malloc_printerr
            ./malloc/malloc.c:5832
    0x7f0cf0cfa41b _int_free_check
            ./malloc/malloc.c:4560
    0x7f0cf0cfa41b _int_free
            ./malloc/malloc.c:4692
    0x7f0cf0cfa41b __GI___libc_free
            ./malloc/malloc.c:3476
    0x563dab19be60 logv
            lightningd/log.c:688
    0x563dab19c0bc log_
            lightningd/log.c:728
    0x563dab1c1047 plugin_log_handle
            lightningd/plugin.c:530
    0x563dab1c5801 plugin_notification_handle
            lightningd/plugin.c:609
    0x563dab1c5a9a plugin_read_json
            lightningd/plugin.c:753
    0x563dab2388a5 next_plan
            ccan/ccan/io/io.c:60
    0x563dab238c83 do_plan
            ccan/ccan/io/io.c:422
    0x563dab238d3c io_ready
            ccan/ccan/io/io.c:439
    0x563dab239e5b io_loop
            ccan/ccan/io/poll.c:470
    0x563dab194399 io_loop_with_timers
            lightningd/io_loop_with_timers.c:22
    0x563dab199c29 main
            lightningd/lightningd.c:1480
    0x7f0cf0c80ca7 __libc_start_call_main
            ../sysdeps/nptl/libc_start_call_main.h:58
    0x7f0cf0c80d64 __libc_start_main_impl
            ../csu/libc-start.c:360
    0x563dab169020 ???
            _start+0x20:0
    0xffffffffffffffff ???
            ???:0
    ```
