### PR TITLE
CI: change email server port from 587 to 465 for repro errors

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -92,7 +92,7 @@ jobs:
         uses: dawidd6/action-send-mail@v17
         with:
           server_address: smtp.gmail.com
-          server_port: 587
+          server_port: 465
           secure: true
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}


### PR DESCRIPTION
Right now we get:
`Error: 00A9A805B77F0000:error:0A00010B:SSL routines:tls_validate_record_header:wrong version number:../deps/openssl/openssl/ssl/record/methods/tlsany_meth.c:77:`

and the action documentation uses port 465.

Google docs say:
 If your client begins with plain text, before issuing the STARTTLS command, use port 465 (for SSL), or port 587 (for TLS).
 
 Seems like the action can't do both? Lets try it!