### PR TITLE
CI: python generation fix

### DIFF
--- a/contrib/pyln-grpc-proto/pyln/grpc/node_pb2_grpc.py
+++ b/contrib/pyln-grpc-proto/pyln/grpc/node_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from pyln.grpc import node_pb2 as node__pb2
+import node_pb2 as node__pb2
 
 GRPC_GENERATED_VERSION = '1.75.1'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
The generate python code is importing differently causing CI to fail.

Manually updating the import code to how CI expects it.