### PR TITLE
flake: test_no_delay: reduce expected_saving threshold to fix probe variance

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4704,8 +4704,10 @@ def test_no_delay(node_factory):
           f"expected saving {expected_saving:.2f}s")
 
     if expected_saving > 0.5:
-        # Platform shows a meaningful Nagle effect: assert the full saving.
-        assert normal_time < nagle_time - expected_saving
+        # Platform shows a meaningful Nagle effect: assert at least half the saving.
+        # The 10-sample probe can overestimate per-RTT delay by ~2x due to variance,
+        # so apply an extra safety factor here.
+        assert normal_time < nagle_time - expected_saving / 2
     else:
         # Platform Nagle delay is too small to measure reliably (e.g. macOS);
         # just assert that disabling Nagle is not slower.


### PR DESCRIPTION
The 10-sample probe introduced in 91c8c37ce3 can overestimate per-RTT Nagle delay by ~2x relative to the full 100-trip run. The assertion `normal_time < nagle_time - expected_saving` then fails even though Nagle disabling is clearly working (19–36% actual savings observed in failing runs).

Fix: halve the required saving (`expected_saving / 2`). Total discount from raw probe estimate is now 4x (2x for Nagle average, 2x for probe noise), while still catching a real regression where TCP_NODELAY is not set (both runs equal speed → assertion fails).

Failing assertions from CI:
- `assert 21.80726671218872 < (28.225794553756714 - 7.359144687652589)`
- `assert 25.825435400009155 < (31.75627374649048 - 6.155816316604614)`
- `assert 14.281448602676392 < (22.333508729934692 - 9.02500867843628)`

Failing runs: https://github.com/ElementsProject/lightning/actions/runs/27700110804/job/81949024879?pr=9230, https://github.com/ElementsProject/lightning/actions/runs/27700110804/job/81949024933?pr=9230, https://github.com/ElementsProject/lightning/actions/runs/27700416165/job/81957741785?pr=9142

Closes #9234