### PR TITLE
ccan: Update vendored ccan to commit 7c38521d, which includes rustyrussell/ccan#128 and rustyrussell/ccan#130

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,7 +825,7 @@ update-ccan:
 	cp ../ccan/tools/configurator/configurator.c ../ccan/doc/configurator.1 ccan/tools/configurator/
 	$(MAKE) ccan/config.h
 	grep -v '^CCAN version:' ccan.old/README > ccan/README
-	echo CCAN version: `git -C ../ccan describe` >> ccan/README
+	echo CCAN version: `git -C ../ccan rev-parse --short HEAD` >> ccan/README
 	$(RM) -r ccan.old
 	$(RM) -r ccan/ccan/hash/ ccan/ccan/tal/talloc/	# Unnecessary deps
 

--- a/ccan/README
+++ b/ccan/README
@@ -1,3 +1,3 @@
-CCAN imported from http://ccodearchive.net.
+CCAN imported from https://github.com/rustyrussell/ccan.
 
-CCAN version: init-2612-ge242779f
+CCAN version: efd48386

--- a/ccan/ccan/io/poll.c
+++ b/ccan/ccan/io/poll.c
@@ -433,6 +433,7 @@ void *io_loop(struct timers *timers, struct timer **expired)
 
 		fairness_counter++;
 		for (size_t rotation = 0; rotation < num_fds && !io_loop_return; rotation++) {
+			socklen_t errno_len = sizeof(errno);
 			struct io_conn *c;
 			int events;
 
@@ -469,8 +470,18 @@ void *io_loop(struct timers *timers, struct timer **expired)
 				r--;
 				io_ready(c, events);
 			} else if (events & (POLLHUP|POLLNVAL|POLLERR)) {
+				/* On `connect` failure, Linux typically
+				 * returns POLLIN|POLLERR. MacOS returns either
+				 * POLLHUP|POLLERR or POLLOUT|POLLHUP depending
+				 * on version, setting the socket error to
+				 * ECONNREFUSED. */
 				r--;
-				errno = EBADF;
+				/* Get fd's specific error to find Mac's
+				 * ECONNREFUSED, among others */
+				if(getsockopt(fds[i]->fd, SOL_SOCKET, SO_ERROR,
+					      &errno, &errno_len) == -1) {
+					errno = EBADF;
+				}
 				io_close(c);
 			}
 		}


### PR DESCRIPTION
On macOS, failed `connect()` calls return `POLLHUP|POLLERR` or `POLLOUT|POLLHUP`from `poll`, and the socket error is set to `ECONNREFUSED`. Previously ccan's `io_poll` hardcoded `EBADF` in the `POLLHUP` case, causing misleading `Bad file descriptor` errors. The fix reads `SO_ERROR` from the socket to surface the real errno.

Also fixes `update-ccan` Makefile target:
- Use `git rev-parse --short HEAD` instead of `git describe` (ccan has no tags)
- Remove reference to `ccodearchive.net` following https://github.com/rustyrussell/ccan/commit/efd48386d280cd79dff191cd7d5a9462ba9ed564

Closes #9236.

The test-level fix for `test_networkevents` (PR #9140) is still needed but will require a different approach now that the underlying error is correct.

Changelog-None