### PR TITLE
Improve reliability of wait_and_check_bitcoind

### DIFF
--- a/plugins/bcli.c
+++ b/plugins/bcli.c
@@ -780,11 +780,22 @@ static void wait_and_check_bitcoind(struct plugin *p)
 {
 	struct bcli_result *res;
 	const char **cmd;
+	int i;
 
 	/* Special case: -rpcwait flags go on command line, not stdin */
-	cmd = gather_args(bitcoind, NULL, "-rpcwait", "-rpcwaittimeout=30",
+	/* We try 30 times one second rather than one time thirty seconds, because
+	 * we have seen cases bitcoind becomes available, but rpcwait still just hangs
+	 * needlessly.
+	 */
+	cmd = gather_args(bitcoind, NULL, "-rpcwait", "-rpcwaittimeout=1",
 			  "getnetworkinfo", NULL);
-	res = execute_bitcoin_cli(bitcoind, p, cmd, NULL);
+	res = NULL;
+	for (i = 0; i < 30; i++) {
+		tal_free(res);            /* NULL-safe; frees previous attempt */
+		res = execute_bitcoin_cli(bitcoind, p, cmd, NULL);
+		if (res->exitstatus != 1)
+			break;
+	}
 
 	if (res->exitstatus == 1)
 		bitcoind_failure(p,


### PR DESCRIPTION
`bitcoin-cli -rpcwait` works probably as expected if the blocks are loading before core lightning start. But doesn't if BitcoinD isn't listening at all before Core Lightning wait, we observed the following behavior.

* **Timestamp: 0**: Core Lightning Starts and wait RPC
* **Timestamp: 10**: Bitcoind starts
* **Timestamp: 30**: Core Lightning fails (RPC connection timed out)
* **Timestamp: 31**: Core Lightning Container crashes, docker restart it
* **Timestamp: 32**: Core Lightning Starts, AND detect bitcoind started

Rather than waiting for 30 seconds, this PR wait 30 times for 1 seconds. This fix the issue for us.

* **Timestamp: 0**: Core Lightning Starts and wait RPC
* **Timestamp: 10**: Bitcoind starts
* **Timestamp: 11**: Core Lightning detect bitcoind started

This is a patch we are using in BTCPay Server deployments. Not really critical in production scenario, but it was causing our tests to fail as lightningd was taking 30 seconds to properly start.

