### PR TITLE
Fix listsendpay flake

### DIFF
--- a/plugins/xpay/listpays.c
+++ b/plugins/xpay/listpays.c
@@ -159,7 +159,8 @@ static void add_new_entry(struct plugin *plugin,
 
 	if (pm->state & PAYMENT_COMPLETE)
 		json_add_string(ret, "status", "complete");
-	else if (pm->state & PAYMENT_PENDING || attempt_ongoing(plugin, pm->payment_hash))
+	else if (pm->state & PAYMENT_PENDING ||
+		 attempt_ongoing(plugin, pm->payment_hash, pm->sortkey.groupid))
 		json_add_string(ret, "status", "pending");
 	else
 		json_add_string(ret, "status", "failed");

--- a/plugins/xpay/xpay.c
+++ b/plugins/xpay/xpay.c
@@ -2510,13 +2510,15 @@ static struct payment *new_payment(const tal_t *ctx,
 	return payment;
 }
 
-bool attempt_ongoing(struct plugin *plugin, const struct sha256 *payment_hash)
+bool attempt_ongoing(struct plugin *plugin, const struct sha256 *payment_hash,
+		     u64 groupid)
 {
 	struct xpay *xpay = xpay_of(plugin);
 	const struct payment *payment;
 
 	list_for_each(&xpay->payments, payment, list) {
-		if (sha256_eq(&payment->payment_hash, payment_hash))
+		if (sha256_eq(&payment->payment_hash, payment_hash) &&
+		    payment->group_id == groupid)
 			return true;
 	}
 	return false;

--- a/plugins/xpay/xpay.h
+++ b/plugins/xpay/xpay.h
@@ -7,6 +7,7 @@ struct plugin;
 struct sha256;
 
 /* Are we still attempting this payment?  If so, we won't list is as failed. */
-bool attempt_ongoing(struct plugin *plugin, const struct sha256 *payment_hash);
+bool attempt_ongoing(struct plugin *plugin, const struct sha256 *payment_hash,
+		     u64 groupid);
 
 #endif /* LIGHTNING_PLUGINS_XPAY_XPAY_H */

--- a/tests/test_pay.py
+++ b/tests/test_pay.py
@@ -5307,7 +5307,7 @@ def test_sendpay_grouping(node_factory, bitcoind):
     wait_for(lambda: only_one(l3.rpc.listpeers()['peers'])['connected'] is True)
     scid = l3.rpc.listpeerchannels()['channels'][0]['short_channel_id']
     wait_for(lambda: [c['active'] for c in l1.rpc.listchannels(scid)['channels']] == [True, True])
-    l1.rpc.pay(inv, amount_msat='10000msat')
+    l1.rpc.xpay(inv, amount_msat='10000msat')
 
     # And finally we should have all 3 attempts to pay the invoice
     pays = l1.rpc.listpays()['pays']


### PR DESCRIPTION
listsendpays: discriminate ongoing payment by groupid
    
A payment attempt in listpays is defined as pair (payment hash, group id).
If we query xpay if there are any ongoing payments we must discrimitate
using both values.
    
Fixes flaky test tests/test_pay.py:test_sendpay_grouping
```
FAILED tests/test_pay.py::test_sendpay_grouping - AssertionError: assert ['pending', 'pending', 'complete'] == ['failed', 'failed', 'complete']
```

Detected while running CI on #9228.

Fixes #9233 