### PR TITLE
repro: add automake as explicit dependency

### DIFF
--- a/contrib/reprobuild/Dockerfile.jammy
+++ b/contrib/reprobuild/Dockerfile.jammy
@@ -12,23 +12,24 @@ RUN sed -i '/updates/d' /etc/apt/sources.list && \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        autoconf \
-        build-essential \
-        ca-certificates \
-        file \
-        gettext \
-        git \
-        libsqlite3-dev \
-        libpq-dev \
-        libsodium23 \
-        libsodium-dev \
-        libtool \
-        m4 \
-        sudo \
-        unzip \
-        wget \
-        jq \
-        zip \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    file \
+    gettext \
+    git \
+    libsqlite3-dev \
+    libpq-dev \
+    libsodium23 \
+    libsodium-dev \
+    libtool \
+    m4 \
+    sudo \
+    unzip \
+    wget \
+    jq \
+    zip \
     && cd /tmp \
     && wget https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_1_0_2.tar.gz \
     && tar -xzf VERSION_1_0_2.tar.gz \

--- a/contrib/reprobuild/Dockerfile.noble
+++ b/contrib/reprobuild/Dockerfile.noble
@@ -12,26 +12,27 @@ RUN sed -i '/updates/d' /etc/apt/sources.list && \
     sed -i 's/^deb \(.*\) noble main$/deb \1 noble main universe/' /etc/apt/sources.list
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-	autoconf \
-	build-essential \
-	ca-certificates \
-	file \
-	gettext \
-	git \
+    && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    file \
+    gettext \
+    git \
     curl \
     libsqlite3-dev \
-	libpq-dev \
-	libsodium23 \
+    libpq-dev \
+    libsodium23 \
     libsodium-dev \
     lowdown \
-	libtool \
-	m4 \
-	sudo \
-	unzip \
-	wget \
+    libtool \
+    m4 \
+    sudo \
+    unzip \
+    wget \
     jq \
-	zip
+    zip
 
 # Configure /repo/.git as 'safe.directory'
 RUN git config --global --add safe.directory /repo/.git

--- a/contrib/reprobuild/Dockerfile.resolute
+++ b/contrib/reprobuild/Dockerfile.resolute
@@ -14,6 +14,7 @@ RUN sed -i '/updates/d' /etc/apt/sources.list && \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     autoconf \
+    automake \
     build-essential \
     ca-certificates \
     file \


### PR DESCRIPTION
noble builds were failing because of a missing aclocal usual recommendation is to install automake which apparently no longer is in the dependency graph for noble

we add it to all ubuntu images in case it gets removed in jammy/resolute as well

Changelog-None

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
