### PR TITLE
Makefile: suppress msggen and grpc gen if SUPPRESS_GENERATION is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,8 +425,10 @@ ifneq ($V,1)
 MSGGEN_ARGS := -s
 endif
 
+ifneq ($(SUPPRESS_GENERATION),1)
 $(MSGGEN_GENALL)&: contrib/msggen/msggen/schema.json
 	@$(call VERBOSE, "msggen $@", PYTHONPATH=contrib/msggen $(PYTHON) contrib/msggen/msggen/__main__.py $(MSGGEN_ARGS) generate)
+endif
 
 # The compiler assumes that the proto files are in the same
 # directory structure as the generated files will be. Since we
@@ -441,11 +443,13 @@ GRPC_GEN = \
 
 ALL_TEST_GEN += $(GRPC_GEN)
 
+ifneq ($(SUPPRESS_GENERATION),1)
 $(GRPC_GEN) &: cln-grpc/proto/node.proto cln-grpc/proto/primitives.proto
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/node.proto --python_out=$(GRPC_PATH)/ --grpc_python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	$(PYTHON) -m grpc_tools.protoc -I cln-grpc/proto cln-grpc/proto/primitives.proto --python_out=$(GRPC_PATH)/ --experimental_allow_proto3_optional
 	find $(GRPC_DIR)/ -type f -name "*.py" -print0 | xargs -0 $(SED) -i'.bak' -e 's/^import \(.*\)_pb2 as .*__pb2/from pyln.grpc import \1_pb2 as \1__pb2/g'
 	find $(GRPC_DIR)/ -type f -name "*.py.bak" -print0 | xargs -0 rm -f
+endif
 
 # We make pretty much everything depend on these.
 ALL_GEN_HEADERS := $(filter %gen.h,$(ALL_C_HEADERS))


### PR DESCRIPTION
there is a race condition between sed rewriting node_pb2.py and node_pb2_grpc.py and the `git diff`'s from check-source causing the prebuild CI step to fail with:

```
--- a/contrib/pyln-grpc-proto/pyln/grpc/node_pb2_grpc.py
+++ b/contrib/pyln-grpc-proto/pyln/grpc/node_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings

-from pyln.grpc import node_pb2 as node__pb2
+import node_pb2 as node__pb2
```

Changelog-None

