### PR TITLE
build: set PYTHON in nix flake so that the docs build

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -20,8 +20,9 @@ stdenv.mkDerivation {
   makeFlags = [
     "VERSION=${version}"
     "MTIME=${self.lastModifiedDate}"
-    "NO_PYTHON=1"
   ];
+
+  env.PYTHON = "${py3}/bin/python3";
 
   # when building on darwin we need cctools to provide the correct libtool
   # as libwally-core detects the host as darwin and tries to add the -static


### PR DESCRIPTION
I notice the nix flake check was removed in #8743. Without the check in CI the flake will keep breaking.

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
