### PR TITLE
pytests: test_self_disable case added that crashes CLN

### DIFF
--- a/common/configvar.c
+++ b/common/configvar.c
@@ -107,6 +107,11 @@ void configvar_finalize_overrides(struct configvar **cvs)
 	opts = tal_arr(tmpctx, const struct opt_table *, tal_count(cvs));
 	for (size_t i = 0; i < tal_count(cvs); i++) {
 		opts[i] = opt_find_long(cvs[i]->optvar, NULL);
+		/* The plugin which registered this option may have
+		 * disabled itself since: leave the stale configvar alone,
+		 * it can still be reused if that plugin is started again. */
+		if (!opts[i])
+			continue;
 		/* If you're allowed multiple, they don't override...
 		 * unless transient values exist, which override non-transient. */
 		if (opts[i]->type & OPT_MULTI) {

--- a/tests/plugins/selfdisable.py
+++ b/tests/plugins/selfdisable.py
@@ -9,4 +9,5 @@ def init(configuration, options, plugin):
     return {'disable': 'init saying disable'}
 
 
+# plugin.add_option('dummy-option', False, 'does nothing', opt_type='bool')
 plugin.run()

--- a/tests/plugins/selfdisable.py
+++ b/tests/plugins/selfdisable.py
@@ -9,5 +9,5 @@ def init(configuration, options, plugin):
     return {'disable': 'init saying disable'}
 
 
-# plugin.add_option('dummy-option', False, 'does nothing', opt_type='bool')
+plugin.add_option('dummy-option', False, 'does nothing', opt_type='bool')
 plugin.run()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3120,6 +3120,12 @@ def test_self_disable(node_factory):
     with pytest.raises(RpcError, match="Disabled via selfdisable option"):
         l1.rpc.plugin_start(p2, selfdisable=True)
 
+    with pytest.raises(RpcError, match="init saying disable"):
+        l1.rpc.plugin_start(pydisable)
+
+    with pytest.raises(RpcError, match="init saying disable"):
+        l1.rpc.plugin_start(pydisable, **{"dummy-option": True})
+
 
 def test_restart_on_update(node_factory):
     """Tests if plugin rescan restarts modified plugins


### PR DESCRIPTION
This is basically and issue report with a test that replicates the problem.

```
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: FATAL SIGNAL 11 (version v26.06-57-g6889d36-modded)
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: common/daemon.c:46 (send_backtrace) 0x55cca29bb0b9
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: common/daemon.c:83 (crashdump) 0x55cca29bb0f6
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0 ((null)) 0x7f642cb26def
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: common/configvar.c:112 (configvar_finalize_overrides) 0x55cca29baa1d
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:1607 (plugin_add_params) 0x55cca295ea4f
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:1806 (plugin_parse_getmanifest_response) 0x55cca2960435
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:1822 (plugin_manifest_cb) 0x55cca296155b
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:693 (plugin_response_handle) 0x55cca295cfd8
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/plugin.c:782 (plugin_read_json) 0x55cca29620c3
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:60 (next_plan) 0x55cca29f8201
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:422 (do_plan) 0x55cca29f868c
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ccan/ccan/io/io.c:439 (io_ready) 0x55cca29f8745
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ccan/ccan/io/poll.c:470 (io_loop) 0x55cca29fa0db
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/io_loop_with_timers.c:22 (io_loop_with_timers) 0x55cca2930979
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: lightningd/lightningd.c:1480 (main) 0x55cca2936209
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ../sysdeps/nptl/libc_start_call_main.h:58 (__libc_start_call_main) 0x7f642cb10ca7
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: ../csu/libc-start.c:360 (__libc_start_main_impl) 0x7f642cb10d64
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0x55cca2905120
lightningd-1 2026-06-23T15:23:52.744Z **BROKEN** lightningd: backtrace: (null):0 ((null)) 0xffffffffffffffff
```

Seems like a stale option is causing it, in this case `selfdisable` from `test_libplugin`

I noticed this during reckless development that when i start the node with a plugin that has options set and disables itself at init and i then start another plugin the node crashes with above stacktrace. This test is here to reproduce it easily.

Looking for someone to fix this, until a fix is added i will keep it in draft.