### PR TITLE
tests: fix flaky bwatch 1-block reorg test

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5463,9 +5463,13 @@ def test_bwatch_reorg_1_block(node_factory, bitcoind):
 
     # Mine a few blocks to establish history
     bitcoind.generate_block(5)
+    expected_height = bitcoind.rpc.getblockcount()
     # Wait for bwatch to fully catch up (important: bwatch must have the block
     # that will be reorged, otherwise it can't detect the reorg)
-    l1.daemon.wait_for_log(r'No block change')
+    l1.daemon.wait_for_log(rf'Added block {expected_height} to history', timeout=60)
+    wait_for(lambda: any(e['key'][-1] == f"{expected_height:010d}"
+                         for e in l1.rpc.listdatastore(['bwatch', 'block_history'])['datastore']),
+             timeout=60)
 
     # Get the actual number of blocks bwatch has stored before reorg
     ds_before = l1.rpc.listdatastore(['bwatch', 'block_history'])


### PR DESCRIPTION
Fixes #9253

The test mined a block and then reorged it, but it did not wait until bwatch had actually seen that block first.

Sometimes bwatch was still one block behind. In that case, the replacement block looked like a normal new block, not a reorg, so the test waited forever for "Reorg detected".

Wait until bwatch has stored the block before reorging it.

Changelog-None