### PR TITLE
lsps-plugin: fail HTLC with TEMPORARY_CHANNEL_FAILURE on JIT channel errors

### DIFF
--- a/plugins/lsps-plugin/src/service.rs
+++ b/plugins/lsps-plugin/src/service.rs
@@ -7,15 +7,16 @@ use cln_lsps::{
     },
     core::{
         lsps2::{
-            htlc::{Htlc, HtlcAcceptedHookHandler, HtlcDecision, Onion, RejectReason},
+            htlc::{Htlc, HtlcAcceptedHookHandler, HtlcDecision, HtlcError, Onion, RejectReason},
             service::Lsps2ServiceHandler,
         },
         server::LspsService,
     },
     proto::lsps0::{LSPS0_MESSAGE_TYPE, Msat},
+    proto::lsps2::failure_codes::TEMPORARY_CHANNEL_FAILURE,
 };
 use cln_plugin::{HookBuilder, HookFilter, Plugin, options};
-use log::{debug, error, trace};
+use log::{debug, error, trace, warn};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -190,14 +191,29 @@ async fn handle_htlc_inner(
             log_decision(&dec);
             decision_to_response(dec)?
         }
-        Err(e) => {
-            // Fixme: Should we log **BROKEN** here?
-            debug!("Htlc handler failed (continuing): {:#}", e);
-            return Ok(json_continue());
-        }
+        Err(e) => return Ok(handle_htlc_error(e)),
     };
 
     Ok(serde_json::to_value(&response)?)
+}
+
+fn handle_htlc_error(e: HtlcError) -> serde_json::Value {
+    match e {
+        HtlcError::FundChannel(ref cause) => {
+            warn!(
+                "LSPS2: Failed to open JIT channel (likely insufficient on-chain balance): {:#}. \
+                 Operator action required.",
+                cause
+            );
+        }
+        HtlcError::ChannelReadyCheck(ref cause) => {
+            warn!("LSPS2: Channel ready check failed: {:#}", cause);
+        }
+        HtlcError::CapacityQuery(ref cause) => {
+            error!("LSPS2: Capacity query failed: {:#}", cause);
+        }
+    }
+    json_fail(TEMPORARY_CHANNEL_FAILURE)
 }
 
 fn decision_to_response(decision: HtlcDecision) -> Result<serde_json::Value, anyhow::Error> {


### PR DESCRIPTION
**Problem**

In `service.rs`, `handle_htlc_safe` caught all errors from `handle_htlc_inner` and responded with `"result": "continue"` while only logging at `debug!` level. This silently swallowed failures during JIT channel opening - most critically, `fundchannel` failures caused by insufficient on-chain balance. The paying node received no failure signal and the operator had no actionable log output

**Fix**

Replace the catch-all `continue` with a typed dispatch on `HtlcError`:

-  `HtlcError::FundChannel` -> `warn!` (operator action required) + `TEMPORARY_CHANNEL_FAILURE`
-  `HtlcError::ChannelReadyCheck` -> ` warn!` + `TEMPORARY_CHANNEL_FAILURE`
-  ` HtlcError::CapacityQuery` -> `error!` + `TEMPORARY_CHANNEL_FAILURE`
The outer `handle_htlc_safe` still catches truly unexpected errors (deserialization and stuff like that) and continues, which is the correct behaviour for unknown failures

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
