### PR TITLE
tests: fix flaky test_simple_close_dust_output_omitted mempool race

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4301,11 +4301,22 @@ def test_simple_close_dust_output_omitted(node_factory, bitcoind):
     # Every closing tx in the mempool must have exactly 1 output: the dust
     # output is omitted in all variants.  Elements appends an explicit fee
     # output (scriptPubKey type 'fee') which must not be counted here.
-    for txid in bitcoind.rpc.getrawmempool():
-        tx = bitcoind.rpc.getrawtransaction(txid, True)
-        real_vouts = [v for v in tx['vout'] if v['scriptPubKey'].get('type') != 'fee']
-        assert len(real_vouts) == 1, \
-            f"tx {txid} has {len(tx['vout'])} outputs; expected 1 (dust omitted)"
+    # Both sides broadcast conflicting closer txs, and l1's higher-fee tx
+    # can RBF-replace l2's between our getrawmempool() snapshot and the
+    # getrawtransaction() call (bitcoind error -5), so retry with a fresh
+    # snapshot until we see a consistent one.
+    def closing_txs_have_single_output():
+        try:
+            for txid in bitcoind.rpc.getrawmempool():
+                tx = bitcoind.rpc.getrawtransaction(txid, True)
+                real_vouts = [v for v in tx['vout'] if v['scriptPubKey'].get('type') != 'fee']
+                assert len(real_vouts) == 1, \
+                    f"tx {txid} has {len(tx['vout'])} outputs; expected 1 (dust omitted)"
+        except bitcoin.rpc.InvalidAddressOrKeyError:
+            return False
+        return True
+
+    wait_for(closing_txs_have_single_output)
 
 
 def test_simple_close_restart(node_factory, bitcoind):


### PR DESCRIPTION
Observed on a CI run for #9286 (postgres full integration, 1 failed / 1012 passed):
https://github.com/ElementsProject/lightning/actions/runs/28971841260

The test snapshots getrawmempool() and then fetches each txid with
getrawtransaction().  Both peers broadcast conflicting closer txs; in
the dust scenario l2's tx pays only 400sat fee (its whole balance)
while l1's pays 3375sat, so l1's tx RBF-replaces l2's.  When the
replacement lands between the snapshot and the fetch,
getrawtransaction() fails with error -5 (No such mempool or blockchain
transaction).  The captured node logs show l2's tx replaced 14ms after
broadcast.

The fix retries the snapshot-and-check loop when a txid vanishes
mid-iteration; the single-output assertion still fails hard.  Same
class of race as the test_simple_close_delay_broadcast fix in
5ae0705f2.

Changelog-None