### PR TITLE
tests: fix broken race handler in test_funding_external_wallet_corners

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1378,7 +1378,7 @@ def test_funding_external_wallet_corners(node_factory, bitcoind):
     try:
         l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
     except RpcError as err:
-        assert "disconnected during connection" in err.error
+        assert "disconnected during connection" in err.error['message']
 
     l1.daemon.wait_for_log('Responded to reestablish for long-closed channel')
     wait_for(lambda: len(l1.rpc.listpeers()['peers']) == 0)


### PR DESCRIPTION
Observed on a CI run for #9299 (First Integration Tests 2/6):
https://github.com/ElementsProject/lightning/actions/runs/29044319311

The test anticipates the "disconnected during connection" reconnect
race (there is a FIXME comment about it) and wraps the connect in
try/except, added in d09d0112f.  But the handler asserts the substring
against err.error, which is the whole error dict -- `in` on a dict
tests its keys -- so the assert fails exactly when the race it is
meant to tolerate occurs:

    E  assert 'disconnected during connection' in {'code': 402,
       'message': 'disconnected during connection'}

The handler has never worked since it was introduced in 2023; the fix
matches against err.error['message'] instead, the same form the
equivalent handlers in test_plugin.py and test_misc.py already use.