### PR TITLE
tests: fix flaky test_sql blockheight race

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4360,6 +4360,11 @@ def test_sql(node_factory, bitcoind):
     # Make sure we have a node_announcement for l1
     wait_for(lambda: l2.rpc.listnodes(l1.info['id'])['nodes'] != [])
 
+    # Under valgrind, the senders can still be digesting the blocks
+    # above and pick a stale blockheight for the payments below, which
+    # the caught-up peers reject as expiry_too_soon.
+    sync_blockheight(bitcoind, [l1, l2, l3])
+
     # This should create a forward through l2
     l1.rpc.xpay(l3.rpc.invoice(amount_msat=12300, label='inv1', description='description')['bolt11'])
 


### PR DESCRIPTION
Observed on CI runs for #9299 and #9300 (Valgrind Test CLN 12/12):
https://github.com/ElementsProject/lightning/actions/runs/29053072126
https://github.com/ElementsProject/lightning/actions/runs/29053114743

The test mines ~106 blocks immediately before making three payments,
without waiting for the nodes to process them.  Under valgrind the
paying node can lag far behind bitcoind, so it builds onions whose
cltv expiries the caught-up peers reject.  The two runs showed both
shapes of the race:

- l1 ~40 blocks behind (l2/l3 at 210): l2 failed the forward ("Expiry
  cltv 181 too close to current 210", expiry_too_soon).  The error
  came from the invoice's route-hint channel, so xpay disabled it and
  the payment failed hard with error 209.

- l1 a few blocks behind: l3 failed the final hop ("Expiry cltv too
  soon 211 < 210 + 5").  xpay's waitblockheight retry succeeded, but
  the failed first attempt left status 'failed' in the forwards row
  the test asserts is 'settled'.

The test paid with pay until 7f6a33394 switched it to xpay; pay took
its start height from bitcoind's headercount and tracked the node's
chainlag, so lagging nodes still built onions valid at the true chain
tip, which is why this only started flaking recently.

The fix syncs the nodes' blockheights before paying, as other tests
do after mining bursts.

Changelog-None