### PR TITLE
lightningd: update graceful notifications when HTLC states change

### DIFF
--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2275,6 +2275,9 @@ void peer_sending_commitsig(struct channel *channel, const u8 *msg)
 	/* Tell it we've got it, and to go ahead with commitment_signed. */
 	subd_send_msg(channel->owner,
 		      take(towire_channeld_sending_commitsig_reply(msg)));
+
+	/* Maybe graceful wants to know? */
+	check_graceful_shutdown(ld);
 }
 
 static bool channel_added_their_htlc(struct channel *channel,
@@ -2542,6 +2545,9 @@ void peer_got_commitsig(struct channel *channel, const u8 *msg)
 	/* Tell it we've committed, and to go ahead with revoke. */
 	msg = towire_channeld_got_commitsig_reply(msg);
 	subd_send_msg(channel->owner, take(msg));
+
+	/* Maybe graceful wants to know? */
+	check_graceful_shutdown(ld);
 }
 
 /* Shuffle them over, forgetting the ancient one. */
@@ -2722,6 +2728,9 @@ void peer_got_revoke(struct channel *channel, const u8 *msg)
 					     : fromwire_peektype(failmsgs[i]));
 	}
 	wallet_channel_save(ld->wallet, channel);
+
+	/* Maybe graceful wants to know? */
+	check_graceful_shutdown(ld);
 
 	if (penalty_tx == NULL)
 		return;

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4410,20 +4410,17 @@ def test_graceful_htlc(node_factory, executor):
 
     fut = executor.submit(run_graceful)
 
-    inotif = 0
+    # If graceful catches the commitment dance mid-flight, it notifies
+    # about each transient state (e.g. RCVD_ADD_REVOCATION) on the way,
+    # so match expected notifications as an ordered subsequence.
+    seen = [0]
 
-    # Wait until graceful has sent at least one HTLC expiry notification
-    wait_for(lambda: len(notifications) >= inotif + 1)
+    def wait_notif(expected):
+        wait_for(lambda: expected in notifications[seen[0]:])
+        seen[0] = notifications.index(expected, seen[0]) + 1
 
-    # Depending on on timing between the sendpay and `l2.rpc.graceful`, we may get
-    # RCVD_ADD_REVOCATION or we may be too late to get that.
-    if notifications[inotif] == f'Next HTLC RCVD_ADD_REVOCATION expires at block #118 (10 blocks from now) going to peer {l3.info["id"]} (connected)':
-        # If we get RCVD_ADD_REVOCATION, ignore it and move onto the next notification
-        inotif += 1
-        wait_for(lambda: len(notifications) >= inotif + 1)
-
-    wait_for(lambda: notifications[inotif] == f'Next HTLC SENT_ADD_ACK_REVOCATION expires at block #118 (10 blocks from now) going to peer {l3.info["id"]} (connected)')
-    inotif += 1
+    # Once the HTLC is fully committed, we get told.
+    wait_notif(f'Next HTLC SENT_ADD_ACK_REVOCATION expires at block #118 (10 blocks from now) going to peer {l3.info["id"]} (connected)')
 
     # This will tell us about htlcs and the peers (peers unordered)
     ret = l2.rpc.graceful(1)
@@ -4434,16 +4431,12 @@ def test_graceful_htlc(node_factory, executor):
 
     # Close incoming connection, so incoming HTLC gets stuck.
     l1.rpc.disconnect(l2.info['id'], force=True)
-    wait_for(lambda: len(notifications) >= inotif + 1)
-    wait_for(lambda: notifications[inotif] == f'Next HTLC SENT_ADD_ACK_REVOCATION expires at block #118 (10 blocks from now) going to peer {l3.info["id"]} (connected)')
-    inotif += 1
 
-    # Release the hold so the *outgoing* HTLC resolves
+    # Release the hold so the *outgoing* HTLC resolves: the incoming HTLC
+    # can't (peer is disconnected), and becomes the next expiry to report.
     open(os.path.join(l3.daemon.lightning_dir, TEST_NETWORK, "unhold"), "w").close()
 
-    wait_for(lambda: len(notifications) >= inotif + 1)
-    wait_for(lambda: notifications[inotif] == f'Next HTLC SENT_REMOVE_HTLC expires at block #124 (16 blocks from now) coming from peer {l1.info["id"]} (disconnected)')
-    inotif += 1
+    wait_notif(f'Next HTLC SENT_REMOVE_HTLC expires at block #124 (16 blocks from now) coming from peer {l1.info["id"]} (disconnected)')
 
     ret = l2.rpc.graceful(1)
     assert ret == {'pending_htlc_expiries': [124]}


### PR DESCRIPTION
Fixes the test_graceful_htlc CI flake (#9219), observed again on a run
for #9286 (Valgrind Test CLN 11/12):
https://github.com/ElementsProject/lightning/actions/runs/29122024616/job/86461830316

graceful only re-evaluated its "Next HTLC ..." notification on HTLC
removal, peer disconnect, or another graceful invocation -- never on
HTLC state transitions.  When graceful catches a commitment dance in
flight (likely under valgrind), the initial notification names a
transient state (e.g. RCVD_ADD_REVOCATION) and no follow-up ever
announces the settled state.  The flake handler added in 6994681ae
waits for exactly that follow-up, so the test times out.  In the CI
failure above, graceful caught the outgoing HTLC in
RCVD_ADD_REVOCATION, the dance completed 600ms later, and no
notification followed for the remaining 180 seconds.

The fix re-checks graceful progress in the three handlers that advance
HTLC states (peer_sending_commitsig, peer_got_commitsig,
peer_got_revoke).  The check is a no-op unless a graceful command is
outstanding, and identical messages are already deduplicated.

Since the dance now generates transient-state notifications, the test
is rewritten to match expected notifications as an ordered subsequence
instead of by exact index.  That also removes two accidents the old
indexing depended on; see the commit message for details.

Fixes: https://github.com/ElementsProject/lightning/issues/9219