### PR TITLE
tests: fix flaky reckless tests by waiting for the canned github server

### DIFF
--- a/tests/test_reckless.py
+++ b/tests/test_reckless.py
@@ -2,7 +2,7 @@ from fixtures import *  # noqa: F401,F403
 import subprocess
 from pathlib import PosixPath, Path
 import socket
-from pyln.testing.utils import VALGRIND
+from pyln.testing.utils import TIMEOUT, VALGRIND
 import pytest
 import os
 import re
@@ -85,6 +85,21 @@ def canned_github_server(directory):
     del my_env['GIT_INDEX_FILE']
     # We also need the github api data for the repo which will be served via http
     shutil.copyfile(str(FILE_PATH / 'data/recklessrepo/rkls_api_lightningd_plugins.json'), os.path.join(directory, 'rkls_api_lightningd_plugins.json'))
+
+    # Flask can be slow to start listening under CI load; make sure the
+    # first reckless invocation doesn't race it and get connection refused.
+    start = time.time()
+    while True:
+        assert server.poll() is None, "canned github server died"
+        try:
+            with socket.create_connection(('127.0.0.1', int(free_port)),
+                                          timeout=5):
+                break
+        except OSError:
+            if time.time() >= start + TIMEOUT:
+                server.terminate()
+                raise RuntimeError("canned github server never started listening")
+            time.sleep(0.2)
     yield
     # Delete requirements.txt from the testplugpass directory
     with open(requirements_file_path, 'w') as f:


### PR DESCRIPTION
Observed on a CI run for #9286 (Valgrind Test CLN 1/12, test_search):
https://github.com/ElementsProject/lightning/actions/runs/29122024616/job/86461830290

The canned_github_server fixture starts a Flask server with Popen and
never waits for it to listen; the git repository setup between the
Popen and the yield usually gives it enough time.  Under CI load it
can lose that race: in the failure above, test_search's first
reckless invocation got connection refused within a second of the
test starting, and Flask's "Running on http://127.0.0.1:39495"
banner only appears in the log after the test had already failed
(so the server did come up and bind its port -- just too late).

The fix waits for the port to accept connections before yielding, and
fails loudly if the server process dies instead of coming up.

Changelog-None