### PR TITLE
CODEOWNERS: remove @devrandom

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ contrib/msggen/             @cdecker
 contrib/pyln-client/        @cdecker
 contrib/pyln-testing/       @cdecker
 # Needed to ensure hsmd wire compatibility between releases
-hsmd/hsmd_wire.csv          @cdecker @ksedgwic @devrandom
+hsmd/hsmd_wire.csv          @cdecker @ksedgwic
 plugins/xpay/               @Lagrang3
 plugins/askrene/            @Lagrang3
 plugins/renepay/            @Lagrang3


### PR DESCRIPTION
without write access CODEOWNER does not work

Changelog-None

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
