### PR TITLE
Fix: SIGINT was ignored by the cln docker container

### DIFF
--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -6,6 +6,8 @@ networkdatadir="${LIGHTNINGD_DATA}/${LIGHTNINGD_NETWORK}"
 
 set -m
 lightningd --network="${LIGHTNINGD_NETWORK}" "$@" &
+LIGHTNINGD_PID=$!
+trap 'kill -TERM "$LIGHTNINGD_PID" 2>/dev/null' TERM INT
 
 echo "Core-Lightning starting"
 while read -r i; do if [ "$i" = "lightning-rpc" ]; then break; fi; done \
@@ -24,4 +26,7 @@ if [ -d "$LIGHTNINGD_DATA"/lightning-poststart.d ]; then
     done
 fi
 
-fg %-
+wait "$LIGHTNINGD_PID"
+trap - TERM INT
+wait "$LIGHTNINGD_PID"
+exit $?


### PR DESCRIPTION
Changelog-Fixed: Fix: SIGINT was ignored by the cln docker container

This was reported by one of our user.

I could replicate with 
```bash
docker kill --signal=SIGINT <container>
```

I confirm that now both, with and without `--signal=SIGINT` works properly.

> The file to fix is tools/docker-entrypoint.sh (the Dockerfile copies it to /entrypoint.sh at lines 245 and 278 for the two image stages — the Dockerfile itself is fine).
> 
> The bug lives in three lines of that script:
> 
> - Lines 64–65: set -m + lightningd "$@" & — lightningd is started as a background job in its own process group, so it will never see signals sent to PID 1.
> - Line 122 (last line): fg %- — bash re-foregrounds lightningd and blocks there as PID 1 with no trap. A PID 1 with no handler installed never receives SIGTERM at all, so docker stop does nothing until the grace-period expires and the container is SIGKILLed — exit 137 on every shutdown, and lightningd never closes its database cleanly.
> 
> The fix — replace line 122's fg %- with:
> 
> trap 'kill -TERM "$LIGHTNINGD_PID" 2>/dev/null' TERM INT
> wait "$LIGHTNINGD_PID"
> trap - TERM INT
> wait "$LIGHTNINGD_PID"
> exit $?
> 
> Why this shape and not just adding a trap above fg: bash defers trap execution while a foreground job is running, so a trap combined with fg would only fire after lightningd already exited. wait, by contrast, is interrupted by trapped signals — the first wait returns when SIGTERM arrives and the trap forwards it to lightningd, the second wait collects lightningd's actual exit status.