### PR TITLE
reject a channel that reuses an existing funding outpoint

### DIFF
--- a/connectd/multiplex.c
+++ b/connectd/multiplex.c
@@ -1729,7 +1729,16 @@ void peer_connect_subd(struct daemon *daemon, const u8 *msg, int fd)
 						       fmt_node_id(tmpctx, &id)));
 	}
 
-	assert(!subd->conn);
+	/* We only keep one connection per channel_id.  If one is already
+	 * attached for this channel_id, drop this fd rather than replacing
+	 * it. */
+	if (subd->conn) {
+		status_peer_debug(&id,
+				  "Already have a subd for channel_id %s: ignoring",
+				  fmt_channel_id(tmpctx, &channel_id));
+		close(fd);
+		return;
+	}
 
 	/* This sets subd->conn inside subd_conn_init, and reparents subd! */
 	io_new_conn(peer, fd, subd_conn_init, subd);

--- a/lightningd/channel.c
+++ b/lightningd/channel.c
@@ -879,6 +879,18 @@ struct channel *find_channel_by_id(const struct peer *peer,
 	return NULL;
 }
 
+struct channel *find_channel_by_funding_outpoint(const struct peer *peer,
+						 const struct bitcoin_outpoint *outpoint)
+{
+	struct channel *c;
+
+	list_for_each(&peer->channels, c, list) {
+		if (bitcoin_outpoint_eq(&c->funding, outpoint))
+			return c;
+	}
+	return NULL;
+}
+
 struct channel *find_channel_by_scid(const struct peer *peer,
 				     struct short_channel_id scid)
 {

--- a/lightningd/channel.h
+++ b/lightningd/channel.h
@@ -918,6 +918,11 @@ struct channel *channel_by_cid(struct lightningd *ld,
 struct channel *find_channel_by_id(const struct peer *peer,
 				   const struct channel_id *cid);
 
+/* Find a channel with this funding outpoint within peer (an outpoint
+ * funds at most one channel). */
+struct channel *find_channel_by_funding_outpoint(const struct peer *peer,
+						 const struct bitcoin_outpoint *outpoint);
+
 /* Find this channel within peer */
 struct channel *find_channel_by_scid(const struct peer *peer,
 				     struct short_channel_id scid);

--- a/lightningd/opening_control.c
+++ b/lightningd/opening_control.c
@@ -533,6 +533,15 @@ static void opening_fundee_finished(struct subd *openingd,
 
 	derive_channel_id(&cid, &funding);
 
+	/* A funding outpoint funds at most one channel; don't accept a second
+	 * channel reusing one we already have.  Drop the connection so the
+	 * peer's open fails cleanly instead of waiting for funding_signed. */
+	if (find_channel_by_funding_outpoint(uc->peer, &funding)) {
+		force_peer_disconnect(ld, uc->peer,
+				      "Funding outpoint already in use");
+		return;
+	}
+
 	/* old_remote_per_commit not valid yet, copy valid one. */
 	channel_info.old_remote_per_commit = channel_info.remote_per_commit;
 


### PR DESCRIPTION
Confirmed working. We do a disconnect in this case.

Changelog-None
