### PR TITLE
Renepay too far

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -24597,7 +24597,7 @@
                 "updated_index": 113,
                 "short_channel_id": "116x1x1",
                 "id": 11,
-                "expiry": 281,
+                "expiry": 143,
                 "direction": "out",
                 "amount_msat": 400000,
                 "payment_hash": "3fe5289854b8924b4ebb3f61cd8f5a29f8f509cc781919230f7ee95ec2fa7c46",

--- a/doc/schemas/listhtlcs.json
+++ b/doc/schemas/listhtlcs.json
@@ -314,7 +314,7 @@
             "updated_index": 113,
             "short_channel_id": "116x1x1",
             "id": 11,
-            "expiry": 281,
+            "expiry": 143,
             "direction": "out",
             "amount_msat": 400000,
             "payment_hash": "3fe5289854b8924b4ebb3f61cd8f5a29f8f509cc781919230f7ee95ec2fa7c46",

--- a/plugins/renepay/routetracker.c
+++ b/plugins/renepay/routetracker.c
@@ -449,8 +449,7 @@ struct command_result *route_sendpay_request(struct command *cmd,
 		json_add_amount_msat(req->js, "amount_msat", hop->amount);
 		json_add_node_id(req->js, "id", &hop->node_id);
 		json_add_short_channel_id(req->js, "channel", hop->scid);
-		json_add_num(req->js, "delay",
-			     hop->delay + payment->blockheight);
+		json_add_num(req->js, "delay", hop->delay);
 		json_object_end(req->js);
 
 		// FIXME: No localinvreqid is provided

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -876,7 +876,6 @@ def test_unannounced(node_factory):
     assert ret["status"] == "complete"
 
 
-@pytest.mark.xfail(strict=True)
 def test_cltv_value(node_factory, bitcoind):
     cltv_delta = 5
     l1, l2, l3 = node_factory.line_graph(

--- a/tests/test_renepay.py
+++ b/tests/test_renepay.py
@@ -874,3 +874,31 @@ def test_unannounced(node_factory):
     b12 = l1.rpc.fetchinvoice(offer, "21sat")["invoice"]
     ret = l1.rpc.call("renepay", {"invstring": b12})
     assert ret["status"] == "complete"
+
+
+@pytest.mark.xfail(strict=True)
+def test_cltv_value(node_factory, bitcoind):
+    cltv_delta = 5
+    l1, l2, l3 = node_factory.line_graph(
+        3,
+        wait_for_announce=True,
+        opts={
+            "allow-deprecated-apis": True,
+            "cltv-delta": cltv_delta,
+            "fee-base": 0,
+            "fee-per-satoshi": 0,
+        },
+    )
+    blockheight = l1.rpc.waitblockheight(0)["blockheight"]
+    # BOLT-11 direct peer
+    b11 = l3.rpc.invoice(
+        "100sat", "test_renepay_expiry_too_far", "test_renepay_expiry_too_far"
+    )["bolt11"]
+    decoded_b11 = l1.rpc.decode(b11)
+    final_cltv = decoded_b11["min_final_cltv_expiry"]
+    ret = l1.rpc.call("renepay", {"invstring": b11})
+    assert ret["status"] == "complete"
+    pattern = r"Adding HTLC 0 amount=100000msat cltv=(\d+)"
+    line = l1.daemon.wait_for_log(pattern)
+    cltv = int(re.search(pattern, line).group(1))
+    assert cltv == (blockheight + 1) + cltv_delta + final_cltv


### PR DESCRIPTION
Renepay's HTLCs are a million blocks into the future.
```
Adding HTLC 28712 amount=101010msat cltv=1917224 gave CHANNEL_ERR_ADD_OK
```
Since v26.04 (580c2f78540449b3d5c13e4518391471fb1a197d)

This is the offending line:
https://github.com/ElementsProject/lightning/blob/8405796b8ef0167d5c3fd28049eff97be8efeb55/plugins/renepay/routetracker.c#L453

We discovered this on Greenlight when upgrading to v26.06. The LSP stopped forwarding onions
generated with renepay with the error `expiry_too_far`.