### PR TITLE
CI: set readme branch name to stable

### DIFF
--- a/.github/workflows/rdme-docs-sync.yml
+++ b/.github/workflows/rdme-docs-sync.yml
@@ -18,24 +18,24 @@ jobs:
       - name: Sync doc/getting-started/ 🚀
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./doc/getting-started --key=${{ secrets.README_API_KEY }} --branch=1
+          rdme: docs upload ./doc/getting-started --key=${{ secrets.README_API_KEY }} --branch=stable
             
       - name: Sync doc/beginners-guide/ 🚀
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./doc/beginners-guide --key=${{ secrets.README_API_KEY }} --branch=1
+          rdme: docs upload ./doc/beginners-guide --key=${{ secrets.README_API_KEY }} --branch=stable
       
       - name: Sync doc/node-operators-guide/ 🚀
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./doc/node-operators-guide --key=${{ secrets.README_API_KEY }} --branch=1
+          rdme: docs upload ./doc/node-operators-guide --key=${{ secrets.README_API_KEY }} --branch=stable
       
       - name: Sync doc/developers-guide/ 🚀
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./doc/developers-guide --key=${{ secrets.README_API_KEY }} --branch=1
+          rdme: docs upload ./doc/developers-guide --key=${{ secrets.README_API_KEY }} --branch=stable
       
       - name: Sync doc/contributing-to-core-lightning/ 🚀
         uses: readmeio/rdme@v10
         with:
-          rdme: docs upload ./doc/contribute-to-core-lightning --key=${{ secrets.README_API_KEY }} --branch=1
+          rdme: docs upload ./doc/contribute-to-core-lightning --key=${{ secrets.README_API_KEY }} --branch=stable


### PR DESCRIPTION
The CI action for readme syncs is failing since about July 1st. 

I used the CLI tool to investigate and found that it thought the page would not exist and fail to create it, since it is missing the `category` yaml attribute.

The reason it thinks it is missing and needs to be created is that it no longer matches the branch `1` to `1-stable`. So instead we use the same branch here as in the readme rpc sync workflow: `stable`. With that the cli tool finds the page again and wants to update it which should work.