### PR TITLE
openingd: fail channel gracefully when funding\_satoshis exceeds maximum Bitcoin supply

### DIFF
--- a/openingd/openingd.c
+++ b/openingd/openingd.c
@@ -248,6 +248,13 @@ static bool setup_channel_funder(struct state *state)
 		return false;
 	}
 
+	if (amount_sat_greater(state->funding_sats, chainparams->max_supply)) {
+		status_failed(STATUS_FAIL_MASTER_IO,
+			      "funding_satoshis %s exceeds maximum Bitcoin supply",
+			      fmt_amount_sat(tmpctx, state->funding_sats));
+		return false;
+	}
+
 	return true;
 }
 
@@ -936,6 +943,19 @@ static u8 *fundee_channel(struct state *state, const u8 *open_channel_msg)
 		negotiation_failed(state,
 				   "funding_satoshis %s too large",
 				   fmt_amount_sat(tmpctx, state->funding_sats));
+		return NULL;
+	}
+
+	/* BOLT #2:
+	 *
+	 * The receiving node MUST fail the channel if:
+	 *...
+	 * - `funding_satoshis` is greater than the maximum Bitcoin supply.
+	 */
+	if (amount_sat_greater(state->funding_sats, chainparams->max_supply)) {
+		peer_failed_err(state->pps, &state->channel_id,
+				"funding_satoshis %s exceeds maximum Bitcoin supply",
+				fmt_amount_sat(tmpctx, state->funding_sats));
 		return NULL;
 	}
 


### PR DESCRIPTION
Fixes #9225

## Problem
A peer can crash \openingd\ by sending \open_channel\ with \unding_satoshis\ greater than \WALLY_SATOSHI_MAX\ (21M BTC). The invalid amount flows through to libwally which asserts and aborts the subdaemon.

Three crash variants were found during fuzzing:
1. \unding_satoshis > WALLY_SATOSHI_MAX\ alone → assert in \psbt_input_set_wit_utxo\
2. \unding_satoshis\ and \push_msat\ both exceeding the supply → assert in \itcoin_tx_add_output\
3. Individual outputs under the cap but total exceeding → assert in \wally_tx_add_output\

## Fix
Add a bounds check in both the \initiator\ and \undee\ paths. If \unding_satoshis > chainparams->max_supply\, fail the channel with a proper error message instead of crashing.

The single check on \unding_satoshis\ covers all three variants since the commitment tx outputs are derived from \unding_satoshis\.

Changelog-Fixed: openingd no longer crashes when a peer sends open_channel with funding_satoshis above the maximum Bitcoin supply.