### PR TITLE
MacOS make check-source fixes

### DIFF
--- a/tests/plugins/compacter-slow.sh
+++ b/tests/plugins/compacter-slow.sh
@@ -2,7 +2,7 @@
 # This pretends to be lightning_gossip_compactd, but waits until the file "compactd-continue"
 # exists.  This lets us test race conditions.
 
-if [ x"$1" != x"--version" ]; then
+if [ "$1" != "--version" ]; then
     while [ ! -f "compactd-continue" ]; do
 	sleep 1
     done


### PR DESCRIPTION
Drop obsolete `x"$1"` idiom in `compacter-slow.sh` (ShellCheck SC2268).

CI does not hit these, so the failures show up mainly for local macOS contributors.
Changelog-None
