### PR TITLE
ci: bind docker/pypi workflow inputs via env before shell

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,8 +23,10 @@ jobs:
       platforms: ${{ steps.plan.outputs.platforms }}
     steps:
       - id: plan
+        env:
+          PLATFORMS_TO_BUILD: ${{ inputs.platforms-to-build }}
         run: |
-          IFS=',' read -ra ARR <<< "${{ inputs.platforms-to-build }}"
+          IFS=',' read -ra ARR <<< "$PLATFORMS_TO_BUILD"
           JSON=$(printf '%s\n' "${ARR[@]}" | jq -R . | jq -sc .)
           echo "platforms=$JSON" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,25 +43,34 @@ jobs:
         merge-multiple: false
 
     - name: Set up values
+      env:
+        DH_REPOSITORY_OWNER: ${{ inputs.dh-repository-owner }}
+        PUSH_LATEST: ${{ inputs.push-latest }}
+        VERSION: ${{ inputs.version }}
+        REF_TYPE: ${{ github.ref_type }}
       run: |
         DIGEST_REFS=""
         for f in /tmp/digests/*/digest.txt; do
           D=$(cat "$f")
-          DIGEST_REFS="$DIGEST_REFS ${{ inputs.dh-repository-owner }}/lightningd@${D}"
+          DIGEST_REFS="$DIGEST_REFS ${DH_REPOSITORY_OWNER}/lightningd@${D}"
         done
         echo "DIGEST_REFS=$DIGEST_REFS" >> $GITHUB_ENV
 
-        if [[ "${{ inputs.push-latest }}" == "true" ]] ||
-          ([[ "${{ github.ref_type }}" == "tag" ]] && [[ ! "${{ inputs.version }}" =~ rc ]]); then
+        if [[ "$PUSH_LATEST" == "true" ]] ||
+          ([[ "$REF_TYPE" == "tag" ]] && [[ ! "$VERSION" =~ rc ]]); then
           echo "PUSHLATEST=true" >> $GITHUB_ENV
         else
           echo "PUSHLATEST=false" >> $GITHUB_ENV
         fi
 
     - name: Create and push real tag(s)
+      env:
+        DH_REPOSITORY_OWNER: ${{ inputs.dh-repository-owner }}
+        VERSION: ${{ inputs.version }}
+        TAG_SUFFIX: ${{ matrix.tag_suffix }}
       run: |
-        TAG_ARGS=(-t "${{ inputs.dh-repository-owner }}/lightningd:${{ inputs.version }}${{ matrix.tag_suffix }}")
+        TAG_ARGS=(-t "${DH_REPOSITORY_OWNER}/lightningd:${VERSION}${TAG_SUFFIX}")
         if [[ "$PUSHLATEST" == "true" ]]; then
-          TAG_ARGS+=(-t "${{ inputs.dh-repository-owner }}/lightningd:latest${{ matrix.tag_suffix }}")
+          TAG_ARGS+=(-t "${DH_REPOSITORY_OWNER}/lightningd:latest${TAG_SUFFIX}")
         fi
         docker buildx imagetools create "${TAG_ARGS[@]}" $DIGEST_REFS

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -31,17 +31,20 @@ jobs:
     - name: Determine PyPI distribution location
       id: set-values
       env:
-          DIST_LOCATION: ${{ inputs.dist-location }}
-        run: |
+        DIST_LOCATION: ${{ inputs.dist-location }}
+        REF_TYPE: ${{ github.ref_type }}
+        VERSION: ${{ inputs.version }}
+        EVENT_DIST_LOCATION: ${{ github.event.inputs.dist-location }}
+      run: |
         if [[ -n "$DIST_LOCATION" ]]; then
           DISTLOCATION="$DIST_LOCATION"
-        elif [[ "${{ github.ref_type }}" == "tag" ]] && [[ ! "${{ inputs.version }}" =~ rc ]]; then
+        elif [[ "$REF_TYPE" == "tag" ]] && [[ ! "$VERSION" =~ rc ]]; then
           DISTLOCATION="prod"
         else
           DISTLOCATION="test"
         fi
         echo "DISTLOCATION=$DISTLOCATION" >> "$GITHUB_OUTPUT"
-        echo "EVENT DISTLOCATION: ${{ github.event.inputs.dist-location }}"
+        echo "EVENT DISTLOCATION: $EVENT_DIST_LOCATION"
         echo "Resolved dist-location: $DISTLOCATION"
 
     - name: Install uv

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,9 +30,11 @@ jobs:
 
     - name: Determine PyPI distribution location
       id: set-values
-      run: |
-        if [[ "${{ inputs.dist-location }}" != "" ]]; then
-          DISTLOCATION="${{ inputs.dist-location }}"
+      env:
+          DIST_LOCATION: ${{ inputs.dist-location }}
+        run: |
+        if [[ -n "$DIST_LOCATION" ]]; then
+          DISTLOCATION="$DIST_LOCATION"
         elif [[ "${{ github.ref_type }}" == "tag" ]] && [[ ! "${{ inputs.version }}" =~ rc ]]; then
           DISTLOCATION="prod"
         else


### PR DESCRIPTION
## Summary
- Bind `inputs.platforms-to-build` through `env:` before the docker-build matrix plan shell step.
- Bind `dh-repository-owner` / `version` / `push-latest` through `env:` before docker-publish tag construction.
- Bind `inputs.dist-location` through `env:` before the pypi-publish shell step.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Docker build matrix still parses comma-separated platforms
- [ ] Publish still creates version/latest tags for trusted inputs
- [ ] PyPI publish still honors optional dist-location

Changelog-None

Made with [Cursor](https://cursor.com)