### PR TITLE
CI: add `concurrency` restrictions for macos and msrv workflows

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -2,6 +2,9 @@
 name: Mac OS pytest
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   smoke-test:
     name: Smoke Test macOS

--- a/.github/workflows/rust-msrv.yml
+++ b/.github/workflows/rust-msrv.yml
@@ -5,6 +5,9 @@ on:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   msrv-test:
     name: Rust MSRV verification test


### PR DESCRIPTION
Quickly force pushing would leave multiple instances of this running

Changelog-None

