### PR TITLE
setconfig: fix crash when a configvar outlives its plugin option

### DIFF
--- a/common/configvar.c
+++ b/common/configvar.c
@@ -107,6 +107,11 @@ void configvar_finalize_overrides(struct configvar **cvs)
 	opts = tal_arr(tmpctx, const struct opt_table *, tal_count(cvs));
 	for (size_t i = 0; i < tal_count(cvs); i++) {
 		opts[i] = opt_find_long(cvs[i]->optvar, NULL);
+		/* A stopped plugin unregisters its options, but
+		 * configvars it didn't own (e.g. from a config file or
+		 * setconfig) remain: they don't override anything. */
+		if (!opts[i])
+			continue;
 		/* If you're allowed multiple, they don't override...
 		 * unless transient values exist, which override non-transient. */
 		if (opts[i]->type & OPT_MULTI) {

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4862,6 +4862,25 @@ def test_setconfig_dynamic_multi_option(node_factory, bitcoind):
     assert l1.rpc.call('dynamic-multi-report')['test-multi-dynamic'] == ['persist1', 'persist2']
 
 
+def test_setconfig_after_plugin_drops_option(node_factory, bitcoind):
+    """A stopped plugin unregisters its options, but a configvar from an
+    earlier setconfig remains: the next setconfig (of any option) must
+    not crash on it."""
+    pluginpath = os.path.join(os.getcwd(), 'tests/plugins/dynamic_option.py')
+    l1 = node_factory.get_node()
+
+    l1.rpc.plugin_start(pluginpath)
+    l1.rpc.setconfig(config='test-dynamic-config', val='soothing')
+
+    # The upgraded plugin no longer has this option (here: it's simply
+    # stopped), but the configvar naming it is still in memory.
+    l1.rpc.plugin_stop(pluginpath)
+
+    # This used to crash lightningd with SIGSEGV.
+    l1.rpc.setconfig(config='min-capacity-sat', val=100000)
+    assert l1.rpc.listconfigs('min-capacity-sat')['configs']['min-capacity-sat']['value_int'] == 100000
+
+
 @unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "deletes database, which is assumed sqlite3")
 @pytest.mark.parametrize("old_hsmsecret", [False, True])
 def test_recover_command(node_factory, bitcoind, old_hsmsecret):


### PR DESCRIPTION
A configvar from a config file or an earlier setconfig outlives its
option when a plugin stops: destroy_plugin_opt() only removes
plugin start configvars.  The next setconfig of any option then
NULL-derefs in configvar_finalize_overrides().  Seen in the field
after a routine dynamic plugin upgrade that dropped an option.

NULL-guard the lookup and add a pytest reproducing the crash
(lightningd SIGSEGVs on the test without the fix).

Fixes #9385 