### PR TITLE
askrene: clean up post-impression follow-ups

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -137,7 +137,7 @@ void clean_tmpctx(void)
 
 void tal_arr_remove_(void *p, size_t elemsize, size_t n)
 {
-    // p is a pointer-to-pointer for tal_resize.
+    /* p is a pointer-to-pointer for tal_resize. */
     char *objp = *(char **)p;
     size_t len = tal_bytelen(objp);
     assert(len % elemsize == 0);
@@ -149,7 +149,7 @@ void tal_arr_remove_(void *p, size_t elemsize, size_t n)
 
 void tal_arr_remove_range_(void *p, size_t position, size_t chunk_size)
 {
-	// p is a pointer-to-pointer for tal_resize.
+	/* p is a pointer-to-pointer for tal_resize. */
 	char *objp = *(char **)p;
 	size_t len = tal_bytelen(objp);
 	assert(chunk_size + position <= len);

--- a/common/utils.h
+++ b/common/utils.h
@@ -87,7 +87,7 @@ bool tal_arr_eq_(const void *a, const void *b, size_t unused);
 void tal_arr_remove_(void *p, size_t elemsize, size_t n);
 
 /**
- * Remove a range of element from an array
+ * Remove a range of elements from an array
  *
  * This will shift the elements past the removed elements, changing
  * their position in memory, so only use this for simple arrays.

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -241,7 +241,7 @@
           "num_removed": {
             "type": "u64",
             "description": [
-              "The number of constraints removed from *layer*"
+              "The number of constraints and impressions removed from *layer*"
             ]
           }
         }
@@ -928,7 +928,7 @@
                       "timestamp": {
                         "type": "u64",
                         "description": [
-                          "The UNIX timestamp when this constraint was created."
+                          "The UNIX timestamp when this impression was created."
                         ]
                       },
                       "amount_msat": {
@@ -1267,7 +1267,7 @@
                 "timestamp": {
                   "type": "u64",
                   "description": [
-                    "The UNIX timestamp when this constraint was created."
+                    "The UNIX timestamp when this impression was created."
                   ]
                 },
                 "amount_msat": {
@@ -1542,7 +1542,7 @@
                       "timestamp": {
                         "type": "u64",
                         "description": [
-                          "The UNIX timestamp when this constraint was created."
+                          "The UNIX timestamp when this impression was created."
                         ]
                       },
                       "amount_msat": {

--- a/doc/schemas/askrene-age.json
+++ b/doc/schemas/askrene-age.json
@@ -44,7 +44,7 @@
       "num_removed": {
         "type": "u64",
         "description": [
-          "The number of constraints removed from *layer*"
+          "The number of constraints and impressions removed from *layer*"
         ]
       }
     }

--- a/doc/schemas/askrene-create-layer.json
+++ b/doc/schemas/askrene-create-layer.json
@@ -218,7 +218,7 @@
                   "timestamp": {
                     "type": "u64",
                     "description": [
-                      "The UNIX timestamp when this constraint was created."
+                      "The UNIX timestamp when this impression was created."
                     ]
                   },
                   "amount_msat": {

--- a/doc/schemas/askrene-inform-channel.json
+++ b/doc/schemas/askrene-inform-channel.json
@@ -127,7 +127,7 @@
             "timestamp": {
               "type": "u64",
               "description": [
-                "The UNIX timestamp when this constraint was created."
+                "The UNIX timestamp when this impression was created."
               ]
             },
             "amount_msat": {

--- a/doc/schemas/askrene-listlayers.json
+++ b/doc/schemas/askrene-listlayers.json
@@ -220,7 +220,7 @@
                   "timestamp": {
                     "type": "u64",
                     "description": [
-                      "The UNIX timestamp when this constraint was created."
+                      "The UNIX timestamp when this impression was created."
                     ]
                   },
                   "amount_msat": {

--- a/lightningd/offer.c
+++ b/lightningd/offer.c
@@ -377,7 +377,6 @@ static struct command_result *json_createinvoicerequest(struct command *cmd,
 	struct tlv_invoice_request *invreq;
 	struct json_escape *label;
 	struct json_stream *response;
-	u64 *prev_basetime = NULL;
 	struct sha256 merkle;
 	bool *save, *single_use;
 	enum offer_status status;
@@ -448,8 +447,6 @@ static struct command_result *json_createinvoicerequest(struct command *cmd,
 			     b12str,
 			     label,
 			     status);
-	if (prev_basetime)
-		json_add_u64(response, "previous_basetime", *prev_basetime);
 	return command_success(cmd, response);
 }
 

--- a/plugins/askrene/datastore_wire.c
+++ b/plugins/askrene/datastore_wire.c
@@ -216,8 +216,7 @@ void towire_dstore_channel_constraint(u8 **data,
 	towire_opt_amount_msat(data, max);
 }
 
-bool fromwire_dstore_channel_impression(const tal_t *ctx,
-					const u8 **cursor, size_t *len,
+bool fromwire_dstore_channel_impression(const u8 **cursor, size_t *len,
 					struct short_channel_id_dir *scidd,
 					u64 *timestamp,
 					struct amount_msat *amount)

--- a/plugins/askrene/datastore_wire.h
+++ b/plugins/askrene/datastore_wire.h
@@ -61,8 +61,7 @@ void towire_dstore_channel_constraint(u8 **data,
 				      const struct amount_msat *min,
 				      const struct amount_msat *max);
 
-bool fromwire_dstore_channel_impression(const tal_t *ctx,
-					const u8 **cursor, size_t *len,
+bool fromwire_dstore_channel_impression(const u8 **cursor, size_t *len,
 					struct short_channel_id_dir *scidd,
 					u64 *timestamp,
 					struct amount_msat *amount);

--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -1139,9 +1139,9 @@ void layer_apply_constraints(const struct layer *layer,
 			} else {
 				/* We made the other way?  Capacity has increased */
 				if (!amount_msat_add(min, *min, imp->amount))
-					*min = AMOUNT_MSAT(-1ULL);
+					*min = AMOUNT_MSAT(UINT64_MAX);
 				if (!amount_msat_add(max, *max, imp->amount))
-					*max = AMOUNT_MSAT(-1ULL);
+					*max = AMOUNT_MSAT(UINT64_MAX);
 			}
 		}
 	}
@@ -1212,7 +1212,7 @@ size_t layer_trim_constraints(struct layer *layer, u64 cutoff)
 		/* We assume the array is sorted by timestamp */
 		for (size_t i = 0; i < tal_count(intelarr); i++) {
 			if (channel_intel_timestamp(&intelarr[i]) >= cutoff)
-				continue;
+				break;
 
 			count_old++;
 			/* The pointer inside channel_intel has to be freed. */
@@ -1220,7 +1220,7 @@ size_t layer_trim_constraints(struct layer *layer, u64 cutoff)
 			tal_steal(tmpctx, intelarr[i].constraint);
 		}
 		num_removed += count_old;
-		if(count_old){
+		if (count_old) {
 			/* Remove from table before realloc!
 			 * Removing elements from the table is safe during
 			 * iteration. */

--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -669,7 +669,7 @@ static void load_channel_impression(struct plugin *plugin,
 	struct amount_msat amount;
 	u64 timestamp;
 
-	if (fromwire_dstore_channel_impression(tmpctx, cursor, len,
+	if (fromwire_dstore_channel_impression(cursor, len,
 						     &scidd, &timestamp,
 						     &amount))
 		add_impression(layer, &scidd, timestamp, amount);

--- a/plugins/libplugin.c
+++ b/plugins/libplugin.c
@@ -344,9 +344,10 @@ static const char *json_id(const tal_t *ctx, struct plugin *plugin,
 			   const char *method, const char *prefix)
 {
 	/* Don't create weird IDs, they will get escaped and we won't match the reply. */
-	if (json_escape_needed(method, strlen(method)) ||
-	    json_escape_needed(prefix, strlen(prefix)))
+	if (json_escape_needed(method, strlen(method)))
 		method = "!weird!";
+	if (json_escape_needed(prefix, strlen(prefix)))
+		prefix = "!weird!";
 	return tal_fmt(ctx, "%s/%s:%s#%"PRIu64,
 		       prefix, plugin->id, method, plugin->next_outreq_id++);
 }

--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -791,8 +791,18 @@ static struct command_result *handle_amount_and_recurrence(struct command *cmd,
 
 	/* Don't allow invoices past expiry of offer. */
 	if (ir->invreq->offer_absolute_expiry) {
-		u64 until = *ir->invreq->offer_absolute_expiry
-			- *ir->inv->invoice_created_at;
+		u64 until;
+
+		/* listoffers_done checked *ir->invreq->offer_absolute_expiry > now,
+		 * then invreq_for_invreq set *ir->inv->invoice_created_at = now.
+		 * Time could change between those, so set a minimum */
+		if (*ir->invreq->offer_absolute_expiry
+		    > *ir->inv->invoice_created_at)
+			until = *ir->invreq->offer_absolute_expiry
+				- *ir->inv->invoice_created_at;
+		else
+			/* Not 0: we use that for cancelled invoices! */
+			until = 1;
 		if (until < rel_expiry)
 			rel_expiry = until;
 	}

--- a/tools/lightning-downgrade.c
+++ b/tools/lightning-downgrade.c
@@ -127,7 +127,7 @@ static const char *convert_layer_data(const tal_t *ctx,
 			continue;
 
 		case DSTORE_CHANNEL_IMPRESSION:
-			if (fromwire_dstore_channel_impression(tmpctx, &data_in, &len,
+			if (fromwire_dstore_channel_impression(&data_in, &len,
 							       &scidd, &timestamp, &msat)) {
 				/* We don't convert, just omit these */
 				if (!convert_impression)


### PR DESCRIPTION
## Summary

- remove dead askrene downgrade and offer state, including the unused impression decode context
- make timestamp trimming stop at the first retained entry and clarify impression-related schema text
- sanitize unsafe plugin ID prefixes and clamp expired-offer invoice expiry to one second
- clean up the related amount sentinel, utility comments, and range documentation

## Validation

- compiled every changed C translation unit with the repository's configured GCC flags and `-Werror`
- `uv run make check-source BASE_REF=origin/master BOLTDIR=../bolts CARGO=false CC=devtools/cc-nobuild SUPPRESS_GENERATION=1`
- verified all four changed JSON schemas are in canonical `jq` format
- `git diff --check origin/master...HEAD`

The full linked build and integration suite are deferred to CI.

## Checklist

- [x] Changelog reviewed (`Changelog-None`; these are cleanups for unreleased v26.09 changes)
- [x] Tests reviewed (no new behavior surface; changed C paths compile with `-Werror` and source checks pass)
- [x] Documentation reviewed and updated
- [x] Related issue linked below
- [x] Downgrade behavior considered; impression records remain omitted for both supported downgrade paths

Changelog-None

Fixes #9378
