### PR TITLE
ci: bind version/ref inputs via env before shell in release workflows

### DIFF
--- a/.github/workflows/check-release-tag.yml
+++ b/.github/workflows/check-release-tag.yml
@@ -28,10 +28,14 @@ jobs:
 
       - name: Validate tag matches .version file
         id: resolve
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.ref_type }}" != "tag" ]]; then
-            echo "::notice::Not triggered by a tag push (ref_type=${{ github.ref_type }}); skipping .version check."
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          if [[ "$REF_TYPE" != "tag" ]]; then
+            echo "::notice::Not triggered by a tag push (ref_type=$REF_TYPE); skipping .version check."
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -41,7 +45,7 @@ jobs:
           fi
 
           FILE_VERSION="$(tr -d '[:space:]' < .version)"
-          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="$REF_NAME"
 
           if [[ "$TAG_VERSION" != "$FILE_VERSION" ]]; then
             echo "::error::Tag '$TAG_VERSION' does not match version in .version file ('$FILE_VERSION'). Refusing to release."
@@ -53,4 +57,6 @@ jobs:
 
       - name: Validate release
         if: ${{ !inputs.skip_validation }}
-        run: tools/check-release.sh --version=${{ steps.resolve.outputs.version }}
+        env:
+          RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
+        run: tools/check-release.sh "--version=$RESOLVED_VERSION"

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -34,8 +34,10 @@ jobs:
       uses: astral-sh/setup-uv@v8.1.0
 
     - name: Update pyln versions
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
-        make update-pyln-versions NEW_VERSION=${{ inputs.version }}
+        make update-pyln-versions NEW_VERSION="$INPUT_VERSION"
 
     - name: Build distribution 📦
       run: uv build --package ${{ matrix.PACKAGE }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -40,9 +40,12 @@ jobs:
         if: contains(matrix.target, 'Ubuntu')
 
       - name: Build release
+        env:
+          SKIP_VALIDATION: ${{ inputs.skip_validation }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [[ "${{ inputs.skip_validation }}" == "true" ]]; then
-            tools/build-release.sh ${{ matrix.target }} --force-version "${{ inputs.version }}" --force-unclean --force-mtime "$(date +%Y-%m-%d)"
+          if [[ "$SKIP_VALIDATION" == "true" ]]; then
+            tools/build-release.sh ${{ matrix.target }} --force-version "$INPUT_VERSION" --force-unclean --force-mtime "$(date +%Y-%m-%d)"
           else
             tools/build-release.sh ${{ matrix.target }}
           fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -49,9 +49,10 @@ jobs:
 
       - name: Determine release data
         id: release_data
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          CHANGELOG_VERSION=${VERSION#v}
-          VERSION="${{ inputs.version }}"
+          VERSION="$INPUT_VERSION"
           CHANGELOG_VERSION=${VERSION#v}
           CHANGELOG_TITLE=$(grep "## \[${CHANGELOG_VERSION}\]" CHANGELOG.md)
           RELEASE_TITLE=$(echo $CHANGELOG_TITLE | cut -d'"' -f2)

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,7 +35,9 @@ jobs:
           trust_level: 5
 
       - name: Set default GPG key
-        run: echo "default-key ${{ steps.gpg.outputs.keyid }}" >> ~/.gnupg/gpg.conf
+        env:
+          GPG_KEYID: ${{ steps.gpg.outputs.keyid }}
+        run: echo "default-key $GPG_KEYID" >> ~/.gnupg/gpg.conf
 
       - name: Sign release
         run: tools/build-release.sh --without-zip sign


### PR DESCRIPTION
## Summary

Follow-up to #9383 (thanks @Andezion for the enumeration). The four workflows feeding the release pipeline still interpolated `inputs.version` / `github.ref_name` directly into `run:` blocks:

- `check-release-tag.yml`: `echo "version=${{ inputs.version }}"`, `TAG_VERSION="${{ github.ref_name }}"`, `check-release.sh --version=${{ steps...version }}`
- `release-build.yml`: `[[ "${{ inputs.skip_validation }}" == "true" ]]`, `--force-version "${{ inputs.version }}"`
- `release-publish.yml`: `VERSION="${{ inputs.version }}"`
- `pypi-build.yml`: `make update-pyln-versions NEW_VERSION=${{ inputs.version }}`

Same class as #9383: GitHub's documented script-injection guidance is to bind workflow inputs through `env:` before shell use. All four now do.

Also dropped a dead duplicate `CHANGELOG_VERSION=${VERSION#v}` line in `release-publish.yml` that executed before `VERSION` was set.

Left untouched deliberately: `if:` / `name:` / `with:` / `tag_name:` interpolations (expression contexts, not shell) and `${{ matrix.* }}` values (hardcoded in the workflow).

## Test plan

- [x] All four files parse as valid YAML
- [x] Behavior identical for well-formed versions/tags (same values reach the scripts, quoted)

Made with [Cursor](https://cursor.com)