### PR TITLE
Pytest: test to reproduce issue #9389

### DIFF
--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -4787,3 +4787,47 @@ def test_onchain_close_no_p2tr(node_factory, bitcoind):
 
     # We should see the output.
     assert len(l1.rpc.listfunds()['outputs']) == 2
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', "Uses regtest addresses")
+def test_closing_anysegwit_lost_unilateral(node_factory, executor):
+    """Test close channel when peer stopps supporting option_shutdown_anysegwit.
+    `close` now refuses both ways, so there is no way to reach the unilateral
+    fallback."""
+    l1, l2 = node_factory.line_graph(2, opts=[{'may_reconnect': True,
+                                               'allow_warning': True},
+                                              {'may_reconnect': True,
+                                               'allow_warning': True}])
+
+    # l2 supports anysegwit, so our shutdown script is P2TR.
+    assert only_one(l1.rpc.listpeerchannels()['channels'])['close_to_addr'].startswith('bcrt1p')
+
+    # Peer vanishes, and we start (but cannot finish) a cooperative close.
+    # unilateraltimeout=0 means "wait forever", so this stays pending.
+    l2.stop()
+    fut = executor.submit(l1.rpc.close, l2.info['id'], 0)
+    wait_for(lambda: only_one(l1.rpc.listpeerchannels()['channels'])['state'] == 'CHANNELD_SHUTTING_DOWN')
+
+    # Now l2 comes back, but without option_shutdown_anysegwit.
+    l2.daemon.opts['dev-force-features'] = "-27"
+    l2.start()
+    l1.rpc.connect(l2.info['id'], 'localhost', l2.port)
+
+    # l1 has now learnt that the peer no longer offers it (bit 27).
+    def anysegwit_dropped():
+        feats = only_one(l1.rpc.listpeers(l2.info['id'])['peers'])['features']
+        return not (int(feats, 16) >> 27) & 1
+    wait_for(anysegwit_dropped)
+
+    # We can't swap in a compatible script: it's already committed.
+    newaddr = l1.rpc.newaddr('bech32')['bech32']
+    with pytest.raises(RpcError, match=r'does not match already-sent shutdown script'):
+        l1.rpc.close(l2.info['id'], 1, destination=newaddr)
+
+    # And we can't reuse the committed one either, so `unilateraltimeout`
+    # never gets armed: the channel is stuck.  This is the bug.
+    with pytest.raises(RpcError, match=r'Peer does not allow v1\+ shutdown addresses'):
+        l1.rpc.close(l2.info['id'], 1)
+
+    assert only_one(l1.rpc.listpeerchannels()['channels'])['state'] == 'CHANNELD_SHUTTING_DOWN'
+    assert not fut.done()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [x] Tests have been added or modified to reflect the changes.
- [x] Documentation has been reviewed and updated as needed.
- [x] Related issues have been listed and linked, including any that this PR closes.
- [x] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Changelog-None

Reproduce #9389

## What this does

Adds `test_closing_anysegwit_lost_unilateral` to `tests/test_closing.py`, which reproduces the reported deadlock: a channel stuck in `CHANNELD_SHUTTING_DOWN` that cannot be closed cooperatively *or* unilaterally.

The test drives the exact sequence:

1. `l1` and `l2` open a channel while both offer `option_shutdown_anysegwit`, so `l1` records a P2TR `shutdown_scriptpubkey[LOCAL]`.
2. `l2` goes away; `l1` issues `close` with `unilateraltimeout=0`, which commits that script and moves the channel to `CHANNELD_SHUTTING_DOWN`.
3. `l2` comes back with `dev-force-features=-27`, i.e. without `option_shutdown_anysegwit`.
4. `l1` can no longer close the channel by any means.

Both RPC paths from the issue fail, and the channel stays stuck:

```
close <id> 1                       -> "Peer does not allow v1+ shutdown addresses"
close <id> 1 <bc1q...>       -> "... does not match already-sent shutdown script ..."
```
