### PR TITLE
make: skip extract-bolt-csv if bolts are absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -674,7 +674,8 @@ update-doc-examples-newchain:
 check-doc-examples: update-doc-examples
 	git diff --exit-code HEAD -- doc
 
-check-wire-format: extract-bolt-csv
+check-wire-format: bolt-precheck
+	@if [ -d .tmp.lightningrfc ]; then $(MAKE) extract-bolt-csv; else echo "Not checking BOLTs: BOLTDIR $(BOLTDIR) does not exist" >&2; fi
 	git diff --exit-code HEAD -- wire
 
 # SECURITY.md and doc/contribute-to-core-lightning/security-policy.md must be


### PR DESCRIPTION
`check-source` -> `check-wire-format` unconditionally ran
`extract-bolt-csv`, which failed when `../bolts` was not checked out:

```
/bin/sh: 1: .tmp.lightningrfc/tools/extract-formats.py: not found
make: *** [wire/Makefile:54: wire/peer_wire.csv.raw] Error 127
```

Skip it via `bolt-precheck` when `.tmp.lightningrfc` is missing,
matching the `bolt-check` pattern.