### PR TITLE
Fix for #8902

### DIFF
--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -552,6 +552,32 @@ static void handle_failure_fatal(struct state *state, u8 *msg)
 	open_err_fatal(state, "%s", err);
 }
 
+static bool check_accepter_error(struct state *state,
+                                 u8 *msg,
+                                 char *err_reason)
+{
+	if (!msg) {
+		if (err_reason)
+			negotiation_failed(state, "%s", err_reason);
+                else
+                        /* FIXME: what do we do here?? */
+		return false;
+	}
+
+        /* `msg` could be a failure message */
+	if (fromwire_peektype(msg) == WIRE_DUALOPEND_FAIL) {
+                handle_failure_fatal(state, msg);
+		return false;
+	}
+
+	if (fromwire_peektype(msg) != WIRE_DUALOPEND_SEND_TX_SIGS) {
+		master_badmsg(WIRE_DUALOPEND_SEND_TX_SIGS, msg);
+                return false;
+        }
+
+        return true;
+}
+
 static void check_channel_id(struct state *state,
 			     struct channel_id *id_in,
 			     struct channel_id *orig_id)
@@ -2305,9 +2331,6 @@ static u8 *accepter_commits(struct state *state,
 	wire_sync_write(REQ_FD, take(msg));
 	msg = wire_sync_read(tmpctx, REQ_FD);
 
-	if (fromwire_peektype(msg) != WIRE_DUALOPEND_SEND_TX_SIGS)
-		master_badmsg(WIRE_DUALOPEND_SEND_TX_SIGS, msg);
-
 	return msg;
 }
 
@@ -2751,11 +2774,8 @@ static void accepter_start(struct state *state, const u8 *oc2_msg)
 	}
 
 	msg = accepter_commits(state, tx_state, total, &err_reason);
-	if (!msg) {
-		if (err_reason)
-			negotiation_failed(state, "%s", err_reason);
-		return;
-	}
+        if (!check_accepter_error(state, msg, err_reason))
+                return;
 
 	/* Finally, send our funding tx sigs */
 	handle_send_tx_sigs(state, msg);
@@ -3462,19 +3482,25 @@ static void rbf_wrap_up(struct state *state,
 	else
 		msg = opener_commits(state, tx_state, total, &err_reason);
 
-	if (!msg) {
-		if (err_reason)
-			open_abort(state, "%s", err_reason);
-		else
-			open_abort(state, "%s", "Unable to commit");
-		/* We need to 'reset' the channel to what it
-		 * was before we did this. */
-		return;
-	}
+        /* in TX_ACCEPTER case, `msg` could be a failure message */
+	if (msg && (fromwire_peektype(msg) == WIRE_DUALOPEND_FAIL)) {
+                if (fromwire_dualopend_fail(msg, msg, &err_reason))
+                        msg = tal_free(msg);
+        }
 
-	if (state->our_role == TX_ACCEPTER)
+        if (!msg) {
+                if (err_reason)
+                        open_abort(state, "%s", err_reason);
+                else
+                        open_abort(state, "%s", "Unable to commit");
+                /* We need to 'reset' the channel to what it
+                 * was before we did this. */
+                return;
+        }
+
+	if (state->our_role == TX_ACCEPTER) {
 		handle_send_tx_sigs(state, msg);
-	else
+	} else
 		wire_sync_write(REQ_FD, take(msg));
 }
 

--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -553,29 +553,27 @@ static void handle_failure_fatal(struct state *state, u8 *msg)
 }
 
 static bool check_accepter_error(struct state *state,
-                                 u8 *msg,
-                                 char *err_reason)
+				 u8 *msg,
+				 char *err_reason)
 {
 	if (!msg) {
 		if (err_reason)
 			negotiation_failed(state, "%s", err_reason);
-                else
-                        /* FIXME: what do we do here?? */
 		return false;
 	}
 
-        /* `msg` could be a failure message */
+	/* `msg` could be a failure message */
 	if (fromwire_peektype(msg) == WIRE_DUALOPEND_FAIL) {
-                handle_failure_fatal(state, msg);
+		handle_failure_fatal(state, msg);
 		return false;
 	}
 
 	if (fromwire_peektype(msg) != WIRE_DUALOPEND_SEND_TX_SIGS) {
 		master_badmsg(WIRE_DUALOPEND_SEND_TX_SIGS, msg);
-                return false;
-        }
+		return false;
+	}
 
-        return true;
+	return true;
 }
 
 static void check_channel_id(struct state *state,
@@ -3482,21 +3480,21 @@ static void rbf_wrap_up(struct state *state,
 	else
 		msg = opener_commits(state, tx_state, total, &err_reason);
 
-        /* in TX_ACCEPTER case, `msg` could be a failure message */
+	/* in TX_ACCEPTER case, `msg` could be a failure message */
 	if (msg && (fromwire_peektype(msg) == WIRE_DUALOPEND_FAIL)) {
-                if (fromwire_dualopend_fail(msg, msg, &err_reason))
-                        msg = tal_free(msg);
-        }
+		if (fromwire_dualopend_fail(msg, msg, &err_reason))
+			msg = tal_free(msg);
+	}
 
-        if (!msg) {
-                if (err_reason)
-                        open_abort(state, "%s", err_reason);
-                else
-                        open_abort(state, "%s", "Unable to commit");
-                /* We need to 'reset' the channel to what it
-                 * was before we did this. */
-                return;
-        }
+	if (!msg) {
+		if (err_reason)
+			open_abort(state, "%s", err_reason);
+		else
+			open_abort(state, "%s", "Unable to commit");
+		/* We need to 'reset' the channel to what it
+		 * was before we did this. */
+		return;
+	}
 
 	if (state->our_role == TX_ACCEPTER) {
 		handle_send_tx_sigs(state, msg);

--- a/plugins/funder.c
+++ b/plugins/funder.c
@@ -117,17 +117,6 @@ static struct command_result *unreserve_psbt(struct command *cmd,
 	return command_still_pending(aux);
 }
 
-static void cleanup_peer_pending_opens(struct command *cmd,
-				       const struct node_id *id)
-{
-	struct pending_open *i, *next;
-	list_for_each_safe(&pending_opens, i, next, list) {
-		if (node_id_eq(&i->peer_id, id)) {
-			unreserve_psbt(cmd, i);
-		}
-	}
-}
-
 static struct command_result *
 command_hook_cont_psbt(struct command *cmd, struct wally_psbt *psbt)
 {
@@ -1086,32 +1075,6 @@ json_rbf_channel_call(struct command *cmd,
 	return send_outreq(req);
 }
 
-static struct command_result *json_disconnect(struct command *cmd,
-					      const char *buf,
-					      const jsmntok_t *params)
-{
-	struct node_id id;
-	const char *err;
-
-	err = json_scan(tmpctx, buf, params,
-			"{disconnect:{id:%}}",
-			JSON_SCAN(json_to_node_id, &id));
-	if (err)
-		plugin_err(cmd->plugin,
-			   "`disconnect` notification payload did not"
-			   " scan %s: %.*s",
-			   err, json_tok_full_len(params),
-			   json_tok_full(buf, params));
-
-	plugin_log(cmd->plugin, LOG_DBG,
-		   "Cleaning up inflights for peer id %s",
-		   fmt_node_id(tmpctx, &id));
-
-	cleanup_peer_pending_opens(cmd, &id);
-
-	return notification_handled(cmd);
-}
-
 static struct command_result *
 delete_channel_from_datastore(struct command *cmd,
 			      struct channel_id *cid)
@@ -1551,10 +1514,6 @@ const struct plugin_notification notifs[] = {
 	{
 		"channel_open_failed",
 		json_channel_open_failed,
-	},
-	{
-		"disconnect",
-		json_disconnect,
 	},
 	{
 		"channel_state_changed",

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -2,7 +2,7 @@ from fixtures import *  # noqa: F401,F403
 from fixtures import TEST_NETWORK
 from pyln.client import RpcError, Millisatoshi
 from utils import (
-    only_one, wait_for, sync_blockheight, first_channel_id, calc_lease_fee, check_coin_moves
+    TIMEOUT, only_one, wait_for, sync_blockheight, first_channel_id, calc_lease_fee, check_coin_moves
 )
 from pyln.testing.utils import FUNDAMOUNT
 
@@ -3089,3 +3089,43 @@ def test_no_retransmit_confirmed_funding(node_factory):
     # Should not have attempted (and failed) to re-broadcast the funding tx.
     assert not l1.daemon.is_in_log('Failed to re-transmit funding tx')
     assert not l1.daemon.is_in_log('Successfully rexmitted funding tx')
+
+
+@unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
+@pytest.mark.openchannel('v2')
+@pytest.mark.xfail(
+    reason="Issue #8902 is not fixed at this commit",
+    strict=True,
+)
+def test_inflight_disconnect_commitment_v2(node_factory, bitcoind):
+    """Disconnect during dual-fund commitment signing should not trigger spurious BROKEN messages.
+    """
+    disconnects = ["+WIRE_COMMITMENT_SIGNED"]
+
+    opts = [{'experimental-dual-fund': None, 'dev-no-reconnect': None,
+             'may_reconnect': True, 'disconnect': disconnects},
+            {'experimental-dual-fund': None, 'dev-no-reconnect': None,
+             'may_reconnect': True}]
+
+    opener, funder = node_factory.get_nodes(2, opts=opts)
+
+    amount = 500000
+    opener.fundwallet(20000000)
+    funder.fundwallet(20000000)
+
+    funder.rpc.call('funderupdate',
+                    {'policy': 'available',
+                     'policy_mod': 100,
+                     'per_channel_max_msat': '1btc',
+                     'reserve_tank_msat': '0msat',
+                     'fund_probability': 100,
+                     'fuzz_percent': 0,
+                     'leases_only': False})
+
+    opener.rpc.connect(funder.info['id'], 'localhost', funder.port)
+    fut = node_factory.executor.submit(opener.rpc.fundchannel,
+                                       funder.info['id'], amount)
+
+    opener.daemon.wait_for_log(r'dev_disconnect: .WIRE_COMMITMENT_SIGNED')
+    opener.rpc.connect(funder.info['id'], 'localhost', funder.port)
+    fut.result(timeout=TIMEOUT)

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3124,4 +3124,15 @@ def test_inflight_disconnect_commitment_v2(node_factory, bitcoind):
 
     opener.daemon.wait_for_log(r'dev_disconnect: .WIRE_COMMITMENT_SIGNED')
     opener.rpc.connect(funder.info['id'], 'localhost', funder.port)
-    fut.result(timeout=TIMEOUT)
+
+    # The disconnect kills the opener's dualopend mid-commitment. Depending on
+    # timing, the opener's `fundchannel` (via spenderp) either completes the
+    # open over the reconnected link, or fails: both are acceptable. The
+    # regression we guard against here is the funder going BROKEN (#8902).
+    try:
+        fut.result(timeout=TIMEOUT)
+    except RpcError:
+        pass
+
+    # The funder must not have gone BROKEN.
+    assert not funder.daemon.is_in_log('BROKEN')

--- a/tests/test_opening.py
+++ b/tests/test_opening.py
@@ -3093,10 +3093,6 @@ def test_no_retransmit_confirmed_funding(node_factory):
 
 @unittest.skipIf(TEST_NETWORK != 'regtest', 'elementsd doesnt yet support PSBT features we need')
 @pytest.mark.openchannel('v2')
-@pytest.mark.xfail(
-    reason="Issue #8902 is not fixed at this commit",
-    strict=True,
-)
 def test_inflight_disconnect_commitment_v2(node_factory, bitcoind):
     """Disconnect during dual-fund commitment signing should not trigger spurious BROKEN messages.
     """


### PR DESCRIPTION
There's two issues identified in #8902. This changeset:
- adds a test to replicate the issue(s)
- Adds handling for failure messages from lightningd in the case when the openchannel_signed_cb returns an error
- Removes the reconnection tracking code from `funder` 

This should resolve both issues identified. 