### PR TITLE
tests: fix flake in test_important_plugin from sync read EBADF

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2700,7 +2700,7 @@ def test_important_plugin(node_factory):
     l1 = node_factory.get_node(options={"important-plugin": os.path.join(pluginsdir, "nonexistent")},
                                may_fail=True, expect_fail=True,
                                # Other plugins can complain as lightningd stops suddenly:
-                               broken_log='Plugin marked as important, shutting down lightningd|Reading sync lightningd: Connection reset by peer|Lost connection to the RPC socket|Plugin terminated before replying to RPC call|plugin-cln-xpay: askrene-create-layer failed with.*Unknown command',
+                               broken_log='Plugin marked as important, shutting down lightningd|Reading sync lightningd: Connection reset by peer|Reading sync lightningd: Bad file descriptor|Lost connection to the RPC socket|Plugin terminated before replying to RPC call|plugin-cln-xpay: askrene-create-layer failed with.*Unknown command',
                                start=False)
 
     l1.daemon.start(wait_for_initialized=False, stderr_redir=True)


### PR DESCRIPTION
When an important plugin dies, lightningd shuts down while other plugins may still be mid-sync-RPC during init.  If `rpc_open()` fails because the RPC socket is already gone (logging "Could not connect ... Connection refused"), `sync_req()` proceeds with `sync_fd == -1`, and the subsequent `read(-1)` fails with EBADF, producing the BROKEN message:

    Reading sync lightningd: Bad file descriptor

This is the same intentional shutdown that already produces the whitelisted "Reading sync lightningd: Connection reset by peer" (or a clean EOF exit); the errno merely differs by the connection race.  Add "Bad file descriptor" to the `broken_log` whitelist so the test no longer fails at teardown on this race.

Fixes: https://github.com/ElementsProject/lightning/issues/9382
