### PR TITLE
tests: fix test_bwatch_spk_watch_reorg_demotes_outputs flake

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5827,6 +5827,11 @@ def test_bwatch_spk_watch_reorg_demotes_outputs(node_factory, bitcoind):
             == [{'blockheight': deposit_height}])
     assert l1.db_query('SELECT COUNT(*) AS c FROM outputs')[0]['c'] == 1
 
+    # bwatch must have observed the deposit block before we reorg it away:
+    # if it's height-based fetch grabs the replacement block instead, it never
+    # sees a reorg.
+    l1.daemon.wait_for_log(rf'Added block {deposit_height} to history', timeout=60)
+
     # Reorg the deposit block away.  Deprioritize the returned mempool tx
     # (same trick as simple_reorg) so the replacement blocks don't just
     # re-confirm it.


### PR DESCRIPTION
We need to wait for bwatch to see the deposit block or it won't see a reorg.

```
        assert l1.db_query('SELECT COUNT(*) AS c FROM outputs')[0]['c'] == 1

        # Reorg the deposit block away.  Deprioritize the returned mempool tx
        # (same trick as simple_reorg) so the replacement blocks don't just
        # re-confirm it.
        bitcoind.rpc.invalidateblock(bitcoind.rpc.getblockhash(deposit_height))
        memp = bitcoind.rpc.getrawmempool()
        assert txid in memp
        for t in memp:
            bitcoind.rpc.prioritisetransaction(t, None, -1000000)
        bitcoind.generate_block(2)

>       l1.daemon.wait_for_log(r'Reorg detected', timeout=60)
```

Changelog-None

Fixes: #9372