### PR TITLE
doc: mention GitHub private vulnerability reporting in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,18 @@ We have a 3 month release cycle, and the last two versions are supported.
 
 ## Reporting a Vulnerability
 
-To report security vulnerabilities, please send an email to:
-- `security@blockstream.com`
+To report security vulnerabilities, you can either:
 
-Note: This email address is exclusively for vulnerability reporting.
+- **Use GitHub private vulnerability reporting** (preferred): click
+  ["Report a vulnerability"](https://github.com/ElementsProject/lightning/security/advisories/new)
+  in the [Security](https://github.com/ElementsProject/lightning/security) tab.
+  This creates a private draft security advisory that is only visible to
+  you and the maintainers, and gives us a single place to discuss the
+  issue, collaborate on a fix, and coordinate disclosure (including
+  requesting a CVE).
+- **Send an email** to `security@blockstream.com` (GPG key below).
+
+Note: The email address is exclusively for vulnerability reporting.
 
 For all other inquiries/communication, please refer to the [Reach Out to Us](https://github.com/ElementsProject/lightning?tab=readme-ov-file#reach-out-to-us) section in our README.
 


### PR DESCRIPTION
## Summary

`SECURITY.md` currently only lists `security@blockstream.com` as the reporting channel. **GitHub private vulnerability reporting is enabled on this repository**, but a reporter reading the security policy would never know.

This PR advertises it as the preferred channel, keeping the email as an alternative.

## Why

Private vulnerability reporting is strictly better for both sides than email:

- **Private by default** — the report opens as a draft advisory visible only to the reporter and maintainers (no risk of a public issue with exploit details).
- **Single workspace** — discussion, fix collaboration (private fork), credit, and coordinated disclosure all happen in one place.
- **CVEs built in** — maintainers can request a CVE from GitHub directly on the advisory when publishing.
- **Better reporter UX** — one click from the Security tab, no GPG setup needed.

## Changes

The "Reporting a Vulnerability" section now reads:

> To report security vulnerabilities, you can either:
>
> - **Use GitHub private vulnerability reporting** (preferred): click "Report a vulnerability" in the Security tab. ...
> - **Send an email** to `security@blockstream.com` (GPG key below).

The note that the email address is exclusively for vulnerability reporting is preserved, as is the GPG key table (still needed for the email channel and release signatures).

Changelog-None
