### PR TITLE
askrene: properly handle invalid "inform" field

### DIFF
--- a/plugins/askrene/askrene.c
+++ b/plugins/askrene/askrene.c
@@ -1167,7 +1167,7 @@ static struct command_result *param_inform(struct command *cmd,
 	else if (json_tok_streq(buffer, tok, "succeeded"))
 		**inform = INFORM_SUCCEEDED;
 	else
-		command_fail_badparam(cmd, name, buffer, tok,
+		return command_fail_badparam(cmd, name, buffer, tok,
 				      "must be constrained/unconstrained/succeeded");
 	return NULL;
 }

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -213,6 +213,13 @@ def test_layers(node_factory):
     expect['channel_updates'] = []
     assert l2.rpc.askrene_listlayers('test_layers') == {'layers': [expect]}
 
+    # askrene should reject invalid inform channel types
+    with pytest.raises(RpcError, match=r"invalid token"):
+        l2.rpc.askrene_inform_channel('test_layers',
+                                      '0x0x1/1',
+                                      100000,
+                                      'imadethisup')
+
     # We can tell it about made up channels...
     first_timestamp = int(time.time())
     l2.rpc.askrene_inform_channel('test_layers',


### PR DESCRIPTION
A small change. We need to properly handle invalid "inform" values.