### PR TITLE
offers: fix recurrence proportional amount

### DIFF
--- a/plugins/offers_invreq_hook.c
+++ b/plugins/offers_invreq_hook.c
@@ -563,10 +563,23 @@ static struct command_result *check_period(struct command *cmd,
 		u64 end = offer_period_start(basetime, period_idx + 1,
 					     invreq_recurrence(ir->invreq));
 
+		if (end <= start) {
+			return fail_invreq(cmd, ir,
+					   "period_index %"PRIu64" bad period",
+					   period_idx);
+		}
+		/* Paywindow can outlive the period; remaining time is then 0. */
+		if (*ir->inv->invoice_created_at >= end) {
+			return fail_invreq(cmd, ir,
+					   "period_index %"PRIu64
+					   " too late (ended %"PRIu64")",
+					   period_idx,
+					   end);
+		}
 		if (*ir->inv->invoice_created_at > start) {
 			*ir->inv->invoice_amount
-				*= (double)((*ir->inv->invoice_created_at - start)
-					    / (end - start));
+				*= ((double)end - *ir->inv->invoice_created_at)
+					    / (end - start);
 			/* Round up to make it non-zero if necessary. */
 			if (*ir->inv->invoice_amount == 0)
 				*ir->inv->invoice_amount = 1;


### PR DESCRIPTION
offers: recurrence with proportional_amount now computes the correct invoice amount based on the time remaining
