### PR TITLE
Build fixes for nix + a rust check error

### DIFF
--- a/cln-rpc/src/primitives.rs
+++ b/cln-rpc/src/primitives.rs
@@ -189,11 +189,13 @@ macro_rules! amount {
                 self.$field
             }
 
-            fn checked_add(self, rhs: Self) -> Option<Self> {
+            /// Adds two amounts, returning `None` if the result overflows.
+            pub fn checked_add(self, rhs: Self) -> Option<Self> {
                 self.$field.checked_add(rhs.$field).map($name::$from_fn)
             }
 
-            fn checked_sub(self, rhs: Self) -> Option<Self> {
+            /// Subtracts two amounts, returning `None` if the result underflows.
+            pub fn checked_sub(self, rhs: Self) -> Option<Self> {
                 self.$field.checked_sub(rhs.$field).map($name::$from_fn)
             }
         }
@@ -202,9 +204,8 @@ macro_rules! amount {
             type Output = Self;
 
             fn add(self, rhs: Self) -> Self {
-                Self {
-                    $field: self.$field + rhs.$field,
-                }
+                self.checked_add(rhs)
+                    .expect("attempt to add with overflow")
             }
         }
 
@@ -212,9 +213,8 @@ macro_rules! amount {
             type Output = Self;
 
             fn sub(self, rhs: Self) -> Self::Output {
-                Self {
-                    $field: self.$field - rhs.$field,
-                }
+                self.checked_sub(rhs)
+                    .expect("attempt to subtract with overflow")
             }
         }
 

--- a/configure
+++ b/configure
@@ -82,6 +82,12 @@ default_python()
                 echo "$p"
                 return
             fi
+            # uv may be unavailable or unable to reach the network
+            # (offline/sandboxed builds); fall back to the interpreter itself.
+            if $p --version 2>&1 | grep -q "Python 3."; then
+                echo "$p"
+                return
+            fi
         fi
     done
 }
@@ -344,6 +350,12 @@ done
 
 # Now fill in any unset vars.
 set_defaults
+
+if [ -z "$PYTHON" ]; then
+    echo "configure: no Python 3 interpreter found." >&2
+    echo "Install python3, or set it explicitly: ./configure PYTHON=/path/to/python3" >&2
+    exit 1
+fi
 
 if [ "$ASAN" = "1" ]; then
     if [ "$VALGRIND" = "1" ]; then

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -12,6 +12,19 @@ let
     p.grpcio-tools
     p.mako
   ]);
+  # lowdown uses sandbox_init(3) on Darwin, which fails when invoked from
+  # within Nix's existing build sandbox. Disable the redundant inner sandbox
+  # for this build-only lowdown dependency.
+  lowdownForBuild =
+    if stdenv.isDarwin then
+      lowdown.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace main.c \
+            --replace-fail '#elif HAVE_SANDBOX_INIT' '#elif 0 /* Already sandboxed by Nix. */'
+        '';
+      })
+    else
+      lowdown;
 in
 stdenv.mkDerivation {
   name = "cln";
@@ -33,7 +46,7 @@ stdenv.mkDerivation {
     gettext
     gitMinimal
     libtool
-    lowdown
+    lowdownForBuild
     pkgconf
     py3
     unzip

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -77,11 +77,6 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--disable-valgrind" ];
 
-  # ./configure detects Python via `uv` (configure:default_python), which is not
-  # part of this derivation. Point it at the python3 we already provide so the
-  # codegen steps that call $(PYTHON) (e.g. devtools/blockreplace.py) work.
-  preConfigure = "export PYTHON=python3";
-
   enableParallelBuilding = true;
 
   # workaround for build issue, happens only x86_64-darwin, not aarch64-darwin


### PR DESCRIPTION
Handful of bugfixes:

- When building CLN on NixOS (outside of the `uv` runner), you run into issues with the python scripts we use for building. By falling back to a python type in the absence of `uv`, we can fix this error. We were masking over it in the built-in nix builds.
- Getting the nix builds running on MacOS unearthed an issue with `lowdown` attempting to spawn a sandbox within a sandbox. We resolve this by telling lowdown not to spawn a sandbox when it's running in a nixos build.
- `nix build .#default` unearthed an issue with the Rust tests masking overflow errors. 