### PR TITLE
askrene: fix crash loading node bias with description

### DIFF
--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -773,10 +773,10 @@ static void load_node_bias(struct plugin *plugin,
 				      &in_bias,
 				      &out_bias,
 				      &timestamp)) {
-		set_node_bias(layer, &node, take(description), in_bias,
+		set_node_bias(layer, &node, description, in_bias,
 			      /* relative = */ false,
 			      /* out dir = */ false, timestamp);
-		set_node_bias(layer, &node, take(description), out_bias,
+		set_node_bias(layer, &node, description, out_bias,
 			      /* relative = */ false,
 			      /* out dir = */ true, timestamp);
 	}

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -473,6 +473,7 @@ def test_node_bias_rpc(node_factory):
     assert listlayers == {"layers": [expect]}
 
 
+@pytest.mark.xfail(strict=True)
 def test_node_bias_persistence(node_factory):
     """Test node bias persistence."""
     # remove xpay, since it creates a layer!
@@ -505,7 +506,7 @@ def test_node_bias_persistence(node_factory):
     ]
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
     # restarting the node we see the same data again
-    l2.restart()
+    l1.restart()
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
 
     r = l1.rpc.askrene_bias_node(
@@ -528,7 +529,7 @@ def test_node_bias_persistence(node_factory):
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
 
     # restarting the node we see the same data again
-    l2.restart()
+    l1.restart()
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
 
 

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -473,7 +473,6 @@ def test_node_bias_rpc(node_factory):
     assert listlayers == {"layers": [expect]}
 
 
-@pytest.mark.xfail(strict=True)
 def test_node_bias_persistence(node_factory):
     """Test node bias persistence."""
     # remove xpay, since it creates a layer!


### PR DESCRIPTION
Fixes #9433.

Two commits, red then green: the first makes the existing
`test_node_bias_persistence` actually exercise layer persistence (it fails
on master with the exact crash below), the second fixes the crash.

## Commit 1: tests only — the reproducer

`test_node_bias_persistence` restarted `l2`, but the layer and its node
bias records live in `l1`'s datastore: the assert was comparing l1's
in-memory layer against itself, so `load_node_bias()` never ran. With
`l1.restart()` the layer is reloaded from the datastore at startup, which
triggers the crash on master:

```
cln-askrene: FATAL SIGNAL 6 (version a744936)
INFO    plugin-cln-askrene: Killing plugin: exited before replying to init
**BROKEN** plugin-cln-askrene: Plugin marked as important, shutting down lightningd!
```

## Commit 2: the fix

`load_node_bias()` passed `take(description)` to two consecutive
`set_node_bias()` calls.  The first call's `tal_strdup()` consumes
the take (`tal_resize_` + `tal_steal` inside `tal_dup_`), so the
second `take()` was on freed memory and we aborted in
`to_tal_hdr()` with "Not a valid header" while loading the layer at
startup:

```
  call_error (tal.c: "Not a valid header")
  check_bounds / to_tal_hdr (tal.c:169/179)
  tal_resize_ (tal.c:750)
  tal_dup_ (tal.c:854)
  tal_strdup_ / tal_strdup_or_null (common/utils.c:192)
  set_node_bias (plugins/askrene/layer.c)
  load_node_bias (plugins/askrene/layer.c)
  populate_layer / load_layers
  init (plugins/askrene/askrene.c)
```

Since lightningd treats askrene as an important plugin, any persistent
layer containing a node bias with a description makes the node unable to
restart.

The description is already a copy off tmpctx, so the simplest thing:
don't take() it, `set_node_bias()` strdups it into the bias anyway
(as the issue notes, it only needs loading once).

## Verified locally

- commit 1 alone: `pytest tests/test_askrene.py::test_node_bias_persistence`
  fails — node crashes at restart (`FATAL SIGNAL 6`, `exited before
  replying to init`).
- commit 1 + 2: same test passes, layer round-trips exactly
  (description, in_bias, out_bias, timestamp).
