### PR TITLE
pyln-testing: truncate long testnames

### DIFF
--- a/contrib/pyln-testing/pyln/testing/db.py
+++ b/contrib/pyln-testing/pyln/testing/db.py
@@ -149,6 +149,9 @@ class SqliteDbProvider(object):
 
 
 class PostgresDbProvider(object):
+    # Postgres truncates identifiers at NAMEDATALEN - 1 bytes.
+    MAX_IDENTIFIER_LEN = 63
+
     def __init__(self, directory):
         self.directory = directory
         self.port = None
@@ -223,10 +226,21 @@ class PostgresDbProvider(object):
         # Required for CREATE DATABASE to work
         self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 
+    @staticmethod
+    def db_name(testname: str, node_id: int, nonce: str) -> str:
+        """Build the database name for a node of a test.
+
+        Truncates the testname, not the suffix: postgres would otherwise
+        cut off the node_id and the nonce, making the names of
+        long-named tests collide and fail with `DuplicateDatabase`.
+        """
+        suffix = "_{}_{}".format(node_id, nonce)
+        return testname[:PostgresDbProvider.MAX_IDENTIFIER_LEN - len(suffix)] + suffix
+
     def get_db(self, node_directory, testname, node_id):
         # Random suffix to avoid collisions on repeated tests
         nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
-        dbname = "{}_{}_{}".format(testname, node_id, nonce)
+        dbname = self.db_name(testname, node_id, nonce)
 
         cur = self.conn.cursor()
         cur.execute("CREATE DATABASE {};".format(dbname))

--- a/contrib/pyln-testing/tests/test_dbname.py
+++ b/contrib/pyln-testing/tests/test_dbname.py
@@ -1,0 +1,44 @@
+from pyln.testing.db import PostgresDbProvider
+
+
+# Longest test name in the CLN test suite at the time of writing, at 66
+# characters it exceeds what postgres can store in an identifier.
+LONG_TESTNAME = "test_hsmtool_checkhsm_legacy_encrypted_with_mnemonic_no_passphrase"
+
+# Hardcoded rather than taken from PostgresDbProvider, so that changing
+# the limit in the provider fails these tests instead of silencing them.
+MAX_IDENTIFIER_LEN = 63
+
+
+def test_long_testname_fits_postgres_identifier():
+    name = PostgresDbProvider.db_name(LONG_TESTNAME, 1, "abcd1234")
+
+    assert len(name) <= MAX_IDENTIFIER_LEN
+
+
+def test_long_testname_keeps_node_id_and_nonce():
+    name = PostgresDbProvider.db_name(LONG_TESTNAME, 7, "abcd1234")
+
+    assert name.endswith("_7_abcd1234")
+
+
+def test_long_testname_distinct_per_node_after_truncation():
+    # Postgres silently truncates at 63 bytes, so names must already be
+    # distinct at that length or nodes of the same test collide.
+    names = {PostgresDbProvider.db_name(LONG_TESTNAME, i, "abcd1234")[:MAX_IDENTIFIER_LEN]
+             for i in range(5)}
+
+    assert len(names) == 5
+
+
+def test_long_testname_distinct_per_nonce_after_truncation():
+    n1 = PostgresDbProvider.db_name(LONG_TESTNAME, 1, "abcd1234")[:MAX_IDENTIFIER_LEN]
+    n2 = PostgresDbProvider.db_name(LONG_TESTNAME, 1, "wxyz5678")[:MAX_IDENTIFIER_LEN]
+
+    assert n1 != n2
+
+
+def test_short_testname_is_not_truncated():
+    name = PostgresDbProvider.db_name("test_peers", 1, "abcd1234")
+
+    assert name == "test_peers_1_abcd1234"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`

Postgres truncates identifiers at 63 chars. This can lead to 'DuplicateDatabase' errors for tests with longer names, as the nonce and the node_id may collapse. This PR truncates the testname in favor of the node_id and the nonce, to avoid conflicting db names.