### PR TITLE
doc: fix typos across getting-started, plugins and contributor docs

### DIFF
--- a/doc/contribute-to-core-lightning/docker-images.md
+++ b/doc/contribute-to-core-lightning/docker-images.md
@@ -138,7 +138,7 @@ docker run -it --rm --platform=linux/amd64 --network=host -v '/root/.lightning:/
 
 2. Start your `bitcoind` node on the local machine.
 
-3. Start `vlsd` locally with your prefered configuration. For example:
+3. Start `vlsd` locally with your preferred configuration. For example:
 
 ```shell
 export LIGHTNING_VLS_DIR=/root/.lightning

--- a/doc/getting-started/getting-started/configuration.md
+++ b/doc/getting-started/getting-started/configuration.md
@@ -379,7 +379,7 @@ Note that for simple setups, the implicit _autolisten_ option does the right thi
 
 Core Lightning also support IPv4/6 address discovery behind NAT routers. If your node detects an new public address, it will update its announcement. For this to work you need to forward the default TCP port 9735 to your node. IP discovery is only active if no other addresses are announced.
 
-You can instead use _addr_ to override this (eg. to change the port), or precisely control where to bind and what to announce with the _bind-addr_ and _announce-addr_ options. These will **disable** the _autolisten_ logic, so you must specifiy exactly what you want!
+You can instead use _addr_ to override this (eg. to change the port), or precisely control where to bind and what to announce with the _bind-addr_ and _announce-addr_ options. These will **disable** the _autolisten_ logic, so you must specify exactly what you want!
 
 - **addr**=_\[IPADDRESS[:PORT]]|autotor:TORIPADDRESS[:SERVICEPORT][/torport=TORPORT]|statictor:TORIPADDRESS[:SERVICEPORT]\[/torport=TORPORT]\[/torblob=[blob]]|DNS[:PORT]_
 
@@ -473,7 +473,7 @@ plugins along with any immediate subdirectories). You can specify additional pat
 
 - **clear-plugins**
 
-  This option clears all _plugin_, _important-plugin_, and _plugin-dir_ options preceeding it, including the default built-in plugin directory. You can still add _plugin-dir_, _plugin_, and _important-plugin_ options following this and they will have the normal effect.
+  This option clears all _plugin_, _important-plugin_, and _plugin-dir_ options preceding it, including the default built-in plugin directory. You can still add _plugin-dir_, _plugin_, and _important-plugin_ options following this and they will have the normal effect.
 
 - **disable-plugin**=_PLUGIN_
 

--- a/doc/getting-started/getting-started/installation.md
+++ b/doc/getting-started/getting-started/installation.md
@@ -439,7 +439,7 @@ uv sync --all-extras --all-groups --frozen
 ./configure
 ```
 
-If you see `/usr/local` in the log, an Intel compatability dependency has been picked up. The simplest solution is to remove brew entirely, reinstall it, and start these instructions over.
+If you see `/usr/local` in the log, an Intel compatibility dependency has been picked up. The simplest solution is to remove brew entirely, reinstall it, and start these instructions over.
 ```shell
 uv run gmake
 ```

--- a/doc/node-operators-guide/plugins.md
+++ b/doc/node-operators-guide/plugins.md
@@ -27,7 +27,7 @@ reckless install plugin_name
 reckless will exit early in the event that:
 
 - the plugin is not found in any available source repositories
-- dependencies are not sucessfully installed
+- dependencies are not successfully installed
 - the plugin fails to execute
 
 Reckless-installed plugins reside in the 'reckless' subdirectory of the user's `.lightning` folder.  By default, plugins are activated on the `bitcoin` network (and use lightningd's bitcoin network config), but regtest may also be used.


### PR DESCRIPTION
Five typo fixes across user and contributor documentation:

| File | Line | Fix |
|---|---|---|
| `doc/contribute-to-core-lightning/docker-images.md` | 141 | `prefered` → `preferred` |
| `doc/getting-started/getting-started/configuration.md` | 382 | `specifiy` → `specify` |
| `doc/getting-started/getting-started/configuration.md` | 476 | `preceeding` → `preceding` |
| `doc/getting-started/getting-started/installation.md` | 442 | `compatability` → `compatibility` |
| `doc/node-operators-guide/plugins.md` | 30 | `sucessfully` → `successfully` |

Documentation prose only — no option names, config keys, or commands changed.

Changelog-None
