### PR TITLE
lightningd: initialize error pointer in connect_activate_subd and handle_splice_abort

### DIFF
--- a/lightningd/channel_control.c
+++ b/lightningd/channel_control.c
@@ -331,7 +331,7 @@ static void handle_splice_abort(struct lightningd *ld,
 	struct bitcoin_outpoint *outpoint;
 	struct channel_inflight *inflight;
 	char *reason;
-	const u8 *error;
+	const u8 *error = NULL;
 	struct peer_fd *pfd;
 	int other_fd;
 

--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -1395,7 +1395,7 @@ static bool ignore_idle_channel(const struct lightningd *ld,
 /* Talk to connectd about an active channel */
 static void connect_activate_subd(struct lightningd *ld, struct channel *channel)
 {
-	const u8 *error;
+	const u8 *error = NULL;
 	struct peer_fd *pfd;
 	int other_fd;
 


### PR DESCRIPTION
Fixes #9442

Same uninitialized-pointer pattern as #8849 (fixed in 090f4b0e6981 for handle_peer_spoke) also exists in:

- `connect_activate_subd()` in lightningd/peer_control.c
- `handle_splice_abort()` in lightningd/channel_control.c

In both, `const u8 *error` - is declared uninitialized and only conditionally set via `sockpair(..., &error)` before falling through to a path that dereferences it. `sockpair()` currently always sets the output pointer on failure, so this isn't exploitable today, but the declaration should still default to `NULL` defensively in case that invariant ever breaks

*Fix*: initialize both declarations to NULL.

*Testing*: compiled `lightningd/channel_control.o` and `lightningd/peer_control.o` cleanly - no behavior change on existing paths

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
