### PR TITLE
doc: document CLN_PLUGIN_LOG in the cln-plugin crate

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,3 +1,25 @@
+//! A library for writing Core Lightning plugins in Rust.
+//!
+//! # Logging
+//!
+//! Records emitted through the `log` and `tracing` facades are forwarded to
+//! `lightningd` as JSON-RPC `log` notifications, and appear in the node's log.
+//!
+//! Which records are forwarded is controlled by the `CLN_PLUGIN_LOG`
+//! environment variable, which accepts the same comma-separated directives as
+//! `RUST_LOG`. Directives that fail to parse are reported on `stderr` and
+//! ignored.
+//!
+//! If `CLN_PLUGIN_LOG` is unset or empty the filter defaults to `info`, so
+//! `info` and above are forwarded while `debug` and `trace` are dropped.
+//! Setting the variable *replaces* that default rather than adding to it, so
+//! `CLN_PLUGIN_LOG=cln_plugin=trace` also silences every other target; append
+//! a bare level, as in `cln_plugin=trace,warn`, to keep a fallback for the
+//! rest.
+//!
+//! `lightningd` applies its own `log-level` setting on top of this filter, so
+//! a record must pass both to be written to the node's log.
+
 use crate::codec::{JsonCodec, JsonRpcCodec};
 pub use anyhow::anyhow;
 use anyhow::{Context, Result};


### PR DESCRIPTION
The `cln-plugin` crate has no crate-level documentation, and `CLN_PLUGIN_LOG` is not mentioned anywhere in the crate or under `doc/`. This adds a short `//!` block to `plugins/src/lib.rs` covering the variable: that it takes the same comma-separated directives as `RUST_LOG`, that the filter defaults to `info` when it is unset or empty, that setting it *replaces* that default rather than adding to it (which is why the in-tree plugins append a bare fallback level, e.g. `cln_plugin=trace,warn`), and that `lightningd` applies its own `log-level` on top.

The behaviour described was read from the source at c1551c557cc524e2241f9cbae7d3895b1b0b627c — `EnvFilter::builder().with_default_directive(INFO).with_env_var("CLN_PLUGIN_LOG").from_env_lossy()` in `plugins/src/logging.rs` — and confirmed by running each case. Note this documents current behaviour: the ERROR-level default reported in #7658 was a regression from 60e1532dd and was fixed by 9e8dd15a9, so the default has been `info` since 2024.

Docs only, no behaviour change. `cargo doc -p cln-plugin --no-deps` and `cargo fmt --check` both pass.

Fixes #6927