### PR TITLE
askrene: fix set zero bias on persistent layers

### DIFF
--- a/plugins/askrene/layer.c
+++ b/plugins/askrene/layer.c
@@ -418,12 +418,6 @@ static const struct bias *set_bias(struct layer *layer,
 	bias->bias = bias_new;
 	bias->description = tal_strdup_or_null(bias, description);
 	bias->timestamp = timestamp;
-
-	/* Don't bother keeping around zero biases */
-	if (bias->bias == 0) {
-		bias_hash_del(layer->biases, bias);
-		bias = tal_free(bias);
-	}
 	return bias;
 }
 
@@ -462,12 +456,6 @@ static const struct node_bias *set_node_bias(struct layer *layer,
 		bias_new = MIN(100, bias_new);
 		bias_new = MAX(-100, bias_new);
 		bias->in_bias = bias_new;
-	}
-
-	/* Don't bother keeping around zero biases */
-	if (bias->in_bias == 0 && bias->out_bias == 0) {
-		node_bias_hash_del(layer->node_biases, bias);
-		bias = tal_free(bias);
 	}
 	return bias;
 }
@@ -726,6 +714,7 @@ static void load_channel_bias(struct plugin *plugin,
 	struct short_channel_id_dir scidd;
 	const char *description;
 	s8 bias_factor;
+	const struct bias *bias;
         /* If we read an old version without timestamp, just put the current
          * time. */
         u64 timestamp = clock_time().ts.tv_sec;
@@ -733,9 +722,15 @@ static void load_channel_bias(struct plugin *plugin,
 	if (fromwire_dstore_channel_bias(tmpctx, cursor, len,
 					 &scidd,
 					 &bias_factor,
-					 &description))
-		set_bias(layer, &scidd, take(description), bias_factor, false,
-			 timestamp);
+					 &description)) {
+		bias = set_bias(layer, &scidd, take(description), bias_factor,
+				false, timestamp);
+
+		if (bias->bias == 0) {
+			bias_hash_del(layer->biases, bias);
+			bias = tal_free(bias);
+		}
+	}
 }
 
 static void load_channel_bias_v2(struct plugin *plugin,
@@ -747,14 +742,21 @@ static void load_channel_bias_v2(struct plugin *plugin,
 	const char *description;
 	s8 bias_factor;
 	u64 timestamp;
+	const struct bias *bias;
 
 	if (fromwire_dstore_channel_bias_v2(tmpctx, cursor, len,
 					    &scidd,
 					    &bias_factor,
 					    &description,
-					    &timestamp))
-		set_bias(layer, &scidd, take(description), bias_factor, false,
+					    &timestamp)) {
+		bias = set_bias(layer, &scidd, take(description), bias_factor, false,
 			 timestamp);
+
+		if (bias->bias == 0) {
+			bias_hash_del(layer->biases, bias);
+			bias = tal_free(bias);
+		}
+	}
 }
 
 static void load_node_bias(struct plugin *plugin,
@@ -766,6 +768,7 @@ static void load_node_bias(struct plugin *plugin,
 	const char *description;
 	s8 in_bias, out_bias;
 	u64 timestamp;
+	const struct node_bias *bias;
 
 	if (fromwire_dstore_node_bias(tmpctx, cursor, len,
 				      &node,
@@ -776,9 +779,14 @@ static void load_node_bias(struct plugin *plugin,
 		set_node_bias(layer, &node, description, in_bias,
 			      /* relative = */ false,
 			      /* out dir = */ false, timestamp);
-		set_node_bias(layer, &node, description, out_bias,
+		bias = set_node_bias(layer, &node, description, out_bias,
 			      /* relative = */ false,
 			      /* out dir = */ true, timestamp);
+
+		if (bias->in_bias == 0 && bias->out_bias == 0) {
+			node_bias_hash_del(layer->node_biases, bias);
+			bias = tal_free(bias);
+		}
 	}
 }
 
@@ -1037,7 +1045,15 @@ const struct bias *layer_set_bias(struct layer *layer,
 
 	bias = set_bias(layer, scidd, description, bias_factor, relative,
 			timestamp);
+	/* Save the resulting bias even if zero to override previously written
+	 * values. */
 	save_channel_bias(layer, bias);
+
+	/* Don't bother keeping around zero biases */
+	if (bias->bias == 0) {
+		bias_hash_del(layer->biases, bias);
+		bias = tal_free(bias);
+	}
 	return bias;
 }
 
@@ -1053,7 +1069,15 @@ const struct node_bias *layer_set_node_bias(struct layer *layer,
 
 	bias = set_node_bias(layer, node, description, bias_factor, relative,
 			     dir_out, timestamp);
+	/* Save the resulting bias even if zero to override previously written
+	 * values. */
 	save_node_bias(layer, bias);
+
+	/* Don't bother keeping around zero biases */
+	if (bias->in_bias == 0 && bias->out_bias == 0) {
+		node_bias_hash_del(layer->node_biases, bias);
+		bias = tal_free(bias);
+	}
 	return bias;
 }
 

--- a/tests/test_askrene.py
+++ b/tests/test_askrene.py
@@ -476,9 +476,8 @@ def test_node_bias_rpc(node_factory):
 def test_node_bias_persistence(node_factory):
     """Test node bias persistence."""
     # remove xpay, since it creates a layer!
-    l1, l2 = node_factory.line_graph(
-        2, wait_for_announce=True, opts={"disable-plugin": "cln-xpay"}
-    )
+    l1 = node_factory.get_node(opts={"disable-plugin": "cln-xpay"})
+    node_id = "020000000000000000000000000000000000000000000000000000000000000001"
 
     expect = {
         "layer": "mylayer",
@@ -493,14 +492,26 @@ def test_node_bias_persistence(node_factory):
     }
     l1.rpc.askrene_create_layer(layer="mylayer", persistent=True)
     r = l1.rpc.askrene_bias_node(
-        layer="mylayer", node=l2.info["id"], direction="out", bias=14, relative=False
+        layer="mylayer", node=node_id, direction="out", bias=14, relative=False
     )
     expect["node_biases"] = [
         {
-            "node": l2.info["id"],
+            "node": node_id,
             "in_bias": 0,
             "out_bias": 14,
             "timestamp": r["node_biases"][0]["timestamp"],
+        }
+    ]
+    r = l1.rpc.askrene_bias_channel(
+        layer="mylayer", short_channel_id_dir="1x1x1/1", bias=10,
+        relative=False, description="some channel bias"
+    )
+    expect["biases"] = [
+        {
+            "short_channel_id_dir": "1x1x1/1",
+            "bias": 10,
+            "description": "some channel bias",
+            "timestamp": r["biases"][0]["timestamp"],
         }
     ]
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
@@ -510,7 +521,7 @@ def test_node_bias_persistence(node_factory):
 
     r = l1.rpc.askrene_bias_node(
         layer="mylayer",
-        node=l2.info["id"],
+        node=node_id,
         direction="in",
         bias=11,
         relative=False,
@@ -518,13 +529,42 @@ def test_node_bias_persistence(node_factory):
     )
     expect["node_biases"] = [
         {
-            "node": l2.info["id"],
+            "node": node_id,
             "in_bias": 11,
             "out_bias": 14,
             "timestamp": r["node_biases"][0]["timestamp"],
             "description": "Some description",
         }
     ]
+    assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
+
+    # restarting the node we see the same data again
+    l1.restart()
+    assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
+
+    # zero bias is like not having any
+    l1.rpc.askrene_bias_node(
+        layer="mylayer",
+        node=node_id,
+        direction="in",
+        bias=0,
+        relative=False,
+        description="adding zero bias",
+    )
+    # zero bias is like not having any
+    l1.rpc.askrene_bias_node(
+        layer="mylayer",
+        node=node_id,
+        direction="out",
+        bias=0,
+        relative=False,
+        description="adding zero bias",
+    )
+    l1.rpc.askrene_bias_channel(
+        layer="mylayer", short_channel_id_dir="1x1x1/1", bias=0, relative=False
+    )
+    expect["node_biases"] = []
+    expect["biases"] = []
     assert l1.rpc.askrene_listlayers("mylayer") == {"layers": [expect]}
 
     # restarting the node we see the same data again


### PR DESCRIPTION
Setting an absolute bias value to zero on a persistent layer doesn't result on a NULL pointer de-reference.

Reported-by: @whkim0 and @Ahmadsm2005
