### PR TITLE
doc: document error 313 where it can actually be returned

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -15008,7 +15008,7 @@
         "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
         "- 302: The output amount is too small, and would be considered dust.",
         "- 303: Broadcasting of the funding transaction failed, the internal call to bitcoin-cli returned with an error.",
-        "- 313: The `min-emergency-msat` reserve not be preserved (and we have or are opening anchor channels).",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels).",
         "",
         "Failure may also occur if **lightningd** and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc.)."
       ],
@@ -30692,7 +30692,7 @@
         "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
         "- 302: The output amount is too small, and would be considered dust.",
         "- 303: Broadcasting of the funding transaction failed, the internal call to bitcoin-cli returned with an error.",
-        "- 313: The `min-emergency-msat` reserve not be preserved (and we have or are opening anchor channels).",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels).",
         "",
         "Failure may also occur if **lightningd** and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc.). See lightning-fundchannel_start(7) and lightning-fundchannel_complete(7).",
         "",
@@ -40958,7 +40958,7 @@
         "- -1: Catchall nonspecific error.",
         "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
         "- 302: The dust limit is not met.",
-        "- 313: The `min-emergency-msat` reserve not be preserved (and we have anchor channels)."
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
       ],
       "author": [
         "Felix [fixone@gmail.com](mailto:fixone@gmail.com) is mainly responsible."

--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -16087,7 +16087,8 @@
         "",
         "- -32602: If the given parameters are wrong.",
         "- -1: Catchall nonspecific error.",
-        "- 301: Insufficient UTXOs to meet *satoshi* value."
+        "- 301: Insufficient UTXOs to meet *satoshi* value.",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels)."
       ],
       "author": [
         "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."
@@ -30937,7 +30938,8 @@
         "",
         "- -1: Catchall nonspecific error.",
         "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
-        "- 302: The dust limit is not met."
+        "- 302: The dust limit is not met.",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
       ],
       "author": [
         "ZmnSCPxj [ZmnSCPxj@protonmail.com](mailto:ZmnSCPxj@protonmail.com) is mainly responsible."
@@ -38460,7 +38462,8 @@
         "",
         "- -1: Catchall nonspecific error.",
         "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
-        "- 302: The dust limit is not met."
+        "- 302: The dust limit is not met.",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
       ],
       "author": [
         "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."
@@ -38832,6 +38835,13 @@
           }
         }
       },
+      "errors": [
+        "On failure, an error is reported and no transaction is created.",
+        "",
+        "- -1: Catchall nonspecific error.",
+        "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
+      ],
       "usage": [
         "The caller is trying to buy a liquidity ad but the command keeps failing. They have funds in their wallet, but they're all P2SH-wrapped outputs.",
         "",
@@ -39067,7 +39077,8 @@
         "",
         "- -32602: If the given parameters are wrong.",
         "- -1: Catchall nonspecific error.",
-        "- 301: Insufficient UTXOs to meet *satoshi* value."
+        "- 301: Insufficient UTXOs to meet *satoshi* value.",
+        "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels)."
       ],
       "author": [
         "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."

--- a/doc/schemas/fundchannel.json
+++ b/doc/schemas/fundchannel.json
@@ -223,7 +223,7 @@
     "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
     "- 302: The output amount is too small, and would be considered dust.",
     "- 303: Broadcasting of the funding transaction failed, the internal call to bitcoin-cli returned with an error.",
-    "- 313: The `min-emergency-msat` reserve not be preserved (and we have or are opening anchor channels).",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels).",
     "",
     "Failure may also occur if **lightningd** and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc.)."
   ],

--- a/doc/schemas/fundpsbt.json
+++ b/doc/schemas/fundpsbt.json
@@ -194,7 +194,8 @@
     "",
     "- -32602: If the given parameters are wrong.",
     "- -1: Catchall nonspecific error.",
-    "- 301: Insufficient UTXOs to meet *satoshi* value."
+    "- 301: Insufficient UTXOs to meet *satoshi* value.",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels)."
   ],
   "author": [
     "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."

--- a/doc/schemas/multifundchannel.json
+++ b/doc/schemas/multifundchannel.json
@@ -313,7 +313,7 @@
     "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
     "- 302: The output amount is too small, and would be considered dust.",
     "- 303: Broadcasting of the funding transaction failed, the internal call to bitcoin-cli returned with an error.",
-    "- 313: The `min-emergency-msat` reserve not be preserved (and we have or are opening anchor channels).",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels).",
     "",
     "Failure may also occur if **lightningd** and the peer cannot agree on channel parameters (funding limits, channel reserves, fees, etc.). See lightning-fundchannel_start(7) and lightning-fundchannel_complete(7).",
     "",

--- a/doc/schemas/multiwithdraw.json
+++ b/doc/schemas/multiwithdraw.json
@@ -72,7 +72,8 @@
     "",
     "- -1: Catchall nonspecific error.",
     "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
-    "- 302: The dust limit is not met."
+    "- 302: The dust limit is not met.",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
   ],
   "author": [
     "ZmnSCPxj [ZmnSCPxj@protonmail.com](mailto:ZmnSCPxj@protonmail.com) is mainly responsible."

--- a/doc/schemas/txprepare.json
+++ b/doc/schemas/txprepare.json
@@ -81,7 +81,8 @@
     "",
     "- -1: Catchall nonspecific error.",
     "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
-    "- 302: The dust limit is not met."
+    "- 302: The dust limit is not met.",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
   ],
   "author": [
     "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."

--- a/doc/schemas/upgradewallet.json
+++ b/doc/schemas/upgradewallet.json
@@ -63,6 +63,13 @@
       }
     }
   },
+  "errors": [
+    "On failure, an error is reported and no transaction is created.",
+    "",
+    "- -1: Catchall nonspecific error.",
+    "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
+  ],
   "usage": [
     "The caller is trying to buy a liquidity ad but the command keeps failing. They have funds in their wallet, but they're all P2SH-wrapped outputs.",
     "",

--- a/doc/schemas/utxopsbt.json
+++ b/doc/schemas/utxopsbt.json
@@ -191,7 +191,8 @@
     "",
     "- -32602: If the given parameters are wrong.",
     "- -1: Catchall nonspecific error.",
-    "- 301: Insufficient UTXOs to meet *satoshi* value."
+    "- 301: Insufficient UTXOs to meet *satoshi* value.",
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have or are opening anchor channels)."
   ],
   "author": [
     "Rusty Russell [rusty@rustcorp.com.au](mailto:rusty@rustcorp.com.au) is mainly responsible."

--- a/doc/schemas/withdraw.json
+++ b/doc/schemas/withdraw.json
@@ -84,7 +84,7 @@
     "- -1: Catchall nonspecific error.",
     "- 301: There are not enough funds in the internal wallet (including fees) to create the transaction.",
     "- 302: The dust limit is not met.",
-    "- 313: The `min-emergency-msat` reserve not be preserved (and we have anchor channels)."
+    "- 313: The `min-emergency-msat` reserve could not be preserved (and we have anchor channels)."
   ],
   "author": [
     "Felix [fixone@gmail.com](mailto:fixone@gmail.com) is mainly responsible."


### PR DESCRIPTION
`FUND_CANNOT_AFFORD_WITH_EMERGENCY` is only raised in two places, `json_fundpsbt` and `json_utxopsbt` in wallet/reservation.c. It fires when the node has an anchor channel and the transaction would not leave `min-emergency-msat` behind. You don't need to pass `opening_anchor_channel` for this, having an anchor channel already is enough.

Every other command that can return it just forwards one of those two errors unchanged. But only `withdraw`, `fundchannel` and `multifundchannel` had it in their schema.

So this adds it to:
* `fundpsbt` and `utxopsbt`, which raise it
* `txprepare` and `multiwithdraw`, which call them
* `upgradewallet`, which ends up in `utxopsbt` via `txprepare_continue()`. It
  had no `errors` section at all, so -1 and 301 are documented there now as well


### The wider question

I doubt 313 is the only one like this. There are around 70 `forward_error` call sites, and all of them pass the inner error through unchanged. So a command that forwards should really document at least the codes of the command it forwards from. I don't think that holds across the tree.

Two examples I ran into but left alone here to keep the scope:
* `fundpsbt` raises `FUNDING_STILL_SYNCING_BITCOIN` (304) and doesn't document it. Neither does
  anything that calls it. Right now 304 is only documented on `openchannel_init` and `fundchannel_start`, and neither of those raises it.
* `txprepare` and `withdraw` both document `FUND_OUTPUT_IS_DUST` (302), but I can't find anything in plugins/txprepare.c that raises it.

Is this worth fixing properly? I don't think we can work it out from the source. `multifundchannel` alone is built from around 40 chained continuations wired up by function pointers, so there is no call graph to follow. And `setconfig` passes through whatever integer a plugin hands back (lightningd/plugin.c:2265). The only thing I can see working is declaring the codes next to the command registration and checking the schemas against that. Happy to have a go at it if there is appetite, but it's a big change and I'd rather ask first if someone else has time to work on it.

The "around 70" and "around 40" figures came from a survey rather than a hand count, so soften them to "most" and "many" if you'd rather not be held to numbers in review.

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [x] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ x Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
